### PR TITLE
Added `NSPipe` implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ project.xcworkspace
 
 Build
 .build
+.configuration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Contributions to Foundation are welcome! This project follows the [contribution guidelines for the Swift project](https://swift.org/contributing/#reporting-bugs). A few additional details are outlined below.
+Contributions to Foundation are welcome! This project follows the [contribution guidelines for the Swift project](https://swift.org/contributing/#contributing-code). A few additional details are outlined below.
 
 ## Licensing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,11 @@
 
 Contributions to Foundation are welcome! This project follows the [contribution guidelines for the Swift project](https://swift.org/contributing/#reporting-bugs). A few additional details are outlined below.
 
+## Licensing
+
+By submitting a pull request, you represent that you have the right to license your contribution to Apple and the community, and agree by submitting the patch that your contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
+
+
 ## Bug Reports
 
 You can use the `Foundation` component in the [bug reporter](https://bugs.swift.org) if you know your bug is specifically about Swift Foundation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Contributions to Foundation are welcome! This project follows the [contribution guidelines for the Swift project](https://swift.org/contributing/#reporting-bugs). A few additional details are outlined below.
+
+## Bug Reports
+
+You can use the `Foundation` component in the [bug reporter](https://bugs.swift.org) if you know your bug is specifically about Swift Foundation.
+
+Please remember to include platform information with your report. If the bug is about the Foundation framework on Darwin, then please use the [Apple bug reporting system](https://bugreport.apple.com).
+
+## Pull Requests
+
+Before embarking on a large amount of work to implement missing functionality, please double-check with the community on the [swift-corelibs-dev](https://lists.swift.org/mailman/listinfo/swift-corelibs-dev) mailing list. Someone may already be working in this area, and we want to avoid duplication of work.
+
+If your request includes functionality changes, please be sure to test your code on Linux as well as OS X. Differences in the compiler and runtime on each platform means that code that compiles and runs correctly on Darwin (where the Objective-C runtime is present) may not compile at all on Linux.
+
+##### Review
+
+Each pull request will be reviewed by a code owner before merging.
+
+* Pull requests should contain small, incremental change.
+* Focus on one task. If a pull request contains several unrelated commits, we will ask for the pull request to be split up.
+* Please squash work-in-progress commits. Each commit should stand on its own (including the addition of tests if possible). This allows us to bisect issues more effectively.
+* After addressing review feedback, please rebase your commit so that we create a clean history in the `master` branch.
+
+##### Tests
+
+All pull requests which contain code changes should come with a new set of automated tests, and every current test must pass on all supported platforms.
+
+##### Documentation
+
+Most of the methods in Foundation are lacking documentation. We appreciate your help in filling out documentation when you implement a method. Use the markdown syntax in the [Swift Naming Guidelines](https://swift.org/documentation/api-design-guidelines.html#write-doc-comment).
+
+## API Changes
+
+The interface of Foundation is intended to be both stable and cross-platform. This means that when API is added to Foundation, it is effectively permanent.
+
+It is therefore critical that any code change that affects the public-facing API go through a full  `swift-evolution` review process. This gives us the chance to ensure several important requirements are satisfied:
+
+* The proposal aligns with our current goals for the upcoming release.
+* We are comfortable supporting the proposed API for the long term.
+* We believe we can make the same change to the API of Darwin Foundation. This could be done via changes in the overlay, changes in the compiler, or changes in Darwin Foundation itself. This must be addressed in every proposal.

--- a/CoreFoundation/Base.subproj/CFBase.h
+++ b/CoreFoundation/Base.subproj/CFBase.h
@@ -231,6 +231,15 @@ CF_EXTERN_C_BEGIN
 #define CF_AUTOMATED_REFCOUNT_UNAVAILABLE
 #endif
 
+#if DEPLOYMENT_RUNTIME_SWIFT
+#ifndef CF_ASSUME_NONNULL_BEGIN
+#define CF_ASSUME_NONNULL_BEGIN _Pragma("clang assume_nonnull begin")
+#endif
+#ifndef CF_ASSUME_NONNULL_BEGIN
+#define CF_ASSUME_NONNULL_END   _Pragma("clang assume_nonnull end")
+#endif
+#endif
+
 #ifndef CF_IMPLICIT_BRIDGING_ENABLED
 #if __has_feature(arc_cf_code_audited)
 #define CF_IMPLICIT_BRIDGING_ENABLED _Pragma("clang arc_cf_code_audited begin")

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -11,9 +11,6 @@
 #ifndef __COREFOUNDATION_FORSWIFTFOUNDATIONONLY__
 #define __COREFOUNDATION_FORSWIFTFOUNDATIONONLY__ 1
 
-#define NS_ASSUME_NONNULL_BEGIN _Pragma("clang assume_nonnull begin")
-#define NS_ASSUME_NONNULL_END   _Pragma("clang assume_nonnull end")
-
 #include <CoreFoundation/CFBase.h>
 #include <CoreFoundation/CFNumber.h>
 #include <CoreFoundation/CFLocaleInternal.h>
@@ -21,7 +18,7 @@
 
 #import <fts.h>
 
-NS_ASSUME_NONNULL_BEGIN
+CF_ASSUME_NONNULL_BEGIN
 
 struct __CFSwiftObject {
     uintptr_t isa;
@@ -211,6 +208,6 @@ extern void _cf_uuid_unparse(const _cf_uuid_t uu, _cf_uuid_string_t out);
 extern void _cf_uuid_unparse_lower(const _cf_uuid_t uu, _cf_uuid_string_t out);
 extern void _cf_uuid_unparse_upper(const _cf_uuid_t uu, _cf_uuid_string_t out);
 
-NS_ASSUME_NONNULL_END
+CF_ASSUME_NONNULL_END
 
 #endif /* __COREFOUNDATION_FORSWIFTFOUNDATIONONLY__ */

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -15,8 +15,8 @@
 #include <CoreFoundation/CFNumber.h>
 #include <CoreFoundation/CFLocaleInternal.h>
 #include <CoreFoundation/CFCalendar.h>
-
-#import <fts.h>
+#include <CoreFoundation/CFXMLInterface.h>
+#include <fts.h>
 
 CF_ASSUME_NONNULL_BEGIN
 
@@ -112,6 +112,68 @@ struct _NSMutableStringBridge {
     void (*_cfAppendCString)(CFTypeRef str, const char *chars, CFIndex appendLength);
 };
 
+struct _NSXMLParserBridge {
+    _CFXMLInterface _Nullable (*_Nonnull currentParser)();
+    _CFXMLInterfaceParserInput _Nonnull (*_Nonnull _xmlExternalEntityWithURL)(_CFXMLInterface interface, const char *url, const char * identifier, _CFXMLInterfaceParserContext context, _CFXMLInterfaceExternalEntityLoader originalLoaderFunction);
+    
+    _CFXMLInterfaceParserContext _Nonnull (*_Nonnull getContext)(_CFXMLInterface ctx);
+    
+    void (*internalSubset)(_CFXMLInterface ctx, const unsigned char *name, const unsigned char *ExternalID, const unsigned char *SystemID);
+    int (*isStandalone)(_CFXMLInterface ctx);
+    int (*hasInternalSubset)(_CFXMLInterface ctx);
+    int (*hasExternalSubset)(_CFXMLInterface ctx);
+    _CFXMLInterfaceEntity _Nonnull (*_Nonnull getEntity)(_CFXMLInterface ctx, const unsigned char *name);
+    void (*notationDecl)(_CFXMLInterface ctx,
+                         const unsigned char *name,
+                         const unsigned char *publicId,
+                         const unsigned char *systemId);
+    void (*attributeDecl)(_CFXMLInterface ctx,
+                          const unsigned char *elem,
+                          const unsigned char *fullname,
+                          int type,
+                          int def,
+                          const unsigned char *defaultValue,
+                          _CFXMLInterfaceEnumeration tree);
+    void (*elementDecl)(_CFXMLInterface ctx,
+                        const unsigned char *name,
+                        int type,
+                        _CFXMLInterfaceElementContent content);
+    void (*unparsedEntityDecl)(_CFXMLInterface ctx,
+                               const unsigned char *name,
+                               const unsigned char *publicId,
+                               const unsigned char *systemId,
+                               const unsigned char *notationName);
+    void (*startDocument)(_CFXMLInterface ctx);
+    void (*endDocument)(_CFXMLInterface ctx);
+    void (*startElementNs)(_CFXMLInterface ctx,
+                           const unsigned char *localname,
+                           const unsigned char *prefix,
+                           const unsigned char *URI,
+                           int nb_namespaces,
+                           const unsigned char *_Nonnull *_Nonnull namespaces,
+                           int nb_attributes,
+                           int nb_defaulted,
+                           const unsigned char *_Nonnull *_Nonnull attributes);
+    void (*endElementNs)(_CFXMLInterface ctx,
+                         const unsigned char *localname,
+                         const unsigned char *prefix,
+                         const unsigned char *URI);
+    void (*characters)(_CFXMLInterface ctx,
+                       const unsigned char *ch,
+                       int len);
+    void (*processingInstruction)(_CFXMLInterface ctx,
+                                  const unsigned char *target,
+                                  const unsigned char *data);
+    void (*cdataBlock)(_CFXMLInterface ctx,
+                       const unsigned char *value,
+                       int len);
+    void (*comment)(_CFXMLInterface ctx, const unsigned char *value);
+    void (*externalSubset)(_CFXMLInterface ctx,
+                           const unsigned char *name,
+                           const unsigned char *ExternalID,
+                           const unsigned char *SystemID);
+};
+
 struct _CFSwiftBridge {
     struct _NSObjectBridge NSObject;
     struct _NSArrayBridge NSArray;
@@ -122,6 +184,7 @@ struct _CFSwiftBridge {
     struct _NSMutableSetBridge NSMutableSet;
     struct _NSStringBridge NSString;
     struct _NSMutableStringBridge NSMutableString;
+    struct _NSXMLParserBridge NSXMLParser;
 };
 
 __attribute__((__visibility__("hidden"))) extern struct _CFSwiftBridge __CFSwiftBridge;

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -1,0 +1,219 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+/*	CFXMLInterface.c
+	Copyright (c) 2015 Apple Inc. and the Swift project authors
+ */
+
+#include <CoreFoundation/CFRuntime.h>
+#include <libxml/globals.h>
+#include <libxml/xmlerror.h>
+#include <libxml/parser.h>
+#include <libxml/parserInternals.h>
+#include <libxml/tree.h>
+#include <libxml/xmlmemory.h>
+#include "CFInternal.h"
+
+/*
+ libxml2 does not have nullability annotations and does not import well into swift when given potentially differing versions of the library that might be installed on the host operating system. This is a simple C wrapper to simplify some of that interface layer to libxml2.
+ */
+
+CFIndex _kCFXMLInterfaceRecover = XML_PARSE_RECOVER;
+CFIndex _kCFXMLInterfaceNoEnt = XML_PARSE_NOENT;
+CFIndex _kCFXMLInterfaceDTDLoad = XML_PARSE_DTDLOAD;
+CFIndex _kCFXMLInterfaceDTDAttr = XML_PARSE_DTDATTR;
+CFIndex _kCFXMLInterfaceDTDValid = XML_PARSE_DTDVALID;
+CFIndex _kCFXMLInterfaceNoError = XML_PARSE_NOERROR;
+CFIndex _kCFXMLInterfaceNoWarning = XML_PARSE_NOWARNING;
+CFIndex _kCFXMLInterfacePedantic = XML_PARSE_PEDANTIC;
+CFIndex _kCFXMLInterfaceNoBlanks = XML_PARSE_NOBLANKS;
+CFIndex _kCFXMLInterfaceSAX1 = XML_PARSE_SAX1;
+CFIndex _kCFXMLInterfaceXInclude = XML_PARSE_XINCLUDE;
+CFIndex _kCFXMLInterfaceNoNet = XML_PARSE_NONET;
+CFIndex _kCFXMLInterfaceNoDict = XML_PARSE_NODICT;
+CFIndex _kCFXMLInterfaceNSClean = XML_PARSE_NSCLEAN;
+CFIndex _kCFXMLInterfaceNoCdata = XML_PARSE_NOCDATA;
+CFIndex _kCFXMLInterfaceNoXIncnode = XML_PARSE_NOXINCNODE;
+CFIndex _kCFXMLInterfaceCompact = XML_PARSE_COMPACT;
+CFIndex _kCFXMLInterfaceOld10 = XML_PARSE_OLD10;
+CFIndex _kCFXMLInterfaceNoBasefix = XML_PARSE_NOBASEFIX;
+CFIndex _kCFXMLInterfaceHuge = XML_PARSE_HUGE;
+CFIndex _kCFXMLInterfaceOldsax = XML_PARSE_OLDSAX;
+CFIndex _kCFXMLInterfaceIgnoreEnc = XML_PARSE_IGNORE_ENC;
+CFIndex _kCFXMLInterfaceBigLines = XML_PARSE_BIG_LINES;
+
+static xmlExternalEntityLoader __originalLoader = NULL;
+
+static xmlParserInputPtr _xmlExternalEntityLoader(const char *urlStr, const char * ID, xmlParserCtxtPtr context) {
+    _CFXMLInterface parser = __CFSwiftBridge.NSXMLParser.currentParser();
+    if (parser != NULL) {
+        return __CFSwiftBridge.NSXMLParser._xmlExternalEntityWithURL(parser, urlStr, ID, context, __originalLoader);
+    }
+    return __originalLoader(urlStr, ID, context);
+}
+
+void _CFSetupXMLInterface(void) {
+    static dispatch_once_t xmlInitGuard;
+    dispatch_once(&xmlInitGuard, ^{
+        xmlInitParser();
+        // set up the external entity loader
+        __originalLoader = xmlGetExternalEntityLoader();
+        xmlSetExternalEntityLoader(_xmlExternalEntityLoader);
+    });
+}
+
+_CFXMLInterfaceParserInput _CFXMLInterfaceNoNetExternalEntityLoader(const char *URL, const char *ID, _CFXMLInterfaceParserContext ctxt) {
+    return xmlNoNetExternalEntityLoader(URL, ID, ctxt);
+}
+
+static void _errorCallback(void *ctx, const char *msg, ...) {
+    xmlParserCtxtPtr context = __CFSwiftBridge.NSXMLParser.getContext((_CFXMLInterface)ctx);
+    xmlErrorPtr error = xmlCtxtGetLastError(context);
+// TODO: reporting
+//    _reportError(error, (_CFXMLInterface)ctx);
+}
+
+_CFXMLInterfaceSAXHandler _CFXMLInterfaceCreateSAXHandler() {
+    _CFXMLInterfaceSAXHandler saxHandler = (_CFXMLInterfaceSAXHandler)calloc(1, sizeof(struct _xmlSAXHandler));
+    saxHandler->internalSubset = (internalSubsetSAXFunc)__CFSwiftBridge.NSXMLParser.internalSubset;
+    saxHandler->isStandalone = (isStandaloneSAXFunc)__CFSwiftBridge.NSXMLParser.isStandalone;
+    
+    saxHandler->hasInternalSubset = (hasInternalSubsetSAXFunc)__CFSwiftBridge.NSXMLParser.hasInternalSubset;
+    saxHandler->hasExternalSubset = (hasExternalSubsetSAXFunc)__CFSwiftBridge.NSXMLParser.hasExternalSubset;
+    
+    saxHandler->getEntity = (getEntitySAXFunc)__CFSwiftBridge.NSXMLParser.getEntity;
+    
+    saxHandler->notationDecl = (notationDeclSAXFunc)__CFSwiftBridge.NSXMLParser.notationDecl;
+    saxHandler->attributeDecl = (attributeDeclSAXFunc)__CFSwiftBridge.NSXMLParser.attributeDecl;
+    saxHandler->elementDecl = (elementDeclSAXFunc)__CFSwiftBridge.NSXMLParser.elementDecl;
+    saxHandler->unparsedEntityDecl = (unparsedEntityDeclSAXFunc)__CFSwiftBridge.NSXMLParser.unparsedEntityDecl;
+    saxHandler->startDocument = (startDocumentSAXFunc)__CFSwiftBridge.NSXMLParser.startDocument;
+    saxHandler->endDocument = (endDocumentSAXFunc)__CFSwiftBridge.NSXMLParser.endDocument;
+    saxHandler->startElementNs = (startElementNsSAX2Func)__CFSwiftBridge.NSXMLParser.startElementNs;
+    saxHandler->endElementNs = (endElementNsSAX2Func)__CFSwiftBridge.NSXMLParser.endElementNs;
+    saxHandler->characters = (charactersSAXFunc)__CFSwiftBridge.NSXMLParser.characters;
+    saxHandler->processingInstruction = (processingInstructionSAXFunc)__CFSwiftBridge.NSXMLParser.processingInstruction;
+    saxHandler->error = _errorCallback;
+    saxHandler->cdataBlock = (cdataBlockSAXFunc)__CFSwiftBridge.NSXMLParser.cdataBlock;
+    saxHandler->comment = (commentSAXFunc)__CFSwiftBridge.NSXMLParser.comment;
+    
+    saxHandler->externalSubset = (externalSubsetSAXFunc)__CFSwiftBridge.NSXMLParser.externalSubset;
+    
+    saxHandler->initialized = XML_SAX2_MAGIC; // make sure start/endElementNS are used
+    return saxHandler;
+}
+
+void _CFXMLInterfaceDestroySAXHandler(_CFXMLInterfaceSAXHandler handler) {
+    free(handler);
+}
+
+void _CFXMLInterfaceSetStructuredErrorFunc(_CFXMLInterface ctx, _CFXMLInterfaceStructuredErrorFunc handler) {
+    xmlSetStructuredErrorFunc(ctx, (xmlStructuredErrorFunc)handler);
+}
+
+_CFXMLInterfaceParserContext _CFXMLInterfaceCreatePushParserCtxt(_CFXMLInterfaceSAXHandler sax, _CFXMLInterface user_data, const char *chunk, int size, const char *filename) {
+    return xmlCreatePushParserCtxt(sax, user_data, chunk, size, filename);
+}
+
+void _CFXMLInterfaceCtxtUseOptions(_CFXMLInterfaceParserContext ctx, CFIndex options) {
+    xmlCtxtUseOptions(ctx, options);
+}
+
+int _CFXMLInterfaceParseChunk(_CFXMLInterfaceParserContext ctxt, const char *chunk, int size, int terminate) {
+    return xmlParseChunk(ctxt, chunk, size, terminate);
+}
+
+void _CFXMLInterfaceStopParser(_CFXMLInterfaceParserContext ctx) {
+    xmlStopParser(ctx);
+}
+
+void _CFXMLInterfaceDestroyContext(_CFXMLInterfaceParserContext ctx) {
+    if (ctx == NULL) return;
+    if (ctx->myDoc) {
+        xmlFreeDoc(ctx->myDoc);
+    }
+    xmlFreeParserCtxt(ctx);
+}
+
+int _CFXMLInterfaceSAX2GetLineNumber(_CFXMLInterfaceParserContext ctx) {
+    if (ctx == NULL) return 0;
+    return xmlSAX2GetLineNumber(ctx);
+}
+
+int _CFXMLInterfaceSAX2GetColumnNumber(_CFXMLInterfaceParserContext ctx) {
+    if (ctx == NULL) return 0;
+    return xmlSAX2GetColumnNumber(ctx);
+}
+
+void _CFXMLInterfaceSAX2InternalSubset(_CFXMLInterfaceParserContext ctx,
+                                       const unsigned char *name,
+                                       const unsigned char *ExternalID,
+                                       const unsigned char *SystemID) {
+    if (ctx != NULL) xmlSAX2InternalSubset(ctx, name, ExternalID, SystemID);
+}
+
+void _CFXMLInterfaceSAX2ExternalSubset(_CFXMLInterfaceParserContext ctx,
+                                       const unsigned char *name,
+                                       const unsigned char *ExternalID,
+                                       const unsigned char *SystemID) {
+    if (ctx != NULL) xmlSAX2ExternalSubset(ctx, name, ExternalID, SystemID);
+}
+
+int _CFXMLInterfaceIsStandalone(_CFXMLInterfaceParserContext ctx) {
+    if (ctx != NULL) return ctx->myDoc->standalone;
+    return 0;
+}
+
+int _CFXMLInterfaceHasInternalSubset(_CFXMLInterfaceParserContext ctx) {
+    if (ctx != NULL) return ctx->myDoc->intSubset != NULL;
+    return 0;
+}
+
+int _CFXMLInterfaceHasExternalSubset(_CFXMLInterfaceParserContext ctx) {
+    if (ctx != NULL) return ctx->myDoc->extSubset != NULL;
+    return 0;
+}
+
+_CFXMLInterfaceEntity _CFXMLInterfaceGetPredefinedEntity(const unsigned char *name) {
+    return xmlGetPredefinedEntity(name);
+}
+
+_CFXMLInterfaceEntity _CFXMLInterfaceSAX2GetEntity(_CFXMLInterfaceParserContext ctx, const unsigned char *name) {
+    if (ctx == NULL) return NULL;
+    _CFXMLInterfaceEntity entity = xmlSAX2GetEntity(ctx, name);
+    if (entity && ctx->instate == XML_PARSER_CONTENT) ctx->_private = (void *)1;
+    return entity;
+}
+
+int _CFXMLInterfaceInRecursiveState(_CFXMLInterfaceParserContext ctx) {
+    return ctx->_private == (void *)1;
+}
+
+void _CFXMLInterfaceResetRecursiveState(_CFXMLInterfaceParserContext ctx) {
+    ctx->_private = NULL;
+}
+
+int _CFXMLInterfaceHasDocument(_CFXMLInterfaceParserContext ctx) {
+    if (ctx == NULL) return 0;
+    return ctx->myDoc != NULL;
+}
+
+void _CFXMLInterfaceFreeEnumeration(_CFXMLInterfaceEnumeration enumeration) {
+    if (enumeration == NULL) return;
+    xmlFreeEnumeration(enumeration);
+}
+
+void _CFXMLInterfaceSAX2UnparsedEntityDecl(_CFXMLInterfaceParserContext ctx, const unsigned char *name, const unsigned char *publicId, const unsigned char *systemId, const unsigned char *notationName) {
+    if (ctx == NULL) return;
+    xmlSAX2UnparsedEntityDecl(ctx, name, publicId, systemId, notationName);
+}
+
+CFErrorRef _CFErrorCreateFromXMLInterface(_CFXMLInterfaceError err) {
+    return CFErrorCreate(kCFAllocatorSystemDefault, CFSTR("NSXMLParserErrorDomain"), err->code, nil);
+}

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.h
@@ -1,0 +1,100 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+/*	CFXMLInterface.h
+	Copyright (c) 2015 Apple Inc. and the Swift project authors
+ */
+
+#if !defined(__COREFOUNDATION_CFXMLINTERFACE__)
+#define __COREFOUNDATION_CFXMLINTERFACE 1
+
+#include <CoreFoundation/CFBase.h>
+#include <CoreFoundation/CFArray.h>
+#include <CoreFoundation/CFData.h>
+#include <CoreFoundation/CFDictionary.h>
+#include <CoreFoundation/CFTree.h>
+#include <CoreFoundation/CFURL.h>
+
+CF_IMPLICIT_BRIDGING_ENABLED
+CF_ASSUME_NONNULL_BEGIN
+CF_EXTERN_C_BEGIN
+
+extern CFIndex _kCFXMLInterfaceRecover;
+extern CFIndex _kCFXMLInterfaceNoEnt;
+extern CFIndex _kCFXMLInterfaceDTDLoad;
+extern CFIndex _kCFXMLInterfaceDTDAttr;
+extern CFIndex _kCFXMLInterfaceDTDValid;
+extern CFIndex _kCFXMLInterfaceNoError;
+extern CFIndex _kCFXMLInterfaceNoWarning;
+extern CFIndex _kCFXMLInterfacePedantic;
+extern CFIndex _kCFXMLInterfaceNoBlanks;
+extern CFIndex _kCFXMLInterfaceSAX1;
+extern CFIndex _kCFXMLInterfaceXInclude;
+extern CFIndex _kCFXMLInterfaceNoNet;
+extern CFIndex _kCFXMLInterfaceNoDict;
+extern CFIndex _kCFXMLInterfaceNSClean;
+extern CFIndex _kCFXMLInterfaceNoCdata;
+extern CFIndex _kCFXMLInterfaceNoXIncnode;
+extern CFIndex _kCFXMLInterfaceCompact;
+extern CFIndex _kCFXMLInterfaceOld10;
+extern CFIndex _kCFXMLInterfaceNoBasefix;
+extern CFIndex _kCFXMLInterfaceHuge;
+extern CFIndex _kCFXMLInterfaceOldsax;
+extern CFIndex _kCFXMLInterfaceIgnoreEnc;
+extern CFIndex _kCFXMLInterfaceBigLines;
+
+typedef struct _xmlParserInput *_CFXMLInterfaceParserInput;
+typedef struct _xmlParserCtxt *_CFXMLInterfaceParserContext;
+typedef struct _xmlSAXHandler *_CFXMLInterfaceSAXHandler;
+typedef struct _xmlEntity *_CFXMLInterfaceEntity;
+typedef struct _xmlEnumeration *_CFXMLInterfaceEnumeration;
+typedef struct _xmlElementContent *_CFXMLInterfaceElementContent;
+typedef struct _xmlError *_CFXMLInterfaceError;
+typedef struct __CFXMLInterface *_CFXMLInterface;
+
+typedef _CFXMLInterfaceParserInput _Nonnull (*_CFXMLInterfaceExternalEntityLoader)(const char *URL, const char *ID, _CFXMLInterfaceParserContext);
+typedef void (*_CFXMLInterfaceStructuredErrorFunc)(_CFXMLInterface ctx, _CFXMLInterfaceError error);
+
+void _CFSetupXMLInterface(void);
+_CFXMLInterfaceParserInput _CFXMLInterfaceNoNetExternalEntityLoader(const char *URL, const char *ID, _CFXMLInterfaceParserContext ctxt);
+_CFXMLInterfaceSAXHandler _CFXMLInterfaceCreateSAXHandler();
+void _CFXMLInterfaceDestroySAXHandler(_CFXMLInterfaceSAXHandler handler);
+void _CFXMLInterfaceSetStructuredErrorFunc(_CFXMLInterface ctx, _CFXMLInterfaceStructuredErrorFunc _Nullable  handler);
+_CFXMLInterfaceParserContext  _CFXMLInterfaceCreatePushParserCtxt(_CFXMLInterfaceSAXHandler _Nullable sax, _CFXMLInterface  user_data, const char * chunk, int size, const char *_Nullable filename);
+void _CFXMLInterfaceCtxtUseOptions(_CFXMLInterfaceParserContext _Nullable ctx, CFIndex options);
+int _CFXMLInterfaceParseChunk(_CFXMLInterfaceParserContext _Nullable ctxt, const char * chunk, int size, int terminate);
+void _CFXMLInterfaceStopParser(_CFXMLInterfaceParserContext _Nullable ctx);
+void _CFXMLInterfaceDestroyContext(_CFXMLInterfaceParserContext _Nullable ctx);
+int _CFXMLInterfaceSAX2GetColumnNumber(_CFXMLInterfaceParserContext _Nullable ctx);
+int _CFXMLInterfaceSAX2GetLineNumber(_CFXMLInterfaceParserContext _Nullable ctx);
+void _CFXMLInterfaceSAX2InternalSubset(_CFXMLInterfaceParserContext _Nullable ctx,
+                                       const unsigned char * name,
+                                       const unsigned char * ExternalID,
+                                       const unsigned char * SystemID);
+void _CFXMLInterfaceSAX2ExternalSubset(_CFXMLInterfaceParserContext _Nullable ctx,
+                                       const unsigned char * name,
+                                       const unsigned char * ExternalID,
+                                       const unsigned char * SystemID);
+int _CFXMLInterfaceIsStandalone(_CFXMLInterfaceParserContext _Nullable ctx);
+int _CFXMLInterfaceHasInternalSubset(_CFXMLInterfaceParserContext _Nullable ctx);
+int _CFXMLInterfaceHasExternalSubset(_CFXMLInterfaceParserContext _Nullable ctx);
+_CFXMLInterfaceEntity _Nullable _CFXMLInterfaceGetPredefinedEntity(const unsigned char * name);
+_CFXMLInterfaceEntity _Nullable _CFXMLInterfaceSAX2GetEntity(_CFXMLInterfaceParserContext _Nullable ctx, const unsigned char *  name);
+int _CFXMLInterfaceInRecursiveState(_CFXMLInterfaceParserContext ctx);
+void _CFXMLInterfaceResetRecursiveState(_CFXMLInterfaceParserContext ctx);
+int _CFXMLInterfaceHasDocument(_CFXMLInterfaceParserContext _Nullable ctx);
+void _CFXMLInterfaceFreeEnumeration(_CFXMLInterfaceEnumeration _Nullable enumeration);
+void _CFXMLInterfaceSAX2UnparsedEntityDecl(_CFXMLInterfaceParserContext _Nullable ctx, const unsigned char * name, const unsigned char *_Nullable publicId, const unsigned char *_Nullable systemId, const unsigned char *_Nullable notationName);
+CFErrorRef _CFErrorCreateFromXMLInterface(_CFXMLInterfaceError err) CF_RETURNS_RETAINED;
+
+CF_EXTERN_C_END
+CF_ASSUME_NONNULL_END
+CF_IMPLICIT_BRIDGING_DISABLED
+
+#endif /* CFXMLInterface_h */

--- a/Docs/Design.md
+++ b/Docs/Design.md
@@ -13,6 +13,8 @@ In a very limited number of cases, key Foundation API as it exists on Apple plat
 
 A significant portion of the implementation of Foundation on Apple platforms is provided by another framework called CoreFoundation (a.k.a. CF). CF is written primarily in C and is very portable. Therefore we have chosen to use it for the internal implementation of Swift Foundation where possible. As CF is present on all platforms, we can use it to provide a common implementation everywhere.
 
+Another aspect of portability is keeping dependencies to an absolute minimum. With fewer dependencies to port, it is more likely that Foundation will be able to easily compile and run on new platforms. Therefore, we will prefer solutions that are implemented in Foundation itself. Exceptions can be made for major functionality (for example, `ICU`, `libdispatch`, and `libxml2`).
+
 ## A Taxonomy of Types
 
 A key to the internal design of the framework is the split between the CF implementation and Swift implementation of the Foundation classes. They can be organized into several categories.

--- a/Docs/GettingStarted.md
+++ b/Docs/GettingStarted.md
@@ -74,3 +74,11 @@ LD_LIBRARY_PATH=../build/Ninja-ReleaseAssert/foundation-linux-x86_64/Foundation/
 ```
 
 Just copy & paste the correct line.
+
+When new source files or flags are added to the `build.py` script, the project will need to be reconfigured in order for the build system to pick them up. The top-level `swift/utils/build-script` can be used, but for quicker iteration you can use the following command to limit the reconfiguration to just the Foundation project:
+
+```
+% ninja reconfigure
+% ninja
+```
+

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -10,6 +10,10 @@
 		525AECED1BF2C9C500D15BB0 /* TestNSFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525AECEB1BF2C96400D15BB0 /* TestNSFileManager.swift */; };
 		528776141BF2629700CB0090 /* FoundationErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522C253A1BF16E1600804FC6 /* FoundationErrors.swift */; };
 		528776191BF27D9500CB0090 /* Test.plist in Resources */ = {isa = PBXBuildFile; fileRef = 528776181BF27D9500CB0090 /* Test.plist */; };
+		5B40F9EF1C124F47000E72E3 /* CFXMLInterface.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B40F9EB1C124F45000E72E3 /* CFXMLInterface.c */; };
+		5B40F9F01C125011000E72E3 /* CFXMLInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B40F9EC1C124F45000E72E3 /* CFXMLInterface.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5B40F9F21C125187000E72E3 /* TestNSXMLParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B40F9F11C125187000E72E3 /* TestNSXMLParser.swift */; };
+		5B40F9F41C12524C000E72E3 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B40F9F31C12524C000E72E3 /* libxml2.dylib */; };
 		5B5D89761BBDADD300234F36 /* libicucore.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B5D89751BBDADD300234F36 /* libicucore.dylib */; };
 		5B5D89781BBDADDB00234F36 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B5D89771BBDADDB00234F36 /* libz.dylib */; };
 		5B5D897A1BBDADDF00234F36 /* libobjc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B5D89791BBDADDF00234F36 /* libobjc.dylib */; };
@@ -189,6 +193,7 @@
 		5BF7AEBF1BCD51F9008F214A /* NSURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4A1BCC5DCB00ED97BB /* NSURL.swift */; };
 		5BF7AEC01BCD51F9008F214A /* NSUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4B1BCC5DCB00ED97BB /* NSUUID.swift */; };
 		5BF7AEC11BCD51F9008F214A /* NSValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4C1BCC5DCB00ED97BB /* NSValue.swift */; };
+		E876A73E1C1180E000F279EC /* TestNSRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = E876A73D1C1180E000F279EC /* TestNSRange.swift */; };
 		EA66F6361BEED03E00136161 /* TargetConditionals.h in Headers */ = {isa = PBXBuildFile; fileRef = EA66F6351BEED03E00136161 /* TargetConditionals.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA66F6441BF1619600136161 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA66F6381BF1619600136161 /* main.swift */; };
 		EA66F6481BF1619600136161 /* NSURLTestData.plist in Resources */ = {isa = PBXBuildFile; fileRef = EA66F63B1BF1619600136161 /* NSURLTestData.plist */; };
@@ -197,7 +202,6 @@
 		EA66F64E1BF1619600136161 /* TestNSIndexSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA66F63E1BF1619600136161 /* TestNSIndexSet.swift */; };
 		EA66F6501BF1619600136161 /* TestNSNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA66F63F1BF1619600136161 /* TestNSNumber.swift */; };
 		EA66F6521BF1619600136161 /* TestNSPropertyList.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA66F6401BF1619600136161 /* TestNSPropertyList.swift */; };
-		E876A73E1C1180E000F279EC /* TestNSRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = E876A73D1C1180E000F279EC /* TestNSRange.swift */; };
 		EA66F6541BF1619600136161 /* TestNSSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA66F6411BF1619600136161 /* TestNSSet.swift */; };
 		EA66F6561BF1619600136161 /* TestNSString.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA66F6421BF1619600136161 /* TestNSString.swift */; };
 		EA66F6581BF1619600136161 /* TestNSURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA66F6431BF1619600136161 /* TestNSURL.swift */; };
@@ -312,6 +316,10 @@
 		522C253A1BF16E1600804FC6 /* FoundationErrors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationErrors.swift; sourceTree = "<group>"; };
 		525AECEB1BF2C96400D15BB0 /* TestNSFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSFileManager.swift; sourceTree = "<group>"; };
 		528776181BF27D9500CB0090 /* Test.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Test.plist; sourceTree = "<group>"; };
+		5B40F9EB1C124F45000E72E3 /* CFXMLInterface.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFXMLInterface.c; sourceTree = "<group>"; };
+		5B40F9EC1C124F45000E72E3 /* CFXMLInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFXMLInterface.h; sourceTree = "<group>"; };
+		5B40F9F11C125187000E72E3 /* TestNSXMLParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSXMLParser.swift; sourceTree = "<group>"; };
+		5B40F9F31C12524C000E72E3 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
 		5B5D885D1BBC938800234F36 /* SwiftFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B5D886A1BBC948300234F36 /* CFApplicationPreferences.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFApplicationPreferences.c; sourceTree = "<group>"; };
 		5B5D886C1BBC94C400234F36 /* CFPreferences.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFPreferences.h; sourceTree = "<group>"; };
@@ -598,6 +606,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5B40F9F41C12524C000E72E3 /* libxml2.dylib in Frameworks */,
 				5B7C8B031BEA86A900C5B690 /* libCoreFoundation.a in Frameworks */,
 				5B5D897A1BBDADDF00234F36 /* libobjc.dylib in Frameworks */,
 				5B5D89781BBDADDB00234F36 /* libz.dylib in Frameworks */,
@@ -867,6 +876,8 @@
 				5B5D89931BBDBFCE00234F36 /* CFXMLParser.c */,
 				5B5D89911BBDBFC500234F36 /* CFXMLParser.h */,
 				5B5D899B1BBDBFEA00234F36 /* CFXMLTree.c */,
+				5B40F9EB1C124F45000E72E3 /* CFXMLInterface.c */,
+				5B40F9EC1C124F45000E72E3 /* CFXMLInterface.h */,
 			);
 			name = Parsing;
 			path = CoreFoundation/Parsing.subproj;
@@ -925,6 +936,7 @@
 		5B5D89AB1BBDCD0B00234F36 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5B40F9F31C12524C000E72E3 /* libxml2.dylib */,
 				5B5D89751BBDADD300234F36 /* libicucore.dylib */,
 				5B5D89791BBDADDF00234F36 /* libobjc.dylib */,
 				5B5D89771BBDADDB00234F36 /* libz.dylib */,
@@ -999,6 +1011,7 @@
 				EA66F6431BF1619600136161 /* TestNSURL.swift */,
 				5BC1D8BC1BF3ADFE009D3973 /* TestNSCharacterSet.swift */,
 				525AECEB1BF2C96400D15BB0 /* TestNSFileManager.swift */,
+				5B40F9F11C125187000E72E3 /* TestNSXMLParser.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -1295,6 +1308,7 @@
 				5B7C8AE11BEA80FC00C5B690 /* CFURL.h in Headers */,
 				5B7C8ABF1BEA807A00C5B690 /* CFUtilities.h in Headers */,
 				5B7C8ADD1BEA80FC00C5B690 /* CFStream.h in Headers */,
+				5B40F9F01C125011000E72E3 /* CFXMLInterface.h in Headers */,
 				5B7C8AD71BEA80FC00C5B690 /* CFPlugInCOM.h in Headers */,
 				5B7C8AFA1BEA81AC00C5B690 /* CFUniChar.h in Headers */,
 				5B7C8AC91BEA80FC00C5B690 /* CFTree.h in Headers */,
@@ -1441,7 +1455,7 @@
 		5B5D88541BBC938800234F36 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0710;
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = Apple;
 				TargetAttributes = {
@@ -1629,6 +1643,7 @@
 				5B7C8AB41BEA801700C5B690 /* CFStringEncodingDatabase.c in Sources */,
 				5B7C8A831BEA7FCE00C5B690 /* CFTree.c in Sources */,
 				5B7C8A981BEA7FF900C5B690 /* CFBundle_InfoPlist.c in Sources */,
+				5B40F9EF1C124F47000E72E3 /* CFXMLInterface.c in Sources */,
 				5B7C8A961BEA7FF900C5B690 /* CFBundle_Binary.c in Sources */,
 				5B7C8AAC1BEA800D00C5B690 /* CFString.c in Sources */,
 				5B7C8A821BEA7FCE00C5B690 /* CFStorage.c in Sources */,
@@ -1688,6 +1703,7 @@
 				EA66F64A1BF1619600136161 /* TestNSArray.swift in Sources */,
 				5BC1D8BE1BF3B09E009D3973 /* TestNSCharacterSet.swift in Sources */,
 				EA66F6561BF1619600136161 /* TestNSString.swift in Sources */,
+				5B40F9F21C125187000E72E3 /* TestNSXMLParser.swift in Sources */,
 				EA66F64C1BF1619600136161 /* TestNSDictionary.swift in Sources */,
 				EA66F6581BF1619600136161 /* TestNSURL.swift in Sources */,
 				EA66F6441BF1619600136161 /* main.swift in Sources */,
@@ -1938,6 +1954,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				EXECUTABLE_PREFIX = lib;
 				GCC_PREFIX_HEADER = CoreFoundation/Base.subproj/CoreFoundation_Prefix.h;
+				HEADER_SEARCH_PATHS = /usr/include/libxml2;
 				OTHER_CFLAGS = (
 					"-DCF_BUILDING_CF",
 					"-DDEPLOYMENT_TARGET_MACOSX",
@@ -1971,6 +1988,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				EXECUTABLE_PREFIX = lib;
 				GCC_PREFIX_HEADER = CoreFoundation/Base.subproj/CoreFoundation_Prefix.h;
+				HEADER_SEARCH_PATHS = /usr/include/libxml2;
 				OTHER_CFLAGS = (
 					"-DCF_BUILDING_CF",
 					"-DDEPLOYMENT_TARGET_MACOSX",

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4DC1D0801C12EEEF00B5948A /* TestNSPipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC1D07F1C12EEEF00B5948A /* TestNSPipe.swift */; };
 		525AECED1BF2C9C500D15BB0 /* TestNSFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525AECEB1BF2C96400D15BB0 /* TestNSFileManager.swift */; };
 		528776141BF2629700CB0090 /* FoundationErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522C253A1BF16E1600804FC6 /* FoundationErrors.swift */; };
 		528776191BF27D9500CB0090 /* Test.plist in Resources */ = {isa = PBXBuildFile; fileRef = 528776181BF27D9500CB0090 /* Test.plist */; };
@@ -313,6 +314,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4DC1D07F1C12EEEF00B5948A /* TestNSPipe.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSPipe.swift; sourceTree = "<group>"; };
 		522C253A1BF16E1600804FC6 /* FoundationErrors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationErrors.swift; sourceTree = "<group>"; };
 		525AECEB1BF2C96400D15BB0 /* TestNSFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSFileManager.swift; sourceTree = "<group>"; };
 		528776181BF27D9500CB0090 /* Test.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Test.plist; sourceTree = "<group>"; };
@@ -1004,6 +1006,7 @@
 				EA66F63D1BF1619600136161 /* TestNSDictionary.swift */,
 				EA66F63E1BF1619600136161 /* TestNSIndexSet.swift */,
 				EA66F63F1BF1619600136161 /* TestNSNumber.swift */,
+				4DC1D07F1C12EEEF00B5948A /* TestNSPipe.swift */,
 				EA66F6401BF1619600136161 /* TestNSPropertyList.swift */,
 				E876A73D1C1180E000F279EC /* TestNSRange.swift */,
 				EA66F6411BF1619600136161 /* TestNSSet.swift */,
@@ -1698,6 +1701,7 @@
 				EA66F6501BF1619600136161 /* TestNSNumber.swift in Sources */,
 				E876A73E1C1180E000F279EC /* TestNSRange.swift in Sources */,
 				EA66F6521BF1619600136161 /* TestNSPropertyList.swift in Sources */,
+				4DC1D0801C12EEEF00B5948A /* TestNSPipe.swift in Sources */,
 				EA66F64E1BF1619600136161 /* TestNSIndexSet.swift in Sources */,
 				EA66F6541BF1619600136161 /* TestNSSet.swift in Sources */,
 				EA66F64A1BF1619600136161 /* TestNSArray.swift in Sources */,

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -414,6 +414,28 @@ extension NSData {
         }
     }
     
+    public func writeToFile(path: String, atomically useAuxiliaryFile: Bool) -> Bool {
+        do {
+            try writeToFile(path, options: useAuxiliaryFile ? .DataWritingAtomic : [])
+        } catch {
+            return false
+        }
+        return true
+    }
+    
+    public func writeToURL(url: NSURL, atomically: Bool) -> Bool {
+        if url.fileURL {
+            if let path = url.path {
+                return writeToFile(path, atomically: atomically)
+            }
+        }
+        return false
+    }
+    
+    public func writeToURL(url: NSURL, options writeOptionsMask: NSDataWritingOptions) throws {
+        NSUnimplemented()
+    }
+    
     internal func enumerateByteRangesUsingBlockRethrows(block: (UnsafePointer<Void>, NSRange, UnsafeMutablePointer<Bool>) throws -> Void) throws {
         var err : ErrorType? = nil
         self.enumerateByteRangesUsingBlock() { (buf, range, stop) -> Void in

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -482,6 +482,33 @@ public class NSMutableData : NSData {
     }
 }
 
+extension NSData {
+    
+    /* Create an NSData from a Base-64 encoded NSString using the given options. By default, returns nil when the input is not recognized as valid Base-64.
+    */
+    public convenience init?(base64EncodedString base64String: String, options: NSDataBase64DecodingOptions) {
+        NSUnimplemented()
+    }
+    
+    /* Create a Base-64 encoded NSString from the receiver's contents using the given options.
+    */
+    public func base64EncodedStringWithOptions(options: NSDataBase64EncodingOptions) -> String {
+        NSUnimplemented()
+    }
+    
+    /* Create an NSData from a Base-64, UTF-8 encoded NSData. By default, returns nil when the input is not recognized as valid Base-64.
+    */
+    public convenience init?(base64EncodedData base64Data: NSData, options: NSDataBase64DecodingOptions) {
+        NSUnimplemented()
+    }
+    
+    /* Create a Base-64, UTF-8 encoded NSData from the receiver's contents using the given options.
+    */
+    public func base64EncodedDataWithOptions(options: NSDataBase64EncodingOptions) -> NSData {
+        NSUnimplemented()
+    }
+}
+
 extension NSMutableData {
 
     public func appendBytes(bytes: UnsafePointer<Void>, length: Int) {

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -168,7 +168,9 @@ extension NSData {
     
     public convenience init(bytesNoCopy bytes: UnsafeMutablePointer<Void>, length: Int, freeWhenDone b: Bool) {
         self.init(bytes: bytes, length: length, copy: true) { buffer, length in
-            free(buffer)
+            if b {
+                free(buffer)
+            }
         }
     }
 

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -255,6 +255,36 @@ extension NSData {
     public convenience init(data: NSData) {
         self.init(bytes:data.bytes, length: data.length)
     }
+    
+    public convenience init(contentsOfURL url: NSURL, options readOptionsMask: NSDataReadingOptions) throws {
+        if url.fileURL {
+            try self.init(contentsOfFile: url.path!, options: readOptionsMask)
+        } else {
+            let session = NSURLSession(configuration: NSURLSessionConfiguration.defaultSessionConfiguration())
+            let cond = NSCondition()
+            var resError: NSError?
+            var resData: NSData?
+            let task = session.dataTaskWithURL(url, completionHandler: { (data: NSData?, response: NSURLResponse?, error: NSError?) -> Void in
+                resData = data
+                resError = error
+                cond.broadcast()
+            })
+            task.resume()
+            cond.wait()
+            if resData == nil {
+                throw resError!
+            }
+            self.init(data: resData!)
+        }
+    }
+    
+    public convenience init?(contentsOfURL url: NSURL) {
+        do {
+            try self.init(contentsOfURL: url, options: [])
+        } catch {
+            return nil
+        }
+    }
 }
 
 extension NSData {

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -175,6 +175,28 @@ internal func __CFInitializeSwift() {
     __CFSwiftBridge.NSMutableString.appendString = _CFSwiftStringAppend
     __CFSwiftBridge.NSMutableString.appendCharacters = _CFSwiftStringAppendCharacters
     __CFSwiftBridge.NSMutableString._cfAppendCString = _CFSwiftStringAppendCString
+    
+    __CFSwiftBridge.NSXMLParser.currentParser = _NSXMLParserCurrentParser
+    __CFSwiftBridge.NSXMLParser._xmlExternalEntityWithURL = _NSXMLParserExternalEntityWithURL
+    __CFSwiftBridge.NSXMLParser.getContext = _NSXMLParserGetContext
+    __CFSwiftBridge.NSXMLParser.internalSubset = _NSXMLParserInternalSubset
+    __CFSwiftBridge.NSXMLParser.isStandalone = _NSXMLParserIsStandalone
+    __CFSwiftBridge.NSXMLParser.hasInternalSubset = _NSXMLParserHasInternalSubset
+    __CFSwiftBridge.NSXMLParser.hasExternalSubset = _NSXMLParserHasExternalSubset
+    __CFSwiftBridge.NSXMLParser.getEntity = _NSXMLParserGetEntity
+    __CFSwiftBridge.NSXMLParser.notationDecl = _NSXMLParserNotationDecl
+    __CFSwiftBridge.NSXMLParser.attributeDecl = _NSXMLParserAttributeDecl
+    __CFSwiftBridge.NSXMLParser.elementDecl = _NSXMLParserElementDecl
+    __CFSwiftBridge.NSXMLParser.unparsedEntityDecl = _NSXMLParserUnparsedEntityDecl
+    __CFSwiftBridge.NSXMLParser.startDocument = _NSXMLParserStartDocument
+    __CFSwiftBridge.NSXMLParser.endDocument = _NSXMLParserEndDocument
+    __CFSwiftBridge.NSXMLParser.startElementNs = _NSXMLParserStartElementNs
+    __CFSwiftBridge.NSXMLParser.endElementNs = _NSXMLParserEndElementNs
+    __CFSwiftBridge.NSXMLParser.characters = _NSXMLParserCharacters
+    __CFSwiftBridge.NSXMLParser.processingInstruction = _NSXMLParserProcessingInstruction
+    __CFSwiftBridge.NSXMLParser.cdataBlock = _NSXMLParserCdataBlock
+    __CFSwiftBridge.NSXMLParser.comment = _NSXMLParserComment
+    __CFSwiftBridge.NSXMLParser.externalSubset = _NSXMLParserExternalSubset
 }
 
 #if os(Linux)

--- a/Foundation/NSThread.swift
+++ b/Foundation/NSThread.swift
@@ -146,6 +146,8 @@ public class NSThread : NSObject {
     
     internal var _main: (Void) -> Void = {}
     internal var _thread = pthread_t()
+    /// - Note: this differs from the Darwin implementation in that the keys must be Strings
+    public var threadDictionary = [String:AnyObject]()
     
     internal init(thread: pthread_t) {
         _thread = thread

--- a/Foundation/NSXMLParser.swift
+++ b/Foundation/NSXMLParser.swift
@@ -7,6 +7,13 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(OSX) || os(iOS)
+    import Darwin
+#elseif os(Linux)
+    import Glibc
+#endif
+import CoreFoundation
+
 public enum NSXMLParserExternalEntityResolvingPolicy : UInt {
     
     case ResolveExternalEntitiesNever // default
@@ -15,58 +22,624 @@ public enum NSXMLParserExternalEntityResolvingPolicy : UInt {
     case ResolveExternalEntitiesAlways
 }
 
+extension _CFXMLInterface {
+    var parser: NSXMLParser {
+        return unsafeBitCast(self, NSXMLParser.self)
+    }
+}
+
+extension NSXMLParser {
+    internal var interface: _CFXMLInterface {
+        return unsafeBitCast(self, _CFXMLInterface.self)
+    }
+}
+
+private func UTF8STRING(bytes: UnsafePointer<UInt8>) -> String? {
+    let len = strlen(UnsafePointer<Int8>(bytes))
+    let str = String._fromCodeUnitSequence(UTF8.self, input: UnsafeBufferPointer(start: bytes, count: Int(len)))
+    return str
+}
+
+internal func _NSXMLParserCurrentParser() -> _CFXMLInterface {
+    if let parser = NSXMLParser.currentParser() {
+        return parser.interface
+    } else {
+        return nil
+    }
+}
+
+internal func _NSXMLParserExternalEntityWithURL(interface: _CFXMLInterface, urlStr: UnsafePointer<Int8>, identifier: UnsafePointer<Int8>, context: _CFXMLInterfaceParserContext, originalLoaderFunction: _CFXMLInterfaceExternalEntityLoader) -> _CFXMLInterfaceParserInput {
+    let parser = interface.parser
+    let policy = parser.externalEntityResolvingPolicy
+    var a: NSURL?
+    if let allowedEntityURLs = parser.allowedExternalEntityURLs {
+        if let url = NSURL(string: String(urlStr)) {
+            a = url
+            if let scheme = url.scheme {
+                if scheme == "file" {
+                    a = NSURL(fileURLWithPath: url.path!)
+                }
+            }
+        }
+        if let url = a {
+            let allowed = allowedEntityURLs.contains(url)
+            if allowed || policy != .ResolveExternalEntitiesSameOriginOnly {
+                if allowed {
+                    return originalLoaderFunction(urlStr, identifier, context)
+                }
+            }
+        }
+    }
+    
+    switch policy {
+    case .ResolveExternalEntitiesSameOriginOnly:
+        if let url = parser._url {
+            if a == nil {
+                a = NSURL(string: String(urlStr))
+            }
+            if let aUrl = a {
+                var matches: Bool
+                if let aHost = aUrl.host {
+                    if let host = url.host {
+                        matches = host == aHost
+                    } else {
+                        matches = false
+                    }
+                } else {
+                    matches = false
+                }
+                if matches {
+                    if let aPort = aUrl.port {
+                        if let port = url.port {
+                            matches = port == aPort
+                        } else {
+                            matches = false
+                        }
+                    } else {
+                        matches = false
+                    }
+                }
+                if matches {
+                    if let aScheme = aUrl.scheme {
+                        if let scheme = url.scheme {
+                            matches = scheme == aScheme
+                        } else {
+                            matches = false
+                        }
+                    } else {
+                        matches = false
+                    }
+                }
+                if !matches {
+                    return nil
+                }
+            }
+        }
+        break
+    case .ResolveExternalEntitiesAlways:
+        break
+    case .ResolveExternalEntitiesNever:
+        return nil
+    case .ResolveExternalEntitiesNoNetwork:
+        return _CFXMLInterfaceNoNetExternalEntityLoader(urlStr, identifier, context)
+    }
+    
+    return originalLoaderFunction(urlStr, identifier, context)
+}
+
+internal func _NSXMLParserGetContext(ctx: _CFXMLInterface) -> _CFXMLInterfaceParserContext {
+    return ctx.parser._parserContext
+}
+
+internal func _NSXMLParserInternalSubset(ctx: _CFXMLInterface, name: UnsafePointer<UInt8>, ExternalID: UnsafePointer<UInt8>, SystemID: UnsafePointer<UInt8>) -> Void {
+    _CFXMLInterfaceSAX2InternalSubset(ctx.parser._parserContext, name, ExternalID, SystemID)
+}
+
+internal func _NSXMLParserIsStandalone(ctx: _CFXMLInterface) -> Int32 {
+    return _CFXMLInterfaceIsStandalone(ctx.parser._parserContext)
+}
+
+internal func _NSXMLParserHasInternalSubset(ctx: _CFXMLInterface) -> Int32 {
+    return _CFXMLInterfaceHasInternalSubset(ctx.parser._parserContext)
+}
+
+internal func _NSXMLParserHasExternalSubset(ctx: _CFXMLInterface) -> Int32 {
+    return _CFXMLInterfaceHasExternalSubset(ctx.parser._parserContext)
+}
+
+internal func _NSXMLParserGetEntity(ctx: _CFXMLInterface, name: UnsafePointer<UInt8>) -> _CFXMLInterfaceEntity {
+    let parser = ctx.parser
+    let context = _NSXMLParserGetContext(ctx)
+    var entity = _CFXMLInterfaceGetPredefinedEntity(name)
+    if entity == nil {
+        entity = _CFXMLInterfaceSAX2GetEntity(context, name)
+    }
+    if entity == nil {
+        if let delegate = parser.delegate {
+            let entityName = UTF8STRING(name)!
+            // if the systemID was valid, we would already have the correct entity (since we're loading external dtds) so this callback is a bit of a misnomer
+            let result = delegate.parser(parser, resolveExternalEntityName: entityName, systemID: nil)
+            if _CFXMLInterfaceHasDocument(context) != 0 {
+                if let data = result {
+                    // unfortunately we can't add the entity to the doc to avoid further lookup since the delegate can change under us
+                    _NSXMLParserCharacters(ctx, ch: UnsafePointer<UInt8>(data.bytes), len: Int32(data.length))
+                }
+            }
+        }
+    }
+    return entity
+}
+
+internal func _NSXMLParserNotationDecl(ctx: _CFXMLInterface, name: UnsafePointer<UInt8>, publicId: UnsafePointer<UInt8>, systemId: UnsafePointer<UInt8>) -> Void {
+    let parser = ctx.parser
+    if let delegate = parser.delegate {
+        let notationName = UTF8STRING(name)!
+        let publicIDString = UTF8STRING(publicId)
+        let systemIDString = UTF8STRING(systemId)
+        delegate.parser(parser, foundNotationDeclarationWithName: notationName, publicID: publicIDString, systemID: systemIDString)
+    }
+}
+
+internal func _NSXMLParserAttributeDecl(ctx: _CFXMLInterface, elem: UnsafePointer<UInt8>, fullname: UnsafePointer<UInt8>, type: Int32, def: Int32, defaultValue: UnsafePointer<UInt8>, tree: _CFXMLInterfaceEnumeration) -> Void {
+    let parser = ctx.parser
+    if let delegate = parser.delegate {
+        let elementString = UTF8STRING(elem)!
+        let nameString = UTF8STRING(fullname)!
+        let typeString = "" // FIXME!
+        let defaultValueString = UTF8STRING(defaultValue)
+        delegate.parser(parser, foundAttributeDeclarationWithName: nameString, forElement: elementString, type: typeString, defaultValue: defaultValueString)
+    }
+    // in a regular sax implementation tree is added to an attribute, which takes ownership of it; in our case we need to make sure to release it
+    _CFXMLInterfaceFreeEnumeration(tree)
+}
+
+internal func _NSXMLParserElementDecl(ctx: _CFXMLInterface, name: UnsafePointer<UInt8>, type: Int32, content: _CFXMLInterfaceElementContent) -> Void {
+    let parser = ctx.parser
+    if let delegate = parser.delegate {
+        let nameString = UTF8STRING(name)!
+        let modelString = "" // FIXME!
+        delegate.parser(parser, foundElementDeclarationWithName: nameString, model: modelString)
+    }
+}
+
+internal func _NSXMLParserUnparsedEntityDecl(ctx: _CFXMLInterface, name: UnsafePointer<UInt8>, publicId: UnsafePointer<UInt8>, systemId: UnsafePointer<UInt8>, notationName: UnsafePointer<UInt8>) -> Void {
+    let parser = ctx.parser
+    let context = _NSXMLParserGetContext(ctx)
+    
+    // Add entities to the libxml2 doc so they'll resolve properly
+    _CFXMLInterfaceSAX2UnparsedEntityDecl(context, name, publicId, systemId, notationName)
+    if let delegate = parser.delegate {
+        let declName = UTF8STRING(name)!
+        let publicIDString = UTF8STRING(publicId)
+        let systemIDString = UTF8STRING(systemId)
+        let notationNameString = UTF8STRING(notationName)
+        delegate.parser(parser, foundUnparsedEntityDeclarationWithName: declName, publicID: publicIDString, systemID: systemIDString, notationName: notationNameString)
+    }
+}
+
+internal func _NSXMLParserStartDocument(ctx: _CFXMLInterface) -> Void {
+    let parser = ctx.parser
+    if let delegate = parser.delegate {
+        delegate.parserDidStartDocument(parser)
+    }
+}
+
+internal func _NSXMLParserEndDocument(ctx: _CFXMLInterface) -> Void {
+    let parser = ctx.parser
+    if let delegate = parser.delegate {
+        delegate.parserDidEndDocument(parser)
+    }
+}
+
+internal func _colonSeparatedStringFromPrefixAndSuffix(prefix: UnsafePointer<UInt8>, _ prefixlen: UInt, _ suffix: UnsafePointer<UInt8>, _ suffixLen: UInt) -> String {
+    let prefixString = String._fromCodeUnitSequence(UTF8.self, input: UnsafeBufferPointer(start: prefix, count: Int(prefixlen)))
+    let suffixString = String._fromCodeUnitSequence(UTF8.self, input: UnsafeBufferPointer(start: suffix, count: Int(suffixLen)))
+    return "\(prefixString!):\(suffixString!)"
+}
+
+internal func _NSXMLParserStartElementNs(ctx: _CFXMLInterface, localname: UnsafePointer<UInt8>, prefix: UnsafePointer<UInt8>, URI: UnsafePointer<UInt8>, nb_namespaces: Int32, namespaces: UnsafeMutablePointer<UnsafePointer<UInt8>>, nb_attributes: Int32, nb_defaulted: Int32, attributes: UnsafeMutablePointer<UnsafePointer<UInt8>>) -> Void {
+    let parser = ctx.parser
+    let reportQNameURI = parser.shouldProcessNamespaces
+    let reportNamespaces = parser.shouldReportNamespacePrefixes
+    let prefixLen = prefix == nil ? strlen(UnsafePointer<Int8>(prefix)) : 0
+    let localnameString = (prefixLen == 0 || reportQNameURI) ? UTF8STRING(localname) : nil
+    let qualifiedNameString = prefixLen != 0 ? _colonSeparatedStringFromPrefixAndSuffix(prefix, prefixLen, localname, strlen(UnsafePointer<Int8>(localname))) : localnameString
+    let namespaceURIString = reportQNameURI ? UTF8STRING(URI) : nil
+    
+    var nsDict = [String:String]()
+    var attrDict = [String:String]()
+    if nb_attributes + nb_namespaces > 0 {
+        for var idx = 0; idx < Int(nb_namespaces) * 2; idx += 2 {
+            var namespaceNameString: String?
+            var asAttrNamespaceNameString: String?
+            if namespaces[idx] != nil {
+                if reportNamespaces {
+                    namespaceNameString = UTF8STRING(namespaces[idx])
+                }
+                asAttrNamespaceNameString = _colonSeparatedStringFromPrefixAndSuffix("xmlns", 5, namespaces[idx], strlen(UnsafePointer<Int8>(namespaces[idx])))
+            } else {
+                namespaceNameString = ""
+                asAttrNamespaceNameString = "xmlns"
+            }
+            let namespaceValueString = namespaces[idx + 1] == nil ? UTF8STRING(namespaces[idx + 1]) : ""
+            if (reportNamespaces) {
+                if let k = namespaceNameString {
+                    if let v = namespaceValueString {
+                        nsDict[k] = v
+                    }
+                }
+            }
+            if !reportQNameURI {
+                if let k = asAttrNamespaceNameString {
+                    if let v = namespaceValueString {
+                        attrDict[k] = v
+                    }
+                }
+            }
+        }
+    }
+    
+    if reportNamespaces {
+        parser._pushNamespaces(nsDict)
+    }
+    
+    for var idx = 0; idx < Int(nb_attributes) * 5; idx += 5 {
+        if attributes[idx] == nil {
+            continue
+        }
+        var attributeQName: String
+        let attrLocalName = attributes[idx]
+        let attrPrefix = attributes[idx + 1]
+        let attrPrefixLen = attrPrefix == nil ? strlen(UnsafePointer<Int8>(attrPrefix)) : 0
+        if attrPrefixLen != 0 {
+            attributeQName = _colonSeparatedStringFromPrefixAndSuffix(attrPrefix, attrPrefixLen, attrLocalName, strlen((UnsafePointer<Int8>(attrLocalName))))
+        } else {
+            attributeQName = UTF8STRING(attrLocalName)!
+        }
+        // idx+2 = URI, which we throw away
+        // idx+3 = value, i+4 = endvalue
+        // By using XML_PARSE_NOENT the attribute value string will already have entities resolved
+        var attributeValue = ""
+        if attributes[idx + 3] != nil && attributes[idx + 4] != nil {
+            let numBytesWithoutTerminator = attributes[idx + 4] - attributes[idx + 3]
+            let numBytesWithTerminator = numBytesWithoutTerminator + 1
+            if numBytesWithoutTerminator != 0 {
+                var chars = [Int8](count: numBytesWithTerminator, repeatedValue: 0)
+                attributeValue = chars.withUnsafeMutableBufferPointer({ (inout buffer: UnsafeMutableBufferPointer<Int8>) -> String in
+                    strncpy(buffer.baseAddress, UnsafePointer<Int8>(attributes[idx + 3]), numBytesWithoutTerminator) //not strlcpy because attributes[i+3] is not Nul terminated
+                    return UTF8STRING(UnsafePointer<UInt8>(buffer.baseAddress))!
+                })
+            }
+            attrDict[attributeQName] = attributeValue
+        }
+        
+    }
+    
+    if let delegate = parser.delegate {
+        if reportQNameURI {
+            delegate.parser(parser, didStartElement: localnameString!, namespaceURI: (namespaceURIString != nil ? namespaceURIString : ""), qualifiedName: (qualifiedNameString != nil ? qualifiedNameString : ""), attributes: attrDict)
+        } else {
+            delegate.parser(parser, didStartElement: qualifiedNameString!, namespaceURI: nil, qualifiedName: nil, attributes: attrDict)
+        }
+    }
+}
+
+internal func _NSXMLParserEndElementNs(ctx: _CFXMLInterface , localname: UnsafePointer<UInt8>, prefix: UnsafePointer<UInt8>, URI: UnsafePointer<UInt8>) -> Void {
+    let parser = ctx.parser
+    let reportQNameURI = parser.shouldProcessNamespaces
+    let prefixLen = prefix == nil ? strlen(UnsafePointer<Int8>(prefix)) : 0
+    let localnameString = (prefixLen == 0 || reportQNameURI) ? UTF8STRING(localname) : nil
+    let nilStr: String? = nil
+    let qualifiedNameString = (prefixLen != 0) ? _colonSeparatedStringFromPrefixAndSuffix(prefix, prefixLen, localname, strlen(UnsafePointer<Int8>(localname))) : nilStr
+    let namespaceURIString = reportQNameURI ? UTF8STRING(URI) : nilStr
+    
+    
+    if let delegate = parser.delegate {
+        if (reportQNameURI) {
+            // When reporting namespace info, the delegate parameters are not passed in nil
+            delegate.parser(parser, didEndElement: localnameString!, namespaceURI: namespaceURIString == nil ? "" : namespaceURIString, qualifiedName: qualifiedNameString == nil ? "" : qualifiedNameString)
+        } else {
+            delegate.parser(parser, didEndElement: qualifiedNameString!, namespaceURI: nil, qualifiedName: nil)
+        }
+    }
+    
+    // Pop the last namespaces that were pushed (safe since XML is balanced)
+    parser._popNamespaces()
+}
+
+internal func _NSXMLParserCharacters(ctx: _CFXMLInterface, ch: UnsafePointer<UInt8>, len: Int32) -> Void {
+    let parser = ctx.parser
+    let context = parser._parserContext
+    if _CFXMLInterfaceInRecursiveState(context) != 0 {
+        _CFXMLInterfaceResetRecursiveState(context)
+    } else {
+        if let delegate = parser.delegate {
+            let str = String._fromCodeUnitSequence(UTF8.self, input: UnsafeBufferPointer(start: ch, count: Int(len)))
+            delegate.parser(parser, foundCharacters: str!)
+        }
+    }
+}
+
+internal func _NSXMLParserProcessingInstruction(ctx: _CFXMLInterface, target: UnsafePointer<UInt8>, data: UnsafePointer<UInt8>) -> Void {
+    let parser = ctx.parser
+    if let delegate = parser.delegate {
+        let targetString = UTF8STRING(target)!
+        let dataString = UTF8STRING(data)
+        delegate.parser(parser, foundProcessingInstructionWithTarget: targetString, data: dataString)
+    }
+}
+
+internal func _NSXMLParserCdataBlock(ctx: _CFXMLInterface, value: UnsafePointer<UInt8>, len: Int32) -> Void {
+    let parser = ctx.parser
+    if let delegate = parser.delegate {
+        delegate.parser(parser, foundCDATA: NSData(bytes: UnsafePointer<Void>(value), length: Int(len)))
+    }
+}
+
+internal func _NSXMLParserComment(ctx: _CFXMLInterface, value: UnsafePointer<UInt8>) -> Void {
+    let parser = ctx.parser
+    if let delegate = parser.delegate {
+        let comment = UTF8STRING(value)!
+        delegate.parser(parser, foundComment: comment)
+    }
+}
+
+internal func _NSXMLParserExternalSubset(ctx: _CFXMLInterface, name: UnsafePointer<UInt8>, ExternalID: UnsafePointer<UInt8>, SystemID: UnsafePointer<UInt8>) -> Void {
+    _CFXMLInterfaceSAX2ExternalSubset(ctx.parser._parserContext, name, ExternalID, SystemID)
+}
+
+internal func _structuredErrorFunc(interface: _CFXMLInterface, error: _CFXMLInterfaceError) {
+    let err = _CFErrorCreateFromXMLInterface(error)._nsObject
+    let parser = interface.parser
+    parser._parserError = err
+    if let delegate = parser.delegate {
+        delegate.parser(parser, parseErrorOccurred: err)
+    }
+}
+
 public class NSXMLParser : NSObject {
+    private var _handler: _CFXMLInterfaceSAXHandler
+    internal var _stream: NSInputStream?
+    internal var _data: NSData?
+    internal var _chunkSize = Int(4096 * 32) // a suitably large number for a decent chunk size
+    internal var _haveDetectedEncoding = false
+    internal var _bomChunk: NSData?
+    private var _parserContext: _CFXMLInterfaceParserContext
+    internal var _delegateAborted = false
+    internal var _url: NSURL?
+    internal var _namespaces = [[String:String]]()
     
     // initializes the parser with the specified URL.
-    public convenience init?(contentsOfURL url: NSURL) { NSUnimplemented() }
+    public convenience init?(contentsOfURL url: NSURL) {
+        if url.fileURL {
+            if let stream = NSInputStream(URL: url) {
+                self.init(stream: stream)
+                _url = url
+            }
+        } else {
+            if let data = NSData(contentsOfURL: url) {
+                self.init(data: data)
+                self._url = url
+            }
+        }
+        return nil
+    }
     
     // create the parser from data
-    public init(data: NSData) { NSUnimplemented() }
+    public init(data: NSData) {
+        _CFSetupXMLInterface()
+        _data = data.copy() as? NSData
+        _handler = _CFXMLInterfaceCreateSAXHandler()
+        _parserContext = nil
+    }
+    
+    deinit {
+        _CFXMLInterfaceDestroySAXHandler(_handler)
+        _CFXMLInterfaceDestroyContext(_parserContext)
+    }
     
     //create a parser that incrementally pulls data from the specified stream and parses it.
-    public convenience init(stream: NSInputStream) { NSUnimplemented() }
+    public init(stream: NSInputStream) {
+        _CFSetupXMLInterface()
+        _stream = stream
+        _handler = _CFXMLInterfaceCreateSAXHandler()
+        _parserContext = nil
+    }
     
     public weak var delegate: NSXMLParserDelegate?
     
-    public var shouldProcessNamespaces: Bool
-    public var shouldReportNamespacePrefixes: Bool
+    public var shouldProcessNamespaces: Bool = false
+    public var shouldReportNamespacePrefixes: Bool = false
     
     //defaults to NSXMLNodeLoadExternalEntitiesNever
-    public var externalEntityResolvingPolicy: NSXMLParserExternalEntityResolvingPolicy
+    public var externalEntityResolvingPolicy: NSXMLParserExternalEntityResolvingPolicy = .ResolveExternalEntitiesNever
     
     public var allowedExternalEntityURLs: Set<NSURL>?
-
-    // called to start the event-driven parse. Returns YES in the event of a successful parse, and NO in case of error.
-    public func parse() -> Bool { NSUnimplemented() }
-
-    // called by the delegate to stop the parse. The delegate will get an error message sent to it.
-    public func abortParsing() { NSUnimplemented() }
     
-    /*@NSCopying*/ public var parserError: NSError? { NSUnimplemented() } // can be called after a parse is over to determine parser state.
+    internal static func currentParser() -> NSXMLParser? {
+        if let current = NSThread.currentThread().threadDictionary["__CurrentNSXMLParser"] {
+            return current as? NSXMLParser
+        } else {
+            return nil
+        }
+    }
+    
+    internal static func setCurrentParser(parser: NSXMLParser?) {
+        if let p = parser {
+            NSThread.currentThread().threadDictionary["__CurrentNSXMLParser"] = p
+        } else {
+            NSThread.currentThread().threadDictionary.removeValueForKey("__CurrentNSXMLParser")
+        }
+    }
+    
+    internal func _handleParseResult(parseResult: Int32) -> Bool {
+        var result = true
+        if parseResult != 0 {
+            if parseResult != -1 {
+                // TODO: determine if this result is a fatal error from libxml via the CF implementations
+            }
+        }
+        return result
+    }
+    
+    internal func parseData(data: NSData) -> Bool {
+        _CFXMLInterfaceSetStructuredErrorFunc(interface, _structuredErrorFunc)
+        var result = true
+        /* The vast majority of this method just deals with ensuring we do a single parse
+         on the first 4 received bytes before continuing on to the actual incremental section */
+        if _haveDetectedEncoding {
+            var totalLength = data.length
+            if let chunk = _bomChunk {
+                totalLength += chunk.length
+            }
+            if (totalLength < 4) {
+                if let chunk = _bomChunk {
+                    let newData = NSMutableData()
+                    newData.appendData(chunk)
+                    newData.appendData(data)
+                    _bomChunk = newData
+                } else {
+                    _bomChunk = data
+                }
+            } else {
+                var allExistingData: NSData
+                if let chunk = _bomChunk {
+                    let newData = NSMutableData()
+                    newData.appendData(chunk)
+                    newData.appendData(data)
+                    allExistingData = newData
+                } else {
+                    allExistingData = data
+                }
+                
+                var handler: _CFXMLInterfaceSAXHandler = nil
+                if delegate != nil {
+                    handler = _handler
+                }
+                
+                _parserContext = _CFXMLInterfaceCreatePushParserCtxt(handler, interface, UnsafePointer<Int8>(allExistingData.bytes), 4, nil)
+                
+                var options = _kCFXMLInterfaceRecover | _kCFXMLInterfaceNoEnt // substitute entities, recover on errors
+                if shouldResolveExternalEntities {
+                    options |= _kCFXMLInterfaceDTDLoad
+                }
+                
+                if handler == nil {
+                    options |= (_kCFXMLInterfaceNoError | _kCFXMLInterfaceNoWarning)
+                }
+                
+                _CFXMLInterfaceCtxtUseOptions(_parserContext, options)
+                _haveDetectedEncoding = true
+                _bomChunk = nil
+                
+                if (totalLength > 4) {
+                    let remainingData = NSData(bytesNoCopy: UnsafeMutablePointer<Void>(allExistingData.bytes.advancedBy(4)), length: totalLength - 4, freeWhenDone: false)
+                    parseData(remainingData)
+                }
+            }
+        } else {
+            let parseResult = _CFXMLInterfaceParseChunk(_parserContext, UnsafePointer<Int8>(data.bytes), Int32(data.length), 0)
+            result = _handleParseResult(parseResult)
+        }
+        _CFXMLInterfaceSetStructuredErrorFunc(interface, nil)
+        return result
+    }
+    
+    internal func parseFromStream() -> Bool {
+        var result = true
+        NSXMLParser.setCurrentParser(self)
+        if let stream = _stream {
+            stream.open()
+            let buffer = malloc(_chunkSize)
+            var len = stream.read(UnsafeMutablePointer<UInt8>(buffer), maxLength: _chunkSize)
+            if len != -1 {
+                while len > 0 {
+                    let data = NSData(bytesNoCopy: buffer, length: len, freeWhenDone: false)
+                    result = parseData(data)
+                    len = stream.read(UnsafeMutablePointer<UInt8>(buffer), maxLength: _chunkSize)
+                }
+            } else {
+                result = false
+            }
+            free(buffer)
+            stream.close()
+        } else if let data = _data {
+            let buffer = malloc(_chunkSize)
+            var range = NSMakeRange(0, min(_chunkSize, data.length))
+            while result {
+                data.getBytes(buffer, range: range)
+                let chunk = NSData(bytesNoCopy: buffer, length: range.length, freeWhenDone: false)
+                result = parseData(chunk)
+                if range.location + range.length >= data.length {
+                    break
+                }
+                range = NSMakeRange(range.location + range.length, min(_chunkSize, data.length - (range.location + range.length)))
+            }
+            free(buffer)
+        } else {
+            result = false
+        }
+        NSXMLParser.setCurrentParser(nil)
+        return result
+    }
+    
+    // called to start the event-driven parse. Returns YES in the event of a successful parse, and NO in case of error.
+    public func parse() -> Bool {
+        return parseFromStream()
+    }
+    
+    // called by the delegate to stop the parse. The delegate will get an error message sent to it.
+    public func abortParsing() {
+        if _parserContext != nil {
+            _CFXMLInterfaceStopParser(_parserContext)
+            _delegateAborted = true
+        }
+    }
+    
+    internal var _parserError: NSError?
+    /*@NSCopying*/ public var parserError: NSError? { return _parserError } // can be called after a parse is over to determine parser state.
     
     //Toggles between disabling external entities entirely, and the current setting of the 'externalEntityResolvingPolicy'.
     //The 'externalEntityResolvingPolicy' property should be used instead of this, unless targeting 10.9/7.0 or earlier
-    public var shouldResolveExternalEntities: Bool
-
+    public var shouldResolveExternalEntities: Bool = false
+    
     // Once a parse has begun, the delegate may be interested in certain parser state. These methods will only return meaningful information during parsing, or after an error has occurred.
-    public var publicID: String? { NSUnimplemented() }
-    public var systemID: String? { NSUnimplemented() }
-    public var lineNumber: Int { NSUnimplemented() }
-    public var columnNumber: Int { NSUnimplemented() }
+    public var publicID: String? { return nil }
+    public var systemID: String? { return nil }
+    public var lineNumber: Int { return Int(_CFXMLInterfaceSAX2GetLineNumber(_parserContext)) }
+    public var columnNumber: Int { return Int(_CFXMLInterfaceSAX2GetColumnNumber(_parserContext)) }
+    
+    internal func _pushNamespaces(ns: [String:String]) {
+        _namespaces.append(ns)
+        if let del = self.delegate {
+            ns.forEach {
+                del.parser(self, didStartMappingPrefix: $0.0, toURI: $0.1)
+            }
+        }
+    }
+    
+    internal func _popNamespaces() {
+        let ns = _namespaces.removeLast()
+        if let del = self.delegate {
+            ns.forEach {
+                del.parser(self, didEndMappingPrefix: $0.0)
+            }
+        }
+    }
 }
 
 /*
  
  For the discussion of event methods, assume the following XML:
-
+ 
  <?xml version="1.0" encoding="UTF-8"?>
  <?xml-stylesheet type='text/css' href='cvslog.css'?>
  <!DOCTYPE cvslog SYSTEM "cvslog.dtd">
  <cvslog xmlns="http://xml.apple.com/cvslog">
-   <radar:radar xmlns:radar="http://xml.apple.com/radar">
-     <radar:bugID>2920186</radar:bugID>
-     <radar:title>API/NSXMLParser: there ought to be an NSXMLParser</radar:title>
-   </radar:radar>
+ <radar:radar xmlns:radar="http://xml.apple.com/radar">
+ <radar:bugID>2920186</radar:bugID>
+ <radar:title>API/NSXMLParser: there ought to be an NSXMLParser</radar:title>
+ </radar:radar>
  </cvslog>
  
  */
@@ -140,7 +713,7 @@ extension NSXMLParserDelegate {
     
     func parserDidStartDocument(parser: NSXMLParser) { }
     func parserDidEndDocument(parser: NSXMLParser) { }
-
+    
     func parser(parser: NSXMLParser, foundNotationDeclarationWithName name: String, publicID: String?, systemID: String?) { }
     
     func parser(parser: NSXMLParser, foundUnparsedEntityDeclarationWithName name: String, publicID: String?, systemID: String?, notationName: String?) { }

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You will want to use the [Swift Package Manager](https://swift.org/package-manag
 
 ## Working on Foundation
 
-Please see [Getting Started](Docs/GettingStarted.md).
+For information on how to build Foundation, please see [Getting Started](Docs/GettingStarted.md). Once you're ready to make changes of your own, check out our [information on contributing](CONTRIBUTING.md).
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In our first year, we are not looking to make major API changes to the library. 
 
 ### API Naming and Foundation
 
-One of the goals of the Swift 3 project is [a new set of naming guidelines](https://swift.org/documentation/api-design-guidelines.html). The Foundation project will soon update all of its names to match the new guidelines. We will also drop the 'NS' prefix from all classes.
+One of the goals of the Swift 3 project is [a new set of naming guidelines](https://swift.org/documentation/api-design-guidelines.html). The Foundation project will soon update all of its names to match the new guidelines. We will also drop the 'NS' prefix from all Foundation classes.
 
 ### Current Status
 

--- a/TestFoundation/TestNSPipe.swift
+++ b/TestFoundation/TestNSPipe.swift
@@ -19,24 +19,32 @@ import SwiftXCTest
 
 class TestNSPipe : XCTestCase {
     
+    public var allTests: [(String, () -> ())] {
+        return [
+            ("test_NSPipe", test_NSPipe)
+        ]
+    }
+    
     func test_NSPipe() {
         let aPipe = NSPipe()
         let text = "test-pipe"
         
         // First write some data into the pipe
-        aPipe.fileHandleForWriting.writeData(text.dataUsingEncoding(NSUTF8StringEncoding)!)
+        let stringAsData = text.bridge().dataUsingEncoding(NSUTF8StringEncoding)
+        XCTAssertNotNil(stringAsData)
+        aPipe.fileHandleForWriting.writeData(stringAsData!)
         
         // Then read it out again
         let data = aPipe.fileHandleForReading.readDataOfLength(text.characters.count)
         
-        // Make sure we *did* get data
+        // Confirm that we did read data
         XCTAssertNotNil(data)
         
-        // Make sure the data can be converted
+        // Confirm the data can be converted to a String
         let convertedData = String(data: data, encoding: NSUTF8StringEncoding)
         XCTAssertNotNil(convertedData)
         
-        // Make sure we did get back what we wrote in
+        // Confirm the data written in is the same as the data we read
         XCTAssertEqual(text, convertedData)
     }
 }

--- a/TestFoundation/TestNSPipe.swift
+++ b/TestFoundation/TestNSPipe.swift
@@ -20,20 +20,23 @@ import SwiftXCTest
 class TestNSPipe : XCTestCase {
     
     func test_NSPipe() {
-        let expectation = self.expectationWithDescription("Should read data")
         let aPipe = NSPipe()
-        
         let text = "test-pipe"
         
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)) { () -> Void in
-            let data = aPipe.fileHandleForReading.readDataOfLength(text.characters.count)
-            if String(data: data, encoding: NSUTF8StringEncoding) == text {
-                expectation.fulfill()
-            }
-        }
-        
+        // First write some data into the pipe
         aPipe.fileHandleForWriting.writeData(text.dataUsingEncoding(NSUTF8StringEncoding)!)
         
-        waitForExpectationsWithTimeout(1.0, handler: nil)
+        // Then read it out again
+        let data = aPipe.fileHandleForReading.readDataOfLength(text.characters.count)
+        
+        // Make sure we *did* get data
+        XCTAssertNotNil(data)
+        
+        // Make sure the data can be converted
+        let convertedData = String(data: data, encoding: NSUTF8StringEncoding)
+        XCTAssertNotNil(convertedData)
+        
+        // Make sure we did get back what we wrote in
+        XCTAssertEqual(text, convertedData)
     }
 }

--- a/TestFoundation/TestNSPipe.swift
+++ b/TestFoundation/TestNSPipe.swift
@@ -1,0 +1,39 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+import Foundation
+import XCTest
+#else
+import SwiftFoundation
+import SwiftXCTest
+#endif
+
+
+class TestNSPipe : XCTestCase {
+    
+    func test_NSPipe() {
+        let expectation = self.expectationWithDescription("Should read data")
+        let aPipe = XNPipe()
+        
+        let text = "test-pipe"
+        
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)) { () -> Void in
+            let data = aPipe.fileHandleForReading.readDataOfLength(text.characters.count)
+            if String(data: data, encoding: NSUTF8StringEncoding) == text {
+                expectation.fulfill()
+            }
+        }
+        
+        aPipe.fileHandleForWriting.writeData(text.dataUsingEncoding(NSUTF8StringEncoding)!)
+        
+        waitForExpectationsWithTimeout(1.0, handler: nil)
+    }
+}

--- a/TestFoundation/TestNSPipe.swift
+++ b/TestFoundation/TestNSPipe.swift
@@ -21,7 +21,7 @@ class TestNSPipe : XCTestCase {
     
     func test_NSPipe() {
         let expectation = self.expectationWithDescription("Should read data")
-        let aPipe = XNPipe()
+        let aPipe = NSPipe()
         
         let text = "test-pipe"
         

--- a/TestFoundation/TestNSRange.swift
+++ b/TestFoundation/TestNSRange.swift
@@ -21,7 +21,8 @@ class TestNSRange : XCTestCase {
     
     var allTests : [(String, () -> ())] {
         return [
-            ("test_NSRangeFromString", test_NSRangeFromString ),
+            // currently disabled due to pending requirements for NSString
+            // ("test_NSRangeFromString", test_NSRangeFromString ),
         ]
     }
     

--- a/TestFoundation/TestNSXMLParser.swift
+++ b/TestFoundation/TestNSXMLParser.swift
@@ -1,0 +1,37 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+import Foundation
+import XCTest
+#else
+import SwiftFoundation
+import SwiftXCTest
+#endif
+
+
+class TestNSXMLParser : XCTestCase {
+    
+    var allTests : [(String, () -> ())] {
+        return [
+            ("test_data", test_data),
+        ]
+    }
+    
+    func test_data() {
+        let xml = Array("<test><foo>bar</foo></test>".nulTerminatedUTF8)
+        let data = xml.withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<UInt8>) -> NSData in
+            return NSData(bytes:UnsafePointer<Void>(buffer.baseAddress), length: buffer.count)
+        }
+        let parser = NSXMLParser(data: data)
+        let res = parser.parse()
+        XCTAssertTrue(res)
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -26,6 +26,7 @@ XCTMain([
     TestNSDictionary(),
     TestNSSet(),
     TestNSNumber(),
+    TestNSPipe(),
     TestNSPropertyList(),
     TestNSURL(),
     TestNSIndexSet(),

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -20,4 +20,17 @@ internal func testBundle() -> NSBundle {
 }
 
 // For the Swift version of the Foundation tests, we must manually list all test cases here.
-XCTMain([TestNSString(), TestNSArray(), TestNSDictionary(), TestNSSet(), TestNSNumber(), TestNSPropertyList(), TestNSURL(), TestNSIndexSet(), TestNSCharacterSet(), TestNSFileManger(), TestNSRange()])
+XCTMain([
+    TestNSString(),
+    TestNSArray(),
+    TestNSDictionary(),
+    TestNSSet(),
+    TestNSNumber(),
+    TestNSPropertyList(),
+    TestNSURL(),
+    TestNSIndexSet(),
+    TestNSCharacterSet(),
+    TestNSFileManger(),
+    TestNSRange(),
+    TestNSXMLParser(),
+])

--- a/build.py
+++ b/build.py
@@ -42,7 +42,8 @@ foundation.CFLAGS += " ".join([
 	'-Wno-unused-variable',
 	'-Wno-int-conversion',
 	'-Wno-unused-function',
-	'-I./'
+	'-I/usr/include/libxml2',
+	'-I./',
 ])
 
 swift_cflags = [
@@ -56,7 +57,7 @@ if "XCTEST_BUILD_DIR" in Configuration.current.variables:
 	]
 foundation.SWIFTCFLAGS = " ".join(swift_cflags)
 
-foundation.LDFLAGS += '-lpthread -ldl -lm -lswiftCore '
+foundation.LDFLAGS += '-lpthread -ldl -lm -lswiftCore -lxml2 '
 
 if "XCTEST_BUILD_DIR" in Configuration.current.variables:
 	foundation.LDFLAGS += '-L${XCTEST_BUILD_DIR}'
@@ -119,6 +120,7 @@ private = [
 	'CoreFoundation/Stream.subproj/CFStreamAbstract.h',
 	'CoreFoundation/Base.subproj/CFInternal.h',
 	'CoreFoundation/Parsing.subproj/CFXMLInputStream.h',
+	'CoreFoundation/Parsing.subproj/CFXMLInterface.h',
 	'CoreFoundation/PlugIn.subproj/CFPlugIn_Factory.h',
 	'CoreFoundation/String.subproj/CFStringLocalizedFormattingInternal.h',
 	'CoreFoundation/PlugIn.subproj/CFBundle_Internal.h',
@@ -190,6 +192,7 @@ sources = CompileSources([
 	'CoreFoundation/Parsing.subproj/CFXMLNode.c',
 	'CoreFoundation/Parsing.subproj/CFXMLParser.c',
 	'CoreFoundation/Parsing.subproj/CFXMLTree.c',
+	'CoreFoundation/Parsing.subproj/CFXMLInterface.c',
 	'CoreFoundation/PlugIn.subproj/CFBundle.c',
 	'CoreFoundation/PlugIn.subproj/CFBundle_Binary.c',
 	'CoreFoundation/PlugIn.subproj/CFBundle_Grok.c',
@@ -358,6 +361,7 @@ foundation_tests = SwiftExecutable('TestFoundation', [
 	'TestFoundation/TestNSURL.swift',
     'TestFoundation/TestNSFileManager.swift',
     'TestFoundation/TestNSCharacterSet.swift',
+    'TestFoundation/TestNSXMLParser.swift',
 ])
 
 foundation_tests.add_dependency(foundation_tests_resources)

--- a/build.py
+++ b/build.py
@@ -350,19 +350,7 @@ foundation_tests_resources = CopyResources('TestFoundation', [
 # TODO: Probably this should be another 'product', but for now it's simply a phase
 foundation_tests = SwiftExecutable('TestFoundation', [
 	'TestFoundation/main.swift',
-	'TestFoundation/TestNSArray.swift',
-	'TestFoundation/TestNSIndexSet.swift',
-	'TestFoundation/TestNSDictionary.swift',
-	'TestFoundation/TestNSNumber.swift',
-	'TestFoundation/TestNSPropertyList.swift',
-	'TestFoundation/TestNSRange.swift',
-	'TestFoundation/TestNSSet.swift',
-	'TestFoundation/TestNSString.swift',
-	'TestFoundation/TestNSURL.swift',
-    'TestFoundation/TestNSFileManager.swift',
-    'TestFoundation/TestNSCharacterSet.swift',
-    'TestFoundation/TestNSXMLParser.swift',
-])
+] + glob.glob('./TestFoundation/Test*.swift')) # all TestSomething.swift are considered sources to the test project in the TestFoundation directory
 
 foundation_tests.add_dependency(foundation_tests_resources)
 foundation.add_phase(foundation_tests_resources)

--- a/configure
+++ b/configure
@@ -48,59 +48,59 @@ def reconfigure(config, path):
     with open(path, 'r') as infile:
         info = json.load(infile)
         if 'version' in info and info['version'] == config.version:
-            if 'command' in info:
+            if 'command' in info and info['command'] is not None:
                 config.command = info['command']
-            if 'project' in info:
+            if 'project' in info and info['project'] is not None:
                 config.command = info['project']
-            if 'script_path' in info:
+            if 'script_path' in info and info['script_path'] is not None:
                 config.script_path = Path(info['script_path'])
-            if 'build_script_path' in info:
+            if 'build_script_path' in info and info['build_script_path'] is not None:
                 config.build_script_path = Path(info['build_script_path'])
-            if 'source_root' in info:
+            if 'source_root' in info and info['source_root'] is not None:
                 config.source_root = Path(info['source_root'])
-            if 'target' in info:
+            if 'target' in info and info['target'] is not None:
                 config.target = Target(info['target'])
-            if 'system_root' in info:
+            if 'system_root' in info and info['system_root'] is not None:
                 config.system_root = Path(info['system_root'])
-            if 'toolchain' in info:
+            if 'toolchain' in info and info['toolchain'] is not None:
                 config.toolchain = info['toolchain']
-            if 'build_directory' in info:
+            if 'build_directory' in info and info['build_directory'] is not None:
                 config.build_directory = Path(info['build_directory'])
-            if 'intermediate_directory' in info:
+            if 'intermediate_directory' in info and info['intermediate_directory'] is not None:
                 config.intermediate_directory = Path(info['intermediate_directory'])
-            if 'module_cache_directory' in info:
+            if 'module_cache_directory' in info and info['module_cache_directory'] is not None:
                 config.module_cache_directory = Path(info['module_cache_directory'])
-            if 'install_directory' in info:
+            if 'install_directory' in info and info['install_directory'] is not None:
                 config.install_directory = Path(info['install_directory'])
-            if 'prefix' in info:
+            if 'prefix' in info and info['prefix'] is not None:
                 config.prefix = info['prefix']
-            if 'swift_install' in info:
+            if 'swift_install' in info and info['swift_install'] is not None:
                 config.swift_install = info['swift_install']
-            if 'clang' in info:
+            if 'clang' in info and info['clang'] is not None:
                 config.clang = info['clang']
-            if 'clangxx' in info:
+            if 'clangxx' in info and info['clangxx'] is not None:
                 config.clangxx = info['clangxx']
-            if 'swift' in info:
+            if 'swift' in info and info['swift'] is not None:
                 config.swift = info['swift']
-            if 'swiftc' in info:
+            if 'swiftc' in info and info['swiftc'] is not None:
                 config.swiftc = info['swiftc']
-            if 'ar' in info:
+            if 'ar' in info and info['ar'] is not None:
                 config.ar = info['ar']
-            if 'swift_sdk' in info:
+            if 'swift_sdk' in info and info['swift_sdk'] is not None:
                 config.swift_sdk = info['swift_sdk']
-            if 'bootstrap_directory' in info:
+            if 'bootstrap_directory' in info and info['bootstrap_directory'] is not None:
                 config.bootstrap_directory = Path(info['bootstrap_directory'])
-            if 'verbose' in info:
+            if 'verbose' in info and info['verbose'] is not None:
                 config.verbose = info['verbose']
-            if 'extra_c_flags' in info:
+            if 'extra_c_flags' in info and info['extra_c_flags'] is not None:
                 config.extra_c_flags = info['extra_c_flags']
-            if 'extra_swift_flags' in info:
+            if 'extra_swift_flags' in info and info['extra_swift_flags'] is not None:
                 config.extra_swift_flags = info['extra_swift_flags']
-            if 'extra_ld_flags' in info:
+            if 'extra_ld_flags' in info and info['extra_ld_flags'] is not None:
                 config.extra_ld_flags = info['extra_ld_flags']
-            if 'build_mode' in info:
+            if 'build_mode' in info and info['build_mode'] is not None:
                 config.build_mode = info['build_mode']
-            if 'variables' in info:
+            if 'variables' in info and info['variables'] is not None:
                 config.variables = info['variables']
         else:
             sys.exit("invalid version")

--- a/configure
+++ b/configure
@@ -44,6 +44,68 @@ from lib.workspace import Workspace
 
 import sys
 
+def reconfigure(config, path):
+    with open(path, 'r') as infile:
+        info = json.load(infile)
+        if 'version' in info and info['version'] == config.version:
+            if 'command' in info:
+                config.command = info['command']
+            if 'project' in info:
+                config.command = info['project']
+            if 'script_path' in info:
+                config.script_path = Path(info['script_path'])
+            if 'build_script_path' in info:
+                config.build_script_path = Path(info['build_script_path'])
+            if 'source_root' in info:
+                config.source_root = Path(info['source_root'])
+            if 'target' in info:
+                config.target = Target(info['target'])
+            if 'system_root' in info:
+                config.system_root = Path(info['system_root'])
+            if 'toolchain' in info:
+                config.toolchain = info['toolchain']
+            if 'build_directory' in info:
+                config.build_directory = Path(info['build_directory'])
+            if 'intermediate_directory' in info:
+                config.intermediate_directory = Path(info['intermediate_directory'])
+            if 'module_cache_directory' in info:
+                config.module_cache_directory = Path(info['module_cache_directory'])
+            if 'install_directory' in info:
+                config.install_directory = Path(info['install_directory'])
+            if 'prefix' in info:
+                config.prefix = info['prefix']
+            if 'swift_install' in info:
+                config.swift_install = info['swift_install']
+            if 'clang' in info:
+                config.clang = info['clang']
+            if 'clangxx' in info:
+                config.clangxx = info['clangxx']
+            if 'swift' in info:
+                config.swift = info['swift']
+            if 'swiftc' in info:
+                config.swiftc = info['swiftc']
+            if 'ar' in info:
+                config.ar = info['ar']
+            if 'swift_sdk' in info:
+                config.swift_sdk = info['swift_sdk']
+            if 'bootstrap_directory' in info:
+                config.bootstrap_directory = Path(info['bootstrap_directory'])
+            if 'verbose' in info:
+                config.verbose = info['verbose']
+            if 'extra_c_flags' in info:
+                config.extra_c_flags = info['extra_c_flags']
+            if 'extra_swift_flags' in info:
+                config.extra_swift_flags = info['extra_swift_flags']
+            if 'extra_ld_flags' in info:
+                config.extra_ld_flags = info['extra_ld_flags']
+            if 'build_mode' in info:
+                config.build_mode = info['build_mode']
+            if 'variables' in info:
+                config.variables = info['variables']
+        else:
+            sys.exit("invalid version")
+
+
 def main():
     config = Configuration()
     CWD                           = Path.path(os.getcwd())
@@ -64,49 +126,56 @@ def main():
     config.swift_sdk              = os.getenv("SDKROOT", None)
     config.script_path            = config.source_root.path_by_appending("build.py")
     config.build_script_path      = config.source_root.path_by_appending("build.ninja")
+    config.config_path            = config.source_root.path_by_appending(".configuration")
 
     parser = argparse.ArgumentParser(description='Configure and emit ninja build scripts for building.')
     parser.add_argument('--target', dest='target', type=str, default=Target.default())
     parser.add_argument('--sysroot', dest='sysroot', type=str, default=None)
     parser.add_argument('--toolchain', dest='toolchain', type=str, default=None)
     parser.add_argument('--bootstrap', dest='bootstrap', type=str, default=os.path.join(os.path.dirname(os.path.abspath(__file__)), "bootstrap"))
+    parser.add_argument('--reconfigure', dest='reconfigure', action="store_true")
     parser.add_argument('-v', '--verbose', dest='verbose', action="store_true")
     args, extras = parser.parse_known_args()
+    
+    if args.reconfigure:
+        reconfigure(config, config.config_path.absolute())
+    else:
+        config.build_mode = Configuration.Debug # by default build in debug mode
 
-    config.build_mode = Configuration.Debug # by default build in debug mode
+        for arg in extras:
+            if arg.lower() == 'debug':
+                config.build_mode = Configuration.Debug
+            elif arg.lower() == 'release':
+                config.build_mode = Configuration.Release
+            elif arg.startswith('-D'): # accept -DNAME=value as extra parameters to the configuration of the build.ninja
+                key, val = arg[2:].split("=", 1)
+                config.variables[key] = val
 
-    for arg in extras:
-        if arg.lower() == 'debug':
-            config.build_mode = Configuration.Debug
-        elif arg.lower() == 'release':
-            config.build_mode = Configuration.Release
-        elif arg.startswith('-D'): # accept -DNAME=value as extra parameters to the configuration of the build.ninja
-            key, val = arg[2:].split("=", 1)
-            config.variables[key] = val
+        config.command = [os.path.abspath(__file__)] + sys.argv[1:]
 
-    config.command = [os.path.abspath(__file__)] + sys.argv[1:]
+        config.target = Target(args.target)
 
-    config.target = Target(args.target)
+        config.system_root = Path.path(args.sysroot)
+        if config.target.sdk == OSType.MacOSX and config.system_root is None and Target(Target.default()).sdk == OSType.MacOSX:
+            import subprocess
+            config.system_root = Path.path(subprocess.Popen(['xcrun', '--show-sdk-path'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE).communicate()[0])
+            swift_path = Path.path(subprocess.Popen(['xcrun', '--find', 'swift'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE).communicate()[0]).parent().parent()
+            config.swift_sdk = swift_path.absolute()
+        elif config.swift_sdk is None:
+            config.swift_sdk = "/usr"
+        config.toolchain = Path.path(args.toolchain)
+        config.bootstrap_directory = Path.path(args.bootstrap)
+        config.verbose = args.verbose
+        if config.toolchain is not None:
+            config.ar = os.path.join(config.toolchain.relative(), "bin", "ar")
+        elif config.ar is None:
+            config.ar = "ar"
 
-    config.system_root = Path.path(args.sysroot)
-    if config.target.sdk == OSType.MacOSX and config.system_root is None and Target(Target.default()).sdk == OSType.MacOSX:
-        import subprocess
-        config.system_root = Path.path(subprocess.Popen(['xcrun', '--show-sdk-path'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE).communicate()[0])
-        swift_path = Path.path(subprocess.Popen(['xcrun', '--find', 'swift'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE).communicate()[0]).parent().parent()
-        config.swift_sdk = swift_path.absolute()
-    elif config.swift_sdk is None:
-        config.swift_sdk = "/usr"
-    config.toolchain = Path.path(args.toolchain)
-    config.bootstrap_directory = Path.path(args.bootstrap)
-    config.verbose = args.verbose
-    if config.toolchain is not None:
-        config.ar = os.path.join(config.toolchain.relative(), "bin", "ar")
-    elif config.ar is None:
-        config.ar = "ar"
-
+    config.write(config.config_path.absolute())
     Configuration.current = config
 
     execfile(config.script_path.absolute())
+
 
 if __name__ == "__main__":
     main()

--- a/configure
+++ b/configure
@@ -13,6 +13,7 @@ import sys
 import os
 import argparse
 import json
+import glob
 
 from lib.config import Configuration
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -48,21 +48,27 @@ class Configuration:
     def __init__(self):
         pass
 
+    def _encode_path(self, path):
+        if path is not None:
+            return path.absolute()
+        else:
+            return None
+
     def write(self, path):
         info = {
             'version' : self.version,
             'command' : self.command,
             'project' : self.project,
-            'script_path' : self.script_path.absolute(),
-            'build_script_path' : self.build_script_path.absolute(),
-            'source_root' : self.source_root.absolute(),
+            'script_path' : self._encode_path(self.script_path),
+            'build_script_path' : self._encode_path(self.build_script_path),
+            'source_root' : self._encode_path(self.source_root),
             'target' : self.target.triple,
-            'system_root' : self.system_root.absolute(),
+            'system_root' : self._encode_path(self.system_root),
             'toolchain' : self.toolchain,
-            'build_directory' : self.build_directory.absolute(),
-            'intermediate_directory' : self.intermediate_directory.absolute(),
-            'module_cache_directory' : self.module_cache_directory.absolute(),
-            'install_directory' : self.install_directory.absolute(),
+            'build_directory' : self._encode_path(self.build_directory),
+            'intermediate_directory' : self._encode_path(self.intermediate_directory),
+            'module_cache_directory' : self._encode_path(self.module_cache_directory),
+            'install_directory' : self._encode_path(self.install_directory),
             'prefix' : self.prefix,
             'swift_install' : self.swift_install,
             'clang' : self.clang,
@@ -71,7 +77,7 @@ class Configuration:
             'swiftc' : self.swiftc,
             'ar' : self.ar,
             'swift_sdk' : self.swift_sdk,
-            'bootstrap_directory' : self.bootstrap_directory.absolute(),
+            'bootstrap_directory' : self._encode_path(self.bootstrap_directory),
             'verbose' : self.verbose,
             'extra_c_flags' : self.extra_c_flags,
             'extra_swift_flags' : self.extra_swift_flags,

--- a/lib/config.py
+++ b/lib/config.py
@@ -7,9 +7,14 @@
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 
+import json
+
+from path import Path
+
 class Configuration:
     Debug = "debug"
     Release = "release"
+    version = 1
 
     command = None
     current = None
@@ -30,6 +35,7 @@ class Configuration:
     clangxx = None
     swift = None
     swiftc = None
+    ar = None
     swift_sdk = None
     bootstrap_directory = None
     verbose = False
@@ -37,6 +43,42 @@ class Configuration:
     extra_swift_flags = None
     extra_ld_flags = None
     build_mode = None
+    config_path = None # dont save this; else it would be recursive
     variables = {}
     def __init__(self):
         pass
+
+    def write(self, path):
+        info = {
+            'version' : self.version,
+            'command' : self.command,
+            'project' : self.project,
+            'script_path' : self.script_path.absolute(),
+            'build_script_path' : self.build_script_path.absolute(),
+            'source_root' : self.source_root.absolute(),
+            'target' : self.target.triple,
+            'system_root' : self.system_root.absolute(),
+            'toolchain' : self.toolchain,
+            'build_directory' : self.build_directory.absolute(),
+            'intermediate_directory' : self.intermediate_directory.absolute(),
+            'module_cache_directory' : self.module_cache_directory.absolute(),
+            'install_directory' : self.install_directory.absolute(),
+            'prefix' : self.prefix,
+            'swift_install' : self.swift_install,
+            'clang' : self.clang,
+            'clangxx' : self.clangxx,
+            'swift' : self.swift,
+            'swiftc' : self.swiftc,
+            'ar' : self.ar,
+            'swift_sdk' : self.swift_sdk,
+            'bootstrap_directory' : self.bootstrap_directory.absolute(),
+            'verbose' : self.verbose,
+            'extra_c_flags' : self.extra_c_flags,
+            'extra_swift_flags' : self.extra_swift_flags,
+            'extra_ld_flags' : self.extra_ld_flags,
+            'build_mode' : self.build_mode,
+            'variables' : self.variables,
+        }
+        with open(path, 'w+') as outfile:
+            json.dump(info, outfile)
+        

--- a/lib/script.py
+++ b/lib/script.py
@@ -213,7 +213,17 @@ rule SwiftExecutable
         for product in self.products:
             script += product.generate()
 
-        script += "\n\n"
+        script += """
+
+rule RunReconfigure
+    command = ./configure --reconfigure
+    description = Reconfiguring build script.
+
+build ${BUILD_DIR}/.reconfigure: RunReconfigure
+
+build reconfigure: phony | ${BUILD_DIR}/.reconfigure
+
+"""
         script += self.extra
         script += "\n\n"
 


### PR DESCRIPTION
The implementation itself is very simple. In the unlikely event that the
`pipe` system call fails, this implementation will stop with a fatalError.
This seems to be the canonical way of doing it based on my cursory reading of
the rest of foundation.

I've also added a first, simple, unit test to make sure the pipe works as expected. 