### PR TITLE
CoreFoundation: correct export attributes

### DIFF
--- a/CoreFoundation/Base.subproj/CFBase.c
+++ b/CoreFoundation/Base.subproj/CFBase.c
@@ -779,7 +779,7 @@ void CFAllocatorGetContext(CFAllocatorRef allocator, CFAllocatorContext *context
     context->preferredSize = __CFAllocatorGetPreferredSizeFunction(&allocator->_context);
 }
 
-CF_PRIVATE void *_CFAllocatorAllocateGC(CFAllocatorRef allocator, CFIndex size, CFOptionFlags hint)
+CF_EXPORT void *_CFAllocatorAllocateGC(CFAllocatorRef allocator, CFIndex size, CFOptionFlags hint)
 {
     if (CF_IS_COLLECTABLE_ALLOCATOR(allocator))
         return auto_zone_allocate_object((auto_zone_t*)kCFAllocatorSystemDefault->_context.info, size, CF_GET_GC_MEMORY_TYPE(hint), false, false);
@@ -787,7 +787,7 @@ CF_PRIVATE void *_CFAllocatorAllocateGC(CFAllocatorRef allocator, CFIndex size, 
         return CFAllocatorAllocate(allocator, size, hint);
 }
 
-CF_PRIVATE void *_CFAllocatorReallocateGC(CFAllocatorRef allocator, void *ptr, CFIndex newsize, CFOptionFlags hint)
+CF_EXPORT void *_CFAllocatorReallocateGC(CFAllocatorRef allocator, void *ptr, CFIndex newsize, CFOptionFlags hint)
 {
     if (CF_IS_COLLECTABLE_ALLOCATOR(allocator)) {
 	if (ptr && (newsize == 0)) {
@@ -801,7 +801,7 @@ CF_PRIVATE void *_CFAllocatorReallocateGC(CFAllocatorRef allocator, void *ptr, C
     return CFAllocatorReallocate(allocator, ptr, newsize, hint);
 }
 
-CF_PRIVATE void _CFAllocatorDeallocateGC(CFAllocatorRef allocator, void *ptr)
+CF_EXPORT void _CFAllocatorDeallocateGC(CFAllocatorRef allocator, void *ptr)
 {
     // when running GC, don't deallocate.
     if (!CF_IS_COLLECTABLE_ALLOCATOR(allocator)) CFAllocatorDeallocate(allocator, ptr);

--- a/CoreFoundation/Base.subproj/CFBase.h
+++ b/CoreFoundation/Base.subproj/CFBase.h
@@ -153,6 +153,16 @@
 #endif
 #endif
 
+#elif TARGET_OS_LINUX
+
+#if !defined(CF_EXPORT)
+#if defined(__cplusplus)
+#define CF_EXPORT extern "C" __attribute__ (( __visibility__("default") ))
+#else
+#endif
+#define CF_EXPORT extern __attribute__ (( __visibility__("default") ))
+#endif
+
 #else
 #define CF_EXPORT extern
 #endif

--- a/CoreFoundation/Base.subproj/CFFileUtilities.c
+++ b/CoreFoundation/Base.subproj/CFFileUtilities.c
@@ -61,7 +61,7 @@ CF_INLINE void closeAutoFSNoWait(int fd) {
     if (-1 != fd) close(fd);
 }
 
-CF_PRIVATE CFStringRef _CFCopyExtensionForAbstractType(CFStringRef abstractType) {
+CF_EXPORT CFStringRef _CFCopyExtensionForAbstractType(CFStringRef abstractType) {
     return (abstractType ? (CFStringRef)CFRetain(abstractType) : NULL);
 }
 
@@ -166,7 +166,7 @@ CF_PRIVATE Boolean _CFReadBytesFromFile(CFAllocatorRef alloc, CFURLRef url, void
     return _CFReadBytesFromPath(alloc, (const char *)path, bytes, length, maxLength, extraOpenFlags);
 }
 
-CF_PRIVATE Boolean _CFWriteBytesToFile(CFURLRef url, const void *bytes, CFIndex length) {
+CF_EXPORT Boolean _CFWriteBytesToFile(CFURLRef url, const void *bytes, CFIndex length) {
     int fd = -1;
     int mode;
     struct statinfo statBuf;
@@ -649,7 +649,7 @@ static Boolean _hasNet(CFStringRef path) {
     #define IS_SLASH(C)	((C) == '/')
 #endif
 
-CF_PRIVATE UniChar _CFGetSlash() {
+CF_EXPORT UniChar _CFGetSlash() {
     return CFPreferredSlash;
 }
 
@@ -657,7 +657,7 @@ CF_PRIVATE CFStringRef _CFGetSlashStr() {
     return CFPreferredSlashStr;
 }
 
-CF_PRIVATE Boolean _CFIsAbsolutePath(UniChar *unichars, CFIndex length) {
+CF_EXPORT Boolean _CFIsAbsolutePath(UniChar *unichars, CFIndex length) {
     if (length < 1) {
         return false;
     }
@@ -753,7 +753,7 @@ CF_PRIVATE void _CFAppendPathComponent2(CFMutableStringRef path, CFStringRef com
     CFStringAppend(path, component);
 }
 
-CF_PRIVATE Boolean _CFAppendPathComponent(UniChar *unichars, CFIndex *length, CFIndex maxLength, UniChar *component, CFIndex componentLength) {
+CF_EXPORT Boolean _CFAppendPathComponent(UniChar *unichars, CFIndex *length, CFIndex maxLength, UniChar *component, CFIndex componentLength) {
     if (0 == componentLength) {
         return true;
     }
@@ -820,7 +820,7 @@ CF_PRIVATE Boolean _CFAppendPathExtension2(CFMutableStringRef path, CFStringRef 
     return true;
 }
 
-CF_PRIVATE Boolean _CFAppendPathExtension(UniChar *unichars, CFIndex *length, CFIndex maxLength, UniChar *extension, CFIndex extensionLength) {
+CF_EXPORT Boolean _CFAppendPathExtension(UniChar *unichars, CFIndex *length, CFIndex maxLength, UniChar *extension, CFIndex extensionLength) {
     if (maxLength < *length + 1 + extensionLength) {
         return false;
     }
@@ -866,7 +866,7 @@ CF_PRIVATE Boolean _CFAppendPathExtension(UniChar *unichars, CFIndex *length, CF
     return true;
 }
 
-CF_PRIVATE Boolean _CFTransmutePathSlashes(UniChar *unichars, CFIndex *length, UniChar replSlash) {
+CF_EXPORT Boolean _CFTransmutePathSlashes(UniChar *unichars, CFIndex *length, UniChar replSlash) {
     CFIndex didx, sidx, scnt = *length;
     sidx = (1 < *length && HAS_NET(unichars)) ? 2 : 0;
     didx = sidx;
@@ -909,7 +909,7 @@ CF_PRIVATE CFStringRef _CFCreateLastPathComponent(CFAllocatorRef alloc, CFString
     return (CFStringRef)CFRetain(path);
 }
 
-CF_PRIVATE CFIndex _CFStartOfLastPathComponent(UniChar *unichars, CFIndex length) {
+CF_EXPORT CFIndex _CFStartOfLastPathComponent(UniChar *unichars, CFIndex length) {
     CFIndex idx;
     if (length < 2) {
         return 0;
@@ -941,7 +941,7 @@ CF_PRIVATE CFIndex _CFStartOfLastPathComponent2(CFStringRef path) {
     return 0;
 }
 
-CF_PRIVATE CFIndex _CFLengthAfterDeletingLastPathComponent(UniChar *unichars, CFIndex length) {
+CF_EXPORT CFIndex _CFLengthAfterDeletingLastPathComponent(UniChar *unichars, CFIndex length) {
     CFIndex idx;
     if (length < 2) {
         return 0;
@@ -981,7 +981,7 @@ CF_PRIVATE CFIndex _CFStartOfPathExtension2(CFStringRef path) {
     return 0;
 }
 
-CF_PRIVATE CFIndex _CFStartOfPathExtension(UniChar *unichars, CFIndex length) {
+CF_EXPORT CFIndex _CFStartOfPathExtension(UniChar *unichars, CFIndex length) {
     CFIndex idx;
     if (length < 2) {
         return 0;
@@ -1006,7 +1006,7 @@ CF_PRIVATE CFIndex _CFLengthAfterDeletingPathExtension2(CFStringRef path) {
     return ((0 < start) ? start : CFStringGetLength(path));
 }
 
-CF_PRIVATE CFIndex _CFLengthAfterDeletingPathExtension(UniChar *unichars, CFIndex length) {
+CF_EXPORT CFIndex _CFLengthAfterDeletingPathExtension(UniChar *unichars, CFIndex length) {
     CFIndex start = _CFStartOfPathExtension(unichars, length);
     return ((0 < start) ? start : length);
 }

--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -147,7 +147,7 @@ CF_EXPORT void _CFMachPortInstallNotifyPort(CFRunLoopRef rl, CFStringRef mode);
 #endif
 
 
-CF_PRIVATE CFIndex __CFActiveProcessorCount();
+CF_EXPORT CFIndex __CFActiveProcessorCount();
 
 #ifndef CLANG_ANALYZER_NORETURN
 #if __has_feature(attribute_analyzer_noreturn)
@@ -429,7 +429,7 @@ extern CFTypeRef CFMakeUncollectable(CFTypeRef cf);
 
 CF_PRIVATE void _CFRaiseMemoryException(CFStringRef reason);
 
-CF_EXPORT CF_PRIVATE Boolean __CFProphylacticAutofsAccess;
+CF_PRIVATE Boolean __CFProphylacticAutofsAccess;
 
 CF_EXPORT id __NSDictionary0__;
 CF_EXPORT id __NSArray0__;

--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -50,7 +50,7 @@ int _CFArgc(void) { return *_NSGetArgc(); }
 #endif
 
 
-CF_PRIVATE Boolean _CFGetCurrentDirectory(char *path, int maxlen) {
+CF_EXPORT Boolean _CFGetCurrentDirectory(char *path, int maxlen) {
     return getcwd(path, maxlen) != NULL;
 }
 
@@ -182,7 +182,7 @@ const char *_CFProcessPath(void) {
 }
 #endif
 
-CF_PRIVATE CFStringRef _CFProcessNameString(void) {
+CF_EXPORT CFStringRef _CFProcessNameString(void) {
     static CFStringRef __CFProcessNameString = NULL;
     if (!__CFProcessNameString) {
         const char *processName = *_CFGetProgname();
@@ -223,7 +223,7 @@ static CFURLRef _CFCopyHomeDirURLForUser(struct passwd *upwd, bool fallBackToHom
 #define CFMaxHostNameLength	256
 #define CFMaxHostNameSize	(CFMaxHostNameLength+1)
 
-CF_PRIVATE CFStringRef _CFStringCreateHostName(void) {
+CF_EXPORT CFStringRef _CFStringCreateHostName(void) {
     char myName[CFMaxHostNameSize];
 
     // return @"" instead of nil a la CFUserName() and Ali Ozer
@@ -1311,7 +1311,7 @@ int _CFOpenFile(const char *path, int opts) {
 #endif
 
 #if DEPLOYMENT_RUNTIME_SWIFT
-CF_PRIVATE char **_CFEnviron(void) {
+CF_EXPORT char **_CFEnviron(void) {
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED
     return *_NSGetEnviron();
 #elif DEPLOYMENT_TARGET_WINDOWS

--- a/CoreFoundation/Base.subproj/CFUtilities.c
+++ b/CoreFoundation/Base.subproj/CFUtilities.c
@@ -95,7 +95,7 @@
    }
    
 */
-CF_PRIVATE CFIndex CFBSearch(const void *element, CFIndex elementSize, const void *list, CFIndex count, CFComparatorFunction comparator, void *context) {
+CF_EXPORT CFIndex CFBSearch(const void *element, CFIndex elementSize, const void *list, CFIndex count, CFComparatorFunction comparator, void *context) {
     const char *ptr = (const char *)list;
     while (0 < count) {
         CFIndex half = count / 2;
@@ -390,7 +390,7 @@ CF_PRIVATE void *__CFLookupCFNetworkFunction(const char *name) {
 }
 #endif
 
-CF_PRIVATE CFIndex __CFActiveProcessorCount() {
+CF_EXPORT CFIndex __CFActiveProcessorCount() {
 #if CF_HAVE_HW_CONFIG_COMMPAGE
     static const uintptr_t p = _COMM_PAGE_ACTIVE_CPUS;
     return (CFIndex)(*(uint8_t*)p);
@@ -424,7 +424,7 @@ CF_PRIVATE CFIndex __CFActiveProcessorCount() {
 #endif
 }
 
-CF_PRIVATE CFIndex __CFProcessorCount() {
+CF_EXPORT CFIndex __CFProcessorCount() {
     int32_t pcnt;
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI
     int32_t mib[] = {CTL_HW, HW_NCPU};
@@ -442,7 +442,7 @@ CF_PRIVATE CFIndex __CFProcessorCount() {
     return pcnt;
 }
 
-CF_PRIVATE uint64_t __CFMemorySize() {
+CF_EXPORT uint64_t __CFMemorySize() {
     uint64_t memsize = 0;
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI
     int32_t mib[] = {CTL_HW, HW_NCPU};

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -43,8 +43,8 @@ typedef struct __CFSwiftObject *CFSwiftRef;
     } \
 } while (0)
 
-CF_PRIVATE CF_EXPORT bool _CFIsSwift(CFTypeID type, CFSwiftRef obj);
-CF_PRIVATE CF_EXPORT void _CFDeinit(CFTypeRef cf);
+CF_EXPORT bool _CFIsSwift(CFTypeID type, CFSwiftRef obj);
+CF_EXPORT void _CFDeinit(CFTypeRef cf);
 
 struct _NSObjectBridge {
     CFTypeID (*_cfTypeID)(CFTypeRef object);
@@ -225,32 +225,32 @@ struct _CFSwiftBridge {
     struct _NSMutableCharacterSetBridge NSMutableCharacterSet;
 };
 
-CF_PRIVATE CF_EXPORT struct _CFSwiftBridge __CFSwiftBridge;
+CF_EXPORT struct _CFSwiftBridge __CFSwiftBridge;
 
 CF_PRIVATE void *_Nullable _CFSwiftRetain(void *_Nullable t);
 CF_PRIVATE void _CFSwiftRelease(void *_Nullable t);
 
-CF_PRIVATE CF_EXPORT void _CFRuntimeBridgeTypeToClass(CFTypeID type, const void *isa);
+CF_EXPORT void _CFRuntimeBridgeTypeToClass(CFTypeID type, const void *isa);
 
 typedef	unsigned char __cf_uuid[16];
 typedef	char __cf_uuid_string[37];
 typedef __cf_uuid _cf_uuid_t;
 typedef __cf_uuid_string _cf_uuid_string_t;
 
-CF_PRIVATE CF_EXPORT void _cf_uuid_clear(_cf_uuid_t uu);
-CF_PRIVATE CF_EXPORT int _cf_uuid_compare(const _cf_uuid_t uu1, const _cf_uuid_t uu2);
-CF_PRIVATE CF_EXPORT void _cf_uuid_copy(_cf_uuid_t dst, const _cf_uuid_t src);
-CF_PRIVATE CF_EXPORT void _cf_uuid_generate(_cf_uuid_t out);
-CF_PRIVATE CF_EXPORT void _cf_uuid_generate_random(_cf_uuid_t out);
-CF_PRIVATE CF_EXPORT void _cf_uuid_generate_time(_cf_uuid_t out);
-CF_PRIVATE CF_EXPORT int _cf_uuid_is_null(const _cf_uuid_t uu);
-CF_PRIVATE CF_EXPORT int _cf_uuid_parse(const _cf_uuid_string_t in, _cf_uuid_t uu);
-CF_PRIVATE CF_EXPORT void _cf_uuid_unparse(const _cf_uuid_t uu, _cf_uuid_string_t out);
-CF_PRIVATE CF_EXPORT void _cf_uuid_unparse_lower(const _cf_uuid_t uu, _cf_uuid_string_t out);
-CF_PRIVATE CF_EXPORT void _cf_uuid_unparse_upper(const _cf_uuid_t uu, _cf_uuid_string_t out);
+CF_EXPORT void _cf_uuid_clear(_cf_uuid_t uu);
+CF_EXPORT int _cf_uuid_compare(const _cf_uuid_t uu1, const _cf_uuid_t uu2);
+CF_EXPORT void _cf_uuid_copy(_cf_uuid_t dst, const _cf_uuid_t src);
+CF_EXPORT void _cf_uuid_generate(_cf_uuid_t out);
+CF_EXPORT void _cf_uuid_generate_random(_cf_uuid_t out);
+CF_EXPORT void _cf_uuid_generate_time(_cf_uuid_t out);
+CF_EXPORT int _cf_uuid_is_null(const _cf_uuid_t uu);
+CF_EXPORT int _cf_uuid_parse(const _cf_uuid_string_t in, _cf_uuid_t uu);
+CF_EXPORT void _cf_uuid_unparse(const _cf_uuid_t uu, _cf_uuid_string_t out);
+CF_EXPORT void _cf_uuid_unparse_lower(const _cf_uuid_t uu, _cf_uuid_string_t out);
+CF_EXPORT void _cf_uuid_unparse_upper(const _cf_uuid_t uu, _cf_uuid_string_t out);
 
 
-CF_PRIVATE CF_EXPORT int32_t _CF_SOCK_STREAM();
+CF_EXPORT int32_t _CF_SOCK_STREAM();
 extern CFWriteStreamRef _CFWriteStreamCreateFromFileDescriptor(CFAllocatorRef alloc, int fd);
 #if !__COREFOUNDATION_FORFOUNDATIONONLY__
 typedef const struct __CFKeyedArchiverUID * CFKeyedArchiverUIDRef;
@@ -266,7 +266,7 @@ extern CFWriteStreamRef _CFWriteStreamCreateFromFileDescriptor(CFAllocatorRef al
 extern _Nullable CFDateRef CFCalendarCopyGregorianStartDate(CFCalendarRef calendar);
 extern void CFCalendarSetGregorianStartDate(CFCalendarRef calendar, CFDateRef date);
 
-CF_PRIVATE CF_EXPORT char *_Nullable *_Nonnull _CFEnviron(void);
+CF_EXPORT char *_Nullable *_Nonnull _CFEnviron(void);
 
 CF_EXPORT void CFLog1(CFLogLevel lev, CFStringRef message);
 

--- a/CoreFoundation/Collections.subproj/CFData.c
+++ b/CoreFoundation/Collections.subproj/CFData.c
@@ -516,7 +516,7 @@ CFMutableDataRef CFDataCreateMutableCopy(CFAllocatorRef allocator, CFIndex capac
     return r;
 }
 
-CFIndex CFDataGetLength(CFDataRef data) {
+CF_EXPORT CFIndex CFDataGetLength(CFDataRef data) {
     CF_OBJC_FUNCDISPATCHV(CFDataGetTypeID(), CFIndex, (NSData *)data, length);
     __CFGenericValidateType(data, CFDataGetTypeID());
     return __CFDataLength(data);

--- a/CoreFoundation/PlugIn.subproj/CFBundle.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle.c
@@ -2375,7 +2375,7 @@ CF_EXPORT CFURLRef CFBundleCopySharedSupportURL(CFBundleRef bundle) {
     return result;
 }
 
-CF_PRIVATE CFURLRef _CFBundleCopyBuiltInPlugInsURL(CFBundleRef bundle) {
+CF_EXPORT CFURLRef _CFBundleCopyBuiltInPlugInsURL(CFBundleRef bundle) {
     return CFBundleCopyBuiltInPlugInsURL(bundle);
 }
 

--- a/CoreFoundation/Preferences.subproj/CFApplicationPreferences.c
+++ b/CoreFoundation/Preferences.subproj/CFApplicationPreferences.c
@@ -423,7 +423,7 @@ void _CFApplicationPreferencesSetStandardSearchList(_CFApplicationPreferences *a
 #undef ADD_DOMAIN
 
 
-CF_PRIVATE _CFApplicationPreferences *_CFStandardApplicationPreferences(CFStringRef appName) {
+CF_EXPORT _CFApplicationPreferences *_CFStandardApplicationPreferences(CFStringRef appName) {
     _CFApplicationPreferences *appPreferences;
 //    CFAssert(appName != kCFPreferencesAnyApplication, __kCFLogAssertion, "Cannot use any of the CFPreferences...App... functions with an appName of kCFPreferencesAnyApplication");
     __CFLock(&__CFApplicationPreferencesLock);

--- a/CoreFoundation/Preferences.subproj/CFPreferences.c
+++ b/CoreFoundation/Preferences.subproj/CFPreferences.c
@@ -54,7 +54,7 @@ CONST_STRING_DECL(kCFPreferencesCurrentUser, "kCFPreferencesCurrentUser")
 
 
 static CFAllocatorRef _preferencesAllocator = NULL;
-CF_PRIVATE CFAllocatorRef __CFPreferencesAllocator(void) {
+CF_EXPORT CFAllocatorRef __CFPreferencesAllocator(void) {
     if (!_preferencesAllocator) {
 #if DEBUG_PREFERENCES_MEMORY
         _preferencesAllocator = CFCountingAllocatorCreate(NULL);
@@ -557,7 +557,7 @@ static void __CFPreferencesPerformSynchronize(const void *key, const void *value
     if (!_CFPreferencesDomainSynchronize(domain)) *cumulativeResult = false;
 }
 
-CF_PRIVATE Boolean _CFSynchronizeDomainCache(void) {
+CF_EXPORT Boolean _CFSynchronizeDomainCache(void) {
     Boolean result = true;
     __CFLock(&domainCacheLock);
     if (domainCache) {
@@ -577,7 +577,7 @@ CF_PRIVATE void _CFPreferencesPurgeDomainCache(void) {
     __CFUnlock(&domainCacheLock);
 }
 
-CF_PRIVATE CFArrayRef  _CFPreferencesCreateDomainList(CFStringRef  userName, CFStringRef  hostName) {
+CF_EXPORT CFArrayRef  _CFPreferencesCreateDomainList(CFStringRef  userName, CFStringRef  hostName) {
     CFAllocatorRef prefAlloc = __CFPreferencesAllocator();
     CFArrayRef  domains;
     CFMutableArrayRef  marray;
@@ -703,11 +703,11 @@ void _CFPreferencesDomainSet(CFPreferencesDomainRef domain, CFStringRef  key, CF
     domain->_callBacks->writeValue(domain->_context, domain->_domain, key, value);
 }
 
-CF_PRIVATE Boolean _CFPreferencesDomainSynchronize(CFPreferencesDomainRef domain) {
+CF_EXPORT Boolean _CFPreferencesDomainSynchronize(CFPreferencesDomainRef domain) {
     return domain->_callBacks->synchronize(domain->_context, domain->_domain);
 }
 
-CF_PRIVATE void _CFPreferencesDomainSetIsWorldReadable(CFPreferencesDomainRef domain, Boolean isWorldReadable) {
+CF_EXPORT void _CFPreferencesDomainSetIsWorldReadable(CFPreferencesDomainRef domain, Boolean isWorldReadable) {
     if (domain->_callBacks->setIsWorldReadable) {
         domain->_callBacks->setIsWorldReadable(domain->_context, domain->_domain, isWorldReadable);
     }

--- a/CoreFoundation/Stream.subproj/CFStream.c
+++ b/CoreFoundation/Stream.subproj/CFStream.c
@@ -389,7 +389,7 @@ CF_EXPORT void* _CFStreamGetInfoPointer(struct _CFStream* stream) {
     return stream == NULL? NULL : stream->info;
 }
 
-CF_PRIVATE struct _CFStream *_CFStreamCreateWithConstantCallbacks(CFAllocatorRef alloc, void *info,  const struct _CFStreamCallBacks *cb, Boolean isReading) {
+CF_EXPORT struct _CFStream *_CFStreamCreateWithConstantCallbacks(CFAllocatorRef alloc, void *info,  const struct _CFStreamCallBacks *cb, Boolean isReading) {
     struct _CFStream *newStream;
     if (cb->version != 1) return NULL;
     newStream = _CFStreamCreate(alloc, isReading);

--- a/CoreFoundation/String.subproj/CFString.c
+++ b/CoreFoundation/String.subproj/CFString.c
@@ -1590,7 +1590,7 @@ CFStringRef  CFStringCreateWithCharactersNoCopy(CFAllocatorRef alloc, const UniC
 }
 
 
-CFStringRef  CFStringCreateWithBytes(CFAllocatorRef alloc, const uint8_t *bytes, CFIndex numBytes, CFStringEncoding encoding, Boolean externalFormat) {
+CF_EXPORT CFStringRef  CFStringCreateWithBytes(CFAllocatorRef alloc, const uint8_t *bytes, CFIndex numBytes, CFStringEncoding encoding, Boolean externalFormat) {
     return __CFStringCreateImmutableFunnel3(alloc, bytes, numBytes, encoding, externalFormat, true, false, false, false, ALLOCATORSFREEFUNC, 0);
 }
 
@@ -1933,7 +1933,7 @@ CFMutableStringRef CFStringCreateMutable(CFAllocatorRef alloc, CFIndex maxLength
     return __CFStringCreateMutableFunnel(alloc, maxLength, __kCFNotInlineContentsDefaultFree);
 }
 
-CFMutableStringRef  CFStringCreateMutableCopy(CFAllocatorRef alloc, CFIndex maxLength, CFStringRef string) {
+CF_EXPORT CFMutableStringRef  CFStringCreateMutableCopy(CFAllocatorRef alloc, CFIndex maxLength, CFStringRef string) {
     CFMutableStringRef newString;
     // TODO: Re-enable this when CFHash, CFEqual, etc. work with bridged NSString objects from Swift. The existing implementation below still works.
 //    CF_SWIFT_FUNCDISPATCHV(__kCFStringTypeID, CFMutableStringRef, (CFSwiftRef)string, _CFSwiftStringCreateMutableCopy);
@@ -1956,7 +1956,7 @@ CF_PRIVATE void _CFStrSetDesiredCapacity(CFMutableStringRef str, CFIndex len) {
 
 /* This one is for CF
 */
-CFIndex CFStringGetLength(CFStringRef str) {
+CF_EXPORT CFIndex CFStringGetLength(CFStringRef str) {
     CF_SWIFT_FUNCDISPATCHV(__kCFStringTypeID, CFIndex, (CFSwiftRef)str, NSString.length);
     CF_OBJC_FUNCDISPATCHV(__kCFStringTypeID, CFIndex, (NSString *)str, length);
 
@@ -2041,7 +2041,7 @@ int _CFStringCheckAndGetCharacters(CFStringRef str, CFRange range, UniChar *buff
 }
 
 
-CFIndex CFStringGetBytes(CFStringRef str, CFRange range, CFStringEncoding encoding, uint8_t lossByte, Boolean isExternalRepresentation, uint8_t *buffer, CFIndex maxBufLen, CFIndex *usedBufLen) {
+CF_EXPORT CFIndex CFStringGetBytes(CFStringRef str, CFRange range, CFStringEncoding encoding, uint8_t lossByte, Boolean isExternalRepresentation, uint8_t *buffer, CFIndex maxBufLen, CFIndex *usedBufLen) {
     if (CF_IS_SWIFT(CFStringGetTypeID(), str) && __CFSwiftBridge.NSString.__getBytes != NULL) {
         return __CFSwiftBridge.NSString.__getBytes(str, encoding, range, buffer, maxBufLen, usedBufLen);
     }
@@ -4192,7 +4192,7 @@ CFStringRef CFStringCreateFromExternalRepresentation(CFAllocatorRef alloc, CFDat
 }
 
 
-CFDataRef CFStringCreateExternalRepresentation(CFAllocatorRef alloc, CFStringRef string, CFStringEncoding encoding, uint8_t lossByte) {
+CF_EXPORT CFDataRef CFStringCreateExternalRepresentation(CFAllocatorRef alloc, CFStringRef string, CFStringEncoding encoding, uint8_t lossByte) {
     CFIndex length;
     CFIndex guessedByteLength;
     uint8_t *bytes;

--- a/CoreFoundation/StringEncodings.subproj/CFStringEncodingConverter.c
+++ b/CoreFoundation/StringEncodings.subproj/CFStringEncodingConverter.c
@@ -850,11 +850,11 @@ uint32_t CFStringEncodingBytesToUnicode(uint32_t encoding, uint32_t flags, const
     return theResult;
 }
 
-CF_PRIVATE bool CFStringEncodingIsValidEncoding(uint32_t encoding) {
+CF_EXPORT bool CFStringEncodingIsValidEncoding(uint32_t encoding) {
     return (CFStringEncodingGetConverter(encoding) ? true : false);
 }
 
-CF_PRIVATE CFIndex CFStringEncodingCharLengthForBytes(uint32_t encoding, uint32_t flags, const uint8_t *bytes, CFIndex numBytes) {
+CF_EXPORT CFIndex CFStringEncodingCharLengthForBytes(uint32_t encoding, uint32_t flags, const uint8_t *bytes, CFIndex numBytes) {
     const _CFEncodingConverter *converter = __CFGetConverter(encoding);
 
     if (converter) {
@@ -898,7 +898,7 @@ CF_PRIVATE CFIndex CFStringEncodingCharLengthForBytes(uint32_t encoding, uint32_
     return 0;
 }
 
-CF_PRIVATE CFIndex CFStringEncodingByteLengthForCharacters(uint32_t encoding, uint32_t flags, const UniChar *characters, CFIndex numChars) {
+CF_EXPORT CFIndex CFStringEncodingByteLengthForCharacters(uint32_t encoding, uint32_t flags, const UniChar *characters, CFIndex numChars) {
     const _CFEncodingConverter *converter = __CFGetConverter(encoding);
 
     if (converter) {
@@ -981,7 +981,7 @@ static void __CFStringEncodingFliterDupes(CFStringEncoding *encodings, CFIndex n
     }
 }
 
-CF_PRIVATE const CFStringEncoding *CFStringEncodingListOfAvailableEncodings(void) {
+CF_EXPORT const CFStringEncoding *CFStringEncodingListOfAvailableEncodings(void) {
     static const CFStringEncoding *encodings = NULL;
 
     if (NULL == encodings) {

--- a/CoreFoundation/StringEncodings.subproj/CFUniChar.c
+++ b/CoreFoundation/StringEncodings.subproj/CFUniChar.c
@@ -563,7 +563,7 @@ const uint8_t *CFUniCharGetBitmapPtrForPlane(uint32_t charset, uint32_t plane) {
     return NULL;
 }
 
-CF_PRIVATE uint8_t CFUniCharGetBitmapForPlane(uint32_t charset, uint32_t plane, void *bitmap, bool isInverted) {
+CF_EXPORT uint8_t CFUniCharGetBitmapForPlane(uint32_t charset, uint32_t plane, void *bitmap, bool isInverted) {
     const uint8_t *src = CFUniCharGetBitmapPtrForPlane(charset, plane);
     int numBytes = (8 * 1024);
 
@@ -691,7 +691,7 @@ CF_PRIVATE uint8_t CFUniCharGetBitmapForPlane(uint32_t charset, uint32_t plane, 
     return (isInverted ? kCFUniCharBitmapAll : kCFUniCharBitmapEmpty);
 }
 
-CF_PRIVATE uint32_t CFUniCharGetNumberOfPlanes(uint32_t charset) {
+CF_EXPORT uint32_t CFUniCharGetNumberOfPlanes(uint32_t charset) {
     if ((charset == kCFUniCharControlCharacterSet) || (charset == kCFUniCharControlAndFormatterCharacterSet)) {
         return 15; // 0 to 14
     } else if (charset < kCFUniCharDecimalDigitCharacterSet) {
@@ -714,7 +714,7 @@ static const void **__CFUniCharMappingTables = NULL;
 
 static CFLock_t __CFUniCharMappingTableLock = CFLockInit;
 
-CF_PRIVATE const void *CFUniCharGetMappingData(uint32_t type) {
+CF_EXPORT const void *CFUniCharGetMappingData(uint32_t type) {
 
     __CFLock(&__CFUniCharMappingTableLock);
 
@@ -1128,7 +1128,7 @@ CF_INLINE bool __CFUniCharIsAfter_i(UTF16Char *buffer, CFIndex length) {
     return true;
 }
 
-CF_PRIVATE uint32_t CFUniCharGetConditionalCaseMappingFlags(UTF32Char theChar, UTF16Char *buffer, CFIndex currentIndex, CFIndex length, uint32_t type, const uint8_t *langCode, uint32_t lastFlags) {
+CF_EXPORT uint32_t CFUniCharGetConditionalCaseMappingFlags(UTF32Char theChar, UTF16Char *buffer, CFIndex currentIndex, CFIndex length, uint32_t type, const uint8_t *langCode, uint32_t lastFlags) {
     if (theChar == 0x03A3) { // GREEK CAPITAL LETTER SIGMA
         if ((type == kCFUniCharToLowercase) && (currentIndex > 0)) {
             UTF16Char *start = buffer;
@@ -1275,12 +1275,12 @@ const void *CFUniCharGetUnicodePropertyDataForPlane(uint32_t propertyType, uint3
     return (plane < __CFUniCharUnicodePropertyTable[propertyType]._numPlanes ? __CFUniCharUnicodePropertyTable[propertyType]._planes[plane] : NULL);
 }
 
-CF_PRIVATE uint32_t CFUniCharGetNumberOfPlanesForUnicodePropertyData(uint32_t propertyType) {
+CF_EXPORT uint32_t CFUniCharGetNumberOfPlanesForUnicodePropertyData(uint32_t propertyType) {
     (void)CFUniCharGetUnicodePropertyDataForPlane(propertyType, 0);
     return __CFUniCharUnicodePropertyTable[propertyType]._numPlanes;
 }
 
-CF_PRIVATE uint32_t CFUniCharGetUnicodeProperty(UTF32Char character, uint32_t propertyType) {
+CF_EXPORT uint32_t CFUniCharGetUnicodeProperty(UTF32Char character, uint32_t propertyType) {
     if (propertyType == kCFUniCharCombiningProperty) {
         return CFUniCharGetCombiningPropertyForCharacter(character, (const uint8_t *)CFUniCharGetUnicodePropertyDataForPlane(propertyType, (character >> 16) & 0xFF));
     } else if (propertyType == kCFUniCharBidiProperty) {

--- a/CoreFoundation/StringEncodings.subproj/CFUnicodeDecomposition.c
+++ b/CoreFoundation/StringEncodings.subproj/CFUnicodeDecomposition.c
@@ -344,7 +344,7 @@ CF_INLINE void __CFUniCharMoveBufferFromEnd1(UTF32Char *convertedChars, CFIndex 
     while (convertedChars > limit) *(--dstP) = *(--convertedChars);
 }
 
-CF_PRIVATE CFIndex CFUniCharCompatibilityDecompose(UTF32Char *convertedChars, CFIndex length, CFIndex maxBufferLength) {
+CF_EXPORT CFIndex CFUniCharCompatibilityDecompose(UTF32Char *convertedChars, CFIndex length, CFIndex maxBufferLength) {
     UTF32Char currentChar;
     UTF32Char buffer[MAX_COMP_DECOMP_LEN];
     const UTF32Char *bufferP;

--- a/CoreFoundation/StringEncodings.subproj/CFUnicodePrecomposition.c
+++ b/CoreFoundation/StringEncodings.subproj/CFUnicodePrecomposition.c
@@ -108,8 +108,8 @@ static uint32_t __CFUniCharGetMappedValue_P(const __CFUniCharPrecomposeMappings 
     return 0;
 }
 
-CF_PRIVATE
-UTF32Char CFUniCharPrecomposeCharacter(UTF32Char base, UTF32Char combining) {
+CF_EXPORT UTF32Char CFUniCharPrecomposeCharacter(UTF32Char base,
+                                                 UTF32Char combining) {
     uint32_t value;
 
     if (NULL == __CFUniCharPrecompSourceTable) __CFUniCharLoadPrecompositionTable();


### PR DESCRIPTION
This adjusts the headers and the definitions to ensure that the export
decorations match.  This enables building CoreFoundation with hidden visibility
by default on Linux targets.