### PR TITLE
Move where clauses to end to adjust to new syntax

### DIFF
--- a/Foundation/Boxing.swift
+++ b/Foundation/Boxing.swift
@@ -13,7 +13,7 @@
 /// A class type which acts as a handle (pointer-to-pointer) to a Foundation reference type which has only a mutable class (e.g., NSURLComponents).
 ///
 /// Note: This assumes that the result of calling copy() is mutable. The documentation says that classes which do not have a mutable/immutable distinction should just adopt NSCopying instead of NSMutableCopying.
-internal final class _MutableHandle<MutableType : NSObject where MutableType : NSCopying> {
+internal final class _MutableHandle<MutableType : NSObject> where MutableType : NSCopying {
     fileprivate var _pointer : MutableType
     
     init(reference : MutableType) {
@@ -60,7 +60,7 @@ extension _MutableBoxing {
     }
 }
 
-internal enum _MutableUnmanagedWrapper<ImmutableType : NSObject, MutableType : NSObject where MutableType : NSMutableCopying> {
+internal enum _MutableUnmanagedWrapper<ImmutableType : NSObject, MutableType : NSObject> where MutableType : NSMutableCopying {
     case Immutable(Unmanaged<ImmutableType>)
     case Mutable(Unmanaged<MutableType>)
 }

--- a/Foundation/IndexPath.swift
+++ b/Foundation/IndexPath.swift
@@ -32,7 +32,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
     }
     
     /// Initialize with a sequence of integers.
-    public init<ElementSequence : Sequence where ElementSequence.Iterator.Element == Element>(indexes: ElementSequence) {
+    public init<ElementSequence : Sequence>(indexes: ElementSequence) where ElementSequence.Iterator.Element == Element {
         _indexes = indexes.map { $0 }
     }
     

--- a/Foundation/IndexSet.swift
+++ b/Foundation/IndexSet.swift
@@ -816,7 +816,7 @@ private enum _MutablePair<ImmutableType, MutableType> {
 /// A class type which acts as a handle (pointer-to-pointer) to a Foundation reference type which has both an immutable and mutable class (e.g., NSData, NSMutableData).
 ///
 /// a.k.a. Box
-private final class _MutablePairHandle<ImmutableType : NSObject, MutableType : NSObject where ImmutableType : NSMutableCopying, MutableType : NSMutableCopying> {
+private final class _MutablePairHandle<ImmutableType : NSObject, MutableType : NSObject> where ImmutableType : NSMutableCopying, MutableType : NSMutableCopying {
     fileprivate var _pointer: _MutablePair<ImmutableType, MutableType>
     
     /// Initialize with an immutable reference instance.

--- a/Foundation/NSCoder.swift
+++ b/Foundation/NSCoder.swift
@@ -46,7 +46,7 @@ open class NSCoder : NSObject {
         NSRequiresConcreteImplementation()
     }
 
-    open func decodeObjectOfClass<DecodedObjectType : NSCoding where DecodedObjectType : NSObject>(_ cls: DecodedObjectType.Type, forKey key: String) -> DecodedObjectType? {
+    open func decodeObjectOfClass<DecodedObjectType : NSCoding>(_ cls: DecodedObjectType.Type, forKey key: String) -> DecodedObjectType? where DecodedObjectType : NSObject {
         NSUnimplemented()
     }
    
@@ -73,7 +73,7 @@ open class NSCoder : NSObject {
         NSUnimplemented()
     }
     
-    open func decodeTopLevelObjectOfClass<DecodedObjectType : NSCoding where DecodedObjectType : NSObject>(_ cls: DecodedObjectType.Type, forKey key: String) throws -> DecodedObjectType? {
+    open func decodeTopLevelObjectOfClass<DecodedObjectType : NSCoding>(_ cls: DecodedObjectType.Type, forKey key: String) throws -> DecodedObjectType? where DecodedObjectType : NSObject {
         NSUnimplemented()
     }
     

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -548,7 +548,7 @@ extension NSData {
         }
         return location.map {NSRange(location: $0, length: search.count)} ?? NSRange(location: NSNotFound, length: 0)
     }
-    private static func searchSubSequence<T : Collection, T2 : Sequence where T.Iterator.Element : Equatable, T.Iterator.Element == T2.Iterator.Element, T.SubSequence.Iterator.Element == T.Iterator.Element, T.Indices.Iterator.Element == T.Index>(_ subSequence : T2, inSequence seq: T,anchored : Bool) -> T.Index? {
+    private static func searchSubSequence<T : Collection, T2 : Sequence>(_ subSequence : T2, inSequence seq: T,anchored : Bool) -> T.Index? where T.Iterator.Element : Equatable, T.Iterator.Element == T2.Iterator.Element, T.SubSequence.Iterator.Element == T.Iterator.Element, T.Indices.Iterator.Element == T.Index {
         for index in seq.indices {
             if seq.suffix(from: index).starts(with: subSequence) {
                 return index

--- a/Foundation/NSEnumerator.swift
+++ b/Foundation/NSEnumerator.swift
@@ -38,7 +38,7 @@ extension NSEnumerator {
 
 }
 
-internal class NSGeneratorEnumerator<Base : IteratorProtocol where Base.Element : AnyObject> : NSEnumerator {
+internal class NSGeneratorEnumerator<Base : IteratorProtocol> : NSEnumerator where Base.Element : AnyObject {
     var generator : Base
     init(_ generator: Base) {
         self.generator = generator

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -192,7 +192,7 @@ public protocol __BridgedNSError : RawRepresentable, Swift.Error {
     static var __NSErrorDomain: String { get }
 }
 
-public func ==<T: __BridgedNSError where T.RawValue: SignedInteger>(lhs: T, rhs: T) -> Bool {
+public func ==<T: __BridgedNSError>(lhs: T, rhs: T) -> Bool where T.RawValue: SignedInteger {
     return lhs.rawValue.toIntMax() == rhs.rawValue.toIntMax()
 }
 
@@ -215,7 +215,7 @@ public extension __BridgedNSError where RawValue: SignedInteger {
     public final var hashValue: Int { return _code }
 }
 
-public func ==<T: __BridgedNSError where T.RawValue: UnsignedInteger>(lhs: T, rhs: T) -> Bool {
+public func ==<T: __BridgedNSError>(lhs: T, rhs: T) -> Bool where T.RawValue: UnsignedInteger {
     return lhs.rawValue.toUIntMax() == rhs.rawValue.toUIntMax()
 }
 

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -650,7 +650,7 @@ open class NSKeyedArchiver : NSCoder {
         _setObjectInCurrentEncodingContext(aPropertyList, forKey: key)
     }
 
-    internal func _encodeValue<T: NSObject where T: NSCoding>(_ objv: T, forKey key: String? = nil) {
+    internal func _encodeValue<T: NSObject>(_ objv: T, forKey key: String? = nil) where T: NSCoding {
         _encodePropertyList(objv, forKey: key)
     }
 

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -651,7 +651,7 @@ open class NSKeyedUnarchiver : NSCoder {
         return nil
     }
 
-    open override func decodeObjectOfClass<DecodedObjectType : NSCoding where DecodedObjectType : NSObject>(_ cls: DecodedObjectType.Type, forKey key: String) -> DecodedObjectType? {
+    open override func decodeObjectOfClass<DecodedObjectType : NSCoding>(_ cls: DecodedObjectType.Type, forKey key: String) -> DecodedObjectType? where DecodedObjectType : NSObject {
         return decodeObjectOfClasses([cls], forKey: key) as? DecodedObjectType
     }
     
@@ -663,7 +663,7 @@ open class NSKeyedUnarchiver : NSCoder {
         return try decodeTopLevelObjectOfClasses([NSArray.self], forKey: key)
     }
     
-    open override func decodeTopLevelObjectOfClass<DecodedObjectType : NSCoding where DecodedObjectType : NSObject>(_ cls: DecodedObjectType.Type, forKey key: String) throws -> DecodedObjectType? {
+    open override func decodeTopLevelObjectOfClass<DecodedObjectType : NSCoding>(_ cls: DecodedObjectType.Type, forKey key: String) throws -> DecodedObjectType? where DecodedObjectType : NSObject {
         return try self.decodeTopLevelObjectOfClasses([cls], forKey: key) as! DecodedObjectType?
     }
     


### PR DESCRIPTION
Apply the fix-its from the compiler to adopt the new `where` clause syntax.