### PR TITLE
[URLSession] Data, response not returned when headers are set [SR-2983]

### DIFF
--- a/Foundation/NSURLSession/HTTPMessage.swift
+++ b/Foundation/NSURLSession/HTTPMessage.swift
@@ -287,8 +287,13 @@ private extension URLSessionTask._HTTPMessage._Header {
         var value: String?
         let line = headView[headView.index(after: nameRange.upperBound)..<headView.endIndex]
         if !line.isEmpty {
-            guard let v = line.trimSPHTPrefix else { return nil }
-            value = String(v)
+            if line.hasSPHTPrefix && line.count == 1 {
+                // to handle empty headers i.e header without value
+                value = String("")
+            } else {
+                guard let v = line.trimSPHTPrefix else { return nil }
+                value = String(v)
+            }
         }
         do {
             var t = tail


### PR DESCRIPTION
In case of Darwin,  response headers with empty value are not ignored .So  through this PR we are handling the headers with empty value  and writing them with to the response header with empty value to match Darwin behavior
