### PR TITLE
[SE-0121] remove use of optional comparison operators

### DIFF
--- a/Foundation/IndexSet.swift
+++ b/Foundation/IndexSet.swift
@@ -432,12 +432,12 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     ///
     /// - parameter range: The range of integers to include.
     public func indexRange(in range: Range<Element>) -> Range<Index> {
-        if range.isEmpty {
+        if isEmpty || range.isEmpty {
             let i = Index(indexSet: self, index: 0)
             return i..<i
         }
         
-        if range.lowerBound > last || (range.upperBound - 1) < first {
+        if range.lowerBound > last! || (range.upperBound - 1) < first! {
             let i = Index(indexSet: self, index: 0)
             return i..<i
         }


### PR DESCRIPTION
Found another. These things are out to get me.  for https://github.com/apple/swift/pull/3637