### PR TITLE
SR-3193, Fix NSCalendar.isDateInWeekend

### DIFF
--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -974,7 +974,7 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     This API reports if the date is within a weekend period, as defined by the calendar and calendar's locale.
     */
     open func isDateInWeekend(_ date: Date) -> Bool {
-        return _CFCalendarIsWeekend(_cfObject, date.timeIntervalSinceReferenceDate)
+        return _CFCalendarIsWeekend(_cfObject, date.timeIntervalSince1970)
     }
     
     /// Revised API for avoiding usage of AutoreleasingUnsafeMutablePointer.

--- a/TestFoundation/TestNSCalendar.swift
+++ b/TestFoundation/TestNSCalendar.swift
@@ -26,7 +26,9 @@ class TestNSCalendar: XCTestCase {
             ("test_gettingDatesOnChineseCalendar", test_gettingDatesOnChineseCalendar),
             ("test_gettingDatesOnISO8601Calendar", test_gettingDatesOnISO8601Calendar),
             ("test_copy",test_copy),
-            ("test_addingDates", test_addingDates)
+            ("test_addingDates", test_addingDates),
+            ("test_datesNotOnWeekend", test_datesNotOnWeekend),
+            ("test_datesOnWeekend", test_datesOnWeekend)
             // Disabled because this fails on linux https://bugs.swift.org/browse/SR-320
             // ("test_currentCalendarRRstability", test_currentCalendarRRstability),
         ]
@@ -140,6 +142,20 @@ class TestNSCalendar: XCTestCase {
         XCTAssertEqual(dayAfterComponents.year, 2016)
         XCTAssertEqual(dayAfterComponents.month, 10)
         XCTAssertEqual(dayAfterComponents.day, 5)
+    }
+    
+    func test_datesNotOnWeekend() {
+        let calendar = Calendar(identifier: .gregorian)
+        let wednesdayInFebruary = calendar.date(from: DateComponents(year: 2016, month: 2, day: 17))!
+        
+        XCTAssertFalse(calendar.isDateInWeekend(wednesdayInFebruary))
+    }
+    
+    func test_datesOnWeekend() {
+        let calendar = Calendar(identifier: .gregorian)
+        let sundayInFebruary = calendar.date(from: DateComponents(year: 2016, month: 2, day: 14))!
+        
+        XCTAssertTrue(calendar.isDateInWeekend(sundayInFebruary))
     }
 }
 


### PR DESCRIPTION
NSCalendar was passing the incorrect time interval for determining if a date is on the weekend.  Ucal was expecting the time interval since 1970 while NSCalendar was passing the time interval since the reference date.

That requirement is documented [here](http://www.icu-project.org/apiref/icu4c/utypes_8h.html#ace1704e9e77d407d1eaaa2e73ec0c039).