### PR TITLE
Add new lines for each variable definition in build.ninja

### DIFF
--- a/lib/script.py
+++ b/lib/script.py
@@ -33,7 +33,7 @@ class Script:
         variables = ""
         for key, val in Configuration.current.variables.items():
             variables += key + "=" + val
-        variables += "\n"
+            variables += "\n"
         verbose_flags = """
 VERBOSE_FLAGS = """ 
         if Configuration.current.verbose:


### PR DESCRIPTION
`./configure -DFOO=BAR -DBAZ=QUX` used to emit `ninja.build` as
```
FOO=BARBAZ=QUX

VERBOSE_FLAGS =
...
```
This PR fix it to:
```
FOO=BAR
BAZ=QUX

VERBOSE_FLAGS =
...
```
