### PR TITLE
[SR-999] Add dot to NSString.stringByAppendingPathExtension() result

### DIFF
--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -305,9 +305,8 @@ public extension NSString {
         if fixedSelf.length <= 1 {
             return fixedSelf
         }
-        
-        if let extensionPos = fixedSelf._startOfPathExtension {
-            return String(fixedSelf.characters.prefix(upTo: extensionPos))
+        if let extensionPos = (fixedSelf._startOfPathExtension) {
+            return String(fixedSelf.characters.prefix(upTo: extensionPos.predecessor()))
         } else {
             return fixedSelf
         }
@@ -318,7 +317,7 @@ public extension NSString {
             print("Cannot append extension \(str) to path \(self)")
             return nil
         }
-        let result = _swiftObject + str._stringByFixingSlashes(compress: false, stripTrailing: true)
+        let result = _swiftObject._stringByFixingSlashes(compress: false, stripTrailing: true) + "." + str
         return result._stringByFixingSlashes()
     }
 

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -81,6 +81,8 @@ class TestNSString : XCTestCase {
             ("test_stringByExpandingTildeInPath", test_stringByExpandingTildeInPath),
             ("test_stringByStandardizingPath", test_stringByStandardizingPath),
             ("test_stringByRemovingPercentEncoding", test_stringByRemovingPercentEncoding),
+            ("test_stringByAppendingPathExtension", test_stringByAppendingPathExtension),
+            ("test_stringByDeletingPathExtension", test_stringByDeletingPathExtension),
             ("test_ExternalRepresentation", test_ExternalRepresentation),
             ("test_mutableStringConstructor", test_mutableStringConstructor),
             ("test_PrefixSuffix", test_PrefixSuffix),
@@ -834,6 +836,36 @@ class TestNSString : XCTestCase {
         XCTAssertEqual(s1, "a b")
         let s2 = "a%1 b".stringByRemovingPercentEncoding
         XCTAssertNil(s2, "returns nil for a string with an invalid percent encoding")
+    }
+    
+    func test_stringByAppendingPathExtension() {
+        let values : Dictionary = [
+            NSString(string: "/tmp/scratch.old") : "/tmp/scratch.old.tiff",
+            NSString(string: "/tmp/scratch.") : "/tmp/scratch..tiff",
+            NSString(string: "/tmp/") : "/tmp.tiff",
+            NSString(string: "/scratch") : "/scratch.tiff",
+            NSString(string: "/~scratch") : "/~scratch.tiff",
+            NSString(string: "scratch") : "scratch.tiff",
+        ]
+        for (fileName, expectedResult) in values {
+            let result = fileName.stringByAppendingPathExtension("tiff")
+            XCTAssertEqual(result, expectedResult, "expected \(expectedResult) for \(fileName) but got \(result)")
+        }
+    }
+    
+    func test_stringByDeletingPathExtension() {
+        let values : Dictionary = [
+            NSString(string: "/tmp/scratch.tiff") : "/tmp/scratch",
+            NSString(string: "/tmp/") : "/tmp",
+            NSString(string: "scratch.bundle") : "scratch",
+            NSString(string: "scratch..tiff") : "scratch.",
+            NSString(string: ".tiff") : ".tiff",
+            NSString(string: "/") : "/",
+        ]
+        for (fileName, expectedResult) in values {
+            let result = fileName.stringByDeletingPathExtension
+            XCTAssertEqual(result, expectedResult, "expected \(expectedResult) for \(fileName) but got \(result)")
+        }
     }
     
     func test_ExternalRepresentation() {


### PR DESCRIPTION
This is for [SR-999](https://bugs.swift.org/browse/SR-999) which reports that `stringByAppendingPathExtension()` and `stringByDeletingPathExtension()` are failing to add/remove the 'dot' before the extension.

I've implemented tests that match the examples given in the API spec, along with an additional test including a tilda, and the modified the relevant functions in `NSPathUtilities`.