### PR TITLE
fix warnings for SE-0049 (Move @noescape ...)

### DIFF
--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -527,7 +527,7 @@ public class NSKeyedUnarchiver : NSCoder {
         Helper for NSArray/NSDictionary to dereference and decode an array of objects
      */
     internal func _decodeArrayOfObjectsForKey(_ key: String,
-                                              @noescape withBlock block: (Any) -> Void) throws {
+                                               withBlock block: @noescape (Any) -> Void) throws {
         let objectRefs : Array<Any>? = _decodeValue(forKey: key)
         
         guard let unwrappedObjectRefs = objectRefs else {

--- a/Foundation/NSLock.swift
+++ b/Foundation/NSLock.swift
@@ -51,7 +51,7 @@ public class NSLock : NSObject, NSLocking {
 }
 
 extension NSLock {
-    internal func synchronized<T>(@noescape _ closure: () -> T) -> T {
+    internal func synchronized<T>(_ closure: @noescape () -> T) -> T {
         self.lock()
         defer { self.unlock() }
         return closure()

--- a/Foundation/NSOperation.swift
+++ b/Foundation/NSOperation.swift
@@ -279,7 +279,7 @@ internal struct _OperationList {
         return all.count
     }
     
-    func map<T>(@noescape _ transform: (NSOperation) throws -> T) rethrows -> [T] {
+    func map<T>(_ transform: @noescape (NSOperation) throws -> T) rethrows -> [T] {
         return try all.map(transform)
     }
 }

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -360,7 +360,7 @@ extension Unmanaged {
 }
 
 extension Array {
-    internal mutating func withUnsafeMutablePointerOrAllocation<R>(_ count: Int, fastpath: UnsafeMutablePointer<Element>? = nil, @noescape body: (UnsafeMutablePointer<Element>) -> R) -> R {
+    internal mutating func withUnsafeMutablePointerOrAllocation<R>(_ count: Int, fastpath: UnsafeMutablePointer<Element>? = nil, body: @noescape (UnsafeMutablePointer<Element>) -> R) -> R {
         if let fastpath = fastpath {
             return body(fastpath)
         } else if self.count > count {

--- a/Foundation/String.swift
+++ b/Foundation/String.swift
@@ -112,7 +112,7 @@ extension String {
     /// memory referred to by `index`
     func _withOptionalOutParameter<Result>(
         _ index: UnsafeMutablePointer<Index>?,
-        @noescape body: (UnsafeMutablePointer<Int>?) -> Result
+        body: @noescape (UnsafeMutablePointer<Int>?) -> Result
         ) -> Result {
         var utf16Index: Int = 0
         let result = (index != nil) ? body(&utf16Index) : body(nil)
@@ -125,7 +125,7 @@ extension String {
     /// it into the memory referred to by `range`
     func _withOptionalOutParameter<Result>(
         _ range: UnsafeMutablePointer<Range<Index>>?,
-        @noescape body: (UnsafeMutablePointer<NSRange>?) -> Result
+        body: @noescape (UnsafeMutablePointer<NSRange>?) -> Result
         ) -> Result {
         var nsRange = NSRange(location: 0, length: 0)
         let result = (range != nil) ? body(&nsRange) : body(nil)

--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -31,7 +31,7 @@ class TestNSFileManger : XCTestCase {
         ]
     }
     
-    func ignoreError(@noescape _ block: () throws -> Void) {
+    func ignoreError(_ block: @noescape () throws -> Void) {
         do { try block() } catch { }
     }
     


### PR DESCRIPTION
Not sure if this change is unwelcome, considering that [proposal](https://github.com/apple/swift-evolution/blob/master/proposals/0049-noescape-autoclosure-type-attrs.md) says:

> The Swift 3 migrator should move these over, and has the information it needs to do a perfect migration in this case.

Anyways the warnings are annoying and I wanted to silence them.