### PR TITLE
NSString: uppercaseString, lowercaseString, capitalizedString

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -500,48 +500,21 @@ extension NSString {
     }
     
     public func uppercaseStringWithLocale(locale: NSLocale?) -> String {
-        func uppercase(cfstring: CFString) -> String {
-            let uppercaseMutableCFString = CFStringCreateMutableCopy(kCFAllocatorSystemDefault, 0, cfstring)
-            CFStringUppercase(uppercaseMutableCFString, locale?._cfObject ?? nil)
-            return uppercaseMutableCFString._swiftObject
-        }
-
-        let characters = CFStringGetCharactersPtr(self._cfObject)
-        if characters != nil, let createdCFString = CFStringCreateWithCharacters(kCFAllocatorSystemDefault, characters, CFStringGetLength(self._cfObject)) {
-            return uppercase(createdCFString)
-        } else {
-            return uppercase(self._cfObject)
-        }
+        let mutableCopy = CFStringCreateMutableCopy(kCFAllocatorSystemDefault, 0, self._cfObject)
+        CFStringUppercase(mutableCopy, locale?._cfObject ?? nil)
+        return mutableCopy._swiftObject
     }
 
     public func lowercaseStringWithLocale(locale: NSLocale?) -> String {
-        func lowercase(cfstring: CFString) -> String {
-            let lowercaseMutableCFString = CFStringCreateMutableCopy(kCFAllocatorSystemDefault, 0, cfstring)
-            CFStringLowercase(lowercaseMutableCFString, locale?._cfObject ?? nil)
-            return lowercaseMutableCFString._swiftObject
-        }
-
-        let characters = CFStringGetCharactersPtr(self._cfObject)
-        if characters != nil, let createdCFString = CFStringCreateWithCharacters(kCFAllocatorSystemDefault, characters, CFStringGetLength(self._cfObject)) {
-            return lowercase(createdCFString)
-        } else {
-            return lowercase(self._cfObject)
-        }
+        let mutableCopy = CFStringCreateMutableCopy(kCFAllocatorSystemDefault, 0, self._cfObject)
+        CFStringLowercase(mutableCopy, locale?._cfObject ?? nil)
+        return mutableCopy._swiftObject
     }
     
     public func capitalizedStringWithLocale(locale: NSLocale?) -> String {
-        func capitalize(cfstring: CFString) -> String {
-            let capitalizeMutableCFString = CFStringCreateMutableCopy(kCFAllocatorSystemDefault, 0, cfstring)
-            CFStringCapitalize(capitalizeMutableCFString, locale?._cfObject ?? nil)
-            return capitalizeMutableCFString._swiftObject
-        }
-
-        let characters = CFStringGetCharactersPtr(self._cfObject)
-        if characters != nil, let createdCFString = CFStringCreateWithCharacters(kCFAllocatorSystemDefault, characters, CFStringGetLength(self._cfObject)) {
-            return capitalize(createdCFString)
-        } else {
-            return capitalize(self._cfObject)
-        }
+        let mutableCopy = CFStringCreateMutableCopy(kCFAllocatorSystemDefault, 0, self._cfObject)
+        CFStringCapitalize(mutableCopy, locale?._cfObject ?? nil)
+        return mutableCopy._swiftObject
     }
     
     public func getLineStart(startPtr: UnsafeMutablePointer<Int>, end lineEndPtr: UnsafeMutablePointer<Int>, contentsEnd contentsEndPtr: UnsafeMutablePointer<Int>, forRange range: NSRange) {

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -465,50 +465,83 @@ extension NSString {
     
     public var uppercaseString: String {
         get {
-            NSUnimplemented()
+            return uppercaseStringWithLocale(nil)
         }
     }
-    
+
     public var lowercaseString: String {
         get {
-            NSUnimplemented()
+            return lowercaseStringWithLocale(nil)
         }
     }
     
     public var capitalizedString: String {
         get {
-            NSUnimplemented()
+            return capitalizedStringWithLocale(nil)
         }
     }
     
     public var localizedUppercaseString: String {
         get {
-            NSUnimplemented()
+            return uppercaseStringWithLocale(NSLocale.currentLocale())
         }
     }
     
     public var localizedLowercaseString: String {
         get {
-            NSUnimplemented()
+            return lowercaseStringWithLocale(NSLocale.currentLocale())
         }
     }
     
     public var localizedCapitalizedString: String {
         get {
-            NSUnimplemented()
+            return capitalizedStringWithLocale(NSLocale.currentLocale())
         }
     }
     
     public func uppercaseStringWithLocale(locale: NSLocale?) -> String {
-        NSUnimplemented()
+        func uppercase(cfstring: CFString) -> String {
+            let uppercaseMutableCFString = CFStringCreateMutableCopy(kCFAllocatorSystemDefault, 0, cfstring)
+            CFStringUppercase(uppercaseMutableCFString, locale?._cfObject ?? nil)
+            return uppercaseMutableCFString._swiftObject
+        }
+
+        let characters = CFStringGetCharactersPtr(self._cfObject)
+        if characters != nil, let createdCFString = CFStringCreateWithCharacters(kCFAllocatorSystemDefault, characters, CFStringGetLength(self._cfObject)) {
+            return uppercase(createdCFString)
+        } else {
+            return uppercase(self._cfObject)
+        }
     }
-    
+
     public func lowercaseStringWithLocale(locale: NSLocale?) -> String {
-        NSUnimplemented()
+        func lowercase(cfstring: CFString) -> String {
+            let lowercaseMutableCFString = CFStringCreateMutableCopy(kCFAllocatorSystemDefault, 0, cfstring)
+            CFStringLowercase(lowercaseMutableCFString, locale?._cfObject ?? nil)
+            return lowercaseMutableCFString._swiftObject
+        }
+
+        let characters = CFStringGetCharactersPtr(self._cfObject)
+        if characters != nil, let createdCFString = CFStringCreateWithCharacters(kCFAllocatorSystemDefault, characters, CFStringGetLength(self._cfObject)) {
+            return lowercase(createdCFString)
+        } else {
+            return lowercase(self._cfObject)
+        }
     }
     
     public func capitalizedStringWithLocale(locale: NSLocale?) -> String {
-        NSUnimplemented()
+        func capitalize(cfstring: CFString) -> String {
+            let capitalizeMutableCFString = CFStringCreateMutableCopy(kCFAllocatorSystemDefault, 0, cfstring)
+            CFStringCapitalize(capitalizeMutableCFString, locale?._cfObject ?? nil)
+            return capitalizeMutableCFString._swiftObject
+        }
+
+        let characters = CFStringGetCharactersPtr(self._cfObject)
+        if characters != nil, let createdCFString = CFStringCreateWithCharacters(kCFAllocatorSystemDefault, characters, CFStringGetLength(self._cfObject)) {
+            return capitalize(createdCFString)
+        } else {
+            return capitalize(self._cfObject)
+        }
     }
     
     public func getLineStart(startPtr: UnsafeMutablePointer<Int>, end lineEndPtr: UnsafeMutablePointer<Int>, contentsEnd contentsEndPtr: UnsafeMutablePointer<Int>, forRange range: NSRange) {

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -32,6 +32,9 @@ class TestNSString : XCTestCase {
             ("test_FromNullTerminatedCStringInASCII", test_FromNullTerminatedCStringInASCII ),
             ("test_FromNullTerminatedCStringInUTF8", test_FromNullTerminatedCStringInUTF8 ),
             ("test_FromMalformedNullTerminatedCStringInUTF8", test_FromMalformedNullTerminatedCStringInUTF8 ),
+            ("test_uppercaseString", test_uppercaseString ),
+            ("test_lowercaseString", test_lowercaseString ),
+            ("test_capitalizedString", test_capitalizedString ),
         ]
     }
     
@@ -126,5 +129,34 @@ class TestNSString : XCTestCase {
         let bytes = mockMalformedUTF8StringBytes + [0x00]
         let string = NSString(CString: bytes.map { Int8(bitPattern: $0) }, encoding: NSUTF8StringEncoding)
         XCTAssertNil(string)
+    }
+
+    func test_uppercaseString() {
+        XCTAssertEqual(NSString(stringLiteral: "abcd").uppercaseString, "ABCD")
+        XCTAssertEqual(NSString(stringLiteral: "абВГ").uppercaseString, "АБВГ")
+        XCTAssertEqual(NSString(stringLiteral: "たちつてと").uppercaseString, "たちつてと")
+
+        // Special casting (see swift/validation-tests/stdlib/NSStringAPI.swift)
+        XCTAssertEqual(NSString(stringLiteral: "\u{0069}").uppercaseStringWithLocale(NSLocale(localeIdentifier: "en")), "\u{0049}")
+        XCTAssertEqual(NSString(stringLiteral: "\u{0069}").uppercaseStringWithLocale(NSLocale(localeIdentifier: "tr")), "\u{0130}")
+        XCTAssertEqual(NSString(stringLiteral: "\u{00df}").uppercaseString, "\u{0053}\u{0053}")
+        XCTAssertEqual(NSString(stringLiteral: "\u{fb01}").uppercaseString, "\u{0046}\u{0049}")
+    }
+
+    func test_lowercaseString() {
+        XCTAssertEqual(NSString(stringLiteral: "abCD").lowercaseString, "abcd")
+        XCTAssertEqual(NSString(stringLiteral: "aБВГ").lowercaseString, "aбвг")
+        XCTAssertEqual(NSString(stringLiteral: "たちつてと").lowercaseString, "たちつてと")
+
+        // Special casting (see swift/validation-tests/stdlib/NSStringAPI.swift)
+        XCTAssertEqual(NSString(stringLiteral: "\u{0130}").lowercaseStringWithLocale(NSLocale(localeIdentifier: "en")), "\u{0069}\u{0307}")
+        XCTAssertEqual(NSString(stringLiteral: "\u{0130}").lowercaseStringWithLocale(NSLocale(localeIdentifier: "tr")), "\u{0069}")
+        XCTAssertEqual(NSString(stringLiteral: "\u{0049}\u{0307}").lowercaseStringWithLocale(NSLocale(localeIdentifier: "en")), "\u{0069}\u{0307}")
+        XCTAssertEqual(NSString(stringLiteral: "\u{0049}\u{0307}").lowercaseStringWithLocale(NSLocale(localeIdentifier: "tr")), "\u{0069}")
+    }
+
+    func test_capitalizedString() {
+        XCTAssertEqual(NSString(stringLiteral: "foo Foo fOO FOO").capitalizedString, "Foo Foo Foo Foo")
+        XCTAssertEqual(NSString(stringLiteral: "жжж").capitalizedString, "Жжж")
     }
 }

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -136,7 +136,7 @@ class TestNSString : XCTestCase {
         XCTAssertEqual(NSString(stringLiteral: "абВГ").uppercaseString, "АБВГ")
         XCTAssertEqual(NSString(stringLiteral: "たちつてと").uppercaseString, "たちつてと")
 
-        // Special casting (see swift/validation-tests/stdlib/NSStringAPI.swift)
+        // Special casing (see swift/validation-tests/stdlib/NSStringAPI.swift)
         XCTAssertEqual(NSString(stringLiteral: "\u{0069}").uppercaseStringWithLocale(NSLocale(localeIdentifier: "en")), "\u{0049}")
         XCTAssertEqual(NSString(stringLiteral: "\u{0069}").uppercaseStringWithLocale(NSLocale(localeIdentifier: "tr")), "\u{0130}")
         XCTAssertEqual(NSString(stringLiteral: "\u{00df}").uppercaseString, "\u{0053}\u{0053}")
@@ -148,7 +148,7 @@ class TestNSString : XCTestCase {
         XCTAssertEqual(NSString(stringLiteral: "aБВГ").lowercaseString, "aбвг")
         XCTAssertEqual(NSString(stringLiteral: "たちつてと").lowercaseString, "たちつてと")
 
-        // Special casting (see swift/validation-tests/stdlib/NSStringAPI.swift)
+        // Special casing (see swift/validation-tests/stdlib/NSStringAPI.swift)
         XCTAssertEqual(NSString(stringLiteral: "\u{0130}").lowercaseStringWithLocale(NSLocale(localeIdentifier: "en")), "\u{0069}\u{0307}")
         XCTAssertEqual(NSString(stringLiteral: "\u{0130}").lowercaseStringWithLocale(NSLocale(localeIdentifier: "tr")), "\u{0069}")
         XCTAssertEqual(NSString(stringLiteral: "\u{0049}\u{0307}").lowercaseStringWithLocale(NSLocale(localeIdentifier: "en")), "\u{0069}\u{0307}")


### PR DESCRIPTION
Implementation of uppercaseString, lowercaseString, capitalizedString (with localized versions) for NSString. Tests for methods.

I tested it with this tests: https://github.com/apple/swift/blob/master/test/1_stdlib/NSStringAPI.swift and noticed strange behaviour. 

this test fail:
```
XCTAssertEqual(NSString(stringLiteral: "\u{0069}").uppercaseStringWithLocale(NSLocale(localeIdentifier: "tr")), "\u{0130}")
```

this don't
```
XCTAssertEqual(String(stringLiteral: "\u{0069}").uppercaseStringWithLocale(NSLocale(localeIdentifier: "tr")), "\u{0130}")
```

Difference is `NSString(stringLiteral:)` vs. `String(stringLiteral:)`. The result of uppercaseStringWithLocale is correct, though comparison is failing. This may be some issue with NSString.