### PR TITLE
[SR-391] _CFSwiftDictionaryGetKeysAndValues() parameter validation

### DIFF
--- a/Foundation/NSCFDictionary.swift
+++ b/Foundation/NSCFDictionary.swift
@@ -138,9 +138,16 @@ internal func _CFSwiftDictionaryContainsValue(dictionary: AnyObject, value: AnyO
 
 internal func _CFSwiftDictionaryGetKeysAndValues(dictionary: AnyObject, keybuf: UnsafeMutablePointer<Unmanaged<AnyObject>?>, valuebuf: UnsafeMutablePointer<Unmanaged<AnyObject>?>) {
     var idx = 0
+    if valuebuf == nil && keybuf == nil {
+        return
+    }
     (dictionary as! NSDictionary).enumerateKeysAndObjectsUsingBlock { key, value, _ in
-        keybuf[idx] = Unmanaged<AnyObject>.passUnretained(key)
-        valuebuf[idx] = Unmanaged<AnyObject>.passUnretained(value)
+	if valuebuf != nil {
+	    valuebuf[idx] = Unmanaged<AnyObject>.passUnretained(value)
+	}
+	if keybuf != nil {
+	    keybuf[idx] = Unmanaged<AnyObject>.passUnretained(key)
+	}
         idx += 1
     }
 }


### PR DESCRIPTION
_CFSwiftDictionaryGetKeysAndValues() crashes with NULL arguguments

It's valid to enumerate a dictionary with CFDictionaryGetKeysAndValues(), only
retrieving the keys or values (or indeed nothing).