### PR TITLE
SR-794 pass supplied subpath through to URLForResource rather than nil

### DIFF
--- a/Foundation/NSBundle.swift
+++ b/Foundation/NSBundle.swift
@@ -205,7 +205,7 @@ public class NSBundle : NSObject {
     }
     
     public func pathForResource(name: String?, ofType ext: String?, inDirectory subpath: String?) -> String? {
-        return self.URLForResource(name, withExtension: ext, subdirectory: nil)?.path
+        return self.URLForResource(name, withExtension: ext, subdirectory: subpath)?.path
     }
     
     public func pathForResource(name: String?, ofType ext: String?, inDirectory subpath: String?, forLocalization localizationName: String?) -> String? {

--- a/TestFoundation/TestNSBundle.swift
+++ b/TestFoundation/TestNSBundle.swift
@@ -98,6 +98,9 @@ class TestNSBundle : XCTestCase {
     
     private let _bundleName = "MyBundle.bundle"
     private let _bundleResourceNames = ["hello.world", "goodbye.world", "swift.org"]
+    private let _subDirectory = "Sources"
+    private let _main = "main"
+    private let _type = "swift"
     
     private func _setupPlayground() -> String? {
         // Make sure the directory is uniquely named
@@ -114,6 +117,10 @@ class TestNSBundle : XCTestCase {
             for n in _bundleResourceNames {
                 NSFileManager.defaultManager().createFileAtPath(bundlePath + "/" + n, contents: nil, attributes: nil)
             }
+            // Add a resource into a subdirectory
+            let subDirPath = bundlePath + "/" + _subDirectory
+            try NSFileManager.defaultManager().createDirectoryAtPath(subDirPath, withIntermediateDirectories: false, attributes: nil)
+            NSFileManager.defaultManager().createFileAtPath(subDirPath + "/" + _main + "." + _type, contents: nil, attributes: nil)
         } catch _ {
             return nil
         }
@@ -139,6 +146,9 @@ class TestNSBundle : XCTestCase {
         let worldResources = bundle?.URLsForResourcesWithExtension("world", subdirectory: nil)
         XCTAssertNotNil(worldResources)
         XCTAssertEqual(worldResources?.count, 2)
+        
+        let path = bundle?.pathForResource(_main, ofType: _type, inDirectory: _subDirectory)
+        XCTAssertNotNil(path)
         
         _cleanupPlayground(playground)
     }


### PR DESCRIPTION
[SR-794](https://bugs.swift.org/browse/SR-794) reports an issue with `NSBundle.pathForResource()` whereby it returns `nil` instead of the expected resource.

It looks like this is cause because the supplied `subpath` value isn't passed down to the underlying `URLForResource()` call.

I've fixed that and added an implementation of the test case to TestNSBundle. I've done that under the existing `test_URLsForResourcesWithExtension()` test as a separate call and check as its a similar test and reuses the same bundle setup/teardown. I can spin it off as a separate test though if it makes sense.