### PR TITLE
Implementation of NSCoding for URLCredential

### DIFF
--- a/Docs/Status.md
+++ b/Docs/Status.md
@@ -47,7 +47,7 @@ There is no _Complete_ status for test coverage because there are always additio
     |------------------------------|-----------------|---------------|--------------------------------------------------------------------------------------------------------------------|
     | `URLAuthenticationChallenge` | Unimplemented   | None          |                                                                                                                    |
     | `URLCache`                   | Unimplemented   | None          |                                                                                                                    |
-    | `URLCredential`              | Mostly Complete | Incomplete    | `NSCoding` and `NSCopying` remain unimplemented                                                                    |
+    | `URLCredential`              | Mostly Complete | Incomplete    | `NSCopying` remains unimplemented                                                                                  |
     | `URLCredentialStorage`       | Unimplemented   | None          |                                                                                                                    |
     | `NSURLError*`                | Complete        | N/A           |                                                                                                                    |
     | `URLProtectionSpace`         | Unimplemented   | None          |                                                                                                                    |

--- a/Foundation/NSURLCredential.swift
+++ b/Foundation/NSURLCredential.swift
@@ -65,11 +65,32 @@ open class URLCredential : NSObject, NSSecureCoding, NSCopying {
      */
     
     public required init?(coder aDecoder: NSCoder) {
-        NSUnimplemented()
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
+        }
+        
+        func bridgeString(_ value: NSString) -> String? {
+            return String._unconditionallyBridgeFromObjectiveC(value)
+        }
+        
+        let encodedUser = aDecoder.decodeObject(forKey: "NS._user") as! NSString
+        self._user = bridgeString(encodedUser)!
+        
+        let encodedPassword = aDecoder.decodeObject(forKey: "NS._password") as! NSString
+        self._password = bridgeString(encodedPassword)!
+        
+        let encodedPersistence = aDecoder.decodeObject(forKey: "NS._persistence") as! NSNumber
+        self._persistence = Persistence(rawValue: encodedPersistence.uintValue)!
     }
     
     open func encode(with aCoder: NSCoder) {
-        NSUnimplemented()
+        guard aCoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
+        }
+        
+        aCoder.encode(self._user._bridgeToObjectiveC(), forKey: "NS._user")
+        aCoder.encode(self._password._bridgeToObjectiveC(), forKey: "NS._password")
+        aCoder.encode(self._persistence.rawValue._bridgeToObjectiveC(), forKey: "NS._persistence")
     }
     
     static public var supportsSecureCoding: Bool {
@@ -82,6 +103,20 @@ open class URLCredential : NSObject, NSSecureCoding, NSCopying {
     
     open func copy(with zone: NSZone? = nil) -> Any {
         return self 
+    }
+    
+    open override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? URLCredential else {
+            return false
+        }
+        
+        guard other !== self else {
+            return true
+        }
+        
+        return other._user == self._user
+            && other._password == self._password
+            && other._persistence == self._persistence
     }
     
     /*!

--- a/Foundation/NSURLCredential.swift
+++ b/Foundation/NSURLCredential.swift
@@ -106,17 +106,14 @@ open class URLCredential : NSObject, NSSecureCoding, NSCopying {
     }
     
     open override func isEqual(_ object: Any?) -> Bool {
-        guard let other = object as? URLCredential else {
-            return false
+        if let other = object as? URLCredential {
+            return other === self
+                || (other._user == self._user
+                    && other._password == self._password
+                    && other._persistence == self._persistence)
         }
         
-        guard other !== self else {
-            return true
-        }
-        
-        return other._user == self._user
-            && other._password == self._password
-            && other._persistence == self._persistence
+        return false
     }
     
     /*!

--- a/TestFoundation/TestNSURLCredential.swift
+++ b/TestFoundation/TestNSURLCredential.swift
@@ -21,7 +21,8 @@ class TestNSURLCredential : XCTestCase {
     static var allTests: [(String, (TestNSURLCredential) -> () throws -> Void)] {
         return [
                    ("test_construction", test_construction),
-                   ("test_copy", test_copy)
+                   ("test_copy", test_copy),
+                   ("test_NSCoding", test_NSCoding)
         ]
     }
     
@@ -38,5 +39,11 @@ class TestNSURLCredential : XCTestCase {
         let credential = URLCredential(user: "swiftUser", password: "swiftPassword", persistence: .forSession)
         let copy = credential.copy() as! URLCredential
         XCTAssertTrue(copy.isEqual(credential))
+    }
+    
+    func test_NSCoding() {
+        let credentialA = URLCredential(user: "swiftUser", password: "swiftPassword", persistence: .forSession)
+        let credentialB = NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: credentialA)) as! URLCredential
+        XCTAssertEqual(credentialA, credentialB, "Archived then unarchived url credential must be equal.")
     }
 }


### PR DESCRIPTION
Implemented a Keyed coding for URLCredentials. Non keyed is not supported in MacOS Foundation, so it's wasn't implemented.
Added test to cover `NSCoding` changes.
Overriden `isEqual` method to match MacOS Foundation.