### PR TITLE
[SR-2431] getStreamsToHost

### DIFF
--- a/CoreFoundation/Stream.subproj/CFSocketStream.c
+++ b/CoreFoundation/Stream.subproj/CFSocketStream.c
@@ -110,7 +110,7 @@ static struct {
 
 #define CFNETWORK_CALL(sym, args)		((CFNetworkSupport.sym)args)
 
-#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED
+#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_LINUX
 #define CFNETWORK_LOAD_SYM(sym)   __CFLookupCFNetworkFunction(#sym)
 #elif DEPLOYMENT_TARGET_WINDOWS
 #define CFNETWORK_LOAD_SYM(sym)   (void *)GetProcAddress(CFNetworkSupport.image, #sym)
@@ -119,7 +119,7 @@ static struct {
 static void initializeCFNetworkSupport(void) {
     __CFBitSet(CFNetworkSupport.flags, kTriedToLoad);
 
-#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED
+#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_LINUX
     CFNetworkSupport._CFSocketStreamCreatePair = CFNETWORK_LOAD_SYM(_CFSocketStreamCreatePair);
     CFNetworkSupport._CFErrorCreateWithStreamError = CFNETWORK_LOAD_SYM(_CFErrorCreateWithStreamError);
     CFNetworkSupport._CFStreamErrorFromCFError = CFNETWORK_LOAD_SYM(_CFStreamErrorFromCFError);

--- a/TestFoundation/TestNSStream.swift
+++ b/TestFoundation/TestNSStream.swift
@@ -29,6 +29,7 @@ class TestNSStream : XCTestCase {
             ("test_outputStreamCreationToMemory", test_outputStreamCreationToMemory),
             ("test_outputStreamHasSpaceAvailable", test_outputStreamHasSpaceAvailable),
             ("test_ouputStreamWithInvalidPath", test_ouputStreamWithInvalidPath),
+            ("test_getStreamsToHost", test_getStreamsToHost),
         ]
     }
     
@@ -214,6 +215,18 @@ class TestNSStream : XCTestCase {
         XCTAssertEqual(Stream.Status.notOpen, outputStream!.streamStatus)
         outputStream?.open()
         XCTAssertEqual(Stream.Status.error, outputStream!.streamStatus)
+    }
+    
+    func test_getStreamsToHost(){
+        var input:InputStream? = nil
+        var output:NSOutputStream? = nil
+        XCTAssertNil(input)
+        XCTAssertNil(output)
+        Stream.getStreamsToHost(withName: "abc", port: 12, inputStream: &input, outputStream: &output)
+        XCTAssertNotNil(input)
+        XCTAssertNotNil(output)
+        XCTAssertEqual(Stream.Status.notOpen, input?.streamStatus)
+        XCTAssertEqual(Stream.Status.notOpen, output?.streamStatus)
     }
     
     private func createTestFile(_ path: String, _contents: Data) -> String? {


### PR DESCRIPTION
Old pull: #489
Old Pull request was closed and split due to the uncertain nature and unknown dependencies  of this pull 

**What's in this pull request?**
Discussion on resolved bug number: 2431 (https://bugs.swift.org/browse/SR-2431)
- The potential API change to 

```
open class func getStreamsToHost(withName hostName: String, port: Int, inputStream: inout InputStream?, outputStream: inout NSOutputStream?)
```
- The dependencies on Linux
  @LoganWright mentioned that these [functions](https://github.com/apple/swift-corelibs-foundation/blob/master/CoreFoundation/Stream.subproj/CFSocketStream.c#L158-L160) will need to be enabled/implemented.
  help would be much appreciated on figuring out the dependencies, as i have not had the time to get a Linux build working locally 
- [ ] @phausler 
- [ ] @parkera 
