### PR TITLE
[NSURLQueryItem] NSCoding Implementation

### DIFF
--- a/Docs/Status.md
+++ b/Docs/Status.md
@@ -58,7 +58,7 @@ There is no _Complete_ status for test coverage because there are always additio
     | `URLResponse`                | Mostly Complete | Incomplete    | `NSCoding` remains unimplemented                                                                                   |
     | `NSHTTPURLResponse`          | Mostly Complete | Substantial   | `NSCoding` remains unimplemented                                                                                   |
     | `NSURL`                      | Mostly Complete | Substantial   | `NSCoding` with non-keyed-coding archivers, `checkResourceIsReachable()`, and resource values remain unimplemented |
-    | `NSURLQueryItem`             | Mostly Complete | N/A           | `NSCoding` remains unimplemented                                                                                   |
+    | `NSURLQueryItem`             | Mostly Complete | N/A           |                                                                                                                    |
     | `URLResourceKey`             | Complete        | N/A           |                                                                                                                    |
     | `URLFileResourceType`        | Complete        | N/A           |                                                                                                                    |
     | `URL`                        | Complete        | Incomplete    |                                                                                                                    |

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -910,11 +910,34 @@ open class NSURLQueryItem : NSObject, NSSecureCoding, NSCopying {
     }
     
     required public init?(coder aDecoder: NSCoder) {
-        NSUnimplemented()
+        guard aDecoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
+        }
+        
+        let encodedName = aDecoder.decodeObject(forKey: "NS.name") as! NSString
+        self.name = encodedName._swiftObject
+        
+        let encodedValue = aDecoder.decodeObject(forKey: "NS.value") as? NSString
+        self.value = encodedValue?._swiftObject
     }
     
     open func encode(with aCoder: NSCoder) {
-        NSUnimplemented()
+        guard aCoder.allowsKeyedCoding else {
+            preconditionFailure("Unkeyed coding is unsupported.")
+        }
+        
+        aCoder.encode(self.name._bridgeToObjectiveC(), forKey: "NS.name")
+        aCoder.encode(self.value?._bridgeToObjectiveC(), forKey: "NS.value")
+    }
+    
+    open override func isEqual(_ object: Any?) -> Bool {
+        if let other = object as? NSURLQueryItem {
+            return other === self
+                || (other.name == self.name
+                    && other.value == self.value)
+        }
+        
+        return false
     }
     
     open let name: String

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -61,7 +61,8 @@ class TestNSURL : XCTestCase {
             ("test_fileURLWithPath", test_fileURLWithPath),
             ("test_fileURLWithPath_isDirectory", test_fileURLWithPath_isDirectory),
             ("test_URLByResolvingSymlinksInPath", test_URLByResolvingSymlinksInPath),
-            ("test_copy", test_copy)
+            ("test_copy", test_copy),
+            ("test_itemNSCoding", test_itemNSCoding),
         ]
     }
     
@@ -412,6 +413,12 @@ class TestNSURL : XCTestCase {
         let queryItem = NSURLQueryItem(name: "id", value: "23")
         let queryItemCopy = queryItem.copy() as! NSURLQueryItem
         XCTAssertTrue(queryItem.isEqual(queryItemCopy))
+    }
+    
+    func test_itemNSCoding() {
+        let queryItemA = NSURLQueryItem(name: "id", value: "23")
+        let queryItemB = NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: queryItemA)) as! NSURLQueryItem
+        XCTAssertEqual(queryItemA, queryItemB, "Archived then unarchived query item must be equal.")
     }
 }
     


### PR DESCRIPTION
Added `NSCoding` to `NSURLQueryItem`.
Added tests.
Overriden `isEqual(_:)` to conform to MacOS Foundation.