### PR TITLE
Support cross-compiling Foundation

### DIFF
--- a/build.py
+++ b/build.py
@@ -15,7 +15,7 @@ foundation.GCC_PREFIX_HEADER = 'CoreFoundation/Base.subproj/CoreFoundation_Prefi
 
 if Configuration.current.target.sdk == OSType.Linux:
 	foundation.CFLAGS = '-DDEPLOYMENT_TARGET_LINUX -D_GNU_SOURCE '
-	foundation.LDFLAGS = '${SWIFT_USE_LINKER} -Wl,@./CoreFoundation/linux.ld -lswiftGlibc `icu-config --ldflags` -Wl,-defsym,__CFConstantStringClassReference=_TMC10Foundation19_NSCFConstantString -Wl,-Bsymbolic '
+	foundation.LDFLAGS = '${SWIFT_USE_LINKER} -Wl,@./CoreFoundation/linux.ld -lswiftGlibc `pkg-config icu-uc icu-i18n --libs` -Wl,-defsym,__CFConstantStringClassReference=_TMC10Foundation19_NSCFConstantString -Wl,-Bsymbolic '
 elif Configuration.current.target.sdk == OSType.FreeBSD:
 	foundation.CFLAGS = '-DDEPLOYMENT_TARGET_FREEBSD -I/usr/local/include -I/usr/local/include/libxml2 '
 	foundation.LDFLAGS = ''
@@ -48,20 +48,20 @@ foundation.CFLAGS += " ".join([
 	'-Wno-unused-variable',
 	'-Wno-int-conversion',
 	'-Wno-unused-function',
-	'-I/usr/include/libxml2',
+	'-I${SYSROOT}/usr/include/libxml2',
 	'-I./',
 ])
 
 swift_cflags = [
 	'-I${BUILD_DIR}/Foundation/usr/lib/swift',
-	'-I/usr/include/libxml2'
+	'-I${SYSROOT}/usr/include/libxml2'
 ]
 
 if "XCTEST_BUILD_DIR" in Configuration.current.variables:
 	swift_cflags += [
 		'-I${XCTEST_BUILD_DIR}',
 		'-L${XCTEST_BUILD_DIR}',
-		'-I/usr/include/libxml2'
+		'-I${SYSROOT}/usr/include/libxml2'
 	]
 
 # Configure use of Dispatch in CoreFoundation and Foundation if libdispatch is being built

--- a/build.py
+++ b/build.py
@@ -15,7 +15,8 @@ foundation.GCC_PREFIX_HEADER = 'CoreFoundation/Base.subproj/CoreFoundation_Prefi
 
 if Configuration.current.target.sdk == OSType.Linux:
 	foundation.CFLAGS = '-DDEPLOYMENT_TARGET_LINUX -D_GNU_SOURCE '
-	foundation.LDFLAGS = '${SWIFT_USE_LINKER} -Wl,@./CoreFoundation/linux.ld -lswiftGlibc `pkg-config icu-uc icu-i18n --libs` -Wl,-defsym,__CFConstantStringClassReference=_TMC10Foundation19_NSCFConstantString -Wl,-Bsymbolic '
+	foundation.LDFLAGS = '${SWIFT_USE_LINKER} -Wl,@./CoreFoundation/linux.ld -lswiftGlibc `${PKG_CONFIG} icu-uc icu-i18n --libs` -Wl,-defsym,__CFConstantStringClassReference=_TMC10Foundation19_NSCFConstantString -Wl,-Bsymbolic '
+	Configuration.current.requires_pkg_config = True
 elif Configuration.current.target.sdk == OSType.FreeBSD:
 	foundation.CFLAGS = '-DDEPLOYMENT_TARGET_FREEBSD -I/usr/local/include -I/usr/local/include/libxml2 '
 	foundation.LDFLAGS = ''

--- a/configure
+++ b/configure
@@ -48,6 +48,7 @@ import sys
 def reconfigure(config, path):
     with open(path, 'r') as infile:
         info = json.load(infile)
+        config.requires_pkg_config = info['requires_pkg_config']
         if 'version' in info and info['version'] == config.version:
             if 'command' in info and info['command'] is not None:
                 config.command = info['command']
