### PR TITLE
Fix for SR-2631 and implementing URLSession.finishTasksAndInvalidate

### DIFF
--- a/Foundation/NSURLSession/NSURLSession.swift
+++ b/Foundation/NSURLSession/NSURLSession.swift
@@ -189,8 +189,9 @@ open class URLSession : NSObject {
     /// This queue is used to make public attributes on `URLSessionTask` instances thread safe.
     /// - Note: It's a **concurrent** queue.
     internal let taskAttributesIsolation: DispatchQueue 
-    fileprivate let taskRegistry = URLSession._TaskRegistry()
+    internal let taskRegistry = URLSession._TaskRegistry()
     fileprivate let identifier: Int32
+    fileprivate var invalidated = false
     
     /*
      * The shared session uses the currently set global NSURLCache,
@@ -237,7 +238,7 @@ open class URLSession : NSObject {
     }
     
     open let delegateQueue: OperationQueue
-    open let delegate: URLSessionDelegate?
+    open var delegate: URLSessionDelegate?
     open let configuration: URLSessionConfiguration
     
     /*
@@ -258,7 +259,27 @@ open class URLSession : NSObject {
      * session with the same identifier until URLSession:didBecomeInvalidWithError: has
      * been issued.
      */
-    open func finishTasksAndInvalidate() { NSUnimplemented() }
+    open func finishTasksAndInvalidate() {
+       //we need to return immediately
+       workQueue.async {
+           //don't allow creation of new tasks from this point onwards
+           self.invalidated = true
+
+           //wait for running tasks to finish
+           if !self.taskRegistry.isEmpty {
+               let tasksCompletion = DispatchSemaphore(value: 0)
+               self.taskRegistry.notify(on: tasksCompletion)
+               tasksCompletion.wait()
+           }
+
+           //invoke the delegate method and break the delegate link
+           guard let sessionDelegate = self.delegate else { return }
+           self.delegateQueue.addOperation {
+               sessionDelegate.urlSession(self, didBecomeInvalidWithError: nil)
+               self.delegate = nil
+           }
+       }
+    }
     
     /* -invalidateAndCancel acts as -finishTasksAndInvalidate, but issues
      * -cancel to all outstanding tasks for this session.  Note task
@@ -367,6 +388,7 @@ fileprivate extension URLSession {
     ///
     /// All public methods funnel into this one.
     func dataTask(with request: _Request, behaviour: _TaskRegistry._Behaviour) -> URLSessionDataTask {
+        guard !self.invalidated else { fatalError("Session invalidated") }
         let r = createConfiguredRequest(from: request)
         let i = createNextTaskIdentifier()
         let task = URLSessionDataTask(session: self, request: r, taskIdentifier: i)
@@ -380,6 +402,7 @@ fileprivate extension URLSession {
     ///
     /// All public methods funnel into this one.
     func uploadTask(with request: _Request, body: URLSessionTask._Body, behaviour: _TaskRegistry._Behaviour) -> URLSessionUploadTask {
+        guard !self.invalidated else { fatalError("Session invalidated") }
         let r = createConfiguredRequest(from: request)
         let i = createNextTaskIdentifier()
         let task = URLSessionUploadTask(session: self, request: r, taskIdentifier: i, body: body)
@@ -391,6 +414,7 @@ fileprivate extension URLSession {
     
     /// Create a download task
     func downloadTask(with request: _Request, behavior: _TaskRegistry._Behaviour) -> URLSessionDownloadTask {
+        guard !self.invalidated else { fatalError("Session invalidated") }
         let r = createConfiguredRequest(from: request)
         let i = createNextTaskIdentifier()
         let task = URLSessionDownloadTask(session: self, request: r, taskIdentifier: i)

--- a/Foundation/NSURLSession/TaskRegistry.swift
+++ b/Foundation/NSURLSession/TaskRegistry.swift
@@ -17,7 +17,7 @@
 // -----------------------------------------------------------------------------
 
 import CoreFoundation
-
+import Dispatch
 
 extension URLSession {
     /// This helper class keeps track of all tasks, and their behaviours.
@@ -45,6 +45,7 @@ extension URLSession {
         
         fileprivate var tasks: [Int: URLSessionTask] = [:]
         fileprivate var behaviours: [Int: _Behaviour] = [:]
+        fileprivate var tasksFinished: DispatchSemaphore?
     }
 }
 
@@ -79,6 +80,19 @@ extension URLSession._TaskRegistry {
             fatalError("Trying to remove task's behaviour, but it's not in the registry.")
         }
         behaviours.remove(at: behaviourIdx)
+
+        guard let allTasksFinished = tasksFinished else { return }
+        if self.isEmpty {
+            allTasksFinished.signal()
+        }
+    }
+
+    func notify(on semaphore: DispatchSemaphore) {
+        tasksFinished = semaphore
+    }
+
+    var isEmpty: Bool {
+        return tasks.count == 0
     }
 }
 extension URLSession._TaskRegistry {


### PR DESCRIPTION
This PR primarily addresses the premature URLSession object cleanup reported in[ SR-2631](https://bugs.swift.org/browse/SR-2631). 

As a solution to SR-2631, we now maintain a reference to the session object from the task object creating a retain cycle. So, this PR also takes care of breaking such cycles on task completion. 

Another type of retain cycle can exist between session objects and the delegates registered with them (see point 15 [here](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/URLLoadingSystem/NSURLSessionConcepts/NSURLSessionConcepts.html)), the ```finishTasksAndInvalidate``` method breaks these cycles per the URLSession specification.