### PR TITLE
[SE-0066] Adopt new function type syntax

### DIFF
--- a/Foundation/NSTimer.swift
+++ b/Foundation/NSTimer.swift
@@ -28,13 +28,13 @@ public class NSTimer : NSObject {
     }
     
     internal var _timer: CFRunLoopTimer? // has to be optional because this is a chicken/egg problem with initialization in swift
-    internal var _fire: NSTimer -> Void = { (_: NSTimer) in }
+    internal var _fire: (NSTimer) -> Void = { (_: NSTimer) in }
     
     /// Alternative API for timer creation with a block.
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative to creation via selector
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
     /// - Warning: Capturing the timer or the owner of the timer inside of the block may cause retain cycles. Use with caution
-    public init(fireDate: NSDate, interval: NSTimeInterval, repeats: Bool, fire: NSTimer -> Void ) {
+    public init(fireDate: NSDate, interval: NSTimeInterval, repeats: Bool, fire: (NSTimer) -> Void ) {
         super.init()
         _fire = fire
         var context = CFRunLoopTimerContext()
@@ -53,7 +53,7 @@ public class NSTimer : NSObject {
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative to creation via selector
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
     /// - Warning: Capturing the timer or the owner of the timer inside of the block may cause retain cycles. Use with caution
-    public class func scheduledTimer(_ ti: NSTimeInterval, repeats: Bool, fire: NSTimer -> Void) -> NSTimer {
+    public class func scheduledTimer(_ ti: NSTimeInterval, repeats: Bool, fire: (NSTimer) -> Void) -> NSTimer {
         let timer = NSTimer(fireDate: NSDate(timeIntervalSinceNow: ti), interval: ti, repeats: repeats, fire: fire)
         CFRunLoopAddTimer(CFRunLoopGetCurrent(), timer._timer!, kCFRunLoopDefaultMode)
         return timer

--- a/TestFoundation/TestNSAffineTransform.swift
+++ b/TestFoundation/TestNSAffineTransform.swift
@@ -21,7 +21,7 @@
 class TestNSAffineTransform : XCTestCase {
     private let accuracyThreshold = 0.001
 
-    static var allTests: [(String, TestNSAffineTransform -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSAffineTransform) -> () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_IdentityTransformation", test_IdentityTransformation),

--- a/TestFoundation/TestNSArray.swift
+++ b/TestFoundation/TestNSArray.swift
@@ -21,7 +21,7 @@ import SwiftXCTest
 
 class TestNSArray : XCTestCase {
     
-    static var allTests: [(String, TestNSArray -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSArray) -> () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_enumeration", test_enumeration),

--- a/TestFoundation/TestNSAttributedString.swift
+++ b/TestFoundation/TestNSAttributedString.swift
@@ -21,7 +21,7 @@
 
 class TestNSAttributedString : XCTestCase {
     
-    static var allTests: [(String, TestNSAttributedString -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSAttributedString) -> () throws -> Void)] {
         return [
             ("test_initWithString", test_initWithString),
             ("test_initWithStringAndAttributes", test_initWithStringAndAttributes)

--- a/TestFoundation/TestNSBundle.swift
+++ b/TestFoundation/TestNSBundle.swift
@@ -21,7 +21,7 @@
 
 class TestNSBundle : XCTestCase {
     
-    static var allTests: [(String, TestNSBundle -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSBundle) -> () throws -> Void)] {
         return [
             ("test_paths", test_paths),
             ("test_resources", test_resources),

--- a/TestFoundation/TestNSByteCountFormatter.swift
+++ b/TestFoundation/TestNSByteCountFormatter.swift
@@ -21,7 +21,7 @@
 
 class TestNSByteCountFormatter : XCTestCase {
     
-    static var allTests: [(String, TestNSByteCountFormatter -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSByteCountFormatter) -> () throws -> Void)] {
         return [
             ("test_DefaultValues", test_DefaultValues)
         ]

--- a/TestFoundation/TestNSCalendar.swift
+++ b/TestFoundation/TestNSCalendar.swift
@@ -18,7 +18,7 @@ import CoreFoundation
 
 class TestNSCalendar: XCTestCase {
     
-    static var allTests: [(String, TestNSCalendar -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSCalendar) -> () throws -> Void)] {
         return [
             ("test_gettingDatesOnGregorianCalendar", test_gettingDatesOnGregorianCalendar ),
             ("test_gettingDatesOnHebrewCalendar", test_gettingDatesOnHebrewCalendar ),

--- a/TestFoundation/TestNSCharacterSet.swift
+++ b/TestFoundation/TestNSCharacterSet.swift
@@ -21,7 +21,7 @@ import SwiftXCTest
 
 class TestNSCharacterSet : XCTestCase {
     
-    static var allTests: [(String, TestNSCharacterSet -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSCharacterSet) -> () throws -> Void)] {
         return [
             ("test_Predefines", test_Predefines),
             ("test_Range", test_Range),

--- a/TestFoundation/TestNSCompoundPredicate.swift
+++ b/TestFoundation/TestNSCompoundPredicate.swift
@@ -17,7 +17,7 @@
 
 class TestNSCompoundPredicate: XCTestCase {
     
-    static var allTests: [(String, TestNSCompoundPredicate -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSCompoundPredicate) -> () throws -> Void)] {
         return [
             ("test_NotPredicate", test_NotPredicate),
             ("test_AndPredicateWithNoSubpredicates", test_AndPredicateWithNoSubpredicates),

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -17,7 +17,7 @@
 
 class TestNSData: XCTestCase {
     
-    static var allTests: [(String, TestNSData -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSData) -> () throws -> Void)] {
         return [
             ("test_description", test_description),
             ("test_emptyDescription", test_emptyDescription),

--- a/TestFoundation/TestNSDate.swift
+++ b/TestFoundation/TestNSDate.swift
@@ -21,7 +21,7 @@
 
 class TestNSDate : XCTestCase {
     
-    static var allTests: [(String, TestNSDate -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSDate) -> () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_InitTimeIntervalSince1970", test_InitTimeIntervalSince1970),

--- a/TestFoundation/TestNSDateFormatter.swift
+++ b/TestFoundation/TestNSDateFormatter.swift
@@ -20,7 +20,7 @@ class TestNSDateFormatter: XCTestCase {
     let DEFAULT_LOCALE = "en_US"
     let DEFAULT_TIMEZONE = "GMT"
     
-    static var allTests : [(String, TestNSDateFormatter -> () throws -> Void)] {
+    static var allTests : [(String, (TestNSDateFormatter) -> () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_dateStyleShort",    test_dateStyleShort),

--- a/TestFoundation/TestNSDictionary.swift
+++ b/TestFoundation/TestNSDictionary.swift
@@ -21,7 +21,7 @@ import SwiftXCTest
 
 class TestNSDictionary : XCTestCase {
     
-    static var allTests: [(String, TestNSDictionary -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSDictionary) -> () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_ArrayConstruction", test_ArrayConstruction),

--- a/TestFoundation/TestNSFileHandle.swift
+++ b/TestFoundation/TestNSFileHandle.swift
@@ -16,7 +16,7 @@
 #endif
 
 class TestNSFileHandle : XCTestCase {
-    static var allTests : [(String, TestNSFileHandle -> () throws -> ())] {
+    static var allTests : [(String, (TestNSFileHandle) -> () throws -> ())] {
         return [
                    ("test_pipe", test_pipe),
         ]

--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -17,7 +17,7 @@
 
 class TestNSFileManager : XCTestCase {
     
-    static var allTests: [(String, TestNSFileManager -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSFileManager) -> () throws -> Void)] {
         return [
             ("test_createDirectory", test_createDirectory ),
             ("test_createFile", test_createFile ),

--- a/TestFoundation/TestNSGeometry.swift
+++ b/TestFoundation/TestNSGeometry.swift
@@ -20,7 +20,7 @@
 
 class TestNSGeometry : XCTestCase {
 
-    static var allTests: [(String, TestNSGeometry -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSGeometry) -> () throws -> Void)] {
         return [
             ("test_CGFloat_BasicConstruction", test_CGFloat_BasicConstruction),
             ("test_CGFloat_Equality", test_CGFloat_Equality),

--- a/TestFoundation/TestNSHTTPCookie.swift
+++ b/TestFoundation/TestNSHTTPCookie.swift
@@ -17,7 +17,7 @@
 
 class TestNSHTTPCookie: XCTestCase {
 
-    static var allTests: [(String, TestNSHTTPCookie -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSHTTPCookie) -> () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_RequestHeaderFields", test_RequestHeaderFields)

--- a/TestFoundation/TestNSIndexPath.swift
+++ b/TestFoundation/TestNSIndexPath.swift
@@ -19,7 +19,7 @@
 
 class TestNSIndexPath: XCTestCase {
     
-    static var allTests: [(String, TestNSIndexPath -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSIndexPath) -> () throws -> Void)] {
         return [
            ("test_BasicConstruction", test_BasicConstruction)
         ]

--- a/TestFoundation/TestNSIndexSet.swift
+++ b/TestFoundation/TestNSIndexSet.swift
@@ -19,7 +19,7 @@ import SwiftXCTest
 
 class TestNSIndexSet : XCTestCase {
     
-    static var allTests: [(String, TestNSIndexSet -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSIndexSet) -> () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_enumeration", test_enumeration),

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -25,7 +25,7 @@ class TestNSJSONSerialization : XCTestCase {
         NSUTF32LittleEndianStringEncoding, NSUTF32BigEndianStringEncoding
     ]
 
-    static var allTests: [(String, TestNSJSONSerialization -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSJSONSerialization) -> () throws -> Void)] {
         return JSONObjectWithDataTests
             + deserializationTests
             + isValidJSONObjectTests
@@ -37,7 +37,7 @@ class TestNSJSONSerialization : XCTestCase {
 //MARK: - JSONObjectWithData
 extension TestNSJSONSerialization {
 
-    class var JSONObjectWithDataTests: [(String, TestNSJSONSerialization -> () throws -> Void)] {
+    class var JSONObjectWithDataTests: [(String, (TestNSJSONSerialization) -> () throws -> Void)] {
         return [
             ("test_JSONObjectWithData_emptyObject", test_JSONObjectWithData_emptyObject),
             ("test_JSONObjectWithData_encodingDetection", test_JSONObjectWithData_encodingDetection),
@@ -85,7 +85,7 @@ extension TestNSJSONSerialization {
 //MARK: - JSONDeserialization
 extension TestNSJSONSerialization {
     
-    class var deserializationTests: [(String, TestNSJSONSerialization -> () throws -> Void)] {
+    class var deserializationTests: [(String, (TestNSJSONSerialization) -> () throws -> Void)] {
         return [
             ("test_deserialize_emptyObject", test_deserialize_emptyObject),
             ("test_deserialize_multiStringObject", test_deserialize_multiStringObject),
@@ -475,7 +475,7 @@ extension TestNSJSONSerialization {
 // MARK: - isValidJSONObjectTests
 extension TestNSJSONSerialization {
 
-    class var isValidJSONObjectTests: [(String, TestNSJSONSerialization -> () throws -> Void)] {
+    class var isValidJSONObjectTests: [(String, (TestNSJSONSerialization) -> () throws -> Void)] {
         return [
             ("test_isValidJSONObjectTrue", test_isValidJSONObjectTrue),
             ("test_isValidJSONObjectFalse", test_isValidJSONObjectFalse),
@@ -583,7 +583,7 @@ extension TestNSJSONSerialization {
 // MARK: - serializationTests
 extension TestNSJSONSerialization {
 
-    class var serializationTests: [(String, TestNSJSONSerialization -> () throws -> Void)] {
+    class var serializationTests: [(String, (TestNSJSONSerialization) -> () throws -> Void)] {
         return [
             ("test_serialize_emptyObject", test_serialize_emptyObject),
             ("test_serialize_null", test_serialize_null),

--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -51,7 +51,7 @@ public class UserClass : NSObject, NSSecureCoding {
 }
 
 class TestNSKeyedArchiver : XCTestCase {
-    static var allTests: [(String, TestNSKeyedArchiver -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSKeyedArchiver) -> () throws -> Void)] {
         return [
             ("test_archive_array", test_archive_array),
             ("test_archive_charptr", test_archive_charptr),

--- a/TestFoundation/TestNSKeyedUnarchiver.swift
+++ b/TestFoundation/TestNSKeyedUnarchiver.swift
@@ -18,7 +18,7 @@
 
 
 class TestNSKeyedUnarchiver : XCTestCase {
-    static var allTests: [(String, TestNSKeyedUnarchiver -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSKeyedUnarchiver) -> () throws -> Void)] {
         return [
             ("test_unarchive_array", test_unarchive_array),
             ("test_unarchive_complex", test_unarchive_complex),

--- a/TestFoundation/TestNSLocale.swift
+++ b/TestFoundation/TestNSLocale.swift
@@ -16,7 +16,7 @@
 #endif
 
 class TestNSLocale : XCTestCase {
-    static var allTests: [(String, TestNSLocale -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSLocale) -> () throws -> Void)] {
         return [
             ("test_constants", test_constants),
         ]

--- a/TestFoundation/TestNSNotificationCenter.swift
+++ b/TestFoundation/TestNSNotificationCenter.swift
@@ -18,7 +18,7 @@
 
 
 class TestNSNotificationCenter : XCTestCase {
-    static var allTests: [(String, TestNSNotificationCenter -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSNotificationCenter) -> () throws -> Void)] {
         return [
             ("test_defaultCenter", test_defaultCenter),
             ("test_postNotification", test_postNotification),

--- a/TestFoundation/TestNSNotificationQueue.swift
+++ b/TestFoundation/TestNSNotificationQueue.swift
@@ -17,7 +17,7 @@
 
 
 class TestNSNotificationQueue : XCTestCase {
-    static var allTests : [(String, TestNSNotificationQueue -> () throws -> Void)] {
+    static var allTests : [(String, (TestNSNotificationQueue) -> () throws -> Void)] {
         return [
             ("test_defaultQueue", test_defaultQueue),
             ("test_postNowToDefaultQueueWithoutCoalescing", test_postNowToDefaultQueueWithoutCoalescing),

--- a/TestFoundation/TestNSNull.swift
+++ b/TestFoundation/TestNSNull.swift
@@ -21,7 +21,7 @@
 
 class TestNSNull : XCTestCase {
     
-    static var allTests: [(String, TestNSNull -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSNull) -> () throws -> Void)] {
         return [
             ("test_alwaysEqual", test_alwaysEqual)
         ]

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -18,7 +18,7 @@ import SwiftXCTest
 
 
 class TestNSNumber : XCTestCase {
-    static var allTests: [(String, TestNSNumber -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSNumber) -> () throws -> Void)] {
         return [
             ("test_NumberWithBool", test_NumberWithBool ),
             ("test_numberWithChar", test_numberWithChar ),

--- a/TestFoundation/TestNSNumberFormatter.swift
+++ b/TestFoundation/TestNSNumberFormatter.swift
@@ -18,7 +18,7 @@ import CoreFoundation
 
 class TestNSNumberFormatter: XCTestCase {
 
-    static var allTests: [(String, TestNSNumberFormatter -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSNumberFormatter) -> () throws -> Void)] {
         return [
             ("test_currencyCode", test_currencyCode),
             ("test_decimalSeparator", test_decimalSeparator),

--- a/TestFoundation/TestNSOperationQueue.swift
+++ b/TestFoundation/TestNSOperationQueue.swift
@@ -18,7 +18,7 @@ import SwiftXCTest
 #endif
 
 class TestNSOperationQueue : XCTestCase {
-    static var allTests: [(String, TestNSOperationQueue -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSOperationQueue) -> () throws -> Void)] {
         return [
             ("test_OperationCount", test_OperationCount)
         ]

--- a/TestFoundation/TestNSOrderedSet.swift
+++ b/TestFoundation/TestNSOrderedSet.swift
@@ -21,7 +21,7 @@
 
 class TestNSOrderedSet : XCTestCase {
 
-    static var allTests: [(String, TestNSOrderedSet -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSOrderedSet) -> () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_Enumeration", test_Enumeration),

--- a/TestFoundation/TestNSPipe.swift
+++ b/TestFoundation/TestNSPipe.swift
@@ -19,7 +19,7 @@ import SwiftXCTest
 
 class TestNSPipe : XCTestCase {
     
-    static var allTests: [(String, TestNSPipe -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSPipe) -> () throws -> Void)] {
         return [
             // Currently disabled until NSString implements dataUsingEncoding
             // ("test_NSPipe", test_NSPipe)

--- a/TestFoundation/TestNSPredicate.swift
+++ b/TestFoundation/TestNSPredicate.swift
@@ -17,7 +17,7 @@
 
 class TestNSPredicate: XCTestCase {
 
-    static var allTests : [(String, TestNSPredicate -> () throws -> Void)] {
+    static var allTests : [(String, (TestNSPredicate) -> () throws -> Void)] {
         return [
             ("test_BooleanPredicate", test_BooleanPredicate),
             ("test_BlockPredicateWithoutVariableBindings", test_BlockPredicateWithoutVariableBindings),

--- a/TestFoundation/TestNSProcessInfo.swift
+++ b/TestFoundation/TestNSProcessInfo.swift
@@ -19,7 +19,7 @@
 
 class TestNSProcessInfo : XCTestCase {
     
-    static var allTests: [(String, TestNSProcessInfo -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSProcessInfo) -> () throws -> Void)] {
         return [
             ("test_operatingSystemVersion", test_operatingSystemVersion ),
             ("test_processName", test_processName ),

--- a/TestFoundation/TestNSPropertyList.swift
+++ b/TestFoundation/TestNSPropertyList.swift
@@ -19,7 +19,7 @@ import SwiftXCTest
 
 
 class TestNSPropertyList : XCTestCase {
-    static var allTests: [(String, TestNSPropertyList -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSPropertyList) -> () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction ),
             ("test_decode", test_decode ),

--- a/TestFoundation/TestNSRange.swift
+++ b/TestFoundation/TestNSRange.swift
@@ -19,7 +19,7 @@ import SwiftXCTest
 
 class TestNSRange : XCTestCase {
     
-    static var allTests: [(String, TestNSRange -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSRange) -> () throws -> Void)] {
         return [
             // currently disabled due to pending requirements for NSString
             // ("test_NSRangeFromString", test_NSRangeFromString ),

--- a/TestFoundation/TestNSRegularExpression.swift
+++ b/TestFoundation/TestNSRegularExpression.swift
@@ -21,7 +21,7 @@ import SwiftXCTest
 
 class TestNSRegularExpression : XCTestCase {
     
-    static var allTests : [(String, TestNSRegularExpression -> () throws -> Void)] {
+    static var allTests : [(String, (TestNSRegularExpression) -> () throws -> Void)] {
         return [
             ("test_simpleRegularExpressions", test_simpleRegularExpressions),
             ("test_regularExpressionReplacement", test_regularExpressionReplacement),

--- a/TestFoundation/TestNSRunLoop.swift
+++ b/TestFoundation/TestNSRunLoop.swift
@@ -17,7 +17,7 @@
 
 
 class TestNSRunLoop : XCTestCase {
-    static var allTests : [(String, TestNSRunLoop -> () throws -> Void)] {
+    static var allTests : [(String, (TestNSRunLoop) -> () throws -> Void)] {
         return [
             ("test_constants", test_constants),
             ("test_runLoopInit", test_runLoopInit),

--- a/TestFoundation/TestNSScanner.swift
+++ b/TestFoundation/TestNSScanner.swift
@@ -21,7 +21,7 @@
 
 class TestNSScanner : XCTestCase {
 
-    static var allTests: [(String, TestNSScanner -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSScanner) -> () throws -> Void)] {
         return [
             ("test_scanInteger", test_scanInteger),
         ]

--- a/TestFoundation/TestNSSet.swift
+++ b/TestFoundation/TestNSSet.swift
@@ -21,7 +21,7 @@ import SwiftXCTest
 
 class TestNSSet : XCTestCase {
     
-    static var allTests: [(String, TestNSSet -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSSet) -> () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("testInitWithSet", testInitWithSet),

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -38,7 +38,7 @@ internal let kCFStringEncodingUTF32LE =  CFStringBuiltInEncodings.UTF32LE.rawVal
 
 class TestNSString : XCTestCase {
     
-    static var allTests: [(String, TestNSString -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSString) -> () throws -> Void)] {
         return [
             ("test_boolValue", test_boolValue ),
             ("test_BridgeConstruction", test_BridgeConstruction ),

--- a/TestFoundation/TestNSTask.swift
+++ b/TestFoundation/TestNSTask.swift
@@ -17,7 +17,7 @@
 import CoreFoundation
 
 class TestNSTask : XCTestCase {
-    static var allTests: [(String, TestNSTask -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSTask) -> () throws -> Void)] {
         return [
                    ("test_exit0" , test_exit0),
                    ("test_exit1" , test_exit1),

--- a/TestFoundation/TestNSThread.swift
+++ b/TestFoundation/TestNSThread.swift
@@ -18,7 +18,7 @@
 
 
 class TestNSThread : XCTestCase {
-    static var allTests: [(String, TestNSThread -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSThread) -> () throws -> Void)] {
         return [
             ("test_currentThread", test_currentThread ),
             ("test_threadStart", test_threadStart),

--- a/TestFoundation/TestNSTimeZone.swift
+++ b/TestFoundation/TestNSTimeZone.swift
@@ -21,7 +21,7 @@
 
 class TestNSTimeZone: XCTestCase {
 
-    static var allTests: [(String, TestNSTimeZone -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSTimeZone) -> () throws -> Void)] {
         return [
             // Disabled see https://bugs.swift.org/browse/SR-300
             // ("test_abbreviation", test_abbreviation),

--- a/TestFoundation/TestNSTimer.swift
+++ b/TestFoundation/TestNSTimer.swift
@@ -18,7 +18,7 @@
 
 
 class TestNSTimer : XCTestCase {
-    static var allTests : [(String, TestNSTimer -> () throws -> Void)] {
+    static var allTests : [(String, (TestNSTimer) -> () throws -> Void)] {
         return [
             ("test_timerInit", test_timerInit),
             ("test_timerTickOnce", test_timerTickOnce),

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -53,7 +53,7 @@ private func getTestData() -> [Any]? {
 }
 
 class TestNSURL : XCTestCase {
-    static var allTests: [(String, TestNSURL -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSURL) -> () throws -> Void)] {
         return [
             ("test_URLStrings", test_URLStrings),
             ("test_fileURLWithPath_relativeToURL", test_fileURLWithPath_relativeToURL ),
@@ -420,7 +420,7 @@ class TestNSURL : XCTestCase {
 }
     
 class TestNSURLComponents : XCTestCase {
-    static var allTests: [(String, TestNSURLComponents -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSURLComponents) -> () throws -> Void)] {
         return [
             ("test_string", test_string),
             ("test_port", test_portSetter),

--- a/TestFoundation/TestNSURLCredential.swift
+++ b/TestFoundation/TestNSURLCredential.swift
@@ -18,7 +18,7 @@
 
 class TestNSURLCredential : XCTestCase {
     
-    static var allTests: [(String, TestNSURLCredential -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSURLCredential) -> () throws -> Void)] {
         return [
                    ("test_construction", test_construction)
         ]

--- a/TestFoundation/TestNSURLRequest.swift
+++ b/TestFoundation/TestNSURLRequest.swift
@@ -18,7 +18,7 @@
 
 class TestNSURLRequest : XCTestCase {
     
-    static var allTests: [(String, TestNSURLRequest -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSURLRequest) -> () throws -> Void)] {
         return [
             ("test_construction", test_construction),
             ("test_mutableConstruction", test_mutableConstruction),

--- a/TestFoundation/TestNSURLResponse.swift
+++ b/TestFoundation/TestNSURLResponse.swift
@@ -18,7 +18,7 @@
 
 
 class TestNSURLResponse : XCTestCase {
-    static var allTests: [(String, TestNSURLResponse -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSURLResponse) -> () throws -> Void)] {
         return [
             ("test_URL", test_URL),
             ("test_MIMEType_1", test_MIMEType_1),
@@ -89,7 +89,7 @@ class TestNSURLResponse : XCTestCase {
 
 
 class TestNSHTTPURLResponse : XCTestCase {
-    static var allTests: [(String, TestNSHTTPURLResponse -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSHTTPURLResponse) -> () throws -> Void)] {
         return [
                    ("test_URL_and_status_1", test_URL_and_status_1),
                    ("test_URL_and_status_2", test_URL_and_status_2),

--- a/TestFoundation/TestNSUUID.swift
+++ b/TestFoundation/TestNSUUID.swift
@@ -19,7 +19,7 @@
 
 class TestNSUUID : XCTestCase {
     
-    static var allTests: [(String, TestNSUUID -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSUUID) -> () throws -> Void)] {
         return [
             ("test_Equality", test_Equality),
             ("test_InvalidUUID", test_InvalidUUID),

--- a/TestFoundation/TestNSUserDefaults.swift
+++ b/TestFoundation/TestNSUserDefaults.swift
@@ -16,7 +16,7 @@
 #endif
 
 class TestNSUserDefaults : XCTestCase {
-	static var allTests : [(String, TestNSUserDefaults -> () throws -> ())] {
+	static var allTests : [(String, (TestNSUserDefaults) -> () throws -> ())] {
 		return [
 			("test_createUserDefaults", test_createUserDefaults ),
 			("test_getRegisteredDefaultItem", test_getRegisteredDefaultItem ),

--- a/TestFoundation/TestNSValue.swift
+++ b/TestFoundation/TestNSValue.swift
@@ -18,7 +18,7 @@
 
 
 class TestNSValue : XCTestCase {
-    static var allTests: [(String, TestNSValue -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSValue) -> () throws -> Void)] {
         return [
             ( "test_valueWithLong", test_valueWithLong ),
             ( "test_valueWithCGPoint", test_valueWithCGPoint ),

--- a/TestFoundation/TestNSXMLDocument.swift
+++ b/TestFoundation/TestNSXMLDocument.swift
@@ -21,7 +21,7 @@ import CoreFoundation
 
 class TestNSXMLDocument : XCTestCase {
 
-    static var allTests: [(String, TestNSXMLDocument -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSXMLDocument) -> () throws -> Void)] {
         #if os(OSX) || os(iOS)
             return [
                 ("test_basicCreation", test_basicCreation),

--- a/TestFoundation/TestNSXMLParser.swift
+++ b/TestFoundation/TestNSXMLParser.swift
@@ -19,7 +19,7 @@ import SwiftXCTest
 
 class TestNSXMLParser : XCTestCase {
     
-    static var allTests: [(String, TestNSXMLParser -> () throws -> Void)] {
+    static var allTests: [(String, (TestNSXMLParser) -> () throws -> Void)] {
         return [
             ("test_data", test_data),
         ]


### PR DESCRIPTION
Enclose single-argument functions in parentheses to silence newly-added (https://github.com/apple/swift/commit/3d2b5bcc5350e1dea2ed8a0a95cd12ff5c760f24) warnings.