### PR TITLE
mark NSCache() initializer as public

### DIFF
--- a/Foundation/NSCache.swift
+++ b/Foundation/NSCache.swift
@@ -32,7 +32,7 @@ public class NSCache : NSObject {
     public var countLimit: Int = -1 // limits are imprecise/not strict
     public var evictsObjectsWithDiscardedContent: Bool = false
 
-    override init() {
+    public override init() {
         
     }
     


### PR DESCRIPTION
mark NSCache() initializer as public to allow instantiate NSCache outside Foundation framework.