### PR TITLE
[SR-380] NSString.hash.getter crash workaround

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -331,7 +331,7 @@ public class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, N
     }
     
     public override var hash: Int {
-        return Int(CFStringHashNSString(self._cfObject))
+        return Int(bitPattern:CFStringHashNSString(self._cfObject))
     }
 }
 

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -83,7 +83,7 @@ internal func _CFSwiftGetTypeID(cf: AnyObject) -> CFTypeID {
 
 
 internal func _CFSwiftGetHash(cf: AnyObject) -> CFHashCode {
-    return CFHashCode((cf as! NSObject).hash)
+    return CFHashCode(bitPattern: (cf as! NSObject).hash)
 }
 
 


### PR DESCRIPTION
Bridging hash functions crash frequently, I suspect due to integer overflow.