### PR TITLE
Further improve performance of JSON serialization on Linux

### DIFF
--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -287,10 +287,6 @@ private struct JSONWriter {
             try serializeString(str)
         case let boolValue as Bool:
             serializeBool(boolValue)
-        case let num as Int:
-            writer(String(describing: num))
-        case let num as UInt:
-            writer(String(describing: num))
         case let array as Array<Any>:
             try serializeArray(array)
         case let dict as Dictionary<AnyHashable, Any>:

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -276,14 +276,18 @@ private struct JSONWriter {
             try serializeString(str)
         case let boolValue as Bool:
             serializeBool(boolValue)
-        case _ where _SwiftValue.store(obj) is NSNumber:
-            try serializeNumber(_SwiftValue.store(obj) as! NSNumber)
+        case let num as Int:
+            writer(String(describing: num))
+        case let num as UInt:
+            writer(String(describing: num))
         case let array as Array<Any>:
             try serializeArray(array)
         case let dict as Dictionary<AnyHashable, Any>:
             try serializeDictionary(dict)
         case let null as NSNull:
             try serializeNull(null)
+        case _ where _SwiftValue.store(obj) is NSNumber:
+            try serializeNumber(_SwiftValue.store(obj) as! NSNumber)
         default:
             throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.propertyListReadCorrupt.rawValue, userInfo: ["NSDebugDescription" : "Invalid object cannot be serialized"])
         }

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -62,13 +62,11 @@ open class JSONSerialization : NSObject {
 
             // object is a Double and is not NaN or infinity
             if let number = obj as? Double  {
-                let invalid = number.isInfinite || number.isNaN
-                return !invalid
+                return number.isFinite
             }
             // object is a Float and is not NaN or infinity
             if let number = obj as? Float  {
-                let invalid = number.isInfinite || number.isNaN
-                return !invalid
+                return number.isFinite
             }
 
             // object is Swift.Array
@@ -92,6 +90,7 @@ open class JSONSerialization : NSObject {
             }
 
             // object is NSNumber and is not NaN or infinity
+            // For better performance, this (most expensive) test should be last.
             if let number = _SwiftValue.store(obj) as? NSNumber {
                 let invalid = number.doubleValue.isInfinite || number.doubleValue.isNaN
                 return !invalid
@@ -282,6 +281,7 @@ private struct JSONWriter {
     
     mutating func serializeJSON(_ obj: Any) throws {
 
+        // For better performance, the most expensive conditions to evaluate should be last.
         switch (obj) {
         case let str as String:
             try serializeString(str)

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -55,14 +55,19 @@ open class JSONSerialization : NSObject {
     open class func isValidJSONObject(_ obj: Any) -> Bool {
         // TODO: - revisit this once bridging story gets fully figured out
         func isValidJSONObjectInternal(_ obj: Any) -> Bool {
-            // object is Swift.String or NSNull
-            if obj is String || obj is NSNull {
+            // object is Swift.String, NSNull, Int, Bool, or UInt
+            if obj is String || obj is NSNull || obj is Int || obj is Bool || obj is UInt {
                 return true
             }
 
-            // object is NSNumber and is not NaN or infinity
-            if let number = _SwiftValue.store(obj) as? NSNumber {
-                let invalid = number.doubleValue.isInfinite || number.doubleValue.isNaN
+            // object is a Double and is not NaN or infinity
+            if let number = obj as? Double  {
+                let invalid = number.isInfinite || number.isNaN
+                return !invalid
+            }
+            // object is a Float and is not NaN or infinity
+            if let number = obj as? Float  {
+                let invalid = number.isInfinite || number.isNaN
                 return !invalid
             }
 
@@ -84,6 +89,12 @@ open class JSONSerialization : NSObject {
                     }
                 }
                 return true
+            }
+
+            // object is NSNumber and is not NaN or infinity
+            if let number = _SwiftValue.store(obj) as? NSNumber {
+                let invalid = number.doubleValue.isInfinite || number.doubleValue.isNaN
+                return !invalid
             }
 
             // invalid object


### PR DESCRIPTION
Following on from #718, this change further improves performance of JSON serialization:
- In `JSONWriter.serializeJSON`, move the expensive NSNumber case (which invokes `_SwiftValue.store`) below the cases for Array, Dictionary and primitive types.
- add fast paths for Int and UInt types, which can be converted directly to a String rather than going via NSNumber.
- Equivalent changes for `isValidJSONObject`

These changes were developed by @shmuelk and myself.

Additional performance can be gained by adding similar fast paths for Double and Float, however doing so fails the tests that expect a whole number to be serialized without decimal places (eg. `Double(1.0)` -> `1`).  For that reason, I have not included a fast path for Double or Float in this PR, but I included the performance numbers below for the sake of interest.

Update: I've removed the Int/UInt fastpath for now, until I can resolve the control over formatting issue raised in the review below.  This PR is now just contains the 1.2x improvement (from case reordering).  I'll submit the fastpaths in a future PR.

Using [the benchmark I developed for #718](https://github.com/djones6/swift-corelibs-foundation/commit/867109e253550e4d1bcb99cfc681fdb02ce0f566), increased to 10,000 repetitions, I get the following results on Ubuntu 16.04:

```
Payload type:       Int   (speedup)        Double   (speedup)

Baseline:           8.72                   8.78
With #718:          4.18  (2.1x)           3.97   (2.2x)
Reorder case:       3.43  (1.2x)           3.29   (1.2x)
Int/UInt fastpath:  2.33  (1.5x)           ----

(Double fastpath):  ----                   2.42   (1.35x)
```
(units are average execution time in seconds,  and the code changes are cumulative).