### PR TITLE
NSSet/CFSet bridge

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -81,6 +81,7 @@ struct _NSDictionaryBridge {
     CFIndex (*countForObject)(CFTypeRef dictionary, CFTypeRef value);
     void (*getObjects)(CFTypeRef dictionary, CFTypeRef _Nullable *_Nullable valuebuf, CFTypeRef _Nullable *_Nullable keybuf);
     void (*__apply)(CFTypeRef dictionary, void (*applier)(CFTypeRef key, CFTypeRef value, void *context), void *context);
+    _Nonnull CFTypeRef (*_Nonnull copy)(CFTypeRef obj);
 };
 
 struct _NSMutableDictionaryBridge {

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -92,11 +92,22 @@ struct _NSMutableDictionaryBridge {
 };
 
 struct _NSSetBridge {
-    
+    CFIndex (*_Nonnull count)(CFTypeRef obj);
+    CFIndex (*countForValue)(CFTypeRef set, CFTypeRef value);
+    bool (*containsValue)(CFTypeRef set, CFTypeRef value);
+    _Nullable CFTypeRef (*_Nonnull getValue)(CFTypeRef set, CFTypeRef value);
+    bool (*getValueIfPresent)(CFTypeRef set, CFTypeRef object, CFTypeRef _Nullable *_Nullable value);
+    void (*getValues)(CFTypeRef set, CFTypeRef _Nullable *_Nullable values);
+    void (*apply)(CFTypeRef set, void (*applier)(CFTypeRef value, void *context), void *context);
+    _Nonnull CFTypeRef (*_Nonnull copy)(CFTypeRef obj);
 };
 
 struct _NSMutableSetBridge {
-    
+    void (*addValue)(CFTypeRef set, CFTypeRef value);
+    void (*replaceValue)(CFTypeRef set, CFTypeRef value);
+    void (*setValue)(CFTypeRef set, CFTypeRef value);
+    void (*removeValue)(CFTypeRef set, CFTypeRef value);
+    void (*removeAllValues)(CFTypeRef set);
 };
 
 struct _NSStringBridge {

--- a/CoreFoundation/Collections.subproj/CFDictionary.c
+++ b/CoreFoundation/Collections.subproj/CFDictionary.c
@@ -290,7 +290,7 @@ CFHashRef CFDictionaryCreateCopy(CFAllocatorRef allocator, CFHashRef other) {
     __CFGenericValidateType(other, typeID);
     Boolean markImmutable = false;
     CFBasicHashRef ht = NULL;
-    if (CF_IS_OBJC(typeID, other)) {
+    if (CF_IS_OBJC(typeID, other) || CF_IS_SWIFT(typeID, other)) {
         if (objc_collectingEnabled()) {
             CFIndex numValues = CFDictionaryGetCount(other);
             const_any_pointer_t vbuffer[256], kbuffer[256];
@@ -314,7 +314,11 @@ CFHashRef CFDictionaryCreateCopy(CFAllocatorRef allocator, CFHashRef other) {
         }
         else { // non-GC
 #if CFDictionary || CFSet
+#if DEPLOYMENT_RUNTIME_SWIFT
+            ht = (CFBasicHashRef)CF_SWIFT_CALLV(other, NSDictionary.copy);
+#else
             ht = (CFBasicHashRef)CF_OBJC_CALLV((id)other, copyWithZone:NULL);
+#endif
 #elif CFBag
             CFIndex numValues = CFDictionaryGetCount(other);
             const_any_pointer_t vbuffer[256];
@@ -350,7 +354,7 @@ CFMutableHashRef CFDictionaryCreateMutableCopy(CFAllocatorRef allocator, CFIndex
     __CFGenericValidateType(other, typeID);
     CFAssert(0 <= capacity, __kCFLogAssertion, "%s(): capacity (%ld) cannot be less than zero", __PRETTY_FUNCTION__, capacity);
     CFBasicHashRef ht = NULL;
-    if (CF_IS_OBJC(typeID, other)) {
+    if (CF_IS_OBJC(typeID, other) || CF_IS_SWIFT(typeID, other)) {
         CFIndex numValues = CFDictionaryGetCount(other);
         const_any_pointer_t vbuffer[256], kbuffer[256];
         const_any_pointer_t *vlist = (numValues <= 256) ? vbuffer : (const_any_pointer_t *)CFAllocatorAllocate(kCFAllocatorSystemDefault, numValues * sizeof(const_any_pointer_t), 0);

--- a/CoreFoundation/Collections.subproj/CFSet.c
+++ b/CoreFoundation/Collections.subproj/CFSet.c
@@ -289,7 +289,7 @@ CFHashRef CFSetCreateCopy(CFAllocatorRef allocator, CFHashRef other) {
     __CFGenericValidateType(other, typeID);
     Boolean markImmutable = false;
     CFBasicHashRef ht = NULL;
-    if (CF_IS_OBJC(typeID, other)) {
+    if (CF_IS_OBJC(typeID, other) || CF_IS_SWIFT(typeID, other)) {
         if (objc_collectingEnabled()) {
             CFIndex numValues = CFSetGetCount(other);
             const_any_pointer_t vbuffer[256], kbuffer[256];
@@ -313,7 +313,11 @@ CFHashRef CFSetCreateCopy(CFAllocatorRef allocator, CFHashRef other) {
         }
         else { // non-GC
 #if CFDictionary || CFSet
+#if DEPLOYMENT_RUNTIME_SWIFT
+            ht = (CFBasicHashRef)CF_SWIFT_CALLV(other, NSSet.copy);
+#else
             ht = (CFBasicHashRef)CF_OBJC_CALLV((id)other, copyWithZone:NULL);
+#endif
 #elif CFBag
             CFIndex numValues = CFSetGetCount(other);
             const_any_pointer_t vbuffer[256];
@@ -349,7 +353,7 @@ CFMutableHashRef CFSetCreateMutableCopy(CFAllocatorRef allocator, CFIndex capaci
     __CFGenericValidateType(other, typeID);
     CFAssert(0 <= capacity, __kCFLogAssertion, "%s(): capacity (%ld) cannot be less than zero", __PRETTY_FUNCTION__, capacity);
     CFBasicHashRef ht = NULL;
-    if (CF_IS_OBJC(typeID, other)) {
+    if (CF_IS_OBJC(typeID, other) || CF_IS_SWIFT(typeID, other)) {
         CFIndex numValues = CFSetGetCount(other);
         const_any_pointer_t vbuffer[256], kbuffer[256];
         const_any_pointer_t *vlist = (numValues <= 256) ? vbuffer : (const_any_pointer_t *)CFAllocatorAllocate(kCFAllocatorSystemDefault, numValues * sizeof(const_any_pointer_t), 0);
@@ -382,6 +386,7 @@ CFIndex CFSetGetCount(CFHashRef hc) {
     if (CFDictionary) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), CFIndex, (NSDictionary *)hc, count);
 #endif
 #if CFSet
+    if (CFSet) CF_SWIFT_FUNCDISPATCHV(CFSetGetTypeID(), CFIndex, (CFSwiftRef)hc, NSSet.count);
     if (CFSet) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), CFIndex, (NSSet *)hc, count);
 #endif
     __CFGenericValidateType(hc, CFSetGetTypeID());
@@ -398,6 +403,7 @@ CFIndex CFSetGetCountOfValue(CFHashRef hc, const_any_pointer_t key) {
     if (CFDictionary) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), CFIndex, (NSDictionary *)hc, countForKey:(id)key);
 #endif
 #if CFSet
+    if (CFSet) CF_SWIFT_FUNCDISPATCHV(CFSetGetTypeID(), CFIndex, (CFSwiftRef)hc, NSSet.countForValue, key);
     if (CFSet) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), CFIndex, (NSSet *)hc, countForObject:(id)key);
 #endif
     __CFGenericValidateType(hc, CFSetGetTypeID());
@@ -414,6 +420,7 @@ Boolean CFSetContainsValue(CFHashRef hc, const_any_pointer_t key) {
     if (CFDictionary) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), char, (NSDictionary *)hc, containsKey:(id)key);
 #endif
 #if CFSet
+    if (CFSet) CF_SWIFT_FUNCDISPATCHV(CFSetGetTypeID(), char, (CFSwiftRef)hc, NSSet.containsValue, key);
     if (CFSet) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), char, (NSSet *)hc, containsObject:(id)key);
 #endif
     __CFGenericValidateType(hc, CFSetGetTypeID());
@@ -425,6 +432,7 @@ const_any_pointer_t CFSetGetValue(CFHashRef hc, const_any_pointer_t key) {
     if (CFDictionary) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), const_any_pointer_t, (NSDictionary *)hc, objectForKey:(id)key);
 #endif
 #if CFSet
+    if (CFSet) CF_SWIFT_FUNCDISPATCHV(CFSetGetTypeID(), CFTypeRef, (CFSwiftRef)hc, NSSet.getValue, key);
     if (CFSet) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), const_any_pointer_t, (NSSet *)hc, member:(id)key);
 #endif
     __CFGenericValidateType(hc, CFSetGetTypeID());
@@ -437,6 +445,7 @@ Boolean CFSetGetValueIfPresent(CFHashRef hc, const_any_pointer_t key, const_any_
     if (CFDictionary) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), Boolean, (NSDictionary *)hc, __getValue:(id *)value forKey:(id)key);
 #endif
 #if CFSet
+    if (CFSet) CF_SWIFT_FUNCDISPATCHV(CFSetGetTypeID(), Boolean, (CFSwiftRef)hc, NSSet.getValueIfPresent, key, value);
     if (CFSet) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), Boolean, (NSSet *)hc, __getValue:(id *)value forObj:(id)key);
 #endif
     __CFGenericValidateType(hc, CFSetGetTypeID());
@@ -495,6 +504,7 @@ void CFSetGetValues(CFHashRef hc, const_any_pointer_t *keybuf) {
     if (CFDictionary) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), void, (NSDictionary *)hc, getObjects:(id *)valuebuf andKeys:(id *)keybuf);
 #endif
 #if CFSet
+    if (CFSet) CF_SWIFT_FUNCDISPATCHV(CFSetGetTypeID(), void, (CFSwiftRef)hc, NSSet.getValues, keybuf);
     if (CFSet) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), void, (NSSet *)hc, getObjects:(id *)keybuf);
 #endif
     __CFGenericValidateType(hc, CFSetGetTypeID());
