### PR TITLE
Swift 3 API Parity: Use URLRequest rather than NSURLRequest in APIs

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -323,6 +323,7 @@
 		D3E8D6D11C367AB600295652 /* NSSpecialValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E8D6D01C367AB600295652 /* NSSpecialValue.swift */; };
 		D3E8D6D31C36982700295652 /* NSKeyedUnarchiver-EdgeInsetsTest.plist in Resources */ = {isa = PBXBuildFile; fileRef = D3E8D6D21C36982700295652 /* NSKeyedUnarchiver-EdgeInsetsTest.plist */; };
 		D3E8D6D51C36AC0C00295652 /* NSKeyedUnarchiver-RectTest.plist in Resources */ = {isa = PBXBuildFile; fileRef = D3E8D6D41C36AC0C00295652 /* NSKeyedUnarchiver-RectTest.plist */; };
+		D4FE895B1D703D1100DA7986 /* TestURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FE895A1D703D1100DA7986 /* TestURLRequest.swift */; };
 		D51239DF1CD9DA0800D433EE /* CFSocket.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B5D88E01BBC9B0300234F36 /* CFSocket.c */; };
 		D512D17C1CD883F00032E6A5 /* TestNSFileHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D512D17B1CD883F00032E6A5 /* TestNSFileHandle.swift */; };
 		D5C40F331CDA1D460005690C /* TestNSOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C40F321CDA1D460005690C /* TestNSOperationQueue.swift */; };
@@ -756,6 +757,7 @@
 		D3E8D6D01C367AB600295652 /* NSSpecialValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSSpecialValue.swift; sourceTree = "<group>"; };
 		D3E8D6D21C36982700295652 /* NSKeyedUnarchiver-EdgeInsetsTest.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "NSKeyedUnarchiver-EdgeInsetsTest.plist"; sourceTree = "<group>"; };
 		D3E8D6D41C36AC0C00295652 /* NSKeyedUnarchiver-RectTest.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "NSKeyedUnarchiver-RectTest.plist"; sourceTree = "<group>"; };
+		D4FE895A1D703D1100DA7986 /* TestURLRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestURLRequest.swift; sourceTree = "<group>"; };
 		D512D17B1CD883F00032E6A5 /* TestNSFileHandle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSFileHandle.swift; sourceTree = "<group>"; };
 		D5C40F321CDA1D460005690C /* TestNSOperationQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSOperationQueue.swift; sourceTree = "<group>"; };
 		D834F9931C31C4060023812A /* TestNSOrderedSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSOrderedSet.swift; sourceTree = "<group>"; };
@@ -1300,6 +1302,7 @@
 		EA66F65A1BF1976100136161 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				D4FE895A1D703D1100DA7986 /* TestURLRequest.swift */,
 				C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */,
 				EA66F63C1BF1619600136161 /* TestNSArray.swift */,
 				294E3C1C1CC5E19300E4F44C /* TestNSAttributedString.swift */,
@@ -2229,6 +2232,7 @@
 				5B13B3251C582D4700651CE2 /* main.swift in Sources */,
 				5B1FD9E31D6D17B80080E83C /* TestNSURLSession.swift in Sources */,
 				D512D17C1CD883F00032E6A5 /* TestNSFileHandle.swift in Sources */,
+				D4FE895B1D703D1100DA7986 /* TestURLRequest.swift in Sources */,
 				5B13B33A1C582D4C00651CE2 /* TestNSNumber.swift in Sources */,
 				5B13B3521C582D4C00651CE2 /* TestNSValue.swift in Sources */,
 				5B13B3311C582D4C00651CE2 /* TestNSIndexPath.swift in Sources */,

