### PR TITLE
Fix NSAffineTransform

### DIFF
--- a/Foundation/NSAffineTransform.swift
+++ b/Foundation/NSAffineTransform.swift
@@ -106,10 +106,10 @@ public class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
     
     // Transforming with transform
     public func appendTransform(transform: NSAffineTransform) {
-        transformStruct = transformStruct.concat(transform.transformStruct)
+        transformStruct = transform.transformStruct.concat(transformStruct)
     }
     public func prependTransform(transform: NSAffineTransform) {
-        transformStruct = transform.transformStruct.concat(transformStruct)
+        transformStruct = transformStruct.concat(transform.transformStruct)
     }
     
     // Transforming points and sizes

--- a/TestFoundation/TestNSAffineTransform.swift
+++ b/TestFoundation/TestNSAffineTransform.swift
@@ -40,6 +40,8 @@ class TestNSAffineTransform : XCTestCase {
             ("test_IdentityTransformation", test_IdentityTransformation),
             ("test_Translation", test_Translation),
             ("test_TranslationComposed", test_TranslationComposed),
+            ("test_AppendTransform", test_AppendTransform),
+            ("test_PrependTransform", test_PrependTransform),
         ]
     }
     
@@ -237,6 +239,42 @@ class TestNSAffineTransform : XCTestCase {
 
         checkPointTransformation(xyTimes5XPlus3, point: NSMakePoint(CGFloat(1.0), CGFloat(2.0)),
                                          expectedPoint: NSMakePoint(CGFloat(20.0), CGFloat(10.0)))
+    }
+    
+    func test_AppendTransform() {
+        let point = NSPoint(x: CGFloat(10.0), y: CGFloat(10.0))
+        
+        let identityTransform = NSAffineTransform()
+        identityTransform.appendTransform(identityTransform)
+        checkPointTransformation(identityTransform, point: point, expectedPoint: point)
+        
+        let translate = NSAffineTransform()
+        translate.translateXBy(CGFloat(10.0), yBy: CGFloat())
+        
+        let scale = NSAffineTransform()
+        scale.scaleBy(CGFloat(2.0))
+        
+        let translateThenScale = NSAffineTransform(transform: translate)
+        translateThenScale.appendTransform(scale)
+        checkPointTransformation(translateThenScale, point: point, expectedPoint: NSPoint(x: CGFloat(40.0), y: CGFloat(20.0)))
+    }
+    
+    func test_PrependTransform() {
+        let point = NSPoint(x: CGFloat(10.0), y: CGFloat(10.0))
+        
+        let identityTransform = NSAffineTransform()
+        identityTransform.prependTransform(identityTransform)
+        checkPointTransformation(identityTransform, point: point, expectedPoint: point)
+        
+        let translate = NSAffineTransform()
+        translate.translateXBy(CGFloat(10.0), yBy: CGFloat())
+        
+        let scale = NSAffineTransform()
+        scale.scaleBy(CGFloat(2.0))
+        
+        let scaleThenTranslate = NSAffineTransform(transform: translate)
+        scaleThenTranslate.prependTransform(scale)
+        checkPointTransformation(scaleThenTranslate, point: point, expectedPoint: NSPoint(x: CGFloat(30.0), y: CGFloat(20.0)))
     }
 }
 

