### PR TITLE
CharacterSet: minor improvements to match darwin

### DIFF
--- a/Foundation/CharacterSet.swift
+++ b/Foundation/CharacterSet.swift
@@ -234,8 +234,8 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     }
     
     /// Returns a character set containing the characters in Unicode General Category P*.
-    public static var punctuation : CharacterSet {
-        return NSCharacterSet.punctuation
+    public static var punctuationCharacters : CharacterSet {
+        return NSCharacterSet.punctuationCharacters
     }
     
     /// Returns a character set containing the characters in Unicode General Category Lt.

--- a/Foundation/NSCharacterSet.swift
+++ b/Foundation/NSCharacterSet.swift
@@ -114,7 +114,7 @@ open class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
         return CFCharacterSetGetPredefined(kCFCharacterSetIllegal)._swiftObject
     }
     
-    open class var punctuation: CharacterSet {
+    open class var punctuationCharacters: CharacterSet {
         return CFCharacterSetGetPredefined(kCFCharacterSetPunctuation)._swiftObject
     }
     
@@ -156,6 +156,7 @@ open class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
     
     public convenience required init(coder aDecoder: NSCoder) {
         self.init(charactersIn: "")
+        NSUnimplemented()
     }
     
     open func characterIsMember(_ aCharacter: unichar) -> Bool {
@@ -219,7 +220,7 @@ open class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
     }
     
     open func encode(with aCoder: NSCoder) {
-        
+        NSUnimplemented()
     }
 }
 


### PR DESCRIPTION
1) we don't actually impl NSCoding methods, so NSUnimplement them
2) punctuationCharacters was incorrectly migrated as punctuation