### PR TITLE
Implement remainder of NSDecimal/NSDecimalNumber

### DIFF
--- a/Foundation/NSDecimal.swift
+++ b/Foundation/NSDecimal.swift
@@ -644,7 +644,7 @@ fileprivate extension UInt16 {
     }
 }
 
-fileprivate func decimalCompare<T:VariableLengthNumber>(
+fileprivate func mantissaCompare<T:VariableLengthNumber>(
     _ left: T,
     _ right: T) -> ComparisonResult {
 
@@ -655,7 +655,7 @@ fileprivate func decimalCompare<T:VariableLengthNumber>(
         return .orderedAscending
     }
     let length = left._length // == right._length
-    for i in 0..<length {
+    for i in (0..<length).reversed() {
         let comparison = left[i].compareTo(right[i])
         if comparison != .orderedSame {
             return comparison
@@ -1131,7 +1131,7 @@ public func NSDecimalAdd(_ result: UnsafeMutablePointer<Decimal>, _ leftOperand:
             }
             result.pointee._length = length
         } else { // not the same sign
-            let comparison = decimalCompare(a,b)
+            let comparison = mantissaCompare(a,b)
 
             switch comparison {
             case .orderedSame:
@@ -1728,7 +1728,7 @@ extension Decimal {
         var selfNormal = self
         var otherNormal = other
         _ = NSDecimalNormalize(&selfNormal, &otherNormal, .down)
-        let comparison = decimalCompare(selfNormal,otherNormal)
+        let comparison = mantissaCompare(selfNormal,otherNormal)
         if selfNormal._isNegative == 1 {
             if comparison == .orderedDescending {
                 return .orderedAscending

--- a/Foundation/NSDecimal.swift
+++ b/Foundation/NSDecimal.swift
@@ -241,7 +241,7 @@ extension Decimal {
 extension Decimal : Hashable, Comparable {
     internal var doubleValue: Double {
         var d = 0.0
-        if _length == 0 && _isNegative == 0 {
+        if _length == 0 && _isNegative == 1 {
             return Double.nan
         }
         for i in 0..<8 {

--- a/Foundation/NSDecimalNumber.swift
+++ b/Foundation/NSDecimalNumber.swift
@@ -7,7 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
 /***************	Exceptions		***********/
 public struct NSExceptionName : RawRepresentable, Equatable, Hashable, Comparable {
     public private(set) var rawValue: String
@@ -443,7 +442,6 @@ open class NSDecimalNumberHandler : NSObject, NSDecimalNumberBehaviors, NSCoding
     }
 }
 
-
 extension NSNumber {
     
     public var decimalValue: Decimal {
@@ -455,10 +453,4 @@ extension NSNumber {
     }
 }
 
-// Could be silently inexact for float and double.
-
-extension Scanner {
-    
-    public func scanDecimal(_ dcm: UnsafeMutablePointer<Decimal>) -> Bool { NSUnimplemented() }
-}
 

--- a/Foundation/NSDecimalNumber.swift
+++ b/Foundation/NSDecimalNumber.swift
@@ -161,7 +161,12 @@ open class NSDecimalNumber : NSNumber {
         NSRequiresConcreteImplementation()
     }
     
-    open override func description(withLocale locale: Locale?) -> String { NSUnimplemented() }
+    open override func description(withLocale locale: Locale?) -> String {
+        guard locale == nil else {
+            fatalError("Locale not supported: \(locale!)")
+        }
+        return self.decimal.description
+    }
 
     open class var zero: NSDecimalNumber {
         return NSDecimalNumber(integerLiteral: 0)
@@ -261,8 +266,16 @@ open class NSDecimalNumber : NSNumber {
         return NSDecimalNumber(decimal: result)
     }
     
-    open func rounding(accordingToBehavior behavior: NSDecimalNumberBehaviors?) -> NSDecimalNumber { NSUnimplemented() }
     // Round to the scale of the behavior.
+    open func rounding(accordingToBehavior b: NSDecimalNumberBehaviors?) -> NSDecimalNumber {
+        var result = Decimal()
+        var input = self.decimal
+        let behavior = b ?? NSDecimalNumber.defaultBehavior
+        let roundingMode = behavior.roundingMode()
+        let scale = behavior.scale()
+        NSDecimalRound(&result, &input, Int(scale), roundingMode)
+        return NSDecimalNumber(decimal: result)
+    }
     
     // compare two NSDecimalNumbers
     open override func compare(_ decimalNumber: NSNumber) -> ComparisonResult {

--- a/TestFoundation/TestNSDecimal.swift
+++ b/TestFoundation/TestNSDecimal.swift
@@ -396,6 +396,8 @@ class TestNSDecimal: XCTestCase {
         XCTAssertTrue(NSDecimalIsNotANumber(&result), "NaN e4")
         XCTAssertNotEqual(.noError, NSDecimalMultiplyByPowerOf10(&result, &NaN, 5, .plain))
         XCTAssertTrue(NSDecimalIsNotANumber(&result), "NaN e5")
+
+        XCTAssertFalse(Double(NSDecimalNumber(decimal:Decimal(0))).isNaN)
     }
 
     func test_NegativeAndZeroMultiplication() {

--- a/TestFoundation/TestNSDecimal.swift
+++ b/TestFoundation/TestNSDecimal.swift
@@ -34,6 +34,7 @@ class TestNSDecimal: XCTestCase {
             ("test_PositivePowers", test_PositivePowers),
             ("test_RepeatingDivision", test_RepeatingDivision),
             ("test_Round", test_Round),
+            ("test_ScanDecimal", test_ScanDecimal),
             ("test_SimpleMultiplication", test_SimpleMultiplication),
             ("test_SmallerNumbers", test_SmallerNumbers),
             ("test_ZeroPower", test_ZeroPower),
@@ -559,6 +560,38 @@ class TestNSDecimal: XCTestCase {
             let result = numnum.rounding(accordingToBehavior:behavior)
             XCTAssertEqual(Double(expected), result.doubleValue)
         }
+    }
+
+    func test_ScanDecimal() {
+        let testCases = [
+            // expected, value
+            ( 123.456e78, "123.456e78" ),
+            ( -123.456e78, "-123.456e78" ),
+            ( 123.456, " 123.456 " ),
+            ( 3.14159, " 3.14159e0" ),
+            ( 3.14159, " 3.14159e-0" ),
+            ( 0.314159, " 3.14159e-1" ),
+            ( 3.14159, " 3.14159e+0" ),
+            ( 31.4159, " 3.14159e+1" ),
+            ( 12.34, " 01234e-02"),
+        ]
+        for testCase in testCases {
+            let (expected, string) = testCase
+            let decimal = Decimal(string:string)!
+            let aboutOne = Decimal(expected) / decimal
+            let approximatelyRight = aboutOne >= Decimal(0.99999) && aboutOne <= Decimal(1.00001)
+            XCTAssertTrue(approximatelyRight, "\(expected) ~= \(decimal) : \(aboutOne) \(aboutOne >= Decimal(0.99999)) \(aboutOne <= Decimal(1.00001))" )
+        }
+        guard let ones = Decimal(string:"111111111111111111111111111111111111111") else {
+            XCTFail("Unable to parse Decimal(string:'111111111111111111111111111111111111111')")
+            return
+        }
+        let num = ones / Decimal(9)
+        guard let answer = Decimal(string:"12345679012345679012345679012345679012.3") else {
+            XCTFail("Unable to parse Decimal(string:'12345679012345679012345679012345679012.3')")
+            return
+        }
+        XCTAssertEqual(answer,num,"\(ones) / 9 = \(answer) \(num)")
     }
 
     func test_SimpleMultiplication() {

--- a/TestFoundation/TestNSDecimal.swift
+++ b/TestFoundation/TestNSDecimal.swift
@@ -174,6 +174,8 @@ class TestNSDecimal: XCTestCase {
         XCTAssertEqual("-5", Decimal(signOf: Decimal(-3), magnitudeOf: Decimal(5)).description)
         XCTAssertEqual("5", Decimal(signOf: Decimal(3), magnitudeOf: Decimal(-5)).description)
         XCTAssertEqual("-5", Decimal(signOf: Decimal(-3), magnitudeOf: Decimal(-5)).description)
+        XCTAssertEqual("5", NSDecimalNumber(decimal:Decimal(5)).description)
+        XCTAssertEqual("-5", NSDecimalNumber(decimal:Decimal(-5)).description)
     }
 
     func test_ExplicitConstruction() {
@@ -552,6 +554,10 @@ class TestNSDecimal: XCTestCase {
             var num = Decimal(start)
             NSDecimalRound(&num, &num, scale, mode)
             XCTAssertEqual(Decimal(expected), num)
+            let numnum = NSDecimalNumber(decimal:Decimal(start))
+            let behavior = NSDecimalNumberHandler(roundingMode: mode, scale: Int16(scale), raiseOnExactness: false, raiseOnOverflow: true, raiseOnUnderflow: true, raiseOnDivideByZero: true)
+            let result = numnum.rounding(accordingToBehavior:behavior)
+            XCTAssertEqual(Double(expected), result.doubleValue)
         }
     }
 


### PR DESCRIPTION
This fixes a couple of bugs in NSDecimal that were exposed in the implementation of NSDecimalNumber, and implements the remainder of the functionality required in order to implement the NSDecimal.scan that allows strings to be converted to wider decimals.