### PR TITLE
Companion PR to Swift #1157 and 32-bit bug fixes

### DIFF
--- a/build.py
+++ b/build.py
@@ -15,8 +15,7 @@ foundation.GCC_PREFIX_HEADER = 'CoreFoundation/Base.subproj/CoreFoundation_Prefi
 
 if Configuration.current.target.sdk == OSType.Linux:
 	foundation.CFLAGS = '-DDEPLOYMENT_TARGET_LINUX -D_GNU_SOURCE '
-	foundation.LDFLAGS = '-Wl,@./CoreFoundation/linux.ld -Xlinker -T ${SDKROOT}/lib/swift/linux/${ARCH}/swift.ld -lswiftGlibc `icu-config --ldflags` -Wl,-defsym,__CFConstantStringClassReference=_TMC10Foundation19_NSCFConstantString -Wl,-Bsymbolic '
-
+	foundation.LDFLAGS = '${SWIFT_USE_LINKER} -Wl,@./CoreFoundation/linux.ld -lswiftGlibc `icu-config --ldflags` -Wl,-defsym,__CFConstantStringClassReference=_TMC10Foundation19_NSCFConstantString -Wl,-Bsymbolic '
 elif Configuration.current.target.sdk == OSType.FreeBSD:
 	foundation.CFLAGS = '-DDEPLOYMENT_TARGET_FREEBSD -I/usr/local/include -I/usr/local/include/libxml2 '
 	foundation.LDFLAGS = ''


### PR DESCRIPTION
This PR is a necessary companion to https://github.com/apple/swift/pull/1157 .  swift.ld is used in the build of Foundation, and with the deletion of the script from Swift, Foundation fails to build.  The first commit uses the conformance begin and end objects generated in Swift for manual share library linking.  Also, this commit allows the Swift build scripts to indicate to Foundation whether it should use the gold linker.

**It's very important that this PR only be merged at the same time as the Swift#1157**

~~The second commit addresses some new regressions introduced in ```NSXML*``` on 32-bit systems.  The ```NSXMLNodeOptionRawType``` type was introduced for working with ```NSXMLNodeOption```s in a bit-width independent way.~~