### PR TITLE
Fix key's typo to NSFileGroupOwnerAccountName

### DIFF
--- a/Foundation/NSFileManager.swift
+++ b/Foundation/NSFileManager.swift
@@ -349,7 +349,7 @@ public class NSFileManager : NSObject {
         let grd = getgrgid(s.st_gid)
         if grd != nil && grd.memory.gr_name != nil {
             if let name = String.fromCString(grd.memory.gr_name) {
-                result[NSFileGroupOwnerAccountID] = name
+                result[NSFileGroupOwnerAccountName] = name
             }
         }
 


### PR DESCRIPTION
The key NSFileGroupOwnerAccountId is a typo as it is later overwritten by an NSNumber on line 381. The correct constant is NSFileGroupOwnerAccountName to correctly add the String of the account's name to the dictionary.