### PR TITLE
Implement NSAffineTransform.transform{Point,Size} with tests

### DIFF
--- a/Foundation/NSAffineTransform.swift
+++ b/Foundation/NSAffineTransform.swift
@@ -62,10 +62,43 @@ public class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
     public func prependTransform(transform: NSAffineTransform) { NSUnimplemented() }
     
     // Transforming points and sizes
-    public func transformPoint(aPoint: NSPoint) -> NSPoint { NSUnimplemented() }
-    public func transformSize(aSize: NSSize) -> NSSize { NSUnimplemented() }
-    
+    public func transformPoint(aPoint: NSPoint) -> NSPoint {
+        let matrix = transformStruct.matrix3x3
+        let vector = Vector3(aPoint.x, aPoint.y, CGFloat(1.0))
+        let resultVector = multiplyMatrix3x3(matrix, byVector3: vector)
+        return NSMakePoint(resultVector.m1, resultVector.m2)
+    }
+
+    public func transformSize(aSize: NSSize) -> NSSize {
+        let matrix = transformStruct.matrix3x3
+        let vector = Vector3(aSize.width, aSize.height, CGFloat(1.0))
+        let resultVector = multiplyMatrix3x3(matrix, byVector3: vector)
+        return NSMakeSize(resultVector.m1, resultVector.m2)
+    }
+
     // Transform Struct
     public var transformStruct: NSAffineTransformStruct
 }
 
+// Private helper functions and structures for linear algebra operations.
+private typealias Vector3 = (m1: CGFloat, m2: CGFloat, m3: CGFloat)
+private typealias Matrix3x3 =
+    (m11: CGFloat, m12: CGFloat, m13: CGFloat,
+     m21: CGFloat, m22: CGFloat, m23: CGFloat,
+     m31: CGFloat, m32: CGFloat, m33: CGFloat)
+
+private func multiplyMatrix3x3(matrix: Matrix3x3, byVector3 vector: Vector3) -> Vector3 {
+    let x = matrix.m11 * vector.m1 + matrix.m12 * vector.m2 + matrix.m13 * vector.m3
+    let y = matrix.m21 * vector.m1 + matrix.m22 * vector.m2 + matrix.m23 * vector.m3
+    let z = matrix.m31 * vector.m1 + matrix.m32 * vector.m2 + matrix.m33 * vector.m3
+
+    return Vector3(x, y, z)
+}
+
+private extension NSAffineTransformStruct {
+    var matrix3x3: Matrix3x3 {
+        return Matrix3x3(m11, m12, tX,
+                         m21, m22, tY,
+                         CGFloat(), CGFloat(), CGFloat())
+    }
+}

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -37,6 +37,14 @@ public func <(lhs: CGFloat, rhs: CGFloat) -> Bool {
     return lhs.native < rhs.native
 }
 
+public func *(lhs: CGFloat, rhs: CGFloat) -> CGFloat {
+    return CGFloat(lhs.native * rhs.native)
+}
+
+public func +(lhs: CGFloat, rhs: CGFloat) -> CGFloat {
+    return CGFloat(lhs.native + rhs.native)
+}
+
 @_transparent extension Double {
     public init(_ value: CGFloat) {
         self = Double(value.native)

--- a/TestFoundation/TestNSAffineTransform.swift
+++ b/TestFoundation/TestNSAffineTransform.swift
@@ -24,10 +24,12 @@
 #endif
 
 class TestNSAffineTransform : XCTestCase {
+    private let accuracyThreshold = 0.001
 
     var allTests : [(String, () -> ())] {
         return [
-            ("test_BasicConstruction", test_BasicConstruction)
+            ("test_BasicConstruction", test_BasicConstruction),
+            ("test_IdentityTransformation", test_IdentityTransformation)
         ]
     }
 
@@ -37,12 +39,36 @@ class TestNSAffineTransform : XCTestCase {
 
         // The diagonal entries (1,1) and (2,2) of the identity matrix are ones. The other entries are zeros.
         // TODO: These should use DBL_MAX but it's not available as part of Glibc on Linux
-        XCTAssertEqualWithAccuracy(Double(transformStruct.m11), Double(1), accuracy: 0.001)
-        XCTAssertEqualWithAccuracy(Double(transformStruct.m22), Double(1), accuracy: 0.001)
+        XCTAssertEqualWithAccuracy(Double(transformStruct.m11), Double(1), accuracy: accuracyThreshold)
+        XCTAssertEqualWithAccuracy(Double(transformStruct.m22), Double(1), accuracy: accuracyThreshold)
 
-        XCTAssertEqualWithAccuracy(Double(transformStruct.m12), Double(0), accuracy: 0.001)
-        XCTAssertEqualWithAccuracy(Double(transformStruct.m21), Double(0), accuracy: 0.001)
-        XCTAssertEqualWithAccuracy(Double(transformStruct.tX), Double(0), accuracy: 0.001)
-        XCTAssertEqualWithAccuracy(Double(transformStruct.tY), Double(0), accuracy: 0.001)
+        XCTAssertEqualWithAccuracy(Double(transformStruct.m12), Double(0), accuracy: accuracyThreshold)
+        XCTAssertEqualWithAccuracy(Double(transformStruct.m21), Double(0), accuracy: accuracyThreshold)
+        XCTAssertEqualWithAccuracy(Double(transformStruct.tX), Double(0), accuracy: accuracyThreshold)
+        XCTAssertEqualWithAccuracy(Double(transformStruct.tY), Double(0), accuracy: accuracyThreshold)
+    }
+
+    func test_IdentityTransformation() {
+        let identityTransform = NSAffineTransform()
+
+        func checkIdentityPointTransformation(point: NSPoint) {
+            let newPoint = identityTransform.transformPoint(point)
+            XCTAssertEqualWithAccuracy(Double(newPoint.x), Double(point.x), accuracy: accuracyThreshold)
+            XCTAssertEqualWithAccuracy(Double(newPoint.y), Double(point.y), accuracy: accuracyThreshold)
+        }
+
+        checkIdentityPointTransformation(NSPoint())
+        checkIdentityPointTransformation(NSMakePoint(CGFloat(24.5), CGFloat(10.0)))
+        checkIdentityPointTransformation(NSMakePoint(CGFloat(-7.5), CGFloat(2.0)))
+
+        func checkIdentitySizeTransformation(size: NSSize) {
+            let newSize = identityTransform.transformSize(size)
+            XCTAssertEqualWithAccuracy(Double(newSize.width), Double(size.width), accuracy: accuracyThreshold)
+            XCTAssertEqualWithAccuracy(Double(newSize.height), Double(size.height), accuracy: accuracyThreshold)
+        }
+
+        checkIdentitySizeTransformation(NSSize())
+        checkIdentitySizeTransformation(NSMakeSize(CGFloat(13.0), CGFloat(12.5)))
+        checkIdentitySizeTransformation(NSMakeSize(CGFloat(100.0), CGFloat(-100.0)))
     }
 }


### PR DESCRIPTION
As part of this change:

- The addition and multiplication operators have been implemented for `CGFloat` so we can compute dot products.
- A private helper function for matrix-vector products has been implemented.
- Tests for the identity transformation have been added. Once we support more operations (translations, rotations, and scales), we can add more tests.