### PR TITLE
Fixes test case TestNSFileManger.test_fileAttributes

### DIFF
--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -121,7 +121,7 @@ class TestNSFileManger : XCTestCase {
             XCTAssertEqual(fileType!, NSFileTypeRegular)
             
             let fileOwnerAccountID = attrs[NSFileOwnerAccountID] as? NSNumber
-            XCTAssertNotEqual(fileOwnerAccountID!.longLongValue, 0)
+            XCTAssertNotNil(fileOwnerAccountID)
             
         } catch let err {
             XCTFail("\(err)")


### PR DESCRIPTION
Check only for the existence of file owner's account (user) identifier instead of comparing its numeric value because
- user identifier of `0` are assigned to the superuser in linux
- negative value are valid account identifier. e.g. `nobody` is `-2` (See https://en.wikipedia.org/wiki/User_identifier)
- There's an assumption made here that account identifier are numeric which is reasonable for most system but there's a slim chance that this might not be the case.

Thanks to @lxcid