### PR TITLE
[NSJSONSerialization] SR-3013 Fix incorrect boolean coercion and enhance NSNumber encoding

### DIFF
--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -333,10 +333,12 @@ private struct JSONWriter {
             throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.propertyListReadCorrupt.rawValue, userInfo: ["NSDebugDescription" : "Number cannot be infinity or NaN"])
         }
         
-        // Cannot detect type information (e.g. bool) as there is no objCType property on NSNumber in Swift
-        // So, just print the number
-
-        writer(_serializationString(for: num))
+        switch num._objCType {
+        case .Bool:
+            serializeBool(num.boolValue)
+        default:
+            writer(_serializationString(for: num))
+        }
     }
 
     mutating func serializeArray(_ array: [Any]) throws {

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -270,21 +270,21 @@ private struct JSONWriter {
     }
     
     mutating func serializeJSON(_ obj: Any) throws {
-        
-        if let str = obj as? String {
+
+        switch (obj) {
+        case let str as String:
             try serializeString(str)
-        } else if let num = _SwiftValue.store(obj) as? NSNumber {
-            try serializeNumber(num)
-        } else if let array = obj as? Array<Any> {
+        case _ where _SwiftValue.store(obj) is NSNumber:
+            try serializeNumber(_SwiftValue.store(obj) as! NSNumber)
+        case let array as Array<Any>:
             try serializeArray(array)
-        } else if let dict = obj as? Dictionary<AnyHashable, Any> {
+        case let dict as Dictionary<AnyHashable, Any>:
             try serializeDictionary(dict)
-        } else if let null = obj as? NSNull {
+        case let null as NSNull:
             try serializeNull(null)
-        } else if let boolVal = obj as? Bool {
-            try serializeNumber(NSNumber(value: boolVal))
-        }
-        else {
+        case let bool as Bool:
+            try serializeNumber(NSNumber(value: bool))
+        default:
             throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.propertyListReadCorrupt.rawValue, userInfo: ["NSDebugDescription" : "Invalid object cannot be serialized"])
         }
     }

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -274,6 +274,8 @@ private struct JSONWriter {
         switch (obj) {
         case let str as String:
             try serializeString(str)
+        case let boolValue as Bool:
+            serializeBool(boolValue)
         case _ where _SwiftValue.store(obj) is NSNumber:
             try serializeNumber(_SwiftValue.store(obj) as! NSNumber)
         case let array as Array<Any>:
@@ -282,8 +284,6 @@ private struct JSONWriter {
             try serializeDictionary(dict)
         case let null as NSNull:
             try serializeNull(null)
-        case let bool as Bool:
-            try serializeNumber(NSNumber(value: bool))
         default:
             throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.propertyListReadCorrupt.rawValue, userInfo: ["NSDebugDescription" : "Invalid object cannot be serialized"])
         }
@@ -317,6 +317,15 @@ private struct JSONWriter {
             }
         }
         writer("\"")
+    }
+
+    func serializeBool(_ bool: Bool) {
+        switch bool {
+        case true:
+            writer("true")
+        case false:
+            writer("false")
+        }
     }
 
     mutating func serializeNumber(_ num: NSNumber) throws {

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -200,7 +200,9 @@ open class NSNumber : NSValue {
     // This layout MUST be the same as CFNumber so that they are bridgeable
     private var _base = _CFInfo(typeID: CFNumberGetTypeID())
     private var _pad: UInt64 = 0
-    
+
+    internal let _objCType: _NSSimpleObjCType
+
     internal var _cfObject: CFType {
         return unsafeBitCast(self, to: CFType.self)
     }
@@ -221,77 +223,95 @@ open class NSNumber : NSValue {
         }
         return false
     }
+
+    open override var objCType: UnsafePointer<Int8> {
+        return UnsafePointer<Int8>(bitPattern: UInt(_objCType.rawValue.value))!
+    }
     
     deinit {
         _CFDeinit(self)
     }
     
     public init(value: Int8) {
+        _objCType = .Int
         super.init()
         _CFNumberInitInt8(_cfObject, value)
     }
     
     public init(value: UInt8) {
+        _objCType = .UInt
         super.init()
         _CFNumberInitUInt8(_cfObject, value)
     }
     
     public init(value: Int16) {
+        _objCType = .Int
         super.init()
         _CFNumberInitInt16(_cfObject, value)
     }
     
     public init(value: UInt16) {
+        _objCType = .UInt
         super.init()
         _CFNumberInitUInt16(_cfObject, value)
     }
     
     public init(value: Int32) {
+        _objCType = .Int
         super.init()
         _CFNumberInitInt32(_cfObject, value)
     }
     
     public init(value: UInt32) {
+        _objCType = .UInt
         super.init()
         _CFNumberInitUInt32(_cfObject, value)
     }
     
     public init(value: Int) {
+        _objCType = .Int
         super.init()
         _CFNumberInitInt(_cfObject, value)
     }
     
     public init(value: UInt) {
+        _objCType = .UInt
         super.init()
         _CFNumberInitUInt(_cfObject, value)
     }
     
     public init(value: Int64) {
+        _objCType = .Int
         super.init()
         _CFNumberInitInt64(_cfObject, value)
     }
     
     public init(value: UInt64) {
+        _objCType = .UInt
         super.init()
         _CFNumberInitUInt64(_cfObject, value)
     }
     
     public init(value: Float) {
+        _objCType = .Float
         super.init()
         _CFNumberInitFloat(_cfObject, value)
     }
     
     public init(value: Double) {
+        _objCType = .Double
         super.init()
         _CFNumberInitDouble(_cfObject, value)
     }
     
     public init(value: Bool) {
+        _objCType = .Bool
         super.init()
         _CFNumberInitBool(_cfObject, value)
     }
 
     override internal init() {
+        _objCType = .Undef
         super.init()
     }
 

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -233,37 +233,37 @@ open class NSNumber : NSValue {
     }
     
     public init(value: Int8) {
-        _objCType = .Int
+        _objCType = .Char
         super.init()
         _CFNumberInitInt8(_cfObject, value)
     }
     
     public init(value: UInt8) {
-        _objCType = .UInt
+        _objCType = .UChar
         super.init()
         _CFNumberInitUInt8(_cfObject, value)
     }
     
     public init(value: Int16) {
-        _objCType = .Int
+        _objCType = .Short
         super.init()
         _CFNumberInitInt16(_cfObject, value)
     }
     
     public init(value: UInt16) {
-        _objCType = .UInt
+        _objCType = .UShort
         super.init()
         _CFNumberInitUInt16(_cfObject, value)
     }
     
     public init(value: Int32) {
-        _objCType = .Int
+        _objCType = .Long
         super.init()
         _CFNumberInitInt32(_cfObject, value)
     }
     
     public init(value: UInt32) {
-        _objCType = .UInt
+        _objCType = .ULong
         super.init()
         _CFNumberInitUInt32(_cfObject, value)
     }
@@ -281,13 +281,13 @@ open class NSNumber : NSValue {
     }
     
     public init(value: Int64) {
-        _objCType = .Int
+        _objCType = .LongLong
         super.init()
         _CFNumberInitInt64(_cfObject, value)
     }
     
     public init(value: UInt64) {
-        _objCType = .UInt
+        _objCType = .ULongLong
         super.init()
         _CFNumberInitUInt64(_cfObject, value)
     }

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -931,8 +931,10 @@ extension TestNSJSONSerialization {
     
     func test_booleanJSONObject() {
         do {
-            let mydata = try JSONSerialization.data(withJSONObject: [true])
-            XCTAssertEqual(String(data: mydata, encoding: String.Encoding.utf8), "[true]")
+            let objectLikeBoolArray = try JSONSerialization.data(withJSONObject: [true, NSNumber(value: false), NSNumber(value: true)] as Array<Any>)
+            XCTAssertEqual(String(data: objectLikeBoolArray, encoding: .utf8), "[true,false,true]")
+            let valueLikeBoolArray = try JSONSerialization.data(withJSONObject: [false, true, false])
+            XCTAssertEqual(String(data: valueLikeBoolArray, encoding: .utf8), "[false,true,false]")
         } catch {
             XCTFail("Failed during serialization")
         }

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -777,7 +777,7 @@ extension TestNSJSONSerialization {
         
         // Cannot generate "true"/"false" currently
         json = [NSNumber(value:false),NSNumber(value:true)]
-        XCTAssertEqual(try trySerialize(json), "[0,1]")
+        XCTAssertEqual(try trySerialize(json), "[false,true]")
     }
     
     func test_serialize_stringEscaping() {

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -932,11 +932,11 @@ extension TestNSJSONSerialization {
     func test_booleanJSONObject() {
         do {
             let mydata = try JSONSerialization.data(withJSONObject: [true])
-            XCTAssertEqual(String(data: mydata, encoding: String.Encoding.utf8), "[1]")
+            XCTAssertEqual(String(data: mydata, encoding: String.Encoding.utf8), "[true]")
         } catch {
             XCTFail("Failed during serialization")
         }
-        XCTAssertTrue(JSONSerialization.isValidJSONObject([1]))
+        XCTAssertTrue(JSONSerialization.isValidJSONObject([true]))
     }
 
     private func createTestFile(_ path: String,_contents: Data) -> String? {


### PR DESCRIPTION
Please review!

This pull request resolves [SR-3013, "JSONSerialization coerces booleans to numbers on Linux"](https://bugs.swift.org/browse/SR-3013)., relates to [SR-72](https://bugs.swift.org/browse/SR-72)

The prevailing bug was due to a prior kludge: if the value could be coerced into an NSNumber, coerce to an NSNumber and encode. NSNumbers were (before this PR) type-opaque, so an `NSNumber(value: true)` -> `"1"`.

I resolved this by first rewriting the type checking code to use a pattern match so the intention was clearer, then added a special case for the primitive bool case. The switch statement should be a clear set of entry points for future maintainers, following the JSON spec.

Next, I implemented objCType for NSNumber. This allows us to correctly discover when an NSNumber is in use boxing a boolean and encode it properly.

As I write this, I realise that we need to:
- [x] tighten up the _NSObjCType assignments in the NSNumber initialiser to correctly reflect `Long` etc.

Future work, which could be included in this PR as it is relatively trivial but definitely out of scope of the bug is to:
1. Differentiate between Integers and Numbers as per the JSON spec (yes, they're different!) by inspecting NSNumber
2. Rewrite the pattern match code to stop using `_SwiftValue.store` and use something less obtuse e.g. type checking.

Longer term I think this code could do with some protocol oriented restructuring, which I would like to discuss with the code owner, whoever they are!
