### PR TITLE
NSUUID improvements

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -210,6 +210,7 @@ extern void _CFURLInitWithFileSystemPathRelativeToBase(CFURLRef url, CFStringRef
 extern Boolean _CFURLInitWithURLString(CFURLRef url, CFStringRef string, Boolean checkForLegalCharacters, _Nullable CFURLRef baseURL);
 extern Boolean _CFURLInitAbsoluteURLWithBytes(CFURLRef url, const UInt8 *relativeURLBytes, CFIndex length, CFStringEncoding encoding, _Nullable CFURLRef baseURL);
 
+extern CFHashCode CFHashBytes(uint8_t *bytes, CFIndex length);
 extern CFIndex __CFProcessorCount();
 extern uint64_t __CFMemorySize();
 extern CFIndex __CFActiveProcessorCount();

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 		88D28DE71C13AE9000494606 /* TestNSGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D28DE61C13AE9000494606 /* TestNSGeometry.swift */; };
 		C93559291C12C49F009FD6A9 /* TestNSAffineTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */; };
 		DCDBB8331C1768AC00313299 /* TestNSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDBB8321C1768AC00313299 /* TestNSData.swift */; };
+		C2A9D75C1C15C08B00993803 /* TestNSUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A9D75B1C15C08B00993803 /* TestNSUUID.swift */; };
 		E876A73E1C1180E000F279EC /* TestNSRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = E876A73D1C1180E000F279EC /* TestNSRange.swift */; };
 		848A30581C137B3500C83206 /* TestNSHTTPCookie.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848A30571C137B3500C83206 /* TestNSHTTPCookie.swift */; };
 		EA66F6361BEED03E00136161 /* TargetConditionals.h in Headers */ = {isa = PBXBuildFile; fileRef = EA66F6351BEED03E00136161 /* TargetConditionals.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -528,6 +529,7 @@
 		88D28DE61C13AE9000494606 /* TestNSGeometry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSGeometry.swift; sourceTree = "<group>"; };
 		C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSAffineTransform.swift; sourceTree = "<group>"; };
 		DCDBB8321C1768AC00313299 /* TestNSData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSData.swift; sourceTree = "<group>"; };
+		C2A9D75B1C15C08B00993803 /* TestNSUUID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSUUID.swift; sourceTree = "<group>"; };
 		E876A73D1C1180E000F279EC /* TestNSRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSRange.swift; sourceTree = "<group>"; };
 		848A30571C137B3500C83206 /* TestNSHTTPCookie.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestNSHTTPCookie.swift; path = TestFoundation/TestNSHTTPCookie.swift; sourceTree = SOURCE_ROOT; };
 		EA313DFC1BE7F2E90060A403 /* CFURLComponents_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFURLComponents_Internal.h; sourceTree = "<group>"; };
@@ -667,7 +669,10 @@
 				5B5D89AB1BBDCD0B00234F36 /* Frameworks */,
 				5B5D885E1BBC938800234F36 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 0;
 		};
 		5B5D885E1BBC938800234F36 /* Products */ = {
 			isa = PBXGroup;
@@ -1031,6 +1036,7 @@
 				E876A73D1C1180E000F279EC /* TestNSRange.swift */,
 				EA66F6411BF1619600136161 /* TestNSSet.swift */,
 				EA66F6421BF1619600136161 /* TestNSString.swift */,
+				C2A9D75B1C15C08B00993803 /* TestNSUUID.swift */,
 				EA66F6431BF1619600136161 /* TestNSURL.swift */,
 				5B40F9F11C125187000E72E3 /* TestNSXMLParser.swift */,
 				22B9C1E01C165D7A00DECFF9 /* TestNSDate.swift */,
@@ -1723,6 +1729,7 @@
 				EA66F6501BF1619600136161 /* TestNSNumber.swift in Sources */,
 				844DC3331C17584F005611F9 /* TestNSScanner.swift in Sources */,
 				E876A73E1C1180E000F279EC /* TestNSRange.swift in Sources */,
+				C2A9D75C1C15C08B00993803 /* TestNSUUID.swift in Sources */,
 				EA66F6521BF1619600136161 /* TestNSPropertyList.swift in Sources */,
 				4DC1D0801C12EEEF00B5948A /* TestNSPipe.swift in Sources */,
 				84BA558E1C16F90900F48C54 /* TestNSTimeZone.swift in Sources */,

--- a/Foundation/NSUUID.swift
+++ b/Foundation/NSUUID.swift
@@ -60,11 +60,11 @@ public class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     public required init?(coder: NSCoder) {
-        
+        NSUnimplemented()
     }
     
     public func encodeWithCoder(aCoder: NSCoder) {
-        
+        NSUnimplemented()
     }
     
     public override func isEqual(object: AnyObject?) -> Bool {

--- a/Foundation/NSUUID.swift
+++ b/Foundation/NSUUID.swift
@@ -80,4 +80,8 @@ public class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
     public override var hash: Int {
         return Int(CFHashBytes(buffer, 16))
     }
+    
+    public override var description: String {
+        return UUIDString
+    }
 }

--- a/Foundation/NSUUID.swift
+++ b/Foundation/NSUUID.swift
@@ -62,4 +62,18 @@ public class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
     public func encodeWithCoder(aCoder: NSCoder) {
         
     }
+    
+    public override func isEqual(object: AnyObject?) -> Bool {
+        if object === self {
+            return true
+        } else if let other = object as? NSUUID {
+            return _cf_uuid_compare(buffer, other.buffer) == 0
+        } else {
+            return false
+        }
+    }
+    
+    public override var hash: Int {
+        return Int(CFHashBytes(buffer, 16))
+    }
 }

