### PR TITLE
The NSMutableArray fixes

### DIFF
--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -618,7 +618,7 @@ public class NSMutableArray : NSArray {
     
     public func replaceObjectAtIndex(index: Int, withObject anObject: AnyObject) {
         if self.dynamicType === NSMutableArray.self {
-            _storage.replaceRange(Range<Int>(start: index, end: index), with: [anObject])
+            _storage.replaceRange(Range<Int>(start: index, end: index + 1), with: [anObject])
         } else {
             NSRequiresConcreteImplementation()
         }
@@ -713,7 +713,7 @@ public class NSMutableArray : NSArray {
     }
     
     public func removeObjectsInArray(otherArray: [AnyObject]) {
-        let set = NSSet(array : _swiftObject)
+        let set = NSSet(array : otherArray)
         for idx in (0..<count).reverse() {
             if set.containsObject(objectAtIndex(idx)) {
                 removeObjectAtIndex(idx)

--- a/TestFoundation/TestNSArray.swift
+++ b/TestFoundation/TestNSArray.swift
@@ -32,6 +32,8 @@ class TestNSArray : XCTestCase {
             ("test_binarySearchFringeCases", test_binarySearchFringeCases),
             ("test_replaceObjectsInRange_withObjectsFromArray", test_replaceObjectsInRange_withObjectsFromArray),
             ("test_replaceObjectsInRange_withObjectsFromArray_range", test_replaceObjectsInRange_withObjectsFromArray_range),
+            ("test_replaceObjectAtIndex", test_replaceObjectAtIndex),
+            ("test_removeObjectsInArray", test_removeObjectsInArray),
             ("test_sortedArrayUsingComparator", test_sortedArrayUsingComparator),
             ("test_sortedArrayWithOptionsUsingComparator", test_sortedArrayWithOptionsUsingComparator),
             ("test_arrayReplacement", test_arrayReplacement),
@@ -176,7 +178,42 @@ class TestNSArray : XCTestCase {
         XCTAssertTrue((array[1] as! NSNumber).integerValue == 10)
         XCTAssertTrue((array[2] as! NSNumber).integerValue == 2)
     }
-    
+
+    func test_replaceObjectAtIndex() {
+        let array = NSMutableArray(array: [
+            NSNumber(int: 0), NSNumber(int: 1), NSNumber(int: 2), NSNumber(int: 3),
+            NSNumber(int: 4), NSNumber(int: 5), NSNumber(int: 7)])
+
+        // 1. Check replacement in the middle of the array
+        array.replaceObjectAtIndex(3, withObject: NSNumber(int: 8))
+        XCTAssertEqual(array.count, 7)
+        XCTAssertEqual((array[3] as! NSNumber).integerValue, 8)
+
+        // 2. Check replacement of the first element
+        array.replaceObjectAtIndex(0, withObject: NSNumber(int: 7))
+        XCTAssertEqual(array.count, 7)
+        XCTAssertEqual((array[0] as! NSNumber).integerValue, 7)
+
+        // 3. Check replacement of the last element
+        array.replaceObjectAtIndex(6, withObject: NSNumber(int: 6))
+        XCTAssertEqual(array.count, 7)
+        XCTAssertEqual((array[6] as! NSNumber).integerValue, 6)
+    }
+
+    func test_removeObjectsInArray() {
+        let array = NSMutableArray(array: [
+            NSNumber(int: 0), NSNumber(int: 1), NSNumber(int: 2), NSNumber(int: 3),
+            NSNumber(int: 4), NSNumber(int: 5), NSNumber(int: 7)])
+        let objectsToRemove: Array<AnyObject> = [
+            NSNumber(int: 1), NSNumber(int: 22), NSNumber(int: 7), NSNumber(int: 5)]
+        array.removeObjectsInArray(objectsToRemove)
+        XCTAssertEqual(array.count, 4)
+        XCTAssertEqual((array[0] as! NSNumber).integerValue, 0)
+        XCTAssertEqual((array[1] as! NSNumber).integerValue, 2)
+        XCTAssertEqual((array[2] as! NSNumber).integerValue, 3)
+        XCTAssertEqual((array[3] as! NSNumber).integerValue, 4)
+    }
+
     func test_binarySearchFringeCases() {
         let array = NSArray(array: [
             NSNumber(int: 0), NSNumber(int: 1), NSNumber(int: 2), NSNumber(int: 2), NSNumber(int: 3),


### PR DESCRIPTION
* the `replaceObjectAtIndex` uses empty range, that is why replacement works as insertion
* typo in the `removeObjectsInArray`

The copy of this [PR](https://github.com/apple/swift-corelibs-foundation/pull/220), that I closed accidentally. Fixed the compiler error related to the `test_removeObjectsInArray` test. 