### PR TITLE
SR-3385 and SR-3391: NumberFormatter - update default attributes for decimalStyle

### DIFF
--- a/Foundation/NSNumberFormatter.swift
+++ b/Foundation/NSNumberFormatter.swift
@@ -192,6 +192,12 @@ open class NumberFormatter : Formatter {
                 _usesGroupingSeparator = true
                 _minimumFractionDigits = 2
                 
+            case .decimal:
+                _usesSignificantDigits = false
+                _usesGroupingSeparator = true
+                _maximumFractionDigits = 3
+                _minimumIntegerDigits = 1
+                
             default:
                 _usesSignificantDigits = true
                 _usesGroupingSeparator = true

--- a/TestFoundation/TestNSNumberFormatter.swift
+++ b/TestFoundation/TestNSNumberFormatter.swift
@@ -198,8 +198,12 @@ class TestNSNumberFormatter: XCTestCase {
     func test_minimumIntegerDigits() {
         let numberFormatter = NumberFormatter()
         numberFormatter.minimumIntegerDigits = 3
-        let formattedString = numberFormatter.string(from: 0)
+        var formattedString = numberFormatter.string(from: 0)
         XCTAssertEqual(formattedString, "000")
+
+        numberFormatter.numberStyle = .decimal
+        formattedString = numberFormatter.string(from: 0.1)
+        XCTAssertEqual(formattedString, "0.1")        
     }
     
     func test_maximumIntegerDigits() {
@@ -375,8 +379,12 @@ class TestNSNumberFormatter: XCTestCase {
         let numberFormatter = NumberFormatter()
         numberFormatter.usesSignificantDigits = true
         numberFormatter.maximumSignificantDigits = 3
-        let formattedString = numberFormatter.string(from: 42.42424242)
+        var formattedString = numberFormatter.string(from: 42.42424242)
         XCTAssertEqual(formattedString, "42.4")
+        
+        numberFormatter.numberStyle = .decimal
+        formattedString = numberFormatter.string(from: 987654321)
+        XCTAssertEqual(formattedString, "987,654,321")
     }
 
     func test_stringFor() {


### PR DESCRIPTION
This PR addresses two issues that were recently raised while using the decimal style of NumberFormatter: [SR-3391](https://bugs.swift.org/browse/SR-3391) and [SR-3385](https://bugs.swift.org/browse/SR-3385). I found discrepancies in the behavior using Foundation vs what I observed in an Xcode Playground:
* The leading 0 in numbers was being dropped, as in .03 (vs 0.03 in the Playground).
* Large numbers like 987654321 were being formatted as 987,654,000 (vs 987,654,321 in the Playground).

I added a new case for `.decimal` that set attribute values to match what I observed in the NumberFormatter decimal style in the playground. I also added the above scenarios into existing test cases.