### PR TITLE
[SR-929] Implement NSString.init() with locale

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -1214,7 +1214,17 @@ extension NSString {
     }
     
     public convenience init(format: String, locale: AnyObject?, arguments argList: CVaListPointer) {
-        NSUnimplemented()    
+        let str: CFString
+        if let loc = locale {
+            if loc.dynamicType === NSLocale.self || loc.dynamicType === NSDictionary.self {
+                str = CFStringCreateWithFormatAndArguments(kCFAllocatorSystemDefault, unsafeBitCast(loc, to: CFDictionary.self), format._cfObject, argList)
+            } else {
+                fatalError("locale parameter must be a NSLocale or a NSDictionary")
+            }
+        } else {
+            str = CFStringCreateWithFormatAndArguments(kCFAllocatorSystemDefault, nil, format._cfObject, argList)
+        }
+        self.init(str._swiftObject)
     }
     
     public convenience init(format: NSString, _ args: CVarArgType...) {

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -70,6 +70,7 @@ class TestNSString : XCTestCase {
             ("test_stringByTrimmingCharactersInSet", test_stringByTrimmingCharactersInSet),
             ("test_initializeWithFormat", test_initializeWithFormat),
             ("test_initializeWithFormat2", test_initializeWithFormat2),
+            ("test_initializeWithFormat3", test_initializeWithFormat3),
             ("test_stringByDeletingLastPathComponent", test_stringByDeletingLastPathComponent),
             ("test_getCString_simple", test_getCString_simple),
             ("test_getCString_nonASCII_withASCIIAccessor", test_getCString_nonASCII_withASCIIAccessor),
@@ -610,6 +611,35 @@ class TestNSString : XCTestCase {
         let argument: UInt8 = 75
         let string = NSString(format: "%02X", argument)
         XCTAssertEqual(string, "4B")
+    }
+    
+    func test_initializeWithFormat3() {
+        let argument: [CVarArg] = [1000, 42.0]
+        
+        withVaList(argument) {
+            pointer in
+            let string = NSString(format: "Default value is %d (%.1f)", locale: nil, arguments: pointer)
+            XCTAssertEqual(string, "Default value is 1000 (42.0)")
+        }
+        
+        withVaList(argument) {
+            pointer in
+            let string = NSString(format: "en_GB value is %d (%.1f)", locale: NSLocale.init(localeIdentifier: "en_GB"), arguments: pointer)
+            XCTAssertEqual(string, "en_GB value is 1,000 (42.0)")
+        }
+
+        withVaList(argument) {
+            pointer in
+            let string = NSString(format: "de_DE value is %d (%.1f)", locale: NSLocale.init(localeIdentifier: "de_DE"), arguments: pointer)
+            XCTAssertEqual(string, "de_DE value is 1.000 (42,0)")
+        }
+        
+        withVaList(argument) {
+            pointer in
+            let loc: NSDictionary = ["NSDecimalSeparator" as NSString : "&" as NSString]
+            let string = NSString(format: "NSDictionary value is %d (%.1f)", locale: loc, arguments: pointer)
+            XCTAssertEqual(string, "NSDictionary value is 1000 (42&0)")
+        }
     }
     
     func test_stringByDeletingLastPathComponent() {


### PR DESCRIPTION
[SR-929](https://bugs.swift.org/browse/SR-929) covers the need to implement the following NSString API:
```swift
public convenience init(format: String, locale: AnyObject?, arguments argList: CVaListPointer)
```

This PR adds an implementation that:
- Allows the for `locale` parameter to be a `NSLocale`,  `NSDictionary` or `nil`.
The parameter type is checked, checking `NSLocale` first as its the expected type
- Casts the type to `CFDictionary` for use in `CFString`
Here I've used `unsafeBitCast` as casting to a CFDictionary directly doesn't work on Linux and there doesn't appear to be a "safer" was of casting that works. The underlying functions check to see if the actual type is a `CFLocale` or a `CFDictionary` and handles as appropriate.
- Throws a `fatalError()` for invalid locale parameters
The actual behaviour is undefined by the spec. As the init function isn't failable there needs to be some kind of error, and it looked better to fail here with a relevant message than further down the call stack.

The behaviour is the same as for Objective-C on Mac, except for the error handling. Let me know if there's any suggest changes to the implementation.

I've also added 4 tests for the implementation:
1. Checking the use of `nil`
2. Checking with the English locale using NSLocale, returning 1,000 (42.0)
3. Checking with the German locale using NSLocale, returning 1.000 (42,0)
4. Checking with a custom decimal separator using a NSDictionary, returning 1000 (42&0)    