### PR TITLE
change NSString(contentsOf:encoding:) to align with Darwin version

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -1257,7 +1257,7 @@ extension NSString {
         }
     }
 
-    public convenience init(contentsOfURL url: NSURL, encoding enc: UInt) throws {
+    public convenience init(contentsOf url: NSURL, encoding enc: UInt) throws {
         let readResult = try NSData.init(contentsOfURL: url, options: [])
         guard let cf = CFStringCreateWithBytes(kCFAllocatorDefault, UnsafePointer<UInt8>(readResult.bytes), readResult.length, CFStringConvertNSStringEncodingToEncoding(enc), true) else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileReadInapplicableStringEncodingError.rawValue, userInfo: [
@@ -1275,10 +1275,10 @@ extension NSString {
     }
 
     public convenience init(contentsOfFile path: String, encoding enc: UInt) throws {
-        try self.init(contentsOfURL: NSURL(fileURLWithPath: path), encoding: enc)
+        try self.init(contentsOf: NSURL(fileURLWithPath: path), encoding: enc)
     }
     
-    public convenience init(contentsOfURL url: NSURL, usedEncoding enc: UnsafeMutablePointer<UInt>?) throws {
+    public convenience init(contentsOf url: NSURL, usedEncoding enc: UnsafeMutablePointer<UInt>?) throws {
         NSUnimplemented()    
     }
     

--- a/Foundation/String.swift
+++ b/Foundation/String.swift
@@ -828,7 +828,7 @@ extension String {
         contentsOfURL url: NSURL,
         encoding enc: NSStringEncoding
         ) throws {
-        let ns = try NSString(contentsOfURL: url, encoding: enc)
+        let ns = try NSString(contentsOf: url, encoding: enc)
         self = ns._swiftObject
     }
     
@@ -844,7 +844,7 @@ extension String {
         contentsOfURL url: NSURL,
         usedEncoding enc: UnsafeMutablePointer<NSStringEncoding>? = nil
         ) throws {
-        let ns = try NSString(contentsOfURL: url, usedEncoding: enc)
+        let ns = try NSString(contentsOf: url, usedEncoding: enc)
         self = ns._swiftObject
     }
     

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -278,16 +278,16 @@ class TestNSString : XCTestCase {
         }
 
         do {
-            let string = try NSString(contentsOfURL: testFileURL, encoding: NSUTF8StringEncoding)
+            let string = try NSString(contentsOf: testFileURL, encoding: NSUTF8StringEncoding)
             XCTAssertEqual(string, "swift-corelibs-foundation")
         } catch {
-            XCTFail("Unable to init NSString from contentsOfURL:encoding:")
+            XCTFail("Unable to init NSString from contentsOf:encoding:")
         }
         do {
-            let string = try NSString(contentsOfURL: testFileURL, encoding: NSUTF16StringEncoding)
-            XCTAssertNotEqual(string, "swift-corelibs-foundation", "Wrong result when reading UTF-8 file with UTF-16 encoding in contentsOfURL:encoding")
+            let string = try NSString(contentsOf: testFileURL, encoding: NSUTF16StringEncoding)
+            XCTAssertNotEqual(string, "swift-corelibs-foundation", "Wrong result when reading UTF-8 file with UTF-16 encoding in contentsOf:encoding")
         } catch {
-            XCTFail("Unable to init NSString from contentsOfURL:encoding:")
+            XCTFail("Unable to init NSString from contentsOf:encoding:")
         }
     }
 


### PR DESCRIPTION
Major work in terms of api refactoring of NSString to align with Darwin version was done as part of https://github.com/apple/swift-corelibs-foundation/pull/332. However below API's got missed.

init(contentsOfURL url: NSURL, encoding enc: UInt)
init(contentsOfURL url: NSURL, usedEncoding enc: UnsafeMutablePointer<UInt>?)

This PR updates above api's to match Darwin version..