### PR TITLE
Foundation: clear up some unused return value warnings

### DIFF
--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -392,12 +392,12 @@ extension NSData {
         }
         return NSData(bytes: bytes.advanced(by: range.location), length: range.length)
     }
-    
+
     internal func makeTemporaryFileInDirectory(_ dirPath: String) throws -> (Int32, String) {
         let template = dirPath._nsObject.stringByAppendingPathComponent("tmp.XXXXXX")
         let maxLength = Int(PATH_MAX) + 1
         var buf = [Int8](repeating: 0, count: maxLength)
-        template._nsObject.getFileSystemRepresentation(&buf, maxLength: maxLength)
+        let _ = template._nsObject.getFileSystemRepresentation(&buf, maxLength: maxLength)
         let fd = mkstemp(&buf)
         if fd == -1 {
             throw _NSErrorWithErrno(errno, reading: false, path: dirPath)
@@ -405,7 +405,7 @@ extension NSData {
         let pathResult = NSFileManager.defaultManager().string(withFileSystemRepresentation:buf, length: Int(strlen(buf)))
         return (fd, pathResult)
     }
-    
+
     internal class func writeToFileDescriptor(_ fd: Int32, path: String? = nil, buf: UnsafePointer<Void>, length: Int) throws {
         var bytesRemaining = length
         while bytesRemaining > 0 {

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -50,17 +50,17 @@ public class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
     public var timeIntervalSinceReferenceDate: NSTimeInterval {
         return _timeIntervalSinceReferenceDate
     }
-    
+
     public convenience override init() {
         var tv = timeval()
-        withUnsafeMutablePointer(&tv) { t in
+        let _ = withUnsafeMutablePointer(&tv) { t in
             gettimeofday(t, nil)
         }
         var timestamp = NSTimeInterval(tv.tv_sec) - NSTimeIntervalSince1970
         timestamp += NSTimeInterval(tv.tv_usec) / 1000000.0
         self.init(timeIntervalSinceReferenceDate: timestamp)
     }
-    
+
     public required init(timeIntervalSinceReferenceDate ti: NSTimeInterval) {
         _timeIntervalSinceReferenceDate = ti
     }

--- a/Foundation/NSFileManager.swift
+++ b/Foundation/NSFileManager.swift
@@ -458,7 +458,7 @@ public class NSFileManager : NSObject {
             }
         }
     }
-    
+
     public func removeItem(atPath path: String) throws {
         if rmdir(path) == 0 {
             return
@@ -471,12 +471,12 @@ public class NSFileManager : NSObject {
             let stream = fts_open(ps, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR, nil)
             ps.deinitialize(count: 2)
             ps.deallocateCapacity(2)
-            
+
             if stream != nil {
                 defer {
                     fts_close(stream)
                 }
-                
+
                 var current = fts_read(stream)
                 while current != nil {
                     switch Int32(current!.pointee.fts_info) {
@@ -496,7 +496,7 @@ public class NSFileManager : NSObject {
                     current = fts_read(stream)
                 }
             } else {
-                _NSErrorWithErrno(ENOTEMPTY, reading: false, path: path)
+                let _ = _NSErrorWithErrno(ENOTEMPTY, reading: false, path: path)
             }
             // TODO: Error handling if fts_read fails.
 
@@ -506,7 +506,7 @@ public class NSFileManager : NSObject {
             throw _NSErrorWithErrno(errno, reading: false, path: path)
         }
     }
-    
+
     public func copyItem(at srcURL: NSURL, to dstURL: NSURL) throws {
         guard srcURL.fileURL else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileWriteUnsupportedSchemeError.rawValue, userInfo: [NSURLErrorKey : srcURL])
@@ -607,7 +607,7 @@ public class NSFileManager : NSObject {
                     return true
                 }
                 // chase the link; too bad if it is a slink to /Net/foo
-                stat(path, &s) >= 0
+                stat(path, &s)
             }
         } else {
             return false

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -786,16 +786,16 @@ private func _scanDoublesFromString(_ aString: String, number: Int) -> [Double] 
     digitSet.addCharacters(in: "-")
     var result = [Double](repeating: 0.0, count: number)
     var index = 0
-    
-    scanner.scanUpToCharactersFromSet(digitSet)
+
+    let _ = scanner.scanUpToCharactersFromSet(digitSet)
     while !scanner.atEnd && index < number {
         if let num = scanner.scanDouble() {
             result[index] = num
         }
-        scanner.scanUpToCharactersFromSet(digitSet)
+        let _ = scanner.scanUpToCharactersFromSet(digitSet)
         index += 1
     }
-    
+
     return result
 }
 

--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -388,17 +388,17 @@ public class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding 
         
         return result
     }
-    
+
     public func enumerateIndexesUsingBlock(_ block: (Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
         enumerateIndexesWithOptions([], usingBlock: block)
     }
     public func enumerateIndexesWithOptions(_ opts: NSEnumerationOptions, usingBlock block: (Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
-        _enumerateWithOptions(opts, range: NSMakeRange(0, Int.max), paramType: Int.self, returnType: Void.self, block: block)
+        let _ = _enumerateWithOptions(opts, range: NSMakeRange(0, Int.max), paramType: Int.self, returnType: Void.self, block: block)
     }
     public func enumerateIndexesInRange(_ range: NSRange, options opts: NSEnumerationOptions, usingBlock block: (Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
-        _enumerateWithOptions(opts, range: range, paramType: Int.self, returnType: Void.self, block: block)
+        let _ = _enumerateWithOptions(opts, range: range, paramType: Int.self, returnType: Void.self, block: block)
     }
-    
+
     public func indexPassingTest(_ predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
         return indexWithOptions([], passingTest: predicate)
     }
@@ -417,30 +417,28 @@ public class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding 
     }
     public func indexesInRange(_ range: NSRange, options opts: NSEnumerationOptions, passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> NSIndexSet {
         let result = NSMutableIndexSet()
-        _enumerateWithOptions(opts, range: range, paramType: Int.self, returnType: Void.self) { idx, stop in
+        let _ = _enumerateWithOptions(opts, range: range, paramType: Int.self, returnType: Void.self) { idx, stop in
             if predicate(idx, stop) {
                 result.addIndex(idx)
             }
         }
         return result
     }
-    
+
     /*
      The following three convenience methods allow you to enumerate the indexes in the receiver by ranges of contiguous indexes. The performance of these methods is not guaranteed to be any better than if they were implemented with enumerateIndexesInRange:options:usingBlock:. However, depending on the receiver's implementation, they may perform better than that.
-     
+
      If the specified range for enumeration intersects a range of contiguous indexes in the receiver, then the block will be invoked with the intersection of those two ranges.
     */
     public func enumerateRangesUsingBlock(_ block: (NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
         enumerateRangesWithOptions([], usingBlock: block)
     }
     public func enumerateRangesWithOptions(_ opts: NSEnumerationOptions, usingBlock block: (NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
-        _enumerateWithOptions(opts, range: NSMakeRange(0, Int.max), paramType: NSRange.self, returnType: Void.self, block: block)
+        let _ = _enumerateWithOptions(opts, range: NSMakeRange(0, Int.max), paramType: NSRange.self, returnType: Void.self, block: block)
     }
     public func enumerateRangesInRange(_ range: NSRange, options opts: NSEnumerationOptions, usingBlock block: (NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
-        _enumerateWithOptions(opts, range: range, paramType: NSRange.self, returnType: Void.self, block: block)
+        let _ = _enumerateWithOptions(opts, range: range, paramType: NSRange.self, returnType: Void.self, block: block)
     }
-
-
 }
 
 extension NSIndexSet : Sequence {

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -202,7 +202,7 @@ public class NSKeyedArchiver : NSCoder {
     private func _writeBinaryData(_ plist : NSDictionary) -> Bool {
         return __CFBinaryPlistWriteToStream(plist, self._stream) > 0
     }
-    
+
     public func finishEncoding() {
         if _flags.contains(ArchiverFlags.FinishedEncoding) {
             return
@@ -210,18 +210,18 @@ public class NSKeyedArchiver : NSCoder {
 
         var plist = Dictionary<String, Any>()
         var success : Bool
-        
+
         plist["$archiver"] = NSStringFromClass(self.dynamicType)
         plist["$version"] = NSKeyedArchivePlistVersion
         plist["$objects"] = self._objects
         plist["$top"] = self._containers[0].dict
-        
+
         if let unwrappedDelegate = self.delegate {
             unwrappedDelegate.archiverWillFinish(self)
         }
 
         let nsPlist = plist.bridge()
-        
+
         if self.outputFormat == NSPropertyListFormat.XMLFormat_v1_0 {
             success = _writeXMLData(nsPlist)
         } else {
@@ -233,10 +233,10 @@ public class NSKeyedArchiver : NSCoder {
         }
 
         if success {
-            self._flags.insert(ArchiverFlags.FinishedEncoding)
+            let _ = self._flags.insert(ArchiverFlags.FinishedEncoding)
         }
     }
-    
+
     public class func setClassName(_ codedName: String?, forClass cls: AnyClass) {
         let clsName = String(cls.dynamicType)
         _classNameMapLock.synchronized {
@@ -555,8 +555,8 @@ public class NSKeyedArchiver : NSCoder {
         var objectRef : CFKeyedArchiverUID? // encoded object reference
         let haveVisited : Bool
 
-        _validateStillEncoding()
-        
+        let _ = _validateStillEncoding()
+
         haveVisited = _haveVisited(objv)
         object = _replacementObject(objv)
 
@@ -565,9 +565,9 @@ public class NSKeyedArchiver : NSCoder {
             // we can return nil if the object is being conditionally encoded
             return nil
         }
-        
+
         _validateObjectSupportsSecureCoding(object)
-    
+
         if !haveVisited {
             var encodedObject : Any
 
@@ -578,7 +578,7 @@ public class NSKeyedArchiver : NSCoder {
 
                 let innerEncodingContext = EncodingContext()
                 var cls : AnyClass?
-                
+
                 _pushEncodingContext(innerEncodingContext)
                 codable.encodeWithCoder(self)
 
@@ -587,17 +587,17 @@ public class NSKeyedArchiver : NSCoder {
                 if cls == nil {
                     cls = object!.dynamicType
                 }
-                
+
                 _setObjectInCurrentEncodingContext(_classReference(cls!), forKey: "$class", escape: false)
                 _popEncodingContext()
                 encodedObject = innerEncodingContext.dict
             } else {
                 encodedObject = object!
             }
-            
+
             _setObject(encodedObject, forReference: unwrappedObjectRef)
         }
-        
+
         if let unwrappedDelegate = self.delegate {
             unwrappedDelegate.archiver(self, didEncodeObject: object)
         }
@@ -643,12 +643,12 @@ public class NSKeyedArchiver : NSCoder {
         }
         encodeObject(aPropertyList, forKey: key)
     }
-    
+
     public func _encodePropertyList(_ aPropertyList: AnyObject, forKey key: String? = nil) {
-        _validateStillEncoding()
+        let _ = _validateStillEncoding()
         _setObjectInCurrentEncodingContext(aPropertyList, forKey: key)
     }
-    
+
     internal func _encodeValue<T: NSObject where T: NSCoding>(_ objv: T, forKey key: String? = nil) {
         _encodePropertyList(objv, forKey: key)
     }
@@ -808,7 +808,7 @@ public class NSKeyedArchiver : NSCoder {
         }
         set {
             if newValue {
-                _flags.insert(ArchiverFlags.RequiresSecureCoding)
+                let _ = _flags.insert(ArchiverFlags.RequiresSecureCoding)
             } else {
                 _flags.remove(ArchiverFlags.RequiresSecureCoding)
             }

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -425,15 +425,15 @@ public class NSKeyedUnarchiver : NSCoder {
         
         return supportsSecureCoding
     }
-    
+
     /**
         Decode an object for the given reference
      */
     private func _decodeObject(_ objectRef: AnyObject) throws -> AnyObject? {
         var object : AnyObject? = nil
-        
-        _validateStillDecoding()
-        
+
+        let _ = _validateStillDecoding()
+
         if !NSKeyedUnarchiver._isReference(objectRef) {
             throw _decodingError(NSCocoaError.CoderReadCorruptError,
                                  withDescription: "Object \(objectRef) is not a reference. The data may be corrupt.")
@@ -443,7 +443,7 @@ public class NSKeyedUnarchiver : NSCoder {
             throw _decodingError(NSCocoaError.CoderReadCorruptError,
                                  withDescription: "Invalid object reference \(objectRef). The data may be corrupt.")
         }
-        
+
         if dereferencedObject as? String == NSKeyedArchiveNullObjectReferenceName {
             return nil
         }
@@ -456,7 +456,7 @@ public class NSKeyedUnarchiver : NSCoder {
                     throw _decodingError(NSCocoaError.CoderReadCorruptError,
                                          withDescription: "Invalid object encoding \(objectRef). The data may be corrupt.")
                 }
-    
+
                 let innerDecodingContext = DecodingContext(dict)
 
                 let classReference = innerDecodingContext.dict["$class"] as? CFKeyedArchiverUID
@@ -467,27 +467,27 @@ public class NSKeyedUnarchiver : NSCoder {
 
                 var classToConstruct : AnyClass? = try _validateAndMapClassReference(classReference!,
                                                                                      allowedClasses: self.allowedClasses)
-                
+
                 _pushDecodingContext(innerDecodingContext)
                 defer { _popDecodingContext() } // ensure an error does not invalidate the decoding context stack
 
                 if let ns = classToConstruct as? NSObject.Type {
                     classToConstruct = ns.classForKeyedUnarchiver()
                 }
-                
+
                 guard let decodableClass = classToConstruct as? NSCoding.Type else {
                     throw _decodingError(NSCocoaError.CoderReadCorruptError,
                                          withDescription: "Class \(classToConstruct!) is not decodable. The data may be corrupt.")
                 }
-                
-                _validateClassSupportsSecureCoding(classToConstruct)
-                
+
+                let _ = _validateClassSupportsSecureCoding(classToConstruct)
+
                 object = decodableClass.init(coder: self) as? AnyObject
                 guard object != nil else {
                     throw _decodingError(NSCocoaError.CoderReadCorruptError,
                                          withDescription: "Class \(classToConstruct!) failed to decode. The data may be corrupt.")
                 }
-                
+
                 _cacheObject(object!, forReference: objectRef)
             }
         } else {
@@ -499,10 +499,10 @@ public class NSKeyedUnarchiver : NSCoder {
                 object = dereferencedObject as? AnyObject
             }
         }
-    
+
         return _replacementObject(object)
     }
-    
+
     /**
             Internal function to decode an object. Returns the decoded object or throws an error.
      */
@@ -514,15 +514,15 @@ public class NSKeyedUnarchiver : NSCoder {
         
         return try _decodeObject(objectRef!)
     }
-    
+
     /**
         Decode a value type in the current decoding context
      */
     internal func _decodeValue<T>(forKey key: String? = nil) -> T? {
-        _validateStillDecoding()
+        let _ = _validateStillDecoding()
         return _objectInCurrentDecodingContext(forKey: key)
     }
-    
+
     /**
         Helper for NSArray/NSDictionary to dereference and decode an array of objects
      */
@@ -562,7 +562,7 @@ public class NSKeyedUnarchiver : NSCoder {
         
         return array
     }
-    
+
     /**
      Called when the caller has finished decoding.
      */
@@ -570,20 +570,20 @@ public class NSKeyedUnarchiver : NSCoder {
         if _flags.contains(UnarchiverFlags.FinishedDecoding) {
             return
         }
-        
+
         if let unwrappedDelegate = self.delegate {
             unwrappedDelegate.unarchiverWillFinish(self)
         }
-        
+
         // FIXME are we supposed to do anything here?
-        
+
         if let unwrappedDelegate = self.delegate {
             unwrappedDelegate.unarchiverDidFinish(self)
         }
-        
-        self._flags.insert(UnarchiverFlags.FinishedDecoding)
+
+        let _ = self._flags.insert(UnarchiverFlags.FinishedDecoding)
     }
-    
+
     public class func setClass(_ cls: AnyClass?, forClassName codedName: String) {
         _classNameMapLock.synchronized {
             _classNameMap[codedName] = cls
@@ -886,7 +886,7 @@ public class NSKeyedUnarchiver : NSCoder {
                 }
             } else {
                 if newValue {
-                    _flags.insert(UnarchiverFlags.RequiresSecureCoding)
+                    let _ = _flags.insert(UnarchiverFlags.RequiresSecureCoding)
                 }
             }
         }

--- a/Foundation/NSLock.swift
+++ b/Foundation/NSLock.swift
@@ -70,11 +70,11 @@ public class NSConditionLock : NSObject, NSLocking {
     public init(condition: Int) {
         _value = condition
     }
-    
+
     public func lock() {
-        lockBeforeDate(NSDate.distantFuture())
+        let _ = lockBeforeDate(NSDate.distantFuture())
     }
-    
+
     public func unlock() {
         _cond.lock()
         _thread = nil
@@ -85,11 +85,11 @@ public class NSConditionLock : NSObject, NSLocking {
     public var condition: Int {
         return _value
     }
-    
+
     public func lockWhenCondition(_ condition: Int) {
-        lockWhenCondition(condition, beforeDate: NSDate.distantFuture())
+        let _ = lockWhenCondition(condition, beforeDate: NSDate.distantFuture())
     }
-    
+
     public func tryLock() -> Bool {
         return lockBeforeDate(NSDate.distantPast())
     }

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -268,7 +268,7 @@ public class NSNumber : NSValue {
             break
         }
     }
-    
+
     public required convenience init?(coder aDecoder: NSCoder) {
         if !aDecoder.allowsKeyedCoding {
             var objCType: UnsafeMutablePointer<Int8>? = nil
@@ -279,7 +279,7 @@ public class NSNumber : NSValue {
                 return nil
             }
             var size: Int = 0
-            NSGetSizeAndAlignment(objCType!, &size, nil)
+            let _ = NSGetSizeAndAlignment(objCType!, &size, nil)
             let buffer = malloc(size)!
             aDecoder.decodeValueOfObjCType(objCType!, at: buffer)
             self.init(bytes: buffer, objCType: objCType!)

--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -631,7 +631,7 @@ internal func _NSCreateTemporaryFile(_ filePath: String) throws -> (Int32, Strin
     let template = "." + filePath + ".tmp.XXXXXX"
     let maxLength = Int(PATH_MAX) + 1
     var buf = [Int8](repeating: 0, count: maxLength)
-    template._nsObject.getFileSystemRepresentation(&buf, maxLength: maxLength)
+    let _ = template._nsObject.getFileSystemRepresentation(&buf, maxLength: maxLength)
     let fd = mkstemp(&buf)
     if fd == -1 {
         throw _NSErrorWithErrno(errno, reading: false, path: filePath)

--- a/Foundation/NSRange.swift
+++ b/Foundation/NSRange.swift
@@ -182,7 +182,7 @@ public func NSRangeFromString(_ aString: String) -> NSRange {
     }
     let scanner = NSScanner(string: aString)
     let digitSet = NSCharacterSet.decimalDigits()
-    scanner.scanUpToCharactersFromSet(digitSet)
+    let _ = scanner.scanUpToCharactersFromSet(digitSet)
     if scanner.atEnd {
         // fail early if there are no decimal digits
         return emptyRange
@@ -195,7 +195,7 @@ public func NSRangeFromString(_ aString: String) -> NSRange {
         // return early if there are no more characters after the first int in the string
         return partialRange
     }
-    scanner.scanUpToCharactersFromSet(digitSet)
+    let _ = scanner.scanUpToCharactersFromSet(digitSet)
     if scanner.atEnd {
         // return early if there are no integer characters after the first int in the string
         return partialRange

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -619,53 +619,53 @@ extension NSString {
     public func appending(_ aString: String) -> String {
         return _swiftObject + aString
     }
-    
+
     public var doubleValue: Double {
         var start: Int = 0
         var result = 0.0
-        _swiftObject.scan(NSCharacterSet.whitespaces(), locale: nil, locationToScanFrom: &start) { (value: Double) -> Void in
+        let _ = _swiftObject.scan(NSCharacterSet.whitespaces(), locale: nil, locationToScanFrom: &start) { (value: Double) -> Void in
             result = value
         }
         return result
     }
-    
+
     public var floatValue: Float {
         var start: Int = 0
         var result: Float = 0.0
-        _swiftObject.scan(NSCharacterSet.whitespaces(), locale: nil, locationToScanFrom: &start) { (value: Float) -> Void in
+        let _ = _swiftObject.scan(NSCharacterSet.whitespaces(), locale: nil, locationToScanFrom: &start) { (value: Float) -> Void in
             result = value
         }
         return result
     }
-    
+
     public var intValue: Int32 {
         return NSScanner(string: _swiftObject).scanInt() ?? 0
     }
-    
+
     public var integerValue: Int {
         let scanner = NSScanner(string: _swiftObject)
         var value: Int = 0
-        scanner.scanInteger(&value)
+        let _ = scanner.scanInteger(&value)
         return value
     }
-    
+
     public var longLongValue: Int64 {
         return NSScanner(string: _swiftObject).scanLongLong() ?? 0
     }
-    
+
     public var boolValue: Bool {
         let scanner = NSScanner(string: _swiftObject)
         // skip initial whitespace if present
-        scanner.scanCharactersFromSet(NSCharacterSet.whitespaces())
+        let _ = scanner.scanCharactersFromSet(NSCharacterSet.whitespaces())
         // scan a single optional '+' or '-' character, followed by zeroes
         if scanner.scanString(string: "+") == nil {
-            scanner.scanString(string: "-")
+            let _ = scanner.scanString(string: "-")
         }
         // scan any following zeroes
-        scanner.scanCharactersFromSet(NSCharacterSet(charactersIn: "0"))
+        let _ = scanner.scanCharactersFromSet(NSCharacterSet(charactersIn: "0"))
         return scanner.scanCharactersFromSet(NSCharacterSet(charactersIn: "tTyY123456789")) != nil
     }
-    
+
     public var uppercased: String {
         return uppercased(with: nil)
     }

--- a/Foundation/NSThread.swift
+++ b/Foundation/NSThread.swift
@@ -104,7 +104,7 @@ public class NSThread : NSObject {
     public class func isMultiThreaded() -> Bool {
         return true
     }
-    
+
     public class func sleepUntilDate(_ date: NSDate) {
         let start_ut = CFGetSystemUptime()
         let start_at = CFAbsoluteTimeGetCurrent()
@@ -121,13 +121,13 @@ public class NSThread : NSObject {
                 __ts__.tv_sec = Int(integ)
                 __ts__.tv_nsec = Int(frac * 1000000000.0)
             }
-            withUnsafePointer(&__ts__) { ts in
+            let _ = withUnsafePointer(&__ts__) { ts in
                 nanosleep(ts, nil)
             }
             ti = end_ut - CFGetSystemUptime()
         }
     }
-    
+
     public class func sleepForTimeInterval(_ interval: NSTimeInterval) {
         var ti = interval
         let start_ut = CFGetSystemUptime()
@@ -142,13 +142,13 @@ public class NSThread : NSObject {
                 __ts__.tv_sec = Int(integ)
                 __ts__.tv_nsec = Int(frac * 1000000000.0)
             }
-            withUnsafePointer(&__ts__) { ts in
+            let _ = withUnsafePointer(&__ts__) { ts in
                 nanosleep(ts, nil)
             }
             ti = end_ut - CFGetSystemUptime()
         }
     }
-    
+
     public class func exit() {
         pthread_exit(nil)
     }
@@ -169,14 +169,14 @@ public class NSThread : NSObject {
         // Note: even on Darwin this is a non-optional pthread_t; this is only used for valid threads, which are never null pointers.
         _thread = thread
     }
-    
+
     public init(_ main: (Void) -> Void) {
         _main = main
-        withUnsafeMutablePointer(&_attr) { attr in
+        let _ = withUnsafeMutablePointer(&_attr) { attr in
             pthread_attr_init(attr)
         }
     }
-    
+
     public func start() {
         precondition(_status == .Initialized, "attempting to start a thread that has already been started")
         _status = .Starting
@@ -208,12 +208,12 @@ public class NSThread : NSObject {
             if (1 << 30) < s {
                 s = 1 << 30
             }
-            withUnsafeMutablePointer(&_attr) { attr in
+            let _ = withUnsafeMutablePointer(&_attr) { attr in
                 pthread_attr_setstacksize(attr, s)
             }
         }
     }
-    
+
     public var executing: Bool {
         return _status == .Executing
     }

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -122,10 +122,10 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
             _CFURLInitWithFileSystemPathRelativeToBase(_cfObject, path._cfObject, kCFURLPOSIXPathStyle, baseURL.hasDirectoryPath, nil)
         }
     }
-    
+
     public convenience init(fileURLWithPath path: String, relativeToURL baseURL: NSURL?) {
         let thePath = _standardizedPath(path)
-        
+
         var isDir : Bool = false
         if thePath.hasSuffix("/") {
             isDir = true
@@ -136,29 +136,29 @@ public class NSURL : NSObject, NSSecureCoding, NSCopying {
             } else {
                 absolutePath = path
             }
-            NSFileManager.defaultManager().fileExists(atPath: absolutePath, isDirectory: &isDir)
+            let _ = NSFileManager.defaultManager().fileExists(atPath: absolutePath, isDirectory: &isDir)
         }
 
         self.init(fileURLWithPath: thePath, isDirectory: isDir, relativeToURL: baseURL)
     }
-    
+
     public convenience init(fileURLWithPath path: String, isDirectory isDir: Bool) {
         self.init(fileURLWithPath: path, isDirectory: isDir, relativeToURL: nil)
     }
-    
+
     public convenience init(fileURLWithPath path: String) {
         let thePath = _standardizedPath(path)
-        
+
         var isDir : Bool = false
         if thePath.hasSuffix("/") {
             isDir = true
         } else {
-            NSFileManager.defaultManager().fileExists(atPath: path, isDirectory: &isDir)
+            let _ = NSFileManager.defaultManager().fileExists(atPath: path, isDirectory: &isDir)
         }
 
         self.init(fileURLWithPath: thePath, isDirectory: isDir, relativeToURL: nil)
     }
-    
+
     public convenience init(fileURLWithFileSystemRepresentation path: UnsafePointer<Int8>, isDirectory isDir: Bool, relativeToURL baseURL: NSURL?) {
         let pathString = String(cString: path)
         self.init(fileURLWithPath: pathString, isDirectory: isDir, relativeToURL: baseURL)
@@ -518,16 +518,16 @@ extension NSURL {
     public var URLByResolvingSymlinksInPath: NSURL? {
         return _resolveSymlinksInPath(excludeSystemDirs: true)
     }
-    
+
     internal func _resolveSymlinksInPath(excludeSystemDirs: Bool) -> NSURL? {
         guard fileURL else {
             return NSURL(string: absoluteString)
         }
-        
+
         guard let selfPath = path else {
             return NSURL(string: absoluteString)
         }
-        
+
         let absolutePath: String
         if selfPath.hasPrefix("/") {
             absolutePath = selfPath
@@ -535,22 +535,22 @@ extension NSURL {
             let workingDir = NSFileManager.defaultManager().currentDirectoryPath
             absolutePath = workingDir.bridge().stringByAppendingPathComponent(selfPath)
         }
-        
+
         var components = absolutePath.pathComponents
         guard !components.isEmpty else {
             return NSURL(string: absoluteString)
         }
-        
+
         var resolvedPath = components.removeFirst()
         for component in components {
             switch component {
-                
+
             case "", ".":
                 break
-                
+
             case "..":
                 resolvedPath = resolvedPath.bridge().stringByDeletingLastPathComponent
-                
+
             default:
                 resolvedPath = resolvedPath.bridge().stringByAppendingPathComponent(component)
                 if let destination = NSFileManager.defaultManager()._tryToResolveTrailingSymlinkInPath(resolvedPath) {
@@ -558,19 +558,19 @@ extension NSURL {
                 }
             }
         }
-        
+
         // It might be a responsibility of NSURL(fileURLWithPath:). Check it.
         var isExistingDirectory = false
-        NSFileManager.defaultManager().fileExists(atPath: resolvedPath, isDirectory: &isExistingDirectory)
-        
+        let _ = NSFileManager.defaultManager().fileExists(atPath: resolvedPath, isDirectory: &isExistingDirectory)
+
         if excludeSystemDirs {
             resolvedPath = resolvedPath._tryToRemovePathPrefix("/private") ?? resolvedPath
         }
-        
+
         if isExistingDirectory && !resolvedPath.hasSuffix("/") {
             resolvedPath += "/"
         }
-        
+
         return NSURL(fileURLWithPath: resolvedPath)
     }
 }

--- a/Foundation/NSXMLParser.swift
+++ b/Foundation/NSXMLParser.swift
@@ -478,7 +478,7 @@ public class NSXMLParser : NSObject {
         return result
         */
     }
-    
+
     internal func parseData(_ data: NSData) -> Bool {
         _CFXMLInterfaceSetStructuredErrorFunc(interface, _structuredErrorFunc)
         var result = true
@@ -508,30 +508,30 @@ public class NSXMLParser : NSObject {
                 } else {
                     allExistingData = data
                 }
-                
+
                 var handler: _CFXMLInterfaceSAXHandler? = nil
                 if delegate != nil {
                     handler = _handler
                 }
-                
+
                 _parserContext = _CFXMLInterfaceCreatePushParserCtxt(handler, interface, UnsafePointer<Int8>(allExistingData.bytes), 4, nil)
-                
+
                 var options = _kCFXMLInterfaceRecover | _kCFXMLInterfaceNoEnt // substitute entities, recover on errors
                 if shouldResolveExternalEntities {
                     options |= _kCFXMLInterfaceDTDLoad
                 }
-                
+
                 if handler == nil {
                     options |= (_kCFXMLInterfaceNoError | _kCFXMLInterfaceNoWarning)
                 }
-                
+
                 _CFXMLInterfaceCtxtUseOptions(_parserContext, options)
                 _haveDetectedEncoding = true
                 _bomChunk = nil
-                
+
                 if (totalLength > 4) {
                     let remainingData = NSData(bytesNoCopy: UnsafeMutablePointer<Void>(allExistingData.bytes.advanced(by: 4)), length: totalLength - 4, freeWhenDone: false)
-                    parseData(remainingData)
+                    let _ = parseData(remainingData)
                 }
             }
         } else {
@@ -541,7 +541,7 @@ public class NSXMLParser : NSObject {
         _CFXMLInterfaceSetStructuredErrorFunc(interface, nil)
         return result
     }
-    
+
     internal func parseFromStream() -> Bool {
         var result = true
         NSXMLParser.setCurrentParser(self)


### PR DESCRIPTION
This just cleans up a set of unused-return-value warnings in the Foundation
implementation.  NFC.