### PR TITLE
Unicode-compatible (mostly) hasPrefix and hasSuffix

### DIFF
--- a/Foundation/String.swift
+++ b/Foundation/String.swift
@@ -1579,43 +1579,26 @@ extension String {
             ) != nil
         return r
     }
-    
-#if os(Linux)
+}
+
+#if !_runtime(_ObjC)
+import CoreFoundation
+
+extension String {
     public func hasPrefix(prefix: String) -> Bool {
-        let characters = utf16
-        let prefixCharacters = prefix.utf16
-        let start = characters.startIndex
-        let prefixStart = prefixCharacters.startIndex
-        if characters.count < prefixCharacters.count {
-            return false
-        }
-        for idx in 0..<prefixCharacters.count {
-            if characters[start.advancedBy(idx)] != prefixCharacters[prefixStart.advancedBy(idx)] {
-                return false
-            }
-        }
-        return true
+        let cfstring = self._cfObject
+        let range = CFRangeMake(0, CFStringGetLength(cfstring))
+        let opts = CFStringCompareFlags(kCFCompareAnchored + kCFCompareNonliteral)
+
+        return CFStringFindWithOptions(cfstring, prefix._cfObject, range, opts, nil)
     }
 
     public func hasSuffix(suffix: String) -> Bool {
-        let characters = utf16
-        let suffixCharacters = suffix.utf16
-        let start = characters.startIndex
-        let suffixStart = suffixCharacters.startIndex
-        
-        if characters.count < suffixCharacters.count {
-            return false
-        }
-        for idx in 0..<suffixCharacters.count {
-            let charactersIdx = start.advancedBy(characters.count - idx - 1)
-            let suffixIdx = suffixStart.advancedBy(suffixCharacters.count - idx - 1)
-            if characters[charactersIdx] != suffixCharacters[suffixIdx] {
-                return false
-            }
-        }
-        return true
+        let cfstring = self._cfObject
+        let range = CFRangeMake(0, CFStringGetLength(cfstring))
+        let opts = CFStringCompareFlags(kCFCompareAnchored + kCFCompareBackwards + kCFCompareNonliteral)
+
+        return CFStringFindWithOptions(cfstring, suffix._cfObject, range, opts, nil)
     }
-#endif
 }
-
-
+#endif

--- a/Foundation/String.swift
+++ b/Foundation/String.swift
@@ -1588,17 +1588,21 @@ extension String {
     public func hasPrefix(prefix: String) -> Bool {
         let cfstring = self._cfObject
         let range = CFRangeMake(0, CFStringGetLength(cfstring))
-        let opts = CFStringCompareFlags(kCFCompareAnchored + kCFCompareNonliteral)
+        let opts = CFStringCompareFlags(
+            kCFCompareAnchored | kCFCompareNonliteral)
 
-        return CFStringFindWithOptions(cfstring, prefix._cfObject, range, opts, nil)
+        return CFStringFindWithOptions(cfstring, prefix._cfObject,
+            range, opts, nil)
     }
 
     public func hasSuffix(suffix: String) -> Bool {
         let cfstring = self._cfObject
         let range = CFRangeMake(0, CFStringGetLength(cfstring))
-        let opts = CFStringCompareFlags(kCFCompareAnchored + kCFCompareBackwards + kCFCompareNonliteral)
+        let opts = CFStringCompareFlags(
+            kCFCompareAnchored | kCFCompareBackwards | kCFCompareNonliteral)
 
-        return CFStringFindWithOptions(cfstring, suffix._cfObject, range, opts, nil)
+        return CFStringFindWithOptions(cfstring, suffix._cfObject,
+            range, opts, nil)
     }
 }
 #endif


### PR DESCRIPTION
The version of hasPrefix and hasSuffix originally found in Foundation for Linux does not do well with Unicode strings. The implementations is this PR reproduce those supplied in the standard library in the presence of the Objective-C runtime, namely swift_stdlib_NSStringHasPrefixNFD and swift_stdlib_NSStringHasSuffixNFD. The test results are largely the same, that is the issues appear to be the same (except the issues related to embedded nulls.)

Closing https://github.com/apple/swift-corelibs-foundation/pull/238, as it is superseded by this.