### PR TITLE
Enable NSRangeFromString test

### DIFF
--- a/TestFoundation/TestNSRange.swift
+++ b/TestFoundation/TestNSRange.swift
@@ -21,8 +21,7 @@ class TestNSRange : XCTestCase {
     
     static var allTests: [(String, (TestNSRange) -> () throws -> Void)] {
         return [
-            // currently disabled due to pending requirements for NSString
-            // ("test_NSRangeFromString", test_NSRangeFromString ),
+            ("test_NSRangeFromString", test_NSRangeFromString ),
             ("test_NSRangeBridging", test_NSRangeBridging),
             ("test_NSMaxRange", test_NSMaxRange),
             ("test_NSLocationInRange", test_NSLocationInRange),


### PR DESCRIPTION
Uncommented the NSRangeFromString test, on macOS it works fine, on Linux it has to be seen if there will be issues.
