### PR TITLE
Remove non-keyed encoding for data objects

### DIFF
--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -317,13 +317,10 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     }
     
     public required convenience init?(coder aDecoder: NSCoder) {
-        if !aDecoder.allowsKeyedCoding {
-            if let data = aDecoder.decodeData() {
-                self.init(data: data)
-            } else {
-                return nil
-            }
-        } else if type(of: aDecoder) == NSKeyedUnarchiver.self || aDecoder.containsValue(forKey: "NS.data") {
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
+        }
+        if type(of: aDecoder) == NSKeyedUnarchiver.self || aDecoder.containsValue(forKey: "NS.data") {
             guard let data = aDecoder._decodePropertyListForKey("NS.data") as? NSData else {
                 return nil
             }

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -274,7 +274,9 @@ open class NSDateInterval : NSObject, NSCopying, NSSecureCoding {
     
     
     public required convenience init?(coder: NSCoder) {
-        precondition(coder.allowsKeyedCoding)
+        guard coder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
+        }
         guard let start = coder.decodeObject(of: NSDate.self, forKey: "NS.startDate") else {
             coder.failWithError(NSError(domain: NSCocoaErrorDomain, code: CocoaError.coderValueNotFound.rawValue, userInfo: nil))
             return nil
@@ -304,7 +306,9 @@ open class NSDateInterval : NSObject, NSCopying, NSSecureCoding {
     }
     
     open func encode(with aCoder: NSCoder) {
-        precondition(aCoder.allowsKeyedCoding)
+        guard aCoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
+        }
         aCoder.encode(startDate._nsObject, forKey: "NS.startDate")
         aCoder.encode(endDate._nsObject, forKey: "NS.endDate")
     }

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -54,27 +54,10 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     }
     
     public required convenience init?(coder aDecoder: NSCoder) {
-        if !aDecoder.allowsKeyedCoding {
-            var cnt: UInt32 = 0
-            // We're stuck with (int) here (rather than unsigned int)
-            // because that's the way the code was originally written, unless
-            // we go to a new version of the class, which has its own problems.
-            withUnsafeMutablePointer(to: &cnt) { (ptr: UnsafeMutablePointer<UInt32>) -> Void in
-                aDecoder.decodeValue(ofObjCType: "i", at: UnsafeMutableRawPointer(ptr))
-            }
-            let keys = UnsafeMutablePointer<NSObject>.allocate(capacity: Int(cnt))
-            let objects = UnsafeMutablePointer<AnyObject>.allocate(capacity: Int(cnt))
-            for idx in 0..<cnt {
-                keys.advanced(by: Int(idx)).initialize(to: aDecoder.decodeObject()! as! NSObject)
-                objects.advanced(by: Int(idx)).initialize(to: aDecoder.decodeObject()! as! NSObject)
-            }
-            self.init(objects: UnsafePointer<AnyObject>(objects), forKeys: UnsafePointer<NSObject>(keys), count: Int(cnt))
-            keys.deinitialize(count: Int(cnt))
-            keys.deallocate(capacity: Int(cnt))
-            objects.deinitialize(count: Int(cnt))
-            objects.deallocate(capacity: Int(cnt))
-            
-        } else if type(of: aDecoder) == NSKeyedUnarchiver.self || aDecoder.containsValue(forKey: "NS.objects") {
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
+        }
+        if type(of: aDecoder) == NSKeyedUnarchiver.self || aDecoder.containsValue(forKey: "NS.objects") {
             let keys = aDecoder._decodeArrayOfObjectsForKey("NS.keys").map() { return $0 as! NSObject }
             let objects = aDecoder._decodeArrayOfObjectsForKey("NS.objects")
             self.init(objects: objects as! [NSObject], forKeys: keys)

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -62,34 +62,20 @@ open class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     public required init?(coder aDecoder: NSCoder) {
-        if aDecoder.allowsKeyedCoding {
-            _code = aDecoder.decodeInteger(forKey: "NSCode")
-            _domain = aDecoder.decodeObject(of: NSString.self, forKey: "NSDomain")!._swiftObject
-            if let info = aDecoder.decodeObject(of: [NSSet.self, NSDictionary.self, NSArray.self, NSString.self, NSNumber.self, NSData.self, NSURL.self], forKey: "NSUserInfo") as? NSDictionary {
-                var filteredUserInfo = [String : Any]()
-                // user info must be filtered so that the keys are all strings
-                info.enumerateKeysAndObjects(options: []) {
-                    if let key = $0.0 as? NSString {
-                        filteredUserInfo[key._swiftObject] = $0.1
-                    }
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
+        }
+        _code = aDecoder.decodeInteger(forKey: "NSCode")
+        _domain = aDecoder.decodeObject(of: NSString.self, forKey: "NSDomain")!._swiftObject
+        if let info = aDecoder.decodeObject(of: [NSSet.self, NSDictionary.self, NSArray.self, NSString.self, NSNumber.self, NSData.self, NSURL.self], forKey: "NSUserInfo") as? NSDictionary {
+            var filteredUserInfo = [String : Any]()
+            // user info must be filtered so that the keys are all strings
+            info.enumerateKeysAndObjects(options: []) {
+                if let key = $0.0 as? NSString {
+                    filteredUserInfo[key._swiftObject] = $0.1
                 }
-                _userInfo = filteredUserInfo
             }
-        } else {
-            var codeValue: Int32 = 0
-            aDecoder.decodeValue(ofObjCType: "i", at: &codeValue)
-            _code = Int(codeValue)
-            _domain = (aDecoder.decodeObject() as? NSString)!._swiftObject
-            if let info = aDecoder.decodeObject() as? NSDictionary {
-                var filteredUserInfo = [String : Any]()
-                // user info must be filtered so that the keys are all strings
-                info.enumerateKeysAndObjects(options: []) {
-                    if let key = $0.0 as? NSString {
-                        filteredUserInfo[key._swiftObject] = $0.1
-                    }
-                }
-                _userInfo = filteredUserInfo
-            }
+            _userInfo = filteredUserInfo
         }
     }
     
@@ -98,16 +84,12 @@ open class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     open func encode(with aCoder: NSCoder) {
-        if aCoder.allowsKeyedCoding {
-            aCoder.encode(_domain._bridgeToObjectiveC(), forKey: "NSDomain")
-            aCoder.encode(Int32(_code), forKey: "NSCode")
-            aCoder.encode(_userInfo?._bridgeToObjectiveC(), forKey: "NSUserInfo")
-        } else {
-            var codeValue: Int32 = Int32(self._code)
-            aCoder.encodeValue(ofObjCType: "i", at: &codeValue)
-            aCoder.encode(self._domain._bridgeToObjectiveC())
-            aCoder.encode(self._userInfo?._bridgeToObjectiveC())
+        guard aCoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        aCoder.encode(_domain._bridgeToObjectiveC(), forKey: "NSDomain")
+        aCoder.encode(Int32(_code), forKey: "NSCode")
+        aCoder.encode(_userInfo?._bridgeToObjectiveC(), forKey: "NSUserInfo")
     }
     
     open override func copy() -> Any {

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -38,19 +38,17 @@ extension CGPoint: NSSpecialValueCoding {
     }
     
     init?(coder aDecoder: NSCoder) {
-        if aDecoder.allowsKeyedCoding {
-            self = aDecoder.decodePointForKey("NS.pointval")
-        } else {
-            self = aDecoder.decodePoint()
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        self = aDecoder.decodePointForKey("NS.pointval")
     }
     
     func encodeWithCoder(_ aCoder: NSCoder) {
-        if aCoder.allowsKeyedCoding {
-            aCoder.encodePoint(self, forKey: "NS.pointval")
-        } else {
-            aCoder.encodePoint(self)
+        guard aCoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        aCoder.encodePoint(self, forKey: "NS.pointval")
     }
     
     static func objCType() -> String {
@@ -103,19 +101,17 @@ extension CGSize: NSSpecialValueCoding {
     }
     
     init?(coder aDecoder: NSCoder) {
-        if aDecoder.allowsKeyedCoding {
-            self = aDecoder.decodeSizeForKey("NS.sizeval")
-        } else {
-            self = aDecoder.decodeSize()
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        self = aDecoder.decodeSizeForKey("NS.sizeval")
     }
     
     func encodeWithCoder(_ aCoder: NSCoder) {
-        if aCoder.allowsKeyedCoding {
-            aCoder.encodeSize(self, forKey: "NS.sizeval")
-        } else {
-            aCoder.encodeSize(self)
+        guard aCoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        aCoder.encodeSize(self, forKey: "NS.sizeval")
     }
     
     static func objCType() -> String {
@@ -187,19 +183,17 @@ extension CGRect: NSSpecialValueCoding {
     }
 
     init?(coder aDecoder: NSCoder) {
-        if aDecoder.allowsKeyedCoding {
-            self = aDecoder.decodeRectForKey("NS.rectval")
-        } else {
-            self = aDecoder.decodeRect()
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        self = aDecoder.decodeRectForKey("NS.rectval")
     }
     
     func encodeWithCoder(_ aCoder: NSCoder) {
-        if aCoder.allowsKeyedCoding {
-            aCoder.encodeRect(self, forKey: "NS.rectval")
-        } else {
-            aCoder.encodeRect(self)
+        guard aCoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        aCoder.encodeRect(self, forKey: "NS.rectval")
     }
     
     static func objCType() -> String {

--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -45,34 +45,24 @@ open class NSNotification: NSObject, NSCopying, NSCoding {
     }
     
     public convenience required init?(coder aDecoder: NSCoder) {
-        if aDecoder.allowsKeyedCoding {
-            guard let name = aDecoder.decodeObject(of: NSString.self, forKey:"NS.name") else {
-                return nil
-            }
-            let object = aDecoder.decodeObject(forKey: "NS.object")
-//            let userInfo = aDecoder.decodeObject(of: NSDictionary.self, forKey: "NS.userinfo")
-            self.init(name: Name(rawValue: String._unconditionallyBridgeFromObjectiveC(name)), object: object as! NSObject, userInfo: nil)
-
-        } else {
-            guard let name = aDecoder.decodeObject() as? NSString else {
-                return nil
-            }
-            let object = aDecoder.decodeObject()
-//            let userInfo = aDecoder.decodeObject() as? NSDictionary
-            self.init(name: Name(rawValue: String._unconditionallyBridgeFromObjectiveC(name)), object: object, userInfo: nil)
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        guard let name = aDecoder.decodeObject(of: NSString.self, forKey:"NS.name") else {
+            return nil
+        }
+        let object = aDecoder.decodeObject(forKey: "NS.object")
+        //            let userInfo = aDecoder.decodeObject(of: NSDictionary.self, forKey: "NS.userinfo")
+        self.init(name: Name(rawValue: String._unconditionallyBridgeFromObjectiveC(name)), object: object as! NSObject, userInfo: nil)
     }
     
     open func encode(with aCoder: NSCoder) {
-        if aCoder.allowsKeyedCoding {
-            aCoder.encode(self.name.rawValue._bridgeToObjectiveC(), forKey:"NS.name")
-            aCoder.encode(self.object, forKey:"NS.object")
-            aCoder.encode(self.userInfo?._bridgeToObjectiveC(), forKey:"NS.userinfo")
-        } else {
-            aCoder.encode(self.name.rawValue._bridgeToObjectiveC())
-            aCoder.encode(self.object)
-            aCoder.encode(self.userInfo?._bridgeToObjectiveC())
+        guard aCoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        aCoder.encode(self.name.rawValue._bridgeToObjectiveC(), forKey:"NS.name")
+        aCoder.encode(self.object, forKey:"NS.object")
+        aCoder.encode(self.userInfo?._bridgeToObjectiveC(), forKey:"NS.userinfo")
     }
     
     open override func copy() -> Any {

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -336,21 +336,10 @@ open class NSNumber : NSValue {
     }
 
     public required convenience init?(coder aDecoder: NSCoder) {
-        if !aDecoder.allowsKeyedCoding {
-            var objCType: UnsafeMutablePointer<Int8>? = nil
-            withUnsafeMutablePointer(to: &objCType, { (ptr: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>) -> Void in
-                aDecoder.decodeValue(ofObjCType: String(_NSSimpleObjCType.CharPtr), at: UnsafeMutableRawPointer(ptr))
-            })
-            if objCType == nil {
-                return nil
-            }
-            var size: Int = 0
-            let _ = NSGetSizeAndAlignment(objCType!, &size, nil)
-            let buffer = malloc(size)!
-            aDecoder.decodeValue(ofObjCType: objCType!, at: buffer)
-            self.init(bytes: buffer, objCType: objCType!)
-            free(buffer)
-        } else if type(of: aDecoder) == NSKeyedUnarchiver.self || aDecoder.containsValue(forKey: "NS.number") {
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
+        }
+        if type(of: aDecoder) == NSKeyedUnarchiver.self || aDecoder.containsValue(forKey: "NS.number") {
             let number = aDecoder._decodePropertyListForKey("NS.number")
             if let val = number as? Double {
                 self.init(value:val)

--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -41,30 +41,28 @@ open class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     }
     
     open func encode(with aCoder: NSCoder) {
-        if aCoder.allowsKeyedCoding {
-            for idx in 0..<self.count {
-                aCoder.encode(_SwiftValue.store(self.object(at: idx)), forKey:"NS.object.\(idx)")
-            }
-        } else {
-            NSUnimplemented()
+        guard aCoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
+        }
+        for idx in 0..<self.count {
+            aCoder.encode(_SwiftValue.store(self.object(at: idx)), forKey:"NS.object.\(idx)")
         }
     }
     
     public required convenience init?(coder aDecoder: NSCoder) {
-        if aDecoder.allowsKeyedCoding {
-            var idx = 0
-            var objects : [AnyObject] = []
-            while aDecoder.containsValue(forKey: ("NS.object.\(idx)")) {
-                guard let object = aDecoder.decodeObject(forKey: "NS.object.\(idx)") else {
-                    return nil
-                }
-                objects.append(object as! NSObject)
-                idx += 1
-            }
-            self.init(array: objects)
-        } else {
-            NSUnimplemented()
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        var idx = 0
+        var objects : [AnyObject] = []
+        while aDecoder.containsValue(forKey: ("NS.object.\(idx)")) {
+            guard let object = aDecoder.decodeObject(forKey: "NS.object.\(idx)") else {
+                return nil
+            }
+            objects.append(object as! NSObject)
+            idx += 1
+        }
+        self.init(array: objects)
     }
     
     open var count: Int {

--- a/Foundation/NSPersonNameComponents.swift
+++ b/Foundation/NSPersonNameComponents.swift
@@ -12,6 +12,9 @@ open class NSPersonNameComponents : NSObject, NSCopying, NSSecureCoding {
     
     public convenience required init?(coder aDecoder: NSCoder) {
         self.init()
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
+        }
         func bridgeOptionalString(_ value: NSString?) -> String? {
             if let obj = value {
                 return String._unconditionallyBridgeFromObjectiveC(obj)
@@ -19,43 +22,26 @@ open class NSPersonNameComponents : NSObject, NSCopying, NSSecureCoding {
                 return nil
             }
         }
-        
-        if aDecoder.allowsKeyedCoding {
-            self.namePrefix = bridgeOptionalString(aDecoder.decodeObject(of: NSString.self, forKey: "NS.namePrefix") as NSString?)
-            self.givenName = bridgeOptionalString(aDecoder.decodeObject(of: NSString.self, forKey: "NS.givenName") as NSString?)
-            self.middleName = bridgeOptionalString(aDecoder.decodeObject(of: NSString.self, forKey: "NS.middleName") as NSString?)
-            self.familyName = bridgeOptionalString(aDecoder.decodeObject(of: NSString.self, forKey: "NS.familyName") as NSString?)
-            self.nameSuffix = bridgeOptionalString(aDecoder.decodeObject(of: NSString.self, forKey: "NS.nameSuffix") as NSString?)
-            self.nickname = bridgeOptionalString(aDecoder.decodeObject(of: NSString.self, forKey: "NS.nickname") as NSString?)
-        } else {
-            self.namePrefix = bridgeOptionalString(aDecoder.decodeObject() as? NSString)
-            self.givenName = bridgeOptionalString(aDecoder.decodeObject() as? NSString)
-            self.middleName = bridgeOptionalString(aDecoder.decodeObject() as? NSString)
-            self.familyName = bridgeOptionalString(aDecoder.decodeObject() as? NSString)
-            self.nameSuffix = bridgeOptionalString(aDecoder.decodeObject() as? NSString)
-            self.nickname = bridgeOptionalString(aDecoder.decodeObject() as? NSString)
-        }
+        self.namePrefix = bridgeOptionalString(aDecoder.decodeObject(of: NSString.self, forKey: "NS.namePrefix") as NSString?)
+        self.givenName = bridgeOptionalString(aDecoder.decodeObject(of: NSString.self, forKey: "NS.givenName") as NSString?)
+        self.middleName = bridgeOptionalString(aDecoder.decodeObject(of: NSString.self, forKey: "NS.middleName") as NSString?)
+        self.familyName = bridgeOptionalString(aDecoder.decodeObject(of: NSString.self, forKey: "NS.familyName") as NSString?)
+        self.nameSuffix = bridgeOptionalString(aDecoder.decodeObject(of: NSString.self, forKey: "NS.nameSuffix") as NSString?)
+        self.nickname = bridgeOptionalString(aDecoder.decodeObject(of: NSString.self, forKey: "NS.nickname") as NSString?)
     }
     
     static public var supportsSecureCoding: Bool { return true }
     
     open func encode(with aCoder: NSCoder) {
-        if aCoder.allowsKeyedCoding {
-            aCoder.encode(self.namePrefix?._bridgeToObjectiveC(), forKey: "NS.namePrefix")
-            aCoder.encode(self.givenName?._bridgeToObjectiveC(), forKey: "NS.givenName")
-            aCoder.encode(self.middleName?._bridgeToObjectiveC(), forKey: "NS.middleName")
-            aCoder.encode(self.familyName?._bridgeToObjectiveC(), forKey: "NS.familyName")
-            aCoder.encode(self.nameSuffix?._bridgeToObjectiveC(), forKey: "NS.nameSuffix")
-            aCoder.encode(self.nickname?._bridgeToObjectiveC(), forKey: "NS.nickname")
-        } else {
-            // FIXME check order
-            aCoder.encode(self.namePrefix?._bridgeToObjectiveC())
-            aCoder.encode(self.givenName?._bridgeToObjectiveC())
-            aCoder.encode(self.middleName?._bridgeToObjectiveC())
-            aCoder.encode(self.familyName?._bridgeToObjectiveC())
-            aCoder.encode(self.nameSuffix?._bridgeToObjectiveC())
-            aCoder.encode(self.nickname?._bridgeToObjectiveC())
+        guard aCoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        aCoder.encode(self.namePrefix?._bridgeToObjectiveC(), forKey: "NS.namePrefix")
+        aCoder.encode(self.givenName?._bridgeToObjectiveC(), forKey: "NS.givenName")
+        aCoder.encode(self.middleName?._bridgeToObjectiveC(), forKey: "NS.middleName")
+        aCoder.encode(self.familyName?._bridgeToObjectiveC(), forKey: "NS.familyName")
+        aCoder.encode(self.nameSuffix?._bridgeToObjectiveC(), forKey: "NS.nameSuffix")
+        aCoder.encode(self.nickname?._bridgeToObjectiveC(), forKey: "NS.nickname")
     }
     
     open func copy(with zone: NSZone? = nil) -> Any { NSUnimplemented() }

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -53,22 +53,10 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
     }
     
     public required convenience init?(coder aDecoder: NSCoder) {
-        if !aDecoder.allowsKeyedCoding {
-            var cnt: UInt32 = 0
-            // We're stuck with (int) here (rather than unsigned int)
-            // because that's the way the code was originally written, unless
-            // we go to a new version of the class, which has its own problems.
-            withUnsafeMutablePointer(to: &cnt) { (ptr: UnsafeMutablePointer<UInt32>) -> Void in
-                aDecoder.decodeValue(ofObjCType: "i", at: UnsafeMutableRawPointer(ptr))
-            }
-            let objects = UnsafeMutablePointer<AnyObject>.allocate(capacity: Int(cnt))
-            for idx in 0..<cnt {
-                objects.advanced(by: Int(idx)).initialize(to: aDecoder.decodeObject() as! NSObject)
-            }
-            self.init(objects: objects, count: Int(cnt))
-            objects.deinitialize(count: Int(cnt))
-            objects.deallocate(capacity: Int(cnt))
-        } else if type(of: aDecoder) == NSKeyedUnarchiver.self || aDecoder.containsValue(forKey: "NS.objects") {
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
+        }
+        if type(of: aDecoder) == NSKeyedUnarchiver.self || aDecoder.containsValue(forKey: "NS.objects") {
             let objects = aDecoder._decodeArrayOfObjectsForKey("NS.objects")
             self.init(array: objects as! [NSObject])
         } else {

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -196,10 +196,10 @@ open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSC
     }
     
     public convenience required init?(coder aDecoder: NSCoder) {
-        if !aDecoder.allowsKeyedCoding {
-            aDecoder.failWithError(NSError(domain: NSCocoaErrorDomain, code: CocoaError.coderReadCorrupt.rawValue, userInfo: ["NSDebugDescription": "NSUUID cannot be decoded by non-keyed coders"]))
-            return nil
-        } else if type(of: aDecoder) == NSKeyedUnarchiver.self || aDecoder.containsValue(forKey: "NS.string") {
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
+        }
+        if type(of: aDecoder) == NSKeyedUnarchiver.self || aDecoder.containsValue(forKey: "NS.string") {
             let str = aDecoder._decodePropertyListForKey("NS.string") as! String
             self.init(string: str)
         } else {

--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -36,27 +36,17 @@ open class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     public convenience required init?(coder aDecoder: NSCoder) {
-        if aDecoder.allowsKeyedCoding {
-            let name = aDecoder.decodeObject(of: NSString.self, forKey: "NS.name")
-            let data = aDecoder.decodeObject(of: NSData.self, forKey: "NS.data")
-            
-            if name == nil {
-                return nil
-            }
-            
-            self.init(name: String._unconditionallyBridgeFromObjectiveC(name), data: data?._swiftObject)
-        } else {
-            if let name = aDecoder.decodeObject() as? NSString {
-                if aDecoder.version(forClassName: "NSTimeZone") == 0 {
-                    self.init(name: name._swiftObject)
-                } else {
-                    let data = aDecoder.decodeObject() as? NSData
-                    self.init(name: name._swiftObject, data: data?._swiftObject)
-                }
-            } else {
-                return nil
-            }
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        let name = aDecoder.decodeObject(of: NSString.self, forKey: "NS.name")
+        let data = aDecoder.decodeObject(of: NSData.self, forKey: "NS.data")
+
+        if name == nil {
+            return nil
+        }
+
+        self.init(name: String._unconditionallyBridgeFromObjectiveC(name), data: data?._swiftObject)
     }
     
     open override var hash: Int {
@@ -110,12 +100,12 @@ open class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
 
     open func encode(with aCoder: NSCoder) {
-        if aCoder.allowsKeyedCoding {
-            aCoder.encode(self.name._bridgeToObjectiveC(), forKey:"NS.name")
-            // Darwin versions of this method can and will encode mutable data, however it is not required for compatibility
-            aCoder.encode(self.data._bridgeToObjectiveC(), forKey:"NS.data")
-        } else {
+        guard aCoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        aCoder.encode(self.name._bridgeToObjectiveC(), forKey:"NS.name")
+        // Darwin versions of this method can and will encode mutable data, however it is not required for compatibility
+        aCoder.encode(self.data._bridgeToObjectiveC(), forKey:"NS.data")
     }
     
     public static var supportsSecureCoding: Bool {

--- a/Foundation/NSUUID.swift
+++ b/Foundation/NSUUID.swift
@@ -58,24 +58,19 @@ open class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     public convenience required init?(coder: NSCoder) {
-        if coder.allowsKeyedCoding {
-            let decodedData : Data? = coder.withDecodedUnsafeBufferPointer(forKey: "NS.uuidbytes") {
-                guard let buffer = $0 else { return nil }
-                return Data(buffer: buffer)
-            }
-
-            guard let data = decodedData else { return nil }
-            guard data.count == 16 else { return nil }
-            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 16)
-            data.copyBytes(to: buffer, count: 16)
-            self.init(uuidBytes: buffer)
-        } else {
-            // NSUUIDs cannot be decoded by non-keyed coders
-            coder.failWithError(NSError(domain: NSCocoaErrorDomain, code: CocoaError.coderReadCorrupt.rawValue, userInfo: [
-                                "NSDebugDescription": "NSUUID cannot be decoded by non-keyed coders"
-                                ]))
-            return nil
+        guard coder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        let decodedData : Data? = coder.withDecodedUnsafeBufferPointer(forKey: "NS.uuidbytes") {
+            guard let buffer = $0 else { return nil }
+            return Data(buffer: buffer)
+        }
+
+        guard let data = decodedData else { return nil }
+        guard data.count == 16 else { return nil }
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 16)
+        data.copyBytes(to: buffer, count: 16)
+        self.init(uuidBytes: buffer)
     }
     
     open func encode(with aCoder: NSCoder) {

--- a/Foundation/Unit.swift
+++ b/Foundation/Unit.swift
@@ -62,27 +62,20 @@ open class UnitConverterLinear : UnitConverter, NSSecureCoding {
     }
     
     public required convenience init?(coder aDecoder: NSCoder) {
-        if aDecoder.allowsKeyedCoding {
-            let coefficient = aDecoder.decodeDouble(forKey: "NS.coefficient")
-            let constant = aDecoder.decodeDouble(forKey: "NS.constant")
-            self.init(coefficient: coefficient, constant: constant)
-        } else {
-            guard
-                let coefficient = aDecoder.decodeObject() as? Double,
-                let constant = aDecoder.decodeObject() as? Double
-                else { return nil }
-            self.init(coefficient: coefficient, constant: constant)
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        let coefficient = aDecoder.decodeDouble(forKey: "NS.coefficient")
+        let constant = aDecoder.decodeDouble(forKey: "NS.constant")
+        self.init(coefficient: coefficient, constant: constant)
     }
     
     open func encode(with aCoder: NSCoder) {
-        if aCoder.allowsKeyedCoding {
-            aCoder.encode(self.coefficient, forKey:"NS.coefficient")
-            aCoder.encode(self.constant, forKey:"NS.constant")
-        } else {
-            aCoder.encode(NSNumber(value: self.coefficient))
-            aCoder.encode(NSNumber(value: self.constant))
+        guard aCoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        aCoder.encode(self.coefficient, forKey:"NS.coefficient")
+        aCoder.encode(self.constant, forKey:"NS.constant")
     }
     
     public static var supportsSecureCoding: Bool { return true }
@@ -107,23 +100,18 @@ private class UnitConverterReciprocal : UnitConverter, NSSecureCoding {
     }
     
     fileprivate required convenience init?(coder aDecoder: NSCoder) {
-        if aDecoder.allowsKeyedCoding {
-            let reciprocal = aDecoder.decodeDouble(forKey: "NS.reciprocal")
-            self.init(reciprocal: reciprocal)
-        } else {
-            guard
-                let reciprocal = aDecoder.decodeObject() as? Double
-                else { return nil }
-            self.init(reciprocal: reciprocal)
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        let reciprocal = aDecoder.decodeDouble(forKey: "NS.reciprocal")
+        self.init(reciprocal: reciprocal)
     }
     
     fileprivate func encode(with aCoder: NSCoder) {
-        if aCoder.allowsKeyedCoding {
-            aCoder.encode(self.reciprocal, forKey:"NS.reciprocal")
-        } else {
-            aCoder.encode(NSNumber(value: self.reciprocal))
+        guard aCoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        aCoder.encode(self.reciprocal, forKey:"NS.reciprocal")
     }
     
     fileprivate static var supportsSecureCoding: Bool { return true }
@@ -148,23 +136,19 @@ open class Unit : NSObject, NSCopying, NSSecureCoding {
     }
     
     public required init?(coder aDecoder: NSCoder) {
-        if aDecoder.allowsKeyedCoding {
-            guard let symbol = aDecoder.decodeObject(forKey: "NS.symbol") as? String
-                else { return nil }
-            self.symbol = symbol
-        } else {
-            guard let symbol = aDecoder.decodeObject() as? String
-                else { return nil }
-            self.symbol = symbol
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        guard let symbol = aDecoder.decodeObject(forKey: "NS.symbol") as? String
+            else { return nil }
+        self.symbol = symbol
     }
     
     open func encode(with aCoder: NSCoder) {
-        if aCoder.allowsKeyedCoding {
-            aCoder.encode(self.symbol._bridgeToObjectiveC(), forKey:"NS.symbol")
-        } else {
-            aCoder.encode(self.symbol._bridgeToObjectiveC())
+        guard aCoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        aCoder.encode(self.symbol._bridgeToObjectiveC(), forKey:"NS.symbol")
     }
 
     public static var supportsSecureCoding: Bool { return true }
@@ -191,31 +175,23 @@ open class Dimension : Unit {
     }
     
     public required init?(coder aDecoder: NSCoder) {
-        if aDecoder.allowsKeyedCoding {
-            guard
-                let symbol = aDecoder.decodeObject(forKey: "NS.symbol") as? String,
-                let converter = aDecoder.decodeObject(forKey: "NS.converter") as? UnitConverter
-                else { return nil }
-            self.converter = converter
-            super.init(symbol: symbol)
-        } else {
-            guard
-                let symbol = aDecoder.decodeObject() as? String,
-                let converter = aDecoder.decodeObject() as? UnitConverter
-                else { return nil }
-            self.converter = converter
-            super.init(symbol: symbol)
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        guard
+            let symbol = aDecoder.decodeObject(forKey: "NS.symbol") as? String,
+            let converter = aDecoder.decodeObject(forKey: "NS.converter") as? UnitConverter
+            else { return nil }
+        self.converter = converter
+        super.init(symbol: symbol)
     }
     
     open override func encode(with aCoder: NSCoder) {
         super.encode(with: aCoder)
-        
-        if aCoder.allowsKeyedCoding {
-            aCoder.encode(self.converter, forKey:"converter")
-        } else {
-            aCoder.encode(self.converter)
+        guard aCoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
         }
+        aCoder.encode(self.converter, forKey:"converter")
     }
 }
 


### PR DESCRIPTION
Instead of having non-keyed encoding supported by some but not
all foundation types, remove the non-keyed encoding everywhere
and make passing a non-keyed encoder a preconditionFailure.