### PR TITLE
NSString bridging and internal NUL, take two [SR-2225]

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -1272,6 +1272,7 @@
 				61E0117B1C1B554D000037DD /* TestNSRunLoop.swift */,
 				844DC3321C17584F005611F9 /* TestNSScanner.swift */,
 				EA66F6411BF1619600136161 /* TestNSSet.swift */,
+				0383A1741D2E558A0052E5D1 /* TestNSStream.swift */,
 				EA66F6421BF1619600136161 /* TestNSString.swift */,
 				5B6F17941C48631C00935030 /* TestNSTask.swift */,
 				5FE52C941D147D1C00F7D270 /* TestNSTextCheckingResult.swift */,
@@ -1289,7 +1290,6 @@
 				5B40F9F11C125187000E72E3 /* TestNSXMLParser.swift */,
 				CC5249BF1D341D23007CB54D /* TestUnitConverter.swift */,
 				5B6F17961C48631C00935030 /* TestUtils.swift */,
-				0383A1741D2E558A0052E5D1 /* TestNSStream.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -777,7 +777,7 @@ extension TestNSJSONSerialization {
             let result = try JSONSerialization.writeJSONObject(dict.bridge(), toStream: outputStream, options: [])
             outputStream.close()
             if(result > -1) {
-                XCTAssertEqual(NSString(bytes: buffer, length: buffer.count, encoding: String.Encoding.utf8.rawValue), "{\"a\":{\"b\":1}}")
+                XCTAssertEqual(NSString(bytes: buffer, length: buffer.count, encoding: String.Encoding.utf8.rawValue), "{\"a\":{\"b\":1}}\0\0\0\0\0\0\0")
             }
         } catch {
             XCTFail("Error thrown: \(error)")
@@ -801,7 +801,7 @@ extension TestNSJSONSerialization {
                         let resultRead: Int = fileStream.read(&buffer, maxLength: buffer.count)
                         fileStream.close()
                         if(resultRead > -1){
-                            XCTAssertEqual(NSString(bytes: buffer, length: buffer.count, encoding: String.Encoding.utf8.rawValue), "{\"a\":{\"b\":1}}")
+                            XCTAssertEqual(NSString(bytes: buffer, length: buffer.count, encoding: String.Encoding.utf8.rawValue), "{\"a\":{\"b\":1}}\0\0\0\0\0\0\0")
                         }
                     }
                     removeTestFile(filePath!)
@@ -814,7 +814,7 @@ extension TestNSJSONSerialization {
         }
     }
     
-    func test_jsonObjectToOutputStreamInsufficeintBuffer() {
+    func test_jsonObjectToOutputStreamInsufficientBuffer() {
         let dict = ["a":["b":1]]
         let buffer = Array<UInt8>(repeating: 0, count: 10)
         let outputStream = NSOutputStream(toBuffer: UnsafeMutablePointer(mutating: buffer), capacity: 20)

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -592,7 +592,7 @@ extension TestNSJSONSerialization {
             ("test_jsonObjectToOutputStreamBuffer", test_jsonObjectToOutputStreamBuffer),
             ("test_jsonObjectToOutputStreamFile", test_jsonObjectToOutputStreamFile),
             ("test_invalidJsonObjectToStreamBuffer", test_invalidJsonObjectToStreamBuffer),
-            ("test_jsonObjectToOutputStreamInsufficeintBuffer", test_jsonObjectToOutputStreamInsufficeintBuffer),
+            ("test_jsonObjectToOutputStreamInsufficientBuffer", test_jsonObjectToOutputStreamInsufficientBuffer),
         ]
     }
 

--- a/TestFoundation/TestNSStream.swift
+++ b/TestFoundation/TestNSStream.swift
@@ -33,7 +33,7 @@ class TestNSStream : XCTestCase {
     }
     
     func test_InputStreamWithData(){
-        let message: NSString = "Hello, playground"
+        let message: NSString = "Hello, playground\0\0\0"
         let messageData: Data = message.data(using: String.Encoding.utf8.rawValue)!
         let dataStream: InputStream = InputStream(data: messageData)
         XCTAssertEqual(Stream.Status.notOpen, dataStream.streamStatus)
@@ -52,7 +52,7 @@ class TestNSStream : XCTestCase {
     }
     
     func test_InputStreamWithUrl() {
-        let message: NSString = "Hello, playground"
+        let message: NSString = "Hello, playground\0\0\0"
         let messageData: Data  = message.data(using: String.Encoding.utf8.rawValue)!
         //Initialiser with url
         let testFile = createTestFile("testFile_in.txt", _contents: messageData)
@@ -80,7 +80,7 @@ class TestNSStream : XCTestCase {
     }
     
     func test_InputStreamWithFile() {
-        let message: NSString = "Hello, playground"
+        let message: NSString = "Hello, playground\0\0\0"
         let messageData: Data  = message.data(using: String.Encoding.utf8.rawValue)!
         //Initialiser with file
         let testFile = createTestFile("testFile_in.txt", _contents: messageData)

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -59,6 +59,7 @@ class TestNSString : XCTestCase {
             ("test_FromNullTerminatedCStringInUTF8", test_FromNullTerminatedCStringInUTF8 ),
             // Swift3 updates broke the expectations of this test. disabling for now
             // ("test_FromMalformedNullTerminatedCStringInUTF8", test_FromMalformedNullTerminatedCStringInUTF8 ),
+            ("test_FromDataWithInternalNullCharacter", test_FromDataWithInternalNullCharacter ),
             ("test_uppercaseString", test_uppercaseString ),
             ("test_lowercaseString", test_lowercaseString ),
             ("test_capitalizedString", test_capitalizedString ),
@@ -69,7 +70,7 @@ class TestNSString : XCTestCase {
             ("test_FromContentOfFile",test_FromContentOfFile),
             ("test_swiftStringUTF16", test_swiftStringUTF16),
             // This test takes forever on build servers; it has been seen up to 1852.084 seconds
-//            ("test_completePathIntoString", test_completePathIntoString),
+            // ("test_completePathIntoString", test_completePathIntoString),
             ("test_stringByTrimmingCharactersInSet", test_stringByTrimmingCharactersInSet),
             ("test_initializeWithFormat", test_initializeWithFormat),
             ("test_initializeWithFormat2", test_initializeWithFormat2),
@@ -270,6 +271,14 @@ class TestNSString : XCTestCase {
         let bytes = mockMalformedUTF8StringBytes + [0x00]
         let string = NSString(CString: bytes.map { Int8(bitPattern: $0) }, encoding: String.Encoding.utf8.rawValue)
         XCTAssertNil(string)
+    }
+
+    func test_FromDataWithInternalNullCharacter() {
+        let bytes = mockASCIIStringBytes + [0x00] + mockASCIIStringBytes
+        let length = mockASCIIStringBytes.count * 2 + 1
+        let data = Data(bytes: bytes, count: length)
+        let string = NSString(data: data, encoding: String.Encoding.ascii.rawValue)
+        XCTAssertTrue(string?.isEqual(to: mockASCIIString + "\0" + mockASCIIString) ?? false)
     }
 
     func test_FromContentsOfURL() {


### PR DESCRIPTION
## What's going on in this PR

### Existing bridging is buggy

The existing implementation of bridging from _NSCFString to String was broken in several ways:

1. The "fast path" blew away internal NUL characters because it used facilities for C strings.
2. Merely removing the "fast path" strangely caused tests to fail. Debugging revealed that the reason for failing tests was that the default "slow path" was also broken.
3. The "slow path" used CFStringGetLength() and CFStringGetCharacters(). However, if the CFString in question contains multi-byte characters _and_ was initialized using bytes, then neither of these CF functions behaves as documented:
  * CFStringGetLength() seems to return the length in bytes, not the length in UTF16 code pairs.
  * CFStringGetCharacters() seems to return the bytes, not the UTF16 code pairs.

As a consequence, if UTF8-encoded bytes that encode internal NUL characters _and_ multi-byte characters were used to initialize an NSString, the "fast path" would clobber bridging in one way, and the "slow path" would clobber bridging in a different way.

### Revised bridging

Since CF UTF16-related functions are erratic, I use a buffer to store UTF8-encoded bytes. If some way can be found to determine (reliably, not relying on the result of a buggy implementation in CF) the length **in bytes** of a CFString that uses UTF8-encoded bytes for storage, then a fast path can be restored that doesn't require allocating a buffer.

### Modified tests

After implementing this revised bridging, five tests began to fail. On further examination, these tests were found to be incorrect because they relied on multiple tandem NUL characters being lost on bridging. On a Mac, Darwin Foundation fails these five tests as well. I have corrected the tests.

This PR additionally adds a test for constructing an NSString with data that contains an internal NUL character.

### Miscellaneous changes

This PR rolls in the previously discussed (#496) change in `init?(data:encoding:)`.

This PR also fixes three nits: a typo in a test name; an alphabetization issue in the Xcode project for a test file; and inconsistent use of an unindented `//`.
