### PR TITLE
Fixes for calendar initialization

### DIFF
--- a/CoreFoundation/Locale.subproj/CFCalendar.c
+++ b/CoreFoundation/Locale.subproj/CFCalendar.c
@@ -49,10 +49,10 @@ static CFStringRef __CFCalendarCopyDescription(CFTypeRef cf) {
 
 static void __CFCalendarDeallocate(CFTypeRef cf) {
     CFCalendarRef calendar = (CFCalendarRef)cf;
-    CFRelease(calendar->_identifier);
+    if (calendar->_identifier) CFRelease(calendar->_identifier);
     if (calendar->_locale) CFRelease(calendar->_locale);
     if (calendar->_localeID) CFRelease(calendar->_localeID);
-    CFRelease(calendar->_tz);
+    if (calendar->_tz) CFRelease(calendar->_tz);
     if (calendar->_cal) ucal_close(calendar->_cal);
 }
 
@@ -236,15 +236,14 @@ CFCalendarRef CFCalendarCopyCurrent(void) {
 }
 
 Boolean _CFCalendarInitWithIdentifier(CFCalendarRef calendar, CFStringRef identifier) {
-    if (identifier != kCFGregorianCalendar && identifier != kCFBuddhistCalendar && identifier != kCFJapaneseCalendar && identifier != kCFIslamicCalendar && identifier != kCFIslamicCivilCalendar && identifier != kCFHebrewCalendar) {
-        //    if (identifier != kCFGregorianCalendar && identifier != kCFBuddhistCalendar && identifier != kCFJapaneseCalendar && identifier != kCFIslamicCalendar && identifier != kCFIslamicCivilCalendar && identifier != kCFHebrewCalendar && identifier != kCFChineseCalendar) {
+    if (identifier != kCFGregorianCalendar && identifier != kCFBuddhistCalendar && identifier != kCFJapaneseCalendar && identifier != kCFIslamicCalendar && identifier != kCFIslamicCivilCalendar && identifier != kCFHebrewCalendar && identifier != kCFChineseCalendar) {
         if (CFEqual(kCFGregorianCalendar, identifier)) identifier = kCFGregorianCalendar;
         else if (CFEqual(kCFBuddhistCalendar, identifier)) identifier = kCFBuddhistCalendar;
         else if (CFEqual(kCFJapaneseCalendar, identifier)) identifier = kCFJapaneseCalendar;
         else if (CFEqual(kCFIslamicCalendar, identifier)) identifier = kCFIslamicCalendar;
         else if (CFEqual(kCFIslamicCivilCalendar, identifier)) identifier = kCFIslamicCivilCalendar;
         else if (CFEqual(kCFHebrewCalendar, identifier)) identifier = kCFHebrewCalendar;
-        //	else if (CFEqual(kCFChineseCalendar, identifier)) identifier = kCFChineseCalendar;
+        else if (CFEqual(kCFChineseCalendar, identifier)) identifier = kCFChineseCalendar;
         else return false;
     }
     
@@ -261,15 +260,14 @@ CFCalendarRef CFCalendarCreateWithIdentifier(CFAllocatorRef allocator, CFStringR
     __CFGenericValidateType(allocator, CFAllocatorGetTypeID());
     __CFGenericValidateType(identifier, CFStringGetTypeID());
     // return NULL until Chinese calendar is available
-    if (identifier != kCFGregorianCalendar && identifier != kCFBuddhistCalendar && identifier != kCFJapaneseCalendar && identifier != kCFIslamicCalendar && identifier != kCFIslamicCivilCalendar && identifier != kCFHebrewCalendar) {
-//    if (identifier != kCFGregorianCalendar && identifier != kCFBuddhistCalendar && identifier != kCFJapaneseCalendar && identifier != kCFIslamicCalendar && identifier != kCFIslamicCivilCalendar && identifier != kCFHebrewCalendar && identifier != kCFChineseCalendar) {
+    if (identifier != kCFGregorianCalendar && identifier != kCFBuddhistCalendar && identifier != kCFJapaneseCalendar && identifier != kCFIslamicCalendar && identifier != kCFIslamicCivilCalendar && identifier != kCFHebrewCalendar && identifier != kCFChineseCalendar) {
 	if (CFEqual(kCFGregorianCalendar, identifier)) identifier = kCFGregorianCalendar;
 	else if (CFEqual(kCFBuddhistCalendar, identifier)) identifier = kCFBuddhistCalendar;
 	else if (CFEqual(kCFJapaneseCalendar, identifier)) identifier = kCFJapaneseCalendar;
 	else if (CFEqual(kCFIslamicCalendar, identifier)) identifier = kCFIslamicCalendar;
 	else if (CFEqual(kCFIslamicCivilCalendar, identifier)) identifier = kCFIslamicCivilCalendar;
 	else if (CFEqual(kCFHebrewCalendar, identifier)) identifier = kCFHebrewCalendar;
-//	else if (CFEqual(kCFChineseCalendar, identifier)) identifier = kCFChineseCalendar;
+	else if (CFEqual(kCFChineseCalendar, identifier)) identifier = kCFChineseCalendar;
 	else return NULL;
     }
     struct __CFCalendar *calendar = NULL;
@@ -422,6 +420,7 @@ static UCalendarDateFields __CFCalendarGetICUFieldCodeFromChar(char ch) {
     case 'G': return UCAL_ERA;
     case 'y': return UCAL_YEAR;
     case 'M': return UCAL_MONTH;
+    case 'l': return UCAL_IS_LEAP_MONTH;
     case 'd': return UCAL_DAY_OF_MONTH;
     case 'h': return UCAL_HOUR;
     case 'H': return UCAL_HOUR_OF_DAY;

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		4DC1D0801C12EEEF00B5948A /* TestNSPipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC1D07F1C12EEEF00B5948A /* TestNSPipe.swift */; };
 		525AECED1BF2C9C500D15BB0 /* TestNSFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525AECEB1BF2C96400D15BB0 /* TestNSFileManager.swift */; };
+		52829AD71C160D64003BC4EF /* TestNSCalendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52829AD61C160D64003BC4EF /* TestNSCalendar.swift */; };
 		528776141BF2629700CB0090 /* FoundationErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522C253A1BF16E1600804FC6 /* FoundationErrors.swift */; };
 		528776191BF27D9500CB0090 /* Test.plist in Resources */ = {isa = PBXBuildFile; fileRef = 528776181BF27D9500CB0090 /* Test.plist */; };
 		5B40F9EF1C124F47000E72E3 /* CFXMLInterface.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B40F9EB1C124F45000E72E3 /* CFXMLInterface.c */; };
@@ -317,6 +318,7 @@
 		4DC1D07F1C12EEEF00B5948A /* TestNSPipe.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSPipe.swift; sourceTree = "<group>"; };
 		522C253A1BF16E1600804FC6 /* FoundationErrors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationErrors.swift; sourceTree = "<group>"; };
 		525AECEB1BF2C96400D15BB0 /* TestNSFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSFileManager.swift; sourceTree = "<group>"; };
+		52829AD61C160D64003BC4EF /* TestNSCalendar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSCalendar.swift; sourceTree = "<group>"; };
 		528776181BF27D9500CB0090 /* Test.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Test.plist; sourceTree = "<group>"; };
 		5B40F9EB1C124F45000E72E3 /* CFXMLInterface.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFXMLInterface.c; sourceTree = "<group>"; };
 		5B40F9EC1C124F45000E72E3 /* CFXMLInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFXMLInterface.h; sourceTree = "<group>"; };
@@ -1003,6 +1005,7 @@
 			isa = PBXGroup;
 			children = (
 				EA66F63C1BF1619600136161 /* TestNSArray.swift */,
+				52829AD61C160D64003BC4EF /* TestNSCalendar.swift */,
 				EA66F63D1BF1619600136161 /* TestNSDictionary.swift */,
 				EA66F63E1BF1619600136161 /* TestNSIndexSet.swift */,
 				EA66F63F1BF1619600136161 /* TestNSNumber.swift */,
@@ -1702,6 +1705,7 @@
 				E876A73E1C1180E000F279EC /* TestNSRange.swift in Sources */,
 				EA66F6521BF1619600136161 /* TestNSPropertyList.swift in Sources */,
 				4DC1D0801C12EEEF00B5948A /* TestNSPipe.swift in Sources */,
+				52829AD71C160D64003BC4EF /* TestNSCalendar.swift in Sources */,
 				EA66F64E1BF1619600136161 /* TestNSIndexSet.swift in Sources */,
 				EA66F6541BF1619600136161 /* TestNSSet.swift in Sources */,
 				EA66F64A1BF1619600136161 /* TestNSArray.swift in Sources */,

--- a/TestFoundation/TestNSCalendar.swift
+++ b/TestFoundation/TestNSCalendar.swift
@@ -1,0 +1,72 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+  import Foundation
+  import XCTest
+#else
+  import SwiftFoundation
+  import SwiftXCTest
+#endif
+import CoreFoundation
+
+class TestNSCalendar: XCTestCase {
+  
+  var allTests : [(String, () -> ())] {
+    return [
+      ("test_gettingDatesOnGregorianCalendar", test_gettingDatesOnGregorianCalendar ),
+      ("test_gettingDatesOnHebrewCalendar", test_gettingDatesOnHebrewCalendar ),
+      ("test_initializingWithInvalidIdentifier", test_initializingWithInvalidIdentifier),
+      ("test_gettingDatesOnChineseCalendar", test_gettingDatesOnChineseCalendar)
+    ]
+  }
+  
+  func test_gettingDatesOnGregorianCalendar() {
+    let date = NSDate(timeIntervalSince1970: 1449332351)
+    
+    guard let components = NSCalendar(calendarIdentifier: NSCalendarIdentifierGregorian)?.components([.Year, .Month, .Day], fromDate: date) else {
+      XCTFail("Could not get date from the gregorian calendar")
+      return
+    }
+    XCTAssertEqual(components.year, 2015)
+    XCTAssertEqual(components.month, 12)
+    XCTAssertEqual(components.day, 5)
+  }
+  
+  func test_gettingDatesOnHebrewCalendar() {
+    let date = NSDate(timeIntervalSince1970: 1552580351)
+    
+    guard let components = NSCalendar(calendarIdentifier: NSCalendarIdentifierHebrew)?.components([.Year, .Month, .Day], fromDate: date) else {
+      XCTFail("Could not get date from the Hebrew calendar")
+      return
+    }
+    XCTAssertEqual(components.year, 5779)
+    XCTAssertEqual(components.month, 7)
+    XCTAssertEqual(components.day, 7)
+    XCTAssertFalse(components.leapMonth)
+  }
+  
+  func test_gettingDatesOnChineseCalendar() {
+    let date = NSDate(timeIntervalSince1970: 1591460351.0)
+    
+    guard let components = NSCalendar(calendarIdentifier: NSCalendarIdentifierChinese)?.components([.Year, .Month, .Day], fromDate: date) else {
+      XCTFail("Could not get date from the Chinese calendar")
+      return
+    }
+    XCTAssertEqual(components.year, 37)
+    XCTAssertEqual(components.month, 4)
+    XCTAssertEqual(components.day, 15)
+    XCTAssertTrue(components.leapMonth)
+  }
+  
+  func test_initializingWithInvalidIdentifier() {
+    let calendar = NSCalendar(calendarIdentifier: "nonexistant_calendar")
+    XCTAssertNil(calendar)
+  }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -23,6 +23,7 @@ internal func testBundle() -> NSBundle {
 XCTMain([
     TestNSString(),
     TestNSArray(),
+    TestNSCalendar(),
     TestNSDictionary(),
     TestNSSet(),
     TestNSNumber(),


### PR DESCRIPTION
This is copied from #44, which got closed when I reorganized the branches and split up the request into two parts.

This request is to fix a few related bugs in initializing calendars and getting date information out of them:

* It adds a mapping for the "leap month" field
* It adds support for the Chinese calendar, which was disabled in the initial commit but seems to be working now.
* It fixes a bug that occurred when a calendar could not be fully initialized. Some of the fields were being left null, but were later given to CFRelease without a check for nulls.