### PR TITLE
Add implementation for NSURL copy()

### DIFF
--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -783,7 +783,7 @@ public class NSURLQueryItem : NSObject, NSSecureCoding, NSCopying {
     }
     
     public func copy(with zone: NSZone? = nil) -> AnyObject {
-        NSUnimplemented()
+        return self
     }
     
     public static func supportsSecureCoding() -> Bool {

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -60,7 +60,8 @@ class TestNSURL : XCTestCase {
             // TODO: these tests fail on linux, more investigation is needed
             ("test_fileURLWithPath", test_fileURLWithPath),
             ("test_fileURLWithPath_isDirectory", test_fileURLWithPath_isDirectory),
-            ("test_URLByResolvingSymlinksInPath", test_URLByResolvingSymlinksInPath)
+            ("test_URLByResolvingSymlinksInPath", test_URLByResolvingSymlinksInPath),
+            ("test_copy", test_copy)
         ]
     }
     
@@ -446,6 +447,16 @@ class TestNSURL : XCTestCase {
         } catch {
             XCTFail()
         }
+    }
+
+    func test_copy() {
+        let url = NSURL(string: "https://www.swift.org")
+        let urlCopy = url!.copy() as! NSURL
+        XCTAssertTrue(url!.isEqual(urlCopy))
+
+        let queryItem = NSURLQueryItem(name: "id", value: "23")
+        let queryItemCopy = queryItem.copy() as! NSURLQueryItem
+        XCTAssertTrue(queryItem.isEqual(queryItemCopy))
     }
 }
     


### PR DESCRIPTION
This PR has below implementations along with testcase

NSURL.copyWithZone()
NSURLQueryItem.copyWithZone()