### PR TITLE
Implement remaining NSDateFormatter attributes, with more tests

### DIFF
--- a/Foundation/NSDateFormatter.swift
+++ b/Foundation/NSDateFormatter.swift
@@ -90,31 +90,31 @@ public class NSDateFormatter : NSFormatter {
     internal func _setFormatterAttributes(formatter: CFDateFormatter) {
         _setFormatterAttribute(formatter, attributeName: kCFDateFormatterIsLenient, value: lenient._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFDateFormatterTimeZone, value: timeZone?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterCalendarName, value: calendar?.calendarIdentifier._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterTwoDigitStartDate, value: twoDigitStartDate?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterCalendarName, value: _calendar?.calendarIdentifier._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterTwoDigitStartDate, value: _twoDigitStartDate?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFDateFormatterDefaultDate, value: defaultDate?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterCalendar, value: calendar?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterEraSymbols, value: eraSymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterMonthSymbols, value: monthSymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterShortMonthSymbols, value: shortMonthSymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterWeekdaySymbols, value: weekdaySymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterShortWeekdaySymbols, value: shortWeekdaySymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterAMSymbol, value: AMSymbol?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterPMSymbol, value: PMSymbol?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterLongEraSymbols, value: longEraSymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterVeryShortMonthSymbols, value: veryShortMonthSymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterStandaloneMonthSymbols, value: standaloneMonthSymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterShortStandaloneMonthSymbols, value: shortStandaloneMonthSymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterVeryShortStandaloneMonthSymbols, value: veryShortStandaloneMonthSymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterVeryShortWeekdaySymbols, value: veryShortWeekdaySymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterStandaloneWeekdaySymbols, value: standaloneWeekdaySymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterShortStandaloneWeekdaySymbols, value: shortStandaloneWeekdaySymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterVeryShortStandaloneWeekdaySymbols, value: veryShortStandaloneWeekdaySymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterQuarterSymbols, value: quarterSymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterShortQuarterSymbols, value: shortQuarterSymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterStandaloneQuarterSymbols, value: standaloneQuarterSymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterShortStandaloneQuarterSymbols, value: shortStandaloneQuarterSymbols?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterGregorianStartDate, value: gregorianStartDate?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterCalendar, value: _calendar?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterEraSymbols, value: _eraSymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterMonthSymbols, value: _monthSymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterShortMonthSymbols, value: _shortMonthSymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterWeekdaySymbols, value: _weekdaySymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterShortWeekdaySymbols, value: _shortWeekdaySymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterAMSymbol, value: _AMSymbol?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterPMSymbol, value: _PMSymbol?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterLongEraSymbols, value: _longEraSymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterVeryShortMonthSymbols, value: _veryShortMonthSymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterStandaloneMonthSymbols, value: _standaloneMonthSymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterShortStandaloneMonthSymbols, value: _shortStandaloneMonthSymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterVeryShortStandaloneMonthSymbols, value: _veryShortStandaloneMonthSymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterVeryShortWeekdaySymbols, value: _veryShortWeekdaySymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterStandaloneWeekdaySymbols, value: _standaloneWeekdaySymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterShortStandaloneWeekdaySymbols, value: _shortStandaloneWeekdaySymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterVeryShortStandaloneWeekdaySymbols, value: _veryShortStandaloneWeekdaySymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterQuarterSymbols, value: _quarterSymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterShortQuarterSymbols, value: _shortQuarterSymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterStandaloneQuarterSymbols, value: _standaloneQuarterSymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterShortStandaloneQuarterSymbols, value: _shortStandaloneQuarterSymbols?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterGregorianStartDate, value: _gregorianStartDate?._cfObject)
     }
 
     internal func _setFormatterAttribute(formatter: CFDateFormatter, attributeName: CFString, value: AnyObject?) {
@@ -123,6 +123,7 @@ public class NSDateFormatter : NSFormatter {
         }
     }
 
+    private var _dateFormat: String? { willSet { _reset() } }
     public var dateFormat: String! {
         get {
             guard let format = _dateFormat else {
@@ -134,7 +135,6 @@ public class NSDateFormatter : NSFormatter {
             _dateFormat = newValue
         }
     }
-    private var _dateFormat: String? { willSet { _reset() } }
 
     public var dateStyle: NSDateFormatterStyle = .NoStyle { willSet { _reset() } }
 
@@ -146,55 +146,327 @@ public class NSDateFormatter : NSFormatter {
 
     /*@NSCopying*/ public var timeZone: NSTimeZone! = .systemTimeZone() { willSet { _reset() } }
 
-    /*@NSCopying*/ public var calendar: NSCalendar! { willSet { _reset() } }
+    /*@NSCopying*/ internal var _calendar: NSCalendar! { willSet { _reset() } }
+    public var calendar: NSCalendar! {
+        get {
+            guard let calendar = _calendar else {
+                return CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterCalendar) as! NSCalendar
+            }
+            return calendar
+        }
+        set {
+            _calendar = newValue
+        }
+    }
 
     public var lenient = false { willSet { _reset() } }
 
-    /*@NSCopying*/ public var twoDigitStartDate: NSDate? { willSet { _reset() } }
+    /*@NSCopying*/ internal var _twoDigitStartDate: NSDate? { willSet { _reset() } }
+    public var twoDigitStartDate: NSDate? {
+        get {
+            guard let startDate = _twoDigitStartDate else {
+                return CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterTwoDigitStartDate) as? NSDate
+            }
+            return startDate
+        }
+        set {
+            _twoDigitStartDate = newValue
+        }
+    }
 
     /*@NSCopying*/ public var defaultDate: NSDate? { willSet { _reset() } }
+    
+    internal var _eraSymbols: [String]! { willSet { _reset() } }
+    public var eraSymbols: [String]! {
+        get {
+            guard let symbols = _eraSymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterEraSymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _eraSymbols = newValue
+        }
+    }
+    
+    internal var _monthSymbols: [String]! { willSet { _reset() } }
+    public var monthSymbols: [String]! {
+        get {
+            guard let symbols = _monthSymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterMonthSymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _monthSymbols = newValue
+        }
+    }
 
-    public var eraSymbols: [String]! { willSet { _reset() } }
+    internal var _shortMonthSymbols: [String]! { willSet { _reset() } }
+    public var shortMonthSymbols: [String]! {
+        get {
+            guard let symbols = _shortMonthSymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterShortMonthSymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _shortMonthSymbols = newValue
+        }
+    }
+    
 
-    public var monthSymbols: [String]! { willSet { _reset() } }
+    internal var _weekdaySymbols: [String]! { willSet { _reset() } }
+    public var weekdaySymbols: [String]! {
+        get {
+            guard let symbols = _weekdaySymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterWeekdaySymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _weekdaySymbols = newValue
+        }
+    }
 
-    public var shortMonthSymbols: [String]! { willSet { _reset() } }
+    internal var _shortWeekdaySymbols: [String]! { willSet { _reset() } }
+    public var shortWeekdaySymbols: [String]! {
+        get {
+            guard let symbols = _shortWeekdaySymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterShortWeekdaySymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _shortWeekdaySymbols = newValue
+        }
+    }
 
-    public var weekdaySymbols: [String]! { willSet { _reset() } }
+    internal var _AMSymbol: String! { willSet { _reset() } }
+    public var AMSymbol: String! {
+        get {
+            guard let symbol = _AMSymbol else {
+                return (CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterAMSymbol) as! CFString)._swiftObject
+            }
+            return symbol
+        }
+        set {
+            _AMSymbol = newValue
+        }
+    }
 
-    public var shortWeekdaySymbols: [String]! { willSet { _reset() } }
+    internal var _PMSymbol: String! { willSet { _reset() } }
+    public var PMSymbol: String! {
+        get {
+            guard let symbol = _PMSymbol else {
+                return (CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterPMSymbol) as! CFString)._swiftObject
+            }
+            return symbol
+        }
+        set {
+            _PMSymbol = newValue
+        }
+    }
 
