### PR TITLE
[SR-568]: fix warning in init(string:)

### DIFF
--- a/Foundation/NSCFString.swift
+++ b/Foundation/NSCFString.swift
@@ -31,8 +31,8 @@ internal class _NSCFString : NSMutableString {
         fatalError()
     }
 
-    public required init(string aString: String) {
-        fatalError("init(string:) has not been implemented")
+    required init(string aString: String) {
+        fatalError()
     }
     
     deinit {


### PR DESCRIPTION
f1554eb introduced a warning by declaring a public method on an internal class. Also, use remove fatalError() message for consistency (or, we should use NSUnimplemented() for consistency).
