### PR TITLE
Use utf8CString instead of nulTerminatedUTF8

### DIFF
--- a/TestFoundation/TestNSXMLParser.swift
+++ b/TestFoundation/TestNSXMLParser.swift
@@ -26,9 +26,9 @@ class TestNSXMLParser : XCTestCase {
     }
     
     func test_data() {
-        let xml = Array("<test><foo>bar</foo></test>".nulTerminatedUTF8)
-        let data = xml.withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<UInt8>) -> Data in
-            return Data(bytes:UnsafeRawPointer(buffer.baseAddress!), count: buffer.count)
+        let xml = Array("<test><foo>bar</foo></test>".utf8CString)
+        let data = xml.withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<CChar>) -> Data in
+            return Data(bytes: UnsafeRawPointer(buffer.baseAddress!), count: buffer.count)
         }
         let parser = XMLParser(data: data)
         let res = parser.parse()


### PR DESCRIPTION
Needs to be committed simultaneously with apple/swift PR implementing SE-0134.