### PR TITLE
Build LDFLAGS overwrite issue

### DIFF
--- a/build.py
+++ b/build.py
@@ -477,7 +477,7 @@ foundation_tests = SwiftExecutable('TestFoundation', [
         'Foundation/ProgressFraction.swift',
 ] + glob.glob('./TestFoundation/Test*.swift')) # all TestSomething.swift are considered sources to the test project in the TestFoundation directory
 
-Configuration.current.extra_ld_flags = '-L'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src/.libs'
+Configuration.current.extra_ld_flags += ' -L'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src/.libs'
 
 foundation_tests.add_dependency(foundation_tests_resources)
 foundation.add_phase(foundation_tests_resources)


### PR DESCRIPTION
extra_ld_flags is overwritten in build.py

Appending the value should keep whatever value was passed at
configuration time.