### PR TITLE
Add support for NSNumber to return a PlaygroundQuickLook

### DIFF
--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -465,13 +465,13 @@ extension NSNumber : CustomPlaygroundQuickLookable {
     public func customPlaygroundQuickLook() -> PlaygroundQuickLook {
         let type = CFNumberGetType(_cfObject)
         switch type {
-        case kCFNumberSInt8Type:
+        case .SInt8Type:
             fallthrough
-        case kCFNumberSInt16Type:
+        case .SInt16Type:
             fallthrough
-        case kCFNumberSInt32Type:
+        case .SInt32Type:
             fallthrough
-        case kCFNumberSInt64Type:
+        case .SInt64Type:
             fallthrough
         case kCFNumberCharType:
             fallthrough
@@ -481,21 +481,21 @@ extension NSNumber : CustomPlaygroundQuickLookable {
             fallthrough
         case kCFNumberLongType:
             fallthrough
-        case kCFNumberCFIndexType:
+        case .CFIndexType:
             fallthrough
-        case kCFNumberNSIntegerType:
+        case .NSIntegerType:
             fallthrough
-        case kCFNumberLongLongType:
+        case .LongLongType:
             return .Int(self.longLongValue)
-        case kCFNumberFloat32Type:
+        case .Float32Type:
             fallthrough
         case kCFNumberFloatType:
             return .Float(self.floatValue)
-        case kCFNumberFloat64Type:
+        case .Float64Type:
             fallthrough
         case kCFNumberDoubleType:
             return .Double(self.doubleValue)
-        case kCFNumberCGFloatType:
+        case .CGFloatType:
             if sizeof(CGFloat) == sizeof(Float32) {
                 return .Float(self.floatValue)
             } else {

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -11,6 +11,12 @@
 import CoreFoundation
 
 #if os(OSX) || os(iOS)
+internal let kCFNumberSInt8Type = CFNumberType.SInt8Type
+internal let kCFNumberSInt16Type = CFNumberType.SInt16Type
+internal let kCFNumberSInt32Type = CFNumberType.SInt32Type
+internal let kCFNumberSInt64Type = CFNumberType.SInt64Type
+internal let kCFNumberFloat32Type = CFNumberType.Float32Type
+internal let kCFNumberFloat64Type = CFNumberType.Float64Type
 internal let kCFNumberCharType = CFNumberType.CharType
 internal let kCFNumberShortType = CFNumberType.ShortType
 internal let kCFNumberIntType = CFNumberType.IntType
@@ -18,6 +24,9 @@ internal let kCFNumberLongType = CFNumberType.LongType
 internal let kCFNumberLongLongType = CFNumberType.LongLongType
 internal let kCFNumberFloatType = CFNumberType.FloatType
 internal let kCFNumberDoubleType = CFNumberType.DoubleType
+internal let kCFNumberCFIndexType = CFNumberType.CFIndexType
+internal let kCFNumberNSIntegerType = CFNumberType.NSIntegerType
+internal let kCFNumberCGFloatType = CFNumberType.CGFloatType
 #endif
 
 extension Int : _ObjectTypeBridgeable {
@@ -465,13 +474,13 @@ extension NSNumber : CustomPlaygroundQuickLookable {
     public func customPlaygroundQuickLook() -> PlaygroundQuickLook {
         let type = CFNumberGetType(_cfObject)
         switch type {
-        case .SInt8Type:
+        case kCFNumberCharType:
             fallthrough
-        case .SInt16Type:
+        case kCFNumberSInt16Type:
             fallthrough
-        case .SInt32Type:
+        case kCFNumberSInt32Type:
             fallthrough
-        case .SInt64Type:
+        case kCFNumberSInt64Type:
             fallthrough
         case kCFNumberCharType:
             fallthrough
@@ -481,21 +490,21 @@ extension NSNumber : CustomPlaygroundQuickLookable {
             fallthrough
         case kCFNumberLongType:
             fallthrough
-        case .CFIndexType:
+        case kCFNumberCFIndexType:
             fallthrough
-        case .NSIntegerType:
+        case kCFNumberNSIntegerType:
             fallthrough
-        case .LongLongType:
+        case kCFNumberLongLongType:
             return .Int(self.longLongValue)
-        case .Float32Type:
+        case kCFNumberFloat32Type:
             fallthrough
         case kCFNumberFloatType:
             return .Float(self.floatValue)
-        case .Float64Type:
+        case kCFNumberFloat64Type:
             fallthrough
         case kCFNumberDoubleType:
             return .Double(self.doubleValue)
-        case .CGFloatType:
+        case kCFNumberCGFloatType:
             if sizeof(CGFloat) == sizeof(Float32) {
                 return .Float(self.floatValue)
             } else {

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -460,3 +460,49 @@ extension CFNumberRef : _NSBridgable {
     typealias NSType = NSNumber
     internal var _nsObject: NSType { return unsafeBitCast(self, NSType.self) }
 }
+
+extension NSNumber : CustomPlaygroundQuickLookable {
+    public func customPlaygroundQuickLook() -> PlaygroundQuickLook {
+        let type = CFNumberGetType(_cfObject)
+        switch type {
+        case kCFNumberSInt8Type:
+            fallthrough
+        case kCFNumberSInt16Type:
+            fallthrough
+        case kCFNumberSInt32Type:
+            fallthrough
+        case kCFNumberSInt64Type:
+            fallthrough
+        case kCFNumberCharType:
+            fallthrough
+        case kCFNumberShortType:
+            fallthrough
+        case kCFNumberIntType:
+            fallthrough
+        case kCFNumberLongType:
+            fallthrough
+        case kCFNumberCFIndexType:
+            fallthrough
+        case kCFNumberNSIntegerType:
+            fallthrough
+        case kCFNumberLongLongType:
+            return .Int(self.longLongValue)
+        case kCFNumberFloat32Type:
+            fallthrough
+        case kCFNumberFloatType:
+            return .Float(self.floatValue)
+        case kCFNumberFloat64Type:
+            fallthrough
+        case kCFNumberDoubleType:
+            return .Double(self.doubleValue)
+        case kCFNumberCGFloatType:
+            if sizeof(CGFloat) == sizeof(Float32) {
+                return .Float(self.floatValue)
+            } else {
+                return .Double(self.doubleValue)
+            }
+        default:
+            return .Text("invalid NSNumber")
+        }
+    }
+}

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -32,6 +32,7 @@ class TestNSNumber : XCTestCase {
             ("test_compareNumberWithShort", test_compareNumberWithShort ),
             ("test_compareNumberWithFloat", test_compareNumberWithFloat ),
             ("test_compareNumberWithDouble", test_compareNumberWithDouble ),
+	    ("test_reflection", test_reflection ),
         ]
     }
     
@@ -363,5 +364,25 @@ class TestNSNumber : XCTestCase {
         XCTAssertEqual(NSNumber(double: 42).compare(NSNumber(float: 42)), NSComparisonResult.OrderedSame)
         XCTAssertEqual(NSNumber(double: 0).compare(NSNumber(float: -37.5)), NSComparisonResult.OrderedDescending)
         XCTAssertEqual(NSNumber(double: -37.5).compare(NSNumber(float: 1234.5)), NSComparisonResult.OrderedAscending)
+    }
+
+    func test_reflection() {
+       let ql = NSNumber(integer: 1234).customPlaygroundQuickLook()
+       switch ql {
+           case .Int(let value): XCTAssertEqual(value, 1234)
+           default: XCTAssert(false, "NSNumber(integer:) quicklook is not an Int")
+       }
+
+       let ql = NSNumber(float: 1.25).customPlaygroundQuickLook()
+       switch ql {
+           case .Float(let value): XCTAssertEqual(value, 1.25)
+           default: XCTAssert(false, "NSNumber(float:) quicklook is not a Float")
+       }
+
+       let ql = NSNumber(double: 1.25).customPlaygroundQuickLook()
+       switch ql {
+           case .Double(let value): XCTAssertEqual(value, 1.25)
+           default: XCTAssert(false, "NSNumber(double:) quicklook is not a Double")
+       }
     }
 }

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -32,7 +32,7 @@ class TestNSNumber : XCTestCase {
             ("test_compareNumberWithShort", test_compareNumberWithShort ),
             ("test_compareNumberWithFloat", test_compareNumberWithFloat ),
             ("test_compareNumberWithDouble", test_compareNumberWithDouble ),
-	    ("test_reflection", test_reflection ),
+            ("test_reflection", test_reflection ),
         ]
     }
     
@@ -367,20 +367,20 @@ class TestNSNumber : XCTestCase {
     }
 
     func test_reflection() {
-       let ql = NSNumber(integer: 1234).customPlaygroundQuickLook()
-       switch ql {
+       let ql1 = NSNumber(integer: 1234).customPlaygroundQuickLook()
+       switch ql1 {
            case .Int(let value): XCTAssertEqual(value, 1234)
            default: XCTAssert(false, "NSNumber(integer:) quicklook is not an Int")
        }
 
-       let ql = NSNumber(float: 1.25).customPlaygroundQuickLook()
-       switch ql {
+       let ql2 = NSNumber(float: 1.25).customPlaygroundQuickLook()
+       switch ql2 {
            case .Float(let value): XCTAssertEqual(value, 1.25)
            default: XCTAssert(false, "NSNumber(float:) quicklook is not a Float")
        }
 
-       let ql = NSNumber(double: 1.25).customPlaygroundQuickLook()
-       switch ql {
+       let ql3 = NSNumber(double: 1.25).customPlaygroundQuickLook()
+       switch ql3 {
            case .Double(let value): XCTAssertEqual(value, 1.25)
            default: XCTAssert(false, "NSNumber(double:) quicklook is not a Double")
        }


### PR DESCRIPTION
This commit adds support for NSNumber to return a PlaygroundQuickLook object

On the OS X Foundation, this works due to a combination of the Swift runtime and the ObjC runtime cooperating (see Reflection.mm in the Swift runtime)

For corelibs Foundation there is no such support. This patch adds it.