-    public var AMSymbol: String! { willSet { _reset() } }
+    internal var _longEraSymbols: [String]! { willSet { _reset() } }
+    public var longEraSymbols: [String]! {
+        get {
+            guard let symbols = _longEraSymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterLongEraSymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _longEraSymbols = newValue
+        }
+    }
 
-    public var PMSymbol: String! { willSet { _reset() } }
+    internal var _veryShortMonthSymbols: [String]! { willSet { _reset() } }
+    public var veryShortMonthSymbols: [String]! {
+        get {
+            guard let symbols = _veryShortMonthSymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterVeryShortMonthSymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _veryShortMonthSymbols = newValue
+        }
+    }
 
-    public var longEraSymbols: [String]! { willSet { _reset() } }
+    internal var _standaloneMonthSymbols: [String]! { willSet { _reset() } }
+    public var standaloneMonthSymbols: [String]! {
+        get {
+            guard let symbols = _standaloneMonthSymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterStandaloneMonthSymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _standaloneMonthSymbols = newValue
+        }
+    }
 
-    public var veryShortMonthSymbols: [String]! { willSet { _reset() } }
+    internal var _shortStandaloneMonthSymbols: [String]! { willSet { _reset() } }
+    public var shortStandaloneMonthSymbols: [String]! {
+        get {
+            guard let symbols = _shortStandaloneMonthSymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterShortStandaloneMonthSymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _shortStandaloneMonthSymbols = newValue
+        }
+    }
 
