### PR TITLE
Base: always define HALT

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -164,14 +164,12 @@ CF_PRIVATE CFIndex __CFActiveProcessorCount();
 #endif
 #endif
 
-#if defined(__i386__) || defined(__x86_64__) || defined(__ppc__) || (__arm__) || (__aarch64__)
-    #if defined(__GNUC__)
-        #define HALT do {__builtin_trap(); kill(getpid(), 9); __builtin_unreachable(); } while (0)
-    #elif defined(_MSC_VER)
-        #define HALT do { __builtin_trap(); abort(); __builtin_unreachable(); } while (0)
-    #else
-        #error Compiler not supported
-    #endif
+#if defined(__GNUC__)
+    #define HALT do {__builtin_trap(); kill(getpid(), 9); __builtin_unreachable(); } while (0)
+#elif defined(_MSC_VER)
+    #define HALT do { __builtin_trap(); abort(); __builtin_unreachable(); } while (0)
+#else
+    #error Compiler not supported
 #endif
 
 #if defined(DEBUG)


### PR DESCRIPTION
HALT is used in various places without a check for the target.  There is nothing
which is architecture specific.  Remove the unnecessary architecture check.