### PR TITLE
Use the prefix for CoreFoundation headers/module data

### DIFF
--- a/build.py
+++ b/build.py
@@ -25,12 +25,12 @@ elif Configuration.current.target.sdk == OSType.MacOSX:
 
 # For now, we do not distinguish between public and private headers (they are all private to Foundation)
 # These are really part of CF, which should ultimately be a separate target
-foundation.ROOT_HEADERS_FOLDER_PATH = "/usr/lib/swift"
-foundation.PUBLIC_HEADERS_FOLDER_PATH = "/usr/lib/swift/CoreFoundation"
-foundation.PRIVATE_HEADERS_FOLDER_PATH = "/usr/lib/swift/CoreFoundation"
-foundation.PROJECT_HEADERS_FOLDER_PATH = "/usr/lib/swift/CoreFoundation"
+foundation.ROOT_HEADERS_FOLDER_PATH = "${PREFIX}/lib/swift"
+foundation.PUBLIC_HEADERS_FOLDER_PATH = "${PREFIX}/lib/swift/CoreFoundation"
+foundation.PRIVATE_HEADERS_FOLDER_PATH = "${PREFIX}/lib/swift/CoreFoundation"
+foundation.PROJECT_HEADERS_FOLDER_PATH = "${PREFIX}/lib/swift/CoreFoundation"
 
-foundation.PUBLIC_MODULE_FOLDER_PATH = "/usr/lib/swift/CoreFoundation"
+foundation.PUBLIC_MODULE_FOLDER_PATH = "${PREFIX}/lib/swift/CoreFoundation"
 
 foundation.CFLAGS += " ".join([
 	'-DU_SHOW_DRAFT_API',


### PR DESCRIPTION
This allows Foundation to be installed with a prefix that is not '/usr' and
resolves [SR-422](https://bugs.swift.org/browse/SR-422).