### PR TITLE
Foundation API Conformance Update: Locking

### DIFF
--- a/Foundation/NSCache.swift
+++ b/Foundation/NSCache.swift
@@ -23,7 +23,7 @@ open class Cache: NSObject {
     }
     
     private var _entries = Dictionary<UnsafeRawPointer, NSCacheEntry>()
-    private let _lock = Lock()
+    private let _lock = NSLock()
     private var _totalCost = 0
     private var _byCost: NSCacheEntry?
     

--- a/Foundation/NSConcreteValue.swift
+++ b/Foundation/NSConcreteValue.swift
@@ -68,7 +68,7 @@ internal class NSConcreteValue : NSValue {
     }
     
     private static var _cachedTypeInfo = Dictionary<String, TypeInfo>()
-    private static var _cachedTypeInfoLock = Lock()
+    private static var _cachedTypeInfoLock = NSLock()
     
     private var _typeInfo : TypeInfo
     private var _storage : UnsafeMutableRawPointer

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -339,7 +339,7 @@ extension NSData {
             try self.init(contentsOfFile: url.path!, options: readOptionsMask)
         } else {
             let session = URLSession(configuration: URLSessionConfiguration.defaultSessionConfiguration())
-            let cond = Condition()
+            let cond = NSCondition()
             var resError: NSError?
             var resData: Data?
             let task = session.dataTaskWithURL(url, completionHandler: { (data: Data?, response: URLResponse?, error: NSError?) -> Void in

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -93,7 +93,7 @@ open class NSKeyedArchiver : NSCoder {
     }
 
     private static var _classNameMap = Dictionary<String, String>()
-    private static var _classNameMapLock = Lock()
+    private static var _classNameMapLock = NSLock()
     
     private var _stream : AnyObject
     private var _flags = ArchiverFlags(rawValue: 0)

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -32,7 +32,7 @@ open class NSKeyedUnarchiver : NSCoder {
     }
     
     private static var _classNameMap : Dictionary<String, AnyClass> = [:]
-    private static var _classNameMapLock = Lock()
+    private static var _classNameMapLock = NSLock()
     
     open weak var delegate: NSKeyedUnarchiverDelegate?
     

--- a/Foundation/NSLock.swift
+++ b/Foundation/NSLock.swift
@@ -16,13 +16,12 @@ import Glibc
 
 import CoreFoundation
 
-public protocol Locking {
-    
+public protocol NSLocking {
     func lock()
     func unlock()
 }
 
-open class Lock: NSObject, Locking {
+open class NSLock: NSObject, NSLocking {
     internal var mutex = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
     
     public override init() {
@@ -43,14 +42,18 @@ open class Lock: NSObject, Locking {
         pthread_mutex_unlock(mutex)
     }
     
-    open func tryLock() -> Bool {
+    open func `try`() -> Bool {
         return pthread_mutex_trylock(mutex) == 0
+    }
+    
+    open func lock(before limit: Date) {
+        NSUnimplemented()
     }
     
     open var name: String?
 }
 
-extension Lock {
+extension NSLock {
     internal func synchronized<T>(_ closure: () -> T) -> T {
         self.lock()
         defer { self.unlock() }
@@ -58,8 +61,8 @@ extension Lock {
     }
 }
 
-open class NSConditionLock : NSObject, Locking {
-    internal var _cond = Condition()
+open class NSConditionLock : NSObject, NSLocking {
+    internal var _cond = NSCondition()
     internal var _value: Int
     internal var _thread: pthread_t?
     
@@ -72,7 +75,7 @@ open class NSConditionLock : NSObject, Locking {
     }
 
     open func lock() {
-        let _ = lockBeforeDate(Date.distantFuture)
+        let _ = lock(before: Date.distantFuture)
     }
 
     open func unlock() {
@@ -86,19 +89,19 @@ open class NSConditionLock : NSObject, Locking {
         return _value
     }
 
-    open func lockWhenCondition(_ condition: Int) {
-        let _ = lockWhenCondition(condition, beforeDate: Date.distantFuture)
+    open func lock(whenCondition condition: Int) {
+        let _ = lock(whenCondition: condition, before: Date.distantFuture)
     }
 
-    open func tryLock() -> Bool {
-        return lockBeforeDate(Date.distantPast)
+    open func `try`() -> Bool {
+        return lock(before: Date.distantPast)
     }
     
-    open func tryLockWhenCondition(_ condition: Int) -> Bool {
-        return lockWhenCondition(condition, beforeDate: Date.distantPast)
+    open func tryLock(whenCondition condition: Int) -> Bool {
+        return lock(whenCondition: condition, before: Date.distantPast)
     }
 
-    open func unlockWithCondition(_ condition: Int) {
+    open func unlock(withCondition condition: Int) {
         _cond.lock()
         _thread = nil
         _value = condition
@@ -106,10 +109,10 @@ open class NSConditionLock : NSObject, Locking {
         _cond.unlock()
     }
 
-    open func lockBeforeDate(_ limit: Date) -> Bool {
+    open func lock(before limit: Date) -> Bool {
         _cond.lock()
         while _thread == nil {
-            if !_cond.waitUntilDate(limit) {
+            if !_cond.wait(until: limit) {
                 _cond.unlock()
                 return false
             }
@@ -119,10 +122,10 @@ open class NSConditionLock : NSObject, Locking {
         return true
     }
     
-    open func lockWhenCondition(_ condition: Int, beforeDate limit: Date) -> Bool {
+    open func lock(whenCondition condition: Int, before limit: Date) -> Bool {
         _cond.lock()
         while _thread != nil || _value != condition {
-            if !_cond.waitUntilDate(limit) {
+            if !_cond.wait(until: limit) {
                 _cond.unlock()
                 return false
             }
@@ -135,7 +138,7 @@ open class NSConditionLock : NSObject, Locking {
     open var name: String?
 }
 
-open class RecursiveLock: NSObject, Locking {
+open class NSRecursiveLock: NSObject, NSLocking {
     internal var mutex = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
     
     public override init() {
@@ -161,14 +164,18 @@ open class RecursiveLock: NSObject, Locking {
         pthread_mutex_unlock(mutex)
     }
     
-    open func tryLock() -> Bool {
+    open func `try`() -> Bool {
         return pthread_mutex_trylock(mutex) == 0
+    }
+    
+    open func lock(before limit: Date) {
+        NSUnimplemented()
     }
 
     open var name: String?
 }
 
-open class Condition: NSObject, Locking {
+open class NSCondition: NSObject, NSLocking {
     internal var mutex = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
     internal var cond = UnsafeMutablePointer<pthread_cond_t>.allocate(capacity: 1)
     
@@ -198,7 +205,7 @@ open class Condition: NSObject, Locking {
         pthread_cond_wait(cond, mutex)
     }
     
-    open func waitUntilDate(_ limit: Date) -> Bool {
+    open func wait(until limit: Date) -> Bool {
         let lim = limit.timeIntervalSinceReferenceDate
         let ti = lim - CFAbsoluteTimeGetCurrent()
         if ti < 0.0 {

--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -159,7 +159,7 @@ private let _defaultCenter: NotificationCenter = NotificationCenter()
 open class NotificationCenter: NSObject {
     
     private var _observers: [NSNotificationReceiver]
-    private let _observersLock = Lock()
+    private let _observersLock = NSLock()
     
     public required override init() {
         _observers = [NSNotificationReceiver]()

--- a/Foundation/NSOperation.swift
+++ b/Foundation/NSOperation.swift
@@ -18,7 +18,7 @@ private func pthread_main_np() -> Int32 {
 #endif
 
 open class Operation: NSObject {
-    let lock = Lock()
+    let lock = NSLock()
     internal weak var _queue: OperationQueue?
     internal var _cancelled = false
     internal var _executing = false
@@ -294,7 +294,7 @@ internal struct _OperationList {
 }
 
 open class OperationQueue: NSObject {
-    let lock = Lock()
+    let lock = NSLock()
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
     var __concurrencyGate: DispatchSemaphore?
     var __underlyingQueue: DispatchQueue?

--- a/Foundation/NSTask.swift
+++ b/Foundation/NSTask.swift
@@ -28,7 +28,7 @@ private func WEXITSTATUS(_ status: CInt) -> CInt {
 
 private var managerThreadRunLoop : RunLoop? = nil
 private var managerThreadRunLoopIsRunning = false
-private var managerThreadRunLoopIsRunningCondition = Condition()
+private var managerThreadRunLoopIsRunningCondition = NSCondition()
 
 #if os(OSX) || os(iOS)
 internal let kCFSocketDataCallBack = CFSocketCallBackType.dataCallBack.rawValue
@@ -95,7 +95,7 @@ open class Task: NSObject {
     private static func setup() {
         struct Once {
             static var done = false
-            static let lock = Lock()
+            static let lock = NSLock()
         }
         Once.lock.synchronized {
             if !Once.done {
@@ -179,7 +179,7 @@ open class Task: NSObject {
     
     fileprivate weak var runLoop : RunLoop? = nil
     
-    private var processLaunchedCondition = Condition()
+    private var processLaunchedCondition = NSCondition()
     
     // actions
     open func launch() {

--- a/Foundation/NSValue.swift
+++ b/Foundation/NSValue.swift
@@ -10,7 +10,7 @@
 open class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
 
     private static var SideTable = [ObjectIdentifier : NSValue]()
-    private static var SideTableLock = Lock()
+    private static var SideTableLock = NSLock()
 
     internal override init() {
         super.init()

--- a/TestFoundation/TestNSThread.swift
+++ b/TestFoundation/TestNSThread.swift
@@ -35,7 +35,7 @@ class TestNSThread : XCTestCase {
     
     func test_threadStart() {
         var started = false
-        let condition = Condition()
+        let condition = NSCondition()
         let thread = Thread() {
             condition.lock()
             started = true


### PR DESCRIPTION
### Changes
* `Locking` → `NSLocking`

#### Lock
* `Lock` → `NSLock`
* `tryLock()` → `try()`

#### ConditionLock
* `ConditionLock` → `NSConditionLock`
* `lockWhenCondition(_ condition: Int)` → `lock(whenCondition condition: Int)`
* `tryLock()` → `try()`
* `tryLockWhenCondition(_ condition: Int)` → `tryLock(whenCondition condition: Int)`
* `unlockWithCondition(_ condition: Int)` → `unlock(withCondition condition: Int)`
* `lockBeforeDate(_ limit: Date)` → `lock(before limit: Date)`
* `lockWhenCondition(_ condition: Int, beforeDate limit: Date)` → `lock(whenCondition condition: Int, before limit: Date)`

#### RecursiveLock
* `RecursiveLock` → `NSRecursiveLock`
* `tryLock()` → `try()`

#### Condition
* `Condition` → `NSCondition`
* `waitUntilDate(_ limit: Date)` → `wait(until limit: Date)`

Additional changes across files which use these classes.