### PR TITLE
add missing implementation for NSLocale

### DIFF
--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -55,7 +55,7 @@ public class NSLocale : NSObject, NSCopying, NSSecureCoding {
         return copyWithZone(nil)
     }
     
-    public func copyWithZone(_ zone: NSZone) -> AnyObject { NSUnimplemented() }
+    public func copyWithZone(_ zone: NSZone) -> AnyObject { return self }
     
     public func encodeWithCoder(_ aCoder: NSCoder) {
         if aCoder.allowsKeyedCoding {

--- a/TestFoundation/TestNSLocale.swift
+++ b/TestFoundation/TestNSLocale.swift
@@ -19,6 +19,7 @@ class TestNSLocale : XCTestCase {
     static var allTests: [(String, (TestNSLocale) -> () throws -> Void)] {
         return [
             ("test_constants", test_constants),
+            ("test_copy", test_copy)
         ]
     }
     
@@ -85,4 +86,10 @@ class TestNSLocale : XCTestCase {
 
     }
 
+    func test_copy() {
+        let locale = NSLocale(localeIdentifier: "en_US")
+        let localeCopy = locale.copy()
+
+        XCTAssertTrue(locale === localeCopy)
+    }
 }


### PR DESCRIPTION
Only UnImplemented api is copy(). This PR added implementation for the same.