### PR TITLE
Activate the ability to integrate libdispatch

### DIFF
--- a/build.py
+++ b/build.py
@@ -68,19 +68,19 @@ if "XCTEST_BUILD_DIR" in Configuration.current.variables:
 foundation.LDFLAGS += '-lpthread -ldl -lm -lswiftCore -lxml2 '
 
 # Configure use of Dispatch in CoreFoundation and Foundation if libdispatch is being built
-#if "LIBDISPATCH_SOURCE_DIR" in Configuration.current.variables:
-#	foundation.CFLAGS += " "+" ".join([
-#		'-DDEPLOYMENT_ENABLE_LIBDISPATCH',
-#		'-I'+Configuration.current.variables["LIBDISPATCH_SOURCE_DIR"],
-#		'-I'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/tests'  # for include of dispatch/private.h in CF
-#	])
-#	swift_cflags += ([
-#		'-DDEPLOYMENT_ENABLE_LIBDISPATCH',
-#		'-I'+Configuration.current.variables["LIBDISPATCH_SOURCE_DIR"],
-#		'-I'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src',
-#		'-Xcc -fblocks'
-#	])
-#	foundation.LDFLAGS += '-ldispatch -L'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src/.libs -rpath \$$ORIGIN '
+if "LIBDISPATCH_SOURCE_DIR" in Configuration.current.variables:
+	foundation.CFLAGS += " "+" ".join([
+		'-DDEPLOYMENT_ENABLE_LIBDISPATCH',
+		'-I'+Configuration.current.variables["LIBDISPATCH_SOURCE_DIR"],
+		'-I'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/tests'  # for include of dispatch/private.h in CF
+	])
+	swift_cflags += ([
+		'-DDEPLOYMENT_ENABLE_LIBDISPATCH',
+		'-I'+Configuration.current.variables["LIBDISPATCH_SOURCE_DIR"],
+		'-I'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src',
+		'-Xcc -fblocks'
+	])
+	foundation.LDFLAGS += '-ldispatch -L'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src/.libs -rpath \$$ORIGIN '
 
 foundation.SWIFTCFLAGS = " ".join(swift_cflags)
 


### PR DESCRIPTION
@parkera @phausler This uncomments the block that configures the use of libdispatch by Foundation in build.py, activating the `__HAS_DISPATCH__` guard.

The block includes guards to check that libdispatch is being built, which means that the toolchain builds in the CI environment won't be affected by this yet. 

It will affect the libdispatch CI build, which also builds Foundation, XCTest and Swift PM, so we'll start to exercise the use of libdispatch via TestFoundation and the XCTest and Swift PM unit tests.

If the libdispatch CI builds run clean/stable, we'll then look at adding libdispatch into the toolchain builds via the "buildbot_linux" preset. 