### PR TITLE
Improve NSString.completePathIntoString

### DIFF
--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -446,13 +446,14 @@ public extension NSString {
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
     public func completePathIntoString(inout outputName: NSString?, caseSensitive flag: Bool, inout matchesIntoArray outputArray: [NSString], filterTypes: [String]?) -> Int {
-        guard !_storage.isEmpty else {
+        let path = _swiftObject
+        guard !path.isEmpty else {
             return 0
         }
         
-        let url = NSURL(fileURLWithPath: _storage)
+        let url = NSURL(fileURLWithPath: path)
         
-        let searchAllFilesInDirectory = _stringIsPathToDirectory(_storage)
+        let searchAllFilesInDirectory = _stringIsPathToDirectory(path)
         let namePrefix = searchAllFilesInDirectory ? nil : url.lastPathComponent
         let checkFileName = _getFileNamePredicate(namePrefix, caseSensetive: flag)
         let checkExtension = _getExtensionPredicate(filterTypes, caseSensetive: flag)
@@ -473,7 +474,7 @@ public extension NSString {
             }
         }
         
-        let commonPath = searchAllFilesInDirectory ? _storage : _ensureLastPathSeparator(stringByDeletingLastPathComponent)
+        let commonPath = searchAllFilesInDirectory ? path : _ensureLastPathSeparator(stringByDeletingLastPathComponent)
         
         if searchAllFilesInDirectory {
             outputName = "/"

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -483,10 +483,10 @@ extension NSURL {
     }
     
     public var URLByResolvingSymlinksInPath: NSURL? {
-        return _resolveSymlinksInPath(self, keepSystemDirs: false)
+        return _resolveSymlinksInPath(self, excludeSystemDirs: true)
     }
     
-    internal func _resolveSymlinksInPath(filePathURL: NSURL, keepSystemDirs: Bool) -> NSURL? {
+    internal func _resolveSymlinksInPath(filePathURL: NSURL, excludeSystemDirs: Bool) -> NSURL? {
         guard fileURL else {
             return NSURL(string: absoluteString!)
         }
@@ -530,16 +530,8 @@ extension NSURL {
         var isExistingDirectory = false
         NSFileManager.defaultManager().fileExistsAtPath(resolvedPath, isDirectory: &isExistingDirectory)
         
-        if !keepSystemDirs {
-            let privatePrefix = "/private"
-            
-            if resolvedPath.hasPrefix(privatePrefix) && resolvedPath != privatePrefix {
-                var temp = resolvedPath
-                temp.removeRange(resolvedPath.startIndex..<privatePrefix.endIndex)
-                if NSFileManager.defaultManager().fileExistsAtPath(temp) {
-                    resolvedPath = temp
-                }
-            }
+        if excludeSystemDirs {
+            resolvedPath = resolvedPath._tryToRemovePathPrefix("/private") ?? resolvedPath
         }
         
         if isExistingDirectory && !resolvedPath.hasSuffix("/") {

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -120,7 +120,13 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
         if thePath.hasSuffix("/") {
             isDir = true
         } else {
-            NSFileManager.defaultManager().fileExistsAtPath(path, isDirectory: &isDir)
+            let absolutePath: String
+            if let absPath = baseURL?.URLByAppendingPathComponent(path)?.path {
+                absolutePath = absPath
+            } else {
+                absolutePath = path
+            }
+            NSFileManager.defaultManager().fileExistsAtPath(absolutePath, isDirectory: &isDir)
         }
 
         self.init(fileURLWithPath: thePath, isDirectory: isDir, relativeToURL: baseURL)

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -483,10 +483,10 @@ extension NSURL {
     }
     
     public var URLByResolvingSymlinksInPath: NSURL? {
-        return _resolveSymlinksInPath(self, excludeSystemDirs: true)
+        return _resolveSymlinksInPath(excludeSystemDirs: true)
     }
     
-    internal func _resolveSymlinksInPath(filePathURL: NSURL, excludeSystemDirs: Bool) -> NSURL? {
+    internal func _resolveSymlinksInPath(excludeSystemDirs excludeSystemDirs: Bool) -> NSURL? {
         guard fileURL else {
             return NSURL(string: absoluteString!)
         }

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -385,11 +385,45 @@ class TestNSString : XCTestCase {
             var matches: [NSString] = []
             let count = path.completePathIntoString(&outName, caseSensitive: false, matchesIntoArray: &matches, filterTypes: nil)
             let content = try NSFileManager.defaultManager().contentsOfDirectoryAtURL(NSURL(string: path.bridge())!, includingPropertiesForKeys: nil, options: [])
-            XCTAssert(outName == path, "If NSString is valid path to directory then outName is string itself.")
+            XCTAssert(outName == "/", "If NSString is valid path to directory which has '/' suffix then outName is '/'.")
             // This assert fails on CI; https://bugs.swift.org/browse/SR-389
 //            XCTAssert(matches.count == content.count && matches.count == count, "If NSString is valid path to directory then matches contain all content of directory. expected \(content) but got \(matches)")
         } catch {
             XCTAssert(false, "Could not finish test due to error")
+        }
+        
+        do {
+            let path: NSString = "/tmp"
+            var outName: NSString?
+            var matches: [NSString] = []
+            let count = path.completePathIntoString(&outName, caseSensitive: false, matchesIntoArray: &matches, filterTypes: nil)
+            let urlToTmp = NSURL(fileURLWithPath: "/private/tmp/").URLByStandardizingPath!
+            let content = try NSFileManager.defaultManager().contentsOfDirectoryAtURL(urlToTmp, includingPropertiesForKeys: nil, options: [])
+            XCTAssert(outName == "/tmp/", "If path could be completed to existing directory then outName is a string itself plus '/'.")
+            // This assert fails on CI; https://bugs.swift.org/browse/SR-389
+            //            XCTAssert(matches.count == content.count && matches.count == count, "If NSString is valid path to directory then matches contain all content of directory. expected \(content) but got \(matches)")
+        } catch {
+            XCTAssert(false, "Could not finish test due to error")
+        }
+        
+        let fileNames2 = [
+            "/tmp/ABC",
+            "/tmp/ABCD",
+            "/tmp/abcde"
+        ]
+        
+        guard ensureFiles(fileNames2) else {
+            XCTAssert(false, "Could not create temp files for testing.")
+            return
+        }
+        
+        do {
+            let path: NSString = tmpPath("ABC")
+            var outName: NSString?
+            var matches: [NSString] = []
+            let count = path.completePathIntoString(&outName, caseSensitive: false, matchesIntoArray: &matches, filterTypes: nil)
+            XCTAssert(outName == path, "If NSString is valid path to directory then outName is string itself.")
+            XCTAssert(matches.count == count && count == fileNames2.count, "")
         }
         
         do {

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -407,8 +407,8 @@ class TestNSString : XCTestCase {
         }
         
         let fileNames2 = [
-            "/tmp/ABC",
-            "/tmp/ABCD",
+            "/tmp/ABC/",
+            "/tmp/ABCD/",
             "/tmp/abcde"
         ]
         

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -422,7 +422,7 @@ class TestNSString : XCTestCase {
             var outName: NSString?
             var matches: [NSString] = []
             let count = path.completePathIntoString(&outName, caseSensitive: false, matchesIntoArray: &matches, filterTypes: nil)
-            XCTAssert(outName == path, "If NSString is valid path to directory then outName is string itself.")
+            XCTAssert(stringsAreCaseInsensitivelyEqual(outName!, path), "If NSString is valid path to directory then outName is string itself.")
             XCTAssert(matches.count == count && count == fileNames2.count, "")
         }
         
@@ -431,7 +431,7 @@ class TestNSString : XCTestCase {
             var outName: NSString?
             var matches: [NSString] = []
             let count = path.completePathIntoString(&outName, caseSensitive: true, matchesIntoArray: &matches, filterTypes: nil)
-            XCTAssert(stringsAreCaseInsensitivelyEqual(outName!, path), "If NSString is valid path to file and search is case sensitive then outName is string itself.")
+            XCTAssert(outName == path, "If NSString is valid path to file and search is case sensitive then outName is string itself.")
             XCTAssert(matches.count == 1 && count == 1 && stringsAreCaseInsensitivelyEqual(matches[0], path), "If NSString is valid path to file and search is case sensitive then matches contain that file path only")
         }
         

--- a/TestFoundation/TestUtils.swift
+++ b/TestFoundation/TestUtils.swift
@@ -23,21 +23,30 @@ func ensureFiles(fileNames: [String]) -> Bool {
             continue
         }
         
-        var isDir: ObjCBool = false
-        let dir = name.bridge().stringByDeletingLastPathComponent
-        if !fm.fileExistsAtPath(dir, isDirectory: &isDir) {
+        if name.hasSuffix("/") {
             do {
-                try fm.createDirectoryAtPath(dir, withIntermediateDirectories: true, attributes: nil)
+                try fm.createDirectoryAtPath(name, withIntermediateDirectories: true, attributes: nil)
             } catch let err {
                 print(err)
                 return false
             }
-        } else if !isDir {
-            return false
+        } else {
+        
+            var isDir: ObjCBool = false
+            let dir = name.bridge().stringByDeletingLastPathComponent
+            if !fm.fileExistsAtPath(dir, isDirectory: &isDir) {
+                do {
+                    try fm.createDirectoryAtPath(dir, withIntermediateDirectories: true, attributes: nil)
+                } catch let err {
+                    print(err)
+                    return false
+                }
+            } else if !isDir {
+                return false
+            }
+            
+            result = result && fm.createFileAtPath(name, contents: nil, attributes: nil)
         }
-        
-        
-        result = result && fm.createFileAtPath(name, contents: nil, attributes: nil)
     }
     return result
 }


### PR DESCRIPTION
Now it works with relative paths, symlinks etc. 
Fix behavior when string point to a directory and there are other directories and(or) files with similar names. Previously it searches for all items in directory always. Now if there is no trailing `/` it starts from the parent directory.