### PR TITLE
NSExpression initial implementation. With unit tests.

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 		5BF7AEBF1BCD51F9008F214A /* NSURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4A1BCC5DCB00ED97BB /* NSURL.swift */; };
 		5BF7AEC01BCD51F9008F214A /* NSUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4B1BCC5DCB00ED97BB /* NSUUID.swift */; };
 		5BF7AEC11BCD51F9008F214A /* NSValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4C1BCC5DCB00ED97BB /* NSValue.swift */; };
+		5BFF7A2D1C3EBB29008C000C /* TestNSExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFF7A2C1C3EBB29008C000C /* TestNSExpression.swift */; };
 		5E5835F41C20C9B500C81317 /* TestNSThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5835F31C20C9B500C81317 /* TestNSThread.swift */; };
 		5EF673AC1C28B527006212A3 /* TestNSNotificationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF673AB1C28B527006212A3 /* TestNSNotificationQueue.swift */; };
 		612952F91C1B235900BE0FD9 /* TestNSNull.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612952F81C1B235900BE0FD9 /* TestNSNull.swift */; };
@@ -557,6 +558,7 @@
 		5BDC3FCF1BCF17E600ED97BB /* NSCFSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSCFSet.swift; sourceTree = "<group>"; };
 		5BDC405C1BD6D83B00ED97BB /* TestFoundation.app */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestFoundation.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BF7AEC21BCD568D008F214A /* ForSwiftFoundationOnly.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ForSwiftFoundationOnly.h; sourceTree = "<group>"; };
+		5BFF7A2C1C3EBB29008C000C /* TestNSExpression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSExpression.swift; sourceTree = "<group>"; };
 		5E5835F31C20C9B500C81317 /* TestNSThread.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSThread.swift; sourceTree = "<group>"; };
 		5EB6A15C1C188FC40037DCB8 /* TestNSJSONSerialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSJSONSerialization.swift; sourceTree = "<group>"; };
 		5EF673AB1C28B527006212A3 /* TestNSNotificationQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSNotificationQueue.swift; sourceTree = "<group>"; };
@@ -1078,6 +1080,7 @@
 				52829AD61C160D64003BC4EF /* TestNSCalendar.swift */,
 				5BC1D8BC1BF3ADFE009D3973 /* TestNSCharacterSet.swift */,
 				EA66F63D1BF1619600136161 /* TestNSDictionary.swift */,
+				5BFF7A2C1C3EBB29008C000C /* TestNSExpression.swift */,
 				525AECEB1BF2C96400D15BB0 /* TestNSFileManager.swift */,
 				88D28DE61C13AE9000494606 /* TestNSGeometry.swift */,
 				848A30571C137B3500C83206 /* TestNSHTTPCookie.swift */,
@@ -1821,6 +1824,7 @@
 				8460AACC1C3307D800B01413 /* TestUtils.swift in Sources */,
 				E876A73E1C1180E000F279EC /* TestNSRange.swift in Sources */,
 				5E5835F41C20C9B500C81317 /* TestNSThread.swift in Sources */,
+				5BFF7A2D1C3EBB29008C000C /* TestNSExpression.swift in Sources */,
 				C2A9D75C1C15C08B00993803 /* TestNSUUID.swift in Sources */,
 				A5A34B561C18C85D00FD972B /* TestNSByteCountFormatter.swift in Sources */,
 				612952F91C1B235900BE0FD9 /* TestNSNull.swift in Sources */,
@@ -1849,7 +1853,6 @@
 				6E203B8D1C1303BB003B2576 /* TestNSBundle.swift in Sources */,
 				88D28DE71C13AE9000494606 /* TestNSGeometry.swift in Sources */,
 				EA66F64C1BF1619600136161 /* TestNSDictionary.swift in Sources */,
-				ED58F76F1C134B3A00E6A5BE /* (null) in Sources */,
 				AA664D4F1C1B03CA00C22186 /* TestNSNumberFormatter.swift in Sources */,
 				EA66F6581BF1619600136161 /* TestNSURL.swift in Sources */,
 				61D6C9EF1C1DFE9500DEF583 /* TestNSTimer.swift in Sources */,

