### PR TITLE
Add NSXMLDTD and NSXMLDTDNode support

### DIFF
--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -522,8 +522,6 @@ void _CFXMLNodeSetContent(_CFXMLNodePtr node, const unsigned char* _Nullable  co
                 resultNode->attributes = NULL;
                 resultNode->contModel = NULL;
                 _CFXMLFreeNode(resultNode);
-
-                xmlDtdPtr dtd = element->parent;
             }
 
             return;
@@ -711,7 +709,17 @@ CFIndex _CFXMLNodeGetElementChildCount(_CFXMLNodePtr node) {
 
 void _CFXMLNodeAddChild(_CFXMLNodePtr node, _CFXMLNodePtr child) {
     if (((xmlNodePtr)node)->type == XML_NOTATION_NODE) {// the "artificial" node we created
-        
+        if (((xmlNodePtr)node)->type == XML_DTD_NODE) {// the only circumstance under which this actually makes sense
+            xmlNotationPtr notation = ((_cfxmlNotation*)child)->notation;
+            xmlDtdPtr dtd = (xmlDtdPtr)node;
+
+            if (dtd->notations == NULL) {
+                xmlDictPtr dict = dtd->doc ? dtd->doc->dict : NULL;
+                dtd->notations = xmlHashCreateDict(0, dict);
+            }
+            xmlHashAddEntry(dtd->notations, notation->name, notation);
+        }
+        return;
     }
     xmlAddChild(node, child);
 }

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -20,6 +20,7 @@
 #include <libxml/xmlmemory.h>
 #include <libxml/xmlsave.h>
 #include <libxml/xpath.h>
+#include <libxml/dict.h>
 #include "CFInternal.h"
 
 /*
@@ -49,21 +50,63 @@ CFIndex _kCFXMLInterfaceHuge = XML_PARSE_HUGE;
 CFIndex _kCFXMLInterfaceOldsax = XML_PARSE_OLDSAX;
 CFIndex _kCFXMLInterfaceIgnoreEnc = XML_PARSE_IGNORE_ENC;
 CFIndex _kCFXMLInterfaceBigLines = XML_PARSE_BIG_LINES;
+
+CFIndex _kCFXMLTypeInvalid = 0;
 CFIndex _kCFXMLTypeDocument = XML_DOCUMENT_NODE;
 CFIndex _kCFXMLTypeElement = XML_ELEMENT_NODE;
 CFIndex _kCFXMLTypeAttribute = XML_ATTRIBUTE_NODE;
 CFIndex _kCFXMLTypeDTD = XML_DTD_NODE;
 CFIndex _kCFXMLDocTypeHTML = XML_DOC_HTML;
+
 CFIndex _kCFXMLDTDNodeTypeEntity = XML_ENTITY_DECL;
 CFIndex _kCFXMLDTDNodeTypeAttribute = XML_ATTRIBUTE_DECL;
 CFIndex _kCFXMLDTDNodeTypeElement = XML_ELEMENT_DECL;
 CFIndex _kCFXMLDTDNodeTypeNotation = XML_NOTATION_NODE;
+
+CFIndex _kCFXMLDTDNodeElementTypeUndefined = XML_ELEMENT_TYPE_UNDEFINED;
+CFIndex _kCFXMLDTDNodeElementTypeEmpty = XML_ELEMENT_TYPE_EMPTY;
+CFIndex _kCFXMLDTDNodeElementTypeAny = XML_ELEMENT_TYPE_ANY;
+CFIndex _kCFXMLDTDNodeElementTypeMixed = XML_ELEMENT_TYPE_MIXED;
+CFIndex _kCFXMLDTDNodeElementTypeElement = XML_ELEMENT_TYPE_ELEMENT;
+
+CFIndex _kCFXMLDTDNodeEntityTypeInternalGeneral = XML_INTERNAL_GENERAL_ENTITY;
+CFIndex _kCFXMLDTDNodeEntityTypeExternalGeneralParsed = XML_EXTERNAL_GENERAL_PARSED_ENTITY;
+CFIndex _kCFXMLDTDNodeEntityTypeExternalGeneralUnparsed = XML_EXTERNAL_GENERAL_UNPARSED_ENTITY;
+CFIndex _kCFXMLDTDNodeEntityTypeInternalParameter = XML_INTERNAL_PARAMETER_ENTITY;
+CFIndex _kCFXMLDTDNodeEntityTypeExternalParameter = XML_EXTERNAL_PARAMETER_ENTITY;
+CFIndex _kCFXMLDTDNodeEntityTypeInternalPredefined = XML_INTERNAL_PREDEFINED_ENTITY;
+
+CFIndex _kCFXMLDTDNodeAttributeTypeCData = XML_ATTRIBUTE_CDATA;
+CFIndex _kCFXMLDTDNodeAttributeTypeID = XML_ATTRIBUTE_ID;
+CFIndex _kCFXMLDTDNodeAttributeTypeIDRef = XML_ATTRIBUTE_IDREF;
+CFIndex _kCFXMLDTDNodeAttributeTypeIDRefs = XML_ATTRIBUTE_IDREFS;
+CFIndex _kCFXMLDTDNodeAttributeTypeEntity = XML_ATTRIBUTE_ENTITY;
+CFIndex _kCFXMLDTDNodeAttributeTypeEntities = XML_ATTRIBUTE_ENTITIES;
+CFIndex _kCFXMLDTDNodeAttributeTypeNMToken = XML_ATTRIBUTE_NMTOKEN;
+CFIndex _kCFXMLDTDNodeAttributeTypeNMTokens = XML_ATTRIBUTE_NMTOKENS;
+CFIndex _kCFXMLDTDNodeAttributeTypeEnumeration = XML_ATTRIBUTE_ENUMERATION;
+CFIndex _kCFXMLDTDNodeAttributeTypeNotation = XML_ATTRIBUTE_NOTATION;
 
 CFIndex _kCFXMLNodePreserveWhitespace = 1 << 25;
 CFIndex _kCFXMLNodeCompactEmptyElement = 1 << 2;
 CFIndex _kCFXMLNodePrettyPrint = 1 << 17;
 CFIndex _kCFXMLNodeLoadExternalEntitiesNever = 1 << 19;
 CFIndex _kCFXMLNodeLoadExternalEntitiesAlways = 1 << 14;
+
+// We define this structure because libxml2's "notation" node does not contain the fields
+// nearly all other libxml2 node fields contain, that we use extensively.
+typedef struct {
+    void * _private;
+    xmlElementType type;
+    const xmlChar* name;
+    xmlNodePtr children;
+    xmlNodePtr last;
+    xmlNodePtr parent;
+    xmlNodePtr next;
+    xmlNodePtr prev;
+    xmlDocPtr doc;
+    xmlNotationPtr notation;
+} _cfxmlNotation;
 
 static xmlExternalEntityLoader __originalLoader = NULL;
 
@@ -201,6 +244,50 @@ _CFXMLInterfaceEntity _CFXMLInterfaceGetPredefinedEntity(const unsigned char *na
     return xmlGetPredefinedEntity(name);
 }
 
+_CFXMLDTDNodePtr _Nullable _CFXMLDTDNewElementDesc(_CFXMLDTDPtr dtd, const unsigned char* name) {
+    bool freeDTD = false;
+    if (!dtd) {
+        dtd = xmlNewDtd(NULL, (const xmlChar*)"tempDTD", NULL, NULL);
+        freeDTD = true;
+    }
+
+    if (!name) {
+        name = (const xmlChar*)"";
+    }
+
+    xmlElementPtr result = xmlAddElementDecl(NULL, dtd, name, XML_ELEMENT_TYPE_ANY, NULL);
+
+    if (freeDTD) {
+        _CFXMLUnlinkNode(result);
+        xmlFreeDtd(dtd);
+    }
+
+    return result;
+}
+
+_CFXMLDTDNodePtr _Nullable _CFXMLDTDNewAttributeDesc(_CFXMLDTDPtr dtd, const unsigned char* name)
+{
+    bool freeDTD = false;
+    if (!dtd) {
+        dtd = xmlNewDtd(NULL, (const xmlChar*)"tempDTD", NULL, NULL);
+        freeDTD = true;
+    }
+
+    if (!name) {
+        name = (const xmlChar*)"";
+    }
+
+    xmlAttributePtr result = xmlAddAttributeDecl(NULL, dtd, NULL, name, NULL, XML_ATTRIBUTE_ID, XML_ATTRIBUTE_NONE, NULL, NULL);
+
+    if (freeDTD) {
+        _CFXMLUnlinkNode(result);
+        xmlFreeDtd(dtd);
+    }
+
+    return result;
+}
+
+
 _CFXMLInterfaceEntity _CFXMLInterfaceSAX2GetEntity(_CFXMLInterfaceParserContext ctx, const unsigned char *name) {
     if (ctx == NULL) return NULL;
     _CFXMLInterfaceEntity entity = xmlSAX2GetEntity(ctx, name);
@@ -240,7 +327,17 @@ _CFXMLNodePtr _CFXMLNewNode(_CFXMLNamespacePtr namespace, const char* name) {
 }
 
 _CFXMLNodePtr _CFXMLCopyNode(_CFXMLNodePtr node, bool recursive) {
-    return xmlCopyNode(node, recursive ? 1 : 0);
+    int recurse = recursive ? 1 : 0;
+    switch (((xmlNodePtr)node)->type) {
+        case XML_DOCUMENT_NODE:
+            return xmlCopyDoc(node, recurse);
+
+        case XML_DTD_NODE:
+            return xmlCopyDtd(node);
+
+        default:
+            return xmlCopyNode(node, recurse);
+    }
 }
 
 _CFXMLDocPtr _CFXMLNewDoc(const unsigned char* version) {
@@ -328,6 +425,10 @@ void _CFXMLNodeSetURI(_CFXMLNodePtr node, const unsigned char* URI) {
 }
 
 void _CFXMLNodeSetPrivateData(_CFXMLNodePtr node, void* data) {
+    if (!node) {
+        return;
+    }
+    
     ((xmlNodePtr)node)->_private = data;
 }
 
@@ -340,6 +441,9 @@ _CFXMLNodePtr _CFXMLNodeProperties(_CFXMLNodePtr node) {
 }
 
 CFIndex _CFXMLNodeGetType(_CFXMLNodePtr node) {
+    if (!node) {
+        return _kCFXMLTypeInvalid;
+    }
     return ((xmlNodePtr)node)->type;
 }
 
@@ -352,23 +456,87 @@ void _CFXMLNodeSetName(_CFXMLNodePtr node, const char* name) {
 }
 
 CFStringRef _CFXMLNodeGetContent(_CFXMLNodePtr node) {
-    xmlChar* content = xmlNodeGetContent(node);
-    if (content == NULL) {
-        return NULL;
-    }
-    CFStringRef result = CFStringCreateWithCString(NULL, (const char*)content, kCFStringEncodingUTF8);
-    xmlFree(content);
+    switch (((xmlNodePtr)node)->type) {
+        case XML_ELEMENT_DECL:
+        {
+            char* buffer = calloc(2048, 1);
+            xmlSnprintfElementContent(buffer, 2047, ((xmlElementPtr)node)->content, 1);
+            CFStringRef result = CFStringCreateWithCString(NULL, buffer, kCFStringEncodingUTF8);
+            free(buffer);
+            return result;
+        }
 
-    return result;
+        default:
+        {
+            xmlChar* content = xmlNodeGetContent(node);
+            if (content == NULL) {
+                return NULL;
+            }
+            CFStringRef result = CFStringCreateWithCString(NULL, (const char*)content, kCFStringEncodingUTF8);
+            xmlFree(content);
+            
+            return result;
+        }
+    }
 }
 
 void _CFXMLNodeSetContent(_CFXMLNodePtr node, const unsigned char* _Nullable  content) {
-    if (content == NULL) {
-        xmlNodeSetContent(node, nil);
-        return;
-    }
+    // So handling set content on XML_ELEMENT_DECL is listed as a TODO !!! in libxml2's source code.
+    // that means we have to do it ourselves.
+    switch (((xmlNodePtr)node)->type) {
+        case XML_ELEMENT_DECL:
+        {
+            xmlElementPtr element = (xmlElementPtr)node;
+            if (content == NULL) {
+                xmlFreeDocElementContent(element->doc, element->content);
+                element->content = NULL;
+                return;
+            }
 
-    xmlNodeSetContent(node, content);
+            // rather than writing custom code to parse the new content into the correct
+            // xmlElementContent structures, let's leverage what we've already got.
+            CFMutableStringRef xmlString = CFStringCreateMutable(NULL, 0);
+            CFStringAppend(xmlString, CFSTR("<!ELEMENT "));
+            CFStringAppendCString(xmlString, _CFXMLNodeGetName(node), kCFStringEncodingUTF8);
+            CFStringAppend(xmlString, CFSTR(" "));
+            CFStringAppendCString(xmlString, (const char*)content, kCFStringEncodingUTF8);
+            CFStringAppend(xmlString, CFSTR(">"));
+
+            size_t bufferSize = CFStringGetMaximumSizeForEncoding(CFStringGetLength(xmlString), kCFStringEncodingUTF8) + 1;
+            char* buffer = calloc(bufferSize, 1);
+            CFStringGetCString(xmlString, buffer, bufferSize, kCFStringEncodingUTF8);
+            xmlElementPtr resultNode = _CFXMLParseDTDNode((const xmlChar*)buffer);
+
+            if (resultNode) {
+                xmlFreeDocElementContent(element->doc, element->content);
+                _CFXMLFreeNode(element->attributes);
+                xmlRegFreeRegexp(element->contModel);
+
+                element->type = resultNode->type;
+                element->etype = resultNode->etype;
+                element->content = resultNode->content;
+                element->attributes = resultNode->attributes;
+                element->contModel = resultNode->contModel;
+
+                resultNode->content = NULL;
+                resultNode->attributes = NULL;
+                resultNode->contModel = NULL;
+                _CFXMLFreeNode(resultNode);
+
+                xmlDtdPtr dtd = element->parent;
+            }
+
+            return;
+        }
+
+        default:
+            if (content == NULL) {
+                xmlNodeSetContent(node, nil);
+                return;
+            }
+
+            xmlNodeSetContent(node, content);
+    }
 }
 
 _CFXMLDocPtr _CFXMLNodeGetDocument(_CFXMLNodePtr node) {
@@ -389,7 +557,60 @@ CFStringRef _CFXMLEncodeEntities(_CFXMLDocPtr doc, const unsigned char* string) 
     return result;
 }
 
+static inline void _removeHashEntry(xmlHashTablePtr table, const xmlChar* name, xmlNodePtr node);
+static inline void _removeHashEntry(xmlHashTablePtr table, const xmlChar* name, xmlNodePtr node) {
+    if (xmlHashLookup(table, name) == node) {
+        xmlHashRemoveEntry(table, name, NULL);
+    }
+}
+
 void _CFXMLUnlinkNode(_CFXMLNodePtr node) {
+    // DTD DECL nodes have references in the parent DTD's various hash tables.
+    // For some reason, libxml2's xmlUnlinkNode doesn't actually remove those references for
+    // anything other than entities, and even then only if there is a parent document!
+    // To make matters worse, when you run xmlFreeDtd on the dtd, it actually deallocs everything
+    // that it has a hash table reference to in addition to all of it's children. So, we need
+    // to manually remove the node from the correct hash table before we can unlink it.
+    switch (((xmlNodePtr)node)->type) {
+        case XML_ELEMENT_DECL:
+        {
+            xmlElementPtr elemDecl = (xmlElementPtr)node;
+            xmlDtdPtr dtd = elemDecl->parent;
+            _removeHashEntry(dtd->elements, elemDecl->name, node);
+        }
+            break;
+
+        case XML_ENTITY_DECL:
+        {
+            xmlEntityPtr entityDecl = (xmlEntityPtr)node;
+            xmlDtdPtr dtd = entityDecl->parent;
+            _removeHashEntry(dtd->entities, entityDecl->name, node);
+            _removeHashEntry(dtd->pentities, entityDecl->name, node);
+        }
+            break;
+
+        case XML_ATTRIBUTE_DECL:
+        {
+            xmlAttributePtr attrDecl = (xmlAttributePtr)node;
+            xmlDtdPtr dtd = attrDecl->parent;
+            if (xmlHashLookup3(dtd->attributes, attrDecl->name, NULL, attrDecl->elem) == node) {
+                xmlHashRemoveEntry3(dtd->attributes, attrDecl->name, NULL, attrDecl->elem, NULL);
+            }
+        }
+            break;
+
+        case XML_NOTATION_NODE:
+        {
+            // Since we're handling notation nodes instead of libxml2, we need to do some extra work here
+            xmlNotationPtr notation = ((_cfxmlNotation*)node)->notation;
+            xmlDtdPtr dtd = (xmlDtdPtr)((_cfxmlNotation*)node)->parent;
+            _removeHashEntry(dtd->notations, notation->name, (xmlNodePtr)notation);
+            return;
+        }
+
+        default:
+            break;
+    }
     xmlUnlinkNode(node);
 }
 
@@ -464,11 +685,34 @@ void _CFXMLDocSetProperties(_CFXMLDocPtr doc, int newProperties) {
     ((xmlDocPtr)doc)->properties = newProperties;
 }
 
+_CFXMLDTDPtr _Nullable _CFXMLDocDTD(_CFXMLDocPtr doc) {
+    return xmlGetIntSubset(doc);
+}
+
+void _CFXMLDocSetDTD(_CFXMLDocPtr doc, _CFXMLDTDPtr _Nullable dtd) {
+    if (!dtd) {
+        ((xmlDocPtr)doc)->intSubset = NULL;
+        return;
+    }
+
+    xmlDocPtr docPtr = (xmlDocPtr)doc;
+    xmlDtdPtr dtdPtr = (xmlDtdPtr)dtd;
+    docPtr->intSubset = dtdPtr;
+    if (docPtr->children == NULL) {
+        xmlAddChild(doc, dtd);
+    } else {
+        xmlAddPrevSibling(docPtr->children, dtd);
+    }
+}
+
 CFIndex _CFXMLNodeGetElementChildCount(_CFXMLNodePtr node) {
     return xmlChildElementCount(node);
 }
 
 void _CFXMLNodeAddChild(_CFXMLNodePtr node, _CFXMLNodePtr child) {
+    if (((xmlNodePtr)node)->type == XML_NOTATION_NODE) {// the "artificial" node we created
+        
+    }
     xmlAddChild(node, child);
 }
 
@@ -509,6 +753,44 @@ CFStringRef _CFXMLGetEntityContent(_CFXMLEntityPtr entity) {
 }
 
 CFStringRef _CFXMLStringWithOptions(_CFXMLNodePtr node, uint32_t options) {
+    if (((xmlNodePtr)node)->type == XML_ENTITY_DECL &&
+        ((xmlEntityPtr)node)->etype == XML_INTERNAL_PREDEFINED_ENTITY) {
+        // predefined entities need special handling, libxml2 just tosses an error and returns a NULL string
+        // if we try to use xmlSaveTree on a predefined entity
+        CFMutableStringRef result = CFStringCreateMutable(NULL, 0);
+        CFStringAppend(result, CFSTR("<!ENTITY "));
+        CFStringAppendCString(result, (const char*)((xmlEntityPtr)node)->name, kCFStringEncodingUTF8);
+        CFStringAppend(result, CFSTR(" \""));
+        CFStringAppendCString(result, (const char*)((xmlEntityPtr)node)->content, kCFStringEncodingUTF8);
+        CFStringAppend(result, CFSTR("\">"));
+
+        return result;
+    } else if (((xmlNodePtr)node)->type == XML_NOTATION_NODE) {
+        // This is not actually a thing that occurs naturally in libxml2
+        xmlNotationPtr notation = ((_cfxmlNotation*)node)->notation;
+        CFMutableStringRef result = CFStringCreateMutable(NULL, 0);
+        CFStringAppend(result, CFSTR("<!NOTATION "));
+        CFStringAppendCString(result, (const char*)notation->name, kCFStringEncodingUTF8);
+        CFStringAppend(result, CFSTR(" "));
+        if (notation->PublicID == NULL && notation->SystemID != NULL) {
+            CFStringAppend(result, CFSTR("SYSTEM "));
+        } else if (notation->PublicID != NULL) {
+            CFStringAppend(result, CFSTR("PUBLIC \""));
+            CFStringAppendCString(result, (const char*)notation->PublicID, kCFStringEncodingUTF8);
+            CFStringAppend(result, CFSTR("\""));
+        }
+
+        if (notation->SystemID != NULL) {
+            CFStringAppend(result, CFSTR("\""));
+            CFStringAppendCString(result, (const char*)notation->SystemID, kCFStringEncodingUTF8);
+            CFStringAppend(result, CFSTR("\""));
+        }
+
+        CFStringAppend(result, CFSTR(" >"));
+
+        return result;
+    }
+    
     xmlBufferPtr buffer = xmlBufferCreate();
 
     uint32_t xmlOptions = XML_SAVE_AS_XML;
@@ -630,7 +912,7 @@ bool _CFXMLDocValidate(_CFXMLDocPtr doc, CFErrorRef _Nullable * error) {
     ctxt->userData = errorMessage;
 
     int result = xmlValidateDocument(ctxt, doc);
-
+    
     xmlFreeValidCtxt(ctxt);
 
     if (result == 0 && error != NULL) {
@@ -644,13 +926,315 @@ bool _CFXMLDocValidate(_CFXMLDocPtr doc, CFErrorRef _Nullable * error) {
 
     CFRelease(errorMessage);
 
-    return error != NULL && *error != NULL;
+    return result != 0;
+}
+
+_CFXMLDTDPtr _CFXMLNewDTD(_CFXMLDocPtr doc, const unsigned char* name, const unsigned char* publicID, const unsigned char* systemID) {
+    return xmlNewDtd(doc, name, publicID, systemID);
+}
+
+_CFXMLDTDNodePtr _CFXMLParseDTDNode(const unsigned char* xmlString) {
+    CFDataRef data = CFDataCreateWithBytesNoCopy(NULL, xmlString, xmlStrlen(xmlString), kCFAllocatorNull);
+    xmlDtdPtr dtd = _CFXMLParseDTDFromData(data, NULL);
+    CFRelease(data);
+
+    if (dtd == NULL) {
+        return NULL;
+    }
+    
+    xmlNodePtr node = dtd->children;
+    xmlUnlinkNode(node);
+
+    return node;
+}
+
+_CFXMLDTDPtr _Nullable _CFXMLParseDTD(const unsigned char* URL) {
+    return xmlParseDTD(NULL, URL);
+}
+
+_CFXMLDTDPtr _Nullable _CFXMLParseDTDFromData(CFDataRef data, CFErrorRef _Nullable * error) {
+    xmlParserInputBufferPtr inBuffer = xmlParserInputBufferCreateMem((const char*)CFDataGetBytePtr(data), CFDataGetLength(data), XML_CHAR_ENCODING_UTF8);
+
+    xmlSAXHandler handler;
+    handler.error = &_CFXMLValidityErrorHandler;
+    CFMutableStringRef errorMessage = CFStringCreateMutable(NULL, 0);
+    handler._private = errorMessage;
+
+    xmlDtdPtr dtd = xmlIOParseDTD(NULL, inBuffer, XML_CHAR_ENCODING_UTF8);
+
+    if (dtd == NULL && error != NULL) {
+        CFMutableDictionaryRef userInfo = CFDictionaryCreateMutable(NULL, 1, &kCFCopyStringDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+        CFDictionarySetValue(userInfo, kCFErrorLocalizedDescriptionKey, errorMessage);
+
+        *error = CFErrorCreate(NULL, CFSTR("NSXMLParserErrorDomain"), 0, userInfo);
+
+        CFRelease(userInfo);
+    }
+    CFRelease(errorMessage);
+
+    return dtd;
+}
+
+CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDExternalID(_CFXMLDTDPtr dtd) {
+    const unsigned char* externalID = ((xmlDtdPtr)dtd)->ExternalID;
+    if (externalID) {
+        return CFStringCreateWithCString(NULL, (const char*)externalID, kCFStringEncodingUTF8);
+    }
+
+    return NULL;
+}
+
+void _CFXMLDTDSetExternalID(_CFXMLDTDPtr dtd, const unsigned char* externalID) {
+    xmlDtdPtr dtdPtr = (xmlDtdPtr)dtd;
+    if (dtdPtr->ExternalID) {
+        xmlDictPtr dict = dtdPtr->doc ? dtdPtr->doc->dict : NULL;
+        if (dict) {
+            if (!xmlDictOwns(dict, dtdPtr->ExternalID)) {
+                xmlFree((xmlChar*)dtdPtr->ExternalID);
+            }
+        } else {
+            xmlFree((xmlChar*)dtdPtr->ExternalID);
+        }
+    }
+
+    dtdPtr->ExternalID = xmlStrdup(externalID);
+}
+
+CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDSystemID(_CFXMLDTDPtr dtd) {
+    const unsigned char* systemID = ((xmlDtdPtr)dtd)->SystemID;
+    if (systemID) {
+        return CFStringCreateWithCString(NULL, (const char*)systemID, kCFStringEncodingUTF8);
+    }
+
+    return NULL;
+}
+
+void _CFXMLDTDSetSystemID(_CFXMLDTDPtr dtd, const unsigned char* systemID) {
+    xmlDtdPtr dtdPtr = (xmlDtdPtr)dtd;
+
+    if (dtdPtr->SystemID) {
+        xmlDictPtr dict = dtdPtr->doc ? dtdPtr->doc->dict : NULL;
+        if (dict) {
+            if (!xmlDictOwns(dict, dtdPtr->SystemID)) {
+                xmlFree((xmlChar*)dtdPtr->SystemID);
+            }
+        } else {
+            xmlFree((xmlChar*)dtdPtr->SystemID);
+        }
+    }
+
+    dtdPtr->SystemID = xmlStrdup(systemID);
+}
+
+_CFXMLDTDNodePtr _Nullable _CFXMLDTDGetElementDesc(_CFXMLDTDPtr dtd, const unsigned char* name) {
+    return xmlGetDtdElementDesc(dtd, name);
+}
+
+_CFXMLDTDNodePtr _Nullable _CFXMLDTDGetAttributeDesc(_CFXMLDTDPtr dtd, const unsigned char* elementName, const unsigned char* name) {
+    return xmlGetDtdAttrDesc(dtd, elementName, name);
+}
+
+_CFXMLDTDNodePtr _Nullable _CFXMLDTDGetNotationDesc(_CFXMLDTDPtr dtd, const unsigned char* name) {
+    xmlNotationPtr notation = xmlGetDtdNotationDesc(dtd, name);
+    _cfxmlNotation *notationPtr = calloc(sizeof(_cfxmlNotation), 1);
+    notationPtr->type = XML_NOTATION_NODE;
+    notationPtr->notation = notation;
+    notationPtr->parent = dtd;
+    notationPtr->doc = ((xmlDtdPtr)dtd)->doc;
+    notationPtr->name = notation->name;
+    
+    return notationPtr;
+}
+
+_CFXMLDTDNodePtr _Nullable _CFXMLDTDGetEntityDesc(_CFXMLDTDPtr dtd, const unsigned char* name) {
+    xmlDocPtr doc = ((xmlDtdPtr)dtd)->doc;
+    bool createdDoc = false;
+    if (doc == NULL) {
+        doc = xmlNewDoc((const xmlChar*)"1.0");
+        doc->extSubset = dtd;
+        ((xmlDtdPtr)dtd)->doc = doc;
+        createdDoc = true;
+    }
+
+    xmlEntityPtr node = xmlGetDtdEntity(doc, name);
+
+    if (!node) {
+        node = xmlGetParameterEntity(doc, name);
+    }
+    
+    if (createdDoc) {
+        doc->extSubset = NULL;
+        ((xmlDtdPtr)dtd)->doc = NULL;
+        xmlFreeDoc(doc);
+    }
+
+    return node;
+}
+
+_CFXMLDTDNodePtr _Nullable _CFXMLDTDGetPredefinedEntity(const unsigned char* name) {
+    return xmlGetPredefinedEntity(name);
+}
+
+CFIndex _CFXMLDTDElementNodeGetType(_CFXMLDTDNodePtr node) {
+    return ((xmlElementPtr)node)->etype;
+}
+
+CFIndex _CFXMLDTDEntityNodeGetType(_CFXMLDTDNodePtr node) {
+    return ((xmlEntityPtr)node)->etype;
+}
+
+CFIndex _CFXMLDTDAttributeNodeGetType(_CFXMLDTDNodePtr node) {
+    return ((xmlAttributePtr)node)->atype;
+}
+
+CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDNodeGetSystemID(_CFXMLDTDNodePtr node) {
+    switch (((xmlNodePtr)node)->type) {
+        case XML_ENTITY_DECL:
+            return CFStringCreateWithCString(NULL, (const char*)((xmlEntityPtr)node)->SystemID, kCFStringEncodingUTF8);
+
+        case XML_NOTATION_NODE:
+            return CFStringCreateWithCString(NULL, (const char*)((_cfxmlNotation*)node)->notation->SystemID, kCFStringEncodingUTF8);
+
+        default:
+            return NULL;
+    }
+}
+
+void _CFXMLDTDNodeSetSystemID(_CFXMLDTDNodePtr node, const unsigned char* systemID) {
+    switch (((xmlNodePtr)node)->type) {
+        case XML_ENTITY_DECL:
+        {
+            xmlEntityPtr entity = (xmlEntityPtr)node;
+            xmlDictPtr dict = entity->doc ? entity->doc->dict : NULL;
+            if (dict) {
+                if (!xmlDictOwns(dict, entity->SystemID)) {
+                    xmlFree((xmlChar*)entity->SystemID);
+                }
+            } else {
+                xmlFree((xmlChar*)entity->SystemID);
+            }
+            entity->SystemID = systemID ? xmlStrdup(systemID) : NULL;
+            return;
+        }
+        case XML_NOTATION_NODE:
+        {
+            xmlNotationPtr notation = ((_cfxmlNotation*)node)->notation;
+            xmlFree((xmlChar*)notation->SystemID);
+            notation->SystemID = systemID ? xmlStrdup(systemID) : NULL;
+            return;
+        }
+
+        default:
+            return;
+    }
+}
+
+CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDNodeGetPublicID(_CFXMLDTDNodePtr node) {
+    switch (((xmlNodePtr)node)->type) {
+        case XML_ENTITY_DECL:
+            return CFStringCreateWithCString(NULL, (const char*)((xmlEntityPtr)node)->ExternalID, kCFStringEncodingUTF8);
+            
+        case XML_NOTATION_NODE:
+            return CFStringCreateWithCString(NULL, (const char*)((_cfxmlNotation*)node)->notation->PublicID, kCFStringEncodingUTF8);
+            
+        default:
+            return NULL;
+    }
+}
+
+void _CFXMLDTDNodeSetPublicID(_CFXMLDTDNodePtr node, const unsigned char* publicID) {
+    switch (((xmlNodePtr)node)->type) {
+        case XML_ENTITY_DECL:
+        {
+            xmlEntityPtr entity = (xmlEntityPtr)node;
+            xmlDictPtr dict = entity->doc ? entity->doc->dict : NULL;
+            if (dict) {
+                if (!xmlDictOwns(dict, entity->ExternalID)) {
+                    xmlFree((xmlChar*)entity->ExternalID);
+                }
+            } else {
+                xmlFree((xmlChar*)entity->ExternalID);
+            }
+            entity->ExternalID = publicID ? xmlStrdup(publicID) : NULL;
+            return;
+        }
+        case XML_NOTATION_NODE:
+        {
+            xmlNotationPtr notation = ((_cfxmlNotation*)node)->notation;
+            xmlFree((xmlChar*)notation->PublicID);
+            notation->PublicID = publicID ? xmlStrdup(publicID) : NULL;
+            return;
+        }
+
+        default:
+            return;
+    }
 }
 
 void _CFXMLFreeNode(_CFXMLNodePtr node) {
-    xmlFreeNode(node);
+    if (!node) {
+        return;
+    }
+    
+    switch (((xmlNodePtr)node)->type) {
+        case XML_ENTITY_DECL:
+            if (((xmlEntityPtr)node)->etype == XML_INTERNAL_PREDEFINED_ENTITY) {
+                // predefined entity nodes are statically declared in libxml2 and can't be free'd
+                return;
+            }
+
+        case XML_NOTATION_NODE:
+            xmlFree(((_cfxmlNotation*)node)->notation);
+            free(node);
+            return;
+
+        case XML_ATTRIBUTE_DECL:
+        {
+            // xmlFreeNode doesn't take into account peculiarities of xmlAttributePtr, such
+            // as not having a content field. So we need to handle freeing it the way libxml2 would if we were
+            // behaving as it expected us to.
+            xmlAttributePtr attribute = (xmlAttributePtr)node;
+            xmlDictPtr dict = attribute->doc ? attribute->doc->dict : NULL;
+            xmlUnlinkNode(node);
+            if (attribute->tree != NULL) {
+                xmlFreeEnumeration(attribute->tree);
+            }
+            if (dict) {
+                if (!xmlDictOwns(dict, attribute->elem)) {
+                    xmlFree((xmlChar*)attribute->elem);
+                }
+                if (!xmlDictOwns(dict, attribute->name)) {
+                    xmlFree((xmlChar*)attribute->name);
+                }
+                if (!xmlDictOwns(dict, attribute->prefix)) {
+                    xmlFree((xmlChar*)attribute->prefix);
+                }
+                if (!xmlDictOwns(dict, attribute->defaultValue)) {
+                    xmlFree((xmlChar*)attribute->defaultValue);
+                }
+            } else {
+                xmlFree((xmlChar*)attribute->elem);
+                xmlFree((xmlChar*)attribute->name);
+                xmlFree((xmlChar*)attribute->prefix);
+                xmlFree((xmlChar*)attribute->defaultValue);
+            }
+            xmlFree(attribute);
+            return;
+        }
+
+        default:
+            xmlFreeNode(node);
+    }
 }
 
 void _CFXMLFreeDocument(_CFXMLDocPtr doc) {
     xmlFreeDoc(doc);
+}
+
+void _CFXMLFreeDTD(_CFXMLDTDPtr dtd) {
+    xmlFreeDtd(dtd);
+}
+
+void _CFXMLFreeProperty(_CFXMLNodePtr prop) {
+    xmlFreeProp(prop);
 }

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.h
@@ -173,6 +173,8 @@ _CFXMLDocPtr _CFXMLDocPtrFromDataWithOptions(CFDataRef data, int options);
 CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNodeLocalName(_CFXMLNodePtr node);
 CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNodePrefix(_CFXMLNodePtr node);
 
+bool _CFXMLDocValidate(_CFXMLDocPtr doc, CFErrorRef _Nullable * error);
+
 void _CFXMLFreeNode(_CFXMLNodePtr node);
 void _CFXMLFreeDocument(_CFXMLDocPtr doc);
 

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.h
@@ -48,16 +48,42 @@ extern CFIndex _kCFXMLInterfaceHuge;
 extern CFIndex _kCFXMLInterfaceOldsax;
 extern CFIndex _kCFXMLInterfaceIgnoreEnc;
 extern CFIndex _kCFXMLInterfaceBigLines;
+
+extern CFIndex _kCFXMLTypeInvalid;
 extern CFIndex _kCFXMLTypeDocument;
 extern CFIndex _kCFXMLTypeElement;
 extern CFIndex _kCFXMLTypeAttribute;
 extern CFIndex _kCFXMLTypeDTD;
 extern CFIndex _kCFXMLDocTypeHTML;
+
 extern CFIndex _kCFXMLDTDNodeTypeEntity;
 extern CFIndex _kCFXMLDTDNodeTypeAttribute;
 extern CFIndex _kCFXMLDTDNodeTypeElement;
 extern CFIndex _kCFXMLDTDNodeTypeNotation;
 
+extern CFIndex _kCFXMLDTDNodeElementTypeUndefined;
+extern CFIndex _kCFXMLDTDNodeElementTypeEmpty;
+extern CFIndex _kCFXMLDTDNodeElementTypeAny;
+extern CFIndex _kCFXMLDTDNodeElementTypeMixed;
+extern CFIndex _kCFXMLDTDNodeElementTypeElement;
+
+extern CFIndex _kCFXMLDTDNodeEntityTypeInternalGeneral;
+extern CFIndex _kCFXMLDTDNodeEntityTypeExternalGeneralParsed;
+extern CFIndex _kCFXMLDTDNodeEntityTypeExternalGeneralUnparsed;
+extern CFIndex _kCFXMLDTDNodeEntityTypeInternalParameter;
+extern CFIndex _kCFXMLDTDNodeEntityTypeExternalParameter;
+extern CFIndex _kCFXMLDTDNodeEntityTypeInternalPredefined;
+
+extern CFIndex _kCFXMLDTDNodeAttributeTypeCData;
+extern CFIndex _kCFXMLDTDNodeAttributeTypeID;
+extern CFIndex _kCFXMLDTDNodeAttributeTypeIDRef;
+extern CFIndex _kCFXMLDTDNodeAttributeTypeIDRefs;
+extern CFIndex _kCFXMLDTDNodeAttributeTypeEntity;
+extern CFIndex _kCFXMLDTDNodeAttributeTypeEntities;
+extern CFIndex _kCFXMLDTDNodeAttributeTypeNMToken;
+extern CFIndex _kCFXMLDTDNodeAttributeTypeNMTokens;
+extern CFIndex _kCFXMLDTDNodeAttributeTypeEnumeration;
+extern CFIndex _kCFXMLDTDNodeAttributeTypeNotation;
 
 typedef struct _xmlParserInput *_CFXMLInterfaceParserInput;
 typedef struct _xmlParserCtxt *_CFXMLInterfaceParserContext;
@@ -107,6 +133,8 @@ typedef void* _CFXMLNodePtr;
 typedef void* _CFXMLDocPtr;
 typedef void* _CFXMLNamespacePtr;
 typedef void* _CFXMLEntityPtr;
+typedef void* _CFXMLDTDPtr;
+typedef void* _CFXMLDTDNodePtr;
 
 _CFXMLNodePtr _CFXMLNewNode(_CFXMLNamespacePtr namespace, const char* name);
 _CFXMLNodePtr _CFXMLCopyNode(_CFXMLNodePtr node, bool recursive);
@@ -154,6 +182,8 @@ CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDocVersion(_CFXMLDocPtr doc);
 void _CFXMLDocSetVersion(_CFXMLDocPtr doc, const unsigned char* version);
 int _CFXMLDocProperties(_CFXMLDocPtr doc);
 void _CFXMLDocSetProperties(_CFXMLDocPtr doc, int newProperties);
+_CFXMLDTDPtr _Nullable _CFXMLDocDTD(_CFXMLDocPtr doc);
+void _CFXMLDocSetDTD(_CFXMLDocPtr doc, _CFXMLDTDPtr _Nullable dtd);
 
 CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLEncodeEntities(_CFXMLDocPtr doc, const unsigned char* string);
 _CFXMLEntityPtr _Nullable _CFXMLGetDocEntity(_CFXMLDocPtr doc, const char* entity);
@@ -175,8 +205,37 @@ CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNodePrefix(_CFXMLNodePtr node);
 
 bool _CFXMLDocValidate(_CFXMLDocPtr doc, CFErrorRef _Nullable * error);
 
+_CFXMLDTDPtr _CFXMLNewDTD(_CFXMLDocPtr doc, const unsigned char* name, const unsigned char* publicID, const unsigned char* systemID);
+_CFXMLDTDNodePtr _Nullable _CFXMLParseDTDNode(const unsigned char* xmlString);
+_CFXMLDTDPtr _Nullable _CFXMLParseDTD(const unsigned char* URL);
+_CFXMLDTDPtr _Nullable _CFXMLParseDTDFromData(CFDataRef data, CFErrorRef _Nullable * error);
+CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDExternalID(_CFXMLDTDPtr dtd);
+void _CFXMLDTDSetExternalID(_CFXMLDTDPtr dtd, const unsigned char* externalID);
+CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDSystemID(_CFXMLDTDPtr dtd);
+void _CFXMLDTDSetSystemID(_CFXMLDTDPtr dtd, const unsigned char* systemID);
+
+_CFXMLDTDNodePtr _Nullable _CFXMLDTDGetElementDesc(_CFXMLDTDPtr dtd, const unsigned char* name);
+_CFXMLDTDNodePtr _Nullable _CFXMLDTDGetAttributeDesc(_CFXMLDTDPtr dtd, const unsigned char* elementName, const unsigned char* name);
+_CFXMLDTDNodePtr _Nullable _CFXMLDTDGetNotationDesc(_CFXMLDTDPtr dtd, const unsigned char* name);
+_CFXMLDTDNodePtr _Nullable _CFXMLDTDGetEntityDesc(_CFXMLDTDPtr dtd, const unsigned char* name);
+_CFXMLDTDNodePtr _Nullable _CFXMLDTDGetPredefinedEntity(const unsigned char* name);
+
+_CFXMLDTDNodePtr _Nullable _CFXMLDTDNewElementDesc(_CFXMLDTDPtr dtd, const unsigned char* name);
+_CFXMLDTDNodePtr _Nullable _CFXMLDTDNewAttributeDesc(_CFXMLDTDPtr dtd, const unsigned char* name);
+
+CFIndex _CFXMLDTDElementNodeGetType(_CFXMLDTDNodePtr node);
+CFIndex _CFXMLDTDEntityNodeGetType(_CFXMLDTDNodePtr node);
+CFIndex _CFXMLDTDAttributeNodeGetType(_CFXMLDTDNodePtr node);
+
+CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDNodeGetSystemID(_CFXMLDTDNodePtr node);
+void _CFXMLDTDNodeSetSystemID(_CFXMLDTDNodePtr node, const unsigned char* systemID);
+CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDNodeGetPublicID(_CFXMLDTDNodePtr node);
+void _CFXMLDTDNodeSetPublicID(_CFXMLDTDNodePtr node, const unsigned char* publicID);
+
 void _CFXMLFreeNode(_CFXMLNodePtr node);
 void _CFXMLFreeDocument(_CFXMLDocPtr doc);
+void _CFXMLFreeDTD(_CFXMLDTDPtr dtd);
+void _CFXMLFreeProperty(_CFXMLNodePtr prop);
 
 CF_EXTERN_C_END
 CF_ASSUME_NONNULL_END

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -245,6 +245,11 @@
 		61E011811C1B5998000037DD /* CFMessagePort.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B5D88DC1BBC9AEC00234F36 /* CFMessagePort.c */; };
 		61E011821C1B599A000037DD /* CFMachPort.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B5D88D01BBC9AAC00234F36 /* CFMachPort.c */; };
 		CE19A88C1C23AA2300B4CB6A /* NSStringTestData.txt in Resources */ = {isa = PBXBuildFile; fileRef = CE19A88B1C23AA2300B4CB6A /* NSStringTestData.txt */; };
