### PR TITLE
Add a missing constructor for NSString

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -1232,6 +1232,13 @@ extension NSString {
         NSUnimplemented()    
     }
     
+    public convenience init(format: NSString, _ args: CVarArgType...) {
+        let str = withVaList(args) { (vaPtr) -> CFString! in
+            CFStringCreateWithFormatAndArguments(kCFAllocatorSystemDefault, nil, format._cfObject, vaPtr)
+        }
+        self.init(str._swiftObject)
+    }
+    
     public convenience init?(data: NSData, encoding: UInt) {
         self.init(bytes: data.bytes, length: data.length, encoding: encoding)
     }

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -49,6 +49,7 @@ class TestNSString : XCTestCase {
             ("test_completePathIntoString", test_completePathIntoString),
             ("test_stringByTrimmingCharactersInSet", test_stringByTrimmingCharactersInSet),
             ("test_initializeWithFormat", test_initializeWithFormat),
+            ("test_initializeWithFormat2", test_initializeWithFormat2),
             ("test_stringByDeletingLastPathComponent", test_stringByDeletingLastPathComponent),
             ("test_getCString_simple", test_getCString_simple),
             ("test_getCString_nonASCII_withASCIIAccessor", test_getCString_nonASCII_withASCIIAccessor),
@@ -508,6 +509,12 @@ class TestNSString : XCTestCase {
             let string = NSString(format: "Value is %d (%.1f)", arguments: pointer)
             XCTAssertEqual(string, "Value is 42 (42.0)")
         }
+    }
+    
+    func test_initializeWithFormat2() {
+        let argument: UInt8 = 75
+        let string = NSString(format: "%02X", argument)
+        XCTAssertEqual(string, "4B")
     }
     
     func test_stringByDeletingLastPathComponent() {


### PR DESCRIPTION
On Darwin we can do

    let argument: UInt8 = 75
    let string = NSString(format: "%02X", argument)

This is because Darwin NSString has constructor

    public convenience init(format: NSString, _ args: CVarArgType...)

This patch adds, implements, and tests this constructor.