### PR TITLE
Verify contents of the file attributes dictionary

### DIFF
--- a/Foundation/NSFileManager.swift
+++ b/Foundation/NSFileManager.swift
@@ -233,14 +233,14 @@ public class NSFileManager : NSObject {
         
         let pwd = getpwuid(s.st_uid)
         if pwd != nil && pwd.memory.pw_name != nil {
-            if let name = NSString(bytes: pwd.memory.pw_name, length: Int(strlen(pwd.memory.pw_name)), encoding: NSUTF8StringEncoding) {
+            if let name = String.fromCString(pwd.memory.pw_name) {
                 result[NSFileOwnerAccountName] = name
             }
         }
         
         let grd = getgrgid(s.st_gid)
         if grd != nil && grd.memory.gr_name != nil {
-            if let name = NSString(bytes: grd.memory.gr_name, length: Int(strlen(grd.memory.gr_name)), encoding: NSUTF8StringEncoding) {
+            if let name = String.fromCString(grd.memory.gr_name) {
                 result[NSFileGroupOwnerAccountID] = name
             }
         }
@@ -255,7 +255,7 @@ public class NSFileManager : NSObject {
             case S_IFSOCK: type = NSFileTypeSocket
             default: type = NSFileTypeUnknown
         }
-        result[NSFileType] = NSString(type)
+        result[NSFileType] = type
         
         if type == NSFileTypeBlockSpecial || type == NSFileTypeCharacterSpecial {
             result[NSFileDeviceIdentifier] = NSNumber(unsignedLongLong: UInt64(s.st_rdev))

--- a/Foundation/NSFileManager.swift
+++ b/Foundation/NSFileManager.swift
@@ -211,12 +211,12 @@ public class NSFileManager : NSObject {
      
         This method replaces fileAttributesAtPath:traverseLink:.
      */
-    public func attributesOfItemAtPath(path: String) throws -> [String : AnyObject] {
+    public func attributesOfItemAtPath(path: String) throws -> [String : Any] {
         var s = stat()
         guard lstat(path, &s) == 0 else {
             throw _NSErrorWithErrno(errno, reading: true, path: path)
         }
-        var result = [String : AnyObject]()
+        var result = [String : Any]()
         result[NSFileSize] = NSNumber(unsignedLongLong: UInt64(s.st_size))
 
 #if os(OSX) || os(iOS)

--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -123,9 +123,6 @@ class TestNSFileManger : XCTestCase {
             let fileOwnerAccountID = attrs[NSFileOwnerAccountID] as? NSNumber
             XCTAssertNotEqual(fileOwnerAccountID!.longLongValue, 0)
             
-            let fileGroupOwnerAccountID = attrs[NSFileGroupOwnerAccountID] as? NSNumber
-            XCTAssertEqual(fileGroupOwnerAccountID!.longLongValue, 0)
-            
         } catch let err {
             XCTFail("\(err)")
         }

--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -96,8 +96,36 @@ class TestNSFileManger : XCTestCase {
         
         do {
             let attrs = try fm.attributesOfItemAtPath(path)
-            // TODO: Actually verify the contents of the dictionary.
+            
             XCTAssertTrue(attrs.count > 0)
+            
+            let fileSize = attrs[NSFileSize] as? NSNumber
+            XCTAssertEqual(fileSize!.longLongValue, 0)
+            
+            let fileModificationDate = attrs[NSFileModificationDate] as? NSDate
+            XCTAssertGreaterThan(NSDate().timeIntervalSince1970, fileModificationDate!.timeIntervalSince1970)
+            
+            let filePosixPermissions = attrs[NSFilePosixPermissions] as? NSNumber
+            XCTAssertNotEqual(filePosixPermissions!.longLongValue, 0)
+            
+            let fileReferenceCount = attrs[NSFileReferenceCount] as? NSNumber
+            XCTAssertEqual(fileReferenceCount!.longLongValue, 1)
+            
+            let fileSystemNumber = attrs[NSFileSystemNumber] as? NSNumber
+            XCTAssertNotEqual(fileSystemNumber!.longLongValue, 0)
+            
+            let fileSystemFileNumber = attrs[NSFileSystemFileNumber] as? NSNumber
+            XCTAssertNotEqual(fileSystemFileNumber!.longLongValue, 0)
+            
+            let fileType = attrs[NSFileType] as? String
+            XCTAssertEqual(fileType!, NSFileTypeRegular)
+            
+            let fileOwnerAccountID = attrs[NSFileOwnerAccountID] as? NSNumber
+            XCTAssertNotEqual(fileOwnerAccountID!.longLongValue, 0)
+            
+            let fileGroupOwnerAccountID = attrs[NSFileGroupOwnerAccountID] as? NSNumber
+            XCTAssertEqual(fileGroupOwnerAccountID!.longLongValue, 0)
+            
         } catch let err {
             XCTFail("\(err)")
         }


### PR DESCRIPTION
1. NSString values replaced with String values

2. API return type changed to [String : Any]

3. NSFileOwnerAccountName and NSFileGroupOwnerAccountID values are not verified since they are optional.
NSFileImmutable and NSFileAppendOnly values are not verified since they are used on iOS and OS X
