### PR TITLE
Add a CustomPlaygroundQuickLookable conformance for NSString

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -1463,3 +1463,9 @@ extension String : Bridgeable {
 extension NSString : Bridgeable {
     public func bridge() -> String { return _swiftObject }
 }
+
+extension NSString : CustomPlaygroundQuickLookable {
+    public func customPlaygroundQuickLook() -> PlaygroundQuickLook {
+        return .Text(self.bridge())
+    }
+}

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -80,6 +80,7 @@ class TestNSString : XCTestCase {
             ("test_ExternalRepresentation", test_ExternalRepresentation),
             ("test_mutableStringConstructor", test_mutableStringConstructor),
             ("test_PrefixSuffix", test_PrefixSuffix),
+            ("test_reflection", test_reflection),
         ]
     }
 
@@ -1059,5 +1060,16 @@ extension TestNSString {
             XCTAssert(test.xfail == fail, "Unexpected \(test.xfail ?"success":"failure"): \(test.loc)")
         }
 #endif
+    }
+}
+
+func test_reflection() {
+    let testString: NSString = "some text here"
+    
+    let ql = PlaygroundQuickLook(reflecting: testString)
+
+    switch ql {
+    case .Text(let str): XCTAssertEqual(testString.bridge(), str)
+    default: XCTAssertTrue(false, "mismatched quicklook")
     }
 }


### PR DESCRIPTION
Similarly to the NSNumber case, this pull request involves providing reflection support for NSString