### PR TITLE
A few more 'fileprivate's for SE-0025.

### DIFF
--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -111,13 +111,13 @@ public class AttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
 }
 
 private extension AttributedString {
-    fileprivate struct RangeInfo {
+    struct RangeInfo {
         let rangePointer: NSRangePointer
         let shouldFetchLongestEffectiveRange: Bool
         let longestEffectiveRangeSearchRange: NSRange?
     }
     
-    fileprivate func _attributesAtIndex(_ location: Int, rangeInfo: RangeInfo) -> [String : AnyObject] {
+    func _attributesAtIndex(_ location: Int, rangeInfo: RangeInfo) -> [String : AnyObject] {
         var cfRange = CFRange()
         return withUnsafeMutablePointer(&cfRange) { (cfRangePointer: UnsafeMutablePointer<CFRange>) -> [String : AnyObject] in
             // Get attributes value using CoreFoundation function
@@ -147,7 +147,7 @@ private extension AttributedString {
         }
     }
     
-    fileprivate func _attribute(_ attrName: String, atIndex location: Int, rangeInfo: RangeInfo) -> AnyObject? {
+    func _attribute(_ attrName: String, atIndex location: Int, rangeInfo: RangeInfo) -> AnyObject? {
         var cfRange = CFRange()
         return withUnsafeMutablePointer(&cfRange) { (cfRangePointer: UnsafeMutablePointer<CFRange>) -> AnyObject? in
             // Get attribute value using CoreFoundation function
@@ -171,7 +171,7 @@ private extension AttributedString {
         }
     }
     
-    fileprivate func addAttributesToAttributeArray(attrs: [String : AnyObject]?) {
+    func addAttributesToAttributeArray(attrs: [String : AnyObject]?) {
         guard _string.length > 0 else {
             return
         }

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -283,7 +283,7 @@ public class NSKeyedArchiver : NSCoder {
         }
     }
     
-    private static func _createObjectRef(_ uid : UInt32) -> CFKeyedArchiverUID {
+    fileprivate static func _createObjectRef(_ uid : UInt32) -> CFKeyedArchiverUID {
         return Unmanaged<CFKeyedArchiverUID>.fromOpaque(
             UnsafePointer<Void>(_CFKeyedArchiverUIDCreate(kCFAllocatorSystemDefault, uid))).takeUnretainedValue()
     }

--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -170,13 +170,13 @@ public class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying
     public static func supportsSecureCoding() -> Bool { return true }
     
     /// The URL of the receiver.
-    /*@NSCopying */public private(set) var url: URL?
+    /*@NSCopying */public fileprivate(set) var url: URL?
     
     /// The main document URL associated with this load.
     ///
     /// This URL is used for the cookie "same domain as main
     /// document" policy. There may also be other future uses.
-    /*@NSCopying*/ public private(set) var mainDocumentURL: URL?
+    /*@NSCopying*/ public fileprivate(set) var mainDocumentURL: URL?
     
     internal var _cachePolicy: CachePolicy = .useProtocolCachePolicy
     public var cachePolicy: CachePolicy {
@@ -189,7 +189,7 @@ public class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying
     }
 
     /// Returns the HTTP request method of the receiver.
-    public private(set) var httpMethod: String? = "GET"
+    public fileprivate(set) var httpMethod: String? = "GET"
     
     /// A dictionary containing all the HTTP header fields
     /// of the receiver.

--- a/Foundation/NSURLResponse.swift
+++ b/Foundation/NSURLResponse.swift
@@ -67,7 +67,7 @@ public class URLResponse : NSObject, NSSecureCoding, NSCopying {
     /// that the origin server or source reported the information
     /// incorrectly or imprecisely. An attempt to guess the MIME type may
     /// be made if the origin source did not report any such information.
-    public private(set) var mimeType: String?
+    public fileprivate(set) var mimeType: String?
     
     /// The expected content length of the receiver.
     ///
@@ -81,7 +81,7 @@ public class URLResponse : NSObject, NSSecureCoding, NSCopying {
     /// The expected content length of the receiver, or `-1` if
     /// there is no expectation that can be arrived at regarding expected
     /// content length.
-    public private(set) var expectedContentLength: Int64
+    public fileprivate(set) var expectedContentLength: Int64
     
     /// The name of the text encoding of the receiver.
     ///
@@ -90,7 +90,7 @@ public class URLResponse : NSObject, NSSecureCoding, NSCopying {
     /// URL load. Clients can inspect this string and convert it to an
     /// NSStringEncoding or CFStringEncoding using the methods and
     /// functions made available in the appropriate framework.
-    public private(set) var textEncodingName: String?
+    public fileprivate(set) var textEncodingName: String?
     
     /// A suggested filename if the resource were saved to disk.
     ///
@@ -104,7 +104,7 @@ public class URLResponse : NSObject, NSSecureCoding, NSCopying {
     /// method appends the proper file extension based on the MIME type.
     ///
     /// This method always returns a valid filename.
-    public private(set) var suggestedFilename: String?
+    public fileprivate(set) var suggestedFilename: String?
 }
 
 /// A Response to an HTTP URL load.

--- a/Foundation/Unit.swift
+++ b/Foundation/Unit.swift
@@ -94,7 +94,7 @@ private class UnitConverterReciprocal : UnitConverter, NSSecureCoding {
     private private(set) var reciprocal: Double
     
     
-    private init(reciprocal: Double) {
+    fileprivate init(reciprocal: Double) {
         self.reciprocal = reciprocal
     }
     


### PR DESCRIPTION
Since I didn't finish the implementation of [SE-0025](https://github.com/apple/swift-evolution/blob/master/proposals/0025-scoped-access-level.md) quite fast enough to avoid these creeping in. This time I have a real implementation in hand, so no further changes should be necessary.

(Some of the diffs actually change what I did in #445. I don't think these changes should strictly be necessary in the model—i.e. there's still bugs in my implementation—but I don't want to block landing the main feature and flipping the switch.)