--- a/Foundation/NSExpression.swift
+++ b/Foundation/NSExpression.swift
@@ -11,7 +11,7 @@
 // Expressions are the core of the predicate implementation. When expressionValueWithObject: is called, the expression is evaluated, and a value returned which can then be handled by an operator. Expressions can be anything from constants to method invocations. Scalars should be wrapped in appropriate NSValue classes.
 
 public enum NSExpressionType : UInt {
-    
+
     case ConstantValueExpressionType // Expression that always returns the same value
     case EvaluatedObjectExpressionType // Expression that always returns the parameter object itself
     case VariableExpressionType // Expression that always returns whatever is stored at 'variable' in the bindings dictionary
@@ -28,40 +28,152 @@ public enum NSExpressionType : UInt {
 }
 
 public class NSExpression : NSObject, NSSecureCoding, NSCopying {
+    public typealias ExpressionBlockType = (AnyObject?, [AnyObject], NSMutableDictionary?) -> AnyObject?
+    internal typealias EvaluateBlockType = (AnyObject?, NSMutableDictionary?) -> AnyObject?
+    internal typealias SubstituteBlockType = (NSMutableDictionary) -> NSExpression
     
+    internal var _evaluationBlock:EvaluateBlockType
+    internal var _substitutionVariablesBlock:SubstituteBlockType?
+    internal var _constantValue:AnyObject?
+    internal var _keyPath: String?
+    internal var _function: String?
+    internal var _variable: String?
+    internal var _operand: NSExpression?
+    internal var _arguments: [NSExpression]?
+    internal var _collection: [NSExpression]?
+    internal var _predicate: NSPredicate?
+    internal var _leftExpression: NSExpression?
+    internal var _rightExpression: NSExpression?
+    internal var _trueExpression: NSExpression?
+    internal var _falseExpression: NSExpression?
+    internal var _expressionBlock: ExpressionBlockType?
+
+    public var expressionType:NSExpressionType
+
     public static func supportsSecureCoding() -> Bool {
         return true
     }
-    
+
     public required init?(coder aDecoder: NSCoder) {
         NSUnimplemented()
     }
-    
+
     public func encodeWithCoder(aCoder: NSCoder) {
         NSUnimplemented()
     }
-    
+
     public override func copy() -> AnyObject {
         return copyWithZone(nil)
     }
-    
+
     public func copyWithZone(zone: NSZone) -> AnyObject {
         NSUnimplemented()
     }
 
-    public /*not inherited*/ init(format expressionFormat: String, argumentArray arguments: [AnyObject]) { NSUnimplemented() }
-    
-    public /*not inherited*/ init(forConstantValue obj: AnyObject?) { NSUnimplemented() } // Expression that returns a constant value
-    public class func expressionForEvaluatedObject() -> NSExpression { NSUnimplemented() } // Expression that returns the object being evaluated
-    public /*not inherited*/ init(forVariable string: String) { NSUnimplemented() } // Expression that pulls a value from the variable bindings dictionary
-    public /*not inherited*/ init(forKeyPath keyPath: String) { NSUnimplemented() } // Expression that invokes valueForKeyPath with keyPath
-    public /*not inherited*/ init(forFunction name: String, arguments parameters: [AnyObject]) { NSUnimplemented() } // Expression that invokes one of the predefined functions. Will throw immediately if the selector is bad; will throw at runtime if the parameters are incorrect.
+    public /*not inherited*/ init(format expressionFormat: String, argumentArray arguments: [AnyObject]) {
+        NSUnimplemented()
+    }
+
+    private init(type:NSExpressionType, evaluation:EvaluateBlockType, substitution:SubstituteBlockType?=nil) {
+        expressionType = type
+        _evaluationBlock = evaluation
+        _substitutionVariablesBlock = substitution
+
+        super.init()
+    }
+
+    public convenience init(forConstantValue value: AnyObject?) {
+        self.init(type:.ConstantValueExpressionType, evaluation:{_,_ in return value})
+
+        _constantValue = value
+    } // Expression that returns a constant value
+
+    public class func expressionForEvaluatedObject() -> NSExpression {
+        return NSExpression(type:.EvaluatedObjectExpressionType, evaluation:{o,_ in return o})
+    } // Expression that returns the object being evaluated
+
+    public convenience init(forVariable aVariable: String) {
+        let evaluationBlock:EvaluateBlockType = {obj,bindings in
+            guard let exp = bindings?.objectForKey(aVariable.bridge()) as? NSExpression else {
+                preconditionFailure("Cannot find variable \(aVariable) in \(bindings)")
+            }
+
+            return exp.expressionValueWithObject(obj, context: bindings)
+        }
+
+        let substitutionVariablesBlock:SubstituteBlockType = {bindings in
+            guard let exp = bindings.objectForKey(aVariable.bridge()) as? NSExpression else {
+                preconditionFailure("Cannot find variable in \(bindings)")
+            }
+
+            return exp
+        }
+
+        self.init(type:.VariableExpressionType, evaluation:evaluationBlock, substitution:substitutionVariablesBlock)
+
+        self._variable = aVariable
+    } // Expression that pulls a value from the variable bindings dictionary
+
+    public convenience init(forKeyPath keyPath: String) {
+        let evaluationBlock:EvaluateBlockType = {obj,_ in
+            // TODO: Change NSObjectProtocol to whatever protocol -valueForKeyPath() belongs to.
+            guard let o = obj where o is NSObjectProtocol else {
+                return nil
+            }
+
+            // TODO: depends on NSObject -valueForKeyPath implementation
+            //return o.valueForKeyPath(keyPath)
+            NSUnimplemented()
+        }
+
+        self.init(type:.KeyPathExpressionType, evaluation:evaluationBlock)
+
+        _keyPath = keyPath
+
+    } // Expression that invokes valueForKeyPath with keyPath
+
+    public convenience init?(forFunction name: String, arguments parameters: [NSExpression]) {
+
+        guard let fn = _NSExpressionFunctions[name] else {
+            // TODO: failable init. Decide if we should throw instead. (Apple Foundation throws an Exception)
+            return nil
+        }
+
+        let evaluationBlock:EvaluateBlockType = {obj, bindings in
+            var result:AnyObject?
+            let args = parameters.expressionValueWithObject(obj, context: bindings)
+
+            do {
+                 result = try _invokeFunction(fn, with:args)
+            } catch let NSExpressionError.InvalidArgumentType(expected: type){
+                // TODO: Decide if we should throw instead. (Apple Foundation throws an Exception)
+                print("InvalidArgumentType \(args.dynamicType), function \(name) expects \(type)")
+                result = nil
+            } catch {
+
+            }
+
+            return result
+        }
+
+        let substitutionVariablesBlock:SubstituteBlockType = {bindings in
+            let subst = parameters.map{$0.expressionWithSubstitutionVariables(bindings)}
+
+            return NSExpression(forFunction: name, arguments: subst)!
+        }
+
+        self.init(type:.FunctionExpressionType, evaluation:evaluationBlock, substitution:substitutionVariablesBlock)
+
+        _function = name
+        _arguments = parameters
+
+    } // Expression that invokes one of the predefined functions. Will throw immediately if the selector is bad; will throw at runtime if the parameters are incorrect.
     // Predefined functions are:
     // name              parameter array contents				returns
     //-------------------------------------------------------------------------------------------------------------------------------------
-    // sum:              NSExpression instances representing numbers		NSNumber 
-    // count:            NSExpression instances representing numbers		NSNumber 
-    // min:              NSExpression instances representing numbers		NSNumber  
+    // sum:              NSExpression instances representing numbers		NSNumber
+    // count:            NSExpression instances representing numbers		NSNumber
+    // min:              NSExpression instances representing numbers		NSNumber
     // max:              NSExpression instances representing numbers		NSNumber
     // average:          NSExpression instances representing numbers		NSNumber
     // median:           NSExpression instances representing numbers		NSNumber
@@ -81,56 +193,358 @@ public class NSExpression : NSObject, NSSecureCoding, NSCopying {
     // ceiling:          one NSExpression instance representing a number	NSNumber
     // abs:              one NSExpression instance representing a number	NSNumber
     // trunc:            one NSExpression instance representing a number	NSNumber
-    // uppercase:	 one NSExpression instance representing a string	NSString
-    // lowercase:	 one NSExpression instance representing a string	NSString
-    // random            none							NSNumber (integer) 
+    // uppercase:	     one NSExpression instance representing a string	NSString
+    // lowercase:	     one NSExpression instance representing a string	NSString
+    // random            none							                    NSNumber (integer)
     // randomn:          one NSExpression instance representing a number	NSNumber (integer) such that 0 <= rand < param
-    // now               none							[NSDate now]
+    // now               none							                    [NSDate now]
     // bitwiseAnd:with:	 two NSExpression instances representing numbers	NSNumber    (numbers will be treated as NSInteger)
     // bitwiseOr:with:	 two NSExpression instances representing numbers	NSNumber    (numbers will be treated as NSInteger)
     // bitwiseXor:with:	 two NSExpression instances representing numbers	NSNumber    (numbers will be treated as NSInteger)
     // leftshift:by:	 two NSExpression instances representing numbers	NSNumber    (numbers will be treated as NSInteger)
     // rightshift:by:	 two NSExpression instances representing numbers	NSNumber    (numbers will be treated as NSInteger)
     // onesComplement:	 one NSExpression instance representing a numbers	NSNumber    (numbers will be treated as NSInteger)
-    // noindex:		 an NSExpression					parameter   (used by CoreData to indicate that an index should be dropped)
+    // noindex:		     an NSExpression parameter (used by CoreData to indicate that an index should be dropped)
     // distanceToLocation:fromLocation:
     //                   two NSExpression instances representing CLLocations    NSNumber
     // length:           an NSExpression instance representing a string         NSNumber
-    
-    public /*not inherited*/ init(forAggregate subexpressions: [AnyObject]) { NSUnimplemented() } // Expression that returns a collection containing the results of other expressions
-    public /*not inherited*/ init(forUnionSet left: NSExpression, with right: NSExpression) { NSUnimplemented() } // return an expression that will return the union of the collections expressed by left and right
-    public /*not inherited*/ init(forIntersectSet left: NSExpression, with right: NSExpression) { NSUnimplemented() } // return an expression that will return the intersection of the collections expressed by left and right
-    public /*not inherited*/ init(forMinusSet left: NSExpression, with right: NSExpression) { NSUnimplemented() } // return an expression that will return the disjunction of the collections expressed by left and right
-    public /*not inherited*/ init(forSubquery expression: NSExpression, usingIteratorVariable variable: String, predicate: AnyObject) { NSUnimplemented() } // Expression that filters a collection by storing elements in the collection in the variable variable and keeping the elements for which qualifer returns true; variable is used as a local variable, and will shadow any instances of variable in the bindings dictionary, the variable is removed or the old value replaced once evaluation completes
-    public /*not inherited*/ init(forFunction target: NSExpression, selectorName name: String, arguments parameters: [AnyObject]?) { NSUnimplemented() } // Expression that invokes the selector on target with parameters. Will throw at runtime if target does not implement selector or if parameters are wrong.
+
+    public convenience init(forAggregate subexpressions: [NSExpression]) {
+        let evaluationBlock:EvaluateBlockType = {object, bindings in
+            return subexpressions.expressionValueWithObject(object, context: bindings).bridge()
+        }
+
+        let substitutionVariablesBlock:SubstituteBlockType = {bindings in
+            let subst = subexpressions.map{$0.expressionWithSubstitutionVariables(bindings)}
+            return NSExpression(forAggregate: subst)
+        }
+
+        self.init(type:.AggregateExpressionType, evaluation:evaluationBlock, substitution:substitutionVariablesBlock)
+
+        _collection = subexpressions
+    } // Expression that returns a collection containing the results of other expressions
+
+    internal typealias SetFunctionType = Set<NSObject> -> (Set<NSObject>) -> Set<NSObject>
+
+    internal convenience init(forSet type: NSExpressionType, left: NSExpression, with right: NSExpression, function:SetFunctionType, operation:String) {
+        let evaluationBlock:EvaluateBlockType = {obj,bindings in
+            guard let left_set = left.expressionValueWithObject(obj, context: bindings) as? NSSet else {
+                return nil
+            }
+
+            guard let right_set = right.expressionValueWithObject(obj, context: bindings) as? NSSet else {
+                // TODO: convert NSOrderedSet, NSDictionary, NSArray to (NS)Set
+                return nil
+            }
+
+            return function(left_set.bridge())(right_set.bridge()).bridge()
+        }
+
+        let substitutionVariablesBlock:SubstituteBlockType = {bindings in
+            let l = left.expressionWithSubstitutionVariables(bindings),
+                r = right.expressionWithSubstitutionVariables(bindings)
+
+            return NSExpression(forSet: type, left: l, with: r, function: function, operation: operation)
+        }
+
+        self.init(type:type, evaluation:evaluationBlock, substitution:substitutionVariablesBlock)
+
+        _leftExpression = left
+        _rightExpression = right
+    }
+
+    public convenience init(forUnionSet left: NSExpression, with right: NSExpression) {
+        self.init(forSet:.UnionSetExpressionType, left:left, with:right, function:Set.union, operation:"UNION")
+    } // return an expression that will return the union of the collections expressed by left and right
+    public convenience init(forIntersectSet left: NSExpression, with right: NSExpression) {
+        self.init(forSet:.IntersectSetExpressionType, left:left, with:right, function:Set.intersect, operation:"INTERSECT")
+    } // return an expression that will return the intersection of the collections expressed by left and right
+    public convenience init(forMinusSet left: NSExpression, with right: NSExpression) {
+        self.init(forSet:.MinusSetExpressionType, left:left, with:right, function:Set.subtract, operation:"MINUS")
+    } // return an expression that will return the disjunction of the collections expressed by left and right
+
+    // TODO: Subquery expression depends on NSPredicate implementation
+    public convenience init(forSubquery expression: NSExpression, usingIteratorVariable variable: String, predicate: NSPredicate) {
+        let evaluationBlock:EvaluateBlockType = {object, context in
+            guard let collection = expression.expressionValueWithObject(object, context: context) as? Array<AnyObject> else {
+                return nil
+            }
+
+            var context_dict:[String:AnyObject]
+
+            if let unwrapped = context {
+                context_dict = unwrapped as! Dictionary<String, AnyObject>
+                if context_dict[variable] == nil{
+                    context_dict[variable] = NSExpression.expressionForEvaluatedObject()
+                }
+            }else{
+                context_dict = [variable:NSExpression.expressionForEvaluatedObject()]
+            }
+
+            let result = collection.filter{predicate.evaluateWithObject($0, substitutionVariables:context_dict)}
+
+            return result.bridge()
+        }
+
+        let substitutionVariablesBlock:SubstituteBlockType = {bindings in
+            let exp = expression.expressionWithSubstitutionVariables(bindings)
+            let p = predicate.predicateWithSubstitutionVariables(bindings as! Dictionary<String,AnyObject>)
+
+            return NSExpression(forSubquery: exp, usingIteratorVariable: variable, predicate: p)
+        }
+
+        self.init(type:.SubqueryExpressionType, evaluation:evaluationBlock, substitution:substitutionVariablesBlock)
+
+        _variable = variable
+        _predicate = predicate
+        _collection = [expression]
+    } // Expression that filters a collection by storing elements in the collection in the variable variable and keeping the elements for which qualifer returns true; variable is used as a local variable, and will shadow any instances of variable in the bindings dictionary, the variable is removed or the old value replaced once evaluation completes
+    public /*not inherited*/ init(forFunction target: NSExpression, selectorName name: String, arguments parameters: [NSExpression]?) {
+        NSUnimplemented()
+    } // Expression that invokes the selector on target with parameters. Will throw at runtime if target does not implement selector or if parameters are wrong.
     public class func expressionForAnyKey() -> NSExpression { NSUnimplemented() }
-    public /*not inherited*/ init(forBlock block: (AnyObject?, [AnyObject], NSMutableDictionary?) -> AnyObject, arguments: [NSExpression]?) { NSUnimplemented() } // Expression that invokes the block with the parameters; note that block expressions are not encodable or representable as parseable strings.
-    public /*not inherited*/ init(forConditional predicate: NSPredicate, trueExpression: NSExpression, falseExpression: NSExpression) { NSUnimplemented() } // Expression that will return the result of trueExpression or falseExpression depending on the value of predicate
-    
-    public init(expressionType type: NSExpressionType) { NSUnimplemented() }
-    
-    // accessors for individual parameters - raise if not applicable
-    public var expressionType: NSExpressionType { NSUnimplemented() }
-    public var constantValue: AnyObject { NSUnimplemented() }
-    public var keyPath: String { NSUnimplemented() }
-    public var function: String { NSUnimplemented() }
-    public var variable: String { NSUnimplemented() }
-    /*@NSCopying*/ public var operand: NSExpression { NSUnimplemented() } // the object on which the selector will be invoked (the result of evaluating a key path or one of the defined functions)
-    public var arguments: [NSExpression]? { NSUnimplemented() } // array of expressions which will be passed as parameters during invocation of the selector on the operand of a function expression
-    
-    public var collection: AnyObject { NSUnimplemented() }
-    /*@NSCopying*/ public var predicate: NSPredicate { NSUnimplemented() }
-    /*@NSCopying*/ public var leftExpression: NSExpression { NSUnimplemented() } // expression which represents the left side of a set expression
-    /*@NSCopying*/ public var rightExpression: NSExpression { NSUnimplemented() } // expression which represents the right side of a set expression
-    
-    /*@NSCopying*/ public var trueExpression: NSExpression { NSUnimplemented() } // expression which will be evaluated if a conditional expression's predicate evaluates to true
-    /*@NSCopying*/ public var falseExpression: NSExpression { NSUnimplemented() } // expression which will be evaluated if a conditional expression's predicate evaluates to false
-    
-    public var expressionBlock: (AnyObject?, [AnyObject], NSMutableDictionary?) -> AnyObject { NSUnimplemented() }
-    
+
+    public convenience init(forBlock block: ExpressionBlockType, arguments: [NSExpression]?) {
+        let evaluationBlock:EvaluateBlockType = {object, context in
+            let args = arguments?.expressionValueWithObject(object, context: context) ?? []
+            return block(object, args, context)
+        }
+
+        let substitutionVariablesBlock:SubstituteBlockType = {bindings in
+            let subst = arguments?.map{$0.expressionWithSubstitutionVariables(bindings)}
+            return NSExpression(forBlock:block, arguments:subst)
+        }
+
+        self.init(type:.BlockExpressionType, evaluation:evaluationBlock, substitution:substitutionVariablesBlock)
+
+        _expressionBlock = block
+        _arguments = arguments
+    } // Expression that invokes the block with the parameters; note that block expressions are not encodable or representable as parseable strings.
+
+    // TODO: Conditional Expression depends on NSPredicate implementation
+    public convenience init(forConditional predicate: NSPredicate, trueExpression: NSExpression, falseExpression: NSExpression) {
+        let evaluationBlock:EvaluateBlockType = {object, context in
+            let eval:Bool = predicate.evaluateWithObject(object, substitutionVariables: context as? Dictionary<String,AnyObject>)
+            let exp = eval ? trueExpression : falseExpression
+            return exp.expressionValueWithObject(object, context: context)
+        }
+
+        let substitutionVariablesBlock:SubstituteBlockType = {bindings in
+            let p = predicate.predicateWithSubstitutionVariables(bindings as! Dictionary<String,AnyObject>),
+                te = trueExpression.expressionWithSubstitutionVariables(bindings),
+                fe = falseExpression.expressionWithSubstitutionVariables(bindings)
+
+            return NSExpression(forConditional: p, trueExpression: te, falseExpression: fe)
+        }
+
+        self.init(type:.ConditionalExpressionType, evaluation:evaluationBlock, substitution:substitutionVariablesBlock)
+
+        _trueExpression = trueExpression
+        _falseExpression = falseExpression
+        _predicate = predicate
+    } // Expression that will return the result of trueExpression or falseExpression depending on the value of predicate
+
+    //MARK - accessors for individual parameters - raise if not applicable
+
+    public var constantValue: AnyObject? {
+        guard self.expressionType == .ConstantValueExpressionType else {
+            preconditionFailure()
+        }
+
+        return self._constantValue
+    }
+
+    public var keyPath: String {
+        guard expressionType == .KeyPathExpressionType else {
+            preconditionFailure()
+        }
+
+        return _keyPath!
+    }
+
+    public var function: String {
+        guard expressionType == .FunctionExpressionType else {
+            preconditionFailure()
+        }
+
+        return self._function!
+    }
+
+    public var variable: String {
+        guard expressionType == .VariableExpressionType else {
+            preconditionFailure()
+        }
+
+        return self._variable!
+    }
+
+    public var operand: NSExpression? {
+        NSUnimplemented()
+    }
+    // the object on which the selector will be invoked (the result of evaluating a key path or one of the defined functions)
+
+    public var arguments: [NSExpression] {
+        guard expressionType == .FunctionExpressionType || expressionType == .BlockExpressionType else {
+            preconditionFailure()
+        }
+
+        // BlockExpressionType accepts nil arguments, we return an empty array in this case.
+        guard let args = self._arguments else {
+            return []
+        }
+
+        return args
+    } // array of expressions which will be passed as parameters during invocation of the selector on the operand of a function expression
+
+    public var collection: [NSExpression] {
+        guard expressionType == .AggregateExpressionType else {
+            preconditionFailure()
+        }
+
+        return self._collection!
+    }
+
+    public var predicate: NSPredicate {
+        guard expressionType == .SubqueryExpressionType || expressionType == .ConditionalExpressionType else {
+            preconditionFailure()
+        }
+
+        return self._predicate!
+    }
+
+    public var leftExpression: NSExpression {
+        guard expressionType == .IntersectSetExpressionType || expressionType == .MinusSetExpressionType || expressionType == .UnionSetExpressionType else {
+            preconditionFailure()
+        }
+
+        return self._leftExpression!
+    }// expression which represents the left side of a set expression
+
+    public var rightExpression: NSExpression {
+        guard expressionType == .IntersectSetExpressionType || expressionType == .MinusSetExpressionType || expressionType == .UnionSetExpressionType else {
+            preconditionFailure()
+        }
+
+        return self._rightExpression!
+    }// expression which represents the right side of a set expression
+
+    public var trueExpression: NSExpression? {
+        guard expressionType == .ConditionalExpressionType else {
+            preconditionFailure()
+        }
+
+        return self._trueExpression
+    }// expression which will be evaluated if a conditional expression's predicate evaluates to true
+
+    public var falseExpression: NSExpression? {
+        guard expressionType == .ConditionalExpressionType else {
+            preconditionFailure()
+        }
+
+        return self._falseExpression
+    }// expression which will be evaluated if a conditional expression's predicate evaluates to false
+
+    public var expressionBlock: ExpressionBlockType {
+        guard expressionType == .BlockExpressionType else {
+            preconditionFailure()
+        }
+
+        return self._expressionBlock!
+    }
+
     // evaluate the expression using the object and bindings- note that context is mutable here and can be used by expressions to store temporary state for one predicate evaluation
-    public func expressionValueWithObject(object: AnyObject?, context: NSMutableDictionary?) -> AnyObject { NSUnimplemented() }
-    
+    public func expressionValueWithObject(object: AnyObject?, context: NSMutableDictionary?) -> AnyObject? {
+        return self._evaluationBlock(object, context)
+    }
+
     public func allowEvaluation() { NSUnimplemented() } // Force an expression which was securely decoded to allow evaluation
+
+    override public var description: String {
+        return self.predicateFormat
+    }
+
+    // Used by NSPredicate -predicateWithSubstitutionVariables
+    private func expressionWithSubstitutionVariables(bindings:NSMutableDictionary?) -> NSExpression {
+        // nil bindings -> crash ?
+        guard let b = bindings, let block = self._substitutionVariablesBlock else {
+            return self
+        }
+
+        return block(b)
+    }
+
+    internal var predicateFormat:String {
+        switch expressionType {
+        case .ConstantValueExpressionType :
+            if let string = self.constantValue as? NSString {
+                return "'\(string)'"
+            } else if let convertible = self.constantValue as? CustomStringConvertible{
+                return "\(convertible.description)"
+            } else if let non_nil = self.constantValue {
+                return "\(non_nil)"
+            } else {
+                return "nil"
+            }
+        case .EvaluatedObjectExpressionType : return "SELF"
+        case .VariableExpressionType : return "$\(self.variable)"
+        case .KeyPathExpressionType : return ".\(self.keyPath)"
+        case .FunctionExpressionType : return "\(self.function)(\(self.arguments.predicateFormat))"
+        case .IntersectSetExpressionType : return "\(self.leftExpression) INTERSECT \(self.rightExpression)"
+        case .MinusSetExpressionType : return "\(self.leftExpression.predicateFormat) MINUS \(self.rightExpression.predicateFormat)"
+        case .UnionSetExpressionType : return "\(self.leftExpression) UNION \(self.rightExpression)"
+        case .SubqueryExpressionType : return "SUBQUERY(\(self.collection.first), \(self.variable), \(self.predicate))"
+        case .AggregateExpressionType : return "{\(self.collection.predicateFormat)}"
+        case .BlockExpressionType : return "BLOCK(\(self.expressionBlock), \(self.arguments.predicateFormat))"
+        case .ConditionalExpressionType : return "TERNARY(\(self.predicate), \(self.trueExpression), \(self.falseExpression))"
+        case .AnyKeyExpressionType : return "UNIMPLEMENTED"
+        }
+    }
 }
 
+internal extension SequenceType where Generator.Element == NSExpression {
+    internal func expressionValueWithObject(object: AnyObject?, context: NSMutableDictionary?) -> [AnyObject] {
+        return self.map{expression in
+            return expression.expressionValueWithObject(object, context: context) ?? NSNull()
+        }
+    }
+    
+    internal var predicateFormat:String {
+        return self.map{$0.description}.joinWithSeparator(", ")
+    }
+}
+
+
+//MARK - Predefined functions and function utilities
+// TODO: implement all pre-defined function which can have to following types :
+//([NSNumber]) -> NSNumber
+//(NSNumber) -> NSNumber
+//(NSNumber) -> NSString
+//(NSString) -> NSString
+//() -> NSDate
+//() -> NSNumber
+//([CLLocation]) -> NSNumber
+
+internal enum NSExpressionError : ErrorType {
+    case InvalidArgumentType(expected:Any)
+}
+
+internal func _invokeFunction<T ,U, V>(function:(Array<T>) -> U, with arguments:Array<V>) throws -> U?{
+    guard let args = arguments.map({ $0 as? T }) as? [T] else {
+        throw NSExpressionError.InvalidArgumentType(expected:T.self)
+    }
+
+    return function(args)
+}
+
+internal typealias NSExpressionFunctionType = ([NSNumber]) -> AnyObject
+internal let _NSExpressionFunctions:[String:NSExpressionFunctionType] = [
+    "sum:":sum,
+    "now":now]
+
+internal func sum(args:[NSNumber]) -> NSNumber {
+    return args.reduce(0, combine: {NSNumber(double:$0.doubleValue + $1.doubleValue)}) as NSNumber
+}
+
+internal func now(_:[NSNumber]) -> NSDate {
+    return NSDate()
+}

--- a/Foundation/NSExpression.swift
+++ b/Foundation/NSExpression.swift
@@ -516,7 +516,7 @@ internal extension SequenceType where Generator.Element == NSExpression {
 
 
 //MARK - Predefined functions and function utilities
-// TODO: implement all pre-defined function which can have to following types :
+// TODO: implement all pre-defined functions which can have to following types :
 //([NSNumber]) -> NSNumber
 //(NSNumber) -> NSNumber
 //(NSNumber) -> NSString

--- a/Foundation/NSExpression.swift
+++ b/Foundation/NSExpression.swift
@@ -136,6 +136,7 @@ public class NSExpression : NSObject, NSSecureCoding, NSCopying {
 
         guard let fn = _NSExpressionFunctions[name] else {
             // TODO: failable init. Decide if we should throw instead. (Apple Foundation throws an Exception)
+            print("\(name) is not a supported method")
             return nil
         }
 

--- a/Foundation/NSExpression.swift
+++ b/Foundation/NSExpression.swift
@@ -529,9 +529,9 @@ internal enum NSExpressionError : ErrorType {
     case InvalidArgumentType(expected:Any)
 }
 
-internal func _invokeFunction<T ,U, V>(function:(Array<T>) -> U, with arguments:Array<V>) throws -> U?{
-    guard let args = arguments.map({ $0 as? T }) as? [T] else {
-        throw NSExpressionError.InvalidArgumentType(expected:T.self)
+internal func _invokeFunction<T ,U, V>(function:(Array<T>) -> U, with arguments:Array<V>) throws -> U? {
+    guard let args = arguments.map({ $0 as? T }) as? Array<T> else {
+        throw NSExpressionError.InvalidArgumentType(expected:Array<T>.self)
     }
 
     return function(args)

--- a/TestFoundation/TestNSExpression.swift
+++ b/TestFoundation/TestNSExpression.swift
@@ -1,0 +1,161 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+class TestNSExpression: XCTestCase {
+    
+    var allTests : [(String, () -> Void)] {
+        return [
+            //("test_keyPathExpression", test_keyPathExpression),
+            //("test_ConditionalExpression", test_ConditionalExpression),
+            //("test_SubqueryExpression", test_SubqueryExpression),
+            ("test_ConstantExpression", test_ConstantExpression),
+            ("test_SelfExpression", test_SelfExpression),
+            ("test_VariableExpression", test_VariableExpression),
+            ("test_FunctionExpression", test_FunctionExpression),
+            ("test_AggregateExpression", test_AggregateExpression),
+            ("test_SetExpresssion", test_SetExpresssion),
+            ("test_blockExpression", test_blockExpression)
+        ]
+    }
+
+    func setUp() {
+
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    func tearDown() {
+
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func test_ConstantExpression() {
+        let exp = NSExpression(forConstantValue: "a".bridge())
+        XCTAssertEqual(exp.expressionValueWithObject(nil, context: nil) as? NSString , "a".bridge())
+        XCTAssertEqual(exp.expressionValueWithObject("o".bridge(), context: nil) as? NSString, "a".bridge())
+
+        let exp2 = NSExpression(forConstantValue: nil)
+        XCTAssertNil(exp2.expressionValueWithObject(nil, context: nil))
+        XCTAssertEqual(exp.description, "'a'", "Expected 'a', got \(exp.description)")
+    }
+
+    func test_SelfExpression() {
+        let exp = NSExpression.expressionForEvaluatedObject()
+        XCTAssertNil(exp.expressionValueWithObject(nil, context: nil))
+        XCTAssertEqual(exp.expressionValueWithObject("o".bridge(), context: nil) as? NSString, "o".bridge())
+        XCTAssertEqual(exp.expressionValueWithObject(1 as NSNumber, context: nil) as? NSNumber, 1 as NSNumber)
+        XCTAssertEqual(exp.description, "SELF", "Expected SELF")
+    }
+
+    func test_keyPathExpression() {
+        let value = "VALUE".bridge()
+        let obj = NSDictionary(object: value, forKey: "prop".bridge())
+
+        let exp = NSExpression(forKeyPath: "prop")
+        XCTAssertEqual(exp.expressionValueWithObject(obj, context: nil) as? NSString, value)
+        XCTAssertNil(exp.expressionValueWithObject(nil, context: nil))
+        XCTAssertEqual(exp.description, "Expected .prop, got \(exp.description)")
+    }
+
+    func test_VariableExpression() {
+        let bindings = ["variable".bridge():NSExpression(forConstantValue:"c".bridge())] as NSMutableDictionary
+
+        let exp = NSExpression(forVariable: "variable")
+        XCTAssertEqual(exp.expressionValueWithObject(nil, context: bindings) as? NSString, "c".bridge())
+        XCTAssertEqual(exp.description, "$variable", "Expected $variable, got \(exp.description)")
+    }
+
+    func test_FunctionExpression() {
+        let exp = NSExpression(forFunction: "sum:", arguments: [NSExpression(forConstantValue:1 as NSNumber), NSExpression(forConstantValue:2 as NSNumber)])
+        let result = exp?.expressionValueWithObject(nil, context: nil) as? NSNumber
+        XCTAssertEqual(result, 3 as NSNumber, "Result should be 3, was \(result)")
+        XCTAssertEqual(exp?.description, "sum:(1, 2)", "Expected sum:(1, 2) was \(exp?.description)")
+
+        let exp2 = NSExpression(forFunction: "sum:", arguments: [NSExpression(forConstantValue:"s".bridge())])
+        XCTAssertNil(exp2?.expressionValueWithObject(nil, context: nil), "Wrong arguments type, expression result should be nil")
+
+        let exp3 = NSExpression(forFunction: "sum", arguments:[NSExpression(forConstantValue:1 as NSNumber)])
+        XCTAssertNil(exp3, "Wrong function name, expression result should be nil")
+    }
+
+    func test_AggregateExpression() {
+        let exp = NSExpression(forAggregate: [NSExpression(forConstantValue:1 as NSNumber), NSExpression(forConstantValue:"c".bridge())])
+        XCTAssertEqual(exp.expressionValueWithObject(nil, context: nil) as? NSArray , [1 as NSNumber, "c".bridge()].bridge())
+        XCTAssertEqual(exp.description, "{1, 'c'}", "Expected {1, 'c'} was \(exp.description)")
+    }
+
+    func test_SetExpresssion() {
+        let left:NSSet = ([1,2] as Set).bridge(),
+            right:NSSet = ([2,3] as Set).bridge()
+
+        let exp_intersect = NSExpression(forIntersectSet: NSExpression(forConstantValue:left), with: NSExpression(forConstantValue:right))
+        XCTAssertEqual(exp_intersect.expressionValueWithObject(nil, context: nil) as? NSSet , ([2] as Set).bridge())
+        XCTAssertEqual(exp_intersect.description, "\(left.description) INTERSECT \(right.description)", "Expects \(left.description) ,was \(exp_intersect.description)")
+
+        let exp_minus = NSExpression(forMinusSet: NSExpression(forConstantValue:left), with: NSExpression(forConstantValue:right))
+        XCTAssertEqual(exp_minus.expressionValueWithObject(nil, context: nil) as? NSSet , ([1] as Set).bridge())
+        XCTAssertEqual(exp_minus.description, "\(left.description) MINUS \(right.description)")
+
+        let exp_union = NSExpression(forUnionSet: NSExpression(forConstantValue:left), with: NSExpression(forConstantValue:right))
+        XCTAssertEqual(exp_union.expressionValueWithObject(nil, context: nil) as? NSSet , ([1,2,3] as Set).bridge())
+        XCTAssertEqual(exp_union.description, "\(left.description) UNION \(right.description)")
+    }
+
+    func test_blockExpression() {
+        let obj = "o".bridge()
+        let exp = NSExpression(forBlock: {obj,_,_ in return obj}, arguments: nil)
+        XCTAssertEqual(exp.expressionValueWithObject(obj, context: nil) as? NSString, obj)
+
+        let exp_with_args = NSExpression(forBlock: {_,args,_ in return args[0]}, arguments: [NSExpression(forConstantValue:1 as NSNumber), NSExpression(forConstantValue:"c".bridge())])
+        XCTAssertEqual(exp_with_args.expressionValueWithObject(nil, context: nil) as? NSNumber, 1 as NSNumber)
+
+        let bindings = ["variable".bridge():NSExpression(forConstantValue:obj)] as NSMutableDictionary
+        let exp_with_args_and_bindings = NSExpression(forBlock: {_,args,_ in return args[0]}, arguments: [NSExpression(forVariable:"variable")])
+        XCTAssertEqual(exp_with_args_and_bindings.expressionValueWithObject(nil, context: bindings) as? NSString, obj)
+    }
+
+    func test_ConditionalExpression() {
+        let t = "true".bridge()
+        let f = "false".bridge()
+        let bindings = ["variable1".bridge():NSExpression(forConstantValue:t),
+                        "variable2".bridge():NSExpression(forConstantValue:f)] as NSMutableDictionary
+        let p = NSPredicate(value: true)
+
+        let exp = NSExpression(forConditional: p, trueExpression: NSExpression(forVariable:"variable1") , falseExpression: NSExpression(forVariable:"variable2"))
+        XCTAssertEqual(exp.expressionValueWithObject(nil, context: bindings) as? NSString, "true".bridge())
+        XCTAssertEqual(exp.description, "TERNARY(TRUEPREDICATE, $variable1, $variable2)")
+    }
+
+    func test_SubqueryExpression() {
+        let object:Dictionary<String,Dictionary<String,Any>> =
+            ["Record1":
+                      ["Name":"John", "Age":34 as NSNumber, "Children":
+                                                                      ["Kid1", "Kid2"]],
+             "Record2":
+                      ["Name":"Mary", "Age":30 as NSNumber, "Children":
+                                                                      ["Kid1", "Girl1"]]]
+
+        let collection = NSExpression(forKeyPath: "Record1.Children")
+        let predicate = NSPredicate(format:"%K BEGINSWITH %K", argumentArray:["x".bridge(), "KidVariable".bridge()])
+        let bindings = NSMutableDictionary(object: NSExpression(forConstantValue:"Kid".bridge()), forKey: "KidVariable".bridge())
+        let exp = NSExpression(forSubquery: collection, usingIteratorVariable: "x", predicate: predicate)
+        let eval = exp.expressionValueWithObject(object.bridge(), context: bindings)
+        let expected = ["Kid1", "Kid2"].bridge()
+        XCTAssertEqual(eval as? NSArray, expected, "\(exp.description) : result is \(eval), should be \(expected)")
+    }
+}

--- a/TestFoundation/TestNSExpression.swift
+++ b/TestFoundation/TestNSExpression.swift
@@ -151,7 +151,7 @@ class TestNSExpression: XCTestCase {
                                                                       ["Kid1", "Girl1"]]]
 
         let collection = NSExpression(forKeyPath: "Record1.Children")
-        let predicate = NSPredicate(format:"%K BEGINSWITH %K", argumentArray:["x".bridge(), "KidVariable".bridge()])
+        let predicate = NSComparisonPredicate(leftExpression: NSExpression(forVariable:"x"), rightExpression: NSExpression(forVariable:"KidVariable"), modifier: .DirectPredicateModifier, type: .BeginsWithPredicateOperatorType, options: .CaseInsensitivePredicateOption)
         let bindings = NSMutableDictionary(object: NSExpression(forConstantValue:"Kid".bridge()), forKey: "KidVariable".bridge())
         let exp = NSExpression(forSubquery: collection, usingIteratorVariable: "x", predicate: predicate)
         let eval = exp.expressionValueWithObject(object.bridge(), context: bindings)

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -30,6 +30,7 @@ XCTMain([
     TestNSData(),
     TestNSDate(),
     TestNSDictionary(),
+    TestNSExpression(),
     TestNSFileManger(),
     TestNSGeometry(),
     TestNSHTTPCookie(),


### PR DESCRIPTION
This is the NSExpression implementation.
In *Apple Foundation Obj-C*, NSExpression  is a class cluster and instances are created via constructors (class methods). In *Apple Foundation Swift*, instances are created via regular initializers.
Following the last approach, I chose to implement NSExpression with closures because it is compact and simple. Each initializer defines 2 closures for evaluation and variables substitution.

Not implemented and incompatible with swift:
```swift
init(forFunction target: NSExpression, selectorName name: String, arguments parameters: [NSExpression]?)
class func expressionForAnyKey() -> NSExpression
```
Implemented but cannot be tested because dependent on another implementation:
```swift
init(forKeyPath:String) depends on NSObject valueForKeyPath(String)
init(forConditional...) and init(forSubquery...) depend on NSPredicate.
```
Most pre-defined function used in init(forFunction:arguments:) need an implementation.

Some methods have their signature changed compared to Apple Foundation in this PR:
The first one have a radar already opened : rdar://23937671
```swift
-expressionValueForObject(_:AnyObject?, context:NSMutableDictionary?) -> AnyObject 
-expressionValueForObject(_:AnyObject?, context:NSMutableDictionary?) -> AnyObject? 
``` 

```swift
init(forSubquery expression: NSExpression, usingIteratorVariable variable: String, predicate: AnyObject) to 
init(forSubquery expression: NSExpression, usingIteratorVariable variable: String, predicate: NSPredicate)

init(forAggregate subexpressions: [AnyObject]) to
init(forAggregate subexpressions: [NSExpression])

init(forFunction name: String, arguments parameters: [AnyObject]) to 
init(forFunction name: String, arguments parameters: [NSExpression])
```

The following method should be discussed IMO for change (not modified in this PR) because  NSExpression documentation clearly states that this method should throw if the function name is incorrect.
```swift
forFunction(_:String, arguments:[NSExpression] ) throws -> AnyObject? instead of
forFunction(_:String, arguments:[NSExpression] ) -> AnyObject?
```

TestNSExpression.swift have not been tested on Linux.

Future improvements: it is interesting to note that theoretically all expressions types except KeyPath and Function can have their evaluated value inferred from their initial values. Generics might help here.
