### PR TITLE
Reserve capacity when creating the storage Dictionary for NSDictionary.

### DIFF
--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -84,7 +84,7 @@ extension Dictionary : _ObjectTypeBridgeable {
 
 open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCoding {
     private let _cfinfo = _CFInfo(typeID: CFDictionaryGetTypeID())
-    internal var _storage = [NSObject: AnyObject]()
+    internal var _storage: [NSObject: AnyObject]
     
     open var count: Int {
         guard type(of: self) === NSDictionary.self || type(of: self) === NSMutableDictionary.self else {
@@ -112,6 +112,8 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     }
     
     public required init(objects: UnsafePointer<AnyObject>, forKeys keys: UnsafePointer<NSObject>, count cnt: Int) {
+        _storage = [NSObject: AnyObject](minimumCapacity: cnt)
+        
         for idx in 0..<cnt {
             let key = keys[idx].copy()
             let value = objects[idx]
@@ -586,6 +588,9 @@ open class NSMutableDictionary : NSDictionary {
     
     public convenience init(capacity numItems: Int) {
         self.init(objects: [], forKeys: [], count: 0)
+        
+        // It is safe to reset the storage here because we know is empty
+        _storage = [NSObject: AnyObject](minimumCapacity: numItems)
     }
     
     public required init(objects: UnsafePointer<AnyObject>, forKeys keys: UnsafePointer<NSObject>, count cnt: Int) {


### PR DESCRIPTION
The allocation of `NSDictionary` will now make use of the capacity and count parameters provided in the constructors.

For `NSMutableDictionary`'s `init(capacity:)` we need to reinstantiate the storage with a new `minimumCapacity` due to the lack of a `reserveCapacity` instance method like the one that `Array` provides.

An option considered was to change the required initializer of `NSDictionary` to a method that creates the underlying `Array` with the desired capacity, but this won't make any sense in the immutable `NSDictionary` context.