### PR TITLE
Swift 3 API Parity: Drop NS prefix from NSHTTPURLResponse

### DIFF
--- a/Foundation/NSURLResponse.swift
+++ b/Foundation/NSURLResponse.swift
@@ -113,7 +113,7 @@ open class URLResponse : NSObject, NSSecureCoding, NSCopying {
 /// HTTP URL load. It is a specialization of NSURLResponse which
 /// provides conveniences for accessing information specific to HTTP
 /// protocol responses.
-open class NSHTTPURLResponse : URLResponse {
+open class HTTPURLResponse : URLResponse {
     
     /// Initializer for NSHTTPURLResponse objects.
     ///

--- a/Foundation/NSURLSession/HTTPMessage.swift
+++ b/Foundation/NSURLSession/HTTPMessage.swift
@@ -101,9 +101,9 @@ internal extension URLSessionTask._ResponseHeaderLines {
     ///
     /// This will parse the header lines.
     /// - Returns: `nil` if an error occured while parsing the header lines.
-    func createHTTPURLResponse(for URL: URL) -> NSHTTPURLResponse? {
+    func createHTTPURLResponse(for URL: URL) -> HTTPURLResponse? {
         guard let message = createHTTPMessage() else { return nil }
-        return NSHTTPURLResponse(message: message, URL: URL)
+        return HTTPURLResponse(message: message, URL: URL)
     }
     /// Parse the lines into a `URLSessionTask.HTTPMessage`.
     func createHTTPMessage() -> URLSessionTask._HTTPMessage? {
@@ -114,7 +114,7 @@ internal extension URLSessionTask._ResponseHeaderLines {
     }
 }
 
-extension NSHTTPURLResponse {
+extension HTTPURLResponse {
     fileprivate convenience init?(message: URLSessionTask._HTTPMessage, URL: URL) {
         /// This needs to be a request, i.e. it needs to have a status line.
         guard case .statusLine(let statusLine) = message.startLine else { return nil }

--- a/Foundation/NSURLSession/NSURLSessionDelegate.swift
+++ b/Foundation/NSURLSession/NSURLSessionDelegate.swift
@@ -95,7 +95,7 @@ public protocol URLSessionTaskDelegate : URLSessionDelegate {
      *
      * For tasks in background sessions, redirections will always be followed and this method will not be called.
      */
-    func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: NSHTTPURLResponse, newRequest request: NSURLRequest, completionHandler: @escaping (NSURLRequest?) -> Void)
+    func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: NSURLRequest, completionHandler: @escaping (NSURLRequest?) -> Void)
     
     /* The task has received a request specific authentication challenge.
      * If this delegate is not implemented, the session specific authentication challenge
@@ -122,7 +122,7 @@ public protocol URLSessionTaskDelegate : URLSessionDelegate {
 }
 
 extension URLSessionTaskDelegate {
-    public func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: NSHTTPURLResponse, newRequest request: NSURLRequest, completionHandler: @escaping (NSURLRequest?) -> Void) {
+    public func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: NSURLRequest, completionHandler: @escaping (NSURLRequest?) -> Void) {
         completionHandler(request)
     }
     

--- a/Foundation/NSURLSession/NSURLSessionTask.swift
+++ b/Foundation/NSURLSession/NSURLSessionTask.swift
@@ -344,7 +344,7 @@ internal extension URLSessionTask {
         /// The easy handle has been removed from the multi handle. This does
         /// not (necessarily mean the task completed. A task that gets
         /// redirected will do multiple transfers.
-        case transferCompleted(response: NSHTTPURLResponse, bodyDataDrain: _TransferState._DataDrain)
+        case transferCompleted(response: HTTPURLResponse, bodyDataDrain: _TransferState._DataDrain)
         /// The transfer failed.
         ///
         /// Same as `.transferCompleted`, but without response / body data
@@ -354,7 +354,7 @@ internal extension URLSessionTask {
         /// When we tell the delegate that we're about to perform an HTTP
         /// redirect, we need to wait for the delegate to let us know what
         /// action to take.
-        case waitingForRedirectCompletionHandler(response: NSHTTPURLResponse, bodyDataDrain: _TransferState._DataDrain)
+        case waitingForRedirectCompletionHandler(response: HTTPURLResponse, bodyDataDrain: _TransferState._DataDrain)
         /// Waiting for the completion handler of the 'did receive response' callback.
         ///
         /// When we tell the delegate that we received a response (i.e. when
@@ -983,7 +983,7 @@ fileprivate extension URLSessionTask {
     /// response / complete header.
     ///
     /// This will pause the transfer.
-    func askDelegateHowToProceedAfterCompleteResponse(_ response: NSHTTPURLResponse, delegate: URLSessionDataDelegate) {
+    func askDelegateHowToProceedAfterCompleteResponse(_ response: HTTPURLResponse, delegate: URLSessionDataDelegate) {
         // Ask the delegate how to proceed.
         
         // This will pause the easy handle. We need to wait for the
@@ -1032,7 +1032,7 @@ fileprivate extension URLSessionTask {
     }
     
     /// What action to take
-    func completionAction(forCompletedRequest request: NSURLRequest, response: NSHTTPURLResponse) -> _CompletionAction {
+    func completionAction(forCompletedRequest request: NSURLRequest, response: HTTPURLResponse) -> _CompletionAction {
         // Redirect:
         if let request = redirectRequest(for: response, fromRequest: request) {
             return .redirectWithRequest(request)
@@ -1044,7 +1044,7 @@ fileprivate extension URLSessionTask {
     /// RFC 7231 section 6.4 defines redirection behavior for HTTP/1.1
     ///
     /// - SeeAlso: <https://tools.ietf.org/html/rfc7231#section-6.4>
-    func redirectRequest(for response: NSHTTPURLResponse, fromRequest: NSURLRequest) -> NSURLRequest? {
+    func redirectRequest(for response: HTTPURLResponse, fromRequest: NSURLRequest) -> NSURLRequest? {
         //TODO: Do we ever want to redirect for HEAD requests?
         func methodAndURL() -> (String, URL)? {
             guard
@@ -1077,7 +1077,7 @@ fileprivate extension URLSessionTask {
 }
 
 
-fileprivate extension NSHTTPURLResponse {
+fileprivate extension HTTPURLResponse {
     /// Type safe HTTP header field name(s)
     enum _Field: String {
         /// `Location`

--- a/Foundation/NSURLSession/TransferState.swift
+++ b/Foundation/NSURLSession/TransferState.swift
@@ -37,7 +37,7 @@ extension URLSessionTask {
         /// Raw headers received.
         let parsedResponseHeader: _ParsedResponseHeader
         /// Once the headers is complete, this will contain the response
-        let response: NSHTTPURLResponse?
+        let response: HTTPURLResponse?
         /// The body data to be sent in the request
         let requestBodySource: _HTTPBodySource?
         /// Body data received

--- a/TestFoundation/TestNSURLResponse.swift
+++ b/TestFoundation/TestNSURLResponse.swift
@@ -133,28 +133,28 @@ class TestNSHTTPURLResponse : XCTestCase {
     let url = URL(string: "https://www.swift.org")!
     
     func test_URL_and_status_1() {
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: ["Content-Length": "5299"])
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: ["Content-Length": "5299"])
         XCTAssertEqual(sut?.url, url)
         XCTAssertEqual(sut?.statusCode, 200)
     }
     func test_URL_and_status_2() {
         let url = URL(string: "http://www.apple.com")!
-        let sut = NSHTTPURLResponse(url: url, statusCode: 302, httpVersion: "HTTP/1.1", headerFields: ["Content-Length": "5299"])
+        let sut = HTTPURLResponse(url: url, statusCode: 302, httpVersion: "HTTP/1.1", headerFields: ["Content-Length": "5299"])
         XCTAssertEqual(sut?.url, url)
         XCTAssertEqual(sut?.statusCode, 302)
     }
 
     func test_headerFields_1() {
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)
         XCTAssertEqual(sut?.allHeaderFields.count, 0)
     }
     func test_headerFields_2() {
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: [:])
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: [:])
         XCTAssertEqual(sut?.allHeaderFields.count, 0)
     }
     func test_headerFields_3() {
         let f = ["A": "1", "B": "2"]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.allHeaderFields.count, 2)
         XCTAssertEqual(sut?.allHeaderFields["A"], "1")
         XCTAssertEqual(sut?.allHeaderFields["B"], "2")
@@ -170,48 +170,48 @@ class TestNSHTTPURLResponse : XCTestCase {
     
     func test_contentLength_available_1() {
         let f = ["Content-Length": "997"]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.expectedContentLength, 997)
     }
     func test_contentLength_available_2() {
         let f = ["Content-Length": "997", "Transfer-Encoding": "identity"]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.expectedContentLength, 997)
     }
     func test_contentLength_available_3() {
         let f = ["Content-Length": "997", "Content-Encoding": "identity"]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.expectedContentLength, 997)
     }
     func test_contentLength_available_4() {
         let f = ["Content-Length": "997", "Content-Encoding": "identity", "Transfer-Encoding": "identity"]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.expectedContentLength, 997)
     }
     
     func test_contentLength_notAvailable() {
         let f = ["Server": "Apache"]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.expectedContentLength, -1)
     }
     func test_contentLength_withTransferEncoding() {
         let f = ["Content-Length": "997", "Transfer-Encoding": "chunked"]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.expectedContentLength, 997)
     }
     func test_contentLength_withContentEncoding() {
         let f = ["Content-Length": "997", "Content-Encoding": "deflate"]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.expectedContentLength, 997)
     }
     func test_contentLength_withContentEncodingAndTransferEncoding() {
         let f = ["Content-Length": "997", "Content-Encoding": "deflate", "Transfer-Encoding": "identity"]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.expectedContentLength, 997)
     }
     func test_contentLength_withContentEncodingAndTransferEncoding_2() {
         let f = ["Content-Length": "997", "Content-Encoding": "identity", "Transfer-Encoding": "chunked"]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.expectedContentLength, 997)
     }
     
@@ -230,45 +230,45 @@ class TestNSHTTPURLResponse : XCTestCase {
     
     func test_suggestedFilename_notAvailable_1() {
         let f: [String: String] = [:]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.suggestedFilename, "Unknown")
     }
     func test_suggestedFilename_notAvailable_2() {
         let f = ["Content-Disposition": "inline"]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.suggestedFilename, "Unknown")
     }
     
     func test_suggestedFilename_1() {
         let f = ["Content-Disposition": "attachment; filename=\"fname.ext\""]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.suggestedFilename, "fname.ext")
     }
 
     func test_suggestedFilename_2() {
         let f = ["Content-Disposition": "attachment; filename=genome.jpeg; modification-date=\"Wed, 12 Feb 1997 16:29:51 -0500\";"]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.suggestedFilename, "genome.jpeg")
     }
     func test_suggestedFilename_3() {
         let f = ["Content-Disposition": "attachment; filename=\";.ext\""]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.suggestedFilename, ";.ext")
     }
     func test_suggestedFilename_4() {
         let f = ["Content-Disposition": "attachment; aa=bb\\; filename=\"wrong.ext\"; filename=\"fname.ext\"; cc=dd"]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.suggestedFilename, "fname.ext")
     }
 
     func test_suggestedFilename_removeSlashes_1() {
         let f = ["Content-Disposition": "attachment; filename=\"/a/b/name\""]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.suggestedFilename, "_a_b_name")
     }
     func test_suggestedFilename_removeSlashes_2() {
         let f = ["Content-Disposition": "attachment; filename=\"a/../b/name\""]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.suggestedFilename, "a_.._b_name")
     }
     
@@ -276,19 +276,19 @@ class TestNSHTTPURLResponse : XCTestCase {
     
     func test_MIMETypeAndCharacterEncoding_1() {
         let f = ["Server": "Apache"]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertNil(sut?.mimeType)
         XCTAssertNil(sut?.textEncodingName)
     }
     func test_MIMETypeAndCharacterEncoding_2() {
         let f = ["Content-Type": "text/html"]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.mimeType, "text/html")
         XCTAssertNil(sut?.textEncodingName)
     }
     func test_MIMETypeAndCharacterEncoding_3() {
         let f = ["Content-Type": "text/HTML; charset=ISO-8859-4"]
-        let sut = NSHTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
+        let sut = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: f)
         XCTAssertEqual(sut?.mimeType, "text/html")
         XCTAssertEqual(sut?.textEncodingName, "iso-8859-4")
     }

--- a/TestFoundation/TestNSURLSession.swift
+++ b/TestFoundation/TestNSURLSession.swift
@@ -58,7 +58,7 @@ class TestURLSession : XCTestCase {
                 return
             }
 
-            let httpResponse = response as! NSHTTPURLResponse?
+            let httpResponse = response as! HTTPURLResponse?
             XCTAssertEqual(200, httpResponse!.statusCode, "HTTP response code is not 200") 
             do {
                 let json = try JSONSerialization.jsonObject(with: data!, options: [])
@@ -99,7 +99,7 @@ class TestURLSession : XCTestCase {
                 expect.fulfill()
                 return
             }
-            let httpResponse = response as! NSHTTPURLResponse?
+            let httpResponse = response as! HTTPURLResponse?
             XCTAssertEqual(200, httpResponse!.statusCode, "HTTP response code is not 200")
             do {
                 let json = try JSONSerialization.jsonObject(with: data!, options: [])


### PR DESCRIPTION
The Swift 3 API changes dropped the `NS` prefix from `NSHTTPURLResponse`, but that was missed in the `URLSession` code drop.

This remove the `NS` prefix from the declaration and where its used in both Foundation and TestFoundation.