### PR TITLE
Fix LiteralSearch in compare and rangeOfString

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -279,12 +279,12 @@ extension NSString {
         }
 #if os(Linux)
         var cfflags = CFStringCompareFlags(mask.rawValue)
-        if mask.contains(.LiteralSearch) {
+        if !mask.contains(.LiteralSearch) {
             cfflags |= UInt(kCFCompareNonliteral)
         }
 #else
         var cfflags = CFStringCompareFlags(rawValue: mask.rawValue)
-        if mask.contains(.LiteralSearch) {
+        if !mask.contains(.LiteralSearch) {
             cfflags.unionInPlace(.CompareNonliteral)
         }
 #endif
@@ -374,12 +374,12 @@ extension NSString {
         
 #if os(Linux)
         var cfflags = CFStringCompareFlags(mask.rawValue)
-        if mask.contains(.LiteralSearch) {
+        if !mask.contains(.LiteralSearch) {
             cfflags |= UInt(kCFCompareNonliteral)
         }
 #else
         var cfflags = CFStringCompareFlags(rawValue: mask.rawValue)
-        if mask.contains(.LiteralSearch) {
+        if !mask.contains(.LiteralSearch) {
             cfflags.unionInPlace(.CompareNonliteral)
         }
 #endif

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -37,6 +37,8 @@ class TestNSString : XCTestCase {
             ("test_FromNullTerminatedCStringInUTF8", test_FromNullTerminatedCStringInUTF8 ),
             ("test_FromMalformedNullTerminatedCStringInUTF8", test_FromMalformedNullTerminatedCStringInUTF8 ),
             ("test_rangeOfCharacterFromSet", test_rangeOfCharacterFromSet ),
+            ("test_compareLiteral", test_compareLiteral ),
+            ("test_rangeOfStringLiteral", test_rangeOfStringLiteral ),
         ]
     }
 
@@ -190,5 +192,17 @@ class TestNSString : XCTestCase {
         XCTAssertEqual(string.rangeOfCharacterFromSet(decimalDigits).location, 0)
         XCTAssertEqual(string.rangeOfCharacterFromSet(letters, options: [.BackwardsSearch]).location, 2)
         XCTAssertEqual(string.rangeOfCharacterFromSet(letters, options: [], range: NSMakeRange(2, 1)).location, 2)
+    }
+
+    func test_compareLiteral() {
+        let str: NSString = "Ma\u{0308}dchen"
+        XCTAssertNotEqual(str.compare("Mädchen", options: [.LiteralSearch]), NSComparisonResult.OrderedSame)
+        XCTAssertEqual(str.compare("Mädchen", options: []), NSComparisonResult.OrderedSame)
+    }
+
+    func test_rangeOfStringLiteral() {
+        let str: NSString = "Ma\u{0308}dchen"
+        XCTAssertEqual(str.rangeOfString("Mädchen", options: [.LiteralSearch]).location, NSNotFound)
+        XCTAssertNotEqual(str.rangeOfString("Mädchen", options: []).location, NSNotFound)
     }
 }


### PR DESCRIPTION
CFString functions take .CompareNonliteral value while String functions
take .LiteralSearch value. They’re opposite.