### PR TITLE
Fix memory corruption with NSMutableData(length:)

### DIFF
--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -936,9 +936,7 @@ extension NSMutableData {
     }
     
     public convenience init?(length: Int) {
-        let memory = malloc(length)
-        self.init(bytes: memory, length: length, copy: false) { buffer, amount in
-            free(buffer)
-        }
+        self.init(bytes: nil, length: 0)
+        self.length = length
     }
 }

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -39,7 +39,8 @@ class TestNSData: XCTestCase {
             ("test_initializeWithBase64EncodedStringGetsDecodedData", test_initializeWithBase64EncodedStringGetsDecodedData),
             ("test_base64DecodeWithPadding1", test_base64DecodeWithPadding1),
             ("test_base64DecodeWithPadding2", test_base64DecodeWithPadding2),
-            ("test_rangeOfData",test_rangeOfData)
+            ("test_rangeOfData",test_rangeOfData),
+            ("test_initMutableDataWithLength", test_initMutableDataWithLength)
         ]
     }
     
@@ -336,6 +337,12 @@ class TestNSData: XCTestCase {
         XCTAssert(NSEqualRanges(base.range(of: empty, options: [.backwards], in: baseFullRange),notFoundRange))
         XCTAssert(NSEqualRanges(base.range(of: empty, options: [.backwards,.anchored], in: baseFullRange),notFoundRange))
         
+    }
+
+    func test_initMutableDataWithLength() {
+        let mData = NSMutableData(length: 30)
+        XCTAssertNotNil(mData)
+        XCTAssertEqual(mData!.length, 30)
     }
 
 }


### PR DESCRIPTION
NSMutableData(length:) allocates a memory of 'length' bytes and initialises NSMutableData with the same malloced bytes as buffer. And, capacity is 16 (default). And, any further appends to NSMutableData actually happens outside malloced region corrupting the memory next to it.

Fix is to avoid reusing malloced region as buffer. Instead, create new buffer with capacity and copy contents of malloced region into the buffer and free malloced region after copy.