### PR TITLE
Implementation for NS(Mutable)URLRequest NSCoding.

### DIFF
--- a/Docs/Status.md
+++ b/Docs/Status.md
@@ -53,8 +53,8 @@ There is no _Complete_ status for test coverage because there are always additio
     | `URLProtectionSpace`         | Unimplemented   | None          |                                                                                                                    |
     | `URLProtocol`                | Unimplemented   | None          |                                                                                                                    |
     | `URLProtocolClient`          | Unimplemented   | None          |                                                                                                                    |
-    | `NSURLRequest`               | Mostly Complete | Incomplete    | `NSCoding` remains unimplemented                                                                                   |
-    | `NSMutableURLRequest`        | Mostly Complete | Incomplete    | `NSCoding` remains unimplemented                                                                                   |
+    | `NSURLRequest`               | Mostly Complete | Incomplete    |                                                                                                                    |
+    | `NSMutableURLRequest`        | Mostly Complete | Incomplete    |                                                                                                                    |
     | `URLResponse`                | Mostly Complete | Incomplete    | `NSCoding` remains unimplemented                                                                                   |
     | `NSHTTPURLResponse`          | Mostly Complete | Substantial   | `NSCoding` remains unimplemented                                                                                   |
     | `NSURL`                      | Mostly Complete | Substantial   | `NSCoding` with non-keyed-coding archivers, `checkResourceIsReachable()`, and resource values remain unimplemented |

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -217,11 +217,12 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     }
     
     open var bytes: UnsafeRawPointer {
-        guard let bytes = CFDataGetBytePtr(_cfObject) else {
+        guard let bytePtr = CFDataGetBytePtr(_cfObject) else {
             //This could occure on empty data being encoded.
-            return UnsafeRawPointer([])
+            //TODO: switch with nil when signature is fixed
+            return UnsafeRawPointer(bitPattern: 0xf00deadb0c0)! //would not result in 'nil unwrapped optional'
         }
-        return UnsafeRawPointer(bytes)
+        return UnsafeRawPointer(bytePtr)
     }
 
     

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -217,7 +217,11 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     }
     
     open var bytes: UnsafeRawPointer {
-        return UnsafeRawPointer(CFDataGetBytePtr(_cfObject))
+        guard let bytes = CFDataGetBytePtr(_cfObject) else {
+            //This could occure on empty data being encoded.
+            return UnsafeRawPointer([])
+        }
+        return UnsafeRawPointer(bytes)
     }
 
     

