### PR TITLE
[SR-71] Repair NSNumber behaviour

### DIFF
--- a/CoreFoundation/NumberDate.subproj/CFNumber.c
+++ b/CoreFoundation/NumberDate.subproj/CFNumber.c
@@ -1099,6 +1099,7 @@ static inline void _CFNumberInit(CFNumberRef result, CFNumberType type, const vo
         case kCFNumberFloat32Type: memmove((void *)&result->_pad, valuePtr, 4); break;
         case kCFNumberFloat64Type: memmove((void *)&result->_pad, valuePtr, 8); break;
     }
+    __CFBitfieldSetValue(((struct __CFNumber *)result)->_base._cfinfo[CF_INFO_BITS], 4, 0, (uint8_t)__CFNumberTypeTable[type].canonicalType);
 }
 
 CF_EXPORT void _CFNumberInitBool(CFNumberRef result, Boolean value) {

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -23,7 +23,7 @@ class TestNSNumber : XCTestCase {
             ("test_NumberWithBool", test_NumberWithBool ),
             ("test_numberWithChar", test_numberWithChar ),
             ("test_numberWithUnsignedChar", test_numberWithUnsignedChar ),
-            ("test_numberWithShort", test_numberWithShort ),   
+            ("test_numberWithShort", test_numberWithShort ),
             ("test_numberWithFloat", test_numberWithFloat ),
             ("test_numberWithDouble", test_numberWithDouble ),
         ]

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -24,6 +24,8 @@ class TestNSNumber : XCTestCase {
             ("test_numberWithChar", test_numberWithChar ),
             ("test_numberWithUnsignedChar", test_numberWithUnsignedChar ),
             ("test_numberWithShort", test_numberWithShort ),   
+            ("test_numberWithFloat", test_numberWithFloat ),
+            ("test_numberWithDouble", test_numberWithDouble ),
         ]
     }
     
