### PR TITLE
NSGeometry: add unit tests

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		5BF7AEBF1BCD51F9008F214A /* NSURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4A1BCC5DCB00ED97BB /* NSURL.swift */; };
 		5BF7AEC01BCD51F9008F214A /* NSUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4B1BCC5DCB00ED97BB /* NSUUID.swift */; };
 		5BF7AEC11BCD51F9008F214A /* NSValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4C1BCC5DCB00ED97BB /* NSValue.swift */; };
+		88D28DE71C13AE9000494606 /* TestNSGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D28DE61C13AE9000494606 /* TestNSGeometry.swift */; };
 		C93559291C12C49F009FD6A9 /* TestNSAffineTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */; };
 		E876A73E1C1180E000F279EC /* TestNSRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = E876A73D1C1180E000F279EC /* TestNSRange.swift */; };
 		EA66F6361BEED03E00136161 /* TargetConditionals.h in Headers */ = {isa = PBXBuildFile; fileRef = EA66F6351BEED03E00136161 /* TargetConditionals.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -519,6 +520,7 @@
 		5BDC3FCF1BCF17E600ED97BB /* NSCFSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSCFSet.swift; sourceTree = "<group>"; };
 		5BDC405C1BD6D83B00ED97BB /* TestFoundation.app */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestFoundation.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BF7AEC21BCD568D008F214A /* ForSwiftFoundationOnly.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ForSwiftFoundationOnly.h; sourceTree = "<group>"; };
+		88D28DE61C13AE9000494606 /* TestNSGeometry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSGeometry.swift; sourceTree = "<group>"; };
 		C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSAffineTransform.swift; sourceTree = "<group>"; };
 		E876A73D1C1180E000F279EC /* TestNSRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSRange.swift; sourceTree = "<group>"; };
 		EA313DFC1BE7F2E90060A403 /* CFURLComponents_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFURLComponents_Internal.h; sourceTree = "<group>"; };
@@ -1010,8 +1012,11 @@
 			children = (
 				C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */,
 				EA66F63C1BF1619600136161 /* TestNSArray.swift */,
+				5BC1D8BC1BF3ADFE009D3973 /* TestNSCharacterSet.swift */,
 				52829AD61C160D64003BC4EF /* TestNSCalendar.swift */,
 				EA66F63D1BF1619600136161 /* TestNSDictionary.swift */,
+				525AECEB1BF2C96400D15BB0 /* TestNSFileManager.swift */,
+				88D28DE61C13AE9000494606 /* TestNSGeometry.swift */,
 				EA66F63E1BF1619600136161 /* TestNSIndexSet.swift */,
 				EA66F63F1BF1619600136161 /* TestNSNumber.swift */,
 				4DC1D07F1C12EEEF00B5948A /* TestNSPipe.swift */,
@@ -1020,8 +1025,6 @@
 				EA66F6411BF1619600136161 /* TestNSSet.swift */,
 				EA66F6421BF1619600136161 /* TestNSString.swift */,
 				EA66F6431BF1619600136161 /* TestNSURL.swift */,
-				5BC1D8BC1BF3ADFE009D3973 /* TestNSCharacterSet.swift */,
-				525AECEB1BF2C96400D15BB0 /* TestNSFileManager.swift */,
 				5B40F9F11C125187000E72E3 /* TestNSXMLParser.swift */,
 				22B9C1E01C165D7A00DECFF9 /* TestNSDate.swift */,
 			);
@@ -1720,6 +1723,7 @@
 				5BC1D8BE1BF3B09E009D3973 /* TestNSCharacterSet.swift in Sources */,
 				EA66F6561BF1619600136161 /* TestNSString.swift in Sources */,
 				5B40F9F21C125187000E72E3 /* TestNSXMLParser.swift in Sources */,
