### PR TITLE
Changing NSFileManager API names to match Darwin version

### DIFF
--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -402,7 +402,7 @@ extension NSData {
         if fd == -1 {
             throw _NSErrorWithErrno(errno, reading: false, path: dirPath)
         }
-        let pathResult = NSFileManager.defaultManager().stringWithFileSystemRepresentation(buf, length: Int(strlen(buf)))
+        let pathResult = NSFileManager.defaultManager().string(withFileSystemRepresentation:buf, length: Int(strlen(buf)))
         return (fd, pathResult)
     }
     
@@ -462,7 +462,7 @@ extension NSData {
                 } catch let err {
                     if let auxFilePath = auxFilePath {
                         do {
-                            try NSFileManager.defaultManager().removeItemAtPath(auxFilePath)
+                            try NSFileManager.defaultManager().removeItem(atPath: auxFilePath)
                         } catch _ {}
                     }
                     throw err
@@ -472,7 +472,7 @@ extension NSData {
         if let auxFilePath = auxFilePath {
             if rename(auxFilePath, path) != 0 {
                 do {
-                    try NSFileManager.defaultManager().removeItemAtPath(auxFilePath)
+                    try NSFileManager.defaultManager().removeItem(atPath: auxFilePath)
                 } catch _ {}
                 throw _NSErrorWithErrno(errno, reading: false, path: path)
             }

--- a/Foundation/NSFileManager.swift
+++ b/Foundation/NSFileManager.swift
@@ -21,11 +21,11 @@ public struct NSVolumeEnumerationOptions : OptionSet {
     
     /* The mounted volume enumeration will skip hidden volumes.
      */
-    public static let SkipHiddenVolumes = NSVolumeEnumerationOptions(rawValue: 1 << 1)
+    public static let skipHiddenVolumes = NSVolumeEnumerationOptions(rawValue: 1 << 1)
     
     /* The mounted volume enumeration will produce file reference URLs rather than path-based URLs.
      */
-    public static let ProduceFileReferenceURLs = NSVolumeEnumerationOptions(rawValue: 1 << 2)
+    public static let produceFileReferenceURLs = NSVolumeEnumerationOptions(rawValue: 1 << 2)
 }
 
 public struct NSDirectoryEnumerationOptions : OptionSet {
@@ -34,15 +34,15 @@ public struct NSDirectoryEnumerationOptions : OptionSet {
     
     /* NSDirectoryEnumerationSkipsSubdirectoryDescendants causes the NSDirectoryEnumerator to perform a shallow enumeration and not descend into directories it encounters.
      */
-    public static let SkipsSubdirectoryDescendants = NSDirectoryEnumerationOptions(rawValue: 1 << 0)
+    public static let skipsSubdirectoryDescendants = NSDirectoryEnumerationOptions(rawValue: 1 << 0)
     
     /* NSDirectoryEnumerationSkipsPackageDescendants will cause the NSDirectoryEnumerator to not descend into packages.
      */
-    public static let SkipsPackageDescendants = NSDirectoryEnumerationOptions(rawValue: 1 << 1)
+    public static let skipsPackageDescendants = NSDirectoryEnumerationOptions(rawValue: 1 << 1)
     
     /* NSDirectoryEnumerationSkipsHiddenFiles causes the NSDirectoryEnumerator to not enumerate hidden files.
      */
-    public static let SkipsHiddenFiles = NSDirectoryEnumerationOptions(rawValue: 1 << 2)
+    public static let skipsHiddenFiles = NSDirectoryEnumerationOptions(rawValue: 1 << 2)
 }
 
 public struct NSFileManagerItemReplacementOptions : OptionSet {
@@ -51,17 +51,17 @@ public struct NSFileManagerItemReplacementOptions : OptionSet {
     
     /* NSFileManagerItemReplacementUsingNewMetadataOnly causes -replaceItemAtURL:withItemAtURL:backupItemName:options:resultingItemURL:error: to use metadata from the new item only and not to attempt to preserve metadata from the original item.
      */
-    public static let UsingNewMetadataOnly = NSFileManagerItemReplacementOptions(rawValue: 1 << 0)
+    public static let usingNewMetadataOnly = NSFileManagerItemReplacementOptions(rawValue: 1 << 0)
     
     /* NSFileManagerItemReplacementWithoutDeletingBackupItem causes -replaceItemAtURL:withItemAtURL:backupItemName:options:resultingItemURL:error: to leave the backup item in place after a successful replacement. The default behavior is to remove the item.
      */
-    public static let WithoutDeletingBackupItem = NSFileManagerItemReplacementOptions(rawValue: 1 << 1)
+    public static let withoutDeletingBackupItem = NSFileManagerItemReplacementOptions(rawValue: 1 << 1)
 }
 
 public enum NSURLRelationship : Int {
-    case Contains
-    case Same
-    case Other
+    case contains
+    case same
+    case other
 }
 
 public class NSFileManager : NSObject {
@@ -89,7 +89,7 @@ public class NSFileManager : NSObject {
      */
     public func contentsOfDirectory(at url: NSURL, includingPropertiesForKeys keys: [String]?, options mask: NSDirectoryEnumerationOptions = []) throws -> [NSURL] {
         var error : NSError? = nil
-        let e = self.enumerator(at: url, includingPropertiesForKeys: keys, options: mask.union(.SkipsSubdirectoryDescendants)) { (url, err) -> Bool in
+        let e = self.enumerator(at: url, includingPropertiesForKeys: keys, options: mask.union(.skipsSubdirectoryDescendants)) { (url, err) -> Bool in
             error = err
             return false
         }
@@ -660,7 +660,7 @@ public class NSFileManager : NSObject {
         If you wish to only receive the URLs and no other attributes, then pass '0' for 'options' and an empty NSArray ('[NSArray array]') for 'keys'. If you wish to have the property caches of the vended URLs pre-populated with a default set of attributes, then pass '0' for 'options' and 'nil' for 'keys'.
      */
     public func enumerator(at url: NSURL, includingPropertiesForKeys keys: [String]?, options mask: NSDirectoryEnumerationOptions = [], errorHandler handler: ((NSURL, NSError) -> Bool)? = nil) -> NSDirectoryEnumerator? {
-        if mask.contains(.SkipsPackageDescendants) || mask.contains(.SkipsHiddenFiles) {
+        if mask.contains(.skipsPackageDescendants) || mask.contains(.skipsHiddenFiles) {
             NSUnimplemented("Enumeration options not yet implemented")
         }
         return NSURLDirectoryEnumerator(url: url, options: mask, errorHandler: handler)
@@ -943,7 +943,7 @@ internal class NSURLDirectoryEnumerator : NSDirectoryEnumerator {
             while let current = _current {
                 switch Int32(current.pointee.fts_info) {
                     case FTS_D:
-                        if _options.contains(.SkipsSubdirectoryDescendants) {
+                        if _options.contains(.skipsSubdirectoryDescendants) {
                             fts_set(_stream, _current, FTS_SKIP)
                         }
                         fallthrough

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -148,7 +148,7 @@ public class NSKeyedArchiver : NSCoder {
                 if finishedEncoding {
                     try _NSCleanupTemporaryFile(auxFilePath, path)
                 } else {
-                    try NSFileManager.defaultManager().removeItemAtPath(auxFilePath)
+                    try NSFileManager.defaultManager().removeItem(atPath: auxFilePath)
                 }
             } catch _ {
             }

--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -455,7 +455,7 @@ public extension NSString {
     internal func _getNamesAtURL(_ filePathURL: NSURL, prependWith: String, namePredicate: _FileNamePredicate, typePredicate: _FileNamePredicate) -> [String] {
         var result: [String] = []
         
-        if let enumerator = NSFileManager.defaultManager().enumerator(at: filePathURL, includingPropertiesForKeys: nil, options: .SkipsSubdirectoryDescendants, errorHandler: nil) {
+        if let enumerator = NSFileManager.defaultManager().enumerator(at: filePathURL, includingPropertiesForKeys: nil, options: .skipsSubdirectoryDescendants, errorHandler: nil) {
             for item in enumerator.lazy.map({ $0 as! NSURL }) {
                 let itemName = item.lastPathComponent
                 

--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -146,7 +146,7 @@ internal extension String {
         }
         
         let temp = _stringByRemovingPrefix(prefix)
-        if NSFileManager.defaultManager().fileExistsAtPath(temp) {
+        if NSFileManager.defaultManager().fileExists(atPath: temp) {
             return temp
         }
         
@@ -446,7 +446,7 @@ public extension NSString {
         }
         
         var isDirectory = false
-        let exists = NSFileManager.defaultManager().fileExistsAtPath(path, isDirectory: &isDirectory)
+        let exists = NSFileManager.defaultManager().fileExists(atPath: path, isDirectory: &isDirectory)
         return exists && isDirectory
     }
     
@@ -455,7 +455,7 @@ public extension NSString {
     internal func _getNamesAtURL(_ filePathURL: NSURL, prependWith: String, namePredicate: _FileNamePredicate, typePredicate: _FileNamePredicate) -> [String] {
         var result: [String] = []
         
-        if let enumerator = NSFileManager.defaultManager().enumeratorAtURL(filePathURL, includingPropertiesForKeys: nil, options: .SkipsSubdirectoryDescendants, errorHandler: nil) {
+        if let enumerator = NSFileManager.defaultManager().enumerator(at: filePathURL, includingPropertiesForKeys: nil, options: .SkipsSubdirectoryDescendants, errorHandler: nil) {
             for item in enumerator.lazy.map({ $0 as! NSURL }) {
                 let itemName = item.lastPathComponent
                 
@@ -635,14 +635,14 @@ internal func _NSCreateTemporaryFile(_ filePath: String) throws -> (Int32, Strin
     if fd == -1 {
         throw _NSErrorWithErrno(errno, reading: false, path: filePath)
     }
-    let pathResult = NSFileManager.defaultManager().stringWithFileSystemRepresentation(buf, length: Int(strlen(buf)))
+    let pathResult = NSFileManager.defaultManager().string(withFileSystemRepresentation: buf, length: Int(strlen(buf)))
     return (fd, pathResult)
 }
 
 internal func _NSCleanupTemporaryFile(_ auxFilePath: String, _ filePath: String) throws  {
     if rename(auxFilePath, filePath) != 0 {
         do {
-            try NSFileManager.defaultManager().removeItemAtPath(auxFilePath)
+            try NSFileManager.defaultManager().removeItem(atPath: auxFilePath)
         } catch _ {
         }
         throw _NSErrorWithErrno(errno, reading: false, path: filePath)

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -136,7 +136,7 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
             } else {
                 absolutePath = path
             }
-            NSFileManager.defaultManager().fileExistsAtPath(absolutePath, isDirectory: &isDir)
+            NSFileManager.defaultManager().fileExists(atPath: absolutePath, isDirectory: &isDir)
         }
 
         self.init(fileURLWithPath: thePath, isDirectory: isDir, relativeToURL: baseURL)
@@ -153,7 +153,7 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
         if thePath.hasSuffix("/") {
             isDir = true
         } else {
-            NSFileManager.defaultManager().fileExistsAtPath(path, isDirectory: &isDir)
+            NSFileManager.defaultManager().fileExists(atPath: path, isDirectory: &isDir)
         }
 
         self.init(fileURLWithPath: thePath, isDirectory: isDir, relativeToURL: nil)
@@ -482,7 +482,7 @@ extension NSURL {
         if !pathComponent.hasSuffix("/") && fileURL {
             if let urlWithoutDirectory = result, path = urlWithoutDirectory.path {
                 var isDir : Bool = false
-                if NSFileManager.defaultManager().fileExistsAtPath(path, isDirectory: &isDir) && isDir {
+                if NSFileManager.defaultManager().fileExists(atPath: path, isDirectory: &isDir) && isDir {
                     result = self.URLByAppendingPathComponent(pathComponent, isDirectory: true)
                 }
             }
@@ -561,7 +561,7 @@ extension NSURL {
         
         // It might be a responsibility of NSURL(fileURLWithPath:). Check it.
         var isExistingDirectory = false
-        NSFileManager.defaultManager().fileExistsAtPath(resolvedPath, isDirectory: &isExistingDirectory)
+        NSFileManager.defaultManager().fileExists(atPath: resolvedPath, isDirectory: &isExistingDirectory)
         
         if excludeSystemDirs {
             resolvedPath = resolvedPath._tryToRemovePathPrefix("/private") ?? resolvedPath

--- a/TestFoundation/TestNSBundle.swift
+++ b/TestFoundation/TestNSBundle.swift
@@ -64,7 +64,7 @@ class TestNSBundle : XCTestCase {
         let testPlist = bundle.URLForResource("Test", withExtension: "plist")
         XCTAssertNotNil(testPlist)
         XCTAssertEqual("Test.plist", testPlist!.lastPathComponent)
-        XCTAssert(NSFileManager.defaultManager().fileExistsAtPath(testPlist!.path!))
+        XCTAssert(NSFileManager.defaultManager().fileExists(atPath: testPlist!.path!))
         
         // aliases, paths
         XCTAssertEqual(testPlist!.path, bundle.URLForResource("Test", withExtension: "plist", subdirectory: nil)!.path)
@@ -107,20 +107,20 @@ class TestNSBundle : XCTestCase {
         let tempDir = "/tmp/TestFoundation_Playground_" + NSUUID().UUIDString + "/"
         
         do {
-            try NSFileManager.defaultManager().createDirectoryAtPath(tempDir, withIntermediateDirectories: false, attributes: nil)
+            try NSFileManager.defaultManager().createDirectory(atPath: tempDir, withIntermediateDirectories: false, attributes: nil)
             
             // Make a flat bundle in the playground
             let bundlePath = tempDir + _bundleName
-            try NSFileManager.defaultManager().createDirectoryAtPath(bundlePath, withIntermediateDirectories: false, attributes: nil)
+            try NSFileManager.defaultManager().createDirectory(atPath: bundlePath, withIntermediateDirectories: false, attributes: nil)
             
             // Put some resources in the bundle
             for n in _bundleResourceNames {
-                NSFileManager.defaultManager().createFileAtPath(bundlePath + "/" + n, contents: nil, attributes: nil)
+                NSFileManager.defaultManager().createFile(atPath: bundlePath + "/" + n, contents: nil, attributes: nil)
             }
             // Add a resource into a subdirectory
             let subDirPath = bundlePath + "/" + _subDirectory
-            try NSFileManager.defaultManager().createDirectoryAtPath(subDirPath, withIntermediateDirectories: false, attributes: nil)
-            NSFileManager.defaultManager().createFileAtPath(subDirPath + "/" + _main + "." + _type, contents: nil, attributes: nil)
+            try NSFileManager.defaultManager().createDirectory(atPath: subDirPath, withIntermediateDirectories: false, attributes: nil)
+            NSFileManager.defaultManager().createFile(atPath: subDirPath + "/" + _main + "." + _type, contents: nil, attributes: nil)
         } catch _ {
             return nil
         }
@@ -131,7 +131,7 @@ class TestNSBundle : XCTestCase {
     
     private func _cleanupPlayground(_ location: String) {
         do {
-            try NSFileManager.defaultManager().removeItemAtPath(location)
+            try NSFileManager.defaultManager().removeItem(atPath: location)
         } catch _ {
             // Oh well
         }

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -49,8 +49,8 @@ class TestNSData: XCTestCase {
         do {
             try saveData!.writeToFile(savePath, options: NSDataWritingOptions.DataWritingAtomic)
             let fileManager = NSFileManager.defaultManager()
-            XCTAssertTrue(fileManager.fileExistsAtPath(savePath))
-            try! fileManager.removeItemAtPath(savePath)
+            XCTAssertTrue(fileManager.fileExists(atPath: savePath))
+            try! fileManager.removeItem(atPath: savePath)
         } catch _ {
             XCTFail()
         }

--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -239,7 +239,7 @@ class TestNSFileManger : XCTestCase {
             XCTFail()
         }
         
-        if let e = NSFileManager.defaultManager().enumerator(at: NSURL(fileURLWithPath: path), includingPropertiesForKeys: nil, options: [.SkipsSubdirectoryDescendants], errorHandler: nil) {
+        if let e = NSFileManager.defaultManager().enumerator(at: NSURL(fileURLWithPath: path), includingPropertiesForKeys: nil, options: [.skipsSubdirectoryDescendants], errorHandler: nil) {
             var foundItems = [String:Int]()
             while let item = e.nextObject() as? NSURL {
                 if let p = item.path {

--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -39,21 +39,21 @@ class TestNSFileManger : XCTestCase {
         let fm = NSFileManager.defaultManager()
         let path = "/tmp/testdir"
         
-        ignoreError { try fm.removeItemAtPath(path) }
+        ignoreError { try fm.removeItem(atPath: path) }
         
         do {
-            try fm.createDirectoryAtPath(path, withIntermediateDirectories: false, attributes: nil)
+            try fm.createDirectory(atPath: path, withIntermediateDirectories: false, attributes: nil)
         } catch _ {
             XCTFail()
         }
         
         var isDir = false
-        let exists = fm.fileExistsAtPath(path, isDirectory: &isDir)
+        let exists = fm.fileExists(atPath: path, isDirectory: &isDir)
         XCTAssertTrue(exists)
         XCTAssertTrue(isDir)
 
         do {
-            try fm.removeItemAtPath(path)
+            try fm.removeItem(atPath: path)
         } catch {
             XCTFail("Failed to clean up file")
         }
@@ -64,17 +64,17 @@ class TestNSFileManger : XCTestCase {
         let fm = NSFileManager.defaultManager()
         let path = "/tmp/testfile"
         
-        ignoreError { try fm.removeItemAtPath(path) }
+        ignoreError { try fm.removeItem(atPath: path) }
         
-        XCTAssertTrue(fm.createFileAtPath(path, contents: NSData(), attributes: nil))
+        XCTAssertTrue(fm.createFile(atPath: path, contents: NSData(), attributes: nil))
         
         var isDir = false
-        let exists = fm.fileExistsAtPath(path, isDirectory: &isDir)
+        let exists = fm.fileExists(atPath: path, isDirectory: &isDir)
         XCTAssertTrue(exists)
         XCTAssertFalse(isDir)
         
         do {
-            try fm.removeItemAtPath(path)
+            try fm.removeItem(atPath: path)
         } catch {
             XCTFail("Failed to clean up file")
         }
@@ -82,7 +82,7 @@ class TestNSFileManger : XCTestCase {
     
     func test_fileSystemRepresentation() {
         let str = "☃"
-        let result = NSFileManager.defaultManager().fileSystemRepresentationWithPath(str)
+        let result = NSFileManager.defaultManager().fileSystemRepresentation(withPath: str)
         XCTAssertNotNil(result)
         let uintResult = UnsafePointer<UInt8>(result)
         XCTAssertEqual(uintResult[0], 0xE2)
@@ -94,12 +94,12 @@ class TestNSFileManger : XCTestCase {
         let fm = NSFileManager.defaultManager()
         let path = "/tmp/test_fileAttributes\(NSUUID().UUIDString)"
 
-        ignoreError { try fm.removeItemAtPath(path) }
+        ignoreError { try fm.removeItem(atPath: path) }
         
-        XCTAssertTrue(fm.createFileAtPath(path, contents: NSData(), attributes: nil))
+        XCTAssertTrue(fm.createFile(atPath: path, contents: NSData(), attributes: nil))
         
         do {
-            let attrs = try fm.attributesOfItemAtPath(path)
+            let attrs = try fm.attributesOfItem(atPath: path)
             
             XCTAssertTrue(attrs.count > 0)
             
@@ -132,7 +132,7 @@ class TestNSFileManger : XCTestCase {
         }
         
         do {
-            try fm.removeItemAtPath(path)
+            try fm.removeItem(atPath: path)
         } catch {
             XCTFail("Failed to clean up files")
         }
@@ -142,8 +142,8 @@ class TestNSFileManger : XCTestCase {
         let path = "/tmp/test_setFileAttributes\(NSUUID().UUIDString)"
         let fm = NSFileManager.defaultManager()
         
-        ignoreError { try fm.removeItemAtPath(path) }
-        XCTAssertTrue(fm.createFileAtPath(path, contents: NSData(), attributes: nil))
+        ignoreError { try fm.removeItem(atPath: path) }
+        XCTAssertTrue(fm.createFile(atPath: path, contents: NSData(), attributes: nil))
         
         do {
             try fm.setAttributes([NSFilePosixPermissions:NSNumber(short: 0o0600)], ofItemAtPath: path)
@@ -152,7 +152,7 @@ class TestNSFileManger : XCTestCase {
         
         //read back the attributes
         do {
-            let attributes = try fm.attributesOfItemAtPath(path)
+            let attributes = try fm.attributesOfItem(atPath: path)
             XCTAssert((attributes[NSFilePosixPermissions] as? NSNumber)?.shortValue == 0o0600)
         }
         catch { XCTFail("\(error)") }
@@ -165,20 +165,20 @@ class TestNSFileManger : XCTestCase {
         let basePath2 = "/tmp/testdir/path2"
         let itemPath2 = "/tmp/testdir/path2/item"
         
-        ignoreError { try fm.removeItemAtPath(basePath) }
+        ignoreError { try fm.removeItem(atPath: basePath) }
         
         do {
-            try fm.createDirectoryAtPath(basePath, withIntermediateDirectories: false, attributes: nil)
-            try fm.createDirectoryAtPath(basePath2, withIntermediateDirectories: false, attributes: nil)
+            try fm.createDirectory(atPath: basePath, withIntermediateDirectories: false, attributes: nil)
+            try fm.createDirectory(atPath: basePath2, withIntermediateDirectories: false, attributes: nil)
 
-            fm.createFileAtPath(itemPath, contents: NSData(), attributes: nil)
-            fm.createFileAtPath(itemPath2, contents: NSData(), attributes: nil)
+            fm.createFile(atPath: itemPath, contents: NSData(), attributes: nil)
+            fm.createFile(atPath: itemPath2, contents: NSData(), attributes: nil)
 
         } catch _ {
             XCTFail()
         }
         
-        if let e = NSFileManager.defaultManager().enumeratorAtPath(basePath) {
+        if let e = NSFileManager.defaultManager().enumerator(atPath: basePath) {
             let foundItems = NSMutableSet()
             while let item = e.nextObject() as? NSString {
                 foundItems.addObject(item)
@@ -195,16 +195,16 @@ class TestNSFileManger : XCTestCase {
         let path = "/tmp/testdir"
         let itemPath = "/tmp/testdir/item"
         
-        ignoreError { try fm.removeItemAtPath(path) }
+        ignoreError { try fm.removeItem(atPath: path) }
         
         do {
-            try fm.createDirectoryAtPath(path, withIntermediateDirectories: false, attributes: nil)
-            fm.createFileAtPath(itemPath, contents: NSData(), attributes: nil)
+            try fm.createDirectory(atPath: path, withIntermediateDirectories: false, attributes: nil)
+            fm.createFile(atPath: itemPath, contents: NSData(), attributes: nil)
         } catch _ {
             XCTFail()
         }
         
-        if let e = NSFileManager.defaultManager().enumeratorAtURL(NSURL(fileURLWithPath: path), includingPropertiesForKeys: nil, options: [], errorHandler: nil) {
+        if let e = NSFileManager.defaultManager().enumerator(at: NSURL(fileURLWithPath: path), includingPropertiesForKeys: nil, options: [], errorHandler: nil) {
             var foundItems = [String:Int]()
             while let item = e.nextObject() as? NSURL {
                 if let p = item.path {
@@ -219,13 +219,13 @@ class TestNSFileManger : XCTestCase {
         let subDirPath = "/tmp/testdir/testdir2"
         let subDirItemPath = "/tmp/testdir/testdir2/item"
         do {
-            try fm.createDirectoryAtPath(subDirPath, withIntermediateDirectories: false, attributes: nil)
-            fm.createFileAtPath(subDirItemPath, contents: NSData(), attributes: nil)
+            try fm.createDirectory(atPath: subDirPath, withIntermediateDirectories: false, attributes: nil)
+            fm.createFile(atPath: subDirItemPath, contents: NSData(), attributes: nil)
         } catch _ {
             XCTFail()
         }
         
-        if let e = NSFileManager.defaultManager().enumeratorAtURL(NSURL(fileURLWithPath: path), includingPropertiesForKeys: nil, options: [], errorHandler: nil) {
+        if let e = NSFileManager.defaultManager().enumerator(at: NSURL(fileURLWithPath: path), includingPropertiesForKeys: nil, options: [], errorHandler: nil) {
             var foundItems = [String:Int]()
             while let item = e.nextObject() as? NSURL {
                 if let p = item.path {
@@ -239,7 +239,7 @@ class TestNSFileManger : XCTestCase {
             XCTFail()
         }
         
-        if let e = NSFileManager.defaultManager().enumeratorAtURL(NSURL(fileURLWithPath: path), includingPropertiesForKeys: nil, options: [.SkipsSubdirectoryDescendants], errorHandler: nil) {
+        if let e = NSFileManager.defaultManager().enumerator(at: NSURL(fileURLWithPath: path), includingPropertiesForKeys: nil, options: [.SkipsSubdirectoryDescendants], errorHandler: nil) {
             var foundItems = [String:Int]()
             while let item = e.nextObject() as? NSURL {
                 if let p = item.path {
@@ -252,7 +252,7 @@ class TestNSFileManger : XCTestCase {
             XCTFail()
         }
         
-        if let e = NSFileManager.defaultManager().enumeratorAtURL(NSURL(fileURLWithPath: path), includingPropertiesForKeys: nil, options: [], errorHandler: nil) {
+        if let e = NSFileManager.defaultManager().enumerator(at: NSURL(fileURLWithPath: path), includingPropertiesForKeys: nil, options: [], errorHandler: nil) {
             var foundItems = [String:Int]()
             while let item = e.nextObject() as? NSURL {
                 if let p = item.path {
@@ -270,7 +270,7 @@ class TestNSFileManger : XCTestCase {
             didGetError = true
             return true
         }
-        if let e = NSFileManager.defaultManager().enumeratorAtURL(NSURL(fileURLWithPath: "/nonexistant-path"), includingPropertiesForKeys: nil, options: [], errorHandler: handler) {
+        if let e = NSFileManager.defaultManager().enumerator(at: NSURL(fileURLWithPath: "/nonexistant-path"), includingPropertiesForKeys: nil, options: [], errorHandler: handler) {
             XCTAssertNil(e.nextObject())
         } else {
             XCTFail()
@@ -278,7 +278,7 @@ class TestNSFileManger : XCTestCase {
         XCTAssertTrue(didGetError)
         
         do {
-            let contents = try NSFileManager.defaultManager().contentsOfDirectoryAtURL(NSURL(fileURLWithPath: path), includingPropertiesForKeys: nil, options: []).map {
+            let contents = try NSFileManager.defaultManager().contentsOfDirectory(at: NSURL(fileURLWithPath: path), includingPropertiesForKeys: nil, options: []).map {
                 return $0.path!
             }
             XCTAssertEqual(contents.count, 2)
@@ -289,7 +289,7 @@ class TestNSFileManger : XCTestCase {
         }
         
         do {
-            try fm.removeItemAtPath(path)
+            try fm.removeItem(atPath: path)
         } catch {
             XCTFail("Failed to clean up files")
         }
@@ -301,18 +301,18 @@ class TestNSFileManger : XCTestCase {
         let itemPath1 = "/tmp/testdir/item"
         let itemPath2 = "/tmp/testdir/item2"
         
-        ignoreError { try fm.removeItemAtPath(path) }
+        ignoreError { try fm.removeItem(atPath: path) }
         
         do {
-            try fm.createDirectoryAtPath(path, withIntermediateDirectories: false, attributes: nil)
-            fm.createFileAtPath(itemPath1, contents: NSData(), attributes: nil)
-            fm.createFileAtPath(itemPath2, contents: NSData(), attributes: nil)
+            try fm.createDirectory(atPath: path, withIntermediateDirectories: false, attributes: nil)
+            fm.createFile(atPath: itemPath1, contents: NSData(), attributes: nil)
+            fm.createFile(atPath: itemPath2, contents: NSData(), attributes: nil)
         } catch _ {
             XCTFail()
         }
         
         do {
-            let entries = try fm.contentsOfDirectoryAtPath(path)
+            let entries = try fm.contentsOfDirectory(atPath: path)
             
             XCTAssertEqual(2, entries.count)
             XCTAssertTrue(entries.contains("item"))
@@ -323,7 +323,7 @@ class TestNSFileManger : XCTestCase {
         }
         
         do {
-            try fm.contentsOfDirectoryAtPath("")
+            try fm.contentsOfDirectory(atPath: "")
             
             XCTFail()
         }
@@ -332,7 +332,7 @@ class TestNSFileManger : XCTestCase {
         }
         
         do {
-            try fm.removeItemAtPath(path)
+            try fm.removeItem(atPath: path)
         } catch {
             XCTFail("Failed to clean up files")
         }
@@ -346,21 +346,21 @@ class TestNSFileManger : XCTestCase {
         let itemPath2 = "/tmp/testdir/item2"
         let itemPath3 = "/tmp/testdir/sub/item3"
                 
-        ignoreError { try fm.removeItemAtPath(path) }
+        ignoreError { try fm.removeItem(atPath: path) }
         
         do {
-            try fm.createDirectoryAtPath(path, withIntermediateDirectories: false, attributes: nil)
-            fm.createFileAtPath(itemPath1, contents: NSData(), attributes: nil)
-            fm.createFileAtPath(itemPath2, contents: NSData(), attributes: nil)
+            try fm.createDirectory(atPath: path, withIntermediateDirectories: false, attributes: nil)
+            fm.createFile(atPath: itemPath1, contents: NSData(), attributes: nil)
+            fm.createFile(atPath: itemPath2, contents: NSData(), attributes: nil)
             
-            try fm.createDirectoryAtPath(path2, withIntermediateDirectories: false, attributes: nil)
-            fm.createFileAtPath(itemPath3, contents: NSData(), attributes: nil)
+            try fm.createDirectory(atPath: path2, withIntermediateDirectories: false, attributes: nil)
+            fm.createFile(atPath: itemPath3, contents: NSData(), attributes: nil)
         } catch _ {
             XCTFail()
         }
         
         do {
-            let entries = try fm.subpathsOfDirectoryAtPath(path)
+            let entries = try fm.subpathsOfDirectory(atPath: path)
             
             XCTAssertEqual(4, entries.count)
             XCTAssertTrue(entries.contains("item"))
@@ -373,7 +373,7 @@ class TestNSFileManger : XCTestCase {
         }
         
         do {
-            try fm.subpathsOfDirectoryAtPath("")
+            try fm.subpathsOfDirectory(atPath: "")
             
             XCTFail()
         }
@@ -382,7 +382,7 @@ class TestNSFileManger : XCTestCase {
         }
         
         do {
-            try fm.removeItemAtPath(path)
+            try fm.removeItem(atPath: path)
         } catch {
             XCTFail("Failed to clean up files")
         }

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -435,7 +435,7 @@ class TestNSString : XCTestCase {
             var outName: NSString?
             var matches: [NSString] = []
             _ = path.completePathIntoString(&outName, caseSensitive: false, matchesIntoArray: &matches, filterTypes: nil)
-            _ = try NSFileManager.defaultManager().contentsOfDirectoryAtURL(NSURL(string: path.bridge())!, includingPropertiesForKeys: nil, options: [])
+            _ = try NSFileManager.defaultManager().contentsOfDirectory(at: NSURL(string: path.bridge())!, includingPropertiesForKeys: nil, options: [])
             XCTAssert(outName == "/", "If NSString is valid path to directory which has '/' suffix then outName is '/'.")
             // This assert fails on CI; https://bugs.swift.org/browse/SR-389
 //            XCTAssert(matches.count == content.count && matches.count == count, "If NSString is valid path to directory then matches contain all content of directory. expected \(content) but got \(matches)")
@@ -449,7 +449,7 @@ class TestNSString : XCTestCase {
             var matches: [NSString] = []
             _ = path.completePathIntoString(&outName, caseSensitive: false, matchesIntoArray: &matches, filterTypes: nil)
             let urlToTmp = NSURL(fileURLWithPath: "/private/tmp/").URLByStandardizingPath!
-            _ = try NSFileManager.defaultManager().contentsOfDirectoryAtURL(urlToTmp, includingPropertiesForKeys: nil, options: [])
+            _ = try NSFileManager.defaultManager().contentsOfDirectory(at: urlToTmp, includingPropertiesForKeys: nil, options: [])
             XCTAssert(outName == "/tmp/", "If path could be completed to existing directory then outName is a string itself plus '/'.")
             // This assert fails on CI; https://bugs.swift.org/browse/SR-389
             //            XCTAssert(matches.count == content.count && matches.count == count, "If NSString is valid path to directory then matches contain all content of directory. expected \(content) but got \(matches)")

--- a/TestFoundation/TestUtils.swift
+++ b/TestFoundation/TestUtils.swift
@@ -19,13 +19,13 @@ func ensureFiles(_ fileNames: [String]) -> Bool {
     var result = true
     let fm = NSFileManager.defaultManager()
     for name in fileNames {
-        guard !fm.fileExistsAtPath(name) else {
+        guard !fm.fileExists(atPath: name) else {
             continue
         }
         
         if name.hasSuffix("/") {
             do {
-                try fm.createDirectoryAtPath(name, withIntermediateDirectories: true, attributes: nil)
+                try fm.createDirectory(atPath: name, withIntermediateDirectories: true, attributes: nil)
             } catch let err {
                 print(err)
                 return false
@@ -34,9 +34,9 @@ func ensureFiles(_ fileNames: [String]) -> Bool {
         
             var isDir: ObjCBool = false
             let dir = name.bridge().stringByDeletingLastPathComponent
-            if !fm.fileExistsAtPath(dir, isDirectory: &isDir) {
+            if !fm.fileExists(atPath: dir, isDirectory: &isDir) {
                 do {
-                    try fm.createDirectoryAtPath(dir, withIntermediateDirectories: true, attributes: nil)
+                    try fm.createDirectory(atPath: dir, withIntermediateDirectories: true, attributes: nil)
                 } catch let err {
                     print(err)
                     return false
@@ -45,7 +45,7 @@ func ensureFiles(_ fileNames: [String]) -> Bool {
                 return false
             }
             
-            result = result && fm.createFileAtPath(name, contents: nil, attributes: nil)
+            result = result && fm.createFile(atPath: name, contents: nil, attributes: nil)
         }
     }
     return result


### PR DESCRIPTION
API names of NSFileManager are modified to match with Darwin version. Files modified are NSFileManager.swift and and other files (including TestFoundation) that use NSFileManager APIs 