### PR TITLE
Use implicit getters for read-only properties

### DIFF
--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -39,12 +39,10 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
     internal var _storage = [AnyObject]()
     
     public var count: Int {
-        get {
-            if self.dynamicType === NSArray.self || self.dynamicType === NSMutableArray.self {
-                return _storage.count
-            } else {
-                NSRequiresConcreteImplementation()
-            }
+        if self.dynamicType === NSArray.self || self.dynamicType === NSMutableArray.self {
+            return _storage.count
+        } else {
+            NSRequiresConcreteImplementation()
         }
     }
     
@@ -148,13 +146,11 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
     }
 
     internal var allObjects: [AnyObject] {
-        get {
-            if self.dynamicType === NSArray.self || self.dynamicType === NSMutableArray.self {
-                return _storage
-            } else {
-                return (0..<count).map { idx in
-                    return self[idx]
-                }
+        if self.dynamicType === NSArray.self || self.dynamicType === NSMutableArray.self {
+            return _storage
+        } else {
+            return (0..<count).map { idx in
+                return self[idx]
             }
         }
     }
@@ -274,22 +270,18 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
     }
 
     public var firstObject: AnyObject? {
-        get {
-            if count > 0 {
-                return objectAtIndex(0)
-            } else {
-                return nil
-            }
+        if count > 0 {
+            return objectAtIndex(0)
+        } else {
+            return nil
         }
     }
     
     public var lastObject: AnyObject? {
-        get {
-            if count > 0 {
-                return objectAtIndex(count - 1)
-            } else {
-                return nil
-            }
+        if count > 0 {
+            return objectAtIndex(count - 1)
+        } else {
+            return nil
         }
     }
     
@@ -324,15 +316,13 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
     }
     
     /*@NSCopying*/ public var sortedArrayHint: NSData {
-        get {
-            let buffer = UnsafeMutablePointer<Int32>.alloc(count)
-            for idx in 0..<count {
-                let item = objectAtIndex(idx) as! NSObject
-                let hash = item.hash
-                buffer.advancedBy(idx).memory = Int32(hash).littleEndian
-            }
-            return NSData(bytesNoCopy: unsafeBitCast(buffer, UnsafeMutablePointer<Void>.self), length: count * sizeof(Int), freeWhenDone: true)
+        let buffer = UnsafeMutablePointer<Int32>.alloc(count)
+        for idx in 0..<count {
+            let item = objectAtIndex(idx) as! NSObject
+            let hash = item.hash
+            buffer.advancedBy(idx).memory = Int32(hash).littleEndian
         }
+        return NSData(bytesNoCopy: unsafeBitCast(buffer, UnsafeMutablePointer<Void>.self), length: count * sizeof(Int), freeWhenDone: true)
     }
     
     public func sortedArrayUsingFunction(comparator: @convention(c) (AnyObject, AnyObject, UnsafeMutablePointer<Void>) -> Int, context: UnsafeMutablePointer<Void>) -> [AnyObject] {
@@ -368,13 +358,11 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
     }
     
     public subscript (idx: Int) -> AnyObject {
-        get {
-            guard idx < count && idx >= 0 else {
-                fatalError("\(self): Index out of bounds")
-            }
-            
-            return objectAtIndex(idx)
+        guard idx < count && idx >= 0 else {
+            fatalError("\(self): Index out of bounds")
         }
+        
+        return objectAtIndex(idx)
     }
     
     public func enumerateObjectsUsingBlock(block: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Void) {

--- a/Foundation/NSCFArray.swift
+++ b/Foundation/NSCFArray.swift
@@ -25,9 +25,7 @@ internal final class _NSCFArray : NSMutableArray {
     }
     
     override var count: Int {
-        get {
-            return CFArrayGetCount(_cfObject)
-        }
+        return CFArrayGetCount(_cfObject)
     }
     
     override func objectAtIndex(index: Int) -> AnyObject {

--- a/Foundation/NSCFString.swift
+++ b/Foundation/NSCFString.swift
@@ -55,17 +55,13 @@ internal class _NSCFString : NSMutableString {
 
 internal final class _NSCFConstantString : _NSCFString {
     internal var _ptr : UnsafePointer<UInt8> {
-        get {
-            let ptr = unsafeAddressOf(self) + sizeof(COpaquePointer) + sizeof(Int32) + sizeof(Int32) + sizeof(_CFInfo)
-            return UnsafePointer<UnsafePointer<UInt8>>(ptr).memory
-        }
+        let ptr = unsafeAddressOf(self) + sizeof(COpaquePointer) + sizeof(Int32) + sizeof(Int32) + sizeof(_CFInfo)
+        return UnsafePointer<UnsafePointer<UInt8>>(ptr).memory
     }
     internal var _length : UInt32 {
-        get {
-            let offset = sizeof(COpaquePointer) + sizeof(Int32) + sizeof(Int32) + sizeof(_CFInfo) + sizeof(UnsafePointer<UInt8>)
-            let ptr = unsafeAddressOf(self) + offset
-            return UnsafePointer<UInt32>(ptr).memory
-        }
+        let offset = sizeof(COpaquePointer) + sizeof(Int32) + sizeof(Int32) + sizeof(_CFInfo) + sizeof(UnsafePointer<UInt8>)
+        let ptr = unsafeAddressOf(self) + offset
+        return UnsafePointer<UInt32>(ptr).memory
     }
     
     required init(characters: UnsafePointer<unichar>, length: Int) {

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -148,9 +148,7 @@ public class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     }
     
     public override var hash: Int {
-        get {
-            return Int(bitPattern: CFHash(_cfObject))
-        }
+        return Int(bitPattern: CFHash(_cfObject))
     }
     
     public override func isEqual(object: AnyObject?) -> Bool {
@@ -162,9 +160,7 @@ public class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     }
     
     public override var description: String {
-        get {
-            return CFCopyDescription(_cfObject)._swiftObject
-        }
+        return CFCopyDescription(_cfObject)._swiftObject
     }
 
     deinit {

--- a/Foundation/NSCharacterSet.swift
+++ b/Foundation/NSCharacterSet.swift
@@ -46,9 +46,7 @@ public class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
     }
     
     public override var hash: Int {
-        get {
-            return Int(bitPattern: CFHash(_cfObject))
-        }
+        return Int(bitPattern: CFHash(_cfObject))
     }
     
     public override func isEqual(object: AnyObject?) -> Bool {
@@ -60,9 +58,7 @@ public class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
     }
     
     public override var description: String {
-        get {
-            return CFCopyDescription(_cfObject)._swiftObject
-        }
+        return CFCopyDescription(_cfObject)._swiftObject
     }
 
     deinit {
@@ -161,15 +157,11 @@ public class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
     }
     
     public var bitmapRepresentation: NSData {
-        get {
-            return CFCharacterSetCreateBitmapRepresentation(kCFAllocatorSystemDefault, _cfObject)._nsObject
-        }
+        return CFCharacterSetCreateBitmapRepresentation(kCFAllocatorSystemDefault, _cfObject)._nsObject
     }
     
     public var invertedSet: NSCharacterSet {
-        get {
-            return CFCharacterSetCreateInvertedSet(kCFAllocatorSystemDefault, _cfObject)._nsObject
-        }
+        return CFCharacterSetCreateInvertedSet(kCFAllocatorSystemDefault, _cfObject)._nsObject
     }
     
     public func longCharacterIsMember(theLongChar: UTF32Char) -> Bool {

--- a/Foundation/NSCoder.swift
+++ b/Foundation/NSCoder.swift
@@ -158,9 +158,7 @@ public class NSCoder : NSObject {
     }
     
     public var allowsKeyedCoding: Bool {
-        get {
-            return false
-        }
+        return false
     }
     
     public func encodeObject(objv: AnyObject?, forKey key: String) {
@@ -244,9 +242,7 @@ public class NSCoder : NSObject {
     }
     
     public var requiresSecureCoding: Bool {
-        get {
-            return false
-        }
+        return false
     }
     
     public func decodePropertyListForKey(key: String) -> AnyObject? {
@@ -254,9 +250,7 @@ public class NSCoder : NSObject {
     }
     
     public var allowedClasses: Set<NSObject>? {
-        get {
-            NSUnimplemented()
-        }
+        NSUnimplemented()
     }
     
     public func failWithError(error: NSError) {

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -80,12 +80,10 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     private var _bytes: UnsafeMutablePointer<UInt8> = nil
     
     internal var _cfObject: CFType {
-        get {
-            if self.dynamicType === NSData.self || self.dynamicType === NSMutableData.self {
-                return unsafeBitCast(self, CFType.self)
-            } else {
-                return CFDataCreate(kCFAllocatorSystemDefault, unsafeBitCast(self.bytes, UnsafePointer<UInt8>.self), self.length)
-            }
+        if self.dynamicType === NSData.self || self.dynamicType === NSMutableData.self {
+            return unsafeBitCast(self, CFType.self)
+        } else {
+            return CFDataCreate(kCFAllocatorSystemDefault, unsafeBitCast(self.bytes, UnsafePointer<UInt8>.self), self.length)
         }
     }
     
@@ -94,9 +92,7 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     }
     
     public override var hash: Int {
-        get {
-            return Int(bitPattern: CFHash(_cfObject))
-        }
+        return Int(bitPattern: CFHash(_cfObject))
     }
     
     public override func isEqual(object: AnyObject?) -> Bool {
@@ -134,15 +130,11 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     }
     
     public var length: Int {
-        get {
-            return CFDataGetLength(_cfObject)
-        }
+        return CFDataGetLength(_cfObject)
     }
 
     public var bytes: UnsafePointer<Void> {
-        get {
-            return UnsafePointer<Void>(CFDataGetBytePtr(_cfObject))
-        }
+        return UnsafePointer<Void>(CFDataGetBytePtr(_cfObject))
     }
     
     public override func copy() -> AnyObject {
@@ -582,9 +574,7 @@ public class NSMutableData : NSData {
     }
     
     public var mutableBytes: UnsafeMutablePointer<Void> {
-        get {
-            return UnsafeMutablePointer(CFDataGetMutableBytePtr(_cfMutableObject))
-        }
+        return UnsafeMutablePointer(CFDataGetMutableBytePtr(_cfMutableObject))
     }
     
     public override var length: Int {

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -18,18 +18,14 @@ import CoreFoundation
 public typealias NSTimeInterval = Double
 
 public var NSTimeIntervalSince1970: Double {
-    get {
-        return 978307200.0
-    }
+    return 978307200.0
 }
 
 public class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
     typealias CFType = CFDateRef
     
     public override var hash: Int {
-        get {
-            return Int(bitPattern: CFHash(_cfObject))
-        }
+        return Int(bitPattern: CFHash(_cfObject))
     }
     
     public override func isEqual(object: AnyObject?) -> Bool {
@@ -52,9 +48,7 @@ public class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
     internal let _timeIntervalSinceReferenceDate: NSTimeInterval
     
     public var timeIntervalSinceReferenceDate: NSTimeInterval {
-        get {
-            return _timeIntervalSinceReferenceDate
-        }
+        return _timeIntervalSinceReferenceDate
     }
     
     public convenience override init() {
@@ -105,14 +99,12 @@ public class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
      `descriptionWithCalendarFormat:timeZone:locale:`.
      */
     public override var description: String {
-        get {
-            let dateFormatterRef = CFDateFormatterCreate(kCFAllocatorSystemDefault, nil, kCFDateFormatterFullStyle, kCFDateFormatterFullStyle)
-            let timeZone = CFTimeZoneCreateWithTimeIntervalFromGMT(kCFAllocatorSystemDefault, 0.0)
-            CFDateFormatterSetProperty(dateFormatterRef, kCFDateFormatterTimeZoneKey, timeZone)
-            CFDateFormatterSetFormat(dateFormatterRef, "uuuu-MM-dd HH:mm:ss '+0000'"._cfObject)
+        let dateFormatterRef = CFDateFormatterCreate(kCFAllocatorSystemDefault, nil, kCFDateFormatterFullStyle, kCFDateFormatterFullStyle)
+        let timeZone = CFTimeZoneCreateWithTimeIntervalFromGMT(kCFAllocatorSystemDefault, 0.0)
+        CFDateFormatterSetProperty(dateFormatterRef, kCFDateFormatterTimeZoneKey, timeZone)
+        CFDateFormatterSetFormat(dateFormatterRef, "uuuu-MM-dd HH:mm:ss '+0000'"._cfObject)
 
-            return CFDateFormatterCreateStringWithDate(kCFAllocatorSystemDefault, dateFormatterRef, _cfObject)._swiftObject
-        }
+        return CFDateFormatterCreateStringWithDate(kCFAllocatorSystemDefault, dateFormatterRef, _cfObject)._swiftObject
     }
 
     /**
@@ -149,15 +141,11 @@ extension NSDate {
     }
     
     public var timeIntervalSinceNow: NSTimeInterval {
-        get {
-            return timeIntervalSinceDate(NSDate())
-        }
+        return timeIntervalSinceDate(NSDate())
     }
     
     public var timeIntervalSince1970: NSTimeInterval {
-        get {
-            return timeIntervalSinceReferenceDate + NSTimeIntervalSince1970
-        }
+        return timeIntervalSinceReferenceDate + NSTimeIntervalSince1970
     }
     
     public func dateByAddingTimeInterval(ti: NSTimeInterval) -> NSDate {

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -98,12 +98,10 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
     internal var _storage = [NSObject: AnyObject]()
     
     public var count: Int {
-        get {
-            if self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self {
-                return _storage.count
-            } else {
-                NSRequiresConcreteImplementation()
-            }
+        if self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self {
+            return _storage.count
+        } else {
+            NSRequiresConcreteImplementation()
         }
     }
     
@@ -229,32 +227,28 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
     }
 
     public var allKeys: [AnyObject] {
-        get {
-            if self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self {
-                return _storage.keys.map { $0 }
-            } else {
-                var keys = [AnyObject]()
-                let enumerator = keyEnumerator()
-                while let key = enumerator.nextObject() {
-                    keys.append(key)
-                }
-                return keys
+        if self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self {
+            return _storage.keys.map { $0 }
+        } else {
+            var keys = [AnyObject]()
+            let enumerator = keyEnumerator()
+            while let key = enumerator.nextObject() {
+                keys.append(key)
             }
+            return keys
         }
     }
     
     public var allValues: [AnyObject] {
-        get {
-            if self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self {
-                return _storage.values.map { $0 }
-            } else {
-                var values = [AnyObject]()
-                let enumerator = keyEnumerator()
-                while let key = enumerator.nextObject() {
-                    values.append(objectForKey(key)!)
-                }
-                return values
+        if self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self {
+            return _storage.values.map { $0 }
+        } else {
+            var values = [AnyObject]()
+            let enumerator = keyEnumerator()
+            while let key = enumerator.nextObject() {
+                values.append(objectForKey(key)!)
             }
+            return values
         }
     }
     
@@ -279,9 +273,7 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
     }
     
     public subscript (key: AnyObject) -> AnyObject? {
-        get {
-            return objectForKey(key)
-        }
+        return objectForKey(key)
     }
     
     
@@ -306,9 +298,7 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
     /// [Property List Programming Guide](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/PropertyLists/Introduction/Introduction.html#//apple_ref/doc/uid/10000048i)
     /// and [Archives and Serializations Programming Guide](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/Archiving/Archiving.html#//apple_ref/doc/uid/10000047i).
     public override var description: String {
-        get {
-            return descriptionWithLocale(nil)
-        }
+        return descriptionWithLocale(nil)
     }
 
     public var descriptionInStringsFileFormat: String { NSUnimplemented() }

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -34,9 +34,7 @@ public class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
     typealias CFType = CFErrorRef
     
     internal var _cfObject: CFType {
-        get {
-            return CFErrorCreate(kCFAllocatorSystemDefault, domain._cfObject, code, nil)
-        }
+        return CFErrorCreate(kCFAllocatorSystemDefault, domain._cfObject, code, nil)
     }
     
     // ErrorType forbids this being internal
@@ -76,65 +74,47 @@ public class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     public var domain: String {
-        get {
-            return _domain
-        }
+        return _domain
     }
     
     public var code: Int {
-        get {
-            return _code
-        }
+        return _code
     }
 
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation
     /// - Note: This API differs from Darwin because it uses [String : Any] as a type instead of [String : AnyObject]. This allows the use of Swift value types.
     public var userInfo: [String : Any] {
-        get {
-            if let info = _userInfo {
-                return info
-            } else {
-                return Dictionary<String, Any>()
-            }
+        if let info = _userInfo {
+            return info
+        } else {
+            return Dictionary<String, Any>()
         }
     }
     
     public var localizedDescription: String {
-        get {
-            let desc = userInfo[NSLocalizedDescriptionKey] as? String
-            
-            return desc ?? "The operation could not be completed"
-        }
+        let desc = userInfo[NSLocalizedDescriptionKey] as? String
+        
+        return desc ?? "The operation could not be completed"
     }
     
     public var localizedFailureReason: String? {
-        get {
-            return userInfo[NSLocalizedFailureReasonErrorKey] as? String
-        }
+        return userInfo[NSLocalizedFailureReasonErrorKey] as? String
     }
     
     public var localizedRecoverySuggestion: String? {
-        get {
-            return userInfo[NSLocalizedRecoverySuggestionErrorKey] as? String
-        }
+        return userInfo[NSLocalizedRecoverySuggestionErrorKey] as? String
     }
 
     public var localizedRecoveryOptions: [String]? {
-        get {
-            return userInfo[NSLocalizedRecoveryOptionsErrorKey] as? [String]
-        }
+        return userInfo[NSLocalizedRecoveryOptionsErrorKey] as? [String]
     }
     
     public var recoveryAttempter: AnyObject? {
-        get {
-            return userInfo[NSRecoveryAttempterErrorKey] as? AnyObject
-        }
+        return userInfo[NSRecoveryAttempterErrorKey] as? AnyObject
     }
     
     public var helpAnchor: String? {
-        get {
-            return userInfo[NSHelpAnchorErrorKey] as? String
-        }
+        return userInfo[NSHelpAnchorErrorKey] as? String
     }
     
     internal typealias NSErrorProvider = (error: NSError, key: String) -> AnyObject?

--- a/Foundation/NSHost.swift
+++ b/Foundation/NSHost.swift
@@ -112,35 +112,25 @@ public class NSHost : NSObject {
     }
     
     public var name: String? {
-        get {
-            return names.first
-        }
+        return names.first
     }
     
     public var names: [String] {
-        get {
-            _resolve()
-            return _names
-        }
+        _resolve()
+        return _names
     }
     
     public var address: String? {
-        get {
-            return addresses.first
-        }
+        return addresses.first
     }
     
     public var addresses: [String] {
-        get {
-            _resolve()
-            return _addresses
-        }
+        _resolve()
+        return _addresses
     }
     
     public var localizedName: String? {
-        get {
-            return nil
-        }
+        return nil
     }
 }
 

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -90,9 +90,7 @@ public class NSKeyedArchiver : NSCoder {
     
     // Enables secure coding support on this keyed archiver. You do not need to enable secure coding on the archiver to enable secure coding on the unarchiver. Enabling secure coding on the archiver is a way for you to be sure that all classes that are encoded conform with NSSecureCoding (it will throw an exception if a class which does not NSSecureCoding is archived). Note that the getter is on the superclass, NSCoder. See NSCoder for more information about secure coding.
     public override var requiresSecureCoding: Bool {
-        get {
-            return false
-        }
+        return false
     }
 }
 
@@ -174,9 +172,7 @@ public class NSKeyedUnarchiver : NSCoder {
     
     // Enables secure coding support on this keyed unarchiver. When enabled, anarchiving a disallowed class throws an exception. Once enabled, attempting to set requiresSecureCoding to NO will throw an exception. This is to prevent classes from selectively turning secure coding off. This is designed to be set once at the top level and remain on. Note that the getter is on the superclass, NSCoder. See NSCoder for more information about secure coding.
     public override var requiresSecureCoding: Bool {
-        get {
             return false
-        }
     }
 }
 

--- a/Foundation/NSLock.swift
+++ b/Foundation/NSLock.swift
@@ -83,9 +83,7 @@ public class NSConditionLock : NSObject, NSLocking {
     }
     
     public var condition: Int {
-        get {
-            return _value
-        }
+        return _value
     }
     
     public func lockWhenCondition(condition: Int) {

--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -42,20 +42,18 @@ public class NSNotification : NSObject, NSCopying, NSCoding {
     }
     
     public override var description: String {
-        get {
-            var str = "\(self.dynamicType) \(unsafeAddressOf(self)) {"
-            
-            str += "name = \(self.name)"
-            if let object = self.object {
-                str += "; object = \(object)"
-            }
-            if let userInfo = self.userInfo {
-                str += "; userInfo = \(userInfo)"
-            }
-            str += "}"
-            
-            return str
+        var str = "\(self.dynamicType) \(unsafeAddressOf(self)) {"
+        
+        str += "name = \(self.name)"
+        if let object = self.object {
+            str += "; object = \(object)"
         }
+        if let userInfo = self.userInfo {
+            str += "; userInfo = \(userInfo)"
+        }
+        str += "}"
+        
+        return str
     }
 }
 

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -132,15 +132,11 @@ public class NSNumber : NSValue {
     private var _pad: UInt64 = 0
     
     internal var _cfObject: CFType {
-        get {
-            return unsafeBitCast(self, CFType.self)
-        }
+        return unsafeBitCast(self, CFType.self)
     }
     
     public override var hash: Int {
-        get {
-            return Int(bitPattern: CFHash(_cfObject))
-        }
+        return Int(bitPattern: CFHash(_cfObject))
     }
     
     public override func isEqual(object: AnyObject?) -> Bool {
@@ -236,149 +232,119 @@ public class NSNumber : NSValue {
     }
 
     public var charValue: Int8 {
-        get {
-            var val: Int8 = 0
-            withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<Int8>) -> Void in
-                CFNumberGetValue(_cfObject, kCFNumberCharType, value)
-            }
-            return val
+        var val: Int8 = 0
+        withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<Int8>) -> Void in
+            CFNumberGetValue(_cfObject, kCFNumberCharType, value)
         }
+        return val
     }
 
     public var unsignedCharValue: UInt8 {
-        get {
-            var val: UInt8 = 0
-            withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<UInt8>) -> Void in
-                CFNumberGetValue(_cfObject, kCFNumberCharType, value)
-            }
-            return val
+        var val: UInt8 = 0
+        withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<UInt8>) -> Void in
+            CFNumberGetValue(_cfObject, kCFNumberCharType, value)
         }
+        return val
     }
     
     public var shortValue: Int16 {
-        get {
-            var val: Int16 = 0
-            withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<Int16>) -> Void in
-                CFNumberGetValue(_cfObject, kCFNumberShortType, value)
-            }
-            return val
+        var val: Int16 = 0
+        withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<Int16>) -> Void in
+            CFNumberGetValue(_cfObject, kCFNumberShortType, value)
         }
+        return val
     }
     
     public var unsignedShortValue: UInt16 {
-        get {
-            var val: UInt16 = 0
-            withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<UInt16>) -> Void in
-                CFNumberGetValue(_cfObject, kCFNumberShortType, value)
-            }
-            return val
+        var val: UInt16 = 0
+        withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<UInt16>) -> Void in
+            CFNumberGetValue(_cfObject, kCFNumberShortType, value)
         }
+        return val
     }
     
     public var intValue: Int32 {
-        get {
-            var val: Int32 = 0
-            withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<Int32>) -> Void in
-                CFNumberGetValue(_cfObject, kCFNumberIntType, value)
-            }
-            return val
+        var val: Int32 = 0
+        withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<Int32>) -> Void in
+            CFNumberGetValue(_cfObject, kCFNumberIntType, value)
         }
+        return val
     }
     
     public var unsignedIntValue: UInt32 {
-        get {
-            var val: UInt32 = 0
-            withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<UInt32>) -> Void in
-                CFNumberGetValue(_cfObject, kCFNumberIntType, value)
-            }
-            return val
+        var val: UInt32 = 0
+        withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<UInt32>) -> Void in
+            CFNumberGetValue(_cfObject, kCFNumberIntType, value)
         }
+        return val
     }
     
     public var longValue: Int {
-        get {
-            var val: Int = 0
-            withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<Int>) -> Void in
-                CFNumberGetValue(_cfObject, kCFNumberLongType, value)
-            }
-            return val
+        var val: Int = 0
+        withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<Int>) -> Void in
+            CFNumberGetValue(_cfObject, kCFNumberLongType, value)
         }
+        return val
     }
     
     public var unsignedLongValue: UInt {
-        get {
-            var val: UInt = 0
-            withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<UInt>) -> Void in
-                CFNumberGetValue(_cfObject, kCFNumberLongType, value)
-            }
-            return val
+        var val: UInt = 0
+        withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<UInt>) -> Void in
+            CFNumberGetValue(_cfObject, kCFNumberLongType, value)
         }
+        return val
     }
     
     public var longLongValue: Int64 {
-        get {
-            var val: Int64 = 0
-            withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<Int64>) -> Void in
-                CFNumberGetValue(_cfObject, kCFNumberLongLongType, value)
-            }
-            return val
+        var val: Int64 = 0
+        withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<Int64>) -> Void in
+            CFNumberGetValue(_cfObject, kCFNumberLongLongType, value)
         }
+        return val
     }
     
     public var unsignedLongLongValue: UInt64 {
-        get {
-            var val: UInt64 = 0
-            withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<UInt64>) -> Void in
-                CFNumberGetValue(_cfObject, kCFNumberLongLongType, value)
-            }
-            return val
+        var val: UInt64 = 0
+        withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<UInt64>) -> Void in
+            CFNumberGetValue(_cfObject, kCFNumberLongLongType, value)
         }
+        return val
     }
     
     public var floatValue: Float {
-        get {
-            var val: Float = 0
-            withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<Float>) -> Void in
-                CFNumberGetValue(_cfObject, kCFNumberFloatType, value)
-            }
-            return val
+        var val: Float = 0
+        withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<Float>) -> Void in
+            CFNumberGetValue(_cfObject, kCFNumberFloatType, value)
         }
+        return val
     }
     
     public var doubleValue: Double {
-        get {
-            var val: Double = 0
-            withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<Double>) -> Void in
-                CFNumberGetValue(_cfObject, kCFNumberDoubleType, value)
-            }
-            return val
+        var val: Double = 0
+        withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<Double>) -> Void in
+            CFNumberGetValue(_cfObject, kCFNumberDoubleType, value)
         }
+        return val
     }
     
     public var boolValue: Bool {
-        get {
-            return longLongValue != 0
-        }
+        return longLongValue != 0
     }
     
     public var integerValue: Int {
-        get {
-            var val: Int = 0
-            withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<Int>) -> Void in
-                CFNumberGetValue(_cfObject, kCFNumberLongType, value)
-            }
-            return val
+        var val: Int = 0
+        withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<Int>) -> Void in
+            CFNumberGetValue(_cfObject, kCFNumberLongType, value)
         }
+        return val
     }
     
     public var unsignedIntegerValue: UInt {
-        get {
-            var val: UInt = 0
-            withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<UInt>) -> Void in
-                CFNumberGetValue(_cfObject, kCFNumberLongType, value)
-            }
-            return val
+        var val: UInt = 0
+        withUnsafeMutablePointer(&val) { (value: UnsafeMutablePointer<UInt>) -> Void in
+            CFNumberGetValue(_cfObject, kCFNumberLongType, value)
         }
+        return val
     }
     
     /// Create an instance initialized to `value`.

--- a/Foundation/NSNumberFormatter.swift
+++ b/Foundation/NSNumberFormatter.swift
@@ -27,21 +27,19 @@ public class NSNumberFormatter : NSFormatter {
     typealias CFType = CFNumberFormatterRef
     private var _currentCfFormatter: CFType?
     private var _cfFormatter: CFType {
-        get {
-            if let obj = _currentCfFormatter {
-                return obj
-            } else {
-                #if os(OSX) || os(iOS)
-                    let numberStyle = CFNumberFormatterStyle(rawValue: CFIndex(self.numberStyle.rawValue))!
-                #else
-                    let numberStyle = CFNumberFormatterStyle(self.numberStyle.rawValue)
-                #endif
-                
-                let obj = CFNumberFormatterCreate(kCFAllocatorSystemDefault, locale._cfObject, numberStyle)
-                _setFormatterAttributes(obj)
-                _currentCfFormatter = obj
-                return obj
-            }
+        if let obj = _currentCfFormatter {
+            return obj
+        } else {
+            #if os(OSX) || os(iOS)
+                let numberStyle = CFNumberFormatterStyle(rawValue: CFIndex(self.numberStyle.rawValue))!
+            #else
+                let numberStyle = CFNumberFormatterStyle(self.numberStyle.rawValue)
+            #endif
+            
+            let obj = CFNumberFormatterCreate(kCFAllocatorSystemDefault, locale._cfObject, numberStyle)
+            _setFormatterAttributes(obj)
+            _currentCfFormatter = obj
+            return obj
         }
     }
     

--- a/Foundation/NSObject.swift
+++ b/Foundation/NSObject.swift
@@ -26,9 +26,7 @@ public protocol NSObjectProtocol {
 
 extension NSObjectProtocol {
     public var debugDescription: String {
-        get {
-            return description
-        }
+        return description
     }
 }
 
@@ -90,9 +88,7 @@ public class NSObject : NSObjectProtocol {
     }
     
     public var hash: Int {
-        get {
-            return ObjectIdentifier(self).hashValue
-        }
+        return ObjectIdentifier(self).hashValue
     }
     
     public func `self`() -> Self {
@@ -104,15 +100,11 @@ public class NSObject : NSObjectProtocol {
     }
     
     public var description: String {
-        get {
-            return "<\(self.dynamicType): \(unsafeAddressOf(self))>"
-        }
+        return "<\(self.dynamicType): \(unsafeAddressOf(self))>"
     }
     
     public var debugDescription: String {
-        get {
-            return description
-        }
+        return description
     }
     
     public var _cfTypeID: CFTypeID {
@@ -123,9 +115,7 @@ public class NSObject : NSObjectProtocol {
 
 extension NSObject : Equatable, Hashable {
     public var hashValue: Int {
-        get {
-            return hash
-        }
+        return hash
     }
 }
 

--- a/Foundation/NSProcessInfo.swift
+++ b/Foundation/NSProcessInfo.swift
@@ -63,79 +63,63 @@ public class NSProcessInfo : NSObject {
     }
     
     public var hostName: String {
-        get {
-            if let name = NSHost.currentHost().name {
-                return name
-            } else {
-                return "localhost"
-            }
+        if let name = NSHost.currentHost().name {
+            return name
+        } else {
+            return "localhost"
         }
     }
     
     public var processName: String = _CFProcessNameString()._swiftObject
     
     public var processIdentifier: Int32 {
-        get {
-            return __CFGetPid()
-        }
+        return __CFGetPid()
     }
     
     public var globallyUniqueString: String {
-        get {
-            let uuid = CFUUIDCreate(kCFAllocatorSystemDefault)
-            return CFUUIDCreateString(kCFAllocatorSystemDefault, uuid)._swiftObject
-        }
+        let uuid = CFUUIDCreate(kCFAllocatorSystemDefault)
+        return CFUUIDCreateString(kCFAllocatorSystemDefault, uuid)._swiftObject
     }
 
     public var operatingSystemVersionString: String {
-        get {
-            return CFCopySystemVersionString()?._swiftObject ?? "Unknown"
-        }
+        return CFCopySystemVersionString()?._swiftObject ?? "Unknown"
     }
     
     public var operatingSystemVersion: NSOperatingSystemVersion {
-        get {
-            // The following fallback values match Darwin Foundation
-            let fallbackMajor = -1
-            let fallbackMinor = 0
-            let fallbackPatch = 0
-
-            guard let systemVersionDictionary = _CFCopySystemVersionDictionary() else {
-                return NSOperatingSystemVersion(majorVersion: fallbackMajor, minorVersion: fallbackMinor, patchVersion: fallbackPatch)
-            }
-            
-            let productVersionKey = unsafeBitCast(_kCFSystemVersionProductVersionKey, UnsafePointer<Void>.self)
-            guard let productVersion = unsafeBitCast(CFDictionaryGetValue(systemVersionDictionary, productVersionKey), NSString!.self) else {
-                return NSOperatingSystemVersion(majorVersion: fallbackMajor, minorVersion: fallbackMinor, patchVersion: fallbackPatch)
-            }
-            
-            let versionComponents = productVersion._swiftObject.characters.split(".").flatMap(String.init).flatMap({ Int($0) })
-            let majorVersion = versionComponents.dropFirst(0).first ?? fallbackMajor
-            let minorVersion = versionComponents.dropFirst(1).first ?? fallbackMinor
-            let patchVersion = versionComponents.dropFirst(2).first ?? fallbackPatch
-            return NSOperatingSystemVersion(majorVersion: majorVersion, minorVersion: minorVersion, patchVersion: patchVersion)
+        // The following fallback values match Darwin Foundation
+        let fallbackMajor = -1
+        let fallbackMinor = 0
+        let fallbackPatch = 0
+        
+        guard let systemVersionDictionary = _CFCopySystemVersionDictionary() else {
+            return NSOperatingSystemVersion(majorVersion: fallbackMajor, minorVersion: fallbackMinor, patchVersion: fallbackPatch)
         }
+        
+        let productVersionKey = unsafeBitCast(_kCFSystemVersionProductVersionKey, UnsafePointer<Void>.self)
+        guard let productVersion = unsafeBitCast(CFDictionaryGetValue(systemVersionDictionary, productVersionKey), NSString!.self) else {
+            return NSOperatingSystemVersion(majorVersion: fallbackMajor, minorVersion: fallbackMinor, patchVersion: fallbackPatch)
+        }
+        
+        let versionComponents = productVersion._swiftObject.characters.split(".").flatMap(String.init).flatMap({ Int($0) })
+        let majorVersion = versionComponents.dropFirst(0).first ?? fallbackMajor
+        let minorVersion = versionComponents.dropFirst(1).first ?? fallbackMinor
+        let patchVersion = versionComponents.dropFirst(2).first ?? fallbackPatch
+        return NSOperatingSystemVersion(majorVersion: majorVersion, minorVersion: minorVersion, patchVersion: patchVersion)
     }
     
     internal let _processorCount = __CFProcessorCount()
     public var processorCount: Int {
-        get {
-            return Int(_processorCount)
-        }
+        return Int(_processorCount)
     }
     
     internal let _activeProcessorCount = __CFActiveProcessorCount()
     public var activeProcessorCount: Int {
-        get {
-            return Int(_activeProcessorCount)
-        }
+        return Int(_activeProcessorCount)
     }
     
     internal let _physicalMemory = __CFMemorySize()
     public var physicalMemory: UInt64 {
-        get {
-            return _physicalMemory
-        }
+        return _physicalMemory
     }
     
     public func isOperatingSystemAtLeastVersion(version: NSOperatingSystemVersion) -> Bool {
@@ -162,8 +146,6 @@ public class NSProcessInfo : NSObject {
     }
     
     public var systemUptime: NSTimeInterval {
-        get {
-            return CFGetSystemUptime()
-        }
+        return CFGetSystemUptime()
     }
 }

--- a/Foundation/NSScanner.swift
+++ b/Foundation/NSScanner.swift
@@ -51,16 +51,14 @@ public class NSScanner : NSObject, NSCopying {
     }
     
     internal var invertedSkipSet: NSCharacterSet? {
-        get {
-            if let inverted = _invertedSkipSet {
-                return inverted
-            } else {
-                if let set = charactersToBeSkipped {
-                    _invertedSkipSet = set.invertedSet
-                    return _invertedSkipSet
-                }
-                return nil
+        if let inverted = _invertedSkipSet {
+            return inverted
+        } else {
+            if let set = charactersToBeSkipped {
+                _invertedSkipSet = set.invertedSet
+                return _invertedSkipSet
             }
+            return nil
         }
     }
     

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -75,12 +75,10 @@ public class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
     internal var _storage: Set<NSObject>
     
     public var count: Int {
-        get {
-            if self.dynamicType === NSSet.self || self.dynamicType === NSMutableSet.self {
-                return _storage.count
-            } else {
-                NSRequiresConcreteImplementation()
-            }
+        if self.dynamicType === NSSet.self || self.dynamicType === NSMutableSet.self {
+            return _storage.count
+        } else {
+            NSRequiresConcreteImplementation()
         }
     }
     
@@ -210,11 +208,9 @@ extension NSSet {
 extension NSSet {
     
     public var allObjects: [AnyObject] {
-        get {
-            // Would be nice to use `Array(self)` here but compiler
-            // crashes on Linux @ swift 6e3e83c
-            return map { $0 }
-        }
+        // Would be nice to use `Array(self)` here but compiler
+        // crashes on Linux @ swift 6e3e83c
+        return map { $0 }
     }
     
     public func anyObject() -> AnyObject? {

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -210,12 +210,10 @@ public class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, N
     internal var _storage: String
     
     public var length: Int {
-        get {
-            if self.dynamicType === NSString.self || self.dynamicType === NSMutableString.self {
-                return _storage.utf16.count
-            } else {
-                NSRequiresConcreteImplementation()
-            }
+        if self.dynamicType === NSString.self || self.dynamicType === NSMutableString.self {
+            return _storage.utf16.count
+        } else {
+            NSRequiresConcreteImplementation()
         }
     }
     
@@ -599,97 +597,73 @@ extension NSString {
     }
     
     public var doubleValue: Double {
-        get {
-            var start: Int = 0
-            var result = 0.0
-            _swiftObject.scan(NSCharacterSet.whitespaceCharacterSet(), locale: nil, locationToScanFrom: &start) { (value: Double) -> Void in
-                result = value
-            }
-            return result
+        var start: Int = 0
+        var result = 0.0
+        _swiftObject.scan(NSCharacterSet.whitespaceCharacterSet(), locale: nil, locationToScanFrom: &start) { (value: Double) -> Void in
+            result = value
         }
+        return result
     }
     
     public var floatValue: Float {
-        get {
-            var start: Int = 0
-            var result: Float = 0.0
-            _swiftObject.scan(NSCharacterSet.whitespaceCharacterSet(), locale: nil, locationToScanFrom: &start) { (value: Float) -> Void in
-                result = value
-            }
-            return result
+        var start: Int = 0
+        var result: Float = 0.0
+        _swiftObject.scan(NSCharacterSet.whitespaceCharacterSet(), locale: nil, locationToScanFrom: &start) { (value: Float) -> Void in
+            result = value
         }
+        return result
     }
     
     public var intValue: Int32 {
-        get {
-            return NSScanner(string: _swiftObject).scanInt() ?? 0
-        }
+        return NSScanner(string: _swiftObject).scanInt() ?? 0
     }
     
     public var integerValue: Int {
-        get {
-            let scanner = NSScanner(string: _swiftObject)
-            var value: Int = 0
-            scanner.scanInteger(&value)
-            return value
-        }
+        let scanner = NSScanner(string: _swiftObject)
+        var value: Int = 0
+        scanner.scanInteger(&value)
+        return value
     }
     
     public var longLongValue: Int64 {
-        get {
-            return NSScanner(string: _swiftObject).scanLongLong() ?? 0
-        }
+        return NSScanner(string: _swiftObject).scanLongLong() ?? 0
     }
     
     public var boolValue: Bool {
-        get {
-            let scanner = NSScanner(string: _swiftObject)
-            // skip initial whitespace if present
-            scanner.scanCharactersFromSet(NSCharacterSet.whitespaceCharacterSet())
-            // scan a single optional '+' or '-' character, followed by zeroes
-            if scanner.scanString(string: "+") == nil {
-                scanner.scanString(string: "-")
-            }
-            // scan any following zeroes
-            scanner.scanCharactersFromSet(NSCharacterSet(charactersInString: "0"))
-            return scanner.scanCharactersFromSet(NSCharacterSet(charactersInString: "tTyY123456789")) != nil
+        let scanner = NSScanner(string: _swiftObject)
+        // skip initial whitespace if present
+        scanner.scanCharactersFromSet(NSCharacterSet.whitespaceCharacterSet())
+        // scan a single optional '+' or '-' character, followed by zeroes
+        if scanner.scanString(string: "+") == nil {
+            scanner.scanString(string: "-")
         }
+        // scan any following zeroes
+        scanner.scanCharactersFromSet(NSCharacterSet(charactersInString: "0"))
+        return scanner.scanCharactersFromSet(NSCharacterSet(charactersInString: "tTyY123456789")) != nil
     }
     
     public var uppercaseString: String {
-        get {
-            return uppercaseStringWithLocale(nil)
-        }
+        return uppercaseStringWithLocale(nil)
     }
 
     public var lowercaseString: String {
-        get {
-            return lowercaseStringWithLocale(nil)
-        }
+        return lowercaseStringWithLocale(nil)
     }
     
     public var capitalizedString: String {
-        get {
-            return capitalizedStringWithLocale(nil)
-        }
+        return capitalizedStringWithLocale(nil)
     }
     
     public var localizedUppercaseString: String {
-        get {
-            return uppercaseStringWithLocale(NSLocale.currentLocale())
-        }
+        return uppercaseStringWithLocale(NSLocale.currentLocale())
     }
     
     public var localizedLowercaseString: String {
-        get {
-            return lowercaseStringWithLocale(NSLocale.currentLocale())
-        }
+        return lowercaseStringWithLocale(NSLocale.currentLocale())
     }
     
     public var localizedCapitalizedString: String {
-        get {
-            return capitalizedStringWithLocale(NSLocale.currentLocale())
-        }
+        return capitalizedStringWithLocale(NSLocale.currentLocale())
     }
     
     public func uppercaseStringWithLocale(locale: NSLocale?) -> String {
@@ -829,24 +803,18 @@ extension NSString {
     }
     
     public var UTF8String: UnsafePointer<Int8> {
-        get {
-            return _bytesInEncoding(self, NSUTF8StringEncoding, false, false, false)
-        }
+        return _bytesInEncoding(self, NSUTF8StringEncoding, false, false, false)
     }
     
     public var fastestEncoding: UInt {
-        get {
-            return NSUnicodeStringEncoding
-        }
+        return NSUnicodeStringEncoding
     }
     
     public var smallestEncoding: UInt {
-        get {
-            if canBeConvertedToEncoding(NSASCIIStringEncoding) {
-                return NSASCIIStringEncoding
-            }
-            return NSUnicodeStringEncoding
+        if canBeConvertedToEncoding(NSASCIIStringEncoding) {
+            return NSASCIIStringEncoding
         }
+        return NSUnicodeStringEncoding
     }
     
     public func dataUsingEncoding(encoding: UInt, allowLossyConversion lossy: Bool) -> NSData? {
@@ -991,39 +959,31 @@ extension NSString {
     }
     
     public var decomposedStringWithCanonicalMapping: String {
-        get {
-            let string = CFStringCreateMutable(kCFAllocatorSystemDefault, 0)
-            CFStringReplaceAll(string, self._cfObject)
-            CFStringNormalize(string, kCFStringNormalizationFormD)
-            return string._swiftObject
-        }
+        let string = CFStringCreateMutable(kCFAllocatorSystemDefault, 0)
+        CFStringReplaceAll(string, self._cfObject)
+        CFStringNormalize(string, kCFStringNormalizationFormD)
+        return string._swiftObject
     }
     
     public var precomposedStringWithCanonicalMapping: String {
-        get {
-            let string = CFStringCreateMutable(kCFAllocatorSystemDefault, 0)
-            CFStringReplaceAll(string, self._cfObject)
-            CFStringNormalize(string, kCFStringNormalizationFormC)
-            return string._swiftObject
-        }
+        let string = CFStringCreateMutable(kCFAllocatorSystemDefault, 0)
+        CFStringReplaceAll(string, self._cfObject)
+        CFStringNormalize(string, kCFStringNormalizationFormC)
+        return string._swiftObject
     }
     
     public var decomposedStringWithCompatibilityMapping: String {
-        get {
-            let string = CFStringCreateMutable(kCFAllocatorSystemDefault, 0)
-            CFStringReplaceAll(string, self._cfObject)
-            CFStringNormalize(string, kCFStringNormalizationFormKD)
-            return string._swiftObject
-        }
+        let string = CFStringCreateMutable(kCFAllocatorSystemDefault, 0)
+        CFStringReplaceAll(string, self._cfObject)
+        CFStringNormalize(string, kCFStringNormalizationFormKD)
+        return string._swiftObject
     }
     
     public var precomposedStringWithCompatibilityMapping: String {
-        get {
-            let string = CFStringCreateMutable(kCFAllocatorSystemDefault, 0)
-            CFStringReplaceAll(string, self._cfObject)
-            CFStringNormalize(string, kCFStringNormalizationFormKC)
-            return string._swiftObject
-        }
+        let string = CFStringCreateMutable(kCFAllocatorSystemDefault, 0)
+        CFStringReplaceAll(string, self._cfObject)
+        CFStringNormalize(string, kCFStringNormalizationFormKC)
+        return string._swiftObject
     }
     
     public func componentsSeparatedByString(separator: String) -> [String] {

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -54,9 +54,7 @@ internal class __NSCFType : NSObject {
     }
     
     override var hash: Int {
-        get {
-            return Int(bitPattern: CFHash(self))
-        }
+        return Int(bitPattern: CFHash(self))
     }
     
     override func isEqual(object: AnyObject?) -> Bool {
@@ -68,9 +66,7 @@ internal class __NSCFType : NSObject {
     }
     
     override var description: String {
-        get {
-            return CFCopyDescription(unsafeBitCast(self, CFTypeRef.self))._swiftObject
-        }
+        return CFCopyDescription(unsafeBitCast(self, CFTypeRef.self))._swiftObject
     }
 
     deinit {

--- a/Foundation/NSThread.swift
+++ b/Foundation/NSThread.swift
@@ -27,16 +27,14 @@ internal class NSThreadSpecific<T: AnyObject> {
     private var NSThreadSpecificKey = pthread_key_t()
 
     private var key: pthread_key_t {
-        get {
-            NSThreadSpecificKeyLock.lock()
-            if !NSThreadSpecificKeySet {
-                withUnsafeMutablePointer(&NSThreadSpecificKey) { key in
-                    NSThreadSpecificKeySet = pthread_key_create(key, disposeTLS) == 0
-                }
+        NSThreadSpecificKeyLock.lock()
+        if !NSThreadSpecificKeySet {
+            withUnsafeMutablePointer(&NSThreadSpecificKey) { key in
+                NSThreadSpecificKeySet = pthread_key_create(key, disposeTLS) == 0
             }
-            NSThreadSpecificKeyLock.unlock()
-            return NSThreadSpecificKey
         }
+        NSThreadSpecificKeyLock.unlock()
+        return NSThreadSpecificKey
     }
     
     internal func get(generator: (Void) -> T) -> T {

--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -40,9 +40,7 @@ public class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     public override var hash: Int {
-        get {
-            return Int(bitPattern: CFHash(_cfObject))
-        }
+        return Int(bitPattern: CFHash(_cfObject))
     }
     
     public override func isEqual(object: AnyObject?) -> Bool {
@@ -54,9 +52,7 @@ public class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     public override var description: String {
-        get {
-            return CFCopyDescription(_cfObject)._swiftObject
-        }
+        return CFCopyDescription(_cfObject)._swiftObject
     }
 
     deinit {
@@ -87,22 +83,18 @@ public class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     public var name: String {
-        get {
-            if self.dynamicType === NSTimeZone.self {
-                return CFTimeZoneGetName(_cfObject)._swiftObject
-            } else {
-                NSRequiresConcreteImplementation()
-            }
+        if self.dynamicType === NSTimeZone.self {
+            return CFTimeZoneGetName(_cfObject)._swiftObject
+        } else {
+            NSRequiresConcreteImplementation()
         }
     }
     
     public var data: NSData {
-        get {
-            if self.dynamicType === NSTimeZone.self {
-                return CFTimeZoneGetData(_cfObject)._nsObject
-            } else {
-                NSRequiresConcreteImplementation()
-            }
+        if self.dynamicType === NSTimeZone.self {
+            return CFTimeZoneGetData(_cfObject)._nsObject
+        } else {
+            NSRequiresConcreteImplementation()
         }
     }
     

--- a/Foundation/NSTimer.swift
+++ b/Foundation/NSTimer.swift
@@ -79,9 +79,7 @@ public class NSTimer : NSObject {
     }
     
     public var timeInterval: NSTimeInterval {
-        get {
-            return CFRunLoopTimerGetInterval(_timer!)
-        }
+        return CFRunLoopTimerGetInterval(_timer!)
     }
 
     public var tolerance: NSTimeInterval {
@@ -98,8 +96,6 @@ public class NSTimer : NSObject {
     }
 
     public var valid: Bool {
-        get {
-            return CFRunLoopTimerIsValid(_timer!)
-        }
+        return CFRunLoopTimerIsValid(_timer!)
     }
 }

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -49,19 +49,15 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
     
     
     internal var _cfObject : CFType {
-        get {
-            if self.dynamicType === NSURL.self {
-                return unsafeBitCast(self, CFType.self)
-            } else {
-                return CFURLCreateWithString(kCFAllocatorSystemDefault, relativeString._cfObject, self.baseURL?._cfObject)
-            }
+        if self.dynamicType === NSURL.self {
+            return unsafeBitCast(self, CFType.self)
+        } else {
+            return CFURLCreateWithString(kCFAllocatorSystemDefault, relativeString._cfObject, self.baseURL?._cfObject)
         }
     }
     
     public override var hash: Int {
-        get {
-            return Int(bitPattern: CFHash(_cfObject))
-        }
+        return Int(bitPattern: CFHash(_cfObject))
     }
     
     public override func isEqual(object: AnyObject?) -> Bool {
@@ -73,9 +69,7 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
     }
     
     public override var description: String {
-        get {
-            return CFCopyDescription(_cfObject)._swiftObject
-        }
+        return CFCopyDescription(_cfObject)._swiftObject
     }
 
     deinit {

--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -260,7 +260,7 @@ public class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopyin
     @abstract Returns the HTTP request method of the receiver.
     @result the HTTP request method of the receiver.
     */
-    public var HTTPMethod: String? { get { return "GET" } }
+    public var HTTPMethod: String? { return "GET" }
     
     /*!
     @method allHTTPHeaderFields

--- a/Foundation/NSUUID.swift
+++ b/Foundation/NSUUID.swift
@@ -44,11 +44,9 @@ public class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     public var UUIDString: String {
-        get {
-            let strPtr = UnsafeMutablePointer<Int8>.alloc(37)
-            _cf_uuid_unparse_lower(buffer, strPtr)
-            return String.fromCString(strPtr)!
-        }
+        let strPtr = UnsafeMutablePointer<Int8>.alloc(37)
+        _cf_uuid_unparse_lower(buffer, strPtr)
+        return String.fromCString(strPtr)!
     }
     
     public override func copy() -> AnyObject {

--- a/Foundation/NSXMLDTDNode.swift
+++ b/Foundation/NSXMLDTDNode.swift
@@ -82,91 +82,89 @@ public class NSXMLDTDNode : NSXMLNode {
         @abstract Sets the DTD sub kind.
     */
     public var DTDKind: NSXMLDTDNodeKind {
-        get {
-            switch _CFXMLNodeGetType(_xmlNode) {
-            case _kCFXMLDTDNodeTypeElement:
-                switch _CFXMLDTDElementNodeGetType(_xmlNode) {
-                case _kCFXMLDTDNodeElementTypeAny:
-                    return .NSXMLElementDeclarationAnyKind
-
-                case _kCFXMLDTDNodeElementTypeEmpty:
-                    return .NSXMLElementDeclarationEmptyKind
-
-                case _kCFXMLDTDNodeElementTypeMixed:
-                    return .NSXMLElementDeclarationMixedKind
-
-                case _kCFXMLDTDNodeElementTypeElement:
-                    return .NSXMLElementDeclarationElementKind
-
-                default:
-                    return .NSXMLElementDeclarationUndefinedKind
-                }
-
-            case _kCFXMLDTDNodeTypeEntity:
-                switch _CFXMLDTDEntityNodeGetType(_xmlNode) {
-                case _kCFXMLDTDNodeEntityTypeInternalGeneral:
-                    return .NSXMLEntityGeneralKind
-
-                case _kCFXMLDTDNodeEntityTypeExternalGeneralUnparsed:
-                    return .NSXMLEntityUnparsedKind
-
-                case _kCFXMLDTDNodeEntityTypeExternalParameter:
-                    fallthrough
-                case _kCFXMLDTDNodeEntityTypeInternalParameter:
-                    return .NSXMLEntityParameterKind
-
-                case _kCFXMLDTDNodeEntityTypeInternalPredefined:
-                    return .NSXMLEntityPredefined
-
-                case _kCFXMLDTDNodeEntityTypeExternalGeneralParsed:
-                    return .NSXMLEntityParsedKind
-
-                default:
-                    fatalError("Invalid entity declaration type");
-                }
+        switch _CFXMLNodeGetType(_xmlNode) {
+        case _kCFXMLDTDNodeTypeElement:
+            switch _CFXMLDTDElementNodeGetType(_xmlNode) {
+            case _kCFXMLDTDNodeElementTypeAny:
+                return .NSXMLElementDeclarationAnyKind
                 
-            case _kCFXMLDTDNodeTypeAttribute:
-                switch _CFXMLDTDAttributeNodeGetType(_xmlNode) {
-                case _kCFXMLDTDNodeAttributeTypeCData:
-                    return .NSXMLAttributeCDATAKind
-
-                case _kCFXMLDTDNodeAttributeTypeID:
-                    return .NSXMLAttributeIDKind
-
-                case _kCFXMLDTDNodeAttributeTypeIDRef:
-                    return .NSXMLAttributeIDRefKind
-
-                case _kCFXMLDTDNodeAttributeTypeIDRefs:
-                    return .NSXMLAttributeIDRefsKind
-
-                case _kCFXMLDTDNodeAttributeTypeEntity:
-                    return .NSXMLAttributeEntityKind
-
-                case _kCFXMLDTDNodeAttributeTypeEntities:
-                    return .NSXMLAttributeEntitiesKind
-
-                case _kCFXMLDTDNodeAttributeTypeNMToken:
-                    return .NSXMLAttributeNMTokenKind
-
-                case _kCFXMLDTDNodeAttributeTypeNMTokens:
-                    return .NSXMLAttributeNMTokensKind
-
-                case _kCFXMLDTDNodeAttributeTypeEnumeration:
-                    return .NSXMLAttributeEnumerationKind
-
-                case _kCFXMLDTDNodeAttributeTypeNotation:
-                    return .NSXMLAttributeNotationKind
-
-                default:
-                    fatalError("Invalid attribute declaration type")
-                }
-
-            case _kCFXMLTypeInvalid:
-                return unsafeBitCast(0, NSXMLDTDNodeKind.self) // this mirrors Darwin
+            case _kCFXMLDTDNodeElementTypeEmpty:
+                return .NSXMLElementDeclarationEmptyKind
+                
+            case _kCFXMLDTDNodeElementTypeMixed:
+                return .NSXMLElementDeclarationMixedKind
+                
+            case _kCFXMLDTDNodeElementTypeElement:
+                return .NSXMLElementDeclarationElementKind
                 
             default:
-                fatalError("This is not actually a DTD node!")
+                return .NSXMLElementDeclarationUndefinedKind
             }
+            
+        case _kCFXMLDTDNodeTypeEntity:
+            switch _CFXMLDTDEntityNodeGetType(_xmlNode) {
+            case _kCFXMLDTDNodeEntityTypeInternalGeneral:
+                return .NSXMLEntityGeneralKind
+                
+            case _kCFXMLDTDNodeEntityTypeExternalGeneralUnparsed:
+                return .NSXMLEntityUnparsedKind
+                
+            case _kCFXMLDTDNodeEntityTypeExternalParameter:
+                fallthrough
+            case _kCFXMLDTDNodeEntityTypeInternalParameter:
+                return .NSXMLEntityParameterKind
+                
+            case _kCFXMLDTDNodeEntityTypeInternalPredefined:
+                return .NSXMLEntityPredefined
+                
+            case _kCFXMLDTDNodeEntityTypeExternalGeneralParsed:
+                return .NSXMLEntityParsedKind
+                
+            default:
+                fatalError("Invalid entity declaration type");
+            }
+            
+        case _kCFXMLDTDNodeTypeAttribute:
+            switch _CFXMLDTDAttributeNodeGetType(_xmlNode) {
+            case _kCFXMLDTDNodeAttributeTypeCData:
+                return .NSXMLAttributeCDATAKind
+                
+            case _kCFXMLDTDNodeAttributeTypeID:
+                return .NSXMLAttributeIDKind
+                
+            case _kCFXMLDTDNodeAttributeTypeIDRef:
+                return .NSXMLAttributeIDRefKind
+                
+            case _kCFXMLDTDNodeAttributeTypeIDRefs:
+                return .NSXMLAttributeIDRefsKind
+                
+            case _kCFXMLDTDNodeAttributeTypeEntity:
+                return .NSXMLAttributeEntityKind
+                
+            case _kCFXMLDTDNodeAttributeTypeEntities:
+                return .NSXMLAttributeEntitiesKind
+                
+            case _kCFXMLDTDNodeAttributeTypeNMToken:
+                return .NSXMLAttributeNMTokenKind
+                
+            case _kCFXMLDTDNodeAttributeTypeNMTokens:
+                return .NSXMLAttributeNMTokensKind
+                
+            case _kCFXMLDTDNodeAttributeTypeEnumeration:
+                return .NSXMLAttributeEnumerationKind
+                
+            case _kCFXMLDTDNodeAttributeTypeNotation:
+                return .NSXMLAttributeNotationKind
+                
+            default:
+                fatalError("Invalid attribute declaration type")
+            }
+            
+        case _kCFXMLTypeInvalid:
+            return unsafeBitCast(0, NSXMLDTDNodeKind.self) // this mirrors Darwin
+            
+        default:
+            fatalError("This is not actually a DTD node!")
         }
     }//primitive
     

--- a/Foundation/NSXMLDocument.swift
+++ b/Foundation/NSXMLDocument.swift
@@ -54,9 +54,7 @@ public enum NSXMLDocumentContentKind : UInt {
 */
 public class NSXMLDocument : NSXMLNode {
     private var _xmlDoc: _CFXMLDocPtr {
-        get {
-            return _CFXMLDocPtr(_xmlNode)
-        }
+        return _CFXMLDocPtr(_xmlNode)
     }
     /*!
         @method initWithXMLString:options:error:

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -227,12 +227,10 @@ class TestNSURL : XCTestCase {
     
     static let gBaseTemporaryDirectoryPath = "/tmp/" // TODO: NSTemporaryDirectory()
     static var gBaseCurrentWorkingDirectoryPath : String {
-        get {
-            let count = Int(1024) // MAXPATHLEN is platform specific; this is the lowest common denominator for darwin and most linuxes
-            var buf : [Int8] = Array(count: count, repeatedValue: 0)
-            getcwd(&buf, count)
-            return String.fromCString(buf)!
-        }
+        let count = Int(1024) // MAXPATHLEN is platform specific; this is the lowest common denominator for darwin and most linuxes
+        var buf : [Int8] = Array(count: count, repeatedValue: 0)
+        getcwd(&buf, count)
+        return String.fromCString(buf)!
     }
     static var gRelativeOffsetFromBaseCurrentWorkingDirectory: UInt = 0
     static let gFileExistsName = "TestCFURL_file_exists\(NSProcessInfo.processInfo().globallyUniqueString)"


### PR DESCRIPTION
Implicit getters makes codes shorter and look cleaner.