### PR TITLE
NSKeyedArchiver, NSKeyedUnarchiver now use Any instead of AnyObject.

### DIFF
--- a/CoreFoundation/Base.subproj/ForFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForFoundationOnly.h
@@ -372,7 +372,7 @@ _CF_EXPORT_SCOPE_END
 
 // ---- Binary plist material ----------------------------------------
 _CF_EXPORT_SCOPE_BEGIN
-typedef const struct __CFKeyedArchiverUID * CFKeyedArchiverUIDRef;
+typedef const struct CF_BRIDGED_TYPE(_NSKeyedArchiverUID) __CFKeyedArchiverUID * CFKeyedArchiverUIDRef;
 CF_EXPORT CFTypeID _CFKeyedArchiverUIDGetTypeID(void);
 CF_EXPORT CFKeyedArchiverUIDRef _CFKeyedArchiverUIDCreate(CFAllocatorRef allocator, uint32_t value);
 CF_EXPORT uint32_t _CFKeyedArchiverUIDGetValue(CFKeyedArchiverUIDRef uid);

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -306,6 +306,7 @@
 		E1A03F361C4828650023AF4D /* PropertyList-1.0.dtd in Resources */ = {isa = PBXBuildFile; fileRef = E1A03F351C4828650023AF4D /* PropertyList-1.0.dtd */; };
 		E1A03F381C482C730023AF4D /* NSXMLDTDTestData.xml in Resources */ = {isa = PBXBuildFile; fileRef = E1A03F371C482C730023AF4D /* NSXMLDTDTestData.xml */; };
 		E1A3726F1C31EBFB0023AF4D /* NSXMLDocumentTestData.xml in Resources */ = {isa = PBXBuildFile; fileRef = E1A3726E1C31EBFB0023AF4D /* NSXMLDocumentTestData.xml */; };
+		EA418C261D57257D005EAD0D /* NSKeyedArchiverHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA418C251D57257D005EAD0D /* NSKeyedArchiverHelpers.swift */; };
 		EA66F6361BEED03E00136161 /* TargetConditionals.h in Headers */ = {isa = PBXBuildFile; fileRef = EA66F6351BEED03E00136161 /* TargetConditionals.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA66F6481BF1619600136161 /* NSURLTestData.plist in Resources */ = {isa = PBXBuildFile; fileRef = EA66F63B1BF1619600136161 /* NSURLTestData.plist */; };
 		EA66F6671BF2F2F100136161 /* CoreFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = EA66F6651BF2F2E800136161 /* CoreFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -723,6 +724,7 @@
 		EA313DFD1BE7F2E90060A403 /* CFURLComponents_URIParser.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFURLComponents_URIParser.c; sourceTree = "<group>"; };
 		EA313DFE1BE7F2E90060A403 /* CFURLComponents.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFURLComponents.c; sourceTree = "<group>"; };
 		EA313DFF1BE7F2E90060A403 /* CFURLComponents.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFURLComponents.h; sourceTree = "<group>"; };
+		EA418C251D57257D005EAD0D /* NSKeyedArchiverHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSKeyedArchiverHelpers.swift; sourceTree = "<group>"; };
 		EA66F6351BEED03E00136161 /* TargetConditionals.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TargetConditionals.h; path = CoreFoundation/Base.subproj/SwiftRuntime/TargetConditionals.h; sourceTree = SOURCE_ROOT; };
 		EA66F6381BF1619600136161 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		EA66F63B1BF1619600136161 /* NSURLTestData.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = NSURLTestData.plist; sourceTree = "<group>"; };
@@ -1418,6 +1420,7 @@
 				EADE0B651BD15DFF00C49C64 /* NSKeyedArchiver.swift */,
 				D3BCEB9F1C2F6DDB00295652 /* NSKeyedCoderOldStyleArray.swift */,
 				D39A14001C2D6E0A00295652 /* NSKeyedUnarchiver.swift */,
+				EA418C251D57257D005EAD0D /* NSKeyedArchiverHelpers.swift */,
 				5BDC3F321BCC5DCB00ED97BB /* NSCoder.swift */,
 				5BDC3F421BCC5DCB00ED97BB /* NSPropertyList.swift */,
 			);
@@ -1954,6 +1957,7 @@
 				EADE0BC71BD15E0000C49C64 /* NSXMLDocument.swift in Sources */,
 				5BDC3FCE1BCF17D300ED97BB /* NSCFDictionary.swift in Sources */,
 				EADE0BA81BD15E0000C49C64 /* NSNotificationQueue.swift in Sources */,
