### PR TITLE
Swift 3 API parity for [NS]TimeZone & [NS]Calendar

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -287,6 +287,8 @@ typedef pthread_t _CFThreadRef;
 
 CF_EXPORT _CFThreadRef _CFThreadCreate(const _CFThreadAttributes attrs, void *_Nullable (* _Nonnull startfn)(void *_Nullable), void *restrict _Nullable context);
 
+CF_EXPORT Boolean _CFTimeZoneInitWithTimeIntervalFromGMT(CFTimeZoneRef result, CFTimeInterval ti);
+
 CF_EXPORT Boolean _CFCharacterSetIsLongCharacterMember(CFCharacterSetRef theSet, UTF32Char theChar);
 CF_EXPORT CFCharacterSetRef _CFCharacterSetCreateCopy(CFAllocatorRef alloc, CFCharacterSetRef theSet);
 CF_EXPORT CFMutableCharacterSetRef _CFCharacterSetCreateMutableCopy(CFAllocatorRef alloc, CFCharacterSetRef theSet);

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -287,8 +287,6 @@ typedef pthread_t _CFThreadRef;
 
 CF_EXPORT _CFThreadRef _CFThreadCreate(const _CFThreadAttributes attrs, void *_Nullable (* _Nonnull startfn)(void *_Nullable), void *restrict _Nullable context);
 
-CF_EXPORT Boolean _CFTimeZoneInitWithTimeIntervalFromGMT(CFTimeZoneRef result, CFTimeInterval ti);
-
 CF_EXPORT Boolean _CFCharacterSetIsLongCharacterMember(CFCharacterSetRef theSet, UTF32Char theChar);
 CF_EXPORT CFCharacterSetRef _CFCharacterSetCreateCopy(CFAllocatorRef alloc, CFCharacterSetRef theSet);
 CF_EXPORT CFMutableCharacterSetRef _CFCharacterSetCreateMutableCopy(CFAllocatorRef alloc, CFCharacterSetRef theSet);

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -119,7 +119,7 @@ public func ==(_ lhs: NSCalendar.Identifier, _ rhs: NSCalendar.Identifier) -> Bo
 public func <(_ lhs: NSCalendar.Identifier, _ rhs: NSCalendar.Identifier) -> Bool {
     return lhs.rawValue < rhs.rawValue
 }
-    
+
 open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     typealias CFType = CFCalendar
     private var _base = _CFInfo(typeID: CFCalendarGetTypeID())
