### PR TITLE
Implemented setLocalizedDateFormatFromTemplate

### DIFF
--- a/Foundation/NSDateFormatter.swift
+++ b/Foundation/NSDateFormatter.swift
@@ -80,7 +80,9 @@ open class DateFormatter : Formatter {
     }
 
     open func setLocalizedDateFormatFromTemplate(_ dateFormatTemplate: String) {
-        NSUnimplemented()
+        if let format = DateFormatter.dateFormat(fromTemplate: dateFormatTemplate, options: 0, locale: .current) {
+            dateFormat = format
+        }
     }
 
     private func _reset() {

--- a/Foundation/NSDateFormatter.swift
+++ b/Foundation/NSDateFormatter.swift
@@ -80,7 +80,7 @@ open class DateFormatter : Formatter {
     }
 
     open func setLocalizedDateFormatFromTemplate(_ dateFormatTemplate: String) {
-        if let format = DateFormatter.dateFormat(fromTemplate: dateFormatTemplate, options: 0, locale: .current) {
+        if let format = DateFormatter.dateFormat(fromTemplate: dateFormatTemplate, options: 0, locale: locale) {
             dateFormat = format
         }
     }

--- a/TestFoundation/TestNSDateFormatter.swift
+++ b/TestFoundation/TestNSDateFormatter.swift
@@ -27,7 +27,8 @@ class TestNSDateFormatter: XCTestCase {
             ("test_dateStyleMedium",   test_dateStyleMedium),
             ("test_dateStyleLong",     test_dateStyleLong),
             ("test_dateStyleFull",     test_dateStyleFull),
-            ("test_customDateFormat", test_customDateFormat)
+            ("test_customDateFormat", test_customDateFormat),
+            ("test_setLocalizedDateFormatFromTemplate", test_setLocalizedDateFormatFromTemplate),
         ]
     }
     
@@ -277,5 +278,17 @@ class TestNSDateFormatter: XCTestCase {
         XCTAssertEqual(f.string(from: testDate), "11-03-2016")
         
     }
-    
+
+    func test_setLocalizedDateFormatFromTemplate() {
+        let locale = Locale(identifier: DEFAULT_LOCALE)
+        let template = "EEEE MMMM d y hhmmss a zzzz"
+
+        let f = DateFormatter()
+        f.locale = locale
+        f.setLocalizedDateFormatFromTemplate(template)
+
+        let dateFormat = DateFormatter.dateFormat(fromTemplate: template, options: 0, locale: locale)
+        XCTAssertEqual(f.dateFormat, dateFormat)
+    }
+
 }


### PR DESCRIPTION
I've implemented the missing method in DateFormatter.

I've only two questions:
1. I've called the relative class method using explicitly the `DateFormatter` class, it is better using the new `type(of:)`?
2. There are no tests for the class method `dateFormat(fromTemplate:opts:locale:)`to get inspiration any guidance on how to add for both the class and the instance method?