-    public var standaloneMonthSymbols: [String]! { willSet { _reset() } }
+    internal var _veryShortStandaloneMonthSymbols: [String]! { willSet { _reset() } }
+    public var veryShortStandaloneMonthSymbols: [String]! {
+        get {
+            guard let symbols = _veryShortStandaloneMonthSymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterVeryShortStandaloneMonthSymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _veryShortStandaloneMonthSymbols = newValue
+        }
+    }
 
-    public var shortStandaloneMonthSymbols: [String]! { willSet { _reset() } }
+    internal var _veryShortWeekdaySymbols: [String]! { willSet { _reset() } }
+    public var veryShortWeekdaySymbols: [String]! {
+        get {
+            guard let symbols = _veryShortWeekdaySymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterVeryShortWeekdaySymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _veryShortWeekdaySymbols = newValue
+        }
+    }
 
-    public var veryShortStandaloneMonthSymbols: [String]! { willSet { _reset() } }
+    internal var _standaloneWeekdaySymbols: [String]! { willSet { _reset() } }
+    public var standaloneWeekdaySymbols: [String]! {
+        get {
+            guard let symbols = _standaloneWeekdaySymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterStandaloneWeekdaySymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _standaloneWeekdaySymbols = newValue
+        }
+    }
 
-    public var veryShortWeekdaySymbols: [String]! { willSet { _reset() } }
+    internal var _shortStandaloneWeekdaySymbols: [String]! { willSet { _reset() } }
+    public var shortStandaloneWeekdaySymbols: [String]! {
+        get {
+            guard let symbols = _shortStandaloneWeekdaySymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterShortStandaloneWeekdaySymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _shortStandaloneWeekdaySymbols = newValue
+        }
+    }
+    
+    internal var _veryShortStandaloneWeekdaySymbols: [String]! { willSet { _reset() } }
+    public var veryShortStandaloneWeekdaySymbols: [String]! {
+        get {
+            guard let symbols = _veryShortStandaloneWeekdaySymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterVeryShortStandaloneWeekdaySymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _veryShortStandaloneWeekdaySymbols = newValue
+        }
+    }
 
-    public var standaloneWeekdaySymbols: [String]! { willSet { _reset() } }
+    internal var _quarterSymbols: [String]! { willSet { _reset() } }
+    public var quarterSymbols: [String]! {
+        get {
+            guard let symbols = _quarterSymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterQuarterSymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _quarterSymbols = newValue
+        }
+    }
+    
+    internal var _shortQuarterSymbols: [String]! { willSet { _reset() } }
+    public var shortQuarterSymbols: [String]! {
+        get {
+            guard let symbols = _shortQuarterSymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterShortQuarterSymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _shortQuarterSymbols = newValue
+        }
+    }
 
