### PR TITLE
Implementing preflight(),loadWithErrorin NSBundle

### DIFF
--- a/Foundation/NSBundle.swift
+++ b/Foundation/NSBundle.swift
@@ -77,9 +77,9 @@ public class Bundle: NSObject {
     public func unload() -> Bool { NSUnimplemented() }
     
     public func preflight() throws {
-        var unmangaedError:Unmanaged<CFError>? = nil
-        try withUnsafeMutablePointer(&unmangaedError) { (unmanagedCFError: UnsafeMutablePointer<Unmanaged<CFError>?>)  in
-            CFBundlePreflightExecutable(_bundle,  unmanagedCFError)
+        var unmanagedError:Unmanaged<CFError>? = nil
+        try withUnsafeMutablePointer(&unmanagedError) { (unmanagedCFError: UnsafeMutablePointer<Unmanaged<CFError>?>)  in
+            CFBundlePreflightExecutable(_bundle, unmanagedCFError)
             if let error = unmanagedCFError.pointee {
                 throw   error.takeRetainedValue()._nsObject
             }
@@ -87,9 +87,9 @@ public class Bundle: NSObject {
     }
     
     public func loadAndReturnError() throws {
-        var unmangaedError:Unmanaged<CFError>? = nil
-        try  withUnsafeMutablePointer(&unmangaedError) { (unmanagedCFError: UnsafeMutablePointer<Unmanaged<CFError>?>)  in
-            CFBundleLoadExecutableAndReturnError(_bundle,  unmanagedCFError)
+        var unmanagedError:Unmanaged<CFError>? = nil
+        try  withUnsafeMutablePointer(&unmanagedError) { (unmanagedCFError: UnsafeMutablePointer<Unmanaged<CFError>?>)  in
+            CFBundleLoadExecutableAndReturnError(_bundle, unmanagedCFError)
             if let error = unmanagedCFError.pointee {
                 let retainedValue = error.takeRetainedValue()
                 throw  retainedValue._nsObject

--- a/Foundation/NSBundle.swift
+++ b/Foundation/NSBundle.swift
@@ -37,6 +37,9 @@ public class Bundle: NSObject {
         
         let url = URL(fileURLWithPath: resolvedPath)
         _bundle = CFBundleCreate(kCFAllocatorSystemDefault, unsafeBitCast(url, to: CFURL.self))
+        if (_bundle == nil) {
+            return nil
+        }
     }
     
     public convenience init?(url: URL) {
@@ -73,8 +76,27 @@ public class Bundle: NSObject {
     }
     public func unload() -> Bool { NSUnimplemented() }
     
-    public func preflight() throws { NSUnimplemented() }
-    public func loadAndReturnError() throws { NSUnimplemented() }
+    public func preflight() throws {
+        var unmangaedError:Unmanaged<CFError>? = nil
+        try withUnsafeMutablePointer(&unmangaedError) { (unmanagedCFError: UnsafeMutablePointer<Unmanaged<CFError>?>)  in
+            CFBundlePreflightExecutable(_bundle,  unmanagedCFError)
+            if let error = unmanagedCFError.pointee {
+                throw   error.takeRetainedValue()._nsObject
+            }
+        }
+    }
+    
+    public func loadAndReturnError() throws {
+        var unmangaedError:Unmanaged<CFError>? = nil
+        try  withUnsafeMutablePointer(&unmangaedError) { (unmanagedCFError: UnsafeMutablePointer<Unmanaged<CFError>?>)  in
+            CFBundleLoadExecutableAndReturnError(_bundle,  unmanagedCFError)
+            if let error = unmanagedCFError.pointee {
+                let retainedValue = error.takeRetainedValue()
+                throw  retainedValue._nsObject
+            }
+        }
+    }
+
     
     /* Methods for locating various components of a bundle. */
     public var bundleURL: URL {

--- a/TestFoundation/TestNSBundle.swift
+++ b/TestFoundation/TestNSBundle.swift
@@ -29,6 +29,10 @@ class TestNSBundle : XCTestCase {
             ("test_localizations", test_localizations),
             ("test_URLsForResourcesWithExtension", test_URLsForResourcesWithExtension),
             ("test_bundleLoad", test_bundleLoad),
+            ("test_bundleLoadWithError",test_bundleLoadWithError),
+            ("test_bundleWithInvalidPath",test_bundleWithInvalidPath),
+            ("test_bundlePreflight",test_bundlePreflight),
+
         ]
     }
     
@@ -153,10 +157,46 @@ class TestNSBundle : XCTestCase {
         
         _cleanupPlayground(playground)
     }
+    
     func test_bundleLoad(){
         let bundle = Bundle.main()
         let _ = bundle.load()
         XCTAssertTrue(bundle.isLoaded)
     }
+    
+    func test_bundleLoadWithError(){
+        let bundleValid = NSBundle.mainBundle()
+        //test valid load using loadAndReturnError
+        do{
+            try bundleValid.loadAndReturnError()
+        }catch{
+            XCTFail("should not fail to load")
+        }
+        // executable cannot be located
+        guard let playground = _setupPlayground() else { XCTFail("Unable to create playground"); return }
+        let bundle = NSBundle(path: playground + _bundleName)
+        XCTAssertThrowsError(try bundle!.loadAndReturnError())
+        _cleanupPlayground(playground)
+    }
+    
+    func test_bundleWithInvalidPath(){
+        let bundleInvalid = NSBundle(path: "/tmp/test.playground")
+        XCTAssertNil(bundleInvalid)
+    }
+    
+    func test_bundlePreflight(){
+        let bundleValid = NSBundle.mainBundle()
+        do{
+            try bundleValid.preflight()
+        }catch{
+            XCTFail("should not fail to load")
+        }
+        // executable cannot be located ..preflight should report error
+        guard let playground = _setupPlayground() else { XCTFail("Unable to create playground"); return }
+        let bundle = NSBundle(path: playground + _bundleName)
+        XCTAssertThrowsError(try bundle!.preflight())
+        _cleanupPlayground(playground)
+    }
+
 
 }

--- a/TestFoundation/TestNSBundle.swift
+++ b/TestFoundation/TestNSBundle.swift
@@ -29,10 +29,9 @@ class TestNSBundle : XCTestCase {
             ("test_localizations", test_localizations),
             ("test_URLsForResourcesWithExtension", test_URLsForResourcesWithExtension),
             ("test_bundleLoad", test_bundleLoad),
-            ("test_bundleLoadWithError",test_bundleLoadWithError),
-            ("test_bundleWithInvalidPath",test_bundleWithInvalidPath),
-            ("test_bundlePreflight",test_bundlePreflight),
-
+            ("test_bundleLoadWithError", test_bundleLoadWithError),
+            ("test_bundleWithInvalidPath", test_bundleWithInvalidPath),
+            ("test_bundlePreflight", test_bundlePreflight),
         ]
     }
     
@@ -165,7 +164,7 @@ class TestNSBundle : XCTestCase {
     }
     
     func test_bundleLoadWithError(){
-        let bundleValid = NSBundle.mainBundle()
+        let bundleValid = Bundle.main()
         //test valid load using loadAndReturnError
         do{
             try bundleValid.loadAndReturnError()
@@ -174,18 +173,18 @@ class TestNSBundle : XCTestCase {
         }
         // executable cannot be located
         guard let playground = _setupPlayground() else { XCTFail("Unable to create playground"); return }
-        let bundle = NSBundle(path: playground + _bundleName)
+        let bundle = Bundle(path: playground + _bundleName)
         XCTAssertThrowsError(try bundle!.loadAndReturnError())
         _cleanupPlayground(playground)
     }
     
     func test_bundleWithInvalidPath(){
-        let bundleInvalid = NSBundle(path: "/tmp/test.playground")
+        let bundleInvalid = Bundle(path: "/tmp/test.playground")
         XCTAssertNil(bundleInvalid)
     }
     
     func test_bundlePreflight(){
-        let bundleValid = NSBundle.mainBundle()
+        let bundleValid = Bundle.main()
         do{
             try bundleValid.preflight()
         }catch{
@@ -193,7 +192,7 @@ class TestNSBundle : XCTestCase {
         }
         // executable cannot be located ..preflight should report error
         guard let playground = _setupPlayground() else { XCTFail("Unable to create playground"); return }
-        let bundle = NSBundle(path: playground + _bundleName)
+        let bundle = Bundle(path: playground + _bundleName)
         XCTAssertThrowsError(try bundle!.preflight())
         _cleanupPlayground(playground)
     }


### PR DESCRIPTION
Also includes the fix for segmentation fault issue when the NSBundle is created with an invalid path