### PR TITLE
Casting to Double of CGFloat.native for math functions

### DIFF
--- a/Foundation/CGFloat.swift
+++ b/Foundation/CGFloat.swift
@@ -617,172 +617,172 @@ public func %=(lhs: inout CGFloat, rhs: CGFloat) {
 
 @_transparent
 public func acos(_ x: CGFloat) -> CGFloat {
-    return CGFloat(acos(x.native))
+    return CGFloat(acos(Double(x.native)))
 }
 
 @_transparent
 public func cos(_ x: CGFloat) -> CGFloat {
-    return CGFloat(cos(x.native))
+    return CGFloat(cos(Double(x.native)))
 }
 
 @_transparent
 public func sin(_ x: CGFloat) -> CGFloat {
-    return CGFloat(sin(x.native))
+    return CGFloat(sin(Double(x.native)))
 }
 
 @_transparent
 public func asin(_ x: CGFloat) -> CGFloat {
-    return CGFloat(asin(x.native))
+    return CGFloat(asin(Double(x.native)))
 }
 
 @_transparent
 public func atan(_ x: CGFloat) -> CGFloat {
-    return CGFloat(atan(x.native))
+    return CGFloat(atan(Double(x.native)))
 }
 
 @_transparent
 public func tan(_ x: CGFloat) -> CGFloat {
-    return CGFloat(tan(x.native))
+    return CGFloat(tan(Double(x.native)))
 }
 
 @_transparent
 public func acosh(_ x: CGFloat) -> CGFloat {
-    return CGFloat(acosh(x.native))
+    return CGFloat(acosh(Double(x.native)))
 }
 
 @_transparent
 public func asinh(_ x: CGFloat) -> CGFloat {
-    return CGFloat(asinh(x.native))
+    return CGFloat(asinh(Double(x.native)))
 }
 
 @_transparent
 public func atanh(_ x: CGFloat) -> CGFloat {
-    return CGFloat(atanh(x.native))
+    return CGFloat(atanh(Double(x.native)))
 }
 
 @_transparent
 public func cosh(_ x: CGFloat) -> CGFloat {
-    return CGFloat(cosh(x.native))
+    return CGFloat(cosh(Double(x.native)))
 }
 
 @_transparent
 public func sinh(_ x: CGFloat) -> CGFloat {
-    return CGFloat(sinh(x.native))
+    return CGFloat(sinh(Double(x.native)))
 }
 
 @_transparent
 public func tanh(_ x: CGFloat) -> CGFloat {
-    return CGFloat(tanh(x.native))
+    return CGFloat(tanh(Double(x.native)))
 }
 
 @_transparent
 public func exp(_ x: CGFloat) -> CGFloat {
-    return CGFloat(exp(x.native))
+    return CGFloat(exp(Double(x.native)))
 }
 
 @_transparent
 public func exp2(_ x: CGFloat) -> CGFloat {
-    return CGFloat(exp2(x.native))
+    return CGFloat(exp2(Double(x.native)))
 }
 
 @_transparent
 public func expm1(_ x: CGFloat) -> CGFloat {
-    return CGFloat(expm1(x.native))
+    return CGFloat(expm1(Double(x.native)))
 }
 
 @_transparent
 public func log(_ x: CGFloat) -> CGFloat {
-    return CGFloat(log(x.native))
+    return CGFloat(log(Double(x.native)))
 }
 
 @_transparent
 public func log10(_ x: CGFloat) -> CGFloat {
-    return CGFloat(log10(x.native))
+    return CGFloat(log10(Double(x.native)))
 }
 
 @_transparent
 public func log2(_ x: CGFloat) -> CGFloat {
-    return CGFloat(log2(x.native))
+    return CGFloat(log2(Double(x.native)))
 }
 
 @_transparent
 public func log1p(_ x: CGFloat) -> CGFloat {
-    return CGFloat(log1p(x.native))
+    return CGFloat(log1p(Double(x.native)))
 }
 
 @_transparent
 public func logb(_ x: CGFloat) -> CGFloat {
-    return CGFloat(logb(x.native))
+    return CGFloat(logb(Double(x.native)))
 }
 
 @_transparent
 public func cbrt(_ x: CGFloat) -> CGFloat {
-    return CGFloat(cbrt(x.native))
+    return CGFloat(cbrt(Double(x.native)))
 }
 
 @_transparent
 public func erf(_ x: CGFloat) -> CGFloat {
-    return CGFloat(erf(x.native))
+    return CGFloat(erf(Double(x.native)))
 }
 
 @_transparent
 public func erfc(_ x: CGFloat) -> CGFloat {
-    return CGFloat(erfc(x.native))
+    return CGFloat(erfc(Double(x.native)))
 }
 
 @_transparent
 public func tgamma(_ x: CGFloat) -> CGFloat {
-    return CGFloat(tgamma(x.native))
+    return CGFloat(tgamma(Double(x.native)))
 }
 
 @_transparent
 public func nearbyint(_ x: CGFloat) -> CGFloat {
-    return CGFloat(nearbyint(x.native))
+    return CGFloat(nearbyint(Double(x.native)))
 }
 
 @_transparent
 public func rint(_ x: CGFloat) -> CGFloat {
-    return CGFloat(rint(x.native))
+    return CGFloat(rint(Double(x.native)))
 }
 
 @_transparent
 public func atan2(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-    return CGFloat(atan2(lhs.native, rhs.native))
+    return CGFloat(atan2(Double(lhs.native), Double(rhs.native)))
 }
 
 @_transparent
 public func hypot(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-    return CGFloat(hypot(lhs.native, rhs.native))
+    return CGFloat(hypot(Double(lhs.native), Double(rhs.native)))
 }
 
 @_transparent
 public func pow(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-    return CGFloat(pow(lhs.native, rhs.native))
+    return CGFloat(pow(Double(lhs.native), Double(rhs.native)))
 }
 
 @_transparent
 public func copysign(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-    return CGFloat(copysign(lhs.native, rhs.native))
+    return CGFloat(copysign(Double(lhs.native), Double(rhs.native)))
 }
 
 @_transparent
 public func nextafter(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-    return CGFloat(nextafter(lhs.native, rhs.native))
+    return CGFloat(nextafter(Double(lhs.native), Double(rhs.native)))
 }
 
 @_transparent
 public func fdim(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-    return CGFloat(fdim(lhs.native, rhs.native))
+    return CGFloat(fdim(Double(lhs.native), Double(rhs.native)))
 }
 
 @_transparent
 public func fmax(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-    return CGFloat(fmax(lhs.native, rhs.native))
+    return CGFloat(fmax(Double(lhs.native), Double(rhs.native)))
 }
 
 @_transparent
 public func fmin(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-    return CGFloat(fmin(lhs.native, rhs.native))
+    return CGFloat(fmin(Double(lhs.native), Double(rhs.native)))
 }
 
 @_transparent
@@ -805,6 +805,8 @@ public func isnan(_ value: CGFloat) -> Bool { return value.isNaN }
 
 @available(*, unavailable, message: "use the sign property.")
 public func signbit(_ value: CGFloat) -> Int { return value.sign.rawValue }
+
+#if !os(Android) // following are not available
 
 @_transparent
 public func modf(_ x: CGFloat) -> (CGFloat, CGFloat) {
@@ -879,6 +881,7 @@ public func y1(_ x: CGFloat) -> CGFloat {
 public func yn(_ n: Int, _ x: CGFloat) -> CGFloat {
     return CGFloat(yn(n, Double(x.native)))
 }
+#endif
 
 @_transparent
 extension CGFloat : _CVarArgPassedAsDouble, _CVarArgAligned {

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -461,81 +461,81 @@ public func NSIntegralRectWithOptions(_ aRect: NSRect, _ opts: NSAlignmentOption
 
     if opts.contains(.AlignWidthInward) && width != 0 {
         guard width.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        width = floor(aRect.size.width.native)
+        width = floor(Double(aRect.size.width.native))
     }
     if opts.contains(.AlignHeightInward) && height != 0 {
         guard height.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        height = floor(aRect.size.height.native)
+        height = floor(Double(aRect.size.height.native))
     }
     if opts.contains(.AlignWidthOutward) && width != 0 {
         guard width.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        width = ceil(aRect.size.width.native)
+        width = ceil(Double(aRect.size.width.native))
     }
     if opts.contains(.AlignHeightOutward) && height != 0 {
         guard height.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        height = ceil(aRect.size.height.native)
+        height = ceil(Double(aRect.size.height.native))
     }
     if opts.contains(.AlignWidthNearest) && width != 0 {
         guard width.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        width = round(aRect.size.width.native)
+        width = round(Double(aRect.size.width.native))
     }
     if opts.contains(.AlignHeightNearest) && height != 0 {
         guard height.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        height = round(aRect.size.height.native)
+        height = round(Double(aRect.size.height.native))
     }
 
     
     if opts.contains(.AlignMinXInward) {
         guard minX.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        minX = ceil(aRect.origin.x.native)
+        minX = ceil(Double(aRect.origin.x.native))
     }
     if opts.contains(.AlignMinYInward) {
         guard minY.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        minY = ceil(aRect.origin.y.native)
+        minY = ceil(Double(aRect.origin.y.native))
     }
     if opts.contains(.AlignMaxXInward) {
         guard maxX.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        maxX = floor(aRect.origin.x.native + aRect.size.width.native)
+        maxX = floor(Double(aRect.origin.x.native + aRect.size.width.native))
     }
     if opts.contains(.AlignMaxYInward) {
         guard maxY.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        maxY = floor(aRect.origin.y.native + aRect.size.height.native)
+        maxY = floor(Double(aRect.origin.y.native + aRect.size.height.native))
     }
 
     
     if opts.contains(.AlignMinXOutward) {
         guard minX.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        minX = floor(aRect.origin.x.native)
+        minX = floor(Double(aRect.origin.x.native))
     }
     if opts.contains(.AlignMinYOutward) {
         guard minY.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        minY = floor(aRect.origin.y.native)
+        minY = floor(Double(aRect.origin.y.native))
     }
     if opts.contains(.AlignMaxXOutward) {
         guard maxX.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        maxX = ceil(aRect.origin.x.native + aRect.size.width.native)
+        maxX = ceil(Double(aRect.origin.x.native + aRect.size.width.native))
     }
     if opts.contains(.AlignMaxYOutward) {
         guard maxY.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        maxY = ceil(aRect.origin.y.native + aRect.size.height.native)
+        maxY = ceil(Double(aRect.origin.y.native + aRect.size.height.native))
     }
     
 
     if opts.contains(.AlignMinXNearest) {
         guard minX.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        minX = round(aRect.origin.x.native)
+        minX = round(Double(aRect.origin.x.native))
     }
     if opts.contains(.AlignMinYNearest) {
         guard minY.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        minY = round(aRect.origin.y.native)
+        minY = round(Double(aRect.origin.y.native))
     }
     if opts.contains(.AlignMaxXNearest) {
         guard maxX.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        maxX = round(aRect.origin.x.native + aRect.size.width.native)
+        maxX = round(Double(aRect.origin.x.native + aRect.size.width.native))
     }
     if opts.contains(.AlignMaxYNearest) {
         guard maxY.isNaN else { fatalError(listOfOptionsIsInconsistentErrorMessage) }
-        maxY = round(aRect.origin.y.native + aRect.size.height.native)
+        maxY = round(Double(aRect.origin.y.native + aRect.size.height.native))
     }
     
     var resultOriginX = Double.nan
@@ -582,10 +582,10 @@ public func NSIntegralRectWithOptions(_ aRect: NSRect, _ opts: NSAlignmentOption
     }
     
     var result = NSZeroRect
-    result.origin.x.native = resultOriginX
-    result.origin.y.native = resultOriginY
-    result.size.width.native = resultWidth
-    result.size.height.native = resultHeight
+    result.origin.x.native = CGFloat.NativeType(resultOriginX)
+    result.origin.y.native = CGFloat.NativeType(resultOriginY)
+    result.size.width.native = CGFloat.NativeType(resultWidth)
+    result.size.height.native = CGFloat.NativeType(resultHeight)
     
     return result
 }


### PR DESCRIPTION
Values of CGFloat.native need to be cast to Double before being passed to math functions. This PR is in preparation for the Android port of Foundation in PR https://github.com/apple/swift-corelibs-foundation/pull/622. There is a question about whether this conversion should be necessary however as CGFloat.swift is derived from code that builds on other 32 bit platforms as is discussed in the Foundation for Android PR. It’s certainly required on Android.