### PR TITLE
Implementation of URLSessionTask '.error', NSCopying

### DIFF
--- a/Docs/Status.md
+++ b/Docs/Status.md
@@ -78,7 +78,7 @@ There is no _Complete_ status for test coverage because there are always additio
     | `URLSession`                 | Mostly Complete | Incomplete    | `shared`, invalidation, resetting, flushing, getting tasks, and others remain unimplemented                        |
     | `URLSessionConfiguration`    | Mostly Complete | Incomplete    | `ephemeral` and `background(withIdentifier:)` remain unimplemented                                                 |
     | `URLSessionDelegate`         | Complete        | N/A           |                                                                                                                    |
-    | `URLSessionTask`             | Mostly Complete | Incomplete    | `NSCopying`, `cancel()`, `error`, `createTransferState(url:)` with streams, and others remain unimplemented        |
+    | `URLSessionTask`             | Mostly Complete | Incomplete    | `cancel()`, `createTransferState(url:)` with streams, and others remain unimplemented                              |
     | `URLSessionDataTask`         | Complete        | Incomplete    |                                                                                                                    |
     | `URLSessionUploadTask`       | Complete        | None          |                                                                                                                    |
     | `URLSessionDownloadTask`     | Incomplete      | Incomplete    | `cancel(byProducingResumeData:)` remains unimplemented                                                             |

