### PR TITLE
Fix tests when running in Darwin

### DIFF
--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -389,14 +389,14 @@ class TestNSURL : XCTestCase {
             let result = url.resolvingSymlinksInPath().absoluteString
             XCTAssertEqual(result, "file:///private/")
         }
-        #endif
-        
+        #else
         do {
             let url = URL(fileURLWithPath: "/tmp/ABC/test_URLByResolvingSymlinksInPath")
             let result = url.resolvingSymlinksInPath().absoluteString
             XCTAssertEqual(result, "file:///tmp/ABC/test_URLByResolvingSymlinksInPath", "URLByResolvingSymlinksInPath appends trailing slash for existing directories only")
         }
-        
+        #endif
+
         do {
             let url = URL(fileURLWithPath: "/tmp/ABC/..")
             let result = url.resolvingSymlinksInPath().absoluteString


### PR DESCRIPTION
When running on Darwin, the /private/ is not stripped from the
URL and so the test fails. Change the logic so that this is only
run when running on Linux platforms.