### PR TITLE
[SR-386] NSLog() API at least for internal use

### DIFF
--- a/CoreFoundation/Base.subproj/CFLogUtilities.h
+++ b/CoreFoundation/Base.subproj/CFLogUtilities.h
@@ -25,7 +25,7 @@
 CF_EXTERN_C_BEGIN
 
 
-enum {	// Legal level values for CFLog()
+typedef CF_ENUM(int32_t, CFLogLevel) {	// Legal level values for CFLog()
     kCFLogLevelEmergency = 0,
     kCFLogLevelAlert = 1,
     kCFLogLevelCritical = 2,
@@ -36,7 +36,7 @@ enum {	// Legal level values for CFLog()
     kCFLogLevelDebug = 7,
 };
 
-CF_EXPORT void CFLog(int32_t level, CFStringRef format, ...);
+CF_EXPORT void CFLog(CFLogLevel level, CFStringRef format, ...);
 /*	Passing in a level value which is outside the range of 0-7 will cause the the call to do nothing.
 	CFLog() logs the message using the asl.h API, and uses the level parameter as the log level.
 	Note that the asl subsystem ignores some log levels by default.
@@ -44,6 +44,10 @@ CF_EXPORT void CFLog(int32_t level, CFStringRef format, ...);
 	Even "no-op" CFLogs are not necessarily fast.
 	If you care about performance, you shouldn't be logging.
 */
+
+#if DEPLOYMENT_RUNTIME_SWIFT
+CF_EXPORT void CFLog1(CFLogLevel lev, CFStringRef message);
+#endif
 
 CF_EXTERN_C_END
 

--- a/CoreFoundation/Base.subproj/CFUtilities.c
+++ b/CoreFoundation/Base.subproj/CFUtilities.c
@@ -754,14 +754,19 @@ CF_PRIVATE void _CFLogSimple(int32_t lev, char *format, ...) {
     va_end(args);
 }
 
-void CFLog(int32_t lev, CFStringRef format, ...) {
+void CFLog(CFLogLevel lev, CFStringRef format, ...) {
     va_list args;
     va_start(args, format); 
     _CFLogvEx3(NULL, NULL, NULL, NULL, lev, format, args, __builtin_return_address(0));
     va_end(args);
 }
 
-
+#if DEPLOYMENT_RUNTIME_SWIFT
+// Temporary as Swift cannot import varag C functions
+void CFLog1(CFLogLevel lev, CFStringRef message) {
+    CFLog(lev, CFSTR("%@"), message);
+}
+#endif
 
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED
 

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -17,6 +17,7 @@
 #include <CoreFoundation/CFCalendar.h>
 #include <CoreFoundation/CFPriv.h>
 #include <CoreFoundation/CFXMLInterface.h>
+#include <CoreFoundation/CFLogUtilities.h>
 #include <fts.h>
 
 CF_ASSUME_NONNULL_BEGIN

--- a/Foundation/NSLog.swift
+++ b/Foundation/NSLog.swift
@@ -1,0 +1,29 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+import CoreFoundation
+
+#if os(OSX) || os(iOS)
+internal let kCFLogLevelEmergency = CFLogLevel.Emergency
+internal let kCFLogLevelAlert = CFLogLevel.Alert
+internal let kCFLogLevelCritical = CFLogLevel.Critical
+internal let kCFLogLevelError = CFLogLevel.Error
+internal let kCFLogLevelWarning = CFLogLevel.Warning
+internal let kCFLogLevelNotice = CFLogLevel.Notice
+internal let kCFLogLevelInfo = CFLogLevel.Info
+internal let kCFLogLevelDebug = CFLogLevel.Debug
+#endif
+
+internal func NSLog(message : String) {
+#if os(OSX) || os(iOS)
+    CFLog1(kCFLogLevelWarning, message._cfObject)
+#else
+    CFLog1(Int32(kCFLogLevelWarning), message._cfObject)
+#endif
+}


### PR DESCRIPTION
This implements an NSLog-like API, currently marked internal, that calls CFLog and can be used for displaying Darwin-style log messages

TODO: propose a better solution for platform-dependent cast in NSLog(). Somehow the enum is coming across differently.