### PR TITLE
Implement getter/setter for NSTimeZone abbreviationDictionary

### DIFF
--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -197,8 +197,19 @@ extension NSTimeZone {
     
     public class func knownTimeZoneNames() -> [String] { NSUnimplemented() }
     
-    public class func abbreviationDictionary() -> [String : String] { NSUnimplemented() }
-    public class func setAbbreviationDictionary(dict: [String : String]) { NSUnimplemented() }
+    public class func abbreviationDictionary() -> [String : String] {
+        let dictionary = CFTimeZoneCopyAbbreviationDictionary()._nsObject
+        var abbreviations = [String : String]()
+        for (key, value) in dictionary {
+            abbreviations[(key as! CFString)._swiftObject] = (value as! CFString)._swiftObject
+        }
+        return abbreviations
+    }
+    
+    public class func setAbbreviationDictionary(dict: [String : String]) {
+        let dictionary: CFDictionary = dict._cfObject
+        CFTimeZoneSetAbbreviationDictionary(dictionary)
+    }
     
     public class func timeZoneDataVersion() -> String { NSUnimplemented() }
     

--- a/TestFoundation/TestNSTimeZone.swift
+++ b/TestFoundation/TestNSTimeZone.swift
@@ -25,6 +25,8 @@ class TestNSTimeZone: XCTestCase {
         return [
             // Disabled see https://bugs.swift.org/browse/SR-300
             // ("test_abbreviation", test_abbreviation),
+            ("test_abbreviationDictionary", test_abbreviationDictionary),
+            ("test_setAbbreviationDictionary", test_setAbbreviationDictionary),
             ("test_initializingTimeZoneWithOffset", test_initializingTimeZoneWithOffset),
             // Also disabled due to https://bugs.swift.org/browse/SR-300
             // ("test_systemTimeZoneUsesSystemTime", test_systemTimeZoneUsesSystemTime),
@@ -43,6 +45,23 @@ class TestNSTimeZone: XCTestCase {
         XCTAssertNotNil(tz)
         let seconds = tz?.secondsFromGMTForDate(NSDate())
         XCTAssertEqual(seconds, -14400, "GMT-0400 should be -14400 seconds but got \(seconds) instead")
+    }
+    
+    func test_abbreviationDictionary() {
+        let dict = NSTimeZone.abbreviationDictionary()
+        let abbr = "AST"
+        let expectedEntry = "America/Halifax"
+        XCTAssertEqual(dict[abbr], expectedEntry,"\(abbr) should match to \(expectedEntry) but got \(dict[abbr]) instead")
+    }
+    
+    func test_setAbbreviationDictionary() {
+        let abbr = "NEW"
+        let expectedEntry = "Test TimeZone"
+        var defaultDict = NSTimeZone.abbreviationDictionary()
+        defaultDict[abbr] = expectedEntry
+        NSTimeZone.setAbbreviationDictionary(defaultDict)
+        let dict = NSTimeZone.abbreviationDictionary()
+        XCTAssertEqual(dict[abbr], expectedEntry,"\(abbr) should match to \(expectedEntry) but got \(dict[abbr]) instead")
     }
     
     func test_systemTimeZoneUsesSystemTime() {


### PR DESCRIPTION
This adds an implementation of the following two APIs in NSTimeZone:

``` swift
public class func abbreviationDictionary() -> [String : String] {}
public class func setAbbreviationDictionary(dict: [String : String]) {}
```

The implementation just reaches down and reflects what's in the underlying CFTimeZone abbreviation dictionary.

I've also added tests for both APIs into TestNSTimeZone, and verified that the behaviour matches Swift 2 on Mac.
