### PR TITLE
Fix: addIndexesInRange now correctly adds neighbor NSRanges

### DIFF
--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -556,7 +556,7 @@ public class NSMutableIndexSet : NSIndexSet {
                 // Nothing to add
                 return
             } else if range.location >= curRange.location && range.location <= curEnd && addEnd > curEnd {
-                _replaceRangeAtIndex(rangeIndex, withRange: NSMakeRange(addEnd - curRange.location, curRange.location))
+                _replaceRangeAtIndex(rangeIndex, withRange: NSMakeRange(curRange.location, addEnd - curRange.location))
                 replacedRangeIndex = rangeIndex
                 // Proceed to merging
                 break

--- a/TestFoundation/TestNSIndexSet.swift
+++ b/TestFoundation/TestNSIndexSet.swift
@@ -25,6 +25,7 @@ class TestNSIndexSet : XCTestCase {
             ("test_enumeration", test_enumeration),
             ("test_sequenceType", test_sequenceType),
             ("test_removal", test_removal),
+            ("test_addition",test_addition),
         ]
     }
     
@@ -101,6 +102,70 @@ class TestNSIndexSet : XCTestCase {
         
         XCTAssertTrue(removalSet.isEqualToIndexSet(additionSet))
         
+    }
+    
+    func test_addition() {
+        
+        let testSetA = NSMutableIndexSet(index: 0)
+        testSetA.addIndex(5)
+        testSetA.addIndex(6)
+        testSetA.addIndex(7)
+        testSetA.addIndex(8)
+        testSetA.addIndex(42)
+        
+        let testInputA1 = [0,5,6,7,8,42]
+        var i = 0
+        
+        if testInputA1.count == testSetA.count {
+            testSetA.enumerateIndexesUsingBlock { (idx, _) in
+                XCTAssertEqual(idx, testInputA1[i])
+                i++
+            }
+        }
+        else {
+            XCTFail("IndexSet does not contain correct number of indexes")
+        }
+        
+        
+        let testInputA2 = [NSMakeRange(0, 1),NSMakeRange(5, 4),NSMakeRange(42, 1)]
+        i = 0
+        
+        testSetA.enumerateRangesUsingBlock { (range, _) in
+            let testRange = testInputA2[i]
+            XCTAssertEqual(range.location, testRange.location)
+            XCTAssertEqual(range.length, testRange.length)
+            i++
+        }
+        
+        let testSetB = NSMutableIndexSet(indexesInRange: NSMakeRange(0,5))
+        testSetB.addIndexesInRange(NSMakeRange(42, 3))
+        testSetB.addIndexesInRange(NSMakeRange(2, 2))
+        testSetB.addIndexesInRange(NSMakeRange(18, 1))
+        
+        let testInputB1 = [0,1,2,3,4,18,42,43,44]
+        i = 0
+        
+        if testInputB1.count == testSetB.count {
+            testSetB.enumerateIndexesUsingBlock { (idx, _) in
+                XCTAssertEqual(idx, testInputB1[i])
+                i++
+            }
+        }
+        else {
+            XCTFail("IndexSet does not contain correct number of indexes")
+        }
+        
+        
+        let testInputB2 = [NSMakeRange(0, 5),NSMakeRange(18, 1),NSMakeRange(42, 3)]
+        i = 0
+        
+        testSetB.enumerateRangesUsingBlock { (range, _) in
+            let testRange = testInputB2[i]
+            XCTAssertEqual(range.location, testRange.location)
+            XCTAssertEqual(range.length, testRange.length)
+            i++
+        }
+    
     }
     
 }


### PR DESCRIPTION
Fixing a bug where adding neighboring indices would result in an incorrect range being created in the index set.

Example:

```swift

let set = NSMutableIndexSet(index: 0)
set.addIndex(1)

```

In this case, the index set would contain one NSRange (location 2, length 0). 

The correct result should be that the index set contains one NSRange (location 0, length 2).

Added some tests as well.