### PR TITLE
Fixes and improvements for NSURL

### DIFF
--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -120,7 +120,13 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
         if thePath.hasSuffix("/") {
             isDir = true
         } else {
-            NSFileManager.defaultManager().fileExistsAtPath(path, isDirectory: &isDir)
+            let absolutePath: String
+            if let absPath = baseURL?.URLByAppendingPathComponent(path)?.path {
+                absolutePath = absPath
+            } else {
+                absolutePath = path
+            }
+            NSFileManager.defaultManager().fileExistsAtPath(absolutePath, isDirectory: &isDir)
         }
 
         self.init(fileURLWithPath: thePath, isDirectory: isDir, relativeToURL: baseURL)
@@ -144,8 +150,10 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
     }
     
     public init(fileURLWithFileSystemRepresentation path: UnsafePointer<Int8>, isDirectory isDir: Bool, relativeToURL baseURL: NSURL?) {
-        // TODO: Not sure if this one is required
-        NSUnimplemented()
+        super.init()
+        var pathString = String.fromCString(path)!
+        pathString = _standardizedPath(pathString)
+        _CFURLInitWithFileSystemPathRelativeToBase(_cfObject, pathString._cfObject, .CFURLPOSIXPathStyle, isDir, baseURL?._cfObject)
     }
     
     public convenience init?(string URLString: String) {
@@ -338,8 +346,22 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
     
     /* Returns the URL's path in file system representation. File system representation is a null-terminated C string with canonical UTF-8 encoding. The returned C string will be automatically freed just as a returned object would be released; your code should copy the representation or use getFileSystemRepresentation:maxLength: if it needs to store the representation outside of the autorelease context in which the representation is created.
     */
+    
+    // Memory leak. See https://github.com/apple/swift-corelibs-foundation/blob/master/Docs/Issues.md
     public var fileSystemRepresentation: UnsafePointer<Int8> {
-        NSUnimplemented()
+        
+        let bufSize = Int(PATH_MAX + 1)
+        
+        let _fsrBuffer = UnsafeMutablePointer<Int8>.alloc(bufSize)
+        for i in 0..<bufSize {
+            _fsrBuffer.advancedBy(i).initialize(0)
+        }
+        
+        if getFileSystemRepresentation(_fsrBuffer, maxLength: bufSize) {
+            return UnsafePointer(_fsrBuffer)
+        }
+
+        return nil
     }
     
     // Whether the scheme is file:; if [myURL isFileURL] is YES, then [myURL path] is suitable for input into NSFileManager or NSPathUtilities.

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -149,11 +149,9 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
         self.init(fileURLWithPath: thePath, isDirectory: isDir, relativeToURL: nil)
     }
     
