### PR TITLE
Remove the description of dropping 'NS' prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In our first year, we are not looking to make major API changes to the library. 
 
 ### API Naming and Foundation
 
-One of the goals of the Swift 3 project is [a new set of naming guidelines](https://swift.org/documentation/api-design-guidelines/). The Foundation project will soon update all of its names to match the new guidelines. We will also drop the 'NS' prefix from all Foundation classes.
+One of the goals of the Swift 3 project is [a new set of naming guidelines](https://swift.org/documentation/api-design-guidelines/). The Foundation project will soon update all of its names to match the new guidelines.
 
 ### Current Status
 


### PR DESCRIPTION
Remove " We will also drop the 'NS' prefix from all Foundation classes." according to https://github.com/apple/swift-evolution/commit/bf2e4c4bcb1ad3dd072920f33514546e75cf59bb