### PR TITLE
Additional fixes for macOS test failure in TestHTTPCookie.

### DIFF
--- a/CoreFoundation/Locale.subproj/CFLocale.c
+++ b/CoreFoundation/Locale.subproj/CFLocale.c
@@ -13,8 +13,6 @@
     Responsibility: David Smith
 */
 
-// Note the header file is in the OpenSource set (stripped to almost nothing), but not the .c file
-
 #include <CoreFoundation/CFLocale.h>
 #include <CoreFoundation/CFString.h>
 #include <CoreFoundation/CFArray.h>
@@ -297,6 +295,9 @@ static CFLocaleRef _CFLocaleCopyCurrentGuts(CFStringRef name, Boolean useCache, 
     if (!name) {
 #if 0 // DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_WINDOWS || DEPLOYMENT_TARGET_LINUX
         name = (CFStringRef)CFPreferencesCopyAppValue(CFSTR("AppleLocale"), kCFPreferencesCurrentApplication);
+#else
+        // For swift-corelibs-foundation, we temporarily assume en_US as the current locale. CFPreferences does not appear to work yet.
+        name = CFSTR("en_US");
 #endif
     } else {
         CFRetain(name);

--- a/CoreFoundation/NumberDate.subproj/CFTimeZone.c
+++ b/CoreFoundation/NumberDate.subproj/CFTimeZone.c
@@ -1106,29 +1106,9 @@ Boolean _CFTimeZoneInit(CFTimeZoneRef timeZone, CFStringRef name, CFDataRef data
             CFStringRef tzName = NULL;
             CFDataRef data = NULL;
             
-            CFIndex len = CFStringGetLength(name);
-            if (6 == len || 8 == len) {
-                UniChar buffer[8];
-                CFStringGetCharacters(name, CFRangeMake(0, len), buffer);
-                if ('G' == buffer[0] && 'M' == buffer[1] && 'T' == buffer[2] && ('+' == buffer[3] || '-' == buffer[3])) {
-                    if (('0' <= buffer[4] && buffer[4] <= '9') && ('0' <= buffer[5] && buffer[5] <= '9')) {
-                        int32_t hours = (buffer[4] - '0') * 10 + (buffer[5] - '0');
-                        if (-14 <= hours && hours <= 14) {
-                            CFTimeInterval ti = hours * 3600.0;
-                            if (6 == len) {
-                                return _CFTimeZoneInitWithTimeIntervalFromGMT(timeZone, ('-' == buffer[3] ? -1.0 : 1.0) * ti);
-                            } else {
-                                if (('0' <= buffer[6] && buffer[6] <= '9') && ('0' <= buffer[7] && buffer[7] <= '9')) {
-                                    int32_t minutes = (buffer[6] - '0') * 10 + (buffer[7] - '0');
-                                    if ((-14 == hours && 0 == minutes) || (14 == hours && 0 == minutes) || (0 <= minutes && minutes <= 59)) {
-                                        ti = ti + minutes * 60.0;
-                                        return _CFTimeZoneInitWithTimeIntervalFromGMT(timeZone, ('-' == buffer[3] ? -1.0 : 1.0) * ti);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+            int32_t offsetFromGMT = __tryParseGMTName(name);
+            if (offsetFromGMT != -1) {
+                return _CFTimeZoneInitWithTimeIntervalFromGMT(timeZone, offsetFromGMT);
             }
             Boolean tryAbbrev = true;
             CFURLRef baseURL, tempURL;

--- a/Foundation/NSDateFormatter.swift
+++ b/Foundation/NSDateFormatter.swift
@@ -24,9 +24,6 @@ open class DateFormatter : Formatter {
             
             let obj = CFDateFormatterCreate(kCFAllocatorSystemDefault, locale._cfObject, dateStyle, timeStyle)!
             _setFormatterAttributes(obj)
-            if let dateFormat = _dateFormat {
-                CFDateFormatterSetFormat(obj, dateFormat._cfObject)
-            }
             __cfObject = obj
             return obj
         }
@@ -55,14 +52,11 @@ open class DateFormatter : Formatter {
     }
 
     open func date(from string: String) -> Date? {
-        var range = CFRange(location: 0, length: string.length)
-        let date = withUnsafeMutablePointer(to: &range) { (rangep: UnsafeMutablePointer<CFRange>) -> Date? in
-            guard let res = CFDateFormatterCreateDateFromString(kCFAllocatorSystemDefault, _cfObject, string._cfObject, rangep) else {
-                return nil
-            }
-            return res._swiftObject
+        // nil range means "use the entire string"
+        guard let res = CFDateFormatterCreateDateFromString(kCFAllocatorSystemDefault, _cfObject, string._cfObject, nil) else {
+            return nil
         }
-        return date
+        return res._swiftObject
     }
 
     open class func localizedString(from date: Date, dateStyle dstyle: Style, timeStyle tstyle: Style) -> String {
@@ -88,16 +82,14 @@ open class DateFormatter : Formatter {
     }
 
     internal func _setFormatterAttributes(_ formatter: CFDateFormatter) {
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterIsLenient, value: lenient._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterTimeZone, value: timeZone?._cfObject)
-        if let ident = _calendar?.identifier {
-            _setFormatterAttribute(formatter, attributeName: kCFDateFormatterCalendarName, value: Calendar._toNSCalendarIdentifier(ident).rawValue._cfObject)
-        } else {
-            _setFormatterAttribute(formatter, attributeName: kCFDateFormatterCalendarName, value: nil)
+        if let dateFormat = _dateFormat {
+            CFDateFormatterSetFormat(formatter, dateFormat._cfObject)
         }
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterTimeZone, value: timeZone?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterCalendar, value: _calendar?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterIsLenient, value: lenient._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFDateFormatterTwoDigitStartDate, value: _twoDigitStartDate?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFDateFormatterDefaultDate, value: defaultDate?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterCalendar, value: _calendar?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFDateFormatterEraSymbols, value: _eraSymbols?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFDateFormatterMonthSymbols, value: _monthSymbols?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFDateFormatterShortMonthSymbols, value: _shortMonthSymbols?._cfObject)
@@ -119,6 +111,16 @@ open class DateFormatter : Formatter {
         _setFormatterAttribute(formatter, attributeName: kCFDateFormatterStandaloneQuarterSymbols, value: _standaloneQuarterSymbols?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFDateFormatterShortStandaloneQuarterSymbols, value: _shortStandaloneQuarterSymbols?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFDateFormatterGregorianStartDate, value: _gregorianStartDate?._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFDateFormatterDoesRelativeDateFormattingKey, value: doesRelativeDateFormatting._cfObject)
+        // TODO: formattingContext
+        /*
+         NSFormattingContextUnknown == UDISPCTX_CAPITALIZATION_NONE
+         NSFormattingContextDynamic == UDISPCTX_CAPITALIZATION_DYNAMIC
+         NSFormattingContextStandalone == UDISPCTX_CAPITALIZATION_FOR_STANDALONE
+         NSFormattingContextListItem == UDISPCTX_CAPITALIZATION_FOR_UI_LIST_OR_MENU
+         NSFormattingContextBeginningOfSentence == UDISPCTX_CAPITALIZATION_FOR_BEGINNING_OF_SENTENCE
+         NSFormattingContextMiddleOfSentence == UDISPCTX_CAPITALIZATION_FOR_MIDDLE_OF_SENTENCE
+        */
     }
 
     internal func _setFormatterAttribute(_ formatter: CFDateFormatter, attributeName: CFString, value: AnyObject?) {


### PR DESCRIPTION
The root cause of the problem is missing logic in the CFTimeZone.c file
to handle "GMT" (no offset) as a time zone, which Darwin Foundation
handles. Also, CFLocale.c was using an empty string for the current locale, due
to not checking the AppleLocale preference. For now, we hard code en_US
as the current locale, although obviously this should be fixed to use
CFPreferences if possible.