### PR TITLE
Speed up JSON Parsing

### DIFF
--- a/Docs/Status.md
+++ b/Docs/Status.md
@@ -48,7 +48,7 @@ As Foundation is a work in progress, not all methods and functionality are prese
 
     * `NSPropertyList` is mostly implemented.
     * `NSCoder` and `NSKeyedArchiver` are mostly not yet implemented (a few funnel methods are implemented).
-    * `NSJSONSerialization` is not yet implemented.
+    * `NSJSONSerialization` is partly implemented (serialization is not yet implemented)
 
 
 * **XML**: A group of classes for parsing and representing XML documents and elements.

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -251,12 +251,12 @@ private struct JSONDeserializer {
     }
     
     struct StructureScalar {
-        static let BeginArray     = UnicodeScalar(0x5B) // [ left square bracket
-        static let EndArray       = UnicodeScalar(0x5D) // ] right square bracket
-        static let BeginObject    = UnicodeScalar(0x7B) // { left curly bracket
-        static let EndObject      = UnicodeScalar(0x7D) // } right curly bracket
-        static let NameSeparator  = UnicodeScalar(0x3A) // : colon
-        static let ValueSeparator = UnicodeScalar(0x2C) // , comma
+        static let BeginArray: UnicodeScalar     = "["
+        static let EndArray: UnicodeScalar       = "]"
+        static let BeginObject: UnicodeScalar    = "{"
+        static let EndObject: UnicodeScalar      = "}"
+        static let NameSeparator: UnicodeScalar  = ":"
+        static let ValueSeparator: UnicodeScalar = ","
     }
     
     static func consumeStructure(scalar: UnicodeScalar, input: UnicodeParser) throws -> UnicodeParser? {
@@ -307,8 +307,8 @@ private struct JSONDeserializer {
 
     //MARK: - String Parsing
     struct StringScalar{
-        static let QuotationMark = UnicodeScalar(0x22) // "
-        static let Escape        = UnicodeScalar(0x5C) // \
+        static let QuotationMark: UnicodeScalar = "\""
+        static let Escape: UnicodeScalar        = "\\"
     }
     
     static func parseString(input: UnicodeParser) throws -> (String, UnicodeParser)? {
@@ -353,23 +353,19 @@ private struct JSONDeserializer {
             ])
         }
         switch scalar {
-        case UnicodeScalar(0x22):                   // "    quotation mark  U+0022
-            fallthrough
-        case UnicodeScalar(0x5C):                   // \    reverse solidus U+005F
-            fallthrough
-        case UnicodeScalar(0x2F):                   // /    solidus         U+002F
+        case "\"", "\\", "/":
             return (scalar, parser)
-        case UnicodeScalar(0x62):                   // b    backspace       U+0008
+        case "b":
             return (UnicodeScalar(0x08), parser)
-        case UnicodeScalar(0x66):                   // f    form feed       U+000C
+        case "f":
             return (UnicodeScalar(0x0C), parser)
-        case UnicodeScalar(0x6E):                   // n    line feed       U+000A
+        case "n":
             return (UnicodeScalar(0x0A), parser)
-        case UnicodeScalar(0x72):                   // r    carriage return U+000D
+        case "r":
             return (UnicodeScalar(0x0D), parser)
-        case UnicodeScalar(0x74):                   // t    tab             U+0009
+        case "t":
             return (UnicodeScalar(0x09), parser)
-        case UnicodeScalar(0x75):                   // u    unicode
+        case "u":
             return try parseUnicodeSequence(parser)
         default:
             return nil

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -107,8 +107,7 @@ public class NSJSONSerialization : NSObject {
                 "NSDebugDescription" : "Unable to convert data to a string using the detected encoding. The data may be corrupt."
             ])
         }
