### PR TITLE
[SE-0121] remove uses of optional comparison operators

### DIFF
--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -831,8 +831,8 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
         let comp2 = components(reducedUnits, from: date2)!
     
         for unit in units {
-            let value1 = comp1.value(forComponent: unit)
-            let value2 = comp2.value(forComponent: unit)
+            let value1 = comp1.value(forComponent: unit)!
+            let value2 = comp2.value(forComponent: unit)!
             if value1 > value2 {
                 return .orderedDescending
             } else if value1 < value2 {


### PR DESCRIPTION
These operators will be removed as part of SE-0121 and apple/swift#3637.

This use site was discovered by CI: https://ci.swift.org/job/swift-PR-Linux/2900/console