@@ -522,6 +532,7 @@ void CFSetApplyFunction(CFHashRef hc, CFSetApplierFunction applier, any_pointer_
     if (CFDictionary) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), void, (NSDictionary *)hc, __apply:(void (*)(const void *, const void *, void *))applier context:(void *)context);
 #endif
 #if CFSet
+    if (CFSet) CF_SWIFT_FUNCDISPATCHV(CFSetGetTypeID(), void, (CFSwiftRef)hc, NSSet.apply, applier, context);
     if (CFSet) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), void, (NSSet *)hc, __applyValues:(void (*)(const void *, void *))applier context:(void *)context);
 #endif
     __CFGenericValidateType(hc, CFSetGetTypeID());
@@ -601,6 +612,7 @@ void CFSetAddValue(CFMutableHashRef hc, const_any_pointer_t key) {
     if (CFDictionary) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), void, (NSMutableDictionary *)hc, __addObject:(id)value forKey:(id)key);
 #endif
 #if CFSet
+    if (CFSet) CF_SWIFT_FUNCDISPATCHV(CFSetGetTypeID(), void, (CFSwiftRef)hc, NSMutableSet.addValue, key);
     if (CFSet) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), void, (NSMutableSet *)hc, addObject:(id)key);
 #endif
     __CFGenericValidateType(hc, CFSetGetTypeID());
