### PR TITLE
Implement some methods for NSAttributedString and NSMutableAttributedString

### DIFF
--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -12,8 +12,8 @@ import CoreFoundation
 public class NSAttributedString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     
     private let _cfinfo = _CFInfo(typeID: CFAttributedStringGetTypeID())
-    private let _string: NSString
-    private let _attributeArray: CFRunArrayRef
+    private var _string: NSString
+    private var _attributeArray: CFRunArrayRef
     
     public required init?(coder aDecoder: NSCoder) {
         NSUnimplemented()
@@ -48,28 +48,11 @@ public class NSAttributedString : NSObject, NSCopying, NSMutableCopying, NSSecur
     }
     
     public func attributesAtIndex(_ location: Int, effectiveRange range: NSRangePointer) -> [String : AnyObject] {
-        var cfRange = CFRange()
-        return withUnsafeMutablePointer(&cfRange) { (rangePointer: UnsafeMutablePointer<CFRange>) -> [String : AnyObject] in
-            // Get attributes value using CoreFoundation function
-            let value = CFAttributedStringGetAttributes(_cfObject, location, rangePointer)
-            
-            // Convert the value to [String : AnyObject]
-            let dictionary = unsafeBitCast(value, to: NSDictionary.self)
-            var results = [String : AnyObject]()
-            for (key, value) in dictionary {
-                guard let stringKey = (key as? NSString)?._swiftObject else {
-                    continue
-                }
-                results[stringKey] = value
-            }
-            
-            // Update effective range
-            let hasAttrs = results.count > 0
-            range.pointee.location = hasAttrs ? rangePointer.pointee.location : NSNotFound
-            range.pointee.length = hasAttrs ? rangePointer.pointee.length : 0
-            
-            return results
-        }
+        let rangeInfo = RangeInfo(
+            rangePointer: range,
+            shouldFetchLongestEffectiveRange: false,
+            longestEffectiveRangeSearchRange: nil)
+        return _attributesAtIndex(location, rangeInfo: rangeInfo)
     }
 
     public var length: Int {
@@ -77,28 +60,30 @@ public class NSAttributedString : NSObject, NSCopying, NSMutableCopying, NSSecur
     }
     
     public func attribute(_ attrName: String, atIndex location: Int, effectiveRange range: NSRangePointer) -> AnyObject? {
-        var cfRange = CFRange()
-        return withUnsafeMutablePointer(&cfRange) { (rangePointer: UnsafeMutablePointer<CFRange>) -> AnyObject? in
-            // Get attribute value using CoreFoundation function
-            let attribute = CFAttributedStringGetAttribute(_cfObject, location, attrName._cfObject, rangePointer)
-            
-            // Update effective range and return the result
-            if let attribute = attribute {
-                range.pointee.location = rangePointer.pointee.location
-                range.pointee.length = rangePointer.pointee.length
-                return attribute
-            } else {
-                range.pointee.location = NSNotFound
-                range.pointee.length = 0
-                return nil
-            }
-        }
+        let rangeInfo = RangeInfo(
+            rangePointer: range,
+            shouldFetchLongestEffectiveRange: false,
+            longestEffectiveRangeSearchRange: nil)
+        return _attribute(attrName, atIndex: location, rangeInfo: rangeInfo)
     }
     
     public func attributedSubstringFromRange(_ range: NSRange) -> NSAttributedString { NSUnimplemented() }
     
-    public func attributesAtIndex(_ location: Int, longestEffectiveRange range: NSRangePointer, inRange rangeLimit: NSRange) -> [String : AnyObject] { NSUnimplemented() }
-    public func attribute(_ attrName: String, atIndex location: Int, longestEffectiveRange range: NSRangePointer, inRange rangeLimit: NSRange) -> AnyObject? { NSUnimplemented() }
+    public func attributesAtIndex(_ location: Int, longestEffectiveRange range: NSRangePointer, inRange rangeLimit: NSRange) -> [String : AnyObject] {
+        let rangeInfo = RangeInfo(
+            rangePointer: range,
+            shouldFetchLongestEffectiveRange: true,
+            longestEffectiveRangeSearchRange: rangeLimit)
+        return _attributesAtIndex(location, rangeInfo: rangeInfo)
+    }
+    
+    public func attribute(_ attrName: String, atIndex location: Int, longestEffectiveRange range: NSRangePointer, inRange rangeLimit: NSRange) -> AnyObject? {
+        let rangeInfo = RangeInfo(
+            rangePointer: range,
+            shouldFetchLongestEffectiveRange: true,
+            longestEffectiveRangeSearchRange: rangeLimit)
+        return _attribute(attrName, atIndex: location, rangeInfo: rangeInfo)
+    }
     
     public func isEqualToAttributedString(_ other: NSAttributedString) -> Bool { NSUnimplemented() }
     