--- a/Foundation/NSUUID.swift
+++ b/Foundation/NSUUID.swift
@@ -46,8 +46,8 @@ public class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
     public var UUIDString: String {
         get {
             let strPtr = UnsafeMutablePointer<Int8>.alloc(37)
-            _cf_uuid_unparse_upper(buffer, strPtr)
-            return String(strPtr)
+            _cf_uuid_unparse_lower(buffer, strPtr)
+            return String.fromCString(strPtr)!
         }
     }
     

--- a/Foundation/NSUUID.swift
+++ b/Foundation/NSUUID.swift
@@ -32,7 +32,11 @@ public class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     public init(UUIDBytes bytes: UnsafePointer<UInt8>) {
-        memcpy(unsafeBitCast(buffer, UnsafeMutablePointer<Void>.self), UnsafePointer<Void>(bytes), 16)
+        if (bytes != nil) {
+            memcpy(unsafeBitCast(buffer, UnsafeMutablePointer<Void>.self), UnsafePointer<Void>(bytes), 16)
+        } else {
+            memset(unsafeBitCast(buffer, UnsafeMutablePointer<Void>.self), 0, 16)
+        }
     }
     
     public func getUUIDBytes(uuid: UnsafeMutablePointer<UInt8>) {

--- a/TestFoundation/TestNSUUID.swift
+++ b/TestFoundation/TestNSUUID.swift
@@ -26,6 +26,8 @@ class TestNSUUID : XCTestCase {
             ("test_InitializationWithNil", test_InitializationWithNil),
             ("test_UUIDString", test_UUIDString),
             ("test_description", test_description),
+            // Disabled until NSKeyedArchiver and NSKeyedUnarchiver are implemented
+            // ("test_NSCoding", test_NSCoding),
         ]
     }
     
@@ -58,5 +60,11 @@ class TestNSUUID : XCTestCase {
     func test_description() {
         let uuid = NSUUID()
         XCTAssertEqual(uuid.description, uuid.UUIDString, "The description must be the same as the UUIDString.")
+    }
+    
+    func test_NSCoding() {
+        let uuidA = NSUUID()
+        let uuidB = NSKeyedUnarchiver.unarchiveObjectWithData(NSKeyedArchiver.archivedDataWithRootObject(uuidA)) as! NSUUID
+        XCTAssertEqual(uuidA, uuidB, "Archived then unarchived uuid must be equal.")
     }
 }

--- a/TestFoundation/TestNSUUID.swift
+++ b/TestFoundation/TestNSUUID.swift
@@ -25,6 +25,7 @@ class TestNSUUID : XCTestCase {
             ("test_InvalidUUID", test_InvalidUUID),
             ("test_InitializationWithNil", test_InitializationWithNil),
             ("test_UUIDString", test_UUIDString),
+            ("test_description", test_description),
         ]
     }
     
@@ -52,5 +53,10 @@ class TestNSUUID : XCTestCase {
     func test_UUIDString() {
         let uuid = NSUUID(UUIDBytes: [0xe6,0x21,0xe1,0xf8,0xc3,0x6c,0x49,0x5a,0x93,0xfc,0x0c,0x24,0x7a,0x3e,0x6e,0x5f])
         XCTAssertEqual(uuid.UUIDString, "e621e1f8-c36c-495a-93fc-0c247a3e6e5f", "The UUIDString representation must be lowercase as defined by RFC 4122.")
+    }
+    
+    func test_description() {
+        let uuid = NSUUID()
+        XCTAssertEqual(uuid.description, uuid.UUIDString, "The description must be the same as the UUIDString.")
     }
 }

