### PR TITLE
Refactor supportsSecureCoding to a property instead of function

### DIFF
--- a/Foundation/NSAffineTransform.swift
+++ b/Foundation/NSAffineTransform.swift
@@ -46,7 +46,7 @@ open class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
     public required init?(coder aDecoder: NSCoder) {
         NSUnimplemented()
     }
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -105,7 +105,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         }
     }
     
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -23,7 +23,7 @@ open class AttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCodi
         NSUnimplemented()
     }
     
-    static public func supportsSecureCoding() -> Bool {
+    static public var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -181,7 +181,7 @@ open class NSCalendar: NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    static public func supportsSecureCoding() -> Bool {
+    static public var supportsSecureCoding: Bool {
         return true
     }
     
@@ -1414,7 +1414,7 @@ open class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    static public func supportsSecureCoding() -> Bool {
+    static public var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSCoder.swift
+++ b/Foundation/NSCoder.swift
@@ -13,7 +13,7 @@ public protocol NSCoding {
 }
 
 public protocol NSSecureCoding : NSCoding {
-    static func supportsSecureCoding() -> Bool
+    static var supportsSecureCoding: Bool { get }
 }
 
 open class NSCoder : NSObject {

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -190,7 +190,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         }
     }
     
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -86,7 +86,7 @@ open class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
         return self
     }
     
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
     
@@ -310,7 +310,7 @@ open class NSDateInterval : NSObject, NSCopying, NSSecureCoding {
         aCoder.encode(endDate._nsObject, forKey: "NS.endDate")
     }
     
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -167,7 +167,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         }
     }
     
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -84,7 +84,7 @@ open class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSExpression.swift
+++ b/Foundation/NSExpression.swift
@@ -30,7 +30,7 @@ extension NSExpression {
 
 open class NSExpression : NSObject, NSSecureCoding, NSCopying {
     
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSFileHandle.swift
+++ b/Foundation/NSFileHandle.swift
@@ -184,7 +184,7 @@ open class FileHandle: NSObject, NSSecureCoding {
         NSUnimplemented()
     }
     
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
 }

--- a/Foundation/NSIndexPath.swift
+++ b/Foundation/NSIndexPath.swift
@@ -39,7 +39,7 @@ open class NSIndexPath: NSObject, NSCopying, NSSecureCoding {
         NSUnimplemented()
     }
     
-    public static func supportsSecureCoding() -> Bool { return true }
+    public static var supportsSecureCoding: Bool { return true }
     
     open func adding(_ index: Int) -> IndexPath {
         return IndexPath(indexes: _indexes + [index])

--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -91,7 +91,7 @@ open class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         }
         return set
     }
-    public static func supportsSecureCoding() -> Bool { return true }
+    public static var supportsSecureCoding: Bool { return true }
     public required init?(coder aDecoder: NSCoder)  { NSUnimplemented() }
     open func encode(with aCoder: NSCoder) {
         NSUnimplemented()

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -269,7 +269,7 @@ open class NSKeyedArchiver : NSCoder {
         var supportsSecureCoding : Bool = false
         
         if let secureCodable = objv as? NSSecureCoding {
-            supportsSecureCoding = type(of: secureCodable).supportsSecureCoding()
+            supportsSecureCoding = type(of: secureCodable).supportsSecureCoding
         }
         
         return supportsSecureCoding

--- a/Foundation/NSKeyedCoderOldStyleArray.swift
+++ b/Foundation/NSKeyedCoderOldStyleArray.swift
@@ -89,7 +89,7 @@ internal final class _NSKeyedCoderOldStyleArray : NSObject, NSCopying, NSSecureC
         }
     }
     
