### PR TITLE
Implement NSAffineTransform

### DIFF
--- a/Foundation/NSAffineTransform.swift
+++ b/Foundation/NSAffineTransform.swift
@@ -15,7 +15,12 @@ public struct NSAffineTransformStruct {
     public var m22: CGFloat
     public var tX: CGFloat
     public var tY: CGFloat
-    public init() { NSUnimplemented() }
+    
+    public init() {
+        (self.m11, self.m12, self.m21, self.m22) = (CGFloat(), CGFloat(), CGFloat(), CGFloat())
+        (self.tX, self.tY) = (CGFloat(), CGFloat())
+    }
+    
     public init(m11: CGFloat, m12: CGFloat, m21: CGFloat, m22: CGFloat, tX: CGFloat, tY: CGFloat) {
         (self.m11, self.m12, self.m21, self.m22) = (m11, m12, m21, m22)
         (self.tX, self.tY) = (tX, tY)

--- a/Foundation/NSAffineTransform.swift
+++ b/Foundation/NSAffineTransform.swift
@@ -33,7 +33,11 @@ public class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
         NSUnimplemented()
     }
     public func copyWithZone(zone: NSZone) -> AnyObject {
-        NSUnimplemented()
+        return NSAffineTransform(transform: self)
+    }
+    // Necessary because `NSObject.copy()` returns `self`.
+    public override func copy() -> AnyObject {
+        return copyWithZone(nil)
     }
     public required init?(coder aDecoder: NSCoder) {
         NSUnimplemented()

--- a/Foundation/NSAffineTransform.swift
+++ b/Foundation/NSAffineTransform.swift
@@ -132,9 +132,9 @@ private extension NSAffineTransformStruct {
      Creates an affine transformation matrix from translation values.
      The matrix takes the following form:
      
-     [ 1  0  tX ]
-     [ 0  1  tY ]
-     [ 0  0   1 ]
+         [ 1  0  tX ]
+         [ 0  1  tY ]
+         [ 0  0   1 ]
      */
     static func translation(tX tX: CGFloat, tY: CGFloat) -> NSAffineTransformStruct {
         return NSAffineTransformStruct(
@@ -148,9 +148,9 @@ private extension NSAffineTransformStruct {
      Creates an affine transformation matrix from scaling values.
      The matrix takes the following form:
      
-     [ sX   0  0 ]
-     [ 0   sY  0 ]
-     [ 0    0  1 ]
+         [ sX   0  0 ]
+         [ 0   sY  0 ]
+         [ 0    0  1 ]
      */
     static func scale(sX sX: CGFloat, sY: CGFloat) -> NSAffineTransformStruct {
         return NSAffineTransformStruct(
@@ -164,9 +164,9 @@ private extension NSAffineTransformStruct {
      Creates an affine transformation matrix from rotation value (angle in radians).
      The matrix takes the following form:
      
-     [ cos α   -sin α  0 ]
-     [ sin α    cos α  0 ]
-     [   0        0    1 ]
+         [ cos α   -sin α  0 ]
+         [ sin α    cos α  0 ]
+         [   0        0    1 ]
      */
     static func rotation(radians angle: CGFloat) -> NSAffineTransformStruct {
         let α = Double(angle)
@@ -182,9 +182,9 @@ private extension NSAffineTransformStruct {
      Creates an affine transformation matrix from a rotation value (angle in degrees).
      The matrix takes the following form:
      
-     [ cos α   -sin α  0 ]
-     [ sin α    cos α  0 ]
-     [   0        0    1 ]
+         [ cos α   -sin α  0 ]
+         [ sin α    cos α  0 ]
+         [   0        0    1 ]
      */
     static func rotation(degrees angle: CGFloat) -> NSAffineTransformStruct {
         let α = Double(angle) * M_PI / 180.0
@@ -198,13 +198,13 @@ private extension NSAffineTransformStruct {
      the `transformStruct`'s affine transformation matrix.
      The resulting matrix takes the following form:
      
-             [ m11_T  m12_T  tX_T ] [ m11_M  m12_M  tX_M ]
-     T * M = [ m21_T  m22_T  tY_T ] [ m21_M  m22_M  tY_M ]
-             [   0      0      1  ] [   0      0      1  ]
+                 [ m11_T  m12_T  tX_T ] [ m11_M  m12_M  tX_M ]
+         T * M = [ m21_T  m22_T  tY_T ] [ m21_M  m22_M  tY_M ]
+                 [   0      0      1  ] [   0      0      1  ]
      
-             [ (m11_T*m11_M + m12_T*m21_M)  (m11_T*m12_M + m12_T*m22_M)  (m11_T*tX_M + m12_T*tY_M + tX_T) ]
-           = [ (m21_T*m11_M + m22_T*m21_M)  (m21_T*m12_M + m22_T*m22_M)  (m21_T*tX_M + m22_T*tY_M + tY_T) ]
-             [              0                            0                                  1             ]
+                 [ (m11_T*m11_M + m12_T*m21_M)  (m11_T*m12_M + m12_T*m22_M)  (m11_T*tX_M + m12_T*tY_M + tX_T) ]
+               = [ (m21_T*m11_M + m22_T*m21_M)  (m21_T*m12_M + m22_T*m22_M)  (m21_T*tX_M + m22_T*tY_M + tY_T) ]
+                 [              0                            0                                  1             ]
      */
     func concat(transformStruct: NSAffineTransformStruct) -> NSAffineTransformStruct {
         let (t, m) = (self, transformStruct)
@@ -221,9 +221,9 @@ private extension NSAffineTransformStruct {
      Applies the affine transformation to `toPoint` and returns the result.
      The resulting point takes the following form:
      
-     [ x' ]     [ x ]   [ m11  m12  tX ] [ x ]   [ m11*x + m12*y + tX ]
-     [ y' ] = T [ y ] = [ m21  m22  tY ] [ y ] = [ m21*x + m22*y + tY ]
-     [  1 ]     [ 1 ]   [  0    0    1 ] [ 1 ]   [           1        ]
+         [ x' ]     [ x ]   [ m11  m12  tX ] [ x ]   [ m11*x + m12*y + tX ]
+         [ y' ] = T [ y ] = [ m21  m22  tY ] [ y ] = [ m21*x + m22*y + tY ]
+         [  1 ]     [ 1 ]   [  0    0    1 ] [ 1 ]   [           1        ]
      */
     func applied(toPoint p: NSPoint) -> NSPoint {
         let x = (m11 * p.x) + (m12 * p.y) + tX
@@ -235,10 +235,10 @@ private extension NSAffineTransformStruct {
     /**
      Applies the affine transformation to `toSize` and returns the result.
      The resulting size takes the following form:
-     
-     [ w' ]     [ w ]   [ m11  m12  tX ] [ w ]   [ m11*w + m12*h ]
-     [ h' ] = T [ h ] = [ m21  m22  tY ] [ h ] = [ m21*w + m22*h ]
-     [  0 ]     [ 0 ]   [  0    0    1 ] [ 1 ]   [       0       ]
+  
+         [ w' ]     [ w ]   [ m11  m12  tX ] [ w ]   [ m11*w + m12*h ]
+         [ h' ] = T [ h ] = [ m21  m22  tY ] [ h ] = [ m21*w + m22*h ]
+         [  0 ]     [ 0 ]   [  0    0    1 ] [ 1 ]   [       0       ]
      
      Note: Translation has no effect on the size.
      */
@@ -253,13 +253,17 @@ private extension NSAffineTransformStruct {
     /**
      Returns the inverse affine transformation matrix or `nil` if it has no inverse.
      The receiver's affine transformation matrix can be divided into matrix sub-block as
-       [ M  t ]
-       [ 0  1 ]
+     
+         [ M  t ]
+         [ 0  1 ]
+     
      where `M` represents the linear map and `t` the translation vector.
      
      The inversion can then be calculated as
-       [ inv(M)  -inv(M) * t ]
-       [   0           1     ]
+     
+         [ inv(M)  -inv(M) * t ]
+         [   0           1     ]
+     
      if `M` is invertible.
      */
     var inverse: NSAffineTransformStruct? {

--- a/Foundation/NSAffineTransform.swift
+++ b/Foundation/NSAffineTransform.swift
@@ -17,8 +17,7 @@ public struct NSAffineTransformStruct {
     public var tY: CGFloat
     
     public init() {
-        (self.m11, self.m12, self.m21, self.m22) = (CGFloat(), CGFloat(), CGFloat(), CGFloat())
-        (self.tX, self.tY) = (CGFloat(), CGFloat())
+        self.init(m11: CGFloat(), m12: CGFloat(), m21: CGFloat(), m22: CGFloat(), tX: CGFloat(), tY: CGFloat())
     }
     
     public init(m11: CGFloat, m12: CGFloat, m21: CGFloat, m22: CGFloat, tX: CGFloat, tY: CGFloat) {

--- a/Foundation/NSAffineTransform.swift
+++ b/Foundation/NSAffineTransform.swift
@@ -76,42 +76,30 @@ public class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
     
     // Transforming points and sizes
     public func transformPoint(aPoint: NSPoint) -> NSPoint {
-        let matrix = transformStruct.matrix3x3
-        let vector = Vector3(aPoint.x, aPoint.y, CGFloat(1.0))
-        let resultVector = multiplyMatrix3x3(matrix, byVector3: vector)
-        return NSMakePoint(resultVector.m1, resultVector.m2)
+        /**
+         [ x' ]     [ x ]   [ m11  m12  tX ] [ x ]   [ m11*x + m12*y + tX ]
+         [ y' ] = T [ y ] = [ m21  m22  tY ] [ y ] = [ m21*x + m22*y + tY ]
+         [  1 ]     [ 1 ]   [  0    0    1 ] [ 1 ]   [           1        ]
+         */
+        let x = transformStruct.m11*aPoint.x + transformStruct.m12*aPoint.y + transformStruct.tX
+        let y = transformStruct.m21*aPoint.x + transformStruct.m22*aPoint.y + transformStruct.tY
+        
+        return NSPoint(x: x, y: y)
     }
 
     public func transformSize(aSize: NSSize) -> NSSize {
-        let matrix = transformStruct.matrix3x3
-        let vector = Vector3(aSize.width, aSize.height, CGFloat(1.0))
-        let resultVector = multiplyMatrix3x3(matrix, byVector3: vector)
-        return NSMakeSize(resultVector.m1, resultVector.m2)
+        /**
+         [ w' ]     [ w ]   [ m11  m12  tX ] [ w ]   [ m11*w + m12*h ]
+         [ h' ] = T [ h ] = [ m21  m22  tY ] [ h ] = [ m21*w + m22*h ]
+         [  0 ]     [ 0 ]   [  0    0    1 ] [ 1 ]   [       0       ]
+         NOTE: Translation has no effect on sizes.
+         */
+        let w = transformStruct.m11*aSize.width + transformStruct.m12*aSize.height
+        let h = transformStruct.m21*aSize.width + transformStruct.m22*aSize.height
+        
+        return NSSize(width: w, height: h)
     }
 
     // Transform Struct
     public var transformStruct: NSAffineTransformStruct
-}
-
-// Private helper functions and structures for linear algebra operations.
-private typealias Vector3 = (m1: CGFloat, m2: CGFloat, m3: CGFloat)
-private typealias Matrix3x3 =
-    (m11: CGFloat, m12: CGFloat, m13: CGFloat,
-     m21: CGFloat, m22: CGFloat, m23: CGFloat,
-     m31: CGFloat, m32: CGFloat, m33: CGFloat)
-
-private func multiplyMatrix3x3(matrix: Matrix3x3, byVector3 vector: Vector3) -> Vector3 {
-    let x = matrix.m11 * vector.m1 + matrix.m12 * vector.m2 + matrix.m13 * vector.m3
-    let y = matrix.m21 * vector.m1 + matrix.m22 * vector.m2 + matrix.m23 * vector.m3
-    let z = matrix.m31 * vector.m1 + matrix.m32 * vector.m2 + matrix.m33 * vector.m3
-
-    return Vector3(x, y, z)
-}
-
-private extension NSAffineTransformStruct {
-    var matrix3x3: Matrix3x3 {
-        return Matrix3x3(m11, m12, tX,
-                         m21, m22, tY,
-                         CGFloat(), CGFloat(), CGFloat())
-    }
 }

--- a/Foundation/NSAffineTransform.swift
+++ b/Foundation/NSAffineTransform.swift
@@ -7,6 +7,11 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(OSX) || os(iOS)
+    import Darwin
+#elseif os(Linux)
+    import Glibc
+#endif
 
 public struct NSAffineTransformStruct {
     public var m11: CGFloat
@@ -52,57 +57,190 @@ public class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
     }
     
     public override init() {
-        transformStruct = NSAffineTransformStruct(m11: CGFloat(1.0), m12: CGFloat(), m21: CGFloat(), m22: CGFloat(1.0), tX: CGFloat(), tY: CGFloat())
+        transformStruct = NSAffineTransformStruct(
+            m11: CGFloat(1.0), m12: CGFloat(),
+            m21: CGFloat(), m22: CGFloat(1.0),
+            tX: CGFloat(), tY: CGFloat()
+        )
     }
     
     // Translating
-    public func translateXBy(deltaX: CGFloat, yBy deltaY: CGFloat) { NSUnimplemented() }
+    public func translateXBy(deltaX: CGFloat, yBy deltaY: CGFloat) {
+        let translation = NSAffineTransformStruct.translation(tX: deltaX, tY: deltaY)
+        
+        transformStruct = transformStruct.concat(translation)
+    }
     
     // Rotating
-    public func rotateByDegrees(angle: CGFloat) { NSUnimplemented() }
-    public func rotateByRadians(angle: CGFloat) { NSUnimplemented() }
+    public func rotateByDegrees(angle: CGFloat) {
+        let rotation = NSAffineTransformStruct.rotation(degrees: angle)
+        
+        transformStruct = transformStruct.concat(rotation)
+    }
+    public func rotateByRadians(angle: CGFloat) {
+        let rotation = NSAffineTransformStruct.rotation(radians: angle)
+        
+        transformStruct = transformStruct.concat(rotation)
+    }
     
     // Scaling
-    public func scaleBy(scale: CGFloat) { NSUnimplemented() }
-    public func scaleXBy(scaleX: CGFloat, yBy scaleY: CGFloat) { NSUnimplemented() }
+    public func scaleBy(scale: CGFloat) {
+        let scale = NSAffineTransformStruct.scale(sX: scale, sY: scale)
+        
+        transformStruct = transformStruct.concat(scale)
+    }
+    public func scaleXBy(scaleX: CGFloat, yBy scaleY: CGFloat) {
+        let scale = NSAffineTransformStruct.scale(sX: scaleX, sY: scaleY)
+        
+        transformStruct = transformStruct.concat(scale)
+    }
     
     // Inverting
     public func invert() { NSUnimplemented() }
     
     // Transforming with transform
-    public func appendTransform(transform: NSAffineTransform) { NSUnimplemented() }
-    public func prependTransform(transform: NSAffineTransform) { NSUnimplemented() }
+    public func appendTransform(transform: NSAffineTransform) {
+        transformStruct = transformStruct.concat(transform.transformStruct)
+    }
+    public func prependTransform(transform: NSAffineTransform) {
+        transformStruct = transform.transformStruct.concat(transformStruct)
+    }
     
     // Transforming points and sizes
     public func transformPoint(aPoint: NSPoint) -> NSPoint {
-        let (t, p) = (transformStruct, aPoint)
-        
-        /**
-         [ x' ]     [ x ]   [ m11  m12  tX ] [ x ]   [ m11*x + m12*y + tX ]
-         [ y' ] = T [ y ] = [ m21  m22  tY ] [ y ] = [ m21*x + m22*y + tY ]
-         [  1 ]     [ 1 ]   [  0    0    1 ] [ 1 ]   [           1        ]
-         */
-        let x = (t.m11 * p.x) + (t.m12 * p.y) + t.tX
-        let y = (t.m21 * p.x) + (t.m22 * p.y) + t.tY
-        
-        return NSPoint(x: x, y: y)
+        return transformStruct.applied(toPoint: aPoint)
     }
 
     public func transformSize(aSize: NSSize) -> NSSize {
-        let (t, s) = (transformStruct, aSize)
-        
-        /**
-         [ w' ]     [ w ]   [ m11  m12  tX ] [ w ]   [ m11*w + m12*h ]
-         [ h' ] = T [ h ] = [ m21  m22  tY ] [ h ] = [ m21*w + m22*h ]
-         [  0 ]     [ 0 ]   [  0    0    1 ] [ 1 ]   [       0       ]
-         NOTE: Translation has no effect on sizes.
-         */
-        let w = (t.m11 * s.width) + (t.m12 * s.height)
-        let h = (t.m21 * s.width) + (t.m22 * s.height)
-        
-        return NSSize(width: w, height: h)
+        return transformStruct.applied(toSize: aSize)
     }
 
     // Transform Struct
     public var transformStruct: NSAffineTransformStruct
 }
+
+
+private extension NSAffineTransformStruct {
+    /**
+     Creates an affine transformation matrix from translation values.
+     The matrix takes the following form:
+     
+     [ 1  0  tX ]
+     [ 0  1  tY ]
+     [ 0  0   1 ]
+     */
+    static func translation(tX tX: CGFloat, tY: CGFloat) -> NSAffineTransformStruct {
+        return NSAffineTransformStruct(
+            m11: CGFloat(1.0), m12: CGFloat(),
+            m21: CGFloat(),    m22: CGFloat(1.0),
+            tX: tX, tY: tY
+        )
+    }
+    
+    /**
+     Creates an affine transformation matrix from scaling values.
+     The matrix takes the following form:
+     
+     [ sX   0  0 ]
+     [ 0   sY  0 ]
+     [ 0    0  1 ]
+     */
+    static func scale(sX sX: CGFloat, sY: CGFloat) -> NSAffineTransformStruct {
+        return NSAffineTransformStruct(
+            m11: sX, m12: CGFloat(),
+            m21: CGFloat(), m22: sY,
+            tX: CGFloat(), tY: CGFloat()
+        )
+    }
+    
+    /**
+     Creates an affine transformation matrix from rotation value (angle in radians).
+     The matrix takes the following form:
+     
+     [ cos α   -sin α  0 ]
+     [ sin α    cos α  0 ]
+     [   0        0    1 ]
+     */
+    static func rotation(radians angle: CGFloat) -> NSAffineTransformStruct {
+        let α = Double(angle)
+        
+        return NSAffineTransformStruct(
+            m11: CGFloat(cos(α)), m12: CGFloat(-sin(α)),
+            m21: CGFloat(sin(α)), m22: CGFloat(cos(α)),
+            tX: CGFloat(), tY: CGFloat()
+        )
+    }
+    
+    /**
+     Creates an affine transformation matrix from a rotation value (angle in degrees).
+     The matrix takes the following form:
+     
+     [ cos α   -sin α  0 ]
+     [ sin α    cos α  0 ]
+     [   0        0    1 ]
+     */
+    static func rotation(degrees angle: CGFloat) -> NSAffineTransformStruct {
+        let α = Double(angle) * M_PI / 180.0
+        
+        return rotation(radians: CGFloat(α))
+    }
+    
+    /**
+     Creates an affine transformation matrix by combining the receiver with `transformStruct`.
+     That is, it computes `T * M` and returns the result, where `T` is the receiver's and `M` is
+     the `transformStruct`'s affine transformation matrix.
+     The resulting matrix takes the following form:
+     
+             [ m11_T  m12_T  tX_T ] [ m11_M  m12_M  tX_M ]
+     T * M = [ m21_T  m22_T  tY_T ] [ m21_M  m22_M  tY_M ]
+             [   0      0      1  ] [   0      0      1  ]
+     
+             [ (m11_T*m11_M + m12_T*m21_M)  (m11_T*m12_M + m12_T*m22_M)  (m11_T*tX_M + m12_T*tY_M + tX_T) ]
+           = [ (m21_T*m11_M + m22_T*m21_M)  (m21_T*m12_M + m22_T*m22_M)  (m21_T*tX_M + m22_T*tY_M + tY_T) ]
+             [              0                            0                                  1             ]
+     */
+    func concat(transformStruct: NSAffineTransformStruct) -> NSAffineTransformStruct {
+        let (t, m) = (self, transformStruct)
+
+        return NSAffineTransformStruct(
+            m11: (t.m11 * m.m11) + (t.m12 * m.m21), m12: (t.m11 * m.m12) + (t.m12 * m.m22),
+            m21: (t.m21 * m.m11) + (t.m22 * m.m21), m22: (t.m21 * m.m12) + (t.m22 * m.m22),
+            tX: (t.m11 * m.tX) + (t.m12 * m.tY) + t.tX,
+            tY: (t.m21 * m.tX) + (t.m22 * m.tY) + t.tY
+        )
+    }
+    
+    /**
+     Applies the affine transformation to `toPoint` and returns the result.
+     The resulting point takes the following form:
+     
+     [ x' ]     [ x ]   [ m11  m12  tX ] [ x ]   [ m11*x + m12*y + tX ]
+     [ y' ] = T [ y ] = [ m21  m22  tY ] [ y ] = [ m21*x + m22*y + tY ]
+     [  1 ]     [ 1 ]   [  0    0    1 ] [ 1 ]   [           1        ]
+     */
+    func applied(toPoint p: NSPoint) -> NSPoint {
+        let x = (m11 * p.x) + (m12 * p.y) + tX
+        let y = (m21 * p.x) + (m22 * p.y) + tY
+        
+        return NSPoint(x: x, y: y)
+    }
+    
+    /**
+     Applies the affine transformation to `toSize` and returns the result.
+     The resulting size takes the following form:
+     
+     [ w' ]     [ w ]   [ m11  m12  tX ] [ w ]   [ m11*w + m12*h ]
+     [ h' ] = T [ h ] = [ m21  m22  tY ] [ h ] = [ m21*w + m22*h ]
+     [  0 ]     [ 0 ]   [  0    0    1 ] [ 1 ]   [       0       ]
+     
+     Note: Translation has no effect on the size.
+     */
+    func applied(toSize s: NSSize) -> NSSize {
+        let w = (m11 * s.width) + (m12 * s.height)
+        let h = (m21 * s.width) + (m22 * s.height)
+        
+        return NSSize(width: w, height: h)
+    }
+}
+
+

--- a/Foundation/NSAffineTransform.swift
+++ b/Foundation/NSAffineTransform.swift
@@ -75,26 +75,30 @@ public class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
     
     // Transforming points and sizes
     public func transformPoint(aPoint: NSPoint) -> NSPoint {
+        let (t, p) = (transformStruct, aPoint)
+        
         /**
          [ x' ]     [ x ]   [ m11  m12  tX ] [ x ]   [ m11*x + m12*y + tX ]
          [ y' ] = T [ y ] = [ m21  m22  tY ] [ y ] = [ m21*x + m22*y + tY ]
          [  1 ]     [ 1 ]   [  0    0    1 ] [ 1 ]   [           1        ]
          */
-        let x = transformStruct.m11*aPoint.x + transformStruct.m12*aPoint.y + transformStruct.tX
-        let y = transformStruct.m21*aPoint.x + transformStruct.m22*aPoint.y + transformStruct.tY
+        let x = (t.m11 * p.x) + (t.m12 * p.y) + t.tX
+        let y = (t.m21 * p.x) + (t.m22 * p.y) + t.tY
         
         return NSPoint(x: x, y: y)
     }
 
     public func transformSize(aSize: NSSize) -> NSSize {
+        let (t, s) = (transformStruct, aSize)
+        
         /**
          [ w' ]     [ w ]   [ m11  m12  tX ] [ w ]   [ m11*w + m12*h ]
          [ h' ] = T [ h ] = [ m21  m22  tY ] [ h ] = [ m21*w + m22*h ]
          [  0 ]     [ 0 ]   [  0    0    1 ] [ 1 ]   [       0       ]
          NOTE: Translation has no effect on sizes.
          */
-        let w = transformStruct.m11*aSize.width + transformStruct.m12*aSize.height
-        let h = transformStruct.m21*aSize.width + transformStruct.m22*aSize.height
+        let w = (t.m11 * s.width) + (t.m12 * s.height)
+        let h = (t.m21 * s.width) + (t.m22 * s.height)
         
         return NSSize(width: w, height: h)
     }

--- a/Foundation/NSAffineTransform.swift
+++ b/Foundation/NSAffineTransform.swift
@@ -43,7 +43,11 @@ public class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
     }
     
     // Initialization
-    public convenience init(transform: NSAffineTransform) { NSUnimplemented() }
+    public convenience init(transform: NSAffineTransform) {
+        self.init()
+        transformStruct = transform.transformStruct
+    }
+    
     public override init() {
         transformStruct = NSAffineTransformStruct(m11: CGFloat(1.0), m12: CGFloat(), m21: CGFloat(), m22: CGFloat(1.0), tX: CGFloat(), tY: CGFloat())
     }

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -45,6 +45,18 @@ public func +(lhs: CGFloat, rhs: CGFloat) -> CGFloat {
     return CGFloat(lhs.native + rhs.native)
 }
 
+public func -(lhs: CGFloat, rhs: CGFloat) -> CGFloat {
+    return CGFloat(lhs.native - rhs.native)
+}
+
+public func /(lhs: CGFloat, rhs: CGFloat) -> CGFloat {
+    return CGFloat(lhs.native / rhs.native)
+}
+
+prefix public func -(x: CGFloat) -> CGFloat {
+    return CGFloat(-x.native)
+}
+
 @_transparent extension Double {
     public init(_ value: CGFloat) {
         self = Double(value.native)

--- a/TestFoundation/TestNSAffineTransform.swift
+++ b/TestFoundation/TestNSAffineTransform.swift
@@ -33,7 +33,8 @@ class TestNSAffineTransform : XCTestCase {
             ("test_Translation", test_Translation),
             ("test_Scale", test_Scale),
             ("test_Rotation_Degrees", test_Rotation_Degrees),
-            ("test_Rotation_Radians", test_Rotation_Radians)
+            ("test_Rotation_Radians", test_Rotation_Radians),
+            ("test_Inversion", test_Inversion)
         ]
     }
 
@@ -142,6 +143,38 @@ class TestNSAffineTransform : XCTestCase {
         let reflectAboutOrigin = NSAffineTransform()
         reflectAboutOrigin.rotateByRadians(CGFloat(M_PI))
         checkPointTransformation(reflectAboutOrigin, point: point, expectedPoint: NSPoint(x: CGFloat(-10.0), y: CGFloat(-10.0)))
+    }
+    
+    func test_Inversion() {
+        let point = NSPoint(x: CGFloat(10.0), y: CGFloat(10.0))
+        
+        let translate = NSAffineTransform()
+        translate.translateXBy(CGFloat(-30.0), yBy: CGFloat(40.0))
+        
+        let rotate = NSAffineTransform()
+        translate.rotateByDegrees(CGFloat(30.0))
+        
+        let scale = NSAffineTransform()
+        scale.scaleBy(CGFloat(2.0))
+        
+        let identityTransform = NSAffineTransform()
+        
+        // append transformations
+        identityTransform.appendTransform(translate)
+        identityTransform.appendTransform(rotate)
+        identityTransform.appendTransform(scale)
+        
+        // invert transformations
+        scale.invert()
+        rotate.invert()
+        translate.invert()
+        
+        // append inverse transformations in reverse order
+        identityTransform.appendTransform(scale)
+        identityTransform.appendTransform(rotate)
+        identityTransform.appendTransform(translate)
+        
+        checkPointTransformation(identityTransform, point: point, expectedPoint: point)
     }
 }
 


### PR DESCRIPTION
Hi,

The changes in this PR improve the implementation of the transformation methods. The new implementation makes use of the fact that a 2D affine transformation matrix is not an arbitrary 3x3 matrix (see code comments), and is both simpler and more efficient by skipping unnecessary computation steps.
Also included is:
- Implementation of `NSAffineTransformStruct.init()` which initializes all entries to zeros.
- Implementation of `NSAffineTransform.init(transform:)`
- Implementation of `NSCopying` methods for `NSAffineTransform`