### PR TITLE
[SR-414] avoid overflow on __NSCFType and NSUUID hash properties

### DIFF
--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -53,7 +53,7 @@ internal class __NSCFType : NSObject {
     
     override var hash: Int {
         get {
-            return Int(CFHash(self))
+            return Int(bitPattern: CFHash(self))
         }
     }
     

--- a/Foundation/NSUUID.swift
+++ b/Foundation/NSUUID.swift
@@ -82,7 +82,7 @@ public class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     public override var hash: Int {
-        return Int(CFHashBytes(buffer, 16))
+        return Int(bitPattern: CFHashBytes(buffer, 16))
     }
     
     public override var description: String {


### PR DESCRIPTION
Some more.