### PR TITLE
Remove workaround for IRGen bug

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1816,14 +1816,6 @@ CFTypeRef objc_retainAutoreleasedReturnValue(CFTypeRef cf) {
     else return NULL;
 }
 
-#if DEPLOYMENT_TARGET_LINUX
-
-// The compiler current emits a reference to this symbol, but it is not actually present unless we define it here ourselves. This is a workaround until the compiler fix can be implemented.
-CF_EXPORT void *_TWVBO;
-void *_TWVBO = &_TWVBO;
-
-#endif
-
 #endif
 
 #undef __kCFAllocatorTypeID_CONST


### PR DESCRIPTION
This was fixed in '54a6b46 IRGen: If Objective-C interop is
disabled foreign classes should use Swift reference counting'.

@parkera @phausler 