### PR TITLE
Change type of threadDictionary objects to Any

### DIFF
--- a/Foundation/NSThread.swift
+++ b/Foundation/NSThread.swift
@@ -144,7 +144,7 @@ open class Thread : NSObject {
     internal var _status = _NSThreadStatus.initialized
     internal var _cancelled = false
     /// - Note: this differs from the Darwin implementation in that the keys must be Strings
-    open var threadDictionary = [String : AnyObject]()
+    open var threadDictionary = [String : Any]()
     
     internal init(thread: pthread_t) {
         // Note: even on Darwin this is a non-optional pthread_t; this is only used for valid threads, which are never null pointers.


### PR DESCRIPTION
On macOS the threadDictionary is an NSMutableDictionary, so the objects are of type Any. For consistency, it seems this should also use Any instead of AnyObject.

I stumbled upon this when looking at making [this Regex library](https://github.com/sharplet/Regex) work on Linux. [This particular line](https://github.com/sharplet/Regex/blob/27b3aab37a6935ef7370dd06b4e47e932621e94e/Source/Regex.swift#L147) along with [this one](https://github.com/sharplet/Regex/blob/27b3aab37a6935ef7370dd06b4e47e932621e94e/Source/ThreadLocal.swift#L27) fails because `MatchResult` is a `struct` so it cannot be converted to `AnyObject`.