### PR TITLE
Update constants

### DIFF
--- a/CoreFoundation/PlugIn.subproj/CFBundle_Binary.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Binary.c
@@ -32,9 +32,6 @@
 #endif /* BINARY_SUPPORT_DYLD */
 
 #if defined(BINARY_SUPPORT_DLFCN)
-#if DEPLOYMENT_TARGET_LINUX
-#define __USE_GNU 1
-#endif
 #include <dlfcn.h>
 #ifndef RTLD_FIRST
 #define RTLD_FIRST 0

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 		5BF7AEC11BCD51F9008F214A /* NSValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4C1BCC5DCB00ED97BB /* NSValue.swift */; };
 		5E5835F41C20C9B500C81317 /* TestNSThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5835F31C20C9B500C81317 /* TestNSThread.swift */; };
 		612952F91C1B235900BE0FD9 /* TestNSNull.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612952F81C1B235900BE0FD9 /* TestNSNull.swift */; };
+		61A395FA1C2484490029B337 /* TestNSLocale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A395F91C2484490029B337 /* TestNSLocale.swift */; };
 		61D6C9EF1C1DFE9500DEF583 /* TestNSTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D6C9EE1C1DFE9500DEF583 /* TestNSTimer.swift */; };
 		61E0117C1C1B554D000037DD /* TestNSRunLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E0117B1C1B554D000037DD /* TestNSRunLoop.swift */; };
 		61E0117D1C1B5590000037DD /* NSRunLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B761BD15DFF00C49C64 /* NSRunLoop.swift */; };
@@ -551,6 +552,7 @@
 		5E5835F31C20C9B500C81317 /* TestNSThread.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSThread.swift; sourceTree = "<group>"; };
 		5EB6A15C1C188FC40037DCB8 /* TestNSJSONSerialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSJSONSerialization.swift; sourceTree = "<group>"; };
 		612952F81C1B235900BE0FD9 /* TestNSNull.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSNull.swift; sourceTree = "<group>"; };
+		61A395F91C2484490029B337 /* TestNSLocale.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSLocale.swift; sourceTree = "<group>"; };
 		61D6C9EE1C1DFE9500DEF583 /* TestNSTimer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSTimer.swift; sourceTree = "<group>"; };
 		61E0117B1C1B554D000037DD /* TestNSRunLoop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSRunLoop.swift; sourceTree = "<group>"; };
 		61F8AE7C1C180FC600FB62F0 /* TestNSNotificationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSNotificationCenter.swift; sourceTree = "<group>"; };
@@ -1060,11 +1062,8 @@
 				C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */,
 				EA66F63C1BF1619600136161 /* TestNSArray.swift */,
 				6E203B8C1C1303BB003B2576 /* TestNSBundle.swift */,
-				A5A34B551C18C85D00FD972B /* TestNSByteCountFormatter.swift */,
 				52829AD61C160D64003BC4EF /* TestNSCalendar.swift */,
 				5BC1D8BC1BF3ADFE009D3973 /* TestNSCharacterSet.swift */,
-				DCDBB8321C1768AC00313299 /* TestNSData.swift */,
-				22B9C1E01C165D7A00DECFF9 /* TestNSDate.swift */,
 				EA66F63D1BF1619600136161 /* TestNSDictionary.swift */,
 				525AECEB1BF2C96400D15BB0 /* TestNSFileManager.swift */,
 				88D28DE61C13AE9000494606 /* TestNSGeometry.swift */,
@@ -1072,8 +1071,8 @@
 				4AE109261C17CCBF007367B5 /* TestNSIndexPath.swift */,
 				EA66F63E1BF1619600136161 /* TestNSIndexSet.swift */,
 				5EB6A15C1C188FC40037DCB8 /* TestNSJSONSerialization.swift */,
+				61A395F91C2484490029B337 /* TestNSLocale.swift */,
 				61F8AE7C1C180FC600FB62F0 /* TestNSNotificationCenter.swift */,
-				612952F81C1B235900BE0FD9 /* TestNSNull.swift */,
 				EA66F63F1BF1619600136161 /* TestNSNumber.swift */,
 				4DC1D07F1C12EEEF00B5948A /* TestNSPipe.swift */,
 				400E22641C1A4E58007C5933 /* TestNSProcessInfo.swift */,
