### PR TITLE
Change tests to use updated `XCTestCaseProvider` protocol

### DIFF
--- a/TestFoundation/TestNSAffineTransform.swift
+++ b/TestFoundation/TestNSAffineTransform.swift
@@ -26,7 +26,7 @@
 class TestNSAffineTransform : XCTestCase {
     private let accuracyThreshold = 0.001
 
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_IdentityTransformation", test_IdentityTransformation),

--- a/TestFoundation/TestNSArray.swift
+++ b/TestFoundation/TestNSArray.swift
@@ -21,7 +21,7 @@ import SwiftXCTest
 
 class TestNSArray : XCTestCase {
     
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_enumeration", test_enumeration),

--- a/TestFoundation/TestNSBundle.swift
+++ b/TestFoundation/TestNSBundle.swift
@@ -21,7 +21,7 @@
 
 class TestNSBundle : XCTestCase {
     
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_paths", test_paths),
             ("test_resources", test_resources),

--- a/TestFoundation/TestNSByteCountFormatter.swift
+++ b/TestFoundation/TestNSByteCountFormatter.swift
@@ -21,7 +21,7 @@
 
 class TestNSByteCountFormatter : XCTestCase {
     
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_DefaultValues", test_DefaultValues)
         ]

--- a/TestFoundation/TestNSCalendar.swift
+++ b/TestFoundation/TestNSCalendar.swift
@@ -18,7 +18,7 @@ import CoreFoundation
 
 class TestNSCalendar: XCTestCase {
     
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_gettingDatesOnGregorianCalendar", test_gettingDatesOnGregorianCalendar ),
             ("test_gettingDatesOnHebrewCalendar", test_gettingDatesOnHebrewCalendar ),

--- a/TestFoundation/TestNSCharacterSet.swift
+++ b/TestFoundation/TestNSCharacterSet.swift
@@ -21,7 +21,7 @@ import SwiftXCTest
 
 class TestNSCharacterSet : XCTestCase {
     
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_Predefines", test_Predefines),
             ("test_Range", test_Range),

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -17,7 +17,7 @@
 
 class TestNSData: XCTestCase {
     
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("test_description", test_description),
             ("test_emptyDescription", test_emptyDescription),

--- a/TestFoundation/TestNSDate.swift
+++ b/TestFoundation/TestNSDate.swift
@@ -21,7 +21,7 @@
 
 class TestNSDate : XCTestCase {
     
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_InitTimeIntervalSince1970", test_InitTimeIntervalSince1970),

--- a/TestFoundation/TestNSDictionary.swift
+++ b/TestFoundation/TestNSDictionary.swift
@@ -21,7 +21,7 @@ import SwiftXCTest
 
 class TestNSDictionary : XCTestCase {
     
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_ArrayConstruction", test_ArrayConstruction),

--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -17,7 +17,7 @@
 
 class TestNSFileManger : XCTestCase {
     
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_createDirectory", test_createDirectory ),
             ("test_createFile", test_createFile ),

--- a/TestFoundation/TestNSGeometry.swift
+++ b/TestFoundation/TestNSGeometry.swift
@@ -22,7 +22,7 @@
 
 class TestNSGeometry : XCTestCase {
 
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_CGFloat_BasicConstruction", test_CGFloat_BasicConstruction),
             ("test_CGFloat_Equality", test_CGFloat_Equality),

--- a/TestFoundation/TestNSHTTPCookie.swift
+++ b/TestFoundation/TestNSHTTPCookie.swift
@@ -17,7 +17,7 @@
 
 class TestNSHTTPCookie: XCTestCase {
 
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_RequestHeaderFields", test_RequestHeaderFields)

--- a/TestFoundation/TestNSIndexPath.swift
+++ b/TestFoundation/TestNSIndexPath.swift
@@ -19,7 +19,7 @@
 
 class TestNSIndexPath: XCTestCase {
     
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
            ("test_BasicConstruction", test_BasicConstruction)
         ]

--- a/TestFoundation/TestNSIndexSet.swift
+++ b/TestFoundation/TestNSIndexSet.swift
@@ -19,7 +19,7 @@ import SwiftXCTest
 
 class TestNSIndexSet : XCTestCase {
     
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_enumeration", test_enumeration),

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -25,7 +25,7 @@ class TestNSJSONSerialization : XCTestCase {
         NSUTF32LittleEndianStringEncoding, NSUTF32BigEndianStringEncoding
     ]
 
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return JSONObjectWithDataTests
             + deserializationTests
             + isValidJSONObjectTests
@@ -36,7 +36,7 @@ class TestNSJSONSerialization : XCTestCase {
 //MARK: - JSONObjectWithData
 extension TestNSJSONSerialization {
 
-    var JSONObjectWithDataTests: [(String, () -> Void)] {
+    var JSONObjectWithDataTests: [(String, () throws -> Void)] {
         return [
             ("test_JSONObjectWithData_emptyObject", test_JSONObjectWithData_emptyObject),
             ("test_JSONObjectWithData_encodingDetection", test_JSONObjectWithData_encodingDetection),
@@ -84,7 +84,7 @@ extension TestNSJSONSerialization {
 //MARK: - JSONDeserialization
 extension TestNSJSONSerialization {
     
-    var deserializationTests: [(String, () -> Void)] {
+    var deserializationTests: [(String, () throws -> Void)] {
         return [
             ("test_deserialize_emptyObject", test_deserialize_emptyObject),
             ("test_deserialize_multiStringObject", test_deserialize_multiStringObject),
@@ -456,7 +456,7 @@ extension TestNSJSONSerialization {
 // MARK: - isValidJSONObjectTests
 extension TestNSJSONSerialization {
 
-    var isValidJSONObjectTests: [(String, () -> Void)] {
+    var isValidJSONObjectTests: [(String, () throws -> Void)] {
         return [
             ("test_isValidJSONObjectTrue", test_isValidJSONObjectTrue),
             ("test_isValidJSONObjectFalse", test_isValidJSONObjectFalse),

--- a/TestFoundation/TestNSLocale.swift
+++ b/TestFoundation/TestNSLocale.swift
@@ -16,7 +16,7 @@
 #endif
 
 class TestNSLocale : XCTestCase {
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_constants", test_constants),
         ]

--- a/TestFoundation/TestNSNotificationCenter.swift
+++ b/TestFoundation/TestNSNotificationCenter.swift
@@ -18,7 +18,7 @@
 
 
 class TestNSNotificationCenter : XCTestCase {
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_defaultCenter", test_defaultCenter),
             ("test_postNotification", test_postNotification),

--- a/TestFoundation/TestNSNotificationQueue.swift
+++ b/TestFoundation/TestNSNotificationQueue.swift
@@ -17,7 +17,7 @@
 
 
 class TestNSNotificationQueue : XCTestCase {
-    var allTests : [(String, () -> ())] {
+    var allTests : [(String, () throws -> ())] {
         return [
             ("test_defaultQueue", test_defaultQueue),
             ("test_postNowToDefaultQueueWithoutCoalescing", test_postNowToDefaultQueueWithoutCoalescing),

--- a/TestFoundation/TestNSNull.swift
+++ b/TestFoundation/TestNSNull.swift
@@ -21,7 +21,7 @@
 
 class TestNSNull : XCTestCase {
     
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("test_alwaysEqual", test_alwaysEqual)
         ]

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -18,7 +18,7 @@ import SwiftXCTest
 
 
 class TestNSNumber : XCTestCase {
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_NumberWithBool", test_NumberWithBool ),
             ("test_numberWithChar", test_numberWithChar ),

--- a/TestFoundation/TestNSNumberFormatter.swift
+++ b/TestFoundation/TestNSNumberFormatter.swift
@@ -18,7 +18,7 @@ import CoreFoundation
 
 class TestNSNumberFormatter: XCTestCase {
 
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_currencyCode", test_currencyCode),
             ("test_decimalSeparator", test_decimalSeparator),

--- a/TestFoundation/TestNSOrderedSet.swift
+++ b/TestFoundation/TestNSOrderedSet.swift
@@ -21,7 +21,7 @@
 
 class TestNSOrderedSet : XCTestCase {
 
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_Enumeration", test_Enumeration),

--- a/TestFoundation/TestNSPipe.swift
+++ b/TestFoundation/TestNSPipe.swift
@@ -19,7 +19,7 @@ import SwiftXCTest
 
 class TestNSPipe : XCTestCase {
     
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             // Currently disabled until NSString implements dataUsingEncoding
             // ("test_NSPipe", test_NSPipe)

--- a/TestFoundation/TestNSProcessInfo.swift
+++ b/TestFoundation/TestNSProcessInfo.swift
@@ -19,7 +19,7 @@
 
 class TestNSProcessInfo : XCTestCase {
     
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_operatingSystemVersion", test_operatingSystemVersion ),
             ("test_processName", test_processName ),

--- a/TestFoundation/TestNSPropertyList.swift
+++ b/TestFoundation/TestNSPropertyList.swift
@@ -19,7 +19,7 @@ import SwiftXCTest
 
 
 class TestNSPropertyList : XCTestCase {
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction ),
             ("test_decode", test_decode ),

--- a/TestFoundation/TestNSRange.swift
+++ b/TestFoundation/TestNSRange.swift
@@ -19,7 +19,7 @@ import SwiftXCTest
 
 class TestNSRange : XCTestCase {
     
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             // currently disabled due to pending requirements for NSString
             // ("test_NSRangeFromString", test_NSRangeFromString ),

--- a/TestFoundation/TestNSRunLoop.swift
+++ b/TestFoundation/TestNSRunLoop.swift
@@ -17,7 +17,7 @@
 
 
 class TestNSRunLoop : XCTestCase {
-    var allTests : [(String, () -> ())] {
+    var allTests : [(String, () throws -> ())] {
         return [
             ("test_constants", test_constants),
             ("test_runLoopInit", test_runLoopInit),

--- a/TestFoundation/TestNSScanner.swift
+++ b/TestFoundation/TestNSScanner.swift
@@ -21,7 +21,7 @@
 
 class TestNSScanner : XCTestCase {
 
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_scanInteger", test_scanInteger),
         ]

--- a/TestFoundation/TestNSSet.swift
+++ b/TestFoundation/TestNSSet.swift
@@ -21,7 +21,7 @@ import SwiftXCTest
 
 class TestNSSet : XCTestCase {
     
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
 //            ("test_BasicConstruction", test_BasicConstruction),
 //            ("testInitWithSet", testInitWithSet),

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -38,7 +38,7 @@ internal let kCFStringEncodingUTF32LE =  CFStringBuiltInEncodings.UTF32LE.rawVal
 
 class TestNSString : XCTestCase {
     
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_boolValue", test_boolValue ),
             ("test_BridgeConstruction", test_BridgeConstruction ),

--- a/TestFoundation/TestNSTask.swift
+++ b/TestFoundation/TestNSTask.swift
@@ -16,7 +16,7 @@
 import CoreFoundation
 
 class TestNSTask : XCTestCase {
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [("test_exit0" , test_exit0),
                 ("test_exit1" , test_exit1),
                 ("test_exit100" , test_exit100),

--- a/TestFoundation/TestNSThread.swift
+++ b/TestFoundation/TestNSThread.swift
@@ -18,7 +18,7 @@
 
 
 class TestNSThread : XCTestCase {
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_currentThread", test_currentThread ),
             ("test_threadStart", test_threadStart),

--- a/TestFoundation/TestNSTimeZone.swift
+++ b/TestFoundation/TestNSTimeZone.swift
@@ -23,7 +23,7 @@
 
 class TestNSTimeZone: XCTestCase {
 
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             // Disabled see https://bugs.swift.org/browse/SR-300
             // ("test_abbreviation", test_abbreviation),

--- a/TestFoundation/TestNSTimer.swift
+++ b/TestFoundation/TestNSTimer.swift
@@ -18,7 +18,7 @@
 
 
 class TestNSTimer : XCTestCase {
-    var allTests : [(String, () -> ())] {
+    var allTests : [(String, () throws -> ())] {
         return [
             ("test_timerInit", test_timerInit),
             ("test_timerTickOnce", test_timerTickOnce),

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -59,7 +59,7 @@ private func getTestData() -> [Any]? {
 }
 
 class TestNSURL : XCTestCase {
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_URLStrings", test_URLStrings),
             ("test_fileURLWithPath_relativeToURL", test_fileURLWithPath_relativeToURL ),
@@ -428,7 +428,7 @@ class TestNSURL : XCTestCase {
 }
     
 class TestNSURLComponents : XCTestCase {
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_string", test_string),
         ]

--- a/TestFoundation/TestNSURLRequest.swift
+++ b/TestFoundation/TestNSURLRequest.swift
@@ -18,7 +18,7 @@
 
 class TestNSURLRequest : XCTestCase {
     
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_construction", test_construction),
             ("test_mutableConstruction", test_mutableConstruction),

--- a/TestFoundation/TestNSURLResponse.swift
+++ b/TestFoundation/TestNSURLResponse.swift
@@ -18,7 +18,7 @@
 
 
 class TestNSURLResponse : XCTestCase {
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_URL", test_URL),
             ("test_MIMEType", test_MIMEType),

--- a/TestFoundation/TestNSUUID.swift
+++ b/TestFoundation/TestNSUUID.swift
@@ -19,7 +19,7 @@
 
 class TestNSUUID : XCTestCase {
     
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_Equality", test_Equality),
             ("test_InvalidUUID", test_InvalidUUID),

--- a/TestFoundation/TestNSXMLDocument.swift
+++ b/TestFoundation/TestNSXMLDocument.swift
@@ -21,7 +21,7 @@ import CoreFoundation
 
 class TestNSXMLDocument : XCTestCase {
 
-    var allTests: [(String, () -> Void)] {
+    var allTests: [(String, () throws -> Void)] {
         return [
             ("test_basicCreation", test_basicCreation),
             ("test_nextPreviousNode", test_nextPreviousNode),

--- a/TestFoundation/TestNSXMLParser.swift
+++ b/TestFoundation/TestNSXMLParser.swift
@@ -19,7 +19,7 @@ import SwiftXCTest
 
 class TestNSXMLParser : XCTestCase {
     
-    var allTests : [(String, () -> Void)] {
+    var allTests : [(String, () throws -> Void)] {
         return [
             ("test_data", test_data),
         ]


### PR DESCRIPTION
Updated swift-corelibs-foundation tests based on changes made in https://github.com/apple/swift-corelibs-xctest/commit/e5c0cb36bc445d0522f7ec28a8342b2681f68666.