### PR TITLE
Fixes for Date Manipulations

### DIFF
--- a/Foundation/DateComponents.swift
+++ b/Foundation/DateComponents.swift
@@ -189,7 +189,7 @@ public struct DateComponents : ReferenceConvertible, Hashable, Equatable, _Mutab
     
     /// Set to true if these components represent a leap month.
     public var isLeapMonth: Bool? {
-        get { return _handle.map { $0.isLeapMonth } }
+        get { return _handle.map { $0.leapMonthSet ? $0.isLeapMonth : nil } }
         set {
             _applyMutation {
                 // Technically, the underlying class does not support setting isLeapMonth to nil, but it could - so we leave the API consistent.

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -461,7 +461,7 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         _convert(comps.weekday, type: "E", vector: &vector, compDesc: &compDesc)
         _convert(comps.weekdayOrdinal, type: "F", vector: &vector, compDesc: &compDesc)
         _convert(comps.month, type: "M", vector: &vector, compDesc: &compDesc)
-        _convert(comps.isLeapMonth, type: "L", vector: &vector, compDesc: &compDesc)
+        _convert(comps.isLeapMonth, type: "l", vector: &vector, compDesc: &compDesc)
         _convert(comps.day, type: "d", vector: &vector, compDesc: &compDesc)
         _convert(comps.hour, type: "H", vector: &vector, compDesc: &compDesc)
         _convert(comps.minute, type: "m", vector: &vector, compDesc: &compDesc)

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -579,7 +579,7 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     
     open func date(byAdding comps: DateComponents, to date: Date, options opts: Options = []) -> Date? {
         var (vector, compDesc) = _convert(comps)
-        var at: CFAbsoluteTime = 0.0
+        var at: CFAbsoluteTime = date.timeIntervalSinceReferenceDate
         
         let res: Bool = withUnsafeMutablePointer(to: &at) { t in
             return vector.withUnsafeMutableBufferPointer { (vectorBuffer: inout UnsafeMutableBufferPointer<Int32>) in

--- a/TestFoundation/TestNSCalendar.swift
+++ b/TestFoundation/TestNSCalendar.swift
@@ -92,7 +92,7 @@ class TestNSCalendar: XCTestCase {
     }
     
     func test_addingDates() {
-        let calendar = Calendar.current
+        let calendar = Calendar(identifier: .gregorian)
         let thisDay = calendar.date(from: DateComponents(year: 2016, month: 10, day: 4))!
         let diffComponents = DateComponents(day: 1)
         let dayAfter = calendar.date(byAdding: diffComponents, to: thisDay)

--- a/TestFoundation/TestNSCalendar.swift
+++ b/TestFoundation/TestNSCalendar.swift
@@ -93,14 +93,14 @@ class TestNSCalendar: XCTestCase {
     
     func test_addingDates() {
         let calendar = Calendar.current
-        let today = Date()
+        let thisDay = calendar.date(from: DateComponents(year: 2016, month: 10, day: 4))!
         let diffComponents = DateComponents(day: 1)
-        let tomorrow = calendar.date(byAdding: diffComponents, to: today)
+        let dayAfter = calendar.date(byAdding: diffComponents, to: thisDay)
         
-        let tomorrowComponents = calendar.dateComponents([.year, .month, .day], from: tomorrow!)
-        XCTAssertEqual(tomorrowComponents.year, 2016)
-        XCTAssertEqual(tomorrowComponents.month, 10)
-        XCTAssertEqual(tomorrowComponents.day, 5)
+        let dayAfterComponents = calendar.dateComponents([.year, .month, .day], from: dayAfter!)
+        XCTAssertEqual(dayAfterComponents.year, 2016)
+        XCTAssertEqual(dayAfterComponents.month, 10)
+        XCTAssertEqual(dayAfterComponents.day, 5)
     }
 }
 

--- a/TestFoundation/TestNSCalendar.swift
+++ b/TestFoundation/TestNSCalendar.swift
@@ -92,14 +92,15 @@ class TestNSCalendar: XCTestCase {
     }
     
     func test_addingDates() {
-        var calendar = Calendar.current
-        let today = calendar.current.date(from: DateComponents(year: 2016, month: 10, day: 4))
+        let calendar = Calendar.current
+        let today = Date()
         let diffComponents = DateComponents(day: 1)
         let tomorrow = calendar.date(byAdding: diffComponents, to: today)
         
-        XCTAssertEqual(tomorrow.year, 2016)
-        XCTAssertEqual(tomorrow.month, 10)
-        XCTAssertEqual(tomorrow.day, 5)
+        let tomorrowComponents = calendar.dateComponents([.year, .month, .day], from: tomorrow!)
+        XCTAssertEqual(tomorrowComponents.year, 2016)
+        XCTAssertEqual(tomorrowComponents.month, 10)
+        XCTAssertEqual(tomorrowComponents.day, 5)
     }
 }
 

--- a/TestFoundation/TestNSCalendar.swift
+++ b/TestFoundation/TestNSCalendar.swift
@@ -24,6 +24,7 @@ class TestNSCalendar: XCTestCase {
             ("test_gettingDatesOnHebrewCalendar", test_gettingDatesOnHebrewCalendar ),
             ("test_gettingDatesOnChineseCalendar", test_gettingDatesOnChineseCalendar),
             ("test_copy",test_copy),
+            ("test_addingDates", test_addingDates)
             // Disabled because this fails on linux https://bugs.swift.org/browse/SR-320
             // ("test_currentCalendarRRstability", test_currentCalendarRRstability),
         ]
@@ -88,6 +89,17 @@ class TestNSCalendar: XCTestCase {
         //verify firstWeekday and minimumDaysInFirstWeek of 'copy'. 
         XCTAssertEqual(copy.firstWeekday, 2)
         XCTAssertEqual(copy.minimumDaysInFirstWeek, 2)
+    }
+    
+    func test_addingDates() {
+        var calendar = Calendar.current
+        let today = calendar.current.date(from: DateComponents(year: 2016, month: 10, day: 4))
+        let diffComponents = DateComponents(day: 1)
+        let tomorrow = calendar.date(byAdding: diffComponents, to: today)
+        
+        XCTAssertEqual(tomorrow.year, 2016)
+        XCTAssertEqual(tomorrow.month, 10)
+        XCTAssertEqual(tomorrow.day, 5)
     }
 }
 


### PR DESCRIPTION
This PR has fixes for DateComponents and Calendar which were causing date manipulations to fail, resolving [SR-2846](https://bugs.swift.org/browse/SR-2846):
- DateComponents no longer returns isLeapMonth = false when isLeapMonth wasn't set (in situations where isLeapMonth is irrelevant, for example using DateComponents to add 1 day to another date).
- NSCalendar's `_convert()` is fixed for the character set for isLeapMonth to align with expected value from `UCalendarDateFields` ('l' instead of 'L').
- NSCalendar's `date(byAdding:to:options:)` is fixed to do math on the passed-in date, rather than the reference time 0.0.

A test for this is included.