### PR TITLE
Add implementation of NSTimeZone.init() with abbreviation

### DIFF
--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -84,7 +84,13 @@ public class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
     // do NOT follow the POSIX convention (of minutes-west).
     public convenience init(forSecondsFromGMT seconds: Int) { NSUnimplemented() }
     
-    public convenience init?(abbreviation: String) { NSUnimplemented() }
+    public convenience init?(abbreviation: String) {
+        let abbr = abbreviation._cfObject
+        guard let name = unsafeBitCast(CFDictionaryGetValue(CFTimeZoneCopyAbbreviationDictionary(), unsafeBitCast(abbr, to: UnsafePointer<Void>.self)), to: NSString!.self) else {
+            return nil
+        }
+        self.init(name: name._swiftObject , data: nil)
+    }
 
     public func encodeWithCoder(aCoder: NSCoder) {
         if aCoder.allowsKeyedCoding {

--- a/TestFoundation/TestNSTimeZone.swift
+++ b/TestFoundation/TestNSTimeZone.swift
@@ -26,6 +26,7 @@ class TestNSTimeZone: XCTestCase {
             // Disabled see https://bugs.swift.org/browse/SR-300
             // ("test_abbreviation", test_abbreviation),
             ("test_initializingTimeZoneWithOffset", test_initializingTimeZoneWithOffset),
+            ("test_initializingTimeZoneWithAbbreviation", test_initializingTimeZoneWithAbbreviation),
             // Also disabled due to https://bugs.swift.org/browse/SR-300
             // ("test_systemTimeZoneUsesSystemTime", test_systemTimeZoneUsesSystemTime),
         ]
@@ -43,6 +44,16 @@ class TestNSTimeZone: XCTestCase {
         XCTAssertNotNil(tz)
         let seconds = tz?.secondsFromGMTForDate(NSDate())
         XCTAssertEqual(seconds, -14400, "GMT-0400 should be -14400 seconds but got \(seconds) instead")
+    }
+    
+    func test_initializingTimeZoneWithAbbreviation() {
+        // Test invalid timezone abbreviation
+        var tz = NSTimeZone(abbreviation: "XXX")
+        XCTAssertNil(tz)
+        // Test valid timezone abbreviation of "AST" for "America/Halifax"
+        tz = NSTimeZone(abbreviation: "AST")
+        let expectedName = "America/Halifax"
+        XCTAssertEqual(tz?.name, expectedName, "expected name \"\(expectedName)\" is not equal to \"\(tz?.name)\"")
     }
     
     func test_systemTimeZoneUsesSystemTime() {


### PR DESCRIPTION
This adds an implementation of the following NSTimeZone.init() API:
```swift
 public convenience init?(abbreviation: String)
```
The implementation does a lookup of the abbreviation in the CFTimeZoneAbbreviationDictionary to generate a name and, if found, uses that to create a NSTimeZone instance. If no entry is found, we return nil.

I've also added two tests, one to check the negative (invalid abbreviation) case, and one to check the valid case using "AST" (the first entry in the dictionary).