### PR TITLE
Lower camel case for swift enum cases

### DIFF
--- a/Foundation/NSByteCountFormatter.swift
+++ b/Foundation/NSByteCountFormatter.swift
@@ -31,12 +31,12 @@ public struct NSByteCountFormatterUnits : OptionSet {
 public enum NSByteCountFormatterCountStyle : Int {
     
     // Specifies display of file or storage byte counts. The actual behavior for this is platform-specific; on OS X 10.8, this uses the decimal style, but that may change over time.
-    case File
+    case file
     // Specifies display of memory byte counts. The actual behavior for this is platform-specific; on OS X 10.8, this uses the binary style, but that may change over time.
-    case Memory
+    case memory
     // The following two allow specifying the number of bytes for KB explicitly. It's better to use one of the above values in most cases.
-    case Decimal // 1000 bytes are shown as 1 KB
-    case Binary // 1024 bytes are shown as 1 KB
+    case decimal // 1000 bytes are shown as 1 KB
+    case binary // 1024 bytes are shown as 1 KB
 }
 
 public class NSByteCountFormatter : NSFormatter {
@@ -62,7 +62,7 @@ public class NSByteCountFormatter : NSFormatter {
     
     /* Specify how the count is displayed by indicating the number of bytes to be used for kilobyte. The default setting is NSByteCountFormatterFileCount, which is the system specific value for file and storage sizes.
     */
-    public var countStyle: NSByteCountFormatterCountStyle = .File
+    public var countStyle: NSByteCountFormatterCountStyle = .file
     
     /* Choose whether to allow more natural display of some values, such as zero, where it may be displayed as "Zero KB," ignoring all other flags or options (with the exception of NSByteCountFormatterUseBytes, which would generate "Zero bytes"). The result is appropriate for standalone output. Default value is YES. Special handling of certain values such as zero is especially important in some languages, so it's highly recommended that this property be left in its default state.
     */
@@ -87,6 +87,6 @@ public class NSByteCountFormatter : NSFormatter {
     
     /* Specify the formatting context for the formatted string. Default is NSFormattingContextUnknown.
     */
-    public var formattingContext: NSFormattingContext = .Unknown
+    public var formattingContext: NSFormattingContext = .unknown
 }
 

--- a/Foundation/NSComparisonPredicate.swift
+++ b/Foundation/NSComparisonPredicate.swift
@@ -21,27 +21,27 @@ public struct NSComparisonPredicateOptions : OptionSet {
 // Describes how the operator is modified: can be direct, ALL, or ANY
 public enum NSComparisonPredicateModifier : UInt {
     
-    case DirectPredicateModifier // Do a direct comparison
-    case AllPredicateModifier // ALL toMany.x = y
-    case AnyPredicateModifier // ANY toMany.x = y
+    case directPredicateModifier // Do a direct comparison
+    case allPredicateModifier // ALL toMany.x = y
+    case anyPredicateModifier // ANY toMany.x = y
 }
 
 // Type basic set of operators defined. Most are obvious
 public enum NSPredicateOperatorType : UInt {
     
-    case LessThanPredicateOperatorType // compare: returns NSOrderedAscending
-    case LessThanOrEqualToPredicateOperatorType // compare: returns NSOrderedAscending || NSOrderedSame
-    case GreaterThanPredicateOperatorType // compare: returns NSOrderedDescending
-    case GreaterThanOrEqualToPredicateOperatorType // compare: returns NSOrderedDescending || NSOrderedSame
-    case EqualToPredicateOperatorType // isEqual: returns true
-    case NotEqualToPredicateOperatorType // isEqual: returns false
-    case MatchesPredicateOperatorType
-    case LikePredicateOperatorType
-    case BeginsWithPredicateOperatorType
-    case EndsWithPredicateOperatorType
-    case InPredicateOperatorType // rhs contains lhs returns true
-    case ContainsPredicateOperatorType // lhs contains rhs returns true
-    case BetweenPredicateOperatorType
+    case lessThanPredicateOperatorType // compare: returns NSOrderedAscending
+    case lessThanOrEqualToPredicateOperatorType // compare: returns NSOrderedAscending || NSOrderedSame
+    case greaterThanPredicateOperatorType // compare: returns NSOrderedDescending
+    case greaterThanOrEqualToPredicateOperatorType // compare: returns NSOrderedDescending || NSOrderedSame
+    case equalToPredicateOperatorType // isEqual: returns true
+    case notEqualToPredicateOperatorType // isEqual: returns false
+    case matchesPredicateOperatorType
+    case likePredicateOperatorType
+    case beginsWithPredicateOperatorType
+    case endsWithPredicateOperatorType
+    case inPredicateOperatorType // rhs contains lhs returns true
+    case containsPredicateOperatorType // lhs contains rhs returns true
+    case betweenPredicateOperatorType
 }
 
 // Comparison predicates are predicates which do some form of comparison between the results of two expressions and return a BOOL. They take an operator, a left expression, and a right expression, and return the result of invoking the operator with the results of evaluating the expressions.

--- a/Foundation/NSCompoundPredicate.swift
+++ b/Foundation/NSCompoundPredicate.swift
@@ -12,15 +12,15 @@
 
 public enum NSCompoundPredicateType : UInt {
     
-    case NotPredicateType
-    case AndPredicateType
-    case OrPredicateType
+    case notPredicateType
+    case andPredicateType
+    case orPredicateType
 }
 
 public class NSCompoundPredicate : NSPredicate {
     
     public init(type: NSCompoundPredicateType, subpredicates: [NSPredicate]) {
-        if type == .NotPredicateType && subpredicates.count == 0 {
+        if type == .notPredicateType && subpredicates.count == 0 {
             preconditionFailure("Unsupported predicate count of \(subpredicates.count) for \(type)")
         }
         self.compoundPredicateType = type
@@ -34,26 +34,26 @@ public class NSCompoundPredicate : NSPredicate {
 
     /*** Convenience Methods ***/
     public convenience init(andPredicateWithSubpredicates subpredicates: [NSPredicate]) {
-        self.init(type: .AndPredicateType, subpredicates: subpredicates)
+        self.init(type: .andPredicateType, subpredicates: subpredicates)
     }
     public convenience init(orPredicateWithSubpredicates subpredicates: [NSPredicate]) {
-        self.init(type: .OrPredicateType, subpredicates: subpredicates)
+        self.init(type: .orPredicateType, subpredicates: subpredicates)
     }
     public convenience init(notPredicateWithSubpredicate predicate: NSPredicate) {
-        self.init(type: .NotPredicateType, subpredicates: [predicate])
+        self.init(type: .notPredicateType, subpredicates: [predicate])
     }
 
     override public func evaluateWithObject(_ object: AnyObject?, substitutionVariables bindings: [String : AnyObject]?) -> Bool {
         switch compoundPredicateType {
-        case .AndPredicateType:
+        case .andPredicateType:
             return subpredicates.reduce(true, combine: {
                 $0 && $1.evaluateWithObject(object, substitutionVariables: bindings)
             })
-        case .OrPredicateType:
+        case .orPredicateType:
             return subpredicates.reduce(false, combine: {
                 $0 || $1.evaluateWithObject(object, substitutionVariables: bindings)
             })
-        case .NotPredicateType:
+        case .notPredicateType:
             // safe to get the 0th item here since we trap if there's not at least one on init
             return !(subpredicates[0].evaluateWithObject(object, substitutionVariables: bindings))
         }

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -675,21 +675,21 @@ extension NSData {
         - returns:              Base64DecodedByte value containing the result (Valid , Invalid, Padding)
         */
     private enum Base64DecodedByte {
-        case Valid(UInt8)
-        case Invalid
-        case Padding
+        case valid(UInt8)
+        case invalid
+        case padding
     }
     private static func base64DecodeByte(_ byte: UInt8) -> Base64DecodedByte {
-        guard byte != base64Padding else {return .Padding}
+        guard byte != base64Padding else {return .padding}
         var decodedStart: UInt8 = 0
         for range in base64ByteMappings {
             if range.contains(byte) {
                 let result = decodedStart + (byte - range.lowerBound)
-                return .Valid(result)
+                return .valid(result)
             }
             decodedStart += range.upperBound - range.lowerBound
         }
-        return .Invalid
+        return .invalid
     }
     
     /**
@@ -741,16 +741,16 @@ extension NSData {
             let value : UInt8
             
             switch base64DecodeByte(base64Char) {
-            case .Valid(let v):
+            case .valid(let v):
                 value = v
                 validCharacterCount += 1
-            case .Invalid:
+            case .invalid:
                 if options.contains(.ignoreUnknownCharacters) {
                     continue
                 } else {
                     return nil
                 }
-            case .Padding:
+            case .padding:
                 paddingCount += 1
                 continue
             }

--- a/Foundation/NSDateComponentsFormatter.swift
+++ b/Foundation/NSDateComponentsFormatter.swift
@@ -10,11 +10,11 @@
 
 public enum NSDateComponentsFormatterUnitsStyle : Int {
     
-    case Positional // "1:10; may fall back to abbreviated units in some cases, e.g. 3d"
-    case Abbreviated // "1h 10m"
-    case Short // "1hr 10min"
-    case Full // "1 hour, 10 minutes"
-    case SpellOut // "One hour, ten minutes"
+    case positional // "1:10; may fall back to abbreviated units in some cases, e.g. 3d"
+    case abbreviated // "1h 10m"
+    case short // "1hr 10min"
+    case full // "1 hour, 10 minutes"
+    case spellOut // "One hour, ten minutes"
 }
 
 public struct NSDateComponentsFormatterZeroFormattingBehavior : OptionSet {

--- a/Foundation/NSDateFormatter.swift
+++ b/Foundation/NSDateFormatter.swift
@@ -41,7 +41,7 @@ public class NSDateFormatter : NSFormatter {
         super.init(coder: coder)
     }
 
-    public var formattingContext: NSFormattingContext = .Unknown // default is NSFormattingContextUnknown
+    public var formattingContext: NSFormattingContext = .unknown // default is NSFormattingContextUnknown
 
     public func objectValue(_ string: String, range rangep: UnsafeMutablePointer<NSRange>) throws -> AnyObject? { NSUnimplemented() }
 
@@ -136,9 +136,9 @@ public class NSDateFormatter : NSFormatter {
         }
     }
 
-    public var dateStyle: NSDateFormatterStyle = .NoStyle { willSet { _dateFormat = nil; _reset() } }
+    public var dateStyle: NSDateFormatterStyle = .noStyle { willSet { _dateFormat = nil; _reset() } }
 
-    public var timeStyle: NSDateFormatterStyle = .NoStyle { willSet { _dateFormat = nil; _reset() } }
+    public var timeStyle: NSDateFormatterStyle = .noStyle { willSet { _dateFormat = nil; _reset() } }
 
     /*@NSCopying*/ public var locale: NSLocale! = .currentLocale() { willSet { _reset() } }
 
@@ -472,9 +472,9 @@ public class NSDateFormatter : NSFormatter {
 }
 
 public enum NSDateFormatterStyle : UInt {
-    case NoStyle
-    case ShortStyle
-    case MediumStyle
-    case LongStyle
-    case FullStyle
+    case noStyle
+    case shortStyle
+    case mediumStyle
+    case longStyle
+    case fullStyle
 }

--- a/Foundation/NSDateIntervalFormatter.swift
+++ b/Foundation/NSDateIntervalFormatter.swift
@@ -10,11 +10,11 @@
 
 public enum NSDateIntervalFormatterStyle : UInt {
     
-    case NoStyle
-    case ShortStyle
-    case MediumStyle
-    case LongStyle
-    case FullStyle
+    case noStyle
+    case shortStyle
+    case mediumStyle
+    case longStyle
+    case fullStyle
 }
 
 // NSDateIntervalFormatter is used to format the range between two NSDates in a locale-sensitive way.

--- a/Foundation/NSDecimal.swift
+++ b/Foundation/NSDecimal.swift
@@ -19,19 +19,19 @@
 /***************	Type definitions		***********/
 public enum NSRoundingMode : UInt {
     
-    case RoundPlain // Round up on a tie
-    case RoundDown // Always down == truncate
-    case RoundUp // Always up
-    case RoundBankers // on a tie round so last digit is even
+    case roundPlain // Round up on a tie
+    case roundDown // Always down == truncate
+    case roundUp // Always up
+    case roundBankers // on a tie round so last digit is even
 }
 
 public enum NSCalculationError : UInt {
     
-    case NoError
-    case LossOfPrecision // Result lost precision
-    case Underflow // Result became 0
-    case Overflow // Result exceeds possible representation
-    case DivideByZero
+    case noError
+    case lossOfPrecision // Result lost precision
+    case underflow // Result became 0
+    case overflow // Result exceeds possible representation
+    case divideByZero
 }
 
 public var NSDecimalMaxSize: Int32 { NSUnimplemented() }

--- a/Foundation/NSEnergyFormatter.swift
+++ b/Foundation/NSEnergyFormatter.swift
@@ -10,10 +10,10 @@
 
 public enum NSEnergyFormatterUnit : Int {
     
-    case Joule
-    case Kilojoule
-    case Calorie // chemistry "calories", abbr "cal"
-    case Kilocalorie // kilocalories in general, abbr “kcal”, or “C” in some locales (e.g. US) when usesFoodEnergy is set to YES
+    case joule
+    case kilojoule
+    case calorie // chemistry "calories", abbr "cal"
+    case kilocalorie // kilocalories in general, abbr “kcal”, or “C” in some locales (e.g. US) when usesFoodEnergy is set to YES
 }
 
 

--- a/Foundation/NSExpression.swift
+++ b/Foundation/NSExpression.swift
@@ -12,19 +12,19 @@
 
 public enum NSExpressionType : UInt {
     
-    case ConstantValueExpressionType // Expression that always returns the same value
-    case EvaluatedObjectExpressionType // Expression that always returns the parameter object itself
-    case VariableExpressionType // Expression that always returns whatever is stored at 'variable' in the bindings dictionary
-    case KeyPathExpressionType // Expression that returns something that can be used as a key path
-    case FunctionExpressionType // Expression that returns the result of evaluating a symbol
-    case UnionSetExpressionType // Expression that returns the result of doing a unionSet: on two expressions that evaluate to flat collections (arrays or sets)
-    case IntersectSetExpressionType // Expression that returns the result of doing an intersectSet: on two expressions that evaluate to flat collections (arrays or sets)
-    case MinusSetExpressionType // Expression that returns the result of doing a minusSet: on two expressions that evaluate to flat collections (arrays or sets)
-    case SubqueryExpressionType
-    case AggregateExpressionType
-    case AnyKeyExpressionType
-    case BlockExpressionType
-    case ConditionalExpressionType
+    case constantValueExpressionType // Expression that always returns the same value
+    case evaluatedObjectExpressionType // Expression that always returns the parameter object itself
+    case variableExpressionType // Expression that always returns whatever is stored at 'variable' in the bindings dictionary
+    case keyPathExpressionType // Expression that returns something that can be used as a key path
+    case functionExpressionType // Expression that returns the result of evaluating a symbol
+    case unionSetExpressionType // Expression that returns the result of doing a unionSet: on two expressions that evaluate to flat collections (arrays or sets)
+    case intersectSetExpressionType // Expression that returns the result of doing an intersectSet: on two expressions that evaluate to flat collections (arrays or sets)
+    case minusSetExpressionType // Expression that returns the result of doing a minusSet: on two expressions that evaluate to flat collections (arrays or sets)
+    case subqueryExpressionType
+    case aggregateExpressionType
+    case anyKeyExpressionType
+    case blockExpressionType
+    case conditionalExpressionType
 }
 
 public class NSExpression : NSObject, NSSecureCoding, NSCopying {

--- a/Foundation/NSFormatter.swift
+++ b/Foundation/NSFormatter.swift
@@ -11,22 +11,22 @@
 public enum NSFormattingContext : Int {
     
     // The capitalization context to be used is unknown (this is the default value).
-    case Unknown
+    case unknown
 
     // The capitalization context is determined dynamically from the set {NSFormattingContextStandalone, NSFormattingContextBeginningOfSentence, NSFormattingContextMiddleOfSentence}. For example, if a date is placed at the beginning of a sentence, NSFormattingContextBeginningOfSentence is used to format the string automatically. When this context is used, the formatter will return a string proxy that works like a normal string in most cases. After returning from the formatter, the string in the string proxy is formatted by using NSFormattingContextUnknown. When the string proxy is used in stringWithFormat:, we can determine where the %@ is and then set the context accordingly. With the new context, the string in the string proxy will be formatted again and be put into the final string returned from stringWithFormat:.
-    case Dynamic
+    case dynamic
     
     // The capitalization context if a date or date symbol is to be formatted with capitalization appropriate for stand-alone usage such as an isolated name on a calendar page.
-    case Standalone
+    case standalone
     
     // The capitalization context if a date or date symbol is to be formatted with capitalization appropriate for a list or menu item.
-    case ListItem
+    case listItem
     
     // The capitalization context if a date or date symbol is to be formatted with capitalization appropriate for the beginning of a sentence.
-    case BeginningOfSentence
+    case beginningOfSentence
 
     // The capitalization context if a date or date symbol is to be formatted with capitalization appropriate for the middle of a sentence.
-    case MiddleOfSentence
+    case middleOfSentence
 }
 
 /*
@@ -37,9 +37,9 @@ public enum NSFormattingContext : Int {
 
 public enum NSFormattingUnitStyle : Int {
     
-    case Short
-    case Medium
-    case Long
+    case short
+    case medium
+    case long
 }
 
 public class NSFormatter : NSObject, NSCopying, NSCoding {

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -299,27 +299,27 @@ extension CGRect: NSSpecialValueCoding {
 
 public enum NSRectEdge : UInt {
     
-    case MinX
-    case MinY
-    case MaxX
-    case MaxY
+    case minX
+    case minY
+    case maxX
+    case maxY
 }
 
 public enum CGRectEdge : UInt32 {
     
-    case MinXEdge
-    case MinYEdge
-    case MaxXEdge
-    case MaxYEdge
+    case minXEdge
+    case minYEdge
+    case maxXEdge
+    case maxYEdge
 }
 
 extension NSRectEdge {
     public init(rectEdge: CGRectEdge) {
         switch rectEdge {
-        case .MinXEdge: self = .MinX
-        case .MinYEdge: self = .MinY
-        case .MaxXEdge: self = .MaxX
-        case .MaxYEdge: self = .MaxY
+        case .minXEdge: self = .minX
+        case .minYEdge: self = .minY
+        case .maxXEdge: self = .maxX
+        case .maxYEdge: self = .maxY
         }
     }
 }
@@ -710,35 +710,35 @@ public func NSDivideRect(_ inRect: NSRect, _ slice: UnsafeMutablePointer<NSRect>
     let height = NSHeight(inRect)
 
     switch (edge, amount) {
-    case (.MinX, let amount) where amount > width:
+    case (.minX, let amount) where amount > width:
         slice.pointee = inRect
         rem.pointee = NSMakeRect(NSMaxX(inRect), NSMinY(inRect), CGFloat(0.0), height)
 
-    case (.MinX, _):
+    case (.minX, _):
         slice.pointee = NSMakeRect(NSMinX(inRect), NSMinY(inRect), amount, height)
         rem.pointee = NSMakeRect(NSMaxX(slice.pointee), NSMinY(inRect), NSMaxX(inRect) - NSMaxX(slice.pointee), height)
 
-    case (.MinY, let amount) where amount > height:
+    case (.minY, let amount) where amount > height:
         slice.pointee = inRect
         rem.pointee = NSMakeRect(NSMinX(inRect), NSMaxY(inRect), width, CGFloat(0.0))
 
-    case (.MinY, _):
+    case (.minY, _):
         slice.pointee = NSMakeRect(NSMinX(inRect), NSMinY(inRect), width, amount)
         rem.pointee = NSMakeRect(NSMinX(inRect), NSMaxY(slice.pointee), width, NSMaxY(inRect) - NSMaxY(slice.pointee))
 
-    case (.MaxX, let amount) where amount > width:
+    case (.maxX, let amount) where amount > width:
         slice.pointee = inRect
         rem.pointee = NSMakeRect(NSMinX(inRect), NSMinY(inRect), CGFloat(0.0), height)
 
-    case (.MaxX, _):
+    case (.maxX, _):
         slice.pointee = NSMakeRect(NSMaxX(inRect) - amount, NSMinY(inRect), amount, height)
         rem.pointee = NSMakeRect(NSMinX(inRect), NSMinY(inRect), NSMinX(slice.pointee) - NSMinX(inRect), height)
 
-    case (.MaxY, let amount) where amount > height:
+    case (.maxY, let amount) where amount > height:
         slice.pointee = inRect
         rem.pointee = NSMakeRect(NSMinX(inRect), NSMinY(inRect), width, CGFloat(0.0))
 
-    case (.MaxY, _):
+    case (.maxY, _):
         slice.pointee = NSMakeRect(NSMinX(inRect), NSMaxY(inRect) - amount, width, amount)
         rem.pointee = NSMakeRect(NSMinX(inRect), NSMinY(inRect), width, NSMinY(slice.pointee) - NSMinY(inRect))
     }

--- a/Foundation/NSHTTPCookieStorage.swift
+++ b/Foundation/NSHTTPCookieStorage.swift
@@ -18,9 +18,9 @@
 */
 public enum NSHTTPCookieAcceptPolicy : UInt {
     
-    case Always
-    case Never
-    case OnlyFromMainDocumentDomain
+    case always
+    case never
+    case onlyFromMainDocumentDomain
 }
 
 

--- a/Foundation/NSHost.swift
+++ b/Foundation/NSHost.swift
@@ -18,9 +18,9 @@ import CoreFoundation
 
 public class NSHost : NSObject {
     enum ResolveType {
-        case Name
-        case Address
-        case Current
+        case name
+        case address
+        case current
     }
     internal var _info: String?
     internal var _type: ResolveType
@@ -33,18 +33,18 @@ public class NSHost : NSObject {
         _type = type
     }
     
-    static internal let current = NSHost(nil, .Current)
+    static internal let current = NSHost(nil, .current)
     
     public class func currentHost() -> NSHost {
         return NSHost.current
     }
     
     public convenience init(name: String?) {
-        self.init(name, .Name)
+        self.init(name, .name)
     }
     
     public convenience init(address: String) {
-        self.init(address, .Address)
+        self.init(address, .address)
     }
     
     public func isEqualToHost(_ aHost: NSHost) -> Bool {
@@ -62,13 +62,13 @@ public class NSHost : NSObject {
         if let info = _info {
             var flags: Int32 = 0
             switch (_type) {
-            case .Name:
+            case .name:
                 flags = AI_PASSIVE | AI_CANONNAME
                 break
-            case .Address:
+            case .address:
                 flags = AI_PASSIVE | AI_CANONNAME | AI_NUMERICHOST
                 break
-            case .Current:
+            case .current:
                 _resolveCurrent()
                 return
             }

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -113,10 +113,10 @@ public class NSKeyedArchiver : NSCoder {
     private var _cache : Array<CFKeyedArchiverUID> = []
 
     public weak var delegate: NSKeyedArchiverDelegate?
-    public var outputFormat = NSPropertyListFormat.BinaryFormat_v1_0 {
+    public var outputFormat = NSPropertyListFormat.binaryFormat_v1_0 {
         willSet {
-            if outputFormat != NSPropertyListFormat.XMLFormat_v1_0 &&
-                outputFormat != NSPropertyListFormat.BinaryFormat_v1_0 {
+            if outputFormat != NSPropertyListFormat.xmlFormat_v1_0 &&
+                outputFormat != NSPropertyListFormat.binaryFormat_v1_0 {
                 NSUnimplemented()
             }
         }
@@ -222,7 +222,7 @@ public class NSKeyedArchiver : NSCoder {
 
         let nsPlist = plist.bridge()
         
-        if self.outputFormat == NSPropertyListFormat.XMLFormat_v1_0 {
+        if self.outputFormat == NSPropertyListFormat.xmlFormat_v1_0 {
             success = _writeXMLData(nsPlist)
         } else {
             success = _writeBinaryData(nsPlist)

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -99,7 +99,7 @@ public class NSKeyedUnarchiver : NSCoder {
   
     private func _readPropertyList() throws {
         var plist : Any? = nil
-        var format = NSPropertyListFormat.BinaryFormat_v1_0
+        var format = NSPropertyListFormat.binaryFormat_v1_0
         
         // FIXME this implementation reads the entire property list into memory
         // which will not scale for large archives. We should support incremental

--- a/Foundation/NSLengthFormatter.swift
+++ b/Foundation/NSLengthFormatter.swift
@@ -10,14 +10,14 @@
 
 public enum NSLengthFormatterUnit : Int {
     
-    case Millimeter
-    case Centimeter
-    case Meter
-    case Kilometer
-    case Inch
-    case Foot
-    case Yard
-    case Mile
+    case millimeter
+    case centimeter
+    case meter
+    case kilometer
+    case inch
+    case foot
+    case yard
+    case mile
 }
 
 public class NSLengthFormatter : NSFormatter {

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -179,11 +179,11 @@ extension NSLocale {
 }
 
 public enum NSLocaleLanguageDirection : UInt {
-    case Unknown
-    case LeftToRight
-    case RightToLeft
-    case TopToBottom
-    case BottomToTop
+    case unknown
+    case leftToRight
+    case rightToLeft
+    case topToBottom
+    case bottomToTop
 }
 
 public let NSCurrentLocaleDidChangeNotification: String = "kCFLocaleCurrentLocaleDidChangeNotification"

--- a/Foundation/NSMassFormatter.swift
+++ b/Foundation/NSMassFormatter.swift
@@ -10,11 +10,11 @@
 
 public enum NSMassFormatterUnit : Int {
     
-    case Gram
-    case Kilogram
-    case Ounce
-    case Pound
-    case Stone
+    case gram
+    case kilogram
+    case ounce
+    case pound
+    case stone
 }
 
 public class NSMassFormatter : NSFormatter {

--- a/Foundation/NSNotificationQueue.swift
+++ b/Foundation/NSNotificationQueue.swift
@@ -11,9 +11,9 @@ import CoreFoundation
 
 public enum NSPostingStyle : UInt {
     
-    case PostWhenIdle
-    case PostASAP
-    case PostNow
+    case postWhenIdle
+    case postASAP
+    case postNow
 }
 
 public struct NSNotificationCoalescing : OptionSet {
@@ -35,12 +35,12 @@ public class NSNotificationQueue : NSObject {
     internal var idleList = NSNotificationList()
     internal lazy var idleRunloopObserver: CFRunLoopObserver = {
         return CFRunLoopObserverCreateWithHandler(kCFAllocatorDefault, CFOptionFlags(kCFRunLoopBeforeTimers), true, 0) {[weak self] observer, activity in
-            self!.notifyQueues(.PostWhenIdle)
+            self!.notifyQueues(.postWhenIdle)
         }
     }()
     internal lazy var asapRunloopObserver: CFRunLoopObserver = {
         return CFRunLoopObserverCreateWithHandler(kCFAllocatorDefault, CFOptionFlags(kCFRunLoopBeforeWaiting | kCFRunLoopExit), true, 0) {[weak self] observer, activity in
-            self!.notifyQueues(.PostASAP)
+            self!.notifyQueues(.postASAP)
         }
     }()
 
@@ -88,15 +88,15 @@ public class NSNotificationQueue : NSObject {
         }
 
         switch postingStyle {
-        case .PostNow:
+        case .postNow:
             let currentMode = NSRunLoop.currentRunLoop().currentMode
             if currentMode == nil || runloopModes.contains(currentMode!) {
                 self.notificationCenter.postNotification(notification)
             }
-        case .PostASAP: // post at the end of the current notification callout or timer
+        case .postASAP: // post at the end of the current notification callout or timer
             addRunloopObserver(self.asapRunloopObserver)
             self.asapList.append((notification, runloopModes))
-        case .PostWhenIdle: // wait until the runloop is idle, then post the notification
+        case .postWhenIdle: // wait until the runloop is idle, then post the notification
             addRunloopObserver(self.idleRunloopObserver)
             self.idleList.append((notification, runloopModes))
         }
@@ -153,7 +153,7 @@ public class NSNotificationQueue : NSObject {
         let currentMode = NSRunLoop.currentRunLoop().currentMode
         for queue in NSNotificationQueue.notificationQueueList {
             let notificationQueue = queue as! NSNotificationQueue
-            if postingStyle == .PostWhenIdle {
+            if postingStyle == .postWhenIdle {
                 notificationQueue.notify(currentMode, notificationList: &notificationQueue.idleList)
             } else {
                 notificationQueue.notify(currentMode, notificationList: &notificationQueue.asapList)

--- a/Foundation/NSNumberFormatter.swift
+++ b/Foundation/NSNumberFormatter.swift
@@ -45,7 +45,7 @@ public class NSNumberFormatter : NSFormatter {
     
     // this is for NSUnitFormatter
     
-    public var formattingContext: NSFormattingContext = .Unknown // default is NSFormattingContextUnknown
+    public var formattingContext: NSFormattingContext = .unknown // default is NSFormattingContextUnknown
     
     // Report the used range of the string and an NSError, in addition to the usual stuff from NSFormatter
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
@@ -139,7 +139,7 @@ public class NSNumberFormatter : NSFormatter {
     }
     
     // Attributes of an NSNumberFormatter
-    internal var _numberStyle: NSNumberFormatterStyle = .NoStyle
+    internal var _numberStyle: NSNumberFormatterStyle = .noStyle
     public var numberStyle: NSNumberFormatterStyle {
         get {
             return _numberStyle
@@ -147,10 +147,10 @@ public class NSNumberFormatter : NSFormatter {
         
         set {
             switch newValue {
-            case .NoStyle, .OrdinalStyle, .SpellOutStyle:
+            case .noStyle, .ordinalStyle, .spellOutStyle:
                 _usesSignificantDigits = false
                 
-            case .CurrencyStyle, .CurrencyPluralStyle, .CurrencyISOCodeStyle, .CurrencyAccountingStyle:
+            case .currencyStyle, .currencyPluralStyle, .currencyISOCodeStyle, .currencyAccountingStyle:
                 _usesSignificantDigits = false
                 _usesGroupingSeparator = true
                 _minimumFractionDigits = 2
@@ -601,7 +601,7 @@ public class NSNumberFormatter : NSFormatter {
     
     //
     
-    internal var _paddingPosition: NSNumberFormatterPadPosition = .BeforePrefix
+    internal var _paddingPosition: NSNumberFormatterPadPosition = .beforePrefix
     public var paddingPosition: NSNumberFormatterPadPosition {
         get {
             return _paddingPosition
@@ -612,7 +612,7 @@ public class NSNumberFormatter : NSFormatter {
         }
     }
     
-    internal var _roundingMode: NSNumberFormatterRoundingMode = .RoundHalfEven
+    internal var _roundingMode: NSNumberFormatterRoundingMode = .roundHalfEven
     public var roundingMode: NSNumberFormatterRoundingMode {
         get {
             return _roundingMode
@@ -869,31 +869,31 @@ public class NSNumberFormatter : NSFormatter {
 }
 
 public enum NSNumberFormatterStyle : UInt {
-    case NoStyle
-    case DecimalStyle
-    case CurrencyStyle
-    case PercentStyle
-    case ScientificStyle
-    case SpellOutStyle
-    case OrdinalStyle
-    case CurrencyISOCodeStyle
-    case CurrencyPluralStyle
-    case CurrencyAccountingStyle
+    case noStyle
+    case decimalStyle
+    case currencyStyle
+    case percentStyle
+    case scientificStyle
+    case spellOutStyle
+    case ordinalStyle
+    case currencyISOCodeStyle
+    case currencyPluralStyle
+    case currencyAccountingStyle
 }
 
 public enum NSNumberFormatterPadPosition : UInt {
-    case BeforePrefix
-    case AfterPrefix
-    case BeforeSuffix
-    case AfterSuffix
+    case beforePrefix
+    case afterPrefix
+    case beforeSuffix
+    case afterSuffix
 }
 
 public enum NSNumberFormatterRoundingMode : UInt {
-    case RoundCeiling
-    case RoundFloor
-    case RoundDown
-    case RoundUp
-    case RoundHalfEven
-    case RoundHalfDown
-    case RoundHalfUp
+    case roundCeiling
+    case roundFloor
+    case roundDown
+    case roundUp
+    case roundHalfEven
+    case roundHalfDown
+    case roundHalfUp
 }

--- a/Foundation/NSOperation.swift
+++ b/Foundation/NSOperation.swift
@@ -130,7 +130,7 @@ public class NSOperation : NSObject {
         return ops
     }
     
-    public var queuePriority: OperationQueuePriority = .Normal
+    public var queuePriority: OperationQueuePriority = .normal
     public var completionBlock: (() -> Void)?
     public func waitUntilFinished() {
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
@@ -154,11 +154,11 @@ public class NSOperation : NSObject {
 }
 
 public enum OperationQueuePriority : Int {
-    case VeryLow
-    case Low
-    case Normal
-    case High
-    case VeryHigh
+    case veryLow
+    case low
+    case normal
+    case high
+    case veryHigh
 }
 
 public class NSBlockOperation : NSOperation {
@@ -206,19 +206,19 @@ internal struct _OperationList {
     mutating func insert(_ operation: NSOperation) {
         all.append(operation)
         switch operation.queuePriority {
-        case .VeryLow:
+        case .veryLow:
             veryLow.append(operation)
             break
-        case .Low:
+        case .low:
             low.append(operation)
             break
-        case .Normal:
+        case .normal:
             normal.append(operation)
             break
-        case .High:
+        case .high:
             high.append(operation)
             break
-        case .VeryHigh:
+        case .veryHigh:
             veryHigh.append(operation)
             break
         }
@@ -229,27 +229,27 @@ internal struct _OperationList {
             all.remove(at: idx)
         }
         switch operation.queuePriority {
-        case .VeryLow:
+        case .veryLow:
             if let idx = veryLow.index(of: operation) {
                 veryLow.remove(at: idx)
             }
             break
-        case .Low:
+        case .low:
             if let idx = low.index(of: operation) {
                 low.remove(at: idx)
             }
             break
-        case .Normal:
+        case .normal:
             if let idx = normal.index(of: operation) {
                 normal.remove(at: idx)
             }
             break
-        case .High:
+        case .high:
             if let idx = high.index(of: operation) {
                 high.remove(at: idx)
             }
             break
-        case .VeryHigh:
+        case .veryHigh:
             if let idx = veryHigh.index(of: operation) {
                 veryHigh.remove(at: idx)
             }

--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -564,33 +564,33 @@ public extension NSString {
 
 public enum NSSearchPathDirectory : UInt {
     
-    case ApplicationDirectory // supported applications (Applications)
-    case DemoApplicationDirectory // unsupported applications, demonstration versions (Demos)
-    case DeveloperApplicationDirectory // developer applications (Developer/Applications). DEPRECATED - there is no one single Developer directory.
-    case AdminApplicationDirectory // system and network administration applications (Administration)
-    case LibraryDirectory // various documentation, support, and configuration files, resources (Library)
-    case DeveloperDirectory // developer resources (Developer) DEPRECATED - there is no one single Developer directory.
-    case UserDirectory // user home directories (Users)
-    case DocumentationDirectory // documentation (Documentation)
-    case DocumentDirectory // documents (Documents)
-    case CoreServiceDirectory // location of CoreServices directory (System/Library/CoreServices)
-    case AutosavedInformationDirectory // location of autosaved documents (Documents/Autosaved)
-    case DesktopDirectory // location of user's desktop
-    case CachesDirectory // location of discardable cache files (Library/Caches)
-    case ApplicationSupportDirectory // location of application support files (plug-ins, etc) (Library/Application Support)
-    case DownloadsDirectory // location of the user's "Downloads" directory
-    case InputMethodsDirectory // input methods (Library/Input Methods)
-    case MoviesDirectory // location of user's Movies directory (~/Movies)
-    case MusicDirectory // location of user's Music directory (~/Music)
-    case PicturesDirectory // location of user's Pictures directory (~/Pictures)
-    case PrinterDescriptionDirectory // location of system's PPDs directory (Library/Printers/PPDs)
-    case SharedPublicDirectory // location of user's Public sharing directory (~/Public)
-    case PreferencePanesDirectory // location of the PreferencePanes directory for use with System Preferences (Library/PreferencePanes)
-    case ApplicationScriptsDirectory // location of the user scripts folder for the calling application (~/Library/Application Scripts/code-signing-id)
-    case ItemReplacementDirectory // For use with NSFileManager's URLForDirectory:inDomain:appropriateForURL:create:error:
-    case AllApplicationsDirectory // all directories where applications can occur
-    case AllLibrariesDirectory // all directories where resources can occur
-    case TrashDirectory // location of Trash directory
+    case applicationDirectory // supported applications (Applications)
+    case demoApplicationDirectory // unsupported applications, demonstration versions (Demos)
+    case developerApplicationDirectory // developer applications (Developer/Applications). DEPRECATED - there is no one single Developer directory.
+    case adminApplicationDirectory // system and network administration applications (Administration)
+    case libraryDirectory // various documentation, support, and configuration files, resources (Library)
+    case developerDirectory // developer resources (Developer) DEPRECATED - there is no one single Developer directory.
+    case userDirectory // user home directories (Users)
+    case documentationDirectory // documentation (Documentation)
+    case documentDirectory // documents (Documents)
+    case coreServiceDirectory // location of CoreServices directory (System/Library/CoreServices)
+    case autosavedInformationDirectory // location of autosaved documents (Documents/Autosaved)
+    case desktopDirectory // location of user's desktop
+    case cachesDirectory // location of discardable cache files (Library/Caches)
+    case applicationSupportDirectory // location of application support files (plug-ins, etc) (Library/Application Support)
+    case downloadsDirectory // location of the user's "Downloads" directory
+    case inputMethodsDirectory // input methods (Library/Input Methods)
+    case moviesDirectory // location of user's Movies directory (~/Movies)
+    case musicDirectory // location of user's Music directory (~/Music)
+    case picturesDirectory // location of user's Pictures directory (~/Pictures)
+    case printerDescriptionDirectory // location of system's PPDs directory (Library/Printers/PPDs)
+    case sharedPublicDirectory // location of user's Public sharing directory (~/Public)
+    case preferencePanesDirectory // location of the PreferencePanes directory for use with System Preferences (Library/PreferencePanes)
+    case applicationScriptsDirectory // location of the user scripts folder for the calling application (~/Library/Application Scripts/code-signing-id)
+    case itemReplacementDirectory // For use with NSFileManager's URLForDirectory:inDomain:appropriateForURL:create:error:
+    case allApplicationsDirectory // all directories where applications can occur
+    case allLibrariesDirectory // all directories where resources can occur
+    case TtrashDirectory // location of Trash directory
 }
 
 public struct NSSearchPathDomainMask : OptionSet {

--- a/Foundation/NSPredicate.swift
+++ b/Foundation/NSPredicate.swift
@@ -13,8 +13,8 @@
 public class NSPredicate : NSObject, NSSecureCoding, NSCopying {
 
     private enum PredicateKind {
-        case Boolean(Bool)
-        case Block((AnyObject?, [String : AnyObject]?) -> Bool)
+        case boolean(Bool)
+        case block((AnyObject?, [String : AnyObject]?) -> Bool)
         // TODO: case for init(format:argumentArray:)
         // TODO: case for init(fromMetadataQueryString:)
     }
@@ -47,12 +47,12 @@ public class NSPredicate : NSObject, NSSecureCoding, NSCopying {
     public init?(fromMetadataQueryString queryString: String) { NSUnimplemented() }
     
     public init(value: Bool) {
-        kind = .Boolean(value)
+        kind = .boolean(value)
         super.init()
     } // return predicates that always evaluate to true/false
 
     public init(block: (AnyObject?, [String : AnyObject]?) -> Bool) {
-        kind = .Block(block)
+        kind = .block(block)
         super.init()
     }
     
@@ -70,9 +70,9 @@ public class NSPredicate : NSObject, NSSecureCoding, NSCopying {
         }
 
         switch kind {
-        case let .Boolean(value):
+        case let .boolean(value):
             return value
-        case let .Block(block):
+        case let .block(block):
             return block(object, bindings)
         }
     } // single pass evaluation substituting variables from the bindings dictionary for any variable expressions encountered

--- a/Foundation/NSPropertyList.swift
+++ b/Foundation/NSPropertyList.swift
@@ -20,9 +20,9 @@ public struct NSPropertyListMutabilityOptions : OptionSet {
 
 public enum NSPropertyListFormat : UInt {
     
-    case OpenStepFormat = 1
-    case XMLFormat_v1_0 = 100
-    case BinaryFormat_v1_0 = 200
+    case openStepFormat = 1
+    case xmlFormat_v1_0 = 100
+    case binaryFormat_v1_0 = 200
 }
 
 #if os(OSX) || os(iOS)

--- a/Foundation/NSStream.swift
+++ b/Foundation/NSStream.swift
@@ -10,14 +10,14 @@
 
 public enum NSStreamStatus : UInt {
     
-    case NotOpen
-    case Opening
-    case Open
-    case Reading
-    case Writing
-    case AtEnd
-    case Closed
-    case Error
+    case notOpen
+    case opening
+    case open
+    case reading
+    case writing
+    case atEnd
+    case closed
+    case error
 }
 
 public struct NSStreamEvent : OptionSet {

--- a/Foundation/NSTask.swift
+++ b/Foundation/NSTask.swift
@@ -16,8 +16,8 @@ import CoreFoundation
 #endif
 
 public enum NSTaskTerminationReason : Int {
-    case Exit
-    case UncaughtSignal
+    case exit
+    case uncaughtSignal
 }
 
 private func WEXITSTATUS(_ status: CInt) -> CInt {

--- a/Foundation/NSThread.swift
+++ b/Foundation/NSThread.swift
@@ -67,19 +67,19 @@ internal class NSThreadSpecific<T: AnyObject> {
 }
 
 internal enum _NSThreadStatus {
-    case Initialized
-    case Starting
-    case Executing
-    case Finished
+    case initialized
+    case starting
+    case executing
+    case finished
 }
 
 private func NSThreadStart(_ context: UnsafeMutablePointer<Void>?) -> UnsafeMutablePointer<Void>? {
     let unmanaged: Unmanaged<NSThread> = Unmanaged.fromOpaque(OpaquePointer(context!))
     let thread = unmanaged.takeUnretainedValue()
     NSThread._currentThread.set(thread)
-    thread._status = _NSThreadStatus.Executing
+    thread._status = .executing
     thread.main()
-    thread._status = _NSThreadStatus.Finished
+    thread._status = .finished
     unmanaged.release()
     return nil
 }
@@ -160,7 +160,7 @@ public class NSThread : NSObject {
     private var _thread = pthread_t()
 #endif
     internal var _attr = pthread_attr_t()
-    internal var _status = _NSThreadStatus.Initialized
+    internal var _status = _NSThreadStatus.initialized
     internal var _cancelled = false
     /// - Note: this differs from the Darwin implementation in that the keys must be Strings
     public var threadDictionary = [String:AnyObject]()
@@ -178,10 +178,10 @@ public class NSThread : NSObject {
     }
     
     public func start() {
-        precondition(_status == .Initialized, "attempting to start a thread that has already been started")
-        _status = .Starting
+        precondition(_status == .initialized, "attempting to start a thread that has already been started")
+        _status = .starting
         if _cancelled {
-            _status = .Finished
+            _status = .finished
             return
         }
         withUnsafeMutablePointers(&_thread, &_attr) { thread, attr in
@@ -215,11 +215,11 @@ public class NSThread : NSObject {
     }
     
     public var executing: Bool {
-        return _status == .Executing
+        return _status == .executing
     }
 
     public var finished: Bool {
-        return _status == .Finished
+        return _status == .finished
     }
     
     public var cancelled: Bool {

--- a/Foundation/NSURLCache.swift
+++ b/Foundation/NSURLCache.swift
@@ -28,9 +28,9 @@
 */
 public enum NSURLCacheStoragePolicy : UInt {
     
-    case Allowed
-    case AllowedInMemoryOnly
-    case NotAllowed
+    case allowed
+    case allowedInMemoryOnly
+    case notAllowed
 }
 
 /*!

--- a/Foundation/NSURLCredential.swift
+++ b/Foundation/NSURLCredential.swift
@@ -19,10 +19,10 @@
         access only its own credentials.
 */
 public enum NSURLCredentialPersistence : UInt {
-    case None
-    case ForSession
-    case Permanent
-    case Synchronizable
+    case none
+    case forSession
+    case permanent
+    case synchronizable
 }
 
 
@@ -44,7 +44,7 @@ public class NSURLCredential : NSObject, NSSecureCoding, NSCopying {
         @result The initialized NSURLCredential
      */
     public init(user: String, password: String, persistence: NSURLCredentialPersistence) {
-        guard persistence != .Permanent && persistence != .Synchronizable else {
+        guard persistence != .permanent && persistence != .synchronizable else {
             NSUnimplemented()
         }
         _user = user

--- a/Foundation/NSURLSession.swift
+++ b/Foundation/NSURLSession.swift
@@ -208,10 +208,10 @@ extension NSURLSession {
 
 public enum NSURLSessionTaskState : Int {
     
-    case Running /* The task is currently being serviced by the session */
-    case Suspended
-    case Canceling /* The task has been told to cancel.  The session will receive a URLSession:task:didCompleteWithError: message. */
-    case Completed /* The task has completed and the session will receive no more delegate notifications */
+    case running /* The task is currently being serviced by the session */
+    case suspended
+    case canceling /* The task has been told to cancel.  The session will receive a URLSession:task:didCompleteWithError: message. */
+    case completed /* The task has completed and the session will receive no more delegate notifications */
 }
 
 /*
@@ -547,18 +547,18 @@ public class NSURLSessionConfiguration : NSObject, NSCopying {
  */
 public enum NSURLSessionAuthChallengeDisposition : Int {
     
-    case UseCredential /* Use the specified credential, which may be nil */
-    case PerformDefaultHandling /* Default handling for the challenge - as if this delegate were not implemented; the credential parameter is ignored. */
-    case CancelAuthenticationChallenge /* The entire request will be canceled; the credential parameter is ignored. */
-    case RejectProtectionSpace /* This challenge is rejected and the next authentication protection space should be tried; the credential parameter is ignored. */
+    case useCredential /* Use the specified credential, which may be nil */
+    case performDefaultHandling /* Default handling for the challenge - as if this delegate were not implemented; the credential parameter is ignored. */
+    case cancelAuthenticationChallenge /* The entire request will be canceled; the credential parameter is ignored. */
+    case rejectProtectionSpace /* This challenge is rejected and the next authentication protection space should be tried; the credential parameter is ignored. */
 }
 
 public enum NSURLSessionResponseDisposition : Int {
     
-    case Cancel /* Cancel the load, this is the same as -[task cancel] */
-    case Allow /* Allow the load to continue */
-    case BecomeDownload /* Turn this request into a download */
-    case BecomeStream /* Turn this task into a stream task */
+    case cancel /* Cancel the load, this is the same as -[task cancel] */
+    case allow /* Allow the load to continue */
+    case becomeDownload /* Turn this request into a download */
+    case becomeStream /* Turn this task into a stream task */
 }
 
 /*

--- a/Foundation/NSUserDefaults.swift
+++ b/Foundation/NSUserDefaults.swift
@@ -120,14 +120,14 @@ public class NSUserDefaults : NSObject {
         //This got out of hand fast...
         let cVal = bVal._swiftObject
         enum convErr: ErrorProtocol {
-            case ConvErr
+            case convErr
         }
         do {
             let dVal = try cVal.map({ (key, val) -> (String, AnyObject) in
                 if let strKey = key as? NSString {
                     return (strKey._swiftObject, val)
                 } else {
-                    throw convErr.ConvErr
+                    throw convErr.convErr
                 }
             })
             var eVal = [String : AnyObject]()

--- a/Foundation/NSXMLParser.swift
+++ b/Foundation/NSXMLParser.swift
@@ -22,10 +22,10 @@ import CoreFoundation
 
 public enum NSXMLParserExternalEntityResolvingPolicy : UInt {
     
-    case ResolveExternalEntitiesNever // default
-    case ResolveExternalEntitiesNoNetwork
-    case ResolveExternalEntitiesSameOriginOnly //only applies to NSXMLParser instances initialized with -initWithContentsOfURL:
-    case ResolveExternalEntitiesAlways
+    case resolveExternalEntitiesNever // default
+    case resolveExternalEntitiesNoNetwork
+    case resolveExternalEntitiesSameOriginOnly //only applies to NSXMLParser instances initialized with -initWithContentsOfURL:
+    case resolveExternalEntitiesAlways
 }
 
 extension _CFXMLInterface {
@@ -69,7 +69,7 @@ internal func _NSXMLParserExternalEntityWithURL(_ interface: _CFXMLInterface, ur
         }
         if let url = a {
             let allowed = allowedEntityURLs.contains(url)
-            if allowed || policy != .ResolveExternalEntitiesSameOriginOnly {
+            if allowed || policy != .resolveExternalEntitiesSameOriginOnly {
                 if allowed {
                     return originalLoaderFunction(urlStr, identifier, context)
                 }
@@ -78,7 +78,7 @@ internal func _NSXMLParserExternalEntityWithURL(_ interface: _CFXMLInterface, ur
     }
     
     switch policy {
-    case .ResolveExternalEntitiesSameOriginOnly:
+    case .resolveExternalEntitiesSameOriginOnly:
         guard let url = parser._url else { break }
         
         if a == nil {
@@ -114,11 +114,11 @@ internal func _NSXMLParserExternalEntityWithURL(_ interface: _CFXMLInterface, ur
             return nil
         }
         break
-    case .ResolveExternalEntitiesAlways:
+    case .resolveExternalEntitiesAlways:
         break
-    case .ResolveExternalEntitiesNever:
+    case .resolveExternalEntitiesNever:
         return nil
-    case .ResolveExternalEntitiesNoNetwork:
+    case .resolveExternalEntitiesNoNetwork:
         return _CFXMLInterfaceNoNetExternalEntityLoader(urlStr, identifier, context)
     }
     
@@ -446,7 +446,7 @@ public class NSXMLParser : NSObject {
     public var shouldReportNamespacePrefixes: Bool = false
     
     //defaults to NSXMLNodeLoadExternalEntitiesNever
-    public var externalEntityResolvingPolicy: NSXMLParserExternalEntityResolvingPolicy = .ResolveExternalEntitiesNever
+    public var externalEntityResolvingPolicy: NSXMLParserExternalEntityResolvingPolicy = .resolveExternalEntitiesNever
     
     public var allowedExternalEntityURLs: Set<NSURL>?
     

--- a/TestFoundation/TestNSByteCountFormatter.swift
+++ b/TestFoundation/TestNSByteCountFormatter.swift
@@ -30,13 +30,13 @@ class TestNSByteCountFormatter : XCTestCase {
     func test_DefaultValues() {
         let formatter = NSByteCountFormatter()
         XCTAssertEqual(formatter.allowedUnits, NSByteCountFormatterUnits.UseDefault)
-        XCTAssertEqual(formatter.countStyle, NSByteCountFormatterCountStyle.File)
+        XCTAssertEqual(formatter.countStyle, NSByteCountFormatterCountStyle.file)
         XCTAssertEqual(formatter.allowsNonnumericFormatting, true)
         XCTAssertEqual(formatter.includesUnit, true)
         XCTAssertEqual(formatter.includesCount, true)
         XCTAssertEqual(formatter.includesActualByteCount, false)
         XCTAssertEqual(formatter.adaptive, true)
         XCTAssertEqual(formatter.zeroPadsFractionDigits, false)
-        XCTAssertEqual(formatter.formattingContext, NSFormattingContext.Unknown)
+        XCTAssertEqual(formatter.formattingContext, NSFormattingContext.unknown)
     }
 }

--- a/TestFoundation/TestNSDateFormatter.swift
+++ b/TestFoundation/TestNSDateFormatter.swift
@@ -108,8 +108,8 @@ class TestNSDateFormatter: XCTestCase {
         ]
         
         let f = NSDateFormatter()
-        f.dateStyle = .ShortStyle
-        f.timeStyle = .ShortStyle
+        f.dateStyle = .shortStyle
+        f.timeStyle = .shortStyle
         
         // ensure tests give consistent results by setting specific timeZone and locale
         f.timeZone = NSTimeZone(name: DEFAULT_TIMEZONE)
@@ -141,8 +141,8 @@ class TestNSDateFormatter: XCTestCase {
         ]
         
         let f = NSDateFormatter()
-        f.dateStyle = .MediumStyle
-        f.timeStyle = .MediumStyle
+        f.dateStyle = .mediumStyle
+        f.timeStyle = .mediumStyle
         f.timeZone = NSTimeZone(name: DEFAULT_TIMEZONE)
         f.locale = NSLocale(localeIdentifier: DEFAULT_LOCALE)
         
@@ -173,8 +173,8 @@ class TestNSDateFormatter: XCTestCase {
         ]
         
         let f = NSDateFormatter()
-        f.dateStyle = .LongStyle
-        f.timeStyle = .LongStyle
+        f.dateStyle = .longStyle
+        f.timeStyle = .longStyle
         f.timeZone = NSTimeZone(name: DEFAULT_TIMEZONE)
         f.locale = NSLocale(localeIdentifier: DEFAULT_LOCALE)
         
@@ -207,8 +207,8 @@ class TestNSDateFormatter: XCTestCase {
         ]
         
         let f = NSDateFormatter()
-        f.dateStyle = .FullStyle
-        f.timeStyle = .FullStyle
+        f.dateStyle = .fullStyle
+        f.timeStyle = .fullStyle
         f.timeZone = NSTimeZone(name: DEFAULT_TIMEZONE)
         f.locale = NSLocale(localeIdentifier: DEFAULT_LOCALE)
         
@@ -268,8 +268,8 @@ class TestNSDateFormatter: XCTestCase {
         
         // Check .dateFormat resets when style changes
         let testDate = NSDate(timeIntervalSince1970: 1457738454)
-        f.dateStyle = .MediumStyle
-        f.timeStyle = .MediumStyle
+        f.dateStyle = .mediumStyle
+        f.timeStyle = .mediumStyle
         XCTAssertEqual(f.string(from: testDate), "Mar 11, 2016, 11:20:54 PM")
         XCTAssertEqual(f.dateFormat, "MMM d, y, h:mm:ss a")
         

--- a/TestFoundation/TestNSGeometry.swift
+++ b/TestFoundation/TestNSGeometry.swift
@@ -367,7 +367,7 @@ class TestNSGeometry : XCTestCase {
         var inRect = NSZeroRect
         var slice = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(25.0), CGFloat(35.0))
         var remainder = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(25.0), CGFloat(35.0))
-        NSDivideRect(inRect, &slice, &remainder, CGFloat(0.0), .MaxX)
+        NSDivideRect(inRect, &slice, &remainder, CGFloat(0.0), .maxX)
         var expectedSlice = NSZeroRect
         var expectedRemainder = NSZeroRect
         XCTAssertEqual(slice, expectedSlice)
@@ -377,7 +377,7 @@ class TestNSGeometry : XCTestCase {
         inRect = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(25.0), CGFloat(35.0))
         slice = NSZeroRect
         remainder = NSZeroRect
-        NSDivideRect(inRect, &slice, &remainder, CGFloat(10.0), .MinX)
+        NSDivideRect(inRect, &slice, &remainder, CGFloat(10.0), .minX)
         expectedSlice = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(10.0), CGFloat(35.0))
         expectedRemainder = NSMakeRect(CGFloat(10.0), CGFloat(-5.0), CGFloat(15.0), CGFloat(35.0))
         XCTAssertEqual(slice, expectedSlice)
@@ -387,7 +387,7 @@ class TestNSGeometry : XCTestCase {
         inRect = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(25.0), CGFloat(35.0))
         slice = NSZeroRect
         remainder = NSZeroRect
-        NSDivideRect(inRect, &slice, &remainder, NSWidth(inRect) + CGFloat(1.0), .MinX)
+        NSDivideRect(inRect, &slice, &remainder, NSWidth(inRect) + CGFloat(1.0), .minX)
         expectedSlice = inRect
         expectedRemainder = NSMakeRect(CGFloat(25.0), CGFloat(-5.0), CGFloat(0.0), CGFloat(35.0))
         XCTAssertEqual(slice, expectedSlice)
@@ -397,7 +397,7 @@ class TestNSGeometry : XCTestCase {
         inRect = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(25.0), CGFloat(35.0))
         slice = NSZeroRect
         remainder = NSZeroRect
-        NSDivideRect(inRect, &slice, &remainder, CGFloat(10.0), .MinY)
+        NSDivideRect(inRect, &slice, &remainder, CGFloat(10.0), .minY)
         expectedSlice = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(25.0), CGFloat(10.0))
         expectedRemainder = NSMakeRect(CGFloat(0.0), CGFloat(5.0), CGFloat(25.0), CGFloat(25.0))
         XCTAssertEqual(slice, expectedSlice)
@@ -407,7 +407,7 @@ class TestNSGeometry : XCTestCase {
         inRect = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(25.0), CGFloat(35.0))
         slice = NSZeroRect
         remainder = NSZeroRect
-        NSDivideRect(inRect, &slice, &remainder, NSHeight(inRect) + CGFloat(1.0), .MinY)
+        NSDivideRect(inRect, &slice, &remainder, NSHeight(inRect) + CGFloat(1.0), .minY)
         expectedSlice = inRect
         expectedRemainder = NSMakeRect(CGFloat(0.0), CGFloat(30.0), CGFloat(25.0), CGFloat(0.0))
         XCTAssertEqual(slice, expectedSlice)
@@ -417,7 +417,7 @@ class TestNSGeometry : XCTestCase {
         inRect = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(25.0), CGFloat(35.0))
         slice = NSZeroRect
         remainder = NSZeroRect
-        NSDivideRect(inRect, &slice, &remainder, CGFloat(10.0), .MaxX)
+        NSDivideRect(inRect, &slice, &remainder, CGFloat(10.0), .maxX)
         expectedSlice = NSMakeRect(CGFloat(15.0), CGFloat(-5.0), CGFloat(10.0), CGFloat(35.0))
         expectedRemainder = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(15.0), CGFloat(35.0))
         XCTAssertEqual(slice, expectedSlice)
@@ -427,7 +427,7 @@ class TestNSGeometry : XCTestCase {
         inRect = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(25.0), CGFloat(35.0))
         slice = NSZeroRect
         remainder = NSZeroRect
-        NSDivideRect(inRect, &slice, &remainder, NSWidth(inRect) + CGFloat(1.0), .MaxX)
+        NSDivideRect(inRect, &slice, &remainder, NSWidth(inRect) + CGFloat(1.0), .maxX)
         expectedSlice = inRect
         expectedRemainder = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(0.0), CGFloat(35.0))
         XCTAssertEqual(slice, expectedSlice)
@@ -437,7 +437,7 @@ class TestNSGeometry : XCTestCase {
         inRect = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(25.0), CGFloat(35.0))
         slice = NSZeroRect
         remainder = NSZeroRect
-        NSDivideRect(inRect, &slice, &remainder, CGFloat(10.0), .MaxY)
+        NSDivideRect(inRect, &slice, &remainder, CGFloat(10.0), .maxY)
         expectedSlice = NSMakeRect(CGFloat(0.0), CGFloat(20.0), CGFloat(25.0), CGFloat(10.0))
         expectedRemainder = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(25.0), CGFloat(25.0))
         XCTAssertEqual(slice, expectedSlice)
@@ -447,7 +447,7 @@ class TestNSGeometry : XCTestCase {
         inRect = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(25.0), CGFloat(35.0))
         slice = NSZeroRect
         remainder = NSZeroRect
-        NSDivideRect(inRect, &slice, &remainder, NSHeight(inRect) + CGFloat(1.0), .MaxY)
+        NSDivideRect(inRect, &slice, &remainder, NSHeight(inRect) + CGFloat(1.0), .maxY)
         expectedSlice = inRect
         expectedRemainder = NSMakeRect(CGFloat(0.0), CGFloat(-5.0), CGFloat(25.0), CGFloat(0.0))
         XCTAssertEqual(slice, expectedSlice)

--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -112,8 +112,8 @@ class TestNSKeyedArchiver : XCTestCase {
     
     private func test_archive(_ object: NSObject, classes: [AnyClass], allowsSecureCoding: Bool = true) {
         // test both XML and binary encodings
-        test_archive(object, classes: classes, allowsSecureCoding: allowsSecureCoding, outputFormat: NSPropertyListFormat.XMLFormat_v1_0)
-        test_archive(object, classes: classes, allowsSecureCoding: allowsSecureCoding, outputFormat: NSPropertyListFormat.BinaryFormat_v1_0)
+        test_archive(object, classes: classes, allowsSecureCoding: allowsSecureCoding, outputFormat: NSPropertyListFormat.xmlFormat_v1_0)
+        test_archive(object, classes: classes, allowsSecureCoding: allowsSecureCoding, outputFormat: NSPropertyListFormat.binaryFormat_v1_0)
     }
     
     private func test_archive(_ object: NSObject, allowsSecureCoding: Bool = true) {

--- a/TestFoundation/TestNSNotificationQueue.swift
+++ b/TestFoundation/TestNSNotificationQueue.swift
@@ -55,7 +55,7 @@ class TestNSNotificationQueue : XCTestCase {
             numberOfCalls += 1
         }
         let queue = NSNotificationQueue.defaultQueue()
-        queue.enqueueNotification(notification, postingStyle: .PostNow)
+        queue.enqueueNotification(notification, postingStyle: .postNow)
         XCTAssertEqual(numberOfCalls, 1)
     }
 
@@ -68,9 +68,9 @@ class TestNSNotificationQueue : XCTestCase {
             numberOfCalls += 1
         }
         let queue = NSNotificationQueue.defaultQueue()
-        queue.enqueueNotification(notification, postingStyle: .PostNow)
-        queue.enqueueNotification(notification, postingStyle: .PostNow)
-        queue.enqueueNotification(notification, postingStyle: .PostNow)
+        queue.enqueueNotification(notification, postingStyle: .postNow)
+        queue.enqueueNotification(notification, postingStyle: .postNow)
+        queue.enqueueNotification(notification, postingStyle: .postNow)
         // Coalescing doesn't work for the NSPostingStyle.PostNow. That is why we expect 3 calls here
         XCTAssertEqual(numberOfCalls, 3)
     }
@@ -85,7 +85,7 @@ class TestNSNotificationQueue : XCTestCase {
             numberOfCalls += 1
         }
         let notificationQueue = NSNotificationQueue(notificationCenter: notificationCenter)
-        notificationQueue.enqueueNotification(notification, postingStyle: .PostNow)
+        notificationQueue.enqueueNotification(notification, postingStyle: .postNow)
         XCTAssertEqual(numberOfCalls, 1)
     }
 
@@ -108,11 +108,11 @@ class TestNSNotificationQueue : XCTestCase {
             }
 
             // post 2 notifications for the NSDefaultRunLoopMode mode
-            queue.enqueueNotification(notification, postingStyle: .PostNow, coalesceMask: [], forModes: [runLoopMode])
-            queue.enqueueNotification(notification, postingStyle: .PostNow)
+            queue.enqueueNotification(notification, postingStyle: .postNow, coalesceMask: [], forModes: [runLoopMode])
+            queue.enqueueNotification(notification, postingStyle: .postNow)
             // here we post notification for the NSRunLoopCommonModes. It shouldn't have any affect, because the timer is scheduled in NSDefaultRunLoopMode.
             // The notification queue will only post the notification to its notification center if the run loop is in one of the modes provided in the array.
-            queue.enqueueNotification(notification, postingStyle: .PostNow, coalesceMask: [], forModes: [NSRunLoopCommonModes])
+            queue.enqueueNotification(notification, postingStyle: .postNow, coalesceMask: [], forModes: [NSRunLoopCommonModes])
         }
         runLoop.addTimer(dummyTimer, forMode: NSDefaultRunLoopMode)
         runLoop.runMode(NSDefaultRunLoopMode, beforeDate: endDate)
@@ -128,7 +128,7 @@ class TestNSNotificationQueue : XCTestCase {
             numberOfCalls += 1
         }
         let queue = NSNotificationQueue.defaultQueue()
-        queue.enqueueNotification(notification, postingStyle: .PostASAP)
+        queue.enqueueNotification(notification, postingStyle: .postASAP)
 
         scheduleTimer(withInterval: 0.001) // run timer trigger the notifications
         XCTAssertEqual(numberOfCalls, 1)
@@ -143,9 +143,9 @@ class TestNSNotificationQueue : XCTestCase {
             numberOfCalls += 1
         }
         let queue = NSNotificationQueue.defaultQueue()
-        queue.enqueueNotification(notification, postingStyle: .PostASAP)
-        queue.enqueueNotification(notification, postingStyle: .PostASAP)
-        queue.enqueueNotification(notification, postingStyle: .PostASAP)
+        queue.enqueueNotification(notification, postingStyle: .postASAP)
+        queue.enqueueNotification(notification, postingStyle: .postASAP)
+        queue.enqueueNotification(notification, postingStyle: .postASAP)
 
         scheduleTimer(withInterval: 0.001)
         XCTAssertEqual(numberOfCalls, 1)
@@ -167,15 +167,15 @@ class TestNSNotificationQueue : XCTestCase {
 
         let queue = NSNotificationQueue.defaultQueue()
         // #1
-        queue.enqueueNotification(notification1, postingStyle: .PostASAP,  coalesceMask: .CoalescingOnName, forModes: nil)
+        queue.enqueueNotification(notification1, postingStyle: .postASAP,  coalesceMask: .CoalescingOnName, forModes: nil)
         // #2
-        queue.enqueueNotification(notification2, postingStyle: .PostASAP,  coalesceMask: .CoalescingOnSender, forModes: nil)
+        queue.enqueueNotification(notification2, postingStyle: .postASAP,  coalesceMask: .CoalescingOnSender, forModes: nil)
         // #3, coalesce with 1 & 2
-        queue.enqueueNotification(notification1, postingStyle: .PostASAP,  coalesceMask: .CoalescingOnName, forModes: nil)
+        queue.enqueueNotification(notification1, postingStyle: .postASAP,  coalesceMask: .CoalescingOnName, forModes: nil)
         // #4, coalesce with #3
-        queue.enqueueNotification(notification2, postingStyle: .PostASAP,  coalesceMask: .CoalescingOnName, forModes: nil)
+        queue.enqueueNotification(notification2, postingStyle: .postASAP,  coalesceMask: .CoalescingOnName, forModes: nil)
         // #5
-        queue.enqueueNotification(notification1, postingStyle: .PostASAP,  coalesceMask: .CoalescingOnSender, forModes: nil)
+        queue.enqueueNotification(notification1, postingStyle: .postASAP,  coalesceMask: .CoalescingOnSender, forModes: nil)
         scheduleTimer(withInterval: 0.001)
         // check that we received notifications #4 and #5
         XCTAssertEqual(numberOfNameCoalescingCalls, 1)
@@ -192,7 +192,7 @@ class TestNSNotificationQueue : XCTestCase {
         NSNotificationCenter.defaultCenter().addObserverForName(notificationName, object: dummyObject, queue: nil) { notification in
             numberOfCalls += 1
         }
-        NSNotificationQueue.defaultQueue().enqueueNotification(notification, postingStyle: .PostWhenIdle)
+        NSNotificationQueue.defaultQueue().enqueueNotification(notification, postingStyle: .postWhenIdle)
         // add a timer to wakeup the runloop, process the timer and call the observer awaiting for any input sources/timers
         scheduleTimer(withInterval: 0.001)
         XCTAssertEqual(numberOfCalls, 1)

--- a/TestFoundation/TestNSNumberFormatter.swift
+++ b/TestFoundation/TestNSNumberFormatter.swift
@@ -70,7 +70,7 @@ class TestNSNumberFormatter: XCTestCase {
     
     func test_decimalSeparator() {
         let numberFormatter = NSNumberFormatter()
-        numberFormatter.numberStyle = .DecimalStyle
+        numberFormatter.numberStyle = .decimalStyle
         numberFormatter.decimalSeparator = "-"
         let formattedString = numberFormatter.stringFromNumber(42.42)
         XCTAssertEqual(formattedString, "42-42")
@@ -106,7 +106,7 @@ class TestNSNumberFormatter: XCTestCase {
     
     func test_percentSymbol() {
         let numberFormatter = NSNumberFormatter()
-        numberFormatter.numberStyle = .PercentStyle
+        numberFormatter.numberStyle = .percentStyle
         numberFormatter.percentSymbol = "💯"
         let formattedString = numberFormatter.stringFromNumber(0.42)
         XCTAssertEqual(formattedString, "42💯")
@@ -168,7 +168,7 @@ class TestNSNumberFormatter: XCTestCase {
     
     func test_exponentSymbol() {
         let numberFormatter = NSNumberFormatter()
-        numberFormatter.numberStyle = .ScientificStyle
+        numberFormatter.numberStyle = .scientificStyle
         numberFormatter.exponentSymbol = "⬆️"
         let formattedString = numberFormatter.stringFromNumber(42)
         XCTAssertEqual(formattedString, "4.2⬆️1")
@@ -225,14 +225,14 @@ class TestNSNumberFormatter: XCTestCase {
     func test_roundingMode() {
         let numberFormatter = NSNumberFormatter()
         numberFormatter.maximumFractionDigits = 0
-        numberFormatter.roundingMode = .RoundCeiling
+        numberFormatter.roundingMode = .roundCeiling
         let formattedString = numberFormatter.stringFromNumber(41.0001)
         XCTAssertEqual(formattedString, "42")
     }
     
     func test_roundingIncrement() {
         let numberFormatter = NSNumberFormatter()
-        numberFormatter.numberStyle = .DecimalStyle
+        numberFormatter.numberStyle = .decimalStyle
         numberFormatter.roundingIncrement = 0.2
         let formattedString = numberFormatter.stringFromNumber(4.25)
         XCTAssertEqual(formattedString, "4.2")
@@ -250,7 +250,7 @@ class TestNSNumberFormatter: XCTestCase {
         let numberFormatter = NSNumberFormatter()
         numberFormatter.paddingCharacter = "_"
         numberFormatter.formatWidth = 5
-        numberFormatter.paddingPosition = .AfterPrefix
+        numberFormatter.paddingPosition = .afterPrefix
         let formattedString = numberFormatter.stringFromNumber(-42)
         XCTAssertEqual(formattedString, "-__42")
     }

--- a/TestFoundation/TestNSOperationQueue.swift
+++ b/TestFoundation/TestNSOperationQueue.swift
@@ -50,10 +50,10 @@ class TestNSOperationQueue : XCTestCase {
         let operation4: NSBlockOperation = NSBlockOperation (block: {
             msgOperations.append("Operation4 executed")
         })
-        operation4.queuePriority = OperationQueuePriority.VeryLow
-        operation3.queuePriority = OperationQueuePriority.VeryHigh
-        operation2.queuePriority = OperationQueuePriority.Low
-        operation1.queuePriority = OperationQueuePriority.Normal
+        operation4.queuePriority = OperationQueuePriority.veryLow
+        operation3.queuePriority = OperationQueuePriority.veryHigh
+        operation2.queuePriority = OperationQueuePriority.low
+        operation1.queuePriority = OperationQueuePriority.normal
         var operations = [NSOperation]()
         operations.append(operation1)
         operations.append(operation2)

--- a/TestFoundation/TestNSPropertyList.swift
+++ b/TestFoundation/TestNSPropertyList.swift
@@ -31,7 +31,7 @@ class TestNSPropertyList : XCTestCase {
 //        dict["foo"] = "bar"
         var data: NSData? = nil
         do {
-            data = try NSPropertyListSerialization.dataWithPropertyList(dict, format: NSPropertyListFormat.BinaryFormat_v1_0, options: 0)
+            data = try NSPropertyListSerialization.dataWithPropertyList(dict, format: NSPropertyListFormat.binaryFormat_v1_0, options: 0)
         } catch {
             
         }
@@ -41,7 +41,7 @@ class TestNSPropertyList : XCTestCase {
     
     func test_decode() {
         var decoded: Any?
-        var fmt = NSPropertyListFormat.BinaryFormat_v1_0
+        var fmt = NSPropertyListFormat.binaryFormat_v1_0
         let path = testBundle().pathForResource("Test", ofType: "plist")
         let data = NSData(contentsOfFile: path!)
         do {

--- a/TestFoundation/TestNSURLCredential.swift
+++ b/TestFoundation/TestNSURLCredential.swift
@@ -25,11 +25,11 @@ class TestNSURLCredential : XCTestCase {
     }
     
     func test_construction() {
-        let credential = NSURLCredential(user: "swiftUser", password: "swiftPassword", persistence: .ForSession)
+        let credential = NSURLCredential(user: "swiftUser", password: "swiftPassword", persistence: .forSession)
         XCTAssertNotNil(credential)
         XCTAssertEqual(credential.user, "swiftUser")
         XCTAssertEqual(credential.password, "swiftPassword")
-        XCTAssertEqual(credential.persistence, NSURLCredentialPersistence.ForSession)
+        XCTAssertEqual(credential.persistence, NSURLCredentialPersistence.forSession)
         XCTAssertEqual(credential.hasPassword, true)
     }
 }


### PR DESCRIPTION
Swift API design guidelines specify `lowerCamelCase` for everything except the names of types and protocols. The rationale is that cases are values and should follow the same convention as other values.

https://swift.org/documentation/api-design-guidelines/#general-conventions

The following files already have `lowerCamelCase` formatting for enumerations, this PR brings the rest into line
- `NSObjCRuntime.swift`
- `NSFileManager.swift`
- `NSTimeZone.swift`
- `NSURLReques.swift`
- `NSURLResponse.swift`