### PR TITLE
[SE-0101] Migration

### DIFF
--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -194,7 +194,7 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
     ///
     /// - parameter buffer: A buffer pointer to copy. The size is calculated from `SourceType` and `buffer.count`.
     public init<SourceType>(buffer: UnsafeBufferPointer<SourceType>) {
-        _wrapped = _SwiftNSData(immutableObject: NSData(bytes: buffer.baseAddress, length: MemoryLayout<SourceType>.size * buffer.count))
+        _wrapped = _SwiftNSData(immutableObject: NSData(bytes: buffer.baseAddress, length: MemoryLayout<SourceType>.stride * buffer.count))
     }
     
     /// Initialize a `Data` with the contents of an Array.
@@ -362,7 +362,7 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
     
     /// Copy the contents of the data into a buffer.
     ///
-    /// This function copies the bytes in `range` from the data into the buffer. If the count of the `range` is greater than `MemoryLayout<DestinationType>.size * buffer.count` then the first N bytes will be copied into the buffer.
+    /// This function copies the bytes in `range` from the data into the buffer. If the count of the `range` is greater than `MemoryLayout<DestinationType>.stride * buffer.count` then the first N bytes will be copied into the buffer.
     /// - precondition: The range must be within the bounds of the data. Otherwise `fatalError` is called.
     /// - parameter buffer: A buffer to copy the data into.
     /// - parameter range: A range in the data to copy into the buffer. If the range is empty, this function will return 0 without copying anything. If the range is nil, as much data as will fit into `buffer` is copied.
@@ -380,9 +380,9 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
             precondition(r.upperBound >= 0)
             precondition(r.upperBound <= cnt, "The range is outside the bounds of the data")
             
-            copyRange = r.lowerBound..<(r.lowerBound + Swift.min(buffer.count * MemoryLayout<DestinationType>.size, r.count))
+            copyRange = r.lowerBound..<(r.lowerBound + Swift.min(buffer.count * MemoryLayout<DestinationType>.stride, r.count))
         } else {
-            copyRange = 0..<Swift.min(buffer.count * MemoryLayout<DestinationType>.size, cnt)
+            copyRange = 0..<Swift.min(buffer.count * MemoryLayout<DestinationType>.stride, cnt)
         }
         
         guard !copyRange.isEmpty else { return 0 }
@@ -470,7 +470,7 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
     /// - parameter buffer: The buffer of bytes to append. The size is calculated from `SourceType` and `buffer.count`.
     public mutating func append<SourceType>(_ buffer : UnsafeBufferPointer<SourceType>) {
         _applyUnmanagedMutation {
-            $0.append(buffer.baseAddress!, length: buffer.count * MemoryLayout<SourceType>.size)
+            $0.append(buffer.baseAddress!, length: buffer.count * MemoryLayout<SourceType>.stride)
         }
     }
     

--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -194,7 +194,7 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
     ///
     /// - parameter buffer: A buffer pointer to copy. The size is calculated from `SourceType` and `buffer.count`.
     public init<SourceType>(buffer: UnsafeBufferPointer<SourceType>) {
-        _wrapped = _SwiftNSData(immutableObject: NSData(bytes: buffer.baseAddress, length: sizeof(SourceType.self) * buffer.count))
+        _wrapped = _SwiftNSData(immutableObject: NSData(bytes: buffer.baseAddress, length: MemoryLayout<SourceType>.size * buffer.count))
     }
     
     /// Initialize a `Data` with the contents of an Array.
