### PR TITLE
Foundation API Conformance Update: Host

### DIFF
--- a/Foundation/NSHost.swift
+++ b/Foundation/NSHost.swift
@@ -33,10 +33,10 @@ open class Host: NSObject {
         _type = type
     }
     
-    static internal let current = Host(nil, .current)
+    static internal let _current = Host(nil, .current)
     
-    open class func currentHost() -> Host {
-        return Host.current
+    open class func current() -> Host {
+        return _current
     }
     
     public convenience init(name: String?) {

--- a/Foundation/NSProcessInfo.swift
+++ b/Foundation/NSProcessInfo.swift
@@ -63,7 +63,7 @@ open class ProcessInfo: NSObject {
     }
     
     open var hostName: String {
-        if let name = Host.currentHost().name {
+        if let name = Host.current().name {
             return name
         } else {
             return "localhost"


### PR DESCRIPTION
`Host.currentHost()` → `Host.current()`