### PR TITLE
Foundation API Conformance Update: URLs

### DIFF
--- a/Foundation/NSBundle.swift
+++ b/Foundation/NSBundle.swift
@@ -50,11 +50,7 @@ open class Bundle: NSObject {
     }
     
     public convenience init?(url: URL) {
-        if let path = url.path {
-            self.init(path: path)
-        } else {
-            return nil
-        }
+        self.init(path: url.path)
     }
     
     public init(for aClass: AnyClass) { NSUnimplemented() }
@@ -70,7 +66,7 @@ open class Bundle: NSObject {
     }
     
     override open var description: String {
-        return "\(String(describing: Bundle.self)) <\(bundleURL.path!)> (\(isLoaded  ? "loaded" : "not yet loaded"))"
+        return "\(String(describing: Bundle.self)) <\(bundleURL.path)> (\(isLoaded  ? "loaded" : "not yet loaded"))"
     }
 
     
@@ -144,7 +140,7 @@ open class Bundle: NSObject {
     }
     
     open var bundlePath: String {
-        return bundleURL.path!
+        return bundleURL.path
     }
     
     open var resourcePath: String? {

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -336,7 +336,7 @@ extension NSData {
     
     public convenience init(contentsOf url: URL, options readOptionsMask: ReadingOptions) throws {
         if url.isFileURL {
-            try self.init(contentsOfFile: url.path!, options: readOptionsMask)
+            try self.init(contentsOfFile: url.path, options: readOptionsMask)
         } else {
             let session = URLSession(configuration: URLSessionConfiguration.defaultSessionConfiguration())
             let cond = NSCondition()
@@ -503,9 +503,7 @@ extension NSData {
     
     public func write(to url: URL, atomically: Bool) -> Bool {
         if url.isFileURL {
-            if let path = url.path {
-                return write(toFile: path, atomically: atomically)
-            }
+            return write(toFile: url.path, atomically: atomically)
         }
         return false
     }
@@ -519,12 +517,12 @@ extension NSData {
     ///
     ///      This method is invoked in a `try` expression and the caller is responsible for handling any errors in the `catch` clauses of a `do` statement, as described in [Error Handling](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/Swift_Programming_Language/ErrorHandling.html#//apple_ref/doc/uid/TP40014097-CH42) in [The Swift Programming Language](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/Swift_Programming_Language/index.html#//apple_ref/doc/uid/TP40014097) and [Error Handling](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/AdoptingCocoaDesignPatterns.html#//apple_ref/doc/uid/TP40014216-CH7-ID10) in [Using Swift with Cocoa and Objective-C](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/index.html#//apple_ref/doc/uid/TP40014216).
     public func write(to url: URL, options writeOptionsMask: WritingOptions = []) throws {
-        guard let path = url.path, url.isFileURL == true else {
+        guard url.isFileURL else {
             let userInfo = [NSLocalizedDescriptionKey : "The folder at “\(url)” does not exist or is not a file URL.", // NSLocalizedString() not yet available
-                            NSURLErrorKey             : url.absoluteString ?? ""] as Dictionary<String, Any>
+                            NSURLErrorKey             : url.absoluteString] as Dictionary<String, Any>
             throw NSError(domain: NSCocoaErrorDomain, code: 4, userInfo: userInfo)
         }
-        try write(toFile: path, options: writeOptionsMask)
+        try write(toFile: url.path, options: writeOptionsMask)
     }
     
     public func range(of searchData: Data, options mask: SearchOptions = [], in searchRange: NSRange) -> NSRange {

--- a/Foundation/NSFileHandle.swift
+++ b/Foundation/NSFileHandle.swift
@@ -232,15 +232,12 @@ extension FileHandle {
     }
     
     internal static func _openFileDescriptorForURL(_ url : URL, flags: Int32, reading: Bool) throws -> Int32 {
-        if let path = url.path {
-            let fd = _CFOpenFile(path, flags)
-            if fd < 0 {
-                throw _NSErrorWithErrno(errno, reading: reading, url: url)
-            }
-            return fd
-        } else {
-            throw _NSErrorWithErrno(ENOENT, reading: reading, url: url)
+        let path = url.path
+        let fd = _CFOpenFile(path, flags)
+        if fd < 0 {
+            throw _NSErrorWithErrno(errno, reading: reading, url: url)
         }
+        return fd
     }
     
     public convenience init(forReadingFrom url: URL) throws {

--- a/Foundation/NSFileManager.swift
+++ b/Foundation/NSFileManager.swift
@@ -144,10 +144,7 @@ open class FileManager: NSObject {
         guard url.isFileURL else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileWriteUnsupportedSchemeError.rawValue, userInfo: [NSURLErrorKey : url])
         }
-        guard let path = url.path else {
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileNoSuchFileError.rawValue, userInfo: nil)
-        }
-        try self.createDirectory(atPath: path, withIntermediateDirectories: createIntermediates, attributes: attributes)
+        try self.createDirectory(atPath: url.path, withIntermediateDirectories: createIntermediates, attributes: attributes)
     }
     
     /* createSymbolicLinkAtURL:withDestinationURL:error: returns YES if the symbolic link that point at 'destURL' was able to be created at the location specified by 'url'. 'destURL' is always resolved against its base URL, if it has one. If 'destURL' has no base URL and it's 'relativePath' is indeed a relative path, then a relative symlink will be created. If this method returns NO, the link was unable to be created and an NSError will be returned by reference in the 'error' parameter. This method does not traverse a terminal symlink.
@@ -159,13 +156,7 @@ open class FileManager: NSObject {
         guard destURL.scheme == nil || destURL.isFileURL else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileWriteUnsupportedSchemeError.rawValue, userInfo: [NSURLErrorKey : destURL])
         }
-        guard let path = url.path else {
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileNoSuchFileError.rawValue, userInfo: [NSURLErrorKey : url])
-        }
-        guard let destPath = destURL.path else {
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileNoSuchFileError.rawValue, userInfo: [NSURLErrorKey : destURL])
-        }
-        try self.createSymbolicLink(atPath: path, withDestinationPath: destPath)
+        try self.createSymbolicLink(atPath: url.path, withDestinationPath: destURL.path)
     }
     
     /* Instances of NSFileManager may now have delegates. Each instance has one delegate, and the delegate is not retained. In versions of Mac OS X prior to 10.5, the behavior of calling [[NSFileManager alloc] init] was undefined. In Mac OS X 10.5 "Leopard" and later, calling [[NSFileManager alloc] init] returns a new instance of an NSFileManager.
@@ -516,13 +507,7 @@ open class FileManager: NSObject {
         guard dstURL.isFileURL else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileWriteUnsupportedSchemeError.rawValue, userInfo: [NSURLErrorKey : dstURL])
         }
-        guard let srcPath = srcURL.path else {
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileNoSuchFileError.rawValue, userInfo: [NSURLErrorKey : srcURL])
-        }
-        guard let dstPath = dstURL.path else {
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileNoSuchFileError.rawValue, userInfo: [NSURLErrorKey : dstURL])
-        }
-        try copyItem(atPath: srcPath, toPath: dstPath)
+        try copyItem(atPath: srcURL.path, toPath: dstURL.path)
     }
     
     open func moveItem(at srcURL: URL, to dstURL: URL) throws {
@@ -532,13 +517,7 @@ open class FileManager: NSObject {
         guard dstURL.isFileURL else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileWriteUnsupportedSchemeError.rawValue, userInfo: [NSURLErrorKey : dstURL])
         }
-        guard let srcPath = srcURL.path else {
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileNoSuchFileError.rawValue, userInfo: [NSURLErrorKey : srcURL])
-        }
-        guard let dstPath = dstURL.path else {
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileNoSuchFileError.rawValue, userInfo: [NSURLErrorKey : dstURL])
-        }
-        try moveItem(atPath: srcPath, toPath: dstPath)
+        try moveItem(atPath: srcURL.path, toPath: dstURL.path)
     }
     
     open func linkItem(at srcURL: URL, to dstURL: URL) throws {
@@ -548,23 +527,14 @@ open class FileManager: NSObject {
         guard dstURL.isFileURL else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileWriteUnsupportedSchemeError.rawValue, userInfo: [NSURLErrorKey : dstURL])
         }
-        guard let srcPath = srcURL.path else {
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileNoSuchFileError.rawValue, userInfo: [NSURLErrorKey : srcURL])
-        }
-        guard let dstPath = dstURL.path else {
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileNoSuchFileError.rawValue, userInfo: [NSURLErrorKey : dstURL])
-        }
-        try linkItem(atPath: srcPath, toPath: dstPath)
+        try linkItem(atPath: srcURL.path, toPath: dstURL.path)
     }
     
     open func removeItem(at url: URL) throws {
         guard url.isFileURL else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileWriteUnsupportedSchemeError.rawValue, userInfo: [NSURLErrorKey : url])
         }
-        guard let path = url.path else {
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileNoSuchFileError.rawValue, userInfo: [NSURLErrorKey : url])
-        }
-        try self.removeItem(atPath: path)
+        try self.removeItem(atPath: url.path)
     }
     
     /* Process working directory management. Despite the fact that these are instance methods on NSFileManager, these methods report and change (respectively) the working directory for the entire process. Developers are cautioned that doing so is fraught with peril.
@@ -890,7 +860,7 @@ extension FileManager {
             guard let url = o as? NSURL else {
                 return nil
             }
-            let path = url.path!.replacingOccurrences(of: baseURL.path!+"/", with: "")
+            let path = url.path!.replacingOccurrences(of: baseURL.path+"/", with: "")
             return NSString(string: path)
         }
 
@@ -910,22 +880,17 @@ extension FileManager {
             _options = options
             _errorHandler = errorHandler
             
-            if let path = _url.path {
-                if FileManager.default.fileExists(atPath: path) {
-                    let fsRep = FileManager.default.fileSystemRepresentation(withPath: path)
-                    let ps = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>.allocate(capacity: 2)
-                    ps.initialize(to: UnsafeMutablePointer(mutating: fsRep))
-                    ps.advanced(by: 1).initialize(to: nil)
-                    _stream = fts_open(ps, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR, nil)
-                    ps.deinitialize(count: 2)
-                    ps.deallocate(capacity: 2)
-                } else {
-                    _rootError = _NSErrorWithErrno(ENOENT, reading: true, url: url)
-                }
+            if FileManager.default.fileExists(atPath: _url.path) {
+                let fsRep = FileManager.default.fileSystemRepresentation(withPath: _url.path)
+                let ps = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>.allocate(capacity: 2)
+                ps.initialize(to: UnsafeMutablePointer(mutating: fsRep))
+                ps.advanced(by: 1).initialize(to: nil)
+                _stream = fts_open(ps, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR, nil)
+                ps.deinitialize(count: 2)
+                ps.deallocate(capacity: 2)
             } else {
                 _rootError = _NSErrorWithErrno(ENOENT, reading: true, url: url)
             }
-
         }
         
         deinit {

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -70,17 +70,21 @@ public struct URLResourceKey : RawRepresentable, Equatable, Hashable, Comparable
         self.rawValue = rawValue
     }
     
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
     public var hashValue: Int {
         return rawValue.hashValue
     }
-}
 
-public func ==(lhs: URLResourceKey, rhs: URLResourceKey) -> Bool {
-    return lhs.rawValue == rhs.rawValue
-}
+    public static func ==(lhs: URLResourceKey, rhs: URLResourceKey) -> Bool {
+        return lhs.rawValue == rhs.rawValue
+    }
 
-public func <(lhs: URLResourceKey, rhs: URLResourceKey) -> Bool {
-    return lhs.rawValue < rhs.rawValue
+    public static func <(lhs: URLResourceKey, rhs: URLResourceKey) -> Bool {
+        return lhs.rawValue < rhs.rawValue
+    }
 }
 
 extension URLResourceKey {
@@ -136,17 +140,21 @@ public struct URLFileResourceType : RawRepresentable, Equatable, Hashable, Compa
         self.rawValue = rawValue
     }
     
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
     public var hashValue: Int {
         return rawValue.hashValue
     }
-}
 
-public func ==(lhs: URLFileResourceType, rhs: URLFileResourceType) -> Bool {
-    return lhs.rawValue == rhs.rawValue
-}
+    public static func ==(lhs: URLFileResourceType, rhs: URLFileResourceType) -> Bool {
+        return lhs.rawValue == rhs.rawValue
+    }
 
-public func <(lhs: URLFileResourceType, rhs: URLFileResourceType) -> Bool {
-    return lhs.rawValue < rhs.rawValue
+    public static func <(lhs: URLFileResourceType, rhs: URLFileResourceType) -> Bool {
+        return lhs.rawValue < rhs.rawValue
+    }
 }
 
 extension URLFileResourceType {
@@ -602,12 +610,12 @@ extension NSCharacterSet {
 extension NSString {
     
     // Returns a new string made from the receiver by replacing all characters not in the allowedCharacters set with percent encoded characters. UTF-8 encoding is used to determine the correct percent encoded characters. Entire URL strings cannot be percent-encoded. This method is intended to percent-encode an URL component or subcomponent string, NOT the entire URL string. Any characters in allowedCharacters outside of the 7-bit ASCII range are ignored.
-    public func stringByAddingPercentEncodingWithAllowedCharacters(_ allowedCharacters: CharacterSet) -> String? {
+    open func addingPercentEncoding(withAllowedCharacters allowedCharacters: CharacterSet) -> String? {
         return _CFStringCreateByAddingPercentEncodingWithAllowedCharacters(kCFAllocatorSystemDefault, self._cfObject, allowedCharacters._cfObject)._swiftObject
     }
     
     // Returns a new string made from the receiver by replacing all percent encoded sequences with the matching UTF-8 characters.
-    public var stringByRemovingPercentEncoding: String? {
+    open var removingPercentEncoding: String? {
         return _CFStringCreateByRemovingPercentEncoding(kCFAllocatorSystemDefault, self._cfObject)?._swiftObject
     }
 }

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -852,8 +852,8 @@ open class NSURLQueryItem : NSObject, NSSecureCoding, NSCopying {
         NSUnimplemented()
     }
     
-    public let name: String
-    public let value: String?
+    open let name: String
+    open let value: String?
 }
 
 open class NSURLComponents: NSObject, NSCopying {

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -96,7 +96,7 @@ extension URLResourceKey {
     public static let isSymbolicLinkKey = URLResourceKey(rawValue: "NSURLIsSymbolicLinkKey")
     public static let isVolumeKey = URLResourceKey(rawValue: "NSURLIsVolumeKey")
     public static let isPackageKey = URLResourceKey(rawValue: "NSURLIsPackageKey")
-    public static let isApplicationKey = URLResourceKey(rawValue: "_NSURLIsApplicationKey")
+    public static let isApplicationKey = URLResourceKey(rawValue: "NSURLIsApplicationKey")
     public static let applicationIsScriptableKey = URLResourceKey(rawValue: "NSURLApplicationIsScriptableKey")
     public static let isSystemImmutableKey = URLResourceKey(rawValue: "NSURLIsSystemImmutableKey")
     public static let isUserImmutableKey = URLResourceKey(rawValue: "NSURLIsUserImmutableKey")
@@ -122,15 +122,71 @@ extension URLResourceKey {
     public static let isReadableKey = URLResourceKey(rawValue: "NSURLIsReadableKey")
     public static let isWritableKey = URLResourceKey(rawValue: "NSURLIsWritableKey")
     public static let isExecutableKey = URLResourceKey(rawValue: "NSURLIsExecutableKey")
-    public static let pathKey = URLResourceKey(rawValue: "_NSURLPathKey")
+    public static let fileSecurityKey = URLResourceKey(rawValue: "NSURLFileSecurityKey")
+    public static let isExcludedFromBackupKey = URLResourceKey(rawValue: "NSURLIsExcludedFromBackupKey")
+    public static let tagNamesKey = URLResourceKey(rawValue: "NSURLTagNamesKey")
+    public static let pathKey = URLResourceKey(rawValue: "NSURLPathKey")
+    public static let canonicalPathKey = URLResourceKey(rawValue: "NSURLCanonicalPathKey")
+    public static let isMountTriggerKey = URLResourceKey(rawValue: "NSURLIsMountTriggerKey")
+    public static let generationIdentifierKey = URLResourceKey(rawValue: "NSURLGenerationIdentifierKey")
     public static let documentIdentifierKey = URLResourceKey(rawValue: "NSURLDocumentIdentifierKey")
     public static let addedToDirectoryDateKey = URLResourceKey(rawValue: "NSURLAddedToDirectoryDateKey")
+    public static let quarantinePropertiesKey = URLResourceKey(rawValue: "NSURLQuarantinePropertiesKey")
     public static let fileResourceTypeKey = URLResourceKey(rawValue: "NSURLFileResourceTypeKey")
+    public static let thumbnailDictionaryKey = URLResourceKey(rawValue: "NSURLThumbnailDictionaryKey")
+    public static let thumbnailKey = URLResourceKey(rawValue: "NSURLThumbnailKey")
     public static let fileSizeKey = URLResourceKey(rawValue: "NSURLFileSizeKey")
     public static let fileAllocatedSizeKey = URLResourceKey(rawValue: "NSURLFileAllocatedSizeKey")
     public static let totalFileSizeKey = URLResourceKey(rawValue: "NSURLTotalFileSizeKey")
     public static let totalFileAllocatedSizeKey = URLResourceKey(rawValue: "NSURLTotalFileAllocatedSizeKey")
     public static let isAliasFileKey = URLResourceKey(rawValue: "NSURLIsAliasFileKey")
+    public static let volumeLocalizedFormatDescriptionKey = URLResourceKey(rawValue: "NSURLVolumeLocalizedFormatDescriptionKey")
+    public static let volumeTotalCapacityKey = URLResourceKey(rawValue: "NSURLVolumeTotalCapacityKey")
+    public static let volumeAvailableCapacityKey = URLResourceKey(rawValue: "NSURLVolumeAvailableCapacityKey")
+    public static let volumeResourceCountKey = URLResourceKey(rawValue: "NSURLVolumeResourceCountKey")
+    public static let volumeSupportsPersistentIDsKey = URLResourceKey(rawValue: "NSURLVolumeSupportsPersistentIDsKey")
+    public static let volumeSupportsSymbolicLinksKey = URLResourceKey(rawValue: "NSURLVolumeSupportsSymbolicLinksKey")
+    public static let volumeSupportsHardLinksKey = URLResourceKey(rawValue: "NSURLVolumeSupportsHardLinksKey")
+    public static let volumeSupportsJournalingKey = URLResourceKey(rawValue: "NSURLVolumeSupportsJournalingKey")
+    public static let volumeIsJournalingKey = URLResourceKey(rawValue: "NSURLVolumeIsJournalingKey")
+    public static let volumeSupportsSparseFilesKey = URLResourceKey(rawValue: "NSURLVolumeSupportsSparseFilesKey")
+    public static let volumeSupportsZeroRunsKey = URLResourceKey(rawValue: "NSURLVolumeSupportsZeroRunsKey")
+    public static let volumeSupportsCaseSensitiveNamesKey = URLResourceKey(rawValue: "NSURLVolumeSupportsCaseSensitiveNamesKey")
+    public static let volumeSupportsCasePreservedNamesKey = URLResourceKey(rawValue: "NSURLVolumeSupportsCasePreservedNamesKey")
+    public static let volumeSupportsRootDirectoryDatesKey = URLResourceKey(rawValue: "NSURLVolumeSupportsRootDirectoryDatesKey")
+    public static let volumeSupportsVolumeSizesKey = URLResourceKey(rawValue: "NSURLVolumeSupportsVolumeSizesKey")
+    public static let volumeSupportsRenamingKey = URLResourceKey(rawValue: "NSURLVolumeSupportsRenamingKey")
+    public static let volumeSupportsAdvisoryFileLockingKey = URLResourceKey(rawValue: "NSURLVolumeSupportsAdvisoryFileLockingKey")
+    public static let volumeSupportsExtendedSecurityKey = URLResourceKey(rawValue: "NSURLVolumeSupportsExtendedSecurityKey")
+    public static let volumeIsBrowsableKey = URLResourceKey(rawValue: "NSURLVolumeIsBrowsableKey")
+    public static let volumeMaximumFileSizeKey = URLResourceKey(rawValue: "NSURLVolumeMaximumFileSizeKey")
+    public static let volumeIsEjectableKey = URLResourceKey(rawValue: "NSURLVolumeIsEjectableKey")
+    public static let volumeIsRemovableKey = URLResourceKey(rawValue: "NSURLVolumeIsRemovableKey")
+    public static let volumeIsInternalKey = URLResourceKey(rawValue: "NSURLVolumeIsInternalKey")
+    public static let volumeIsAutomountedKey = URLResourceKey(rawValue: "NSURLVolumeIsAutomountedKey")
+    public static let volumeIsLocalKey = URLResourceKey(rawValue: "NSURLVolumeIsLocalKey")
+    public static let volumeIsReadOnlyKey = URLResourceKey(rawValue: "NSURLVolumeIsReadOnlyKey")
+    public static let volumeCreationDateKey = URLResourceKey(rawValue: "NSURLVolumeCreationDateKey")
+    public static let volumeURLForRemountingKey = URLResourceKey(rawValue: "NSURLVolumeURLForRemountingKey")
+    public static let volumeUUIDStringKey = URLResourceKey(rawValue: "NSURLVolumeUUIDStringKey")
+    public static let volumeNameKey = URLResourceKey(rawValue: "NSURLVolumeNameKey")
+    public static let volumeLocalizedNameKey = URLResourceKey(rawValue: "NSURLVolumeLocalizedNameKey")
+    public static let volumeIsEncryptedKey = URLResourceKey(rawValue: "NSURLVolumeIsEncryptedKey")
+    public static let volumeIsRootFileSystemKey = URLResourceKey(rawValue: "NSURLVolumeIsRootFileSystemKey")
+    public static let volumeSupportsCompressionKey = URLResourceKey(rawValue: "NSURLVolumeSupportsCompressionKey")
+    public static let volumeSupportsFileCloningKey = URLResourceKey(rawValue: "NSURLVolumeSupportsFileCloningKey")
+    public static let volumeSupportsSwapRenamingKey = URLResourceKey(rawValue: "NSURLVolumeSupportsSwapRenamingKey")
+    public static let volumeSupportsExclusiveRenamingKey = URLResourceKey(rawValue: "NSURLVolumeSupportsExclusiveRenamingKey")
+    public static let isUbiquitousItemKey = URLResourceKey(rawValue: "NSURLIsUbiquitousItemKey")
+    public static let ubiquitousItemHasUnresolvedConflictsKey = URLResourceKey(rawValue: "NSURLUbiquitousItemHasUnresolvedConflictsKey")
+    public static let ubiquitousItemIsDownloadingKey = URLResourceKey(rawValue: "NSURLUbiquitousItemIsDownloadingKey")
+    public static let ubiquitousItemIsUploadedKey = URLResourceKey(rawValue: "NSURLUbiquitousItemIsUploadedKey")
+    public static let ubiquitousItemIsUploadingKey = URLResourceKey(rawValue: "NSURLUbiquitousItemIsUploadingKey")
+    public static let ubiquitousItemDownloadingStatusKey = URLResourceKey(rawValue: "NSURLUbiquitousItemDownloadingStatusKey")
+    public static let ubiquitousItemDownloadingErrorKey = URLResourceKey(rawValue: "NSURLUbiquitousItemDownloadingErrorKey")
+    public static let ubiquitousItemUploadingErrorKey = URLResourceKey(rawValue: "NSURLUbiquitousItemUploadingErrorKey")
+    public static let ubiquitousItemDownloadRequestedKey = URLResourceKey(rawValue: "NSURLUbiquitousItemDownloadRequestedKey")
+    public static let ubiquitousItemContainerDisplayNameKey = URLResourceKey(rawValue: "NSURLUbiquitousItemContainerDisplayNameKey")
 }
 
 
@@ -256,8 +312,8 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
         if thePath.length > 0 {
             
             _CFURLInitWithFileSystemPathRelativeToBase(_cfObject, thePath._cfObject, kCFURLPOSIXPathStyle, isDir, baseURL?._cfObject)
-        } else if let baseURL = baseURL, let path = baseURL.path {
-            _CFURLInitWithFileSystemPathRelativeToBase(_cfObject, path._cfObject, kCFURLPOSIXPathStyle, baseURL.hasDirectoryPath, nil)
+        } else if let baseURL = baseURL {
+            _CFURLInitWithFileSystemPathRelativeToBase(_cfObject, baseURL.path._cfObject, kCFURLPOSIXPathStyle, baseURL.hasDirectoryPath, nil)
         }
     }
     
@@ -270,16 +326,13 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
             isDir = true
         } else {
             let absolutePath: String
-            do {
-                if let absPath = try baseURL?.appendingPathComponent(path).path {
-                    absolutePath = absPath
-                } else {
-                    absolutePath = path
-                }
-                let _ = FileManager.default.fileExists(atPath: absolutePath, isDirectory: &isDir)
-            } catch {
-                // ignored
+            if let absPath = baseURL?.appendingPathComponent(path).path {
+                absolutePath = absPath
+            } else {
+                absolutePath = path
             }
+            
+            let _ = FileManager.default.fileExists(atPath: absolutePath, isDirectory: &isDir)
         }
 
         self.init(fileURLWithPath: thePath, isDirectory: isDir, relativeTo: baseURL)
@@ -553,7 +606,7 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     */
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    open func resourceIsReachable() throws -> Bool {
+    open func checkResourceIsReachable() throws -> Bool {
         NSUnimplemented()
     }
 
@@ -711,10 +764,9 @@ extension NSURL {
     open func appendingPathComponent(_ pathComponent: String) -> URL? {
         var result : URL? = appendingPathComponent(pathComponent, isDirectory: false)
         if !pathComponent.hasSuffix("/") && isFileURL {
-            if let urlWithoutDirectory = result,
-               let path = urlWithoutDirectory.path {
+            if let urlWithoutDirectory = result {
                 var isDir : Bool = false
-                if FileManager.default.fileExists(atPath: path, isDirectory: &isDir) && isDir {
+                if FileManager.default.fileExists(atPath: urlWithoutDirectory.path, isDirectory: &isDir) && isDir {
                     result = self.appendingPathComponent(pathComponent, isDirectory: true)
                 }
             }
@@ -769,7 +821,7 @@ extension NSURL {
         }
 
         
-        var components = URL(fileURLWithPath: absolutePath).pathComponents!
+        var components = URL(fileURLWithPath: absolutePath).pathComponents
         guard !components.isEmpty else {
             return URL(string: absoluteString)
         }

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -168,7 +168,7 @@ extension URLFileResourceType {
     public static let unknown = URLFileResourceType(rawValue: "NSURLFileResourceTypeUnknown")
 }
 
-open class NSURL: NSObject, NSSecureCoding, NSCopying {
+open class NSURL : NSObject, NSSecureCoding, NSCopying {
     typealias CFType = CFURL
     internal var _base = _CFInfo(typeID: CFURLGetTypeID())
     internal var _flags : UInt32 = 0
@@ -250,7 +250,7 @@ open class NSURL: NSObject, NSSecureCoding, NSCopying {
         }
     }
     
-    internal init(fileURLWithPath path: String, isDirectory isDir: Bool, relativeTo baseURL: URL?) {
+    public init(fileURLWithPath path: String, isDirectory isDir: Bool, relativeTo baseURL: URL?) {
         super.init()
         let thePath = _standardizedPath(path)
         if thePath.length > 0 {
@@ -570,6 +570,13 @@ open class NSURL: NSObject, NSSecureCoding, NSCopying {
     override open var _cfTypeID: CFTypeID {
         return CFURLGetTypeID()
     }
+
+    open func removeAllCachedResourceValues() { NSUnimplemented() }
+    open func removeCachedResourceValue(forKey key: URLResourceKey) { NSUnimplemented() }
+    open func resourceValues(forKeys keys: [URLResourceKey]) throws -> [URLResourceKey : Any] { NSUnimplemented() }
+    open func setResourceValue(_ value: Any?, forKey key: URLResourceKey) throws { NSUnimplemented() }
+    open func setResourceValues(_ keyedValues: [URLResourceKey : Any]) throws { NSUnimplemented() }
+    open func setTemporaryResourceValue(_ value: Any?, forKey key: URLResourceKey) { NSUnimplemented() }
 }
 
 extension NSCharacterSet {
@@ -577,32 +584,32 @@ extension NSCharacterSet {
     // Predefined character sets for the six URL components and subcomponents which allow percent encoding. These character sets are passed to -stringByAddingPercentEncodingWithAllowedCharacters:.
     
     // Returns a character set containing the characters allowed in an URL's user subcomponent.
-    public static var urlUserAllowed: CharacterSet {
+    open class var urlUserAllowed: CharacterSet {
         return _CFURLComponentsGetURLUserAllowedCharacterSet()._swiftObject
     }
     
     // Returns a character set containing the characters allowed in an URL's password subcomponent.
-    public static var urlPasswordAllowed: CharacterSet {
+    open class var urlPasswordAllowed: CharacterSet {
         return _CFURLComponentsGetURLPasswordAllowedCharacterSet()._swiftObject
     }
     
     // Returns a character set containing the characters allowed in an URL's host subcomponent.
-    public static var urlHostAllowed: CharacterSet {
+    open class var urlHostAllowed: CharacterSet {
         return _CFURLComponentsGetURLHostAllowedCharacterSet()._swiftObject
     }
     
     // Returns a character set containing the characters allowed in an URL's path component. ';' is a legal path character, but it is recommended that it be percent-encoded for best compatibility with NSURL (-stringByAddingPercentEncodingWithAllowedCharacters: will percent-encode any ';' characters if you pass the URLPathAllowedCharacterSet).
-    public static var urlPathAllowed: CharacterSet {
+    open class var urlPathAllowed: CharacterSet {
         return _CFURLComponentsGetURLPathAllowedCharacterSet()._swiftObject
     }
     
     // Returns a character set containing the characters allowed in an URL's query component.
-    public static var urlQueryAllowed: CharacterSet {
+    open class var urlQueryAllowed: CharacterSet {
         return _CFURLComponentsGetURLQueryAllowedCharacterSet()._swiftObject
     }
     
     // Returns a character set containing the characters allowed in an URL's fragment component.
-    public static var urlFragmentAllowed: CharacterSet {
+    open class var urlFragmentAllowed: CharacterSet {
         return _CFURLComponentsGetURLFragmentAllowedCharacterSet()._swiftObject
     }
 }
@@ -624,7 +631,7 @@ extension NSURL {
     
     /* The following methods work on the path portion of a URL in the same manner that the NSPathUtilities methods on NSString do.
     */
-    open class func fileURLWithPathComponents(_ components: [String]) -> URL? {
+    open class func fileURL(withPathComponents components: [String]) -> URL? {
         let path = NSString.pathWithComponents(components)
         if components.last == "/" {
             return URL(fileURLWithPath: path, isDirectory: true)
@@ -720,7 +727,7 @@ extension NSURL {
         return CFURLCreateCopyAppendingPathComponent(kCFAllocatorSystemDefault, _cfObject, pathComponent._cfObject, isDirectory)?._swiftObject
     }
     
-    public var deletingLastPathComponent: URL? {
+    open var deletingLastPathComponent: URL? {
         return CFURLCreateCopyDeletingLastPathComponent(kCFAllocatorSystemDefault, _cfObject)?._swiftObject
     }
     
@@ -728,7 +735,7 @@ extension NSURL {
         return CFURLCreateCopyAppendingPathExtension(kCFAllocatorSystemDefault, _cfObject, pathExtension._cfObject)?._swiftObject
     }
     
-    public var deletingPathExtension: URL? {
+    open var deletingPathExtension: URL? {
         return CFURLCreateCopyDeletingPathExtension(kCFAllocatorSystemDefault, _cfObject)?._swiftObject
     }
     

--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -82,15 +82,12 @@ extension NSURLRequest {
     }
     
     public enum NetworkServiceType : UInt {
-        case networkServiceTypeDefault // Standard internet traffic
-        
-        case networkServiceTypeVoIP // Voice over IP control traffic
-        
-        case networkServiceTypeVideo // Video traffic
-        
-        case networkServiceTypeBackground // Background traffic
-        
-        case networkServiceTypeVoice // Voice data
+        case `default` // Standard internet traffic
+        case voip // Voice over IP control traffic
+        case video // Video traffic
+        case background // Background traffic
+        case voice // Voice data
+        case networkServiceTypeCallSignaling // Call Signaling
     }
 }
 
@@ -115,7 +112,7 @@ extension NSURLRequest {
 ///
 /// Objects of this class are used with the `NSURLSession` API to perform the
 /// load of a URL.
-open class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying {
+open class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopying {
     
     open override func copy() -> Any {
         return copy(with: nil)
@@ -167,7 +164,7 @@ open class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying {
     }
     
     /// Indicates that NSURLRequest implements the NSSecureCoding protocol.
-    public static var supportsSecureCoding: Bool { return true }
+    open class  var supportsSecureCoding: Bool { return true }
     
     /// The URL of the receiver.
     /*@NSCopying */open fileprivate(set) var url: URL?
@@ -193,8 +190,8 @@ open class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying {
     
     /// A dictionary containing all the HTTP header fields
     /// of the receiver.
-    internal var _allHTTPHeaderFields: [String: String]? = nil
-    open var allHTTPHeaderFields: [String: String]? {
+    internal var _allHTTPHeaderFields: [String : String]? = nil
+    open var allHTTPHeaderFields: [String : String]? {
         get {
             return _allHTTPHeaderFields
         }
@@ -243,7 +240,7 @@ open class NSURLRequest: NSObject, NSSecureCoding, NSCopying, NSMutableCopying {
         return nil
     }
     
-    internal var _networkServiceType: NetworkServiceType = .networkServiceTypeDefault
+    internal var _networkServiceType: NetworkServiceType = .`default`
     open var networkServiceType: NetworkServiceType {
         return _networkServiceType
     }
@@ -348,7 +345,7 @@ open class NSMutableURLRequest : NSURLRequest {
         }
     }
     
-    open override var allHTTPHeaderFields: [String: String]? {
+    open override var allHTTPHeaderFields: [String : String]? {
         get {
             return _allHTTPHeaderFields
         }
@@ -366,7 +363,7 @@ open class NSMutableURLRequest : NSURLRequest {
     /// - Parameter value: the header field value.
     /// - Parameter field: the header field name (case-insensitive).
     open func setValue(_ value: String?, forHTTPHeaderField field: String) {
-        var f: [String: String] = allHTTPHeaderFields ?? [:]
+        var f: [String : String] = allHTTPHeaderFields ?? [:]
         if let old = existingHeaderField(field, inHeaderFields: f) {
             f.removeValue(forKey: old.0)
         }
@@ -386,7 +383,7 @@ open class NSMutableURLRequest : NSURLRequest {
     /// - Parameter value: the header field value.
     /// - Parameter field: the header field name (case-insensitive).
     open func addValue(_ value: String, forHTTPHeaderField field: String) {
-        var f: [String: String] = allHTTPHeaderFields ?? [:]
+        var f: [String : String] = allHTTPHeaderFields ?? [:]
         if let old = existingHeaderField(field, inHeaderFields: f) {
             f[old.0] = old.1 + "," + value
         } else {
@@ -475,7 +472,7 @@ open class NSMutableURLRequest : NSURLRequest {
 }
 
 /// Returns an existing key-value pair inside the header fields if it exists.
-private func existingHeaderField(_ key: String, inHeaderFields fields: [String: String]) -> (String, String)? {
+private func existingHeaderField(_ key: String, inHeaderFields fields: [String : String]) -> (String, String)? {
     for (k, v) in fields {
         if k.lowercased() == key.lowercased() {
             return (k, v)

--- a/Foundation/NSURLResponse.swift
+++ b/Foundation/NSURLResponse.swift
@@ -52,7 +52,7 @@ open class URLResponse : NSObject, NSSecureCoding, NSCopying {
         self.expectedContentLength = Int64(length)
         self.textEncodingName = name
         let c = url.lastPathComponent
-        self.suggestedFilename = (c?.isEmpty ?? true) ? "Unknown" : c
+        self.suggestedFilename = c.isEmpty ? "Unknown" : c
     }
     
     /// The URL of the receiver.

--- a/Foundation/NSUserDefaults.swift
+++ b/Foundation/NSUserDefaults.swift
@@ -221,7 +221,7 @@ open class UserDefaults: NSObject {
                 if !CFURLIsFileReferenceURL(url._cfObject) {
                     //FIXME: stringByAbbreviatingWithTildeInPath isn't implemented in SwiftFoundation
                     //TODO: use stringByAbbreviatingWithTildeInPath when it is
-                    let urlPath = url.path!
+                    let urlPath = url.path
                     
                     setObject(urlPath._nsObject, forKey: defaultName)
                     return

--- a/Foundation/NSUserDefaults.swift
+++ b/Foundation/NSUserDefaults.swift
@@ -227,12 +227,10 @@ open class UserDefaults: NSObject {
                     return
                 }
             #else
-                if let urlPath = url.path {
-                    //FIXME: stringByAbbreviatingWithTildeInPath isn't implemented in SwiftFoundation
-                    //TODO: use stringByAbbreviatingWithTildeInPath when it is
-                    setObject(urlPath._nsObject, forKey: defaultName)
-                    return
-                }
+                //FIXME: stringByAbbreviatingWithTildeInPath isn't implemented in SwiftFoundation
+                //TODO: use stringByAbbreviatingWithTildeInPath when it is
+                setObject(url.path._nsObject, forKey: defaultName)
+                return
             #endif
             let data = NSKeyedArchiver.archivedData(withRootObject: url._nsObject)
             setObject(data._nsObject, forKey: defaultName)

--- a/Foundation/NSXMLDTD.swift
+++ b/Foundation/NSXMLDTD.swift
@@ -25,7 +25,7 @@ open class XMLDTD : XMLNode {
     public convenience init(contentsOf url: URL, options: Options = []) throws {
         let urlString = url.absoluteString
 
-        guard let node = _CFXMLParseDTD(urlString!) else {
+        guard let node = _CFXMLParseDTD(urlString) else {
             //TODO: throw error
             fatalError("parsing dtd string failed")
         }

--- a/Foundation/NSXMLParser.swift
+++ b/Foundation/NSXMLParser.swift
@@ -68,7 +68,7 @@ internal func _NSXMLParserExternalEntityWithURL(_ interface: _CFXMLInterface, ur
             a = url
             if let scheme = url.scheme {
                 if scheme == "file" {
-                    a = URL(fileURLWithPath: url.path!)
+                    a = URL(fileURLWithPath: url.path)
                 }
             }
         }

--- a/Foundation/String.swift
+++ b/Foundation/String.swift
@@ -1295,7 +1295,7 @@ extension String {
   /// all percent encoded sequences with the matching UTF-8
   /// characters.
   public var removingPercentEncoding: String? {
-    return _ns.stringByRemovingPercentEncoding
+    return _ns.removingPercentEncoding
   }
 
   // - (NSString *)

--- a/Foundation/URL.swift
+++ b/Foundation/URL.swift
@@ -15,7 +15,7 @@
  As a convenience, volume resource values can be requested from any file system URL. The value returned will reflect the property value for the volume on which the resource is located.
 */
 public struct URLResourceValues {
-    fileprivate var _values: [URLResourceKey: AnyObject]
+    fileprivate var _values: [URLResourceKey: Any]
     fileprivate var _keys: Set<URLResourceKey>
     
     public init() {
@@ -23,7 +23,7 @@ public struct URLResourceValues {
         _keys = []
     }
     
-    fileprivate init(keys: Set<URLResourceKey>, values: [URLResourceKey: AnyObject]) {
+    fileprivate init(keys: Set<URLResourceKey>, values: [URLResourceKey: Any]) {
         _values = values
         _keys = keys
     }
@@ -42,7 +42,7 @@ public struct URLResourceValues {
         return (_values[key] as? NSNumber)?.intValue
     }
     
-    private mutating func _set(_ key : URLResourceKey, newValue : AnyObject?) {
+    private mutating func _set(_ key : URLResourceKey, newValue : Any?) {
         _keys.insert(key)
         _values[key] = newValue
     }
@@ -82,7 +82,7 @@ public struct URLResourceValues {
     /// A loosely-typed dictionary containing all keys and values.
     ///
     /// If you have set temporary keys or non-standard keys, you can find them in here.
-    public var allValues : [URLResourceKey : AnyObject] {
+    public var allValues : [URLResourceKey : Any] {
         return _values
     }
     
@@ -579,7 +579,6 @@ public struct URL : ReferenceConvertible, CustomStringConvertible, Equatable {
     }
     
     // MARK: - Resource Values
-#if false // disabled for now...
     /// Sets the resource value identified by a given resource key.
     ///
     /// This method writes the new resource values out to the backing store. Attempts to set a read-only resource property or to set a resource property not supported by the resource are ignored and are not considered errors. This method is currently applicable only to URLs for file system resources.
@@ -622,7 +621,6 @@ public struct URL : ReferenceConvertible, CustomStringConvertible, Equatable {
     public mutating func removeCachedResourceValue(forKey key: URLResourceKey) {
         _url.removeCachedResourceValue(forKey: key)
     }
-#endif
     
     internal func _resolveSymlinksInPath(excludeSystemDirs: Bool) -> URL? {
         return _url._resolveSymlinksInPath(excludeSystemDirs: excludeSystemDirs)

--- a/Foundation/URL.swift
+++ b/Foundation/URL.swift
@@ -1,3 +1,5 @@
+//===----------------------------------------------------------------------===//
+//
 // This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
@@ -6,6 +8,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
+//===----------------------------------------------------------------------===//
 
 /**
  URLs to file system resources support the properties defined below. Note that not all property values will exist for all file system URLs. For example, if a file is located on a volume that does not support creation dates, it is valid to request the creation date property, but the returned value will be nil, and no error will be generated.
@@ -13,7 +16,7 @@
  Only the fields requested by the keys you pass into the `URL` function to receive this value will be populated. The others will return `nil` regardless of the underlying property on the file system.
  
  As a convenience, volume resource values can be requested from any file system URL. The value returned will reflect the property value for the volume on which the resource is located.
-*/
+ */
 public struct URLResourceValues {
     fileprivate var _values: [URLResourceKey: Any]
     fileprivate var _keys: Set<URLResourceKey>
@@ -48,19 +51,19 @@ public struct URLResourceValues {
     }
     private mutating func _set(_ key : URLResourceKey, newValue : String?) {
         _keys.insert(key)
-        _values[key] = newValue?._nsObject
+        _values[key] = newValue
     }
     private mutating func _set(_ key : URLResourceKey, newValue : [String]?) {
         _keys.insert(key)
-        _values[key] = newValue?._nsObject
+        _values[key] = newValue
     }
     private mutating func _set(_ key : URLResourceKey, newValue : Date?) {
         _keys.insert(key)
-        _values[key] = newValue?._nsObject
+        _values[key] = newValue
     }
     private mutating func _set(_ key : URLResourceKey, newValue : URL?) {
         _keys.insert(key)
-        _values[key] = newValue?._nsObject
+        _values[key] = newValue
     }
     private mutating func _set(_ key : URLResourceKey, newValue : Bool?) {
         _keys.insert(key)
@@ -118,10 +121,8 @@ public struct URLResourceValues {
     /// True if resource is an application.
     public var isApplication: Bool? { return _get(.isApplicationKey) }
     
-#if os(OSX)
     /// True if the resource is scriptable. Only applies to applications.
     public var applicationIsScriptable: Bool? { return _get(.applicationIsScriptableKey) }
-#endif
     
     /// True for system-immutable resources.
     public var isSystemImmutable: Bool? { return _get(.isSystemImmutableKey) }
@@ -188,12 +189,11 @@ public struct URLResourceValues {
         set { _set(.labelNumberKey, newValue: newValue) }
     }
     
-    
     /// The user-visible label text.
     public var localizedLabel: String? {
         get { return _get(.localizedLabelKey) }
     }
-        
+    
     /// An identifier which can be used to compare two file system objects for equality using `isEqual`.
     ///
     /// Two object identifiers are equal if they have the same file system path or if the paths are linked to same inode on the same file system. This identifier is not persistent across system restarts.
@@ -216,19 +216,180 @@ public struct URLResourceValues {
     /// True if this process (as determined by EUID) can execute a file resource or search a directory resource.
     public var isExecutable: Bool? { return _get(.isExecutableKey) }
 
+    
+    /// True if resource should be excluded from backups, false otherwise.
+    ///
+    /// This property is only useful for excluding cache and other application support files which are not needed in a backup. Some operations commonly made to user documents will cause this property to be reset to false and so this property should not be used on user documents.
+    public var isExcludedFromBackup: Bool? {
+        get { return _get(.isExcludedFromBackupKey) }
+        set { _set(.isExcludedFromBackupKey, newValue: newValue) }
+    }
+    
+    /// The array of Tag names.
+    public var tagNames: [String]? { return _get(.tagNamesKey) }
+
     /// The URL's path as a file system path.
     public var path: String? { return _get(.pathKey) }
-
+    
+    /// The URL's path as a canonical absolute file system path.
+    public var canonicalPath: String? { return _get(.canonicalPathKey) }
+    
+    /// True if this URL is a file system trigger directory. Traversing or opening a file system trigger will cause an attempt to mount a file system on the trigger directory.
+    public var isMountTrigger: Bool? { return _get(.isMountTriggerKey) }
+    
+    /// An opaque generation identifier which can be compared using `==` to determine if the data in a document has been modified.
+    ///
+    /// For URLs which refer to the same file inode, the generation identifier will change when the data in the file's data fork is changed (changes to extended attributes or other file system metadata do not change the generation identifier). For URLs which refer to the same directory inode, the generation identifier will change when direct children of that directory are added, removed or renamed (changes to the data of the direct children of that directory will not change the generation identifier). The generation identifier is persistent across system restarts. The generation identifier is tied to a specific document on a specific volume and is not transferred when the document is copied to another volume. This property is not supported by all volumes.
+    public var generationIdentifier: (NSCopying & NSCoding & NSSecureCoding & NSObjectProtocol)? { return _get(.generationIdentifierKey) }
+    
     /// The document identifier -- a value assigned by the kernel to a document (which can be either a file or directory) and is used to identify the document regardless of where it gets moved on a volume.
     ///
-    /// The document identifier survives "safe save” operations; i.e it is sticky to the path it was assigned to (`replaceItem(at:,withItemAt:,backupItemName:,options:,resultingItem:) throws` is the preferred safe-save API). The document identifier is persistent across system restarts. The document identifier is not transferred when the file is copied. Document identifiers are only unique within a single volume. This property is not supported by all volumes.
+    /// The document identifier survives "safe save" operations; i.e it is sticky to the path it was assigned to (`replaceItem(at:,withItemAt:,backupItemName:,options:,resultingItem:) throws` is the preferred safe-save API). The document identifier is persistent across system restarts. The document identifier is not transferred when the file is copied. Document identifiers are only unique within a single volume. This property is not supported by all volumes.
     public var documentIdentifier: Int? { return _get(.documentIdentifierKey) }
     
     /// The date the resource was created, or renamed into or within its parent directory. Note that inconsistent behavior may be observed when this attribute is requested on hard-linked items. This property is not supported by all volumes.
     public var addedToDirectoryDate: Date? { return _get(.addedToDirectoryDateKey) }
     
+    /// The quarantine properties as defined in LSQuarantine.h. To remove quarantine information from a file, pass `nil` as the value when setting this property.
+    public var quarantineProperties: [String : Any]? {
+        get { return _get(.quarantinePropertiesKey) }
+        set { _set(.quarantinePropertiesKey, newValue: newValue) }
+    }
+    
     /// Returns the file system object type.
     public var fileResourceType: URLFileResourceType? { return _get(.fileResourceTypeKey) }
+    
+    /// The user-visible volume format.
+    public var volumeLocalizedFormatDescription : String? { return _get(.volumeLocalizedFormatDescriptionKey) }
+    
+    /// Total volume capacity in bytes.
+    public var volumeTotalCapacity : Int? { return _get(.volumeTotalCapacityKey) }
+    
+    /// Total free space in bytes.
+    public var volumeAvailableCapacity : Int? { return _get(.volumeAvailableCapacityKey) }
+    
+    /// Total number of resources on the volume.
+    public var volumeResourceCount : Int? { return _get(.volumeResourceCountKey) }
+    
+    /// true if the volume format supports persistent object identifiers and can look up file system objects by their IDs.
+    public var volumeSupportsPersistentIDs : Bool? { return _get(.volumeSupportsPersistentIDsKey) }
+    
+    /// true if the volume format supports symbolic links.
+    public var volumeSupportsSymbolicLinks : Bool? { return _get(.volumeSupportsSymbolicLinksKey) }
+    
+    /// true if the volume format supports hard links.
+    public var volumeSupportsHardLinks : Bool? { return _get(.volumeSupportsHardLinksKey) }
+    
+    /// true if the volume format supports a journal used to speed recovery in case of unplanned restart (such as a power outage or crash). This does not necessarily mean the volume is actively using a journal.
+    public var volumeSupportsJournaling : Bool? { return _get(.volumeSupportsJournalingKey) }
+    
+    /// true if the volume is currently using a journal for speedy recovery after an unplanned restart.
+    public var volumeIsJournaling : Bool? { return _get(.volumeIsJournalingKey) }
+    
+    /// true if the volume format supports sparse files, that is, files which can have 'holes' that have never been written to, and thus do not consume space on disk. A sparse file may have an allocated size on disk that is less than its logical length.
+    public var volumeSupportsSparseFiles : Bool? { return _get(.volumeSupportsSparseFilesKey) }
+    
+    /// For security reasons, parts of a file (runs) that have never been written to must appear to contain zeroes. true if the volume keeps track of allocated but unwritten runs of a file so that it can substitute zeroes without actually writing zeroes to the media.
+    public var volumeSupportsZeroRuns : Bool? { return _get(.volumeSupportsZeroRunsKey) }
+    
+    /// true if the volume format treats upper and lower case characters in file and directory names as different. Otherwise an upper case character is equivalent to a lower case character, and you can't have two names that differ solely in the case of the characters.
+    public var volumeSupportsCaseSensitiveNames : Bool? { return _get(.volumeSupportsCaseSensitiveNamesKey) }
+    
+    /// true if the volume format preserves the case of file and directory names.  Otherwise the volume may change the case of some characters (typically making them all upper or all lower case).
+    public var volumeSupportsCasePreservedNames : Bool? { return _get(.volumeSupportsCasePreservedNamesKey) }
+    
+    /// true if the volume supports reliable storage of times for the root directory.
+    public var volumeSupportsRootDirectoryDates : Bool? { return _get(.volumeSupportsRootDirectoryDatesKey) }
+    
+    /// true if the volume supports returning volume size values (`volumeTotalCapacity` and `volumeAvailableCapacity`).
+    public var volumeSupportsVolumeSizes : Bool? { return _get(.volumeSupportsVolumeSizesKey) }
+    
+    /// true if the volume can be renamed.
+    public var volumeSupportsRenaming : Bool? { return _get(.volumeSupportsRenamingKey) }
+    
+    /// true if the volume implements whole-file flock(2) style advisory locks, and the O_EXLOCK and O_SHLOCK flags of the open(2) call.
+    public var volumeSupportsAdvisoryFileLocking : Bool? { return _get(.volumeSupportsAdvisoryFileLockingKey) }
+    
+    /// true if the volume implements extended security (ACLs).
+    public var volumeSupportsExtendedSecurity : Bool? { return _get(.volumeSupportsExtendedSecurityKey) }
+    
+    /// true if the volume should be visible via the GUI (i.e., appear on the Desktop as a separate volume).
+    public var volumeIsBrowsable : Bool? { return _get(.volumeIsBrowsableKey) }
+    
+    /// The largest file size (in bytes) supported by this file system, or nil if this cannot be determined.
+    public var volumeMaximumFileSize : Int? { return _get(.volumeMaximumFileSizeKey) }
+    
+    /// true if the volume's media is ejectable from the drive mechanism under software control.
+    public var volumeIsEjectable : Bool? { return _get(.volumeIsEjectableKey) }
+    
+    /// true if the volume's media is removable from the drive mechanism.
+    public var volumeIsRemovable : Bool? { return _get(.volumeIsRemovableKey) }
+    
+    /// true if the volume's device is connected to an internal bus, false if connected to an external bus, or nil if not available.
+    public var volumeIsInternal : Bool? { return _get(.volumeIsInternalKey) }
+    
+    /// true if the volume is automounted. Note: do not mistake this with the functionality provided by kCFURLVolumeSupportsBrowsingKey.
+    public var volumeIsAutomounted : Bool? { return _get(.volumeIsAutomountedKey) }
+
+    /// true if the volume is stored on a local device.
+    public var volumeIsLocal : Bool? { return _get(.volumeIsLocalKey) }
+
+    /// true if the volume is read-only.
+    public var volumeIsReadOnly : Bool? { return _get(.volumeIsReadOnlyKey) }
+
+    /// The volume's creation date, or nil if this cannot be determined.
+    public var volumeCreationDate : Date? { return _get(.volumeCreationDateKey) }
+
+    /// The `URL` needed to remount a network volume, or nil if not available.
+    public var volumeURLForRemounting : URL? { return _get(.volumeURLForRemountingKey) }
+
+    /// The volume's persistent `UUID` as a string, or nil if a persistent `UUID` is not available for the volume.
+    public var volumeUUIDString : String? { return _get(.volumeUUIDStringKey) }
+
+    /// The name of the volume
+    public var volumeName : String? {
+        get { return _get(.volumeNameKey) }
+        set { _set(.volumeNameKey, newValue: newValue) }
+    }
+    
+    /// The user-presentable name of the volume
+    public var volumeLocalizedName : String? { return _get(.volumeLocalizedNameKey) }
+    
+    /// true if the volume is encrypted.
+    public var volumeIsEncrypted : Bool? { return _get(.volumeIsEncryptedKey) }
+
+    /// true if the volume is the root filesystem.
+    public var volumeIsRootFileSystem : Bool? { return _get(.volumeIsRootFileSystemKey) }
+
+    /// true if the volume supports transparent decompression of compressed files using decmpfs.
+    public var volumeSupportsCompression : Bool? { return _get(.volumeSupportsCompressionKey) }
+    
+    /// true if this item is synced to the cloud, false if it is only a local file.
+    public var isUbiquitousItem : Bool? { return _get(.isUbiquitousItemKey) }
+
+    /// true if this item has conflicts outstanding.
+    public var ubiquitousItemHasUnresolvedConflicts : Bool? { return _get(.ubiquitousItemHasUnresolvedConflictsKey) }
+
+    /// true if data is being downloaded for this item.
+    public var ubiquitousItemIsDownloading : Bool? { return _get(.ubiquitousItemIsDownloadingKey) }
+
+    /// true if there is data present in the cloud for this item.
+    public var ubiquitousItemIsUploaded : Bool? { return _get(.ubiquitousItemIsUploadedKey) }
+
+    /// true if data is being uploaded for this item.
+    public var ubiquitousItemIsUploading : Bool? { return _get(.ubiquitousItemIsUploadingKey) }
+    
+    /// returns the error when downloading the item from iCloud failed, see the NSUbiquitousFile section in FoundationErrors.h
+    public var ubiquitousItemDownloadingError : NSError? { return _get(.ubiquitousItemDownloadingErrorKey) }
+
+    /// returns the error when uploading the item to iCloud failed, see the NSUbiquitousFile section in FoundationErrors.h
+    public var ubiquitousItemUploadingError : NSError? { return _get(.ubiquitousItemUploadingErrorKey) }
+    
+    /// returns whether a download of this item has already been requested with an API like `startDownloadingUbiquitousItem(at:) throws`.
+    public var ubiquitousItemDownloadRequested : Bool? { return _get(.ubiquitousItemDownloadRequestedKey) }
+    
+    /// returns the name of this item's container as displayed to users.
+    public var ubiquitousItemContainerDisplayName : String? { return _get(.ubiquitousItemContainerDisplayNameKey) }
     
     /// Total file size in bytes
     ///
@@ -257,31 +418,41 @@ public struct URLResourceValues {
 
 }
 
-public struct URL : ReferenceConvertible, CustomStringConvertible, Equatable {
+/**
+ A URL is a type that can potentially contain the location of a resource on a remote server, the path of a local file on disk, or even an arbitrary piece of encoded data.
+ 
+ You can construct URLs and access their parts. For URLs that represent local files, you can also manipulate properties of those files directly, such as changing the file's last modification date. Finally, you can pass URLs to other APIs to retrieve the contents of those URLs. For example, you can use the URLSession classes to access the contents of remote resources, as described in URL Session Programming Guide.
+ 
+ URLs are the preferred way to refer to local files. Most objects that read data from or write data to a file have methods that accept a URL instead of a pathname as the file reference. For example, you can get the contents of a local file URL as `String` by calling `func init(contentsOf:encoding) throws`, or as a `Data` by calling `func init(contentsOf:options) throws`.
+*/
+public struct URL : ReferenceConvertible, Equatable {
     public typealias ReferenceType = NSURL
-    private var _url : NSURL
+    fileprivate var _url : NSURL
 
     /// Initialize with string.
     ///
-    /// Returns `nil` if a `URL` cannot be formed with the string.
+    /// Returns `nil` if a `URL` cannot be formed with the string (for example, if the string contains characters that are illegal in a URL, or is an empty string).
     public init?(string: String) {
+        guard !string.isEmpty else { return nil }
+        
         if let inner = NSURL(string: string) {
-            _url = inner
+            _url = URL._converted(from: inner)
         } else {
             return nil
         }
     }
     
+    /// Initialize with string, relative to another URL.
+    ///
+    /// Returns `nil` if a `URL` cannot be formed with the string (for example, if the string contains characters that are illegal in a URL, or is an empty string).
     public init?(string: String, relativeTo url: URL?) {
+        guard !string.isEmpty else { return nil }
+        
         if let inner = NSURL(string: string, relativeTo: url) {
-            _url = inner
+            _url = URL._converted(from: inner)
         } else {
             return nil
         }
-    }
-    
-    public init(fileURLWithFileSystemRepresentation path: UnsafePointer<Int8>, isDirectory isDir: Bool, relativeTo baseURL: URL?) {
-        _url = NSURL(fileURLWithFileSystemRepresentation: path, isDirectory:  isDir, relativeTo: baseURL)
     }
     
     /// Initializes a newly created file URL referencing the local file or directory at path, relative to a base URL.
@@ -289,13 +460,14 @@ public struct URL : ReferenceConvertible, CustomStringConvertible, Equatable {
     /// If an empty string is used for the path, then the path is assumed to be ".".
     /// - note: This function avoids an extra file system access to check if the file URL is a directory. You should use it if you know the answer already.
     public init(fileURLWithPath path: String, isDirectory: Bool, relativeTo base: URL?) {
-        _url = NSURL(fileURLWithPath: path.isEmpty ? "." : path, isDirectory: isDirectory, relativeTo: base)
+        _url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path, isDirectory: isDirectory, relativeTo: base))
     }
     
     /// Initializes a newly created file URL referencing the local file or directory at path, relative to a base URL.
     ///
+    /// If an empty string is used for the path, then the path is assumed to be ".".
     public init(fileURLWithPath path: String, relativeTo base: URL?) {
-        _url = NSURL(fileURLWithPath: path.isEmpty ? "." : path, relativeTo: base)
+        _url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path, relativeTo: base))
     }
     
     /// Initializes a newly created file URL referencing the local file or directory at path.
@@ -303,282 +475,417 @@ public struct URL : ReferenceConvertible, CustomStringConvertible, Equatable {
     /// If an empty string is used for the path, then the path is assumed to be ".".
     /// - note: This function avoids an extra file system access to check if the file URL is a directory. You should use it if you know the answer already.
     public init(fileURLWithPath path: String, isDirectory: Bool) {
-        _url = NSURL(fileURLWithPath: path.isEmpty ? "." : path, isDirectory: isDirectory)
+        _url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path, isDirectory: isDirectory))
     }
     
     /// Initializes a newly created file URL referencing the local file or directory at path.
     ///
     /// If an empty string is used for the path, then the path is assumed to be ".".
     public init(fileURLWithPath path: String) {
-        _url = NSURL(fileURLWithPath: path.isEmpty ? "." : path)
+        _url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path))
     }
     
-    /// Initializes a newly created URL using the contents of the given data, relative to a base URL. If the data representation is not a legal URL string as ASCII bytes, the URL object may not behave as expected.
-    public init(dataRepresentation: Data, relativeTo url: URL?, isAbsolute: Bool = false) {
+    /// Initializes a newly created URL using the contents of the given data, relative to a base URL.
+    ///
+    /// If the data representation is not a legal URL string as ASCII bytes, the URL object may not behave as expected. If the URL cannot be formed then this will return nil.
+    public init?(dataRepresentation: Data, relativeTo url: URL?, isAbsolute: Bool = false) {
+        guard dataRepresentation.count > 0 else { return nil }
+        
         if isAbsolute {
-            _url = NSURL(absoluteURLWithDataRepresentation: dataRepresentation, relativeTo: url)
+            _url = URL._converted(from: NSURL(absoluteURLWithDataRepresentation: dataRepresentation, relativeTo: url))
         } else {
-            _url = NSURL(dataRepresentation: dataRepresentation, relativeTo: url)
+            _url = URL._converted(from: NSURL(dataRepresentation: dataRepresentation, relativeTo: url))
         }
     }
 
     /// Initializes a newly created URL referencing the local file or directory at the file system representation of the path. File system representation is a null-terminated C string with canonical UTF-8 encoding.
-    public init(fileURLWithFileSystemRepresentation path: UnsafePointer<Int8>, isDirectory: Bool, relativeToURL baseURL: URL?) {
-        _url = NSURL(fileURLWithFileSystemRepresentation: path, isDirectory: isDirectory, relativeTo: baseURL)
+    public init(fileURLWithFileSystemRepresentation path: UnsafePointer<Int8>, isDirectory: Bool, relativeTo baseURL: URL?) {
+        _url = URL._converted(from: NSURL(fileURLWithFileSystemRepresentation: path, isDirectory: isDirectory, relativeTo: baseURL))
     }
     
-    // MARK: -
-    
-    public var description: String {
-        return _url.description
-    }
-
-    public var debugDescription: String {
-        return _url.debugDescription
-    }
-
-    public var hashValue : Int {
+    public var hashValue: Int {
         return _url.hash
     }
     
     // MARK: -
     
-    /// Returns the data representation of the URL's relativeString. If the URL was initialized with -initWithData:relativeToURL:, the data representation returned are the same bytes as those used at initialization; otherwise, the data representation returned are the bytes of the relativeString encoded with NSUTF8StringEncoding.
-    public var dataRepresentation: Data { return _url.dataRepresentation }
-    
-    public var absoluteString: String? { return _url.absoluteString }
-    
-    /// The relative portion of a URL.  If baseURL is nil, or if the receiver is itself absolute, this is the same as absoluteString
-    public var relativeString: String { return _url.relativeString }
-    public var baseURL: URL? { return _url.baseURL }
-    
-    /// If the receiver is itself absolute, this will return self.
-    public var absoluteURL: URL? {  return _url.absoluteURL }
-    
-    /// Any URL is composed of these two basic pieces.  The full URL would be the concatenation of `myURL.scheme, ':', myURL.resourceSpecifier`.
-    public var scheme: String? { return _url.scheme }
-    
-    /// Any URL is composed of these two basic pieces.  The full URL would be the concatenation of `myURL.scheme, ':', myURL.resourceSpecifier`.
-    public var resourceSpecifier: String? { return _url.resourceSpecifier }
-    
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    /// Returns the data representation of the URL's relativeString.
     ///
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var host: String? { return _url.host }
+    /// If the URL was initialized with `init?(dataRepresentation:relativeTo:isAbsolute:)`, the data representation returned are the same bytes as those used at initialization; otherwise, the data representation returned are the bytes of the `relativeString` encoded with UTF8 string encoding.
+    public var dataRepresentation: Data {
+        return _url.dataRepresentation
+    }
     
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    // MARK: -
+    
+    // Future implementation note:
+    // NSURL (really CFURL, which provides its implementation) has quite a few quirks in its processing of some more esoteric (and some not so esoteric) strings. We would like to move much of this over to the more modern NSURLComponents, but binary compat concerns have made this difficult.
+    // Hopefully soon, we can replace some of the below delegation to NSURL with delegation to NSURLComponents instead. It cannot be done piecemeal, because otherwise we will get inconsistent results from the API.
+    
+    /// Returns the absolute string for the URL.
+    public var absoluteString: String {
+        return _url.absoluteString
+    }
+    
+    /// The relative portion of a URL.
     ///
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var port: Int? { return _url.port?.intValue }
+    /// If `baseURL` is nil, or if the receiver is itself absolute, this is the same as `absoluteString`.
+    public var relativeString: String {
+        return _url.relativeString
+    }
     
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    /// Returns the base URL.
     ///
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var user: String? { return _url.user }
+    /// If the URL is itself absolute, then this value is nil.
+    public var baseURL: URL? {
+        return _url.baseURL
+    }
     
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    /// Returns the absolute URL.
     ///
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var password: String? { return _url.password }
+    /// If the URL is itself absolute, this will return self.
+    public var absoluteURL: URL {
+        if let url = _url.absoluteURL {
+            return url
+        } else {
+            // This should never fail for non-file reference URLs
+            return self
+        }
+    }
     
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    // MARK: -
+    
+    /// Returns the scheme of the URL.
+    public var scheme: String? {
+        return _url.scheme
+    }
+    
+    /// Returns true if the scheme is `file:`.
+    public var isFileURL: Bool {
+        return _url.isFileURL
+    }
+
+    // This thing was never really part of the URL specs
+    @available(*, unavailable, message: "Use `path`, `query`, and `fragment` instead")
+    public var resourceSpecifier: String {
+        fatalError()
+    }
+    
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the host component of the URL; otherwise it returns nil.
     ///
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var path: String? { return _url.path }
+    /// - note: This function will resolve against the base `URL`.
+    public var host: String? {
+        return _url.host
+    }
     
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the port component of the URL; otherwise it returns nil.
     ///
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var fragment: String? { return _url.fragment }
+    /// - note: This function will resolve against the base `URL`.
+    public var port: Int? {
+        return _url.port?.intValue
+    }
     
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the user component of the URL; otherwise it returns nil.
     ///
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var parameterString: String? { return _url.parameterString }
+    /// - note: This function will resolve against the base `URL`.
+    public var user: String? {
+        return _url.user
+    }
     
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the password component of the URL; otherwise it returns nil.
     ///
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var query: String? { return _url.query }
+    /// - note: This function will resolve against the base `URL`.
+    public var password: String? {
+        return _url.password
+    }
     
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the path component of the URL; otherwise it returns an empty string.
+    ///
+    /// If the URL contains a parameter string, it is appended to the path with a `;`.
+    /// - note: This function will resolve against the base `URL`.
+    /// - returns: The path, or an empty string if the URL has an empty path.
+    public var path: String {
+        if let parameterString = _url.parameterString {
+            if let path = _url.path {
+                return path + ";" + parameterString
+            } else {
+                return ";" + parameterString
+            }
+        } else if let path = _url.path {
+            return path
+        } else {
+            return ""
+        }
+    }
+    
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the relative path of the URL; otherwise it returns nil.
     ///
     /// This is the same as path if baseURL is nil.
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var relativePath: String? { return _url.relativePath }
+    /// If the URL contains a parameter string, it is appended to the path with a `;`.
+    ///
+    /// - note: This function will resolve against the base `URL`.
+    /// - returns: The relative path, or an empty string if the URL has an empty path.
+    public var relativePath: String {
+        if let parameterString = _url.parameterString {
+            if let path = _url.relativePath {
+                return path + ";" + parameterString
+            } else {
+                return ";" + parameterString
+            }
+        } else if let path = _url.relativePath {
+            return path
+        } else {
+            return ""
+        }
+    }
+
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the fragment component of the URL; otherwise it returns nil.
+    ///
+    /// - note: This function will resolve against the base `URL`.
+    public var fragment: String? {
+        return _url.fragment
+    }
     
-    public var hasDirectoryPath: Bool { return _url.hasDirectoryPath }
+    @available(*, unavailable, message: "use the 'path' property")
+    public var parameterString: String? {
+        fatalError()
+    }
+    
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the query of the URL; otherwise it returns nil.
+    ///
+    /// - note: This function will resolve against the base `URL`.
+    public var query: String? {
+        return _url.query
+    }
+    
+    /// Returns true if the URL path represents a directory.
+    public var hasDirectoryPath: Bool {
+        return _url.hasDirectoryPath
+    }
     
     /// Passes the URL's path in file system representation to `block`.
     ///
     /// File system representation is a null-terminated C string with canonical UTF-8 encoding.
     /// - note: The pointer is not valid outside the context of the block.
-    public func withUnsafeFileSystemRepresentation(_ block: (UnsafePointer<Int8>) throws -> Void) rethrows {
-        try block(_url.fileSystemRepresentation)
+    public func withUnsafeFileSystemRepresentation<ResultType>(_ block: (UnsafePointer<Int8>?) throws -> ResultType) rethrows -> ResultType {
+        return try block(_url.fileSystemRepresentation)
     }
     
-    /// Whether the scheme is file:; if `myURL.isFileURL` is `true`, then `myURL.path` is suitable for input into `FileManager` or `PathUtilities`.
-    public var isFileURL: Bool {
-        return _url.isFileURL
+    // MARK: -
+    // MARK: Path manipulation
+    
+    /// Returns the path components of the URL, or an empty array if the path is an empty string.
+    public var pathComponents: [String] {
+        // In accordance with our above change to never return a nil path, here we return an empty array.
+        return _url.pathComponents ?? []
     }
     
-    public func standardized() throws -> URL {
-        if let result = _url.standardized.map({ $0 }) {
-            return result;
-        } else {
-            // TODO: We need to call into CFURL to figure out the error
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileReadUnknownError.rawValue, userInfo: [:])
-        }
+    /// Returns the last path component of the URL, or an empty string if the path is an empty string.
+    public var lastPathComponent: String {
+        return _url.lastPathComponent ?? ""
     }
-
-    /// Returns a file path URL that refers to the same resource as a specified URL.
+    
+    /// Returns the path extension of the URL, or an empty string if the path is an empty string.
+    public var pathExtension: String {
+        return _url.pathExtension ?? ""
+    }
+    
+    /// Returns a URL constructed by appending the given path component to self.
     ///
-    /// File path URLs use a file system style path. A file reference URL's resource must exist and be reachable to be converted to a file path URL.
-    public func filePathURL() throws -> URL {
-        if let result = _url.filePathURL.map({ $0 }) {
+    /// - parameter pathComponent: The path component to add.
+    /// - parameter isDirectory: If `true`, then a trailing `/` is added to the resulting path.
+    public func appendingPathComponent(_ pathComponent: String, isDirectory: Bool) -> URL {
+        if let result = _url.appendingPathComponent(pathComponent, isDirectory: isDirectory) {
             return result
         } else {
-            // TODO: We need to call into CFURL to figure out the error
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileReadUnknownError.rawValue, userInfo: [:])
+            // Now we need to do something more expensive
+            if var c = URLComponents(url: self, resolvingAgainstBaseURL: true),
+               let path = c.path {
+                c.path = path._stringByAppendingPathComponent(pathComponent)
+                
+                if let result = c.url {
+                    return result
+                } else {
+                    // Couldn't get url from components
+                    // Ultimate fallback:
+                    return self
+                }
+            } else {
+                return self
+            }
         }
     }
     
-    public var pathComponents: [String]? { return _url.pathComponents }
-    
-    public var lastPathComponent: String? { return _url.lastPathComponent }
-    
-    public var pathExtension: String? { return _url.pathExtension }
-    
-    public func appendingPathComponent(_ pathComponent: String, isDirectory: Bool) throws -> URL {
-        // TODO: Use URLComponents to handle an empty-path case
-        /*
-         URLByAppendingPathComponent can return nil if:
-         • the URL does not have a path component. (see note 1)
-         • a mutable copy of the URLs string could not be created.
-         • a percent-encoded string of the new path component could not created using the same encoding as the URL’s string. (see note 2)
-         • a new URL object could not be created with the modified URL string.
-         
-         Note 1: If NS/CFURL parsed URLs correctly, this would not occur because URL strings always have a path component. For example, the URL <mailto:user@example.com> should be parsed as Scheme=“mailto”, and Path= “user@example.com". Instead, CFURL returns false for CFURLCanBeDecomposed(), says Scheme=“mailto”, Path=nil, and ResourceSpecifier=“user@example.com”. rdar://problem/15060399
-         
-         Note 2: CFURLCreateWithBytes() and CFURLCreateAbsoluteURLWithBytes() allow URLs to be created with an array of bytes and a CFStringEncoding. All other CFURL functions and URL methods which create URLs use kCFStringEncodingUTF8/NSUTF8StringEncoding. So, the encoding passed to CFURLCreateWithBytes/CFURLCreateAbsoluteURLWithBytes might prevent the percent-encoding of the new path component or path extension.
-         */
-        guard let result = _url.appendingPathComponent(pathComponent, isDirectory: isDirectory) else {
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileReadUnknownError.rawValue, userInfo: [:])
+    /// Returns a URL constructed by appending the given path component to self.
+    ///
+    /// - note: This function performs a file system operation to determine if the path component is a directory. If so, it will append a trailing `/`. If you know in advance that the path component is a directory or not, then use `func appendingPathComponent(_:isDirectory:)`.
+    /// - parameter pathComponent: The path component to add.
+    public func appendingPathComponent(_ pathComponent: String) -> URL {
+        if let result = _url.appendingPathComponent(pathComponent) {
+            return result
+        } else {
+            // Now we need to do something more expensive
+            if var c = URLComponents(url: self, resolvingAgainstBaseURL: true),
+               let path = c.path {
+                c.path = path._stringByAppendingPathComponent(pathComponent)
+                
+                if let result = c.url {
+                    return result
+                } else {
+                    // Couldn't get url from components
+                    // Ultimate fallback:
+                    return self
+                }
+            } else {
+                // Ultimate fallback:
+                return self
+            }
         }
-        return result
-    }
-    public mutating func appendPathComponent(_ pathComponent: String, isDirectory: Bool) throws {
-        self = try appendingPathComponent(pathComponent, isDirectory: isDirectory)
     }
     
-    public func appendingPathComponent(_ pathComponent: String) throws -> URL {
-        guard let result = _url.appendingPathComponent(pathComponent) else {
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileReadUnknownError.rawValue, userInfo: [:])
+    /// Returns a URL constructed by removing the last path component of self.
+    ///
+    /// This function may either remove a path component or append `/..`.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will return the URL unchanged.
+    public func deletingLastPathComponent() -> URL {
+        // This is a slight behavior change from NSURL, but better than returning "http://www.example.com../".
+        if path.isEmpty {
+            return self
         }
-        return result
+        
+        if let result = _url.deletingLastPathComponent.map({ URL(reference: $0 as NSURL) }) {
+            return result
+        } else {
+            return self
+        }
     }
-    public mutating func appendPathComponent(_ pathComponent: String) throws {
-        self = try appendingPathComponent(pathComponent)
+    
+    /// Returns a URL constructed by appending the given path extension to self.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will return the URL unchanged.
+    ///
+    /// Certain special characters (for example, Unicode Right-To-Left marks) cannot be used as path extensions. If any of those are contained in `pathExtension`, the function will return the URL unchanged.
+    /// - parameter pathExtension: The extension to append.
+    public func appendingPathExtension(_ pathExtension: String) -> URL {
+        if path.isEmpty {
+            return self
+        }
+        
+        if let result = _url.appendingPathExtension(pathExtension) {
+            return result
+        } else {
+            return self
+        }
     }
+    
+    /// Returns a URL constructed by removing any path extension.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will return the URL unchanged.
+    public func deletingPathExtension() -> URL {
+        if path.isEmpty {
+            return self
+        }
 
-    public func deletingLastPathComponent() throws -> URL {
-        /*
-         URLByDeletingLastPathComponent can return nil if:
-         • the URL is a file reference URL which cannot be resolved back to a path.
-         • the URL does not have a path component. (see note 1)
-         • a mutable copy of the URLs string could not be created.
-         • a new URL object could not be created with the modified URL string.
-         */
-        if let result = _url.deletingLastPathComponent.map({ $0 }) {
+        if let result = _url.deletingPathExtension.map({ URL(reference: $0 as NSURL) }) {
             return result
         } else {
-            // TODO: We need to call into CFURL to figure out the error
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileReadUnknownError.rawValue, userInfo: [:])
-        }
-    }
-    public mutating func deleteLastPathComponent() throws {
-        let result = try deletingLastPathComponent()
-        self = result
-    }
-    
-    public func appendingPathExtension(_ pathExtension: String) throws -> URL {
-        /*
-         URLByAppendingPathExtension can return nil if:
-         • the new path extension is not a valid extension (see _CFExtensionIsValidToAppend)
-         • the URL is a file reference URL which cannot be resolved back to a path.
-         • the URL does not have a path component. (see note 1)
-         • a mutable copy of the URLs string could not be created.
-         • a percent-encoded string of the new path extension could not created using the same encoding as the URL’s string. (see note 1))
-         • a new URL object could not be created with the modified URL string.
-         */
-        guard let result = _url.appendingPathExtension(pathExtension) else {
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileReadUnknownError.rawValue, userInfo: [:])
-        }
-        return result
-    }
-    public mutating func appendPathExtension(_ pathExtension: String) throws {
-        self = try appendingPathExtension(pathExtension)
-    }
-    
-    public func deletingPathExtension() throws -> URL {
-        /*
-         URLByDeletingPathExtension can return nil if:
-         • the URL is a file reference URL which cannot be resolved back to a path.
-         • the URL does not have a path component. (see note 1)
-         • a mutable copy of the URLs string could not be created.
-         • a new URL object could not be created with the modified URL string.
-         */
-        if let result = _url.deletingPathExtension.map({ $0 }) {
-            return result
-        } else {
-            // TODO: We need to call into CFURL to figure out the error
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileReadUnknownError.rawValue, userInfo: [:])
-        }
-    }
-    public mutating func deletePathExtension() throws {
-        let result = try deletingPathExtension()
-        self = result
-    }
-    
-    public func standardizingPath() throws -> URL {
-        /*
-         URLByStandardizingPath can return nil if:
-         • the URL is a file reference URL which cannot be resolved back to a path.
-         • a new URL object could not be created with the standardized path).
-         */
-        if let result = _url.standardizingPath.map({ $0 }) {
-            return result
-        } else {
-            // TODO: We need to call into CFURL to figure out the error
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileReadUnknownError.rawValue, userInfo: [:])
-        }
-    }
-    public mutating func standardizePath() throws {
-        let result = try standardizingPath()
-        self = result
-    }
-    
-    public func resolvingSymlinksInPath() throws -> URL {
-        /*
-         URLByResolvingSymlinksInPath can return nil if:
-         • the URL is a file reference URL which cannot be resolved back to a path.
-         • NSPathUtilities’ stringByResolvingSymlinksInPath property returns nil.
-         • a new URL object could not be created with the resolved path).
-         */
-        if let result = _url.resolvingSymlinksInPath.map({ $0 }) {
-            return result
-        } else {
-            // TODO: We need to call into CFURL to figure out the error
-            throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileReadUnknownError.rawValue, userInfo: [:])
+            return self
         }
     }
 
-    public mutating func resolveSymlinksInPath() throws {
-        let result = try resolvingSymlinksInPath()
-        self = result
+    /// Appends a path component to the URL.
+    ///
+    /// - parameter pathComponent: The path component to add.
+    /// - parameter isDirectory: Use `true` if the resulting path is a directory.
+    public mutating func appendPathComponent(_ pathComponent: String, isDirectory: Bool) {
+        self = appendingPathComponent(pathComponent, isDirectory: isDirectory)
     }
     
+    /// Appends a path component to the URL.
+    ///
+    /// - note: This function performs a file system operation to determine if the path component is a directory. If so, it will append a trailing `/`. If you know in advance that the path component is a directory or not, then use `func appendingPathComponent(_:isDirectory:)`.
+    /// - parameter pathComponent: The path component to add.
+    public mutating func appendPathComponent(_ pathComponent: String) {
+        self = appendingPathComponent(pathComponent)
+    }
+    
+    /// Appends the given path extension to self.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will do nothing.
+    /// Certain special characters (for example, Unicode Right-To-Left marks) cannot be used as path extensions. If any of those are contained in `pathExtension`, the function will return the URL unchanged.
+    /// - parameter pathExtension: The extension to append.
+    public mutating func appendPathExtension(_ pathExtension: String) {
+        self = appendingPathExtension(pathExtension)
+    }
+
+    /// Returns a URL constructed by removing the last path component of self.
+    ///
+    /// This function may either remove a path component or append `/..`.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will do nothing.
+    public mutating func deleteLastPathComponent() {
+        self = deletingLastPathComponent()
+    }
+    
+
+    /// Returns a URL constructed by removing any path extension.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will do nothing.
+    public mutating func deletePathExtension() {
+        self = deletingPathExtension()
+    }
+    
+    /// Returns a `URL` with any instances of ".." or "." removed from its path.
+    public var standardized : URL {
+        // The NSURL API can only return nil in case of file reference URL, which we should not be
+        if let result = _url.standardized.map({ URL(reference: $0 as NSURL) }) {
+            return result
+        } else {
+            return self
+        }
+    }
+    
+    /// Standardizes the path of a file URL.
+    ///
+    /// If the `isFileURL` is false, this method does nothing.
+    public mutating func standardize() {
+        self = self.standardized
+    }
+    
+    /// Standardizes the path of a file URL.
+    ///
+    /// If the `isFileURL` is false, this method returns `self`.
+    public var standardizedFileURL : URL {
+        // NSURL should not return nil here unless this is a file reference URL, which should be impossible
+        if let result = _url.standardizingPath.map({ URL(reference: $0 as NSURL) }) {
+            return result
+        } else {
+            return self
+        }
+    }
+    
+    /// Resolves any symlinks in the path of a file URL.
+    ///
+    /// If the `isFileURL` is false, this method returns `self`.
+    public func resolvingSymlinksInPath() -> URL {
+        // NSURL should not return nil here unless this is a file reference URL, which should be impossible
+        if let result = _url.resolvingSymlinksInPath.map({ URL(reference: $0 as NSURL) }) {
+            return result
+        } else {
+            return self
+        }
+    }
+
+    /// Resolves any symlinks in the path of a file URL.
+    ///
+    /// If the `isFileURL` is false, this method does nothing.
+    public mutating func resolveSymlinksInPath() {
+        self = self.resolvingSymlinksInPath()
+    }
+
     // MARK: - Resource Values
+    
     /// Sets the resource value identified by a given resource key.
     ///
     /// This method writes the new resource values out to the backing store. Attempts to set a read-only resource property or to set a resource property not supported by the resource are ignored and are not considered errors. This method is currently applicable only to URLs for file system resources.
@@ -604,7 +911,7 @@ public struct URL : ReferenceConvertible, CustomStringConvertible, Equatable {
     /// Temporary resource values are for client use. Temporary resource values exist only in memory and are never written to the resource's backing store. Once set, a temporary resource value can be copied from the URL object with `func resourceValues(forKeys:)`. The values are stored in the loosely-typed `allValues` dictionary property.
     ///
     /// To remove a temporary resource value from the URL object, use `func removeCachedResourceValue(forKey:)`. Care should be taken to ensure the key that identifies a temporary resource value is unique and does not conflict with system defined keys (using reverse domain name notation in your temporary resource value keys is recommended). This method is currently applicable only to URLs for file system resources.
-    public mutating func setTemporaryResourceValue(_ value : AnyObject, forKey key: URLResourceKey) {
+    public mutating func setTemporaryResourceValue(_ value : Any, forKey key: URLResourceKey) {
         _url.setTemporaryResourceValue(value, forKey: key)
     }
     
@@ -622,35 +929,103 @@ public struct URL : ReferenceConvertible, CustomStringConvertible, Equatable {
         _url.removeCachedResourceValue(forKey: key)
     }
     
-    internal func _resolveSymlinksInPath(excludeSystemDirs: Bool) -> URL? {
-        return _url._resolveSymlinksInPath(excludeSystemDirs: excludeSystemDirs)
+    @available(*, unavailable, message: "Use struct URLResourceValues and URL.setResourceValues(_:) instead")
+    public func setResourceValue(_ value: AnyObject?, forKey key: URLResourceKey) throws {
+        fatalError()
+    }
+    
+    @available(*, unavailable, message: "Use struct URLResourceValues and URL.setResourceValues(_:) instead")
+    public func setResourceValues(_ keyedValues: [URLResourceKey : AnyObject]) throws {
+        fatalError()
+    }
+    
+    @available(*, unavailable, message: "Use struct URLResourceValues and URL.resourceValues(forKeys:) instead")
+    public func resourceValues(forKeys keys: [URLResourceKey]) throws -> [URLResourceKey : AnyObject] {
+        fatalError()
+    }
+    
+    @available(*, unavailable, message: "Use struct URLResourceValues and URL.setResourceValues(_:) instead")
+    public func getResourceValue(_ value: AutoreleasingUnsafeMutablePointer<AnyObject?>, forKey key: URLResourceKey) throws {
+        fatalError()
     }
     
     // MARK: - Bridging Support
     
+    /// We must not store an NSURL without running it through this function. This makes sure that we do not hold a file reference URL, which changes the nullability of many NSURL functions.
+    internal static func _converted(from url: NSURL) -> NSURL {
+        // On Linux, there's nothing to convert because file reference URLs are not supported.
+        return url
+    }
+    
     internal init(reference: NSURL) {
-        _url = reference.copy() as! NSURL
+        _url = URL._converted(from: reference).copy() as! NSURL
     }
     
     internal var reference : NSURL {
         return _url
     }
-}
 
-public func ==(lhs: URL, rhs: URL) -> Bool {
-    return lhs.reference.isEqual(rhs.reference)
-}
-
-extension URL : Bridgeable {
-    public typealias BridgeType = NSURL
-    public func bridge() -> BridgeType {
-        return _nsObject
+    public static func ==(lhs: URL, rhs: URL) -> Bool {
+        return lhs.reference.isEqual(rhs.reference)
     }
 }
 
-extension NSURL : Bridgeable {
-    public typealias BridgeType = URL
-    public func bridge() -> BridgeType {
-        return _swiftObject
+extension URL : _ObjectiveCBridgeable {
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSURL {
+        return _url
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ source: NSURL, result: inout URL?) {
+        if !_conditionallyBridgeFromObjectiveC(source, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ source: NSURL, result: inout URL?) -> Bool {
+        result = URL(reference: source)
+        return true
+    }
+
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSURL?) -> URL {
+        var result: URL? = nil
+        _forceBridgeFromObjectiveC(source!, result: &result)
+        return result!
     }
 }
+
+extension URL : CustomStringConvertible, CustomDebugStringConvertible {
+    public var description: String {
+        return _url.description
+    }
+    
+    public var debugDescription: String {
+        return _url.debugDescription
+    }
+}
+
+extension NSURL : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as URL)
+    }
+}
+
+extension URL : CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .url(absoluteString)
+    }
+}
+
+//===----------------------------------------------------------------------===//
+// File references, for playgrounds.
+//===----------------------------------------------------------------------===//
+
+extension URL : _ExpressibleByFileReferenceLiteral {
+  public init(fileReferenceLiteralResourceName name: String) {
+    self = Bundle.main.url(forResource: name, withExtension: nil)!
+  }
+}
+
+public typealias _FileReferenceLiteralType = URL

--- a/Foundation/URL.swift
+++ b/Foundation/URL.swift
@@ -699,9 +699,8 @@ public struct URL : ReferenceConvertible, Equatable {
             return result
         } else {
             // Now we need to do something more expensive
-            if var c = URLComponents(url: self, resolvingAgainstBaseURL: true),
-               let path = c.path {
-                c.path = path._stringByAppendingPathComponent(pathComponent)
+            if var c = URLComponents(url: self, resolvingAgainstBaseURL: true) {
+                c.path = c.path._stringByAppendingPathComponent(pathComponent)
                 
                 if let result = c.url {
                     return result
@@ -725,9 +724,8 @@ public struct URL : ReferenceConvertible, Equatable {
             return result
         } else {
             // Now we need to do something more expensive
-            if var c = URLComponents(url: self, resolvingAgainstBaseURL: true),
-               let path = c.path {
-                c.path = path._stringByAppendingPathComponent(pathComponent)
+            if var c = URLComponents(url: self, resolvingAgainstBaseURL: true) {
+                c.path = c.path._stringByAppendingPathComponent(pathComponent)
                 
                 if let result = c.url {
                     return result

--- a/Foundation/URL.swift
+++ b/Foundation/URL.swift
@@ -752,7 +752,7 @@ public struct URL : ReferenceConvertible, Equatable {
             return self
         }
         
-        if let result = _url.deletingLastPathComponent.map({ URL(reference: $0 as NSURL) }) {
+        if let result = _url.deletingLastPathComponent {
             return result
         } else {
             return self
@@ -785,7 +785,7 @@ public struct URL : ReferenceConvertible, Equatable {
             return self
         }
 
-        if let result = _url.deletingPathExtension.map({ URL(reference: $0 as NSURL) }) {
+        if let result = _url.deletingPathExtension {
             return result
         } else {
             return self
@@ -837,7 +837,7 @@ public struct URL : ReferenceConvertible, Equatable {
     /// Returns a `URL` with any instances of ".." or "." removed from its path.
     public var standardized : URL {
         // The NSURL API can only return nil in case of file reference URL, which we should not be
-        if let result = _url.standardized.map({ URL(reference: $0 as NSURL) }) {
+        if let result = _url.standardized {
             return result
         } else {
             return self
@@ -856,7 +856,7 @@ public struct URL : ReferenceConvertible, Equatable {
     /// If the `isFileURL` is false, this method returns `self`.
     public var standardizedFileURL : URL {
         // NSURL should not return nil here unless this is a file reference URL, which should be impossible
-        if let result = _url.standardizingPath.map({ URL(reference: $0 as NSURL) }) {
+        if let result = _url.standardizingPath {
             return result
         } else {
             return self
@@ -868,7 +868,7 @@ public struct URL : ReferenceConvertible, Equatable {
     /// If the `isFileURL` is false, this method returns `self`.
     public func resolvingSymlinksInPath() -> URL {
         // NSURL should not return nil here unless this is a file reference URL, which should be impossible
-        if let result = _url.resolvingSymlinksInPath.map({ URL(reference: $0 as NSURL) }) {
+        if let result = _url.resolvingSymlinksInPath {
             return result
         } else {
             return self
@@ -927,26 +927,6 @@ public struct URL : ReferenceConvertible, Equatable {
         _url.removeCachedResourceValue(forKey: key)
     }
     
-    @available(*, unavailable, message: "Use struct URLResourceValues and URL.setResourceValues(_:) instead")
-    public func setResourceValue(_ value: AnyObject?, forKey key: URLResourceKey) throws {
-        fatalError()
-    }
-    
-    @available(*, unavailable, message: "Use struct URLResourceValues and URL.setResourceValues(_:) instead")
-    public func setResourceValues(_ keyedValues: [URLResourceKey : AnyObject]) throws {
-        fatalError()
-    }
-    
-    @available(*, unavailable, message: "Use struct URLResourceValues and URL.resourceValues(forKeys:) instead")
-    public func resourceValues(forKeys keys: [URLResourceKey]) throws -> [URLResourceKey : AnyObject] {
-        fatalError()
-    }
-    
-    @available(*, unavailable, message: "Use struct URLResourceValues and URL.setResourceValues(_:) instead")
-    public func getResourceValue(_ value: AutoreleasingUnsafeMutablePointer<AnyObject?>, forKey key: URLResourceKey) throws {
-        fatalError()
-    }
-    
     // MARK: - Bridging Support
     
     /// We must not store an NSURL without running it through this function. This makes sure that we do not hold a file reference URL, which changes the nullability of many NSURL functions.
@@ -968,7 +948,7 @@ public struct URL : ReferenceConvertible, Equatable {
     }
 }
 
-extension URL : _ObjectiveCBridgeable {
+extension URL {
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSURL {
         return _url
@@ -976,7 +956,7 @@ extension URL : _ObjectiveCBridgeable {
     
     public static func _forceBridgeFromObjectiveC(_ source: NSURL, result: inout URL?) {
         if !_conditionallyBridgeFromObjectiveC(source, result: &result) {
-            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+            fatalError("Unable to bridge \(NSURL.self) to \(self)")
         }
     }
     
@@ -999,14 +979,6 @@ extension URL : CustomStringConvertible, CustomDebugStringConvertible {
     
     public var debugDescription: String {
         return _url.debugDescription
-    }
-}
-
-extension NSURL : _HasCustomAnyHashableRepresentation {
-    // Must be @nonobjc to avoid infinite recursion during bridging.
-    @nonobjc
-    public func _toCustomAnyHashable() -> AnyHashable? {
-        return AnyHashable(self as URL)
     }
 }
 

--- a/Foundation/URLComponents.swift
+++ b/Foundation/URLComponents.swift
@@ -11,7 +11,7 @@
 /// A structure designed to parse URLs based on RFC 3986 and to construct URLs from their constituent parts.
 ///
 /// Its behavior differs subtly from the `URL` struct, which conforms to older RFCs. However, you can easily obtain a `URL` based on the contents of a `URLComponents` or vice versa.
-public struct URLComponents : ReferenceConvertible, Hashable, CustomStringConvertible, Equatable, _MutableBoxing {
+public struct URLComponents : ReferenceConvertible, Hashable, Equatable, _MutableBoxing {
     public typealias ReferenceType = NSURLComponents
     
     internal var _handle: _MutableHandle<NSURLComponents>
@@ -37,12 +37,16 @@ public struct URLComponents : ReferenceConvertible, Hashable, CustomStringConver
         _handle = _MutableHandle(adoptingReference: result)
     }
     
-    /// Returns a URL created from the NSURLComponents. If the NSURLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
+    /// Returns a URL created from the NSURLComponents.
+    ///
+    /// If the NSURLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
     public var url: URL? {
         return _handle.map { $0.url }
     }
     
-    // Returns a URL created from the NSURLComponents relative to a base URL. If the NSURLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
+    // Returns a URL created from the NSURLComponents relative to a base URL.
+    ///
+    /// If the NSURLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
     public func url(relativeTo base: URL?) -> URL? {
         return _handle.map { $0.url(relativeTo: base) }
     }
@@ -95,23 +99,20 @@ public struct URLComponents : ReferenceConvertible, Hashable, CustomStringConver
     /// Attempting to set a negative port number will cause a fatal error.
     public var port: Int? {
         get { return _handle.map { $0.port?.intValue } }
-        set {
-            _applyMutation {
-                if let val = newValue {
-                    $0.port = NSNumber(integerLiteral: val)
-                } else {
-                    $0.port = nil
-                }
-            }
-        }
+        set { _applyMutation { $0.port = newValue != nil ? NSNumber(value: newValue!) : nil as NSNumber?} }
     }
     
     /// The path subcomponent.
     ///
     /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
-    public var path: String? {
-        get { return _handle.map { $0.path } }
-        set { _applyMutation { $0.path = newValue } }
+    public var path: String {
+        get {
+            guard let result = _handle.map({ $0.path }) else { return "" }
+            return result
+        }
+        set {
+            _applyMutation { $0.path = newValue }
+        }
     }
     
     /// The query subcomponent.
@@ -158,9 +159,14 @@ public struct URLComponents : ReferenceConvertible, Hashable, CustomStringConver
     /// The path subcomponent, percent-encoded.
     ///
     /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlPathAllowed`).
-    public var percentEncodedPath: String? {
-        get { return _handle.map { $0.percentEncodedPath } }
-        set { _applyMutation { $0.percentEncodedPath = newValue } }
+    public var percentEncodedPath: String {
+        get {
+            guard let result = _handle.map({ $0.percentEncodedPath }) else { return "" }
+            return result
+        }
+        set {
+            _applyMutation { $0.percentEncodedPath = newValue }
+        }
     }
     
     /// The query subcomponent, percent-encoded.
@@ -184,7 +190,7 @@ public struct URLComponents : ReferenceConvertible, Hashable, CustomStringConver
         
         let utf16Start = String.UTF16View.Index(_offset: r.location)
         let utf16End = String.UTF16View.Index(_offset: r.location + r.length)
-
+        
         guard let s = self.string else { return nil }
         guard let start = String.Index(utf16Start, within: s) else { return nil }
         guard let end = String.Index(utf16End, within: s) else { return nil }
@@ -255,12 +261,12 @@ public struct URLComponents : ReferenceConvertible, Hashable, CustomStringConver
     public var rangeOfFragment: Range<String.Index>? {
         return _toStringRange(_handle.map { $0.rangeOfFragment})
     }
-
+    
     /// Returns an array of query items for this `URLComponents`, in the order in which they appear in the original query string.
     ///
     /// Each `URLQueryItem` represents a single key-value pair,
     ///
-    /// Note that a name may appear more than once in a single query string, so the name values are not guaranteed to be unique. If the `URLComponents` has an empty query component, returns an empty array. If the `URLComponents` has no query component, returns nil.
+    /// Note that a name may appear more than once in a single query string, so the name values are not guaranteed to be unique. If the `URLComponents` has an empty query component, returns an empty array. If the `URLComponents` has no query component, returns nil.
     ///
     /// The setter combines an array containing any number of `URLQueryItem`s, each of which represents a single key-value pair, into a query string and sets the `URLComponents` query property. Passing an empty array sets the query component of the `URLComponents` to an empty string. Passing nil removes the query component of the `URLComponents`.
     ///
@@ -270,14 +276,6 @@ public struct URLComponents : ReferenceConvertible, Hashable, CustomStringConver
         set { _applyMutation { $0.queryItems = newValue?.map { $0 } } }
     }
     
-    public var description: String {
-        return _handle.map { $0.description }
-    }
-    
-    public var debugDescription: String {
-        return _handle.map { $0.debugDescription }
-    }
-
     public var hashValue: Int {
         return _handle.map { $0.hash }
     }
@@ -288,16 +286,48 @@ public struct URLComponents : ReferenceConvertible, Hashable, CustomStringConver
         _handle = _MutableHandle(reference: reference)
     }
     
+    public static func ==(lhs: URLComponents, rhs: URLComponents) -> Bool {
+        // Don't copy references here; no one should be storing anything
+        return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
+    }
 }
 
-public func ==(lhs: URLComponents, rhs: URLComponents) -> Bool {
-    // Don't copy references here; no one should be storing anything
-    return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
+extension URLComponents : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    public var description: String {
+        if let u = url {
+            return u.description
+        } else {
+            return self.customMirror.children.reduce("") {
+                $0.appending("\($1.label ?? ""): \($1.value) ")
+            }
+        }
+    }
+    
+    public var debugDescription: String {
+        return self.description
+    }
+    
+    public var customMirror: Mirror {
+        var c: [(label: String?, value: Any)] = []
+        
+        if let s = self.scheme { c.append((label: "scheme", value: s)) }
+        if let u = self.user { c.append((label: "user", value: u)) }
+        if let pw = self.password { c.append((label: "password", value: pw)) }
+        if let h = self.host { c.append((label: "host", value: h)) }
+        if let p = self.port { c.append((label: "port", value: p)) }
+        
+        c.append((label: "path", value: self.path))
+        if #available(OSX 10.10, iOS 8.0, *) {
+            if let qi = self.queryItems { c.append((label: "queryItems", value: qi )) }
+        }
+        if let f = self.fragment { c.append((label: "fragment", value: f)) }
+        let m = Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+        return m
+    }
 }
-
 
 /// A single name-value pair, for use with `URLComponents`.
-public struct URLQueryItem : ReferenceConvertible, Hashable, Equatable, CustomStringConvertible {
+public struct URLQueryItem : ReferenceConvertible, Hashable, Equatable {
     public typealias ReferenceType = NSURLQueryItem
     
     fileprivate var _queryItem : NSURLQueryItem
@@ -307,27 +337,45 @@ public struct URLQueryItem : ReferenceConvertible, Hashable, Equatable, CustomSt
     }
     
     fileprivate init(reference: NSURLQueryItem) { _queryItem = reference.copy() as! NSURLQueryItem }
-    private var reference : NSURLQueryItem { return _queryItem }
+    fileprivate var reference : NSURLQueryItem { return _queryItem }
     
-    public var name : String {
+    public var name: String {
         get { return _queryItem.name }
         set { _queryItem = NSURLQueryItem(name: newValue, value: value) }
     }
     
-    public var value : String? {
+    public var value: String? {
         get { return _queryItem.value }
         set { _queryItem = NSURLQueryItem(name: name, value: newValue) }
     }
     
-    public var description: String { return _queryItem.description }
-    public var debugDescription: String { return _queryItem.debugDescription }
     public var hashValue: Int { return _queryItem.hash }
+    
+    public static func ==(lhs: URLQueryItem, rhs: URLQueryItem) -> Bool {
+        return lhs._queryItem.isEqual(rhs._queryItem)
+    }
 }
 
-public func ==(lhs: URLQueryItem, rhs: URLQueryItem) -> Bool {
-    return lhs._queryItem.isEqual(rhs._nsObject)
+extension URLQueryItem : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    public var description: String {
+        if let v = value {
+            return "\(name)=\(v)"
+        } else {
+            return name
+        }
+    }
+    
+    public var debugDescription: String {
+        return self.description
+    }
+    
+    public var customMirror: Mirror {
+        var c: [(label: String?, value: Any)] = []
+        c.append((label: "name", value: name))
+        c.append((label: "value", value: value))
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+    }
 }
-
 
 extension NSURLComponents : _SwiftBridgable {
     typealias SwiftType = URLComponents

--- a/Foundation/URLRequest.swift
+++ b/Foundation/URLRequest.swift
@@ -10,8 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-
-public struct URLRequest : ReferenceConvertible, CustomStringConvertible, Equatable, Hashable {
+public struct URLRequest : ReferenceConvertible, Equatable, Hashable {
     public typealias ReferenceType = NSURLRequest
     public typealias CachePolicy = NSURLRequest.CachePolicy
     public typealias NetworkServiceType = NSURLRequest.NetworkServiceType
@@ -63,7 +62,7 @@ public struct URLRequest : ReferenceConvertible, CustomStringConvertible, Equata
     
     /// Returns the timeout interval of the receiver.
     /// - discussion: The timeout interval specifies the limit on the idle
-    /// interval alloted to a request in the process of loading. The "idle
+    /// interval allotted to a request in the process of loading. The "idle
     /// interval" is defined as the period of time that has passed since the
     /// last instance of load activity occurred for a request that is in the
     /// process of loading. Hence, when an instance of load activity occurs
@@ -106,7 +105,7 @@ public struct URLRequest : ReferenceConvertible, CustomStringConvertible, Equata
     }
     
     /// `true` if the receiver is allowed to use the built in cellular radios to
-    /// satify the request, `false` otherwise.
+    /// satisfy the request, `false` otherwise.
     public var allowsCellularAccess: Bool {
         get {
             return _handle.map { $0.allowsCellularAccess }
@@ -226,24 +225,43 @@ public struct URLRequest : ReferenceConvertible, CustomStringConvertible, Equata
         return _handle.map { $0.hashValue }
     }
     
+    public static func ==(lhs: URLRequest, rhs: URLRequest) -> Bool {
+        return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
+    }
+}
+
+extension URLRequest : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
     public var description: String {
-        return _handle.map { $0.description }
+        if let u = url {
+            return u.description
+        } else {
+            return "url: nil"
+        }
     }
     
     public var debugDescription: String {
-        return _handle.map { $0.debugDescription }
+        return self.description
     }
-}
-
-public func ==(lhs: URLRequest, rhs: URLRequest) -> Bool {
-    return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
+    
+    public var customMirror: Mirror {
+        var c: [(label: String?, value: Any)] = []
+        c.append((label: "url", value: url))
+        c.append((label: "cachePolicy", value: cachePolicy.rawValue))
+        c.append((label: "timeoutInterval", value: timeoutInterval))
+        c.append((label: "mainDocumentURL", value: mainDocumentURL))
+        c.append((label: "networkServiceType", value: networkServiceType))
+        c.append((label: "allowsCellularAccess", value: allowsCellularAccess))
+        c.append((label: "httpMethod", value: httpMethod))
+        c.append((label: "allHTTPHeaderFields", value: allHTTPHeaderFields))
+        c.append((label: "httpBody", value: httpBody))
+        c.append((label: "httpBodyStream", value: httpBodyStream))
+        c.append((label: "httpShouldHandleCookies", value: httpShouldHandleCookies))
+        c.append((label: "httpShouldUsePipelining", value: httpShouldUsePipelining))
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+    }
 }
 
 extension URLRequest {
-    public static func _isBridgedToObjectiveC() -> Bool {
-        return true
-    }
-    
     public static func _getObjectiveCType() -> Any.Type {
         return NSURLRequest.self
     }

--- a/TestFoundation/TestNSBundle.swift
+++ b/TestFoundation/TestNSBundle.swift
@@ -68,7 +68,7 @@ class TestNSBundle : XCTestCase {
         let testPlist = bundle.url(forResource: "Test", withExtension: "plist")
         XCTAssertNotNil(testPlist)
         XCTAssertEqual("Test.plist", testPlist!.lastPathComponent)
-        XCTAssert(FileManager.default.fileExists(atPath: testPlist!.path!))
+        XCTAssert(FileManager.default.fileExists(atPath: testPlist!.path))
         
         // aliases, paths
         XCTAssertEqual(testPlist!.path, bundle.url(forResource: "Test", withExtension: "plist", subdirectory: nil)!.path)

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -53,8 +53,8 @@ class TestNSData: XCTestCase {
         do {
             try saveData.write(to: savePath, options: .dataWritingAtomic)
             let fileManager = FileManager.default
-            XCTAssertTrue(fileManager.fileExists(atPath: savePath.path!))
-            try! fileManager.removeItem(atPath: savePath.path!)
+            XCTAssertTrue(fileManager.fileExists(atPath: savePath.path))
+            try! fileManager.removeItem(atPath: savePath.path)
         } catch _ {
             XCTFail()
         }

--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -309,7 +309,7 @@ class TestNSFileManager : XCTestCase {
         
         do {
             let contents = try FileManager.default.contentsOfDirectory(at: URL(fileURLWithPath: path), includingPropertiesForKeys: nil, options: []).map {
-                return $0.path!
+                return $0.path
             }
             XCTAssertEqual(contents.count, 2)
             XCTAssertTrue(contents.contains(itemPath))

--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -211,8 +211,8 @@ class TestNSKeyedArchiver : XCTestCase {
     }
     
     func test_archive_url() {
-        let url = URL(string: "index.html", relativeTo: URL(string: "http://www.apple.com"))!
-        test_archive(url.bridge())
+        let url = NSURL(string: "index.html", relativeTo: URL(string: "http://www.apple.com"))!
+        test_archive(url)
     }
     
     func test_archive_charptr() {

--- a/TestFoundation/TestNSKeyedUnarchiver.swift
+++ b/TestFoundation/TestNSKeyedUnarchiver.swift
@@ -52,11 +52,11 @@ class TestNSKeyedUnarchiver : XCTestCase {
     
     func test_unarchive_complex() {
         let uuid = NSUUID(uuidString: "71DC068E-3420-45FF-919E-3A267D55EC22")!
-        let url = URL(string: "index.xml", relativeTo: URL(string: "https://www.swift.org"))!
+        let url = NSURL(string: "index.xml", relativeTo: URL(string: "https://www.swift.org"))!
         let array = NSArray(array: [ NSNull(), NSString(string: "hello"), NSNumber(value: 34545), ["key" : "val"].bridge() ])
         let dict : Dictionary<String, NSObject> = [
             "uuid" : uuid,
-            "url" : url.bridge(),
+            "url" : url,
             "string" : "hello".bridge(),
             "array" : array
         ]
@@ -101,8 +101,8 @@ class TestNSKeyedUnarchiver : XCTestCase {
     }
     
     func test_unarchive_url() {
-        let url = URL(string: "foo.xml", relativeTo: URL(string: "https://www.example.com"))
-        test_unarchive_from_file("NSKeyedUnarchiver-URLTest", url!.bridge())
+        let url = NSURL(string: "foo.xml", relativeTo: URL(string: "https://www.example.com"))
+        test_unarchive_from_file("NSKeyedUnarchiver-URLTest", url!)
     }
     
     func test_unarchive_uuid() {

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -449,7 +449,7 @@ class TestNSString : XCTestCase {
             var outName: NSString?
             var matches: [NSString] = []
             _ = path.completePathIntoString(&outName, caseSensitive: false, matchesIntoArray: &matches, filterTypes: nil)
-            let urlToTmp = try URL(fileURLWithPath: "/private/tmp/").standardizingPath()
+            let urlToTmp = URL(fileURLWithPath: "/private/tmp/").standardized
             _ = try FileManager.default.contentsOfDirectory(at: urlToTmp, includingPropertiesForKeys: nil, options: [])
             XCTAssert(outName == "/tmp/", "If path could be completed to existing directory then outName is a string itself plus '/'.")
             // This assert fails on CI; https://bugs.swift.org/browse/SR-389

--- a/TestFoundation/TestNSTask.swift
+++ b/TestFoundation/TestNSTask.swift
@@ -248,7 +248,7 @@ class TestNSTask : XCTestCase {
 }
 
 private func mkstemp(template: String, body: (FileHandle) throws -> Void) rethrows {
-    let url = try! URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("TestNSTask.XXXXXX")
+    let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("TestNSTask.XXXXXX")
     var buffer = [Int8](repeating: 0, count: Int(PATH_MAX))
     try url.withUnsafeFileSystemRepresentation {
         switch mkstemp(UnsafeMutablePointer(mutating: $0)) {

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -473,7 +473,7 @@ class TestNSURLComponents : XCTestCase {
         for obj in getTestData()! {
             let testDict = obj as! [String: Any]
             let unencodedString = testDict[kURLTestUrlKey] as! String
-            let expectedString = NSString(string: unencodedString).stringByAddingPercentEncodingWithAllowedCharacters(.urlPathAllowed)!
+            let expectedString = NSString(string: unencodedString).addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
             guard let components = URLComponents(string: expectedString) else { continue }
             XCTAssertEqual(components.string!, expectedString, "should be the expected string (\(components.string!) != \(expectedString))")
         }

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -105,74 +105,41 @@ class TestNSURL : XCTestCase {
     internal func generateResults(_ url: URL, pathComponent: String?, pathExtension : String?) -> [String : String] {
         var result = [String : String]()
         if let pathComponent = pathComponent {
-            do {
-                let newURL = try url.appendingPathComponent(pathComponent, isDirectory: false)
-                result["appendingPathComponent-File"] = newURL.relativeString
-                result["appendingPathComponent-File-BaseURL"] = newURL.baseURL?.relativeString ?? kNullString
-            } catch {
-                result["appendingPathComponent-File"] = kNullString
-                result["appendingPathComponent-File-BaseURL"] = kNullString
-            }
+            let newFileURL = url.appendingPathComponent(pathComponent, isDirectory: false)
+            result["appendingPathComponent-File"] = newFileURL.relativeString
+            result["appendingPathComponent-File-BaseURL"] = newFileURL.baseURL?.relativeString ?? kNullString
 
-            do {
-               let newURL = try url.appendingPathComponent(pathComponent, isDirectory: true)
-                result["appendingPathComponent-Directory"] = newURL.relativeString
-                result["appendingPathComponent-Directory-BaseURL"] = newURL.baseURL?.relativeString ?? kNullString
-            } catch {
-                result["appendingPathComponent-Directory"] = kNullString
-                result["appendingPathComponent-Directory-BaseURL"] = kNullString
-            }
-            
+            let newDirURL = url.appendingPathComponent(pathComponent, isDirectory: true)
+            result["appendingPathComponent-Directory"] = newDirURL.relativeString
+            result["appendingPathComponent-Directory-BaseURL"] = newDirURL.baseURL?.relativeString ?? kNullString
         } else if let pathExtension = pathExtension {
-            do {
-                let newURL = try url.appendingPathExtension(pathExtension)
-                result["appendingPathExtension"] = newURL.relativeString
-                result["appendingPathExtension-BaseURL"] = newURL.baseURL?.relativeString ?? kNullString
-            } catch {
-                result["appendingPathExtension"] = kNullString
-                result["appendingPathExtension-BaseURL"] = kNullString
-            }
+            let newURL = url.appendingPathExtension(pathExtension)
+            result["appendingPathExtension"] = newURL.relativeString
+            result["appendingPathExtension-BaseURL"] = newURL.baseURL?.relativeString ?? kNullString
         } else {
             result["relativeString"] = url.relativeString
             result["baseURLString"] = url.baseURL?.relativeString ?? kNullString
             result["absoluteString"] = url.absoluteString
-            result["absoluteURLString"] = url.absoluteURL?.relativeString ?? kNullString
+            result["absoluteURLString"] = url.absoluteURL.relativeString
             result["scheme"] = url.scheme ?? kNullString
-            result["resourceSpecifier"] = url.resourceSpecifier ?? kNullString
             result["host"] = url.host ?? kNullString
             // Temporarily disabled because we're only checking string results
             // result["port"] = url.port ?? kNullString
             result["user"] = url.user ?? kNullString
             result["password"] = url.password ?? kNullString
-            result["path"] = url.path ?? kNullString
+            result["path"] = url.path
             result["query"] = url.query ?? kNullString
             result["fragment"] = url.fragment ?? kNullString
-            result["parameterString"] = url.parameterString ?? kNullString
-            result["relativePath"] = url.relativePath ?? kNullString
+            result["relativePath"] = url.relativePath
             result["isFileURL"] = url.isFileURL ? "YES" : "NO"
-            do {
-                let url = try url.standardized()
-                result["standardizedURL"] = url.relativeString
-            } catch {
-                result["standardizedURL"] = kNullString
-            } 
+            result["standardizedURL"] = url.standardized.relativeString
+            
             // Temporarily disabled because we're only checking string results
             // result["pathComponents"] = url.pathComponents ?? kNullString
-            result["lastPathComponent"] = url.lastPathComponent ?? kNullString
-            result["pathExtension"] = url.pathExtension ?? kNullString
-            do {
-                let url = try url.deletingLastPathComponent()
-                result["deletingLastPathComponent"] = url.relativeString
-            } catch {
-                result["deletingLastPathComponent"] = kNullString
-            }
-            
-            do {
-                let url = try url.deletingPathExtension()
-                result["deletingLastPathExtension"] = url.relativeString
-            } catch {
-                result["deletingLastPathExtension"] = kNullString
-            }
+            result["lastPathComponent"] = url.lastPathComponent 
+            result["pathExtension"] = url.pathExtension
+            result["deletingLastPathComponent"] = url.deletingLastPathComponent().relativeString
+            result["deletingLastPathExtension"] = url.deletingPathExtension().relativeString
         }
         return result
     }
@@ -224,8 +191,8 @@ class TestNSURL : XCTestCase {
             default:
                 XCTFail()
             }
+            
             if let url = url {
-
                 if title == "NSURLWithString-parse-ambiguous-url-001" {
                     // TODO: Fix this test
                 } else {
@@ -397,55 +364,43 @@ class TestNSURL : XCTestCase {
         // so tmp is tmp. On Linux tmp is not symlinked so it would be the same.
         do {
             let url = URL(fileURLWithPath: "/.//tmp/ABC/..")
-            let result = try url.resolvingSymlinksInPath().absoluteString
+            let result = url.resolvingSymlinksInPath().absoluteString
             XCTAssertEqual(result, "file:///tmp/", "URLByResolvingSymlinksInPath removes extraneous path components and resolve symlinks.")
-        } catch {
-            XCTFail()
         }
-            
+        
         do {
             let url = URL(fileURLWithPath: "~")
-            let result = try url.resolvingSymlinksInPath().absoluteString
+            let result = url.resolvingSymlinksInPath().absoluteString
             let expected = "file://" + FileManager.default.currentDirectoryPath + "/~"
             XCTAssertEqual(result, expected, "URLByResolvingSymlinksInPath resolves relative paths using current working directory.")
-        } catch {
-            XCTFail()
         }
 
         do {
             let url = URL(fileURLWithPath: "anysite.com/search")
-            let result = try url.resolvingSymlinksInPath().absoluteString
+            let result = url.resolvingSymlinksInPath().absoluteString
             let expected = "file://" + FileManager.default.currentDirectoryPath + "/anysite.com/search"
             XCTAssertEqual(result, expected)
-        } catch {
-            XCTFail()
         }
 
         // tmp is symlinked on OS X only
         #if os(OSX)
         do {
             let url = URL(fileURLWithPath: "/tmp/..")
-            let result = try url.resolvingSymlinksInPath().absoluteString
+            let result = url.resolvingSymlinksInPath().absoluteString
             XCTAssertEqual(result, "file:///private/")
-        } catch {
-            XCTFail()
-            }
+        }
         #endif
         
         do {
             let url = URL(fileURLWithPath: "/tmp/ABC/test_URLByResolvingSymlinksInPath")
-            let result = try url.resolvingSymlinksInPath().absoluteString
+            let result = url.resolvingSymlinksInPath().absoluteString
             XCTAssertEqual(result, "file:///tmp/ABC/test_URLByResolvingSymlinksInPath", "URLByResolvingSymlinksInPath appends trailing slash for existing directories only")
-        } catch {
-            XCTFail()
         }
         
         do {
             let url = URL(fileURLWithPath: "/tmp/ABC/..")
-            let result = try url.resolvingSymlinksInPath().absoluteString
+            let result = url.resolvingSymlinksInPath().absoluteString
             XCTAssertEqual(result, "file:///tmp/")
-        } catch {
-            XCTFail()
         }
     }
 


### PR DESCRIPTION
### Changes
#### `NSURL`
* Add resource values API
* `public` → `open`
* `fileURLWithPathComponents(_ components: [String])` → `fileURL(withPathComponents components: [String])`
* `AnyObject` → `Any`
* Add missing URL resource keys

#### `NSURLQueryItem`
* `public` → `open`

#### `NSString`
* `stringByAddingPercentEncodingWithAllowedCharacters(_ allowedCharacters: CharacterSet)` → `addingPercentEncoding(withAllowedCharacters allowedCharacters: CharacterSet)`
* `stringByRemovingPercentEncoding: String?` → `removingPercentEncoding: String?`

#### `URL`
* Integrate work from overlay (with nullability/throws changes)
* Update tests to remove now missing elements (e.g. `resourceSpecifier`)
* Update auxiliary usages to match new nullability/throws

#### `URLComponents`/`URLQueryItems`/`URLRequest`
* Integrate work from overlay

#### `NSURLRequest`
* Update types in `NetworkServiceType`