### PR TITLE
Start the NSMassFormatter implementation

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -248,14 +248,15 @@
 		5BF7AEBF1BCD51F9008F214A /* NSURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4A1BCC5DCB00ED97BB /* NSURL.swift */; };
 		5BF7AEC01BCD51F9008F214A /* NSUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4B1BCC5DCB00ED97BB /* NSUUID.swift */; };
 		5BF7AEC11BCD51F9008F214A /* NSValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F4C1BCC5DCB00ED97BB /* NSValue.swift */; };
+		5C1676A81CC0F4870091A32C /* TestNSMassFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1676A71CC0F4870091A32C /* TestNSMassFormatter.swift */; };
 		61E0117D1C1B5590000037DD /* NSRunLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B761BD15DFF00C49C64 /* NSRunLoop.swift */; };
 		61E0117E1C1B55B9000037DD /* NSTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F481BCC5DCB00ED97BB /* NSTimer.swift */; };
 		61E0117F1C1B5990000037DD /* CFRunLoop.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B5D88D81BBC9AD800234F36 /* CFRunLoop.c */; };
 		61E011811C1B5998000037DD /* CFMessagePort.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B5D88DC1BBC9AEC00234F36 /* CFMessagePort.c */; };
 		61E011821C1B599A000037DD /* CFMachPort.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B5D88D01BBC9AAC00234F36 /* CFMachPort.c */; };
-		AE35A1861CBAC85E0042DB84 /* SwiftFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = AE35A1851CBAC85E0042DB84 /* SwiftFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7900433B1CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790043391CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift */; };
 		7900433C1CACD33E00ECCBF1 /* TestNSPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900433A1CACD33E00ECCBF1 /* TestNSPredicate.swift */; };
+		AE35A1861CBAC85E0042DB84 /* SwiftFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = AE35A1851CBAC85E0042DB84 /* SwiftFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE19A88C1C23AA2300B4CB6A /* NSStringTestData.txt in Resources */ = {isa = PBXBuildFile; fileRef = CE19A88B1C23AA2300B4CB6A /* NSStringTestData.txt */; };
 		D31302011C30CEA900295652 /* NSConcreteValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31302001C30CEA900295652 /* NSConcreteValue.swift */; };
 		D370696E1C394FBF00295652 /* NSKeyedUnarchiver-RangeTest.plist in Resources */ = {isa = PBXBuildFile; fileRef = D370696D1C394FBF00295652 /* NSKeyedUnarchiver-RangeTest.plist */; };
@@ -604,6 +605,7 @@
 		5BDF628E1C1A550800A89075 /* CFRegularExpression.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFRegularExpression.c; sourceTree = "<group>"; };
 		5BDF628F1C1A550800A89075 /* CFRegularExpression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFRegularExpression.h; sourceTree = "<group>"; };
 		5BF7AEC21BCD568D008F214A /* ForSwiftFoundationOnly.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ForSwiftFoundationOnly.h; sourceTree = "<group>"; };
+		5C1676A71CC0F4870091A32C /* TestNSMassFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSMassFormatter.swift; sourceTree = "<group>"; };
 		5E5835F31C20C9B500C81317 /* TestNSThread.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSThread.swift; sourceTree = "<group>"; };
 		5EB6A15C1C188FC40037DCB8 /* TestNSJSONSerialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSJSONSerialization.swift; sourceTree = "<group>"; };
 		5EF673AB1C28B527006212A3 /* TestNSNotificationQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSNotificationQueue.swift; sourceTree = "<group>"; };
@@ -1180,6 +1182,7 @@
 				D3A597F11C33C68E00295652 /* TestNSKeyedArchiver.swift */,
 				D3A597EF1C33A9E500295652 /* TestNSKeyedUnarchiver.swift */,
 				61A395F91C2484490029B337 /* TestNSLocale.swift */,
+				5C1676A71CC0F4870091A32C /* TestNSMassFormatter.swift */,
 				61F8AE7C1C180FC600FB62F0 /* TestNSNotificationCenter.swift */,
 				5EF673AB1C28B527006212A3 /* TestNSNotificationQueue.swift */,
 				5B6F17921C48631C00935030 /* TestNSNull.swift */,
