### PR TITLE
Implementation of HTTPCookie.cookies(withResponseHeaderFields:forURL:)

### DIFF
--- a/TestFoundation/TestNSHTTPCookie.swift
+++ b/TestFoundation/TestNSHTTPCookie.swift
@@ -20,7 +20,12 @@ class TestNSHTTPCookie: XCTestCase {
     static var allTests: [(String, (TestNSHTTPCookie) -> () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
-            ("test_RequestHeaderFields", test_RequestHeaderFields)
+            ("test_RequestHeaderFields", test_RequestHeaderFields),
+            ("test_cookiesWithResponseHeader1cookie", test_cookiesWithResponseHeader1cookie), 
+            ("test_cookiesWithResponseHeader0cookies", test_cookiesWithResponseHeader0cookies), 
+            ("test_cookiesWithResponseHeader2cookies", test_cookiesWithResponseHeader2cookies), 
+            ("test_cookiesWithResponseHeaderNoDomain", test_cookiesWithResponseHeaderNoDomain), 
+            ("test_cookiesWithResponseHeaderNoPathNoDomain", test_cookiesWithResponseHeaderNoPathNoDomain)
         ]
     }
 
@@ -113,5 +118,57 @@ class TestNSHTTPCookie: XCTestCase {
         
         let basicCookieString = HTTPCookie.requestHeaderFields(with: basicCookies)["Cookie"]
         XCTAssertEqual(basicCookieString, "TestCookie1=testValue1; TestCookie2=testValue2")
+    }
+
+    func test_cookiesWithResponseHeader1cookie() {
+        let header = ["header1":"value1", 
+                      "Set-Cookie": "fr=anjd&232; Max-Age=7776000; path=/; domain=.example.com; secure; httponly", 
+                      "header2":"value2", 
+                      "header3":"value3"]
+        let cookies = HTTPCookie.cookies(withResponseHeaderFields: header, forURL: URL(string: "http://example.com")!)
+        XCTAssertEqual(cookies.count, 1)
+        XCTAssertEqual(cookies[0].name, "fr")
+        XCTAssertEqual(cookies[0].value, "anjd&232")
+    }
+
+    func test_cookiesWithResponseHeader0cookies() {
+        let header = ["header1":"value1", "header2":"value2", "header3":"value3"]
+        let cookies =  HTTPCookie.cookies(withResponseHeaderFields: header, forURL: URL(string: "http://example.com")!)
+        XCTAssertEqual(cookies.count, 0)
+    }
+
+    func test_cookiesWithResponseHeader2cookies() {
+        let header = ["header1":"value1", 
+                      "Set-Cookie": "fr=a&2@#; Max-Age=1186000; path=/; domain=.example.com; secure, xd=plm!@#;path=/;domain=.example2.com", 
+                      "header2":"value2", 
+                      "header3":"value3"]
+        let cookies =  HTTPCookie.cookies(withResponseHeaderFields: header, forURL: URL(string: "http://example.com")!)
+        XCTAssertEqual(cookies.count, 2)
+        XCTAssertTrue(cookies[0].isSecure)
+        XCTAssertFalse(cookies[1].isSecure)
+    }
+
+    func test_cookiesWithResponseHeaderNoDomain() {
+        let header =  ["header1":"value1", 
+                       "Set-Cookie": "fr=anjd&232; expires=Wed, 21 Sep 2016 05:33:00 GMT; Max-Age=7776000; path=/; secure; httponly", 
+                       "header2":"value2", 
+                       "header3":"value3"]
+        let cookies =  HTTPCookie.cookies(withResponseHeaderFields: header, forURL: URL(string: "http://example.com")!)
+        XCTAssertEqual(cookies[0].domain, "http://example.com")
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss O"   
+        formatter.timeZone = TimeZone(abbreviation: "GMT") 
+        let expiresDate = formatter.date(from: "Wed, 21 Sep 2016 05:33:00 GMT")!
+        XCTAssertTrue(expiresDate.compare(cookies[0].expiresDate!) == .orderedSame)
+    }
+
+    func test_cookiesWithResponseHeaderNoPathNoDomain() {
+        let header = ["header1":"value1", 
+                      "Set-Cookie": "fr=tx; expires=Wed, 21-Sep-2016 05:33:00 GMT; Max-Age=7776000; secure; httponly", 
+                      "header2":"value2", 
+                      "header3":"value3"]
+        let cookies =  HTTPCookie.cookies(withResponseHeaderFields: header, forURL: URL(string: "http://example.com")!)
+        XCTAssertEqual(cookies[0].domain, "http://example.com")
+        XCTAssertEqual(cookies[0].path, "/") 
     }
 }


### PR DESCRIPTION
This is for an initial implementaion of HTTPCookie.cookies(withResponseHeaderFields:forURL:).
In addition to the contributed unit tests, I have also tested this code against cookies
returned by some of the twenty most popular websites. 

Kindly review and provide feedback.