### PR TITLE
Sets correct locale for date parsing in HTTPCookie

### DIFF
--- a/Foundation/NSHTTPCookie.swift
+++ b/Foundation/NSHTTPCookie.swift
@@ -259,6 +259,7 @@ open class HTTPCookie : NSObject {
                 _expiresDate = date
             } else if let dateString = expiresProperty as? String {
                 let formatter = DateFormatter()
+                formatter.locale = Locale(localeIdentifier: "en_US_POSIX")
                 formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss O"   // per RFC 6265 '<rfc1123-date, defined in [RFC2616], Section 3.3.1>'
                 let timeZone = TimeZone(abbreviation: "GMT")
                 formatter.timeZone = timeZone

--- a/TestFoundation/TestNSHTTPCookie.swift
+++ b/TestFoundation/TestNSHTTPCookie.swift
@@ -156,8 +156,9 @@ class TestNSHTTPCookie: XCTestCase {
         let cookies =  HTTPCookie.cookies(withResponseHeaderFields: header, forURL: URL(string: "http://example.com")!)
         XCTAssertEqual(cookies[0].domain, "http://example.com")
         let formatter = DateFormatter()
-        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss O"   
-        formatter.timeZone = TimeZone(abbreviation: "GMT") 
+        formatter.locale = Locale(localeIdentifier: "en_US_POSIX")
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss O"
+        formatter.timeZone = TimeZone(abbreviation: "GMT")
         if let expiresDate = formatter.date(from: "Wed, 21 Sep 2016 05:33:00 GMT") {
             XCTAssertTrue(expiresDate.compare(cookies[0].expiresDate!) == .orderedSame)
         } else {


### PR DESCRIPTION
As mentioned in https://developer.apple.com/library/ios/qa/qa1480/_index.html, the correct locale to use when parsing "Internet-style dates" is "en_US_POSIX", which is strongly specified, and date- and time-invariant. We should *not* be defaulting to using the user's current locale, which is what DateFormatter currently does.

This fix also side-steps an issue where the test and cookie expiration parsing were failing on macOS because the bundled version of CFLite defaults to a locale identifier of "", failing to parse the "MMM" format specifier. This test did not fail on Linux or on the regular CoreFoundation project because on those platforms, CFDateFormatter defaults to a locale of "en_US" (still wrong, but it works); here, a locale of "" caused the failing test. A fix for this incorrect default is forthcoming in CF itself.