### PR TITLE
CoreFoundation: name tags for externally visible types

### DIFF
--- a/CoreFoundation/Base.subproj/CFBase.h
+++ b/CoreFoundation/Base.subproj/CFBase.h
@@ -475,9 +475,9 @@ static const CFIndex kCFNotFound = -1;
 
 
 /* Range type */
-typedef struct {
-    CFIndex location;
-    CFIndex length;
+typedef struct CFRange {
+  CFIndex location;
+  CFIndex length;
 } CFRange;
 
 #if defined(CF_INLINE)
@@ -561,16 +561,16 @@ typedef void *		(*CFAllocatorAllocateCallBack)(CFIndex allocSize, CFOptionFlags 
 typedef void *		(*CFAllocatorReallocateCallBack)(void *ptr, CFIndex newsize, CFOptionFlags hint, void *info);
 typedef void		(*CFAllocatorDeallocateCallBack)(void *ptr, void *info);
 typedef CFIndex		(*CFAllocatorPreferredSizeCallBack)(CFIndex size, CFOptionFlags hint, void *info);
-typedef struct {
-    CFIndex				version;
-    void *				info;
-    CFAllocatorRetainCallBack		retain;
-    CFAllocatorReleaseCallBack		release;        
-    CFAllocatorCopyDescriptionCallBack	copyDescription;
-    CFAllocatorAllocateCallBack		allocate;
-    CFAllocatorReallocateCallBack	reallocate;
-    CFAllocatorDeallocateCallBack	deallocate;
-    CFAllocatorPreferredSizeCallBack	preferredSize;
+typedef struct CFAllocatorContext {
+  CFIndex version;
+  void *info;
+  CFAllocatorRetainCallBack retain;
+  CFAllocatorReleaseCallBack release;
+  CFAllocatorCopyDescriptionCallBack copyDescription;
+  CFAllocatorAllocateCallBack allocate;
+  CFAllocatorReallocateCallBack reallocate;
+  CFAllocatorDeallocateCallBack deallocate;
+  CFAllocatorPreferredSizeCallBack preferredSize;
 } CFAllocatorContext;
 
 CF_EXPORT

--- a/CoreFoundation/Base.subproj/CFPriv.h
+++ b/CoreFoundation/Base.subproj/CFPriv.h
@@ -96,36 +96,37 @@ typedef CF_ENUM(CFIndex, CFURLComponentDecomposition) {
 	kCFURLComponentDecompositionRFC2396
 };
 
-typedef struct {
-	CFStringRef scheme;
-	CFStringRef schemeSpecific;
+typedef struct CFURLComponentsNonHierarchical {
+  CFStringRef scheme;
+  CFStringRef schemeSpecific;
 } CFURLComponentsNonHierarchical;
 
-typedef struct {
-	CFStringRef scheme;
-	CFStringRef user;
-	CFStringRef password;
-	CFStringRef host;
-	CFIndex port; /* kCFNotFound means ignore/omit */
-	CFArrayRef pathComponents;
-	CFStringRef parameterString;
-	CFStringRef query;
-	CFStringRef fragment;
-	CFURLRef baseURL;
+typedef struct CFURLComponentsRFC1808 {
+  CFStringRef scheme;
+  CFStringRef user;
+  CFStringRef password;
+  CFStringRef host;
+  CFIndex port; /* kCFNotFound means ignore/omit */
+  CFArrayRef pathComponents;
+  CFStringRef parameterString;
+  CFStringRef query;
+  CFStringRef fragment;
+  CFURLRef baseURL;
 } CFURLComponentsRFC1808;
 
-typedef struct {
-	CFStringRef scheme;
+typedef struct CFURLComponentsRFC2396 {
+  CFStringRef scheme;
 
-	/* if the registered name form of the net location is used, userinfo is NULL, port is kCFNotFound, and host is the entire registered name. */
-	CFStringRef userinfo;
-	CFStringRef host;
-	CFIndex port;
+  /* if the registered name form of the net location is used, userinfo is NULL,
+   * port is kCFNotFound, and host is the entire registered name. */
+  CFStringRef userinfo;
+  CFStringRef host;
+  CFIndex port;
 
-	CFArrayRef pathComponents;
-	CFStringRef query;
-	CFStringRef fragment;
-	CFURLRef baseURL;
+  CFArrayRef pathComponents;
+  CFStringRef query;
+  CFStringRef fragment;
+  CFURLRef baseURL;
 } CFURLComponentsRFC2396;
 
 /* Fills components and returns TRUE if the URL can be decomposed according to decompositionType; FALSE (leaving components unchanged) otherwise.  components should be a pointer to the CFURLComponents struct defined above that matches decompositionStyle */
@@ -366,10 +367,10 @@ CF_INLINE void CFStringGetCharactersFromInlineBuffer(CFStringInlineBuffer *buf, 
 #ifndef __kCFStringAppendBufferLength
     #define __kCFStringAppendBufferLength 1024
 #endif
-typedef struct {
-    UniChar buffer[__kCFStringAppendBufferLength];
-    CFIndex bufferIndex;
-    CFMutableStringRef theString;
+typedef struct CFStringAppendBuffer {
+  UniChar buffer[__kCFStringAppendBufferLength];
+  CFIndex bufferIndex;
+  CFMutableStringRef theString;
 } CFStringAppendBuffer;
 
 
@@ -450,12 +451,12 @@ CF_INLINE CFMutableStringRef CFStringCreateMutableWithAppendBuffer(CFStringAppen
  @field bitmap The bitmap data representing the membership of the Basic Multilingual Plane characters.
  If NULL, all BMP characters inside the range are members of the character set.
  */
-typedef struct {
-    CFCharacterSetRef cset;
-    uint32_t flags;
-    uint32_t rangeStart;
-    uint32_t rangeLimit;
-    const uint8_t *bitmap;
+typedef struct CFCharacterSetInlineBuffer {
+  CFCharacterSetRef cset;
+  uint32_t flags;
+  uint32_t rangeStart;
+  uint32_t rangeLimit;
+  const uint8_t *bitmap;
 } CFCharacterSetInlineBuffer;
 
 // Bits for flags field

--- a/CoreFoundation/Base.subproj/CFUUID.h
+++ b/CoreFoundation/Base.subproj/CFUUID.h
@@ -23,23 +23,23 @@ CF_EXTERN_C_BEGIN
 
 typedef const struct CF_BRIDGED_TYPE(id) __CFUUID * CFUUIDRef;
 
-typedef struct {
-    UInt8 byte0;
-    UInt8 byte1;
-    UInt8 byte2;
-    UInt8 byte3;
-    UInt8 byte4;
-    UInt8 byte5;
-    UInt8 byte6;
-    UInt8 byte7;
-    UInt8 byte8;
-    UInt8 byte9;
-    UInt8 byte10;
-    UInt8 byte11;
-    UInt8 byte12;
-    UInt8 byte13;
-    UInt8 byte14;
-    UInt8 byte15;
+typedef struct CFUUIDBytes {
+  UInt8 byte0;
+  UInt8 byte1;
+  UInt8 byte2;
+  UInt8 byte3;
+  UInt8 byte4;
+  UInt8 byte5;
+  UInt8 byte6;
+  UInt8 byte7;
+  UInt8 byte8;
+  UInt8 byte9;
+  UInt8 byte10;
+  UInt8 byte11;
+  UInt8 byte12;
+  UInt8 byte13;
+  UInt8 byte14;
+  UInt8 byte15;
 } CFUUIDBytes;
 /* The CFUUIDBytes struct is a 128-bit struct that contains the
 raw UUID.  A CFUUIDRef can provide such a struct from the

--- a/CoreFoundation/Base.subproj/ForFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForFoundationOnly.h
@@ -274,7 +274,7 @@ enum {
      __kCFVarWidthLocalBufferSize = 1008
 };
 
-typedef struct {      /* A simple struct to maintain ASCII/Unicode versions of the same buffer. */
+typedef struct CFVarWidthCharBuffer {      /* A simple struct to maintain ASCII/Unicode versions of the same buffer. */
      union {
         UInt8 *ascii;
 	UniChar *unicode;
@@ -395,19 +395,19 @@ enum {
     kCFBinaryPlistMarkerDict = 0xD0
 };
 
-typedef struct {
-    uint8_t	_magic[6];
-    uint8_t	_version[2];
+typedef struct CFBinaryPlistHeader {
+  uint8_t _magic[6];
+  uint8_t _version[2];
 } CFBinaryPlistHeader;
 
-typedef struct {
-    uint8_t	_unused[5];
-    uint8_t     _sortVersion;
-    uint8_t	_offsetIntSize;
-    uint8_t	_objectRefSize;
-    uint64_t	_numObjects;
-    uint64_t	_topObject;
-    uint64_t	_offsetTableOffset;
+typedef struct CFBinaryPlistTrailer {
+  uint8_t _unused[5];
+  uint8_t _sortVersion;
+  uint8_t _offsetIntSize;
+  uint8_t _objectRefSize;
+  uint64_t _numObjects;
+  uint64_t _topObject;
+  uint64_t _offsetTableOffset;
 } CFBinaryPlistTrailer;
 
 
@@ -566,7 +566,7 @@ CF_EXPORT CFTypeRef _CFRunLoopGet2(CFRunLoopRef rl);
 CF_EXPORT CFIndex _CFStreamInstanceSize(void);
 
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED
-    typedef struct {
+    typedef struct CFDiscorporateMemory {
         mach_vm_address_t address;
         mach_vm_size_t size;
         mach_vm_address_t map_address;

--- a/CoreFoundation/Collections.subproj/CFArray.h
+++ b/CoreFoundation/Collections.subproj/CFArray.h
@@ -85,12 +85,13 @@ typedef const void *	(*CFArrayRetainCallBack)(CFAllocatorRef allocator, const vo
 typedef void		(*CFArrayReleaseCallBack)(CFAllocatorRef allocator, const void *value);
 typedef CFStringRef	(*CFArrayCopyDescriptionCallBack)(const void *value);
 typedef Boolean		(*CFArrayEqualCallBack)(const void *value1, const void *value2);
-typedef struct {
-    CFIndex				version;
-    CFArrayRetainCallBack		retain;
-    CFArrayReleaseCallBack		release;
-    CFArrayCopyDescriptionCallBack	copyDescription;
-    CFArrayEqualCallBack		equal;
+
+typedef struct CFArrayCallBacks {
+  CFIndex version;
+  CFArrayRetainCallBack retain;
+  CFArrayReleaseCallBack release;
+  CFArrayCopyDescriptionCallBack copyDescription;
+  CFArrayEqualCallBack equal;
 } CFArrayCallBacks;
 
 /*!

--- a/CoreFoundation/Collections.subproj/CFBag.h
+++ b/CoreFoundation/Collections.subproj/CFBag.h
@@ -25,13 +25,14 @@ typedef void		(*CFBagReleaseCallBack)(CFAllocatorRef allocator, const void *valu
 typedef CFStringRef	(*CFBagCopyDescriptionCallBack)(const void *value);
 typedef Boolean		(*CFBagEqualCallBack)(const void *value1, const void *value2);
 typedef CFHashCode	(*CFBagHashCallBack)(const void *value);
-typedef struct {
-    CFIndex				version;
-    CFBagRetainCallBack			retain;
-    CFBagReleaseCallBack		release;
-    CFBagCopyDescriptionCallBack	copyDescription;
-    CFBagEqualCallBack			equal;
-    CFBagHashCallBack			hash;
+
+typedef struct CFBagCallBacks {
+  CFIndex version;
+  CFBagRetainCallBack retain;
+  CFBagReleaseCallBack release;
+  CFBagCopyDescriptionCallBack copyDescription;
+  CFBagEqualCallBack equal;
+  CFBagHashCallBack hash;
 } CFBagCallBacks;
 
 CF_EXPORT

--- a/CoreFoundation/Collections.subproj/CFBasicHash.h
+++ b/CoreFoundation/Collections.subproj/CFBasicHash.h
@@ -57,11 +57,11 @@ enum {
 // Note that for a hash table without keys, the value is treated as the key,
 // and the value should be passed in as the key for operations which take a key.
 
-typedef struct {
-    CFIndex idx;
-    uintptr_t weak_key;
-    uintptr_t weak_value;
-    uintptr_t count;
+typedef struct CFBasicHashBucket {
+  CFIndex idx;
+  uintptr_t weak_key;
+  uintptr_t weak_value;
+  uintptr_t count;
 } CFBasicHashBucket;
 
 typedef struct __CFBasicHash *CFBasicHashRef;

--- a/CoreFoundation/Collections.subproj/CFBinaryHeap.h
+++ b/CoreFoundation/Collections.subproj/CFBinaryHeap.h
@@ -26,12 +26,12 @@
 CF_IMPLICIT_BRIDGING_ENABLED
 CF_EXTERN_C_BEGIN
 
-typedef struct {
-    CFIndex	version;
-    void *	info;
-    const void *(*retain)(const void *info);
-    void	(*release)(const void *info);
-    CFStringRef	(*copyDescription)(const void *info);
+typedef struct CFBinaryHeapCompareContext {
+  CFIndex version;
+  void *info;
+  const void *(*retain)(const void *info);
+  void (*release)(const void *info);
+  CFStringRef (*copyDescription)(const void *info);
 } CFBinaryHeapCompareContext;
 
 /*!
@@ -57,12 +57,13 @@ typedef struct {
 	@field compare The callback used to compare values in the binary heap for
 		equality in some operations.
 */
-typedef struct {
-    CFIndex	version;
-    const void *(*retain)(CFAllocatorRef allocator, const void *ptr);
-    void	(*release)(CFAllocatorRef allocator, const void *ptr);
-    CFStringRef	(*copyDescription)(const void *ptr);
-    CFComparisonResult	(*compare)(const void *ptr1, const void *ptr2, void *context);
+typedef struct CFBinaryHeapCallBacks {
+  CFIndex version;
+  const void *(*retain)(CFAllocatorRef allocator, const void *ptr);
+  void (*release)(CFAllocatorRef allocator, const void *ptr);
+  CFStringRef (*copyDescription)(const void *ptr);
+  CFComparisonResult (*compare)(const void *ptr1, const void *ptr2,
+                                void *context);
 } CFBinaryHeapCallBacks;
 
 /*!

--- a/CoreFoundation/Collections.subproj/CFDictionary.h
+++ b/CoreFoundation/Collections.subproj/CFDictionary.h
@@ -104,13 +104,13 @@ typedef void		(*CFDictionaryReleaseCallBack)(CFAllocatorRef allocator, const voi
 typedef CFStringRef	(*CFDictionaryCopyDescriptionCallBack)(const void *value);
 typedef Boolean		(*CFDictionaryEqualCallBack)(const void *value1, const void *value2);
 typedef CFHashCode	(*CFDictionaryHashCallBack)(const void *value);
-typedef struct {
-    CFIndex				version;
-    CFDictionaryRetainCallBack		retain;
-    CFDictionaryReleaseCallBack		release;
-    CFDictionaryCopyDescriptionCallBack	copyDescription;
-    CFDictionaryEqualCallBack		equal;
-    CFDictionaryHashCallBack		hash;
+typedef struct CFDictionaryKeyCallBacks {
+  CFIndex version;
+  CFDictionaryRetainCallBack retain;
+  CFDictionaryReleaseCallBack release;
+  CFDictionaryCopyDescriptionCallBack copyDescription;
+  CFDictionaryEqualCallBack equal;
+  CFDictionaryHashCallBack hash;
 } CFDictionaryKeyCallBacks;
 
 /*!
@@ -156,12 +156,12 @@ const CFDictionaryKeyCallBacks kCFCopyStringDictionaryKeyCallBacks;
 	@field equal The callback used to compare values in the dictionary for
 		equality in some operations.
 */
-typedef struct {
-    CFIndex				version;
-    CFDictionaryRetainCallBack		retain;
-    CFDictionaryReleaseCallBack		release;
-    CFDictionaryCopyDescriptionCallBack	copyDescription;
-    CFDictionaryEqualCallBack		equal;
+typedef struct CFDictionaryValueCallBacks {
+  CFIndex version;
+  CFDictionaryRetainCallBack retain;
+  CFDictionaryReleaseCallBack release;
+  CFDictionaryCopyDescriptionCallBack copyDescription;
+  CFDictionaryEqualCallBack equal;
 } CFDictionaryValueCallBacks;
 
 /*!

--- a/CoreFoundation/Collections.subproj/CFSet.h
+++ b/CoreFoundation/Collections.subproj/CFSet.h
@@ -92,13 +92,13 @@ typedef CFHashCode	(*CFSetHashCallBack)(const void *value);
 	@field hash The callback used to compare values in the set for
 		uniqueness for some operations.
 */
-typedef struct {
-    CFIndex				version;
-    CFSetRetainCallBack			retain;
-    CFSetReleaseCallBack		release;
-    CFSetCopyDescriptionCallBack	copyDescription;
-    CFSetEqualCallBack			equal;
-    CFSetHashCallBack			hash;
+typedef struct CFSetCallBacks {
+  CFIndex version;
+  CFSetRetainCallBack retain;
+  CFSetReleaseCallBack release;
+  CFSetCopyDescriptionCallBack copyDescription;
+  CFSetEqualCallBack equal;
+  CFSetHashCallBack hash;
 } CFSetCallBacks;
 
 /*!

--- a/CoreFoundation/Collections.subproj/CFTree.h
+++ b/CoreFoundation/Collections.subproj/CFTree.h
@@ -71,12 +71,12 @@ typedef CFStringRef	(*CFTreeCopyDescriptionCallBack)(const void *info);
         @field copyDescription The callback used to provide a description of
                 the info field.
 */
-typedef struct {
-    CFIndex				version;
-    void *				info;
-    CFTreeRetainCallBack		retain;
-    CFTreeReleaseCallBack		release;	
-    CFTreeCopyDescriptionCallBack	copyDescription;
+typedef struct CFTreeContext {
+  CFIndex version;
+  void *info;
+  CFTreeRetainCallBack retain;
+  CFTreeReleaseCallBack release;
+  CFTreeCopyDescriptionCallBack copyDescription;
 } CFTreeContext;
 
 /*!

--- a/CoreFoundation/NumberDate.subproj/CFDate.h
+++ b/CoreFoundation/NumberDate.subproj/CFDate.h
@@ -60,22 +60,22 @@ typedef const struct CF_BRIDGED_TYPE(NSTimeZone) __CFTimeZone * CFTimeZoneRef;
 #define CF_CALENDAR_DEPRECATED(A, B, C, D, ...) CF_DEPRECATED(A, B, C, D, __VA_ARGS__)
 #endif
 
-typedef struct {
-    SInt32 year;
-    SInt8 month;
-    SInt8 day;
-    SInt8 hour;
-    SInt8 minute;
-    double second;
+typedef struct CFGregorianDate {
+  SInt32 year;
+  SInt8 month;
+  SInt8 day;
+  SInt8 hour;
+  SInt8 minute;
+  double second;
 } CFGregorianDate CF_CALENDAR_DEPRECATED(10_4, 10_10, 2_0, 8_0, "Use CFCalendar or NSCalendar API instead");
 
-typedef struct {
-    SInt32 years;
-    SInt32 months;
-    SInt32 days;
-    SInt32 hours;
-    SInt32 minutes;
-    double seconds;
+typedef struct CFGregorianUnits {
+  SInt32 years;
+  SInt32 months;
+  SInt32 days;
+  SInt32 hours;
+  SInt32 minutes;
+  double seconds;
 } CFGregorianUnits CF_CALENDAR_DEPRECATED(10_4, 10_10, 2_0, 8_0, "Use CFCalendar or NSCalendar API instead");
 
 typedef CF_OPTIONS(CFOptionFlags, CFGregorianUnitFlags) {

--- a/CoreFoundation/Parsing.subproj/CFXMLNode.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLNode.h
@@ -72,50 +72,50 @@ typedef CF_ENUM(CFIndex, CFXMLNodeTypeCode) {
     kCFXMLNodeTypeAttributeListDeclaration = 15
 };
 
-typedef struct {
-    CFDictionaryRef attributes;
-    CFArrayRef attributeOrder;
-    Boolean isEmpty;
-    char _reserved[3];
+typedef struct CFXMLElementInfo {
+  CFDictionaryRef attributes;
+  CFArrayRef attributeOrder;
+  Boolean isEmpty;
+  char _reserved[3];
 } CFXMLElementInfo;
 
-typedef struct {
-    CFStringRef dataString;
+typedef struct CFXMLProcessingInstructionInfo {
+  CFStringRef dataString;
 } CFXMLProcessingInstructionInfo;
 
-typedef struct {
-    CFURLRef sourceURL;
-    CFStringEncoding encoding;
+typedef struct CFXMLDocumentInfo {
+  CFURLRef sourceURL;
+  CFStringEncoding encoding;
 } CFXMLDocumentInfo;
 
-typedef struct {
-    CFURLRef systemID;
-    CFStringRef publicID;
+typedef struct CFXMLExternalID {
+  CFURLRef systemID;
+  CFStringRef publicID;
 } CFXMLExternalID;
 
-typedef struct {
-    CFXMLExternalID externalID;
+typedef struct CFXMLDocumentTypeInfo {
+  CFXMLExternalID externalID;
 } CFXMLDocumentTypeInfo;
 
-typedef struct {
-    CFXMLExternalID externalID;
+typedef struct CFXMLNotationInfo {
+  CFXMLExternalID externalID;
 } CFXMLNotationInfo;
 
-typedef struct {
-    /* This is expected to change in future versions */
-    CFStringRef contentDescription;
+typedef struct CFXMLElementTypeDeclarationInfo {
+  /* This is expected to change in future versions */
+  CFStringRef contentDescription;
 } CFXMLElementTypeDeclarationInfo;
 
-typedef struct {
-    /* This is expected to change in future versions */
-    CFStringRef attributeName;
-    CFStringRef typeString;
-    CFStringRef defaultString;
+typedef struct CFXMLAttributeDeclarationInfo {
+  /* This is expected to change in future versions */
+  CFStringRef attributeName;
+  CFStringRef typeString;
+  CFStringRef defaultString;
 } CFXMLAttributeDeclarationInfo;
 
-typedef struct {
-    CFIndex numberOfAttributes;
-    CFXMLAttributeDeclarationInfo *attributes;
+typedef struct CFXMLAttributeListDeclarationInfo {
+  CFIndex numberOfAttributes;
+  CFXMLAttributeDeclarationInfo *attributes;
 } CFXMLAttributeListDeclarationInfo;
 
 typedef CF_ENUM(CFIndex, CFXMLEntityTypeCode) {
@@ -126,15 +126,15 @@ typedef CF_ENUM(CFIndex, CFXMLEntityTypeCode) {
     kCFXMLEntityTypeCharacter
 };
 
-typedef struct {
-    CFXMLEntityTypeCode entityType;
-    CFStringRef replacementText;     /* NULL if entityType is external or unparsed */
-    CFXMLExternalID entityID;          /* entityID.systemID will be NULL if entityType is internal */
-    CFStringRef notationName;        /* NULL if entityType is parsed */
+typedef struct CFXMLEntityInfo {
+  CFXMLEntityTypeCode entityType;
+  CFStringRef replacementText; /* NULL if entityType is external or unparsed */
+  CFXMLExternalID entityID;    /* entityID.systemID will be NULL if entityType is internal */
+  CFStringRef notationName;    /* NULL if entityType is parsed */
 } CFXMLEntityInfo;
 
-typedef struct {
-    CFXMLEntityTypeCode entityType;
+typedef struct CFXMLEntityReferenceInfo {
+  CFXMLEntityTypeCode entityType;
 } CFXMLEntityReferenceInfo;
 
 /*

--- a/CoreFoundation/Parsing.subproj/CFXMLParser.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLParser.h
@@ -140,24 +140,24 @@ typedef void		(*CFXMLParserAddChildCallBack)(CFXMLParserRef parser, void *parent
 typedef void		(*CFXMLParserEndXMLStructureCallBack)(CFXMLParserRef parser, void *xmlType, void *info);
 typedef CFDataRef	(*CFXMLParserResolveExternalEntityCallBack)(CFXMLParserRef parser, CFXMLExternalID *extID, void *info);
 typedef Boolean		(*CFXMLParserHandleErrorCallBack)(CFXMLParserRef parser, CFXMLParserStatusCode error, void *info);
-typedef struct {
-    CFIndex                                  version;
-    CFXMLParserCreateXMLStructureCallBack    createXMLStructure;
-    CFXMLParserAddChildCallBack              addChild;
-    CFXMLParserEndXMLStructureCallBack       endXMLStructure;
-    CFXMLParserResolveExternalEntityCallBack resolveExternalEntity;
-    CFXMLParserHandleErrorCallBack           handleError;
+typedef struct CFXMLParserCallBacks {
+  CFIndex version;
+  CFXMLParserCreateXMLStructureCallBack createXMLStructure;
+  CFXMLParserAddChildCallBack addChild;
+  CFXMLParserEndXMLStructureCallBack endXMLStructure;
+  CFXMLParserResolveExternalEntityCallBack resolveExternalEntity;
+  CFXMLParserHandleErrorCallBack handleError;
 } CFXMLParserCallBacks;
 
 typedef const void *	(*CFXMLParserRetainCallBack)(const void *info);
 typedef void		(*CFXMLParserReleaseCallBack)(const void *info);
 typedef CFStringRef	(*CFXMLParserCopyDescriptionCallBack)(const void *info);
-typedef struct {
-    CFIndex				version;
-    void *				info;
-    CFXMLParserRetainCallBack		retain;
-    CFXMLParserReleaseCallBack		release;
-    CFXMLParserCopyDescriptionCallBack	copyDescription;
+typedef struct CFXMLParserContext {
+  CFIndex version;
+  void *info;
+  CFXMLParserRetainCallBack retain;
+  CFXMLParserReleaseCallBack release;
+  CFXMLParserCopyDescriptionCallBack copyDescription;
 } CFXMLParserContext;
 
 CF_EXPORT

--- a/CoreFoundation/RunLoop.subproj/CFMachPort.h
+++ b/CoreFoundation/RunLoop.subproj/CFMachPort.h
@@ -25,12 +25,12 @@ CF_EXTERN_C_BEGIN
 
 typedef struct CF_BRIDGED_MUTABLE_TYPE(NSMachPort) __CFMachPort * CFMachPortRef;
 
-typedef struct {
-    CFIndex	version;
-    void *	info;
-    const void *(*retain)(const void *info);
-    void	(*release)(const void *info);
-    CFStringRef	(*copyDescription)(const void *info);
+typedef struct CFMachPortContext {
+  CFIndex version;
+  void *info;
+  const void *(*retain)(const void *info);
+  void (*release)(const void *info);
+  CFStringRef (*copyDescription)(const void *info);
 } CFMachPortContext;
 
 typedef void (*CFMachPortCallBack)(CFMachPortRef port, void *msg, CFIndex size, void *info);

--- a/CoreFoundation/RunLoop.subproj/CFMessagePort.h
+++ b/CoreFoundation/RunLoop.subproj/CFMessagePort.h
@@ -36,12 +36,12 @@ CF_ENUM(SInt32) {
     kCFMessagePortBecameInvalidError = -5
 };
 
-typedef struct {
-    CFIndex	version;
-    void *	info;
-    const void *(*retain)(const void *info);
-    void	(*release)(const void *info);
-    CFStringRef	(*copyDescription)(const void *info);
+typedef struct CFMessagePortContext {
+  CFIndex version;
+  void *info;
+  const void *(*retain)(const void *info);
+  void (*release)(const void *info);
+  CFStringRef (*copyDescription)(const void *info);
 } CFMessagePortContext;
 
 typedef CFDataRef (*CFMessagePortCallBack)(CFMessagePortRef local, SInt32 msgid, CFDataRef data, void *info);

--- a/CoreFoundation/RunLoop.subproj/CFRunLoop.h
+++ b/CoreFoundation/RunLoop.subproj/CFRunLoop.h
@@ -91,33 +91,34 @@ CF_EXPORT Boolean CFRunLoopContainsTimer(CFRunLoopRef rl, CFRunLoopTimerRef time
 CF_EXPORT void CFRunLoopAddTimer(CFRunLoopRef rl, CFRunLoopTimerRef timer, CFStringRef mode);
 CF_EXPORT void CFRunLoopRemoveTimer(CFRunLoopRef rl, CFRunLoopTimerRef timer, CFStringRef mode);
 
-typedef struct {
-    CFIndex	version;
-    void *	info;
-    const void *(*retain)(const void *info);
-    void	(*release)(const void *info);
-    CFStringRef	(*copyDescription)(const void *info);
-    Boolean	(*equal)(const void *info1, const void *info2);
-    CFHashCode	(*hash)(const void *info);
-    void	(*schedule)(void *info, CFRunLoopRef rl, CFStringRef mode);
-    void	(*cancel)(void *info, CFRunLoopRef rl, CFStringRef mode);
-    void	(*perform)(void *info);
+typedef struct CFRunLoopSourceContext {
+  CFIndex version;
+  void *info;
+  const void *(*retain)(const void *info);
+  void (*release)(const void *info);
+  CFStringRef (*copyDescription)(const void *info);
+  Boolean (*equal)(const void *info1, const void *info2);
+  CFHashCode (*hash)(const void *info);
+  void (*schedule)(void *info, CFRunLoopRef rl, CFStringRef mode);
+  void (*cancel)(void *info, CFRunLoopRef rl, CFStringRef mode);
+  void (*perform)(void *info);
 } CFRunLoopSourceContext;
 
-typedef struct {
-    CFIndex	version;
-    void *	info;
-    const void *(*retain)(const void *info);
-    void	(*release)(const void *info);
-    CFStringRef	(*copyDescription)(const void *info);
-    Boolean	(*equal)(const void *info1, const void *info2);
-    CFHashCode	(*hash)(const void *info);
+typedef struct CFRunLoopSourceContext1 {
+  CFIndex version;
+  void *info;
+  const void *(*retain)(const void *info);
+  void (*release)(const void *info);
+  CFStringRef (*copyDescription)(const void *info);
+  Boolean (*equal)(const void *info1, const void *info2);
+  CFHashCode (*hash)(const void *info);
 #if (TARGET_OS_MAC && !(TARGET_OS_EMBEDDED || TARGET_OS_IPHONE)) || (TARGET_OS_EMBEDDED || TARGET_OS_IPHONE)
-    mach_port_t	(*getPort)(void *info);
-    void *	(*perform)(void *msg, CFIndex size, CFAllocatorRef allocator, void *info);
+  mach_port_t (*getPort)(void *info);
+  void *(*perform)(void *msg, CFIndex size, CFAllocatorRef allocator,
+                   void *info);
 #else
-    void *	(*getPort)(void *info);
-    void	(*perform)(void *info);
+  void *(*getPort)(void *info);
+  void (*perform)(void *info);
 #endif
 } CFRunLoopSourceContext1;
 
@@ -131,12 +132,12 @@ CF_EXPORT Boolean CFRunLoopSourceIsValid(CFRunLoopSourceRef source);
 CF_EXPORT void CFRunLoopSourceGetContext(CFRunLoopSourceRef source, CFRunLoopSourceContext *context);
 CF_EXPORT void CFRunLoopSourceSignal(CFRunLoopSourceRef source);
 
-typedef struct {
-    CFIndex	version;
-    void *	info;
-    const void *(*retain)(const void *info);
-    void	(*release)(const void *info);
-    CFStringRef	(*copyDescription)(const void *info);
+typedef struct CFRunLoopObserverContext {
+  CFIndex version;
+  void *info;
+  const void *(*retain)(const void *info);
+  void (*release)(const void *info);
+  CFStringRef (*copyDescription)(const void *info);
 } CFRunLoopObserverContext;
 
 typedef void (*CFRunLoopObserverCallBack)(CFRunLoopObserverRef observer, CFRunLoopActivity activity, void *info);
@@ -155,12 +156,12 @@ CF_EXPORT void CFRunLoopObserverInvalidate(CFRunLoopObserverRef observer);
 CF_EXPORT Boolean CFRunLoopObserverIsValid(CFRunLoopObserverRef observer);
 CF_EXPORT void CFRunLoopObserverGetContext(CFRunLoopObserverRef observer, CFRunLoopObserverContext *context);
 
-typedef struct {
-    CFIndex	version;
-    void *	info;
-    const void *(*retain)(const void *info);
-    void	(*release)(const void *info);
-    CFStringRef	(*copyDescription)(const void *info);
+typedef struct CFRunLoopTimerContext {
+  CFIndex version;
+  void *info;
+  const void *(*retain)(const void *info);
+  void (*release)(const void *info);
+  CFStringRef (*copyDescription)(const void *info);
 } CFRunLoopTimerContext;
 
 typedef void (*CFRunLoopTimerCallBack)(CFRunLoopTimerRef timer, void *info);

--- a/CoreFoundation/RunLoop.subproj/CFSocket.h
+++ b/CoreFoundation/RunLoop.subproj/CFSocket.h
@@ -107,11 +107,11 @@ typedef CF_ENUM(CFIndex, CFSocketError) {
     kCFSocketTimeout = -2L
 };
 
-typedef struct {
-    SInt32	protocolFamily;
-    SInt32	socketType;
-    SInt32	protocol;
-    CFDataRef	address;
+typedef struct CFSocketSignature {
+  SInt32 protocolFamily;
+  SInt32 socketType;
+  SInt32 protocol;
+  CFDataRef address;
 } CFSocketSignature;
 
 /* Values for CFSocketCallBackType */
@@ -137,12 +137,12 @@ CF_ENUM(CFOptionFlags) {
 typedef void (*CFSocketCallBack)(CFSocketRef s, CFSocketCallBackType type, CFDataRef address, const void *data, void *info);
 /* If the callback wishes to keep hold of address or data after the point that it returns, then it must copy them. */
 
-typedef struct {
-    CFIndex	version;
-    void *	info;
-    const void *(*retain)(const void *info);
-    void	(*release)(const void *info);
-    CFStringRef	(*copyDescription)(const void *info);
+typedef struct CFSocketContext {
+  CFIndex version;
+  void *info;
+  const void *(*retain)(const void *info);
+  void (*release)(const void *info);
+  CFStringRef (*copyDescription)(const void *info);
 } CFSocketContext;
 
 #if TARGET_OS_WIN32

--- a/CoreFoundation/Stream.subproj/CFStream.h
+++ b/CoreFoundation/Stream.subproj/CFStream.h
@@ -49,12 +49,12 @@ typedef CF_OPTIONS(CFOptionFlags, CFStreamEventType) {
     kCFStreamEventEndEncountered = 16
 };
 
-typedef struct {
-    CFIndex version;
-    void *info;
-    void *(*retain)(void *info);
-    void (*release)(void *info);
-    CFStringRef (*copyDescription)(void *info);
+typedef struct CFStreamClientContext {
+  CFIndex version;
+  void *info;
+  void *(*retain)(void *info);
+  void (*release)(void *info);
+  CFStringRef (*copyDescription)(void *info);
 } CFStreamClientContext;
 
 typedef struct CF_BRIDGED_MUTABLE_TYPE(NSInputStream) __CFReadStream * CFReadStreamRef;
@@ -285,10 +285,11 @@ typedef CF_ENUM(CFIndex, CFStreamErrorDomain) {
     kCFStreamErrorDomainMacOSStatus      /* OSStatus type from Carbon APIs; interpret using <MacTypes.h> */
 };
 
-typedef struct {
-    CFIndex domain; 
-    SInt32 error;
+typedef struct CFStreamError {
+  CFIndex domain;
+  SInt32 error;
 } CFStreamError;
+
 CF_EXPORT
 CFStreamError CFReadStreamGetError(CFReadStreamRef stream);
 CF_EXPORT

--- a/CoreFoundation/Stream.subproj/CFStreamAbstract.h
+++ b/CoreFoundation/Stream.subproj/CFStreamAbstract.h
@@ -34,48 +34,66 @@ CF_EXTERN_C_BEGIN
     In all cases, errors returned by reference will be initialized to NULL by the caller, and if they are set to non-NULL, will
     be released by the caller 
 */
-   
-typedef struct {
-    CFIndex version; /* == 2 */
 
-    void *(*create)(CFReadStreamRef stream, void *info);
-    void (*finalize)(CFReadStreamRef stream, void *info);
-    CFStringRef (*copyDescription)(CFReadStreamRef stream, void *info);
+typedef struct CFReadStreamCallBacks {
+  CFIndex version; /* == 2 */
 
-    Boolean (*open)(CFReadStreamRef stream, CFErrorRef *error, Boolean *openComplete, void *info);
-    Boolean (*openCompleted)(CFReadStreamRef stream, CFErrorRef *error, void *info);
-    CFIndex (*read)(CFReadStreamRef stream, UInt8 *buffer, CFIndex bufferLength, CFErrorRef *error, Boolean *atEOF, void *info);
-    const UInt8 *(*getBuffer)(CFReadStreamRef stream, CFIndex maxBytesToRead, CFIndex *numBytesRead, CFErrorRef *error, Boolean *atEOF, void *info);
-    Boolean (*canRead)(CFReadStreamRef stream, CFErrorRef *error, void *info);
-    void (*close)(CFReadStreamRef stream, void *info);
+  void *(*create)(CFReadStreamRef stream, void *info);
+  void (*finalize)(CFReadStreamRef stream, void *info);
+  CFStringRef (*copyDescription)(CFReadStreamRef stream, void *info);
 
-    CFTypeRef (*copyProperty)(CFReadStreamRef stream, CFStringRef propertyName, void *info);
-    Boolean (*setProperty)(CFReadStreamRef stream, CFStringRef propertyName, CFTypeRef propertyValue, void *info);
+  Boolean (*open)(CFReadStreamRef stream, CFErrorRef *error,
+                  Boolean *openComplete, void *info);
+  Boolean (*openCompleted)(CFReadStreamRef stream, CFErrorRef *error,
+                           void *info);
+  CFIndex (*read)(CFReadStreamRef stream, UInt8 *buffer, CFIndex bufferLength,
+                  CFErrorRef *error, Boolean *atEOF, void *info);
+  const UInt8 *(*getBuffer)(CFReadStreamRef stream, CFIndex maxBytesToRead,
+                            CFIndex *numBytesRead, CFErrorRef *error,
+                            Boolean *atEOF, void *info);
+  Boolean (*canRead)(CFReadStreamRef stream, CFErrorRef *error, void *info);
+  void (*close)(CFReadStreamRef stream, void *info);
 
-    void (*requestEvents)(CFReadStreamRef stream, CFOptionFlags streamEvents, void *info);
-    void (*schedule)(CFReadStreamRef stream, CFRunLoopRef runLoop, CFStringRef runLoopMode, void *info);
-    void (*unschedule)(CFReadStreamRef stream, CFRunLoopRef runLoop, CFStringRef runLoopMode, void *info);
+  CFTypeRef (*copyProperty)(CFReadStreamRef stream, CFStringRef propertyName,
+                            void *info);
+  Boolean (*setProperty)(CFReadStreamRef stream, CFStringRef propertyName,
+                         CFTypeRef propertyValue, void *info);
+
+  void (*requestEvents)(CFReadStreamRef stream, CFOptionFlags streamEvents,
+                        void *info);
+  void (*schedule)(CFReadStreamRef stream, CFRunLoopRef runLoop,
+                   CFStringRef runLoopMode, void *info);
+  void (*unschedule)(CFReadStreamRef stream, CFRunLoopRef runLoop,
+                     CFStringRef runLoopMode, void *info);
 } CFReadStreamCallBacks;
 
-typedef struct {
-    CFIndex version; /* == 2 */
+typedef struct CFWriteStreamCallBacks {
+  CFIndex version; /* == 2 */
 
-    void *(*create)(CFWriteStreamRef stream, void *info);
-    void (*finalize)(CFWriteStreamRef stream, void *info);
-    CFStringRef (*copyDescription)(CFWriteStreamRef stream, void *info);
+  void *(*create)(CFWriteStreamRef stream, void *info);
+  void (*finalize)(CFWriteStreamRef stream, void *info);
+  CFStringRef (*copyDescription)(CFWriteStreamRef stream, void *info);
 
-    Boolean (*open)(CFWriteStreamRef stream, CFErrorRef *error, Boolean *openComplete, void *info);
-    Boolean (*openCompleted)(CFWriteStreamRef stream, CFErrorRef *error, void *info);
-    CFIndex (*write)(CFWriteStreamRef stream, const UInt8 *buffer, CFIndex bufferLength, CFErrorRef *error, void *info);
-    Boolean (*canWrite)(CFWriteStreamRef stream, CFErrorRef *error, void *info); 
-    void (*close)(CFWriteStreamRef stream, void *info);
+  Boolean (*open)(CFWriteStreamRef stream, CFErrorRef *error,
+                  Boolean *openComplete, void *info);
+  Boolean (*openCompleted)(CFWriteStreamRef stream, CFErrorRef *error,
+                           void *info);
+  CFIndex (*write)(CFWriteStreamRef stream, const UInt8 *buffer,
+                   CFIndex bufferLength, CFErrorRef *error, void *info);
+  Boolean (*canWrite)(CFWriteStreamRef stream, CFErrorRef *error, void *info);
+  void (*close)(CFWriteStreamRef stream, void *info);
 
-    CFTypeRef (*copyProperty)(CFWriteStreamRef stream, CFStringRef propertyName, void *info);
-    Boolean (*setProperty)(CFWriteStreamRef stream, CFStringRef propertyName, CFTypeRef propertyValue, void *info);
+  CFTypeRef (*copyProperty)(CFWriteStreamRef stream, CFStringRef propertyName,
+                            void *info);
+  Boolean (*setProperty)(CFWriteStreamRef stream, CFStringRef propertyName,
+                         CFTypeRef propertyValue, void *info);
 
-    void (*requestEvents)(CFWriteStreamRef stream, CFOptionFlags streamEvents, void *info);
-    void (*schedule)(CFWriteStreamRef stream, CFRunLoopRef runLoop, CFStringRef runLoopMode, void *info);
-    void (*unschedule)(CFWriteStreamRef stream, CFRunLoopRef runLoop, CFStringRef runLoopMode, void *info);
+  void (*requestEvents)(CFWriteStreamRef stream, CFOptionFlags streamEvents,
+                        void *info);
+  void (*schedule)(CFWriteStreamRef stream, CFRunLoopRef runLoop,
+                   CFStringRef runLoopMode, void *info);
+  void (*unschedule)(CFWriteStreamRef stream, CFRunLoopRef runLoop,
+                     CFStringRef runLoopMode, void *info);
 } CFWriteStreamCallBacks;
 
 // Primitive creation mechanisms.
@@ -134,64 +152,96 @@ CF_EXPORT
 CFArrayRef _CFWriteStreamCopyRunLoopsAndModes(CFWriteStreamRef writeStream);
 
 /* Deprecated versions; here for backwards compatibility. */
-typedef struct {
-    CFIndex version; /* == 1 */
-    void *(*create)(CFReadStreamRef stream, void *info);
-    void (*finalize)(CFReadStreamRef stream, void *info);
-    CFStringRef (*copyDescription)(CFReadStreamRef stream, void *info);
-    Boolean (*open)(CFReadStreamRef stream, CFStreamError *error, Boolean *openComplete, void *info);
-    Boolean (*openCompleted)(CFReadStreamRef stream, CFStreamError *error, void *info);
-    CFIndex (*read)(CFReadStreamRef stream, UInt8 *buffer, CFIndex bufferLength, CFStreamError *error, Boolean *atEOF, void *info);
-    const UInt8 *(*getBuffer)(CFReadStreamRef stream, CFIndex maxBytesToRead, CFIndex *numBytesRead, CFStreamError *error, Boolean *atEOF, void *info);
-    Boolean (*canRead)(CFReadStreamRef stream, void *info);
-    void (*close)(CFReadStreamRef stream, void *info);
-    CFTypeRef (*copyProperty)(CFReadStreamRef stream, CFStringRef propertyName, void *info);
-    Boolean (*setProperty)(CFReadStreamRef stream, CFStringRef propertyName, CFTypeRef propertyValue, void *info);
-    void (*requestEvents)(CFReadStreamRef stream, CFOptionFlags streamEvents, void *info);
-    void (*schedule)(CFReadStreamRef stream, CFRunLoopRef runLoop, CFStringRef runLoopMode, void *info);
-    void (*unschedule)(CFReadStreamRef stream, CFRunLoopRef runLoop, CFStringRef runLoopMode, void *info);
+typedef struct CFReadStreamCallBacksV1 {
+  CFIndex version; /* == 1 */
+  void *(*create)(CFReadStreamRef stream, void *info);
+  void (*finalize)(CFReadStreamRef stream, void *info);
+  CFStringRef (*copyDescription)(CFReadStreamRef stream, void *info);
+  Boolean (*open)(CFReadStreamRef stream, CFStreamError *error,
+                  Boolean *openComplete, void *info);
+  Boolean (*openCompleted)(CFReadStreamRef stream, CFStreamError *error,
+                           void *info);
+  CFIndex (*read)(CFReadStreamRef stream, UInt8 *buffer, CFIndex bufferLength,
+                  CFStreamError *error, Boolean *atEOF, void *info);
+  const UInt8 *(*getBuffer)(CFReadStreamRef stream, CFIndex maxBytesToRead,
+                            CFIndex *numBytesRead, CFStreamError *error,
+                            Boolean *atEOF, void *info);
+  Boolean (*canRead)(CFReadStreamRef stream, void *info);
+  void (*close)(CFReadStreamRef stream, void *info);
+  CFTypeRef (*copyProperty)(CFReadStreamRef stream, CFStringRef propertyName,
+                            void *info);
+  Boolean (*setProperty)(CFReadStreamRef stream, CFStringRef propertyName,
+                         CFTypeRef propertyValue, void *info);
+  void (*requestEvents)(CFReadStreamRef stream, CFOptionFlags streamEvents,
+                        void *info);
+  void (*schedule)(CFReadStreamRef stream, CFRunLoopRef runLoop,
+                   CFStringRef runLoopMode, void *info);
+  void (*unschedule)(CFReadStreamRef stream, CFRunLoopRef runLoop,
+                     CFStringRef runLoopMode, void *info);
 } CFReadStreamCallBacksV1;
 
-typedef struct {
-    CFIndex version; /* == 1 */
-    void *(*create)(CFWriteStreamRef stream, void *info);
-    void (*finalize)(CFWriteStreamRef stream, void *info);
-    CFStringRef (*copyDescription)(CFWriteStreamRef stream, void *info);
-    Boolean (*open)(CFWriteStreamRef stream, CFStreamError *error, Boolean *openComplete, void *info);
-    Boolean (*openCompleted)(CFWriteStreamRef stream, CFStreamError *error, void *info);
-    CFIndex (*write)(CFWriteStreamRef stream, const UInt8 *buffer, CFIndex bufferLength, CFStreamError *error, void *info);
-    Boolean (*canWrite)(CFWriteStreamRef stream, void *info); 
-    void (*close)(CFWriteStreamRef stream, void *info);
-    CFTypeRef (*copyProperty)(CFWriteStreamRef stream, CFStringRef propertyName, void *info);
-    Boolean (*setProperty)(CFWriteStreamRef stream, CFStringRef propertyName, CFTypeRef propertyValue, void *info);
-    void (*requestEvents)(CFWriteStreamRef stream, CFOptionFlags streamEvents, void *info);
-    void (*schedule)(CFWriteStreamRef stream, CFRunLoopRef runLoop, CFStringRef runLoopMode, void *info);
-    void (*unschedule)(CFWriteStreamRef stream, CFRunLoopRef runLoop, CFStringRef runLoopMode, void *info);
+typedef struct CFWriteStreamCallBacksV1 {
+  CFIndex version; /* == 1 */
+  void *(*create)(CFWriteStreamRef stream, void *info);
+  void (*finalize)(CFWriteStreamRef stream, void *info);
+  CFStringRef (*copyDescription)(CFWriteStreamRef stream, void *info);
+  Boolean (*open)(CFWriteStreamRef stream, CFStreamError *error,
+                  Boolean *openComplete, void *info);
+  Boolean (*openCompleted)(CFWriteStreamRef stream, CFStreamError *error,
+                           void *info);
+  CFIndex (*write)(CFWriteStreamRef stream, const UInt8 *buffer,
+                   CFIndex bufferLength, CFStreamError *error, void *info);
+  Boolean (*canWrite)(CFWriteStreamRef stream, void *info);
+  void (*close)(CFWriteStreamRef stream, void *info);
+  CFTypeRef (*copyProperty)(CFWriteStreamRef stream, CFStringRef propertyName,
+                            void *info);
+  Boolean (*setProperty)(CFWriteStreamRef stream, CFStringRef propertyName,
+                         CFTypeRef propertyValue, void *info);
+  void (*requestEvents)(CFWriteStreamRef stream, CFOptionFlags streamEvents,
+                        void *info);
+  void (*schedule)(CFWriteStreamRef stream, CFRunLoopRef runLoop,
+                   CFStringRef runLoopMode, void *info);
+  void (*unschedule)(CFWriteStreamRef stream, CFRunLoopRef runLoop,
+                     CFStringRef runLoopMode, void *info);
 } CFWriteStreamCallBacksV1;
 
-typedef struct {
-    CFIndex version; /* == 0 */
-    Boolean (*open)(CFReadStreamRef stream, CFStreamError *error, Boolean *openComplete, void *info);
-    Boolean (*openCompleted)(CFReadStreamRef stream, CFStreamError *error, void *info);
-    CFIndex (*read)(CFReadStreamRef stream, UInt8 *buffer, CFIndex bufferLength, CFStreamError *error, Boolean *atEOF, void *info);
-    const UInt8 *(*getBuffer)(CFReadStreamRef stream, CFIndex maxBytesToRead, CFIndex *numBytesRead, CFStreamError *error, Boolean *atEOF, void *info);
-    Boolean (*canRead)(CFReadStreamRef stream, void *info);
-    void (*close)(CFReadStreamRef stream, void *info);
-    CFTypeRef (*copyProperty)(CFReadStreamRef stream, CFStringRef propertyName, void *info);
-    void (*schedule)(CFReadStreamRef stream, CFRunLoopRef runLoop, CFStringRef runLoopMode, void *info);
-    void (*unschedule)(CFReadStreamRef stream, CFRunLoopRef runLoop, CFStringRef runLoopMode, void *info);
+typedef struct CFReadStreamCallBacksV0 {
+  CFIndex version; /* == 0 */
+  Boolean (*open)(CFReadStreamRef stream, CFStreamError *error,
+                  Boolean *openComplete, void *info);
+  Boolean (*openCompleted)(CFReadStreamRef stream, CFStreamError *error,
+                           void *info);
+  CFIndex (*read)(CFReadStreamRef stream, UInt8 *buffer, CFIndex bufferLength,
+                  CFStreamError *error, Boolean *atEOF, void *info);
+  const UInt8 *(*getBuffer)(CFReadStreamRef stream, CFIndex maxBytesToRead,
+                            CFIndex *numBytesRead, CFStreamError *error,
+                            Boolean *atEOF, void *info);
+  Boolean (*canRead)(CFReadStreamRef stream, void *info);
+  void (*close)(CFReadStreamRef stream, void *info);
+  CFTypeRef (*copyProperty)(CFReadStreamRef stream, CFStringRef propertyName,
+                            void *info);
+  void (*schedule)(CFReadStreamRef stream, CFRunLoopRef runLoop,
+                   CFStringRef runLoopMode, void *info);
+  void (*unschedule)(CFReadStreamRef stream, CFRunLoopRef runLoop,
+                     CFStringRef runLoopMode, void *info);
 } CFReadStreamCallBacksV0;
 
-typedef struct {
-    CFIndex version; /* == 0 */
-    Boolean (*open)(CFWriteStreamRef stream, CFStreamError *error, Boolean *openComplete, void *info);
-    Boolean (*openCompleted)(CFWriteStreamRef stream, CFStreamError *error, void *info);
-    CFIndex (*write)(CFWriteStreamRef stream, const UInt8 *buffer, CFIndex bufferLength, CFStreamError *error, void *info);
-    Boolean (*canWrite)(CFWriteStreamRef stream, void *info); 
-    void (*close)(CFWriteStreamRef stream, void *info);
-    CFTypeRef (*copyProperty)(CFWriteStreamRef stream, CFStringRef propertyName, void *info);
-    void (*schedule)(CFWriteStreamRef stream, CFRunLoopRef runLoop, CFStringRef runLoopMode, void *info);
-    void (*unschedule)(CFWriteStreamRef stream, CFRunLoopRef runLoop, CFStringRef runLoopMode, void *info);
+typedef struct CFWriteStreamCallBacksV0 {
+  CFIndex version; /* == 0 */
+  Boolean (*open)(CFWriteStreamRef stream, CFStreamError *error,
+                  Boolean *openComplete, void *info);
+  Boolean (*openCompleted)(CFWriteStreamRef stream, CFStreamError *error,
+                           void *info);
+  CFIndex (*write)(CFWriteStreamRef stream, const UInt8 *buffer,
+                   CFIndex bufferLength, CFStreamError *error, void *info);
+  Boolean (*canWrite)(CFWriteStreamRef stream, void *info);
+  void (*close)(CFWriteStreamRef stream, void *info);
+  CFTypeRef (*copyProperty)(CFWriteStreamRef stream, CFStringRef propertyName,
+                            void *info);
+  void (*schedule)(CFWriteStreamRef stream, CFRunLoopRef runLoop,
+                   CFStringRef runLoopMode, void *info);
+  void (*unschedule)(CFWriteStreamRef stream, CFRunLoopRef runLoop,
+                     CFStringRef runLoopMode, void *info);
 } CFWriteStreamCallBacksV0;
 
 CF_EXTERN_C_END

--- a/CoreFoundation/String.subproj/CFString.h
+++ b/CoreFoundation/String.subproj/CFString.h
@@ -811,14 +811,17 @@ CFStringEncoding CFStringGetMostCompatibleMacStringEncoding(CFStringEncoding enc
    a location outside the original range is specified.
 */
 #define __kCFStringInlineBufferLength 64
-typedef struct {
-    UniChar buffer[__kCFStringInlineBufferLength];
-    CFStringRef theString;
-    const UniChar *directUniCharBuffer;
-    const char *directCStringBuffer;
-    CFRange rangeToBuffer;		/* Range in string to buffer */
-    CFIndex bufferedRangeStart;		/* Start of range currently buffered (relative to rangeToBuffer.location) */
-    CFIndex bufferedRangeEnd;		/* bufferedRangeStart + number of chars actually buffered */
+typedef struct CFStringInlineBuffer {
+  UniChar buffer[__kCFStringInlineBufferLength];
+  CFStringRef theString;
+  const UniChar *directUniCharBuffer;
+  const char *directCStringBuffer;
+  CFRange rangeToBuffer; /* Range in string to buffer */
+  CFIndex
+      bufferedRangeStart;   /* Start of range currently buffered (relative to
+                               rangeToBuffer.location) */
+  CFIndex bufferedRangeEnd; /* bufferedRangeStart + number of chars actually
+                               buffered */
 } CFStringInlineBuffer;
 
 #if defined(CF_INLINE)

--- a/CoreFoundation/StringEncodings.subproj/CFStringEncodingConverterExt.h
+++ b/CoreFoundation/StringEncodings.subproj/CFStringEncodingConverterExt.h
@@ -49,19 +49,19 @@ typedef CFIndex (*CFStringEncodingToUnicodeLenProc)(uint32_t flags, const uint8_
 typedef CFIndex (*CFStringEncodingToBytesPrecomposeProc)(uint32_t flags, const UniChar *character, CFIndex numChars, uint8_t *bytes, CFIndex maxByteLen, CFIndex *usedByteLen);
 typedef bool (*CFStringEncodingIsValidCombiningCharacterProc)(UniChar character);
 
-typedef struct {
-    void *toBytes;
-    void *toUnicode;
-    uint16_t maxBytesPerChar;
-    uint16_t maxDecomposedCharLen;
-    uint8_t encodingClass;
-    uint32_t :24;
-    CFStringEncodingToBytesLenProc toBytesLen;
-    CFStringEncodingToUnicodeLenProc toUnicodeLen;
-    CFStringEncodingToBytesFallbackProc toBytesFallback;
-    CFStringEncodingToUnicodeFallbackProc toUnicodeFallback;
-    CFStringEncodingToBytesPrecomposeProc toBytesPrecompose;
-    CFStringEncodingIsValidCombiningCharacterProc isValidCombiningChar;
+typedef struct CFStringEncodingConverter {
+  void *toBytes;
+  void *toUnicode;
+  uint16_t maxBytesPerChar;
+  uint16_t maxDecomposedCharLen;
+  uint8_t encodingClass;
+  uint32_t : 24;
+  CFStringEncodingToBytesLenProc toBytesLen;
+  CFStringEncodingToUnicodeLenProc toUnicodeLen;
+  CFStringEncodingToBytesFallbackProc toBytesFallback;
+  CFStringEncodingToUnicodeFallbackProc toUnicodeFallback;
+  CFStringEncodingToBytesPrecomposeProc toBytesPrecompose;
+  CFStringEncodingIsValidCombiningCharacterProc isValidCombiningChar;
 } CFStringEncodingConverter;
 
 extern const CFStringEncodingConverter *CFStringEncodingGetConverter(uint32_t encoding);


### PR DESCRIPTION
When building LLDB with modules, CF headers cause some problems due to the tags
being unnamed.  The anonymous tag gets internal linkage which is then changed by
the subsequent typedef.  Name all the tags, which allows these headers to be
used with modules.
