### PR TITLE
[NSRunLoop] Remove _CFRunLoopFinished check

### DIFF
--- a/Foundation/NSRunLoop.swift
+++ b/Foundation/NSRunLoop.swift
@@ -95,10 +95,6 @@ extension NSRunLoop {
             return false
         }
         let modeArg = mode._cfObject
-        if _CFRunLoopFinished(_cfRunLoop, modeArg) {
-            return false
-        }
-        
         let limitTime = limitDate.timeIntervalSinceReferenceDate
         let ti = limitTime - CFAbsoluteTimeGetCurrent()
         CFRunLoopRunInMode(modeArg, ti, true)


### PR DESCRIPTION
A call to `_CFRunLoopFinished` in `NSRunLoop.runMode()` always returns `false` on OS X, causing unexpected behavior.

For example, the following program exits immediately on OS X:

```swift
import SwiftFoundation

let runLoop = NSRunLoop.currentRunLoop()
let date = NSDate(timeIntervalSinceNow: 60)
while runLoop.runMode(NSDefaultRunLoopMode, beforeDate: date) {}
```

Whereas it (correctly) takes 60 seconds to exit on Linux:

```swift
import Foundation

let runLoop = NSRunLoop.currentRunLoop()
let date = NSDate(timeIntervalSinceNow: 60)
while runLoop.runMode(NSDefaultRunLoopMode, beforeDate: date) {}
```

The problem appears to be `_CFRunLoopFinished`, which incorrectly returns `false` on OS X. Remove the faulty check to get things working on both OS X and Linux.

---

As requested by @parkera in our discussion on https://github.com/apple/swift-corelibs-xctest/pull/43. See that pull request for another example of code that misbehaves on OS X due to this check.

/cc @phausler, who originally added the deleted lines.
/cc @Catfish-Man, since he strikes me as the kind of CoreFoundation guru that would know why this doesn't work on OS X. :)