@@ -1084,9 +1083,6 @@
 				EA66F6411BF1619600136161 /* TestNSSet.swift */,
 				EA66F6421BF1619600136161 /* TestNSString.swift */,
 				5E5835F31C20C9B500C81317 /* TestNSThread.swift */,
-				C2A9D75B1C15C08B00993803 /* TestNSUUID.swift */,
-				EA66F6431BF1619600136161 /* TestNSURL.swift */,
-				5B40F9F11C125187000E72E3 /* TestNSXMLParser.swift */,
 				22B9C1E01C165D7A00DECFF9 /* TestNSDate.swift */,
 				DCDBB8321C1768AC00313299 /* TestNSData.swift */,
 				61D6C9EE1C1DFE9500DEF583 /* TestNSTimer.swift */,
@@ -1824,10 +1820,11 @@
 				7A7D6FBB1C16439400957E2E /* TestNSURLResponse.swift in Sources */,
 				61F8AE7D1C180FC600FB62F0 /* TestNSNotificationCenter.swift in Sources */,
 				5B40F9F21C125187000E72E3 /* TestNSXMLParser.swift in Sources */,
+				61A395FA1C2484490029B337 /* TestNSLocale.swift in Sources */,
 				6E203B8D1C1303BB003B2576 /* TestNSBundle.swift in Sources */,
 				88D28DE71C13AE9000494606 /* TestNSGeometry.swift in Sources */,
 				EA66F64C1BF1619600136161 /* TestNSDictionary.swift in Sources */,
-				ED58F76F1C134B3A00E6A5BE /* TestNSJSONSerialization.swift in Sources */,
+				ED58F76F1C134B3A00E6A5BE /* (null) in Sources */,
 				AA664D4F1C1B03CA00C22186 /* TestNSNumberFormatter.swift in Sources */,
 				EA66F6581BF1619600136161 /* TestNSURL.swift in Sources */,
 				61D6C9EF1C1DFE9500DEF583 /* TestNSTimer.swift in Sources */,

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -168,7 +168,7 @@ public enum NSLocaleLanguageDirection : UInt {
     case BottomToTop
 }
 
-public let NSCurrentLocaleDidChangeNotification: String = "" // NSUnimplemented
+public let NSCurrentLocaleDidChangeNotification: String = "kCFLocaleCurrentLocaleDidChangeNotification"
 
 public let NSLocaleIdentifier: String = "kCFLocaleIdentifierKey"
 public let NSLocaleLanguageCode: String = "kCFLocaleLanguageCodeKey"
@@ -184,11 +184,11 @@ public let NSLocaleDecimalSeparator: String = "kCFLocaleDecimalSeparatorKey"
 public let NSLocaleGroupingSeparator: String = "kCFLocaleGroupingSeparatorKey"
 public let NSLocaleCurrencySymbol: String = "kCFLocaleCurrencySymbolKey"
 public let NSLocaleCurrencyCode: String = "currency"
