### PR TITLE
SR-1908 Set detach state on creation to DETACHED

### DIFF
--- a/Foundation/NSThread.swift
+++ b/Foundation/NSThread.swift
@@ -146,6 +146,8 @@ public class Thread: NSObject {
         _main = main
         let _ = withUnsafeMutablePointer(&_attr) { attr in
             pthread_attr_init(attr)
+            pthread_attr_setscope(attr, Int32(PTHREAD_SCOPE_SYSTEM))
+            pthread_attr_setdetachstate(attr, Int32(PTHREAD_CREATE_DETACHED))
         }
     }
 


### PR DESCRIPTION
### What's in this pull request?

Prior to `pthread_create` call there is an opportunity to set the thread's attributes with `pthread_attr_set*` routines.  This PR sets both the scope of the thread to SYSTEM and the detached state to CREATE_DETACHED which allows the thread to exit and cleanup its resources upon `pthread_exit` without waiting for a `pthread_join`.

### Resolved bug number:  [SR-1908](https://bugs.swift.org/browse/SR-1908)