### PR TITLE
[SR-2133] archive to streams in XML, not OpenStep, format

### DIFF
--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -193,7 +193,7 @@ public class NSKeyedArchiver : NSCoder {
             }
         } else {
             success = CFPropertyListWrite(plist, self._stream as! CFWriteStream,
-                                          kCFPropertyListOpenStepFormat, 0, nil) > 0
+                                          kCFPropertyListXMLFormat_v1_0, 0, nil) > 0
         }
         
         return success


### PR DESCRIPTION
_Note: I have not had a chance to test this fix, I just noticed it whilst glancing through the code recently._

_writeXMLData() in NSKeyedArchiver invokes CFPropertyListWrite() with kCFPropertyListOpenStepFormat, which not only does not make sense (given the name of the calling function) but will also assert fail in CF. Presumably it should be changed to kCFPropertyListXMLFormat_v1_0.