### PR TITLE
Foundation API Conformance Update: [NS]Index{Set,Path}

### DIFF
--- a/Foundation/IndexPath.swift
+++ b/Foundation/IndexPath.swift
@@ -32,8 +32,9 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
     }
     
     /// Initialize with a sequence of integers.
-    public init<ElementSequence : Sequence>(indexes: ElementSequence) where ElementSequence.Iterator.Element == Element {
-        _indexes = indexes.map { $0 }
+    public init<ElementSequence : Sequence>(indexes: ElementSequence)
+        where ElementSequence.Iterator.Element == Element {
+            _indexes = indexes.map { $0 }
     }
     
     /// Initialize with an array literal.
@@ -42,7 +43,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
     }
     
     /// Initialize with an array of elements.
-    public init(indexes: Array<Element>) {
+    public init(indexes: [Element]) {
         _indexes = indexes
     }
     
@@ -67,7 +68,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
     }
     
     /// Append an array of elements to `self`.
-    public mutating func append(_ other: Array<Element>) {
+    public mutating func append(_ other: [Element]) {
         _indexes.append(contentsOf: other)
     }
     
@@ -84,7 +85,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
     }
     
     /// Return a new `IndexPath` containing the elements in self and the elements in `other`.
-    public func appending(_ other: Array<Element>) -> IndexPath {
+    public func appending(_ other: [Element]) -> IndexPath {
         return IndexPath(indexes: _indexes + other)
     }
     
@@ -131,24 +132,17 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
     }
     
     /// Sorting an array of `IndexPath` using this comparison results in an array representing nodes in depth-first traversal order.
-    public func compare(_ other: IndexPath) -> ComparisonResult  {
+    public func compare(_ other: IndexPath) -> ComparisonResult {
         // This is temporary
         let me = self.makeReference()
-        return me.compare(other)
+        let other = other.makeReference()
+        return me.compare(other as IndexPath)
     }
     
     public var hashValue: Int {
         // This is temporary
         let me = self.makeReference()
         return me.hash
-    }
-    
-    public var description: String {
-        return _indexes.description
-    }
-    
-    public var debugDescription: String {
-        return _indexes.debugDescription
     }
     
     // MARK: - Bridging Helpers
@@ -158,59 +152,69 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
         if count == 0 {
             _indexes = []
         } else {
-            var ptr = malloc(count * MemoryLayout<Element>.size)?.bindMemory(to: Element.self, capacity: count * MemoryLayout<Element>.size)
+            var ptr = malloc(count * MemoryLayout<Element>.size)
             defer { free(ptr) }
             
-            nsIndexPath.getIndexes(ptr!, range: NSMakeRange(0, count))
+            let elementPtr = ptr!.bindMemory(to: Element.self, capacity: count)
+            nsIndexPath.getIndexes(elementPtr, range: NSMakeRange(0, count))
             
-            let buffer = UnsafeBufferPointer(start: ptr, count: count)
+            let buffer = UnsafeBufferPointer(start: elementPtr, count: count)
             _indexes = buffer.map { $0 }
         }
     }
     
     fileprivate func makeReference() -> ReferenceType {
         return _indexes.withUnsafeBufferPointer {
-            return ReferenceType(indexes: $0.baseAddress!, length: $0.count)
+            return ReferenceType(indexes: $0.baseAddress, length: $0.count)
         }
     }
     
+    public static func ==(lhs: IndexPath, rhs: IndexPath) -> Bool {
+        return lhs._indexes == rhs._indexes
+    }
+
+    public static func +(lhs: IndexPath, rhs: IndexPath) -> IndexPath {
+        return lhs.appending(rhs)
+    }
+
+    public static func +=(lhs: inout IndexPath, rhs: IndexPath) {
+        lhs.append(rhs)
+    }
+
+    public static func <(lhs: IndexPath, rhs: IndexPath) -> Bool {
+        return lhs.compare(rhs) == ComparisonResult.orderedAscending
+    }
+
+    public static func <=(lhs: IndexPath, rhs: IndexPath) -> Bool {
+        let order = lhs.compare(rhs)
+        return order == ComparisonResult.orderedAscending || order == ComparisonResult.orderedSame
+    }
+
+    public static func >(lhs: IndexPath, rhs: IndexPath) -> Bool {
+        return lhs.compare(rhs) == ComparisonResult.orderedDescending
+    }
+
+    public static func >=(lhs: IndexPath, rhs: IndexPath) -> Bool {
+        let order = lhs.compare(rhs)
+        return order == ComparisonResult.orderedDescending || order == ComparisonResult.orderedSame
+    }
 }
 
-public func ==(lhs: IndexPath, rhs: IndexPath) -> Bool {
-    return lhs._indexes == rhs._indexes
-}
+extension IndexPath : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    public var description: String {
+        return _indexes.description
+    }
 
-public func +(lhs: IndexPath, rhs: IndexPath) -> IndexPath {
-    return lhs.appending(rhs)
-}
-
-public func +=(lhs: inout IndexPath, rhs: IndexPath) {
-    lhs.append(rhs)
-}
-
-public func <(lhs: IndexPath, rhs: IndexPath) -> Bool {
-    return lhs.compare(rhs) == ComparisonResult.orderedAscending
-}
-
-public func <=(lhs: IndexPath, rhs: IndexPath) -> Bool {
-    let order = lhs.compare(rhs)
-    return order == ComparisonResult.orderedAscending || order == ComparisonResult.orderedSame
-}
-
-public func >(lhs: IndexPath, rhs: IndexPath) -> Bool {
-    return lhs.compare(rhs) == ComparisonResult.orderedDescending
-}
-
-public func >=(lhs: IndexPath, rhs: IndexPath) -> Bool {
-    let order = lhs.compare(rhs)
-    return order == ComparisonResult.orderedDescending || order == ComparisonResult.orderedSame
-}
-
-extension IndexPath {
-    public static func _isBridgedToObjectiveC() -> Bool {
-        return true
+    public var debugDescription: String {
+        return _indexes.debugDescription
     }
     
+    public var customMirror: Mirror {
+        return _indexes.customMirror
+    }
+}
+
+extension IndexPath : _ObjectiveCBridgeable {
     public static func _getObjectiveCType() -> Any.Type {
         return NSIndexPath.self
     }
@@ -231,5 +235,13 @@ extension IndexPath {
     
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSIndexPath?) -> IndexPath {
         return IndexPath(nsIndexPath: source!)
-    }    
+    }
+}
+
+extension NSIndexPath : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as IndexPath)
+    }
 }

--- a/Foundation/IndexPath.swift
+++ b/Foundation/IndexPath.swift
@@ -136,7 +136,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
         // This is temporary
         let me = self.makeReference()
         let other = other.makeReference()
-        return me.compare(other as IndexPath)
+        return me.compare(IndexPath._unconditionallyBridgeFromObjectiveC(other))
     }
     
     public var hashValue: Int {
@@ -214,7 +214,7 @@ extension IndexPath : CustomStringConvertible, CustomDebugStringConvertible, Cus
     }
 }
 
