### PR TITLE
Fix for a URLSession crash (SR-2630)

### DIFF
--- a/Foundation/NSURLSession/NSURLSessionTask.swift
+++ b/Foundation/NSURLSession/NSURLSessionTask.swift
@@ -833,10 +833,13 @@ extension URLSessionTask {
             guard case .inMemory(let bodyData) = bodyDataDrain else {
                 fatalError("Task has data completion handler, but data drain is not in-memory.")
             }
+
             guard let s = session as? URLSession else { fatalError() }
-           
-            var data = Data(capacity: bodyData!.length)
-            data.append(Data(bytes: bodyData!.bytes, count: bodyData!.length)) 
+
+            var data = Data()
+            if let body = bodyData {
+                data = Data(bytes: body.bytes, count: body.length)
+            }
 
             s.delegateQueue.addOperation {
                 completion(data, response, nil)


### PR DESCRIPTION
I am abstaining from adding the tests from SR-2630 to TestFoundation because the reach out to external URLs and I saw them hang on a few instances. 