### PR TITLE
[NSMutableArray] replace objects in range docs/tests/impl

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 		61F8AE7D1C180FC600FB62F0 /* TestNSNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F8AE7C1C180FC600FB62F0 /* TestNSNotificationCenter.swift */; };
 		6E203B8D1C1303BB003B2576 /* TestNSBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E203B8C1C1303BB003B2576 /* TestNSBundle.swift */; };
 		7A7D6FBB1C16439400957E2E /* TestNSURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A7D6FBA1C16439400957E2E /* TestNSURLResponse.swift */; };
+		7AD22BF01C1CE0AA00377EC0 /* TestNSMutableArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AD22BEF1C1CE0AA00377EC0 /* TestNSMutableArray.swift */; };
 		83712C8E1C1684900049AD49 /* TestNSURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83712C8D1C1684900049AD49 /* TestNSURLRequest.swift */; };
 		844DC3331C17584F005611F9 /* TestNSScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844DC3321C17584F005611F9 /* TestNSScanner.swift */; };
 		848A30581C137B3500C83206 /* TestNSHTTPCookie.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848A30571C137B3500C83206 /* TestNSHTTPCookie.swift */; };
@@ -543,6 +544,7 @@
 		61F8AE7C1C180FC600FB62F0 /* TestNSNotificationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSNotificationCenter.swift; sourceTree = "<group>"; };
 		6E203B8C1C1303BB003B2576 /* TestNSBundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSBundle.swift; sourceTree = "<group>"; };
 		7A7D6FBA1C16439400957E2E /* TestNSURLResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSURLResponse.swift; sourceTree = "<group>"; };
+		7AD22BEF1C1CE0AA00377EC0 /* TestNSMutableArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSMutableArray.swift; sourceTree = "<group>"; };
 		83712C8D1C1684900049AD49 /* TestNSURLRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSURLRequest.swift; sourceTree = "<group>"; };
 		844DC3321C17584F005611F9 /* TestNSScanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSScanner.swift; sourceTree = "<group>"; };
 		848A30571C137B3500C83206 /* TestNSHTTPCookie.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestNSHTTPCookie.swift; path = TestFoundation/TestNSHTTPCookie.swift; sourceTree = SOURCE_ROOT; };
@@ -1043,37 +1045,38 @@
 		EA66F65A1BF1976100136161 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				61F8AE7C1C180FC600FB62F0 /* TestNSNotificationCenter.swift */,
 				C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */,
 				EA66F63C1BF1619600136161 /* TestNSArray.swift */,
 				6E203B8C1C1303BB003B2576 /* TestNSBundle.swift */,
-				5BC1D8BC1BF3ADFE009D3973 /* TestNSCharacterSet.swift */,
+				A5A34B551C18C85D00FD972B /* TestNSByteCountFormatter.swift */,
 				52829AD61C160D64003BC4EF /* TestNSCalendar.swift */,
+				5BC1D8BC1BF3ADFE009D3973 /* TestNSCharacterSet.swift */,
+				DCDBB8321C1768AC00313299 /* TestNSData.swift */,
+				22B9C1E01C165D7A00DECFF9 /* TestNSDate.swift */,
 				EA66F63D1BF1619600136161 /* TestNSDictionary.swift */,
-				848A30571C137B3500C83206 /* TestNSHTTPCookie.swift */,
 				525AECEB1BF2C96400D15BB0 /* TestNSFileManager.swift */,
 				88D28DE61C13AE9000494606 /* TestNSGeometry.swift */,
+				848A30571C137B3500C83206 /* TestNSHTTPCookie.swift */,
 				4AE109261C17CCBF007367B5 /* TestNSIndexPath.swift */,
 				EA66F63E1BF1619600136161 /* TestNSIndexSet.swift */,
 				5EB6A15C1C188FC40037DCB8 /* TestNSJSONSerialization.swift */,
+				7AD22BEF1C1CE0AA00377EC0 /* TestNSMutableArray.swift */,
+				61F8AE7C1C180FC600FB62F0 /* TestNSNotificationCenter.swift */,
+				612952F81C1B235900BE0FD9 /* TestNSNull.swift */,
 				EA66F63F1BF1619600136161 /* TestNSNumber.swift */,
 				4DC1D07F1C12EEEF00B5948A /* TestNSPipe.swift */,
 				400E22641C1A4E58007C5933 /* TestNSProcessInfo.swift */,
 				EA66F6401BF1619600136161 /* TestNSPropertyList.swift */,
 				E876A73D1C1180E000F279EC /* TestNSRange.swift */,
+				844DC3321C17584F005611F9 /* TestNSScanner.swift */,
 				EA66F6411BF1619600136161 /* TestNSSet.swift */,
 				EA66F6421BF1619600136161 /* TestNSString.swift */,
-				C2A9D75B1C15C08B00993803 /* TestNSUUID.swift */,
-				EA66F6431BF1619600136161 /* TestNSURL.swift */,
-				5B40F9F11C125187000E72E3 /* TestNSXMLParser.swift */,
-				22B9C1E01C165D7A00DECFF9 /* TestNSDate.swift */,
-				DCDBB8321C1768AC00313299 /* TestNSData.swift */,
 				84BA558D1C16F90900F48C54 /* TestNSTimeZone.swift */,
-				844DC3321C17584F005611F9 /* TestNSScanner.swift */,
+				EA66F6431BF1619600136161 /* TestNSURL.swift */,
 				83712C8D1C1684900049AD49 /* TestNSURLRequest.swift */,
 				7A7D6FBA1C16439400957E2E /* TestNSURLResponse.swift */,