--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -156,11 +156,103 @@ open class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopying 
     }
     
     public required init?(coder aDecoder: NSCoder) {
-        NSUnimplemented()
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
+        }
+        
+        if let encodedURL = aDecoder.decodeObject(forKey: "NS.url") as? NSURL {
+            self.url = encodedURL._swiftObject
+        }
+        
+        if let encodedHeaders = aDecoder.decodeObject(forKey: "NS._allHTTPHeaderFields") as? NSDictionary {
+            self._allHTTPHeaderFields = encodedHeaders.reduce([String : String]()) { result, item in
+                var result = result
+                if let key = item.key as? NSString,
+                    let value = item.value as? NSString {
+                    result[key._swiftObject] = value._swiftObject
+                }
+                return result
+            }
+        }
+        
+        if let encodedDocumentURL = aDecoder.decodeObject(forKey: "NS.mainDocumentURL") as? NSURL {
+            self.mainDocumentURL = encodedDocumentURL._swiftObject
+        }
+        
+        if let encodedMethod = aDecoder.decodeObject(forKey: "NS.httpMethod") as? NSString {
+            self.httpMethod = encodedMethod._swiftObject
+        }
+        
+        let encodedCachePolicy = aDecoder.decodeObject(forKey: "NS._cachePolicy") as! NSNumber
+        self._cachePolicy = CachePolicy(rawValue: encodedCachePolicy.uintValue)!
+        
+        let encodedTimeout = aDecoder.decodeObject(forKey: "NS._timeoutInterval") as! NSNumber
+        self._timeoutInterval = encodedTimeout.doubleValue
+
+        let encodedHttpBody: Data? = aDecoder.withDecodedUnsafeBufferPointer(forKey: "NS.httpBody") {
+            guard let buffer = $0 else { return nil }
+            return Data(buffer: buffer)
+        }
+        
+        if let encodedHttpBody = encodedHttpBody {
+            self._body = .data(encodedHttpBody)
+        }
+        
+        let encodedNetworkServiceType = aDecoder.decodeObject(forKey: "NS._networkServiceType") as! NSNumber
+        self._networkServiceType = NetworkServiceType(rawValue: encodedNetworkServiceType.uintValue)!
+        
+        let encodedCellularAccess = aDecoder.decodeObject(forKey: "NS._allowsCellularAccess") as! NSNumber
+        self._allowsCellularAccess = encodedCellularAccess.boolValue
+        
+        let encodedHandleCookies = aDecoder.decodeObject(forKey: "NS._httpShouldHandleCookies") as! NSNumber
+        self._httpShouldHandleCookies = encodedHandleCookies.boolValue
+        
+        let encodedUsePipelining = aDecoder.decodeObject(forKey: "NS._httpShouldUsePipelining") as! NSNumber
+        self._httpShouldUsePipelining = encodedUsePipelining.boolValue
     }
     
     open func encode(with aCoder: NSCoder) {
-        NSUnimplemented()
+        guard aCoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
+        }
+        
+        self._body = .data(Data())
+        
+        aCoder.encode(self.url?._bridgeToObjectiveC(), forKey: "NS.url")
+        aCoder.encode(self._allHTTPHeaderFields?._bridgeToObjectiveC(), forKey: "NS._allHTTPHeaderFields")
+        aCoder.encode(self.mainDocumentURL?._bridgeToObjectiveC(), forKey: "NS.mainDocumentURL")
+        aCoder.encode(self.httpMethod?._bridgeToObjectiveC(), forKey: "NS.httpMethod")
+        aCoder.encode(self._cachePolicy.rawValue._bridgeToObjectiveC(), forKey: "NS._cachePolicy")
+        aCoder.encode(self._timeoutInterval._bridgeToObjectiveC(), forKey: "NS._timeoutInterval")
+        if let httpBody = self.httpBody?._bridgeToObjectiveC() {
+            let bytePtr = httpBody.bytes.bindMemory(to: UInt8.self, capacity: httpBody.length)
+            aCoder.encodeBytes(bytePtr, length: httpBody.length, forKey: "NS.httpBody")
+        }
+        //On macOS input stream is not encoded.
+        aCoder.encode(self._networkServiceType.rawValue._bridgeToObjectiveC(), forKey: "NS._networkServiceType")
+        aCoder.encode(self._allowsCellularAccess._bridgeToObjectiveC(), forKey: "NS._allowsCellularAccess")
+        aCoder.encode(self._httpShouldHandleCookies._bridgeToObjectiveC(), forKey: "NS._httpShouldHandleCookies")
+        aCoder.encode(self._httpShouldUsePipelining._bridgeToObjectiveC(), forKey: "NS._httpShouldUsePipelining")
+    }
+    
+    open override func isEqual(_ object: Any?) -> Bool {
+        //On macOS this fields do not determine the result:
+        //allHTTPHeaderFields
+        //timeoutInterval
+        //httBody
+        //networkServiceType
+        //httpShouldUsePipelining
+        if let other = object as? NSURLRequest {
+            return other === self
+                || (other.url == self.url
+                    && other.mainDocumentURL == self.mainDocumentURL
+                    && other.httpMethod == self.httpMethod
+                    && other._cachePolicy == self._cachePolicy
+                    && other.httpBodyStream == self.httpBodyStream
+                    && other._allowsCellularAccess == self._allowsCellularAccess
+                    && other._httpShouldHandleCookies == self._httpShouldHandleCookies)
+        }
+        return false
     }
     
     /// Indicates that NSURLRequest implements the NSSecureCoding protocol.
