### PR TITLE
[SR-272] make _cfTypeID public for now

### DIFF
--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -523,7 +523,7 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
     public convenience init?(contentsOfFile path: String) { NSUnimplemented() }
     public convenience init?(contentsOfURL url: NSURL) { NSUnimplemented() }
     
-    override internal var _cfTypeID: CFTypeID {
+    override public var _cfTypeID: CFTypeID {
         return CFArrayGetTypeID()
     }
 }

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -206,7 +206,7 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         return "<\(byteDescription())>"
     }
     
-    override internal var _cfTypeID: CFTypeID {
+    override public var _cfTypeID: CFTypeID {
         return CFDataGetTypeID()
     }
 }

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -137,7 +137,7 @@ public class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
         return CFDateFormatterCreateStringWithDate(kCFAllocatorSystemDefault, dateFormatterRef, _cfObject)._swiftObject
     }
     
-    override internal var _cfTypeID: CFTypeID {
+    override public var _cfTypeID: CFTypeID {
         return CFDateGetTypeID()
     }
 }

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -492,7 +492,7 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         return matching
     }
     
-    override internal var _cfTypeID: CFTypeID {
+    override public var _cfTypeID: CFTypeID {
         return CFDictionaryGetTypeID()
     }
     

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -400,7 +400,7 @@ public class NSNumber : NSValue {
         return ._fromCF(CFNumberCompare(_cfObject, otherNumber._cfObject, nil))
     }
     
-    override internal var _cfTypeID: CFTypeID {
+    override public var _cfTypeID: CFTypeID {
         return CFNumberGetTypeID()
     }
     

--- a/Foundation/NSObject.swift
+++ b/Foundation/NSObject.swift
@@ -115,7 +115,7 @@ public class NSObject : NSObjectProtocol {
         }
     }
     
-    internal var _cfTypeID: CFTypeID {
+    public var _cfTypeID: CFTypeID {
         return 0
     }
 }

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -146,7 +146,7 @@ public class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
     
     public func descriptionWithLocale(locale: AnyObject?) -> String { NSUnimplemented() }
     
-    override internal var _cfTypeID: CFTypeID {
+    override public var _cfTypeID: CFTypeID {
         return CFSetGetTypeID()
     }
 

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -317,7 +317,7 @@ public class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, N
         return false
     }
     
-    override internal var _cfTypeID: CFTypeID {
+    override public var _cfTypeID: CFTypeID {
         return CFStringGetTypeID()
     }
   

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -366,7 +366,7 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
         NSUnimplemented()
     }
     
-    override internal var _cfTypeID: CFTypeID {
+    override public var _cfTypeID: CFTypeID {
         return CFURLGetTypeID()
     }
 }


### PR DESCRIPTION
The _cfTypeID property in NSObject was marked internal, which currently breaks subclassing Foundation classes on Linux. Marking it public for now per comment from @jrose-apple in bug report.