### PR TITLE
Fix a missing test case in NSAttributedString

### DIFF
--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -91,7 +91,7 @@ internal func __CFInitializeSwift() {
     _CFRuntimeBridgeTypeToClass(_CFKeyedArchiverUIDGetTypeID(), unsafeBitCast(_NSKeyedArchiverUID.self, to: UnsafeRawPointer.self))
     
 //    _CFRuntimeBridgeTypeToClass(CFErrorGetTypeID(), unsafeBitCast(NSError.self, UnsafeRawPointer.self))
-//    _CFRuntimeBridgeTypeToClass(CFAttributedStringGetTypeID(), unsafeBitCast(NSMutableAttributedString.self, UnsafeRawPointer.self))
+    _CFRuntimeBridgeTypeToClass(CFAttributedStringGetTypeID(), unsafeBitCast(NSMutableAttributedString.self, to: UnsafeRawPointer.self))
 //    _CFRuntimeBridgeTypeToClass(CFReadStreamGetTypeID(), unsafeBitCast(InputStream.self, UnsafeRawPointer.self))
 //    _CFRuntimeBridgeTypeToClass(CFWriteStreamGetTypeID(), unsafeBitCast(OutputStream.self, UnsafeRawPointer.self))
    _CFRuntimeBridgeTypeToClass(CFRunLoopTimerGetTypeID(), unsafeBitCast(Timer.self, to: UnsafeRawPointer.self))

--- a/TestFoundation/TestNSAttributedString.swift
+++ b/TestFoundation/TestNSAttributedString.swift
@@ -24,7 +24,8 @@ class TestNSAttributedString : XCTestCase {
     static var allTests: [(String, (TestNSAttributedString) -> () throws -> Void)] {
         return [
             ("test_initWithString", test_initWithString),
-            ("test_initWithStringAndAttributes", test_initWithStringAndAttributes)
+            ("test_initWithStringAndAttributes", test_initWithStringAndAttributes),
+            ("test_longestEffectiveRange", test_longestEffectiveRange),
         ]
     }
     
@@ -97,11 +98,11 @@ class TestNSAttributedString : XCTestCase {
         
         _ = attrString.attribute(attrKey, at: 0, longestEffectiveRange: &range, in: searchRange)
         XCTAssertEqual(range.location, 0)
-        XCTAssertEqual(range.length, 29)
+        XCTAssertEqual(range.length, 28)
         
         _ = attrString.attributes(at: 0, longestEffectiveRange: &range, in: searchRange)
         XCTAssertEqual(range.location, 0)
-        XCTAssertEqual(range.length, 29)
+        XCTAssertEqual(range.length, 28)
     }
     
 }


### PR DESCRIPTION
Previously, the `test_longestEffectiveRange` was not added to `allTests`.
Also some of the asserts were miscalculated.