### PR TITLE
[swift-3.0-branch] Fix crash in NSValue.isEqual() when it is passed an NSNumber

### DIFF
--- a/Foundation/NSValue.swift
+++ b/Foundation/NSValue.swift
@@ -58,10 +58,12 @@ open class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
             } else {
                 // bypass _concreteValue accessor in order to avoid acquiring lock twice
                 let (lhs, rhs) = NSValue.SideTableLock.synchronized {
-                    return (NSValue.SideTable[ObjectIdentifier(self)]!,
-                            NSValue.SideTable[ObjectIdentifier(object)]!)
+                    return (NSValue.SideTable[ObjectIdentifier(self)],
+                            NSValue.SideTable[ObjectIdentifier(object)])
                 }
-                return lhs.isEqual(rhs)
+                if let lhs = lhs, let rhs = rhs {
+                    return lhs.isEqual(rhs)
+                }
             }
         }
         return false

--- a/TestFoundation/TestNSValue.swift
+++ b/TestFoundation/TestNSValue.swift
@@ -29,6 +29,7 @@ class TestNSValue : XCTestCase {
             ( "test_valueWithShortArray", test_valueWithShortArray ),
             ( "test_valueWithULongLongArray", test_valueWithULongLongArray ),
             ( "test_valueWithCharPtr", test_valueWithULongLongArray ),
+            ( "test_isEqual", test_isEqual ),
         ]
     }
     
@@ -125,5 +126,12 @@ class TestNSValue : XCTestCase {
         
         NSValue(bytes: &charPtr, objCType: "*").getValue(&expectedPtr)
         XCTAssertEqual(charPtr, expectedPtr)
+    }
+
+    func test_isEqual() {
+        let number = NSNumber(value: Int(123))
+        var long: Int32 = 123456
+        let value = NSValue(bytes: &long, objCType: "l")
+        XCTAssertFalse(value.isEqual(number))
     }
 }


### PR DESCRIPTION
* Explanation: Fixing the crash in NSValue.isEqual 
* Scope of Issue: NSValue.isEqual was not handling the case where the underlying value was an NSNumber
* Origination: Existing bug in the code
* Risk: Minimal
* Reviewed By: Dmitri Gribenko
* Testing: Ran the existing test suite.
* Directions for QA: N/A

rdar://problem/28284641