### PR TITLE
NSOperationQueue.operationCount always return 0

### DIFF
--- a/Foundation/NSOperation.swift
+++ b/Foundation/NSOperation.swift
@@ -204,6 +204,7 @@ internal struct _OperationList {
     var all = [NSOperation]()
     
     mutating func insert(_ operation: NSOperation) {
+        all.append(operation)
         switch operation.queuePriority {
         case .VeryLow:
             veryLow.append(operation)
@@ -257,22 +258,24 @@ internal struct _OperationList {
     }
     
     mutating func dequeue() -> NSOperation? {
+        var result : NSOperation?
         if veryHigh.count > 0 {
-            return veryHigh.remove(at: 0)
+            result = veryHigh.remove(at: 0)
+        } else if high.count > 0 {
+            result = high.remove(at: 0)
+        } else if normal.count > 0 {
+            result = normal.remove(at: 0)
+        } else if low.count > 0 {
+            result = low.remove(at: 0)
+        } else if veryLow.count > 0 {
+            result = veryLow.remove(at: 0)
         }
-        if high.count > 0 {
-            return high.remove(at: 0)
+
+        if let idx = all.index(of: result!) {
+            all.remove(at: idx)
         }
-        if normal.count > 0 {
-            return normal.remove(at: 0)
-        }
-        if low.count > 0 {
-            return low.remove(at: 0)
-        }
-        if veryLow.count > 0 {
-            return veryLow.remove(at: 0)
-        }
-        return nil
+
+        return result
     }
     
     var count: Int {

--- a/TestFoundation/TestNSOperationQueue.swift
+++ b/TestFoundation/TestNSOperationQueue.swift
@@ -1,0 +1,36 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+import Foundation
+import XCTest
+#else
+import SwiftFoundation
+import SwiftXCTest
+#endif
+
+class TestNSOperationQueue : XCTestCase {
+    static var allTests: [(String, TestNSOperationQueue -> () throws -> Void)] {
+        return [
+            ("test_OperationCount", test_OperationCount)
+        ]
+    }
+    
+    func test_OperationCount() {
+        let queue = NSOperationQueue()
+        let op1 = NSBlockOperation(block: { sleep(2) })
+        queue.addOperation(op1)
+        XCTAssertTrue(queue.operationCount == 1)
+        /* uncomment below lines once Dispatch is enabled in Foundation */
+        //queue.waitUntilAllOperationsAreFinished()
+        //XCTAssertTrue(queue.operationCount == 0)
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -46,6 +46,7 @@ XCTMain([
     testCase(TestNSNull.allTests),
     testCase(TestNSNumber.allTests),
     testCase(TestNSNumberFormatter.allTests),
+    testCase(TestNSOperationQueue.allTests),
     testCase(TestNSOrderedSet.allTests),
     testCase(TestNSPipe.allTests),
     testCase(TestNSPredicate.allTests),


### PR DESCRIPTION
NSOperationQueue maintain different queues based on priority and a queue 'all' to maintain operations of all priorities. 

NSOperationQueue.operationCount is nothing but the no.of operations in 'all' queue. However, addOperation() doesn't add Operations to 'all' queue and thereby NSOperationQueue.operationCount is always 0.

Currently, there is no testsuite for NSOperationQueue. I've added test case for this scenario (partially, as it would require Dispatch support to add more scenarios to it).