### PR TITLE
Creation of a serial queue in NSOperationQueue fails on setting property maxConcurrentOperationCount to "1"

### DIFF
--- a/Foundation/NSOperation.swift
+++ b/Foundation/NSOperation.swift
@@ -318,7 +318,7 @@ public class NSOperationQueue : NSObject {
             } else {
                 effectiveName = "NSOperationQueue::\(unsafeAddress(of: self))"
             }
-            let attr: dispatch_queue_attr_t
+            let attr: dispatch_queue_attr_t?
             if maxConcurrentOperationCount == 1 {
                 attr = DISPATCH_QUEUE_SERIAL
             } else {

--- a/TestFoundation/TestNSOperationQueue.swift
+++ b/TestFoundation/TestNSOperationQueue.swift
@@ -20,6 +20,8 @@ import SwiftXCTest
 class TestNSOperationQueue : XCTestCase {
     static var allTests: [(String, (TestNSOperationQueue) -> () throws -> Void)] {
         return [
+           /* uncomment below lines once Dispatch is enabled in Foundation */
+           // ("test_OperationPriorities", test_OperationPriorities),
             ("test_OperationCount", test_OperationCount)
         ]
     }
@@ -32,5 +34,37 @@ class TestNSOperationQueue : XCTestCase {
         /* uncomment below lines once Dispatch is enabled in Foundation */
         //queue.waitUntilAllOperationsAreFinished()
         //XCTAssertTrue(queue.operationCount == 0)
+    }
+
+    func test_OperationPriorities() {
+        var msgOperations = [String]()
+        let operation1 : NSBlockOperation = NSBlockOperation (block: {
+            msgOperations.append("Operation1 executed")
+        })
+        let operation2 : NSBlockOperation = NSBlockOperation (block: {
+            msgOperations.append("Operation2 executed")
+        })
+        let operation3 : NSBlockOperation = NSBlockOperation (block: {
+            msgOperations.append("Operation3 executed")
+        })
+        let operation4: NSBlockOperation = NSBlockOperation (block: {
+            msgOperations.append("Operation4 executed")
+        })
+        operation4.queuePriority = OperationQueuePriority.VeryLow
+        operation3.queuePriority = OperationQueuePriority.VeryHigh
+        operation2.queuePriority = OperationQueuePriority.Low
+        operation1.queuePriority = OperationQueuePriority.Normal
+        var operations = [NSOperation]()
+        operations.append(operation1)
+        operations.append(operation2)
+        operations.append(operation3)
+        operations.append(operation4)
+        let queue = NSOperationQueue()
+        queue.maxConcurrentOperationCount = 1
+        queue.addOperations(operations, waitUntilFinished: true)
+        XCTAssertEqual(msgOperations[0], "Operation3 executed")
+        XCTAssertEqual(msgOperations[1], "Operation1 executed")
+        XCTAssertEqual(msgOperations[2], "Operation2 executed")
+        XCTAssertEqual(msgOperations[3], "Operation4 executed")
     }
 }


### PR DESCRIPTION
Recreate:
----------------------------------------------------------------------------------------------------

     let operation1 : NSBlockOperation = NSBlockOperation (block: {
            sleep(1)
            print("Operation1")
        })
        let operation2 : NSBlockOperation = NSBlockOperation (block: {
            sleep(1)
            print("Operation2”)
        })
        var operations = [NSOperation]()
        operations.append(operation1)
        operations.append(operation2)
        let queue = NSOperationQueue()
        queue.maxConcurrentOperationCount = 1
        queue.addOperations(operations, waitUntilFinished: true)

----------------------------------------------------------------------------------------------------

Above code was tested with OpenSource Foundation on Mac. 

