### PR TITLE
[SR-765] Implement NSNumberFormatter.stringForObjectValue()

### DIFF
--- a/Foundation/NSNumberFormatter.swift
+++ b/Foundation/NSNumberFormatter.swift
@@ -52,6 +52,11 @@ public class NSNumberFormatter : NSFormatter {
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
     public func objectValue(string: String, inout range: NSRange) throws -> AnyObject? { NSUnimplemented() }
     
+    public override func stringForObjectValue(obj: AnyObject) -> String? {
+        guard let number = obj as? NSNumber else { return nil }
+        return stringFromNumber(number)
+    }
+    
     // Even though NSNumberFormatter responds to the usual NSFormatter methods,
     //   here are some convenience methods which are a little more obvious.
     public func stringFromNumber(number: NSNumber) -> String? {


### PR DESCRIPTION
[SR 765](https://bugs.swift.org/browse/SR-765) reports that `NSNumberFormatter` is missing an implementation for `stringForObjectValue()`.

I've added an implementation for that which follows the [NSFormatter Class Reference](https://developer.apple.com/library/prerelease/ios/documentation/Cocoa/Reference/Foundation/Classes/NSFormatter_Class/index.html#//apple_ref/occ/instm/NSFormatter/stringForObjectValue:) by returning `nil` if the class is incorrect, otherwise returning a formatted string. The formatted string is obtained by calling through to `stringFromNumber()`, which also deals with the localisation of the string. 