### PR TITLE
Allow numeric types in NSNumberFormatter.string(for:)[SR-2477]

### DIFF
--- a/Foundation/NSNumberFormatter.swift
+++ b/Foundation/NSNumberFormatter.swift
@@ -85,7 +85,8 @@ open class NumberFormatter : Formatter {
     open func objectValue(_ string: String, range: inout NSRange) throws -> Any? { NSUnimplemented() }
     
     open override func string(for obj: Any) -> String? {
-        guard let number = obj as? NSNumber else { return nil }
+        //we need to allow Swift's numeric types here - Int, Double et al.
+        guard let number = _SwiftValue.store(obj) as? NSNumber else { return nil }
         return string(from: number)
     }
     

--- a/TestFoundation/TestNSNumberFormatter.swift
+++ b/TestFoundation/TestNSNumberFormatter.swift
@@ -52,7 +52,8 @@ class TestNSNumberFormatter: XCTestCase {
             ("test_currencyGroupingSeparator", test_currencyGroupingSeparator),
             ("test_lenient", test_lenient),
             ("test_minimumSignificantDigits", test_minimumSignificantDigits),
-            ("test_maximumSignificantDigits", test_maximumSignificantDigits)
+            ("test_maximumSignificantDigits", test_maximumSignificantDigits),
+            ("test_stringFor", test_stringFor)
         ]
     }
     
@@ -341,5 +342,18 @@ class TestNSNumberFormatter: XCTestCase {
         let formattedString = numberFormatter.string(from: 42.42424242)
         XCTAssertEqual(formattedString, "42.4")
     }
+
+    func test_stringFor() {
+        let numberFormatter = NumberFormatter()
+        XCTAssertEqual(numberFormatter.string(for: 10)!, "10")
+        XCTAssertEqual(numberFormatter.string(for: 3.14285714285714)!, "3")
+        XCTAssertEqual(numberFormatter.string(for: true)!, "1")
+        XCTAssertEqual(numberFormatter.string(for: false)!, "0")
+        XCTAssertNil(numberFormatter.string(for: [1,2]))
+        XCTAssertEqual(numberFormatter.string(for: NSNumber(value: 99.1))!, "99")
+        XCTAssertNil(numberFormatter.string(for: "NaN"))
+        XCTAssertNil(numberFormatter.string(for: NSString(string: "NaN")))
+    }
+  
 }
 


### PR DESCRIPTION
Reported by https://bugs.swift.org/browse/SR-2477

In the absence of coercion of Swift types to Foundation types on Linux, this is to bring about functional similarity with Darwin.