### PR TITLE
Changed the NSOrderedSet to use NSMutableArray and NSMutableSet internally

### DIFF
--- a/Foundation/NSPredicate.swift
+++ b/Foundation/NSPredicate.swift
@@ -127,7 +127,7 @@ extension NSMutableSet {
 
 extension NSOrderedSet {
     open func filtered(using predicate: NSPredicate) -> NSOrderedSet {
-        return NSOrderedSet(array: self.allObjects.filter({ object in
+        return NSOrderedSet(array: self.array.filter({ object in
             return predicate.evaluate(with: object)
         }))
     }


### PR DESCRIPTION
`NSOrderedSet` API contains lots of methods similar to the ones we have in `NSSet` & `NSArray`. I'd consider using these collections instead of the Swift ones in the `NSOrderedSet`/`NSMutabeOrderedSet` implementation.