@@ -624,6 +636,7 @@ void CFSetReplaceValue(CFMutableHashRef hc, const_any_pointer_t key) {
     if (CFDictionary) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), void, (NSMutableDictionary *)hc, replaceObject:(id)value forKey:(id)key);
 #endif
 #if CFSet
+    if (CFSet) CF_SWIFT_FUNCDISPATCHV(CFSetGetTypeID(), void, (CFSwiftRef)hc, NSMutableSet.replaceValue, key);
     if (CFSet) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), void, (NSMutableSet *)hc, replaceObject:(id)key);
 #endif
     __CFGenericValidateType(hc, CFSetGetTypeID());
@@ -647,6 +660,7 @@ void CFSetSetValue(CFMutableHashRef hc, const_any_pointer_t key) {
     if (CFDictionary) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), void, (NSMutableDictionary *)hc, __setObject:(id)value forKey:(id)key);
 #endif
 #if CFSet
+    if (CFSet) CF_SWIFT_FUNCDISPATCHV(CFSetGetTypeID(), void, (CFSwiftRef)hc, NSMutableSet.setValue, key);
     if (CFSet) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), void, (NSMutableSet *)hc, setObject:(id)key);
 #endif
     __CFGenericValidateType(hc, CFSetGetTypeID());
@@ -665,6 +679,7 @@ void CFSetRemoveValue(CFMutableHashRef hc, const_any_pointer_t key) {
     if (CFDictionary) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), void, (NSMutableDictionary *)hc, removeObjectForKey:(id)key);
 #endif
 #if CFSet
