### PR TITLE
Initial implementation of NSFileManager.enumeratorAtPath.

### DIFF
--- a/Foundation/NSFileManager.swift
+++ b/Foundation/NSFileManager.swift
@@ -642,7 +642,7 @@ public class NSFileManager : NSObject {
     /* enumeratorAtPath: returns an NSDirectoryEnumerator rooted at the provided path. If the enumerator cannot be created, this returns NULL. Because NSDirectoryEnumerator is a subclass of NSEnumerator, the returned object can be used in the for...in construct.
      */
     public func enumeratorAtPath(path: String) -> NSDirectoryEnumerator? {
-        NSUnimplemented()
+        return NSPathDirectoryEnumerator(path: path)
     }
     
     /* enumeratorAtURL:includingPropertiesForKeys:options:errorHandler: returns an NSDirectoryEnumerator rooted at the provided directory URL. The NSDirectoryEnumerator returns NSURLs from the -nextObject method. The optional 'includingPropertiesForKeys' parameter indicates which resource properties should be pre-fetched and cached with each enumerated URL. The optional 'errorHandler' block argument is invoked when an error occurs. Parameters to the block are the URL on which an error occurred and the error. When the error handler returns YES, enumeration continues if possible. Enumeration stops immediately when the error handler returns NO.
@@ -840,6 +840,44 @@ public class NSDirectoryEnumerator : NSEnumerator {
     public func skipDescendants() {
         NSRequiresConcreteImplementation()
     }
+}
+
+internal class NSPathDirectoryEnumerator: NSDirectoryEnumerator {
+    let baseURL: NSURL
+    let innerEnumerator : NSDirectoryEnumerator
+    override var fileAttributes: [String : AnyObject]? {
+        NSUnimplemented()
+    }
+    override var directoryAttributes: [String : AnyObject]? {
+        NSUnimplemented()
+    }
+    
+    override var level: Int {
+        NSUnimplemented()
+    }
+    
+    override func skipDescendants() {
+        NSUnimplemented()
+    }
+    
+    init?(path: String) {
+        let url = NSURL(fileURLWithPath: path)
+        self.baseURL = url
+        guard let ie = NSFileManager.defaultManager().enumeratorAtURL(url, includingPropertiesForKeys: nil, options: NSDirectoryEnumerationOptions(), errorHandler: nil) else {
+            return nil
+        }
+        self.innerEnumerator = ie
+    }
+    
+    override func nextObject() -> AnyObject? {
+        let o = innerEnumerator.nextObject()
+        guard let url = o as? NSURL else {
+            return nil
+        }
+        let path = url.path!.stringByReplacingOccurrencesOfString(baseURL.path!+"/", withString: "")
+        return NSString(string: path)
+    }
+
 }
 
 internal class NSURLDirectoryEnumerator : NSDirectoryEnumerator {

--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -158,11 +158,11 @@ class TestNSFileManger : XCTestCase {
         }
         
         if let e = NSFileManager.defaultManager().enumeratorAtPath(basePath) {
-            var foundItems : [String] = []
+            let foundItems = NSMutableSet()
             while let item = e.nextObject() as? NSString {
-                    foundItems.append(item.bridge())
+                foundItems.addObject(item)
             }
-            XCTAssertEqual(foundItems, ["item","path2","path2/item"])
+            XCTAssertEqual(foundItems, NSMutableSet(array: ["item".bridge(),"path2".bridge(),"path2/item".bridge()]))
         } else {
             XCTFail()
         }

--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -24,6 +24,7 @@ class TestNSFileManger : XCTestCase {
             ("test_fileSystemRepresentation", test_fileSystemRepresentation),
             ("test_fileAttributes", test_fileAttributes),
             ("test_directoryEnumerator", test_directoryEnumerator),
+            ("test_pathEnumerator",test_pathEnumerator),
             ("test_contentsOfDirectoryAtPath", test_contentsOfDirectoryAtPath),
             ("test_subpathsOfDirectoryAtPath", test_subpathsOfDirectoryAtPath)
         ]
@@ -134,6 +135,38 @@ class TestNSFileManger : XCTestCase {
         } catch {
             XCTFail("Failed to clean up files")
         }
+    }
+    
+    func test_pathEnumerator() {
+        let fm = NSFileManager.defaultManager()
+        let basePath = "/tmp/testdir"
+        let itemPath = "/tmp/testdir/item"
+        let basePath2 = "/tmp/testdir/path2"
+        let itemPath2 = "/tmp/testdir/path2/item"
+        
+        ignoreError { try fm.removeItemAtPath(basePath) }
+        
+        do {
+            try fm.createDirectoryAtPath(basePath, withIntermediateDirectories: false, attributes: nil)
+            try fm.createDirectoryAtPath(basePath2, withIntermediateDirectories: false, attributes: nil)
+
+            fm.createFileAtPath(itemPath, contents: NSData(), attributes: nil)
+            fm.createFileAtPath(itemPath2, contents: NSData(), attributes: nil)
+
+        } catch _ {
+            XCTFail()
+        }
+        
+        if let e = NSFileManager.defaultManager().enumeratorAtPath(basePath) {
+            var foundItems : [String] = []
+            while let item = e.nextObject() as? NSString {
+                    foundItems.append(item.bridge())
+            }
+            XCTAssertEqual(foundItems, ["item","path2","path2/item"])
+        } else {
+            XCTFail()
+        }
+
     }
     
     func test_directoryEnumerator() {


### PR DESCRIPTION
This implementation wraps the existing NSPathDirectoryEnumerator to do
all the heavy lifting.

Add test coverage.