### PR TITLE
Don't lose userInfo when converting CFError to NSError

### DIFF
--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -155,7 +155,15 @@ extension NSError : _CFBridgable { }
 extension CFErrorRef : _NSBridgable {
     typealias NSType = NSError
     internal var _nsObject: NSType {
-        return NSError(domain: CFErrorGetDomain(self)._swiftObject, code: CFErrorGetCode(self), userInfo: nil)
+        let userInfo = CFErrorCopyUserInfo(self)._swiftObject
+        var newUserInfo: [String: Any] = [:]
+        for (key, value) in userInfo {
+            if let key = key as? NSString {
+                newUserInfo[key._swiftObject] = value
+            }
+        }
+
+        return NSError(domain: CFErrorGetDomain(self)._swiftObject, code: CFErrorGetCode(self), userInfo: newUserInfo)
     }
 }
 


### PR DESCRIPTION
Came upon this when adding some more implementation to NSXMLDocument.