### PR TITLE
Add Dispatch to the library list and library search path for linking

### DIFF
--- a/build.py
+++ b/build.py
@@ -88,6 +88,7 @@ if "LIBDISPATCH_SOURCE_DIR" in Configuration.current.variables:
 		'-DDEPLOYMENT_ENABLE_LIBDISPATCH',
 		'-I'+Configuration.current.variables["LIBDISPATCH_SOURCE_DIR"],
 		'-I'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src/swift',
+		'-ldispatch -L'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src/.libs',
 		'-Xcc -fblocks'
 	])
 	foundation.LDFLAGS += '-ldispatch -L'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src/.libs -rpath \$$ORIGIN '


### PR DESCRIPTION
While building on s390x, the linker cannot find the symbols from libdispatch while building TestFoundation.  I'd like to add libdispatch to the library list and search path for linking.