### PR TITLE
Revert "Swift 3: Value Types and Naming"

### DIFF
--- a/Foundation/CharacterSet.swift
+++ b/Foundation/CharacterSet.swift
@@ -54,19 +54,12 @@ internal final class _SwiftNSCharacterSet : NSCharacterSet, _SwiftNativeFoundati
         releaseWrappedObject()
     }
 
+// These for some reason cause a crash in the compiler
+    // Stubs
+    // -----
 
-   override func copy(with zone: NSZone? = nil) -> AnyObject {
-        return _mapUnmanaged { $0.copy(with: zone) }
-    }
-    
-    override func mutableCopy(with zone: NSZone? = nil) ->  AnyObject {
-        return _mapUnmanaged { $0.mutableCopy(with: zone) }
-    }
-    
-    public override var classForCoder: AnyClass {
-        return NSCharacterSet.self
-    }
-    
+    // Immutable
+
     override var bitmapRepresentation: Data {
         return _mapUnmanaged { $0.bitmapRepresentation }
     }
@@ -75,8 +68,8 @@ internal final class _SwiftNSCharacterSet : NSCharacterSet, _SwiftNativeFoundati
         return _mapUnmanaged { $0.inverted }
     }
 
-    override func hasMemberInPlane(_ thePlane: UInt8) -> Bool {
-        return _mapUnmanaged {$0.hasMemberInPlane(thePlane) }
+    override func hasMember(inPlane plane: UInt8) -> Bool {
+        return _mapUnmanaged {$0.hasMember(inPlane: plane) }
     }
 
     override func characterIsMember(_ member: unichar) -> Bool {
@@ -180,77 +173,77 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     
     /// Returns a character set containing the characters in Unicode General Category Cc and Cf.
     public static var controlCharacters : CharacterSet {
-        return NSCharacterSet.controlCharacters
+        return NSCharacterSet.controlCharacters()
     }
     
     /// Returns a character set containing the characters in Unicode General Category Zs and `CHARACTER TABULATION (U+0009)`.
     public static var whitespaces : CharacterSet {
-        return NSCharacterSet.whitespaces
+        return NSCharacterSet.whitespaces()
     }
     
     /// Returns a character set containing characters in Unicode General Category Z*, `U+000A ~ U+000D`, and `U+0085`.
     public static var whitespacesAndNewlines : CharacterSet {
-        return NSCharacterSet.whitespacesAndNewlines
+        return NSCharacterSet.whitespacesAndNewlines()
     }
     
     /// Returns a character set containing the characters in the category of Decimal Numbers.
     public static var decimalDigits : CharacterSet {
-        return NSCharacterSet.decimalDigits
+        return NSCharacterSet.decimalDigits()
     }
     
     /// Returns a character set containing the characters in Unicode General Category L* & M*.
     public static var letters : CharacterSet {
-        return NSCharacterSet.letters
+        return NSCharacterSet.letters()
     }
     
     /// Returns a character set containing the characters in Unicode General Category Ll.
     public static var lowercaseLetters : CharacterSet {
-        return NSCharacterSet.lowercaseLetters
+        return NSCharacterSet.lowercaseLetters()
     }
     
     /// Returns a character set containing the characters in Unicode General Category Lu and Lt.
     public static var uppercaseLetters : CharacterSet {
-        return NSCharacterSet.uppercaseLetters
+        return NSCharacterSet.uppercaseLetters()
     }
     
     /// Returns a character set containing the characters in Unicode General Category M*.
     public static var nonBaseCharacters : CharacterSet {
-        return NSCharacterSet.nonBaseCharacters
+        return NSCharacterSet.nonBaseCharacters()
     }
     
     /// Returns a character set containing the characters in Unicode General Categories L*, M*, and N*.
     public static var alphanumerics : CharacterSet {
-        return NSCharacterSet.alphanumerics
+        return NSCharacterSet.alphanumerics()
     }
     
-    /// Returns a character set containing individual Unicode characters that can also be represented as composed character sequences (such as for letters with accents), by the definition of "standard decomposition" in version 3.2 of the Unicode character encoding standard.
+    /// Returns a character set containing individual Unicode characters that can also be represented as composed character sequences (such as for letters with accents), by the definition of “standard decomposition” in version 3.2 of the Unicode character encoding standard.
     public static var decomposables : CharacterSet {
-        return NSCharacterSet.decomposables
+        return NSCharacterSet.decomposables()
     }
     
     /// Returns a character set containing values in the category of Non-Characters or that have not yet been defined in version 3.2 of the Unicode standard.
     public static var illegalCharacters : CharacterSet {
-        return NSCharacterSet.illegalCharacters
+        return NSCharacterSet.illegalCharacters()
     }
     
     /// Returns a character set containing the characters in Unicode General Category P*.
     public static var punctuation : CharacterSet {
-        return NSCharacterSet.punctuation
+        return NSCharacterSet.punctuation()
     }
     
     /// Returns a character set containing the characters in Unicode General Category Lt.
     public static var capitalizedLetters : CharacterSet {
-        return NSCharacterSet.capitalizedLetters
+        return NSCharacterSet.capitalizedLetters()
     }
     
     /// Returns a character set containing the characters in Unicode General Category S*.
     public static var symbols : CharacterSet {
-        return NSCharacterSet.symbols
+        return NSCharacterSet.symbols()
     }
     
     /// Returns a character set containing the newline characters (`U+000A ~ U+000D`, `U+0085`, `U+2028`, and `U+2029`).
     public static var newlines : CharacterSet {
-        return NSCharacterSet.newlines
+        return NSCharacterSet.newlines()
     }
     
     // MARK: Static functions, from NSURL
@@ -301,7 +294,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     ///
     /// This method makes it easier to find the plane containing the members of the current character set. The Basic Multilingual Plane (BMP) is plane 0.
     public func hasMember(inPlane plane: UInt8) -> Bool {
-        return _mapUnmanaged { $0.hasMemberInPlane(plane) }
+        return _mapUnmanaged { $0.hasMember(inPlane: plane) }
     }
     
     // MARK: Mutable functions
@@ -366,7 +359,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     // -----
     // MARK: -
     // MARK: SetAlgebraType
-
+    
     /// Insert a `UnicodeScalar` representation of a character into the `CharacterSet`.
     ///
     /// `UnicodeScalar` values are available on `Swift.String.UnicodeScalarView`.
@@ -455,11 +448,11 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     public func isSuperset(of other: CharacterSet) -> Bool {
         return _mapUnmanaged { $0.isSuperset(of: other) }
     }
+}
 
-    /// Returns true if the two `CharacterSet`s are equal.
-    public static func ==(lhs : CharacterSet, rhs: CharacterSet) -> Bool {
-        return lhs._wrapped.isEqual(rhs._bridgeToObjectiveC()) // TODO: mlehew - as  NSCharacterSet
-    }
+/// Returns true if the two `CharacterSet`s are equal.
+public func ==(lhs : CharacterSet, rhs: CharacterSet) -> Bool {
+    return lhs._wrapped.isEqual(rhs._bridgeToObjectiveC())
 }
 
 
@@ -491,4 +484,10 @@ extension CharacterSet {
         return CharacterSet(_bridged: source!)
     }
     
+}
+
+extension CharacterSet {
+    public func contains(_ member: unichar) -> Bool {
+        return contains(UnicodeScalar(member)!)
+    }
 }

