### PR TITLE
Clarify where NSCalendar timezone is set and return values

### DIFF
--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -365,11 +365,7 @@ public class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     public func dateFromComponents(comps: NSDateComponents) -> NSDate? {
         var (vector, compDesc) = _convert(comps)
         
-        let oldTz = timeZone
-        let tempTz = comps.timeZone
-        if let tz = tempTz {
-            timeZone = tz
-        }
+        self.timeZone = comps.timeZone ?? timeZone
         
         var at: CFAbsoluteTime = 0.0
         let res: Bool = withUnsafeMutablePointer(&at) { t in
@@ -378,15 +374,11 @@ public class NSCalendar : NSObject, NSCopying, NSSecureCoding {
             }
         }
         
-        if tempTz != nil {
-            self.timeZone = oldTz
-        }
-        
         if res {
             return NSDate(timeIntervalSinceReferenceDate: at)
+        } else {
+            return nil
         }
-        
-        return nil
     }
     
     private func _setup(unitFlags: NSCalendarUnit, field: NSCalendarUnit, type: String, inout compDesc: [Int8]) {


### PR DESCRIPTION
Flow is more logical and easy to follow by setting `timezone` immediately after declaration. Additionally, return values more closely follow idioms specified [here](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/Swift_Programming_Language/Functions.html#//apple_ref/doc/uid/TP40014097-CH10-ID528).