### PR TITLE
Add string constructor for NSMutableString.

### DIFF
--- a/Foundation/NSCFString.swift
+++ b/Foundation/NSCFString.swift
@@ -30,6 +30,10 @@ internal class _NSCFString : NSMutableString {
     required init(capacity: Int) {
         fatalError()
     }
+
+    public required init(string aString: String) {
+        fatalError("init(string:) has not been implemented")
+    }
     
     deinit {
         _CFDeinit(self)
@@ -82,6 +86,10 @@ internal final class _NSCFConstantString : _NSCFString {
     
     required init(capacity: Int) {
         fatalError()
+    }
+
+    required init(string aString: String) {
+        fatalError("init(string:) has not been implemented")
     }
     
     deinit {

--- a/Foundation/NSCFString.swift
+++ b/Foundation/NSCFString.swift
@@ -89,7 +89,7 @@ internal final class _NSCFConstantString : _NSCFString {
     }
 
     required init(string aString: String) {
-        fatalError("init(string:) has not been implemented")
+        fatalError("Constant strings cannot be constructed in code")
     }
     
     deinit {

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -241,6 +241,10 @@ public class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, N
         NSUnimplemented()
     }
     
+    public required convenience init(string aString: String) {
+        self.init(aString)
+    }
+    
     public override func copy() -> AnyObject {
         return copyWithZone(nil)
     }
@@ -1219,10 +1223,6 @@ extension NSString {
         }
     }
     
-    public convenience init(string aString: String) {
-        self.init(aString)
-    }
-    
     public convenience init(format: String, arguments argList: CVaListPointer) {
         let str = CFStringCreateWithFormatAndArguments(kCFAllocatorSystemDefault, nil, format._cfObject, argList)
         self.init(str._swiftObject)
@@ -1347,6 +1347,10 @@ public class NSMutableString : NSString {
             var uintValue = value.unicodeScalar.value
             super.init(String._fromWellFormedCodeUnitSequence(UTF32.self, input: UnsafeBufferPointer(start: &uintValue, count: 1)))
         }
+    }
+
+    public required init(string aString: String) {
+        super.init(aString)
     }
     
     internal func appendCharacters(characters: UnsafePointer<unichar>, length: Int) {

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -75,7 +75,8 @@ class TestNSString : XCTestCase {
             ("test_stringByResolvingSymlinksInPath", test_stringByResolvingSymlinksInPath),
             ("test_stringByExpandingTildeInPath", test_stringByExpandingTildeInPath),
             ("test_stringByStandardizingPath", test_stringByStandardizingPath),
-            ("test_ExternalRepresentation", test_ExternalRepresentation)
+            ("test_ExternalRepresentation", test_ExternalRepresentation),
+            ("test_mutableStringConstructor", test_mutableStringConstructor)
         ]
     }
 
@@ -835,5 +836,10 @@ class TestNSString : XCTestCase {
             let ISOLatin1Data = CFStringCreateExternalRepresentation(kCFAllocatorDefault, string, ISOLatin1Encoding, 0)
             XCTAssertNil(ISOLatin1Data)
         }
+    }
+    
+    func test_mutableStringConstructor() {
+        let mutableString = NSMutableString(string: "Test")
+        XCTAssertEqual(mutableString, "Test")
     }
 }


### PR DESCRIPTION
On Darwin we can say

```swift
import Foundation
let a = NSMutableString(string: "Foo")
```

This constructor is not present on corelibs-foundation.

* Implement the constructor
* Test coverage
* We have to move NSString's existing version of the constructor (which shares
  the name, so we're overriding) out of its extension and into the
  class.  This is because overriding an init declared in an extension is
  "not yet supported".  This may be why we don't have the constructor
  already.
* Marking required, so as to enforce all subclasses support this.