### PR TITLE
Next step in connecting libdispatch and foundation builds

### DIFF
--- a/CoreFoundation/Base.subproj/CFBase.h
+++ b/CoreFoundation/Base.subproj/CFBase.h
@@ -61,6 +61,10 @@
 #define __HAS_DISPATCH__ 1
 #endif
 #endif
+#if DEPLOYMENT_TARGET_LINUX && DEPLOYMENT_RUNTIME_SWIFT && DEPLOYMENT_ENABLE_LIBDISPATCH
+#define __HAS_DISPATCH__ 1
+#endif
+
 // Some compilers provide the capability to test if certain features are available. This macro provides a compatibility path for other compilers.
 #ifndef __has_feature
 #define __has_feature(x) 0

--- a/build.py
+++ b/build.py
@@ -61,6 +61,14 @@ if "XCTEST_BUILD_DIR" in Configuration.current.variables:
 		'-L${XCTEST_BUILD_DIR}',
 		'-I/usr/include/libxml2'
 	]
+
+if "LIBDISPATCH_SOURCE_DIR" in Configuration.current.variables:
+        foundation.CFLAGS += " "+" ".join([
+                '-DDEPLOYMENT_ENABLE_LIBDISPATCH',
+                '-I'+Configuration.current.variables["LIBDISPATCH_SOURCE_DIR"],
+                '-I'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/tests'  # for include of dispatch/private.h in CF
+        ])
+
 foundation.SWIFTCFLAGS = " ".join(swift_cflags)
 
 foundation.LDFLAGS += '-lpthread -ldl -lm -lswiftCore -lxml2 '


### PR DESCRIPTION
If the foundation build script is invoked from build-script-impl
with libdispatch enabled then add includes and define to CFLAGS.

Add another case in which __HAS_DISPATCH__ is set to 1 that will
be enabled by the CFLAGS set in build.py (staging while work in
progress).