### PR TITLE
Foundation API Conformance Update: Decimal/NSDecimalNumber

### DIFF
--- a/Foundation/NSDecimal.swift
+++ b/Foundation/NSDecimal.swift
@@ -7,35 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-// Rounding policies :
-// Original
-//    value 1.2  1.21  1.25  1.35  1.27
-// Plain    1.2  1.2   1.3   1.4   1.3
-// Down     1.2  1.2   1.2   1.3   1.2
-// Up       1.2  1.3   1.3   1.4   1.3
-// Bankers  1.2  1.2   1.2   1.4   1.3
-
-/***************	Type definitions		***********/
-extension Decimal {
-    public enum RoundingMode : UInt {
-        
-        case roundPlain // Round up on a tie
-        case roundDown // Always down == truncate
-        case roundUp // Always up
-        case roundBankers // on a tie round so last digit is even
-    }
-
-    public enum CalculationError : UInt {
-        
-        case noError
-        case lossOfPrecision // Result lost precision
-        case underflow // Result became 0
-        case overflow // Result exceeds possible representation
-        case divideByZero
-    }
-
-}
 public var NSDecimalMaxSize: Int32 { NSUnimplemented() }
 // Give a precision of at least 38 decimal digits, 128 binary positions.
 
@@ -52,6 +23,97 @@ public struct Decimal {
     public init(_exponent: Int32, _length: UInt32, _isNegative: UInt32, _isCompact: UInt32, _reserved: UInt32, _mantissa: (UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16)){ NSUnimplemented() }
 }
 