-    public var shortStandaloneWeekdaySymbols: [String]! { willSet { _reset() } }
+    internal var _standaloneQuarterSymbols: [String]! { willSet { _reset() } }
+    public var standaloneQuarterSymbols: [String]! {
+        get {
+            guard let symbols = _standaloneQuarterSymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterStandaloneQuarterSymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _standaloneQuarterSymbols = newValue
+        }
+    }
 
-    public var veryShortStandaloneWeekdaySymbols: [String]! { willSet { _reset() } }
+    internal var _shortStandaloneQuarterSymbols: [String]! { willSet { _reset() } }
+    public var shortStandaloneQuarterSymbols: [String]! {
+        get {
+            guard let symbols = _shortStandaloneQuarterSymbols else {
+                let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterShortStandaloneQuarterSymbols) as! NSArray
+                return cfSymbols.bridge().map { ($0 as! NSString).bridge() }
+            }
+            return symbols
+        }
+        set {
+            _shortStandaloneQuarterSymbols = newValue
+        }
+    }
 
-    public var quarterSymbols: [String]! { willSet { _reset() } }
-
-    public var shortQuarterSymbols: [String]! { willSet { _reset() } }
-
-    public var standaloneQuarterSymbols: [String]! { willSet { _reset() } }
-
-    public var shortStandaloneQuarterSymbols: [String]! { willSet { _reset() } }
-
-    public var gregorianStartDate: NSDate? { willSet { _reset() } }
+    internal var _gregorianStartDate: NSDate? { willSet { _reset() } }
+    public var gregorianStartDate: NSDate? {
+        get {
+            guard let startDate = _gregorianStartDate else {
+                return CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterGregorianStartDate) as? NSDate
+            }
+            return startDate
+        }
+        set {
+            _gregorianStartDate = newValue
+        }
+    }
 
     public var doesRelativeDateFormatting = false { willSet { _reset() } }
 }

--- a/Foundation/NSDateFormatter.swift
+++ b/Foundation/NSDateFormatter.swift
@@ -136,9 +136,9 @@ public class NSDateFormatter : NSFormatter {
         }
     }
 
-    public var dateStyle: NSDateFormatterStyle = .NoStyle { willSet { _reset() } }
+    public var dateStyle: NSDateFormatterStyle = .NoStyle { willSet { _dateFormat = nil; _reset() } }
 
-    public var timeStyle: NSDateFormatterStyle = .NoStyle { willSet { _reset() } }
+    public var timeStyle: NSDateFormatterStyle = .NoStyle { willSet { _dateFormat = nil; _reset() } }
 
     /*@NSCopying*/ public var locale: NSLocale! = .currentLocale() { willSet { _reset() } }
 
@@ -251,7 +251,7 @@ public class NSDateFormatter : NSFormatter {
     public var AMSymbol: String! {
         get {
             guard let symbol = _AMSymbol else {
-                return (CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterAMSymbol) as! CFString)._swiftObject
+                return (CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterAMSymbol) as! NSString)._swiftObject
             }
             return symbol
         }
@@ -264,7 +264,7 @@ public class NSDateFormatter : NSFormatter {
     public var PMSymbol: String! {
         get {
             guard let symbol = _PMSymbol else {
-                return (CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterPMSymbol) as! CFString)._swiftObject
+                return (CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterPMSymbol) as! NSString)._swiftObject
             }
             return symbol
         }

