### PR TITLE
Fix a build warning in NSDecimal

### DIFF
--- a/Foundation/NSDecimal.swift
+++ b/Foundation/NSDecimal.swift
@@ -1386,7 +1386,7 @@ public func NSDecimalMultiplyByPowerOf10(_ result: UnsafeMutablePointer<Decimal>
 
 public func NSDecimalString(_ dcm: UnsafePointer<Decimal>, _ locale: AnyObject?) -> String {
     guard locale == nil else {
-        fatalError("Locale not supported: \(locale)")
+        fatalError("Locale not supported: \(locale!)")
     }
     return dcm.pointee.description
 }


### PR DESCRIPTION
This warning has been showing up for a while now:

```
Foundation/NSDecimal.swift:1389:44: warning: string interpolation produces a debug description for an optional value; did you mean to make this explicit?
        fatalError("Locale not supported: \(locale)")
```