### PR TITLE
NSURLError CustomStringConvertable conformance

### DIFF
--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -28,7 +28,7 @@ private func _standardizedPath(path: String) -> String {
     return path
 }
 
-public class NSURL : NSObject, NSSecureCoding, NSCopying {
+public class NSURL : NSObject, NSSecureCoding, NSCopying, CustomStringConvertible {
     typealias CFType = CFURLRef
     internal var _base = _CFInfo(typeID: CFURLGetTypeID())
     internal var _flags : UInt32 = 0
@@ -341,6 +341,16 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
     
     override internal var _cfTypeID: CFTypeID {
         return CFURLGetTypeID()
+    }
+    
+    override public var description: String {
+        // The percent encoding is removed to ensure readability
+        if let absoluteString = self.absoluteString,
+            let unencodedString = NSString(absoluteString).stringByRemovingPercentEncoding {
+            return unencodedString
+        } else {
+            return super.description
+        }
     }
 }
 

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -344,10 +344,8 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying, CustomStringConvertibl
     }
     
     override public var description: String {
-        // The percent encoding is removed to ensure readability
-        if let absoluteString = self.absoluteString,
-            let unencodedString = NSString(absoluteString).stringByRemovingPercentEncoding {
-            return unencodedString
+        if let absoluteString = self.absoluteString {
+            return absoluteString
         } else {
             return super.description
         }

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -50,6 +50,7 @@ class TestNSURL : XCTestCase {
             ("test_fileURLWithPath_relativeToURL", test_fileURLWithPath_relativeToURL ),
             ("test_fileURLWithPath", test_fileURLWithPath),
             ("test_fileURLWithPath_isDirectory", test_fileURLWithPath_isDirectory),
+            ("test_description", test_description),
         ]
     }
     
@@ -343,4 +344,11 @@ class TestNSURL : XCTestCase {
         */
     }
 
+    func test_description() {
+        // test with file that exists
+        let path = TestNSURL.gFileExistsPath
+        let url = NSURL(fileURLWithPath: path)
+        
+        XCTAssertEqual(path, url.description, "expected description does not match")
+    }
 }


### PR DESCRIPTION
I've added conformance to CustomStringConvertable to NSURL. I want to make sure that this is the intended support before adding additional support throughout the framework or if we are just going to rely on overriding the getter for the description property?

This is less about getting API parity with Foundation and more about making it bridge better with Swift.