-				A5A34B551C18C85D00FD972B /* TestNSByteCountFormatter.swift */,
-				612952F81C1B235900BE0FD9 /* TestNSNull.swift */,
+				C2A9D75B1C15C08B00993803 /* TestNSUUID.swift */,
+				5B40F9F11C125187000E72E3 /* TestNSXMLParser.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -1796,6 +1799,7 @@
 				88D28DE71C13AE9000494606 /* TestNSGeometry.swift in Sources */,
 				EA66F64C1BF1619600136161 /* TestNSDictionary.swift in Sources */,
 				ED58F76F1C134B3A00E6A5BE /* (null) in Sources */,
+				7AD22BF01C1CE0AA00377EC0 /* TestNSMutableArray.swift in Sources */,
 				EA66F6581BF1619600136161 /* TestNSURL.swift in Sources */,
 				EA66F6441BF1619600136161 /* main.swift in Sources */,
 			);

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -658,7 +658,19 @@ public class NSMutableArray : NSArray {
             }
         }
     }
-    public func replaceObjectsInRange(range: NSRange, withObjectsFromArray otherArray: [AnyObject], range otherRange: NSRange) { NSUnimplemented() }
+    
+    /// Replaces the objects in the receiving array specified by one given range with the objects in another array specified by another range.
+    /// - parameter range: The range of objects to be replaced in (or removed from) the receiving array.
+    /// - parameter otherArray: The array of objects from which to select replacements for the objects in `range`.
+    /// - parameter otherRange: The range of objects be selected from `otherArray` as replacements for the objects in `range`.
+    public func replaceObjectsInRange(range: NSRange, withObjectsFromArray otherArray: [AnyObject], range otherRange: NSRange) {
+        let slicedOtherArray = Array(otherArray[otherRange.location...otherRange.length+otherRange.location])
+        replaceObjectsInRange(range, withObjectsFromArray: slicedOtherArray)
+    }
+    
+    /// Replaces the objects in the receiving array specified by a given range with all of the objects from a given array.
+    /// - parameter range: The range of objects to be replaced in (or removed from) the receiving array.
+    /// - parameter otherArray: The array of objects from which to select replacements for the objects in `range`.
     public func replaceObjectsInRange(range: NSRange, withObjectsFromArray otherArray: [AnyObject]) {
         if self.dynamicType === NSMutableArray.self {
             _storage.reserveCapacity(count - range.length + otherArray.count)

--- a/TestFoundation/TestNSMutableArray.swift
+++ b/TestFoundation/TestNSMutableArray.swift
@@ -1,0 +1,58 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+
+
+class TestNSMutableArray : XCTestCase {
+    
+    var allTests : [(String, () -> ())] {
+        return [
+            ("test_replaceObjectsInRangeWithObjectsFromArray", test_replaceObjectsInRangeWithObjectsFromArray),
+        ]
+    }
+    
+    func test_replaceObjectsInRangeWithObjectsFromArray() {
+        let existing = [NSNumber(int: 1), NSNumber(int: 2), NSNumber(int: 3), NSNumber(int: 4), NSNumber(int: 5), NSNumber(int: 6)]
+        let nsExisting = NSMutableArray(array: existing)
+        let otherArr = [NSNumber(int: 7), NSNumber(int: 8), NSNumber(int: 9)]
+        let range = NSMakeRange(3, 3)
+        nsExisting.replaceObjectsInRange(range, withObjectsFromArray: otherArr)
+        XCTAssertEqual((nsExisting[0] as! NSNumber).intValue, 1)
+        XCTAssertEqual((nsExisting[1] as! NSNumber).intValue, 2)
+        XCTAssertEqual((nsExisting[2] as! NSNumber).intValue, 3)
+        XCTAssertEqual((nsExisting[3] as! NSNumber).intValue, 7)
+        XCTAssertEqual((nsExisting[4] as! NSNumber).intValue, 8)
+        XCTAssertEqual((nsExisting[5] as! NSNumber).intValue, 9)
+    }
+    
+    func test_replaceObjectsInRangeWithObjectsFromArrayOtherRange() {
+        let existing = [NSNumber(int: 1), NSNumber(int: 2), NSNumber(int: 3), NSNumber(int: 4), NSNumber(int: 5), NSNumber(int: 6)]
+        let nsExisting = NSMutableArray(array: existing)
+        let otherArr = [NSNumber(int: 7), NSNumber(int: 8), NSNumber(int: 9), NSNumber(int: 1), NSNumber(int: 2), NSNumber(int: 3)]
+        let range = NSMakeRange(3, 3)
+        let otherRange = NSMakeRange(2, 3)
+        nsExisting.replaceObjectsInRange(range, withObjectsFromArray: otherArr, range: otherRange)
+        XCTAssertEqual((nsExisting[0] as! NSNumber).intValue, 1)
+        XCTAssertEqual((nsExisting[1] as! NSNumber).intValue, 2)
+        XCTAssertEqual((nsExisting[2] as! NSNumber).intValue, 9)
+        XCTAssertEqual((nsExisting[3] as! NSNumber).intValue, 1)
+        XCTAssertEqual((nsExisting[4] as! NSNumber).intValue, 2)
+        XCTAssertEqual((nsExisting[5] as! NSNumber).intValue, 6)
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -36,6 +36,7 @@ XCTMain([
     TestNSIndexPath(),
     TestNSIndexSet(),
     TestNSJSONSerialization(),
+    TestNSMutableArray(),
     TestNSNotificationCenter(),
     TestNSNumber(),
     TestNSPipe(),


### PR DESCRIPTION
I think I found a bug while writing these tests. Not sure what the process is for filing it, but I was getting a a complier error "Int does not conform to expected element type AnyObject"  when doing `NSMutableArray(array: [1, 2, 3])` which seems...wrong.

Tested on latests official xcode build from app store and it definitely works.

Will be happy to try and resolve that issue before this gets merged as the tests look a little verbose as a result of the bug.