### PR TITLE
Fix pthread warnings on ubuntu

### DIFF
--- a/CoreFoundation/Base.subproj/CFPriv.h
+++ b/CoreFoundation/Base.subproj/CFPriv.h
@@ -563,9 +563,9 @@ CF_EXPORT CFMessagePortRef _CFMessagePortCreateLocalEx(CFAllocatorRef allocator,
 
 #endif
 
-#if TARGET_OS_MAC || TARGET_OS_EMBEDDED || TARGET_OS_IPHONE || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_EMBEDDED || TARGET_OS_IPHONE
 #include <pthread.h>
-#else
+#elif !TARGET_OS_LINUX
 // Avoid including the pthread header
 #ifndef HAVE_STRUCT_TIMESPEC
 #define HAVE_STRUCT_TIMESPEC 1


### PR DESCRIPTION
These warnings:
<img width="1119" alt="screen shot 2015-12-16 at 9 15 58 am" src="https://cloud.githubusercontent.com/assets/1967999/11835879/f981b6ee-a3d6-11e5-9a97-bc8277a4186a.png">