+				EA418C261D57257D005EAD0D /* NSKeyedArchiverHelpers.swift in Sources */,
 				EADE0B981BD15DFF00C49C64 /* NSDecimalNumber.swift in Sources */,
 				5BA9BEA61CF3D747009DBD6C /* Data.swift in Sources */,
 				5BF7AEA71BCD51F9008F214A /* NSCoder.swift in Sources */,

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -74,19 +74,20 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
             }
             let objects = UnsafeMutablePointer<AnyObject?>.allocate(capacity: Int(cnt))
             for idx in 0..<cnt {
-                objects.advanced(by: Int(idx)).initialize(to: aDecoder.decodeObject())
+                // If conversion to NSObject fails then we really can't hold it anyway
+                objects.advanced(by: Int(idx)).initialize(to: aDecoder.decodeObject() as! NSObject)
             }
             self.init(objects: UnsafePointer<AnyObject?>(objects), count: Int(cnt))
             objects.deinitialize(count: Int(cnt))
             objects.deallocate(capacity: Int(cnt))
         } else if type(of: aDecoder) == NSKeyedUnarchiver.self || aDecoder.containsValue(forKey: "NS.objects") {
             let objects = aDecoder._decodeArrayOfObjectsForKey("NS.objects")
-            self.init(array: objects)
+            self.init(array: objects as! [NSObject])
         } else {
             var objects = [AnyObject]()
             var count = 0
             while let object = aDecoder.decodeObject(forKey: "NS.object.\(count)") {
-                objects.append(object)
+                objects.append(object as! NSObject)
                 count += 1
             }
             self.init(array: objects)

--- a/Foundation/NSCoder.swift
+++ b/Foundation/NSCoder.swift
@@ -61,15 +61,15 @@ open class NSCoder : NSObject {
         be casted to NSObject, nor is it Hashable.
      */
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation
-    open func decodeObjectOfClasses(_ classes: [AnyClass], forKey key: String) -> AnyObject? {
+    open func decodeObjectOfClasses(_ classes: [AnyClass], forKey key: String) -> Any? {
         NSUnimplemented()
     }
     
-    open func decodeTopLevelObject() throws -> AnyObject? {
+    open func decodeTopLevelObject() throws -> Any? {
         NSUnimplemented()
     }
     
-    open func decodeTopLevelObjectForKey(_ key: String) throws -> AnyObject? {
+    open func decodeTopLevelObjectForKey(_ key: String) throws -> Any? {
         NSUnimplemented()
     }
     
@@ -88,7 +88,7 @@ open class NSCoder : NSObject {
      be casted to NSObject, nor is it Hashable.
      */
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation
-    open func decodeTopLevelObjectOfClasses(_ classes: [AnyClass], forKey key: String) throws -> AnyObject? {
+    open func decodeTopLevelObjectOfClasses(_ classes: [AnyClass], forKey key: String) throws -> Any? {
         NSUnimplemented()
     }
     
@@ -97,26 +97,26 @@ open class NSCoder : NSObject {
     }
     
     
-    open func encode(_ object: AnyObject?) {
+    open func encode(_ object: Any?) {
         var object = object
-        withUnsafePointer(to: &object) { (ptr: UnsafePointer<AnyObject?>) -> Void in
+        withUnsafePointer(to: &object) { (ptr: UnsafePointer<Any?>) -> Void in
             encodeValue(ofObjCType: "@", at: unsafeBitCast(ptr, to: UnsafeRawPointer.self))
         }
     }
     
-    open func encodeRootObject(_ rootObject: AnyObject) {
+    open func encodeRootObject(_ rootObject: Any) {
         encode(rootObject)
     }
     
-    open func encodeBycopyObject(_ anObject: AnyObject?) {
+    open func encodeBycopyObject(_ anObject: Any?) {
         encode(anObject)
     }
     
-    open func encodeByrefObject(_ anObject: AnyObject?) {
+    open func encodeByrefObject(_ anObject: Any?) {
         encode(anObject)
     }
     
-    open func encodeConditionalObject(_ object: AnyObject?) {
+    open func encodeConditionalObject(_ object: Any?) {
         encode(object)
     }
     
@@ -135,13 +135,13 @@ open class NSCoder : NSObject {
         }
     }
     
-    open func decodeObject() -> AnyObject? {
+    open func decodeObject() -> Any? {
         if self.error != nil {
             return nil
         }
         
-        var obj: AnyObject? = nil
-        withUnsafeMutablePointer(to: &obj) { (ptr: UnsafeMutablePointer<AnyObject?>) -> Void in
+        var obj: Any? = nil
+        withUnsafeMutablePointer(to: &obj) { (ptr: UnsafeMutablePointer<Any?>) -> Void in
             decodeValue(ofObjCType: "@", at: unsafeBitCast(ptr, to: UnsafeMutableRawPointer.self))
         }
         return obj
@@ -167,11 +167,11 @@ open class NSCoder : NSObject {
     }
     */
     
-    open func encodePropertyList(_ aPropertyList: AnyObject) {
+    open func encodePropertyList(_ aPropertyList: Any) {
         NSUnimplemented()
     }
     
-    open func decodePropertyList() -> AnyObject? {
+    open func decodePropertyList() -> Any? {
         NSUnimplemented()
     }
     
@@ -183,11 +183,11 @@ open class NSCoder : NSObject {
         return false
     }
     
-    open func encode(_ objv: AnyObject?, forKey key: String) {
+    open func encode(_ objv: Any?, forKey key: String) {
         NSRequiresConcreteImplementation()
     }
     
-    open func encodeConditionalObject(_ objv: AnyObject?, forKey key: String) {
+    open func encodeConditionalObject(_ objv: Any?, forKey key: String) {
         NSRequiresConcreteImplementation()
     }
     
@@ -219,7 +219,7 @@ open class NSCoder : NSObject {
         NSRequiresConcreteImplementation()
     }
     
-    open func decodeObject(forKey key: String) -> AnyObject? {
+    open func decodeObject(forKey key: String) -> Any? {
         NSRequiresConcreteImplementation()
     }
     
@@ -266,7 +266,7 @@ open class NSCoder : NSObject {
         return false
     }
     
-    open func decodePropertyListForKey(_ key: String) -> AnyObject? {
+    open func decodePropertyListForKey(_ key: String) -> Any? {
         NSUnimplemented()
     }
     
@@ -290,7 +290,7 @@ open class NSCoder : NSObject {
         }
     }
     
-    internal func _decodeArrayOfObjectsForKey(_ key: String) -> [AnyObject] {
+    internal func _decodeArrayOfObjectsForKey(_ key: String) -> [Any] {
         NSRequiresConcreteImplementation()
     }
     

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -132,7 +132,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
             let objects = UnsafeMutablePointer<AnyObject>.allocate(capacity: Int(cnt))
             for idx in 0..<cnt {
                 keys.advanced(by: Int(idx)).initialize(to: aDecoder.decodeObject()! as! NSObject)
-                objects.advanced(by: Int(idx)).initialize(to: aDecoder.decodeObject()!)
+                objects.advanced(by: Int(idx)).initialize(to: aDecoder.decodeObject()! as! NSObject)
             }
             self.init(objects: UnsafePointer<AnyObject>(objects), forKeys: UnsafePointer<NSObject>(keys), count: Int(cnt))
             keys.deinitialize(count: Int(cnt))
@@ -143,7 +143,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         } else if type(of: aDecoder) == NSKeyedUnarchiver.self || aDecoder.containsValue(forKey: "NS.objects") {
             let keys = aDecoder._decodeArrayOfObjectsForKey("NS.keys").map() { return $0 as! NSObject }
             let objects = aDecoder._decodeArrayOfObjectsForKey("NS.objects")
-            self.init(objects: objects, forKeys: keys)
+            self.init(objects: objects as! [NSObject], forKeys: keys)
         } else {
             var objects = [AnyObject]()
             var keys = [NSObject]()
@@ -151,7 +151,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
             while let key = aDecoder.decodeObject(forKey: "NS.key.\(count)"),
                 let object = aDecoder.decodeObject(forKey: "NS.object.\(count)") {
                     keys.append(key as! NSObject)
-                    objects.append(object)
+                    objects.append(object as! NSObject)
                     count += 1
             }
             self.init(objects: objects, forKeys: keys)

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -12,19 +12,10 @@ import CoreFoundation
 // Archives created using the class method archivedRootDataWithObject used this key for the root object in the hierarchy of encoded objects. The NSKeyedUnarchiver class method unarchiveObjectWithData: will look for this root key as well. You can also use it as the key for the root object in your own archives.
 public let NSKeyedArchiveRootObjectKey: String = "root"
 
-typealias CFKeyedArchiverUID = CFTypeRef
-
-internal let NSKeyedArchiveNullObjectReference = NSKeyedArchiver._createObjectRef(0)
+internal let NSKeyedArchiveNullObjectReference = _NSKeyedArchiverUID(value: 0)
 internal let NSKeyedArchiveNullObjectReferenceName: String = "$null"
 internal let NSKeyedArchivePlistVersion = 100000
 internal let NSKeyedArchiverSystemVersion : UInt32 = 2000
-
-internal func objectRefGetValue(_ objectRef : CFKeyedArchiverUID) -> UInt32 {
-    assert(type(of: objectRef) == __NSCFType.self)
-    assert(CFGetTypeID(objectRef) == _CFKeyedArchiverUIDGetTypeID())
-
-    return _CFKeyedArchiverUIDGetValue(unsafeBitCast(objectRef, to: CFKeyedArchiverUIDRef.self))
-}
 
 internal func escapeArchiverKey(_ key: String) -> String {
     if key.hasPrefix("$") {
@@ -61,12 +52,14 @@ internal struct NSUniqueObject : Hashable {
         }
     }
     
-    init(_ object: AnyObject) {
+    init(_ object: Any) {
         // FIXME can't we check for Hashable directly?
         if let ns = object as? NSObject {
             self.init(hashableObject: ns)
+        } else if let ah = object as? AnyHashable {
+            self.init(hashableObject: ah)
         } else {
-            self.init(hashableObject: ObjectIdentifier(object))
+            fatalError("Non-object, non-hashable type used as key")
         }
     }
     
@@ -107,10 +100,10 @@ open class NSKeyedArchiver : NSCoder {
     private var _containers : Array<EncodingContext> = [EncodingContext()]
     private var _objects : Array<Any> = [NSKeyedArchiveNullObjectReferenceName]
     private var _objRefMap : Dictionary<NSUniqueObject, UInt32> = [:]
-    private var _replacementMap : Dictionary<NSUniqueObject, AnyObject> = [:]
+    private var _replacementMap : Dictionary<NSUniqueObject, Any> = [:]
     private var _classNameMap : Dictionary<String, String> = [:]
-    private var _classes : Dictionary<String, CFKeyedArchiverUID> = [:]
-    private var _cache : Array<CFKeyedArchiverUID> = []
+    private var _classes : Dictionary<String, _NSKeyedArchiverUID> = [:]
+    private var _cache : Array<_NSKeyedArchiverUID> = []
 
     open weak var delegate: NSKeyedArchiverDelegate?
     open var outputFormat = PropertyListSerialization.PropertyListFormat.binary {
@@ -122,7 +115,7 @@ open class NSKeyedArchiver : NSCoder {
         }
     }
     
-    open class func archivedData(withRootObject rootObject: AnyObject) -> Data {
+    open class func archivedData(withRootObject rootObject: Any) -> Data {
         let data = NSMutableData()
         let keyedArchiver = NSKeyedArchiver(forWritingWith: data)
         
@@ -132,7 +125,7 @@ open class NSKeyedArchiver : NSCoder {
         return data._swiftObject
     }
     
-    open class func archiveRootObject(_ rootObject: AnyObject, toFile path: String) -> Bool {
+    open class func archiveRootObject(_ rootObject: Any, toFile path: String) -> Bool {
         var fd : Int32 = -1
         var auxFilePath : String
         var finishedEncoding : Bool = false
@@ -265,7 +258,7 @@ open class NSKeyedArchiver : NSCoder {
         return true
     }
     
-    private class func _supportsSecureCoding(_ objv : AnyObject?) -> Bool {
+    private class func _supportsSecureCoding(_ objv : Any?) -> Bool {
         var supportsSecureCoding : Bool = false
         
         if let secureCodable = objv as? NSSecureCoding {
@@ -275,7 +268,7 @@ open class NSKeyedArchiver : NSCoder {
         return supportsSecureCoding
     }
     
-    private func _validateObjectSupportsSecureCoding(_ objv : AnyObject?) {
+    private func _validateObjectSupportsSecureCoding(_ objv : Any?) {
         if objv != nil &&
             self.requiresSecureCoding &&
             !NSKeyedArchiver._supportsSecureCoding(objv) {
@@ -283,18 +276,13 @@ open class NSKeyedArchiver : NSCoder {
         }
     }
     
-    fileprivate static func _createObjectRef(_ uid : UInt32) -> CFKeyedArchiverUID {
-        return Unmanaged<CFKeyedArchiverUID>.fromOpaque(
-            UnsafeRawPointer(_CFKeyedArchiverUIDCreate(kCFAllocatorSystemDefault, uid))).takeUnretainedValue()
-    }
-    
-    private func _createObjectRefCached(_ uid : UInt32) -> CFKeyedArchiverUID {
+    private func _createObjectRefCached(_ uid : UInt32) -> _NSKeyedArchiverUID {
         if uid == 0 {
             return NSKeyedArchiveNullObjectReference
         } else if Int(uid) <= self._cache.count {
             return self._cache[Int(uid) - 1]
         } else {
-            let objectRef = NSKeyedArchiver._createObjectRef(uid)
+            let objectRef = _NSKeyedArchiverUID(value: uid)
             self._cache.insert(objectRef, at: Int(uid) - 1)
             return objectRef
         }
@@ -304,7 +292,7 @@ open class NSKeyedArchiver : NSCoder {
         Return a new object identifier, freshly allocated if need be. A placeholder null
         object is associated with the reference.
      */
-    private func _referenceObject(_ objv: AnyObject?, conditional: Bool = false) -> CFKeyedArchiverUID? {
+    private func _referenceObject(_ objv: Any?, conditional: Bool = false) -> _NSKeyedArchiverUID? {
         var uid : UInt32?
         
         if objv == nil {
@@ -331,7 +319,7 @@ open class NSKeyedArchiver : NSCoder {
     /**
         Returns true if the object has already been encoded.
      */ 
-    private func _haveVisited(_ objv: AnyObject?) -> Bool {
+    private func _haveVisited(_ objv: Any?) -> Bool {
         if objv == nil {
             return true // always have a null reference
         } else {
@@ -344,7 +332,7 @@ open class NSKeyedArchiver : NSCoder {
     /**
         Get or create an object reference, and associate the object.
      */
-    private func _addObject(_ objv: AnyObject?) -> CFKeyedArchiverUID? {
+    private func _addObject(_ objv: Any?) -> _NSKeyedArchiverUID? {
         let haveVisited = _haveVisited(objv)
         let objectRef = _referenceObject(objv)
         
@@ -370,7 +358,7 @@ open class NSKeyedArchiver : NSCoder {
     /**
         Associate an encoded object or reference with a key in the current encoding context
      */
-    private func _setObjectInCurrentEncodingContext(_ object : AnyObject?, forKey key: String? = nil, escape: Bool = true) {
+    private func _setObjectInCurrentEncodingContext(_ object : Any?, forKey key: String? = nil, escape: Bool = true) {
         let encodingContext = self._containers.last!
         var encodingKey : String
  
@@ -404,7 +392,7 @@ open class NSKeyedArchiver : NSCoder {
     /**
         Update replacement object mapping
      */
-    private func replaceObject(_ object: AnyObject, withObject replacement: AnyObject?) {
+    private func replaceObject(_ object: Any, withObject replacement: Any?) {
         let oid = NSUniqueObject(object)
         
         if let unwrappedDelegate = self.delegate {
@@ -417,23 +405,20 @@ open class NSKeyedArchiver : NSCoder {
     /**
         Returns true if the type cannot be encoded directly (i.e. is a container type)
      */
-    private func _isContainer(_ objv: AnyObject?) -> Bool {
+    private func _isContainer(_ objv: Any?) -> Bool {
         // Note that we check for class equality rather than membership, because
         // their mutable subclasses are as object references
-        let valueType = (objv == nil ||
-                         objv is String ||
-                         type(of: objv!) === NSString.self ||
-                         type(of: objv!) === NSNumber.self ||
-                         type(of: objv!) === NSData.self)
-        
-        return !valueType
+        guard let obj = objv else { return false }
+        if obj is String { return false }
+        guard let nsObject = obj as? NSObject else { return true }
+        return !(type(of: nsObject) === NSString.self || type(of: nsObject) === NSNumber.self || type(of: nsObject) === NSData.self)
     }
    
     /**
         Associates an object with an existing reference
      */ 
-    private func _setObject(_ objv: Any, forReference reference : CFKeyedArchiverUID) {
-        let index = Int(objectRefGetValue(reference))
+    private func _setObject(_ objv: Any, forReference reference : _NSKeyedArchiverUID) {
+        let index = Int(reference.value)
         self._objects[index] = objv
     }
     
@@ -491,7 +476,7 @@ open class NSKeyedArchiver : NSCoder {
         different), we maintain a private mapping between class name and
         object reference to avoid redundantly encoding class metadata
      */
-    private func _classReference(_ clsv: AnyClass) -> CFKeyedArchiverUID? {
+    private func _classReference(_ clsv: AnyClass) -> _NSKeyedArchiverUID? {
         let className = NSStringFromClass(clsv)
         var classRef = self._classes[className] // keyed by actual class name
         
@@ -510,8 +495,8 @@ open class NSKeyedArchiver : NSCoder {
     /**
         Return the object replacing another object (if any)
      */
-    private func _replacementObject(_ object: AnyObject?) -> AnyObject? {
-        var objectToEncode : AnyObject? = nil // object to encode after substitution
+    private func _replacementObject(_ object: Any?) -> Any? {
+        var objectToEncode : Any? = nil // object to encode after substitution
 
         // nil cannot be mapped
         if object == nil {
@@ -551,9 +536,9 @@ open class NSKeyedArchiver : NSCoder {
     /**
         Internal function to encode an object. Returns the object reference.
      */
-    private func _encodeObject(_ objv: AnyObject?, conditional: Bool = false) -> CFKeyedArchiverUID? {
-        var object : AnyObject? = nil // object to encode after substitution
-        var objectRef : CFKeyedArchiverUID? // encoded object reference
+    private func _encodeObject(_ objv: Any?, conditional: Bool = false) -> NSObject? {
+        var object : Any? = nil // object to encode after substitution
+        var objectRef : _NSKeyedArchiverUID? // encoded object reference
         let haveVisited : Bool
 
         let _ = _validateStillEncoding()
@@ -578,18 +563,16 @@ open class NSKeyedArchiver : NSCoder {
                 }
 
                 let innerEncodingContext = EncodingContext()
-                var cls : AnyClass?
-
                 _pushEncodingContext(innerEncodingContext)
                 codable.encode(with: self)
 
-                let ns = object as? NSObject
-                cls = ns?.classForKeyedArchiver
-                if cls == nil {
-                    cls = type(of: object!)
+                guard let ns = object as? NSObject else {
+                    fatalError("Attempt to encode non-NSObject");
                 }
 
-                _setObjectInCurrentEncodingContext(_classReference(cls!), forKey: "$class", escape: false)
+                let cls : AnyClass = ns.classForKeyedArchiver ?? type(of: object) as! AnyClass
+
+                _setObjectInCurrentEncodingContext(_classReference(cls), forKey: "$class", escape: false)
                 _popEncodingContext()
                 encodedObject = innerEncodingContext.dict
             } else {
@@ -609,43 +592,43 @@ open class NSKeyedArchiver : NSCoder {
     /**
 	Encode an object and associate it with a key in the current encoding context.
      */
-    private func _encodeObject(_ objv: AnyObject?, forKey key: String?, conditional: Bool = false) {
+    private func _encodeObject(_ objv: Any?, forKey key: String?, conditional: Bool = false) {
         if let objectRef = _encodeObject(objv, conditional: conditional) {
             _setObjectInCurrentEncodingContext(objectRef, forKey: key, escape: key != nil)
         }
     }
     
-    open override func encode(_ object: AnyObject?) {
+    open override func encode(_ object: Any?) {
         _encodeObject(object, forKey: nil)
     }
     
-    open override func encodeConditionalObject(_ object: AnyObject?) {
+    open override func encodeConditionalObject(_ object: Any?) {
         _encodeObject(object, forKey: nil, conditional: true)
     }
 
-    open override func encode(_ objv: AnyObject?, forKey key: String) {
+    open override func encode(_ objv: Any?, forKey key: String) {
         _encodeObject(objv, forKey: key, conditional: false)
     }
     
-    open override func encodeConditionalObject(_ objv: AnyObject?, forKey key: String) {
+    open override func encodeConditionalObject(_ objv: Any?, forKey key: String) {
         _encodeObject(objv, forKey: key, conditional: true)
     }
     
-    open override func encodePropertyList(_ aPropertyList: AnyObject) {
+    open override func encodePropertyList(_ aPropertyList: Any) {
         if !NSPropertyListClasses.contains(where: { $0 == type(of: aPropertyList) }) {
             fatalError("Cannot encode non-property list type \(type(of: aPropertyList)) as property list")
         }
         encode(aPropertyList)
     }
     
-    open func encodePropertyList(_ aPropertyList: AnyObject, forKey key: String) {
+    open func encodePropertyList(_ aPropertyList: Any, forKey key: String) {
         if !NSPropertyListClasses.contains(where: { $0 == type(of: aPropertyList) }) {
             fatalError("Cannot encode non-property list type \(type(of: aPropertyList)) as property list")
         }
         encode(aPropertyList, forKey: key)
     }
 
-    open func _encodePropertyList(_ aPropertyList: AnyObject, forKey key: String? = nil) {
+    open func _encodePropertyList(_ aPropertyList: Any, forKey key: String? = nil) {
         let _ = _validateStillEncoding()
         _setObjectInCurrentEncodingContext(aPropertyList, forKey: key)
     }
@@ -657,7 +640,7 @@ open class NSKeyedArchiver : NSCoder {
     private func _encodeValueOfObjCType(_ type: _NSSimpleObjCType, at addr: UnsafeRawPointer) {
         switch type {
         case .ID:
-            let objectp = unsafeBitCast(addr, to: UnsafePointer<AnyObject>.self)
+            let objectp = unsafeBitCast(addr, to: UnsafePointer<Any>.self)
             encode(objectp.pointee)
             break
         case .Class:
@@ -779,7 +762,7 @@ open class NSKeyedArchiver : NSCoder {
         creating references as it goes
      */ 
     internal func _encodeArrayOfObjects(_ objects : NSArray, forKey key : String) {
-        var objectRefs = [CFKeyedArchiverUID]()
+        var objectRefs = [NSObject]()
         
         objectRefs.reserveCapacity(objects.count)
         
@@ -833,14 +816,14 @@ open class NSKeyedArchiver : NSCoder {
 }
 
 extension NSKeyedArchiverDelegate {
-    func archiver(_ archiver: NSKeyedArchiver, willEncode object: AnyObject) -> AnyObject? {
+    func archiver(_ archiver: NSKeyedArchiver, willEncode object: Any) -> Any? {
         // Returning the same object is the same as doing nothing
         return object
     }
     
-    func archiver(_ archiver: NSKeyedArchiver, didEncode object: AnyObject?) { }
+    func archiver(_ archiver: NSKeyedArchiver, didEncode object: Any?) { }
 
-    func archiver(_ archiver: NSKeyedArchiver, willReplace object: AnyObject?, with newObject: AnyObject?) { }
+    func archiver(_ archiver: NSKeyedArchiver, willReplace object: Any?, with newObject: Any?) { }
 
     func archiverWillFinish(_ archiver: NSKeyedArchiver) { }
 
@@ -859,19 +842,19 @@ public protocol NSKeyedArchiverDelegate : class {
     // setup for that object (either explicitly, or because the object has previously
     // been encoded).  This is also not called when nil is about to be encoded.
     // This method is called whether or not the object is being encoded conditionally.
-    func archiver(_ archiver: NSKeyedArchiver, willEncode object: AnyObject) -> AnyObject?
+    func archiver(_ archiver: NSKeyedArchiver, willEncode object: Any) -> Any?
     
     // Informs the delegate that the given object has been encoded.  The delegate
     // might restore some state it had fiddled previously, or use this to keep
     // track of the objects which are encoded.  The object may be nil.  Not called
     // for conditional objects until they are really encoded (if ever).
-    func archiver(_ archiver: NSKeyedArchiver, didEncode object: AnyObject?)
+    func archiver(_ archiver: NSKeyedArchiver, didEncode object: Any?)
     
     // Informs the delegate that the newObject is being substituted for the
     // object. This is also called when the delegate itself is doing/has done
     // the substitution. The delegate may use this method if it is keeping track
     // of the encoded or decoded objects.
-    func archiver(_ archiver: NSKeyedArchiver, willReplace object: AnyObject?, withObject newObject: AnyObject?)
+    func archiver(_ archiver: NSKeyedArchiver, willReplace object: Any?, withObject newObject: Any?)
     
     // Notifies the delegate that encoding is about to finish.
     func archiverWillFinish(_ archiver: NSKeyedArchiver)

--- a/Foundation/NSKeyedArchiverHelpers.swift
+++ b/Foundation/NSKeyedArchiverHelpers.swift
@@ -1,0 +1,47 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+import CoreFoundation
+
+extension CFKeyedArchiverUIDRef : _NSBridgable {
+    typealias NSType = _NSKeyedArchiverUID
+    
+    internal var _nsObject: NSType { return unsafeBitCast(self, to: NSType.self) }
+}
+
+internal class _NSKeyedArchiverUID : NSObject {
+    typealias CFType = CFURL
+    internal var _base = _CFInfo(typeID: _CFKeyedArchiverUIDGetTypeID())
+    internal var value : UInt32 = 0
+    
+    internal var _cfObject : CFType {
+        return unsafeBitCast(self, to: CFType.self)
+    }
+    
+    override open var _cfTypeID: CFTypeID {
+        return _CFKeyedArchiverUIDGetTypeID()
+    }
+
+    open override var hash: Int {
+        return Int(bitPattern: CFHash(_cfObject))
+    }
+    
+    open override func isEqual(_ object: AnyObject?) -> Bool {
+        // no need to compare these?
+        return false
+    }
+    
+    init(value : UInt32) {
+        self.value = value
+    }
+    
+    deinit {
+        _CFDeinit(self)
+    }
+}

--- a/Foundation/NSKeyedArchiverHelpers.swift
+++ b/Foundation/NSKeyedArchiverHelpers.swift
@@ -9,14 +9,14 @@
 
 import CoreFoundation
 
-extension CFKeyedArchiverUIDRef : _NSBridgable {
+extension CFKeyedArchiverUID : _NSBridgable {
     typealias NSType = _NSKeyedArchiverUID
     
     internal var _nsObject: NSType { return unsafeBitCast(self, to: NSType.self) }
 }
 
 internal class _NSKeyedArchiverUID : NSObject {
-    typealias CFType = CFURL
+    typealias CFType = CFKeyedArchiverUID
     internal var _base = _CFInfo(typeID: _CFKeyedArchiverUIDGetTypeID())
     internal var value : UInt32 = 0
     
@@ -29,7 +29,7 @@ internal class _NSKeyedArchiverUID : NSObject {
     }
 
     open override var hash: Int {
-        return Int(bitPattern: CFHash(_cfObject))
+        return Int(bitPattern: CFHash(_cfObject as CFTypeRef!))
     }
     
     open override func isEqual(_ object: AnyObject?) -> Bool {

--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -53,14 +53,14 @@ open class NSNotification: NSObject, NSCopying, NSCoding {
             }
             let object = aDecoder.decodeObject(forKey: "NS.object")
 //            let userInfo = aDecoder.decodeObjectOfClass(NSDictionary.self, forKey: "NS.userinfo")
-            self.init(name: Name(rawValue: name.bridge()), object: object, userInfo: nil)
+            self.init(name: Name(rawValue: name.bridge()), object: object as! NSObject, userInfo: nil)
         } else {
             guard let name = aDecoder.decodeObject() as? NSString else {
                 return nil
             }
             let object = aDecoder.decodeObject()
 //            let userInfo = aDecoder.decodeObject() as? NSDictionary
-            self.init(name: Name(rawValue: name.bridge()), object: object, userInfo: nil)
+            self.init(name: Name(rawValue: name.bridge()), object: object as! NSObject, userInfo: nil)
         }
     }
     

--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -58,7 +58,7 @@ open class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
                 guard let object = aDecoder.decodeObject(forKey: "NS.object.\(idx)") else {
                     return nil
                 }
-                objects.append(object)
+                objects.append(object as! NSObject)
                 idx += 1
             }
             self.init(array: objects)

--- a/Foundation/NSPropertyList.swift
+++ b/Foundation/NSPropertyList.swift
@@ -140,12 +140,12 @@ internal func _expensivePropertyListConversion(_ input : AnyObject) -> Any {
         return data._swiftObject
     } else if let number = input as? NSNumber {
         return number
+    } else if let keyedArchiverUID = input as? _NSKeyedArchiverUID {
+        return keyedArchiverUID
     } else if input === kCFBooleanTrue {
         return true
     } else if input === kCFBooleanFalse {
         return false
-    } else if input is __NSCFType && CFGetTypeID(input) == _CFKeyedArchiverUIDGetTypeID() {
-        return input
     } else {
         fatalError("Attempt to convert a non-plist type \(type(of: input))")
     }

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -124,19 +124,19 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
             }
             let objects = UnsafeMutablePointer<AnyObject?>.allocate(capacity: Int(cnt))
             for idx in 0..<cnt {
-                objects.advanced(by: Int(idx)).initialize(to: aDecoder.decodeObject())
+                objects.advanced(by: Int(idx)).initialize(to: aDecoder.decodeObject() as! NSObject)
             }
             self.init(objects: UnsafePointer<AnyObject?>(objects), count: Int(cnt))
             objects.deinitialize(count: Int(cnt))
             objects.deallocate(capacity: Int(cnt))
         } else if type(of: aDecoder) == NSKeyedUnarchiver.self || aDecoder.containsValue(forKey: "NS.objects") {
             let objects = aDecoder._decodeArrayOfObjectsForKey("NS.objects")
-            self.init(array: objects)
+            self.init(array: objects as! [NSObject])
         } else {
             var objects = [AnyObject]()
             var count = 0
             while let object = aDecoder.decodeObject(forKey: "NS.object.\(count)") {
-                objects.append(object)
+                objects.append(object as! NSObject)
                 count += 1
             }
             self.init(array: objects)

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -89,6 +89,7 @@ internal func __CFInitializeSwift() {
     _CFRuntimeBridgeTypeToClass(CFLocaleGetTypeID(), unsafeBitCast(NSLocale.self, to: UnsafeRawPointer.self))
     _CFRuntimeBridgeTypeToClass(CFTimeZoneGetTypeID(), unsafeBitCast(NSTimeZone.self, to: UnsafeRawPointer.self))
     _CFRuntimeBridgeTypeToClass(CFCharacterSetGetTypeID(), unsafeBitCast(_NSCFCharacterSet.self, to: UnsafeRawPointer.self))
+    _CFRuntimeBridgeTypeToClass(_CFKeyedArchiverUIDGetTypeID(), unsafeBitCast(_NSKeyedArchiverUID.self, to: UnsafeRawPointer.self))
     
 //    _CFRuntimeBridgeTypeToClass(CFErrorGetTypeID(), unsafeBitCast(NSError.self, UnsafeRawPointer.self))
 //    _CFRuntimeBridgeTypeToClass(CFAttributedStringGetTypeID(), unsafeBitCast(NSMutableAttributedString.self, UnsafeRawPointer.self))

--- a/build.py
+++ b/build.py
@@ -322,6 +322,7 @@ swift_sources = CompileSwiftSources([
 	'Foundation/NSJSONSerialization.swift',
 	'Foundation/NSKeyedCoderOldStyleArray.swift',
 	'Foundation/NSKeyedArchiver.swift',
+	'Foundation/NSKeyedArchiverHelpers.swift',
 	'Foundation/NSKeyedUnarchiver.swift',
 	'Foundation/NSLengthFormatter.swift',
 	'Foundation/NSLocale.swift',


### PR DESCRIPTION
This also contains another kind of fix for the NSKeyedArchiver tests for macOS, which were failing because of assumptions made in the implementation about AnyObject. To help reduce the amount of casting in the implementation, this commit adds a private NS "toll free bridged" type for the private
CF type used as a keyed archiver UID in CFPropertyList.