### PR TITLE
Guard clauses for NSRequiresConcreteImplementation

### DIFF
--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -39,19 +39,17 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
     internal var _storage = [AnyObject]()
     
     public var count: Int {
-        if self.dynamicType === NSArray.self || self.dynamicType === NSMutableArray.self {
-            return _storage.count
-        } else {
+        guard self.dynamicType === NSArray.self || self.dynamicType === NSMutableArray.self else {
             NSRequiresConcreteImplementation()
         }
+        return _storage.count
     }
     
     public func objectAtIndex(_ index: Int) -> AnyObject {
-        if self.dynamicType === NSArray.self || self.dynamicType === NSMutableArray.self {
-           return _storage[index]
-        } else {
-            NSRequiresConcreteImplementation()
+        guard self.dynamicType === NSArray.self || self.dynamicType === NSMutableArray.self else {
+           NSRequiresConcreteImplementation()
         }
+        return _storage[index]
     }
     
     public convenience override init() {
@@ -617,11 +615,10 @@ public class NSMutableArray : NSArray {
     }
     
     public func insertObject(_ anObject: AnyObject, atIndex index: Int) {
-        if self.dynamicType === NSMutableArray.self {
-            _storage.insert(anObject, at: index)
-        } else {
+        guard self.dynamicType === NSMutableArray.self else {
             NSRequiresConcreteImplementation()
         }
+        _storage.insert(anObject, at: index)
     }
     
     public func removeLastObject() {
@@ -631,21 +628,19 @@ public class NSMutableArray : NSArray {
     }
     
     public func removeObjectAtIndex(_ index: Int) {
-        if self.dynamicType === NSMutableArray.self {
-            _storage.remove(at: index)
-        } else {
+        guard self.dynamicType === NSMutableArray.self else {
             NSRequiresConcreteImplementation()
         }
+        _storage.remove(at: index)
     }
     
     public func replaceObjectAtIndex(_ index: Int, withObject anObject: AnyObject) {
-        if self.dynamicType === NSMutableArray.self {
-            let min = index
-            let max = index + 1
-            _storage.replaceSubrange(min..<max, with: [anObject])
-        } else {
+        guard self.dynamicType === NSMutableArray.self else {
             NSRequiresConcreteImplementation()
         }
+        let min = index
+        let max = index + 1
+        _storage.replaceSubrange(min..<max, with: [anObject])
     }
     
     public convenience init() {

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -87,27 +87,24 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
     internal var _storage = [NSObject: AnyObject]()
     
     public var count: Int {
-        if self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self {
-            return _storage.count
-        } else {
+        guard self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self else {
             NSRequiresConcreteImplementation()
         }
+        return _storage.count
     }
     
     public func objectForKey(_ aKey: AnyObject) -> AnyObject? {
-        if self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self {
-            return _storage[aKey as! NSObject]
-        } else {
+        guard self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self else {
             NSRequiresConcreteImplementation()
         }
+        return _storage[aKey as! NSObject]
     }
     
     public func keyEnumerator() -> NSEnumerator {
-        if self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self {
-            return NSGeneratorEnumerator(_storage.keys.makeIterator())
-        } else {
+        guard self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self else {
             NSRequiresConcreteImplementation()
         }
+        return NSGeneratorEnumerator(_storage.keys.makeIterator())
     }
     
     public override convenience init() {
@@ -567,24 +564,20 @@ extension Dictionary : _NSBridgable, _CFBridgable {
 public class NSMutableDictionary : NSDictionary {
     
     public func removeObjectForKey(_ aKey: AnyObject) {
-        if self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self {
-            if let key = aKey as? NSObject {
-                _storage.removeValue(forKey: key)
-            }
-            
-//            CFDictionaryRemoveValue(unsafeBitCast(self, CFMutableDictionaryRef.self), unsafeBitCast(aKey, UnsafePointer<Void>.self))
-        } else {
+        guard self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self else {
             NSRequiresConcreteImplementation()
+        }
+
+        if let key = aKey as? NSObject {
+            _storage.removeValue(forKey: key)
         }
     }
     
     public func setObject(_ anObject: AnyObject, forKey aKey: NSObject) {
-        if self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self {
-            _storage[aKey] = anObject
-//            CFDictionarySetValue(unsafeBitCast(self, CFMutableDictionaryRef.self), unsafeBitCast(aKey, UnsafePointer<Void>.self), unsafeBitCast(anObject, UnsafePointer<Void>.self))
-        } else {
+        guard self.dynamicType === NSDictionary.self || self.dynamicType === NSMutableDictionary.self else {
             NSRequiresConcreteImplementation()
         }
+        _storage[aKey] = anObject
     }
     
     public convenience required init() {

--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -217,19 +217,17 @@ extension NSOrderedSet {
     }
     
     public func objectEnumerator() -> NSEnumerator {
-        if self.dynamicType === NSOrderedSet.self || self.dynamicType === NSMutableOrderedSet.self {
-            return NSGeneratorEnumerator(_orderedStorage.makeIterator())
-        } else {
+        guard self.dynamicType === NSOrderedSet.self || self.dynamicType === NSMutableOrderedSet.self else {
             NSRequiresConcreteImplementation()
         }
+        return NSGeneratorEnumerator(_orderedStorage.makeIterator())
     }
 
     public func reverseObjectEnumerator() -> NSEnumerator { 
-        if self.dynamicType === NSOrderedSet.self || self.dynamicType === NSMutableOrderedSet.self {
-            return NSGeneratorEnumerator(_orderedStorage.reversed().makeIterator())
-        } else {
+        guard self.dynamicType === NSOrderedSet.self || self.dynamicType === NSMutableOrderedSet.self else {
             NSRequiresConcreteImplementation()
         }
+        return NSGeneratorEnumerator(_orderedStorage.reversed().makeIterator())
     }
     
     /*@NSCopying*/ 

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -75,30 +75,29 @@ public class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
     internal var _storage: Set<NSObject>
     
     public var count: Int {
-        if self.dynamicType === NSSet.self || self.dynamicType === NSMutableSet.self || self.dynamicType === NSCountedSet.self {
-            return _storage.count
-        } else {
-            NSRequiresConcreteImplementation()
+        guard self.dynamicType === NSSet.self || self.dynamicType === NSMutableSet.self || self.dynamicType === NSCountedSet.self else {
+                NSRequiresConcreteImplementation()
         }
+        return _storage.count
     }
     
     public func member(_ object: AnyObject) -> AnyObject? {
-        if self.dynamicType === NSSet.self || self.dynamicType === NSMutableSet.self || self.dynamicType === NSCountedSet.self {
-            if let obj = object as? NSObject where _storage.contains(obj) {
-                return obj // this is not exactly the same behavior, but it is reasonably close
-            }
-            return nil
-        } else {
+        guard self.dynamicType === NSSet.self || self.dynamicType === NSMutableSet.self || self.dynamicType === NSCountedSet.self else {
             NSRequiresConcreteImplementation()
         }
+        
+        guard let obj = object as? NSObject where _storage.contains(obj) else {
+            return nil
+        }
+        
+        return obj // this is not exactly the same behavior, but it is reasonably close
     }
     
     public func objectEnumerator() -> NSEnumerator {
-        if self.dynamicType === NSSet.self || self.dynamicType === NSMutableSet.self || self.dynamicType === NSCountedSet.self {
-            return NSGeneratorEnumerator(_storage.makeIterator())
-        } else {
+        guard self.dynamicType === NSSet.self || self.dynamicType === NSMutableSet.self || self.dynamicType === NSCountedSet.self else {
             NSRequiresConcreteImplementation()
         }
+        return NSGeneratorEnumerator(_storage.makeIterator())
     }
 
     public convenience override init() {
@@ -355,20 +354,19 @@ extension NSSet : Sequence {
 public class NSMutableSet : NSSet {
     
     public func addObject(_ object: AnyObject) {
-        if self.dynamicType === NSMutableSet.self {
-            _storage.insert(object as! NSObject)
-        } else {
+        guard self.dynamicType === NSMutableSet.self else {
             NSRequiresConcreteImplementation()
         }
+        _storage.insert(object as! NSObject)
     }
     
     public func removeObject(_ object: AnyObject) {
-        if self.dynamicType === NSMutableSet.self {
-            if let obj = object as? NSObject {
-                _storage.remove(obj)
-            }
-        } else {
+        guard self.dynamicType === NSMutableSet.self else {
             NSRequiresConcreteImplementation()
+        }
+
+        if let obj = object as? NSObject {
+            _storage.remove(obj)
         }
     }
     
@@ -497,42 +495,41 @@ public class NSCountedSet : NSMutableSet {
     }
 
     public func countForObject(_ object: AnyObject) -> Int {
-        if self.dynamicType === NSCountedSet.self {
-            guard let count = _table[object as! NSObject] else {
-                return 0
-            }
-            return count
-        } else {
+        guard self.dynamicType === NSCountedSet.self else {
             NSRequiresConcreteImplementation()
         }
+        guard let count = _table[object as! NSObject] else {
+            return 0
+        }
+        return count
     }
 
     public override func addObject(_ object: AnyObject) {
-        if self.dynamicType === NSCountedSet.self {
-            if let count = _table[object as! NSObject] {
-                _table[object as! NSObject] = count + 1
-            } else {
-                _table[object as! NSObject] = 1
-                _storage.insert(object as! NSObject)
-            }
-        } else {
+        guard self.dynamicType === NSCountedSet.self else {
             NSRequiresConcreteImplementation()
+        }
+
+        if let count = _table[object as! NSObject] {
+            _table[object as! NSObject] = count + 1
+        } else {
+            _table[object as! NSObject] = 1
+            _storage.insert(object as! NSObject)
         }
     }
 
     public override func removeObject(_ object: AnyObject) {
-        if self.dynamicType === NSCountedSet.self {
-            guard let count = _table[object as! NSObject] else {
-                return
-            }
-            if count > 1 {
-                _table[object as! NSObject] = count - 1
-            } else {
-                _table[object as! NSObject] = nil
-                _storage.remove(object as! NSObject)
-            }
-        } else {
+        guard self.dynamicType === NSCountedSet.self else {
             NSRequiresConcreteImplementation()
+        }
+        guard let count = _table[object as! NSObject] else {
+            return
+        }
+
+        if count > 1 {
+            _table[object as! NSObject] = count - 1
+        } else {
+            _table[object as! NSObject] = nil
+            _storage.remove(object as! NSObject)
         }
     }
 

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -210,20 +210,18 @@ public class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, N
     internal var _storage: String
     
     public var length: Int {
-        if self.dynamicType === NSString.self || self.dynamicType === NSMutableString.self {
-            return _storage.utf16.count
-        } else {
+        guard self.dynamicType === NSString.self || self.dynamicType === NSMutableString.self else {
             NSRequiresConcreteImplementation()
         }
+        return _storage.utf16.count
     }
     
     public func character(at index: Int) -> unichar {
-        if self.dynamicType === NSString.self || self.dynamicType === NSMutableString.self {
-            let start = _storage.utf16.startIndex
-            return _storage.utf16[start.advanced(by: index)]
-        } else {
+        guard self.dynamicType === NSString.self || self.dynamicType === NSMutableString.self else {
             NSRequiresConcreteImplementation()
         }
+        let start = _storage.utf16.startIndex
+        return _storage.utf16[start.advanced(by: index)]
     }
     
     public override convenience init() {
@@ -1291,15 +1289,15 @@ extension NSString : StringLiteralConvertible { }
 
 public class NSMutableString : NSString {
     public func replaceCharacters(in range: NSRange, with aString: String) {
-        if self.dynamicType === NSString.self || self.dynamicType === NSMutableString.self {
-            // this is incorrectly calculated for grapheme clusters that have a size greater than a single unichar
-            let start = _storage.startIndex
-            let min = _storage.index(start, offsetBy: range.location)
-            let max = _storage.index(start, offsetBy: range.location + range.length)
-            _storage.replaceSubrange(min..<max, with: aString)
-        } else {
+        guard self.dynamicType === NSString.self || self.dynamicType === NSMutableString.self else {
             NSRequiresConcreteImplementation()
         }
+
+        // this is incorrectly calculated for grapheme clusters that have a size greater than a single unichar
+        let start = _storage.startIndex
+        let min = _storage.index(start, offsetBy: range.location)
+        let max = _storage.index(start, offsetBy: range.location + range.length)
+        _storage.replaceSubrange(min..<max, with: aString)
     }
     
     public required override init(characters: UnsafePointer<unichar>, length: Int) {

--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -114,59 +114,52 @@ public class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     public var name: String {
-        if self.dynamicType === NSTimeZone.self {
-            return CFTimeZoneGetName(_cfObject)._swiftObject
-        } else {
+        guard self.dynamicType === NSTimeZone.self else {
             NSRequiresConcreteImplementation()
         }
+        return CFTimeZoneGetName(_cfObject)._swiftObject
     }
     
     public var data: NSData {
-        if self.dynamicType === NSTimeZone.self {
-            return CFTimeZoneGetData(_cfObject)._nsObject
-        } else {
+        guard self.dynamicType === NSTimeZone.self else {
             NSRequiresConcreteImplementation()
         }
+        return CFTimeZoneGetData(_cfObject)._nsObject
     }
     
     public func secondsFromGMT(for aDate: NSDate) -> Int {
-        if self.dynamicType === NSTimeZone.self {
-            return Int(CFTimeZoneGetSecondsFromGMT(_cfObject, aDate.timeIntervalSinceReferenceDate))
-        } else {
+        guard self.dynamicType === NSTimeZone.self else {
             NSRequiresConcreteImplementation()
         }
+        return Int(CFTimeZoneGetSecondsFromGMT(_cfObject, aDate.timeIntervalSinceReferenceDate))
     }
     
     public func abbreviation(for aDate: NSDate) -> String? {
-        if self.dynamicType === NSTimeZone.self {
-            return CFTimeZoneCopyAbbreviation(_cfObject, aDate.timeIntervalSinceReferenceDate)._swiftObject
-        } else {
+        guard self.dynamicType === NSTimeZone.self else {
             NSRequiresConcreteImplementation()
         }
+        return CFTimeZoneCopyAbbreviation(_cfObject, aDate.timeIntervalSinceReferenceDate)._swiftObject
     }
     
     public func isDaylightSavingTime(for aDate: NSDate) -> Bool {
-        if self.dynamicType === NSTimeZone.self {
-            return CFTimeZoneIsDaylightSavingTime(_cfObject, aDate.timeIntervalSinceReferenceDate)
-        } else {
+        guard self.dynamicType === NSTimeZone.self else {
             NSRequiresConcreteImplementation()
         }
+        return CFTimeZoneIsDaylightSavingTime(_cfObject, aDate.timeIntervalSinceReferenceDate)
     }
     
     public func daylightSavingTimeOffset(for aDate: NSDate) -> NSTimeInterval {
-        if self.dynamicType === NSTimeZone.self {
-            return CFTimeZoneGetDaylightSavingTimeOffset(_cfObject, aDate.timeIntervalSinceReferenceDate)
-        } else {
+        guard self.dynamicType === NSTimeZone.self else {
             NSRequiresConcreteImplementation()
         }
+        return CFTimeZoneGetDaylightSavingTimeOffset(_cfObject, aDate.timeIntervalSinceReferenceDate)
     }
     
     public func nextDaylightSavingTimeTransition(after aDate: NSDate) -> NSDate? {
-        if self.dynamicType === NSTimeZone.self {
-            return NSDate(timeIntervalSinceReferenceDate: CFTimeZoneGetNextDaylightSavingTimeTransition(_cfObject, aDate.timeIntervalSinceReferenceDate))
-        } else {
+        guard self.dynamicType === NSTimeZone.self else {
             NSRequiresConcreteImplementation()
         }
+        return NSDate(timeIntervalSinceReferenceDate: CFTimeZoneGetNextDaylightSavingTimeTransition(_cfObject, aDate.timeIntervalSinceReferenceDate))
     }
 }
 


### PR DESCRIPTION
Use `guard` statements to exit early with `NSRequiresConcreteImplementation()`. This approach is more succinct, and has the added safety of `guard` requiring a transfer of program control.