@@ -314,7 +314,7 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
     public func withUnsafeBytes<ResultType, ContentType>(_ body: @noescape (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
         let bytes =  _getUnsafeBytesPointer()
         defer { _fixLifetime(self)}
-        let contentPtr = bytes.bindMemory(to: ContentType.self, capacity: count / strideof(ContentType.self))
+        let contentPtr = bytes.bindMemory(to: ContentType.self, capacity: count / MemoryLayout<ContentType>.stride)
         return try body(contentPtr)
     }
     
@@ -331,7 +331,7 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
     public mutating func withUnsafeMutableBytes<ResultType, ContentType>(_ body: @noescape (UnsafeMutablePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
         let mutableBytes = _getUnsafeMutableBytesPointer()
         defer { _fixLifetime(self)}
-        let contentPtr = mutableBytes.bindMemory(to: ContentType.self, capacity: count / strideof(ContentType.self))
+        let contentPtr = mutableBytes.bindMemory(to: ContentType.self, capacity: count / MemoryLayout<ContentType>.stride)
         return try body(contentPtr)
     }
     
@@ -362,7 +362,7 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
     
     /// Copy the contents of the data into a buffer.
     ///
-    /// This function copies the bytes in `range` from the data into the buffer. If the count of the `range` is greater than `sizeof(DestinationType) * buffer.count` then the first N bytes will be copied into the buffer.
+    /// This function copies the bytes in `range` from the data into the buffer. If the count of the `range` is greater than `MemoryLayout<DestinationType>.size * buffer.count` then the first N bytes will be copied into the buffer.
     /// - precondition: The range must be within the bounds of the data. Otherwise `fatalError` is called.
     /// - parameter buffer: A buffer to copy the data into.
     /// - parameter range: A range in the data to copy into the buffer. If the range is empty, this function will return 0 without copying anything. If the range is nil, as much data as will fit into `buffer` is copied.
@@ -380,9 +380,9 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
             precondition(r.upperBound >= 0)
             precondition(r.upperBound <= cnt, "The range is outside the bounds of the data")
             
-            copyRange = r.lowerBound..<(r.lowerBound + Swift.min(buffer.count * sizeof(DestinationType.self), r.count))
+            copyRange = r.lowerBound..<(r.lowerBound + Swift.min(buffer.count * MemoryLayout<DestinationType>.size, r.count))
         } else {
-            copyRange = 0..<Swift.min(buffer.count * sizeof(DestinationType.self), cnt)
+            copyRange = 0..<Swift.min(buffer.count * MemoryLayout<DestinationType>.size, cnt)
         }
         
         guard !copyRange.isEmpty else { return 0 }
@@ -470,7 +470,7 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
     /// - parameter buffer: The buffer of bytes to append. The size is calculated from `SourceType` and `buffer.count`.
     public mutating func append<SourceType>(_ buffer : UnsafeBufferPointer<SourceType>) {
         _applyUnmanagedMutation {
-            $0.append(buffer.baseAddress!, length: buffer.count * sizeof(SourceType.self))
+            $0.append(buffer.baseAddress!, length: buffer.count * MemoryLayout<SourceType>.size)
         }
     }
     

--- a/Foundation/DateInterval.swift
+++ b/Foundation/DateInterval.swift
@@ -156,7 +156,7 @@ public struct DateInterval : ReferenceConvertible, Comparable, Hashable {
     public var hashValue: Int {
         var buf: (UInt, UInt) = (UInt(start.timeIntervalSinceReferenceDate), UInt(end.timeIntervalSinceReferenceDate))
         return withUnsafeMutablePointer(to: &buf) {
-            return Int(bitPattern: CFHashBytes(unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self), CFIndex(sizeof(UInt.self) * 2)))
+            return Int(bitPattern: CFHashBytes(unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self), CFIndex(MemoryLayout<UInt>.size * 2)))
         }
     }
     

--- a/Foundation/IndexPath.swift
+++ b/Foundation/IndexPath.swift
@@ -158,7 +158,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
         if count == 0 {
             _indexes = []
         } else {
-            var ptr = malloc(count * sizeof(Element.self))?.bindMemory(to: Element.self, capacity: count * sizeof(Element.self))
+            var ptr = malloc(count * MemoryLayout<Element>.size)?.bindMemory(to: Element.self, capacity: count * MemoryLayout<Element>.size)
             defer { free(ptr) }
             
             nsIndexPath.getIndexes(ptr!, range: NSMakeRange(0, count))

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -382,7 +382,7 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
             let hash = item.hash
             buffer.advanced(by: idx).pointee = Int32(hash).littleEndian
         }
