### PR TITLE
Migrate from the removed unsafeAddress(of:) API.

### DIFF
--- a/Foundation/NSCFString.swift
+++ b/Foundation/NSCFString.swift
@@ -59,12 +59,12 @@ internal class _NSCFString : NSMutableString {
 
 internal final class _NSCFConstantString : _NSCFString {
     internal var _ptr : UnsafePointer<UInt8> {
-        let ptr = unsafeAddress(of: self) + sizeof(OpaquePointer.self) + sizeof(Int32.self) + sizeof(Int32.self) + sizeof(_CFInfo.self)
+        let ptr = Unmanaged.passUnretained(self).toOpaque() + sizeof(OpaquePointer.self) + sizeof(Int32.self) + sizeof(Int32.self) + sizeof(_CFInfo.self)
         return UnsafePointer<UnsafePointer<UInt8>>(ptr).pointee
     }
     internal var _length : UInt32 {
         let offset = sizeof(OpaquePointer.self) + sizeof(Int32.self) + sizeof(Int32.self) + sizeof(_CFInfo.self) + sizeof(UnsafePointer<UInt8>.self)
-        let ptr = unsafeAddress(of: self) + offset
+        let ptr = Unmanaged.passUnretained(self).toOpaque() + offset
         return UnsafePointer<UInt32>(ptr).pointee
     }
     

--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -85,7 +85,7 @@ public class NSNotification: NSObject, NSCopying, NSCoding {
     }
     
     public override var description: String {
-        var str = "\(self.dynamicType) \(unsafeAddress(of: self)) {"
+        var str = "\(self.dynamicType) \(Unmanaged.passUnretained(self).toOpaque()) {"
         
         str += "name = \(self.name.rawValue)"
         if let object = self.object {

--- a/Foundation/NSObject.swift
+++ b/Foundation/NSObject.swift
@@ -100,7 +100,7 @@ public class NSObject : NSObjectProtocol, Equatable, Hashable {
     }
     
     public var description: String {
-        return "<\(self.dynamicType): \(unsafeAddress(of: self))>"
+        return "<\(self.dynamicType): \(Unmanaged.passUnretained(self).toOpaque())>"
     }
     
     public var debugDescription: String {

--- a/Foundation/NSOperation.swift
+++ b/Foundation/NSOperation.swift
@@ -324,7 +324,7 @@ public class OperationQueue: NSObject {
             if let requestedName = _name {
                 effectiveName = requestedName
             } else {
-                effectiveName = "NSOperationQueue::\(unsafeAddress(of: self))"
+                effectiveName = "NSOperationQueue::\(Unmanaged.passUnretained(self).toOpaque())"
             }
             let attr: DispatchQueueAttributes
             if maxConcurrentOperationCount == 1 {

--- a/Foundation/NSURLResponse.swift
+++ b/Foundation/NSURLResponse.swift
@@ -232,7 +232,7 @@ public class NSHTTPURLResponse : URLResponse {
     /// A string that represents the contents of the NSHTTPURLResponse Object.
     /// This property is intended to produce readable output.
     override public var description: String {
-        var result = "<\(self.dynamicType) \(unsafeAddress(of: self))> { URL: \(url!.absoluteString) }{ status: \(statusCode), headers {\n"
+        var result = "<\(self.dynamicType) \(Unmanaged.passUnretained(self).toOpaque())> { URL: \(url!.absoluteString) }{ status: \(statusCode), headers {\n"
         for(key, value) in allHeaderFields {
             if((key.lowercased() == "content-disposition" && suggestedFilename != "Unknown") || key.lowercased() == "content-type") {
                 result += "   \"\(key)\" = \"\(value)\";\n"


### PR DESCRIPTION
Use Unmanaged.passUnretained(x).toOpaque() instead.

These changes are due to the [SE-0127](https://github.com/apple/swift-evolution/blob/master/proposals/0127-cleaning-up-stdlib-ptr-buffer.md)