### PR TITLE
Suppress string interpolation warnings

### DIFF
--- a/Foundation/NSFileManager.swift
+++ b/Foundation/NSFileManager.swift
@@ -125,7 +125,7 @@ open class FileManager : NSObject {
         for attribute in attributes.keys {
             if attribute == .posixPermissions {
                 guard let number = attributes[attribute] as? NSNumber else {
-                    fatalError("Can't set file permissions to \(attributes[attribute])")
+                    fatalError("Can't set file permissions to \(attributes[attribute] as Any?)")
                 }
                 #if os(OSX) || os(iOS)
                     let modeT = number.uint16Value

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -241,8 +241,7 @@ open class NSKeyedArchiver : NSCoder {
     }
     
     private func _validateObjectSupportsSecureCoding(_ objv : Any?) {
-        if objv != nil &&
-            self.requiresSecureCoding &&
+        if let objv = objv, self.requiresSecureCoding &&
             !NSKeyedArchiver._supportsSecureCoding(objv) {
             fatalError("Secure coding required when encoding \(objv)")
         }

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -418,7 +418,7 @@ open class NSKeyedUnarchiver : NSCoder {
         
         if self.requiresSecureCoding && !supportsSecureCoding {
             // FIXME should this be a fatal error?
-            fatalError("Archiver \(self) requires secure coding but class \(classToConstruct) does not support it")
+            fatalError("Archiver \(self) requires secure coding but class \(classToConstruct as Optional) does not support it")
         }
         
         return supportsSecureCoding
@@ -505,8 +505,7 @@ open class NSKeyedUnarchiver : NSCoder {
      */
     private func _decodeObject(forKey key: String?) throws -> Any? {
         guard let objectRef : Any? = _objectInCurrentDecodingContext(forKey: key) else {
-            throw _decodingError(CocoaError.coderValueNotFound,
-                                 withDescription: "No value found for key \(key). The data may be corrupt.")
+            throw _decodingError(CocoaError.coderValueNotFound, withDescription: "No value found for key \(key as Optional). The data may be corrupt.")
         }
         
         return try _decodeObject(objectRef!)

--- a/Foundation/Notification.swift
+++ b/Foundation/Notification.swift
@@ -40,9 +40,12 @@ public struct Notification : ReferenceConvertible, Equatable, Hashable {
     public var hashValue: Int {
         return name.rawValue.hash
     }
-    
+
     public var description: String {
-        return "name = \(name.rawValue),  object = \(object), userInfo = \(userInfo)"
+        var description = "name = \(name.rawValue)"
+        if let obj = object { description += ", object = \(obj)" }
+        if let info = userInfo { description += ", userInfo = \(info)" }
+        return description
     }
     
     public var debugDescription: String {

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -872,7 +872,7 @@ class TestNSString : XCTestCase {
     }
     
     func test_stringByAppendingPathExtension() {
-        let values : Dictionary = [
+        let values = [
             NSString(string: "/tmp/scratch.old") : "/tmp/scratch.old.tiff",
             NSString(string: "/tmp/scratch.") : "/tmp/scratch..tiff",
             NSString(string: "/tmp/") : "/tmp.tiff",
@@ -882,7 +882,7 @@ class TestNSString : XCTestCase {
         ]
         for (fileName, expectedResult) in values {
             let result = fileName.appendingPathExtension("tiff")
-            XCTAssertEqual(result, expectedResult, "expected \(expectedResult) for \(fileName) but got \(result)")
+            XCTAssertEqual(result, expectedResult, "expected \(expectedResult) for \(fileName) but got \(result as Optional)")
         }
     }
     

--- a/TestFoundation/TestNSTimeZone.swift
+++ b/TestFoundation/TestNSTimeZone.swift
@@ -47,7 +47,7 @@ class TestNSTimeZone: XCTestCase {
         let tz = NSTimeZone.system
         let abbreviation1 = tz.abbreviation()
         let abbreviation2 = tz.abbreviation(for: Date())
-        XCTAssertEqual(abbreviation1, abbreviation2, "\(abbreviation1) should be equal to \(abbreviation2)")
+        XCTAssertEqual(abbreviation1, abbreviation2, "\(abbreviation1 as Optional) should be equal to \(abbreviation2 as Optional)")
     }
 
     func test_abbreviationDictionary() {
@@ -98,7 +98,7 @@ class TestNSTimeZone: XCTestCase {
 
         let abbreviation1 = tz.abbreviation()
         let abbreviation2 = obj.abbreviation
-        XCTAssertEqual(abbreviation1, abbreviation2, "\(abbreviation1) should be equal to \(abbreviation2)")
+        XCTAssertEqual(abbreviation1, abbreviation2, "\(abbreviation1 as Optional) should be equal to \(abbreviation2 as Optional)")
 
         let isDaylightSavingTime1 = tz.isDaylightSavingTime()
         let isDaylightSavingTime2 = obj.isDaylightSavingTime
@@ -112,7 +112,7 @@ class TestNSTimeZone: XCTestCase {
         let nextDaylightSavingTimeTransition1 = tz.nextDaylightSavingTimeTransition
         let nextDaylightSavingTimeTransition2 = obj.nextDaylightSavingTimeTransition
         let nextDaylightSavingTimeTransition3 = tz.nextDaylightSavingTimeTransition(after: Date())
-        XCTAssert(nextDaylightSavingTimeTransition1 == nextDaylightSavingTimeTransition2 || nextDaylightSavingTimeTransition2 == nextDaylightSavingTimeTransition3, "\(nextDaylightSavingTimeTransition1) should be equal to \(nextDaylightSavingTimeTransition2), or in the rare circumstance where a daylight saving time transition has just occurred, \(nextDaylightSavingTimeTransition2) should be equal to \(nextDaylightSavingTimeTransition3)")
+        XCTAssert(nextDaylightSavingTimeTransition1 == nextDaylightSavingTimeTransition2 || nextDaylightSavingTimeTransition2 == nextDaylightSavingTimeTransition3, "\(nextDaylightSavingTimeTransition1 as Optional) should be equal to \(nextDaylightSavingTimeTransition2 as Optional), or in the rare circumstance where a daylight saving time transition has just occurred, \(nextDaylightSavingTimeTransition2 as Optional) should be equal to \(nextDaylightSavingTimeTransition3 as Optional)")
     }
 
     func test_knownTimeZoneNames() {
@@ -137,18 +137,18 @@ class TestNSTimeZone: XCTestCase {
     func test_initializingTimeZoneWithOffset() {
         let tz = TimeZone(identifier: "GMT-0400")
         XCTAssertNotNil(tz)
-        let seconds = tz?.secondsFromGMT(for: Date())
+        let seconds = tz?.secondsFromGMT(for: Date()) ?? 0
         XCTAssertEqual(seconds, -14400, "GMT-0400 should be -14400 seconds but got \(seconds) instead")
 
         let tz2 = TimeZone(secondsFromGMT: -14400)
         XCTAssertNotNil(tz2)
         let expectedName = "GMT-0400"
         let actualName = tz2?.identifier
-        XCTAssertEqual(actualName, expectedName, "expected name \"\(expectedName)\" is not equal to \"\(actualName)\"")
+        XCTAssertEqual(actualName, expectedName, "expected name \"\(expectedName)\" is not equal to \"\(actualName as Optional)\"")
         let expectedLocalizedName = "GMT-04:00"
         let actualLocalizedName = tz2?.localizedName(for: .generic, locale: Locale(identifier: "en_US"))
-        XCTAssertEqual(actualLocalizedName, expectedLocalizedName, "expected name \"\(expectedLocalizedName)\" is not equal to \"\(actualLocalizedName)\"")
-        let seconds2 = tz2?.secondsFromGMT()
+        XCTAssertEqual(actualLocalizedName, expectedLocalizedName, "expected name \"\(expectedLocalizedName)\" is not equal to \"\(actualLocalizedName as Optional)\"")
+        let seconds2 = tz2?.secondsFromGMT() ?? 0
         XCTAssertEqual(seconds2, -14400, "GMT-0400 should be -14400 seconds but got \(seconds2) instead")
 
         let tz3 = TimeZone(identifier: "GMT-9999")
@@ -161,8 +161,9 @@ class TestNSTimeZone: XCTestCase {
         XCTAssertNil(tz)
         // Test valid timezone abbreviation of "AST" for "America/Halifax"
         tz = TimeZone(abbreviation: "AST")
-        let expectedName = "America/Halifax"
-        XCTAssertEqual(tz?.identifier, expectedName, "expected name \"\(expectedName)\" is not equal to \"\(tz?.identifier)\"")
+        let expectedIdentifier = "America/Halifax"
+        let actualIdentifier = tz?.identifier
+        XCTAssertEqual(actualIdentifier, expectedIdentifier, "expected identifier \"\(expectedIdentifier)\" is not equal to \"\(actualIdentifier as Optional)\"")
     }
 
     func test_systemTimeZoneUsesSystemTime() {

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -153,7 +153,7 @@ class TestNSURL : XCTestCase {
             }
             if let stringObj = obj as? String {
                 if stringObj != got[key] {
-                    differences.append(" \(key)  Expected = '\(stringObj)',  Got = '\(got[key])'")
+                    differences.append(" \(key)  Expected = '\(stringObj)',  Got = '\(got[key] as Optional)'")
                 }
             }
         }
@@ -442,7 +442,7 @@ class TestNSURLComponents : XCTestCase {
         var url = URLComponents(string: urlString)
         url!.port = port
         let receivedString = url!.string
-        XCTAssertEqual(receivedString, expectedString, "expected \(expectedString) but received \(receivedString)")
+        XCTAssertEqual(receivedString, expectedString, "expected \(expectedString) but received \(receivedString as Optional)")
     }
 
     func test_url() {
@@ -454,7 +454,7 @@ class TestNSURLComponents : XCTestCase {
         compWithAuthority!.path = "/path/to/file with space.html"
         compWithAuthority!.query = "id=23&search=Foo Bar"
         var expectedString = "https://www.swift.org/path/to/file%20with%20space.html?id=23&search=Foo%20Bar"
-        XCTAssertEqual(compWithAuthority!.string, expectedString, "expected \(expectedString) but received \(compWithAuthority!.string)")
+        XCTAssertEqual(compWithAuthority!.string, expectedString, "expected \(expectedString) but received \(compWithAuthority!.string as Optional)")
 
         var aURL = compWithAuthority!.url(relativeTo: baseURL)
         XCTAssertNotNil(aURL)
@@ -474,7 +474,7 @@ class TestNSURLComponents : XCTestCase {
         compWithoutAuthority.path = "path/to/file with space.html"
         compWithoutAuthority.query = "id=23&search=Foo Bar"
         expectedString = "path/to/file%20with%20space.html?id=23&search=Foo%20Bar"
-        XCTAssertEqual(compWithoutAuthority.string, expectedString, "expected \(expectedString) but received \(compWithoutAuthority.string)")
+        XCTAssertEqual(compWithoutAuthority.string, expectedString, "expected \(expectedString) but received \(compWithoutAuthority.string as Optional)")
 
         aURL = compWithoutAuthority.url(relativeTo: baseURL)
         XCTAssertNotNil(aURL)

--- a/TestFoundation/TestNSXMLDocument.swift
+++ b/TestFoundation/TestNSXMLDocument.swift
@@ -161,7 +161,7 @@ class TestNSXMLDocument : XCTestCase {
         element.insertChildren([foo, bar], at: 1)
         XCTAssertEqual(element.children?[1], foo)
         XCTAssertEqual(element.children?[2], bar)
-        XCTAssertEqual(element.children?[0], baz, "\(element.children?[0])")
+        XCTAssertEqual(element.children?[0], baz)
 
         let faz = XMLElement(name: "faz")
         element.replaceChild(at: 2, with: faz)
@@ -239,7 +239,7 @@ class TestNSXMLDocument : XCTestCase {
         XCTAssertEqual(element.attributes?.last, bazAttribute)
 
         element.setAttributesWith(["hello": "world", "foobar": "buzbaz"])
-        XCTAssertEqual(element.attribute(forName:"hello")?.stringValue, "world", "\(element.attribute(forName:"hello")?.stringValue)")
+        XCTAssertEqual(element.attribute(forName:"hello")?.stringValue, "world", "\(element.attribute(forName:"hello")?.stringValue as Optional)")
         XCTAssertEqual(element.attribute(forName:"foobar")?.stringValue, "buzbaz", "\(element.attributes ?? [])")
     }
 


### PR DESCRIPTION
Suppresses new warnings from https://github.com/apple/swift/pull/5195

- Avoid optional where no impact w/IUO
- Mostly cast to Optional
- Change in Notification description() to avoid issue