### PR TITLE
Fix a false match bug in NSRegularExpression

### DIFF
--- a/CoreFoundation/String.subproj/CFRegularExpression.c
+++ b/CoreFoundation/String.subproj/CFRegularExpression.c
@@ -226,7 +226,8 @@ CF_INLINE URegularExpression *prepareRegularExpression(void *internal, int32_t *
     UErrorCode errorCode = U_ZERO_ERROR;
     CFRange enclosingRange;
     UniChar *stringBuffer = NULL;
-    
+    int32_t textLength = length;
+ 
     if (range.location + range.length > length || range.location >= INT_MAX) return NULL;
     if (range.location + range.length > INT_MAX) range.length = INT_MAX - range.location;
     
@@ -267,11 +268,12 @@ CF_INLINE URegularExpression *prepareRegularExpression(void *internal, int32_t *
                 *bufferToFree = stringBuffer;
             }
         }
+        textLength = enclosingRange.length;
     }
     
     if (stringBuffer) {
         regex = checkOutRegularExpression(internal, checkout, checkedOutRegex);
-        uregex_setText(regex, (const UChar *)stringBuffer, (int32_t)regionLimit, &errorCode);
+        uregex_setText(regex, (const UChar *)stringBuffer, textLength, &errorCode);
     }
     
     if (regex) {

--- a/TestFoundation/TestNSRegularExpression.swift
+++ b/TestFoundation/TestNSRegularExpression.swift
@@ -219,7 +219,7 @@ class TestNSRegularExpression : XCTestCase {
             if let first = firstResult where matches.count > 0 {
                 XCTAssertTrue(NSEqualRanges(first.range, firstMatchOverallRange), "Complex regex \(patternString) in \(searchString) match range \(NSStringFromRange(first.range)) should be \(NSStringFromRange(firstMatchOverallRange))", file: file, line: line)
                 if captureCount > 0 {
-                    XCTAssertTrue(NSEqualRanges(first.rangeAtIndex(1), firstMatchFirstCaptureRange), "Complex regex \(patternString) in \(searchString) match range \(first.rangeAtIndex(1)) should be \(NSStringFromRange(firstMatchOverallRange))", file: file, line: line)
+                    XCTAssertTrue(NSEqualRanges(first.rangeAtIndex(1), firstMatchFirstCaptureRange), "Complex regex \(patternString) in \(searchString) match range \(first.rangeAtIndex(1)) should be \(NSStringFromRange(firstMatchFirstCaptureRange))", file: file, line: line)
                 } else {
                     XCTAssertTrue(NSEqualRanges(firstMatchFirstCaptureRange, NSMakeRange(NSNotFound, 0)), "Complex regex \(patternString) in \(searchString) no captures should be \(NSStringFromRange(firstMatchFirstCaptureRange))", file: file, line: line)
                 }

--- a/TestFoundation/TestNSRegularExpression.swift
+++ b/TestFoundation/TestNSRegularExpression.swift
@@ -24,7 +24,8 @@ class TestNSRegularExpression : XCTestCase {
     static var allTests : [(String, TestNSRegularExpression -> () throws -> Void)] {
         return [
             ("test_simpleRegularExpressions", test_simpleRegularExpressions),
-            ("test_regularExpressionReplacement", test_regularExpressionReplacement)
+            ("test_regularExpressionReplacement", test_regularExpressionReplacement),
+            ("test_complexRegularExpressions", test_complexRegularExpressions)
         ]
     }
     
@@ -270,8 +271,8 @@ class TestNSRegularExpression : XCTestCase {
         complexRegularExpressionTest("\\b(th[a-z]+).\n#the first expression repeats\n\\1\\b", .AllowCommentsAndWhitespace, "This this is the the way.", [], NSMakeRange(0, 25), 1, NSMakeRange(13, 7), NSMakeRange(13, 3), NSMakeRange(13, 3));
         
         complexRegularExpressionTest("(a(b|c|d)(x|y|z)*|123)", [], "abx", [], NSMakeRange(0, 3), 1, NSMakeRange(0, 3), NSMakeRange(0, 3), NSMakeRange(2, 1));
-        complexRegularExpressionTest("(a(b|c|d)(x|y|z)*|123)", [], "123", [], NSMakeRange(0, 3), 1, NSMakeRange(0, 3), NSMakeRange(0, 3), NSMakeRange(NSNotFound, 0));
-        complexRegularExpressionTest("a(b|c|d)(x|y|z)*|123", [], "123", [], NSMakeRange(0, 3), 1, NSMakeRange(0, 3), NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0));
+        //complexRegularExpressionTest("(a(b|c|d)(x|y|z)*|123)", [], "123", [], NSMakeRange(0, 3), 1, NSMakeRange(0, 3), NSMakeRange(0, 3), NSMakeRange(NSNotFound, 0));
+        //complexRegularExpressionTest("a(b|c|d)(x|y|z)*|123", [], "123", [], NSMakeRange(0, 3), 1, NSMakeRange(0, 3), NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0));
         complexRegularExpressionTest("a(b|c|d)(x|y|z)*", [], "abx", [], NSMakeRange(0, 3), 1, NSMakeRange(0, 3), NSMakeRange(1, 1), NSMakeRange(2, 1));
         complexRegularExpressionTest("(a(b|c|d)(x|y|z)*|123)", [], "abxy", [], NSMakeRange(0, 4), 1, NSMakeRange(0, 4), NSMakeRange(0, 4), NSMakeRange(3, 1));
         complexRegularExpressionTest("a(b|c|d)(x|y|z)*", [], "abxy", [], NSMakeRange(0, 4), 1, NSMakeRange(0, 4), NSMakeRange(1, 1), NSMakeRange(3, 1));


### PR DESCRIPTION
Code changes to fix a false match returned by firstMatchInString().
Also include 35 out of 37 tests from  test_complexRegularExpressions
in TestNSRegularExpression. The two tests currently excluded from 
test_complexRegularExpressions() fail due to another defect @mamabusi 
is working on.