### PR TITLE
Strings: make the assembly slightly more portable

### DIFF
--- a/CoreFoundation/Base.subproj/CFAsmMacros.h
+++ b/CoreFoundation/Base.subproj/CFAsmMacros.h
@@ -1,0 +1,18 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+#if !defined(__COREFOUNDATION_CFASMMACROS__)
+#define __COREFOUNDATION_CFASMMACROS__ 1
+
+#define CONCAT(a,b) a##b
+#define CONCAT_EXPANDED(a,b) CONCAT(a,b)
+#define _C_LABEL(name) CONCAT_EXPANDED(__USER_LABEL_PREFIX__,name)
+
+#endif
+

--- a/CoreFoundation/String.subproj/CFCharacterSetData.S
+++ b/CoreFoundation/String.subproj/CFCharacterSetData.S
@@ -7,14 +7,16 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-    .global __CFCharacterSetBitmapData
-__CFCharacterSetBitmapData:
+#include <CoreFoundation/CFAsmMacros.h>
+
+    .global _C_LABEL(__CFCharacterSetBitmapData)
+_C_LABEL(__CFCharacterSetBitmapData):
     .incbin "CoreFoundation/CharacterSets/CFCharacterSetBitmaps.bitmap"
 
-    .global __CFCharacterSetBitmapDataEnd
-__CFCharacterSetBitmapDataEnd:
+    .global _C_LABEL(__CFCharacterSetBitmapDataEnd)
+_C_LABEL(__CFCharacterSetBitmapDataEnd):
     .byte 0
 
-    .global __CFCharacterSetBitmapDataSize
-__CFCharacterSetBitmapDataSize:
-    .int __CFCharacterSetBitmapDataEnd - __CFCharacterSetBitmapData
+    .global _C_LABEL(__CFCharacterSetBitmapDataSize)
+_C_LABEL(__CFCharacterSetBitmapDataSize):
+    .int _C_LABEL(__CFCharacterSetBitmapDataEnd) - _C_LABEL(__CFCharacterSetBitmapData)

--- a/CoreFoundation/String.subproj/CFUniCharPropertyDatabase.S
+++ b/CoreFoundation/String.subproj/CFUniCharPropertyDatabase.S
@@ -7,14 +7,16 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-    .global __CFUniCharPropertyDatabase
-__CFUniCharPropertyDatabase:
+#include <CoreFoundation/CFAsmMacros.h>
+
+    .global _C_LABEL(__CFUniCharPropertyDatabase)
+_C_LABEL(__CFUniCharPropertyDatabase):
     .incbin "CoreFoundation/CharacterSets/CFUniCharPropertyDatabase.data"
 
-    .global __CFUniCharPropertyDatabaseEnd
-__CFUniCharPropertyDatabaseEnd:
+    .global _C_LABEL(__CFUniCharPropertyDatabaseEnd)
+_C_LABEL(__CFUniCharPropertyDatabaseEnd):
     .byte 0
 
-    .global __CFUniCharPropertyDatabaseSize
-__CFUniCharPropertyDatabaseSize:
-    .int __CFUniCharPropertyDatabaseEnd - __CFUniCharPropertyDatabase
+    .global _C_LABEL(__CFUniCharPropertyDatabaseSize)
+_C_LABEL(__CFUniCharPropertyDatabaseSize):
+    .int _C_LABEL(__CFUniCharPropertyDatabaseEnd) - _C_LABEL(__CFUniCharPropertyDatabase)

--- a/CoreFoundation/String.subproj/CFUnicodeData.S
+++ b/CoreFoundation/String.subproj/CFUnicodeData.S
@@ -7,28 +7,30 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#include <CoreFoundation/CFAsmMacros.h>
+
 #if defined(__BIG_ENDIAN__)
-    .global __CFUnicodeDataB
-__CFUnicodeDataB:
+    .global _C_LABEL(__CFUnicodeDataB)
+_C_LABEL(__CFUnicodeDataB):
     .incbin "CoreFoundation/CharacterSets/CFUnicodeData-B.mapping"
 
-    .global __CFUnicodeDataBEnd
-__CFUnicodeDataBEnd:
+    .global _C_LABEL(__CFUnicodeDataBEnd)
+_C_LABEL(__CFUnicodeDataBEnd):
     .byte 0
 
-    .global __CFUnicodeDataBSize
-__CFUnicodeDataBSize:
-    .int __CFUnicodeDataBEnd - __CFUnicodeDataB
+    .global _C_LABEL(__CFUnicodeDataBSize)
+_C_LABEL(__CFUnicodeDataBSize):
+    .int _C_LABEL(__CFUnicodeDataBEnd) - _C_LABEL(__CFUnicodeDataB)
 #else
-    .global __CFUnicodeDataL
-__CFUnicodeDataL:
+    .global _C_LABEL(__CFUnicodeDataL)
+_C_LABEL(__CFUnicodeDataL):
     .incbin "CoreFoundation/CharacterSets/CFUnicodeData-L.mapping"
 
