### PR TITLE
Foundation API Conformance Update: Datetime

### DIFF
--- a/Foundation/Date.swift
+++ b/Foundation/Date.swift
@@ -17,13 +17,13 @@ import CoreFoundation
 public struct Date : ReferenceConvertible, Comparable, Equatable {
     public typealias ReferenceType = NSDate
     
-    fileprivate var _time : TimeInterval
+    fileprivate var _time: TimeInterval
     
     /// The number of seconds from 1 January 1970 to the reference date, 1 January 2001.
-    public static let timeIntervalBetween1970AndReferenceDate : TimeInterval = 978307200.0
+    public static let timeIntervalBetween1970AndReferenceDate: TimeInterval = 978307200.0
     
     /// The interval between 00:00:00 UTC on 1 January 2001 and the current date and time.
-    public static var timeIntervalSinceReferenceDate : TimeInterval {
+    public static var timeIntervalSinceReferenceDate: TimeInterval {
         return CFAbsoluteTimeGetCurrent()
     }
     

--- a/Foundation/Date.swift
+++ b/Foundation/Date.swift
@@ -138,11 +138,7 @@ public struct Date : ReferenceConvertible, Comparable, Equatable {
     public static let distantPast = Date(timeIntervalSinceReferenceDate: -63114076800.0)
     
     public var hashValue: Int {
-        if #available(OSX 10.12, iOS 10.0, *) {
-            return Int(bitPattern: __CFHashDouble(_time))
-        } else { // 10.11 and previous behavior fallback; this must allocate a date to reference the hash value and then throw away the reference
-            return NSDate(timeIntervalSinceReferenceDate: _time).hash
-        }
+        return Int(bitPattern: __CFHashDouble(_time))
     }
     
     /// Compare two `Date` values.
@@ -234,7 +230,7 @@ extension Date : CustomDebugStringConvertible, CustomStringConvertible, CustomRe
     }
 }
 
