### PR TITLE
Use #include over #import in C souce

### DIFF
--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -1308,7 +1308,7 @@ CF_EXPORT int32_t _CF_SOCK_STREAM() { return SOCK_STREAM; }
 #endif
 
 #if DEPLOYMENT_RUNTIME_SWIFT
-#import <fcntl.h>
+#include <fcntl.h>
 int _CFOpenFileWithMode(const char *path, int opts, mode_t mode) {
     return open(path, opts, mode);
 }

--- a/CoreFoundation/Collections.subproj/CFBasicHash.c
+++ b/CoreFoundation/Collections.subproj/CFBasicHash.c
@@ -13,13 +13,13 @@
 	Responsibility: Christopher Kane
 */
 
-#import "CFBasicHash.h"
-#import <CoreFoundation/CFRuntime.h>
-#import <CoreFoundation/CFSet.h>
-#import <math.h>
+#include "CFBasicHash.h"
+#include <CoreFoundation/CFRuntime.h>
+#include <CoreFoundation/CFSet.h>
+#include <math.h>
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED
 #if __HAS_DISPATCH__
-#import <dispatch/dispatch.h>
+#include <dispatch/dispatch.h>
 #endif
 #endif
 

--- a/CoreFoundation/Collections.subproj/CFData.c
+++ b/CoreFoundation/Collections.subproj/CFData.c
@@ -27,7 +27,7 @@
 #endif
 
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI
-#import <mach/mach.h>
+#include <mach/mach.h>
 CF_INLINE unsigned long __CFPageSize() { return vm_page_size; }
 #elif DEPLOYMENT_TARGET_WINDOWS
 CF_INLINE unsigned long __CFPageSize() {


### PR DESCRIPTION
This is because Clang's MSVC compatibility does not handle `#import` statements outside of of objc.

    #import of type library is an unsupported Microsoft feature

This is a follow up to a similar change in #663.