### PR TITLE
NSMutableURLRequest implementation

### DIFF
--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -389,7 +389,13 @@ public class NSMutableURLRequest : NSURLRequest {
         if _httpHeaderFields == nil {
             _httpHeaderFields = [:]
         }
-        _httpHeaderFields?[field.lowercaseString] = value
+        if let existingHeader = _httpHeaderFields?.filter({ (existingField, _) -> Bool in
+            return existingField.lowercaseString == field.lowercaseString
+        }).first {
+            let (existingField, _) = existingHeader
+            _httpHeaderFields?.removeValueForKey(existingField)
+        }
+        _httpHeaderFields?[field] = value
     }
     
     /*! 
@@ -410,10 +416,13 @@ public class NSMutableURLRequest : NSURLRequest {
         if _httpHeaderFields == nil {
             _httpHeaderFields = [:]
         }
-        if let oldValue = _httpHeaderFields?[field.lowercaseString] {
-            _httpHeaderFields?[field.lowercaseString] = "\(oldValue),\(value)"
+        if let existingHeader = _httpHeaderFields?.filter({ (existingField, _) -> Bool in
+            return existingField.lowercaseString == field.lowercaseString
+        }).first {
+            let (existingField, existingValue) = existingHeader
+            _httpHeaderFields?[existingField] = "\(existingValue),\(value)"
         } else {
-            _httpHeaderFields?[field.lowercaseString] = value
+            _httpHeaderFields?[field] = value
         }
     }
 }

--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -252,7 +252,7 @@ public class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopyin
     @abstract Returns the HTTP request method of the receiver.
     @result the HTTP request method of the receiver.
     */
-    public var HTTPMethod: String? { get { return "GET" }}
+    public var HTTPMethod: String? { get { return "GET" } }
     
     /*!
     @method allHTTPHeaderFields
@@ -308,15 +308,40 @@ public class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopyin
 */
 public class NSMutableURLRequest : NSURLRequest {
     
+    private var _HTTPMethod: String? = "GET"
+    
     public required init?(coder aDecoder: NSCoder) {
         NSUnimplemented()
     }
-    /*! 
+    
+    /*!
+     @method initWithURL:
+     @abstract Initializes an NSMutableURLRequest with the given URL.
+     @discussion Default values are used for cache policy
+     (NSURLRequestUseProtocolCachePolicy) and timeout interval (60
+     seconds).
+     @param URL The URL for the request.
+     @result An initialized NSMutableURLRequest.
+     */
+    public init(URL: NSURL) {
+        super.init()
+        _URL = URL
+    }
+    
+    
+    /*!
         @method URL
         @abstract Sets the URL of the receiver. 
         @param URL The new URL for the receiver. 
     */
-    /*@NSCopying */ public override var URL: NSURL? { get { NSUnimplemented() } set { NSUnimplemented() } }
+    /*@NSCopying */ public override var URL: NSURL? {
+        get {
+            return _URL
+        }
+        set(newURL) {
+            _URL = newURL
+        }
+    }
 
     /*!
         @method setMainDocumentURL:
@@ -329,14 +354,27 @@ public class NSMutableURLRequest : NSURLRequest {
         "only from same domain as main document" policy, and possibly
         other things in the future.
     */
-    /*@NSCopying*/ public override var mainDocumentURL: NSURL? { get { NSUnimplemented() } set { NSUnimplemented() } }
+    /*@NSCopying*/ public override var mainDocumentURL: NSURL? {
+        get {
+            return _mainDocumentURL
+        } set(newMainDocumentURL) {
+            _mainDocumentURL = newMainDocumentURL
+        }
+    }
+    
     
     /*!
         @method HTTPMethod
         @abstract Sets the HTTP request method of the receiver.
         @result the HTTP request method of the receiver.
     */
-    public override var HTTPMethod: String? { get { NSUnimplemented() } set { NSUnimplemented() } }
+    public override var HTTPMethod: String? {
+        get {
+            return _HTTPMethod
+        } set(newHTTPMethod) {
+            _HTTPMethod = newHTTPMethod
+        }
+    }
     
     /*!
         @method setValue:forHTTPHeaderField:
@@ -348,7 +386,12 @@ public class NSMutableURLRequest : NSURLRequest {
         @param value the header field value. 
         @param field the header field name (case-insensitive). 
     */
-    public func setValue(value: String?, forHTTPHeaderField field: String) { NSUnimplemented() }
+    public func setValue(value: String?, forHTTPHeaderField field: String) {
+        if _httpHeaderFields == nil {
+            _httpHeaderFields = [:]
+        }
+        _httpHeaderFields?[field.lowercaseString] = value
+    }
     
     /*! 
         @method addValue:forHTTPHeaderField:
@@ -364,7 +407,16 @@ public class NSMutableURLRequest : NSURLRequest {
         @param value the header field value. 
         @param field the header field name (case-insensitive). 
     */
-    public func addValue(value: String, forHTTPHeaderField field: String) { NSUnimplemented() }
+    public func addValue(value: String, forHTTPHeaderField field: String) {
+        if _httpHeaderFields == nil {
+            _httpHeaderFields = [:]
+        }
+        if let oldValue = _httpHeaderFields?[field.lowercaseString] {
+            _httpHeaderFields?[field.lowercaseString] = "\(oldValue),\(value)"
+        } else {
+            _httpHeaderFields?[field.lowercaseString] = value
+        }
+    }
 }
 
 

