### PR TITLE
Adds an implementation of isEqual to the NSString class.

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -229,6 +229,11 @@ public class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, N
     override internal var _cfTypeID: CFTypeID {
         return CFStringGetTypeID()
     }
+  
+    public override func isEqual(object: AnyObject?) -> Bool {
+        guard let string = (object as? NSString)?._swiftObject else { return false }
+        return self.isEqualToString(string)
+    }
 }
 
 extension NSString {

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -23,6 +23,8 @@ class TestNSString : XCTestCase {
         return [
             ("test_BridgeConstruction", test_BridgeConstruction ),
             ("test_isEqualToStringWithSwiftString", test_isEqualToStringWithSwiftString ),
+            ("test_isEqualToObjectWithNSString", test_isEqualToObjectWithNSString ),
+            ("test_isNotEqualToObjectWithNSNumber", test_isNotEqualToObjectWithNSNumber ),
             ("test_FromASCIIData", test_FromASCIIData ),
             ("test_FromUTF8Data", test_FromUTF8Data ),
             ("test_FromMalformedUTF8Data", test_FromMalformedUTF8Data ),
@@ -57,6 +59,18 @@ class TestNSString : XCTestCase {
         let string: NSString = "literal"
         let swiftString = "literal"
         XCTAssertTrue(string.isEqualToString(swiftString))
+    }
+  
+    func test_isEqualToObjectWithNSString() {
+        let string1: NSString = "literal"
+        let string2: NSString = "literal"
+        XCTAssertTrue(string1.isEqual(string2))
+    }
+    
+    func test_isNotEqualToObjectWithNSNumber() {
+      let string: NSString = "5"
+      let number: NSNumber = 5
+      XCTAssertFalse(string.isEqual(number))
     }
 
     internal let mockASCIIStringBytes: [UInt8] = [0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0x53, 0x77, 0x69, 0x66, 0x74, 0x21]


### PR DESCRIPTION
This was extracted from https://github.com/apple/swift-corelibs-foundation/pull/44. This adds an implementation of isEqual for NSString, which is necessary for initializing NSCalendar instances.