--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -300,6 +300,10 @@ open class NSMutableURLRequest : NSURLRequest {
         super.init(url: url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
     }
     
+    open override func copy(with zone: NSZone? = nil) -> Any {
+        return mutableCopy(with: zone)
+    }
+    
     /*@NSCopying */ open override var url: URL? {
         get { return super.url }
         //TODO: set { super.URL = newValue.map{ $0.copy() as! NSURL } }

--- a/Foundation/NSURLSession/Configuration.swift
+++ b/Foundation/NSURLSession/Configuration.swift
@@ -24,7 +24,7 @@ internal extension URLSession {
         let identifier: String?
         
         /// default cache policy for requests
-        let requestCachePolicy: NSURLRequest.CachePolicy
+        let requestCachePolicy: URLRequest.CachePolicy
         
         /// default timeout for requests.  This will cause a timeout if no data is transmitted for the given timeout value, and is reset whenever data is transmitted.
         let timeoutIntervalForRequest: TimeInterval
@@ -33,7 +33,7 @@ internal extension URLSession {
         let timeoutIntervalForResource: TimeInterval
         
         /// type of service for requests.
-        let networkServiceType: NSURLRequest.NetworkServiceType
+        let networkServiceType: URLRequest.NetworkServiceType
         
         /// allow request to route over cellular.
         let allowsCellularAccess: Bool
@@ -100,13 +100,14 @@ internal extension URLSession._Configuration {
 
 // Configure NSURLRequests
 internal extension URLSession._Configuration {
-    func configure(request: NSMutableURLRequest) {
+    func configure(request: URLRequest) {
+        var request = request
         httpAdditionalHeaders?.forEach {
             guard request.value(forHTTPHeaderField: $0.0) == nil else { return }
             request.setValue($0.1, forHTTPHeaderField: $0.0)
         }
     }
-    func setCookies(on request: NSMutableURLRequest) {
+    func setCookies(on request: URLRequest) {
         if httpShouldSetCookies {
             //TODO: Ask the cookie storage what cookie to set.
         }
@@ -114,7 +115,7 @@ internal extension URLSession._Configuration {
 }
 // Cache Management
 private extension URLSession._Configuration {
-    func cachedResponse(forRequest request: NSURLRequest) -> CachedURLResponse? {
+    func cachedResponse(forRequest request: URLRequest) -> CachedURLResponse? {
         //TODO: Check the policy & consult the cache.
         // There's more detail on how this should work here:
         // <https://developer.apple.com/library/prerelease/ios/documentation/Cocoa/Reference/Foundation/Classes/NSURLRequest_Class/index.html#//apple_ref/swift/enum/c:@E@URLRequestCachePolicy>

--- a/Foundation/NSURLSession/NSURLSession.swift
+++ b/Foundation/NSURLSession/NSURLSession.swift
@@ -281,7 +281,7 @@ open class URLSession : NSObject {
      */
     
     /* Creates a data task with the given request.  The request may have a body stream. */
-    open func dataTask(with request: NSURLRequest) -> URLSessionDataTask {
+    open func dataTask(with request: URLRequest) -> URLSessionDataTask {
         return dataTask(with: _Request(request), behaviour: .callDelegate)
     }
     
@@ -291,22 +291,22 @@ open class URLSession : NSObject {
     }
     
     /* Creates an upload task with the given request.  The body of the request will be created from the file referenced by fileURL */
-    open func uploadTask(with request: NSURLRequest, fromFile fileURL: URL) -> URLSessionUploadTask {
+    open func uploadTask(with request: URLRequest, fromFile fileURL: URL) -> URLSessionUploadTask {
         let r = URLSession._Request(request)
         return uploadTask(with: r, body: .file(fileURL), behaviour: .callDelegate)
     }
     
     /* Creates an upload task with the given request.  The body of the request is provided from the bodyData. */
-    open func uploadTask(with request: NSURLRequest, fromData bodyData: Data) -> URLSessionUploadTask {
+    open func uploadTask(with request: URLRequest, fromData bodyData: Data) -> URLSessionUploadTask {
         let r = URLSession._Request(request)
         return uploadTask(with: r, body: .data(createDispatchData(bodyData)), behaviour: .callDelegate)
     }
     
     /* Creates an upload task with the given request.  The previously set body stream of the request (if any) is ignored and the URLSession:task:needNewBodyStream: delegate will be called when the body payload is required. */
-    open func uploadTask(withStreamedRequest request: NSURLRequest) -> URLSessionUploadTask { NSUnimplemented() }
+    open func uploadTask(withStreamedRequest request: URLRequest) -> URLSessionUploadTask { NSUnimplemented() }
     
     /* Creates a download task with the given request. */
-    open func downloadTask(with request: NSURLRequest) -> URLSessionDownloadTask {
+    open func downloadTask(with request: URLRequest) -> URLSessionDownloadTask {
         let r = URLSession._Request(request)
         return downloadTask(with: r, behavior: .callDelegate)
     }
@@ -328,10 +328,10 @@ open class URLSession : NSObject {
 // Helpers
 fileprivate extension URLSession {
     enum _Request {
-        case request(NSURLRequest)
+        case request(URLRequest)
         case url(URL)
     }
-    func createConfiguredRequest(from request: URLSession._Request) -> NSURLRequest {
+    func createConfiguredRequest(from request: URLSession._Request) -> URLRequest {
         let r = request.createMutableURLRequest()
         _configuration.configure(request: r)
         return r
@@ -341,15 +341,15 @@ extension URLSession._Request {
     init(_ url: URL) {
         self = .url(url)
     }
-    init(_ request: NSURLRequest) {
+    init(_ request: URLRequest) {
         self = .request(request)
     }
 }
 extension URLSession._Request {
-    func createMutableURLRequest() -> NSMutableURLRequest {
+    func createMutableURLRequest() -> URLRequest {
         switch self {
-        case .url(let url): return NSMutableURLRequest(url: url)
-        case .request(let r): return r.mutableCopy() as! NSMutableURLRequest
+        case .url(let url): return URLRequest(url: url)
+        case .request(let r): return r
         }
     }
 }
@@ -420,7 +420,7 @@ extension URLSession {
      * see <Foundation/NSURLError.h>.  The delegate, if any, will still be
      * called for authentication challenges.
      */
-    open func dataTask(with request: NSURLRequest, completionHandler: @escaping (Data?, URLResponse?, NSError?) -> Void) -> URLSessionDataTask {
+    open func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, NSError?) -> Void) -> URLSessionDataTask {
         return dataTask(with: _Request(request), behaviour: .dataCompletionHandler(completionHandler))
     }
 
@@ -431,12 +431,12 @@ extension URLSession {
     /*
      * upload convenience method.
      */
-    open func uploadTask(with request: NSURLRequest, fromFile fileURL: URL, completionHandler: @escaping (Data?, URLResponse?, NSError?) -> Void) -> URLSessionUploadTask {
+    open func uploadTask(with request: URLRequest, fromFile fileURL: URL, completionHandler: @escaping (Data?, URLResponse?, NSError?) -> Void) -> URLSessionUploadTask {
         let fileData = try! Data(contentsOf: fileURL) 
         return uploadTask(with: request, fromData: fileData, completionHandler: completionHandler)
     }
 
-    open func uploadTask(with request: NSURLRequest, fromData bodyData: Data?, completionHandler: @escaping (Data?, URLResponse?, NSError?) -> Void) -> URLSessionUploadTask { 
+    open func uploadTask(with request: URLRequest, fromData bodyData: Data?, completionHandler: @escaping (Data?, URLResponse?, NSError?) -> Void) -> URLSessionUploadTask {
         return uploadTask(with: _Request(request), body: .data(createDispatchData(bodyData!)), behaviour: .dataCompletionHandler(completionHandler))
     }
     
@@ -446,7 +446,7 @@ extension URLSession {
      * copied during the invocation of the completion routine.  The file
      * will be removed automatically.
      */
-    open func downloadTask(with request: NSURLRequest, completionHandler: @escaping (URL?, URLResponse?, NSError?) -> Void) -> URLSessionDownloadTask { 
+    open func downloadTask(with request: URLRequest, completionHandler: @escaping (URL?, URLResponse?, NSError?) -> Void) -> URLSessionDownloadTask {
         return downloadTask(with: _Request(request), behavior: .downloadCompletionHandler(completionHandler))
     }
 

--- a/Foundation/NSURLSession/NSURLSessionConfiguration.swift
+++ b/Foundation/NSURLSession/NSURLSessionConfiguration.swift
@@ -33,7 +33,7 @@
 /// on behalf of a suspended application, within certain constraints.
 open class URLSessionConfiguration : NSObject, NSCopying {
     public override init() {
-        self.requestCachePolicy = NSURLRequest.CachePolicy.useProtocolCachePolicy
+        self.requestCachePolicy = URLRequest.CachePolicy.useProtocolCachePolicy
         self.timeoutIntervalForRequest = 60
         self.timeoutIntervalForResource = 604800
         self.networkServiceType = .default
@@ -51,10 +51,10 @@ open class URLSessionConfiguration : NSObject, NSCopying {
     }
     
     private init(identifier: String?,
-                 requestCachePolicy: NSURLRequest.CachePolicy,
+                 requestCachePolicy: URLRequest.CachePolicy,
                  timeoutIntervalForRequest: TimeInterval,
                  timeoutIntervalForResource: TimeInterval,
-                 networkServiceType: NSURLRequest.NetworkServiceType,
+                 networkServiceType: URLRequest.NetworkServiceType,
                  allowsCellularAccess: Bool,
                  discretionary: Bool,
                  connectionProxyDictionary: [AnyHashable:Any]?,
@@ -126,7 +126,7 @@ open class URLSessionConfiguration : NSObject, NSCopying {
     open var identifier: String?
     
     /* default cache policy for requests */
-    open var requestCachePolicy: NSURLRequest.CachePolicy
+    open var requestCachePolicy: URLRequest.CachePolicy
     
     /* default timeout for requests.  This will cause a timeout if no data is transmitted for the given timeout value, and is reset whenever data is transmitted. */
     open var timeoutIntervalForRequest: TimeInterval
@@ -135,7 +135,7 @@ open class URLSessionConfiguration : NSObject, NSCopying {
     open var timeoutIntervalForResource: TimeInterval
     
     /* type of service for requests. */
-    open var networkServiceType: NSURLRequest.NetworkServiceType
+    open var networkServiceType: URLRequest.NetworkServiceType
     
     /* allow request to route over cellular. */
     open var allowsCellularAccess: Bool

--- a/Foundation/NSURLSession/NSURLSessionDelegate.swift
+++ b/Foundation/NSURLSession/NSURLSessionDelegate.swift
@@ -95,7 +95,7 @@ public protocol URLSessionTaskDelegate : URLSessionDelegate {
      *
      * For tasks in background sessions, redirections will always be followed and this method will not be called.
      */
-    func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: NSURLRequest, completionHandler: @escaping (NSURLRequest?) -> Void)
+    func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void)
     
     /* The task has received a request specific authentication challenge.
      * If this delegate is not implemented, the session specific authentication challenge
@@ -122,7 +122,7 @@ public protocol URLSessionTaskDelegate : URLSessionDelegate {
 }
 
 extension URLSessionTaskDelegate {
-    public func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: NSURLRequest, completionHandler: @escaping (NSURLRequest?) -> Void) {
+    public func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
         completionHandler(request)
     }
     

--- a/TestFoundation/TestNSURLSession.swift
+++ b/TestFoundation/TestNSURLSession.swift
@@ -76,7 +76,7 @@ class TestURLSession : XCTestCase {
 
     func test_dataTaskWithURLRequest() {
         let urlString = "https://restcountries.eu/rest/v1/name/Peru?fullText=true"
-        let urlRequest = NSURLRequest(url: URL(string: urlString)!)
+        let urlRequest = URLRequest(url: URL(string: urlString)!)
         let d = DataTask(with: expectation(description: "data task"))     
         d.run(with: urlRequest)
         waitForExpectations(timeout: 12)
@@ -87,7 +87,7 @@ class TestURLSession : XCTestCase {
 
     func test_dataTaskWithURLRequestCompletionHandler() {
         let urlString = "https://restcountries.eu/rest/v1/name/Italy?fullText=true"
-        let urlRequest = NSURLRequest(url: URL(string: urlString)!)
+        let urlRequest = URLRequest(url: URL(string: urlString)!)
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 8
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
@@ -125,7 +125,7 @@ class TestURLSession : XCTestCase {
 
     func test_downloadTaskWithURLRequest() {
        let urlString = "https://swift.org/LICENSE.txt"
-       let urlRequest = NSURLRequest(url: URL(string: urlString)!)  
+       let urlRequest = URLRequest(url: URL(string: urlString)!)
        let d = DownloadTask(with: expectation(description: "download task with delegate"))
        d.run(with: urlRequest)
        waitForExpectations(timeout: 12)
@@ -136,7 +136,7 @@ class TestURLSession : XCTestCase {
         config.timeoutIntervalForRequest = 8
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
         let expect = expectation(description: "download task with handler")
-        let req = NSMutableURLRequest(url: URL(string: "https://swift.org/LICENSE.txt")!)
+        let req = URLRequest(url: URL(string: "https://swift.org/LICENSE.txt")!)
         let task = session.downloadTask(with: req) { (_, _, error) -> Void in
             if let e = error {
                 XCTAssertEqual(e.code, NSURLErrorTimedOut, "Unexpected error code")
@@ -152,7 +152,7 @@ class TestURLSession : XCTestCase {
         config.timeoutIntervalForRequest = 8
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
         let expect = expectation(description: "download task with handler")
-        let req = NSMutableURLRequest(url: URL(string: "https://swift.org/LICENSE.txt")!)
+        let req = URLRequest(url: URL(string: "https://swift.org/LICENSE.txt")!)
         let task = session.downloadTask(with: req) { (_, _, error) -> Void in
             if let e = error {
                 XCTAssertEqual(e.code, NSURLErrorTimedOut, "Unexpected error code")
@@ -175,7 +175,7 @@ class DataTask: NSObject {
        dataTaskExpectation = expectation 
     }
 
-    func run(with request: NSURLRequest) {
+    func run(with request: URLRequest) {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 8
         session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
@@ -233,7 +233,7 @@ class DownloadTask : NSObject {
         task.resume()
     }
 
-    func run(with urlRequest: NSURLRequest) {
+    func run(with urlRequest: URLRequest) {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 8
         session = URLSession(configuration: config, delegate: self, delegateQueue: nil)

--- a/TestFoundation/TestURLRequest.swift
+++ b/TestFoundation/TestURLRequest.swift
@@ -1,0 +1,198 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+class TestURLRequest : XCTestCase {
+    
+    static var allTests: [(String, (TestURLRequest) -> () throws -> Void)] {
+        return [
+            ("test_construction", test_construction),
+            ("test_mutableConstruction", test_mutableConstruction),
+            ("test_headerFields", test_headerFields),
+            ("test_copy", test_copy),
+            ("test_mutableCopy_1", test_mutableCopy_1),
+            ("test_mutableCopy_2", test_mutableCopy_2),
+            ("test_mutableCopy_3", test_mutableCopy_3),
+        ]
+    }
+    
+    let url = URL(string: "http://swift.org")!
+    
+    func test_construction() {
+        let request = URLRequest(url: url)
+        // Match OS X Foundation responses
+        XCTAssertNotNil(request)
+        XCTAssertEqual(request.url, url)
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertNil(request.allHTTPHeaderFields)
+        XCTAssertNil(request.mainDocumentURL)
+    }
+    
+    func test_mutableConstruction() {
+        let url = URL(string: "http://swift.org")!
+        var request = URLRequest(url: url)
+        
+        //Confirm initial state matches NSURLRequest responses
+        XCTAssertNotNil(request)
+        XCTAssertEqual(request.url, url)
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertNil(request.allHTTPHeaderFields)
+        XCTAssertNil(request.mainDocumentURL)
+        
+        request.mainDocumentURL = url
+        XCTAssertEqual(request.mainDocumentURL, url)
+        
+        request.httpMethod = "POST"
+        XCTAssertEqual(request.httpMethod, "POST")
+        
+        let newURL = URL(string: "http://github.com")!
+        request.url = newURL
+        XCTAssertEqual(request.url, newURL)
+    }
+    
+    func test_headerFields() {
+        var request = URLRequest(url: url)
+        
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        XCTAssertNotNil(request.allHTTPHeaderFields)
+        XCTAssertEqual(request.allHTTPHeaderFields?["Accept"], "application/json")
+        
+        // Setting "accept" should remove "Accept"
+        request.setValue("application/xml", forHTTPHeaderField: "accept")
+        XCTAssertNil(request.allHTTPHeaderFields?["Accept"])
+        XCTAssertEqual(request.allHTTPHeaderFields?["accept"], "application/xml")
+        
+        // Adding to "Accept" should add to "accept"
+        request.addValue("text/html", forHTTPHeaderField: "Accept")
+        XCTAssertEqual(request.allHTTPHeaderFields?["accept"], "application/xml,text/html")
+    }
+    
+    func test_copy() {
+        var mutableRequest = URLRequest(url: url)
+        
+        let urlA = URL(string: "http://swift.org")!
+        let urlB = URL(string: "http://github.com")!
+        mutableRequest.mainDocumentURL = urlA
+        mutableRequest.url = urlB
+        mutableRequest.httpMethod = "POST"
+        mutableRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        
+        let requestCopy1 = mutableRequest
+        
+        // Check that all attributes are copied and that the original ones are
+        // unchanged:
+        XCTAssertEqual(mutableRequest.mainDocumentURL, urlA)
+        XCTAssertEqual(requestCopy1.mainDocumentURL, urlA)
+        XCTAssertEqual(mutableRequest.httpMethod, "POST")
+        XCTAssertEqual(requestCopy1.httpMethod, "POST")
+        XCTAssertEqual(mutableRequest.url, urlB)
+        XCTAssertEqual(requestCopy1.url, urlB)
+        XCTAssertEqual(mutableRequest.allHTTPHeaderFields?["Accept"], "application/json")
+        XCTAssertEqual(requestCopy1.allHTTPHeaderFields?["Accept"], "application/json")
+        
+        // Change the original, and check that the copy has unchanged
+        // values:
+        let urlC = URL(string: "http://apple.com")!
+        let urlD = URL(string: "http://ibm.com")!
+        mutableRequest.mainDocumentURL = urlC
+        mutableRequest.url = urlD
+        mutableRequest.httpMethod = "HEAD"
+        mutableRequest.addValue("text/html", forHTTPHeaderField: "Accept")
+        XCTAssertEqual(requestCopy1.mainDocumentURL, urlA)
+        XCTAssertEqual(requestCopy1.httpMethod, "POST")
+        XCTAssertEqual(requestCopy1.url, urlB)
+        XCTAssertEqual(requestCopy1.allHTTPHeaderFields?["Accept"], "application/json")
+        
+        // Check that we can copy the copy:
+        let requestCopy2 = requestCopy1
+        
+        XCTAssertEqual(requestCopy2.mainDocumentURL, urlA)
+        XCTAssertEqual(requestCopy2.httpMethod, "POST")
+        XCTAssertEqual(requestCopy2.url, urlB)
+        XCTAssertEqual(requestCopy2.allHTTPHeaderFields?["Accept"], "application/json")
+    }
+    
+    func test_mutableCopy_1() {
+        var originalRequest = URLRequest(url: url)
+        
+        let urlA = URL(string: "http://swift.org")!
+        let urlB = URL(string: "http://github.com")!
+        originalRequest.mainDocumentURL = urlA
+        originalRequest.url = urlB
+        originalRequest.httpMethod = "POST"
+        originalRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        
+        let requestCopy = originalRequest
+        
+        // Change the original, and check that the copy has unchanged values:
+        let urlC = URL(string: "http://apple.com")!
+        let urlD = URL(string: "http://ibm.com")!
+        originalRequest.mainDocumentURL = urlC
+        originalRequest.url = urlD
+        originalRequest.httpMethod = "HEAD"
+        originalRequest.addValue("text/html", forHTTPHeaderField: "Accept")
+        XCTAssertEqual(requestCopy.mainDocumentURL, urlA)
+        XCTAssertEqual(requestCopy.httpMethod, "POST")
+        XCTAssertEqual(requestCopy.url, urlB)
+        XCTAssertEqual(requestCopy.allHTTPHeaderFields?["Accept"], "application/json")
+    }
+    
+    func test_mutableCopy_2() {
+        var originalRequest = URLRequest(url: url)
+        
+        let urlA = URL(string: "http://swift.org")!
+        let urlB = URL(string: "http://github.com")!
+        originalRequest.mainDocumentURL = urlA
+        originalRequest.url = urlB
+        originalRequest.httpMethod = "POST"
+        originalRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        
+        var requestCopy = originalRequest
+        
+        // Change the copy, and check that the original has unchanged values:
+        let urlC = URL(string: "http://apple.com")!
+        let urlD = URL(string: "http://ibm.com")!
+        requestCopy.mainDocumentURL = urlC
+        requestCopy.url = urlD
+        requestCopy.httpMethod = "HEAD"
+        requestCopy.addValue("text/html", forHTTPHeaderField: "Accept")
+        XCTAssertEqual(originalRequest.mainDocumentURL, urlA)
+        XCTAssertEqual(originalRequest.httpMethod, "POST")
+        XCTAssertEqual(originalRequest.url, urlB)
+        XCTAssertEqual(originalRequest.allHTTPHeaderFields?["Accept"], "application/json")
+    }
+    
+    func test_mutableCopy_3() {
+        let urlA = URL(string: "http://swift.org")!
+        let originalRequest = URLRequest(url: urlA)
+        
+        var requestCopy = originalRequest
+        
+        // Change the copy, and check that the original has unchanged values:
+        let urlC = URL(string: "http://apple.com")!
+        let urlD = URL(string: "http://ibm.com")!
+        requestCopy.mainDocumentURL = urlC
+        requestCopy.url = urlD
+        requestCopy.httpMethod = "HEAD"
+        requestCopy.addValue("text/html", forHTTPHeaderField: "Accept")
+        XCTAssertNil(originalRequest.mainDocumentURL)
+        XCTAssertEqual(originalRequest.httpMethod, "GET")
+        XCTAssertEqual(originalRequest.url, urlA)
+        XCTAssertNil(originalRequest.allHTTPHeaderFields)
+    }
+}
+

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -68,6 +68,7 @@ XCTMain([
     testCase(TestNSURLComponents.allTests),
     testCase(TestNSURLCredential.allTests),
     testCase(TestNSURLRequest.allTests),
+    testCase(TestURLRequest.allTests),
     testCase(TestNSURLResponse.allTests),
     testCase(TestNSHTTPURLResponse.allTests),
     testCase(TestURLSession.allTests),


### PR DESCRIPTION
A number of the URLSession APIs should now take `URLRequest` rather than `NSURLRequest` or `NSMutableURLRequest` as parameters. Examples of this include:
```
open func dataTask(with request: URLRequest) -> URLSessionDataTask
open func uploadTask(with request: URLRequest, from bodyData: Data) -> URLSessionUploadTask
open func downloadTask(with request: URLRequest) -> URLSessionDownloadTask
```
This PR switches over to using `URLRequest` rather than the existing use of `NSURLRequest`.

I've additionally added tests for `URLRequest` in addition to `NSURLRequest` (which still exists) by duplicating the existing `NSURLRequest` tests. 

Whilst doing this I hit a crash when trying to mutate a value in a copied `URLRequest`. This is caused because, when we call `_appyMutation` for a non-uniquely referenced value, we create a new `_MutableHandle`. The `_MutableHandle` constructor calls `copy()` on the referent (in our case a `NSMutableURLSession`). Calling `NSMutableURLSession.copy()` actually returns a `NSURLSession` (as it inherits copy() from NSURLSession), which fails because its not a `MutableType`. I've fixed this by overriding copy in `NSMutableURLSession` to return `mutableCopy()`.