+extension Decimal {
+    // These will need to be `let`s when implemented for Foundation API compatibility
+    public static var leastFiniteMagnitude: Decimal { NSUnimplemented() }
+    public static var greatestFiniteMagnitude: Decimal { NSUnimplemented() }
+    public static var leastNormalMagnitude: Decimal { NSUnimplemented() }
+    public static var leastNonzeroMagnitude: Decimal { NSUnimplemented() }
+    public static var pi: Decimal { NSUnimplemented() }
+    public var exponent: Int { NSUnimplemented() }
+    public var significand: Decimal { NSUnimplemented() }
+    public init(sign: FloatingPointSign, exponent: Int, significand: Decimal) { NSUnimplemented() }
+    public init(signOf: Decimal, magnitudeOf magnitude: Decimal) { NSUnimplemented() }
+    public var sign: FloatingPointSign { NSUnimplemented() }
+    public static var radix: Int { NSUnimplemented() }
+    public var ulp: Decimal { NSUnimplemented() }
+    public mutating func add(_ other: Decimal) { NSUnimplemented() }
+    public mutating func subtract(_ other: Decimal) { NSUnimplemented() }
+    public mutating func multiply(by other: Decimal) { NSUnimplemented() }
+    public mutating func divide(by other: Decimal) { NSUnimplemented() }
+    public mutating func negate() { NSUnimplemented() }
+    public func isEqual(to other: Decimal) -> Bool { NSUnimplemented() }
+    public func isLess(than other: Decimal) -> Bool { NSUnimplemented() }
+    public func isLessThanOrEqualTo(_ other: Decimal) -> Bool { NSUnimplemented() }
+    public func isTotallyOrdered(belowOrEqualTo other: Decimal) -> Bool { NSUnimplemented() }
+    public var isCanonical: Bool { NSUnimplemented() }
+    public var nextUp: Decimal { NSUnimplemented() }
+    public var nextDown: Decimal { NSUnimplemented() }
+    public static func +(lhs: Decimal, rhs: Decimal) -> Decimal { NSUnimplemented() }
+    public static func -(lhs: Decimal, rhs: Decimal) -> Decimal { NSUnimplemented() }
+    public static func /(lhs: Decimal, rhs: Decimal) -> Decimal { NSUnimplemented() }
+    public static func *(lhs: Decimal, rhs: Decimal) -> Decimal { NSUnimplemented() }
+}
+
+extension Decimal : Hashable, Comparable {
+    public var hashValue: Int { NSUnimplemented() }
+    public static func ==(lhs: Decimal, rhs: Decimal) -> Bool { NSUnimplemented() }
+    public static func <(lhs: Decimal, rhs: Decimal) -> Bool { NSUnimplemented() }
+}
+
+extension Decimal : ExpressibleByFloatLiteral {
+    public init(floatLiteral value: Double) { NSUnimplemented() }
+}
+
+extension Decimal : ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int) { NSUnimplemented() }
+}
+
+extension Decimal : SignedNumber {
+}
+
+extension Decimal : Strideable {
+    public func distance(to other: Decimal) -> Decimal { NSUnimplemented() }
+    public func advanced(by n: Decimal) -> Decimal { NSUnimplemented() }
+}
+
+extension Decimal : AbsoluteValuable {
+    public static func abs(_ x: Decimal) -> Decimal { NSUnimplemented() }
+}
+
+extension Decimal {
+    public typealias RoundingMode = NSDecimalNumber.RoundingMode
+    public typealias CalculationError = NSDecimalNumber.CalculationError
+    public init(_ value: UInt8) { NSUnimplemented() }
+    public init(_ value: Int8) { NSUnimplemented() }
+    public init(_ value: UInt16) { NSUnimplemented() }
+    public init(_ value: Int16) { NSUnimplemented() }
+    public init(_ value: UInt32) { NSUnimplemented() }
+    public init(_ value: Int32) { NSUnimplemented() }
+    public init(_ value: Double) { NSUnimplemented() }
+    public init(_ value: UInt64) { NSUnimplemented() }
+    public init(_ value: Int64) { NSUnimplemented() }
+    public init(_ value: UInt) { NSUnimplemented() }
+    public init(_ value: Int) { NSUnimplemented() }
+    public var isSignalingNaN: Bool { NSUnimplemented() }
+    public static var nan: Decimal { NSUnimplemented() }
+    public static var quietNaN: Decimal { NSUnimplemented() }
+    public var floatingPointClass: FloatingPointClassification { NSUnimplemented() }
+    public var isSignMinus: Bool { NSUnimplemented() }
+    public var isNormal: Bool { NSUnimplemented() }
+    public var isFinite: Bool { NSUnimplemented() }
+    public var isZero: Bool { NSUnimplemented() }
+    public var isSubnormal: Bool { NSUnimplemented() }
+    public var isInfinite: Bool { NSUnimplemented() }
+    public var isNaN: Bool { NSUnimplemented() }
+    public var isSignaling: Bool { NSUnimplemented() }
+}
+
+extension Decimal : CustomStringConvertible {
+    public init?(string: String, locale: Locale? = nil) { NSUnimplemented() }
+    public var description: String { NSUnimplemented() }
+}
+
 public func NSDecimalIsNotANumber(_ dcm: UnsafePointer<Decimal>) -> Bool { NSUnimplemented() }
 
 
