### PR TITLE
Fix the "DEBUGGING TESTS" command

### DIFF
--- a/build.py
+++ b/build.py
@@ -471,7 +471,7 @@ build install: phony | ${BUILD_DIR}/.install
 """
 extra_script += """
 rule RunTestFoundation
-    command = echo "**** RUNNING TESTS ****\\nexecute:\\nLD_LIBRARY_PATH=${BUILD_DIR}/Foundation/:${LIBS_DIRS} ${BUILD_DIR}/TestFoundation/TestFoundation\\n**** DEBUGGING TESTS ****\\nexecute:\\nLD_LIBRARY_PATH=${LIBS_DIRS} lldb ${BUILD_DIR}/TestFoundation/TestFoundation\\n"
+    command = echo "**** RUNNING TESTS ****\\nexecute:\\nLD_LIBRARY_PATH=${BUILD_DIR}/Foundation/:${LIBS_DIRS} ${BUILD_DIR}/TestFoundation/TestFoundation\\n**** DEBUGGING TESTS ****\\nexecute:\\nLD_LIBRARY_PATH=${BUILD_DIR}/Foundation/:${LIBS_DIRS} lldb ${BUILD_DIR}/TestFoundation/TestFoundation\\n"
     description = Building Tests
 
 build ${BUILD_DIR}/.test: RunTestFoundation | TestFoundation


### PR DESCRIPTION
The printed debugging command is missing `Foundation` path:

```
**** RUNNING TESTS ****
execute:
LD_LIBRARY_PATH=../build/Ninja-ReleaseAssert/foundation-linux-x86_64/Foundation/:/swift.org/build/Ninja-ReleaseAssert/xctest-linux-x86_64: ../build/Ninja-ReleaseAssert/foundation-linux-x86_64/TestFoundation/TestFoundation
**** DEBUGGING TESTS ****
execute:
LD_LIBRARY_PATH=/swift.org/build/Ninja-ReleaseAssert/xctest-linux-x86_64: lldb ../build/Ninja-ReleaseAssert/foundation-linux-x86_64/TestFoundation/TestFoundation
```

This will require the user to manually insert something like `../build/Ninja-ReleaseAssert/foundation-linux-x86_64/Foundation/` in the command to make it work.

This pull request fixes this issue. The result will look like this:

```
**** RUNNING TESTS ****
execute:
LD_LIBRARY_PATH=../build/Ninja-ReleaseAssert/foundation-linux-x86_64/Foundation/:/swift.org/build/Ninja-ReleaseAssert/xctest-linux-x86_64: ../build/Ninja-ReleaseAssert/foundation-linux-x86_64/TestFoundation/TestFoundation
**** DEBUGGING TESTS ****
execute:
LD_LIBRARY_PATH=../build/Ninja-ReleaseAssert/foundation-linux-x86_64/Foundation/:/swift.org/build/Ninja-ReleaseAssert/xctest-linux-x86_64: lldb ../build/Ninja-ReleaseAssert/foundation-linux-x86_64/TestFoundation/TestFoundation
```