### PR TITLE
Make NSDate conform to Comparable protocol

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		5BF7AEBF1BCD51F9008F214A /* NSURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4A1BCC5DCB00ED97BB /* NSURL.swift */; };
 		5BF7AEC01BCD51F9008F214A /* NSUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4B1BCC5DCB00ED97BB /* NSUUID.swift */; };
 		5BF7AEC11BCD51F9008F214A /* NSValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4C1BCC5DCB00ED97BB /* NSValue.swift */; };
+		9C7684F01C11D9B50046490B /* TestNSDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7684EF1C11D9B50046490B /* TestNSDate.swift */; settings = {ASSET_TAGS = (); }; };
 		EA66F6361BEED03E00136161 /* TargetConditionals.h in Headers */ = {isa = PBXBuildFile; fileRef = EA66F6351BEED03E00136161 /* TargetConditionals.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA66F6441BF1619600136161 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA66F6381BF1619600136161 /* main.swift */; };
 		EA66F6481BF1619600136161 /* NSURLTestData.plist in Resources */ = {isa = PBXBuildFile; fileRef = EA66F63B1BF1619600136161 /* NSURLTestData.plist */; };
@@ -503,6 +504,7 @@
 		5BDC3FCF1BCF17E600ED97BB /* NSCFSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSCFSet.swift; sourceTree = "<group>"; };
 		5BDC405C1BD6D83B00ED97BB /* TestFoundation.app */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestFoundation.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BF7AEC21BCD568D008F214A /* ForSwiftFoundationOnly.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ForSwiftFoundationOnly.h; sourceTree = "<group>"; };
+		9C7684EF1C11D9B50046490B /* TestNSDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSDate.swift; sourceTree = "<group>"; };
 		EA313DFC1BE7F2E90060A403 /* CFURLComponents_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFURLComponents_Internal.h; sourceTree = "<group>"; };
 		EA313DFD1BE7F2E90060A403 /* CFURLComponents_URIParser.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFURLComponents_URIParser.c; sourceTree = "<group>"; };
 		EA313DFE1BE7F2E90060A403 /* CFURLComponents.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFURLComponents.c; sourceTree = "<group>"; };
@@ -996,6 +998,7 @@
 				EA66F6431BF1619600136161 /* TestNSURL.swift */,
 				5BC1D8BC1BF3ADFE009D3973 /* TestNSCharacterSet.swift */,
 				525AECEB1BF2C96400D15BB0 /* TestNSFileManager.swift */,
+				9C7684EF1C11D9B50046490B /* TestNSDate.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -1682,6 +1685,7 @@
 				EA66F64E1BF1619600136161 /* TestNSIndexSet.swift in Sources */,
 				EA66F6541BF1619600136161 /* TestNSSet.swift in Sources */,
 				EA66F64A1BF1619600136161 /* TestNSArray.swift in Sources */,
+				9C7684F01C11D9B50046490B /* TestNSDate.swift in Sources */,
 				5BC1D8BE1BF3B09E009D3973 /* TestNSCharacterSet.swift in Sources */,
 				EA66F6561BF1619600136161 /* TestNSString.swift in Sources */,
 				EA66F64C1BF1619600136161 /* TestNSDictionary.swift in Sources */,

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -174,6 +174,28 @@ extension CFDateRef : _NSBridgable {
     internal var _nsObject: NSType { return unsafeBitCast(self, NSType.self) }
 }
 
+extension NSDate : Comparable { }
+
+public func ==(lhs: NSDate, rhs: NSDate) -> Bool {
+    return lhs === rhs || lhs.compare(rhs) == .OrderedSame
+}
+
+public func <(lhs: NSDate, rhs: NSDate) -> Bool {
+    return lhs.compare(rhs) == .OrderedAscending
+}
+
+public func <=(lhs: NSDate, rhs: NSDate) -> Bool {
+    return lhs < rhs || lhs == rhs
+}
+
+public func >(lhs: NSDate, rhs: NSDate) -> Bool {
+    return lhs.compare(rhs) == .OrderedDescending
+}
+
+public func >=(lhs: NSDate, rhs: NSDate) -> Bool {
+    return lhs > rhs || lhs == rhs
+}
+
 /// Alternative API for avoiding AutoreleasingUnsafeMutablePointer usage in NSCalendar and NSFormatter
 /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative to the AutoreleasingUnsafeMutablePointer usage case of returning a NSDate + NSTimeInterval or using a pair of dates representing a range
 /// - Note: Since this API is under consideration it may be either removed or revised in the near future

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -184,18 +184,6 @@ public func <(lhs: NSDate, rhs: NSDate) -> Bool {
     return lhs.compare(rhs) == .OrderedAscending
 }
 
-public func <=(lhs: NSDate, rhs: NSDate) -> Bool {
-    return lhs < rhs || lhs == rhs
-}
-
-public func >(lhs: NSDate, rhs: NSDate) -> Bool {
-    return lhs.compare(rhs) == .OrderedDescending
-}
-
-public func >=(lhs: NSDate, rhs: NSDate) -> Bool {
-    return lhs > rhs || lhs == rhs
-}
-
 /// Alternative API for avoiding AutoreleasingUnsafeMutablePointer usage in NSCalendar and NSFormatter
 /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative to the AutoreleasingUnsafeMutablePointer usage case of returning a NSDate + NSTimeInterval or using a pair of dates representing a range
 /// - Note: Since this API is under consideration it may be either removed or revised in the near future

--- a/TestFoundation/TestNSDate.swift
+++ b/TestFoundation/TestNSDate.swift
@@ -1,0 +1,46 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+    #else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+class TestNSDate : XCTestCase {
+    
+    var allTests : [(String, () -> ())] {
+        return [
+            ("test_comparable", test_comparable ),
+        ]
+    }
+    
+    func ignoreError(@noescape block: () throws -> Void) {
+        do { try block() } catch { }
+    }
+    
+    func test_comparable() {
+        
+        let past = NSDate.distantPast()
+        let future = NSDate.distantFuture()
+        let present = NSDate()
+        
+        XCTAssertTrue(past < present)
+        XCTAssertTrue(past <= present)
+        
+        XCTAssertTrue(past != present)
+        XCTAssertTrue(present == present)
+
+        XCTAssertTrue(future > present)
+        XCTAssertTrue(future >= present)
+    }
+    
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -20,4 +20,4 @@ internal func testBundle() -> NSBundle {
 }
 
 // For the Swift version of the Foundation tests, we must manually list all test cases here.
-XCTMain([TestNSString(), TestNSArray(), TestNSDictionary(), TestNSSet(), TestNSNumber(), TestNSPropertyList(), TestNSURL(), TestNSIndexSet(), TestNSCharacterSet(), TestNSFileManger()])
+XCTMain([TestNSString(), TestNSArray(), TestNSDictionary(), TestNSSet(), TestNSNumber(), TestNSPropertyList(), TestNSURL(), TestNSIndexSet(), TestNSCharacterSet(), TestNSFileManger(), TestNSDate()])


### PR DESCRIPTION
It would be nice to provide more natural way to compare instances of `NSDate` -- using `<`, `<=`, `>`, and `>=` operators. This PR implements all methods declared in `Comparable` protocol for `NSDate` class.