### PR TITLE
Fix crash in NSValue.isEqual() when it is passed an NSNumber

### DIFF
--- a/Foundation/NSValue.swift
+++ b/Foundation/NSValue.swift
@@ -58,10 +58,12 @@ open class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
             } else {
                 // bypass _concreteValue accessor in order to avoid acquiring lock twice
                 let (lhs, rhs) = NSValue.SideTableLock.synchronized {
-                    return (NSValue.SideTable[ObjectIdentifier(self)]!,
-                            NSValue.SideTable[ObjectIdentifier(object)]!)
+                    return (NSValue.SideTable[ObjectIdentifier(self)],
+                            NSValue.SideTable[ObjectIdentifier(object)])
                 }
-                return lhs.isEqual(rhs)
+                if let lhs = lhs, let rhs = rhs {
+                    return lhs.isEqual(rhs)
+                }
             }
         }
         return false

--- a/TestFoundation/TestNSValue.swift
+++ b/TestFoundation/TestNSValue.swift
@@ -29,6 +29,7 @@ class TestNSValue : XCTestCase {
             ( "test_valueWithShortArray", test_valueWithShortArray ),
             ( "test_valueWithULongLongArray", test_valueWithULongLongArray ),
             ( "test_valueWithCharPtr", test_valueWithULongLongArray ),
+            ( "test_isEqual", test_isEqual ),
         ]
     }
     
@@ -125,5 +126,12 @@ class TestNSValue : XCTestCase {
         
         NSValue(bytes: &charPtr, objCType: "*").getValue(&expectedPtr)
         XCTAssertEqual(charPtr, expectedPtr)
+    }
+
+    func test_isEqual() {
+        let number = NSNumber(value: Int(123))
+        var long: Int32 = 123456
+        let value = NSValue(bytes: &long, objCType: "l")
+        XCTAssertFalse(value.isEqual(number))
     }
 }


### PR DESCRIPTION
NSNumbers are not added to the side table, so we can't find them.

I don't think that `NSValue.isEqual()` is correct in general, but this gets us closer to the correct implementation and unblocks https://github.com/apple/swift/pull/4621 . For example, subclasses that have custom storage -- like NSNumber -- should compare equal to an NSValue as long as they have the same bytes and the same type, but the current implementation of `NSValue.isEqual()` can only return true if two references are equal.

Note: this issue blocks https://github.com/apple/swift/pull/4621 (after we change the hashing algorithm, the test TestNSKeyedArchiver.test_archive_set starts to compare NSValue to NSNumber where it previously wasn't doing that just because we got lucky in the hash table order).