### PR TITLE
[SR-414] isEqual/hash/description for bridged CF objects

### DIFF
--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -149,7 +149,7 @@ public class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     
     public override var hash: Int {
         get {
-            return Int(CFHash(_cfObject))
+            return Int(bitPattern: CFHash(_cfObject))
         }
     }
     

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -147,6 +147,26 @@ public class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
+    public override var hash: Int {
+        get {
+            return Int(CFHash(_cfObject))
+        }
+    }
+    
+    public override func isEqual(object: AnyObject?) -> Bool {
+        if let cal = object as? NSCalendar {
+            return CFEqual(_cfObject, cal._cfObject)
+        } else {
+            return false
+        }
+    }
+    
+    public override var description: String {
+        get {
+            return CFCopyDescription(_cfObject)._swiftObject
+        }
+    }
+
     deinit {
         _CFDeinit(self)
     }

--- a/Foundation/NSCharacterSet.swift
+++ b/Foundation/NSCharacterSet.swift
@@ -45,6 +45,26 @@ public class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
         return unsafeBitCast(self, CFMutableCharacterSetRef.self)
     }
     
+    public override var hash: Int {
+        get {
+            return Int(CFHash(_cfObject))
+        }
+    }
+    
+    public override func isEqual(object: AnyObject?) -> Bool {
+        if let cs = object as? NSCharacterSet {
+            return CFEqual(_cfObject, cs._cfObject)
+        } else {
+            return false
+        }
+    }
+    
+    public override var description: String {
+        get {
+            return CFCopyDescription(_cfObject)._swiftObject
+        }
+    }
+
     deinit {
         _CFDeinit(self)
     }

--- a/Foundation/NSCharacterSet.swift
+++ b/Foundation/NSCharacterSet.swift
@@ -47,7 +47,7 @@ public class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
     
     public override var hash: Int {
         get {
-            return Int(CFHash(_cfObject))
+            return Int(bitPattern: CFHash(_cfObject))
         }
     }
     

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -93,6 +93,20 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         self.init(bytes: nil, length: 0, copy: false, deallocator: nil)
     }
     
+    public override var hash: Int {
+        get {
+            return Int(CFHash(_cfObject))
+        }
+    }
+    
+    public override func isEqual(object: AnyObject?) -> Bool {
+        if let data = object as? NSData {
+            return self.isEqualToData(data)
+        } else {
+            return false
+        }
+    }
+    
     deinit {
         if _bytes != nil {
             _deallocHandler?.handler(_bytes, _length)

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -95,7 +95,7 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     
     public override var hash: Int {
         get {
-            return Int(CFHash(_cfObject))
+            return Int(bitPattern: CFHash(_cfObject))
         }
     }
     

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -28,7 +28,7 @@ public class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
     
     public override var hash: Int {
         get {
-            return Int(CFHash(_cfObject))
+            return Int(bitPattern: CFHash(_cfObject))
         }
     }
     

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -26,6 +26,20 @@ public var NSTimeIntervalSince1970: Double {
 public class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
     typealias CFType = CFDateRef
     
+    public override var hash: Int {
+        get {
+            return Int(CFHash(_cfObject))
+        }
+    }
+    
+    public override func isEqual(object: AnyObject?) -> Bool {
+        if let date = object as? NSDate {
+            return isEqualToDate(date)
+        } else {
+            return false
+        }
+    }
+    
     deinit {
         _CFDeinit(self)
     }

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -137,6 +137,20 @@ public class NSNumber : NSValue {
         }
     }
     
+    public override var hash: Int {
+        get {
+            return Int(CFHash(_cfObject))
+        }
+    }
+    
+    public override func isEqual(object: AnyObject?) -> Bool {
+        if let obj = object {
+            return CFEqual(_cfObject, obj)
+        } else {
+            return false
+        }
+    }
+    
     deinit {
         _CFDeinit(self)
     }

--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -41,7 +41,7 @@ public class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
     
     public override var hash: Int {
         get {
-            return Int(CFHash(_cfObject))
+            return Int(bitPattern: CFHash(_cfObject))
         }
     }
     

--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -39,6 +39,26 @@ public class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
         NSUnimplemented()
     }
     
+    public override var hash: Int {
+        get {
+            return Int(CFHash(_cfObject))
+        }
+    }
+    
+    public override func isEqual(object: AnyObject?) -> Bool {
+        if let tz = object as? NSTimeZone {
+            return isEqualToTimeZone(tz)
+        } else {
+            return false
+        }
+    }
+    
+    public override var description: String {
+        get {
+            return CFCopyDescription(_cfObject)._swiftObject
+        }
+    }
+
     deinit {
         _CFDeinit(self)
     }
@@ -179,7 +199,9 @@ extension NSTimeZone {
     public var daylightSavingTimeOffset: NSTimeInterval { NSUnimplemented() }
     /*@NSCopying*/ public var nextDaylightSavingTimeTransition: NSDate?  { NSUnimplemented() }
     
-    public func isEqualToTimeZone(aTimeZone: NSTimeZone) -> Bool { NSUnimplemented() }
+    public func isEqualToTimeZone(aTimeZone: NSTimeZone) -> Bool {
+        return CFEqual(self._cfObject, aTimeZone._cfObject)
+    }
     
     public func localizedName(style: NSTimeZoneNameStyle, locale: NSLocale?) -> String? { NSUnimplemented() }
 }

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -58,6 +58,26 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
         }
     }
     
+    public override var hash: Int {
+        get {
+            return Int(bitPattern: CFHash(_cfObject))
+        }
+    }
+    
+    public override func isEqual(object: AnyObject?) -> Bool {
+        if let url = object as? NSURL {
+            return CFEqual(_cfObject, url._cfObject)
+        } else {
+            return false
+        }
+    }
+    
+    public override var description: String {
+        get {
+            return CFCopyDescription(_cfObject)._swiftObject
+        }
+    }
+
     deinit {
         _CFDeinit(self)
     }


### PR DESCRIPTION
CF bridged objects are not correctly implementing Equatable because they do not provide an isEqual method. Whilst we're at it, implement hash and description.