### PR TITLE
Basic usage of ObjectiveCBridgeable protocol on Linux

### DIFF
--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -34,6 +34,44 @@ extension Array : _ObjectTypeBridgeable {
     }
 }
 
+extension Array : _ObjectiveCBridgeable {
+
+  public static func _isBridgedToObjectiveC() -> Bool {
+    return Swift._isBridgedToObjectiveC(Element.self)
+  }
+
+  @_semantics("convertToObjectiveC")
+  public func _bridgeToObjectiveC() -> NSArray {
+    return _bridgeToObject()
+  }
+
+  public static func _forceBridgeFromObjectiveC(
+    _ source: NSArray,
+    result: inout Array?
+  ) {
+    _forceBridgeFromObject(source, result: &result)
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ source: NSArray,
+    result: inout Array?
+  ) -> Bool {
+    return _conditionallyBridgeFromObject(source, result: &result)
+  }
+
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ source: NSArray?
+  ) -> Array {
+    // `nil` has historically been used as a stand-in for an empty
+    // array; map it to an empty array instead of failing.
+    if _slowPath(source == nil) { return Array() }
+
+    var result:Array?
+    _forceBridgeFromObject(source!, result: &result)
+    return result!
+  }
+}
+
 public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCoding {
     private let _cfinfo = _CFInfo(typeID: CFArrayGetTypeID())
     internal var _storage = [AnyObject]()

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -93,6 +93,45 @@ extension Dictionary : _ObjectTypeBridgeable {
     }
 }
 
+// Dictionary<Key, Value> is conditionally bridged to NSDictionary
+extension Dictionary : _ObjectiveCBridgeable {
+  @_semantics("convertToObjectiveC")
+  public func _bridgeToObjectiveC() -> NSDictionary {
+    return _bridgeToObject()
+  }
+
+  public static func _forceBridgeFromObjectiveC(
+    _ d: NSDictionary,
+    result: inout Dictionary?
+  ) {
+    _forceBridgeFromObject(d, result: &result)
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSDictionary,
+    result: inout Dictionary?
+  ) -> Bool {
+    return _conditionallyBridgeFromObject(x, result: &result)
+  }
+
+  public static func _isBridgedToObjectiveC() -> Bool {
+    return Swift._isBridgedToObjectiveC(Key.self) &&
+           Swift._isBridgedToObjectiveC(Value.self)
+  }
+
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ d: NSDictionary?
+  ) -> Dictionary {
+    // `nil` has historically been used as a stand-in for an empty
+    // dictionary; map it to an empty dictionary.
+    if _slowPath(d == nil) { return Dictionary() }
+
+    var result:Dictionary?
+    _forceBridgeFromObject(d!, result: &result)
+    return result!
+  }
+}
+
 public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCoding {
     private let _cfinfo = _CFInfo(typeID: CFDictionaryGetTypeID())
     internal var _storage = [NSObject: AnyObject]()

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -48,6 +48,38 @@ extension Int : _ObjectTypeBridgeable {
     }
 }
 