-extension IndexPath : _ObjectiveCBridgeable {
+extension IndexPath {
     public static func _getObjectiveCType() -> Any.Type {
         return NSIndexPath.self
     }
@@ -242,6 +242,6 @@ extension NSIndexPath : _HasCustomAnyHashableRepresentation {
     // Must be @nonobjc to avoid infinite recursion during bridging.
     @nonobjc
     public func _toCustomAnyHashable() -> AnyHashable? {
-        return AnyHashable(self as IndexPath)
+        return AnyHashable(IndexPath._unconditionallyBridgeFromObjectiveC(self))
     }
 }

--- a/Foundation/IndexSet.swift
+++ b/Foundation/IndexSet.swift
@@ -865,7 +865,7 @@ private func _toNSRange(_ r : Range<IndexSet.Element>) -> NSRange {
     return NSMakeRange(r.lowerBound, r.upperBound - r.lowerBound)
 }
 
-extension IndexSet : _ObjectiveCBridgeable {
+extension IndexSet {
     public static func _getObjectiveCType() -> Any.Type {
         return NSIndexSet.self
     }
@@ -894,7 +894,7 @@ extension NSIndexSet : _HasCustomAnyHashableRepresentation {
     // Must be @nonobjc to avoid infinite recursion during bridging.
     @nonobjc
     public func _toCustomAnyHashable() -> AnyHashable? {
-        return AnyHashable(self as IndexSet)
+        return AnyHashable(IndexSet._unconditionallyBridgeFromObjectiveC(self))
     }
 }
 

--- a/Foundation/IndexSet.swift
+++ b/Foundation/IndexSet.swift
@@ -10,29 +10,32 @@
 //
 //===----------------------------------------------------------------------===//
 
-
-public func ==(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
-    return lhs.value == rhs.value && rhs.rangeIndex == rhs.rangeIndex
+extension IndexSet.Index {
+    public static func ==(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
+        return lhs.value == rhs.value && rhs.rangeIndex == rhs.rangeIndex
+    }
+    
+    public static func <(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
+        return lhs.value < rhs.value && rhs.rangeIndex <= rhs.rangeIndex
+    }
+    
+    public static func <=(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
+        return lhs.value <= rhs.value && rhs.rangeIndex <= rhs.rangeIndex
+    }
+    
+    public static func >(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
+        return lhs.value > rhs.value && rhs.rangeIndex >= rhs.rangeIndex
+    }
+    
+    public static func >=(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
+        return lhs.value >= rhs.value && rhs.rangeIndex >= rhs.rangeIndex
+    }
 }
 
-public func <(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
-    return lhs.value < rhs.value && rhs.rangeIndex <= rhs.rangeIndex
-}
-
-public func <=(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
-    return lhs.value <= rhs.value && rhs.rangeIndex <= rhs.rangeIndex
-}
-
-public func >(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
-    return lhs.value > rhs.value && rhs.rangeIndex >= rhs.rangeIndex
-}
-
-public func >=(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
-    return lhs.value >= rhs.value && rhs.rangeIndex >= rhs.rangeIndex
-}
-
-public func ==(lhs: IndexSet.RangeView, rhs: IndexSet.RangeView) -> Bool {
-    return lhs.startIndex == rhs.startIndex && lhs.endIndex == rhs.endIndex && lhs.indexSet == rhs.indexSet
+extension IndexSet.RangeView {
+    public static func ==(lhs: IndexSet.RangeView, rhs: IndexSet.RangeView) -> Bool {
+        return lhs.startIndex == rhs.startIndex && lhs.endIndex == rhs.endIndex && lhs.indexSet == rhs.indexSet
+    }
 }
 
 // We currently cannot use this mechanism because NSIndexSet is not abstract; it has its own ivars and therefore subclassing it using the same trick as NSData, etc. does not work.
@@ -49,37 +52,37 @@ public func ==(lhs: IndexSet.RangeView, rhs: IndexSet.RangeView) -> Bool {
  __wrapped = .Immutable(
  Unmanaged.passRetained(
  _unsafeReferenceCast(immutableObject, to: ImmutableType.self)))
- 
- super.init()
- }
- 
- init(mutableObject: AnyObject) {
- // Take ownership.
- __wrapped = .Mutable(
- Unmanaged.passRetained(
- _unsafeReferenceCast(mutableObject, to: MutableType.self)))
- super.init()
- }
- 
- public required init(unmanagedImmutableObject: Unmanaged<ImmutableType>) {
- // Take ownership.
- __wrapped = .Immutable(unmanagedImmutableObject)
- 
- super.init()
- }
- 
- public required init(unmanagedMutableObject: Unmanaged<MutableType>) {
- // Take ownership.
- __wrapped = .Mutable(unmanagedMutableObject)
- 
- super.init()
- }
- 
- deinit {
- releaseWrappedObject()
- }
- }
- */
+
+      super.init()
+    }
+
+    init(mutableObject: AnyObject) {
+      // Take ownership.
+      __wrapped = .Mutable(
+       Unmanaged.passRetained(
+         _unsafeReferenceCast(mutableObject, to: MutableType.self)))
+      super.init()
+    }
+
+    public required init(unmanagedImmutableObject: Unmanaged<ImmutableType>) {
+      // Take ownership.
+      __wrapped = .Immutable(unmanagedImmutableObject)
+
+      super.init()
+    }
+
+    public required init(unmanagedMutableObject: Unmanaged<MutableType>) {
+      // Take ownership.
+      __wrapped = .Mutable(unmanagedMutableObject)
+
+      super.init()
+    }
+
+    deinit {
+      releaseWrappedObject()
+    }
+}
+*/
 
 /// Manages a `Set` of integer values, which are commonly used as an index type in Cocoa API.
 ///
@@ -93,15 +96,15 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     /// then calling `next()` on this view's iterator will produce 3 ranges before returning nil.
     public struct RangeView : Equatable, BidirectionalCollection {
         public typealias Index = Int
-        public let startIndex : Index
-        public let endIndex : Index
+        public let startIndex: Index
+        public let endIndex: Index
         
         fileprivate var indexSet : IndexSet
         
         // Range of element values
-        private var intersectingRange : Range<IndexSet.Element>?
+        private var intersectingRange: Range<IndexSet.Element>?
         
-        fileprivate init(indexSet : IndexSet, intersecting range : Range<IndexSet.Element>?) {
+        fileprivate init(indexSet: IndexSet, intersecting range : Range<IndexSet.Element>?) {
             self.indexSet = indexSet
             self.intersectingRange = range
             
@@ -140,7 +143,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
             return IndexingIterator(_elements: self)
         }
         
-        public subscript(index : Index) -> CountableRange<IndexSet.Element> {
+        public subscript(index: Index) -> CountableRange<IndexSet.Element> {
             let indexSetRange = indexSet._range(at: index)
             if let intersectingRange = intersectingRange {
                 return Swift.max(intersectingRange.lowerBound, indexSetRange.lowerBound)..<Swift.min(intersectingRange.upperBound, indexSetRange.upperBound)
@@ -152,7 +155,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         public subscript(bounds: Range<Index>) -> BidirectionalSlice<RangeView> {
             return BidirectionalSlice(base: self, bounds: bounds)
         }
-        
+
         public func index(after i: Index) -> Index {
             return i + 1
         }
@@ -163,152 +166,41 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         
     }
     
-    /// The mechanism for getting to the integers stored in an IndexSet.
+    /// The mechanism for accessing the integers stored in an IndexSet.
     public struct Index : CustomStringConvertible, Comparable {
-        fileprivate let indexSet : IndexSet
         fileprivate var value : IndexSet.Element
         fileprivate var extent : Range<IndexSet.Element>
         fileprivate var rangeIndex : Int
         fileprivate let rangeCount : Int
         
-        fileprivate init(firstIn indexSet : IndexSet) {
-            self.indexSet = indexSet
-            self.rangeCount = indexSet._rangeCount
-            self.rangeIndex = 0
-            self.extent =  indexSet._range(at: 0)
-            self.value = extent.lowerBound
-        }
-        
-        fileprivate init(lastIn indexSet : IndexSet) {
-            self.indexSet = indexSet
-            let rangeCount = indexSet._rangeCount
-            self.rangeIndex = rangeCount - 1
-            if rangeCount > 0 {
-                self.extent = indexSet._range(at: rangeCount - 1)
-                self.value = extent.upperBound // "1 past the end" position is the last range, 1 + the end of that range's extent
-            } else {
-                self.extent = 0..<0
-                self.value = 0
-            }
-            self.rangeCount = rangeCount
-        }
-        
-        fileprivate init(indexSet: IndexSet, index: Int) {
-            self.indexSet = indexSet
-            self.rangeCount = self.indexSet._rangeCount
-            self.value = index
-            if let rangeIndex = self.indexSet._indexOfRange(containing: index) {
-                self.extent = self.indexSet._range(at: rangeIndex)
-                self.rangeIndex = rangeIndex
-            } else {
-                self.extent = 0..<0
-                self.rangeIndex = 0
-            }
-        }
-        
-        // First or last value in a specified range
-        fileprivate init(indexSet: IndexSet, rangeIndex: Int, rangeCount: Int, first : Bool) {
-            self.indexSet = indexSet
-            let extent = indexSet._range(at: rangeIndex)
-            if first {
-                self.value = extent.lowerBound
-            } else {
-                self.value = extent.upperBound-1
-            }
-            self.extent = extent
-            self.rangeCount = rangeCount
-            self.rangeIndex = rangeIndex
-        }
-        
-        fileprivate init(indexSet: IndexSet, value: Int, extent: Range<Int>, rangeIndex: Int, rangeCount: Int) {
-            self.indexSet = indexSet
+        fileprivate init(value: Int, extent: Range<Int>, rangeIndex: Int, rangeCount: Int) {
             self.value = value
             self.extent = extent
             self.rangeCount = rangeCount
             self.rangeIndex = rangeIndex
         }
         
-        fileprivate func successor() -> Index {
-            if value + 1 == extent.upperBound {
-                // Move to the next range
-                if rangeIndex + 1 == rangeCount {
-                    // We have no more to go; return a 'past the end' index
-                    return Index(indexSet: indexSet, value: value + 1, extent: extent, rangeIndex: rangeIndex, rangeCount: rangeCount)
-                } else {
-                    return Index(indexSet: indexSet, rangeIndex: rangeIndex + 1, rangeCount: rangeCount, first: true)
-                }
-            } else {
-                // Move to the next value in this range
-                return Index(indexSet: indexSet, value: value + 1, extent: extent, rangeIndex: rangeIndex, rangeCount: rangeCount)
-            }
-        }
-        
-        fileprivate mutating func _successorInPlace() {
-            if value + 1 == extent.upperBound {
-                // Move to the next range
-                if rangeIndex + 1 == rangeCount {
-                    // We have no more to go; return a 'past the end' index
-                    value += 1
-                } else {
-                    rangeIndex += 1
-                    extent = indexSet._range(at: rangeIndex)
-                    value = extent.lowerBound
-                }
-            } else {
-                // Move to the next value in this range
-                value += 1
-            }
-        }
-        
-        fileprivate func predecessor() -> Index {
-            if value == extent.lowerBound {
-                // Move to the next range
-                if rangeIndex == 0 {
-                    // We have no more to go
-                    return Index(indexSet: indexSet, value: value, extent: extent, rangeIndex: rangeIndex, rangeCount: rangeCount)
-                } else {
-                    return Index(indexSet: indexSet, rangeIndex: rangeIndex - 1, rangeCount: rangeCount, first: false)
-                }
-            } else {
-                // Move to the previous value in this range
-                return Index(indexSet: indexSet, value: value - 1, extent: extent, rangeIndex: rangeIndex, rangeCount: rangeCount)
-            }
-        }
-        
         public var description: String {
             return "index \(value) in a range of \(extent) [range #\(rangeIndex + 1)/\(rangeCount)]"
         }
-        
-        fileprivate mutating func _predecessorInPlace() {
-            if value == extent.lowerBound {
-                // Move to the next range
-                if rangeIndex == 0 {
-                    // We have no more to go
-                } else {
-                    rangeIndex -= 1
-                    extent = indexSet._range(at: rangeIndex)
-                    value = extent.upperBound - 1
-                }
-            } else {
-                // Move to the previous value in this range
-                value -= 1
-            }
-        }
     }
-    
+
     public typealias ReferenceType = NSIndexSet
     public typealias Element = Int
     
     fileprivate var _handle: _MutablePairHandle<NSIndexSet, NSMutableIndexSet>
     
-    internal init(indexesIn range: NSRange) {
-        _handle = _MutablePairHandle(NSIndexSet(indexesIn: range), copying: false)
-    }
-    
     /// Initialize an `IndexSet` with a range of integers.
     public init(integersIn range: Range<Element>) {
         _handle = _MutablePairHandle(NSIndexSet(indexesIn: _toNSRange(range)), copying: false)
     }
+    
+    /// Initialize an `IndexSet` with a range of integers.
+    public init(integersIn range: ClosedRange<Element>) { self.init(integersIn: Range(range)) }
+    /// Initialize an `IndexSet` with a range of integers.
+    public init(integersIn range: CountableClosedRange<Element>) { self.init(integersIn: Range(range)) }
+    /// Initialize an `IndexSet` with a range of integers.
+    public init(integersIn range: CountableRange<Element>) { self.init(integersIn: Range(range)) }
     
     /// Initialize an `IndexSet` with a single integer.
     public init(integer: Element) {
@@ -320,7 +212,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         _handle = _MutablePairHandle(NSIndexSet(), copying: false)
     }
     
-    public var hashValue : Int {
+    public var hashValue: Int {
         return _handle.map { $0.hash }
     }
     
@@ -332,13 +224,34 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     public func makeIterator() -> IndexingIterator<IndexSet> {
         return IndexingIterator(_elements: self)
     }
+
+    /// Returns a `Range`-based view of the entire contents of `self`.
+    ///
+    /// - seealso: rangeView(of:)
+    public var rangeView: RangeView {
+        return RangeView(indexSet: self, intersecting: nil)
+    }
+
+    /// Returns a `Range`-based view of `self`.
+    ///
+    /// - parameter range: A subrange of `self` to view.
+    public func rangeView(of range: Range<Element>) -> RangeView {
+        return RangeView(indexSet: self, intersecting: range)
+    }
     
     /// Returns a `Range`-based view of `self`.
     ///
-    /// - parameter range: A subrange of `self` to view. The default value is `nil`, which means that the entire `IndexSet` is used.
-    public func rangeView(of range : Range<Element>? = nil) -> RangeView {
-        return RangeView(indexSet: self, intersecting: range)
-    }
+    /// - parameter range: A subrange of `self` to view.
+    public func rangeView(of range: ClosedRange<Element>) -> RangeView { return self.rangeView(of: Range(range)) }
+    /// Returns a `Range`-based view of `self`.
+    ///
+    /// - parameter range: A subrange of `self` to view.
+    public func rangeView(of range: CountableClosedRange<Element>) -> RangeView { return self.rangeView(of: Range(range)) }
+    /// Returns a `Range`-based view of `self`.
+    ///
+    /// - parameter range: A subrange of `self` to view.
+    public func rangeView(of range: CountableRange<Element>) -> RangeView { return self.rangeView(of: Range(range)) }
+
     
     private func _indexOfRange(containing integer : Element) -> RangeView.Index? {
         let result = _handle.map {
@@ -355,9 +268,6 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         return _handle.map {
             var location : UInt = 0
             var length : UInt = 0
-            if __NSIndexSetRangeCount($0) == 0 {
-                return 0..<0
-            }
             __NSIndexSetRangeAtIndex($0, UInt(index), &location, &length)
             return Int(location)..<Int(location)+Int(length)
         }
@@ -370,32 +280,43 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     }
     
     public var startIndex: Index {
-        // TODO: We should cache this result
-        
         // If this winds up being NSNotFound, that's ok because then endIndex is also NSNotFound, and empty collections have startIndex == endIndex
-        return Index(firstIn: self)
-    }
-    
-    public var endIndex: Index {
-        // TODO: We should cache this result
+        let extent: Range<Int>
+        if _rangeCount > 0 {
+            extent = _range(at: 0)
+        } else {
+            extent = NSNotFound..<NSNotFound
+        }
         
-        return Index(lastIn: self)
+        return Index(value: extent.lowerBound, extent: extent, rangeIndex: 0, rangeCount: _rangeCount)
+    }
+
+    public var endIndex: Index {
+        let rangeIndex = _rangeCount - 1;
+        let extent: Range<Int>
+        if _rangeCount > 0 {
+            extent = _range(at: rangeIndex)
+        } else {
+            extent = NSNotFound..<NSNotFound
+        }
+        
+        return Index(value: extent.upperBound, extent: extent, rangeIndex: rangeIndex, rangeCount: _rangeCount)
     }
     
-    public subscript(index : Index) -> Element {
+    public subscript(index: Index) -> Element {
         return index.value
     }
-    
+
     public subscript(bounds: Range<Index>) -> BidirectionalSlice<IndexSet> {
         return BidirectionalSlice(base: self, bounds: bounds)
     }
-    
+
     // We adopt the default implementation of subscript(range: Range<Index>) from MutableCollection
     
     private func _toOptional(_ x : Int) -> Int? {
         if x == NSNotFound { return nil } else { return x }
     }
-    
+
     /// Returns the first integer in `self`, or nil if `self` is empty.
     public var first: Element? {
         return _handle.map { _toOptional($0.firstIndex) }
@@ -406,24 +327,50 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         return _handle.map { _toOptional($0.lastIndex) }
     }
     
-    /// Returns an integer contained in `self` which is greater than `integer`.
-    public func integerGreaterThan(_ integer: Element) -> Element {
-        return _handle.map { $0.indexGreaterThanIndex(integer) }
+    /// Returns an integer contained in `self` which is greater than `integer`, or `nil` if a result could not be found.
+    public func integerGreaterThan(_ integer: Element) -> Element? {
+        return _handle.map { _toOptional($0.indexGreaterThanIndex(integer)) }
     }
     
-    /// Returns an integer contained in `self` which is less than `integer`.
-    public func integerLessThan(_ integer: Element) -> Element {
-        return _handle.map { $0.indexLessThanIndex(integer) }
+    /// Returns an integer contained in `self` which is less than `integer`, or `nil` if a result could not be found.
+    public func integerLessThan(_ integer: Element) -> Element? {
+        return _handle.map { _toOptional($0.indexLessThanIndex(integer)) }
     }
     
-    /// Returns an integer contained in `self` which is greater than or equal to `integer`.
-    public func integerGreaterThanOrEqualTo(_ integer: Element) -> Element {
-        return _handle.map { $0.indexGreaterThanOrEqual(to: integer) }
+    /// Returns an integer contained in `self` which is greater than or equal to `integer`, or `nil` if a result could not be found.
+    public func integerGreaterThanOrEqualTo(_ integer: Element) -> Element? {
+        return _handle.map { _toOptional($0.indexGreaterThanOrEqual(to: integer)) }
     }
     
-    /// Returns an integer contained in `self` which is less than or equal to `integer`.
-    public func integerLessThanOrEqualTo(_ integer: Element) -> Element {
-        return _handle.map { $0.indexLessThanOrEqual(to: integer) }
+    /// Returns an integer contained in `self` which is less than or equal to `integer`, or `nil` if a result could not be found.
+    public func integerLessThanOrEqualTo(_ integer: Element) -> Element? {
+        return _handle.map { _toOptional($0.indexLessThanOrEqual(to: integer)) }
+    }
+    
+    /// Return a `Range<IndexSet.Index>` which can be used to subscript the index set.
+    ///
+    /// The resulting range is the range of the intersection of the integers in `range` with the index set. The resulting range will be `isEmpty` if the intersection is empty.
+    ///
+    /// - parameter range: The range of integers to include.
+    public func indexRange(in range: Range<Element>) -> Range<Index> {
+        guard !range.isEmpty, let first = first, let last = last else {
+            let i = _index(ofInteger: 0)
+            return i..<i
+        }
+
+        if range.lowerBound > last || (range.upperBound - 1) < first {
+            let i = _index(ofInteger: 0)
+            return i..<i
+        }
+        
+        if let start = integerGreaterThanOrEqualTo(range.lowerBound), let end = integerLessThanOrEqualTo(range.upperBound - 1) {
+            let resultFirst = _index(ofInteger: start)
+            let resultLast = _index(ofInteger: end)
+            return resultFirst..<index(after: resultLast)
+        } else {
+            let i = _index(ofInteger: 0)
+            return i..<i
+        }
     }
     
     /// Return a `Range<IndexSet.Index>` which can be used to subscript the index set.
@@ -431,27 +378,33 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     /// The resulting range is the range of the intersection of the integers in `range` with the index set.
     ///
     /// - parameter range: The range of integers to include.
-    public func indexRange(in range: Range<Element>) -> Range<Index> {
-        if isEmpty || range.isEmpty {
-            let i = Index(indexSet: self, index: 0)
-            return i..<i
-        }
-        
-        if range.lowerBound > last! || (range.upperBound - 1) < first! {
-            let i = Index(indexSet: self, index: 0)
-            return i..<i
-        }
-        
-        let resultFirst = Index(indexSet: self, index: integerGreaterThanOrEqualTo(range.lowerBound))
-        let resultLast = Index(indexSet: self, index: integerLessThanOrEqualTo(range.upperBound - 1))
-        return resultFirst..<resultLast.successor()
-    }
-    
+    public func indexRange(in range: CountableRange<Element>) -> Range<Index> { return self.indexRange(in: Range(range)) }
+    /// Return a `Range<IndexSet.Index>` which can be used to subscript the index set.
+    ///
+    /// The resulting range is the range of the intersection of the integers in `range` with the index set.
+    ///
+    /// - parameter range: The range of integers to include.
+    public func indexRange(in range: ClosedRange<Element>) -> Range<Index> { return self.indexRange(in: Range(range)) }
+    /// Return a `Range<IndexSet.Index>` which can be used to subscript the index set.
+    ///
+    /// The resulting range is the range of the intersection of the integers in `range` with the index set.
+    ///
+    /// - parameter range: The range of integers to include.
+    public func indexRange(in range: CountableClosedRange<Element>) -> Range<Index> { return self.indexRange(in: Range(range)) }
+
+
     /// Returns the count of integers in `self` that intersect `range`.
     public func count(in range: Range<Element>) -> Int {
         return _handle.map { $0.countOfIndexes(in: _toNSRange(range)) }
     }
-    
+
+    /// Returns the count of integers in `self` that intersect `range`.
+    public func count(in range: CountableRange<Element>) -> Int { return self.count(in: Range(range)) }
+    /// Returns the count of integers in `self` that intersect `range`.
+    public func count(in range: ClosedRange<Element>) -> Int { return self.count(in: Range(range)) }
+    /// Returns the count of integers in `self` that intersect `range`.
+    public func count(in range: CountableClosedRange<Element>) -> Int { return self.count(in: Range(range)) }
+
     /// Returns `true` if `self` contains `integer`.
     public func contains(_ integer: Element) -> Bool {
         return _handle.map { $0.contains(integer) }
@@ -461,6 +414,14 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     public func contains(integersIn range: Range<Element>) -> Bool {
         return _handle.map { $0.contains(in: _toNSRange(range)) }
     }
+
+    /// Returns `true` if `self` contains all of the integers in `range`.
+    public func contains(integersIn range: CountableRange<Element>) -> Bool { return self.contains(integersIn: Range(range)) }
+    /// Returns `true` if `self` contains all of the integers in `range`.
+    public func contains(integersIn range: ClosedRange<Element>) -> Bool { return self.contains(integersIn: Range(range)) }
+    /// Returns `true` if `self` contains all of the integers in `range`.
+    public func contains(integersIn range: CountableClosedRange<Element>) -> Bool { return self.contains(integersIn: Range(range)) }
+
     
     /// Returns `true` if `self` contains all of the integers in `indexSet`.
     public func contains(integersIn indexSet: IndexSet) -> Bool {
@@ -471,24 +432,100 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     public func intersects(integersIn range: Range<Element>) -> Bool {
         return _handle.map { $0.intersects(in: _toNSRange(range)) }
     }
-    
+
+    /// Returns `true` if `self` intersects any of the integers in `range`.
+    public func intersects(integersIn range: CountableRange<Element>) -> Bool { return self.intersects(integersIn: Range(range)) }
+    /// Returns `true` if `self` intersects any of the integers in `range`.
+    public func intersects(integersIn range: ClosedRange<Element>) -> Bool { return self.intersects(integersIn: Range(range)) }
+    /// Returns `true` if `self` intersects any of the integers in `range`.
+    public func intersects(integersIn range: CountableClosedRange<Element>) -> Bool { return self.intersects(integersIn: Range(range)) }
+
     // MARK: -
     // Indexable
     
     public func index(after i: Index) -> Index {
-        return i.successor()
+        if i.value + 1 == i.extent.upperBound {
+            // Move to the next range
+            if i.rangeIndex + 1 == i.rangeCount {
+                // We have no more to go; return a 'past the end' index
+                return Index(value: i.value + 1, extent: i.extent, rangeIndex: i.rangeIndex, rangeCount: i.rangeCount)
+            } else {
+                let rangeIndex = i.rangeIndex + 1
+                let rangeCount = i.rangeCount
+                let extent = _range(at: rangeIndex)
+                let value = extent.lowerBound
+                return Index(value: value, extent: extent, rangeIndex: rangeIndex, rangeCount: rangeCount)
+            }
+        } else {
+            // Move to the next value in this range
+            return Index(value: i.value + 1, extent: i.extent, rangeIndex: i.rangeIndex, rangeCount: i.rangeCount)
+        }
     }
     
     public func formIndex(after i: inout Index) {
-        i._successorInPlace()
+        if i.value + 1 == i.extent.upperBound {
+            // Move to the next range
+            if i.rangeIndex + 1 == i.rangeCount {
+                // We have no more to go; return a 'past the end' index
+                i.value += 1
+            } else {
+                i.rangeIndex += 1
+                i.extent = _range(at: i.rangeIndex)
+                i.value = i.extent.lowerBound
+            }
+        } else {
+            // Move to the next value in this range
+            i.value += 1
+        }
     }
     
     public func index(before i: Index) -> Index {
-        return i.predecessor()
+        if i.value == i.extent.lowerBound {
+            // Move to the next range
+            if i.rangeIndex == 0 {
+                // We have no more to go
+                return Index(value: i.value, extent: i.extent, rangeIndex: i.rangeIndex, rangeCount: i.rangeCount)
+            } else {
+                let rangeIndex = i.rangeIndex - 1
+                let rangeCount = i.rangeCount
+                let extent = _range(at: rangeIndex)
+                let value = extent.upperBound - 1
+                return Index(value: value, extent: extent, rangeIndex: rangeIndex, rangeCount: rangeCount)
+            }
+        } else {
+            // Move to the previous value in this range
+            return Index(value: i.value - 1, extent: i.extent, rangeIndex: i.rangeIndex, rangeCount: i.rangeCount)
+        }
     }
     
     public func formIndex(before i: inout Index) {
-        i._predecessorInPlace()
+        if i.value == i.extent.lowerBound {
+            // Move to the next range
+            if i.rangeIndex == 0 {
+                // We have no more to go
+            } else {
+                i.rangeIndex -= 1
+                i.extent = _range(at: i.rangeIndex)
+                i.value = i.extent.upperBound - 1
+            }
+        } else {
+            // Move to the previous value in this range
+            i.value -= 1
+        }
+    }
+    
+    private func _index(ofInteger integer: Element) -> Index {
+        let rangeCount = _rangeCount
+        let value = integer
+        if let rangeIndex = _indexOfRange(containing: integer) {
+            let extent = _range(at: rangeIndex)
+            let rangeIndex = rangeIndex
+            return Index(value: value, extent: extent, rangeIndex: rangeIndex, rangeCount: rangeCount)
+        } else {
+            let extent = 0..<0
+            let rangeIndex = 0
+            return Index(value: value, extent: Range(extent), rangeIndex: rangeIndex, rangeCount: rangeCount)
+        }
     }
     
     // MARK: -
@@ -504,11 +541,11 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         // This algorithm is naïve but it works. We could avoid calling insert in some cases.
         
         var result = IndexSet()
-        for r in self.rangeView() {
+        for r in self.rangeView {
             result.insert(integersIn: Range(r))
         }
         
-        for r in other.rangeView() {
+        for r in other.rangeView {
             result.insert(integersIn: Range(r))
         }
         return result
@@ -520,7 +557,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         var boundaryIterator = IndexSetBoundaryIterator(self, other)
         var flag = false
         var start = 0
-        
+
         while let i = boundaryIterator.next() {
             if !flag {
                 // Start a range if one set contains but not the other.
@@ -571,12 +608,12 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         
         return result
     }
-    
+
     /// Intersect the `IndexSet` with `other`.
     public mutating func formIntersection(_ other: IndexSet) {
         self = self.intersection(other)
     }
-    
+
     /// Insert an integer into the `IndexSet`.
     @discardableResult
     public mutating func insert(_ integer: Element) -> (inserted: Bool, memberAfterInsert: Element) {
@@ -584,7 +621,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         // TODO: figure out how to return the truth here
         return (true, integer)
     }
-    
+
     /// Insert an integer into the `IndexSet`.
     @discardableResult
     public mutating func update(with integer: Element) -> Element? {
@@ -592,8 +629,8 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         // TODO: figure out how to return the truth here
         return integer
     }
-    
-    
+
+
     /// Remove an integer from the `IndexSet`.
     @discardableResult
     public mutating func remove(_ integer: Element) -> Element? {
@@ -602,7 +639,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         _applyMutation { $0.remove(integer) }
         return result
     }
-    
+
     // MARK: -
     
     /// Remove all values from the `IndexSet`.
@@ -614,25 +651,39 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     public mutating func insert(integersIn range: Range<Element>) {
         _applyMutation { $0.add(in: _toNSRange(range)) }
     }
-    
+
+    /// Insert a range of integers into the `IndexSet`.
+    public mutating func insert(integersIn range: CountableRange<Element>) { self.insert(integersIn: Range(range)) }
+    /// Insert a range of integers into the `IndexSet`.
+    public mutating func insert(integersIn range: ClosedRange<Element>) { self.insert(integersIn: Range(range)) }
+    /// Insert a range of integers into the `IndexSet`.
+    public mutating func insert(integersIn range: CountableClosedRange<Element>) { self.insert(integersIn: Range(range)) }
+
     /// Remove a range of integers from the `IndexSet`.
     public mutating func remove(integersIn range: Range<Element>) {
         _applyMutation { $0.remove(in: _toNSRange(range)) }
     }
     
+    /// Remove a range of integers from the `IndexSet`.
+    public mutating func remove(integersIn range: CountableRange<Element>) { self.remove(integersIn: Range(range)) }
+    /// Remove a range of integers from the `IndexSet`.
+    public mutating func remove(integersIn range: ClosedRange<Element>) { self.remove(integersIn: Range(range)) }
+    /// Remove a range of integers from the `IndexSet`.
+    public mutating func remove(integersIn range: CountableClosedRange<Element>) { self.remove(integersIn: Range(range)) }
+
     /// Returns `true` if self contains no values.
-    public var isEmpty : Bool {
+    public var isEmpty: Bool {
         return self.count == 0
     }
     
     /// Returns an IndexSet filtered according to the result of `includeInteger`.
     ///
-    /// - parameter range: A range of integers. For each integer in the range that intersects the integers in the IndexSet, then the `includeInteger predicate will be invoked. Pass `nil` (the default) to use the entire range.
+    /// - parameter range: A range of integers. For each integer in the range that intersects the integers in the IndexSet, then the `includeInteger` predicate will be invoked.
     /// - parameter includeInteger: The predicate which decides if an integer will be included in the result or not.
-    public func filteredIndexSet(in range : Range<Element>? = nil, includeInteger: (Element) throws -> Bool) rethrows -> IndexSet {
-        let r : NSRange = range != nil ? _toNSRange(range!) : NSMakeRange(0, NSNotFound - 1)
+    public func filteredIndexSet(in range: Range<Element>, includeInteger: (Element) throws -> Bool) rethrows -> IndexSet {
+        let r : NSRange = _toNSRange(range)
         return try _handle.map {
-            var error : Swift.Error? = nil
+            var error : Error? = nil
             let result = $0.indexes(in: r, options: [], passingTest: { (i, stop) -> Bool in
                 do {
                     let include = try includeInteger(i)
@@ -651,35 +702,59 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         }
     }
     
+    /// Returns an IndexSet filtered according to the result of `includeInteger`.
+    ///
+    /// - parameter range: A range of integers. For each integer in the range that intersects the integers in the IndexSet, then the `includeInteger` predicate will be invoked.
+    /// - parameter includeInteger: The predicate which decides if an integer will be included in the result or not.
+    public func filteredIndexSet(in range: CountableRange<Element>, includeInteger: (Element) throws -> Bool) rethrows -> IndexSet { return try self.filteredIndexSet(in: Range(range), includeInteger: includeInteger) }
+    /// Returns an IndexSet filtered according to the result of `includeInteger`.
+    ///
+    /// - parameter range: A range of integers. For each integer in the range that intersects the integers in the IndexSet, then the `includeInteger` predicate will be invoked.
+    /// - parameter includeInteger: The predicate which decides if an integer will be included in the result or not.
+    public func filteredIndexSet(in range: ClosedRange<Element>, includeInteger: (Element) throws -> Bool) rethrows -> IndexSet { return try self.filteredIndexSet(in: Range(range), includeInteger: includeInteger) }
+    /// Returns an IndexSet filtered according to the result of `includeInteger`.
+    ///
+    /// - parameter range: A range of integers. For each integer in the range that intersects the integers in the IndexSet, then the `includeInteger` predicate will be invoked.
+    /// - parameter includeInteger: The predicate which decides if an integer will be included in the result or not.
+    public func filteredIndexSet(in range: CountableClosedRange<Element>, includeInteger: (Element) throws -> Bool) rethrows -> IndexSet { return try self.filteredIndexSet(in: Range(range), includeInteger: includeInteger) }
+    
+    /// Returns an IndexSet filtered according to the result of `includeInteger`.
+    ///
+    /// - parameter includeInteger: The predicate which decides if an integer will be included in the result or not.
+    public func filteredIndexSet(includeInteger: (Element) throws -> Bool) rethrows -> IndexSet {
+        return try self.filteredIndexSet(in: 0..<NSNotFound-1, includeInteger: includeInteger)
+    }
+
     /// For a positive delta, shifts the indexes in [index, INT_MAX] to the right, thereby inserting an "empty space" [index, delta], for a negative delta, shifts the indexes in [index, INT_MAX] to the left, thereby deleting the indexes in the range [index - delta, delta].
     public mutating func shift(startingAt integer: Element, by delta: IndexSet.IndexDistance) {
         _applyMutation { $0.shiftIndexesStarting(at: integer, by: delta) }
     }
     
-    public var description: String {
-        return _handle.map { $0.description }
-    }
-    
-    public var debugDescription: String {
-        return _handle.map { $0.debugDescription }
-    }
-    
     // Temporary boxing function, until we can get a native Swift type for NSIndexSet
     /// TODO: making this inline causes the compiler to crash horrifically.
-    // @inline(__always)
+    //  @inline(__always)
     mutating func _applyMutation<ReturnType>(_ whatToDo : (NSMutableIndexSet) throws -> ReturnType) rethrows -> ReturnType {
+        // This check is done twice because: <rdar://problem/24939065> Value kept live for too long causing uniqueness check to fail
+        var unique = true
+        switch _handle._pointer {
+        case .Default(_):
+            break
+        case .Mutable(_):
+            unique = isKnownUniquelyReferenced(&_handle)
+        }
+
         switch _handle._pointer {
         case .Default(let i):
             // We need to become mutable; by creating a new box we also become unique
-            let copy = i.mutableCopy(with: nil) as! NSMutableIndexSet
+            let copy = i.mutableCopy() as! NSMutableIndexSet
             // Be sure to set the _handle before calling out; otherwise references to the struct in the closure may be looking at the old _handle
             _handle = _MutablePairHandle(copy, copying: false)
             let result = try whatToDo(copy)
             return result
         case .Mutable(let m):
             // Only create a new box if we are not uniquely referenced
-            if !isKnownUniquelyReferenced(&_handle) {
-                let copy = m.mutableCopy(with: nil) as! NSMutableIndexSet
+            if !unique {
+                let copy = m.mutableCopy() as! NSMutableIndexSet
                 _handle = _MutablePairHandle(copy, copying: false)
                 let result = try whatToDo(copy)
                 return result
@@ -700,9 +775,25 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     }
 }
 
+extension IndexSet : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    public var description: String {
+        return "\(count) indexes"
+    }
+    
+    public var debugDescription: String {
+        return "\(count) indexes"
+    }
+
+    public var customMirror: Mirror {
+        var c: [(label: String?, value: Any)] = []
+        c.append((label: "ranges", value: rangeView.map { $0 }))
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+    }
+}
+
 /// Iterate two index sets on the boundaries of their ranges. This is where all of the interesting stuff happens for exclusive or, intersect, etc.
 private struct IndexSetBoundaryIterator : IteratorProtocol {
-    fileprivate typealias Element = IndexSet.Element
+    typealias Element = IndexSet.Element
     
     private var i1 : IndexSet.RangeView.Iterator
     private var i2 : IndexSet.RangeView.Iterator
@@ -712,8 +803,8 @@ private struct IndexSetBoundaryIterator : IteratorProtocol {
     private var i2UsedLower : Bool
     
     fileprivate init(_ is1 : IndexSet, _ is2 : IndexSet) {
-        i1 = is1.rangeView().makeIterator()
-        i2 = is2.rangeView().makeIterator()
+        i1 = is1.rangeView.makeIterator()
+        i2 = is2.rangeView.makeIterator()
         
         i1Range = i1.next()
         i2Range = i2.next()
@@ -764,19 +855,17 @@ private struct IndexSetBoundaryIterator : IteratorProtocol {
     }
 }
 
-public func ==(lhs: IndexSet, rhs: IndexSet) -> Bool {
-    return lhs._handle.map { $0.isEqual(to: rhs) }
+extension IndexSet {
+    public static func ==(lhs: IndexSet, rhs: IndexSet) -> Bool {
+        return lhs._handle.map { $0.isEqual(to: rhs) }
+    }
 }
 
 private func _toNSRange(_ r : Range<IndexSet.Element>) -> NSRange {
     return NSMakeRange(r.lowerBound, r.upperBound - r.lowerBound)
 }
 
-extension IndexSet {
-    public static func _isBridgedToObjectiveC() -> Bool {
-        return true
-    }
-    
+extension IndexSet : _ObjectiveCBridgeable {
     public static func _getObjectiveCType() -> Any.Type {
         return NSIndexSet.self
     }
@@ -794,13 +883,20 @@ extension IndexSet {
         result = IndexSet(reference: x)
         return true
     }
-    
+
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSIndexSet?) -> IndexSet {
         return IndexSet(reference: source!)
     }
     
 }
 
+extension NSIndexSet : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as IndexSet)
+    }
+}
 
 // MARK: Protocol
 
@@ -816,7 +912,8 @@ private enum _MutablePair<ImmutableType, MutableType> {
 /// A class type which acts as a handle (pointer-to-pointer) to a Foundation reference type which has both an immutable and mutable class (e.g., NSData, NSMutableData).
 ///
 /// a.k.a. Box
-private final class _MutablePairHandle<ImmutableType : NSObject, MutableType : NSObject> where ImmutableType : NSMutableCopying, MutableType : NSMutableCopying {
+private final class _MutablePairHandle<ImmutableType : NSObject, MutableType : NSObject>
+  where ImmutableType : NSMutableCopying, MutableType : NSMutableCopying {
     fileprivate var _pointer: _MutablePair<ImmutableType, MutableType>
     
     /// Initialize with an immutable reference instance.

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -434,10 +434,10 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
     public func enumerateObjects(_ block: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
         self.enumerateObjects([], using: block)
     }
-    public func enumerateObjects(_ opts: EnumerationOptions = [], using block: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) {
+    public func enumerateObjects(_ opts: NSEnumerationOptions = [], using block: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) {
         self.enumerateObjects(at: IndexSet(indexesIn: NSMakeRange(0, count)), options: opts, using: block)
     }
-    public func enumerateObjects(at s: IndexSet, options opts: EnumerationOptions = [], using block: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
+    public func enumerateObjects(at s: IndexSet, options opts: NSEnumerationOptions = [], using block: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
         guard !opts.contains(.concurrent) else {
             NSUnimplemented()
         }
@@ -449,10 +449,10 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
     open func indexOfObject(passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
         return indexOfObject([], passingTest: predicate)
     }
-    open func indexOfObject(_ opts: EnumerationOptions = [], passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
+    open func indexOfObject(_ opts: NSEnumerationOptions = [], passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
         return indexOfObject(at: IndexSet(indexesIn: NSMakeRange(0, count)), options: opts, passingTest: predicate)
     }
-    open func indexOfObject(at s: IndexSet, options opts: EnumerationOptions = [], passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
+    open func indexOfObject(at s: IndexSet, options opts: NSEnumerationOptions = [], passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
         var result = NSNotFound
         enumerateObjects(at: s, options: opts) { (obj, idx, stop) -> Void in
             if predicate(obj, idx, stop) {
@@ -466,10 +466,10 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
     open func indexesOfObjects(passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
         return indexesOfObjects([], passingTest: predicate)
     }
-    open func indexesOfObjects(_ opts: EnumerationOptions = [], passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
+    open func indexesOfObjects(_ opts: NSEnumerationOptions = [], passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
         return indexesOfObjects(at: IndexSet(indexesIn: NSMakeRange(0, count)), options: opts, passingTest: predicate)
     }
-    open func indexesOfObjects(at s: IndexSet, options opts: EnumerationOptions = [], passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
+    open func indexesOfObjects(at s: IndexSet, options opts: NSEnumerationOptions = [], passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
         var result = IndexSet()
         enumerateObjects(at: s, options: opts) { (obj, idx, stop) in
             if predicate(obj, idx, stop) {

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -441,7 +441,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         guard !opts.contains(.concurrent) else {
             NSUnimplemented()
         }
-        s._bridgeToObjectiveC().enumerate(opts) { (idx, stop) in
+        s._bridgeToObjectiveC().enumerate(options: opts) { (idx, stop) in
             block(self.object(at: idx), idx, stop)
         }
     }

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -416,7 +416,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
     
     open func objects(at indexes: IndexSet) -> [AnyObject] {
         var objs = [AnyObject]()
-        indexes.rangeView().forEach {
+        indexes.rangeView.forEach {
             objs.append(contentsOf: self.subarray(with: NSRange(location: $0.lowerBound, length: $0.upperBound - $0.lowerBound)))
         }
         
@@ -435,7 +435,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         self.enumerateObjects([], using: block)
     }
     public func enumerateObjects(_ opts: NSEnumerationOptions = [], using block: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) {
-        self.enumerateObjects(at: IndexSet(indexesIn: NSMakeRange(0, count)), options: opts, using: block)
+        self.enumerateObjects(at: IndexSet(integersIn: 0..<count), options: opts, using: block)
     }
     public func enumerateObjects(at s: IndexSet, options opts: NSEnumerationOptions = [], using block: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
         guard !opts.contains(.concurrent) else {
@@ -450,7 +450,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         return indexOfObject([], passingTest: predicate)
     }
     open func indexOfObject(_ opts: NSEnumerationOptions = [], passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
-        return indexOfObject(at: IndexSet(indexesIn: NSMakeRange(0, count)), options: opts, passingTest: predicate)
+        return indexOfObject(at: IndexSet(integersIn: 0..<count), options: opts, passingTest: predicate)
     }
     open func indexOfObject(at s: IndexSet, options opts: NSEnumerationOptions = [], passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
         var result = NSNotFound
@@ -467,7 +467,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         return indexesOfObjects([], passingTest: predicate)
     }
     open func indexesOfObjects(_ opts: NSEnumerationOptions = [], passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
-        return indexesOfObjects(at: IndexSet(indexesIn: NSMakeRange(0, count)), options: opts, passingTest: predicate)
+        return indexesOfObjects(at: IndexSet(integersIn: 0..<count), options: opts, passingTest: predicate)
     }
     open func indexesOfObjects(at s: IndexSet, options opts: NSEnumerationOptions = [], passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
         var result = IndexSet()
@@ -821,14 +821,14 @@ open class NSMutableArray : NSArray {
     }
     
     open func removeObjectsAtIndexes(_ indexes: IndexSet) {
-        for range in indexes.rangeView().reversed() {
+        for range in indexes.rangeView.reversed() {
             self.removeObjects(in: NSMakeRange(range.lowerBound, range.upperBound - range.lowerBound))
         }
     }
     
     open func replaceObjectsAtIndexes(_ indexes: IndexSet, withObjects objects: [AnyObject]) {
         var objectIndex = 0
-        for countedRange in indexes.rangeView() {
+        for countedRange in indexes.rangeView {
             let range = NSMakeRange(countedRange.lowerBound, countedRange.upperBound - countedRange.lowerBound)
             let subObjects = objects[objectIndex..<objectIndex + range.length]
             self.replaceObjectsInRange(range, withObjectsFromArray: Array(subObjects))

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -479,7 +479,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         enumerateKeysAndObjects([], using: block)
     }
 
-    public func enumerateKeysAndObjects(_ opts: EnumerationOptions = [], using block: (AnyObject, AnyObject, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) {
+    public func enumerateKeysAndObjects(_ opts: NSEnumerationOptions = [], using block: (AnyObject, AnyObject, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) {
         let count = self.count
         var keys = [AnyObject]()
         var objects = [AnyObject]()
@@ -511,7 +511,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         return keysOfEntries([], passingTest: predicate)
     }
 
-    open func keysOfEntries(_ opts: EnumerationOptions = [], passingTest predicate: (AnyObject, AnyObject, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Set<NSObject> {
+    open func keysOfEntries(_ opts: NSEnumerationOptions = [], passingTest predicate: (AnyObject, AnyObject, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Set<NSObject> {
         var matching = Set<NSObject>()
         enumerateKeysAndObjects(opts) { key, value, stop in
             if predicate(key, value, stop) {

--- a/Foundation/NSIndexPath.swift
+++ b/Foundation/NSIndexPath.swift
@@ -8,13 +8,13 @@
 //
 
 
-open class NSIndexPath: NSObject, NSCopying, NSSecureCoding {
+open class NSIndexPath : NSObject, NSCopying, NSSecureCoding {
     
     internal var _indexes : [Int]
     override public init() {
         _indexes = []
     }
-    public init(indexes: UnsafePointer<Int>, length: Int) {
+    public init(indexes: UnsafePointer<Int>!, length: Int) {
         _indexes = Array(UnsafeBufferPointer(start: indexes, count: length))
     }
     
@@ -55,7 +55,7 @@ open class NSIndexPath: NSObject, NSCopying, NSSecureCoding {
     open func index(atPosition position: Int) -> Int {
         return _indexes[position]
     }
-    open var length: Int  {
+    open var length: Int {
         return _indexes.count
     }
     
@@ -94,4 +94,8 @@ open class NSIndexPath: NSObject, NSCopying, NSSecureCoding {
         }
         return .orderedSame
     }
+}
+
+extension NSIndexPath {
+    open func getIndexes(_ indexes: UnsafeMutablePointer<Int>) { NSUnimplemented() }
 }

--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -367,7 +367,7 @@ open class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         return false
     }
     
-    internal func _enumerateWithOptions<P, R>(_ opts : EnumerationOptions, range: NSRange, paramType: P.Type, returnType: R.Type, block: (P, UnsafeMutablePointer<ObjCBool>) -> R) -> Int? {
+    internal func _enumerateWithOptions<P, R>(_ opts : NSEnumerationOptions, range: NSRange, paramType: P.Type, returnType: R.Type, block: (P, UnsafeMutablePointer<ObjCBool>) -> R) -> Int? {
         guard !opts.contains(.concurrent) else {
             NSUnimplemented()
         }
@@ -418,30 +418,30 @@ open class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     public func enumerate(_ block: (Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
         enumerate([], using: block)
     }
-    public func enumerate(_ opts: EnumerationOptions = [], using block: (Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
+    public func enumerate(_ opts: NSEnumerationOptions = [], using block: (Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
         let _ = _enumerateWithOptions(opts, range: NSMakeRange(0, Int.max), paramType: Int.self, returnType: Void.self, block: block)
     }
-    public func enumerate(in range: NSRange, options opts: EnumerationOptions = [], using block: (Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
+    public func enumerate(in range: NSRange, options opts: NSEnumerationOptions = [], using block: (Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
         let _ = _enumerateWithOptions(opts, range: range, paramType: Int.self, returnType: Void.self, block: block)
     }
 
     open func index(passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
         return index([], passingTest: predicate)
     }
-    open func index(_ opts: EnumerationOptions = [], passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
+    open func index(_ opts: NSEnumerationOptions = [], passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
         return _enumerateWithOptions(opts, range: NSMakeRange(0, Int.max), paramType: Int.self, returnType: Bool.self, block: predicate) ?? NSNotFound
     }
-    open func index(in range: NSRange, options opts: EnumerationOptions = [], passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
+    open func index(in range: NSRange, options opts: NSEnumerationOptions = [], passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
         return _enumerateWithOptions(opts, range: range, paramType: Int.self, returnType: Bool.self, block: predicate) ?? NSNotFound
     }
     
     open func indexes(passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
         return indexes(in: NSMakeRange(0, Int.max), options: [], passingTest: predicate)
     }
-    open func indexes(_ opts: EnumerationOptions = [], passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
+    open func indexes(_ opts: NSEnumerationOptions = [], passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
         return indexes(in: NSMakeRange(0, Int.max), options: opts, passingTest: predicate)
     }
-    open func indexes(in range: NSRange, options opts: EnumerationOptions = [], passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
+    open func indexes(in range: NSRange, options opts: NSEnumerationOptions = [], passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
         var result = IndexSet()
         let _ = _enumerateWithOptions(opts, range: range, paramType: Int.self, returnType: Void.self) { idx, stop in
             if predicate(idx, stop) {
@@ -459,10 +459,10 @@ open class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     public func enumerateRanges(_ block: (NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
         enumerateRanges([], using: block)
     }
-    public func enumerateRanges(_ opts: EnumerationOptions = [], using block: (NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
+    public func enumerateRanges(_ opts: NSEnumerationOptions = [], using block: (NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
         let _ = _enumerateWithOptions(opts, range: NSMakeRange(0, Int.max), paramType: NSRange.self, returnType: Void.self, block: block)
     }
-    public func enumerateRanges(in range: NSRange, options opts: EnumerationOptions = [], using block: (NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
+    public func enumerateRanges(in range: NSRange, options opts: NSEnumerationOptions = [], using block: (NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
         let _ = _enumerateWithOptions(opts, range: range, paramType: NSRange.self, returnType: Void.self, block: block)
     }
 }

--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -70,7 +70,7 @@ open class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         _ranges = _count == 0 ? [] : [range]
     }
     public init(indexSet: IndexSet) {
-        _ranges = indexSet.rangeView().map { NSRange(location: $0.lowerBound, length: $0.upperBound - $0.lowerBound) }
+        _ranges = indexSet.rangeView.map { NSRange(location: $0.lowerBound, length: $0.upperBound - $0.lowerBound) }
         _count = indexSet.count
     }
     
@@ -103,7 +103,7 @@ open class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     
     open func isEqual(to indexSet: IndexSet) -> Bool {
         
-        let otherRanges = indexSet.rangeView().map { NSRange(location: $0.lowerBound, length: $0.upperBound - $0.lowerBound) }
+        let otherRanges = indexSet.rangeView.map { NSRange(location: $0.lowerBound, length: $0.upperBound - $0.lowerBound) }
         if _ranges.count != otherRanges.count {
             return false
         }
@@ -501,11 +501,11 @@ extension NSIndexSet : Sequence {
 open class NSMutableIndexSet : NSIndexSet {
     
     open func add(_ indexSet: IndexSet) {
-        indexSet.rangeView().forEach { add(in: NSRange(location: $0.lowerBound, length: $0.upperBound - $0.lowerBound)) }
+        indexSet.rangeView.forEach { add(in: NSRange(location: $0.lowerBound, length: $0.upperBound - $0.lowerBound)) }
     }
     
     open func remove(_ indexSet: IndexSet) {
-        indexSet.rangeView().forEach { remove(in: NSRange(location: $0.lowerBound, length: $0.upperBound - $0.lowerBound)) }
+        indexSet.rangeView.forEach { remove(in: NSRange(location: $0.lowerBound, length: $0.upperBound - $0.lowerBound)) }
     }
     
     open func removeAllIndexes() {

--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -56,7 +56,7 @@ internal func __NSIndexSetIndexOfRangeContainingIndex(_ indexSet: NSIndexSet, _ 
     return UInt(bitPattern: NSNotFound)
 }
 
-open class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
+open class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     // all instance variables are private
     
     internal var _ranges = [NSRange]()
@@ -86,7 +86,7 @@ open class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     
     open func mutableCopy(with zone: NSZone? = nil) -> Any {
         let set = NSMutableIndexSet()
-        enumerateRanges([]) {
+        enumerateRanges(options: []) {
             set.add(in: $0.0)
         }
         return set
@@ -340,7 +340,7 @@ open class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     }
     open func contains(_ indexSet: IndexSet) -> Bool {
         var result = true
-        enumerateRanges([]) { range, stop in
+        enumerateRanges(options: []) { range, stop in
             if !self.contains(in: range) {
                 result = false
                 stop.pointee = true
@@ -415,20 +415,20 @@ open class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         return result
     }
 
-    public func enumerate(_ block: (Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
-        enumerate([], using: block)
+    open func enumerate(_ block: (Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
+        enumerate(options: [], using: block)
     }
-    public func enumerate(_ opts: NSEnumerationOptions = [], using block: (Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
+    open func enumerate(options opts: NSEnumerationOptions = [], using block: (Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
         let _ = _enumerateWithOptions(opts, range: NSMakeRange(0, Int.max), paramType: Int.self, returnType: Void.self, block: block)
     }
-    public func enumerate(in range: NSRange, options opts: NSEnumerationOptions = [], using block: (Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
+    open func enumerate(in range: NSRange, options opts: NSEnumerationOptions = [], using block: (Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
         let _ = _enumerateWithOptions(opts, range: range, paramType: Int.self, returnType: Void.self, block: block)
     }
 
     open func index(passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
-        return index([], passingTest: predicate)
+        return index(options: [], passingTest: predicate)
     }
-    open func index(_ opts: NSEnumerationOptions = [], passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
+    open func index(options opts: NSEnumerationOptions = [], passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
         return _enumerateWithOptions(opts, range: NSMakeRange(0, Int.max), paramType: Int.self, returnType: Bool.self, block: predicate) ?? NSNotFound
     }
     open func index(in range: NSRange, options opts: NSEnumerationOptions = [], passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int {
@@ -438,7 +438,7 @@ open class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     open func indexes(passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
         return indexes(in: NSMakeRange(0, Int.max), options: [], passingTest: predicate)
     }
-    open func indexes(_ opts: NSEnumerationOptions = [], passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
+    open func indexes(options opts: NSEnumerationOptions = [], passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
         return indexes(in: NSMakeRange(0, Int.max), options: opts, passingTest: predicate)
     }
     open func indexes(in range: NSRange, options opts: NSEnumerationOptions = [], passingTest predicate: (Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet {
@@ -456,47 +456,46 @@ open class NSIndexSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
 
      If the specified range for enumeration intersects a range of contiguous indexes in the receiver, then the block will be invoked with the intersection of those two ranges.
     */
-    public func enumerateRanges(_ block: (NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
-        enumerateRanges([], using: block)
+    open func enumerateRanges(_ block: (NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
+        enumerateRanges(options: [], using: block)
     }
-    public func enumerateRanges(_ opts: NSEnumerationOptions = [], using block: (NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
+    open func enumerateRanges(options opts: NSEnumerationOptions = [], using block: (NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
         let _ = _enumerateWithOptions(opts, range: NSMakeRange(0, Int.max), paramType: NSRange.self, returnType: Void.self, block: block)
     }
-    public func enumerateRanges(in range: NSRange, options opts: NSEnumerationOptions = [], using block: (NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
+    open func enumerateRanges(in range: NSRange, options opts: NSEnumerationOptions = [], using block: (NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
         let _ = _enumerateWithOptions(opts, range: range, paramType: NSRange.self, returnType: Void.self, block: block)
     }
 }
 
-extension NSIndexSet: Sequence {
-
-    public struct Iterator : IteratorProtocol {
-        internal let _set: NSIndexSet
-        internal var _first: Bool = true
-        internal var _current: Int?
-        
-        internal init(_ set: NSIndexSet) {
-            self._set = set
-            self._current = nil
-        }
-        
-        public mutating func next() -> Int? {
-            if _first {
-                _current = _set.firstIndex
-                _first = false
-            } else if let c = _current {
-                _current = _set.indexGreaterThanIndex(c)
-            }
-            if _current == NSNotFound {
-                _current = nil
-            }
-            return _current
-        }
+public struct NSIndexSetIterator : IteratorProtocol {
+    public typealias Element = Int
+    internal let _set: NSIndexSet
+    internal var _first: Bool = true
+    internal var _current: Element?
+    
+    internal init(_ set: NSIndexSet) {
+        self._set = set
+        self._current = nil
     }
     
-    public func makeIterator() -> Iterator {
-        return Iterator(self)
+    public mutating func next() -> Element? {
+        if _first {
+            _current = _set.firstIndex
+            _first = false
+        } else if let c = _current {
+            _current = _set.indexGreaterThanIndex(c)
+        }
+        if _current == NSNotFound {
+            _current = nil
+        }
+        return _current
     }
+}
 
+extension NSIndexSet : Sequence {
+    public func makeIterator() -> NSIndexSetIterator {
+        return NSIndexSetIterator(self)
+    }
 }
 
 open class NSMutableIndexSet : NSIndexSet {

--- a/Foundation/NSObjCRuntime.swift
+++ b/Foundation/NSObjCRuntime.swift
@@ -179,12 +179,12 @@ public struct SortOptions: OptionSet {
     public static let stable = SortOptions(rawValue: UInt(1 << 4))
 }
 
-public struct EnumerationOptions: OptionSet {
+public struct NSEnumerationOptions: OptionSet {
     public let rawValue : UInt
     public init(rawValue: UInt) { self.rawValue = rawValue }
     
-    public static let concurrent = EnumerationOptions(rawValue: UInt(1 << 0))
-    public static let reverse = EnumerationOptions(rawValue: UInt(1 << 1))
+    public static let concurrent = NSEnumerationOptions(rawValue: UInt(1 << 0))
+    public static let reverse = NSEnumerationOptions(rawValue: UInt(1 << 1))
 }
 
 public typealias Comparator = (AnyObject, AnyObject) -> ComparisonResult

--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -245,16 +245,16 @@ extension NSOrderedSet {
     public var set: Set<NSObject> { NSUnimplemented() }
     
     public func enumerateObjectsUsingBlock(_ block: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Void) { NSUnimplemented() }
-    public func enumerateObjectsWithOptions(_ opts: EnumerationOptions, usingBlock block: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Void) { NSUnimplemented() }
-    public func enumerateObjectsAtIndexes(_ s: IndexSet, options opts: EnumerationOptions, usingBlock block: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Void) { NSUnimplemented() }
+    public func enumerateObjectsWithOptions(_ opts: NSEnumerationOptions, usingBlock block: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Void) { NSUnimplemented() }
+    public func enumerateObjectsAtIndexes(_ s: IndexSet, options opts: NSEnumerationOptions, usingBlock block: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Void) { NSUnimplemented() }
     
     public func indexOfObjectPassingTest(_ predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int { NSUnimplemented() }
-    public func indexOfObjectWithOptions(_ opts: EnumerationOptions, passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int { NSUnimplemented() }
-    public func indexOfObjectAtIndexes(_ s: IndexSet, options opts: EnumerationOptions, passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int { NSUnimplemented() }
+    public func indexOfObjectWithOptions(_ opts: NSEnumerationOptions, passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int { NSUnimplemented() }
+    public func indexOfObjectAtIndexes(_ s: IndexSet, options opts: NSEnumerationOptions, passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Int { NSUnimplemented() }
     
     public func indexesOfObjectsPassingTest(_ predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet { NSUnimplemented() }
-    public func indexesOfObjectsWithOptions(_ opts: EnumerationOptions, passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet { NSUnimplemented() }
-    public func indexesOfObjectsAtIndexes(_ s: IndexSet, options opts: EnumerationOptions, passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet { NSUnimplemented() }
+    public func indexesOfObjectsWithOptions(_ opts: NSEnumerationOptions, passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet { NSUnimplemented() }
+    public func indexesOfObjectsAtIndexes(_ s: IndexSet, options opts: NSEnumerationOptions, passingTest predicate: (AnyObject, Int, UnsafeMutablePointer<ObjCBool>) -> Bool) -> IndexSet { NSUnimplemented() }
     
     public func indexOfObject(_ object: AnyObject, inSortedRange range: NSRange, options opts: NSBinarySearchingOptions, usingComparator cmp: Comparator) -> Int { NSUnimplemented() } // binary search
     

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -298,7 +298,7 @@ extension NSSet {
         enumerateObjects([], using: block)
     }
     
-    public func enumerateObjects(_ opts: EnumerationOptions = [], using block: (AnyObject, UnsafeMutablePointer<ObjCBool>) -> Void) {
+    public func enumerateObjects(_ opts: NSEnumerationOptions = [], using block: (AnyObject, UnsafeMutablePointer<ObjCBool>) -> Void) {
         var stop : ObjCBool = false
         for obj in self {
             withUnsafeMutablePointer(to: &stop) { stop in
@@ -314,7 +314,7 @@ extension NSSet {
         return objects([], passingTest: predicate)
     }
     
-    public func objects(_ opts: EnumerationOptions = [], passingTest predicate: (AnyObject, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Set<NSObject> {
+    public func objects(_ opts: NSEnumerationOptions = [], passingTest predicate: (AnyObject, UnsafeMutablePointer<ObjCBool>) -> Bool) -> Set<NSObject> {
         var result = Set<NSObject>()
         enumerateObjects(opts) { obj, stopp in
             if predicate(obj, stopp) {

--- a/TestFoundation/TestNSIndexSet.swift
+++ b/TestFoundation/TestNSIndexSet.swift
@@ -73,7 +73,7 @@ class TestNSIndexSet : XCTestCase {
         disjointSet.add(11)
         disjointSet.add(in: NSMakeRange(13, 2))
         result = Array<Int>()
-        disjointSet.enumerate([]) { (idx, _) in
+        disjointSet.enumerate(options: []) { (idx, _) in
             result.append(idx)
         }
         XCTAssertEqual(result, [2, 5, 7, 8, 9, 11, 13, 14])
@@ -118,7 +118,7 @@ class TestNSIndexSet : XCTestCase {
         var i = 0
         
         if testInputA1.count == testSetA.count {
-            testSetA.enumerate([]) { (idx, _) in
+            testSetA.enumerate(options: []) { (idx, _) in
                 XCTAssertEqual(idx, testInputA1[i])
                 i += 1
             }
@@ -131,7 +131,7 @@ class TestNSIndexSet : XCTestCase {
         let testInputA2 = [NSMakeRange(0, 1),NSMakeRange(5, 4),NSMakeRange(42, 1)]
         i = 0
         
-        testSetA.enumerateRanges([]) { (range, _) in
+        testSetA.enumerateRanges(options: []) { (range, _) in
             let testRange = testInputA2[i]
             XCTAssertEqual(range.location, testRange.location)
             XCTAssertEqual(range.length, testRange.length)
@@ -147,7 +147,7 @@ class TestNSIndexSet : XCTestCase {
         i = 0
         
         if testInputB1.count == testSetB.count {
-            testSetB.enumerate([]) { (idx, _) in
+            testSetB.enumerate(options: []) { (idx, _) in
                 XCTAssertEqual(idx, testInputB1[i])
                 i += 1
             }
@@ -160,7 +160,7 @@ class TestNSIndexSet : XCTestCase {
         let testInputB2 = [NSMakeRange(0, 5),NSMakeRange(18, 1),NSMakeRange(42, 3)]
         i = 0
         
-        testSetB.enumerateRanges([]) { (range, _) in
+        testSetB.enumerateRanges(options: []) { (range, _) in
             let testRange = testInputB2[i]
             XCTAssertEqual(range.location, testRange.location)
             XCTAssertEqual(range.length, testRange.length)


### PR DESCRIPTION
### Changes
#### `IndexPath`
* Integrate `IndexPath` implementation from overlay
* `Array<Element>` → `[Element]`

#### `NSIndexPath`
* Add missing unimplemented `NSIndexPath.getIndexes()` in extension
* Trivial whitespace changes
* `UnsafePointer<Int>` → `UnsafePointer<Int>!` to match Foundation and uses throughout framework/tests

#### `IndexSet`
* Integrate `IndexSet` implementation from overlay
* Trivial whitespace changes
* Rewrite `firstIndex` and `lastIndex` implementations from overlay to return correct values for empty sets (and fix associated crashes in tests due to incorrect implementation)

#### `NSIndexSet`
* Trivial whitespace changes
* Add `options:` labels where necessary
* `public` → `open` where necessary

Integrates/relies on changes submitted in [pr-enumerationoptions](https://github.com/apple/swift-corelibs-foundation/pull/530) (`EnumerationOptions` → `NSEnumerationOptions`)