### PR TITLE
Fixes NSString.stringByDeletingLastPathComponent.

### DIFF
--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -237,14 +237,28 @@ public extension NSString {
         if fixedSelf == "/" {
             return fixedSelf
         }
-        if fixedSelf.length <= 1 {
-            return ""
-        }
         
-        return String(fixedSelf.characters.prefixUpTo(fixedSelf._startOfLastPathComponent))
+        switch fixedSelf._startOfLastPathComponent {
+        
+        // relative path, single component
+        case fixedSelf.startIndex:
+            return ""
+        
+        // absolute path, single component
+        case fixedSelf.startIndex.successor():
+            return "/"
+        
+        // all common cases
+        case let startOfLast:
+            return String(fixedSelf.characters.prefixUpTo(startOfLast.predecessor()))
+        }
     }
     
     internal func _stringByFixingSlashes(compress compress : Bool = true, stripTrailing: Bool = true) -> String {
+        if _swiftObject == "/" {
+            return _swiftObject
+        }
+        
         var result = _swiftObject
         if compress {
             result.withMutableCharacters { characterView in

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -48,7 +48,8 @@ class TestNSString : XCTestCase {
             ("test_swiftStringUTF16", test_swiftStringUTF16),
             ("test_completePathIntoString", test_completePathIntoString),
             ("test_stringByTrimmingCharactersInSet", test_stringByTrimmingCharactersInSet),
-            ("test_initializeWithFormat", test_initializeWithFormat)
+            ("test_initializeWithFormat", test_initializeWithFormat),
+            ("test_stringByDeletingLastPathComponent", test_stringByDeletingLastPathComponent)
         ]
     }
 
@@ -512,6 +513,50 @@ class TestNSString : XCTestCase {
             pointer in
             let string = NSString(format: "Value is %d (%.1f)", arguments: pointer)
             XCTAssertEqual(string, "Value is 42 (42.0)")
+        }
+    }
+    
+    func test_stringByDeletingLastPathComponent() {
+        do {
+            let path: NSString = "/tmp/scratch.tiff"
+            let result = path.stringByDeletingLastPathComponent
+            XCTAssertEqual(result, "/tmp")
+        }
+        
+        do {
+            let path: NSString = "/tmp/lock/"
+            let result = path.stringByDeletingLastPathComponent
+            XCTAssertEqual(result, "/tmp")
+        }
+        
+        do {
+            let path: NSString = "/tmp/"
+            let result = path.stringByDeletingLastPathComponent
+            XCTAssertEqual(result, "/")
+        }
+        
+        do {
+            let path: NSString = "/tmp"
+            let result = path.stringByDeletingLastPathComponent
+            XCTAssertEqual(result, "/")
+        }
+        
+        do {
+            let path: NSString = "/"
+            let result = path.stringByDeletingLastPathComponent
+            XCTAssertEqual(result, "/")
+        }
+        
+        do {
+            let path: NSString = "scratch.tiff"
+            let result = path.stringByDeletingLastPathComponent
+            XCTAssertEqual(result, "")
+        }
+        
+        do {
+            let path: NSString = "foo/bar"
+            let result = path.stringByDeletingLastPathComponent
+            XCTAssertEqual(result, "foo", "Relative path stays relative.")
         }
     }
 }


### PR DESCRIPTION
It deletes final path separator now. If the receiver represents the root path it is returned unaltered.