### PR TITLE
CFStorage: use the reserved spelling of restrict

### DIFF
--- a/CoreFoundation/Collections.subproj/CFStorage.c
+++ b/CoreFoundation/Collections.subproj/CFStorage.c
@@ -42,12 +42,8 @@
 #endif
 
 #if DEPLOYMENT_TARGET_WINDOWS
-// No C99 support
-#define restrict
-
 // Replace bzero
 #define bzero(dst, size)    ZeroMemory(dst, size)
-
 #endif
 
 #if !defined(PAGE_SIZE)
@@ -250,7 +246,7 @@ static inline void __CFStorageSetChild(CFStorageNode *parentNode, CFIndex childI
     __CFAssignWithWriteBarrier((void **)&parentNode->info.notLeaf.child[childIndex], newChild);
 }
 
-static inline void __CFStorageGetChildren(const CFStorageNode *parent, CFStorageNode ** restrict resultArray, bool shouldRetain, bool shouldFreeze) {
+static inline void __CFStorageGetChildren(const CFStorageNode *parent, CFStorageNode ** __restrict resultArray, bool shouldRetain, bool shouldFreeze) {
     ASSERT(! parent->isLeaf);
     CFIndex i;
     for (i=0; i < 3; i++) {
@@ -278,7 +274,7 @@ CF_INLINE void __CFStorageSetCache(CFStorageRef storage, CFStorageNode *node, CF
 /* Gets the location for the specified absolute loc from the cached info.
  Returns NULL if the location is not in the cache.
  */
-CF_INLINE uint8_t *__CFStorageGetFromCache(CFStorageRef storage, CFIndex loc, CFRange * restrict validConsecutiveValueRange, bool requireUnfrozenNode) {
+CF_INLINE uint8_t *__CFStorageGetFromCache(CFStorageRef storage, CFIndex loc, CFRange * __restrict validConsecutiveValueRange, bool requireUnfrozenNode) {
     CFStorageNode * const cachedNode = storage->cacheNode; /* It's important we read from this field no more than once, for thread safety with other concurrent reads; that is why the field is marked volatile. */
     if (! cachedNode) return NULL; /* No cache */
     
@@ -313,7 +309,7 @@ CF_INLINE uint8_t *__CFStorageGetFromCache(CFStorageRef storage, CFIndex loc, CF
  relativeByteNum (not optional, for performance reasons) returns the relative byte number of the specified byte in the child.
  Don't call with leaf nodes!
  */
-CF_INLINE CFStorageNode *__CFStorageFindChild(const CFStorageNode * restrict node, CFIndex byteNum, bool forInsertionOrDeletion, CFIndex * restrict childNum, CFIndex * restrict relativeByteNum) {
+CF_INLINE CFStorageNode *__CFStorageFindChild(const CFStorageNode * __restrict node, CFIndex byteNum, bool forInsertionOrDeletion, CFIndex * __restrict childNum, CFIndex * __restrict relativeByteNum) {
     if (forInsertionOrDeletion) byteNum--;	/* If for insertion, we do <= checks, not <, so this accomplishes the same thing */
     CFStorageNode *result;
     result = node->info.notLeaf.child[0];


### PR DESCRIPTION
`__restrict` is the reserved extension.  It avoids the need for the use of the
preprocesor on Windows, but has the same results on compilers which support
restrict (though, some like MSVC support __restrict though not restrict).