### PR TITLE
[NSFileManager] Cast file types as Int32

### DIFF
--- a/Foundation/NSFileManager.swift
+++ b/Foundation/NSFileManager.swift
@@ -253,12 +253,12 @@ open class FileManager : NSObject {
                 #if os(OSX) || os(iOS)
                     let tempEntryType = entryType
                 #elseif os(Linux) || os(Android)
-                    let tempEntryType = Int(entryType)
+                    let tempEntryType = Int32(entryType)
                 #endif
-                        
-                if tempEntryType == Int(DT_DIR) {
+
+                if tempEntryType == Int32(DT_DIR) {
                     let subPath: String = path + "/" + entryName
-                            
+
                     let entries =  try subpathsOfDirectory(atPath: subPath)
                     contents.append(contentsOf: entries.map({file in "\(entryName)/\(file)"}))
                 }


### PR DESCRIPTION
On macOS, `DT_DIR` is imported as an `Int`. `Int` and `Int32` cannot be compared via `==`, so on macOS the comparison results in a build failure. Cast the variables to `Int32` to resolve.

---

This fixes a Foundation build failure on XCTest's macOS CI. Unblocks https://github.com/apple/swift-corelibs-xctest/pull/172 and https://github.com/apple/swift-corelibs-xctest/pull/174.