### PR TITLE
SR-2617: URLSession.dataTask() ignores httpBody

### DIFF
--- a/Foundation/NSURLSession/NSURLSessionTask.swift
+++ b/Foundation/NSURLSession/NSURLSessionTask.swift
@@ -90,9 +90,13 @@ open class URLSessionTask : NSObject, NSCopying {
         self.tempFileURL = URL(fileURLWithPath: fileName)
         super.init()
     }
-    /// Create a data task, i.e. with no body
+    /// Create a data task. If there is a httpBody in the URLRequest, use that as a parameter
     internal convenience init(session: URLSession, request: URLRequest, taskIdentifier: Int) {
-        self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: .none)
+        if let bodyData = request.httpBody {
+            self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: _Body.data(createDispatchData(bodyData)))
+        } else {
+            self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: .none)
+        }
     }
     internal init(session: URLSession, request: URLRequest, taskIdentifier: Int, body: _Body) {
         self.session = session


### PR DESCRIPTION
SR-2617 reports that if you create a `URLRequest` with a `httpBody` set, and then try to create a session using `URLSession.dataTask()`, the httpBody is ignored.

This is because the call to URLSession.dataTask() creates a task with the following constructor:
```
URLSessionDataTask(session: self, request: r, taskIdentifier: i)
```
which in turn calls:
```
init(session: session, request: request, taskIdentifier: taskIdentifier, body: .none)
```
ie, we create a task with no body.

I've therefore made a change to pass through `URLRequest.httpBody` if one exists.

The reported bug has a second issue: the request is a `POST`, and we're not setting `"Content-Type" : "application/x-www-form-urlencoded"`. I'll look at fixing that separately. 

