### PR TITLE
[swift-corelibs-foundation]-- Fixed JSON Deserialisation of string values with spaces at the start String

### DIFF
--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -306,7 +306,12 @@ private struct JSONReader {
     }
 
     func consumeStructure(ascii: UInt8, input: Index) throws -> Index? {
-        return try consumeWhitespace(input).flatMap(consumeASCII(ascii)).flatMap(consumeWhitespace)
+        switch ascii {
+        case Structure.QuotationMark:
+            return try consumeWhitespace(input).flatMap(consumeASCII(ascii)) // for strings we don't consume(ignore) the whitespaces after the starting Quotation Mark because they are part of string  e.g in "{\"title\" : \" hello world!!\" }" the value should be " hello world!!" instead of "hello world"
+        default:
+            return try consumeWhitespace(input).flatMap(consumeASCII(ascii)).flatMap(consumeWhitespace)
+        }
     }
 
     func consumeASCII(ascii: UInt8) -> (Index) throws -> Index? {

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -92,6 +92,7 @@ extension TestNSJSONSerialization {
             ("test_deserialize_emptyArray", test_deserialize_emptyArray),
             ("test_deserialize_multiStringArray", test_deserialize_multiStringArray),
             ("test_deserialize_unicodeString", test_deserialize_unicodeString),
+            ("test_deserialize_stringWithSpacesAtStart", test_deserialize_stringWithSpacesAtStart),
             
             
             ("test_deserialize_values", test_deserialize_values),
@@ -146,6 +147,23 @@ extension TestNSJSONSerialization {
         } catch {
             XCTFail("Error thrown: \(error)")
         }
+    }
+    
+    func test_deserialize_stringWithSpacesAtStart(){
+        
+        let subject = "{\"title\" : \" hello world!!\" }"
+        do {
+            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else  {
+                XCTFail("Unable to convert string to data")
+                return
+            }
+            let result = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? [String : Any]
+            XCTAssertEqual(result?["title"] as? String, " hello world!!")
+        } catch{
+            XCTFail("Error thrown: \(error)")
+        }
+        
+        
     }
     
     //MARK: - Array Deserialization


### PR DESCRIPTION
currently for strings that had spaces at the start, the spaces were ignored during deserialisation process. e.g "{\"title\" : \" hello world!!\" }" would deserialise into ["title" : "hello world!!"] instead of ["title" : " hello world!"] skipping the space at the start of hello world. This was due to `func consumeStructure(ascii: UInt8, input: Index) throws -> Index?` consuming white spaces at the start and end of every structure. The fix is  just to consume the starting whitespace sequence in case of QuotationMark Structure.