### PR TITLE
Foundation API Conformance Update: Formatter (AnyObject → Any)

### DIFF
--- a/Foundation/NSDateComponentsFormatter.swift
+++ b/Foundation/NSDateComponentsFormatter.swift
@@ -49,7 +49,7 @@ open class DateComponentsFormatter : Formatter {
     
     /* 'obj' must be an instance of NSDateComponents.
      */
-    open override func string(for obj: AnyObject) -> String? { NSUnimplemented() }
+    open override func string(for obj: Any) -> String? { NSUnimplemented() }
     
     open func string(from components: DateComponents) -> String? { NSUnimplemented() }
     
@@ -133,6 +133,6 @@ open class DateComponentsFormatter : Formatter {
      */
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    open override func objectValue(_ string: String) throws -> AnyObject? { return nil }
+    open override func objectValue(_ string: String) throws -> Any? { return nil }
 }
 

--- a/Foundation/NSDateFormatter.swift
+++ b/Foundation/NSDateFormatter.swift
@@ -45,7 +45,7 @@ open class DateFormatter : Formatter {
 
     open func objectValue(_ string: String, range rangep: UnsafeMutablePointer<NSRange>) throws -> AnyObject? { NSUnimplemented() }
 
-    open override func string(for obj: AnyObject) -> String? {
+    open override func string(for obj: Any) -> String? {
         guard let date = obj as? Date else { return nil }
         return string(from: date)
     }

--- a/Foundation/NSEnergyFormatter.swift
+++ b/Foundation/NSEnergyFormatter.swift
@@ -43,5 +43,5 @@ open class EnergyFormatter : Formatter {
     
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    open override func objectValue(_ string: String) throws -> AnyObject? { return nil }
+    open override func objectValue(_ string: String) throws -> Any? { return nil }
 }

--- a/Foundation/NSFormatter.swift
+++ b/Foundation/NSFormatter.swift
@@ -65,7 +65,7 @@ open class Formatter : NSObject, NSCopying, NSCoding {
         return self
     }
     
-    open func string(for obj: AnyObject) -> String? {
+    open func string(for obj: Any) -> String? {
         NSRequiresConcreteImplementation()
     }
     
@@ -75,7 +75,7 @@ open class Formatter : NSObject, NSCopying, NSCoding {
     
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    open func objectValue(_ string: String) throws -> AnyObject? {
+    open func objectValue(_ string: String) throws -> Any? {
         NSRequiresConcreteImplementation()
     }
 }

--- a/Foundation/NSFormatter.swift
+++ b/Foundation/NSFormatter.swift
@@ -69,7 +69,7 @@ open class Formatter : NSObject, NSCopying, NSCoding {
         NSRequiresConcreteImplementation()
     }
     
-    open func editingString(for obj: AnyObject) -> String? {
+    open func editingString(for obj: Any) -> String? {
         return string(for: obj)
     }
     

--- a/Foundation/NSLengthFormatter.swift
+++ b/Foundation/NSLengthFormatter.swift
@@ -47,7 +47,7 @@ open class LengthFormatter : Formatter {
     
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    open override func objectValue(_ string: String) throws -> AnyObject? { return nil }
+    open override func objectValue(_ string: String) throws -> Any? { return nil }
 }
 
 

--- a/Foundation/NSMassFormatter.swift
+++ b/Foundation/NSMassFormatter.swift
@@ -43,6 +43,6 @@ open class MassFormatter : Formatter {
     
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    open override func objectValue(_ string: String) throws -> AnyObject? { return nil }
+    open override func objectValue(_ string: String) throws -> Any? { return nil }
 }
 

--- a/Foundation/NSNumberFormatter.swift
+++ b/Foundation/NSNumberFormatter.swift
@@ -52,7 +52,7 @@ open class NumberFormatter : Formatter {
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
     open func objectValue(_ string: String, range: inout NSRange) throws -> AnyObject? { NSUnimplemented() }
     
-    open override func string(for obj: AnyObject) -> String? {
+    open override func string(for obj: Any) -> String? {
         guard let number = obj as? NSNumber else { return nil }
         return string(from: number)
     }

--- a/Foundation/NSPersonNameComponentsFormatter.swift
+++ b/Foundation/NSPersonNameComponentsFormatter.swift
@@ -73,7 +73,7 @@ open class PersonNameComponentsFormatter : Formatter {
      */
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    open override func objectValue(_ string: String) throws -> AnyObject? { return nil }
+    open override func objectValue(_ string: String) throws -> Any? { return nil }
 }
 
 // Attributed String identifier key string


### PR DESCRIPTION
All formatters should now accept `Any` instead of `AnyObject`