--- a/TestFoundation/TestNSUUID.swift
+++ b/TestFoundation/TestNSUUID.swift
@@ -21,6 +21,18 @@ class TestNSUUID : XCTestCase {
     
     var allTests : [(String, () -> ())] {
         return [
+            ("test_Equality", test_Equality),
         ]
+    }
+    
+    func test_Equality() {
+        let uuidA = NSUUID(UUIDString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")
+        let uuidB = NSUUID(UUIDString: "e621e1f8-c36c-495a-93fc-0c247a3e6e5f")
+        let uuidC = NSUUID(UUIDBytes: [0xe6,0x21,0xe1,0xf8,0xc3,0x6c,0x49,0x5a,0x93,0xfc,0x0c,0x24,0x7a,0x3e,0x6e,0x5f])
+        let uuidD = NSUUID()
+        
+        XCTAssertEqual(uuidA, uuidB, "String case must not matter.")
+        XCTAssertEqual(uuidA, uuidC, "A UUID initialized with a string must be equal to the same UUID initialized with its UnsafePointer<UInt8> equivalent representation.")
+        XCTAssertNotEqual(uuidC, uuidD, "Two different UUIDs must not be equal.")
     }
 }

--- a/TestFoundation/TestNSUUID.swift
+++ b/TestFoundation/TestNSUUID.swift
@@ -1,0 +1,26 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+
+class TestNSUUID : XCTestCase {
+    
+    var allTests : [(String, () -> ())] {
+        return [
+        ]
+    }
+}

--- a/TestFoundation/TestNSUUID.swift
+++ b/TestFoundation/TestNSUUID.swift
@@ -22,6 +22,7 @@ class TestNSUUID : XCTestCase {
     var allTests : [(String, () -> ())] {
         return [
             ("test_Equality", test_Equality),
+            ("test_InvalidUUID", test_InvalidUUID),
         ]
     }
     
@@ -34,5 +35,10 @@ class TestNSUUID : XCTestCase {
         XCTAssertEqual(uuidA, uuidB, "String case must not matter.")
         XCTAssertEqual(uuidA, uuidC, "A UUID initialized with a string must be equal to the same UUID initialized with its UnsafePointer<UInt8> equivalent representation.")
         XCTAssertNotEqual(uuidC, uuidD, "Two different UUIDs must not be equal.")
+    }
+    
+    func test_InvalidUUID() {
+        let uuid = NSUUID(UUIDString: "Invalid UUID")
+        XCTAssertNil(uuid, "The convenience initializer `init?(UUIDString string:)` must return nil for an invalid UUID string.")
     }
 }

--- a/TestFoundation/TestNSUUID.swift
+++ b/TestFoundation/TestNSUUID.swift
@@ -23,6 +23,7 @@ class TestNSUUID : XCTestCase {
         return [
             ("test_Equality", test_Equality),
             ("test_InvalidUUID", test_InvalidUUID),
+            ("test_InitializationWithNil", test_InitializationWithNil),
         ]
     }
     
@@ -40,5 +41,10 @@ class TestNSUUID : XCTestCase {
     func test_InvalidUUID() {
         let uuid = NSUUID(UUIDString: "Invalid UUID")
         XCTAssertNil(uuid, "The convenience initializer `init?(UUIDString string:)` must return nil for an invalid UUID string.")
+    }
+    
+    func test_InitializationWithNil() {
+        let uuid = NSUUID(UUIDBytes: nil)
+        XCTAssertEqual(uuid, NSUUID(UUIDBytes: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]), "The convenience initializer `init(UUIDBytes bytes:)` must return the Nil UUID when UUIDBytes is nil.")
     }
 }

--- a/TestFoundation/TestNSUUID.swift
+++ b/TestFoundation/TestNSUUID.swift
@@ -24,6 +24,7 @@ class TestNSUUID : XCTestCase {
             ("test_Equality", test_Equality),
             ("test_InvalidUUID", test_InvalidUUID),
             ("test_InitializationWithNil", test_InitializationWithNil),
+            ("test_UUIDString", test_UUIDString),
         ]
     }
     
@@ -46,5 +47,10 @@ class TestNSUUID : XCTestCase {
     func test_InitializationWithNil() {
         let uuid = NSUUID(UUIDBytes: nil)
         XCTAssertEqual(uuid, NSUUID(UUIDBytes: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]), "The convenience initializer `init(UUIDBytes bytes:)` must return the Nil UUID when UUIDBytes is nil.")
+    }
+    
+    func test_UUIDString() {
+        let uuid = NSUUID(UUIDBytes: [0xe6,0x21,0xe1,0xf8,0xc3,0x6c,0x49,0x5a,0x93,0xfc,0x0c,0x24,0x7a,0x3e,0x6e,0x5f])
+        XCTAssertEqual(uuid.UUIDString, "e621e1f8-c36c-495a-93fc-0c247a3e6e5f", "The UUIDString representation must be lowercase as defined by RFC 4122.")
     }
 }

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -42,5 +42,6 @@ XCTMain([
     TestNSScanner(),
     TestNSHTTPCookie(),
     TestNSGeometry(),
+    TestNSUUID(),
 ])
 


### PR DESCRIPTION
* Implement `isEqual` and `hash`
* Do not crash when initialised with `NSUUID(UUIDBytes: nil)`
* Fix `UUIDString` implementation
* Implement a sensible `description`