### PR TITLE
[SR-1608] NSStream unimplemented features PT1

### DIFF
--- a/Foundation/NSStream.swift
+++ b/Foundation/NSStream.swift
@@ -144,10 +144,6 @@ open class InputStream: Stream {
     public init?(url: URL) {
         _stream = CFReadStreamCreateWithFile(kCFAllocatorDefault, url._cfObject)
     }
-
-    public static func initialize(url:URL) -> CFReadStream{
-        return CFReadStreamCreateWithFile(kCFAllocatorDefault, url._cfObject)
-    }
     
     public convenience init?(fileAtPath path: String) {
         self.init(url: URL(fileURLWithPath: path))
@@ -182,6 +178,7 @@ open class InputStream: Stream {
     fileprivate init(cfStream stream:CFReadStream){
         _stream = stream
     }
+    
 }
 
 // NSOutputStream is an abstract class representing the base functionality of a write stream.
@@ -266,7 +263,8 @@ extension CFReadStream {
 }
 // Discussion of this API is ongoing for its usage of AutoreleasingUnsafeMutablePointer
 extension Stream {
-
+    
+    /// - experimental: Discussion of this API is ongoing for its usage of AutoreleasingUnsafeMutablePointer .
     open class func getStreamsToHost(withName hostName: String, port: Int, inputStream: inout InputStream?, outputStream: inout NSOutputStream?){
         var read: Unmanaged<CFReadStream>?
         var write: Unmanaged<CFWriteStream>?
@@ -275,19 +273,9 @@ extension Stream {
         outputStream = write?.takeRetainedValue().outputStream()
     }
     
-    open class func getInputStreamToHost(withName hostName: String, port: Int, inputStream: inout InputStream?){
-        var read: Unmanaged<CFReadStream>?
-        CFStreamCreatePairWithSocketToHost(kCFAllocatorDefault, hostName._cfObject, UInt32(port), &read, nil)
-        inputStream = read?.takeRetainedValue().inputStream()
-    }
-    
-    open class func getOutPutStreamToHost(withName hostName: String, port: Int, outPutStream: inout NSOutputStream?){
-        var write: Unmanaged<CFWriteStream>?
-        CFStreamCreatePairWithSocketToHost(kCFAllocatorDefault, hostName._cfObject, UInt32(port), nil, &write)
-        outPutStream = write?.takeRetainedValue().outputStream()
-    }
 }
 
+#if false
 extension Stream {
     open class func getBoundStreams(withBufferSize bufferSize: Int, inputStream: inout InputStream?, outputStream: inout NSOutputStream?) {
         var read: Unmanaged<CFReadStream>?
@@ -297,6 +285,7 @@ extension Stream {
         outputStream = write?.takeRetainedValue().outputStream()
     }
 }
+#endif
 
 extension StreamDelegate {
     func stream(_ aStream: Stream, handleEvent eventCode: Stream.Event) { }

--- a/TestFoundation/TestNSStream.swift
+++ b/TestFoundation/TestNSStream.swift
@@ -36,7 +36,6 @@ class TestNSStream : XCTestCase {
             ("test_ouputStreamWithInvalidPath", test_ouputStreamWithInvalidPath),
             ("test_outputStreamGetSetProperty", test_outputStreamGetSetProperty),
             ("test_getStreamsToHost", test_getStreamsToHost),
-            ("test_getBoundStreams", test_getBoundStreams),
 
         ]
     }
@@ -366,33 +365,8 @@ class TestNSStream : XCTestCase {
         XCTAssertEqual(Stream.Status.notOpen, input?.streamStatus)
         XCTAssertEqual(Stream.Status.notOpen, output?.streamStatus)
 
-        
-        input = nil
-        output = nil
-        XCTAssertNil(input)
-        XCTAssertNil(output)
-        Stream.getInputStreamToHost(withName: "def", port: 12, inputStream: &input)
-        XCTAssertNotNil(input)
-        XCTAssertNil(output)
-        
-        input = nil
-        output = nil
-        XCTAssertNil(input)
-        XCTAssertNil(output)
-        Stream.getOutPutStreamToHost(withName: "lmn", port: 12, outPutStream: &output)
-        XCTAssertNotNil(output)
-        XCTAssertNil(input)
     }
 
-    func test_getBoundStreams(){
-        var input:InputStream? = nil
-        var output:NSOutputStream? = nil
-        XCTAssertNil(input)
-        XCTAssertNil(output)
-        Stream.getBoundStreams(withBufferSize: 23, inputStream: &input, outputStream: &output)
-        XCTAssertNotNil(input)
-        XCTAssertNotNil(output)
-    }
     
     private func createTestFile(_ path: String, _contents: Data) -> String? {
         let tempDir = "/tmp/TestFoundation_Playground_" + NSUUID().uuidString + "/"


### PR DESCRIPTION
Old pull: https://github.com/apple/swift-corelibs-foundation/pull/489
Old Pull request was closed due to churn about experimental un official API particularly 

```
class func getStreamsToHost(withName hostname: String, port: Int, inputStream: AutoreleasingUnsafeMutablePointer<InputStream?>?, outputStream: AutoreleasingUnsafeMutablePointer<NSOutputStream?>?) 
```

I have decoupled these 2 issues and created a separate Jira ticket for it here and will be filing a pr for soon https://bugs.swift.org/browse/SR-2431

**What's in this pull request?**
1st part of Resolved bug number: 1608 (https://bugs.swift.org/browse/SR-1608)
NSStream implementation of unimplemented features with tests

SR-1608 has been split in 2 pulls in effort to keep pulls small
- [ ] @phausler 
- [ ] @parkera 