@@ -289,7 +381,7 @@ open class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopying 
 /// example.
 open class NSMutableURLRequest : NSURLRequest {
     public required init?(coder aDecoder: NSCoder) {
-        NSUnimplemented()
+        super.init(coder: aDecoder)
     }
     
     public convenience init(url: URL) {

--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -216,8 +216,6 @@ open class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopying 
             preconditionFailure("Unkeyed coding is unsupported.")
         }
         
-        self._body = .data(Data())
-        
         aCoder.encode(self.url?._bridgeToObjectiveC(), forKey: "NS.url")
         aCoder.encode(self._allHTTPHeaderFields?._bridgeToObjectiveC(), forKey: "NS._allHTTPHeaderFields")
         aCoder.encode(self.mainDocumentURL?._bridgeToObjectiveC(), forKey: "NS.mainDocumentURL")

--- a/TestFoundation/TestNSURLRequest.swift
+++ b/TestFoundation/TestNSURLRequest.swift
@@ -27,7 +27,9 @@ class TestNSURLRequest : XCTestCase {
             ("test_mutableCopy_1", test_mutableCopy_1),
             ("test_mutableCopy_2", test_mutableCopy_2),
             ("test_mutableCopy_3", test_mutableCopy_3),
-            ("test_NSCoding", test_NSCoding),
+            ("test_NSCoding_1", test_NSCoding_1),
+            ("test_NSCoding_2", test_NSCoding_2),
+            ("test_NSCoding_3", test_NSCoding_3)
         ]
     }
     
@@ -205,12 +207,37 @@ class TestNSURLRequest : XCTestCase {
         XCTAssertNil(originalRequest.allHTTPHeaderFields)
     }
     
-    func test_NSCoding() {
+    func test_NSCoding_1() {
         let url = URL(string: "https://apple.com")!
-        
         let requestA = NSURLRequest(url: url)
-        XCTAssertEqual(requestA.url, url)
         let requestB = NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: requestA)) as! NSURLRequest
         XCTAssertEqual(requestA, requestB, "Archived then unarchived url request must be equal.")
+    }
+    
+    func test_NSCoding_2() {
+        let url = URL(string: "https://apple.com")!
+        let requestA = NSMutableURLRequest(url: url)
+        //Also checks crash on NSData.bytes
+        requestA.httpBody = Data()
+        let requestB = NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: requestA)) as! NSURLRequest
+        XCTAssertEqual(requestA, requestB, "Archived then unarchived url request must be equal.")
+        //Check `.httpBody` as it is not checked in `isEqual(_:)`
+        XCTAssertEqual(requestB.httpBody, requestA.httpBody)
+    }
+    
+    func test_NSCoding_3() {
+        let url = URL(string: "https://apple.com")!
+        let urlForDocument = URL(string: "http://ibm.com")!
+        
+        let requestA = NSMutableURLRequest(url: url)
+        requestA.mainDocumentURL = urlForDocument
+        //Also checks crash on NSData.bytes
+        requestA.httpBody = Data(bytes: [1, 2, 3])
+        let requestB = NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: requestA)) as! NSURLRequest
+        XCTAssertEqual(requestA, requestB, "Archived then unarchived url request must be equal.")
+        //Check `.httpBody` as it is not checked in `isEqual(_:)`
+        XCTAssertNotNil(requestB.httpBody)
+        XCTAssertEqual(3, requestB.httpBody!.count)
+        XCTAssertEqual(requestB.httpBody, requestA.httpBody)
     }
 }

--- a/TestFoundation/TestNSURLRequest.swift
+++ b/TestFoundation/TestNSURLRequest.swift
@@ -27,6 +27,7 @@ class TestNSURLRequest : XCTestCase {
             ("test_mutableCopy_1", test_mutableCopy_1),
             ("test_mutableCopy_2", test_mutableCopy_2),
             ("test_mutableCopy_3", test_mutableCopy_3),
+            ("test_NSCoding", test_NSCoding),
         ]
     }
     
@@ -202,5 +203,14 @@ class TestNSURLRequest : XCTestCase {
         XCTAssertEqual(originalRequest.httpMethod, "GET")
         XCTAssertEqual(originalRequest.url, urlA)
         XCTAssertNil(originalRequest.allHTTPHeaderFields)
+    }
+    
+    func test_NSCoding() {
+        let url = URL(string: "https://apple.com")!
+        
+        let requestA = NSURLRequest(url: url)
+        XCTAssertEqual(requestA.url, url)
+        let requestB = NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: requestA)) as! NSURLRequest
+        XCTAssertEqual(requestA, requestB, "Archived then unarchived url request must be equal.")
     }
 }


### PR DESCRIPTION
Implemented `NSCoding` for `NSURLRequest` and `NSMutableURLRequest`.
Overriden `isEqual(_:)` method to conform to macOS Foundation.
Also fixed `NSData.bytes` crash when empty data was decoded. `test_NSCoding_2()` tests this crash.