-public let NSLocaleCollatorIdentifier: String = "" // NSUnimplemented // NSString
-public let NSLocaleQuotationBeginDelimiterKey: String = "" // NSUnimplemented // NSString
-public let NSLocaleQuotationEndDelimiterKey: String = "" // NSUnimplemented // NSString
-public let NSLocaleAlternateQuotationBeginDelimiterKey: String = "" // NSUnimplemented // NSString
-public let NSLocaleAlternateQuotationEndDelimiterKey: String = "" // NSUnimplemented // NSString
+public let NSLocaleCollatorIdentifier: String = "kCFLocaleCollatorIdentifierKey"
+public let NSLocaleQuotationBeginDelimiterKey: String = "kCFLocaleQuotationBeginDelimiterKey"
+public let NSLocaleQuotationEndDelimiterKey: String = "kCFLocaleQuotationEndDelimiterKey"
+public let NSLocaleAlternateQuotationBeginDelimiterKey: String = "kCFLocaleAlternateQuotationBeginDelimiterKey"
+public let NSLocaleAlternateQuotationEndDelimiterKey: String = "kCFLocaleAlternateQuotationEndDelimiterKey"
 
 extension CFLocaleRef : _NSBridgable {
     typealias NSType = NSLocale

--- a/Foundation/NSRunLoop.swift
+++ b/Foundation/NSRunLoop.swift
@@ -9,8 +9,8 @@
 
 import CoreFoundation
 
-public let NSDefaultRunLoopMode: String = kCFRunLoopDefaultMode._swiftObject
-public let NSRunLoopCommonModes: String = kCFRunLoopCommonModes._swiftObject
+public let NSDefaultRunLoopMode: String = "kCFRunLoopDefaultMode"
+public let NSRunLoopCommonModes: String = "kCFRunLoopCommonModes"
 
 internal func _NSRunLoopNew(cf: CFRunLoopRef) -> Unmanaged<AnyObject> {
     let rl = Unmanaged<NSRunLoop>.passRetained(NSRunLoop(cfObject: cf))
@@ -77,7 +77,7 @@ extension NSRunLoop {
     public func runMode(mode: String, beforeDate limitDate: NSDate) -> Bool {
         let runloopResult = CFRunLoopRunInMode(mode._cfObject, limitDate.timeIntervalSinceNow, false)
 #if os(Linux)
-        return runloopResult == 2 || runloopResult == 3
+        return runloopResult == Int32(kCFRunLoopRunHandledSource) || runloopResult == Int32(kCFRunLoopRunTimedOut)
 #else
         return runloopResult == .HandledSource || runloopResult == .TimedOut
 #endif

--- a/TestFoundation/TestNSLocale.swift
+++ b/TestFoundation/TestNSLocale.swift
@@ -1,0 +1,88 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+class TestNSLocale : XCTestCase {
+    var allTests : [(String, () -> Void)] {
+        return [
+            ("test_constants", test_constants),
+        ]
+    }
+    
+    func test_constants() {
+        XCTAssertEqual(NSCurrentLocaleDidChangeNotification, "kCFLocaleCurrentLocaleDidChangeNotification",
+                        "\(NSCurrentLocaleDidChangeNotification) is not equal to kCFLocaleCurrentLocaleDidChangeNotification")
+        
+        XCTAssertEqual(NSLocaleIdentifier, "kCFLocaleIdentifierKey",
+                        "\(NSLocaleIdentifier) is not equal to kCFLocaleIdentifierKey")
+
+        XCTAssertEqual(NSLocaleLanguageCode, "kCFLocaleLanguageCodeKey",
+                        "\(NSLocaleLanguageCode) is not equal to kCFLocaleLanguageCodeKey")
+
+        XCTAssertEqual(NSLocaleCountryCode, "kCFLocaleCountryCodeKey", 
+                        "\(NSLocaleCountryCode) is not equal to kCFLocaleCountryCodeKey")
+
+        XCTAssertEqual(NSLocaleScriptCode, "kCFLocaleScriptCodeKey",
+                        "\(NSLocaleScriptCode) is not equal to kCFLocaleScriptCodeKey")
+
+        XCTAssertEqual(NSLocaleVariantCode, "kCFLocaleVariantCodeKey", 
+                        "\(NSLocaleVariantCode) is not equal to kCFLocaleVariantCodeKey")
+
+        XCTAssertEqual(NSLocaleExemplarCharacterSet, "kCFLocaleExemplarCharacterSetKey",
+                        "\(NSLocaleExemplarCharacterSet) is not equal to kCFLocaleExemplarCharacterSetKey")
+
+        XCTAssertEqual(NSLocaleCalendar, "kCFLocaleCalendarKey",
+                        "\(NSLocaleCalendar) is not equal to kCFLocaleCalendarKey")
+
+        XCTAssertEqual(NSLocaleCollationIdentifier, "collation",
+                        "\(NSLocaleCollationIdentifier) is not equal to collation")
+
+        XCTAssertEqual(NSLocaleUsesMetricSystem, "kCFLocaleUsesMetricSystemKey",
+                        "\(NSLocaleUsesMetricSystem) is not equal to kCFLocaleUsesMetricSystemKey")
+
+        XCTAssertEqual(NSLocaleMeasurementSystem, "kCFLocaleMeasurementSystemKey",
+                        "\(NSLocaleMeasurementSystem) is not equal to kCFLocaleMeasurementSystemKey")
+
+        XCTAssertEqual(NSLocaleDecimalSeparator, "kCFLocaleDecimalSeparatorKey",
+                        "\(NSLocaleDecimalSeparator) is not equal to kCFLocaleDecimalSeparatorKey")
+
+        XCTAssertEqual(NSLocaleGroupingSeparator, "kCFLocaleGroupingSeparatorKey",
+                        "\(NSLocaleGroupingSeparator) is not equal to kCFLocaleGroupingSeparatorKey")
+
+        XCTAssertEqual(NSLocaleCurrencySymbol, "kCFLocaleCurrencySymbolKey",
+                        "\(NSLocaleCurrencySymbol) is not equal to kCFLocaleCurrencySymbolKey")
+
+        XCTAssertEqual(NSLocaleCurrencyCode, "currency",
+                        "\(NSLocaleCurrencyCode) is not equal to currency")
+
+        XCTAssertEqual(NSLocaleCollatorIdentifier, "kCFLocaleCollatorIdentifierKey",
+                        "\(NSLocaleCollatorIdentifier) is not equal to kCFLocaleCollatorIdentifierKey")
+
+        XCTAssertEqual(NSLocaleQuotationBeginDelimiterKey, "kCFLocaleQuotationBeginDelimiterKey",
+                        "\(NSLocaleQuotationBeginDelimiterKey) is not equal to kCFLocaleQuotationBeginDelimiterKey")
+
+        XCTAssertEqual(NSLocaleQuotationEndDelimiterKey, "kCFLocaleQuotationEndDelimiterKey",
+                        "\(NSLocaleQuotationEndDelimiterKey) is not equal to kCFLocaleQuotationEndDelimiterKey")
+
+        XCTAssertEqual(NSLocaleAlternateQuotationBeginDelimiterKey, "kCFLocaleAlternateQuotationBeginDelimiterKey",
+                        "\(NSLocaleAlternateQuotationBeginDelimiterKey) is not equal to kCFLocaleAlternateQuotationBeginDelimiterKey")
+
+        XCTAssertEqual(NSLocaleAlternateQuotationEndDelimiterKey, "kCFLocaleAlternateQuotationEndDelimiterKey",
+                        "\(NSLocaleAlternateQuotationEndDelimiterKey) is not equal to kCFLocaleAlternateQuotationEndDelimiterKey")
+
+    }
+
+}

--- a/TestFoundation/TestNSRunLoop.swift
+++ b/TestFoundation/TestNSRunLoop.swift
@@ -7,7 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
 #if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
     import Foundation
     import XCTest
@@ -20,10 +19,19 @@
 class TestNSRunLoop : XCTestCase {
     var allTests : [(String, () -> ())] {
         return [
+            ("test_constants", test_constants),
             ("test_runLoopInit", test_runLoopInit),
             ("test_runLoopRunMode", test_runLoopRunMode),
             ("test_runLoopLimitDate", test_runLoopLimitDate),
         ]
+    }
+    
+    func test_constants() {
+        XCTAssertEqual(NSRunLoopCommonModes, "kCFRunLoopCommonModes",
+                       "\(NSRunLoopCommonModes) is not equal to kCFRunLoopCommonModes")
+        
+        XCTAssertEqual(NSDefaultRunLoopMode, "kCFRunLoopDefaultMode",
+                       "\(NSDefaultRunLoopMode) is not equal to kCFRunLoopDefaultMode")
     }
     
     func test_runLoopInit() {

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -36,6 +36,7 @@ XCTMain([
     TestNSIndexPath(),
     TestNSIndexSet(),
     TestNSJSONSerialization(),
+    TestNSLocale(),
     TestNSNotificationCenter(),
     TestNSNumber(),
     TestNSNumberFormatter(),


### PR DESCRIPTION
As we're now using `_GNU_SOURCE` in the compiler flags for Linux, it's ok to remove `__USE_GNU` from `CFBundle_Binary.c`

Also, I replaced string constants with CF ones, so they could be defined in one place. There are still similar (`let NSConst: String = "kCFConst"`) defines in `NSStream`, but `CFStream` is not compatible with linux yet.