@@ -63,29 +125,28 @@ public func NSDecimalCompact(_ number: UnsafeMutablePointer<Decimal>) { NSUnimpl
 public func NSDecimalCompare(_ leftOperand: UnsafePointer<Decimal>, _ rightOperand: UnsafePointer<Decimal>) -> ComparisonResult { NSUnimplemented() }
 // NSDecimalCompare:Compares leftOperand and rightOperand.
 
-public func NSDecimalRound(_ result: UnsafeMutablePointer<Decimal>, _ number: UnsafePointer<Decimal>, _ scale: Int, _ roundingMode: Decimal.RoundingMode) { NSUnimplemented() }
+public func NSDecimalRound(_ result: UnsafeMutablePointer<Decimal>, _ number: UnsafePointer<Decimal>, _ scale: Int, _ roundingMode: NSDecimalNumber.RoundingMode) { NSUnimplemented() }
 // Rounds num to the given scale using the given mode.
 // result may be a pointer to same space as num.
 // scale indicates number of significant digits after the decimal point
 
-public func NSDecimalNormalize(_ number1: UnsafeMutablePointer<Decimal>, _ number2: UnsafeMutablePointer<Decimal>, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError { NSUnimplemented() }
+public func NSDecimalNormalize(_ number1: UnsafeMutablePointer<Decimal>, _ number2: UnsafeMutablePointer<Decimal>, _ roundingMode: NSDecimalNumber.RoundingMode) -> NSDecimalNumber.CalculationError { NSUnimplemented() }
 
-public func NSDecimalAdd(_ result: UnsafeMutablePointer<Decimal>, _ leftOperand: UnsafePointer<Decimal>, _ rightOperand: UnsafePointer<Decimal>, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError { NSUnimplemented() }
+public func NSDecimalAdd(_ result: UnsafeMutablePointer<Decimal>, _ leftOperand: UnsafePointer<Decimal>, _ rightOperand: UnsafePointer<Decimal>, _ roundingMode: NSDecimalNumber.RoundingMode) -> NSDecimalNumber.CalculationError { NSUnimplemented() }
 // Exact operations. result may be a pointer to same space as leftOperand or rightOperand
 
-public func NSDecimalSubtract(_ result: UnsafeMutablePointer<Decimal>, _ leftOperand: UnsafePointer<Decimal>, _ rightOperand: UnsafePointer<Decimal>, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError { NSUnimplemented() }
+public func NSDecimalSubtract(_ result: UnsafeMutablePointer<Decimal>, _ leftOperand: UnsafePointer<Decimal>, _ rightOperand: UnsafePointer<Decimal>, _ roundingMode: NSDecimalNumber.RoundingMode) -> NSDecimalNumber.CalculationError { NSUnimplemented() }
 // Exact operations. result may be a pointer to same space as leftOperand or rightOperand
 
-public func NSDecimalMultiply(_ result: UnsafeMutablePointer<Decimal>, _ leftOperand: UnsafePointer<Decimal>, _ rightOperand: UnsafePointer<Decimal>, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError { NSUnimplemented() }
+public func NSDecimalMultiply(_ result: UnsafeMutablePointer<Decimal>, _ leftOperand: UnsafePointer<Decimal>, _ rightOperand: UnsafePointer<Decimal>, _ roundingMode: NSDecimalNumber.RoundingMode) -> NSDecimalNumber.CalculationError { NSUnimplemented() }
 // Exact operations. result may be a pointer to same space as leftOperand or rightOperand
 
-public func NSDecimalDivide(_ result: UnsafeMutablePointer<Decimal>, _ leftOperand: UnsafePointer<Decimal>, _ rightOperand: UnsafePointer<Decimal>, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError { NSUnimplemented() }
+public func NSDecimalDivide(_ result: UnsafeMutablePointer<Decimal>, _ leftOperand: UnsafePointer<Decimal>, _ rightOperand: UnsafePointer<Decimal>, _ roundingMode: NSDecimalNumber.RoundingMode) -> NSDecimalNumber.CalculationError { NSUnimplemented() }
 // Division could be silently inexact;
 // Exact operations. result may be a pointer to same space as leftOperand or rightOperand
 
-public func NSDecimalPower(_ result: UnsafeMutablePointer<Decimal>, _ number: UnsafePointer<Decimal>, _ power: Int, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError { NSUnimplemented() }
+public func NSDecimalPower(_ result: UnsafeMutablePointer<Decimal>, _ number: UnsafePointer<Decimal>, _ power: Int, _ roundingMode: NSDecimalNumber.RoundingMode) -> NSDecimalNumber.CalculationError { NSUnimplemented() }
 
-public func NSDecimalMultiplyByPowerOf10(_ result: UnsafeMutablePointer<Decimal>, _ number: UnsafePointer<Decimal>, _ power: Int16, _ roundingMode: Decimal.RoundingMode) -> Decimal.CalculationError { NSUnimplemented() }
+public func NSDecimalMultiplyByPowerOf10(_ result: UnsafeMutablePointer<Decimal>, _ number: UnsafePointer<Decimal>, _ power: Int16, _ roundingMode: NSDecimalNumber.RoundingMode) -> NSDecimalNumber.CalculationError { NSUnimplemented() }
 
 public func NSDecimalString(_ dcm: UnsafePointer<Decimal>, _ locale: AnyObject?) -> String { NSUnimplemented() }
-

--- a/Foundation/NSDecimalNumber.swift
+++ b/Foundation/NSDecimalNumber.swift
@@ -9,19 +9,68 @@
 
 
 /***************	Exceptions		***********/
-public let NSDecimalNumberExactnessException: String = "NSDecimalNumberExactnessException"
-public let NSDecimalNumberOverflowException: String = "NSDecimalNumberOverflowException"
-public let NSDecimalNumberUnderflowException: String = "NSDecimalNumberUnderflowException"
-public let NSDecimalNumberDivideByZeroException: String = "NSDecimalNumberDivideByZeroException"
+public struct NSExceptionName : RawRepresentable, Equatable, Hashable, Comparable {
+    public private(set) var rawValue: String
+    
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+    
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+    
+    public var hashValue: Int {
+        return self.rawValue.hashValue
+    }
+    
+    public static func ==(_ lhs: NSExceptionName, _ rhs: NSExceptionName) -> Bool {
+        return lhs.rawValue == rhs.rawValue
+    }
+    
+    public static func <(_ lhs: NSExceptionName, _ rhs: NSExceptionName) -> Bool {
+        return lhs.rawValue < rhs.rawValue
+    }
+}
+
+extension NSExceptionName {
+    public static let decimalNumberExactnessException = NSExceptionName(rawValue: "NSDecimalNumberExactnessException")
+    public static let decimalNumberOverflowException = NSExceptionName(rawValue: "NSDecimalNumberOverflowException")
+    public static let decimalNumberUnderflowException = NSExceptionName(rawValue: "NSDecimalNumberUnderflowException")
+    public static let decimalNumberDivideByZeroException = NSExceptionName(rawValue: "NSDecimalNumberDivideByZeroException")
+}
 
 /***************	Rounding and Exception behavior		***********/
 
+// Rounding policies :
+// Original
+//    value 1.2  1.21  1.25  1.35  1.27
+// Plain    1.2  1.2   1.3   1.4   1.3
+// Down     1.2  1.2   1.2   1.3   1.2
+// Up       1.2  1.3   1.3   1.4   1.3
+// Bankers  1.2  1.2   1.2   1.4   1.3
+
+/***************	Type definitions		***********/
+extension NSDecimalNumber {
+    public enum RoundingMode : UInt {
+        case plain // Round up on a tie
+        case down // Always down == truncate
+        case up // Always up
+        case bankers // on a tie round so last digit is even
+    }
+    
+    public enum CalculationError : UInt {
+        case noError
+        case lossOfPrecision // Result lost precision
+        case underflow // Result became 0
+        case overflow // Result exceeds possible representation
+        case divideByZero
+    }
+}
+
 public protocol NSDecimalNumberBehaviors {
-    
-    func roundingMode() -> Decimal.RoundingMode
-    
+    func roundingMode() -> NSDecimalNumber.RoundingMode
     func scale() -> Int16
-    // The scale could return NO_SCALE for no defined scale.
 }
 
 // Receiver can raise, return a new value, or return nil to ignore the exception.
@@ -59,13 +108,13 @@ open class NSDecimalNumber : NSNumber {
     
     // TODO: "declarations from extensions cannot be overridden yet"
     // Although it's not clear we actually need to redeclare this here when the extension adds it to the superclass of this class
-    // open var decimalValue: NSDecimal { NSUnimplemented() }
+    // open var decimalValue: Decimal { NSUnimplemented() }
     
-    open class func zero() -> NSDecimalNumber { NSUnimplemented() }
-    open class func one() -> NSDecimalNumber { NSUnimplemented() }
-    open class func minimum() -> NSDecimalNumber { NSUnimplemented() }
-    open class func maximum() -> NSDecimalNumber { NSUnimplemented() }
-    open class func notANumber() -> NSDecimalNumber { NSUnimplemented() }
+    open class var zero: NSDecimalNumber { NSUnimplemented() }
+    open class var one: NSDecimalNumber { NSUnimplemented() }
+    open class var minimum: NSDecimalNumber { NSUnimplemented() }
+    open class var maximum: NSDecimalNumber { NSUnimplemented() }
+    open class var notANumber: NSDecimalNumber { NSUnimplemented() }
     
     open func adding(_ decimalNumber: NSDecimalNumber) -> NSDecimalNumber { NSUnimplemented() }
     open func adding(_ decimalNumber: NSDecimalNumber, withBehavior behavior: NSDecimalNumberBehaviors?) -> NSDecimalNumber { NSUnimplemented() }
@@ -91,9 +140,7 @@ open class NSDecimalNumber : NSNumber {
     open override func compare(_ decimalNumber: NSNumber) -> ComparisonResult { NSUnimplemented() }
     // compare two NSDecimalNumbers
     
-    open class func setDefaultBehavior(_ behavior: NSDecimalNumberBehaviors) { NSUnimplemented() }
-    
-    open class func defaultBehavior() -> NSDecimalNumberBehaviors { NSUnimplemented() }
+    open class var defaultBehavior: NSDecimalNumberBehaviors { NSUnimplemented() }
     // One behavior per thread - The default behavior is
     //   rounding mode: NSRoundPlain
     //   scale: No defined scale (full precision)
@@ -120,15 +167,15 @@ open class NSDecimalNumberHandler : NSObject, NSDecimalNumberBehaviors, NSCoding
         NSUnimplemented()
     }
     
-    open class func defaultDecimalNumberHandler() -> NSDecimalNumberHandler{ NSUnimplemented() }
+    open class func `default`() -> NSDecimalNumberHandler { NSUnimplemented() }
     // rounding mode: NSRoundPlain
     // scale: No defined scale (full precision)
     // ignore exactnessException (return nil)
     // raise on overflow, underflow and divide by zero.
     
-    public init(roundingMode: Decimal.RoundingMode, scale: Int16, raiseOnExactness exact: Bool, raiseOnOverflow overflow: Bool, raiseOnUnderflow underflow: Bool, raiseOnDivideByZero divideByZero: Bool) { NSUnimplemented() }
+    public init(roundingMode: NSDecimalNumber.RoundingMode, scale: Int16, raiseOnExactness exact: Bool, raiseOnOverflow overflow: Bool, raiseOnUnderflow underflow: Bool, raiseOnDivideByZero divideByZero: Bool) { NSUnimplemented() }
     
-    open func roundingMode() -> Decimal.RoundingMode { NSUnimplemented() }
+    open func roundingMode() -> NSDecimalNumber.RoundingMode { NSUnimplemented() }
     
     open func scale() -> Int16 { NSUnimplemented() }
     // The scale could return NO_SCALE for no defined scale.


### PR DESCRIPTION
### Changes
* Move `Decimal.RoundingMode` and `Decimal.CalculationError` → `NSDecimalNumber.RoundingMode` and `NSDecimalNumber.CalculationError`
* Add unimplemented `Decimal` API to match Foundation
* Add `NSExceptionName` type and move raw exception names to be instances of that type
* `open class func zero() -> NSDecimalNumber` and co → `open class var zero: NSDecimalNumber`
* `NSDecimalNumberBehavior`'s default behavior getter and setter → `open class var defaultBehavior`
* `NSDecimalNumberHandler`'s `open class func defaultDecimalNumberHandler()` → `open class func default()`