### PR TITLE
Remove invalid characters introduced in f699c8d

### DIFF
--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -344,11 +344,11 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
     
     public subscript (idx: Int) -> AnyObject {
         get {
-                guard idx < count && idx >= 0 else {
-                    fatalError("\(self): Index out of bounds")
-                }
+            guard idx < count && idx >= 0 else {
+              fatalError("\(self): Index out of bounds")
+            }
             
-                return objectAtIndex(idx)
+            return objectAtIndex(idx)
         }
     }
     


### PR DESCRIPTION
f699c8d introduced invalid characters into a few lines of `-[NSArray subscript:]` which block compilation.

In Xcode: http://i.imgur.com/cDaUt8I.jpg

In TextMate: http://i.imgur.com/03JceeF.png