+		D834F9941C31C4060023812A /* TestNSOrderedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D834F9931C31C4060023812A /* TestNSOrderedSet.swift */; };
+		DCDBB8331C1768AC00313299 /* TestNSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDBB8321C1768AC00313299 /* TestNSData.swift */; };
+		E19E17DC1C2225930023AF4D /* TestNSXMLDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19E17DB1C2225930023AF4D /* TestNSXMLDocument.swift */; };
+		E1A03F361C4828650023AF4D /* PropertyList-1.0.dtd in Resources */ = {isa = PBXBuildFile; fileRef = E1A03F351C4828650023AF4D /* PropertyList-1.0.dtd */; };
+		E1A03F381C482C730023AF4D /* NSXMLDTDTestData.xml in Resources */ = {isa = PBXBuildFile; fileRef = E1A03F371C482C730023AF4D /* NSXMLDTDTestData.xml */; };
 		E1A3726F1C31EBFB0023AF4D /* NSXMLDocumentTestData.xml in Resources */ = {isa = PBXBuildFile; fileRef = E1A3726E1C31EBFB0023AF4D /* NSXMLDocumentTestData.xml */; };
 		EA66F6361BEED03E00136161 /* TargetConditionals.h in Headers */ = {isa = PBXBuildFile; fileRef = EA66F6351BEED03E00136161 /* TargetConditionals.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA66F6481BF1619600136161 /* NSURLTestData.plist in Resources */ = {isa = PBXBuildFile; fileRef = EA66F63B1BF1619600136161 /* NSURLTestData.plist */; };
@@ -590,6 +595,9 @@
 		CE19A88B1C23AA2300B4CB6A /* NSStringTestData.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = NSStringTestData.txt; sourceTree = "<group>"; };
 		D834F9931C31C4060023812A /* TestNSOrderedSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSOrderedSet.swift; sourceTree = "<group>"; };
 		DCDBB8321C1768AC00313299 /* TestNSData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSData.swift; sourceTree = "<group>"; };
+		E19E17DB1C2225930023AF4D /* TestNSXMLDocument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSXMLDocument.swift; sourceTree = "<group>"; };
+		E1A03F351C4828650023AF4D /* PropertyList-1.0.dtd */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "PropertyList-1.0.dtd"; sourceTree = "<group>"; };
+		E1A03F371C482C730023AF4D /* NSXMLDTDTestData.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = NSXMLDTDTestData.xml; sourceTree = "<group>"; };
 		E1A3726E1C31EBFB0023AF4D /* NSXMLDocumentTestData.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = NSXMLDocumentTestData.xml; sourceTree = "<group>"; };
 		E876A73D1C1180E000F279EC /* TestNSRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSRange.swift; sourceTree = "<group>"; };
 		EA313DFC1BE7F2E90060A403 /* CFURLComponents_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFURLComponents_Internal.h; sourceTree = "<group>"; };
@@ -1079,6 +1087,8 @@
 				528776181BF27D9500CB0090 /* Test.plist */,
 				EA66F63B1BF1619600136161 /* NSURLTestData.plist */,
 				E1A3726E1C31EBFB0023AF4D /* NSXMLDocumentTestData.xml */,
