### PR TITLE
Improvements suggested to PR 423

### DIFF
--- a/Foundation/NSHTTPCookie.swift
+++ b/Foundation/NSHTTPCookie.swift
@@ -362,7 +362,7 @@ open class HTTPCookie : NSObject {
         //bake the cookies
         var httpCookies: [HTTPCookie] = []
         for i in 0..<cookieIndices.count-1 {
-            if let aCookie = createHttpCookie(url: url, pairs: nameValuePairs, start: cookieIndices[i], end: cookieIndices[i+1]) {
+            if let aCookie = createHttpCookie(url: url, pairs: nameValuePairs[cookieIndices[i]..<cookieIndices[i+1]]) {
                 httpCookies.append(aCookie)
             }
         }
@@ -371,11 +371,11 @@ open class HTTPCookie : NSObject {
     } 
 
     //Bake a cookie
-    private class func createHttpCookie(url: URL, pairs: [String], start: Int, end: Int) -> HTTPCookie? {
+    private class func createHttpCookie(url: URL, pairs: ArraySlice<String>) -> HTTPCookie? {
         var properties: [String:Any] = [:]
-        for index in start..<end {
-            let name = pairs[index].components(separatedBy: "=")[0]
-            var value = pairs[index].components(separatedBy: "\(name)=")[1]  //a value can have an "="
+        for pair in pairs {
+            let name = pair.components(separatedBy: "=")[0]
+            var value = pair.components(separatedBy: "\(name)=")[1]  //a value can have an "="
             if canonicalize(name) == "Expires" {
                 value = value.insertComma(at: 3)    //re-insert the comma   
             }
@@ -553,7 +553,7 @@ open class HTTPCookie : NSObject {
 }
 
 //utils for cookie parsing
-internal extension String {
+fileprivate extension String {
     func trim() -> String {
         return self.trimmingCharacters(in: NSCharacterSet.whitespacesAndNewlines())
     }


### PR DESCRIPTION
This addresses the improvements suggested to https://github.com/apple/swift-corelibs-foundation/pull/423/files viz. 
1) Using an array slice instead of (array, start, end) 
2) Keeping the String extension (3 utility methods) private to the defining file

Thanks!