### PR TITLE
minor change to license header for TestNSTask

### DIFF
--- a/TestFoundation/TestNSTask.swift
+++ b/TestFoundation/TestNSTask.swift
@@ -1,9 +1,10 @@
+// This source file is part of the Swift.org open source project
 //
-//  TestNSTask.swift
-//  Foundation
+// Copyright (c) 2015 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
 //
-//  Created by Daniel Stenmark on 12/27/15.
-//  Copyright © 2015 Apple. All rights reserved.
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
 #if DEPLOYMENT_RUNTIME_OBJC || os(Linux)


### PR DESCRIPTION
This makes the comment header more consistent with the other tests. 