### PR TITLE
Change TestNSCharacterSet.test_Predefines

### DIFF
--- a/TestFoundation/TestNSCharacterSet.swift
+++ b/TestFoundation/TestNSCharacterSet.swift
@@ -52,12 +52,9 @@ class TestNSCharacterSet : XCTestCase {
         
         let mcset = NSMutableCharacterSet.whitespaceAndNewlineCharacterSet()
         let cset2 = NSCharacterSet.whitespaceAndNewlineCharacterSet()
-        let count = UInt32(0x10FFFF)
-        for var idx = UInt32(0); idx < count; idx++ {
-            let a = mcset.longCharacterIsMember(idx)
-            let b = cset2.longCharacterIsMember(idx)
-            XCTAssertEqual(a, b, "\(String(idx, radix: 16)) \(a ? "exists in" : "does not exist in") mutable and \(b ? "exists in" : "does not exist in") immutable character set")
-        }
+
+        XCTAssert(mcset.isSupersetOfSet(cset2))
+        XCTAssert(cset2.isSupersetOfSet(mcset))
         
         XCTAssertTrue(NSCharacterSet.whitespaceAndNewlineCharacterSet().isSupersetOfSet(NSCharacterSet.newlineCharacterSet()), "whitespace and newline should be a superset of newline")
         let data = NSCharacterSet.uppercaseLetterCharacterSet().bitmapRepresentation


### PR DESCRIPTION
This test used to take 2 minutes on my (virtual) linux machine. On OS X it used to be 2.5 seconds, which is acceptable.
<img width="692" alt="screen shot 2015-12-16 at 9 13 02 am" src="https://cloud.githubusercontent.com/assets/1967999/11838771/6bd613cc-a3e9-11e5-8386-10d0efca05c7.png">

Also here's a list of tests that are also relatively slow to run:

```
Test Case 'TestNSURL.test_URLStrings' passed (7.307 seconds).
Test Case 'TestNSURLComponents.test_string' passed (14.938 seconds).
```