+extension Int : _ObjectiveCBridgeable {
+    public static func _isBridgedToObjectiveC() -> Bool {
+        return true
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(integer: self)
+    }
+
+    public static func _forceBridgeFromObjectiveC(
+        _ x: NSNumber,
+        result: inout Int?
+        ) {
+        result = x.integerValue
+    }
+
+    public static func _conditionallyBridgeFromObjectiveC(
+        _ x: NSNumber,
+        result: inout Int?
+        ) -> Bool {
+        self._forceBridgeFromObjectiveC(x, result: &result)
+        return true
+    }
+
+    public static func _unconditionallyBridgeFromObjectiveC(
+        _ source: NSNumber?
+        ) -> Int {
+        return source!.integerValue
+    }
+}
+
 extension UInt : _ObjectTypeBridgeable {
     public init(_ number: NSNumber) {
         self = number.unsignedIntegerValue
@@ -63,6 +95,38 @@ extension UInt : _ObjectTypeBridgeable {
     public static func _conditionallyBridgeFromObject(_ x: NSNumber, result: inout UInt?) -> Bool {
         _forceBridgeFromObject(x, result: &result)
         return true
+    }
+}
+
+extension UInt : _ObjectiveCBridgeable {
+    public static func _isBridgedToObjectiveC() -> Bool {
+        return true
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(unsignedInteger: self)
+    }
+
+    public static func _forceBridgeFromObjectiveC(
+        _ x: NSNumber,
+        result: inout UInt?
+        ) {
+        result = x.unsignedIntegerValue
+    }
+
+    public static func _conditionallyBridgeFromObjectiveC(
+        _ x: NSNumber,
+        result: inout UInt?
+        ) -> Bool {
+        self._forceBridgeFromObjectiveC(x, result: &result)
+        return true
+    }
+
+    public static func _unconditionallyBridgeFromObjectiveC(
+        _ source: NSNumber?
+        ) -> UInt {
+        return source!.unsignedIntegerValue
     }
 }
 
@@ -85,6 +149,38 @@ extension Float : _ObjectTypeBridgeable {
     }
 }
 
+extension Float : _ObjectiveCBridgeable {
+    public static func _isBridgedToObjectiveC() -> Bool {
+        return true
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(float: self)
+    }
+
+    public static func _forceBridgeFromObjectiveC(
+        _ x: NSNumber,
+        result: inout Float?
+        ) {
+        result = x.floatValue
+    }
+
+    public static func _conditionallyBridgeFromObjectiveC(
+        _ x: NSNumber,
+        result: inout Float?
+        ) -> Bool {
+        self._forceBridgeFromObjectiveC(x, result: &result)
+        return true
+    }
+
+    public static func _unconditionallyBridgeFromObjectiveC(
+        _ source: NSNumber?
+        ) -> Float {
+        return source!.floatValue
+    }
+}
+
 extension Double : _ObjectTypeBridgeable {
     public init(_ number: NSNumber) {
         self = number.doubleValue
@@ -104,6 +200,38 @@ extension Double : _ObjectTypeBridgeable {
     }
 }
 
+extension Double : _ObjectiveCBridgeable {
+    public static func _isBridgedToObjectiveC() -> Bool {
+        return true
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(double: self)
+    }
+
+    public static func _forceBridgeFromObjectiveC(
+        _ x: NSNumber,
+        result: inout Double?
+        ) {
+        result = x.doubleValue
+    }
+
+    public static func _conditionallyBridgeFromObjectiveC(
+        _ x: NSNumber,
+        result: inout Double?
+        ) -> Bool {
+        self._forceBridgeFromObjectiveC(x, result: &result)
+        return true
+    }
+
+    public static func _unconditionallyBridgeFromObjectiveC(
+        _ source: NSNumber?
+        ) -> Double {
+        return source!.doubleValue
+    }
+}
+
 extension Bool : _ObjectTypeBridgeable {
     public init(_ number: NSNumber) {
         self = number.boolValue
@@ -120,6 +248,38 @@ extension Bool : _ObjectTypeBridgeable {
     public static func _conditionallyBridgeFromObject(_ x: NSNumber, result: inout Bool?) -> Bool {
         _forceBridgeFromObject(x, result: &result)
         return true
+    }
+}
+
+extension Bool: _ObjectiveCBridgeable {
+    public static func _isBridgedToObjectiveC() -> Bool {
+        return true
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(bool: self)
+    }
+
+    public static func _forceBridgeFromObjectiveC(
+        _ x: NSNumber,
+        result: inout Bool?
+        ) {
+        result = x.boolValue
+    }
+
+    public static func _conditionallyBridgeFromObjectiveC(
+        _ x: NSNumber,
+        result: inout Bool?
+        ) -> Bool {
+        self._forceBridgeFromObjectiveC(x, result: &result)
+        return true
+    }
+
+    public static func _unconditionallyBridgeFromObjectiveC(
+        _ source: NSNumber?
+        ) -> Bool {
+        return source!.boolValue
     }
 }
 

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -70,6 +70,39 @@ extension Set : _ObjectTypeBridgeable {
     }
 }
 
+// Set<Element> is conditionally bridged to NSSet
+extension Set : _ObjectiveCBridgeable {
+  @_semantics("convertToObjectiveC")
+  public func _bridgeToObjectiveC() -> NSSet {
+    return _bridgeToObject()
+  }
+
+  public static func _forceBridgeFromObjectiveC(_ s: NSSet, result: inout Set?) {
+    _forceBridgeFromObject(s, result: &result)
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSSet, result: inout Set?
+  ) -> Bool {
+    return _conditionallyBridgeFromObject(x, result: &result)
+  }
+
+  public static func _unconditionallyBridgeFromObjectiveC(_ s: NSSet?) -> Set {
+    // `nil` has historically been used as a stand-in for an empty
+    // set; map it to an empty set.
+    if _slowPath(s == nil) { return Set() }
+
+    var result:Set?
+    _forceBridgeFromObject(s!, result: &result)
+    return result!
+  }
+
+  public static func _isBridgedToObjectiveC() -> Bool {
+    return Swift._isBridgedToObjectiveC(Element.self)
+  }
+}
+
+
 public class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCoding {
     private let _cfinfo = _CFInfo(typeID: CFSetGetTypeID())
     internal var _storage: Set<NSObject>

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -116,6 +116,43 @@ extension String : _ObjectTypeBridgeable {
     }
 }
 
+extension String : _ObjectiveCBridgeable {
+  public static func _isBridgedToObjectiveC() -> Bool {
+    return true
+  }
+
+  @_semantics("convertToObjectiveC")
+  public func _bridgeToObjectiveC() -> NSString {
+    return _bridgeToObject()
+  }
+
+  public static func _forceBridgeFromObjectiveC(
+    _ x: NSString,
+    result: inout String?
+  ) {
+    return _forceBridgeFromObject(x, result: &result)
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSString,
+    result: inout String?
+  ) -> Bool {
+    return _conditionallyBridgeFromObject(x, result: &result)
+  }
+
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ source: NSString?
+  ) -> String {
+    // `nil` has historically been used as a stand-in for an empty
+    // string; map it to an empty string.
+    if _slowPath(source == nil) { return String() }
+    var result:String?
+    _forceBridgeFromObject(source!, result: &result)
+    return result!
+  }
+}
+
+
 public struct NSStringCompareOptions : OptionSet {
     public let rawValue : UInt
     public init(rawValue: UInt) { self.rawValue = rawValue }


### PR DESCRIPTION
Add extensions to Bridgeable types to define
their conformance to the ObjectiveCBridgeable
protocol in terms of the existing bridging
support.  Since the compiler understands the
semantics of ObjectiveCBridgeable this allows
'as' conversions to be performed to/from various
NS types on platforms without ObjectiveC.