--- a/Foundation/NSAffineTransform.swift
+++ b/Foundation/NSAffineTransform.swift
@@ -13,19 +13,7 @@
     import Glibc
 #endif
 
-private let ε: CGFloat = CGFloat(2.22045e-16)
-
-
-/**
- AffineTransform represents an affine transformation matrix of the following form:
-
- [ m11  m12  0 ]
- [ m21  m22  0 ]
- [  tX   tY  1 ]
- */
-public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConvertible {
-    public typealias ReferenceType = NSAffineTransform
-
+public struct NSAffineTransformStruct {
     public var m11: CGFloat
     public var m12: CGFloat
     public var m21: CGFloat
@@ -36,250 +24,10 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
     public init() {
         self.init(m11: CGFloat(), m12: CGFloat(), m21: CGFloat(), m22: CGFloat(), tX: CGFloat(), tY: CGFloat())
     }
+    
     public init(m11: CGFloat, m12: CGFloat, m21: CGFloat, m22: CGFloat, tX: CGFloat, tY: CGFloat) {
         (self.m11, self.m12, self.m21, self.m22) = (m11, m12, m21, m22)
         (self.tX, self.tY) = (tX, tY)
-    }
-
-    private init(reference: NSAffineTransform) {
-        self = reference.transformStruct
-    }
-
-    private var reference : NSAffineTransform {
-        let ref = NSAffineTransform()
-        ref.transformStruct = self
-        return ref
-    }
-
-    /**
-     Creates an affine transformation matrix from translation values.
-     The matrix takes the following form:
-
-     [ 1  0  0 ]
-     [ 0  1  0 ]
-     [ x  y  1 ]
-     */
-    public init(translationByX x: CGFloat, byY y: CGFloat) {
-        self.init(m11: CGFloat(1.0), m12: CGFloat(0.0),
-                  m21: CGFloat(0.0), m22: CGFloat(1.0),
-                  tX: x,             tY: y)
-    }
-
-    /**
-     Creates an affine transformation matrix from scaling values.
-     The matrix takes the following form:
-
-     [ x  0  0 ]
-     [ 0  y  0 ]
-     [ 0  0  1 ]
-     */
-    public init(scaleByX x: CGFloat, byY y: CGFloat) {
-        self.init(m11: x,            m12: CGFloat(0.0),
-                  m21: CGFloat(0.0), m22: y,
-                  tX: CGFloat(0.0),  tY: CGFloat(0.0))
-    }
-
-    /**
-     Creates an affine transformation matrix from scaling a single value.
-     The matrix takes the following form:
-
-     [ f  0  0 ]
-     [ 0  f  0 ]
-     [ 0  0  1 ]
-     */
-    public init(scale factor: CGFloat) {
-        self.init(scaleByX: factor, byY: factor)
-    }
-
-    /**
-     Creates an affine transformation matrix from rotation value (angle in radians).
-     The matrix takes the following form:
-
-     [  cos α   sin α  0 ]
-     [ -sin α   cos α  0 ]
-     [    0       0    1 ]
-     */
-    public init(rotationByRadians angle: CGFloat) {
-        let α = Double(angle)
-
-        let sine = CGFloat(sin(α))
-        let cosine = CGFloat(cos(α))
-
-        self.init(m11: cosine, m12: sine, m21: -sine, m22: cosine, tX: CGFloat(0.0), tY: CGFloat(0.0))
-    }
-
-    /**
-     Creates an affine transformation matrix from a rotation value (angle in degrees).
-     The matrix takes the following form:
-
-     [  cos α   sin α  0 ]
-     [ -sin α   cos α  0 ]
-     [    0       0    1 ]
-     */
-    public init(rotationByDegrees angle: CGFloat) {
-        let α = Double(angle) * M_PI / 180.0
-        self.init(rotationByRadians: CGFloat(α))
-    }
-
-    /**
-     An identity affine transformation matrix
-
-     [ 1  0  0 ]
-     [ 0  1  0 ]
-     [ 0  0  1 ]
-     */
-    public static let identity = AffineTransform(m11: CGFloat(1.0), m12: CGFloat(0.0), m21: CGFloat(0.0), m22: CGFloat(1.0), tX: CGFloat(0.0), tY: CGFloat(0.0))
-
-    // Translating
-    public mutating func translate(x: CGFloat, y: CGFloat) {
-        tX += m11 * x + m21 * y
-        tY += m12 * x + m22 * y
-    }
-
-    /**
-     Mutates an affine transformation matrix from a rotation value (angle α in degrees).
-     The matrix takes the following form:
-
-     [  cos α   sin α  0 ]
-     [ -sin α   cos α  0 ]
-     [    0       0    1 ]
-     */
-    public mutating func rotate(byDegrees angle: CGFloat) {
-        let α = Double(angle) * M_PI / 180.0
-        return rotate(byRadians: CGFloat(α))
-    }
-
-    /**
-     Mutates an affine transformation matrix from a rotation value (angle α in radians).
-     The matrix takes the following form:
-
-     [  cos α   sin α  0 ]
-     [ -sin α   cos α  0 ]
-     [    0       0    1 ]
-     */
-    public mutating func rotate(byRadians angle: CGFloat) {
-        let α = Double(angle)
-
-        let sine = CGFloat(sin(α))
-        let cosine = CGFloat(cos(α))
-
-        m11 = cosine
-        m12 = sine
-        m21 = -sine
-        m22 = cosine
-    }
-
-    /**
-     Creates an affine transformation matrix by combining the receiver with `transformStruct`.
-     That is, it computes `T * M` and returns the result, where `T` is the receiver's and `M` is
-     the `transformStruct`'s affine transformation matrix.
-     The resulting matrix takes the following form:
-
-     [ m11_T  m12_T  0 ] [ m11_M  m12_M  0 ]
-     T * M = [ m21_T  m22_T  0 ] [ m21_M  m22_M  0 ]
-     [  tX_T   tY_T  1 ] [  tX_M   tY_M  1 ]
-     
-     [    (m11_T*m11_M + m12_T*m21_M)       (m11_T*m12_M + m12_T*m22_M)    0 ]
-     = [    (m21_T*m11_M + m22_T*m21_M)       (m21_T*m12_M + m22_T*m22_M)    0 ]
-     [ (tX_T*m11_M + tY_T*m21_M + tX_M)  (tX_T*m12_M + tY_T*m22_M + tY_M)  1 ]
-     */
-    internal func concatenated(_ other: AffineTransform) -> AffineTransform {
-        let (t, m) = (self, other)
-        
-        // this could be optimized with a vector version
-        return AffineTransform(
-            m11: (t.m11 * m.m11) + (t.m12 * m.m21), m12: (t.m11 * m.m12) + (t.m12 * m.m22),
-            m21: (t.m21 * m.m11) + (t.m22 * m.m21), m22: (t.m21 * m.m12) + (t.m22 * m.m22),
-            tX: (t.tX * m.m11) + (t.tY * m.m21) + m.tX,
-            tY: (t.tX * m.m12) + (t.tY * m.m22) + m.tY
-        )
-    }
-
-    // Scaling
-    public mutating func scale(_ scale: CGFloat) {
-        self.scale(x: scale, y: scale)
-    }
-
-    public mutating func scale(x: CGFloat, y: CGFloat) {
-        m11 = CGFloat(m11.native * x.native)
-        m12 = CGFloat(m12.native * x.native)
-        m21 = CGFloat(m21.native * y.native)
-        m22 = CGFloat(m22.native * y.native)
-    }
-
-    /**
-     Inverts the transformation matrix if possible. Matrices with a determinant that is less than
-     the smallest valid representation of a double value greater than zero are considered to be
-     invalid for representing as an inverse. If the input AffineTransform can potentially fall into
-     this case then the inverted() method is suggested to be used instead since that will return
-     an optional value that will be nil in the case that the matrix cannot be inverted.
-
-     D = (m11 * m22) - (m12 * m21)
-
-     D < ε the inverse is undefined and will be nil
-     */
-    public mutating func invert() {
-        guard let inverse = inverted() else {
-            fatalError("Transform has no inverse")
-        }
-        self = inverse
-    }
-
-    public func inverted() -> AffineTransform? {
-        let determinant = (m11 * m22) - (m12 * m21)
-        if fabs(determinant.native) <= ε.native {
-            return nil
-        }
-        var inverse = AffineTransform()
-        inverse.m11 = m22 / determinant
-        inverse.m12 = -m12 / determinant
-        inverse.m21 = -m21 / determinant
-        inverse.m22 = m11 / determinant
-        inverse.tX = (m21 * tY - m22 * tX) / determinant
-        inverse.tY = (m12 * tX - m11 * tY) / determinant
-        return inverse
-    }
-
-    // Transforming with transform
-    public mutating func append(_ transform: AffineTransform) {
-        self = concatenated(transform)
-    }
-
-    public mutating func prepend(_ transform: AffineTransform) {
-        self = transform.concatenated(self)
-    }
-
-    // Transforming points and sizes
-    public func transform(_ point: NSPoint) -> NSPoint {
-        var newPoint = NSPoint()
-        newPoint.x = (m11 * point.x) + (m21 * point.y) + tX
-        newPoint.y = (m12 * point.x) + (m22 * point.y) + tY
-        return newPoint
-    }
-
-    public func transform(_ size: NSSize) -> NSSize {
-        var newSize = NSSize()
-        newSize.width = (m11 * size.width) + (m21 * size.height)
-        newSize.height = (m12 * size.width) + (m22 * size.height)
-        return newSize
-    }
-
-    public var hashValue : Int {
-        return Int((m11 + m12 + m21 + m22 + tX + tY).native)
-    }
-
-    public var description: String {
-        return "{m11:\(m11), m12:\(m12), m21:\(m21), m22:\(m22), tX:\(tX), tY:\(tY)}"
-    }
-
-    public var debugDescription: String {
-        return description
-    }
-
-    public static func ==(lhs: AffineTransform, rhs: AffineTransform) -> Bool {
-        return lhs.m11 == rhs.m11 && lhs.m12 == rhs.m12 &&
-            lhs.m21 == rhs.m21 && lhs.m22 == rhs.m22 &&
-            lhs.tX == rhs.tX && lhs.tY == rhs.tY
     }
 }
 
@@ -309,7 +57,7 @@ open class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
     }
     
     public override init() {
-        transformStruct = AffineTransform(
+        transformStruct = NSAffineTransformStruct(
             m11: CGFloat(1.0), m12: CGFloat(),
             m21: CGFloat(), m22: CGFloat(1.0),
             tX: CGFloat(), tY: CGFloat()
@@ -317,34 +65,38 @@ open class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
     }
     
     // Translating
-    open func translateX(by deltaX: CGFloat, yBy deltaY: CGFloat) {
-        let translation = AffineTransform(translationByX: deltaX, byY: deltaY)
-        transformStruct = translation.concatenated(transformStruct)
+    open func translateXBy(_ deltaX: CGFloat, yBy deltaY: CGFloat) {
+        let translation = NSAffineTransformStruct.translation(tX: deltaX, tY: deltaY)
+        
+        transformStruct = translation.concat(transformStruct)
     }
     
     // Rotating
-    open func rotate(byDegrees angle: CGFloat) {
-        let rotation = AffineTransform(rotationByDegrees: angle)
-        transformStruct = rotation.concatenated(transformStruct)
+    open func rotateByDegrees(_ angle: CGFloat) {
+        let rotation = NSAffineTransformStruct.rotation(degrees: angle)
+        
+        transformStruct = rotation.concat(transformStruct)
     }
-    open func rotate(byRadians angle: CGFloat) {
-        let rotation = AffineTransform(rotationByRadians: angle)
-        transformStruct = rotation.concatenated(transformStruct)
+    open func rotateByRadians(_ angle: CGFloat) {
+        let rotation = NSAffineTransformStruct.rotation(radians: angle)
+        
+        transformStruct = rotation.concat(transformStruct)
     }
     
     // Scaling
-    open func scale(by scale: CGFloat) {
-        scaleX(by: scale, yBy: scale)
+    open func scaleBy(_ scale: CGFloat) {
+        scaleXBy(scale, yBy: scale)
     }
 
-    open func scaleX(by scaleX: CGFloat, yBy scaleY: CGFloat) {
-        let scale = AffineTransform(scaleByX: scaleX, byY: scaleY)
-        transformStruct = scale.concatenated(transformStruct)
+    open func scaleXBy(_ scaleX: CGFloat, yBy scaleY: CGFloat) {
+        let scale = NSAffineTransformStruct.scale(sX: scaleX, sY: scaleY)
+        
+        transformStruct = scale.concat(transformStruct)
     }
     
     // Inverting
     open func invert() {
-        if let inverse = transformStruct.inverted() {
+        if let inverse = transformStruct.inverse {
             transformStruct = inverse
         }
         else {
@@ -353,56 +105,204 @@ open class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
     }
     
     // Transforming with transform
-    open func append(_ transform: NSAffineTransform) {
-        transformStruct = transformStruct.concatenated(transform.transformStruct)
+    open func appendTransform(_ transform: NSAffineTransform) {
+        transformStruct = transformStruct.concat(transform.transformStruct)
     }
-    open func prepend(_ transform: NSAffineTransform) {
-        transformStruct = transform.transformStruct.concatenated(transformStruct)
+    open func prependTransform(_ transform: NSAffineTransform) {
+        transformStruct = transform.transformStruct.concat(transformStruct)
     }
     
     // Transforming points and sizes
-    open func transform(_ aPoint: NSPoint) -> NSPoint {
-        return transformStruct.transform(aPoint)
+    open func transformPoint(_ aPoint: NSPoint) -> NSPoint {
+        return transformStruct.applied(toPoint: aPoint)
     }
 
-    open func transform(_ aSize: NSSize) -> NSSize {
-        return transformStruct.transform(aSize)
+    open func transformSize(_ aSize: NSSize) -> NSSize {
+        return transformStruct.applied(toSize: aSize)
     }
 
     // Transform Struct
-    open var transformStruct: AffineTransform
+    open var transformStruct: NSAffineTransformStruct
 }
 
-extension AffineTransform {
-    public static func _isBridgedToObjectiveC() -> Bool {
-        return true
+/**
+ NSAffineTransformStruct represents an affine transformation matrix of the following form:
+ 
+     [ m11  m12  0 ]
+     [ m21  m22  0 ]
+     [  tX   tY  1 ]
+ */
+private extension NSAffineTransformStruct {
+    /**
+     Creates an affine transformation matrix from translation values.
+     The matrix takes the following form:
+     
+         [  1   0  0 ]
+         [  0   1  0 ]
+         [ tX  tY  1 ]
+     */
+    static func translation(tX: CGFloat, tY: CGFloat) -> NSAffineTransformStruct {
+        return NSAffineTransformStruct(
+            m11: CGFloat(1.0), m12: CGFloat(),
+            m21: CGFloat(),    m22: CGFloat(1.0),
+            tX: tX, tY: tY
+        )
     }
-
-    public static func _getObjectiveCType() -> Any.Type {
-        return NSAffineTransform.self
+    
+    /**
+     Creates an affine transformation matrix from scaling values.
+     The matrix takes the following form:
+     
+         [ sX   0  0 ]
+         [ 0   sY  0 ]
+         [ 0    0  1 ]
+     */
+    static func scale(sX: CGFloat, sY: CGFloat) -> NSAffineTransformStruct {
+        return NSAffineTransformStruct(
+            m11: sX, m12: CGFloat(),
+            m21: CGFloat(), m22: sY,
+            tX: CGFloat(), tY: CGFloat()
+        )
     }
-
-    @_semantics("convertToObjectiveC")
-    public func _bridgeToObjectiveC() -> NSAffineTransform {
-        let t = NSAffineTransform()
-        t.transformStruct = self
-        return t
+    
+    /**
+     Creates an affine transformation matrix from rotation value (angle in radians).
+     The matrix takes the following form:
+     
+         [  cos α   sin α  0 ]
+         [ -sin α   cos α  0 ]
+         [    0       0    1 ]
+     */
+    static func rotation(radians angle: CGFloat) -> NSAffineTransformStruct {
+        let α = Double(angle)
+        
+        let sine = CGFloat(sin(α))
+        let cosine = CGFloat(cos(α))
+        
+        return NSAffineTransformStruct(
+            m11: cosine, m12: sine,
+            m21: -sine,  m22: cosine,
+            tX: CGFloat(), tY: CGFloat()
+        )
     }
+    
+    /**
+     Creates an affine transformation matrix from a rotation value (angle in degrees).
+     The matrix takes the following form:
+     
+         [  cos α   sin α  0 ]
+         [ -sin α   cos α  0 ]
+         [    0       0    1 ]
+     */
+    static func rotation(degrees angle: CGFloat) -> NSAffineTransformStruct {
+        let α = Double(angle) * M_PI / 180.0
+        
+        return rotation(radians: CGFloat(α))
+    }
+    
+    /**
+     Creates an affine transformation matrix by combining the receiver with `transformStruct`.
+     That is, it computes `T * M` and returns the result, where `T` is the receiver's and `M` is
+     the `transformStruct`'s affine transformation matrix.
+     The resulting matrix takes the following form:
+     
+                 [ m11_T  m12_T  0 ] [ m11_M  m12_M  0 ]
+         T * M = [ m21_T  m22_T  0 ] [ m21_M  m22_M  0 ]
+                 [  tX_T   tY_T  1 ] [  tX_M   tY_M  1 ]
+     
+                 [    (m11_T*m11_M + m12_T*m21_M)       (m11_T*m12_M + m12_T*m22_M)    0 ]
+               = [    (m21_T*m11_M + m22_T*m21_M)       (m21_T*m12_M + m22_T*m22_M)    0 ]
+                 [ (tX_T*m11_M + tY_T*m21_M + tX_M)  (tX_T*m12_M + tY_T*m22_M + tY_M)  1 ]
+     */
+    func concat(_ transformStruct: NSAffineTransformStruct) -> NSAffineTransformStruct {
+        let (t, m) = (self, transformStruct)
 
-    public static func _forceBridgeFromObjectiveC(_ x: NSAffineTransform, result: inout AffineTransform?) {
-        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
-            fatalError("Unable to bridge type")
+        return NSAffineTransformStruct(
+            m11: (t.m11 * m.m11) + (t.m12 * m.m21), m12: (t.m11 * m.m12) + (t.m12 * m.m22),
+            m21: (t.m21 * m.m11) + (t.m22 * m.m21), m22: (t.m21 * m.m12) + (t.m22 * m.m22),
+            tX: (t.tX * m.m11) + (t.tY * m.m21) + m.tX,
+            tY: (t.tX * m.m12) + (t.tY * m.m22) + m.tY
+        )
+    }
+    
+    /**
+     Applies the affine transformation to `toPoint` and returns the result.
+     The resulting point takes the following form:
+     
+         [ x'  y'  1 ] = [ x  y  1 ] * T
+
+                                       [ m11  m12  0 ]
+                       = [ x  y  1 ] * [ m21  m22  0 ]
+                                       [  tX   tY  1 ]
+
+                       = [ (x*m11 + y*m21 + tX)  (x*m12 + y*m22 + tY)  1 ]
+     */
+    func applied(toPoint p: NSPoint) -> NSPoint {
+        let x = (p.x * m11) + (p.y * m21) + tX
+        let y = (p.x * m12) + (p.y * m22) + tY
+        
+        return NSPoint(x: x, y: y)
+    }
+    
+    /**
+     Applies the affine transformation to `toSize` and returns the result.
+     The resulting size takes the following form:
+  
+         [ w'  h'  0 ] = [ w  h  0] * T
+
+                                     [ m11  m12  0 ]
+                       = [ w  h  0 ] [ m21  m22  0 ]
+                                     [  tX   tY  1 ]
+
+                       = [ (w*m11 + h*m21)  (w*m12 + h*m22)  0 ]
+     
+     Note: Translation has no effect on the size.
+     */
+    func applied(toSize s: NSSize) -> NSSize {
+        let w = (m11 * s.width) + (m12 * s.height)
+        let h = (m21 * s.width) + (m22 * s.height)
+        
+        return NSSize(width: w, height: h)
+    }
+    
+    
+    /**
+     Returns the inverse affine transformation matrix or `nil` if it has no inverse.
+     The receiver's affine transformation matrix can be divided into matrix sub-block as
+     
+         [ M  0 ]
+         [ t  1 ]
+     
+     where `M` represents the linear map and `t` the translation vector.
+     
+     The inversion can then be calculated as
+     
+         [   inv(M)  0 ]
+         [ -t*inv(M)  1 ]
+     
+     if `M` is invertible.
+     */
+    var inverse: NSAffineTransformStruct? {
+        // Calculate determinant of M: det(M)
+        let det = (m11 * m22) - (m12 * m21)
+        if det == CGFloat() {
+            return nil
         }
-    }
 
-    public static func _conditionallyBridgeFromObjectiveC(_ x: NSAffineTransform, result: inout AffineTransform?) -> Bool {
-        result = x.transformStruct
-        return true // Can't fail
-    }
-
-    public static func _unconditionallyBridgeFromObjectiveC(_ x: NSAffineTransform?) -> AffineTransform {
-        var result: AffineTransform?
-        _forceBridgeFromObjectiveC(x!, result: &result)
-        return result!
+        // Calculate the inverse of M: inv(M)
+        let (invM11, invM12) = ( m22 / det, -m12 / det)
+        let (invM21, invM22) = (-m21 / det,  m11 / det)
+        
+        // Calculate -t*inv(M)
+        let invTX = (-tX * invM11) + (-tY * invM21)
+        let invTY = (-tX * invM12) + (-tY * invM22)
+        
+        return NSAffineTransformStruct(
+            m11: invM11, m12: invM12,
+            m21: invM21, m22: invM22,
+            tX: invTX, tY: invTY
+        )
     }
 }
+
+

--- a/Foundation/NSCFCharacterSet.swift
+++ b/Foundation/NSCFCharacterSet.swift
@@ -34,8 +34,8 @@ internal class _NSCFCharacterSet : NSMutableCharacterSet {
         return CFCharacterSetIsSupersetOfSet(_cfObject, theOtherSet._cfObject)
     }
     
-    override func hasMemberInPlane(_ thePlane: UInt8) -> Bool {
-        return CFCharacterSetHasMemberInPlane(_cfObject, CFIndex(thePlane))
+    override func hasMember(inPlane plane: UInt8) -> Bool {
+        return CFCharacterSetHasMemberInPlane(_cfObject, CFIndex(plane))
     }
     
     override func copy() -> Any {
@@ -101,7 +101,7 @@ internal  func _CFSwiftCharacterSetLongCharacterIsMember(_ cset: CFTypeRef, _ ch
 }
 
 internal  func _CFSwiftCharacterSetHasMemberInPlane(_ cset: CFTypeRef, _ plane: UInt8) -> Bool {
-    return (cset as! NSCharacterSet).hasMemberInPlane(plane)
+    return (cset as! NSCharacterSet).hasMember(inPlane: plane)
 }
 
 internal  func _CFSwiftCharacterSetInverted(_ cset: CFTypeRef) -> Unmanaged<CFCharacterSet> {

--- a/Foundation/NSCharacterSet.swift
+++ b/Foundation/NSCharacterSet.swift
@@ -70,63 +70,63 @@ open class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
         _CFDeinit(self)
     }
     
-    open class var controlCharacters: CharacterSet {
+    open class func controlCharacters() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetControl)._swiftObject
     }
     
-    open class var whitespaces: CharacterSet {
+    open class func whitespaces() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetWhitespace)._swiftObject
     }
 
-    open class var whitespacesAndNewlines: CharacterSet {
+    open class func whitespacesAndNewlines() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetWhitespaceAndNewline)._swiftObject
     }
     
-    open class var decimalDigits: CharacterSet {
+    open class func decimalDigits() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetDecimalDigit)._swiftObject
     }
     
-    public class var letters: CharacterSet {
+    public class func letters() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetLetter)._swiftObject
     }
     
-    open class var lowercaseLetters: CharacterSet {
+    open class func lowercaseLetters() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetLowercaseLetter)._swiftObject
     }
     
-    open class var uppercaseLetters: CharacterSet {
+    open class func uppercaseLetters() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetUppercaseLetter)._swiftObject
     }
     
-    open class var nonBaseCharacters: CharacterSet {
+    open class func nonBaseCharacters() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetNonBase)._swiftObject
     }
     
-    open class var alphanumerics: CharacterSet {
+    open class func alphanumerics() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetAlphaNumeric)._swiftObject
     }
     
-    open class var decomposables: CharacterSet {
+    open class func decomposables() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetDecomposable)._swiftObject
     }
     
-    open class var illegalCharacters: CharacterSet {
+    open class func illegalCharacters() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetIllegal)._swiftObject
     }
     
-    open class var punctuation: CharacterSet {
+    open class func punctuation() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetPunctuation)._swiftObject
     }
     
-    open class var capitalizedLetters: CharacterSet {
+    open class func capitalizedLetters() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetCapitalizedLetter)._swiftObject
     }
     
-    open class var symbols: CharacterSet {
+    open class func symbols() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetSymbol)._swiftObject
     }
     
-    open class var newlines: CharacterSet {
+    open class func newlines() -> CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetNewline)._swiftObject
     }
 
@@ -186,8 +186,8 @@ open class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
         return CFCharacterSetIsSupersetOfSet(_cfObject, theOtherSet._cfObject)
     }
     
-    open func hasMemberInPlane(_ thePlane: UInt8) -> Bool {
-        return CFCharacterSetHasMemberInPlane(_cfObject, CFIndex(thePlane))
+    open func hasMember(inPlane plane: UInt8) -> Bool {
+        return CFCharacterSetHasMemberInPlane(_cfObject, CFIndex(plane))
     }
     
     open override func copy() -> Any {
@@ -257,47 +257,47 @@ open class NSMutableCharacterSet : NSCharacterSet {
         CFCharacterSetInvert(_cfMutableObject)
     }
 
-    open class func control() -> NSMutableCharacterSet {
+    open class func controlCharacters() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetControl)), to: NSMutableCharacterSet.self)
     }
     
-    open class func whitespace() -> NSMutableCharacterSet {
+    open class func whitespaces() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetWhitespace)), to: NSMutableCharacterSet.self)
     }
     
