### PR TITLE
Fix failure in setter for NSURLComponents.port

### DIFF
--- a/CoreFoundation/URL.subproj/CFURLComponents.c
+++ b/CoreFoundation/URL.subproj/CFURLComponents.c
@@ -655,7 +655,7 @@ CF_EXPORT Boolean _CFURLComponentsSetPort(CFURLComponentsRef components, CFNumbe
     } else {
         components->_portComponent = NULL;
     }
-    components->_passwordComponentValid = true;
+    components->_portComponentValid = true;
     __CFUnlock(&components->_lock);
     return true;
 }

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -423,6 +423,7 @@ class TestNSURLComponents : XCTestCase {
     static var allTests: [(String, TestNSURLComponents -> () throws -> Void)] {
         return [
             ("test_string", test_string),
+            ("test_port", test_portSetter),
         ]
     }
     
@@ -434,6 +435,16 @@ class TestNSURLComponents : XCTestCase {
             guard let components = NSURLComponents(string: expectedString) else { continue }
             XCTAssertEqual(components.string!, expectedString, "should be the expected string (\(components.string!) != \(expectedString))")
         }
+    }
+    
+    func test_portSetter() {
+        let urlString = "http://myhost.mydomain.com"
+        let port: NSNumber = 8080
+        let expectedString = "http://myhost.mydomain.com:8080"
+        let url = NSURLComponents(string: urlString)
+        url!.port = port
+        let receivedString = url!.string
+        XCTAssertEqual(receivedString, expectedString, "expected \(expectedString) but received \(receivedString)")
     }
 
 }


### PR DESCRIPTION
Once you've created a `NSURLComponents` object, setting the `port` value has no effect. This is caused by why looks like a copy/paste issue in `_CFURLComponentsSetPort` where the code is calling `_passwordComponentValid` rather than `_portComponentValid`

I've fixed this, and added a test for the setter. Note that the test case sets the expected string explicitly rather than concatenating the `urlString` and the `port` value. This is because of the issue that PR #296 fixes - when converting the port to a string it currently localises it into 8,080. 