### PR TITLE
Support JSONSerialization of more number types

### DIFF
--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -273,11 +273,7 @@ private struct JSONWriter {
         
         if let str = obj as? String {
             try serializeString(str)
-        } else if let num = obj as? Int {
-            try serializeNumber(NSNumber(value: num))
-        } else if let num = obj as? Double {
-            try serializeNumber(NSNumber(value: num))
-        } else if let num = obj as? NSNumber {
+        } else if let num = _SwiftValue.store(obj) as? NSNumber {
             try serializeNumber(num)
         } else if let array = obj as? Array<Any> {
             try serializeArray(array)


### PR DESCRIPTION
Currently the JSON Serializer only handles the "common" numbers types: `Int`, `Double` and `NSNumber`.

Trying to serialise the other number types: `UInt`, `Int8`, `UInt8`, etc as well as `Float` results in an Error.

This PR adds support for the wider set of standard types. 