### PR TITLE
Updates to NSHTTPCookie

### DIFF
--- a/Foundation/NSHTTPCookie.swift
+++ b/Foundation/NSHTTPCookie.swift
@@ -95,23 +95,20 @@ public let NSHTTPCookiePort: String = "Port"
     attributes of a cookie.
 */
 public class NSHTTPCookie : NSObject {
-    private struct Cookie {
-        let comment: String?
-        let commentURL: NSURL?
-        let domain: String
-        let expiresDate: NSDate?
-        let HTTPOnly: Bool
-        let secure: Bool
-        let sessionOnly: Bool
-        let name: String
-        let path: String
-        let portList: [NSNumber]?
-        let properties: [String: Any]?
-        let value: String
-        let version: Int
-    }
-    private let cookieRepresentation: Cookie
-
+    let _comment: String?
+    let _commentURL: NSURL?
+    let _domain: String
+    let _expiresDate: NSDate?
+    let _HTTPOnly: Bool
+    let _secure: Bool
+    let _sessionOnly: Bool
+    let _name: String
+    let _path: String
+    let _portList: [NSNumber]?
+    let _value: String
+    let _version: Int
+    var _properties: [String : Any]
+    
     /*!
         @method initWithProperties:
         @abstract Initialize a NSHTTPCookie object with a dictionary of
@@ -245,7 +242,7 @@ public class NSHTTPCookie : NSObject {
         else {
             return nil
         }
-
+        
         let canonicalDomain: String
         if let domain = properties[NSHTTPCookieDomain] as? String {
             canonicalDomain = domain
@@ -257,99 +254,100 @@ public class NSHTTPCookie : NSObject {
         } else {
             return nil
         }
-
-        let secure: Bool
+        
+        _path = path
+        _name = name
+        _value = value
+        _domain = canonicalDomain
+        
         if let
             secureString = properties[NSHTTPCookieSecure] as? String
             where secureString.characters.count > 0
         {
-            secure = true
+            _secure = true
         } else {
-            secure = false
+            _secure = false
         }
 
         let version: Int
         if let
-            versionString = properties[NSHTTPCookieSecure] as? String
+            versionString = properties[NSHTTPCookieVersion] as? String
             where versionString == "1"
         {
             version = 1
         } else {
             version = 0
         }
-
-        let portList: [NSNumber]?
-        if let portString = properties[NSHTTPCookiePort] as? String {
-            portList = portString.characters
+        _version = version
+        
+        if let portString = properties[NSHTTPCookiePort] as? String
+        where _version == 1 {
+            _portList = portString.characters
                 .split(",")
                 .flatMap { Int(String($0)) }
                 .map { NSNumber(integer: $0) }
         } else {
-            portList = nil
+            _portList = nil
         }
 
         // TODO: factor into a utility function
-        let expiresDate: NSDate?
         if version == 0 {
             let expiresProperty = properties[NSHTTPCookieExpires]
             if let date = expiresProperty as? NSDate {
-                // If the dictionary value is already an NSDate,
-                // nothing left to do
-                expiresDate = date
+                _expiresDate = date
             } else if let dateString = expiresProperty as? String {
-                // If the dictionary value is a string, parse it
                 let formatter = NSDateFormatter()
-                formatter.dateFormat = "yyyy-MM-dd'T'HH:mm"
-
+                formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss O"   // per RFC 6265 '<rfc1123-date, defined in [RFC2616], Section 3.3.1>'
                 let timeZone = NSTimeZone(abbreviation: "GMT")
                 formatter.timeZone = timeZone
-
-                expiresDate = formatter.dateFromString(dateString)
+                _expiresDate = formatter.dateFromString(dateString)
             } else {
-                expiresDate = nil
+                _expiresDate = nil
             }
-        } else if version == 1 {
-            if let
-                maximumAge = properties[NSHTTPCookieMaximumAge] as? String,
-                secondsFromNow = Double(maximumAge)
-            {
-                expiresDate = NSDate(timeIntervalSinceNow: secondsFromNow)
-            } else {
-                expiresDate = nil
-            }
-        } else {
-            expiresDate = nil
-        }
-
-        var discard = false
-        if let discardString = properties[NSHTTPCookieDiscard] as? String {
-            discard = discardString == "TRUE"
         } else if let
-            _ = properties[NSHTTPCookieMaximumAge] as? String
-            where version >= 1
-        {
-            discard = false
+            maximumAge = properties[NSHTTPCookieMaximumAge] as? String,
+            secondsFromNow = Int(maximumAge)
+            where _version == 1 {
+            _expiresDate = NSDate(timeIntervalSinceNow: Double(secondsFromNow))
+        } else {
+            _expiresDate = nil
         }
-
-        // TODO: commentURL can be a string or NSURL
-
-        self.cookieRepresentation = Cookie(
-            comment: version == 1 ?
-                properties[NSHTTPCookieComment] as? String : nil,
-            commentURL: version == 1 ?
-                properties[NSHTTPCookieCommentURL] as? NSURL : nil,
-            domain: canonicalDomain,
-            expiresDate: expiresDate,
-            HTTPOnly: secure,
-            secure: secure,
-            sessionOnly: discard,
-            name: name,
-            path: path,
-            portList: version == 1 ? portList : nil,
-            properties: properties,
-            value: value,
-            version: version
-        )
+        
+        
+        if let discardString = properties[NSHTTPCookieDiscard] as? String {
+            _sessionOnly = discardString == "TRUE"
+        } else {
+            _sessionOnly = properties[NSHTTPCookieMaximumAge] == nil && version >= 1
+        }
+        if version == 0 {
+            _comment = nil
+            _commentURL = nil
+        } else {
+            _comment = properties[NSHTTPCookieComment] as? String
+            if let commentURL = properties[NSHTTPCookieCommentURL] as? NSURL {
+                _commentURL = commentURL
+            } else if let commentURL = properties[NSHTTPCookieCommentURL] as? String {
+                _commentURL = NSURL(string: commentURL)
+            } else {
+                _commentURL = nil
+            }
+        }
+        _HTTPOnly = false
+        _properties = [NSHTTPCookieComment : properties[NSHTTPCookieComment],
+                       NSHTTPCookieCommentURL : properties[NSHTTPCookieCommentURL],
+                       "Created" : NSDate().timeIntervalSinceReferenceDate,         // Cocoa Compatibility
+                       NSHTTPCookieDiscard : _sessionOnly,
+                       NSHTTPCookieDomain : _domain,
+                       NSHTTPCookieExpires : _expiresDate,
+                       NSHTTPCookieMaximumAge : properties[NSHTTPCookieMaximumAge],
+                       NSHTTPCookieName : _name,
+                       NSHTTPCookieOriginURL : properties[NSHTTPCookieOriginURL],
+                       NSHTTPCookiePath : _path,
+                       NSHTTPCookiePort : _portList,
+                       NSHTTPCookieSecure : _secure,
+                       NSHTTPCookieValue : _value,
+                       NSHTTPCookieVersion : _version
+        ]
     }
     
     /*!
@@ -376,7 +374,7 @@ public class NSHTTPCookie : NSObject {
     */
     public class func requestHeaderFieldsWithCookies(cookies: [NSHTTPCookie]) -> [String : String] {
         var cookieString = cookies.reduce("") { (sum, next) -> String in
-            return sum + "\(next.cookieRepresentation.name)=\(next.cookieRepresentation.value); "
+            return sum + "\(next._name)=\(next._value); "
         }
         //Remove the final trailing semicolon and whitespace
         if ( cookieString.length > 0 ) {
@@ -412,7 +410,7 @@ public class NSHTTPCookie : NSObject {
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
     public var properties: [String : Any]? {
-        return self.cookieRepresentation.properties
+        return _properties
     }
     
     /*!
@@ -423,7 +421,7 @@ public class NSHTTPCookie : NSObject {
         @result the version of the receiver.
     */
     public var version: Int {
-        return self.cookieRepresentation.version
+        return _version
     }
     
     /*!
@@ -432,7 +430,7 @@ public class NSHTTPCookie : NSObject {
         @result the name of the receiver.
     */
     public var name: String {
-        return self.cookieRepresentation.name
+        return _name
     }
     
     /*!
@@ -441,7 +439,7 @@ public class NSHTTPCookie : NSObject {
         @result the value of the receiver.
     */
     public var value: String {
-        return self.cookieRepresentation.value
+        return _value
     }
     
     /*!
@@ -454,7 +452,7 @@ public class NSHTTPCookie : NSObject {
         @result The expires date of the receiver.
     */
     /*@NSCopying*/ public var expiresDate: NSDate? {
-        return self.cookieRepresentation.expiresDate
+        return _expiresDate
     }
     
     /*!
@@ -465,7 +463,7 @@ public class NSHTTPCookie : NSObject {
         be discarded at the end of the session.
     */
     public var sessionOnly: Bool {
-        return self.cookieRepresentation.sessionOnly
+        return _sessionOnly
     }
     
     /*!
@@ -478,7 +476,7 @@ public class NSHTTPCookie : NSObject {
         @result The domain of the receiver.
     */
     public var domain: String {
-        return self.cookieRepresentation.domain
+        return _domain
     }
     
     /*!
@@ -490,7 +488,7 @@ public class NSHTTPCookie : NSObject {
         @result The path of the receiver.
     */
     public var path: String {
-        return self.cookieRepresentation.path
+        return _path
     }
     
     /*!
@@ -505,7 +503,7 @@ public class NSHTTPCookie : NSObject {
         NO otherwise.
     */
     public var secure: Bool {
-        return self.cookieRepresentation.secure
+        return _secure
     }
     
     /*!
@@ -521,7 +519,7 @@ public class NSHTTPCookie : NSObject {
         NO otherwise.
     */
     public var HTTPOnly: Bool {
-        return self.cookieRepresentation.HTTPOnly
+        return _HTTPOnly
     }
     
     /*!
@@ -534,7 +532,7 @@ public class NSHTTPCookie : NSObject {
         comment.
     */
     public var comment: String? {
-        return self.cookieRepresentation.comment
+        return _comment
     }
     
     /*!
@@ -547,7 +545,7 @@ public class NSHTTPCookie : NSObject {
         has no comment URL.
     */
     /*@NSCopying*/ public var commentURL: NSURL? {
-        return self.cookieRepresentation.commentURL
+        return _commentURL
     }
     
     /*!
@@ -562,7 +560,7 @@ public class NSHTTPCookie : NSObject {
         port.
     */
     public var portList: [NSNumber]? {
-        return self.cookieRepresentation.portList
+        return _portList
     }
 }
 


### PR DESCRIPTION
Updates to NSHTTPCookie

## Changes in this pull request

* Fixed setting version from NSHTTPCookieVersion, was NSHTTPCookieSecure
* Fixed string format when setting expires date
* Fixed creating expiresDate from timeInterval. Docs state must be integer.
* Fixed setting discard to match documentation
* Replaced internal struct with private properties, serve the same purpose
* Created internal properties dictionary that is returned by properties get. Closer to Cocoa compatibility
* Added "Created" key and value to properties dictionary for Cocoa compatibility.

## Notes
The documentation of NSHTTPCookie and the Cocoa implementation of NSHTTPCookie differ. Not sure if it's a bug or if it's proper, yet undocumented behavior.  The question is, do we want to be compatible with Cocoa or more closely follow documentation.

### Examples
* Certain values that are string representations of numbers, such as ```NSHTTPCookieVersion``` are documented as accepting strings when using ```initWithProperties```. The Cocoa implementation actually accepts NSNumbers as well
* Along with the above example, the ```properties``` dictionary returns numbers instead of strings. The documentation states that the properties dictionary can be used to created a new cookie with the same values. This contradicts the documentation which states that all the numeric values of the properties dictionary are supposed to be strings.
* Created value in properties dictionary is undocumented.
* Cocoa implementation does not exclude any properties based on the cookie's version.
* Initializing with property values that should be invalid according to documentation returns a cookie, For example, comment and commentURL values should only be used with cookie version 1. Yet, you can initialize a cookie that is version 0 and with values in the comment and/or commentURL keys.

