### PR TITLE
Implement NSIntegralRect and NSIntegralRectWithOptions

### DIFF
--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -7,6 +7,12 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(OSX) || os(iOS)
+    import Darwin
+#elseif os(Linux)
+    import Glibc
+#endif
+
 // TODO: It's not clear who is responsibile for defining these CGTypes, but we'll do it here.
 
 public struct CGFloat {
@@ -268,8 +274,165 @@ public func NSInsetRect(aRect: NSRect, _ dX: CGFloat, _ dY: CGFloat) -> NSRect {
     return NSMakeRect(x, y, w, h)
 }
 
-public func NSIntegralRect(aRect: NSRect) -> NSRect { NSUnimplemented() }
-public func NSIntegralRectWithOptions(aRect: NSRect, _ opts: NSAlignmentOptions) -> NSRect { NSUnimplemented() }
+public func NSIntegralRect(aRect: NSRect) -> NSRect {
+    if aRect.size.height.native <= 0 || aRect.size.width.native <= 0 {
+        return NSZeroRect
+    }
+    
+    return NSIntegralRectWithOptions(aRect, [.AlignMinXOutward, .AlignMaxXOutward, .AlignMinYOutward, .AlignMaxYOutward])
+}
+public func NSIntegralRectWithOptions(aRect: NSRect, _ opts: NSAlignmentOptions) -> NSRect {
+    let listOfOptionsIsInconsistentErrorMessage = "List of options is inconsistent"
+    
+    if opts.contains(.AlignRectFlipped) {
+        NSUnimplemented()
+    }
+
+    var width = Double.NaN
+    var height = Double.NaN
+    var minX = Double.NaN
+    var minY = Double.NaN
+    var maxX = Double.NaN
+    var maxY = Double.NaN
+
+    if aRect.size.height.native < 0 {
+        height = 0
+    }
+    if aRect.size.width.native < 0 {
+        width = 0
+    }
+    
+
+    if opts.contains(.AlignWidthInward) && width != 0 {
+        guard width.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        width = floor(aRect.size.width.native)
+    }
+    if opts.contains(.AlignHeightInward) && height != 0 {
+        guard height.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        height = floor(aRect.size.height.native)
+    }
+    if opts.contains(.AlignWidthOutward) && width != 0 {
+        guard width.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        width = ceil(aRect.size.width.native)
+    }
+    if opts.contains(.AlignHeightOutward) && height != 0 {
+        guard height.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        height = ceil(aRect.size.height.native)
+    }
+    if opts.contains(.AlignWidthNearest) && width != 0 {
+        guard width.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        width = round(aRect.size.width.native)
+    }
+    if opts.contains(.AlignHeightNearest) && height != 0 {
+        guard height.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        height = round(aRect.size.height.native)
+    }
+
+    
+    if opts.contains(.AlignMinXInward) {
+        guard minX.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        minX = ceil(aRect.origin.x.native)
+    }
+    if opts.contains(.AlignMinYInward) {
+        guard minY.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        minY = ceil(aRect.origin.y.native)
+    }
+    if opts.contains(.AlignMaxXInward) {
+        guard maxX.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        maxX = floor(aRect.origin.x.native + aRect.size.width.native)
+    }
+    if opts.contains(.AlignMaxYInward) {
+        guard maxY.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        maxY = floor(aRect.origin.y.native + aRect.size.height.native)
+    }
+
+    
+    if opts.contains(.AlignMinXOutward) {
+        guard minX.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        minX = floor(aRect.origin.x.native)
+    }
+    if opts.contains(.AlignMinYOutward) {
+        guard minY.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        minY = floor(aRect.origin.y.native)
+    }
+    if opts.contains(.AlignMaxXOutward) {
+        guard maxX.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        maxX = ceil(aRect.origin.x.native + aRect.size.width.native)
+    }
+    if opts.contains(.AlignMaxYOutward) {
+        guard maxY.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        maxY = ceil(aRect.origin.y.native + aRect.size.height.native)
+    }
+    
+
+    if opts.contains(.AlignMinXNearest) {
+        guard minX.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        minX = round(aRect.origin.x.native)
+    }
+    if opts.contains(.AlignMinYNearest) {
+        guard minY.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        minY = round(aRect.origin.y.native)
+    }
+    if opts.contains(.AlignMaxXNearest) {
+        guard maxX.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        maxX = round(aRect.origin.x.native + aRect.size.width.native)
+    }
+    if opts.contains(.AlignMaxYNearest) {
+        guard maxY.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+        maxY = round(aRect.origin.y.native + aRect.size.height.native)
+    }
+    
+    var resultOriginX = Double.NaN
+    var resultOriginY = Double.NaN
+    var resultWidth = Double.NaN
+    var resultHeight = Double.NaN
+    
+    if !minX.isNaN {
+        resultOriginX = minX
+    }
+    if !width.isNaN {
+        resultWidth = width
+    }
+    if !maxX.isNaN {
+        if width.isNaN {
+            guard resultWidth.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+            resultWidth = maxX - minX
+        } else {
+            guard resultOriginX.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+            resultOriginX = maxX - width
+        }
+    }
+    
+    
+    if !minY.isNaN {
+        resultOriginY = minY
+    }
+    if !height.isNaN {
+        resultHeight = height
+    }
+    if !maxY.isNaN {
+        if height.isNaN {
+            guard resultHeight.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+            resultHeight = maxY - minY
+        } else {
+            guard resultOriginY.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
+            resultOriginY = maxY - height
+        }
+    }
+    
+    if resultOriginX.isNaN || resultOriginY.isNaN
+        || resultHeight.isNaN || resultWidth.isNaN {
+        fatalError(listOfOptionsIsInconsistentErrorMessage)
+    }
+    
+    var result = NSZeroRect
+    result.origin.x.native = resultOriginX
+    result.origin.y.native = resultOriginY
+    result.size.width.native = resultWidth
+    result.size.height.native = resultHeight
+    
+    return result
+}
 
 public func NSUnionRect(aRect: NSRect, _ bRect: NSRect) -> NSRect { NSUnimplemented() }
 public func NSIntersectionRect(aRect: NSRect, _ bRect: NSRect) -> NSRect { NSUnimplemented() }

--- a/TestFoundation/TestNSGeometry.swift
+++ b/TestFoundation/TestNSGeometry.swift
@@ -31,6 +31,8 @@ class TestNSGeometry : XCTestCase {
             ("test_NSMakePoint", test_NSMakePoint),
             ("test_NSMakeSize", test_NSMakeSize),
             ("test_NSMakeRect", test_NSMakeRect),
+            ("test_NSIntegralRect", test_NSIntegralRect),
+            ("test_NSIntegralRectWithOptions", test_NSIntegralRectWithOptions),
         ]
     }
 