-    public init(fileURLWithFileSystemRepresentation path: UnsafePointer<Int8>, isDirectory isDir: Bool, relativeToURL baseURL: NSURL?) {
-        super.init()
-        var pathString = String.fromCString(path)!
-        pathString = _standardizedPath(pathString)
-        _CFURLInitWithFileSystemPathRelativeToBase(_cfObject, pathString._cfObject, .CFURLPOSIXPathStyle, isDir, baseURL?._cfObject)
+    public convenience init(fileURLWithFileSystemRepresentation path: UnsafePointer<Int8>, isDirectory isDir: Bool, relativeToURL baseURL: NSURL?) {
+        let pathString = String.fromCString(path)!
+        self.init(fileURLWithPath: pathString, isDirectory: isDir, relativeToURL: baseURL)
     }
     
     public convenience init?(string URLString: String) {

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -80,7 +80,7 @@ class TestNSURL : XCTestCase {
         #if os(OSX)
         let baseURL = NSURL(fileURLWithPath: homeDirectory, isDirectory: true)
         let relativePath = "Documents"
-        #else
+        #elseif os(Linux)
         let baseURL = NSURL(fileURLWithPath: "/usr", isDirectory: true)
         let relativePath = "include"
         #endif

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -73,19 +73,26 @@ class TestNSURL : XCTestCase {
     func test_fileURLWithPath_relativeToURL() {
         let homeDirectory = NSHomeDirectory()
         XCTAssertNotNil(homeDirectory, "Failed to find home directory")
-        let baseURL = NSURL(fileURLWithPath: homeDirectory, isDirectory: true)
-        XCTAssertNotNil(baseURL, "fileURLWithPath:isDirectory: failed")
-        XCTAssertEqual(homeDirectory, baseURL.path)
+        let homeURL = NSURL(fileURLWithPath: homeDirectory, isDirectory: true)
+        XCTAssertNotNil(homeURL, "fileURLWithPath:isDirectory: failed")
+        XCTAssertEqual(homeDirectory, homeURL.path)
 
+        #if os(OSX)
+        let baseURL = NSURL(fileURLWithPath: homeDirectory, isDirectory: true)
+        let relativePath = "Documents"
+        #else
+        let baseURL = NSURL(fileURLWithPath: "/usr", isDirectory: true)
+        let relativePath = "include"
+        #endif
         // we're telling fileURLWithPath:isDirectory:relativeToURL: Documents is a directory
-        let url1 = NSURL(fileURLWithFileSystemRepresentation: "Documents", isDirectory: true, relativeToURL: baseURL)
+        let url1 = NSURL(fileURLWithFileSystemRepresentation: relativePath, isDirectory: true, relativeToURL: baseURL)
         XCTAssertNotNil(url1, "fileURLWithPath:isDirectory:relativeToURL: failed")
         // we're letting fileURLWithPath:relativeToURL: determine Documents is a directory with I/O
-        let url2 = NSURL(fileURLWithPath: "Documents", relativeToURL: baseURL)
+        let url2 = NSURL(fileURLWithPath: relativePath, relativeToURL: baseURL)
         XCTAssertNotNil(url2, "fileURLWithPath:relativeToURL: failed")
         XCTAssertEqual(url1, url2, "\(url1) was not equal to \(url2)")
         // we're telling fileURLWithPath:relativeToURL: Documents is a directory with a trailing slash
-        let url3 = NSURL(fileURLWithPath: "Documents/", relativeToURL: baseURL)
+        let url3 = NSURL(fileURLWithPath: relativePath + "/", relativeToURL: baseURL)
         XCTAssertNotNil(url3, "fileURLWithPath:relativeToURL: failed")
         XCTAssertEqual(url1, url3, "\(url1) was not equal to \(url3)")
     }

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -77,15 +77,15 @@ class TestNSURL : XCTestCase {
         XCTAssertNotNil(baseURL, "fileURLWithPath:isDirectory: failed")
         XCTAssertEqual(homeDirectory, baseURL.path)
 
-        // we're telling fileURLWithPath:isDirectory:relativeToURL: Library is a directory
-        let url1 = NSURL(fileURLWithFileSystemRepresentation: "Library", isDirectory: true, relativeToURL: baseURL)
+        // we're telling fileURLWithPath:isDirectory:relativeToURL: Documents is a directory
+        let url1 = NSURL(fileURLWithFileSystemRepresentation: "Documents", isDirectory: true, relativeToURL: baseURL)
         XCTAssertNotNil(url1, "fileURLWithPath:isDirectory:relativeToURL: failed")
-        // we're letting fileURLWithPath:relativeToURL: determine Library is a directory with I/O
-        let url2 = NSURL(fileURLWithPath: "Library", relativeToURL: baseURL)
+        // we're letting fileURLWithPath:relativeToURL: determine Documents is a directory with I/O
+        let url2 = NSURL(fileURLWithPath: "Documents", relativeToURL: baseURL)
         XCTAssertNotNil(url2, "fileURLWithPath:relativeToURL: failed")
         XCTAssertEqual(url1, url2, "\(url1) was not equal to \(url2)")
-        // we're telling fileURLWithPath:relativeToURL: Library is a directory with a trailing slash
-        let url3 = NSURL(fileURLWithPath: "Library/", relativeToURL: baseURL)
+        // we're telling fileURLWithPath:relativeToURL: Documents is a directory with a trailing slash
+        let url3 = NSURL(fileURLWithPath: "Documents/", relativeToURL: baseURL)
         XCTAssertNotNil(url3, "fileURLWithPath:relativeToURL: failed")
         XCTAssertEqual(url1, url3, "\(url1) was not equal to \(url3)")
     }


### PR DESCRIPTION
Implement `NSURL.fileSystemRepresentation` and `init(fileURLWithFileSystemRepresentation: isDirectory: relativeToURL)`.
Fix `init(fileURLWithFileSystemRepresentation: isDirectory: relativeToURL)`
Reenable tests for `NSURL`.