-        let result = try JSONObjectWithString(string._swiftObject)
-        return result
+        return try JSONObjectWithString(string._swiftObject)
     }
     
     /* Write JSON data into a stream. The stream should be opened and configured. The return value is the number of bytes written to the stream, or 0 on error. All other behavior of this method is the same as the dataWithJSONObject:options:error: method.

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -54,7 +54,6 @@ public class NSJSONSerialization : NSObject {
             // object is NSNumber and is not NaN or infinity
             if let number = obj as? NSNumber {
                 let invalid = number.doubleValue.isInfinite || number.doubleValue.isNaN
-                    || number.floatValue.isInfinite || number.floatValue.isNaN
                 return !invalid
             }
 

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -420,7 +420,23 @@ private struct JSONDeserializer {
     }
     
     //MARK: - Number parsing
-    static let numberScalars = ".+-0123456789eE".unicodeScalars
+    static let numberScalars = [
+        UnicodeScalar(0x2E), // .
+        UnicodeScalar(0x30), // 0
+        UnicodeScalar(0x31), // 1
+        UnicodeScalar(0x32), // 2
+        UnicodeScalar(0x33), // 3
+        UnicodeScalar(0x34), // 4
+        UnicodeScalar(0x35), // 5
+        UnicodeScalar(0x36), // 6
+        UnicodeScalar(0x37), // 7
+        UnicodeScalar(0x38), // 8
+        UnicodeScalar(0x39), // 9
+        UnicodeScalar(0x65), // e
+        UnicodeScalar(0x45), // E
+        UnicodeScalar(0x2B), // +
+        UnicodeScalar(0x2D), // -
+    ]
     static func parseNumber(input: UnicodeParser) throws -> (Double, UnicodeParser)? {
         let view = input.view
         let endIndex = view.endIndex

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -126,6 +126,9 @@ public class NSJSONSerialization : NSObject {
         else if let (array, _) = try reader.parseArray(0) {
             return array
         }
+        else if opt.contains(.AllowFragments), let (value, _) = try reader.parseValue(0) {
+            return value
+        }
         throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.PropertyListReadCorruptError.rawValue, userInfo: [
             "NSDebugDescription" : "JSON text did not start with array or object and option to allow fragments not set."
         ])

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -248,7 +248,7 @@ private struct JSONReader {
             }()
         }
 
-        func peekASCII(input: Index) -> UInt8? {
+        func takeASCII(input: Index) -> (UInt8, Index)? {
             guard hasNext(input) else {
                 return nil
             }
@@ -268,14 +268,7 @@ private struct JSONReader {
             default:
                 return nil
             }
-            return (buffer[index] < 0x80) ? buffer[index] : nil
-        }
-
-        func takeASCII(input: Index) -> (UInt8, Index)? {
-            if let ascii = peekASCII(input) {
-                return (ascii, input + step)
-            }
-            return nil
+            return (buffer[index] < 0x80) ? (buffer[index], input + step) : nil
         }
 
         func takeString(begin: Index, end: Index) throws -> String {
@@ -302,8 +295,8 @@ private struct JSONReader {
 
     func consumeWhitespace(input: Index) -> Index? {
         var index = input
-        while let char = source.peekASCII(index) where JSONReader.whitespaceASCII.contains(char) {
-            index += source.step
+        while let (char, nextIndex) = source.takeASCII(index) where JSONReader.whitespaceASCII.contains(char) {
+            index = nextIndex
         }
         return index
     }
@@ -384,7 +377,7 @@ private struct JSONReader {
                     ])
                 }
             default:
-                currentIndex += source.step
+                currentIndex = index
             }
         }
         throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.PropertyListReadCorruptError.rawValue, userInfo: [

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -233,12 +233,12 @@ private struct JSONDeserializer {
             return view.startIndex.distanceTo(index)
         }
     }
-    
+
     static let whitespaceScalars = [
-        UnicodeScalar(0x20), // Space
         UnicodeScalar(0x09), // Horizontal tab
         UnicodeScalar(0x0A), // Line feed or New line
-        UnicodeScalar(0x0D)  // Carriage return
+        UnicodeScalar(0x0D), // Carriage return
+        UnicodeScalar(0x20), // Space
     ]
 
     static func consumeWhitespace(parser: UnicodeParser) -> UnicodeParser {
@@ -421,6 +421,8 @@ private struct JSONDeserializer {
     
     //MARK: - Number parsing
     static let numberScalars = [
+        UnicodeScalar(0x2B), // +
+        UnicodeScalar(0x2D), // -
         UnicodeScalar(0x2E), // .
         UnicodeScalar(0x30), // 0
         UnicodeScalar(0x31), // 1
@@ -432,10 +434,8 @@ private struct JSONDeserializer {
         UnicodeScalar(0x37), // 7
         UnicodeScalar(0x38), // 8
         UnicodeScalar(0x39), // 9
-        UnicodeScalar(0x65), // e
         UnicodeScalar(0x45), // E
-        UnicodeScalar(0x2B), // +
-        UnicodeScalar(0x2D), // -
+        UnicodeScalar(0x65), // e
     ]
     static func parseNumber(input: UnicodeParser) throws -> (Double, UnicodeParser)? {
         let view = input.view

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -540,12 +540,12 @@ private struct JSONReader {
         }
         guard let separatorIndex = try consumeStructure(Structure.NameSeparator, input: index) else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.PropertyListReadCorruptError.rawValue, userInfo: [
-                "NSDebugDescription" : "Invalid value at location \(source.distanceFromStart(input))"
+                "NSDebugDescription" : "Invalid separator at location \(source.distanceFromStart(index))"
             ])
         }
         guard let (value, finalIndex) = try parseValue(separatorIndex) else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.PropertyListReadCorruptError.rawValue, userInfo: [
-                "NSDebugDescription" : "Invalid value at location \(source.distanceFromStart(input))"
+                "NSDebugDescription" : "Invalid value at location \(source.distanceFromStart(separatorIndex))"
             ])
         }
         
@@ -574,14 +574,9 @@ private struct JSONReader {
                     index = nextIndex
                     continue
                 }
-                else {
-                    throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.PropertyListReadCorruptError.rawValue, userInfo: [
-                        "NSDebugDescription" : "Unexpected end of file while parsing array at location \(source.distanceFromStart(input))"
-                    ])
-                }
             }
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.PropertyListReadCorruptError.rawValue, userInfo: [
-                "NSDebugDescription" : "Unexpected end of file while parsing array at location \(source.distanceFromStart(input))"
+                "NSDebugDescription" : "Badly formed array at location \(source.distanceFromStart(index))"
             ])
         }
     }

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -234,7 +234,13 @@ private struct JSONDeserializer {
         }
     }
     
-    static let whitespaceScalars = "\u{20}\u{09}\u{0A}\u{0D}".unicodeScalars
+    static let whitespaceScalars = [
+        UnicodeScalar(0x20), // Space
+        UnicodeScalar(0x09), // Horizontal tab
+        UnicodeScalar(0x0A), // Line feed or New line
+        UnicodeScalar(0x0D)  // Carriage return
+    ]
+
     static func consumeWhitespace(parser: UnicodeParser) -> UnicodeParser {
         var index = parser.index
         let view = parser.view

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -249,18 +249,23 @@ private struct JSONReader {
         }
 
         func peekASCII(input: Index) -> UInt8? {
+            guard hasNext(input) else {
+                return nil
+            }
+
             let index: Int
             switch encoding {
-            case NSUTF8StringEncoding, NSUTF16LittleEndianStringEncoding, NSUTF32LittleEndianStringEncoding:
+            case NSUTF8StringEncoding:
                 index = input
-            case NSUTF16BigEndianStringEncoding:
+            case NSUTF16LittleEndianStringEncoding where buffer[input+1] == 0:
+                index = input
+            case NSUTF16BigEndianStringEncoding where buffer[input] == 0:
                 index = input + 1
-            case NSUTF32BigEndianStringEncoding:
+            case NSUTF32LittleEndianStringEncoding where buffer[input+1] == 0 && buffer[input+2] == 0 && buffer[input+3] == 0:
+                index = input
+            case NSUTF32BigEndianStringEncoding where buffer[input] == 0 && buffer[input+1] == 0 && buffer[input+2] == 0:
                 index = input + 3
             default:
-                index = input
-            }
-            guard hasNext(input) else {
                 return nil
             }
             return (buffer[index] < 0x80) ? buffer[index] : nil

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -257,14 +257,14 @@ private struct JSONReader {
             switch encoding {
             case NSUTF8StringEncoding:
                 index = input
-            case NSUTF16LittleEndianStringEncoding where buffer[input+1] == 0:
-                index = input
             case NSUTF16BigEndianStringEncoding where buffer[input] == 0:
                 index = input + 1
-            case NSUTF32LittleEndianStringEncoding where buffer[input+1] == 0 && buffer[input+2] == 0 && buffer[input+3] == 0:
-                index = input
             case NSUTF32BigEndianStringEncoding where buffer[input] == 0 && buffer[input+1] == 0 && buffer[input+2] == 0:
                 index = input + 3
+            case NSUTF16LittleEndianStringEncoding where buffer[input+1] == 0:
+                index = input
+            case NSUTF32LittleEndianStringEncoding where buffer[input+1] == 0 && buffer[input+2] == 0 && buffer[input+3] == 0:
+                index = input
             default:
                 return nil
             }

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -286,10 +286,9 @@ private struct JSONReader {
         func hasNext(input: Index) -> Bool {
             return input + step <= buffer.endIndex
         }
-
-        func distanceFromStart(index: Index) -> Int {
-            /// Keep track of deltas after decoding strings
-            return 0
+        
+        func distanceFromStart(index: Index) -> Index.Distance {
+            return buffer.startIndex.distanceTo(index) / step
         }
     }
 

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -85,6 +85,8 @@ extension TestNSJSONSerialization {
             
             ("test_deserialize_emptyArray", test_deserialize_emptyArray),
             ("test_deserialize_multiStringArray", test_deserialize_multiStringArray),
+            ("test_deserialize_unicodeString", test_deserialize_unicodeString),
+            
             
             ("test_deserialize_values", test_deserialize_values),
             ("test_deserialize_numbers", test_deserialize_numbers),
@@ -166,6 +168,26 @@ extension TestNSJSONSerialization {
                 let result = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? [Any]
                 XCTAssertEqual(result?[0] as? String, "hello")
                 XCTAssertEqual(result?[1] as? String, "swift⚡️")
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
+    func test_deserialize_unicodeString() {
+        /// Ģ has the same LSB as quotation mark " (U+0022) so test guarding against this case
+        let subject = "[\"unicode\", \"Ģ\", \"😢\"]"
+        
+        do {
+            for encoding in [NSUTF16LittleEndianStringEncoding, NSUTF16BigEndianStringEncoding, NSUTF32LittleEndianStringEncoding, NSUTF32BigEndianStringEncoding] {
+                guard let data = subject.bridge().dataUsingEncoding(encoding) else {
+                    XCTFail("Unable to convert string to data")
+                    return
+                }
+                let result = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? [Any]
+                XCTAssertEqual(result?[0] as? String, "unicode")
+                XCTAssertEqual(result?[1] as? String, "Ģ")
+                XCTAssertEqual(result?[2] as? String, "😢")
             }
         } catch {
             XCTFail("Unexpected error: \(error)")

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -100,6 +100,8 @@ extension TestNSJSONSerialization {
             ("test_deserialize_simpleEscapeSequences", test_deserialize_simpleEscapeSequences),
             ("test_deserialize_unicodeEscapeSequence", test_deserialize_unicodeEscapeSequence),
             ("test_deserialize_unicodeSurrogatePairEscapeSequence", test_deserialize_unicodeSurrogatePairEscapeSequence),
+
+            ("test_deserialize_allowFragments", test_deserialize_allowFragments),
             
             ("test_deserialize_unterminatedObjectString", test_deserialize_unterminatedObjectString),
             ("test_deserialize_missingObjectKey", test_deserialize_missingObjectKey),
@@ -292,6 +294,23 @@ extension TestNSJSONSerialization {
             }
             let result = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? [Any]
             XCTAssertEqual(result?[0] as? String, "\u{1D11E}")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
+    func test_deserialize_allowFragments() {
+        let subject = "3"
+        
+        do {
+            for encoding in supportedEncodings {
+                guard let data = subject.bridge().dataUsingEncoding(encoding) else {
+                    XCTFail("Unable to convert string to data")
+                    return
+                }
+                let result = try NSJSONSerialization.JSONObjectWithData(data, options: .AllowFragments) as? Double
+                XCTAssertEqual(result, 3)
+            }
         } catch {
             XCTFail("Unexpected error: \(error)")
         }

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -19,6 +19,12 @@
 
 class TestNSJSONSerialization : XCTestCase {
     
+    let supportedEncodings = [
+        NSUTF8StringEncoding,
+        NSUTF16LittleEndianStringEncoding, NSUTF16BigEndianStringEncoding,
+        NSUTF32LittleEndianStringEncoding, NSUTF32BigEndianStringEncoding
+    ]
+
     var allTests : [(String, () -> Void)] {
         return JSONObjectWithDataTests
             + deserializationTests
@@ -199,17 +205,19 @@ extension TestNSJSONSerialization {
         let subject = "[true, false, \"hello\", null, {}, []]"
         
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
-                XCTFail("Unable to convert string to data")
-                return
+            for encoding in supportedEncodings {
+                guard let data = subject.bridge().dataUsingEncoding(encoding) else {
+                    XCTFail("Unable to convert string to data")
+                    return
+                }
+                let result = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? [Any]
+                XCTAssertEqual(result?[0] as? Bool, true)
+                XCTAssertEqual(result?[1] as? Bool, false)
+                XCTAssertEqual(result?[2] as? String, "hello")
+                XCTAssertNotNil(result?[3] as? NSNull)
+                XCTAssertNotNil(result?[4] as? [String:Any])
+                XCTAssertNotNil(result?[5] as? [Any])
             }
-            let result = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? [Any]
-            XCTAssertEqual(result?[0] as? Bool, true)
-            XCTAssertEqual(result?[1] as? Bool, false)
-            XCTAssertEqual(result?[2] as? String, "hello")
-            XCTAssertNotNil(result?[3] as? NSNull)
-            XCTAssertNotNil(result?[4] as? [String:Any])
-            XCTAssertNotNil(result?[5] as? [Any])
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
@@ -220,17 +228,19 @@ extension TestNSJSONSerialization {
         let subject = "[1, -1, 1.3, -1.3, 1e3, 1E-3]"
         
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
-                XCTFail("Unable to convert string to data")
-                return
+            for encoding in supportedEncodings {
+                guard let data = subject.bridge().dataUsingEncoding(encoding) else {
+                    XCTFail("Unable to convert string to data")
+                    return
+                }
+                let result = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? [Any]
+                XCTAssertEqual(result?[0] as? Double,     1)
+                XCTAssertEqual(result?[1] as? Double,    -1)
+                XCTAssertEqual(result?[2] as? Double,   1.3)
+                XCTAssertEqual(result?[3] as? Double,  -1.3)
+                XCTAssertEqual(result?[4] as? Double,  1000)
+                XCTAssertEqual(result?[5] as? Double, 0.001)
             }
-            let result = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? [Any]
-            XCTAssertEqual(result?[0] as? Double,     1)
-            XCTAssertEqual(result?[1] as? Double,    -1)
-            XCTAssertEqual(result?[2] as? Double,   1.3)
-            XCTAssertEqual(result?[3] as? Double,  -1.3)
-            XCTAssertEqual(result?[4] as? Double,  1000)
-            XCTAssertEqual(result?[5] as? Double, 0.001)
         } catch {
             XCTFail("Unexpected error: \(error)")
         }

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -124,13 +124,15 @@ extension TestNSJSONSerialization {
     func test_deserialize_multiStringObject() {
         let subject = "{ \"hello\": \"world\", \"swift\": \"rocks\" }"
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
-                XCTFail("Unable to convert string to data")
-                return
+            for encoding in [NSUTF8StringEncoding, NSUTF16BigEndianStringEncoding] {
+                guard let data = subject.bridge().dataUsingEncoding(encoding) else {
+                    XCTFail("Unable to convert string to data")
+                    return
+                }
+                let result = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? [String: Any]
+                XCTAssertEqual(result?["hello"] as? String, "world")
+                XCTAssertEqual(result?["swift"] as? String, "rocks")
             }
-            let result = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? [String: Any]
-            XCTAssertEqual(result?["hello"] as? String, "world")
-            XCTAssertEqual(result?["swift"] as? String, "rocks")
         } catch {
             XCTFail("Error thrown: \(error)")
         }
@@ -156,13 +158,15 @@ extension TestNSJSONSerialization {
         let subject = "[\"hello\", \"swift⚡️\"]"
         
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
-                XCTFail("Unable to convert string to data")
-                return
+            for encoding in [NSUTF8StringEncoding, NSUTF16BigEndianStringEncoding] {
+                guard let data = subject.bridge().dataUsingEncoding(encoding) else {
+                    XCTFail("Unable to convert string to data")
+                    return
+                }
+                let result = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? [Any]
+                XCTAssertEqual(result?[0] as? String, "hello")
+                XCTAssertEqual(result?[1] as? String, "swift⚡️")
             }
-            let result = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? [Any]
-            XCTAssertEqual(result?[0] as? String, "hello")
-            XCTAssertEqual(result?[1] as? String, "swift⚡️")
         } catch {
             XCTFail("Unexpected error: \(error)")
         }


### PR DESCRIPTION
I ran 2 benchmarks against the current JSON parser implementation on `master`, comparing it to Darwin Foundation for [large inputs](https://github.com/zemirco/sf-city-lots-json/blob/master/citylots.json) and found it was 5-10x slower. (72s vs 8s for a single decode). This new code reduces this to a factor for 2-4x (17s)

While JSON is a text-based serialization, all control characters are ASCII characters. The data can be most efficiently parsed as a stream of bytes instead of the initial overhead of converting the bytes to a String.

The byte -> string conversion in the current code only accounts for 3s of time but parsing numbers is incredibly expensive (`Double.init?(_ text: String)` converts the string back to bytes to use [`strtod()`](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man3/strtod.3.html#//apple_ref/doc/man/3/strtod)). This technique uses `strtod` directly on the byte array. There is a penalty for non-UTF-8 encoded data which is inline with the Darwin implementation

> The most efficient encoding to use for parsing is UTF-8, so if you have a choice in encoding the data passed to this method, use UTF-8.

Another modification has been made to remove the intermediate `parser` values as the heap allocations for each intermediate parser was adding significant overhead.

This also includes a commit to implement `.AllowFragments`.