### PR TITLE
Fix API parity to ObjC Foundation NSURL.absoluteString

### DIFF
--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -213,12 +213,12 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
         }
     }
     
-    public var absoluteString: String? {
+    public var absoluteString: String {
         if let absURL = CFURLCopyAbsoluteURL(_cfObject) {
             return CFURLGetString(absURL)._swiftObject
-        } else {
-            return nil
         }
+
+        return CFURLGetString(_cfObject)._swiftObject
     }
     
     // The relative portion of a URL.  If baseURL is nil, or if the receiver is itself absolute, this is the same as absoluteString
@@ -518,11 +518,11 @@ extension NSURL {
     
     internal func _resolveSymlinksInPath(excludeSystemDirs excludeSystemDirs: Bool) -> NSURL? {
         guard fileURL else {
-            return NSURL(string: absoluteString!)
+            return NSURL(string: absoluteString)
         }
         
         guard let selfPath = path else {
-            return NSURL(string: absoluteString!)
+            return NSURL(string: absoluteString)
         }
         
         let absolutePath: String
@@ -535,7 +535,7 @@ extension NSURL {
         
         var components = absolutePath.pathComponents
         guard !components.isEmpty else {
-            return NSURL(string: absoluteString!)
+            return NSURL(string: absoluteString)
         }
         
         var resolvedPath = components.removeFirst()

--- a/Foundation/NSXMLDTD.swift
+++ b/Foundation/NSXMLDTD.swift
@@ -19,10 +19,7 @@ public class NSXMLDTD : NSXMLNode {
     }
     
     public convenience init(contentsOfURL url: NSURL, options mask: Int) throws {
-        guard let urlString = url.absoluteString else {
-            //TODO: throw an error
-            fatalError("nil URL")
-        }
+        let urlString = url.absoluteString
 
         let node = _CFXMLParseDTD(urlString)
         if node == nil {


### PR DESCRIPTION
The Objective-C Foundation's NSURL.absoluteString returns non-optional, but SwiftFoundation's is currently an optional. This makes the APIs consistent between eachother so importing Foundation on either platform works the same with this method.