### PR TITLE
Update for SE-0055: Making pointer nullability explicit.

### DIFF
--- a/CoreFoundation/Base.subproj/ForFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForFoundationOnly.h
@@ -588,7 +588,7 @@ enum {
 // This is for NSNumberFormatter use only!
 CF_EXPORT void *_CFNumberFormatterGetFormatter(CFNumberFormatterRef formatter);
 
-CF_EXPORT void _CFDataInit(CFMutableDataRef memory, CFOptionFlags flags, CFIndex capacity, const uint8_t *bytes, CFIndex length, Boolean noCopy);
+CF_EXPORT void _CFDataInit(CFMutableDataRef memory, CFOptionFlags flags, CFIndex capacity, const uint8_t * _Nullable bytes, CFIndex length, Boolean noCopy);
 CF_EXPORT CFRange _CFDataFindBytes(CFDataRef data, CFDataRef dataToFind, CFRange searchRange, CFDataSearchFlags compareOptions);
 
 

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -54,7 +54,7 @@ struct _NSObjectBridge {
 struct _NSArrayBridge {
     CFIndex (*_Nonnull count)(CFTypeRef obj);
     _Nonnull CFTypeRef (*_Nonnull objectAtIndex)(CFTypeRef obj, CFIndex index);
-    void (*_Nonnull getObjects)(CFTypeRef array, CFRange range, CFTypeRef _Nonnull * _Nonnull values);
+    void (*_Nonnull getObjects)(CFTypeRef array, CFRange range, CFTypeRef _Nullable *_Nonnull values);
 };
 
 struct _NSMutableArrayBridge {
@@ -73,11 +73,11 @@ struct _NSDictionaryBridge {
     CFIndex (*countForKey)(CFTypeRef dictionary, CFTypeRef key);
     bool (*containsKey)(CFTypeRef dictionary, CFTypeRef key);
     _Nullable CFTypeRef (*_Nonnull objectForKey)(CFTypeRef dictionary, CFTypeRef key);
-    bool (*_getValueIfPresent)(CFTypeRef dictionary, CFTypeRef key, CFTypeRef _Nonnull * _Nullable value);
+    bool (*_getValueIfPresent)(CFTypeRef dictionary, CFTypeRef key, CFTypeRef _Nullable *_Nullable value);
     CFIndex (*__getValue)(CFTypeRef dictionary, CFTypeRef value, CFTypeRef key);
     bool (*containsObject)(CFTypeRef dictionary, CFTypeRef value);
     CFIndex (*countForObject)(CFTypeRef dictionary, CFTypeRef value);
-    void (*getObjects)(CFTypeRef dictionary, CFTypeRef _Nonnull * _Nonnull valuebuf, CFTypeRef _Nonnull * _Nonnull keybuf);
+    void (*getObjects)(CFTypeRef dictionary, CFTypeRef _Nullable *_Nullable valuebuf, CFTypeRef _Nullable *_Nullable keybuf);
     void (*__apply)(CFTypeRef dictionary, void (*applier)(CFTypeRef key, CFTypeRef value, void *context), void *context);
 };
 
@@ -104,7 +104,7 @@ struct _NSStringBridge {
     CFIndex (*length)(CFTypeRef str);
     UniChar (*characterAtIndex)(CFTypeRef str, CFIndex idx);
     void (*getCharacters)(CFTypeRef str, CFRange range, UniChar *buffer);
-    CFIndex (*__getBytes)(CFTypeRef str, CFStringEncoding encoding, CFRange range, uint8_t *buffer, CFIndex maxBufLen, CFIndex *usedBufLen);
+    CFIndex (*__getBytes)(CFTypeRef str, CFStringEncoding encoding, CFRange range, uint8_t *_Nullable buffer, CFIndex maxBufLen, CFIndex *_Nullable usedBufLen);
     const char *_Nullable (*_Nonnull _fastCStringContents)(CFTypeRef str);
     const UniChar *_Nullable (*_Nonnull _fastCharacterContents)(CFTypeRef str);
     bool (*_getCString)(CFTypeRef str, char *buffer, size_t len, UInt32 encoding);
@@ -123,7 +123,7 @@ struct _NSMutableStringBridge {
 
 struct _NSXMLParserBridge {
     _CFXMLInterface _Nullable (*_Nonnull currentParser)();
-    _CFXMLInterfaceParserInput _Nonnull (*_Nonnull _xmlExternalEntityWithURL)(_CFXMLInterface interface, const char *url, const char * identifier, _CFXMLInterfaceParserContext context, _CFXMLInterfaceExternalEntityLoader originalLoaderFunction);
+    _CFXMLInterfaceParserInput _Nullable (*_Nonnull _xmlExternalEntityWithURL)(_CFXMLInterface interface, const char *url, const char * identifier, _CFXMLInterfaceParserContext context, _CFXMLInterfaceExternalEntityLoader originalLoaderFunction);
     
     _CFXMLInterfaceParserContext _Nonnull (*_Nonnull getContext)(_CFXMLInterface ctx);
     
@@ -131,7 +131,7 @@ struct _NSXMLParserBridge {
     int (*isStandalone)(_CFXMLInterface ctx);
     int (*hasInternalSubset)(_CFXMLInterface ctx);
     int (*hasExternalSubset)(_CFXMLInterface ctx);
-    _CFXMLInterfaceEntity _Nonnull (*_Nonnull getEntity)(_CFXMLInterface ctx, const unsigned char *name);
+    _CFXMLInterfaceEntity _Nullable (*_Nonnull getEntity)(_CFXMLInterface ctx, const unsigned char *name);
     void (*notationDecl)(_CFXMLInterface ctx,
                          const unsigned char *name,
                          const unsigned char *publicId,
@@ -156,16 +156,16 @@ struct _NSXMLParserBridge {
     void (*endDocument)(_CFXMLInterface ctx);
     void (*startElementNs)(_CFXMLInterface ctx,
                            const unsigned char *localname,
-                           const unsigned char *prefix,
+                           const unsigned char *_Nullable prefix,
                            const unsigned char *URI,
                            int nb_namespaces,
-                           const unsigned char *_Nonnull *_Nonnull namespaces,
+                           const unsigned char *_Nullable *_Nonnull namespaces,
                            int nb_attributes,
                            int nb_defaulted,
-                           const unsigned char *_Nonnull *_Nonnull attributes);
+                           const unsigned char *_Nullable *_Nonnull attributes);
     void (*endElementNs)(_CFXMLInterface ctx,
                          const unsigned char *localname,
-                         const unsigned char *prefix,
+                         const unsigned char *_Nullable prefix,
                          const unsigned char *URI);
     void (*characters)(_CFXMLInterface ctx,
                        const unsigned char *ch,
@@ -239,7 +239,7 @@ extern CFWriteStreamRef _CFWriteStreamCreateFromFileDescriptor(CFAllocatorRef al
 extern _Nullable CFDateRef CFCalendarCopyGregorianStartDate(CFCalendarRef calendar);
 extern void CFCalendarSetGregorianStartDate(CFCalendarRef calendar, CFDateRef date);
 
-CF_PRIVATE CF_EXPORT char *_Nonnull*_Nonnull _CFEnviron(void);
+CF_PRIVATE CF_EXPORT char *_Nullable *_Nonnull _CFEnviron(void);
 
 CF_EXPORT void CFLog1(CFLogLevel lev, CFStringRef message);
 

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.h
@@ -136,7 +136,7 @@ typedef void* _CFXMLEntityPtr;
 typedef void* _CFXMLDTDPtr;
 typedef void* _CFXMLDTDNodePtr;
 
-_CFXMLNodePtr _CFXMLNewNode(_CFXMLNamespacePtr namespace, const char* name);
+_CFXMLNodePtr _CFXMLNewNode(_CFXMLNamespacePtr _Nullable namespace, const char* name);
 _CFXMLNodePtr _CFXMLCopyNode(_CFXMLNodePtr node, bool recursive);
 
 _CFXMLDocPtr _CFXMLNewDoc(const unsigned char* version);
@@ -147,7 +147,7 @@ _CFXMLNodePtr _CFXMLNewProperty(_CFXMLNodePtr _Nullable node, const unsigned cha
 _CFXMLNamespacePtr _CFXMLNewNamespace(_CFXMLNodePtr _Nullable node, const unsigned char* uri, const unsigned char* prefix);
 
 CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNodeURI(_CFXMLNodePtr node);
-void _CFXMLNodeSetURI(_CFXMLNodePtr node, const unsigned char* URI);
+void _CFXMLNodeSetURI(_CFXMLNodePtr node, const unsigned char* _Nullable URI);
 
 void _CFXMLNodeSetPrivateData(_CFXMLNodePtr node, void* data);
 void* _Nullable  _CFXMLNodeGetPrivateData(_CFXMLNodePtr node);
@@ -156,7 +156,7 @@ CFIndex _CFXMLNodeGetType(_CFXMLNodePtr node);
 const char* _CFXMLNodeGetName(_CFXMLNodePtr node);
 void _CFXMLNodeSetName(_CFXMLNodePtr node, const char* name);
 CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNodeGetContent(_CFXMLNodePtr node);
-void _CFXMLNodeSetContent(_CFXMLNodePtr node,  const unsigned char* _Nullable  content);
+void _CFXMLNodeSetContent(_CFXMLNodePtr node,  const unsigned char* _Nullable content);
 void _CFXMLUnlinkNode(_CFXMLNodePtr node);
 
 _CFXMLNodePtr _Nullable _CFXMLNodeGetFirstChild(_CFXMLNodePtr node);
@@ -179,13 +179,13 @@ void _CFXMLDocSetRootElement(_CFXMLDocPtr doc, _CFXMLNodePtr node);
 CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDocCharacterEncoding(_CFXMLDocPtr doc);
 void _CFXMLDocSetCharacterEncoding(_CFXMLDocPtr doc,  const unsigned char* _Nullable  encoding);
 CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDocVersion(_CFXMLDocPtr doc);
-void _CFXMLDocSetVersion(_CFXMLDocPtr doc, const unsigned char* version);
+void _CFXMLDocSetVersion(_CFXMLDocPtr doc, const unsigned char* _Nullable version);
 int _CFXMLDocProperties(_CFXMLDocPtr doc);
 void _CFXMLDocSetProperties(_CFXMLDocPtr doc, int newProperties);
 _CFXMLDTDPtr _Nullable _CFXMLDocDTD(_CFXMLDocPtr doc);
 void _CFXMLDocSetDTD(_CFXMLDocPtr doc, _CFXMLDTDPtr _Nullable dtd);
 
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLEncodeEntities(_CFXMLDocPtr doc, const unsigned char* string);
+CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLEncodeEntities(_CFXMLDocPtr _Nullable doc, const unsigned char* string);
 _CFXMLEntityPtr _Nullable _CFXMLGetDocEntity(_CFXMLDocPtr doc, const char* entity);
 _CFXMLEntityPtr _Nullable _CFXMLGetDTDEntity(_CFXMLDocPtr doc, const char* entity);
 _CFXMLEntityPtr _Nullable _CFXMLGetParameterEntity(_CFXMLDocPtr doc, const char* entity);
@@ -205,14 +205,14 @@ CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNodePrefix(_CFXMLNodePtr node);
 
 bool _CFXMLDocValidate(_CFXMLDocPtr doc, CFErrorRef _Nullable * error);
 
-_CFXMLDTDPtr _CFXMLNewDTD(_CFXMLDocPtr doc, const unsigned char* name, const unsigned char* publicID, const unsigned char* systemID);
+_CFXMLDTDPtr _CFXMLNewDTD(_CFXMLDocPtr _Nullable doc, const unsigned char* name, const unsigned char* publicID, const unsigned char* systemID);
 _CFXMLDTDNodePtr _Nullable _CFXMLParseDTDNode(const unsigned char* xmlString);
 _CFXMLDTDPtr _Nullable _CFXMLParseDTD(const unsigned char* URL);
 _CFXMLDTDPtr _Nullable _CFXMLParseDTDFromData(CFDataRef data, CFErrorRef _Nullable * error);
 CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDExternalID(_CFXMLDTDPtr dtd);
-void _CFXMLDTDSetExternalID(_CFXMLDTDPtr dtd, const unsigned char* externalID);
+void _CFXMLDTDSetExternalID(_CFXMLDTDPtr dtd, const unsigned char* _Nullable externalID);
 CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDSystemID(_CFXMLDTDPtr dtd);
-void _CFXMLDTDSetSystemID(_CFXMLDTDPtr dtd, const unsigned char* systemID);
+void _CFXMLDTDSetSystemID(_CFXMLDTDPtr dtd, const unsigned char* _Nullable systemID);
 
 _CFXMLDTDNodePtr _Nullable _CFXMLDTDGetElementDesc(_CFXMLDTDPtr dtd, const unsigned char* name);
 _CFXMLDTDNodePtr _Nullable _CFXMLDTDGetAttributeDesc(_CFXMLDTDPtr dtd, const unsigned char* elementName, const unsigned char* name);
@@ -220,7 +220,7 @@ _CFXMLDTDNodePtr _Nullable _CFXMLDTDGetNotationDesc(_CFXMLDTDPtr dtd, const unsi
 _CFXMLDTDNodePtr _Nullable _CFXMLDTDGetEntityDesc(_CFXMLDTDPtr dtd, const unsigned char* name);
 _CFXMLDTDNodePtr _Nullable _CFXMLDTDGetPredefinedEntity(const unsigned char* name);
 
-_CFXMLDTDNodePtr _Nullable _CFXMLDTDNewElementDesc(_CFXMLDTDPtr dtd, const unsigned char* name);
+_CFXMLDTDNodePtr _Nullable _CFXMLDTDNewElementDesc(_CFXMLDTDPtr _Nullable dtd, const unsigned char* _Nullable name);
 _CFXMLDTDNodePtr _Nullable _CFXMLDTDNewAttributeDesc(_CFXMLDTDPtr dtd, const unsigned char* name);
 
 CFIndex _CFXMLDTDElementNodeGetType(_CFXMLDTDNodePtr node);
@@ -228,9 +228,9 @@ CFIndex _CFXMLDTDEntityNodeGetType(_CFXMLDTDNodePtr node);
 CFIndex _CFXMLDTDAttributeNodeGetType(_CFXMLDTDNodePtr node);
 
 CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDNodeGetSystemID(_CFXMLDTDNodePtr node);
-void _CFXMLDTDNodeSetSystemID(_CFXMLDTDNodePtr node, const unsigned char* systemID);
+void _CFXMLDTDNodeSetSystemID(_CFXMLDTDNodePtr node, const unsigned char* _Nullable systemID);
 CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDNodeGetPublicID(_CFXMLDTDNodePtr node);
-void _CFXMLDTDNodeSetPublicID(_CFXMLDTDNodePtr node, const unsigned char* publicID);
+void _CFXMLDTDNodeSetPublicID(_CFXMLDTDNodePtr node, const unsigned char* _Nullable publicID);
 
 void _CFXMLFreeNode(_CFXMLNodePtr node);
 void _CFXMLFreeDocument(_CFXMLDocPtr doc);

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -55,7 +55,7 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
     }
     
     public convenience override init() {
-        self.init(objects: nil, count:0)
+        self.init(objects: [], count:0)
     }
     
     public required init(objects: UnsafePointer<AnyObject?>, count cnt: Int) {
@@ -359,13 +359,13 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         return NSData(bytesNoCopy: unsafeBitCast(buffer, to: UnsafeMutablePointer<Void>.self), length: count * sizeof(Int), freeWhenDone: true)
     }
     
-    public func sortedArrayUsingFunction(_ comparator: @convention(c) (AnyObject, AnyObject, UnsafeMutablePointer<Void>) -> Int, context: UnsafeMutablePointer<Void>) -> [AnyObject] {
+    public func sortedArrayUsingFunction(_ comparator: @convention(c) (AnyObject, AnyObject, UnsafeMutablePointer<Void>?) -> Int, context: UnsafeMutablePointer<Void>?) -> [AnyObject] {
         return sortedArrayWithOptions([]) { lhs, rhs in
             return NSComparisonResult(rawValue: comparator(lhs, rhs, context))!
         }
     }
     
-    public func sortedArrayUsingFunction(_ comparator: @convention(c) (AnyObject, AnyObject, UnsafeMutablePointer<Void>) -> Int, context: UnsafeMutablePointer<Void>, hint: NSData?) -> [AnyObject] {
+    public func sortedArrayUsingFunction(_ comparator: @convention(c) (AnyObject, AnyObject, UnsafeMutablePointer<Void>?) -> Int, context: UnsafeMutablePointer<Void>?, hint: NSData?) -> [AnyObject] {
         return sortedArrayWithOptions([]) { lhs, rhs in
             return NSComparisonResult(rawValue: comparator(lhs, rhs, context))!
         }
@@ -653,7 +653,7 @@ public class NSMutableArray : NSArray {
     }
     
     public init(capacity numItems: Int) {
-        super.init(objects: nil, count: 0)
+        super.init(objects: [], count: 0)
 
         if self.dynamicType === NSMutableArray.self {
             _storage.reserveCapacity(numItems)
@@ -807,7 +807,7 @@ public class NSMutableArray : NSArray {
         }
     }
 
-    public func sortUsingFunction(_ compare: @convention(c) (AnyObject, AnyObject, UnsafeMutablePointer<Void>) -> Int, context: UnsafeMutablePointer<Void>) {
+    public func sortUsingFunction(_ compare: @convention(c) (AnyObject, AnyObject, UnsafeMutablePointer<Void>?) -> Int, context: UnsafeMutablePointer<Void>?) {
         self.setArray(self.sortedArrayUsingFunction(compare, context: context))
     }
 

--- a/Foundation/NSCFArray.swift
+++ b/Foundation/NSCFArray.swift
@@ -89,7 +89,7 @@ internal func _CFSwiftArrayRemoveAllValues(_ array: AnyObject) {
     (array as! NSMutableArray).removeAllObjects()
 }
 
-internal func _CFSwiftArrayReplaceValues(_ array: AnyObject, _ range: CFRange, _ newValues: UnsafeMutablePointer<Unmanaged<AnyObject>?>, _ newCount: CFIndex) {
+internal func _CFSwiftArrayReplaceValues(_ array: AnyObject, _ range: CFRange, _ newValues: UnsafeMutablePointer<Unmanaged<AnyObject>>, _ newCount: CFIndex) {
     NSUnimplemented()
 //    (array as! NSMutableArray).replaceObjectsInRange(NSMakeRange(range.location, range.length), withObjectsFromArray: newValues.array(newCount))
 }

--- a/Foundation/NSCFDictionary.swift
+++ b/Foundation/NSCFDictionary.swift
@@ -64,11 +64,11 @@ internal final class _NSCFDictionary : NSMutableDictionary {
             let cf = dict._cfObject
             count = CFDictionaryGetCount(cf)
             
-            let keys = UnsafeMutablePointer<UnsafePointer<Void>>(allocatingCapacity: count)            
+            let keys = UnsafeMutablePointer<UnsafePointer<Void>?>(allocatingCapacity: count)            
             CFDictionaryGetKeysAndValues(cf, keys, nil)
             
             for idx in 0..<count {
-                let key = unsafeBitCast(keys.advanced(by: idx).pointee, to: NSObject.self)
+                let key = unsafeBitCast(keys.advanced(by: idx).pointee!, to: NSObject.self)
                 keyArray.append(key)
             }
             keys.deinitialize()
@@ -118,12 +118,12 @@ internal func _CFSwiftDictionaryGetValue(_ dictionary: AnyObject, key: AnyObject
     }
 }
 
-internal func _CFSwiftDictionaryGetValueIfPresent(_ dictionary: AnyObject, key: AnyObject, value: UnsafeMutablePointer<Unmanaged<AnyObject>?>) -> Bool {
+internal func _CFSwiftDictionaryGetValueIfPresent(_ dictionary: AnyObject, key: AnyObject, value: UnsafeMutablePointer<Unmanaged<AnyObject>?>?) -> Bool {
     if let val = _CFSwiftDictionaryGetValue(dictionary, key: key) {
-        value.pointee = val
+        value?.pointee = val
         return true
     } else {
-        value.pointee = nil
+        value?.pointee = nil
         return false
     }
 }
@@ -140,18 +140,14 @@ internal func _CFSwiftDictionaryContainsValue(_ dictionary: AnyObject, value: An
     NSUnimplemented()
 }
 
-internal func _CFSwiftDictionaryGetValuesAndKeys(_ dictionary: AnyObject, valuebuf: UnsafeMutablePointer<Unmanaged<AnyObject>?>, keybuf: UnsafeMutablePointer<Unmanaged<AnyObject>?>) {
+internal func _CFSwiftDictionaryGetValuesAndKeys(_ dictionary: AnyObject, valuebuf: UnsafeMutablePointer<Unmanaged<AnyObject>?>?, keybuf: UnsafeMutablePointer<Unmanaged<AnyObject>?>?) {
     var idx = 0
     if valuebuf == nil && keybuf == nil {
         return
     }
     (dictionary as! NSDictionary).enumerateKeysAndObjectsUsingBlock { key, value, _ in
-	if valuebuf != nil {
-	    valuebuf[idx] = Unmanaged<AnyObject>.passUnretained(value)
-	}
-	if keybuf != nil {
-	    keybuf[idx] = Unmanaged<AnyObject>.passUnretained(key)
-	}
+        valuebuf?[idx] = Unmanaged<AnyObject>.passUnretained(value)
+        keybuf?[idx] = Unmanaged<AnyObject>.passUnretained(key)
         idx += 1
     }
 }

--- a/Foundation/NSCFString.swift
+++ b/Foundation/NSCFString.swift
@@ -125,26 +125,24 @@ internal func _CFSwiftStringGetCharacters(_ str: AnyObject, range: CFRange, buff
     (str as! NSString).getCharacters(buffer, range: NSMakeRange(range.location, range.length))
 }
 
-internal func _CFSwiftStringGetBytes(_ str: AnyObject, encoding: CFStringEncoding, range: CFRange, buffer: UnsafeMutablePointer<UInt8>, maxBufLen: CFIndex, usedBufLen: UnsafeMutablePointer<CFIndex>) -> CFIndex {
+internal func _CFSwiftStringGetBytes(_ str: AnyObject, encoding: CFStringEncoding, range: CFRange, buffer: UnsafeMutablePointer<UInt8>?, maxBufLen: CFIndex, usedBufLen: UnsafeMutablePointer<CFIndex>?) -> CFIndex {
     switch encoding {
         // TODO: Don't treat many encodings like they are UTF8
     case CFStringEncoding(kCFStringEncodingUTF8), CFStringEncoding(kCFStringEncodingISOLatin1), CFStringEncoding(kCFStringEncodingMacRoman), CFStringEncoding(kCFStringEncodingASCII), CFStringEncoding(kCFStringEncodingNonLossyASCII):
         let encodingView = (str as! NSString)._swiftObject.utf8
         let start = encodingView.startIndex
-        if buffer != nil {
+        if let buffer = buffer {
             for idx in 0..<range.length {
                 let character = encodingView[start.advanced(by: idx + range.location)]
                 buffer.advanced(by: idx).initialize(with: character)
             }
         }
-        if usedBufLen != nil {
-            usedBufLen.pointee = range.length
-        }
+        usedBufLen?.pointee = range.length
         
     case CFStringEncoding(kCFStringEncodingUTF16):
         let encodingView = (str as! NSString)._swiftObject.utf16
         let start = encodingView.startIndex
-        if buffer != nil {
+        if let buffer = buffer {
             for idx in 0..<range.length {
                 // Since character is 2 bytes but the buffer is in term of 1 byte values, we have to split it up
                 let character = encodingView[start.advanced(by: idx + range.location)]
@@ -154,10 +152,8 @@ internal func _CFSwiftStringGetBytes(_ str: AnyObject, encoding: CFStringEncodin
                 buffer.advanced(by: (idx * 2) + 1).initialize(with: byte1)
             }
         }
-        if usedBufLen != nil {
-            // Every character was 2 bytes
-            usedBufLen.pointee = range.length * 2
-        }
+        // Every character was 2 bytes
+        usedBufLen?.pointee = range.length * 2
 
 
     default:
@@ -180,11 +176,11 @@ internal func _CFSwiftStringCreateMutableCopy(_ str: AnyObject) -> Unmanaged<Any
     return Unmanaged<AnyObject>.passRetained((str as! NSString).mutableCopyWithZone(nil))
 }
 
-internal func _CFSwiftStringFastCStringContents(_ str: AnyObject) -> UnsafePointer<Int8> {
+internal func _CFSwiftStringFastCStringContents(_ str: AnyObject) -> UnsafePointer<Int8>? {
     return (str as! NSString)._fastCStringContents
 }
 
-internal func _CFSwiftStringFastContents(_ str: AnyObject) -> UnsafePointer<UniChar> {
+internal func _CFSwiftStringFastContents(_ str: AnyObject) -> UnsafePointer<UniChar>? {
     return (str as! NSString)._fastContents
 }
 

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -96,11 +96,11 @@ public struct NSCalendarOptions : OptionSet {
 public class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     typealias CFType = CFCalendar
     private var _base = _CFInfo(typeID: CFCalendarGetTypeID())
-    private var _identifier: UnsafeMutablePointer<Void> = nil
-    private var _locale: UnsafeMutablePointer<Void> = nil
-    private var _localeID: UnsafeMutablePointer<Void> = nil
-    private var _tz: UnsafeMutablePointer<Void> = nil
-    private var _cal: UnsafeMutablePointer<Void> = nil
+    private var _identifier: UnsafeMutablePointer<Void>? = nil
+    private var _locale: UnsafeMutablePointer<Void>? = nil
+    private var _localeID: UnsafeMutablePointer<Void>? = nil
+    private var _tz: UnsafeMutablePointer<Void>? = nil
+    private var _cal: UnsafeMutablePointer<Void>? = nil
     
     internal var _cfObject: CFType {
         return unsafeBitCast(self, to: CFCalendar.self)
@@ -435,7 +435,7 @@ public class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         var at: CFAbsoluteTime = 0.0
         let res: Bool = withUnsafeMutablePointer(&at) { t in
             return vector.withUnsafeMutableBufferPointer { (vectorBuffer: inout UnsafeMutableBufferPointer<Int32>) in
-                return _CFCalendarComposeAbsoluteTimeV(_cfObject, t, compDesc, vectorBuffer.baseAddress, Int32(vector.count))
+                return _CFCalendarComposeAbsoluteTimeV(_cfObject, t, compDesc, vectorBuffer.baseAddress!, Int32(vectorBuffer.count))
             }
         }
         
@@ -519,11 +519,11 @@ public class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         var ints = [Int32](repeating: 0, count: 20)
         let res = ints.withUnsafeMutableBufferPointer { (intArrayBuffer: inout UnsafeMutableBufferPointer<Int32>) -> Bool in
             var vector: [UnsafeMutablePointer<Int32>] = (0..<20).map { idx in
-                intArrayBuffer.baseAddress.advanced(by: idx)
+                intArrayBuffer.baseAddress!.advanced(by: idx)
             }
 
             return vector.withUnsafeMutableBufferPointer { (vecBuffer: inout UnsafeMutableBufferPointer<UnsafeMutablePointer<Int32>>) in
-                return _CFCalendarDecomposeAbsoluteTimeV(_cfObject, date.timeIntervalSinceReferenceDate, compDesc, vecBuffer.baseAddress, Int32(compDesc.count - 1))
+                return _CFCalendarDecomposeAbsoluteTimeV(_cfObject, date.timeIntervalSinceReferenceDate, compDesc, vecBuffer.baseAddress!, Int32(compDesc.count - 1))
             }
         }
         if res {
@@ -539,7 +539,7 @@ public class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         
         let res: Bool = withUnsafeMutablePointer(&at) { t in
             return vector.withUnsafeMutableBufferPointer { (vectorBuffer: inout UnsafeMutableBufferPointer<Int32>) in
-                return _CFCalendarAddComponentsV(_cfObject, t, CFOptionFlags(opts.rawValue), compDesc, vectorBuffer.baseAddress, Int32(vector.count))
+                return _CFCalendarAddComponentsV(_cfObject, t, CFOptionFlags(opts.rawValue), compDesc, vectorBuffer.baseAddress!, Int32(vector.count))
             }
         }
         
@@ -555,11 +555,11 @@ public class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         var ints = [Int32](repeating: 0, count: 20)
         let res = ints.withUnsafeMutableBufferPointer { (intArrayBuffer: inout UnsafeMutableBufferPointer<Int32>) -> Bool in
             var vector: [UnsafeMutablePointer<Int32>] = (0..<20).map { idx in
-                return intArrayBuffer.baseAddress.advanced(by: idx)
+                return intArrayBuffer.baseAddress!.advanced(by: idx)
             }
 
             return vector.withUnsafeMutableBufferPointer { (vecBuffer: inout UnsafeMutableBufferPointer<UnsafeMutablePointer<Int32>>) in
-                _CFCalendarGetComponentDifferenceV(_cfObject, startingDate.timeIntervalSinceReferenceDate, resultDate.timeIntervalSinceReferenceDate, CFOptionFlags(opts.rawValue), compDesc, vecBuffer.baseAddress, Int32(vector.count))
+                _CFCalendarGetComponentDifferenceV(_cfObject, startingDate.timeIntervalSinceReferenceDate, resultDate.timeIntervalSinceReferenceDate, CFOptionFlags(opts.rawValue), compDesc, vecBuffer.baseAddress!, Int32(vector.count))
                 return false
             }
         }
@@ -573,20 +573,12 @@ public class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     This API is a convenience for getting era, year, month, and day of a given date.
     Pass NULL for a NSInteger pointer parameter if you don't care about that value.
     */
-    public func getEra(_ eraValuePointer: UnsafeMutablePointer<Int>, year yearValuePointer: UnsafeMutablePointer<Int>, month monthValuePointer: UnsafeMutablePointer<Int>, day dayValuePointer: UnsafeMutablePointer<Int>, fromDate date: NSDate) {
+    public func getEra(_ eraValuePointer: UnsafeMutablePointer<Int>?, year yearValuePointer: UnsafeMutablePointer<Int>?, month monthValuePointer: UnsafeMutablePointer<Int>?, day dayValuePointer: UnsafeMutablePointer<Int>?, fromDate date: NSDate) {
         if let comps = components([.Era, .Year, .Month, .Day], fromDate: date) {
-            if eraValuePointer != nil {
-                eraValuePointer.pointee = comps.era
-            }
-            if yearValuePointer != nil {
-                yearValuePointer.pointee = comps.year
-            }
-            if monthValuePointer != nil {
-                monthValuePointer.pointee = comps.month
-            }
-            if dayValuePointer != nil {
-                dayValuePointer.pointee = comps.day
-            }
+            eraValuePointer?.pointee = comps.era
+            yearValuePointer?.pointee = comps.year
+            monthValuePointer?.pointee = comps.month
+            dayValuePointer?.pointee = comps.day
         }
     }
     
@@ -594,20 +586,12 @@ public class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     This API is a convenience for getting era, year for week-of-year calculations, week of year, and weekday of a given date.
     Pass NULL for a NSInteger pointer parameter if you don't care about that value.
     */
-    public func getEra(_ eraValuePointer: UnsafeMutablePointer<Int>, yearForWeekOfYear yearValuePointer: UnsafeMutablePointer<Int>, weekOfYear weekValuePointer: UnsafeMutablePointer<Int>, weekday weekdayValuePointer: UnsafeMutablePointer<Int>, fromDate date: NSDate) {
+    public func getEra(_ eraValuePointer: UnsafeMutablePointer<Int>?, yearForWeekOfYear yearValuePointer: UnsafeMutablePointer<Int>?, weekOfYear weekValuePointer: UnsafeMutablePointer<Int>?, weekday weekdayValuePointer: UnsafeMutablePointer<Int>?, fromDate date: NSDate) {
         if let comps = components([.Era, .YearForWeekOfYear, .WeekOfYear, .Weekday], fromDate: date) {
-            if eraValuePointer != nil {
-                eraValuePointer.pointee = comps.era
-            }
-            if yearValuePointer != nil {
-                yearValuePointer.pointee = comps.yearForWeekOfYear
-            }
-            if weekValuePointer != nil {
-                weekValuePointer.pointee = comps.weekOfYear
-            }
-            if weekdayValuePointer != nil {
-                weekdayValuePointer.pointee = comps.weekday
-            }
+            eraValuePointer?.pointee = comps.era
+            yearValuePointer?.pointee = comps.yearForWeekOfYear
+            weekValuePointer?.pointee = comps.weekOfYear
+            weekdayValuePointer?.pointee = comps.weekday
         }
     }
     
@@ -615,20 +599,12 @@ public class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     This API is a convenience for getting hour, minute, second, and nanoseconds of a given date.
     Pass NULL for a NSInteger pointer parameter if you don't care about that value.
     */
-    public func getHour(_ hourValuePointer: UnsafeMutablePointer<Int>, minute minuteValuePointer: UnsafeMutablePointer<Int>, second secondValuePointer: UnsafeMutablePointer<Int>, nanosecond nanosecondValuePointer: UnsafeMutablePointer<Int>, fromDate date: NSDate) {
+    public func getHour(_ hourValuePointer: UnsafeMutablePointer<Int>?, minute minuteValuePointer: UnsafeMutablePointer<Int>?, second secondValuePointer: UnsafeMutablePointer<Int>?, nanosecond nanosecondValuePointer: UnsafeMutablePointer<Int>?, fromDate date: NSDate) {
         if let comps = components([.Hour, .Minute, .Second, .Nanosecond], fromDate: date) {
-            if hourValuePointer != nil {
-                hourValuePointer.pointee = comps.hour
-            }
-            if minuteValuePointer != nil {
-                minuteValuePointer.pointee = comps.minute
-            }
-            if secondValuePointer != nil {
-                secondValuePointer.pointee = comps.second
-            }
-            if nanosecondValuePointer != nil {
-                nanosecondValuePointer.pointee = comps.nanosecond
-            }
+            hourValuePointer?.pointee = comps.hour
+            minuteValuePointer?.pointee = comps.minute
+            secondValuePointer?.pointee = comps.second
+            nanosecondValuePointer?.pointee = comps.nanosecond
         }
     }
     

--- a/Foundation/NSCharacterSet.swift
+++ b/Foundation/NSCharacterSet.swift
@@ -33,9 +33,9 @@ public class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
     typealias CFType = CFCharacterSet
     private var _base = _CFInfo(typeID: CFCharacterSetGetTypeID())
     private var _hashValue = CFHashCode(0)
-    private var _buffer: UnsafeMutablePointer<Void> = nil
+    private var _buffer: UnsafeMutablePointer<Void>? = nil
     private var _length = CFIndex(0)
-    private var _annex: UnsafeMutablePointer<Void> = nil
+    private var _annex: UnsafeMutablePointer<Void>? = nil
     
     internal var _cfObject: CFType {
         return unsafeBitCast(self, to: CFType.self)

--- a/Foundation/NSCoder.swift
+++ b/Foundation/NSCoder.swift
@@ -130,12 +130,15 @@ public class NSCoder : NSObject {
         encodeValueOfObjCType("[\(count)\(String(cString: type))]", at: array)
     }
     
-    public func encodeBytes(_ byteaddr: UnsafePointer<Void>, length: Int) {
+    public func encodeBytes(_ byteaddr: UnsafePointer<Void>?, length: Int) {
         var newLength = UInt32(length)
         withUnsafePointer(&newLength) { (ptr: UnsafePointer<UInt32>) -> Void in
             encodeValueOfObjCType("I", at: ptr)
         }
-        encodeArrayOfObjCType("c", count: length, at: byteaddr)
+        var empty: [Int8] = []
+        withUnsafePointer(&empty) {
+            encodeArrayOfObjCType("c", count: length, at: byteaddr ?? UnsafePointer($0))
+        }
     }
     
     public func decodeObject() -> AnyObject? {
@@ -251,7 +254,7 @@ public class NSCoder : NSObject {
         NSRequiresConcreteImplementation()
     }
     
-    public func decodeBytesForKey(_ key: String, returnedLength lengthp: UnsafeMutablePointer<Int>) -> UnsafePointer<UInt8> { // returned bytes immutable!
+    public func decodeBytesForKey(_ key: String, returnedLength lengthp: UnsafeMutablePointer<Int>?) -> UnsafePointer<UInt8>? { // returned bytes immutable!
         NSRequiresConcreteImplementation()
     }
     

--- a/Foundation/NSConcreteValue.swift
+++ b/Foundation/NSConcreteValue.swift
@@ -92,9 +92,7 @@ internal class NSConcreteValue : NSValue {
         self._typeInfo = typeInfo!
 
         self._storage = UnsafeMutablePointer<UInt8>(allocatingCapacity: self._typeInfo.size)
-        if value != nil {
-            self._storage.initializeFrom(unsafeBitCast(value, to: UnsafeMutablePointer<UInt8>.self), count: self._typeInfo.size)
-        }
+        self._storage.initializeFrom(unsafeBitCast(value, to: UnsafeMutablePointer<UInt8>.self), count: self._typeInfo.size)
     }
 
     deinit {
@@ -107,7 +105,7 @@ internal class NSConcreteValue : NSValue {
     }
     
     override var objCType : UnsafePointer<Int8> {
-        return NSString(self._typeInfo.name).UTF8String // XXX leaky
+        return NSString(self._typeInfo.name).UTF8String! // XXX leaky
     }
     
     override var classForCoder: AnyClass {
@@ -127,8 +125,9 @@ internal class NSConcreteValue : NSValue {
             }
             
             let typep = type._swiftObject
-            
-            self.init(bytes: nil, objCType: typep)
+
+            // FIXME: This will result in reading garbage memory.
+            self.init(bytes: [], objCType: typep)
             aDecoder.decodeValueOfObjCType(typep, at: self.value)
         }
     }

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -75,20 +75,21 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     private var _base = _CFInfo(typeID: CFDataGetTypeID())
     private var _length: CFIndex = 0
     private var _capacity: CFIndex = 0
-    private var _deallocator: UnsafeMutablePointer<Void> = nil // for CF only
+    private var _deallocator: UnsafeMutablePointer<Void>? = nil // for CF only
     private var _deallocHandler: _NSDataDeallocator? = _NSDataDeallocator() // for Swift
-    private var _bytes: UnsafeMutablePointer<UInt8> = nil
+    private var _bytes: UnsafeMutablePointer<UInt8>? = nil
     
     internal var _cfObject: CFType {
         if self.dynamicType === NSData.self || self.dynamicType === NSMutableData.self {
             return unsafeBitCast(self, to: CFType.self)
         } else {
-            return CFDataCreate(kCFAllocatorSystemDefault, unsafeBitCast(self.bytes, to: UnsafePointer<UInt8>.self), self.length)
+            return CFDataCreate(kCFAllocatorSystemDefault, UnsafePointer<UInt8>(self.bytes), self.length)
         }
     }
     
     public override required convenience init() {
-        self.init(bytes: nil, length: 0, copy: false, deallocator: nil)
+        let dummyPointer = unsafeBitCast(NSData.self, to: UnsafeMutablePointer<Void>.self)
+        self.init(bytes: dummyPointer, length: 0, copy: false, deallocator: nil)
     }
     
     public override var hash: Int {
@@ -104,21 +105,21 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     }
     
     deinit {
-        if _bytes != nil {
-            _deallocHandler?.handler(_bytes, _length)
+        if let allocatedBytes = _bytes {
+            _deallocHandler?.handler(allocatedBytes, _length)
         }
         if self.dynamicType === NSData.self || self.dynamicType === NSMutableData.self {
             _CFDeinit(self._cfObject)
         }
     }
     
-    internal init(bytes: UnsafeMutablePointer<Void>, length: Int, copy: Bool, deallocator: ((UnsafeMutablePointer<Void>, Int) -> Void)?) {
+    internal init(bytes: UnsafeMutablePointer<Void>?, length: Int, copy: Bool, deallocator: ((UnsafeMutablePointer<Void>, Int) -> Void)?) {
         super.init()
         let options : CFOptionFlags = (self.dynamicType == NSMutableData.self) ? __kCFMutable | __kCFGrowable : 0x0
         if copy {
             _CFDataInit(unsafeBitCast(self, to: CFMutableData.self), options, length, UnsafeMutablePointer<UInt8>(bytes), length, false)
             if let handler = deallocator {
-                handler(bytes, length)
+                handler(bytes!, length)
             }
         } else {
             if let handler = deallocator {
@@ -224,7 +225,7 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
 
 extension NSData {
     
-    public convenience init(bytes: UnsafePointer<Void>, length: Int) {
+    public convenience init(bytes: UnsafePointer<Void>?, length: Int) {
         self.init(bytes: UnsafeMutablePointer<Void>(bytes), length: length, copy: true, deallocator: nil)
     }
 
@@ -583,7 +584,7 @@ public class NSMutableData : NSData {
         self.init(bytes: nil, length: 0)
     }
     
-    internal override init(bytes: UnsafeMutablePointer<Void>, length: Int, copy: Bool, deallocator: ((UnsafeMutablePointer<Void>, Int) -> Void)?) {
+    internal override init(bytes: UnsafeMutablePointer<Void>?, length: Int, copy: Bool, deallocator: ((UnsafeMutablePointer<Void>, Int) -> Void)?) {
         super.init(bytes: bytes, length: length, copy: copy, deallocator: deallocator)
     }
     

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -57,14 +57,14 @@ extension Dictionary : _ObjectTypeBridgeable {
             let cf = x._cfObject
             let cnt = CFDictionaryGetCount(cf)
 
-            let keys = UnsafeMutablePointer<UnsafePointer<Void>>(allocatingCapacity: cnt)
-            let values = UnsafeMutablePointer<UnsafePointer<Void>>(allocatingCapacity: cnt)
+            let keys = UnsafeMutablePointer<UnsafePointer<Void>?>(allocatingCapacity: cnt)
+            let values = UnsafeMutablePointer<UnsafePointer<Void>?>(allocatingCapacity: cnt)
             
             CFDictionaryGetKeysAndValues(cf, keys, values)
             
             for idx in 0..<cnt {
-                let key = unsafeBitCast(keys.advanced(by: idx).pointee, to: AnyObject.self)
-                let value = unsafeBitCast(values.advanced(by: idx).pointee, to: AnyObject.self)
+                let key = unsafeBitCast(keys.advanced(by: idx).pointee!, to: AnyObject.self)
+                let value = unsafeBitCast(values.advanced(by: idx).pointee!, to: AnyObject.self)
                 if let k = key as? Key {
                     if let v = value as? Value {
                         dict[k] = v
@@ -122,7 +122,7 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
     }
     
     public override convenience init() {
-        self.init(objects: nil, forKeys: nil, count: 0)
+        self.init(objects: [], forKeys: [], count: 0)
     }
     
     public required init(objects: UnsafePointer<AnyObject>, forKeys keys: UnsafePointer<NSObject>, count cnt: Int) {
@@ -603,8 +603,8 @@ public class NSMutableDictionary : NSDictionary {
         self.init(capacity: 0)
     }
     
-    public init(capacity numItems: Int) {
-        super.init(objects: nil, forKeys: nil, count: 0)
+    public convenience init(capacity numItems: Int) {
+        self.init(objects: [], forKeys: [], count: 0)
     }
     
     public required init(objects: UnsafePointer<AnyObject>, forKeys keys: UnsafePointer<NSObject>, count cnt: Int) {

--- a/Foundation/NSFileHandle.swift
+++ b/Foundation/NSFileHandle.swift
@@ -30,7 +30,7 @@ public class NSFileHandle : NSObject, NSSecureCoding {
     
     public func readDataOfLength(_ length: Int) -> NSData {
         var statbuf = stat()
-        var dynamicBuffer: UnsafeMutablePointer<UInt8> = nil
+        var dynamicBuffer: UnsafeMutablePointer<UInt8>? = nil
         var total = 0
         if _closed || fstat(_fd, &statbuf) < 0 {
             fatalError("Unable to read file")
@@ -45,11 +45,11 @@ public class NSFileHandle : NSObject, NSSecureCoding {
                 // Make sure there is always at least amountToRead bytes available in the buffer.
                 if (currentAllocationSize - total) < amountToRead {
                     currentAllocationSize *= 2
-                    dynamicBuffer = UnsafeMutablePointer<UInt8>(_CFReallocf(UnsafeMutablePointer<Void>(dynamicBuffer), currentAllocationSize))
+                    dynamicBuffer = UnsafeMutablePointer<UInt8>(_CFReallocf(UnsafeMutablePointer<Void>(dynamicBuffer!), currentAllocationSize))
                     if dynamicBuffer == nil {
                         fatalError("unable to allocate backing buffer")
                     }
-                    let amtRead = read(_fd, dynamicBuffer.advanced(by: total), amountToRead)
+                    let amtRead = read(_fd, dynamicBuffer!.advanced(by: total), amountToRead)
                     if 0 > amtRead {
                         free(dynamicBuffer)
                         fatalError("read failure")
@@ -81,7 +81,7 @@ public class NSFileHandle : NSObject, NSSecureCoding {
                 }
                 
                 while remaining > 0 {
-                    let count = read(_fd, dynamicBuffer.advanced(by: total), remaining)
+                    let count = read(_fd, dynamicBuffer!.advanced(by: total), remaining)
                     if count < 0 {
                         free(dynamicBuffer)
                         fatalError("Unable to read from fd")
@@ -96,7 +96,7 @@ public class NSFileHandle : NSObject, NSSecureCoding {
         }
 
         if length == Int.max && total > 0 {
-            dynamicBuffer = UnsafeMutablePointer<UInt8>(_CFReallocf(UnsafeMutablePointer<Void>(dynamicBuffer), total))
+            dynamicBuffer = UnsafeMutablePointer<UInt8>(_CFReallocf(UnsafeMutablePointer<Void>(dynamicBuffer!), total))
         }
         
         if (0 == total) {
@@ -104,7 +104,7 @@ public class NSFileHandle : NSObject, NSSecureCoding {
         }
         
         if total > 0 {
-            return NSData(bytesNoCopy: UnsafeMutablePointer<Void>(dynamicBuffer), length: total)
+            return NSData(bytesNoCopy: UnsafeMutablePointer<Void>(dynamicBuffer!), length: total)
         }
         
         return NSData()

--- a/Foundation/NSHost.swift
+++ b/Foundation/NSHost.swift
@@ -77,24 +77,23 @@ public class NSHost : NSObject {
             hints.ai_socktype = _CF_SOCK_STREAM()
             hints.ai_flags = flags
             
-            var res0: UnsafeMutablePointer<addrinfo> = nil
-            let r = withUnsafeMutablePointers(&hints, &res0) { hintsPtr, res0Ptr in
-                return getaddrinfo(info, nil, hintsPtr, res0Ptr)
-            }
+            var res0: UnsafeMutablePointer<addrinfo>? = nil
+            let r = getaddrinfo(info, nil, &hints, &res0)
             if r != 0 {
                 return
             }
-            var res: UnsafeMutablePointer<addrinfo> = res0
+            var res: UnsafeMutablePointer<addrinfo>? = res0
             while res != nil {
-                let family = res.pointee.ai_family
+                let info = res!.pointee
+                let family = info.ai_family
                 if family != AF_INET && family != AF_INET6 {
-                    res = res.pointee.ai_next
+                    res = info.ai_next
                     continue
                 }
                 let sa_len: socklen_t = socklen_t((family == AF_INET6) ? sizeof(sockaddr_in6) : sizeof(sockaddr_in))
                 let lookupInfo = { (content: inout [String], flags: Int32) in
                     let hname = UnsafeMutablePointer<Int8>(allocatingCapacity: 1024)
-                    if (getnameinfo(res.pointee.ai_addr, sa_len, hname, 1024, nil, 0, flags) == 0) {
+                    if (getnameinfo(info.ai_addr, sa_len, hname, 1024, nil, 0, flags) == 0) {
                         content.append(String(hname))
                     }
                     hname.deinitialize()
@@ -103,7 +102,7 @@ public class NSHost : NSObject {
                 lookupInfo(&_addresses, NI_NUMERICHOST)
                 lookupInfo(&_names, NI_NAMEREQD)
                 lookupInfo(&_names, NI_NOFQDN|NI_NAMEREQD)
-                res = res.pointee.ai_next
+                res = info.ai_next
             }
             
             freeaddrinfo(res0)

--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -209,12 +209,12 @@ public class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding 
     
     /* Fills up to bufferSize indexes in the specified range into the buffer and returns the number of indexes actually placed in the buffer; also modifies the optional range passed in by pointer to be "positioned" after the last index filled into the buffer.Example: if the index set contains the indexes 0, 2, 4, ..., 98, 100, for a buffer of size 10 and the range (20, 80) the buffer would contain 20, 22, ..., 38 and the range would be modified to (40, 60).
     */
-    public func getIndexes(_ indexBuffer: UnsafeMutablePointer<Int>, maxCount bufferSize: Int, inIndexRange range: NSRangePointer) -> Int {
+    public func getIndexes(_ indexBuffer: UnsafeMutablePointer<Int>, maxCount bufferSize: Int, inIndexRange range: NSRangePointer?) -> Int {
         let minIndex : Int
         let maxIndex : Int
-        if range != nil {
-            minIndex = range.pointee.location
-            maxIndex = NSMaxRange(range.pointee) - 1
+        if let initialRange = range {
+            minIndex = initialRange.pointee.location
+            maxIndex = NSMaxRange(initialRange.pointee) - 1
         } else {
             minIndex = firstIndex
             maxIndex = lastIndex
@@ -250,10 +250,10 @@ public class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding 
                 }
             }
             
-            if counter > 0 && range != nil {
+            if counter > 0, let resultRange = range {
                 let delta = indexBuffer.advanced(by: counter - 1).pointee - minIndex + 1
-                range.pointee.location += delta
-                range.pointee.length -= delta
+                resultRange.pointee.location += delta
+                resultRange.pointee.length -= delta
             }
             return counter
         } else {

--- a/Foundation/NSKeyedCoderOldStyleArray.swift
+++ b/Foundation/NSKeyedCoderOldStyleArray.swift
@@ -11,7 +11,7 @@ import CoreFoundation
 
 internal final class _NSKeyedCoderOldStyleArray : NSObject, NSCopying, NSSecureCoding, NSCoding {
 
-    private var _addr : UnsafeMutablePointer<UInt8> = nil // free if decoding
+    private var _addr : UnsafeMutablePointer<UInt8> // free if decoding
     private var _count : Int
     private var _size : Int
     private var _type : _NSSimpleObjCType

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -752,11 +752,11 @@ public class NSKeyedUnarchiver : NSCoder {
     }
     
     // returned bytes immutable, and they go away with the unarchiver, not the containing autorelease pool
-    public override func decodeBytesForKey(_ key: String, returnedLength lengthp: UnsafeMutablePointer<Int>) -> UnsafePointer<UInt8> {
+    public override func decodeBytesForKey(_ key: String, returnedLength lengthp: UnsafeMutablePointer<Int>?) -> UnsafePointer<UInt8>? {
         let ns : NSData? = _decodeValue(forKey: key)
         
         if let value = ns {
-            lengthp.pointee = Int(value.length)
+            lengthp?.pointee = Int(value.length)
             return UnsafePointer<UInt8>(value.bytes)
         }
         
@@ -828,7 +828,7 @@ public class NSKeyedUnarchiver : NSCoder {
             break
         case .CharPtr:
             if let ns = decodeObject() as? NSString {
-                let string = ns.UTF8String // XXX leaky
+                let string = ns.UTF8String! // XXX leaky
                 unsafeBitCast(addr, to: UnsafeMutablePointer<UnsafePointer<Int8>>.self).pointee = string
             }
             break

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -13,9 +13,9 @@ import CoreFoundation
 public class NSLocale : NSObject, NSCopying, NSSecureCoding {
     typealias CFType = CFLocale
     private var _base = _CFInfo(typeID: CFLocaleGetTypeID())
-    private var _identifier: UnsafeMutablePointer<Void> = nil
-    private var _cache: UnsafeMutablePointer<Void> = nil
-    private var _prefs: UnsafeMutablePointer<Void> = nil
+    private var _identifier: UnsafeMutablePointer<Void>? = nil
+    private var _cache: UnsafeMutablePointer<Void>? = nil
+    private var _prefs: UnsafeMutablePointer<Void>? = nil
 #if os(OSX) || os(iOS)
     private var _lock = pthread_mutex_t()
 #elseif os(Linux)

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -281,18 +281,18 @@ public class NSNumber : NSValue {
     
     public required convenience init?(coder aDecoder: NSCoder) {
         if !aDecoder.allowsKeyedCoding {
-            var objCType: UnsafeMutablePointer<Int8> = nil
-            var size: Int = 0
-            NSGetSizeAndAlignment(objCType, &size, nil)
-            let buffer = malloc(size)
-            aDecoder.decodeValueOfObjCType(objCType, at: buffer)
-            withUnsafeMutablePointer(&objCType, { (ptr: UnsafeMutablePointer<UnsafeMutablePointer<Int8>>) -> Void in
+            var objCType: UnsafeMutablePointer<Int8>? = nil
+            withUnsafeMutablePointer(&objCType, { (ptr: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>) -> Void in
                 aDecoder.decodeValueOfObjCType(String(_NSSimpleObjCType.CharPtr), at: UnsafeMutablePointer<Void>(ptr))
             })
             if objCType == nil {
                 return nil
             }
-            self.init(bytes: buffer, objCType: objCType)
+            var size: Int = 0
+            NSGetSizeAndAlignment(objCType!, &size, nil)
+            let buffer = malloc(size)
+            aDecoder.decodeValueOfObjCType(objCType!, at: buffer)
+            self.init(bytes: buffer, objCType: objCType!)
             free(buffer)
         } else if aDecoder.dynamicType == NSKeyedUnarchiver.self || aDecoder.containsValueForKey("NS.number") {
             let number = aDecoder._decodePropertyListForKey("NS.number")

--- a/Foundation/NSObjCRuntime.swift
+++ b/Foundation/NSObjCRuntime.swift
@@ -116,24 +116,21 @@ internal func _NSGetSizeAndAlignment(_ type: _NSSimpleObjCType,
 }
 
 public func NSGetSizeAndAlignment(_ typePtr: UnsafePointer<Int8>,
-                                  _ sizep: UnsafeMutablePointer<Int>,
-                                  _ alignp: UnsafeMutablePointer<Int>) -> UnsafePointer<Int8> {
+                                  _ sizep: UnsafeMutablePointer<Int>?,
+                                  _ alignp: UnsafeMutablePointer<Int>?) -> UnsafePointer<Int8> {
     let type = _NSSimpleObjCType(UInt8(typePtr.pointee))!
 
     var size : Int = 0
     var align : Int = 0
     
     if !_NSGetSizeAndAlignment(type, &size, &align) {
-        return nil
+        // FIXME: This used to return nil, but the corresponding Darwin
+        // implementation is defined as returning a non-optional value.
+        fatalError("invalid type encoding")
     }
     
-    if sizep != nil {
-        sizep.pointee = size
-    }
-    
-    if alignp != nil {
-        alignp.pointee = align
-    }
+    sizep?.pointee = size
+    alignp?.pointee = align
 
     return typePtr.advanced(by: 1)
 }

--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -84,7 +84,7 @@ public class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
     }
 
     public convenience override init() {
-        self.init(objects: nil, count: 0)
+        self.init(objects: [], count: 0)
     }
 
     public init(objects: UnsafePointer<AnyObject?>, count cnt: Int) {
@@ -361,7 +361,7 @@ public class NSMutableOrderedSet : NSOrderedSet {
     }
 
     public init(capacity numItems: Int) {
-        super.init(objects: nil, count: 0)
+        super.init(objects: [], count: 0)
     }
 
     required public convenience init(arrayLiteral elements: AnyObject...) {

--- a/Foundation/NSPropertyList.swift
+++ b/Foundation/NSPropertyList.swift
@@ -64,20 +64,17 @@ public class NSPropertyListSerialization : NSObject {
     }
     
     /// - Experiment: Note that the return type of this function is different than on Darwin Foundation (Any instead of AnyObject). This is likely to change once we have a more complete story for bridging in place.
-    public class func propertyListWithData(_ data: NSData, options opt: NSPropertyListReadOptions, format: UnsafeMutablePointer<NSPropertyListFormat>) throws -> Any {
+    public class func propertyListWithData(_ data: NSData, options opt: NSPropertyListReadOptions, format: UnsafeMutablePointer<NSPropertyListFormat>?) throws -> Any {
         var fmt = kCFPropertyListBinaryFormat_v1_0
         var error: Unmanaged<CFError>? = nil
         let decoded = withUnsafeMutablePointers(&fmt, &error) { (outFmt: UnsafeMutablePointer<CFPropertyListFormat>, outErr: UnsafeMutablePointer<Unmanaged<CFError>?>) -> NSObject? in
             return unsafeBitCast(CFPropertyListCreateWithData(kCFAllocatorSystemDefault, unsafeBitCast(data, to: CFData.self), CFOptionFlags(CFIndex(opt.rawValue)), outFmt, outErr), to: NSObject.self)
         }
-        if format != nil {
 #if os(OSX) || os(iOS)
-            format.pointee = NSPropertyListFormat(rawValue: UInt(fmt.rawValue))!
+        format?.pointee = NSPropertyListFormat(rawValue: UInt(fmt.rawValue))!
 #else
-            format.pointee = NSPropertyListFormat(rawValue: UInt(fmt))!
+        format?.pointee = NSPropertyListFormat(rawValue: UInt(fmt))!
 #endif
-        }
-
         if let err = error {
             throw err.takeUnretainedValue()._nsObject
         } else {
@@ -85,19 +82,17 @@ public class NSPropertyListSerialization : NSObject {
         }
     }
     
-    internal class func propertyListWithStream(_ stream: CFReadStream, length streamLength: Int, options opt: NSPropertyListReadOptions, format: UnsafeMutablePointer <NSPropertyListFormat>) throws -> Any {
+    internal class func propertyListWithStream(_ stream: CFReadStream, length streamLength: Int, options opt: NSPropertyListReadOptions, format: UnsafeMutablePointer <NSPropertyListFormat>?) throws -> Any {
         var fmt = kCFPropertyListBinaryFormat_v1_0
         var error: Unmanaged<CFError>? = nil
         let decoded = withUnsafeMutablePointers(&fmt, &error) { (outFmt: UnsafeMutablePointer<CFPropertyListFormat>, outErr: UnsafeMutablePointer<Unmanaged<CFError>?>) -> NSObject? in
             return unsafeBitCast(CFPropertyListCreateWithStream(kCFAllocatorSystemDefault, stream, streamLength, CFOptionFlags(CFIndex(opt.rawValue)), outFmt, outErr), to: NSObject.self)
         }
-        if format != nil {
 #if os(OSX) || os(iOS)
-            format.pointee = NSPropertyListFormat(rawValue: UInt(fmt.rawValue))!
+        format?.pointee = NSPropertyListFormat(rawValue: UInt(fmt.rawValue))!
 #else
-            format.pointee = NSPropertyListFormat(rawValue: UInt(fmt))!
+        format?.pointee = NSPropertyListFormat(rawValue: UInt(fmt))!
 #endif
-        }
         if let err = error {
             throw err.takeUnretainedValue()._nsObject
         } else {

--- a/Foundation/NSRegularExpression.swift
+++ b/Foundation/NSRegularExpression.swift
@@ -118,7 +118,7 @@ internal class _NSRegularExpressionMatcher {
     }
 }
 
-internal func _NSRegularExpressionMatch(_ context: UnsafeMutablePointer<Void>, ranges: UnsafeMutablePointer<CFRange>, count: CFIndex, options: _CFRegularExpressionMatchingOptions, stop: UnsafeMutablePointer<_DarwinCompatibleBoolean>) -> Void {
+internal func _NSRegularExpressionMatch(_ context: UnsafeMutablePointer<Void>?, ranges: UnsafeMutablePointer<CFRange>?, count: CFIndex, options: _CFRegularExpressionMatchingOptions, stop: UnsafeMutablePointer<_DarwinCompatibleBoolean>) -> Void {
     let matcher = unsafeBitCast(context, to: _NSRegularExpressionMatcher.self)
     if ranges == nil {
 #if os(OSX) || os(iOS)
@@ -128,7 +128,7 @@ internal func _NSRegularExpressionMatch(_ context: UnsafeMutablePointer<Void>, r
 #endif
         matcher.block(nil, NSMatchingFlags(rawValue: opts), UnsafeMutablePointer<ObjCBool>(stop))
     } else {
-        let result = NSTextCheckingResult.regularExpressionCheckingResultWithRanges(NSRangePointer(ranges), count: count, regularExpression: matcher.regex)
+        let result = NSTextCheckingResult.regularExpressionCheckingResultWithRanges(NSRangePointer(ranges!), count: count, regularExpression: matcher.regex)
 #if os(OSX) || os(iOS)
         let flags = NSMatchingFlags(rawValue: options.rawValue)
 #else

--- a/Foundation/NSScanner.swift
+++ b/Foundation/NSScanner.swift
@@ -95,7 +95,7 @@ internal struct _NSStringBuffer {
             let range = NSMakeRange(_stringLoc, bufferLen)
             bufferLoc = 1
             buffer.withUnsafeMutableBufferPointer({ (ptr: inout UnsafeMutableBufferPointer<unichar>) -> Void in
-                self.string.getCharacters(ptr.baseAddress, range: range)
+                self.string.getCharacters(ptr.baseAddress!, range: range)
             })
             curChar = buffer[0]
         } else {
@@ -115,7 +115,7 @@ internal struct _NSStringBuffer {
             let range = NSMakeRange(_stringLoc, bufferLen)
             bufferLoc = 1
             buffer.withUnsafeMutableBufferPointer({ (ptr: inout UnsafeMutableBufferPointer<unichar>) -> Void in
-                self.string.getCharacters(ptr.baseAddress, range: range)
+                self.string.getCharacters(ptr.baseAddress!, range: range)
             })
             curChar = buffer[0]
         } else {
@@ -137,7 +137,7 @@ internal struct _NSStringBuffer {
         bufferLen = min(32, stringLen - _stringLoc);
         let range = NSMakeRange(_stringLoc, bufferLen)
         buffer.withUnsafeMutableBufferPointer({ (ptr: inout UnsafeMutableBufferPointer<unichar>) -> Void in
-            string.getCharacters(ptr.baseAddress, range: range)
+            string.getCharacters(ptr.baseAddress!, range: range)
         })
         bufferLoc = 1
         curChar = buffer[0]
@@ -166,7 +166,7 @@ internal struct _NSStringBuffer {
             _stringLoc -= bufferLen
             let range = NSMakeRange(_stringLoc, bufferLen)
             buffer.withUnsafeMutableBufferPointer({ (ptr: inout UnsafeMutableBufferPointer<unichar>) -> Void in
-                string.getCharacters(ptr.baseAddress, range: range)
+                string.getCharacters(ptr.baseAddress!, range: range)
             })
         } else {
             bufferLoc = 0

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -43,7 +43,7 @@ extension Set : _ObjectTypeBridgeable {
             let cf = x._cfObject
             let cnt = CFSetGetCount(cf)
             
-            let objs = UnsafeMutablePointer<UnsafePointer<Void>>(allocatingCapacity: cnt)
+            let objs = UnsafeMutablePointer<UnsafePointer<Void>?>(allocatingCapacity: cnt)
             
             CFSetGetValues(cf, objs)
             
@@ -102,8 +102,7 @@ public class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
     }
 
     public convenience override init() {
-        let objects: UnsafePointer<AnyObject?> = nil
-        self.init(objects: objects, count: 0)
+        self.init(objects: [], count: 0)
     }
     
     public init(objects: UnsafePointer<AnyObject?>, count cnt: Int) {
@@ -382,7 +381,7 @@ public class NSMutableSet : NSSet {
     }
     
     public required init(capacity numItems: Int) {
-        super.init(objects: nil, count: 0)
+        super.init(objects: [], count: 0)
     }
     
     public required convenience init?(coder: NSCoder) {

--- a/Foundation/NSSpecialValue.swift
+++ b/Foundation/NSSpecialValue.swift
@@ -121,7 +121,7 @@ internal class NSSpecialValue : NSValue {
     
     override var objCType : UnsafePointer<Int8> {
         let typeName = NSSpecialValue._objCTypeFromType(_value.dynamicType)
-        return typeName!.bridge().UTF8String // leaky
+        return typeName!.bridge().UTF8String! // leaky
     }
     
     override var classForCoder: AnyClass {

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -350,9 +350,9 @@ extension Unmanaged {
         return self.fromOpaque(OpaquePointer(value))
     }
     
-    internal static func fromOptionalOpaque(_ value: UnsafePointer<Void>) -> Unmanaged<Instance>? {
-        if value != nil {
-            return self.fromOpaque(OpaquePointer(value))
+    internal static func fromOptionalOpaque(_ value: UnsafePointer<Void>?) -> Unmanaged<Instance>? {
+        if let opaqueValue = value {
+            return self.fromOpaque(OpaquePointer(opaqueValue))
         } else {
             return nil
         }
@@ -360,8 +360,8 @@ extension Unmanaged {
 }
 
 extension Array {
-    internal mutating func withUnsafeMutablePointerOrAllocation<R>(_ count: Int, fastpath: UnsafeMutablePointer<Element> = nil, @noescape body: (UnsafeMutablePointer<Element>) -> R) -> R {
-        if fastpath != nil {
+    internal mutating func withUnsafeMutablePointerOrAllocation<R>(_ count: Int, fastpath: UnsafeMutablePointer<Element>? = nil, @noescape body: (UnsafeMutablePointer<Element>) -> R) -> R {
+        if let fastpath = fastpath {
             return body(fastpath)
         } else if self.count > count {
             let buffer = UnsafeMutablePointer<Element>(allocatingCapacity: count)
@@ -371,7 +371,7 @@ extension Array {
             return res
         } else {
             return withUnsafeMutableBufferPointer() { (bufferPtr: inout UnsafeMutableBufferPointer<Element>) -> R in
-                return body(bufferPtr.baseAddress)
+                return body(bufferPtr.baseAddress!)
             }
         }
     }

--- a/Foundation/NSTask.swift
+++ b/Foundation/NSTask.swift
@@ -27,7 +27,7 @@ private func WEXITSTATUS(_ status: CInt) -> CInt {
 private var managerThreadSetupOnceToken = pthread_once_t()
 // these are different sadly...
 #if os(OSX) || os(iOS)
-private var threadID: pthread_t = nil
+private var threadID: pthread_t? = nil
 #elseif os(Linux)
 private var threadID = pthread_t()
 #endif
@@ -40,24 +40,24 @@ private var managerThreadRunLoopIsRunningCondition = NSCondition()
 internal let kCFSocketDataCallBack = CFSocketCallBackType.dataCallBack.rawValue
 #endif
 
-private func emptyRunLoopCallback(_ context : UnsafeMutablePointer<Void>) -> Void {}
+private func emptyRunLoopCallback(_ context : UnsafeMutablePointer<Void>!) -> Void {}
 
 
 // Retain method for run loop source
-private func runLoopSourceRetain(_ pointer : UnsafePointer<Void>) -> UnsafePointer<Void> {
+private func runLoopSourceRetain(_ pointer : UnsafePointer<Void>!) -> UnsafePointer<Void>! {
     let ref = Unmanaged<AnyObject>.fromOpaque(OpaquePointer(pointer)).takeUnretainedValue()
     let retained = Unmanaged<AnyObject>.passRetained(ref)
     return unsafeBitCast(retained, to: UnsafePointer<Void>.self)
 }
 
 // Release method for run loop source
-private func runLoopSourceRelease(_ pointer : UnsafePointer<Void>) -> Void {
+private func runLoopSourceRelease(_ pointer : UnsafePointer<Void>!) -> Void {
     Unmanaged<AnyObject>.fromOpaque(OpaquePointer(pointer)).release()
 }
 
 // Equal method for run loop source
 
-private func runloopIsEqual(_ a : UnsafePointer<Void>, b : UnsafePointer<Void>) -> _DarwinCompatibleBoolean {
+private func runloopIsEqual(_ a : UnsafePointer<Void>!, b : UnsafePointer<Void>!) -> _DarwinCompatibleBoolean {
     
     let unmanagedrunLoopA = Unmanaged<AnyObject>.fromOpaque(OpaquePointer(a))
     guard let runLoopA = unmanagedrunLoopA.takeUnretainedValue() as? NSRunLoop else {
@@ -76,7 +76,7 @@ private func runloopIsEqual(_ a : UnsafePointer<Void>, b : UnsafePointer<Void>) 
     return true
 }
 
-@noreturn private func managerThread(_ x: UnsafeMutablePointer<Void>) -> UnsafeMutablePointer<Void> {
+@noreturn private func managerThread(_ x: UnsafeMutablePointer<Void>!) -> UnsafeMutablePointer<Void>! {
     
     managerThreadRunLoop = NSRunLoop.currentRunLoop()
     var emptySourceContext = CFRunLoopSourceContext (version: 0, info: UnsafeMutablePointer<Void>(OpaquePointer(bitPattern: Unmanaged.passUnretained(managerThreadRunLoop!))),
@@ -111,7 +111,7 @@ private func managerThreadSetup() -> Void {
 
 
 // Equal method for task in run loop source
-private func nstaskIsEqual(_ a : UnsafePointer<Void>, b : UnsafePointer<Void>) -> _DarwinCompatibleBoolean {
+private func nstaskIsEqual(_ a : UnsafePointer<Void>!, b : UnsafePointer<Void>!) -> _DarwinCompatibleBoolean {
     
     let unmanagedTaskA = Unmanaged<AnyObject>.fromOpaque(OpaquePointer(a))
     guard let taskA = unmanagedTaskA.takeUnretainedValue() as? NSTask else {
@@ -184,9 +184,9 @@ public class NSTask : NSObject {
             args.append(contentsOf: arguments)
         }
         
-        let argv : UnsafeMutablePointer<UnsafeMutablePointer<Int8>> = args.withUnsafeBufferPointer {
+        let argv : UnsafeMutablePointer<UnsafeMutablePointer<Int8>?> = args.withUnsafeBufferPointer {
             let array : UnsafeBufferPointer<String> = $0
-            let buffer = UnsafeMutablePointer<UnsafeMutablePointer<Int8>>(allocatingCapacity: array.count + 1)
+            let buffer = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>(allocatingCapacity: array.count + 1)
             buffer.initializeFrom(array.map { $0.withCString(strdup) })
             buffer[array.count] = nil
             return buffer
@@ -200,11 +200,11 @@ public class NSTask : NSObject {
             argv.deallocateCapacity(args.count + 1)
         }
         
-        let envp: UnsafeMutablePointer<UnsafeMutablePointer<Int8>>
+        let envp: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>
         
         if let env = environment {
             let nenv = env.count
-            envp = UnsafeMutablePointer<UnsafeMutablePointer<Int8>>(allocatingCapacity: 1 + nenv)
+            envp = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>(allocatingCapacity: 1 + nenv)
             envp.initializeFrom(env.map { strdup("\($0)=\($1)") })
             envp[env.count] = nil
             
@@ -250,11 +250,11 @@ public class NSTask : NSObject {
             
             if task.terminationHandler != nil {
                 #if os(OSX) || os(iOS)
-                var threadID: pthread_t = nil
+                var threadID: pthread_t? = nil
                 #elseif os(Linux)
                 var threadID = pthread_t()
                 #endif
-                pthread_create(&threadID, nil, { (context) -> UnsafeMutablePointer<Void> in
+                pthread_create(&threadID, nil, { (context) -> UnsafeMutablePointer<Void>! in
                     
                     let unmanagedTask : Unmanaged<NSTask> = Unmanaged.fromOpaque(context)
                     let task = unmanagedTask.takeRetainedValue()

--- a/Foundation/NSThread.swift
+++ b/Foundation/NSThread.swift
@@ -16,7 +16,7 @@ import Glibc
 
 import CoreFoundation
 
-private func disposeTLS(_ ctx: UnsafeMutablePointer<Void>) -> Void {
+private func disposeTLS(_ ctx: UnsafeMutablePointer<Void>!) -> Void {
     Unmanaged<AnyObject>.fromOpaque(OpaquePointer(ctx)).release()
 }
 
@@ -73,7 +73,7 @@ internal enum _NSThreadStatus {
     case Finished
 }
 
-private func NSThreadStart(_ context: UnsafeMutablePointer<Void>) -> UnsafeMutablePointer<Void> {
+private func NSThreadStart(_ context: UnsafeMutablePointer<Void>!) -> UnsafeMutablePointer<Void>! {
     let unmanaged: Unmanaged<NSThread> = Unmanaged.fromOpaque(OpaquePointer(context))
     let thread = unmanaged.takeUnretainedValue()
     NSThread._currentThread.set(thread)
@@ -155,7 +155,7 @@ public class NSThread : NSObject {
     
     internal var _main: (Void) -> Void = {}
 #if os(OSX) || os(iOS)
-    private var _thread: pthread_t = nil
+    private var _thread: pthread_t? = nil
 #elseif os(Linux)
     private var _thread = pthread_t()
 #endif
@@ -166,6 +166,7 @@ public class NSThread : NSObject {
     public var threadDictionary = [String:AnyObject]()
     
     internal init(thread: pthread_t) {
+        // Note: even on Darwin this is a non-optional pthread_t; this is only used for valid threads, which are never null pointers.
         _thread = thread
     }
     

--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -13,9 +13,9 @@ import CoreFoundation
 public class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
     typealias CFType = CFTimeZone
     private var _base = _CFInfo(typeID: CFTimeZoneGetTypeID())
-    private var _name: UnsafeMutablePointer<Void> = nil
-    private var _data: UnsafeMutablePointer<Void> = nil
-    private var _periods: UnsafeMutablePointer<Void> = nil
+    private var _name: UnsafeMutablePointer<Void>? = nil
+    private var _data: UnsafeMutablePointer<Void>? = nil
+    private var _periods: UnsafeMutablePointer<Void>? = nil
     private var _periodCnt = Int32(0)
     
     internal var _cfObject: CFType {

--- a/Foundation/NSTimer.swift
+++ b/Foundation/NSTimer.swift
@@ -10,7 +10,7 @@
 
 import CoreFoundation
 
-internal func __NSFireTimer(_ timer: CFRunLoopTimer!, info: UnsafeMutablePointer<Void>) -> Void {
+internal func __NSFireTimer(_ timer: CFRunLoopTimer!, info: UnsafeMutablePointer<Void>!) -> Void {
     let t = Unmanaged<NSTimer>.fromOpaque(info).takeUnretainedValue()
     t._fire(t)
 }

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -33,10 +33,10 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
     internal var _base = _CFInfo(typeID: CFURLGetTypeID())
     internal var _flags : UInt32 = 0
     internal var _encoding : CFStringEncoding = 0
-    internal var _string : UnsafeMutablePointer<CFString> = nil
-    internal var _baseURL : UnsafeMutablePointer<CFURL> = nil
-    internal var _extra : OpaquePointer = nil
-    internal var _resourceInfo : OpaquePointer = nil
+    internal var _string : UnsafeMutablePointer<CFString>? = nil
+    internal var _baseURL : UnsafeMutablePointer<CFURL>? = nil
+    internal var _extra : OpaquePointer? = nil
+    internal var _resourceInfo : OpaquePointer? = nil
     internal var _range1 = NSRange(location: 0, length: 0)
     internal var _range2 = NSRange(location: 0, length: 0)
     internal var _range3 = NSRange(location: 0, length: 0)
@@ -314,7 +314,7 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
         
         let passwordBuf = buf[passwordRange.location ..< passwordRange.location+passwordRange.length]
         return passwordBuf.withUnsafeBufferPointer { ptr in
-            NSString(bytes: ptr.baseAddress, length: passwordBuf.count, encoding: NSUTF8StringEncoding)?._swiftObject
+            NSString(bytes: ptr.baseAddress!, length: passwordBuf.count, encoding: NSUTF8StringEncoding)?._swiftObject
         }
     }
     
@@ -369,7 +369,10 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
             return UnsafePointer(_fsrBuffer)
         }
 
-        return nil
+        // FIXME: This used to return nil, but the corresponding Darwin
+        // implementation is marked as non-nullable.
+        fatalError("URL cannot be expressed in the filesystem representation;" +
+                   "use getFileSystemRepresentation to handle this case")
     }
     
     // Whether the scheme is file:; if [myURL isFileURL] is YES, then [myURL path] is suitable for input into NSFileManager or NSPathUtilities.

--- a/Foundation/NSUUID.swift
+++ b/Foundation/NSUUID.swift
@@ -32,11 +32,7 @@ public class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     public init(UUIDBytes bytes: UnsafePointer<UInt8>) {
-        if (bytes != nil) {
-            memcpy(unsafeBitCast(buffer, to: UnsafeMutablePointer<Void>.self), UnsafePointer<Void>(bytes), 16)
-        } else {
-            memset(unsafeBitCast(buffer, to: UnsafeMutablePointer<Void>.self), 0, 16)
-        }
+        memcpy(unsafeBitCast(buffer, to: UnsafeMutablePointer<Void>.self), UnsafePointer<Void>(bytes), 16)
     }
     
     public func getUUIDBytes(_ uuid: UnsafeMutablePointer<UInt8>) {
@@ -66,7 +62,7 @@ public class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
             var length : Int = 0
             let bytes = coder.decodeBytesForKey("NS.uuidbytes", returnedLength: &length)
             if (length == 16) {
-                self.init(UUIDBytes: bytes)
+                self.init(UUIDBytes: bytes!)
             } else {
                 self.init() // failure to decode the entire uuid_t results in a new uuid
             }

--- a/Foundation/NSXMLDTDNode.swift
+++ b/Foundation/NSXMLDTDNode.swift
@@ -54,20 +54,16 @@ public class NSXMLDTDNode : NSXMLNode {
         @abstract Returns an element, attribute, entity, or notation DTD node based on the full XML string.
     */
     public init?(XMLString string: String) {
-        let ptr = _CFXMLParseDTDNode(string)
-        if ptr == nil {
-            return nil
-        } else {
-            super.init(ptr: ptr)
-        }
+        guard let ptr = _CFXMLParseDTDNode(string) else { return nil }
+        super.init(ptr: ptr)
     } //primitive
     
     public override init(kind: NSXMLNodeKind, options: Int) {
-        var ptr: _CFXMLNodePtr = nil
+        let ptr: _CFXMLNodePtr
 
         switch kind {
         case .ElementDeclarationKind:
-            ptr = _CFXMLDTDNewElementDesc(nil, nil)
+            ptr = _CFXMLDTDNewElementDesc(nil, nil)!
 
         default:
             super.init(kind: kind, options: options)
@@ -242,8 +238,8 @@ public class NSXMLDTDNode : NSXMLNode {
                      type == _kCFXMLDTDNodeTypeEntity    ||
                      type == _kCFXMLDTDNodeTypeElement)
 
-        if _CFXMLNodeGetPrivateData(node) != nil {
-            let unmanaged = Unmanaged<NSXMLDTDNode>.fromOpaque(_CFXMLNodeGetPrivateData(node))
+        if let privateData = _CFXMLNodeGetPrivateData(node) {
+            let unmanaged = Unmanaged<NSXMLDTDNode>.fromOpaque(privateData)
             return unmanaged.takeUnretainedValue()
         }
 

--- a/Foundation/NSXMLDocument.swift
+++ b/Foundation/NSXMLDocument.swift
@@ -197,11 +197,10 @@ public class NSXMLDocument : NSXMLNode {
     */
     /*@NSCopying*/ public var DTD: NSXMLDTD? {
         get {
-            return NSXMLDTD._objectNodeForNode(_CFXMLDocDTD(_xmlDoc));
+            return NSXMLDTD._objectNodeForNode(_CFXMLDocDTD(_xmlDoc)!);
         }
         set {
-            let currDTD = _CFXMLDocDTD(_xmlDoc)
-            if currDTD != nil {
+            if let currDTD = _CFXMLDocDTD(_xmlDoc) {
                 if _CFXMLNodeGetPrivateData(currDTD) != nil {
                     let DTD = NSXMLDTD._objectNodeForNode(currDTD)
                     _CFXMLUnlinkNode(currDTD)
@@ -243,8 +242,7 @@ public class NSXMLDocument : NSXMLNode {
         @abstract The root element.
     */
     public func rootElement() -> NSXMLElement? {
-        let rootPtr = _CFXMLDocRootElement(_xmlDoc)
-        if rootPtr == nil {
+        guard let rootPtr = _CFXMLDocRootElement(_xmlDoc) else {
             return nil
         }
 
@@ -347,8 +345,8 @@ public class NSXMLDocument : NSXMLNode {
     internal override class func _objectNodeForNode(_ node: _CFXMLNodePtr) -> NSXMLDocument {
         precondition(_CFXMLNodeGetType(node) == _kCFXMLTypeDocument)
 
-        if _CFXMLNodeGetPrivateData(node) != nil {
-            let unmanaged = Unmanaged<NSXMLDocument>.fromOpaque(_CFXMLNodeGetPrivateData(node))
+        if let privateData = _CFXMLNodeGetPrivateData(node) {
+            let unmanaged = Unmanaged<NSXMLDocument>.fromOpaque(privateData)
             return unmanaged.takeUnretainedValue()
         }
 

--- a/Foundation/NSXMLParser.swift
+++ b/Foundation/NSXMLParser.swift
@@ -46,7 +46,7 @@ private func UTF8STRING(_ bytes: UnsafePointer<UInt8>) -> String? {
     return str
 }
 
-internal func _NSXMLParserCurrentParser() -> _CFXMLInterface {
+internal func _NSXMLParserCurrentParser() -> _CFXMLInterface? {
     if let parser = NSXMLParser.currentParser() {
         return parser.interface
     } else {
@@ -54,7 +54,7 @@ internal func _NSXMLParserCurrentParser() -> _CFXMLInterface {
     }
 }
 
-internal func _NSXMLParserExternalEntityWithURL(_ interface: _CFXMLInterface, urlStr: UnsafePointer<Int8>, identifier: UnsafePointer<Int8>, context: _CFXMLInterfaceParserContext, originalLoaderFunction: _CFXMLInterfaceExternalEntityLoader) -> _CFXMLInterfaceParserInput {
+internal func _NSXMLParserExternalEntityWithURL(_ interface: _CFXMLInterface, urlStr: UnsafePointer<Int8>, identifier: UnsafePointer<Int8>, context: _CFXMLInterfaceParserContext, originalLoaderFunction: _CFXMLInterfaceExternalEntityLoader) -> _CFXMLInterfaceParserInput? {
     let parser = interface.parser
     let policy = parser.externalEntityResolvingPolicy
     var a: NSURL?
@@ -126,7 +126,7 @@ internal func _NSXMLParserExternalEntityWithURL(_ interface: _CFXMLInterface, ur
 }
 
 internal func _NSXMLParserGetContext(_ ctx: _CFXMLInterface) -> _CFXMLInterfaceParserContext {
-    return ctx.parser._parserContext
+    return ctx.parser._parserContext!
 }
 
 internal func _NSXMLParserInternalSubset(_ ctx: _CFXMLInterface, name: UnsafePointer<UInt8>, ExternalID: UnsafePointer<UInt8>, SystemID: UnsafePointer<UInt8>) -> Void {
@@ -145,7 +145,7 @@ internal func _NSXMLParserHasExternalSubset(_ ctx: _CFXMLInterface) -> Int32 {
     return _CFXMLInterfaceHasExternalSubset(ctx.parser._parserContext)
 }
 
-internal func _NSXMLParserGetEntity(_ ctx: _CFXMLInterface, name: UnsafePointer<UInt8>) -> _CFXMLInterfaceEntity {
+internal func _NSXMLParserGetEntity(_ ctx: _CFXMLInterface, name: UnsafePointer<UInt8>) -> _CFXMLInterfaceEntity? {
     let parser = ctx.parser
     let context = _NSXMLParserGetContext(ctx)
     var entity = _CFXMLInterfaceGetPredefinedEntity(name)
@@ -235,13 +235,13 @@ internal func _colonSeparatedStringFromPrefixAndSuffix(_ prefix: UnsafePointer<U
     return "\(prefixString!):\(suffixString!)"
 }
 
-internal func _NSXMLParserStartElementNs(_ ctx: _CFXMLInterface, localname: UnsafePointer<UInt8>, prefix: UnsafePointer<UInt8>, URI: UnsafePointer<UInt8>, nb_namespaces: Int32, namespaces: UnsafeMutablePointer<UnsafePointer<UInt8>>, nb_attributes: Int32, nb_defaulted: Int32, attributes: UnsafeMutablePointer<UnsafePointer<UInt8>>) -> Void {
+internal func _NSXMLParserStartElementNs(_ ctx: _CFXMLInterface, localname: UnsafePointer<UInt8>, prefix: UnsafePointer<UInt8>?, URI: UnsafePointer<UInt8>, nb_namespaces: Int32, namespaces: UnsafeMutablePointer<UnsafePointer<UInt8>?>, nb_attributes: Int32, nb_defaulted: Int32, attributes: UnsafeMutablePointer<UnsafePointer<UInt8>?>) -> Void {
     let parser = ctx.parser
     let reportQNameURI = parser.shouldProcessNamespaces
     let reportNamespaces = parser.shouldReportNamespacePrefixes
-    let prefixLen = prefix == nil ? UInt(strlen(UnsafePointer<Int8>(prefix))) : 0
+    let prefixLen = prefix != nil ? UInt(strlen(UnsafePointer<Int8>(prefix!))) : 0
     let localnameString = (prefixLen == 0 || reportQNameURI) ? UTF8STRING(localname) : nil
-    let qualifiedNameString = prefixLen != 0 ? _colonSeparatedStringFromPrefixAndSuffix(prefix, UInt(prefixLen), localname, UInt(strlen(UnsafePointer<Int8>(localname)))) : localnameString
+    let qualifiedNameString = prefixLen != 0 ? _colonSeparatedStringFromPrefixAndSuffix(prefix!, UInt(prefixLen), localname, UInt(strlen(UnsafePointer<Int8>(localname)))) : localnameString
     let namespaceURIString = reportQNameURI ? UTF8STRING(URI) : nil
     
     var nsDict = [String:String]()
@@ -250,16 +250,16 @@ internal func _NSXMLParserStartElementNs(_ ctx: _CFXMLInterface, localname: Unsa
         for idx in stride(from: 0, to: Int(nb_namespaces) * 2, by: 2) {
             var namespaceNameString: String?
             var asAttrNamespaceNameString: String?
-            if namespaces[idx] != nil {
+            if let ns = namespaces[idx] {
                 if reportNamespaces {
-                    namespaceNameString = UTF8STRING(namespaces[idx])
+                    namespaceNameString = UTF8STRING(ns)
                 }
-                asAttrNamespaceNameString = _colonSeparatedStringFromPrefixAndSuffix("xmlns", 5, namespaces[idx], UInt(strlen(UnsafePointer<Int8>(namespaces[idx]))))
+                asAttrNamespaceNameString = _colonSeparatedStringFromPrefixAndSuffix("xmlns", 5, ns, UInt(strlen(UnsafePointer<Int8>(ns))))
             } else {
                 namespaceNameString = ""
                 asAttrNamespaceNameString = "xmlns"
             }
-            let namespaceValueString = namespaces[idx + 1] == nil ? UTF8STRING(namespaces[idx + 1]) : ""
+            let namespaceValueString = namespaces[idx + 1] != nil ? UTF8STRING(namespaces[idx + 1]!) : ""
             if reportNamespaces {
                 if let k = namespaceNameString, v = namespaceValueString {
                     nsDict[k] = v
@@ -282,11 +282,11 @@ internal func _NSXMLParserStartElementNs(_ ctx: _CFXMLInterface, localname: Unsa
             continue
         }
         var attributeQName: String
-        let attrLocalName = attributes[idx]
+        let attrLocalName = attributes[idx]!
         let attrPrefix = attributes[idx + 1]
-        let attrPrefixLen = attrPrefix == nil ? strlen(UnsafePointer<Int8>(attrPrefix)) : 0
+        let attrPrefixLen = attrPrefix != nil ? strlen(UnsafePointer<Int8>(attrPrefix!)) : 0
         if attrPrefixLen != 0 {
-            attributeQName = _colonSeparatedStringFromPrefixAndSuffix(attrPrefix, UInt(attrPrefixLen), attrLocalName, UInt(strlen((UnsafePointer<Int8>(attrLocalName)))))
+            attributeQName = _colonSeparatedStringFromPrefixAndSuffix(attrPrefix!, UInt(attrPrefixLen), attrLocalName, UInt(strlen((UnsafePointer<Int8>(attrLocalName)))))
         } else {
             attributeQName = UTF8STRING(attrLocalName)!
         }
@@ -295,13 +295,13 @@ internal func _NSXMLParserStartElementNs(_ ctx: _CFXMLInterface, localname: Unsa
         // By using XML_PARSE_NOENT the attribute value string will already have entities resolved
         var attributeValue = ""
         if attributes[idx + 3] != nil && attributes[idx + 4] != nil {
-            let numBytesWithoutTerminator = attributes[idx + 4] - attributes[idx + 3]
+            let numBytesWithoutTerminator = attributes[idx + 4]! - attributes[idx + 3]!
             let numBytesWithTerminator = numBytesWithoutTerminator + 1
             if numBytesWithoutTerminator != 0 {
                 var chars = [Int8](repeating: 0, count: numBytesWithTerminator)
                 attributeValue = chars.withUnsafeMutableBufferPointer({ (buffer: inout UnsafeMutableBufferPointer<Int8>) -> String in
-                    strncpy(buffer.baseAddress, UnsafePointer<Int8>(attributes[idx + 3]), numBytesWithoutTerminator) //not strlcpy because attributes[i+3] is not Nul terminated
-                    return UTF8STRING(UnsafePointer<UInt8>(buffer.baseAddress))!
+                    strncpy(buffer.baseAddress!, UnsafePointer<Int8>(attributes[idx + 3]!), numBytesWithoutTerminator) //not strlcpy because attributes[i+3] is not Nul terminated
+                    return UTF8STRING(UnsafePointer<UInt8>(buffer.baseAddress!))!
                 })
             }
             attrDict[attributeQName] = attributeValue
@@ -318,13 +318,13 @@ internal func _NSXMLParserStartElementNs(_ ctx: _CFXMLInterface, localname: Unsa
     }
 }
 
-internal func _NSXMLParserEndElementNs(_ ctx: _CFXMLInterface , localname: UnsafePointer<UInt8>, prefix: UnsafePointer<UInt8>, URI: UnsafePointer<UInt8>) -> Void {
+internal func _NSXMLParserEndElementNs(_ ctx: _CFXMLInterface , localname: UnsafePointer<UInt8>, prefix: UnsafePointer<UInt8>?, URI: UnsafePointer<UInt8>) -> Void {
     let parser = ctx.parser
     let reportQNameURI = parser.shouldProcessNamespaces
-    let prefixLen = prefix == nil ? strlen(UnsafePointer<Int8>(prefix)) : 0
+    let prefixLen = prefix != nil ? strlen(UnsafePointer<Int8>(prefix!)) : 0
     let localnameString = (prefixLen == 0 || reportQNameURI) ? UTF8STRING(localname) : nil
     let nilStr: String? = nil
-    let qualifiedNameString = (prefixLen != 0) ? _colonSeparatedStringFromPrefixAndSuffix(prefix, UInt(prefixLen), localname, UInt(strlen(UnsafePointer<Int8>(localname)))) : nilStr
+    let qualifiedNameString = (prefixLen != 0) ? _colonSeparatedStringFromPrefixAndSuffix(prefix!, UInt(prefixLen), localname, UInt(strlen(UnsafePointer<Int8>(localname)))) : nilStr
     let namespaceURIString = reportQNameURI ? UTF8STRING(URI) : nilStr
     
     
@@ -343,7 +343,7 @@ internal func _NSXMLParserEndElementNs(_ ctx: _CFXMLInterface , localname: Unsaf
 
 internal func _NSXMLParserCharacters(_ ctx: _CFXMLInterface, ch: UnsafePointer<UInt8>, len: Int32) -> Void {
     let parser = ctx.parser
-    let context = parser._parserContext
+    let context = parser._parserContext!
     if _CFXMLInterfaceInRecursiveState(context) != 0 {
         _CFXMLInterfaceResetRecursiveState(context)
     } else {
@@ -398,7 +398,7 @@ public class NSXMLParser : NSObject {
     internal var _chunkSize = Int(4096 * 32) // a suitably large number for a decent chunk size
     internal var _haveDetectedEncoding = false
     internal var _bomChunk: NSData?
-    private var _parserContext: _CFXMLInterfaceParserContext
+    private var _parserContext: _CFXMLInterfaceParserContext?
     internal var _delegateAborted = false
     internal var _url: NSURL?
     internal var _namespaces = [[String:String]]()
@@ -509,7 +509,7 @@ public class NSXMLParser : NSObject {
                     allExistingData = data
                 }
                 
-                var handler: _CFXMLInterfaceSAXHandler = nil
+                var handler: _CFXMLInterfaceSAXHandler? = nil
                 if delegate != nil {
                     handler = _handler
                 }
@@ -587,8 +587,8 @@ public class NSXMLParser : NSObject {
     
     // called by the delegate to stop the parse. The delegate will get an error message sent to it.
     public func abortParsing() {
-        if _parserContext != nil {
-            _CFXMLInterfaceStopParser(_parserContext)
+        if let context = _parserContext {
+            _CFXMLInterfaceStopParser(context)
             _delegateAborted = true
         }
     }

--- a/Foundation/String.swift
+++ b/Foundation/String.swift
@@ -111,14 +111,12 @@ extension String {
     /// non-`nil`, convert the buffer to an `Index` and write it into the
     /// memory referred to by `index`
     func _withOptionalOutParameter<Result>(
-        _ index: UnsafeMutablePointer<Index>,
-        @noescape body: (UnsafeMutablePointer<Int>) -> Result
+        _ index: UnsafeMutablePointer<Index>?,
+        @noescape body: (UnsafeMutablePointer<Int>?) -> Result
         ) -> Result {
         var utf16Index: Int = 0
-        let result = index._withBridgeValue(&utf16Index) {
-            body($0)
-        }
-        index._setIfNonNil { self._index(utf16Index) }
+        let result = (index != nil) ? body(&utf16Index) : body(nil)
+        index?.pointee = self._index(utf16Index)
         return result
     }
     
@@ -126,14 +124,12 @@ extension String {
     /// from non-`nil`, convert the buffer to a `Range<Index>` and write
     /// it into the memory referred to by `range`
     func _withOptionalOutParameter<Result>(
-        _ range: UnsafeMutablePointer<Range<Index>>,
-        @noescape body: (UnsafeMutablePointer<NSRange>) -> Result
+        _ range: UnsafeMutablePointer<Range<Index>>?,
+        @noescape body: (UnsafeMutablePointer<NSRange>?) -> Result
         ) -> Result {
         var nsRange = NSRange(location: 0, length: 0)
-        let result = range._withBridgeValue(&nsRange) {
-            body($0)
-        }
-        range._setIfNonNil { self._range(nsRange) }
+        let result = (range != nil) ? body(&nsRange) : body(nil)
+        range?.pointee = self._range(nsRange)
         return result
     }
     
@@ -802,7 +798,7 @@ extension String {
     /// interpret the file.
     public init(
         contentsOfFile path: String,
-        usedEncoding: UnsafeMutablePointer<NSStringEncoding> = nil
+        usedEncoding: UnsafeMutablePointer<NSStringEncoding>? = nil
         ) throws {
         let ns = try NSString(contentsOfFile: path, usedEncoding: usedEncoding)
         self = ns._swiftObject
@@ -834,7 +830,7 @@ extension String {
     /// data.  Errors are written into the inout `error` argument.
     public init(
         contentsOfURL url: NSURL,
-        usedEncoding enc: UnsafeMutablePointer<NSStringEncoding> = nil
+        usedEncoding enc: UnsafeMutablePointer<NSStringEncoding>? = nil
         ) throws {
         let ns = try NSString(contentsOfURL: url, usedEncoding: enc)
         self = ns._swiftObject

--- a/TestFoundation/TestNSArray.swift
+++ b/TestFoundation/TestNSArray.swift
@@ -358,7 +358,7 @@ class TestNSArray : XCTestCase {
         let mutableInput = inputNumbers.bridge().mutableCopy() as! NSMutableArray
         let expectedNumbers = inputNumbers.sorted()
 
-        func compare(_ left: AnyObject, right:AnyObject,  context: UnsafeMutablePointer<Void>) -> Int {
+        func compare(_ left: AnyObject, right:AnyObject,  context: UnsafeMutablePointer<Void>?) -> Int {
             let l = (left as! NSNumber).integerValue
             let r = (right as! NSNumber).integerValue
             return l < r ? -1 : (l > r ? 0 : 1)

--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -129,7 +129,7 @@ class TestNSKeyedArchiver : XCTestCase {
         let array: Array<UInt64> = [12341234123, 23452345234, 23475982345, 9893563243, 13469816598]
         let objctype = "[5Q]"
         array.withUnsafeBufferPointer { cArray in
-            let concrete = NSValue(bytes: cArray.baseAddress, objCType: objctype)
+            let concrete = NSValue(bytes: cArray.baseAddress!, objCType: objctype)
             test_archive(concrete)
         }
     }
@@ -144,14 +144,14 @@ class TestNSKeyedArchiver : XCTestCase {
 
         test_archive({ archiver -> Bool in
             array.withUnsafeBufferPointer { cArray in
-                archiver.encodeValueOfObjCType("[4i]", at: cArray.baseAddress)
+                archiver.encodeValueOfObjCType("[4i]", at: cArray.baseAddress!)
             }
             return true
         },
         decode: {unarchiver -> Bool in
             var expected: Array<Int32> = [0, 0, 0, 0]
             expected.withUnsafeMutableBufferPointer {(p: inout UnsafeMutableBufferPointer<Int32>) in
-                unarchiver.decodeValueOfObjCType("[4i]", at: UnsafeMutablePointer<Void>(p.baseAddress))
+                unarchiver.decodeValueOfObjCType("[4i]", at: UnsafeMutablePointer<Void>(p.baseAddress!))
             }
             XCTAssertEqual(expected, array)
             return true
@@ -229,15 +229,15 @@ class TestNSKeyedArchiver : XCTestCase {
                 guard let value = unarchiver.decodeObjectOfClass(NSValue.self, forKey: "root") else {
                     return false
                 }
-                var expectedCharPtr: UnsafeMutablePointer<CChar> = nil
+                var expectedCharPtr: UnsafeMutablePointer<CChar>? = nil
                 value.getValue(&expectedCharPtr)
                 
                 let s1 = String(cString: charPtr)
-                let s2 = String(cString: expectedCharPtr)
+                let s2 = String(cString: expectedCharPtr!)
                 
                 // On Darwin decoded strings would belong to the autorelease pool, but as we don't have
                 // one in SwiftFoundation let's explicitly deallocate it here.
-                expectedCharPtr.deallocateCapacity(charArray.count)
+                expectedCharPtr!.deallocateCapacity(charArray.count)
                 
                 return s1 == s2
         })

--- a/TestFoundation/TestNSKeyedUnarchiver.swift
+++ b/TestFoundation/TestNSKeyedUnarchiver.swift
@@ -67,7 +67,7 @@ class TestNSKeyedUnarchiver : XCTestCase {
         let array: Array<Int32> = [1, 2, 3]
         let objctype = "[3i]"
         array.withUnsafeBufferPointer { cArray in
-            let concrete = NSValue(bytes: cArray.baseAddress, objCType: objctype)
+            let concrete = NSValue(bytes: cArray.baseAddress!, objCType: objctype)
             test_unarchive_from_file("NSKeyedUnarchiver-ConcreteValueTest", concrete)
         }
     }

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -743,7 +743,7 @@ class TestNSString : XCTestCase {
         let expected: [Int8] = [102, 111, 111, 0]
         var res: Bool = false
         chars.withUnsafeMutableBufferPointer() {
-            let ptr = $0.baseAddress
+            let ptr = $0.baseAddress!
             res = str.getCString(ptr, maxLength: count, encoding: NSASCIIStringEncoding)
         }
         XCTAssertTrue(res, "getCString should work on simple strings with ascii string encoding")
@@ -757,12 +757,12 @@ class TestNSString : XCTestCase {
         let count = chars.count
         var res: Bool = false
         chars.withUnsafeMutableBufferPointer() {
-            let ptr = $0.baseAddress
+            let ptr = $0.baseAddress!
             res = str.getCString(ptr, maxLength: count, encoding: NSASCIIStringEncoding)
         }
         XCTAssertFalse(res, "getCString should not work on non ascii strings accessing as ascii string encoding")
         chars.withUnsafeMutableBufferPointer() {
-            let ptr = $0.baseAddress
+            let ptr = $0.baseAddress!
             res = str.getCString(ptr, maxLength: count, encoding: NSUTF8StringEncoding)
         }
         XCTAssertTrue(res, "getCString should work on UTF8 encoding")

--- a/TestFoundation/TestNSUUID.swift
+++ b/TestFoundation/TestNSUUID.swift
@@ -23,7 +23,6 @@ class TestNSUUID : XCTestCase {
         return [
             ("test_Equality", test_Equality),
             ("test_InvalidUUID", test_InvalidUUID),
-            ("test_InitializationWithNil", test_InitializationWithNil),
             ("test_UUIDString", test_UUIDString),
             ("test_description", test_description),
             // Disabled until NSKeyedArchiver and NSKeyedUnarchiver are implemented
@@ -45,11 +44,6 @@ class TestNSUUID : XCTestCase {
     func test_InvalidUUID() {
         let uuid = NSUUID(UUIDString: "Invalid UUID")
         XCTAssertNil(uuid, "The convenience initializer `init?(UUIDString string:)` must return nil for an invalid UUID string.")
-    }
-    
-    func test_InitializationWithNil() {
-        let uuid = NSUUID(UUIDBytes: nil)
-        XCTAssertEqual(uuid, NSUUID(UUIDBytes: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]), "The convenience initializer `init(UUIDBytes bytes:)` must return the Nil UUID when UUIDBytes is nil.")
     }
     
     // `UUIDString` should return an uppercase string

--- a/TestFoundation/TestNSValue.swift
+++ b/TestFoundation/TestNSValue.swift
@@ -103,7 +103,7 @@ class TestNSValue : XCTestCase {
         let array: Array<UInt64> = [12341234123, 23452345234, 23475982345, 9893563243, 13469816598]
         array.withUnsafeBufferPointer { cArray in
             var expected = [UInt64](repeating: 0, count: 5)
-            NSValue(bytes: cArray.baseAddress, objCType: "[5Q]").getValue(&expected)
+            NSValue(bytes: cArray.baseAddress!, objCType: "[5Q]").getValue(&expected)
             XCTAssertEqual(array, expected)
         }
     }
@@ -113,7 +113,7 @@ class TestNSValue : XCTestCase {
         let objctype = "[" + String(array.count) + "s]"
         array.withUnsafeBufferPointer { cArray in
             var expected = [Int16](repeating: 0, count: array.count)
-            NSValue(bytes: cArray.baseAddress, objCType: objctype).getValue(&expected)
+            NSValue(bytes: cArray.baseAddress!, objCType: objctype).getValue(&expected)
             XCTAssertEqual(array, expected)
         }
     }
@@ -121,7 +121,7 @@ class TestNSValue : XCTestCase {
     func test_valueWithCharPtr() {
         let charArray = [UInt8]("testing123".utf8)
         var charPtr = UnsafeMutablePointer<UInt8>(charArray)
-        var expectedPtr: UnsafeMutablePointer<UInt8> = nil
+        var expectedPtr: UnsafeMutablePointer<UInt8>? = nil
         
         NSValue(bytes: &charPtr, objCType: "*").getValue(&expectedPtr)
         XCTAssertEqual(charPtr, expectedPtr)


### PR DESCRIPTION
See apple/swift#1878. Note: this needs a coordinated merge, i.e. it must go in ASAP after that request!

@phausler or someone else, would you mind reviewing? I tried to keep APIs matching the nullability audit of the Darwin Foundation, and attempted to change as little behavior as possible besides that, but there were definitely a few rough spots.