### PR TITLE
Generalize trap intrinsic and allow aarch64

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -163,15 +163,15 @@ CF_PRIVATE CFIndex __CFActiveProcessorCount();
 
 #if defined(__i386__) || defined(__x86_64__)
     #if defined(__GNUC__)
-        #define HALT do {asm __volatile__("int3"); kill(getpid(), 9); __builtin_unreachable(); } while (0)
+        #define HALT do {__builtin_trap(); kill(getpid(), 9); __builtin_unreachable(); } while (0)
     #elif defined(_MSC_VER)
         #define HALT do { DebugBreak(); abort(); __builtin_unreachable(); } while (0)
     #else
         #error Compiler not supported
     #endif
-#elif defined(__ppc__) || (__arm__)
+#elif defined(__ppc__) || (__arm__) || (__aarch64__)
     #if defined(__GNUC__)
-        #define HALT do {asm __volatile__("trap"); kill(getpid(), 9); __builtin_unreachable(); } while (0)
+        #define HALT do {__builtin_trap(); kill(getpid(), 9); __builtin_unreachable(); } while (0)
     #elif defined(_MSC_VER)
         #define HALT do { DebugBreak(); abort(); __builtin_unreachable(); } while (0)
     #else

--- a/CoreFoundation/Base.subproj/SwiftRuntime/TargetConditionals.h
+++ b/CoreFoundation/Base.subproj/SwiftRuntime/TargetConditionals.h
@@ -107,7 +107,7 @@
 #define TARGET_CPU_ARM64        0
 #define TARGET_CPU_MIPS         0
 #define TARGET_CPU_MIPS64       0
-#elif __arm64__
+#elif __arm64__ || __aarch64__
 #define TARGET_CPU_PPC          0
 #define TARGET_CPU_PPC64        0
 #define TARGET_CPU_X86          0


### PR DESCRIPTION
These are just some small changes that begin to enable building Foundation on 64-bit arm linux.