@@ -1982,6 +1985,7 @@
 				5B13B3511C582D4C00651CE2 /* TestNSByteCountFormatter.swift in Sources */,
 				5B13B3501C582D4C00651CE2 /* TestUtils.swift in Sources */,
 				5B13B3431C582D4C00651CE2 /* TestNSScanner.swift in Sources */,
+				5C1676A81CC0F4870091A32C /* TestNSMassFormatter.swift in Sources */,
 				5B13B3401C582D4C00651CE2 /* TestNSRange.swift in Sources */,
 				5B13B3371C582D4C00651CE2 /* TestNSNotificationCenter.swift in Sources */,
 				5B13B3251C582D4700651CE2 /* main.swift in Sources */,

--- a/Foundation/NSMassFormatter.swift
+++ b/Foundation/NSMassFormatter.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -17,21 +17,100 @@ public enum NSMassFormatterUnit : Int {
     case Stone
 }
 
+internal let NSMassFormatterScaleKilogram: String = "kg"
+internal let NSMassFormatterScaleGram: String = "g"
+internal let NSMassFormatterScalePound: String = "lb"
+internal let NSMassFormatterScaleOunce: String = "oz"
+internal let NSMassFormatterScalePoundStyleShort: String = "#"
+internal let NSMassFormatterScaleKilogramStyleLong: String = "kilograms"
+internal let NSMassFormatterScaleGramStyleLong: String = "grams"
+internal let NSMassFormatterScalePoundStyleLong: String = "pounds"
+internal let NSMassFormatterScaleOunceStyleLong: String = "ounces"
+internal let NSMassFormatterKgtoLb: Double = 2.2046226218 // 1 kg = 2.2046226218 lb
+internal let NSMassFormatterKgtoG: Double = 1000.0 // 1 kg = 1000.0 lb
+internal let NSMassFormatterLbtoOz: Double = 16.0 // 1 lb = 16.0 oz
+
+
 public class NSMassFormatter : NSFormatter {
     
-    public required init?(coder: NSCoder) {
-        NSUnimplemented()
+    public override init() {
+        super.init()
     }
     
-    /*@NSCopying*/ public var numberFormatter: NSNumberFormatter! // default is NSNumberFormatter with NSNumberFormatterDecimalStyle
-    public var unitStyle: NSFormattingUnitStyle // default is NSFormattingUnitStyleMedium
-    public var forPersonMassUse: Bool // default is NO; if it is set to YES, the number argument for -stringFromKilograms: and -unitStringFromKilograms: is considered as a person’s mass
+    public required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    /*@NSCopying*/ public var numberFormatter: NSNumberFormatter!  {   // default is NSNumberFormatter with NSNumberFormatterDecimalStyle
+        let numForm = NSNumberFormatter()
+        numForm.locale = NSLocale.currentLocale()
+        numForm.numberStyle = .DecimalStyle
+        return numForm
+    }
+    public var unitStyle: NSFormattingUnitStyle = .Medium // default is NSFormattingUnitStyleMedium
+    public var forPersonMassUse: Bool = false // default is NO; if it is set to YES, the number argument for -stringFromKilograms: and -unitStringFromKilograms: is considered as a person’s mass
     
     // Format a combination of a number and an unit to a localized string.
     public func stringFromValue(_ value: Double, unit: NSMassFormatterUnit) -> String { NSUnimplemented() }
     
     // Format a number in kilograms to a localized string with the locale-appropriate unit and an appropriate scale (e.g. 1.2kg = 2.64lb in the US locale).
-    public func stringFromKilograms(_ numberInKilograms: Double) -> String { NSUnimplemented() }
+    public func stringFromKilograms(_ numberInKilograms: Double) -> String {
+        var numberToFormat = numberInKilograms
+        var isLessThanOne = false
+        var scale = ""
+        var useMetricSystem = true
+        
+        if numberFormatter.locale.objectForKey(NSLocaleLanguageCode) != nil { //Workaround because I'm getting "empty" locale
+            guard let useMetricSys = numberFormatter.locale.objectForKey(NSLocaleUsesMetricSystem) as? Bool else {
+                return ""
+            }
+            useMetricSystem = useMetricSys
+        } else {
+            useMetricSystem = false // set default to true so I can test like en_US locale
+        }
+        
+        
+        if useMetricSystem == true {
+            
+            if numberToFormat < 1 {
+                numberToFormat = numberToFormat * NSMassFormatterKgtoG
+                isLessThanOne = true
+            }
+            
+            switch unitStyle {
+            case .Short:
+                scale = isLessThanOne ? NSMassFormatterScaleGram : NSMassFormatterScaleKilogram
+            case .Long:
+                scale = isLessThanOne ? NSMassFormatterScaleGramStyleLong : NSMassFormatterScaleKilogramStyleLong
+            default:
+                scale = isLessThanOne ? NSMassFormatterScaleGram : NSMassFormatterScaleKilogram
+            }
+            
+        } else {
+            numberToFormat = numberInKilograms * NSMassFormatterKgtoLb
+            
+            if numberToFormat < 1 {
+                numberToFormat = numberToFormat * NSMassFormatterLbtoOz
+                isLessThanOne = true
+            }
+            
+            switch unitStyle {
+            case .Short:
+                scale = isLessThanOne ? NSMassFormatterScaleOunce : NSMassFormatterScalePoundStyleShort
+            case .Long:
+                scale = isLessThanOne ? NSMassFormatterScaleOunceStyleLong : NSMassFormatterScalePoundStyleLong
+            default:
+                scale = isLessThanOne ? NSMassFormatterScaleOunce : NSMassFormatterScalePound
+            }
+        }
+        
+        guard let formatedNumber = numberFormatter.stringFromNumber(NSNumber(double:numberToFormat)) else {
+            return ""
+        }
+        
+        return formatedNumber + (unitStyle == .Short ? "" : " " ) + scale
+    
+    }
     
     // Return a localized string of the given unit, and if the unit is singular or plural is based on the given number.
     public func unitStringFromValue(_ value: Double, unit: NSMassFormatterUnit) -> String { NSUnimplemented() }

--- a/TestFoundation/TestNSMassFormatter.swift
+++ b/TestFoundation/TestNSMassFormatter.swift
@@ -1,0 +1,91 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+import CoreFoundation
+
+class TestNSMassFormatter: XCTestCase {
+
+    static var allTests: [(String, TestNSMassFormatter -> () throws -> Void)] {
+        return [
+            ("test_stringFromKilogramsLb", test_stringFromKilogramsLb),
+            ("test_stringFromKilogramsOz", test_stringFromKilogramsOz),
+            ("test_stringFromKilogramsLbLong", test_stringFromKilogramsLbLong),
+            ("test_stringFromKilogramsOzLong", test_stringFromKilogramsOzLong),
+            ("test_stringFromKilogramsLbShort", test_stringFromKilogramsLbShort),
+            ("test_stringFromKilogramsOzShort", test_stringFromKilogramsOzShort),
+        ]
+    }
+
+    func test_stringFromKilogramsLb() {
+        let massFormatter = NSMassFormatter()
+        let numForm = NSNumberFormatter()
+        numForm.locale = NSLocale(localeIdentifier: "en_US")
+        numForm.numberStyle = .DecimalStyle
+        let formattedString = massFormatter.stringFromKilograms(75.0)
+        XCTAssertEqual(formattedString, "165.347 lb")
+    }
+    
+    func test_stringFromKilogramsOz() {
+        let massFormatter = NSMassFormatter()
+        let numForm = NSNumberFormatter()
+        numForm.locale = NSLocale(localeIdentifier: "en_US")
+        numForm.numberStyle = .DecimalStyle
+        let formattedString = massFormatter.stringFromKilograms(0.01)
+        XCTAssertEqual(formattedString, "0.35274 oz")
+    }
+    
+    func test_stringFromKilogramsLbLong() {
+        let massFormatter = NSMassFormatter()
+        massFormatter.unitStyle = .Long
+        let numForm = NSNumberFormatter()
+        numForm.locale = NSLocale(localeIdentifier: "en_US")
+        numForm.numberStyle = .DecimalStyle
+        let formattedString = massFormatter.stringFromKilograms(80.0)
+        XCTAssertEqual(formattedString, "176.37 pounds")
+    }
+    
+    func test_stringFromKilogramsOzLong() {
+        let massFormatter = NSMassFormatter()
+        massFormatter.unitStyle = .Long
+        let numForm = NSNumberFormatter()
+        numForm.locale = NSLocale(localeIdentifier: "en_US")
+        numForm.numberStyle = .DecimalStyle
+        let formattedString = massFormatter.stringFromKilograms(0.5)
+        XCTAssertEqual(formattedString, "1.10231 pounds")
+    }
+    
+    func test_stringFromKilogramsLbShort() {
+        let massFormatter = NSMassFormatter()
+        massFormatter.unitStyle = .Short
+        let numForm = NSNumberFormatter()
+        numForm.locale = NSLocale(localeIdentifier: "en_US")
+        numForm.numberStyle = .DecimalStyle
+        let formattedString = massFormatter.stringFromKilograms(83.0)
+        XCTAssertEqual(formattedString, "182.984#")
+    }
+    
+    func test_stringFromKilogramsOzShort() {
+        let massFormatter = NSMassFormatter()
+        massFormatter.unitStyle = .Short
+        let numForm = NSNumberFormatter()
+        numForm.locale = NSLocale(localeIdentifier: "en_US")
+        numForm.numberStyle = .DecimalStyle
+        let formattedString = massFormatter.stringFromKilograms(0.69)
+        XCTAssertEqual(formattedString, "1.52119#")
+    }
+    
+}
+

--- a/TestFoundation/TestNSMassFormatter.swift
+++ b/TestFoundation/TestNSMassFormatter.swift
@@ -26,6 +26,13 @@ class TestNSMassFormatter: XCTestCase {
             ("test_stringFromKilogramsOzLong", test_stringFromKilogramsOzLong),
             ("test_stringFromKilogramsLbShort", test_stringFromKilogramsLbShort),
             ("test_stringFromKilogramsOzShort", test_stringFromKilogramsOzShort),
+            ("test_stringUnitLb", test_stringUnitLb),
+            ("test_stringUnitOz", test_stringUnitOz),
+            ("test_stringUnitLbLong", test_stringUnitLbLong),
+            ("test_stringUnitOzLong", test_stringUnitOzLong),
+            ("test_stringUnitLbShort", test_stringUnitLbShort),
+            ("test_stringUnitOzShort", test_stringUnitOzShort),
+            ("test_stringUnitOzShortInOunces", test_stringUnitOzShortInOunces),
         ]
     }
 
@@ -63,8 +70,8 @@ class TestNSMassFormatter: XCTestCase {
         let numForm = NSNumberFormatter()
         numForm.locale = NSLocale(localeIdentifier: "en_US")
         numForm.numberStyle = .DecimalStyle
-        let formattedString = massFormatter.stringFromKilograms(0.5)
-        XCTAssertEqual(formattedString, "1.10231 pounds")
+        let formattedString = massFormatter.stringFromKilograms(0.005)
+        XCTAssertEqual(formattedString, "0.17637 ounces")
     }
     
     func test_stringFromKilogramsLbShort() {
@@ -83,9 +90,86 @@ class TestNSMassFormatter: XCTestCase {
         let numForm = NSNumberFormatter()
         numForm.locale = NSLocale(localeIdentifier: "en_US")
         numForm.numberStyle = .DecimalStyle
-        let formattedString = massFormatter.stringFromKilograms(0.69)
-        XCTAssertEqual(formattedString, "1.52119#")
+        let formattedString = massFormatter.stringFromKilograms(0.0069)
+        XCTAssertEqual(formattedString, "0.24339oz")
     }
+    
+    
+    func test_stringUnitLb() {
+        let massFormatter = NSMassFormatter()
+        let numForm = NSNumberFormatter()
+        numForm.locale = NSLocale(localeIdentifier: "en_US")
+        numForm.numberStyle = .DecimalStyle
+        var unitUsed = NSMassFormatterUnit.Kilogram
+        let formattedString = massFormatter.unitStringFromKilograms(75.0,usedUnit:&unitUsed)
+        XCTAssertEqual(formattedString, "lb")
+    }
+
+    func test_stringUnitOz() {
+        let massFormatter = NSMassFormatter()
+        let numForm = NSNumberFormatter()
+        numForm.locale = NSLocale(localeIdentifier: "en_US")
+        numForm.numberStyle = .DecimalStyle
+        var unitUsed = NSMassFormatterUnit.Kilogram
+        let formattedString = massFormatter.unitStringFromKilograms(0.01,usedUnit:&unitUsed)
+        XCTAssertEqual(formattedString, "oz")
+    }
+    
+    func test_stringUnitLbLong() {
+        let massFormatter = NSMassFormatter()
+        massFormatter.unitStyle = .Long
+        let numForm = NSNumberFormatter()
+        numForm.locale = NSLocale(localeIdentifier: "en_US")
+        numForm.numberStyle = .DecimalStyle
+        var unitUsed = NSMassFormatterUnit.Kilogram
+        let formattedString = massFormatter.unitStringFromKilograms(80.0,usedUnit:&unitUsed)
+        XCTAssertEqual(formattedString, "pounds")
+    }
+    
+    func test_stringUnitOzLong() {
+        let massFormatter = NSMassFormatter()
+        massFormatter.unitStyle = .Long
+        let numForm = NSNumberFormatter()
+        numForm.locale = NSLocale(localeIdentifier: "en_US")
+        numForm.numberStyle = .DecimalStyle
+        var unitUsed = NSMassFormatterUnit.Kilogram
+        let formattedString = massFormatter.unitStringFromKilograms(0.005,usedUnit:&unitUsed)
+        XCTAssertEqual(formattedString, "ounces")
+    }
+    
+    func test_stringUnitLbShort() {
+        let massFormatter = NSMassFormatter()
+        massFormatter.unitStyle = .Short
+        let numForm = NSNumberFormatter()
+        numForm.locale = NSLocale(localeIdentifier: "en_US")
+        numForm.numberStyle = .DecimalStyle
+        var unitUsed = NSMassFormatterUnit.Kilogram
+        let formattedString = massFormatter.unitStringFromKilograms(83.0,usedUnit:&unitUsed)
+        XCTAssertEqual(formattedString, "#")
+    }
+    
+    func test_stringUnitOzShort() {
+        let massFormatter = NSMassFormatter()
+        massFormatter.unitStyle = .Short
+        let numForm = NSNumberFormatter()
+        numForm.locale = NSLocale(localeIdentifier: "en_US")
+        numForm.numberStyle = .DecimalStyle
+        var unitUsed = NSMassFormatterUnit.Kilogram
+        let formattedString = massFormatter.unitStringFromKilograms(0.0069,usedUnit:&unitUsed)
+        XCTAssertEqual(formattedString, "oz")
+    }
+    
+    func test_stringUnitOzShortInOunces() {
+        let massFormatter = NSMassFormatter()
+        massFormatter.unitStyle = .Short
+        let numForm = NSNumberFormatter()
+        numForm.locale = NSLocale(localeIdentifier: "en_US")
+        numForm.numberStyle = .DecimalStyle
+        var unitUsed = NSMassFormatterUnit.Ounce
+        let formattedString = massFormatter.unitStringFromKilograms(5.0,usedUnit:&unitUsed)
+        XCTAssertEqual(formattedString, "oz")
+    }
+
     
 }
 

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -41,6 +41,7 @@ XCTMain([
     testCase(TestNSKeyedArchiver.allTests),
     testCase(TestNSKeyedUnarchiver.allTests),
     testCase(TestNSLocale.allTests),
+    testCase(TestNSMassFormatter.allTests),
     testCase(TestNSNotificationCenter.allTests),
     testCase(TestNSNotificationQueue.allTests),
     testCase(TestNSNull.allTests),


### PR DESCRIPTION
Start the implementation of NSMassFormatter and create its tests. I’ve started with English, with and without metric system. To finish all other languages I’ll need the translations for “kg”, “g”, “lb”, “oz”,
“kilograms”, “grams”, “pounds”, “ounces”.