--- a/Foundation/NSURLSession/NSURLSessionTask.swift
+++ b/Foundation/NSURLSession/NSURLSessionTask.swift
@@ -221,8 +221,8 @@ open class URLSessionTask : NSObject, NSCopying {
      * The error, if any, delivered via -URLSession:task:didCompleteWithError:
      * This property will be nil in the event that no error occured.
      */
-    fileprivate var _error: Error?
-    /*@NSCopying*/ open var error: Error? {
+    fileprivate var _error: NSError?
+    /*@NSCopying*/ open var error: NSError? {
         return self._error
     }
     

--- a/Foundation/NSURLSession/NSURLSessionTask.swift
+++ b/Foundation/NSURLSession/NSURLSessionTask.swift
@@ -221,7 +221,10 @@ open class URLSessionTask : NSObject, NSCopying {
      * The error, if any, delivered via -URLSession:task:didCompleteWithError:
      * This property will be nil in the event that no error occured.
      */
-    /*@NSCopying*/ open fileprivate(set) var error: NSError?
+    fileprivate var _error: Error?
+    /*@NSCopying*/ open var error: Error? {
+        return self._error
+    }
     
     /// Suspend the task.
     ///
@@ -877,7 +880,7 @@ extension URLSessionTask {
         }
     }
     func completeTask(withError error: NSError) {
-        self.error = error
+        self._error = error
         
         guard case .transferFailed = internalState else {
             fatalError("Trying to complete the task, but its transfer isn't complete / failed.")

--- a/Foundation/NSURLSession/NSURLSessionTask.swift
+++ b/Foundation/NSURLSession/NSURLSessionTask.swift
@@ -221,7 +221,7 @@ open class URLSessionTask : NSObject, NSCopying {
      * The error, if any, delivered via -URLSession:task:didCompleteWithError:
      * This property will be nil in the event that no error occured.
      */
-    /*@NSCopying*/ open var error: NSError? { NSUnimplemented() }
+    /*@NSCopying*/ open fileprivate(set) var error: NSError?
     
     /// Suspend the task.
     ///
@@ -877,6 +877,8 @@ extension URLSessionTask {
         }
     }
     func completeTask(withError error: NSError) {
+        self.error = error
+        
         guard case .transferFailed = internalState else {
             fatalError("Trying to complete the task, but its transfer isn't complete / failed.")
         }

--- a/Foundation/NSURLSession/NSURLSessionTask.swift
+++ b/Foundation/NSURLSession/NSURLSessionTask.swift
@@ -1034,8 +1034,8 @@ fileprivate extension URLSessionTask {
         guard case .waitingForResponseCompletionHandler(let ts) = internalState else { fatalError("Received response disposition, but we're not waiting for it.") }
         switch disposition {
         case .cancel:
-            //TODO: Fail the task with NSURLErrorCancelled
-            NSUnimplemented()
+            let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)
+            self.completeTask(withError: error)
         case .allow:
             // Continue the transfer. This will unpause the easy handle.
             internalState = .transferInProgress(ts)

--- a/Foundation/NSURLSession/NSURLSessionTask.swift
+++ b/Foundation/NSURLSession/NSURLSessionTask.swift
@@ -128,7 +128,7 @@ open class URLSessionTask : NSObject, NSCopying {
     }
     
     open func copy(with zone: NSZone?) -> Any {
-        NSUnimplemented()
+        return self
     }
     
     /// An identifier for this task, assigned by and unique to the owning session

--- a/TestFoundation/TestNSURLSession.swift
+++ b/TestFoundation/TestNSURLSession.swift
@@ -30,7 +30,8 @@ class TestURLSession : XCTestCase {
             ("test_downloadTaskWithRequestAndHandler", test_downloadTaskWithRequestAndHandler),
             ("test_downloadTaskWithURLAndHandler", test_downloadTaskWithURLAndHandler),
             ("test_finishTaskAndInvalidate", test_finishTasksAndInvalidate),
-            ("test_taskError", test_taskError)
+            ("test_taskError", test_taskError),
+            ("test_taskCopy", test_taskCopy),
         ]
     }
 

--- a/TestFoundation/TestNSURLSession.swift
+++ b/TestFoundation/TestNSURLSession.swift
@@ -284,7 +284,7 @@ class TestURLSession : XCTestCase {
             XCTAssertNil(error)
             
             XCTAssertNotNil(task.error)
-            XCTAssertEqual(task.error?.code, NSURLErrorBadURL)
+            XCTAssertEqual((task.error as! NSError).code, NSURLErrorBadURL)
         }
     }
     

--- a/TestFoundation/TestNSURLSession.swift
+++ b/TestFoundation/TestNSURLSession.swift
@@ -284,7 +284,7 @@ class TestURLSession : XCTestCase {
             XCTAssertNil(error)
             
             XCTAssertNotNil(task.error)
-            XCTAssertEqual((task.error as! NSError).code, NSURLErrorBadURL)
+            XCTAssertEqual(task.error?.code, NSURLErrorBadURL)
         }
     }
     

--- a/TestFoundation/TestNSURLSession.swift
+++ b/TestFoundation/TestNSURLSession.swift
@@ -286,6 +286,16 @@ class TestURLSession : XCTestCase {
             XCTAssertEqual(task.error?.code, NSURLErrorBadURL)
         }
     }
+    
+    func test_taskCopy() {
+        let url = URL(string: "http://127.0.0.1:\(serverPort)/Nepal")!
+        let session = URLSession(configuration: URLSessionConfiguration.default,
+                                 delegate: nil,
+                                 delegateQueue: nil)
+        let task = session.dataTask(with: url)
+        
+        XCTAssert(task.isEqual(task.copy()))
+    }
 }
 
 class SessionDelegate: NSObject, URLSessionDelegate {

--- a/TestFoundation/TestNSURLSession.swift
+++ b/TestFoundation/TestNSURLSession.swift
@@ -29,7 +29,8 @@ class TestURLSession : XCTestCase {
             ("test_downloadTaskWithURLRequest", test_downloadTaskWithURLRequest),
             ("test_downloadTaskWithRequestAndHandler", test_downloadTaskWithRequestAndHandler),
             ("test_downloadTaskWithURLAndHandler", test_downloadTaskWithURLAndHandler),
-            ("test_finishTaskAndInvalidate", test_finishTasksAndInvalidate)
+            ("test_finishTaskAndInvalidate", test_finishTasksAndInvalidate),
+            ("test_taskError", test_taskError)
         ]
     }
 
@@ -261,6 +262,29 @@ class TestURLSession : XCTestCase {
         task.resume()
         session.finishTasksAndInvalidate()
         waitForExpectations(timeout: 12)
+    }
+    
+    func test_taskError() {
+        let url = URL(string: "http://127.0.0.1:\(serverPort)/Nepal")!
+        let session = URLSession(configuration: URLSessionConfiguration.default,
+                                 delegate: nil,
+                                 delegateQueue: nil)
+        let completionExpectation = expectation(description: "dataTask completion block wasn't called")
+        let task = session.dataTask(with: url) { result in
+            let error = result.2
+            XCTAssertNotNil(error)
+            XCTAssertEqual(error?.code, NSURLErrorBadURL)
+            completionExpectation.fulfill()
+        }
+        //should result in Bad URL error
+        task.resume()
+        
+        waitForExpectations(timeout: 5) { error in
+            XCTAssertNil(error)
+            
+            XCTAssertNotNil(task.error)
+            XCTAssertEqual(task.error?.code, NSURLErrorBadURL)
+        }
     }
 }
 


### PR DESCRIPTION
Added an implementation for `.error` property and `NSCopying` for `URLSessionTask`
Added tests.

`.cancel()` is implemented in: #689 