### PR TITLE
Replace all bridge() calls with corresponding as expression in test cases

### DIFF
--- a/TestFoundation/TestNSArray.swift
+++ b/TestFoundation/TestNSArray.swift
@@ -48,24 +48,24 @@ class TestNSArray : XCTestCase {
     
     func test_BasicConstruction() {
         let array = NSArray()
-        let array2 : NSArray = ["foo", "bar"].bridge()
+        let array2 : NSArray = ["foo", "bar"] as NSArray
         XCTAssertEqual(array.count, 0)
         XCTAssertEqual(array2.count, 2)
     }
     
     func test_enumeration() {
-        let array : NSArray = ["foo", "bar", "baz"].bridge()
+        let array : NSArray = ["foo", "bar", "baz"] as NSArray
         let e = array.objectEnumerator()
-        XCTAssertEqual((e.nextObject() as! NSString).bridge(), "foo")
-        XCTAssertEqual((e.nextObject() as! NSString).bridge(), "bar")
-        XCTAssertEqual((e.nextObject() as! NSString).bridge(), "baz")
+        XCTAssertEqual((e.nextObject() as! NSString) as String, "foo")
+        XCTAssertEqual((e.nextObject() as! NSString) as String, "bar")
+        XCTAssertEqual((e.nextObject() as! NSString) as String, "baz")
         XCTAssertNil(e.nextObject())
         XCTAssertNil(e.nextObject())
         
         let r = array.reverseObjectEnumerator()
-        XCTAssertEqual((r.nextObject() as! NSString).bridge(), "baz")
-        XCTAssertEqual((r.nextObject() as! NSString).bridge(), "bar")
-        XCTAssertEqual((r.nextObject() as! NSString).bridge(), "foo")
+        XCTAssertEqual((r.nextObject() as! NSString) as String, "baz")
+        XCTAssertEqual((r.nextObject() as! NSString) as String, "bar")
+        XCTAssertEqual((r.nextObject() as! NSString) as String, "foo")
         XCTAssertNil(r.nextObject())
         XCTAssertNil(r.nextObject())
         
@@ -79,34 +79,34 @@ class TestNSArray : XCTestCase {
     }
     
     func test_sequenceType() {
-        let array : NSArray = ["foo", "bar", "baz"].bridge()
+        let array : NSArray = ["foo", "bar", "baz"] as NSArray
         var res = [String]()
         for obj in array {
-            res.append((obj as! NSString).bridge())
+            res.append((obj as! NSString) as String)
         }
         XCTAssertEqual(res, ["foo", "bar", "baz"])
     }
 
     func test_getObjects() {
-        let array : NSArray = ["foo", "bar", "baz", "foo1", "bar2", "baz3",].bridge()
+        let array : NSArray = ["foo", "bar", "baz", "foo1", "bar2", "baz3",] as NSArray
         var objects = [AnyObject]()
         array.getObjects(&objects, range: NSMakeRange(1, 3))
         XCTAssertEqual(objects.count, 3)
         let fetched = [
-            (objects[0] as! NSString).bridge(),
-            (objects[1] as! NSString).bridge(),
-            (objects[2] as! NSString).bridge(),
+            (objects[0] as! NSString) as String,
+            (objects[1] as! NSString) as String,
+            (objects[2] as! NSString) as String,
         ]
         XCTAssertEqual(fetched, ["bar", "baz", "foo1"])
     }
     
     func test_objectAtIndex() {
-        let array : NSArray = ["foo", "bar"].bridge()
+        let array : NSArray = ["foo", "bar"] as NSArray
         let foo = array.objectAtIndex(0) as! NSString
-        XCTAssertEqual(foo, "foo".bridge())
+        XCTAssertEqual(foo, "foo" as NSString)
         
         let bar = array.objectAtIndex(1) as! NSString
-        XCTAssertEqual(bar, "bar".bridge())
+        XCTAssertEqual(bar, "bar" as NSString)
     }
 
     func test_binarySearch() {
@@ -273,52 +273,52 @@ class TestNSArray : XCTestCase {
     
     func test_replaceObjectsInRange_withObjectsFromArray() {
         let array1 = NSMutableArray(array:[
-            "foo1".bridge(),
-            "bar1".bridge(),
-            "baz1".bridge()])
+            "foo1" as NSString,
+            "bar1" as NSString,
+            "baz1" as NSString])
         
         let array2: [AnyObject] = [
-            "foo2".bridge(),
-            "bar2".bridge(),
-            "baz2".bridge()]
+            "foo2" as NSString,
+            "bar2" as NSString,
+            "baz2" as NSString]
         
         array1.replaceObjectsInRange(NSMakeRange(0, 2), withObjectsFromArray: array2)
         
-        XCTAssertEqual(array1[0] as? NSString, "foo2".bridge(), "Expected foo2 but was \(array1[0])")
-        XCTAssertEqual(array1[1] as? NSString, "bar2".bridge(), "Expected bar2 but was \(array1[1])")
-        XCTAssertEqual(array1[2] as? NSString, "baz2".bridge(), "Expected baz2 but was \(array1[2])")
-        XCTAssertEqual(array1[3] as? NSString, "baz1".bridge(), "Expected baz1 but was \(array1[3])")
+        XCTAssertEqual(array1[0] as? NSString, "foo2" as NSString, "Expected foo2 but was \(array1[0])")
+        XCTAssertEqual(array1[1] as? NSString, "bar2" as NSString, "Expected bar2 but was \(array1[1])")
+        XCTAssertEqual(array1[2] as? NSString, "baz2" as NSString, "Expected baz2 but was \(array1[2])")
+        XCTAssertEqual(array1[3] as? NSString, "baz1" as NSString, "Expected baz1 but was \(array1[3])")
     }
     
     func test_replaceObjectsInRange_withObjectsFromArray_range() {
         let array1 = NSMutableArray(array:[
-            "foo1".bridge(),
-            "bar1".bridge(),
-            "baz1".bridge()])
+            "foo1" as NSString,
+            "bar1" as NSString,
+            "baz1" as NSString])
         
         let array2: [AnyObject] = [
-            "foo2".bridge(),
-            "bar2".bridge(),
-            "baz2".bridge()]
+            "foo2" as NSString,
+            "bar2" as NSString,
+            "baz2" as NSString]
         
         array1.replaceObjectsInRange(NSMakeRange(1, 1), withObjectsFromArray: array2, range: NSMakeRange(1, 2))
         
