### PR TITLE
Allow httpAdditionalHeaders to contain Strings or NSStrings

### DIFF
--- a/Foundation/NSURLSession/Configuration.swift
+++ b/Foundation/NSURLSession/Configuration.swift
@@ -130,9 +130,17 @@ private func convertToStringString(dictionary: [AnyHashable:Any]) -> [String: St
     // C.f. <https://github.com/apple/swift-corelibs-foundation/pull/287>
     var r: [String: String] = [:]
     dictionary.forEach {
-        let k = String(describing: $0.key as! NSString)
-        let v = String(describing: $0.value as! NSString)
+        let k = getString(from: $0.key)
+        let v = getString(from: $0.value)
         r[k] = v
     }
     return r
+}
+
+private func getString(from obj: Any) -> String {
+    if let string = obj as? String {
+        return string
+    } else {
+        return String(describing: obj as! NSString)
+    }
 }


### PR DESCRIPTION
`NSURLSessionConfiguration.httpAdditonalHeaders` is declared to accept `[AnyHashable:Any]`, but internally this maps to `[String : String]`.

Currently the code assumes that the `[AnyHashable:Any]` actually only contains `NSString`s, whereas on macOS/Darwin its acceptable for either `NSString`s or `String`s to be used.

I've therefore updated `URLSession._Configuration.convertToStringString()` to allow either and coerce to String if needed.