### PR TITLE
Add NSNull.null()

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		5BF7AEBF1BCD51F9008F214A /* NSURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4A1BCC5DCB00ED97BB /* NSURL.swift */; };
 		5BF7AEC01BCD51F9008F214A /* NSUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4B1BCC5DCB00ED97BB /* NSUUID.swift */; };
 		5BF7AEC11BCD51F9008F214A /* NSValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4C1BCC5DCB00ED97BB /* NSValue.swift */; };
+		6C2CDAE51C12AB5200E52B3B /* TestNSNull.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2CDAE31C12AB3900E52B3B /* TestNSNull.swift */; };
 		E876A73E1C1180E000F279EC /* TestNSRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = E876A73D1C1180E000F279EC /* TestNSRange.swift */; };
 		EA66F6361BEED03E00136161 /* TargetConditionals.h in Headers */ = {isa = PBXBuildFile; fileRef = EA66F6351BEED03E00136161 /* TargetConditionals.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA66F6441BF1619600136161 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA66F6381BF1619600136161 /* main.swift */; };
@@ -512,6 +513,7 @@
 		5BDC3FCF1BCF17E600ED97BB /* NSCFSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSCFSet.swift; sourceTree = "<group>"; };
 		5BDC405C1BD6D83B00ED97BB /* TestFoundation.app */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestFoundation.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BF7AEC21BCD568D008F214A /* ForSwiftFoundationOnly.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ForSwiftFoundationOnly.h; sourceTree = "<group>"; };
+		6C2CDAE31C12AB3900E52B3B /* TestNSNull.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSNull.swift; sourceTree = "<group>"; };
 		E876A73D1C1180E000F279EC /* TestNSRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSRange.swift; sourceTree = "<group>"; };
 		EA313DFC1BE7F2E90060A403 /* CFURLComponents_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFURLComponents_Internal.h; sourceTree = "<group>"; };
 		EA313DFD1BE7F2E90060A403 /* CFURLComponents_URIParser.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFURLComponents_URIParser.c; sourceTree = "<group>"; };
@@ -1012,6 +1014,7 @@
 				5BC1D8BC1BF3ADFE009D3973 /* TestNSCharacterSet.swift */,
 				525AECEB1BF2C96400D15BB0 /* TestNSFileManager.swift */,
 				5B40F9F11C125187000E72E3 /* TestNSXMLParser.swift */,
+				6C2CDAE31C12AB3900E52B3B /* TestNSNull.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -1695,6 +1698,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				525AECED1BF2C9C500D15BB0 /* TestNSFileManager.swift in Sources */,
+				6C2CDAE51C12AB5200E52B3B /* TestNSNull.swift in Sources */,
 				EA66F6501BF1619600136161 /* TestNSNumber.swift in Sources */,
 				E876A73E1C1180E000F279EC /* TestNSRange.swift in Sources */,
 				EA66F6521BF1619600136161 /* TestNSPropertyList.swift in Sources */,

--- a/Foundation/NSNull.swift
+++ b/Foundation/NSNull.swift
@@ -8,7 +8,14 @@
 //
 
 
+import CoreFoundation
+
 public class NSNull : NSObject, NSCopying, NSSecureCoding {
+    internal static let defaultInstance = kCFNull
+    public class func null() -> NSNull {
+        return defaultInstance._nsObject
+    }
+    
     public func copyWithZone(zone: NSZone) -> AnyObject {
         return self
     }
@@ -28,6 +35,15 @@ public class NSNull : NSObject, NSCopying, NSSecureCoding {
     public static func supportsSecureCoding() -> Bool {
         return true
     }
+
 }
 
+extension NSNull : _CFBridgable {
+    typealias CFType = CFNullRef
+    internal var _cfObject: CFType { return unsafeBitCast(self, CFType.self) }
+}
 
+extension CFNullRef : _NSBridgable {
+    typealias NSType = NSNull
+    internal var _nsObject: NSType { return unsafeBitCast(self, NSType.self) }
+}

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -116,6 +116,7 @@ internal func __CFInitializeSwift() {
     _CFRuntimeBridgeTypeToClass(CFLocaleGetTypeID(), unsafeBitCast(NSLocale.self, UnsafePointer<Void>.self))
     _CFRuntimeBridgeTypeToClass(CFTimeZoneGetTypeID(), unsafeBitCast(NSTimeZone.self, UnsafePointer<Void>.self))
     _CFRuntimeBridgeTypeToClass(CFCharacterSetGetTypeID(), unsafeBitCast(NSMutableCharacterSet.self, UnsafePointer<Void>.self))
+    _CFRuntimeBridgeTypeToClass(CFNullGetTypeID(), unsafeBitCast(NSNull.self, UnsafePointer<Void>.self))
     
 //    _CFRuntimeBridgeTypeToClass(CFErrorGetTypeID(), unsafeBitCast(NSError.self, UnsafePointer<Void>.self))
 //    _CFRuntimeBridgeTypeToClass(CFAttributedStringGetTypeID(), unsafeBitCast(NSMutableAttributedString.self, UnsafePointer<Void>.self))

--- a/TestFoundation/TestNSNull.swift
+++ b/TestFoundation/TestNSNull.swift
@@ -15,6 +15,8 @@
     import SwiftXCTest
 #endif
 
+import CoreFoundation
+
 class TestNSNull: XCTestCase {
     
     var allTests : [(String, () -> ())] {
@@ -24,7 +26,7 @@ class TestNSNull: XCTestCase {
     }
     
     func test_null() {
-        let nullIsDefined = NSNull.null() == NSNull.null()
+        let nullIsDefined = NSNull.null() == unsafeBitCast(kCFNull, NSNull.self)
         XCTAssertTrue(nullIsDefined)
     }
 

--- a/TestFoundation/TestNSNull.swift
+++ b/TestFoundation/TestNSNull.swift
@@ -1,0 +1,31 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+class TestNSNull: XCTestCase {
+    
+    var allTests : [(String, () -> ())] {
+        return [
+            ("test_null", test_null),
+        ]
+    }
+    
+    func test_null() {
+        let nullIsDefined = NSNull.null() == NSNull.null()
+        XCTAssertTrue(nullIsDefined)
+    }
+
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -33,4 +33,5 @@ XCTMain([
     TestNSFileManger(),
     TestNSRange(),
     TestNSXMLParser(),
+    TestNSNull(),
 ])

--- a/build.py
+++ b/build.py
@@ -362,6 +362,7 @@ foundation_tests = SwiftExecutable('TestFoundation', [
     'TestFoundation/TestNSFileManager.swift',
     'TestFoundation/TestNSCharacterSet.swift',
     'TestFoundation/TestNSXMLParser.swift',
+    'TestFoundation/TestNSNull.swift',
 ])
 
 foundation_tests.add_dependency(foundation_tests_resources)


### PR DESCRIPTION
Returns kCFNull and bridges from CFNullRef
as described in Apple documentation.