### PR TITLE
Add rpath of ORIGIN on Linux in order to pick up libdispatch

### DIFF
--- a/build.py
+++ b/build.py
@@ -64,6 +64,8 @@ if "XCTEST_BUILD_DIR" in Configuration.current.variables:
 		'-I/usr/include/libxml2'
 	]
 
+foundation.LDFLAGS += '-lpthread -ldl -lm -lswiftCore -lxml2 '
+
 # Configure use of Dispatch in CoreFoundation and Foundation if libdispatch is being built
 #if "LIBDISPATCH_SOURCE_DIR" in Configuration.current.variables:
 #	foundation.CFLAGS += " "+" ".join([
@@ -76,11 +78,9 @@ if "XCTEST_BUILD_DIR" in Configuration.current.variables:
 #		'-I'+Configuration.current.variables["LIBDISPATCH_SOURCE_DIR"],
 #		'-I'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src'
 #	])
-#	foundation.LDFLAGS += '-ldispatch -L'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src/.libs '
+#	foundation.LDFLAGS += '-ldispatch -L'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src/.libs -rpath \$$ORIGIN '
 
 foundation.SWIFTCFLAGS = " ".join(swift_cflags)
-
-foundation.LDFLAGS += '-lpthread -ldl -lm -lswiftCore -lxml2 '
 
 if "XCTEST_BUILD_DIR" in Configuration.current.variables:
 	foundation.LDFLAGS += '-L${XCTEST_BUILD_DIR}'


### PR DESCRIPTION
When Dispatch is added into the toolchain it adds the libdispatch library into the `/usr/lib/swift/linux` directory, which is where the other libraries such as libFoundation are located.

Applications built using `swiftc` have `/usr/lib/swift/linux` added to their library search path, so anything using Dispatch directly can find the library at runtime and runs correctly. The Foundation library however doesn't, so fails to find Dispatch at runtime if its not added to the LD_LIBRARY_PATH.

This PR adds a RPATH of ORIGIN to the Foundation library so that it can link to Dispatch at runtime without the need for the path to be explicitly set using LD_LIBRARY_PATH.