-    open class func whitespaceAndNewline() -> NSMutableCharacterSet {
+    open class func whitespacesAndNewlines() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetWhitespaceAndNewline)), to: NSMutableCharacterSet.self)
     }
     
-    open class func decimalDigit() -> NSMutableCharacterSet {
+    open class func decimalDigits() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetDecimalDigit)), to: NSMutableCharacterSet.self)
     }
     
-    public class func letter() -> NSMutableCharacterSet {
+    public class func letters() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetLetter)), to: NSMutableCharacterSet.self)
     }
     
-    open class func lowercaseLetter() -> NSMutableCharacterSet {
+    open class func lowercaseLetters() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetLowercaseLetter)), to: NSMutableCharacterSet.self)
     }
     
-    open class func uppercaseLetter() -> NSMutableCharacterSet {
+    open class func uppercaseLetters() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetUppercaseLetter)), to: NSMutableCharacterSet.self)
     }
     
-    open class func nonBase() -> NSMutableCharacterSet {
+    open class func nonBaseCharacters() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetNonBase)), to: NSMutableCharacterSet.self)
     }
     
-    open class func alphanumeric() -> NSMutableCharacterSet {
+    open class func alphanumerics() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetAlphaNumeric)), to: NSMutableCharacterSet.self)
     }
     