@@ -79,6 +80,8 @@ def reconfigure(config, path):
                 config.prefix = info['prefix']
             if 'swift_install' in info and info['swift_install'] is not None:
                 config.swift_install = info['swift_install']
+            if 'pkg_config' in info and info['pkg_config'] is not None:
+                config.pkg_config = info['pkg_config']
             if 'clang' in info and info['clang'] is not None:
                 config.clang = info['clang']
             if 'clangxx' in info and info['clangxx'] is not None:
@@ -136,6 +139,7 @@ def main():
     parser.add_argument('--sysroot', dest='sysroot', type=str, default=None)
     parser.add_argument('--toolchain', dest='toolchain', type=str, default=None)
     parser.add_argument('--linker', dest='linker', type=str, default=None)
+    parser.add_argument('--pkg-config', dest='pkg_config', type=str, default="pkg-config")
     parser.add_argument('--bootstrap', dest='bootstrap', type=str, default=os.path.join(os.path.dirname(os.path.abspath(__file__)), "bootstrap"))
     parser.add_argument('--reconfigure', dest='reconfigure', action="store_true")
     parser.add_argument('-v', '--verbose', dest='verbose', action="store_true")
@@ -173,6 +177,7 @@ def main():
         elif config.swift_sdk is None:
             config.swift_sdk = "/usr"
         config.toolchain = Path.path(args.toolchain)
+        config.pkg_config = args.pkg_config
         config.linker = args.linker
         config.bootstrap_directory = Path.path(args.bootstrap)
         config.verbose = args.verbose

--- a/configure
+++ b/configure
@@ -64,7 +64,9 @@ def reconfigure(config, path):
             if 'system_root' in info and info['system_root'] is not None:
                 config.system_root = Path(info['system_root'])
             if 'toolchain' in info and info['toolchain'] is not None:
-                config.toolchain = info['toolchain']
+                config.toolchain = Path(info['toolchain'])
+            if 'linker' in info and info['linker'] is not None:
+                config.linker = info['linker']
             if 'build_directory' in info and info['build_directory'] is not None:
                 config.build_directory = Path(info['build_directory'])
             if 'intermediate_directory' in info and info['intermediate_directory'] is not None:
@@ -133,6 +135,7 @@ def main():
     parser.add_argument('--target', dest='target', type=str, default=Target.default())
     parser.add_argument('--sysroot', dest='sysroot', type=str, default=None)
     parser.add_argument('--toolchain', dest='toolchain', type=str, default=None)
+    parser.add_argument('--linker', dest='linker', type=str, default=None)
     parser.add_argument('--bootstrap', dest='bootstrap', type=str, default=os.path.join(os.path.dirname(os.path.abspath(__file__)), "bootstrap"))
     parser.add_argument('--reconfigure', dest='reconfigure', action="store_true")
     parser.add_argument('-v', '--verbose', dest='verbose', action="store_true")
@@ -170,10 +173,14 @@ def main():
         elif config.swift_sdk is None:
             config.swift_sdk = "/usr"
         config.toolchain = Path.path(args.toolchain)
+        config.linker = args.linker
         config.bootstrap_directory = Path.path(args.bootstrap)
         config.verbose = args.verbose
         if config.toolchain is not None:
-            config.ar = os.path.join(config.toolchain.relative(), "bin", "ar")
+            ar_path = os.path.join(config.toolchain.relative(), "ar")
+            if not os.path.exists(ar_path):
+                ar_path = os.path.join(config.toolchain.relative(), "bin", "ar")
+            config.ar = ar_path
         elif config.ar is None:
             config.ar = "ar"
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -32,6 +32,8 @@ class Configuration:
     install_directory = None
     prefix = None
     swift_install = None
+    pkg_config = None
+    requires_pkg_config = False
     clang = None
     clangxx = None
     swift = None
@@ -73,6 +75,8 @@ class Configuration:
             'install_directory' : self._encode_path(self.install_directory),
             'prefix' : self.prefix,
             'swift_install' : self.swift_install,
