### PR TITLE
Fixes a shadowed variable in the system time zone initializer.

### DIFF
--- a/CoreFoundation/NumberDate.subproj/CFTimeZone.c
+++ b/CoreFoundation/NumberDate.subproj/CFTimeZone.c
@@ -753,7 +753,6 @@ static CFTimeZoneRef __CFTimeZoneCreateSystem(void) {
     }
     ret = readlink(TZZONELINK, linkbuf, sizeof(linkbuf));
     if (0 < ret) {
-        CFStringRef name;
         linkbuf[ret] = '\0';
         if (strncmp(linkbuf, TZZONEINFO, sizeof(TZZONEINFO) - 1) == 0) {
             name = CFStringCreateWithBytes(kCFAllocatorSystemDefault, (uint8_t *)linkbuf + sizeof(TZZONEINFO) - 1, strlen(linkbuf) - sizeof(TZZONEINFO) + 1, kCFStringEncodingUTF8, false);

--- a/TestFoundation/TestNSTimeZone.swift
+++ b/TestFoundation/TestNSTimeZone.swift
@@ -12,9 +12,11 @@
 #if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
     import Foundation
     import XCTest
+    import Glibc
 #else
     import SwiftFoundation
     import SwiftXCTest
+    import Darwin
 #endif
 
 
@@ -25,6 +27,7 @@ class TestNSTimeZone: XCTestCase {
         return [
             ("test_abbreviation", test_abbreviation),
             ("test_initializingTimeZoneWithOffset", test_initializingTimeZoneWithOffset),
+            ("test_systemTimeZoneUsesSystemTime", test_systemTimeZoneUsesSystemTime),
         ]
     }
 
@@ -38,5 +41,15 @@ class TestNSTimeZone: XCTestCase {
         XCTAssertNotNil(tz)
         let seconds = tz?.secondsFromGMTForDate(NSDate())
         XCTAssertEqual(seconds, -14400)
+    }
+    
+    func test_systemTimeZoneUsesSystemTime() {
+        tzset();
+        var t = time(nil)
+        var lt = tm()
+        localtime_r(&t, &lt)
+        let zoneName = NSTimeZone.systemTimeZone().abbreviation ?? "Invalid Abbreviation"
+        let expectedName = NSString(CString: lt.tm_zone, encoding: NSASCIIStringEncoding)?.bridge() ?? "Invalid Zone"
+        XCTAssertEqual(zoneName, expectedName)
     }
 }


### PR DESCRIPTION
The shadowed variable that's being removed in this PR causes the name to fall out of scope as soon as it exits the "if (0 < ret)" block, and the outermost "name" field is left null. This causes the systemTimeZone to always report as GMT.

I'm not sure if the mechanism I'm using to test this is the best way to go. Calling into the C time functions seems like a hack, and something that might get broken by subtle changes to system configurations. It works on both my Mac and Linux installs, and it correctly gives an error when the change to CFTimeZone.c is removed.