### PR TITLE
Implement basic initializers of NSAttributedString

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0B6439E01CA192FC0019CB56 /* TestNSAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B6439DF1CA192FC0019CB56 /* TestNSAttributedString.swift */; };
 		2EBE67A51C77BF0E006583D5 /* TestNSDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EBE67A31C77BF05006583D5 /* TestNSDateFormatter.swift */; };
 		528776141BF2629700CB0090 /* FoundationErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522C253A1BF16E1600804FC6 /* FoundationErrors.swift */; };
 		528776191BF27D9500CB0090 /* Test.plist in Resources */ = {isa = PBXBuildFile; fileRef = 528776181BF27D9500CB0090 /* Test.plist */; };
@@ -381,6 +382,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0B6439DF1CA192FC0019CB56 /* TestNSAttributedString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSAttributedString.swift; sourceTree = "<group>"; };
 		22B9C1E01C165D7A00DECFF9 /* TestNSDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSDate.swift; sourceTree = "<group>"; };
 		2EBE67A31C77BF05006583D5 /* TestNSDateFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSDateFormatter.swift; sourceTree = "<group>"; };
 		400E22641C1A4E58007C5933 /* TestNSProcessInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSProcessInfo.swift; sourceTree = "<group>"; };
@@ -1156,6 +1158,7 @@
 			children = (
 				C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */,
 				EA66F63C1BF1619600136161 /* TestNSArray.swift */,
+				0B6439DF1CA192FC0019CB56 /* TestNSAttributedString.swift */,
 				6E203B8C1C1303BB003B2576 /* TestNSBundle.swift */,
 				52829AD61C160D64003BC4EF /* TestNSCalendar.swift */,
 				5BC1D8BC1BF3ADFE009D3973 /* TestNSCharacterSet.swift */,
@@ -1978,6 +1981,7 @@
 				5B13B3521C582D4C00651CE2 /* TestNSValue.swift in Sources */,
 				5B13B3311C582D4C00651CE2 /* TestNSIndexPath.swift in Sources */,
 				5B13B3271C582D4C00651CE2 /* TestNSArray.swift in Sources */,
+				0B6439E01CA192FC0019CB56 /* TestNSAttributedString.swift in Sources */,
 				5B13B3461C582D4C00651CE2 /* TestNSTask.swift in Sources */,
 				555683BD1C1250E70041D4C6 /* TestNSUserDefaults.swift in Sources */,
 			);

--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -7,8 +7,11 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+import CoreFoundation
 
 public class NSAttributedString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
+    
+    internal var _cfObject: CFAttributedString!
     
     public required init?(coder aDecoder: NSCoder) {
         NSUnimplemented()
@@ -38,10 +41,16 @@ public class NSAttributedString : NSObject, NSCopying, NSMutableCopying, NSSecur
         NSUnimplemented()
     }
     
-    public var string: String { NSUnimplemented() }
+    public var string: String {
+        return CFAttributedStringGetString(_cfObject)._swiftObject
+    }
+    
     public func attributesAtIndex(_ location: Int, effectiveRange range: NSRangePointer) -> [String : AnyObject] { NSUnimplemented() }
 
-    public var length: Int { NSUnimplemented() }
+    public var length: Int {
+        return CFAttributedStringGetLength(_cfObject)
+    }
+    
     public func attribute(_ attrName: String, atIndex location: Int, effectiveRange range: NSRangePointer) -> AnyObject? { NSUnimplemented() }
     public func attributedSubstringFromRange(_ range: NSRange) -> NSAttributedString { NSUnimplemented() }
     
@@ -50,9 +59,20 @@ public class NSAttributedString : NSObject, NSCopying, NSMutableCopying, NSSecur
     
     public func isEqualToAttributedString(_ other: NSAttributedString) -> Bool { NSUnimplemented() }
     
