### PR TITLE
Always close file descriptor (eventually runs out of them)

### DIFF
--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -215,7 +215,10 @@ extension NSData {
         if fd < 0 {
             throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: nil)
         }
-        
+        defer {
+            close(fd)
+        }
+
         var info = stat()
         let ret = withUnsafeMutablePointer(&info) { infoPointer -> Bool in
             if fstat(fd, infoPointer) < 0 {
@@ -225,7 +228,6 @@ extension NSData {
         }
         
         if !ret {
-            close(fd)
             throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: nil)
         }
         
@@ -236,7 +238,6 @@ extension NSData {
             
             // Swift does not currently expose MAP_FAILURE
             if data != UnsafeMutablePointer<Void>(bitPattern: -1) {
-                close(fd)
                 return NSDataReadResult(bytes: data, length: length) { buffer, length in
                     munmap(data, length)
                 }
@@ -256,7 +257,6 @@ extension NSData {
             total += amt
         }
 
-        close(fd)
         if remaining != 0 {
             throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: nil)
         }

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -255,8 +255,9 @@ extension NSData {
             remaining -= amt
             total += amt
         }
+
+        close(fd)
         if remaining != 0 {
-            close(fd)
             throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: nil)
         }
         


### PR DESCRIPTION
File descriptor is not closed if no error occurs. Eventually they get exhausted after 1000 NSData( contentsOfFile: path )