+				88D28DE71C13AE9000494606 /* TestNSGeometry.swift in Sources */,
 				EA66F64C1BF1619600136161 /* TestNSDictionary.swift in Sources */,
 				EA66F6581BF1619600136161 /* TestNSURL.swift in Sources */,
 				EA66F6441BF1619600136161 /* main.swift in Sources */,

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -47,8 +47,7 @@ public struct CGPoint {
     public var x: CGFloat
     public var y: CGFloat
     public init() {
-        self.x = CGFloat()
-        self.y = CGFloat()
+        self.init(x: CGFloat(), y: CGFloat())
     }
     public init(x: CGFloat, y: CGFloat) {
         self.x = x
@@ -59,15 +58,14 @@ public struct CGPoint {
 extension CGPoint: Equatable { }
 
 public func ==(lhs: CGPoint, rhs: CGPoint) -> Bool {
-    return (lhs.x == rhs.x) && (lhs.y == rhs.y)
+    return lhs.x == rhs.x && lhs.y == rhs.y
 }
 
 public struct CGSize {
     public var width: CGFloat
     public var height: CGFloat
     public init() {
-        self.width = CGFloat()
-        self.height = CGFloat()
+        self.init(width: CGFloat(), height: CGFloat())
     }
     public init(width: CGFloat, height: CGFloat) {
         self.width = width
@@ -78,15 +76,14 @@ public struct CGSize {
 extension CGSize: Equatable { }
 
 public func ==(lhs: CGSize, rhs: CGSize) -> Bool {
-    return (lhs.width == rhs.width) && (lhs.height == rhs.height)
+    return lhs.width == rhs.width && lhs.height == rhs.height
 }
 
 public struct CGRect {
     public var origin: CGPoint
     public var size: CGSize
     public init() {
-        self.origin = CGPoint()
-        self.size = CGSize()
+        self.init(origin: CGPoint(), size: CGSize())
     }
     public init(origin: CGPoint, size: CGSize) {
         self.origin = origin
@@ -97,7 +94,7 @@ public struct CGRect {
 extension CGRect: Equatable { }
 
 public func ==(lhs: CGRect, rhs: CGRect) -> Bool {
-    return (lhs.origin == rhs.origin) && (lhs.size == rhs.size)
+    return lhs.origin == rhs.origin && lhs.size == rhs.size
 }
 
 public typealias NSPoint = CGPoint
@@ -149,10 +146,7 @@ public struct NSEdgeInsets {
     public var right: CGFloat
 
     public init() {
-        self.top = CGFloat()
-        self.left = CGFloat()
-        self.bottom = CGFloat()
-        self.right = CGFloat()
+        self.init(top: CGFloat(), left: CGFloat(), bottom: CGFloat(), right: CGFloat())
     }
 
     public init(top: CGFloat, left: CGFloat, bottom: CGFloat, right: CGFloat) {
@@ -187,8 +181,9 @@ public struct NSAlignmentOptions : OptionSetType {
     public static let AlignMaxYNearest = NSAlignmentOptions(rawValue: 1 << 19)
     public static let AlignWidthNearest = NSAlignmentOptions(rawValue: 1 << 20)
     public static let AlignHeightNearest = NSAlignmentOptions(rawValue: 1 << 21)
-    
-    public static let AlignRectFlipped = NSAlignmentOptions(rawValue: 1 << 63) // pass this if the rect is in a flipped coordinate system. This allows 0.5 to be treated in a visually consistent way.
+
+    // pass this if the rect is in a flipped coordinate system. This allows 0.5 to be treated in a visually consistent way.
+    public static let AlignRectFlipped = NSAlignmentOptions(rawValue: 1 << 63)
     
     // convenience combinations
     public static let AlignAllEdgesInward = [NSAlignmentOptions.AlignMinXInward, NSAlignmentOptions.AlignMaxXInward, NSAlignmentOptions.AlignMinYInward, NSAlignmentOptions.AlignMaxYInward]
@@ -201,11 +196,17 @@ public let NSZeroSize: NSSize = NSSize()
 public let NSZeroRect: NSRect = NSRect()
 public let NSEdgeInsetsZero: NSEdgeInsets = NSEdgeInsets()
 
-public func NSMakePoint(x: CGFloat, _ y: CGFloat) -> NSPoint { return NSPoint(x: x, y: y) }
+public func NSMakePoint(x: CGFloat, _ y: CGFloat) -> NSPoint {
+    return NSPoint(x: x, y: y)
+}
 
-public func NSMakeSize(w: CGFloat, _ h: CGFloat) -> NSSize { return NSSize(width: w, height: h) }
+public func NSMakeSize(w: CGFloat, _ h: CGFloat) -> NSSize {
+    return NSSize(width: w, height: h)
+}
 
-public func NSMakeRect(x: CGFloat, _ y: CGFloat, _ w: CGFloat, _ h: CGFloat) -> NSRect { return NSRect(origin: NSPoint(x: x, y: y), size: NSSize(width: w, height: h)) }
+public func NSMakeRect(x: CGFloat, _ y: CGFloat, _ w: CGFloat, _ h: CGFloat) -> NSRect {
+    return NSRect(origin: NSPoint(x: x, y: y), size: NSSize(width: w, height: h))
+}
 
 public func NSMaxX(aRect: NSRect) -> CGFloat { return CGFloat(aRect.origin.x.native + aRect.size.width.native) }
 
@@ -235,20 +236,27 @@ public func NSSizeFromCGSize(cgsize: CGSize) -> NSSize { return cgsize }
 
 public func NSSizeToCGSize(nssize: NSSize) -> CGSize { return nssize }
 
-public func NSEdgeInsetsMake(top: CGFloat, _ left: CGFloat, _ bottom: CGFloat, _ right: CGFloat) -> NSEdgeInsets { return NSEdgeInsets(top: top, left: left, bottom: bottom, right: right) }
+public func NSEdgeInsetsMake(top: CGFloat, _ left: CGFloat, _ bottom: CGFloat, _ right: CGFloat) -> NSEdgeInsets {
+    return NSEdgeInsets(top: top, left: left, bottom: bottom, right: right)
+}
 
 public func NSEqualPoints(aPoint: NSPoint, _ bPoint: NSPoint) -> Bool { return aPoint == bPoint }
+
 public func NSEqualSizes(aSize: NSSize, _ bSize: NSSize) -> Bool { return aSize == bSize }
+
 public func NSEqualRects(aRect: NSRect, _ bRect: NSRect) -> Bool { return aRect == bRect }
+
 public func NSIsEmptyRect(aRect: NSRect) -> Bool { return (aRect.size.width.native <= 0) || (aRect.size.height.native <= 0) }
-public func NSEdgeInsetsEqual(aInsets: NSEdgeInsets, _ bInsets: NSEdgeInsets) -> Bool { return (aInsets.top == bInsets.top) && (aInsets.left == bInsets.left) && (aInsets.bottom == bInsets.bottom) && (aInsets.right == bInsets.right) }
+
+public func NSEdgeInsetsEqual(aInsets: NSEdgeInsets, _ bInsets: NSEdgeInsets) -> Bool {
+    return (aInsets.top == bInsets.top) && (aInsets.left == bInsets.left) && (aInsets.bottom == bInsets.bottom) && (aInsets.right == bInsets.right)
+}
 
 public func NSInsetRect(aRect: NSRect, _ dX: CGFloat, _ dY: CGFloat) -> NSRect {
     let x = CGFloat(aRect.origin.x.native + dX.native)
     let y = CGFloat(aRect.origin.y.native + dY.native)
     let w = CGFloat(aRect.size.width.native - (dX.native * 2))
     let h = CGFloat(aRect.size.height.native - (dY.native * 2))
-
     return NSMakeRect(x, y, w, h)
 }
 
@@ -307,5 +315,3 @@ extension NSCoder {
     public func decodeSizeForKey(key: String) -> NSSize { NSUnimplemented() }
     public func decodeRectForKey(key: String) -> NSRect { NSUnimplemented() }
 }
-
-

--- a/TestFoundation/TestNSGeometry.swift
+++ b/TestFoundation/TestNSGeometry.swift
@@ -1,0 +1,141 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+
+class TestNSGeometry : XCTestCase {
+
+    var allTests : [(String, () -> ())] {
+        return [
+            ("test_CGFloat_BasicConstruction", test_CGFloat_BasicConstruction),
+            ("test_CGFloat_Equality", test_CGFloat_Equality),
+            ("test_CGFloat_LessThanOrEqual", test_CGFloat_LessThanOrEqual),
+            ("test_CGFloat_GreaterThanOrEqual", test_CGFloat_GreaterThanOrEqual),
+            ("test_CGPoint_BasicConstruction", test_CGPoint_BasicConstruction),
+            ("test_CGSize_BasicConstruction", test_CGSize_BasicConstruction),
+            ("test_CGRect_BasicConstruction", test_CGRect_BasicConstruction),
+            ("test_NSMakePoint", test_NSMakePoint),
+            ("test_NSMakeSize", test_NSMakeSize),
+            ("test_NSMakeRect", test_NSMakeRect),
+        ]
+    }
+
+    func test_CGFloat_BasicConstruction() {
+        XCTAssertEqual(CGFloat().native, 0.0)
+        XCTAssertEqual(CGFloat(Double(3.0)).native, 3.0)
+    }
+
+    func test_CGFloat_Equality() {
+        XCTAssertEqual(CGFloat(), CGFloat())
+        XCTAssertEqual(CGFloat(1.0), CGFloat(1.0))
+        XCTAssertEqual(CGFloat(-42.0), CGFloat(-42.0))
+
+        XCTAssertNotEqual(CGFloat(1.0), CGFloat(1.4))
+        XCTAssertNotEqual(CGFloat(37.3), CGFloat(-42.0))
+        XCTAssertNotEqual(CGFloat(1.345), CGFloat())
+    }
+
+    func test_CGFloat_LessThanOrEqual() {
+        let w = CGFloat(-4.5)
+        let x = CGFloat(1.0)
+        let y = CGFloat(2.2)
+
+        XCTAssertLessThanOrEqual(CGFloat(), CGFloat())
+        XCTAssertLessThanOrEqual(w, w)
+        XCTAssertLessThanOrEqual(y, y)
+
+        XCTAssertLessThan(w, x)
+        XCTAssertLessThanOrEqual(w, x)
+        XCTAssertLessThan(x, y)
+        XCTAssertLessThanOrEqual(x, y)
+        XCTAssertLessThan(w, y)
+        XCTAssertLessThanOrEqual(w, y)
+    }
+
+    func test_CGFloat_GreaterThanOrEqual() {
+        let w = CGFloat(-4.5)
+        let x = CGFloat(1.0)
+        let y = CGFloat(2.2)
+
+        XCTAssertGreaterThanOrEqual(CGFloat(), CGFloat())
+        XCTAssertGreaterThanOrEqual(w, w)
+        XCTAssertGreaterThanOrEqual(y, y)
+
+        XCTAssertGreaterThan(x, w)
+        XCTAssertGreaterThanOrEqual(x, w)
+        XCTAssertGreaterThan(y, x)
+        XCTAssertGreaterThanOrEqual(y, x)
+        XCTAssertGreaterThan(y, w)
+        XCTAssertGreaterThanOrEqual(y, w)
+    }
+
+    func test_CGPoint_BasicConstruction() {
+        let p1 = CGPoint()
+        XCTAssertEqual(p1.x, CGFloat(0.0))
+        XCTAssertEqual(p1.y, CGFloat(0.0))
+
+        let p2 = CGPoint(x: CGFloat(3.6), y: CGFloat(4.5))
+        XCTAssertEqual(p2.x, CGFloat(3.6))
+        XCTAssertEqual(p2.y, CGFloat(4.5))
+    }
+
+    func test_CGSize_BasicConstruction() {
+        let s1 = CGSize()
+        XCTAssertEqual(s1.width, CGFloat(0.0))
+        XCTAssertEqual(s1.height, CGFloat(0.0))
+
+        let s2 = CGSize(width: CGFloat(3.6), height: CGFloat(4.5))
+        XCTAssertEqual(s2.width, CGFloat(3.6))
+        XCTAssertEqual(s2.height, CGFloat(4.5))
+    }
+
+    func test_CGRect_BasicConstruction() {
+        let r1 = CGRect()
+        XCTAssertEqual(r1.origin.x, CGFloat(0.0))
+        XCTAssertEqual(r1.origin.y, CGFloat(0.0))
+        XCTAssertEqual(r1.size.width, CGFloat(0.0))
+        XCTAssertEqual(r1.size.height, CGFloat(0.0))
+
+        let p = CGPoint(x: CGFloat(2.2), y: CGFloat(3.0))
+        let s = CGSize(width: CGFloat(5.0), height: CGFloat(5.0))
+        let r2 = CGRect(origin: p, size: s)
+        XCTAssertEqual(r2.origin.x, p.x)
+        XCTAssertEqual(r2.origin.y, p.y)
+        XCTAssertEqual(r2.size.width, s.width)
+        XCTAssertEqual(r2.size.height, s.height)
+    }
+
+    func test_NSMakePoint() {
+        let p2 = NSMakePoint(CGFloat(3.6), CGFloat(4.5))
+        XCTAssertEqual(p2.x, CGFloat(3.6))
+        XCTAssertEqual(p2.y, CGFloat(4.5))
+    }
+
+    func test_NSMakeSize() {
+        let s2 = NSMakeSize(CGFloat(3.6), CGFloat(4.5))
+        XCTAssertEqual(s2.width, CGFloat(3.6))
+        XCTAssertEqual(s2.height, CGFloat(4.5))
+    }
+
+    func test_NSMakeRect() {
+        let r2 = NSMakeRect(CGFloat(2.2), CGFloat(3.0), CGFloat(5.0), CGFloat(5.0))
+        XCTAssertEqual(r2.origin.x, CGFloat(2.2))
+        XCTAssertEqual(r2.origin.y, CGFloat(3.0))
+        XCTAssertEqual(r2.size.width, CGFloat(5.0))
+        XCTAssertEqual(r2.size.height, CGFloat(5.0))
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -37,4 +37,5 @@ XCTMain([
     TestNSRange(),
     TestNSXMLParser(),
     TestNSDate(),
+    TestNSGeometry(),
 ])


### PR DESCRIPTION
This PR implements the following:

- `NSMake*` functions from `NSGeometry`
    - `NSMakePoint`
    - `NSMakeSize`
    - `NSMakeRect` 
- Simplify the default initializers to delegate to the memberwise initializers
- Unit tests for all additions/changes

I decided to make `CGFloat` implement `Comparable` mostly to simplify testing. (Since `CGFloat(1.0).native` became very verbose and repetitive.) However, I noticed that a PR for [conforming `NSDate` to `Comparable`](https://github.com/apple/swift-corelibs-foundation/pull/19) was declined because it was considered an API change. It's not clear if this is also considered an API change that necessitates following the *Swift evolution process* since `CGFloat` is more or less a a basic type? In any case, I'm happy to make any necessary changes.