### PR TITLE
Cleanup NSURLRequest. Implement copy / mutableCopy.

### DIFF
--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -8,95 +8,76 @@
 //
 
 
-/*!
-    @header NSURLRequest.h
+// -----------------------------------------------------------------------------
+///
+/// This header file describes the constructs used to represent URL
+/// load requests in a manner independent of protocol and URL scheme.
+/// Immutable and mutable variants of this URL load request concept
+/// are described, named `NSURLRequest` and `NSMutableURLRequest`,
+/// respectively. A collection of constants is also declared to
+/// exercise control over URL content caching policy.
+///
+/// `NSURLRequest` and `NSMutableURLRequest` are designed to be
+/// customized to support protocol-specific requests. Protocol
+/// implementors who need to extend the capabilities of `NSURLRequest`
+/// and `NSMutableURLRequest` are encouraged to provide categories on
+/// these classes as appropriate to support protocol-specific data. To
+/// store and retrieve data, category methods can use the
+/// `propertyForKey(_:,inRequest:)` and
+/// `setProperty(_:,forKey:,inRequest:)` class methods on
+/// `NSURLProtocol`. See the `NSHTTPURLRequest` on `NSURLRequest` and
+/// `NSMutableHTTPURLRequest` on `NSMutableURLRequest` for examples of
+/// such extensions.
+///
+/// The main advantage of this design is that a client of the URL
+/// loading library can implement request policies in a standard way
+/// without type checking of requests or protocol checks on URLs. Any
+/// protocol-specific details that have been set on a URL request will
+/// be used if they apply to the particular URL being loaded, and will
+/// be ignored if they do not apply.
+///
+// -----------------------------------------------------------------------------
 
-    This header file describes the constructs used to represent URL
-    load requests in a manner independent of protocol and URL scheme.
-    Immutable and mutable variants of this URL load request concept
-    are described, named NSURLRequest and NSMutableURLRequest,
-    respectively. A collection of constants is also declared to
-    exercise control over URL content caching policy.
-
-    <p>NSURLRequest and NSMutableURLRequest are designed to be
-    customized to support protocol-specific requests. Protocol
-    implementors who need to extend the capabilities of NSURLRequest
-    and NSMutableURLRequest are encouraged to provide categories on
-    these classes as appropriate to support protocol-specific data. To
-    store and retrieve data, category methods can use the
-    <tt>+propertyForKey:inRequest:</tt> and
-    <tt>+setProperty:forKey:inRequest:</tt> class methods on
-    NSURLProtocol. See the NSHTTPURLRequest on NSURLRequest and
-    NSMutableHTTPURLRequest on NSMutableURLRequest for examples of
-    such extensions.
-
-    <p>The main advantage of this design is that a client of the URL
-    loading library can implement request policies in a standard way
-    without type checking of requests or protocol checks on URLs. Any
-    protocol-specific details that have been set on a URL request will
-    be used if they apply to the particular URL being loaded, and will
-    be ignored if they do not apply.
-*/
-
-/*!
-    @enum NSURLRequestCachePolicy
-
-    @discussion The NSURLRequestCachePolicy enum defines constants that
-    can be used to specify the type of interactions that take place with
-    the caching system when the URL loading system processes a request.
-    Specifically, these constants cover interactions that have to do
-    with whether already-existing cache data is returned to satisfy a
-    URL load request.
-
-    @constant NSURLRequestUseProtocolCachePolicy Specifies that the
-    caching logic defined in the protocol implementation, if any, is
-    used for a particular URL load request. This is the default policy
-    for URL load requests.
-
-    @constant NSURLRequestReloadIgnoringLocalCacheData Specifies that the
-    data for the URL load should be loaded from the origin source. No
-    existing local cache data, regardless of its freshness or validity,
-    should be used to satisfy a URL load request.
-
-    @constant NSURLRequestReloadIgnoringLocalAndRemoteCacheData Specifies that
-    not only should the local cache data be ignored, but that proxies and
-    other intermediates should be instructed to disregard their caches
-    so far as the protocol allows.  Unimplemented.
-
-    @constant NSURLRequestReloadIgnoringCacheData Older name for
-    NSURLRequestReloadIgnoringLocalCacheData.
-
-    @constant NSURLRequestReturnCacheDataElseLoad Specifies that the
-    existing cache data should be used to satisfy a URL load request,
-    regardless of its age or expiration date. However, if there is no
-    existing data in the cache corresponding to a URL load request,
-    the URL is loaded from the origin source.
-
-    @constant NSURLRequestReturnCacheDataDontLoad Specifies that the
-    existing cache data should be used to satisfy a URL load request,
-    regardless of its age or expiration date. However, if there is no
-    existing data in the cache corresponding to a URL load request, no
-    attempt is made to load the URL from the origin source, and the
-    load is considered to have failed. This constant specifies a
-    behavior that is similar to an "offline" mode.
-
-    @constant NSURLRequestReloadRevalidatingCacheData Specifies that
-    the existing cache data may be used provided the origin source
-    confirms its validity, otherwise the URL is loaded from the
-    origin source.  Unimplemented.
-*/
+/// A cache policy
+///
+/// The `NSURLRequestCachePolicy` `enum` defines constants that
+/// can be used to specify the type of interactions that take place with
+/// the caching system when the URL loading system processes a request.
+/// Specifically, these constants cover interactions that have to do
+/// with whether already-existing cache data is returned to satisfy a
+/// URL load request.
 public enum NSURLRequestCachePolicy : UInt {
-    
-    case UseProtocolCachePolicy
-    
-    case ReloadIgnoringLocalCacheData
-    case ReloadIgnoringLocalAndRemoteCacheData // Unimplemented
-    public static var ReloadIgnoringCacheData: NSURLRequestCachePolicy { return .ReloadIgnoringLocalCacheData }
-    
-    case ReturnCacheDataElseLoad
-    case ReturnCacheDataDontLoad
-    
-    case ReloadRevalidatingCacheData // Unimplemented
+    /// Specifies that the caching logic defined in the protocol
+    /// implementation, if any, is used for a particular URL load request. This
+    /// is the default policy for URL load requests.
+    case useProtocolCachePolicy
+    /// Specifies that the data for the URL load should be loaded from the
+    /// origin source. No existing local cache data, regardless of its freshness
+    /// or validity, should be used to satisfy a URL load request.
+    case reloadIgnoringLocalCacheData
+    /// Specifies that not only should the local cache data be ignored, but that
+    /// proxies and other intermediates should be instructed to disregard their
+    /// caches so far as the protocol allows.  Unimplemented.
+    case reloadIgnoringLocalAndRemoteCacheData // Unimplemented
+    /// Older name for `NSURLRequestReloadIgnoringLocalCacheData`.
+    public static var reloadIgnoringCacheData: NSURLRequestCachePolicy { return .reloadIgnoringLocalCacheData }
+    /// Specifies that the existing cache data should be used to satisfy a URL
+    /// load request, regardless of its age or expiration date. However, if
+    /// there is no existing data in the cache corresponding to a URL load
+    /// request, the URL is loaded from the origin source.
+    case returnCacheDataElseLoad
+    /// Specifies that the existing cache data should be used to satisfy a URL
+    /// load request, regardless of its age or expiration date. However, if
+    /// there is no existing data in the cache corresponding to a URL load
+    /// request, no attempt is made to load the URL from the origin source, and
+    /// the load is considered to have failed. This constant specifies a
+    /// behavior that is similar to an "offline" mode.
+    case returnCacheDataDontLoad
+    /// Specifies that the existing cache data may be used provided the origin
+    /// source confirms its validity, otherwise the URL is loaded from the
+    /// origin source.
+    /// - Note: Unimplemented.
+    case reloadRevalidatingCacheData // Unimplemented
 }
 
 /*!
@@ -124,56 +105,55 @@ public enum NSURLRequestCachePolicy : UInt {
 */
 public enum NSURLRequestNetworkServiceType : UInt {
     
-    case NetworkServiceTypeDefault // Standard internet traffic
-    case NetworkServiceTypeVoIP // Voice over IP control traffic
-    case NetworkServiceTypeVideo // Video traffic
-    case NetworkServiceTypeBackground // Background traffic
-    case NetworkServiceTypeVoice // Voice data
+    case networkServiceTypeDefault // Standard internet traffic
+    case networkServiceTypeVoIP // Voice over IP control traffic
+    case networkServiceTypeVideo // Video traffic
+    case networkServiceTypeBackground // Background traffic
+    case networkServiceTypeVoice // Voice data
 }
 
