### PR TITLE
Fix the CFAssert macro when used with no format string parameters

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -176,7 +176,7 @@ CF_PRIVATE CFIndex __CFActiveProcessorCount();
     #define __CFAssert(cond, prio, desc, ...)                                  \
         do {                                                                   \
           if (!(cond)) {                                                       \
-            CFLog(prio, CFSTR(desc), __VA_ARGS__);                             \
+            CFLog(prio, CFSTR(desc), ##__VA_ARGS__);                             \
             HALT;                                                              \
           }                                                                    \
         } while (0)
@@ -187,7 +187,7 @@ CF_PRIVATE CFIndex __CFActiveProcessorCount();
 #endif
 
 #define CFAssert(condition, priority, description, ...)                        \
-  __CFAssert((condition), (priority), description, __VA_ARGS__)
+  __CFAssert((condition), (priority), description, ##__VA_ARGS__)
 
 #define __kCFLogAssertion	3
 


### PR DESCRIPTION
https://github.com/apple/swift-corelibs-foundation/pull/379 simplified the usage of the `CFAssert` macro, however it introduced a regression when Foundation is built in the `DEBUG` configuration such that `CFAssert` can no longer be used if no variable arguments are passed after the assertion description, because a trailing comma ends up being produced once the macro is expanded. This is causing build failures for the Corelibs XCTest CI on OS X.

Using `##__VA_ARGS__` (already being used elsewhere in this CoreFoundation) invokes compiler magic which removes the trailing comma in this situation.