-        XCTAssertEqual(array1[0] as? NSString, "foo1".bridge(), "Expected foo1 but was \(array1[0])")
-        XCTAssertEqual(array1[1] as? NSString, "bar2".bridge(), "Expected bar2 but was \(array1[1])")
-        XCTAssertEqual(array1[2] as? NSString, "baz2".bridge(), "Expected baz2 but was \(array1[2])")
-        XCTAssertEqual(array1[3] as? NSString, "baz1".bridge(), "Expected baz1 but was \(array1[3])")
+        XCTAssertEqual(array1[0] as? NSString, "foo1" as NSString, "Expected foo1 but was \(array1[0])")
+        XCTAssertEqual(array1[1] as? NSString, "bar2" as NSString, "Expected bar2 but was \(array1[1])")
+        XCTAssertEqual(array1[2] as? NSString, "baz2" as NSString, "Expected baz2 but was \(array1[2])")
+        XCTAssertEqual(array1[3] as? NSString, "baz1" as NSString, "Expected baz1 but was \(array1[3])")
     }
 
     func test_sortedArrayUsingComparator() {
         // sort with localized caseInsensitive compare
         let input = ["this", "is", "a", "test", "of", "sort", "with", "strings"]
         let expectedResult: Array<String> = input.sorted()
-        let result = input.bridge().sortedArrayUsingComparator { left, right -> NSComparisonResult in
+        let result = (input as NSArray).sortedArrayUsingComparator { left, right -> NSComparisonResult in
             let l = left as! NSString
             let r = right as! NSString
-            return l.localizedCaseInsensitiveCompare(r.bridge())
+            return l.localizedCaseInsensitiveCompare(r as String)
         }
-        XCTAssertEqual(result.map { ($0 as! NSString).bridge()} , expectedResult)
+        XCTAssertEqual(result.map { ($0 as! NSString) as String} , expectedResult)
 
         // sort empty array
         let emptyArray = NSArray().sortedArrayUsingComparator { _,_ in .OrderedSame }
@@ -327,7 +327,7 @@ class TestNSArray : XCTestCase {
         // sort numbers
         let inputNumbers = [0, 10, 25, 100, 21, 22]
         let expectedNumbers = inputNumbers.sorted()
-        let resultNumbers = inputNumbers.bridge().sortedArrayUsingComparator { left, right -> NSComparisonResult in
+        let resultNumbers = (inputNumbers as NSArray).sortedArrayUsingComparator { left, right -> NSComparisonResult in
             let l = (left as! NSNumber).integerValue
             let r = (right as! NSNumber).integerValue
             return l < r ? .OrderedAscending : (l > r ? .OrderedSame : .OrderedDescending)
@@ -337,16 +337,16 @@ class TestNSArray : XCTestCase {
 
     func test_sortedArrayWithOptionsUsingComparator() {
         // check that sortedArrayWithOptions:comparator: works in the way sortedArrayUsingComparator does
-        let input = ["this", "is", "a", "test", "of", "sort", "with", "strings"].bridge()
+        let input = ["this", "is", "a", "test", "of", "sort", "with", "strings"] as NSArray
         let comparator: (AnyObject, AnyObject) -> NSComparisonResult = { left, right -> NSComparisonResult in
             let l = left as! NSString
             let r = right as! NSString
-            return l.localizedCaseInsensitiveCompare(r.bridge())
+            return l.localizedCaseInsensitiveCompare(r as String)
         }
         let result1 = input.sortedArrayUsingComparator(comparator)
         let result2 = input.sortedArrayWithOptions([], usingComparator: comparator)
 
-        XCTAssertTrue(result1.bridge().isEqualToArray(result2))
+        XCTAssertTrue((result1 as NSArray).isEqualToArray(result2))
 
         // sort empty array
         let emptyArray = NSArray().sortedArrayWithOptions([]) { _,_ in .OrderedSame }
@@ -355,7 +355,7 @@ class TestNSArray : XCTestCase {
 
     func test_sortUsingFunction() {
         let inputNumbers = [11, 120, 215, 11, 1, -22, 35, -89, 65]
-        let mutableInput = inputNumbers.bridge().mutableCopy() as! NSMutableArray
+        let mutableInput = (inputNumbers as NSArray).mutableCopy() as! NSMutableArray
         let expectedNumbers = inputNumbers.sorted()
 
         func compare(_ left: AnyObject, right:AnyObject,  context: UnsafeMutablePointer<Void>?) -> Int {
@@ -371,7 +371,7 @@ class TestNSArray : XCTestCase {
     func test_sortUsingComparator() {
         // check behaviour with Array's sort method
         let inputNumbers = [11, 120, 215, 11, 1, -22, 35, -89, 65]
-        let mutableInput = inputNumbers.bridge().mutableCopy() as! NSMutableArray
+        let mutableInput = (inputNumbers as NSArray).mutableCopy() as! NSMutableArray
         let expectedNumbers = inputNumbers.sorted()
 
         mutableInput.sortUsingComparator { left, right -> NSComparisonResult in
@@ -384,40 +384,40 @@ class TestNSArray : XCTestCase {
 
         // check that it works in the way self.sortWithOptions([], usingComparator: cmptr) does
         let inputStrings = ["this", "is", "a", "test", "of", "sort", "with", "strings"]
-        let mutableStringsInput1 = inputStrings.bridge().mutableCopy() as! NSMutableArray
-        let mutableStringsInput2 = inputStrings.bridge().mutableCopy() as! NSMutableArray
+        let mutableStringsInput1 = (inputStrings as NSArray).mutableCopy() as! NSMutableArray
+        let mutableStringsInput2 = (inputStrings as NSArray).mutableCopy() as! NSMutableArray
         let comparator: (AnyObject, AnyObject) -> NSComparisonResult = { left, right -> NSComparisonResult in
             let l = left as! NSString
             let r = right as! NSString
-            return l.localizedCaseInsensitiveCompare(r.bridge())
+            return l.localizedCaseInsensitiveCompare(r as String)
         }
         mutableStringsInput1.sortUsingComparator(comparator)
         mutableStringsInput2.sortWithOptions([], usingComparator: comparator)
-        XCTAssertTrue(mutableStringsInput1.isEqualToArray(mutableStringsInput2.bridge()))
+        XCTAssertTrue(mutableStringsInput1.isEqualToArray(mutableStringsInput2 as Array))
     }
 
     func test_equality() {
-        let array1 = ["this", "is", "a", "test", "of", "equal", "with", "strings"].bridge()
-        let array2 = ["this", "is", "a", "test", "of", "equal", "with", "strings"].bridge()
-        let array3 = ["this", "is", "a", "test", "of", "equal", "with", "objects"].bridge()
+        let array1 = ["this", "is", "a", "test", "of", "equal", "with", "strings"] as NSArray
+        let array2 = ["this", "is", "a", "test", "of", "equal", "with", "strings"] as NSArray
+        let array3 = ["this", "is", "a", "test", "of", "equal", "with", "objects"] as NSArray
 
         XCTAssertTrue(array1 == array2)
         XCTAssertTrue(array1.isEqual(array2))
-        XCTAssertTrue(array1.isEqualToArray(array2.bridge()))
+        XCTAssertTrue(array1.isEqualToArray(array2 as Array))
         // if 2 arrays are equal, hashes should be equal as well. But not vise versa
         XCTAssertEqual(array1.hash, array2.hash)
         XCTAssertEqual(array1.hashValue, array2.hashValue)
 
         XCTAssertFalse(array1 == array3)
         XCTAssertFalse(array1.isEqual(array3))
-        XCTAssertFalse(array1.isEqualToArray(array3.bridge()))
+        XCTAssertFalse(array1.isEqualToArray(array3 as Array))
 
         XCTAssertFalse(array1.isEqual(nil))
         XCTAssertFalse(array1.isEqual(NSObject()))
     }
 
     func test_copying() {
-        let array = ["this", "is", "a", "test", "of", "copy", "with", "strings"].bridge()
+        let array = ["this", "is", "a", "test", "of", "copy", "with", "strings"] as NSArray
 
         let arrayCopy1 = array.copy() as! NSArray
         XCTAssertTrue(array === arrayCopy1)
@@ -433,7 +433,7 @@ class TestNSArray : XCTestCase {
     }
 
     func test_mutableCopying() {
-        let array = ["this", "is", "a", "test", "of", "mutableCopy", "with", "strings"].bridge()
+        let array = ["this", "is", "a", "test", "of", "mutableCopy", "with", "strings"] as NSArray
 
         let arrayMutableCopy1 = array.mutableCopy() as! NSMutableArray
         XCTAssertTrue(arrayMutableCopy1.dynamicType === NSMutableArray.self)

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -125,7 +125,7 @@ class TestNSData: XCTestCase {
     func test_initializeWithBase64EncodedDataGetsDecodedData() {
         let plainText = "ARMA virumque cano, Troiae qui primus ab oris\nItaliam, fato profugus, Laviniaque venit"
         let encodedText = "QVJNQSB2aXJ1bXF1ZSBjYW5vLCBUcm9pYWUgcXVpIHByaW11cyBhYiBvcmlzCkl0YWxpYW0sIGZhdG8gcHJvZnVndXMsIExhdmluaWFxdWUgdmVuaXQ="
-        guard let encodedData = encodedText.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+        guard let encodedData = (encodedText as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
             XCTFail("Could not get UTF-8 data")
             return
         }
@@ -133,17 +133,17 @@ class TestNSData: XCTestCase {
             XCTFail("Could not Base-64 decode data")
             return
         }
-        guard let decodedText = NSString(data: decodedData, encoding: NSUTF8StringEncoding)?.bridge() else {
+        guard let decodedText = NSString(data: decodedData, encoding: NSUTF8StringEncoding) as? String else {
             XCTFail("Could not convert decoded data to a UTF-8 String")
             return
         }
 
         XCTAssertEqual(decodedText, plainText)
-        XCTAssertTrue(decodedData.isEqual(to: plainText.bridge().dataUsingEncoding(NSUTF8StringEncoding)!))    }
+        XCTAssertTrue(decodedData.isEqual(to: (plainText as NSString).dataUsingEncoding(NSUTF8StringEncoding)!))    }
     
     func test_initializeWithBase64EncodedDataWithNonBase64CharacterIsNil() {
         let encodedText = "QVJNQSB2aXJ1bXF1ZSBjYW5vLCBUcm9pYWUgcXVpIHBya$W11cyBhYiBvcmlzCkl0YWxpYW0sIGZhdG8gcHJvZnVndXMsIExhdmluaWFxdWUgdmVuaXQ="
-        guard let encodedData = encodedText.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+        guard let encodedData = (encodedText as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
             XCTFail("Could not get UTF-8 data")
             return
         }
@@ -154,7 +154,7 @@ class TestNSData: XCTestCase {
     func test_initializeWithBase64EncodedDataWithNonBase64CharacterWithOptionToAllowItSkipsCharacter() {
         let plainText = "ARMA virumque cano, Troiae qui primus ab oris\nItaliam, fato profugus, Laviniaque venit"
         let encodedText = "QVJNQSB2aXJ1bXF1ZSBjYW5vLCBUcm9pYWUgcXVpIHBya$W11cyBhYiBvcmlzCkl0YWxpYW0sIGZhdG8gcHJvZnVndXMsIExhdmluaWFxdWUgdmVuaXQ="
-        guard let encodedData = encodedText.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+        guard let encodedData = (encodedText as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
             XCTFail("Could not get UTF-8 data")
             return
         }
@@ -162,13 +162,13 @@ class TestNSData: XCTestCase {
             XCTFail("Could not Base-64 decode data")
             return
         }
-        guard let decodedText = NSString(data: decodedData, encoding: NSUTF8StringEncoding)?.bridge() else {
+        guard let decodedText = NSString(data: decodedData, encoding: NSUTF8StringEncoding) as? String else {
             XCTFail("Could not convert decoded data to a UTF-8 String")
             return
         }
         
         XCTAssertEqual(decodedText, plainText)
-        XCTAssertTrue(decodedData.isEqual(to: plainText.bridge().dataUsingEncoding(NSUTF8StringEncoding)!))
+        XCTAssertTrue(decodedData.isEqual(to: (plainText as NSString).dataUsingEncoding(NSUTF8StringEncoding)!))
     }
     
     func test_initializeWithBase64EncodedStringGetsDecodedData() {
@@ -178,7 +178,7 @@ class TestNSData: XCTestCase {
             XCTFail("Could not Base-64 decode data")
             return
         }
-        guard let decodedText = NSString(data: decodedData, encoding: NSUTF8StringEncoding)?.bridge() else {
+        guard let decodedText = NSString(data: decodedData, encoding: NSUTF8StringEncoding) as? String else {
             XCTFail("Could not convert decoded data to a UTF-8 String")
             return
         }
@@ -189,12 +189,12 @@ class TestNSData: XCTestCase {
     func test_base64EncodedDataGetsEncodedText() {
         let plainText = "Constitit, et lacrimans, `Quis iam locus’ inquit `Achate,\nquae regio in terris nostri non plena laboris?`"
         let encodedText = "Q29uc3RpdGl0LCBldCBsYWNyaW1hbnMsIGBRdWlzIGlhbSBsb2N1c+KAmSBpbnF1aXQgYEFjaGF0ZSwKcXVhZSByZWdpbyBpbiB0ZXJyaXMgbm9zdHJpIG5vbiBwbGVuYSBsYWJvcmlzP2A="
-        guard let data = plainText.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+        guard let data = (plainText as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
             XCTFail("Could not encode UTF-8 string")
             return
         }
         let encodedData = data.base64EncodedData([])
-        guard let encodedTextResult = NSString(data: encodedData, encoding: NSASCIIStringEncoding)?.bridge() else {
+        guard let encodedTextResult = NSString(data: encodedData, encoding: NSASCIIStringEncoding) as? String else {
             XCTFail("Could not convert encoded data to an ASCII String")
             return
         }
@@ -204,12 +204,12 @@ class TestNSData: XCTestCase {
     func test_base64EncodedDataWithOptionToInsertLineFeedsContainsLineFeed() {
         let plainText = "Constitit, et lacrimans, `Quis iam locus’ inquit `Achate,\nquae regio in terris nostri non plena laboris?`"
         let encodedText = "Q29uc3RpdGl0LCBldCBsYWNyaW1hbnMsIGBRdWlzIGlhbSBsb2N1c+KAmSBpbnF1\naXQgYEFjaGF0ZSwKcXVhZSByZWdpbyBpbiB0ZXJyaXMgbm9zdHJpIG5vbiBwbGVu\nYSBsYWJvcmlzP2A="
-        guard let data = plainText.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+        guard let data = (plainText as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
             XCTFail("Could not encode UTF-8 string")
             return
         }
         let encodedData = data.base64EncodedData([.encoding64CharacterLineLength, .encodingEndLineWithLineFeed])
-        guard let encodedTextResult = NSString(data: encodedData, encoding: NSASCIIStringEncoding)?.bridge() else {
+        guard let encodedTextResult = NSString(data: encodedData, encoding: NSASCIIStringEncoding) as? String else {
             XCTFail("Could not convert encoded data to an ASCII String")
             return
         }
@@ -219,12 +219,12 @@ class TestNSData: XCTestCase {
     func test_base64EncodedDataWithOptionToInsertCarriageReturnContainsCarriageReturn() {
         let plainText = "Constitit, et lacrimans, `Quis iam locus’ inquit `Achate,\nquae regio in terris nostri non plena laboris?`"
         let encodedText = "Q29uc3RpdGl0LCBldCBsYWNyaW1hbnMsIGBRdWlzIGlhbSBsb2N1c+KAmSBpbnF1aXQgYEFjaGF0\rZSwKcXVhZSByZWdpbyBpbiB0ZXJyaXMgbm9zdHJpIG5vbiBwbGVuYSBsYWJvcmlzP2A="
-        guard let data = plainText.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+        guard let data = (plainText as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
             XCTFail("Could not encode UTF-8 string")
             return
         }
         let encodedData = data.base64EncodedData([.encoding76CharacterLineLength, .encodingEndLineWithCarriageReturn])
-        guard let encodedTextResult = NSString(data: encodedData, encoding: NSASCIIStringEncoding)?.bridge() else {
+        guard let encodedTextResult = NSString(data: encodedData, encoding: NSASCIIStringEncoding) as? String else {
             XCTFail("Could not convert encoded data to an ASCII String")
             return
         }
@@ -234,12 +234,12 @@ class TestNSData: XCTestCase {
     func test_base64EncodedDataWithOptionToInsertCarriageReturnAndLineFeedContainsBoth() {
         let plainText = "Revocate animos, maestumque timorem mittite: forsan et haec olim meminisse iuvabit."
         let encodedText = "UmV2b2NhdGUgYW5pbW9zLCBtYWVzdHVtcXVlIHRpbW9yZW0gbWl0dGl0ZTogZm9yc2FuIGV0IGhh\r\nZWMgb2xpbSBtZW1pbmlzc2UgaXV2YWJpdC4="
-        guard let data = plainText.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+        guard let data = (plainText as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
             XCTFail("Could not encode UTF-8 string")
             return
         }
         let encodedData = data.base64EncodedData([.encoding76CharacterLineLength, .encodingEndLineWithCarriageReturn, .encodingEndLineWithLineFeed])
-        guard let encodedTextResult = NSString(data: encodedData, encoding: NSASCIIStringEncoding)?.bridge() else {
+        guard let encodedTextResult = NSString(data: encodedData, encoding: NSASCIIStringEncoding) as? String else {
             XCTFail("Could not convert encoded data to an ASCII String")
             return
         }
@@ -249,7 +249,7 @@ class TestNSData: XCTestCase {
     func test_base64EncodedStringGetsEncodedText() {
         let plainText = "Revocate animos, maestumque timorem mittite: forsan et haec olim meminisse iuvabit."
         let encodedText = "UmV2b2NhdGUgYW5pbW9zLCBtYWVzdHVtcXVlIHRpbW9yZW0gbWl0dGl0ZTogZm9yc2FuIGV0IGhhZWMgb2xpbSBtZW1pbmlzc2UgaXV2YWJpdC4="
-        guard let data = plainText.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+        guard let data = (plainText as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
             XCTFail("Could not encode UTF-8 string")
             return
         }

--- a/TestFoundation/TestNSDictionary.swift
+++ b/TestFoundation/TestNSDictionary.swift
@@ -35,7 +35,7 @@ class TestNSDictionary : XCTestCase {
         
     func test_BasicConstruction() {
         let dict = NSDictionary()
-         let dict2: NSDictionary = ["foo": "bar"].bridge()
+         let dict2: NSDictionary = ["foo": "bar"] as NSDictionary
         XCTAssertEqual(dict.count, 0)
         XCTAssertEqual(dict2.count, 1)
     }
@@ -45,9 +45,9 @@ class TestNSDictionary : XCTestCase {
         // Disabled due to [SR-251]
         // Assertion disabled since it fails on linux targets due to heterogenious collection conversion failure
         /*
-        let d1: NSDictionary = [ "foo": "bar", "baz": "qux"].bridge()
+        let d1: NSDictionary = [ "foo": "bar", "baz": "qux"] as NSDictionary
         XCTAssertEqual(d1.description, "{\n    baz = qux;\n    foo = bar;\n}")
-        let d2: NSDictionary = ["1" : ["1" : ["1" : "1"]]].bridge()
+        let d2: NSDictionary = ["1" : ["1" : ["1" : "1"]]] as NSDictionary
         XCTAssertEqual(d2.description, "{\n    1 =     {\n        1 =         {\n            1 = 1;\n        };\n    };\n}")
         */
     }
@@ -76,59 +76,59 @@ class TestNSDictionary : XCTestCase {
     }
     
     func test_enumeration() {
-        let dict : NSDictionary = ["foo" : "bar", "whiz" : "bang", "toil" : "trouble"].bridge()
+        let dict : NSDictionary = ["foo" : "bar", "whiz" : "bang", "toil" : "trouble"] as NSDictionary
         let e = dict.keyEnumerator()
         var keys = Set<String>()
-        keys.insert((e.nextObject()! as! NSString).bridge())
-        keys.insert((e.nextObject()! as! NSString).bridge())
-        keys.insert((e.nextObject()! as! NSString).bridge())
+        keys.insert((e.nextObject()! as! NSString) as String)
+        keys.insert((e.nextObject()! as! NSString) as String)
+        keys.insert((e.nextObject()! as! NSString) as String)
         XCTAssertNil(e.nextObject())
         XCTAssertNil(e.nextObject())
         XCTAssertEqual(keys, ["foo", "whiz", "toil"])
         
         let o = dict.objectEnumerator()
         var objs = Set<String>()
-        objs.insert((o.nextObject()! as! NSString).bridge())
-        objs.insert((o.nextObject()! as! NSString).bridge())
-        objs.insert((o.nextObject()! as! NSString).bridge())
+        objs.insert((o.nextObject()! as! NSString) as String)
+        objs.insert((o.nextObject()! as! NSString) as String)
+        objs.insert((o.nextObject()! as! NSString) as String)
         XCTAssertNil(o.nextObject())
         XCTAssertNil(o.nextObject())
         XCTAssertEqual(objs, ["bar", "bang", "trouble"])
     }
     
     func test_sequenceType() {
-        let dict : NSDictionary = ["foo" : "bar", "whiz" : "bang", "toil" : "trouble"].bridge()
+        let dict : NSDictionary = ["foo" : "bar", "whiz" : "bang", "toil" : "trouble"] as NSDictionary
         var result = [String:String]()
         for (key, value) in dict {
-            result[key as! String] = (value as! NSString).bridge()
+            result[key as! String] = (value as! NSString) as String
         }
         XCTAssertEqual(result, ["foo" : "bar", "whiz" : "bang", "toil" : "trouble"])
     }
 
     func test_equality() {
-        let keys = ["foo", "whiz", "toil"].bridge().bridge()
-        let objects1 = ["bar", "bang", "trouble"].bridge().bridge()
-        let objects2 = ["bar", "bang", "troubl"].bridge().bridge()
+        let keys = ["foo", "whiz", "toil"] as NSArray as Array
+        let objects1 = ["bar", "bang", "trouble"] as NSArray as Array
+        let objects2 = ["bar", "bang", "troubl"] as NSArray as Array
         let dict1 = NSDictionary(objects: objects1, forKeys: keys.map({ $0 as! NSObject}))
         let dict2  = NSDictionary(objects: objects1, forKeys: keys.map({ $0 as! NSObject}))
         let dict3  = NSDictionary(objects: objects2, forKeys: keys.map({ $0 as! NSObject}))
 
         XCTAssertTrue(dict1 == dict2)
         XCTAssertTrue(dict1.isEqual(dict2))
-        XCTAssertTrue(dict1.isEqualToDictionary(dict2.bridge()))
+        XCTAssertTrue(dict1.isEqualToDictionary(dict2 as! Dictionary))
         XCTAssertEqual(dict1.hash, dict2.hash)
         XCTAssertEqual(dict1.hashValue, dict2.hashValue)
 
         XCTAssertFalse(dict1 == dict3)
         XCTAssertFalse(dict1.isEqual(dict3))
-        XCTAssertFalse(dict1.isEqualToDictionary(dict3.bridge()))
+        XCTAssertFalse(dict1.isEqualToDictionary(dict3 as! Dictionary))
 
         XCTAssertFalse(dict1.isEqual(nil))
         XCTAssertFalse(dict1.isEqual(NSObject()))
     }
 
     func test_copying() {
-        let inputDictionary : NSDictionary = ["foo" : "bar", "whiz" : "bang", "toil" : "trouble"].bridge()
+        let inputDictionary : NSDictionary = ["foo" : "bar", "whiz" : "bang", "toil" : "trouble"] as NSDictionary
 
         let copy: NSDictionary = inputDictionary.copy() as! NSDictionary
         XCTAssertTrue(inputDictionary === copy)
@@ -141,7 +141,7 @@ class TestNSDictionary : XCTestCase {
     }
 
     func test_mutableCopying() {
-        let inputDictionary : NSDictionary = ["foo" : "bar", "whiz" : "bang", "toil" : "trouble"].bridge()
+        let inputDictionary : NSDictionary = ["foo" : "bar", "whiz" : "bang", "toil" : "trouble"] as NSDictionary
 
         let dictMutableCopy1 = inputDictionary.mutableCopy() as! NSMutableDictionary
         XCTAssertTrue(dictMutableCopy1.dynamicType === NSMutableDictionary.self)

--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -183,7 +183,7 @@ class TestNSFileManger : XCTestCase {
             while let item = e.nextObject() as? NSString {
                 foundItems.addObject(item)
             }
-            XCTAssertEqual(foundItems, NSMutableSet(array: ["item".bridge(),"path2".bridge(),"path2/item".bridge()]))
+            XCTAssertEqual(foundItems, NSMutableSet(array: ["item" as NSString,"path2" as NSString,"path2/item" as NSString]))
         } else {
             XCTFail()
         }

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -120,7 +120,7 @@ extension TestNSJSONSerialization {
     func test_deserialize_emptyObject() {
         let subject = "{}"
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+            guard let data = (subject as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
                 XCTFail("Unable to convert string to data")
                 return
             }
@@ -136,7 +136,7 @@ extension TestNSJSONSerialization {
         let subject = "{ \"hello\": \"world\", \"swift\": \"rocks\" }"
         do {
             for encoding in [NSUTF8StringEncoding, NSUTF16BigEndianStringEncoding] {
-                guard let data = subject.bridge().dataUsingEncoding(encoding) else {
+                guard let data = (subject as NSString).dataUsingEncoding(encoding) else {
                     XCTFail("Unable to convert string to data")
                     return
                 }
@@ -154,7 +154,7 @@ extension TestNSJSONSerialization {
         let subject = "[]"
         
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+            guard let data = (subject as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
                 XCTFail("Unable to convert string to data")
                 return
             }
@@ -170,7 +170,7 @@ extension TestNSJSONSerialization {
         
         do {
             for encoding in [NSUTF8StringEncoding, NSUTF16BigEndianStringEncoding] {
-                guard let data = subject.bridge().dataUsingEncoding(encoding) else {
+                guard let data = (subject as NSString).dataUsingEncoding(encoding) else {
                     XCTFail("Unable to convert string to data")
                     return
                 }
@@ -189,7 +189,7 @@ extension TestNSJSONSerialization {
         
         do {
             for encoding in [NSUTF16LittleEndianStringEncoding, NSUTF16BigEndianStringEncoding, NSUTF32LittleEndianStringEncoding, NSUTF32BigEndianStringEncoding] {
-                guard let data = subject.bridge().dataUsingEncoding(encoding) else {
+                guard let data = (subject as NSString).dataUsingEncoding(encoding) else {
                     XCTFail("Unable to convert string to data")
                     return
                 }
@@ -209,7 +209,7 @@ extension TestNSJSONSerialization {
         
         do {
             for encoding in supportedEncodings {
-                guard let data = subject.bridge().dataUsingEncoding(encoding) else {
+                guard let data = (subject as NSString).dataUsingEncoding(encoding) else {
                     XCTFail("Unable to convert string to data")
                     return
                 }
@@ -232,7 +232,7 @@ extension TestNSJSONSerialization {
         
         do {
             for encoding in supportedEncodings {
-                guard let data = subject.bridge().dataUsingEncoding(encoding) else {
+                guard let data = (subject as NSString).dataUsingEncoding(encoding) else {
                     XCTFail("Unable to convert string to data")
                     return
                 }
@@ -253,7 +253,7 @@ extension TestNSJSONSerialization {
     func test_deserialize_simpleEscapeSequences() {
         let subject = "[\"\\\"\", \"\\\\\", \"\\/\", \"\\b\", \"\\f\", \"\\n\", \"\\r\", \"\\t\"]"
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+            guard let data = (subject as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
                 XCTFail("Unable to convert string to data")
                 return
             }
@@ -275,7 +275,7 @@ extension TestNSJSONSerialization {
     func test_deserialize_unicodeEscapeSequence() {
         let subject = "[\"\\u2728\"]"
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+            guard let data = (subject as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
                 XCTFail("Unable to convert string to data")
                 return
             }
@@ -289,7 +289,7 @@ extension TestNSJSONSerialization {
     func test_deserialize_unicodeSurrogatePairEscapeSequence() {
         let subject = "[\"\\uD834\\udd1E\"]"
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+            guard let data = (subject as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
                 XCTFail("Unable to convert string to data")
                 return
             }
@@ -305,7 +305,7 @@ extension TestNSJSONSerialization {
         
         do {
             for encoding in supportedEncodings {
-                guard let data = subject.bridge().dataUsingEncoding(encoding) else {
+                guard let data = (subject as NSString).dataUsingEncoding(encoding) else {
                     XCTFail("Unable to convert string to data")
                     return
                 }
@@ -322,7 +322,7 @@ extension TestNSJSONSerialization {
         let subject = "{\"}"
         
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+            guard let data = (subject as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
                 XCTFail("Unable to convert string to data")
                 return
             }
@@ -337,7 +337,7 @@ extension TestNSJSONSerialization {
         let subject = "{3}"
         
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+            guard let data = (subject as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
                 XCTFail("Unable to convert string to data")
                 return
             }
@@ -352,7 +352,7 @@ extension TestNSJSONSerialization {
         let subject = "{"
         
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+            guard let data = (subject as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
                 XCTFail("Unable to convert string to data")
                 return
             }
@@ -367,7 +367,7 @@ extension TestNSJSONSerialization {
         let subject = "{\"error\":}"
         
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+            guard let data = (subject as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
                 XCTFail("Unable to convert string to data")
                 return
             }
@@ -382,7 +382,7 @@ extension TestNSJSONSerialization {
         let subject = "{\"missing\";}"
         
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+            guard let data = (subject as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
                 XCTFail("Unable to convert string to data")
                 return
             }
@@ -397,7 +397,7 @@ extension TestNSJSONSerialization {
         let subject = "[,"
         
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+            guard let data = (subject as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
                 XCTFail("Unable to convert string to data")
                 return
             }
@@ -412,7 +412,7 @@ extension TestNSJSONSerialization {
         let subject = "[2b4]"
         
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+            guard let data = (subject as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
                 XCTFail("Unable to convert string to data")
                 return
             }
@@ -427,7 +427,7 @@ extension TestNSJSONSerialization {
         let subject = "[\"\\e\"]"
         
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+            guard let data = (subject as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
                 XCTFail("Unable to convert string to data")
                 return
             }
@@ -441,7 +441,7 @@ extension TestNSJSONSerialization {
     func test_deserialize_unicodeMissingTrailingSurrogate() {
         let subject = "[\"\\uD834\"]"
         do {
-            guard let data = subject.bridge().dataUsingEncoding(NSUTF8StringEncoding) else {
+            guard let data = (subject as NSString).dataUsingEncoding(NSUTF8StringEncoding) else {
                 XCTFail("Unable to convert string to data")
                 return
             }

--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -122,7 +122,7 @@ class TestNSKeyedArchiver : XCTestCase {
     
     func test_archive_array() {
         let array = ["one", "two", "three"]
-        test_archive(array.bridge())
+        test_archive(array as NSArray)
     }
     
     func test_archive_concrete_value() {
@@ -136,7 +136,7 @@ class TestNSKeyedArchiver : XCTestCase {
     
     func test_archive_dictionary() {
         let dictionary = ["one" : 1, "two" : 2, "three" : 3]
-        test_archive(dictionary.bridge())
+        test_archive(dictionary as NSDictionary)
     }
     
     func test_archive_generic_objc() {
@@ -165,17 +165,17 @@ class TestNSKeyedArchiver : XCTestCase {
     
     func test_archive_string() {
         let string = "hello"
-        test_archive(string.bridge())
+        test_archive(string as NSString)
     }
     
     func test_archive_mutable_array() {
         let array = ["one", "two", "three"]
-        test_archive(array.bridge().mutableCopy() as! NSObject)
+        test_archive((array as NSArray).mutableCopy() as! NSObject)
     }
 
     func test_archive_mutable_dictionary() {
         let mdictionary = NSMutableDictionary(objects: [NSNumber(integer: 1), NSNumber(integer: 2), NSNumber(integer: 3)],
-                                              forKeys: ["one".bridge(), "two".bridge(), "three".bridge()])
+                                              forKeys: ["one" as NSString, "two"as NSString, "three" as NSString])
         test_archive(mdictionary)
     }
     

--- a/TestFoundation/TestNSKeyedUnarchiver.swift
+++ b/TestFoundation/TestNSKeyedUnarchiver.swift
@@ -47,20 +47,20 @@ class TestNSKeyedUnarchiver : XCTestCase {
 
     func test_unarchive_array() {
         let array = ["baa", "baa", "black", "sheep"]
-        test_unarchive_from_file("NSKeyedUnarchiver-ArrayTest", array.bridge())
+        test_unarchive_from_file("NSKeyedUnarchiver-ArrayTest", array as NSArray)
     }
     
     func test_unarchive_complex() {
         let uuid = NSUUID(UUIDString: "71DC068E-3420-45FF-919E-3A267D55EC22")!
         let url = NSURL(string: "index.xml", relativeToURL:NSURL(string: "https://www.swift.org"))!
-        let array = NSArray(array: [ NSNull(), NSString(string: "hello"), NSNumber(int: 34545), ["key" : "val"].bridge() ])
+        let array = NSArray(array: [ NSNull(), NSString(string: "hello"), NSNumber(int: 34545), ["key" : "val"] as NSDictionary ])
         let dict : Dictionary<String, NSObject> = [
             "uuid" : uuid,
             "url" : url,
-            "string" : "hello".bridge(),
+            "string" : "hello" as NSString,
             "array" : array
         ]
-        test_unarchive_from_file("NSKeyedUnarchiver-ComplexTest", dict.bridge())
+        test_unarchive_from_file("NSKeyedUnarchiver-ComplexTest", dict as NSDictionary)
     }
     
     func test_unarchive_concrete_value() {
@@ -73,8 +73,8 @@ class TestNSKeyedUnarchiver : XCTestCase {
     }
 
     func test_unarchive_notification() {
-        let notification = NSNotification(name: "notification-name", object: "notification-object".bridge(),
-                                          userInfo: ["notification-key".bridge(): "notification-val".bridge()])
+        let notification = NSNotification(name: "notification-name", object: "notification-object" as NSString,
+                                          userInfo: ["notification-key" as NSString: "notification-val" as NSString])
         test_unarchive_from_file("NSKeyedUnarchiver-NotificationTest", notification)
     }
     
@@ -96,7 +96,7 @@ class TestNSKeyedUnarchiver : XCTestCase {
     }
     
     func test_unarchive_ordered_set() {
-        let set = NSOrderedSet(array: ["valgeir".bridge(), "nico".bridge(), "puzzle".bridge()])
+        let set = NSOrderedSet(array: ["valgeir" as NSString, "nico" as NSString, "puzzle" as NSString])
         test_unarchive_from_file("NSKeyedUnarchiver-OrderedSetTest", set)
     }
     

--- a/TestFoundation/TestNSOrderedSet.swift
+++ b/TestFoundation/TestNSOrderedSet.swift
@@ -59,23 +59,23 @@ class TestNSOrderedSet : XCTestCase {
 
     func test_BasicConstruction() {
         let set = NSOrderedSet()
-        let set2 = NSOrderedSet(array: ["foo", "bar"].bridge().bridge())
+        let set2 = NSOrderedSet(array: ["foo", "bar"] as NSArray as Array)
         XCTAssertEqual(set.count, 0)
         XCTAssertEqual(set2.count, 2)
     }
 
     func test_Enumeration() {
         let arr = ["foo", "bar", "bar"]
-        let set = NSOrderedSet(array: arr.bridge().bridge())
+        let set = NSOrderedSet(array: arr as NSArray as Array)
         var index = 0
         for item in set {
-            XCTAssertEqual(arr[index].bridge(), item as? NSString)
+            XCTAssertEqual(arr[index] as NSString, item as? NSString)
             index += 1
         }
     }
 
     func test_Uniqueness() {
-        let set = NSOrderedSet(array: ["foo", "bar", "bar"].bridge().bridge())
+        let set = NSOrderedSet(array: ["foo", "bar", "bar"] as NSArray as Array)
         XCTAssertEqual(set.count, 2)
         XCTAssertEqual(set.objectAtIndex(0) as? NSString, "foo")
         XCTAssertEqual(set.objectAtIndex(1) as? NSString, "bar")
@@ -112,14 +112,14 @@ class TestNSOrderedSet : XCTestCase {
     }
 
     func test_ObjectAtIndex() {
-        let set = NSOrderedSet(array: ["foo", "bar", "baz"].bridge().bridge())
+        let set = NSOrderedSet(array: ["foo", "bar", "baz"] as NSArray as Array)
         XCTAssertEqual(set.objectAtIndex(0) as? NSString, "foo")
         XCTAssertEqual(set.objectAtIndex(1) as? NSString, "bar")
         XCTAssertEqual(set.objectAtIndex(2) as? NSString, "baz")
     }
 
     func test_ObjectsAtIndexes() {
-        let set = NSOrderedSet(array: ["foo", "bar", "baz", "1", "2", "3"].bridge().bridge())
+        let set = NSOrderedSet(array: ["foo", "bar", "baz", "1", "2", "3"] as NSArray as Array)
         let indexSet = NSMutableIndexSet()
         indexSet.addIndex(1)
         indexSet.addIndex(3)
@@ -131,7 +131,7 @@ class TestNSOrderedSet : XCTestCase {
     }
 
     func test_GetObjects() {
-        let set = NSOrderedSet(array: ["foo", "bar", "baz"].bridge().bridge())
+        let set = NSOrderedSet(array: ["foo", "bar", "baz"] as NSArray as Array)
         var objects = [AnyObject]()
         set.getObjects(&objects, range: NSMakeRange(1, 2))
         XCTAssertEqual(objects[0] as? NSString, "bar")
@@ -139,22 +139,22 @@ class TestNSOrderedSet : XCTestCase {
     }
 
     func test_FirstAndLastObjects() {
-        let set = NSOrderedSet(array: ["foo", "bar", "baz"].bridge().bridge())
+        let set = NSOrderedSet(array: ["foo", "bar", "baz"] as NSArray as Array)
         XCTAssertEqual(set.firstObject as? NSString, "foo")
         XCTAssertEqual(set.lastObject as? NSString, "baz")
     }
 
     func test_AddObject() {
         let set = NSMutableOrderedSet()
-        set.addObject("1".bridge())
-        set.addObject("2".bridge())
+        set.addObject("1" as NSString)
+        set.addObject("2" as NSString)
         XCTAssertEqual(set[0] as? NSString, "1")
         XCTAssertEqual(set[1] as? NSString, "2")
     }
 
     func test_AddObjects() {
         let set = NSMutableOrderedSet()
-        set.addObjectsFromArray(["foo", "bar", "baz"].bridge().bridge())
+        set.addObjectsFromArray(["foo", "bar", "baz"] as NSArray as Array)
         XCTAssertEqual(set.objectAtIndex(0) as? NSString, "foo")
         XCTAssertEqual(set.objectAtIndex(1) as? NSString, "bar")
         XCTAssertEqual(set.objectAtIndex(2) as? NSString, "baz")
@@ -162,7 +162,7 @@ class TestNSOrderedSet : XCTestCase {
 
     func test_RemoveAllObjects() {
         let set = NSMutableOrderedSet()
-        set.addObjectsFromArray(["foo", "bar", "baz"].bridge().bridge())
+        set.addObjectsFromArray(["foo", "bar", "baz"] as NSArray as Array)
         XCTAssertEqual(set.indexOfObject("foo" as NSString), 0)
         set.removeAllObjects()
         XCTAssertEqual(set.count, 0)
@@ -171,7 +171,7 @@ class TestNSOrderedSet : XCTestCase {
 
     func test_RemoveObject() {
         let set = NSMutableOrderedSet()
-        set.addObjectsFromArray(["foo", "bar", "baz"].bridge().bridge())
+        set.addObjectsFromArray(["foo", "bar", "baz"] as NSArray as Array)
         set.removeObject("bar" as NSString)
         XCTAssertEqual(set.count, 2)
         XCTAssertEqual(set.indexOfObject("baz" as NSString), 1)
@@ -179,25 +179,25 @@ class TestNSOrderedSet : XCTestCase {
 
     func test_RemoveObjectAtIndex() {
         let set = NSMutableOrderedSet()
-        set.addObjectsFromArray(["foo", "bar", "baz"].bridge().bridge())
+        set.addObjectsFromArray(["foo", "bar", "baz"] as NSArray as Array)
         set.removeObjectAtIndex(1)
         XCTAssertEqual(set.count, 2)
         XCTAssertEqual(set.indexOfObject("baz" as NSString), 1)
     }
 
     func test_IsEqualToOrderedSet() {
-        let set = NSOrderedSet(array: ["foo", "bar", "baz"].bridge().bridge())
-        let otherSet = NSOrderedSet(array: ["foo", "bar", "baz"].bridge().bridge())
-        let otherOtherSet = NSOrderedSet(array: ["foo", "bar", "123"].bridge().bridge())
+        let set = NSOrderedSet(array: ["foo", "bar", "baz"] as NSArray as Array)
+        let otherSet = NSOrderedSet(array: ["foo", "bar", "baz"] as NSArray as Array)
+        let otherOtherSet = NSOrderedSet(array: ["foo", "bar", "123"] as NSArray as Array)
         XCTAssert(set.isEqualToOrderedSet(otherSet))
         XCTAssertFalse(set.isEqualToOrderedSet(otherOtherSet))
     }
 
     func test_Subsets() {
-        let set = NSOrderedSet(array: ["foo", "bar", "baz"].bridge().bridge())
-        let otherOrderedSet = NSOrderedSet(array: ["foo", "bar"].bridge().bridge())
+        let set = NSOrderedSet(array: ["foo", "bar", "baz"] as NSArray as Array)
+        let otherOrderedSet = NSOrderedSet(array: ["foo", "bar"] as NSArray as Array)
         let otherSet = Set<NSObject>(["foo" as NSString, "baz" as NSString])
-        let otherOtherSet = Set<NSObject>(["foo".bridge(), "bar".bridge(), "baz".bridge(), "123".bridge()])
+        let otherOtherSet = Set<NSObject>(["foo" as NSString, "bar" as NSString, "baz" as NSString, "123" as NSString])
         XCTAssert(otherOrderedSet.isSubsetOfOrderedSet(set))
         XCTAssertFalse(set.isSubsetOfOrderedSet(otherOrderedSet))
         XCTAssertFalse(set.isSubsetOfSet(otherSet))
@@ -205,8 +205,8 @@ class TestNSOrderedSet : XCTestCase {
     }
 
     func test_ReplaceObject() {
-        let set = NSMutableOrderedSet(arrayLiteral: "foo".bridge(), "bar".bridge(), "baz".bridge())
-        set.replaceObjectAtIndex(1, withObject: "123".bridge())
+        let set = NSMutableOrderedSet(arrayLiteral: "foo" as NSString, "bar" as NSString, "baz" as NSString)
+        set.replaceObjectAtIndex(1, withObject: "123" as NSString)
         XCTAssertEqual(set.count, 3)
         XCTAssertEqual(set[0] as? NSString, "foo")
         XCTAssertEqual(set[1] as? NSString, "123")
@@ -214,7 +214,7 @@ class TestNSOrderedSet : XCTestCase {
     }
 
     func test_ExchangeObjects() {
-        let set = NSMutableOrderedSet(arrayLiteral: "foo".bridge(), "bar".bridge(), "baz".bridge())
+        let set = NSMutableOrderedSet(arrayLiteral: "foo" as NSString, "bar" as NSString, "baz" as NSString)
         set.exchangeObjectAtIndex(0, withObjectAtIndex: 2)
         XCTAssertEqual(set.count, 3)
         XCTAssertEqual(set[0] as? NSString, "baz")
@@ -223,7 +223,7 @@ class TestNSOrderedSet : XCTestCase {
     }
 
     func test_MoveObjects() {
-        let set = NSMutableOrderedSet(arrayLiteral: "foo".bridge(), "bar".bridge(), "baz".bridge(), "123".bridge(), "456".bridge())
+        let set = NSMutableOrderedSet(arrayLiteral: "foo" as NSString, "bar" as NSString, "baz" as NSString, "123" as NSString, "456" as NSString)
         let indexes = NSMutableIndexSet()
         indexes.addIndex(1)
         indexes.addIndex(2)
@@ -238,11 +238,11 @@ class TestNSOrderedSet : XCTestCase {
     }
 
     func test_InsertObjects() {
-        let set = NSMutableOrderedSet(arrayLiteral: "foo".bridge(), "bar".bridge(), "baz".bridge())
+        let set = NSMutableOrderedSet(arrayLiteral: "foo" as NSString, "bar" as NSString, "baz" as NSString)
         let indexes = NSMutableIndexSet()
         indexes.addIndex(1)
         indexes.addIndex(3)
-        set.insertObjects(["123".bridge(), "456".bridge()], atIndexes: indexes)
+        set.insertObjects(["123" as NSString, "456" as NSString], atIndexes: indexes)
         XCTAssertEqual(set.count, 5)
         XCTAssertEqual(set[0] as? NSString, "foo")
         XCTAssertEqual(set[1] as? NSString, "123")
@@ -252,17 +252,17 @@ class TestNSOrderedSet : XCTestCase {
     }
 
     func test_SetObjectAtIndex() {
-        let set = NSMutableOrderedSet(arrayLiteral: "foo".bridge(), "bar".bridge(), "baz".bridge())
-        set.setObject("123".bridge(), atIndex: 1)
+        let set = NSMutableOrderedSet(arrayLiteral: "foo" as NSString, "bar" as NSString, "baz" as NSString)
+        set.setObject("123" as NSString, atIndex: 1)
         XCTAssertEqual(set[0] as? NSString, "foo")
         XCTAssertEqual(set[1] as? NSString, "123")
         XCTAssertEqual(set[2] as? NSString, "baz")
-        set.setObject("456".bridge(), atIndex: 3)
+        set.setObject("456" as NSString, atIndex: 3)
         XCTAssertEqual(set[3] as? NSString, "456")
     }
 
     func test_RemoveObjectsInRange() {
-        let set = NSMutableOrderedSet(arrayLiteral: "foo".bridge(), "bar".bridge(), "baz".bridge(), "123".bridge(), "456".bridge())
+        let set = NSMutableOrderedSet(arrayLiteral: "foo" as NSString, "bar" as NSString, "baz" as NSString, "123" as NSString, "456" as NSString)
         set.removeObjectsInRange(NSMakeRange(1, 2))
         XCTAssertEqual(set.count, 3)
         XCTAssertEqual(set[0] as? NSString, "foo")
@@ -271,11 +271,11 @@ class TestNSOrderedSet : XCTestCase {
     }
 
     func test_ReplaceObjectsAtIndexes() {
-        let set = NSMutableOrderedSet(arrayLiteral: "foo".bridge(), "bar".bridge(), "baz".bridge())
+        let set = NSMutableOrderedSet(arrayLiteral: "foo" as NSString, "bar" as NSString, "baz" as NSString)
         let indexes = NSMutableIndexSet()
         indexes.addIndex(0)
         indexes.addIndex(2)
-        set.replaceObjectsAtIndexes(indexes, withObjects: ["a".bridge(), "b".bridge()])
+        set.replaceObjectsAtIndexes(indexes, withObjects: ["a" as NSString, "b" as NSString])
         XCTAssertEqual(set.count, 3)
         XCTAssertEqual(set[0] as? NSString, "a")
         XCTAssertEqual(set[1] as? NSString, "bar")
@@ -283,10 +283,10 @@ class TestNSOrderedSet : XCTestCase {
     }
 
     func test_Intersection() {
-        let set = NSMutableOrderedSet(arrayLiteral: "foo".bridge(), "bar".bridge(), "baz".bridge())
-        let otherSet = NSOrderedSet(array: ["foo", "baz"].bridge().bridge())
+        let set = NSMutableOrderedSet(arrayLiteral: "foo" as NSString, "bar" as NSString, "baz" as NSString)
+        let otherSet = NSOrderedSet(array: ["foo", "baz"] as NSArray as Array)
         XCTAssert(set.intersectsOrderedSet(otherSet))
-        let otherOtherSet = Set<NSObject>(["foo".bridge(), "123".bridge()])
+        let otherOtherSet = Set<NSObject>(["foo" as NSString, "123" as NSString])
         XCTAssert(set.intersectsSet(otherOtherSet))
         set.intersectOrderedSet(otherSet)
         XCTAssertEqual(set.count, 2)
@@ -296,14 +296,14 @@ class TestNSOrderedSet : XCTestCase {
         XCTAssertEqual(set.count, 1)
         XCTAssertEqual(set[0] as? NSString, "foo")
 
-        let nonIntersectingSet = Set<NSObject>(["asdf".bridge()])
+        let nonIntersectingSet = Set<NSObject>(["asdf" as NSString])
         XCTAssertFalse(set.intersectsSet(nonIntersectingSet))
     }
 
     func test_Subtraction() {
-        let set = NSMutableOrderedSet(arrayLiteral: "foo".bridge(), "bar".bridge(), "baz".bridge())
-        let otherSet = NSOrderedSet(array: ["baz"].bridge().bridge())
-        let otherOtherSet = Set<NSObject>(["foo".bridge()])
+        let set = NSMutableOrderedSet(arrayLiteral: "foo" as NSString, "bar" as NSString, "baz" as NSString)
+        let otherSet = NSOrderedSet(array: ["baz"] as NSArray as Array)
+        let otherOtherSet = Set<NSObject>(["foo" as NSString])
         set.minusOrderedSet(otherSet)
         XCTAssertEqual(set.count, 2)
         XCTAssertEqual(set[0] as? NSString, "foo")
@@ -314,9 +314,9 @@ class TestNSOrderedSet : XCTestCase {
     }
 
     func test_Union() {
-        let set = NSMutableOrderedSet(arrayLiteral: "foo".bridge(), "bar".bridge(), "baz".bridge())
-        let otherSet = NSOrderedSet(array: ["123", "baz"].bridge().bridge())
-        let otherOtherSet = Set<NSObject>(["foo".bridge(), "456".bridge()])
+        let set = NSMutableOrderedSet(arrayLiteral: "foo" as NSString, "bar" as NSString, "baz" as NSString)
+        let otherSet = NSOrderedSet(array: ["123", "baz"] as NSArray as Array)
+        let otherOtherSet = Set<NSObject>(["foo" as NSString, "456" as NSString])
         set.unionOrderedSet(otherSet)
         XCTAssertEqual(set.count, 4)
         XCTAssertEqual(set[0] as? NSString, "foo")
@@ -330,22 +330,22 @@ class TestNSOrderedSet : XCTestCase {
 
     func test_Initializers() {
         let copyableObject = NSObject()
-        let set = NSMutableOrderedSet(arrayLiteral: copyableObject, "bar".bridge(), "baz".bridge())
+        let set = NSMutableOrderedSet(arrayLiteral: copyableObject, "bar" as NSString, "baz" as NSString)
         let newSet = NSOrderedSet(orderedSet: set)
         XCTAssert(newSet.isEqualToOrderedSet(set))
         XCTAssert(set[0] === newSet[0])
 
-        let unorderedSet = Set<NSObject>(["foo".bridge(), "bar".bridge(), "baz".bridge()])
+        let unorderedSet = Set<NSObject>(["foo" as NSString, "bar" as NSString, "baz" as NSString])
         let newSetFromUnorderedSet = NSOrderedSet(set: unorderedSet)
         XCTAssertEqual(newSetFromUnorderedSet.count, 3)
-        XCTAssert(newSetFromUnorderedSet.containsObject("foo".bridge()))
+        XCTAssert(newSetFromUnorderedSet.containsObject("foo" as NSString))
     }
 
     func test_Sorting() {
-        let set = NSMutableOrderedSet(arrayLiteral: "a".bridge(), "d".bridge(), "c".bridge(), "b".bridge())
+        let set = NSMutableOrderedSet(arrayLiteral: "a" as NSString, "d" as NSString, "c" as NSString, "b" as NSString)
         set.sortUsingComparator { lhs, rhs in
             if let lhs = lhs as? NSString, rhs = rhs as? NSString {
-                return lhs.compare(rhs.bridge())
+                return lhs.compare(rhs as String)
             }
             return NSComparisonResult.OrderedSame
         }
@@ -356,7 +356,7 @@ class TestNSOrderedSet : XCTestCase {
 
         set.sortRange(NSMakeRange(1, 2), options: []) { lhs, rhs in
             if let lhs = lhs as? NSString, rhs = rhs as? NSString {
-                return rhs.compare(lhs.bridge())
+                return rhs.compare(lhs as String)
             }
             return NSComparisonResult.OrderedSame
         }

--- a/TestFoundation/TestNSPipe.swift
+++ b/TestFoundation/TestNSPipe.swift
@@ -31,7 +31,7 @@ class TestNSPipe : XCTestCase {
         let text = "test-pipe"
         
         // First write some data into the pipe
-        let stringAsData = text.bridge().dataUsingEncoding(NSUTF8StringEncoding)
+        let stringAsData = (text as NSString).dataUsingEncoding(NSUTF8StringEncoding)
         XCTAssertNotNil(stringAsData)
         aPipe.fileHandleForWriting.writeData(stringAsData!)
         

--- a/TestFoundation/TestNSProcessInfo.swift
+++ b/TestFoundation/TestNSProcessInfo.swift
@@ -57,13 +57,13 @@ class TestNSProcessInfo : XCTestCase {
     
     func test_globallyUniqueString() {
         let uuid = NSProcessInfo.processInfo().globallyUniqueString
-        let parts = uuid.bridge().componentsSeparatedByString("-")
+        let parts = (uuid as NSString).componentsSeparatedByString("-")
         XCTAssertEqual(parts.count, 5)
-        XCTAssertEqual(parts[0].bridge().length, 8)
-        XCTAssertEqual(parts[1].bridge().length, 4)
-        XCTAssertEqual(parts[2].bridge().length, 4)
-        XCTAssertEqual(parts[3].bridge().length, 4)
-        XCTAssertEqual(parts[4].bridge().length, 12)
+        XCTAssertEqual((parts[0] as String).length, 8)
+        XCTAssertEqual((parts[1] as String).length, 4)
+        XCTAssertEqual((parts[2] as String).length, 4)
+        XCTAssertEqual((parts[3] as String).length, 4)
+        XCTAssertEqual((parts[4] as String).length, 12)
     }
     
 }

--- a/TestFoundation/TestNSRegularExpression.swift
+++ b/TestFoundation/TestNSRegularExpression.swift
@@ -31,7 +31,7 @@ class TestNSRegularExpression : XCTestCase {
     
     func simpleRegularExpressionTestWithPattern(_ patternString: String, target searchString: String, looking: Bool, match: Bool, file: StaticString = #file, line: UInt = #line) {
         do {
-            let str = searchString.bridge()
+            let str = searchString as NSString
             var range = NSMakeRange(0, str.length)
             let regex = try NSRegularExpression(pattern: patternString, options: [])
             do {
@@ -54,7 +54,7 @@ class TestNSRegularExpression : XCTestCase {
             do {
                 let prefixString = "when in the course of human events "
                 let suffixString = " becomes necessary"
-                let searchString2 = "\(prefixString)\(searchString)\(suffixString)".bridge()
+                let searchString2 = "\(prefixString)\(searchString)\(suffixString)" as NSString
                 range.location = prefixString.utf16.count
                 let lookingRange = searchString2.rangeOfString(patternString, options: [.RegularExpressionSearch, .AnchoredSearch], range: range, locale: nil)
                 let matchRange = searchString2.rangeOfString(patternString, options: [.RegularExpressionSearch], range: range, locale: nil)
@@ -68,7 +68,7 @@ class TestNSRegularExpression : XCTestCase {
             if !patternString.hasPrefix(".") {
                 let prefixString = "when in the course of human events "
                 let suffixString = " becomes necessary becomes necessary becomes necessary becomes necessary becomes necessary becomes necessary becomes necessary becomes necessary becomes necessary becomes necessary becomes necessary becomes necessary becomes necessary becomes necessary becomes necessary"
-                let searchString2 = "\(prefixString)\(searchString)\(suffixString)".bridge()
+                let searchString2 = "\(prefixString)\(searchString)\(suffixString)" as NSString
                 range.location = prefixString.utf16.count
                 let lookingRange = searchString2.rangeOfString(patternString, options:  [.RegularExpressionSearch, .AnchoredSearch], range: NSMakeRange(range.location, range.length + suffixString.utf16.count), locale: nil)
                 let matchRange = searchString2.rangeOfString(patternString, options: .RegularExpressionSearch, range: NSMakeRange(range.location, range.length + suffixString.utf16.count), locale: nil)
@@ -82,7 +82,7 @@ class TestNSRegularExpression : XCTestCase {
             do {
                 let prefixString = "when in the course of human events "
                 let suffixString = " becomes necessary’"
-                let searchString2 = "\(prefixString)\(searchString)\(suffixString)".bridge()
+                let searchString2 = "\(prefixString)\(searchString)\(suffixString)" as NSString
                 range.location = prefixString.utf16.count
                 let lookingRange = searchString2.rangeOfString(patternString, options: [.RegularExpressionSearch, .AnchoredSearch], range: range, locale: nil)
                 let matchRange = searchString2.rangeOfString(patternString, options: [.RegularExpressionSearch], range: range, locale: nil)
@@ -165,12 +165,12 @@ class TestNSRegularExpression : XCTestCase {
     func replaceRegularExpressionTest(_ patternString: String, _ patternOptions: NSRegularExpressionOptions, _ searchString: String, _ searchOptions: NSMatchingOptions, _ searchRange: NSRange, _ templ: String, _ numberOfMatches: Int, _ result: String, file: StaticString = #file, line: UInt = #line) {
         do {
             let regex = try NSRegularExpression(pattern: patternString, options: patternOptions)
-            let mutableString = searchString.bridge().mutableCopy() as! NSMutableString
+            let mutableString = (searchString as NSString).mutableCopy() as! NSMutableString
             let matchCount = regex.replaceMatches(in: mutableString, options: searchOptions, range: searchRange, withTemplate: templ)
             let replacedString = regex.stringByReplacingMatches(in: searchString, options: searchOptions, range: searchRange, withTemplate: templ)
             XCTAssertEqual(numberOfMatches, matchCount, "Regex replace \(patternString) in \(searchString) with \(templ) number \(matchCount) should be \(numberOfMatches)", file: file, line: line)
             XCTAssertEqual(result, replacedString, "Regex replace \(patternString) in \(searchString) with \(templ) replaced \(replacedString) should be \(result)", file: file, line: line)
-            XCTAssertEqual(result, mutableString.bridge(), "Regex replace \(patternString) in \(searchString) with \(templ) mutated \(mutableString) should be \(result)", file: file, line: line)
+            XCTAssertEqual(result, mutableString as String, "Regex replace \(patternString) in \(searchString) with \(templ) mutated \(mutableString) should be \(result)", file: file, line: line)
         } catch {
             XCTFail("Unable to construct regular expression from \(patternString) options \(patternOptions)", file: file, line: line)
         }

--- a/TestFoundation/TestNSSet.swift
+++ b/TestFoundation/TestNSSet.swift
@@ -41,13 +41,13 @@ class TestNSSet : XCTestCase {
     
     func test_BasicConstruction() {
         let set = NSSet()
-        let set2 = NSSet(array: ["foo", "bar"].bridge().bridge())
+        let set2 = NSSet(array: ["foo", "bar"] as NSArray as Array<AnyObject>)
         XCTAssertEqual(set.count, 0)
         XCTAssertEqual(set2.count, 2)
     }
 
     func testInitWithSet() {
-        let genres: Set<NSObject> = ["Rock".bridge(), "Classical".bridge(), "Hip hop".bridge()]
+        let genres: Set<NSObject> = ["Rock" as NSString, "Classical" as NSString, "Hip hop" as NSString]
         let set1 = NSSet(set: genres)
         let set2 = NSSet(set: genres, copyItems: false)
         XCTAssertEqual(set1.count, 3)
@@ -60,12 +60,12 @@ class TestNSSet : XCTestCase {
     }
     
     func test_enumeration() {
-        let set = NSSet(array: ["foo", "bar", "baz"].bridge().bridge())
+        let set = NSSet(array: ["foo", "bar", "baz"] as NSArray as Array)
         let e = set.objectEnumerator()
         var result = Set<String>()
-        result.insert((e.nextObject()! as! NSString).bridge())
-        result.insert((e.nextObject()! as! NSString).bridge())
-        result.insert((e.nextObject()! as! NSString).bridge())
+        result.insert((e.nextObject()! as! NSString) as String)
+        result.insert((e.nextObject()! as! NSString) as String)
+        result.insert((e.nextObject()! as! NSString) as String)
         XCTAssertEqual(result, Set(["foo", "bar", "baz"]))
         
         let empty = NSSet().objectEnumerator()
@@ -74,45 +74,45 @@ class TestNSSet : XCTestCase {
     }
     
     func test_sequenceType() {
-        let set = NSSet(array: ["foo", "bar", "baz"].bridge().bridge())
+        let set = NSSet(array: ["foo", "bar", "baz"] as NSArray as Array)
         var res = Set<String>()
         for obj in set {
-            res.insert((obj as! NSString).bridge())
+            res.insert((obj as! NSString) as String)
         }
         XCTAssertEqual(res, Set(["foo", "bar", "baz"]))
     }
     
     func test_setOperations() {
-        let set = NSMutableSet(array: ["foo", "bar"].bridge().bridge())
-        set.unionSet(["bar".bridge(), "baz".bridge()])
-        XCTAssertTrue(set.isEqualToSet(["foo".bridge(), "bar".bridge(), "baz".bridge()]))
+        let set = NSMutableSet(array: ["foo", "bar"] as NSArray as Array)
+        set.unionSet(["bar" as NSString, "baz" as NSString])
+        XCTAssertTrue(set.isEqualToSet(["foo" as NSString, "bar" as NSString, "baz" as NSString]))
     }
 
     func test_equality() {
-        let inputArray1 = ["this", "is", "a", "test", "of", "equality", "with", "strings"].bridge()
-        let inputArray2 = ["this", "is", "a", "test", "of", "equality", "with", "objects"].bridge()
-        let set1 = NSSet(array: inputArray1.bridge())
-        let set2 = NSSet(array: inputArray1.bridge())
-        let set3 = NSSet(array: inputArray2.bridge())
+        let inputArray1 = ["this", "is", "a", "test", "of", "equality", "with", "strings"] as NSArray
+        let inputArray2 = ["this", "is", "a", "test", "of", "equality", "with", "objects"] as NSArray
+        let set1 = NSSet(array: inputArray1 as Array)
+        let set2 = NSSet(array: inputArray1 as Array)
+        let set3 = NSSet(array: inputArray2 as Array)
 
         XCTAssertTrue(set1 == set2)
         XCTAssertTrue(set1.isEqual(set2))
-        XCTAssertTrue(set1.isEqualToSet(set2.bridge()))
+        XCTAssertTrue(set1.isEqualToSet(set2 as! Set))
         XCTAssertEqual(set1.hash, set2.hash)
         XCTAssertEqual(set1.hashValue, set2.hashValue)
 
         XCTAssertFalse(set1 == set3)
         XCTAssertFalse(set1.isEqual(set3))
-        XCTAssertFalse(set1.isEqualToSet(set3.bridge()))
+        XCTAssertFalse(set1.isEqualToSet(set3 as! Set))
 
         XCTAssertFalse(set1.isEqual(nil))
         XCTAssertFalse(set1.isEqual(NSObject()))
     }
 
     func test_copying() {
-        let inputArray = ["this", "is", "a", "test", "of", "copy", "with", "strings"].bridge()
+        let inputArray = ["this", "is", "a", "test", "of", "copy", "with", "strings"] as NSArray
         
-        let set = NSSet(array: inputArray.bridge())
+        let set = NSSet(array: inputArray as Array)
         let setCopy1 = set.copy() as! NSSet
         XCTAssertTrue(set === setCopy1)
 
@@ -121,33 +121,33 @@ class TestNSSet : XCTestCase {
         XCTAssertTrue(setCopy2.dynamicType === NSSet.self)
         XCTAssertFalse(setMutableCopy === setCopy2)
         for entry in setCopy2 {
-            XCTAssertTrue(setMutableCopy.allObjects.bridge().indexOfObjectIdenticalTo(entry) != NSNotFound)
+            XCTAssertTrue((setMutableCopy.allObjects as NSArray).indexOfObjectIdenticalTo(entry) != NSNotFound)
         }
     }
 
     func test_mutableCopying() {
-        let inputArray = ["this", "is", "a", "test", "of", "mutableCopy", "with", "strings"].bridge()
-        let set = NSSet(array: inputArray.bridge())
+        let inputArray = ["this", "is", "a", "test", "of", "mutableCopy", "with", "strings"] as NSArray
+        let set = NSSet(array: inputArray as Array)
 
         let setMutableCopy1 = set.mutableCopy() as! NSMutableSet
         XCTAssertTrue(setMutableCopy1.dynamicType === NSMutableSet.self)
         XCTAssertFalse(set === setMutableCopy1)
         for entry in setMutableCopy1 {
-            XCTAssertTrue(set.allObjects.bridge().indexOfObjectIdenticalTo(entry) != NSNotFound)
+            XCTAssertTrue((set.allObjects as NSArray).indexOfObjectIdenticalTo(entry) != NSNotFound)
         }
 
         let setMutableCopy2 = setMutableCopy1.mutableCopy() as! NSMutableSet
         XCTAssertTrue(setMutableCopy2.dynamicType === NSMutableSet.self)
         XCTAssertFalse(setMutableCopy2 === setMutableCopy1)
         for entry in setMutableCopy2 {
-            XCTAssertTrue(setMutableCopy1.allObjects.bridge().indexOfObjectIdenticalTo(entry) != NSNotFound)
+            XCTAssertTrue((setMutableCopy1.allObjects as NSArray).indexOfObjectIdenticalTo(entry) != NSNotFound)
         }
     }
 
     func test_CountedSetBasicConstruction() {
-        let v1 = "v1".bridge()
-        let v2 = "v2".bridge()
-        let v3asv1 = "v1".bridge()
+        let v1 = "v1" as NSString
+        let v2 = "v2" as NSString
+        let v3asv1 = "v1" as NSString
         let set = NSCountedSet()
         let set2 = NSCountedSet(array: [v1, v1, v2,v3asv1])
         let set3 = NSCountedSet(set: [v1, v1, v2,v3asv1])
@@ -161,9 +161,9 @@ class TestNSSet : XCTestCase {
     }
 
     func test_CountedSetObjectCount() {
-        let v1 = "v1".bridge()
-        let v2 = "v2".bridge()
-        let v3asv1 = "v1".bridge()
+        let v1 = "v1" as NSString
+        let v2 = "v2" as NSString
+        let v3asv1 = "v1" as NSString
         let set = NSCountedSet()
         let set2 = NSCountedSet(array: [v1, v1, v2,v3asv1])
         let set3 = NSCountedSet(set: [v1, v1, v2,v3asv1])
@@ -178,9 +178,9 @@ class TestNSSet : XCTestCase {
     }
 
     func test_CountedSetAddObject() {
-        let v1 = "v1".bridge()
-        let v2 = "v2".bridge()
-        let v3asv1 = "v1".bridge()
+        let v1 = "v1" as NSString
+        let v2 = "v2" as NSString
+        let v3asv1 = "v1" as NSString
         let set = NSCountedSet(array: [v1, v1, v2])
 
         XCTAssertEqual(set.countForObject(v1), 2)
@@ -194,8 +194,8 @@ class TestNSSet : XCTestCase {
 
 
     func test_CountedSetRemoveObject() {
-        let v1 = "v1".bridge()
-        let v2 = "v2".bridge()
+        let v1 = "v1" as NSString
+        let v2 = "v2" as NSString
         let set = NSCountedSet(array: [v1, v1, v2])
 
         XCTAssertEqual(set.countForObject(v1), 2)
@@ -212,9 +212,9 @@ class TestNSSet : XCTestCase {
     }
 
     func test_CountedSetCopying() {
-        let inputArray = ["this", "is", "a", "test", "of", "copy", "with", "strings"].bridge()
+        let inputArray = ["this", "is", "a", "test", "of", "copy", "with", "strings"] as NSArray
 
-        let set = NSCountedSet(array: inputArray.bridge())
+        let set = NSCountedSet(array: inputArray as Array)
         let setCopy = set.copy() as! NSCountedSet
         XCTAssertFalse(set === setCopy)
 
@@ -223,7 +223,7 @@ class TestNSSet : XCTestCase {
         XCTAssertTrue(setCopy.dynamicType === NSCountedSet.self)
         XCTAssertTrue(setMutableCopy.dynamicType === NSCountedSet.self)
         for entry in setCopy {
-            XCTAssertTrue(setMutableCopy.allObjects.bridge().indexOfObjectIdenticalTo(entry) != NSNotFound)
+            XCTAssertTrue((setMutableCopy.allObjects as NSArray).indexOfObjectIdenticalTo(entry) != NSNotFound)
         }
     }
 

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -106,14 +106,14 @@ class TestNSString : XCTestCase {
         let literalConversion: NSString = "literal"
         XCTAssertEqual(literalConversion.length, 7)
         
-        let nonLiteralConversion: NSString = "test\(self)".bridge()
+        let nonLiteralConversion: NSString = "test\(self)" as NSString
         XCTAssertTrue(nonLiteralConversion.length > 4)
         
-        let nonLiteral2: NSString = String(4).bridge()
+        let nonLiteral2: NSString = String(4) as NSString
         let t = nonLiteral2.characterAtIndex(0)
         XCTAssertTrue(t == 52)
         
-        let externalString: NSString = String.localizedNameOfStringEncoding(String.defaultCStringEncoding()).bridge()
+        let externalString: NSString = String.localizedNameOfStringEncoding(String.defaultCStringEncoding()) as NSString
         XCTAssertTrue(externalString.length >= 4)
         
         let cluster: NSString = "✌🏾"
@@ -382,8 +382,8 @@ class TestNSString : XCTestCase {
     func test_CFStringCreateMutableCopy() {
         let nsstring: NSString = "абВГ"
         let mCopy = CFStringCreateMutableCopy(kCFAllocatorSystemDefault, 0, unsafeBitCast(nsstring, to: CFString.self))
-        let str = unsafeBitCast(mCopy, to: NSString.self).bridge()
-        XCTAssertEqual(nsstring.bridge(), str)
+        let str = unsafeBitCast(mCopy, to: NSString.self) as String
+        XCTAssertEqual(nsstring as String, str)
     }
     
     // This test verifies that CFStringGetBytes with a UTF16 encoding works on an NSString backed by a Swift string
@@ -427,7 +427,7 @@ class TestNSString : XCTestCase {
         }
 
         let tmpPath = { (path: String) -> NSString in
-        	return "/tmp/\(path)".bridge()
+        	return "/tmp/\(path)" as NSString
         }
 
         do {
@@ -435,7 +435,7 @@ class TestNSString : XCTestCase {
             var outName: NSString?
             var matches: [NSString] = []
             _ = path.completePathIntoString(&outName, caseSensitive: false, matchesIntoArray: &matches, filterTypes: nil)
-            _ = try NSFileManager.defaultManager().contentsOfDirectory(at: NSURL(string: path.bridge())!, includingPropertiesForKeys: nil, options: [])
+            _ = try NSFileManager.defaultManager().contentsOfDirectory(at: NSURL(string: path as String)!, includingPropertiesForKeys: nil, options: [])
             XCTAssert(outName == "/", "If NSString is valid path to directory which has '/' suffix then outName is '/'.")
             // This assert fails on CI; https://bugs.swift.org/browse/SR-389
 //            XCTAssert(matches.count == content.count && matches.count == count, "If NSString is valid path to directory then matches contain all content of directory. expected \(content) but got \(matches)")
@@ -561,7 +561,7 @@ class TestNSString : XCTestCase {
             let count = path.completePathIntoString(&outName, caseSensitive: false, matchesIntoArray: &matches, filterTypes: nil)
             // Build directory at least contains executable itself and *.swiftmodule directory
             XCTAssert(matches.count == count && count >= 2, "Supports relative paths.")
-            XCTAssert(startWith(path.bridge(), strings: matches), "For relative paths matches are relative too.")
+            XCTAssert(startWith(path as String, strings: matches), "For relative paths matches are relative too.")
         }
         
         // Next check has no sense on Linux due to case sensitive file system.
@@ -594,7 +594,7 @@ class TestNSString : XCTestCase {
     }
     
     private func stringsAreCaseInsensitivelyEqual(_ lhs: NSString, _ rhs: NSString) -> Bool {
-    	return lhs.compare(rhs.bridge(), options: .CaseInsensitiveSearch) == .OrderedSame
+    	return lhs.compare(rhs as String, options: .CaseInsensitiveSearch) == .OrderedSame
     }
 
     func test_stringByTrimmingCharactersInSet() {
@@ -836,7 +836,7 @@ class TestNSString : XCTestCase {
         do {
             let path: NSString = "foo/bar"
             let result = path.stringByStandardizingPath
-            XCTAssertEqual(result, path.bridge(), "stringByStandardizingPath doesn't resolve relative paths")
+            XCTAssertEqual(result, path as String, "stringByStandardizingPath doesn't resolve relative paths")
         }
         
         // tmp is symlinked on OS X only
@@ -857,7 +857,7 @@ class TestNSString : XCTestCase {
         do {
             let path: NSString = "tmp/ABC/.."
             let result = path.stringByStandardizingPath
-            XCTAssertEqual(result, path.bridge(), "parent links could not be resolved for relative paths")
+            XCTAssertEqual(result, path as String, "parent links could not be resolved for relative paths")
         }
     }
 
@@ -1142,7 +1142,7 @@ func test_reflection() {
     let ql = PlaygroundQuickLook(reflecting: testString)
 
     switch ql {
-    case .text(let str): XCTAssertEqual(testString.bridge(), str)
+    case .text(let str): XCTAssertEqual(testString as String, str)
     default: XCTAssertTrue(false, "mismatched quicklook")
     }
 }

--- a/TestFoundation/TestNSTimeZone.swift
+++ b/TestFoundation/TestNSTimeZone.swift
@@ -62,7 +62,7 @@ class TestNSTimeZone: XCTestCase {
         var lt = tm()
         localtime_r(&t, &lt)
         let zoneName = NSTimeZone.systemTimeZone().abbreviation ?? "Invalid Abbreviation"
-        let expectedName = NSString(CString: lt.tm_zone, encoding: NSASCIIStringEncoding)?.bridge() ?? "Invalid Zone"
+        let expectedName = NSString(CString: lt.tm_zone, encoding: NSASCIIStringEncoding) as? String ?? "Invalid Zone"
         XCTAssertEqual(zoneName, expectedName, "expected name \"\(expectedName)\" is not equal to \"\(zoneName)\"")
     }
 }

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -267,7 +267,7 @@ class TestNSURL : XCTestCase {
     func test_fileURLWithPath() {
         if !TestNSURL.setup_test_paths() {
             let error = strerror(errno)
-            XCTFail("Failed to set up test paths: \(NSString(bytes: error, length: Int(strlen(error)), encoding: NSASCIIStringEncoding)!.bridge())")
+            XCTFail("Failed to set up test paths: \(NSString(bytes: error, length: Int(strlen(error)), encoding: NSASCIIStringEncoding) as! String)")
         }
         
         // test with file that exists
@@ -312,7 +312,7 @@ class TestNSURL : XCTestCase {
     func test_fileURLWithPath_isDirectory() {
         if !TestNSURL.setup_test_paths() {
             let error = strerror(errno)
-            XCTFail("Failed to set up test paths: \(NSString(bytes: error, length: Int(strlen(error)), encoding: NSASCIIStringEncoding)!.bridge())")
+            XCTFail("Failed to set up test paths: \(NSString(bytes: error, length: Int(strlen(error)), encoding: NSASCIIStringEncoding) as! String)")
         }
             
         // test with file that exists

--- a/TestFoundation/TestNSXMLDocument.swift
+++ b/TestFoundation/TestNSXMLDocument.swift
@@ -199,8 +199,8 @@ class TestNSXMLDocument : XCTestCase {
 
     func test_objectValue() {
         let element = NSXMLElement(name: "root")
-        let dict: [String: AnyObject] = ["hello": "world"._bridgeToObject()]
-        element.objectValue = dict._bridgeToObject()
+        let dict: [String: AnyObject] = ["hello": "world" as NSString]
+        element.objectValue = dict as NSDictionary
 
         XCTAssertEqual(element.XMLString, "<root>{\n    hello = world;\n}</root>", element.XMLString)
     }

--- a/TestFoundation/TestUtils.swift
+++ b/TestFoundation/TestUtils.swift
@@ -33,7 +33,7 @@ func ensureFiles(_ fileNames: [String]) -> Bool {
         } else {
         
             var isDir: ObjCBool = false
-            let dir = name.bridge().stringByDeletingLastPathComponent
+            let dir = (name as NSString).stringByDeletingLastPathComponent
             if !fm.fileExists(atPath: dir, isDirectory: &isDir) {
                 do {
                     try fm.createDirectory(atPath: dir, withIntermediateDirectories: true, attributes: nil)


### PR DESCRIPTION
This change replaces all bridge() calls in TestFoundation with the corresponding 'as' expressions.  It gets the same test results (Total executed 395 tests, with 1 failure (0 unexpected)) as an unmodified test suite.

Opening pull request for discussion.  I'm a bit behind the master branch of foundation because of the current problems with build stability.  Once things stabilize, I will rebase/merge as needed.

This pull request assumes that Swift pull request https://github.com/apple/swift/pull/1994 and Foundation pull request https://github.com/apple/swift-corelibs-foundation/pull/303 have been applied.