### PR TITLE
[NSTask] Cleanup environment after task is launched

### DIFF
--- a/Foundation/NSTask.swift
+++ b/Foundation/NSTask.swift
@@ -222,18 +222,19 @@ public class NSTask : NSObject {
             envp = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>(allocatingCapacity: 1 + nenv)
             envp.initializeFrom(env.map { strdup("\($0)=\($1)") })
             envp[env.count] = nil
-            
-            defer {
+        } else {
+            envp = _CFEnviron()
+        }
+
+        defer {
+            if let env = environment {
                 for pair in envp ..< envp + env.count {
                     free(UnsafeMutablePointer<Void>(pair.pointee))
                 }
                 envp.deallocateCapacity(env.count + 1)
             }
-        } else {
-            envp = _CFEnviron()
         }
-        
-        
+
         var taskSocketPair : [Int32] = [0, 0]
         socketpair(AF_UNIX, _CF_SOCK_STREAM(), 0, &taskSocketPair)
         


### PR DESCRIPTION
Currently the environment is deallocated before the task is launched. This results in memory being overwritten, and a corrupt environment. @ddunbar suggested moving the `defer` up a scope. I've added a few tests to verify the correctness of the environment.