### PR TITLE
Fix crash when running test_xmlpath

### DIFF
--- a/Foundation/NSXMLNode.swift
+++ b/Foundation/NSXMLNode.swift
@@ -262,7 +262,11 @@ public class NSXMLNode : NSObject, NSCopying {
     */
     public var name: String? {
         get {
-            return String(cString: _CFXMLNodeGetName(_xmlNode))
+            guard _CFXMLNodeGetName(_xmlNode) != UnsafePointer<Int8>(bitPattern: 0) else
+            {
+                return nil
+            }
+            return String(UTF8String: _CFXMLNodeGetName(_xmlNode))
         }
         set {
             if let newName = newValue {

--- a/TestFoundation/TestNSXMLDocument.swift
+++ b/TestFoundation/TestNSXMLDocument.swift
@@ -46,7 +46,7 @@ class TestNSXMLDocument : XCTestCase {
             return [
                 ("test_basicCreation", test_basicCreation),
                 ("test_nextPreviousNode", test_nextPreviousNode),
-                //                ("test_xpath", test_xpath),
+                ("test_xpath", test_xpath),
                 ("test_elementCreation", test_elementCreation),
                 ("test_elementChildren", test_elementChildren),
                 ("test_stringValue", test_stringValue),


### PR DESCRIPTION
Resolve crash when _CFXMLNodeGetName returns an empty string.

For some reason and empty pointer causes a crash during the String init.