### PR TITLE
Update for SE-0025 ('private' and 'fileprivate')

### DIFF
--- a/Foundation/Boxing.swift
+++ b/Foundation/Boxing.swift
@@ -14,7 +14,7 @@
 ///
 /// Note: This assumes that the result of calling copy() is mutable. The documentation says that classes which do not have a mutable/immutable distinction should just adopt NSCopying instead of NSMutableCopying.
 internal final class _MutableHandle<MutableType : NSObject where MutableType : NSCopying> {
-    private var _pointer : MutableType
+    fileprivate var _pointer : MutableType
     
     init(reference : MutableType) {
         _pointer = reference.copy() as! MutableType

--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -163,7 +163,7 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
         /// A custom deallocator.
         case custom((UnsafeMutablePointer<UInt8>, Int) -> Void)
         
-        private var _deallocator : ((UnsafeMutablePointer<Void>, Int) -> Void)? {
+        fileprivate var _deallocator : ((UnsafeMutablePointer<Void>, Int) -> Void)? {
             switch self {
             case .unmap:
                 return { __NSDataInvokeDeallocatorUnmap($0, $1) }

--- a/Foundation/IndexPath.swift
+++ b/Foundation/IndexPath.swift
@@ -24,7 +24,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
     public typealias Index = Array<Int>.Index
     public typealias Indices = DefaultRandomAccessIndices<IndexPath>
     
-    private var _indexes : Array<Int>
+    fileprivate var _indexes : Array<Int>
     
     /// Initialize an empty index path.
     public init() {
@@ -153,7 +153,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
     
     // MARK: - Bridging Helpers
     
-    private init(nsIndexPath: ReferenceType) {
+    fileprivate init(nsIndexPath: ReferenceType) {
         let count = nsIndexPath.length
         if count == 0 {
             _indexes = []
@@ -168,7 +168,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
         }
     }
     
-    private func makeReference() -> ReferenceType {
+    fileprivate func makeReference() -> ReferenceType {
         return _indexes.withUnsafeBufferPointer {
             return ReferenceType(indexes: $0.baseAddress!, length: $0.count)
         }

--- a/Foundation/IndexSet.swift
+++ b/Foundation/IndexSet.swift
@@ -96,12 +96,12 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         public let startIndex : Index
         public let endIndex : Index
         
-        private var indexSet : IndexSet
+        fileprivate var indexSet : IndexSet
         
         // Range of element values
         private var intersectingRange : Range<IndexSet.Element>?
         
-        private init(indexSet : IndexSet, intersecting range : Range<IndexSet.Element>?) {
+        fileprivate init(indexSet : IndexSet, intersecting range : Range<IndexSet.Element>?) {
             self.indexSet = indexSet
             self.intersectingRange = range
             
@@ -165,13 +165,13 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     
     /// The mechanism for getting to the integers stored in an IndexSet.
     public struct Index : CustomStringConvertible, Comparable {
-        private let indexSet : IndexSet
-        private var value : IndexSet.Element
-        private var extent : Range<IndexSet.Element>
-        private var rangeIndex : Int
-        private let rangeCount : Int
+        fileprivate let indexSet : IndexSet
+        fileprivate var value : IndexSet.Element
+        fileprivate var extent : Range<IndexSet.Element>
+        fileprivate var rangeIndex : Int
+        fileprivate let rangeCount : Int
         
-        private init(firstIn indexSet : IndexSet) {
+        fileprivate init(firstIn indexSet : IndexSet) {
             self.indexSet = indexSet
             self.rangeCount = indexSet._rangeCount
             self.rangeIndex = 0
@@ -179,7 +179,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
             self.value = extent.lowerBound
         }
         
-        private init(lastIn indexSet : IndexSet) {
+        fileprivate init(lastIn indexSet : IndexSet) {
             self.indexSet = indexSet
             let rangeCount = indexSet._rangeCount
             self.rangeIndex = rangeCount - 1
@@ -193,7 +193,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
             self.rangeCount = rangeCount
         }
         
-        private init(indexSet: IndexSet, index: Int) {
+        fileprivate init(indexSet: IndexSet, index: Int) {
             self.indexSet = indexSet
             self.rangeCount = self.indexSet._rangeCount
             self.value = index
@@ -207,7 +207,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         }
         
         // First or last value in a specified range
-        private init(indexSet: IndexSet, rangeIndex: Int, rangeCount: Int, first : Bool) {
+        fileprivate init(indexSet: IndexSet, rangeIndex: Int, rangeCount: Int, first : Bool) {
             self.indexSet = indexSet
             let extent = indexSet._range(at: rangeIndex)
             if first {
@@ -220,7 +220,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
             self.rangeIndex = rangeIndex
         }
         
-        private init(indexSet: IndexSet, value: Int, extent: Range<Int>, rangeIndex: Int, rangeCount: Int) {
+        fileprivate init(indexSet: IndexSet, value: Int, extent: Range<Int>, rangeIndex: Int, rangeCount: Int) {
             self.indexSet = indexSet
             self.value = value
             self.extent = extent
@@ -228,7 +228,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
             self.rangeIndex = rangeIndex
         }
         
-        private func successor() -> Index {
+        fileprivate func successor() -> Index {
             if value + 1 == extent.upperBound {
                 // Move to the next range
                 if rangeIndex + 1 == rangeCount {
@@ -243,7 +243,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
             }
         }
         
-        private mutating func _successorInPlace() {
+        fileprivate mutating func _successorInPlace() {
             if value + 1 == extent.upperBound {
                 // Move to the next range
                 if rangeIndex + 1 == rangeCount {
@@ -260,7 +260,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
             }
         }
         
-        private func predecessor() -> Index {
+        fileprivate func predecessor() -> Index {
             if value == extent.lowerBound {
                 // Move to the next range
                 if rangeIndex == 0 {
@@ -279,7 +279,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
             return "index \(value) in a range of \(extent) [range #\(rangeIndex + 1)/\(rangeCount)]"
         }
         
-        private mutating func _predecessorInPlace() {
+        fileprivate mutating func _predecessorInPlace() {
             if value == extent.lowerBound {
                 // Move to the next range
                 if rangeIndex == 0 {
@@ -299,7 +299,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     public typealias ReferenceType = NSIndexSet
     public typealias Element = Int
     
-    private var _handle: _MutablePairHandle<NSIndexSet, NSMutableIndexSet>
+    fileprivate var _handle: _MutablePairHandle<NSIndexSet, NSMutableIndexSet>
     
     internal init(indexesIn range: NSRange) {
         _handle = _MutablePairHandle(NSIndexSet(indexesIn: range), copying: false)
@@ -693,18 +693,18 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     
     // MARK: - Bridging Support
     
-    private var reference: NSIndexSet {
+    fileprivate var reference: NSIndexSet {
         return _handle.reference
     }
     
-    private init(reference: NSIndexSet) {
+    fileprivate init(reference: NSIndexSet) {
         _handle = _MutablePairHandle(reference)
     }
 }
 
 /// Iterate two index sets on the boundaries of their ranges. This is where all of the interesting stuff happens for exclusive or, intersect, etc.
 private struct IndexSetBoundaryIterator : IteratorProtocol {
-    private typealias Element = IndexSet.Element
+    fileprivate typealias Element = IndexSet.Element
     
     private var i1 : IndexSet.RangeView.Iterator
     private var i2 : IndexSet.RangeView.Iterator
@@ -713,7 +713,7 @@ private struct IndexSetBoundaryIterator : IteratorProtocol {
     private var i1UsedFirst : Bool
     private var i2UsedFirst : Bool
     
-    private init(_ is1 : IndexSet, _ is2 : IndexSet) {
+    fileprivate init(_ is1 : IndexSet, _ is2 : IndexSet) {
         i1 = is1.rangeView().makeIterator()
         i2 = is2.rangeView().makeIterator()
         
@@ -725,7 +725,7 @@ private struct IndexSetBoundaryIterator : IteratorProtocol {
         i2UsedFirst = false
     }
     
-    private mutating func next() -> Element? {
+    fileprivate mutating func next() -> Element? {
         if i1Range == nil && i2Range == nil {
             return nil
         }
@@ -814,7 +814,7 @@ private enum _MutablePair<ImmutableType, MutableType> {
 ///
 /// a.k.a. Box
 private final class _MutablePairHandle<ImmutableType : NSObject, MutableType : NSObject where ImmutableType : NSMutableCopying, MutableType : NSMutableCopying> {
-    private var _pointer: _MutablePair<ImmutableType, MutableType>
+    fileprivate var _pointer: _MutablePair<ImmutableType, MutableType>
     
     /// Initialize with an immutable reference instance.
     ///

--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -12,8 +12,8 @@ import CoreFoundation
 public class AttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     
     private let _cfinfo = _CFInfo(typeID: CFAttributedStringGetTypeID())
-    private var _string: NSString
-    private var _attributeArray: CFRunArrayRef
+    fileprivate var _string: NSString
+    fileprivate var _attributeArray: CFRunArrayRef
     
     public required init?(coder aDecoder: NSCoder) {
         NSUnimplemented()
@@ -111,13 +111,13 @@ public class AttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
 }
 
 private extension AttributedString {
-    private struct RangeInfo {
+    fileprivate struct RangeInfo {
         let rangePointer: NSRangePointer
         let shouldFetchLongestEffectiveRange: Bool
         let longestEffectiveRangeSearchRange: NSRange?
     }
     
-    private func _attributesAtIndex(_ location: Int, rangeInfo: RangeInfo) -> [String : AnyObject] {
+    fileprivate func _attributesAtIndex(_ location: Int, rangeInfo: RangeInfo) -> [String : AnyObject] {
         var cfRange = CFRange()
         return withUnsafeMutablePointer(&cfRange) { (cfRangePointer: UnsafeMutablePointer<CFRange>) -> [String : AnyObject] in
             // Get attributes value using CoreFoundation function
@@ -147,7 +147,7 @@ private extension AttributedString {
         }
     }
     
-    private func _attribute(_ attrName: String, atIndex location: Int, rangeInfo: RangeInfo) -> AnyObject? {
+    fileprivate func _attribute(_ attrName: String, atIndex location: Int, rangeInfo: RangeInfo) -> AnyObject? {
         var cfRange = CFRange()
         return withUnsafeMutablePointer(&cfRange) { (cfRangePointer: UnsafeMutablePointer<CFRange>) -> AnyObject? in
             // Get attribute value using CoreFoundation function
@@ -171,7 +171,7 @@ private extension AttributedString {
         }
     }
     
-    private func addAttributesToAttributeArray(attrs: [String : AnyObject]?) {
+    fileprivate func addAttributesToAttributeArray(attrs: [String : AnyObject]?) {
         guard _string.length > 0 else {
             return
         }

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -32,7 +32,7 @@ public struct CGFloat {
     /// The native value.
     public var native: NativeType
     
-    private var hash: Int {
+    fileprivate var hash: Int {
 #if arch(i386) || arch(arm)
         return Int(Float(self.native).bitPattern)
 #else

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -23,8 +23,8 @@ public class NSKeyedUnarchiver : NSCoder {
     }
     
     class DecodingContext {
-        private var dict : Dictionary<String, Any>
-        private var genericKey : UInt = 0
+        fileprivate var dict : Dictionary<String, Any>
+        fileprivate var genericKey : UInt = 0
         
         init(_ dict : Dictionary<String, Any>) {
             self.dict = dict

--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -107,10 +107,10 @@ extension NSNotification {
 }
 
 private class NSNotificationReceiver : NSObject {
-    private weak var object: NSObject?
-    private var name: Notification.Name?
-    private var block: ((Notification) -> Void)?
-    private var sender: AnyObject?
+    fileprivate weak var object: NSObject?
+    fileprivate var name: Notification.Name?
+    fileprivate var block: ((Notification) -> Void)?
+    fileprivate var sender: AnyObject?
 }
 
 extension Sequence where Iterator.Element : NSNotificationReceiver {
@@ -122,7 +122,7 @@ extension Sequence where Iterator.Element : NSNotificationReceiver {
     ///  - elements that property `name` is not equal to parameter `name` if specified.
     ///  - elements that property `sender` is not equal to parameter `object` if specified.
     ///
-    private func filterOutObserver(_ observerToFilter: AnyObject, name:Notification.Name? = nil, object: AnyObject? = nil) -> [Iterator.Element] {
+    fileprivate func filterOutObserver(_ observerToFilter: AnyObject, name:Notification.Name? = nil, object: AnyObject? = nil) -> [Iterator.Element] {
         return self.filter { observer in
 
             let differentObserver = observer.object !== observerToFilter
@@ -141,7 +141,7 @@ extension Sequence where Iterator.Element : NSNotificationReceiver {
     ///  - elements that property `sender` is `nil` or equals specified parameter `sender`.
     ///  - elements that property `name` is `nil` or equals specified parameter `name`.
     ///
-    private func observersMatchingName(_ name:Notification.Name? = nil, sender: AnyObject? = nil) -> [Iterator.Element] {
+    fileprivate func observersMatchingName(_ name:Notification.Name? = nil, sender: AnyObject? = nil) -> [Iterator.Element] {
         return self.filter { observer in
 
             let emptyName = observer.name == nil

--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -108,7 +108,7 @@ public class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         return objectAtIndex(idx)
     }
 
-    private func _insertObject(_ object: AnyObject) {
+    fileprivate func _insertObject(_ object: AnyObject) {
         guard !containsObject(object), let object = object as? NSObject else {
             return
         }
@@ -117,7 +117,7 @@ public class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         _orderedStorage.append(object)
     }
 
-    private func _insertObjects(_ objects: UnsafePointer<AnyObject?>, count cnt: Int) {
+    fileprivate func _insertObjects(_ objects: UnsafePointer<AnyObject?>, count cnt: Int) {
         let buffer = UnsafeBufferPointer(start: objects, count: cnt)
         for obj in buffer {
             _insertObject(obj!)
@@ -370,7 +370,7 @@ public class NSMutableOrderedSet : NSOrderedSet {
 
     public required init?(coder aDecoder: NSCoder) { NSUnimplemented() }
 
-    private func _removeObject(_ object: AnyObject) {
+    fileprivate func _removeObject(_ object: AnyObject) {
       guard containsObject(object), let object = object as? NSObject else {
         return
       }

--- a/Foundation/NSTask.swift
+++ b/Foundation/NSTask.swift
@@ -176,7 +176,7 @@ public class Task: NSObject {
     private var runLoopSourceContext : CFRunLoopSourceContext?
     private var runLoopSource : CFRunLoopSource?
     
-    private weak var runLoop : RunLoop? = nil
+    fileprivate weak var runLoop : RunLoop? = nil
     
     private var processLaunchedCondition = Condition()
     

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -787,7 +787,7 @@ extension NSURL {
         return URL(fileURLWithPath: resolvedPath)
     }
 
-    private func _pathByRemovingDots(_ comps: [String]) -> String {
+    fileprivate func _pathByRemovingDots(_ comps: [String]) -> String {
         var components = comps
         
         if(components.last == "/") {

--- a/Foundation/NSXMLNode.swift
+++ b/Foundation/NSXMLNode.swift
@@ -883,8 +883,8 @@ internal protocol _NSXMLNodeCollectionType: Collection { }
 extension XMLNode: _NSXMLNodeCollectionType {
 
     public struct Index: Comparable {
-        private let node: _CFXMLNodePtr?
-        private let offset: Int?
+        fileprivate let node: _CFXMLNodePtr?
+        fileprivate let offset: Int?
     }
 
     public subscript(index: Index) -> XMLNode {

--- a/Foundation/NSXMLParser.swift
+++ b/Foundation/NSXMLParser.swift
@@ -403,7 +403,7 @@ public class XMLParser : NSObject {
     internal var _chunkSize = Int(4096 * 32) // a suitably large number for a decent chunk size
     internal var _haveDetectedEncoding = false
     internal var _bomChunk: Data?
-    private var _parserContext: _CFXMLInterfaceParserContext?
+    fileprivate var _parserContext: _CFXMLInterfaceParserContext?
     internal var _delegateAborted = false
     internal var _url: URL?
     internal var _namespaces = [[String:String]]()

--- a/Foundation/String.swift
+++ b/Foundation/String.swift
@@ -75,9 +75,9 @@ extension String {
   /// representation.
   func _index(_ utf16Index: Int) -> Index {
     return Index(
-      _base: String.UnicodeScalarView.Index(_position: utf16Index),
-      in: characters
-    )
+      String.UTF16View.Index(utf16Index),
+      within: self
+    )!
   }
 
   /// Return a `Range<Index>` corresponding to the given `NSRange` of

--- a/Foundation/URL.swift
+++ b/Foundation/URL.swift
@@ -15,15 +15,15 @@
  As a convenience, volume resource values can be requested from any file system URL. The value returned will reflect the property value for the volume on which the resource is located.
 */
 public struct URLResourceValues {
-    private var _values: [URLResourceKey: AnyObject]
-    private var _keys: Set<URLResourceKey>
+    fileprivate var _values: [URLResourceKey: AnyObject]
+    fileprivate var _keys: Set<URLResourceKey>
     
     public init() {
         _values = [:]
         _keys = []
     }
     
-    private init(keys: Set<URLResourceKey>, values: [URLResourceKey: AnyObject]) {
+    fileprivate init(keys: Set<URLResourceKey>, values: [URLResourceKey: AnyObject]) {
         _values = values
         _keys = keys
     }

--- a/Foundation/URLComponents.swift
+++ b/Foundation/URLComponents.swift
@@ -284,7 +284,7 @@ public struct URLComponents : ReferenceConvertible, Hashable, CustomStringConver
     
     // MARK: - Bridging
     
-    private init(reference: NSURLComponents) {
+    fileprivate init(reference: NSURLComponents) {
         _handle = _MutableHandle(reference: reference)
     }
     
@@ -300,13 +300,13 @@ public func ==(lhs: URLComponents, rhs: URLComponents) -> Bool {
 public struct URLQueryItem : ReferenceConvertible, Hashable, Equatable, CustomStringConvertible {
     public typealias ReferenceType = NSURLQueryItem
     
-    private var _queryItem : NSURLQueryItem
+    fileprivate var _queryItem : NSURLQueryItem
     
     public init(name: String, value: String?) {
         _queryItem = NSURLQueryItem(name: name, value: value)
     }
     
-    private init(reference: NSURLQueryItem) { _queryItem = reference.copy() as! NSURLQueryItem }
+    fileprivate init(reference: NSURLQueryItem) { _queryItem = reference.copy() as! NSURLQueryItem }
     private var reference : NSURLQueryItem { return _queryItem }
     
     public var name : String {

--- a/Foundation/URLRequest.swift
+++ b/Foundation/URLRequest.swift
@@ -37,7 +37,7 @@ public struct URLRequest : ReferenceConvertible, CustomStringConvertible, Equata
         _handle = _MutableHandle(adoptingReference: NSMutableURLRequest(url: url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval))
     }
     
-    private init(_bridged request: NSURLRequest) {
+    fileprivate init(_bridged request: NSURLRequest) {
         _handle = _MutableHandle(reference: request.mutableCopy() as! NSMutableURLRequest)
     }
     


### PR DESCRIPTION
[SE-0025](https://github.com/apple/swift-evolution/blob/master/proposals/0025-scoped-access-level.md) makes `private` restrict access to a lexical scope; the Swift 2 behavior is now named `fileprivate`. At the time of this pull request, the compiler treats both `private` and `fileprivate` as having `fileprivate` semantics, but that will soon change.

Supersedes #413; the latest amendment to SE-0025 permits some accesses that the original model (or at least our interpretation of it) would have forbidden. This was done by hand, so it's possible I missed a few cases, but it's at least a smaller diff.