### PR TITLE
Add more NSRange tests

### DIFF
--- a/TestFoundation/TestNSRange.swift
+++ b/TestFoundation/TestNSRange.swift
@@ -23,7 +23,13 @@ class TestNSRange : XCTestCase {
         return [
             // currently disabled due to pending requirements for NSString
             // ("test_NSRangeFromString", test_NSRangeFromString ),
-            ("test_NSRangeBridging", test_NSRangeBridging)
+            ("test_NSRangeBridging", test_NSRangeBridging),
+            ("test_NSMaxRange", test_NSMaxRange),
+            ("test_NSLocationInRange", test_NSLocationInRange),
+            ("test_NSEqualRanges", test_NSEqualRanges),
+            ("test_NSUnionRange", test_NSUnionRange),
+            ("test_NSIntersectionRange", test_NSIntersectionRange),
+            ("test_NSStringFromRange", test_NSStringFromRange),
         ]
     }
     
@@ -65,5 +71,70 @@ class TestNSRange : XCTestCase {
         let range = NSRange(swiftRange)
         let swiftRange2 = range.toRange()
         XCTAssertEqual(swiftRange, swiftRange2)
+    }
+
+    func test_NSMaxRange() {
+        let ranges = [(NSMakeRange(0, 3), 3),
+                      (NSMakeRange(7, 8), 15),
+                      (NSMakeRange(56, 1), 57)]
+        for (range, result) in ranges {
+            XCTAssertEqual(NSMaxRange(range), result)
+        }
+    }
+
+    func test_NSLocationInRange() {
+        let ranges = [(3, NSMakeRange(0, 5), true),
+                      (10, NSMakeRange(2, 9), true),
+                      (7, NSMakeRange(2, 5), false),
+                      (5, NSMakeRange(5, 1), true)];
+        for (location, range, result) in ranges {
+            XCTAssertEqual(NSLocationInRange(location, range), result);
+        }
+    }
+
+    func test_NSEqualRanges() {
+        let ranges = [(NSMakeRange(0, 3), NSMakeRange(0, 3), true),
+                      (NSMakeRange(0, 4), NSMakeRange(0, 8), false),
+                      (NSMakeRange(3, 6), NSMakeRange(3, 10), false),
+                      (NSMakeRange(0, 5), NSMakeRange(7, 8), false)]
+        for (first, second, result) in ranges {
+            XCTAssertEqual(NSEqualRanges(first, second), result)
+        }
+    }
+
+    
+    func test_NSUnionRange() {
+        let ranges = [(NSMakeRange(0, 5), NSMakeRange(3, 8), NSMakeRange(0, 11)),
+                      (NSMakeRange(6, 10), NSMakeRange(3, 8), NSMakeRange(3, 13)),
+                      (NSMakeRange(3, 8), NSMakeRange(6, 10), NSMakeRange(3, 13)),
+                      (NSMakeRange(0, 5), NSMakeRange(7, 8), NSMakeRange(0, 15)),
+                      (NSMakeRange(0, 3), NSMakeRange(1, 2), NSMakeRange(0, 3))]
+        for (first, second, result) in ranges {
+            XCTAssert(NSEqualRanges(NSUnionRange(first, second), result))
+        }
+    }
+
+    func test_NSIntersectionRange() {
+        let ranges = [(NSMakeRange(0, 5), NSMakeRange(3, 8), NSMakeRange(3, 2)),
+                      (NSMakeRange(6, 10), NSMakeRange(3, 8), NSMakeRange(6, 5)),
+                      (NSMakeRange(3, 8), NSMakeRange(6, 10), NSMakeRange(6, 5)),
+                      (NSMakeRange(0, 5), NSMakeRange(7, 8), NSMakeRange(0, 0)),
+                      (NSMakeRange(0, 3), NSMakeRange(1, 2), NSMakeRange(1, 2))]
+        for (first, second, result) in ranges {
+            XCTAssert(NSEqualRanges(NSIntersectionRange(first, second), result))
+        }
+    }
+
+    func test_NSStringFromRange() {
+        let ranges = ["{0, 0}": NSMakeRange(0, 0),
+                      "{6, 4}": NSMakeRange(6, 4),
+                      "{0, 10}": NSMakeRange(0, 10),
+                      "{10, 200}": NSMakeRange(10, 200),
+                      "{100, 10}": NSMakeRange(100, 10),
+                      "{1000, 100000}": NSMakeRange(1000, 100_000)];
+
+        for (string, range) in ranges {
+            XCTAssertEqual(NSStringFromRange(range), string)
+        }
     }
 }


### PR DESCRIPTION
I've add more tests to cover NSRange implementation. They are pretty straight forward, but anyone can remember because the one for NSRangeFromString is commented out? On macOS it pass just fine, there is some issues on Ubuntu?