### PR TITLE
Implement missing stringValue and descriptionWithLocale APIs

### DIFF
--- a/Foundation/NSDecimalNumber.swift
+++ b/Foundation/NSDecimalNumber.swift
@@ -55,7 +55,7 @@ public class NSDecimalNumber : NSNumber {
         NSRequiresConcreteImplementation()
     }
     
-    public func descriptionWithLocale(locale: AnyObject?) -> String { NSUnimplemented() }
+    public override func descriptionWithLocale(locale: AnyObject?) -> String { NSUnimplemented() }
     
     // TODO: "declarations from extensions cannot be overridden yet"
     // Although it's not clear we actually need to redeclare this here when the extension adds it to the superclass of this class

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -434,6 +434,10 @@ public class NSNumber : NSValue {
         return val
     }
     
+    public var stringValue: String {
+        return descriptionWithLocale(nil)
+    }
+    
     /// Create an instance initialized to `value`.
     public required convenience init(integerLiteral value: Int) {
         self.init(integer: value)
@@ -451,6 +455,12 @@ public class NSNumber : NSValue {
 
     public func compare(otherNumber: NSNumber) -> NSComparisonResult {
         return ._fromCF(CFNumberCompare(_cfObject, otherNumber._cfObject, nil))
+    }
+
+    public func descriptionWithLocale(locale: AnyObject?) -> String {
+        guard let aLocale = locale else { return description }
+        let formatter = CFNumberFormatterCreate(nil, (aLocale as! NSLocale)._cfObject, kCFNumberFormatterDecimalStyle)
+        return CFNumberFormatterCreateStringWithNumber(nil, formatter, self._cfObject)._swiftObject
     }
     
     override public var _cfTypeID: CFTypeID {


### PR DESCRIPTION
The [NSNumber reference](https://developer.apple.com/library/prerelease/ios/documentation/Cocoa/Reference/Foundation/Classes/NSNumber_Class/index.html#//apple_ref/occ/instm/NSNumber/descriptionWithLocale:) documents the following two APIs which appear not to be implemented (even as calls to `NSUnimplemented`):
```swift
var stringValue: String { get }
func descriptionWithLocale(_ locale: AnyObject?) -> String
```
Additionally `stringValue()` is described as a call to `descriptionWithLocale(nil)`.

I've therefore implemented `descriptionWithLocal()`, and `stringValue()` as a call through to it.