### PR TITLE
[NSDate] Comparable Protocol Implementation

### DIFF
--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -169,6 +169,18 @@ extension NSDate {
 
 extension NSDate : _CFBridgable { }
 
+extension NSDate : Comparable, Equatable { }
+
+@warn_unused_result public func <(_ lhs: NSDate, _ rhs: NSDate) -> Bool
+{
+    return lhs.timeIntervalSinceReferenceDate < rhs.timeIntervalSinceReferenceDate
+}
+
+@warn_unused_result public func ==(_ lhs: NSDate, _ rhs: NSDate) -> Bool
+{
+    return lhs.timeIntervalSinceReferenceDate == rhs.timeIntervalSinceReferenceDate
+}
+
 extension CFDateRef : _NSBridgable {
     typealias NSType = NSDate
     internal var _nsObject: NSType { return unsafeBitCast(self, NSType.self) }

--- a/TestFoundation/TestNSDate.swift
+++ b/TestFoundation/TestNSDate.swift
@@ -34,6 +34,10 @@ class TestNSDate : XCTestCase {
             ("test_LaterDate", test_LaterDate),
             ("test_Compare", test_Compare),
             ("test_IsEqualToDate", test_IsEqualToDate),
+            ("test_EquatableTrue", test_EquatableTrue),
+            ("test_EquatableFalse", test_EquatableFalse),
+            ("test_ComparableGreaterThan", test_ComparableGreaterThan),
+            ("test_ComparableLessThan", test_ComparableLessThan),
         ]
     }
     
@@ -106,5 +110,38 @@ class TestNSDate : XCTestCase {
         let d2 = d1.dateByAddingTimeInterval(ti)
         let d3 = d1.dateByAddingTimeInterval(ti)
         XCTAssertTrue(d2.isEqualToDate(d3))
+    }
+    
+    func test_EquatableTrue() {
+        let ti: NSTimeInterval = 1
+        let d1 = NSDate()
+        let d2 = d1.dateByAddingTimeInterval(ti)
+        let d3 = d1.dateByAddingTimeInterval(ti)
+        XCTAssertTrue(d2 == d3)
+    }
+    
+    func test_EquatableFalse() {
+        let ti: NSTimeInterval = 1
+        let d1 = NSDate()
+        let d2 = d1.dateByAddingTimeInterval(ti)
+        let d3 = d1
+        XCTAssertTrue(d2 != d3)
+    }
+    
+    func test_ComparableGreaterThan() {
+        let ti: NSTimeInterval = 1
+        let d1 = NSDate()
+        let d2 = d1.dateByAddingTimeInterval(ti)
+        let d3 = d1
+        XCTAssertTrue(d2 > d3)
+    }
+    
+    func test_ComparableLessThan()
+    {
+        let ti: NSTimeInterval = 1
+        let d1 = NSDate()
+        let d2 = d1
+        let d3 = d1.dateByAddingTimeInterval(ti)
+        XCTAssertTrue(d2 < d3)
     }
 }


### PR DESCRIPTION
Pull Request re-done after failing to rebase.

Added basic comparison operators.

Equatable has been explicitly declared as a conformed protocol, whilst this is implicitly declared by conforming to the Comparable protocol, adding the explicit declaration makes it more readable and understandable that this is the case.