### PR TITLE
Use _CFIsMainThread as a shim for pthread_main_np on Linux

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -806,7 +806,6 @@ CF_EXPORT void _NS_pthread_setname_np(const char *name);
 #endif
 
 #if DEPLOYMENT_TARGET_LINUX
-CF_EXPORT Boolean _CFIsMainThread(void);
 #define pthread_main_np _CFIsMainThread
 #endif
 

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -243,6 +243,8 @@ CF_PRIVATE CF_EXPORT char *_Nullable *_Nonnull _CFEnviron(void);
 
 CF_EXPORT void CFLog1(CFLogLevel lev, CFStringRef message);
 
+CF_EXPORT Boolean _CFIsMainThread(void);
+
 _CF_EXPORT_SCOPE_END
 
 #endif /* __COREFOUNDATION_FORSWIFTFOUNDATIONONLY__ */

--- a/Foundation/NSOperation.swift
+++ b/Foundation/NSOperation.swift
@@ -9,6 +9,12 @@
 
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
 import Dispatch
+#if os(Linux)
+import CoreFoundation
+private func pthread_main_np() -> Int32 {
+    return _CFIsMainThread() ? 1 : 0
+}
+#endif
 #endif
 
 public class NSOperation : NSObject {


### PR DESCRIPTION
`NSOperation.currentQueue()` makes a call to `pthread_main_np()`, which isn't supported on Linux. There's already a shim in CoreFoundation that implements the function under `_CFIsMainThread()`, so this PR:
1. Externalizes `_CFIsMainThread()`
2. Imports `CoreFoundation` and creates a `pthread_main_np` function that calls it

The implementation of the `pthread_main_np()` function in `NSOperation` is done as a top level function - that's probably not the right thing to do, but it allows it to be groups with the import of `CoreFoundation`, which is only required to expose `_CFIsMainThread()`. This way its a little more clear why the function is there, and makes it easier to clean up the code if we implement the `pthread_main_np()` shim a better way.