--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -328,7 +328,6 @@ public class NSMutableURLRequest : NSURLRequest {
         _URL = URL
     }
     
-    
     /*!
         @method URL
         @abstract Sets the URL of the receiver. 

--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -311,22 +311,10 @@ public class NSMutableURLRequest : NSURLRequest {
     private var _HTTPMethod: String? = "GET"
     
     public required init?(coder aDecoder: NSCoder) {
-        NSUnimplemented()
+        super.init()
     }
     
-    /*!
-     @method initWithURL:
-     @abstract Initializes an NSMutableURLRequest with the given URL.
-     @discussion Default values are used for cache policy
-     (NSURLRequestUseProtocolCachePolicy) and timeout interval (60
-     seconds).
-     @param URL The URL for the request.
-     @result An initialized NSMutableURLRequest.
-     */
-    public init(URL: NSURL) {
-        super.init()
-        _URL = URL
-    }
+    private override init() { super.init() }
     
     /*!
         @method URL

--- a/TestFoundation/TestNSURLRequest.swift
+++ b/TestFoundation/TestNSURLRequest.swift
@@ -21,11 +21,14 @@ class TestNSURLRequest : XCTestCase {
     var allTests : [(String, () -> ())] {
         return [
             ("test_construction", test_construction),
+            ("test_mutableConstruction", test_mutableConstruction),
+            ("test_headerFields", test_headerFields)
         ]
     }
     
+    let URL = NSURL(string: "http://swift.org")!
+    
     func test_construction() {
-        let URL = NSURL(string: "http://swift.org")!
         let request = NSURLRequest(URL: URL)
         // Match OS X Foundation responses
         XCTAssertNotNil(request)
@@ -33,5 +36,36 @@ class TestNSURLRequest : XCTestCase {
         XCTAssertEqual(request.HTTPMethod, "GET")
         XCTAssertNil(request.allHTTPHeaderFields)
         XCTAssertNil(request.mainDocumentURL)
+    }
+    
+    func test_mutableConstruction() {
+        let URL = NSURL(string: "http://swift.org")!
+        let request = NSMutableURLRequest(URL: URL)
+        //Confirm initial state matches NSURLRequest responses
+        XCTAssertNotNil(request)
+        XCTAssertEqual(request.URL, URL)
+        XCTAssertEqual(request.HTTPMethod, "GET")
+        XCTAssertNil(request.allHTTPHeaderFields)
+        XCTAssertNil(request.mainDocumentURL)
+        
+        request.mainDocumentURL = URL
+        XCTAssertEqual(request.mainDocumentURL, URL)
+        
+        request.HTTPMethod = "POST"
+        XCTAssertEqual(request.HTTPMethod, "POST")
+        
+        let newURL = NSURL(string: "http://github.com")!
+        request.URL = newURL
+        XCTAssertEqual(request.URL, newURL)
+    }
+    
+    func test_headerFields() {
+        let request = NSMutableURLRequest(URL: URL)
+        request.setValue("application/json", forHTTPHeaderField: "accept")
+        XCTAssertNotNil(request.allHTTPHeaderFields)
+        XCTAssertEqual(request.allHTTPHeaderFields?["accept"], "application/json")
+        //HTTP Header fields should be case insensitive
+        request.addValue("text/html", forHTTPHeaderField: "Accept")
+        XCTAssertEqual(request.allHTTPHeaderFields?["accept"], "application/json,text/html")
     }
 }

--- a/TestFoundation/TestNSURLRequest.swift
+++ b/TestFoundation/TestNSURLRequest.swift
@@ -41,6 +41,7 @@ class TestNSURLRequest : XCTestCase {
     func test_mutableConstruction() {
         let URL = NSURL(string: "http://swift.org")!
         let request = NSMutableURLRequest(URL: URL)
+        
         //Confirm initial state matches NSURLRequest responses
         XCTAssertNotNil(request)
         XCTAssertEqual(request.URL, URL)
@@ -61,11 +62,18 @@ class TestNSURLRequest : XCTestCase {
     
     func test_headerFields() {
         let request = NSMutableURLRequest(URL: URL)
-        request.setValue("application/json", forHTTPHeaderField: "accept")
+        
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
         XCTAssertNotNil(request.allHTTPHeaderFields)
-        XCTAssertEqual(request.allHTTPHeaderFields?["accept"], "application/json")
-        //HTTP Header fields should be case insensitive
+        XCTAssertEqual(request.allHTTPHeaderFields?["Accept"], "application/json")
+
+        // Setting "accept" should remove "Accept"
+        request.setValue("application/xml", forHTTPHeaderField: "accept")
+        XCTAssertNil(request.allHTTPHeaderFields?["Accept"])
+        XCTAssertEqual(request.allHTTPHeaderFields?["accept"], "application/xml")
+        
+        // Adding to "Accept" should add to "accept"
         request.addValue("text/html", forHTTPHeaderField: "Accept")
-        XCTAssertEqual(request.allHTTPHeaderFields?["accept"], "application/json,text/html")
+        XCTAssertEqual(request.allHTTPHeaderFields?["accept"], "application/xml,text/html")
     }
 }


### PR DESCRIPTION
+ Basic initialization
+ Getters / setters
+ Set / add request header functions
+ Tests

I didn't implement this to avoid changing the interface, but I think it would make sense going forward to change NSURLRequest's init(NSURL) method from convenience to required and mark the URL property as non-optional.  