### PR TITLE
Fixes wrong behavior of NSArray.indexOfObject…

### DIFF
--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -543,15 +543,15 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
             }
         }
         
-        guard searchForInsertionIndex && lastEqual else {
+        if !searchForInsertionIndex {
             return result
         }
         
-        guard result == NSNotFound else {
-            return result + 1
+        if result == NSNotFound {
+            return indexOfLeastGreaterThanObj
         }
         
-        return indexOfLeastGreaterThanObj
+        return lastEqual ? result + 1 : result
     }
     
     

--- a/TestFoundation/TestNSArray.swift
+++ b/TestFoundation/TestNSArray.swift
@@ -156,6 +156,14 @@ class TestNSArray : XCTestCase {
         let rangeLength = 13
         let endOfArray = objectIndexInArray(array, value: 10, startingFrom: rangeStart, length: rangeLength, options: [.InsertionIndex, .LastEqual])
         XCTAssertTrue(endOfArray == (rangeStart + rangeLength), "...or the index at the end of the array if the object is larger than all other elements.")
+        
+        let arrayOfTwo = NSArray(array: [NSNumber(int: 0), NSNumber(int: 2)])
+        let indexInMiddle = objectIndexInArray(arrayOfTwo, value: 1, startingFrom: 0, length: 2, options: [.InsertionIndex, .FirstEqual])
+        XCTAssertEqual(indexInMiddle, 1, "If no match found item should be inserted before least greater object")
+        let indexInMiddle2 = objectIndexInArray(arrayOfTwo, value: 1, startingFrom: 0, length: 2, options: [.InsertionIndex, .LastEqual])
+        XCTAssertEqual(indexInMiddle2, 1, "If no match found item should be inserted before least greater object")
+        let indexInMiddle3 = objectIndexInArray(arrayOfTwo, value: 1, startingFrom: 0, length: 2, options: [.InsertionIndex])
+        XCTAssertEqual(indexInMiddle3, 1, "If no match found item should be inserted before least greater object")
     }
 
 


### PR DESCRIPTION
…when looking for insertion index for object not yet presented in an array.

Expected behavior is method to return index of least greater object or last index in array. Without this fix the method returns correct result if .LastEqual specified only.