### PR TITLE
Update for SE-0107: Migrate Void->Raw.

### DIFF
--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -16,11 +16,11 @@ import Darwin
 import Glibc
 #endif
 
-internal func __NSDataInvokeDeallocatorUnmap(_ mem: UnsafeMutablePointer<Void>, _ length: Int) -> Void {
+internal func __NSDataInvokeDeallocatorUnmap(_ mem: UnsafeMutableRawPointer, _ length: Int) -> Void {
     munmap(mem, length)
 }
 
-internal func __NSDataInvokeDeallocatorFree(_ mem: UnsafeMutablePointer<Void>, _ length: Int) -> Void {
+internal func __NSDataInvokeDeallocatorFree(_ mem: UnsafeMutableRawPointer, _ length: Int) -> Void {
     free(mem)
 }
 
@@ -34,14 +34,14 @@ internal final class _SwiftNSData : NSData, _SwiftNativeFoundationType {
         // Take ownership.
         __wrapped = .Immutable(Unmanaged.passRetained(_unsafeReferenceCast(immutableObject, to: ImmutableType.self)))
         
-        let dummyPointer = unsafeBitCast(NSData.self, to: UnsafeMutablePointer<Void>.self)
+        let dummyPointer = unsafeBitCast(NSData.self, to: UnsafeMutableRawPointer.self)
         super.init(bytes: dummyPointer, length: 0, copy: false, deallocator: nil)
     }
     
     init(mutableObject: AnyObject) {
         // Take ownership.
         __wrapped = .Mutable(Unmanaged.passRetained(_unsafeReferenceCast(mutableObject, to: MutableType.self)))
-        let dummyPointer = unsafeBitCast(NSData.self, to: UnsafeMutablePointer<Void>.self)
+        let dummyPointer = unsafeBitCast(NSData.self, to: UnsafeMutableRawPointer.self)
         super.init(bytes: dummyPointer, length: 0, copy: false, deallocator: nil)
     }
     
@@ -49,7 +49,7 @@ internal final class _SwiftNSData : NSData, _SwiftNativeFoundationType {
         // Take ownership.
         __wrapped = .Immutable(unmanagedImmutableObject)
         
-        let dummyPointer = unsafeBitCast(NSData.self, to: UnsafeMutablePointer<Void>.self)
+        let dummyPointer = unsafeBitCast(NSData.self, to: UnsafeMutableRawPointer.self)
         super.init(bytes: dummyPointer, length: 0, copy: false, deallocator: nil)
     }
     
@@ -57,7 +57,7 @@ internal final class _SwiftNSData : NSData, _SwiftNativeFoundationType {
         // Take ownership.
         __wrapped = .Mutable(unmanagedMutableObject)
         
-        let dummyPointer = unsafeBitCast(NSData.self, to: UnsafeMutablePointer<Void>.self)
+        let dummyPointer = unsafeBitCast(NSData.self, to: UnsafeMutableRawPointer.self)
         super.init(bytes: dummyPointer, length: 0, copy: false, deallocator: nil)
     }
     
@@ -82,7 +82,7 @@ internal final class _SwiftNSData : NSData, _SwiftNativeFoundationType {
         }
     }
     
-    override var bytes : UnsafePointer<Void> {
+    override var bytes : UnsafeRawPointer {
         return _mapUnmanaged { $0.bytes }
     }
     
@@ -90,11 +90,11 @@ internal final class _SwiftNSData : NSData, _SwiftNativeFoundationType {
 //        return _mapUnmanaged { $0.subdata(with: range) }
 //    }
 //    
-//    override func getBytes(_ buffer: UnsafeMutablePointer<Void>, length: Int) {
+//    override func getBytes(_ buffer: UnsafeMutableRawPointer, length: Int) {
 //        return _mapUnmanaged { $0.getBytes(buffer, length: length) }
 //    }
 //    
-//    override func getBytes(_ buffer: UnsafeMutablePointer<Void>, range: NSRange) {
+//    override func getBytes(_ buffer: UnsafeMutableRawPointer, range: NSRange) {
 //        return _mapUnmanaged { $0.getBytes(buffer, range: range) }
 //    }
 //    
@@ -112,7 +112,7 @@ internal final class _SwiftNSData : NSData, _SwiftNativeFoundationType {
 //        }
 //    }
 //    
-//    override func enumerateByteRanges(using block: @noescape (UnsafePointer<Void>, NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
+//    override func enumerateByteRanges(using block: @noescape (UnsafeRawPointer, NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
 //        return _mapUnmanaged { $0.enumerateBytes(block) }
 //    }
 //    
@@ -163,7 +163,7 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
         /// A custom deallocator.
         case custom((UnsafeMutablePointer<UInt8>, Int) -> Void)
         
-        fileprivate var _deallocator : ((UnsafeMutablePointer<Void>, Int) -> Void)? {
+        fileprivate var _deallocator : ((UnsafeMutableRawPointer, Int) -> Void)? {
             switch self {
             case .unmap:
                 return { __NSDataInvokeDeallocatorUnmap($0, $1) }
@@ -186,7 +186,7 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
     ///
     /// - parameter bytes: A pointer to the memory. It will be copied.
     /// - parameter count: The number of bytes to copy.
-    public init(bytes: UnsafePointer<Void>, count: Int) {
+    public init(bytes: UnsafeRawPointer, count: Int) {
         _wrapped = _SwiftNSData(immutableObject: NSData(bytes: bytes, length: count))
     }
     
@@ -279,8 +279,8 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
     }
 
     public init?(count: Int) {
-        if let memory = malloc(count) {
-            self.init(bytesNoCopy: UnsafeMutablePointer<UInt8>(memory), count: count, deallocator: .free)
+        if let memory = malloc(count)?.bindMemory(to: UInt8.self, capacity: count) {
+            self.init(bytesNoCopy: memory, count: count, deallocator: .free)
         } else {
             return nil
         }
@@ -304,7 +304,7 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
         }
     }
     
-    private func _getUnsafeBytesPointer() -> UnsafePointer<Void> {
+    private func _getUnsafeBytesPointer() -> UnsafeRawPointer {
         return _mapUnmanaged { return $0.bytes }
     }
     
@@ -314,10 +314,11 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
     public func withUnsafeBytes<ResultType, ContentType>(_ body: @noescape (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
         let bytes =  _getUnsafeBytesPointer()
         defer { _fixLifetime(self)}
-        return try body(UnsafePointer(bytes))
+        let contentPtr = bytes.bindMemory(to: ContentType.self, capacity: count / strideof(ContentType.self))
+        return try body(contentPtr)
     }
     
-    private mutating func _getUnsafeMutableBytesPointer() -> UnsafeMutablePointer<Void> {
+    private mutating func _getUnsafeMutableBytesPointer() -> UnsafeMutableRawPointer {
         return _applyUnmanagedMutation {
             return $0.mutableBytes
         }
@@ -330,7 +331,8 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
     public mutating func withUnsafeMutableBytes<ResultType, ContentType>(_ body: @noescape (UnsafeMutablePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
         let mutableBytes = _getUnsafeMutableBytesPointer()
         defer { _fixLifetime(self)}
-        return try body(UnsafeMutablePointer(mutableBytes))
+        let contentPtr = mutableBytes.bindMemory(to: ContentType.self, capacity: count / strideof(ContentType.self))
+        return try body(contentPtr)
     }
     
     // MARK: -

--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -173,7 +173,8 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
                 return nil
             case .custom(let b):
                 return { (ptr, len) in
-                    b(UnsafeMutablePointer<UInt8>(ptr), len)
+                    let bytePtr = ptr.bindMemory(to: UInt8.self, capacity: len)
+                    b(bytePtr, len)
                 }
             }
         }
@@ -439,7 +440,8 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
         _mapUnmanaged {
             $0.enumerateBytes { (ptr, range, stop) in
                 var stopv = false
-                block(buffer: UnsafeBufferPointer(start: UnsafePointer<UInt8>(ptr), count: range.length), byteIndex: range.length, stop: &stopv)
+                let bytePtr = ptr.bindMemory(to: UInt8.self, capacity: range.length)
+                block(buffer: UnsafeBufferPointer(start: bytePtr, count: range.length), byteIndex: range.length, stop: &stopv)
                 if stopv {
                     stop.pointee = true
                 }

--- a/Foundation/IndexPath.swift
+++ b/Foundation/IndexPath.swift
@@ -158,7 +158,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
         if count == 0 {
             _indexes = []
         } else {
-            var ptr = UnsafeMutablePointer<Element>(malloc(count * sizeof(Element.self)))
+            var ptr = malloc(count * sizeof(Element.self))?.bindMemory(to: Element.self, capacity: count * sizeof(Element.self))
             defer { free(ptr) }
             
             nsIndexPath.getIndexes(ptr!, range: NSMakeRange(0, count))

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -70,7 +70,7 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
             // because that's the way the code was originally written, unless
             // we go to a new version of the class, which has its own problems.
             withUnsafeMutablePointer(&cnt) { (ptr: UnsafeMutablePointer<UInt32>) -> Void in
-                aDecoder.decodeValue(ofObjCType: "i", at: UnsafeMutablePointer<Void>(ptr))
+                aDecoder.decodeValue(ofObjCType: "i", at: UnsafeMutableRawPointer(ptr))
             }
             let objects = UnsafeMutablePointer<AnyObject?>.allocate(capacity: Int(cnt))
             for idx in 0..<cnt {
@@ -388,13 +388,13 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         }))
     }
     
-    public func sortedArray(_ comparator: @noescape @convention(c) (AnyObject, AnyObject, UnsafeMutablePointer<Swift.Void>?) -> Int, context: UnsafeMutablePointer<Swift.Void>?) -> [AnyObject] {
+    public func sortedArray(_ comparator: @noescape @convention(c) (AnyObject, AnyObject, UnsafeMutableRawPointer?) -> Int, context: UnsafeMutableRawPointer?) -> [AnyObject] {
         return sortedArray([]) { lhs, rhs in
             return ComparisonResult(rawValue: comparator(lhs, rhs, context))!
         }
     }
     
-    public func sortedArray(_ comparator: @noescape @convention(c) (AnyObject, AnyObject, UnsafeMutablePointer<Swift.Void>?) -> Int, context: UnsafeMutablePointer<Swift.Void>?, hint: Data?) -> [AnyObject] {
+    public func sortedArray(_ comparator: @noescape @convention(c) (AnyObject, AnyObject, UnsafeMutableRawPointer?) -> Int, context: UnsafeMutableRawPointer?, hint: Data?) -> [AnyObject] {
         return sortedArray([]) { lhs, rhs in
             return ComparisonResult(rawValue: comparator(lhs, rhs, context))!
         }
@@ -834,7 +834,7 @@ public class NSMutableArray : NSArray {
         }
     }
 
-    public func sortUsingFunction(_ compare: @convention(c) (AnyObject, AnyObject, UnsafeMutablePointer<Void>?) -> Int, context: UnsafeMutablePointer<Void>?) {
+    public func sortUsingFunction(_ compare: @convention(c) (AnyObject, AnyObject, UnsafeMutableRawPointer?) -> Int, context: UnsafeMutableRawPointer?) {
         self.setArray(self.sortedArray(compare, context: context))
     }
 

--- a/Foundation/NSCFArray.swift
+++ b/Foundation/NSCFArray.swift
@@ -34,7 +34,7 @@ internal final class _NSCFArray : NSMutableArray {
     }
     
     override func insert(_ anObject: AnyObject, at index: Int) {
-        CFArrayInsertValueAtIndex(_cfMutableObject, index, unsafeBitCast(anObject, to: UnsafePointer<Void>.self))
+        CFArrayInsertValueAtIndex(_cfMutableObject, index, unsafeBitCast(anObject, to: UnsafeRawPointer.self))
     }
     
     override func removeObject(at index: Int) {

--- a/Foundation/NSCFDictionary.swift
+++ b/Foundation/NSCFDictionary.swift
@@ -37,7 +37,7 @@ internal final class _NSCFDictionary : NSMutableDictionary {
     }
     
     override func objectForKey(_ aKey: AnyObject) -> AnyObject? {
-        let value = CFDictionaryGetValue(_cfObject, unsafeBitCast(aKey, to: UnsafePointer<Void>.self))
+        let value = CFDictionaryGetValue(_cfObject, unsafeBitCast(aKey, to: UnsafeRawPointer.self))
         if value != nil {
             return unsafeBitCast(value, to: AnyObject.self)
         } else {
@@ -64,7 +64,7 @@ internal final class _NSCFDictionary : NSMutableDictionary {
             let cf = dict._cfObject
             count = CFDictionaryGetCount(cf)
             
-            let keys = UnsafeMutablePointer<UnsafePointer<Void>?>.allocate(capacity: count)            
+            let keys = UnsafeMutablePointer<UnsafeRawPointer?>.allocate(capacity: count)            
             CFDictionaryGetKeysAndValues(cf, keys, nil)
             
             for idx in 0..<count {
@@ -81,11 +81,11 @@ internal final class _NSCFDictionary : NSMutableDictionary {
     }
 
     override func removeObject(forKey aKey: AnyObject) {
-        CFDictionaryRemoveValue(_cfMutableObject, unsafeBitCast(aKey, to: UnsafePointer<Void>.self))
+        CFDictionaryRemoveValue(_cfMutableObject, unsafeBitCast(aKey, to: UnsafeRawPointer.self))
     }
     
     override func setObject(_ anObject: AnyObject, forKey aKey: NSObject) {
-        CFDictionarySetValue(_cfMutableObject, unsafeBitCast(aKey, to: UnsafePointer<Void>.self), unsafeBitCast(anObject, to: UnsafePointer<Void>.self))
+        CFDictionarySetValue(_cfMutableObject, unsafeBitCast(aKey, to: UnsafeRawPointer.self), unsafeBitCast(anObject, to: UnsafeRawPointer.self))
     }
     
     override var classForCoder: AnyClass {
@@ -152,7 +152,7 @@ internal func _CFSwiftDictionaryGetValuesAndKeys(_ dictionary: AnyObject, valueb
     }
 }
 
-internal func _CFSwiftDictionaryApplyFunction(_ dictionary: AnyObject, applier: @convention(c) (AnyObject, AnyObject, UnsafeMutablePointer<Void>) -> Void, context: UnsafeMutablePointer<Void>) {
+internal func _CFSwiftDictionaryApplyFunction(_ dictionary: AnyObject, applier: @convention(c) (AnyObject, AnyObject, UnsafeMutableRawPointer) -> Void, context: UnsafeMutableRawPointer) {
     (dictionary as! NSDictionary).enumerateKeysAndObjects([]) { key, value, _ in
         applier(key, value, context)
     }

--- a/Foundation/NSCFString.swift
+++ b/Foundation/NSCFString.swift
@@ -59,13 +59,14 @@ internal class _NSCFString : NSMutableString {
 
 internal final class _NSCFConstantString : _NSCFString {
     internal var _ptr : UnsafePointer<UInt8> {
-        let ptr = unsafeAddress(of: self) + sizeof(OpaquePointer.self) + sizeof(Int32.self) + sizeof(Int32.self) + sizeof(_CFInfo.self)
-        return UnsafePointer<UnsafePointer<UInt8>>(ptr).pointee
+        let offset = sizeof(OpaquePointer.self) + sizeof(Int32.self) + sizeof(Int32.self) + sizeof(_CFInfo.self)
+        let ptr = Unmanaged.passUnretained(self).toOpaque()
+        return ptr.load(fromByteOffset: offset, as: UnsafePointer<UInt8>.self)
     }
     internal var _length : UInt32 {
         let offset = sizeof(OpaquePointer.self) + sizeof(Int32.self) + sizeof(Int32.self) + sizeof(_CFInfo.self) + sizeof(UnsafePointer<UInt8>.self)
-        let ptr = unsafeAddress(of: self) + offset
-        return UnsafePointer<UInt32>(ptr).pointee
+        let ptr = Unmanaged.passUnretained(self).toOpaque()
+        return ptr.load(fromByteOffset: offset, as: UInt32.self)
     }
     
     required init(characters: UnsafePointer<unichar>, length: Int) {

--- a/Foundation/NSCache.swift
+++ b/Foundation/NSCache.swift
@@ -22,7 +22,7 @@ public class Cache: NSObject {
         }
     }
     
-    private var _entries = Dictionary<UnsafePointer<Void>, NSCacheEntry>()
+    private var _entries = Dictionary<UnsafeRawPointer, NSCacheEntry>()
     private let _lock = Lock()
     private var _totalCost = 0
     private var _byCost: NSCacheEntry?
@@ -41,7 +41,7 @@ public class Cache: NSObject {
     public func object(forKey key: AnyObject) -> AnyObject? {
         var object: AnyObject?
         
-        let keyRef = unsafeBitCast(key, to: UnsafePointer<Void>.self)
+        let keyRef = unsafeBitCast(key, to: UnsafeRawPointer.self)
         
         _lock.lock()
         if let entry = _entries[keyRef] {
@@ -84,7 +84,7 @@ public class Cache: NSObject {
     }
     
     public func setObject(_ obj: AnyObject, forKey key: AnyObject, cost g: Int) {
-        let keyRef = unsafeBitCast(key, to: UnsafePointer<Void>.self)
+        let keyRef = unsafeBitCast(key, to: UnsafeRawPointer.self)
         
         _lock.lock()
         _totalCost += g
@@ -152,13 +152,13 @@ public class Cache: NSObject {
         
         _lock.lock()
         for entry in toRemove {
-            _entries.removeValue(forKey: unsafeBitCast(entry.key, to: UnsafePointer<Void>.self)) // the cost list is already fixed up in the purge routines
+            _entries.removeValue(forKey: unsafeBitCast(entry.key, to: UnsafeRawPointer.self)) // the cost list is already fixed up in the purge routines
         }
         _lock.unlock()
     }
     
     public func removeObject(forKey key: AnyObject) {
-        let keyRef = unsafeBitCast(key, to: UnsafePointer<Void>.self)
+        let keyRef = unsafeBitCast(key, to: UnsafeRawPointer.self)
         
         _lock.lock()
         if let entry = _entries.removeValue(forKey: keyRef) {

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -100,11 +100,11 @@ extension Calendar {
 public class Calendar: NSObject, NSCopying, NSSecureCoding {
     typealias CFType = CFCalendar
     private var _base = _CFInfo(typeID: CFCalendarGetTypeID())
-    private var _identifier: UnsafeMutablePointer<Void>? = nil
-    private var _locale: UnsafeMutablePointer<Void>? = nil
-    private var _localeID: UnsafeMutablePointer<Void>? = nil
-    private var _tz: UnsafeMutablePointer<Void>? = nil
-    private var _cal: UnsafeMutablePointer<Void>? = nil
+    private var _identifier: UnsafeMutableRawPointer? = nil
+    private var _locale: UnsafeMutableRawPointer? = nil
+    private var _localeID: UnsafeMutableRawPointer? = nil
+    private var _tz: UnsafeMutableRawPointer? = nil
+    private var _cal: UnsafeMutableRawPointer? = nil
     
     internal var _cfObject: CFType {
         return unsafeBitCast(self, to: CFCalendar.self)

--- a/Foundation/NSCharacterSet.swift
+++ b/Foundation/NSCharacterSet.swift
@@ -33,9 +33,9 @@ public class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
     typealias CFType = CFCharacterSet
     private var _base = _CFInfo(typeID: CFCharacterSetGetTypeID())
     private var _hashValue = CFHashCode(0)
-    private var _buffer: UnsafeMutablePointer<Void>? = nil
+    private var _buffer: UnsafeMutableRawPointer? = nil
     private var _length = CFIndex(0)
-    private var _annex: UnsafeMutablePointer<Void>? = nil
+    private var _annex: UnsafeMutableRawPointer? = nil
     
     internal var _cfObject: CFType {
         return unsafeBitCast(self, to: CFType.self)

--- a/Foundation/NSCoder.swift
+++ b/Foundation/NSCoder.swift
@@ -17,16 +17,16 @@ public protocol NSSecureCoding : NSCoding {
 }
 
 public class NSCoder : NSObject {
-    internal var _pendingBuffers = Array<(UnsafeMutablePointer<Void>, Int)>()
+    internal var _pendingBuffers = Array<(UnsafeMutableRawPointer, Int)>()
     
     deinit {
         for buffer in _pendingBuffers {
-            buffer.0.deinitialize()
-            buffer.0.deallocate(capacity: buffer.1)
+            // Cannot deinitialize a pointer to unknown type.
+            buffer.0.deallocate(bytes: buffer.1, alignedTo: alignof(Int.self))
         }
     }
     
-    public func encodeValue(ofObjCType type: UnsafePointer<Int8>, at addr: UnsafePointer<Void>) {
+    public func encodeValue(ofObjCType type: UnsafePointer<Int8>, at addr: UnsafeRawPointer) {
         NSRequiresConcreteImplementation()
     }
     
@@ -34,7 +34,7 @@ public class NSCoder : NSObject {
         NSRequiresConcreteImplementation()
     }
     
-    public func decodeValue(ofObjCType type: UnsafePointer<Int8>, at data: UnsafeMutablePointer<Void>) {
+    public func decodeValue(ofObjCType type: UnsafePointer<Int8>, at data: UnsafeMutableRawPointer) {
         NSRequiresConcreteImplementation()
     }
     
@@ -100,7 +100,7 @@ public class NSCoder : NSObject {
     public func encode(_ object: AnyObject?) {
         var object = object
         withUnsafePointer(&object) { (ptr: UnsafePointer<AnyObject?>) -> Void in
-            encodeValue(ofObjCType: "@", at: unsafeBitCast(ptr, to: UnsafePointer<Void>.self))
+            encodeValue(ofObjCType: "@", at: unsafeBitCast(ptr, to: UnsafeRawPointer.self))
         }
     }
     
@@ -120,18 +120,18 @@ public class NSCoder : NSObject {
         encode(object)
     }
     
-    public func encodeArray(ofObjCType type: UnsafePointer<Int8>, count: Int, at array: UnsafePointer<Void>) {
+    public func encodeArray(ofObjCType type: UnsafePointer<Int8>, count: Int, at array: UnsafeRawPointer) {
         encodeValue(ofObjCType: "[\(count)\(String(cString: type))]", at: array)
     }
     
-    public func encodeBytes(_ byteaddr: UnsafePointer<Void>?, length: Int) {
+    public func encodeBytes(_ byteaddr: UnsafeRawPointer?, length: Int) {
         var newLength = UInt32(length)
         withUnsafePointer(&newLength) { (ptr: UnsafePointer<UInt32>) -> Void in
             encodeValue(ofObjCType: "I", at: ptr)
         }
         var empty: [Int8] = []
         withUnsafePointer(&empty) {
-            encodeArray(ofObjCType: "c", count: length, at: byteaddr ?? UnsafePointer($0))
+            encodeArray(ofObjCType: "c", count: length, at: byteaddr ?? UnsafeRawPointer($0))
         }
     }
     
@@ -142,24 +142,24 @@ public class NSCoder : NSObject {
         
         var obj: AnyObject? = nil
         withUnsafeMutablePointer(&obj) { (ptr: UnsafeMutablePointer<AnyObject?>) -> Void in
-            decodeValue(ofObjCType: "@", at: unsafeBitCast(ptr, to: UnsafeMutablePointer<Void>.self))
+            decodeValue(ofObjCType: "@", at: unsafeBitCast(ptr, to: UnsafeMutableRawPointer.self))
         }
         return obj
     }
     
-    public func decodeArray(ofObjCType itemType: UnsafePointer<Int8>, count: Int, at array: UnsafeMutablePointer<Void>) {
+    public func decodeArray(ofObjCType itemType: UnsafePointer<Int8>, count: Int, at array: UnsafeMutableRawPointer) {
         decodeValue(ofObjCType: "[\(count)\(String(cString: itemType))]", at: array)
     }
    
     /*
     // TODO: This is disabled, as functions which return unsafe interior pointers are inherently unsafe when we have no autorelease pool. 
-    public func decodeBytes(withReturnedLength lengthp: UnsafeMutablePointer<Int>) -> UnsafeMutablePointer<Void>? {
+    public func decodeBytes(withReturnedLength lengthp: UnsafeMutablePointer<Int>) -> UnsafeMutableRawPointer? {
         var length: UInt32 = 0
         withUnsafeMutablePointer(&length) { (ptr: UnsafeMutablePointer<UInt32>) -> Void in
-            decodeValue(ofObjCType: "I", at: unsafeBitCast(ptr, to: UnsafeMutablePointer<Void>.self))
+            decodeValue(ofObjCType: "I", at: unsafeBitCast(ptr, to: UnsafeMutableRawPointer.self))
         }
         // we cannot autorelease here so instead the pending buffers will manage the lifespan of the returned data... this is wasteful but good enough...
-        let result = UnsafeMutablePointer<Void>.allocate(capacity: Int(length))
+        let result = UnsafeMutableRawPointer.allocate(bytes: Int(length), alignedTo: alignof(Int.self))
         decodeValue(ofObjCType: "c", at: result)
         lengthp.pointee = Int(length)
         _pendingBuffers.append((result, Int(length)))

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -61,7 +61,7 @@ extension NSData {
 }
 
 private final class _NSDataDeallocator {
-    var handler: (UnsafeMutablePointer<Void>, Int) -> Void = {_,_ in }
+    var handler: (UnsafeMutableRawPointer, Int) -> Void = {_,_ in }
 }
 
 private let __kCFMutable: CFOptionFlags = 0x01
@@ -77,7 +77,7 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     private var _base = _CFInfo(typeID: CFDataGetTypeID())
     private var _length: CFIndex = 0
     private var _capacity: CFIndex = 0
-    private var _deallocator: UnsafeMutablePointer<Void>? = nil // for CF only
+    private var _deallocator: UnsafeMutableRawPointer? = nil // for CF only
     private var _deallocHandler: _NSDataDeallocator? = _NSDataDeallocator() // for Swift
     private var _bytes: UnsafeMutablePointer<UInt8>? = nil
     
@@ -85,12 +85,13 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         if self.dynamicType === NSData.self || self.dynamicType === NSMutableData.self {
             return unsafeBitCast(self, to: CFType.self)
         } else {
-            return CFDataCreate(kCFAllocatorSystemDefault, UnsafePointer<UInt8>(self.bytes), self.length)
+            let bytePtr = self.bytes.bindMemory(to: UInt8.self, capacity: self.length)
+            return CFDataCreate(kCFAllocatorSystemDefault, bytePtr, self.length)
         }
     }
     
     public override required convenience init() {
-        let dummyPointer = unsafeBitCast(NSData.self, to: UnsafeMutablePointer<Void>.self)
+        let dummyPointer = unsafeBitCast(NSData.self, to: UnsafeMutableRawPointer.self)
         self.init(bytes: dummyPointer, length: 0, copy: false, deallocator: nil)
     }
     
@@ -115,11 +116,12 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         }
     }
     
-    internal init(bytes: UnsafeMutablePointer<Void>?, length: Int, copy: Bool, deallocator: ((UnsafeMutablePointer<Void>, Int) -> Void)?) {
+    internal init(bytes: UnsafeMutableRawPointer?, length: Int, copy: Bool, deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?) {
         super.init()
         let options : CFOptionFlags = (self.dynamicType == NSMutableData.self) ? __kCFMutable | __kCFGrowable : 0x0
+        let bytePtr = bytes?.bindMemory(to: UInt8.self, capacity: length)
         if copy {
-            _CFDataInit(unsafeBitCast(self, to: CFMutableData.self), options, length, UnsafeMutablePointer<UInt8>(bytes), length, false)
+            _CFDataInit(unsafeBitCast(self, to: CFMutableData.self), options, length, bytePtr, length, false)
             if let handler = deallocator {
                 handler(bytes!, length)
             }
@@ -128,7 +130,7 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
                 _deallocHandler!.handler = handler
             }
             // The data initialization should flag that CF should not deallocate which leaves the handler a chance to deallocate instead
-            _CFDataInit(unsafeBitCast(self, to: CFMutableData.self), options | __kCFDontDeallocate, length, UnsafeMutablePointer<UInt8>(bytes), length, true)
+            _CFDataInit(unsafeBitCast(self, to: CFMutableData.self), options | __kCFDontDeallocate, length, bytePtr, length, true)
         }
     }
     
@@ -136,8 +138,8 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         return CFDataGetLength(_cfObject)
     }
 
-    public var bytes: UnsafePointer<Void> {
-        return UnsafePointer<Void>(CFDataGetBytePtr(_cfObject))
+    public var bytes: UnsafeRawPointer {
+        return UnsafeRawPointer(CFDataGetBytePtr(_cfObject))
     }
     
     public override func copy() -> AnyObject {
@@ -153,14 +155,15 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     }
     
     public func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
-        return NSMutableData(bytes: UnsafeMutablePointer<Void>(bytes), length: length, copy: true, deallocator: nil)
+        return NSMutableData(bytes: UnsafeMutableRawPointer(mutating: bytes), length: length, copy: true, deallocator: nil)
     }
 
     public func encode(with aCoder: NSCoder) {
         if let aKeyedCoder = aCoder as? NSKeyedArchiver {
             aKeyedCoder._encodePropertyList(self, forKey: "NS.data")
         } else {
-            aCoder.encodeBytes(UnsafePointer<UInt8>(self.bytes), length: self.length)
+            let bytePtr = self.bytes.bindMemory(to: UInt8.self, capacity: self.length)
+            aCoder.encodeBytes(bytePtr, length: self.length)
         }
     }
     
@@ -193,7 +196,6 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     
     private func byteDescription(limit: Int? = nil) -> String {
         var s = ""
-        let buffer = UnsafePointer<UInt8>(bytes)
         var i = 0
         while i < self.length {
             if i > 0 && i % 4 == 0 {
@@ -201,7 +203,7 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
                 if let limit = limit where self.length > limit && i == self.length - (limit / 2) { /* do nothing */ }
                 else { s += " " }
             }
-            let byte = buffer[i]
+            let byte = bytes.load(fromByteOffset: i, as: UInt8.self)
             var byteStr = String(byte, radix: 16, uppercase: false)
             if byte <= 0xf { byteStr = "0\(byteStr)" }
             s += byteStr
@@ -231,15 +233,15 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
 
 extension NSData {
     
-    public convenience init(bytes: UnsafePointer<Void>?, length: Int) {
-        self.init(bytes: UnsafeMutablePointer<Void>(bytes), length: length, copy: true, deallocator: nil)
+    public convenience init(bytes: UnsafeRawPointer?, length: Int) {
+        self.init(bytes: UnsafeMutableRawPointer(mutating: bytes), length: length, copy: true, deallocator: nil)
     }
 
-    public convenience init(bytesNoCopy bytes: UnsafeMutablePointer<Void>, length: Int) {
+    public convenience init(bytesNoCopy bytes: UnsafeMutableRawPointer, length: Int) {
         self.init(bytes: bytes, length: length, copy: false, deallocator: nil)
     }
     
-    public convenience init(bytesNoCopy bytes: UnsafeMutablePointer<Void>, length: Int, freeWhenDone b: Bool) {
+    public convenience init(bytesNoCopy bytes: UnsafeMutableRawPointer, length: Int, freeWhenDone b: Bool) {
         self.init(bytes: bytes, length: length, copy: false) { buffer, length in
             if b {
                 free(buffer)
@@ -247,15 +249,15 @@ extension NSData {
         }
     }
 
-    public convenience init(bytesNoCopy bytes: UnsafeMutablePointer<Void>, length: Int, deallocator: ((UnsafeMutablePointer<Void>, Int) -> Void)?) {
+    public convenience init(bytesNoCopy bytes: UnsafeMutableRawPointer, length: Int, deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?) {
         self.init(bytes: bytes, length: length, copy: false, deallocator: deallocator)
     }
     
     
     internal struct NSDataReadResult {
-        var bytes: UnsafeMutablePointer<Void>
+        var bytes: UnsafeMutableRawPointer
         var length: Int
-        var deallocator: ((buffer: UnsafeMutablePointer<Void>, length: Int) -> Void)?
+        var deallocator: ((buffer: UnsafeMutableRawPointer, length: Int) -> Void)?
     }
     
     internal static func readBytesFromFileWithExtendedAttributes(_ path: String, options: ReadingOptions) throws -> NSDataReadResult {
@@ -285,7 +287,7 @@ extension NSData {
             let data = mmap(nil, length, PROT_READ, MAP_PRIVATE, fd, 0)
             
             // Swift does not currently expose MAP_FAILURE
-            if data != UnsafeMutablePointer<Void>(bitPattern: -1) {
+            if data != UnsafeMutableRawPointer(bitPattern: -1) {
                 return NSDataReadResult(bytes: data!, length: length) { buffer, length in
                     munmap(buffer, length)
                 }
@@ -364,12 +366,14 @@ extension NSData {
 }
 
 extension NSData {
-    public func getBytes(_ buffer: UnsafeMutablePointer<Void>, length: Int) {
-        CFDataGetBytes(_cfObject, CFRangeMake(0, length), UnsafeMutablePointer<UInt8>(buffer))
+    public func getBytes(_ buffer: UnsafeMutableRawPointer, length: Int) {
+        let bytePtr = buffer.bindMemory(to: UInt8.self, capacity: length)
+        CFDataGetBytes(_cfObject, CFRangeMake(0, length), bytePtr)
     }
     
-    public func getBytes(_ buffer: UnsafeMutablePointer<Void>, range: NSRange) {
-        CFDataGetBytes(_cfObject, CFRangeMake(range.location, range.length), UnsafeMutablePointer<UInt8>(buffer))
+    public func getBytes(_ buffer: UnsafeMutableRawPointer, range: NSRange) {
+        let bytePtr = buffer.bindMemory(to: UInt8.self, capacity: range.length)
+        CFDataGetBytes(_cfObject, CFRangeMake(range.location, range.length), bytePtr)
     }
     
     public func isEqual(to other: Data) -> Bool {
@@ -408,7 +412,7 @@ extension NSData {
         return (fd, pathResult)
     }
 
-    internal class func writeToFileDescriptor(_ fd: Int32, path: String? = nil, buf: UnsafePointer<Void>, length: Int) throws {
+    internal class func writeToFileDescriptor(_ fd: Int32, path: String? = nil, buf: UnsafeRawPointer, length: Int) throws {
         var bytesRemaining = length
         while bytesRemaining > 0 {
             var bytesWritten : Int
@@ -529,9 +533,11 @@ extension NSData {
         guard let searchRange = searchRange.toRange() else {fatalError("invalid range")}
         
         precondition(searchRange.endIndex <= self.length, "range outside the bounds of data")
-        
-        let baseData = UnsafeBufferPointer<UInt8>(start: UnsafePointer<UInt8>(self.bytes), count: self.length)[searchRange]
-        let search = UnsafeBufferPointer<UInt8>(start: UnsafePointer<UInt8>(dataToFind.bytes), count: dataToFind.length)
+
+        let basePtr = self.bytes.bindMemory(to: UInt8.self, capacity: self.length)
+        let baseData = UnsafeBufferPointer<UInt8>(start: basePtr, count: self.length)[searchRange]
+        let searchPtr = dataToFind.bytes.bindMemory(to: UInt8.self, capacity: dataToFind.length)
+        let search = UnsafeBufferPointer<UInt8>(start: searchPtr, count: dataToFind.length)
         
         let location : Int?
         let anchored = mask.contains(.anchored)
@@ -552,7 +558,7 @@ extension NSData {
         return nil
     }
     
-    internal func enumerateByteRangesUsingBlockRethrows(_ block: @noescape (UnsafePointer<Void>, NSRange, UnsafeMutablePointer<Bool>) throws -> Void) throws {
+    internal func enumerateByteRangesUsingBlockRethrows(_ block: @noescape (UnsafeRawPointer, NSRange, UnsafeMutablePointer<Bool>) throws -> Void) throws {
         var err : Swift.Error? = nil
         self.enumerateBytes() { (buf, range, stop) -> Void in
             do {
@@ -566,7 +572,7 @@ extension NSData {
         }
     }
 
-    public func enumerateBytes(_ block: @noescape (UnsafePointer<Void>, NSRange, UnsafeMutablePointer<Bool>) -> Void) {
+    public func enumerateBytes(_ block: @noescape (UnsafeRawPointer, NSRange, UnsafeMutablePointer<Bool>) -> Void) {
         var stop = false
         withUnsafeMutablePointer(&stop) { stopPointer in
             block(bytes, NSMakeRange(0, length), stopPointer)
@@ -611,12 +617,12 @@ public class NSMutableData : NSData {
         self.init(bytes: nil, length: 0)
     }
     
-    internal override init(bytes: UnsafeMutablePointer<Void>?, length: Int, copy: Bool, deallocator: ((UnsafeMutablePointer<Void>, Int) -> Void)?) {
+    internal override init(bytes: UnsafeMutableRawPointer?, length: Int, copy: Bool, deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?) {
         super.init(bytes: bytes, length: length, copy: copy, deallocator: deallocator)
     }
     
-    public var mutableBytes: UnsafeMutablePointer<Void> {
-        return UnsafeMutablePointer(CFDataGetMutableBytePtr(_cfMutableObject))
+    public var mutableBytes: UnsafeMutableRawPointer {
+        return UnsafeMutableRawPointer(CFDataGetMutableBytePtr(_cfMutableObject))
     }
     
     public override var length: Int {
@@ -892,8 +898,9 @@ extension NSData {
 
 extension NSMutableData {
 
-    public func append(_ bytes: UnsafePointer<Void>, length: Int) {
-        CFDataAppendBytes(_cfMutableObject, UnsafePointer<UInt8>(bytes), length)
+    public func append(_ bytes: UnsafeRawPointer, length: Int) {
+        let bytePtr = bytes.bindMemory(to: UInt8.self, capacity: length)
+        CFDataAppendBytes(_cfMutableObject, bytePtr, length)
     }
     
     public func append(_ other: Data) {
@@ -908,8 +915,9 @@ extension NSMutableData {
         CFDataSetLength(_cfMutableObject, CFDataGetLength(_cfObject) + extraLength)
     }
     
-    public func replaceBytes(in range: NSRange, withBytes bytes: UnsafePointer<Void>) {
-        CFDataReplaceBytes(_cfMutableObject, CFRangeMake(range.location, range.length), UnsafePointer<UInt8>(bytes), length)
+    public func replaceBytes(in range: NSRange, withBytes bytes: UnsafeRawPointer) {
+        let bytePtr = bytes.bindMemory(to: UInt8.self, capacity: length)
+        CFDataReplaceBytes(_cfMutableObject, CFRangeMake(range.location, range.length), bytePtr, length)
     }
     
     public func resetBytes(in range: NSRange) {
@@ -924,8 +932,9 @@ extension NSMutableData {
         
     }
     
-    public func replaceBytes(in range: NSRange, withBytes replacementBytes: UnsafePointer<Void>, length replacementLength: Int) {
-        CFDataReplaceBytes(_cfMutableObject, CFRangeMake(range.location, range.length), UnsafePointer<UInt8>(bytes), replacementLength)
+    public func replaceBytes(in range: NSRange, withBytes replacementBytes: UnsafeRawPointer, length replacementLength: Int) {
+        let bytePtr = bytes.bindMemory(to: UInt8.self, capacity: replacementLength)
+        CFDataReplaceBytes(_cfMutableObject, CFRangeMake(range.location, range.length), bytePtr, replacementLength)
     }
 }
 

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -72,7 +72,7 @@ public class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
         } else {
             var ti: TimeInterval = 0.0
             withUnsafeMutablePointer(&ti) { (ptr: UnsafeMutablePointer<Double>) -> Void in
-                aDecoder.decodeValue(ofObjCType: "d", at: UnsafeMutablePointer<Void>(ptr))
+                aDecoder.decodeValue(ofObjCType: "d", at: UnsafeMutableRawPointer(ptr))
             }
             self.init(timeIntervalSinceReferenceDate: ti)
         }

--- a/Foundation/NSDecimalNumber.swift
+++ b/Foundation/NSDecimalNumber.swift
@@ -51,7 +51,7 @@ public class NSDecimalNumber : NSNumber {
         NSUnimplemented()
     }
     
-    public required convenience init(bytes buffer: UnsafePointer<Void>, objCType type: UnsafePointer<Int8>) {
+    public required convenience init(bytes buffer: UnsafeRawPointer, objCType type: UnsafePointer<Int8>) {
         NSRequiresConcreteImplementation()
     }
     

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -52,8 +52,8 @@ extension Dictionary : _ObjectTypeBridgeable {
             let cf = x._cfObject
             let cnt = CFDictionaryGetCount(cf)
 
-            let keys = UnsafeMutablePointer<UnsafePointer<Void>?>.allocate(capacity: cnt)
-            let values = UnsafeMutablePointer<UnsafePointer<Void>?>.allocate(capacity: cnt)
+            let keys = UnsafeMutablePointer<UnsafeRawPointer?>.allocate(capacity: cnt)
+            let values = UnsafeMutablePointer<UnsafeRawPointer?>.allocate(capacity: cnt)
             
             CFDictionaryGetKeysAndValues(cf, keys, values)
             
@@ -126,7 +126,7 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
             // because that's the way the code was originally written, unless
             // we go to a new version of the class, which has its own problems.
             withUnsafeMutablePointer(&cnt) { (ptr: UnsafeMutablePointer<UInt32>) -> Void in
-                aDecoder.decodeValue(ofObjCType: "i", at: UnsafeMutablePointer<Void>(ptr))
+                aDecoder.decodeValue(ofObjCType: "i", at: UnsafeMutableRawPointer(ptr))
             }
             let keys = UnsafeMutablePointer<NSObject>.allocate(capacity: Int(cnt))
             let objects = UnsafeMutablePointer<AnyObject>.allocate(capacity: Int(cnt))

--- a/Foundation/NSFileHandle.swift
+++ b/Foundation/NSFileHandle.swift
@@ -34,7 +34,7 @@ public class FileHandle: NSObject, NSSecureCoding {
 
     internal func _readDataOfLength(_ length: Int, untilEOF: Bool) -> Data {
         var statbuf = stat()
-        var dynamicBuffer: UnsafeMutablePointer<UInt8>? = nil
+        var dynamicBuffer: UnsafeMutableRawPointer? = nil
         var total = 0
         if _closed || fstat(_fd, &statbuf) < 0 {
             fatalError("Unable to read file")
@@ -42,14 +42,14 @@ public class FileHandle: NSObject, NSSecureCoding {
         if statbuf.st_mode & S_IFMT != S_IFREG {
             /* We get here on sockets, character special files, FIFOs ... */
             var currentAllocationSize: size_t = 1024 * 8
-            dynamicBuffer = UnsafeMutablePointer<UInt8>(malloc(currentAllocationSize))
+            dynamicBuffer = malloc(currentAllocationSize)
             var remaining = length
             while remaining > 0 {
                 let amountToRead = min(1024 * 8, remaining)
                 // Make sure there is always at least amountToRead bytes available in the buffer.
                 if (currentAllocationSize - total) < amountToRead {
                     currentAllocationSize *= 2
-                    dynamicBuffer = UnsafeMutablePointer<UInt8>(_CFReallocf(UnsafeMutablePointer<Void>(dynamicBuffer!), currentAllocationSize))
+                    dynamicBuffer = _CFReallocf(dynamicBuffer!, currentAllocationSize)
                     if dynamicBuffer == nil {
                         fatalError("unable to allocate backing buffer")
                     }
@@ -79,7 +79,7 @@ public class FileHandle: NSObject, NSSecureCoding {
                 var remaining = size_t(statbuf.st_size - offset)
                 remaining = min(remaining, size_t(length))
                 
-                dynamicBuffer = UnsafeMutablePointer<UInt8>(malloc(remaining))
+                dynamicBuffer = malloc(remaining)
                 if dynamicBuffer == nil {
                     fatalError("Malloc failure")
                 }
@@ -100,7 +100,7 @@ public class FileHandle: NSObject, NSSecureCoding {
         }
 
         if length == Int.max && total > 0 {
-            dynamicBuffer = UnsafeMutablePointer<UInt8>(_CFReallocf(UnsafeMutablePointer<Void>(dynamicBuffer!), total))
+            dynamicBuffer = _CFReallocf(dynamicBuffer!, total)
         }
         
         if (0 == total) {
@@ -108,7 +108,8 @@ public class FileHandle: NSObject, NSSecureCoding {
         }
         
         if total > 0 {
-            return Data(bytesNoCopy: dynamicBuffer!, count: total, deallocator: .none)
+            let bytePtr = dynamicBuffer!.bindMemory(to: UInt8.self, capacity: total)
+            return Data(bytesNoCopy: bytePtr, count: total, deallocator: .none)
         }
         
         return Data()
@@ -117,7 +118,7 @@ public class FileHandle: NSObject, NSSecureCoding {
     public func write(_ data: Data) {
         data.enumerateBytes() { (bytes, range, stop) in
             do {
-                try NSData.writeToFileDescriptor(self._fd, path: nil, buf: UnsafePointer<Void>(bytes.baseAddress!), length: bytes.count)
+                try NSData.writeToFileDescriptor(self._fd, path: nil, buf: UnsafeRawPointer(bytes.baseAddress!), length: bytes.count)
             } catch {
                 fatalError("Write failure")
             }

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -100,11 +100,9 @@ public func ==(lhs: CGPoint, rhs: CGPoint) -> Bool {
 }
 
 extension CGPoint: NSSpecialValueCoding {
-    init(bytes: UnsafePointer<Void>) {
-        let buffer = UnsafePointer<CGFloat>(bytes)
-
-        self.x = buffer.pointee
-        self.y = buffer.advanced(by: 1).pointee
+    init(bytes: UnsafeRawPointer) {
+        self.x = bytes.load(as: CGFloat.self)
+        self.y = bytes.load(fromByteOffset: strideof(CGFloat.self), as: CGFloat.self)
     }
     
     init?(coder aDecoder: NSCoder) {
@@ -127,8 +125,8 @@ extension CGPoint: NSSpecialValueCoding {
         return "{CGPoint=dd}"
     }
 
-    func getValue(_ value: UnsafeMutablePointer<Void>) {
-        UnsafeMutablePointer<CGPoint>(value).pointee = self
+    func getValue(_ value: UnsafeMutableRawPointer) {
+        value.initializeMemory(as: CGPoint.self, to: self)
     }
 
     func isEqual(_ aValue: Any) -> Bool {
@@ -167,11 +165,9 @@ public func ==(lhs: CGSize, rhs: CGSize) -> Bool {
 }
 
 extension CGSize: NSSpecialValueCoding {
-    init(bytes: UnsafePointer<Void>) {
-        let buffer = UnsafePointer<CGFloat>(bytes)
-
-        self.width = buffer.pointee
-        self.height = buffer.advanced(by: 1).pointee
+    init(bytes: UnsafeRawPointer) {
+        self.width = bytes.load(as: CGFloat.self)
+        self.height = bytes.load(fromByteOffset: strideof(CGFloat.self), as: CGFloat.self)
     }
     
     init?(coder aDecoder: NSCoder) {
@@ -194,8 +190,8 @@ extension CGSize: NSSpecialValueCoding {
         return "{CGSize=dd}"
     }
     
-    func getValue(_ value: UnsafeMutablePointer<Void>) {
-        UnsafeMutablePointer<CGSize>(value).pointee = self
+    func getValue(_ value: UnsafeMutableRawPointer) {
+        value.initializeMemory(as: CGSize.self, to: self)
     }
     
     func isEqual(_ aValue: Any) -> Bool {
@@ -249,11 +245,13 @@ public typealias NSRectPointer = UnsafeMutablePointer<NSRect>
 public typealias NSRectArray = UnsafeMutablePointer<NSRect>
 
 extension CGRect: NSSpecialValueCoding {
-    init(bytes: UnsafePointer<Void>) {
-        let buffer = UnsafePointer<CGFloat>(bytes)
-
-        self.origin = CGPoint(x: buffer.pointee, y: buffer.advanced(by: 1).pointee)
-        self.size = CGSize(width: buffer.advanced(by: 2).pointee, height: buffer.advanced(by: 3).pointee)
+    init(bytes: UnsafeRawPointer) {
+        self.origin = CGPoint(
+            x: bytes.load(as: CGFloat.self),
+            y: bytes.load(fromByteOffset: 1 * strideof(CGFloat.self), as: CGFloat.self))
+        self.size = CGSize(
+            width: bytes.load(fromByteOffset: 2 * strideof(CGFloat.self), as: CGFloat.self),
+            height: bytes.load(fromByteOffset: 3 * strideof(CGFloat.self), as: CGFloat.self))
     }
 
     init?(coder aDecoder: NSCoder) {
@@ -276,8 +274,8 @@ extension CGRect: NSSpecialValueCoding {
         return "{CGRect={CGPoint=dd}{CGSize=dd}}"
     }
     
-    func getValue(_ value: UnsafeMutablePointer<Void>) {
-        UnsafeMutablePointer<CGRect>(value).pointee = self
+    func getValue(_ value: UnsafeMutableRawPointer) {
+        value.initializeMemory(as: CGRect.self, to: self)
     }
     
     func isEqual(_ aValue: Any) -> Bool {
@@ -344,13 +342,11 @@ public struct NSEdgeInsets {
 }
 
 extension NSEdgeInsets: NSSpecialValueCoding {
-    init(bytes: UnsafePointer<Void>) {
-        let buffer = UnsafePointer<CGFloat>(bytes)
-
-        self.top = buffer.pointee
-        self.left = buffer.advanced(by: 1).pointee
-        self.bottom = buffer.advanced(by: 2).pointee
-        self.right = buffer.advanced(by: 3).pointee
+    init(bytes: UnsafeRawPointer) {
+        self.top = bytes.load(as: CGFloat.self)
+        self.left = bytes.load(fromByteOffset: strideof(CGFloat.self), as: CGFloat.self)
+        self.bottom = bytes.load(fromByteOffset: 2 * strideof(CGFloat.self), as: CGFloat.self)
+        self.right = bytes.load(fromByteOffset: 3 * strideof(CGFloat.self), as: CGFloat.self)
     }
 
     init?(coder aDecoder: NSCoder) {
@@ -379,8 +375,8 @@ extension NSEdgeInsets: NSSpecialValueCoding {
         return "{NSEdgeInsets=dddd}"
     }
     
-    func getValue(_ value: UnsafeMutablePointer<Void>) {
-        UnsafeMutablePointer<NSEdgeInsets>(value).pointee = self
+    func getValue(_ value: UnsafeMutableRawPointer) {
+        value.initializeMemory(as: NSEdgeInsets.self, to: self)
     }
     
     func isEqual(_ aValue: Any) -> Bool {

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -285,7 +285,7 @@ public class NSKeyedArchiver : NSCoder {
     
     private static func _createObjectRef(_ uid : UInt32) -> CFKeyedArchiverUID {
         return Unmanaged<CFKeyedArchiverUID>.fromOpaque(
-            UnsafePointer<Void>(_CFKeyedArchiverUIDCreate(kCFAllocatorSystemDefault, uid))).takeUnretainedValue()
+            UnsafeRawPointer(_CFKeyedArchiverUIDCreate(kCFAllocatorSystemDefault, uid))).takeUnretainedValue()
     }
     
     private func _createObjectRefCached(_ uid : UInt32) -> CFKeyedArchiverUID {
@@ -654,7 +654,7 @@ public class NSKeyedArchiver : NSCoder {
         _encodePropertyList(objv, forKey: key)
     }
 
-    private func _encodeValueOfObjCType(_ type: _NSSimpleObjCType, at addr: UnsafePointer<Void>) {
+    private func _encodeValueOfObjCType(_ type: _NSSimpleObjCType, at addr: UnsafeRawPointer) {
         switch type {
         case .ID:
             let objectp = unsafeBitCast(addr, to: UnsafePointer<AnyObject>.self)
@@ -710,7 +710,7 @@ public class NSKeyedArchiver : NSCoder {
         }
     }
     
-    public override func encodeValue(ofObjCType typep: UnsafePointer<Int8>, at addr: UnsafePointer<Void>) {
+    public override func encodeValue(ofObjCType typep: UnsafePointer<Int8>, at addr: UnsafeRawPointer) {
         guard let type = _NSSimpleObjCType(UInt8(typep.pointee)) else {
             let spec = String(typep.pointee)
             fatalError("NSKeyedArchiver.encodeValueOfObjCType: unsupported type encoding spec '\(spec)'")

--- a/Foundation/NSKeyedCoderOldStyleArray.swift
+++ b/Foundation/NSKeyedCoderOldStyleArray.swift
@@ -11,7 +11,7 @@ import CoreFoundation
 
 internal final class _NSKeyedCoderOldStyleArray : NSObject, NSCopying, NSSecureCoding, NSCoding {
 
-    private var _addr : UnsafeMutablePointer<UInt8> // free if decoding
+    private var _addr : UnsafeMutableRawPointer // free if decoding
     private var _count : Int
     private var _size : Int
     private var _type : _NSSimpleObjCType
@@ -24,14 +24,15 @@ internal final class _NSKeyedCoderOldStyleArray : NSObject, NSCopying, NSSecureC
         return _NSGetSizeAndAlignment(type, &size, &align) ? size : nil
     }
 
-    init?(objCType type: _NSSimpleObjCType, count: Int, at addr: UnsafePointer<Void>) {
-        self._addr = UnsafeMutablePointer<UInt8>(addr)
-        self._count = count
-        
+    // TODO: Why isn't `addr` passed as a mutable pointer?
+    init?(objCType type: _NSSimpleObjCType, count: Int, at addr: UnsafeRawPointer) {
+        self._addr = UnsafeMutableRawPointer(mutating: addr)
+        self._count = count        
+
         guard let size = _NSKeyedCoderOldStyleArray.sizeForObjCType(type) else {
             return nil
         }
-        
+
         self._size = size
         self._type = type
         self._decoded = false
@@ -39,8 +40,8 @@ internal final class _NSKeyedCoderOldStyleArray : NSObject, NSCopying, NSSecureC
 
     deinit {
         if self._decoded {
-            self._addr.deinitialize(count: self._count * self._size)
-            self._addr.deallocate(capacity: self._count * self._size)
+            // Cannot deinitialize memory without knowing the element type.
+            self._addr.deallocate(bytes: self._count * self._size, alignedTo: 1)
         }
     }
     
@@ -60,7 +61,7 @@ internal final class _NSKeyedCoderOldStyleArray : NSObject, NSCopying, NSSecureC
             return nil
         }
         
-        self._addr = UnsafeMutablePointer<UInt8>.allocate(capacity: self._count * self._size)
+        self._addr = UnsafeMutableRawPointer.allocate(bytes: self._count * self._size, alignedTo: 1)
         
         super.init()
         
@@ -83,7 +84,7 @@ internal final class _NSKeyedCoderOldStyleArray : NSObject, NSCopying, NSSecureC
             var type = Int8(self._type)
 
             withUnsafePointer(&type) { typep in
-                aCoder.encodeValue(ofObjCType: typep, at: &self._addr[idx * self._size])
+                aCoder.encodeValue(ofObjCType: typep, at: self._addr + (idx * self._size))
             }
         }
     }
@@ -92,9 +93,9 @@ internal final class _NSKeyedCoderOldStyleArray : NSObject, NSCopying, NSSecureC
         return true
     }
     
-    func fillObjCType(_ type: _NSSimpleObjCType, count: Int, at addr: UnsafeMutablePointer<Void>) {
+    func fillObjCType(_ type: _NSSimpleObjCType, count: Int, at addr: UnsafeMutableRawPointer) {
         if type == self._type && count <= self._count {
-            UnsafeMutablePointer<UInt8>(addr).moveInitialize(from: self._addr, count: count * self._size)
+            addr.copyBytes(from: self._addr, count: count * self._size)
         }
     }
     

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -763,7 +763,7 @@ public class NSKeyedUnarchiver : NSCoder {
         return decodeObject() as? Data
     }
     
-    private func _decodeValueOfObjCType(_ type: _NSSimpleObjCType, at addr: UnsafeMutablePointer<Void>) {
+    private func _decodeValueOfObjCType(_ type: _NSSimpleObjCType, at addr: UnsafeMutableRawPointer) {
         switch type {
         case .ID:
             if let ns = decodeObject() {
@@ -834,7 +834,7 @@ public class NSKeyedUnarchiver : NSCoder {
         }
     }
     
-    public override func decodeValue(ofObjCType typep: UnsafePointer<Int8>, at addr: UnsafeMutablePointer<Void>) {
+    public override func decodeValue(ofObjCType typep: UnsafePointer<Int8>, at addr: UnsafeMutableRawPointer) {
         guard let type = _NSSimpleObjCType(UInt8(typep.pointee)) else {
             let spec = String(typep.pointee)
             fatalError("NSKeyedUnarchiver.decodeValueOfObjCType: unsupported type encoding spec '\(spec)'")

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -13,9 +13,9 @@ import CoreFoundation
 public class Locale: NSObject, NSCopying, NSSecureCoding {
     typealias CFType = CFLocale
     private var _base = _CFInfo(typeID: CFLocaleGetTypeID())
-    private var _identifier: UnsafeMutablePointer<Void>? = nil
-    private var _cache: UnsafeMutablePointer<Void>? = nil
-    private var _prefs: UnsafeMutablePointer<Void>? = nil
+    private var _identifier: UnsafeMutableRawPointer? = nil
+    private var _cache: UnsafeMutableRawPointer? = nil
+    private var _prefs: UnsafeMutableRawPointer? = nil
 #if os(OSX) || os(iOS)
     private var _lock = pthread_mutex_t()
 #elseif os(Linux)

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -225,43 +225,43 @@ public class NSNumber : NSValue {
         _CFNumberInitBool(_cfObject, value)
     }
     
-    public required convenience init(bytes buffer: UnsafePointer<Void>, objCType: UnsafePointer<Int8>) {
+    public required convenience init(bytes buffer: UnsafeRawPointer, objCType: UnsafePointer<Int8>) {
         guard let type = _NSSimpleObjCType(UInt8(objCType.pointee)) else {
             fatalError("NSNumber.init: unsupported type encoding spec '\(String(cString: objCType))'")
         }
         switch type {
         case .Bool:
-            self.init(value:UnsafePointer<Bool>(buffer).pointee)
+            self.init(value:buffer.load(as: Bool.self))
             break
         case .Char:
-            self.init(value:UnsafePointer<Int8>(buffer).pointee)
+            self.init(value:buffer.load(as: Int8.self))
             break
         case .UChar:
-            self.init(value:UnsafePointer<UInt8>(buffer).pointee)
+            self.init(value:buffer.load(as: UInt8.self))
             break
         case .Short:
-            self.init(value:UnsafePointer<Int16>(buffer).pointee)
+            self.init(value:buffer.load(as: Int16.self))
             break
         case .UShort:
-            self.init(value:UnsafePointer<UInt16>(buffer).pointee)
+            self.init(value:buffer.load(as: UInt16.self))
             break
         case .Int, .Long:
-            self.init(value:UnsafePointer<Int32>(buffer).pointee)
+            self.init(value:buffer.load(as: Int32.self))
             break
         case .UInt, .ULong:
-            self.init(value:UnsafePointer<UInt32>(buffer).pointee)
+            self.init(value:buffer.load(as: UInt32.self))
             break
         case .LongLong:
-            self.init(value:UnsafePointer<Int64>(buffer).pointee)
+            self.init(value:buffer.load(as: Int64.self))
             break
         case .ULongLong:
-            self.init(value:UnsafePointer<UInt64>(buffer).pointee)
+            self.init(value:buffer.load(as: UInt64.self))
             break
         case .Float:
-            self.init(value:UnsafePointer<Float>(buffer).pointee)
+            self.init(value:buffer.load(as: Float.self))
             break
         case .Double:
-            self.init(value:UnsafePointer<Double>(buffer).pointee)
+            self.init(value:buffer.load(as: Double.self))
             break
         default:
             fatalError("NSNumber.init: unsupported type encoding spec '\(String(cString: objCType))'")
@@ -273,7 +273,7 @@ public class NSNumber : NSValue {
         if !aDecoder.allowsKeyedCoding {
             var objCType: UnsafeMutablePointer<Int8>? = nil
             withUnsafeMutablePointer(&objCType, { (ptr: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>) -> Void in
-                aDecoder.decodeValue(ofObjCType: String(_NSSimpleObjCType.CharPtr), at: UnsafeMutablePointer<Void>(ptr))
+                aDecoder.decodeValue(ofObjCType: String(_NSSimpleObjCType.CharPtr), at: UnsafeMutableRawPointer(ptr))
             })
             if objCType == nil {
                 return nil

--- a/Foundation/NSProcessInfo.swift
+++ b/Foundation/NSProcessInfo.swift
@@ -95,7 +95,7 @@ public class ProcessInfo: NSObject {
             return NSOperatingSystemVersion(majorVersion: fallbackMajor, minorVersion: fallbackMinor, patchVersion: fallbackPatch)
         }
         
-        let productVersionKey = unsafeBitCast(_kCFSystemVersionProductVersionKey, to: UnsafePointer<Void>.self)
+        let productVersionKey = unsafeBitCast(_kCFSystemVersionProductVersionKey, to: UnsafeRawPointer.self)
         guard let productVersion = unsafeBitCast(CFDictionaryGetValue(systemVersionDictionary, productVersionKey), to: NSString!.self) else {
             return NSOperatingSystemVersion(majorVersion: fallbackMajor, minorVersion: fallbackMinor, patchVersion: fallbackPatch)
         }

--- a/Foundation/NSRange.swift
+++ b/Foundation/NSRange.swift
@@ -52,11 +52,9 @@ extension NSRange {
 }
 
 extension NSRange: NSSpecialValueCoding {
-    init(bytes: UnsafePointer<Void>) {
-        let buffer = UnsafePointer<Int>(bytes)
-        
-        self.location = buffer.pointee
-        self.length = buffer.advanced(by: 1).pointee
+    init(bytes: UnsafeRawPointer) {
+        self.location = bytes.load(as: Int.self)
+        self.length = bytes.load(fromByteOffset: strideof(Int.self), as: Int.self)
     }
     
     init?(coder aDecoder: NSCoder) {
@@ -95,8 +93,8 @@ extension NSRange: NSSpecialValueCoding {
 #endif
     }
     
-    func getValue(_ value: UnsafeMutablePointer<Void>) {
-        UnsafeMutablePointer<NSRange>(value).pointee = self
+    func getValue(_ value: UnsafeMutableRawPointer) {
+        value.initializeMemory(as: NSRange.self, to: self)
     }
     
     func isEqual(_ aValue: Any) -> Bool {

--- a/Foundation/NSRegularExpression.swift
+++ b/Foundation/NSRegularExpression.swift
@@ -120,7 +120,7 @@ internal class _NSRegularExpressionMatcher {
     }
 }
 
-internal func _NSRegularExpressionMatch(_ context: UnsafeMutablePointer<Void>?, ranges: UnsafeMutablePointer<CFRange>?, count: CFIndex, options: _CFRegularExpressionMatchingOptions, stop: UnsafeMutablePointer<_DarwinCompatibleBoolean>) -> Void {
+internal func _NSRegularExpressionMatch(_ context: UnsafeMutableRawPointer?, ranges: UnsafeMutablePointer<CFRange>?, count: CFIndex, options: _CFRegularExpressionMatchingOptions, stop: UnsafeMutablePointer<_DarwinCompatibleBoolean>) -> Void {
     let matcher = unsafeBitCast(context, to: _NSRegularExpressionMatcher.self)
     if ranges == nil {
 #if os(OSX) || os(iOS)
@@ -153,7 +153,7 @@ extension RegularExpression {
 #else
         let opts = _CFRegularExpressionMatchingOptions(options.rawValue)
 #endif
-            _CFRegularExpressionEnumerateMatchesInString(_internal, string._cfObject, opts, CFRange(range), unsafeBitCast(matcher, to: UnsafeMutablePointer<Void>.self), _NSRegularExpressionMatch)
+            _CFRegularExpressionEnumerateMatchesInString(_internal, string._cfObject, opts, CFRange(range), unsafeBitCast(matcher, to: UnsafeMutableRawPointer.self), _NSRegularExpressionMatch)
         }
     }
     

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -43,7 +43,7 @@ extension Set : _ObjectTypeBridgeable {
             let cf = x._cfObject
             let cnt = CFSetGetCount(cf)
             
-            let objs = UnsafeMutablePointer<UnsafePointer<Void>?>.allocate(capacity: cnt)
+            let objs = UnsafeMutablePointer<UnsafeRawPointer?>.allocate(capacity: cnt)
             
             CFSetGetValues(cf, objs)
             
@@ -120,7 +120,7 @@ public class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
             // because that's the way the code was originally written, unless
             // we go to a new version of the class, which has its own problems.
             withUnsafeMutablePointer(&cnt) { (ptr: UnsafeMutablePointer<UInt32>) -> Void in
-                aDecoder.decodeValue(ofObjCType: "i", at: UnsafeMutablePointer<Void>(ptr))
+                aDecoder.decodeValue(ofObjCType: "i", at: UnsafeMutableRawPointer(ptr))
             }
             let objects = UnsafeMutablePointer<AnyObject?>.allocate(capacity: Int(cnt))
             for idx in 0..<cnt {

--- a/Foundation/NSSpecialValue.swift
+++ b/Foundation/NSSpecialValue.swift
@@ -10,10 +10,10 @@
 internal protocol NSSpecialValueCoding {
     static func objCType() -> String
     
-    init(bytes value: UnsafePointer<Void>)
+    init(bytes value: UnsafeRawPointer)
     func encodeWithCoder(_ aCoder: NSCoder)
     init?(coder aDecoder: NSCoder)
-    func getValue(_ value: UnsafeMutablePointer<Void>)
+    func getValue(_ value: UnsafeMutableRawPointer)
     
     // Ideally we would make NSSpecialValue a generic class and specialise it for
     // NSPoint, etc, but then we couldn't implement NSValue.init?(coder:) because 
@@ -81,7 +81,7 @@ internal class NSSpecialValue : NSValue {
         self._value = value
     }
     
-    required init(bytes value: UnsafePointer<Void>, objCType type: UnsafePointer<Int8>) {
+    required init(bytes value: UnsafeRawPointer, objCType type: UnsafePointer<Int8>) {
         guard let specialType = NSSpecialValue._typeFromObjCType(type) else {
             NSUnimplemented()
         }
@@ -89,7 +89,7 @@ internal class NSSpecialValue : NSValue {
         self._value = specialType.init(bytes: value)
     }
 
-    override func getValue(_ value: UnsafeMutablePointer<Void>) {
+    override func getValue(_ value: UnsafeMutableRawPointer) {
         self._value.getValue(value)
     }
 

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -194,7 +194,7 @@ internal func _bytesInEncoding(_ str: NSString, _ encoding: String.Encoding, _ f
     
     buffer.advanced(by: cLength).initialize(to: 0)
     
-    return buffer // leaked and should be autoreleased via a NSData backing but we cannot here
+    return UnsafePointer(buffer) // leaked and should be autoreleased via a NSData backing but we cannot here
 }
 
 internal func isALineSeparatorTypeCharacter(_ ch: unichar) -> Bool {
@@ -905,7 +905,7 @@ extension NSString {
                 let lossyOk = options.contains(.allowLossy)
                 let externalRep = options.contains(.externalRepresentation)
                 let failOnPartial = options.contains(.failOnPartialEncodingConversion)
-                let bytePtr = buffer?.bindMemory(as: UInt8.self, capacity: maxBufferCount)
+                let bytePtr = buffer?.bindMemory(to: UInt8.self, capacity: maxBufferCount)
                 numCharsProcessed = __CFStringEncodeByteStream(_cfObject, range.location, range.length, externalRep, cfStringEncoding, lossyOk ? (encoding == String.Encoding.ascii.rawValue ? 0xFF : 0x3F) : 0, bytePtr, bytePtr != nil ? maxBufferCount : 0, &totalBytesWritten)
                 if (failOnPartial && numCharsProcessed < range.length) || numCharsProcessed == 0 {
                     result = false
@@ -1230,7 +1230,7 @@ extension NSString {
     }
     
     public convenience init?(bytes: UnsafeRawPointer, length len: Int, encoding: UInt) {
-        let bytePtr = bytes.bindMemory(as: UInt8.self, capacity: len)
+        let bytePtr = bytes.bindMemory(to: UInt8.self, capacity: len)
         guard let cf = CFStringCreateWithBytes(kCFAllocatorDefault, bytePtr, len, CFStringConvertNSStringEncodingToEncoding(encoding), true) else {
             return nil
         }
@@ -1265,7 +1265,7 @@ extension NSString {
     public convenience init(contentsOf url: URL, encoding enc: UInt) throws {
         let readResult = try NSData(contentsOf: url, options: [])
 
-        let bytePtr = readResult.bindMemory(as: UInt8.self, capacity: readResult.length)
+        let bytePtr = readResult.bytes.bindMemory(to: UInt8.self, capacity: readResult.length)
         guard let cf = CFStringCreateWithBytes(kCFAllocatorDefault, bytePtr, readResult.length, CFStringConvertNSStringEncodingToEncoding(enc), true) else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileReadInapplicableStringEncodingError.rawValue, userInfo: [
                 "NSDebugDescription" : "Unable to create a string using the specified encoding."
@@ -1402,7 +1402,7 @@ extension NSMutableString {
             let numOccurrences = CFArrayGetCount(findResults)
             for cnt in 0..<numOccurrences {
                 let rangePtr = CFArrayGetValueAtIndex(findResults, backwards ? cnt : numOccurrences - cnt - 1)
-                replaceCharacters(in: NSRange(range!.load(as: CFRange)), with: replacement)
+                replaceCharacters(in: NSRange(rangePtr!.load(as: CFRange.self)), with: replacement)
             }
             return numOccurrences
         } else {

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -187,14 +187,14 @@ internal func _bytesInEncoding(_ str: NSString, _ encoding: String.Encoding, _ f
         return nil
     }
     
-    let buffer = malloc(cLength + 1)!
+    let buffer = malloc(cLength + 1)!.bindMemory(to: Int8.self, capacity: cLength + 1)
     if !str.getBytes(buffer, maxLength: cLength, usedLength: &used, encoding: encoding.rawValue, options: options, range: theRange, remaining: nil) {
         fatalError("Internal inconsistency; previously claimed getBytes returned success but failed with similar invocation")
     }
     
-    UnsafeMutablePointer<Int8>(buffer).advanced(by: cLength).initialize(to: 0)
+    buffer.advanced(by: cLength).initialize(to: 0)
     
-    return UnsafePointer<Int8>(buffer) // leaked and should be autoreleased via a NSData backing but we cannot here
+    return buffer // leaked and should be autoreleased via a NSData backing but we cannot here
 }
 
 internal func isALineSeparatorTypeCharacter(_ ch: unichar) -> Bool {
@@ -888,14 +888,14 @@ extension NSString {
                 return true
             }
         }
-        if getBytes(UnsafeMutablePointer<Void>(buffer), maxLength: maxBufferCount, usedLength: &used, encoding: encoding, options: [], range: NSMakeRange(0, self.length), remaining: nil) {
+        if getBytes(UnsafeMutableRawPointer(buffer), maxLength: maxBufferCount, usedLength: &used, encoding: encoding, options: [], range: NSMakeRange(0, self.length), remaining: nil) {
             buffer.advanced(by: used).initialize(to: 0)
             return true
         }
         return false
     }
     
-    public func getBytes(_ buffer: UnsafeMutablePointer<Void>?, maxLength maxBufferCount: Int, usedLength usedBufferCount: UnsafeMutablePointer<Int>?, encoding: UInt, options: EncodingConversionOptions = [], range: NSRange, remaining leftover: NSRangePointer?) -> Bool {
+    public func getBytes(_ buffer: UnsafeMutableRawPointer?, maxLength maxBufferCount: Int, usedLength usedBufferCount: UnsafeMutablePointer<Int>?, encoding: UInt, options: EncodingConversionOptions = [], range: NSRange, remaining leftover: NSRangePointer?) -> Bool {
         var totalBytesWritten = 0
         var numCharsProcessed = 0
         let cfStringEncoding = CFStringConvertNSStringEncodingToEncoding(encoding)
@@ -905,7 +905,8 @@ extension NSString {
                 let lossyOk = options.contains(.allowLossy)
                 let externalRep = options.contains(.externalRepresentation)
                 let failOnPartial = options.contains(.failOnPartialEncodingConversion)
-                numCharsProcessed = __CFStringEncodeByteStream(_cfObject, range.location, range.length, externalRep, cfStringEncoding, lossyOk ? (encoding == String.Encoding.ascii.rawValue ? 0xFF : 0x3F) : 0, UnsafeMutablePointer<UInt8>(buffer), buffer != nil ? maxBufferCount : 0, &totalBytesWritten)
+                let bytePtr = buffer?.bindMemory(as: UInt8.self, capacity: maxBufferCount)
+                numCharsProcessed = __CFStringEncodeByteStream(_cfObject, range.location, range.length, externalRep, cfStringEncoding, lossyOk ? (encoding == String.Encoding.ascii.rawValue ? 0xFF : 0x3F) : 0, bytePtr, bytePtr != nil ? maxBufferCount : 0, &totalBytesWritten)
                 if (failOnPartial && numCharsProcessed < range.length) || numCharsProcessed == 0 {
                     result = false
                 }
@@ -1147,7 +1148,8 @@ extension NSString {
         var mData = Data(count: numBytes)!
         // The getBytes:... call should hopefully not fail, given it succeeded above, but check anyway (mutable string changing behind our back?)
         var used = 0
-        try mData.withUnsafeMutableBytes { (mutableBytes: UnsafeMutablePointer<Void>) -> Void in
+        // This binds mData memory to UInt8 because Data.withUnsafeMutableBytes does not handle raw pointers.
+        try mData.withUnsafeMutableBytes { (mutableBytes: UnsafeMutablePointer<UInt8>) -> Void in
             if !getBytes(mutableBytes, maxLength: numBytes, usedLength: &used, encoding: enc, options: [], range: theRange, remaining: nil) {
                 throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileWriteUnknownError.rawValue, userInfo: [
                     NSURLErrorKey: dest,
@@ -1175,7 +1177,7 @@ extension NSString {
         // ignore the no-copy-ness
         self.init(characters: characters, length: length)
         if freeBuffer { // cant take a hint here...
-            free(UnsafeMutablePointer<Void>(characters))
+            free(UnsafeMutableRawPointer(characters))
         }
     }
     
@@ -1215,8 +1217,8 @@ extension NSString {
     }
     
     public convenience init?(data: Data, encoding: UInt) {
-        guard let cf = data.withUnsafeBytes({ (bytes: UnsafePointer<Void>) -> CFString? in
-            return CFStringCreateWithBytes(kCFAllocatorDefault, UnsafePointer<UInt8>(bytes), data.count, CFStringConvertNSStringEncodingToEncoding(encoding), true)
+        guard let cf = data.withUnsafeBytes({ (bytes: UnsafePointer<UInt8>) -> CFString? in
+            return CFStringCreateWithBytes(kCFAllocatorDefault, bytes, data.count, CFStringConvertNSStringEncodingToEncoding(encoding), true)
         }) else { return nil }
         
         var str: String?
@@ -1227,8 +1229,9 @@ extension NSString {
         }
     }
     
-    public convenience init?(bytes: UnsafePointer<Void>, length len: Int, encoding: UInt) {
-        guard let cf = CFStringCreateWithBytes(kCFAllocatorDefault, UnsafePointer<UInt8>(bytes), len, CFStringConvertNSStringEncodingToEncoding(encoding), true) else {
+    public convenience init?(bytes: UnsafeRawPointer, length len: Int, encoding: UInt) {
+        let bytePtr = bytes.bindMemory(as: UInt8.self, capacity: len)
+        guard let cf = CFStringCreateWithBytes(kCFAllocatorDefault, bytePtr, len, CFStringConvertNSStringEncodingToEncoding(encoding), true) else {
             return nil
         }
         var str: String?
@@ -1239,7 +1242,7 @@ extension NSString {
         }
     }
     
-    public convenience init?(bytesNoCopy bytes: UnsafeMutablePointer<Void>, length len: Int, encoding: UInt, freeWhenDone freeBuffer: Bool) /* "NoCopy" is a hint */ {
+    public convenience init?(bytesNoCopy bytes: UnsafeMutableRawPointer, length len: Int, encoding: UInt, freeWhenDone freeBuffer: Bool) /* "NoCopy" is a hint */ {
         // just copy for now since the internal storage will be a copy anyhow
         self.init(bytes: bytes, length: len, encoding: encoding)
         if freeBuffer { // dont take the hint
@@ -1262,7 +1265,8 @@ extension NSString {
     public convenience init(contentsOf url: URL, encoding enc: UInt) throws {
         let readResult = try NSData(contentsOf: url, options: [])
 
-        guard let cf = CFStringCreateWithBytes(kCFAllocatorDefault, UnsafePointer<UInt8>(readResult.bytes), readResult.length, CFStringConvertNSStringEncodingToEncoding(enc), true) else {
+        let bytePtr = readResult.bindMemory(as: UInt8.self, capacity: readResult.length)
+        guard let cf = CFStringCreateWithBytes(kCFAllocatorDefault, bytePtr, readResult.length, CFStringConvertNSStringEncodingToEncoding(enc), true) else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileReadInapplicableStringEncodingError.rawValue, userInfo: [
                 "NSDebugDescription" : "Unable to create a string using the specified encoding."
                 ])
@@ -1397,8 +1401,8 @@ extension NSMutableString {
         if let findResults = CFStringCreateArrayWithFindResults(kCFAllocatorSystemDefault, _cfObject, target._cfObject, CFRange(searchRange), options._cfValue(true)) {
             let numOccurrences = CFArrayGetCount(findResults)
             for cnt in 0..<numOccurrences {
-                let range = UnsafePointer<CFRange>(CFArrayGetValueAtIndex(findResults, backwards ? cnt : numOccurrences - cnt - 1)!)
-                replaceCharacters(in: NSRange(range.pointee), with: replacement)
+                let rangePtr = CFArrayGetValueAtIndex(findResults, backwards ? cnt : numOccurrences - cnt - 1)
+                replaceCharacters(in: NSRange(range!.load(as: CFRange)), with: replacement)
             }
             return numOccurrences
         } else {

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -67,7 +67,7 @@ internal func _CFSwiftIsEqual(_ cf1: AnyObject, cf2: AnyObject) -> Bool {
 // Ivars in _NSCF* types must be zeroed via an unsafe accessor to avoid deinit of potentially unsafe memory to accces as an object/struct etc since it is stored via a foreign object graph
 internal func _CFZeroUnsafeIvars<T>(_ arg: inout T) {
     withUnsafeMutablePointer(&arg) { (ptr: UnsafeMutablePointer<T>) -> Void in
-        bzero(unsafeBitCast(ptr, to: UnsafeMutablePointer<Void>.self), sizeof(T.self))
+        bzero(unsafeBitCast(ptr, to: UnsafeMutableRawPointer.self), sizeof(T.self))
     }
 }
 
@@ -77,24 +77,24 @@ internal func __CFSwiftGetBaseClass() -> AnyObject.Type {
 
 internal func __CFInitializeSwift() {
     
-    _CFRuntimeBridgeTypeToClass(CFStringGetTypeID(), unsafeBitCast(_NSCFString.self, to: UnsafePointer<Void>.self))
-    _CFRuntimeBridgeTypeToClass(CFArrayGetTypeID(), unsafeBitCast(_NSCFArray.self, to: UnsafePointer<Void>.self))
-    _CFRuntimeBridgeTypeToClass(CFDictionaryGetTypeID(), unsafeBitCast(_NSCFDictionary.self, to: UnsafePointer<Void>.self))
-    _CFRuntimeBridgeTypeToClass(CFSetGetTypeID(), unsafeBitCast(_NSCFSet.self, to: UnsafePointer<Void>.self))
-    _CFRuntimeBridgeTypeToClass(CFNumberGetTypeID(), unsafeBitCast(NSNumber.self, to: UnsafePointer<Void>.self))
-    _CFRuntimeBridgeTypeToClass(CFDataGetTypeID(), unsafeBitCast(NSData.self, to: UnsafePointer<Void>.self))
-    _CFRuntimeBridgeTypeToClass(CFDateGetTypeID(), unsafeBitCast(NSDate.self, to: UnsafePointer<Void>.self))
-    _CFRuntimeBridgeTypeToClass(CFURLGetTypeID(), unsafeBitCast(NSURL.self, to: UnsafePointer<Void>.self))
-    _CFRuntimeBridgeTypeToClass(CFCalendarGetTypeID(), unsafeBitCast(Calendar.self, to: UnsafePointer<Void>.self))
-    _CFRuntimeBridgeTypeToClass(CFLocaleGetTypeID(), unsafeBitCast(Locale.self, to: UnsafePointer<Void>.self))
-    _CFRuntimeBridgeTypeToClass(CFTimeZoneGetTypeID(), unsafeBitCast(TimeZone.self, to: UnsafePointer<Void>.self))
-    _CFRuntimeBridgeTypeToClass(CFCharacterSetGetTypeID(), unsafeBitCast(_NSCFCharacterSet.self, to: UnsafePointer<Void>.self))
+    _CFRuntimeBridgeTypeToClass(CFStringGetTypeID(), unsafeBitCast(_NSCFString.self, to: UnsafeRawPointer.self))
+    _CFRuntimeBridgeTypeToClass(CFArrayGetTypeID(), unsafeBitCast(_NSCFArray.self, to: UnsafeRawPointer.self))
+    _CFRuntimeBridgeTypeToClass(CFDictionaryGetTypeID(), unsafeBitCast(_NSCFDictionary.self, to: UnsafeRawPointer.self))
+    _CFRuntimeBridgeTypeToClass(CFSetGetTypeID(), unsafeBitCast(_NSCFSet.self, to: UnsafeRawPointer.self))
+    _CFRuntimeBridgeTypeToClass(CFNumberGetTypeID(), unsafeBitCast(NSNumber.self, to: UnsafeRawPointer.self))
+    _CFRuntimeBridgeTypeToClass(CFDataGetTypeID(), unsafeBitCast(NSData.self, to: UnsafeRawPointer.self))
+    _CFRuntimeBridgeTypeToClass(CFDateGetTypeID(), unsafeBitCast(NSDate.self, to: UnsafeRawPointer.self))
+    _CFRuntimeBridgeTypeToClass(CFURLGetTypeID(), unsafeBitCast(NSURL.self, to: UnsafeRawPointer.self))
+    _CFRuntimeBridgeTypeToClass(CFCalendarGetTypeID(), unsafeBitCast(Calendar.self, to: UnsafeRawPointer.self))
+    _CFRuntimeBridgeTypeToClass(CFLocaleGetTypeID(), unsafeBitCast(Locale.self, to: UnsafeRawPointer.self))
+    _CFRuntimeBridgeTypeToClass(CFTimeZoneGetTypeID(), unsafeBitCast(TimeZone.self, to: UnsafeRawPointer.self))
+    _CFRuntimeBridgeTypeToClass(CFCharacterSetGetTypeID(), unsafeBitCast(_NSCFCharacterSet.self, to: UnsafeRawPointer.self))
     
-//    _CFRuntimeBridgeTypeToClass(CFErrorGetTypeID(), unsafeBitCast(NSError.self, UnsafePointer<Void>.self))
-//    _CFRuntimeBridgeTypeToClass(CFAttributedStringGetTypeID(), unsafeBitCast(NSMutableAttributedString.self, UnsafePointer<Void>.self))
-//    _CFRuntimeBridgeTypeToClass(CFReadStreamGetTypeID(), unsafeBitCast(NSInputStream.self, UnsafePointer<Void>.self))
-//    _CFRuntimeBridgeTypeToClass(CFWriteStreamGetTypeID(), unsafeBitCast(NSOutputStream.self, UnsafePointer<Void>.self))
-   _CFRuntimeBridgeTypeToClass(CFRunLoopTimerGetTypeID(), unsafeBitCast(Timer.self, to: UnsafePointer<Void>.self))
+//    _CFRuntimeBridgeTypeToClass(CFErrorGetTypeID(), unsafeBitCast(NSError.self, UnsafeRawPointer.self))
+//    _CFRuntimeBridgeTypeToClass(CFAttributedStringGetTypeID(), unsafeBitCast(NSMutableAttributedString.self, UnsafeRawPointer.self))
+//    _CFRuntimeBridgeTypeToClass(CFReadStreamGetTypeID(), unsafeBitCast(NSInputStream.self, UnsafeRawPointer.self))
+//    _CFRuntimeBridgeTypeToClass(CFWriteStreamGetTypeID(), unsafeBitCast(NSOutputStream.self, UnsafeRawPointer.self))
+   _CFRuntimeBridgeTypeToClass(CFRunLoopTimerGetTypeID(), unsafeBitCast(Timer.self, to: UnsafeRawPointer.self))
     
     __CFSwiftBridge.NSObject.isEqual = _CFSwiftIsEqual
     __CFSwiftBridge.NSObject.hash = _CFSwiftGetHash
@@ -307,7 +307,7 @@ extension Bool : _NSObjectRepresentable {
 }
 
 public func === (lhs: AnyClass, rhs: AnyClass) -> Bool {
-    return unsafeBitCast(lhs, to: UnsafePointer<Void>.self) == unsafeBitCast(rhs, to: UnsafePointer<Void>.self)
+    return unsafeBitCast(lhs, to: UnsafeRawPointer.self) == unsafeBitCast(rhs, to: UnsafeRawPointer.self)
 }
 
 /// Swift extensions for common operations in Foundation that use unsafe things...
@@ -323,7 +323,7 @@ extension NSObject {
     }
     
     static func releaseReference<T>(_ value: UnsafePointer<T>) {
-        _CFSwiftRelease(UnsafeMutablePointer<Void>(value))
+        _CFSwiftRelease(UnsafeMutableRawPointer(mutating: value))
     }
     
     static func releaseReference<T>(_ value: UnsafeMutablePointer<T>) {
@@ -331,11 +331,11 @@ extension NSObject {
     }
 
     func withRetainedReference<T, R>(_ work: @noescape (UnsafePointer<T>) -> R) -> R {
-        return work(UnsafePointer<T>(_CFSwiftRetain(unsafeBitCast(self, to: UnsafeMutablePointer<Void>.self))!))
+        return work(UnsafePointer<T>(_CFSwiftRetain(unsafeBitCast(self, to: UnsafeMutableRawPointer.self))!))
     }
     
     func withRetainedReference<T, R>(_ work: @noescape (UnsafeMutablePointer<T>) -> R) -> R {
-        return work(UnsafeMutablePointer<T>(_CFSwiftRetain(unsafeBitCast(self, to: UnsafeMutablePointer<Void>.self))!))
+        return work(UnsafeMutablePointer<T>(_CFSwiftRetain(unsafeBitCast(self, to: UnsafeMutableRawPointer.self))!))
     }
     
     func withUnretainedReference<T, R>(_ work: @noescape (UnsafePointer<T>) -> R) -> R {

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -331,19 +331,23 @@ extension NSObject {
     }
 
     func withRetainedReference<T, R>(_ work: @noescape (UnsafePointer<T>) -> R) -> R {
-        return work(UnsafePointer<T>(_CFSwiftRetain(unsafeBitCast(self, to: UnsafeMutableRawPointer.self))!))
+        let selfPtr = Unmanaged.passRetained(self).toOpaque().assumingMemoryBound(to: T.self)
+        return work(selfPtr)
     }
     
     func withRetainedReference<T, R>(_ work: @noescape (UnsafeMutablePointer<T>) -> R) -> R {
-        return work(UnsafeMutablePointer<T>(_CFSwiftRetain(unsafeBitCast(self, to: UnsafeMutableRawPointer.self))!))
+        let selfPtr = Unmanaged.passRetained(self).toOpaque().assumingMemoryBound(to: T.self)
+        return work(selfPtr)
     }
     
     func withUnretainedReference<T, R>(_ work: @noescape (UnsafePointer<T>) -> R) -> R {
-        return work(unsafeBitCast(self, to: UnsafePointer<T>.self))
+        let selfPtr = Unmanaged.passRetained(self).toOpaque().assumingMemoryBound(to: T.self)
+        return work(selfPtr)
     }
     
     func withUnretainedReference<T, R>(_ work: @noescape (UnsafeMutablePointer<T>) -> R) -> R {
-        return work(unsafeBitCast(self, to: UnsafeMutablePointer<T>.self))
+        let selfPtr = Unmanaged.passRetained(self).toOpaque().assumingMemoryBound(to: T.self)
+        return work(selfPtr)
     }
 }
 

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -314,19 +314,19 @@ public func === (lhs: AnyClass, rhs: AnyClass) -> Bool {
 
 
 extension NSObject {
-    static func unretainedReference<T, R: NSObject>(_ value: UnsafePointer<T>) -> R {
+    static func unretainedReference<R: NSObject>(_ value: UnsafeRawPointer) -> R {
         return unsafeBitCast(value, to: R.self)
     }
     
-    static func unretainedReference<T, R: NSObject>(_ value: UnsafeMutablePointer<T>) -> R {
-        return unretainedReference(UnsafePointer<T>(value))
+    static func unretainedReference<R: NSObject>(_ value: UnsafeMutableRawPointer) -> R {
+        return unretainedReference(value)
     }
     
-    static func releaseReference<T>(_ value: UnsafePointer<T>) {
+    static func releaseReference(_ value: UnsafeRawPointer) {
         _CFSwiftRelease(UnsafeMutableRawPointer(mutating: value))
     }
     
-    static func releaseReference<T>(_ value: UnsafeMutablePointer<T>) {
+    static func releaseReference(_ value: UnsafeMutableRawPointer) {
         _CFSwiftRelease(value)
     }
 

--- a/Foundation/NSTask.swift
+++ b/Foundation/NSTask.swift
@@ -34,24 +34,24 @@ private var managerThreadRunLoopIsRunningCondition = Condition()
 internal let kCFSocketDataCallBack = CFSocketCallBackType.dataCallBack.rawValue
 #endif
 
-private func emptyRunLoopCallback(_ context : UnsafeMutablePointer<Void>?) -> Void {}
+private func emptyRunLoopCallback(_ context : UnsafeMutableRawPointer?) -> Void {}
 
 
 // Retain method for run loop source
-private func runLoopSourceRetain(_ pointer : UnsafePointer<Void>?) -> UnsafePointer<Void>? {
+private func runLoopSourceRetain(_ pointer : UnsafeRawPointer?) -> UnsafeRawPointer? {
     let ref = Unmanaged<AnyObject>.fromOpaque(pointer!).takeUnretainedValue()
     let retained = Unmanaged<AnyObject>.passRetained(ref)
-    return unsafeBitCast(retained, to: UnsafePointer<Void>.self)
+    return unsafeBitCast(retained, to: UnsafeRawPointer.self)
 }
 
 // Release method for run loop source
-private func runLoopSourceRelease(_ pointer : UnsafePointer<Void>?) -> Void {
+private func runLoopSourceRelease(_ pointer : UnsafeRawPointer?) -> Void {
     Unmanaged<AnyObject>.fromOpaque(pointer!).release()
 }
 
 // Equal method for run loop source
 
-private func runloopIsEqual(_ a : UnsafePointer<Void>?, _ b : UnsafePointer<Void>?) -> _DarwinCompatibleBoolean {
+private func runloopIsEqual(_ a : UnsafeRawPointer?, _ b : UnsafeRawPointer?) -> _DarwinCompatibleBoolean {
     
     let unmanagedrunLoopA = Unmanaged<AnyObject>.fromOpaque(a!)
     guard let runLoopA = unmanagedrunLoopA.takeUnretainedValue() as? RunLoop else {
@@ -72,7 +72,7 @@ private func runloopIsEqual(_ a : UnsafePointer<Void>?, _ b : UnsafePointer<Void
 
 
 // Equal method for task in run loop source
-private func nstaskIsEqual(_ a : UnsafePointer<Void>?, _ b : UnsafePointer<Void>?) -> _DarwinCompatibleBoolean {
+private func nstaskIsEqual(_ a : UnsafeRawPointer?, _ b : UnsafeRawPointer?) -> _DarwinCompatibleBoolean {
     
     let unmanagedTaskA = Unmanaged<AnyObject>.fromOpaque(a!)
     guard let taskA = unmanagedTaskA.takeUnretainedValue() as? Task else {
@@ -212,7 +212,7 @@ public class Task: NSObject {
         
         defer {
             for arg in argv ..< argv + args.count {
-                free(UnsafeMutablePointer<Void>(arg.pointee))
+                free(UnsafeMutableRawPointer(arg.pointee))
             }
             
             argv.deallocate(capacity: args.count + 1)
@@ -232,7 +232,7 @@ public class Task: NSObject {
         defer {
             if let env = environment {
                 for pair in envp ..< envp + env.count {
-                    free(UnsafeMutablePointer<Void>(pair.pointee))
+                    free(UnsafeMutableRawPointer(pair.pointee))
                 }
                 envp.deallocate(capacity: env.count + 1)
             }
@@ -244,7 +244,7 @@ public class Task: NSObject {
         context.version = 0
         context.retain = runLoopSourceRetain
         context.release = runLoopSourceRelease
-		context.info = UnsafeMutablePointer<Void>(Unmanaged.passUnretained(self).toOpaque())
+	context.info = Unmanaged.passUnretained(self).toOpaque()
         
         let socket = CFSocketCreateWithNative( nil, taskSocketPair[0], CFOptionFlags(kCFSocketDataCallBack), {
             (socket, type, address, data, info )  in
@@ -368,7 +368,7 @@ public class Task: NSObject {
         
         self.runLoop = RunLoop.current()
         self.runLoopSourceContext = CFRunLoopSourceContext(version: 0,
-                                                           info: UnsafeMutablePointer<Void>(Unmanaged.passUnretained(self).toOpaque()),
+                                                           info: Unmanaged.passUnretained(self).toOpaque(),
                                                            retain: { return runLoopSourceRetain($0) },
                                                            release: { runLoopSourceRelease($0) },
                                                            copyDescription: nil,

--- a/Foundation/NSTask.swift
+++ b/Foundation/NSTask.swift
@@ -108,7 +108,8 @@ public class Task: NSObject {
                     emptySourceContext.equal = runloopIsEqual
                     emptySourceContext.perform = emptyRunLoopCallback
                     managerThreadRunLoop!.withUnretainedReference {
-                        emptySourceContext.info = $0
+                        (refPtr: UnsafeMutablePointer<UInt8>) in
+                        emptySourceContext.info = UnsafeMutableRawPointer(refPtr)
                     }
                     
                     CFRunLoopAddSource(managerThreadRunLoop?._cfRunLoop, CFRunLoopSourceCreate(kCFAllocatorDefault, 0, &emptySourceContext), kCFRunLoopDefaultMode)
@@ -386,7 +387,8 @@ public class Task: NSObject {
         runLoopContext.equal = nstaskIsEqual
         runLoopContext.perform = emptyRunLoopCallback
         self.withUnretainedReference {
-            runLoopContext.info = $0
+            (refPtr: UnsafeMutablePointer<UInt8>) in
+            runLoopContext.info = UnsafeMutableRawPointer(refPtr)
         }
         self.runLoopSourceContext = runLoopContext
         

--- a/Foundation/NSThread.swift
+++ b/Foundation/NSThread.swift
@@ -46,7 +46,7 @@ internal enum _NSThreadStatus {
     case finished
 }
 
-private func NSThreadStart(_ context: UnsafeMutablePointer<Void>?) -> UnsafeMutablePointer<Void>? {
+private func NSThreadStart(_ context: UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer? {
     let thread: Thread = NSObject.unretainedReference(context!)
     Thread._currentThread.set(thread)
     thread._status = .executing

--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -13,9 +13,9 @@ import CoreFoundation
 public class TimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
     typealias CFType = CFTimeZone
     private var _base = _CFInfo(typeID: CFTimeZoneGetTypeID())
-    private var _name: UnsafeMutablePointer<Void>? = nil
-    private var _data: UnsafeMutablePointer<Void>? = nil
-    private var _periods: UnsafeMutablePointer<Void>? = nil
+    private var _name: UnsafeMutableRawPointer? = nil
+    private var _data: UnsafeMutableRawPointer? = nil
+    private var _periods: UnsafeMutableRawPointer? = nil
     private var _periodCnt = Int32(0)
     
     internal var _cfObject: CFType {
@@ -86,7 +86,7 @@ public class TimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
     
     public convenience init?(abbreviation: String) {
         let abbr = abbreviation._cfObject
-        guard let name = unsafeBitCast(CFDictionaryGetValue(CFTimeZoneCopyAbbreviationDictionary(), unsafeBitCast(abbr, to: UnsafePointer<Void>.self)), to: NSString!.self) else {
+        guard let name = unsafeBitCast(CFDictionaryGetValue(CFTimeZoneCopyAbbreviationDictionary(), unsafeBitCast(abbr, to: UnsafeRawPointer.self)), to: NSString!.self) else {
             return nil
         }
         self.init(name: name._swiftObject , data: nil)

--- a/Foundation/NSTimer.swift
+++ b/Foundation/NSTimer.swift
@@ -10,7 +10,7 @@
 
 import CoreFoundation
 
-internal func __NSFireTimer(_ timer: CFRunLoopTimer?, info: UnsafeMutablePointer<Void>?) -> Void {
+internal func __NSFireTimer(_ timer: CFRunLoopTimer?, info: UnsafeMutableRawPointer?) -> Void {
     let t: Timer = NSObject.unretainedReference(info!)
     t._fire(t)
 }

--- a/Foundation/NSTimer.swift
+++ b/Foundation/NSTimer.swift
@@ -39,7 +39,8 @@ public class Timer: NSObject {
         _fire = block
         var context = CFRunLoopTimerContext()
         withRetainedReference {
-            context.info = $0
+            (refPtr: UnsafeMutablePointer<UInt8>) in
+            context.info = UnsafeMutableRawPointer(refPtr)
         }
         let timer = withUnsafeMutablePointer(&context) { (ctx: UnsafeMutablePointer<CFRunLoopTimerContext>) -> CFRunLoopTimer in
             var t = interval

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -343,10 +343,10 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
         let bytesNeeded = CFURLGetBytes(_cfObject, nil, 0)
         assert(bytesNeeded > 0)
         
-        let buffer = malloc(bytesNeeded)!
-        let bytesFilled = CFURLGetBytes(_cfObject, UnsafeMutablePointer<UInt8>(buffer), bytesNeeded)
+        let buffer = malloc(bytesNeeded)!.bindMemory(to: UInt8.self, capacity: bytesNeeded)
+        let bytesFilled = CFURLGetBytes(_cfObject, buffer, bytesNeeded)
         if bytesFilled == bytesNeeded {
-            return Data(bytesNoCopy: UnsafeMutablePointer<UInt8>(buffer), count: bytesNeeded, deallocator: .none)
+            return Data(bytesNoCopy: buffer, count: bytesNeeded, deallocator: .none)
         } else {
             fatalError()
         }

--- a/Foundation/NSUUID.swift
+++ b/Foundation/NSUUID.swift
@@ -32,7 +32,7 @@ public class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     public init(UUIDBytes bytes: UnsafePointer<UInt8>) {
-        memcpy(unsafeBitCast(buffer, to: UnsafeMutablePointer<Void>.self), UnsafePointer<Void>(bytes), 16)
+        memcpy(unsafeBitCast(buffer, to: UnsafeMutableRawPointer.self), UnsafeRawPointer(bytes), 16)
     }
     
     public func getUUIDBytes(_ uuid: UnsafeMutablePointer<UInt8>) {

--- a/Foundation/NSValue.swift
+++ b/Foundation/NSValue.swift
@@ -76,7 +76,7 @@ public class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    public func getValue(_ value: UnsafeMutablePointer<Void>) {
+    public func getValue(_ value: UnsafeMutableRawPointer) {
         if self.dynamicType == NSValue.self {
             return _concreteValue.getValue(value)
         } else {
@@ -96,7 +96,7 @@ public class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
         return NSSpecialValue._typeFromObjCType(type) != nil
     }
     
-    public convenience required init(bytes value: UnsafePointer<Void>, objCType type: UnsafePointer<Int8>) {
+    public convenience required init(bytes value: UnsafeRawPointer, objCType type: UnsafePointer<Int8>) {
         if self.dynamicType == NSValue.self {
             self.init()
             if NSValue._isSpecialObjCType(type) {

--- a/Foundation/NSXMLNode.swift
+++ b/Foundation/NSXMLNode.swift
@@ -719,7 +719,7 @@ public class XMLNode: NSObject, NSCopying {
         var result: [XMLNode] = []
         for i in 0..<CFArrayGetCount(nodes) {
             let nodePtr = CFArrayGetValueAtIndex(nodes, i)!
-            result.append(XMLNode._objectNodeForNode(_CFXMLNodePtr(nodePtr)))
+            result.append(XMLNode._objectNodeForNode(_CFXMLNodePtr(mutating: nodePtr)))
         }
 
         return result

--- a/Foundation/NSXMLParser.swift
+++ b/Foundation/NSXMLParser.swift
@@ -565,13 +565,13 @@ public class XMLParser : NSObject {
         XMLParser.setCurrentParser(self)
         if let stream = _stream {
             stream.open()
-            let buffer = malloc(_chunkSize)!
-            var len = stream.read(UnsafeMutablePointer<UInt8>(buffer), maxLength: _chunkSize)
+            let buffer = malloc(_chunkSize)!.bindMemory(to: UInt8.self, capacity: _chunkSize)
+            var len = stream.read(buffer, maxLength: _chunkSize)
             if len != -1 {
                 while len > 0 {
-                    let data = Data(bytesNoCopy: UnsafeMutablePointer<UInt8>(buffer), count: len, deallocator: .none)
+                    let data = Data(bytesNoCopy: buffer, count: len, deallocator: .none)
                     result = parseData(data)
-                    len = stream.read(UnsafeMutablePointer<UInt8>(buffer), maxLength: _chunkSize)
+                    len = stream.read(buffer, maxLength: _chunkSize)
                 }
             } else {
                 result = false
@@ -579,7 +579,7 @@ public class XMLParser : NSObject {
             free(buffer)
             stream.close()
         } else if let data = _data {
-            let buffer = malloc(_chunkSize)!
+            let buffer = malloc(_chunkSize)!.bindMemory(to: UInt8.self, capacity: _chunkSize)
             var range = NSMakeRange(0, min(_chunkSize, data.count))
             while result {
                 let chunk = data.withUnsafeBytes { (buffer: UnsafePointer<UInt8>) -> Data in

--- a/Foundation/NSXMLParser.swift
+++ b/Foundation/NSXMLParser.swift
@@ -372,7 +372,7 @@ internal func _NSXMLParserProcessingInstruction(_ ctx: _CFXMLInterface, target: 
 internal func _NSXMLParserCdataBlock(_ ctx: _CFXMLInterface, value: UnsafePointer<UInt8>, len: Int32) -> Void {
     let parser = ctx.parser
     if let delegate = parser.delegate {
-        delegate.parser(parser, foundCDATA: Data(bytes: UnsafePointer<Void>(value), count: Int(len)))
+        delegate.parser(parser, foundCDATA: Data(bytes: UnsafeRawPointer(value), count: Int(len)))
     }
 }
 

--- a/Foundation/String.swift
+++ b/Foundation/String.swift
@@ -653,7 +653,7 @@ extension String {
   /// in a given encoding, and optionally frees the buffer.  WARNING:
   /// this initializer is not memory-safe!
   public init?(
-    bytesNoCopy bytes: UnsafeMutablePointer<Void>, length: Int,
+    bytesNoCopy bytes: UnsafeMutableRawPointer, length: Int,
     encoding: Encoding, freeWhenDone flag: Bool
   ) {
     if let ns = NSString(

--- a/TestFoundation/TestNSArray.swift
+++ b/TestFoundation/TestNSArray.swift
@@ -363,12 +363,12 @@ class TestNSArray : XCTestCase {
         let mutableInput = inputNumbers.bridge().mutableCopy() as! NSMutableArray
         let expectedNumbers = inputNumbers.sorted()
 
-        func compare(_ left: AnyObject, right:AnyObject,  context: UnsafeMutablePointer<Void>?) -> Int {
+        func compare(_ left: AnyObject, right:AnyObject,  context: UnsafeMutableRawPointer?) -> Int {
             let l = (left as! NSNumber).intValue
             let r = (right as! NSNumber).intValue
             return l < r ? -1 : (l > r ? 0 : 1)
         }
-        mutableInput.sortUsingFunction(compare, context: UnsafeMutablePointer<Void>(bitPattern: 0))
+        mutableInput.sortUsingFunction(compare, context: UnsafeMutableRawPointer(bitPattern: 0))
 
         XCTAssertEqual(mutableInput.map { ($0 as! NSNumber).intValue}, expectedNumbers)
     }

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -45,7 +45,7 @@ extension TestNSJSONSerialization {
     }
     
     func test_JSONObjectWithData_emptyObject() {
-        let subject = Data(bytes: UnsafePointer<Void>([UInt8]([0x7B, 0x7D])), count: 2)
+        let subject = Data(bytes: UnsafeRawPointer([UInt8]([0x7B, 0x7D])), count: 2)
         
         let object = try! JSONSerialization.jsonObject(with: subject, options: []) as? [String:Any]
         XCTAssertEqual(object?.count, 0)
@@ -75,7 +75,7 @@ extension TestNSJSONSerialization {
         ]
         
         for (description, encoded) in subjects {
-            let result = try? JSONSerialization.jsonObject(with: Data(bytes:UnsafePointer<Void>(encoded), count: encoded.count), options: [])
+            let result = try? JSONSerialization.jsonObject(with: Data(bytes:UnsafeRawPointer(encoded), count: encoded.count), options: [])
             XCTAssertNotNil(result, description)
         }
     }

--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -151,7 +151,7 @@ class TestNSKeyedArchiver : XCTestCase {
         decode: {unarchiver -> Bool in
             var expected: Array<Int32> = [0, 0, 0, 0]
             expected.withUnsafeMutableBufferPointer {(p: inout UnsafeMutableBufferPointer<Int32>) in
-                unarchiver.decodeValue(ofObjCType: "[4i]", at: UnsafeMutablePointer<Void>(p.baseAddress!))
+                unarchiver.decodeValue(ofObjCType: "[4i]", at: UnsafeMutableRawPointer(p.baseAddress!))
             }
             XCTAssertEqual(expected, array)
             return true

--- a/TestFoundation/TestNSXMLParser.swift
+++ b/TestFoundation/TestNSXMLParser.swift
@@ -28,7 +28,7 @@ class TestNSXMLParser : XCTestCase {
     func test_data() {
         let xml = Array("<test><foo>bar</foo></test>".nulTerminatedUTF8)
         let data = xml.withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<UInt8>) -> Data in
-            return Data(bytes:UnsafePointer<Void>(buffer.baseAddress!), count: buffer.count)
+            return Data(bytes:UnsafeRawPointer(buffer.baseAddress!), count: buffer.count)
         }
         let parser = XMLParser(data: data)
         let res = parser.parse()


### PR DESCRIPTION
Unsafe[Mutable]Pointer is replaced by Unsafe[Mutable]RawPointer.

Migrating often means simply removing casts to/from UnsafePointer
and working directly with UnsafeRawPointer instead.

Unfortunately some API's, like NSData still want UnsafePointer,
which requires "binding" memory to UInt8 before passing it to the API.