### PR TITLE
ensure the concurrency gate is present for all variations of OperationQueue (irregardless of the queue width)

### DIFF
--- a/Foundation/NSOperation.swift
+++ b/Foundation/NSOperation.swift
@@ -328,7 +328,8 @@ open class OperationQueue: NSObject {
             }
             let attr: DispatchQueue.Attributes
             if maxConcurrentOperationCount == 1 {
-                attr = [] 
+                attr = []
+                __concurrencyGate = DispatchSemaphore(value: 1)
             } else {
                 attr = .concurrent
                 if maxConcurrentOperationCount != NSOperationQueueDefaultMaxConcurrentOperationCount {


### PR DESCRIPTION
Testing with malloc scribble, guard edges, and guard malloc revealed this failure on Darwin builds. Evidently it alters the timing enough to show the race on un-gated operations