### PR TITLE
Replacing error constant for empty NSData byte representation to a 32bit compatible value.

### DIFF
--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -220,7 +220,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         guard let bytePtr = CFDataGetBytePtr(_cfObject) else {
             //This could occure on empty data being encoded.
             //TODO: switch with nil when signature is fixed
-            return UnsafeRawPointer(bitPattern: 0xf00deadb0c0)! //would not result in 'nil unwrapped optional'
+            return UnsafeRawPointer(bitPattern: 0x7f00dead)! //would not result in 'nil unwrapped optional'
         }
         return UnsafeRawPointer(bytePtr)
     }


### PR DESCRIPTION
The return UnsafeRawPointer constant for empty Data objects added in #710 (discussed [here](https://github.com/apple/swift-corelibs-foundation/pull/710/commits/2c198bbad663a1387be2242fb1dd9df801e18805)) is breaking 32bit compilation.

This PR fixes the issue.