### PR TITLE
implementation for NSURLComponents.copy(with:)

### DIFF
--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -929,9 +929,49 @@ open class NSURLComponents: NSObject, NSCopying {
     open override func copy() -> Any {
         return copy(with: nil)
     }
-    
+
+    open override func isEqual(_ object: Any?) -> Bool {
+        if let other = object as? NSURLComponents {
+            if scheme != other.scheme {
+                return false
+            }
+            if user != other.user {
+                return false
+            }
+            if password != other.password {
+                return false
+            }
+            if host != other.host {
+                return false
+            }
+            if port != other.port {
+                return false
+            }
+            if path != other.path {
+                return false
+            }
+            if query != other.query {
+                return false
+            }
+            if fragment != other.fragment {
+                return false
+            }
+            return true
+        }
+        return false
+    }
+
     open func copy(with zone: NSZone? = nil) -> Any {
-        NSUnimplemented()
+        let copy = NSURLComponents()
+        copy.scheme = self.scheme
+        copy.user = self.user
+        copy.password = self.password
+        copy.host = self.host
+        copy.port = self.port
+        copy.path = self.path
+        copy.query = self.query
+        copy.fragment = self.fragment
+        return copy
     }
     
     // Initialize a NSURLComponents with the components of a URL. If resolvingAgainstBaseURL is YES and url is a relative URL, the components of [url absoluteURL] are used. If the url string from the NSURL is malformed, nil is returned.

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -421,6 +421,7 @@ class TestNSURLComponents : XCTestCase {
             ("test_string", test_string),
             ("test_port", test_portSetter),
             ("test_url", test_url),
+            ("test_copy", test_copy)
         ]
     }
     
@@ -485,5 +486,17 @@ class TestNSURLComponents : XCTestCase {
 
         aURL = compWithoutAuthority.url(relativeTo: baseURL)
         XCTAssertNil(aURL) //must be nil
+    }
+
+    func test_copy() {
+        let urlString = "https://www.swift.org/path/to/file.html?id=name"
+        let urlComponent = NSURLComponents(string: urlString)!
+        let copy = urlComponent.copy() as! NSURLComponents
+
+        /* Assert that NSURLComponents.copy did not return self */
+        XCTAssertFalse(copy === urlComponent)
+
+        /* Assert that NSURLComponents.copy is actually a copy of NSURLComponents */ 
+        XCTAssertTrue(copy.isEqual(urlComponent))
     }
 }


### PR DESCRIPTION
This PR has following:

1. Implementation for NSURLComponents.copy(with:). Approach is to create default NSURLComponent and update fields one by one.

2. Override isEqual() function. Since copy is not 'self', it is required to override isEqual to compare properties instead of object references. 

3. Unit test for copy(). I've used NSURLComponents class in testcase instead of URLComponents structure because it doesn't have mapping for copy() function.

