### PR TITLE
Foundation API Conformance Update: Miscellaneous

### DIFF
--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -508,11 +508,11 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
             NSInvalidArgument("range \(r) extends beyond bounds \(bounds)")
         }
         
-        if opts.contains(.FirstEqual) && opts.contains(.LastEqual) {
-            NSInvalidArgument("both NSBinarySearching.FirstEqual and NSBinarySearching.LastEqual options cannot be specified")
+        if opts.contains(.firstEqual) && opts.contains(.lastEqual) {
+            NSInvalidArgument("both NSBinarySearching.firstEqual and NSBinarySearching.lastEqual options cannot be specified")
         }
         
-        let searchForInsertionIndex = opts.contains(.InsertionIndex)
+        let searchForInsertionIndex = opts.contains(.insertionIndex)
         
         // fringe cases
         if r.length == 0 {
@@ -530,8 +530,8 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         }
         
         // common processing
-        let firstEqual = opts.contains(.FirstEqual)
-        let lastEqual = opts.contains(.LastEqual)
+        let firstEqual = opts.contains(.firstEqual)
+        let lastEqual = opts.contains(.lastEqual)
         let anyEqual = !(firstEqual || lastEqual)
         
         var result = NSNotFound
@@ -627,9 +627,9 @@ public struct NSBinarySearchingOptions : OptionSet {
     public let rawValue : UInt
     public init(rawValue: UInt) { self.rawValue = rawValue }
     
-    public static let FirstEqual = NSBinarySearchingOptions(rawValue: 1 << 8)
-    public static let LastEqual = NSBinarySearchingOptions(rawValue: 1 << 9)
-    public static let InsertionIndex = NSBinarySearchingOptions(rawValue: 1 << 10)
+    public static let firstEqual = NSBinarySearchingOptions(rawValue: 1 << 8)
+    public static let lastEqual = NSBinarySearchingOptions(rawValue: 1 << 9)
+    public static let insertionIndex = NSBinarySearchingOptions(rawValue: 1 << 10)
 }
 
 open class NSMutableArray : NSArray {

--- a/Foundation/NSComparisonPredicate.swift
+++ b/Foundation/NSComparisonPredicate.swift
@@ -7,9 +7,8 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
 // Flags(s) that can be passed to the factory to indicate that a operator operating on strings should do so in a case insensitive fashion.
-extension ComparisonPredicate {
+extension NSComparisonPredicate {
     public struct Options : OptionSet {
         public let rawValue : UInt
         public init(rawValue: UInt) { self.rawValue = rawValue }
@@ -21,7 +20,6 @@ extension ComparisonPredicate {
 
     // Describes how the operator is modified: can be direct, ALL, or ANY
     public enum Modifier : UInt {
-        
         case direct // Do a direct comparison
         case all // ALL toMany.x = y
         case any // ANY toMany.x = y
@@ -29,7 +27,6 @@ extension ComparisonPredicate {
 
     // Type basic set of operators defined. Most are obvious
     public enum Operator : UInt {
-        
         case lessThan // compare: returns NSOrderedAscending
         case lessThanOrEqualTo // compare: returns NSOrderedAscending || NSOrderedSame
         case greaterThan // compare: returns NSOrderedDescending
@@ -45,9 +42,9 @@ extension ComparisonPredicate {
         case between
     }
 }
-// Comparison predicates are predicates which do some form of comparison between the results of two expressions and return a BOOL. They take an operator, a left expression, and a right expression, and return the result of invoking the operator with the results of evaluating the expressions.
 
-open class ComparisonPredicate : Predicate {
+// Comparison predicates are predicates which do some form of comparison between the results of two expressions and return a BOOL. They take an operator, a left expression, and a right expression, and return the result of invoking the operator with the results of evaluating the expressions.
+open class NSComparisonPredicate : NSPredicate {
     
     public init(leftExpression lhs: NSExpression, rightExpression rhs: NSExpression, modifier: Modifier, type: Operator, options: Options) { NSUnimplemented() }
     public required init?(coder: NSCoder) { NSUnimplemented() }

--- a/Foundation/NSCompoundPredicate.swift
+++ b/Foundation/NSCompoundPredicate.swift
@@ -10,38 +10,38 @@
 
 // Compound predicates are predicates which act on the results of evaluating other operators. We provide the basic boolean operators: AND, OR, and NOT.
 
-extension CompoundPredicate {
+extension NSCompoundPredicate {
     public enum LogicalType : UInt {
-        
         case not
         case and
         case or
     }
 }
 
-open class CompoundPredicate : Predicate {
-    
-    public init(type: LogicalType, subpredicates: [Predicate]) {
+open class NSCompoundPredicate : NSPredicate {
+    public init(type: LogicalType, subpredicates: [NSPredicate]) {
         if type == .not && subpredicates.count == 0 {
             preconditionFailure("Unsupported predicate count of \(subpredicates.count) for \(type)")
         }
+
         self.compoundPredicateType = type
         self.subpredicates = subpredicates
         super.init(value: false)
     }
+
     public required init?(coder: NSCoder) { NSUnimplemented() }
     
-    public let compoundPredicateType: LogicalType
-    public let subpredicates: [Predicate]
+    open var compoundPredicateType: LogicalType
+    open var subpredicates: [NSPredicate]
 
     /*** Convenience Methods ***/
-    public convenience init(andPredicateWithSubpredicates subpredicates: [Predicate]) {
+    public convenience init(andPredicateWithSubpredicates subpredicates: [NSPredicate]) {
         self.init(type: .and, subpredicates: subpredicates)
     }
-    public convenience init(orPredicateWithSubpredicates subpredicates: [Predicate]) {
+    public convenience init(orPredicateWithSubpredicates subpredicates: [NSPredicate]) {
         self.init(type: .or, subpredicates: subpredicates)
     }
-    public convenience init(notPredicateWithSubpredicate predicate: Predicate) {
+    public convenience init(notPredicateWithSubpredicate predicate: NSPredicate) {
         self.init(type: .not, subpredicates: [predicate])
     }
 

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -145,8 +145,8 @@ open class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
         return userInfo[NSLocalizedRecoveryOptionsErrorKey] as? [String]
     }
     
-    open var recoveryAttempter: AnyObject? {
-        return userInfo[NSRecoveryAttempterErrorKey] as? AnyObject
+    open var recoveryAttempter: Any? {
+        return userInfo[NSRecoveryAttempterErrorKey]
     }
     
     open var helpAnchor: String? {

--- a/Foundation/NSExpression.swift
+++ b/Foundation/NSExpression.swift
@@ -50,13 +50,14 @@ open class NSExpression : NSObject, NSSecureCoding, NSCopying {
         NSUnimplemented()
     }
 
-    public /*not inherited*/ init(format expressionFormat: String, argumentArray arguments: [AnyObject]) { NSUnimplemented() }
+    public /*not inherited*/ init(format expressionFormat: String, argumentArray arguments: [Any]) { NSUnimplemented() }
+    public /*not inherited*/ init(format expressionFormat: String, arguments argList: CVaListPointer) { NSUnimplemented() }
     
-    public /*not inherited*/ init(forConstantValue obj: AnyObject?) { NSUnimplemented() } // Expression that returns a constant value
+    public /*not inherited*/ init(forConstantValue obj: Any?) { NSUnimplemented() } // Expression that returns a constant value
     open class func expressionForEvaluatedObject() -> NSExpression { NSUnimplemented() } // Expression that returns the object being evaluated
     public /*not inherited*/ init(forVariable string: String) { NSUnimplemented() } // Expression that pulls a value from the variable bindings dictionary
     public /*not inherited*/ init(forKeyPath keyPath: String) { NSUnimplemented() } // Expression that invokes valueForKeyPath with keyPath
-    public /*not inherited*/ init(forFunction name: String, arguments parameters: [AnyObject]) { NSUnimplemented() } // Expression that invokes one of the predefined functions. Will throw immediately if the selector is bad; will throw at runtime if the parameters are incorrect.
+    public /*not inherited*/ init(forFunction name: String, arguments parameters: [Any]) { NSUnimplemented() } // Expression that invokes one of the predefined functions. Will throw immediately if the selector is bad; will throw at runtime if the parameters are incorrect.
     // Predefined functions are:
     // name              parameter array contents				returns
     //-------------------------------------------------------------------------------------------------------------------------------------
@@ -98,40 +99,43 @@ open class NSExpression : NSObject, NSSecureCoding, NSCopying {
     //                   two NSExpression instances representing CLLocations    NSNumber
     // length:           an NSExpression instance representing a string         NSNumber
     
-    public /*not inherited*/ init(forAggregate subexpressions: [AnyObject]) { NSUnimplemented() } // Expression that returns a collection containing the results of other expressions
+    public /*not inherited*/ init(forAggregate subexpressions: [Any]) { NSUnimplemented() } // Expression that returns a collection containing the results of other expressions
     public /*not inherited*/ init(forUnionSet left: NSExpression, with right: NSExpression) { NSUnimplemented() } // return an expression that will return the union of the collections expressed by left and right
     public /*not inherited*/ init(forIntersectSet left: NSExpression, with right: NSExpression) { NSUnimplemented() } // return an expression that will return the intersection of the collections expressed by left and right
     public /*not inherited*/ init(forMinusSet left: NSExpression, with right: NSExpression) { NSUnimplemented() } // return an expression that will return the disjunction of the collections expressed by left and right
-    public /*not inherited*/ init(forSubquery expression: NSExpression, usingIteratorVariable variable: String, predicate: AnyObject) { NSUnimplemented() } // Expression that filters a collection by storing elements in the collection in the variable variable and keeping the elements for which qualifer returns true; variable is used as a local variable, and will shadow any instances of variable in the bindings dictionary, the variable is removed or the old value replaced once evaluation completes
-    public /*not inherited*/ init(forFunction target: NSExpression, selectorName name: String, arguments parameters: [AnyObject]?) { NSUnimplemented() } // Expression that invokes the selector on target with parameters. Will throw at runtime if target does not implement selector or if parameters are wrong.
+    public /*not inherited*/ init(forSubquery expression: NSExpression, usingIteratorVariable variable: String, predicate: Any) { NSUnimplemented() } // Expression that filters a collection by storing elements in the collection in the variable variable and keeping the elements for which qualifer returns true; variable is used as a local variable, and will shadow any instances of variable in the bindings dictionary, the variable is removed or the old value replaced once evaluation completes
+    public /*not inherited*/ init(forFunction target: NSExpression, selectorName name: String, arguments parameters: [Any]?) { NSUnimplemented() } // Expression that invokes the selector on target with parameters. Will throw at runtime if target does not implement selector or if parameters are wrong.
     open class func expressionForAnyKey() -> NSExpression { NSUnimplemented() }
-    public /*not inherited*/ init(forBlock block: (AnyObject?, [AnyObject], NSMutableDictionary?) -> AnyObject, arguments: [NSExpression]?) { NSUnimplemented() } // Expression that invokes the block with the parameters; note that block expressions are not encodable or representable as parseable strings.
-    public /*not inherited*/ init(forConditional predicate: Predicate, trueExpression: NSExpression, falseExpression: NSExpression) { NSUnimplemented() } // Expression that will return the result of trueExpression or falseExpression depending on the value of predicate
+    public /*not inherited*/ init(block: @escaping (Any?, [Any], NSMutableDictionary?) -> Any, arguments: [NSExpression]?) { NSUnimplemented() } // Expression that invokes the block with the parameters; note that block expressions are not encodable or representable as parseable strings.
+    public /*not inherited*/ init(forConditional predicate: Any, trueExpression: NSExpression, falseExpression: NSExpression) { NSUnimplemented() } // Expression that will return the result of trueExpression or falseExpression depending on the value of predicate
     
     public init(expressionType type: ExpressionType) { NSUnimplemented() }
     
     // accessors for individual parameters - raise if not applicable
     open var expressionType: ExpressionType { NSUnimplemented() }
-    open var constantValue: AnyObject { NSUnimplemented() }
+    open var constantValue: Any { NSUnimplemented() }
     open var keyPath: String { NSUnimplemented() }
     open var function: String { NSUnimplemented() }
     open var variable: String { NSUnimplemented() }
     /*@NSCopying*/ open var operand: NSExpression { NSUnimplemented() } // the object on which the selector will be invoked (the result of evaluating a key path or one of the defined functions)
     open var arguments: [NSExpression]? { NSUnimplemented() } // array of expressions which will be passed as parameters during invocation of the selector on the operand of a function expression
     
-    open var collection: AnyObject { NSUnimplemented() }
-    /*@NSCopying*/ open var predicate: Predicate { NSUnimplemented() }
+    open var collection: Any { NSUnimplemented() }
+    /*@NSCopying*/ open var predicate: NSPredicate { NSUnimplemented() }
     /*@NSCopying*/ open var left: NSExpression { NSUnimplemented() } // expression which represents the left side of a set expression
     /*@NSCopying*/ open var right: NSExpression { NSUnimplemented() } // expression which represents the right side of a set expression
     
     /*@NSCopying*/ open var `true`: NSExpression { NSUnimplemented() } // expression which will be evaluated if a conditional expression's predicate evaluates to true
     /*@NSCopying*/ open var `false`: NSExpression { NSUnimplemented() } // expression which will be evaluated if a conditional expression's predicate evaluates to false
     
-    open var expressionBlock: (AnyObject?, [AnyObject], NSMutableDictionary?) -> AnyObject { NSUnimplemented() }
+    open var expressionBlock: (Any?, [Any], NSMutableDictionary?) -> Any { NSUnimplemented() }
     
     // evaluate the expression using the object and bindings- note that context is mutable here and can be used by expressions to store temporary state for one predicate evaluation
-    open func expressionValueWithObject(_ object: AnyObject?, context: NSMutableDictionary?) -> AnyObject { NSUnimplemented() }
+    open func expressionValue(with object: Any?, context: NSMutableDictionary?) -> Any? { NSUnimplemented() }
     
     open func allowEvaluation() { NSUnimplemented() } // Force an expression which was securely decoded to allow evaluation
 }
 
+extension NSExpression {
+    public convenience init(format expressionFormat: String, _ args: CVarArg...) { NSUnimplemented() }
+}

--- a/Foundation/NSFileHandle.swift
+++ b/Foundation/NSFileHandle.swift
@@ -15,7 +15,7 @@ import Darwin
 import Glibc
 #endif
 
-open class FileHandle: NSObject, NSSecureCoding {
+open class FileHandle : NSObject, NSSecureCoding {
     internal var _fd: Int32
     internal var _closeOnDealloc: Bool
     internal var _closed: Bool = false
@@ -195,7 +195,7 @@ extension FileHandle {
         return FileHandle(fileDescriptor: STDIN_FILENO, closeOnDealloc: false)
     }()
 
-    open class func standardInput() -> FileHandle {
+    open class var standardInput: FileHandle {
         return _stdinFileHandle
     }
     
@@ -203,7 +203,7 @@ extension FileHandle {
         return FileHandle(fileDescriptor: STDOUT_FILENO, closeOnDealloc: false)
     }()
 
-    open class func standardOutput() -> FileHandle {
+    open class var standardOutput: FileHandle {
         return _stdoutFileHandle
     }
     
@@ -211,11 +211,11 @@ extension FileHandle {
         return FileHandle(fileDescriptor: STDERR_FILENO, closeOnDealloc: false)
     }()
     
-    open class func standardError() -> FileHandle {
+    open class var standardError: FileHandle {
         return _stderrFileHandle
     }
     
-    open class func nullDevice() -> FileHandle {
+    open class var nullDevice: FileHandle {
         NSUnimplemented()
     }
     
@@ -256,76 +256,73 @@ extension FileHandle {
     }
 }
 
-public let NSFileHandleOperationException: String = "" // NSUnimplemented
+extension NSExceptionName {
+    public static let fileHandleOperationException = "" // NSUnimplemented
+}
 
-public let NSFileHandleReadCompletionNotification: String = "" // NSUnimplemented
-public let NSFileHandleReadToEndOfFileCompletionNotification: String = "" // NSUnimplemented
-public let NSFileHandleConnectionAcceptedNotification: String = "" // NSUnimplemented
-public let NSFileHandleDataAvailableNotification: String = "" // NSUnimplemented
+extension Notification.Name {
+    public static let NSFileHandleReadToEndOfFileCompletion = Notification.Name(rawValue: "") // NSUnimplemented
+    public static let NSFileHandleConnectionAccepted = Notification.Name(rawValue: "") // NSUnimplemented
+    public static let NSFileHandleDataAvailable = Notification.Name(rawValue: "") // NSUnimplemented
+    public static let NSFileHandleReadCompletion = Notification.Name(rawValue: "") // NSUnimplemented
+}
 
 public let NSFileHandleNotificationDataItem: String = "" // NSUnimplemented
 public let NSFileHandleNotificationFileHandleItem: String = "" // NSUnimplemented
 
 extension FileHandle {
-    
-    public func readInBackgroundAndNotify(forModes modes: [String]?) {
+    open func readInBackgroundAndNotify(forModes modes: [RunLoopMode]?) {
         NSUnimplemented()
     }
 
-    public func readInBackgroundAndNotify() {
+    open func readInBackgroundAndNotify() {
         NSUnimplemented()
     }
 
-    
-    public func readToEndOfFileInBackgroundAndNotify(forModes modes: [String]?) {
+    open func readToEndOfFileInBackgroundAndNotify(forModes modes: [RunLoopMode]?) {
         NSUnimplemented()
     }
 
-    public func readToEndOfFileInBackgroundAndNotify() {
-        NSUnimplemented()
-    }
-
-    
-    public func acceptConnectionInBackgroundAndNotify(forModes modes: [String]?) {
-        NSUnimplemented()
-    }
-
-    public func acceptConnectionInBackgroundAndNotify() {
-        NSUnimplemented()
-    }
-
-    
-    public func waitForDataInBackgroundAndNotify(forModes modes: [String]?) {
-        NSUnimplemented()
-    }
-
-    public func waitForDataInBackgroundAndNotify() {
+    open func readToEndOfFileInBackgroundAndNotify() {
         NSUnimplemented()
     }
     
-    public var readabilityHandler: ((FileHandle) -> Void)? {
+    open func acceptConnectionInBackgroundAndNotify(forModes modes: [RunLoopMode]?) {
         NSUnimplemented()
     }
 
-    public var writeabilityHandler: ((FileHandle) -> Void)? {
+    open func acceptConnectionInBackgroundAndNotify() {
+        NSUnimplemented()
+    }
+    
+    open func waitForDataInBackgroundAndNotify(forModes modes: [RunLoopMode]?) {
         NSUnimplemented()
     }
 
+    open func waitForDataInBackgroundAndNotify() {
+        NSUnimplemented()
+    }
+    
+    open var readabilityHandler: ((FileHandle) -> Void)? {
+        NSUnimplemented()
+    }
+
+    open var writeabilityHandler: ((FileHandle) -> Void)? {
+        NSUnimplemented()
+    }
 }
 
 extension FileHandle {
-    
     public convenience init(fileDescriptor fd: Int32) {
         self.init(fileDescriptor: fd, closeOnDealloc: false)
     }
     
-    public var fileDescriptor: Int32 {
+    open var fileDescriptor: Int32 {
         return _fd
     }
 }
 
 open class Pipe: NSObject {
-    
     private let readHandle: FileHandle
     private let writeHandle: FileHandle
     

--- a/Foundation/NSFileManager.swift
+++ b/Foundation/NSFileManager.swift
@@ -576,7 +576,7 @@ open class FileManager : NSObject {
     
         If you wish to only receive the URLs and no other attributes, then pass '0' for 'options' and an empty NSArray ('[NSArray array]') for 'keys'. If you wish to have the property caches of the vended URLs pre-populated with a default set of attributes, then pass '0' for 'options' and 'nil' for 'keys'.
      */
-    open func enumerator(at url: URL, includingPropertiesForKeys keys: [URLResourceKey]?, options mask: DirectoryEnumerationOptions = [], errorHandler handler: (@escaping (URL, Error) -> Bool)? = nil) -> DirectoryEnumerator? {
+    open func enumerator(at url: URL, includingPropertiesForKeys keys: [URLResourceKey]?, options mask: DirectoryEnumerationOptions = [], errorHandler handler: ((URL, Error) -> Bool)? = nil) -> DirectoryEnumerator? {
         if mask.contains(.skipsPackageDescendants) || mask.contains(.skipsHiddenFiles) {
             NSUnimplemented("Enumeration options not yet implemented")
         }

--- a/Foundation/NSFileManager.swift
+++ b/Foundation/NSFileManager.swift
@@ -576,7 +576,8 @@ open class FileManager : NSObject {
     
         If you wish to only receive the URLs and no other attributes, then pass '0' for 'options' and an empty NSArray ('[NSArray array]') for 'keys'. If you wish to have the property caches of the vended URLs pre-populated with a default set of attributes, then pass '0' for 'options' and 'nil' for 'keys'.
      */
-    open func enumerator(at url: URL, includingPropertiesForKeys keys: [URLResourceKey]?, options mask: DirectoryEnumerationOptions = [], errorHandler handler: ((URL, Error) -> Bool)? = nil) -> DirectoryEnumerator? {
+    // Note: Because the error handler is an optional block, the compiler treats it as @escaping by default. If that behavior changes, the @escaping will need to be added back.
+    open func enumerator(at url: URL, includingPropertiesForKeys keys: [URLResourceKey]?, options mask: DirectoryEnumerationOptions = [], errorHandler handler: (/* @escaping */ (URL, Error) -> Bool)? = nil) -> DirectoryEnumerator? {
         if mask.contains(.skipsPackageDescendants) || mask.contains(.skipsHiddenFiles) {
             NSUnimplemented("Enumeration options not yet implemented")
         }
@@ -963,7 +964,8 @@ extension FileManager {
         var _rootError : NSError? = nil
         var _gotRoot : Bool = false
         
-        init(url: URL, options: FileManager.DirectoryEnumerationOptions, errorHandler: ((URL, NSError) -> Bool)?) {
+        // See @escaping comments above.
+        init(url: URL, options: FileManager.DirectoryEnumerationOptions, errorHandler: (/* @escaping */ (URL, NSError) -> Bool)?) {
             _url = url
             _options = options
             _errorHandler = errorHandler

--- a/Foundation/NSFileManager.swift
+++ b/Foundation/NSFileManager.swift
@@ -15,61 +15,7 @@
 
 import CoreFoundation
 
-extension FileManager {
-    public struct VolumeEnumerationOptions: OptionSet {
-        public let rawValue : UInt
-        public init(rawValue: UInt) { self.rawValue = rawValue }
-        
-        /* The mounted volume enumeration will skip hidden volumes.
-         */
-        public static let skipHiddenVolumes = VolumeEnumerationOptions(rawValue: 1 << 1)
-        
-        /* The mounted volume enumeration will produce file reference URLs rather than path-based URLs.
-         */
-        public static let produceFileReferenceURLs = VolumeEnumerationOptions(rawValue: 1 << 2)
-    }
-
-    public struct DirectoryEnumerationOptions: OptionSet {
-        public let rawValue : UInt
-        public init(rawValue: UInt) { self.rawValue = rawValue }
-        
-        /* NSDirectoryEnumerationSkipsSubdirectoryDescendants causes the NSDirectoryEnumerator to perform a shallow enumeration and not descend into directories it encounters.
-         */
-        public static let skipsSubdirectoryDescendants = DirectoryEnumerationOptions(rawValue: 1 << 0)
-        
-        /* NSDirectoryEnumerationSkipsPackageDescendants will cause the NSDirectoryEnumerator to not descend into packages.
-         */
-        public static let skipsPackageDescendants = DirectoryEnumerationOptions(rawValue: 1 << 1)
-        
-        /* NSDirectoryEnumerationSkipsHiddenFiles causes the NSDirectoryEnumerator to not enumerate hidden files.
-         */
-        public static let skipsHiddenFiles = DirectoryEnumerationOptions(rawValue: 1 << 2)
-    }
-}
-
-public struct NSFileManagerItemReplacementOptions : OptionSet {
-    public let rawValue : UInt
-    public init(rawValue: UInt) { self.rawValue = rawValue }
-    
-    /* NSFileManagerItemReplacementUsingNewMetadataOnly causes -replaceItemAtURL:withItemAtURL:backupItemName:options:resultingItemURL:error: to use metadata from the new item only and not to attempt to preserve metadata from the original item.
-     */
-    public static let usingNewMetadataOnly = NSFileManagerItemReplacementOptions(rawValue: 1 << 0)
-    
-    /* NSFileManagerItemReplacementWithoutDeletingBackupItem causes -replaceItemAtURL:withItemAtURL:backupItemName:options:resultingItemURL:error: to leave the backup item in place after a successful replacement. The default behavior is to remove the item.
-     */
-    public static let withoutDeletingBackupItem = NSFileManagerItemReplacementOptions(rawValue: 1 << 1)
-}
-
-extension FileManager {
-    public enum URLRelationship : Int {
-        case contains
-        case same
-        case other
-    }
-}
-
-open class FileManager: NSObject {
-    public typealias FileAttributeKey = String
+open class FileManager : NSObject {
     
     /* Returns the default singleton instance.
     */
@@ -114,7 +60,7 @@ open class FileManager: NSObject {
     
     /* -URLsForDirectory:inDomains: is analogous to NSSearchPathForDirectoriesInDomains(), but returns an array of NSURL instances for use with URL-taking APIs. This API is suitable when you need to search for a file or files which may live in one of a variety of locations in the domains specified.
      */
-    open func urls(forDirectory directory: SearchPathDirectory, in domainMask: SearchPathDomainMask) -> [URL] {
+    open func urls(for directory: SearchPathDirectory, in domainMask: SearchPathDomainMask) -> [URL] {
         NSUnimplemented()
     }
     
@@ -122,25 +68,25 @@ open class FileManager: NSObject {
      
         You may pass only one of the values from the NSSearchPathDomainMask enumeration, and you may not pass NSAllDomainsMask.
      */
-    open func url(forDirectory directory: SearchPathDirectory, in domain: SearchPathDomainMask, appropriateFor url: URL?, create shouldCreate: Bool) throws -> URL {
+    open func url(for directory: SearchPathDirectory, in domain: SearchPathDomainMask, appropriateFor url: URL?, create shouldCreate: Bool) throws -> URL {
         NSUnimplemented()
     }
     
     /* Sets 'outRelationship' to NSURLRelationshipContains if the directory at 'directoryURL' directly or indirectly contains the item at 'otherURL', meaning 'directoryURL' is found while enumerating parent URLs starting from 'otherURL'. Sets 'outRelationship' to NSURLRelationshipSame if 'directoryURL' and 'otherURL' locate the same item, meaning they have the same NSURLFileResourceIdentifierKey value. If 'directoryURL' is not a directory, or does not contain 'otherURL' and they do not locate the same file, then sets 'outRelationship' to NSURLRelationshipOther. If an error occurs, returns NO and sets 'error'.
      */
-    open func getRelationship(_ outRelationship: UnsafeMutablePointer<URLRelationship>, ofDirectoryAtURL directoryURL: URL, toItemAtURL otherURL: URL) throws {
+    open func getRelationship(_ outRelationship: UnsafeMutablePointer<URLRelationship>, ofDirectoryAt directoryURL: URL, toItemAt otherURL: URL) throws {
         NSUnimplemented()
     }
     
     /* Similar to -[NSFileManager getRelationship:ofDirectoryAtURL:toItemAtURL:error:], except that the directory is instead defined by an NSSearchPathDirectory and NSSearchPathDomainMask. Pass 0 for domainMask to instruct the method to automatically choose the domain appropriate for 'url'. For example, to discover if a file is contained by a Trash directory, call [fileManager getRelationship:&result ofDirectory:NSTrashDirectory inDomain:0 toItemAtURL:url error:&error].
      */
-    open func getRelationship(_ outRelationship: UnsafeMutablePointer<URLRelationship>, ofDirectory directory: SearchPathDirectory, in domainMask: SearchPathDomainMask, toItemAtURL url: URL) throws {
+    open func getRelationship(_ outRelationship: UnsafeMutablePointer<URLRelationship>, of directory: SearchPathDirectory, in domainMask: SearchPathDomainMask, toItemAt url: URL) throws {
         NSUnimplemented()
     }
     
     /* createDirectoryAtURL:withIntermediateDirectories:attributes:error: creates a directory at the specified URL. If you pass 'NO' for withIntermediateDirectories, the directory must not exist at the time this call is made. Passing 'YES' for withIntermediateDirectories will create any necessary intermediate directories. This method returns YES if all directories specified in 'url' were created and attributes were set. Directories are created with attributes specified by the dictionary passed to 'attributes'. If no dictionary is supplied, directories are created according to the umask of the process. This method returns NO if a failure occurs at any stage of the operation. If an error parameter was provided, a presentable NSError will be returned by reference.
      */
-    open func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool, attributes: [String : Any]? = [:]) throws {
+    open func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey : Any]? = [:]) throws {
         guard url.isFileURL else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSCocoaError.FileWriteUnsupportedSchemeError.rawValue, userInfo: [NSURLErrorKey : url])
         }
@@ -171,8 +117,7 @@ open class FileManager: NSObject {
      */
     open func setAttributes(_ attributes: [FileAttributeKey : Any], ofItemAtPath path: String) throws {
         for attribute in attributes.keys {
-            switch attribute {
-            case NSFilePosixPermissions:
+            if attribute == .posixPermissions {
                 guard let number = attributes[attribute] as? NSNumber else {
                     fatalError("Can't set file permissions to \(attributes[attribute])")
                 }
@@ -184,7 +129,7 @@ open class FileManager: NSObject {
                 if chmod(path, modeT) != 0 {
                     fatalError("errno \(errno)")
                 }
-            default:
+            } else {
                 fatalError("Attribute type not implemented: \(attribute)")
             }
         }
@@ -194,7 +139,7 @@ open class FileManager: NSObject {
      
         This method replaces createDirectoryAtPath:attributes:
      */
-    open func createDirectory(atPath path: String, withIntermediateDirectories createIntermediates: Bool, attributes: [String : Any]? = [:]) throws {
+    open func createDirectory(atPath path: String, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey : Any]? = [:]) throws {
         if createIntermediates {
             var isDir: ObjCBool = false
             if !fileExists(atPath: path, isDirectory: &isDir) {
@@ -329,59 +274,59 @@ open class FileManager: NSObject {
         guard lstat(path, &s) == 0 else {
             throw _NSErrorWithErrno(errno, reading: true, path: path)
         }
-        var result = [String : Any]()
-        result[NSFileSize] = NSNumber(value: UInt64(s.st_size))
+        var result = [FileAttributeKey : Any]()
+        result[.size] = NSNumber(value: UInt64(s.st_size))
 
 #if os(OSX) || os(iOS)
         let ti = (TimeInterval(s.st_mtimespec.tv_sec) - kCFAbsoluteTimeIntervalSince1970) + (1.0e-9 * TimeInterval(s.st_mtimespec.tv_nsec))
 #else
         let ti = (TimeInterval(s.st_mtim.tv_sec) - kCFAbsoluteTimeIntervalSince1970) + (1.0e-9 * TimeInterval(s.st_mtim.tv_nsec))
 #endif
-        result[NSFileModificationDate] = Date(timeIntervalSinceReferenceDate: ti)
+        result[.modificationDate] = Date(timeIntervalSinceReferenceDate: ti)
         
-        result[NSFilePosixPermissions] = NSNumber(value: UInt64(s.st_mode & 0o7777))
-        result[NSFileReferenceCount] = NSNumber(value: UInt64(s.st_nlink))
-        result[NSFileSystemNumber] = NSNumber(value: UInt64(s.st_dev))
-        result[NSFileSystemFileNumber] = NSNumber(value: UInt64(s.st_ino))
+        result[.posixPermissions] = NSNumber(value: UInt64(s.st_mode & 0o7777))
+        result[.referenceCount] = NSNumber(value: UInt64(s.st_nlink))
+        result[.systemNumber] = NSNumber(value: UInt64(s.st_dev))
+        result[.systemFileNumber] = NSNumber(value: UInt64(s.st_ino))
         
         let pwd = getpwuid(s.st_uid)
         if pwd != nil && pwd!.pointee.pw_name != nil {
             let name = String(cString: pwd!.pointee.pw_name)
-            result[NSFileOwnerAccountName] = name
+            result[.ownerAccountName] = name
         }
         
         let grd = getgrgid(s.st_gid)
         if grd != nil && grd!.pointee.gr_name != nil {
             let name = String(cString: grd!.pointee.gr_name)
-            result[NSFileGroupOwnerAccountID] = name
+            result[.groupOwnerAccountID] = name
         }
 
-        var type : String
+        var type : FileAttributeType
         switch s.st_mode & S_IFMT {
-            case S_IFCHR: type = NSFileTypeCharacterSpecial
-            case S_IFDIR: type = NSFileTypeDirectory
-            case S_IFBLK: type = NSFileTypeBlockSpecial
-            case S_IFREG: type = NSFileTypeRegular
-            case S_IFLNK: type = NSFileTypeSymbolicLink
-            case S_IFSOCK: type = NSFileTypeSocket
-            default: type = NSFileTypeUnknown
+            case S_IFCHR: type = .typeCharacterSpecial
+            case S_IFDIR: type = .typeDirectory
+            case S_IFBLK: type = .typeBlockSpecial
+            case S_IFREG: type = .typeRegular
+            case S_IFLNK: type = .typeSymbolicLink
+            case S_IFSOCK: type = .typeSocket
+            default: type = .typeUnknown
         }
-        result[NSFileType] = type
+        result[.type] = type
         
-        if type == NSFileTypeBlockSpecial || type == NSFileTypeCharacterSpecial {
-            result[NSFileDeviceIdentifier] = NSNumber(value: UInt64(s.st_rdev))
+        if type == .typeBlockSpecial || type == .typeCharacterSpecial {
+            result[.deviceIdentifier] = NSNumber(value: UInt64(s.st_rdev))
         }
 
 #if os(OSX) || os(iOS)
         if (s.st_flags & UInt32(UF_IMMUTABLE | SF_IMMUTABLE)) != 0 {
-            result[NSFileImmutable] = NSNumber(value: true)
+            result[.immutable] = NSNumber(value: true)
         }
         if (s.st_flags & UInt32(UF_APPEND | SF_APPEND)) != 0 {
-            result[NSFileAppendOnly] = NSNumber(value: true)
+            result[.appendOnly] = NSNumber(value: true)
         }
 #endif
-        result[NSFileOwnerAccountID] = NSNumber(value: UInt64(s.st_uid))
-        result[NSFileGroupOwnerAccountID] = NSNumber(value: UInt64(s.st_gid))
+        result[.ownerAccountID] = NSNumber(value: UInt64(s.st_uid))
+        result[.groupOwnerAccountID] = NSNumber(value: UInt64(s.st_gid))
         
         return result
     }
@@ -631,7 +576,7 @@ open class FileManager: NSObject {
     
         If you wish to only receive the URLs and no other attributes, then pass '0' for 'options' and an empty NSArray ('[NSArray array]') for 'keys'. If you wish to have the property caches of the vended URLs pre-populated with a default set of attributes, then pass '0' for 'options' and 'nil' for 'keys'.
      */
-    open func enumerator(at url: URL, includingPropertiesForKeys keys: [URLResourceKey]?, options mask: DirectoryEnumerationOptions = [], errorHandler handler: ((URL, Error) -> Bool)? = nil) -> DirectoryEnumerator? {
+    open func enumerator(at url: URL, includingPropertiesForKeys keys: [URLResourceKey]?, options mask: DirectoryEnumerationOptions = [], errorHandler handler: (@escaping (URL, Error) -> Bool)? = nil) -> DirectoryEnumerator? {
         if mask.contains(.skipsPackageDescendants) || mask.contains(.skipsHiddenFiles) {
             NSUnimplemented("Enumeration options not yet implemented")
         }
@@ -699,7 +644,7 @@ open class FileManager: NSObject {
     
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    open func replaceItem(at originalItemURL: URL, withItemAt newItemURL: URL, backupItemName: String?, options: NSFileManagerItemReplacementOptions = []) throws {
+    open func replaceItem(at originalItemURL: URL, withItemAt newItemURL: URL, backupItemName: String?, options: ItemReplacementOptions = []) throws {
         NSUnimplemented()
     }
     
@@ -727,82 +672,225 @@ open class FileManager: NSObject {
     internal func _pathIsSymbolicLink(_ path: String) -> Bool {
         guard
             let attrs = try? attributesOfItem(atPath: path),
-            let fileType = attrs[NSFileType] as? String
+            let fileType = attrs[.type] as? FileAttributeType
         else {
             return false
         }
-        return fileType == NSFileTypeSymbolicLink
+        return fileType == .typeSymbolicLink
     }
 }
 
-extension FileManagerDelegate {
-    func fileManager(_ fileManager: FileManager, shouldCopyItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return true }
-    func fileManager(_ fileManager: FileManager, shouldCopyItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool { return true }
-    
-    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: NSError, copyingItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return false }
-    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: NSError, copyingItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool { return false }
-
-    func fileManager(_ fileManager: FileManager, shouldMoveItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return true }
-    func fileManager(_ fileManager: FileManager, shouldMoveItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool { return true }
-    
-    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: NSError, movingItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return false }
-    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: NSError, movingItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool { return false }
-    
-    func fileManager(_ fileManager: FileManager, shouldLinkItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return true }
-    func fileManager(_ fileManager: FileManager, shouldLinkItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool { return true }
-    
-    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: NSError, linkingItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return false }
-    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: NSError, linkingItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool { return false }
-    
-    func fileManager(_ fileManager: FileManager, shouldRemoveItemAtPath path: String) -> Bool { return true }
-    func fileManager(_ fileManager: FileManager, shouldRemoveItemAtURL url: URL) -> Bool { return true }
-    
-    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: NSError, removingItemAtPath path: String) -> Bool { return false }
-    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: NSError, removingItemAtURL url: URL) -> Bool { return false }
+extension FileManager {
+    public func replaceItemAt(_ originalItemURL: URL, withItemAt newItemURL: URL, backupItemName: String? = nil, options: ItemReplacementOptions = []) throws -> NSURL? {
+        NSUnimplemented()
+    }
 }
 
-public protocol FileManagerDelegate : class {
+extension FileManager {
+    open var homeDirectoryForCurrentUser: URL { NSUnimplemented() }
+    open var temporaryDirectory: URL { NSUnimplemented() }
+    open func homeDirectory(forUser userName: String) -> URL? { NSUnimplemented() }
+}
+
+extension FileManager {
+    public struct VolumeEnumerationOptions : OptionSet {
+        public let rawValue : UInt
+        public init(rawValue: UInt) { self.rawValue = rawValue }
+
+        /* The mounted volume enumeration will skip hidden volumes.
+         */
+        public static let skipHiddenVolumes = VolumeEnumerationOptions(rawValue: 1 << 1)
+
+        /* The mounted volume enumeration will produce file reference URLs rather than path-based URLs.
+         */
+        public static let produceFileReferenceURLs = VolumeEnumerationOptions(rawValue: 1 << 2)
+    }
+    
+    public struct DirectoryEnumerationOptions : OptionSet {
+        public let rawValue : UInt
+        public init(rawValue: UInt) { self.rawValue = rawValue }
+
+        /* NSDirectoryEnumerationSkipsSubdirectoryDescendants causes the NSDirectoryEnumerator to perform a shallow enumeration and not descend into directories it encounters.
+         */
+        public static let skipsSubdirectoryDescendants = DirectoryEnumerationOptions(rawValue: 1 << 0)
+
+        /* NSDirectoryEnumerationSkipsPackageDescendants will cause the NSDirectoryEnumerator to not descend into packages.
+         */
+        public static let skipsPackageDescendants = DirectoryEnumerationOptions(rawValue: 1 << 1)
+
+        /* NSDirectoryEnumerationSkipsHiddenFiles causes the NSDirectoryEnumerator to not enumerate hidden files.
+         */
+        public static let skipsHiddenFiles = DirectoryEnumerationOptions(rawValue: 1 << 2)
+    }
+
+    public struct ItemReplacementOptions : OptionSet {
+        public let rawValue : UInt
+        public init(rawValue: UInt) { self.rawValue = rawValue }
+
+        /* Causes -replaceItemAtURL:withItemAtURL:backupItemName:options:resultingItemURL:error: to use metadata from the new item only and not to attempt to preserve metadata from the original item.
+         */
+        public static let usingNewMetadataOnly = ItemReplacementOptions(rawValue: 1 << 0)
+
+        /* Causes -replaceItemAtURL:withItemAtURL:backupItemName:options:resultingItemURL:error: to leave the backup item in place after a successful replacement. The default behavior is to remove the item.
+         */
+        public static let withoutDeletingBackupItem = ItemReplacementOptions(rawValue: 1 << 1)
+    }
+
+    public enum URLRelationship : Int {
+        case contains
+        case same
+        case other
+    }
+}
+
+public struct FileAttributeKey : RawRepresentable, Equatable, Hashable, Comparable {
+    public let rawValue: String
+    
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+    
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+    
+    public var hashValue: Int {
+        return self.rawValue.hashValue
+    }
+    
+    public static func ==(_ lhs: FileAttributeKey, _ rhs: FileAttributeKey) -> Bool {
+        return lhs.rawValue == rhs.rawValue
+    }
+    
+    public static func <(_ lhs: FileAttributeKey, _ rhs: FileAttributeKey) -> Bool {
+        return lhs.rawValue < rhs.rawValue
+    }
+
+    public static let type = FileAttributeKey(rawValue: "NSFileType")
+    public static let size = FileAttributeKey(rawValue: "NSFileSize")
+    public static let modificationDate = FileAttributeKey(rawValue: "NSFileModificationDate")
+    public static let referenceCount = FileAttributeKey(rawValue: "NSFileReferenceCount")
+    public static let deviceIdentifier = FileAttributeKey(rawValue: "NSFileDeviceIdentifier")
+    public static let ownerAccountName = FileAttributeKey(rawValue: "NSFileOwnerAccountName")
+    public static let groupOwnerAccountName = FileAttributeKey(rawValue: "NSFileGroupOwnerAccountName")
+    public static let posixPermissions = FileAttributeKey(rawValue: "NSFilePosixPermissions")
+    public static let systemNumber = FileAttributeKey(rawValue: "NSFileSystemNumber")
+    public static let systemFileNumber = FileAttributeKey(rawValue: "NSFileSystemFileNumber")
+    public static let extensionHidden = FileAttributeKey(rawValue: "") // NSUnimplemented
+    public static let hfsCreatorCode = FileAttributeKey(rawValue: "") // NSUnimplemented
+    public static let hfsTypeCode = FileAttributeKey(rawValue: "") // NSUnimplemented
+    public static let immutable = FileAttributeKey(rawValue: "NSFileImmutable")
+    public static let appendOnly = FileAttributeKey(rawValue: "NSFileAppendOnly")
+    public static let creationDate = FileAttributeKey(rawValue: "") // NSUnimplemented
+    public static let ownerAccountID = FileAttributeKey(rawValue: "NSFileOwnerAccountID")
+    public static let groupOwnerAccountID = FileAttributeKey(rawValue: "NSFileGroupOwnerAccountID")
+    public static let busy = FileAttributeKey(rawValue: "") // NSUnimplemented
+    public static let systemSize = FileAttributeKey(rawValue: "") // NSUnimplemented
+    public static let systemFreeSize = FileAttributeKey(rawValue: "") // NSUnimplemented
+    public static let systemNodes = FileAttributeKey(rawValue: "") // NSUnimplemented
+    public static let systemFreeNodes = FileAttributeKey(rawValue: "") // NSUnimplemented
+}
+
+public struct FileAttributeType : RawRepresentable, Equatable, Hashable, Comparable {
+    public let rawValue: String
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var hashValue: Int {
+        return self.rawValue.hashValue
+    }
+
+    public static func ==(_ lhs: FileAttributeType, _ rhs: FileAttributeType) -> Bool {
+        return lhs.rawValue == rhs.rawValue
+    }
+
+    public static func <(_ lhs: FileAttributeType, _ rhs: FileAttributeType) -> Bool {
+        return lhs.rawValue < rhs.rawValue
+    }
+
+    public static let typeDirectory = FileAttributeType(rawValue: "NSFileTypeDirectory")
+    public static let typeRegular = FileAttributeType(rawValue: "NSFileTypeRegular")
+    public static let typeSymbolicLink = FileAttributeType(rawValue: "NSFileTypeSymbolicLink")
+    public static let typeSocket = FileAttributeType(rawValue: "NSFileTypeSocket")
+    public static let typeCharacterSpecial = FileAttributeType(rawValue: "NSFileTypeCharacterSpecial")
+    public static let typeBlockSpecial = FileAttributeType(rawValue: "NSFileTypeBlockSpecial")
+    public static let typeUnknown = FileAttributeType(rawValue: "NSFileTypeUnknown")
+}
+
+public protocol FileManagerDelegate : NSObjectProtocol {
     
     /* fileManager:shouldCopyItemAtPath:toPath: gives the delegate an opportunity to filter the resulting copy. Returning YES from this method will allow the copy to happen. Returning NO from this method causes the item in question to be skipped. If the item skipped was a directory, no children of that directory will be copied, nor will the delegate be notified of those children.
      */
     func fileManager(_ fileManager: FileManager, shouldCopyItemAtPath srcPath: String, toPath dstPath: String) -> Bool
-    func fileManager(_ fileManager: FileManager, shouldCopyItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldCopyItemAt srcURL: URL, to dstURL: URL) -> Bool
     
     /* fileManager:shouldProceedAfterError:copyingItemAtPath:toPath: gives the delegate an opportunity to recover from or continue copying after an error. If an error occurs, the error object will contain an NSError indicating the problem. The source path and destination paths are also provided. If this method returns YES, the NSFileManager instance will continue as if the error had not occurred. If this method returns NO, the NSFileManager instance will stop copying, return NO from copyItemAtPath:toPath:error: and the error will be provied there.
      */
-    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: NSError, copyingItemAtPath srcPath: String, toPath dstPath: String) -> Bool
-    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: NSError, copyingItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, copyingItemAtPath srcPath: String, toPath dstPath: String) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, copyingItemAt srcURL: URL, to dstURL: URL) -> Bool
     
     /* fileManager:shouldMoveItemAtPath:toPath: gives the delegate an opportunity to not move the item at the specified path. If the source path and the destination path are not on the same device, a copy is performed to the destination path and the original is removed. If the copy does not succeed, an error is returned and the incomplete copy is removed, leaving the original in place.
     
      */
     func fileManager(_ fileManager: FileManager, shouldMoveItemAtPath srcPath: String, toPath dstPath: String) -> Bool
-    func fileManager(_ fileManager: FileManager, shouldMoveItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldMoveItemAt srcURL: URL, to dstURL: URL) -> Bool
     
     /* fileManager:shouldProceedAfterError:movingItemAtPath:toPath: functions much like fileManager:shouldProceedAfterError:copyingItemAtPath:toPath: above. The delegate has the opportunity to remedy the error condition and allow the move to continue.
      */
-    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: NSError, movingItemAtPath srcPath: String, toPath dstPath: String) -> Bool
-    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: NSError, movingItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, movingItemAtPath srcPath: String, toPath dstPath: String) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, movingItemAt srcURL: URL, to dstURL: URL) -> Bool
     
     /* fileManager:shouldLinkItemAtPath:toPath: acts as the other "should" methods, but this applies to the file manager creating hard links to the files in question.
      */
     func fileManager(_ fileManager: FileManager, shouldLinkItemAtPath srcPath: String, toPath dstPath: String) -> Bool
-    func fileManager(_ fileManager: FileManager, shouldLinkItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldLinkItemAt srcURL: URL, to dstURL: URL) -> Bool
     
     /* fileManager:shouldProceedAfterError:linkingItemAtPath:toPath: allows the delegate an opportunity to remedy the error which occurred in linking srcPath to dstPath. If the delegate returns YES from this method, the linking will continue. If the delegate returns NO from this method, the linking operation will stop and the error will be returned via linkItemAtPath:toPath:error:.
      */
-    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: NSError, linkingItemAtPath srcPath: String, toPath dstPath: String) -> Bool
-    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: NSError, linkingItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, linkingItemAtPath srcPath: String, toPath dstPath: String) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, linkingItemAt srcURL: URL, to dstURL: URL) -> Bool
     
     /* fileManager:shouldRemoveItemAtPath: allows the delegate the opportunity to not remove the item at path. If the delegate returns YES from this method, the NSFileManager instance will attempt to remove the item. If the delegate returns NO from this method, the remove skips the item. If the item is a directory, no children of that item will be visited.
      */
     func fileManager(_ fileManager: FileManager, shouldRemoveItemAtPath path: String) -> Bool
-    func fileManager(_ fileManager: FileManager, shouldRemoveItemAtURL URL: URL) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldRemoveItemAt URL: URL) -> Bool
     
     /* fileManager:shouldProceedAfterError:removingItemAtPath: allows the delegate an opportunity to remedy the error which occurred in removing the item at the path provided. If the delegate returns YES from this method, the removal operation will continue. If the delegate returns NO from this method, the removal operation will stop and the error will be returned via linkItemAtPath:toPath:error:.
      */
-    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: NSError, removingItemAtPath path: String) -> Bool
-    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: NSError, removingItemAtURL URL: URL) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, removingItemAtPath path: String) -> Bool
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, removingItemAt URL: URL) -> Bool
+}
+
+extension FileManagerDelegate {
+    func fileManager(_ fileManager: FileManager, shouldCopyItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return true }
+    func fileManager(_ fileManager: FileManager, shouldCopyItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool { return true }
+
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, copyingItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return false }
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, copyingItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool { return false }
+
+    func fileManager(_ fileManager: FileManager, shouldMoveItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return true }
+    func fileManager(_ fileManager: FileManager, shouldMoveItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool { return true }
+
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, movingItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return false }
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, movingItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool { return false }
+
+    func fileManager(_ fileManager: FileManager, shouldLinkItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return true }
+    func fileManager(_ fileManager: FileManager, shouldLinkItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool { return true }
+
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, linkingItemAtPath srcPath: String, toPath dstPath: String) -> Bool { return false }
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, linkingItemAtURL srcURL: URL, toURL dstURL: URL) -> Bool { return false }
+
+    func fileManager(_ fileManager: FileManager, shouldRemoveItemAtPath path: String) -> Bool { return true }
+    func fileManager(_ fileManager: FileManager, shouldRemoveItemAtURL url: URL) -> Bool { return true }
+
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, removingItemAtPath path: String) -> Bool { return false }
+    func fileManager(_ fileManager: FileManager, shouldProceedAfterError error: Error, removingItemAtURL url: URL) -> Bool { return false }
 }
 
 extension FileManager {
@@ -810,10 +898,10 @@ extension FileManager {
         
         /* For NSDirectoryEnumerators created with -enumeratorAtPath:, the -fileAttributes and -directoryAttributes methods return an NSDictionary containing the keys listed below. For NSDirectoryEnumerators created with -enumeratorAtURL:includingPropertiesForKeys:options:errorHandler:, these two methods return nil.
          */
-        open var fileAttributes: [String : AnyObject]? {
+        open var fileAttributes: [FileAttributeKey : Any]? {
             NSRequiresConcreteImplementation()
         }
-        open var directoryAttributes: [String : AnyObject]? {
+        open var directoryAttributes: [FileAttributeKey : Any]? {
             NSRequiresConcreteImplementation()
         }
         
@@ -831,10 +919,10 @@ extension FileManager {
     internal class NSPathDirectoryEnumerator: DirectoryEnumerator {
         let baseURL: URL
         let innerEnumerator : DirectoryEnumerator
-        override var fileAttributes: [String : AnyObject]? {
+        override var fileAttributes: [FileAttributeKey : Any]? {
             NSUnimplemented()
         }
-        override var directoryAttributes: [String : AnyObject]? {
+        override var directoryAttributes: [FileAttributeKey : Any]? {
             NSUnimplemented()
         }
         
@@ -950,11 +1038,11 @@ extension FileManager {
             return nil
         }
         
-        override var directoryAttributes : [String : AnyObject]? {
+        override var directoryAttributes : [FileAttributeKey : Any]? {
             return nil
         }
         
-        override var fileAttributes: [String : AnyObject]? {
+        override var fileAttributes: [FileAttributeKey : Any]? {
             return nil
         }
         
@@ -969,35 +1057,3 @@ extension FileManager {
         }
     }
 }
-
-public let NSFileType: String = "NSFileType"
-public let NSFileTypeDirectory: String = "NSFileTypeDirectory"
-public let NSFileTypeRegular: String = "NSFileTypeRegular"
-public let NSFileTypeSymbolicLink: String = "NSFileTypeSymbolicLink"
-public let NSFileTypeSocket: String = "NSFileTypeSocket"
-public let NSFileTypeCharacterSpecial: String = "NSFileTypeCharacterSpecial"
-public let NSFileTypeBlockSpecial: String = "NSFileTypeBlockSpecial"
-public let NSFileTypeUnknown: String = "NSFileTypeUnknown"
-public let NSFileSize: String = "NSFileSize"
-public let NSFileModificationDate: String = "NSFileModificationDate"
-public let NSFileReferenceCount: String = "NSFileReferenceCount"
-public let NSFileDeviceIdentifier: String = "NSFileDeviceIdentifier"
-public let NSFileOwnerAccountName: String = "NSFileOwnerAccountName"
-public let NSFileGroupOwnerAccountName: String = "NSFileGroupOwnerAccountName"
-public let NSFilePosixPermissions: String = "NSFilePosixPermissions"
-public let NSFileSystemNumber: String = "NSFileSystemNumber"
-public let NSFileSystemFileNumber: String = "NSFileSystemFileNumber"
-public let NSFileExtensionHidden: String = "" // NSUnimplemented
-public let NSFileHFSCreatorCode: String = "" // NSUnimplemented
-public let NSFileHFSTypeCode: String = "" // NSUnimplemented
-public let NSFileImmutable: String = "NSFileImmutable"
-public let NSFileAppendOnly: String = "NSFileAppendOnly"
-public let NSFileCreationDate: String = "" // NSUnimplemented
-public let NSFileOwnerAccountID: String = "NSFileOwnerAccountID"
-public let NSFileGroupOwnerAccountID: String = "NSFileGroupOwnerAccountID"
-public let NSFileBusy: String = "" // NSUnimplemented
-
-public let NSFileSystemSize: String = "" // NSUnimplemented
-public let NSFileSystemFreeSize: String = "" // NSUnimplemented
-public let NSFileSystemNodes: String = "" // NSUnimplemented
-public let NSFileSystemFreeNodes: String = "" // NSUnimplemented

--- a/Foundation/NSMeasurementFormatter.swift
+++ b/Foundation/NSMeasurementFormatter.swift
@@ -77,3 +77,7 @@ open class MeasurementFormatter : Formatter, NSSecureCoding {
     open override func encode(with aCoder: NSCoder) { NSUnimplemented() }
     public static var supportsSecureCoding: Bool { return true }
 }
+
+extension MeasurementFormatter {
+    public func string<UnitType : Unit>(from measurement: Measurement<UnitType>) -> String { NSUnimplemented() }
+}

--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -7,7 +7,15 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-extension NSNotification {
+public func ==(lhs: NSNotification.Name, rhs: NSNotification.Name) -> Bool {
+    return lhs.rawValue == rhs.rawValue
+}
+
+public func <(lhs: NSNotification.Name, rhs: NSNotification.Name) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+}
+
+open class NSNotification: NSObject, NSCopying, NSCoding {
     public struct Name : RawRepresentable, Equatable, Hashable, Comparable {
         public private(set) var rawValue: String
         public init(rawValue: String) {
@@ -18,17 +26,7 @@ extension NSNotification {
             return self.rawValue.hashValue
         }
     }
-}
 
-public func ==(lhs: NSNotification.Name, rhs: NSNotification.Name) -> Bool {
-    return lhs.rawValue == rhs.rawValue
-}
-
-public func <(lhs: NSNotification.Name, rhs: NSNotification.Name) -> Bool {
-    return lhs.rawValue < rhs.rawValue
-}
-
-open class NSNotification: NSObject, NSCopying, NSCoding {
     private(set) open var name: Name
     
     private(set) open var object: Any?

--- a/Foundation/NSNumberFormatter.swift
+++ b/Foundation/NSNumberFormatter.swift
@@ -22,6 +22,38 @@ internal let kCFNumberFormatterCurrencyPluralStyle = CFNumberFormatterStyle.curr
 internal let kCFNumberFormatterCurrencyAccountingStyle = CFNumberFormatterStyle.currencyAccountingStyle
 #endif
 
+extension NumberFormatter {
+    public enum Style : UInt {
+        case none
+        case decimal
+        case currency
+        case percent
+        case scientific
+        case spellOut
+        case ordinal
+        case currencyISOCode
+        case currencyPlural
+        case currencyAccounting
+    }
+
+    public enum PadPosition : UInt {
+        case beforePrefix
+        case afterPrefix
+        case beforeSuffix
+        case afterSuffix
+    }
+
+    public enum RoundingMode : UInt {
+        case ceiling
+        case floor
+        case down
+        case up
+        case halfEven
+        case halfDown
+        case halfUp
+    }
+}
+
 open class NumberFormatter : Formatter {
     
     typealias CFType = CFNumberFormatter
@@ -50,7 +82,7 @@ open class NumberFormatter : Formatter {
     // Report the used range of the string and an NSError, in addition to the usual stuff from NSFormatter
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    open func objectValue(_ string: String, range: inout NSRange) throws -> AnyObject? { NSUnimplemented() }
+    open func objectValue(_ string: String, range: inout NSRange) throws -> Any? { NSUnimplemented() }
     
     open override func string(for obj: Any) -> String? {
         guard let number = obj as? NSNumber else { return nil }
@@ -139,7 +171,7 @@ open class NumberFormatter : Formatter {
     }
     
     // Attributes of an NSNumberFormatter
-    internal var _numberStyle: Style = .noStyle
+    internal var _numberStyle: Style = .none
     open var numberStyle: Style {
         get {
             return _numberStyle
@@ -147,10 +179,10 @@ open class NumberFormatter : Formatter {
         
         set {
             switch newValue {
-            case .noStyle, .ordinalStyle, .spellOutStyle:
+            case .none, .ordinal, .spellOut:
                 _usesSignificantDigits = false
                 
-            case .currencyStyle, .currencyPluralStyle, .currencyISOCodeStyle, .currencyAccountingStyle:
+            case .currency, .currencyPlural, .currencyISOCode, .currencyAccounting:
                 _usesSignificantDigits = false
                 _usesGroupingSeparator = true
                 _minimumFractionDigits = 2
@@ -197,8 +229,8 @@ open class NumberFormatter : Formatter {
         }
     }
     
-    internal var _textAttributesForNegativeValues: [String : AnyObject]?
-    open var textAttributesForNegativeValues: [String : AnyObject]? {
+    internal var _textAttributesForNegativeValues: [String : Any]?
+    open var textAttributesForNegativeValues: [String : Any]? {
         get {
             return _textAttributesForNegativeValues
         }
@@ -219,8 +251,8 @@ open class NumberFormatter : Formatter {
         }
     }
     
-    internal var _textAttributesForPositiveValues: [String : AnyObject]?
-    open var textAttributesForPositiveValues: [String : AnyObject]? {
+    internal var _textAttributesForPositiveValues: [String : Any]?
+    open var textAttributesForPositiveValues: [String : Any]? {
         get {
             return _textAttributesForPositiveValues
         }
@@ -309,8 +341,8 @@ open class NumberFormatter : Formatter {
         }
     }
     
-    internal var _textAttributesForZero: [String : AnyObject]?
-    open var textAttributesForZero: [String : AnyObject]? {
+    internal var _textAttributesForZero: [String : Any]?
+    open var textAttributesForZero: [String : Any]? {
         get {
             return _textAttributesForZero
         }
@@ -331,8 +363,8 @@ open class NumberFormatter : Formatter {
         }
     }
     
-    internal var _textAttributesForNil: [String : AnyObject]?
-    open var textAttributesForNil: [String : AnyObject]? {
+    internal var _textAttributesForNil: [String : Any]?
+    open var textAttributesForNil: [String : Any]? {
         get {
             return _textAttributesForNil
         }
@@ -353,8 +385,8 @@ open class NumberFormatter : Formatter {
         }
     }
     
-    internal var _textAttributesForNotANumber: [String : AnyObject]?
-    open var textAttributesForNotANumber: [String : AnyObject]? {
+    internal var _textAttributesForNotANumber: [String : Any]?
+    open var textAttributesForNotANumber: [String : Any]? {
         get {
             return _textAttributesForNotANumber
         }
@@ -365,7 +397,7 @@ open class NumberFormatter : Formatter {
     }
     
     internal var _positiveInfinitySymbol: String = "+∞"
-    public var positiveInfinitySymbol: String {
+    open var positiveInfinitySymbol: String {
         get {
             return _positiveInfinitySymbol
         }
@@ -375,8 +407,8 @@ open class NumberFormatter : Formatter {
         }
     }
     
-    internal var _textAttributesForPositiveInfinity: [String : AnyObject]?
-    public var textAttributesForPositiveInfinity: [String : AnyObject]? {
+    internal var _textAttributesForPositiveInfinity: [String : Any]?
+    open var textAttributesForPositiveInfinity: [String : Any]? {
         get {
             return _textAttributesForPositiveInfinity
         }
@@ -387,7 +419,7 @@ open class NumberFormatter : Formatter {
     }
     
     internal var _negativeInfinitySymbol: String = "-∞"
-    public var negativeInfinitySymbol: String {
+    open var negativeInfinitySymbol: String {
         get {
             return _negativeInfinitySymbol
         }
@@ -397,8 +429,8 @@ open class NumberFormatter : Formatter {
         }
     }
     
-    internal var _textAttributesForNegativeInfinity: [String : AnyObject]?
-    public var textAttributesForNegativeInfinity: [String : AnyObject]? {
+    internal var _textAttributesForNegativeInfinity: [String : Any]?
+    open var textAttributesForNegativeInfinity: [String : Any]? {
         get {
             return _textAttributesForNegativeInfinity
         }
@@ -531,7 +563,7 @@ open class NumberFormatter : Formatter {
         }
     }
     
-    open var _exponentSymbol: String!
+    internal var _exponentSymbol: String!
     open var exponentSymbol: String! {
         get {
             return _exponentSymbol
@@ -612,7 +644,7 @@ open class NumberFormatter : Formatter {
         }
     }
     
-    internal var _roundingMode: RoundingMode = .roundHalfEven
+    internal var _roundingMode: RoundingMode = .halfEven
     open var roundingMode: RoundingMode {
         get {
             return _roundingMode
@@ -712,7 +744,7 @@ open class NumberFormatter : Formatter {
     }
     
     internal var _lenient: Bool = false
-    open var lenient: Bool {
+    open var isLenient: Bool {
         get {
             return _lenient
         }
@@ -756,7 +788,7 @@ open class NumberFormatter : Formatter {
     }
     
     internal var _partialStringValidationEnabled: Bool = false
-    open var partialStringValidationEnabled: Bool {
+    open var isPartialStringValidationEnabled: Bool {
         get {
             return _partialStringValidationEnabled
         }
@@ -818,45 +850,42 @@ open class NumberFormatter : Formatter {
     
     //
     
-    //FIXME: Uncomment these when NSAttributedString get rid of NSUnimplementend(), 
-    // this is currently commented out so that NSNumberFormatter instances can be tested
+    internal var _attributedStringForZero: NSAttributedString = NSAttributedString(string: "0")
+    /*@NSCopying*/ open var attributedStringForZero: NSAttributedString {
+        get {
+            return _attributedStringForZero
+        }
+        set {
+            _reset()
+            _attributedStringForZero = newValue
+        }
+    }
     
-//    internal var _attributedStringForZero: NSAttributedString = NSAttributedString(string: "0")
-//    /*@NSCopying*/ open var attributedStringForZero: NSAttributedString {
-//        get {
-//            return _attributedStringForZero
-//        }
-//        set {
-//            _reset()
-//            _attributedStringForZero = newValue
-//        }
-//    }
-//    
-//    internal var _attributedStringForNil: NSAttributedString = NSAttributedString(string: "")
-//    /*@NSCopying*/ open var attributedStringForNil: NSAttributedString {
-//        get {
-//            return _attributedStringForNil
-//        }
-//        set {
-//            _reset()
-//            _attributedStringForNil = newValue
-//        }
-//    }
-//    
-//    internal var _attributedStringForNotANumber: NSAttributedString = NSAttributedString(string: "NaN")
-//    /*@NSCopying*/ open var attributedStringForNotANumber: NSAttributedString {
-//        get {
-//            return _attributedStringForNotANumber
-//        }
-//        set {
-//            _reset()
-//            _attributedStringForNotANumber = newValue
-//        }
-//    }
+    internal var _attributedStringForNil: NSAttributedString = NSAttributedString(string: "")
+    /*@NSCopying*/ open var attributedStringForNil: NSAttributedString {
+        get {
+            return _attributedStringForNil
+        }
+        set {
+            _reset()
+            _attributedStringForNil = newValue
+        }
+    }
     
-    //
+    internal var _attributedStringForNotANumber: NSAttributedString = NSAttributedString(string: "NaN")
+    /*@NSCopying*/ open var attributedStringForNotANumber: NSAttributedString {
+        get {
+            return _attributedStringForNotANumber
+        }
+        set {
+            _reset()
+            _attributedStringForNotANumber = newValue
+        }
+    }
     
-//    internal var _roundingBehavior: NSDecimalNumberHandler = .defaultDecimalNumberHandler()
+    // FIXME: Uncomment this when NSDecimalNumberHandler.default() gets rid of NSUnimplementend()
+    // This is currently commented out so that NSNumberFormatter instances can be tested
+//    internal var _roundingBehavior: NSDecimalNumberHandler = NSDecimalNumberHandler.default()
 //    /*@NSCopying*/ open var roundingBehavior: NSDecimalNumberHandler {
 //        get {
 //            return _roundingBehavior
@@ -866,36 +895,4 @@ open class NumberFormatter : Formatter {
 //            _roundingBehavior = newValue
 //        }
 //    }
-}
-
-extension NumberFormatter {
-    public enum Style : UInt {
-        case noStyle
-        case decimalStyle
-        case currencyStyle
-        case percentStyle
-        case scientificStyle
-        case spellOutStyle
-        case ordinalStyle
-        case currencyISOCodeStyle
-        case currencyPluralStyle
-        case currencyAccountingStyle
-    }
-
-    public enum PadPosition : UInt {
-        case beforePrefix
-        case afterPrefix
-        case beforeSuffix
-        case afterSuffix
-    }
-
-    public enum RoundingMode : UInt {
-        case roundCeiling
-        case roundFloor
-        case roundDown
-        case roundUp
-        case roundHalfEven
-        case roundHalfDown
-        case roundHalfUp
-    }
 }

--- a/Foundation/NSPersonNameComponents.swift
+++ b/Foundation/NSPersonNameComponents.swift
@@ -86,3 +86,10 @@ open class NSPersonNameComponents : NSObject, NSCopying, NSSecureCoding {
     /*@NSCopying*/ open var phoneticRepresentation: PersonNameComponents?
 }
 
+extension NSPersonNameComponents : _StructTypeBridgeable {
+    public typealias _StructType = PersonNameComponents
+
+    public func _bridgeToSwift() -> _StructType {
+        return PersonNameComponents._unconditionallyBridgeFromObjectiveC(self)
+    }
+}

--- a/Foundation/NSPersonNameComponentsFormatter.swift
+++ b/Foundation/NSPersonNameComponentsFormatter.swift
@@ -51,7 +51,7 @@ open class PersonNameComponentsFormatter : Formatter {
     
     /* Specify that the formatter should only format the components object's phoneticRepresentation
      */
-    open var phonetic: Bool
+    open var isPhonetic: Bool
     
     /* Shortcut for converting an NSPersonNameComponents object into a string without explicitly creating an instance.
         Create an instance for greater customizability.

--- a/Foundation/NSPredicate.swift
+++ b/Foundation/NSPredicate.swift
@@ -10,7 +10,7 @@
 
 // Predicates wrap some combination of expressions and operators and when evaluated return a BOOL.
 
-open class Predicate : NSObject, NSSecureCoding, NSCopying {
+open class NSPredicate : NSObject, NSSecureCoding, NSCopying {
 
     private enum PredicateKind {
         case boolean(Bool)
@@ -44,6 +44,8 @@ open class Predicate : NSObject, NSSecureCoding, NSCopying {
     // Parse predicateFormat and return an appropriate predicate
     public init(format predicateFormat: String, argumentArray arguments: [Any]?) { NSUnimplemented() }
     
+    public init(format predicateFormat: String, arguments argList: CVaListPointer) { NSUnimplemented() }
+
     public init?(fromMetadataQueryString queryString: String) { NSUnimplemented() }
     
     public init(value: Bool) {
@@ -80,10 +82,12 @@ open class Predicate : NSObject, NSSecureCoding, NSCopying {
     open func allowEvaluation() { NSUnimplemented() } // Force a predicate which was securely decoded to allow evaluation
 }
 
+extension NSPredicate {
+    public convenience init(format predicateFormat: String, _ args: CVarArg...) { NSUnimplemented() }
+}
 
 extension NSArray {
-     // evaluate a predicate against an array of objects and return a filtered array
-    open func filtered(using predicate: Predicate) -> [Any] {
+    open func filtered(using predicate: NSPredicate) -> [Any] {
         return allObjects.filter({ object in
             return predicate.evaluate(with: object)
         })
@@ -91,8 +95,7 @@ extension NSArray {
 }
 
 extension NSMutableArray {
-    // evaluate a predicate against an array of objects and filter the mutable array directly
-    open func filter(using predicate: Predicate) {
+    open func filter(using predicate: NSPredicate) {
         var indexesToRemove = IndexSet()
         for (index, object) in self.enumerated() {
             if !predicate.evaluate(with: object) {
@@ -104,8 +107,7 @@ extension NSMutableArray {
 }
 
 extension NSSet {
-    // evaluate a predicate against a set of objects and return a filtered set
-    open func filtered(using predicate: Predicate) -> Set<AnyHashable> {
+    open func filtered(using predicate: NSPredicate) -> Set<AnyHashable> {
         let objs = allObjects.filter { (object) -> Bool in
             return predicate.evaluate(with: object)
         }
@@ -114,8 +116,7 @@ extension NSSet {
 }
 
 extension NSMutableSet {
-    // evaluate a predicate against a set of objects and filter the mutable set directly
-    open func filter(using predicate: Predicate) {
+    open func filter(using predicate: NSPredicate) {
         for object in self {
             if !predicate.evaluate(with: object) {
                 self.remove(object)
@@ -125,20 +126,18 @@ extension NSMutableSet {
 }
 
 extension NSOrderedSet {
-    // evaluate a predicate against an ordered set of objects and return a filtered ordered set
-    open func filtered(using p: Predicate) -> NSOrderedSet {
+    open func filtered(using predicate: NSPredicate) -> NSOrderedSet {
         return NSOrderedSet(array: self._orderedStorage.filter({ object in
-            return p.evaluate(with: object)
+            return predicate.evaluate(with: object)
         }))
     }
 }
 
 extension NSMutableOrderedSet {
-    // evaluate a predicate against an ordered set of objects and filter the mutable ordered set directly
-    open func filter(using p: Predicate) {
+    open func filter(using predicate: NSPredicate) {
         var indexesToRemove = IndexSet()
         for (index, object) in self.enumerated() {
-            if !p.evaluate(with: object) {
+            if !predicate.evaluate(with: object) {
                 indexesToRemove.insert(index)
             }
         }

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -1046,7 +1046,7 @@ extension NSString {
         return mStr._swiftObject
     }
     
-    open func folding(options options: CompareOptions = [], locale: Locale?) -> String {
+    open func folding(options: CompareOptions = [], locale: Locale?) -> String {
         let string = CFStringCreateMutable(kCFAllocatorSystemDefault, 0)!
         CFStringReplaceAll(string, self._cfObject)
         CFStringFold(string, options._cfValue(), locale?._cfObject)

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -103,8 +103,8 @@ extension NSString {
 
 internal func _createRegexForPattern(_ pattern: String, _ options: RegularExpression.Options) -> RegularExpression? {
     struct local {
-        static let __NSRegularExpressionCache: Cache = {
-            let cache = Cache()
+        static let __NSRegularExpressionCache: NSCache<NSString, RegularExpression> = {
+            let cache = NSCache<NSString, RegularExpression>()
             cache.name = "NSRegularExpressionCache"
             cache.countLimit = 10
             return cache
@@ -112,7 +112,7 @@ internal func _createRegexForPattern(_ pattern: String, _ options: RegularExpres
     }
     let key = "\(options):\(pattern)"
     if let regex = local.__NSRegularExpressionCache.object(forKey: key._nsObject) {
-        return (regex as! RegularExpression)
+        return regex
     }
     do {
         let regex = try RegularExpression(pattern: pattern, options: options)

--- a/Foundation/NSUserDefaults.swift
+++ b/Foundation/NSUserDefaults.swift
@@ -9,17 +9,13 @@
 
 import CoreFoundation
 
-public let NSGlobalDomain: String = "NSGlobalDomain"
-public let NSArgumentDomain: String = "NSArgumentDomain"
-public let NSRegistrationDomain: String = "NSRegistrationDomain"
-
-private var registeredDefaults = [String: AnyObject]()
+private var registeredDefaults = [String: Any]()
 private var sharedDefaults = UserDefaults()
 
 open class UserDefaults: NSObject {
     private let suite: String?
     
-    open class func standardUserDefaults() -> UserDefaults {
+    open class var standard: UserDefaults {
         return sharedDefaults
     }
     
@@ -37,8 +33,8 @@ open class UserDefaults: NSObject {
         suite = suitename
     }
     
-    open func objectForKey(_ defaultName: String) -> AnyObject? {
-        func getFromRegistered() -> AnyObject? {
+    open func object(forKey defaultName: String) -> Any? {
+        func getFromRegistered() -> Any? {
             return registeredDefaults[defaultName]
         }
         
@@ -70,7 +66,7 @@ open class UserDefaults: NSObject {
             return getFromRegistered()
         }
     }
-    open func setObject(_ value: AnyObject?, forKey defaultName: String) {
+    open func set(_ value: Any?, forKey defaultName: String) {
         guard let value = value else {
             CFPreferencesSetAppValue(defaultName._cfObject, nil, suite?._cfObject ?? kCFPreferencesCurrentApplication)
             return
@@ -89,7 +85,7 @@ open class UserDefaults: NSObject {
         } else if let bType = value as? NSDictionary {
             cfType = bType._cfObject
         } else if let bType = value as? URL {
-			setURL(bType, forKey: defaultName)
+			set(bType, forKey: defaultName)
 			return
         } else if let bType = value as? Data {
             cfType = bType._cfObject
@@ -97,26 +93,25 @@ open class UserDefaults: NSObject {
         
         CFPreferencesSetAppValue(defaultName._cfObject, cfType, suite?._cfObject ?? kCFPreferencesCurrentApplication)
     }
-    open func removeObjectForKey(_ defaultName: String) {
+    open func removeObject(forKey defaultName: String) {
         CFPreferencesSetAppValue(defaultName._cfObject, nil, suite?._cfObject ?? kCFPreferencesCurrentApplication)
     }
-    
-    open func stringForKey(_ defaultName: String) -> String? {
-        guard let aVal = objectForKey(defaultName),
+    open func string(forKey defaultName: String) -> String? {
+        guard let aVal = object(forKey: defaultName),
               let bVal = aVal as? NSString else {
             return nil
         }
         return bVal._swiftObject
     }
-    open func arrayForKey(_ defaultName: String) -> [Any]? {
-        guard let aVal = objectForKey(defaultName),
+    open func array(forKey defaultName: String) -> [Any]? {
+        guard let aVal = object(forKey: defaultName),
               let bVal = aVal as? NSArray else {
             return nil
         }
         return bVal._swiftObject
     }
-    open func dictionaryForKey(_ defaultName: String) -> [String : Any]? {
-        guard let aVal = objectForKey(defaultName),
+    open func dictionary(forKey defaultName: String) -> [String : Any]? {
+        guard let aVal = object(forKey: defaultName),
               let bVal = aVal as? NSDictionary else {
             return nil
         }
@@ -143,50 +138,50 @@ open class UserDefaults: NSObject {
         } catch _ { }
         return nil
     }
-    open func dataForKey(_ defaultName: String) -> Data? {
-        guard let aVal = objectForKey(defaultName),
+    open func data(forKey defaultName: String) -> Data? {
+        guard let aVal = object(forKey: defaultName),
               let bVal = aVal as? Data else {
             return nil
         }
         return bVal
     }
-    open func stringArrayForKey(_ defaultName: String) -> [String]? {
-        guard let aVal = objectForKey(defaultName),
+    open func stringArray(forKey defaultName: String) -> [String]? {
+        guard let aVal = object(forKey: defaultName),
               let bVal = aVal as? NSArray else {
             return nil
         }
         return _SwiftValue.fetch(bVal) as? [String]
     }
-    open func integerForKey(_ defaultName: String) -> Int {
-        guard let aVal = objectForKey(defaultName),
+    open func integer(forKey defaultName: String) -> Int {
+        guard let aVal = object(forKey: defaultName),
               let bVal = aVal as? NSNumber else {
             return 0
         }
         return bVal.intValue
     }
-    open func floatForKey(_ defaultName: String) -> Float {
-        guard let aVal = objectForKey(defaultName),
+    open func float(forKey defaultName: String) -> Float {
+        guard let aVal = object(forKey: defaultName),
               let bVal = aVal as? NSNumber else {
             return 0
         }
         return bVal.floatValue
     }
-    open func doubleForKey(_ defaultName: String) -> Double {
-        guard let aVal = objectForKey(defaultName),
+    open func double(forKey defaultName: String) -> Double {
+        guard let aVal = object(forKey: defaultName),
               let bVal = aVal as? NSNumber else {
             return 0
         }
         return bVal.doubleValue
     }
-    open func boolForKey(_ defaultName: String) -> Bool {
-        guard let aVal = objectForKey(defaultName),
+    open func bool(forKey defaultName: String) -> Bool {
+        guard let aVal = object(forKey: defaultName),
               let bVal = aVal as? NSNumber else {
             return false
         }
         return bVal.boolValue
     }
-    open func URLForKey(_ defaultName: String) -> URL? {
-        guard let aVal = objectForKey(defaultName) else {
+    open func url(forKey defaultName: String) -> URL? {
+        guard let aVal = object(forKey: defaultName) else {
             return nil
         }
         
@@ -200,19 +195,19 @@ open class UserDefaults: NSObject {
         return nil
     }
     
-    open func setInteger(_ value: Int, forKey defaultName: String) {
-        setObject(NSNumber(value: value), forKey: defaultName)
+    open func set(_ value: Int, forKey defaultName: String) {
+        set(NSNumber(value: value), forKey: defaultName)
     }
-    open func setFloat(_ value: Float, forKey defaultName: String) {
-        setObject(NSNumber(value: value), forKey: defaultName)
+    open func set(_ value: Float, forKey defaultName: String) {
+        set(NSNumber(value: value), forKey: defaultName)
     }
-    open func setDouble(_ value: Double, forKey defaultName: String) {
-        setObject(NSNumber(value: value), forKey: defaultName)
+    open func set(_ value: Double, forKey defaultName: String) {
+        set(NSNumber(value: value), forKey: defaultName)
     }
-    open func setBool(_ value: Bool, forKey defaultName: String) {
-        setObject(NSNumber(value: value), forKey: defaultName)
+    open func set(_ value: Bool, forKey defaultName: String) {
+        set(NSNumber(value: value), forKey: defaultName)
     }
-    open func setURL(_ url: URL?, forKey defaultName: String) {
+    open func set(_ url: URL?, forKey defaultName: String) {
 		if let url = url {
             //FIXME: CFURLIsFileReferenceURL is limited to OS X/iOS
             #if os(OSX) || os(iOS)
@@ -222,37 +217,39 @@ open class UserDefaults: NSObject {
                     //TODO: use stringByAbbreviatingWithTildeInPath when it is
                     let urlPath = url.path
                     
-                    setObject(urlPath._nsObject, forKey: defaultName)
+                    set(urlPath._nsObject, forKey: defaultName)
                 }
             #else
                 //FIXME: stringByAbbreviatingWithTildeInPath isn't implemented in SwiftFoundation
                 //TODO: use stringByAbbreviatingWithTildeInPath when it is
                 setObject(url.path._nsObject, forKey: defaultName)
             #endif
+            let data = NSKeyedArchiver.archivedData(withRootObject: url._nsObject)
+            set(data._nsObject, forKey: defaultName)
         } else {
-            setObject(nil, forKey: defaultName)
+            set(nil, forKey: defaultName)
         }
     }
     
-    open func registerDefaults(_ registrationDictionary: [String : AnyObject]) {
+    open func register(defaults registrationDictionary: [String : Any]) {
         for (key, value) in registrationDictionary {
             registeredDefaults[key] = value
         }
     }
     
-    open func addSuiteNamed(_ suiteName: String) {
+    open func addSuite(named suiteName: String) {
         CFPreferencesAddSuitePreferencesToApp(kCFPreferencesCurrentApplication, suiteName._cfObject)
     }
-    open func removeSuiteNamed(_ suiteName: String) {
+    open func removeSuite(named suiteName: String) {
         CFPreferencesRemoveSuitePreferencesFromApp(kCFPreferencesCurrentApplication, suiteName._cfObject)
     }
     
-    open func dictionaryRepresentation() -> [String : AnyObject] {
+    open func dictionaryRepresentation() -> [String : Any] {
         NSUnimplemented()
         /*
         Currently crashes the compiler.
         guard let aPref = CFPreferencesCopyMultiple(nil, kCFPreferencesCurrentApplication, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost),
-            bPref = (aPref._swiftObject) as? [NSString: AnyObject] else {
+            bPref = (aPref._swiftObject) as? [NSString: Any] else {
                 return registeredDefaults
         }
         var allDefaults = registeredDefaults
@@ -266,21 +263,25 @@ open class UserDefaults: NSObject {
     }
     
     open var volatileDomainNames: [String] { NSUnimplemented() }
-    open func volatileDomainForName(_ domainName: String) -> [String : AnyObject] { NSUnimplemented() }
-    open func setVolatileDomain(_ domain: [String : AnyObject], forName domainName: String) { NSUnimplemented() }
-    open func removeVolatileDomainForName(_ domainName: String) { NSUnimplemented() }
+    open func volatileDomain(forName domainName: String) -> [String : Any] { NSUnimplemented() }
+    open func setVolatileDomain(_ domain: [String : Any], forName domainName: String) { NSUnimplemented() }
+    open func removeVolatileDomain(forName domainName: String) { NSUnimplemented() }
     
-    open func persistentDomainForName(_ domainName: String) -> [String : AnyObject]? { NSUnimplemented() }
-    open func setPersistentDomain(_ domain: [String : AnyObject], forName domainName: String) { NSUnimplemented() }
-    open func removePersistentDomainForName(_ domainName: String) { NSUnimplemented() }
+    open func persistentDomain(forName domainName: String) -> [String : Any]? { NSUnimplemented() }
+    open func setPersistentDomain(_ domain: [String : Any], forName domainName: String) { NSUnimplemented() }
+    open func removePersistentDomain(forName domainName: String) { NSUnimplemented() }
     
     open func synchronize() -> Bool {
         return CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
     }
     
-    open func objectIsForcedForKey(_ key: String) -> Bool { NSUnimplemented() }
-    open func objectIsForcedForKey(_ key: String, inDomain domain: String) -> Bool { NSUnimplemented() }
+    open func objectIsForced(forKey key: String) -> Bool { NSUnimplemented() }
+    open func objectIsForced(forKey key: String, inDomain domain: String) -> Bool { NSUnimplemented() }
 }
 
-public let NSUserDefaultsDidChangeNotification: String = "NSUserDefaultsDidChangeNotification"
-
+extension UserDefaults {
+    public static let didChangeNotification = NSNotification.Name(rawValue: "NSUserDefaultsDidChangeNotification")
+    public static let globalDomain: String = "NSGlobalDomain"
+    public static let argumentDomain: String = "NSArgumentDomain"
+    public static let registrationDomain: String = "NSRegistrationDomain"
+}

--- a/Foundation/NSUserDefaults.swift
+++ b/Foundation/NSUserDefaults.swift
@@ -212,20 +212,14 @@ open class UserDefaults: NSObject {
             //FIXME: CFURLIsFileReferenceURL is limited to OS X/iOS
             #if os(OSX) || os(iOS)
                 //FIXME: no SwiftFoundation version of CFURLIsFileReferenceURL at time of writing!
-                if !CFURLIsFileReferenceURL(url._cfObject) {
-                    //FIXME: stringByAbbreviatingWithTildeInPath isn't implemented in SwiftFoundation
-                    //TODO: use stringByAbbreviatingWithTildeInPath when it is
-                    let urlPath = url.path
-                    
-                    set(urlPath._nsObject, forKey: defaultName)
+                if CFURLIsFileReferenceURL(url._cfObject) {
+                    let data = NSKeyedArchiver.archivedData(withRootObject: url._nsObject)
+                    set(data._nsObject, forKey: defaultName)
+                    return
                 }
-            #else
-                //FIXME: stringByAbbreviatingWithTildeInPath isn't implemented in SwiftFoundation
-                //TODO: use stringByAbbreviatingWithTildeInPath when it is
-                setObject(url.path._nsObject, forKey: defaultName)
             #endif
-            let data = NSKeyedArchiver.archivedData(withRootObject: url._nsObject)
-            set(data._nsObject, forKey: defaultName)
+            
+            set(url.path._nsObject, forKey: defaultName)
         } else {
             set(nil, forKey: defaultName)
         }

--- a/TestFoundation/TestNSArray.swift
+++ b/TestFoundation/TestNSArray.swift
@@ -119,10 +119,10 @@ class TestNSArray : XCTestCase {
         
 //        NSArray throws NSInvalidArgument if range exceeds bounds of the array.
 //        let rangeOutOfArray = NSRange(location: 5, length: 15)
-//        let _ = array.indexOfObject(NSNumber(value: 9 as Int), inSortedRange: rangeOutOfArray, options: [.InsertionIndex, .FirstEqual], usingComparator: compareIntNSNumber)
+//        let _ = array.indexOfObject(NSNumber(value: 9 as Int), inSortedRange: rangeOutOfArray, options: [.insertionIndex, .firstEqual], usingComparator: compareIntNSNumber)
         
-//        NSArray throws NSInvalidArgument if both .FirstEqual and .LastEqaul are specified
-//        let searchForBoth: NSBinarySearchingOptions = [.FirstEqual, .LastEqual]
+//        NSArray throws NSInvalidArgument if both .firstEqual and .lastEqual are specified
+//        let searchForBoth: NSBinarySearchingOptions = [.firstEqual, .lastEqual]
 //        let _ = objectIndexInArray(array, value: 9, startingFrom: 0, length: 13, options: searchForBoth)
 
         let notFound = objectIndexInArray(array, value: 11, startingFrom: 0, length: 13)
@@ -134,35 +134,35 @@ class TestNSArray : XCTestCase {
         let indexOfAnySeven = objectIndexInArray(array, value: 7, startingFrom: 0, length: 13)
         XCTAssertTrue(Set([8, 9, 10]).contains(indexOfAnySeven), "If no options provided NSArray returns an arbitrary matching object's index.")
         
-        let indexOfFirstNine = objectIndexInArray(array, value: 9, startingFrom: 7, length: 6, options: [.FirstEqual])
+        let indexOfFirstNine = objectIndexInArray(array, value: 9, startingFrom: 7, length: 6, options: [.firstEqual])
         XCTAssertTrue(indexOfFirstNine == 12, "If .FirstEqual is set NSArray returns the lowest index of equal objects.")
         
-        let indexOfLastTwo = objectIndexInArray(array, value: 2, startingFrom: 1, length: 7, options: [.LastEqual])
+        let indexOfLastTwo = objectIndexInArray(array, value: 2, startingFrom: 1, length: 7, options: [.lastEqual])
         XCTAssertTrue(indexOfLastTwo == 3, "If .LastEqual is set NSArray returns the highest index of equal objects.")
         
-        let anyIndexToInsertNine = objectIndexInArray(array, value: 9, startingFrom: 0, length: 13, options: [.InsertionIndex])
+        let anyIndexToInsertNine = objectIndexInArray(array, value: 9, startingFrom: 0, length: 13, options: [.insertionIndex])
         XCTAssertTrue(Set([12, 13, 14]).contains(anyIndexToInsertNine), "If .InsertionIndex is specified and no other options provided NSArray returns any equal or one larger index than any matching object’s index.")
         
-        let lowestIndexToInsertTwo = objectIndexInArray(array, value: 2, startingFrom: 0, length: 5, options: [.InsertionIndex, .FirstEqual])
+        let lowestIndexToInsertTwo = objectIndexInArray(array, value: 2, startingFrom: 0, length: 5, options: [.insertionIndex, .firstEqual])
         XCTAssertTrue(lowestIndexToInsertTwo == 2, "If both .InsertionIndex and .FirstEqual are specified NSArray returns the lowest index of equal objects.")
         
-        let highestIndexToInsertNine = objectIndexInArray(array, value: 9, startingFrom: 7, length: 6, options: [.InsertionIndex, .LastEqual])
+        let highestIndexToInsertNine = objectIndexInArray(array, value: 9, startingFrom: 7, length: 6, options: [.insertionIndex, .lastEqual])
         XCTAssertTrue(highestIndexToInsertNine == 13, "If both .InsertionIndex and .LastEqual are specified NSArray returns the index of the least greater object...")
         
-        let indexOfLeastGreaterObjectThanFive = objectIndexInArray(array, value: 5, startingFrom: 0, length: 10, options: [.InsertionIndex, .LastEqual])
+        let indexOfLeastGreaterObjectThanFive = objectIndexInArray(array, value: 5, startingFrom: 0, length: 10, options: [.insertionIndex, .lastEqual])
         XCTAssertTrue(indexOfLeastGreaterObjectThanFive == 7, "If both .InsertionIndex and .LastEqual are specified NSArray returns the index of the least greater object...")
         
         let rangeStart = 0
         let rangeLength = 13
-        let endOfArray = objectIndexInArray(array, value: 10, startingFrom: rangeStart, length: rangeLength, options: [.InsertionIndex, .LastEqual])
+        let endOfArray = objectIndexInArray(array, value: 10, startingFrom: rangeStart, length: rangeLength, options: [.insertionIndex, .lastEqual])
         XCTAssertTrue(endOfArray == (rangeStart + rangeLength), "...or the index at the end of the array if the object is larger than all other elements.")
         
         let arrayOfTwo = NSArray(array: [NSNumber(value: 0 as Int), NSNumber(value: 2 as Int)])
-        let indexInMiddle = objectIndexInArray(arrayOfTwo, value: 1, startingFrom: 0, length: 2, options: [.InsertionIndex, .FirstEqual])
+        let indexInMiddle = objectIndexInArray(arrayOfTwo, value: 1, startingFrom: 0, length: 2, options: [.insertionIndex, .firstEqual])
         XCTAssertEqual(indexInMiddle, 1, "If no match found item should be inserted before least greater object")
-        let indexInMiddle2 = objectIndexInArray(arrayOfTwo, value: 1, startingFrom: 0, length: 2, options: [.InsertionIndex, .LastEqual])
+        let indexInMiddle2 = objectIndexInArray(arrayOfTwo, value: 1, startingFrom: 0, length: 2, options: [.insertionIndex, .lastEqual])
         XCTAssertEqual(indexInMiddle2, 1, "If no match found item should be inserted before least greater object")
-        let indexInMiddle3 = objectIndexInArray(arrayOfTwo, value: 1, startingFrom: 0, length: 2, options: [.InsertionIndex])
+        let indexInMiddle3 = objectIndexInArray(arrayOfTwo, value: 1, startingFrom: 0, length: 2, options: [.insertionIndex])
         XCTAssertEqual(indexInMiddle3, 1, "If no match found item should be inserted before least greater object")
     }
 
@@ -240,7 +240,7 @@ class TestNSArray : XCTestCase {
         let notFoundInEmptyArray = objectIndexInArray(emptyArray, value: 9, startingFrom: 0, length: 0)
         XCTAssertEqual(notFoundInEmptyArray, NSNotFound, "Empty NSArray return NSNotFound for any valid arguments.")
         
-        let startIndex = objectIndexInArray(emptyArray, value: 7, startingFrom: 0, length: 0, options: [.InsertionIndex])
+        let startIndex = objectIndexInArray(emptyArray, value: 7, startingFrom: 0, length: 0, options: [.insertionIndex])
         XCTAssertTrue(startIndex == 0, "For Empty NSArray any objects should be inserted at start.")
         
         let rangeStart = 0
@@ -252,10 +252,10 @@ class TestNSArray : XCTestCase {
         let greatestSearch = objectIndexInArray(array, value: 15, startingFrom: rangeStart, length: rangeLength)
         XCTAssertTrue(greatestSearch == NSNotFound, "If object is greater than greatest object in the range then there is no change it could be found.")
         
-        let leastInsert = objectIndexInArray(array, value: -1, startingFrom: rangeStart, length: rangeLength, options: .InsertionIndex)
+        let leastInsert = objectIndexInArray(array, value: -1, startingFrom: rangeStart, length: rangeLength, options: .insertionIndex)
         XCTAssertTrue(leastInsert == rangeStart, "If object is less than least object in the range it should be inserted at range' location.")
         
-        let greatestInsert = objectIndexInArray(array, value: 15, startingFrom: rangeStart, length: rangeLength, options: .InsertionIndex)
+        let greatestInsert = objectIndexInArray(array, value: 15, startingFrom: rangeStart, length: rangeLength, options: .insertionIndex)
         XCTAssertTrue(greatestInsert == (rangeStart + rangeLength), "If object is greater than greatest object in the range it should be inserted at range' end.")
     }
     

--- a/TestFoundation/TestNSCompoundPredicate.swift
+++ b/TestFoundation/TestNSCompoundPredicate.swift
@@ -31,35 +31,35 @@ class TestNSCompoundPredicate: XCTestCase {
         ]
     }
 
-    private func eval(_ predicate: Predicate, object: NSObject = NSObject()) -> Bool {
+    private func eval(_ predicate: NSPredicate, object: NSObject = NSObject()) -> Bool {
         return predicate.evaluate(with: object, substitutionVariables: nil)
     }
 
     func test_NotPredicate() {
-        let notTruePredicate = CompoundPredicate(notPredicateWithSubpredicate: Predicate(value: true))
-        let notFalsePredicate = CompoundPredicate(notPredicateWithSubpredicate: Predicate(value: false))
+        let notTruePredicate = NSCompoundPredicate(notPredicateWithSubpredicate: NSPredicate(value: true))
+        let notFalsePredicate = NSCompoundPredicate(notPredicateWithSubpredicate: NSPredicate(value: false))
 
         XCTAssertFalse(eval(notTruePredicate))
         XCTAssertTrue(eval(notFalsePredicate))
     }
 
     func test_AndPredicateWithNoSubpredicates() {
-        let predicate = CompoundPredicate(andPredicateWithSubpredicates: [])
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [])
 
         XCTAssertTrue(eval(predicate))
     }
 
     func test_AndPredicateWithOneSubpredicate() {
-        let truePredicate = CompoundPredicate(andPredicateWithSubpredicates: [Predicate(value: true)])
-        let falsePredicate = CompoundPredicate(andPredicateWithSubpredicates: [Predicate(value: false)])
+        let truePredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [NSPredicate(value: true)])
+        let falsePredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [NSPredicate(value: false)])
 
         XCTAssertTrue(eval(truePredicate))
         XCTAssertFalse(eval(falsePredicate))
     }
 
     func test_AndPredicateWithMultipleSubpredicates() {
-        let truePredicate = CompoundPredicate(andPredicateWithSubpredicates: [Predicate(value: true), Predicate(value: true)])
-        let falsePredicate = CompoundPredicate(andPredicateWithSubpredicates: [Predicate(value: true), Predicate(value: false)])
+        let truePredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [NSPredicate(value: true), NSPredicate(value: true)])
+        let falsePredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [NSPredicate(value: true), NSPredicate(value: false)])
 
         XCTAssertTrue(eval(truePredicate))
         XCTAssertFalse(eval(falsePredicate))
@@ -67,22 +67,22 @@ class TestNSCompoundPredicate: XCTestCase {
 
 
     func test_OrPredicateWithNoSubpredicates() {
-        let predicate = CompoundPredicate(orPredicateWithSubpredicates: [])
+        let predicate = NSCompoundPredicate(orPredicateWithSubpredicates: [])
 
         XCTAssertFalse(eval(predicate))
     }
 
     func test_OrPredicateWithOneSubpredicate() {
-        let truePredicate = CompoundPredicate(orPredicateWithSubpredicates: [Predicate(value: true)])
-        let falsePredicate = CompoundPredicate(orPredicateWithSubpredicates: [Predicate(value: false)])
+        let truePredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [NSPredicate(value: true)])
+        let falsePredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [NSPredicate(value: false)])
 
         XCTAssertTrue(eval(truePredicate))
         XCTAssertFalse(eval(falsePredicate))
     }
 
     func test_OrPredicateWithMultipleSubpredicates() {
-        let truePredicate = CompoundPredicate(orPredicateWithSubpredicates: [Predicate(value: true), Predicate(value: false)])
-        let falsePredicate = CompoundPredicate(orPredicateWithSubpredicates: [Predicate(value: false), Predicate(value: false)])
+        let truePredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [NSPredicate(value: true), NSPredicate(value: false)])
+        let falsePredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [NSPredicate(value: false), NSPredicate(value: false)])
 
         XCTAssertTrue(eval(truePredicate))
         XCTAssertFalse(eval(falsePredicate))
@@ -91,13 +91,13 @@ class TestNSCompoundPredicate: XCTestCase {
     func test_AndPredicateShortCircuits() {
         var shortCircuited = true
 
-        let bOK = Predicate(value: false)
-        let bDontEval = Predicate(block: { _ in
+        let bOK = NSPredicate(value: false)
+        let bDontEval = NSPredicate(block: { _ in
             shortCircuited = false
             return true
         })
 
-        let both = CompoundPredicate(andPredicateWithSubpredicates: [bOK, bDontEval])
+        let both = NSCompoundPredicate(andPredicateWithSubpredicates: [bOK, bDontEval])
         XCTAssertFalse(eval(both))
         XCTAssertTrue(shortCircuited)
     }
@@ -105,13 +105,13 @@ class TestNSCompoundPredicate: XCTestCase {
     func test_OrPredicateShortCircuits() {
         var shortCircuited = true
 
-        let bOK = Predicate(value: true)
-        let bDontEval = Predicate(block: { _ in
+        let bOK = NSPredicate(value: true)
+        let bDontEval = NSPredicate(block: { _ in
             shortCircuited = false
             return true
         })
 
-        let both = CompoundPredicate(orPredicateWithSubpredicates: [bOK, bDontEval])
+        let both = NSCompoundPredicate(orPredicateWithSubpredicates: [bOK, bDontEval])
         XCTAssertTrue(eval(both))
         XCTAssertTrue(shortCircuited)
     }

--- a/TestFoundation/TestNSDictionary.swift
+++ b/TestFoundation/TestNSDictionary.swift
@@ -44,7 +44,7 @@ class TestNSDictionary : XCTestCase {
     func test_description() {
         let d1: NSDictionary = [ "foo": "bar", "baz": "qux"]
         XCTAssertEqual(d1.description, "{\n    baz = qux;\n    foo = bar;\n}")
-        let d2: NSDictionary = ["1" : ["1" : ["1" : "1"]]]
+        let _: NSDictionary = ["1" : ["1" : ["1" : "1"]]]
         // Disabled since it emits AnyHashable in the description for now...
         // XCTAssertEqual(d2.description, "{\n    1 =     {\n        1 =         {\n            1 = 1;\n        };\n    };\n}")
     }

--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -125,28 +125,28 @@ class TestNSFileManager : XCTestCase {
             
             XCTAssertTrue(attrs.count > 0)
             
-            let fileSize = attrs[NSFileSize] as? NSNumber
+            let fileSize = attrs[.size] as? NSNumber
             XCTAssertEqual(fileSize!.int64Value, 0)
             
-            let fileModificationDate = attrs[NSFileModificationDate] as? Date
+            let fileModificationDate = attrs[.modificationDate] as? Date
             XCTAssertGreaterThan(Date().timeIntervalSince1970, fileModificationDate!.timeIntervalSince1970)
             
-            let filePosixPermissions = attrs[NSFilePosixPermissions] as? NSNumber
+            let filePosixPermissions = attrs[.posixPermissions] as? NSNumber
             XCTAssertNotEqual(filePosixPermissions!.int64Value, 0)
             
-            let fileReferenceCount = attrs[NSFileReferenceCount] as? NSNumber
+            let fileReferenceCount = attrs[.referenceCount] as? NSNumber
             XCTAssertEqual(fileReferenceCount!.int64Value, 1)
             
-            let fileSystemNumber = attrs[NSFileSystemNumber] as? NSNumber
+            let fileSystemNumber = attrs[.systemNumber] as? NSNumber
             XCTAssertNotEqual(fileSystemNumber!.int64Value, 0)
             
-            let fileSystemFileNumber = attrs[NSFileSystemFileNumber] as? NSNumber
+            let fileSystemFileNumber = attrs[.systemFileNumber] as? NSNumber
             XCTAssertNotEqual(fileSystemFileNumber!.int64Value, 0)
             
-            let fileType = attrs[NSFileType] as? String
-            XCTAssertEqual(fileType!, NSFileTypeRegular)
+            let fileType = attrs[.type] as? FileAttributeType
+            XCTAssertEqual(fileType!, .typeRegular)
             
-            let fileOwnerAccountID = attrs[NSFileOwnerAccountID] as? NSNumber
+            let fileOwnerAccountID = attrs[.ownerAccountID] as? NSNumber
             XCTAssertNotNil(fileOwnerAccountID)
             
         } catch let err {
@@ -168,14 +168,14 @@ class TestNSFileManager : XCTestCase {
         XCTAssertTrue(fm.createFile(atPath: path, contents: Data(), attributes: nil))
         
         do {
-            try fm.setAttributes([NSFilePosixPermissions:NSNumber(value: Int16(0o0600))], ofItemAtPath: path)
+            try fm.setAttributes([.posixPermissions : NSNumber(value: Int16(0o0600))], ofItemAtPath: path)
         }
         catch { XCTFail("\(error)") }
         
         //read back the attributes
         do {
             let attributes = try fm.attributesOfItem(atPath: path)
-            XCTAssert((attributes[NSFilePosixPermissions] as? NSNumber)?.int16Value == 0o0600)
+            XCTAssert((attributes[.posixPermissions] as? NSNumber)?.int16Value == 0o0600)
         }
         catch { XCTFail("\(error)") }
 

--- a/TestFoundation/TestNSNumberFormatter.swift
+++ b/TestFoundation/TestNSNumberFormatter.swift
@@ -70,7 +70,7 @@ class TestNSNumberFormatter: XCTestCase {
     
     func test_decimalSeparator() {
         let numberFormatter = NumberFormatter()
-        numberFormatter.numberStyle = .decimalStyle
+        numberFormatter.numberStyle = .decimal
         numberFormatter.decimalSeparator = "-"
         let formattedString = numberFormatter.string(from: 42.42)
         XCTAssertEqual(formattedString, "42-42")
@@ -106,7 +106,7 @@ class TestNSNumberFormatter: XCTestCase {
     
     func test_percentSymbol() {
         let numberFormatter = NumberFormatter()
-        numberFormatter.numberStyle = .percentStyle
+        numberFormatter.numberStyle = .percent
         numberFormatter.percentSymbol = "💯"
         let formattedString = numberFormatter.string(from: 0.42)
         XCTAssertEqual(formattedString, "42💯")
@@ -168,7 +168,7 @@ class TestNSNumberFormatter: XCTestCase {
     
     func test_exponentSymbol() {
         let numberFormatter = NumberFormatter()
-        numberFormatter.numberStyle = .scientificStyle
+        numberFormatter.numberStyle = .scientific
         numberFormatter.exponentSymbol = "⬆️"
         let formattedString = numberFormatter.string(from: 42)
         XCTAssertEqual(formattedString, "4.2⬆️1")
@@ -225,14 +225,14 @@ class TestNSNumberFormatter: XCTestCase {
     func test_roundingMode() {
         let numberFormatter = NumberFormatter()
         numberFormatter.maximumFractionDigits = 0
-        numberFormatter.roundingMode = .roundCeiling
+        numberFormatter.roundingMode = .ceiling
         let formattedString = numberFormatter.string(from: 41.0001)
         XCTAssertEqual(formattedString, "42")
     }
     
     func test_roundingIncrement() {
         let numberFormatter = NumberFormatter()
-        numberFormatter.numberStyle = .decimalStyle
+        numberFormatter.numberStyle = .decimal
         numberFormatter.roundingIncrement = 0.2
         let formattedString = numberFormatter.string(from: 4.25)
         XCTAssertEqual(formattedString, "4.2")

--- a/TestFoundation/TestNSPredicate.swift
+++ b/TestFoundation/TestNSPredicate.swift
@@ -31,8 +31,8 @@ class TestNSPredicate: XCTestCase {
     }
 
     func test_BooleanPredicate() {
-        let truePredicate = Predicate(value: true)
-        let falsePredicate = Predicate(value: false)
+        let truePredicate = NSPredicate(value: true)
+        let falsePredicate = NSPredicate(value: false)
 
         XCTAssertTrue(truePredicate.evaluate(with: NSObject()))
         XCTAssertFalse(falsePredicate.evaluate(with: NSObject()))
@@ -40,7 +40,7 @@ class TestNSPredicate: XCTestCase {
 
 
     func test_BlockPredicateWithoutVariableBindings() {
-        let isNSStringPredicate = Predicate { (object, bindings) -> Bool in
+        let isNSStringPredicate = NSPredicate { (object, bindings) -> Bool in
             return object is NSString
         }
 
@@ -48,7 +48,7 @@ class TestNSPredicate: XCTestCase {
         XCTAssertFalse(isNSStringPredicate.evaluate(with: NSArray()))
     }
 
-    let lengthLessThanThreePredicate = Predicate { (obj, bindings) -> Bool in
+    let lengthLessThanThreePredicate = NSPredicate { (obj, bindings) -> Bool in
         return (obj as! String).utf16.count < 3
     }
 
@@ -56,25 +56,20 @@ class TestNSPredicate: XCTestCase {
     let expectedArray = ["1", "12"]
 
     func test_filterNSArray() {
-        
         let filteredArray = NSArray(array: startArray).filtered(using: lengthLessThanThreePredicate).map { $0 as! String }
-        // .filteredArrayUsingPredicate(lengthLessThanThreePredicate).map { $0 as! String }
 
         XCTAssertEqual(expectedArray, filteredArray)
     }
 
     func test_filterNSMutableArray() {
         let array = NSMutableArray(array: startArray)
-        
         array.filter(using: lengthLessThanThreePredicate)
-
         XCTAssertEqual(NSArray(array: expectedArray), array)
     }
 
     func test_filterNSSet() {
         let set = NSSet(array: startArray)
         let filteredSet = set.filtered(using: lengthLessThanThreePredicate)
-
         XCTAssertEqual(Set(expectedArray), filteredSet)
     }
 

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -449,7 +449,7 @@ class TestNSString : XCTestCase {
             var outName: String = ""
             var matches: [String] = []
             _ = path.completePath(into: &outName, caseSensitive: false, matchesInto: &matches, filterTypes: nil)
-            let urlToTmp = try URL(fileURLWithPath: "/private/tmp/").standardized
+            let urlToTmp = URL(fileURLWithPath: "/private/tmp/").standardized
             _ = try FileManager.default.contentsOfDirectory(at: urlToTmp, includingPropertiesForKeys: nil, options: [])
             XCTAssert(outName == "/tmp/", "If path could be completed to existing directory then outName is a string itself plus '/'.")
             // This assert fails on CI; https://bugs.swift.org/browse/SR-389

--- a/TestFoundation/TestNSTimer.swift
+++ b/TestFoundation/TestNSTimer.swift
@@ -79,13 +79,13 @@ class TestNSTimer : XCTestCase {
         var flag = false
         
         let dummyTimer = Timer.scheduledTimer(withTimeInterval: 0.01, repeats: true) { timer in
-            XCTAssertTrue(timer.valid)
+            XCTAssertTrue(timer.isValid)
             XCTAssertFalse(flag) // timer should tick only once
             
             flag = true
             
             timer.invalidate()
-            XCTAssertFalse(timer.valid)
+            XCTAssertFalse(timer.isValid)
         }
         
         let runLoop = RunLoop.current()

--- a/TestFoundation/TestNSUserDefaults.swift
+++ b/TestFoundation/TestNSUserDefaults.swift
@@ -25,19 +25,19 @@ class TestNSUserDefaults : XCTestCase {
 	}
 
 	func test_createUserDefaults() {
-		let defaults = UserDefaults.standardUserDefaults()
+		let defaults = UserDefaults.standard
 		
-		defaults.setInteger(4, forKey: "ourKey")
+		defaults.set(4, forKey: "ourKey")
 	}
 	
 	func test_getRegisteredDefaultItem() {
-		let defaults = UserDefaults.standardUserDefaults()
+		let defaults = UserDefaults.standard
 		
-		defaults.registerDefaults(["key1": NSNumber(value: Int(5))])
+		defaults.register(defaults: ["key1": NSNumber(value: Int(5))])
 		
 		//make sure we don't have anything in the saved plist.
-		defaults.removeObjectForKey("key1")
+		defaults.removeObject(forKey: "key1")
 		
-		XCTAssertEqual(defaults.integerForKey("key1"), 5)
+		XCTAssertEqual(defaults.integer(forKey: "key1"), 5)
 	}
 }


### PR DESCRIPTION
### Changes
#### `NSBinarySearchOptions`
* `FirstEqual` → `firstEqual`
* `LastEqual` → `lastEqual`
* `InsertionIndex` → `insertionIndex`

#### `Cache`
* `Cache` → `NSCache`
* Make `NSCache` generic for type safety

#### `FileHandle`
* `func` → `var`
* `public` → `open`
* `String` → `RunLoopMode`

#### `NSExpression`
* `AnyObject` → `Any`
* `expressionValueWithObject(_ object: AnyObject?, context: NSMutableDictionary?)` → `expressionValue(with object: AnyObject?, context: NSMutableDictionary?)`

#### `Predicate`
* `Predicate` → `NSPredicate`
* Add missing `public init(format predicateFormat: String, arguments argList: CVaListPointer) { NSUnimplemented() }` and `public convenience init(format predicateFormat: String, _ args: CVarArg...) { NSUnimplemented() }`
* Update `filter`/`filtered` extensions for collection classes

#### `ComparisonPredicate`
* `ComparisonPredicate` → `NSComparisonPredicate`

#### `CompoundPredicate`
* `CompoundPredicate` → `NSCompoundPredicate`
* `public` → `open`

#### `UserDefaults`
* `func standardUserDefaults() -> UserDefaults` → `var standard: UserDefaults`
* Method name changes

#### `NumberFormatter`
* `AnyObject` → `Any`
* enum name changes
* Uncomment out `NSAttributedString` methods

#### `[NS]PersonNameComponents`
* Integrate work from overlay
* Update bridging to new model

#### `PersonNameComponentsFormatter`
* `phonetic` → `isPhonetic`

#### `MeasurementFormatter`
* Add missing `public func string<UnitType : Unit>(from measurement: Measurement<UnitType>) -> String { NSUnimplemented() }`

#### `FileManager`
* Method naming changes
* `String` → `FileAttributeKey`/`FileAttributeType` structs
* `NSFileManagerItemReplacementOptions` → `NSFileManager.ItemReplacementOptions`
* `AnyObject` → `Any`