### PR TITLE
Fix building on linux (arm)

### DIFF
--- a/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
+++ b/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
@@ -34,7 +34,6 @@
 #include <setjmp.h>
 #include <signal.h>
 #include <stddef.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>


### PR DESCRIPTION
Without this, we're unable to build on Debian (armv7) because of a conflicting va_list definition.

The include doesn't seem to be required, and removing needless includes is usually a good idea anyway.

See: https://bugs.swift.org/browse/SR-1412