### PR TITLE
NSGeometry: update accessors

### DIFF
--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -34,9 +34,9 @@ public struct CGFloat {
     
     private var hash: Int {
 #if arch(i386) || arch(arm)
-        return Int(Float(self.native)._toBitPattern())
+        return Int(Float(self.native).bitPattern)
 #else
-        return Int(self.native._toBitPattern())
+        return Int(self.native.bitPattern)
 #endif
     }
 }


### PR DESCRIPTION
Apply fixit for '_toBitPattern()' deprecation.  NFC.