### PR TITLE
Implementation of NSURLCredential.copy(with:)

### DIFF
--- a/Foundation/NSURLCredential.swift
+++ b/Foundation/NSURLCredential.swift
@@ -81,7 +81,7 @@ open class URLCredential : NSObject, NSSecureCoding, NSCopying {
     }
     
     open func copy(with zone: NSZone? = nil) -> Any {
-        NSUnimplemented()
+        return self 
     }
     
     /*!

--- a/TestFoundation/TestNSURLCredential.swift
+++ b/TestFoundation/TestNSURLCredential.swift
@@ -20,7 +20,8 @@ class TestNSURLCredential : XCTestCase {
     
     static var allTests: [(String, (TestNSURLCredential) -> () throws -> Void)] {
         return [
-                   ("test_construction", test_construction)
+                   ("test_construction", test_construction),
+                   ("test_copy", test_copy)
         ]
     }
     
@@ -31,5 +32,11 @@ class TestNSURLCredential : XCTestCase {
         XCTAssertEqual(credential.password, "swiftPassword")
         XCTAssertEqual(credential.persistence, URLCredential.Persistence.forSession)
         XCTAssertEqual(credential.hasPassword, true)
+    }
+
+    func test_copy() {
+        let credential = URLCredential(user: "swiftUser", password: "swiftPassword", persistence: .forSession)
+        let copy = credential.copy() as! URLCredential
+        XCTAssertTrue(copy.isEqual(credential))
     }
 }


### PR DESCRIPTION
This PR has Implementation of NSURLCredential.copy(with:) along with the unit test case.