### PR TITLE
Replace NSNotFound for kCFNotFound in NSRange

### DIFF
--- a/Foundation/NSTextCheckingResult.swift
+++ b/Foundation/NSTextCheckingResult.swift
@@ -7,6 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+import CoreFoundation
 
 /* NSTextCheckingType in this project is limited to regular expressions. */
 public struct NSTextCheckingType : OptionSet {
@@ -57,9 +58,10 @@ internal class _NSRegularExpressionTextCheckingResultResult : NSTextCheckingResu
     init(ranges: NSRangePointer, count: Int, regularExpression: NSRegularExpression) {
         _regularExpression = regularExpression
         super.init()
+        let notFound = NSRange(location: NSNotFound,length: 0)
         for i in 0..<count {
-            _ranges.append(ranges[i])
-        }
+            ranges[i].location == kCFNotFound ? _ranges.append(notFound) : _ranges.append(ranges[i])
+        }  
     }
 
     internal required init?(coder aDecoder: NSCoder) {

--- a/TestFoundation/TestNSRegularExpression.swift
+++ b/TestFoundation/TestNSRegularExpression.swift
@@ -24,7 +24,8 @@ class TestNSRegularExpression : XCTestCase {
     static var allTests : [(String, TestNSRegularExpression -> () throws -> Void)] {
         return [
             ("test_simpleRegularExpressions", test_simpleRegularExpressions),
-            ("test_regularExpressionReplacement", test_regularExpressionReplacement)
+            ("test_regularExpressionReplacement", test_regularExpressionReplacement),
+            ("test_complexRegularExpressions", test_complexRegularExpressions) 
         ]
     }
     
@@ -236,13 +237,13 @@ class TestNSRegularExpression : XCTestCase {
         complexRegularExpressionTest("\\b(th[a-z]+) \\1\\b", [], "This this is the the way.", [], NSMakeRange(0, 25), 1, NSMakeRange(13, 7), NSMakeRange(13, 3), NSMakeRange(13, 3));
         complexRegularExpressionTest("\\b(th[a-z]+) \\1\\b", .CaseInsensitive, "This this is the the way.", [], NSMakeRange(0, 25), 2, NSMakeRange(0, 9), NSMakeRange(0, 4), NSMakeRange(0, 4));
         
-        complexRegularExpressionTest("\\b(th[a-z]+) \\1\\b", [], "This this is the theway.", [], NSMakeRange(0, 24), 0, NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0));
+        //complexRegularExpressionTest("\\b(th[a-z]+) \\1\\b", [], "This this is the theway.", [], NSMakeRange(0, 24), 0, NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0));
         complexRegularExpressionTest("\\b(th[a-z]+) \\1\\b", [], "This this is the theway.", [], NSMakeRange(0, 20), 1, NSMakeRange(13, 7), NSMakeRange(13, 3), NSMakeRange(13, 3));
-        complexRegularExpressionTest("\\b(th[a-z]+) \\1\\b", [], "This this is the theway.", .WithTransparentBounds, NSMakeRange(0, 20), 0, NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0));
+        //complexRegularExpressionTest("\\b(th[a-z]+) \\1\\b", [], "This this is the theway.", .WithTransparentBounds, NSMakeRange(0, 20), 0, NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0));
         complexRegularExpressionTest("\\b(th[a-z]+) \\1\\b", .CaseInsensitive, "xThis this is the theway.", [], NSMakeRange(0, 25), 0, NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0));
-        complexRegularExpressionTest("\\b(th[a-z]+) \\1\\b", [], "xThis this is the theway.", [], NSMakeRange(1, 20), 1, NSMakeRange(14, 7), NSMakeRange(14, 3), NSMakeRange(14, 3));
+        //complexRegularExpressionTest("\\b(th[a-z]+) \\1\\b", [], "xThis this is the theway.", [], NSMakeRange(1, 20), 1, NSMakeRange(14, 7), NSMakeRange(14, 3), NSMakeRange(14, 3));
         complexRegularExpressionTest("\\b(th[a-z]+) \\1\\b", .CaseInsensitive, "xThis this is the theway.", [], NSMakeRange(1, 20), 2, NSMakeRange(1, 9), NSMakeRange(1, 4), NSMakeRange(1, 4));
-        complexRegularExpressionTest("\\b(th[a-z]+) \\1\\b", .CaseInsensitive, "xThis this is the theway.", .WithTransparentBounds, NSMakeRange(1, 20), 0, NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0));
+        //complexRegularExpressionTest("\\b(th[a-z]+) \\1\\b", .CaseInsensitive, "xThis this is the theway.", .WithTransparentBounds, NSMakeRange(1, 20), 0, NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0));
         
         complexRegularExpressionTest(NSRegularExpression.escapedPatternForString("\\b(th[a-z]+) \\1\\b"), [], "This this is the the way.", [], NSMakeRange(0, 25), 0, NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0));
         complexRegularExpressionTest(NSRegularExpression.escapedPatternForString("\\b(th[a-z]+) \\1\\b"), [], "x\\b(th[a-z]+) \\1\\by", [], NSMakeRange(0, 19), 1, NSMakeRange(1, 17), NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0));
@@ -275,5 +276,9 @@ class TestNSRegularExpression : XCTestCase {
         complexRegularExpressionTest("a(b|c|d)(x|y|z)*", [], "abx", [], NSMakeRange(0, 3), 1, NSMakeRange(0, 3), NSMakeRange(1, 1), NSMakeRange(2, 1));
         complexRegularExpressionTest("(a(b|c|d)(x|y|z)*|123)", [], "abxy", [], NSMakeRange(0, 4), 1, NSMakeRange(0, 4), NSMakeRange(0, 4), NSMakeRange(3, 1));
         complexRegularExpressionTest("a(b|c|d)(x|y|z)*", [], "abxy", [], NSMakeRange(0, 4), 1, NSMakeRange(0, 4), NSMakeRange(1, 1), NSMakeRange(3, 1));
+        complexRegularExpressionTest("(a|b)x|123|(c|d)y", [], "123dy", [], NSMakeRange(0, 5), 2, NSMakeRange(0, 3), NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0));
+        complexRegularExpressionTest("(a|b)x|123|(c|d)y", [], "903847123", [], NSMakeRange(0, 9), 1, NSMakeRange(6, 3), NSMakeRange(NSNotFound, 0), NSMakeRange(NSNotFound, 0));
+        complexRegularExpressionTest("(a|b)x|123|(c|d)y", [], "axcy", [], NSMakeRange(0, 4), 2, NSMakeRange(0, 2), NSMakeRange(0, 1), NSMakeRange(NSNotFound, 0));
+        complexRegularExpressionTest("(a|b)x|123|(c|d)y", [], "cya", [], NSMakeRange(0, 3), 1, NSMakeRange(0, 2), NSMakeRange(NSNotFound, 0), NSMakeRange(0, 1)); 
     }
 }


### PR DESCRIPTION
CoreFoundation returns a "not found"  range as {-1, 0}.
This needs to be represented as {NSNotFound, 0} in Foundation.
Included all but four tests from test_complexRegularExpression
in TestNSRegularExpression (the excluded depend on PR 278)
Added four new tests as well.