### PR TITLE
Fix compilation issues with HAS_DISPATCH on Linux

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -805,7 +805,7 @@ CF_EXPORT void _NS_pthread_setname_np(const char *name);
 #define pthread_setname_np _NS_pthread_setname_np
 #endif
 
-#if DEPLOYMENT_TARGET_WINDOWS
+#if DEPLOYMENT_TARGET_WINDOWS || DEPLOYMENT_TARGET_LINUX
 // replacement for DISPATCH_QUEUE_OVERCOMMIT until we get a bug fix in dispatch on Windows
 // <rdar://problem/7923891> dispatch on Windows: Need queue_private.h
 #define DISPATCH_QUEUE_OVERCOMMIT 2
@@ -866,7 +866,6 @@ CF_INLINE long qos_class_main() {
 CF_INLINE long qos_class_self() {
 	return QOS_CLASS_DEFAULT;
 }
-
 #endif
 
 // Returns a generic dispatch queue for when you want to just throw some work

--- a/CoreFoundation/RunLoop.subproj/CFRunLoop.c
+++ b/CoreFoundation/RunLoop.subproj/CFRunLoop.c
@@ -2541,7 +2541,7 @@ static int32_t __CFRunLoopRun(CFRunLoopRef rl, CFRunLoopModeRef rlm, CFTimeInter
     }
     
 #if __HAS_DISPATCH__
-    mach_port_name_t dispatchPort = MACH_PORT_NULL;
+    __CFPort dispatchPort = CFPORT_NULL;
     Boolean libdispatchQSafe = pthread_main_np() && ((HANDLE_DISPATCH_ON_BASE_INVOCATION_ONLY && NULL == previousMode) || (!HANDLE_DISPATCH_ON_BASE_INVOCATION_ONLY && 0 == _CFGetTSD(__CFTSDKeyIsInGCDMainQ)));
     if (libdispatchQSafe && (CFRunLoopGetMain() == rl) && CFSetContainsValue(rl->_commonModes, rlm->_name)) dispatchPort = _dispatch_get_main_queue_port_4CF();
 #endif
@@ -2798,7 +2798,7 @@ static int32_t __CFRunLoopRun(CFRunLoopRef rl, CFRunLoopModeRef rlm, CFTimeInter
             __CFRunLoopModeUnlock(rlm);
             __CFRunLoopUnlock(rl);
             _CFSetTSD(__CFTSDKeyIsInGCDMainQ, (void *)6, NULL);
-#if DEPLOYMENT_TARGET_WINDOWS
+#if DEPLOYMENT_TARGET_WINDOWS || DEPLOYMENT_TARGET_LINUX
             void *msg = 0;
 #endif
             __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__(msg);

--- a/CoreFoundation/Stream.subproj/CFStream.c
+++ b/CoreFoundation/Stream.subproj/CFStream.c
@@ -1690,7 +1690,11 @@ static void _perform(void* info)
 
 static void* _legacyStreamRunLoop_workThread(void* arg)
 {
+#if DEPLOYMENT_TARGET_LINUX || DEPLOYMENT_TARGET_FREEBSD
+    pthread_setname_np(pthread_self(), "com.apple.CFStream.LegacyThread");
+#else
     pthread_setname_np("com.apple.CFStream.LegacyThread");
+#endif
     sLegacyRL = CFRunLoopGetCurrent();
 
 #if defined(LOG_STREAM)


### PR DESCRIPTION
As part of the prep work I'm doing with @dgrove-oss to enable Dispatch, I've done some testing of compiling swift-corelibs-foundation with `__HAS_DISPATCH__` enabled. That's highlighted a number of compile errors which this PR resolves.

Enabling `__HAS_DISPATCH__` will still result in linker errors, which we'll look to resolve once we have the Dispatch overlay built into lib dispatch on Linux ([libdispatch PR #43](https://github.com/apple/swift-corelibs-libdispatch/pull/43), and made the necessary modifications to the foundation build scripts.