### PR TITLE
[SR-789] Remove localization of NSNumber.description

### DIFF
--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -458,8 +458,15 @@ public class NSNumber : NSValue {
     }
 
     public func descriptionWithLocale(locale: AnyObject?) -> String {
-        guard let aLocale = locale else { return description }
-        let formatter = CFNumberFormatterCreate(nil, (aLocale as! NSLocale)._cfObject, kCFNumberFormatterDecimalStyle)
+        let aLocale = locale
+        let formatter: CFNumberFormatter
+        if (aLocale == nil) {
+            formatter = CFNumberFormatterCreate(nil, CFLocaleCopyCurrent(), kCFNumberFormatterNoStyle)
+            CFNumberFormatterSetProperty(formatter, kCFNumberFormatterMaxFractionDigits, 15._bridgeToObject())
+
+        } else {
+            formatter = CFNumberFormatterCreate(nil, (aLocale as! NSLocale)._cfObject, kCFNumberFormatterDecimalStyle)
+        }
         return CFNumberFormatterCreateStringWithNumber(nil, formatter, self._cfObject)._swiftObject
     }
     
@@ -468,11 +475,13 @@ public class NSNumber : NSValue {
     }
     
     public override var description: String {
-        let locale = CFLocaleCopyCurrent()
-        let formatter = CFNumberFormatterCreate(nil, locale, kCFNumberFormatterDecimalStyle)
-        CFNumberFormatterSetProperty(formatter, kCFNumberFormatterMaxFractionDigits, 15._bridgeToObject())
-        return CFNumberFormatterCreateStringWithNumber(nil, formatter, self._cfObject)._swiftObject
+        return descriptionWithLocale(nil)
     }
+//        let locale = CFLocaleCopyCurrent()
+//        let formatter = CFNumberFormatterCreate(nil, locale, kCFNumberFormatterNoStyle)
+//        CFNumberFormatterSetProperty(formatter, kCFNumberFormatterMaxFractionDigits, 15._bridgeToObject())
+//        return CFNumberFormatterCreateStringWithNumber(nil, formatter, self._cfObject)._swiftObject
+//    }
 }
 
 extension CFNumber : _NSBridgable {

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -33,6 +33,8 @@ class TestNSNumber : XCTestCase {
             ("test_compareNumberWithFloat", test_compareNumberWithFloat ),
             ("test_compareNumberWithDouble", test_compareNumberWithDouble ),
             ("test_reflection", test_reflection ),
+            ("test_description", test_description ),
+            ("test_descriptionWithLocale", test_descriptionWithLocale ),
         ]
     }
     
@@ -417,5 +419,23 @@ class TestNSNumber : XCTestCase {
            case .double(let value): XCTAssertEqual(value, 1.25)
            default: XCTAssert(false, "NSNumber(double:) quicklook is not a Double")
        }
+    }
+    
+    func test_description() {
+        let nsnumber: NSNumber = 1000
+        let expectedDesc = "1000"
+        XCTAssertEqual(nsnumber.description, expectedDesc, "expected \(expectedDesc) but received \(nsnumber.description)")
+    }
+    
+    func test_descriptionWithLocale() {
+        let nsnumber: NSNumber = 1000
+        let values : Dictionary = [
+            NSLocale.init(localeIdentifier: "en_GB") : "1,000",
+            NSLocale.init(localeIdentifier: "de_DE") : "1.000",
+        ]
+        for (locale, expectedDesc) in values {
+            let receivedDesc = nsnumber.descriptionWithLocale(locale)
+            XCTAssertEqual(receivedDesc, expectedDesc, "expected \(expectedDesc) but received \(receivedDesc)")
+        }
     }
 }


### PR DESCRIPTION
This is for [SR-789](https://bugs.swift.org/browse/SR-789) which reports that `NSNumber.description` is providing a localised string whereas it didn't do so previously.

In order to be behaviour compatible I've made a slight modification to the existing implementation to use a number formatter style of `kCFNumberFormatterNoStyle` rather than `kCFNumberFormatterDecimalStyle`.

At the same time I've done some refactoring to improve the delegation between `description` and `descriptionWithLocale()` as suggested in PR #277 and added tests for both `description` and `descriptionWithLocale()`