### PR TITLE
Implementation of the api 'resultByAdjustingRangesWithOffset' in NSTestCheckingResult

### DIFF
--- a/Foundation/NSTextCheckingResult.swift
+++ b/Foundation/NSTextCheckingResult.swift
@@ -78,5 +78,20 @@ extension NSTextCheckingResult {
     
     
     
-    public func resultByAdjustingRangesWithOffset(_ offset: Int) -> NSTextCheckingResult { NSUnimplemented() }
+    public func resultByAdjustingRangesWithOffset(_ offset: Int) -> NSTextCheckingResult {
+        let count = self.numberOfRanges
+        var newRanges = [NSRange]()
+        for idx in 0..<count {
+           let currentRange = self.range(at: idx)
+           if (currentRange.location == NSNotFound) {
+              newRanges.append(currentRange)
+           } else if ((offset > 0 && NSNotFound - currentRange.location <= offset) || (offset < 0 && currentRange.location < -offset)) {
+              NSInvalidArgument(" \(offset) invalid offset for range {\(currentRange.location), \(currentRange.length)}")
+           } else {
+              newRanges.append(NSRange(location: currentRange.location + offset,length: currentRange.length))
+           }
+        }
+        let result = NSTextCheckingResult.regularExpressionCheckingResultWithRanges(&newRanges, count: count, regularExpression: self.regularExpression!)
+        return result
+    }
 }

--- a/TestFoundation/TestNSTextCheckingResult.swift
+++ b/TestFoundation/TestNSTextCheckingResult.swift
@@ -1,0 +1,55 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+class TestNSTextCheckingResult: XCTestCase {
+    static var allTests: [(String, TestNSTextCheckingResult -> () throws -> Void)] {
+        return [
+           ("test_textCheckingResult", test_textCheckingResult),
+        ]
+    }
+    
+    func test_textCheckingResult() {
+       let patternString = "(a|b)x|123|(c|d)y"
+       do {
+           let patternOptions: NSRegularExpressionOptions = []
+           let regex = try NSRegularExpression(pattern: patternString, options: patternOptions)
+           let searchString = "1x030cy"
+           let searchOptions: NSMatchingOptions = []
+           let searchRange = NSMakeRange(0,7)
+           let match: NSTextCheckingResult =  regex.firstMatch(in: searchString, options: searchOptions, range: searchRange)!
+           //Positive offset
+           var result = match.resultByAdjustingRangesWithOffset(1)
+           XCTAssertEqual(result.range(at: 0).location, 6)
+           XCTAssertEqual(result.range(at: 1).location, NSNotFound)
+           XCTAssertEqual(result.range(at: 2).location, 6)
+           //Negative offset
+           result = match.resultByAdjustingRangesWithOffset(-2)
+           XCTAssertEqual(result.range(at: 0).location, 3)
+           XCTAssertEqual(result.range(at: 1).location, NSNotFound)
+           XCTAssertEqual(result.range(at: 2).location, 3)
+           //ZeroOffset
+           result = match.resultByAdjustingRangesWithOffset(0)
+           XCTAssertEqual(result.range(at: 0).location, 5)
+           XCTAssertEqual(result.range(at: 1).location, NSNotFound)
+           XCTAssertEqual(result.range(at: 2).location, 5)
+        } catch {
+            XCTFail("Unable to build regular expression for pattern \(patternString)")
+        }
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -60,6 +60,7 @@ XCTMain([
     testCase(TestNSString.allTests),
 //    testCase(TestNSThread.allTests),
     testCase(TestNSTask.allTests),
+    testCase(TestNSTextCheckingResult.allTests),
     testCase(TestNSTimer.allTests),
     testCase(TestNSTimeZone.allTests),
     testCase(TestNSURL.allTests),


### PR DESCRIPTION
Also added test case to TestFoundation. 
Sample output from the implementation:
If Range(5,2)
then: 
.resultByAdjustingRangesWithOffset(5) -> Range(10,2)
.resultByAdjustingRangesWithOffset(-3) -> Range(2,2)
.resultByAdjustingRangesWithOffset(0) -> Range(5,2)
.resultByAdjustingRangesWithOffset(-10) -> NSError
.resultByAdjustingRangesWithOffset(NSNotFound) -> NSError

If Range(NSNotFound,0)
.resultByAdjustingRangesWithOffset(5) -> Range(NSNotFound,0)
.resultByAdjustingRangesWithOffset(-3) -> Range(NSNotFound,0)
.resultByAdjustingRangesWithOffset(0) -> Range(NSNotFound,0)
