### PR TITLE
[SR-379] CFDictionaryGetKeysAndValues() order

### DIFF
--- a/Foundation/NSCFDictionary.swift
+++ b/Foundation/NSCFDictionary.swift
@@ -136,11 +136,11 @@ internal func _CFSwiftDictionaryContainsValue(dictionary: AnyObject, value: AnyO
     NSUnimplemented()
 }
 
-internal func _CFSwiftDictionaryGetKeysAndValues(dictionary: AnyObject, keybuf: UnsafeMutablePointer<Unmanaged<AnyObject>?>, valuebuf: UnsafeMutablePointer<Unmanaged<AnyObject>?>) {
+internal func _CFSwiftDictionaryGetValuesAndKeys(dictionary: AnyObject, valuebuf: UnsafeMutablePointer<Unmanaged<AnyObject>?>, keybuf: UnsafeMutablePointer<Unmanaged<AnyObject>?>) {
     var idx = 0
     (dictionary as! NSDictionary).enumerateKeysAndObjectsUsingBlock { key, value, _ in
-        keybuf[idx] = Unmanaged<AnyObject>.passUnretained(key)
         valuebuf[idx] = Unmanaged<AnyObject>.passUnretained(value)
+        keybuf[idx] = Unmanaged<AnyObject>.passUnretained(key)
         idx += 1
     }
 }

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -148,7 +148,7 @@ internal func __CFInitializeSwift() {
     __CFSwiftBridge.NSDictionary._getValueIfPresent = _CFSwiftDictionaryGetValueIfPresent
     __CFSwiftBridge.NSDictionary.containsObject = _CFSwiftDictionaryContainsValue
     __CFSwiftBridge.NSDictionary.countForObject = _CFSwiftDictionaryGetCountOfValue
-    __CFSwiftBridge.NSDictionary.getObjects = _CFSwiftDictionaryGetKeysAndValues
+    __CFSwiftBridge.NSDictionary.getObjects = _CFSwiftDictionaryGetValuesAndKeys
     __CFSwiftBridge.NSDictionary.__apply = _CFSwiftDictionaryApplyFunction
     
     __CFSwiftBridge.NSMutableDictionary.__addObject = _CFSwiftDictionaryAddValue


### PR DESCRIPTION
CFDictionaryGetKeysAndValues() bridges to _CFSwiftDictionaryGetKeysAndValues()
which accepts parameters in the CF, not Foundation order. The arguments are
transposed in the current code.

[SR-379] CFDictionaryGetKeysAndValues() bridges values and keys in wrong order

CFDictionaryGetKeysAndValues() bridges to _CFSwiftDictionaryGetKeysAndValues()
which accepts parameters in the CF, not Foundation order. The arguments are
transposed in the current code.

[SR-379] CFDictionaryGetKeysAndValues() bridges values and keys in wrong order