### PR TITLE
Don't use #import when #include will do

### DIFF
--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -73,8 +73,8 @@ typedef char * Class;
 #endif
 
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI
-#import <libkern/OSAtomic.h>
-#import <pthread.h>
+#include <libkern/OSAtomic.h>
+#include <pthread.h>
 #endif
 
 /* This macro creates some helper functions which are useful in dealing with libdispatch:

--- a/CoreFoundation/Base.subproj/ForFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForFoundationOnly.h
@@ -61,10 +61,10 @@ CF_IMPLICIT_BRIDGING_DISABLED
 
 
 #if INCLUDE_OBJC
-#import <objc/message.h>
+#include <objc/message.h>
 #endif
 #if DEPLOYMENT_TARGET_MACOSX && !LIBAUTO_STUB
-#import <objc/objc-auto.h>
+#include <objc/objc-auto.h>
 #endif
 
 // ---- CFBundle material ----------------------------------------


### PR DESCRIPTION
This changes a few `#import` statements to `#include`. This is because Clang's MSVC compatibility does not handle `#import` statements outside of of objc.

    #import of type library is an unsupported Microsoft feature