@@ -120,6 +105,71 @@ public class NSAttributedString : NSObject, NSCopying, NSMutableCopying, NSSecur
     
     public init(attributedString attrStr: NSAttributedString) { NSUnimplemented() }
     
+    public func enumerateAttributesInRange(_ enumerationRange: NSRange, options opts: NSAttributedStringEnumerationOptions, usingBlock block: ([String : AnyObject], NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) { NSUnimplemented() }
+    public func enumerateAttribute(_ attrName: String, inRange enumerationRange: NSRange, options opts: NSAttributedStringEnumerationOptions, usingBlock block: (AnyObject?, NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) { NSUnimplemented() }
+}
+
+private extension NSAttributedString {
+    private struct RangeInfo {
+        let rangePointer: NSRangePointer
+        let shouldFetchLongestEffectiveRange: Bool
+        let longestEffectiveRangeSearchRange: NSRange?
+    }
+    
+    private func _attributesAtIndex(_ location: Int, rangeInfo: RangeInfo) -> [String : AnyObject] {
+        var cfRange = CFRange()
+        return withUnsafeMutablePointer(&cfRange) { (cfRangePointer: UnsafeMutablePointer<CFRange>) -> [String : AnyObject] in
+            // Get attributes value using CoreFoundation function
+            let value: CFDictionary
+            if rangeInfo.shouldFetchLongestEffectiveRange, let searchRange = rangeInfo.longestEffectiveRangeSearchRange {
+                value = CFAttributedStringGetAttributesAndLongestEffectiveRange(_cfObject, location, CFRange(searchRange), cfRangePointer)
+            } else {
+                value = CFAttributedStringGetAttributes(_cfObject, location, cfRangePointer)
+            }
+            
+            // Convert the value to [String : AnyObject]
+            let dictionary = unsafeBitCast(value, to: NSDictionary.self)
+            var results = [String : AnyObject]()
+            for (key, value) in dictionary {
+                guard let stringKey = (key as? NSString)?._swiftObject else {
+                    continue
+                }
+                results[stringKey] = value
+            }
+            
+            // Update effective range
+            let hasAttrs = results.count > 0
+            rangeInfo.rangePointer.pointee.location = hasAttrs ? cfRangePointer.pointee.location : NSNotFound
+            rangeInfo.rangePointer.pointee.length = hasAttrs ? cfRangePointer.pointee.length : 0
+            
+            return results
+        }
+    }
+    
+    private func _attribute(_ attrName: String, atIndex location: Int, rangeInfo: RangeInfo) -> AnyObject? {
+        var cfRange = CFRange()
+        return withUnsafeMutablePointer(&cfRange) { (cfRangePointer: UnsafeMutablePointer<CFRange>) -> AnyObject? in
+            // Get attribute value using CoreFoundation function
+            let attribute: AnyObject?
+            if rangeInfo.shouldFetchLongestEffectiveRange, let searchRange = rangeInfo.longestEffectiveRangeSearchRange {
+                attribute = CFAttributedStringGetAttributeAndLongestEffectiveRange(_cfObject, location, attrName._cfObject, CFRange(searchRange), cfRangePointer)
+            } else {
+                attribute = CFAttributedStringGetAttribute(_cfObject, location, attrName._cfObject, cfRangePointer)
+            }
+            
+            // Update effective range and return the result
+            if let attribute = attribute {
+                rangeInfo.rangePointer.pointee.location = cfRangePointer.pointee.location
+                rangeInfo.rangePointer.pointee.length = cfRangePointer.pointee.length
+                return attribute
+            } else {
+                rangeInfo.rangePointer.pointee.location = NSNotFound
+                rangeInfo.rangePointer.pointee.length = 0
+                return nil
+            }
+        }
+    }
+    
     private func addAttributesToAttributeArray(attrs: [String : AnyObject]?) {
         guard _string.length > 0 else {
             return
@@ -133,9 +183,6 @@ public class NSAttributedString : NSObject, NSCopying, NSMutableCopying, NSSecur
             CFRunArrayInsert(_attributeArray, range, emptyAttrs._cfObject)
         }
     }
-
-    public func enumerateAttributesInRange(_ enumerationRange: NSRange, options opts: NSAttributedStringEnumerationOptions, usingBlock block: ([String : AnyObject], NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) { NSUnimplemented() }
-    public func enumerateAttribute(_ attrName: String, inRange enumerationRange: NSRange, options opts: NSAttributedStringEnumerationOptions, usingBlock block: (AnyObject?, NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) { NSUnimplemented() }
 }
 
 extension NSAttributedString: _CFBridgable {
@@ -155,12 +202,17 @@ public class NSMutableAttributedString : NSAttributedString {
     
     public func replaceCharactersInRange(_ range: NSRange, withString str: String) { NSUnimplemented() }
     public func setAttributes(_ attrs: [String : AnyObject]?, range: NSRange) { NSUnimplemented() }
-
     
-    public var mutableString: NSMutableString { NSUnimplemented() }
+    public var mutableString: NSMutableString {
+        return _string as! NSMutableString
+    }
     
-    public func addAttribute(_ name: String, value: AnyObject, range: NSRange) { NSUnimplemented() }
+    public func addAttribute(_ name: String, value: AnyObject, range: NSRange) {
+        CFAttributedStringSetAttribute(_cfMutableObject, CFRange(range), name._cfObject, value)
+    }
+    
     public func addAttributes(_ attrs: [String : AnyObject], range: NSRange) { NSUnimplemented() }
+    
     public func removeAttribute(_ name: String, range: NSRange) { NSUnimplemented() }
     
     public func replaceCharactersInRange(_ range: NSRange, withAttributedString attrString: NSAttributedString) { NSUnimplemented() }
@@ -171,5 +223,18 @@ public class NSMutableAttributedString : NSAttributedString {
     
     public func beginEditing() { NSUnimplemented() }
     public func endEditing() { NSUnimplemented() }
+    
+    public override init(string str: String) {
+        super.init(string: str)
+        _string = NSMutableString(string: str)
+    }
+    
+    public required init?(coder aDecoder: NSCoder) {
+        NSUnimplemented()
+    }
+    
 }
 
+extension NSMutableAttributedString {
+    internal var _cfMutableObject: CFMutableAttributedString { return unsafeBitCast(self, to: CFMutableAttributedString.self) }
+}

--- a/TestFoundation/TestNSAttributedString.swift
+++ b/TestFoundation/TestNSAttributedString.swift
@@ -79,4 +79,45 @@ class TestNSAttributedString : XCTestCase {
         XCTAssertEqual(validAttribute, "attribute.placeholder.value")
     }
     
+    func test_longestEffectiveRange() {
+        let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur et sem vitae consectetur. Nam venenatis lectus a laoreet blandit."
+        
+        let attrKey = "attribute.placeholder.key"
+        let attrValue = "attribute.placeholder.value" as NSString
+        
+        let attrRange1 = NSRange(location: 0, length: 20)
+        let attrRange2 = NSRange(location: 18, length: 10)
+        
+        let attrString = NSMutableAttributedString(string: string)
+        attrString.addAttribute(attrKey, value: attrValue, range: attrRange1)
+        attrString.addAttribute(attrKey, value: attrValue, range: attrRange2)
+        
+        let searchRange = NSRange(location: 0, length: attrString.length)
+        var range = NSRange()
+        
+        _ = attrString.attribute(attrKey, atIndex: 0, longestEffectiveRange: &range, inRange: searchRange)
+        XCTAssertEqual(range.location, 0)
+        XCTAssertEqual(range.length, 29)
+        
+        _ = attrString.attributesAtIndex(0, longestEffectiveRange: &range, inRange: searchRange)
+        XCTAssertEqual(range.location, 0)
+        XCTAssertEqual(range.length, 29)
+    }
+    
+}
+
+class TestNSMutableAttributedString : XCTestCase {
+    
+    static var allTests: [(String, (TestNSMutableAttributedString) -> () throws -> Void)] {
+        return [
+            ("test_initWithString", test_initWithString),
+        ]
+    }
+    
+    func test_initWithString() {
+        let string = "Lorem 😀 ipsum dolor sit amet, consectetur adipiscing elit. ⌘ Phasellus consectetur et sem vitae consectetur. Nam venenatis lectus a laoreet blandit. ಠ_ರೃ"
+        let mutableAttrString = NSMutableAttributedString(string: string)
+        XCTAssertEqual(mutableAttrString.mutableString, NSMutableString(string: string))
+    }
+    
 }

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -75,5 +75,6 @@ XCTMain([
     testCase(TestNSXMLParser.allTests),
     testCase(TestNSXMLDocument.allTests),
     testCase(TestNSAttributedString.allTests),
+    testCase(TestNSMutableAttributedString.allTests),
     testCase(TestNSFileHandle.allTests),
 ])


### PR DESCRIPTION
This pull request contains the following NSAttributedString and NSMutableAttributedString method implementations:

#### NSAttributedString
- `attributesAtIndex(_ location: Int, longestEffectiveRange range: NSRangePointer, inRange rangeLimit: NSRange) -> [String : AnyObject]`
- `attribute(_ attrName: String, atIndex location: Int, longestEffectiveRange range: NSRangePointer, inRange rangeLimit: NSRange) -> AnyObject?`

#### NSMutableAttributedString
- `init(string str: String)`
- `mutableString: NSMutableString`
- `addAttribute(_ name: String, value: AnyObject, range: NSRange)`