-        return Data(bytesNoCopy: unsafeBitCast(buffer, to: UnsafeMutablePointer<UInt8>.self), count: count * sizeof(Int.self), deallocator: .custom({ _ in
+        return Data(bytesNoCopy: unsafeBitCast(buffer, to: UnsafeMutablePointer<UInt8>.self), count: count * MemoryLayout<Int>.size, deallocator: .custom({ _ in
             buffer.deallocate(capacity: size)
             buffer.deinitialize(count: size)
         }))

--- a/Foundation/NSCFString.swift
+++ b/Foundation/NSCFString.swift
@@ -59,12 +59,12 @@ internal class _NSCFString : NSMutableString {
 
 internal final class _NSCFConstantString : _NSCFString {
     internal var _ptr : UnsafePointer<UInt8> {
-        let offset = sizeof(OpaquePointer.self) + sizeof(Int32.self) + sizeof(Int32.self) + sizeof(_CFInfo.self)
+        let offset = MemoryLayout<OpaquePointer>.size + MemoryLayout<Int32>.size + MemoryLayout<Int32>.size + MemoryLayout<_CFInfo>.size
         let ptr = Unmanaged.passUnretained(self).toOpaque()
         return ptr.load(fromByteOffset: offset, as: UnsafePointer<UInt8>.self)
     }
     internal var _length : UInt32 {
-        let offset = sizeof(OpaquePointer.self) + sizeof(Int32.self) + sizeof(Int32.self) + sizeof(_CFInfo.self) + sizeof(UnsafePointer<UInt8>.self)
+        let offset = MemoryLayout<OpaquePointer>.size + MemoryLayout<Int32>.size + MemoryLayout<Int32>.size + MemoryLayout<_CFInfo>.size + MemoryLayout<UnsafePointer<UInt8>>.size
         let ptr = Unmanaged.passUnretained(self).toOpaque()
         return ptr.load(fromByteOffset: offset, as: UInt32.self)
     }

--- a/Foundation/NSCoder.swift
+++ b/Foundation/NSCoder.swift
@@ -22,7 +22,7 @@ public class NSCoder : NSObject {
     deinit {
         for buffer in _pendingBuffers {
             // Cannot deinitialize a pointer to unknown type.
-            buffer.0.deallocate(bytes: buffer.1, alignedTo: alignof(Int.self))
+            buffer.0.deallocate(bytes: buffer.1, alignedTo: MemoryLayout<Int>.alignment)
         }
     }
     
@@ -159,7 +159,7 @@ public class NSCoder : NSObject {
             decodeValue(ofObjCType: "I", at: unsafeBitCast(ptr, to: UnsafeMutableRawPointer.self))
         }
         // we cannot autorelease here so instead the pending buffers will manage the lifespan of the returned data... this is wasteful but good enough...
-        let result = UnsafeMutableRawPointer.allocate(bytes: Int(length), alignedTo: alignof(Int.self))
+        let result = UnsafeMutableRawPointer.allocate(bytes: Int(length), alignedTo: MemoryLayout<Int>.alignment)
         decodeValue(ofObjCType: "c", at: result)
         lengthp.pointee = Int(length)
         _pendingBuffers.append((result, Int(length)))

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -102,7 +102,7 @@ public func ==(lhs: CGPoint, rhs: CGPoint) -> Bool {
 extension CGPoint: NSSpecialValueCoding {
     init(bytes: UnsafeRawPointer) {
         self.x = bytes.load(as: CGFloat.self)
-        self.y = bytes.load(fromByteOffset: strideof(CGFloat.self), as: CGFloat.self)
+        self.y = bytes.load(fromByteOffset: MemoryLayout<CGFloat>.stride, as: CGFloat.self)
     }
     
     init?(coder aDecoder: NSCoder) {
@@ -167,7 +167,7 @@ public func ==(lhs: CGSize, rhs: CGSize) -> Bool {
 extension CGSize: NSSpecialValueCoding {
     init(bytes: UnsafeRawPointer) {
         self.width = bytes.load(as: CGFloat.self)
-        self.height = bytes.load(fromByteOffset: strideof(CGFloat.self), as: CGFloat.self)
+        self.height = bytes.load(fromByteOffset: MemoryLayout<CGFloat>.stride, as: CGFloat.self)
     }
     
     init?(coder aDecoder: NSCoder) {
@@ -248,10 +248,10 @@ extension CGRect: NSSpecialValueCoding {
     init(bytes: UnsafeRawPointer) {
         self.origin = CGPoint(
             x: bytes.load(as: CGFloat.self),
-            y: bytes.load(fromByteOffset: 1 * strideof(CGFloat.self), as: CGFloat.self))
+            y: bytes.load(fromByteOffset: 1 * MemoryLayout<CGFloat>.stride, as: CGFloat.self))
         self.size = CGSize(
-            width: bytes.load(fromByteOffset: 2 * strideof(CGFloat.self), as: CGFloat.self),
-            height: bytes.load(fromByteOffset: 3 * strideof(CGFloat.self), as: CGFloat.self))
+            width: bytes.load(fromByteOffset: 2 * MemoryLayout<CGFloat>.stride, as: CGFloat.self),
+            height: bytes.load(fromByteOffset: 3 * MemoryLayout<CGFloat>.stride, as: CGFloat.self))
     }
 
     init?(coder aDecoder: NSCoder) {
@@ -344,9 +344,9 @@ public struct NSEdgeInsets {
 extension NSEdgeInsets: NSSpecialValueCoding {
     init(bytes: UnsafeRawPointer) {
         self.top = bytes.load(as: CGFloat.self)
-        self.left = bytes.load(fromByteOffset: strideof(CGFloat.self), as: CGFloat.self)
-        self.bottom = bytes.load(fromByteOffset: 2 * strideof(CGFloat.self), as: CGFloat.self)
-        self.right = bytes.load(fromByteOffset: 3 * strideof(CGFloat.self), as: CGFloat.self)
+        self.left = bytes.load(fromByteOffset: MemoryLayout<CGFloat>.stride, as: CGFloat.self)
+        self.bottom = bytes.load(fromByteOffset: 2 * MemoryLayout<CGFloat>.stride, as: CGFloat.self)
+        self.right = bytes.load(fromByteOffset: 3 * MemoryLayout<CGFloat>.stride, as: CGFloat.self)
     }
 
     init?(coder aDecoder: NSCoder) {

--- a/Foundation/NSHost.swift
+++ b/Foundation/NSHost.swift
@@ -90,7 +90,7 @@ public class Host: NSObject {
                     res = info.ai_next
                     continue
                 }
-                let sa_len: socklen_t = socklen_t((family == AF_INET6) ? sizeof(sockaddr_in6.self) : sizeof(sockaddr_in.self))
+                let sa_len: socklen_t = socklen_t((family == AF_INET6) ? MemoryLayout<sockaddr_in6>.size : MemoryLayout<sockaddr_in>.size)
                 let lookupInfo = { (content: inout [String], flags: Int32) in
                     let hname = UnsafeMutablePointer<Int8>.allocate(capacity: 1024)
                     if (getnameinfo(info.ai_addr, sa_len, hname, 1024, nil, 0, flags) == 0) {

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -493,7 +493,7 @@ extension NSNumber : CustomPlaygroundQuickLookable {
         case kCFNumberDoubleType:
             return .double(self.doubleValue)
         case kCFNumberCGFloatType:
-            if sizeof(CGFloat.self) == sizeof(Float32.self) {
+            if MemoryLayout<CGFloat>.size == MemoryLayout<Float32>.size {
                 return .float(self.floatValue)
             } else {
                 return .double(self.doubleValue)

--- a/Foundation/NSObjCRuntime.swift
+++ b/Foundation/NSObjCRuntime.swift
@@ -84,22 +84,22 @@ extension _NSSimpleObjCType {
 // mapping of ObjC types to sizes and alignments (note that .Int is 32-bit)
 // FIXME use a generic function, unfortuantely this seems to promote the size to 8
 private let _NSObjCSizesAndAlignments : Dictionary<_NSSimpleObjCType, (Int, Int)> = [
-    .ID         : ( sizeof(AnyObject.self),              alignof(AnyObject.self)          ),
-    .Class      : ( sizeof(AnyClass.self),               alignof(AnyClass.self)           ),
-    .Char       : ( sizeof(CChar.self),                  alignof(CChar.self)              ),
-    .UChar      : ( sizeof(UInt8.self),                  alignof(UInt8.self)              ),
-    .Short      : ( sizeof(Int16.self),                  alignof(Int16.self)              ),
-    .UShort     : ( sizeof(UInt16.self),                 alignof(UInt16.self)             ),
-    .Int        : ( sizeof(Int32.self),                  alignof(Int32.self)              ),
-    .UInt       : ( sizeof(UInt32.self),                 alignof(UInt32.self)             ),
-    .Long       : ( sizeof(Int32.self),                  alignof(Int32.self)              ),
-    .ULong      : ( sizeof(UInt32.self),                 alignof(UInt32.self)             ),
-    .LongLong   : ( sizeof(Int64.self),                  alignof(Int64.self)              ),
-    .ULongLong  : ( sizeof(UInt64.self),                 alignof(UInt64.self)             ),
-    .Float      : ( sizeof(Float.self),                  alignof(Float.self)              ),
-    .Double     : ( sizeof(Double.self),                 alignof(Double.self)             ),
-    .Bool       : ( sizeof(Bool.self),                   alignof(Bool.self)               ),
-    .CharPtr    : ( sizeof(UnsafePointer<CChar>.self),   alignof(UnsafePointer<CChar>.self))
+    .ID         : ( MemoryLayout<AnyObject>.size,              MemoryLayout<AnyObject>.alignment          ),
+    .Class      : ( MemoryLayout<AnyClass>.size,               MemoryLayout<AnyClass>.alignment           ),
+    .Char       : ( MemoryLayout<CChar>.size,                  MemoryLayout<CChar>.alignment              ),
+    .UChar      : ( MemoryLayout<UInt8>.size,                  MemoryLayout<UInt8>.alignment              ),
+    .Short      : ( MemoryLayout<Int16>.size,                  MemoryLayout<Int16>.alignment              ),
+    .UShort     : ( MemoryLayout<UInt16>.size,                 MemoryLayout<UInt16>.alignment             ),
+    .Int        : ( MemoryLayout<Int32>.size,                  MemoryLayout<Int32>.alignment              ),
+    .UInt       : ( MemoryLayout<UInt32>.size,                 MemoryLayout<UInt32>.alignment             ),
+    .Long       : ( MemoryLayout<Int32>.size,                  MemoryLayout<Int32>.alignment              ),
+    .ULong      : ( MemoryLayout<UInt32>.size,                 MemoryLayout<UInt32>.alignment             ),
+    .LongLong   : ( MemoryLayout<Int64>.size,                  MemoryLayout<Int64>.alignment              ),
+    .ULongLong  : ( MemoryLayout<UInt64>.size,                 MemoryLayout<UInt64>.alignment             ),
+    .Float      : ( MemoryLayout<Float>.size,                  MemoryLayout<Float>.alignment              ),
+    .Double     : ( MemoryLayout<Double>.size,                 MemoryLayout<Double>.alignment             ),
+    .Bool       : ( MemoryLayout<Bool>.size,                   MemoryLayout<Bool>.alignment               ),
+    .CharPtr    : ( MemoryLayout<UnsafePointer<CChar>>.size,   MemoryLayout<UnsafePointer<CChar>>.alignment)
 ]
 
 internal func _NSGetSizeAndAlignment(_ type: _NSSimpleObjCType,

--- a/Foundation/NSRange.swift
+++ b/Foundation/NSRange.swift
@@ -54,7 +54,7 @@ extension NSRange {
 extension NSRange: NSSpecialValueCoding {
     init(bytes: UnsafeRawPointer) {
         self.location = bytes.load(as: Int.self)
-        self.length = bytes.load(fromByteOffset: strideof(Int.self), as: Int.self)
+        self.length = bytes.load(fromByteOffset: MemoryLayout<Int>.stride, as: Int.self)
     }
     
     init?(coder aDecoder: NSCoder) {

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -67,7 +67,7 @@ internal func _CFSwiftIsEqual(_ cf1: AnyObject, cf2: AnyObject) -> Bool {
 // Ivars in _NSCF* types must be zeroed via an unsafe accessor to avoid deinit of potentially unsafe memory to accces as an object/struct etc since it is stored via a foreign object graph
 internal func _CFZeroUnsafeIvars<T>(_ arg: inout T) {
     withUnsafeMutablePointer(to: &arg) { (ptr: UnsafeMutablePointer<T>) -> Void in
-        bzero(unsafeBitCast(ptr, to: UnsafeMutableRawPointer.self), sizeof(T.self))
+        bzero(unsafeBitCast(ptr, to: UnsafeMutableRawPointer.self), MemoryLayout<T>.size)
     }
 }
 


### PR DESCRIPTION
Depends on https://github.com/apple/swift/pull/3854

[SE-0101](https://github.com/apple/swift-evolution/blob/master/proposals/0101-standardizing-sizeof-naming.md) removes `sizeof`, `sizeofValue` and related functions from the stdlib.
This PR is migrating them to newly introduced `MemoryLayout<T>` values.