### PR TITLE
Sets the special flags in the CFType info on NSString to properly indicate its storage type.

### DIFF
--- a/CoreFoundation/String.subproj/CFString.c
+++ b/CoreFoundation/String.subproj/CFString.c
@@ -6041,7 +6041,7 @@ static void __CFStringAppendFormatCore(CFMutableStringRef outputString, CFString
 
 
     formatLen = CFStringGetLength(formatString);
-    if (!CF_IS_OBJC(__kCFStringTypeID, formatString)) {
+    if (!CF_IS_OBJC(__kCFStringTypeID, formatString) && !CF_IS_SWIFT(CFStringGetTypeID(), formatString)) {
         __CFAssertIsString(formatString);
         if (!__CFStrIsUnicode(formatString)) {
             cformat = (const uint8_t *)__CFStrContents(formatString);

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -46,6 +46,7 @@ class TestNSString : XCTestCase {
             ("test_CFStringCreateMutableCopy", test_CFStringCreateMutableCopy),
             ("test_swiftStringUTF16", test_swiftStringUTF16),
             ("test_stringByTrimmingCharactersInSet", test_stringByTrimmingCharactersInSet),
+            ("test_initializeWithFormat", test_initializeWithFormat),
         ]
     }
 
@@ -342,5 +343,14 @@ class TestNSString : XCTestCase {
         let characterSet = NSCharacterSet.whitespaceCharacterSet()
         let string: NSString = " abc   "
         XCTAssertEqual(string.stringByTrimmingCharactersInSet(characterSet), "abc")
+    }
+    
+    func test_initializeWithFormat() {
+        let argument: [CVarArgType] = [42, 42.0]
+        withVaList(argument) {
+            pointer in
+            let string = NSString(format: "Value is %d (%.1f)", arguments: pointer)
+            XCTAssertEqual(string, "Value is 42 (42.0)")
+        }
     }
 }


### PR DESCRIPTION
Currently the CFInfo fields on NSString are being set to 0x80, 0x07, 0x00, 0x00. This means that the flag for __kCFContentsMask is being set to __kCFHasInlineContents, which is not an accurate description of how the data is laid out in an NSString that's created from a  Swift String. This in turn causes the result of `NSString.init(format:arguments:)` to be empty, since it's going through a CFString method that can't properly read the format string.