### PR TITLE
Adding implementation of NSRegularExpression.escapedPatternForString(_:)

### DIFF
--- a/Foundation/NSRegularExpression.swift
+++ b/Foundation/NSRegularExpression.swift
@@ -81,7 +81,9 @@ public class NSRegularExpression : NSObject, NSCopying, NSCoding {
     
     /* This class method will produce a string by adding backslash escapes as necessary to the given string, to escape any characters that would otherwise be treated as pattern metacharacters.
     */
-    public class func escapedPatternForString(string: String) -> String { NSUnimplemented() }
+    public class func escapedPatternForString(string: String) -> String { 
+        return _CFRegularExpressionCreateEscapedPattern(string._cfObject)._swiftObject
+    }
 }
 
 public struct NSMatchingOptions : OptionSetType {

--- a/TestFoundation/TestNSRegularExpression.swift
+++ b/TestFoundation/TestNSRegularExpression.swift
@@ -157,6 +157,8 @@ class TestNSRegularExpression : XCTestCase {
         simpleRegularExpressionTestWithPattern(".*\\Ax", target:"xyz", looking:true, match:false)
         simpleRegularExpressionTestWithPattern(".*\\Ax", target:" xyz", looking:false, match:false)
         simpleRegularExpressionTestWithPattern("\\\\\\|\\(\\)\\[\\{\\~\\$\\*\\+\\?\\.", target:"\\|()[{~$*+?.", looking:true, match:true)
+        simpleRegularExpressionTestWithPattern(NSRegularExpression.escapedPatternForString("+\\{}[].^$?#<=!&*()"), target:"+\\{}[].^$?#<=!&*()", looking:true, match:true)
+        simpleRegularExpressionTestWithPattern(NSRegularExpression.escapedPatternForString("+\\{}[].^$?#<=!&*()"), target:"+\\{}[].^$?#<=!&*() abc", looking:true, match:false)
     }
     
     func replaceRegularExpressionTest(patternString: String, _ patternOptions: NSRegularExpressionOptions, _ searchString: String, _ searchOptions: NSMatchingOptions, _ searchRange: NSRange, _ templ: String, _ numberOfMatches: Int, _ result: String, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
Added implementation of class method escapedPatternForString() which simply calls
_CFRegularExpressionCreateEscapedPattern(). Also added two tests to
TestFoundation/TestNSRegularExpression.swift.