+				E1A03F351C4828650023AF4D /* PropertyList-1.0.dtd */,
+				E1A03F371C482C730023AF4D /* NSXMLDTDTestData.xml */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -1635,7 +1645,9 @@
 				528776191BF27D9500CB0090 /* Test.plist in Resources */,
 				EA66F6481BF1619600136161 /* NSURLTestData.plist in Resources */,
 				CE19A88C1C23AA2300B4CB6A /* NSStringTestData.txt in Resources */,
+				E1A03F361C4828650023AF4D /* PropertyList-1.0.dtd in Resources */,
 				E1A3726F1C31EBFB0023AF4D /* NSXMLDocumentTestData.xml in Resources */,
+				E1A03F381C482C730023AF4D /* NSXMLDTDTestData.xml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -387,7 +387,7 @@ public protocol Bridgeable {
 }
 
 #if os(OSX) || os(iOS)
-internal typealias _DarwinCompatibleBoolean = DarwinBoolean
+    internal typealias _DarwinCompatibleBoolean = DarwinBoolean
 #else
-internal typealias _DarwinCompatibleBoolean = Bool
+    internal typealias _DarwinCompatibleBoolean = Bool
 #endif

--- a/Foundation/NSXMLDTD.swift
+++ b/Foundation/NSXMLDTD.swift
@@ -13,81 +13,171 @@ import CoreFoundation
     @abstract Defines the order, repetition, and allowable values for a document
 */
 public class NSXMLDTD : NSXMLNode {
+
+    internal var _xmlDTD: _CFXMLDTDPtr {
+        return _CFXMLDTDPtr(_xmlNode)
+    }
     
-    public convenience init(contentsOfURL url: NSURL, options mask: Int) throws { NSUnimplemented() }
-    public init(data: NSData, options mask: Int) throws { NSUnimplemented() } //primitive
+    public convenience init(contentsOfURL url: NSURL, options mask: Int) throws {
+        guard let urlString = url.absoluteString else {
+            //TODO: throw an error
+            fatalError("nil URL")
+        }
+
+        let node = _CFXMLParseDTD(urlString)
+        if node == nil {
+            //TODO: throw error
+            fatalError("parsing dtd string failed")
+        }
+        self.init(ptr: node)
+    }
+
+    public convenience init(data: NSData, options mask: Int) throws {
+        var unmanagedError: Unmanaged<CFErrorRef>? = nil
+        let node = _CFXMLParseDTDFromData(data._cfObject, &unmanagedError)
+        if node == nil {
+            if let error = unmanagedError?.takeRetainedValue()._nsObject {
+                throw error
+            }
+        }
+
+        self.init(ptr: node)
+    } //primitive
     
     /*!
         @method publicID
         @abstract Sets the public id. This identifier should be in the default catalog in /etc/xml/catalog or in a path specified by the environment variable XML_CATALOG_FILES. When the public id is set the system id must also be set.
     */
-    public var publicID: String? //primitive
+    public var publicID: String? {
+        get {
+            return _CFXMLDTDExternalID(_xmlDTD)?._swiftObject
+        }
+
+        set {
+            if let value = newValue {
+                _CFXMLDTDSetExternalID(_xmlDTD, value)
+            } else {
+                _CFXMLDTDSetExternalID(_xmlDTD, nil)
+            }
+        }
+    }
     
     /*!
         @method systemID
         @abstract Sets the system id. This should be a URL that points to a valid DTD.
     */
-    public var systemID: String? //primitive
-    
+    public var systemID: String? {
+        get {
+            return _CFXMLDTDSystemID(_xmlDTD)?._swiftObject
+        }
+
+        set {
+            if let value = newValue {
+                _CFXMLDTDSetSystemID(_xmlDTD, value)
+            } else {
+                _CFXMLDTDSetSystemID(_xmlDTD, nil)
+            }
+        }
+    }
+
     /*!
         @method insertChild:atIndex:
         @abstract Inserts a child at a particular index.
     */
-    public func insertChild(child: NSXMLNode, atIndex index: Int) { NSUnimplemented() } //primitive
+    public func insertChild(child: NSXMLNode, atIndex index: Int) {
+        _insertChild(child, atIndex: index)
+    } //primitive
     
     /*!
         @method insertChildren:atIndex:
         @abstract Insert several children at a particular index.
     */
-    public func insertChildren(children: [NSXMLNode], atIndex index: Int) { NSUnimplemented() }
+    public func insertChildren(children: [NSXMLNode], atIndex index: Int) {
+        _insertChildren(children, atIndex: index)
+    }
     
     /*!
         @method removeChildAtIndex:
         @abstract Removes a child at a particular index.
     */
-    public func removeChildAtIndex(index: Int) { NSUnimplemented() } //primitive
+    public func removeChildAtIndex(index: Int) {
+        _removeChildAtIndex(index)
+    } //primitive
     
     /*!
         @method setChildren:
         @abstract Removes all existing children and replaces them with the new children. Set children to nil to simply remove all children.
     */
-    public func setChildren(children: [NSXMLNode]?) { NSUnimplemented() } //primitive
+    public func setChildren(children: [NSXMLNode]?) {
+        _setChildren(children)
+    } //primitive
     
     /*!
         @method addChild:
         @abstract Adds a child to the end of the existing children.
     */
-    public func addChild(child: NSXMLNode) { NSUnimplemented() }
+    public func addChild(child: NSXMLNode) {
+        _addChild(child)
+    }
     
     /*!
         @method replaceChildAtIndex:withNode:
         @abstract Replaces a child at a particular index with another child.
     */
-    public func replaceChildAtIndex(index: Int, withNode node: NSXMLNode) { NSUnimplemented() }
+    public func replaceChildAtIndex(index: Int, withNode node: NSXMLNode) {
+        _replaceChildAtIndex(index, withNode: node)
+    }
     
     /*!
         @method entityDeclarationForName:
         @abstract Returns the entity declaration matching this name.
     */
-    public func entityDeclarationForName(name: String) -> NSXMLDTDNode? { NSUnimplemented() } //primitive
+    public func entityDeclarationForName(name: String) -> NSXMLDTDNode? {
+        let node = _CFXMLDTDGetEntityDesc(_xmlDTD, name)
+        if node == nil {
+            return nil
+        }
+        return NSXMLDTDNode._objectNodeForNode(node)
+    } //primitive
     
     /*!
         @method notationDeclarationForName:
         @abstract Returns the notation declaration matching this name.
     */
-    public func notationDeclarationForName(name: String) -> NSXMLDTDNode? { NSUnimplemented() } //primitive
+    public func notationDeclarationForName(name: String) -> NSXMLDTDNode? {
+        let node = _CFXMLDTDGetNotationDesc(_xmlDTD, name)
+
+        if node == nil {
+            return nil
+        }
+        return NSXMLDTDNode._objectNodeForNode(node)
+    } //primitive
     
     /*!
         @method elementDeclarationForName:
         @abstract Returns the element declaration matching this name.
     */
-    public func elementDeclarationForName(name: String) -> NSXMLDTDNode? { NSUnimplemented() } //primitive
+    public func elementDeclarationForName(name: String) -> NSXMLDTDNode? {
+        let node = _CFXMLDTDGetElementDesc(_xmlDTD, name)
+
+        if node == nil {
+            return nil
+        }
+        return NSXMLDTDNode._objectNodeForNode(node)
+    } //primitive
     
     /*!
         @method attributeDeclarationForName:
         @abstract Returns the attribute declaration matching this name.
     */
-    public func attributeDeclarationForName(name: String, elementName: String) -> NSXMLDTDNode? { NSUnimplemented() } //primitive
+    public func attributeDeclarationForName(name: String, elementName: String) -> NSXMLDTDNode? {
+        let node = _CFXMLDTDGetAttributeDesc(_xmlDTD, elementName, name)
+
+        if node == nil {
+            return nil
+        }
+        return NSXMLDTDNode._objectNodeForNode(node)
+    } //primitive
     
     /*!
         @method predefinedEntityDeclarationForName:
@@ -95,7 +185,15 @@ public class NSXMLDTD : NSXMLNode {
     	@discussion The five predefined entities are
     	<ul><li>&amp;lt; - &lt;</li><li>&amp;gt; - &gt;</li><li>&amp;amp; - &amp;</li><li>&amp;quot; - &quot;</li><li>&amp;apos; - &amp;</li></ul>
     */
-    public class func predefinedEntityDeclarationForName(name: String) -> NSXMLDTDNode? { NSUnimplemented() }
+    public class func predefinedEntityDeclarationForName(name: String) -> NSXMLDTDNode? {
+        let node = _CFXMLDTDGetPredefinedEntity(name)
+
+        if node == nil {
+            return nil
+        }
+
+        return NSXMLDTDNode._objectNodeForNode(node)
+    }
     
     internal override class func _objectNodeForNode(node: _CFXMLNodePtr) -> NSXMLDTD {
         precondition(_CFXMLNodeGetType(node) == _kCFXMLTypeDTD)

--- a/Foundation/NSXMLDTDNode.swift
+++ b/Foundation/NSXMLDTDNode.swift
@@ -53,39 +53,208 @@ public class NSXMLDTDNode : NSXMLNode {
         @method initWithXMLString:
         @abstract Returns an element, attribute, entity, or notation DTD node based on the full XML string.
     */
-    public init?(XMLString string: String) { NSUnimplemented() } //primitive
+    public init?(XMLString string: String) {
+        let ptr = _CFXMLParseDTDNode(string)
+        if ptr == nil {
+            return nil
+        } else {
+            super.init(ptr: ptr)
+        }
+    } //primitive
     
-    public override init(kind: NSXMLNodeKind, options: Int) { NSUnimplemented() } //primitive
+    public override init(kind: NSXMLNodeKind, options: Int) {
+        var ptr: _CFXMLNodePtr = nil
+
+        switch kind {
+        case .ElementDeclarationKind:
+            ptr = _CFXMLDTDNewElementDesc(nil, nil)
+
+        default:
+            super.init(kind: kind, options: options)
+            return
+        }
+
+        super.init(ptr: ptr)
+    } //primitive
     
     /*!
         @method DTDKind
         @abstract Sets the DTD sub kind.
     */
-    public var DTDKind: NSXMLDTDNodeKind //primitive
+    public var DTDKind: NSXMLDTDNodeKind {
+        get {
+            switch _CFXMLNodeGetType(_xmlNode) {
+            case _kCFXMLDTDNodeTypeElement:
+                switch _CFXMLDTDElementNodeGetType(_xmlNode) {
+                case _kCFXMLDTDNodeElementTypeAny:
+                    return .NSXMLElementDeclarationAnyKind
+
+                case _kCFXMLDTDNodeElementTypeEmpty:
+                    return .NSXMLElementDeclarationEmptyKind
+
+                case _kCFXMLDTDNodeElementTypeMixed:
+                    return .NSXMLElementDeclarationMixedKind
+
+                case _kCFXMLDTDNodeElementTypeElement:
+                    return .NSXMLElementDeclarationElementKind
+
+                default:
+                    return .NSXMLElementDeclarationUndefinedKind
+                }
+
+            case _kCFXMLDTDNodeTypeEntity:
+                switch _CFXMLDTDEntityNodeGetType(_xmlNode) {
+                case _kCFXMLDTDNodeEntityTypeInternalGeneral:
+                    return .NSXMLEntityGeneralKind
+
+                case _kCFXMLDTDNodeEntityTypeExternalGeneralUnparsed:
+                    return .NSXMLEntityUnparsedKind
+
+                case _kCFXMLDTDNodeEntityTypeExternalParameter:
+                    fallthrough
+                case _kCFXMLDTDNodeEntityTypeInternalParameter:
+                    return .NSXMLEntityParameterKind
+
+                case _kCFXMLDTDNodeEntityTypeInternalPredefined:
+                    return .NSXMLEntityPredefined
+
+                case _kCFXMLDTDNodeEntityTypeExternalGeneralParsed:
+                    return .NSXMLEntityParsedKind
+
+                default:
+                    fatalError("Invalid entity declaration type");
+                }
+                
+            case _kCFXMLDTDNodeTypeAttribute:
+                switch _CFXMLDTDAttributeNodeGetType(_xmlNode) {
+                case _kCFXMLDTDNodeAttributeTypeCData:
+                    return .NSXMLAttributeCDATAKind
+
+                case _kCFXMLDTDNodeAttributeTypeID:
+                    return .NSXMLAttributeIDKind
+
+                case _kCFXMLDTDNodeAttributeTypeIDRef:
+                    return .NSXMLAttributeIDRefKind
+
+                case _kCFXMLDTDNodeAttributeTypeIDRefs:
+                    return .NSXMLAttributeIDRefsKind
+
+                case _kCFXMLDTDNodeAttributeTypeEntity:
+                    return .NSXMLAttributeEntityKind
+
+                case _kCFXMLDTDNodeAttributeTypeEntities:
+                    return .NSXMLAttributeEntitiesKind
+
+                case _kCFXMLDTDNodeAttributeTypeNMToken:
+                    return .NSXMLAttributeNMTokenKind
+
+                case _kCFXMLDTDNodeAttributeTypeNMTokens:
+                    return .NSXMLAttributeNMTokensKind
+
+                case _kCFXMLDTDNodeAttributeTypeEnumeration:
+                    return .NSXMLAttributeEnumerationKind
+
+                case _kCFXMLDTDNodeAttributeTypeNotation:
+                    return .NSXMLAttributeNotationKind
+
+                default:
+                    fatalError("Invalid attribute declaration type")
+                }
+
+            case _kCFXMLTypeInvalid:
+                return unsafeBitCast(0, NSXMLDTDNodeKind.self) // this mirrors Darwin
+                
+            default:
+                fatalError("This is not actually a DTD node!")
+            }
+        }
+    }//primitive
     
     /*!
         @method isExternal
         @abstract True if the system id is set. Valid for entities and notations.
     */
-    public var external: Bool { NSUnimplemented() } //primitive
+    public var external: Bool {
+        return systemID != nil
+    } //primitive
     
     /*!
         @method publicID
         @abstract Sets the public id. This identifier should be in the default catalog in /etc/xml/catalog or in a path specified by the environment variable XML_CATALOG_FILES. When the public id is set the system id must also be set. Valid for entities and notations.
     */
-    public var publicID: String? //primitive
+    public var publicID: String? {
+        get {
+            return _CFXMLDTDNodeGetPublicID(_xmlNode)?._swiftObject
+        }
+        set {
+            if let value = newValue {
+                _CFXMLDTDNodeSetPublicID(_xmlNode, value)
+            } else {
+                _CFXMLDTDNodeSetPublicID(_xmlNode, nil)
+            }
+        }
+    }
     
     /*!
         @method systemID
         @abstract Sets the system id. This should be a URL that points to a valid DTD. Valid for entities and notations.
     */
-    public var systemID: String? //primitive
+    public var systemID: String? {
+        get {
+            return _CFXMLDTDNodeGetSystemID(_xmlNode)?._swiftObject
+        }
+        set {
+            if let value = newValue {
+                _CFXMLDTDNodeSetSystemID(_xmlNode, value)
+            } else {
+                _CFXMLDTDNodeSetSystemID(_xmlNode, nil)
+            }
+        }
+    }
     
     /*!
         @method notationName
         @abstract Set the notation name. Valid for entities only.
     */
-    public var notationName: String? //primitive
+    public var notationName: String? {
+        get {
+            guard DTDKind == .NSXMLEntityUnparsedKind else {
+                return nil
+            }
+
+            return _CFXMLGetEntityContent(_xmlNode)?._swiftObject
+        }
+        set {
+            guard DTDKind == .NSXMLEntityUnparsedKind else {
+                return
+            }
+
+            if let value = newValue {
+                _CFXMLNodeSetContent(_xmlNode, value)
+            } else {
+                _CFXMLNodeSetContent(_xmlNode, nil)
+            }
+        }
+    }//primitive
+
+    internal override class func _objectNodeForNode(node: _CFXMLNodePtr) -> NSXMLDTDNode {
+        let type = _CFXMLNodeGetType(node)
+        precondition(type == _kCFXMLDTDNodeTypeAttribute ||
+                     type == _kCFXMLDTDNodeTypeNotation  ||
+                     type == _kCFXMLDTDNodeTypeEntity    ||
+                     type == _kCFXMLDTDNodeTypeElement)
+
+        if _CFXMLNodeGetPrivateData(node) != nil {
+            let unmanaged = Unmanaged<NSXMLDTDNode>.fromOpaque(_CFXMLNodeGetPrivateData(node))
+            return unmanaged.takeUnretainedValue()
+        }
+
+        return NSXMLDTDNode(ptr: node)
+    }
+
+    internal override init(ptr: _CFXMLNodePtr) {
+        super.init(ptr: ptr)
+    }
 }
 
 

--- a/Foundation/NSXMLDocument.swift
+++ b/Foundation/NSXMLDocument.swift
@@ -88,6 +88,10 @@ public class NSXMLDocument : NSXMLNode {
     public init(data: NSData, options mask: Int) throws {
         let docPtr = _CFXMLDocPtrFromDataWithOptions(data._cfObject, Int32(mask))
         super.init(ptr: _CFXMLNodePtr(docPtr))
+
+        if mask & NSXMLDocumentValidate != 0 {
+            try validate()
+        }
     } //primitive
 
     /*!
@@ -306,7 +310,15 @@ public class NSXMLDocument : NSXMLNode {
     */
     public func objectByApplyingXSLTAtURL(xsltURL: NSURL, arguments argument: [String : String]?) throws -> AnyObject { NSUnimplemented() }
 
-    public func validate() throws { NSUnimplemented() }
+    public func validate() throws {
+        var unmanagedError: Unmanaged<CFError>? = nil
+        let result = _CFXMLDocValidate(_xmlDoc, &unmanagedError)
+        if !result,
+            let unmanagedError = unmanagedError {
+            let error = unmanagedError.takeRetainedValue()
+            throw error._nsObject
+        }
+    }
 
     internal override class func _objectNodeForNode(node: _CFXMLNodePtr) -> NSXMLDocument {
         precondition(_CFXMLNodeGetType(node) == _kCFXMLTypeDocument)

--- a/Foundation/NSXMLDocument.swift
+++ b/Foundation/NSXMLDocument.swift
@@ -197,7 +197,33 @@ public class NSXMLDocument : NSXMLNode {
         @method DTD
         @abstract Set the associated DTD. This DTD will be output with the document.
     */
-    /*@NSCopying*/ public var DTD: NSXMLDTD? //primitive
+    /*@NSCopying*/ public var DTD: NSXMLDTD? {
+        get {
+            return NSXMLDTD._objectNodeForNode(_CFXMLDocDTD(_xmlDoc));
+        }
+        set {
+            let currDTD = _CFXMLDocDTD(_xmlDoc)
+            if currDTD != nil {
+                if _CFXMLNodeGetPrivateData(currDTD) != nil {
+                    let DTD = NSXMLDTD._objectNodeForNode(currDTD)
+                    _CFXMLUnlinkNode(currDTD)
+                    _childNodes.remove(DTD)
+                } else {
+                    _CFXMLFreeDTD(currDTD)
+                }
+            }
+
+            if let value = newValue {
+                guard let dtd = value.copy() as? NSXMLDTD else {
+                    fatalError("Failed to copy DTD")
+                }
+                _CFXMLDocSetDTD(_xmlDoc, dtd._xmlDTD)
+                _childNodes.insert(dtd)
+            } else {
+                _CFXMLDocSetDTD(_xmlDoc, nil)
+            }
+        }
+    }//primitive
 
     /*!
         @method setRootElement:

--- a/TestFoundation/Resources/NSXMLDTDTestData.xml
+++ b/TestFoundation/Resources/NSXMLDTDTestData.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0'?>
+<!DOCTYPE root [
+    <!NOTATION myNotation SYSTEM 'http://www.example.com' >
+    <!ELEMENT root (foo | bar | baz)> <!ELEMENT foo (string, bar)>
+    <!ELEMENT bar (#PCDATA)> <!ELEMENT baz (#PCDATA)>
+    <!ELEMENT string (#PCDATA)>
+    <!ELEMENT fooBar (foo | bar)*>
+    <!ELEMENT img EMPTY>
+    <!ATTLIST foo
+        src CDATA   #REQUIRED
+        id  ID      #IMPLIED
+        print (yes | no) "yes"
+    >
+]>
+<root>
+    <foo src='hello'>
+        <string>Hello</string>
+        <bar>world</bar>
+    </foo>
+</root>

--- a/TestFoundation/Resources/PropertyList-1.0.dtd
+++ b/TestFoundation/Resources/PropertyList-1.0.dtd
@@ -1,0 +1,19 @@
+<!ENTITY % plistObject "(array | data | date | dict | real | integer | string | true | false )" >
+<!ELEMENT plist %plistObject;>
+<!ATTLIST plist version CDATA "1.0" >
+
+<!-- Collections -->
+<!ELEMENT array (%plistObject;)*>
+<!ELEMENT dict (key, %plistObject;)*>
+<!ELEMENT key (#PCDATA)>
+
+<!--- Primitive types -->
+<!ELEMENT string (#PCDATA)>
+<!ELEMENT data (#PCDATA)> <!-- Contents interpreted as Base-64 encoded -->
+<!ELEMENT date (#PCDATA)> <!-- Contents should conform to a subset of ISO 8601 (in particular, YYYY '-' MM '-' DD 'T' HH ':' MM ':' SS 'Z'.  Smaller units may be omitted with a loss of precision) -->
+
+<!-- Numerical primitives -->
+<!ELEMENT true EMPTY>  <!-- Boolean constant true -->
+<!ELEMENT false EMPTY> <!-- Boolean constant false -->
+<!ELEMENT real (#PCDATA)> <!-- Contents should represent a floating point number matching ("+" | "-")? d+ ("."d*)? ("E" ("+" | "-") d+)? where d is a digit 0-9.  -->
+<!ELEMENT integer (#PCDATA)> <!-- Contents should represent a (possibly signed) integer number in base 10 -->

--- a/build.py
+++ b/build.py
@@ -357,6 +357,8 @@ foundation_tests_resources = CopyResources('TestFoundation', [
     'TestFoundation/Resources/Test.plist',
     'TestFoundation/Resources/NSStringTestData.txt',
     'TestFoundation/Resources/NSXMLDocumentTestData.xml',
+    'TestFoundation/Resources/PropertyList-1.0.dtd',
+    'TestFoundation/Resources/NSXMLDTDTestData.xml',
 ])
 
 # TODO: Probably this should be another 'product', but for now it's simply a phase


### PR DESCRIPTION
Namespaces are still basically completely unsupported. There are some hack-y things in this one because libxml2 doesn't quite handle things the way Darwin's NSXMLDocument seems to. That said, everything seems to work. There is one thing that is _technically_ an API change; `objectValue` for a `NSXMLNodeKind.ElementDeclarationKind` on Darwin returns a `NSXMLElementDeclarationContent`, but that is private API that I have no access to or knowledge of despite the lack of a leading underscore. Since it's (apparently, it isn't in any public header or documentation anyway) private, are we OK to not use such a structure here?

There are two test functions I had to disable on Linux because they were segfaulting in swift_dynamicCast. This has something to do with `throw`ing an NSError.

Also, on OS X, tests were spinning forever on the `NSTask` test, but that's happening for me on an unmodified master branch too, so it's nothing to do with this code!