### PR TITLE
[SR-2798] Fix deadlock in URLSession.

### DIFF
--- a/Foundation/NSURLSession/TaskRegistry.swift
+++ b/Foundation/NSURLSession/TaskRegistry.swift
@@ -45,7 +45,7 @@ extension URLSession {
         
         fileprivate var tasks: [Int: URLSessionTask] = [:]
         fileprivate var behaviours: [Int: _Behaviour] = [:]
-        fileprivate var tasksFinished: DispatchSemaphore?
+        fileprivate var tasksFinishedCallback: (() -> ())?
     }
 }
 
@@ -81,14 +81,14 @@ extension URLSession._TaskRegistry {
         }
         behaviours.remove(at: behaviourIdx)
 
-        guard let allTasksFinished = tasksFinished else { return }
+        guard let allTasksFinished = tasksFinishedCallback else { return }
         if self.isEmpty {
-            allTasksFinished.signal()
+            allTasksFinished()
         }
     }
 
-    func notify(on semaphore: DispatchSemaphore) {
-        tasksFinished = semaphore
+    func notify(on tasksCompetion: @escaping () -> ()) {
+        tasksFinishedCallback = tasksCompetion
     }
 
     var isEmpty: Bool {


### PR DESCRIPTION
The problem is in the current implementation of `finishTasksAndInvalidate`, if there're executing tasks in session - it will create a semaphore, that will block session work queue, but to release, it has to enter that queue again.

Resolves [SR-2798](https://bugs.swift.org/browse/SR-2798).