### PR TITLE
[SR-439] Cached floating-point CF values do not bridge

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -662,6 +662,9 @@ CF_INLINE uintptr_t __CFISAForTypeID(CFTypeID typeID) {
     return (typeID < __CFRuntimeClassTableSize) ? __CFRuntimeObjCClassTable[typeID] : 0;
 }
 
+/* For Swift, which can't allocate any CF objects until after the bridge is initialized */
+CF_PRIVATE void __CFNumberInitialize(void);
+
 /* See comments in CFBase.c
 */
 #define FAULT_CALLBACK(V)

--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1169,6 +1169,7 @@ void __CFInitialize(void) {
         extern void __CFInitializeSwift();
         __CFInitializeSwift();
 #endif
+        __CFNumberInitialize(); /* needs to happen after Swift bridge is initialized */
         {
             CFIndex idx, cnt = 0;
             char **args = NULL;

--- a/CoreFoundation/NumberDate.subproj/CFNumber.c
+++ b/CoreFoundation/NumberDate.subproj/CFNumber.c
@@ -1045,39 +1045,40 @@ CFTypeID CFNumberGetTypeID(void) {
     dispatch_once(&initOnce, ^{
         __kCFNumberTypeID = _CFRuntimeRegisterClass(&__CFNumberClass); // initOnce covered
 
-        _CFRuntimeSetInstanceTypeIDAndIsa(&__kCFNumberNaN, __kCFNumberTypeID);
-        __CFBitfieldSetValue(__kCFNumberNaN._base._cfinfo[CF_INFO_BITS], 4, 0, kCFNumberFloat64Type);
-        __kCFNumberNaN._pad = BITSFORDOUBLENAN;
-
-        _CFRuntimeSetInstanceTypeIDAndIsa(& __kCFNumberNegativeInfinity, __kCFNumberTypeID);
-        __CFBitfieldSetValue(__kCFNumberNegativeInfinity._base._cfinfo[CF_INFO_BITS], 4, 0, kCFNumberFloat64Type);
-        __kCFNumberNegativeInfinity._pad = BITSFORDOUBLENEGINF;
-
-        _CFRuntimeSetInstanceTypeIDAndIsa(& __kCFNumberPositiveInfinity, __kCFNumberTypeID);
-        __CFBitfieldSetValue(__kCFNumberPositiveInfinity._base._cfinfo[CF_INFO_BITS], 4, 0, kCFNumberFloat64Type);
-        __kCFNumberPositiveInfinity._pad = BITSFORDOUBLEPOSINF;
-
-        _CFRuntimeSetInstanceTypeIDAndIsa(& __kCFNumberFloat32Zero, __kCFNumberTypeID);
-        __CFBitfieldSetValue(__kCFNumberFloat32Zero._base._cfinfo[CF_INFO_BITS], 4, 0, kCFNumberFloat32Type);
-        __kCFNumberFloat32Zero._pad = BITSFORFLOATZERO;
-
-        _CFRuntimeSetInstanceTypeIDAndIsa(& __kCFNumberFloat32One, __kCFNumberTypeID);
-        __CFBitfieldSetValue(__kCFNumberFloat32One._base._cfinfo[CF_INFO_BITS], 4, 0, kCFNumberFloat32Type);
-        __kCFNumberFloat32One._pad = BITSFORFLOATONE;
-
-        _CFRuntimeSetInstanceTypeIDAndIsa(& __kCFNumberFloat64Zero, __kCFNumberTypeID);
-        __CFBitfieldSetValue(__kCFNumberFloat64Zero._base._cfinfo[CF_INFO_BITS], 4, 0, kCFNumberFloat64Type);
-        __kCFNumberFloat64Zero._pad = BITSFORDOUBLEZERO;
-
-        _CFRuntimeSetInstanceTypeIDAndIsa(& __kCFNumberFloat64One, __kCFNumberTypeID);
-        __CFBitfieldSetValue(__kCFNumberFloat64One._base._cfinfo[CF_INFO_BITS], 4, 0, kCFNumberFloat64Type);
-        __kCFNumberFloat64One._pad = BITSFORDOUBLEONE;
-
-
         const char *caching = __CFgetenv("CFNumberDisableCache");	// "all" to disable caching and tagging; anything else to disable caching; nothing to leave both enabled
         if (caching) __CFNumberCaching = (!strcmp(caching, "all")) ? kCFNumberCachingFullyDisabled : kCFNumberCachingDisabled;	// initial state above is kCFNumberCachingEnabled
     });
     return __kCFNumberTypeID;
+}
+
+CF_PRIVATE void __CFNumberInitialize(void) {
+    _CFRuntimeSetInstanceTypeIDAndIsa(&__kCFNumberNaN, __kCFNumberTypeID);
+    __CFBitfieldSetValue(__kCFNumberNaN._base._cfinfo[CF_INFO_BITS], 4, 0, kCFNumberFloat64Type);
+    __kCFNumberNaN._pad = BITSFORDOUBLENAN;
+
+    _CFRuntimeSetInstanceTypeIDAndIsa(& __kCFNumberNegativeInfinity, __kCFNumberTypeID);
+    __CFBitfieldSetValue(__kCFNumberNegativeInfinity._base._cfinfo[CF_INFO_BITS], 4, 0, kCFNumberFloat64Type);
+    __kCFNumberNegativeInfinity._pad = BITSFORDOUBLENEGINF;
+
+    _CFRuntimeSetInstanceTypeIDAndIsa(& __kCFNumberPositiveInfinity, __kCFNumberTypeID);
+    __CFBitfieldSetValue(__kCFNumberPositiveInfinity._base._cfinfo[CF_INFO_BITS], 4, 0, kCFNumberFloat64Type);
+    __kCFNumberPositiveInfinity._pad = BITSFORDOUBLEPOSINF;
+
+    _CFRuntimeSetInstanceTypeIDAndIsa(& __kCFNumberFloat32Zero, __kCFNumberTypeID);
+    __CFBitfieldSetValue(__kCFNumberFloat32Zero._base._cfinfo[CF_INFO_BITS], 4, 0, kCFNumberFloat32Type);
+    __kCFNumberFloat32Zero._pad = BITSFORFLOATZERO;
+
+    _CFRuntimeSetInstanceTypeIDAndIsa(& __kCFNumberFloat32One, __kCFNumberTypeID);
+    __CFBitfieldSetValue(__kCFNumberFloat32One._base._cfinfo[CF_INFO_BITS], 4, 0, kCFNumberFloat32Type);
+    __kCFNumberFloat32One._pad = BITSFORFLOATONE;
+
+    _CFRuntimeSetInstanceTypeIDAndIsa(& __kCFNumberFloat64Zero, __kCFNumberTypeID);
+    __CFBitfieldSetValue(__kCFNumberFloat64Zero._base._cfinfo[CF_INFO_BITS], 4, 0, kCFNumberFloat64Type);
+    __kCFNumberFloat64Zero._pad = BITSFORDOUBLEZERO;
+
+    _CFRuntimeSetInstanceTypeIDAndIsa(& __kCFNumberFloat64One, __kCFNumberTypeID);
+    __CFBitfieldSetValue(__kCFNumberFloat64One._base._cfinfo[CF_INFO_BITS], 4, 0, kCFNumberFloat64Type);
+    __kCFNumberFloat64One._pad = BITSFORDOUBLEONE;
 }
 
 #define MinCachedInt (-1)


### PR DESCRIPTION
If a bridged CF type is instantiated before __CFInitializeSwift() is called, then those types will not be bridged. This created unusual and unexpected results when initializing floating point numbers containing cached values such as 0.0, 1.0 and NaN: decoding a property list containing these would assert fail but other numbers would be fine.

This patch fixes this bug by moving the initialization of CFNumber constants to a new function, __CFNumberInitialize(), which is called after the Swift bridge is initialized. This patch is enabled but should not regress non-Swift builds.

CFNull and CFBooleans are instantiated before __CFInitializeSwift() is called; if these types are ever bridged then a similar fix must be made.