### PR TITLE
[WIP] SR-936. Segmentation fault on NSMutableData().hash

### DIFF
--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -944,11 +944,6 @@ open class NSMutableData : NSData {
             CFDataReplaceBytes(_cfMutableObject, CFRangeMake(range.location, range.length), bytePtr, replacementLength)
         }
     }
-    
-    /// SR-936 workaround
-    open override var hash: Int {
-        return (self.copy() as! NSData).hash
-    }
 }
 
 extension NSData : _StructTypeBridgeable {

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -944,6 +944,11 @@ open class NSMutableData : NSData {
             CFDataReplaceBytes(_cfMutableObject, CFRangeMake(range.location, range.length), bytePtr, replacementLength)
         }
     }
+    
+    /// SR-936 workaround
+    open override var hash: Int {
+        return (self.copy() as! NSData).hash
+    }
 }
 
 extension NSData : _StructTypeBridgeable {

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -90,6 +90,8 @@ class TestNSData: XCTestCase {
             ("test_initDataWithCapacity", test_initDataWithCapacity),
             ("test_initDataWithCount", test_initDataWithCount),
             ("test_emptyStringToData", test_emptyStringToData),
+            
+            ("test_hash", test_hash)
         ]
     }
     
@@ -443,6 +445,23 @@ class TestNSData: XCTestCase {
     func test_emptyStringToData() {
         let data = "".data(using: .utf8)!
         XCTAssertEqual(0, data.count, "data from empty string is empty")
+    }
+    
+    func test_hash() {
+        //tests crashes at SR-936
+        
+        let data = "foobar".data(using: .utf8)!
+        
+        _ = NSData().hash
+        
+        _ = NSData(data: data).hash
+        
+        _ = data.hashValue
+        
+        _ = NSMutableData(data: data).hash
+        
+        
+        _ = NSMutableData().hash
     }
 }
 


### PR DESCRIPTION
Issue: https://bugs.swift.org/browse/SR-936

Currently this code: `NSMutableData().hash` - produces a Segmentation fault.
The reason i found is that on `.hash` call, CoreFoundation uses `_CFIsSwift` to check if used class is Swift class or not. 
For `NSData` the result is`false` and runs normally without an error. 
For `NSMutableData` the result is `true` which causes it to call `.hash` again and creates a loop.