### PR TITLE
[NSScanner] Fix a bug in the initialization of _NSStringBuffer that makes NSScanner unable to find any number

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		5BF7AEBF1BCD51F9008F214A /* NSURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4A1BCC5DCB00ED97BB /* NSURL.swift */; };
 		5BF7AEC01BCD51F9008F214A /* NSUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4B1BCC5DCB00ED97BB /* NSUUID.swift */; };
 		5BF7AEC11BCD51F9008F214A /* NSValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4C1BCC5DCB00ED97BB /* NSValue.swift */; };
+		844DC3331C17584F005611F9 /* TestNSScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844DC3321C17584F005611F9 /* TestNSScanner.swift */; };
 		84BA558E1C16F90900F48C54 /* TestNSTimeZone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BA558D1C16F90900F48C54 /* TestNSTimeZone.swift */; };
 		C93559291C12C49F009FD6A9 /* TestNSAffineTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */; };
 		DCDBB8331C1768AC00313299 /* TestNSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDBB8321C1768AC00313299 /* TestNSData.swift */; };
@@ -521,6 +522,7 @@
 		5BDC3FCF1BCF17E600ED97BB /* NSCFSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSCFSet.swift; sourceTree = "<group>"; };
 		5BDC405C1BD6D83B00ED97BB /* TestFoundation.app */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestFoundation.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BF7AEC21BCD568D008F214A /* ForSwiftFoundationOnly.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ForSwiftFoundationOnly.h; sourceTree = "<group>"; };
+		844DC3321C17584F005611F9 /* TestNSScanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSScanner.swift; sourceTree = "<group>"; };
 		84BA558D1C16F90900F48C54 /* TestNSTimeZone.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSTimeZone.swift; sourceTree = "<group>"; };
 		C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSAffineTransform.swift; sourceTree = "<group>"; };
 		DCDBB8321C1768AC00313299 /* TestNSData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSData.swift; sourceTree = "<group>"; };
@@ -1030,6 +1032,7 @@
 				22B9C1E01C165D7A00DECFF9 /* TestNSDate.swift */,
 				DCDBB8321C1768AC00313299 /* TestNSData.swift */,
 				84BA558D1C16F90900F48C54 /* TestNSTimeZone.swift */,
+				844DC3321C17584F005611F9 /* TestNSScanner.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -1714,6 +1717,7 @@
 			files = (
 				525AECED1BF2C9C500D15BB0 /* TestNSFileManager.swift in Sources */,
 				EA66F6501BF1619600136161 /* TestNSNumber.swift in Sources */,
+				844DC3331C17584F005611F9 /* TestNSScanner.swift in Sources */,
 				E876A73E1C1180E000F279EC /* TestNSRange.swift in Sources */,
 				EA66F6521BF1619600136161 /* TestNSPropertyList.swift in Sources */,
 				4DC1D0801C12EEEF00B5948A /* TestNSPipe.swift in Sources */,

--- a/Foundation/NSScanner.swift
+++ b/Foundation/NSScanner.swift
@@ -79,7 +79,7 @@ private struct _NSStringBuffer {
     var stringLen: Int
     var stringLoc: Int
     var buffer = Array<unichar>(count: 32, repeatedValue: 0)
-    var curChar: unichar
+    var curChar: unichar?
     
     static let EndCharacter = unichar(0xffff)
     
@@ -92,10 +92,10 @@ private struct _NSStringBuffer {
             bufferLen = min(32, stringLen - stringLoc);
             let range = NSMakeRange(stringLoc, bufferLen)
             bufferLoc = 1
-            curChar = buffer[0]
             buffer.withUnsafeMutableBufferPointer({ (inout ptr: UnsafeMutableBufferPointer<unichar>) -> Void in
                 self.string.getCharacters(ptr.baseAddress, range: range)
             })
+            curChar = buffer[0]
         } else {
             bufferLen = 0
             bufferLoc = 1
@@ -104,7 +104,7 @@ private struct _NSStringBuffer {
     }
     
     var currentCharacter: unichar {
-        return curChar
+        return curChar!
     }
     
     var isAtEnd: Bool {

--- a/TestFoundation/TestNSScanner.swift
+++ b/TestFoundation/TestNSScanner.swift
@@ -1,0 +1,36 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+
+
+class TestNSScanner : XCTestCase {
+
+    var allTests : [(String, () -> Void)] {
+        return [
+            ("test_scanInteger", test_scanInteger),
+        ]
+    }
+
+    func test_scanInteger() {
+        let scanner = NSScanner(string: "123")
+        var value: Int = 0
+        XCTAssert(scanner.scanInteger(&value), "An Integer should be found in the string `123`.")
+        XCTAssertEqual(value, 123, "Scanned Integer value of the string `123` should be `123`.")
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -39,4 +39,5 @@ XCTMain([
     TestNSDate(),
     TestNSData(),
     TestNSTimeZone(),
+    TestNSScanner(),
 ])


### PR DESCRIPTION
Copied from commit message:

After writing a simple test case for `NSScanner`, I found that `NSScanner` always returns 0 when scanning numbers. The problem is in `_NSStringBuffer`'s init function, `curChar` was assigned to `buffer[0]` before `buffer` gets characters from scanned string. Changing `curChar` to an optional variable and assign it to `buffer[0]` after `buffer` got all characters from scanned string fixed this.