### PR TITLE
Changes for SE-0125: Remove NonObjectiveCBase and isUniquelyReferenced

### DIFF
--- a/Foundation/Boxing.swift
+++ b/Foundation/Boxing.swift
@@ -52,7 +52,7 @@ extension _MutableBoxing {
     @inline(__always)
     mutating func _applyMutation<ReturnType>(_ whatToDo : @noescape(ReferenceType) -> ReturnType) -> ReturnType {
         // Only create a new box if we are not uniquely referenced
-        if !isUniquelyReferencedNonObjC(&_handle) {
+        if !isKnownUniquelyReferenced(&_handle) {
             let ref = _handle._pointer
             _handle = _MutableHandle(reference: ref)
         }
@@ -185,7 +185,7 @@ extension _MutablePairBoxing {
         case .Immutable(_):
             break
         case .Mutable(_):
-            unique = isUniquelyReferencedNonObjC(&_wrapped)
+            unique = isKnownUniquelyReferenced(&_wrapped)
         }
         
         switch (wrapper) {

--- a/Foundation/IndexSet.swift
+++ b/Foundation/IndexSet.swift
@@ -678,7 +678,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
             return result
         case .Mutable(let m):
             // Only create a new box if we are not uniquely referenced
-            if !isUniquelyReferencedNonObjC(&_handle) {
+            if !isKnownUniquelyReferenced(&_handle) {
                 let copy = m.mutableCopy(with: nil) as! NSMutableIndexSet
                 _handle = _MutablePairHandle(copy, copying: false)
                 let result = try whatToDo(copy)

--- a/Foundation/URLRequest.swift
+++ b/Foundation/URLRequest.swift
@@ -22,7 +22,7 @@ public struct URLRequest : ReferenceConvertible, CustomStringConvertible, Equata
     internal var _handle: _MutableHandle<NSMutableURLRequest>
     
     internal mutating func _applyMutation<ReturnType>(_ whatToDo : @noescape (NSMutableURLRequest) -> ReturnType) -> ReturnType {
-        if !isUniquelyReferencedNonObjC(&_handle) {
+        if !isKnownUniquelyReferenced(&_handle) {
             let ref = _handle._uncopiedReference()
             _handle = _MutableHandle(reference: ref)
         }


### PR DESCRIPTION
The API calls to `isUniquelyReferencedNonObjC` need to be replace by the new API call `isKnownUniquelyReferenced `.

This needs to be merge in sync with the stdlib changes for SE-0125 in apple/swift#3638