### PR TITLE
Revert "Updates for SE-0110 Part I"

### DIFF
--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -382,7 +382,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
             let hash = item.hash
             buffer.advanced(by: idx).pointee = Int32(hash).littleEndian
         }
-        return Data(bytesNoCopy: unsafeBitCast(buffer, to: UnsafeMutablePointer<UInt8>.self), count: count * MemoryLayout<Int>.size, deallocator: .custom({ _, _ in
+        return Data(bytesNoCopy: unsafeBitCast(buffer, to: UnsafeMutablePointer<UInt8>.self), count: count * MemoryLayout<Int>.size, deallocator: .custom({ _ in
             buffer.deallocate(capacity: size)
             buffer.deinitialize(count: size)
         }))

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -18,8 +18,8 @@ extension Dictionary : _ObjectTypeBridgeable {
         var idx = 0
         
         self.forEach {
-            let key = _NSObjectRepresentableBridge($0)
-            let value = _NSObjectRepresentableBridge($1)
+            let key = _NSObjectRepresentableBridge($0.0)
+            let value = _NSObjectRepresentableBridge($0.1)
             keyBuffer.advanced(by: idx).initialize(to: key)
             valueBuffer.advanced(by: idx).initialize(to: value)
             idx += 1

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -59,9 +59,9 @@ open class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
             if let info = aDecoder.decodeObjectOfClasses([NSSet.self, NSDictionary.self, NSArray.self, NSString.self, NSNumber.self, NSData.self, NSURL.self], forKey: "NSUserInfo") as? NSDictionary {
                 var filteredUserInfo = [String : Any]()
                 // user info must be filtered so that the keys are all strings
-                info.enumerateKeysAndObjects([]) { key, object, _ in
-                    if let key = key as? NSString {
-                        filteredUserInfo[key._swiftObject] = object
+                info.enumerateKeysAndObjects([]) {
+                    if let key = $0.0 as? NSString {
+                        filteredUserInfo[key._swiftObject] = $0.1
                     }
                 }
                 _userInfo = filteredUserInfo
@@ -74,9 +74,9 @@ open class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
             if let info = aDecoder.decodeObject() as? NSDictionary {
                 var filteredUserInfo = [String : Any]()
                 // user info must be filtered so that the keys are all strings
-                info.enumerateKeysAndObjects([]) { key, object, _ in
-                    if let key = key as? NSString {
-                        filteredUserInfo[key._swiftObject] = object
+                info.enumerateKeysAndObjects([]) {
+                    if let key = $0.0 as? NSString {
+                        filteredUserInfo[key._swiftObject] = $0.1
                     }
                 }
                 _userInfo = filteredUserInfo

--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -86,8 +86,8 @@ open class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     
     open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
         let set = NSMutableIndexSet()
-        enumerateRanges([]) { i, _ in
-            set.add(in: i)
+        enumerateRanges([]) {
+            set.add(in: $0.0)
         }
         return set
     }

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -667,7 +667,7 @@ private struct JSONReader {
         
         if source.encoding == String.Encoding.utf8 {
             
-            return parseTypedNumber(source.buffer.baseAddress!.advanced(by: input), count: source.buffer.count - input).map { return ($0, input + $1) }
+            return parseTypedNumber(source.buffer.baseAddress!.advanced(by: input), count: source.buffer.count - input).map { return ($0.0, input + $0.1) }
         }
         else {
             var numberCharacters = [UInt8]()
@@ -681,7 +681,7 @@ private struct JSONReader {
             
             return numberCharacters.withUnsafeBufferPointer {
                 parseTypedNumber($0.baseAddress!, count: $0.count)
-            }.map { any, _ in return (any, index) }
+            }.map { return ($0.0, index) }
         }
     }
 

--- a/Foundation/NSXMLNode.swift
+++ b/Foundation/NSXMLNode.swift
@@ -578,8 +578,8 @@ open class XMLNode: NSObject, NSCopying {
             if let parentNode = _CFXMLNodeGetParent(parent!) {
                 let grandparent = XMLNode._objectNodeForNode(parentNode)
                 let possibleParentNodes = grandparent.filter { $0.name == self.parent?.name }
-                let count = possibleParentNodes.reduce(0) { n, _ in
-                    return n + 1
+                let count = possibleParentNodes.reduce(0) {
+                    return $0.0 + 1
                 }
 
                 if count <= 1 {

--- a/Foundation/NSXMLParser.swift
+++ b/Foundation/NSXMLParser.swift
@@ -640,7 +640,7 @@ open class XMLParser : NSObject {
         _namespaces.append(ns)
         if let del = self.delegate {
             ns.forEach {
-                del.parser(self, didStartMappingPrefix: $0, toURI: $1)
+                del.parser(self, didStartMappingPrefix: $0.0, toURI: $0.1)
             }
         }
     }
@@ -648,8 +648,8 @@ open class XMLParser : NSObject {
     internal func _popNamespaces() {
         let ns = _namespaces.removeLast()
         if let del = self.delegate {
-            ns.forEach { prefix, _ in
-                del.parser(self, didEndMappingPrefix: prefix)
+            ns.forEach {
+                del.parser(self, didEndMappingPrefix: $0.0)
             }
         }
     }

--- a/TestFoundation/TestNSCompoundPredicate.swift
+++ b/TestFoundation/TestNSCompoundPredicate.swift
@@ -92,7 +92,7 @@ class TestNSCompoundPredicate: XCTestCase {
         var shortCircuited = true
 
         let bOK = Predicate(value: false)
-        let bDontEval = Predicate(block: { _, _ in
+        let bDontEval = Predicate(block: { _ in
             shortCircuited = false
             return true
         })
@@ -106,7 +106,7 @@ class TestNSCompoundPredicate: XCTestCase {
         var shortCircuited = true
 
         let bOK = Predicate(value: true)
-        let bDontEval = Predicate(block: { _, _ in
+        let bDontEval = Predicate(block: { _ in
             shortCircuited = false
             return true
         })


### PR DESCRIPTION
Reverts apple/swift-corelibs-foundation#497. The changes to higher-order functions are not correct. See apple/swift#3922.