### PR TITLE
Correct NSOrderedSet filtering by unboxing objects

### DIFF
--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -120,6 +120,16 @@ open class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
             _insertObject(obj)
         }
     }
+    
+    internal var allObjects: [Any] {
+        if type(of: self) === NSOrderedSet.self || type(of: self) === NSMutableOrderedSet.self {
+            return _orderedStorage.map { _SwiftValue.fetch($0) }
+        } else {
+            return (0..<count).map { idx in
+                return self[idx]
+            }
+        }
+    }
 }
 
 extension NSOrderedSet : Sequence {

--- a/Foundation/NSPredicate.swift
+++ b/Foundation/NSPredicate.swift
@@ -127,8 +127,8 @@ extension NSMutableSet {
 
 extension NSOrderedSet {
     open func filtered(using predicate: NSPredicate) -> NSOrderedSet {
-        return NSOrderedSet(array: self._orderedStorage.filter({ object in
-            return predicate.evaluate(with: _SwiftValue.fetch(object))
+        return NSOrderedSet(array: self.allObjects.filter({ object in
+            return predicate.evaluate(with: object)
         }))
     }
 }

--- a/Foundation/NSPredicate.swift
+++ b/Foundation/NSPredicate.swift
@@ -128,7 +128,7 @@ extension NSMutableSet {
 extension NSOrderedSet {
     open func filtered(using predicate: NSPredicate) -> NSOrderedSet {
         return NSOrderedSet(array: self._orderedStorage.filter({ object in
-            return predicate.evaluate(with: object)
+            return predicate.evaluate(with: _SwiftValue.fetch(object))
         }))
     }
 }

--- a/TestFoundation/TestNSPredicate.swift
+++ b/TestFoundation/TestNSPredicate.swift
@@ -21,7 +21,7 @@ class TestNSPredicate: XCTestCase {
         return [
             ("test_BooleanPredicate", test_BooleanPredicate),
             ("test_BlockPredicateWithoutVariableBindings", test_BlockPredicateWithoutVariableBindings),
-//            ("test_filterNSArray", test_filterNSArray),
+            ("test_filterNSArray", test_filterNSArray),
             ("test_filterNSMutableArray", test_filterNSMutableArray),
             ("test_filterNSSet", test_filterNSSet),
             ("test_filterNSMutableSet", test_filterNSMutableSet),
@@ -57,7 +57,6 @@ class TestNSPredicate: XCTestCase {
 
     func test_filterNSArray() {
         let filteredArray = NSArray(array: startArray).filtered(using: lengthLessThanThreePredicate).map { $0 as! String }
-
         XCTAssertEqual(expectedArray, filteredArray)
     }
 
@@ -81,28 +80,18 @@ class TestNSPredicate: XCTestCase {
     }
 
     func test_filterNSOrderedSet() {
-        // TODO
-        // This test is temporarily disabled due to a compile crash when calling the initializer of NSOrderedSet with an array
-        /*
         let orderedSet = NSOrderedSet(array: startArray)
-        let filteredOrderedSet = orderedSet.filteredOrderedSetUsingPredicate(lengthLessThanThreePredicate)
-
+        let filteredOrderedSet = orderedSet.filtered(using: lengthLessThanThreePredicate)
         XCTAssertEqual(NSOrderedSet(array: expectedArray), filteredOrderedSet)
-        */
     }
 
     func test_filterNSMutableOrderedSet() {
-        // TODO
-        // This test is temporarily disabled due to a compile crash when calling the initializer of NSOrderedSet with an array
-        /*
         let orderedSet = NSMutableOrderedSet()
-        orderedSet.addObjectsFromArray(startArray)
-
-        orderedSet.filterUsingPredicate(lengthLessThanThreePredicate)
+        orderedSet.addObjects(from: startArray)
+        orderedSet.filter(using: lengthLessThanThreePredicate)
 
         let expectedOrderedSet = NSMutableOrderedSet()
-        expectedOrderedSet.addObjectsFromArray(expectedArray)
+        expectedOrderedSet.addObjects(from: expectedArray)
         XCTAssertEqual(expectedOrderedSet, orderedSet)
-        */
     }
 }


### PR DESCRIPTION
Our updated collections store boxed values as `_SwiftValue` objects. All implementations of `filtered(using:)` for our other collections use methods which automatically unbox those stored objects (e.g. `self.enumerated()` in mutable variants, `allObjects` in `NSArray` and `NSSet`) before passing to a predicate. The method for `NSOrderedSet` did not, causing the predicate to receive an unexpected box instead of the contained value (crashing when the predicate attempted to force cast the box instead of the value).

This was caught while uncommenting unit tests for `NSPredicate`; there's now no longer a reason to keep them commented out.