### PR TITLE
Fix va_list on arm, and 32-bit CGFloat.NativeType

### DIFF
--- a/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
+++ b/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
@@ -34,7 +34,9 @@
 #include <setjmp.h>
 #include <signal.h>
 #include <stddef.h>
+#if !defined(__arm__)
 #include <stdio.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>

--- a/CoreFoundation/URL.subproj/CFURLSessionInterface.h
+++ b/CoreFoundation/URL.subproj/CFURLSessionInterface.h
@@ -27,7 +27,9 @@
 #if !defined(__COREFOUNDATION_URLSESSIONINTERFACE__)
 #define __COREFOUNDATION_URLSESSIONINTERFACE__ 1
 
+#if !defined(__arm__)
 #include <stdio.h>
+#endif
 
 CF_IMPLICIT_BRIDGING_ENABLED
 CF_EXTERN_C_BEGIN

--- a/Foundation/NSXMLNode.swift
+++ b/Foundation/NSXMLNode.swift
@@ -83,7 +83,7 @@ open class XMLNode: NSObject, NSCopying {
         public static let nodePromoteSignificantWhitespace = Options(rawValue: 1 << 28)
         public static let nodePreserveEmptyElements = Options([.nodeExpandEmptyElement, .nodeCompactEmptyElement])
         public static let nodePreserveQuotes = Options([.nodeUseSingleQuotes, .nodeUseDoubleQuotes])
-        public static let nodePreserveAll = Options(rawValue: Options([.nodePreserveNamespaceOrder, .nodePreserveAttributeOrder, .nodePreserveEntities, .nodePreservePrefixes, .nodePreserveCDATA, .nodePreserveEmptyElements, .nodePreserveQuotes, .nodePreserveWhitespace, .nodePreserveDTD, .nodePreserveCharacterReferences]).rawValue | UInt(bitPattern: 0xFFF00000))
+        public static let nodePreserveAll = Options([.nodePreserveNamespaceOrder, .nodePreserveAttributeOrder, .nodePreserveEntities, .nodePreservePrefixes, .nodePreserveCDATA, .nodePreserveEmptyElements, .nodePreserveQuotes, .nodePreserveWhitespace, .nodePreserveDTD, .nodePreserveCharacterReferences])
     }
 
     open override func copy() -> Any {


### PR DESCRIPTION
This PR addresses a few problems that CF has accumulated on arm-linux platforms.  One obviates the need for https://github.com/apple/swift-corelibs-foundation/pull/399 by @karwa (and makes it hopefully more palatable).  Also, a more recent addition of an import of stdio.h expresses a similar issue with the redefinition of va_list.

Another issue addressed with this PR is the fact that CGFloat.NativeType is now Float on32-bit systems and Double on 64-bit, thanks to https://github.com/apple/swift-corelibs-foundation/pull/585 .  There is a function in NSGeometry that assumed that CGFloat.native would always return Double.  It's intermediate variables are now CGFloat.NativeType.

Finally, NSXML has a constant bitfield assignment that has been mentioned is redundant (see https://github.com/apple/swift-corelibs-foundation/commit/998d5c04da984bfc0128acf57ed88375370b2b0e#commitcomment-18697699 ), but causes issues when used with signed 32-bit types.  I've removed that.
