### PR TITLE
Fix TestFoundation build order issue in Xcode 

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -347,6 +347,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		AE2FC5941CFEFC70008F7981 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5B5D885C1BBC938800234F36;
+			remoteInfo = SwiftFoundation;
+		};
 		EA993CE21BEACD8E000969A2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
@@ -1656,6 +1663,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				AE2FC5951CFEFC70008F7981 /* PBXTargetDependency */,
 			);
 			name = TestFoundation;
 			productName = TestFoundation;
@@ -2024,6 +2032,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		AE2FC5951CFEFC70008F7981 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5B5D885C1BBC938800234F36 /* SwiftFoundation */;
+			targetProxy = AE2FC5941CFEFC70008F7981 /* PBXContainerItemProxy */;
+		};
 		EA993CE31BEACD8E000969A2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 5B7C8A6D1BEA7F8F00C5B690 /* CoreFoundation */;

--- a/Foundation.xcodeproj/xcshareddata/xcschemes/TestFoundation.xcscheme
+++ b/Foundation.xcodeproj/xcshareddata/xcschemes/TestFoundation.xcscheme
@@ -11,23 +11,7 @@
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "YES"
-            hideIssues = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5B5D86DA1BBC74AD00234F36"
-               BuildableName = "SwiftXCTest.framework"
-               BlueprintName = "SwiftXCTest"
-               ReferencedContainer = "container:../swift-corelibs-xctest/XCTest.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES"
-            hideIssues = "NO">
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "5B5D885C1BBC938800234F36"
@@ -41,8 +25,21 @@
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "YES"
-            hideIssues = "NO">
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5B5D86DA1BBC74AD00234F36"
+               BuildableName = "SwiftXCTest.framework"
+               BlueprintName = "SwiftXCTest"
+               ReferencedContainer = "container:../swift-corelibs-xctest/XCTest.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "5BDC405B1BD6D83B00ED97BB"


### PR DESCRIPTION
Currently when building the `TestFoundation` scheme in Xcode with a clean build directory, the build fails because it attempts to build `SwiftXCTest` before `SwiftFoundation`. This fixes the build order in the scheme.