### PR TITLE
[configure] Refactor to be compatible with Python 2 or 3

### DIFF
--- a/configure
+++ b/configure
@@ -175,7 +175,7 @@ def main():
     config.write(config.config_path.absolute())
     Configuration.current = config
 
-    execfile(config.script_path.absolute())
+    exec(compile(open(config.script_path.absolute()).read(), config.script_path.absolute(), 'exec'))
 
 
 if __name__ == "__main__":

--- a/lib/config.py
+++ b/lib/config.py
@@ -9,7 +9,7 @@
 
 import json
 
-from path import Path
+from .path import Path
 
 class Configuration:
     Debug = "debug"

--- a/lib/phases.py
+++ b/lib/phases.py
@@ -7,9 +7,9 @@
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 
-from config import Configuration
-from target import TargetConditional
-from path import Path
+from .config import Configuration
+from .target import TargetConditional
+from .path import Path
 import os
 
 class BuildAction:

--- a/lib/product.py
+++ b/lib/product.py
@@ -7,14 +7,14 @@
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 
-from config import Configuration
-from phases import CompileC
-from phases import CompileCxx
-from phases import Assemble
-from phases import BuildAction
-from phases import MergeSwiftModule
-from target import OSType
-from path import Path
+from .config import Configuration
+from .phases import CompileC
+from .phases import CompileCxx
+from .phases import Assemble
+from .phases import BuildAction
+from .phases import MergeSwiftModule
+from .target import OSType
+from .path import Path
 
 import os
 

--- a/lib/script.py
+++ b/lib/script.py
@@ -7,7 +7,7 @@
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 
-from config import Configuration
+from .config import Configuration
 import os
 
 class Script:
@@ -31,7 +31,7 @@ class Script:
 
     def generate_products(self):
         variables = ""
-        for key, val in Configuration.current.variables.iteritems():
+        for key, val in Configuration.current.variables.items():
             variables += key + "=" + val
         variables += "\n"
         verbose_flags = """

--- a/lib/target.py
+++ b/lib/target.py
@@ -7,7 +7,7 @@
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 
-from config import Configuration
+from .config import Configuration
 import platform
 
 class ArchType:

--- a/lib/workspace.py
+++ b/lib/workspace.py
@@ -8,8 +8,8 @@
 #
 
 from subprocess import call
-from config import Configuration
-from path import Path
+from .config import Configuration
+from .path import Path
 import os
 
 class Workspace:
@@ -36,8 +36,8 @@ class Workspace:
 
             if Configuration.current.verbose:
                 cmd.append("--verbose")
-                print "cd " + working_dir
-                print "    " + " ".join(cmd)
+                print("cd " + working_dir)
+                print("    " + " ".join(cmd))
             status = call(cmd, cwd=working_dir)
             if status != 0:
                 exit(status) # pass the exit value along if one of the sub-configurations fails


### PR DESCRIPTION
Other projects have asked that their Python enabled scripts were refactored to be compatible with Python 2 or 3. This patch continues that vein in the `corelibs-foundation` project.
