### PR TITLE
[SR-414] redux: fix NSNumber.hash and isEqual

### DIFF
--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -139,13 +139,13 @@ public class NSNumber : NSValue {
     
     public override var hash: Int {
         get {
-            return Int(CFHash(_cfObject))
+            return Int(bitPattern: CFHash(_cfObject))
         }
     }
     
     public override func isEqual(object: AnyObject?) -> Bool {
-        if let obj = object {
-            return CFEqual(_cfObject, obj)
+        if let number = object as? NSNumber {
+            return CFEqual(_cfObject, number._cfObject)
         } else {
             return false
         }


### PR DESCRIPTION
Was missing fix for [SR-380] hash overflow and NSNumber type check in isEqual

Sorry @phausler – sloppiness on my part