### PR TITLE
add implementation for NSRangeFromString and testNSRange.swift

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 		EA66F64E1BF1619600136161 /* TestNSIndexSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA66F63E1BF1619600136161 /* TestNSIndexSet.swift */; };
 		EA66F6501BF1619600136161 /* TestNSNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA66F63F1BF1619600136161 /* TestNSNumber.swift */; };
 		EA66F6521BF1619600136161 /* TestNSPropertyList.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA66F6401BF1619600136161 /* TestNSPropertyList.swift */; };
+		E876A73E1C1180E000F279EC /* TestNSRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = E876A73D1C1180E000F279EC /* TestNSRange.swift */; };
 		EA66F6541BF1619600136161 /* TestNSSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA66F6411BF1619600136161 /* TestNSSet.swift */; };
 		EA66F6561BF1619600136161 /* TestNSString.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA66F6421BF1619600136161 /* TestNSString.swift */; };
 		EA66F6581BF1619600136161 /* TestNSURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA66F6431BF1619600136161 /* TestNSURL.swift */; };
@@ -503,6 +504,7 @@
 		5BDC3FCF1BCF17E600ED97BB /* NSCFSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSCFSet.swift; sourceTree = "<group>"; };
 		5BDC405C1BD6D83B00ED97BB /* TestFoundation.app */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestFoundation.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BF7AEC21BCD568D008F214A /* ForSwiftFoundationOnly.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ForSwiftFoundationOnly.h; sourceTree = "<group>"; };
+		E876A73D1C1180E000F279EC /* TestNSRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSRange.swift; sourceTree = "<group>"; };
 		EA313DFC1BE7F2E90060A403 /* CFURLComponents_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFURLComponents_Internal.h; sourceTree = "<group>"; };
 		EA313DFD1BE7F2E90060A403 /* CFURLComponents_URIParser.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFURLComponents_URIParser.c; sourceTree = "<group>"; };
 		EA313DFE1BE7F2E90060A403 /* CFURLComponents.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFURLComponents.c; sourceTree = "<group>"; };
@@ -991,6 +993,7 @@
 				EA66F63E1BF1619600136161 /* TestNSIndexSet.swift */,
 				EA66F63F1BF1619600136161 /* TestNSNumber.swift */,
 				EA66F6401BF1619600136161 /* TestNSPropertyList.swift */,
+				E876A73D1C1180E000F279EC /* TestNSRange.swift */,
 				EA66F6411BF1619600136161 /* TestNSSet.swift */,
 				EA66F6421BF1619600136161 /* TestNSString.swift */,
 				EA66F6431BF1619600136161 /* TestNSURL.swift */,
@@ -1678,6 +1681,7 @@
 			files = (
 				525AECED1BF2C9C500D15BB0 /* TestNSFileManager.swift in Sources */,
 				EA66F6501BF1619600136161 /* TestNSNumber.swift in Sources */,
+				E876A73E1C1180E000F279EC /* TestNSRange.swift in Sources */,
 				EA66F6521BF1619600136161 /* TestNSPropertyList.swift in Sources */,
 				EA66F64E1BF1619600136161 /* TestNSIndexSet.swift in Sources */,
 				EA66F6541BF1619600136161 /* TestNSSet.swift in Sources */,

--- a/Foundation/NSRange.swift
+++ b/Foundation/NSRange.swift
@@ -99,5 +99,33 @@ public func NSStringFromRange(range: NSRange) -> String {
 }
 
 public func NSRangeFromString(aString: String) -> NSRange {
-    NSUnimplemented()
+    let emptyRange = NSMakeRange(0, 0)
+    if aString.isEmpty {
+        // fail early if the string is empty
+        return emptyRange
+    }
+    let scanner = NSScanner(string: aString)
+    let digitSet = NSCharacterSet.decimalDigitCharacterSet()
+    scanner.scanUpToCharactersFromSet(digitSet)
+    if scanner.atEnd {
+        // fail early if there are no decimal digits
+        return emptyRange
+    }
+    guard let location = scanner.scanInteger() else {
+        return emptyRange
+    }
+    let partialRange = NSMakeRange(location, 0)
+    if scanner.atEnd {
+        // return early if there are no more characters after the first int in the string
+        return partialRange
+    }
+    scanner.scanUpToCharactersFromSet(digitSet)
+    if scanner.atEnd {
+        // return early if there are no integer characters after the first int in the string
+        return partialRange
+    }
+    guard let length = scanner.scanInteger() else {
+        return partialRange
+    }
+    return NSMakeRange(location, length)
 }

--- a/TestFoundation/TestNSRange.swift
+++ b/TestFoundation/TestNSRange.swift
@@ -1,0 +1,60 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+import Foundation
+import XCTest
+#else
+import SwiftFoundation
+import SwiftXCTest
+#endif
+
+
+class TestNSRange : XCTestCase {
+    
+    var allTests : [(String, () -> ())] {
+        return [
+            ("test_NSRangeFromString", test_NSRangeFromString ),
+        ]
+    }
+    
+    func test_NSRangeFromString() {
+        let emptyRangeStrings = [
+            "",
+            "{}",
+            "{a, b}",
+        ]
+        let emptyRange = NSMakeRange(0, 0)
+        for string in emptyRangeStrings {
+            XCTAssert(NSEqualRanges(NSRangeFromString(string), emptyRange))
+        }
+
+        let partialRangeStrings = [
+            "12",
+            "[12]",
+            "{12",
+            "{12,",
+        ]
+        let partialRange = NSMakeRange(12, 0)
+        for string in partialRangeStrings {
+            XCTAssert(NSEqualRanges(NSRangeFromString(string), partialRange))
+        }
+
+        let fullRangeStrings = [
+            "{12, 34}",
+            "[12, 34]",
+            "12.34",
+        ]
+        let fullRange = NSMakeRange(12, 34)
+        for string in fullRangeStrings {
+            XCTAssert(NSEqualRanges(NSRangeFromString(string), fullRange))
+        }
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -20,4 +20,4 @@ internal func testBundle() -> NSBundle {
 }
 
 // For the Swift version of the Foundation tests, we must manually list all test cases here.
-XCTMain([TestNSString(), TestNSArray(), TestNSDictionary(), TestNSSet(), TestNSNumber(), TestNSPropertyList(), TestNSURL(), TestNSIndexSet(), TestNSCharacterSet(), TestNSFileManger()])
+XCTMain([TestNSString(), TestNSArray(), TestNSDictionary(), TestNSSet(), TestNSNumber(), TestNSPropertyList(), TestNSURL(), TestNSIndexSet(), TestNSCharacterSet(), TestNSFileManger(), TestNSRange()])

--- a/build.py
+++ b/build.py
@@ -352,6 +352,7 @@ foundation_tests = SwiftExecutable('TestFoundation', [
 	'TestFoundation/TestNSDictionary.swift',
 	'TestFoundation/TestNSNumber.swift',
 	'TestFoundation/TestNSPropertyList.swift',
+	'TestFoundation/TestNSRange.swift',
 	'TestFoundation/TestNSSet.swift',
 	'TestFoundation/TestNSString.swift',
 	'TestFoundation/TestNSURL.swift',


### PR DESCRIPTION
Great job with the OSS release! :clap: 

Here's a first attempt at contributing something small.

All strings in the test cases were compared against the result of using `NSRangeFromString` in Foundation today. Some of that behavior I find odd, but I opted to keep it as-is. I'm happy to consider other implementation approaches too.