### PR TITLE
[SR-2503] Implement subtraction for CharacterSet

### DIFF
--- a/Foundation/CharacterSet.swift
+++ b/Foundation/CharacterSet.swift
@@ -434,29 +434,29 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
         return result
     }
     
-    /// Sets the value to the intersection of the `CharacterSet` with another `CharacterSet`.
+    /// Sets the value to an intersection of the `CharacterSet` with another `CharacterSet`.
     public mutating func formIntersection(_ other: CharacterSet) {
         _applyUnmanagedMutation {
             $0.formIntersection(with: other)
         }
     }
 
-    /// Returns the set of elements in the `CharacterSet` but not in another `CharacterSet`.
+    /// Returns a `CharacterSet` created by removing elements in `other` from `self`.
     public func subtracting(_ other: CharacterSet) -> CharacterSet {
         return intersection(other.inverted)
     }
 
-    /// Sets the value to the set of elements in the `CharacterSet` but not in another `CharacterSet`.
+    /// Sets the value to a `CharacterSet` created by removing elements in `other` from `self`.
     public mutating func subtract(_ other: CharacterSet) {
         self = subtracting(other)
     }
 
-    /// Returns the exclusive or of the `CharacterSet` with another `CharacterSet`.
+    /// Returns an exclusive or of the `CharacterSet` with another `CharacterSet`.
     public func symmetricDifference(_ other: CharacterSet) -> CharacterSet {
         return union(other).subtracting(intersection(other))
     }
     
-    /// Sets the value to the exclusive or of the `CharacterSet` with another `CharacterSet`.
+    /// Sets the value to an exclusive or of the `CharacterSet` with another `CharacterSet`.
     public mutating func formSymmetricDifference(_ other: CharacterSet) {
         self = symmetricDifference(other)
     }

--- a/Foundation/CharacterSet.swift
+++ b/Foundation/CharacterSet.swift
@@ -440,7 +440,17 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
             $0.formIntersection(with: other)
         }
     }
-    
+
+    /// Returns the set of elements in the `CharacterSet` but not in another `CharacterSet`.
+    public func subtracting(_ other: CharacterSet) -> CharacterSet {
+        return intersection(other.inverted)
+    }
+
+    /// Sets the value to the set of elements in the `CharacterSet` but not in another `CharacterSet`.
+    public mutating func subtract(_ other: CharacterSet) {
+        self = subtracting(other)
+    }
+
     /// Returns the exclusive or of the `CharacterSet` with another `CharacterSet`.
     public func symmetricDifference(_ other: CharacterSet) -> CharacterSet {
         return union(other).subtracting(intersection(other))

--- a/TestFoundation/TestNSCharacterSet.swift
+++ b/TestFoundation/TestNSCharacterSet.swift
@@ -36,7 +36,8 @@ class TestNSCharacterSet : XCTestCase {
             ("test_AnnexPlanes", test_AnnexPlanes),
             ("test_Planes", test_Planes),
             ("test_InlineBuffer", test_InlineBuffer),
-            ("test_SubtractAndFormSymmetricDifference", test_SubtractAndFormSymmetricDifference),
+            // Test must remain disabled until SR-2509 is resolved.
+            // ("test_SubtractAndFormSymmetricDifference", test_SubtractAndFormSymmetricDifference),
         ]
     }
     
@@ -247,6 +248,13 @@ class TestNSCharacterSet : XCTestCase {
         XCTAssertFalse(set1.contains("b"))
         set1.formSymmetricDifference(set2)
         XCTAssertTrue(set1.contains("b"))
+
+        let expected = set1
+        var set3 = CharacterSet()
+        set1.subtract(set3)
+        XCTAssertEqual(expected, set1)
+        set3.subtract(set1)
+        XCTAssertTrue(set3.isEmpty)
     }
 }
 

--- a/TestFoundation/TestNSCharacterSet.swift
+++ b/TestFoundation/TestNSCharacterSet.swift
@@ -36,6 +36,7 @@ class TestNSCharacterSet : XCTestCase {
             ("test_AnnexPlanes", test_AnnexPlanes),
             ("test_Planes", test_Planes),
             ("test_InlineBuffer", test_InlineBuffer),
+            ("test_SubtractAndFormSymmetricDifference", test_SubtractAndFormSymmetricDifference),
         ]
     }
     
