### PR TITLE
Modified build scripts for Cygwin

### DIFF
--- a/build.py
+++ b/build.py
@@ -13,6 +13,7 @@ foundation = DynamicLibrary("Foundation")
 
 foundation.GCC_PREFIX_HEADER = 'CoreFoundation/Base.subproj/CoreFoundation_Prefix.h'
 
+swift_cflags = []
 if Configuration.current.target.sdk == OSType.Linux:
 	foundation.CFLAGS = '-DDEPLOYMENT_TARGET_LINUX -D_GNU_SOURCE '
 	foundation.LDFLAGS = '${SWIFT_USE_LINKER} -Wl,@./CoreFoundation/linux.ld -lswiftGlibc `${PKG_CONFIG} icu-uc icu-i18n --libs` -Wl,-defsym,__CFConstantStringClassReference=_TMC10Foundation19_NSCFConstantString -Wl,-Bsymbolic '
@@ -23,6 +24,10 @@ elif Configuration.current.target.sdk == OSType.FreeBSD:
 elif Configuration.current.target.sdk == OSType.MacOSX:
 	foundation.CFLAGS = '-DDEPLOYMENT_TARGET_MACOSX '
 	foundation.LDFLAGS = '-licucore -twolevel_namespace -Wl,-alias_list,CoreFoundation/Base.subproj/DarwinSymbolAliases -sectcreate __UNICODE __csbitmaps CoreFoundation/CharacterSets/CFCharacterSetBitmaps.bitmap -sectcreate __UNICODE __properties CoreFoundation/CharacterSets/CFUniCharPropertyDatabase.data -sectcreate __UNICODE __data CoreFoundation/CharacterSets/CFUnicodeData-L.mapping -segprot __UNICODE r r '
+elif Configuration.current.target.sdk == OSType.Win32 and Configuration.current.target.environ == EnvironmentType.Cygnus:
+	foundation.CFLAGS = '-DDEPLOYMENT_TARGET_LINUX -D_GNU_SOURCE -mcmodel=large '
+	foundation.LDFLAGS = '${SWIFT_USE_LINKER} -lswiftGlibc `icu-config --ldflags` -Wl,-defsym,__CFConstantStringClassReference=_TMC10Foundation19_NSCFConstantString,--allow-multiple-definition '
+	swift_cflags += ['-DCYGWIN']
 
 if Configuration.current.build_mode == Configuration.Debug:
         foundation.LDFLAGS += ' -lswiftSwiftOnoneSupport '
@@ -53,7 +58,7 @@ foundation.CFLAGS += " ".join([
 	'-I./',
 ])
 
-swift_cflags = [
+swift_cflags += [
 	'-I${BUILD_DIR}/Foundation/usr/lib/swift',
 	'-I${SYSROOT}/usr/include/libxml2'
 ]

--- a/lib/script.py
+++ b/lib/script.py
@@ -199,7 +199,7 @@ rule Assemble
 
         link_command = """
 rule Link
-    command = mkdir -p `dirname $out`; ${CLANG} ${TARGET_LDFLAGS} $flags ${VERBOSE_FLAGS} $start $in $end -o $out""" 
+    command = mkdir -p `dirname $out`; ${CLANG} ${TARGET_LDFLAGS} ${VERBOSE_FLAGS} $start $in $end $flags -o $out""" 
         if Configuration.current.verbose:
             link_command += "-Xlinker --verbose"
         link_command += """

--- a/lib/target.py
+++ b/lib/target.py
@@ -325,6 +325,7 @@ class Target:
     triple = None
     sdk = None
     arch = None
+    environ = None
     executable_suffix = ""
     dynamic_library_prefix = "lib"
     dynamic_library_suffix = ".dylib"
@@ -342,6 +343,10 @@ class Target:
             self.sdk = OSType.Win32
             self.dynamic_library_suffix = ".dll"
             self.executable_suffix = ".exe"
+            if "cygnus" in triple:
+                self.environ = EnvironmentType.Cygnus
+            else:
+                self.environ = EnvironmentType.UnknownEnvironment
         elif "darwin" in triple:
             self.sdk = OSType.MacOSX
         else:
@@ -366,6 +371,8 @@ class Target:
         elif platform.system() == "FreeBSD":
             # Make this work on 10 as well.
             triple += "-freebsd11.0"
+        elif platform.system() == "CYGWIN_NT-10.0":
+            triple += "-windows-cygnus"
         else:
             # TODO: This should be a bit more exhaustive
             print("unknown host os")
@@ -385,6 +392,8 @@ class Target:
                 triple += "-unknown-linux"
         elif self.sdk == OSType.FreeBSD:
             triple += "-unknown-freebsd"
+        elif self.sdk == OSType.Win32 and self.environ == EnvironmentType.Cygnus:
+            triple += "-unknown-windows-cygnus"
         else:
             print("unknown sdk for swift")
             return None
@@ -399,6 +408,8 @@ class Target:
             return "linux"
         elif self.sdk == OSType.FreeBSD:
             return "freebsd"
+        elif self.sdk == OSType.Win32:
+            return "cygwin"
         else:
             print("unknown sdk for swift")
             return None


### PR DESCRIPTION
1. Modified `lib/Target.py` for Cygwin
2. Add compile and linker options in `build.py` for Cygwin
3. Changed the order of '-lFoo' type option in `lib/script.py`.  

This is related to #381
