### PR TITLE
[Notification] Implement CustomReflectable for Notifications

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -308,6 +308,7 @@
 		7900433B1CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790043391CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift */; };
 		7900433C1CACD33E00ECCBF1 /* TestNSPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900433A1CACD33E00ECCBF1 /* TestNSPredicate.swift */; };
 		AE35A1861CBAC85E0042DB84 /* SwiftFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = AE35A1851CBAC85E0042DB84 /* SwiftFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF8E65311DC3B3CB005AB5C3 /* TestNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8E65301DC3B3CB005AB5C3 /* TestNotification.swift */; };
 		CC5249C01D341D23007CB54D /* TestUnitConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5249BF1D341D23007CB54D /* TestUnitConverter.swift */; };
 		CE19A88C1C23AA2300B4CB6A /* NSStringTestData.txt in Resources */ = {isa = PBXBuildFile; fileRef = CE19A88B1C23AA2300B4CB6A /* NSStringTestData.txt */; };
 		D31302011C30CEA900295652 /* NSConcreteValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31302001C30CEA900295652 /* NSConcreteValue.swift */; };
@@ -744,6 +745,7 @@
 		88D28DE61C13AE9000494606 /* TestNSGeometry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSGeometry.swift; sourceTree = "<group>"; };
 		A5A34B551C18C85D00FD972B /* TestNSByteCountFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSByteCountFormatter.swift; sourceTree = "<group>"; };
 		AE35A1851CBAC85E0042DB84 /* SwiftFoundation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwiftFoundation.h; sourceTree = "<group>"; };
+		BF8E65301DC3B3CB005AB5C3 /* TestNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNotification.swift; sourceTree = "<group>"; };
 		C2A9D75B1C15C08B00993803 /* TestNSUUID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSUUID.swift; sourceTree = "<group>"; };
 		C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSAffineTransform.swift; sourceTree = "<group>"; };
 		CC5249BF1D341D23007CB54D /* TestUnitConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUnitConverter.swift; sourceTree = "<group>"; };
@@ -1378,6 +1380,7 @@
 				0383A1741D2E558A0052E5D1 /* TestNSStream.swift */,
 				5B1FD9E21D6D17B80080E83C /* TestNSURLSession.swift */,
 				EA54A6FA1DB16D53009E0809 /* TestObjCRuntime.swift */,
+				BF8E65301DC3B3CB005AB5C3 /* TestNotification.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -2215,6 +2218,7 @@
 				5B13B34D1C582D4C00651CE2 /* TestNSUUID.swift in Sources */,
 				5B13B3281C582D4C00651CE2 /* TestNSBundle.swift in Sources */,
 				5B13B32A1C582D4C00651CE2 /* TestNSCharacterSet.swift in Sources */,
+				BF8E65311DC3B3CB005AB5C3 /* TestNotification.swift in Sources */,
 				EA01AAEC1DA839C4008F4E07 /* TestProgress.swift in Sources */,
 				5B13B3411C582D4C00651CE2 /* TestNSRegularExpression.swift in Sources */,
 				5B13B3491C582D4C00651CE2 /* TestNSTimeZone.swift in Sources */,

--- a/Foundation/Notification.swift
+++ b/Foundation/Notification.swift
@@ -76,7 +76,17 @@ public struct Notification : ReferenceConvertible, Equatable, Hashable {
 
 extension Notification : CustomReflectable {
     public var customMirror: Mirror {
-        NSUnimplemented()
+        var children: [(label: String?, value: Any)] = [(label: "name", self.name.rawValue)]
+
+        if let object = self.object {
+            children.append((label: "object", object))
+        }
+
+        if let info = self.userInfo {
+            children.append((label: "userInfo", info))
+        }
+
+        return Mirror(self, children: children, displayStyle: .class)
     }
 }
 

--- a/TestFoundation/TestNotification.swift
+++ b/TestFoundation/TestNotification.swift
@@ -1,0 +1,56 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+
+
+class TestNotification : XCTestCase {
+
+    static var allTests: [(String, (TestNotification) -> () throws -> Void)] {
+        return [
+            ("test_customReflection", test_customReflection),
+        ]
+    }
+
+    func test_customReflection() {
+        let someName = "somenotifname"
+        let targetObject = NSObject()
+        let userInfo = ["hello": "world", "indexThis": 350] as [AnyHashable: Any]
+        let notif = Notification(name: Notification.Name(rawValue: someName), object: targetObject, userInfo: userInfo)
+        let mirror = notif.customMirror
+
+        XCTAssertEqual(mirror.displayStyle, .class)
+        XCTAssertNil(mirror.superclassMirror)
+
+        var children = Array(mirror.children).makeIterator()
+        let firstChild = children.next()
+        let secondChild = children.next()
+        let thirdChild = children.next()
+        XCTAssertEqual(firstChild?.label, "name")
+        XCTAssertEqual(firstChild?.value as? String, someName)
+
+        XCTAssertEqual(secondChild?.label, "object")
+        XCTAssertEqual(secondChild?.value as? NSObject, targetObject)
+
+        XCTAssertEqual(thirdChild?.label, "userInfo")
+        XCTAssertEqual((thirdChild?.value as? [AnyHashable: Any])?["hello"] as? String, "world")
+        XCTAssertEqual((thirdChild?.value as? [AnyHashable: Any])?["indexThis"] as? Int, 350)
+
+    }
+
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -87,4 +87,5 @@ XCTMain([
     testCase(TestProgressFraction.allTests),
     testCase(TestProgress.allTests),
     testCase(TestObjCRuntime.allTests),
+    testCase(TestNotification.allTests),
 ])


### PR DESCRIPTION
Please review!

I've reverse engineered the reflectable behaviour to be effectively:
1. Translate NSNotification.Name types to Strings
2. Only include userInfo and object in children when the properties are non-nil
3. Provide them in the order of name, object, userInfo

This PR implements tests and the implementation to provide this.

For reference, this code can be dumped into a playground to see how Apple do it.

```
//: Playground - noun: a place where people can play

import UIKit
import Foundation

let thisObject = NSObject()
let anotherObject = NSObject()
let userInfo = ["something": 1, "anotherObject": anotherObject] as [String : Any]

let notif = Notification(name: .UIScreenDidConnect, object: thisObject, userInfo: userInfo)

let customMirror = notif.customMirror
let mirror = Mirror(reflecting: notif)

var a = Array(mirror.children).makeIterator()
a.next()
a.next()
a.next()


customMirror.subjectType
mirror.subjectType

customMirror.description
mirror.description

customMirror.displayStyle
mirror.displayStyle

customMirror.superclassMirror
mirror.superclassMirror

mirror.subjectType
```