+            'pkg_config' : self.pkg_config,
+            'requires_pkg_config' : self.requires_pkg_config,
             'clang' : self.clang,
             'clangxx' : self.clangxx,
             'swift' : self.swift,

--- a/lib/config.py
+++ b/lib/config.py
@@ -25,6 +25,7 @@ class Configuration:
     target = None
     system_root = None
     toolchain = None
+    linker = None
     build_directory = None
     intermediate_directory = None
     module_cache_directory = None
@@ -64,7 +65,8 @@ class Configuration:
             'source_root' : self._encode_path(self.source_root),
             'target' : self.target.triple,
             'system_root' : self._encode_path(self.system_root),
-            'toolchain' : self.toolchain,
+            'toolchain' : self._encode_path(self.toolchain),
+            'linker' : self.linker,
             'build_directory' : self._encode_path(self.build_directory),
             'intermediate_directory' : self._encode_path(self.intermediate_directory),
             'module_cache_directory' : self._encode_path(self.module_cache_directory),

--- a/lib/script.py
+++ b/lib/script.py
@@ -65,6 +65,10 @@ DYLIB_PREFIX          = """ + Configuration.current.target.dynamic_library_prefi
 DYLIB_SUFFIX          = """ + Configuration.current.target.dynamic_library_suffix + """
 PREFIX                = """ + Configuration.current.prefix + """
 """
+        if Configuration.current.requires_pkg_config:
+            base_flags += """
+PKG_CONFIG            = """ + Configuration.current.pkg_config + """
+"""
         if Configuration.current.system_root is not None:
             base_flags += """
 SYSROOT               = """ + Configuration.current.system_root.absolute() + """

--- a/lib/script.py
+++ b/lib/script.py
@@ -98,7 +98,7 @@ TARGET_CFLAGS         = -fcolor-diagnostics -fdollars-in-identifiers -fblocks -f
         
         c_flags += Configuration.current.extra_c_flags
 
-        swift_flags = "\nTARGET_SWIFTCFLAGS    = -I${SDKROOT}/lib/swift/" + Configuration.current.target.swift_sdk_name + " -Xcc -fblocks "
+        swift_flags = "\nTARGET_SWIFTCFLAGS    = -I${SDKROOT}/lib/swift/" + Configuration.current.target.swift_sdk_name + " -Xcc -fblocks -resource-dir ${SDKROOT}/lib/swift "
         if swift_triple is not None:
             swift_flags += "-target ${SWIFT_TARGET} "
         if Configuration.current.system_root is not None:
@@ -136,9 +136,15 @@ TARGET_LDFLAGS       = --target=${TARGET} ${EXTRA_LD_FLAGS} -L${SDKROOT}/lib/swi
         if Configuration.current.bootstrap_directory is not None:
             ld_flags += """ -L${TARGET_BOOTSTRAP_DIR}/usr/lib"""
 
+        if Configuration.current.linker is not None:
+            ld_flags += " -fuse-ld=" + Configuration.current.linker
+
         if Configuration.current.toolchain is not None:
-            c_flags += " -B" + Configuration.current.toolchain.path_by_appending("bin").relative()
-            ld_flags += " -B" + Configuration.current.toolchain.path_by_appending("bin").relative()
+            bin_dir = Configuration.current.toolchain
+            if not os.path.exists(bin_dir.path_by_appending("ld").relative()):
+                bin_dir = Configuration.current.toolchain.path_by_appending("bin")
+            c_flags += " -B" + bin_dir.relative()
+            ld_flags += " -B" + bin_dir.relative()
 
         c_flags += "\n"
         swift_flags += "\n"


### PR DESCRIPTION
Support for cross-compiling:
- Replace `icu-config` with `pkg-config`. Even ICU [recommends](http://userguide.icu-project.org/howtouseicu) to use pkg-config these days.
- Include sysroot in include directories
- Added `linker` flag, which gets passed through as the `-fuse-ld` option (so it accepts either a linker name or absolute path, as clang does)
- Added `resource-dir` flag to swift. Similarly to https://github.com/apple/swift/commit/f7353a73ceb2e23af1404155dc0db85adc40200b
- Check for presence of binaries in the toolchain folder before appending `bin`. Our toolchain might just be a folder full of binaries.