### PR TITLE
id as Any conversion of NSCopying and NSMutableCopying

### DIFF
--- a/Foundation/Boxing.swift
+++ b/Foundation/Boxing.swift
@@ -73,7 +73,7 @@ internal protocol _SwiftNativeFoundationType : class {
     init(unmanagedImmutableObject: Unmanaged<ImmutableType>)
     init(unmanagedMutableObject: Unmanaged<MutableType>)
     
-    func mutableCopy(with zone : NSZone) -> AnyObject
+    func mutableCopy(with zone : NSZone) -> Any
     
     var hashValue: Int { get }
     var description: String { get }
@@ -113,7 +113,7 @@ extension _SwiftNativeFoundationType {
         }
     }
     
-    func mutableCopy(with zone : NSZone) -> AnyObject {
+    func mutableCopy(with zone : NSZone) -> Any {
         return _mapUnmanaged { ($0 as NSObject).mutableCopy() }
     }
     

--- a/Foundation/CharacterSet.swift
+++ b/Foundation/CharacterSet.swift
@@ -103,7 +103,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     
     internal init(_bridged characterSet: NSCharacterSet) {
         // We must copy the input because it might be mutable; just like storing a value type in ObjC
-        _wrapped = _SwiftNSCharacterSet(immutableObject: characterSet.copy())
+        _wrapped = _SwiftNSCharacterSet(immutableObject: characterSet.copy() as! NSObject)
     }
     
     /// Initialize an empty instance.

--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -288,7 +288,7 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
     
     internal init(_bridged data: NSData) {
         // We must copy the input because it might be mutable; just like storing a value type in ObjC
-        _wrapped = _SwiftNSData(immutableObject: data.copy())
+        _wrapped = _SwiftNSData(immutableObject: data.copy() as! NSObject)
     }
     
     // -----------------------------------

--- a/Foundation/NSAffineTransform.swift
+++ b/Foundation/NSAffineTransform.swift
@@ -36,11 +36,11 @@ open class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
     open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         return NSAffineTransform(transform: self)
     }
     // Necessary because `NSObject.copy()` returns `self`.
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     public required init?(coder aDecoder: NSCoder) {

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -109,11 +109,11 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         return true
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         if type(of: self) === NSArray.self {
             // return self for immutable type
             return self
@@ -125,11 +125,11 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         return NSArray(array: self.allObjects)
     }
     
-    open override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> Any {
         return mutableCopy(with: nil)
     }
     
-    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> Any {
         if type(of: self) === NSArray.self || type(of: self) === NSMutableArray.self {
             // always create and return an NSMutableArray
             let mutableArray = NSMutableArray()
@@ -150,7 +150,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
     public convenience init(array: [AnyObject], copyItems: Bool) {
         let optionalArray : [AnyObject?] =
             copyItems ?
-                array.map { return Optional<AnyObject>(($0 as! NSObject).copy()) } :
+                array.map { return Optional<AnyObject>(($0 as! NSObject).copy() as! NSObject) } :
                 array.map { return Optional<AnyObject>($0) }
         
         // This would have been nice, but "initializer delegation cannot be nested in another expression"

--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -27,19 +27,19 @@ open class AttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCodi
         return true
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         NSUnimplemented()
     }
 
-    open override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> Any {
         return mutableCopy(with: nil)
     }
     
-    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> Any {
         NSUnimplemented()
     }
     

--- a/Foundation/NSCFCharacterSet.swift
+++ b/Foundation/NSCFCharacterSet.swift
@@ -38,15 +38,15 @@ internal class _NSCFCharacterSet : NSMutableCharacterSet {
         return CFCharacterSetHasMemberInPlane(_cfObject, CFIndex(plane))
     }
     
-    override func copy() -> AnyObject {
+    override func copy() -> Any {
         return copy(with: nil)
     }
     
-    override func copy(with zone: NSZone? = nil) -> AnyObject {
+    override func copy(with zone: NSZone? = nil) -> Any {
         return CFCharacterSetCreateCopy(kCFAllocatorSystemDefault, self._cfObject)
     }
     
-    override func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    override func mutableCopy(with zone: NSZone? = nil) -> Any {
         return CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, _cfObject)._nsObject
     }
     

--- a/Foundation/NSCFString.swift
+++ b/Foundation/NSCFString.swift
@@ -171,11 +171,11 @@ internal func _CFSwiftStringCreateWithSubstring(_ str: AnyObject, range: CFRange
 
 
 internal func _CFSwiftStringCreateCopy(_ str: AnyObject) -> Unmanaged<AnyObject> {
-    return Unmanaged<AnyObject>.passRetained((str as! NSString).copy(with: nil))
+    return Unmanaged<AnyObject>.passRetained((str as! NSString).copy() as! NSObject)
 }
 
 internal func _CFSwiftStringCreateMutableCopy(_ str: AnyObject) -> Unmanaged<AnyObject> {
-    return Unmanaged<AnyObject>.passRetained((str as! NSString).mutableCopy(with: nil))
+    return Unmanaged<AnyObject>.passRetained((str as! NSString).mutableCopy() as! NSObject)
 }
 
 internal func _CFSwiftStringFastCStringContents(_ str: AnyObject) -> UnsafePointer<Int8>? {

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -185,11 +185,11 @@ open class NSCalendar: NSObject, NSCopying, NSSecureCoding {
         return true
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         let copy = NSCalendar(identifier: calendarIdentifier)!
         copy.locale = locale
         copy.timeZone = timeZone
@@ -1418,11 +1418,11 @@ open class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         return true
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         NSUnimplemented()
     }
     

--- a/Foundation/NSCharacterSet.swift
+++ b/Foundation/NSCharacterSet.swift
@@ -190,11 +190,11 @@ open class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
         return CFCharacterSetHasMemberInPlane(_cfObject, CFIndex(plane))
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         if type(of: self) == NSCharacterSet.self || type(of: self) == NSMutableCharacterSet.self {
             return _CFCharacterSetCreateCopy(kCFAllocatorSystemDefault, self._cfObject)
         } else if type(of: self) == _NSCFCharacterSet.self {
@@ -204,11 +204,11 @@ open class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
         }
     }
     
-    open override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> Any {
         return mutableCopy(with: nil)
     }
     
-    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> Any {
         if type(of: self) == NSCharacterSet.self || type(of: self) == NSMutableCharacterSet.self {
             return _CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, _cfObject)._nsObject
         } else if type(of: self) == _NSCFCharacterSet.self {

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -142,19 +142,19 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         return UnsafeRawPointer(CFDataGetBytePtr(_cfObject))
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         return self
     }
     
-    open override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> Any {
         return mutableCopy(with: nil)
     }
     
-    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> Any {
         return NSMutableData(bytes: UnsafeMutableRawPointer(mutating: bytes), length: length, copy: true, deallocator: nil)
     }
 
@@ -634,7 +634,7 @@ open class NSMutableData : NSData {
         }
     }
     
-    open override func copy(with zone: NSZone? = nil) -> AnyObject {
+    open override func copy(with zone: NSZone? = nil) -> Any {
         return NSData(bytes: bytes, length: length)
     }
 }

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -78,11 +78,11 @@ open class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
 
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         return self
     }
     
@@ -300,7 +300,7 @@ open class NSDateInterval : NSObject, NSCopying, NSSecureCoding {
         self.init(start: startDate, duration: endDate.timeIntervalSince(startDate))
     }
     
-    open func copy(with zone: NSZone?) -> AnyObject {
+    open func copy(with zone: NSZone?) -> Any {
         return NSDateInterval(start: startDate, duration: duration)
     }
     

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -171,11 +171,11 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         return true
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
 
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         if type(of: self) === NSDictionary.self {
             // return self for immutable type
             return self
@@ -187,11 +187,11 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         return NSDictionary(objects: self.allValues, forKeys: self.allKeys.map({ $0 as! NSObject}))
     }
 
-    open override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> Any {
         return mutableCopy(with: nil)
     }
 
-    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> Any {
         if type(of: self) === NSDictionary.self || type(of: self) === NSMutableDictionary.self {
             // always create and return an NSMutableDictionary
             let mutableDictionary = NSMutableDictionary()

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -101,11 +101,11 @@ open class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         return self
     }
     

--- a/Foundation/NSExpression.swift
+++ b/Foundation/NSExpression.swift
@@ -42,11 +42,11 @@ open class NSExpression : NSObject, NSSecureCoding, NSCopying {
         NSUnimplemented()
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         NSUnimplemented()
     }
 

--- a/Foundation/NSFormatter.swift
+++ b/Foundation/NSFormatter.swift
@@ -57,11 +57,11 @@ open class Formatter : NSObject, NSCopying, NSCoding {
         
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         return self
     }
     

--- a/Foundation/NSIndexPath.swift
+++ b/Foundation/NSIndexPath.swift
@@ -22,11 +22,11 @@ open class NSIndexPath: NSObject, NSCopying, NSSecureCoding {
         _indexes = indexes
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject { NSUnimplemented() }
+    open func copy(with zone: NSZone? = nil) -> Any { NSUnimplemented() }
     public convenience init(index: Int) {
         self.init(indexes: [index])
     }

--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -74,17 +74,17 @@ open class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         _count = indexSet.count
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject  { NSUnimplemented() }
+    open func copy(with zone: NSZone? = nil) -> Any  { NSUnimplemented() }
     
-    open override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> Any {
         return mutableCopy(with: nil)
     }
     
-    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> Any {
         let set = NSMutableIndexSet()
         enumerateRanges([]) {
             set.add(in: $0.0)

--- a/Foundation/NSKeyedCoderOldStyleArray.swift
+++ b/Foundation/NSKeyedCoderOldStyleArray.swift
@@ -99,11 +99,11 @@ internal final class _NSKeyedCoderOldStyleArray : NSObject, NSCopying, NSSecureC
         }
     }
     
-    override func copy() -> AnyObject {
+    override func copy() -> Any {
         return copy(with: nil)
     }
     
-    func copy(with zone: NSZone? = nil) -> AnyObject {
+    func copy(with zone: NSZone? = nil) -> Any {
         return self
     }
 }

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -51,11 +51,11 @@ open class NSLocale: NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject { 
+    open func copy(with zone: NSZone? = nil) -> Any { 
         return self 
     }
     

--- a/Foundation/NSMeasurement.swift
+++ b/Foundation/NSMeasurement.swift
@@ -31,7 +31,7 @@ open class NSMeasurement : NSObject, NSCopying, NSSecureCoding {
     
     open func subtracting(_ measurement: Measurement<Unit>) -> Measurement<Unit> { NSUnimplemented() }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject { NSUnimplemented() }
+    open func copy(with zone: NSZone? = nil) -> Any { NSUnimplemented() }
     
     open class func supportsSecureCoding() -> Bool { return true }
     

--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -76,11 +76,11 @@ open class NSNotification: NSObject, NSCopying, NSCoding {
         }
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         return self
     }
     

--- a/Foundation/NSNull.swift
+++ b/Foundation/NSNull.swift
@@ -10,11 +10,11 @@
 
 open class NSNull : NSObject, NSCopying, NSSecureCoding {
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         return self
     }
     

--- a/Foundation/NSObject.swift
+++ b/Foundation/NSObject.swift
@@ -42,22 +42,22 @@ public struct NSZone : ExpressibleByNilLiteral {
 
 public protocol NSCopying {
     
-    func copy(with zone: NSZone?) -> AnyObject
+    func copy(with zone: NSZone?) -> Any
 }
 
 extension NSCopying {
-    public func copy() -> AnyObject {
+    public func copy() -> Any {
         return copy(with: nil)
     }
 }
 
 public protocol NSMutableCopying {
     
-    func mutableCopy(with zone: NSZone?) -> AnyObject
+    func mutableCopy(with zone: NSZone?) -> Any
 }
 
 extension NSMutableCopying {
-    public func mutableCopy() -> AnyObject {
+    public func mutableCopy() -> Any {
         return mutableCopy(with: nil)
     }
 }
@@ -69,14 +69,14 @@ open class NSObject : NSObjectProtocol, Equatable, Hashable {
         
     }
     
-    open func copy() -> AnyObject {
+    open func copy() -> Any {
         if let copyable = self as? NSCopying {
             return copyable.copy(with: nil)
         }
         return self
     }
     
-    open func mutableCopy() -> AnyObject {
+    open func mutableCopy() -> Any {
         if let copyable = self as? NSMutableCopying {
             return copyable.mutableCopy(with: nil)
         }

--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -12,19 +12,19 @@ open class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     internal var _storage: Set<NSObject>
     internal var _orderedStorage: [NSObject]
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         NSUnimplemented()
     }
 
-    open override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> Any {
         return mutableCopy(with: nil)
     }
 
-    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> Any {
         NSUnimplemented()
     }
     
@@ -305,7 +305,7 @@ extension NSOrderedSet {
             objects = [AnyObject]()
             for index in range.indices {
                 let object = set[index] as! NSObject
-                objects.append(flag ? object.copy() : object)
+                objects.append(flag ? object.copy() as! NSObject : object)
             }
         }
 

--- a/Foundation/NSPersonNameComponents.swift
+++ b/Foundation/NSPersonNameComponents.swift
@@ -50,7 +50,7 @@ open class NSPersonNameComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject { NSUnimplemented() }
+    open func copy(with zone: NSZone? = nil) -> Any { NSUnimplemented() }
     
     /* The below examples all assume the full name Dr. Johnathan Maple Appleseed Esq., nickname "Johnny" */
     

--- a/Foundation/NSPort.swift
+++ b/Foundation/NSPort.swift
@@ -26,7 +26,7 @@ open class Port : NSObject, NSCopying, NSCoding {
         NSUnimplemented()
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         NSUnimplemented()
     }
     

--- a/Foundation/NSPredicate.swift
+++ b/Foundation/NSPredicate.swift
@@ -33,11 +33,11 @@ open class Predicate : NSObject, NSSecureCoding, NSCopying {
         NSUnimplemented()
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         NSUnimplemented()
     }
     

--- a/Foundation/NSRegularExpression.swift
+++ b/Foundation/NSRegularExpression.swift
@@ -30,11 +30,11 @@ extension RegularExpression {
 open class RegularExpression: NSObject, NSCopying, NSCoding {
     internal var _internal: _CFRegularExpression
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         return self
     }
     

--- a/Foundation/NSScanner.swift
+++ b/Foundation/NSScanner.swift
@@ -17,11 +17,11 @@ open class Scanner: NSObject, NSCopying {
     internal var _invertedSkipSet: CharacterSet?
     internal var _scanLocation: Int
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         return Scanner(string: string)
     }
     

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -148,11 +148,11 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
         self.allObjects._nsObject.encode(with: aCoder)
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         if type(of: self) === NSSet.self {
             // return self for immutable type
             return self
@@ -164,11 +164,11 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
         return NSSet(array: self.allObjects)
     }
     
-    open override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> Any {
         return mutableCopy(with: nil)
     }
 
-    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> Any {
         if type(of: self) === NSSet.self || type(of: self) === NSMutableSet.self {
             // always create and return an NSMutableSet
             let mutableSet = NSMutableSet()
@@ -217,7 +217,7 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
     public convenience init(set: Set<NSObject>, copyItems flag: Bool) {
         var array = set.bridge().allObjects
         if (flag) {
-            array = array.map() { ($0 as! NSObject).copy() }
+            array = array.map() { ($0 as! NSObject).copy() as! NSObject }
         }
         self.init(array: array)
     }
@@ -474,7 +474,7 @@ open class NSCountedSet : NSMutableSet {
 
     public required convenience init?(coder: NSCoder) { NSUnimplemented() }
 
-    open override func copy(with zone: NSZone? = nil) -> AnyObject {
+    open override func copy(with zone: NSZone? = nil) -> Any {
         if type(of: self) === NSCountedSet.self {
             let countedSet = NSCountedSet()
             countedSet._storage = self._storage
@@ -484,7 +484,7 @@ open class NSCountedSet : NSMutableSet {
         return NSCountedSet(array: self.allObjects)
     }
 
-    open override func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open override func mutableCopy(with zone: NSZone? = nil) -> Any {
         if type(of: self) === NSCountedSet.self {
             let countedSet = NSCountedSet()
             countedSet._storage = self._storage

--- a/Foundation/NSSortDescriptor.swift
+++ b/Foundation/NSSortDescriptor.swift
@@ -22,11 +22,11 @@ open class SortDescriptor: NSObject, NSSecureCoding, NSCopying {
         return true
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         NSUnimplemented()
     }
 

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -260,19 +260,19 @@ open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSC
         self.init(aString)
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         return self
     }
     
-    open override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> Any {
         return mutableCopy(with: nil)
     }
     
-    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> Any {
         if type(of: self) === NSString.self || type(of: self) === NSMutableString.self {
             if let contents = _fastContents {
                 return NSMutableString(characters: contents, length: length)

--- a/Foundation/NSTextCheckingResult.swift
+++ b/Foundation/NSTextCheckingResult.swift
@@ -37,11 +37,11 @@ open class TextCheckingResult: NSObject, NSCopying, NSCoding {
         NSUnimplemented()
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         NSUnimplemented()
     }
     

--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -105,11 +105,11 @@ open class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
         return true
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         return self
     }
     

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -208,11 +208,11 @@ open class NSURL: NSObject, NSSecureCoding, NSCopying {
         _CFDeinit(self)
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         return self
     }
     
@@ -830,11 +830,11 @@ open class NSURLQueryItem : NSObject, NSSecureCoding, NSCopying {
         self.value = value
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         return self
     }
     
@@ -857,11 +857,11 @@ open class NSURLQueryItem : NSObject, NSSecureCoding, NSCopying {
 open class NSURLComponents: NSObject, NSCopying {
     private let _components : CFURLComponentsRef!
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         NSUnimplemented()
     }
     

--- a/Foundation/NSURLCache.swift
+++ b/Foundation/NSURLCache.swift
@@ -56,11 +56,11 @@ open class CachedURLResponse : NSObject, NSSecureCoding, NSCopying {
         return true
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         NSUnimplemented()
     }
 

--- a/Foundation/NSURLCredential.swift
+++ b/Foundation/NSURLCredential.swift
@@ -76,11 +76,11 @@ open class URLCredential : NSObject, NSSecureCoding, NSCopying {
         return true
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         NSUnimplemented()
     }
     

--- a/Foundation/NSURLProtectionSpace.swift
+++ b/Foundation/NSURLProtectionSpace.swift
@@ -106,11 +106,11 @@ public let NSURLAuthenticationMethodServerTrust: String = "NSURLAuthenticationMe
 */
 open class URLProtectionSpace : NSObject, NSSecureCoding, NSCopying {
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject { NSUnimplemented() }
+    open func copy(with zone: NSZone? = nil) -> Any { NSUnimplemented() }
     public static func supportsSecureCoding() -> Bool { return true }
     open func encode(with aCoder: NSCoder) {
         NSUnimplemented()

--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -117,11 +117,11 @@ extension NSURLRequest {
 /// load of a URL.
 open class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying {
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         if type(of: self) === NSURLRequest.self {
             // Already immutable
             return self
@@ -148,11 +148,11 @@ open class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying {
         self.httpMethod = source.httpMethod
     }
     
-    open override func mutableCopy() -> AnyObject {
+    open override func mutableCopy() -> Any {
         return mutableCopy(with: nil)
     }
     
-    open func mutableCopy(with zone: NSZone? = nil) -> AnyObject {
+    open func mutableCopy(with zone: NSZone? = nil) -> Any {
         let c = NSMutableURLRequest(url: url!)
         c.setValues(from: self)
         return c

--- a/Foundation/NSURLResponse.swift
+++ b/Foundation/NSURLResponse.swift
@@ -30,11 +30,11 @@ open class URLResponse : NSObject, NSSecureCoding, NSCopying {
         NSUnimplemented()
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         return self
     }
     

--- a/Foundation/NSURLSession.swift
+++ b/Foundation/NSURLSession.swift
@@ -227,11 +227,11 @@ open class URLSessionTask: NSObject, NSCopying {
         NSUnimplemented()
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         NSUnimplemented()
     }
     
@@ -445,11 +445,11 @@ open class URLSessionConfiguration: NSObject, NSCopying {
         NSUnimplemented()
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         NSUnimplemented()
     }
     

--- a/Foundation/NSUUID.swift
+++ b/Foundation/NSUUID.swift
@@ -45,11 +45,11 @@ open class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
         return String(cString: strPtr)
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         return self
     }
     

--- a/Foundation/NSValue.swift
+++ b/Foundation/NSValue.swift
@@ -144,11 +144,11 @@ open class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
         return true
     }
     
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         return self
     }
 }

--- a/Foundation/NSXMLNode.swift
+++ b/Foundation/NSXMLNode.swift
@@ -49,13 +49,13 @@ open class XMLNode: NSObject, NSCopying {
         case notationDeclaration
     }
 
-    open override func copy() -> AnyObject {
+    open override func copy() -> Any {
         return copy(with: nil)
     }
 
     internal let _xmlNode: _CFXMLNodePtr
 
-    open func copy(with zone: NSZone? = nil) -> AnyObject {
+    open func copy(with zone: NSZone? = nil) -> Any {
         let newNode = _CFXMLCopyNode(_xmlNode, true)
         return XMLNode._objectNodeForNode(newNode)
     }

--- a/Foundation/Unit.swift
+++ b/Foundation/Unit.swift
@@ -143,7 +143,7 @@ open class Unit : NSObject, NSCopying, NSSecureCoding {
         self.symbol = symbol
     }
     
-    open func copy(with zone: NSZone?) -> AnyObject {
+    open func copy(with zone: NSZone?) -> Any {
         return self
     }
     

--- a/TestFoundation/TestNSURLResponse.swift
+++ b/TestFoundation/TestNSURLResponse.swift
@@ -89,7 +89,7 @@ class TestNSURLResponse : XCTestCase {
     func test_copyWithZone() {
         let url = URL(string: "a/test/path")!
         let res = URLResponse(url: url, mimeType: "txt", expectedContentLength: 0, textEncodingName: nil)
-        XCTAssertTrue(res.isEqual(res.copy()))
+        XCTAssertTrue(res.isEqual(res.copy() as! NSObject))
     }
 }
 


### PR DESCRIPTION
This updates NSCopying to return Any instead of AnyObject (only as a superficial return type change)