### PR TITLE
Fix refcount issue in CFDateFormatter

### DIFF
--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -115,8 +115,8 @@ open class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
      */
     open override var description: String {
         let dateFormatterRef = CFDateFormatterCreate(kCFAllocatorSystemDefault, nil, kCFDateFormatterFullStyle, kCFDateFormatterFullStyle)
-        let timeZone = CFTimeZoneCreateWithTimeIntervalFromGMT(kCFAllocatorSystemDefault, 0.0)
-        CFDateFormatterSetProperty(dateFormatterRef, kCFDateFormatterTimeZoneKey, timeZone)
+        CFDateFormatterSetProperty(dateFormatterRef, kCFDateFormatterTimeZoneKey,
+            CFTimeZoneCreateWithTimeIntervalFromGMT(kCFAllocatorSystemDefault, 0.0))
         CFDateFormatterSetFormat(dateFormatterRef, "uuuu-MM-dd HH:mm:ss '+0000'"._cfObject)
 
         return CFDateFormatterCreateStringWithDate(kCFAllocatorSystemDefault, dateFormatterRef, _cfObject)._swiftObject

--- a/TestFoundation/TestNSDate.swift
+++ b/TestFoundation/TestNSDate.swift
@@ -35,6 +35,7 @@ class TestNSDate : XCTestCase {
             ("test_LaterDate", test_LaterDate),
             ("test_Compare", test_Compare),
             ("test_IsEqualToDate", test_IsEqualToDate),
+            ("test_descriptionTimeZone", test_descriptionTimeZone)
         ]
     }
     
@@ -113,5 +114,12 @@ class TestNSDate : XCTestCase {
         let d2 = d1 + ti
         let d3 = d1 + ti
         XCTAssertEqual(d2, d3)
+    }
+
+    func test_descriptionTimeZone() {
+        // Regression test for TimeZone being double released, causing a use after free
+        for _ in 0...1000 {
+            _ = NSDate().description
+        }
     }
 }


### PR DESCRIPTION
- __CFDateFormatterDeallocate() always releases _TimeZone but
  __CFDateFormatterSetProperty() only retains it if the value
  is different

- Triggered by NSDate.description() if used enough times, simple
  regression test to expose it

I think I have the CFRetain() in the correct place but it will definitely need a review by someone more familiar with CFDateFormatter.c. 

Without this fix, calls to NSDate.description will eventually cause a segfault