-    open class func decomposable() -> NSMutableCharacterSet {
+    open class func decomposables() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetDecomposable)), to: NSMutableCharacterSet.self)
     }
     
-    open class func illegal() -> NSMutableCharacterSet {
+    open class func illegalCharacters() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetIllegal)), to: NSMutableCharacterSet.self)
     }
     
@@ -305,15 +305,15 @@ open class NSMutableCharacterSet : NSCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetPunctuation)), to: NSMutableCharacterSet.self)
     }
     
-    open class func capitalizedLetter() -> NSMutableCharacterSet {
+    open class func capitalizedLetters() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetCapitalizedLetter)), to: NSMutableCharacterSet.self)
     }
     
-    open class func symbol() -> NSMutableCharacterSet {
+    open class func symbols() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetSymbol)), to: NSMutableCharacterSet.self)
     }
     
-    open class func newline() -> NSMutableCharacterSet {
+    open class func newlines() -> NSMutableCharacterSet {
         return unsafeBitCast(CFCharacterSetCreateMutableCopy(kCFAllocatorSystemDefault, CFCharacterSetGetPredefined(kCFCharacterSetNewline)), to: NSMutableCharacterSet.self)
     }
 }

--- a/Foundation/NSHTTPCookie.swift
+++ b/Foundation/NSHTTPCookie.swift
@@ -555,7 +555,7 @@ open class HTTPCookie : NSObject {
 //utils for cookie parsing
 internal extension String {
     func trim() -> String {
-        return self.trimmingCharacters(in: NSCharacterSet.whitespacesAndNewlines)
+        return self.trimmingCharacters(in: NSCharacterSet.whitespacesAndNewlines())
     }
 
     func removeCommas() -> String {

--- a/Foundation/NSScanner.swift
+++ b/Foundation/NSScanner.swift
@@ -176,7 +176,7 @@ internal struct _NSStringBuffer {
     
     mutating func skip(_ skipSet: CharacterSet?) {
         if let set = skipSet {
-            while set.contains(UnicodeScalar(currentCharacter)!) && !isAtEnd {
+            while set.contains(currentCharacter) && !isAtEnd {
                 advance()
             }
         }
@@ -208,7 +208,7 @@ private func isADigit(_ ch: unichar) -> Bool {
     struct Local {
         static let set = CharacterSet.decimalDigits
     }
-    return Local.set.contains(UnicodeScalar(ch)!)
+    return Local.set.contains(ch)
 }
 
 // This is just here to allow just enough generic math to handle what is needed for scanning an abstract integer from a string, perhaps these should be on IntegerType?

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -1050,7 +1050,7 @@ extension NSString {
     open func trimmingCharacters(in set: CharacterSet) -> String {
         let len = length
         var buf = _NSStringBuffer(string: self, start: 0, end: len)
-        while !buf.isAtEnd && set.contains(UnicodeScalar(buf.currentCharacter)!) {
+        while !buf.isAtEnd && set.contains(buf.currentCharacter) {
             buf.advance()
         }
         
@@ -1060,7 +1060,7 @@ extension NSString {
             return ""
         } else if startOfNonTrimmedRange < len - 1 {
             buf.location = len - 1
-            while set.contains(UnicodeScalar(buf.currentCharacter)!) && buf.location >= startOfNonTrimmedRange {
+            while set.contains(buf.currentCharacter) && buf.location >= startOfNonTrimmedRange {
                 buf.rewind()
             }
             let endOfNonTrimmedRange = buf.location

--- a/TestFoundation/TestNSAffineTransform.swift
+++ b/TestFoundation/TestNSAffineTransform.swift
@@ -42,7 +42,7 @@ class TestNSAffineTransform : XCTestCase {
     }
     
     func checkPointTransformation(_ transform: NSAffineTransform, point: NSPoint, expectedPoint: NSPoint, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
-        let newPoint = transform.transform(point)
+        let newPoint = transform.transformPoint(point)
         XCTAssertEqualWithAccuracy(Double(newPoint.x), Double(expectedPoint.x), accuracy: accuracyThreshold,
                                    "x (expected: \(expectedPoint.x), was: \(newPoint.x)): \(message)", file: file, line: line)
         XCTAssertEqualWithAccuracy(Double(newPoint.y), Double(expectedPoint.y), accuracy: accuracyThreshold,
@@ -50,7 +50,7 @@ class TestNSAffineTransform : XCTestCase {
     }
     
     func checkSizeTransformation(_ transform: NSAffineTransform, size: NSSize, expectedSize: NSSize, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
-        let newSize = transform.transform(size)
+        let newSize = transform.transformSize(size)
         XCTAssertEqualWithAccuracy(Double(newSize.width), Double(expectedSize.width), accuracy: accuracyThreshold,
                                    "width (expected: \(expectedSize.width), was: \(newSize.width)): \(message)", file: file, line: line)
         XCTAssertEqualWithAccuracy(Double(newSize.height), Double(expectedSize.height), accuracy: accuracyThreshold,
@@ -105,19 +105,19 @@ class TestNSAffineTransform : XCTestCase {
         let point = NSPoint(x: CGFloat(0.0), y: CGFloat(0.0))
 
         let noop = NSAffineTransform()
-        noop.translateX(by: CGFloat(), yBy: CGFloat())
+        noop.translateXBy(CGFloat(), yBy: CGFloat())
         checkPointTransformation(noop, point: point, expectedPoint: point)
         
         let translateH = NSAffineTransform()
-        translateH.translateX(by: CGFloat(10.0), yBy: CGFloat())
+        translateH.translateXBy(CGFloat(10.0), yBy: CGFloat())
         checkPointTransformation(translateH, point: point, expectedPoint: NSPoint(x: CGFloat(10.0), y: CGFloat()))
         
         let translateV = NSAffineTransform()
-        translateV.translateX(by: CGFloat(), yBy: CGFloat(20.0))
+        translateV.translateXBy(CGFloat(), yBy: CGFloat(20.0))
         checkPointTransformation(translateV, point: point, expectedPoint: NSPoint(x: CGFloat(), y: CGFloat(20.0)))
         
         let translate = NSAffineTransform()
-        translate.translateX(by: CGFloat(-30.0), yBy: CGFloat(40.0))
+        translate.translateXBy(CGFloat(-30.0), yBy: CGFloat(40.0))
         checkPointTransformation(translate, point: point, expectedPoint: NSPoint(x: CGFloat(-30.0), y: CGFloat(40.0)))
     }
     
@@ -125,19 +125,19 @@ class TestNSAffineTransform : XCTestCase {
         let size = NSSize(width: CGFloat(10.0), height: CGFloat(10.0))
         
         let noop = NSAffineTransform()
-        noop.scale(by: CGFloat(1.0))
+        noop.scaleBy(CGFloat(1.0))
         checkSizeTransformation(noop, size: size, expectedSize: size)
         
         let shrink = NSAffineTransform()
-        shrink.scale(by: CGFloat(0.5))
+        shrink.scaleBy(CGFloat(0.5))
         checkSizeTransformation(shrink, size: size, expectedSize: NSSize(width: CGFloat(5.0), height: CGFloat(5.0)))
         
         let grow = NSAffineTransform()
-        grow.scale(by: CGFloat(3.0))
+        grow.scaleBy(CGFloat(3.0))
         checkSizeTransformation(grow, size: size, expectedSize: NSSize(width: CGFloat(30.0), height: CGFloat(30.0)))
         
         let stretch = NSAffineTransform()
-        stretch.scaleX(by: CGFloat(2.0), yBy: CGFloat(0.5))
+        stretch.scaleXBy(CGFloat(2.0), yBy: CGFloat(0.5))
         checkSizeTransformation(stretch, size: size, expectedSize: NSSize(width: CGFloat(20.0), height: CGFloat(5.0)))
     }
     
@@ -145,23 +145,23 @@ class TestNSAffineTransform : XCTestCase {
         let point = NSPoint(x: CGFloat(10.0), y: CGFloat(10.0))
         
         let noop = NSAffineTransform()
-        noop.rotate(byDegrees: CGFloat())
+        noop.rotateByDegrees(CGFloat())
         checkPointTransformation(noop, point: point, expectedPoint: point)
         
         let tenEighty = NSAffineTransform()
-        tenEighty.rotate(byDegrees: CGFloat(1080.0))
+        tenEighty.rotateByDegrees(CGFloat(1080.0))
         checkPointTransformation(tenEighty, point: point, expectedPoint: point)
         
         let rotateCounterClockwise = NSAffineTransform()
-        rotateCounterClockwise.rotate(byDegrees: CGFloat(90.0))
+        rotateCounterClockwise.rotateByDegrees(CGFloat(90.0))
         checkPointTransformation(rotateCounterClockwise, point: point, expectedPoint: NSPoint(x: CGFloat(-10.0), y: CGFloat(10.0)))
         
         let rotateClockwise = NSAffineTransform()
-        rotateClockwise.rotate(byDegrees: CGFloat(-90.0))
+        rotateClockwise.rotateByDegrees(CGFloat(-90.0))
         checkPointTransformation(rotateClockwise, point: point, expectedPoint: NSPoint(x: CGFloat(10.0), y: CGFloat(-10.0)))
         
         let reflectAboutOrigin = NSAffineTransform()
-        reflectAboutOrigin.rotate(byDegrees: CGFloat(180.0))
+        reflectAboutOrigin.rotateByDegrees(CGFloat(180.0))
         checkPointTransformation(reflectAboutOrigin, point: point, expectedPoint: NSPoint(x: CGFloat(-10.0), y: CGFloat(-10.0)))
     }
     
@@ -169,23 +169,23 @@ class TestNSAffineTransform : XCTestCase {
         let point = NSPoint(x: CGFloat(10.0), y: CGFloat(10.0))
         
         let noop = NSAffineTransform()
-        noop.rotate(byRadians: CGFloat())
+        noop.rotateByRadians(CGFloat())
         checkPointTransformation(noop, point: point, expectedPoint: point)
         
         let tenEighty = NSAffineTransform()
-        tenEighty.rotate(byRadians: CGFloat(6 * M_PI))
+        tenEighty.rotateByRadians(CGFloat(6 * M_PI))
         checkPointTransformation(tenEighty, point: point, expectedPoint: point)
         
         let rotateCounterClockwise = NSAffineTransform()
-        rotateCounterClockwise.rotate(byRadians: CGFloat(M_PI_2))
+        rotateCounterClockwise.rotateByRadians(CGFloat(M_PI_2))
         checkPointTransformation(rotateCounterClockwise, point: point, expectedPoint: NSPoint(x: CGFloat(-10.0), y: CGFloat(10.0)))
         
         let rotateClockwise = NSAffineTransform()
-        rotateClockwise.rotate(byRadians: CGFloat(-M_PI_2))
+        rotateClockwise.rotateByRadians(CGFloat(-M_PI_2))
         checkPointTransformation(rotateClockwise, point: point, expectedPoint: NSPoint(x: CGFloat(10.0), y: CGFloat(-10.0)))
         
         let reflectAboutOrigin = NSAffineTransform()
-        reflectAboutOrigin.rotate(byRadians: CGFloat(M_PI))
+        reflectAboutOrigin.rotateByRadians(CGFloat(M_PI))
         checkPointTransformation(reflectAboutOrigin, point: point, expectedPoint: NSPoint(x: CGFloat(-10.0), y: CGFloat(-10.0)))
     }
     
@@ -193,20 +193,20 @@ class TestNSAffineTransform : XCTestCase {
         let point = NSPoint(x: CGFloat(10.0), y: CGFloat(10.0))
         
         let translate = NSAffineTransform()
-        translate.translateX(by: CGFloat(-30.0), yBy: CGFloat(40.0))
+        translate.translateXBy(CGFloat(-30.0), yBy: CGFloat(40.0))
         
         let rotate = NSAffineTransform()
-        translate.rotate(byDegrees: CGFloat(30.0))
+        translate.rotateByDegrees(CGFloat(30.0))
         
         let scale = NSAffineTransform()
-        scale.scale(by: CGFloat(2.0))
+        scale.scaleBy(CGFloat(2.0))
         
         let identityTransform = NSAffineTransform()
         
         // append transformations
-        identityTransform.append(translate)
-        identityTransform.append(rotate)
-        identityTransform.append(scale)
+        identityTransform.appendTransform(translate)
+        identityTransform.appendTransform(rotate)
+        identityTransform.appendTransform(scale)
         
         // invert transformations
         scale.invert()
@@ -214,17 +214,17 @@ class TestNSAffineTransform : XCTestCase {
         translate.invert()
         
         // append inverse transformations in reverse order
-        identityTransform.append(scale)
-        identityTransform.append(rotate)
-        identityTransform.append(translate)
+        identityTransform.appendTransform(scale)
+        identityTransform.appendTransform(rotate)
+        identityTransform.appendTransform(translate)
         
         checkPointTransformation(identityTransform, point: point, expectedPoint: point)
     }
 
     func test_TranslationComposed() {
         let xyPlus5 = NSAffineTransform()
-        xyPlus5.translateX(by: CGFloat(2.0), yBy: CGFloat(3.0))
-        xyPlus5.translateX(by: CGFloat(3.0), yBy: CGFloat(2.0))
+        xyPlus5.translateXBy(CGFloat(2.0), yBy: CGFloat(3.0))
+        xyPlus5.translateXBy(CGFloat(3.0), yBy: CGFloat(2.0))
 
         checkPointTransformation(xyPlus5, point: NSMakePoint(CGFloat(-2.0), CGFloat(-3.0)),
                                   expectedPoint: NSMakePoint(CGFloat(3.0), CGFloat(2.0)))
@@ -232,13 +232,13 @@ class TestNSAffineTransform : XCTestCase {
 
     func test_Scaling() {
         let xyTimes5 = NSAffineTransform()
-        xyTimes5.scale(by: CGFloat(5.0))
+        xyTimes5.scaleBy(CGFloat(5.0))
 
         checkPointTransformation(xyTimes5, point: NSMakePoint(CGFloat(-2.0), CGFloat(3.0)),
                                    expectedPoint: NSMakePoint(CGFloat(-10.0), CGFloat(15.0)))
 
         let xTimes2YTimes3 = NSAffineTransform()
-        xTimes2YTimes3.scaleX(by: CGFloat(2.0), yBy: CGFloat(-3.0))
+        xTimes2YTimes3.scaleXBy(CGFloat(2.0), yBy: CGFloat(-3.0))
 
         checkPointTransformation(xTimes2YTimes3, point: NSMakePoint(CGFloat(-1.0), CGFloat(3.5)),
                                          expectedPoint: NSMakePoint(CGFloat(-2.0), CGFloat(-10.5)))
@@ -246,8 +246,8 @@ class TestNSAffineTransform : XCTestCase {
 
     func test_TranslationScaling() {
         let xPlus2XYTimes5 = NSAffineTransform()
-        xPlus2XYTimes5.translateX(by: CGFloat(2.0), yBy: CGFloat())
-        xPlus2XYTimes5.scaleX(by: CGFloat(5.0), yBy: CGFloat(-5.0))
+        xPlus2XYTimes5.translateXBy(CGFloat(2.0), yBy: CGFloat())
+        xPlus2XYTimes5.scaleXBy(CGFloat(5.0), yBy: CGFloat(-5.0))
 
         checkPointTransformation(xPlus2XYTimes5, point: NSMakePoint(CGFloat(1.0), CGFloat(2.0)),
                                          expectedPoint: NSMakePoint(CGFloat(7.0), CGFloat(-10.0)))
@@ -255,8 +255,8 @@ class TestNSAffineTransform : XCTestCase {
 
     func test_ScalingTranslation() {
         let xyTimes5XPlus3 = NSAffineTransform()
-        xyTimes5XPlus3.scale(by: CGFloat(5.0))
-        xyTimes5XPlus3.translateX(by: CGFloat(3.0), yBy: CGFloat())
+        xyTimes5XPlus3.scaleBy(CGFloat(5.0))
+        xyTimes5XPlus3.translateXBy(CGFloat(3.0), yBy: CGFloat())
 
         checkPointTransformation(xyTimes5XPlus3, point: NSMakePoint(CGFloat(1.0), CGFloat(2.0)),
                                          expectedPoint: NSMakePoint(CGFloat(20.0), CGFloat(10.0)))
@@ -266,17 +266,17 @@ class TestNSAffineTransform : XCTestCase {
         let point = NSPoint(x: CGFloat(10.0), y: CGFloat(10.0))
         
         let identityTransform = NSAffineTransform()
-        identityTransform.append(identityTransform)
+        identityTransform.appendTransform(identityTransform)
         checkPointTransformation(identityTransform, point: point, expectedPoint: point)
         
         let translate = NSAffineTransform()
-        translate.translateX(by: CGFloat(10.0), yBy: CGFloat())
+        translate.translateXBy(CGFloat(10.0), yBy: CGFloat())
         
         let scale = NSAffineTransform()
-        scale.scale(by: CGFloat(2.0))
+        scale.scaleBy(CGFloat(2.0))
         
         let translateThenScale = NSAffineTransform(transform: translate)
-        translateThenScale.append(scale)
+        translateThenScale.appendTransform(scale)
         checkPointTransformation(translateThenScale, point: point, expectedPoint: NSPoint(x: CGFloat(40.0), y: CGFloat(20.0)))
     }
     
@@ -284,17 +284,17 @@ class TestNSAffineTransform : XCTestCase {
         let point = NSPoint(x: CGFloat(10.0), y: CGFloat(10.0))
         
         let identityTransform = NSAffineTransform()
-        identityTransform.prepend(identityTransform)
+        identityTransform.prependTransform(identityTransform)
         checkPointTransformation(identityTransform, point: point, expectedPoint: point)
         
         let translate = NSAffineTransform()
-        translate.translateX(by: CGFloat(10.0), yBy: CGFloat())
+        translate.translateXBy(CGFloat(10.0), yBy: CGFloat())
         
         let scale = NSAffineTransform()
-        scale.scale(by: CGFloat(2.0))
+        scale.scaleBy(CGFloat(2.0))
         
         let scaleThenTranslate = NSAffineTransform(transform: translate)
-        scaleThenTranslate.prepend(scale)
+        scaleThenTranslate.prependTransform(scale)
         checkPointTransformation(scaleThenTranslate, point: point, expectedPoint: NSPoint(x: CGFloat(30.0), y: CGFloat(20.0)))
     }
     
@@ -306,47 +306,25 @@ class TestNSAffineTransform : XCTestCase {
         let center = NSPoint(x: NSMidX(rect), y: NSMidY(rect))
         
         let rotate = NSAffineTransform()
-        rotate.rotate(byDegrees: CGFloat(90.0))
+        rotate.rotateByDegrees(CGFloat(90.0))
         
         let moveOrigin = NSAffineTransform()
-        moveOrigin.translateX(by: -center.x, yBy: -center.y)
+        moveOrigin.translateXBy(-center.x, yBy: -center.y)
         
         let moveBack = NSAffineTransform(transform: moveOrigin)
         moveBack.invert()
         
         let rotateAboutCenter = NSAffineTransform(transform: rotate)
-        rotateAboutCenter.prepend(moveOrigin)
-        rotateAboutCenter.append(moveBack)
+        rotateAboutCenter.prependTransform(moveOrigin)
+        rotateAboutCenter.appendTransform(moveBack)
         
         // center of rect shouldn't move as its the rotation anchor
         checkPointTransformation(rotateAboutCenter, point: center, expectedPoint: center)
-    }
-
-    func test_hashing_identity() {
-        let ref = NSAffineTransform()
-        let val = AffineTransform.identity
-        XCTAssertEqual(ref.hashValue, val.hashValue)
-    }
-
-    func test_hashing_values() {
-        // the transforms are made up and the values don't matter
-        let values = [
-            AffineTransform(m11: CGFloat(1.0), m12: CGFloat(2.5), m21: CGFloat(66.2), m22: CGFloat(40.2), tX: CGFloat(-5.5), tY: CGFloat(3.7)),
-            AffineTransform(m11: CGFloat(-55.66), m12: CGFloat(22.7), m21: CGFloat(1.5), m22: CGFloat(0.0), tX: CGFloat(-22.0), tY: CGFloat(-33.0)),
-            AffineTransform(m11: CGFloat(4.5), m12: CGFloat(1.1), m21: CGFloat(0.025), m22: CGFloat(0.077), tX: CGFloat(-0.55), tY: CGFloat(33.2)),
-            AffineTransform(m11: CGFloat(7.0), m12: CGFloat(-2.3), m21: CGFloat(6.7), m22: CGFloat(0.25), tX: CGFloat(0.556), tY: CGFloat(0.99)),
-            AffineTransform(m11: CGFloat(0.498), m12: CGFloat(-0.284), m21: CGFloat(-0.742), m22: CGFloat(0.3248), tX: CGFloat(12.0), tY: CGFloat(44.0))
-        ]
-        for val in values {
-            let ref = NSAffineTransform()
-            ref.transformStruct = val
-            XCTAssertEqual(ref.hashValue, val.hashValue)
-        }
     }
 }
 
 extension NSAffineTransform {
     func transformRect(_ aRect: NSRect) -> NSRect {
-        return NSRect(origin: transform(aRect.origin), size: transform(aRect.size))
+        return NSRect(origin: transformPoint(aRect.origin), size: transformSize(aRect.size))
     }
 }


### PR DESCRIPTION
Reverts apple/swift-corelibs-foundation#508. It broke on Linux.