### PR TITLE
The `currentThread` method call returns different values

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		5BF7AEBF1BCD51F9008F214A /* NSURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4A1BCC5DCB00ED97BB /* NSURL.swift */; };
 		5BF7AEC01BCD51F9008F214A /* NSUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4B1BCC5DCB00ED97BB /* NSUUID.swift */; };
 		5BF7AEC11BCD51F9008F214A /* NSValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4C1BCC5DCB00ED97BB /* NSValue.swift */; };
+		5E5835F41C20C9B500C81317 /* TestNSThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5835F31C20C9B500C81317 /* TestNSThread.swift */; };
 		612952F91C1B235900BE0FD9 /* TestNSNull.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612952F81C1B235900BE0FD9 /* TestNSNull.swift */; };
 		61F8AE7D1C180FC600FB62F0 /* TestNSNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F8AE7C1C180FC600FB62F0 /* TestNSNotificationCenter.swift */; };
 		6E203B8D1C1303BB003B2576 /* TestNSBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E203B8C1C1303BB003B2576 /* TestNSBundle.swift */; };
@@ -538,6 +539,7 @@
 		5BDC3FCF1BCF17E600ED97BB /* NSCFSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSCFSet.swift; sourceTree = "<group>"; };
 		5BDC405C1BD6D83B00ED97BB /* TestFoundation.app */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestFoundation.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BF7AEC21BCD568D008F214A /* ForSwiftFoundationOnly.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ForSwiftFoundationOnly.h; sourceTree = "<group>"; };
+		5E5835F31C20C9B500C81317 /* TestNSThread.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSThread.swift; sourceTree = "<group>"; };
 		5EB6A15C1C188FC40037DCB8 /* TestNSJSONSerialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSJSONSerialization.swift; sourceTree = "<group>"; };
 		612952F81C1B235900BE0FD9 /* TestNSNull.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSNull.swift; sourceTree = "<group>"; };
 		61F8AE7C1C180FC600FB62F0 /* TestNSNotificationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSNotificationCenter.swift; sourceTree = "<group>"; };
@@ -1043,37 +1045,38 @@
 		EA66F65A1BF1976100136161 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				61F8AE7C1C180FC600FB62F0 /* TestNSNotificationCenter.swift */,
 				C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */,
 				EA66F63C1BF1619600136161 /* TestNSArray.swift */,
 				6E203B8C1C1303BB003B2576 /* TestNSBundle.swift */,
-				5BC1D8BC1BF3ADFE009D3973 /* TestNSCharacterSet.swift */,
+				A5A34B551C18C85D00FD972B /* TestNSByteCountFormatter.swift */,
 				52829AD61C160D64003BC4EF /* TestNSCalendar.swift */,
+				5BC1D8BC1BF3ADFE009D3973 /* TestNSCharacterSet.swift */,
+				DCDBB8321C1768AC00313299 /* TestNSData.swift */,
+				22B9C1E01C165D7A00DECFF9 /* TestNSDate.swift */,
 				EA66F63D1BF1619600136161 /* TestNSDictionary.swift */,
-				848A30571C137B3500C83206 /* TestNSHTTPCookie.swift */,
 				525AECEB1BF2C96400D15BB0 /* TestNSFileManager.swift */,
 				88D28DE61C13AE9000494606 /* TestNSGeometry.swift */,
+				848A30571C137B3500C83206 /* TestNSHTTPCookie.swift */,
 				4AE109261C17CCBF007367B5 /* TestNSIndexPath.swift */,
 				EA66F63E1BF1619600136161 /* TestNSIndexSet.swift */,
 				5EB6A15C1C188FC40037DCB8 /* TestNSJSONSerialization.swift */,
+				61F8AE7C1C180FC600FB62F0 /* TestNSNotificationCenter.swift */,
+				612952F81C1B235900BE0FD9 /* TestNSNull.swift */,
 				EA66F63F1BF1619600136161 /* TestNSNumber.swift */,
 				4DC1D07F1C12EEEF00B5948A /* TestNSPipe.swift */,
 				400E22641C1A4E58007C5933 /* TestNSProcessInfo.swift */,
 				EA66F6401BF1619600136161 /* TestNSPropertyList.swift */,
 				E876A73D1C1180E000F279EC /* TestNSRange.swift */,
