### PR TITLE
Further integration of Dispatch into Foundation

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -805,7 +805,12 @@ CF_EXPORT void _NS_pthread_setname_np(const char *name);
 #define pthread_setname_np _NS_pthread_setname_np
 #endif
 
-#if DEPLOYMENT_TARGET_WINDOWS || DEPLOYMENT_TARGET_LINUX
+#if DEPLOYMENT_TARGET_LINUX
+CF_EXPORT Boolean _CFIsMainThread(void);
+#define pthread_main_np _CFIsMainThread
+#endif
+
+#if DEPLOYMENT_TARGET_WINDOWS
 // replacement for DISPATCH_QUEUE_OVERCOMMIT until we get a bug fix in dispatch on Windows
 // <rdar://problem/7923891> dispatch on Windows: Need queue_private.h
 #define DISPATCH_QUEUE_OVERCOMMIT 2

--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -157,6 +157,11 @@ const char *_CFProcessPath(void) {
 
 #if DEPLOYMENT_TARGET_LINUX
 #include <unistd.h>
+#include <syscall.h>
+
+Boolean _CFIsMainThread(void) {
+    return syscall(SYS_gettid) == getpid();
+}
 
 const char *_CFProcessPath(void) {
     if (__CFProcessPath) return __CFProcessPath;

--- a/CoreFoundation/RunLoop.subproj/CFRunLoop.c
+++ b/CoreFoundation/RunLoop.subproj/CFRunLoop.c
@@ -78,8 +78,8 @@ DISPATCH_EXPORT void _dispatch_main_queue_callback_4CF(void);
 #include <sys/eventfd.h>
 #include <sys/timerfd.h>
 
-#define _dispatch_get_main_queue_port_4CF dispatch_get_main_queue_eventfd_np
-#define _dispatch_main_queue_callback_4CF(x) dispatch_main_queue_drain_np()
+#define _dispatch_get_main_queue_port_4CF dispatch_get_main_queue_eventfd_4CF
+#define _dispatch_main_queue_callback_4CF(x) dispatch_main_queue_drain_4CF()
 #endif
 
 #if DEPLOYMENT_TARGET_WINDOWS || DEPLOYMENT_TARGET_IPHONESIMULATOR || DEPLOYMENT_TARGET_LINUX

--- a/build.py
+++ b/build.py
@@ -64,14 +64,18 @@ if "XCTEST_BUILD_DIR" in Configuration.current.variables:
 		'-I/usr/include/libxml2'
 	]
 
-# Disable until changes are merged into dispatch.
+# Configure use of Dispatch in CoreFoundation and Foundation if libdispatch is being built
 #if "LIBDISPATCH_SOURCE_DIR" in Configuration.current.variables:
-#        foundation.CFLAGS += " "+" ".join([
-#                '-DDEPLOYMENT_ENABLE_LIBDISPATCH',
-#                '-I'+Configuration.current.variables["LIBDISPATCH_SOURCE_DIR"],
-#                '-I'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/tests'  # for include of dispatch/private.h in CF
-#        ])
-
+#	foundation.CFLAGS += " "+" ".join([
+#		'-DDEPLOYMENT_ENABLE_LIBDISPATCH',
+#		'-I'+Configuration.current.variables["LIBDISPATCH_SOURCE_DIR"],
+#		'-I'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/tests'  # for include of dispatch/private.h in CF
+#	])
+#	swift_cflags += ([
+#		'-DDEPLOYMENT_ENABLE_LIBDISPATCH',
+#		'-I'+Configuration.current.variables["LIBDISPATCH_SOURCE_DIR"],
+#	])
+#	foundation.LDFLAGS += '-ldispatch -L'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src/.libs '
 
 foundation.SWIFTCFLAGS = " ".join(swift_cflags)
 


### PR DESCRIPTION
This makes some minor changes that gets us closer to having Dispatch built and included in CoreFoundation and Foundation, including:
* Switching CFRunLoop to use the new `4CF` functions in libdispatch  
Note that these APIs are only available in the `experimental/foundation' branch of libdispatch.
* Adding a basic implementation for `pthread_main_np()`  
There isn't an implementation in Glibc and there isn't a shim today. We should potentially move the implementation to the Glibc overlay. 
* Updated the build scripts to include Dispatch in Foundation as well as CoreFoundation  
This is still commented out as there's a number of compile errors in NSOperation and the incoming NSURLSession code - we should fix those up before uncommenting this code.

The changes should allow anyone to build a toolchain with Dispatch enabled by:
1. Extracting the `experimental/foundation` branch of `swift-corelibs-libdispatch`
2. Uncommenting the code in `build.py`
3. Running a build with the `libdispatch` and `install-libdispatch` flags added