### PR TITLE
[SR-2151]NSJSONSerialization.data produces illegal JSON code

### DIFF
--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -306,7 +306,7 @@ private struct JSONWriter {
         // Cannot detect type information (e.g. bool) as there is no objCType property on NSNumber in Swift
         // So, just print the number
 
-        writer("\(num)")
+        writer(num.serializationString)
     }
 
     mutating func serializeArray(_ array: NSArray) throws {

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -7,6 +7,8 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+import CoreFoundation
+
 #if os(OSX) || os(iOS)
     import Darwin
 #elseif os(Linux)
@@ -240,6 +242,14 @@ private struct JSONWriter {
     let pretty: Bool
     let writer: (String?) -> Void
     
+    private lazy var _numberformatter: CFNumberFormatter = {
+        let formatter: CFNumberFormatter
+        formatter = CFNumberFormatterCreate(nil, CFLocaleCopyCurrent(), kCFNumberFormatterNoStyle)
+        CFNumberFormatterSetProperty(formatter, kCFNumberFormatterMaxFractionDigits, 15._bridgeToObject())
+        CFNumberFormatterSetFormat(formatter, "0.###############"._cfObject)
+        return formatter
+    }()
+
     init(pretty: Bool = false, writer: @escaping (String?) -> Void) {
         self.pretty = pretty
         self.writer = writer
@@ -298,7 +308,7 @@ private struct JSONWriter {
         writer("\"")
     }
 
-    func serializeNumber(_ num: NSNumber) throws {
+    mutating func serializeNumber(_ num: NSNumber) throws {
         if num.doubleValue.isInfinite || num.doubleValue.isNaN {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.PropertyListReadCorruptError.rawValue, userInfo: ["NSDebugDescription" : "Number cannot be infinity or NaN"])
         }
@@ -306,7 +316,7 @@ private struct JSONWriter {
         // Cannot detect type information (e.g. bool) as there is no objCType property on NSNumber in Swift
         // So, just print the number
 
-        writer(num.serializationString)
+        writer(_serializationString(for: num))
     }
 
     mutating func serializeArray(_ array: NSArray) throws {
@@ -388,6 +398,11 @@ private struct JSONWriter {
         for _ in 0..<indent {
             writer(" ")
         }
+    }
+    
+    //[SR-2151] https://bugs.swift.org/browse/SR-2151
+    private mutating func _serializationString(for number: NSNumber) -> String {
+        return CFNumberFormatterCreateStringWithNumber(nil, _numberformatter, number._cfObject)._swiftObject
     }
 }
 

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -139,7 +139,6 @@ open class NSNumber : NSValue {
     // This layout MUST be the same as CFNumber so that they are bridgeable
     private var _base = _CFInfo(typeID: CFNumberGetTypeID())
     private var _pad: UInt64 = 0
-    
     internal var _cfObject: CFType {
         return unsafeBitCast(self, to: CFType.self)
     }
@@ -451,7 +450,22 @@ open class NSNumber : NSValue {
     open override var description: String {
         return description(withLocale: nil)
     }
+
+    //[SR-2151] https://bugs.swift.org/browse/SR-2151
+    internal var serializationString: String {
+        let formatter: CFNumberFormatter
+        formatter = CFNumberFormatterCreate(nil, CFLocaleCopyCurrent(), kCFNumberFormatterNoStyle)
+        CFNumberFormatterSetProperty(formatter, kCFNumberFormatterMaxFractionDigits, 15._bridgeToObject())
+        switch  CFNumberGetType(_cfObject as CFNumber){
+            case .floatType, .float32Type, .float64Type, .cgFloatType, .doubleType:
+                CFNumberFormatterSetFormat(formatter, "0.###############"._cfObject);
+            default:break
+        }
+        return CFNumberFormatterCreateStringWithNumber(nil, formatter, self._cfObject)._swiftObject
+    }
 }
+
+
 
 extension CFNumber : _NSBridgable {
     typealias NSType = NSNumber

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -139,6 +139,7 @@ open class NSNumber : NSValue {
     // This layout MUST be the same as CFNumber so that they are bridgeable
     private var _base = _CFInfo(typeID: CFNumberGetTypeID())
     private var _pad: UInt64 = 0
+    
     internal var _cfObject: CFType {
         return unsafeBitCast(self, to: CFType.self)
     }
@@ -450,22 +451,7 @@ open class NSNumber : NSValue {
     open override var description: String {
         return description(withLocale: nil)
     }
-
-    //[SR-2151] https://bugs.swift.org/browse/SR-2151
-    internal var serializationString: String {
-        let formatter: CFNumberFormatter
-        formatter = CFNumberFormatterCreate(nil, CFLocaleCopyCurrent(), kCFNumberFormatterNoStyle)
-        CFNumberFormatterSetProperty(formatter, kCFNumberFormatterMaxFractionDigits, 15._bridgeToObject())
-        switch  CFNumberGetType(_cfObject as CFNumber){
-            case .floatType, .float32Type, .float64Type, .cgFloatType, .doubleType:
-                CFNumberFormatterSetFormat(formatter, "0.###############"._cfObject);
-            default:break
-        }
-        return CFNumberFormatterCreateStringWithNumber(nil, formatter, self._cfObject)._swiftObject
-    }
 }
-
-
 
 extension CFNumber : _NSBridgable {
     typealias NSType = NSNumber

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -655,7 +655,7 @@ extension TestNSJSONSerialization {
                            ("-0.23456789012345",-0.23456789012345),
                            ]
             for param in params {
-                let testDict = [param.0 : param.1 as AnyObject] as [String : AnyObject]
+                let testDict = [param.0 : param.1]
                 let str = try? trySerialize(testDict.bridge())
                 XCTAssertEqual(str!, "{\"\(param.0)\":\(param.1)}", "serialized value should  have a decimal places and leading zero")
             }
@@ -671,7 +671,7 @@ extension TestNSJSONSerialization {
                 ("-1.23456789012345",-1.23456789012345),
                 ]
             for param in paramsBove1 {
-                let testDict = [param.0 : param.1 as AnyObject] as [String : AnyObject]
+                let testDict = [param.0 : param.1]
                 let str = try? trySerialize(testDict.bridge())
                 XCTAssertEqual(str!, "{\"\(param.0)\":\(param.1)}", "serialized Double should  have a decimal places and leading value")
             }
@@ -686,7 +686,7 @@ extension TestNSJSONSerialization {
                 ("1"  ,1.0),
                 ]
             for param in paramsWholeNumbers {
-                let testDict = [param.0 : param.1 as AnyObject] as [String : AnyObject]
+                let testDict = [param.0 : param.1]
                 let str = try? trySerialize(testDict.bridge())
                 XCTAssertEqual(str!, "{\"\(param.0)\":\(param.0._bridgeToObject().intValue)}", "expect that serialized value should not contain trailing zero or decimal as they are whole numbers ")
             }
@@ -695,7 +695,7 @@ extension TestNSJSONSerialization {
         func excecute_testWholeNumbersWithIntInput() {
             for i  in -10..<10 {
                 let iStr = "\(i)"
-                let testDict = [iStr : i as AnyObject] as [String : AnyObject]
+                let testDict = [iStr : i]
                 let str = try? trySerialize(testDict.bridge())
                 XCTAssertEqual(str!, "{\"\(iStr)\":\(i)}", "expect that serialized value should not contain trailing zero or decimal as they are whole numbers ")
             }

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -691,9 +691,19 @@ extension TestNSJSONSerialization {
                 XCTAssertEqual(str!, "{\"\(param.0)\":\(param.0._bridgeToObject().intValue)}", "expect that serialized value should not contain trailing zero or decimal as they are whole numbers ")
             }
         }
+        
+        func excecute_testWholeNumbersWithIntInput() {
+            for i  in -10..<10 {
+                let iStr = "\(i)"
+                let testDict = [iStr : i as AnyObject] as [String : AnyObject]
+                let str = try? trySerialize(testDict.bridge())
+                XCTAssertEqual(str!, "{\"\(iStr)\":\(i)}", "expect that serialized value should not contain trailing zero or decimal as they are whole numbers ")
+            }
+        }
         excecute_testSetLessThanOne()
         excecute_testSetGraterThanOne()
         excecute_testWholeNumbersWithDoubleAsInput()
+        excecute_testWholeNumbersWithIntInput()
     }
     
     func test_serialize_null() {


### PR DESCRIPTION
**What's in this pull request?**
Resolved bug number:SR-2151 (https://bugs.swift.org/browse/SR-2151)
Implementation 
Tests (note all tests are done on NSJSONSerialization due to access lvl protection )

**Problem :** 
NSJSONSerialization.data produces illegal JSON code

**Cause :** 

NSJSONSerialization ```func serializeNumber(_ num: NSNumber) throws ```
uses NSNumber ```open override var description: String``` which calls 
```open func description(withLocale locale: Locale?) -> String```  with a nil locale.

The nil locale case is handled by setting the format style to kCFNumberFormatterNoStyle & kCFNumberFormatterMaxFractionDigits
the leading zero does not show up which results in the incorrect format.

``` ["foo": 0.123] ```
should be
```
{
   "foo": 0.1234
}
```
but is 
```
{
    "foo": .1234
}
```
**Proposed Solution:** 
1.  ```NSJSONSerialization func serializeNumber(_ num: NSNumber)```  stop calling ```description(withLocale locale: Locale?) -> String``` as locale imho should not have any determination for JSON serialization
2. Create a separate internal computed property ```internal var serializationString: String ``` to return the proper formatted string 
- check whether or not the underlying store is a _cfObject is a fractionDigit type which need leading zero padding and conditionally use a custom formatter string  ``` "0.###############"  ```. 


 Reason for using custom format string instead of existing style was largely due to the documentation and programing guide suggestions on the fact exact  formats of this sort should be decoupled from Locale 

https://developer.apple.com/library/prerelease/content/documentation/CoreFoundation/Conceptual/CFDataFormatting/Articles/dfCreatingCFNumberFormatters.html
> To create a CFNumberFormatter, you must specify a locale and a formatter style as illustrated in Listing 1, or a format string, as shown in Listing 2. Format styles do not specify an exact format—they depend on the locale, user preference settings, and operating system version. If you want to specify an exact format, use the CFNumberFormatterSetFormat function to set the format string, and the CFNumberFormatterSetProperty function to change specific properties such as separators, the "Not a number" symbol, and the padding character.

https://developer.apple.com/library/ios/documentation/CoreFoundation/Reference/CFNumberFormatterRef/#//apple_ref/doc/constant_group/Number_Formatter_Styles
> The format for these number styles is not exact because they depend on the locale, user preference settings, and operating system version. Do not use these constants if you want an exact format (for example, if you are parsing data in a given format). In general, however, you are encouraged to use these styles to accommodate user preferences.