@@ -137,5 +139,115 @@ class TestNSGeometry : XCTestCase {
         XCTAssertEqual(r2.origin.y, CGFloat(3.0))
         XCTAssertEqual(r2.size.width, CGFloat(5.0))
         XCTAssertEqual(r2.size.height, CGFloat(5.0))
+    }
+
+    func test_NSIntegralRect() {
+        let referenceNegativeRect = NSMakeRect(CGFloat(-0.6), CGFloat(-5.4), CGFloat(-105.7), CGFloat(-24.3))
+        XCTAssertEqual(NSIntegralRect(referenceNegativeRect), NSZeroRect)
+
+        
+        let referenceRect = NSMakeRect(CGFloat(0.6), CGFloat(5.4), CGFloat(105.7), CGFloat(24.3))
+        let referenceNegativeOriginRect = NSMakeRect(CGFloat(-0.6), CGFloat(-5.4), CGFloat(105.7), CGFloat(24.3))
+        
+        var expectedResult = NSMakeRect(CGFloat(0.0), CGFloat(5.0), CGFloat(107.0), CGFloat(25.0))
+        var result = NSIntegralRect(referenceRect)
+        XCTAssertEqual(result, expectedResult)
+
+        expectedResult = NSMakeRect(CGFloat(-1.0), CGFloat(-6.0), CGFloat(107.0), CGFloat(25.0))
+        result = NSIntegralRect(referenceNegativeOriginRect)
+        XCTAssertEqual(result, expectedResult)
+    
+    }
+    
+    func test_NSIntegralRectWithOptions() {
+        let referenceRect = NSMakeRect(CGFloat(0.6), CGFloat(5.4), CGFloat(105.7), CGFloat(24.3))
+        let referenceNegativeRect = NSMakeRect(CGFloat(-0.6), CGFloat(-5.4), CGFloat(-105.7), CGFloat(-24.3))
+        let referenceNegativeOriginRect = NSMakeRect(CGFloat(-0.6), CGFloat(-5.4), CGFloat(105.7), CGFloat(24.3))
+
+        var options: NSAlignmentOptions = [.AlignMinXInward, .AlignMinYInward, .AlignHeightInward, .AlignWidthInward]
+        var expectedResult = NSMakeRect(CGFloat(1.0), CGFloat(6.0), CGFloat(105.0), CGFloat(24.0))
+        var result = NSIntegralRectWithOptions(referenceRect, options)
+        XCTAssertEqual(result, expectedResult)
+
+        options = [.AlignMinXOutward, .AlignMinYOutward, .AlignHeightOutward, .AlignWidthOutward]
+        expectedResult = NSMakeRect(CGFloat(0.0), CGFloat(5.0), CGFloat(106.0), CGFloat(25.0))
+        result = NSIntegralRectWithOptions(referenceRect, options)
+        XCTAssertEqual(result, expectedResult)
+
+        options = [.AlignMinXInward, .AlignMinYInward, .AlignHeightInward, .AlignWidthInward]
+        expectedResult = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(0.0), CGFloat(0.0))
+        result = NSIntegralRectWithOptions(referenceNegativeRect, options)
+        XCTAssertEqual(result, expectedResult)
+        
+        options = [.AlignMinXInward, .AlignMinYInward, .AlignHeightInward, .AlignWidthInward]
+        expectedResult = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(105.0), CGFloat(24.0))
+        result = NSIntegralRectWithOptions(referenceNegativeOriginRect, options)
+        XCTAssertEqual(result, expectedResult)
+
+        options = [.AlignMinXOutward, .AlignMinYOutward, .AlignHeightOutward, .AlignWidthOutward]
+        expectedResult = NSMakeRect(CGFloat(-1.0), CGFloat(-6.0), CGFloat(106.0), CGFloat(25.0))
+        result = NSIntegralRectWithOptions(referenceNegativeOriginRect, options)
+        XCTAssertEqual(result, expectedResult)
+
+        options = [.AlignMaxXOutward, .AlignMaxYOutward, .AlignHeightOutward, .AlignWidthOutward]
+        expectedResult = NSMakeRect(CGFloat(0.0), CGFloat(-6.0), CGFloat(106.0), CGFloat(25.0))
+        result = NSIntegralRectWithOptions(referenceNegativeOriginRect, options)
+        XCTAssertEqual(result, expectedResult)
+
+        options = [.AlignMinXOutward, .AlignMaxXOutward, .AlignMinYOutward, .AlignMaxYOutward]
+        expectedResult = NSMakeRect(CGFloat(-1.0), CGFloat(-6.0), CGFloat(107.0), CGFloat(25.0))
+        result = NSIntegralRectWithOptions(referenceNegativeOriginRect, options)
+        XCTAssertEqual(result, expectedResult)
+
+        options = [.AlignMaxXOutward, .AlignMaxYOutward, .AlignHeightOutward, .AlignWidthOutward]
+        expectedResult = NSMakeRect(CGFloat(1.0), CGFloat(5.0), CGFloat(106.0), CGFloat(25.0))
+        result = NSIntegralRectWithOptions(referenceRect, options)
+        XCTAssertEqual(result, expectedResult)
+
+        options = [.AlignMaxXInward, .AlignMaxYInward, .AlignHeightOutward, .AlignWidthOutward]
+        expectedResult = NSMakeRect(CGFloat(-1.0), CGFloat(-7.0), CGFloat(106.0), CGFloat(25.0))
+        result = NSIntegralRectWithOptions(referenceNegativeOriginRect, options)
+        XCTAssertEqual(result, expectedResult)
+
+        options = [.AlignMaxXInward, .AlignMaxYInward, .AlignHeightOutward, .AlignWidthOutward]
+        expectedResult = NSMakeRect(CGFloat(0.0), CGFloat(4.0), CGFloat(106.0), CGFloat(25.0))
+        result = NSIntegralRectWithOptions(referenceRect, options)
+        XCTAssertEqual(result, expectedResult)
+
+        options = [.AlignMinXNearest, .AlignMinYNearest, .AlignHeightNearest, .AlignWidthNearest]
+        expectedResult = NSMakeRect(CGFloat(1.0), CGFloat(5.0), CGFloat(106.0), CGFloat(24.0))
+        result = NSIntegralRectWithOptions(referenceRect, options)
+        XCTAssertEqual(result, expectedResult)
+        
+        options = [.AlignMinXNearest, .AlignMinYNearest, .AlignHeightNearest, .AlignWidthNearest]
+        expectedResult = NSMakeRect(CGFloat(-1.0), CGFloat(-5.0), CGFloat(106.0), CGFloat(24.0))
+        result = NSIntegralRectWithOptions(referenceNegativeOriginRect, options)
+        XCTAssertEqual(result, expectedResult)
+
+        options = [.AlignMaxXNearest, .AlignMaxYNearest, .AlignHeightNearest, .AlignWidthNearest]
+        expectedResult = NSMakeRect(CGFloat(0.0), CGFloat(6.0), CGFloat(106.0), CGFloat(24.0))
+        result = NSIntegralRectWithOptions(referenceRect, options)
+        XCTAssertEqual(result, expectedResult)
+        
+        options = [.AlignMaxXNearest, .AlignMaxYNearest, .AlignHeightNearest, .AlignWidthNearest]
+        expectedResult = NSMakeRect(CGFloat(-1.0), CGFloat(-5.0), CGFloat(106.0), CGFloat(24.0))
+        result = NSIntegralRectWithOptions(referenceNegativeOriginRect, options)
+        XCTAssertEqual(result, expectedResult)
+
+        options = [.AlignMinXInward, .AlignMaxXInward, .AlignMinYInward, .AlignMaxYInward]
+        expectedResult = NSMakeRect(CGFloat(1.0), CGFloat(6.0), CGFloat(105.0), CGFloat(23.0))
+        result = NSIntegralRectWithOptions(referenceRect, options)
+        XCTAssertEqual(result, expectedResult)
+        
+        options = [.AlignMinXInward, .AlignMaxXInward, .AlignMinYInward, .AlignMaxYInward]
+        expectedResult = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(105.0), CGFloat(23.0))
+        result = NSIntegralRectWithOptions(referenceNegativeOriginRect, options)
+        XCTAssertEqual(result, expectedResult)
+
+        options = [.AlignMinXNearest, .AlignMaxXInward, .AlignMinYInward, .AlignMaxYNearest]
+        expectedResult = NSMakeRect(CGFloat(-1.0), CGFloat(-5.0), CGFloat(106.0), CGFloat(24.0))
+        result = NSIntegralRectWithOptions(referenceNegativeOriginRect, options)
+        XCTAssertEqual(result, expectedResult)
+
     }
 }


### PR DESCRIPTION
Implemented two more functions from NSGeometry: NSIntegralRect and NSIntegralRectWithOptions

Not sure if the function should produce fatalError in case if input is wrong, but it seems to behave like this in objc version of foundation.

Also tried to cover NSIntegralRectWithOptions with tests, but I'm not 100% sure if test covers every possible case. Would be really great to see objc version of the same tests.