--- a/TestFoundation/TestNSAffineTransform.swift
+++ b/TestFoundation/TestNSAffineTransform.swift
@@ -46,14 +46,18 @@ class TestNSAffineTransform : XCTestCase {
     
     func checkPointTransformation(transform: NSAffineTransform, point: NSPoint, expectedPoint: NSPoint, _ message: String = "", _ file: StaticString = __FILE__, _ line: UInt = __LINE__) {
         let newPoint = transform.transformPoint(point)
-        XCTAssertEqualWithAccuracy(Double(newPoint.x), Double(expectedPoint.x), accuracy: accuracyThreshold, "x: \(message)", file: file, line: line)
-        XCTAssertEqualWithAccuracy(Double(newPoint.y), Double(expectedPoint.y), accuracy: accuracyThreshold, "y: \(message)", file: file, line: line)
+        XCTAssertEqualWithAccuracy(Double(newPoint.x), Double(expectedPoint.x), accuracy: accuracyThreshold, file: file, line: line,
+                                   "x (expected: \(expectedPoint.x), was: \(newPoint.x)): \(message)")
+        XCTAssertEqualWithAccuracy(Double(newPoint.y), Double(expectedPoint.y), accuracy: accuracyThreshold, file: file, line: line,
+                                   "y (expected: \(expectedPoint.y), was: \(newPoint.y)): \(message)")
     }
     
     func checkSizeTransformation(transform: NSAffineTransform, size: NSSize, expectedSize: NSSize, _ message: String = "", _ file: StaticString = __FILE__, _ line: UInt = __LINE__) {
         let newSize = transform.transformSize(size)
-        XCTAssertEqualWithAccuracy(Double(newSize.width), Double(expectedSize.width), accuracy: accuracyThreshold, "width: \(message)", file: file, line: line)
-        XCTAssertEqualWithAccuracy(Double(newSize.height), Double(expectedSize.height), accuracy: accuracyThreshold, "height: \(message)", file: file, line: line)
+        XCTAssertEqualWithAccuracy(Double(newSize.width), Double(expectedSize.width), accuracy: accuracyThreshold, file: file, line: line,
+                                   "width (expected: \(expectedSize.width), was: \(newSize.width)): \(message)")
+        XCTAssertEqualWithAccuracy(Double(newSize.height), Double(expectedSize.height), accuracy: accuracyThreshold, file: file, line: line,
+                                   "height (expected: \(expectedSize.height), was: \(newSize.height)): \(message)")
     }
 
     func test_BasicConstruction() {

--- a/TestFoundation/TestNSAffineTransform.swift
+++ b/TestFoundation/TestNSAffineTransform.swift
@@ -39,7 +39,6 @@ class TestNSAffineTransform : XCTestCase {
             ("test_Inversion", test_Inversion),
             ("test_IdentityTransformation", test_IdentityTransformation),
             ("test_Translation", test_Translation),
-            ("test_Translation2", test_Translation2),
             ("test_TranslationComposed", test_TranslationComposed),
         ]
     }
@@ -197,14 +196,6 @@ class TestNSAffineTransform : XCTestCase {
         identityTransform.appendTransform(translate)
         
         checkPointTransformation(identityTransform, point: point, expectedPoint: point)
-    }
-
-    func test_Translation2() {
-        let xPlus2 = NSAffineTransform()
-        xPlus2.translateXBy(CGFloat(2.0), yBy: CGFloat())
-
-        checkPointTransformation(xPlus2, point: NSMakePoint(CGFloat(22.0), CGFloat(10.0)),
-                                 expectedPoint: NSMakePoint(CGFloat(24.0), CGFloat(10.0)))
     }
 
     func test_TranslationComposed() {

--- a/TestFoundation/TestNSAffineTransform.swift
+++ b/TestFoundation/TestNSAffineTransform.swift
@@ -147,6 +147,14 @@ class TestNSAffineTransform : XCTestCase {
         tenEighty.rotateByDegrees(CGFloat(1080.0))
         checkPointTransformation(tenEighty, point: point, expectedPoint: point)
         
+        let rotateCounterClockwise = NSAffineTransform()
+        rotateCounterClockwise.rotateByDegrees(CGFloat(90.0))
+        checkPointTransformation(rotateCounterClockwise, point: point, expectedPoint: NSPoint(x: CGFloat(-10.0), y: CGFloat(10.0)))
+        
+        let rotateClockwise = NSAffineTransform()
+        rotateClockwise.rotateByDegrees(CGFloat(-90.0))
+        checkPointTransformation(rotateClockwise, point: point, expectedPoint: NSPoint(x: CGFloat(10.0), y: CGFloat(-10.0)))
+        
         let reflectAboutOrigin = NSAffineTransform()
         reflectAboutOrigin.rotateByDegrees(CGFloat(180.0))
         checkPointTransformation(reflectAboutOrigin, point: point, expectedPoint: NSPoint(x: CGFloat(-10.0), y: CGFloat(-10.0)))
@@ -162,6 +170,14 @@ class TestNSAffineTransform : XCTestCase {
         let tenEighty = NSAffineTransform()
         tenEighty.rotateByRadians(CGFloat(6 * M_PI))
         checkPointTransformation(tenEighty, point: point, expectedPoint: point)
+        
+        let rotateCounterClockwise = NSAffineTransform()
+        rotateCounterClockwise.rotateByRadians(CGFloat(M_PI_2))
+        checkPointTransformation(rotateCounterClockwise, point: point, expectedPoint: NSPoint(x: CGFloat(-10.0), y: CGFloat(10.0)))
+        
+        let rotateClockwise = NSAffineTransform()
+        rotateClockwise.rotateByRadians(CGFloat(-M_PI_2))
+        checkPointTransformation(rotateClockwise, point: point, expectedPoint: NSPoint(x: CGFloat(10.0), y: CGFloat(-10.0)))
         
         let reflectAboutOrigin = NSAffineTransform()
         reflectAboutOrigin.rotateByRadians(CGFloat(M_PI))


### PR DESCRIPTION
Hi,

I just noticed that my implementation of `NSAffineTransform` (added in #93) was applying transformations in the opposite order than Darwin's.
My previous implementation assumed that the properties of `NSAffineTransform` represent a matrix that looks like this
```
[ m11  m12  tX ]
[ m21  m22  tY ]
[  0    0    1 ]
```
and applied transformations by `T * p` where `T` is the transformation matrix and `p` a column vector.

As it turns out, however, the matrix rather looks like that
```
[ m11  m12  0 ]
[ m21  m22  0 ]
[  tX   tY  1 ]
```
and transformation are applied by `p' * T` where `p'` is a row vector.

This has direct influence on the order of application, because `T * p = S * R * p` would apply `R` before `S`, whereas `p' * T = p' * S * R` would apply `S` before `R`.

I've also added tests for…
- `appendTransform` and `prependTransform`
- the direction of rotation (that was basically just a lucky guess)
- composed transformations

I apologise for that!