### PR TITLE
Improve JSON serialization performance on Linux

### DIFF
--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -15,7 +15,7 @@
     import SwiftFoundation
     import SwiftXCTest
 #endif
-import Dispatch
+
 
 class TestNSJSONSerialization : XCTestCase {
     
@@ -598,7 +598,6 @@ extension TestNSJSONSerialization {
             ("test_invalidJsonObjectToStreamBuffer", test_invalidJsonObjectToStreamBuffer),
             ("test_jsonObjectToOutputStreamInsufficeintBuffer", test_jsonObjectToOutputStreamInsufficeintBuffer),
             ("test_booleanJSONObject", test_booleanJSONObject),
-            ("test_serialization_perf", test_serialize_perf),
         ]
     }
 
@@ -742,35 +741,6 @@ extension TestNSJSONSerialization {
         
         let jsonArr4 = [["a":NSNull()],["b":NSNull()]]
         XCTAssertEqual(try trySerialize(jsonArr4), "[{\"a\":null},{\"b\":null}]")
-    }
-    
-    func test_serialize_perf() {
-        let numItems = 20                  // Number of elements in the payload
-        let loops = 500                    // Number of times to invoke serialization per measurement
-        let concurrency = 4                // Number of concurrent threads
-        var PAYLOAD = [String:Any]()       // The string to convert
-        
-        for i in 1...numItems {
-            PAYLOAD["Item \(i)"] = Double(i)
-        }
-        
-        let queue = DispatchQueue(label: "testcaseQueue", attributes: .concurrent)
-        let group = DispatchGroup()
-        
-        self.measure {
-            for _ in 1...concurrency {
-                queue.async(group: group) {
-                    for _ in 1...loops {
-                        do {
-                            _ = try JSONSerialization.data(withJSONObject: PAYLOAD)
-                        } catch {
-                            XCTFail("Could not serialize to JSON: \(error)")
-                        }
-                    }
-                }
-            }
-            _ = group.wait(timeout: .distantFuture) // forever
-        }
     }
     
     func test_nested_array() {

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -15,7 +15,7 @@
     import SwiftFoundation
     import SwiftXCTest
 #endif
-
+import Dispatch
 
 class TestNSJSONSerialization : XCTestCase {
     
@@ -598,6 +598,7 @@ extension TestNSJSONSerialization {
             ("test_invalidJsonObjectToStreamBuffer", test_invalidJsonObjectToStreamBuffer),
             ("test_jsonObjectToOutputStreamInsufficeintBuffer", test_jsonObjectToOutputStreamInsufficeintBuffer),
             ("test_booleanJSONObject", test_booleanJSONObject),
+            ("test_serialization_perf", test_serialize_perf),
         ]
     }
 
@@ -741,6 +742,35 @@ extension TestNSJSONSerialization {
         
         let jsonArr4 = [["a":NSNull()],["b":NSNull()]]
         XCTAssertEqual(try trySerialize(jsonArr4), "[{\"a\":null},{\"b\":null}]")
+    }
+    
+    func test_serialize_perf() {
+        let numItems = 20                  // Number of elements in the payload
+        let loops = 500                    // Number of times to invoke serialization per measurement
+        let concurrency = 4                // Number of concurrent threads
+        var PAYLOAD = [String:Any]()       // The string to convert
+        
+        for i in 1...numItems {
+            PAYLOAD["Item \(i)"] = Double(i)
+        }
+        
+        let queue = DispatchQueue(label: "testcaseQueue", attributes: .concurrent)
+        let group = DispatchGroup()
+        
+        self.measure {
+            for _ in 1...concurrency {
+                queue.async(group: group) {
+                    for _ in 1...loops {
+                        do {
+                            _ = try JSONSerialization.data(withJSONObject: PAYLOAD)
+                        } catch {
+                            XCTFail("Could not serialize to JSON: \(error)")
+                        }
+                    }
+                }
+            }
+            _ = group.wait(timeout: .distantFuture) // forever
+        }
     }
     
     func test_nested_array() {


### PR DESCRIPTION
This change improves the performance of serializing objects to a Data, by using String concatenation to build the result, and then convert to a Data once.  This change was developed by @shmuelk and myself.

We may want to revisit this in the future as the performance of appending to Data improves.

Note, we initially used `jsonStr.cString(using: .utf8)` to create the Data, but in testing this seemed to leak memory (perhaps this is a bug): https://github.com/IBM-Swift/SwiftyJSON/pull/22

I've provided a microbenchmark to demonstrate the effect of these changes:

Before:
```
TestFoundation/TestNSJSONSerialization.swift:760: Test Case 'TestNSJSONSerialization.test_serialization_perf' measured [Time, seconds] average: 0.463, relative standard deviation: 3.143%, values: [0.485122, 0.469292, 0.439064, 0.447310, 0.455177, 0.482358, 0.455306, 0.468886, 0.468181, 0.461310], performanceMetricID:org.swift.XCTPerformanceMetric_WallClockTime, maxPercentRelativeStandardDeviation: 10.000%, maxStandardDeviation: 0.100
Test Case 'TestNSJSONSerialization.test_serialization_perf' passed (4.632 seconds).
```
After:
```
TestFoundation/TestNSJSONSerialization.swift:760: Test Case 'TestNSJSONSerialization.test_serialization_perf' measured [Time, seconds] average: 0.238, relative standard deviation: 8.555%, values: [0.235258, 0.234057, 0.224006, 0.257510, 0.248202, 0.241663, 0.209058, 0.259959, 0.204592, 0.261825], performanceMetricID:org.swift.XCTPerformanceMetric_WallClockTime, maxPercentRelativeStandardDeviation: 10.000%, maxStandardDeviation: 0.100
Test Case 'TestNSJSONSerialization.test_serialization_perf' passed (2.376 seconds).
```
The above results were collected on Ubuntu 16.04.  I obtained similar results on OS X.