### PR TITLE
Rename Process to CommandLine

### DIFF
--- a/Foundation/NSProcessInfo.swift
+++ b/Foundation/NSProcessInfo.swift
@@ -59,7 +59,7 @@ public class ProcessInfo: NSObject {
     }
     
     public var arguments: [String] {
-        return Process.arguments // seems reasonable to flip the script here...
+        return CommandLine.arguments // seems reasonable to flip the script here...
     }
     
     public var hostName: String {


### PR DESCRIPTION
As part of [SE-0086](https://github.com/apple/swift-evolution/blob/master/proposals/0086-drop-foundation-ns.md), we decided to rename the `NSTask` class to `Process`. This PR changes `Swift.Process` to `Swift.CommandLine` to make that possible.

See [Swift PR 3598](https://github.com/apple/swift/pull/3598).