### PR TITLE
Duplicate HTTP headers should be joined with a comma

### DIFF
--- a/Foundation/NSURLSession/HTTPMessage.swift
+++ b/Foundation/NSURLSession/HTTPMessage.swift
@@ -141,12 +141,17 @@ extension URLSessionTask {
 
 extension URLSessionTask._HTTPMessage {
     var headersAsDictionary: [String: String] {
-        var result: [String: String] = [:]
-        headers.forEach {
-            result[$0.name] = $0.value
-        }
-        return result
-    }
+		var result: [String: String] = [:]
+		headers.forEach {
+			if result[$0.name] == nil {
+				result[$0.name] = $0.value
+			}
+			else {
+				result[$0.name]! += (", " + $0.value)
+			}
+		}
+		return result
+	}
 }
 extension URLSessionTask._HTTPMessage {
     /// A single HTTP message header field


### PR DESCRIPTION
`headersAsDictionary` didn't support duplicate header fields; if there are multiple occurrences of one field, only one of them was returned.   However, [duplicate header fields are valid](http://stackoverflow.com/q/4371328/3476191), and are equivalent to one comma-separated field.