@@ -213,7 +213,7 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    public init?(calendar ident: Identifier) {
+    public init?(calendarIdentifier ident: Identifier) {
         super.init()
         if !_CFCalendarInitWithIdentifier(_cfObject, ident.rawValue._cfObject) {
             return nil
@@ -1243,7 +1243,9 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
 // notification is received by observers in a "timely" manner, same as
 // with distributed notifications.
 
-public let NSCalendarDayChangedNotification: String = "" // NSUnimplemented
+extension NSNotification.Name {
+    public static let NSCalendarDayChanged = NSNotification.Name(rawValue: "") // NSUnimplemented
+}
 
 // This is a just used as an extensible struct, basically;
 // note that there are two uses: one for specifying a date
@@ -1445,8 +1447,6 @@ open class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         }
     }
     /*@NSCopying*/ open var timeZone: TimeZone?
-    
-    // these all should probably be optionals
     
     open var era: Int {
         get {

--- a/Foundation/NSDateFormatter.swift
+++ b/Foundation/NSDateFormatter.swift
@@ -148,7 +148,7 @@ open class DateFormatter : Formatter {
 
     open var generatesCalendarDates = false { willSet { _reset() } }
 
-    /*@NSCopying*/ open var timeZone: TimeZone! = NSTimeZone.systemTimeZone() { willSet { _reset() } }
+    /*@NSCopying*/ open var timeZone: TimeZone! = NSTimeZone.system { willSet { _reset() } }
 
     /*@NSCopying*/ internal var _calendar: Calendar! { willSet { _reset() } }
     open var calendar: Calendar! {

--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -294,5 +294,5 @@ extension NSTimeZone {
 }
 
 extension NSNotification.Name {
-    public static let NSSystemTimeZoneDidChange = NSNotification.Name(rawValue: "NSSystemTimeZoneDidChangeNotification") // NSUnimplemented
+    public static let NSSystemTimeZoneDidChange = NSNotification.Name(rawValue: "") // NSUnimplemented
 }

--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -174,7 +174,7 @@ extension NSTimeZone {
 
     open class func resetSystemTimeZone() {
         CFTimeZoneResetSystem()
-        NotificationCenter.default.post(name: NSNotification.Name.NSSystemTimeZoneDidChange, object: nil)
+        // NotificationCenter.default.post(name: NSNotification.Name.NSSystemTimeZoneDidChange, object: nil)
     }
 
     open class var `default`: TimeZone {
@@ -183,7 +183,7 @@ extension NSTimeZone {
         }
         set {
             CFTimeZoneSetDefault(newValue._cfObject)
-            NotificationCenter.default.post(name: NSNotification.Name.NSSystemTimeZoneDidChange, object: nil)
+            // NotificationCenter.default.post(name: NSNotification.Name.NSSystemTimeZoneDidChange, object: nil)
         }
     }
 

--- a/Foundation/TimeZone.swift
+++ b/Foundation/TimeZone.swift
@@ -11,9 +11,16 @@
 //===----------------------------------------------------------------------===//
 
 
-
 internal func __NSTimeZoneIsAutoupdating(_ timezone: NSTimeZone) -> Bool {
     return false
+}
+
+internal func __NSTimeZoneAutoupdating() -> NSTimeZone {
+    return NSTimeZone.local._nsObject
+}
+
+internal func __NSTimeZoneCurrent() -> NSTimeZone {
+    return NSTimeZone.system._nsObject
 }
 
 /**
@@ -25,7 +32,7 @@ internal func __NSTimeZoneIsAutoupdating(_ timezone: NSTimeZone) -> Bool {
  
  Cocoa does not provide any API to change the time zone of the computer, or of other applications.
  */
-public struct TimeZone : CustomStringConvertible, CustomDebugStringConvertible, Hashable, Equatable, ReferenceConvertible {
+public struct TimeZone : Hashable, Equatable, ReferenceConvertible {
     public typealias ReferenceType = NSTimeZone
     
     internal var _wrapped : NSTimeZone
@@ -33,12 +40,16 @@ public struct TimeZone : CustomStringConvertible, CustomDebugStringConvertible, 
     
     /// The time zone currently used by the system.
     public static var current : TimeZone {
-        return NSTimeZone.system
+        return TimeZone(adoptingReference: __NSTimeZoneCurrent(), autoupdating: false)
     }
 
-    /// The time zone currently used by the system, automatically updating to the user’s current preference.
+    /// The time zone currently used by the system, automatically updating to the user's current preference.
+    ///
+    /// If this time zone is mutated, then it no longer tracks the application time zone.
+    ///
+    /// The autoupdating time zone only compares equal to itself.
     public static var autoupdatingCurrent : TimeZone {
-        return NSTimeZone.local
+        return TimeZone(adoptingReference: __NSTimeZoneAutoupdating(), autoupdating: true)
     }
     
     // MARK: -
@@ -195,14 +206,6 @@ public struct TimeZone : CustomStringConvertible, CustomDebugStringConvertible, 
     
     // MARK: -
     
-    public var description: String {
-        return _wrapped.description
-    }
-    
-    public var debugDescription : String {
-        return _wrapped.debugDescription
-    }
-    
     public var hashValue : Int {
         if _autoupdating {
             return 1
@@ -210,13 +213,43 @@ public struct TimeZone : CustomStringConvertible, CustomDebugStringConvertible, 
             return _wrapped.hash
         }
     }
+
+    public static func ==(lhs: TimeZone, rhs: TimeZone) -> Bool {
+        if lhs._autoupdating || rhs._autoupdating {
+            return lhs._autoupdating == rhs._autoupdating
+        } else {
+            return lhs._wrapped.isEqual(rhs._wrapped)
+        }
+    }
 }
 
-public func ==(_ lhs: TimeZone, _ rhs: TimeZone) -> Bool {
-    if lhs._autoupdating || rhs._autoupdating {
-        return lhs._autoupdating == rhs._autoupdating
-    } else {
-        return lhs._wrapped.isEqual(rhs._wrapped)
+extension TimeZone : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    private var _kindDescription : String {
+        if (self == TimeZone.autoupdatingCurrent) {
+            return "autoupdatingCurrent"
+        } else if (self == TimeZone.current) {
+            return "current"
+        } else {
+            return "fixed"
+        }
+    }
+
+    public var customMirror : Mirror {
+        var c: [(label: String?, value: Any)] = []
+        c.append((label: "identifier", value: identifier))
+        c.append((label: "kind", value: _kindDescription))
+        c.append((label: "abbreviation", value: abbreviation()))
+        c.append((label: "secondsFromGMT", value: secondsFromGMT()))
+        c.append((label: "isDaylightSavingTime", value: isDaylightSavingTime()))
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+    }
+
+    public var description: String {
+        return "\(identifier) (\(_kindDescription))"
+    }
+
+    public var debugDescription : String {
+        return "\(identifier) (\(_kindDescription))"
     }
 }
 
@@ -248,4 +281,3 @@ extension TimeZone {
         return result!
     }
 }
-

--- a/Foundation/TimeZone.swift
+++ b/Foundation/TimeZone.swift
@@ -16,10 +16,6 @@ internal func __NSTimeZoneIsAutoupdating(_ timezone: NSTimeZone) -> Bool {
     return false
 }
 
-internal func __NSTimeZoneCurrent() -> NSTimeZone {
-    fatalError()
-}
-
 /**
  `TimeZone` defines the behavior of a time zone. Time zone values represent geopolitical regions. Consequently, these values have names for these regions. Time zone values also represent a temporal offset, either plus or minus, from Greenwich Mean Time (GMT) and an abbreviation (such as PST for Pacific Standard Time).
  
@@ -37,7 +33,12 @@ public struct TimeZone : CustomStringConvertible, CustomDebugStringConvertible, 
     
     /// The time zone currently used by the system.
     public static var current : TimeZone {
-        return TimeZone(adoptingReference: __NSTimeZoneCurrent(), autoupdating: false)
+        return NSTimeZone.system
+    }
+
+    /// The time zone currently used by the system, automatically updating to the user’s current preference.
+    public static var autoupdatingCurrent : TimeZone {
+        return NSTimeZone.local
     }
     
     // MARK: -

--- a/Foundation/TimeZone.swift
+++ b/Foundation/TimeZone.swift
@@ -225,9 +225,7 @@ public struct TimeZone : Hashable, Equatable, ReferenceConvertible {
 
 extension TimeZone : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
     private var _kindDescription : String {
-        if (self == TimeZone.autoupdatingCurrent) {
-            return "autoupdatingCurrent"
-        } else if (self == TimeZone.current) {
+        if (self == TimeZone.current) {
             return "current"
         } else {
             return "fixed"

--- a/TestFoundation/TestNSTimeZone.swift
+++ b/TestFoundation/TestNSTimeZone.swift
@@ -33,7 +33,7 @@ class TestNSTimeZone: XCTestCase {
     }
 
     func test_abbreviation() {
-        let tz = NSTimeZone.systemTimeZone()
+        let tz = NSTimeZone.system
         let abbreviation1 = tz.abbreviation()
         let abbreviation2 = tz.abbreviation(for: Date())
         XCTAssertEqual(abbreviation1, abbreviation2, "\(abbreviation1) should be equal to \(abbreviation2)")
@@ -61,7 +61,7 @@ class TestNSTimeZone: XCTestCase {
         var t = time(nil)
         var lt = tm()
         localtime_r(&t, &lt)
-        let zoneName = NSTimeZone.systemTimeZone().abbreviation() ?? "Invalid Abbreviation"
+        let zoneName = NSTimeZone.system.abbreviation() ?? "Invalid Abbreviation"
         let expectedName = String(cString: lt.tm_zone, encoding: String.Encoding.ascii) ?? "Invalid Zone"
         XCTAssertEqual(zoneName, expectedName, "expected name \"\(expectedName)\" is not equal to \"\(zoneName)\"")
     }

--- a/TestFoundation/TestNSTimeZone.swift
+++ b/TestFoundation/TestNSTimeZone.swift
@@ -25,8 +25,17 @@ class TestNSTimeZone: XCTestCase {
         return [
             // Disabled see https://bugs.swift.org/browse/SR-300
             // ("test_abbreviation", test_abbreviation),
+
+            // Disabled because `CFTimeZoneSetAbbreviationDictionary()` attempts
+            // to release non-CF objects while removing values from
+            // `__CFTimeZoneCache`
+            // ("test_abbreviationDictionary", test_abbreviationDictionary),
+
+            ("test_changingDefaultTimeZone", test_changingDefaultTimeZone),
+            ("test_computedPropertiesMatchMethodReturnValues", test_computedPropertiesMatchMethodReturnValues),
             ("test_initializingTimeZoneWithOffset", test_initializingTimeZoneWithOffset),
             ("test_initializingTimeZoneWithAbbreviation", test_initializingTimeZoneWithAbbreviation),
+
             // Also disabled due to https://bugs.swift.org/browse/SR-300
             // ("test_systemTimeZoneUsesSystemTime", test_systemTimeZoneUsesSystemTime),
         ]
@@ -38,12 +47,96 @@ class TestNSTimeZone: XCTestCase {
         let abbreviation2 = tz.abbreviation(for: Date())
         XCTAssertEqual(abbreviation1, abbreviation2, "\(abbreviation1) should be equal to \(abbreviation2)")
     }
-    
+
+    func test_abbreviationDictionary() {
+        let oldDictionary = TimeZone.abbreviationDictionary
+        let newDictionary = [
+            "UTC": "UTC",
+            "JST": "Asia/Tokyo",
+            "GMT": "GMT",
+            "ICT": "Asia/Bangkok",
+            "TEST": "Foundation/TestNSTimeZone"
+        ]
+        TimeZone.abbreviationDictionary = newDictionary
+        XCTAssertEqual(TimeZone.abbreviationDictionary, newDictionary)
+        TimeZone.abbreviationDictionary = oldDictionary
+        XCTAssertEqual(TimeZone.abbreviationDictionary, oldDictionary)
+    }
+
+    func test_changingDefaultTimeZone() {
+        let oldDefault = NSTimeZone.default
+        let oldSystem = NSTimeZone.system
+
+        let expectedDefault = TimeZone(identifier: "GMT-0400")!
+        NSTimeZone.default = expectedDefault
+        let newDefault = NSTimeZone.default
+        let newSystem = NSTimeZone.system
+        XCTAssertEqual(oldSystem, newSystem)
+        XCTAssertEqual(expectedDefault, newDefault)
+
+        let expectedDefault2 = TimeZone(identifier: "GMT+0400")!
+        NSTimeZone.default = expectedDefault2
+        let newDefault2 = NSTimeZone.default
+        XCTAssertEqual(expectedDefault2, newDefault2)
+        XCTAssertNotEqual(newDefault, newDefault2)
+
+        NSTimeZone.default = oldDefault
+        let revertedDefault = NSTimeZone.default
+        XCTAssertEqual(oldDefault, revertedDefault)
+    }
+
+    func test_computedPropertiesMatchMethodReturnValues() {
+        let tz = NSTimeZone.default
+        let obj = tz._bridgeToObjectiveC()
+
+        let secondsFromGMT1 = tz.secondsFromGMT()
+        let secondsFromGMT2 = obj.secondsFromGMT
+        let secondsFromGMT3 = tz.secondsFromGMT()
+        XCTAssert(secondsFromGMT1 == secondsFromGMT2 || secondsFromGMT2 == secondsFromGMT3, "\(secondsFromGMT1) should be equal to \(secondsFromGMT2), or in the rare circumstance where a daylight saving time transition has just occurred, \(secondsFromGMT2) should be equal to \(secondsFromGMT3)")
+
+        let abbreviation1 = tz.abbreviation()
+        let abbreviation2 = obj.abbreviation
+        XCTAssertEqual(abbreviation1, abbreviation2, "\(abbreviation1) should be equal to \(abbreviation2)")
+
+        let isDaylightSavingTime1 = tz.isDaylightSavingTime()
+        let isDaylightSavingTime2 = obj.isDaylightSavingTime
+        let isDaylightSavingTime3 = tz.isDaylightSavingTime()
+        XCTAssert(isDaylightSavingTime1 == isDaylightSavingTime2 || isDaylightSavingTime2 == isDaylightSavingTime3, "\(isDaylightSavingTime1) should be equal to \(isDaylightSavingTime2), or in the rare circumstance where a daylight saving time transition has just occurred, \(isDaylightSavingTime2) should be equal to \(isDaylightSavingTime3)")
+
+        let daylightSavingTimeOffset1 = tz.daylightSavingTimeOffset()
+        let daylightSavingTimeOffset2 = obj.daylightSavingTimeOffset
+        XCTAssertEqual(daylightSavingTimeOffset1, daylightSavingTimeOffset2, "\(daylightSavingTimeOffset1) should be equal to \(daylightSavingTimeOffset2)")
+
+        let nextDaylightSavingTimeTransition1 = tz.nextDaylightSavingTimeTransition
+        let nextDaylightSavingTimeTransition2 = obj.nextDaylightSavingTimeTransition
+        let nextDaylightSavingTimeTransition3 = tz.nextDaylightSavingTimeTransition(after: Date())
+        XCTAssert(nextDaylightSavingTimeTransition1 == nextDaylightSavingTimeTransition2 || nextDaylightSavingTimeTransition2 == nextDaylightSavingTimeTransition3, "\(nextDaylightSavingTimeTransition1) should be equal to \(nextDaylightSavingTimeTransition2), or in the rare circumstance where a daylight saving time transition has just occurred, \(nextDaylightSavingTimeTransition2) should be equal to \(nextDaylightSavingTimeTransition3)")
+    }
+
+    func test_knownTimeZoneNames() {
+        let known = NSTimeZone.knownTimeZoneNames
+        XCTAssertNotEqual([], known, "known time zone names not expected to be empty")
+    }
+
     func test_initializingTimeZoneWithOffset() {
         let tz = TimeZone(identifier: "GMT-0400")
         XCTAssertNotNil(tz)
         let seconds = tz?.secondsFromGMT(for: Date())
         XCTAssertEqual(seconds, -14400, "GMT-0400 should be -14400 seconds but got \(seconds) instead")
+
+        let tz2 = TimeZone(secondsFromGMT: -14400)
+        XCTAssertNotNil(tz2)
+        let expectedName = "GMT-0400"
+        let actualName = tz2?.identifier
+        XCTAssertEqual(actualName, expectedName, "expected name \"\(expectedName)\" is not equal to \"\(actualName)\"")
+        let expectedLocalizedName = "GMT-04:00"
+        let actualLocalizedName = tz2?.localizedName(for: .generic, locale: Locale(identifier: "en_US"))
+        XCTAssertEqual(actualLocalizedName, expectedLocalizedName, "expected name \"\(expectedLocalizedName)\" is not equal to \"\(actualLocalizedName)\"")
+        let seconds2 = tz2?.secondsFromGMT()
+        XCTAssertEqual(seconds2, -14400, "GMT-0400 should be -14400 seconds but got \(seconds2) instead")
+
+        let tz3 = TimeZone(identifier: "GMT-9999")
+        XCTAssertNil(tz3)
     }
     
     func test_initializingTimeZoneWithAbbreviation() {


### PR DESCRIPTION
Pulls #602 and #608 into swift-3.0-branch