### PR TITLE
Fix `NSString.stringByTrimmingCharactersInSet` behavior

### DIFF
--- a/Foundation/NSScanner.swift
+++ b/Foundation/NSScanner.swift
@@ -182,7 +182,7 @@ internal struct _NSStringBuffer {
     
     var location: Int {
         get {
-            return _stringLoc
+            return _stringLoc + bufferLoc - 1
         }
         mutating set {
             if newValue < _stringLoc || newValue >= _stringLoc + bufferLen {

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -45,6 +45,7 @@ class TestNSString : XCTestCase {
             ("test_rangeOfCharacterFromSet", test_rangeOfCharacterFromSet ),
             ("test_CFStringCreateMutableCopy", test_CFStringCreateMutableCopy),
             ("test_swiftStringUTF16", test_swiftStringUTF16),
+            ("test_stringByTrimmingCharactersInSet", test_stringByTrimmingCharactersInSet),
         ]
     }
 
@@ -335,5 +336,11 @@ class TestNSString : XCTestCase {
         let newString = unsafeBitCast(newCFString, NSString.self)
         
         XCTAssertTrue(newString.isEqualToString(testString))
+    }
+
+    func test_stringByTrimmingCharactersInSet() {
+        let characterSet = NSCharacterSet.whitespaceCharacterSet()
+        let string: NSString = " abc   "
+        XCTAssertEqual(string.stringByTrimmingCharactersInSet(characterSet), "abc")
     }
 }


### PR DESCRIPTION
Previously it would always return just the first character in the string due
to broken location reporting in `_NSStringBuffer`