### PR TITLE
Attempt to address test resilience issue

### DIFF
--- a/TestFoundation/TestNSTask.swift
+++ b/TestFoundation/TestNSTask.swift
@@ -145,7 +145,7 @@ class TestNSTask : XCTestCase {
             XCTFail("Could not read stdout")
             return
         }
-        XCTAssertEqual(string, "/usr/bin/which\n")
+        XCTAssertTrue(string.hasSuffix("/which\n"))
     }
 
     func test_pipe_stderr() {
@@ -211,7 +211,7 @@ class TestNSTask : XCTestCase {
                 XCTFail("Could not read stdout")
                 return
             }
-            XCTAssertEqual(string, "/usr/bin/which\n")
+            XCTAssertTrue(string.hasSuffix("/which\n"))
         }
     }
     


### PR DESCRIPTION
Please see [this note](https://github.com/apple/swift-corelibs-foundation/commit/afe26ffcb53525e6fdc9a758d571a86702542127#commitcomment-18298543).  This is a rough fix; I don't have confidence that the test's overall approach won't fail in some environments even with this change, but it should work in more places.