### PR TITLE
Implementation of NSByteCountFormatter default values

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 		5BF7AEC01BCD51F9008F214A /* NSUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4B1BCC5DCB00ED97BB /* NSUUID.swift */; };
 		5BF7AEC11BCD51F9008F214A /* NSValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4C1BCC5DCB00ED97BB /* NSValue.swift */; };
 		84BA558E1C16F90900F48C54 /* TestNSTimeZone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BA558D1C16F90900F48C54 /* TestNSTimeZone.swift */; };
+		A501D6021C1745E7004636F1 /* TestNSByteCountFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A501D6011C1745E7004636F1 /* TestNSByteCountFormatter.swift */; };
 		C93559291C12C49F009FD6A9 /* TestNSAffineTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */; };
 		E876A73E1C1180E000F279EC /* TestNSRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = E876A73D1C1180E000F279EC /* TestNSRange.swift */; };
 		EA66F6361BEED03E00136161 /* TargetConditionals.h in Headers */ = {isa = PBXBuildFile; fileRef = EA66F6351BEED03E00136161 /* TargetConditionals.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -521,6 +522,7 @@
 		5BDC405C1BD6D83B00ED97BB /* TestFoundation.app */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestFoundation.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BF7AEC21BCD568D008F214A /* ForSwiftFoundationOnly.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ForSwiftFoundationOnly.h; sourceTree = "<group>"; };
 		84BA558D1C16F90900F48C54 /* TestNSTimeZone.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSTimeZone.swift; sourceTree = "<group>"; };
+		A501D6011C1745E7004636F1 /* TestNSByteCountFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSByteCountFormatter.swift; sourceTree = "<group>"; };
 		C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSAffineTransform.swift; sourceTree = "<group>"; };
 		E876A73D1C1180E000F279EC /* TestNSRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSRange.swift; sourceTree = "<group>"; };
 		EA313DFC1BE7F2E90060A403 /* CFURLComponents_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFURLComponents_Internal.h; sourceTree = "<group>"; };
@@ -1027,6 +1029,7 @@
 				5B40F9F11C125187000E72E3 /* TestNSXMLParser.swift */,
 				22B9C1E01C165D7A00DECFF9 /* TestNSDate.swift */,
 				84BA558D1C16F90900F48C54 /* TestNSTimeZone.swift */,
+				A501D6011C1745E7004636F1 /* TestNSByteCountFormatter.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -1726,6 +1729,7 @@
 				5B40F9F21C125187000E72E3 /* TestNSXMLParser.swift in Sources */,
 				EA66F64C1BF1619600136161 /* TestNSDictionary.swift in Sources */,
 				EA66F6581BF1619600136161 /* TestNSURL.swift in Sources */,
+				A501D6021C1745E7004636F1 /* TestNSByteCountFormatter.swift in Sources */,
 				EA66F6441BF1619600136161 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Foundation/NSByteCountFormatter.swift
+++ b/Foundation/NSByteCountFormatter.swift
@@ -40,49 +40,57 @@ public enum NSByteCountFormatterCountStyle : Int {
 }
 
 public class NSByteCountFormatter : NSFormatter {
+    public override init() {
+        super.init()
+    }
+    
     public required init?(coder: NSCoder) {
         NSUnimplemented()
     }
     
     /* Shortcut for converting a byte count into a string without creating an NSByteCountFormatter and an NSNumber. If you need to specify options other than countStyle, create an instance of NSByteCountFormatter first.
     */
-    public class func stringFromByteCount(byteCount: Int64, countStyle: NSByteCountFormatterCountStyle) -> String { NSUnimplemented() }
-    
+    public class func stringFromByteCount(byteCount: Int64, countStyle: NSByteCountFormatterCountStyle) -> String {
+        let byteCountFormatter = NSByteCountFormatter()
+        byteCountFormatter.countStyle = countStyle
+        return byteCountFormatter.stringFromByteCount(byteCount)
+    }
+
     /* Convenience method on stringForObjectValue:. Convert a byte count into a string without creating an NSNumber.
     */
     public func stringFromByteCount(byteCount: Int64) -> String { NSUnimplemented() }
     
     /* Specify the units that can be used in the output. If NSByteCountFormatterUseDefault, uses platform-appropriate settings; otherwise will only use the specified units. This is the default value. Note that ZB and YB cannot be covered by the range of possible values, but you can still choose to use these units to get fractional display ("0.0035 ZB" for instance).
     */
-    public var allowedUnits: NSByteCountFormatterUnits
+    public var allowedUnits: NSByteCountFormatterUnits = .UseDefault
     
     /* Specify how the count is displayed by indicating the number of bytes to be used for kilobyte. The default setting is NSByteCountFormatterFileCount, which is the system specific value for file and storage sizes.
     */
-    public var countStyle: NSByteCountFormatterCountStyle
+    public var countStyle: NSByteCountFormatterCountStyle = .File
     
     /* Choose whether to allow more natural display of some values, such as zero, where it may be displayed as "Zero KB," ignoring all other flags or options (with the exception of NSByteCountFormatterUseBytes, which would generate "Zero bytes"). The result is appropriate for standalone output. Default value is YES. Special handling of certain values such as zero is especially important in some languages, so it's highly recommended that this property be left in its default state.
     */
-    public var allowsNonnumericFormatting: Bool
+    public var allowsNonnumericFormatting: Bool = true
     
     /* Choose whether to include the number or the units in the resulting formatted string. (For example, instead of 723 KB, returns "723" or "KB".) You can call the API twice to get both parts, separately. But note that putting them together yourself via string concatenation may be wrong for some locales; so use this functionality with care.  Both of these values are YES by default.  Setting both to NO will unsurprisingly result in an empty string.
     */
-    public var includesUnit: Bool
-    public var includesCount: Bool
+    public var includesUnit: Bool = true
+    public var includesCount: Bool = true
     
     /* Choose whether to parenthetically (localized as appropriate) display the actual number of bytes as well, for instance "723 KB (722,842 bytes)".  This will happen only if needed, that is, the first part is already not showing the exact byte count.  If includesUnit or includesCount are NO, then this setting has no effect.  Default value is NO.
     */
-    public var includesActualByteCount: Bool
+    public var includesActualByteCount: Bool = false
     
     /* Choose the display style. The "adaptive" algorithm is platform specific and uses a different number of fraction digits based on the magnitude (in 10.8: 0 fraction digits for bytes and KB; 1 fraction digits for MB; 2 for GB and above). Otherwise the result always tries to show at least three significant digits, introducing fraction digits as necessary. Default is YES.
     */
-    public var adaptive: Bool
+    public var adaptive: Bool = true
     
     /* Choose whether to zero pad fraction digits so a consistent number of fraction digits are displayed, causing updating displays to remain more stable. For instance, if the adaptive algorithm is used, this option formats 1.19 and 1.2 GB as "1.19 GB" and "1.20 GB" respectively, while without the option the latter would be displayed as "1.2 GB". Default value is NO.
     */
-    public var zeroPadsFractionDigits: Bool
+    public var zeroPadsFractionDigits: Bool = false
     
     /* Specify the formatting context for the formatted string. Default is NSFormattingContextUnknown.
     */
-    public var formattingContext: NSFormattingContext
+    public var formattingContext: NSFormattingContext = .Unknown
 }
 

--- a/TestFoundation/TestNSByteCountFormatter.swift
+++ b/TestFoundation/TestNSByteCountFormatter.swift
@@ -1,0 +1,42 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+
+
+class TestNSByteCountFormatter : XCTestCase {
+    
+    var allTests : [(String, () -> ())] {
+        return [
+            ("test_DefaultValues", test_DefaultValues)
+        ]
+    }
+    
+    func test_DefaultValues() {
+        let formatter = NSByteCountFormatter()
+        XCTAssertEqual(formatter.allowedUnits, NSByteCountFormatterUnits.UseDefault)
+        XCTAssertEqual(formatter.countStyle, NSByteCountFormatterCountStyle.File)
+        XCTAssertEqual(formatter.allowsNonnumericFormatting, true)
+        XCTAssertEqual(formatter.includesUnit, true)
+        XCTAssertEqual(formatter.includesCount, true)
+        XCTAssertEqual(formatter.includesActualByteCount, false)
+        XCTAssertEqual(formatter.adaptive, true)
+        XCTAssertEqual(formatter.zeroPadsFractionDigits, false)
+        XCTAssertEqual(formatter.formattingContext, NSFormattingContext.Unknown)
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -38,4 +38,5 @@ XCTMain([
     TestNSXMLParser(),
     TestNSDate(),
     TestNSTimeZone(),
+    TestNSByteCountFormatter(),
 ])


### PR DESCRIPTION
Default values are added.
Unit test for the NSByteCountFormatter added.

Based on comments from the closed pull request #61