### PR TITLE
fix NSOperationQueue to retain operation in 'all' queue once it is dispatched

### DIFF
--- a/Foundation/NSOperation.swift
+++ b/Foundation/NSOperation.swift
@@ -258,24 +258,22 @@ internal struct _OperationList {
     }
     
     mutating func dequeue() -> NSOperation? {
-        var result : NSOperation?
         if veryHigh.count > 0 {
-            result = veryHigh.remove(at: 0)
-        } else if high.count > 0 {
-            result = high.remove(at: 0)
-        } else if normal.count > 0 {
-            result = normal.remove(at: 0)
-        } else if low.count > 0 {
-            result = low.remove(at: 0)
-        } else if veryLow.count > 0 {
-            result = veryLow.remove(at: 0)
+            return veryHigh.remove(at: 0)
         }
-
-        if let idx = all.index(of: result!) {
-            all.remove(at: idx)
+        if high.count > 0 {
+            return high.remove(at: 0)
         }
-
-        return result
+        if normal.count > 0 {
+            return normal.remove(at: 0)
+        }
+        if low.count > 0 {
+            return low.remove(at: 0)
+        }
+        if veryLow.count > 0 {
+            return veryLow.remove(at: 0)
+        }
+        return nil
     }
     
     var count: Int {


### PR DESCRIPTION
After https://github.com/apple/swift-corelibs-foundation/pull/340,  NSOperationQueue.operationCount is decremented as soon as task is dispatched for execution. This is because dequeue() method is modified to delete operation from 'all' queue.