### PR TITLE
Update NSIndexSet enumeration snippets to Swift

### DIFF
--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -13,17 +13,17 @@
 The following code snippets can be used to enumerate over the indexes in an NSIndexSet:
 
     // Forward
-    NSUInteger currentIndex = [set firstIndex];
-    while (currentIndex != NSNotFound) {
+    var currentIndex = set.firstIndex
+    while currentIndex != NSNotFound {
         ...
-        currentIndex = [set indexGreaterThanIndex:currentIndex];
+        currentIndex = set.indexGreaterThanIndex(currentIndex)
     }
-    
+
     // Backward
-    NSUInteger currentIndex = [set lastIndex];
-    while (currentIndex != NSNotFound) {
+    var currentIndex = set.lastIndex
+    while currentIndex != NSNotFound {
         ...
-        currentIndex = [set indexLessThanIndex:currentIndex];
+        currentIndex = set.indexLessThanIndex(currentIndex)
     }
 
 To enumerate without doing a call per index, you can use the method getIndexes:maxCount:inIndexRange:.


### PR DESCRIPTION
The code snippets in NSIndexSet's comments are currently written in Objective-C. Even though this code does not execute on Swift Foundation, I have tried it with Foundation on OS X in a playground and it executes as you would expect from the Obj-C snippet.