### PR TITLE
Rename *LiteralConvertible conformances to ExpressibleBy*Literal

### DIFF
--- a/Foundation/IndexPath.swift
+++ b/Foundation/IndexPath.swift
@@ -18,7 +18,7 @@
  
  Each index in an index path represents the index into an array of children from one node in the tree to another, deeper, node.
  */
-public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableCollection, RandomAccessCollection, Comparable, ArrayLiteralConvertible {
+public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableCollection, RandomAccessCollection, Comparable, ExpressibleByArrayLiteral {
     public typealias ReferenceType = NSIndexPath
     public typealias Element = Int
     public typealias Index = Array<Int>.Index

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -679,7 +679,7 @@ extension NSMutableDictionary {
     public convenience init(sharedKeySet keyset: AnyObject) { NSUnimplemented() }
 }
 
-extension NSDictionary : DictionaryLiteralConvertible { }
+extension NSDictionary : ExpressibleByDictionaryLiteral { }
 
 extension Dictionary : Bridgeable {
     public func bridge() -> NSDictionary { return _nsObject }

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -130,7 +130,7 @@ extension Bool : _CFBridgable {
     }
 }
 
-extension NSNumber : FloatLiteralConvertible, IntegerLiteralConvertible, BooleanLiteralConvertible {
+extension NSNumber : ExpressibleByFloatLiteral, ExpressibleByIntegerLiteral, ExpressibleByBooleanLiteral {
 
 }
 

--- a/Foundation/NSObject.swift
+++ b/Foundation/NSObject.swift
@@ -30,7 +30,7 @@ extension NSObjectProtocol {
     }
 }
 
-public struct NSZone : NilLiteralConvertible {
+public struct NSZone : ExpressibleByNilLiteral {
     public init() {
         
     }

--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -8,7 +8,7 @@
 //
 
 /****************       Immutable Ordered Set   ****************/
-public class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, ArrayLiteralConvertible {
+public class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, ExpressibleByArrayLiteral {
     internal var _storage: Set<NSObject>
     internal var _orderedStorage: [NSObject]
     

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -12,7 +12,7 @@ import CoreFoundation
 
 public typealias unichar = UInt16
 
-extension unichar : UnicodeScalarLiteralConvertible {
+extension unichar : ExpressibleByUnicodeScalarLiteral {
     public typealias UnicodeScalarLiteralType = UnicodeScalar
     
     public init(unicodeScalarLiteral scalar: UnicodeScalar) {
@@ -1290,7 +1290,7 @@ extension NSString {
     }
 }
 
-extension NSString : StringLiteralConvertible { }
+extension NSString : ExpressibleByStringLiteral { }
 
 public class NSMutableString : NSString {
     public func replaceCharacters(in range: NSRange, with aString: String) {


### PR DESCRIPTION
In accordance with SE-0115 and apple/swift#3474.