### PR TITLE
Enable NSLocale keyed archiving unit tests

### DIFF
--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -61,7 +61,7 @@ open class NSLocale: NSObject, NSCopying, NSSecureCoding {
     
     open func encode(with aCoder: NSCoder) {
         if aCoder.allowsKeyedCoding {
-            let identifier = CFLocaleGetIdentifier(self._cfObject)
+            let identifier = CFLocaleGetIdentifier(self._cfObject)._nsObject
             aCoder.encode(identifier, forKey: "NS.identifier")
         } else {
             NSUnimplemented()

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -59,6 +59,14 @@ open class NSLocale: NSObject, NSCopying, NSSecureCoding {
         return self 
     }
     
+    override open func isEqual(_ object: Any?) -> Bool {
+        guard let locale = object as? NSLocale else {
+            return false
+        }
+        
+        return locale.localeIdentifier == localeIdentifier
+    }
+    
     open func encode(with aCoder: NSCoder) {
         if aCoder.allowsKeyedCoding {
             let identifier = CFLocaleGetIdentifier(self._cfObject)._nsObject

--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -58,7 +58,7 @@ class TestNSKeyedArchiver : XCTestCase {
             ("test_archive_concrete_value", test_archive_concrete_value),
             ("test_archive_dictionary", test_archive_dictionary),
             ("test_archive_generic_objc", test_archive_generic_objc),
-//            ("test_archive_locale", test_archive_locale),
+            ("test_archive_locale", test_archive_locale),
             ("test_archive_string", test_archive_string),
             ("test_archive_mutable_array", test_archive_mutable_array),
             ("test_archive_mutable_dictionary", test_archive_mutable_dictionary),


### PR DESCRIPTION
`NSLocale`'s `encode(with:)` encodes the locale's identifier as a `CFString`, which causes a crash in `NSKeyedArchiver`'s `_haveVisited` ref map, since `CFString` cannot be forcibly cast to `AnyHashable`. Encoding the identifier as an `NSString` fixes the issue.

In decoding, a different `NSLocale` instance is returned. Since `NSLocale` no longer has value semantics (which were ported to `Locale`), it needs an `isEqual` implementation to compare two `NSLocale` instances as equal.

These changes combined allows us to uncomment the keyed archiving test and have it pass.