-/*!
-    @class NSURLRequest
-    
-    @abstract An NSURLRequest object represents a URL load request in a
-    manner independent of protocol and URL scheme.
-    
-    @discussion NSURLRequest encapsulates two basic data elements about
-    a URL load request:
-    <ul>
-    <li>The URL to load.
-    <li>The policy to use when consulting the URL content cache made
-    available by the implementation.
-    </ul>
-    In addition, NSURLRequest is designed to be extended to support
-    protocol-specific data by adding categories to access a property
-    object provided in an interface targeted at protocol implementors.
-    <ul>
-    <li>Protocol implementors should direct their attention to the
-    NSURLRequestExtensibility category on NSURLRequest for more
-    information on how to provide extensions on NSURLRequest to
-    support protocol-specific request information.
-    <li>Clients of this API who wish to create NSURLRequest objects to
-    load URL content should consult the protocol-specific NSURLRequest
-    categories that are available. The NSHTTPURLRequest category on
-    NSURLRequest is an example.
-    </ul>
-    <p>
-    Objects of this class are used to create NSURLConnection instances,
-    which can are used to perform the load of a URL, or as input to the
-    NSURLConnection class method which performs synchronous loads.
-*/
+/// An `NSURLRequest` object represents a URL load request in a
+/// manner independent of protocol and URL scheme.
+///
+/// `NSURLRequest` encapsulates basic data elements about a URL load request.
+///
+/// In addition, `NSURLRequest` is designed to be extended to support
+/// protocol-specific data by adding categories to access a property
+/// object provided in an interface targeted at protocol implementors.
+///
+/// Protocol implementors should direct their attention to the
+/// `NSURLRequestExtensibility` category on `NSURLRequest` for more
+/// information on how to provide extensions on `NSURLRequest` to
+/// support protocol-specific request information.
+///
+/// Clients of this API who wish to create `NSURLRequest` objects to
+/// load URL content should consult the protocol-specific `NSURLRequest`
+/// categories that are available. The `NSHTTPURLRequest` category on
+/// `NSURLRequest` is an example.
+///
+/// Objects of this class are used with the `NSURLSession` API to perform the
+/// load of a URL.
 public class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopying {
-    
-    private var _URL : NSURL?
-    private var _mainDocumentURL: NSURL?
-    private var _httpHeaderFields: [String: String]?
     
     public override func copy() -> AnyObject {
         return copyWithZone(nil)
     }
     
     public func copyWithZone(_ zone: NSZone) -> AnyObject {
-        NSUnimplemented()
+        if self.dynamicType === NSURLRequest.self {
+            // Already immutable
+            return self
+        }
+        let c = NSURLRequest()
+        c.setValues(from: self)
+        return c
+    }
+    
+    private func setValues(from source: NSURLRequest) {
+        self.allHTTPHeaderFields = source.allHTTPHeaderFields
+        self.url = source.url
+        self.mainDocumentURL = source.mainDocumentURL
+        self.httpMethod = source.httpMethod
     }
     
     public override func mutableCopy() -> AnyObject {
@@ -181,7 +161,9 @@ public class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopyin
     }
     
     public func mutableCopyWithZone(_ zone: NSZone) -> AnyObject {
-        NSUnimplemented()
+        let c = NSMutableURLRequest()
+        c.setValues(from: self)
+        return c
     }
     
     public required init?(coder aDecoder: NSCoder) {
@@ -194,233 +176,152 @@ public class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopyin
     
     private override init() {}
     
-    /*! 
-        @method requestWithURL:
-        @abstract Allocates and initializes an NSURLRequest with the given
-        URL.
-        @discussion Default values are used for cache policy
-        (NSURLRequestUseProtocolCachePolicy) and timeout interval (60
-        seconds).
-        @param URL The URL for the request.
-        @result A newly-created and autoreleased NSURLRequest instance.
-    */
-    
-    /*
-        @method supportsSecureCoding
-        @abstract Indicates that NSURLRequest implements the NSSecureCoding protocol.
-        @result A BOOL value set to YES.
-    */
+    /// Indicates that NSURLRequest implements the NSSecureCoding protocol.
     public static func supportsSecureCoding() -> Bool { return true }
     
-    /*!
-        @method requestWithURL:cachePolicy:timeoutInterval:
-        @abstract Allocates and initializes a NSURLRequest with the given
-        URL and cache policy.
-        @param URL The URL for the request. 
-        @param cachePolicy The cache policy for the request. 
-        @param timeoutInterval The timeout interval for the request. See the
-        commentary for the <tt>timeoutInterval</tt> for more information on
-        timeout intervals.
-        @result A newly-created and autoreleased NSURLRequest instance. 
-    */
-    
-    /*! 
-        @method initWithURL:
-        @abstract Initializes an NSURLRequest with the given URL. 
-        @discussion Default values are used for cache policy
-        (NSURLRequestUseProtocolCachePolicy) and timeout interval (60
-        seconds).
-        @param URL The URL for the request. 
-        @result An initialized NSURLRequest. 
-    */
-    public convenience init(URL: NSURL) {
+    /// Initializes an NSURLRequest with the given URL.
+    ///
+    /// - Parameter URL: The URL for the request.
+    public convenience init(url: NSURL) {
         self.init()
-        _URL = URL
+        self.url = url
     }
     
-    /*!
-        @method URL
-        @abstract Returns the URL of the receiver. 
-        @result The URL of the receiver. 
-    */
-    /*@NSCopying */public var URL: NSURL? { return _URL }
+    /// The URL of the receiver.
+    /*@NSCopying */public private(set) var url: NSURL?
     
-    /*!
-        @method mainDocumentURL
-        @abstract The main document URL associated with this load.
-        @discussion This URL is used for the cookie "same domain as main
-        document" policy. There may also be other future uses.
-        See setMainDocumentURL:
-        @result The main document URL.
-    */
-    /*@NSCopying*/ public var mainDocumentURL: NSURL? { return _mainDocumentURL }
+    /// The main document URL associated with this load.
+    ///
+    /// This URL is used for the cookie "same domain as main
+    /// document" policy. There may also be other future uses.
+    /*@NSCopying*/ public private(set) var mainDocumentURL: NSURL?
     
-    /*!
-    @method HTTPMethod
-    @abstract Returns the HTTP request method of the receiver.
-    @result the HTTP request method of the receiver.
-    */
-    public var HTTPMethod: String? { return "GET" }
+    /// Returns the HTTP request method of the receiver.
+    public private(set) var httpMethod: String? = "GET"
     
-    /*!
-    @method allHTTPHeaderFields
-    @abstract Returns a dictionary containing all the HTTP header fields
-    of the receiver.
-    @result a dictionary containing all the HTTP header fields of the
-    receiver.
-    */
-    public var allHTTPHeaderFields: [String : String]? { return _httpHeaderFields  }
+    /// A dictionary containing all the HTTP header fields
+    /// of the receiver.
+    public private(set) var allHTTPHeaderFields: [String: String]?
     
-    /*!
-    @method valueForHTTPHeaderField:
-    @abstract Returns the value which corresponds to the given header
-    field. Note that, in keeping with the HTTP RFC, HTTP header field
-    names are case-insensitive.
-    @param field the header field name to use for the lookup
-    (case-insensitive).
-    @result the value associated with the given header field, or nil if
-    there is no value associated with the given header field.
-    */
-    public func valueForHTTPHeaderField(_ field: String) -> String? { return _httpHeaderFields?[field.lowercased()] }
-    
+    /// Returns the value which corresponds to the given header field.
+    ///
+    /// Note that, in keeping with the HTTP RFC, HTTP header field
+    /// names are case-insensitive.
+    /// - Parameter field: the header field name to use for the lookup
+    ///     (case-insensitive).
+    /// - Returns: the value associated with the given header field, or `nil` if
+    /// there is no value associated with the given header field.
+    public func value(forHTTPHeaderField field: String) -> String? {
+        guard let f = allHTTPHeaderFields else { return nil }
+        return existingHeaderField(field, inHeaderFields: f)?.1
+    }
 }
 
-/*!
-    @class NSMutableURLRequest
-
-    @abstract An NSMutableURLRequest object represents a mutable URL load
-    request in a manner independent of protocol and URL scheme.
-    
-    @discussion This specialization of NSURLRequest is provided to aid
-    developers who may find it more convenient to mutate a single request
-    object for a series of URL loads instead of creating an immutable
-    NSURLRequest for each load. This programming model is supported by
-    the following contract stipulation between NSMutableURLRequest and 
-    NSURLConnection: NSURLConnection makes a deep copy of each 
-    NSMutableURLRequest object passed to one of its initializers.    
-    <p>NSMutableURLRequest is designed to be extended to support
-    protocol-specific data by adding categories to access a property
-    object provided in an interface targeted at protocol implementors.
-    <ul>
-    <li>Protocol implementors should direct their attention to the
-    NSMutableURLRequestExtensibility category on
-    NSMutableURLRequest for more information on how to provide
-    extensions on NSMutableURLRequest to support protocol-specific
-    request information.
-    <li>Clients of this API who wish to create NSMutableURLRequest
-    objects to load URL content should consult the protocol-specific
-    NSMutableURLRequest categories that are available. The
-    NSMutableHTTPURLRequest category on NSMutableURLRequest is an
-    example.
-    </ul>
-*/
+/// An `NSMutableURLRequest` object represents a mutable URL load
+/// request in a manner independent of protocol and URL scheme.
+///
+/// This specialization of `NSURLRequest` is provided to aid
+/// developers who may find it more convenient to mutate a single request
+/// object for a series of URL loads instead of creating an immutable
+/// `NSURLRequest` for each load. This programming model is supported by
+/// the following contract stipulation between `NSMutableURLRequest` and the
+/// `NSURLSession` API: `NSURLSession` makes a deep copy of each
+/// `NSMutableURLRequest` object passed to it.
+///
+/// `NSMutableURLRequest` is designed to be extended to support
+/// protocol-specific data by adding categories to access a property
+/// object provided in an interface targeted at protocol implementors.
+///
+/// Protocol implementors should direct their attention to the
+/// `NSMutableURLRequestExtensibility` category on
+/// `NSMutableURLRequest` for more information on how to provide
+/// extensions on `NSMutableURLRequest` to support protocol-specific
+/// request information.
+///
+/// Clients of this API who wish to create `NSMutableURLRequest`
+/// objects to load URL content should consult the protocol-specific
+/// `NSMutableURLRequest` categories that are available. The
+/// `NSMutableHTTPURLRequest` category on `NSMutableURLRequest` is an
+/// example.
 public class NSMutableURLRequest : NSURLRequest {
-    
-    private var _HTTPMethod: String? = "GET"
-    
     public required init?(coder aDecoder: NSCoder) {
         super.init()
     }
     
     private override init() { super.init() }
     
-    /*!
-        @method URL
-        @abstract Sets the URL of the receiver. 
-        @param URL The new URL for the receiver. 
-    */
-    /*@NSCopying */ public override var URL: NSURL? {
-        get {
-            return _URL
-        }
-        set(newURL) {
-            _URL = newURL
-        }
+    /*@NSCopying */ public override var url: NSURL? {
+        get { return super.url }
+        //TODO: set { super.URL = newValue.map{ $0.copy() as! NSURL } }
+        set { super.url = newValue }
     }
-
-    /*!
-        @method setMainDocumentURL:
-        @abstract Sets the main document URL
-        @param URL The main document URL.
-        @discussion The caller should pass the URL for an appropriate main
-        document, if known. For example, when loading a web page, the URL
-        of the main html document for the top-level frame should be
-        passed.  This main document will be used to implement the cookie
-        "only from same domain as main document" policy, and possibly
-        other things in the future.
-    */
+    
+    /// The main document URL.
+    ///
+    /// The caller should pass the URL for an appropriate main
+    /// document, if known. For example, when loading a web page, the URL
+    /// of the main html document for the top-level frame should be
+    /// passed.  This main document will be used to implement the cookie
+    /// *only from same domain as main document* policy, and possibly
+    /// other things in the future.
     /*@NSCopying*/ public override var mainDocumentURL: NSURL? {
-        get {
-            return _mainDocumentURL
-        } set(newMainDocumentURL) {
-            _mainDocumentURL = newMainDocumentURL
-        }
+        get { return super.mainDocumentURL }
+        //TODO: set { super.mainDocumentURL = newValue.map{ $0.copy() as! NSURL } }
+        set { super.mainDocumentURL = newValue }
     }
     
     
-    /*!
-        @method HTTPMethod
-        @abstract Sets the HTTP request method of the receiver.
-        @result the HTTP request method of the receiver.
-    */
-    public override var HTTPMethod: String? {
-        get {
-            return _HTTPMethod
-        } set(newHTTPMethod) {
-            _HTTPMethod = newHTTPMethod
-        }
+    /// The HTTP request method of the receiver.
+    public override var httpMethod: String? {
+        get { return super.httpMethod }
+        set { super.httpMethod = newValue }
     }
     
-    /*!
-        @method setValue:forHTTPHeaderField:
-        @abstract Sets the value of the given HTTP header field.
-        @discussion If a value was previously set for the given header
-        field, that value is replaced with the given value. Note that, in
-        keeping with the HTTP RFC, HTTP header field names are
-        case-insensitive.
-        @param value the header field value. 
-        @param field the header field name (case-insensitive). 
-    */
+    /// Sets the value of the given HTTP header field.
+    ///
+    /// If a value was previously set for the given header
+    /// field, that value is replaced with the given value. Note that, in
+    /// keeping with the HTTP RFC, HTTP header field names are
+    /// case-insensitive.
+    /// - Parameter value: the header field value.
+    /// - Parameter field: the header field name (case-insensitive).
     public func setValue(_ value: String?, forHTTPHeaderField field: String) {
-        if _httpHeaderFields == nil {
-            _httpHeaderFields = [:]
+        var f: [String: String] = allHTTPHeaderFields ?? [:]
+        if let old = existingHeaderField(field, inHeaderFields: f) {
+            f.removeValue(forKey: old.0)
         }
-        if let existingHeader = _httpHeaderFields?.filter({ (existingField, _) -> Bool in
-            return existingField.lowercased() == field.lowercased()
-        }).first {
-            let (existingField, _) = existingHeader
-            _httpHeaderFields?.removeValue(forKey: existingField)
-        }
-        _httpHeaderFields?[field] = value
+        f[field] = value
+        allHTTPHeaderFields = f
     }
     
-    /*! 
-        @method addValue:forHTTPHeaderField:
-        @abstract Adds an HTTP header field in the current header
-        dictionary.
-        @discussion This method provides a way to add values to header
-        fields incrementally. If a value was previously set for the given
-        header field, the given value is appended to the previously-existing
-        value. The appropriate field delimiter, a comma in the case of HTTP,
-        is added by the implementation, and should not be added to the given
-        value by the caller. Note that, in keeping with the HTTP RFC, HTTP
-        header field names are case-insensitive.
-        @param value the header field value. 
-        @param field the header field name (case-insensitive). 
-    */
+    /// Adds an HTTP header field in the current header dictionary.
+    ///
+    /// This method provides a way to add values to header
+    /// fields incrementally. If a value was previously set for the given
+    /// header field, the given value is appended to the previously-existing
+    /// value. The appropriate field delimiter, a comma in the case of HTTP,
+    /// is added by the implementation, and should not be added to the given
+    /// value by the caller. Note that, in keeping with the HTTP RFC, HTTP
+    /// header field names are case-insensitive.
+    /// - Parameter value: the header field value.
+    /// - Parameter field: the header field name (case-insensitive).
     public func addValue(_ value: String, forHTTPHeaderField field: String) {
-        if _httpHeaderFields == nil {
-            _httpHeaderFields = [:]
-        }
-        if let existingHeader = _httpHeaderFields?.filter({ (existingField, _) -> Bool in
-            return existingField.lowercased() == field.lowercased()
-        }).first {
-            let (existingField, existingValue) = existingHeader
-            _httpHeaderFields?[existingField] = "\(existingValue),\(value)"
+        var f: [String: String] = allHTTPHeaderFields ?? [:]
+        if let old = existingHeaderField(field, inHeaderFields: f) {
+            f[old.0] = old.1 + "," + value
         } else {
-            _httpHeaderFields?[field] = value
+            f[field] = value
         }
+        allHTTPHeaderFields = f
     }
 }
 
-
+/// Returns an existing key-value pair inside the header fields if it exists.
+private func existingHeaderField(_ key: String, inHeaderFields fields: [String: String]) -> (String, String)? {
+    for (k, v) in fields {
+        if k.lowercased() == key.lowercased() {
+            return (k, v)
+        }
+    }
+    return nil
+}

--- a/TestFoundation/TestNSURLRequest.swift
+++ b/TestFoundation/TestNSURLRequest.swift
@@ -22,51 +22,55 @@ class TestNSURLRequest : XCTestCase {
         return [
             ("test_construction", test_construction),
             ("test_mutableConstruction", test_mutableConstruction),
-            ("test_headerFields", test_headerFields)
+            ("test_headerFields", test_headerFields),
+            ("test_copy", test_copy),
+            ("test_mutableCopy_1", test_mutableCopy_1),
+            ("test_mutableCopy_2", test_mutableCopy_2),
+            ("test_mutableCopy_3", test_mutableCopy_3),
         ]
     }
     
-    let URL = NSURL(string: "http://swift.org")!
+    let url = NSURL(string: "http://swift.org")!
     
     func test_construction() {
-        let request = NSURLRequest(URL: URL)
+        let request = NSURLRequest(url: url)
         // Match OS X Foundation responses
         XCTAssertNotNil(request)
-        XCTAssertEqual(request.URL, URL)
-        XCTAssertEqual(request.HTTPMethod, "GET")
+        XCTAssertEqual(request.url, url)
+        XCTAssertEqual(request.httpMethod, "GET")
         XCTAssertNil(request.allHTTPHeaderFields)
         XCTAssertNil(request.mainDocumentURL)
     }
     
     func test_mutableConstruction() {
         let URL = NSURL(string: "http://swift.org")!
-        let request = NSMutableURLRequest(URL: URL)
+        let request = NSMutableURLRequest(url: url)
         
         //Confirm initial state matches NSURLRequest responses
         XCTAssertNotNil(request)
-        XCTAssertEqual(request.URL, URL)
-        XCTAssertEqual(request.HTTPMethod, "GET")
+        XCTAssertEqual(request.url, url)
+        XCTAssertEqual(request.httpMethod, "GET")
         XCTAssertNil(request.allHTTPHeaderFields)
         XCTAssertNil(request.mainDocumentURL)
         
-        request.mainDocumentURL = URL
-        XCTAssertEqual(request.mainDocumentURL, URL)
+        request.mainDocumentURL = url
+        XCTAssertEqual(request.mainDocumentURL, url)
         
-        request.HTTPMethod = "POST"
-        XCTAssertEqual(request.HTTPMethod, "POST")
+        request.httpMethod = "POST"
+        XCTAssertEqual(request.httpMethod, "POST")
         
         let newURL = NSURL(string: "http://github.com")!
-        request.URL = newURL
-        XCTAssertEqual(request.URL, newURL)
+        request.url = newURL
+        XCTAssertEqual(request.url, newURL)
     }
     
     func test_headerFields() {
-        let request = NSMutableURLRequest(URL: URL)
+        let request = NSMutableURLRequest(url: url)
         
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         XCTAssertNotNil(request.allHTTPHeaderFields)
         XCTAssertEqual(request.allHTTPHeaderFields?["Accept"], "application/json")
-
+        
         // Setting "accept" should remove "Accept"
         request.setValue("application/xml", forHTTPHeaderField: "accept")
         XCTAssertNil(request.allHTTPHeaderFields?["Accept"])
@@ -75,5 +79,128 @@ class TestNSURLRequest : XCTestCase {
         // Adding to "Accept" should add to "accept"
         request.addValue("text/html", forHTTPHeaderField: "Accept")
         XCTAssertEqual(request.allHTTPHeaderFields?["accept"], "application/xml,text/html")
+    }
+    
+    func test_copy() {
+        let mutableRequest = NSMutableURLRequest(url: url)
+        
+        let urlA = NSURL(string: "http://swift.org")!
+        let urlB = NSURL(string: "http://github.com")!
+        mutableRequest.mainDocumentURL = urlA
+        mutableRequest.url = urlB
+        mutableRequest.httpMethod = "POST"
+        mutableRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        guard let requestCopy1 = mutableRequest.copy() as? NSURLRequest else {
+            XCTFail(); return
+        }
+        
+        // Check that all attributes are copied and that the original ones are
+        // unchanged:
+        XCTAssertEqual(mutableRequest.mainDocumentURL, urlA)
+        XCTAssertEqual(requestCopy1.mainDocumentURL, urlA)
+        XCTAssertEqual(mutableRequest.httpMethod, "POST")
+        XCTAssertEqual(requestCopy1.httpMethod, "POST")
+        XCTAssertEqual(mutableRequest.url, urlB)
+        XCTAssertEqual(requestCopy1.url, urlB)
+        XCTAssertEqual(mutableRequest.allHTTPHeaderFields?["Accept"], "application/json")
+        XCTAssertEqual(requestCopy1.allHTTPHeaderFields?["Accept"], "application/json")
+
+        // Change the original, and check that the copy has unchanged
+        // values:
+        let urlC = NSURL(string: "http://apple.com")!
+        let urlD = NSURL(string: "http://ibm.com")!
+        mutableRequest.mainDocumentURL = urlC
+        mutableRequest.url = urlD
+        mutableRequest.httpMethod = "HEAD"
+        mutableRequest.addValue("text/html", forHTTPHeaderField: "Accept")
+        XCTAssertEqual(requestCopy1.mainDocumentURL, urlA)
+        XCTAssertEqual(requestCopy1.httpMethod, "POST")
+        XCTAssertEqual(requestCopy1.url, urlB)
+        XCTAssertEqual(requestCopy1.allHTTPHeaderFields?["Accept"], "application/json")
+
+        // Check that we can copy the copy:
+        guard let requestCopy2 = requestCopy1.copy() as? NSURLRequest else {
+            XCTFail(); return
+        }
+        XCTAssertEqual(requestCopy2.mainDocumentURL, urlA)
+        XCTAssertEqual(requestCopy2.httpMethod, "POST")
+        XCTAssertEqual(requestCopy2.url, urlB)
+        XCTAssertEqual(requestCopy2.allHTTPHeaderFields?["Accept"], "application/json")
+    }
+
+    func test_mutableCopy_1() {
+        let originalRequest = NSMutableURLRequest(url: url)
+        
+        let urlA = NSURL(string: "http://swift.org")!
+        let urlB = NSURL(string: "http://github.com")!
+        originalRequest.mainDocumentURL = urlA
+        originalRequest.url = urlB
+        originalRequest.httpMethod = "POST"
+        originalRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        
+        guard let requestCopy = originalRequest.mutableCopy() as? NSMutableURLRequest else {
+            XCTFail(); return
+        }
+        
+        // Change the original, and check that the copy has unchanged values:
+        let urlC = NSURL(string: "http://apple.com")!
+        let urlD = NSURL(string: "http://ibm.com")!
+        originalRequest.mainDocumentURL = urlC
+        originalRequest.url = urlD
+        originalRequest.httpMethod = "HEAD"
+        originalRequest.addValue("text/html", forHTTPHeaderField: "Accept")
+        XCTAssertEqual(requestCopy.mainDocumentURL, urlA)
+        XCTAssertEqual(requestCopy.httpMethod, "POST")
+        XCTAssertEqual(requestCopy.url, urlB)
+        XCTAssertEqual(requestCopy.allHTTPHeaderFields?["Accept"], "application/json")
+    }
+
+    func test_mutableCopy_2() {
+        let originalRequest = NSMutableURLRequest(url: url)
+        
+        let urlA = NSURL(string: "http://swift.org")!
+        let urlB = NSURL(string: "http://github.com")!
+        originalRequest.mainDocumentURL = urlA
+        originalRequest.url = urlB
+        originalRequest.httpMethod = "POST"
+        originalRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        
+        guard let requestCopy = originalRequest.mutableCopy() as? NSMutableURLRequest else {
+            XCTFail(); return
+        }
+        
+        // Change the copy, and check that the original has unchanged values:
+        let urlC = NSURL(string: "http://apple.com")!
+        let urlD = NSURL(string: "http://ibm.com")!
+        requestCopy.mainDocumentURL = urlC
+        requestCopy.url = urlD
+        requestCopy.httpMethod = "HEAD"
+        requestCopy.addValue("text/html", forHTTPHeaderField: "Accept")
+        XCTAssertEqual(originalRequest.mainDocumentURL, urlA)
+        XCTAssertEqual(originalRequest.httpMethod, "POST")
+        XCTAssertEqual(originalRequest.url, urlB)
+        XCTAssertEqual(originalRequest.allHTTPHeaderFields?["Accept"], "application/json")
+    }
+
+    func test_mutableCopy_3() {
+        let urlA = NSURL(string: "http://swift.org")!
+        let originalRequest = NSURLRequest(url: urlA)
+        
+        guard let requestCopy = originalRequest.mutableCopy() as? NSMutableURLRequest else {
+            XCTFail(); return
+        }
+        
+        // Change the copy, and check that the original has unchanged values:
+        let urlC = NSURL(string: "http://apple.com")!
+        let urlD = NSURL(string: "http://ibm.com")!
+        requestCopy.mainDocumentURL = urlC
+        requestCopy.url = urlD
+        requestCopy.httpMethod = "HEAD"
+        requestCopy.addValue("text/html", forHTTPHeaderField: "Accept")
+        XCTAssertNil(originalRequest.mainDocumentURL)
+        XCTAssertEqual(originalRequest.httpMethod, "GET")
+        XCTAssertEqual(originalRequest.url, urlA)
+        XCTAssertNil(originalRequest.allHTTPHeaderFields)
     }
 }


### PR DESCRIPTION
Change code comments to *Swift Documentation Markup*.
Rework how attributes are stored.
Refactor header field code into existingHeaderField().