### PR TITLE
Return copy of path

### DIFF
--- a/CoreFoundation/Base.subproj/CFUtilities.c
+++ b/CoreFoundation/Base.subproj/CFUtilities.c
@@ -309,7 +309,7 @@ static CFStringRef copySystemVersionPath(CFStringRef suffix) {
     if (!simulatorRoot) simulatorRoot = "/";
     return CFStringCreateWithFormat(kCFAllocatorSystemDefault, NULL, CFSTR("%s%@"), simulatorRoot, suffix);
 #else
-    return suffix;
+    return CFStringCreateCopy(kCFAllocatorSystemDefault, suffix);
 #endif
 }
 


### PR DESCRIPTION
I'm not 100% sure about this one, primarily because it doesn't crash on OS X, however this fixes [this crash](https://github.com/apple/swift-corelibs-foundation/pull/50#discussion_r47550314) on linux for me

Also, looking at the line above (return within `#if TARGET_IPHONE_SIMULATOR`) I see that it actually creates and returns a new copy of a string - just what method's name says.