### PR TITLE
NSData and struct Data should not have a function called bridge

### DIFF
--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -850,10 +850,6 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
 extension NSData : _CFBridgable, _SwiftBridgable {
     typealias SwiftType = Data
     internal var _swiftObject: SwiftType { return Data(referencing: self) }
-    
-    public func bridge() -> Data {
-        return _swiftObject
-    }
 }
 
 extension Data : _NSBridgable, _CFBridgable {
@@ -861,10 +857,6 @@ extension Data : _NSBridgable, _CFBridgable {
     typealias NSType = NSData
     internal var _cfObject: CFType { return _nsObject._cfObject }
     internal var _nsObject: NSType { return _bridgeToObjectiveC() }
-    
-    public func bridge() -> NSData {
-        return _nsObject
-    }
 }
 
 extension CFData : _NSBridgable, _SwiftBridgable {

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -176,9 +176,10 @@ open class JSONSerialization : NSObject {
      */
     open class func writeJSONObject(_ obj: Any, toStream stream: NSOutputStream, options opt: WritingOptions) throws -> Int {
         let jsonData = try _data(withJSONObject: obj, options: opt, stream: true)
-        let jsonNSData = jsonData.bridge()
-        let bytePtr = jsonNSData.bytes.bindMemory(to: UInt8.self, capacity: jsonNSData.length)
-        return stream.write(bytePtr, maxLength: jsonNSData.length)
+        let count = jsonData.count
+        return jsonData.withUnsafeBytes { (bytePtr) -> Int in
+            return stream.write(bytePtr, maxLength: count)
+        }
     }
     
     /* Create a JSON object from JSON data stream. The stream should be opened and configured. All other behavior of this method is the same as the JSONObjectWithData:options:error: method.

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -856,7 +856,7 @@ extension TestNSData {
     
     func test_dataHash() {
         let dataStruct = "Hello World".data(using: .utf8)!
-        let dataObj = dataStruct.bridge()
+        let dataObj = dataStruct._bridgeToObjectiveC()
         XCTAssertEqual(dataObj.hashValue, dataStruct.hashValue, "Data and NSData should have the same hash value")
     }
     

--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -81,7 +81,7 @@ class TestNSKeyedArchiver : XCTestCase {
         XCTAssertTrue(encode(archiver))
         archiver.finishEncoding()
         
-        let unarchiver = NSKeyedUnarchiver(forReadingWithData: data.bridge())
+        let unarchiver = NSKeyedUnarchiver(forReadingWithData: Data._unconditionallyBridgeFromObjectiveC(data))
         XCTAssertTrue(decode(unarchiver))
     }
     


### PR DESCRIPTION
This function was removed on purpose and should not be re-introduced.