### PR TITLE
[NSDate] comparable protocol implementation.

### DIFF
--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -169,6 +169,18 @@ extension NSDate {
 
 extension NSDate : _CFBridgable { }
 
+extension NSDate : Comparable, Equatable { }
+
+@warn_unused_result public func <(_ lhs: NSDate, _ rhs: NSDate) -> Bool
+{
+    return lhs.timeIntervalSinceReferenceDate < rhs.timeIntervalSinceReferenceDate
+}
+
+@warn_unused_result public func ==(_ lhs: NSDate, _ rhs: NSDate) -> Bool
+{
+    return lhs.timeIntervalSinceReferenceDate == rhs.timeIntervalSinceReferenceDate
+}
+
 extension CFDateRef : _NSBridgable {
     typealias NSType = NSDate
     internal var _nsObject: NSType { return unsafeBitCast(self, NSType.self) }

--- a/TestFoundation/TestNSDate.swift
+++ b/TestFoundation/TestNSDate.swift
@@ -34,6 +34,10 @@ class TestNSDate : XCTestCase {
             ("test_LaterDate", test_LaterDate),
             ("test_Compare", test_Compare),
             ("test_IsEqualToDate", test_IsEqualToDate),
+            ("test_NSDateEquatableTrue", test_NSDateEquatableTrue),
+            ("test_NSDateEquatableFalse", test_NSDateEquatableFalse),
+            ("test_NSDateComparableLessThan", test_NSDateComparableLessThan),
+            ("test_NSDateComparableGreaterThan", test_NSDateComparableGreaterThan),
         ]
     }
     
@@ -106,5 +110,37 @@ class TestNSDate : XCTestCase {
         let d2 = d1.dateByAddingTimeInterval(ti)
         let d3 = d1.dateByAddingTimeInterval(ti)
         XCTAssertTrue(d2.isEqualToDate(d3))
+    }
+    
+    func test_NSDateEquatableTrue() {
+        let ti: NSTimeInterval = 1
+        let d1 = NSDate()
+        let d2 = d1.dateByAddingTimeInterval(ti)
+        let d3 = d1.dateByAddingTimeInterval(ti)
+        XCTAssertTrue(d2 == d3)
+    }
+    
+    func test_NSDateEquatableFalse() {
+        let ti: NSTimeInterval = 1
+        let d1 = NSDate()
+        let d2 = d1.dateByAddingTimeInterval(ti)
+        let d3 = d1
+        XCTAssertTrue(d2 != d3)
+    }
+    
+    func test_NSDateComparableLessThan() {
+        let ti: NSTimeInterval = 1
+        let d1 = NSDate()
+        let d2 = d1.dateByAddingTimeInterval(ti)
+        let d3 = d1
+        XCTAssertTrue(d3 < d2)
+    }
+    
+    func test_NSDateComparableGreaterThan() {
+        let ti: NSTimeInterval = 1
+        let d1 = NSDate()
+        let d2 = d1
+        let d3 = d1.dateByAddingTimeInterval(ti)
+        XCTAssertTrue(d3 > d2)
     }
 }


### PR DESCRIPTION
Added basic comparison operators.

Equatable has been explicitly declared as a conformed protocol, whilst this is implicitly declared by conforming to the Comparable protocol, adding the explicit declaration makes it more readable and understandable that this is the case.