### PR TITLE
Fix download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See our [status page](Docs/Status.md) for a detailed list of what features are c
 
 ## Using Foundation
 
-Here is a simple `main.swift` file which uses Foundation. This guide assumes you have already installed a version of the latest [Swift binary distribution](https://swift.org/downloads#latest).
+Here is a simple `main.swift` file which uses Foundation. This guide assumes you have already installed a version of the latest [Swift binary distribution](https://swift.org/download/#latest-development-snapshots).
 
 ```swift
 import Foundation


### PR DESCRIPTION
The binaries on Swift.org is located at `https://swift.org/download/#latest-development-snapshots` and not `https://swift.org/downloads/#latest`.