@@ -179,5 +181,69 @@ class TestNSNumber : XCTestCase {
         XCTAssertEqual(NSNumber(short: Int16(0)).doubleValue, Double(0))
         XCTAssertEqual(NSNumber(short: Int16(-37)).doubleValue, Double(-37))
         XCTAssertEqual(NSNumber(short: Int16(42)).doubleValue, Double(42))
+    }
+    
+    func test_numberWithFloat() {
+        XCTAssertEqual(NSNumber(float: Float(0)).boolValue, false)
+        XCTAssertEqual(NSNumber(float: Float(0)).charValue, Int8(0))
+        XCTAssertEqual(NSNumber(float: Float(0)).unsignedCharValue, UInt8(0))
+        XCTAssertEqual(NSNumber(float: Float(0)).shortValue, Int16(0))
+        XCTAssertEqual(NSNumber(float: Float(0)).unsignedShortValue, UInt16(0))
+        XCTAssertEqual(NSNumber(float: Float(0)).intValue, Int32(0))
+        XCTAssertEqual(NSNumber(float: Float(0)).unsignedIntValue, UInt32(0))
+        XCTAssertEqual(NSNumber(float: Float(0)).longLongValue, Int64(0))
+        XCTAssertEqual(NSNumber(float: Float(0)).unsignedLongLongValue, UInt64(0))
+        XCTAssertEqual(NSNumber(float: Float(-37)).boolValue, true);
+        XCTAssertEqual(NSNumber(float: Float(-37)).charValue, Int8(-37))
+        XCTAssertEqual(NSNumber(float: Float(-37)).shortValue, Int16(-37))
+        XCTAssertEqual(NSNumber(float: Float(-37)).intValue, Int32(-37))
+        XCTAssertEqual(NSNumber(float: Float(-37)).longLongValue, Int64(-37))
+        XCTAssertEqual(NSNumber(float: Float(42)).boolValue, true)
+        XCTAssertEqual(NSNumber(float: Float(42)).charValue, Int8(42))
+        XCTAssertEqual(NSNumber(float: Float(42)).unsignedCharValue, UInt8(42))
+        XCTAssertEqual(NSNumber(float: Float(42)).shortValue, Int16(42))
+        XCTAssertEqual(NSNumber(float: Float(42)).unsignedShortValue, UInt16(42))
+        XCTAssertEqual(NSNumber(float: Float(42)).intValue, Int32(42))
+        XCTAssertEqual(NSNumber(float: Float(42)).unsignedIntValue, UInt32(42))
+        XCTAssertEqual(NSNumber(float: Float(42)).longLongValue, Int64(42))
+        XCTAssertEqual(NSNumber(float: Float(42)).unsignedLongLongValue, UInt64(42))
+        XCTAssertEqual(NSNumber(float: Float(0)).floatValue, Float(0))
+        XCTAssertEqual(NSNumber(float: Float(-37.5)).floatValue, Float(-37.5))
+        XCTAssertEqual(NSNumber(float: Float(42.1)).floatValue, Float(42.1))
+        XCTAssertEqual(NSNumber(float: Float(0)).doubleValue, Double(0))
+        XCTAssertEqual(NSNumber(float: Float(-37.5)).doubleValue, Double(-37.5))
+        XCTAssertEqual(NSNumber(float: Float(42.5)).doubleValue, Double(42.5))
+    }
+    
+    func test_numberWithDouble() {
+        XCTAssertEqual(NSNumber(double: Double(0)).boolValue, false)
+        XCTAssertEqual(NSNumber(double: Double(0)).charValue, Int8(0))
+        XCTAssertEqual(NSNumber(double: Double(0)).unsignedCharValue, UInt8(0))
+        XCTAssertEqual(NSNumber(double: Double(0)).shortValue, Int16(0))
+        XCTAssertEqual(NSNumber(double: Double(0)).unsignedShortValue, UInt16(0))
+        XCTAssertEqual(NSNumber(double: Double(0)).intValue, Int32(0))
+        XCTAssertEqual(NSNumber(double: Double(0)).unsignedIntValue, UInt32(0))
+        XCTAssertEqual(NSNumber(double: Double(0)).longLongValue, Int64(0))
+        XCTAssertEqual(NSNumber(double: Double(0)).unsignedLongLongValue, UInt64(0))
+        XCTAssertEqual(NSNumber(double: Double(-37)).boolValue, true);
+        XCTAssertEqual(NSNumber(double: Double(-37)).charValue, Int8(-37))
+        XCTAssertEqual(NSNumber(double: Double(-37)).shortValue, Int16(-37))
+        XCTAssertEqual(NSNumber(double: Double(-37)).intValue, Int32(-37))
+        XCTAssertEqual(NSNumber(double: Double(-37)).longLongValue, Int64(-37))
+        XCTAssertEqual(NSNumber(double: Double(42)).boolValue, true)
+        XCTAssertEqual(NSNumber(double: Double(42)).charValue, Int8(42))
+        XCTAssertEqual(NSNumber(double: Double(42)).unsignedCharValue, UInt8(42))
+        XCTAssertEqual(NSNumber(double: Double(42)).shortValue, Int16(42))
+        XCTAssertEqual(NSNumber(double: Double(42)).unsignedShortValue, UInt16(42))
+        XCTAssertEqual(NSNumber(double: Double(42)).intValue, Int32(42))
+        XCTAssertEqual(NSNumber(double: Double(42)).unsignedIntValue, UInt32(42))
+        XCTAssertEqual(NSNumber(double: Double(42)).longLongValue, Int64(42))
+        XCTAssertEqual(NSNumber(double: Double(42)).unsignedLongLongValue, UInt64(42))
+        XCTAssertEqual(NSNumber(double: Double(0)).floatValue, Float(0))
+        XCTAssertEqual(NSNumber(double: Double(-37.5)).floatValue, Float(-37.5))
+        XCTAssertEqual(NSNumber(double: Double(42.1)).floatValue, Float(42.1))
+        XCTAssertEqual(NSNumber(double: Double(0)).doubleValue, Double(0))
+        XCTAssertEqual(NSNumber(double: Double(-37.5)).doubleValue, Double(-37.5))
+        XCTAssertEqual(NSNumber(double: Double(42.1)).doubleValue, Double(42.1))
     }
 }


### PR DESCRIPTION
During initalization store the number type in the CFInfo bitfield in the
same way that CFNumberCreate does.

NSNumber/CFNumber stores its value in a UInt64 (_pad) with associated type
information as part of the CFInfo bitfield. NSNUmber Initialization is
performed through _CFNumberInit which copies the value bytes into _pad but
does not store the type information. This leads to broken behaviour when
converting between type repesentations. i.e. Double -> NSNumber ->
Integer.

Fixes: https://bugs.swift.org/browse/SR-71