### PR TITLE
Make empty NSNotification.Name.NSSystemTimeZoneDidChange.rawValue

### DIFF
--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -294,5 +294,5 @@ extension NSTimeZone {
 }
 
 extension NSNotification.Name {
-    public static let NSSystemTimeZoneDidChange = NSNotification.Name(rawValue: "NSSystemTimeZoneDidChangeNotification") // NSUnimplemented
+    public static let NSSystemTimeZoneDidChange = NSNotification.Name(rawValue: "") // NSUnimplemented
 }


### PR DESCRIPTION
A minor fix-up, discussed in #609, for consistency with how things are done with elsewhere in the project for raw values associated with `NSNotification.Name` constants.