### PR TITLE
Fix for NSOperationQueue race condition causing public CI failures

### DIFF
--- a/Foundation/NSOperation.swift
+++ b/Foundation/NSOperation.swift
@@ -399,11 +399,13 @@ open class OperationQueue: NSObject {
          execution. The only differential is that the block enqueued to dispatch_async
          is balanced with the number of Operations enqueued to the NSOperationQueue.
          */
+        lock.lock()
         ops.forEach { (operation: Operation) -> Void in
-            lock.lock()
             operation._queue = self
             _operations.insert(operation)
-            lock.unlock()
+        }
+        lock.unlock()
+        ops.forEach { (operation: Operation) -> Void in
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
             if let group = waitGroup {
                 group.enter()


### PR DESCRIPTION
- Description: Fixes an issue where adding tasks to an OperationQueue has a race condition which may cause them to execute without regard to priority order.

- Scope of the issue: Currently causing stochastic public CI build failures.
https://ci.swift.org/view/swift-3.0-branch/job/oss-swift-3.0-incremental-RA-linux-ubuntu-15_10/182/consoleFull#-289045209ee1a197b-acac-4b17-83cf-a53b95139a76

- Risk: Low.

- Tested: Fixes existing test.

- Reviewed by: 

- Radar: rdar://problem/28178534

- Jira: https://bugs.swift.org/browse/SR-2569