### PR TITLE
Fixing a typo in internal bridging protocol names (NFC)

### DIFF
--- a/Foundation/Bridging.swift
+++ b/Foundation/Bridging.swift
@@ -33,7 +33,7 @@ public protocol _ObjectTypeBridgeable : _ObjectBridgeable {
     static func _unconditionallyBridgeFromObjectiveC(_ source: _ObjectType?) -> Self
 }
 
-/// - Note: This does not exist currently on Darwin but it is the inverse corrilation to the bridge types such that a 
+/// - Note: This does not exist currently on Darwin but it is the inverse correlation to the bridge types such that a 
 /// reference type can be converted via a callout to a conversion method.
 public protocol _StructTypeBridgeable : _StructBridgeable {
     associatedtype _StructType

--- a/Foundation/Bridging.swift
+++ b/Foundation/Bridging.swift
@@ -55,17 +55,17 @@ extension _StructTypeBridgeable {
 }
 
 // slated for removal, these are the swift-corelibs-only variant of the _ObjectiveCBridgeable
-internal protocol _CFBridgable {
+internal protocol _CFBridgeable {
     associatedtype CFType
     var _cfObject: CFType { get }
 }
 
-internal protocol _SwiftBridgable {
+internal protocol _SwiftBridgeable {
     associatedtype SwiftType
     var _swiftObject: SwiftType { get }
 }
 
-internal protocol _NSBridgable {
+internal protocol _NSBridgeable {
     associatedtype NSType
     var _nsObject: NSType { get }
 }

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -589,7 +589,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
     }
 }
 
-extension NSArray : _CFBridgable, _SwiftBridgable {
+extension NSArray : _CFBridgeable, _SwiftBridgeable {
     internal var _cfObject: CFArray { return unsafeBitCast(self, to: CFArray.self) }
     internal var _swiftObject: [AnyObject] { return Array._unconditionallyBridgeFromObjectiveC(self) }
 }
@@ -598,7 +598,7 @@ extension NSMutableArray {
     internal var _cfMutableObject: CFMutableArray { return unsafeBitCast(self, to: CFMutableArray.self) }
 }
 
-extension CFArray : _NSBridgable, _SwiftBridgable {
+extension CFArray : _NSBridgeable, _SwiftBridgeable {
     internal var _nsObject: NSArray { return unsafeBitCast(self, to: NSArray.self) }
     internal var _swiftObject: Array<Any> { return _nsObject._swiftObject }
 }
@@ -606,7 +606,7 @@ extension CFArray : _NSBridgable, _SwiftBridgable {
 extension CFArray {
     /// Bridge something returned from CF to an Array<T>. Useful when we already know that a CFArray contains objects that are toll-free bridged with Swift objects, e.g. CFArray<CFURLRef>.
     /// - Note: This bridging operation is unfortunately still O(n), but it only traverses the NSArray once, creating the Swift array and casting at the same time.
-    func _unsafeTypedBridge<T : _CFBridgable>() -> Array<T> {
+    func _unsafeTypedBridge<T : _CFBridgeable>() -> Array<T> {
         var result = Array<T>()
         let count = CFArrayGetCount(self)
         result.reserveCapacity(count)
@@ -617,7 +617,7 @@ extension CFArray {
     }
 }
 
-extension Array : _NSBridgable, _CFBridgable {
+extension Array : _NSBridgeable, _CFBridgeable {
     internal var _nsObject: NSArray { return _bridgeToObjectiveC() }
     internal var _cfObject: CFArray { return _nsObject._cfObject }
 }

--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -186,7 +186,7 @@ private extension NSAttributedString {
     }
 }
 
-extension NSAttributedString: _CFBridgable {
+extension NSAttributedString: _CFBridgeable {
     internal var _cfObject: CFAttributedString { return unsafeBitCast(self, to: CFAttributedString.self) }
 }
 

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -1822,28 +1822,28 @@ open class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
     }
 }
 
-extension NSDateComponents : _SwiftBridgable {
+extension NSDateComponents : _SwiftBridgeable {
     typealias SwiftType = DateComponents
     var _swiftObject: SwiftType { return DateComponents(reference: self) }
 }
 
-extension DateComponents : _NSBridgable {
+extension DateComponents : _NSBridgeable {
     typealias NSType = NSDateComponents
     var _nsObject: NSType { return _bridgeToObjectiveC() }
 }
 
-extension NSCalendar: _SwiftBridgable, _CFBridgable {
+extension NSCalendar: _SwiftBridgeable, _CFBridgeable {
     typealias SwiftType = Calendar
     var _swiftObject: SwiftType { return Calendar(reference: self) }
 }
-extension Calendar: _NSBridgable, _CFBridgable {
+extension Calendar: _NSBridgeable, _CFBridgeable {
     typealias NSType = NSCalendar
     typealias CFType = CFCalendar
     var _nsObject: NSCalendar { return _bridgeToObjectiveC() }
     var _cfObject: CFCalendar { return _nsObject._cfObject }
 }
 
-extension CFCalendar : _NSBridgable, _SwiftBridgable {
+extension CFCalendar : _NSBridgeable, _SwiftBridgeable {
     typealias NSType = NSCalendar
     internal var _nsObject: NSType { return unsafeBitCast(self, to: NSType.self) }
     internal var _swiftObject: Calendar { return _nsObject._swiftObject }

--- a/Foundation/NSCharacterSet.swift
+++ b/Foundation/NSCharacterSet.swift
@@ -320,7 +320,7 @@ open class NSMutableCharacterSet : NSCharacterSet {
     }
 }
 
-extension CharacterSet : _CFBridgable, _NSBridgable {
+extension CharacterSet : _CFBridgeable, _NSBridgeable {
     typealias CFType = CFCharacterSet
     typealias NSType = NSCharacterSet
     internal var _cfObject: CFType {
@@ -331,7 +331,7 @@ extension CharacterSet : _CFBridgable, _NSBridgable {
     }
 }
 
-extension CFCharacterSet : _NSBridgable, _SwiftBridgable {
+extension CFCharacterSet : _NSBridgeable, _SwiftBridgeable {
     typealias NSType = NSCharacterSet
     typealias SwiftType = CharacterSet
     internal var _nsObject: NSType {
@@ -342,7 +342,7 @@ extension CFCharacterSet : _NSBridgable, _SwiftBridgable {
     }
 }
 
-extension NSCharacterSet : _SwiftBridgable {
+extension NSCharacterSet : _SwiftBridgeable {
     typealias SwiftType = CharacterSet
     internal var _swiftObject: SwiftType {
         return CharacterSet(_bridged: self)

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -847,19 +847,19 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
 }
 
 // MARK: -
-extension NSData : _CFBridgable, _SwiftBridgable {
+extension NSData : _CFBridgeable, _SwiftBridgeable {
     typealias SwiftType = Data
     internal var _swiftObject: SwiftType { return Data(referencing: self) }
 }
 
-extension Data : _NSBridgable, _CFBridgable {
+extension Data : _NSBridgeable, _CFBridgeable {
     typealias CFType = CFData
     typealias NSType = NSData
     internal var _cfObject: CFType { return _nsObject._cfObject }
     internal var _nsObject: NSType { return _bridgeToObjectiveC() }
 }
 
-extension CFData : _NSBridgable, _SwiftBridgable {
+extension CFData : _NSBridgeable, _SwiftBridgeable {
     typealias NSType = NSData
     typealias SwiftType = Data
     internal var _nsObject: NSType { return unsafeBitCast(self, to: NSType.self) }

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -225,14 +225,14 @@ extension NSDate {
     }
 }
 
-extension NSDate: _CFBridgable, _SwiftBridgable {
+extension NSDate: _CFBridgeable, _SwiftBridgeable {
     typealias SwiftType = Date
     var _swiftObject: Date {
         return Date(timeIntervalSinceReferenceDate: timeIntervalSinceReferenceDate)
     }
 }
 
-extension CFDate : _NSBridgable, _SwiftBridgable {
+extension CFDate : _NSBridgeable, _SwiftBridgeable {
     typealias NSType = NSDate
     typealias SwiftType = Date
     
@@ -240,7 +240,7 @@ extension CFDate : _NSBridgable, _SwiftBridgable {
     internal var _swiftObject: Date { return _nsObject._swiftObject }
 }
 
-extension Date : _NSBridgable, _CFBridgable {
+extension Date : _NSBridgeable, _CFBridgeable {
     typealias NSType = NSDate
     typealias CFType = CFDate
     

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -466,7 +466,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     }
 }
 
-extension NSDictionary : _CFBridgable, _SwiftBridgable {
+extension NSDictionary : _CFBridgeable, _SwiftBridgeable {
     internal var _cfObject: CFDictionary { return unsafeBitCast(self, to: CFDictionary.self) }
     internal var _swiftObject: Dictionary<AnyHashable, Any> { return Dictionary._unconditionallyBridgeFromObjectiveC(self) }
 }
@@ -475,12 +475,12 @@ extension NSMutableDictionary {
     internal var _cfMutableObject: CFMutableDictionary { return unsafeBitCast(self, to: CFMutableDictionary.self) }
 }
 
-extension CFDictionary : _NSBridgable, _SwiftBridgable {
+extension CFDictionary : _NSBridgeable, _SwiftBridgeable {
     internal var _nsObject: NSDictionary { return unsafeBitCast(self, to: NSDictionary.self) }
     internal var _swiftObject: [AnyHashable: Any] { return _nsObject._swiftObject }
 }
 
-extension Dictionary : _NSBridgable, _CFBridgable {
+extension Dictionary : _NSBridgeable, _CFBridgeable {
     internal var _nsObject: NSDictionary { return _bridgeToObjectiveC() }
     internal var _cfObject: CFDictionary { return _nsObject._cfObject }
 }

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -197,8 +197,8 @@ open class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
 
 extension NSError : Swift.Error { }
 
-extension NSError : _CFBridgable { }
-extension CFError : _NSBridgable {
+extension NSError : _CFBridgeable { }
+extension CFError : _NSBridgeable {
     typealias NSType = NSError
     internal var _nsObject: NSType {
         let userInfo = CFErrorCopyUserInfo(self)._swiftObject

--- a/Foundation/NSKeyedArchiverHelpers.swift
+++ b/Foundation/NSKeyedArchiverHelpers.swift
@@ -9,7 +9,7 @@
 
 import CoreFoundation
 
-extension CFKeyedArchiverUID : _NSBridgable {
+extension CFKeyedArchiverUID : _NSBridgeable {
     typealias NSType = _NSKeyedArchiverUID
     
     internal var _nsObject: NSType { return unsafeBitCast(self, to: NSType.self) }

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -251,7 +251,7 @@ public func <(_ lhs: NSLocale.Key, _ rhs: NSLocale.Key) -> Bool {
 public let NSCurrentLocaleDidChangeNotification: String = "kCFLocaleCurrentLocaleDidChangeNotification"
 
 
-extension CFLocale : _NSBridgable, _SwiftBridgable {
+extension CFLocale : _NSBridgeable, _SwiftBridgeable {
     typealias NSType = NSLocale
     typealias SwiftType = Locale
     internal var _nsObject: NSLocale {
@@ -262,14 +262,14 @@ extension CFLocale : _NSBridgable, _SwiftBridgable {
     }
 }
 
-extension NSLocale : _SwiftBridgable {
+extension NSLocale : _SwiftBridgeable {
     typealias SwiftType = Locale
     internal var _swiftObject: Locale {
         return Locale(reference: self)
     }
 }
 
-extension Locale : _CFBridgable {
+extension Locale : _CFBridgeable {
     typealias CFType = CFLocale
     internal var _cfObject: CFLocale {
         return _bridgeToObjectiveC()._cfObject

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -184,7 +184,7 @@ extension Bool : _ObjectTypeBridgeable {
     }
 }
 
-extension Bool : _CFBridgable {
+extension Bool : _CFBridgeable {
     typealias CFType = CFBoolean
     var _cfObject: CFType {
         return self ? kCFBooleanTrue : kCFBooleanFalse
@@ -519,7 +519,7 @@ open class NSNumber : NSValue {
     }
 }
 
-extension CFNumber : _NSBridgable {
+extension CFNumber : _NSBridgeable {
     typealias NSType = NSNumber
     internal var _nsObject: NSType { return unsafeBitCast(self, to: NSType.self) }
 }

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -288,17 +288,17 @@ extension NSSet {
     }
 }
 
-extension NSSet : _CFBridgable, _SwiftBridgable {
+extension NSSet : _CFBridgeable, _SwiftBridgeable {
     internal var _cfObject: CFSet { return unsafeBitCast(self, to: CFSet.self) }
     internal var _swiftObject: Set<NSObject> { return Set._unconditionallyBridgeFromObjectiveC(self) }
 }
 
-extension CFSet : _NSBridgable, _SwiftBridgable {
+extension CFSet : _NSBridgeable, _SwiftBridgeable {
     internal var _nsObject: NSSet { return unsafeBitCast(self, to: NSSet.self) }
     internal var _swiftObject: Set<NSObject> { return _nsObject._swiftObject }
 }
 
-extension Set : _NSBridgable, _CFBridgable {
+extension Set : _NSBridgeable, _CFBridgeable {
     internal var _nsObject: NSSet { return _bridgeToObjectiveC() }
     internal var _cfObject: CFSet { return _nsObject._cfObject }
 }

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -1394,7 +1394,7 @@ extension String {
     }
 }
 
-extension NSString : _CFBridgable, _SwiftBridgable {
+extension NSString : _CFBridgeable, _SwiftBridgeable {
     typealias SwiftType = String
     internal var _cfObject: CFString { return unsafeBitCast(self, to: CFString.self) }
     internal var _swiftObject: String { return String._unconditionallyBridgeFromObjectiveC(self) }
@@ -1404,14 +1404,14 @@ extension NSMutableString {
     internal var _cfMutableObject: CFMutableString { return unsafeBitCast(self, to: CFMutableString.self) }
 }
 
-extension CFString : _NSBridgable, _SwiftBridgable {
+extension CFString : _NSBridgeable, _SwiftBridgeable {
     typealias NSType = NSString
     typealias SwiftType = String
     internal var _nsObject: NSType { return unsafeBitCast(self, to: NSString.self) }
     internal var _swiftObject: String { return _nsObject._swiftObject }
 }
 
-extension String : _NSBridgable, _CFBridgable {
+extension String : _NSBridgeable, _CFBridgeable {
     typealias NSType = NSString
     typealias CFType = CFString
     internal var _nsObject: NSType { return _bridgeToObjectiveC() }

--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -262,18 +262,18 @@ extension NSTimeZone {
 
 }
 
-extension NSTimeZone: _SwiftBridgable, _CFBridgable {
+extension NSTimeZone: _SwiftBridgeable, _CFBridgeable {
     typealias SwiftType = TimeZone
     var _swiftObject: TimeZone { return TimeZone(reference: self) }
 }
 
-extension CFTimeZone : _SwiftBridgable, _NSBridgable {
+extension CFTimeZone : _SwiftBridgeable, _NSBridgeable {
     typealias NSType = NSTimeZone
     var _nsObject : NSTimeZone { return unsafeBitCast(self, to: NSTimeZone.self) }
     var _swiftObject: TimeZone { return _nsObject._swiftObject }
 }
 
-extension TimeZone : _NSBridgable, _CFBridgable {
+extension TimeZone : _NSBridgeable, _CFBridgeable {
     typealias NSType = NSTimeZone
     typealias CFType = CFTimeZone
     var _nsObject : NSTimeZone { return _bridgeToObjectiveC() }

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -1255,19 +1255,19 @@ open class NSURLComponents: NSObject, NSCopying {
     }
 }
 
-extension NSURL: _CFBridgable, _SwiftBridgable {
+extension NSURL: _CFBridgeable, _SwiftBridgeable {
     typealias SwiftType = URL
     internal var _swiftObject: SwiftType { return URL(reference: self) }
 }
 
-extension CFURL : _NSBridgable, _SwiftBridgable {
+extension CFURL : _NSBridgeable, _SwiftBridgeable {
     typealias NSType = NSURL
     typealias SwiftType = URL
     internal var _nsObject: NSType { return unsafeBitCast(self, to: NSType.self) }
     internal var _swiftObject: SwiftType { return _nsObject._swiftObject }
 }
 
-extension URL : _NSBridgable, _CFBridgable {
+extension URL : _NSBridgeable, _CFBridgeable {
     typealias NSType = NSURL
     typealias CFType = CFURL
     internal var _nsObject: NSType { return self.reference }

--- a/Foundation/URLComponents.swift
+++ b/Foundation/URLComponents.swift
@@ -377,22 +377,22 @@ extension URLQueryItem : CustomStringConvertible, CustomDebugStringConvertible, 
     }
 }
 
-extension NSURLComponents : _SwiftBridgable {
+extension NSURLComponents : _SwiftBridgeable {
     typealias SwiftType = URLComponents
     internal var _swiftObject: SwiftType { return URLComponents(reference: self) }
 }
 
-extension URLComponents : _NSBridgable {
+extension URLComponents : _NSBridgeable {
     typealias NSType = NSURLComponents
     internal var _nsObject: NSType { return _handle._copiedReference() }
 }
 
-extension NSURLQueryItem : _SwiftBridgable {
+extension NSURLQueryItem : _SwiftBridgeable {
     typealias SwiftType = URLQueryItem
     internal var _swiftObject: SwiftType { return URLQueryItem(reference: self) }
 }
 
-extension URLQueryItem : _NSBridgable {
+extension URLQueryItem : _NSBridgeable {
     typealias NSType = NSURLQueryItem
     internal var _nsObject: NSType { return _queryItem }
 }


### PR DESCRIPTION
"Bridgeable" not "bridgable".