+    if (CFSet) CF_SWIFT_FUNCDISPATCHV(CFSetGetTypeID(), void, (CFSwiftRef)hc, NSMutableSet.removeValue, key);
     if (CFSet) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), void, (NSMutableSet *)hc, removeObject:(id)key);
 #endif
     __CFGenericValidateType(hc, CFSetGetTypeID());
@@ -682,6 +697,7 @@ void CFSetRemoveAllValues(CFMutableHashRef hc) {
     if (CFDictionary) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), void, (NSMutableDictionary *)hc, removeAllObjects);
 #endif
 #if CFSet
+    if (CFSet) CF_SWIFT_FUNCDISPATCHV(CFSetGetTypeID(), void, (CFSwiftRef)hc, NSMutableSet.removeAllValues);
     if (CFSet) CF_OBJC_FUNCDISPATCHV(CFSetGetTypeID(), void, (NSMutableSet *)hc, removeAllObjects);
 #endif
     __CFGenericValidateType(hc, CFSetGetTypeID());

--- a/Foundation/NSCFDictionary.swift
+++ b/Foundation/NSCFDictionary.swift
@@ -213,3 +213,7 @@ internal func _CFSwiftDictionaryRemoveValue(_ dictionary:  AnyObject, key: AnyOb
 internal func _CFSwiftDictionaryRemoveAllValues(_ dictionary: AnyObject) {
     (dictionary as! NSMutableDictionary).removeAllObjects()
 }
+
+internal func _CFSwiftDictionaryCreateCopy(_ set: AnyObject) -> Unmanaged<AnyObject> {
+    return Unmanaged<AnyObject>.passRetained((set as! NSDictionary).copy() as! NSObject)
+}

--- a/Foundation/NSCFDictionary.swift
+++ b/Foundation/NSCFDictionary.swift
@@ -214,6 +214,6 @@ internal func _CFSwiftDictionaryRemoveAllValues(_ dictionary: AnyObject) {
     (dictionary as! NSMutableDictionary).removeAllObjects()
 }
 
-internal func _CFSwiftDictionaryCreateCopy(_ set: AnyObject) -> Unmanaged<AnyObject> {
-    return Unmanaged<AnyObject>.passRetained((set as! NSDictionary).copy() as! NSObject)
+internal func _CFSwiftDictionaryCreateCopy(_ dictionary: AnyObject) -> Unmanaged<AnyObject> {
+    return Unmanaged<AnyObject>.passRetained((dictionary as! NSDictionary).copy() as! NSObject)
 }

--- a/Foundation/NSCFSet.swift
+++ b/Foundation/NSCFSet.swift
@@ -31,4 +31,138 @@ internal final class _NSCFSet : NSMutableSet {
     override var classForCoder: AnyClass {
         return NSMutableSet.self
     }
+    
+    override var count: Int {
+        return CFSetGetCount(_cfObject)
+    }
+    
+    override func member(_ object: Any) -> Any? {
+        
+        guard let value = CFSetGetValue(_cfObject, unsafeBitCast(_SwiftValue.store(object), to: UnsafeRawPointer.self)) else {
+            return nil
+        }
+        return _SwiftValue.fetch(unsafeBitCast(value, to: AnyObject.self))
+        
+    }
+    
+    override func objectEnumerator() -> NSEnumerator {
+        
+        var objArray: [AnyObject] = []
+        let cf = _cfObject
+        let count = CFSetGetCount(cf)
+        
+        let objects = UnsafeMutablePointer<UnsafeRawPointer?>.allocate(capacity: count)
+        CFSetGetValues(cf, objects)
+        
+        for idx in 0..<count {
+            let obj = unsafeBitCast(objects.advanced(by: idx).pointee!, to: AnyObject.self)
+            objArray.append(obj)
+        }
+        objects.deinitialize()
+        objects.deallocate(capacity: count)
+        
+        return NSGeneratorEnumerator(objArray.makeIterator())
+        
+    }
+    
+    override func add(_ object: Any) {
+        CFSetAddValue(_cfMutableObject, unsafeBitCast(_SwiftValue.store(object), to: UnsafeRawPointer.self))
+    }
+    
+    override func remove(_ object: Any) {
+        CFSetRemoveValue(_cfMutableObject, unsafeBitCast(_SwiftValue.store(object), to: UnsafeRawPointer.self))
+    }
+    
+}
+
+internal func _CFSwiftSetGetCount(_ set: AnyObject) -> CFIndex {
+    return (set as! NSSet).count
+}
+
+internal func _CFSwiftSetGetCountOfValue(_ set: AnyObject, value: AnyObject) -> CFIndex {
+    if _CFSwiftSetContainsValue(set, value: value) {
+        return 1
+    } else {
+        return 0
+    }
+}
+
+internal func _CFSwiftSetContainsValue(_ set: AnyObject, value: AnyObject) -> Bool {
+    return _CFSwiftSetGetValue((set as! NSSet)._cfObject, value: value) != nil
+}
+
+internal func _CFSwiftSetGetValues(_ set: AnyObject, _ values: UnsafeMutablePointer<Unmanaged<AnyObject>?>?) {
+    
+    var idx = 0
+    if values == nil {
+        return
+    }
+    
+    let set = set as! NSSet
+    if type(of: set) === NSSet.self || type(of: set) === NSMutableSet.self {
+        for obj in set._storage {
+            values?[idx] = Unmanaged<AnyObject>.passUnretained(obj)
+            idx += 1
+        }
+    } else {
+        //hmmm...
+    }
+}
+
+internal func _CFSwiftSetGetValue(_ set: AnyObject, value: AnyObject) -> Unmanaged<AnyObject>? {
+    let set = set as! NSSet
+    if type(of: set) === NSSet.self || type(of: set) === NSMutableSet.self {
+        if let obj = set.member(value) {
+            return Unmanaged<AnyObject>.passUnretained(obj as AnyObject)
+        }
+    } else {
+        //hmmm...
+    }
+    return nil
+}
+
+internal func _CFSwiftSetGetValueIfPresent(_ set: AnyObject, object: AnyObject, value: UnsafeMutablePointer<Unmanaged<AnyObject>?>?) -> Bool {
+    if let val = _CFSwiftSetGetValue(set, value: object) {
+        value?.pointee = val
+        return true
+    } else {
+        value?.pointee = nil
+        return false
+    }
+}
+
+internal func _CFSwiftSetApplyFunction(_ set: AnyObject, applier: @convention(c) (AnyObject, UnsafeMutableRawPointer) -> Void, context: UnsafeMutableRawPointer) {
+    (set as! NSSet).enumerateObjects({ value, _ in
+        applier(_SwiftValue.store(value), context)
+    })
+}
+
+internal func _CFSwiftSetAddValue(_ set: AnyObject, value: AnyObject) {
+    (set as! NSMutableSet).add(value)
+}
+
+internal func _CFSwiftSetReplaceValue(_ set:  AnyObject, value: AnyObject) {
+    let set = set as! NSMutableSet
+    if (set.contains(value)){
+        set.remove(value)
+        set.add(value)
+    }
+}
+
+internal func _CFSwiftSetSetValue(_ set:  AnyObject, value: AnyObject) {
+    let set = set as! NSMutableSet
+    set.remove(value)
+    set.add(value)
+}
+
+internal func _CFSwiftSetRemoveValue(_ set:  AnyObject, value: AnyObject) {
+    (set as! NSMutableSet).remove(value)
+}
+
+internal func _CFSwiftSetRemoveAllValues(_ set: AnyObject) {
+    (set as! NSMutableSet).removeAllObjects()
+}
+
+internal func _CFSwiftSetCreateCopy(_ set: AnyObject) -> Unmanaged<AnyObject> {
+    return Unmanaged<AnyObject>.passRetained((set as! NSSet).copy() as! NSObject)
 }

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -298,6 +298,10 @@ extension CFSet : _NSBridgeable, _SwiftBridgeable {
     internal var _swiftObject: Set<NSObject> { return _nsObject._swiftObject }
 }
 
+extension NSMutableSet {
+    internal var _cfMutableObject: CFMutableSet { return unsafeBitCast(self, to: CFMutableSet.self) }
+}
+
 extension Set : _NSBridgeable, _CFBridgeable {
     internal var _nsObject: NSSet { return _bridgeToObjectiveC() }
     internal var _cfObject: CFSet { return _nsObject._cfObject }

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -26,10 +26,8 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
             NSRequiresConcreteImplementation()
         }
         let value = _SwiftValue.store(object)
-        if _storage.contains(value) {
-            return object // this is not exactly the same behavior, but it is reasonably close
-        }
-        return nil
+        guard let idx = _storage.index(of: value) else { return nil }
+        return _storage[idx]
     }
     
     open func objectEnumerator() -> NSEnumerator {

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -100,6 +100,19 @@ internal func __CFInitializeSwift() {
     __CFSwiftBridge.NSObject.hash = _CFSwiftGetHash
     __CFSwiftBridge.NSObject._cfTypeID = _CFSwiftGetTypeID
     
+    __CFSwiftBridge.NSSet.count = _CFSwiftSetGetCount
+    __CFSwiftBridge.NSSet.countForValue = _CFSwiftSetGetCountOfValue
+    __CFSwiftBridge.NSSet.containsValue = _CFSwiftSetContainsValue
+    __CFSwiftBridge.NSSet.getValue = _CFSwiftSetGetValue
+    __CFSwiftBridge.NSSet.getValueIfPresent = _CFSwiftSetGetValueIfPresent
+    __CFSwiftBridge.NSSet.getValues = _CFSwiftSetGetValues
+    __CFSwiftBridge.NSSet.copy = _CFSwiftSetCreateCopy
+    
+    __CFSwiftBridge.NSMutableSet.addValue = _CFSwiftSetAddValue
+    __CFSwiftBridge.NSMutableSet.replaceValue = _CFSwiftSetReplaceValue
+    __CFSwiftBridge.NSMutableSet.setValue = _CFSwiftSetSetValue
+    __CFSwiftBridge.NSMutableSet.removeValue = _CFSwiftSetRemoveValue
+    __CFSwiftBridge.NSMutableSet.removeAllValues = _CFSwiftSetRemoveAllValues
     
     __CFSwiftBridge.NSArray.count = _CFSwiftArrayGetCount
     __CFSwiftBridge.NSArray.objectAtIndex = _CFSwiftArrayGetValueAtIndex

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -136,6 +136,7 @@ internal func __CFInitializeSwift() {
     __CFSwiftBridge.NSDictionary.countForObject = _CFSwiftDictionaryGetCountOfValue
     __CFSwiftBridge.NSDictionary.getObjects = _CFSwiftDictionaryGetValuesAndKeys
     __CFSwiftBridge.NSDictionary.__apply = _CFSwiftDictionaryApplyFunction
+    __CFSwiftBridge.NSDictionary.copy = _CFSwiftDictionaryCreateCopy
     
     __CFSwiftBridge.NSMutableDictionary.__addObject = _CFSwiftDictionaryAddValue
     __CFSwiftBridge.NSMutableDictionary.replaceObject = _CFSwiftDictionaryReplaceValue


### PR DESCRIPTION
Implements the bridge between NSSet and CFSet in the same way as the other NSCF classes.
I believe that NSSet member() now behaves as expected, returning the actual object stored in the set, rather than the compared value.

Also includes a fix that allows bridged dictionaries to be copied.