### PR TITLE
Implement contentsOfDirectoryAtPath

### DIFF
--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -24,6 +24,8 @@ class TestNSFileManger : XCTestCase {
             ("test_fileSystemRepresentation", test_fileSystemRepresentation),
             ("test_fileAttributes", test_fileAttributes),
             ("test_directoryEnumerator", test_directoryEnumerator),
+            ("test_contentsOfDirectoryAtPath", test_contentsOfDirectoryAtPath),
+            ("test_subpathsOfDirectoryAtPath", test_subpathsOfDirectoryAtPath)
         ]
     }
     
@@ -239,4 +241,96 @@ class TestNSFileManger : XCTestCase {
         }
     }
     
+    func test_contentsOfDirectoryAtPath() {
+        let fm = NSFileManager.defaultManager()
+        let path = "/tmp/testdir"
+        let itemPath1 = "/tmp/testdir/item"
+        let itemPath2 = "/tmp/testdir/item2"
+        
+        ignoreError { try fm.removeItemAtPath(path) }
+        
+        do {
+            try fm.createDirectoryAtPath(path, withIntermediateDirectories: false, attributes: nil)
+            fm.createFileAtPath(itemPath1, contents: NSData(), attributes: nil)
+            fm.createFileAtPath(itemPath2, contents: NSData(), attributes: nil)
+        } catch _ {
+            XCTFail()
+        }
+        
+        do {
+            let entries = try fm.contentsOfDirectoryAtPath(path)
+            
+            XCTAssertEqual(2, entries.count)
+            XCTAssertTrue(entries.contains("item"))
+            XCTAssertTrue(entries.contains("item2"))
+        }
+        catch _ {
+            XCTFail()
+        }
+        
+        do {
+            try fm.contentsOfDirectoryAtPath("")
+            
+            XCTFail()
+        }
+        catch _ {
+            // Invalid directories should fail.
+        }
+        
+        do {
+            try fm.removeItemAtPath(path)
+        } catch {
+            XCTFail("Failed to clean up files")
+        }
+    }
+    
+    func test_subpathsOfDirectoryAtPath() {
+        let fm = NSFileManager.defaultManager()
+        let path = "/tmp/testdir"
+        let path2 = "/tmp/testdir/sub"
+        let itemPath1 = "/tmp/testdir/item"
+        let itemPath2 = "/tmp/testdir/item2"
+        let itemPath3 = "/tmp/testdir/sub/item3"
+                
+        ignoreError { try fm.removeItemAtPath(path) }
+        
+        do {
+            try fm.createDirectoryAtPath(path, withIntermediateDirectories: false, attributes: nil)
+            fm.createFileAtPath(itemPath1, contents: NSData(), attributes: nil)
+            fm.createFileAtPath(itemPath2, contents: NSData(), attributes: nil)
+            
+            try fm.createDirectoryAtPath(path2, withIntermediateDirectories: false, attributes: nil)
+            fm.createFileAtPath(itemPath3, contents: NSData(), attributes: nil)
+        } catch _ {
+            XCTFail()
+        }
+        
+        do {
+            let entries = try fm.subpathsOfDirectoryAtPath(path)
+            
+            XCTAssertEqual(4, entries.count)
+            XCTAssertTrue(entries.contains("item"))
+            XCTAssertTrue(entries.contains("item2"))
+            XCTAssertTrue(entries.contains("sub"))
+            XCTAssertTrue(entries.contains("sub/item3"))
+        }
+        catch _ {
+            XCTFail()
+        }
+        
+        do {
+            try fm.subpathsOfDirectoryAtPath("")
+            
+            XCTFail()
+        }
+        catch _ {
+            // Invalid directories should fail.
+        }
+        
+        do {
+            try fm.removeItemAtPath(path)
+        } catch {
+            XCTFail("Failed to clean up files")
+        }
+    }
 }


### PR DESCRIPTION
Implementing NSFileManager::contentsOfDirectoryAtPath() and NSFileManager::subpathsOfDirectoryAtPath().

Error messages aren't currently an exact match for the standard Foundation library, which throws:

```
Fatal error: Error raised at top level: Error Domain=NSCocoaErrorDomain Code=260 "The folder “notexist” doesn’t exist." UserInfo={NSFilePath=/Users/euan/Desktop/notexist, NSUserStringVariant=(
    Folder
), NSUnderlyingError=0x1007019f0 {Error Domain=NSOSStatusErrorDomain Code=-43 "fnfErr: File not found"}}: file /Library/Caches/com.apple.xbs/Sources/swiftlang/swiftlang-700.1.101.15/src/swift/stdlib/public/core/ErrorType.swift, line 56
(lldb)
```

Whereas this commit throws:

```
fatal error: Error raised at top level: Error Domain=NSCocoaErrorDomain Code=260 "The file notexist couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Users/euan/Desktop/notexist}: file /Library/Caches/com.apple.xbs/Sources/swiftlang/swiftlang-700.1.101.15/src/swift/stdlib/public/core/ErrorType.swift, line 56
```

However, I lack the knowledge to know what I'm missing with the `NSError`.

Otherwise, the test cases pass and this should hopefully work.