### PR TITLE
Porting to Cygwin

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -98,7 +98,10 @@ CF_EXTERN_C_BEGIN
 #include <CoreFoundation/CFRuntime.h>
 #include <limits.h>
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI || DEPLOYMENT_TARGET_LINUX || DEPLOYMENT_TARGET_FREEBSD
+#if TARGET_OS_CYGWIN
+#else
 #include <xlocale.h>
+#endif
 #include <unistd.h>
 #include <sys/time.h>
 #include <signal.h>

--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -156,6 +156,8 @@ const char *_CFProcessPath(void) {
 #endif
 
 #if DEPLOYMENT_TARGET_LINUX
+#if TARGET_OS_CYGWIN
+#else
 #include <unistd.h>
 #if __has_include(<syscall.h>)
 #include <syscall.h>
@@ -166,6 +168,7 @@ const char *_CFProcessPath(void) {
 Boolean _CFIsMainThread(void) {
     return syscall(SYS_gettid) == getpid();
 }
+#endif
 
 const char *_CFProcessPath(void) {
     if (__CFProcessPath) return __CFProcessPath;

--- a/CoreFoundation/Base.subproj/CFUtilities.c
+++ b/CoreFoundation/Base.subproj/CFUtilities.c
@@ -1302,7 +1302,7 @@ CFDictionaryRef __CFGetEnvironment() {
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED
         extern char ***_NSGetEnviron();
         char **envp = *_NSGetEnviron();
-#elif DEPLOYMENT_TARGET_FREEBSD
+#elif DEPLOYMENT_TARGET_FREEBSD || TARGET_OS_CYGWIN
         extern char **environ;
         char **envp = environ;
 #elif DEPLOYMENT_TARGET_LINUX

--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -182,7 +182,7 @@ typedef int		boolean_t;
 typedef unsigned long fd_mask;
 #endif
 
-#ifndef __ANDROID__
+#if !defined(__ANDROID__) && !TARGET_OS_CYGWIN
 CF_INLINE size_t
 strlcpy(char * dst, const char * src, size_t maxlen) {
     const size_t srclen = strlen(src);
@@ -210,7 +210,9 @@ strlcat(char * dst, const char * src, size_t maxlen) {
 }
 #endif
 
+#if !TARGET_OS_CYGWIN
 #define issetugid() 0
+#endif
     
 // Implemented in CFPlatform.c 
 bool OSAtomicCompareAndSwapPtr(void *oldp, void *newp, void *volatile *dst);
@@ -269,7 +271,14 @@ void OSMemoryBarrier();
 
 #endif
 
-#if DEPLOYMENT_TARGET_WINDOWS || DEPLOYMENT_TARGET_LINUX    
+#if TARGET_OS_CYGWIN
+#define HAVE_STRUCT_TIMESPEC 1
+#define strncasecmp_l(a, b, c, d) strncasecmp(a, b, c)
+#define _NO_BOOL_TYPEDEF
+#undef interface
+#endif
+
+#if DEPLOYMENT_TARGET_WINDOWS || DEPLOYMENT_TARGET_LINUX
 #if !defined(MIN)
 #define MIN(A,B)	((A) < (B) ? (A) : (B))
 #endif

--- a/CoreFoundation/Base.subproj/SwiftRuntime/TargetConditionals.h
+++ b/CoreFoundation/Base.subproj/SwiftRuntime/TargetConditionals.h
@@ -46,6 +46,7 @@
     
         TARGET_OS_WIN32           - Generated code will run under 32-bit Windows
         TARGET_OS_UNIX            - Generated code will run under some Unix (not OSX) 
+           TARGET_OS_CYGWIN           - Generated code will run under 64-bit Cygwin
         TARGET_OS_MAC             - Generated code will run under Mac OS X variant
            TARGET_OS_IPHONE          - Generated code for firmware, devices, or simulator 
               TARGET_OS_IOS             - Generated code will run under iOS 
@@ -76,21 +77,31 @@
 #define TARGET_OS_LINUX        0
 #define TARGET_OS_WINDOWS      0
 #define TARGET_OS_BSD          0
+#define TARGET_OS_CYGWIN       0
 #elif __linux__
 #define TARGET_OS_DARWIN       0
 #define TARGET_OS_LINUX        1
 #define TARGET_OS_WINDOWS      0
 #define TARGET_OS_BSD          0
+#define TARGET_OS_CYGWIN       0
+#elif __CYGWIN__
+#define TARGET_OS_DARWIN       0
+#define TARGET_OS_LINUX        1
+#define TARGET_OS_WINDOWS      0
+#define TARGET_OS_BSD          0
+#define TARGET_OS_CYGWIN       1
 #elif _WIN32 || _WIN64
 #define TARGET_OS_DARWIN       0
 #define TARGET_OS_LINUX        0
 #define TARGET_OS_WINDOWS      1
 #define TARGET_OS_BSD          0
+#define TARGET_OS_CYGWIN       0
 #elif __unix__
 #define TARGET_OS_DARWIN       0
 #define TARGET_OS_LINUX        0
 #define TARGET_OS_WINDOWS      0
 #define TARGET_OS_BSD          1
+#define TARGET_OS_CYGWIN       0
 #else
 #error unknown operating system
 #endif

--- a/CoreFoundation/PlugIn.subproj/CFBundle_Binary.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Binary.c
@@ -684,6 +684,12 @@ static void *_CFBundleDlfcnGetSymbolByNameWithSearch(CFBundleRef bundle, CFStrin
 
 #if !defined(BINARY_SUPPORT_DYLD)
 
+#if TARGET_OS_CYGWIN
+static CFStringRef _CFBundleDlfcnCopyLoadedImagePathForPointer(void *p) {
+// Cygwin does not support dladdr()
+    return NULL;
+}
+#else
 static CFStringRef _CFBundleDlfcnCopyLoadedImagePathForPointer(void *p) {
     CFStringRef result = NULL;
     Dl_info info;
@@ -693,6 +699,7 @@ static CFStringRef _CFBundleDlfcnCopyLoadedImagePathForPointer(void *p) {
 #endif /* LOG_BUNDLE_LOAD */
     return result;
 }
+#endif
 
 #endif /* !BINARY_SUPPORT_DYLD */
 #endif /* BINARY_SUPPORT_DLFCN */

--- a/CoreFoundation/PlugIn.subproj/CFBundle_InfoPlist.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_InfoPlist.c
@@ -24,11 +24,14 @@
 #include <CoreFoundation/CFURLAccess.h>
 
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_LINUX || DEPLOYMENT_TARGET_EMBEDDED_MINI || DEPLOYMENT_TARGET_FREEBSD
+#if TARGET_OS_CYGWIN
+#else
 #include <dirent.h>
 #if __has_include(<sys/sysctl.h>)
 #include <sys/sysctl.h>
 #endif
 #include <sys/mman.h>
+#endif
 #endif
 
 // The following strings are initialized 'later' (i.e., not at static initialization time) because static init time is too early for CFSTR to work, on platforms without constant CF strings
@@ -144,7 +147,11 @@ CF_EXPORT CFStringRef _CFGetPlatformName(void) {
 #elif DEPLOYMENT_TARGET_HPUX
     return _CFBundleHPUXPlatformName;
 #elif DEPLOYMENT_TARGET_LINUX
+#if TARGET_OS_CYGWIN
+    return _CFBundleCygwinPlatformName;
+#else
     return _CFBundleLinuxPlatformName;
+#endif
 #elif DEPLOYMENT_TARGET_FREEBSD
     return _CFBundleFreeBSDPlatformName;
 #else
@@ -160,7 +167,11 @@ CF_EXPORT CFStringRef _CFGetAlternatePlatformName(void) {
 #elif DEPLOYMENT_TARGET_WINDOWS
     return CFSTR("");
 #elif DEPLOYMENT_TARGET_LINUX
+#if TARGET_OS_CYGWIN
+    return CFSTR("Cygwin");
+#else
     return CFSTR("Linux");
+#endif
 #elif DEPLOYMENT_TARGET_FREEBSD
     return CFSTR("FreeBSD");
 #else

--- a/CoreFoundation/PlugIn.subproj/CFBundle_Internal.h
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Internal.h
@@ -346,6 +346,7 @@ extern void _CFPlugInRemoveFactory(CFPlugInRef plugIn, _CFPFactoryRef factory);
 #define _CFBundleSolarisPlatformName CFSTR("solaris")
 #define _CFBundleLinuxPlatformName CFSTR("linux")
 #define _CFBundleFreeBSDPlatformName CFSTR("freebsd")
+#define _CFBundleCygwinPlatformName CFSTR("cygwin")
 
 #define _CFBundleDefaultStringTableName CFSTR("Localizable")
 #define _CFBundleStringTableType CFSTR("strings")

--- a/CoreFoundation/PlugIn.subproj/CFBundle_Resources.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Resources.c
@@ -315,7 +315,11 @@ CF_EXPORT CFStringRef _CFBundleGetCurrentPlatform(void) {
 #elif DEPLOYMENT_TARGET_HPUX
     return CFSTR("HPUX");
 #elif DEPLOYMENT_TARGET_LINUX
+#if TARGET_OS_CYGWIN
+    return CFSTR("Cygwin");
+#else
     return CFSTR("Linux");
+#endif
 #elif DEPLOYMENT_TARGET_FREEBSD
     return CFSTR("FreeBSD");
 #else
@@ -333,7 +337,11 @@ CF_PRIVATE CFStringRef _CFBundleGetPlatformExecutablesSubdirectoryName(void) {
 #elif DEPLOYMENT_TARGET_HPUX
     return CFSTR("HPUX");
 #elif DEPLOYMENT_TARGET_LINUX
+#if TARGET_OS_CYGWIN
+    return CFSTR("Cygwin");
+#else
     return CFSTR("Linux");
+#endif
 #elif DEPLOYMENT_TARGET_FREEBSD
     return CFSTR("FreeBSD");
 #else
@@ -351,7 +359,11 @@ CF_PRIVATE CFStringRef _CFBundleGetAlternatePlatformExecutablesSubdirectoryName(
 #elif DEPLOYMENT_TARGET_HPUX
     return CFSTR("HP-UX");
 #elif DEPLOYMENT_TARGET_LINUX
+#if TARGET_OS_CYGWIN
+    return CFSTR("Cygwin");
+#else
     return CFSTR("Linux");
+#endif
 #elif DEPLOYMENT_TARGET_FREEBSD
     return CFSTR("FreeBSD");
 #else

--- a/CoreFoundation/RunLoop.subproj/CFSocket.c
+++ b/CoreFoundation/RunLoop.subproj/CFSocket.c
@@ -948,6 +948,9 @@
 #include <libc.h>
 #include <dlfcn.h>
 #endif
+#if TARGET_OS_CYGWIN
+#include <sys/socket.h>
+#endif
 #include <arpa/inet.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
@@ -2064,8 +2067,9 @@ manageSelectError()
 
 static void *__CFSocketManager(void * arg)
 {
-#if DEPLOYMENT_TARGET_LINUX || DEPLOYMENT_TARGET_FREEBSD
+#if (DEPLOYMENT_TARGET_LINUX && !TARGET_OS_CYGWIN) || DEPLOYMENT_TARGET_FREEBSD
     pthread_setname_np(pthread_self(), "com.apple.CFSocket.private");
+#elif TARGET_OS_CYGWIN
 #else
     pthread_setname_np("com.apple.CFSocket.private");
 #endif

--- a/Foundation/FoundationErrors.swift
+++ b/Foundation/FoundationErrors.swift
@@ -57,7 +57,7 @@ public var NSCoderValueNotFoundError: Int                    { return CocoaError
 
 #if os(OSX) || os(iOS)
     import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || CYGWIN
     import Glibc
 #endif
 

--- a/Foundation/NSAffineTransform.swift
+++ b/Foundation/NSAffineTransform.swift
@@ -9,7 +9,7 @@
 
 #if os(OSX) || os(iOS)
     import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || CYGWIN
     import Glibc
 #endif
 

--- a/Foundation/NSConcreteValue.swift
+++ b/Foundation/NSConcreteValue.swift
@@ -11,7 +11,7 @@ import CoreFoundation
 
 #if os(OSX) || os(iOS)
     import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || CYGWIN
     import Glibc
 #endif
 

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -11,7 +11,7 @@ import CoreFoundation
 
 #if os(OSX) || os(iOS)
 import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || CYGWIN
 import Glibc
 #endif
 
@@ -423,7 +423,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
             repeat {
                 #if os(OSX) || os(iOS)
                     bytesWritten = Darwin.write(fd, buf.advanced(by: length - bytesRemaining), bytesRemaining)
-                #elseif os(Linux) || os(Android)
+                #elseif os(Linux) || os(Android) || CYGWIN
                     bytesWritten = Glibc.write(fd, buf.advanced(by: length - bytesRemaining), bytesRemaining)
                 #endif
             } while (bytesWritten < 0 && errno == EINTR)

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -11,7 +11,7 @@ import CoreFoundation
 
 #if os(OSX) || os(iOS)
     import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || CYGWIN
     import Glibc
 #endif
 

--- a/Foundation/NSFileHandle.swift
+++ b/Foundation/NSFileHandle.swift
@@ -11,7 +11,7 @@ import CoreFoundation
 
 #if os(OSX) || os(iOS)
 import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || CYGWIN
 import Glibc
 #endif
 

--- a/Foundation/NSFileManager.swift
+++ b/Foundation/NSFileManager.swift
@@ -9,7 +9,7 @@
 
 #if os(OSX) || os(iOS)
     import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || CYGWIN
     import Glibc
 #endif
 
@@ -129,7 +129,7 @@ open class FileManager : NSObject {
                 }
                 #if os(OSX) || os(iOS)
                     let modeT = number.uint16Value
-                #elseif os(Linux) || os(Android)
+                #elseif os(Linux) || os(Android) || CYGWIN
                     let modeT = number.uint32Value
                 #endif
                 if chmod(path, mode_t(modeT)) != 0 {
@@ -252,7 +252,7 @@ open class FileManager : NSObject {
                 }
                 #if os(OSX) || os(iOS)
                     let tempEntryType = entryType
-                #elseif os(Linux) || os(Android)
+                #elseif os(Linux) || os(Android) || CYGWIN
                     let tempEntryType = Int32(entryType)
                 #endif
 

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -9,7 +9,7 @@
 
 #if os(OSX) || os(iOS)
     import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || CYGWIN
     import Glibc
 #endif
 

--- a/Foundation/NSHost.swift
+++ b/Foundation/NSHost.swift
@@ -10,7 +10,7 @@
 
 #if os(OSX) || os(iOS)
 import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || CYGWIN
 import Glibc
 #endif
 

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -11,7 +11,7 @@ import CoreFoundation
 
 #if os(OSX) || os(iOS)
     import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || CYGWIN
     import Glibc
 #endif
 

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -18,7 +18,7 @@ open class NSLocale: NSObject, NSCopying, NSSecureCoding {
     private var _prefs: UnsafeMutableRawPointer? = nil
 #if os(OSX) || os(iOS)
     private var _lock = pthread_mutex_t()
-#elseif os(Linux) || os(Android)
+#elseif os(Linux) || os(Android) || CYGWIN
     private var _lock = Int32(0)
 #endif
     private var _nullLocale = false

--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -11,7 +11,7 @@ import CoreFoundation
 
 #if os(OSX) || os(iOS)
 import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || CYGWIN
 import Glibc
 #endif
 

--- a/Foundation/NSProcessInfo.swift
+++ b/Foundation/NSProcessInfo.swift
@@ -10,7 +10,7 @@
 
 #if os(OSX) || os(iOS)
 import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || CYGWIN
 import Glibc
 #endif
 

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -14,7 +14,7 @@ import CoreFoundation
 // This mimics the behavior of the swift sdk overlay on Darwin
 #if os(OSX) || os(iOS)
 @_exported import Darwin
-#elseif os(Linux) || os(Android)
+#elseif os(Linux) || os(Android) || CYGWIN
 @_exported import Glibc
 #endif
 

--- a/Foundation/NSTask.swift
+++ b/Foundation/NSTask.swift
@@ -12,7 +12,7 @@ import CoreFoundation
 
 #if os(OSX) || os(iOS)
     import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || CYGWIN
     import Glibc
 #endif
 
@@ -261,10 +261,20 @@ open class Task: NSObject {
             task.processLaunchedCondition.unlock()
             
             var exitCode : Int32 = 0
+#if CYGWIN
+            let exitCodePtrWrapper = withUnsafeMutablePointer(to: &exitCode) {
+                exitCodePtr in
+                __wait_status_ptr_t(__int_ptr: exitCodePtr)
+            }
+#endif
             var waitResult : Int32 = 0
             
             repeat {
+#if CYGWIN
+                waitResult = waitpid( task.processIdentifier, exitCodePtrWrapper, 0)
+#else
                 waitResult = waitpid( task.processIdentifier, &exitCode, 0)
+#endif
             } while ( (waitResult == -1) && (errno == EINTR) )
             
             task.terminationStatus = WEXITSTATUS( exitCode )
@@ -299,7 +309,7 @@ open class Task: NSObject {
         CFRunLoopAddSource(managerThreadRunLoop?._cfRunLoop, source, kCFRunLoopDefaultMode)
 
         // file_actions
-        #if os(OSX) || os(iOS)
+        #if os(OSX) || os(iOS) || CYGWIN
             var fileActions: posix_spawn_file_actions_t? = nil
         #else
             var fileActions: posix_spawn_file_actions_t = posix_spawn_file_actions_t()

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -12,7 +12,7 @@ import CoreFoundation
 
 #if os(OSX) || os(iOS)
 import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || CYGWIN
 import Glibc
 #endif
 
@@ -496,7 +496,7 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     
     open var password: String? {
         let absoluteURL = CFURLCopyAbsoluteURL(_cfObject)
-#if os(Linux) || os(Android)
+#if os(Linux) || os(Android) || CYGWIN
         let passwordRange = CFURLGetByteRangeForComponent(absoluteURL, kCFURLComponentPassword, nil)
 #else
         let passwordRange = CFURLGetByteRangeForComponent(absoluteURL, .password, nil)

--- a/Foundation/NSUUID.swift
+++ b/Foundation/NSUUID.swift
@@ -12,7 +12,7 @@ import CoreFoundation
 
 #if os(OSX) || os(iOS)
     import Darwin.uuid
-#elseif os(Linux)
+#elseif os(Linux) || CYGWIN
     import Glibc
 #endif
 

--- a/Foundation/NSXMLParser.swift
+++ b/Foundation/NSXMLParser.swift
@@ -15,7 +15,7 @@
 
 #if os(OSX) || os(iOS)
     import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || CYGWIN
     import Glibc
 #endif
 import CoreFoundation

--- a/uuid/uuid.h
+++ b/uuid/uuid.h
@@ -41,6 +41,9 @@
 #include <sys/types.h>
 typedef	unsigned char __darwin_uuid_t[16];
 typedef	char __darwin_uuid_string_t[37];
+#ifdef uuid_t
+#undef uuid_t
+#endif
 typedef __darwin_uuid_t	uuid_t;
 #endif
 


### PR DESCRIPTION
This is the initial porting.

A simple function like below code is working in Cygwin.
```
import Foundation
let swifty = NSURLComponents(string: "https://swift.org")!
print("\(swifty.host!)")
```

Maybe there are many bugs in this port, but it is sufficient us to review and taste the Foundation in Cygwin.

The Swift compiler option "-DCYGWIN" will be added if companion PR #541 is merged.

The macro might be changed to some other macro function like os(Cygwin) later.
