### PR TITLE
Mechanically add 'open' to all public classes.

### DIFF
--- a/Foundation/NSAffineTransform.swift
+++ b/Foundation/NSAffineTransform.swift
@@ -31,16 +31,16 @@ public struct NSAffineTransformStruct {
     }
 }
 
-public class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
+open class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         return NSAffineTransform(transform: self)
     }
     // Necessary because `NSObject.copy()` returns `self`.
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     public required init?(coder aDecoder: NSCoder) {
@@ -65,37 +65,37 @@ public class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
     }
     
     // Translating
-    public func translateXBy(_ deltaX: CGFloat, yBy deltaY: CGFloat) {
+    open func translateXBy(_ deltaX: CGFloat, yBy deltaY: CGFloat) {
         let translation = NSAffineTransformStruct.translation(tX: deltaX, tY: deltaY)
         
         transformStruct = translation.concat(transformStruct)
     }
     
     // Rotating
-    public func rotateByDegrees(_ angle: CGFloat) {
+    open func rotateByDegrees(_ angle: CGFloat) {
         let rotation = NSAffineTransformStruct.rotation(degrees: angle)
         
         transformStruct = rotation.concat(transformStruct)
     }
-    public func rotateByRadians(_ angle: CGFloat) {
+    open func rotateByRadians(_ angle: CGFloat) {
         let rotation = NSAffineTransformStruct.rotation(radians: angle)
         
         transformStruct = rotation.concat(transformStruct)
     }
     
     // Scaling
-    public func scaleBy(_ scale: CGFloat) {
+    open func scaleBy(_ scale: CGFloat) {
         scaleXBy(scale, yBy: scale)
     }
 
-    public func scaleXBy(_ scaleX: CGFloat, yBy scaleY: CGFloat) {
+    open func scaleXBy(_ scaleX: CGFloat, yBy scaleY: CGFloat) {
         let scale = NSAffineTransformStruct.scale(sX: scaleX, sY: scaleY)
         
         transformStruct = scale.concat(transformStruct)
     }
     
     // Inverting
-    public func invert() {
+    open func invert() {
         if let inverse = transformStruct.inverse {
             transformStruct = inverse
         }
@@ -105,24 +105,24 @@ public class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
     }
     
     // Transforming with transform
-    public func appendTransform(_ transform: NSAffineTransform) {
+    open func appendTransform(_ transform: NSAffineTransform) {
         transformStruct = transformStruct.concat(transform.transformStruct)
     }
-    public func prependTransform(_ transform: NSAffineTransform) {
+    open func prependTransform(_ transform: NSAffineTransform) {
         transformStruct = transform.transformStruct.concat(transformStruct)
     }
     
     // Transforming points and sizes
-    public func transformPoint(_ aPoint: NSPoint) -> NSPoint {
+    open func transformPoint(_ aPoint: NSPoint) -> NSPoint {
         return transformStruct.applied(toPoint: aPoint)
     }
 
-    public func transformSize(_ aSize: NSSize) -> NSSize {
+    open func transformSize(_ aSize: NSSize) -> NSSize {
         return transformStruct.applied(toSize: aSize)
     }
 
     // Transform Struct
-    public var transformStruct: NSAffineTransformStruct
+    open var transformStruct: NSAffineTransformStruct
 }
 
 /**

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -34,18 +34,18 @@ extension Array : _ObjectTypeBridgeable {
     }
 }
 
-public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCoding {
+open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCoding {
     private let _cfinfo = _CFInfo(typeID: CFArrayGetTypeID())
     internal var _storage = [AnyObject]()
     
-    public var count: Int {
+    open var count: Int {
         guard type(of: self) === NSArray.self || type(of: self) === NSMutableArray.self else {
             NSRequiresConcreteImplementation()
         }
         return _storage.count
     }
     
-    public func object(at index: Int) -> AnyObject {
+    open func object(at index: Int) -> AnyObject {
         guard type(of: self) === NSArray.self || type(of: self) === NSMutableArray.self else {
            NSRequiresConcreteImplementation()
         }
@@ -93,7 +93,7 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         }
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         if let keyedArchiver = aCoder as? NSKeyedArchiver {
             keyedArchiver._encodeArrayOfObjects(self, forKey:"NS.objects")
         } else {
@@ -109,11 +109,11 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         return true
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         if type(of: self) === NSArray.self {
             // return self for immutable type
             return self
@@ -125,11 +125,11 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         return NSArray(array: self.allObjects)
     }
     
-    public override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> AnyObject {
         return mutableCopy(with: nil)
     }
     
-    public func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
         if type(of: self) === NSArray.self || type(of: self) === NSMutableArray.self {
             // always create and return an NSMutableArray
             let mutableArray = NSMutableArray()
@@ -165,7 +165,7 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         buffer.deallocate(capacity: cnt)
     }
 
-    public override func isEqual(_ object: AnyObject?) -> Bool {
+    open override func isEqual(_ object: AnyObject?) -> Bool {
         guard let otherObject = object, otherObject is NSArray else {
             return false
         }
@@ -173,7 +173,7 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         return self.isEqual(to: otherArray.bridge())
     }
 
-    public override var hash: Int {
+    open override var hash: Int {
         return self.count
     }
 
@@ -187,20 +187,20 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         }
     }
     
-    public func adding(_ anObject: AnyObject) -> [AnyObject] {
+    open func adding(_ anObject: AnyObject) -> [AnyObject] {
         return allObjects + [anObject]
     }
     
-    public func addingObjects(from otherArray: [AnyObject]) -> [AnyObject] {
+    open func addingObjects(from otherArray: [AnyObject]) -> [AnyObject] {
         return allObjects + otherArray
     }
     
-    public func componentsJoined(by separator: String) -> String {
+    open func componentsJoined(by separator: String) -> String {
         // make certain to call NSObject's description rather than asking the string interpolator for the swift description
         return bridge().map() { ($0 as! NSObject).description }.joined(separator: separator)
     }
 
-    public func contains(_ anObject: AnyObject) -> Bool {
+    open func contains(_ anObject: AnyObject) -> Bool {
         let other = anObject as! NSObject
 
         for idx in 0..<count {
@@ -213,8 +213,8 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         return false
     }
     
-    public func description(withLocale locale: AnyObject?) -> String { return description(withLocale: locale, indent: 0) }
-    public func description(withLocale locale: AnyObject?, indent level: Int) -> String {
+    open func description(withLocale locale: AnyObject?) -> String { return description(withLocale: locale, indent: 0) }
+    open func description(withLocale locale: AnyObject?, indent level: Int) -> String {
         var descriptions = [String]()
         let cnt = count
         for idx in 0..<cnt {
@@ -246,7 +246,7 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         return result
     }
     
-    public func firstObjectCommon(with otherArray: [AnyObject]) -> AnyObject? {
+    open func firstObjectCommon(with otherArray: [AnyObject]) -> AnyObject? {
         let set = NSSet(array: otherArray)
 
         for idx in 0..<count {
@@ -269,7 +269,7 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         objects += range.toRange()!.map { self[$0] }
     }
     
-    public func index(of anObject: AnyObject) -> Int {
+    open func index(of anObject: AnyObject) -> Int {
         for idx in 0..<count {
             let obj = object(at: idx) as! NSObject
             if anObject === obj || obj.isEqual(anObject) {
@@ -279,7 +279,7 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         return NSNotFound
     }
     
-    public func index(of anObject: AnyObject, in range: NSRange) -> Int {
+    open func index(of anObject: AnyObject, in range: NSRange) -> Int {
         for idx in 0..<range.length {
             let obj = object(at: idx + range.location) as! NSObject
             if anObject === obj || obj.isEqual(anObject) {
@@ -289,7 +289,7 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         return NSNotFound
     }
     
-    public func indexOfObjectIdentical(to anObject: AnyObject) -> Int {
+    open func indexOfObjectIdentical(to anObject: AnyObject) -> Int {
         for idx in 0..<count {
             let obj = object(at: idx) as! NSObject
             if anObject === obj {
@@ -299,7 +299,7 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         return NSNotFound
     }
     
-    public func indexOfObjectIdentical(to anObject: AnyObject, in range: NSRange) -> Int {
+    open func indexOfObjectIdentical(to anObject: AnyObject, in range: NSRange) -> Int {
         for idx in 0..<range.length {
             let obj = object(at: idx + range.location) as! NSObject
             if anObject === obj {
@@ -309,7 +309,7 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         return NSNotFound
     }
     
-    public func isEqual(to otherArray: [AnyObject]) -> Bool {
+    open func isEqual(to otherArray: [AnyObject]) -> Bool {
         if count != otherArray.count {
             return false
         }
@@ -328,7 +328,7 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         return true
     }
 
-    public var firstObject: AnyObject? {
+    open var firstObject: AnyObject? {
         if count > 0 {
             return object(at: 0)
         } else {
@@ -336,7 +336,7 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         }
     }
     
-    public var lastObject: AnyObject? {
+    open var lastObject: AnyObject? {
         if count > 0 {
             return object(at: count - 1)
         } else {
@@ -366,15 +366,15 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
             self.reverse = reverse
         }
     }
-    public func objectEnumerator() -> NSEnumerator {
+    open func objectEnumerator() -> NSEnumerator {
         return NSGeneratorEnumerator(Iterator(self))
     }
     
-    public func reverseObjectEnumerator() -> NSEnumerator {
+    open func reverseObjectEnumerator() -> NSEnumerator {
         return NSGeneratorEnumerator(Iterator(self, reverse: true))
     }
     
-    /*@NSCopying*/ public var sortedArrayHint: Data {
+    /*@NSCopying*/ open var sortedArrayHint: Data {
         let size = count
         let buffer = UnsafeMutablePointer<Int32>.allocate(capacity: size)
         for idx in 0..<count {
@@ -388,19 +388,19 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         }))
     }
     
-    public func sortedArray(_ comparator: @noescape @convention(c) (AnyObject, AnyObject, UnsafeMutableRawPointer?) -> Int, context: UnsafeMutableRawPointer?) -> [AnyObject] {
+    open func sortedArray(_ comparator: @noescape @convention(c) (AnyObject, AnyObject, UnsafeMutableRawPointer?) -> Int, context: UnsafeMutableRawPointer?) -> [AnyObject] {
         return sortedArray([]) { lhs, rhs in
             return ComparisonResult(rawValue: comparator(lhs, rhs, context))!
         }
     }
     
-    public func sortedArray(_ comparator: @noescape @convention(c) (AnyObject, AnyObject, UnsafeMutableRawPointer?) -> Int, context: UnsafeMutableRawPointer?, hint: Data?) -> [AnyObject] {
+    open func sortedArray(_ comparator: @noescape @convention(c) (AnyObject, AnyObject, UnsafeMutableRawPointer?) -> Int, context: UnsafeMutableRawPointer?, hint: Data?) -> [AnyObject] {
         return sortedArray([]) { lhs, rhs in
             return ComparisonResult(rawValue: comparator(lhs, rhs, context))!
         }
     }
 
-    public func subarray(with range: NSRange) -> [AnyObject] {
+    open func subarray(with range: NSRange) -> [AnyObject] {
         if range.length == 0 {
             return []
         }
@@ -409,10 +409,10 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         return objects
     }
     
-    public func write(toFile path: String, atomically useAuxiliaryFile: Bool) -> Bool { NSUnimplemented() }
-    public func write(to url: URL, atomically: Bool) -> Bool { NSUnimplemented() }
+    open func write(toFile path: String, atomically useAuxiliaryFile: Bool) -> Bool { NSUnimplemented() }
+    open func write(to url: URL, atomically: Bool) -> Bool { NSUnimplemented() }
     
-    public func objects(at indexes: IndexSet) -> [AnyObject] {
+    open func objects(at indexes: IndexSet) -> [AnyObject] {
         var objs = [AnyObject]()
         indexes.rangeView().forEach {
             objs.append(contentsOf: self.subarray(with: NSRange(location: $0.lowerBound, length: $0.upperBound - $0.lowerBound)))
@@ -421,7 +421,7 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         return objs
     }
     
-    public subscript (idx: Int) -> AnyObject {
+    open subscript (idx: Int) -> AnyObject {
         guard idx < count && idx >= 0 else {
             fatalError("\(self): Index out of bounds")
         }
@@ -444,13 +444,13 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         }
     }
     
-    public func indexOfObject(passingTest predicate: @noescape (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
+    open func indexOfObject(passingTest predicate: @noescape (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
         return indexOfObject([], passingTest: predicate)
     }
-    public func indexOfObject(_ opts: EnumerationOptions = [], passingTest predicate: @noescape (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
+    open func indexOfObject(_ opts: EnumerationOptions = [], passingTest predicate: @noescape (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
         return indexOfObject(at: IndexSet(indexesIn: NSMakeRange(0, count)), options: opts, passingTest: predicate)
     }
-    public func indexOfObject(at s: IndexSet, options opts: EnumerationOptions = [], passingTest predicate: @noescape (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
+    open func indexOfObject(at s: IndexSet, options opts: EnumerationOptions = [], passingTest predicate: @noescape (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
         var result = NSNotFound
         enumerateObjects(at: s, options: opts) { (obj, idx, stop) -> Void in
             if predicate(obj, idx, stop) {
@@ -461,13 +461,13 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         return result
     }
     
-    public func indexesOfObjects(passingTest predicate: @noescape (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
+    open func indexesOfObjects(passingTest predicate: @noescape (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
         return indexesOfObjects([], passingTest: predicate)
     }
-    public func indexesOfObjects(_ opts: EnumerationOptions = [], passingTest predicate: @noescape (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
+    open func indexesOfObjects(_ opts: EnumerationOptions = [], passingTest predicate: @noescape (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
         return indexesOfObjects(at: IndexSet(indexesIn: NSMakeRange(0, count)), options: opts, passingTest: predicate)
     }
-    public func indexesOfObjects(at s: IndexSet, options opts: EnumerationOptions = [], passingTest predicate: @noescape (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
+    open func indexesOfObjects(at s: IndexSet, options opts: EnumerationOptions = [], passingTest predicate: @noescape (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
         var result = IndexSet()
         enumerateObjects(at: s, options: opts) { (obj, idx, stop) in
             if predicate(obj, idx, stop) {
@@ -494,15 +494,15 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
         }
     }
     
-    public func sortedArray(comparator cmptr: @noescape (AnyObject, AnyObject) -> ComparisonResult) -> [AnyObject] {
+    open func sortedArray(comparator cmptr: @noescape (AnyObject, AnyObject) -> ComparisonResult) -> [AnyObject] {
         return sortedArrayFromRange(NSMakeRange(0, count), options: [], usingComparator: cmptr)
     }
 
-    public func sortedArray(_ opts: SortOptions = [], usingComparator cmptr: @noescape (AnyObject, AnyObject) -> ComparisonResult) -> [AnyObject] {
+    open func sortedArray(_ opts: SortOptions = [], usingComparator cmptr: @noescape (AnyObject, AnyObject) -> ComparisonResult) -> [AnyObject] {
         return sortedArrayFromRange(NSMakeRange(0, count), options: opts, usingComparator: cmptr)
     }
 
-    public func index(of obj: AnyObject, inSortedRange r: NSRange, options opts: NSBinarySearchingOptions = [], usingComparator cmp: @noescape (AnyObject, AnyObject) -> ComparisonResult) -> Int {
+    open func index(of obj: AnyObject, inSortedRange r: NSRange, options opts: NSBinarySearchingOptions = [], usingComparator cmp: @noescape (AnyObject, AnyObject) -> ComparisonResult) -> Int {
         let lastIndex = r.location + r.length - 1
         
         // argument validation
@@ -588,7 +588,7 @@ public class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NS
     public convenience init?(contentsOfFile path: String) { NSUnimplemented() }
     public convenience init?(contentsOfURL url: URL) { NSUnimplemented() }
     
-    override public var _cfTypeID: CFTypeID {
+    override open var _cfTypeID: CFTypeID {
         return CFArrayGetTypeID()
     }
 }
@@ -639,33 +639,33 @@ public struct NSBinarySearchingOptions : OptionSet {
     public static let InsertionIndex = NSBinarySearchingOptions(rawValue: 1 << 10)
 }
 
-public class NSMutableArray : NSArray {
+open class NSMutableArray : NSArray {
     
-    public func add(_ anObject: AnyObject) {
+    open func add(_ anObject: AnyObject) {
         insert(anObject, at: count)
     }
     
-    public func insert(_ anObject: AnyObject, at index: Int) {
+    open func insert(_ anObject: AnyObject, at index: Int) {
         guard type(of: self) === NSMutableArray.self else {
             NSRequiresConcreteImplementation()
         }
         _storage.insert(anObject, at: index)
     }
     
-    public func removeLastObject() {
+    open func removeLastObject() {
         if count > 0 {
             removeObject(at: count - 1)
         }
     }
     
-    public func removeObject(at index: Int) {
+    open func removeObject(at index: Int) {
         guard type(of: self) === NSMutableArray.self else {
             NSRequiresConcreteImplementation()
         }
         _storage.remove(at: index)
     }
     
-    public func replaceObject(at index: Int, with anObject: AnyObject) {
+    open func replaceObject(at index: Int, with anObject: AnyObject) {
         guard type(of: self) === NSMutableArray.self else {
             NSRequiresConcreteImplementation()
         }
@@ -693,7 +693,7 @@ public class NSMutableArray : NSArray {
         }
     }
     
-    public override subscript (idx: Int) -> AnyObject {
+    open override subscript (idx: Int) -> AnyObject {
         get {
             return object(at: idx)
         }
@@ -702,7 +702,7 @@ public class NSMutableArray : NSArray {
         }
     }
     
-    public func addObjectsFromArray(_ otherArray: [AnyObject]) {
+    open func addObjectsFromArray(_ otherArray: [AnyObject]) {
         if type(of: self) === NSMutableArray.self {
             _storage += otherArray
         } else {
@@ -712,7 +712,7 @@ public class NSMutableArray : NSArray {
         }
     }
     
-    public func exchangeObject(at idx1: Int, withObjectAt idx2: Int) {
+    open func exchangeObject(at idx1: Int, withObjectAt idx2: Int) {
         if type(of: self) === NSMutableArray.self {
             swap(&_storage[idx1], &_storage[idx2])
         } else {
@@ -720,7 +720,7 @@ public class NSMutableArray : NSArray {
         }
     }
     
-    public func removeAllObjects() {
+    open func removeAllObjects() {
         if type(of: self) === NSMutableArray.self {
             _storage.removeAll()
         } else {
@@ -730,35 +730,35 @@ public class NSMutableArray : NSArray {
         }
     }
     
-    public func removeObject(_ anObject: AnyObject, inRange range: NSRange) {
+    open func removeObject(_ anObject: AnyObject, inRange range: NSRange) {
         let idx = index(of: anObject, in: range)
         if idx != NSNotFound {
             removeObject(at: idx)
         }
     }
     
-    public func removeObject(_ anObject: AnyObject) {
+    open func removeObject(_ anObject: AnyObject) {
         let idx = index(of: anObject)
         if idx != NSNotFound {
             removeObject(at: idx)
         }
     }
     
-    public func removeObjectIdenticalTo(_ anObject: AnyObject, inRange range: NSRange) {
+    open func removeObjectIdenticalTo(_ anObject: AnyObject, inRange range: NSRange) {
         let idx = indexOfObjectIdentical(to: anObject, in: range)
         if idx != NSNotFound {
             removeObject(at: idx)
         }
     }
     
-    public func removeObjectIdenticalTo(_ anObject: AnyObject) {
+    open func removeObjectIdenticalTo(_ anObject: AnyObject) {
         let idx = indexOfObjectIdentical(to: anObject)
         if idx != NSNotFound {
             removeObject(at: idx)
         }
     }
     
-    public func removeObjects(in otherArray: [AnyObject]) {
+    open func removeObjects(in otherArray: [AnyObject]) {
         let set = NSSet(array : otherArray)
         for idx in (0..<count).reversed() {
             if set.contains(object(at: idx)) {
@@ -767,7 +767,7 @@ public class NSMutableArray : NSArray {
         }
     }
     
-    public func removeObjects(in range: NSRange) {
+    open func removeObjects(in range: NSRange) {
         if type(of: self) === NSMutableArray.self {
             _storage.removeSubrange(range.toRange()!)
         } else {
@@ -776,13 +776,13 @@ public class NSMutableArray : NSArray {
             }
         }
     }
-    public func replaceObjects(in range: NSRange, withObjectsFrom otherArray: [AnyObject], range otherRange: NSRange) {
+    open func replaceObjects(in range: NSRange, withObjectsFrom otherArray: [AnyObject], range otherRange: NSRange) {
         var list = [AnyObject]()
         otherArray.bridge().getObjects(&list, range:otherRange)
         replaceObjectsInRange(range, withObjectsFromArray:list)
     }
     
-    public func replaceObjectsInRange(_ range: NSRange, withObjectsFromArray otherArray: [AnyObject]) {
+    open func replaceObjectsInRange(_ range: NSRange, withObjectsFromArray otherArray: [AnyObject]) {
         if type(of: self) === NSMutableArray.self {
             _storage.reserveCapacity(count - range.length + otherArray.count)
             for idx in 0..<range.length {
@@ -796,7 +796,7 @@ public class NSMutableArray : NSArray {
         }
     }
     
-    public func setArray(_ otherArray: [AnyObject]) {
+    open func setArray(_ otherArray: [AnyObject]) {
         if type(of: self) === NSMutableArray.self {
             _storage = otherArray
         } else {
@@ -804,7 +804,7 @@ public class NSMutableArray : NSArray {
         }
     }
     
-    public func insertObjects(_ objects: [AnyObject], atIndexes indexes: IndexSet) {
+    open func insertObjects(_ objects: [AnyObject], atIndexes indexes: IndexSet) {
         precondition(objects.count == indexes.count)
         
         if type(of: self) === NSMutableArray.self {
@@ -818,13 +818,13 @@ public class NSMutableArray : NSArray {
         }
     }
     
-    public func removeObjectsAtIndexes(_ indexes: IndexSet) {
+    open func removeObjectsAtIndexes(_ indexes: IndexSet) {
         for range in indexes.rangeView().reversed() {
             self.removeObjects(in: NSMakeRange(range.lowerBound, range.upperBound - range.lowerBound))
         }
     }
     
-    public func replaceObjectsAtIndexes(_ indexes: IndexSet, withObjects objects: [AnyObject]) {
+    open func replaceObjectsAtIndexes(_ indexes: IndexSet, withObjects objects: [AnyObject]) {
         var objectIndex = 0
         for countedRange in indexes.rangeView() {
             let range = NSMakeRange(countedRange.lowerBound, countedRange.upperBound - countedRange.lowerBound)
@@ -834,15 +834,15 @@ public class NSMutableArray : NSArray {
         }
     }
 
-    public func sortUsingFunction(_ compare: @convention(c) (AnyObject, AnyObject, UnsafeMutableRawPointer?) -> Int, context: UnsafeMutableRawPointer?) {
+    open func sortUsingFunction(_ compare: @convention(c) (AnyObject, AnyObject, UnsafeMutableRawPointer?) -> Int, context: UnsafeMutableRawPointer?) {
         self.setArray(self.sortedArray(compare, context: context))
     }
 
-    public func sortUsingComparator(_ cmptr: Comparator) {
+    open func sortUsingComparator(_ cmptr: Comparator) {
         self.sortWithOptions([], usingComparator: cmptr)
     }
 
-    public func sortWithOptions(_ opts: SortOptions, usingComparator cmptr: Comparator) {
+    open func sortWithOptions(_ opts: SortOptions, usingComparator cmptr: Comparator) {
         self.setArray(self.sortedArray(opts, usingComparator: cmptr))
     }
     

--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -9,7 +9,7 @@
 
 import CoreFoundation
 
-public class AttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
+open class AttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     
     private let _cfinfo = _CFInfo(typeID: CFAttributedStringGetTypeID())
     fileprivate var _string: NSString
@@ -19,7 +19,7 @@ public class AttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
         NSUnimplemented()
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     
@@ -27,27 +27,27 @@ public class AttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
         return true
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         NSUnimplemented()
     }
 
-    public override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> AnyObject {
         return mutableCopy(with: nil)
     }
     
-    public func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
         NSUnimplemented()
     }
     
-    public var string: String {
+    open var string: String {
         return _string._swiftObject
     }
     
-    public func attributesAtIndex(_ location: Int, effectiveRange range: NSRangePointer) -> [String : AnyObject] {
+    open func attributesAtIndex(_ location: Int, effectiveRange range: NSRangePointer) -> [String : AnyObject] {
         let rangeInfo = RangeInfo(
             rangePointer: range,
             shouldFetchLongestEffectiveRange: false,
@@ -55,11 +55,11 @@ public class AttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
         return _attributesAtIndex(location, rangeInfo: rangeInfo)
     }
 
-    public var length: Int {
+    open var length: Int {
         return CFAttributedStringGetLength(_cfObject)
     }
     
-    public func attribute(_ attrName: String, atIndex location: Int, effectiveRange range: NSRangePointer) -> AnyObject? {
+    open func attribute(_ attrName: String, atIndex location: Int, effectiveRange range: NSRangePointer) -> AnyObject? {
         let rangeInfo = RangeInfo(
             rangePointer: range,
             shouldFetchLongestEffectiveRange: false,
@@ -67,9 +67,9 @@ public class AttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
         return _attribute(attrName, atIndex: location, rangeInfo: rangeInfo)
     }
     
-    public func attributedSubstringFromRange(_ range: NSRange) -> AttributedString { NSUnimplemented() }
+    open func attributedSubstringFromRange(_ range: NSRange) -> AttributedString { NSUnimplemented() }
     
-    public func attributesAtIndex(_ location: Int, longestEffectiveRange range: NSRangePointer, inRange rangeLimit: NSRange) -> [String : AnyObject] {
+    open func attributesAtIndex(_ location: Int, longestEffectiveRange range: NSRangePointer, inRange rangeLimit: NSRange) -> [String : AnyObject] {
         let rangeInfo = RangeInfo(
             rangePointer: range,
             shouldFetchLongestEffectiveRange: true,
@@ -77,7 +77,7 @@ public class AttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
         return _attributesAtIndex(location, rangeInfo: rangeInfo)
     }
     
-    public func attribute(_ attrName: String, atIndex location: Int, longestEffectiveRange range: NSRangePointer, inRange rangeLimit: NSRange) -> AnyObject? {
+    open func attribute(_ attrName: String, atIndex location: Int, longestEffectiveRange range: NSRangePointer, inRange rangeLimit: NSRange) -> AnyObject? {
         let rangeInfo = RangeInfo(
             rangePointer: range,
             shouldFetchLongestEffectiveRange: true,
@@ -85,7 +85,7 @@ public class AttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
         return _attribute(attrName, atIndex: location, rangeInfo: rangeInfo)
     }
     
-    public func isEqualToAttributedString(_ other: AttributedString) -> Bool { NSUnimplemented() }
+    open func isEqualToAttributedString(_ other: AttributedString) -> Bool { NSUnimplemented() }
     
     public init(string str: String) {
         _string = str._nsObject
@@ -204,31 +204,31 @@ extension AttributedString {
 }
 
 
-public class NSMutableAttributedString : AttributedString {
+open class NSMutableAttributedString : AttributedString {
     
-    public func replaceCharactersInRange(_ range: NSRange, withString str: String) { NSUnimplemented() }
-    public func setAttributes(_ attrs: [String : AnyObject]?, range: NSRange) { NSUnimplemented() }
+    open func replaceCharactersInRange(_ range: NSRange, withString str: String) { NSUnimplemented() }
+    open func setAttributes(_ attrs: [String : AnyObject]?, range: NSRange) { NSUnimplemented() }
     
-    public var mutableString: NSMutableString {
+    open var mutableString: NSMutableString {
         return _string as! NSMutableString
     }
     
-    public func addAttribute(_ name: String, value: AnyObject, range: NSRange) {
+    open func addAttribute(_ name: String, value: AnyObject, range: NSRange) {
         CFAttributedStringSetAttribute(_cfMutableObject, CFRange(range), name._cfObject, value)
     }
     
-    public func addAttributes(_ attrs: [String : AnyObject], range: NSRange) { NSUnimplemented() }
+    open func addAttributes(_ attrs: [String : AnyObject], range: NSRange) { NSUnimplemented() }
     
-    public func removeAttribute(_ name: String, range: NSRange) { NSUnimplemented() }
+    open func removeAttribute(_ name: String, range: NSRange) { NSUnimplemented() }
     
-    public func replaceCharactersInRange(_ range: NSRange, withAttributedString attrString: AttributedString) { NSUnimplemented() }
-    public func insertAttributedString(_ attrString: AttributedString, atIndex loc: Int) { NSUnimplemented() }
-    public func appendAttributedString(_ attrString: AttributedString) { NSUnimplemented() }
+    open func replaceCharactersInRange(_ range: NSRange, withAttributedString attrString: AttributedString) { NSUnimplemented() }
+    open func insertAttributedString(_ attrString: AttributedString, atIndex loc: Int) { NSUnimplemented() }
+    open func appendAttributedString(_ attrString: AttributedString) { NSUnimplemented() }
     public func deleteCharactersInRange(_ range: NSRange) { NSUnimplemented() }
-    public func setAttributedString(_ attrString: AttributedString) { NSUnimplemented() }
+    open func setAttributedString(_ attrString: AttributedString) { NSUnimplemented() }
     
-    public func beginEditing() { NSUnimplemented() }
-    public func endEditing() { NSUnimplemented() }
+    open func beginEditing() { NSUnimplemented() }
+    open func endEditing() { NSUnimplemented() }
     
     public override init(string str: String) {
         super.init(string: str)

--- a/Foundation/NSBundle.swift
+++ b/Foundation/NSBundle.swift
@@ -9,14 +9,14 @@
 
 import CoreFoundation
 
-public class Bundle: NSObject {
+open class Bundle: NSObject {
     private var _bundle : CFBundle!
 
     private static var _mainBundle : Bundle = {
         return Bundle(cfBundle: CFBundleGetMainBundle())
     }()
     
-    public class func main() -> Bundle {
+    open class func main() -> Bundle {
         return _mainBundle
     }
     
@@ -62,21 +62,21 @@ public class Bundle: NSObject {
         _bundle = result
     }
     
-    override public var description: String {
+    override open var description: String {
         return "\(String(describing: Bundle.self)) <\(bundleURL.path!)> (\(isLoaded  ? "loaded" : "not yet loaded"))"
     }
 
     
     /* Methods for loading and unloading bundles. */
-    public func load() -> Bool {
+    open func load() -> Bool {
         return  CFBundleLoadExecutable(_bundle)
     }
-    public var isLoaded: Bool {
+    open var isLoaded: Bool {
         return CFBundleIsExecutableLoaded(_bundle)
     }
-    public func unload() -> Bool { NSUnimplemented() }
+    open func unload() -> Bool { NSUnimplemented() }
     
-    public func preflight() throws {
+    open func preflight() throws {
         var unmanagedError:Unmanaged<CFError>? = nil
         try withUnsafeMutablePointer(to: &unmanagedError) { (unmanagedCFError: UnsafeMutablePointer<Unmanaged<CFError>?>)  in
             CFBundlePreflightExecutable(_bundle, unmanagedCFError)
@@ -86,7 +86,7 @@ public class Bundle: NSObject {
         }
     }
     
-    public func loadAndReturnError() throws {
+    open func loadAndReturnError() throws {
         var unmanagedError:Unmanaged<CFError>? = nil
         try  withUnsafeMutablePointer(to: &unmanagedError) { (unmanagedCFError: UnsafeMutablePointer<Unmanaged<CFError>?>)  in
             CFBundleLoadExecutableAndReturnError(_bundle, unmanagedCFError)
@@ -99,79 +99,79 @@ public class Bundle: NSObject {
 
     
     /* Methods for locating various components of a bundle. */
-    public var bundleURL: URL {
+    open var bundleURL: URL {
         return CFBundleCopyBundleURL(_bundle)._swiftObject
     }
     
-    public var resourceURL: URL? {
+    open var resourceURL: URL? {
         return CFBundleCopyResourcesDirectoryURL(_bundle)?._swiftObject
     }
     
-    public var executableURL: URL? {
+    open var executableURL: URL? {
         return CFBundleCopyExecutableURL(_bundle)?._swiftObject
     }
     
-    public func urlForAuxiliaryExecutable(_ executableName: String) -> NSURL? {
+    open func urlForAuxiliaryExecutable(_ executableName: String) -> NSURL? {
         return CFBundleCopyAuxiliaryExecutableURL(_bundle, executableName._cfObject)?._nsObject
     }
     
-    public var privateFrameworksURL: URL? {
+    open var privateFrameworksURL: URL? {
         return CFBundleCopyPrivateFrameworksURL(_bundle)?._swiftObject
     }
     
-    public var sharedFrameworksURL: URL? {
+    open var sharedFrameworksURL: URL? {
         return CFBundleCopySharedFrameworksURL(_bundle)?._swiftObject
     }
     
-    public var sharedSupportURL: URL? {
+    open var sharedSupportURL: URL? {
         return CFBundleCopySharedSupportURL(_bundle)?._swiftObject
     }
     
-    public var builtInPlugInsURL: URL? {
+    open var builtInPlugInsURL: URL? {
         return CFBundleCopyBuiltInPlugInsURL(_bundle)?._swiftObject
     }
     
-    public var appStoreReceiptURL: URL? {
+    open var appStoreReceiptURL: URL? {
         // Always nil on this platform
         return nil
     }
     
-    public var bundlePath: String {
+    open var bundlePath: String {
         return bundleURL.path!
     }
     
-    public var resourcePath: String? {
+    open var resourcePath: String? {
         return resourceURL?.path
     }
     
-    public var executablePath: String? {
+    open var executablePath: String? {
         return executableURL?.path
     }
     
-    public func pathForAuxiliaryExecutable(_ executableName: String) -> String? {
+    open func pathForAuxiliaryExecutable(_ executableName: String) -> String? {
         return urlForAuxiliaryExecutable(executableName)?.path
     }
     
-    public var privateFrameworksPath: String? {
+    open var privateFrameworksPath: String? {
         return privateFrameworksURL?.path
     }
     
-    public var sharedFrameworksPath: String? {
+    open var sharedFrameworksPath: String? {
         return sharedFrameworksURL?.path
     }
     
-    public var sharedSupportPath: String? {
+    open var sharedSupportPath: String? {
         return sharedSupportURL?.path
     }
     
-    public var builtInPlugInsPath: String? {
+    open var builtInPlugInsPath: String? {
         return builtInPlugInsURL?.path
     }
     
     // -----------------------------------------------------------------------------------
     // MARK: - URL Resource Lookup - Class
     
-    public class func urlForResource(_ name: String?, withExtension ext: String?, subdirectory subpath: String?, inBundleWith bundleURL: URL) -> URL? {
+    open class func urlForResource(_ name: String?, withExtension ext: String?, subdirectory subpath: String?, inBundleWith bundleURL: URL) -> URL? {
         // If both name and ext are nil/zero-length, return nil
         if (name == nil || name!.isEmpty) && (ext == nil || ext!.isEmpty) {
             return nil
@@ -180,18 +180,18 @@ public class Bundle: NSObject {
         return CFBundleCopyResourceURLInDirectory(bundleURL._cfObject, name?._cfObject, ext?._cfObject, subpath?._cfObject)._swiftObject
     }
     
-    public class func urlsForResources(withExtension ext: String?, subdirectory subpath: String?, inBundleWith bundleURL: NSURL) -> [NSURL]? {
+    open class func urlsForResources(withExtension ext: String?, subdirectory subpath: String?, inBundleWith bundleURL: NSURL) -> [NSURL]? {
         return CFBundleCopyResourceURLsOfTypeInDirectory(bundleURL._cfObject, ext?._cfObject, subpath?._cfObject)?._unsafeTypedBridge()
     }
     
     // -----------------------------------------------------------------------------------
     // MARK: - URL Resource Lookup - Instance
 
-    public func urlForResource(_ name: String?, withExtension ext: String?) -> URL? {
+    open func urlForResource(_ name: String?, withExtension ext: String?) -> URL? {
         return self.urlForResource(name, withExtension: ext, subdirectory: nil)
     }
     
-    public func urlForResource(_ name: String?, withExtension ext: String?, subdirectory subpath: String?) -> URL? {
+    open func urlForResource(_ name: String?, withExtension ext: String?, subdirectory subpath: String?) -> URL? {
         // If both name and ext are nil/zero-length, return nil
         if (name == nil || name!.isEmpty) && (ext == nil || ext!.isEmpty) {
             return nil
@@ -199,7 +199,7 @@ public class Bundle: NSObject {
         return CFBundleCopyResourceURL(_bundle, name?._cfObject, ext?._cfObject, subpath?._cfObject)?._swiftObject
     }
     
-    public func urlForResource(_ name: String?, withExtension ext: String?, subdirectory subpath: String?, localization localizationName: String?) -> URL? {
+    open func urlForResource(_ name: String?, withExtension ext: String?, subdirectory subpath: String?, localization localizationName: String?) -> URL? {
         // If both name and ext are nil/zero-length, return nil
         if (name == nil || name!.isEmpty) && (ext == nil || ext!.isEmpty) {
             return nil
@@ -208,22 +208,22 @@ public class Bundle: NSObject {
         return CFBundleCopyResourceURLForLocalization(_bundle, name?._cfObject, ext?._cfObject, subpath?._cfObject, localizationName?._cfObject)?._swiftObject
     }
     
-    public func urlsForResources(withExtension ext: String?, subdirectory subpath: String?) -> [NSURL]? {
+    open func urlsForResources(withExtension ext: String?, subdirectory subpath: String?) -> [NSURL]? {
         return CFBundleCopyResourceURLsOfType(_bundle, ext?._cfObject, subpath?._cfObject)?._unsafeTypedBridge()
     }
     
-    public func urlsForResources(withExtension ext: String?, subdirectory subpath: String?, localization localizationName: String?) -> [NSURL]? {
+    open func urlsForResources(withExtension ext: String?, subdirectory subpath: String?, localization localizationName: String?) -> [NSURL]? {
         return CFBundleCopyResourceURLsOfTypeForLocalization(_bundle, ext?._cfObject, subpath?._cfObject, localizationName?._cfObject)?._unsafeTypedBridge()
     }
     
     // -----------------------------------------------------------------------------------
     // MARK: - Path Resource Lookup - Class
 
-    public class func pathForResource(_ name: String?, ofType ext: String?, inDirectory bundlePath: String) -> String? {
+    open class func pathForResource(_ name: String?, ofType ext: String?, inDirectory bundlePath: String) -> String? {
         return Bundle.urlForResource(name, withExtension: ext, subdirectory: bundlePath, inBundleWith: URL(fileURLWithPath: bundlePath))?.path ?? nil
     }
     
-    public class func pathsForResources(ofType ext: String?, inDirectory bundlePath: String) -> [String] {
+    open class func pathsForResources(ofType ext: String?, inDirectory bundlePath: String) -> [String] {
         // Force-unwrap path, beacuse if the URL can't be turned into a path then something is wrong anyway
         return urlsForResources(withExtension: ext, subdirectory: bundlePath, inBundleWith: NSURL(fileURLWithPath: bundlePath))?.map { $0.path! } ?? []
     }
@@ -231,24 +231,24 @@ public class Bundle: NSObject {
     // -----------------------------------------------------------------------------------
     // MARK: - Path Resource Lookup - Instance
 
-    public func pathForResource(_ name: String?, ofType ext: String?) -> String? {
+    open func pathForResource(_ name: String?, ofType ext: String?) -> String? {
         return self.urlForResource(name, withExtension: ext, subdirectory: nil)?.path
     }
     
-    public func pathForResource(_ name: String?, ofType ext: String?, inDirectory subpath: String?) -> String? {
+    open func pathForResource(_ name: String?, ofType ext: String?, inDirectory subpath: String?) -> String? {
         return self.urlForResource(name, withExtension: ext, subdirectory: subpath)?.path
     }
     
-    public func pathForResource(_ name: String?, ofType ext: String?, inDirectory subpath: String?, forLocalization localizationName: String?) -> String? {
+    open func pathForResource(_ name: String?, ofType ext: String?, inDirectory subpath: String?, forLocalization localizationName: String?) -> String? {
         return self.urlForResource(name, withExtension: ext, subdirectory: subpath, localization: localizationName)?.path
     }
     
-    public func pathsForResources(ofType ext: String?, inDirectory subpath: String?) -> [String] {
+    open func pathsForResources(ofType ext: String?, inDirectory subpath: String?) -> [String] {
         // Force-unwrap path, beacuse if the URL can't be turned into a path then something is wrong anyway
         return self.urlsForResources(withExtension: ext, subdirectory: subpath)?.map { $0.path! } ?? []
     }
     
-    public func pathsForResources(ofType ext: String?, inDirectory subpath: String?, forLocalization localizationName: String?) -> [String] {
+    open func pathsForResources(ofType ext: String?, inDirectory subpath: String?, forLocalization localizationName: String?) -> [String] {
         // Force-unwrap path, beacuse if the URL can't be turned into a path then something is wrong anyway
         return self.urlsForResources(withExtension: ext, subdirectory: subpath, localization: localizationName)?.map { $0.path! } ?? []
     }
@@ -256,7 +256,7 @@ public class Bundle: NSObject {
     // -----------------------------------------------------------------------------------
     // MARK: - Localized Strings
     
-    public func localizedString(forKey key: String, value: String?, table tableName: String?) -> String {
+    open func localizedString(forKey key: String, value: String?, table tableName: String?) -> String {
         let localizedString = CFBundleCopyLocalizedString(_bundle, key._cfObject, value?._cfObject, tableName?._cfObject)!
         return localizedString._swiftObject
     }
@@ -264,27 +264,27 @@ public class Bundle: NSObject {
     // -----------------------------------------------------------------------------------
     // MARK: - Other
     
-    public var bundleIdentifier: String? {
+    open var bundleIdentifier: String? {
         return CFBundleGetIdentifier(_bundle)?._swiftObject
     }
     
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation
     /// - Note: This API differs from Darwin because it uses [String : Any] as a type instead of [String : AnyObject]. This allows the use of Swift value types.
-    public var infoDictionary: [String : Any]? {
+    open var infoDictionary: [String : Any]? {
         let cfDict: CFDictionary? = CFBundleGetInfoDictionary(_bundle)
         return cfDict.map(_expensivePropertyListConversion) as? [String: Any]
     }
     
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation
     /// - Note: This API differs from Darwin because it uses [String : Any] as a type instead of [String : AnyObject]. This allows the use of Swift value types.
-    public var localizedInfoDictionary: [String : Any]? {
+    open var localizedInfoDictionary: [String : Any]? {
         let cfDict: CFDictionary? = CFBundleGetLocalInfoDictionary(_bundle)
         return cfDict.map(_expensivePropertyListConversion) as? [String: Any]
     }
     
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation
     /// - Note: This API differs from Darwin because it uses [String : Any] as a type instead of [String : AnyObject]. This allows the use of Swift value types.
-    public func objectForInfoDictionaryKey(_ key: String) -> Any? {
+    open func objectForInfoDictionaryKey(_ key: String) -> Any? {
         if let localizedInfoDictionary = localizedInfoDictionary {
             return localizedInfoDictionary[key]
         } else {
@@ -292,34 +292,34 @@ public class Bundle: NSObject {
         }
     }
     
-    public func classNamed(_ className: String) -> AnyClass? { NSUnimplemented() }
-    public var principalClass: AnyClass? { NSUnimplemented() }
-    public var preferredLocalizations: [String] {
+    open func classNamed(_ className: String) -> AnyClass? { NSUnimplemented() }
+    open var principalClass: AnyClass? { NSUnimplemented() }
+    open var preferredLocalizations: [String] {
         return Bundle.preferredLocalizations(from: localizations)
     }
-    public var localizations: [String] {
+    open var localizations: [String] {
         let cfLocalizations: CFArray? = CFBundleCopyBundleLocalizations(_bundle)
         let nsLocalizations = cfLocalizations.map(_expensivePropertyListConversion) as? [Any]
         return nsLocalizations?.map { $0 as! String } ?? []
     }
 
-    public var developmentLocalization: String? {
+    open var developmentLocalization: String? {
         let region = CFBundleGetDevelopmentRegion(_bundle)!
         return region._swiftObject
     }
 
-    public class func preferredLocalizations(from localizationsArray: [String]) -> [String] {
+    open class func preferredLocalizations(from localizationsArray: [String]) -> [String] {
         let cfLocalizations: CFArray? = CFBundleCopyPreferredLocalizationsFromArray(localizationsArray._cfObject)
         let nsLocalizations = cfLocalizations.map(_expensivePropertyListConversion) as? [Any]
         return nsLocalizations?.map { $0 as! String } ?? []
     }
     
-	public class func preferredLocalizations(from localizationsArray: [String], forPreferences preferencesArray: [String]?) -> [String] {
+	open class func preferredLocalizations(from localizationsArray: [String], forPreferences preferencesArray: [String]?) -> [String] {
         let localizations = CFBundleCopyLocalizationsForPreferences(localizationsArray._cfObject, preferencesArray?._cfObject)!
         return localizations._swiftObject.map { return ($0 as! NSString)._swiftObject }
     }
 	
-	public var executableArchitectures: [NSNumber]? {
+	open var executableArchitectures: [NSNumber]? {
         let architectures = CFBundleCopyExecutableArchitectures(_bundle)!
         return architectures._swiftObject.map() { $0 as! NSNumber }
     }

--- a/Foundation/NSByteCountFormatter.swift
+++ b/Foundation/NSByteCountFormatter.swift
@@ -41,7 +41,7 @@ extension ByteCountFormatter {
     }
 }
 
-public class ByteCountFormatter : Formatter {
+open class ByteCountFormatter : Formatter {
     public override init() {
         super.init()
     }
@@ -52,43 +52,43 @@ public class ByteCountFormatter : Formatter {
     
     /* Shortcut for converting a byte count into a string without creating an NSByteCountFormatter and an NSNumber. If you need to specify options other than countStyle, create an instance of NSByteCountFormatter first.
     */
-    public class func string(fromByteCount byteCount: Int64, countStyle: ByteCountFormatter.CountStyle) -> String { NSUnimplemented() }
+    open class func string(fromByteCount byteCount: Int64, countStyle: ByteCountFormatter.CountStyle) -> String { NSUnimplemented() }
     
     /* Convenience method on string(for:):. Convert a byte count into a string without creating an NSNumber.
     */
-    public func stringFromByteCount(_ byteCount: Int64) -> String { NSUnimplemented() }
+    open func stringFromByteCount(_ byteCount: Int64) -> String { NSUnimplemented() }
     
     /* Specify the units that can be used in the output. If NSByteCountFormatterUseDefault, uses platform-appropriate settings; otherwise will only use the specified units. This is the default value. Note that ZB and YB cannot be covered by the range of possible values, but you can still choose to use these units to get fractional display ("0.0035 ZB" for instance).
     */
-    public var allowedUnits: Units = .useDefault
+    open var allowedUnits: Units = .useDefault
     
     /* Specify how the count is displayed by indicating the number of bytes to be used for kilobyte. The default setting is NSByteCountFormatterFileCount, which is the system specific value for file and storage sizes.
     */
-    public var countStyle: CountStyle = .file
+    open var countStyle: CountStyle = .file
     
     /* Choose whether to allow more natural display of some values, such as zero, where it may be displayed as "Zero KB," ignoring all other flags or options (with the exception of NSByteCountFormatterUseBytes, which would generate "Zero bytes"). The result is appropriate for standalone output. Default value is YES. Special handling of certain values such as zero is especially important in some languages, so it's highly recommended that this property be left in its default state.
     */
-    public var allowsNonnumericFormatting: Bool = true
+    open var allowsNonnumericFormatting: Bool = true
     
     /* Choose whether to include the number or the units in the resulting formatted string. (For example, instead of 723 KB, returns "723" or "KB".) You can call the API twice to get both parts, separately. But note that putting them together yourself via string concatenation may be wrong for some locales; so use this functionality with care.  Both of these values are YES by default.  Setting both to NO will unsurprisingly result in an empty string.
     */
-    public var includesUnit: Bool = true
-    public var includesCount: Bool = true
+    open var includesUnit: Bool = true
+    open var includesCount: Bool = true
     
     /* Choose whether to parenthetically (localized as appropriate) display the actual number of bytes as well, for instance "723 KB (722,842 bytes)".  This will happen only if needed, that is, the first part is already not showing the exact byte count.  If includesUnit or includesCount are NO, then this setting has no effect.  Default value is NO.
     */
-    public var includesActualByteCount: Bool = false
+    open var includesActualByteCount: Bool = false
     
     /* Choose the display style. The "adaptive" algorithm is platform specific and uses a different number of fraction digits based on the magnitude (in 10.8: 0 fraction digits for bytes and KB; 1 fraction digits for MB; 2 for GB and above). Otherwise the result always tries to show at least three significant digits, introducing fraction digits as necessary. Default is YES.
     */
-    public var isAdaptive: Bool = true
+    open var isAdaptive: Bool = true
     
     /* Choose whether to zero pad fraction digits so a consistent number of fraction digits are displayed, causing updating displays to remain more stable. For instance, if the adaptive algorithm is used, this option formats 1.19 and 1.2 GB as "1.19 GB" and "1.20 GB" respectively, while without the option the latter would be displayed as "1.2 GB". Default value is NO.
     */
-    public var zeroPadsFractionDigits: Bool = false
+    open var zeroPadsFractionDigits: Bool = false
     
     /* Specify the formatting context for the formatted string. Default is NSFormattingContextUnknown.
     */
-    public var formattingContext: Context = .unknown
+    open var formattingContext: Context = .unknown
 }
 

--- a/Foundation/NSCache.swift
+++ b/Foundation/NSCache.swift
@@ -8,7 +8,7 @@
 //
 
 
-public class Cache: NSObject {
+open class Cache: NSObject {
     private class NSCacheEntry {
         var key: AnyObject
         var value: AnyObject
@@ -27,18 +27,18 @@ public class Cache: NSObject {
     private var _totalCost = 0
     private var _byCost: NSCacheEntry?
     
-    public var name: String = ""
-    public var totalCostLimit: Int = -1 // limits are imprecise/not strict
-    public var countLimit: Int = -1 // limits are imprecise/not strict
-    public var evictsObjectsWithDiscardedContent: Bool = false
+    open var name: String = ""
+    open var totalCostLimit: Int = -1 // limits are imprecise/not strict
+    open var countLimit: Int = -1 // limits are imprecise/not strict
+    open var evictsObjectsWithDiscardedContent: Bool = false
 
     public override init() {
         
     }
     
-    public weak var delegate: NSCacheDelegate?
+    open weak var delegate: NSCacheDelegate?
     
-    public func object(forKey key: AnyObject) -> AnyObject? {
+    open func object(forKey key: AnyObject) -> AnyObject? {
         var object: AnyObject?
         
         let keyRef = unsafeBitCast(key, to: UnsafeRawPointer.self)
@@ -52,7 +52,7 @@ public class Cache: NSObject {
         return object
     }
     
-    public func setObject(_ obj: AnyObject, forKey key: AnyObject) {
+    open func setObject(_ obj: AnyObject, forKey key: AnyObject) {
         setObject(obj, forKey: key, cost: 0)
     }
     
@@ -83,7 +83,7 @@ public class Cache: NSObject {
         }
     }
     
-    public func setObject(_ obj: AnyObject, forKey key: AnyObject, cost g: Int) {
+    open func setObject(_ obj: AnyObject, forKey key: AnyObject, cost g: Int) {
         let keyRef = unsafeBitCast(key, to: UnsafeRawPointer.self)
         
         _lock.lock()
@@ -157,7 +157,7 @@ public class Cache: NSObject {
         _lock.unlock()
     }
     
-    public func removeObject(forKey key: AnyObject) {
+    open func removeObject(forKey key: AnyObject) {
         let keyRef = unsafeBitCast(key, to: UnsafeRawPointer.self)
         
         _lock.lock()
@@ -168,7 +168,7 @@ public class Cache: NSObject {
         _lock.unlock()
     }
     
-    public func removeAllObjects() {
+    open func removeAllObjects() {
         _lock.lock()
         _entries.removeAll()
         _byCost = nil

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -97,7 +97,7 @@ extension Calendar {
     }
 }
     
-public class Calendar: NSObject, NSCopying, NSSecureCoding {
+open class Calendar: NSObject, NSCopying, NSSecureCoding {
     typealias CFType = CFCalendar
     private var _base = _CFInfo(typeID: CFCalendarGetTypeID())
     private var _identifier: UnsafeMutableRawPointer? = nil
@@ -145,7 +145,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         if aCoder.allowsKeyedCoding {
             aCoder.encode(self.calendarIdentifier.bridge(), forKey: "NS.identifier")
             aCoder.encode(self.timeZone, forKey: "NS.timezone")
@@ -162,11 +162,11 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
         return true
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         let copy = Calendar(calendarIdentifier: calendarIdentifier)!
         copy.locale = locale
         copy.timeZone = timeZone
@@ -177,11 +177,11 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     }
     
 
-    public class var current: Calendar {
+    open class var current: Calendar {
         return CFCalendarCopyCurrent()._nsObject
     }
     
-    public class func autoupdatingCurrentCalendar() -> Calendar { NSUnimplemented() }  // tracks changes to user's preferred calendar identifier
+    open class func autoupdatingCurrentCalendar() -> Calendar { NSUnimplemented() }  // tracks changes to user's preferred calendar identifier
     
     public /*not inherited*/ init?(identifier calendarIdentifierConstant: String) {
         super.init()
@@ -197,11 +197,11 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public override var hash: Int {
+    open override var hash: Int {
         return Int(bitPattern: CFHash(_cfObject))
     }
     
-    public override func isEqual(_ object: AnyObject?) -> Bool {
+    open override func isEqual(_ object: AnyObject?) -> Bool {
         if let cal = object as? Calendar {
             return CFEqual(_cfObject, cal._cfObject)
         } else {
@@ -209,7 +209,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public override var description: String {
+    open override var description: String {
         return CFCopyDescription(_cfObject)._swiftObject
     }
 
@@ -217,13 +217,13 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
         _CFDeinit(self)
     }
     
-    public var calendarIdentifier: String  {
+    open var calendarIdentifier: String  {
         get {
             return CFCalendarGetIdentifier(_cfObject)._swiftObject
         }
     }
     
-    /*@NSCopying*/ public var locale: Locale? {
+    /*@NSCopying*/ open var locale: Locale? {
         get {
             return CFCalendarCopyLocale(_cfObject)._nsObject
         }
@@ -231,7 +231,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
             CFCalendarSetLocale(_cfObject, newValue?._cfObject)
         }
     }
-    /*@NSCopying*/ public var timeZone: TimeZone {
+    /*@NSCopying*/ open var timeZone: TimeZone {
         get {
             return CFCalendarCopyTimeZone(_cfObject)._nsObject
         }
@@ -240,7 +240,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public var firstWeekday: Int {
+    open var firstWeekday: Int {
         get {
             return CFCalendarGetFirstWeekday(_cfObject)
         }
@@ -249,7 +249,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public var minimumDaysInFirstWeek: Int {
+    open var minimumDaysInFirstWeek: Int {
         get {
             return CFCalendarGetMinimumDaysInFirstWeek(_cfObject)
         }
@@ -275,89 +275,89 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
         return (CFDateFormatterCopyProperty(dateFormatter, key) as! CFString)._swiftObject
     }
     
-    public var eraSymbols: [String] {
+    open var eraSymbols: [String] {
         return _symbols(kCFDateFormatterEraSymbolsKey)
     }
     
-    public var longEraSymbols: [String] {
+    open var longEraSymbols: [String] {
         return _symbols(kCFDateFormatterLongEraSymbolsKey)
     }
     
-    public var monthSymbols: [String] {
+    open var monthSymbols: [String] {
         return _symbols(kCFDateFormatterMonthSymbolsKey)
     }
     
-    public var shortMonthSymbols: [String] {
+    open var shortMonthSymbols: [String] {
         return _symbols(kCFDateFormatterShortMonthSymbolsKey)
     }
     
-    public var veryShortMonthSymbols: [String] {
+    open var veryShortMonthSymbols: [String] {
         return _symbols(kCFDateFormatterVeryShortMonthSymbolsKey)
     }
     
-    public var standaloneMonthSymbols: [String] {
+    open var standaloneMonthSymbols: [String] {
         return _symbols(kCFDateFormatterStandaloneMonthSymbolsKey)
     }
     
-    public var shortStandaloneMonthSymbols: [String] {
+    open var shortStandaloneMonthSymbols: [String] {
         return _symbols(kCFDateFormatterShortStandaloneMonthSymbolsKey)
     }
     
-    public var veryShortStandaloneMonthSymbols: [String] {
+    open var veryShortStandaloneMonthSymbols: [String] {
         return _symbols(kCFDateFormatterVeryShortStandaloneMonthSymbolsKey)
     }
     
-    public var weekdaySymbols: [String] {
+    open var weekdaySymbols: [String] {
         return _symbols(kCFDateFormatterWeekdaySymbolsKey)
     }
     
-    public var shortWeekdaySymbols: [String] {
+    open var shortWeekdaySymbols: [String] {
         return _symbols(kCFDateFormatterShortWeekdaySymbolsKey)
     }
     
-    public var veryShortWeekdaySymbols: [String] {
+    open var veryShortWeekdaySymbols: [String] {
         return _symbols(kCFDateFormatterVeryShortWeekdaySymbolsKey)
     }
     
-    public var standaloneWeekdaySymbols: [String] {
+    open var standaloneWeekdaySymbols: [String] {
         return _symbols(kCFDateFormatterStandaloneWeekdaySymbolsKey)
     }
     
-    public var shortStandaloneWeekdaySymbols: [String] {
+    open var shortStandaloneWeekdaySymbols: [String] {
         return _symbols(kCFDateFormatterShortStandaloneWeekdaySymbolsKey)
     }
 
-    public var veryShortStandaloneWeekdaySymbols: [String] {
+    open var veryShortStandaloneWeekdaySymbols: [String] {
         return _symbols(kCFDateFormatterVeryShortStandaloneWeekdaySymbolsKey)
     }
     
-    public var quarterSymbols: [String] {
+    open var quarterSymbols: [String] {
         return _symbols(kCFDateFormatterQuarterSymbolsKey)
     }
     
-    public var shortQuarterSymbols: [String] {
+    open var shortQuarterSymbols: [String] {
         return _symbols(kCFDateFormatterShortQuarterSymbolsKey)
     }
     
-    public var standaloneQuarterSymbols: [String] {
+    open var standaloneQuarterSymbols: [String] {
         return _symbols(kCFDateFormatterStandaloneQuarterSymbolsKey)
     }
     
-    public var shortStandaloneQuarterSymbols: [String] {
+    open var shortStandaloneQuarterSymbols: [String] {
         return _symbols(kCFDateFormatterShortStandaloneQuarterSymbolsKey)
     }
     
-    public var AMSymbol: String {
+    open var AMSymbol: String {
         return _symbol(kCFDateFormatterAMSymbolKey)
     }
     
-    public var PMSymbol: String {
+    open var PMSymbol: String {
         return _symbol(kCFDateFormatterPMSymbolKey)
     }
     
     // Calendrical calculations
     
-    public func minimumRange(of unit: Unit) -> NSRange {
+    open func minimumRange(of unit: Unit) -> NSRange {
         let r = CFCalendarGetMinimumRangeOfUnit(self._cfObject, unit._cfValue)
         if (r.location == kCFNotFound) {
             return NSMakeRange(NSNotFound, NSNotFound)
@@ -365,7 +365,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
         return NSMakeRange(r.location, r.length)
     }
     
-    public func maximumRange(of unit: Unit) -> NSRange {
+    open func maximumRange(of unit: Unit) -> NSRange {
         let r = CFCalendarGetMaximumRangeOfUnit(_cfObject, unit._cfValue)
         if r.location == kCFNotFound {
             return NSMakeRange(NSNotFound, NSNotFound)
@@ -373,7 +373,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
         return NSMakeRange(r.location, r.length)
     }
     
-    public func range(of smaller: Unit, in larger: Unit, for date: Date) -> NSRange {
+    open func range(of smaller: Unit, in larger: Unit, for date: Date) -> NSRange {
         let r = CFCalendarGetRangeOfUnit(_cfObject, smaller._cfValue, larger._cfValue, date.timeIntervalSinceReferenceDate)
         if r.location == kCFNotFound {
             return NSMakeRange(NSNotFound, NSNotFound)
@@ -381,17 +381,17 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
         return NSMakeRange(r.location, r.length)
     }
     
-    public func ordinality(of smaller: Unit, in larger: Unit, for date: Date) -> Int {
+    open func ordinality(of smaller: Unit, in larger: Unit, for date: Date) -> Int {
         return Int(CFCalendarGetOrdinalityOfUnit(_cfObject, smaller._cfValue, larger._cfValue, date.timeIntervalSinceReferenceDate))
     }
     
     /// Revised API for avoiding usage of AutoreleasingUnsafeMutablePointer.
     /// The current exposed API in Foundation on Darwin platforms is:
-    /// public func rangeOfUnit(_ unit: Unit, startDate datep: AutoreleasingUnsafeMutablePointer<NSDate?>, interval tip: UnsafeMutablePointer<NSTimeInterval>, forDate date: NSDate) -> Bool
+    /// open func rangeOfUnit(_ unit: Unit, startDate datep: AutoreleasingUnsafeMutablePointer<NSDate?>, interval tip: UnsafeMutablePointer<NSTimeInterval>, forDate date: NSDate) -> Bool
     /// which is not implementable on Linux due to the lack of being able to properly implement AutoreleasingUnsafeMutablePointer.
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    public func range(of unit: Unit, forDate date: Date) -> DateInterval? {
+    open func range(of unit: Unit, forDate date: Date) -> DateInterval? {
         var start: CFAbsoluteTime = 0.0
         var ti: CFTimeInterval = 0.0
         let res: Bool = withUnsafeMutablePointer(to: &start) { startp in
@@ -446,7 +446,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
         return (vector, compDesc)
     }
     
-    public func date(from comps: DateComponents) -> Date? {
+    open func date(from comps: DateComponents) -> Date? {
         var (vector, compDesc) = _convert(comps)
         
         self.timeZone = comps.timeZone ?? timeZone
@@ -529,7 +529,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// The Darwin version is not nullable but this one is since the conversion from the date and unit flags can potentially return nil
-    public func components(_ unitFlags: Unit, from date: Date) -> DateComponents? {
+    open func components(_ unitFlags: Unit, from date: Date) -> DateComponents? {
         let compDesc = _setup(unitFlags)
         
         // _CFCalendarDecomposeAbsoluteTimeV requires a bit of a funky vector layout; which does not express well in swift; this is the closest I can come up with to the required format
@@ -552,7 +552,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
         return nil
     }
     
-    public func date(byAdding comps: DateComponents, to date: Date, options opts: Options = []) -> Date? {
+    open func date(byAdding comps: DateComponents, to date: Date, options opts: Options = []) -> Date? {
         var (vector, compDesc) = _convert(comps)
         var at: CFAbsoluteTime = 0.0
         
@@ -569,7 +569,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
         return nil
     }
     
-    public func components(_ unitFlags: Unit, from startingDate: Date, to resultDate: Date, options opts: Options = []) -> DateComponents {
+    open func components(_ unitFlags: Unit, from startingDate: Date, to resultDate: Date, options opts: Options = []) -> DateComponents {
         let compDesc = _setup(unitFlags)
         var ints = [Int32](repeating: 0, count: 20)
         let res = ints.withUnsafeMutableBufferPointer { (intArrayBuffer: inout UnsafeMutableBufferPointer<Int32>) -> Bool in
@@ -592,7 +592,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     This API is a convenience for getting era, year, month, and day of a given date.
     Pass NULL for a NSInteger pointer parameter if you don't care about that value.
     */
-    public func getEra(_ eraValuePointer: UnsafeMutablePointer<Int>?, year yearValuePointer: UnsafeMutablePointer<Int>?, month monthValuePointer: UnsafeMutablePointer<Int>?, day dayValuePointer: UnsafeMutablePointer<Int>?, from date: Date) {
+    open func getEra(_ eraValuePointer: UnsafeMutablePointer<Int>?, year yearValuePointer: UnsafeMutablePointer<Int>?, month monthValuePointer: UnsafeMutablePointer<Int>?, day dayValuePointer: UnsafeMutablePointer<Int>?, from date: Date) {
         if let comps = components([.era, .year, .month, .day], from: date) {
             if let value = comps.era {
                 eraValuePointer?.pointee = value
@@ -621,7 +621,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     This API is a convenience for getting era, year for week-of-year calculations, week of year, and weekday of a given date.
     Pass NULL for a NSInteger pointer parameter if you don't care about that value.
     */
-    public func getEra(_ eraValuePointer: UnsafeMutablePointer<Int>?, yearForWeekOfYear yearValuePointer: UnsafeMutablePointer<Int>?, weekOfYear weekValuePointer: UnsafeMutablePointer<Int>?, weekday weekdayValuePointer: UnsafeMutablePointer<Int>?, from date: Date) {
+    open func getEra(_ eraValuePointer: UnsafeMutablePointer<Int>?, yearForWeekOfYear yearValuePointer: UnsafeMutablePointer<Int>?, weekOfYear weekValuePointer: UnsafeMutablePointer<Int>?, weekday weekdayValuePointer: UnsafeMutablePointer<Int>?, from date: Date) {
         if let comps = components([.era, .yearForWeekOfYear, .weekOfYear, .weekday], from: date) {
             if let value = comps.era {
                 eraValuePointer?.pointee = value
@@ -650,7 +650,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     This API is a convenience for getting hour, minute, second, and nanoseconds of a given date.
     Pass NULL for a NSInteger pointer parameter if you don't care about that value.
     */
-    public func getHour(_ hourValuePointer: UnsafeMutablePointer<Int>?, minute minuteValuePointer: UnsafeMutablePointer<Int>?, second secondValuePointer: UnsafeMutablePointer<Int>?, nanosecond nanosecondValuePointer: UnsafeMutablePointer<Int>?, from date: Date) {
+    open func getHour(_ hourValuePointer: UnsafeMutablePointer<Int>?, minute minuteValuePointer: UnsafeMutablePointer<Int>?, second secondValuePointer: UnsafeMutablePointer<Int>?, nanosecond nanosecondValuePointer: UnsafeMutablePointer<Int>?, from date: Date) {
         if let comps = components([.hour, .minute, .second, .nanosecond], from: date) {
             if let value = comps.hour {
                 hourValuePointer?.pointee = value
@@ -679,7 +679,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     /*
     Get just one component's value.
     */
-    public func component(_ unit: Unit, from date: Date) -> Int {
+    open func component(_ unit: Unit, from date: Date) -> Int {
         let comps = components(unit, from: date)
         if let res = comps?.value(forComponent: unit) {
             return res
@@ -692,7 +692,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     Create a date with given components.
     Current era is assumed.
     */
-    public func date(era eraValue: Int, year yearValue: Int, month monthValue: Int, day dayValue: Int, hour hourValue: Int, minute minuteValue: Int, second secondValue: Int, nanosecond nanosecondValue: Int) -> Date? {
+    open func date(era eraValue: Int, year yearValue: Int, month monthValue: Int, day dayValue: Int, hour hourValue: Int, minute minuteValue: Int, second secondValue: Int, nanosecond nanosecondValue: Int) -> Date? {
         var comps = DateComponents()
         comps.era = eraValue
         comps.year = yearValue
@@ -709,7 +709,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     Create a date with given components.
     Current era is assumed.
     */
-    public func date(era eraValue: Int, yearForWeekOfYear yearValue: Int, weekOfYear weekValue: Int, weekday weekdayValue: Int, hour hourValue: Int, minute minuteValue: Int, second secondValue: Int, nanosecond nanosecondValue: Int) -> Date? {
+    open func date(era eraValue: Int, yearForWeekOfYear yearValue: Int, weekOfYear weekValue: Int, weekday weekdayValue: Int, hour hourValue: Int, minute minuteValue: Int, second secondValue: Int, nanosecond nanosecondValue: Int) -> Date? {
         var comps = DateComponents()
         comps.era = eraValue
         comps.yearForWeekOfYear = yearValue
@@ -727,7 +727,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     Pass in [NSDate date], for example, if you want the start of "today".
     If there were two midnights, it returns the first.  If there was none, it returns the first moment that did exist.
     */
-    public func startOfDay(for date: Date) -> Date {
+    open func startOfDay(for date: Date) -> Date {
         return range(of: .day, forDate: date)!.start
     }
     
@@ -738,7 +738,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     */
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// The Darwin version is not nullable but this one is since the conversion from the date and unit flags can potentially return nil
-    public func components(in timezone: TimeZone, fromDate date: Date) -> DateComponents? {
+    open func components(in timezone: TimeZone, fromDate date: Date) -> DateComponents? {
         let oldTz = self.timeZone
         self.timeZone = timezone
         let comps = components([.era, .year, .month, .day, .hour, .minute, .second, .nanosecond, .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear, .yearForWeekOfYear, .calendar, .timeZone], from: date)
@@ -749,7 +749,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     /*
     This API compares the given dates down to the given unit, reporting them equal if they are the same in the given unit and all larger units, otherwise either less than or greater than.
     */
-    public func compare(_ date1: Date, to date2: Date, toUnitGranularity unit: Unit) -> ComparisonResult {
+    open func compare(_ date1: Date, to date2: Date, toUnitGranularity unit: Unit) -> ComparisonResult {
         switch (unit) {
             case Unit.calendar:
                 return .orderedSame
@@ -862,28 +862,28 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     /*
     This API compares the given dates down to the given unit, reporting them equal if they are the same in the given unit and all larger units.
     */
-    public func isDate(_ date1: Date, equalToDate date2: Date, toUnitGranularity unit: Unit) -> Bool {
+    open func isDate(_ date1: Date, equalToDate date2: Date, toUnitGranularity unit: Unit) -> Bool {
         return compare(date1, to: date2, toUnitGranularity: unit) == .orderedSame
     }
     
     /*
     This API compares the Days of the given dates, reporting them equal if they are in the same Day.
     */
-    public func isDate(_ date1: Date, inSameDayAsDate date2: Date) -> Bool {
+    open func isDate(_ date1: Date, inSameDayAsDate date2: Date) -> Bool {
         return compare(date1, to: date2, toUnitGranularity: .day) == .orderedSame
     }
     
     /*
     This API reports if the date is within "today".
     */
-    public func isDateInToday(_ date: Date) -> Bool {
+    open func isDateInToday(_ date: Date) -> Bool {
         return compare(date, to: Date(), toUnitGranularity: .day) == .orderedSame
     }
     
     /*
     This API reports if the date is within "yesterday".
     */
-    public func isDateInYesterday(_ date: Date) -> Bool {
+    open func isDateInYesterday(_ date: Date) -> Bool {
         if let interval = range(of: .day, forDate: Date()) {
             let inYesterday = interval.start - 60.0
             return compare(date, to: inYesterday, toUnitGranularity: .day) == .orderedSame
@@ -895,7 +895,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     /*
     This API reports if the date is within "tomorrow".
     */
-    public func isDateInTomorrow(_ date: Date) -> Bool {
+    open func isDateInTomorrow(_ date: Date) -> Bool {
         if let interval = range(of: .day, forDate: Date()) {
             let inTomorrow = interval.end + 60.0
             return compare(date, to: inTomorrow, toUnitGranularity: .day) == .orderedSame
@@ -907,20 +907,20 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     /*
     This API reports if the date is within a weekend period, as defined by the calendar and calendar's locale.
     */
-    public func isDateInWeekend(_ date: Date) -> Bool {
+    open func isDateInWeekend(_ date: Date) -> Bool {
         return _CFCalendarIsWeekend(_cfObject, date.timeIntervalSinceReferenceDate)
     }
     
     /// Revised API for avoiding usage of AutoreleasingUnsafeMutablePointer.
     /// The current exposed API in Foundation on Darwin platforms is:
-    /// public func rangeOfWeekendStartDate(_ datep: AutoreleasingUnsafeMutablePointer<NSDate?>, interval tip: UnsafeMutablePointer<NSTimeInterval>, containingDate date: NSDate) -> Bool
+    /// open func rangeOfWeekendStartDate(_ datep: AutoreleasingUnsafeMutablePointer<NSDate?>, interval tip: UnsafeMutablePointer<NSTimeInterval>, containingDate date: NSDate) -> Bool
     /// which is not implementable on Linux due to the lack of being able to properly implement AutoreleasingUnsafeMutablePointer.
     /// Find the range of the weekend around the given date, returned via two by-reference parameters.
     /// Returns nil if the given date is not in a weekend.
     /// - Note: A given entire Day within a calendar is not necessarily all in a weekend or not; weekends can start in the middle of a Day in some calendars and locales.
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    public func rangeOfWeekendContaining(_ date: Date) -> DateInterval? {
+    open func rangeOfWeekendContaining(_ date: Date) -> DateInterval? {
         if let next = nextWeekendAfter(date, options: []) {
             if let prev = nextWeekendAfter(next.start, options: .searchBackwards) {
                 if prev.start.timeIntervalSinceReferenceDate <= date.timeIntervalSinceReferenceDate && date.timeIntervalSinceReferenceDate <= prev.end.timeIntervalSinceReferenceDate {
@@ -933,14 +933,14 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     
     /// Revised API for avoiding usage of AutoreleasingUnsafeMutablePointer.
     /// The current exposed API in Foundation on Darwin platforms is:
-    /// public func nextWeekendStartDate(_ datep: AutoreleasingUnsafeMutablePointer<NSDate?>, interval tip: UnsafeMutablePointer<NSTimeInterval>, options: Options, afterDate date: NSDate) -> Bool
+    /// open func nextWeekendStartDate(_ datep: AutoreleasingUnsafeMutablePointer<NSDate?>, interval tip: UnsafeMutablePointer<NSTimeInterval>, options: Options, afterDate date: NSDate) -> Bool
     /// Returns the range of the next weekend, via two by-reference parameters, which starts strictly after the given date.
     /// The .SearchBackwards option can be used to find the previous weekend range strictly before the date.
     /// Returns nil if there are no such things as weekend in the calendar and its locale.
     /// - Note: A given entire Day within a calendar is not necessarily all in a weekend or not; weekends can start in the middle of a Day in some calendars and locales.
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    public func nextWeekendAfter(_ date: Date, options: Options) -> DateInterval? {
+    open func nextWeekendAfter(_ date: Date, options: Options) -> DateInterval? {
         var range = _CFCalendarWeekendRange()
         let res = withUnsafeMutablePointer(to: &range) { rangep in
             return _CFCalendarGetNextWeekend(_cfObject, rangep)
@@ -983,7 +983,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     For each date components object, if its time zone property is set, that time zone is used for it; if the calendar property is set, that is used rather than the receiving calendar, and if both the calendar and time zone are set, the time zone property value overrides the time zone of the calendar property.
     No options are currently defined; pass 0.
     */
-    public func components(_ unitFlags: Unit, from startingDateComp: DateComponents, to resultDateComp: DateComponents, options: Options = []) -> DateComponents? {
+    open func components(_ unitFlags: Unit, from startingDateComp: DateComponents, to resultDateComp: DateComponents, options: Options = []) -> DateComponents? {
         var startDate: Date?
         var toDate: Date?
         if let startCalendar = startingDateComp.calendar {
@@ -1008,7 +1008,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     This API returns a new NSDate object representing the date calculated by adding an amount of a specific component to a given date.
     The NSCalendarWrapComponents option specifies if the component should be incremented and wrap around to zero/one on overflow, and should not cause higher units to be incremented.
     */
-    public func date(byAdding unit: Unit, value: Int, to date: Date, options: Options = []) -> Date? {
+    open func date(byAdding unit: Unit, value: Int, to date: Date, options: Options = []) -> Date? {
         var comps = DateComponents()
         comps.setValue(value, forComponent: unit)
         return self.date(byAdding: comps, to: date, options: options)
@@ -1043,7 +1043,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     The general semantics follow those of the -enumerateDatesStartingAfterDate:... method above.
     To compute a sequence of results, use the -enumerateDatesStartingAfterDate:... method above, rather than looping and calling this method with the previous loop iteration's result.
     */
-    public func nextDate(after date: Date, matchingComponents comps: DateComponents, options: Options = []) -> Date? {
+    open func nextDate(after date: Date, matchingComponents comps: DateComponents, options: Options = []) -> Date? {
         var result: Date?
         enumerateDates(startingAfter: date, matchingComponents: comps, options: options) { date, exactMatch, stop in
             result = date
@@ -1057,7 +1057,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     The general semantics follow those of the -enumerateDatesStartingAfterDate:... method above.
     To compute a sequence of results, use the -enumerateDatesStartingAfterDate:... method above, rather than looping and calling this method with the previous loop iteration's result.
     */
-    public func nextDate(after date: Date, matchingUnit unit: Unit, value: Int, options: Options = []) -> Date? {
+    open func nextDate(after date: Date, matchingUnit unit: Unit, value: Int, options: Options = []) -> Date? {
         var comps = DateComponents()
         comps.setValue(value, forComponent: unit)
         return nextDate(after:date, matchingComponents: comps, options: options)
@@ -1068,7 +1068,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     The general semantics follow those of the -enumerateDatesStartingAfterDate:... method above.
     To compute a sequence of results, use the -enumerateDatesStartingAfterDate:... method above, rather than looping and calling this method with the previous loop iteration's result.
     */
-    public func nextDate(after date: Date, matchingHour hourValue: Int, minute minuteValue: Int, second secondValue: Int, options: Options = []) -> Date? {
+    open func nextDate(after date: Date, matchingHour hourValue: Int, minute minuteValue: Int, second secondValue: Int, options: Options = []) -> Date? {
         var comps = DateComponents()
         comps.hour = hourValue
         comps.minute = minuteValue
@@ -1082,7 +1082,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     If no such time exists, the next available time is returned (which could, for example, be in a different day, week, month, ... than the nominal target date).  Setting a component to something which would be inconsistent forces other units to change; for example, setting the Weekday to Thursday probably shifts the Day and possibly Month and Year.
     The specific behaviors here are as yet unspecified; for example, if I change the weekday to Thursday, does that move forward to the next, backward to the previous, or to the nearest Thursday?  A likely rule is that the algorithm will try to produce a result which is in the next-larger unit to the one given (there's a table of this mapping at the top of this document).  So for the "set to Thursday" example, find the Thursday in the Week in which the given date resides (which could be a forwards or backwards move, and not necessarily the nearest Thursday).  For forwards or backwards behavior, one can use the -nextDateAfterDate:matchingUnit:value:options: method above.
     */
-    public func date(bySettingUnit unit: Unit, value v: Int, ofDate date: Date, options opts: Options = []) -> Date? {
+    open func date(bySettingUnit unit: Unit, value v: Int, ofDate date: Date, options opts: Options = []) -> Date? {
         let currentValue = component(unit, from: date)
         if currentValue == v {
             return date
@@ -1102,7 +1102,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     If no such time exists, the next available time is returned (which could, for example, be in a different day than the nominal target date).
     The intent is to return a date on the same day as the original date argument.  This may result in a date which is earlier than the given date, of course.
     */
-    public func date(bySettingHour h: Int, minute m: Int, second s: Int, ofDate date: Date, options opts: Options = []) -> Date? {
+    open func date(bySettingHour h: Int, minute m: Int, second s: Int, ofDate date: Date, options opts: Options = []) -> Date? {
         if let range = range(of: .day, forDate: date) {
             var comps = DateComponents()
             comps.hour = h
@@ -1128,7 +1128,7 @@ public class Calendar: NSObject, NSCopying, NSSecureCoding {
     This API returns YES if the date has all the matched components. Otherwise, it returns NO.
     It is useful to test the return value of the -nextDateAfterDate:matchingUnit:value:options:, to find out if the components were obeyed or if the method had to fudge the result value due to missing time.
     */
-    public func date(_ date: Date, matchesComponents components: DateComponents) -> Bool {
+    open func date(_ date: Date, matchesComponents components: DateComponents) -> Bool {
         let units: [Unit] = [.era, .year, .month, .day, .hour, .minute, .second, .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear, .yearForWeekOfYear, .nanosecond]
         var unitFlags: Unit = []
         for unit in units {
@@ -1197,7 +1197,7 @@ public let NSCalendarDayChangedNotification: String = "" // NSUnimplemented
 
 public var NSDateComponentUndefined: Int = LONG_MAX
 
-public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
+open class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
     internal var _calendar: Calendar?
     internal var _timeZone: TimeZone?
     internal var _values = [Int](repeating: NSDateComponentUndefined, count: 19)
@@ -1205,7 +1205,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         super.init()
     }
     
-    public override var hash: Int {
+    open override var hash: Int {
         var calHash = 0
         if let cal = calendar {
             calHash = cal.hash
@@ -1244,7 +1244,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         return calHash + (32832013 * (y + yy) + 2678437 * m + 86413 * d + 3607 * h + 61 * mm + s) + (41 * weekOfYear + 11 * weekOfMonth + 7 * weekday + 3 * weekdayOrdinal + quarter) * (1 << 5)
     }
     
-    public override func isEqual(_ object: AnyObject?) -> Bool {
+    open override func isEqual(_ object: AnyObject?) -> Bool {
         if let other = object as? NSDateComponents {
             if era != other.era {
                 return false
@@ -1328,7 +1328,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         if aCoder.allowsKeyedCoding {
             aCoder.encode(self.era, forKey: "NS.era")
             aCoder.encode(self.year, forKey: "NS.year")
@@ -1356,15 +1356,15 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         return true
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         NSUnimplemented()
     }
     
-    /*@NSCopying*/ public var calendar: Calendar? {
+    /*@NSCopying*/ open var calendar: Calendar? {
         get {
             return _calendar
         }
@@ -1376,7 +1376,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
             }
         }
     }
-    /*@NSCopying*/ public var timeZone: TimeZone? {
+    /*@NSCopying*/ open var timeZone: TimeZone? {
         get {
             return _timeZone
         }
@@ -1390,7 +1390,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
     }
     // these all should probably be optionals
     
-    public var era: Int {
+    open var era: Int {
         get {
             return _values[0]
         }
@@ -1399,7 +1399,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public var year: Int {
+    open var year: Int {
         get {
             return _values[1]
         }
@@ -1408,7 +1408,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public var month: Int {
+    open var month: Int {
         get {
             return _values[2]
         }
@@ -1417,7 +1417,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public var day: Int {
+    open var day: Int {
         get {
             return _values[3]
         }
@@ -1426,7 +1426,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public var hour: Int {
+    open var hour: Int {
         get {
             return _values[4]
         }
@@ -1435,7 +1435,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public var minute: Int {
+    open var minute: Int {
         get {
             return _values[5]
         }
@@ -1444,7 +1444,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public var second: Int {
+    open var second: Int {
         get {
             return _values[6]
         }
@@ -1453,7 +1453,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public var weekday: Int {
+    open var weekday: Int {
         get {
             return _values[8]
         }
@@ -1462,7 +1462,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public var weekdayOrdinal: Int {
+    open var weekdayOrdinal: Int {
         get {
             return _values[9]
         }
@@ -1471,7 +1471,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public var quarter: Int {
+    open var quarter: Int {
         get {
             return _values[10]
         }
@@ -1480,7 +1480,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public var nanosecond: Int {
+    open var nanosecond: Int {
         get {
             return _values[11]
         }
@@ -1489,7 +1489,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public var weekOfYear: Int {
+    open var weekOfYear: Int {
         get {
             return _values[12]
         }
@@ -1498,7 +1498,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public var weekOfMonth: Int {
+    open var weekOfMonth: Int {
         get {
             return _values[13]
         }
@@ -1507,7 +1507,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public var yearForWeekOfYear: Int {
+    open var yearForWeekOfYear: Int {
         get {
             return _values[14]
         }
@@ -1516,7 +1516,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public var isLeapMonth: Bool {
+    open var isLeapMonth: Bool {
         get {
             return _values[15] == 1
         }
@@ -1529,7 +1529,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         return _values[15] != NSDateComponentUndefined
     }
     
-    /*@NSCopying*/ public var date: Date? {
+    /*@NSCopying*/ open var date: Date? {
         if let tz = timeZone {
             calendar?.timeZone = tz
         }
@@ -1540,7 +1540,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
     This API allows one to set a specific component of NSDateComponents, by enum constant value rather than property name.
     The calendar and timeZone and isLeapMonth properties cannot be set by this method.
     */
-    public func setValue(_ value: Int, forComponent unit: Calendar.Unit) {
+    open func setValue(_ value: Int, forComponent unit: Calendar.Unit) {
         switch unit {
             case Calendar.Unit.era:
                 era = value
@@ -1599,7 +1599,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
     This API allows one to get the value of a specific component of NSDateComponents, by enum constant value rather than property name.
     The calendar and timeZone and isLeapMonth property values cannot be gotten by this method.
     */
-    public func value(forComponent unit: Calendar.Unit) -> Int {
+    open func value(forComponent unit: Calendar.Unit) -> Int {
         switch unit {
             case Calendar.Unit.era:
                 return era
@@ -1642,7 +1642,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
     If the time zone property is set in the NSDateComponents object, it is used.
     The calendar property must be set, or NO is returned.
     */
-    public var isValidDate: Bool {
+    open var isValidDate: Bool {
         if let cal = calendar {
             return isValidDate(in: cal)
         }
@@ -1655,7 +1655,7 @@ public class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
     Except for some trivial cases (e.g., 'seconds' should be 0 - 59 in any calendar), this method is not necessarily cheap.
     If the time zone property is set in the NSDateComponents object, it is used.
     */
-    public func isValidDate(in calendar: Calendar) -> Bool {
+    open func isValidDate(in calendar: Calendar) -> Bool {
         let cal = calendar.copy() as! Calendar
         if let tz = timeZone {
             cal.timeZone = tz

--- a/Foundation/NSCharacterSet.swift
+++ b/Foundation/NSCharacterSet.swift
@@ -29,7 +29,7 @@ let kCFCharacterSetIllegal = CFCharacterSetPredefinedSet.illegal
 #endif
 
 
-public class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
+open class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
     typealias CFType = CFCharacterSet
     private var _base = _CFInfo(typeID: CFCharacterSetGetTypeID())
     private var _hashValue = CFHashCode(0)
@@ -45,11 +45,11 @@ public class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
         return unsafeBitCast(self, to: CFMutableCharacterSet.self)
     }
     
-    public override var hash: Int {
+    open override var hash: Int {
         return Int(bitPattern: CFHash(_cfObject))
     }
     
-    public override func isEqual(_ object: AnyObject?) -> Bool {
+    open override func isEqual(_ object: AnyObject?) -> Bool {
         if let cs = object as? NSCharacterSet {
             return CFEqual(_cfObject, cs._cfObject)
         } else {
@@ -57,7 +57,7 @@ public class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
         }
     }
     
-    public override var description: String {
+    open override var description: String {
         return CFCopyDescription(_cfObject)._swiftObject
     }
     
@@ -70,19 +70,19 @@ public class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
         _CFDeinit(self)
     }
     
-    public class func controlCharacters() -> CharacterSet {
+    open class func controlCharacters() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetControl)._swiftObject
     }
     
-    public class func whitespaces() -> CharacterSet {
+    open class func whitespaces() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetWhitespace)._swiftObject
     }
 
-    public class func whitespacesAndNewlines() -> CharacterSet {
+    open class func whitespacesAndNewlines() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetWhitespaceAndNewline)._swiftObject
     }
     
-    public class func decimalDigits() -> CharacterSet {
+    open class func decimalDigits() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetDecimalDigit)._swiftObject
     }
     
@@ -90,43 +90,43 @@ public class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
         return CFCharacterSetGetPredefined(kCFCharacterSetLetter)._swiftObject
     }
     
-    public class func lowercaseLetters() -> CharacterSet {
+    open class func lowercaseLetters() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetLowercaseLetter)._swiftObject
     }
     
-    public class func uppercaseLetters() -> CharacterSet {
+    open class func uppercaseLetters() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetUppercaseLetter)._swiftObject
     }
     
-    public class func nonBaseCharacters() -> CharacterSet {
+    open class func nonBaseCharacters() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetNonBase)._swiftObject
     }
     
-    public class func alphanumerics() -> CharacterSet {
+    open class func alphanumerics() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetAlphaNumeric)._swiftObject
     }
     
-    public class func decomposables() -> CharacterSet {
+    open class func decomposables() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetDecomposable)._swiftObject
     }
     
-    public class func illegalCharacters() -> CharacterSet {
+    open class func illegalCharacters() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetIllegal)._swiftObject
     }
     
-    public class func punctuation() -> CharacterSet {
+    open class func punctuation() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetPunctuation)._swiftObject
     }
     
-    public class func capitalizedLetters() -> CharacterSet {
+    open class func capitalizedLetters() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetCapitalizedLetter)._swiftObject
     }
     
-    public class func symbols() -> CharacterSet {
+    open class func symbols() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetSymbol)._swiftObject
     }
     
-    public class func newlines() -> CharacterSet {
+    open class func newlines() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetNewline)._swiftObject
     }
 
@@ -158,21 +158,21 @@ public class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
         self.init(charactersIn: "")
     }
     
-    public func characterIsMember(_ aCharacter: unichar) -> Bool {
+    open func characterIsMember(_ aCharacter: unichar) -> Bool {
         return longCharacterIsMember(UInt32(aCharacter))
     }
     
-    public var bitmapRepresentation: Data {
+    open var bitmapRepresentation: Data {
         return CFCharacterSetCreateBitmapRepresentation(kCFAllocatorSystemDefault, _cfObject)._swiftObject
     }
     
-    public var inverted: CharacterSet {
+    open var inverted: CharacterSet {
         let copy = mutableCopy() as! NSMutableCharacterSet
         copy.invert()
         return copy._swiftObject
     }
     
-    public func longCharacterIsMember(_ theLongChar: UInt32) -> Bool {
+    open func longCharacterIsMember(_ theLongChar: UInt32) -> Bool {
         if type(of: self) == NSCharacterSet.self || type(of: self) == NSMutableCharacterSet.self {
             return _CFCharacterSetIsLongCharacterMember(unsafeBitCast(self, to: CFType.self), theLongChar)
         } else if type(of: self) == _NSCFCharacterSet.self {
@@ -182,19 +182,19 @@ public class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
         }
     }
     
-    public func isSuperset(of theOtherSet: CharacterSet) -> Bool {
+    open func isSuperset(of theOtherSet: CharacterSet) -> Bool {
         return CFCharacterSetIsSupersetOfSet(_cfObject, theOtherSet._cfObject)
     }
     
-    public func hasMember(inPlane plane: UInt8) -> Bool {
+    open func hasMember(inPlane plane: UInt8) -> Bool {
         return CFCharacterSetHasMemberInPlane(_cfObject, CFIndex(plane))
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         if type(of: self) == NSCharacterSet.self || type(of: self) == NSMutableCharacterSet.self {
             return _CFCharacterSetCreateCopy(kCFAllocatorSystemDefault, self._cfObject)
         } else if type(of: self) == _NSCFCharacterSet.self {
@@ -204,11 +204,11 @@ public class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
         }
     }
     
-    public override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> AnyObject {
         return mutableCopy(with: nil)
     }
     
-    public func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
         if type(of: self) == NSCharacterSet.self || type(of: self) == NSMutableCharacterSet.self {
             return _CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, _cfObject)._nsObject
         } else if type(of: self) == _NSCFCharacterSet.self {
@@ -218,58 +218,58 @@ public class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
         }
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         
     }
 }
 
-public class NSMutableCharacterSet : NSCharacterSet {
+open class NSMutableCharacterSet : NSCharacterSet {
 
     public convenience required init(coder aDecoder: NSCoder) {
         NSUnimplemented()
     }
     
-    public func addCharacters(in aRange: NSRange) {
+    open func addCharacters(in aRange: NSRange) {
         CFCharacterSetAddCharactersInRange(_cfMutableObject , CFRangeMake(aRange.location, aRange.length))
     }
     
-    public func removeCharacters(in aRange: NSRange) {
+    open func removeCharacters(in aRange: NSRange) {
         CFCharacterSetRemoveCharactersInRange(_cfMutableObject , CFRangeMake(aRange.location, aRange.length))
     }
     
-    public func addCharacters(in aString: String) {
+    open func addCharacters(in aString: String) {
         CFCharacterSetAddCharactersInString(_cfMutableObject, aString._cfObject)
     }
     
-    public func removeCharacters(in aString: String) {
+    open func removeCharacters(in aString: String) {
         CFCharacterSetRemoveCharactersInString(_cfMutableObject, aString._cfObject)
     }
     
-    public func formUnion(with otherSet: CharacterSet) {
+    open func formUnion(with otherSet: CharacterSet) {
         CFCharacterSetUnion(_cfMutableObject, otherSet._cfObject)
     }
     
-    public func formIntersection(with otherSet: CharacterSet) {
+    open func formIntersection(with otherSet: CharacterSet) {
         CFCharacterSetIntersect(_cfMutableObject, otherSet._cfObject)
     }
     
-    public func invert() {
+    open func invert() {
         CFCharacterSetInvert(_cfMutableObject)
     }
 
-    public class func controlCharacters() -> NSMutableCharacterSet {
+    open class func controlCharacters() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetControl)), to: NSMutableCharacterSet.self)
     }
     
-    public class func whitespaces() -> NSMutableCharacterSet {
+    open class func whitespaces() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetWhitespace)), to: NSMutableCharacterSet.self)
     }
     
-    public class func whitespacesAndNewlines() -> NSMutableCharacterSet {
+    open class func whitespacesAndNewlines() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetWhitespaceAndNewline)), to: NSMutableCharacterSet.self)
     }
     
-    public class func decimalDigits() -> NSMutableCharacterSet {
+    open class func decimalDigits() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetDecimalDigit)), to: NSMutableCharacterSet.self)
     }
     
@@ -277,43 +277,43 @@ public class NSMutableCharacterSet : NSCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetLetter)), to: NSMutableCharacterSet.self)
     }
     
-    public class func lowercaseLetters() -> NSMutableCharacterSet {
+    open class func lowercaseLetters() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetLowercaseLetter)), to: NSMutableCharacterSet.self)
     }
     
-    public class func uppercaseLetters() -> NSMutableCharacterSet {
+    open class func uppercaseLetters() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetUppercaseLetter)), to: NSMutableCharacterSet.self)
     }
     
-    public class func nonBaseCharacters() -> NSMutableCharacterSet {
+    open class func nonBaseCharacters() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetNonBase)), to: NSMutableCharacterSet.self)
     }
     
-    public class func alphanumerics() -> NSMutableCharacterSet {
+    open class func alphanumerics() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetAlphaNumeric)), to: NSMutableCharacterSet.self)
     }
     
-    public class func decomposables() -> NSMutableCharacterSet {
+    open class func decomposables() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetDecomposable)), to: NSMutableCharacterSet.self)
     }
     
-    public class func illegalCharacters() -> NSMutableCharacterSet {
+    open class func illegalCharacters() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetIllegal)), to: NSMutableCharacterSet.self)
     }
     
-    public class func punctuation() -> NSMutableCharacterSet {
+    open class func punctuation() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetPunctuation)), to: NSMutableCharacterSet.self)
     }
     
-    public class func capitalizedLetters() -> NSMutableCharacterSet {
+    open class func capitalizedLetters() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetCapitalizedLetter)), to: NSMutableCharacterSet.self)
     }
     
-    public class func symbols() -> NSMutableCharacterSet {
+    open class func symbols() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetSymbol)), to: NSMutableCharacterSet.self)
     }
     
-    public class func newlines() -> NSMutableCharacterSet {
+    open class func newlines() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetNewline)), to: NSMutableCharacterSet.self)
     }
 }

--- a/Foundation/NSCoder.swift
+++ b/Foundation/NSCoder.swift
@@ -16,7 +16,7 @@ public protocol NSSecureCoding : NSCoding {
     static func supportsSecureCoding() -> Bool
 }
 
-public class NSCoder : NSObject {
+open class NSCoder : NSObject {
     internal var _pendingBuffers = Array<(UnsafeMutableRawPointer, Int)>()
     
     deinit {
@@ -26,27 +26,27 @@ public class NSCoder : NSObject {
         }
     }
     
-    public func encodeValue(ofObjCType type: UnsafePointer<Int8>, at addr: UnsafeRawPointer) {
+    open func encodeValue(ofObjCType type: UnsafePointer<Int8>, at addr: UnsafeRawPointer) {
         NSRequiresConcreteImplementation()
     }
     
-    public func encodeDataObject(_ data: Data) {
+    open func encodeDataObject(_ data: Data) {
         NSRequiresConcreteImplementation()
     }
     
-    public func decodeValue(ofObjCType type: UnsafePointer<Int8>, at data: UnsafeMutableRawPointer) {
+    open func decodeValue(ofObjCType type: UnsafePointer<Int8>, at data: UnsafeMutableRawPointer) {
         NSRequiresConcreteImplementation()
     }
     
-    public func decodeDataObject() -> Data? {
+    open func decodeDataObject() -> Data? {
         NSRequiresConcreteImplementation()
     }
     
-    public func version(forClassName className: String) -> Int {
+    open func version(forClassName className: String) -> Int {
         NSRequiresConcreteImplementation()
     }
 
-    public func decodeObjectOfClass<DecodedObjectType : NSCoding where DecodedObjectType : NSObject>(_ cls: DecodedObjectType.Type, forKey key: String) -> DecodedObjectType? {
+    open func decodeObjectOfClass<DecodedObjectType : NSCoding where DecodedObjectType : NSObject>(_ cls: DecodedObjectType.Type, forKey key: String) -> DecodedObjectType? {
         NSUnimplemented()
     }
    
@@ -61,19 +61,19 @@ public class NSCoder : NSObject {
         be casted to NSObject, nor is it Hashable.
      */
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation
-    public func decodeObjectOfClasses(_ classes: [AnyClass], forKey key: String) -> AnyObject? {
+    open func decodeObjectOfClasses(_ classes: [AnyClass], forKey key: String) -> AnyObject? {
         NSUnimplemented()
     }
     
-    public func decodeTopLevelObject() throws -> AnyObject? {
+    open func decodeTopLevelObject() throws -> AnyObject? {
         NSUnimplemented()
     }
     
-    public func decodeTopLevelObjectForKey(_ key: String) throws -> AnyObject? {
+    open func decodeTopLevelObjectForKey(_ key: String) throws -> AnyObject? {
         NSUnimplemented()
     }
     
-    public func decodeTopLevelObjectOfClass<DecodedObjectType : NSCoding where DecodedObjectType : NSObject>(_ cls: DecodedObjectType.Type, forKey key: String) throws -> DecodedObjectType? {
+    open func decodeTopLevelObjectOfClass<DecodedObjectType : NSCoding where DecodedObjectType : NSObject>(_ cls: DecodedObjectType.Type, forKey key: String) throws -> DecodedObjectType? {
         NSUnimplemented()
     }
     
@@ -88,7 +88,7 @@ public class NSCoder : NSObject {
      be casted to NSObject, nor is it Hashable.
      */
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation
-    public func decodeTopLevelObjectOfClasses(_ classes: [AnyClass], forKey key: String) throws -> AnyObject? {
+    open func decodeTopLevelObjectOfClasses(_ classes: [AnyClass], forKey key: String) throws -> AnyObject? {
         NSUnimplemented()
     }
     
@@ -97,34 +97,34 @@ public class NSCoder : NSObject {
     }
     
     
-    public func encode(_ object: AnyObject?) {
+    open func encode(_ object: AnyObject?) {
         var object = object
         withUnsafePointer(to: &object) { (ptr: UnsafePointer<AnyObject?>) -> Void in
             encodeValue(ofObjCType: "@", at: unsafeBitCast(ptr, to: UnsafeRawPointer.self))
         }
     }
     
-    public func encodeRootObject(_ rootObject: AnyObject) {
+    open func encodeRootObject(_ rootObject: AnyObject) {
         encode(rootObject)
     }
     
-    public func encodeBycopyObject(_ anObject: AnyObject?) {
+    open func encodeBycopyObject(_ anObject: AnyObject?) {
         encode(anObject)
     }
     
-    public func encodeByrefObject(_ anObject: AnyObject?) {
+    open func encodeByrefObject(_ anObject: AnyObject?) {
         encode(anObject)
     }
     
-    public func encodeConditionalObject(_ object: AnyObject?) {
+    open func encodeConditionalObject(_ object: AnyObject?) {
         encode(object)
     }
     
-    public func encodeArray(ofObjCType type: UnsafePointer<Int8>, count: Int, at array: UnsafeRawPointer) {
+    open func encodeArray(ofObjCType type: UnsafePointer<Int8>, count: Int, at array: UnsafeRawPointer) {
         encodeValue(ofObjCType: "[\(count)\(String(cString: type))]", at: array)
     }
     
-    public func encodeBytes(_ byteaddr: UnsafeRawPointer?, length: Int) {
+    open func encodeBytes(_ byteaddr: UnsafeRawPointer?, length: Int) {
         var newLength = UInt32(length)
         withUnsafePointer(to: &newLength) { (ptr: UnsafePointer<UInt32>) -> Void in
             encodeValue(ofObjCType: "I", at: ptr)
@@ -135,7 +135,7 @@ public class NSCoder : NSObject {
         }
     }
     
-    public func decodeObject() -> AnyObject? {
+    open func decodeObject() -> AnyObject? {
         if self.error != nil {
             return nil
         }
@@ -147,13 +147,13 @@ public class NSCoder : NSObject {
         return obj
     }
     
-    public func decodeArray(ofObjCType itemType: UnsafePointer<Int8>, count: Int, at array: UnsafeMutableRawPointer) {
+    open func decodeArray(ofObjCType itemType: UnsafePointer<Int8>, count: Int, at array: UnsafeMutableRawPointer) {
         decodeValue(ofObjCType: "[\(count)\(String(cString: itemType))]", at: array)
     }
    
     /*
     // TODO: This is disabled, as functions which return unsafe interior pointers are inherently unsafe when we have no autorelease pool. 
-    public func decodeBytes(withReturnedLength lengthp: UnsafeMutablePointer<Int>) -> UnsafeMutableRawPointer? {
+    open func decodeBytes(withReturnedLength lengthp: UnsafeMutablePointer<Int>) -> UnsafeMutableRawPointer? {
         var length: UInt32 = 0
         withUnsafeMutablePointer(to: &length) { (ptr: UnsafeMutablePointer<UInt32>) -> Void in
             decodeValue(ofObjCType: "I", at: unsafeBitCast(ptr, to: UnsafeMutableRawPointer.self))
@@ -167,106 +167,106 @@ public class NSCoder : NSObject {
     }
     */
     
-    public func encodePropertyList(_ aPropertyList: AnyObject) {
+    open func encodePropertyList(_ aPropertyList: AnyObject) {
         NSUnimplemented()
     }
     
-    public func decodePropertyList() -> AnyObject? {
+    open func decodePropertyList() -> AnyObject? {
         NSUnimplemented()
     }
     
-    public var systemVersion: UInt32 {
+    open var systemVersion: UInt32 {
         return 1000
     }
     
-    public var allowsKeyedCoding: Bool {
+    open var allowsKeyedCoding: Bool {
         return false
     }
     
-    public func encode(_ objv: AnyObject?, forKey key: String) {
+    open func encode(_ objv: AnyObject?, forKey key: String) {
         NSRequiresConcreteImplementation()
     }
     
-    public func encodeConditionalObject(_ objv: AnyObject?, forKey key: String) {
+    open func encodeConditionalObject(_ objv: AnyObject?, forKey key: String) {
         NSRequiresConcreteImplementation()
     }
     
-    public func encode(_ boolv: Bool, forKey key: String) {
+    open func encode(_ boolv: Bool, forKey key: String) {
         NSRequiresConcreteImplementation()
     }
     
-    public func encode(_ intv: Int32, forKey key: String) {
+    open func encode(_ intv: Int32, forKey key: String) {
         NSRequiresConcreteImplementation()
     }
     
-    public func encode(_ intv: Int64, forKey key: String) {
+    open func encode(_ intv: Int64, forKey key: String) {
         NSRequiresConcreteImplementation()
     }
     
-    public func encode(_ realv: Float, forKey key: String) {
+    open func encode(_ realv: Float, forKey key: String) {
         NSRequiresConcreteImplementation()
     }
     
-    public func encode(_ realv: Double, forKey key: String) {
+    open func encode(_ realv: Double, forKey key: String) {
         NSRequiresConcreteImplementation()
     }
     
-    public func encodeBytes(_ bytesp: UnsafePointer<UInt8>?, length lenv: Int, forKey key: String) {
+    open func encodeBytes(_ bytesp: UnsafePointer<UInt8>?, length lenv: Int, forKey key: String) {
         NSRequiresConcreteImplementation()
     }
     
-    public func containsValue(forKey key: String) -> Bool {
+    open func containsValue(forKey key: String) -> Bool {
         NSRequiresConcreteImplementation()
     }
     
-    public func decodeObject(forKey key: String) -> AnyObject? {
+    open func decodeObject(forKey key: String) -> AnyObject? {
         NSRequiresConcreteImplementation()
     }
     
-    public func decodeBool(forKey key: String) -> Bool {
+    open func decodeBool(forKey key: String) -> Bool {
         NSRequiresConcreteImplementation()
     }
     
-    public func decodeInt32(forKey key: String) -> Int32 {
+    open func decodeInt32(forKey key: String) -> Int32 {
         NSRequiresConcreteImplementation()
     }
     
-    public func decodeInt64(forKey key: String) -> Int64 {
+    open func decodeInt64(forKey key: String) -> Int64 {
         NSRequiresConcreteImplementation()
     }
     
-    public func decodeFloat(forKey key: String) -> Float {
+    open func decodeFloat(forKey key: String) -> Float {
         NSRequiresConcreteImplementation()
     }
     
-    public func decodeDouble(forKey key: String) -> Double {
+    open func decodeDouble(forKey key: String) -> Double {
         NSRequiresConcreteImplementation()
     }
     
     // TODO: This is disabled, as functions which return unsafe interior pointers are inherently unsafe when we have no autorelease pool. 
     /*
-    public func decodeBytes(forKey key: String, returnedLength lengthp: UnsafeMutablePointer<Int>?) -> UnsafePointer<UInt8>? { // returned bytes immutable!
+    open func decodeBytes(forKey key: String, returnedLength lengthp: UnsafeMutablePointer<Int>?) -> UnsafePointer<UInt8>? { // returned bytes immutable!
         NSRequiresConcreteImplementation()
     }
     */
     /// - experimental: This method does not exist in the Darwin Foundation.
-    public func withDecodedUnsafeBufferPointer<ResultType>(forKey key: String, body: @noescape (UnsafeBufferPointer<UInt8>?) throws -> ResultType) rethrows -> ResultType {
+    open func withDecodedUnsafeBufferPointer<ResultType>(forKey key: String, body: @noescape (UnsafeBufferPointer<UInt8>?) throws -> ResultType) rethrows -> ResultType {
         NSRequiresConcreteImplementation()
     }
 
-    public func encode(_ intv: Int, forKey key: String) {
+    open func encode(_ intv: Int, forKey key: String) {
         NSRequiresConcreteImplementation()
     }
     
-    public func decodeInteger(forKey key: String) -> Int {
+    open func decodeInteger(forKey key: String) -> Int {
         NSRequiresConcreteImplementation()
     }
     
-    public var requiresSecureCoding: Bool {
+    open var requiresSecureCoding: Bool {
         return false
     }
     
-    public func decodePropertyListForKey(_ key: String) -> AnyObject? {
+    open func decodePropertyListForKey(_ key: String) -> AnyObject? {
         NSUnimplemented()
     }
     
@@ -278,11 +278,11 @@ public class NSCoder : NSObject {
      hashable.
      */
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation
-    public var allowedClasses: [AnyClass]? {
+    open var allowedClasses: [AnyClass]? {
         NSUnimplemented()
     }
     
-    public func failWithError(_ error: NSError) {
+    open func failWithError(_ error: NSError) {
         if let debugDescription = error.userInfo["NSDebugDescription"] {
             NSLog("*** NSKeyedUnarchiver.init: \(debugDescription)")
         } else {

--- a/Foundation/NSComparisonPredicate.swift
+++ b/Foundation/NSComparisonPredicate.swift
@@ -47,15 +47,15 @@ extension ComparisonPredicate {
 }
 // Comparison predicates are predicates which do some form of comparison between the results of two expressions and return a BOOL. They take an operator, a left expression, and a right expression, and return the result of invoking the operator with the results of evaluating the expressions.
 
-public class ComparisonPredicate : Predicate {
+open class ComparisonPredicate : Predicate {
     
     public init(leftExpression lhs: NSExpression, rightExpression rhs: NSExpression, modifier: Modifier, type: Operator, options: Options) { NSUnimplemented() }
     public required init?(coder: NSCoder) { NSUnimplemented() }
     
-    public var predicateOperatorType: Operator { NSUnimplemented() }
-    public var comparisonPredicateModifier: Modifier { NSUnimplemented() }
-    public var leftExpression: NSExpression { NSUnimplemented() }
-    public var rightExpression: NSExpression { NSUnimplemented() }
-    public var options: Options { NSUnimplemented() }
+    open var predicateOperatorType: Operator { NSUnimplemented() }
+    open var comparisonPredicateModifier: Modifier { NSUnimplemented() }
+    open var leftExpression: NSExpression { NSUnimplemented() }
+    open var rightExpression: NSExpression { NSUnimplemented() }
+    open var options: Options { NSUnimplemented() }
 }
 

--- a/Foundation/NSCompoundPredicate.swift
+++ b/Foundation/NSCompoundPredicate.swift
@@ -19,7 +19,7 @@ extension CompoundPredicate {
     }
 }
 
-public class CompoundPredicate : Predicate {
+open class CompoundPredicate : Predicate {
     
     public init(type: LogicalType, subpredicates: [Predicate]) {
         if type == .not && subpredicates.count == 0 {
@@ -45,7 +45,7 @@ public class CompoundPredicate : Predicate {
         self.init(type: .not, subpredicates: [predicate])
     }
 
-    override public func evaluate(with object: AnyObject?, substitutionVariables bindings: [String : AnyObject]?) -> Bool {
+    override open func evaluate(with object: AnyObject?, substitutionVariables bindings: [String : AnyObject]?) -> Bool {
         switch compoundPredicateType {
         case .and:
             return subpredicates.reduce(true, {

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -72,7 +72,7 @@ private let __kCFUseAllocator: CFOptionFlags = 0x08
 private let __kCFDontDeallocate: CFOptionFlags = 0x10
 private let __kCFAllocatesCollectable: CFOptionFlags = 0x20
 
-public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
+open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     typealias CFType = CFData
     private var _base = _CFInfo(typeID: CFDataGetTypeID())
     private var _length: CFIndex = 0
@@ -95,11 +95,11 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         self.init(bytes: dummyPointer, length: 0, copy: false, deallocator: nil)
     }
     
-    public override var hash: Int {
+    open override var hash: Int {
         return Int(bitPattern: CFHash(_cfObject))
     }
     
-    public override func isEqual(_ object: AnyObject?) -> Bool {
+    open override func isEqual(_ object: AnyObject?) -> Bool {
         if let data = object as? NSData {
             return self.isEqual(to: data._swiftObject)
         } else {
@@ -134,31 +134,31 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         }
     }
     
-    public var length: Int {
+    open var length: Int {
         return CFDataGetLength(_cfObject)
     }
 
-    public var bytes: UnsafeRawPointer {
+    open var bytes: UnsafeRawPointer {
         return UnsafeRawPointer(CFDataGetBytePtr(_cfObject))
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         return self
     }
     
-    public override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> AnyObject {
         return mutableCopy(with: nil)
     }
     
-    public func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
         return NSMutableData(bytes: UnsafeMutableRawPointer(mutating: bytes), length: length, copy: true, deallocator: nil)
     }
 
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         if let aKeyedCoder = aCoder as? NSKeyedArchiver {
             aKeyedCoder._encodePropertyList(self, forKey: "NS.data")
         } else {
@@ -218,15 +218,15 @@ public class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         return s
     }
     
-    override public var debugDescription: String {
+    override open var debugDescription: String {
         return "<\(byteDescription(limit: 1024))>"
     }
     
-    override public var description: String {
+    override open var description: String {
         return "<\(byteDescription())>"
     }
     
-    override public var _cfTypeID: CFTypeID {
+    override open var _cfTypeID: CFTypeID {
         return CFDataGetTypeID()
     }
 }
@@ -611,7 +611,7 @@ extension NSMutableData {
     internal var _cfMutableObject: CFMutableData { return unsafeBitCast(self, to: CFMutableData.self) }
 }
 
-public class NSMutableData : NSData {
+open class NSMutableData : NSData {
 
     public required convenience init() {
         self.init(bytes: nil, length: 0)
@@ -621,11 +621,11 @@ public class NSMutableData : NSData {
         super.init(bytes: bytes, length: length, copy: copy, deallocator: deallocator)
     }
     
-    public var mutableBytes: UnsafeMutableRawPointer {
+    open var mutableBytes: UnsafeMutableRawPointer {
         return UnsafeMutableRawPointer(CFDataGetMutableBytePtr(_cfMutableObject))
     }
     
-    public override var length: Int {
+    open override var length: Int {
         get {
             return CFDataGetLength(_cfObject)
         }
@@ -634,7 +634,7 @@ public class NSMutableData : NSData {
         }
     }
     
-    public override func copy(with zone: NSZone? = nil) -> AnyObject {
+    open override func copy(with zone: NSZone? = nil) -> AnyObject {
         return NSData(bytes: bytes, length: length)
     }
 }

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -21,14 +21,14 @@ public var NSTimeIntervalSince1970: Double {
     return 978307200.0
 }
 
-public class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
+open class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
     typealias CFType = CFDate
     
-    public override var hash: Int {
+    open override var hash: Int {
         return Int(bitPattern: CFHash(_cfObject))
     }
     
-    public override func isEqual(_ object: AnyObject?) -> Bool {
+    open override func isEqual(_ object: AnyObject?) -> Bool {
         if let date = object as? Date {
             return isEqual(to: date)
         } else {
@@ -47,7 +47,7 @@ public class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
     internal let _base = _CFInfo(typeID: CFDateGetTypeID())
     internal let _timeIntervalSinceReferenceDate: TimeInterval
     
-    public var timeIntervalSinceReferenceDate: TimeInterval {
+    open var timeIntervalSinceReferenceDate: TimeInterval {
         return _timeIntervalSinceReferenceDate
     }
 
@@ -78,11 +78,11 @@ public class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
 
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         return self
     }
     
@@ -90,7 +90,7 @@ public class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
         return true
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
 	if aCoder.allowsKeyedCoding {
 	    aCoder.encode(_timeIntervalSinceReferenceDate, forKey: "NS.time")
 	} else {
@@ -111,7 +111,7 @@ public class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
      `dateWithCalendarFormat:timeZone:`, and
      `descriptionWithCalendarFormat:timeZone:locale:`.
      */
-    public override var description: String {
+    open override var description: String {
         let dateFormatterRef = CFDateFormatterCreate(kCFAllocatorSystemDefault, nil, kCFDateFormatterFullStyle, kCFDateFormatterFullStyle)
         let timeZone = CFTimeZoneCreateWithTimeIntervalFromGMT(kCFAllocatorSystemDefault, 0.0)
         CFDateFormatterSetProperty(dateFormatterRef, kCFDateFormatterTimeZoneKey, timeZone)
@@ -134,7 +134,7 @@ public class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
        offset in hours and minutes from UTC (for example,
        "2001-03-24 10:45:32 +0600")
      */
-    public func descriptionWithLocale(_ locale: AnyObject?) -> String {
+    open func descriptionWithLocale(_ locale: AnyObject?) -> String {
         guard let aLocale = locale else { return description }
         let dateFormatterRef = CFDateFormatterCreate(kCFAllocatorSystemDefault, (aLocale as! Locale)._cfObject, kCFDateFormatterFullStyle, kCFDateFormatterFullStyle)
         CFDateFormatterSetProperty(dateFormatterRef, kCFDateFormatterTimeZoneKey, CFTimeZoneCopySystem())
@@ -142,7 +142,7 @@ public class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
         return CFDateFormatterCreateStringWithDate(kCFAllocatorSystemDefault, dateFormatterRef, _cfObject)._swiftObject
     }
     
-    override public var _cfTypeID: CFTypeID {
+    override open var _cfTypeID: CFTypeID {
         return CFDateGetTypeID()
     }
 }
@@ -246,16 +246,16 @@ extension Date : _NSBridgable, _CFBridgable {
 }
 
 
-public class NSDateInterval : NSObject, NSCopying, NSSecureCoding {
+open class NSDateInterval : NSObject, NSCopying, NSSecureCoding {
     
     
     /*
      NSDateInterval represents a closed date interval in the form of [startDate, endDate].  It is possible for the start and end dates to be the same with a duration of 0.  NSDateInterval does not support reverse intervals i.e. intervals where the duration is less than 0 and the end date occurs earlier in time than the start date.
      */
     
-    public private(set) var startDate: Date
+    open private(set) var startDate: Date
     
-    public var endDate: Date {
+    open var endDate: Date {
         get {
             if duration == 0 {
                 return startDate
@@ -265,7 +265,7 @@ public class NSDateInterval : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public private(set) var duration: TimeInterval
+    open private(set) var duration: TimeInterval
     
     
     // This method initializes an NSDateInterval object with start and end dates set to the current date and the duration set to 0.
@@ -300,11 +300,11 @@ public class NSDateInterval : NSObject, NSCopying, NSSecureCoding {
         self.init(start: startDate, duration: endDate.timeIntervalSince(startDate))
     }
     
-    public func copy(with zone: NSZone?) -> AnyObject {
+    open func copy(with zone: NSZone?) -> AnyObject {
         return NSDateInterval(start: startDate, duration: duration)
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         precondition(aCoder.allowsKeyedCoding)
         aCoder.encode(startDate._nsObject, forKey: "NS.startDate")
         aCoder.encode(endDate._nsObject, forKey: "NS.endDate")
@@ -331,7 +331,7 @@ public class NSDateInterval : NSObject, NSCopying, NSSecureCoding {
      
      If both the start dates and the durations are equal, then the intervals are considered equal and NSOrderedSame is returned as the result.
      */
-    public func compare(_ dateInterval: DateInterval) -> ComparisonResult {
+    open func compare(_ dateInterval: DateInterval) -> ComparisonResult {
         let result = startDate.compare(dateInterval.start)
         if result == .orderedSame {
             if self.duration < dateInterval.duration { return .orderedAscending }
@@ -342,11 +342,11 @@ public class NSDateInterval : NSObject, NSCopying, NSSecureCoding {
     }
     
     
-    public func isEqual(to dateInterval: DateInterval) -> Bool {
+    open func isEqual(to dateInterval: DateInterval) -> Bool {
         return startDate == dateInterval.start && duration == dateInterval.duration
     }
     
-    public func intersects(_ dateInterval: DateInterval) -> Bool {
+    open func intersects(_ dateInterval: DateInterval) -> Bool {
         return contains(dateInterval.start) || contains(dateInterval.end) || dateInterval.contains(startDate) || dateInterval.contains(endDate)
     }
     
@@ -354,7 +354,7 @@ public class NSDateInterval : NSObject, NSCopying, NSSecureCoding {
     /*
      This method returns an NSDateInterval object that represents the interval where the given date interval and the current instance intersect. In the event that there is no intersection, the method returns nil.
      */
-    public func intersection(with dateInterval: DateInterval) -> DateInterval? {
+    open func intersection(with dateInterval: DateInterval) -> DateInterval? {
         if !intersects(dateInterval) {
             return nil
         }
@@ -388,7 +388,7 @@ public class NSDateInterval : NSObject, NSCopying, NSSecureCoding {
     }
     
     
-    public func contains(_ date: Date) -> Bool {
+    open func contains(_ date: Date) -> Bool {
         let timeIntervalForGivenDate = date.timeIntervalSinceReferenceDate
         let timeIntervalForSelfStart = startDate.timeIntervalSinceReferenceDate
         let timeIntervalforSelfEnd = endDate.timeIntervalSinceReferenceDate

--- a/Foundation/NSDateComponentsFormatter.swift
+++ b/Foundation/NSDateComponentsFormatter.swift
@@ -37,7 +37,7 @@ extension DateComponentsFormatter {
 /* NSDateComponentsFormatter provides locale-correct and flexible string formatting of quantities of time, such as "1 day" or "1h 10m", as specified by NSDateComponents. For formatting intervals of time (such as "2PM to 5PM"), see NSDateIntervalFormatter. NSDateComponentsFormatter is thread-safe, in that calling methods on it from multiple threads will not cause crashes or incorrect results, but it makes no attempt to prevent confusion when one thread sets something and another thread isn't expecting it to change.
  */
 
-public class DateComponentsFormatter : Formatter {
+open class DateComponentsFormatter : Formatter {
     
     public override init() {
         NSUnimplemented()
@@ -49,9 +49,9 @@ public class DateComponentsFormatter : Formatter {
     
     /* 'obj' must be an instance of NSDateComponents.
      */
-    public override func string(for obj: AnyObject) -> String? { NSUnimplemented() }
+    open override func string(for obj: AnyObject) -> String? { NSUnimplemented() }
     
-    public func string(from components: DateComponents) -> String? { NSUnimplemented() }
+    open func string(from components: DateComponents) -> String? { NSUnimplemented() }
     
     /* Normally, NSDateComponentsFormatter will calculate as though counting from the current date and time (e.g. in February, 1 month formatted as a number of days will be 28). -stringFromDate:toDate: calculates from the passed-in startDate instead.
      
@@ -59,17 +59,17 @@ public class DateComponentsFormatter : Formatter {
      
        Note that this is still formatting the quantity of time between the dates, not the pair of dates itself. For strings like "Feb 22nd - Feb 28th", use NSDateIntervalFormatter.
      */
-    public func string(from startDate: Date, to endDate: Date) -> String? { NSUnimplemented() }
+    open func string(from startDate: Date, to endDate: Date) -> String? { NSUnimplemented() }
     
     /* Convenience method for formatting a number of seconds. See 'allowedUnits' for how the default set of allowed units differs from -stringFromDateComponents:.
      */
-    public func string(from ti: TimeInterval) -> String? { NSUnimplemented() }
+    open func string(from ti: TimeInterval) -> String? { NSUnimplemented() }
     
-    public class func localizedString(from components: DateComponents, unitsStyle: UnitsStyle) -> String? { NSUnimplemented() }
+    open class func localizedString(from components: DateComponents, unitsStyle: UnitsStyle) -> String? { NSUnimplemented() }
     
     /* Choose how to indicate units. For example, 1h 10m vs 1:10. Default is NSDateComponentsFormatterUnitsStylePositional.
      */
-    public var unitsStyle: UnitsStyle
+    open var unitsStyle: UnitsStyle
     
     /* Bitmask of units to include. Set to 0 to get the default behavior. Note that, especially if the maximum number of units is low, unit collapsing is on, or zero dropping is on, not all allowed units may actually be used for a given NSDateComponents. Default value is the components of the passed-in NSDateComponents object, or years | months | weeks | days | hours | minutes | seconds if passed an NSTimeInterval or pair of NSDates.
      
@@ -85,21 +85,21 @@ public class DateComponentsFormatter : Formatter {
      
        Specifying any other NSCalendarUnits will result in an exception.
      */
-    public var allowedUnits: Calendar.Unit
+    open var allowedUnits: Calendar.Unit
     
     /* Bitmask specifying how to handle zeros in units. This includes both padding and dropping zeros so that a consistent number digits are displayed, causing updating displays to remain more stable. Default is NSDateComponentsFormatterZeroFormattingBehaviorDefault.
      
        If the combination of zero formatting behavior and style would lead to ambiguous date formats (for example, 1:10 meaning 1 hour, 10 seconds), NSDateComponentsFormatter will throw an exception.
      */
-    public var zeroFormattingBehavior: ZeroFormattingBehavior
+    open var zeroFormattingBehavior: ZeroFormattingBehavior
     
     /* Specifies the locale and calendar to use for formatting date components that do not themselves have calendars. Defaults to NSAutoupdatingCurrentCalendar. If set to nil, uses the gregorian calendar with the en_US_POSIX locale.
      */
-    /*@NSCopying*/ public var calendar: Calendar?
+    /*@NSCopying*/ open var calendar: Calendar?
     
     /* Choose whether non-integer units should be used to handle display of values that can't be exactly represented with the allowed units. For example, if minutes aren't allowed, then "1h 30m" could be formatted as "1.5h". Default is NO.
      */
-    public var allowsFractionalUnits: Bool
+    open var allowsFractionalUnits: Bool
     
     /* Choose whether or not, and at which point, to round small units in large values to zero.
        Examples:
@@ -110,29 +110,29 @@ public class DateComponentsFormatter : Formatter {
     
        Default is 0, which is interpreted as unlimited.
      */
-    public var maximumUnitCount: Int
+    open var maximumUnitCount: Int
     
     /* Choose whether to express largest units just above the threshold for the next lowest unit as a larger quantity of the lower unit. For example: "1m 3s" vs "63s". Default is NO.
      */
-    public var collapsesLargestUnit: Bool
+    open var collapsesLargestUnit: Bool
     
     /* Choose whether to indicate that the allowed units/insignificant units choices lead to inexact results. In some languages, simply prepending "about " to the string will produce incorrect results; this handles those cases correctly. Default is NO.
      */
-    public var includesApproximationPhrase: Bool
+    open var includesApproximationPhrase: Bool
     
     /* Choose whether to produce strings like "35 minutes remaining". Default is NO.
      */
-    public var includesTimeRemainingPhrase: Bool
+    open var includesTimeRemainingPhrase: Bool
     
     /* 
        Currently unimplemented, will be removed in a future seed.
      */
-    public var formattingContext: Context
+    open var formattingContext: Context
     
     /* NSDateComponentsFormatter currently only implements formatting, not parsing. Until it implements parsing, this will always return NO.
      */
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    public override func objectValue(_ string: String) throws -> AnyObject? { return nil }
+    open override func objectValue(_ string: String) throws -> AnyObject? { return nil }
 }
 

--- a/Foundation/NSDateFormatter.swift
+++ b/Foundation/NSDateFormatter.swift
@@ -9,7 +9,7 @@
 
 import CoreFoundation
 
-public class DateFormatter : Formatter {
+open class DateFormatter : Formatter {
     typealias CFType = CFDateFormatter
     private var __cfObject: CFType?
     private var _cfObject: CFType {
@@ -41,20 +41,20 @@ public class DateFormatter : Formatter {
         super.init(coder: coder)
     }
 
-    public var formattingContext: Context = .unknown // default is NSFormattingContextUnknown
+    open var formattingContext: Context = .unknown // default is NSFormattingContextUnknown
 
-    public func objectValue(_ string: String, range rangep: UnsafeMutablePointer<NSRange>) throws -> AnyObject? { NSUnimplemented() }
+    open func objectValue(_ string: String, range rangep: UnsafeMutablePointer<NSRange>) throws -> AnyObject? { NSUnimplemented() }
 
-    public override func string(for obj: AnyObject) -> String? {
+    open override func string(for obj: AnyObject) -> String? {
         guard let date = obj as? Date else { return nil }
         return string(from: date)
     }
 
-    public func string(from date: Date) -> String {
+    open func string(from date: Date) -> String {
         return CFDateFormatterCreateStringWithDate(kCFAllocatorSystemDefault, _cfObject, date._cfObject)._swiftObject
     }
 
-    public func date(from string: String) -> Date? {
+    open func date(from string: String) -> Date? {
         var range = CFRange(location: 0, length: string.length)
         let date = withUnsafeMutablePointer(to: &range) { (rangep: UnsafeMutablePointer<CFRange>) -> Date? in
             guard let res = CFDateFormatterCreateDateFromString(kCFAllocatorSystemDefault, _cfObject, string._cfObject, rangep) else {
@@ -65,21 +65,21 @@ public class DateFormatter : Formatter {
         return date
     }
 
-    public class func localizedString(from date: Date, dateStyle dstyle: Style, timeStyle tstyle: Style) -> String {
+    open class func localizedString(from date: Date, dateStyle dstyle: Style, timeStyle tstyle: Style) -> String {
         let df = DateFormatter()
         df.dateStyle = dstyle
         df.timeStyle = tstyle
         return df.string(for: date._nsObject)!
     }
 
-    public class func dateFormat(fromTemplate tmplate: String, options opts: Int, locale: Locale?) -> String? {
+    open class func dateFormat(fromTemplate tmplate: String, options opts: Int, locale: Locale?) -> String? {
         guard let res = CFDateFormatterCreateDateFormatFromTemplate(kCFAllocatorSystemDefault, tmplate._cfObject, CFOptionFlags(opts), locale?._cfObject) else {
             return nil
         }
         return res._swiftObject
     }
 
-    public func setLocalizedDateFormatFromTemplate(_ dateFormatTemplate: String) {
+    open func setLocalizedDateFormatFromTemplate(_ dateFormatTemplate: String) {
         NSUnimplemented()
     }
 
@@ -124,7 +124,7 @@ public class DateFormatter : Formatter {
     }
 
     private var _dateFormat: String? { willSet { _reset() } }
-    public var dateFormat: String! {
+    open var dateFormat: String! {
         get {
             guard let format = _dateFormat else {
                 return __cfObject.map { CFDateFormatterGetFormat($0)._swiftObject } ?? ""
@@ -136,18 +136,18 @@ public class DateFormatter : Formatter {
         }
     }
 
-    public var dateStyle: Style = .noStyle { willSet { _dateFormat = nil; _reset() } }
+    open var dateStyle: Style = .noStyle { willSet { _dateFormat = nil; _reset() } }
 
-    public var timeStyle: Style = .noStyle { willSet { _dateFormat = nil; _reset() } }
+    open var timeStyle: Style = .noStyle { willSet { _dateFormat = nil; _reset() } }
 
-    /*@NSCopying*/ public var locale: Locale! = .current { willSet { _reset() } }
+    /*@NSCopying*/ open var locale: Locale! = .current { willSet { _reset() } }
 
-    public var generatesCalendarDates = false { willSet { _reset() } }
+    open var generatesCalendarDates = false { willSet { _reset() } }
 
-    /*@NSCopying*/ public var timeZone: TimeZone! = .systemTimeZone() { willSet { _reset() } }
+    /*@NSCopying*/ open var timeZone: TimeZone! = .systemTimeZone() { willSet { _reset() } }
 
     /*@NSCopying*/ internal var _calendar: Calendar! { willSet { _reset() } }
-    public var calendar: Calendar! {
+    open var calendar: Calendar! {
         get {
             guard let calendar = _calendar else {
                 return CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterCalendar) as! Calendar
@@ -159,10 +159,10 @@ public class DateFormatter : Formatter {
         }
     }
 
-    public var lenient = false { willSet { _reset() } }
+    open var lenient = false { willSet { _reset() } }
 
     /*@NSCopying*/ internal var _twoDigitStartDate: Date? { willSet { _reset() } }
-    public var twoDigitStartDate: Date? {
+    open var twoDigitStartDate: Date? {
         get {
             guard let startDate = _twoDigitStartDate else {
                 return (CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterTwoDigitStartDate) as? NSDate)?._swiftObject
@@ -174,10 +174,10 @@ public class DateFormatter : Formatter {
         }
     }
 
-    /*@NSCopying*/ public var defaultDate: Date? { willSet { _reset() } }
+    /*@NSCopying*/ open var defaultDate: Date? { willSet { _reset() } }
     
     internal var _eraSymbols: [String]! { willSet { _reset() } }
-    public var eraSymbols: [String]! {
+    open var eraSymbols: [String]! {
         get {
             guard let symbols = _eraSymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterEraSymbols) as! NSArray
@@ -191,7 +191,7 @@ public class DateFormatter : Formatter {
     }
     
     internal var _monthSymbols: [String]! { willSet { _reset() } }
-    public var monthSymbols: [String]! {
+    open var monthSymbols: [String]! {
         get {
             guard let symbols = _monthSymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterMonthSymbols) as! NSArray
@@ -205,7 +205,7 @@ public class DateFormatter : Formatter {
     }
 
     internal var _shortMonthSymbols: [String]! { willSet { _reset() } }
-    public var shortMonthSymbols: [String]! {
+    open var shortMonthSymbols: [String]! {
         get {
             guard let symbols = _shortMonthSymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterShortMonthSymbols) as! NSArray
@@ -220,7 +220,7 @@ public class DateFormatter : Formatter {
     
 
     internal var _weekdaySymbols: [String]! { willSet { _reset() } }
-    public var weekdaySymbols: [String]! {
+    open var weekdaySymbols: [String]! {
         get {
             guard let symbols = _weekdaySymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterWeekdaySymbols) as! NSArray
@@ -234,7 +234,7 @@ public class DateFormatter : Formatter {
     }
 
     internal var _shortWeekdaySymbols: [String]! { willSet { _reset() } }
-    public var shortWeekdaySymbols: [String]! {
+    open var shortWeekdaySymbols: [String]! {
         get {
             guard let symbols = _shortWeekdaySymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterShortWeekdaySymbols) as! NSArray
@@ -248,7 +248,7 @@ public class DateFormatter : Formatter {
     }
 
     internal var _AMSymbol: String! { willSet { _reset() } }
-    public var AMSymbol: String! {
+    open var AMSymbol: String! {
         get {
             guard let symbol = _AMSymbol else {
                 return (CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterAMSymbol) as! NSString)._swiftObject
@@ -261,7 +261,7 @@ public class DateFormatter : Formatter {
     }
 
     internal var _PMSymbol: String! { willSet { _reset() } }
-    public var PMSymbol: String! {
+    open var PMSymbol: String! {
         get {
             guard let symbol = _PMSymbol else {
                 return (CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterPMSymbol) as! NSString)._swiftObject
@@ -274,7 +274,7 @@ public class DateFormatter : Formatter {
     }
 
     internal var _longEraSymbols: [String]! { willSet { _reset() } }
-    public var longEraSymbols: [String]! {
+    open var longEraSymbols: [String]! {
         get {
             guard let symbols = _longEraSymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterLongEraSymbols) as! NSArray
@@ -288,7 +288,7 @@ public class DateFormatter : Formatter {
     }
 
     internal var _veryShortMonthSymbols: [String]! { willSet { _reset() } }
-    public var veryShortMonthSymbols: [String]! {
+    open var veryShortMonthSymbols: [String]! {
         get {
             guard let symbols = _veryShortMonthSymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterVeryShortMonthSymbols) as! NSArray
@@ -302,7 +302,7 @@ public class DateFormatter : Formatter {
     }
 
     internal var _standaloneMonthSymbols: [String]! { willSet { _reset() } }
-    public var standaloneMonthSymbols: [String]! {
+    open var standaloneMonthSymbols: [String]! {
         get {
             guard let symbols = _standaloneMonthSymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterStandaloneMonthSymbols) as! NSArray
@@ -316,7 +316,7 @@ public class DateFormatter : Formatter {
     }
 
     internal var _shortStandaloneMonthSymbols: [String]! { willSet { _reset() } }
-    public var shortStandaloneMonthSymbols: [String]! {
+    open var shortStandaloneMonthSymbols: [String]! {
         get {
             guard let symbols = _shortStandaloneMonthSymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterShortStandaloneMonthSymbols) as! NSArray
@@ -330,7 +330,7 @@ public class DateFormatter : Formatter {
     }
 
     internal var _veryShortStandaloneMonthSymbols: [String]! { willSet { _reset() } }
-    public var veryShortStandaloneMonthSymbols: [String]! {
+    open var veryShortStandaloneMonthSymbols: [String]! {
         get {
             guard let symbols = _veryShortStandaloneMonthSymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterVeryShortStandaloneMonthSymbols) as! NSArray
@@ -344,7 +344,7 @@ public class DateFormatter : Formatter {
     }
 
     internal var _veryShortWeekdaySymbols: [String]! { willSet { _reset() } }
-    public var veryShortWeekdaySymbols: [String]! {
+    open var veryShortWeekdaySymbols: [String]! {
         get {
             guard let symbols = _veryShortWeekdaySymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterVeryShortWeekdaySymbols) as! NSArray
@@ -358,7 +358,7 @@ public class DateFormatter : Formatter {
     }
 
     internal var _standaloneWeekdaySymbols: [String]! { willSet { _reset() } }
-    public var standaloneWeekdaySymbols: [String]! {
+    open var standaloneWeekdaySymbols: [String]! {
         get {
             guard let symbols = _standaloneWeekdaySymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterStandaloneWeekdaySymbols) as! NSArray
@@ -372,7 +372,7 @@ public class DateFormatter : Formatter {
     }
 
     internal var _shortStandaloneWeekdaySymbols: [String]! { willSet { _reset() } }
-    public var shortStandaloneWeekdaySymbols: [String]! {
+    open var shortStandaloneWeekdaySymbols: [String]! {
         get {
             guard let symbols = _shortStandaloneWeekdaySymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterShortStandaloneWeekdaySymbols) as! NSArray
@@ -386,7 +386,7 @@ public class DateFormatter : Formatter {
     }
     
     internal var _veryShortStandaloneWeekdaySymbols: [String]! { willSet { _reset() } }
-    public var veryShortStandaloneWeekdaySymbols: [String]! {
+    open var veryShortStandaloneWeekdaySymbols: [String]! {
         get {
             guard let symbols = _veryShortStandaloneWeekdaySymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterVeryShortStandaloneWeekdaySymbols) as! NSArray
@@ -400,7 +400,7 @@ public class DateFormatter : Formatter {
     }
 
     internal var _quarterSymbols: [String]! { willSet { _reset() } }
-    public var quarterSymbols: [String]! {
+    open var quarterSymbols: [String]! {
         get {
             guard let symbols = _quarterSymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterQuarterSymbols) as! NSArray
@@ -414,7 +414,7 @@ public class DateFormatter : Formatter {
     }
     
     internal var _shortQuarterSymbols: [String]! { willSet { _reset() } }
-    public var shortQuarterSymbols: [String]! {
+    open var shortQuarterSymbols: [String]! {
         get {
             guard let symbols = _shortQuarterSymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterShortQuarterSymbols) as! NSArray
@@ -428,7 +428,7 @@ public class DateFormatter : Formatter {
     }
 
     internal var _standaloneQuarterSymbols: [String]! { willSet { _reset() } }
-    public var standaloneQuarterSymbols: [String]! {
+    open var standaloneQuarterSymbols: [String]! {
         get {
             guard let symbols = _standaloneQuarterSymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterStandaloneQuarterSymbols) as! NSArray
@@ -442,7 +442,7 @@ public class DateFormatter : Formatter {
     }
 
     internal var _shortStandaloneQuarterSymbols: [String]! { willSet { _reset() } }
-    public var shortStandaloneQuarterSymbols: [String]! {
+    open var shortStandaloneQuarterSymbols: [String]! {
         get {
             guard let symbols = _shortStandaloneQuarterSymbols else {
                 let cfSymbols = CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterShortStandaloneQuarterSymbols) as! NSArray
@@ -456,7 +456,7 @@ public class DateFormatter : Formatter {
     }
 
     internal var _gregorianStartDate: Date? { willSet { _reset() } }
-    public var gregorianStartDate: Date? {
+    open var gregorianStartDate: Date? {
         get {
             guard let startDate = _gregorianStartDate else {
                 return (CFDateFormatterCopyProperty(_cfObject, kCFDateFormatterGregorianStartDate) as? NSDate)?._swiftObject
@@ -468,7 +468,7 @@ public class DateFormatter : Formatter {
         }
     }
 
-    public var doesRelativeDateFormatting = false { willSet { _reset() } }
+    open var doesRelativeDateFormatting = false { willSet { _reset() } }
 }
 
 extension DateFormatter {

--- a/Foundation/NSDateIntervalFormatter.swift
+++ b/Foundation/NSDateIntervalFormatter.swift
@@ -22,7 +22,7 @@ extension DateIntervalFormatter {
 // NSDateIntervalFormatter is used to format the range between two NSDates in a locale-sensitive way.
 // NSDateIntervalFormatter returns nil and NO for all methods in NSFormatter.
 
-public class DateIntervalFormatter : Formatter {
+open class DateIntervalFormatter : Formatter {
     
     public override init() {
         NSUnimplemented()
@@ -32,12 +32,12 @@ public class DateIntervalFormatter : Formatter {
         NSUnimplemented()
     }
     
-    /*@NSCopying*/ public var locale: Locale! // default is [NSLocale currentLocale]
-    /*@NSCopying*/ public var calendar: Calendar! // default is the calendar of the locale
-    /*@NSCopying*/ public var timeZone: TimeZone! // default is [NSTimeZone defaultTimeZone]
-    public var dateTemplate: String! // default is an empty string
-    public var dateStyle: Style // default is NSDateIntervalFormatterNoStyle
-    public var timeStyle: Style // default is NSDateIntervalFormatterNoStyle
+    /*@NSCopying*/ open var locale: Locale! // default is [NSLocale currentLocale]
+    /*@NSCopying*/ open var calendar: Calendar! // default is the calendar of the locale
+    /*@NSCopying*/ open var timeZone: TimeZone! // default is [NSTimeZone defaultTimeZone]
+    open var dateTemplate: String! // default is an empty string
+    open var dateStyle: Style // default is NSDateIntervalFormatterNoStyle
+    open var timeStyle: Style // default is NSDateIntervalFormatterNoStyle
     
     /*
          If the range smaller than the resolution specified by the dateTemplate, a single date format will be produced. If the range is larger than the format specified by the dateTemplate, a locale-specific fallback will be used to format the items missing from the pattern.
@@ -57,7 +57,7 @@ public class DateIntervalFormatter : Formatter {
             for en_US, "Mar 4-8"
             for en_GB, "4-8 Mar"
     */
-    public func stringFromDate(_ fromDate: Date, toDate: Date) -> String { NSUnimplemented() }
+    open func stringFromDate(_ fromDate: Date, toDate: Date) -> String { NSUnimplemented() }
     
-    public func string(from dateInterval: NSDateInterval) -> String? { NSUnimplemented() }
+    open func string(from dateInterval: NSDateInterval) -> String? { NSUnimplemented() }
 }

--- a/Foundation/NSDecimalNumber.swift
+++ b/Foundation/NSDecimalNumber.swift
@@ -28,7 +28,7 @@ public protocol NSDecimalNumberBehaviors {
 
 
 /***************	NSDecimalNumber: the class		***********/
-public class NSDecimalNumber : NSNumber {
+open class NSDecimalNumber : NSNumber {
     
     public convenience init(mantissa: UInt64, exponent: Int16, isNegative flag: Bool) { NSUnimplemented() }
     public init(decimal dcm: Decimal) { NSUnimplemented() }
@@ -55,72 +55,72 @@ public class NSDecimalNumber : NSNumber {
         NSRequiresConcreteImplementation()
     }
     
-    public override func description(withLocale locale: AnyObject?) -> String { NSUnimplemented() }
+    open override func description(withLocale locale: AnyObject?) -> String { NSUnimplemented() }
     
     // TODO: "declarations from extensions cannot be overridden yet"
     // Although it's not clear we actually need to redeclare this here when the extension adds it to the superclass of this class
-    // public var decimalValue: NSDecimal { NSUnimplemented() }
+    // open var decimalValue: NSDecimal { NSUnimplemented() }
     
-    public class func zero() -> NSDecimalNumber { NSUnimplemented() }
-    public class func one() -> NSDecimalNumber { NSUnimplemented() }
-    public class func minimum() -> NSDecimalNumber { NSUnimplemented() }
-    public class func maximum() -> NSDecimalNumber { NSUnimplemented() }
-    public class func notANumber() -> NSDecimalNumber { NSUnimplemented() }
+    open class func zero() -> NSDecimalNumber { NSUnimplemented() }
+    open class func one() -> NSDecimalNumber { NSUnimplemented() }
+    open class func minimum() -> NSDecimalNumber { NSUnimplemented() }
+    open class func maximum() -> NSDecimalNumber { NSUnimplemented() }
+    open class func notANumber() -> NSDecimalNumber { NSUnimplemented() }
     
-    public func adding(_ decimalNumber: NSDecimalNumber) -> NSDecimalNumber { NSUnimplemented() }
-    public func adding(_ decimalNumber: NSDecimalNumber, withBehavior behavior: NSDecimalNumberBehaviors?) -> NSDecimalNumber { NSUnimplemented() }
+    open func adding(_ decimalNumber: NSDecimalNumber) -> NSDecimalNumber { NSUnimplemented() }
+    open func adding(_ decimalNumber: NSDecimalNumber, withBehavior behavior: NSDecimalNumberBehaviors?) -> NSDecimalNumber { NSUnimplemented() }
     
-    public func subtracting(_ decimalNumber: NSDecimalNumber) -> NSDecimalNumber { NSUnimplemented() }
-    public func subtracting(_ decimalNumber: NSDecimalNumber, withBehavior behavior: NSDecimalNumberBehaviors?) -> NSDecimalNumber { NSUnimplemented() }
+    open func subtracting(_ decimalNumber: NSDecimalNumber) -> NSDecimalNumber { NSUnimplemented() }
+    open func subtracting(_ decimalNumber: NSDecimalNumber, withBehavior behavior: NSDecimalNumberBehaviors?) -> NSDecimalNumber { NSUnimplemented() }
     
-    public func multiplying(by decimalNumber: NSDecimalNumber) -> NSDecimalNumber { NSUnimplemented() }
-    public func multiplying(by decimalNumber: NSDecimalNumber, withBehavior behavior: NSDecimalNumberBehaviors?) -> NSDecimalNumber { NSUnimplemented() }
+    open func multiplying(by decimalNumber: NSDecimalNumber) -> NSDecimalNumber { NSUnimplemented() }
+    open func multiplying(by decimalNumber: NSDecimalNumber, withBehavior behavior: NSDecimalNumberBehaviors?) -> NSDecimalNumber { NSUnimplemented() }
     
-    public func dividing(by decimalNumber: NSDecimalNumber) -> NSDecimalNumber { NSUnimplemented() }
-    public func dividing(by decimalNumber: NSDecimalNumber, withBehavior behavior: NSDecimalNumberBehaviors?) -> NSDecimalNumber { NSUnimplemented() }
+    open func dividing(by decimalNumber: NSDecimalNumber) -> NSDecimalNumber { NSUnimplemented() }
+    open func dividing(by decimalNumber: NSDecimalNumber, withBehavior behavior: NSDecimalNumberBehaviors?) -> NSDecimalNumber { NSUnimplemented() }
     
-    public func raising(toPower power: Int) -> NSDecimalNumber { NSUnimplemented() }
-    public func raising(toPower power: Int, withBehavior behavior: NSDecimalNumberBehaviors?) -> NSDecimalNumber { NSUnimplemented() }
+    open func raising(toPower power: Int) -> NSDecimalNumber { NSUnimplemented() }
+    open func raising(toPower power: Int, withBehavior behavior: NSDecimalNumberBehaviors?) -> NSDecimalNumber { NSUnimplemented() }
     
-    public func multiplying(byPowerOf10 power: Int16) -> NSDecimalNumber { NSUnimplemented() }
-    public func multiplying(byPowerOf10 power: Int16, withBehavior behavior: NSDecimalNumberBehaviors?) -> NSDecimalNumber { NSUnimplemented() }
+    open func multiplying(byPowerOf10 power: Int16) -> NSDecimalNumber { NSUnimplemented() }
+    open func multiplying(byPowerOf10 power: Int16, withBehavior behavior: NSDecimalNumberBehaviors?) -> NSDecimalNumber { NSUnimplemented() }
     
-    public func rounding(accordingToBehavior behavior: NSDecimalNumberBehaviors?) -> NSDecimalNumber { NSUnimplemented() }
+    open func rounding(accordingToBehavior behavior: NSDecimalNumberBehaviors?) -> NSDecimalNumber { NSUnimplemented() }
     // Round to the scale of the behavior.
     
-    public override func compare(_ decimalNumber: NSNumber) -> ComparisonResult { NSUnimplemented() }
+    open override func compare(_ decimalNumber: NSNumber) -> ComparisonResult { NSUnimplemented() }
     // compare two NSDecimalNumbers
     
-    public class func setDefaultBehavior(_ behavior: NSDecimalNumberBehaviors) { NSUnimplemented() }
+    open class func setDefaultBehavior(_ behavior: NSDecimalNumberBehaviors) { NSUnimplemented() }
     
-    public class func defaultBehavior() -> NSDecimalNumberBehaviors { NSUnimplemented() }
+    open class func defaultBehavior() -> NSDecimalNumberBehaviors { NSUnimplemented() }
     // One behavior per thread - The default behavior is
     //   rounding mode: NSRoundPlain
     //   scale: No defined scale (full precision)
     //   ignore exactnessException
     //   raise on overflow, underflow and divide by zero.
     
-    public override var objCType: UnsafePointer<Int8> { NSUnimplemented() }
+    open override var objCType: UnsafePointer<Int8> { NSUnimplemented() }
     // return 'd' for double
     
-    public override var doubleValue: Double { NSUnimplemented() }
+    open override var doubleValue: Double { NSUnimplemented() }
 }
 
 // return an approximate double value
 
 
 /***********	A class for defining common behaviors		*******/
-public class NSDecimalNumberHandler : NSObject, NSDecimalNumberBehaviors, NSCoding {
+open class NSDecimalNumberHandler : NSObject, NSDecimalNumberBehaviors, NSCoding {
     
     public required init?(coder aDecoder: NSCoder) {
         NSUnimplemented()
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     
-    public class func defaultDecimalNumberHandler() -> NSDecimalNumberHandler{ NSUnimplemented() }
+    open class func defaultDecimalNumberHandler() -> NSDecimalNumberHandler{ NSUnimplemented() }
     // rounding mode: NSRoundPlain
     // scale: No defined scale (full precision)
     // ignore exactnessException (return nil)
@@ -128,9 +128,9 @@ public class NSDecimalNumberHandler : NSObject, NSDecimalNumberBehaviors, NSCodi
     
     public init(roundingMode: Decimal.RoundingMode, scale: Int16, raiseOnExactness exact: Bool, raiseOnOverflow overflow: Bool, raiseOnUnderflow underflow: Bool, raiseOnDivideByZero divideByZero: Bool) { NSUnimplemented() }
     
-    public func roundingMode() -> Decimal.RoundingMode { NSUnimplemented() }
+    open func roundingMode() -> Decimal.RoundingMode { NSUnimplemented() }
     
-    public func scale() -> Int16 { NSUnimplemented() }
+    open func scale() -> Int16 { NSUnimplemented() }
     // The scale could return NO_SCALE for no defined scale.
 }
 

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -82,25 +82,25 @@ extension Dictionary : _ObjectTypeBridgeable {
     }
 }
 
-public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCoding {
+open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCoding {
     private let _cfinfo = _CFInfo(typeID: CFDictionaryGetTypeID())
     internal var _storage = [NSObject: AnyObject]()
     
-    public var count: Int {
+    open var count: Int {
         guard type(of: self) === NSDictionary.self || type(of: self) === NSMutableDictionary.self else {
             NSRequiresConcreteImplementation()
         }
         return _storage.count
     }
     
-    public func objectForKey(_ aKey: AnyObject) -> AnyObject? {
+    open func objectForKey(_ aKey: AnyObject) -> AnyObject? {
         guard type(of: self) === NSDictionary.self || type(of: self) === NSMutableDictionary.self else {
             NSRequiresConcreteImplementation()
         }
         return _storage[aKey as! NSObject]
     }
     
-    public func keyEnumerator() -> NSEnumerator {
+    open func keyEnumerator() -> NSEnumerator {
         guard type(of: self) === NSDictionary.self || type(of: self) === NSMutableDictionary.self else {
             NSRequiresConcreteImplementation()
         }
@@ -158,7 +158,7 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         }
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         if let keyedArchiver = aCoder as? NSKeyedArchiver {
             keyedArchiver._encodeArrayOfObjects(self.allKeys._nsObject, forKey:"NS.keys")
             keyedArchiver._encodeArrayOfObjects(self.allValues._nsObject, forKey:"NS.objects")
@@ -171,11 +171,11 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         return true
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
 
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         if type(of: self) === NSDictionary.self {
             // return self for immutable type
             return self
@@ -187,11 +187,11 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         return NSDictionary(objects: self.allValues, forKeys: self.allKeys.map({ $0 as! NSObject}))
     }
 
-    public override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> AnyObject {
         return mutableCopy(with: nil)
     }
 
-    public func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
         if type(of: self) === NSDictionary.self || type(of: self) === NSMutableDictionary.self {
             // always create and return an NSMutableDictionary
             let mutableDictionary = NSMutableDictionary()
@@ -240,18 +240,18 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         valueBuffer.deallocate(capacity: objects.count)
     }
 
-    public override func isEqual(_ object: AnyObject?) -> Bool {
+    open override func isEqual(_ object: AnyObject?) -> Bool {
         guard let otherDictionary = object as? NSDictionary else {
             return false
         }
         return self.isEqual(to: otherDictionary.bridge())
     }
 
-    public override var hash: Int {
+    open override var hash: Int {
         return self.count
     }
 
-    public var allKeys: [AnyObject] {
+    open var allKeys: [AnyObject] {
         if type(of: self) === NSDictionary.self || type(of: self) === NSMutableDictionary.self {
             return _storage.keys.map { $0 }
         } else {
@@ -264,7 +264,7 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         }
     }
     
-    public var allValues: [AnyObject] {
+    open var allValues: [AnyObject] {
         if type(of: self) === NSDictionary.self || type(of: self) === NSMutableDictionary.self {
             return _storage.values.map { $0 }
         } else {
@@ -280,7 +280,7 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
     /// Alternative pseudo funnel method for fastpath fetches from dictionaries
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    public func getObjects(_ objects: inout [AnyObject], andKeys keys: inout [AnyObject], count: Int) {
+    open func getObjects(_ objects: inout [AnyObject], andKeys keys: inout [AnyObject], count: Int) {
         if type(of: self) === NSDictionary.self || type(of: self) === NSMutableDictionary.self {
             for (key, value) in _storage {
                 keys.append(key)
@@ -297,12 +297,12 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         }
     }
     
-    public subscript (key: AnyObject) -> AnyObject? {
+    open subscript (key: AnyObject) -> AnyObject? {
         return objectForKey(key)
     }
     
     
-    public func allKeys(for anObject: AnyObject) -> [AnyObject] {
+    open func allKeys(for anObject: AnyObject) -> [AnyObject] {
         var matching = Array<AnyObject>()
         enumerateKeysAndObjects([]) { key, value, _ in
             if value === anObject {
@@ -322,11 +322,11 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
     /// store dictionary data for later retrieval, see
     /// [Property List Programming Guide](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/PropertyLists/Introduction/Introduction.html#//apple_ref/doc/uid/10000048i)
     /// and [Archives and Serializations Programming Guide](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/Archiving/Archiving.html#//apple_ref/doc/uid/10000047i).
-    public override var description: String {
+    open override var description: String {
         return description(withLocale: nil)
     }
 
-    public var descriptionInStringsFileFormat: String { NSUnimplemented() }
+    open var descriptionInStringsFileFormat: String { NSUnimplemented() }
 
     /// Returns a string object that represents the contents of the dictionary,
     /// formatted as a property list.
@@ -334,7 +334,7 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
     /// - parameter locale: An object that specifies options used for formatting
     ///   each of the dictionary’s keys and values; pass `nil` if you don’t
     ///   want them formatted.
-    public func description(withLocale locale: AnyObject?) -> String {
+    open func description(withLocale locale: AnyObject?) -> String {
         return description(withLocale: locale, indent: 0)
     }
 
@@ -350,7 +350,7 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
     ///
     /// - returns: A string object that represents the contents of the dictionary,
     ///   formatted as a property list.
-    public func description(withLocale locale: AnyObject?, indent level: Int) -> String {
+    open func description(withLocale locale: AnyObject?, indent level: Int) -> String {
         if level > 100 { return "..." }
 
         var lines = [String]()
@@ -405,7 +405,7 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         return lines.joined(separator: "\n")
     }
 
-    public func isEqual(to otherDictionary: [NSObject : AnyObject]) -> Bool {
+    open func isEqual(to otherDictionary: [NSObject : AnyObject]) -> Bool {
         if count != otherDictionary.count {
             return false
         }
@@ -456,11 +456,11 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         }
     }
 
-    public func objectEnumerator() -> NSEnumerator {
+    open func objectEnumerator() -> NSEnumerator {
         return NSGeneratorEnumerator(ObjectGenerator(self))
     }
     
-    public func objects(forKeys keys: [AnyObject], notFoundMarker marker: AnyObject) -> [AnyObject] {
+    open func objects(forKeys keys: [AnyObject], notFoundMarker marker: AnyObject) -> [AnyObject] {
         var objects = [AnyObject]()
         for key in keys {
             if let object = objectForKey(key) {
@@ -472,8 +472,8 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         return objects
     }
     
-    public func write(toFile path: String, atomically useAuxiliaryFile: Bool) -> Bool { NSUnimplemented() }
-    public func write(to url: URL, atomically: Bool) -> Bool { NSUnimplemented() } // the atomically flag is ignored if url of a type that cannot be written atomically.
+    open func write(toFile path: String, atomically useAuxiliaryFile: Bool) -> Bool { NSUnimplemented() }
+    open func write(to url: URL, atomically: Bool) -> Bool { NSUnimplemented() } // the atomically flag is ignored if url of a type that cannot be written atomically.
     
     public func enumerateKeysAndObjects(_ block: @noescape (AnyObject, AnyObject, UnsafeMutablePointer<ObjCBool>) -> Void) {
         enumerateKeysAndObjects([], using: block)
@@ -496,22 +496,22 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         }
     }
     
-    public func keysSortedByValue(comparator cmptr: @noescape (AnyObject, AnyObject) -> ComparisonResult) -> [AnyObject] {
+    open func keysSortedByValue(comparator cmptr: @noescape (AnyObject, AnyObject) -> ComparisonResult) -> [AnyObject] {
         return keysSortedByValue([], usingComparator: cmptr)
     }
 
-    public func keysSortedByValue(_ opts: SortOptions = [], usingComparator cmptr: @noescape (AnyObject, AnyObject) -> ComparisonResult) -> [AnyObject] {
+    open func keysSortedByValue(_ opts: SortOptions = [], usingComparator cmptr: @noescape (AnyObject, AnyObject) -> ComparisonResult) -> [AnyObject] {
         let sorted = allKeys.sorted { lhs, rhs in
             return cmptr(lhs, rhs) == .orderedSame
         }
         return sorted
     }
 
-    public func keysOfEntries(passingTest predicate: @noescape (AnyObject, AnyObject, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Set<NSObject> {
+    open func keysOfEntries(passingTest predicate: @noescape (AnyObject, AnyObject, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Set<NSObject> {
         return keysOfEntries([], passingTest: predicate)
     }
 
-    public func keysOfEntries(_ opts: EnumerationOptions = [], passingTest predicate: @noescape (AnyObject, AnyObject, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Set<NSObject> {
+    open func keysOfEntries(_ opts: EnumerationOptions = [], passingTest predicate: @noescape (AnyObject, AnyObject, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Set<NSObject> {
         var matching = Set<NSObject>()
         enumerateKeysAndObjects(opts) { key, value, stop in
             if predicate(key, value, stop) {
@@ -521,7 +521,7 @@ public class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         return matching
     }
     
-    override public var _cfTypeID: CFTypeID {
+    override open var _cfTypeID: CFTypeID {
         return CFDictionaryGetTypeID()
     }
     
@@ -561,9 +561,9 @@ extension Dictionary : _NSBridgable, _CFBridgable {
     internal var _cfObject: CFDictionary { return _nsObject._cfObject }
 }
 
-public class NSMutableDictionary : NSDictionary {
+open class NSMutableDictionary : NSDictionary {
     
-    public func removeObject(forKey aKey: AnyObject) {
+    open func removeObject(forKey aKey: AnyObject) {
         guard type(of: self) === NSDictionary.self || type(of: self) === NSMutableDictionary.self else {
             NSRequiresConcreteImplementation()
         }
@@ -573,7 +573,7 @@ public class NSMutableDictionary : NSDictionary {
         }
     }
     
-    public func setObject(_ anObject: AnyObject, forKey aKey: NSObject) {
+    open func setObject(_ anObject: AnyObject, forKey aKey: NSObject) {
         guard type(of: self) === NSDictionary.self || type(of: self) === NSMutableDictionary.self else {
             NSRequiresConcreteImplementation()
         }
@@ -665,7 +665,7 @@ extension NSDictionary {
     As for any usage of hashing, is recommended that the keys have a well-distributed implementation of -hash, and the hash codes must satisfy the hash/isEqual: invariant.
     Keys with duplicate hash codes are allowed, but will cause lower performance and increase memory usage.
     */
-    public class func sharedKeySet(forKeys keys: [NSCopying]) -> AnyObject { NSUnimplemented() }
+    open class func sharedKeySet(forKeys keys: [NSCopying]) -> AnyObject { NSUnimplemented() }
 }
 
 extension NSMutableDictionary {

--- a/Foundation/NSEnergyFormatter.swift
+++ b/Foundation/NSEnergyFormatter.swift
@@ -18,30 +18,30 @@ extension EnergyFormatter {
     }
 }
 
-public class EnergyFormatter : Formatter {
+open class EnergyFormatter : Formatter {
     
     public required init?(coder: NSCoder) {
         NSUnimplemented()
     }
     
-    /*@NSCopying*/ public var numberFormatter: NumberFormatter! // default is NSNumberFormatter with NSNumberFormatterDecimalStyle
-    public var unitStyle: UnitStyle // default is NSFormattingUnitStyleMedium
-    public var isForFoodEnergyUse: Bool // default is NO; if it is set to YES, NSEnergyFormatterUnitKilocalorie may be “C” instead of “kcal"
+    /*@NSCopying*/ open var numberFormatter: NumberFormatter! // default is NSNumberFormatter with NSNumberFormatterDecimalStyle
+    open var unitStyle: UnitStyle // default is NSFormattingUnitStyleMedium
+    open var isForFoodEnergyUse: Bool // default is NO; if it is set to YES, NSEnergyFormatterUnitKilocalorie may be “C” instead of “kcal"
     
     // Format a combination of a number and an unit to a localized string.
-    public func string(fromValue value: Double, unit: Unit) -> String { NSUnimplemented() }
+    open func string(fromValue value: Double, unit: Unit) -> String { NSUnimplemented() }
     
     // Format a number in joules to a localized string with the locale-appropriate unit and an appropriate scale (e.g. 10.3J = 2.46cal in the US locale).
-    public func string(fromJoules numberInJoules: Double) -> String { NSUnimplemented() }
+    open func string(fromJoules numberInJoules: Double) -> String { NSUnimplemented() }
     
     // Return a localized string of the given unit, and if the unit is singular or plural is based on the given number.
-    public func unitString(fromValue value: Double, unit: Unit) -> String { NSUnimplemented() }
+    open func unitString(fromValue value: Double, unit: Unit) -> String { NSUnimplemented() }
     
     // Return the locale-appropriate unit, the same unit used by -stringFromJoules:.
-    public func unitString(fromJoules numberInJoules: Double, usedUnit unitp: UnsafeMutablePointer<Unit>?) -> String { NSUnimplemented() }
+    open func unitString(fromJoules numberInJoules: Double, usedUnit unitp: UnsafeMutablePointer<Unit>?) -> String { NSUnimplemented() }
     
     
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    public override func objectValue(_ string: String) throws -> AnyObject? { return nil }
+    open override func objectValue(_ string: String) throws -> AnyObject? { return nil }
 }

--- a/Foundation/NSEnumerator.swift
+++ b/Foundation/NSEnumerator.swift
@@ -7,9 +7,9 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-public class NSEnumerator : NSObject {
+open class NSEnumerator : NSObject {
     
-    public func nextObject() -> AnyObject? {
+    open func nextObject() -> AnyObject? {
         NSRequiresConcreteImplementation()
     }
 

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -30,7 +30,7 @@ public let NSURLErrorKey: String = "NSURL"
 public let NSFilePathErrorKey: String = "NSFilePathErrorKey"
 
 
-public class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
+open class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
     typealias CFType = CFError
     
     internal var _cfObject: CFType {
@@ -38,8 +38,8 @@ public class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     // ErrorType forbids this being internal
-    public var _domain: String
-    public var _code: Int
+    open var _domain: String
+    open var _code: Int
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation
     /// - Note: This API differs from Darwin because it uses [String : Any] as a type instead of [String : AnyObject]. This allows the use of Swift value types.
     private var _userInfo: [String : Any]?
@@ -88,7 +88,7 @@ public class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
         return true
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         if aCoder.allowsKeyedCoding {
             aCoder.encode(_domain.bridge(), forKey: "NSDomain")
             aCoder.encode(Int32(_code), forKey: "NSCode")
@@ -101,25 +101,25 @@ public class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         return self
     }
     
-    public var domain: String {
+    open var domain: String {
         return _domain
     }
     
-    public var code: Int {
+    open var code: Int {
         return _code
     }
 
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation
     /// - Note: This API differs from Darwin because it uses [String : Any] as a type instead of [String : AnyObject]. This allows the use of Swift value types.
-    public var userInfo: [String : Any] {
+    open var userInfo: [String : Any] {
         if let info = _userInfo {
             return info
         } else {
@@ -127,40 +127,40 @@ public class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    public var localizedDescription: String {
+    open var localizedDescription: String {
         let desc = userInfo[NSLocalizedDescriptionKey] as? String
         
         return desc ?? "The operation could not be completed"
     }
     
-    public var localizedFailureReason: String? {
+    open var localizedFailureReason: String? {
         return userInfo[NSLocalizedFailureReasonErrorKey] as? String
     }
     
-    public var localizedRecoverySuggestion: String? {
+    open var localizedRecoverySuggestion: String? {
         return userInfo[NSLocalizedRecoverySuggestionErrorKey] as? String
     }
 
-    public var localizedRecoveryOptions: [String]? {
+    open var localizedRecoveryOptions: [String]? {
         return userInfo[NSLocalizedRecoveryOptionsErrorKey] as? [String]
     }
     
-    public var recoveryAttempter: AnyObject? {
+    open var recoveryAttempter: AnyObject? {
         return userInfo[NSRecoveryAttempterErrorKey] as? AnyObject
     }
     
-    public var helpAnchor: String? {
+    open var helpAnchor: String? {
         return userInfo[NSHelpAnchorErrorKey] as? String
     }
     
     internal typealias NSErrorProvider = (_ error: NSError, _ key: String) -> AnyObject?
     internal static var userInfoProviders = [String: NSErrorProvider]()
     
-    public class func setUserInfoValueProviderForDomain(_ errorDomain: String, provider: ((NSError, String) -> AnyObject?)?) {
+    open class func setUserInfoValueProviderForDomain(_ errorDomain: String, provider: ((NSError, String) -> AnyObject?)?) {
         NSError.userInfoProviders[errorDomain] = provider
     }
 
-    public class func userInfoValueProviderForDomain(_ errorDomain: String) -> ((NSError, String) -> AnyObject?)? {
+    open class func userInfoValueProviderForDomain(_ errorDomain: String) -> ((NSError, String) -> AnyObject?)? {
         return NSError.userInfoProviders[errorDomain]
     }
 }

--- a/Foundation/NSExpression.swift
+++ b/Foundation/NSExpression.swift
@@ -28,7 +28,7 @@ extension NSExpression {
     }
 }
 
-public class NSExpression : NSObject, NSSecureCoding, NSCopying {
+open class NSExpression : NSObject, NSSecureCoding, NSCopying {
     
     public static func supportsSecureCoding() -> Bool {
         return true
@@ -38,22 +38,22 @@ public class NSExpression : NSObject, NSSecureCoding, NSCopying {
         NSUnimplemented()
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         NSUnimplemented()
     }
 
     public /*not inherited*/ init(format expressionFormat: String, argumentArray arguments: [AnyObject]) { NSUnimplemented() }
     
     public /*not inherited*/ init(forConstantValue obj: AnyObject?) { NSUnimplemented() } // Expression that returns a constant value
-    public class func expressionForEvaluatedObject() -> NSExpression { NSUnimplemented() } // Expression that returns the object being evaluated
+    open class func expressionForEvaluatedObject() -> NSExpression { NSUnimplemented() } // Expression that returns the object being evaluated
     public /*not inherited*/ init(forVariable string: String) { NSUnimplemented() } // Expression that pulls a value from the variable bindings dictionary
     public /*not inherited*/ init(forKeyPath keyPath: String) { NSUnimplemented() } // Expression that invokes valueForKeyPath with keyPath
     public /*not inherited*/ init(forFunction name: String, arguments parameters: [AnyObject]) { NSUnimplemented() } // Expression that invokes one of the predefined functions. Will throw immediately if the selector is bad; will throw at runtime if the parameters are incorrect.
@@ -104,34 +104,34 @@ public class NSExpression : NSObject, NSSecureCoding, NSCopying {
     public /*not inherited*/ init(forMinusSet left: NSExpression, with right: NSExpression) { NSUnimplemented() } // return an expression that will return the disjunction of the collections expressed by left and right
     public /*not inherited*/ init(forSubquery expression: NSExpression, usingIteratorVariable variable: String, predicate: AnyObject) { NSUnimplemented() } // Expression that filters a collection by storing elements in the collection in the variable variable and keeping the elements for which qualifer returns true; variable is used as a local variable, and will shadow any instances of variable in the bindings dictionary, the variable is removed or the old value replaced once evaluation completes
     public /*not inherited*/ init(forFunction target: NSExpression, selectorName name: String, arguments parameters: [AnyObject]?) { NSUnimplemented() } // Expression that invokes the selector on target with parameters. Will throw at runtime if target does not implement selector or if parameters are wrong.
-    public class func expressionForAnyKey() -> NSExpression { NSUnimplemented() }
+    open class func expressionForAnyKey() -> NSExpression { NSUnimplemented() }
     public /*not inherited*/ init(forBlock block: (AnyObject?, [AnyObject], NSMutableDictionary?) -> AnyObject, arguments: [NSExpression]?) { NSUnimplemented() } // Expression that invokes the block with the parameters; note that block expressions are not encodable or representable as parseable strings.
     public /*not inherited*/ init(forConditional predicate: Predicate, trueExpression: NSExpression, falseExpression: NSExpression) { NSUnimplemented() } // Expression that will return the result of trueExpression or falseExpression depending on the value of predicate
     
     public init(expressionType type: ExpressionType) { NSUnimplemented() }
     
     // accessors for individual parameters - raise if not applicable
-    public var expressionType: ExpressionType { NSUnimplemented() }
-    public var constantValue: AnyObject { NSUnimplemented() }
-    public var keyPath: String { NSUnimplemented() }
-    public var function: String { NSUnimplemented() }
-    public var variable: String { NSUnimplemented() }
-    /*@NSCopying*/ public var operand: NSExpression { NSUnimplemented() } // the object on which the selector will be invoked (the result of evaluating a key path or one of the defined functions)
-    public var arguments: [NSExpression]? { NSUnimplemented() } // array of expressions which will be passed as parameters during invocation of the selector on the operand of a function expression
+    open var expressionType: ExpressionType { NSUnimplemented() }
+    open var constantValue: AnyObject { NSUnimplemented() }
+    open var keyPath: String { NSUnimplemented() }
+    open var function: String { NSUnimplemented() }
+    open var variable: String { NSUnimplemented() }
+    /*@NSCopying*/ open var operand: NSExpression { NSUnimplemented() } // the object on which the selector will be invoked (the result of evaluating a key path or one of the defined functions)
+    open var arguments: [NSExpression]? { NSUnimplemented() } // array of expressions which will be passed as parameters during invocation of the selector on the operand of a function expression
     
-    public var collection: AnyObject { NSUnimplemented() }
-    /*@NSCopying*/ public var predicate: Predicate { NSUnimplemented() }
-    /*@NSCopying*/ public var left: NSExpression { NSUnimplemented() } // expression which represents the left side of a set expression
-    /*@NSCopying*/ public var right: NSExpression { NSUnimplemented() } // expression which represents the right side of a set expression
+    open var collection: AnyObject { NSUnimplemented() }
+    /*@NSCopying*/ open var predicate: Predicate { NSUnimplemented() }
+    /*@NSCopying*/ open var left: NSExpression { NSUnimplemented() } // expression which represents the left side of a set expression
+    /*@NSCopying*/ open var right: NSExpression { NSUnimplemented() } // expression which represents the right side of a set expression
     
-    /*@NSCopying*/ public var `true`: NSExpression { NSUnimplemented() } // expression which will be evaluated if a conditional expression's predicate evaluates to true
-    /*@NSCopying*/ public var `false`: NSExpression { NSUnimplemented() } // expression which will be evaluated if a conditional expression's predicate evaluates to false
+    /*@NSCopying*/ open var `true`: NSExpression { NSUnimplemented() } // expression which will be evaluated if a conditional expression's predicate evaluates to true
+    /*@NSCopying*/ open var `false`: NSExpression { NSUnimplemented() } // expression which will be evaluated if a conditional expression's predicate evaluates to false
     
-    public var expressionBlock: (AnyObject?, [AnyObject], NSMutableDictionary?) -> AnyObject { NSUnimplemented() }
+    open var expressionBlock: (AnyObject?, [AnyObject], NSMutableDictionary?) -> AnyObject { NSUnimplemented() }
     
     // evaluate the expression using the object and bindings- note that context is mutable here and can be used by expressions to store temporary state for one predicate evaluation
-    public func expressionValueWithObject(_ object: AnyObject?, context: NSMutableDictionary?) -> AnyObject { NSUnimplemented() }
+    open func expressionValueWithObject(_ object: AnyObject?, context: NSMutableDictionary?) -> AnyObject { NSUnimplemented() }
     
-    public func allowEvaluation() { NSUnimplemented() } // Force an expression which was securely decoded to allow evaluation
+    open func allowEvaluation() { NSUnimplemented() } // Force an expression which was securely decoded to allow evaluation
 }
 

--- a/Foundation/NSFileHandle.swift
+++ b/Foundation/NSFileHandle.swift
@@ -15,20 +15,20 @@ import Darwin
 import Glibc
 #endif
 
-public class FileHandle: NSObject, NSSecureCoding {
+open class FileHandle: NSObject, NSSecureCoding {
     internal var _fd: Int32
     internal var _closeOnDealloc: Bool
     internal var _closed: Bool = false
     
-    public var availableData: Data {
+    open var availableData: Data {
         return _readDataOfLength(Int.max, untilEOF: false)
     }
     
-    public func readDataToEndOfFile() -> Data {
+    open func readDataToEndOfFile() -> Data {
         return readData(ofLength: Int.max)
     }
 
-    public func readData(ofLength length: Int) -> Data {
+    open func readData(ofLength length: Int) -> Data {
         return _readDataOfLength(length, untilEOF: true)
     }
 
@@ -115,7 +115,7 @@ public class FileHandle: NSObject, NSSecureCoding {
         return Data()
     }
     
-    public func write(_ data: Data) {
+    open func write(_ data: Data) {
         data.enumerateBytes() { (bytes, range, stop) in
             do {
                 try NSData.writeToFileDescriptor(self._fd, path: nil, buf: UnsafeRawPointer(bytes.baseAddress!), length: bytes.count)
@@ -127,29 +127,29 @@ public class FileHandle: NSObject, NSSecureCoding {
     
     // TODO: Error handling.
     
-    public var offsetInFile: UInt64 {
+    open var offsetInFile: UInt64 {
         return UInt64(lseek(_fd, 0, L_INCR))
     }
     
-    public func seekToEndOfFile() -> UInt64 {
+    open func seekToEndOfFile() -> UInt64 {
         return UInt64(lseek(_fd, 0, L_XTND))
     }
     
-    public func seek(toFileOffset offset: UInt64) {
+    open func seek(toFileOffset offset: UInt64) {
         lseek(_fd, off_t(offset), L_SET)
     }
     
-    public func truncateFile(atOffset offset: UInt64) {
+    open func truncateFile(atOffset offset: UInt64) {
         if lseek(_fd, off_t(offset), L_SET) == 0 {
             ftruncate(_fd, off_t(offset))
         }
     }
     
-    public func synchronizeFile() {
+    open func synchronizeFile() {
         fsync(_fd)
     }
     
-    public func closeFile() {
+    open func closeFile() {
         if !_closed {
             close(_fd)
             _closed = true
@@ -180,7 +180,7 @@ public class FileHandle: NSObject, NSSecureCoding {
         NSUnimplemented()
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     
@@ -195,7 +195,7 @@ extension FileHandle {
         return FileHandle(fileDescriptor: STDIN_FILENO, closeOnDealloc: false)
     }()
 
-    public class func standardInput() -> FileHandle {
+    open class func standardInput() -> FileHandle {
         return _stdinFileHandle
     }
     
@@ -203,7 +203,7 @@ extension FileHandle {
         return FileHandle(fileDescriptor: STDOUT_FILENO, closeOnDealloc: false)
     }()
 
-    public class func standardOutput() -> FileHandle {
+    open class func standardOutput() -> FileHandle {
         return _stdoutFileHandle
     }
     
@@ -211,11 +211,11 @@ extension FileHandle {
         return FileHandle(fileDescriptor: STDERR_FILENO, closeOnDealloc: false)
     }()
     
-    public class func standardError() -> FileHandle {
+    open class func standardError() -> FileHandle {
         return _stderrFileHandle
     }
     
-    public class func nullDevice() -> FileHandle {
+    open class func nullDevice() -> FileHandle {
         NSUnimplemented()
     }
     
@@ -327,7 +327,7 @@ extension FileHandle {
     }
 }
 
-public class Pipe: NSObject {
+open class Pipe: NSObject {
     
     private let readHandle: FileHandle
     private let writeHandle: FileHandle
@@ -353,11 +353,11 @@ public class Pipe: NSObject {
         super.init()
     }
     
-    public var fileHandleForReading: FileHandle {
+    open var fileHandleForReading: FileHandle {
         return self.readHandle
     }
     
-    public var fileHandleForWriting: FileHandle {
+    open var fileHandleForWriting: FileHandle {
         return self.writeHandle
     }
 }

--- a/Foundation/NSFileManager.swift
+++ b/Foundation/NSFileManager.swift
@@ -66,18 +66,18 @@ public enum NSURLRelationship : Int {
     case other
 }
 
-public class FileManager: NSObject {
+open class FileManager: NSObject {
     
     /* Returns the default singleton instance.
     */
     internal static let defaultInstance = FileManager()
-    public class func `default`() -> FileManager {
+    open class func `default`() -> FileManager {
         return defaultInstance
     }
     
     /* Returns an NSArray of NSURLs locating the mounted volumes available on the computer. The property keys that can be requested are available in NSURL.
      */
-    public func mountedVolumeURLs(includingResourceValuesForKeys propertyKeys: [String]?, options: VolumeEnumerationOptions = []) -> [URL]? {
+    open func mountedVolumeURLs(includingResourceValuesForKeys propertyKeys: [String]?, options: VolumeEnumerationOptions = []) -> [URL]? {
         NSUnimplemented()
     }
     
@@ -89,7 +89,7 @@ public class FileManager: NSObject {
      
         If you wish to only receive the URLs and no other attributes, then pass '0' for 'options' and an empty NSArray ('[NSArray array]') for 'keys'. If you wish to have the property caches of the vended URLs pre-populated with a default set of attributes, then pass '0' for 'options' and 'nil' for 'keys'.
      */
-    public func contentsOfDirectory(at url: URL, includingPropertiesForKeys keys: [String]?, options mask: DirectoryEnumerationOptions = []) throws -> [URL] {
+    open func contentsOfDirectory(at url: URL, includingPropertiesForKeys keys: [String]?, options mask: DirectoryEnumerationOptions = []) throws -> [URL] {
         var error : NSError? = nil
         let e = self.enumerator(at: url, includingPropertiesForKeys: keys, options: mask.union(.skipsSubdirectoryDescendants)) { (url, err) -> Bool in
             error = err
@@ -109,7 +109,7 @@ public class FileManager: NSObject {
     
     /* -URLsForDirectory:inDomains: is analogous to NSSearchPathForDirectoriesInDomains(), but returns an array of NSURL instances for use with URL-taking APIs. This API is suitable when you need to search for a file or files which may live in one of a variety of locations in the domains specified.
      */
-    public func urlsForDirectory(_ directory: SearchPathDirectory, inDomains domainMask: SearchPathDomainMask) -> [URL] {
+    open func urlsForDirectory(_ directory: SearchPathDirectory, inDomains domainMask: SearchPathDomainMask) -> [URL] {
         NSUnimplemented()
     }
     
@@ -117,25 +117,25 @@ public class FileManager: NSObject {
      
         You may pass only one of the values from the NSSearchPathDomainMask enumeration, and you may not pass NSAllDomainsMask.
      */
-    public func urlForDirectory(_ directory: SearchPathDirectory, in domain: SearchPathDomainMask, appropriateFor url: URL?, create shouldCreate: Bool) throws -> URL {
+    open func urlForDirectory(_ directory: SearchPathDirectory, in domain: SearchPathDomainMask, appropriateFor url: URL?, create shouldCreate: Bool) throws -> URL {
         NSUnimplemented()
     }
     
     /* Sets 'outRelationship' to NSURLRelationshipContains if the directory at 'directoryURL' directly or indirectly contains the item at 'otherURL', meaning 'directoryURL' is found while enumerating parent URLs starting from 'otherURL'. Sets 'outRelationship' to NSURLRelationshipSame if 'directoryURL' and 'otherURL' locate the same item, meaning they have the same NSURLFileResourceIdentifierKey value. If 'directoryURL' is not a directory, or does not contain 'otherURL' and they do not locate the same file, then sets 'outRelationship' to NSURLRelationshipOther. If an error occurs, returns NO and sets 'error'.
      */
-    public func getRelationship(_ outRelationship: UnsafeMutablePointer<NSURLRelationship>, ofDirectoryAtURL directoryURL: URL, toItemAtURL otherURL: URL) throws {
+    open func getRelationship(_ outRelationship: UnsafeMutablePointer<NSURLRelationship>, ofDirectoryAtURL directoryURL: URL, toItemAtURL otherURL: URL) throws {
         NSUnimplemented()
     }
     
     /* Similar to -[NSFileManager getRelationship:ofDirectoryAtURL:toItemAtURL:error:], except that the directory is instead defined by an NSSearchPathDirectory and NSSearchPathDomainMask. Pass 0 for domainMask to instruct the method to automatically choose the domain appropriate for 'url'. For example, to discover if a file is contained by a Trash directory, call [fileManager getRelationship:&result ofDirectory:NSTrashDirectory inDomain:0 toItemAtURL:url error:&error].
      */
-    public func getRelationship(_ outRelationship: UnsafeMutablePointer<NSURLRelationship>, ofDirectory directory: SearchPathDirectory, in domainMask: SearchPathDomainMask, toItemAtURL url: URL) throws {
+    open func getRelationship(_ outRelationship: UnsafeMutablePointer<NSURLRelationship>, ofDirectory directory: SearchPathDirectory, in domainMask: SearchPathDomainMask, toItemAtURL url: URL) throws {
         NSUnimplemented()
     }
     
     /* createDirectoryAtURL:withIntermediateDirectories:attributes:error: creates a directory at the specified URL. If you pass 'NO' for withIntermediateDirectories, the directory must not exist at the time this call is made. Passing 'YES' for withIntermediateDirectories will create any necessary intermediate directories. This method returns YES if all directories specified in 'url' were created and attributes were set. Directories are created with attributes specified by the dictionary passed to 'attributes'. If no dictionary is supplied, directories are created according to the umask of the process. This method returns NO if a failure occurs at any stage of the operation. If an error parameter was provided, a presentable NSError will be returned by reference.
      */
-    public func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool, attributes: [String : AnyObject]? = [:]) throws {
+    open func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool, attributes: [String : AnyObject]? = [:]) throws {
         guard url.isFileURL else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileWriteUnsupportedSchemeError.rawValue, userInfo: [NSURLErrorKey : url])
         }
@@ -147,7 +147,7 @@ public class FileManager: NSObject {
     
     /* createSymbolicLinkAtURL:withDestinationURL:error: returns YES if the symbolic link that point at 'destURL' was able to be created at the location specified by 'url'. 'destURL' is always resolved against its base URL, if it has one. If 'destURL' has no base URL and it's 'relativePath' is indeed a relative path, then a relative symlink will be created. If this method returns NO, the link was unable to be created and an NSError will be returned by reference in the 'error' parameter. This method does not traverse a terminal symlink.
      */
-    public func createSymbolicLink(at url: URL, withDestinationURL destURL: URL) throws {
+    open func createSymbolicLink(at url: URL, withDestinationURL destURL: URL) throws {
         guard url.isFileURL else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileWriteUnsupportedSchemeError.rawValue, userInfo: [NSURLErrorKey : url])
         }
@@ -165,7 +165,7 @@ public class FileManager: NSObject {
     
     /* Instances of NSFileManager may now have delegates. Each instance has one delegate, and the delegate is not retained. In versions of Mac OS X prior to 10.5, the behavior of calling [[NSFileManager alloc] init] was undefined. In Mac OS X 10.5 "Leopard" and later, calling [[NSFileManager alloc] init] returns a new instance of an NSFileManager.
      */
-    public weak var delegate: NSFileManagerDelegate? {
+    open weak var delegate: NSFileManagerDelegate? {
         NSUnimplemented()
     }
     
@@ -173,7 +173,7 @@ public class FileManager: NSObject {
      
         This method replaces changeFileAttributes:atPath:.
      */
-    public func setAttributes(_ attributes: [String : AnyObject], ofItemAtPath path: String) throws {
+    open func setAttributes(_ attributes: [String : AnyObject], ofItemAtPath path: String) throws {
         for attribute in attributes.keys {
             switch attribute {
             case NSFilePosixPermissions:
@@ -198,7 +198,7 @@ public class FileManager: NSObject {
      
         This method replaces createDirectoryAtPath:attributes:
      */
-    public func createDirectory(atPath path: String, withIntermediateDirectories createIntermediates: Bool, attributes: [String : AnyObject]? = [:]) throws {
+    open func createDirectory(atPath path: String, withIntermediateDirectories createIntermediates: Bool, attributes: [String : AnyObject]? = [:]) throws {
         if createIntermediates {
             var isDir: ObjCBool = false
             if !fileExists(atPath: path, isDirectory: &isDir) {
@@ -238,7 +238,7 @@ public class FileManager: NSObject {
      
      - Returns: An array of String each of which identifies a file, directory, or symbolic link contained in `path`. The order of the files returned is undefined.
      */
-    public func contentsOfDirectory(atPath path: String) throws -> [String] {
+    open func contentsOfDirectory(atPath path: String) throws -> [String] {
         var contents : [String] = [String]()
         
         let dir = opendir(path)
@@ -277,7 +277,7 @@ public class FileManager: NSObject {
     
     - Returns: An array of NSString objects, each of which contains the path of an item in the directory specified by path. If path is a symbolic link, this method traverses the link. This method returns nil if it cannot retrieve the device of the linked-to file.
     */
-    public func subpathsOfDirectory(atPath path: String) throws -> [String] {
+    open func subpathsOfDirectory(atPath path: String) throws -> [String] {
         var contents : [String] = [String]()
         
         let dir = opendir(path)
@@ -328,7 +328,7 @@ public class FileManager: NSObject {
         This method replaces fileAttributesAtPath:traverseLink:.
      */
     /// - Experiment: Note that the return type of this function is different than on Darwin Foundation (Any instead of AnyObject). This is likely to change once we have a more complete story for bridging in place.
-    public func attributesOfItem(atPath path: String) throws -> [String : Any] {    
+    open func attributesOfItem(atPath path: String) throws -> [String : Any] {    
         var s = stat()
         guard lstat(path, &s) == 0 else {
             throw _NSErrorWithErrno(errno, reading: true, path: path)
@@ -394,7 +394,7 @@ public class FileManager: NSObject {
      
         This method replaces fileSystemAttributesAtPath:.
      */
-    public func attributesOfFileSystem(forPath path: String) throws -> [String : AnyObject] {
+    open func attributesOfFileSystem(forPath path: String) throws -> [String : AnyObject] {
         NSUnimplemented()
     }
     
@@ -402,7 +402,7 @@ public class FileManager: NSObject {
      
         This method replaces createSymbolicLinkAtPath:pathContent:
      */
-    public func createSymbolicLink(atPath path: String, withDestinationPath destPath: String) throws {
+    open func createSymbolicLink(atPath path: String, withDestinationPath destPath: String) throws {
         if symlink(destPath, path) == -1 {
             throw _NSErrorWithErrno(errno, reading: false, path: path)
         }
@@ -412,7 +412,7 @@ public class FileManager: NSObject {
      
         This method replaces pathContentOfSymbolicLinkAtPath:
      */
-    public func destinationOfSymbolicLink(atPath path: String) throws -> String {
+    open func destinationOfSymbolicLink(atPath path: String) throws -> String {
         let bufSize = Int(PATH_MAX + 1)
         var buf = [Int8](repeating: 0, count: bufSize)
         let len = readlink(path, &buf, bufSize)
@@ -423,11 +423,11 @@ public class FileManager: NSObject {
         return self.string(withFileSystemRepresentation: buf, length: len)
     }
     
-    public func copyItem(atPath srcPath: String, toPath dstPath: String) throws {
+    open func copyItem(atPath srcPath: String, toPath dstPath: String) throws {
         NSUnimplemented()
     }
     
-    public func moveItem(atPath srcPath: String, toPath dstPath: String) throws {
+    open func moveItem(atPath srcPath: String, toPath dstPath: String) throws {
         guard !self.fileExists(atPath: dstPath) else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileWriteFileExistsError.rawValue, userInfo: [NSFilePathErrorKey : NSString(dstPath)])
         }
@@ -441,7 +441,7 @@ public class FileManager: NSObject {
         }
     }
     
-    public func linkItem(atPath srcPath: String, toPath dstPath: String) throws {
+    open func linkItem(atPath srcPath: String, toPath dstPath: String) throws {
         var isDir = false
         if self.fileExists(atPath: srcPath, isDirectory: &isDir) {
             if !isDir {
@@ -456,7 +456,7 @@ public class FileManager: NSObject {
         }
     }
 
-    public func removeItem(atPath path: String) throws {
+    open func removeItem(atPath path: String) throws {
         if rmdir(path) == 0 {
             return
         } else if errno == ENOTEMPTY {
@@ -504,7 +504,7 @@ public class FileManager: NSObject {
         }
     }
     
-    public func copyItem(at srcURL: URL, to dstURL: URL) throws {
+    open func copyItem(at srcURL: URL, to dstURL: URL) throws {
         guard srcURL.isFileURL else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileWriteUnsupportedSchemeError.rawValue, userInfo: [NSURLErrorKey : srcURL])
         }
@@ -520,7 +520,7 @@ public class FileManager: NSObject {
         try copyItem(atPath: srcPath, toPath: dstPath)
     }
     
-    public func moveItem(at srcURL: URL, to dstURL: URL) throws {
+    open func moveItem(at srcURL: URL, to dstURL: URL) throws {
         guard srcURL.isFileURL else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileWriteUnsupportedSchemeError.rawValue, userInfo: [NSURLErrorKey : srcURL])
         }
@@ -536,7 +536,7 @@ public class FileManager: NSObject {
         try moveItem(atPath: srcPath, toPath: dstPath)
     }
     
-    public func linkItem(at srcURL: URL, to dstURL: URL) throws {
+    open func linkItem(at srcURL: URL, to dstURL: URL) throws {
         guard srcURL.isFileURL else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileWriteUnsupportedSchemeError.rawValue, userInfo: [NSURLErrorKey : srcURL])
         }
@@ -552,7 +552,7 @@ public class FileManager: NSObject {
         try linkItem(atPath: srcPath, toPath: dstPath)
     }
     
-    public func removeItem(at url: URL) throws {
+    open func removeItem(at url: URL) throws {
         guard url.isFileURL else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileWriteUnsupportedSchemeError.rawValue, userInfo: [NSURLErrorKey : url])
         }
@@ -564,7 +564,7 @@ public class FileManager: NSObject {
     
     /* Process working directory management. Despite the fact that these are instance methods on NSFileManager, these methods report and change (respectively) the working directory for the entire process. Developers are cautioned that doing so is fraught with peril.
      */
-    public var currentDirectoryPath: String {
+    open var currentDirectoryPath: String {
         let length = Int(PATH_MAX) + 1
         var buf = [Int8](repeating: 0, count: length)
         getcwd(&buf, length)
@@ -572,17 +572,17 @@ public class FileManager: NSObject {
         return result
     }
     
-    public func changeCurrentDirectoryPath(_ path: String) -> Bool {
+    open func changeCurrentDirectoryPath(_ path: String) -> Bool {
         return chdir(path) == 0
     }
     
     /* The following methods are of limited utility. Attempting to predicate behavior based on the current state of the filesystem or a particular file on the filesystem is encouraging odd behavior in the face of filesystem race conditions. It's far better to attempt an operation (like loading a file or creating a directory) and handle the error gracefully than it is to try to figure out ahead of time whether the operation will succeed.
      */
-    public func fileExists(atPath path: String) -> Bool {
+    open func fileExists(atPath path: String) -> Bool {
         return self.fileExists(atPath: path, isDirectory: nil)
     }
     
-    public func fileExists(atPath path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) -> Bool {
+    open func fileExists(atPath path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) -> Bool {
         var s = stat()
         if lstat(path, &s) >= 0 {
             if let isDirectory = isDirectory {
@@ -612,15 +612,15 @@ public class FileManager: NSObject {
         return true
     }
     
-    public func isReadableFile(atPath path: String) -> Bool {
+    open func isReadableFile(atPath path: String) -> Bool {
         return access(path, R_OK) == 0
     }
     
-    public func isWritableFile(atPath path: String) -> Bool {
+    open func isWritableFile(atPath path: String) -> Bool {
         return access(path, W_OK) == 0
     }
     
-    public func isExecutableFile(atPath path: String) -> Bool {
+    open func isExecutableFile(atPath path: String) -> Bool {
         return access(path, X_OK) == 0
     }
     
@@ -630,19 +630,19 @@ public class FileManager: NSObject {
     
     /* -contentsEqualAtPath:andPath: does not take into account data stored in the resource fork or filesystem extended attributes.
      */
-    public func contentsEqual(atPath path1: String, andPath path2: String) -> Bool {
+    open func contentsEqual(atPath path1: String, andPath path2: String) -> Bool {
         NSUnimplemented()
     }
     
     /* displayNameAtPath: returns an NSString suitable for presentation to the user. For directories which have localization information, this will return the appropriate localized string. This string is not suitable for passing to anything that must interact with the filesystem.
      */
-    public func displayName(atPath path: String) -> String {
+    open func displayName(atPath path: String) -> String {
         NSUnimplemented()
     }
     
     /* componentsToDisplayForPath: returns an NSArray of display names for the path provided. Localization will occur as in displayNameAtPath: above. This array cannot and should not be reassembled into an usable filesystem path for any kind of access.
      */
-    public func componentsToDisplay(forPath path: String) -> [String]? {
+    open func componentsToDisplay(forPath path: String) -> [String]? {
         NSUnimplemented()
     }
     
@@ -665,13 +665,13 @@ public class FileManager: NSObject {
     
     /* subpathsAtPath: returns an NSArray of all contents and subpaths recursively from the provided path. This may be very expensive to compute for deep filesystem hierarchies, and should probably be avoided.
      */
-    public func subpaths(atPath path: String) -> [String]? {
+    open func subpaths(atPath path: String) -> [String]? {
         NSUnimplemented()
     }
     
     /* These methods are provided here for compatibility. The corresponding methods on NSData which return NSErrors should be regarded as the primary method of creating a file from an NSData or retrieving the contents of a file as an NSData.
      */
-    public func contents(atPath path: String) -> Data? {
+    open func contents(atPath path: String) -> Data? {
         do {
             return try Data(contentsOf: URL(fileURLWithPath: path))
         } catch {
@@ -679,7 +679,7 @@ public class FileManager: NSObject {
         }
     }
     
-    public func createFile(atPath path: String, contents data: Data?, attributes attr: [String : AnyObject]? = [:]) -> Bool {
+    open func createFile(atPath path: String, contents data: Data?, attributes attr: [String : AnyObject]? = [:]) -> Bool {
         do {
             try (data ?? Data()).write(to: URL(fileURLWithPath: path), options: .dataWritingAtomic)
             return true
@@ -690,7 +690,7 @@ public class FileManager: NSObject {
     
     /* fileSystemRepresentationWithPath: returns an array of characters suitable for passing to lower-level POSIX style APIs. The string is provided in the representation most appropriate for the filesystem in question.
      */
-    public func fileSystemRepresentation(withPath path: String) -> UnsafePointer<Int8> {
+    open func fileSystemRepresentation(withPath path: String) -> UnsafePointer<Int8> {
         precondition(path != "", "Empty path argument")
         let len = CFStringGetMaximumSizeOfFileSystemRepresentation(path._cfObject)
         if len == kCFNotFound {
@@ -710,7 +710,7 @@ public class FileManager: NSObject {
     
     /* stringWithFileSystemRepresentation:length: returns an NSString created from an array of bytes that are in the filesystem representation.
      */
-    public func string(withFileSystemRepresentation str: UnsafePointer<Int8>, length len: Int) -> String {
+    open func string(withFileSystemRepresentation str: UnsafePointer<Int8>, length len: Int) -> String {
         return NSString(bytes: str, length: len, encoding: String.Encoding.utf8.rawValue)!._swiftObject
     }
     
@@ -724,7 +724,7 @@ public class FileManager: NSObject {
     
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    public func replaceItem(at originalItemURL: URL, withItemAt newItemURL: URL, backupItemName: String?, options: NSFileManagerItemReplacementOptions = []) throws {
+    open func replaceItem(at originalItemURL: URL, withItemAt newItemURL: URL, backupItemName: String?, options: NSFileManagerItemReplacementOptions = []) throws {
         NSUnimplemented()
     }
     
@@ -831,24 +831,24 @@ public protocol NSFileManagerDelegate : class {
 }
 
 extension FileManager {
-    public class DirectoryEnumerator : NSEnumerator {
+    open class DirectoryEnumerator : NSEnumerator {
         
         /* For NSDirectoryEnumerators created with -enumeratorAtPath:, the -fileAttributes and -directoryAttributes methods return an NSDictionary containing the keys listed below. For NSDirectoryEnumerators created with -enumeratorAtURL:includingPropertiesForKeys:options:errorHandler:, these two methods return nil.
          */
-        public var fileAttributes: [String : AnyObject]? {
+        open var fileAttributes: [String : AnyObject]? {
             NSRequiresConcreteImplementation()
         }
-        public var directoryAttributes: [String : AnyObject]? {
+        open var directoryAttributes: [String : AnyObject]? {
             NSRequiresConcreteImplementation()
         }
         
         /* This method returns the number of levels deep the current object is in the directory hierarchy being enumerated. The directory passed to -enumeratorAtURL:includingPropertiesForKeys:options:errorHandler: is considered to be level 0.
          */
-        public var level: Int {
+        open var level: Int {
             NSRequiresConcreteImplementation()
         }
         
-        public func skipDescendants() {
+        open func skipDescendants() {
             NSRequiresConcreteImplementation()
         }
     }

--- a/Foundation/NSFormatter.swift
+++ b/Foundation/NSFormatter.swift
@@ -43,7 +43,7 @@ extension Formatter {
     }
 }
 
-public class Formatter : NSObject, NSCopying, NSCoding {
+open class Formatter : NSObject, NSCopying, NSCoding {
     
     public override init() {
         
@@ -53,29 +53,29 @@ public class Formatter : NSObject, NSCopying, NSCoding {
         
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         return self
     }
     
-    public func string(for obj: AnyObject) -> String? {
+    open func string(for obj: AnyObject) -> String? {
         NSRequiresConcreteImplementation()
     }
     
-    public func editingString(for obj: AnyObject) -> String? {
+    open func editingString(for obj: AnyObject) -> String? {
         return string(for: obj)
     }
     
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    public func objectValue(_ string: String) throws -> AnyObject? {
+    open func objectValue(_ string: String) throws -> AnyObject? {
         NSRequiresConcreteImplementation()
     }
 }

--- a/Foundation/NSHTTPCookie.swift
+++ b/Foundation/NSHTTPCookie.swift
@@ -53,7 +53,7 @@ public let NSHTTPCookiePort: String = "Port"
 /// an immutable object initialized from a dictionary that contains
 /// the various cookie attributes. It has accessors to get the various
 /// attributes of a cookie.
-public class HTTPCookie : NSObject {
+open class HTTPCookie : NSObject {
 
     let _comment: String?
     let _commentURL: URL?
@@ -317,7 +317,7 @@ public class HTTPCookie : NSObject {
     /// - Parameter cookies: The cookies to turn into request headers.
     /// - Returns: A dictionary where the keys are header field names, and the values
     /// are the corresponding header field values.
-    public class func requestHeaderFields(with cookies: [HTTPCookie]) -> [String : String] {
+    open class func requestHeaderFields(with cookies: [HTTPCookie]) -> [String : String] {
         var cookieString = cookies.reduce("") { (sum, next) -> String in
             return sum + "\(next._name)=\(next._value); "
         }
@@ -336,7 +336,7 @@ public class HTTPCookie : NSObject {
     /// - Parameter headerFields: The response header fields to check for cookies.
     /// - Parameter URL: The URL that the cookies came from - relevant to how the cookies are interpeted.
     /// - Returns: An array of NSHTTPCookie objects
-    public class func cookies(withResponseHeaderFields headerFields: [String : String], forURL url: URL) -> [HTTPCookie] {
+    open class func cookies(withResponseHeaderFields headerFields: [String : String], forURL url: URL) -> [HTTPCookie] {
 
         //HTTP Cookie parsing based on RFC 6265: https://tools.ietf.org/html/rfc6265
         //Though RFC6265 suggests that multiple cookies cannot be folded into a single Set-Cookie field, this is
@@ -440,7 +440,7 @@ public class HTTPCookie : NSObject {
     ///
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    public var properties: [String : Any]? {
+    open var properties: [String : Any]? {
         return _properties
     }
     
@@ -448,17 +448,17 @@ public class HTTPCookie : NSObject {
     ///
     /// Version 0 maps to "old-style" Netscape cookies.
     /// Version 1 maps to RFC2965 cookies. There may be future versions.
-    public var version: Int {
+    open var version: Int {
         return _version
     }
     
     /// The name of the receiver.
-    public var name: String {
+    open var name: String {
         return _name
     }
     
     /// The value of the receiver.
-    public var value: String {
+    open var value: String {
         return _value
     }
     
@@ -467,7 +467,7 @@ public class HTTPCookie : NSObject {
     /// The expires date is the date when the cookie should be
     /// deleted. The result will be nil if there is no specific expires
     /// date. This will be the case only for *session-only* cookies.
-    /*@NSCopying*/ public var expiresDate: Date? {
+    /*@NSCopying*/ open var expiresDate: Date? {
         return _expiresDate
     }
    
@@ -476,7 +476,7 @@ public class HTTPCookie : NSObject {
     /// `true` if this receiver should be discarded at the end of the
     /// session (regardless of expiration date), `false` if receiver need not
     /// be discarded at the end of the session.
-    public var isSessionOnly: Bool {
+    open var isSessionOnly: Bool {
         return _sessionOnly
     }
     
@@ -486,7 +486,7 @@ public class HTTPCookie : NSObject {
     /// should be sent. A domain with a leading dot means the cookie
     /// should be sent to subdomains as well, assuming certain other
     /// restrictions are valid. See RFC 2965 for more detail.
-    public var domain: String {
+    open var domain: String {
         return _domain
     }
     
@@ -495,7 +495,7 @@ public class HTTPCookie : NSObject {
     /// This value specifies the URL path under the cookie's
     /// domain for which this cookie should be sent. The cookie will also
     /// be sent for children of that path, so `"/"` is the most general.
-    public var path: String {
+    open var path: String {
         return _path
     }
    
@@ -505,7 +505,7 @@ public class HTTPCookie : NSObject {
     /// Cookies marked as such must only be sent via an encrypted connection to
     /// trusted servers (i.e. via SSL or TLS), and should not be delievered to any
     /// javascript applications to prevent cross-site scripting vulnerabilities. 
-    public var isSecure: Bool {
+    open var isSecure: Bool {
         return _secure
     }
     
@@ -516,7 +516,7 @@ public class HTTPCookie : NSObject {
     /// for URL's that match both the path and domain of the respective Cookies.
     /// Specifically these cookies should not be delivered to any javascript
     /// applications to prevent cross-site scripting vulnerabilities.
-    public var isHTTPOnly: Bool {
+    open var isHTTPOnly: Bool {
         return _HTTPOnly
     }
     
@@ -525,7 +525,7 @@ public class HTTPCookie : NSObject {
     /// This value specifies a string which is suitable for
     /// presentation to the user explaining the contents and purpose of this
     /// cookie. It may be nil.
-    public var comment: String? {
+    open var comment: String? {
         return _comment
     }
     
@@ -534,7 +534,7 @@ public class HTTPCookie : NSObject {
     /// This value specifies a URL which is suitable for
     /// presentation to the user as a link for further information about
     /// this cookie. It may be nil.
-    /*@NSCopying*/ public var commentURL: URL? {
+    /*@NSCopying*/ open var commentURL: URL? {
         return _commentURL
     }
     
@@ -546,7 +546,7 @@ public class HTTPCookie : NSObject {
     ///
     /// The array may be nil, in which case this cookie can be sent to any
     /// port.
-    public var portList: [NSNumber]? {
+    open var portList: [NSNumber]? {
         return _portList
     }
 }

--- a/Foundation/NSHTTPCookieStorage.swift
+++ b/Foundation/NSHTTPCookieStorage.swift
@@ -34,7 +34,7 @@ extension HTTPCookie {
     set of cookies.  It also has convenience methods to parse and
     generate cookie-related HTTP header fields.
 */
-public class HTTPCookieStorage: NSObject {
+open class HTTPCookieStorage: NSObject {
     
     public override init() { NSUnimplemented() }
     
@@ -66,7 +66,7 @@ public class HTTPCookieStorage: NSObject {
         @discussion The cookie will override an existing cookie with the
         same name, domain and path, if any.
     */
-    public func setCookie(_ cookie: HTTPCookie) { NSUnimplemented() }
+    open func setCookie(_ cookie: HTTPCookie) { NSUnimplemented() }
     
     /*!
         @method deleteCookie:
@@ -78,7 +78,7 @@ public class HTTPCookieStorage: NSObject {
      @method removeCookiesSince:
      @abstract Delete all cookies from the cookie storage since the provided date.
      */
-    public func removeCookiesSinceDate(_ date: Date) { NSUnimplemented() }
+    open func removeCookiesSinceDate(_ date: Date) { NSUnimplemented() }
     
     /*!
         @method cookiesForURL:
@@ -90,7 +90,7 @@ public class HTTPCookieStorage: NSObject {
         <tt>+[NSCookie requestHeaderFieldsWithCookies:]</tt> to turn this array
         into a set of header fields to add to a request.
     */
-    public func cookiesForURL(_ url: URL) -> [HTTPCookie]? { NSUnimplemented() }
+    open func cookiesForURL(_ url: URL) -> [HTTPCookie]? { NSUnimplemented() }
     
     /*!
         @method setCookies:forURL:mainDocumentURL:
@@ -109,14 +109,14 @@ public class HTTPCookieStorage: NSObject {
         dictionary and then use this method to store the resulting cookies
         in accordance with policy settings.
     */
-    public func setCookies(_ cookies: [HTTPCookie], forURL url: URL?, mainDocumentURL: URL?) { NSUnimplemented() }
+    open func setCookies(_ cookies: [HTTPCookie], forURL url: URL?, mainDocumentURL: URL?) { NSUnimplemented() }
     
     /*!
         @method cookieAcceptPolicy
         @abstract The cookie accept policy preference of the
         receiver.
     */
-    public var cookieAcceptPolicy: HTTPCookie.AcceptPolicy
+    open var cookieAcceptPolicy: HTTPCookie.AcceptPolicy
     
     /*!
       @method sortedCookiesUsingDescriptors:
@@ -124,7 +124,7 @@ public class HTTPCookieStorage: NSObject {
       @param sortOrder an array of NSSortDescriptors which represent the preferred sort order of the resulting array.
       @discussion proper sorting of cookies may require extensive string conversion, which can be avoided by allowing the system to perform the sorting.  This API is to be preferred over the more generic -[NSHTTPCookieStorage cookies] API, if sorting is going to be performed.
     */
-    public func sortedCookiesUsingDescriptors(_ sortOrder: [SortDescriptor]) -> [HTTPCookie] { NSUnimplemented() }
+    open func sortedCookiesUsingDescriptors(_ sortOrder: [SortDescriptor]) -> [HTTPCookie] { NSUnimplemented() }
 }
 
 /*!

--- a/Foundation/NSHost.swift
+++ b/Foundation/NSHost.swift
@@ -16,7 +16,7 @@ import Glibc
 
 import CoreFoundation
 
-public class Host: NSObject {
+open class Host: NSObject {
     enum ResolveType {
         case name
         case address
@@ -35,7 +35,7 @@ public class Host: NSObject {
     
     static internal let current = Host(nil, .current)
     
-    public class func currentHost() -> Host {
+    open class func currentHost() -> Host {
         return Host.current
     }
     
@@ -47,7 +47,7 @@ public class Host: NSObject {
         self.init(address, .address)
     }
     
-    public func isEqual(to aHost: Host) -> Bool {
+    open func isEqual(to aHost: Host) -> Bool {
         return false
     }
     
@@ -110,25 +110,25 @@ public class Host: NSObject {
 
     }
     
-    public var name: String? {
+    open var name: String? {
         return names.first
     }
     
-    public var names: [String] {
+    open var names: [String] {
         _resolve()
         return _names
     }
     
-    public var address: String? {
+    open var address: String? {
         return addresses.first
     }
     
-    public var addresses: [String] {
+    open var addresses: [String] {
         _resolve()
         return _addresses
     }
     
-    public var localizedName: String? {
+    open var localizedName: String? {
         return nil
     }
 }

--- a/Foundation/NSIndexPath.swift
+++ b/Foundation/NSIndexPath.swift
@@ -8,7 +8,7 @@
 //
 
 
-public class NSIndexPath: NSObject, NSCopying, NSSecureCoding {
+open class NSIndexPath: NSObject, NSCopying, NSSecureCoding {
     
     internal var _indexes : [Int]
     override public init() {
@@ -22,16 +22,16 @@ public class NSIndexPath: NSObject, NSCopying, NSSecureCoding {
         _indexes = indexes
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject { NSUnimplemented() }
+    open func copy(with zone: NSZone? = nil) -> AnyObject { NSUnimplemented() }
     public convenience init(index: Int) {
         self.init(indexes: [index])
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     
@@ -41,10 +41,10 @@ public class NSIndexPath: NSObject, NSCopying, NSSecureCoding {
     
     public static func supportsSecureCoding() -> Bool { return true }
     
-    public func adding(_ index: Int) -> IndexPath {
+    open func adding(_ index: Int) -> IndexPath {
         return IndexPath(indexes: _indexes + [index])
     }
-    public func removingLastIndex() -> IndexPath {
+    open func removingLastIndex() -> IndexPath {
         if _indexes.count <= 1 {
             return IndexPath(indexes: [])
         } else {
@@ -52,10 +52,10 @@ public class NSIndexPath: NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public func index(atPosition position: Int) -> Int {
+    open func index(atPosition position: Int) -> Int {
         return _indexes[position]
     }
-    public var length: Int  {
+    open var length: Int  {
         return _indexes.count
     }
     
@@ -66,7 +66,7 @@ public class NSIndexPath: NSObject, NSCopying, NSSecureCoding {
      @discussion
         It is the developer’s responsibility to allocate the memory for the C array.
      */
-    public func getIndexes(_ indexes: UnsafeMutablePointer<Int>, range positionRange: NSRange) {
+    open func getIndexes(_ indexes: UnsafeMutablePointer<Int>, range positionRange: NSRange) {
         for (pos, idx) in _indexes[positionRange.location ..< NSMaxRange(positionRange)].enumerated() {
             indexes.advanced(by: pos).pointee = idx
         }
@@ -74,7 +74,7 @@ public class NSIndexPath: NSObject, NSCopying, NSSecureCoding {
     
     // comparison support
     // sorting an array of indexPaths using this comparison results in an array representing nodes in depth-first traversal order
-    public func compare(_ otherObject: IndexPath) -> ComparisonResult {
+    open func compare(_ otherObject: IndexPath) -> ComparisonResult {
         let thisLength = length
         let otherLength = otherObject.count
         let minLength = thisLength >= otherLength ? otherLength : thisLength

--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -56,7 +56,7 @@ internal func __NSIndexSetIndexOfRangeContainingIndex(_ indexSet: NSIndexSet, _ 
     return UInt(bitPattern: NSNotFound)
 }
 
-public class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
+open class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     // all instance variables are private
     
     internal var _ranges = [NSRange]()
@@ -74,17 +74,17 @@ public class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         _count = indexSet.count
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject  { NSUnimplemented() }
+    open func copy(with zone: NSZone? = nil) -> AnyObject  { NSUnimplemented() }
     
-    public override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> AnyObject {
         return mutableCopy(with: nil)
     }
     
-    public func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
         let set = NSMutableIndexSet()
         enumerateRanges([]) { i, _ in
             set.add(in: i)
@@ -93,7 +93,7 @@ public class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     }
     public static func supportsSecureCoding() -> Bool { return true }
     public required init?(coder aDecoder: NSCoder)  { NSUnimplemented() }
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     
@@ -101,7 +101,7 @@ public class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         self.init(indexesIn: NSMakeRange(value, 1))
     }
     
-    public func isEqual(to indexSet: IndexSet) -> Bool {
+    open func isEqual(to indexSet: IndexSet) -> Bool {
         
         let otherRanges = indexSet.rangeView().map { NSRange(location: $0.lowerBound, length: $0.upperBound - $0.lowerBound) }
         if _ranges.count != otherRanges.count {
@@ -115,16 +115,16 @@ public class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         return true
     }
     
-    public var count: Int {
+    open var count: Int {
         return _count
     }
     
     /* The following six methods will return NSNotFound if there is no index in the set satisfying the query. 
     */
-    public var firstIndex: Int {
+    open var firstIndex: Int {
         return _ranges.first?.location ?? NSNotFound
     }
-    public var lastIndex: Int {
+    open var lastIndex: Int {
         guard _ranges.count > 0 else {
             return NSNotFound
         }
@@ -224,22 +224,22 @@ public class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         return nil
     }
     
-    public func indexGreaterThanIndex(_ value: Int) -> Int {
+    open func indexGreaterThanIndex(_ value: Int) -> Int {
         return _indexClosestToIndex(value, equalAllowed: false, following: true) ?? NSNotFound
     }
-    public func indexLessThanIndex(_ value: Int) -> Int {
+    open func indexLessThanIndex(_ value: Int) -> Int {
         return _indexClosestToIndex(value, equalAllowed: false, following: false) ?? NSNotFound
     }
-    public func indexGreaterThanOrEqual(to value: Int) -> Int {
+    open func indexGreaterThanOrEqual(to value: Int) -> Int {
         return _indexClosestToIndex(value, equalAllowed: true, following: true) ?? NSNotFound
     }
-    public func indexLessThanOrEqual(to value: Int) -> Int {
+    open func indexLessThanOrEqual(to value: Int) -> Int {
         return _indexClosestToIndex(value, equalAllowed: true, following: false) ?? NSNotFound
     }
     
     /* Fills up to bufferSize indexes in the specified range into the buffer and returns the number of indexes actually placed in the buffer; also modifies the optional range passed in by pointer to be "positioned" after the last index filled into the buffer.Example: if the index set contains the indexes 0, 2, 4, ..., 98, 100, for a buffer of size 10 and the range (20, 80) the buffer would contain 20, 22, ..., 38 and the range would be modified to (40, 60).
     */
-    public func getIndexes(_ indexBuffer: UnsafeMutablePointer<Int>, maxCount bufferSize: Int, inIndexRange range: NSRangePointer?) -> Int {
+    open func getIndexes(_ indexBuffer: UnsafeMutablePointer<Int>, maxCount bufferSize: Int, inIndexRange range: NSRangePointer?) -> Int {
         let minIndex : Int
         let maxIndex : Int
         if let initialRange = range {
@@ -291,7 +291,7 @@ public class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         }
     }
     
-    public func countOfIndexes(in range: NSRange) -> Int {
+    open func countOfIndexes(in range: NSRange) -> Int {
         guard _count > 0 && range.length > 0 else {
             return 0
         }
@@ -325,10 +325,10 @@ public class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         }
     }
     
-    public func contains(_ value: Int) -> Bool {
+    open func contains(_ value: Int) -> Bool {
         return _indexOfRangeContainingIndex(value) != nil
     }
-    public func contains(in range: NSRange) -> Bool {
+    open func contains(in range: NSRange) -> Bool {
         guard range.length > 0 else {
             return false
         }
@@ -338,7 +338,7 @@ public class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
             return false
         }
     }
-    public func contains(_ indexSet: IndexSet) -> Bool {
+    open func contains(_ indexSet: IndexSet) -> Bool {
         var result = true
         enumerateRanges([]) { range, stop in
             if !self.contains(in: range) {
@@ -349,7 +349,7 @@ public class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         return result
     }
     
-    public func intersects(in range: NSRange) -> Bool {
+    open func intersects(in range: NSRange) -> Bool {
         guard range.length > 0 else {
             return false
         }
@@ -425,23 +425,23 @@ public class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         let _ = _enumerateWithOptions(opts, range: range, paramType: Int.self, returnType: Void.self, block: block)
     }
 
-    public func index(passingTest predicate: @noescape (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
+    open func index(passingTest predicate: @noescape (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
         return index([], passingTest: predicate)
     }
-    public func index(_ opts: EnumerationOptions = [], passingTest predicate: @noescape (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
+    open func index(_ opts: EnumerationOptions = [], passingTest predicate: @noescape (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
         return _enumerateWithOptions(opts, range: NSMakeRange(0, Int.max), paramType: Int.self, returnType: Bool.self, block: predicate) ?? NSNotFound
     }
-    public func index(in range: NSRange, options opts: EnumerationOptions = [], passingTest predicate: @noescape (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
+    open func index(in range: NSRange, options opts: EnumerationOptions = [], passingTest predicate: @noescape (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
         return _enumerateWithOptions(opts, range: range, paramType: Int.self, returnType: Bool.self, block: predicate) ?? NSNotFound
     }
     
-    public func indexes(passingTest predicate: @noescape (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
+    open func indexes(passingTest predicate: @noescape (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
         return indexes(in: NSMakeRange(0, Int.max), options: [], passingTest: predicate)
     }
-    public func indexes(_ opts: EnumerationOptions = [], passingTest predicate: @noescape (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
+    open func indexes(_ opts: EnumerationOptions = [], passingTest predicate: @noescape (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
         return indexes(in: NSMakeRange(0, Int.max), options: opts, passingTest: predicate)
     }
-    public func indexes(in range: NSRange, options opts: EnumerationOptions = [], passingTest predicate: @noescape (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
+    open func indexes(in range: NSRange, options opts: EnumerationOptions = [], passingTest predicate: @noescape (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
         var result = IndexSet()
         let _ = _enumerateWithOptions(opts, range: range, paramType: Int.self, returnType: Void.self) { idx, stop in
             if predicate(idx, stop) {
@@ -499,26 +499,26 @@ extension NSIndexSet: Sequence {
 
 }
 
-public class NSMutableIndexSet : NSIndexSet {
+open class NSMutableIndexSet : NSIndexSet {
     
-    public func add(_ indexSet: IndexSet) {
+    open func add(_ indexSet: IndexSet) {
         indexSet.rangeView().forEach { add(in: NSRange(location: $0.lowerBound, length: $0.upperBound - $0.lowerBound)) }
     }
     
-    public func remove(_ indexSet: IndexSet) {
+    open func remove(_ indexSet: IndexSet) {
         indexSet.rangeView().forEach { remove(in: NSRange(location: $0.lowerBound, length: $0.upperBound - $0.lowerBound)) }
     }
     
-    public func removeAllIndexes() {
+    open func removeAllIndexes() {
         _ranges = []
         _count = 0
     }
     
-    public func add(_ value: Int) {
+    open func add(_ value: Int) {
         add(in: NSMakeRange(value, 1))
     }
     
-    public func remove(_ value: Int) {
+    open func remove(_ value: Int) {
         remove(in: NSMakeRange(value, 1))
     }
     
@@ -558,7 +558,7 @@ public class NSMutableIndexSet : NSIndexSet {
         }
     }
     
-    public func add(in range: NSRange) {
+    open func add(in range: NSRange) {
         guard range.length > 0 else {
             return
         }
@@ -600,7 +600,7 @@ public class NSMutableIndexSet : NSIndexSet {
         }
     }
     
-    public func remove(in range: NSRange) {
+    open func remove(in range: NSRange) {
         guard range.length > 0 else {
             return
         }
@@ -640,6 +640,6 @@ public class NSMutableIndexSet : NSIndexSet {
     
     /* For a positive delta, shifts the indexes in [index, INT_MAX] to the right, thereby inserting an "empty space" [index, delta], for a negative delta, shifts the indexes in [index, INT_MAX] to the left, thereby deleting the indexes in the range [index - delta, delta].
     */
-    public func shiftIndexesStarting(at index: Int, by delta: Int) { NSUnimplemented() }
+    open func shiftIndexesStarting(at index: Int, by delta: Int) { NSUnimplemented() }
 }
 

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -42,7 +42,7 @@ extension JSONSerialization {
     - `NSNumber`s are not NaN or infinity
 */
 
-public class JSONSerialization : NSObject {
+open class JSONSerialization : NSObject {
     
     /* Determines whether the given object can be converted to JSON.
        Other rules may apply. Calling this method or attempting a conversion are the definitive ways
@@ -50,7 +50,7 @@ public class JSONSerialization : NSObject {
        - parameter obj: The object to test.
        - returns: `true` if `obj` can be converted to JSON, otherwise `false`.
      */
-    public class func isValidJSONObject(_ obj: Any) -> Bool {
+    open class func isValidJSONObject(_ obj: Any) -> Bool {
         // TODO: - revisit this once bridging story gets fully figured out
         func isValidJSONObjectInternal(_ obj: Any) -> Bool {
             // object is Swift.String or NSNull
@@ -98,7 +98,7 @@ public class JSONSerialization : NSObject {
     
     /* Generate JSON data from a Foundation object. If the object will not produce valid JSON then an exception will be thrown. Setting the NSJSONWritingPrettyPrinted option will generate JSON with whitespace designed to make the output more readable. If that option is not set, the most compact possible JSON will be generated. If an error occurs, the error parameter will be set and the return value will be nil. The resulting data is a encoded in UTF-8.
      */
-    public class func data(withJSONObject obj: AnyObject, options opt: WritingOptions = []) throws -> Data {
+    open class func data(withJSONObject obj: AnyObject, options opt: WritingOptions = []) throws -> Data {
         guard obj is NSArray || obj is NSDictionary else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.PropertyListReadCorruptError.rawValue, userInfo: [
                 "NSDebugDescription" : "Top-level object was not NSArray or NSDictionary"
@@ -126,7 +126,7 @@ public class JSONSerialization : NSObject {
        The data must be in one of the 5 supported encodings listed in the JSON specification: UTF-8, UTF-16LE, UTF-16BE, UTF-32LE, UTF-32BE. The data may or may not have a BOM. The most efficient encoding to use for parsing is UTF-8, so if you have a choice in encoding the data passed to this method, use UTF-8.
      */
     /// - Experiment: Note that the return type of this function is different than on Darwin Foundation (Any instead of AnyObject). This is likely to change once we have a more complete story for bridging in place.
-    public class func jsonObject(with data: Data, options opt: ReadingOptions = []) throws -> Any {
+    open class func jsonObject(with data: Data, options opt: ReadingOptions = []) throws -> Any {
         return try data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> Any in
             let encoding: String.Encoding
             let buffer: UnsafeBufferPointer<UInt8>
@@ -159,7 +159,7 @@ public class JSONSerialization : NSObject {
     
     /* Write JSON data into a stream. The stream should be opened and configured. The return value is the number of bytes written to the stream, or 0 on error. All other behavior of this method is the same as the dataWithJSONObject:options:error: method.
      */
-    public class func writeJSONObject(_ obj: AnyObject, toStream stream: NSOutputStream, options opt: WritingOptions) throws -> Int {
+    open class func writeJSONObject(_ obj: AnyObject, toStream stream: NSOutputStream, options opt: WritingOptions) throws -> Int {
             let jsonData = try data(withJSONObject: obj, options: opt)
             let jsonNSData = jsonData.bridge()
             let bytePtr = jsonNSData.bytes.bindMemory(to: UInt8.self, capacity: jsonNSData.length)
@@ -168,7 +168,7 @@ public class JSONSerialization : NSObject {
     
     /* Create a JSON object from JSON data stream. The stream should be opened and configured. All other behavior of this method is the same as the JSONObjectWithData:options:error: method.
      */
-    public class func jsonObject(with stream: InputStream, options opt: ReadingOptions = []) throws -> AnyObject {
+    open class func jsonObject(with stream: InputStream, options opt: ReadingOptions = []) throws -> AnyObject {
         NSUnimplemented()
     }
 }

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -79,7 +79,7 @@ internal func ==(x : NSUniqueObject, y : NSUniqueObject) -> Bool {
     return x._equality(y._backing)
 }
 
-public class NSKeyedArchiver : NSCoder {
+open class NSKeyedArchiver : NSCoder {
     struct ArchiverFlags : OptionSet {
         let rawValue : UInt
         
@@ -112,8 +112,8 @@ public class NSKeyedArchiver : NSCoder {
     private var _classes : Dictionary<String, CFKeyedArchiverUID> = [:]
     private var _cache : Array<CFKeyedArchiverUID> = []
 
-    public weak var delegate: NSKeyedArchiverDelegate?
-    public var outputFormat = PropertyListSerialization.PropertyListFormat.binary {
+    open weak var delegate: NSKeyedArchiverDelegate?
+    open var outputFormat = PropertyListSerialization.PropertyListFormat.binary {
         willSet {
             if outputFormat != PropertyListSerialization.PropertyListFormat.xml &&
                 outputFormat != PropertyListSerialization.PropertyListFormat.binary {
@@ -122,7 +122,7 @@ public class NSKeyedArchiver : NSCoder {
         }
     }
     
-    public class func archivedData(withRootObject rootObject: AnyObject) -> Data {
+    open class func archivedData(withRootObject rootObject: AnyObject) -> Data {
         let data = NSMutableData()
         let keyedArchiver = NSKeyedArchiver(forWritingWith: data)
         
@@ -132,7 +132,7 @@ public class NSKeyedArchiver : NSCoder {
         return data._swiftObject
     }
     
-    public class func archiveRootObject(_ rootObject: AnyObject, toFile path: String) -> Bool {
+    open class func archiveRootObject(_ rootObject: AnyObject, toFile path: String) -> Bool {
         var fd : Int32 = -1
         var auxFilePath : String
         var finishedEncoding : Bool = false
@@ -203,7 +203,7 @@ public class NSKeyedArchiver : NSCoder {
         return __CFBinaryPlistWriteToStream(plist, self._stream) > 0
     }
 
-    public func finishEncoding() {
+    open func finishEncoding() {
         if _flags.contains(ArchiverFlags.finishedEncoding) {
             return
         }
@@ -237,23 +237,23 @@ public class NSKeyedArchiver : NSCoder {
         }
     }
 
-    public class func setClassName(_ codedName: String?, for cls: AnyClass) {
+    open class func setClassName(_ codedName: String?, for cls: AnyClass) {
         let clsName = String(describing: type(of: cls))
         _classNameMapLock.synchronized {
             _classNameMap[clsName] = codedName
         }
     }
     
-    public func setClassName(_ codedName: String?, for cls: AnyClass) {
+    open func setClassName(_ codedName: String?, for cls: AnyClass) {
         let clsName = String(describing: type(of: cls))
         _classNameMap[clsName] = codedName
     }
     
-    public override var systemVersion: UInt32 {
+    open override var systemVersion: UInt32 {
         return NSKeyedArchiverSystemVersion
     }
 
-    public override var allowsKeyedCoding: Bool {
+    open override var allowsKeyedCoding: Bool {
         return true
     }
     
@@ -615,37 +615,37 @@ public class NSKeyedArchiver : NSCoder {
         }
     }
     
-    public override func encode(_ object: AnyObject?) {
+    open override func encode(_ object: AnyObject?) {
         _encodeObject(object, forKey: nil)
     }
     
-    public override func encodeConditionalObject(_ object: AnyObject?) {
+    open override func encodeConditionalObject(_ object: AnyObject?) {
         _encodeObject(object, forKey: nil, conditional: true)
     }
 
-    public override func encode(_ objv: AnyObject?, forKey key: String) {
+    open override func encode(_ objv: AnyObject?, forKey key: String) {
         _encodeObject(objv, forKey: key, conditional: false)
     }
     
-    public override func encodeConditionalObject(_ objv: AnyObject?, forKey key: String) {
+    open override func encodeConditionalObject(_ objv: AnyObject?, forKey key: String) {
         _encodeObject(objv, forKey: key, conditional: true)
     }
     
-    public override func encodePropertyList(_ aPropertyList: AnyObject) {
+    open override func encodePropertyList(_ aPropertyList: AnyObject) {
         if !NSPropertyListClasses.contains(where: { $0 == type(of: aPropertyList) }) {
             fatalError("Cannot encode non-property list type \(type(of: aPropertyList)) as property list")
         }
         encode(aPropertyList)
     }
     
-    public func encodePropertyList(_ aPropertyList: AnyObject, forKey key: String) {
+    open func encodePropertyList(_ aPropertyList: AnyObject, forKey key: String) {
         if !NSPropertyListClasses.contains(where: { $0 == type(of: aPropertyList) }) {
             fatalError("Cannot encode non-property list type \(type(of: aPropertyList)) as property list")
         }
         encode(aPropertyList, forKey: key)
     }
 
-    public func _encodePropertyList(_ aPropertyList: AnyObject, forKey key: String? = nil) {
+    open func _encodePropertyList(_ aPropertyList: AnyObject, forKey key: String? = nil) {
         let _ = _validateStillEncoding()
         _setObjectInCurrentEncodingContext(aPropertyList, forKey: key)
     }
@@ -710,7 +710,7 @@ public class NSKeyedArchiver : NSCoder {
         }
     }
     
-    public override func encodeValue(ofObjCType typep: UnsafePointer<Int8>, at addr: UnsafeRawPointer) {
+    open override func encodeValue(ofObjCType typep: UnsafePointer<Int8>, at addr: UnsafeRawPointer) {
         guard let type = _NSSimpleObjCType(UInt8(typep.pointee)) else {
             let spec = String(typep.pointee)
             fatalError("NSKeyedArchiver.encodeValueOfObjCType: unsupported type encoding spec '\(spec)'")
@@ -738,37 +738,37 @@ public class NSKeyedArchiver : NSCoder {
         }
     }
 
-    public override func encode(_ boolv: Bool, forKey key: String) {
+    open override func encode(_ boolv: Bool, forKey key: String) {
         _encodeValue(NSNumber(value: boolv), forKey: key)
     }
     
 
-    public override func encode(_ intv: Int32, forKey key: String) {
+    open override func encode(_ intv: Int32, forKey key: String) {
         _encodeValue(NSNumber(value: intv), forKey: key)
     }
     
-    public override func encode(_ intv: Int64, forKey key: String) {
+    open override func encode(_ intv: Int64, forKey key: String) {
         _encodeValue(NSNumber(value: intv), forKey: key)
     }
     
-    public override func encode(_ realv: Float, forKey key: String) {
+    open override func encode(_ realv: Float, forKey key: String) {
         _encodeValue(NSNumber(value: realv), forKey: key)
     }
     
-    public override func encode(_ realv: Double, forKey key: String) {
+    open override func encode(_ realv: Double, forKey key: String) {
         _encodeValue(NSNumber(value: realv), forKey: key)
     }
     
-    public override func encode(_ intv: Int, forKey key: String) {
+    open override func encode(_ intv: Int, forKey key: String) {
         _encodeValue(NSNumber(value: intv), forKey: key)
     }
 
-    public override func encodeDataObject(_ data: Data) {
+    open override func encodeDataObject(_ data: Data) {
         // this encodes as a reference to an NSData object rather than encoding inline
         encode(data._nsObject)
     }
     
-    public override func encodeBytes(_ bytesp: UnsafePointer<UInt8>?, length lenv: Int, forKey key: String) {
+    open override func encodeBytes(_ bytesp: UnsafePointer<UInt8>?, length lenv: Int, forKey key: String) {
         // this encodes the data inline
         let data = NSData(bytes: bytesp, length: lenv)
         _encodeValue(data, forKey: key)
@@ -800,7 +800,7 @@ public class NSKeyedArchiver : NSCoder {
         which does not NSSecureCoding is archived). Note that the getter is on the superclass,
         NSCoder. See NSCoder for more information about secure coding.
      */
-    public override var requiresSecureCoding: Bool {
+    open override var requiresSecureCoding: Bool {
         get {
             return _flags.contains(ArchiverFlags.requiresSecureCoding)
         }
@@ -815,7 +815,7 @@ public class NSKeyedArchiver : NSCoder {
     
     // During encoding, the coder first checks with the coder's
     // own table, then if there was no mapping there, the class's.
-    public class func classNameForClass(_ cls: AnyClass) -> String? {
+    open class func classNameForClass(_ cls: AnyClass) -> String? {
         let clsName = String(reflecting: cls)
         var mappedClass : String?
         
@@ -826,7 +826,7 @@ public class NSKeyedArchiver : NSCoder {
         return mappedClass
     }
     
-    public func classNameForClass(_ cls: AnyClass) -> String? {
+    open func classNameForClass(_ cls: AnyClass) -> String? {
         let clsName = String(reflecting: cls)
         return _classNameMap[clsName]
     }

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -9,7 +9,7 @@
 
 import CoreFoundation
 
-public class NSKeyedUnarchiver : NSCoder {
+open class NSKeyedUnarchiver : NSCoder {
     struct UnarchiverFlags : OptionSet {
         let rawValue : UInt
         
@@ -34,7 +34,7 @@ public class NSKeyedUnarchiver : NSCoder {
     private static var _classNameMap : Dictionary<String, AnyClass> = [:]
     private static var _classNameMapLock = Lock()
     
-    public weak var delegate: NSKeyedUnarchiverDelegate?
+    open weak var delegate: NSKeyedUnarchiverDelegate?
     
     private enum Stream {
         case data(Data)
@@ -57,7 +57,7 @@ public class NSKeyedUnarchiver : NSCoder {
         return _error
     }
     
-    public class func unarchiveObjectWithData(_ data: Data) -> AnyObject? {
+    open class func unarchiveObjectWithData(_ data: Data) -> AnyObject? {
         do {
             return try unarchiveTopLevelObjectWithData(data)
         } catch {
@@ -65,7 +65,7 @@ public class NSKeyedUnarchiver : NSCoder {
         return nil
     }
     
-    public class func unarchiveObjectWithFile(_ path: String) -> AnyObject? {
+    open class func unarchiveObjectWithFile(_ path: String) -> AnyObject? {
         let url = URL(fileURLWithPath: path)
         let readStream = CFReadStreamCreateWithFile(kCFAllocatorSystemDefault, url._cfObject)!
         var root : AnyObject? = nil
@@ -194,11 +194,11 @@ public class NSKeyedUnarchiver : NSCoder {
         return self._objects[uid]
     }
     
-    public override var systemVersion: UInt32 {
+    open override var systemVersion: UInt32 {
         return NSKeyedArchiverSystemVersion
     }
     
-    public override var allowsKeyedCoding: Bool {
+    open override var allowsKeyedCoding: Bool {
         get {
             return true
         }
@@ -574,7 +574,7 @@ public class NSKeyedUnarchiver : NSCoder {
     /**
      Called when the caller has finished decoding.
      */
-    public func finishDecoding() {
+    open func finishDecoding() {
         if _flags.contains(UnarchiverFlags.FinishedDecoding) {
             return
         }
@@ -592,20 +592,20 @@ public class NSKeyedUnarchiver : NSCoder {
         let _ = self._flags.insert(UnarchiverFlags.FinishedDecoding)
     }
 
-    public class func setClass(_ cls: AnyClass?, forClassName codedName: String) {
+    open class func setClass(_ cls: AnyClass?, forClassName codedName: String) {
         _classNameMapLock.synchronized {
             _classNameMap[codedName] = cls
         }
     }
     
-    public func setClass(_ cls: AnyClass?, forClassName codedName: String) {
+    open func setClass(_ cls: AnyClass?, forClassName codedName: String) {
         _classNameMap[codedName] = cls
     }
     
     // During decoding, the coder first checks with the coder's
     // own table, then if there was no mapping there, the class's.
     
-    public class func classForClassName(_ codedName: String) -> AnyClass? {
+    open class func classForClassName(_ codedName: String) -> AnyClass? {
         var mappedClass : AnyClass?
         
         _classNameMapLock.synchronized {
@@ -615,16 +615,16 @@ public class NSKeyedUnarchiver : NSCoder {
         return mappedClass
     }
     
-    public func classForClassName(_ codedName: String) -> AnyClass? {
+    open func classForClassName(_ codedName: String) -> AnyClass? {
         return _classNameMap[codedName]
     }
     
-    public override func containsValue(forKey key: String) -> Bool {
+    open override func containsValue(forKey key: String) -> Bool {
         let any : Any? = _decodeValue(forKey: key)
         return any != nil
     }
     
-    public override func decodeObject(forKey key: String) -> AnyObject? {
+    open override func decodeObject(forKey key: String) -> AnyObject? {
         do {
             return try _decodeObject(forKey: key)
         } catch let error as NSError {
@@ -651,23 +651,23 @@ public class NSKeyedUnarchiver : NSCoder {
         return nil
     }
 
-    public override func decodeObjectOfClass<DecodedObjectType : NSCoding where DecodedObjectType : NSObject>(_ cls: DecodedObjectType.Type, forKey key: String) -> DecodedObjectType? {
+    open override func decodeObjectOfClass<DecodedObjectType : NSCoding where DecodedObjectType : NSObject>(_ cls: DecodedObjectType.Type, forKey key: String) -> DecodedObjectType? {
         return decodeObjectOfClasses([cls], forKey: key) as? DecodedObjectType
     }
     
-    public override func decodeObjectOfClasses(_ classes: [AnyClass], forKey key: String) -> AnyObject? {
+    open override func decodeObjectOfClasses(_ classes: [AnyClass], forKey key: String) -> AnyObject? {
         return _decodeObjectOfClasses(classes, forKey: key)
     }
     
-    public override func decodeTopLevelObjectForKey(_ key: String) throws -> AnyObject? {
+    open override func decodeTopLevelObjectForKey(_ key: String) throws -> AnyObject? {
         return try decodeTopLevelObjectOfClasses([NSArray.self], forKey: key)
     }
     
-    public override func decodeTopLevelObjectOfClass<DecodedObjectType : NSCoding where DecodedObjectType : NSObject>(_ cls: DecodedObjectType.Type, forKey key: String) throws -> DecodedObjectType? {
+    open override func decodeTopLevelObjectOfClass<DecodedObjectType : NSCoding where DecodedObjectType : NSObject>(_ cls: DecodedObjectType.Type, forKey key: String) throws -> DecodedObjectType? {
         return try self.decodeTopLevelObjectOfClasses([cls], forKey: key) as! DecodedObjectType?
     }
     
-    public override func decodeTopLevelObjectOfClasses(_ classes: [AnyClass], forKey key: String) throws -> AnyObject? {
+    open override func decodeTopLevelObjectOfClasses(_ classes: [AnyClass], forKey key: String) throws -> AnyObject? {
         guard self._containers?.count == 1 else {
             throw _decodingError(NSCocoaError.CoderReadCorruptError,
                                  withDescription: "Can only call decodeTopLevelObjectOfClasses when decoding top level objects.")
@@ -676,7 +676,7 @@ public class NSKeyedUnarchiver : NSCoder {
         return decodeObjectOfClasses(classes, forKey: key)
     }
     
-    public override func decodeObject() -> AnyObject? {
+    open override func decodeObject() -> AnyObject? {
         do {
             return try _decodeObject(forKey: nil)
         } catch let error as NSError {
@@ -688,11 +688,11 @@ public class NSKeyedUnarchiver : NSCoder {
         return nil
     }
     
-    public override func decodePropertyList() -> AnyObject? {
+    open override func decodePropertyList() -> AnyObject? {
         return _decodeObjectOfClasses(NSPropertyListClasses)
     }
     
-    public override func decodePropertyListForKey(_ key: String) -> AnyObject? {
+    open override func decodePropertyListForKey(_ key: String) -> AnyObject? {
         return decodeObjectOfClasses(NSPropertyListClasses, forKey:key)
     }
     
@@ -705,42 +705,42 @@ public class NSKeyedUnarchiver : NSCoder {
         return _decodeValue(forKey: key)!
     }
     
-    public override func decodeBool(forKey key: String) -> Bool {
+    open override func decodeBool(forKey key: String) -> Bool {
         guard let result : NSNumber = _decodeValue(forKey: key) else {
             return false
         }
         return result.boolValue
     }
     
-    public override func decodeInt32(forKey key: String) -> Int32 {
+    open override func decodeInt32(forKey key: String) -> Int32 {
         guard let result : NSNumber = _decodeValue(forKey: key) else {
             return 0
         }
         return result.int32Value
     }
     
-    public override func decodeInt64(forKey key: String) -> Int64 {
+    open override func decodeInt64(forKey key: String) -> Int64 {
         guard let result : NSNumber = _decodeValue(forKey: key) else {
             return 0
         }
         return result.int64Value
     }
     
-    public override func decodeFloat(forKey key: String) -> Float {
+    open override func decodeFloat(forKey key: String) -> Float {
         guard let result : NSNumber = _decodeValue(forKey: key) else {
             return 0
         }
         return result.floatValue
     }
     
-    public override func decodeDouble(forKey key: String) -> Double {
+    open override func decodeDouble(forKey key: String) -> Double {
         guard let result : NSNumber = _decodeValue(forKey: key) else {
             return 0
         }
         return result.doubleValue
     }
     
-    public override func decodeInteger(forKey key: String) -> Int {
+    open override func decodeInteger(forKey key: String) -> Int {
         guard let result : NSNumber = _decodeValue(forKey: key) else {
             return 0
         }
@@ -748,7 +748,7 @@ public class NSKeyedUnarchiver : NSCoder {
     }
     
     /// - experimental: replaces decodeBytes(forKey:)
-    public override func withDecodedUnsafeBufferPointer<ResultType>(forKey key: String, body: @noescape (UnsafeBufferPointer<UInt8>?) throws -> ResultType) rethrows -> ResultType {
+    open override func withDecodedUnsafeBufferPointer<ResultType>(forKey key: String, body: @noescape (UnsafeBufferPointer<UInt8>?) throws -> ResultType) rethrows -> ResultType {
         let ns : Data? = _decodeValue(forKey: key)
         if let value = ns {
             return try value.withUnsafeBytes {
@@ -759,7 +759,7 @@ public class NSKeyedUnarchiver : NSCoder {
         }
     }
     
-    public override func decodeDataObject() -> Data? {
+    open override func decodeDataObject() -> Data? {
         return decodeObject() as? Data
     }
     
@@ -834,7 +834,7 @@ public class NSKeyedUnarchiver : NSCoder {
         }
     }
     
-    public override func decodeValue(ofObjCType typep: UnsafePointer<Int8>, at addr: UnsafeMutableRawPointer) {
+    open override func decodeValue(ofObjCType typep: UnsafePointer<Int8>, at addr: UnsafeMutableRawPointer) {
         guard let type = _NSSimpleObjCType(UInt8(typep.pointee)) else {
             let spec = String(typep.pointee)
             fatalError("NSKeyedUnarchiver.decodeValueOfObjCType: unsupported type encoding spec '\(spec)'")
@@ -864,14 +864,14 @@ public class NSKeyedUnarchiver : NSCoder {
         }
     }
 
-    public override var allowedClasses: [AnyClass]? {
+    open override var allowedClasses: [AnyClass]? {
         get {
             return self._allowedClasses.last
         }
     }
  
     // Enables secure coding support on this keyed unarchiver. When enabled, anarchiving a disallowed class throws an exception. Once enabled, attempting to set requiresSecureCoding to NO will throw an exception. This is to prevent classes from selectively turning secure coding off. This is designed to be set once at the top level and remain on. Note that the getter is on the superclass, NSCoder. See NSCoder for more information about secure coding.
-    public override var requiresSecureCoding: Bool {
+    open override var requiresSecureCoding: Bool {
         get {
             return _flags.contains(UnarchiverFlags.RequiresSecureCoding)
         }
@@ -890,7 +890,7 @@ public class NSKeyedUnarchiver : NSCoder {
 }
 
 extension NSKeyedUnarchiver {
-    public class func unarchiveTopLevelObjectWithData(_ data: Data) throws -> AnyObject? {
+    open class func unarchiveTopLevelObjectWithData(_ data: Data) throws -> AnyObject? {
         var root : AnyObject? = nil
         
         let keyedUnarchiver = NSKeyedUnarchiver(forReadingWithData: data)

--- a/Foundation/NSLengthFormatter.swift
+++ b/Foundation/NSLengthFormatter.swift
@@ -22,32 +22,32 @@ extension LengthFormatter {
     }
 }
 
-public class LengthFormatter : Formatter {
+open class LengthFormatter : Formatter {
     
     public required init?(coder: NSCoder) {
         NSUnimplemented()
     }
     
-    /*@NSCopying*/ public var numberFormatter: NumberFormatter! // default is NSNumberFormatter with NSNumberFormatterDecimalStyle
-    public var unitStyle: UnitStyle // default is NSFormattingUnitStyleMedium
+    /*@NSCopying*/ open var numberFormatter: NumberFormatter! // default is NSNumberFormatter with NSNumberFormatterDecimalStyle
+    open var unitStyle: UnitStyle // default is NSFormattingUnitStyleMedium
     
-    public var isForPersonHeightUse: Bool // default is NO; if it is set to YES, the number argument for -stringFromMeters: and -unitStringFromMeters: is considered as a person's height
+    open var isForPersonHeightUse: Bool // default is NO; if it is set to YES, the number argument for -stringFromMeters: and -unitStringFromMeters: is considered as a person's height
     
     // Format a combination of a number and an unit to a localized string.
-    public func string(fromValue value: Double, unit: LengthFormatter.Unit) -> String { NSUnimplemented() }
+    open func string(fromValue value: Double, unit: LengthFormatter.Unit) -> String { NSUnimplemented() }
     
     // Format a number in meters to a localized string with the locale-appropriate unit and an appropriate scale (e.g. 4.3m = 14.1ft in the US locale).
-    public func string(fromMeters numberInMeters: Double) -> String { NSUnimplemented() }
+    open func string(fromMeters numberInMeters: Double) -> String { NSUnimplemented() }
     
     // Return a localized string of the given unit, and if the unit is singular or plural is based on the given number.
-    public func unitString(fromValue value: Double, unit: Unit) -> String { NSUnimplemented() }
+    open func unitString(fromValue value: Double, unit: Unit) -> String { NSUnimplemented() }
     
     // Return the locale-appropriate unit, the same unit used by -stringFromMeters:.
-    public func unitString(fromMeters numberInMeters: Double, usedUnit unitp: UnsafeMutablePointer<Unit>?) -> String { NSUnimplemented() }
+    open func unitString(fromMeters numberInMeters: Double, usedUnit unitp: UnsafeMutablePointer<Unit>?) -> String { NSUnimplemented() }
     
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    public override func objectValue(_ string: String) throws -> AnyObject? { return nil }
+    open override func objectValue(_ string: String) throws -> AnyObject? { return nil }
 }
 
 

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -10,7 +10,7 @@
 
 import CoreFoundation
 
-public class Locale: NSObject, NSCopying, NSSecureCoding {
+open class Locale: NSObject, NSCopying, NSSecureCoding {
     typealias CFType = CFLocale
     private var _base = _CFInfo(typeID: CFLocaleGetTypeID())
     private var _identifier: UnsafeMutableRawPointer? = nil
@@ -27,11 +27,11 @@ public class Locale: NSObject, NSCopying, NSSecureCoding {
         return unsafeBitCast(self, to: CFType.self)
     }
     
-    public func objectForKey(_ key: String) -> AnyObject? {
+    open func objectForKey(_ key: String) -> AnyObject? {
         return CFLocaleGetValue(_cfObject, key._cfObject)
     }
     
-    public func displayNameForKey(_ key: String, value: String) -> String? {
+    open func displayNameForKey(_ key: String, value: String) -> String? {
         return CFLocaleCopyDisplayNameForPropertyValue(_cfObject, key._cfObject, value._cfObject)?._swiftObject
     }
     
@@ -51,15 +51,15 @@ public class Locale: NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject { 
+    open func copy(with zone: NSZone? = nil) -> AnyObject { 
         return self 
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         if aCoder.allowsKeyedCoding {
             let identifier = CFLocaleGetIdentifier(self._cfObject)
             aCoder.encode(identifier, forKey: "NS.identifier")
@@ -74,18 +74,18 @@ public class Locale: NSObject, NSCopying, NSSecureCoding {
 }
 
 extension Locale {
-    public class var current: Locale {
+    open class var current: Locale {
         return CFLocaleCopyCurrent()._nsObject
     }
     
-    public class func systemLocale() -> Locale {
+    open class func systemLocale() -> Locale {
         return CFLocaleGetSystem()._nsObject
     }
 }
 
 extension Locale {
     
-    public class func availableLocaleIdentifiers() -> [String] {
+    open class func availableLocaleIdentifiers() -> [String] {
         var identifiers = Array<String>()
         for obj in CFLocaleCopyAvailableLocaleIdentifiers()._nsObject {
             identifiers.append((obj as! NSString)._swiftObject)
@@ -93,7 +93,7 @@ extension Locale {
         return identifiers
     }
     
-    public class func ISOLanguageCodes() -> [String] {
+    open class func ISOLanguageCodes() -> [String] {
         var identifiers = Array<String>()
         for obj in CFLocaleCopyISOLanguageCodes()._nsObject {
             identifiers.append((obj as! NSString)._swiftObject)
@@ -101,7 +101,7 @@ extension Locale {
         return identifiers
     }
     
-    public class func ISOCountryCodes() -> [String] {
+    open class func ISOCountryCodes() -> [String] {
         var identifiers = Array<String>()
         for obj in CFLocaleCopyISOCountryCodes()._nsObject {
             identifiers.append((obj as! NSString)._swiftObject)
@@ -109,7 +109,7 @@ extension Locale {
         return identifiers
     }
     
-    public class func ISOCurrencyCodes() -> [String] {
+    open class func ISOCurrencyCodes() -> [String] {
         var identifiers = Array<String>()
         for obj in CFLocaleCopyISOCurrencyCodes()._nsObject {
             identifiers.append((obj as! NSString)._swiftObject)
@@ -117,7 +117,7 @@ extension Locale {
         return identifiers
     }
     
-    public class func commonISOCurrencyCodes() -> [String] {
+    open class func commonISOCurrencyCodes() -> [String] {
         var identifiers = Array<String>()
         for obj in CFLocaleCopyCommonISOCurrencyCodes()._nsObject {
             identifiers.append((obj as! NSString)._swiftObject)
@@ -125,7 +125,7 @@ extension Locale {
         return identifiers
     }
     
-    public class func preferredLanguages() -> [String] {
+    open class func preferredLanguages() -> [String] {
         var identifiers = Array<String>()
         for obj in CFLocaleCopyPreferredLanguages()._nsObject {
             identifiers.append((obj as! NSString)._swiftObject)
@@ -133,7 +133,7 @@ extension Locale {
         return identifiers
     }
     
-    public class func componentsFromLocaleIdentifier(_ string: String) -> [String : String] {
+    open class func componentsFromLocaleIdentifier(_ string: String) -> [String : String] {
         var comps = Dictionary<String, String>()
         let values = CFLocaleCreateComponentsFromLocaleIdentifier(kCFAllocatorSystemDefault, string._cfObject)._nsObject
         values.enumerateKeysAndObjects([]) { (k, v, stop) in
@@ -144,27 +144,27 @@ extension Locale {
         return comps
     }
     
-    public class func localeIdentifierFromComponents(_ dict: [String : String]) -> String {
+    open class func localeIdentifierFromComponents(_ dict: [String : String]) -> String {
         return CFLocaleCreateLocaleIdentifierFromComponents(kCFAllocatorSystemDefault, dict._cfObject)._swiftObject
     }
     
-    public class func canonicalLocaleIdentifierFromString(_ string: String) -> String {
+    open class func canonicalLocaleIdentifierFromString(_ string: String) -> String {
         return CFLocaleCreateCanonicalLocaleIdentifierFromString(kCFAllocatorSystemDefault, string._cfObject)._swiftObject
     }
     
-    public class func canonicalLanguageIdentifierFromString(_ string: String) -> String {
+    open class func canonicalLanguageIdentifierFromString(_ string: String) -> String {
         return CFLocaleCreateCanonicalLanguageIdentifierFromString(kCFAllocatorSystemDefault, string._cfObject)._swiftObject
     }
     
-    public class func localeIdentifierFromWindowsLocaleCode(_ lcid: UInt32) -> String? {
+    open class func localeIdentifierFromWindowsLocaleCode(_ lcid: UInt32) -> String? {
         return CFLocaleCreateLocaleIdentifierFromWindowsLocaleCode(kCFAllocatorSystemDefault, lcid)._swiftObject
     }
     
-    public class func windowsLocaleCodeFromLocaleIdentifier(_ localeIdentifier: String) -> UInt32 {
+    open class func windowsLocaleCodeFromLocaleIdentifier(_ localeIdentifier: String) -> UInt32 {
         return CFLocaleGetWindowsLocaleCodeFromLocaleIdentifier(localeIdentifier._cfObject)
     }
     
-    public class func characterDirectionForLanguage(_ isoLangCode: String) -> NSLocaleLanguageDirection {
+    open class func characterDirectionForLanguage(_ isoLangCode: String) -> NSLocaleLanguageDirection {
         let dir = CFLocaleGetLanguageCharacterDirection(isoLangCode._cfObject)
 #if os(OSX) || os(iOS)
         return NSLocaleLanguageDirection(rawValue: UInt(dir.rawValue))!
@@ -173,7 +173,7 @@ extension Locale {
 #endif
     }
     
-    public class func lineDirectionForLanguage(_ isoLangCode: String) -> NSLocaleLanguageDirection {
+    open class func lineDirectionForLanguage(_ isoLangCode: String) -> NSLocaleLanguageDirection {
         let dir = CFLocaleGetLanguageLineDirection(isoLangCode._cfObject)
 #if os(OSX) || os(iOS)
         return NSLocaleLanguageDirection(rawValue: UInt(dir.rawValue))!

--- a/Foundation/NSLock.swift
+++ b/Foundation/NSLock.swift
@@ -22,7 +22,7 @@ public protocol Locking {
     func unlock()
 }
 
-public class Lock: NSObject, Locking {
+open class Lock: NSObject, Locking {
     internal var mutex = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
     
     public override init() {
@@ -35,19 +35,19 @@ public class Lock: NSObject, Locking {
         mutex.deallocate(capacity: 1)
     }
     
-    public func lock() {
+    open func lock() {
         pthread_mutex_lock(mutex)
     }
     
-    public func unlock() {
+    open func unlock() {
         pthread_mutex_unlock(mutex)
     }
     
-    public func tryLock() -> Bool {
+    open func tryLock() -> Bool {
         return pthread_mutex_trylock(mutex) == 0
     }
     
-    public var name: String?
+    open var name: String?
 }
 
 extension Lock {
@@ -58,7 +58,7 @@ extension Lock {
     }
 }
 
-public class NSConditionLock : NSObject, Locking {
+open class NSConditionLock : NSObject, Locking {
     internal var _cond = Condition()
     internal var _value: Int
     internal var _thread: pthread_t?
@@ -71,34 +71,34 @@ public class NSConditionLock : NSObject, Locking {
         _value = condition
     }
 
-    public func lock() {
+    open func lock() {
         let _ = lockBeforeDate(Date.distantFuture)
     }
 
-    public func unlock() {
+    open func unlock() {
         _cond.lock()
         _thread = nil
         _cond.broadcast()
         _cond.unlock()
     }
     
-    public var condition: Int {
+    open var condition: Int {
         return _value
     }
 
-    public func lockWhenCondition(_ condition: Int) {
+    open func lockWhenCondition(_ condition: Int) {
         let _ = lockWhenCondition(condition, beforeDate: Date.distantFuture)
     }
 
-    public func tryLock() -> Bool {
+    open func tryLock() -> Bool {
         return lockBeforeDate(Date.distantPast)
     }
     
-    public func tryLockWhenCondition(_ condition: Int) -> Bool {
+    open func tryLockWhenCondition(_ condition: Int) -> Bool {
         return lockWhenCondition(condition, beforeDate: Date.distantPast)
     }
 
-    public func unlockWithCondition(_ condition: Int) {
+    open func unlockWithCondition(_ condition: Int) {
         _cond.lock()
         _thread = nil
         _value = condition
@@ -106,7 +106,7 @@ public class NSConditionLock : NSObject, Locking {
         _cond.unlock()
     }
 
-    public func lockBeforeDate(_ limit: Date) -> Bool {
+    open func lockBeforeDate(_ limit: Date) -> Bool {
         _cond.lock()
         while _thread == nil {
             if !_cond.waitUntilDate(limit) {
@@ -119,7 +119,7 @@ public class NSConditionLock : NSObject, Locking {
         return true
     }
     
-    public func lockWhenCondition(_ condition: Int, beforeDate limit: Date) -> Bool {
+    open func lockWhenCondition(_ condition: Int, beforeDate limit: Date) -> Bool {
         _cond.lock()
         while _thread != nil || _value != condition {
             if !_cond.waitUntilDate(limit) {
@@ -132,10 +132,10 @@ public class NSConditionLock : NSObject, Locking {
         return true
     }
     
-    public var name: String?
+    open var name: String?
 }
 
-public class RecursiveLock: NSObject, Locking {
+open class RecursiveLock: NSObject, Locking {
     internal var mutex = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
     
     public override init() {
@@ -153,22 +153,22 @@ public class RecursiveLock: NSObject, Locking {
         mutex.deallocate(capacity: 1)
     }
     
-    public func lock() {
+    open func lock() {
         pthread_mutex_lock(mutex)
     }
     
-    public func unlock() {
+    open func unlock() {
         pthread_mutex_unlock(mutex)
     }
     
-    public func tryLock() -> Bool {
+    open func tryLock() -> Bool {
         return pthread_mutex_trylock(mutex) == 0
     }
 
-    public var name: String?
+    open var name: String?
 }
 
-public class Condition: NSObject, Locking {
+open class Condition: NSObject, Locking {
     internal var mutex = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
     internal var cond = UnsafeMutablePointer<pthread_cond_t>.allocate(capacity: 1)
     
@@ -186,19 +186,19 @@ public class Condition: NSObject, Locking {
         cond.deallocate(capacity: 1)
     }
     
-    public func lock() {
+    open func lock() {
         pthread_mutex_lock(mutex)
     }
     
-    public func unlock() {
+    open func unlock() {
         pthread_mutex_unlock(mutex)
     }
     
-    public func wait() {
+    open func wait() {
         pthread_cond_wait(cond, mutex)
     }
     
-    public func waitUntilDate(_ limit: Date) -> Bool {
+    open func waitUntilDate(_ limit: Date) -> Bool {
         let lim = limit.timeIntervalSinceReferenceDate
         let ti = lim - CFAbsoluteTimeGetCurrent()
         if ti < 0.0 {
@@ -220,13 +220,13 @@ public class Condition: NSObject, Locking {
         return retVal == 0
     }
     
-    public func signal() {
+    open func signal() {
         pthread_cond_signal(cond)
     }
     
-    public func broadcast() {
+    open func broadcast() {
         pthread_cond_broadcast(cond)
     }
     
-    public var name: String?
+    open var name: String?
 }

--- a/Foundation/NSMassFormatter.swift
+++ b/Foundation/NSMassFormatter.swift
@@ -19,30 +19,30 @@ extension MassFormatter {
     }
 }
     
-public class MassFormatter : Formatter {
+open class MassFormatter : Formatter {
     
     public required init?(coder: NSCoder) {
         NSUnimplemented()
     }
     
-    /*@NSCopying*/ public var numberFormatter: NumberFormatter! // default is NSNumberFormatter with NSNumberFormatterDecimalStyle
-    public var unitStyle: UnitStyle // default is NSFormattingUnitStyleMedium
-    public var isForPersonMassUse: Bool // default is NO; if it is set to YES, the number argument for -stringFromKilograms: and -unitStringFromKilograms: is considered as a person’s mass
+    /*@NSCopying*/ open var numberFormatter: NumberFormatter! // default is NSNumberFormatter with NSNumberFormatterDecimalStyle
+    open var unitStyle: UnitStyle // default is NSFormattingUnitStyleMedium
+    open var isForPersonMassUse: Bool // default is NO; if it is set to YES, the number argument for -stringFromKilograms: and -unitStringFromKilograms: is considered as a person’s mass
     
     // Format a combination of a number and an unit to a localized string.
-    public func string(fromValue value: Double, unit: Unit) -> String { NSUnimplemented() }
+    open func string(fromValue value: Double, unit: Unit) -> String { NSUnimplemented() }
     
     // Format a number in kilograms to a localized string with the locale-appropriate unit and an appropriate scale (e.g. 1.2kg = 2.64lb in the US locale).
-    public func string(fromKilograms numberInKilograms: Double) -> String { NSUnimplemented() }
+    open func string(fromKilograms numberInKilograms: Double) -> String { NSUnimplemented() }
     
     // Return a localized string of the given unit, and if the unit is singular or plural is based on the given number.
-    public func unitString(fromValue value: Double, unit: Unit) -> String { NSUnimplemented() }
+    open func unitString(fromValue value: Double, unit: Unit) -> String { NSUnimplemented() }
     
     // Return the locale-appropriate unit, the same unit used by -stringFromKilograms:.
-    public func unitString(fromKilograms numberInKilograms: Double, usedUnit unitp: UnsafeMutablePointer<Unit>?) -> String { NSUnimplemented() }
+    open func unitString(fromKilograms numberInKilograms: Double, usedUnit unitp: UnsafeMutablePointer<Unit>?) -> String { NSUnimplemented() }
     
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    public override func objectValue(_ string: String) throws -> AnyObject? { return nil }
+    open override func objectValue(_ string: String) throws -> AnyObject? { return nil }
 }
 

--- a/Foundation/NSMeasurement.swift
+++ b/Foundation/NSMeasurement.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 
-public class NSMeasurement : NSObject, NSCopying, NSSecureCoding {
-    public private(set) var unit: Unit
-    public private(set) var doubleValue: Double
+open class NSMeasurement : NSObject, NSCopying, NSSecureCoding {
+    open private(set) var unit: Unit
+    open private(set) var doubleValue: Double
     
     @available(*, unavailable)
     public convenience override init() { fatalError("Measurements must be constructed with a value and unit") }
@@ -23,19 +23,19 @@ public class NSMeasurement : NSObject, NSCopying, NSSecureCoding {
         self.unit = unit
     }
     
-    public func canBeConverted(to unit: Unit) -> Bool { NSUnimplemented() }
+    open func canBeConverted(to unit: Unit) -> Bool { NSUnimplemented() }
     
-    public func converting(to unit: Unit) -> Measurement<Unit> { NSUnimplemented() }
+    open func converting(to unit: Unit) -> Measurement<Unit> { NSUnimplemented() }
     
-    public func adding(_ measurement: Measurement<Unit>) -> Measurement<Unit> { NSUnimplemented() }
+    open func adding(_ measurement: Measurement<Unit>) -> Measurement<Unit> { NSUnimplemented() }
     
-    public func subtracting(_ measurement: Measurement<Unit>) -> Measurement<Unit> { NSUnimplemented() }
+    open func subtracting(_ measurement: Measurement<Unit>) -> Measurement<Unit> { NSUnimplemented() }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject { NSUnimplemented() }
+    open func copy(with zone: NSZone? = nil) -> AnyObject { NSUnimplemented() }
     
-    public class func supportsSecureCoding() -> Bool { return true }
+    open class func supportsSecureCoding() -> Bool { return true }
     
-    public func encode(with aCoder: NSCoder) { NSUnimplemented() }
+    open func encode(with aCoder: NSCoder) { NSUnimplemented() }
     
     public required init?(coder aDecoder: NSCoder) { NSUnimplemented() }
 }

--- a/Foundation/NSMeasurementFormatter.swift
+++ b/Foundation/NSMeasurementFormatter.swift
@@ -22,7 +22,7 @@ extension MeasurementFormatter {
     }
 }
 
-public class MeasurementFormatter : Formatter, NSSecureCoding {
+open class MeasurementFormatter : Formatter, NSSecureCoding {
     
     
     /*
@@ -41,39 +41,39 @@ public class MeasurementFormatter : Formatter, NSSecureCoding {
      Note that NSMeasurementFormatter will handle converting measurement objects to the preferred units in a particular locale.  For instance, if provided a measurement object in kilometers and the set locale is en_US, the formatter will implicitly convert the measurement object to miles and return the formatted string as the equivalent measurement in miles.
      
      */
-    public var unitOptions: MeasurementFormatter.UnitOptions = []
+    open var unitOptions: MeasurementFormatter.UnitOptions = []
     
     
     /*
      If not specified, unitStyle is set to NSFormattingUnitStyleMedium.
      */
-    public var unitStyle: Formatter.UnitStyle
+    open var unitStyle: Formatter.UnitStyle
     
     
     /*
      If not specified, locale is set to the user's current locale.
      */
-    /*@NSCopying*/ public var locale: Locale!
+    /*@NSCopying*/ open var locale: Locale!
     
     
     /*
      If not specified, the number formatter is set up with NSNumberFormatterDecimalStyle.
      */
-    public var numberFormatter: NumberFormatter!
+    open var numberFormatter: NumberFormatter!
     
     
-    public func string(from measurement: Measurement<Unit>) -> String { NSUnimplemented() }
+    open func string(from measurement: Measurement<Unit>) -> String { NSUnimplemented() }
     
     
     /*
      @param An NSUnit
      @return A formatted string representing the localized form of the unit without a value attached to it.  This method will return [unit symbol] if the provided unit cannot be localized.
      */
-    public func string(from unit: Unit) -> String { NSUnimplemented() }
+    open func string(from unit: Unit) -> String { NSUnimplemented() }
     
     public override init() { NSUnimplemented() }
     
     public required init?(coder aDecoder: NSCoder) { NSUnimplemented() }
-    public override func encode(with aCoder: NSCoder) { NSUnimplemented() }
+    open override func encode(with aCoder: NSCoder) { NSUnimplemented() }
     public static func supportsSecureCoding() -> Bool { return true }
 }

--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -28,12 +28,12 @@ public func <(lhs: NSNotification.Name, rhs: NSNotification.Name) -> Bool {
     return lhs.rawValue < rhs.rawValue
 }
 
-public class NSNotification: NSObject, NSCopying, NSCoding {
-    private(set) public var name: Name
+open class NSNotification: NSObject, NSCopying, NSCoding {
+    private(set) open var name: Name
     
-    private(set) public var object: AnyObject?
+    private(set) open var object: AnyObject?
     
-    private(set) public var userInfo: [String : Any]?
+    private(set) open var userInfo: [String : Any]?
     
     public convenience override init() {
         /* do not invoke; not a valid initializer for this class */
@@ -64,7 +64,7 @@ public class NSNotification: NSObject, NSCopying, NSCoding {
         }
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         if aCoder.allowsKeyedCoding {
             aCoder.encode(self.name.rawValue.bridge(), forKey:"NS.name")
             aCoder.encode(self.object, forKey:"NS.object")
@@ -76,15 +76,15 @@ public class NSNotification: NSObject, NSCopying, NSCoding {
         }
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         return self
     }
     
-    public override var description: String {
+    open override var description: String {
         var str = "\(type(of: self)) \(Unmanaged.passUnretained(self).toOpaque()) {"
         
         str += "name = \(self.name.rawValue)"
@@ -156,7 +156,7 @@ extension Sequence where Iterator.Element : NSNotificationReceiver {
 
 private let _defaultCenter: NotificationCenter = NotificationCenter()
 
-public class NotificationCenter: NSObject {
+open class NotificationCenter: NSObject {
     
     private var _observers: [NSNotificationReceiver]
     private let _observersLock = Lock()
@@ -165,11 +165,11 @@ public class NotificationCenter: NSObject {
         _observers = [NSNotificationReceiver]()
     }
     
-    public class func defaultCenter() -> NotificationCenter {
+    open class func defaultCenter() -> NotificationCenter {
         return _defaultCenter
     }
     
-    public func postNotification(_ notification: Notification) {
+    open func postNotification(_ notification: Notification) {
 
         let sendTo = _observersLock.synchronized({
             return _observers.observersMatchingName(notification.name, sender: notification.object)
@@ -184,21 +184,21 @@ public class NotificationCenter: NSObject {
         }
     }
 
-    public func postNotificationName(_ aName: Notification.Name, object anObject: AnyObject?) {
+    open func postNotificationName(_ aName: Notification.Name, object anObject: AnyObject?) {
         let notification = Notification(name: aName, object: anObject)
         postNotification(notification)
     }
 
-    public func postNotificationName(_ aName: Notification.Name, object anObject: AnyObject?, userInfo aUserInfo: [String : Any]?) {
+    open func postNotificationName(_ aName: Notification.Name, object anObject: AnyObject?, userInfo aUserInfo: [String : Any]?) {
         let notification = Notification(name: aName, object: anObject, userInfo: aUserInfo)
         postNotification(notification)
     }
 
-    public func removeObserver(_ observer: AnyObject) {
+    open func removeObserver(_ observer: AnyObject) {
         removeObserver(observer, name: nil, object: nil)
     }
 
-    public func removeObserver(_ observer: AnyObject, name: Notification.Name?, object: AnyObject?) {
+    open func removeObserver(_ observer: AnyObject, name: Notification.Name?, object: AnyObject?) {
         guard let observer = observer as? NSObject else {
             return
         }
@@ -208,7 +208,7 @@ public class NotificationCenter: NSObject {
         })
     }
     
-    public func addObserverForName(_ name: Notification.Name?, object obj: AnyObject?, queue: OperationQueue?, usingBlock block: @escaping (Notification) -> Void) -> NSObjectProtocol {
+    open func addObserverForName(_ name: Notification.Name?, object obj: AnyObject?, queue: OperationQueue?, usingBlock block: @escaping (Notification) -> Void) -> NSObjectProtocol {
         if queue != nil {
             NSUnimplemented()
         }

--- a/Foundation/NSNotificationQueue.swift
+++ b/Foundation/NSNotificationQueue.swift
@@ -27,7 +27,7 @@ extension NotificationQueue {
     }
 }
 
-public class NotificationQueue: NSObject {
+open class NotificationQueue: NSObject {
 
     internal typealias NotificationQueueList = NSMutableArray
     internal typealias NSNotificationListEntry = (Notification, [RunLoopMode]) // Notification ans list of modes the notification may be posted in.
@@ -58,7 +58,7 @@ public class NotificationQueue: NSObject {
 
     // The default notification queue for the current thread.
     private static var _defaultQueue = NSThreadSpecific<NotificationQueue>()
-    public class func defaultQueue() -> NotificationQueue {
+    open class func defaultQueue() -> NotificationQueue {
         return _defaultQueue.get() {
             return NotificationQueue(notificationCenter: NotificationCenter.defaultCenter())
         }
@@ -76,11 +76,11 @@ public class NotificationQueue: NSObject {
         removeRunloopObserver(self.asapRunloopObserver)
     }
 
-    public func enqueueNotification(_ notification: Notification, postingStyle: PostingStyle) {
+    open func enqueueNotification(_ notification: Notification, postingStyle: PostingStyle) {
         enqueueNotification(notification, postingStyle: postingStyle, coalesceMask: [.CoalescingOnName, .CoalescingOnSender], forModes: nil)
     }
 
-    public func enqueueNotification(_ notification: Notification, postingStyle: PostingStyle, coalesceMask: Coalescing, forModes modes: [RunLoopMode]?) {
+    open func enqueueNotification(_ notification: Notification, postingStyle: PostingStyle, coalesceMask: Coalescing, forModes modes: [RunLoopMode]?) {
         var runloopModes: [RunLoopMode] = [.defaultRunLoopMode]
         if let modes = modes  {
             runloopModes = modes
@@ -105,7 +105,7 @@ public class NotificationQueue: NSObject {
         }
     }
     
-    public func dequeueNotificationsMatching(_ notification: Notification, coalesceMask: Coalescing) {
+    open func dequeueNotificationsMatching(_ notification: Notification, coalesceMask: Coalescing) {
         var predicate: (NSNotificationListEntry) -> Bool
         switch coalesceMask {
         case [.CoalescingOnName, .CoalescingOnSender]:

--- a/Foundation/NSNull.swift
+++ b/Foundation/NSNull.swift
@@ -8,13 +8,13 @@
 //
 
 
-public class NSNull : NSObject, NSCopying, NSSecureCoding {
+open class NSNull : NSObject, NSCopying, NSSecureCoding {
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         return self
     }
     
@@ -26,7 +26,7 @@ public class NSNull : NSObject, NSCopying, NSSecureCoding {
         // Nothing to do here
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         // Nothing to do here
     }
     
@@ -34,7 +34,7 @@ public class NSNull : NSObject, NSCopying, NSSecureCoding {
         return true
     }
     
-    public override func isEqual(_ object: AnyObject?) -> Bool {
+    open override func isEqual(_ object: AnyObject?) -> Bool {
         return object is NSNull
     }
 }

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -134,7 +134,7 @@ extension NSNumber : ExpressibleByFloatLiteral, ExpressibleByIntegerLiteral, Exp
 
 }
 
-public class NSNumber : NSValue {
+open class NSNumber : NSValue {
     typealias CFType = CFNumber
     // This layout MUST be the same as CFNumber so that they are bridgeable
     private var _base = _CFInfo(typeID: CFNumberGetTypeID())
@@ -144,11 +144,11 @@ public class NSNumber : NSValue {
         return unsafeBitCast(self, to: CFType.self)
     }
     
-    public override var hash: Int {
+    open override var hash: Int {
         return Int(bitPattern: CFHash(_cfObject))
     }
     
-    public override func isEqual(_ object: AnyObject?) -> Bool {
+    open override func isEqual(_ object: AnyObject?) -> Bool {
         if let number = object as? NSNumber {
             return CFEqual(_cfObject, number._cfObject)
         } else {
@@ -308,7 +308,7 @@ public class NSNumber : NSValue {
         }
     }
 
-    public var int8Value: Int8 {
+    open var int8Value: Int8 {
         var val: Int8 = 0
         withUnsafeMutablePointer(to: &val) { (value: UnsafeMutablePointer<Int8>) -> Void in
             CFNumberGetValue(_cfObject, kCFNumberCharType, value)
@@ -316,7 +316,7 @@ public class NSNumber : NSValue {
         return val
     }
 
-    public var uint8Value: UInt8 {
+    open var uint8Value: UInt8 {
         var val: UInt8 = 0
         withUnsafeMutablePointer(to: &val) { (value: UnsafeMutablePointer<UInt8>) -> Void in
             CFNumberGetValue(_cfObject, kCFNumberCharType, value)
@@ -324,7 +324,7 @@ public class NSNumber : NSValue {
         return val
     }
     
-    public var int16Value: Int16 {
+    open var int16Value: Int16 {
         var val: Int16 = 0
         withUnsafeMutablePointer(to: &val) { (value: UnsafeMutablePointer<Int16>) -> Void in
             CFNumberGetValue(_cfObject, kCFNumberShortType, value)
@@ -332,7 +332,7 @@ public class NSNumber : NSValue {
         return val
     }
     
-    public var uint16Value: UInt16 {
+    open var uint16Value: UInt16 {
         var val: UInt16 = 0
         withUnsafeMutablePointer(to: &val) { (value: UnsafeMutablePointer<UInt16>) -> Void in
             CFNumberGetValue(_cfObject, kCFNumberShortType, value)
@@ -340,7 +340,7 @@ public class NSNumber : NSValue {
         return val
     }
     
-    public var int32Value: Int32 {
+    open var int32Value: Int32 {
         var val: Int32 = 0
         withUnsafeMutablePointer(to: &val) { (value: UnsafeMutablePointer<Int32>) -> Void in
             CFNumberGetValue(_cfObject, kCFNumberIntType, value)
@@ -348,7 +348,7 @@ public class NSNumber : NSValue {
         return val
     }
     
-    public var uint32Value: UInt32 {
+    open var uint32Value: UInt32 {
         var val: UInt32 = 0
         withUnsafeMutablePointer(to: &val) { (value: UnsafeMutablePointer<UInt32>) -> Void in
             CFNumberGetValue(_cfObject, kCFNumberIntType, value)
@@ -356,7 +356,7 @@ public class NSNumber : NSValue {
         return val
     }
     
-    public var int64Value: Int64 {
+    open var int64Value: Int64 {
         var val: Int64 = 0
         withUnsafeMutablePointer(to: &val) { (value: UnsafeMutablePointer<Int64>) -> Void in
             CFNumberGetValue(_cfObject, kCFNumberLongLongType, value)
@@ -364,7 +364,7 @@ public class NSNumber : NSValue {
         return val
     }
     
-    public var uint64Value: UInt64 {
+    open var uint64Value: UInt64 {
         var val: UInt64 = 0
         withUnsafeMutablePointer(to: &val) { (value: UnsafeMutablePointer<UInt64>) -> Void in
             CFNumberGetValue(_cfObject, kCFNumberLongLongType, value)
@@ -372,7 +372,7 @@ public class NSNumber : NSValue {
         return val
     }
     
-    public var floatValue: Float {
+    open var floatValue: Float {
         var val: Float = 0
         withUnsafeMutablePointer(to: &val) { (value: UnsafeMutablePointer<Float>) -> Void in
             CFNumberGetValue(_cfObject, kCFNumberFloatType, value)
@@ -380,7 +380,7 @@ public class NSNumber : NSValue {
         return val
     }
     
-    public var doubleValue: Double {
+    open var doubleValue: Double {
         var val: Double = 0
         withUnsafeMutablePointer(to: &val) { (value: UnsafeMutablePointer<Double>) -> Void in
             CFNumberGetValue(_cfObject, kCFNumberDoubleType, value)
@@ -388,11 +388,11 @@ public class NSNumber : NSValue {
         return val
     }
     
-    public var boolValue: Bool {
+    open var boolValue: Bool {
         return int64Value != 0
     }
     
-    public var intValue: Int {
+    open var intValue: Int {
         var val: Int = 0
         withUnsafeMutablePointer(to: &val) { (value: UnsafeMutablePointer<Int>) -> Void in
             CFNumberGetValue(_cfObject, kCFNumberLongType, value)
@@ -400,7 +400,7 @@ public class NSNumber : NSValue {
         return val
     }
     
-    public var uintValue: UInt {
+    open var uintValue: UInt {
         var val: UInt = 0
         withUnsafeMutablePointer(to: &val) { (value: UnsafeMutablePointer<UInt>) -> Void in
             CFNumberGetValue(_cfObject, kCFNumberLongType, value)
@@ -408,7 +408,7 @@ public class NSNumber : NSValue {
         return val
     }
     
-    public var stringValue: String {
+    open var stringValue: String {
         return description(withLocale: nil)
     }
     
@@ -427,11 +427,11 @@ public class NSNumber : NSValue {
         self.init(value: value)
     }
 
-    public func compare(_ otherNumber: NSNumber) -> ComparisonResult {
+    open func compare(_ otherNumber: NSNumber) -> ComparisonResult {
         return ._fromCF(CFNumberCompare(_cfObject, otherNumber._cfObject, nil))
     }
 
-    public func description(withLocale locale: AnyObject?) -> String {
+    open func description(withLocale locale: AnyObject?) -> String {
         let aLocale = locale
         let formatter: CFNumberFormatter
         if (aLocale == nil) {
@@ -444,11 +444,11 @@ public class NSNumber : NSValue {
         return CFNumberFormatterCreateStringWithNumber(nil, formatter, self._cfObject)._swiftObject
     }
     
-    override public var _cfTypeID: CFTypeID {
+    override open var _cfTypeID: CFTypeID {
         return CFNumberGetTypeID()
     }
     
-    public override var description: String {
+    open override var description: String {
         return description(withLocale: nil)
     }
 }

--- a/Foundation/NSNumberFormatter.swift
+++ b/Foundation/NSNumberFormatter.swift
@@ -22,7 +22,7 @@ internal let kCFNumberFormatterCurrencyPluralStyle = CFNumberFormatterStyle.curr
 internal let kCFNumberFormatterCurrencyAccountingStyle = CFNumberFormatterStyle.currencyAccountingStyle
 #endif
 
-public class NumberFormatter : Formatter {
+open class NumberFormatter : Formatter {
     
     typealias CFType = CFNumberFormatter
     private var _currentCfFormatter: CFType?
@@ -45,25 +45,25 @@ public class NumberFormatter : Formatter {
     
     // this is for NSUnitFormatter
     
-    public var formattingContext: Context = .unknown // default is NSFormattingContextUnknown
+    open var formattingContext: Context = .unknown // default is NSFormattingContextUnknown
     
     // Report the used range of the string and an NSError, in addition to the usual stuff from NSFormatter
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    public func objectValue(_ string: String, range: inout NSRange) throws -> AnyObject? { NSUnimplemented() }
+    open func objectValue(_ string: String, range: inout NSRange) throws -> AnyObject? { NSUnimplemented() }
     
-    public override func string(for obj: AnyObject) -> String? {
+    open override func string(for obj: AnyObject) -> String? {
         guard let number = obj as? NSNumber else { return nil }
         return string(from: number)
     }
     
     // Even though NSNumberFormatter responds to the usual NSFormatter methods,
     //   here are some convenience methods which are a little more obvious.
-    public func string(from number: NSNumber) -> String? {
+    open func string(from number: NSNumber) -> String? {
         return CFNumberFormatterCreateStringWithNumber(kCFAllocatorSystemDefault, _cfFormatter, number._cfObject)._swiftObject
     }
     
-    public func number(from string: String) -> NSNumber? {
+    open func number(from string: String) -> NSNumber? {
         var range = CFRange(location: 0, length: string.length)
         let number = withUnsafeMutablePointer(to: &range) { (rangePointer: UnsafeMutablePointer<CFRange>) -> NSNumber? in
             
@@ -78,7 +78,7 @@ public class NumberFormatter : Formatter {
         return number
     }
     
-    public class func localizedString(from num: NSNumber, number nstyle: Style) -> String {
+    open class func localizedString(from num: NSNumber, number nstyle: Style) -> String {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = nstyle
         return numberFormatter.string(for: num)!
@@ -140,7 +140,7 @@ public class NumberFormatter : Formatter {
     
     // Attributes of an NSNumberFormatter
     internal var _numberStyle: Style = .noStyle
-    public var numberStyle: Style {
+    open var numberStyle: Style {
         get {
             return _numberStyle
         }
@@ -165,7 +165,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _locale: Locale = Locale.current
-    /*@NSCopying*/ public var locale: Locale! {
+    /*@NSCopying*/ open var locale: Locale! {
         get {
             return _locale
         }
@@ -176,7 +176,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _generatesDecimalNumbers: Bool = false
-    public var generatesDecimalNumbers: Bool {
+    open var generatesDecimalNumbers: Bool {
         get {
             return _generatesDecimalNumbers
         }
@@ -187,7 +187,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _negativeFormat: String!
-    public var negativeFormat: String! {
+    open var negativeFormat: String! {
         get {
             return _negativeFormat
         }
@@ -198,7 +198,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _textAttributesForNegativeValues: [String : AnyObject]?
-    public var textAttributesForNegativeValues: [String : AnyObject]? {
+    open var textAttributesForNegativeValues: [String : AnyObject]? {
         get {
             return _textAttributesForNegativeValues
         }
@@ -209,7 +209,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _positiveFormat: String!
-    public var positiveFormat: String! {
+    open var positiveFormat: String! {
         get {
             return _positiveFormat
         }
@@ -220,7 +220,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _textAttributesForPositiveValues: [String : AnyObject]?
-    public var textAttributesForPositiveValues: [String : AnyObject]? {
+    open var textAttributesForPositiveValues: [String : AnyObject]? {
         get {
             return _textAttributesForPositiveValues
         }
@@ -231,7 +231,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _allowsFloats: Bool = true
-    public var allowsFloats: Bool {
+    open var allowsFloats: Bool {
         get {
             return _allowsFloats
         }
@@ -242,7 +242,7 @@ public class NumberFormatter : Formatter {
     }
 
     internal var _decimalSeparator: String!
-    public var decimalSeparator: String! {
+    open var decimalSeparator: String! {
         get {
             return _decimalSeparator
         }
@@ -253,7 +253,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _alwaysShowsDecimalSeparator: Bool = false
-    public var alwaysShowsDecimalSeparator: Bool {
+    open var alwaysShowsDecimalSeparator: Bool {
         get {
             return _alwaysShowsDecimalSeparator
         }
@@ -264,7 +264,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _currencyDecimalSeparator: String!
-    public var currencyDecimalSeparator: String! {
+    open var currencyDecimalSeparator: String! {
         get {
             return _currencyDecimalSeparator
         }
@@ -275,7 +275,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _usesGroupingSeparator: Bool = false
-    public var usesGroupingSeparator: Bool {
+    open var usesGroupingSeparator: Bool {
         get {
             return _usesGroupingSeparator
         }
@@ -286,7 +286,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _groupingSeparator: String!
-    public var groupingSeparator: String! {
+    open var groupingSeparator: String! {
         get {
             return _groupingSeparator
         }
@@ -299,7 +299,7 @@ public class NumberFormatter : Formatter {
     //
     
     internal var _zeroSymbol: String?
-    public var zeroSymbol: String? {
+    open var zeroSymbol: String? {
         get {
             return _zeroSymbol
         }
@@ -310,7 +310,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _textAttributesForZero: [String : AnyObject]?
-    public var textAttributesForZero: [String : AnyObject]? {
+    open var textAttributesForZero: [String : AnyObject]? {
         get {
             return _textAttributesForZero
         }
@@ -321,7 +321,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _nilSymbol: String = ""
-    public var nilSymbol: String {
+    open var nilSymbol: String {
         get {
             return _nilSymbol
         }
@@ -332,7 +332,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _textAttributesForNil: [String : AnyObject]?
-    public var textAttributesForNil: [String : AnyObject]? {
+    open var textAttributesForNil: [String : AnyObject]? {
         get {
             return _textAttributesForNil
         }
@@ -343,7 +343,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _notANumberSymbol: String!
-    public var notANumberSymbol: String! {
+    open var notANumberSymbol: String! {
         get {
             return _notANumberSymbol
         }
@@ -354,7 +354,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _textAttributesForNotANumber: [String : AnyObject]?
-    public var textAttributesForNotANumber: [String : AnyObject]? {
+    open var textAttributesForNotANumber: [String : AnyObject]? {
         get {
             return _textAttributesForNotANumber
         }
@@ -411,7 +411,7 @@ public class NumberFormatter : Formatter {
     //
     
     internal var _positivePrefix: String!
-    public var positivePrefix: String! {
+    open var positivePrefix: String! {
         get {
             return _positivePrefix
         }
@@ -422,7 +422,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _positiveSuffix: String!
-    public var positiveSuffix: String! {
+    open var positiveSuffix: String! {
         get {
             return _positiveSuffix
         }
@@ -433,7 +433,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _negativePrefix: String!
-    public var negativePrefix: String! {
+    open var negativePrefix: String! {
         get {
             return _negativePrefix
         }
@@ -444,7 +444,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _negativeSuffix: String!
-    public var negativeSuffix: String! {
+    open var negativeSuffix: String! {
         get {
             return _negativeSuffix
         }
@@ -455,7 +455,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _currencyCode: String!
-    public var currencyCode: String! {
+    open var currencyCode: String! {
         get {
             return _currencyCode
         }
@@ -466,7 +466,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _currencySymbol: String!
-    public var currencySymbol: String! {
+    open var currencySymbol: String! {
         get {
             return _currencySymbol
         }
@@ -477,7 +477,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _internationalCurrencySymbol: String!
-    public var internationalCurrencySymbol: String! {
+    open var internationalCurrencySymbol: String! {
         get {
             return _internationalCurrencySymbol
         }
@@ -488,7 +488,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _percentSymbol: String!
-    public var percentSymbol: String! {
+    open var percentSymbol: String! {
         get {
             return _percentSymbol
         }
@@ -499,7 +499,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _perMillSymbol: String!
-    public var perMillSymbol: String! {
+    open var perMillSymbol: String! {
         get {
             return _perMillSymbol
         }
@@ -510,7 +510,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _minusSign: String!
-    public var minusSign: String! {
+    open var minusSign: String! {
         get {
             return _minusSign
         }
@@ -521,7 +521,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _plusSign: String!
-    public var plusSign: String! {
+    open var plusSign: String! {
         get {
             return _plusSign
         }
@@ -531,8 +531,8 @@ public class NumberFormatter : Formatter {
         }
     }
     
-    public var _exponentSymbol: String!
-    public var exponentSymbol: String! {
+    open var _exponentSymbol: String!
+    open var exponentSymbol: String! {
         get {
             return _exponentSymbol
         }
@@ -545,7 +545,7 @@ public class NumberFormatter : Formatter {
     //
     
     internal var _groupingSize: Int = 3
-    public var groupingSize: Int {
+    open var groupingSize: Int {
         get {
             return _groupingSize
         }
@@ -556,7 +556,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _secondaryGroupingSize: Int = 0
-    public var secondaryGroupingSize: Int {
+    open var secondaryGroupingSize: Int {
         get {
             return _secondaryGroupingSize
         }
@@ -567,7 +567,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _multiplier: NSNumber?
-    /*@NSCopying*/ public var multiplier: NSNumber? {
+    /*@NSCopying*/ open var multiplier: NSNumber? {
         get {
             return _multiplier
         }
@@ -578,7 +578,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _formatWidth: Int = 0
-    public var formatWidth: Int {
+    open var formatWidth: Int {
         get {
             return _formatWidth
         }
@@ -589,7 +589,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _paddingCharacter: String!
-    public var paddingCharacter: String! {
+    open var paddingCharacter: String! {
         get {
             return _paddingCharacter
         }
@@ -602,7 +602,7 @@ public class NumberFormatter : Formatter {
     //
     
     internal var _paddingPosition: PadPosition = .beforePrefix
-    public var paddingPosition: PadPosition {
+    open var paddingPosition: PadPosition {
         get {
             return _paddingPosition
         }
@@ -613,7 +613,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _roundingMode: RoundingMode = .roundHalfEven
-    public var roundingMode: RoundingMode {
+    open var roundingMode: RoundingMode {
         get {
             return _roundingMode
         }
@@ -624,7 +624,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _roundingIncrement: NSNumber! = 0
-    /*@NSCopying*/ public var roundingIncrement: NSNumber! {
+    /*@NSCopying*/ open var roundingIncrement: NSNumber! {
         get {
             return _roundingIncrement
         }
@@ -635,7 +635,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _minimumIntegerDigits: Int = 0
-    public var minimumIntegerDigits: Int {
+    open var minimumIntegerDigits: Int {
         get {
             return _minimumIntegerDigits
         }
@@ -646,7 +646,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _maximumIntegerDigits: Int = 42
-    public var maximumIntegerDigits: Int {
+    open var maximumIntegerDigits: Int {
         get {
             return _maximumIntegerDigits
         }
@@ -657,7 +657,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _minimumFractionDigits: Int = 0
-    public var minimumFractionDigits: Int {
+    open var minimumFractionDigits: Int {
         get {
             return _minimumFractionDigits
         }
@@ -668,7 +668,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _maximumFractionDigits: Int = 0
-    public var maximumFractionDigits: Int {
+    open var maximumFractionDigits: Int {
         get {
             return _maximumFractionDigits
         }
@@ -679,7 +679,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _minimum: NSNumber?
-    /*@NSCopying*/ public var minimum: NSNumber? {
+    /*@NSCopying*/ open var minimum: NSNumber? {
         get {
             return _minimum
         }
@@ -690,7 +690,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _maximum: NSNumber?
-    /*@NSCopying*/ public var maximum: NSNumber? {
+    /*@NSCopying*/ open var maximum: NSNumber? {
         get {
             return _maximum
         }
@@ -701,7 +701,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _currencyGroupingSeparator: String!
-    public var currencyGroupingSeparator: String! {
+    open var currencyGroupingSeparator: String! {
         get {
             return _currencyGroupingSeparator
         }
@@ -712,7 +712,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _lenient: Bool = false
-    public var lenient: Bool {
+    open var lenient: Bool {
         get {
             return _lenient
         }
@@ -723,7 +723,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _usesSignificantDigits: Bool = false
-    public var usesSignificantDigits: Bool {
+    open var usesSignificantDigits: Bool {
         get {
             return _usesSignificantDigits
         }
@@ -734,7 +734,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _minimumSignificantDigits: Int = 1
-    public var minimumSignificantDigits: Int {
+    open var minimumSignificantDigits: Int {
         get {
             return _minimumSignificantDigits
         }
@@ -745,7 +745,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _maximumSignificantDigits: Int = 6
-    public var maximumSignificantDigits: Int {
+    open var maximumSignificantDigits: Int {
         get {
             return _maximumSignificantDigits
         }
@@ -756,7 +756,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _partialStringValidationEnabled: Bool = false
-    public var partialStringValidationEnabled: Bool {
+    open var partialStringValidationEnabled: Bool {
         get {
             return _partialStringValidationEnabled
         }
@@ -769,7 +769,7 @@ public class NumberFormatter : Formatter {
     //
     
     internal var _hasThousandSeparators: Bool = false
-    public var hasThousandSeparators: Bool {
+    open var hasThousandSeparators: Bool {
         get {
             return _hasThousandSeparators
         }
@@ -780,7 +780,7 @@ public class NumberFormatter : Formatter {
     }
     
     internal var _thousandSeparator: String!
-    public var thousandSeparator: String! {
+    open var thousandSeparator: String! {
         get {
             return _thousandSeparator
         }
@@ -793,7 +793,7 @@ public class NumberFormatter : Formatter {
     //
     
     internal var _localizesFormat: Bool = true
-    public var localizesFormat: Bool {
+    open var localizesFormat: Bool {
         get {
             return _localizesFormat
         }
@@ -806,7 +806,7 @@ public class NumberFormatter : Formatter {
     //
     
     internal var _format: String = "#;0;#"
-    public var format: String {
+    open var format: String {
         get {
             return _format
         }
@@ -822,7 +822,7 @@ public class NumberFormatter : Formatter {
     // this is currently commented out so that NSNumberFormatter instances can be tested
     
 //    internal var _attributedStringForZero: NSAttributedString = NSAttributedString(string: "0")
-//    /*@NSCopying*/ public var attributedStringForZero: NSAttributedString {
+//    /*@NSCopying*/ open var attributedStringForZero: NSAttributedString {
 //        get {
 //            return _attributedStringForZero
 //        }
@@ -833,7 +833,7 @@ public class NumberFormatter : Formatter {
 //    }
 //    
 //    internal var _attributedStringForNil: NSAttributedString = NSAttributedString(string: "")
-//    /*@NSCopying*/ public var attributedStringForNil: NSAttributedString {
+//    /*@NSCopying*/ open var attributedStringForNil: NSAttributedString {
 //        get {
 //            return _attributedStringForNil
 //        }
@@ -844,7 +844,7 @@ public class NumberFormatter : Formatter {
 //    }
 //    
 //    internal var _attributedStringForNotANumber: NSAttributedString = NSAttributedString(string: "NaN")
-//    /*@NSCopying*/ public var attributedStringForNotANumber: NSAttributedString {
+//    /*@NSCopying*/ open var attributedStringForNotANumber: NSAttributedString {
 //        get {
 //            return _attributedStringForNotANumber
 //        }
@@ -857,7 +857,7 @@ public class NumberFormatter : Formatter {
     //
     
 //    internal var _roundingBehavior: NSDecimalNumberHandler = .defaultDecimalNumberHandler()
-//    /*@NSCopying*/ public var roundingBehavior: NSDecimalNumberHandler {
+//    /*@NSCopying*/ open var roundingBehavior: NSDecimalNumberHandler {
 //        get {
 //            return _roundingBehavior
 //        }

--- a/Foundation/NSObject.swift
+++ b/Foundation/NSObject.swift
@@ -62,66 +62,66 @@ extension NSMutableCopying {
     }
 }
 
-public class NSObject : NSObjectProtocol, Equatable, Hashable {
+open class NSObject : NSObjectProtocol, Equatable, Hashable {
     // Important: add no ivars here. It will subvert the careful layout of subclasses that bridge into CF.    
     
     public init() {
         
     }
     
-    public func copy() -> AnyObject {
+    open func copy() -> AnyObject {
         if let copyable = self as? NSCopying {
             return copyable.copy(with: nil)
         }
         return self
     }
     
-    public func mutableCopy() -> AnyObject {
+    open func mutableCopy() -> AnyObject {
         if let copyable = self as? NSMutableCopying {
             return copyable.mutableCopy(with: nil)
         }
         return self
     }
     
-    public func isEqual(_ object: AnyObject?) -> Bool {
+    open func isEqual(_ object: AnyObject?) -> Bool {
         return object === self
     }
     
-    public var hash: Int {
+    open var hash: Int {
         return ObjectIdentifier(self).hashValue
     }
     
-    public func `self`() -> Self {
+    open func `self`() -> Self {
         return self
     }
     
-    public func isProxy() -> Bool {
+    open func isProxy() -> Bool {
         return false
     }
     
-    public var description: String {
+    open var description: String {
         return "<\(type(of: self)): \(Unmanaged.passUnretained(self).toOpaque())>"
     }
     
-    public var debugDescription: String {
+    open var debugDescription: String {
         return description
     }
     
-    public var _cfTypeID: CFTypeID {
+    open var _cfTypeID: CFTypeID {
         return 0
     }
     
     // TODO move these back into extensions once extension methods can be overriden
-    public var classForCoder: AnyClass {
+    open var classForCoder: AnyClass {
         return type(of: self)
     }
  
-    public func replacementObjectForCoder(_ aCoder: NSCoder) -> AnyObject? {
+    open func replacementObjectForCoder(_ aCoder: NSCoder) -> AnyObject? {
         return self
     }
 
     // TODO: Could perhaps be an extension of NSCoding instead. The reason it is an extension of NSObject is the lack of default implementations on protocols in Objective-C.
-    public var classForKeyedArchiver: AnyClass? {
+    open var classForKeyedArchiver: AnyClass? {
         return self.classForCoder
     }
     
@@ -133,7 +133,7 @@ public class NSObject : NSObjectProtocol, Equatable, Hashable {
     // [self classForArchiver] by default, NOT -classForCoder as might be
     // expected.  This is a concession to source compatibility.
     
-    public func replacementObjectForKeyedArchiver(_ archiver: NSKeyedArchiver) -> AnyObject? {
+    open func replacementObjectForKeyedArchiver(_ archiver: NSKeyedArchiver) -> AnyObject? {
         return self.replacementObjectForCoder(archiver)
     }
     
@@ -147,15 +147,15 @@ public class NSObject : NSObjectProtocol, Equatable, Hashable {
     // -replacementObjectForCoder: as might be expected.  This is a concession
     // to source compatibility.
     
-    public class func classFallbacksForKeyedArchiver() -> [String] {
+    open class func classFallbacksForKeyedArchiver() -> [String] {
         return []
     }
 
-    public class func classForKeyedUnarchiver() -> AnyClass {
+    open class func classForKeyedUnarchiver() -> AnyClass {
         return self
     }
 
-    public var hashValue: Int {
+    open var hashValue: Int {
         return hash
     }
 }

--- a/Foundation/NSOperation.swift
+++ b/Foundation/NSOperation.swift
@@ -17,7 +17,7 @@ private func pthread_main_np() -> Int32 {
 #endif
 #endif
 
-public class Operation: NSObject {
+open class Operation: NSObject {
     let lock = Lock()
     internal weak var _queue: OperationQueue?
     internal var _cancelled = false
@@ -48,7 +48,7 @@ public class Operation: NSObject {
     }
     
     /// - Note: Operations that are asynchronous from the execution of the operation queue itself are not supported since there is no KVO to trigger the finish.
-    public func start() {
+    open func start() {
         main()
         finish()
     }
@@ -72,37 +72,37 @@ public class Operation: NSObject {
 #endif
     }
     
-    public func main() { }
+    open func main() { }
     
-    public var isCancelled: Bool {
+    open var isCancelled: Bool {
         return _cancelled
     }
     
-    public func cancel() {
+    open func cancel() {
         lock.lock()
         _cancelled = true
         _leaveGroups()
         lock.unlock()
     }
     
-    public var isExecuting: Bool {
+    open var isExecuting: Bool {
         return _executing
     }
     
-    public var isFinished: Bool {
+    open var isFinished: Bool {
         return _finished
     }
     
     // - Note: This property is NEVER used in the objective-c implementation!
-    public var isAsynchronous: Bool {
+    open var isAsynchronous: Bool {
         return false
     }
     
-    public var isReady: Bool {
+    open var isReady: Bool {
         return _ready
     }
     
-    public func addDependency(_ op: Operation) {
+    open func addDependency(_ op: Operation) {
         lock.lock()
         _dependencies.insert(op)
         op.lock.lock()
@@ -114,7 +114,7 @@ public class Operation: NSObject {
         lock.unlock()
     }
     
-    public func removeDependency(_ op: Operation) {
+    open func removeDependency(_ op: Operation) {
         lock.lock()
         _dependencies.remove(op)
         op.lock.lock()
@@ -129,27 +129,27 @@ public class Operation: NSObject {
         lock.unlock()
     }
     
-    public var dependencies: [Operation] {
+    open var dependencies: [Operation] {
         lock.lock()
         let ops = _dependencies.map() { $0 }
         lock.unlock()
         return ops
     }
     
-    public var queuePriority: QueuePriority = .normal
+    open var queuePriority: QueuePriority = .normal
     public var completionBlock: (() -> Void)?
-    public func waitUntilFinished() {
+    open func waitUntilFinished() {
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
         _group.wait()
 #endif
     }
     
-    public var threadPriority: Double = 0.5
+    open var threadPriority: Double = 0.5
     
     /// - Note: Quality of service is not directly supported here since there are not qos class promotions available outside of darwin targets.
-    public var qualityOfService: NSQualityOfService = .default
+    open var qualityOfService: NSQualityOfService = .default
     
-    public var name: String?
+    open var name: String?
     
     internal func _waitUntilReady() {
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
@@ -169,7 +169,7 @@ extension Operation {
     }
 }
 
-public class BlockOperation: Operation {
+open class BlockOperation: Operation {
     typealias ExecutionBlock = () -> Void
     internal var _block: () -> Void
     internal var _executionBlocks = [ExecutionBlock]()
@@ -178,7 +178,7 @@ public class BlockOperation: Operation {
         _block = block
     }
     
-    override public func main() {
+    override open func main() {
         lock.lock()
         let block = _block
         let executionBlocks = _executionBlocks
@@ -187,13 +187,13 @@ public class BlockOperation: Operation {
         executionBlocks.forEach { $0() }
     }
     
-    public func addExecutionBlock(_ block: @escaping () -> Void) {
+    open func addExecutionBlock(_ block: @escaping () -> Void) {
         lock.lock()
         _executionBlocks.append(block)
         lock.unlock()
     }
     
-    public var executionBlocks: [() -> Void] {
+    open var executionBlocks: [() -> Void] {
         lock.lock()
         let blocks = _executionBlocks
         lock.unlock()
@@ -293,7 +293,7 @@ internal struct _OperationList {
     }
 }
 
-public class OperationQueue: NSObject {
+open class OperationQueue: NSObject {
     let lock = Lock()
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
     var __concurrencyGate: DispatchSemaphore?
@@ -366,7 +366,7 @@ public class OperationQueue: NSObject {
         return op
     }
     
-    public func addOperation(_ op: Operation) {
+    open func addOperation(_ op: Operation) {
         addOperations([op], waitUntilFinished: false)
     }
     
@@ -381,7 +381,7 @@ public class OperationQueue: NSObject {
         }
     }
     
-    public func addOperations(_ ops: [Operation], waitUntilFinished wait: Bool) {
+    open func addOperations(_ ops: [Operation], waitUntilFinished wait: Bool) {
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
         var waitGroup: DispatchGroup?
         if wait {
@@ -437,14 +437,14 @@ public class OperationQueue: NSObject {
         lock.unlock()
     }
     
-    public func addOperationWithBlock(_ block: @escaping () -> Void) {
+    open func addOperationWithBlock(_ block: @escaping () -> Void) {
         let op = BlockOperation(block: block)
         op.qualityOfService = qualityOfService
         addOperation(op)
     }
     
     // WARNING: the return value of this property can never be used to reliably do anything sensible
-    public var operations: [Operation] {
+    open var operations: [Operation] {
         lock.lock()
         let ops = _operations.map() { $0 }
         lock.unlock()
@@ -452,17 +452,17 @@ public class OperationQueue: NSObject {
     }
     
     // WARNING: the return value of this property can never be used to reliably do anything sensible
-    public var operationCount: Int {
+    open var operationCount: Int {
         lock.lock()
         let count = _operations.count
         lock.unlock()
         return count
     }
     
-    public var maxConcurrentOperationCount: Int = NSOperationQueueDefaultMaxConcurrentOperationCount
+    open var maxConcurrentOperationCount: Int = NSOperationQueueDefaultMaxConcurrentOperationCount
     
     internal var _suspended = false
-    public var suspended: Bool {
+    open var suspended: Bool {
         get {
             return _suspended
         }
@@ -485,7 +485,7 @@ public class OperationQueue: NSObject {
     }
     
     internal var _name: String?
-    public var name: String? {
+    open var name: String? {
         get {
             lock.lock()
             let val = _name
@@ -502,11 +502,11 @@ public class OperationQueue: NSObject {
         }
     }
     
-    public var qualityOfService: NSQualityOfService = .default
+    open var qualityOfService: NSQualityOfService = .default
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
     // Note: this will return non nil whereas the objective-c version will only return non nil when it has been set.
     // it uses a target queue assignment instead of returning the actual underlying queue.
-    public var underlyingQueue: DispatchQueue? {
+    open var underlyingQueue: DispatchQueue? {
         get {
             lock.lock()
             let queue = __underlyingQueue
@@ -521,14 +521,14 @@ public class OperationQueue: NSObject {
     }
 #endif
     
-    public func cancelAllOperations() {
+    open func cancelAllOperations() {
         lock.lock()
         let ops = _operations.map() { $0 }
         lock.unlock()
         ops.forEach() { $0.cancel() }
     }
     
-    public func waitUntilAllOperationsAreFinished() {
+    open func waitUntilAllOperationsAreFinished() {
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
         queueGroup.wait()
 #endif
@@ -538,7 +538,7 @@ public class OperationQueue: NSObject {
     static let OperationQueueKey = DispatchSpecificKey<Unmanaged<OperationQueue>>()
 #endif
 
-    public class func currentQueue() -> OperationQueue? {
+    open class func currentQueue() -> OperationQueue? {
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
         let specific = DispatchQueue.getSpecific(key: OperationQueue.OperationQueueKey)
         if specific == nil {
@@ -555,7 +555,7 @@ public class OperationQueue: NSObject {
 #endif
     }
     
-    public class func mainQueue() -> OperationQueue {
+    open class func mainQueue() -> OperationQueue {
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
         let specific = DispatchQueue.main.getSpecific(key: OperationQueue.OperationQueueKey)
         if specific == nil {

--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -8,23 +8,23 @@
 //
 
 /****************       Immutable Ordered Set   ****************/
-public class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, ExpressibleByArrayLiteral {
+open class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, ExpressibleByArrayLiteral {
     internal var _storage: Set<NSObject>
     internal var _orderedStorage: [NSObject]
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         NSUnimplemented()
     }
 
-    public override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> AnyObject {
         return mutableCopy(with: nil)
     }
 
-    public func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
         NSUnimplemented()
     }
     
@@ -32,7 +32,7 @@ public class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         return true
     }
     
-    public override func isEqual(_ object: AnyObject?) -> Bool {
+    open override func isEqual(_ object: AnyObject?) -> Bool {
         if let orderedSet = object as? NSOrderedSet {
             return isEqualToOrderedSet(orderedSet)
         } else {
@@ -40,7 +40,7 @@ public class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         }
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         if aCoder.allowsKeyedCoding {
             for idx in 0..<self.count {
                 aCoder.encode(self.objectAtIndex(idx), forKey:"NS.object.\(idx)")
@@ -67,15 +67,15 @@ public class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         }
     }
     
-    public var count: Int {
+    open var count: Int {
         return _storage.count
     }
 
-    public func objectAtIndex(_ idx: Int) -> AnyObject {
+    open func objectAtIndex(_ idx: Int) -> AnyObject {
         return _orderedStorage[idx]
     }
 
-    public func indexOfObject(_ object: AnyObject) -> Int {
+    open func indexOfObject(_ object: AnyObject) -> Int {
         guard let object = object as? NSObject else {
             return NSNotFound
         }
@@ -104,7 +104,7 @@ public class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
       self.init(array: elements)
     }
     
-    public subscript (idx: Int) -> AnyObject {
+    open subscript (idx: Int) -> AnyObject {
         return objectAtIndex(idx)
     }
 
@@ -324,9 +324,9 @@ extension NSOrderedSet {
 
 /****************       Mutable Ordered Set     ****************/
 
-public class NSMutableOrderedSet : NSOrderedSet {
+open class NSMutableOrderedSet : NSOrderedSet {
     
-    public func insertObject(_ object: AnyObject, atIndex idx: Int) {
+    open func insertObject(_ object: AnyObject, atIndex idx: Int) {
         guard idx < count && idx >= 0 else {
             fatalError("\(self): Index out of bounds")
         }
@@ -341,12 +341,12 @@ public class NSMutableOrderedSet : NSOrderedSet {
         }
     }
 
-    public func removeObjectAtIndex(_ idx: Int) {
+    open func removeObjectAtIndex(_ idx: Int) {
         _storage.remove(_orderedStorage[idx])
         _orderedStorage.remove(at: idx)
     }
 
-    public func replaceObjectAtIndex(_ idx: Int, withObject object: AnyObject) {
+    open func replaceObjectAtIndex(_ idx: Int, withObject object: AnyObject) {
         guard idx < count && idx >= 0 else {
             fatalError("\(self): Index out of bounds")
         }

--- a/Foundation/NSPersonNameComponents.swift
+++ b/Foundation/NSPersonNameComponents.swift
@@ -8,7 +8,7 @@
 //
 
 
-public class NSPersonNameComponents : NSObject, NSCopying, NSSecureCoding {
+open class NSPersonNameComponents : NSObject, NSCopying, NSSecureCoding {
     
     public convenience required init?(coder aDecoder: NSCoder) {
         self.init()
@@ -31,7 +31,7 @@ public class NSPersonNameComponents : NSObject, NSCopying, NSSecureCoding {
     
     static public func supportsSecureCoding() -> Bool { return true }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         if aCoder.allowsKeyedCoding {
             aCoder.encode(self.namePrefix?.bridge(), forKey: "NS.namePrefix")
             aCoder.encode(self.givenName?.bridge(), forKey: "NS.givenName")
@@ -50,31 +50,31 @@ public class NSPersonNameComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject { NSUnimplemented() }
+    open func copy(with zone: NSZone? = nil) -> AnyObject { NSUnimplemented() }
     
     /* The below examples all assume the full name Dr. Johnathan Maple Appleseed Esq., nickname "Johnny" */
     
     /* Pre-nominal letters denoting title, salutation, or honorific, e.g. Dr., Mr. */
-    public var namePrefix: String?
+    open var namePrefix: String?
     
     /* Name bestowed upon an individual by one's parents, e.g. Johnathan */
-    public var givenName: String?
+    open var givenName: String?
     
     /* Secondary given name chosen to differentiate those with the same first name, e.g. Maple  */
-    public var middleName: String?
+    open var middleName: String?
     
     /* Name passed from one generation to another to indicate lineage, e.g. Appleseed  */
-    public var familyName: String?
+    open var familyName: String?
     
     /* Post-nominal letters denoting degree, accreditation, or other honor, e.g. Esq., Jr., Ph.D. */
-    public var nameSuffix: String?
+    open var nameSuffix: String?
     
     /* Name substituted for the purposes of familiarity, e.g. "Johnny"*/
-    public var nickname: String?
+    open var nickname: String?
     
     /* Each element of the phoneticRepresentation should correspond to an element of the original PersonNameComponents instance.
        The phoneticRepresentation of the phoneticRepresentation object itself will be ignored. nil by default, must be instantiated.
     */
-    /*@NSCopying*/ public var phoneticRepresentation: PersonNameComponents?
+    /*@NSCopying*/ open var phoneticRepresentation: PersonNameComponents?
 }
 

--- a/Foundation/NSPersonNameComponentsFormatter.swift
+++ b/Foundation/NSPersonNameComponentsFormatter.swift
@@ -39,7 +39,7 @@ extension PersonNameComponentsFormatter {
     }
 }
 
-public class PersonNameComponentsFormatter : Formatter {
+open class PersonNameComponentsFormatter : Formatter {
     
     public required init?(coder: NSCoder) {
         NSUnimplemented()
@@ -47,33 +47,33 @@ public class PersonNameComponentsFormatter : Formatter {
     
     /* Specify the formatting style for the formatted string on an instance. ShortStyle will fall back to user preferences and language-specific defaults
      */
-    public var style: Style
+    open var style: Style
     
     /* Specify that the formatter should only format the components object's phoneticRepresentation
      */
-    public var phonetic: Bool
+    open var phonetic: Bool
     
     /* Shortcut for converting an NSPersonNameComponents object into a string without explicitly creating an instance.
         Create an instance for greater customizability.
      */
-    public class func localizedString(from components: PersonNameComponents, style nameFormatStyle: Style, options nameOptions: Options = []) -> String { NSUnimplemented() }
+    open class func localizedString(from components: PersonNameComponents, style nameFormatStyle: Style, options nameOptions: Options = []) -> String { NSUnimplemented() }
     
     /* Convenience method on string(for:):. Returns a string containing the formatted value of the provided components object.
      */
-    public func string(from components: PersonNameComponents) -> String { NSUnimplemented() }
+    open func string(from components: PersonNameComponents) -> String { NSUnimplemented() }
     
     /* Returns attributed string with annotations for each component. For each range, attributes can be obtained by querying
         dictionary key NSPersonNameComponentKey , using NSPersonNameComponent constant values.
      */
-    public func annotatedString(from components: PersonNameComponents) -> AttributedString { NSUnimplemented() }
+    open func annotatedString(from components: PersonNameComponents) -> AttributedString { NSUnimplemented() }
     
-    public func personNameComponents(from string: String) -> PersonNameComponents? { NSUnimplemented() }
+    open func personNameComponents(from string: String) -> PersonNameComponents? { NSUnimplemented() }
     
     /* NSPersonNameComponentsFormatter currently only implements formatting, not parsing. Until it implements parsing, this will always return NO.
      */
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    public override func objectValue(_ string: String) throws -> AnyObject? { return nil }
+    open override func objectValue(_ string: String) throws -> AnyObject? { return nil }
 }
 
 // Attributed String identifier key string

--- a/Foundation/NSPort.swift
+++ b/Foundation/NSPort.swift
@@ -12,7 +12,7 @@ public typealias SocketNativeHandle = Int32
 
 public let NSPortDidBecomeInvalidNotification: String = "NSPortDidBecomeInvalidNotification"
 
-public class Port : NSObject, NSCopying, NSCoding {
+open class Port : NSObject, NSCopying, NSCoding {
     
     public override init() {
         
@@ -22,49 +22,49 @@ public class Port : NSObject, NSCopying, NSCoding {
         NSUnimplemented()
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         NSUnimplemented()
     }
     
-    public func invalidate() {
+    open func invalidate() {
         NSUnimplemented()
     }
 
-    public var valid: Bool {
+    open var valid: Bool {
         NSUnimplemented()
     }
     
     // TODO: this delegate situation is confusing on all platforms
     /*
-    public func setDelegate(_ anObject: PortDelegate?)
-    public func delegate() -> PortDelegate?
+    open func setDelegate(_ anObject: PortDelegate?)
+    open func delegate() -> PortDelegate?
     */
     
     // These two methods should be implemented by subclasses
     // to setup monitoring of the port when added to a run loop,
     // and stop monitoring if needed when removed;
     // These methods should not be called directly!
-    public func schedule(in runLoop: RunLoop, forMode mode: RunLoopMode) {
+    open func schedule(in runLoop: RunLoop, forMode mode: RunLoopMode) {
         NSUnimplemented()
     }
 
-    public func remove(from runLoop: RunLoop, forMode mode: RunLoopMode) {
+    open func remove(from runLoop: RunLoop, forMode mode: RunLoopMode) {
         NSUnimplemented()
     }
     
-    public var reservedSpaceLength: Int {
+    open var reservedSpaceLength: Int {
         return 0
     }
     
-    public func sendBeforeDate(_ limitDate: Date, components: NSMutableArray?, from receivePort: Port?, reserved headerSpaceReserved: Int) -> Bool {
+    open func sendBeforeDate(_ limitDate: Date, components: NSMutableArray?, from receivePort: Port?, reserved headerSpaceReserved: Int) -> Bool {
         NSUnimplemented()
     }
 
-    public func sendBeforeDate(_ limitDate: Date, msgid msgID: Int, components: NSMutableArray?, from receivePort: Port?, reserved headerSpaceReserved: Int) -> Bool {
+    open func sendBeforeDate(_ limitDate: Date, msgid msgID: Int, components: NSMutableArray?, from receivePort: Port?, reserved headerSpaceReserved: Int) -> Bool {
         NSUnimplemented()
     }
 }
@@ -80,13 +80,13 @@ public protocol PortDelegate : class {
 // A subclass of NSPort which can be used for local
 // message sending on all platforms.
 
-public class MessagePort : Port {
+open class MessagePort : Port {
 }
 
 // A subclass of NSPort which can be used for remote
 // message sending on all platforms.
 
-public class SocketPort : Port {
+open class SocketPort : Port {
     
     public convenience override init() {
         NSUnimplemented()
@@ -116,23 +116,23 @@ public class SocketPort : Port {
         NSUnimplemented()
     }
 
-    public var protocolFamily: Int32 {
+    open var protocolFamily: Int32 {
         NSUnimplemented()
     }
     
-    public var socketType: Int32 {
+    open var socketType: Int32 {
         NSUnimplemented()
     }
     
-    public var `protocol`: Int32 {
+    open var `protocol`: Int32 {
         NSUnimplemented()
     }
     
-    /*@NSCopying*/ public var address: Data {
+    /*@NSCopying*/ open var address: Data {
         NSUnimplemented()
     }
     
-    public var socket: SocketNativeHandle {
+    open var socket: SocketNativeHandle {
         NSUnimplemented()
     }
 }

--- a/Foundation/NSPortMessage.swift
+++ b/Foundation/NSPortMessage.swift
@@ -8,27 +8,27 @@
 //
 
 
-public class PortMessage : NSObject {
+open class PortMessage : NSObject {
     
     public init(sendPort: Port?, receivePort replyPort: Port?, components: [AnyObject]?) {
         NSUnimplemented()
     }
     
-    public var components: [AnyObject]? {
+    open var components: [AnyObject]? {
         NSUnimplemented()
     }
     
-    public var receivePort: Port? {
+    open var receivePort: Port? {
         NSUnimplemented()
     }
     
-    public var sendPort: Port? {
+    open var sendPort: Port? {
         NSUnimplemented()
     }
     
-    public func sendBeforeDate(_ date: Date) -> Bool {
+    open func sendBeforeDate(_ date: Date) -> Bool {
         NSUnimplemented()
     }
     
-    public var msgid: UInt32
+    open var msgid: UInt32
 }

--- a/Foundation/NSPredicate.swift
+++ b/Foundation/NSPredicate.swift
@@ -10,7 +10,7 @@
 
 // Predicates wrap some combination of expressions and operators and when evaluated return a BOOL.
 
-public class Predicate : NSObject, NSSecureCoding, NSCopying {
+open class Predicate : NSObject, NSSecureCoding, NSCopying {
 
     private enum PredicateKind {
         case boolean(Bool)
@@ -29,15 +29,15 @@ public class Predicate : NSObject, NSSecureCoding, NSCopying {
         NSUnimplemented()
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         NSUnimplemented()
     }
     
@@ -56,15 +56,15 @@ public class Predicate : NSObject, NSSecureCoding, NSCopying {
         super.init()
     }
     
-    public var predicateFormat: String  { NSUnimplemented() } // returns the format string of the predicate
+    open var predicateFormat: String  { NSUnimplemented() } // returns the format string of the predicate
     
-    public func withSubstitutionVariables(_ variables: [String : AnyObject]) -> Self { NSUnimplemented() } // substitute constant values for variables
+    open func withSubstitutionVariables(_ variables: [String : AnyObject]) -> Self { NSUnimplemented() } // substitute constant values for variables
     
-    public func evaluate(with object: AnyObject?) -> Bool {
+    open func evaluate(with object: AnyObject?) -> Bool {
         return evaluate(with: object, substitutionVariables: nil)
     } // evaluate a predicate against a single object
     
-    public func evaluate(with object: AnyObject?, substitutionVariables bindings: [String : AnyObject]?) -> Bool {
+    open func evaluate(with object: AnyObject?, substitutionVariables bindings: [String : AnyObject]?) -> Bool {
         if bindings != nil {
             NSUnimplemented()
         }
@@ -77,7 +77,7 @@ public class Predicate : NSObject, NSSecureCoding, NSCopying {
         }
     } // single pass evaluation substituting variables from the bindings dictionary for any variable expressions encountered
     
-    public func allowEvaluation() { NSUnimplemented() } // Force a predicate which was securely decoded to allow evaluation
+    open func allowEvaluation() { NSUnimplemented() } // Force a predicate which was securely decoded to allow evaluation
 }
 
 extension NSArray {

--- a/Foundation/NSProcessInfo.swift
+++ b/Foundation/NSProcessInfo.swift
@@ -33,10 +33,10 @@ public struct NSOperatingSystemVersion {
 
 
 
-public class ProcessInfo: NSObject {
+open class ProcessInfo: NSObject {
     
     internal static let _processInfo = ProcessInfo()
-    public class func processInfo() -> ProcessInfo {
+    open class func processInfo() -> ProcessInfo {
         return _processInfo
     }
     
@@ -54,15 +54,15 @@ public class ProcessInfo: NSObject {
         return env
     }()
     
-    public var environment: [String : String] {
+    open var environment: [String : String] {
         return ProcessInfo._environment
     }
     
-    public var arguments: [String] {
+    open var arguments: [String] {
         return CommandLine.arguments // seems reasonable to flip the script here...
     }
     
-    public var hostName: String {
+    open var hostName: String {
         if let name = Host.currentHost().name {
             return name
         } else {
@@ -70,22 +70,22 @@ public class ProcessInfo: NSObject {
         }
     }
     
-    public var processName: String = _CFProcessNameString()._swiftObject
+    open var processName: String = _CFProcessNameString()._swiftObject
     
-    public var processIdentifier: Int32 {
+    open var processIdentifier: Int32 {
         return __CFGetPid()
     }
     
-    public var globallyUniqueString: String {
+    open var globallyUniqueString: String {
         let uuid = CFUUIDCreate(kCFAllocatorSystemDefault)
         return CFUUIDCreateString(kCFAllocatorSystemDefault, uuid)._swiftObject
     }
 
-    public var operatingSystemVersionString: String {
+    open var operatingSystemVersionString: String {
         return CFCopySystemVersionString()?._swiftObject ?? "Unknown"
     }
     
-    public var operatingSystemVersion: NSOperatingSystemVersion {
+    open var operatingSystemVersion: NSOperatingSystemVersion {
         // The following fallback values match Darwin Foundation
         let fallbackMajor = -1
         let fallbackMinor = 0
@@ -108,21 +108,21 @@ public class ProcessInfo: NSObject {
     }
     
     internal let _processorCount = __CFProcessorCount()
-    public var processorCount: Int {
+    open var processorCount: Int {
         return Int(_processorCount)
     }
     
     internal let _activeProcessorCount = __CFActiveProcessorCount()
-    public var activeProcessorCount: Int {
+    open var activeProcessorCount: Int {
         return Int(_activeProcessorCount)
     }
     
     internal let _physicalMemory = __CFMemorySize()
-    public var physicalMemory: UInt64 {
+    open var physicalMemory: UInt64 {
         return _physicalMemory
     }
     
-    public func isOperatingSystemAtLeastVersion(_ version: NSOperatingSystemVersion) -> Bool {
+    open func isOperatingSystemAtLeastVersion(_ version: NSOperatingSystemVersion) -> Bool {
         let ourVersion = operatingSystemVersion
         if ourVersion.majorVersion < version.majorVersion {
             return false
@@ -145,7 +145,7 @@ public class ProcessInfo: NSObject {
         return true
     }
     
-    public var systemUptime: TimeInterval {
+    open var systemUptime: TimeInterval {
         return CFGetSystemUptime()
     }
 }

--- a/Foundation/NSProgress.swift
+++ b/Foundation/NSProgress.swift
@@ -24,11 +24,11 @@
 
  The localizedDescription and localizedAdditionalDescription properties are meant to be observed as well as set. So are the cancellable and pausable properties. totalUnitCount and completedUnitCount on the other hand are often not the best properties to observe when presenting progress to the user. For example, you should observe fractionCompleted instead of observing totalUnitCount and completedUnitCount and doing your own calculation. NSProgress' default implementation of fractionCompleted does fairly sophisticated things like taking child NSProgresses into account.
  */
-public class NSProgress : NSObject {
+open class NSProgress : NSObject {
     
     /* The instance of NSProgress associated with the current thread by a previous invocation of -becomeCurrentWithPendingUnitCount:, if any. The purpose of this per-thread value is to allow code that does work to usefully report progress even when it is widely separated from the code that actually presents progress to the user, without requiring layers of intervening code to pass the instance of NSProgress through. Using the result of invoking this directly will often not be the right thing to do, because the invoking code will often not even know what units of work the current progress object deals in. Invoking +progressWithTotalUnitCount: to create a child NSProgress object and then using that to report progress makes more sense in that situation.
     */
-    public class func currentProgress() -> NSProgress? { NSUnimplemented() }
+    open class func currentProgress() -> NSProgress? { NSUnimplemented() }
     
     /* Return an instance of NSProgress that has been initialized with -initWithParent:userInfo:. The initializer is passed the current progress object, if there is one, and the value of the totalUnitCount property is set. In many cases you can simply precede code that does a substantial amount of work with an invocation of this method, with repeated invocations of -setCompletedUnitCount: and -isCancelled in the loop that does the work.
     
@@ -38,7 +38,7 @@ public class NSProgress : NSObject {
     
     /* Return an instance of NSProgress that has been initialized with -initWithParent:userInfo:. The initializer is passed nil for the parent, resulting in a progress object that is not part of an existing progress tree. The value of the totalUnitCount property is also set.
      */
-    public class func discreteProgressWithTotalUnitCount(_ unitCount: Int64) -> NSProgress { NSUnimplemented() }
+    open class func discreteProgressWithTotalUnitCount(_ unitCount: Int64) -> NSProgress { NSUnimplemented() }
     
     /* Return an instance of NSProgress that has been attached to a parent progress with the given pending unit count.
      */
@@ -52,21 +52,21 @@ public class NSProgress : NSObject {
      
        With this mechanism, code that doesn't know anything about its callers can report progress accurately by using +progressWithTotalUnitCount: and -setCompletedUnitCount:. The calling code will account for the fact that the work done is only a portion of the work to be done as part of a larger operation. The unit of work in a call to -becomeCurrentWithPendingUnitCount: has to be the same unit of work as that used for the value of the totalUnitCount property, but the unit of work used by the child can be a completely different one, and often will be. You must always balance invocations of this method with invocations of -resignCurrent.
     */
-    public func becomeCurrentWithPendingUnitCount(_ unitCount: Int64) { NSUnimplemented() }
+    open func becomeCurrentWithPendingUnitCount(_ unitCount: Int64) { NSUnimplemented() }
     
     /* Balance the most recent previous invocation of -becomeCurrentWithPendingUnitCount: on the same thread by restoring the current progress object to what it was before -becomeCurrentWithPendingUnitCount: was invoked.
     */
-    public func resignCurrent() { NSUnimplemented() }
+    open func resignCurrent() { NSUnimplemented() }
     
     /* Directly add a child progress to the receiver, assigning it a portion of the receiver's total unit count.
      */
-    public func addChild(_ child: NSProgress, withPendingUnitCount inUnitCount: Int64) { NSUnimplemented() }
+    open func addChild(_ child: NSProgress, withPendingUnitCount inUnitCount: Int64) { NSUnimplemented() }
     
     /* The size of the job whose progress is being reported, and how much of it has been completed so far, respectively. For an NSProgress with a kind of NSProgressKindFile, the unit of these properties is bytes while the NSProgressFileTotalCountKey and NSProgressFileCompletedCountKey keys in the userInfo dictionary are used for the overall count of files. For any other kind of NSProgress, the unit of measurement you use does not matter as long as you are consistent. The values may be reported to the user in the localizedDescription and localizedAdditionalDescription.
      
        If the receiver NSProgress object is a "leaf progress" (no children), then the fractionCompleted is generally completedUnitCount / totalUnitCount. If the receiver NSProgress has children, the fractionCompleted will reflect progress made in child objects in addition to its own completedUnitCount. As children finish, the completedUnitCount of the parent will be updated.
     */
-    public var totalUnitCount: Int64
+    open var totalUnitCount: Int64
     public var completedUnitCount: Int64
     
     /* A description of what progress is being made, fit to present to the user. NSProgress is by default KVO-compliant for this property, with the notifications always being sent on thread which updates the property. The default implementation of the getter for this property does not always return the most recently set value of the property. If the most recently set value of this property is nil then NSProgress uses the value of the kind property to determine how to use the values of other properties, as well as values in the user info dictionary, to return a computed string. If it fails to do that then it returns an empty string.
@@ -76,7 +76,7 @@ public class NSProgress : NSObject {
         30% completed
         Copying “TextEdit”…
     */
-    public var localizedDescription: String!
+    open var localizedDescription: String!
     
     /* A more specific description of what progress is being made, fit to present to the user. NSProgress is by default KVO-compliant for this property, with the notifications always being sent on thread which updates the property. The default implementation of the getter for this property does not always return the most recently set value of the property. If the most recently set value of this property is nil then NSProgress uses the value of the kind property to determine how to use the values of other properties, as well as values in the user info dictionary, to return a computed string. If it fails to do that then it returns an empty string. The difference between this and localizedDescription is that this text is meant to be more specific about what work is being done at any particular moment.
     
@@ -88,37 +88,37 @@ public class NSProgress : NSObject {
         1 minute remaining (1 KB/sec)
     
     */
-    public var localizedAdditionalDescription: String!
+    open var localizedAdditionalDescription: String!
     
     /* Whether the work being done can be cancelled or paused, respectively. By default NSProgresses are cancellable but not pausable. NSProgress is by default KVO-compliant for these properties, with the notifications always being sent on the thread which updates the property. These properties are for communicating whether controls for cancelling and pausing should appear in a progress reporting user interface. NSProgress itself does not do anything with these properties other than help pass their values from progress reporters to progress observers. It is valid for the values of these properties to change in virtually any way during the lifetime of an NSProgress. Of course, if an NSProgress is cancellable you should actually implement cancellability by setting a cancellation handler or by making your code poll the result of invoking -isCancelled. Likewise for pausability.
     */
-    public var cancellable: Bool
-    public var pausable: Bool
+    open var cancellable: Bool
+    open var pausable: Bool
     
     /* Whether the work being done has been cancelled or paused, respectively. NSProgress is by default KVO-compliant for these properties, with the notifications always being sent on the thread which updates the property. Instances of NSProgress that have parents are at least as cancelled or paused as their parents.
     */
-    public var cancelled: Bool { NSUnimplemented() }
-    public var paused: Bool { NSUnimplemented() }
+    open var cancelled: Bool { NSUnimplemented() }
+    open var paused: Bool { NSUnimplemented() }
     
     /* A block to be invoked when cancel is invoked. The block will be invoked even when the method is invoked on an ancestor of the receiver, or an instance of NSProgress in another process that resulted from publishing the receiver or an ancestor of the receiver. Your block won't be invoked on any particular queue. If it must do work on a specific queue then it should schedule that work on that queue.
     */
-    public var cancellationHandler: (() -> Void)?
+    open var cancellationHandler: (() -> Void)?
     
     /* A block to be invoked when pause is invoked. The block will be invoked even when the method is invoked on an ancestor of the receiver, or an instance of NSProgress in another process that resulted from publishing the receiver or an ancestor of the receiver. Your block won't be invoked on any particular queue. If it must do work on a specific queue then it should schedule that work on that queue.
      */
-    public var pausingHandler: (() -> Void)?
+    open var pausingHandler: (() -> Void)?
     
     /* A block to be invoked when resume is invoked. The block will be invoked even when the method is invoked on an ancestor of the receiver, or an instance of NSProgress in another process that resulted from publishing the receiver or an ancestor of the receiver. Your block won't be invoked on any particular queue. If it must do work on a specific queue then it should schedule that work on that queue.
      */
-    public var resumingHandler: (() -> Void)?
+    open var resumingHandler: (() -> Void)?
     
     /* Set a value in the dictionary returned by invocations of -userInfo, with appropriate KVO notification for properties whose values can depend on values in the user info dictionary, like localizedDescription. If a nil value is passed then the dictionary entry is removed.
     */
-    public func setUserInfoObject(_ objectOrNil: AnyObject?, forKey key: String) { NSUnimplemented() }
+    open func setUserInfoObject(_ objectOrNil: AnyObject?, forKey key: String) { NSUnimplemented() }
     
     /* Whether the progress being made is indeterminate. -isIndeterminate returns YES when the value of the totalUnitCount or completedUnitCount property is less than zero. Zero values for both of those properties indicates that there turned out to not be any work to do after all; -isIndeterminate returns NO and -fractionCompleted returns 1.0 in that case. NSProgress is by default KVO-compliant for these properties, with the notifications always being sent on the thread which updates the property.
     */
-    public var indeterminate: Bool { NSUnimplemented() }
+    open var indeterminate: Bool { NSUnimplemented() }
     
     /* The fraction of the overall work completed by this progress object, including work done by any children it may have.
     */
@@ -126,23 +126,23 @@ public class NSProgress : NSObject {
     
     /* Invoke the block registered with the cancellationHandler property, if there is one, and set the cancelled property to YES. Do this for the receiver, any descendants of the receiver, the instance of NSProgress that was published in another process to make the receiver if that's the case, and any descendants of such a published instance of NSProgress.
     */
-    public func cancel() { NSUnimplemented() }
+    open func cancel() { NSUnimplemented() }
     
     /* Invoke the block registered with the pausingHandler property, if there is one, and set the paused property to YES. Do this for the receiver, any descendants of the receiver, the instance of NSProgress that was published in another process to make the receiver if that's the case, and any descendants of such a published instance of NSProgress.
     */
-    public func pause() { NSUnimplemented() }
+    open func pause() { NSUnimplemented() }
     
     /* Invoke the block registered with the resumingHandler property, if there is one, and set the paused property to NO. Do this for the receiver, any descendants of the receiver, the instance of NSProgress that was published in another process to make the receiver if that's the case, and any descendants of such a published instance of NSProgress.
     */
-    public func resume() { NSUnimplemented() }
+    open func resume() { NSUnimplemented() }
     
     /* Arbitrary values associated with the receiver. Returns a KVO-compliant dictionary that changes as -setUserInfoObject:forKey: is sent to the receiver. The dictionary will send all of its KVO notifications on the thread which updates the property. The result will never be nil, but may be an empty dictionary. Some entries have meanings that are recognized by the NSProgress class itself. See the NSProgress...Key string constants listed below.
     */
-    public var userInfo: [NSObject : AnyObject] { NSUnimplemented() }
+    open var userInfo: [NSObject : AnyObject] { NSUnimplemented() }
     
     /* Either a string identifying what kind of progress is being made, like NSProgressKindFile, or nil. If the value of the localizedDescription property has not been set to a non-nil value then the default implementation of -localizedDescription uses the progress kind to determine how to use the values of other properties, as well as values in the user info dictionary, to create a string that is presentable to the user. This is most useful when -localizedDescription is actually being invoked in another process, whose localization language may be different, as a result of using the publish and subscribe mechanism described here.
     */
-    public var kind: String?
+    open var kind: String?
     
 }
 

--- a/Foundation/NSPropertyList.swift
+++ b/Foundation/NSPropertyList.swift
@@ -37,9 +37,9 @@ extension PropertyListSerialization {
     public typealias WriteOptions = Int
 }
 
-public class PropertyListSerialization : NSObject {
+open class PropertyListSerialization : NSObject {
 
-    public class func propertyList(_ plist: AnyObject, isValidFor format: PropertyListFormat) -> Bool {
+    open class func propertyList(_ plist: AnyObject, isValidFor format: PropertyListFormat) -> Bool {
 #if os(OSX) || os(iOS)
         let fmt = CFPropertyListFormat(rawValue: CFIndex(format.rawValue))!
 #else
@@ -48,7 +48,7 @@ public class PropertyListSerialization : NSObject {
         return CFPropertyListIsValid(unsafeBitCast(plist, to: CFPropertyList.self), fmt)
     }
     
-    public class func data(fromPropertyList plist: AnyObject, format: PropertyListFormat, options opt: WriteOptions) throws -> Data {
+    open class func data(fromPropertyList plist: AnyObject, format: PropertyListFormat, options opt: WriteOptions) throws -> Data {
         var error: Unmanaged<CFError>? = nil
         let result = withUnsafeMutablePointer(to: &error) { (outErr: UnsafeMutablePointer<Unmanaged<CFError>?>) -> CFData? in
 #if os(OSX) || os(iOS)
@@ -67,7 +67,7 @@ public class PropertyListSerialization : NSObject {
     }
     
     /// - Experiment: Note that the return type of this function is different than on Darwin Foundation (Any instead of AnyObject). This is likely to change once we have a more complete story for bridging in place.
-    public class func propertyList(from data: Data, options opt: ReadOptions = [], format: UnsafeMutablePointer<PropertyListFormat>?) throws -> Any {
+    open class func propertyList(from data: Data, options opt: ReadOptions = [], format: UnsafeMutablePointer<PropertyListFormat>?) throws -> Any {
         var fmt = kCFPropertyListBinaryFormat_v1_0
         var error: Unmanaged<CFError>? = nil
         let decoded = withUnsafeMutablePointer(to: &fmt) { (outFmt: UnsafeMutablePointer<CFPropertyListFormat>) -> NSObject? in
@@ -107,7 +107,7 @@ public class PropertyListSerialization : NSObject {
         }
     }
     
-    public class func propertyList(with stream: InputStream, options opt: ReadOptions = [], format: UnsafeMutablePointer<PropertyListFormat>?) throws -> Any {
+    open class func propertyList(with stream: InputStream, options opt: ReadOptions = [], format: UnsafeMutablePointer<PropertyListFormat>?) throws -> Any {
         NSUnimplemented()
     }
 }

--- a/Foundation/NSRegularExpression.swift
+++ b/Foundation/NSRegularExpression.swift
@@ -27,18 +27,18 @@ extension RegularExpression {
     }
 }
 
-public class RegularExpression: NSObject, NSCopying, NSCoding {
+open class RegularExpression: NSObject, NSCopying, NSCoding {
     internal var _internal: _CFRegularExpression
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         return self
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     
@@ -63,11 +63,11 @@ public class RegularExpression: NSObject, NSCopying, NSCoding {
         }
     }
     
-    public var pattern: String {
+    open var pattern: String {
         return _CFRegularExpressionGetPattern(_internal)._swiftObject
     }
     
-    public var options: Options {
+    open var options: Options {
 #if os(OSX) || os(iOS)
         let opt = _CFRegularExpressionGetOptions(_internal).rawValue
 #else
@@ -77,13 +77,13 @@ public class RegularExpression: NSObject, NSCopying, NSCoding {
         return Options(rawValue: opt)
     }
     
-    public var numberOfCaptureGroups: Int {
+    open var numberOfCaptureGroups: Int {
         return _CFRegularExpressionGetNumberOfCaptureGroups(_internal)
     }
     
     /* This class method will produce a string by adding backslash escapes as necessary to the given string, to escape any characters that would otherwise be treated as pattern metacharacters.
     */
-    public class func escapedPattern(for string: String) -> String { 
+    open class func escapedPattern(for string: String) -> String { 
         return _CFRegularExpressionCreateEscapedPattern(string._cfObject)._swiftObject
     }
 }
@@ -337,7 +337,7 @@ extension RegularExpression {
     
     /* This class method will produce a string by adding backslash escapes as necessary to the given string, to escape any characters that would otherwise be treated as template metacharacters. 
     */
-    public class func escapedTemplate(for string: String) -> String {
+    open class func escapedTemplate(for string: String) -> String {
         return _CFRegularExpressionCreateEscapedPattern(string._cfObject)._swiftObject
     }
 }

--- a/Foundation/NSRunLoop.swift
+++ b/Foundation/NSRunLoop.swift
@@ -54,7 +54,7 @@ internal func _NSRunLoopNew(_ cf: CFRunLoop) -> Unmanaged<AnyObject> {
     return unsafeBitCast(rl, to: Unmanaged<AnyObject>.self) // this retain is balanced on the other side of the CF fence
 }
 
-public class RunLoop: NSObject {
+open class RunLoop: NSObject {
     internal var _cfRunLoop : CFRunLoop!
     internal static var _mainRunLoop : RunLoop = {
         return RunLoop(cfObject: CFRunLoopGetMain())
@@ -64,15 +64,15 @@ public class RunLoop: NSObject {
         _cfRunLoop = cfObject
     }
 
-    public class func current() -> RunLoop {
+    open class func current() -> RunLoop {
         return _CFRunLoopGet2(CFRunLoopGetCurrent()) as! RunLoop
     }
 
-    public class func main() -> RunLoop {
+    open class func main() -> RunLoop {
         return _CFRunLoopGet2(CFRunLoopGetMain()) as! RunLoop
     }
 
-    public var currentMode: RunLoopMode? {
+    open var currentMode: RunLoopMode? {
         if let mode = CFRunLoopCopyCurrentMode(_cfRunLoop) {
             return RunLoopMode(mode._swiftObject)
         } else {
@@ -80,23 +80,23 @@ public class RunLoop: NSObject {
         }
     }
     
-    public func getCFRunLoop() -> CFRunLoop {
+    open func getCFRunLoop() -> CFRunLoop {
         return _cfRunLoop
     }
 
-    public func add(_ timer: Timer, forMode mode: RunLoopMode) {
+    open func add(_ timer: Timer, forMode mode: RunLoopMode) {
         CFRunLoopAddTimer(CFRunLoopGetCurrent(), timer._cfObject, mode.rawValue._cfObject)
     }
 
-    public func add(_ aPort: Port, forMode mode: RunLoopMode) {
+    open func add(_ aPort: Port, forMode mode: RunLoopMode) {
         NSUnimplemented()
     }
 
-    public func remove(_ aPort: Port, forMode mode: RunLoopMode) {
+    open func remove(_ aPort: Port, forMode mode: RunLoopMode) {
         NSUnimplemented()
     }
 
-    public func limitDate(forMode mode: RunLoopMode) -> Date? {
+    open func limitDate(forMode mode: RunLoopMode) -> Date? {
         if _cfRunLoop !== CFRunLoopGetCurrent() {
             return nil
         }
@@ -116,7 +116,7 @@ public class RunLoop: NSObject {
         return Date(timeIntervalSinceReferenceDate: nextTimerFireAbsoluteTime)
     }
 
-    public func acceptInputForMode(_ mode: String, before limitDate: Date) {
+    open func acceptInputForMode(_ mode: String, before limitDate: Date) {
         if _cfRunLoop !== CFRunLoopGetCurrent() {
             return
         }

--- a/Foundation/NSScanner.swift
+++ b/Foundation/NSScanner.swift
@@ -11,25 +11,25 @@
 
 import CoreFoundation
 
-public class Scanner: NSObject, NSCopying {
+open class Scanner: NSObject, NSCopying {
     internal var _scanString: String
     internal var _skipSet: CharacterSet?
     internal var _invertedSkipSet: CharacterSet?
     internal var _scanLocation: Int
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         return Scanner(string: string)
     }
     
-    public var string: String {
+    open var string: String {
         return _scanString
     }
     
-    public var scanLocation: Int {
+    open var scanLocation: Int {
         get {
             return _scanLocation
         }
@@ -40,7 +40,7 @@ public class Scanner: NSObject, NSCopying {
             _scanLocation = newValue
         }
     }
-    /*@NSCopying*/ public var charactersToBeSkipped: CharacterSet? {
+    /*@NSCopying*/ open var charactersToBeSkipped: CharacterSet? {
         get {
             return _skipSet
         }
@@ -62,8 +62,8 @@ public class Scanner: NSObject, NSCopying {
         }
     }
     
-    public var caseSensitive: Bool = false
-    public var locale: Locale?
+    open var caseSensitive: Bool = false
+    open var locale: Locale?
     
     internal static let defaultSkipSet = CharacterSet.whitespacesAndNewlines
     
@@ -503,7 +503,7 @@ extension Scanner {
         return stringLoc == stringLen
     }
     
-    public class func localizedScannerWithString(_ string: String) -> AnyObject { NSUnimplemented() }
+    open class func localizedScannerWithString(_ string: String) -> AnyObject { NSUnimplemented() }
 }
 
 

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -70,18 +70,18 @@ extension Set : _ObjectTypeBridgeable {
     }
 }
 
-public class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCoding {
+open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCoding {
     private let _cfinfo = _CFInfo(typeID: CFSetGetTypeID())
     internal var _storage: Set<NSObject>
     
-    public var count: Int {
+    open var count: Int {
         guard type(of: self) === NSSet.self || type(of: self) === NSMutableSet.self || type(of: self) === NSCountedSet.self else {
                 NSRequiresConcreteImplementation()
         }
         return _storage.count
     }
     
-    public func member(_ object: AnyObject) -> AnyObject? {
+    open func member(_ object: AnyObject) -> AnyObject? {
         guard type(of: self) === NSSet.self || type(of: self) === NSMutableSet.self || type(of: self) === NSCountedSet.self else {
             NSRequiresConcreteImplementation()
         }
@@ -93,7 +93,7 @@ public class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         return obj // this is not exactly the same behavior, but it is reasonably close
     }
     
-    public func objectEnumerator() -> NSEnumerator {
+    open func objectEnumerator() -> NSEnumerator {
         guard type(of: self) === NSSet.self || type(of: self) === NSMutableSet.self || type(of: self) === NSCountedSet.self else {
             NSRequiresConcreteImplementation()
         }
@@ -143,16 +143,16 @@ public class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         }
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         // The encoding of a NSSet is identical to the encoding of an NSArray of its contents
         self.allObjects._nsObject.encode(with: aCoder)
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         if type(of: self) === NSSet.self {
             // return self for immutable type
             return self
@@ -164,11 +164,11 @@ public class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         return NSSet(array: self.allObjects)
     }
     
-    public override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> AnyObject {
         return mutableCopy(with: nil)
     }
 
-    public func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
         if type(of: self) === NSSet.self || type(of: self) === NSMutableSet.self {
             // always create and return an NSMutableSet
             let mutableSet = NSMutableSet()
@@ -182,13 +182,13 @@ public class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         return true
     }
     
-    public func description(withLocale locale: AnyObject?) -> String { NSUnimplemented() }
+    open func description(withLocale locale: AnyObject?) -> String { NSUnimplemented() }
     
-    override public var _cfTypeID: CFTypeID {
+    override open var _cfTypeID: CFTypeID {
         return CFSetGetTypeID()
     }
 
-    public override func isEqual(_ object: AnyObject?) -> Bool {
+    open override func isEqual(_ object: AnyObject?) -> Bool {
         guard let otherObject = object, otherObject is NSSet else {
             return false
         }
@@ -196,7 +196,7 @@ public class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         return self.isEqual(to: otherSet.bridge())
     }
 
-    public override var hash: Int {
+    open override var hash: Int {
         return self.count
     }
 
@@ -351,16 +351,16 @@ extension NSSet : Sequence {
     }
 }
 
-public class NSMutableSet : NSSet {
+open class NSMutableSet : NSSet {
     
-    public func add(_ object: AnyObject) {
+    open func add(_ object: AnyObject) {
         guard type(of: self) === NSMutableSet.self else {
             NSRequiresConcreteImplementation()
         }
         _storage.insert(object as! NSObject)
     }
     
-    public func remove(_ object: AnyObject) {
+    open func remove(_ object: AnyObject) {
         guard type(of: self) === NSMutableSet.self else {
             NSRequiresConcreteImplementation()
         }
@@ -386,7 +386,7 @@ public class NSMutableSet : NSSet {
         NSUnimplemented()
     }
     
-    public func addObjects(from array: [AnyObject]) {
+    open func addObjects(from array: [AnyObject]) {
         if type(of: self) === NSMutableSet.self {
             for case let obj as NSObject in array {
                 _storage.insert(obj)
@@ -396,7 +396,7 @@ public class NSMutableSet : NSSet {
         }
     }
     
-    public func intersect(_ otherSet: Set<NSObject>) {
+    open func intersect(_ otherSet: Set<NSObject>) {
         if type(of: self) === NSMutableSet.self {
             _storage.formIntersection(otherSet)
         } else {
@@ -406,7 +406,7 @@ public class NSMutableSet : NSSet {
         }
     }
     
-    public func minus(_ otherSet: Set<NSObject>) {
+    open func minus(_ otherSet: Set<NSObject>) {
         if type(of: self) === NSMutableSet.self {
             _storage.subtract(otherSet)
         } else {
@@ -414,7 +414,7 @@ public class NSMutableSet : NSSet {
         }
     }
     
-    public func removeAllObjects() {
+    open func removeAllObjects() {
         if type(of: self) === NSMutableSet.self {
             _storage.removeAll()
         } else {
@@ -422,7 +422,7 @@ public class NSMutableSet : NSSet {
         }
     }
     
-    public func union(_ otherSet: Set<NSObject>) {
+    open func union(_ otherSet: Set<NSObject>) {
         if type(of: self) === NSMutableSet.self {
             _storage.formUnion(otherSet)
         } else {
@@ -430,7 +430,7 @@ public class NSMutableSet : NSSet {
         }
     }
     
-    public func setSet(_ otherSet: Set<NSObject>) {
+    open func setSet(_ otherSet: Set<NSObject>) {
         if type(of: self) === NSMutableSet.self {
             _storage = otherSet
         } else {
@@ -442,7 +442,7 @@ public class NSMutableSet : NSSet {
 }
 
 /****************	Counted Set	****************/
-public class NSCountedSet : NSMutableSet {
+open class NSCountedSet : NSMutableSet {
     internal var _table: Dictionary<NSObject, Int>
 
     public required init(capacity numItems: Int) {
@@ -474,7 +474,7 @@ public class NSCountedSet : NSMutableSet {
 
     public required convenience init?(coder: NSCoder) { NSUnimplemented() }
 
-    public override func copy(with zone: NSZone? = nil) -> AnyObject {
+    open override func copy(with zone: NSZone? = nil) -> AnyObject {
         if type(of: self) === NSCountedSet.self {
             let countedSet = NSCountedSet()
             countedSet._storage = self._storage
@@ -484,7 +484,7 @@ public class NSCountedSet : NSMutableSet {
         return NSCountedSet(array: self.allObjects)
     }
 
-    public override func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open override func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
         if type(of: self) === NSCountedSet.self {
             let countedSet = NSCountedSet()
             countedSet._storage = self._storage
@@ -494,7 +494,7 @@ public class NSCountedSet : NSMutableSet {
         return NSCountedSet(array: self.allObjects)
     }
 
-    public func countForObject(_ object: AnyObject) -> Int {
+    open func countForObject(_ object: AnyObject) -> Int {
         guard type(of: self) === NSCountedSet.self else {
             NSRequiresConcreteImplementation()
         }
@@ -504,7 +504,7 @@ public class NSCountedSet : NSMutableSet {
         return count
     }
 
-    public override func add(_ object: AnyObject) {
+    open override func add(_ object: AnyObject) {
         guard type(of: self) === NSCountedSet.self else {
             NSRequiresConcreteImplementation()
         }
@@ -517,7 +517,7 @@ public class NSCountedSet : NSMutableSet {
         }
     }
 
-    public override func remove(_ object: AnyObject) {
+    open override func remove(_ object: AnyObject) {
         guard type(of: self) === NSCountedSet.self else {
             NSRequiresConcreteImplementation()
         }
@@ -533,7 +533,7 @@ public class NSCountedSet : NSMutableSet {
         }
     }
 
-    public override func removeAllObjects() {
+    open override func removeAllObjects() {
         if type(of: self) === NSCountedSet.self {
             _storage.removeAll()
             _table.removeAll()

--- a/Foundation/NSSortDescriptor.swift
+++ b/Foundation/NSSortDescriptor.swift
@@ -8,13 +8,13 @@
 //
 
 
-public class SortDescriptor: NSObject, NSSecureCoding, NSCopying {
+open class SortDescriptor: NSObject, NSSecureCoding, NSCopying {
     
     public required init?(coder aDecoder: NSCoder) {
         NSUnimplemented()
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     
@@ -22,28 +22,28 @@ public class SortDescriptor: NSObject, NSSecureCoding, NSCopying {
         return true
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         NSUnimplemented()
     }
 
     // keys may be key paths
     public init(key: String?, ascending: Bool) { NSUnimplemented() }
     
-    public var key: String? { NSUnimplemented() }
-    public var ascending: Bool { NSUnimplemented() }
+    open var key: String? { NSUnimplemented() }
+    open var ascending: Bool { NSUnimplemented() }
     
-    public func allowEvaluation() { NSUnimplemented() } // Force a sort descriptor which was securely decoded to allow evaluation
+    open func allowEvaluation() { NSUnimplemented() } // Force a sort descriptor which was securely decoded to allow evaluation
     
     public init(key: String?, ascending: Bool, comparator cmptr: Comparator) { NSUnimplemented() }
     
-    public var comparator: Comparator { NSUnimplemented() }
+    open var comparator: Comparator { NSUnimplemented() }
     
-    public func compareObject(_ object1: AnyObject, toObject object2: AnyObject) -> ComparisonResult  { NSUnimplemented() }// primitive - override this method if you want to perform comparisons differently (not key based for example)
-    public var reversedSortDescriptor: AnyObject  { NSUnimplemented() } // primitive - override this method to return a sort descriptor instance with reversed sort order
+    open func compareObject(_ object1: AnyObject, toObject object2: AnyObject) -> ComparisonResult  { NSUnimplemented() }// primitive - override this method if you want to perform comparisons differently (not key based for example)
+    open var reversedSortDescriptor: AnyObject  { NSUnimplemented() } // primitive - override this method to return a sort descriptor instance with reversed sort order
 }
 
 extension NSSet {

--- a/Foundation/NSStream.swift
+++ b/Foundation/NSStream.swift
@@ -69,68 +69,68 @@ public func <(lhs: Stream.PropertyKey, rhs: Stream.PropertyKey) -> Bool {
 
 // NSStream is an abstract class encapsulating the common API to NSInputStream and NSOutputStream.
 // Subclassers of NSInputStream and NSOutputStream must also implement these methods.
-public class Stream: NSObject {
+open class Stream: NSObject {
 
     public override init() {
 
     }
     
-    public func open() {
+    open func open() {
         NSRequiresConcreteImplementation()
     }
     
-    public func close() {
+    open func close() {
         NSRequiresConcreteImplementation()
     }
     
-    public weak var delegate: StreamDelegate?
+    open weak var delegate: StreamDelegate?
     // By default, a stream is its own delegate, and subclassers of NSInputStream and NSOutputStream must maintain this contract. [someStream setDelegate:nil] must restore this behavior. As usual, delegates are not retained.
     
-    public func propertyForKey(_ key: String) -> AnyObject? {
+    open func propertyForKey(_ key: String) -> AnyObject? {
         NSUnimplemented()
     }
     
-    public func setProperty(_ property: AnyObject?, forKey key: String) -> Bool {
+    open func setProperty(_ property: AnyObject?, forKey key: String) -> Bool {
         NSUnimplemented()
     }
 
 // Re-enable once run loop is compiled on all platforms
 
-    public func schedule(in aRunLoop: RunLoop, forMode mode: RunLoopMode) {
+    open func schedule(in aRunLoop: RunLoop, forMode mode: RunLoopMode) {
         NSUnimplemented()
     }
     
-    public func remove(from aRunLoop: RunLoop, forMode mode: RunLoopMode) {
+    open func remove(from aRunLoop: RunLoop, forMode mode: RunLoopMode) {
         NSUnimplemented()
     }
     
-    public var streamStatus: Status {
+    open var streamStatus: Status {
         NSRequiresConcreteImplementation()
     }
     
-    /*@NSCopying */public var streamError: NSError? {
+    /*@NSCopying */open var streamError: NSError? {
         NSUnimplemented()
     }
 }
 
 // NSInputStream is an abstract class representing the base functionality of a read stream.
 // Subclassers are required to implement these methods.
-public class InputStream: Stream {
+open class InputStream: Stream {
 
     private var _stream: CFReadStream!
 
     // reads up to length bytes into the supplied buffer, which must be at least of size len. Returns the actual number of bytes read.
-    public func read(_ buffer: UnsafeMutablePointer<UInt8>, maxLength len: Int) -> Int {
+    open func read(_ buffer: UnsafeMutablePointer<UInt8>, maxLength len: Int) -> Int {
         return CFReadStreamRead(_stream, buffer, CFIndex(len._bridgeToObject()))
     }
     
     // returns in O(1) a pointer to the buffer in 'buffer' and by reference in 'len' how many bytes are available. This buffer is only valid until the next stream operation. Subclassers may return NO for this if it is not appropriate for the stream type. This may return NO if the buffer is not available.
-    public func getBuffer(_ buffer: UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>, length len: UnsafeMutablePointer<Int>) -> Bool {
+    open func getBuffer(_ buffer: UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>, length len: UnsafeMutablePointer<Int>) -> Bool {
         NSUnimplemented()
     }
     
     // returns YES if the stream has bytes available or if it impossible to tell without actually doing the read.
-    public var hasBytesAvailable: Bool {
+    open var hasBytesAvailable: Bool {
         return CFReadStreamHasBytesAvailable(_stream)
     }
     
@@ -146,15 +146,15 @@ public class InputStream: Stream {
         self.init(url: URL(fileURLWithPath: path))
     }
 
-    public override func open() {
+    open override func open() {
         CFReadStreamOpen(_stream)
     }
     
-    public override func close() {
+    open override func close() {
         CFReadStreamClose(_stream)
     }
     
-    public override var streamStatus: Status {
+    open override var streamStatus: Status {
         return Stream.Status(rawValue: UInt(CFReadStreamGetStatus(_stream)))!
     }
 }
@@ -162,17 +162,17 @@ public class InputStream: Stream {
 // NSOutputStream is an abstract class representing the base functionality of a write stream.
 // Subclassers are required to implement these methods.
 // Currently this is left as named NSOutputStream due to conflicts with the standard library's text streaming target protocol named OutputStream (which ideally should be renamed)
-public class NSOutputStream : Stream {
+open class NSOutputStream : Stream {
     
     private  var _stream: CFWriteStream!
     
     // writes the bytes from the specified buffer to the stream up to len bytes. Returns the number of bytes actually written.
-    public func write(_ buffer: UnsafePointer<UInt8>, maxLength len: Int) -> Int {
+    open func write(_ buffer: UnsafePointer<UInt8>, maxLength len: Int) -> Int {
         return  CFWriteStreamWrite(_stream, buffer, len)
     }
     
     // returns YES if the stream can be written to or if it is impossible to tell without actually doing the write.
-    public var hasSpaceAvailable: Bool {
+    open var hasSpaceAvailable: Bool {
         return CFWriteStreamCanAcceptBytes(_stream)
     }
     
@@ -193,27 +193,27 @@ public class NSOutputStream : Stream {
         self.init(url: URL(fileURLWithPath: path), append: shouldAppend)
     }
     
-    public override func open() {
+    open override func open() {
         CFWriteStreamOpen(_stream)
     }
     
-    public override func close() {
+    open override func close() {
         CFWriteStreamClose(_stream)
     }
     
-    public override var streamStatus: Status {
+    open override var streamStatus: Status {
         return Stream.Status(rawValue: UInt(CFWriteStreamGetStatus(_stream)))!
     }
     
-    public class func outputStreamToMemory() -> Self {
+    open class func outputStreamToMemory() -> Self {
         return self.init(toMemory: ())
     }
     
-    public override func propertyForKey(_ key: String) -> AnyObject? {
+    open override func propertyForKey(_ key: String) -> AnyObject? {
         return CFWriteStreamCopyProperty(_stream, key._cfObject)
     }
     
-    public  override func setProperty(_ property: AnyObject?, forKey key: String) -> Bool {
+    open  override func setProperty(_ property: AnyObject?, forKey key: String) -> Bool {
         return CFWriteStreamSetProperty(_stream, key._cfObject, property)
     }
 }
@@ -221,13 +221,13 @@ public class NSOutputStream : Stream {
 // Discussion of this API is ongoing for its usage of AutoreleasingUnsafeMutablePointer
 #if false
 extension Stream {
-    public class func getStreamsToHost(withName hostname: String, port: Int, inputStream: AutoreleasingUnsafeMutablePointer<InputStream?>?, outputStream: AutoreleasingUnsafeMutablePointer<NSOutputStream?>?) {
+    open class func getStreamsToHost(withName hostname: String, port: Int, inputStream: AutoreleasingUnsafeMutablePointer<InputStream?>?, outputStream: AutoreleasingUnsafeMutablePointer<NSOutputStream?>?) {
         NSUnimplemented()
     }
 }
 
 extension Stream {
-    public class func getBoundStreams(withBufferSize bufferSize: Int, inputStream: AutoreleasingUnsafeMutablePointer<InputStream?>?, outputStream: AutoreleasingUnsafeMutablePointer<NSOutputStream?>?) {
+    open class func getBoundStreams(withBufferSize bufferSize: Int, inputStream: AutoreleasingUnsafeMutablePointer<InputStream?>?, outputStream: AutoreleasingUnsafeMutablePointer<NSOutputStream?>?) {
         NSUnimplemented()
     }
 }

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -211,18 +211,18 @@ internal func isAParagraphSeparatorTypeCharacter(_ ch: unichar) -> Bool {
     return ch == 0x0a || ch == 0x0d || ch == 0x2029
 }
 
-public class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCoding {
+open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCoding {
     private let _cfinfo = _CFInfo(typeID: CFStringGetTypeID())
     internal var _storage: String
     
-    public var length: Int {
+    open var length: Int {
         guard type(of: self) === NSString.self || type(of: self) === NSMutableString.self else {
             NSRequiresConcreteImplementation()
         }
         return _storage.utf16.count
     }
     
-    public func character(at index: Int) -> unichar {
+    open func character(at index: Int) -> unichar {
         guard type(of: self) === NSString.self || type(of: self) === NSMutableString.self else {
             NSRequiresConcreteImplementation()
         }
@@ -260,19 +260,19 @@ public class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, N
         self.init(aString)
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         return self
     }
     
-    public override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> AnyObject {
         return mutableCopy(with: nil)
     }
     
-    public func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
         if type(of: self) === NSString.self || type(of: self) === NSMutableString.self {
             if let contents = _fastContents {
                 return NSMutableString(characters: contents, length: length)
@@ -290,7 +290,7 @@ public class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, N
         return true
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         if let aKeyedCoder = aCoder as? NSKeyedArchiver {
             aKeyedCoder._encodePropertyList(self, forKey: "NS.string")
         } else {
@@ -339,20 +339,20 @@ public class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, N
         return false
     }
     
-    override public var _cfTypeID: CFTypeID {
+    override open var _cfTypeID: CFTypeID {
         return CFStringGetTypeID()
     }
   
-    public override func isEqual(_ object: AnyObject?) -> Bool {
+    open override func isEqual(_ object: AnyObject?) -> Bool {
         guard let string = (object as? NSString)?._swiftObject else { return false }
         return self.isEqual(to: string)
     }
     
-    public override var description: String {
+    open override var description: String {
         return _swiftObject
     }
     
-    public override var hash: Int {
+    open override var hash: Int {
         return Int(bitPattern:CFStringHashNSString(self._cfObject))
     }
 }
@@ -933,7 +933,7 @@ extension NSString {
         return convertedLen != len ? 0 : numBytes
     }
     
-    public class func availableStringEncodings() -> UnsafePointer<UInt> {
+    open class func availableStringEncodings() -> UnsafePointer<UInt> {
         struct once {
             static let encodings: UnsafePointer<UInt> = {
                 let cfEncodings = CFStringGetListOfAvailableEncodings()!
@@ -960,7 +960,7 @@ extension NSString {
         return once.encodings
     }
     
-    public class func localizedName(of encoding: UInt) -> String {
+    open class func localizedName(of encoding: UInt) -> String {
         if let theString = CFStringGetNameOfEncoding(CFStringConvertNSStringEncodingToEncoding(encoding)) {
             // TODO: read the localized version from the Foundation "bundle"
             return theString._swiftObject
@@ -969,39 +969,39 @@ extension NSString {
         return ""
     }
     
-    public class func defaultCStringEncoding() -> UInt {
+    open class func defaultCStringEncoding() -> UInt {
         return CFStringConvertEncodingToNSStringEncoding(CFStringGetSystemEncoding())
     }
     
-    public var decomposedStringWithCanonicalMapping: String {
+    open var decomposedStringWithCanonicalMapping: String {
         let string = CFStringCreateMutable(kCFAllocatorSystemDefault, 0)!
         CFStringReplaceAll(string, self._cfObject)
         CFStringNormalize(string, kCFStringNormalizationFormD)
         return string._swiftObject
     }
     
-    public var precomposedStringWithCanonicalMapping: String {
+    open var precomposedStringWithCanonicalMapping: String {
         let string = CFStringCreateMutable(kCFAllocatorSystemDefault, 0)!
         CFStringReplaceAll(string, self._cfObject)
         CFStringNormalize(string, kCFStringNormalizationFormC)
         return string._swiftObject
     }
     
-    public var decomposedStringWithCompatibilityMapping: String {
+    open var decomposedStringWithCompatibilityMapping: String {
         let string = CFStringCreateMutable(kCFAllocatorSystemDefault, 0)!
         CFStringReplaceAll(string, self._cfObject)
         CFStringNormalize(string, kCFStringNormalizationFormKD)
         return string._swiftObject
     }
     
-    public var precomposedStringWithCompatibilityMapping: String {
+    open var precomposedStringWithCompatibilityMapping: String {
         let string = CFStringCreateMutable(kCFAllocatorSystemDefault, 0)!
         CFStringReplaceAll(string, self._cfObject)
         CFStringNormalize(string, kCFStringNormalizationFormKC)
         return string._swiftObject
     }
     
-    public func components(separatedBy separator: String) -> [String] {
+    open func components(separatedBy separator: String) -> [String] {
         let len = length
         var lrange = range(of: separator, options: [], range: NSMakeRange(0, len))
         if lrange.length == 0 {
@@ -1024,7 +1024,7 @@ extension NSString {
         }
     }
     
-    public func components(separatedBy separator: CharacterSet) -> [String] {
+    open func components(separatedBy separator: CharacterSet) -> [String] {
         let len = length
         var range = rangeOfCharacter(from: separator, options: [], range: NSMakeRange(0, len))
         if range.length == 0 {
@@ -1047,7 +1047,7 @@ extension NSString {
         }
     }
     
-    public func trimmingCharacters(in set: CharacterSet) -> String {
+    open func trimmingCharacters(in set: CharacterSet) -> String {
         let len = length
         var buf = _NSStringBuffer(string: self, start: 0, end: len)
         while !buf.isAtEnd && set.contains(buf.currentCharacter) {
@@ -1070,7 +1070,7 @@ extension NSString {
         }
     }
     
-    public func padding(toLength newLength: Int, withPad padString: String, startingAt padIndex: Int) -> String {
+    open func padding(toLength newLength: Int, withPad padString: String, startingAt padIndex: Int) -> String {
         let len = length
         if newLength <= len {	// The simple cases (truncation)
             return newLength == len ? _swiftObject : substring(with: NSMakeRange(0, newLength))
@@ -1088,7 +1088,7 @@ extension NSString {
         return mStr._swiftObject
     }
     
-    public func folding(_ options: CompareOptions = [], locale: Locale?) -> String {
+    open func folding(_ options: CompareOptions = [], locale: Locale?) -> String {
         let string = CFStringCreateMutable(kCFAllocatorSystemDefault, 0)!
         CFStringReplaceAll(string, self._cfObject)
         CFStringFold(string, options._cfValue(), locale?._cfObject)
@@ -1104,7 +1104,7 @@ extension NSString {
         return ""
     }
     
-    public func replacingOccurrences(of target: String, with replacement: String, options: CompareOptions = [], range searchRange: NSRange) -> String {
+    open func replacingOccurrences(of target: String, with replacement: String, options: CompareOptions = [], range searchRange: NSRange) -> String {
         if options.contains(.regularExpression) {
             return _stringByReplacingOccurrencesOfRegularExpressionPattern(target, withTemplate: replacement, options: options, range: searchRange)
         }
@@ -1116,17 +1116,17 @@ extension NSString {
         }
     }
     
-    public func replacingOccurrences(of target: String, with replacement: String) -> String {
+    open func replacingOccurrences(of target: String, with replacement: String) -> String {
         return replacingOccurrences(of: target, with: replacement, options: [], range: NSMakeRange(0, length))
     }
     
-    public func replacingCharacters(in range: NSRange, with replacement: String) -> String {
+    open func replacingCharacters(in range: NSRange, with replacement: String) -> String {
         let str = mutableCopy(with: nil) as! NSMutableString
         str.replaceCharacters(in: range, with: replacement)
         return str._swiftObject
     }
     
-    public func applyingTransform(_ transform: String, reverse: Bool) -> String? {
+    open func applyingTransform(_ transform: String, reverse: Bool) -> String? {
         let string = CFStringCreateMutable(kCFAllocatorSystemDefault, 0)!
         CFStringReplaceAll(string, _cfObject)
         if (CFStringTransform(string, nil, transform._cfObject, reverse)) {
@@ -1165,11 +1165,11 @@ extension NSString {
         try data.write(to: url, options: useAuxiliaryFile ? .dataWritingAtomic : [])
     }
     
-    public func write(to url: URL, atomically useAuxiliaryFile: Bool, encoding enc: UInt) throws {
+    open func write(to url: URL, atomically useAuxiliaryFile: Bool, encoding enc: UInt) throws {
         try _writeTo(url, useAuxiliaryFile, enc)
     }
     
-    public func write(toFile path: String, atomically useAuxiliaryFile: Bool, encoding enc: UInt) throws {
+    open func write(toFile path: String, atomically useAuxiliaryFile: Bool, encoding enc: UInt) throws {
         try _writeTo(URL(fileURLWithPath: path), useAuxiliaryFile, enc)
     }
     
@@ -1300,8 +1300,8 @@ extension NSString {
 
 extension NSString : ExpressibleByStringLiteral { }
 
-public class NSMutableString : NSString {
-    public func replaceCharacters(in range: NSRange, with aString: String) {
+open class NSMutableString : NSString {
+    open func replaceCharacters(in range: NSRange, with aString: String) {
         guard type(of: self) === NSString.self || type(of: self) === NSMutableString.self else {
             NSRequiresConcreteImplementation()
         }

--- a/Foundation/NSTask.swift
+++ b/Foundation/NSTask.swift
@@ -91,7 +91,7 @@ private func nstaskIsEqual(_ a : UnsafeRawPointer?, _ b : UnsafeRawPointer?) -> 
     return true
 }
 
-public class Task: NSObject {
+open class Task: NSObject {
     private static func setup() {
         struct Once {
             static var done = false
@@ -148,26 +148,26 @@ public class Task: NSObject {
     }
     
     // these methods can only be set before a launch
-    public var launchPath: String?
-    public var arguments: [String]?
-    public var environment: [String : String]? // if not set, use current
+    open var launchPath: String?
+    open var arguments: [String]?
+    open var environment: [String : String]? // if not set, use current
     
-    public var currentDirectoryPath: String = FileManager.defaultInstance.currentDirectoryPath
+    open var currentDirectoryPath: String = FileManager.defaultInstance.currentDirectoryPath
     
     // standard I/O channels; could be either an NSFileHandle or an NSPipe
-    public var standardInput: AnyObject? {
+    open var standardInput: AnyObject? {
         willSet {
             precondition(newValue is Pipe || newValue is FileHandle,
                          "standardInput must be either NSPipe or NSFileHandle")
         }
     }
-    public var standardOutput: AnyObject? {
+    open var standardOutput: AnyObject? {
         willSet {
             precondition(newValue is Pipe || newValue is FileHandle,
                          "standardOutput must be either NSPipe or NSFileHandle")
         }
     }
-    public var standardError: AnyObject? {
+    open var standardError: AnyObject? {
         willSet {
             precondition(newValue is Pipe || newValue is FileHandle,
                          "standardError must be either NSPipe or NSFileHandle")
@@ -182,7 +182,7 @@ public class Task: NSObject {
     private var processLaunchedCondition = Condition()
     
     // actions
-    public func launch() {
+    open func launch() {
         
         self.processLaunchedCondition.lock()
     
@@ -403,30 +403,30 @@ public class Task: NSObject {
         self.processLaunchedCondition.broadcast()
     }
     
-    public func interrupt() { NSUnimplemented() } // Not always possible. Sends SIGINT.
-    public func terminate()  { NSUnimplemented() }// Not always possible. Sends SIGTERM.
+    open func interrupt() { NSUnimplemented() } // Not always possible. Sends SIGINT.
+    open func terminate()  { NSUnimplemented() }// Not always possible. Sends SIGTERM.
     
-    public func suspend() -> Bool { NSUnimplemented() }
-    public func resume() -> Bool { NSUnimplemented() }
+    open func suspend() -> Bool { NSUnimplemented() }
+    open func resume() -> Bool { NSUnimplemented() }
     
     // status
-    public private(set) var processIdentifier: Int32 = -1
-    public private(set) var running: Bool = false
+    open private(set) var processIdentifier: Int32 = -1
+    open private(set) var running: Bool = false
     
-    public private(set) var terminationStatus: Int32 = 0
-    public var terminationReason: TerminationReason { NSUnimplemented() }
+    open private(set) var terminationStatus: Int32 = 0
+    open var terminationReason: TerminationReason { NSUnimplemented() }
     
     /*
     A block to be invoked when the process underlying the NSTask terminates.  Setting the block to nil is valid, and stops the previous block from being invoked, as long as it hasn't started in any way.  The NSTask is passed as the argument to the block so the block does not have to capture, and thus retain, it.  The block is copied when set.  Only one termination handler block can be set at any time.  The execution context in which the block is invoked is undefined.  If the NSTask has already finished, the block is executed immediately/soon (not necessarily on the current thread).  If a terminationHandler is set on an NSTask, the NSTaskDidTerminateNotification notification is not posted for that task.  Also note that -waitUntilExit won't wait until the terminationHandler has been fully executed.  You cannot use this property in a concrete subclass of NSTask which hasn't been updated to include an implementation of the storage and use of it.  
     */
-    public var terminationHandler: ((Task) -> Void)?
-    public var qualityOfService: NSQualityOfService = .default  // read-only after the task is launched
+    open var terminationHandler: ((Task) -> Void)?
+    open var qualityOfService: NSQualityOfService = .default  // read-only after the task is launched
 }
 
 extension Task {
     
     // convenience; create and launch
-    public class func launchedTaskWithLaunchPath(_ path: String, arguments: [String]) -> Task {
+    open class func launchedTaskWithLaunchPath(_ path: String, arguments: [String]) -> Task {
         let task = Task()
         task.launchPath = path
         task.arguments = arguments
@@ -436,7 +436,7 @@ extension Task {
     }
     
     // poll the runLoop in defaultMode until task completes
-    public func waitUntilExit() {
+    open func waitUntilExit() {
         
         repeat {
             

--- a/Foundation/NSTextCheckingResult.swift
+++ b/Foundation/NSTextCheckingResult.swift
@@ -19,13 +19,13 @@ extension TextCheckingResult {
     }
 }
 
-public class TextCheckingResult: NSObject, NSCopying, NSCoding {
+open class TextCheckingResult: NSObject, NSCopying, NSCoding {
     
     public override init() {
         super.init()
     }
     
-    public class func regularExpressionCheckingResultWithRanges(_ ranges: NSRangePointer, count: Int, regularExpression: RegularExpression) -> TextCheckingResult {
+    open class func regularExpressionCheckingResultWithRanges(_ ranges: NSRangePointer, count: Int, regularExpression: RegularExpression) -> TextCheckingResult {
         return _NSRegularExpressionTextCheckingResultResult(ranges: ranges, count: count, regularExpression: regularExpression)
     }
 
@@ -33,25 +33,25 @@ public class TextCheckingResult: NSObject, NSCopying, NSCoding {
         NSUnimplemented()
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         NSUnimplemented()
     }
     
     /* Mandatory properties, used with all types of results. */
-    public var resultType: CheckingType { NSUnimplemented() }
-    public var range: NSRange { return range(at: 0) }
+    open var resultType: CheckingType { NSUnimplemented() }
+    open var range: NSRange { return range(at: 0) }
     /* A result must have at least one range, but may optionally have more (for example, to represent regular expression capture groups).  The range at index 0 always matches the range property.  Additional ranges, if any, will have indexes from 1 to numberOfRanges-1. */
-    public func range(at idx: Int) -> NSRange { NSUnimplemented() }
-    public var regularExpression: RegularExpression? { return nil }
-    public var numberOfRanges: Int { return 1 }
+    open func range(at idx: Int) -> NSRange { NSUnimplemented() }
+    open var regularExpression: RegularExpression? { return nil }
+    open var numberOfRanges: Int { return 1 }
 }
 
 internal class _NSRegularExpressionTextCheckingResultResult : TextCheckingResult {

--- a/Foundation/NSThread.swift
+++ b/Foundation/NSThread.swift
@@ -56,7 +56,7 @@ private func NSThreadStart(_ context: UnsafeMutableRawPointer?) -> UnsafeMutable
     return nil
 }
 
-public class Thread: NSObject {
+open class Thread: NSObject {
     
     static internal var _currentThread = NSThreadSpecific<Thread>()
     public static var current: Thread {
@@ -68,16 +68,16 @@ public class Thread: NSObject {
     /// Alternative API for detached thread creation
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative to creation via selector
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    public class func detachNewThread(_ main: @escaping (Void) -> Void) {
+    open class func detachNewThread(_ main: @escaping (Void) -> Void) {
         let t = Thread(main)
         t.start()
     }
     
-    public class func isMultiThreaded() -> Bool {
+    open class func isMultiThreaded() -> Bool {
         return true
     }
     
-    public class func sleepUntilDate(_ date: Date) {
+    open class func sleepUntilDate(_ date: Date) {
         let start_ut = CFGetSystemUptime()
         let start_at = CFAbsoluteTimeGetCurrent()
         let end_at = date.timeIntervalSinceReferenceDate
@@ -100,7 +100,7 @@ public class Thread: NSObject {
         }
     }
 
-    public class func sleepForTimeInterval(_ interval: TimeInterval) {
+    open class func sleepForTimeInterval(_ interval: TimeInterval) {
         var ti = interval
         let start_ut = CFGetSystemUptime()
         let end_ut = start_ut + ti
@@ -121,7 +121,7 @@ public class Thread: NSObject {
         }
     }
 
-    public class func exit() {
+    open class func exit() {
         pthread_exit(nil)
     }
     
@@ -135,7 +135,7 @@ public class Thread: NSObject {
     internal var _status = _NSThreadStatus.initialized
     internal var _cancelled = false
     /// - Note: this differs from the Darwin implementation in that the keys must be Strings
-    public var threadDictionary = [String:AnyObject]()
+    open var threadDictionary = [String:AnyObject]()
     
     internal init(thread: pthread_t) {
         // Note: even on Darwin this is a non-optional pthread_t; this is only used for valid threads, which are never null pointers.
@@ -151,7 +151,7 @@ public class Thread: NSObject {
         }
     }
 
-    public func start() {
+    open func start() {
         precondition(_status == .initialized, "attempting to start a thread that has already been started")
         _status = .starting
         if _cancelled {
@@ -163,11 +163,11 @@ public class Thread: NSObject {
         }
     }
     
-    public func main() {
+    open func main() {
         _main()
     }
 
-    public var stackSize: Int {
+    open var stackSize: Int {
         get {
             var size: Int = 0
             return withUnsafeMutablePointer(to: &_attr) { attr in
@@ -189,27 +189,27 @@ public class Thread: NSObject {
         }
     }
 
-    public var executing: Bool {
+    open var executing: Bool {
         return _status == .executing
     }
 
-    public var finished: Bool {
+    open var finished: Bool {
         return _status == .finished
     }
     
-    public var cancelled: Bool {
+    open var cancelled: Bool {
         return _cancelled
     }
     
-    public func cancel() {
+    open func cancel() {
         _cancelled = true
     }
 
-    public class func callStackReturnAddresses() -> [NSNumber] {
+    open class func callStackReturnAddresses() -> [NSNumber] {
         NSUnimplemented()
     }
     
-    public class func callStackSymbols() -> [String] {
+    open class func callStackSymbols() -> [String] {
         NSUnimplemented()
     }
 }

--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -10,7 +10,7 @@
 
 import CoreFoundation
 
-public class TimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
+open class TimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
     typealias CFType = CFTimeZone
     private var _base = _CFInfo(typeID: CFTimeZoneGetTypeID())
     private var _name: UnsafeMutableRawPointer? = nil
@@ -59,11 +59,11 @@ public class TimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    public override var hash: Int {
+    open override var hash: Int {
         return Int(bitPattern: CFHash(_cfObject))
     }
     
-    public override func isEqual(_ object: AnyObject?) -> Bool {
+    open override func isEqual(_ object: AnyObject?) -> Bool {
         if let tz = object as? TimeZone {
             return isEqual(to: tz)
         } else {
@@ -71,7 +71,7 @@ public class TimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    public override var description: String {
+    open override var description: String {
         return CFCopyDescription(_cfObject)._swiftObject
     }
 
@@ -92,7 +92,7 @@ public class TimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
         self.init(name: name._swiftObject , data: nil)
     }
 
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         if aCoder.allowsKeyedCoding {
             aCoder.encode(self.name.bridge(), forKey:"NS.name")
             // darwin versions of this method can and will encode mutable data, however it is not required for compatability
@@ -105,57 +105,57 @@ public class TimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
         return true
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         return self
     }
     
-    public var name: String {
+    open var name: String {
         guard type(of: self) === TimeZone.self else {
             NSRequiresConcreteImplementation()
         }
         return CFTimeZoneGetName(_cfObject)._swiftObject
     }
     
-    public var data: Data {
+    open var data: Data {
         guard type(of: self) === TimeZone.self else {
             NSRequiresConcreteImplementation()
         }
         return CFTimeZoneGetData(_cfObject)._swiftObject
     }
     
-    public func secondsFromGMT(for aDate: Date) -> Int {
+    open func secondsFromGMT(for aDate: Date) -> Int {
         guard type(of: self) === TimeZone.self else {
             NSRequiresConcreteImplementation()
         }
         return Int(CFTimeZoneGetSecondsFromGMT(_cfObject, aDate.timeIntervalSinceReferenceDate))
     }
     
-    public func abbreviation(for aDate: Date) -> String? {
+    open func abbreviation(for aDate: Date) -> String? {
         guard type(of: self) === TimeZone.self else {
             NSRequiresConcreteImplementation()
         }
         return CFTimeZoneCopyAbbreviation(_cfObject, aDate.timeIntervalSinceReferenceDate)._swiftObject
     }
     
-    public func isDaylightSavingTime(for aDate: Date) -> Bool {
+    open func isDaylightSavingTime(for aDate: Date) -> Bool {
         guard type(of: self) === TimeZone.self else {
             NSRequiresConcreteImplementation()
         }
         return CFTimeZoneIsDaylightSavingTime(_cfObject, aDate.timeIntervalSinceReferenceDate)
     }
     
-    public func daylightSavingTimeOffset(for aDate: Date) -> TimeInterval {
+    open func daylightSavingTimeOffset(for aDate: Date) -> TimeInterval {
         guard type(of: self) === TimeZone.self else {
             NSRequiresConcreteImplementation()
         }
         return CFTimeZoneGetDaylightSavingTimeOffset(_cfObject, aDate.timeIntervalSinceReferenceDate)
     }
     
-    public func nextDaylightSavingTimeTransition(after aDate: Date) -> Date? {
+    open func nextDaylightSavingTimeTransition(after aDate: Date) -> Date? {
         guard type(of: self) === TimeZone.self else {
             NSRequiresConcreteImplementation()
         }
@@ -165,19 +165,19 @@ public class TimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
 
 extension TimeZone {
 
-    public class func systemTimeZone() -> TimeZone {
+    open class func systemTimeZone() -> TimeZone {
         return CFTimeZoneCopySystem()._nsObject
     }
 
-    public class func resetSystemTimeZone() {
+    open class func resetSystemTimeZone() {
         CFTimeZoneResetSystem()
     }
 
-    public class func defaultTimeZone() -> TimeZone {
+    open class func defaultTimeZone() -> TimeZone {
         return CFTimeZoneCopyDefault()._nsObject
     }
 
-    public class func setDefaultTimeZone(_ aTimeZone: TimeZone) {
+    open class func setDefaultTimeZone(_ aTimeZone: TimeZone) {
         CFTimeZoneSetDefault(aTimeZone._cfObject)
     }
 }
@@ -192,34 +192,34 @@ extension CFTimeZone : _NSBridgable {
 }
 
 extension TimeZone {
-    public class func localTimeZone() -> TimeZone { NSUnimplemented() }
+    open class func localTimeZone() -> TimeZone { NSUnimplemented() }
     
-    public class func knownTimeZoneNames() -> [String] { NSUnimplemented() }
+    open class func knownTimeZoneNames() -> [String] { NSUnimplemented() }
     
-    public class func abbreviationDictionary() -> [String : String] { NSUnimplemented() }
-    public class func setAbbreviationDictionary(_ dict: [String : String]) { NSUnimplemented() }
+    open class func abbreviationDictionary() -> [String : String] { NSUnimplemented() }
+    open class func setAbbreviationDictionary(_ dict: [String : String]) { NSUnimplemented() }
     
-    public class func timeZoneDataVersion() -> String { NSUnimplemented() }
+    open class func timeZoneDataVersion() -> String { NSUnimplemented() }
     
-    public var secondsFromGMT: Int { NSUnimplemented() }
+    open var secondsFromGMT: Int { NSUnimplemented() }
 
     /// The abbreviation for the receiver, such as "EDT" (Eastern Daylight Time). (read-only)
     ///
     /// This invokes `abbreviationForDate:` with the current date as the argument.
-    public var abbreviation: String? {
+    open var abbreviation: String? {
         let currentDate = Date()
         return abbreviation(for: currentDate)
     }
 
-    public var daylightSavingTime: Bool { NSUnimplemented() }
-    public var daylightSavingTimeOffset: TimeInterval { NSUnimplemented() }
-    /*@NSCopying*/ public var nextDaylightSavingTimeTransition: Date?  { NSUnimplemented() }
+    open var daylightSavingTime: Bool { NSUnimplemented() }
+    open var daylightSavingTimeOffset: TimeInterval { NSUnimplemented() }
+    /*@NSCopying*/ open var nextDaylightSavingTimeTransition: Date?  { NSUnimplemented() }
     
-    public func isEqual(to aTimeZone: TimeZone) -> Bool {
+    open func isEqual(to aTimeZone: TimeZone) -> Bool {
         return CFEqual(self._cfObject, aTimeZone._cfObject)
     }
     
-    public func localizedName(_ style: NSTimeZoneNameStyle, locale: Locale?) -> String? { NSUnimplemented() }
+    open func localizedName(_ style: NSTimeZoneNameStyle, locale: Locale?) -> String? { NSUnimplemented() }
 }
 public enum NSTimeZoneNameStyle : Int {
     case standard    // Central Standard Time

--- a/Foundation/NSTimer.swift
+++ b/Foundation/NSTimer.swift
@@ -15,7 +15,7 @@ internal func __NSFireTimer(_ timer: CFRunLoopTimer?, info: UnsafeMutableRawPoin
     t._fire(t)
 }
 
-public class Timer: NSObject {
+open class Timer: NSObject {
     typealias CFType = CFRunLoopTimer
     
     internal var _cfObject: CFType {
@@ -56,13 +56,13 @@ public class Timer: NSObject {
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative to creation via selector
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
     /// - Warning: Capturing the timer or the owner of the timer inside of the block may cause retain cycles. Use with caution
-    public class func scheduledTimer(withTimeInterval interval: TimeInterval, repeats: Bool, block: @escaping (Timer) -> Void) -> Timer {
+    open class func scheduledTimer(withTimeInterval interval: TimeInterval, repeats: Bool, block: @escaping (Timer) -> Void) -> Timer {
         let timer = Timer(fire: Date(timeIntervalSinceNow: interval), interval: interval, repeats: repeats, block: block)
         CFRunLoopAddTimer(CFRunLoopGetCurrent(), timer._timer!, kCFRunLoopDefaultMode)
         return timer
     }
     
-    public func fire() {
+    open func fire() {
         if !valid {
             return
         }
@@ -72,7 +72,7 @@ public class Timer: NSObject {
         }
     }
 
-    public var fireDate: Date {
+    open var fireDate: Date {
         get {
             return Date(timeIntervalSinceReferenceDate: CFRunLoopTimerGetNextFireDate(_timer!))
         }
@@ -81,11 +81,11 @@ public class Timer: NSObject {
         }
     }
     
-    public var timeInterval: TimeInterval {
+    open var timeInterval: TimeInterval {
         return CFRunLoopTimerGetInterval(_timer!)
     }
 
-    public var tolerance: TimeInterval {
+    open var tolerance: TimeInterval {
         get {
             return CFRunLoopTimerGetTolerance(_timer!)
         }
@@ -94,11 +94,11 @@ public class Timer: NSObject {
         }
     }
     
-    public func invalidate() {
+    open func invalidate() {
         CFRunLoopTimerInvalidate(_timer!)
     }
 
-    public var valid: Bool {
+    open var valid: Bool {
         return CFRunLoopTimerIsValid(_timer!)
     }
 }

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -160,7 +160,7 @@ extension URLFileResourceType {
     public static let unknown = URLFileResourceType(rawValue: "NSURLFileResourceTypeUnknown")
 }
 
-public class NSURL: NSObject, NSSecureCoding, NSCopying {
+open class NSURL: NSObject, NSSecureCoding, NSCopying {
     typealias CFType = CFURL
     internal var _base = _CFInfo(typeID: CFURLGetTypeID())
     internal var _flags : UInt32 = 0
@@ -188,11 +188,11 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
         }
     }
     
-    public override var hash: Int {
+    open override var hash: Int {
         return Int(bitPattern: CFHash(_cfObject))
     }
     
-    public override func isEqual(_ object: AnyObject?) -> Bool {
+    open override func isEqual(_ object: AnyObject?) -> Bool {
         if let url = object as? NSURL {
             return CFEqual(_cfObject, url._cfObject)
         } else {
@@ -200,7 +200,7 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
         }
     }
     
-    public override var description: String {
+    open override var description: String {
         return CFCopyDescription(_cfObject)._swiftObject
     }
 
@@ -208,11 +208,11 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
         _CFDeinit(self)
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         return self
     }
     
@@ -233,7 +233,7 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
         }
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
 	if aCoder.allowsKeyedCoding {
             aCoder.encode(self.baseURL?._nsObject, forKey:"NS.base")
             aCoder.encode(self.relativeString.bridge(), forKey:"NS.relative")
@@ -339,7 +339,7 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
     
     /* Returns the data representation of the URL's relativeString. If the URL was initialized with -initWithData:relativeToURL:, the data representation returned are the same bytes as those used at initialization; otherwise, the data representation returned are the bytes of the relativeString encoded with NSUTF8StringEncoding.
     */
-    public var dataRepresentation: Data {
+    open var dataRepresentation: Data {
         let bytesNeeded = CFURLGetBytes(_cfObject, nil, 0)
         assert(bytesNeeded > 0)
         
@@ -352,7 +352,7 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
         }
     }
     
-    public var absoluteString: String {
+    open var absoluteString: String {
         if let absURL = CFURLCopyAbsoluteURL(_cfObject) {
             return CFURLGetString(absURL)._swiftObject
         }
@@ -361,22 +361,22 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
     }
     
     // The relative portion of a URL.  If baseURL is nil, or if the receiver is itself absolute, this is the same as absoluteString
-    public var relativeString: String {
+    open var relativeString: String {
         return CFURLGetString(_cfObject)._swiftObject
     }
     
-    public var baseURL: URL? {
+    open var baseURL: URL? {
         return CFURLGetBaseURL(_cfObject)?._swiftObject
     }
     
     // if the receiver is itself absolute, this will return self.
-    public var absoluteURL: URL? {
+    open var absoluteURL: URL? {
         return CFURLCopyAbsoluteURL(_cfObject)?._swiftObject
     }
     
     /* Any URL is composed of these two basic pieces.  The full URL would be the concatenation of [myURL scheme], ':', [myURL resourceSpecifier]
     */
-    public var scheme: String? {
+    open var scheme: String? {
         return CFURLCopyScheme(_cfObject)?._swiftObject
     }
     
@@ -384,7 +384,7 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
         return self.baseURL == nil && self.scheme != nil
     }
     
-    public var resourceSpecifier: String? {
+    open var resourceSpecifier: String? {
         // Note that this does NOT have the same meaning as CFURL's resource specifier, which, for decomposeable URLs is merely that portion of the URL which comes after the path.  NSURL means everything after the scheme.
         if !_isAbsolute {
             return self.relativeString
@@ -416,11 +416,11 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
     
     /* If the URL conforms to rfc 1808 (the most common form of URL), the following accessors will return the various components; otherwise they return nil.  The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is @"//".  In all cases, they return the component's value after resolving the receiver against its base URL.
     */
-    public var host: String? {
+    open var host: String? {
         return CFURLCopyHostName(_cfObject)?._swiftObject
     }
     
-    public var port: NSNumber? {
+    open var port: NSNumber? {
         let port = CFURLGetPortNumber(_cfObject)
         if port == -1 {
             return nil
@@ -429,11 +429,11 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
         }
     }
     
-    public var user: String? {
+    open var user: String? {
         return CFURLCopyUserName(_cfObject)?._swiftObject
     }
     
-    public var password: String? {
+    open var password: String? {
         let absoluteURL = CFURLCopyAbsoluteURL(_cfObject)
 #if os(Linux)
         let passwordRange = CFURLGetByteRangeForComponent(absoluteURL, kCFURLComponentPassword, nil)
@@ -457,37 +457,37 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
         }
     }
     
-    public var path: String? {
+    open var path: String? {
         let absURL = CFURLCopyAbsoluteURL(_cfObject)
         return CFURLCopyFileSystemPath(absURL, kCFURLPOSIXPathStyle)?._swiftObject
     }
     
-    public var fragment: String? {
+    open var fragment: String? {
         return CFURLCopyFragment(_cfObject, nil)?._swiftObject
     }
     
-    public var parameterString: String? {
+    open var parameterString: String? {
         return CFURLCopyParameterString(_cfObject, nil)?._swiftObject
     }
     
-    public var query: String? {
+    open var query: String? {
         return CFURLCopyQueryString(_cfObject, nil)?._swiftObject
     }
     
     // The same as path if baseURL is nil
-    public var relativePath: String? {
+    open var relativePath: String? {
         return CFURLCopyFileSystemPath(_cfObject, kCFURLPOSIXPathStyle)?._swiftObject
     }
     
     /* Determines if a given URL string's path represents a directory (i.e. the path component in the URL string ends with a '/' character). This does not check the resource the URL refers to.
     */
-    public var hasDirectoryPath: Bool {
+    open var hasDirectoryPath: Bool {
         return CFURLHasDirectoryPath(_cfObject)
     }
     
     /* Returns the URL's path in file system representation. File system representation is a null-terminated C string with canonical UTF-8 encoding.
     */
-    public func getFileSystemRepresentation(_ buffer: UnsafeMutablePointer<Int8>, maxLength maxBufferLength: Int) -> Bool {
+    open func getFileSystemRepresentation(_ buffer: UnsafeMutablePointer<Int8>, maxLength maxBufferLength: Int) -> Bool {
         return buffer.withMemoryRebound(to: UInt8.self, capacity: maxBufferLength) {
             CFURLGetFileSystemRepresentation(_cfObject, true, $0, maxBufferLength)
         }
@@ -497,7 +497,7 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
     */
     
     // Memory leak. See https://github.com/apple/swift-corelibs-foundation/blob/master/Docs/Issues.md
-    public var fileSystemRepresentation: UnsafePointer<Int8> {
+    open var fileSystemRepresentation: UnsafePointer<Int8> {
         
         let bufSize = Int(PATH_MAX + 1)
         
@@ -517,12 +517,12 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
     }
     
     // Whether the scheme is file:; if [myURL isFileURL] is YES, then [myURL path] is suitable for input into NSFileManager or NSPathUtilities.
-    public var isFileURL: Bool {
+    open var isFileURL: Bool {
         return _CFURLIsFileURL(_cfObject)
     }
     
     /* A string constant for the "file" URL scheme. If you are using this to compare to a URL's scheme to see if it is a file URL, you should instead use the NSURL fileURL property -- the fileURL property is much faster. */
-    public var standardized: URL? {
+    open var standardized: URL? {
         guard (path != nil) else {
             return nil
         }
@@ -543,13 +543,13 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
     */
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    public func resourceIsReachable() throws -> Bool {
+    open func resourceIsReachable() throws -> Bool {
         NSUnimplemented()
     }
 
     /* Returns a file path URL that refers to the same resource as a specified URL. File path URLs use a file system style path. An error will occur if the url parameter is not a file URL. A file reference URL's resource must exist and be reachable to be converted to a file path URL. Symbol is present in iOS 4, but performs no operation.
     */
-    public var filePathURL: URL? {
+    open var filePathURL: URL? {
         guard isFileURL else {
             return nil
         }
@@ -557,7 +557,7 @@ public class NSURL: NSObject, NSSecureCoding, NSCopying {
         return URL(string: absoluteString)
     }
     
-    override public var _cfTypeID: CFTypeID {
+    override open var _cfTypeID: CFTypeID {
         return CFURLGetTypeID()
     }
 }
@@ -614,7 +614,7 @@ extension NSURL {
     
     /* The following methods work on the path portion of a URL in the same manner that the NSPathUtilities methods on NSString do.
     */
-    public class func fileURLWithPathComponents(_ components: [String]) -> URL? {
+    open class func fileURLWithPathComponents(_ components: [String]) -> URL? {
         let path = NSString.pathWithComponents(components)
         if components.last == "/" {
             return URL(fileURLWithPath: path, isDirectory: true)
@@ -661,11 +661,11 @@ extension NSURL {
         return nil
     }
 
-    public var pathComponents: [String]? {
+    open var pathComponents: [String]? {
         return _pathComponents(path)
     }
     
-    public var lastPathComponent: String? {
+    open var lastPathComponent: String? {
         guard let fixedSelf = _pathByFixingSlashes() else {
             return nil
         }
@@ -676,7 +676,7 @@ extension NSURL {
         return String(fixedSelf.characters.suffix(from: fixedSelf._startOfLastPathComponent))
     }
     
-    public var pathExtension: String? {
+    open var pathExtension: String? {
         guard let fixedSelf = _pathByFixingSlashes() else {
             return nil
         }
@@ -691,7 +691,7 @@ extension NSURL {
         }
     }
     
-    public func appendingPathComponent(_ pathComponent: String) -> URL? {
+    open func appendingPathComponent(_ pathComponent: String) -> URL? {
         var result : URL? = appendingPathComponent(pathComponent, isDirectory: false)
         if !pathComponent.hasSuffix("/") && isFileURL {
             if let urlWithoutDirectory = result,
@@ -706,7 +706,7 @@ extension NSURL {
         return result
     }
     
-    public func appendingPathComponent(_ pathComponent: String, isDirectory: Bool) -> URL? {
+    open func appendingPathComponent(_ pathComponent: String, isDirectory: Bool) -> URL? {
         return CFURLCreateCopyAppendingPathComponent(kCFAllocatorSystemDefault, _cfObject, pathComponent._cfObject, isDirectory)?._swiftObject
     }
     
@@ -714,7 +714,7 @@ extension NSURL {
         return CFURLCreateCopyDeletingLastPathComponent(kCFAllocatorSystemDefault, _cfObject)?._swiftObject
     }
     
-    public func appendingPathExtension(_ pathExtension: String) -> URL? {
+    open func appendingPathExtension(_ pathExtension: String) -> URL? {
         return CFURLCreateCopyAppendingPathExtension(kCFAllocatorSystemDefault, _cfObject, pathExtension._cfObject)?._swiftObject
     }
     
@@ -724,13 +724,13 @@ extension NSURL {
     
     /* The following methods work only on `file:` scheme URLs; for non-`file:` scheme URLs, these methods return the URL unchanged.
     */
-    public var standardizingPath: URL? {
+    open var standardizingPath: URL? {
         // Documentation says it should expand initial tilde, but it does't do this on OS X.
         // In remaining cases it works just like URLByResolvingSymlinksInPath.
         return resolvingSymlinksInPath
     }
     
-    public var resolvingSymlinksInPath: URL? {
+    open var resolvingSymlinksInPath: URL? {
         return _resolveSymlinksInPath(excludeSystemDirs: true)
     }
     
@@ -824,17 +824,17 @@ extension NSURL {
 }
 
 // NSURLQueryItem encapsulates a single query name-value pair. The name and value strings of a query name-value pair are not percent encoded. For use with the NSURLComponents queryItems property.
-public class NSURLQueryItem : NSObject, NSSecureCoding, NSCopying {
+open class NSURLQueryItem : NSObject, NSSecureCoding, NSCopying {
     public init(name: String, value: String?) {
         self.name = name
         self.value = value
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         return self
     }
     
@@ -846,7 +846,7 @@ public class NSURLQueryItem : NSObject, NSSecureCoding, NSCopying {
         NSUnimplemented()
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     
@@ -854,14 +854,14 @@ public class NSURLQueryItem : NSObject, NSSecureCoding, NSCopying {
     public let value: String?
 }
 
-public class NSURLComponents: NSObject, NSCopying {
+open class NSURLComponents: NSObject, NSCopying {
     private let _components : CFURLComponentsRef!
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         NSUnimplemented()
     }
     
@@ -888,13 +888,13 @@ public class NSURLComponents: NSObject, NSCopying {
     }
     
     // Returns a URL created from the NSURLComponents. If the NSURLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
-    public var url: URL? {
+    open var url: URL? {
         guard let result = _CFURLComponentsCopyURL(_components) else { return nil }
         return unsafeBitCast(result, to: URL.self)
     }
     
     // Returns a URL created from the NSURLComponents relative to a base URL. If the NSURLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
-    public func url(relativeTo baseURL: URL?) -> URL? {
+    open func url(relativeTo baseURL: URL?) -> URL? {
         if let componentString = string {
             return URL(string: componentString, relativeTo: baseURL)
         }
@@ -902,7 +902,7 @@ public class NSURLComponents: NSObject, NSCopying {
     }
     
     // Returns a URL string created from the NSURLComponents. If the NSURLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
-    public var string: String?  {
+    open var string: String?  {
         return _CFURLComponentsCopyString(_components)?._swiftObject
     }
     
@@ -910,7 +910,7 @@ public class NSURLComponents: NSObject, NSCopying {
     
     // Getting these properties removes any percent encoding these components may have (if the component allows percent encoding). Setting these properties assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
     // Attempting to set the scheme with an invalid scheme string will cause an exception.
-    public var scheme: String? {
+    open var scheme: String? {
         get {
             return _CFURLComponentsCopyScheme(_components)?._swiftObject
         }
@@ -921,7 +921,7 @@ public class NSURLComponents: NSObject, NSCopying {
         }
     }
     
-    public var user: String? {
+    open var user: String? {
         get {
             return _CFURLComponentsCopyUser(_components)?._swiftObject
         }
@@ -932,7 +932,7 @@ public class NSURLComponents: NSObject, NSCopying {
         }
     }
     
-    public var password: String? {
+    open var password: String? {
         get {
             return _CFURLComponentsCopyPassword(_components)?._swiftObject
         }
@@ -943,7 +943,7 @@ public class NSURLComponents: NSObject, NSCopying {
         }
     }
     
-    public var host: String? {
+    open var host: String? {
         get {
             return _CFURLComponentsCopyHost(_components)?._swiftObject
         }
@@ -955,7 +955,7 @@ public class NSURLComponents: NSObject, NSCopying {
     }
     
     // Attempting to set a negative port number will cause an exception.
-    public var port: NSNumber? {
+    open var port: NSNumber? {
         get {
             if let result = _CFURLComponentsCopyPort(_components) {
                 return unsafeBitCast(result, to: NSNumber.self)
@@ -970,7 +970,7 @@ public class NSURLComponents: NSObject, NSCopying {
         }
     }
     
-    public var path: String? {
+    open var path: String? {
         get {
             return _CFURLComponentsCopyPath(_components)?._swiftObject
         }
@@ -981,7 +981,7 @@ public class NSURLComponents: NSObject, NSCopying {
         }
     }
     
-    public var query: String? {
+    open var query: String? {
         get {
             return _CFURLComponentsCopyQuery(_components)?._swiftObject
         }
@@ -992,7 +992,7 @@ public class NSURLComponents: NSObject, NSCopying {
         }
     }
     
-    public var fragment: String? {
+    open var fragment: String? {
         get {
             return _CFURLComponentsCopyFragment(_components)?._swiftObject
         }
@@ -1005,7 +1005,7 @@ public class NSURLComponents: NSObject, NSCopying {
     
     
     // Getting these properties retains any percent encoding these components may have. Setting these properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause an exception. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with NSURL (-stringByAddingPercentEncodingWithAllowedCharacters: will percent-encode any ';' characters if you pass the URLPathAllowedCharacterSet).
-    public var percentEncodedUser: String? {
+    open var percentEncodedUser: String? {
         get {
             return _CFURLComponentsCopyPercentEncodedUser(_components)?._swiftObject
         }
@@ -1016,7 +1016,7 @@ public class NSURLComponents: NSObject, NSCopying {
         }
     }
     
-    public var percentEncodedPassword: String? {
+    open var percentEncodedPassword: String? {
         get {
             return _CFURLComponentsCopyPercentEncodedPassword(_components)?._swiftObject
         }
@@ -1027,7 +1027,7 @@ public class NSURLComponents: NSObject, NSCopying {
         }
     }
     
-    public var percentEncodedHost: String? {
+    open var percentEncodedHost: String? {
         get {
             return _CFURLComponentsCopyPercentEncodedHost(_components)?._swiftObject
         }
@@ -1038,7 +1038,7 @@ public class NSURLComponents: NSObject, NSCopying {
         }
     }
     
-    public var percentEncodedPath: String? {
+    open var percentEncodedPath: String? {
         get {
             return _CFURLComponentsCopyPercentEncodedPath(_components)?._swiftObject
         }
@@ -1049,7 +1049,7 @@ public class NSURLComponents: NSObject, NSCopying {
         }
     }
     
-    public var percentEncodedQuery: String? {
+    open var percentEncodedQuery: String? {
         get {
             return _CFURLComponentsCopyPercentEncodedQuery(_components)?._swiftObject
         }
@@ -1060,7 +1060,7 @@ public class NSURLComponents: NSObject, NSCopying {
         }
     }
     
-    public var percentEncodedFragment: String? {
+    open var percentEncodedFragment: String? {
         get {
             return _CFURLComponentsCopyPercentEncodedFragment(_components)?._swiftObject
         }
@@ -1074,42 +1074,42 @@ public class NSURLComponents: NSObject, NSCopying {
     
     /* These properties return the character range of a component in the URL string returned by -[NSURLComponents string]. If the component does not exist in the NSURLComponents object, {NSNotFound, 0} is returned. Note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
     */
-    public var rangeOfScheme: NSRange {
+    open var rangeOfScheme: NSRange {
         return NSRange(_CFURLComponentsGetRangeOfScheme(_components))
     }
     
-    public var rangeOfUser: NSRange {
+    open var rangeOfUser: NSRange {
         return NSRange(_CFURLComponentsGetRangeOfUser(_components))
     }
     
-    public var rangeOfPassword: NSRange {
+    open var rangeOfPassword: NSRange {
         return NSRange(_CFURLComponentsGetRangeOfPassword(_components))
     }
     
-    public var rangeOfHost: NSRange {
+    open var rangeOfHost: NSRange {
         return NSRange(_CFURLComponentsGetRangeOfHost(_components))
     }
     
-    public var rangeOfPort: NSRange {
+    open var rangeOfPort: NSRange {
         return NSRange(_CFURLComponentsGetRangeOfPort(_components))
     }
     
-    public var rangeOfPath: NSRange {
+    open var rangeOfPath: NSRange {
         return NSRange(_CFURLComponentsGetRangeOfPath(_components))
     }
     
-    public var rangeOfQuery: NSRange {
+    open var rangeOfQuery: NSRange {
         return NSRange(_CFURLComponentsGetRangeOfQuery(_components))
     }
     
-    public var rangeOfFragment: NSRange {
+    open var rangeOfFragment: NSRange {
         return NSRange(_CFURLComponentsGetRangeOfFragment(_components))
     }
     
     // The getter method that underlies the queryItems property parses the query string based on these delimiters and returns an NSArray containing any number of NSURLQueryItem objects, each of which represents a single key-value pair, in the order in which they appear in the original query string.  Note that a name may appear more than once in a single query string, so the name values are not guaranteed to be unique. If the NSURLComponents object has an empty query component, queryItems returns an empty NSArray. If the NSURLComponents object has no query component, queryItems returns nil.
     // The setter method that underlies the queryItems property combines an NSArray containing any number of NSURLQueryItem objects, each of which represents a single key-value pair, into a query string and sets the NSURLComponents' query property. Passing an empty NSArray to setQueryItems sets the query component of the NSURLComponents object to an empty string. Passing nil to setQueryItems removes the query component of the NSURLComponents object.
     // Note: If a name-value pair in a query is empty (i.e. the query string starts with '&', ends with '&', or has "&&" within it), you get a NSURLQueryItem with a zero-length name and and a nil value. If a query's name-value pair has nothing before the equals sign, you get a zero-length name. If a query's name-value pair has nothing after the equals sign, you get a zero-length value. If a query's name-value pair has no equals sign, the query name-value pair string is the name and you get a nil value.
-    public var queryItems: [URLQueryItem]? {
+    open var queryItems: [URLQueryItem]? {
         get {
             // This CFURL implementation returns a CFArray of CFDictionary; each CFDictionary has an entry for name and optionally an entry for value
             if let queryArray = _CFURLComponentsCopyQueryItems(_components) {

--- a/Foundation/NSURLAuthenticationChallenge.swift
+++ b/Foundation/NSURLAuthenticationChallenge.swift
@@ -46,7 +46,7 @@ public protocol URLAuthenticationChallengeSender : NSObjectProtocol {
     provides all the information about the challenge, and has a method
     to indicate when it's done.
 */
-public class URLAuthenticationChallenge : NSObject, NSSecureCoding {
+open class URLAuthenticationChallenge : NSObject, NSSecureCoding {
     
     static public func supportsSecureCoding() -> Bool {
         return true
@@ -56,7 +56,7 @@ public class URLAuthenticationChallenge : NSObject, NSSecureCoding {
         NSUnimplemented()
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     
@@ -94,7 +94,7 @@ public class URLAuthenticationChallenge : NSObject, NSSecureCoding {
      @abstract Get a description of the protection space that requires authentication
      @result The protection space that needs authentication
      */
-    /*@NSCopying*/ public var protectionSpace: URLProtectionSpace {
+    /*@NSCopying*/ open var protectionSpace: URLProtectionSpace {
         get {
             NSUnimplemented()
         }
@@ -113,7 +113,7 @@ public class URLAuthenticationChallenge : NSObject, NSSecureCoding {
      credential is not ready to use as-is, but provides a default
      username the client could use when prompting.
      */
-    /*@NSCopying*/ public var proposedCredential: URLCredential? {
+    /*@NSCopying*/ open var proposedCredential: URLCredential? {
         get {
             NSUnimplemented()
         }
@@ -125,7 +125,7 @@ public class URLAuthenticationChallenge : NSObject, NSSecureCoding {
      @abstract Get count of previous failed authentication attempts
      @result The count of previous failures
      */
-    public var previousFailureCount: Int {
+    open var previousFailureCount: Int {
         get {
             NSUnimplemented()
         }
@@ -141,7 +141,7 @@ public class URLAuthenticationChallenge : NSObject, NSSecureCoding {
      then this method will return the response. Otherwise it will
      return nil.
      */
-    /*@NSCopying*/ public var failureResponse: URLResponse? {
+    /*@NSCopying*/ open var failureResponse: URLResponse? {
         get {
             NSUnimplemented()
         }
@@ -156,7 +156,7 @@ public class URLAuthenticationChallenge : NSObject, NSSecureCoding {
      then this method will return the error. Otherwise it will
      return nil.
      */
-    /*@NSCopying*/ public var error: NSError? {
+    /*@NSCopying*/ open var error: NSError? {
         get {
             NSUnimplemented()
         }
@@ -169,7 +169,7 @@ public class URLAuthenticationChallenge : NSObject, NSSecureCoding {
      @result The sender of the challenge
      @discussion The sender is the object you should reply to when done processing the challenge.
      */
-    public var sender: URLAuthenticationChallengeSender? {
+    open var sender: URLAuthenticationChallengeSender? {
         get {
             NSUnimplemented()
         }

--- a/Foundation/NSURLCache.swift
+++ b/Foundation/NSURLCache.swift
@@ -42,13 +42,13 @@ extension URLCache {
     It is used to maintain characteristics and attributes of a cached 
     object. 
 */
-public class CachedURLResponse : NSObject, NSSecureCoding, NSCopying {
+open class CachedURLResponse : NSObject, NSSecureCoding, NSCopying {
     
     public required init?(coder aDecoder: NSCoder) {
         NSUnimplemented()
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     
@@ -56,11 +56,11 @@ public class CachedURLResponse : NSObject, NSSecureCoding, NSCopying {
         return true
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         NSUnimplemented()
     }
 
@@ -97,31 +97,31 @@ public class CachedURLResponse : NSObject, NSSecureCoding, NSCopying {
         @abstract Returns the response wrapped by this instance. 
         @result The response wrapped by this instance. 
     */
-    /*@NSCopying*/ public var response: URLResponse { NSUnimplemented() }
+    /*@NSCopying*/ open var response: URLResponse { NSUnimplemented() }
     
     /*! 
         @method data
         @abstract Returns the data of the receiver. 
         @result The data of the receiver. 
     */
-    /*@NSCopying*/ public var data: Data { NSUnimplemented() }
+    /*@NSCopying*/ open var data: Data { NSUnimplemented() }
     
     /*! 
         @method userInfo
         @abstract Returns the userInfo dictionary of the receiver. 
         @result The userInfo dictionary of the receiver. 
     */
-    public var userInfo: [NSObject : AnyObject]? { NSUnimplemented() }
+    open var userInfo: [NSObject : AnyObject]? { NSUnimplemented() }
     
     /*! 
         @method storagePolicy
         @abstract Returns the NSURLCacheStoragePolicy constant of the receiver. 
         @result The NSURLCacheStoragePolicy constant of the receiver. 
     */
-    public var storagePolicy: URLCache.StoragePolicy { NSUnimplemented() }
+    open var storagePolicy: URLCache.StoragePolicy { NSUnimplemented() }
 }
 
-public class URLCache : NSObject {
+open class URLCache : NSObject {
     
     /*! 
         @method sharedURLCache
@@ -141,7 +141,7 @@ public class URLCache : NSObject {
         different NSURLCache instance to be returned from this method.
         @result the shared NSURLCache instance.
     */
-    public class var shared: URLCache {
+    open class var shared: URLCache {
         get {
             NSUnimplemented()
         }
@@ -176,7 +176,7 @@ public class URLCache : NSObject {
         request, or nil if there is no NSCachedURLResponse stored with the
         given request.
     */
-    public func cachedResponse(for request: URLRequest) -> CachedURLResponse? { NSUnimplemented() }
+    open func cachedResponse(for request: URLRequest) -> CachedURLResponse? { NSUnimplemented() }
     
     /*! 
         @method storeCachedResponse:forRequest:
@@ -185,7 +185,7 @@ public class URLCache : NSObject {
         @param cachedResponse The cached response to store.
         @param request the NSURLRequest to use as a key for the storage.
     */
-    public func storeCachedResponse(_ cachedResponse: CachedURLResponse, for request: URLRequest) { NSUnimplemented() }
+    open func storeCachedResponse(_ cachedResponse: CachedURLResponse, for request: URLRequest) { NSUnimplemented() }
     
     /*! 
         @method removeCachedResponseForRequest:
@@ -195,20 +195,20 @@ public class URLCache : NSObject {
         stored with the given request.
         @param request the NSURLRequest to use as a key for the lookup.
     */
-    public func removeCachedResponse(for request: URLRequest) { NSUnimplemented() }
+    open func removeCachedResponse(for request: URLRequest) { NSUnimplemented() }
     
     /*! 
         @method removeAllCachedResponses
         @abstract Clears the given cache, removing all NSCachedURLResponse
         objects that it stores.
     */
-    public func removeAllCachedResponses() { NSUnimplemented() }
+    open func removeAllCachedResponses() { NSUnimplemented() }
     
     /*!
      @method removeCachedResponsesSince:
      @abstract Clears the given cache of any cached responses since the provided date.
      */
-    public func removeCachedResponses(since date: Date) { NSUnimplemented() }
+    open func removeCachedResponses(since date: Date) { NSUnimplemented() }
     
     /*! 
         @method memoryCapacity
@@ -216,7 +216,7 @@ public class URLCache : NSObject {
         @discussion At the time this call is made, the in-memory cache will truncate its contents to the size given, if necessary.
         @result The in-memory capacity, measured in bytes, for the receiver. 
     */
-    public var memoryCapacity: Int
+    open var memoryCapacity: Int
     
     /*! 
         @method diskCapacity
@@ -224,7 +224,7 @@ public class URLCache : NSObject {
         @discussion At the time this call is made, the on-disk cache will truncate its contents to the size given, if necessary.
         @param diskCapacity the new on-disk capacity, measured in bytes, for the receiver.
     */
-    public var diskCapacity: Int
+    open var diskCapacity: Int
     
     /*! 
         @method currentMemoryUsage
@@ -234,7 +234,7 @@ public class URLCache : NSObject {
         usage of the in-memory cache. 
         @result the current usage of the in-memory cache of the receiver.
     */
-    public var currentMemoryUsage: Int { NSUnimplemented() }
+    open var currentMemoryUsage: Int { NSUnimplemented() }
     
     /*! 
         @method currentDiskUsage
@@ -244,7 +244,7 @@ public class URLCache : NSObject {
         usage of the on-disk cache. 
         @result the current usage of the on-disk cache of the receiver.
     */
-    public var currentDiskUsage: Int { NSUnimplemented() }
+    open var currentDiskUsage: Int { NSUnimplemented() }
 }
 
 extension URLCache {

--- a/Foundation/NSURLCredential.swift
+++ b/Foundation/NSURLCredential.swift
@@ -32,7 +32,7 @@ extension URLCredential {
     @class NSURLCredential
     @discussion This class is an immutable object representing an authentication credential.  The actual type of the credential is determined by the constructor called in the categories declared below.
 */
-public class URLCredential : NSObject, NSSecureCoding, NSCopying {
+open class URLCredential : NSObject, NSSecureCoding, NSCopying {
     private var _user : String
     private var _password : String
     private var _persistence : Persistence
@@ -68,7 +68,7 @@ public class URLCredential : NSObject, NSSecureCoding, NSCopying {
         NSUnimplemented()
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     
@@ -76,11 +76,11 @@ public class URLCredential : NSObject, NSSecureCoding, NSCopying {
         return true
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         NSUnimplemented()
     }
     
@@ -89,14 +89,14 @@ public class URLCredential : NSObject, NSSecureCoding, NSCopying {
         @abstract Determine whether this credential is or should be stored persistently
         @result A value indicating whether this credential is stored permanently, per session or not at all.
      */
-    public var persistence: Persistence { return _persistence }
+    open var persistence: Persistence { return _persistence }
     
     /*!
         @method user
         @abstract Get the username
         @result The user string
      */
-    public var user: String? { return _user }
+    open var user: String? { return _user }
     
     /*!
         @method password
@@ -106,7 +106,7 @@ public class URLCredential : NSObject, NSSecureCoding, NSCopying {
         password from an external store, possible resulting in prompting,
         so do not call it unless needed.
      */
-    public var password: String? { return _password }
+    open var password: String? { return _password }
 
     /*!
         @method hasPassword
@@ -117,7 +117,7 @@ public class URLCredential : NSObject, NSSecureCoding, NSCopying {
         method returns YES, since getting the password may fail, or the
         user may refuse access.
      */
-    public var hasPassword: Bool {
+    open var hasPassword: Bool {
         // Currently no support for SecTrust/SecIdentity, always return true
         return true
     }

--- a/Foundation/NSURLCredentialStorage.swift
+++ b/Foundation/NSURLCredentialStorage.swift
@@ -12,14 +12,14 @@
     @class NSURLCredentialStorage
     @discussion NSURLCredentialStorage implements a singleton object (shared instance) which manages the shared credentials cache. Note: Whereas in Mac OS X any application can access any credential with a persistence of NSURLCredentialPersistencePermanent provided the user gives permission, in iPhone OS an application can access only its own credentials.
 */
-public class URLCredentialStorage: NSObject {
+open class URLCredentialStorage: NSObject {
     
     /*!
         @method sharedCredentialStorage
         @abstract Get the shared singleton authentication storage
         @result the shared authentication storage
     */
-    public class var shared: URLCredentialStorage { get { NSUnimplemented() } }
+    open class var shared: URLCredentialStorage { get { NSUnimplemented() } }
     
     /*!
         @method credentialsForProtectionSpace:
@@ -27,7 +27,7 @@ public class URLCredentialStorage: NSObject {
         @param protectionSpace An NSURLProtectionSpace indicating the protection space for which to get credentials
         @result A dictionary where the keys are usernames and the values are the corresponding NSURLCredentials.
     */
-    public func credentials(for space: URLProtectionSpace) -> [String : URLCredential]? { NSUnimplemented() }
+    open func credentials(for space: URLProtectionSpace) -> [String : URLCredential]? { NSUnimplemented() }
     
     /*!
         @method allCredentials
@@ -36,7 +36,7 @@ public class URLCredentialStorage: NSObject {
         and the values are dictionaries, in which the keys are usernames
         and the values are NSURLCredentials
     */
-    public var allCredentials: [URLProtectionSpace : [String : URLCredential]] { NSUnimplemented() }
+    open var allCredentials: [URLProtectionSpace : [String : URLCredential]] { NSUnimplemented() }
     
     /*!
         @method setCredential:forProtectionSpace:
@@ -47,7 +47,7 @@ public class URLCredentialStorage: NSObject {
         a distinct user. If a credential with the same user is already set for the protection space,
         the new one will replace it.
     */
-    public func set(_ credential: URLCredential, for space: URLProtectionSpace) { NSUnimplemented() }
+    open func set(_ credential: URLCredential, for space: URLProtectionSpace) { NSUnimplemented() }
     
     /*!
         @method removeCredential:forProtectionSpace:
@@ -58,7 +58,7 @@ public class URLCredentialStorage: NSObject {
         has a persistence policy of NSURLCredentialPersistenceSynchronizable will fail.  
         See removeCredential:forProtectionSpace:options.
     */
-    public func remove(_ credential: URLCredential, for space: URLProtectionSpace) { NSUnimplemented() }
+    open func remove(_ credential: URLCredential, for space: URLProtectionSpace) { NSUnimplemented() }
     
     /*!
      @method removeCredential:forProtectionSpace:options
@@ -71,14 +71,14 @@ public class URLCredentialStorage: NSObject {
      are removed, the credential will be removed on all devices that contain this credential.
      @discussion The credential is removed from both persistent and temporary storage.
      */
-    public func remove(_ credential: URLCredential, for space: URLProtectionSpace, options: [String : AnyObject]? = [:]) { NSUnimplemented() }
+    open func remove(_ credential: URLCredential, for space: URLProtectionSpace, options: [String : AnyObject]? = [:]) { NSUnimplemented() }
     
     /*!
         @method defaultCredentialForProtectionSpace:
         @abstract Get the default credential for the specified protection space.
         @param space The protection space for which to get the default credential.
     */
-    public func defaultCredential(for space: URLProtectionSpace) -> URLCredential? { NSUnimplemented() }
+    open func defaultCredential(for space: URLProtectionSpace) -> URLCredential? { NSUnimplemented() }
     
     /*!
         @method setDefaultCredential:forProtectionSpace:
@@ -87,7 +87,7 @@ public class URLCredentialStorage: NSObject {
         @param space The protection space for which the credential should be set as default.
         @discussion If the credential is not yet in the set for the protection space, it will be added to it.
     */
-    public func setDefaultCredential(_ credential: URLCredential, for space: URLProtectionSpace) { NSUnimplemented() }
+    open func setDefaultCredential(_ credential: URLCredential, for space: URLProtectionSpace) { NSUnimplemented() }
 }
 
 extension URLCredentialStorage {

--- a/Foundation/NSURLProtectionSpace.swift
+++ b/Foundation/NSURLProtectionSpace.swift
@@ -104,15 +104,15 @@ public let NSURLAuthenticationMethodServerTrust: String = "NSURLAuthenticationMe
     @class NSURLProtectionSpace
     @discussion This class represents a protection space requiring authentication.
 */
-public class URLProtectionSpace : NSObject, NSSecureCoding, NSCopying {
+open class URLProtectionSpace : NSObject, NSSecureCoding, NSCopying {
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject { NSUnimplemented() }
+    open func copy(with zone: NSZone? = nil) -> AnyObject { NSUnimplemented() }
     public static func supportsSecureCoding() -> Bool { return true }
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     public required init?(coder aDecoder: NSCoder) {
@@ -160,14 +160,14 @@ public class URLProtectionSpace : NSObject, NSSecureCoding, NSCopying {
         authentication, and may be nil otherwise.
         @result The realm string
     */
-    public var realm: String? { NSUnimplemented() }
+    open var realm: String? { NSUnimplemented() }
     
     /*!
         @method receivesCredentialSecurely
         @abstract Determine if the password for this protection space can be sent securely
         @result YES if a secure authentication method or protocol will be used, NO otherwise
     */
-    public var receivesCredentialSecurely: Bool { NSUnimplemented() }
+    open var receivesCredentialSecurely: Bool { NSUnimplemented() }
     
     /*!
         @method isProxy
@@ -180,36 +180,36 @@ public class URLProtectionSpace : NSObject, NSSecureCoding, NSCopying {
         @abstract Get the proxy host if this is a proxy authentication, or the host from the URL.
         @result The host for this protection space.
     */
-    public var host: String { NSUnimplemented() }
+    open var host: String { NSUnimplemented() }
     
     /*!
         @method port
         @abstract Get the proxy port if this is a proxy authentication, or the port from the URL.
         @result The port for this protection space, or 0 if not set.
     */
-    public var port: Int { NSUnimplemented() }
+    open var port: Int { NSUnimplemented() }
     
     /*!
         @method proxyType
         @abstract Get the type of this protection space, if a proxy
         @result The type string, or nil if not a proxy.
      */
-    public var proxyType: String? { NSUnimplemented() }
+    open var proxyType: String? { NSUnimplemented() }
     
     /*!
         @method protocol
         @abstract Get the protocol of this protection space, if not a proxy
         @result The type string, or nil if a proxy.
     */
-    public var `protocol`: String? { NSUnimplemented() }
+    open var `protocol`: String? { NSUnimplemented() }
     
     /*!
         @method authenticationMethod
         @abstract Get the authentication method to be used for this protection space
         @result The authentication method
     */
-    public var authenticationMethod: String { NSUnimplemented() }
-    public override func isProxy() -> Bool { NSUnimplemented() }
+    open var authenticationMethod: String { NSUnimplemented() }
+    open override func isProxy() -> Bool { NSUnimplemented() }
 }
 
 extension URLProtectionSpace {

--- a/Foundation/NSURLProtocol.swift
+++ b/Foundation/NSURLProtocol.swift
@@ -150,7 +150,7 @@ public protocol URLProtocolClient : NSObjectProtocol {
     data. Concrete subclasses handle the specifics associated with one
     or more protocols or URL schemes.
 */
-public class URLProtocol : NSObject {
+open class URLProtocol : NSObject {
     
     /*! 
         @method initWithRequest:cachedResponse:client:
@@ -172,21 +172,21 @@ public class URLProtocol : NSObject {
         @abstract Returns the NSURLProtocolClient of the receiver. 
         @result The NSURLProtocolClient of the receiver.  
     */
-    public var client: URLProtocolClient? { NSUnimplemented() }
+    open var client: URLProtocolClient? { NSUnimplemented() }
     
     /*! 
         @method request
         @abstract Returns the NSURLRequest of the receiver. 
         @result The NSURLRequest of the receiver. 
     */
-    /*@NSCopying*/ public var request: URLRequest { NSUnimplemented() }
+    /*@NSCopying*/ open var request: URLRequest { NSUnimplemented() }
     
     /*! 
         @method cachedResponse
         @abstract Returns the NSCachedURLResponse of the receiver.  
         @result The NSCachedURLResponse of the receiver. 
     */
-    /*@NSCopying*/ public var cachedResponse: CachedURLResponse? { NSUnimplemented() }
+    /*@NSCopying*/ open var cachedResponse: CachedURLResponse? { NSUnimplemented() }
     
     /*======================================================================
       Begin responsibilities for protocol implementors
@@ -207,7 +207,7 @@ public class URLProtocol : NSObject {
         @param request A request to inspect.
         @result YES if the protocol can handle the given request, NO if not.
     */
-    public class func canInit(with request: URLRequest) -> Bool { NSUnimplemented() }
+    open class func canInit(with request: URLRequest) -> Bool { NSUnimplemented() }
     
     /*! 
         @method canonicalRequestForRequest:
@@ -227,7 +227,7 @@ public class URLProtocol : NSObject {
         @param request A request to make canonical.
         @result The canonical form of the given request. 
     */
-    public class func canonicalRequest(for request: URLRequest) -> URLRequest { NSUnimplemented() }
+    open class func canonicalRequest(for request: URLRequest) -> URLRequest { NSUnimplemented() }
     
     /*!
         @method requestIsCacheEquivalent:toRequest:
@@ -238,7 +238,7 @@ public class URLProtocol : NSObject {
         implementation-specific checks.
         @result YES if the two requests are cache-equivalent, NO otherwise.
     */
-    public class func requestIsCacheEquivalent(_ a: URLRequest, to b: URLRequest) -> Bool { NSUnimplemented() }
+    open class func requestIsCacheEquivalent(_ a: URLRequest, to b: URLRequest) -> Bool { NSUnimplemented() }
     
     /*! 
         @method startLoading
@@ -246,7 +246,7 @@ public class URLProtocol : NSObject {
         @discussion When this method is called, the protocol implementation
         should start loading a request.
     */
-    public func startLoading() { NSUnimplemented() }
+    open func startLoading() { NSUnimplemented() }
     
     /*! 
         @method stopLoading
@@ -256,7 +256,7 @@ public class URLProtocol : NSObject {
         to a cancel operation, so protocol implementations must be able to
         handle this call while a load is in progress.
     */
-    public func stopLoading() { NSUnimplemented() }
+    open func stopLoading() { NSUnimplemented() }
     
     /*======================================================================
       End responsibilities for protocol implementors
@@ -274,7 +274,7 @@ public class URLProtocol : NSObject {
         @result The property stored with the given key, or nil if no property
         had previously been stored with the given key in the given request.
     */
-    public class func property(forKey key: String, in request: URLRequest) -> AnyObject? { NSUnimplemented() }
+    open class func property(forKey key: String, in request: URLRequest) -> AnyObject? { NSUnimplemented() }
     
     /*! 
         @method setProperty:forKey:inRequest:
@@ -287,7 +287,7 @@ public class URLProtocol : NSObject {
         @param key The string to use for the property storage. 
         @param request The request in which to store the property. 
     */
-    public class func setProperty(_ value: AnyObject, forKey key: String, in request: NSMutableURLRequest) { NSUnimplemented() }
+    open class func setProperty(_ value: AnyObject, forKey key: String, in request: NSMutableURLRequest) { NSUnimplemented() }
     
     /*!
         @method removePropertyForKey:inRequest:
@@ -298,7 +298,7 @@ public class URLProtocol : NSObject {
         @param key The key whose value should be removed
         @param request The request to be modified
     */
-    public class func removeProperty(forKey key: String, in request: NSMutableURLRequest) { NSUnimplemented() }
+    open class func removeProperty(forKey key: String, in request: NSMutableURLRequest) { NSUnimplemented() }
     
     /*! 
         @method registerClass:
@@ -323,7 +323,7 @@ public class URLProtocol : NSObject {
         The only way that failure can occur is if the given class is not a
         subclass of NSURLProtocol.
     */
-    public class func registerClass(_ protocolClass: AnyClass) -> Bool { NSUnimplemented() }
+    open class func registerClass(_ protocolClass: AnyClass) -> Bool { NSUnimplemented() }
     
     /*! 
         @method unregisterClass:
@@ -332,10 +332,10 @@ public class URLProtocol : NSObject {
         consulted in calls to NSURLProtocol class methods.
         @param protocolClass The class to unregister.
     */
-    public class func unregisterClass(_ protocolClass: AnyClass) { NSUnimplemented() }
+    open class func unregisterClass(_ protocolClass: AnyClass) { NSUnimplemented() }
 
-    public class func canInit(with task: URLSessionTask) -> Bool { NSUnimplemented() }
+    open class func canInit(with task: URLSessionTask) -> Bool { NSUnimplemented() }
     public convenience init(task: URLSessionTask, cachedResponse: CachedURLResponse?, client: URLProtocolClient?) { NSUnimplemented() }
-    /*@NSCopying*/ public var task: URLSessionTask? { NSUnimplemented() }
+    /*@NSCopying*/ open var task: URLSessionTask? { NSUnimplemented() }
 }
 

--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -115,13 +115,13 @@ extension NSURLRequest {
 ///
 /// Objects of this class are used with the `NSURLSession` API to perform the
 /// load of a URL.
-public class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying {
+open class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying {
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         if type(of: self) === NSURLRequest.self {
             // Already immutable
             return self
@@ -148,11 +148,11 @@ public class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying
         self.httpMethod = source.httpMethod
     }
     
-    public override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> AnyObject {
         return mutableCopy(with: nil)
     }
     
-    public func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
         let c = NSMutableURLRequest(url: url!)
         c.setValues(from: self)
         return c
@@ -162,7 +162,7 @@ public class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying
         NSUnimplemented()
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     
@@ -170,31 +170,31 @@ public class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying
     public static func supportsSecureCoding() -> Bool { return true }
     
     /// The URL of the receiver.
-    /*@NSCopying */public fileprivate(set) var url: URL?
+    /*@NSCopying */open fileprivate(set) var url: URL?
     
     /// The main document URL associated with this load.
     ///
     /// This URL is used for the cookie "same domain as main
     /// document" policy. There may also be other future uses.
-    /*@NSCopying*/ public fileprivate(set) var mainDocumentURL: URL?
+    /*@NSCopying*/ open fileprivate(set) var mainDocumentURL: URL?
     
     internal var _cachePolicy: CachePolicy = .useProtocolCachePolicy
-    public var cachePolicy: CachePolicy {
+    open var cachePolicy: CachePolicy {
         return _cachePolicy
     }
     
     internal var _timeoutInterval: TimeInterval = 60.0
-    public var timeoutInterval: TimeInterval {
+    open var timeoutInterval: TimeInterval {
         return _timeoutInterval
     }
 
     /// Returns the HTTP request method of the receiver.
-    public fileprivate(set) var httpMethod: String? = "GET"
+    open fileprivate(set) var httpMethod: String? = "GET"
     
     /// A dictionary containing all the HTTP header fields
     /// of the receiver.
     internal var _allHTTPHeaderFields: [String: String]? = nil
-    public var allHTTPHeaderFields: [String: String]? {
+    open var allHTTPHeaderFields: [String: String]? {
         get {
             return _allHTTPHeaderFields
         }
@@ -208,7 +208,7 @@ public class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying
     ///     (case-insensitive).
     /// - Returns: the value associated with the given header field, or `nil` if
     /// there is no value associated with the given header field.
-    public func value(forHTTPHeaderField field: String) -> String? {
+    open func value(forHTTPHeaderField field: String) -> String? {
         guard let f = allHTTPHeaderFields else { return nil }
         return existingHeaderField(field, inHeaderFields: f)?.1
     }
@@ -219,7 +219,7 @@ public class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying
     }
     internal var _body: Body?
     
-    public var httpBody: Data? {
+    open var httpBody: Data? {
         if let body = _body {
             switch body {
             case .data(let data):
@@ -231,7 +231,7 @@ public class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying
         return nil
     }
     
-    public var httpBodyStream: InputStream? {
+    open var httpBodyStream: InputStream? {
         if let body = _body {
             switch body {
             case .data(_):
@@ -244,22 +244,22 @@ public class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying
     }
     
     internal var _networkServiceType: NetworkServiceType = .networkServiceTypeDefault
-    public var networkServiceType: NetworkServiceType {
+    open var networkServiceType: NetworkServiceType {
         return _networkServiceType
     }
     
     internal var _allowsCellularAccess: Bool = true
-    public var allowsCellularAccess: Bool {
+    open var allowsCellularAccess: Bool {
         return _allowsCellularAccess
     }
     
     internal var _httpShouldHandleCookies: Bool = true
-    public var httpShouldHandleCookies: Bool {
+    open var httpShouldHandleCookies: Bool {
         return _httpShouldHandleCookies
     }
     
     internal var _httpShouldUsePipelining: Bool = true
-    public var httpShouldUsePipelining: Bool {
+    open var httpShouldUsePipelining: Bool {
         return _httpShouldUsePipelining
     }
 }
@@ -290,7 +290,7 @@ public class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying
 /// `NSMutableURLRequest` categories that are available. The
 /// `NSMutableHTTPURLRequest` category on `NSMutableURLRequest` is an
 /// example.
-public class NSMutableURLRequest : NSURLRequest {
+open class NSMutableURLRequest : NSURLRequest {
     public required init?(coder aDecoder: NSCoder) {
         NSUnimplemented()
     }
@@ -303,7 +303,7 @@ public class NSMutableURLRequest : NSURLRequest {
         super.init(url: url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
     }
     
-    /*@NSCopying */ public override var url: URL? {
+    /*@NSCopying */ open override var url: URL? {
         get { return super.url }
         //TODO: set { super.URL = newValue.map{ $0.copy() as! NSURL } }
         set { super.url = newValue }
@@ -317,7 +317,7 @@ public class NSMutableURLRequest : NSURLRequest {
     /// passed.  This main document will be used to implement the cookie
     /// *only from same domain as main document* policy, and possibly
     /// other things in the future.
-    /*@NSCopying*/ public override var mainDocumentURL: URL? {
+    /*@NSCopying*/ open override var mainDocumentURL: URL? {
         get { return super.mainDocumentURL }
         //TODO: set { super.mainDocumentURL = newValue.map{ $0.copy() as! NSURL } }
         set { super.mainDocumentURL = newValue }
@@ -325,12 +325,12 @@ public class NSMutableURLRequest : NSURLRequest {
     
     
     /// The HTTP request method of the receiver.
-    public override var httpMethod: String? {
+    open override var httpMethod: String? {
         get { return super.httpMethod }
         set { super.httpMethod = newValue }
     }
     
-    public override var cachePolicy: CachePolicy {
+    open override var cachePolicy: CachePolicy {
         get {
             return _cachePolicy
         }
@@ -339,7 +339,7 @@ public class NSMutableURLRequest : NSURLRequest {
         }
     }
     
-    public override var timeoutInterval: TimeInterval {
+    open override var timeoutInterval: TimeInterval {
         get {
             return _timeoutInterval
         }
@@ -348,7 +348,7 @@ public class NSMutableURLRequest : NSURLRequest {
         }
     }
     
-    public override var allHTTPHeaderFields: [String: String]? {
+    open override var allHTTPHeaderFields: [String: String]? {
         get {
             return _allHTTPHeaderFields
         }
@@ -365,7 +365,7 @@ public class NSMutableURLRequest : NSURLRequest {
     /// case-insensitive.
     /// - Parameter value: the header field value.
     /// - Parameter field: the header field name (case-insensitive).
-    public func setValue(_ value: String?, forHTTPHeaderField field: String) {
+    open func setValue(_ value: String?, forHTTPHeaderField field: String) {
         var f: [String: String] = allHTTPHeaderFields ?? [:]
         if let old = existingHeaderField(field, inHeaderFields: f) {
             f.removeValue(forKey: old.0)
@@ -385,7 +385,7 @@ public class NSMutableURLRequest : NSURLRequest {
     /// header field names are case-insensitive.
     /// - Parameter value: the header field value.
     /// - Parameter field: the header field name (case-insensitive).
-    public func addValue(_ value: String, forHTTPHeaderField field: String) {
+    open func addValue(_ value: String, forHTTPHeaderField field: String) {
         var f: [String: String] = allHTTPHeaderFields ?? [:]
         if let old = existingHeaderField(field, inHeaderFields: f) {
             f[old.0] = old.1 + "," + value
@@ -395,7 +395,7 @@ public class NSMutableURLRequest : NSURLRequest {
         _allHTTPHeaderFields = f
     }
     
-    public override var httpBody: Data? {
+    open override var httpBody: Data? {
         get {
             if let body = _body {
                 switch body {
@@ -416,7 +416,7 @@ public class NSMutableURLRequest : NSURLRequest {
         }
     }
     
-    public override var httpBodyStream: InputStream? {
+    open override var httpBodyStream: InputStream? {
         get {
             if let body = _body {
                 switch body {
@@ -437,7 +437,7 @@ public class NSMutableURLRequest : NSURLRequest {
         }
     }
     
-    public override var networkServiceType: NetworkServiceType {
+    open override var networkServiceType: NetworkServiceType {
         get {
             return _networkServiceType
         }
@@ -446,7 +446,7 @@ public class NSMutableURLRequest : NSURLRequest {
         }
     }
     
-    public override var allowsCellularAccess: Bool {
+    open override var allowsCellularAccess: Bool {
         get {
             return _allowsCellularAccess
         }
@@ -455,7 +455,7 @@ public class NSMutableURLRequest : NSURLRequest {
         }
     }
     
-    public override var httpShouldHandleCookies: Bool {
+    open override var httpShouldHandleCookies: Bool {
         get {
             return _httpShouldHandleCookies
         }
@@ -464,7 +464,7 @@ public class NSMutableURLRequest : NSURLRequest {
         }
     }
     
-    public override var httpShouldUsePipelining: Bool {
+    open override var httpShouldUsePipelining: Bool {
         get {
             return _httpShouldUsePipelining
         }

--- a/Foundation/NSURLResponse.swift
+++ b/Foundation/NSURLResponse.swift
@@ -16,7 +16,7 @@
 /// the actual bytes representing the content of a URL. See
 /// `NSURLSession` for more information about receiving the content
 /// data for a URL load.
-public class URLResponse : NSObject, NSSecureCoding, NSCopying {
+open class URLResponse : NSObject, NSSecureCoding, NSCopying {
 
     static public func supportsSecureCoding() -> Bool {
         return true
@@ -26,15 +26,15 @@ public class URLResponse : NSObject, NSSecureCoding, NSCopying {
         NSUnimplemented()
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         return self
     }
     
@@ -56,7 +56,7 @@ public class URLResponse : NSObject, NSSecureCoding, NSCopying {
     }
     
     /// The URL of the receiver.
-    /*@NSCopying*/ public private(set) var url: URL?
+    /*@NSCopying*/ open private(set) var url: URL?
 
     
     /// The MIME type of the receiver.
@@ -67,7 +67,7 @@ public class URLResponse : NSObject, NSSecureCoding, NSCopying {
     /// that the origin server or source reported the information
     /// incorrectly or imprecisely. An attempt to guess the MIME type may
     /// be made if the origin source did not report any such information.
-    public fileprivate(set) var mimeType: String?
+    open fileprivate(set) var mimeType: String?
     
     /// The expected content length of the receiver.
     ///
@@ -81,7 +81,7 @@ public class URLResponse : NSObject, NSSecureCoding, NSCopying {
     /// The expected content length of the receiver, or `-1` if
     /// there is no expectation that can be arrived at regarding expected
     /// content length.
-    public fileprivate(set) var expectedContentLength: Int64
+    open fileprivate(set) var expectedContentLength: Int64
     
     /// The name of the text encoding of the receiver.
     ///
@@ -90,7 +90,7 @@ public class URLResponse : NSObject, NSSecureCoding, NSCopying {
     /// URL load. Clients can inspect this string and convert it to an
     /// NSStringEncoding or CFStringEncoding using the methods and
     /// functions made available in the appropriate framework.
-    public fileprivate(set) var textEncodingName: String?
+    open fileprivate(set) var textEncodingName: String?
     
     /// A suggested filename if the resource were saved to disk.
     ///
@@ -104,7 +104,7 @@ public class URLResponse : NSObject, NSSecureCoding, NSCopying {
     /// method appends the proper file extension based on the MIME type.
     ///
     /// This method always returns a valid filename.
-    public fileprivate(set) var suggestedFilename: String?
+    open fileprivate(set) var suggestedFilename: String?
 }
 
 /// A Response to an HTTP URL load.
@@ -113,7 +113,7 @@ public class URLResponse : NSObject, NSSecureCoding, NSCopying {
 /// HTTP URL load. It is a specialization of NSURLResponse which
 /// provides conveniences for accessing information specific to HTTP
 /// protocol responses.
-public class NSHTTPURLResponse : URLResponse {
+open class NSHTTPURLResponse : URLResponse {
     
     /// Initializer for NSHTTPURLResponse objects.
     ///
@@ -159,7 +159,7 @@ public class NSHTTPURLResponse : URLResponse {
     /// Convenience method which returns a localized string
     /// corresponding to the status code for this response.
     /// - Parameter forStatusCode: the status code to use to produce a localized string.
-    public class func localizedString(forStatusCode statusCode: Int) -> String {
+    open class func localizedString(forStatusCode statusCode: Int) -> String {
         switch statusCode {
         case 100: return "Continue"
         case 101: return "Switching Protocols"
@@ -231,7 +231,7 @@ public class NSHTTPURLResponse : URLResponse {
 
     /// A string that represents the contents of the NSHTTPURLResponse Object.
     /// This property is intended to produce readable output.
-    override public var description: String {
+    override open var description: String {
         var result = "<\(type(of: self)) \(Unmanaged.passUnretained(self).toOpaque())> { URL: \(url!.absoluteString) }{ status: \(statusCode), headers {\n"
         for(key, value) in allHeaderFields {
             if((key.lowercased() == "content-disposition" && suggestedFilename != "Unknown") || key.lowercased() == "content-type") {

--- a/Foundation/NSURLSession.swift
+++ b/Foundation/NSURLSession.swift
@@ -78,13 +78,13 @@
 
 public let NSURLSessionTransferSizeUnknown: Int64 = -1
 
-public class URLSession: NSObject {
+open class URLSession: NSObject {
     
     /*
      * The shared session uses the currently set global NSURLCache,
      * NSHTTPCookieStorage and NSURLCredentialStorage objects.
      */
-    public class func sharedSession() -> URLSession { NSUnimplemented() }
+    open class func sharedSession() -> URLSession { NSUnimplemented() }
     
     /*
      * Customization of NSURLSession occurs during creation of a new session.
@@ -96,15 +96,15 @@ public class URLSession: NSObject {
     public /*not inherited*/ init(configuration: URLSessionConfiguration) { NSUnimplemented() }
     public /*not inherited*/ init(configuration: URLSessionConfiguration, delegate: URLSessionDelegate?, delegateQueue queue: OperationQueue?) { NSUnimplemented() }
     
-    public var delegateQueue: OperationQueue { NSUnimplemented() }
-    public var delegate: URLSessionDelegate? { NSUnimplemented() }
-    /*@NSCopying*/ public var configuration: URLSessionConfiguration { NSUnimplemented() }
+    open var delegateQueue: OperationQueue { NSUnimplemented() }
+    open var delegate: URLSessionDelegate? { NSUnimplemented() }
+    /*@NSCopying*/ open var configuration: URLSessionConfiguration { NSUnimplemented() }
     
     /*
      * The sessionDescription property is available for the developer to
      * provide a descriptive label for the session.
      */
-    public var sessionDescription: String?
+    open var sessionDescription: String?
     
     /* -finishTasksAndInvalidate returns immediately and existing tasks will be allowed
      * to run to completion.  New tasks may not be created.  The session
@@ -118,14 +118,14 @@ public class URLSession: NSObject {
      * session with the same identifier until URLSession:didBecomeInvalidWithError: has
      * been issued.
      */
-    public func finishTasksAndInvalidate() { NSUnimplemented() }
+    open func finishTasksAndInvalidate() { NSUnimplemented() }
     
     /* -invalidateAndCancel acts as -finishTasksAndInvalidate, but issues
      * -cancel to all outstanding tasks for this session.  Note task 
      * cancellation is subject to the state of the task, and some tasks may
      * have already have completed at the time they are sent -cancel. 
      */
-    public func invalidateAndCancel() { NSUnimplemented() }
+    open func invalidateAndCancel() { NSUnimplemented() }
     
     public func resetWithCompletionHandler(_ completionHandler: () -> Void)  { NSUnimplemented() }/* empty all cookies, cache and credential stores, removes disk files, issues -flushWithCompletionHandler:. Invokes completionHandler() on the delegate queue if not nil. */
     public func flushWithCompletionHandler(_ completionHandler: () -> Void)  { NSUnimplemented() }/* flush storage to disk and clear transient network caches.  Invokes completionHandler() on the delegate queue if not nil. */
@@ -140,32 +140,32 @@ public class URLSession: NSObject {
      */
     
     /* Creates a data task with the given request.  The request may have a body stream. */
-    public func dataTaskWithRequest(_ request: URLRequest) -> URLSessionDataTask { NSUnimplemented() }
+    open func dataTaskWithRequest(_ request: URLRequest) -> URLSessionDataTask { NSUnimplemented() }
     
     /* Creates a data task to retrieve the contents of the given URL. */
-    public func dataTaskWithURL(_ url: URL) -> URLSessionDataTask { NSUnimplemented() }
+    open func dataTaskWithURL(_ url: URL) -> URLSessionDataTask { NSUnimplemented() }
     
     /* Creates an upload task with the given request.  The body of the request will be created from the file referenced by fileURL */
-    public func uploadTaskWithRequest(_ request: URLRequest, fromFile fileURL: URL) -> URLSessionUploadTask { NSUnimplemented() }
+    open func uploadTaskWithRequest(_ request: URLRequest, fromFile fileURL: URL) -> URLSessionUploadTask { NSUnimplemented() }
     
     /* Creates an upload task with the given request.  The body of the request is provided from the bodyData. */
-    public func uploadTaskWithRequest(_ request: URLRequest, fromData bodyData: Data) -> URLSessionUploadTask { NSUnimplemented() }
+    open func uploadTaskWithRequest(_ request: URLRequest, fromData bodyData: Data) -> URLSessionUploadTask { NSUnimplemented() }
     
     /* Creates an upload task with the given request.  The previously set body stream of the request (if any) is ignored and the URLSession:task:needNewBodyStream: delegate will be called when the body payload is required. */
-    public func uploadTaskWithStreamedRequest(_ request: URLRequest) -> URLSessionUploadTask { NSUnimplemented() }
+    open func uploadTaskWithStreamedRequest(_ request: URLRequest) -> URLSessionUploadTask { NSUnimplemented() }
     
     /* Creates a download task with the given request. */
-    public func downloadTaskWithRequest(_ request: URLRequest) -> URLSessionDownloadTask { NSUnimplemented() }
+    open func downloadTaskWithRequest(_ request: URLRequest) -> URLSessionDownloadTask { NSUnimplemented() }
     
     /* Creates a download task to download the contents of the given URL. */
-    public func downloadTaskWithURL(_ url: URL) -> URLSessionDownloadTask { NSUnimplemented() }
+    open func downloadTaskWithURL(_ url: URL) -> URLSessionDownloadTask { NSUnimplemented() }
     
     /* Creates a download task with the resume data.  If the download cannot be successfully resumed, URLSession:task:didCompleteWithError: will be called. */
-    public func downloadTaskWithResumeData(_ resumeData: Data) -> URLSessionDownloadTask { NSUnimplemented() }
+    open func downloadTaskWithResumeData(_ resumeData: Data) -> URLSessionDownloadTask { NSUnimplemented() }
     
     /* Creates a bidirectional stream task to a given host and port.
      */
-    public func streamTaskWithHostName(_ hostname: String, port: Int) -> URLSessionStreamTask { NSUnimplemented() }
+    open func streamTaskWithHostName(_ hostname: String, port: Int) -> URLSessionStreamTask { NSUnimplemented() }
 }
 
 /*
@@ -221,24 +221,24 @@ extension URLSessionTask {
  * of processing a given request.
  */
 
-public class URLSessionTask: NSObject, NSCopying {
+open class URLSessionTask: NSObject, NSCopying {
     
     public override init() {
         NSUnimplemented()
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         NSUnimplemented()
     }
     
-    public var taskIdentifier: Int { NSUnimplemented() } /* an identifier for this task, assigned by and unique to the owning session */
-    /*@NSCopying*/ public var originalRequest: URLRequest? { NSUnimplemented() } /* may be nil if this is a stream task */
-    /*@NSCopying*/ public var currentRequest: URLRequest? { NSUnimplemented() } /* may differ from originalRequest due to http server redirection */
-    /*@NSCopying*/ public var response: URLResponse? { NSUnimplemented() } /* may be nil if no response has been received */
+    open var taskIdentifier: Int { NSUnimplemented() } /* an identifier for this task, assigned by and unique to the owning session */
+    /*@NSCopying*/ open var originalRequest: URLRequest? { NSUnimplemented() } /* may be nil if this is a stream task */
+    /*@NSCopying*/ open var currentRequest: URLRequest? { NSUnimplemented() } /* may differ from originalRequest due to http server redirection */
+    /*@NSCopying*/ open var response: URLResponse? { NSUnimplemented() } /* may be nil if no response has been received */
     
     /* Byte count properties may be zero if no body is expected, 
      * or NSURLSessionTransferSizeUnknown if it is not possible 
@@ -246,22 +246,22 @@ public class URLSessionTask: NSObject, NSCopying {
      */
     
     /* number of body bytes already received */
-    public var countOfBytesReceived: Int64 { NSUnimplemented() }
+    open var countOfBytesReceived: Int64 { NSUnimplemented() }
     
     /* number of body bytes already sent */
-    public var countOfBytesSent: Int64 { NSUnimplemented() }
+    open var countOfBytesSent: Int64 { NSUnimplemented() }
     
     /* number of body bytes we expect to send, derived from the Content-Length of the HTTP request */
-    public var countOfBytesExpectedToSend: Int64 { NSUnimplemented() }
+    open var countOfBytesExpectedToSend: Int64 { NSUnimplemented() }
     
     /* number of byte bytes we expect to receive, usually derived from the Content-Length header of an HTTP response. */
-    public var countOfBytesExpectedToReceive: Int64 { NSUnimplemented() }
+    open var countOfBytesExpectedToReceive: Int64 { NSUnimplemented() }
     
     /*
      * The taskDescription property is available for the developer to
      * provide a descriptive label for the task.
      */
-    public var taskDescription: String?
+    open var taskDescription: String?
     
     /* -cancel returns immediately, but marks a task as being canceled.
      * The task will signal -URLSession:task:didCompleteWithError: with an
@@ -269,18 +269,18 @@ public class URLSessionTask: NSObject, NSCopying {
      * cases, the task may signal other work before it acknowledges the 
      * cancelation.  -cancel may be sent to a task that has been suspended.
      */
-    public func cancel() { NSUnimplemented() }
+    open func cancel() { NSUnimplemented() }
     
     /*
      * The current state of the task within the session.
      */
-    public var state: State { NSUnimplemented() }
+    open var state: State { NSUnimplemented() }
     
     /*
      * The error, if any, delivered via -URLSession:task:didCompleteWithError:
      * This property will be nil in the event that no error occured.
      */
-    /*@NSCopying*/ public var error: NSError? { NSUnimplemented() }
+    /*@NSCopying*/ open var error: NSError? { NSUnimplemented() }
     
     /*
      * Suspending a task will prevent the NSURLSession from continuing to
@@ -291,8 +291,8 @@ public class URLSessionTask: NSObject, NSCopying {
      * will be disabled while a task is suspended. -suspend and -resume are
      * nestable. 
      */
-    public func suspend() { NSUnimplemented() }
-    public func resume() { NSUnimplemented() }
+    open func suspend() { NSUnimplemented() }
+    open func resume() { NSUnimplemented() }
     
     /*
      * Sets a scaling factor for the priority of the task. The scaling factor is a
@@ -309,7 +309,7 @@ public class URLSessionTask: NSObject, NSCopying {
      * priority levels are provided: NSURLSessionTaskPriorityLow and
      * NSURLSessionTaskPriorityHigh, but use is not restricted to these.
      */
-    public var priority: Float
+    open var priority: Float
 }
 
 public let NSURLSessionTaskPriorityDefault: Float = 0.0 // NSUnimplemented
@@ -321,7 +321,7 @@ public let NSURLSessionTaskPriorityHigh: Float = 0.0 // NSUnimplemented
  * functionality over an NSURLSessionTask and its presence is merely
  * to provide lexical differentiation from download and upload tasks.
  */
-public class URLSessionDataTask: URLSessionTask {
+open class URLSessionDataTask: URLSessionTask {
 }
 
 /*
@@ -330,14 +330,14 @@ public class URLSessionDataTask: URLSessionTask {
  * that may be sent referencing an NSURLSessionDataTask equally apply
  * to NSURLSessionUploadTasks.
  */
-public class URLSessionUploadTask: URLSessionDataTask {
+open class URLSessionUploadTask: URLSessionDataTask {
 }
 
 /*
  * NSURLSessionDownloadTask is a task that represents a download to
  * local storage.
  */
-public class URLSessionDownloadTask: URLSessionTask {
+open class URLSessionDownloadTask: URLSessionTask {
     
     /* Cancel the download (and calls the superclass -cancel).  If
      * conditions will allow for resuming the download in the future, the
@@ -372,7 +372,7 @@ public class URLSessionDownloadTask: URLSessionTask {
  * disassociated from the underlying session.
  */
 
-public class URLSessionStreamTask: URLSessionTask {
+open class URLSessionStreamTask: URLSessionTask {
     
     /* Read minBytes, or at most maxBytes bytes and invoke the completion
      * handler on the sessions delegate queue with the data or an error.
@@ -394,7 +394,7 @@ public class URLSessionStreamTask: URLSessionTask {
      * message. When that message is received, the task object is
      * considered completed and will not receive any more delegate
      * messages. */
-    public func captureStreams() { NSUnimplemented() }
+    open func captureStreams() { NSUnimplemented() }
     
     /* Enqueue a request to close the write end of the underlying socket.
      * All outstanding IO will complete before the write side of the
@@ -402,26 +402,26 @@ public class URLSessionStreamTask: URLSessionTask {
      * back to the client, so best practice is to continue reading from
      * the server until you receive EOF.
      */
-    public func closeWrite() { NSUnimplemented() }
+    open func closeWrite() { NSUnimplemented() }
     
     /* Enqueue a request to close the read side of the underlying socket.
      * All outstanding IO will complete before the read side is closed.
      * You may continue writing to the server.
      */
-    public func closeRead() { NSUnimplemented() }
+    open func closeRead() { NSUnimplemented() }
     
     /*
      * Begin encrypted handshake.  The hanshake begins after all pending 
      * IO has completed.  TLS authentication callbacks are sent to the 
      * session's -URLSession:task:didReceiveChallenge:completionHandler:
      */
-    public func startSecureConnection() { NSUnimplemented() }
+    open func startSecureConnection() { NSUnimplemented() }
     
     /*
      * Cleanly close a secure connection after all pending secure IO has 
      * completed.
      */
-    public func stopSecureConnection() { NSUnimplemented() }
+    open func stopSecureConnection() { NSUnimplemented() }
 }
 
 /*
@@ -439,50 +439,50 @@ public class URLSessionStreamTask: URLSessionTask {
  * on behalf of a suspended application, within certain constraints.
  */
 
-public class URLSessionConfiguration: NSObject, NSCopying {
+open class URLSessionConfiguration: NSObject, NSCopying {
     
     public override init() {
         NSUnimplemented()
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         NSUnimplemented()
     }
     
-    public class func defaultSessionConfiguration() -> URLSessionConfiguration { NSUnimplemented() }
-    public class func ephemeralSessionConfiguration() -> URLSessionConfiguration { NSUnimplemented() }
-    public class func backgroundSessionConfigurationWithIdentifier(_ identifier: String) -> URLSessionConfiguration { NSUnimplemented() }
+    open class func defaultSessionConfiguration() -> URLSessionConfiguration { NSUnimplemented() }
+    open class func ephemeralSessionConfiguration() -> URLSessionConfiguration { NSUnimplemented() }
+    open class func backgroundSessionConfigurationWithIdentifier(_ identifier: String) -> URLSessionConfiguration { NSUnimplemented() }
     
     /* identifier for the background session configuration */
-    public var identifier: String? { NSUnimplemented() }
+    open var identifier: String? { NSUnimplemented() }
     
     /* default cache policy for requests */
-    public var requestCachePolicy: NSURLRequest.CachePolicy
+    open var requestCachePolicy: NSURLRequest.CachePolicy
     
     /* default timeout for requests.  This will cause a timeout if no data is transmitted for the given timeout value, and is reset whenever data is transmitted. */
-    public var timeoutIntervalForRequest: TimeInterval
+    open var timeoutIntervalForRequest: TimeInterval
     
     /* default timeout for requests.  This will cause a timeout if a resource is not able to be retrieved within a given timeout. */
-    public var timeoutIntervalForResource: TimeInterval
+    open var timeoutIntervalForResource: TimeInterval
     
     /* type of service for requests. */
-    public var networkServiceType: URLRequest.NetworkServiceType
+    open var networkServiceType: URLRequest.NetworkServiceType
     
     /* allow request to route over cellular. */
-    public var allowsCellularAccess: Bool
+    open var allowsCellularAccess: Bool
     
     /* allows background tasks to be scheduled at the discretion of the system for optimal performance. */
-    public var discretionary: Bool
+    open var discretionary: Bool
     
     /* The identifier of the shared data container into which files in background sessions should be downloaded.
      * App extensions wishing to use background sessions *must* set this property to a valid container identifier, or
      * all transfers in that session will fail with NSURLErrorBackgroundSessionRequiresSharedContainer.
      */
-    public var sharedContainerIdentifier: String?
+    open var sharedContainerIdentifier: String?
     
     /* 
      * Allows the app to be resumed or launched in the background when tasks in background sessions complete
@@ -491,46 +491,46 @@ public class URLSessionConfiguration: NSObject, NSCopying {
      */
     
     /* The proxy dictionary, as described by <CFNetwork/CFHTTPStream.h> */
-    public var connectionProxyDictionary: [NSObject : AnyObject]?
+    open var connectionProxyDictionary: [NSObject : AnyObject]?
     
     // TODO: We don't have the SSLProtocol type from Security
     /*
     /* The minimum allowable versions of the TLS protocol, from <Security/SecureTransport.h> */
-    public var TLSMinimumSupportedProtocol: SSLProtocol
+    open var TLSMinimumSupportedProtocol: SSLProtocol
     
     /* The maximum allowable versions of the TLS protocol, from <Security/SecureTransport.h> */
-    public var TLSMaximumSupportedProtocol: SSLProtocol
+    open var TLSMaximumSupportedProtocol: SSLProtocol
     */
     
     /* Allow the use of HTTP pipelining */
-    public var HTTPShouldUsePipelining: Bool
+    open var HTTPShouldUsePipelining: Bool
     
     /* Allow the session to set cookies on requests */
-    public var HTTPShouldSetCookies: Bool
+    open var HTTPShouldSetCookies: Bool
     
     /* Policy for accepting cookies.  This overrides the policy otherwise specified by the cookie storage. */
-    public var httpCookieAcceptPolicy: HTTPCookie.AcceptPolicy
+    open var httpCookieAcceptPolicy: HTTPCookie.AcceptPolicy
     
     /* Specifies additional headers which will be set on outgoing requests.
        Note that these headers are added to the request only if not already present. */
-    public var HTTPAdditionalHeaders: [NSObject : AnyObject]?
+    open var HTTPAdditionalHeaders: [NSObject : AnyObject]?
     
     /* The maximum number of simultanous persistent connections per host */
-    public var HTTPMaximumConnectionsPerHost: Int
+    open var HTTPMaximumConnectionsPerHost: Int
     
     /* The cookie storage object to use, or nil to indicate that no cookies should be handled */
-    public var httpCookieStorage: HTTPCookieStorage?
+    open var httpCookieStorage: HTTPCookieStorage?
     
     /* The credential storage object, or nil to indicate that no credential storage is to be used */
-    public var urlCredentialStorage: URLCredentialStorage?
+    open var urlCredentialStorage: URLCredentialStorage?
     
     /* The URL resource cache, or nil to indicate that no caching is to be performed */
-    public var urlCache: URLCache?
+    open var urlCache: URLCache?
     
     /* Enable extended background idle mode for any tcp sockets created.    Enabling this mode asks the system to keep the socket open
      *  and delay reclaiming it when the process moves to the background (see https://developer.apple.com/library/ios/technotes/tn2277/_index.html) 
      */
-    public var shouldUseExtendedBackgroundIdleMode: Bool
+    open var shouldUseExtendedBackgroundIdleMode: Bool
     
     /* An optional array of Class objects which subclass NSURLProtocol.
        The Class will be sent +canInitWithRequest: when determining if
@@ -541,7 +541,7 @@ public class URLSessionConfiguration: NSObject, NSCopying {
        Custom NSURLProtocol subclasses are not available to background
        sessions.
      */
-    public var protocolClasses: [AnyClass]?
+    open var protocolClasses: [AnyClass]?
 }
 
 /*

--- a/Foundation/NSUUID.swift
+++ b/Foundation/NSUUID.swift
@@ -16,7 +16,7 @@ import CoreFoundation
     import Glibc
 #endif
 
-public class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
+open class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
     internal var buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 16)
     
     public override init() {
@@ -35,21 +35,21 @@ public class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
         memcpy(unsafeBitCast(buffer, to: UnsafeMutableRawPointer.self), UnsafeRawPointer(bytes), 16)
     }
     
-    public func getUUIDBytes(_ uuid: UnsafeMutablePointer<UInt8>) {
+    open func getUUIDBytes(_ uuid: UnsafeMutablePointer<UInt8>) {
         _cf_uuid_copy(uuid, buffer)
     }
     
-    public var uuidString: String {
+    open var uuidString: String {
         let strPtr = UnsafeMutablePointer<Int8>.allocate(capacity: 37)
         _cf_uuid_unparse_upper(buffer, strPtr)
         return String(cString: strPtr)
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         return self
     }
     
@@ -78,11 +78,11 @@ public class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         aCoder.encodeBytes(buffer, length: 16, forKey: "NS.uuidbytes")
     }
     
-    public override func isEqual(_ object: AnyObject?) -> Bool {
+    open override func isEqual(_ object: AnyObject?) -> Bool {
         if object === self {
             return true
         } else if let other = object as? NSUUID {
@@ -92,11 +92,11 @@ public class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    public override var hash: Int {
+    open override var hash: Int {
         return Int(bitPattern: CFHashBytes(buffer, 16))
     }
     
-    public override var description: String {
+    open override var description: String {
         return uuidString
     }
 }

--- a/Foundation/NSUserDefaults.swift
+++ b/Foundation/NSUserDefaults.swift
@@ -16,14 +16,14 @@ public let NSRegistrationDomain: String = "NSRegistrationDomain"
 private var registeredDefaults = [String: AnyObject]()
 private var sharedDefaults = UserDefaults()
 
-public class UserDefaults: NSObject {
+open class UserDefaults: NSObject {
     private let suite: String?
     
-    public class func standardUserDefaults() -> UserDefaults {
+    open class func standardUserDefaults() -> UserDefaults {
         return sharedDefaults
     }
     
-    public class func resetStandardUserDefaults() {
+    open class func resetStandardUserDefaults() {
         //sharedDefaults.synchronize()
         //sharedDefaults = NSUserDefaults()
     }
@@ -37,7 +37,7 @@ public class UserDefaults: NSObject {
         suite = suitename
     }
     
-    public func objectForKey(_ defaultName: String) -> AnyObject? {
+    open func objectForKey(_ defaultName: String) -> AnyObject? {
         func getFromRegistered() -> AnyObject? {
             return registeredDefaults[defaultName]
         }
@@ -70,7 +70,7 @@ public class UserDefaults: NSObject {
             return getFromRegistered()
         }
     }
-    public func setObject(_ value: AnyObject?, forKey defaultName: String) {
+    open func setObject(_ value: AnyObject?, forKey defaultName: String) {
         guard let value = value else {
             CFPreferencesSetAppValue(defaultName._cfObject, nil, suite?._cfObject ?? kCFPreferencesCurrentApplication)
             return
@@ -97,25 +97,25 @@ public class UserDefaults: NSObject {
         
         CFPreferencesSetAppValue(defaultName._cfObject, cfType, suite?._cfObject ?? kCFPreferencesCurrentApplication)
     }
-    public func removeObjectForKey(_ defaultName: String) {
+    open func removeObjectForKey(_ defaultName: String) {
         CFPreferencesSetAppValue(defaultName._cfObject, nil, suite?._cfObject ?? kCFPreferencesCurrentApplication)
     }
     
-    public func stringForKey(_ defaultName: String) -> String? {
+    open func stringForKey(_ defaultName: String) -> String? {
         guard let aVal = objectForKey(defaultName),
               let bVal = aVal as? NSString else {
             return nil
         }
         return bVal._swiftObject
     }
-    public func arrayForKey(_ defaultName: String) -> [AnyObject]? {
+    open func arrayForKey(_ defaultName: String) -> [AnyObject]? {
         guard let aVal = objectForKey(defaultName),
               let bVal = aVal as? NSArray else {
             return nil
         }
         return bVal._swiftObject
     }
-    public func dictionaryForKey(_ defaultName: String) -> [String : AnyObject]? {
+    open func dictionaryForKey(_ defaultName: String) -> [String : AnyObject]? {
         guard let aVal = objectForKey(defaultName),
               let bVal = aVal as? NSDictionary else {
             return nil
@@ -143,49 +143,49 @@ public class UserDefaults: NSObject {
         } catch _ { }
         return nil
     }
-    public func dataForKey(_ defaultName: String) -> Data? {
+    open func dataForKey(_ defaultName: String) -> Data? {
         guard let aVal = objectForKey(defaultName),
               let bVal = aVal as? Data else {
             return nil
         }
         return bVal
     }
-    public func stringArrayForKey(_ defaultName: String) -> [String]? {
+    open func stringArrayForKey(_ defaultName: String) -> [String]? {
         guard let aVal = objectForKey(defaultName),
               let bVal = aVal as? NSArray else {
             return nil
         }
         return _expensivePropertyListConversion(bVal) as? [String]
     }
-    public func integerForKey(_ defaultName: String) -> Int {
+    open func integerForKey(_ defaultName: String) -> Int {
         guard let aVal = objectForKey(defaultName),
               let bVal = aVal as? NSNumber else {
             return 0
         }
         return bVal.intValue
     }
-    public func floatForKey(_ defaultName: String) -> Float {
+    open func floatForKey(_ defaultName: String) -> Float {
         guard let aVal = objectForKey(defaultName),
               let bVal = aVal as? NSNumber else {
             return 0
         }
         return bVal.floatValue
     }
-    public func doubleForKey(_ defaultName: String) -> Double {
+    open func doubleForKey(_ defaultName: String) -> Double {
         guard let aVal = objectForKey(defaultName),
               let bVal = aVal as? NSNumber else {
             return 0
         }
         return bVal.doubleValue
     }
-    public func boolForKey(_ defaultName: String) -> Bool {
+    open func boolForKey(_ defaultName: String) -> Bool {
         guard let aVal = objectForKey(defaultName),
               let bVal = aVal as? NSNumber else {
             return false
         }
         return bVal.boolValue
     }
-    public func URLForKey(_ defaultName: String) -> URL? {
+    open func URLForKey(_ defaultName: String) -> URL? {
         guard let aVal = objectForKey(defaultName) else {
             return nil
         }
@@ -201,19 +201,19 @@ public class UserDefaults: NSObject {
         return nil
     }
     
-    public func setInteger(_ value: Int, forKey defaultName: String) {
+    open func setInteger(_ value: Int, forKey defaultName: String) {
         setObject(NSNumber(value: value), forKey: defaultName)
     }
-    public func setFloat(_ value: Float, forKey defaultName: String) {
+    open func setFloat(_ value: Float, forKey defaultName: String) {
         setObject(NSNumber(value: value), forKey: defaultName)
     }
-    public func setDouble(_ value: Double, forKey defaultName: String) {
+    open func setDouble(_ value: Double, forKey defaultName: String) {
         setObject(NSNumber(value: value), forKey: defaultName)
     }
-    public func setBool(_ value: Bool, forKey defaultName: String) {
+    open func setBool(_ value: Bool, forKey defaultName: String) {
         setObject(NSNumber(value: value), forKey: defaultName)
     }
-    public func setURL(_ url: URL?, forKey defaultName: String) {
+    open func setURL(_ url: URL?, forKey defaultName: String) {
 		if let url = url {
             //FIXME: CFURLIsFileReferenceURL is limited to OS X/iOS
             #if os(OSX) || os(iOS)
@@ -241,20 +241,20 @@ public class UserDefaults: NSObject {
         }
     }
     
-    public func registerDefaults(_ registrationDictionary: [String : AnyObject]) {
+    open func registerDefaults(_ registrationDictionary: [String : AnyObject]) {
         for (key, value) in registrationDictionary {
             registeredDefaults[key] = value
         }
     }
     
-    public func addSuiteNamed(_ suiteName: String) {
+    open func addSuiteNamed(_ suiteName: String) {
         CFPreferencesAddSuitePreferencesToApp(kCFPreferencesCurrentApplication, suiteName._cfObject)
     }
-    public func removeSuiteNamed(_ suiteName: String) {
+    open func removeSuiteNamed(_ suiteName: String) {
         CFPreferencesRemoveSuitePreferencesFromApp(kCFPreferencesCurrentApplication, suiteName._cfObject)
     }
     
-    public func dictionaryRepresentation() -> [String : AnyObject] {
+    open func dictionaryRepresentation() -> [String : AnyObject] {
         NSUnimplemented()
         /*
         Currently crashes the compiler.
@@ -272,21 +272,21 @@ public class UserDefaults: NSObject {
         */
     }
     
-    public var volatileDomainNames: [String] { NSUnimplemented() }
-    public func volatileDomainForName(_ domainName: String) -> [String : AnyObject] { NSUnimplemented() }
-    public func setVolatileDomain(_ domain: [String : AnyObject], forName domainName: String) { NSUnimplemented() }
-    public func removeVolatileDomainForName(_ domainName: String) { NSUnimplemented() }
+    open var volatileDomainNames: [String] { NSUnimplemented() }
+    open func volatileDomainForName(_ domainName: String) -> [String : AnyObject] { NSUnimplemented() }
+    open func setVolatileDomain(_ domain: [String : AnyObject], forName domainName: String) { NSUnimplemented() }
+    open func removeVolatileDomainForName(_ domainName: String) { NSUnimplemented() }
     
-    public func persistentDomainForName(_ domainName: String) -> [String : AnyObject]? { NSUnimplemented() }
-    public func setPersistentDomain(_ domain: [String : AnyObject], forName domainName: String) { NSUnimplemented() }
-    public func removePersistentDomainForName(_ domainName: String) { NSUnimplemented() }
+    open func persistentDomainForName(_ domainName: String) -> [String : AnyObject]? { NSUnimplemented() }
+    open func setPersistentDomain(_ domain: [String : AnyObject], forName domainName: String) { NSUnimplemented() }
+    open func removePersistentDomainForName(_ domainName: String) { NSUnimplemented() }
     
-    public func synchronize() -> Bool {
+    open func synchronize() -> Bool {
         return CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
     }
     
-    public func objectIsForcedForKey(_ key: String) -> Bool { NSUnimplemented() }
-    public func objectIsForcedForKey(_ key: String, inDomain domain: String) -> Bool { NSUnimplemented() }
+    open func objectIsForcedForKey(_ key: String) -> Bool { NSUnimplemented() }
+    open func objectIsForcedForKey(_ key: String, inDomain domain: String) -> Bool { NSUnimplemented() }
 }
 
 public let NSUserDefaultsDidChangeNotification: String = "NSUserDefaultsDidChangeNotification"

--- a/Foundation/NSValue.swift
+++ b/Foundation/NSValue.swift
@@ -7,7 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-public class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
+open class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
 
     private static var SideTable = [ObjectIdentifier : NSValue]()
     private static var SideTableLock = Lock()
@@ -41,7 +41,7 @@ public class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    public override var hash: Int {
+    open override var hash: Int {
         get {
             if type(of: self) == NSValue.self {
                 return _concreteValue.hash
@@ -51,7 +51,7 @@ public class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    public override func isEqual(_ object: AnyObject?) -> Bool {
+    open override func isEqual(_ object: AnyObject?) -> Bool {
         if self === object {
             return true
         } else if let o = object, type(of: self) == NSValue.self && type(of: o) == NSValue.self {
@@ -66,7 +66,7 @@ public class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    public override var description : String {
+    open override var description : String {
         get {
             if type(of: self) == NSValue.self {
                 return _concreteValue.description
@@ -76,7 +76,7 @@ public class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    public func getValue(_ value: UnsafeMutableRawPointer) {
+    open func getValue(_ value: UnsafeMutableRawPointer) {
         if type(of: self) == NSValue.self {
             return _concreteValue.getValue(value)
         } else {
@@ -84,7 +84,7 @@ public class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    public var objCType: UnsafePointer<Int8> {
+    open var objCType: UnsafePointer<Int8> {
         if type(of: self) == NSValue.self {
             return _concreteValue.objCType
         } else {
@@ -132,7 +132,7 @@ public class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
         
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         if type(of: self) == NSValue.self {
             _concreteValue.encode(with: aCoder)
         } else {
@@ -140,15 +140,15 @@ public class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    public class func supportsSecureCoding() -> Bool {
+    open class func supportsSecureCoding() -> Bool {
         return true
     }
     
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
     
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         return self
     }
 }

--- a/Foundation/NSXMLDTD.swift
+++ b/Foundation/NSXMLDTD.swift
@@ -12,7 +12,7 @@ import CoreFoundation
     @class NSXMLDTD
     @abstract Defines the order, repetition, and allowable values for a document
 */
-public class XMLDTD : XMLNode {
+open class XMLDTD : XMLNode {
 
     internal var _xmlDTD: _CFXMLDTDPtr {
         return _CFXMLDTDPtr(_xmlNode)
@@ -43,10 +43,10 @@ public class XMLDTD : XMLNode {
     } //primitive
     
     /*!
-        @method publicID
-        @abstract Sets the public id. This identifier should be in the default catalog in /etc/xml/catalog or in a path specified by the environment variable XML_CATALOG_FILES. When the public id is set the system id must also be set.
+        @method openID
+        @abstract Sets the open id. This identifier should be in the default catalog in /etc/xml/catalog or in a path specified by the environment variable XML_CATALOG_FILES. When the public id is set the system id must also be set.
     */
-    public var publicID: String? {
+    open var publicID: String? {
         get {
             return _CFXMLDTDExternalID(_xmlDTD)?._swiftObject
         }
@@ -64,7 +64,7 @@ public class XMLDTD : XMLNode {
         @method systemID
         @abstract Sets the system id. This should be a URL that points to a valid DTD.
     */
-    public var systemID: String? {
+    open var systemID: String? {
         get {
             return _CFXMLDTDSystemID(_xmlDTD)?._swiftObject
         }
@@ -82,7 +82,7 @@ public class XMLDTD : XMLNode {
         @method insertChild:atIndex:
         @abstract Inserts a child at a particular index.
     */
-    public func insertChild(_ child: XMLNode, at index: Int) {
+    open func insertChild(_ child: XMLNode, at index: Int) {
         _insertChild(child, atIndex: index)
     } //primitive
     
@@ -90,7 +90,7 @@ public class XMLDTD : XMLNode {
         @method insertChildren:atIndex:
         @abstract Insert several children at a particular index.
     */
-    public func insertChildren(_ children: [XMLNode], at index: Int) {
+    open func insertChildren(_ children: [XMLNode], at index: Int) {
         _insertChildren(children, atIndex: index)
     }
     
@@ -98,7 +98,7 @@ public class XMLDTD : XMLNode {
         @method removeChildAtIndex:
         @abstract Removes a child at a particular index.
     */
-    public func removeChild(at index: Int) {
+    open func removeChild(at index: Int) {
         _removeChildAtIndex(index)
     } //primitive
     
@@ -106,7 +106,7 @@ public class XMLDTD : XMLNode {
         @method setChildren:
         @abstract Removes all existing children and replaces them with the new children. Set children to nil to simply remove all children.
     */
-    public func setChildren(_ children: [XMLNode]?) {
+    open func setChildren(_ children: [XMLNode]?) {
         _setChildren(children)
     } //primitive
     
@@ -114,7 +114,7 @@ public class XMLDTD : XMLNode {
         @method addChild:
         @abstract Adds a child to the end of the existing children.
     */
-    public func addChild(_ child: XMLNode) {
+    open func addChild(_ child: XMLNode) {
         _addChild(child)
     }
     
@@ -122,7 +122,7 @@ public class XMLDTD : XMLNode {
         @method replaceChildAtIndex:withNode:
         @abstract Replaces a child at a particular index with another child.
     */
-    public func replaceChild(at index: Int, with node: XMLNode) {
+    open func replaceChild(at index: Int, with node: XMLNode) {
         _replaceChildAtIndex(index, withNode: node)
     }
     
@@ -130,7 +130,7 @@ public class XMLDTD : XMLNode {
         @method entityDeclarationForName:
         @abstract Returns the entity declaration matching this name.
     */
-    public func entityDeclaration(forName name: String) -> XMLDTDNode? {
+    open func entityDeclaration(forName name: String) -> XMLDTDNode? {
         guard let node = _CFXMLDTDGetEntityDesc(_xmlDTD, name) else { return nil }
         return XMLDTDNode._objectNodeForNode(node)
     } //primitive
@@ -139,7 +139,7 @@ public class XMLDTD : XMLNode {
         @method notationDeclarationForName:
         @abstract Returns the notation declaration matching this name.
     */
-    public func notationDeclaration(forName name: String) -> XMLDTDNode? {
+    open func notationDeclaration(forName name: String) -> XMLDTDNode? {
         guard let node = _CFXMLDTDGetNotationDesc(_xmlDTD, name) else { return nil }
         return XMLDTDNode._objectNodeForNode(node)
     } //primitive
@@ -148,7 +148,7 @@ public class XMLDTD : XMLNode {
         @method elementDeclarationForName:
         @abstract Returns the element declaration matching this name.
     */
-    public func elementDeclaration(forName name: String) -> XMLDTDNode? {
+    open func elementDeclaration(forName name: String) -> XMLDTDNode? {
         guard let node = _CFXMLDTDGetElementDesc(_xmlDTD, name) else { return nil }
         return XMLDTDNode._objectNodeForNode(node)
     } //primitive
@@ -157,7 +157,7 @@ public class XMLDTD : XMLNode {
         @method attributeDeclarationForName:
         @abstract Returns the attribute declaration matching this name.
     */
-    public func attributeDeclaration(forName name: String, elementName: String) -> XMLDTDNode? {
+    open func attributeDeclaration(forName name: String, elementName: String) -> XMLDTDNode? {
         guard let node = _CFXMLDTDGetAttributeDesc(_xmlDTD, elementName, name) else { return nil }
         return XMLDTDNode._objectNodeForNode(node)
     } //primitive
@@ -168,7 +168,7 @@ public class XMLDTD : XMLNode {
     	@discussion The five predefined entities are
     	<ul><li>&amp;lt; - &lt;</li><li>&amp;gt; - &gt;</li><li>&amp;amp; - &amp;</li><li>&amp;quot; - &quot;</li><li>&amp;apos; - &amp;</li></ul>
     */
-    public class func predefinedEntityDeclaration(forName name: String) -> XMLDTDNode? {
+    open class func predefinedEntityDeclaration(forName name: String) -> XMLDTDNode? {
         guard let node = _CFXMLDTDGetPredefinedEntity(name) else { return nil }
         return XMLDTDNode._objectNodeForNode(node)
     }

--- a/Foundation/NSXMLDTDNode.swift
+++ b/Foundation/NSXMLDTDNode.swift
@@ -69,7 +69,7 @@ extension XMLDTDNode {
 		<li><b>Element declaration</b> - the validation string</li>
 		<li><b>Notation declaration</b> - no objectValue</li></ul>
 */
-public class XMLDTDNode: XMLNode {
+open class XMLDTDNode: XMLNode {
     
     /*!
         @method initWithXMLString:
@@ -99,7 +99,7 @@ public class XMLDTDNode: XMLNode {
         @method DTDKind
         @abstract Sets the DTD sub kind.
     */
-    public var dtdKind: DTDKind {
+    open var dtdKind: DTDKind {
         switch _CFXMLNodeGetType(_xmlNode) {
         case _kCFXMLDTDNodeTypeElement:
             switch _CFXMLDTDElementNodeGetType(_xmlNode) {
@@ -190,15 +190,15 @@ public class XMLDTDNode: XMLNode {
         @method isExternal
         @abstract True if the system id is set. Valid for entities and notations.
     */
-    public var external: Bool {
+    open var external: Bool {
         return systemID != nil
     } //primitive
     
     /*!
-        @method publicID
-        @abstract Sets the public id. This identifier should be in the default catalog in /etc/xml/catalog or in a path specified by the environment variable XML_CATALOG_FILES. When the public id is set the system id must also be set. Valid for entities and notations.
+        @method openID
+        @abstract Sets the open id. This identifier should be in the default catalog in /etc/xml/catalog or in a path specified by the environment variable XML_CATALOG_FILES. When the public id is set the system id must also be set. Valid for entities and notations.
     */
-    public var publicID: String? {
+    open var publicID: String? {
         get {
             return _CFXMLDTDNodeGetPublicID(_xmlNode)?._swiftObject
         }
@@ -215,7 +215,7 @@ public class XMLDTDNode: XMLNode {
         @method systemID
         @abstract Sets the system id. This should be a URL that points to a valid DTD. Valid for entities and notations.
     */
-    public var systemID: String? {
+    open var systemID: String? {
         get {
             return _CFXMLDTDNodeGetSystemID(_xmlNode)?._swiftObject
         }
@@ -232,7 +232,7 @@ public class XMLDTDNode: XMLNode {
         @method notationName
         @abstract Set the notation name. Valid for entities only.
     */
-    public var notationName: String? {
+    open var notationName: String? {
         get {
             guard dtdKind == .unparsed else {
                 return nil

--- a/Foundation/NSXMLDocument.swift
+++ b/Foundation/NSXMLDocument.swift
@@ -55,7 +55,7 @@ extension XMLDocument {
     @abstract An XML Document
 	@discussion Note: if the application of a method would result in more than one element in the children array, an exception is thrown. Trying to add a document, namespace, attribute, or node with a parent also throws an exception. To add a node with a parent first detach or create a copy of it.
 */
-public class XMLDocument : XMLNode {
+open class XMLDocument : XMLNode {
     private var _xmlDoc: _CFXMLDocPtr {
         return _CFXMLDocPtr(_xmlNode)
     }
@@ -109,13 +109,13 @@ public class XMLDocument : XMLNode {
         }
     }
 
-    public class func replacementClassForClass(_ cls: AnyClass) -> AnyClass { NSUnimplemented() }
+    open class func replacementClassForClass(_ cls: AnyClass) -> AnyClass { NSUnimplemented() }
 
     /*!
         @method characterEncoding
         @abstract Sets the character encoding to an IANA type.
     */
-    public var characterEncoding: String? {
+    open var characterEncoding: String? {
         get {
             return _CFXMLDocCharacterEncoding(_xmlDoc)?._swiftObject
         }
@@ -132,7 +132,7 @@ public class XMLDocument : XMLNode {
         @method version
         @abstract Sets the XML version. Should be 1.0 or 1.1.
     */
-    public var version: String? {
+    open var version: String? {
         get {
             return _CFXMLDocVersion(_xmlDoc)?._swiftObject
         }
@@ -150,7 +150,7 @@ public class XMLDocument : XMLNode {
         @method standalone
         @abstract Set whether this document depends on an external DTD. If this option is set the standalone declaration will appear on output.
     */
-    public var standalone: Bool {
+    open var standalone: Bool {
         get {
             return _CFXMLDocStandalone(_xmlDoc)
         }
@@ -163,7 +163,7 @@ public class XMLDocument : XMLNode {
         @method documentContentKind
         @abstract The kind of document.
     */
-    public var documentContentKind: ContentKind  {
+    open var documentContentKind: ContentKind  {
         get {
             let properties = _CFXMLDocProperties(_xmlDoc)
 
@@ -192,13 +192,13 @@ public class XMLDocument : XMLNode {
         @method MIMEType
         @abstract Set the MIME type, eg text/xml.
     */
-    public var mimeType: String? //primitive
+    open var mimeType: String? //primitive
 
     /*!
         @method DTD
         @abstract Set the associated DTD. This DTD will be output with the document.
     */
-    /*@NSCopying*/ public var dtd: XMLDTD? {
+    /*@NSCopying*/ open var dtd: XMLDTD? {
         get {
             return XMLDTD._objectNodeForNode(_CFXMLDocDTD(_xmlDoc)!)
         }
@@ -229,7 +229,7 @@ public class XMLDocument : XMLNode {
         @method setRootElement:
         @abstract Set the root element. Removes all other children including comments and processing-instructions.
     */
-    public func setRootElement(_ root: XMLElement) {
+    open func setRootElement(_ root: XMLElement) {
         precondition(root.parent == nil)
 
         for child in _childNodes {
@@ -244,7 +244,7 @@ public class XMLDocument : XMLNode {
         @method rootElement
         @abstract The root element.
     */
-    public func rootElement() -> XMLElement? {
+    open func rootElement() -> XMLElement? {
         guard let rootPtr = _CFXMLDocRootElement(_xmlDoc) else {
             return nil
         }
@@ -256,7 +256,7 @@ public class XMLDocument : XMLNode {
         @method insertChild:atIndex:
         @abstract Inserts a child at a particular index.
     */
-    public func insertChild(_ child: XMLNode, at index: Int) {
+    open func insertChild(_ child: XMLNode, at index: Int) {
         _insertChild(child, atIndex: index)
     } //primitive
 
@@ -264,7 +264,7 @@ public class XMLDocument : XMLNode {
         @method insertChildren:atIndex:
         @abstract Insert several children at a particular index.
     */
-    public func insertChildren(_ children: [XMLNode], at index: Int) {
+    open func insertChildren(_ children: [XMLNode], at index: Int) {
         _insertChildren(children, atIndex: index)
     }
 
@@ -272,7 +272,7 @@ public class XMLDocument : XMLNode {
         @method removeChildAtIndex:atIndex:
         @abstract Removes a child at a particular index.
     */
-    public func removeChild(at index: Int) {
+    open func removeChild(at index: Int) {
         _removeChildAtIndex(index)
     } //primitive
 
@@ -280,7 +280,7 @@ public class XMLDocument : XMLNode {
         @method setChildren:
         @abstract Removes all existing children and replaces them with the new children. Set children to nil to simply remove all children.
     */
-    public func setChildren(_ children: [XMLNode]?) {
+    open func setChildren(_ children: [XMLNode]?) {
         _setChildren(children)
     } //primitive
 
@@ -288,7 +288,7 @@ public class XMLDocument : XMLNode {
         @method addChild:
         @abstract Adds a child to the end of the existing children.
     */
-    public func addChild(_ child: XMLNode) {
+    open func addChild(_ child: XMLNode) {
         _addChild(child)
     }
 
@@ -296,7 +296,7 @@ public class XMLDocument : XMLNode {
         @method replaceChildAtIndex:withNode:
         @abstract Replaces a child at a particular index with another child.
     */
-    public func replaceChild(at index: Int, with node: XMLNode) {
+    open func replaceChild(at index: Int, with node: XMLNode) {
         _replaceChildAtIndex(index, withNode: node)
     }
 
@@ -304,13 +304,13 @@ public class XMLDocument : XMLNode {
         @method XMLData
         @abstract Invokes XMLDataWithOptions with NSXMLNodeOptionsNone.
     */
-    /*@NSCopying*/ public var xmlData: Data { return xmlData(withOptions: NSXMLNodeOptionsNone) }
+    /*@NSCopying*/ open var xmlData: Data { return xmlData(withOptions: NSXMLNodeOptionsNone) }
 
     /*!
         @method XMLDataWithOptions:
         @abstract The representation of this node as it would appear in an XML document, encoded based on characterEncoding.
     */
-    public func xmlData(withOptions options: Int) -> Data {
+    open func xmlData(withOptions options: Int) -> Data {
         let string = xmlString(withOptions: options)
         // TODO: support encodings other than UTF-8
 
@@ -321,21 +321,21 @@ public class XMLDocument : XMLNode {
         @method objectByApplyingXSLT:arguments:error:
         @abstract Applies XSLT with arguments (NSString key/value pairs) to this document, returning a new document.
     */
-    public func object(byApplyingXSLT xslt: NSData, arguments: [String : String]?) throws -> AnyObject { NSUnimplemented() }
+    open func object(byApplyingXSLT xslt: NSData, arguments: [String : String]?) throws -> AnyObject { NSUnimplemented() }
 
     /*!
         @method objectByApplyingXSLTString:arguments:error:
         @abstract Applies XSLT as expressed by a string with arguments (NSString key/value pairs) to this document, returning a new document.
     */
-    public func object(byApplyingXSLTString xslt: String, arguments: [String : String]?) throws -> AnyObject { NSUnimplemented() }
+    open func object(byApplyingXSLTString xslt: String, arguments: [String : String]?) throws -> AnyObject { NSUnimplemented() }
 
     /*!
         @method objectByApplyingXSLTAtURL:arguments:error:
         @abstract Applies the XSLT at a URL with arguments (NSString key/value pairs) to this document, returning a new document. Error may contain a connection error from the URL.
     */
-    public func objectByApplyingXSLT(at xsltURL: URL, arguments argument: [String : String]?) throws -> AnyObject { NSUnimplemented() }
+    open func objectByApplyingXSLT(at xsltURL: URL, arguments argument: [String : String]?) throws -> AnyObject { NSUnimplemented() }
 
-    public func validate() throws {
+    open func validate() throws {
         var unmanagedError: Unmanaged<CFError>? = nil
         let result = _CFXMLDocValidate(_xmlDoc, &unmanagedError)
         if !result,

--- a/Foundation/NSXMLElement.swift
+++ b/Foundation/NSXMLElement.swift
@@ -13,7 +13,7 @@ import CoreFoundation
     @abstract An XML element
     @discussion Note: Trying to add a document, namespace, attribute, or node with a parent throws an exception. To add a node with a parent first detach or create a copy of it.
 */
-public class XMLElement: XMLNode {
+open class XMLElement: XMLNode {
 
     /*!
         @method initWithName:
@@ -59,7 +59,7 @@ public class XMLElement: XMLNode {
         @method elementsForName:
         @abstract Returns all of the child elements that match this name.
     */
-    public func elements(forName name: String) -> [XMLElement] {
+    open func elements(forName name: String) -> [XMLElement] {
         return self.filter({ _CFXMLNodeGetType($0._xmlNode) == _kCFXMLTypeElement }).filter({ $0.name == name }).flatMap({ $0 as? XMLElement })
     }
 
@@ -67,13 +67,13 @@ public class XMLElement: XMLNode {
         @method elementsForLocalName:URI
         @abstract Returns all of the child elements that match this localname URI pair.
     */
-    public func elements(forLocalName localName: String, uri: String?) -> [XMLElement] { NSUnimplemented() }
+    open func elements(forLocalName localName: String, uri: String?) -> [XMLElement] { NSUnimplemented() }
 
     /*!
         @method addAttribute:
         @abstract Adds an attribute. Attributes with duplicate names are not added.
     */
-    public func addAttribute(_ attribute: XMLNode) {
+    open func addAttribute(_ attribute: XMLNode) {
         let name = _CFXMLNodeGetName(attribute._xmlNode)!
         let len = strlen(name)
         name.withMemoryRebound(to: UInt8.self, capacity: Int(len)) {
@@ -86,7 +86,7 @@ public class XMLElement: XMLNode {
         @method removeAttributeForName:
         @abstract Removes an attribute based on its name.
     */
-    public func removeAttribute(forName name: String) {
+    open func removeAttribute(forName name: String) {
         if let prop = _CFXMLNodeHasProp(_xmlNode, name) {
             let propNode = XMLNode._objectNodeForNode(_CFXMLNodePtr(prop))
             _childNodes.remove(propNode)
@@ -99,7 +99,7 @@ public class XMLElement: XMLNode {
         @method setAttributes
         @abstract Set the attributes. In the case of duplicate names, the first attribute with the name is used.
     */
-    public var attributes: [XMLNode]? {
+    open var attributes: [XMLNode]? {
         get {
             var result: [XMLNode] = []
             var nextAttribute = _CFXMLNodeProperties(_xmlNode)
@@ -147,7 +147,7 @@ public class XMLElement: XMLNode {
      @method setAttributesWithDictionary:
      @abstract Set the attributes based on a name-value dictionary.
      */
-    public func setAttributesWith(_ attributes: [String : String]) {
+    open func setAttributesWith(_ attributes: [String : String]) {
         removeAttributes()
         for (name, value) in attributes {
             addAttribute(XMLNode.attributeWithName(name, stringValue: value) as! XMLNode)
@@ -158,7 +158,7 @@ public class XMLElement: XMLNode {
         @method attributeForName:
         @abstract Returns an attribute matching this name.
     */
-    public func attribute(forName name: String) -> XMLNode? {
+    open func attribute(forName name: String) -> XMLNode? {
         guard let attribute = _CFXMLNodeHasProp(_xmlNode, name) else { return nil }
         return XMLNode._objectNodeForNode(attribute)
     }
@@ -167,49 +167,49 @@ public class XMLElement: XMLNode {
         @method attributeForLocalName:URI:
         @abstract Returns an attribute matching this localname URI pair.
     */
-    public func attribute(forLocalName localName: String, uri: String?) -> XMLNode? { NSUnimplemented() } //primitive
+    open func attribute(forLocalName localName: String, uri: String?) -> XMLNode? { NSUnimplemented() } //primitive
 
     /*!
         @method addNamespace:URI:
         @abstract Adds a namespace. Namespaces with duplicate names are not added.
     */
-    public func addNamespace(_ aNamespace: XMLNode) { NSUnimplemented() } //primitive
+    open func addNamespace(_ aNamespace: XMLNode) { NSUnimplemented() } //primitive
 
     /*!
         @method addNamespace:URI:
         @abstract Removes a namespace with a particular name.
     */
-    public func removeNamespaceForPrefix(_ name: String) { NSUnimplemented() } //primitive
+    open func removeNamespaceForPrefix(_ name: String) { NSUnimplemented() } //primitive
 
     /*!
         @method namespaces
         @abstract Set the namespaces. In the case of duplicate names, the first namespace with the name is used.
     */
-    public var namespaces: [XMLNode]? { NSUnimplemented() } //primitive
+    open var namespaces: [XMLNode]? { NSUnimplemented() } //primitive
 
     /*!
         @method namespaceForPrefix:
         @abstract Returns the namespace matching this prefix.
     */
-    public func namespace(forPrefix name: String) -> XMLNode? { NSUnimplemented() }
+    open func namespace(forPrefix name: String) -> XMLNode? { NSUnimplemented() }
 
     /*!
         @method resolveNamespaceForName:
         @abstract Returns the namespace who matches the prefix of the name given. Looks in the entire namespace chain.
     */
-    public func resolveNamespace(forName name: String) -> XMLNode? { NSUnimplemented() }
+    open func resolveNamespace(forName name: String) -> XMLNode? { NSUnimplemented() }
 
     /*!
         @method resolvePrefixForNamespaceURI:
         @abstract Returns the URI of this prefix. Looks in the entire namespace chain.
     */
-    public func resolvePrefix(forNamespaceURI namespaceURI: String) -> String? { NSUnimplemented() }
+    open func resolvePrefix(forNamespaceURI namespaceURI: String) -> String? { NSUnimplemented() }
 
     /*!
         @method insertChild:atIndex:
         @abstract Inserts a child at a particular index.
     */
-    public func insertChild(_ child: XMLNode, at index: Int) {
+    open func insertChild(_ child: XMLNode, at index: Int) {
         _insertChild(child, atIndex: index)
     } //primitive
 
@@ -217,7 +217,7 @@ public class XMLElement: XMLNode {
         @method insertChildren:atIndex:
         @abstract Insert several children at a particular index.
     */
-    public func insertChildren(_ children: [XMLNode], at index: Int) {
+    open func insertChildren(_ children: [XMLNode], at index: Int) {
         _insertChildren(children, atIndex: index)
     }
 
@@ -225,7 +225,7 @@ public class XMLElement: XMLNode {
         @method removeChildAtIndex:atIndex:
         @abstract Removes a child at a particular index.
     */
-    public func removeChild(at index: Int) {
+    open func removeChild(at index: Int) {
         _removeChildAtIndex(index)
     } //primitive
 
@@ -233,7 +233,7 @@ public class XMLElement: XMLNode {
         @method setChildren:
         @abstract Removes all existing children and replaces them with the new children. Set children to nil to simply remove all children.
     */
-    public func setChildren(_ children: [XMLNode]?) {
+    open func setChildren(_ children: [XMLNode]?) {
         _setChildren(children)
     } //primitive
 
@@ -241,7 +241,7 @@ public class XMLElement: XMLNode {
         @method addChild:
         @abstract Adds a child to the end of the existing children.
     */
-    public func addChild(_ child: XMLNode) {
+    open func addChild(_ child: XMLNode) {
         _addChild(child)
     }
 
@@ -249,7 +249,7 @@ public class XMLElement: XMLNode {
         @method replaceChildAtIndex:withNode:
         @abstract Replaces a child at a particular index with another child.
     */
-    public func replaceChild(at index: Int, with node: XMLNode) {
+    open func replaceChild(at index: Int, with node: XMLNode) {
         _replaceChildAtIndex(index, withNode: node)
     }
 
@@ -257,7 +257,7 @@ public class XMLElement: XMLNode {
         @method normalizeAdjacentTextNodesPreservingCDATA:
         @abstract Adjacent text nodes are coalesced. If the node's value is the empty string, it is removed. This should be called with a value of NO before using XQuery or XPath.
     */
-    public func normalizeAdjacentTextNodesPreservingCDATA(_ preserve: Bool) { NSUnimplemented() }
+    open func normalizeAdjacentTextNodesPreservingCDATA(_ preserve: Bool) { NSUnimplemented() }
 
     internal override class func _objectNodeForNode(_ node: _CFXMLNodePtr) -> XMLElement {
         precondition(_CFXMLNodeGetType(node) == _kCFXMLTypeElement)

--- a/Foundation/NSXMLNode.swift
+++ b/Foundation/NSXMLNode.swift
@@ -31,7 +31,7 @@ import CoreFoundation
     @class NSXMLNode
     @abstract The basic unit of an XML document.
 */
-public class XMLNode: NSObject, NSCopying {
+open class XMLNode: NSObject, NSCopying {
 
     public enum Kind : UInt {
         case invalid
@@ -49,13 +49,13 @@ public class XMLNode: NSObject, NSCopying {
         case notationDeclaration
     }
 
-    public override func copy() -> AnyObject {
+    open override func copy() -> AnyObject {
         return copy(with: nil)
     }
 
     internal let _xmlNode: _CFXMLNodePtr
 
-    public func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> AnyObject {
         let newNode = _CFXMLCopyNode(_xmlNode, true)
         return XMLNode._objectNodeForNode(newNode)
     }
@@ -104,7 +104,7 @@ public class XMLNode: NSObject, NSCopying {
         @method document:
         @abstract Returns an empty document.
     */
-    public class func document() -> AnyObject {
+    open class func document() -> AnyObject {
         return XMLDocument(rootElement: nil)
     }
 
@@ -113,7 +113,7 @@ public class XMLNode: NSObject, NSCopying {
         @abstract Returns a document
         @param element The document's root node.
     */
-    public class func document(withRootElement element: XMLElement) -> AnyObject {
+    open class func document(withRootElement element: XMLElement) -> AnyObject {
         return XMLDocument(rootElement: element)
     }
 
@@ -121,7 +121,7 @@ public class XMLNode: NSObject, NSCopying {
         @method elementWithName:
         @abstract Returns an element <tt>&lt;name>&lt;/name></tt>.
     */
-    public class func elementWithName(_ name: String) -> AnyObject {
+    open class func elementWithName(_ name: String) -> AnyObject {
         return XMLElement(name: name)
     }
 
@@ -129,7 +129,7 @@ public class XMLNode: NSObject, NSCopying {
         @method elementWithName:URI:
         @abstract Returns an element whose full QName is specified.
     */
-    public class func element(withName name: String, uri: String) -> AnyObject {
+    open class func element(withName name: String, uri: String) -> AnyObject {
         return XMLElement(name: name, uri: uri)
     }
 
@@ -137,7 +137,7 @@ public class XMLNode: NSObject, NSCopying {
         @method elementWithName:stringValue:
         @abstract Returns an element with a single text node child <tt>&lt;name>string&lt;/name></tt>.
     */
-    public class func element(withName name: String, stringValue string: String) -> AnyObject {
+    open class func element(withName name: String, stringValue string: String) -> AnyObject {
         return XMLElement(name: name, stringValue: string)
     }
 
@@ -145,7 +145,7 @@ public class XMLNode: NSObject, NSCopying {
         @method elementWithName:children:attributes:
         @abstract Returns an element children and attributes <tt>&lt;name attr1="foo" attr2="bar">&lt;-- child1 -->child2&lt;/name></tt>.
     */
-    public class func element(withName name: String, children: [XMLNode]?, attributes: [XMLNode]?) -> AnyObject {
+    open class func element(withName name: String, children: [XMLNode]?, attributes: [XMLNode]?) -> AnyObject {
         let element = XMLElement(name: name)
         element.setChildren(children)
         element.attributes = attributes
@@ -157,7 +157,7 @@ public class XMLNode: NSObject, NSCopying {
         @method attributeWithName:stringValue:
         @abstract Returns an attribute <tt>name="stringValue"</tt>.
     */
-    public class func attributeWithName(_ name: String, stringValue: String) -> AnyObject {
+    open class func attributeWithName(_ name: String, stringValue: String) -> AnyObject {
         let attribute = _CFXMLNewProperty(nil, name, stringValue)
 
         return XMLNode(ptr: attribute)
@@ -167,7 +167,7 @@ public class XMLNode: NSObject, NSCopying {
         @method attributeWithLocalName:URI:stringValue:
         @abstract Returns an attribute whose full QName is specified.
     */
-    public class func attribute(withName name: String, uri: String, stringValue: String) -> AnyObject {
+    open class func attribute(withName name: String, uri: String, stringValue: String) -> AnyObject {
         let attribute = XMLNode.attributeWithName(name, stringValue: stringValue) as! XMLNode
 //        attribute.URI = URI
 
@@ -178,7 +178,7 @@ public class XMLNode: NSObject, NSCopying {
         @method namespaceWithName:stringValue:
         @abstract Returns a namespace <tt>xmlns:name="stringValue"</tt>.
     */
-    public class func namespace(withName name: String, stringValue: String) -> AnyObject { NSUnimplemented() }
+    open class func namespace(withName name: String, stringValue: String) -> AnyObject { NSUnimplemented() }
 
     /*!
         @method processingInstructionWithName:stringValue:
@@ -193,7 +193,7 @@ public class XMLNode: NSObject, NSCopying {
         @method commentWithStringValue:
         @abstract Returns a comment <tt>&lt;--stringValue--></tt>.
     */
-    public class func comment(withStringValue stringValue: String) -> AnyObject {
+    open class func comment(withStringValue stringValue: String) -> AnyObject {
         let node = _CFXMLNewComment(stringValue)
         return XMLNode(ptr: node)
     }
@@ -202,7 +202,7 @@ public class XMLNode: NSObject, NSCopying {
         @method textWithStringValue:
         @abstract Returns a text node.
     */
-    public class func text(withStringValue stringValue: String) -> AnyObject {
+    open class func text(withStringValue stringValue: String) -> AnyObject {
         let node = _CFXMLNewTextNode(stringValue)
         return XMLNode(ptr: node)
     }
@@ -211,7 +211,7 @@ public class XMLNode: NSObject, NSCopying {
         @method DTDNodeWithXMLString:
         @abstract Returns an element, attribute, entity, or notation DTD node based on the full XML string.
     */
-    public class func dtdNode(withXMLString string: String) -> AnyObject? {
+    open class func dtdNode(withXMLString string: String) -> AnyObject? {
         guard let node = _CFXMLParseDTDNode(string) else { return nil }
 
         return XMLDTDNode(ptr: node)
@@ -221,7 +221,7 @@ public class XMLNode: NSObject, NSCopying {
         @method kind
         @abstract Returns an element, attribute, entity, or notation DTD node based on the full XML string.
     */
-    public var kind: Kind  {
+    open var kind: Kind  {
         switch _CFXMLNodeGetType(_xmlNode) {
         case _kCFXMLTypeElement:
             return .element
@@ -256,7 +256,7 @@ public class XMLNode: NSObject, NSCopying {
         @method name
         @abstract Sets the nodes name. Applicable for element, attribute, namespace, processing-instruction, document type declaration, element declaration, attribute declaration, entity declaration, and notation declaration.
     */
-    public var name: String? {
+    open var name: String? {
         get {
             if let ptr = _CFXMLNodeGetName(_xmlNode) {
                 return String(cString: ptr)
@@ -279,7 +279,7 @@ public class XMLNode: NSObject, NSCopying {
         @method objectValue
         @abstract Sets the content of the node. Setting the objectValue removes all existing children including processing instructions and comments. Setting the object value on an element creates a single text node child.
     */
-    public var objectValue: AnyObject? {
+    open var objectValue: AnyObject? {
         get {
             if let value = _objectValue {
                 return value
@@ -303,7 +303,7 @@ public class XMLNode: NSObject, NSCopying {
         @method stringValue:
         @abstract Sets the content of the node. Setting the stringValue removes all existing children including processing instructions and comments. Setting the string value on an element creates a single text node child. The getter returns the string value of the node, which may be either its content or child text nodes, depending on the type of node. Elements are recursed and text nodes concatenated in document order with no intervening spaces.
     */
-    public var stringValue: String? {
+    open var stringValue: String? {
         get {
             switch kind {
             case .entityDeclaration:
@@ -347,7 +347,7 @@ public class XMLNode: NSObject, NSCopying {
         @method setStringValue:resolvingEntities:
         @abstract Sets the content as with @link setStringValue: @/link, but when "resolve" is true, character references, predefined entities and user entities available in the document's dtd are resolved. Entities not available in the dtd remain in their entity form.
     */
-    public func setStringValue(_ string: String, resolvingEntities resolve: Bool) {
+    open func setStringValue(_ string: String, resolvingEntities resolve: Bool) {
         guard resolve else {
             stringValue = string
             return
@@ -402,7 +402,7 @@ public class XMLNode: NSObject, NSCopying {
         @method index
         @abstract A node's index amongst its siblings.
     */
-    public var index: Int {
+    open var index: Int {
         if let siblings = self.parent?.children,
             let index = siblings.index(of: self) {
             return index
@@ -415,7 +415,7 @@ public class XMLNode: NSObject, NSCopying {
         @method level
         @abstract The depth of the node within the tree. Documents and standalone nodes are level 0.
     */
-    public var level: Int {
+    open var level: Int {
         var result = 0
         var nextParent = _CFXMLNodeGetParent(_xmlNode)
         while let parent = nextParent {
@@ -430,7 +430,7 @@ public class XMLNode: NSObject, NSCopying {
         @method rootDocument
         @abstract The encompassing document or nil.
     */
-    public var rootDocument: XMLDocument? {
+    open var rootDocument: XMLDocument? {
         guard let doc = _CFXMLNodeGetDocument(_xmlNode) else { return nil }
 
         return XMLNode._objectNodeForNode(_CFXMLNodePtr(doc)) as? XMLDocument
@@ -440,7 +440,7 @@ public class XMLNode: NSObject, NSCopying {
         @method parent
         @abstract The parent of this node. Documents and standalone Nodes have a nil parent; there is not a 1-to-1 relationship between parent and children, eg a namespace cannot be a child but has a parent element.
     */
-    /*@NSCopying*/ public var parent: XMLNode? {
+    /*@NSCopying*/ open var parent: XMLNode? {
         guard let parentPtr = _CFXMLNodeGetParent(_xmlNode) else { return nil }
 
         return XMLNode._objectNodeForNode(parentPtr)
@@ -450,7 +450,7 @@ public class XMLNode: NSObject, NSCopying {
         @method childCount
         @abstract The amount of children, relevant for documents, elements, and document type declarations. Use this instead of [[self children] count].
     */
-    public var childCount: Int {
+    open var childCount: Int {
         return _CFXMLNodeGetElementChildCount(_xmlNode)
     } //primitive
 
@@ -458,7 +458,7 @@ public class XMLNode: NSObject, NSCopying {
         @method children
         @abstract An immutable array of child nodes. Relevant for documents, elements, and document type declarations.
     */
-    public var children: [XMLNode]? {
+    open var children: [XMLNode]? {
         switch kind {
         case .document:
             fallthrough
@@ -476,7 +476,7 @@ public class XMLNode: NSObject, NSCopying {
         @method childAtIndex:
         @abstract Returns the child node at a particular index.
     */
-    public func childAtIndex(_ index: Int) -> XMLNode? {
+    open func childAtIndex(_ index: Int) -> XMLNode? {
         precondition(index >= 0)
         precondition(index < childCount)
 
@@ -487,7 +487,7 @@ public class XMLNode: NSObject, NSCopying {
         @method previousSibling:
         @abstract Returns the previous sibling, or nil if there isn't one.
     */
-    /*@NSCopying*/ public var previousSibling: XMLNode? {
+    /*@NSCopying*/ open var previousSibling: XMLNode? {
         guard let prev = _CFXMLNodeGetPrevSibling(_xmlNode) else { return nil }
 
         return XMLNode._objectNodeForNode(prev)
@@ -497,7 +497,7 @@ public class XMLNode: NSObject, NSCopying {
         @method nextSibling:
         @abstract Returns the next sibling, or nil if there isn't one.
     */
-    /*@NSCopying*/ public var nextSibling: XMLNode? {
+    /*@NSCopying*/ open var nextSibling: XMLNode? {
         guard let next = _CFXMLNodeGetNextSibling(_xmlNode) else { return nil }
 
         return XMLNode._objectNodeForNode(next)
@@ -507,7 +507,7 @@ public class XMLNode: NSObject, NSCopying {
         @method previousNode:
         @abstract Returns the previous node in document order. This can be used to walk the tree backwards.
     */
-    /*@NSCopying*/ public var previousNode: XMLNode? {
+    /*@NSCopying*/ open var previousNode: XMLNode? {
         if let previousSibling = self.previousSibling {
             if let lastChild = _CFXMLNodeGetLastChild(previousSibling._xmlNode) {
                 return XMLNode._objectNodeForNode(lastChild)
@@ -525,7 +525,7 @@ public class XMLNode: NSObject, NSCopying {
         @method nextNode:
         @abstract Returns the next node in document order. This can be used to walk the tree forwards.
     */
-    /*@NSCopying*/ public var nextNode: XMLNode? {
+    /*@NSCopying*/ open var nextNode: XMLNode? {
         if let children = _CFXMLNodeGetFirstChild(_xmlNode) {
             return XMLNode._objectNodeForNode(children)
         } else if let next = nextSibling {
@@ -541,7 +541,7 @@ public class XMLNode: NSObject, NSCopying {
         @method detach:
         @abstract Detaches this node from its parent.
     */
-    public func detach() {
+    open func detach() {
         guard let parentPtr = _CFXMLNodeGetParent(_xmlNode) else { return }
         _CFXMLUnlinkNode(_xmlNode)
 
@@ -555,7 +555,7 @@ public class XMLNode: NSObject, NSCopying {
         @method XPath
         @abstract Returns the XPath to this node, for example foo/bar[2]/baz.
     */
-    public var XPath: String? {
+    open var XPath: String? {
         guard _CFXMLNodeGetDocument(_xmlNode) != nil else { return nil }
 
         var pathComponents: [String?] = []
@@ -611,7 +611,7 @@ public class XMLNode: NSObject, NSCopying {
     	@method localName
     	@abstract Returns the local name bar if this attribute or element's name is foo:bar
     */
-    public var localName: String? {
+    open var localName: String? {
         return _CFXMLNodeLocalName(_xmlNode)?._swiftObject
     } //primitive
 
@@ -619,7 +619,7 @@ public class XMLNode: NSObject, NSCopying {
     	@method prefix
     	@abstract Returns the prefix foo if this attribute or element's name if foo:bar
     */
-    public var prefix: String? {
+    open var prefix: String? {
         return _CFXMLNodePrefix(_xmlNode)?._swiftObject
     } //primitive
 
@@ -627,7 +627,7 @@ public class XMLNode: NSObject, NSCopying {
     	@method URI
     	@abstract Set the URI of this element, attribute, or document. For documents it is the URI of document origin. Getter returns the URI of this element, attribute, or document. For documents it is the URI of document origin and is automatically set when using initWithContentsOfURL.
     */
-    public var URI: String? { //primitive
+    open var URI: String? { //primitive
         get {
             return _CFXMLNodeURI(_xmlNode)?._swiftObject
         }
@@ -644,7 +644,7 @@ public class XMLNode: NSObject, NSCopying {
         @method localNameForName:
         @abstract Returns the local name bar in foo:bar.
      */
-    public class func localName(forName name: String) -> String {
+    open class func localName(forName name: String) -> String {
 //        return name.withCString {
 //            var length: Int32 = 0
 //            let result = xmlSplitQName3(UnsafePointer<xmlChar>($0), &length)
@@ -657,7 +657,7 @@ public class XMLNode: NSObject, NSCopying {
         @method localNameForName:
         @abstract Returns the prefix foo in the name foo:bar.
     */
-    public class func prefix(forName name: String) -> String? {
+    open class func prefix(forName name: String) -> String? {
 //        return name.withCString {
 //            var result: UnsafeMutablePointer<xmlChar> = nil
 //            let unused = xmlSplitQName2(UnsafePointer<xmlChar>($0), &result)
@@ -674,13 +674,13 @@ public class XMLNode: NSObject, NSCopying {
         @method predefinedNamespaceForPrefix:
         @abstract Returns the namespace belonging to one of the predefined namespaces xml, xs, or xsi
     */
-    public class func predefinedNamespace(forPrefix name: String) -> XMLNode? { NSUnimplemented() }
+    open class func predefinedNamespace(forPrefix name: String) -> XMLNode? { NSUnimplemented() }
 
     /*!
         @method description
         @abstract Used for debugging. May give more information than XMLString.
     */
-    public override var description: String {
+    open override var description: String {
         return xmlString
     }
 
@@ -688,7 +688,7 @@ public class XMLNode: NSObject, NSCopying {
         @method XMLString
         @abstract The representation of this node as it would appear in an XML document.
     */
-    public var xmlString: String {
+    open var xmlString: String {
         return xmlString(withOptions: NSXMLNodeOptionsNone)
     }
 
@@ -696,7 +696,7 @@ public class XMLNode: NSObject, NSCopying {
         @method XMLStringWithOptions:
         @abstract The representation of this node as it would appear in an XML document, with various output options available.
     */
-    public func xmlString(withOptions options: Int) -> String {
+    open func xmlString(withOptions options: Int) -> String {
         return _CFXMLStringWithOptions(_xmlNode, UInt32(options))._swiftObject
     }
 
@@ -704,14 +704,14 @@ public class XMLNode: NSObject, NSCopying {
         @method canonicalXMLStringPreservingComments:
         @abstract W3 canonical form (http://www.w3.org/TR/xml-c14n). The input option NSXMLNodePreserveWhitespace should be set for true canonical form.
     */
-    public func canonicalXMLStringPreservingComments(_ comments: Bool) -> String { NSUnimplemented() }
+    open func canonicalXMLStringPreservingComments(_ comments: Bool) -> String { NSUnimplemented() }
 
     /*!
         @method nodesForXPath:error:
         @abstract Returns the nodes resulting from applying an XPath to this node using the node as the context item ("."). normalizeAdjacentTextNodesPreservingCDATA:NO should be called if there are adjacent text nodes since they are not allowed under the XPath/XQuery Data Model.
     	@returns An array whose elements are a kind of NSXMLNode.
     */
-    public func nodes(forXPath xpath: String) throws -> [XMLNode] {
+    open func nodes(forXPath xpath: String) throws -> [XMLNode] {
         guard let nodes = _CFXMLNodesForXPath(_xmlNode, xpath) else {
             NSUnimplemented()
         }
@@ -730,9 +730,9 @@ public class XMLNode: NSObject, NSCopying {
         @abstract Returns the objects resulting from applying an XQuery to this node using the node as the context item ("."). Constants are a name-value dictionary for constants declared "external" in the query. normalizeAdjacentTextNodesPreservingCDATA:NO should be called if there are adjacent text nodes since they are not allowed under the XPath/XQuery Data Model.
     	@returns An array whose elements are kinds of NSArray, NSData, NSDate, NSNumber, NSString, NSURL, or NSXMLNode.
     */
-    public func objects(forXQuery xquery: String, constants: [String : AnyObject]?) throws -> [AnyObject] { NSUnimplemented() }
+    open func objects(forXQuery xquery: String, constants: [String : AnyObject]?) throws -> [AnyObject] { NSUnimplemented() }
 
-    public func objects(forXQuery xquery: String) throws -> [AnyObject] { NSUnimplemented() }
+    open func objects(forXQuery xquery: String) throws -> [AnyObject] { NSUnimplemented() }
 
     internal var _childNodes: Set<XMLNode> = []
 

--- a/Foundation/NSXMLParser.swift
+++ b/Foundation/NSXMLParser.swift
@@ -406,7 +406,7 @@ internal func _structuredErrorFunc(_ interface: _CFXMLInterface, error: _CFXMLIn
     }
 }
 
-public class XMLParser : NSObject {
+open class XMLParser : NSObject {
     private var _handler: _CFXMLInterfaceSAXHandler
     internal var _stream: InputStream?
     internal var _data: Data?
@@ -459,15 +459,15 @@ public class XMLParser : NSObject {
         _parserContext = nil
     }
     
-    public weak var delegate: XMLParserDelegate?
+    open weak var delegate: XMLParserDelegate?
     
-    public var shouldProcessNamespaces: Bool = false
-    public var shouldReportNamespacePrefixes: Bool = false
+    open var shouldProcessNamespaces: Bool = false
+    open var shouldReportNamespacePrefixes: Bool = false
     
     //defaults to NSXMLNodeLoadExternalEntitiesNever
-    public var externalEntityResolvingPolicy: ExternalEntityResolvingPolicy = .resolveExternalEntitiesNever
+    open var externalEntityResolvingPolicy: ExternalEntityResolvingPolicy = .resolveExternalEntitiesNever
     
-    public var allowedExternalEntityURLs: Set<URL>?
+    open var allowedExternalEntityURLs: Set<URL>?
     
     internal static func currentParser() -> XMLParser? {
         if let current = Thread.current.threadDictionary["__CurrentNSXMLParser"] {
@@ -611,12 +611,12 @@ public class XMLParser : NSObject {
     }
     
     // called to start the event-driven parse. Returns YES in the event of a successful parse, and NO in case of error.
-    public func parse() -> Bool {
+    open func parse() -> Bool {
         return parseFromStream()
     }
     
     // called by the delegate to stop the parse. The delegate will get an error message sent to it.
-    public func abortParsing() {
+    open func abortParsing() {
         if let context = _parserContext {
             _CFXMLInterfaceStopParser(context)
             _delegateAborted = true
@@ -624,17 +624,17 @@ public class XMLParser : NSObject {
     }
     
     internal var _parserError: NSError?
-    /*@NSCopying*/ public var parserError: NSError? { return _parserError } // can be called after a parse is over to determine parser state.
+    /*@NSCopying*/ open var parserError: NSError? { return _parserError } // can be called after a parse is over to determine parser state.
     
     //Toggles between disabling external entities entirely, and the current setting of the 'externalEntityResolvingPolicy'.
     //The 'externalEntityResolvingPolicy' property should be used instead of this, unless targeting 10.9/7.0 or earlier
-    public var shouldResolveExternalEntities: Bool = false
+    open var shouldResolveExternalEntities: Bool = false
     
     // Once a parse has begun, the delegate may be interested in certain parser state. These methods will only return meaningful information during parsing, or after an error has occurred.
-    public var publicID: String? { return nil }
-    public var systemID: String? { return nil }
-    public var lineNumber: Int { return Int(_CFXMLInterfaceSAX2GetLineNumber(_parserContext)) }
-    public var columnNumber: Int { return Int(_CFXMLInterfaceSAX2GetColumnNumber(_parserContext)) }
+    open var publicID: String? { return nil }
+    open var systemID: String? { return nil }
+    open var lineNumber: Int { return Int(_CFXMLInterfaceSAX2GetLineNumber(_parserContext)) }
+    open var columnNumber: Int { return Int(_CFXMLInterfaceSAX2GetColumnNumber(_parserContext)) }
     
     internal func _pushNamespaces(_ ns: [String:String]) {
         _namespaces.append(ns)

--- a/Foundation/Unit.swift
+++ b/Foundation/Unit.swift
@@ -2,7 +2,7 @@
  NSUnitConverter describes how to convert a unit to and from the base unit of its dimension.  Use the NSUnitConverter protocol to implement new ways of converting a unit.
  */
 
-public class UnitConverter : NSObject {
+open class UnitConverter : NSObject {
     
     
     /*
@@ -20,7 +20,7 @@ public class UnitConverter : NSObject {
      @param value Value in terms of the unit class
      @return Value in terms of the base unit
      */
-    public func baseUnitValue(fromValue value: Double) -> Double {
+    open func baseUnitValue(fromValue value: Double) -> Double {
         return value
     }
     
@@ -30,17 +30,17 @@ public class UnitConverter : NSObject {
      @param baseUnitValue Value in terms of the base unit
      @return Value in terms of the unit class
      */
-    public func value(fromBaseUnitValue baseUnitValue: Double) -> Double {
+    open func value(fromBaseUnitValue baseUnitValue: Double) -> Double {
         return baseUnitValue
     }
 }
 
-public class UnitConverterLinear : UnitConverter, NSSecureCoding {
+open class UnitConverterLinear : UnitConverter, NSSecureCoding {
     
     
-    public private(set) var coefficient: Double
+    open private(set) var coefficient: Double
     
-    public private(set) var constant: Double
+    open private(set) var constant: Double
     
     
     public convenience init(coefficient: Double) {
@@ -53,11 +53,11 @@ public class UnitConverterLinear : UnitConverter, NSSecureCoding {
         self.constant = constant
     }
     
-    public override func baseUnitValue(fromValue value: Double) -> Double {
+    open override func baseUnitValue(fromValue value: Double) -> Double {
         return value * coefficient + constant
     }
     
-    public override func value(fromBaseUnitValue baseUnitValue: Double) -> Double {
+    open override func value(fromBaseUnitValue baseUnitValue: Double) -> Double {
         return (baseUnitValue - constant) / coefficient
     }
     
@@ -75,7 +75,7 @@ public class UnitConverterLinear : UnitConverter, NSSecureCoding {
         }
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         if aCoder.allowsKeyedCoding {
             aCoder.encode(self.coefficient, forKey:"NS.coefficient")
             aCoder.encode(self.constant, forKey:"NS.constant")
@@ -133,17 +133,17 @@ private class UnitConverterReciprocal : UnitConverter, NSSecureCoding {
  NSUnit is the base class for all unit types (dimensional and dimensionless).
  */
 
-public class Unit : NSObject, NSCopying, NSSecureCoding {
+open class Unit : NSObject, NSCopying, NSSecureCoding {
     
     
-    public private(set) var symbol: String
+    open private(set) var symbol: String
     
     
     public init(symbol: String) {
         self.symbol = symbol
     }
     
-    public func copy(with zone: NSZone?) -> AnyObject {
+    open func copy(with zone: NSZone?) -> AnyObject {
         return self
     }
     
@@ -159,7 +159,7 @@ public class Unit : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public func encode(with aCoder: NSCoder) {
+    open func encode(with aCoder: NSCoder) {
         if aCoder.allowsKeyedCoding {
             aCoder.encode(self.symbol.bridge(), forKey:"NS.symbol")
         } else {
@@ -170,10 +170,10 @@ public class Unit : NSObject, NSCopying, NSSecureCoding {
     public static func supportsSecureCoding() -> Bool { return true }
 }
 
-public class Dimension : Unit {
+open class Dimension : Unit {
     
     
-    public private(set) var converter: UnitConverter
+    open private(set) var converter: UnitConverter
     
     
     public init(symbol: String, converter: UnitConverter) {
@@ -186,7 +186,7 @@ public class Dimension : Unit {
      e.g.
      NSUnitSpeed *metersPerSecond = [NSUnitSpeed baseUnit];
      */
-    public class func baseUnit() -> Self {
+    open class func baseUnit() -> Self {
         fatalError("*** You must override baseUnit in your class to define its base unit.")
     }
     
@@ -208,7 +208,7 @@ public class Dimension : Unit {
         }
     }
     
-    public override func encode(with aCoder: NSCoder) {
+    open override func encode(with aCoder: NSCoder) {
         super.encode(with: aCoder)
         
         if aCoder.allowsKeyedCoding {
@@ -219,7 +219,7 @@ public class Dimension : Unit {
     }
 }
 
-public class UnitAcceleration : Dimension {
+open class UnitAcceleration : Dimension {
     
     /*
      Base unit - metersPerSecondSquared
@@ -239,28 +239,28 @@ public class UnitAcceleration : Dimension {
         super.init(symbol: symbol, converter: UnitConverterLinear(coefficient: coefficient))
     }
     
-    public class var metersPerSecondSquared: UnitAcceleration {
+    open class var metersPerSecondSquared: UnitAcceleration {
         get {
             return UnitAcceleration(symbol: Symbol.metersPerSecondSquared, coefficient: Coefficient.metersPerSecondSquared)
         }
     }
     
-    public class var gravity: UnitAcceleration {
+    open class var gravity: UnitAcceleration {
         get {
             return UnitAcceleration(symbol: Symbol.gravity, coefficient: Coefficient.gravity)
         }
     }
     
-    public override class func baseUnit() -> UnitAcceleration {
+    open override class func baseUnit() -> UnitAcceleration {
         return UnitAcceleration.metersPerSecondSquared
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitAngle : Dimension {
+open class UnitAngle : Dimension {
     
     /*
      Base unit - degrees
@@ -289,52 +289,52 @@ public class UnitAngle : Dimension {
     }
     
     
-    public class var degrees: UnitAngle {
+    open class var degrees: UnitAngle {
         get {
             return UnitAngle(symbol: Symbol.degrees, coefficient: Coefficient.degrees)
         }
     }
     
-    public class var arcMinutes: UnitAngle {
+    open class var arcMinutes: UnitAngle {
         get {
             return UnitAngle(symbol: Symbol.arcMinutes, coefficient: Coefficient.arcMinutes)
         }
     }
     
-    public class var arcSeconds: UnitAngle {
+    open class var arcSeconds: UnitAngle {
         get {
             return UnitAngle(symbol: Symbol.arcSeconds, coefficient: Coefficient.arcSeconds)
         }
     }
     
-    public class var radians: UnitAngle {
+    open class var radians: UnitAngle {
         get {
             return UnitAngle(symbol: Symbol.radians, coefficient: Coefficient.radians)
         }
     }
     
-    public class var gradians: UnitAngle {
+    open class var gradians: UnitAngle {
         get {
             return UnitAngle(symbol: Symbol.gradians, coefficient: Coefficient.gradians)
         }
     }
     
-    public class var revolutions: UnitAngle {
+    open class var revolutions: UnitAngle {
         get {
             return UnitAngle(symbol: Symbol.revolutions, coefficient: Coefficient.revolutions)
         }
     }
     
-    public override class func baseUnit() -> UnitAngle {
+    open override class func baseUnit() -> UnitAngle {
         return UnitAngle.degrees
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitArea : Dimension {
+open class UnitArea : Dimension {
     
     /*
      Base unit - squareMeters
@@ -379,100 +379,100 @@ public class UnitArea : Dimension {
     }
     
     
-    public class var squareMegameters: UnitArea {
+    open class var squareMegameters: UnitArea {
         get {
             return UnitArea(symbol: Symbol.squareMegameters, coefficient: Coefficient.squareMegameters)
         }
     }
     
-    public class var squareKilometers: UnitArea {
+    open class var squareKilometers: UnitArea {
         get {
             return UnitArea(symbol: Symbol.squareKilometers, coefficient: Coefficient.squareKilometers)
         }
     }
     
-    public class var squareMeters: UnitArea {
+    open class var squareMeters: UnitArea {
         get {
             return UnitArea(symbol: Symbol.squareMeters, coefficient: Coefficient.squareMeters)
         }
     }
     
-    public class var squareCentimeters: UnitArea {
+    open class var squareCentimeters: UnitArea {
         get {
             return UnitArea(symbol: Symbol.squareCentimeters, coefficient: Coefficient.squareCentimeters)
         }
     }
     
-    public class var squareMillimeters: UnitArea {
+    open class var squareMillimeters: UnitArea {
         get {
             return UnitArea(symbol: Symbol.squareMillimeters, coefficient: Coefficient.squareMillimeters)
         }
     }
     
-    public class var squareMicrometers: UnitArea {
+    open class var squareMicrometers: UnitArea {
         get {
             return UnitArea(symbol: Symbol.squareMicrometers, coefficient: Coefficient.squareMicrometers)
         }
     }
     
-    public class var squareNanometers: UnitArea {
+    open class var squareNanometers: UnitArea {
         get {
             return UnitArea(symbol: Symbol.squareNanometers, coefficient: Coefficient.squareNanometers)
         }
     }
     
-    public class var squareInches: UnitArea {
+    open class var squareInches: UnitArea {
         get {
             return UnitArea(symbol: Symbol.squareInches, coefficient: Coefficient.squareInches)
         }
     }
     
-    public class var squareFeet: UnitArea {
+    open class var squareFeet: UnitArea {
         get {
             return UnitArea(symbol: Symbol.squareFeet, coefficient: Coefficient.squareFeet)
         }
     }
     
-    public class var squareYards: UnitArea {
+    open class var squareYards: UnitArea {
         get {
             return UnitArea(symbol: Symbol.squareYards, coefficient: Coefficient.squareYards)
         }
     }
     
-    public class var squareMiles: UnitArea {
+    open class var squareMiles: UnitArea {
         get {
             return UnitArea(symbol: Symbol.squareMiles, coefficient: Coefficient.squareMiles)
         }
     }
     
-    public class var acres: UnitArea {
+    open class var acres: UnitArea {
         get {
             return UnitArea(symbol: Symbol.acres, coefficient: Coefficient.acres)
         }
     }
     
-    public class var ares: UnitArea {
+    open class var ares: UnitArea {
         get {
             return UnitArea(symbol: Symbol.ares, coefficient: Coefficient.ares)
         }
     }
     
-    public class var hectares: UnitArea {
+    open class var hectares: UnitArea {
         get {
             return UnitArea(symbol: Symbol.hectares, coefficient: Coefficient.hectares)
         }
     }
     
-    public override class func baseUnit() -> UnitArea {
+    open override class func baseUnit() -> UnitArea {
         return UnitArea.squareMeters
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitConcentrationMass : Dimension {
+open class UnitConcentrationMass : Dimension {
     
     /*
      Base unit - gramsPerLiter
@@ -495,32 +495,32 @@ public class UnitConcentrationMass : Dimension {
     }
     
     
-    public class var gramsPerLiter: UnitConcentrationMass {
+    open class var gramsPerLiter: UnitConcentrationMass {
         get {
             return UnitConcentrationMass(symbol: Symbol.gramsPerLiter, coefficient: Coefficient.gramsPerLiter)
         }
     }
     
-    public class var milligramsPerDeciliter: UnitConcentrationMass {
+    open class var milligramsPerDeciliter: UnitConcentrationMass {
         get {
             return UnitConcentrationMass(symbol: Symbol.milligramsPerDeciliter, coefficient: Coefficient.milligramsPerDeciliter)
         }
     }
     
-    public class func millimolesPerLiter(withGramsPerMole gramsPerMole: Double) -> UnitConcentrationMass {
+    open class func millimolesPerLiter(withGramsPerMole gramsPerMole: Double) -> UnitConcentrationMass {
         return UnitConcentrationMass(symbol: Symbol.millimolesPerLiter, coefficient: Coefficient.millimolesPerLiter * gramsPerMole)
     }
     
-    public override class func baseUnit() -> UnitConcentrationMass {
+    open override class func baseUnit() -> UnitConcentrationMass {
         return UnitConcentrationMass.gramsPerLiter
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitDispersion : Dimension {
+open class UnitDispersion : Dimension {
     
     /*
      Base unit - partsPerMillion
@@ -539,22 +539,22 @@ public class UnitDispersion : Dimension {
     }
     
     
-    public class var partsPerMillion: UnitDispersion {
+    open class var partsPerMillion: UnitDispersion {
         get {
             return UnitDispersion(symbol: Symbol.partsPerMillion, coefficient: Coefficient.partsPerMillion)
         }
     }
     
-    public override class func baseUnit() -> UnitDispersion {
+    open override class func baseUnit() -> UnitDispersion {
         return UnitDispersion.partsPerMillion
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitDuration : Dimension {
+open class UnitDuration : Dimension {
     
     /*
      Base unit - seconds
@@ -576,34 +576,34 @@ public class UnitDuration : Dimension {
         super.init(symbol: symbol, converter: UnitConverterLinear(coefficient: coefficient))
     }
     
-    public class var seconds: UnitDuration {
+    open class var seconds: UnitDuration {
         get {
             return UnitDuration(symbol: Symbol.seconds, coefficient: Coefficient.seconds)
         }
     }
     
-    public class var minutes: UnitDuration {
+    open class var minutes: UnitDuration {
         get {
             return UnitDuration(symbol: Symbol.minutes, coefficient: Coefficient.minutes)
         }
     }
     
-    public class var hours: UnitDuration {
+    open class var hours: UnitDuration {
         get {
             return UnitDuration(symbol: Symbol.hours, coefficient: Coefficient.hours)
         }
     }
     
-    public override class func baseUnit() -> UnitDuration {
+    open override class func baseUnit() -> UnitDuration {
         return UnitDuration.seconds
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitElectricCharge : Dimension {
+open class UnitElectricCharge : Dimension {
     /*
      Base unit - coulombs
      */
@@ -631,52 +631,52 @@ public class UnitElectricCharge : Dimension {
     }
     
     
-    public class var coulombs: UnitElectricCharge {
+    open class var coulombs: UnitElectricCharge {
         get {
             return UnitElectricCharge(symbol: Symbol.coulombs, coefficient: Coefficient.coulombs)
         }
     }
     
-    public class var megaampereHours: UnitElectricCharge {
+    open class var megaampereHours: UnitElectricCharge {
         get {
             return UnitElectricCharge(symbol: Symbol.megaampereHours, coefficient: Coefficient.megaampereHours)
         }
     }
     
-    public class var kiloampereHours: UnitElectricCharge {
+    open class var kiloampereHours: UnitElectricCharge {
         get {
             return UnitElectricCharge(symbol: Symbol.kiloampereHours, coefficient: Coefficient.kiloampereHours)
         }
     }
     
-    public class var ampereHours: UnitElectricCharge {
+    open class var ampereHours: UnitElectricCharge {
         get {
             return UnitElectricCharge(symbol: Symbol.ampereHours, coefficient: Coefficient.ampereHours)
         }
     }
     
-    public class var milliampereHours: UnitElectricCharge {
+    open class var milliampereHours: UnitElectricCharge {
         get {
             return UnitElectricCharge(symbol: Symbol.milliampereHours, coefficient: Coefficient.milliampereHours)
         }
     }
     
-    public class var microampereHours: UnitElectricCharge {
+    open class var microampereHours: UnitElectricCharge {
         get {
             return UnitElectricCharge(symbol: Symbol.microampereHours, coefficient: Coefficient.microampereHours)
         }
     }
     
-    public override class func baseUnit() -> UnitElectricCharge {
+    open override class func baseUnit() -> UnitElectricCharge {
         return UnitElectricCharge.coulombs
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitElectricCurrent : Dimension {
+open class UnitElectricCurrent : Dimension {
     
     /*
      Base unit - amperes
@@ -703,46 +703,46 @@ public class UnitElectricCurrent : Dimension {
     }
     
     
-    public class var megaamperes: UnitElectricCurrent {
+    open class var megaamperes: UnitElectricCurrent {
         get {
             return UnitElectricCurrent(symbol: Symbol.megaamperes, coefficient: Coefficient.megaamperes)
         }
     }
     
-    public class var kiloamperes: UnitElectricCurrent {
+    open class var kiloamperes: UnitElectricCurrent {
         get {
             return UnitElectricCurrent(symbol: Symbol.kiloamperes, coefficient: Coefficient.kiloamperes)
         }
     }
     
-    public class var amperes: UnitElectricCurrent {
+    open class var amperes: UnitElectricCurrent {
         get {
             return UnitElectricCurrent(symbol: Symbol.amperes, coefficient: Coefficient.amperes)
         }
     }
     
-    public class var milliamperes: UnitElectricCurrent {
+    open class var milliamperes: UnitElectricCurrent {
         get {
             return UnitElectricCurrent(symbol: Symbol.milliamperes, coefficient: Coefficient.milliamperes)
         }
     }
     
-    public class var microamperes: UnitElectricCurrent {
+    open class var microamperes: UnitElectricCurrent {
         get {
             return UnitElectricCurrent(symbol: Symbol.microamperes, coefficient: Coefficient.microamperes)
         }
     }
     
-    public override class func baseUnit() -> UnitElectricCurrent {
+    open override class func baseUnit() -> UnitElectricCurrent {
         return UnitElectricCurrent.amperes
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitElectricPotentialDifference : Dimension {
+open class UnitElectricPotentialDifference : Dimension {
     
     /*
      Base unit - volts
@@ -770,46 +770,46 @@ public class UnitElectricPotentialDifference : Dimension {
     }
     
     
-    public class var megavolts: UnitElectricPotentialDifference {
+    open class var megavolts: UnitElectricPotentialDifference {
         get {
             return UnitElectricPotentialDifference(symbol: Symbol.megavolts, coefficient: Coefficient.megavolts)
         }
     }
     
-    public class var kilovolts: UnitElectricPotentialDifference {
+    open class var kilovolts: UnitElectricPotentialDifference {
         get {
             return UnitElectricPotentialDifference(symbol: Symbol.kilovolts, coefficient: Coefficient.kilovolts)
         }
     }
     
-    public class var volts: UnitElectricPotentialDifference {
+    open class var volts: UnitElectricPotentialDifference {
         get {
             return UnitElectricPotentialDifference(symbol: Symbol.volts, coefficient: Coefficient.volts)
         }
     }
     
-    public class var millivolts: UnitElectricPotentialDifference {
+    open class var millivolts: UnitElectricPotentialDifference {
         get {
             return UnitElectricPotentialDifference(symbol: Symbol.millivolts, coefficient: Coefficient.millivolts)
         }
     }
     
-    public class var microvolts: UnitElectricPotentialDifference {
+    open class var microvolts: UnitElectricPotentialDifference {
         get {
             return UnitElectricPotentialDifference(symbol: Symbol.microvolts, coefficient: Coefficient.microvolts)
         }
     }
     
-    public override class func baseUnit() -> UnitElectricPotentialDifference {
+    open override class func baseUnit() -> UnitElectricPotentialDifference {
         return UnitElectricPotentialDifference.volts
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitElectricResistance : Dimension {
+open class UnitElectricResistance : Dimension {
     
     /*
      Base unit - ohms
@@ -836,46 +836,46 @@ public class UnitElectricResistance : Dimension {
         super.init(symbol: symbol, converter: UnitConverterLinear(coefficient: coefficient))
     }
     
-    public class var megaohms: UnitElectricResistance {
+    open class var megaohms: UnitElectricResistance {
         get {
             return UnitElectricResistance(symbol: Symbol.megaohms, coefficient: Coefficient.megaohms)
         }
     }
     
-    public class var kiloohms: UnitElectricResistance {
+    open class var kiloohms: UnitElectricResistance {
         get {
             return UnitElectricResistance(symbol: Symbol.kiloohms, coefficient: Coefficient.kiloohms)
         }
     }
     
-    public class var ohms: UnitElectricResistance {
+    open class var ohms: UnitElectricResistance {
         get {
             return UnitElectricResistance(symbol: Symbol.ohms, coefficient: Coefficient.ohms)
         }
     }
     
-    public class var milliohms: UnitElectricResistance {
+    open class var milliohms: UnitElectricResistance {
         get {
             return UnitElectricResistance(symbol: Symbol.milliohms, coefficient: Coefficient.milliohms)
         }
     }
     
-    public class var microohms: UnitElectricResistance {
+    open class var microohms: UnitElectricResistance {
         get {
             return UnitElectricResistance(symbol: Symbol.microohms, coefficient: Coefficient.microohms)
         }
     }
     
-    public override class func baseUnit() -> UnitElectricResistance {
+    open override class func baseUnit() -> UnitElectricResistance {
         return UnitElectricResistance.ohms
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitEnergy : Dimension {
+open class UnitEnergy : Dimension {
     
     /*
      Base unit - joules
@@ -902,46 +902,46 @@ public class UnitEnergy : Dimension {
         super.init(symbol: symbol, converter: UnitConverterLinear(coefficient: coefficient))
     }
     
-    public class var kilojoules: UnitEnergy {
+    open class var kilojoules: UnitEnergy {
         get {
             return UnitEnergy(symbol: Symbol.kilojoules, coefficient: Coefficient.kilojoules)
         }
     }
     
-    public class var joules: UnitEnergy {
+    open class var joules: UnitEnergy {
         get {
             return UnitEnergy(symbol: Symbol.joules, coefficient: Coefficient.joules)
         }
     }
     
-    public class var kilocalories: UnitEnergy {
+    open class var kilocalories: UnitEnergy {
         get {
             return UnitEnergy(symbol: Symbol.kilocalories, coefficient: Coefficient.kilocalories)
         }
     }
     
-    public class var calories: UnitEnergy {
+    open class var calories: UnitEnergy {
         get {
             return UnitEnergy(symbol: Symbol.calories, coefficient: Coefficient.calories)
         }
     }
     
-    public class var kilowattHours: UnitEnergy {
+    open class var kilowattHours: UnitEnergy {
         get {
             return UnitEnergy(symbol: Symbol.kilowattHours, coefficient: Coefficient.kilowattHours)
         }
     }
     
-    public override class func baseUnit() -> UnitEnergy {
+    open override class func baseUnit() -> UnitEnergy {
         return UnitEnergy.joules
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitFrequency : Dimension {
+open class UnitFrequency : Dimension {
     
     /*
      Base unit - hertz
@@ -974,64 +974,64 @@ public class UnitFrequency : Dimension {
     }
     
     
-    public class var terahertz: UnitFrequency {
+    open class var terahertz: UnitFrequency {
         get {
             return UnitFrequency(symbol: Symbol.terahertz, coefficient: Coefficient.terahertz)
         }
     }
     
-    public class var gigahertz: UnitFrequency {
+    open class var gigahertz: UnitFrequency {
         get {
             return UnitFrequency(symbol: Symbol.gigahertz, coefficient: Coefficient.gigahertz)
         }
     }
     
-    public class var megahertz: UnitFrequency {
+    open class var megahertz: UnitFrequency {
         get {
             return UnitFrequency(symbol: Symbol.megahertz, coefficient: Coefficient.megahertz)
         }
     }
     
-    public class var kilohertz: UnitFrequency {
+    open class var kilohertz: UnitFrequency {
         get {
             return UnitFrequency(symbol: Symbol.kilohertz, coefficient: Coefficient.kilohertz)
         }
     }
     
-    public class var hertz: UnitFrequency {
+    open class var hertz: UnitFrequency {
         get {
             return UnitFrequency(symbol: Symbol.hertz, coefficient: Coefficient.hertz)
         }
     }
     
-    public class var millihertz: UnitFrequency {
+    open class var millihertz: UnitFrequency {
         get {
             return UnitFrequency(symbol: Symbol.millihertz, coefficient: Coefficient.millihertz)
         }
     }
     
-    public class var microhertz: UnitFrequency {
+    open class var microhertz: UnitFrequency {
         get {
             return UnitFrequency(symbol: Symbol.microhertz, coefficient: Coefficient.microhertz)
         }
     }
     
-    public class var nanohertz: UnitFrequency {
+    open class var nanohertz: UnitFrequency {
         get {
             return UnitFrequency(symbol: Symbol.nanohertz, coefficient: Coefficient.nanohertz)
         }
     }
     
-    public override class func baseUnit() -> UnitFrequency {
+    open override class func baseUnit() -> UnitFrequency {
         return UnitFrequency.hertz
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitFuelEfficiency : Dimension {
+open class UnitFuelEfficiency : Dimension {
     
     /*
      Base unit - litersPer100Kilometers
@@ -1054,34 +1054,34 @@ public class UnitFuelEfficiency : Dimension {
     }
     
     
-    public class var litersPer100Kilometers: UnitFuelEfficiency {
+    open class var litersPer100Kilometers: UnitFuelEfficiency {
         get {
             return UnitFuelEfficiency(symbol: Symbol.litersPer100Kilometers, reciprocal: Coefficient.litersPer100Kilometers)
         }
     }
     
-    public class var milesPerImperialGallon: UnitFuelEfficiency {
+    open class var milesPerImperialGallon: UnitFuelEfficiency {
         get {
             return UnitFuelEfficiency(symbol: Symbol.milesPerImperialGallon, reciprocal: Coefficient.milesPerImperialGallon)
         }
     }
     
-    public class var milesPerGallon: UnitFuelEfficiency {
+    open class var milesPerGallon: UnitFuelEfficiency {
         get {
             return UnitFuelEfficiency(symbol: Symbol.milesPerGallon, reciprocal: Coefficient.milesPerGallon)
         }
     }
     
-    public override class func baseUnit() -> UnitFuelEfficiency {
+    open override class func baseUnit() -> UnitFuelEfficiency {
         return UnitFuelEfficiency.litersPer100Kilometers
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitLength : Dimension {
+open class UnitLength : Dimension {
     
     /*
      Base unit - meters
@@ -1141,148 +1141,148 @@ public class UnitLength : Dimension {
         super.init(symbol: symbol, converter: UnitConverterLinear(coefficient: coefficient))
     }
     
-    public class var megameters: UnitLength {
+    open class var megameters: UnitLength {
         get {
             return UnitLength(symbol: Symbol.megameters, coefficient: Coefficient.megameters)
         }
     }
     
-    public class var kilometers: UnitLength {
+    open class var kilometers: UnitLength {
         get {
             return UnitLength(symbol: Symbol.kilometers, coefficient: Coefficient.kilometers)
         }
     }
     
-    public class var hectometers: UnitLength {
+    open class var hectometers: UnitLength {
         get {
             return UnitLength(symbol: Symbol.hectometers, coefficient: Coefficient.hectometers)
         }
     }
     
-    public class var decameters: UnitLength {
+    open class var decameters: UnitLength {
         get {
             return UnitLength(symbol: Symbol.decameters, coefficient: Coefficient.decameters)
         }
     }
     
-    public class var meters: UnitLength {
+    open class var meters: UnitLength {
         get {
             return UnitLength(symbol: Symbol.meters, coefficient: Coefficient.meters)
         }
     }
     
-    public class var decimeters: UnitLength {
+    open class var decimeters: UnitLength {
         get {
             return UnitLength(symbol: Symbol.decimeters, coefficient: Coefficient.decimeters)
         }
     }
     
-    public class var centimeters: UnitLength {
+    open class var centimeters: UnitLength {
         get {
             return UnitLength(symbol: Symbol.centimeters, coefficient: Coefficient.centimeters)
         }
     }
     
-    public class var millimeters: UnitLength {
+    open class var millimeters: UnitLength {
         get {
             return UnitLength(symbol: Symbol.millimeters, coefficient: Coefficient.millimeters)
         }
     }
     
-    public class var micrometers: UnitLength {
+    open class var micrometers: UnitLength {
         get {
             return UnitLength(symbol: Symbol.micrometers, coefficient: Coefficient.micrometers)
         }
     }
     
-    public class var nanometers: UnitLength {
+    open class var nanometers: UnitLength {
         get {
             return UnitLength(symbol: Symbol.nanometers, coefficient: Coefficient.nanometers)
         }
     }
     
-    public class var picometers: UnitLength {
+    open class var picometers: UnitLength {
         get {
             return UnitLength(symbol: Symbol.picometers, coefficient: Coefficient.picometers)
         }
     }
     
-    public class var inches: UnitLength {
+    open class var inches: UnitLength {
         get {
             return UnitLength(symbol: Symbol.inches, coefficient: Coefficient.inches)
         }
     }
     
-    public class var feet: UnitLength {
+    open class var feet: UnitLength {
         get {
             return UnitLength(symbol: Symbol.feet, coefficient: Coefficient.feet)
         }
     }
     
-    public class var yards: UnitLength {
+    open class var yards: UnitLength {
         get {
             return UnitLength(symbol: Symbol.yards, coefficient: Coefficient.yards)
         }
     }
     
-    public class var miles: UnitLength {
+    open class var miles: UnitLength {
         get {
             return UnitLength(symbol: Symbol.miles, coefficient: Coefficient.miles)
         }
     }
     
-    public class var scandinavianMiles: UnitLength {
+    open class var scandinavianMiles: UnitLength {
         get {
             return UnitLength(symbol: Symbol.scandinavianMiles, coefficient: Coefficient.scandinavianMiles)
         }
     }
     
-    public class var lightyears: UnitLength {
+    open class var lightyears: UnitLength {
         get {
             return UnitLength(symbol: Symbol.lightyears, coefficient: Coefficient.lightyears)
         }
     }
     
-    public class var nauticalMiles: UnitLength {
+    open class var nauticalMiles: UnitLength {
         get {
             return UnitLength(symbol: Symbol.nauticalMiles, coefficient: Coefficient.nauticalMiles)
         }
     }
     
-    public class var fathoms: UnitLength {
+    open class var fathoms: UnitLength {
         get {
             return UnitLength(symbol: Symbol.fathoms, coefficient: Coefficient.fathoms)
         }
     }
     
-    public class var furlongs: UnitLength {
+    open class var furlongs: UnitLength {
         get {
             return UnitLength(symbol: Symbol.furlongs, coefficient: Coefficient.furlongs)
         }
     }
     
-    public class var astronomicalUnits: UnitLength {
+    open class var astronomicalUnits: UnitLength {
         get {
             return UnitLength(symbol: Symbol.astronomicalUnits, coefficient: Coefficient.astronomicalUnits)
         }
     }
     
-    public class var parsecs: UnitLength {
+    open class var parsecs: UnitLength {
         get {
             return UnitLength(symbol: Symbol.parsecs, coefficient: Coefficient.parsecs)
         }
     }
     
-    public override class func baseUnit() -> UnitLength {
+    open override class func baseUnit() -> UnitLength {
         return UnitLength.meters
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitIlluminance : Dimension {
+open class UnitIlluminance : Dimension {
     
     /*
      Base unit - lux
@@ -1300,22 +1300,22 @@ public class UnitIlluminance : Dimension {
         super.init(symbol: symbol, converter: UnitConverterLinear(coefficient: coefficient))
     }
     
-    public class var lux: UnitIlluminance {
+    open class var lux: UnitIlluminance {
         get {
             return UnitIlluminance(symbol: Symbol.lux, coefficient: Coefficient.lux)
         }
     }
     
-    public override class func baseUnit() -> UnitIlluminance {
+    open override class func baseUnit() -> UnitIlluminance {
         return UnitIlluminance.lux
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitMass : Dimension {
+open class UnitMass : Dimension {
     
     /*
      Base unit - kilograms
@@ -1363,112 +1363,112 @@ public class UnitMass : Dimension {
         super.init(symbol: symbol, converter: UnitConverterLinear(coefficient: coefficient))
     }
     
-    public class var kilograms: UnitMass {
+    open class var kilograms: UnitMass {
         get {
             return UnitMass(symbol: Symbol.kilograms, coefficient: Coefficient.kilograms)
         }
     }
     
-    public class var grams: UnitMass {
+    open class var grams: UnitMass {
         get {
             return UnitMass(symbol: Symbol.grams, coefficient: Coefficient.grams)
         }
     }
     
-    public class var decigrams: UnitMass {
+    open class var decigrams: UnitMass {
         get {
             return UnitMass(symbol: Symbol.decigrams, coefficient: Coefficient.decigrams)
         }
     }
     
-    public class var centigrams: UnitMass {
+    open class var centigrams: UnitMass {
         get {
             return UnitMass(symbol: Symbol.centigrams, coefficient: Coefficient.centigrams)
         }
     }
     
-    public class var milligrams: UnitMass {
+    open class var milligrams: UnitMass {
         get {
             return UnitMass(symbol: Symbol.milligrams, coefficient: Coefficient.milligrams)
         }
     }
     
-    public class var micrograms: UnitMass {
+    open class var micrograms: UnitMass {
         get {
             return UnitMass(symbol: Symbol.micrograms, coefficient: Coefficient.micrograms)
         }
     }
     
-    public class var nanograms: UnitMass {
+    open class var nanograms: UnitMass {
         get {
             return UnitMass(symbol: Symbol.nanograms, coefficient: Coefficient.nanograms)
         }
     }
     
-    public class var picograms: UnitMass {
+    open class var picograms: UnitMass {
         get {
             return UnitMass(symbol: Symbol.picograms, coefficient: Coefficient.picograms)
         }
     }
     
-    public class var ounces: UnitMass {
+    open class var ounces: UnitMass {
         get {
             return UnitMass(symbol: Symbol.ounces, coefficient: Coefficient.ounces)
         }
     }
     
-    public class var pounds: UnitMass {
+    open class var pounds: UnitMass {
         get {
             return UnitMass(symbol: Symbol.pounds, coefficient: Coefficient.pounds)
         }
     }
     
-    public class var stones: UnitMass {
+    open class var stones: UnitMass {
         get {
             return UnitMass(symbol: Symbol.stones, coefficient: Coefficient.stones)
         }
     }
     
-    public class var metricTons: UnitMass {
+    open class var metricTons: UnitMass {
         get {
             return UnitMass(symbol: Symbol.metricTons, coefficient: Coefficient.metricTons)
         }
     }
     
-    public class var shortTons: UnitMass {
+    open class var shortTons: UnitMass {
         get {
             return UnitMass(symbol: Symbol.shortTons, coefficient: Coefficient.shortTons)
         }
     }
     
-    public class var carats: UnitMass {
+    open class var carats: UnitMass {
         get {
             return UnitMass(symbol: Symbol.carats, coefficient: Coefficient.carats)
         }
     }
     
-    public class var ouncesTroy: UnitMass {
+    open class var ouncesTroy: UnitMass {
         get {
             return UnitMass(symbol: Symbol.ouncesTroy, coefficient: Coefficient.ouncesTroy)
         }
     }
     
-    public class var slugs: UnitMass {
+    open class var slugs: UnitMass {
         get {
             return UnitMass(symbol: Symbol.slugs, coefficient: Coefficient.slugs)
         }
     }
     
-    public override class func baseUnit() -> UnitMass {
+    open override class func baseUnit() -> UnitMass {
         return UnitMass.kilograms
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitPower : Dimension {
+open class UnitPower : Dimension {
     
     /*
      Base unit - watts
@@ -1506,82 +1506,82 @@ public class UnitPower : Dimension {
         super.init(symbol: symbol, converter: UnitConverterLinear(coefficient: coefficient))
     }
     
-    public class var terawatts: UnitPower {
+    open class var terawatts: UnitPower {
         get {
             return UnitPower(symbol: Symbol.terawatts, coefficient: Coefficient.terawatts)
         }
     }
     
-    public class var gigawatts: UnitPower {
+    open class var gigawatts: UnitPower {
         get {
             return UnitPower(symbol: Symbol.gigawatts, coefficient: Coefficient.gigawatts)
         }
     }
     
-    public class var megawatts: UnitPower {
+    open class var megawatts: UnitPower {
         get {
             return UnitPower(symbol: Symbol.megawatts, coefficient: Coefficient.megawatts)
         }
     }
     
-    public class var kilowatts: UnitPower {
+    open class var kilowatts: UnitPower {
         get {
             return UnitPower(symbol: Symbol.kilowatts, coefficient: Coefficient.kilowatts)
         }
     }
     
-    public class var watts: UnitPower {
+    open class var watts: UnitPower {
         get {
             return UnitPower(symbol: Symbol.watts, coefficient: Coefficient.watts)
         }
     }
     
-    public class var milliwatts: UnitPower {
+    open class var milliwatts: UnitPower {
         get {
             return UnitPower(symbol: Symbol.milliwatts, coefficient: Coefficient.milliwatts)
         }
     }
     
-    public class var microwatts: UnitPower {
+    open class var microwatts: UnitPower {
         get {
             return UnitPower(symbol: Symbol.microwatts, coefficient: Coefficient.microwatts)
         }
     }
     
-    public class var nanowatts: UnitPower {
+    open class var nanowatts: UnitPower {
         get {
             return UnitPower(symbol: Symbol.nanowatts, coefficient: Coefficient.nanowatts)
         }
     }
     
-    public class var picowatts: UnitPower {
+    open class var picowatts: UnitPower {
         get {
             return UnitPower(symbol: Symbol.picowatts, coefficient: Coefficient.picowatts)
         }
     }
     
-    public class var femtowatts: UnitPower {
+    open class var femtowatts: UnitPower {
         get {
             return UnitPower(symbol: Symbol.femtowatts, coefficient: Coefficient.femtowatts)
         }
     }
     
-    public class var horsepower: UnitPower {
+    open class var horsepower: UnitPower {
         get {
             return UnitPower(symbol: Symbol.horsepower, coefficient: Coefficient.horsepower)
         }
     }
     
-    public override class func baseUnit() -> UnitPower {
+    open override class func baseUnit() -> UnitPower {
         return UnitPower.watts
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitPressure : Dimension {
+open class UnitPressure : Dimension {
     
     /*
      Base unit - newtonsPerMetersSquared (equivalent to 1 pascal)
@@ -1618,76 +1618,76 @@ public class UnitPressure : Dimension {
     }
     
     
-    public class var newtonsPerMetersSquared: UnitPressure {
+    open class var newtonsPerMetersSquared: UnitPressure {
         get {
             return UnitPressure(symbol: Symbol.newtonsPerMetersSquared, coefficient: Coefficient.newtonsPerMetersSquared)
         }
     }
     
-    public class var gigapascals: UnitPressure {
+    open class var gigapascals: UnitPressure {
         get {
             return UnitPressure(symbol: Symbol.gigapascals, coefficient: Coefficient.gigapascals)
         }
     }
     
-    public class var megapascals: UnitPressure {
+    open class var megapascals: UnitPressure {
         get {
             return UnitPressure(symbol: Symbol.megapascals, coefficient: Coefficient.megapascals)
         }
     }
     
-    public class var kilopascals: UnitPressure {
+    open class var kilopascals: UnitPressure {
         get {
             return UnitPressure(symbol: Symbol.kilopascals, coefficient: Coefficient.kilopascals)
         }
     }
     
-    public class var hectopascals: UnitPressure {
+    open class var hectopascals: UnitPressure {
         get {
             return UnitPressure(symbol: Symbol.hectopascals, coefficient: Coefficient.hectopascals)
         }
     }
     
-    public class var inchesOfMercury: UnitPressure {
+    open class var inchesOfMercury: UnitPressure {
         get {
             return UnitPressure(symbol: Symbol.inchesOfMercury, coefficient: Coefficient.inchesOfMercury)
         }
     }
     
-    public class var bars: UnitPressure {
+    open class var bars: UnitPressure {
         get {
             return UnitPressure(symbol: Symbol.bars, coefficient: Coefficient.bars)
         }
     }
     
-    public class var millibars: UnitPressure {
+    open class var millibars: UnitPressure {
         get {
             return UnitPressure(symbol: Symbol.millibars, coefficient: Coefficient.millibars)
         }
     }
     
-    public class var millimetersOfMercury: UnitPressure {
+    open class var millimetersOfMercury: UnitPressure {
         get {
             return UnitPressure(symbol: Symbol.millimetersOfMercury, coefficient: Coefficient.millimetersOfMercury)
         }
     }
     
-    public class var poundsForcePerSquareInch: UnitPressure {
+    open class var poundsForcePerSquareInch: UnitPressure {
         get {
             return UnitPressure(symbol: Symbol.poundsForcePerSquareInch, coefficient: Coefficient.poundsForcePerSquareInch)
         }
     }
     
-    public override class func baseUnit() -> UnitPressure {
+    open override class func baseUnit() -> UnitPressure {
         return UnitPressure.newtonsPerMetersSquared
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitSpeed : Dimension {
+open class UnitSpeed : Dimension {
     
     /*
      Base unit - metersPerSecond
@@ -1712,40 +1712,40 @@ public class UnitSpeed : Dimension {
     }
     
     
-    public class var metersPerSecond: UnitSpeed {
+    open class var metersPerSecond: UnitSpeed {
         get {
             return UnitSpeed(symbol: Symbol.metersPerSecond, coefficient: Coefficient.metersPerSecond)
         }
     }
     
-    public class var kilometersPerHour: UnitSpeed {
+    open class var kilometersPerHour: UnitSpeed {
         get {
             return UnitSpeed(symbol: Symbol.kilometersPerHour, coefficient: Coefficient.kilometersPerHour)
         }
     }
     
-    public class var milesPerHour: UnitSpeed {
+    open class var milesPerHour: UnitSpeed {
         get {
             return UnitSpeed(symbol: Symbol.milesPerHour, coefficient: Coefficient.milesPerHour)
         }
     }
     
-    public class var knots: UnitSpeed {
+    open class var knots: UnitSpeed {
         get {
             return UnitSpeed(symbol: Symbol.knots, coefficient: Coefficient.knots)
         }
     }
     
-    public override class func baseUnit() -> UnitSpeed {
+    open override class func baseUnit() -> UnitSpeed {
         return UnitSpeed.metersPerSecond
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitTemperature : Dimension {
+open class UnitTemperature : Dimension {
     
     /*
      Base unit - kelvin
@@ -1773,34 +1773,34 @@ public class UnitTemperature : Dimension {
         super.init(symbol: symbol, converter: UnitConverterLinear(coefficient: coefficient, constant: constant))
     }
     
-    public class var kelvin: UnitTemperature {
+    open class var kelvin: UnitTemperature {
         get {
             return UnitTemperature(symbol: Symbol.kelvin, coefficient: Coefficient.kelvin, constant: Constant.kelvin)
         }
     }
     
-    public class var celsius: UnitTemperature {
+    open class var celsius: UnitTemperature {
         get {
             return UnitTemperature(symbol: Symbol.celsius, coefficient: Coefficient.celsius, constant: Constant.celsius)
         }
     }
     
-    public class var fahrenheit: UnitTemperature {
+    open class var fahrenheit: UnitTemperature {
         get {
             return UnitTemperature(symbol: Symbol.fahrenheit, coefficient: Coefficient.fahrenheit, constant: Constant.fahrenheit)
         }
     }
     
-    public override class func baseUnit() -> UnitTemperature {
+    open override class func baseUnit() -> UnitTemperature {
         return UnitTemperature.kelvin
     }
     
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }
 
-public class UnitVolume : Dimension {
+open class UnitVolume : Dimension {
     
     /*
      Base unit - liters
@@ -1879,196 +1879,196 @@ public class UnitVolume : Dimension {
     }
     
     
-    public class var megaliters: UnitVolume {
+    open class var megaliters: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.megaliters, coefficient: Coefficient.megaliters)
         }
     }
     
-    public class var kiloliters: UnitVolume {
+    open class var kiloliters: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.kiloliters, coefficient: Coefficient.kiloliters)
         }
     }
     
-    public class var liters: UnitVolume {
+    open class var liters: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.liters, coefficient: Coefficient.liters)
         }
     }
     
-    public class var deciliters: UnitVolume {
+    open class var deciliters: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.deciliters, coefficient: Coefficient.deciliters)
         }
     }
     
-    public class var centiliters: UnitVolume {
+    open class var centiliters: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.centiliters, coefficient: Coefficient.centiliters)
         }
     }
     
-    public class var milliliters: UnitVolume {
+    open class var milliliters: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.milliliters, coefficient: Coefficient.milliliters)
         }
     }
     
-    public class var cubicKilometers: UnitVolume {
+    open class var cubicKilometers: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.cubicKilometers, coefficient: Coefficient.cubicKilometers)
         }
     }
     
-    public class var cubicMeters: UnitVolume {
+    open class var cubicMeters: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.cubicMeters, coefficient: Coefficient.cubicMeters)
         }
     }
     
-    public class var cubicDecimeters: UnitVolume {
+    open class var cubicDecimeters: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.cubicDecimeters, coefficient: Coefficient.cubicDecimeters)
         }
     }
     
-    public class var cubicCentimeters: UnitVolume {
+    open class var cubicCentimeters: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.cubicCentimeters, coefficient: Coefficient.cubicCentimeters)
         }
     }
     
-    public class var cubicMillimeters: UnitVolume {
+    open class var cubicMillimeters: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.cubicMillimeters, coefficient: Coefficient.cubicMillimeters)
         }
     }
     
-    public class var cubicInches: UnitVolume {
+    open class var cubicInches: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.cubicInches, coefficient: Coefficient.cubicInches)
         }
     }
     
-    public class var cubicFeet: UnitVolume {
+    open class var cubicFeet: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.cubicFeet, coefficient: Coefficient.cubicFeet)
         }
     }
     
-    public class var cubicYards: UnitVolume {
+    open class var cubicYards: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.cubicYards, coefficient: Coefficient.cubicYards)
         }
     }
     
-    public class var cubicMiles: UnitVolume {
+    open class var cubicMiles: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.cubicMiles, coefficient: Coefficient.cubicMiles)
         }
     }
     
-    public class var acreFeet: UnitVolume {
+    open class var acreFeet: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.acreFeet, coefficient: Coefficient.acreFeet)
         }
     }
     
-    public class var bushels: UnitVolume {
+    open class var bushels: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.bushels, coefficient: Coefficient.bushels)
         }
     }
     
-    public class var teaspoons: UnitVolume {
+    open class var teaspoons: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.teaspoons, coefficient: Coefficient.teaspoons)
         }
     }
     
-    public class var tablespoons: UnitVolume {
+    open class var tablespoons: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.tablespoons, coefficient: Coefficient.tablespoons)
         }
     }
     
-    public class var fluidOunces: UnitVolume {
+    open class var fluidOunces: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.fluidOunces, coefficient: Coefficient.fluidOunces)
         }
     }
     
-    public class var cups: UnitVolume {
+    open class var cups: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.cups, coefficient: Coefficient.cups)
         }
     }
     
-    public class var pints: UnitVolume {
+    open class var pints: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.pints, coefficient: Coefficient.pints)
         }
     }
     
-    public class var quarts: UnitVolume {
+    open class var quarts: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.quarts, coefficient: Coefficient.quarts)
         }
     }
     
-    public class var gallons: UnitVolume {
+    open class var gallons: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.gallons, coefficient: Coefficient.gallons)
         }
     }
     
-    public class var imperialTeaspoons: UnitVolume {
+    open class var imperialTeaspoons: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.imperialTeaspoons, coefficient: Coefficient.imperialTeaspoons)
         }
     }
     
-    public class var imperialTablespoons: UnitVolume {
+    open class var imperialTablespoons: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.imperialTablespoons, coefficient: Coefficient.imperialTablespoons)
         }
     }
     
-    public class var imperialFluidOunces: UnitVolume {
+    open class var imperialFluidOunces: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.imperialFluidOunces, coefficient: Coefficient.imperialFluidOunces)
         }
     }
     
-    public class var imperialPints: UnitVolume {
+    open class var imperialPints: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.imperialPints, coefficient: Coefficient.imperialPints)
         }
     }
     
-    public class var imperialQuarts: UnitVolume {
+    open class var imperialQuarts: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.imperialQuarts, coefficient: Coefficient.imperialQuarts)
         }
     }
     
-    public class var imperialGallons: UnitVolume {
+    open class var imperialGallons: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.imperialGallons, coefficient: Coefficient.imperialGallons)
         }
     }
     
-    public class var metricCups: UnitVolume {
+    open class var metricCups: UnitVolume {
         get {
             return UnitVolume(symbol: Symbol.metricCups, coefficient: Coefficient.metricCups)
         }
     }
     
-    public override class func baseUnit() -> UnitVolume {
+    open override class func baseUnit() -> UnitVolume {
         return UnitVolume.liters
     }
     
     public required init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    public override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
+    open override func encode(with aCoder: NSCoder) { super.encode(with: aCoder) }
 }


### PR DESCRIPTION
This applies `open` to all public classes and all of their non-final public methods, properties, and subscripts, preserving the existing behavior when [SE-0117](https://github.com/apple/swift-evolution/blob/master/proposals/0117-non-public-subclassable-by-default.md) is implemented. This transformation was performed mechanically using the following sed script (run with `sed -E`):

    /(init|mutating|struct|enum|typealias|final|let|static)/ {
      p
      d
    }
    /public class/,/^}/ s/public/open/

This should probably be refined soon, but for now this allows us to implement SE-0117 without immediately requiring updates in all clients. Specifically, there are two areas where this change may not be correct to match Foundation on Apple platforms:

- Members in extensions cannot yet be overridden, so none of them have been marked `open`.
- Some classes are *not* intended to be overridden, even in Objective-C. Specifying this requires input from the Foundation team.

Groundwork for SE-0117 "Allow distinguishing between public access and public overridability"