### PR TITLE
Foundation API Conformance Update: FileManager

### DIFF
--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -296,7 +296,7 @@ class TestNSFileManager : XCTestCase {
         }
         
         var didGetError = false
-        let handler : (URL, NSError) -> Bool = { (URL, NSError) in
+        let handler : (URL, Error) -> Bool = { (URL, Error) in
             didGetError = true
             return true
         }


### PR DESCRIPTION
### Changes
* `public static let default` → `open class var default`
* `URLRelationship` → `FileManager.URLRelationship`
* `NSFileManagerDelegate` → `FileManagerDelegate`

Where appropriate:
* `String` → `URLResourceKey`
* `String` → `FileAttributesKey`
* `public` → `open`
* `NSError` → `Error`