+				844DC3321C17584F005611F9 /* TestNSScanner.swift */,
 				EA66F6411BF1619600136161 /* TestNSSet.swift */,
 				EA66F6421BF1619600136161 /* TestNSString.swift */,
-				C2A9D75B1C15C08B00993803 /* TestNSUUID.swift */,
-				EA66F6431BF1619600136161 /* TestNSURL.swift */,
-				5B40F9F11C125187000E72E3 /* TestNSXMLParser.swift */,
-				22B9C1E01C165D7A00DECFF9 /* TestNSDate.swift */,
-				DCDBB8321C1768AC00313299 /* TestNSData.swift */,
+				5E5835F31C20C9B500C81317 /* TestNSThread.swift */,
 				84BA558D1C16F90900F48C54 /* TestNSTimeZone.swift */,
-				844DC3321C17584F005611F9 /* TestNSScanner.swift */,
+				EA66F6431BF1619600136161 /* TestNSURL.swift */,
 				83712C8D1C1684900049AD49 /* TestNSURLRequest.swift */,
 				7A7D6FBA1C16439400957E2E /* TestNSURLResponse.swift */,
-				A5A34B551C18C85D00FD972B /* TestNSByteCountFormatter.swift */,
-				612952F81C1B235900BE0FD9 /* TestNSNull.swift */,
+				C2A9D75B1C15C08B00993803 /* TestNSUUID.swift */,
+				5B40F9F11C125187000E72E3 /* TestNSXMLParser.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -1771,6 +1774,7 @@
 				EA66F6501BF1619600136161 /* TestNSNumber.swift in Sources */,
 				844DC3331C17584F005611F9 /* TestNSScanner.swift in Sources */,
 				E876A73E1C1180E000F279EC /* TestNSRange.swift in Sources */,
+				5E5835F41C20C9B500C81317 /* TestNSThread.swift in Sources */,
 				C2A9D75C1C15C08B00993803 /* TestNSUUID.swift in Sources */,
 				A5A34B561C18C85D00FD972B /* TestNSByteCountFormatter.swift in Sources */,
 				612952F91C1B235900BE0FD9 /* TestNSNull.swift in Sources */,

--- a/Foundation/NSThread.swift
+++ b/Foundation/NSThread.swift
@@ -31,7 +31,7 @@ internal class NSThreadSpecific<T: AnyObject> {
             NSThreadSpecificKeyLock.lock()
             if !NSThreadSpecificKeySet {
                 withUnsafeMutablePointer(&NSThreadSpecificKey) { key in
-                    NSThreadSpecificKeySet = pthread_key_create(key, disposeTLS) != 0
+                    NSThreadSpecificKeySet = pthread_key_create(key, disposeTLS) == 0
                 }
             }
             NSThreadSpecificKeyLock.unlock()

--- a/TestFoundation/TestNSThread.swift
+++ b/TestFoundation/TestNSThread.swift
@@ -1,0 +1,34 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+
+class TestNSThread : XCTestCase {
+    var allTests : [(String, () -> Void)] {
+        return [
+            ("test_currentThread", test_currentThread ),
+        ]
+    }
+
+    func test_currentThread() {
+        let thread1 = NSThread.currentThread()
+        let thread2 = NSThread.currentThread()
+        XCTAssertNotNil(thread1)
+        XCTAssertNotNil(thread2)
+        XCTAssertEqual(thread1, thread2)
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -45,6 +45,7 @@ XCTMain([
     TestNSScanner(),
     TestNSSet(),
     TestNSString(),
+    TestNSThread(),
     TestNSTimeZone(),
     TestNSURL(),
     TestNSURLComponents(),


### PR DESCRIPTION
The `currentThread` method call returns different values. We should check the `pthread_key_create` result for 0. According to documentation:

> If successful, the pthread_key_create() function shall store the newly created key value at *key and
> shall return zero. Otherwise, an error number shall be returned to indicate the error.