-    public init(string str: String) { NSUnimplemented() }
-    public init(string str: String, attributes attrs: [String : AnyObject]?) { NSUnimplemented() }
-    public init(attributedString attrStr: NSAttributedString) { NSUnimplemented() }
+    public init(string str: String) {
+        super.init()
+        _cfObject = CFAttributedStringCreate(kCFAllocatorDefault, str._cfObject, nil)
+    }
+    
+    public init(string str: String, attributes attrs: [String : AnyObject]?) {
+        super.init()
+        _cfObject = CFAttributedStringCreate(kCFAllocatorDefault, str._cfObject, attrs?._cfObject)
+    }
+    
+    public init(attributedString attrStr: NSAttributedString) {
+        super.init()
+        _cfObject = CFAttributedStringCreateCopy(kCFAllocatorDefault, attrStr._cfObject)
+    }
     
     public func enumerateAttributesInRange(_ enumerationRange: NSRange, options opts: NSAttributedStringEnumerationOptions, usingBlock block: ([String : AnyObject], NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) { NSUnimplemented() }
     public func enumerateAttribute(_ attrName: String, inRange enumerationRange: NSRange, options opts: NSAttributedStringEnumerationOptions, usingBlock block: (AnyObject?, NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) { NSUnimplemented() }

--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -11,7 +11,11 @@ import CoreFoundation
 
 public class NSAttributedString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     
-    internal var _cfObject: CFAttributedString!
+    private var _cfAttributedString: CFAttributedString!
+    
+    internal init(cfObject: CFAttributedString) {
+        _cfAttributedString = cfObject
+    }
     
     public required init?(coder aDecoder: NSCoder) {
         NSUnimplemented()
@@ -42,13 +46,13 @@ public class NSAttributedString : NSObject, NSCopying, NSMutableCopying, NSSecur
     }
     
     public var string: String {
-        return CFAttributedStringGetString(_cfObject)._swiftObject
+        return CFAttributedStringGetString(_cfAttributedString)._swiftObject
     }
     
     public func attributesAtIndex(_ location: Int, effectiveRange range: NSRangePointer) -> [String : AnyObject] { NSUnimplemented() }
 
     public var length: Int {
-        return CFAttributedStringGetLength(_cfObject)
+        return CFAttributedStringGetLength(_cfAttributedString)
     }
     
     public func attribute(_ attrName: String, atIndex location: Int, effectiveRange range: NSRangePointer) -> AnyObject? { NSUnimplemented() }
@@ -61,17 +65,17 @@ public class NSAttributedString : NSObject, NSCopying, NSMutableCopying, NSSecur
     
     public init(string str: String) {
         super.init()
-        _cfObject = CFAttributedStringCreate(kCFAllocatorDefault, str._cfObject, nil)
+        _cfAttributedString = CFAttributedStringCreate(kCFAllocatorDefault, str._cfObject, nil)
     }
     
     public init(string str: String, attributes attrs: [String : AnyObject]?) {
         super.init()
-        _cfObject = CFAttributedStringCreate(kCFAllocatorDefault, str._cfObject, attrs?._cfObject)
+        _cfAttributedString = CFAttributedStringCreate(kCFAllocatorDefault, str._cfObject, attrs?._cfObject)
     }
     
     public init(attributedString attrStr: NSAttributedString) {
         super.init()
-        _cfObject = CFAttributedStringCreateCopy(kCFAllocatorDefault, attrStr._cfObject)
+        _cfAttributedString = CFAttributedStringCreateCopy(kCFAllocatorDefault, attrStr._cfAttributedString)
     }
     
     public func enumerateAttributesInRange(_ enumerationRange: NSRange, options opts: NSAttributedStringEnumerationOptions, usingBlock block: ([String : AnyObject], NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) { NSUnimplemented() }

--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -11,7 +11,7 @@ import CoreFoundation
 
 public class NSAttributedString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     
-    private var _cfAttributedString: CFAttributedString!
+    private var _cfAttributedString: CFAttributedString
     
     internal init(cfObject: CFAttributedString) {
         _cfAttributedString = cfObject
@@ -64,18 +64,18 @@ public class NSAttributedString : NSObject, NSCopying, NSMutableCopying, NSSecur
     public func isEqualToAttributedString(_ other: NSAttributedString) -> Bool { NSUnimplemented() }
     
     public init(string str: String) {
-        super.init()
         _cfAttributedString = CFAttributedStringCreate(kCFAllocatorDefault, str._cfObject, nil)
+        super.init()
     }
     
     public init(string str: String, attributes attrs: [String : AnyObject]?) {
-        super.init()
         _cfAttributedString = CFAttributedStringCreate(kCFAllocatorDefault, str._cfObject, attrs?._cfObject)
+        super.init()
     }
     
     public init(attributedString attrStr: NSAttributedString) {
-        super.init()
         _cfAttributedString = CFAttributedStringCreateCopy(kCFAllocatorDefault, attrStr._cfAttributedString)
+        super.init()
     }
     
     public func enumerateAttributesInRange(_ enumerationRange: NSRange, options opts: NSAttributedStringEnumerationOptions, usingBlock block: ([String : AnyObject], NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) { NSUnimplemented() }

--- a/TestFoundation/TestNSAttributedString.swift
+++ b/TestFoundation/TestNSAttributedString.swift
@@ -26,6 +26,7 @@ class TestNSAttributedString: XCTestCase {
             ("test_initWithSimpleString", test_initWithSimpleString),
             ("test_initWithComplexString", test_initWithComplexString),
             ("test_initWithSimpleStringAndAttributes", test_initWithSimpleStringAndAttributes),
+            ("test_initWithAttributedString", test_initWithAttributedString),
         ]
     }
     

--- a/TestFoundation/TestNSAttributedString.swift
+++ b/TestFoundation/TestNSAttributedString.swift
@@ -1,0 +1,66 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+
+
+class TestNSAttributedString: XCTestCase {
+    
+    static var allTests: [(String, TestNSAttributedString -> () throws -> Void)] {
+        return [
+            ("test_initWithSimpleString", test_initWithSimpleString),
+            ("test_initWithComplexString", test_initWithComplexString),
+            ("test_initWithSimpleStringAndAttributes", test_initWithSimpleStringAndAttributes),
+        ]
+    }
+    
+    func test_initWithSimpleString() {
+        let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur et sem vitae consectetur. Nam venenatis lectus a laoreet blandit."
+        let attrString = NSAttributedString(string: string)
+        XCTAssertEqual(attrString.string, string)
+        XCTAssertEqual(attrString.length, string.utf16Count)
+    }
+    
+    func test_initWithComplexString() {
+        let string = "Lorem 😀 ipsum dolor sit amet, consectetur adipiscing elit. ⌘ Phasellus consectetur et sem vitae consectetur. Nam venenatis lectus a laoreet blandit. ಠ_ರೃ"
+        let attrString = NSAttributedString(string: string)
+        XCTAssertEqual(attrString.string, string)
+        XCTAssertEqual(attrString.length, string.utf16Count)
+    }
+    
+    func test_initWithSimpleStringAndAttributes() {
+        let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur et sem vitae consectetur. Nam venenatis lectus a laoreet blandit."
+        let attributes: [String : AnyObject] = ["attribute.placeholder.key" : "attribute.placeholder.value" as NSString]
+
+        let attrString = NSAttributedString(string: string, attributes: attributes)
+        XCTAssertEqual(attrString.string, string)
+        XCTAssertEqual(attrString.length, string.utf16Count)
+        
+        // TODO: None of the attributes retrival methods is implemented, as a result attributes can't be tested yet.
+    }
+    
+    func test_initWithAttributedString() {
+        let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur et sem vitae consectetur. Nam venenatis lectus a laoreet blandit."
+        let attrString = NSAttributedString(string: string)
+        let newAttrString = NSAttributedString(attributedString: attrString)
+        
+        // FIXME: Should use `isEqualToAttributedString:` instead after it's implemented
+        XCTAssertEqual(attrString.string, newAttrString.string)
+    }
+    
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -23,6 +23,7 @@ internal func testBundle() -> NSBundle {
 XCTMain([
     testCase(TestNSAffineTransform.allTests),
     testCase(TestNSArray.allTests),
+    testCase(TestNSAttributedString.allTests),
     testCase(TestNSBundle.allTests),
     testCase(TestNSByteCountFormatter.allTests),
     testCase(TestNSCalendar.allTests),


### PR DESCRIPTION
Implemented and tested the following methods (and properties):

- `public var string: String`
- `public var length: Int`
- `public init(string str: String)`
- `public init(string str: String, attributes attrs: [String : AnyObject]?)`
- `public init(attributedString attrStr: NSAttributedString)`

The implementation is based on CFAttributedString.