-extension Date : _ObjectiveCBridgeable {
+extension Date {
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSDate {
         return NSDate(timeIntervalSinceReferenceDate: _time)
@@ -242,7 +238,7 @@ extension Date : _ObjectiveCBridgeable {
     
     public static func _forceBridgeFromObjectiveC(_ x: NSDate, result: inout Date?) {
         if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
-            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+            fatalError("Unable to bridge \(NSDate.self) to \(self)")
         }
     }
     
@@ -255,14 +251,6 @@ extension Date : _ObjectiveCBridgeable {
         var result: Date? = nil
         _forceBridgeFromObjectiveC(source!, result: &result)
         return result!
-    }
-}
-
-extension NSDate : _HasCustomAnyHashableRepresentation {
-    // Must be @nonobjc to avoid infinite recursion during bridging.
-    @nonobjc
-    public func _toCustomAnyHashable() -> AnyHashable? {
-        return AnyHashable(self as Date)
     }
 }
 

--- a/Foundation/Date.swift
+++ b/Foundation/Date.swift
@@ -1,23 +1,26 @@
+// This source file is part of the Swift.org open source project
 //
-//  Date.swift
-//  Foundation
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
 //
-//  Created by Philippe Hausler on 5/13/16.
-//  Copyright © 2016 Apple. All rights reserved.
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
 import CoreFoundation
 
 /**
- `Date` structs represent a single point in time.
+ `Date` represents a single point in time.
+ 
+ A `Date` is independent of a particular calendar or time zone. To represent a `Date` to a user, you must interpret it in the context of a `Calendar`.
  */
-public struct Date : ReferenceConvertible, Comparable, Equatable, CustomStringConvertible {
+public struct Date : ReferenceConvertible, Comparable, Equatable {
     public typealias ReferenceType = NSDate
     
-    private var _time : TimeInterval
+    fileprivate var _time : TimeInterval
     
     /// The number of seconds from 1 January 1970 to the reference date, 1 January 2001.
-    public static let timeIntervalBetween1970AndReferenceDate = 978307200.0
+    public static let timeIntervalBetween1970AndReferenceDate : TimeInterval = 978307200.0
     
     /// The interval between 00:00:00 UTC on 1 January 2001 and the current date and time.
     public static var timeIntervalSinceReferenceDate : TimeInterval {
@@ -54,19 +57,10 @@ public struct Date : ReferenceConvertible, Comparable, Equatable, CustomStringCo
         _time = ti
     }
     
-    /// Returns a `Date` initialized with the value from a `NSDate`. `Date` does not store the reference after initialization.
-    private init(reference: NSDate) {
-        self.init(timeIntervalSinceReferenceDate: reference.timeIntervalSinceReferenceDate)
-    }
-    
-    private var reference : NSDate {
-        return NSDate(timeIntervalSinceReferenceDate: _time)
-    }
-    
     /**
      Returns the interval between the date object and 00:00:00 UTC on 1 January 2001.
      
-     This property’s value is negative if the date object is earlier than the system’s absolute reference date (00:00:00 UTC on 1 January 2001).
+     This property's value is negative if the date object is earlier than the system's absolute reference date (00:00:00 UTC on 1 January 2001).
      */
     public var timeIntervalSinceReferenceDate: TimeInterval {
         return _time
@@ -90,7 +84,7 @@ public struct Date : ReferenceConvertible, Comparable, Equatable, CustomStringCo
     /**
      The time interval between the date and the current date and time.
      
-     If the date is earlier than the current date and time, this property’s value is negative.
+     If the date is earlier than the current date and time, this property's value is negative.
      
      - SeeAlso: `timeIntervalSince(_:)`
      - SeeAlso: `timeIntervalSince1970`
@@ -103,7 +97,7 @@ public struct Date : ReferenceConvertible, Comparable, Equatable, CustomStringCo
     /**
      The interval between the date object and 00:00:00 UTC on 1 January 1970.
      
-     This property’s value is negative if the date object is earlier than 00:00:00 UTC on 1 January 1970.
+     This property's value is negative if the date object is earlier than 00:00:00 UTC on 1 January 1970.
      
      - SeeAlso: `timeIntervalSince(_:)`
      - SeeAlso: `timeIntervalSinceNow`
@@ -111,6 +105,22 @@ public struct Date : ReferenceConvertible, Comparable, Equatable, CustomStringCo
      */
     public var timeIntervalSince1970: TimeInterval {
         return self.timeIntervalSinceReferenceDate + Date.timeIntervalBetween1970AndReferenceDate
+    }
+    
+    /// Return a new `Date` by adding a `TimeInterval` to this `Date`.
+    ///
+    /// - parameter timeInterval: The value to add, in seconds.
+    /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
+    public func addingTimeInterval(_ timeInterval: TimeInterval) -> Date {
+        return self + timeInterval
+    }
+    
+    /// Add a `TimeInterval` to this `Date`.
+    ///
+    /// - parameter timeInterval: The value to add, in seconds.
+    /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
+    public mutating func addTimeInterval(_ timeInterval: TimeInterval) {
+        self += timeInterval
     }
     
     /**
@@ -128,9 +138,14 @@ public struct Date : ReferenceConvertible, Comparable, Equatable, CustomStringCo
     public static let distantPast = Date(timeIntervalSinceReferenceDate: -63114076800.0)
     
     public var hashValue: Int {
-        return Int(bitPattern: __CFHashDouble(_time))
+        if #available(OSX 10.12, iOS 10.0, *) {
+            return Int(bitPattern: __CFHashDouble(_time))
+        } else { // 10.11 and previous behavior fallback; this must allocate a date to reference the hash value and then throw away the reference
+            return NSDate(timeIntervalSinceReferenceDate: _time).hash
+        }
     }
     
+    /// Compare two `Date` values.
     public func compare(_ other: Date) -> ComparisonResult {
         if _time < other.timeIntervalSinceReferenceDate {
             return .orderedAscending
@@ -141,13 +156,55 @@ public struct Date : ReferenceConvertible, Comparable, Equatable, CustomStringCo
         }
     }
     
+    /// Returns true if the two `Date` values represent the same point in time.
+    public static func ==(lhs: Date, rhs: Date) -> Bool {
+        return lhs.timeIntervalSinceReferenceDate == rhs.timeIntervalSinceReferenceDate
+    }
+    
+    /// Returns true if the left hand `Date` is earlier in time than the right hand `Date`.
+    public static func <(lhs: Date, rhs: Date) -> Bool {
+        return lhs.timeIntervalSinceReferenceDate < rhs.timeIntervalSinceReferenceDate
+    }
+    
+    /// Returns true if the left hand `Date` is later in time than the right hand `Date`.
+    public static func >(lhs: Date, rhs: Date) -> Bool {
+        return lhs.timeIntervalSinceReferenceDate > rhs.timeIntervalSinceReferenceDate
+    }
+    
+    /// Returns a `Date` with a specified amount of time added to it.
+    public static func +(lhs: Date, rhs: TimeInterval) -> Date {
+        return Date(timeIntervalSinceReferenceDate: lhs.timeIntervalSinceReferenceDate + rhs)
+    }
+    
+    /// Returns a `Date` with a specified amount of time subtracted from it.
+    public static func -(lhs: Date, rhs: TimeInterval) -> Date {
+        return Date(timeIntervalSinceReferenceDate: lhs.timeIntervalSinceReferenceDate - rhs)
+    }
+    
+    /// Add a `TimeInterval` to a `Date`.
+    ///
+    /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
+    public static func +=(lhs: inout Date, rhs: TimeInterval) {
+        lhs = lhs + rhs
+    }
+    
+    /// Subtract a `TimeInterval` from a `Date`.
+    ///
+    /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
+    public static func -=(lhs: inout Date, rhs: TimeInterval) {
+        lhs = lhs - rhs
+    }
+    
+}
+
+extension Date : CustomDebugStringConvertible, CustomStringConvertible, CustomReflectable {
     /**
      A string representation of the date object (read-only).
      
      The representation is useful for debugging only.
      
      There are a number of options to acquire a formatted string for a date including: date formatters (see
-     [NSDateFormatter](//apple_ref/occ/cl/NSDateFormatter) and [Data Formatting Guide](//apple_ref/doc/uid/10000029i)), and the `Date` functions `description(locale:)`.
+     [NSDateFormatter](//apple_ref/occ/cl/NSDateFormatter) and [Data Formatting Guide](//apple_ref/doc/uid/10000029i)), and the `Date` function `description(locale:)`.
      */
     public var description: String {
         // Defer to NSDate for description
@@ -158,41 +215,66 @@ public struct Date : ReferenceConvertible, Comparable, Equatable, CustomStringCo
      Returns a string representation of the receiver using the given
      locale.
      
-     - Parameter locale: A `Locale` object. If you pass `nil`, `NSDate` formats the date in the same way as the `description` property.
+     - Parameter locale: A `Locale`. If you pass `nil`, `Date` formats the date in the same way as the `description` property.
      
-     - Returns: A string representation of the receiver, using the given locale, or if the locale argument is `nil`, in the international format `YYYY-MM-DD HH:MM:SS ±HHMM`, where `±HHMM` represents the time zone offset in hours and minutes from UTC (for example, “`2001-03-24 10:45:32 +0600`”).
+     - Returns: A string representation of the `Date`, using the given locale, or if the locale argument is `nil`, in the international format `YYYY-MM-DD HH:MM:SS ±HHMM`, where `±HHMM` represents the time zone offset in hours and minutes from UTC (for example, "`2001-03-24 10:45:32 +0600`").
      */
     public func description(with locale: Locale?) -> String {
-        return NSDate(timeIntervalSinceReferenceDate: _time).description(withLocale: locale)
+        return NSDate(timeIntervalSinceReferenceDate: _time).description(with: locale)
     }
     
-    public var debugDescription: String { return description }
+    public var debugDescription: String {
+        return description
+    }
+    
+    public var customMirror: Mirror {
+        var c: [(label: String?, value: Any)] = []
+        c.append((label: "timeIntervalSinceReferenceDate", value: timeIntervalSinceReferenceDate))
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+    }
 }
 
-/// Returns true if the two Date values are equal.
-public func ==(lhs: Date, rhs: Date) -> Bool {
-    return lhs.timeIntervalSinceReferenceDate == rhs.timeIntervalSinceReferenceDate
+extension Date : _ObjectiveCBridgeable {
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSDate {
+        return NSDate(timeIntervalSinceReferenceDate: _time)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSDate, result: inout Date?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSDate, result: inout Date?) -> Bool {
+        result = Date(timeIntervalSinceReferenceDate: x.timeIntervalSinceReferenceDate)
+        return true
+    }
+    
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSDate?) -> Date {
+        var result: Date? = nil
+        _forceBridgeFromObjectiveC(source!, result: &result)
+        return result!
+    }
 }
 
-/// Returns true if the left hand Date is less than the right hand Date.
-public func <(lhs: Date, rhs: Date) -> Bool {
-    return lhs.timeIntervalSinceReferenceDate < rhs.timeIntervalSinceReferenceDate
+extension NSDate : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as Date)
+    }
 }
 
-/// Returns a Date with a specified amount of time added to it.
-public func +(lhs: Date, rhs: TimeInterval) -> Date {
-    return Date(timeIntervalSinceReferenceDate: lhs.timeIntervalSinceReferenceDate + rhs)
-}
-
-/// Returns a Date with a specified amount of time subtracted from it.
-public func -(lhs: Date, rhs: TimeInterval) -> Date {
-    return Date(timeIntervalSinceReferenceDate: lhs.timeIntervalSinceReferenceDate - rhs)
-}
-
-public func +=(lhs: inout Date, rhs: TimeInterval) {
-    lhs = lhs + rhs
-}
-
-public func -=(lhs: inout Date, rhs: TimeInterval) {
-    lhs = lhs - rhs
+extension Date : CustomPlaygroundQuickLookable {
+    var summary: String {
+        let df = DateFormatter()
+        df.dateStyle = .medium
+        df.timeStyle = .short
+        return df.string(from: self)
+    }
+    
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .text(summary)
+    }
 }

--- a/Foundation/DateComponents.swift
+++ b/Foundation/DateComponents.swift
@@ -263,10 +263,23 @@ public struct DateComponents : ReferenceConvertible, Hashable, Equatable, _Mutab
     
     // MARK: -
     
-    public var hashValue : Int {
+    public var hashValue: Int {
         return _handle.map { $0.hash }
     }
     
+    public static func ==(lhs: DateComponents, rhs: DateComponents) -> Bool {
+        // Don't copy references here; no one should be storing anything
+        return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
+    }
+    
+    // MARK: - Bridging Helpers
+    
+    internal init(reference: NSDateComponents) {
+        _handle = _MutableHandle(reference: reference)
+    }
+}
+
+extension DateComponents : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
     public var description: String {
         return _handle.map { $0.description }
     }
@@ -275,17 +288,27 @@ public struct DateComponents : ReferenceConvertible, Hashable, Equatable, _Mutab
         return _handle.map { $0.debugDescription }
     }
     
-    // MARK: - Bridging Helpers
-    
-    internal init(reference: NSDateComponents) {
-        _handle = _MutableHandle(reference: reference)
+    public var customMirror: Mirror {
+        var c: [(label: String?, value: Any)] = []
+        if let r = calendar { c.append((label: "calendar", value: r)) }
+        if let r = timeZone { c.append((label: "timeZone", value: r)) }
+        if let r = era { c.append((label: "era", value: r)) }
+        if let r = year { c.append((label: "year", value: r)) }
+        if let r = month { c.append((label: "month", value: r)) }
+        if let r = day { c.append((label: "day", value: r)) }
+        if let r = hour { c.append((label: "hour", value: r)) }
+        if let r = minute { c.append((label: "minute", value: r)) }
+        if let r = second { c.append((label: "second", value: r)) }
+        if let r = nanosecond { c.append((label: "nanosecond", value: r)) }
+        if let r = weekday { c.append((label: "weekday", value: r)) }
+        if let r = weekdayOrdinal { c.append((label: "weekdayOrdinal", value: r)) }
+        if let r = quarter { c.append((label: "quarter", value: r)) }
+        if let r = weekOfMonth { c.append((label: "weekOfMonth", value: r)) }
+        if let r = weekOfYear { c.append((label: "weekOfYear", value: r)) }
+        if let r = yearForWeekOfYear { c.append((label: "yearForWeekOfYear", value: r)) }
+        if let r = isLeapMonth { c.append((label: "isLeapMonth", value: r)) }
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
     }
-    
-}
-
-public func ==(lhs : DateComponents, rhs: DateComponents) -> Bool {
-    // Don't copy references here; no one should be storing anything
-    return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
 }
 
 // MARK: - Bridging

--- a/Foundation/DateInterval.swift
+++ b/Foundation/DateInterval.swift
@@ -17,12 +17,12 @@ public struct DateInterval : ReferenceConvertible, Comparable, Hashable {
     public typealias ReferenceType = NSDateInterval
     
     /// The start date.
-    public var start : Date
+    public var start: Date
     
     /// The end date.
     ///
     /// - precondition: `end >= start`
-    public var end : Date {
+    public var end: Date {
         get {
             return start + duration
         }
@@ -35,7 +35,7 @@ public struct DateInterval : ReferenceConvertible, Comparable, Hashable {
     /// The duration.
     ///
     /// - precondition: `duration >= 0`
-    public var duration : TimeInterval {
+    public var duration: TimeInterval {
         willSet {
             precondition(newValue >= 0, "Negative durations are not allowed")
         }
@@ -160,6 +160,16 @@ public struct DateInterval : ReferenceConvertible, Comparable, Hashable {
         }
     }
     
+    public static func ==(lhs: DateInterval, rhs: DateInterval) -> Bool {
+        return lhs.start == rhs.start && lhs.duration == rhs.duration
+    }
+    
+    public static func <(lhs: DateInterval, rhs: DateInterval) -> Bool {
+        return lhs.compare(rhs) == .orderedAscending
+    }
+}
+
+extension DateInterval : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
     public var description: String {
         return "(Start Date) \(start) + (Duration) \(duration) seconds = (End Date) \(end)"
     }
@@ -167,14 +177,14 @@ public struct DateInterval : ReferenceConvertible, Comparable, Hashable {
     public var debugDescription: String {
         return description
     }
-}
-
-public func ==(lhs: DateInterval, rhs: DateInterval) -> Bool {
-    return lhs.start == rhs.start && lhs.duration == rhs.duration
-}
-
-public func <(lhs: DateInterval, rhs: DateInterval) -> Bool {
-    return lhs.compare(rhs) == .orderedAscending
+    
+    public var customMirror: Mirror {
+        var c: [(label: String?, value: Any)] = []
+        c.append((label: "start", value: start))
+        c.append((label: "end", value: end))
+        c.append((label: "duration", value: duration))
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+    }
 }
 
 extension DateInterval {

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -120,7 +120,7 @@ public func <(_ lhs: NSCalendar.Identifier, _ rhs: NSCalendar.Identifier) -> Boo
     return lhs.rawValue < rhs.rawValue
 }
     
-open class NSCalendar: NSObject, NSCopying, NSSecureCoding {
+open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     typealias CFType = CFCalendar
     private var _base = _CFInfo(typeID: CFCalendarGetTypeID())
     private var _identifier: UnsafeMutableRawPointer? = nil
@@ -204,7 +204,7 @@ open class NSCalendar: NSObject, NSCopying, NSSecureCoding {
         return CFCalendarCopyCurrent()._swiftObject
     }
     
-    open class func autoupdatingCurrentCalendar() -> Calendar { NSUnimplemented() }  // tracks changes to user's preferred calendar identifier
+    open class var autoupdatingCurrent: Calendar { NSUnimplemented() }  // tracks changes to user's preferred calendar identifier
     
     public /*not inherited*/ init?(identifier calendarIdentifierConstant: Identifier) {
         super.init()
@@ -1100,7 +1100,7 @@ open class NSCalendar: NSObject, NSCopying, NSSecureCoding {
     Result dates have an integer number of seconds (as if 0 was specified for the nanoseconds property of the NSDateComponents matching parameter), unless a value was set in the nanoseconds property, in which case the result date will have that number of nanoseconds (or as close as possible with floating point numbers).
     The enumeration is stopped by setting *stop = YES in the block and return.  It is not necessary to set *stop to NO to keep the enumeration going.
     */
-    public func enumerateDates(startingAfter start: Date, matching comps: DateComponents, options opts: NSCalendar.Options = [], using block: (Date?, Bool, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) {
+    open func enumerateDates(startingAfter start: Date, matching comps: DateComponents, options opts: NSCalendar.Options = [], using block: (Date?, Bool, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) {
         NSUnimplemented()
     }
     
@@ -1123,7 +1123,7 @@ open class NSCalendar: NSObject, NSCopying, NSSecureCoding {
     The general semantics follow those of the -enumerateDatesStartingAfterDate:... method above.
     To compute a sequence of results, use the -enumerateDatesStartingAfterDate:... method above, rather than looping and calling this method with the previous loop iteration's result.
     */
-    open func nextDate(after date: Date, matchingUnit unit: Unit, value: Int, options: Options = []) -> Date? {
+    open func nextDate(after date: Date, matching unit: Unit, value: Int, options: Options = []) -> Date? {
         var comps = DateComponents()
         comps.setValue(value, for: Calendar._fromCalendarUnit(unit))
         return nextDate(after:date, matching: comps, options: options)

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -50,6 +50,8 @@ open class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
     open var timeIntervalSinceReferenceDate: TimeInterval {
         return _timeIntervalSinceReferenceDate
     }
+    
+    open class var timeIntervalSinceReferenceDate: TimeInterval { NSUnimplemented() }
 
     public convenience override init() {
         var tv = timeval()
@@ -91,11 +93,11 @@ open class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     open func encode(with aCoder: NSCoder) {
-	if aCoder.allowsKeyedCoding {
-	    aCoder.encode(_timeIntervalSinceReferenceDate, forKey: "NS.time")
-	} else {
-	    NSUnimplemented()
-	}
+        if aCoder.allowsKeyedCoding {
+            aCoder.encode(_timeIntervalSinceReferenceDate, forKey: "NS.time")
+        } else {
+            NSUnimplemented()
+        }
     }
 
     /**
@@ -134,7 +136,7 @@ open class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
        offset in hours and minutes from UTC (for example,
        "2001-03-24 10:45:32 +0600")
      */
-    open func description(withLocale locale: Locale?) -> String {
+    open func description(with locale: Locale?) -> String {
         guard let aLocale = locale else { return description }
         let dateFormatterRef = CFDateFormatterCreate(kCFAllocatorSystemDefault, aLocale._cfObject, kCFDateFormatterFullStyle, kCFDateFormatterFullStyle)
         CFDateFormatterSetProperty(dateFormatterRef, kCFDateFormatterTimeZoneKey, CFTimeZoneCopySystem())
@@ -149,23 +151,23 @@ open class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
 
 extension NSDate {
     
-    public func timeIntervalSince(_ anotherDate: Date) -> TimeInterval {
+    open func timeIntervalSince(_ anotherDate: Date) -> TimeInterval {
         return self.timeIntervalSinceReferenceDate - anotherDate.timeIntervalSinceReferenceDate
     }
     
-    public var timeIntervalSinceNow: TimeInterval {
+    open var timeIntervalSinceNow: TimeInterval {
         return timeIntervalSince(Date())
     }
     
-    public var timeIntervalSince1970: TimeInterval {
+    open var timeIntervalSince1970: TimeInterval {
         return timeIntervalSinceReferenceDate + NSTimeIntervalSince1970
     }
     
-    public func addingTimeInterval(_ ti: TimeInterval) -> Date {
+    open func addingTimeInterval(_ ti: TimeInterval) -> Date {
         return Date(timeIntervalSinceReferenceDate:_timeIntervalSinceReferenceDate + ti)
     }
     
-    public func earlierDate(_ anotherDate: Date) -> Date {
+    open func earlierDate(_ anotherDate: Date) -> Date {
         if self.timeIntervalSinceReferenceDate < anotherDate.timeIntervalSinceReferenceDate {
             return Date(timeIntervalSinceReferenceDate: timeIntervalSinceReferenceDate)
         } else {
@@ -173,7 +175,7 @@ extension NSDate {
         }
     }
     
-    public func laterDate(_ anotherDate: Date) -> Date {
+    open func laterDate(_ anotherDate: Date) -> Date {
         if self.timeIntervalSinceReferenceDate < anotherDate.timeIntervalSinceReferenceDate {
             return anotherDate
         } else {
@@ -181,7 +183,7 @@ extension NSDate {
         }
     }
     
-    public func compare(_ other: Date) -> ComparisonResult {
+    open func compare(_ other: Date) -> ComparisonResult {
         let t1 = self.timeIntervalSinceReferenceDate
         let t2 = other.timeIntervalSinceReferenceDate
         if t1 < t2 {
@@ -193,19 +195,19 @@ extension NSDate {
         }
     }
     
-    public func isEqual(to otherDate: Date) -> Bool {
+    open func isEqual(to otherDate: Date) -> Bool {
         return timeIntervalSinceReferenceDate == otherDate.timeIntervalSinceReferenceDate
     }
 }
 
 extension NSDate {
     internal static let _distantFuture = Date(timeIntervalSinceReferenceDate: 63113904000.0)
-    public static func distantFuture() -> Date {
+    open class var distantFuture: Date {
         return _distantFuture
     }
     
     internal static let _distantPast = Date(timeIntervalSinceReferenceDate: -63113904000.0)
-    public static func distantPast() -> Date {
+    open class var distantPast: Date {
         return _distantPast
     }
     
@@ -217,7 +219,7 @@ extension NSDate {
         self.init(timeIntervalSinceReferenceDate: secs - NSTimeIntervalSince1970)
     }
     
-    public convenience init(timeInterval secsToBeAdded: TimeInterval, sinceDate date: Date) {
+    public convenience init(timeInterval secsToBeAdded: TimeInterval, since date: Date) {
         self.init(timeIntervalSinceReferenceDate: date.timeIntervalSinceReferenceDate + secsToBeAdded)
     }
 }

--- a/Foundation/NSDateComponentsFormatter.swift
+++ b/Foundation/NSDateComponentsFormatter.swift
@@ -10,12 +10,12 @@
 
 extension DateComponentsFormatter {
     public enum UnitsStyle : Int {
-        
         case positional // "1:10; may fall back to abbreviated units in some cases, e.g. 3d"
         case abbreviated // "1h 10m"
-        case short // "1hr 10min"
+        case short // "1hr, 10min"
         case full // "1 hour, 10 minutes"
         case spellOut // "One hour, ten minutes"
+        case brief // "1hr 10min"
     }
 
     public struct ZeroFormattingBehavior : OptionSet {
@@ -49,7 +49,7 @@ open class DateComponentsFormatter : Formatter {
     
     /* 'obj' must be an instance of NSDateComponents.
      */
-    open override func string(for obj: Any) -> String? { NSUnimplemented() }
+    open override func string(for obj: Any?) -> String? { NSUnimplemented() }
     
     open func string(from components: DateComponents) -> String? { NSUnimplemented() }
     

--- a/Foundation/NSDateFormatter.swift
+++ b/Foundation/NSDateFormatter.swift
@@ -140,9 +140,9 @@ open class DateFormatter : Formatter {
         }
     }
 
-    open var dateStyle: Style = .noStyle { willSet { _dateFormat = nil; _reset() } }
+    open var dateStyle: Style = .none { willSet { _dateFormat = nil; _reset() } }
 
-    open var timeStyle: Style = .noStyle { willSet { _dateFormat = nil; _reset() } }
+    open var timeStyle: Style = .none { willSet { _dateFormat = nil; _reset() } }
 
     /*@NSCopying*/ open var locale: Locale! = .current { willSet { _reset() } }
 
@@ -477,10 +477,10 @@ open class DateFormatter : Formatter {
 
 extension DateFormatter {
     public enum Style : UInt {
-        case noStyle
-        case shortStyle
-        case mediumStyle
-        case longStyle
-        case fullStyle
+        case none
+        case short
+        case medium
+        case long
+        case full
     }
 }

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -365,7 +365,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
             if key is NSArray {
                 line += (key as! NSArray).description(withLocale: locale, indent: level + 1)
             } else if key is Date {
-                line += (key as! NSDate).description(withLocale: locale)
+                line += (key as! NSDate).description(with: locale)
             } else if key is NSDecimalNumber {
                 line += (key as! NSDecimalNumber).description(withLocale: locale)
             } else if key is NSDictionary {
@@ -384,7 +384,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
             if object is NSArray {
                 line += (object as! NSArray).description(withLocale: locale, indent: level + 1)
             } else if object is Date {
-                line += (object as! NSDate).description(withLocale: locale)
+                line += (object as! NSDate).description(with: locale)
             } else if object is NSDecimalNumber {
                 line += (object as! NSDecimalNumber).description(withLocale: locale)
             } else if object is NSDictionary {

--- a/TestFoundation/TestNSDate.swift
+++ b/TestFoundation/TestNSDate.swift
@@ -45,8 +45,8 @@ class TestNSDate : XCTestCase {
 
     func test_descriptionWithLocale() {
         let d = NSDate(timeIntervalSince1970: 0)
-        XCTAssertEqual(d.description(withLocale: nil), "1970-01-01 00:00:00 +0000")
-        XCTAssertNotNil(d.description(withLocale: Locale(identifier: "ja_JP")))
+        XCTAssertEqual(d.description(with: nil), "1970-01-01 00:00:00 +0000")
+        XCTAssertNotNil(d.description(with: Locale(identifier: "ja_JP")))
     }
     
     func test_InitTimeIntervalSince1970() {

--- a/TestFoundation/TestNSDateFormatter.swift
+++ b/TestFoundation/TestNSDateFormatter.swift
@@ -108,8 +108,8 @@ class TestNSDateFormatter: XCTestCase {
         ]
         
         let f = DateFormatter()
-        f.dateStyle = .shortStyle
-        f.timeStyle = .shortStyle
+        f.dateStyle = .short
+        f.timeStyle = .short
         
         // ensure tests give consistent results by setting specific timeZone and locale
         f.timeZone = TimeZone(identifier: DEFAULT_TIMEZONE)
@@ -141,8 +141,8 @@ class TestNSDateFormatter: XCTestCase {
         ]
         
         let f = DateFormatter()
-        f.dateStyle = .mediumStyle
-        f.timeStyle = .mediumStyle
+        f.dateStyle = .medium
+        f.timeStyle = .medium
         f.timeZone = TimeZone(identifier: DEFAULT_TIMEZONE)
         f.locale = Locale(identifier: DEFAULT_LOCALE)
         
@@ -173,8 +173,8 @@ class TestNSDateFormatter: XCTestCase {
         ]
         
         let f = DateFormatter()
-        f.dateStyle = .longStyle
-        f.timeStyle = .longStyle
+        f.dateStyle = .long
+        f.timeStyle = .long
         f.timeZone = TimeZone(identifier: DEFAULT_TIMEZONE)
         f.locale = Locale(identifier: DEFAULT_LOCALE)
         
@@ -207,8 +207,8 @@ class TestNSDateFormatter: XCTestCase {
         ]
         
         let f = DateFormatter()
-        f.dateStyle = .fullStyle
-        f.timeStyle = .fullStyle
+        f.dateStyle = .full
+        f.timeStyle = .full
         f.timeZone = TimeZone(identifier: DEFAULT_TIMEZONE)
         f.locale = Locale(identifier: DEFAULT_LOCALE)
         
@@ -268,8 +268,8 @@ class TestNSDateFormatter: XCTestCase {
         
         // Check .dateFormat resets when style changes
         let testDate = Date(timeIntervalSince1970: 1457738454)
-        f.dateStyle = .mediumStyle
-        f.timeStyle = .mediumStyle
+        f.dateStyle = .medium
+        f.timeStyle = .medium
         XCTAssertEqual(f.string(from: testDate), "Mar 11, 2016, 11:20:54 PM")
         XCTAssertEqual(f.dateFormat, "MMM d, y, h:mm:ss a")
         


### PR DESCRIPTION
### Changes
#### `Date`
* Add missing `addingTimeInterval(_ timeInterval: TimeInterval)` and `addTimeInterval(_ timeInterval: TimeInterval)`
* Move operators into struct
* Add missing mirror type, and bridging from overlay

#### `DateComponents`
* Whitespace fixes
* Integrate custom mirror from overlay

#### `DateInterval`
* Whitespace fixes
* Move operators into struct
* Integrate custom mirror from overlay

#### `NSCalendar`
* Naming fixes

#### `NSDate`
* `description(withLocale locale: Locale?)` → `description(with locale: Locale?)`
* `public` → `open`
* Fix type of `distantPast` and `distantFuture`

#### `NSDateComponentsFormatter`
* Add `brief` unit style
* `string(for obj: Any)` → `string(for obj: Any?)`

#### `NSDateFormatter`
* Shorten formatter style names

Update tests and names as used throughout.