### PR TITLE
NSCopying for NSDictionary

### DIFF
--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -162,6 +162,11 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         } else if self.dynamicType === NSMutableDictionary.self {
             // Otherwise, create a new NSDictionary object
             
+            let newDict = NSDictionary()
+            newDict._storage = _storage
+            
+            return newDict
+        } else {
             // TODO: speed up?
             var keys = [AnyObject]()
             var values = [AnyObject]()
@@ -171,8 +176,6 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
             }
             
             return NSDictionary(objects: values, forKeys: keys as! [NSObject])
-        } else {
-            NSRequiresConcreteImplementation()
         }
     }
     
@@ -180,6 +183,11 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         if self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self {
             //ALWAYS create and return an NSMutableDictionary
             
+            let newDict = NSMutableDictionary()
+            newDict._storage = _storage
+            
+            return newDict
+        } else {
             // TODO: speed up?
             var keys = [AnyObject]()
             var values = [AnyObject]()
@@ -189,8 +197,6 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
             }
             
             return NSMutableDictionary(objects: values, forKeys: keys as! [NSObject])
-        } else {
-            NSRequiresConcreteImplementation()
         }
     }
     

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -156,13 +156,44 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
     }
     
     public func copyWithZone(zone: NSZone) -> AnyObject {
-        NSUnimplemented()
+        if self.dynamicType === NSDictionary.self {
+            // NSDictionary is immutable; just return ourself
+            return self
+        } else if self.dynamicType === NSMutableDictionary.self {
+            // Otherwise, create a new NSDictionary object
+            
+            // TODO: speed up?
+            var keys = [AnyObject]()
+            var values = [AnyObject]()
+            for (key, value) in self {
+                keys.append(key)
+                values.append(value)
+            }
+            
+            return NSDictionary(objects: values, forKeys: keys as! [NSObject])
+        } else {
+            NSRequiresConcreteImplementation()
+        }
     }
     
     public func mutableCopyWithZone(zone: NSZone) -> AnyObject {
-        NSUnimplemented()
+        if self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self {
+            //ALWAYS create and return an NSMutableDictionary
+            
+            // TODO: speed up?
+            var keys = [AnyObject]()
+            var values = [AnyObject]()
+            for (key, value) in self {
+                keys.append(key)
+                values.append(value)
+            }
+            
+            return NSMutableDictionary(objects: values, forKeys: keys as! [NSObject])
+        } else {
+            NSRequiresConcreteImplementation()
+        }
     }
-
+    
     public convenience init(object: AnyObject, forKey key: NSCopying) {
         self.init(objects: [object], forKeys: [key as! NSObject])
     }

--- a/TestFoundation/TestNSDictionary.swift
+++ b/TestFoundation/TestNSDictionary.swift
@@ -26,6 +26,8 @@ class TestNSDictionary : XCTestCase {
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_ArrayConstruction", test_ArrayConstruction),
             ("test_enumeration", test_enumeration),
+            ("test_NSCopying", test_NSCopying),
+            ("test_NSMutableCopying", test_NSMutableCopying),
         ]
     }
         
@@ -87,5 +89,33 @@ class TestNSDictionary : XCTestCase {
             result[key as! String] = (value as! NSString).bridge()
         }
         XCTAssertEqual(result, ["foo" : "bar", "whiz" : "bang", "toil" : "trouble"])
+    }
+    
+    func test_NSCopying() {
+        let dict1 : NSDictionary = ["foo" : "bar", "whiz" : "bang", "toil" : "trouble"].bridge()
+        let dict2 : NSDictionary = dict1.copy() as! NSDictionary
+        XCTAssertEqual(dict1, dict2)
+        XCTAssert(dict1 === dict2, "dict1's copy should have returned self")
+        
+        // NSMutableDictionary copying
+        let mutDict1 = NSMutableDictionary(objects: ["bar".bridge(), "bang".bridge(), "trouble".bridge()], forKeys: ["foo".bridge(), "whiz".bridge(), "toil".bridge()])
+        let dict4 = mutDict1.copy() as! NSDictionary
+        XCTAssertEqual(mutDict1, dict4)
+        mutDict1.setObject("bubble".bridge(), forKey: "toil".bridge())
+        XCTAssertNotEqual(mutDict1, dict4)
+    }
+    
+    func test_NSMutableCopying() {
+        let dict1 : NSDictionary = ["foo" : "bar", "whiz" : "bang", "toil" : "trouble"].bridge()
+        
+        let mutDict1 = dict1.mutableCopy() as! NSMutableDictionary
+        XCTAssertEqual(dict1, mutDict1)
+        
+        mutDict1.setObject("bubble".bridge(), forKey: "toil".bridge())
+        XCTAssertNotEqual(dict1, mutDict1)
+        let mutDict2 = mutDict1.mutableCopy() as! NSMutableDictionary
+        XCTAssertEqual(mutDict1, mutDict2)
+        mutDict1.setObject("baz".bridge(), forKey: "foo".bridge())
+        XCTAssertNotEqual(mutDict1, mutDict2)
     }
 }


### PR DESCRIPTION
This patch implements `NSCopying` and `NSMutableCopying` protocols in `NSDictionary`, as well as creating a couple of test methods for verifying the behavior of the copy methods.