-    static func supportsSecureCoding() -> Bool {
+    static var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -217,7 +217,7 @@ open class NSKeyedUnarchiver : NSCoder {
     
     private static func _supportsSecureCoding(_ clsv : AnyClass) -> Bool {
         if let secureCodable = clsv as? NSSecureCoding.Type {
-            return secureCodable.supportsSecureCoding()
+            return secureCodable.supportsSecureCoding
         }
         
         return false
@@ -426,7 +426,7 @@ open class NSKeyedUnarchiver : NSCoder {
         var supportsSecureCoding : Bool = false
         
         if let secureDecodableClass = classToConstruct as? NSSecureCoding.Type {
-            supportsSecureCoding = secureDecodableClass.supportsSecureCoding()
+            supportsSecureCoding = secureDecodableClass.supportsSecureCoding
         }
         
         if self.requiresSecureCoding && !supportsSecureCoding {

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -68,7 +68,7 @@ open class NSLocale: NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
 }

--- a/Foundation/NSMeasurement.swift
+++ b/Foundation/NSMeasurement.swift
@@ -33,7 +33,7 @@ open class NSMeasurement : NSObject, NSCopying, NSSecureCoding {
     
     open func copy(with zone: NSZone? = nil) -> AnyObject { NSUnimplemented() }
     
-    open class func supportsSecureCoding() -> Bool { return true }
+    open class var supportsSecureCoding: Bool { return true }
     
     open func encode(with aCoder: NSCoder) { NSUnimplemented() }
     

--- a/Foundation/NSMeasurementFormatter.swift
+++ b/Foundation/NSMeasurementFormatter.swift
@@ -75,5 +75,5 @@ open class MeasurementFormatter : Formatter, NSSecureCoding {
     
     public required init?(coder aDecoder: NSCoder) { NSUnimplemented() }
     open override func encode(with aCoder: NSCoder) { NSUnimplemented() }
-    public static func supportsSecureCoding() -> Bool { return true }
+    public static var supportsSecureCoding: Bool { return true }
 }

--- a/Foundation/NSNull.swift
+++ b/Foundation/NSNull.swift
@@ -30,7 +30,7 @@ open class NSNull : NSObject, NSCopying, NSSecureCoding {
         // Nothing to do here
     }
     
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -28,7 +28,7 @@ open class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         NSUnimplemented()
     }
     
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSPersonNameComponents.swift
+++ b/Foundation/NSPersonNameComponents.swift
@@ -29,7 +29,7 @@ open class NSPersonNameComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    static public func supportsSecureCoding() -> Bool { return true }
+    static public var supportsSecureCoding: Bool { return true }
     
     open func encode(with aCoder: NSCoder) {
         if aCoder.allowsKeyedCoding {

--- a/Foundation/NSPredicate.swift
+++ b/Foundation/NSPredicate.swift
@@ -21,7 +21,7 @@ open class Predicate : NSObject, NSSecureCoding, NSCopying {
 
     private let kind: PredicateKind
 
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -178,7 +178,7 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
         return NSMutableSet(array: self.allObjects)
     }
 
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSSortDescriptor.swift
+++ b/Foundation/NSSortDescriptor.swift
@@ -18,7 +18,7 @@ open class SortDescriptor: NSObject, NSSecureCoding, NSCopying {
         NSUnimplemented()
     }
     
-    static public func supportsSecureCoding() -> Bool {
+    static public var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -286,7 +286,7 @@ open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSC
         return result
     }
     
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -101,7 +101,7 @@ open class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -216,7 +216,7 @@ open class NSURL: NSObject, NSSecureCoding, NSCopying {
         return self
     }
     
-    public static func supportsSecureCoding() -> Bool { return true }
+    public static var supportsSecureCoding: Bool { return true }
     
     public convenience required init?(coder aDecoder: NSCoder) {
         if aDecoder.allowsKeyedCoding {
@@ -838,7 +838,7 @@ open class NSURLQueryItem : NSObject, NSSecureCoding, NSCopying {
         return self
     }
     
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSURLAuthenticationChallenge.swift
+++ b/Foundation/NSURLAuthenticationChallenge.swift
@@ -48,7 +48,7 @@ public protocol URLAuthenticationChallengeSender : NSObjectProtocol {
 */
 open class URLAuthenticationChallenge : NSObject, NSSecureCoding {
     
-    static public func supportsSecureCoding() -> Bool {
+    static public var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSURLCache.swift
+++ b/Foundation/NSURLCache.swift
@@ -52,7 +52,7 @@ open class CachedURLResponse : NSObject, NSSecureCoding, NSCopying {
         NSUnimplemented()
     }
     
-    static public func supportsSecureCoding() -> Bool {
+    static public var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSURLCredential.swift
+++ b/Foundation/NSURLCredential.swift
@@ -72,7 +72,7 @@ open class URLCredential : NSObject, NSSecureCoding, NSCopying {
         NSUnimplemented()
     }
     
-    static public func supportsSecureCoding() -> Bool {
+    static public var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSURLProtectionSpace.swift
+++ b/Foundation/NSURLProtectionSpace.swift
@@ -111,7 +111,7 @@ open class URLProtectionSpace : NSObject, NSSecureCoding, NSCopying {
     }
     
     open func copy(with zone: NSZone? = nil) -> AnyObject { NSUnimplemented() }
-    public static func supportsSecureCoding() -> Bool { return true }
+    public static var supportsSecureCoding: Bool { return true }
     open func encode(with aCoder: NSCoder) {
         NSUnimplemented()
     }

--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -167,7 +167,7 @@ open class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying {
     }
     
     /// Indicates that NSURLRequest implements the NSSecureCoding protocol.
-    public static func supportsSecureCoding() -> Bool { return true }
+    public static var supportsSecureCoding: Bool { return true }
     
     /// The URL of the receiver.
     /*@NSCopying */open fileprivate(set) var url: URL?

--- a/Foundation/NSURLResponse.swift
+++ b/Foundation/NSURLResponse.swift
@@ -18,7 +18,7 @@
 /// data for a URL load.
 open class URLResponse : NSObject, NSSecureCoding, NSCopying {
 
-    static public func supportsSecureCoding() -> Bool {
+    static public var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSUUID.swift
+++ b/Foundation/NSUUID.swift
@@ -53,7 +53,7 @@ open class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
         return self
     }
     
-    public static func supportsSecureCoding() -> Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/NSValue.swift
+++ b/Foundation/NSValue.swift
@@ -140,7 +140,7 @@ open class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
     }
     
-    open class func supportsSecureCoding() -> Bool {
+    open class var supportsSecureCoding: Bool {
         return true
     }
     

--- a/Foundation/Unit.swift
+++ b/Foundation/Unit.swift
@@ -85,7 +85,7 @@ open class UnitConverterLinear : UnitConverter, NSSecureCoding {
         }
     }
     
-    public static func supportsSecureCoding() -> Bool { return true }
+    public static var supportsSecureCoding: Bool { return true }
 }
 
 private class UnitConverterReciprocal : UnitConverter, NSSecureCoding {
@@ -126,7 +126,7 @@ private class UnitConverterReciprocal : UnitConverter, NSSecureCoding {
         }
     }
     
-    fileprivate static func supportsSecureCoding() -> Bool { return true }
+    fileprivate static var supportsSecureCoding: Bool { return true }
 }
 
 /*
@@ -167,7 +167,7 @@ open class Unit : NSObject, NSCopying, NSSecureCoding {
         }
     }
 
-    public static func supportsSecureCoding() -> Bool { return true }
+    public static var supportsSecureCoding: Bool { return true }
 }
 
 open class Dimension : Unit {

--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -19,7 +19,7 @@
 public class UserClass : NSObject, NSSecureCoding {
     var ivar : Int
     
-    public class func supportsSecureCoding() -> Bool {
+    public class var supportsSecureCoding: Bool {
         return true
     }
     


### PR DESCRIPTION
Conversion of the static function `supportsSecureCoding()` to a property