### PR TITLE
Simplify implementation of `init(indexes:length:)`.

### DIFF
--- a/Foundation/NSIndexPath.swift
+++ b/Foundation/NSIndexPath.swift
@@ -15,10 +15,7 @@ public class NSIndexPath : NSObject, NSCopying, NSSecureCoding {
         _indexes = []
     }
     public init(indexes: UnsafePointer<Int>, length: Int) {
-        _indexes = []
-        for var idx = 0; idx < length; idx++ {
-            _indexes.append(indexes[idx])
-        }
+        _indexes = Array(UnsafeBufferPointer(start: indexes, count: length))
     }
     
     private init(indexes: [Int]) {


### PR DESCRIPTION
In `init(indexes:length:)`, initialize `_indexes` to an `Array` constructed with an `UnsafeBufferPointer` built from `indexes`, instead of initializing it to an empty array and adding each `idx` in `indexes` to it in a loop.