--- a/TestFoundation/TestNSDateFormatter.swift
+++ b/TestFoundation/TestNSDateFormatter.swift
@@ -23,17 +23,16 @@ class TestNSDateFormatter: XCTestCase {
     static var allTests : [(String, TestNSDateFormatter -> () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
-//            ("test_customDateFormat", test_customDateFormat),
             ("test_dateStyleShort",    test_dateStyleShort),
             ("test_dateStyleMedium",   test_dateStyleMedium),
             ("test_dateStyleLong",     test_dateStyleLong),
-            ("test_dateStyleFull",     test_dateStyleFull)
+            ("test_dateStyleFull",     test_dateStyleFull),
+            ("test_customDateFormat", test_customDateFormat)
         ]
     }
     
     func test_BasicConstruction() {
         
-        // TODO: move to plist
         let symbolDictionaryOne = ["eraSymbols" : ["BC", "AD"],
                              "monthSymbols" : ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
                              "shortMonthSymbols" : ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
@@ -93,19 +92,10 @@ class TestNSDateFormatter: XCTestCase {
         
     }
     
-    func test_customDateFormat() {
-        let dateFormatter = NSDateFormatter()
-        dateFormatter.dateFormat = String("dd-MM-yyyy")
-        let dateStr = dateFormatter.stringFromDate(NSDate())
-        
-        print("With dateFormat '\(dateFormatter.dateFormat)':  '\(dateStr)'")
-        
-    }
-    
     // ShortStyle
     // locale  stringFromDate  example
     // ------  --------------  --------
-    // en_US   M/d/yy       12/25/15
+    // en_US   M/d/yy h:mm a   12/25/15 12:00 AM
     func test_dateStyleShort() {
         
         let timestamps = [
@@ -136,9 +126,9 @@ class TestNSDateFormatter: XCTestCase {
     }
     
     // MediumStyle
-    // locale  stringFromDate  example
-    // ------  --------------  ------------
-    // en_US   MMM d, y       Dec 25, 2015
+    // locale  stringFromDate        example
+    // ------  --------------        ------------
+    // en_US   MMM d, y, h:mm:ss a   Dec 25, 2015, 12:00:00 AM
     func test_dateStyleMedium() {
         
         let timestamps = [
@@ -168,9 +158,9 @@ class TestNSDateFormatter: XCTestCase {
     
     
     // LongStyle
-    // locale  stringFromDate  example
-    // ------  --------------  -----------------
-    // en_US   MMMM d, y       December 25, 2015
+    // locale  stringFromDate                 example
+    // ------  --------------                 -----------------
+    // en_US   MMMM d, y 'at' h:mm:ss a zzz   December 25, 2015 at 12:00:00 AM GMT
     func test_dateStyleLong() {
         
         let timestamps = [
@@ -199,9 +189,9 @@ class TestNSDateFormatter: XCTestCase {
     }
     
     // FullStyle
-    // locale  stringFromDate  example
-    // ------  --------------  -------------------------
-    // en_US   EEEE, MMMM d, y  Friday, December 25, 2015
+    // locale  stringFromDate                       example
+    // ------  --------------                       -------------------------
+    // en_US   EEEE, MMMM d, y 'at' h:mm:ss a zzzz  Friday, December 25, 2015 at 12:00:00 AM GMT
     func test_dateStyleFull() {
         
         let timestamps = [
@@ -229,6 +219,62 @@ class TestNSDateFormatter: XCTestCase {
 
             XCTAssertEqual(sf, stringResult)
         }
+        
+    }
+    
+    // Custom Style
+    // locale  stringFromDate                        example
+    // ------  --------------                        -------------------------
+    // en_US   EEEE, MMMM d, y 'at' hh:mm:ss a zzzz  Friday, December 25, 2015 at 12:00:00 AM GMT
+    func test_customDateFormat() {
+
+        let timestamps = [
+             -31536000 : "Wednesday, January 1, 1969 at 12:00:00 AM GMT" , 0.0 : "Thursday, January 1, 1970 at 12:00:00 AM GMT",
+             31536000 : "Friday, January 1, 1971 at 12:00:00 AM GMT", 2145916800 : "Friday, January 1, 2038 at 12:00:00 AM GMT",
+             1456272000 : "Wednesday, February 24, 2016 at 12:00:00 AM GMT", 1456358399 : "Wednesday, February 24, 2016 at 11:59:59 PM GMT",
+             1452574638 : "Tuesday, January 12, 2016 at 04:57:18 AM GMT", 1455685038 : "Wednesday, February 17, 2016 at 04:57:18 AM GMT",
+             1458622638 : "Tuesday, March 22, 2016 at 04:57:18 AM GMT", 1459745838 : "Monday, April 4, 2016 at 04:57:18 AM GMT",
+             1462597038 : "Saturday, May 7, 2016 at 04:57:18 AM GMT", 1465534638 : "Friday, June 10, 2016 at 04:57:18 AM GMT",
+             1469854638 : "Saturday, July 30, 2016 at 04:57:18 AM GMT", 1470718638 : "Tuesday, August 9, 2016 at 04:57:18 AM GMT",
+             1473915438 : "Thursday, September 15, 2016 at 04:57:18 AM GMT", 1477285038 : "Monday, October 24, 2016 at 04:57:18 AM GMT",
+             1478062638 : "Wednesday, November 2, 2016 at 04:57:18 AM GMT", 1482641838 : "Sunday, December 25, 2016 at 04:57:18 AM GMT"
+        ]
+        
+        let f = NSDateFormatter()
+        f.dateFormat = "EEEE, MMMM d, y 'at' hh:mm:ss a zzzz"
+        f.timeZone = NSTimeZone(name: DEFAULT_TIMEZONE)
+        f.locale = NSLocale(localeIdentifier: DEFAULT_LOCALE)
+        
+        for (timestamp, stringResult) in timestamps {
+            
+            let testDate = NSDate(timeIntervalSince1970: timestamp)
+            let sf = f.stringFromDate(testDate)
+            
+            XCTAssertEqual(sf, stringResult)
+        }
+        
+        let quarterTimestamps: [Double : String] = [
+            1451679712 : "1", 1459542112 : "2", 1467404512 : "3", 1475353312 : "4"
+        ]
+        
+        f.dateFormat = "Q"
+        
+        for (timestamp, stringResult) in quarterTimestamps {
+            let testDate = NSDate(timeIntervalSince1970: timestamp)
+            let sf = f.stringFromDate(testDate)
+            
+            XCTAssertEqual(sf, stringResult)
+        }
+        
+        // Check .dateFormat resets when style changes
+        let testDate = NSDate(timeIntervalSince1970: 1457738454)
+        f.dateStyle = .MediumStyle
+        f.timeStyle = .MediumStyle
+        XCTAssertEqual(f.stringFromDate(testDate), "Mar 11, 2016, 11:20:54 PM")
+        XCTAssertEqual(f.dateFormat, "MMM d, y, h:mm:ss a")
+        
+        f.dateFormat = "dd-MM-yyyy"
+        XCTAssertEqual(f.stringFromDate(testDate), "11-03-2016")
         
     }
     

--- a/TestFoundation/TestNSDateFormatter.swift
+++ b/TestFoundation/TestNSDateFormatter.swift
@@ -32,8 +32,65 @@ class TestNSDateFormatter: XCTestCase {
     }
     
     func test_BasicConstruction() {
+        
+        // TODO: move to plist
+        let symbolDictionaryOne = ["eraSymbols" : ["BC", "AD"],
+                             "monthSymbols" : ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+                             "shortMonthSymbols" : ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+                             "weekdaySymbols" : ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+                             "shortWeekdaySymbols" : ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+                             "longEraSymbols" : ["Before Christ", "Anno Domini"],
+                             "veryShortMonthSymbols" : ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"],
+                            "standaloneMonthSymbols" : ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+                            "shortStandaloneMonthSymbols" : ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+                            "veryShortStandaloneMonthSymbols" : ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"]]
+        
+        let symbolDictionaryTwo = ["veryShortWeekdaySymbols" : ["S", "M", "T", "W", "T", "F", "S"],
+                            "standaloneWeekdaySymbols" : ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+                            "shortStandaloneWeekdaySymbols" : ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+                            "veryShortStandaloneWeekdaySymbols" : ["S", "M", "T", "W", "T", "F", "S"],
+                            "quarterSymbols" : ["1st quarter", "2nd quarter", "3rd quarter", "4th quarter"],
+                            "shortQuarterSymbols" : ["Q1", "Q2", "Q3", "Q4"],
+                            "standaloneQuarterSymbols" : ["1st quarter", "2nd quarter", "3rd quarter", "4th quarter"],
+                            "shortStandaloneQuarterSymbols" : ["Q1", "Q2", "Q3", "Q4"]]
+        
         let f = NSDateFormatter()
         XCTAssertNotNil(f)
+        XCTAssertNotNil(f.timeZone)
+        XCTAssertNotNil(f.locale)
+        
+        f.timeZone = NSTimeZone(name: DEFAULT_TIMEZONE)
+        f.locale = NSLocale(localeIdentifier: DEFAULT_LOCALE)
+
+        // Assert default values are set properly
+        XCTAssertFalse(f.generatesCalendarDates)
+        XCTAssertNotNil(f.calendar)
+        XCTAssertFalse(f.lenient)
+        XCTAssertEqual(f.twoDigitStartDate!, NSDate(timeIntervalSince1970: -631152000))
+        XCTAssertNil(f.defaultDate)
+        XCTAssertEqual(f.eraSymbols, symbolDictionaryOne["eraSymbols"]!)
+        XCTAssertEqual(f.monthSymbols, symbolDictionaryOne["monthSymbols"]!)
+        XCTAssertEqual(f.shortMonthSymbols, symbolDictionaryOne["shortMonthSymbols"]!)
+        XCTAssertEqual(f.weekdaySymbols, symbolDictionaryOne["weekdaySymbols"]!)
+        XCTAssertEqual(f.shortWeekdaySymbols, symbolDictionaryOne["shortWeekdaySymbols"]!)
+        XCTAssertEqual(f.AMSymbol, "AM")
+        XCTAssertEqual(f.PMSymbol, "PM")
+        XCTAssertEqual(f.longEraSymbols, symbolDictionaryOne["longEraSymbols"]!)
+        XCTAssertEqual(f.veryShortMonthSymbols, symbolDictionaryOne["veryShortMonthSymbols"]!)
+        XCTAssertEqual(f.standaloneMonthSymbols, symbolDictionaryOne["standaloneMonthSymbols"]!)
+        XCTAssertEqual(f.shortStandaloneMonthSymbols, symbolDictionaryOne["shortStandaloneMonthSymbols"]!)
+        XCTAssertEqual(f.veryShortStandaloneMonthSymbols, symbolDictionaryOne["veryShortStandaloneMonthSymbols"]!)
+        XCTAssertEqual(f.veryShortWeekdaySymbols, symbolDictionaryTwo["veryShortWeekdaySymbols"]!)
+        XCTAssertEqual(f.standaloneWeekdaySymbols, symbolDictionaryTwo["standaloneWeekdaySymbols"]!)
+        XCTAssertEqual(f.shortStandaloneWeekdaySymbols, symbolDictionaryTwo["shortStandaloneWeekdaySymbols"]!)
+        XCTAssertEqual(f.veryShortStandaloneWeekdaySymbols, symbolDictionaryTwo["veryShortStandaloneWeekdaySymbols"]!)
+        XCTAssertEqual(f.quarterSymbols, symbolDictionaryTwo["quarterSymbols"]!)
+        XCTAssertEqual(f.shortQuarterSymbols, symbolDictionaryTwo["shortQuarterSymbols"]!)
+        XCTAssertEqual(f.standaloneQuarterSymbols, symbolDictionaryTwo["standaloneQuarterSymbols"]!)
+        XCTAssertEqual(f.shortStandaloneQuarterSymbols, symbolDictionaryTwo["shortStandaloneQuarterSymbols"]!)
+        XCTAssertEqual(f.gregorianStartDate, NSDate(timeIntervalSince1970: -12219292800))
+        XCTAssertFalse(f.doesRelativeDateFormatting)
+        
     }
     
     func test_customDateFormat() {


### PR DESCRIPTION
[SR-208](https://bugs.swift.org/browse/SR-208) should be resolved with the additions of this PR and recent commit 89556789cf1003dfa137eec9eed43ed965f3ea74 setting of dateFormat.

In this PR:
- Implemented getters and setters on remaining properties missing them
- Added tests for initial values on NSDateFormatter
- Added tests for setting custom `.dateFormat` values

Also, tests will need PR #285 to actually run.