### PR TITLE
Remove XML validation from NSArray/NSDictionary tests

### DIFF
--- a/TestFoundation/TestNSArray.swift
+++ b/TestFoundation/TestNSArray.swift
@@ -483,13 +483,12 @@ class TestNSArray : XCTestCase {
             if isWritten {
                 do {
                     let plistDoc = try XMLDocument(contentsOf: URL(fileURLWithPath: testFilePath!, isDirectory: false), options: [])
-                    try plistDoc.validate()
                     XCTAssert(plistDoc.rootElement()?.name == "plist")
                     let plist = try PropertyListSerialization.propertyList(from: plistDoc.xmlData, options: [], format: nil) as! [Any]
                     XCTAssert((plist[0] as? String) == d1[0] as? String)
                     XCTAssert((plist[1] as? String) == d1[1] as? String)
                 } catch {
-                    XCTFail("XMLDocument failes to read / validate contenets")
+                    XCTFail("Failed to read and parse XMLDocument")
                 }
             } else {
                 XCTFail("Write to file failed")

--- a/TestFoundation/TestNSDictionary.swift
+++ b/TestFoundation/TestNSDictionary.swift
@@ -168,16 +168,15 @@ class TestNSDictionary : XCTestCase {
         if let _ = testFilePath {
             let d1: NSDictionary = [ "foo": "bar", "baz": "qux"]
             let isWritten = d1.write(toFile: testFilePath!, atomically: true)
-            if(isWritten){
-                do{
+            if isWritten {
+                do {
                     let plistDoc = try XMLDocument(contentsOf: URL(fileURLWithPath: testFilePath!, isDirectory: false), options: [])
-                    try plistDoc.validate()
                     XCTAssert(plistDoc.rootElement()?.name == "plist")
                     let plist = try PropertyListSerialization.propertyList(from: plistDoc.xmlData, options: [], format: nil) as! [String: Any]
                     XCTAssert((plist["foo"] as? String) == d1["foo"] as? String)
                     XCTAssert((plist["baz"] as? String) == d1["baz"] as? String)
                 } catch {
-                    XCTFail("XMLDocument failes to read / validate contenets")
+                    XCTFail("Failed to read and parse XMLDocument")
                 }
             } else {
                 XCTFail("Write to file failed")


### PR DESCRIPTION
Calling XML validation results in hitting the Apple web servers
to load a DTD for plists http://www.apple.com/DTDs/PropertyList-1.0.dtd
to correctly validate the XML file.

Given that this test is not about whether it is possible to read
or write property lists, but they're just being used to validate
that they can read and write arrays from them, remove this part
of the test. The property list gets parsed from the subsequent
PropertyListSerialization call anyway, which will do the same error
checking as if the document is valid (but probably with a hard-coded
DTD instead of a network accessible one)

Issue: SR-2793