### PR TITLE
implementation for NSURL.standardizedURL and NSURL.filePathURL properties

### DIFF
--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -521,7 +521,20 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
     
     /* A string constant for the "file" URL scheme. If you are using this to compare to a URL's scheme to see if it is a file URL, you should instead use the NSURL fileURL property -- the fileURL property is much faster. */
     public var standardized: URL? {
-        NSUnimplemented()
+        guard (path != nil) else {
+            return nil
+        }
+
+        let URLComponents = NSURLComponents(string: relativeString)
+        guard ((URLComponents != nil) && (URLComponents!.path != nil)) else {
+            return nil
+        }
+        guard (URLComponents!.path!.contains("..") || URLComponents!.path!.contains(".")) else{
+            return URLComponents!.url(relativeTo: baseURL)
+        }
+
+        URLComponents!.path! = _pathByRemovingDots(pathComponents!)
+        return URLComponents!.url(relativeTo: baseURL)
     }
     
     /* Returns whether the URL's resource exists and is reachable. This method synchronously checks if the resource's backing store is reachable. Checking reachability is appropriate when making decisions that do not require other immediate operations on the resource, e.g. periodic maintenance of UI state that depends on the existence of a specific document. When performing operations such as opening a file or copying resource properties, it is more efficient to simply try the operation and handle failures. If this method returns NO, the optional error is populated. This method is currently applicable only to URLs for file system resources. For other URL types, NO is returned. Symbol is present in iOS 4, but performs no operation.
@@ -535,7 +548,11 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
     /* Returns a file path URL that refers to the same resource as a specified URL. File path URLs use a file system style path. An error will occur if the url parameter is not a file URL. A file reference URL's resource must exist and be reachable to be converted to a file path URL. Symbol is present in iOS 4, but performs no operation.
     */
     public var filePathURL: URL? {
-        NSUnimplemented()
+        guard isFileURL else {
+            return nil
+        }
+
+        return URL(string: absoluteString)
     }
     
     override public var _cfTypeID: CFTypeID {
@@ -768,6 +785,38 @@ extension NSURL {
         }
         
         return URL(fileURLWithPath: resolvedPath)
+    }
+
+    private func _pathByRemovingDots(_ comps: [String]) -> String {
+        var components = comps
+        
+        if(components.last == "/") {
+            components.removeLast()
+        }
+
+        guard !components.isEmpty else {
+            return self.path!
+        }
+
+        let isAbsolutePath = components.first == "/"
+        var result : String = components.removeFirst()
+
+        for component in components {
+            switch component {
+                case ".":
+                    break
+                case ".." where isAbsolutePath:
+                    result = result.bridge().stringByDeletingLastPathComponent
+                default:
+                    result = result.bridge().stringByAppendingPathComponent(component)
+            }
+        }
+
+        if(self.path!.hasSuffix("/")) {
+            result += "/"
+        }
+
+        return result
     }
 }
 

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -149,9 +149,12 @@ class TestNSURL : XCTestCase {
             result["parameterString"] = url.parameterString ?? kNullString
             result["relativePath"] = url.relativePath ?? kNullString
             result["isFileURL"] = url.isFileURL ? "YES" : "NO"
-            // Not yet implemented
-            // result["standardizedURL"] = url.standardizedURL?.relativeString ?? kNullString
-            
+            do {
+                let url = try url.standardized()
+                result["standardizedURL"] = url.relativeString
+            } catch {
+                result["standardizedURL"] = kNullString
+            } 
             // Temporarily disabled because we're only checking string results
             // result["pathComponents"] = url.pathComponents ?? kNullString
             result["lastPathComponent"] = url.lastPathComponent ?? kNullString
@@ -222,14 +225,11 @@ class TestNSURL : XCTestCase {
             }
             if let url = url {
 
-                // TODO: NSURL.standardizedURL isn't implemented yet.
-                var modifiedExpectedNSResult = expectedNSResult as! [String: Any]
-                modifiedExpectedNSResult["standardizedURL"] = nil
                 if title == "NSURLWithString-parse-ambiguous-url-001" {
                     // TODO: Fix this test
                 } else {
                     let results = generateResults(url, pathComponent: inPathComponent, pathExtension: inPathExtension)
-                    let (isEqual, differences) = compareResults(url, expected: modifiedExpectedNSResult, got: results)
+                    let (isEqual, differences) = compareResults(url, expected: expectedNSResult as! [String: Any], got: results)
                     XCTAssertTrue(isEqual, "\(title): \(differences)")
                 }
             } else {


### PR DESCRIPTION
Implementation for NSURL.standardizedURL and NSURL.filePathURL is added and enabled tests for NSURL.standardizedURL in TestNSURL.swift

