### PR TITLE
[SE-0127] Remove calls to withUnsafe[Mutable]Pointers

### DIFF
--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -394,8 +394,10 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     public func range(of unit: Unit, forDate date: Date) -> DateInterval? {
         var start: CFAbsoluteTime = 0.0
         var ti: CFTimeInterval = 0.0
-        let res: Bool = withUnsafeMutablePointers(&start, &ti) { startp, tip in
-           return CFCalendarGetTimeRangeOfUnit(_cfObject, unit._cfValue, date.timeIntervalSinceReferenceDate, startp, tip)
+        let res: Bool = withUnsafeMutablePointer(&start) { startp in
+            withUnsafeMutablePointer(&ti) { tip in
+                return CFCalendarGetTimeRangeOfUnit(_cfObject, unit._cfValue, date.timeIntervalSinceReferenceDate, startp, tip)
+            }
         }
         
         if res {

--- a/Foundation/NSPropertyList.swift
+++ b/Foundation/NSPropertyList.swift
@@ -70,8 +70,10 @@ public class PropertyListSerialization : NSObject {
     public class func propertyList(from data: Data, options opt: ReadOptions = [], format: UnsafeMutablePointer<PropertyListFormat>?) throws -> Any {
         var fmt = kCFPropertyListBinaryFormat_v1_0
         var error: Unmanaged<CFError>? = nil
-        let decoded = withUnsafeMutablePointers(&fmt, &error) { (outFmt: UnsafeMutablePointer<CFPropertyListFormat>, outErr: UnsafeMutablePointer<Unmanaged<CFError>?>) -> NSObject? in
-            return unsafeBitCast(CFPropertyListCreateWithData(kCFAllocatorSystemDefault, data._cfObject, CFOptionFlags(CFIndex(opt.rawValue)), outFmt, outErr), to: NSObject.self)
+        let decoded = withUnsafeMutablePointer(&fmt) { (outFmt: UnsafeMutablePointer<CFPropertyListFormat>) -> NSObject? in
+            withUnsafeMutablePointer(&error) { (outErr: UnsafeMutablePointer<Unmanaged<CFError>?>) -> NSObject? in
+                return unsafeBitCast(CFPropertyListCreateWithData(kCFAllocatorSystemDefault, data._cfObject, CFOptionFlags(CFIndex(opt.rawValue)), outFmt, outErr), to: NSObject.self)
+            }
         }
 #if os(OSX) || os(iOS)
         format?.pointee = PropertyListFormat(rawValue: UInt(fmt.rawValue))!

--- a/Foundation/NSThread.swift
+++ b/Foundation/NSThread.swift
@@ -170,9 +170,11 @@ public class Thread: NSObject {
     public var stackSize: Int {
         get {
             var size: Int = 0
-            return withUnsafeMutablePointers(&_attr, &size) { attr, sz in
-                pthread_attr_getstacksize(attr, sz)
-                return sz.pointee
+            return withUnsafeMutablePointer(&_attr) { attr in
+                withUnsafeMutablePointer(&size) { sz in
+                    pthread_attr_getstacksize(attr, sz)
+                    return sz.pointee
+                }
             }
         }
         set {


### PR DESCRIPTION
Groundwork for removing withUnsafe[Mutable]Pointers from stdlib.