### PR TITLE
Improve NSUserName NSHomeDirectoryForUser

### DIFF
--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -603,7 +603,7 @@ public func NSHomeDirectory() -> String {
 public func NSHomeDirectoryForUser(user: String?) -> String? {
     let usr = user ?? NSUserName()
     var info = passwd()
-    let recommendedBufSize = sysconf(_SC_GETPW_R_SIZE_MAX)
+    let recommendedBufSize = sysconf(Int32(_SC_GETPW_R_SIZE_MAX))
     let bufSize = recommendedBufSize > 0 ? recommendedBufSize : Int(BUFSIZ * 10)
     var buffer = [Int8](count: bufSize, repeatedValue: 0)
     var result: UnsafeMutablePointer<passwd> = nil
@@ -620,7 +620,7 @@ public func NSUserName() -> String {
     let euid = geteuid()
     
     var info = passwd()
-    let recommendedBufSize = sysconf(_SC_GETPW_R_SIZE_MAX)
+    let recommendedBufSize = sysconf(Int32(_SC_GETPW_R_SIZE_MAX))
     let bufSize = recommendedBufSize > 0 ? recommendedBufSize : Int(BUFSIZ * 10)
     var buffer = [Int8](count: bufSize, repeatedValue: 0)
     var result: UnsafeMutablePointer<passwd> = nil

--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -612,7 +612,7 @@ public func NSHomeDirectoryForUser(user: String?) -> String? {
 
 public func NSUserName() -> String {
     let userName = CFCopyUserName().takeRetainedValue()
-    return String(userName)
+    return userName._swiftObject
 }
 
 internal func _NSCreateTemporaryFile(filePath: String) throws -> (Int32, String) {

--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -601,7 +601,18 @@ public func NSHomeDirectory() -> String {
 }
 
 public func NSHomeDirectoryForUser(user: String?) -> String? {
-    let usr = user ?? NSUserName()
+    let currentUserName = NSUserName()
+    let usr = user ?? currentUserName
+    
+    if usr == currentUserName {
+        // From http://linux.die.net/man/3/getpwuid
+        // An application that wants to determine its user's home directory should inspect the value of HOME (rather than the value getpwuid(getuid())->pw_dir) 
+        // since this allows the user to modify their notion of "the home directory" during a login session.
+        if let envHome = NSProcessInfo.processInfo().environment["HOME"] {
+            return envHome
+        }
+    }
+    
     var info = passwd()
     let recommendedBufSize = sysconf(Int32(_SC_GETPW_R_SIZE_MAX))
     let bufSize = recommendedBufSize > 0 ? recommendedBufSize : Int(BUFSIZ * 10)

--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -603,7 +603,8 @@ public func NSHomeDirectory() -> String {
 public func NSHomeDirectoryForUser(user: String?) -> String? {
     let usr = user ?? NSUserName()
     var info = passwd()
-    let bufSize = Int(BUFSIZ * 10)
+    let recommendedBufSize = sysconf(_SC_GETPW_R_SIZE_MAX)
+    let bufSize = recommendedBufSize > 0 ? recommendedBufSize : Int(BUFSIZ * 10)
     var buffer = [Int8](count: bufSize, repeatedValue: 0)
     var result: UnsafeMutablePointer<passwd> = nil
 
@@ -619,7 +620,8 @@ public func NSUserName() -> String {
     let euid = geteuid()
     
     var info = passwd()
-    let bufSize = Int(BUFSIZ * 10)
+    let recommendedBufSize = sysconf(_SC_GETPW_R_SIZE_MAX)
+    let bufSize = recommendedBufSize > 0 ? recommendedBufSize : Int(BUFSIZ * 10)
     var buffer = [Int8](count: bufSize, repeatedValue: 0)
     var result: UnsafeMutablePointer<passwd> = nil
     


### PR DESCRIPTION
* `getlogin_r` replaced with get `getpwuid_r->name`. According to the manpage it should be more reliable.
* use `sysconf(Int32(_SC_GETPW_R_SIZE_MAX))` to get recommended size of a buffer
* for the current user check `$HOME` environment variable first