### PR TITLE
[SR-2617] POST requests should have Content-Type : application/x-www-form-urlencoded by default

### DIFF
--- a/Foundation/NSURLSession/NSURLSessionTask.swift
+++ b/Foundation/NSURLSession/NSURLSessionTask.swift
@@ -568,6 +568,8 @@ fileprivate extension URLSessionTask {
         easyHandle.set(requestMethod: request.httpMethod ?? "GET")
         if request.httpMethod == "HEAD" {
             easyHandle.set(noBody: true)
+        } else if ((request.httpMethod == "POST") && (request.value(forHTTPHeaderField: "Content-Type") == nil)) {
+            easyHandle.set(customHeaders: ["Content-Type:application/x-www-form-urlencoded"])
         }
     }
 }


### PR DESCRIPTION
The test case provided in SR-2617 has highlighted multiple differences between Darwin and Linux, the second of which is that POST requests are automatically set to have a header value of `Content-Type : application/x-www-form-urlencoded` on Darwin, but don't on Linux.

The behaviour on Darwin is that:
1. The value is set, but doesn't appear in the `URLRequest.allHTTPHeaderFields`
2. The value is overridden by any call to `req.setValue(value, forHTTPHeaderField: "Content-Type" )`

This PR mimics that behaviour by setting the header as we pass it to the underlying libcurl implementation, if and only if Content-Type isn't already set. 