### PR TITLE
String: prevent executable stacks on GNU targets

### DIFF
--- a/CoreFoundation/Base.subproj/CFAsmMacros.h
+++ b/CoreFoundation/Base.subproj/CFAsmMacros.h
@@ -14,5 +14,11 @@
 #define CONCAT_EXPANDED(a,b) CONCAT(a,b)
 #define _C_LABEL(name) CONCAT_EXPANDED(__USER_LABEL_PREFIX__,name)
 
+#if defined(__GNU__) || defined(__ANDROID__) || defined(__FreeBSD__)
+#define NO_EXEC_STACK_DIRECTIVE .section .note.GNU-stack,"",%progbits
+#else
+#define NO_EXEC_STACK_DIRECTIVE
+#endif
+
 #endif
 

--- a/CoreFoundation/String.subproj/CFCharacterSetData.S
+++ b/CoreFoundation/String.subproj/CFCharacterSetData.S
@@ -20,3 +20,6 @@ _C_LABEL(__CFCharacterSetBitmapDataEnd):
     .global _C_LABEL(__CFCharacterSetBitmapDataSize)
 _C_LABEL(__CFCharacterSetBitmapDataSize):
     .int _C_LABEL(__CFCharacterSetBitmapDataEnd) - _C_LABEL(__CFCharacterSetBitmapData)
+
+NO_EXEC_STACK_DIRECTIVE
+

--- a/CoreFoundation/String.subproj/CFUniCharPropertyDatabase.S
+++ b/CoreFoundation/String.subproj/CFUniCharPropertyDatabase.S
@@ -20,3 +20,6 @@ _C_LABEL(__CFUniCharPropertyDatabaseEnd):
     .global _C_LABEL(__CFUniCharPropertyDatabaseSize)
 _C_LABEL(__CFUniCharPropertyDatabaseSize):
     .int _C_LABEL(__CFUniCharPropertyDatabaseEnd) - _C_LABEL(__CFUniCharPropertyDatabase)
+
+NO_EXEC_STACK_DIRECTIVE
+

--- a/CoreFoundation/String.subproj/CFUnicodeData.S
+++ b/CoreFoundation/String.subproj/CFUnicodeData.S
@@ -34,3 +34,6 @@ _C_LABEL(__CFUnicodeDataLEnd):
 _C_LABEL(__CFUnicodeDataLSize):
     .int _C_LABEL(__CFUnicodeDataLEnd) - _C_LABEL(__CFUnicodeDataL)
 #endif
+
+NO_EXEC_STACK_DIRECTIVE
+


### PR DESCRIPTION
The use of the hand written assembly files could potentially introduce
executable stacks.  Since these files do not require the executable stacks,
ensure that we add the special marker to indicate that executable stacks are not
required.