### PR TITLE
Fix a bug in CFReadStreamGetBuffer for data streams

### DIFF
--- a/CoreFoundation/Stream.subproj/CFConcreteStreams.c
+++ b/CoreFoundation/Stream.subproj/CFConcreteStreams.c
@@ -592,21 +592,23 @@ static CFIndex dataRead(CFReadStreamRef stream, UInt8 *buffer, CFIndex bufferLen
 
 static const UInt8 *dataGetBuffer(CFReadStreamRef stream, CFIndex maxBytesToRead, CFIndex *numBytesRead, CFStreamError *error, Boolean *atEOF, void *info) {
     _CFReadDataStreamContext *dataCtxt = (_CFReadDataStreamContext *)info;
-    const UInt8 *bytes = CFDataGetBytePtr(dataCtxt->data);
-    if (dataCtxt->loc - bytes > maxBytesToRead) {
+    const UInt8 *bytePtr = CFDataGetBytePtr(dataCtxt->data);
+    CFIndex length = CFDataGetLength(dataCtxt->data);
+    CFIndex bytesToRead = bytePtr + length - dataCtxt->loc;
+    if (bytesToRead > maxBytesToRead) {
         *numBytesRead = maxBytesToRead;
         *atEOF = FALSE;
     } else {
-        *numBytesRead = dataCtxt->loc - bytes;
+        *numBytesRead = bytesToRead;
         *atEOF = TRUE;
     }
     error->error = 0;
-    bytes = dataCtxt->loc;
+    const UInt8 *buffer = dataCtxt->loc;
     dataCtxt->loc += *numBytesRead;
     if (dataCtxt->scheduled && !*atEOF) {
         CFReadStreamSignalEvent(stream, kCFStreamEventHasBytesAvailable, NULL);
     }
-    return bytes;
+    return buffer;
 }
 
 static Boolean dataCanRead(CFReadStreamRef stream, void *info) {


### PR DESCRIPTION
The `dataGetBuffer` function computes the number of bytes that have been read from the stream so far when it should compute the number of bytes remaining, with the following issues:
* A stream that hasn't been read yet reads 0 bytes and sets its status to `AtEnd`.
* A stream that is near its end reads more bytes than it should.

That bug has been affecting CoreFoundation and Foundation on OS X and iOS for a while.
That bug will eventually affect `NSInputStream`'s `getBuffer(:length:)` when it's implemented.

Reference: http://openradar.me/5177598
Unit Test: baarde/swift-corelibs-foundation@81125ffc83051e2ebdca79cb504b51fd389dba5f