-    .global __CFUnicodeDataLEnd
-__CFUnicodeDataLEnd:
+    .global _C_LABEL(__CFUnicodeDataLEnd)
+_C_LABEL(__CFUnicodeDataLEnd):
     .byte 0
 
-    .global __CFUnicodeDataLSize
-__CFUnicodeDataLSize:
-    .int __CFUnicodeDataLEnd - __CFUnicodeDataL
+    .global _C_LABEL(__CFUnicodeDataLSize)
+_C_LABEL(__CFUnicodeDataLSize):
+    .int _C_LABEL(__CFUnicodeDataLEnd) - _C_LABEL(__CFUnicodeDataL)
 #endif

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -367,6 +367,7 @@
 		EADE0BCB1BD15E0000C49C64 /* NSXMLNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B8D1BD15DFF00C49C64 /* NSXMLNode.swift */; };
 		EADE0BCC1BD15E0000C49C64 /* NSXMLNodeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B8E1BD15DFF00C49C64 /* NSXMLNodeOptions.swift */; };
 		EADE0BCD1BD15E0000C49C64 /* NSXMLParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B8F1BD15DFF00C49C64 /* NSXMLParser.swift */; };
+		F03A43181D4877DD00A7791E /* CFAsmMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = F03A43161D48778200A7791E /* CFAsmMacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F9E0BB371CA70B8000F7FF3C /* TestNSURLCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E0BB361CA70B8000F7FF3C /* TestNSURLCredential.swift */; };
 /* End PBXBuildFile section */
 
@@ -798,6 +799,7 @@
 		EADE0B8D1BD15DFF00C49C64 /* NSXMLNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSXMLNode.swift; sourceTree = "<group>"; };
 		EADE0B8E1BD15DFF00C49C64 /* NSXMLNodeOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSXMLNodeOptions.swift; sourceTree = "<group>"; };
 		EADE0B8F1BD15DFF00C49C64 /* NSXMLParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSXMLParser.swift; sourceTree = "<group>"; };
+		F03A43161D48778200A7791E /* CFAsmMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFAsmMacros.h; sourceTree = "<group>"; };
 		F9E0BB361CA70B8000F7FF3C /* TestNSURLCredential.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSURLCredential.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -880,6 +882,7 @@
 		5B5D88711BBC951A00234F36 /* Base */ = {
 			isa = PBXGroup;
 			children = (
+				F03A43161D48778200A7791E /* CFAsmMacros.h */,
 				5BDC3F721BCC60EF00ED97BB /* module.modulemap */,
 				5B5D88741BBC954000234F36 /* CFAvailability.h */,
 				5B5D895D1BBDABBF00234F36 /* CFBase.c */,
@@ -1643,6 +1646,7 @@
 				5B7C8AD51BEA80FC00C5B690 /* CFBundle.h in Headers */,
 				5B6228C11C17905B009587FE /* CFAttributedString.h in Headers */,
 				5B7C8AE21BEA80FC00C5B690 /* CFURLAccess.h in Headers */,
+				F03A43181D4877DD00A7791E /* CFAsmMacros.h in Headers */,
 				5B7C8ACA1BEA80FC00C5B690 /* CFError.h in Headers */,
 				5B7C8AE91BEA81AC00C5B690 /* CFLocaleInternal.h in Headers */,
 				5B7C8AE61BEA81AC00C5B690 /* ForSwiftFoundationOnly.h in Headers */,

--- a/build.py
+++ b/build.py
@@ -137,6 +137,7 @@ public = [
 private = [
 	'CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h',
 	'CoreFoundation/Base.subproj/ForFoundationOnly.h',
+	'CoreFoundation/Base.subproj/CFAsmMacros.h',
 	'CoreFoundation/String.subproj/CFBurstTrie.h',
 	'CoreFoundation/Error.subproj/CFError_Private.h',
 	'CoreFoundation/URL.subproj/CFURLPriv.h',

--- a/lib/phases.py
+++ b/lib/phases.py
@@ -139,6 +139,12 @@ class Assemble(CompileSource):
         generated = """
 build """ + self.output.relative() + """: Assemble """ + self.path.relative() + self.generate_dependencies() + """
     flags = """
+        generated += " -I" + Configuration.current.build_directory.path_by_appending(self.product.name).relative()
+        generated += " -I" + Configuration.current.build_directory.relative()
+        generated += " -I" + Configuration.current.build_directory.path_by_appending(self.product.name).relative() + self.product.ROOT_HEADERS_FOLDER_PATH
+        generated += " -I" + Configuration.current.build_directory.path_by_appending(self.product.name).relative() + self.product.PUBLIC_HEADERS_FOLDER_PATH
+        generated += " -I" + Configuration.current.build_directory.path_by_appending(self.product.name).relative() + self.product.PRIVATE_HEADERS_FOLDER_PATH
+        generated += " -I" + Configuration.current.build_directory.path_by_appending(self.product.name).relative() + self.product.PROJECT_HEADERS_FOLDER_PATH
         asflags = TargetConditional.value(self.product.ASFLAGS)
         if asflags is not None:
             generated += " " + asflags


### PR DESCRIPTION
This ensures that we get the user label prefix correct for the references to the
symbol in the rest of CoreFoundation.