### PR TITLE
Retain localeID when constructing a Calendar

### DIFF
--- a/CoreFoundation/Locale.subproj/CFCalendar.c
+++ b/CoreFoundation/Locale.subproj/CFCalendar.c
@@ -249,7 +249,7 @@ Boolean _CFCalendarInitWithIdentifier(CFCalendarRef calendar, CFStringRef identi
     
     calendar->_identifier = (CFStringRef)CFRetain(identifier);
     calendar->_locale = NULL;
-    calendar->_localeID = CFLocaleGetIdentifier(CFLocaleGetSystem());
+    calendar->_localeID = CFRetain(CFLocaleGetIdentifier(CFLocaleGetSystem()));
     calendar->_tz = CFTimeZoneCopyDefault();
     calendar->_cal = NULL;
     return true;
@@ -278,7 +278,7 @@ CFCalendarRef CFCalendarCreateWithIdentifier(CFAllocatorRef allocator, CFStringR
     }
     calendar->_identifier = (CFStringRef)CFRetain(identifier);
     calendar->_locale = NULL;
-    calendar->_localeID = CFLocaleGetIdentifier(CFLocaleGetSystem());
+    calendar->_localeID = CFRetain(CFLocaleGetIdentifier(CFLocaleGetSystem()));
     calendar->_tz = CFTimeZoneCopyDefault();
     calendar->_cal = NULL;
     return (CFCalendarRef)calendar;


### PR DESCRIPTION
The Calendar destructor releases stored values when the
Calendar is being deallocated, including releasing the localeID.

By default this is an empty string (kCFEmptyString) which results
in multiple Calendars causing a fault when it is over-released.
Ensure that instead the localeID is retained to balance the
release when it is cleaned up.

Issue: SR-2879