### PR TITLE
Implemented NSAffineTransform.init() with tests

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		5BF7AEBF1BCD51F9008F214A /* NSURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4A1BCC5DCB00ED97BB /* NSURL.swift */; };
 		5BF7AEC01BCD51F9008F214A /* NSUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4B1BCC5DCB00ED97BB /* NSUUID.swift */; };
 		5BF7AEC11BCD51F9008F214A /* NSValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4C1BCC5DCB00ED97BB /* NSValue.swift */; };
+		C93559291C12C49F009FD6A9 /* TestNSAffineTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */; };
 		E876A73E1C1180E000F279EC /* TestNSRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = E876A73D1C1180E000F279EC /* TestNSRange.swift */; };
 		EA66F6361BEED03E00136161 /* TargetConditionals.h in Headers */ = {isa = PBXBuildFile; fileRef = EA66F6351BEED03E00136161 /* TargetConditionals.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA66F6441BF1619600136161 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA66F6381BF1619600136161 /* main.swift */; };
@@ -512,6 +513,7 @@
 		5BDC3FCF1BCF17E600ED97BB /* NSCFSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSCFSet.swift; sourceTree = "<group>"; };
 		5BDC405C1BD6D83B00ED97BB /* TestFoundation.app */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestFoundation.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BF7AEC21BCD568D008F214A /* ForSwiftFoundationOnly.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ForSwiftFoundationOnly.h; sourceTree = "<group>"; };
+		C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSAffineTransform.swift; sourceTree = "<group>"; };
 		E876A73D1C1180E000F279EC /* TestNSRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSRange.swift; sourceTree = "<group>"; };
 		EA313DFC1BE7F2E90060A403 /* CFURLComponents_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFURLComponents_Internal.h; sourceTree = "<group>"; };
 		EA313DFD1BE7F2E90060A403 /* CFURLComponents_URIParser.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFURLComponents_URIParser.c; sourceTree = "<group>"; };
@@ -1000,6 +1002,7 @@
 		EA66F65A1BF1976100136161 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */,
 				EA66F63C1BF1619600136161 /* TestNSArray.swift */,
 				EA66F63D1BF1619600136161 /* TestNSDictionary.swift */,
 				EA66F63E1BF1619600136161 /* TestNSIndexSet.swift */,
@@ -1698,6 +1701,7 @@
 				EA66F6501BF1619600136161 /* TestNSNumber.swift in Sources */,
 				E876A73E1C1180E000F279EC /* TestNSRange.swift in Sources */,
 				EA66F6521BF1619600136161 /* TestNSPropertyList.swift in Sources */,
+				C93559291C12C49F009FD6A9 /* TestNSAffineTransform.swift in Sources */,
 				EA66F64E1BF1619600136161 /* TestNSIndexSet.swift in Sources */,
 				EA66F6541BF1619600136161 /* TestNSSet.swift in Sources */,
 				EA66F64A1BF1619600136161 /* TestNSArray.swift in Sources */,

--- a/Foundation/NSAffineTransform.swift
+++ b/Foundation/NSAffineTransform.swift
@@ -16,7 +16,10 @@ public struct NSAffineTransformStruct {
     public var tX: CGFloat
     public var tY: CGFloat
     public init() { NSUnimplemented() }
-    public init(m11: CGFloat, m12: CGFloat, m21: CGFloat, m22: CGFloat, tX: CGFloat, tY: CGFloat) { NSUnimplemented() }
+    public init(m11: CGFloat, m12: CGFloat, m21: CGFloat, m22: CGFloat, tX: CGFloat, tY: CGFloat) {
+        (self.m11, self.m12, self.m21, self.m22) = (m11, m12, m21, m22)
+        (self.tX, self.tY) = (tX, tY)
+    }
 }
 
 public class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
@@ -36,7 +39,9 @@ public class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
     
     // Initialization
     public convenience init(transform: NSAffineTransform) { NSUnimplemented() }
-    public override init() { NSUnimplemented() }
+    public override init() {
+        transformStruct = NSAffineTransformStruct(m11: CGFloat(1.0), m12: CGFloat(), m21: CGFloat(), m22: CGFloat(1.0), tX: CGFloat(), tY: CGFloat())
+    }
     
     // Translating
     public func translateXBy(deltaX: CGFloat, yBy deltaY: CGFloat) { NSUnimplemented() }

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -27,6 +27,12 @@ public struct CGFloat {
     public var native: NativeType
 }
 
+extension Double {
+    public init(_ value: CGFloat) {
+        self = Double(value.native)
+    }
+}
+
 public struct CGPoint {
     public var x: CGFloat
     public var y: CGFloat

--- a/TestFoundation/TestNSAffineTransform.swift
+++ b/TestFoundation/TestNSAffineTransform.swift
@@ -1,0 +1,47 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+#if os(OSX) || os(iOS)
+    import Darwin
+#elseif os(Linux)
+    import Glibc
+#endif
+
+class TestNSAffineTransform : XCTestCase {
+
+    var allTests : [(String, () -> ())] {
+        return [
+            ("test_BasicConstruction", test_BasicConstruction)
+        ]
+    }
+
+    func test_BasicConstruction() {
+        let identityTransform = NSAffineTransform()
+        let transformStruct = identityTransform.transformStruct
+
+        // The diagonal entries (1,1) and (2,2) of the identity matrix are ones. The other entries are zeros.
+        XCTAssertEqualWithAccuracy(Double(transformStruct.m11), Double(1), accuracy: DBL_MIN)
+        XCTAssertEqualWithAccuracy(Double(transformStruct.m22), Double(1), accuracy: DBL_MIN)
+
+        XCTAssertEqualWithAccuracy(Double(transformStruct.m12), Double(0), accuracy: DBL_MIN)
+        XCTAssertEqualWithAccuracy(Double(transformStruct.m21), Double(0), accuracy: DBL_MIN)
+        XCTAssertEqualWithAccuracy(Double(transformStruct.tX), Double(0), accuracy: DBL_MIN)
+        XCTAssertEqualWithAccuracy(Double(transformStruct.tY), Double(0), accuracy: DBL_MIN)
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -22,6 +22,7 @@ internal func testBundle() -> NSBundle {
 // For the Swift version of the Foundation tests, we must manually list all test cases here.
 XCTMain([
     TestNSString(),
+    TestNSAffineTransform(),
     TestNSArray(),
     TestNSDictionary(),
     TestNSSet(),

--- a/build.py
+++ b/build.py
@@ -350,6 +350,7 @@ foundation_tests_resources = CopyResources('TestFoundation', [
 # TODO: Probably this should be another 'product', but for now it's simply a phase
 foundation_tests = SwiftExecutable('TestFoundation', [
 	'TestFoundation/main.swift',
+	'TestFoundation/TestNSAffineTransform.swift',
 	'TestFoundation/TestNSArray.swift',
 	'TestFoundation/TestNSIndexSet.swift',
 	'TestFoundation/TestNSDictionary.swift',


### PR DESCRIPTION
As described in the reference for NSAffineTransform, this initializer:

    Creates and returns a new NSAffineTransform object initialized to the identity matrix.

Part of this change:

- an initializer for the underlying `NSAffineTransformStruct`'s members has been implemented
- an initializer for creating `Double`s from `CGFloat`s has been added to aid testing. Its signature is identical to the one in `CoreGraphics` in the iOS 9.1 SDK. Tests are implemented in terms of `Double`s since `XCTAssertEqualWithAccuracy` only works with types that implement `FloatingPointType`, which `CGFloat` currently does not.
