### PR TITLE
Fix CFStringCreateByCombiningStrings' handling of non-ASCII separators.

### DIFF
--- a/CoreFoundation/String.subproj/CFString.c
+++ b/CoreFoundation/String.subproj/CFString.c
@@ -4117,7 +4117,7 @@ CFStringRef CFStringCreateByCombiningStrings(CFAllocatorRef alloc, CFArrayRef ar
             } else {
                 if (!isSepCFString) { // NSString
                     CFStringGetCharacters(separatorString, CFRangeMake(0, CFStringGetLength(separatorString)), (UniChar *)bufPtr);
-                } else if (canBeEightbit) {
+                } else if (canBeEightbit || __CFStrIsUnicode(separatorString)) {
                     memmove(bufPtr, (const uint8_t *)__CFStrContents(separatorString) + __CFStrSkipAnyLengthByte(separatorString), separatorNumByte);
                 } else {	
                     __CFStrConvertBytesToUnicode((uint8_t *)__CFStrContents(separatorString) + __CFStrSkipAnyLengthByte(separatorString), (UniChar *)bufPtr, __CFStrLength(separatorString));


### PR DESCRIPTION
This fixes CFStringCreateByCombiningStrings' handling of non-ASCII separator strings (radar 23834767).

Test code that reproduces the bug:
```c
int main(int argc, const char *argv[])
{
	CFMutableArrayRef arr = CFArrayCreateMutable(kCFAllocatorDefault, 2, &kCFTypeArrayCallBacks);
	CFArraySetValueAtIndex(arr, 0, CFSTR("Hello"));
	CFArraySetValueAtIndex(arr, 1, CFSTR("World"));

	CFStringRef result = CFStringCreateByCombiningStrings(kCFAllocatorDefault, arr, CFSTR("»"));
	assert(CFStringGetLength(result) == 11);

	UniChar expectedResult[11] = {
		0x0048, 0x0065, 0x006C, 0x006C, 0x006F, // Hello
		0x00BB,                                 // »
		0x0057, 0x006F, 0x0072, 0x006C, 0x0064  // World
	};
	for (CFIndex i = 0; i < CFStringGetLength(result); i++) {
		UniChar ch = CFStringGetCharacterAtIndex(result, i);
		if (ch != expectedResult[i]) {
			printf("String is wrong at index %li (expected 0x%X but got 0x%X)\n",
			       i, expectedResult[i], ch);
			abort();
		}
	}

	CFRelease(result);
	CFRelease(arr);
	return 0;
}
```