### PR TITLE
LiteralSearch cannot be specified for rangeOfCharacterFromSet

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -408,15 +408,9 @@ extension NSString {
         }
         
 #if os(Linux)
-        var cfflags = CFStringCompareFlags(mask.rawValue)
-        if mask.contains(.LiteralSearch) {
-            cfflags |= UInt(kCFCompareNonliteral)
-        }
+        let cfflags = CFStringCompareFlags(mask.rawValue)
 #else
-        var cfflags = CFStringCompareFlags(rawValue: mask.rawValue)
-        if mask.contains(.LiteralSearch) {
-            cfflags.unionInPlace(.CompareNonliteral)
-        }
+        let cfflags = CFStringCompareFlags(rawValue: mask.rawValue)
 #endif
         var result = CFRangeMake(kCFNotFound, 0)
 


### PR DESCRIPTION
Only .AnchoredSearch and .BackwardsSearch are valid options.