### PR TITLE
NSAffineTransform: implemented support for scaling with tests

### DIFF
--- a/Foundation/NSAffineTransform.swift
+++ b/Foundation/NSAffineTransform.swift
@@ -58,8 +58,18 @@ public class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
     public func rotateByRadians(angle: CGFloat) { NSUnimplemented() }
     
     // Scaling
-    public func scaleBy(scale: CGFloat) { NSUnimplemented() }
-    public func scaleXBy(scaleX: CGFloat, yBy scaleY: CGFloat) { NSUnimplemented() }
+    public func scaleBy(scale: CGFloat) {
+        scaleXBy(scale, yBy: scale)
+    }
+    
+    public func scaleXBy(scaleX: CGFloat, yBy scaleY: CGFloat) {
+        let matrix = transformStruct.matrix3x3
+        let scaleMatrix = Matrix3x3(scaleX,    CGFloat(), CGFloat(),
+                                    CGFloat(), scaleY,    CGFloat(),
+                                    CGFloat(), CGFloat(), CGFloat(1.0))
+        let product = multiplyMatrix3x3(matrix, byMatrix3x3: scaleMatrix)
+        transformStruct = NSAffineTransformStruct(matrix: product)
+    }
     
     // Inverting
     public func invert() { NSUnimplemented() }

--- a/TestFoundation/TestNSAffineTransform.swift
+++ b/TestFoundation/TestNSAffineTransform.swift
@@ -31,7 +31,10 @@ class TestNSAffineTransform : XCTestCase {
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_IdentityTransformation", test_IdentityTransformation),
             ("test_Translation", test_Translation),
-            ("test_TranslationComposed", test_TranslationComposed)
+            ("test_TranslationComposed", test_TranslationComposed),
+            ("test_Scaling", test_Scaling),
+            ("test_TranslationScaling", test_TranslationScaling),
+            ("test_ScalingTranslation", test_ScalingTranslation)
         ]
     }
 
@@ -93,5 +96,37 @@ class TestNSAffineTransform : XCTestCase {
 
         checkPointTransformation(xyPlus5, point: NSMakePoint(CGFloat(-2.0), CGFloat(-3.0)),
                                   expectedPoint: NSMakePoint(CGFloat(3.0), CGFloat(2.0)))
+    }
+
+    func test_Scaling() {
+        let xyTimes5 = NSAffineTransform()
+        xyTimes5.scaleBy(CGFloat(5.0))
+
+        checkPointTransformation(xyTimes5, point: NSMakePoint(CGFloat(-2.0), CGFloat(3.0)),
+                                   expectedPoint: NSMakePoint(CGFloat(-10.0), CGFloat(15.0)))
+
+        let xTimes2YTimes3 = NSAffineTransform()
+        xTimes2YTimes3.scaleXBy(CGFloat(2.0), yBy: CGFloat(-3.0))
+
+        checkPointTransformation(xTimes2YTimes3, point: NSMakePoint(CGFloat(-1.0), CGFloat(3.5)),
+                                         expectedPoint: NSMakePoint(CGFloat(-2.0), CGFloat(-10.5)))
+    }
+
+    func test_TranslationScaling() {
+        let xPlus2XYTimes5 = NSAffineTransform()
+        xPlus2XYTimes5.translateXBy(CGFloat(2.0), yBy: CGFloat())
+        xPlus2XYTimes5.scaleXBy(CGFloat(5.0), yBy: CGFloat(-5.0))
+
+        checkPointTransformation(xPlus2XYTimes5, point: NSMakePoint(CGFloat(1.0), CGFloat(2.0)),
+                                         expectedPoint: NSMakePoint(CGFloat(7.0), CGFloat(-10.0)))
+    }
+
+    func test_ScalingTranslation() {
+        let xyTimes5XPlus3 = NSAffineTransform()
+        xyTimes5XPlus3.scaleBy(CGFloat(5.0))
+        xyTimes5XPlus3.translateXBy(CGFloat(3.0), yBy: CGFloat())
+
+        checkPointTransformation(xyTimes5XPlus3, point: NSMakePoint(CGFloat(1.0), CGFloat(2.0)),
+                                         expectedPoint: NSMakePoint(CGFloat(20.0), CGFloat(10.0)))
     }
 }


### PR DESCRIPTION
Now that we have a generic matrix multiplication function, this becomes trivial. I have also verified these tests against the `NSAffineTransform` in the 10.11 SDK to ensure consistent results (e.g. order of oeprations).