@@ -237,6 +238,15 @@ class TestNSCharacterSet : XCTestCase {
     
     func test_InlineBuffer() {
         
+    }
+
+    func test_SubtractAndFormSymmetricDifference() {
+        var set1 = CharacterSet(charactersIn: "abc")
+        let set2 = CharacterSet(charactersIn: "b")
+        set1.subtract(set2)
+        XCTAssertFalse(set1.contains("b"))
+        set1.formSymmetricDifference(set2)
+        XCTAssertTrue(set1.contains("b"))
     }
 }
 

--- a/TestFoundation/TestNSCharacterSet.swift
+++ b/TestFoundation/TestNSCharacterSet.swift
@@ -36,8 +36,11 @@ class TestNSCharacterSet : XCTestCase {
             ("test_AnnexPlanes", test_AnnexPlanes),
             ("test_Planes", test_Planes),
             ("test_InlineBuffer", test_InlineBuffer),
-            // Test must remain disabled until SR-2509 is resolved.
-            // ("test_SubtractAndFormSymmetricDifference", test_SubtractAndFormSymmetricDifference),
+            // The following tests must remain disabled until SR-2509 is resolved.
+            // ("test_Subtracting", test_Subtracting),
+            // ("test_SubtractEmptySet", test_SubtractEmptySet),
+            // ("test_SubtractNonEmptySet", test_SubtractNonEmptySet),
+            // ("test_SymmetricDifference", test_SymmetricDifference),
         ]
     }
     
@@ -241,20 +244,31 @@ class TestNSCharacterSet : XCTestCase {
         
     }
 
-    func test_SubtractAndFormSymmetricDifference() {
-        var set1 = CharacterSet(charactersIn: "abc")
-        let set2 = CharacterSet(charactersIn: "b")
-        set1.subtract(set2)
-        XCTAssertFalse(set1.contains("b"))
-        set1.formSymmetricDifference(set2)
-        XCTAssertTrue(set1.contains("b"))
+    func test_Subtracting() {
+        let difference = CharacterSet(charactersIn: "abc").subtracting(CharacterSet(charactersIn: "b"))
+        let expected = CharacterSet(charactersIn: "ac")
+        XCTAssertEqual(expected, difference)
+    }
 
-        let expected = set1
-        var set3 = CharacterSet()
-        set1.subtract(set3)
-        XCTAssertEqual(expected, set1)
-        set3.subtract(set1)
-        XCTAssertTrue(set3.isEmpty)
+    func test_SubtractEmptySet() {
+        var mutableSet = CharacterSet(charactersIn: "abc")
+        let emptySet = CharacterSet()
+        mutableSet.subtract(emptySet)
+        let expected = CharacterSet(charactersIn: "abc")
+        XCTAssertEqual(expected, mutableSet)
+    }
+
+    func test_SubtractNonEmptySet() {
+        var mutableSet = CharacterSet()
+        let nonEmptySet = CharacterSet(charactersIn: "abc")
+        mutableSet.subtract(nonEmptySet)
+        XCTAssertTrue(mutableSet.isEmpty)
+    }
+
+    func test_SymmetricDifference() {
+        let symmetricDifference = CharacterSet(charactersIn: "ac").symmetricDifference(CharacterSet(charactersIn: "b"))
+        let expected = CharacterSet(charactersIn: "abc")
+        XCTAssertEqual(expected, symmetricDifference)
     }
 }
 


### PR DESCRIPTION
This is a PR that parallels apple/swift#5201.

Execution is interrupted when `CharacterSet.subtracting(_:)` is invoked. The underlying reason is that `subtracting(_:)` is a default implementation that calls `symmetricDifference(_:)`, but `CharacterSet.symmetricDifference(_:)` invokes `subtracting(_:)`. This PR implements `CharacterSet.subtracting(_:)` and `CharacterSet.subtract(_:)`.

A new test has been added for this code; however, as reported in [SR-2509](https://bugs.swift.org/browse/SR-2509), `CharacterSet.union(_:)` is not currently working in corelibs-foundation, so the test must be disabled in this repo until that entirely separate issue is resolved.

Resolves [SR-2503](https://bugs.swift.org/browse/SR-2503).
