### PR TITLE
[LengthFormatter] Implementation of LengthFormatter and tests

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 		7900433B1CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790043391CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift */; };
 		7900433C1CACD33E00ECCBF1 /* TestNSPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900433A1CACD33E00ECCBF1 /* TestNSPredicate.swift */; };
 		AE35A1861CBAC85E0042DB84 /* SwiftFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = AE35A1851CBAC85E0042DB84 /* SwiftFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BDDAC2061E01907D00082132 /* TestNSLengthFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAC2051E01907D00082132 /* TestNSLengthFormatter.swift */; };
 		BF8E65311DC3B3CB005AB5C3 /* TestNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8E65301DC3B3CB005AB5C3 /* TestNotification.swift */; };
 		CC5249C01D341D23007CB54D /* TestUnitConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5249BF1D341D23007CB54D /* TestUnitConverter.swift */; };
 		CE19A88C1C23AA2300B4CB6A /* NSStringTestData.txt in Resources */ = {isa = PBXBuildFile; fileRef = CE19A88B1C23AA2300B4CB6A /* NSStringTestData.txt */; };
@@ -749,6 +750,7 @@
 		88D28DE61C13AE9000494606 /* TestNSGeometry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSGeometry.swift; sourceTree = "<group>"; };
 		A5A34B551C18C85D00FD972B /* TestNSByteCountFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSByteCountFormatter.swift; sourceTree = "<group>"; };
 		AE35A1851CBAC85E0042DB84 /* SwiftFoundation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwiftFoundation.h; sourceTree = "<group>"; };
+		BDDAC2051E01907D00082132 /* TestNSLengthFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSLengthFormatter.swift; sourceTree = "<group>"; };
 		BF8E65301DC3B3CB005AB5C3 /* TestNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNotification.swift; sourceTree = "<group>"; };
 		C2A9D75B1C15C08B00993803 /* TestNSUUID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSUUID.swift; sourceTree = "<group>"; };
 		C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSAffineTransform.swift; sourceTree = "<group>"; };
@@ -1347,6 +1349,7 @@
 				5EB6A15C1C188FC40037DCB8 /* TestNSJSONSerialization.swift */,
 				D3A597F11C33C68E00295652 /* TestNSKeyedArchiver.swift */,
 				D3A597EF1C33A9E500295652 /* TestNSKeyedUnarchiver.swift */,
+				BDDAC2051E01907D00082132 /* TestNSLengthFormatter.swift */,
 				61A395F91C2484490029B337 /* TestNSLocale.swift */,
 				61F8AE7C1C180FC600FB62F0 /* TestNSNotificationCenter.swift */,
 				5EF673AB1C28B527006212A3 /* TestNSNotificationQueue.swift */,
@@ -2219,6 +2222,7 @@
 				5B13B32E1C582D4C00651CE2 /* TestNSFileManager.swift in Sources */,
 				5B13B3381C582D4C00651CE2 /* TestNSNotificationQueue.swift in Sources */,
 				CC5249C01D341D23007CB54D /* TestUnitConverter.swift in Sources */,
+				BDDAC2061E01907D00082132 /* TestNSLengthFormatter.swift in Sources */,
 				5B13B3331C582D4C00651CE2 /* TestNSJSONSerialization.swift in Sources */,
 				5B13B33C1C582D4C00651CE2 /* TestNSOrderedSet.swift in Sources */,
 				5B13B34A1C582D4C00651CE2 /* TestNSURL.swift in Sources */,

--- a/Foundation/NSLengthFormatter.swift
+++ b/Foundation/NSLengthFormatter.swift
@@ -7,25 +7,35 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
 extension LengthFormatter {
-    public enum Unit : Int {
-        
-        case millimeter
-        case centimeter
-        case meter
-        case kilometer
-        case inch
-        case foot
-        case yard
-        case mile
+    public enum Unit: Int {
+        case millimeter = 8
+        case centimeter = 9
+        case meter = 11
+        case kilometer = 14
+        case inch = 1281
+        case foot = 1282
+        case yard = 1283
+        case mile = 1284
     }
 }
 
 open class LengthFormatter : Formatter {
     
+    public override init() {
+        numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        unitStyle = .medium
+        isForPersonHeightUse = false
+        super.init()
+    }
+    
     public required init?(coder: NSCoder) {
-        NSUnimplemented()
+        numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        unitStyle = .medium
+        isForPersonHeightUse = false
+        super.init(coder:coder)
     }
     
     /*@NSCopying*/ open var numberFormatter: NumberFormatter! // default is NSNumberFormatter with NSNumberFormatterDecimalStyle
@@ -34,20 +44,183 @@ open class LengthFormatter : Formatter {
     open var isForPersonHeightUse: Bool // default is NO; if it is set to YES, the number argument for -stringFromMeters: and -unitStringFromMeters: is considered as a person's height
     
     // Format a combination of a number and an unit to a localized string.
-    open func string(fromValue value: Double, unit: LengthFormatter.Unit) -> String { NSUnimplemented() }
+    open func string(fromValue value: Double, unit: LengthFormatter.Unit) -> String {
+        guard let formattedValue = numberFormatter.string(from:NSNumber(value: value)) else {
+            fatalError("Cannot format \(value) as string")
+        }
+        let separator = unitStyle == LengthFormatter.UnitStyle.short ? "" : " "
+        return "\(formattedValue)\(separator)\(unitString(fromValue: value, unit: unit))"
+    }
     
     // Format a number in meters to a localized string with the locale-appropriate unit and an appropriate scale (e.g. 4.3m = 14.1ft in the US locale).
-    open func string(fromMeters numberInMeters: Double) -> String { NSUnimplemented() }
+    open func string(fromMeters numberInMeters: Double) -> String {
+        //Convert to the locale-appropriate unit
+        let unitFromMeters = unit(fromMeters: numberInMeters)
+        
+        //Map the unit to UnitLength type for conversion later
+        let unitLengthFromMeters = LengthFormatter.unitLength[unitFromMeters]!
+        
+        //Create a measurement object based on the value in meters
+        let meterMeasurement = Measurement<UnitLength>(value:numberInMeters, unit: .meters)
+        
+        //Convert the object to the locale-appropriate unit determined above
+        let unitMeasurement = meterMeasurement.converted(to: unitLengthFromMeters)
+        
+        //Extract the number from the measurement
+        let numberInUnit = unitMeasurement.value
+        
+        if isForPersonHeightUse && !LengthFormatter.isMetricSystemLocale(numberFormatter.locale) {
+            let feet = numberInUnit.rounded(.towardZero)
+            let feetString = string(fromValue: feet, unit: .foot)
+            
+            let inches = abs(numberInUnit.truncatingRemainder(dividingBy: 1.0)) * 12
+            let inchesString = string(fromValue: inches, unit: .inch)
+            
+            return ("\(feetString), \(inchesString)")
+        }
+        return string(fromValue: numberInUnit, unit: unitFromMeters)
+    }
     
     // Return a localized string of the given unit, and if the unit is singular or plural is based on the given number.
-    open func unitString(fromValue value: Double, unit: Unit) -> String { NSUnimplemented() }
+    open func unitString(fromValue value: Double, unit: Unit) -> String {
+        if unitStyle == .short {
+            return LengthFormatter.shortSymbol[unit]!
+        } else if unitStyle == .medium {
+            return LengthFormatter.mediumSymbol[unit]!
+        } else if value == 1.0 {
+            return LengthFormatter.largeSingularSymbol[unit]!
+        } else {
+            return LengthFormatter.largePluralSymbol[unit]!
+        }
+    }
     
     // Return the locale-appropriate unit, the same unit used by -stringFromMeters:.
-    open func unitString(fromMeters numberInMeters: Double, usedUnit unitp: UnsafeMutablePointer<Unit>?) -> String { NSUnimplemented() }
+    open func unitString(fromMeters numberInMeters: Double, usedUnit unitp: UnsafeMutablePointer<Unit>?) -> String {
+        
+        //Convert to the locale-appropriate unit
+        let unitFromMeters = unit(fromMeters: numberInMeters)
+        unitp?.pointee = unitFromMeters
+        
+        //Map the unit to UnitLength type for conversion later
+        let unitLengthFromMeters = LengthFormatter.unitLength[unitFromMeters]!
+        
+        //Create a measurement object based on the value in meters
+        let meterMeasurement = Measurement<UnitLength>(value:numberInMeters, unit: .meters)
+        
+        //Convert the object to the locale-appropriate unit determined above
+        let unitMeasurement = meterMeasurement.converted(to: unitLengthFromMeters)
+        
+        //Extract the number from the measurement
+        let numberInUnit = unitMeasurement.value
+        
+        //Return the appropriate representation of the unit based on the selected unit style
+        return unitString(fromValue: numberInUnit, unit: unitFromMeters)
+    }
+    
+    /// This method selects the appropriate unit based on the formatter’s locale,
+    /// the magnitude of the value, and isForPersonHeightUse property.
+    ///
+    /// - Parameter numberInMeters: the magnitude in terms of meters
+    /// - Returns: Returns the appropriate unit
+    private func unit(fromMeters numberInMeters: Double) -> Unit {
+        if LengthFormatter.isMetricSystemLocale(numberFormatter.locale) {
+            //Person height is always returned in cm for metric system
+            if isForPersonHeightUse { return .centimeter }
+            
+            if numberInMeters > 1000 || numberInMeters < 0.0 {
+                return .kilometer
+            } else if numberInMeters > 1.0 {
+                return .meter
+            } else if numberInMeters > 0.01 {
+                return .centimeter
+            } else { return .millimeter }
+        } else {
+            //Person height is always returned in ft for U.S. system
+            if isForPersonHeightUse { return .foot }
+            
+            let metricMeasurement = Measurement<UnitLength>(value:numberInMeters, unit: .meters)
+            let usMeasurement = metricMeasurement.converted(to: .feet)
+            let numberInFeet = usMeasurement.value
+            
+            if numberInFeet < 0.0 || numberInFeet > 5280 {
+                return .mile
+            } else if numberInFeet > 3 || numberInFeet == 0.0 {
+                return .yard
+            } else if numberInFeet >= 1.0 {
+                return .foot
+            } else { return .inch }
+        }
+    }
+    
+    /// TODO: Replace calls to the below function to use Locale.usesMetricSystem
+    /// Temporary workaround due to unpopulated Locale attributes
+    /// See https://bugs.swift.org/browse/SR-3202
+    private static func isMetricSystemLocale(_ locale: Locale) -> Bool {
+        switch locale.identifier {
+        case "en_US": return false
+        case "en_US_POSIX": return false
+        case "haw_US": return false
+        case "es_US": return false
+        case "chr_US": return false
+        case "my_MM": return false
+        case "en_LR": return false
+        case "vai_LR": return false
+        default: return true
+        }
+    }
     
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
     open override func objectValue(_ string: String) throws -> Any? { return nil }
+    
+    
+    /// Maps NSLengthFormatter.Unit enum to UnitLength class. Used for measurement conversion.
+    private static let unitLength: [Unit:UnitLength] = [.millimeter:.millimeters,
+                                                 .centimeter:.centimeters,
+                                                 .meter:.meters,
+                                                 .kilometer:.kilometers,
+                                                 .inch:.inches,
+                                                 .foot:.feet,
+                                                 .yard:.yards,
+                                                 .mile:.miles]
+
+    /// Maps a unit to its short symbol. Reuses strings from UnitLength wherever possible.
+    private static let shortSymbol: [Unit: String] = [.millimeter:UnitLength.millimeters.symbol,
+                                                   .centimeter:UnitLength.centimeters.symbol,
+                                                   .meter:UnitLength.meters.symbol,
+                                                   .kilometer:UnitLength.kilometers.symbol,
+                                                   .inch:"\"",
+                                                   .foot:"′",
+                                                   .yard:UnitLength.yards.symbol,
+                                                   .mile:UnitLength.miles.symbol]
+    
+    /// Maps a unit to its medium symbol. Reuses strings from UnitLength.
+    private static let mediumSymbol: [Unit: String] = [.millimeter:UnitLength.millimeters.symbol,
+                                                    .centimeter:UnitLength.centimeters.symbol,
+                                                    .meter:UnitLength.meters.symbol,
+                                                    .kilometer:UnitLength.kilometers.symbol,
+                                                    .inch:UnitLength.inches.symbol,
+                                                    .foot:UnitLength.feet.symbol,
+                                                    .yard:UnitLength.yards.symbol,
+                                                    .mile:UnitLength.miles.symbol]
+    
+    /// Maps a unit to its large, singular symbol.
+    private static let largeSingularSymbol: [Unit: String] = [.millimeter:"millimeter",
+                                                           .centimeter:"centimeter",
+                                                           .meter:"meter",
+                                                           .kilometer:"kilometer",
+                                                           .inch:"inch",
+                                                           .foot:"foot",
+                                                           .yard:"yard",
+                                                           .mile:"mile"]
+    
+    /// Maps a unit to its large, plural symbol.
+    private static let largePluralSymbol: [Unit: String] = [.millimeter:"millimeters",
+                                                         .centimeter:"centimeters",
+                                                         .meter:"meters",
+                                                         .kilometer:"kilometers",
+                                                         .inch:"inches",
+                                                         .foot:"feet",
+                                                         .yard:"yards",
+                                                         .mile:"miles"]
 }
-
-

--- a/TestFoundation/TestNSLengthFormatter.swift
+++ b/TestFoundation/TestNSLengthFormatter.swift
@@ -1,0 +1,178 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+class TestNSLengthFormatter: XCTestCase {
+    let formatter: LengthFormatter = LengthFormatter()
+    
+    static var allTests: [(String, (TestNSLengthFormatter) -> () throws -> Void)] {
+        return [
+            ("test_stringFromMetersUS", test_stringFromMetersUS),
+            ("test_stringFromMetersUSPersonHeight", test_stringFromMetersUSPersonHeight),
+            ("test_stringFromMetersMetric", test_stringFromMetersMetric),
+            ("test_stringFromMetersMetricPersonHeight", test_stringFromMetersMetricPersonHeight),
+            ("test_stringFromValue", test_stringFromValue),
+            ("test_unitStringFromMeters", test_unitStringFromMeters),
+            ("test_unitStringFromValue", test_unitStringFromValue)
+        ]
+    }
+
+    override func setUp() {
+        formatter.numberFormatter.locale = Locale(identifier: "en_US")
+        formatter.isForPersonHeightUse = false
+        super.setUp()
+    }
+    
+    func test_stringFromMetersUS() {
+        XCTAssertEqual(formatter.string(fromMeters:-100000), "-62.137 mi")
+        XCTAssertEqual(formatter.string(fromMeters: -1), "-0.001 mi")
+        XCTAssertEqual(formatter.string(fromMeters: 0.00001), "0 in")
+        XCTAssertEqual(formatter.string(fromMeters: 0.0001), "0.004 in")
+        XCTAssertEqual(formatter.string(fromMeters: 0.001), "0.039 in")
+        XCTAssertEqual(formatter.string(fromMeters: 0.01), "0.394 in")
+        XCTAssertEqual(formatter.string(fromMeters: 0.1), "3.937 in")
+        XCTAssertEqual(formatter.string(fromMeters: 1), "1.094 yd")
+        XCTAssertEqual(formatter.string(fromMeters: 10), "10.936 yd")
+        XCTAssertEqual(formatter.string(fromMeters: 10000), "6.214 mi")
+        XCTAssertEqual(formatter.string(fromMeters: 1000000), "621.373 mi")
+        XCTAssertEqual(formatter.string(fromMeters: 10000000), "6,213.727 mi")
+        XCTAssertEqual(formatter.string(fromMeters: 100000000), "62,137.274 mi")
+    }
+    
+    func test_stringFromMetersUSPersonHeight() {
+        formatter.isForPersonHeightUse = true
+        XCTAssertEqual(formatter.string(fromMeters: -100000), "-328,083 ft, 11.874 in")
+        XCTAssertEqual(formatter.string(fromMeters: -1), "-3 ft, 3.37 in")
+        XCTAssertEqual(formatter.string(fromMeters: 0.00001), "0 ft, 0 in")
+        XCTAssertEqual(formatter.string(fromMeters: 0.0001), "0 ft, 0.004 in")
+        XCTAssertEqual(formatter.string(fromMeters: 0.001), "0 ft, 0.039 in")
+        XCTAssertEqual(formatter.string(fromMeters: 0.01), "0 ft, 0.394 in")
+        XCTAssertEqual(formatter.string(fromMeters: 0.1), "0 ft, 3.937 in")
+        XCTAssertEqual(formatter.string(fromMeters: 1), "3 ft, 3.37 in")
+        XCTAssertEqual(formatter.string(fromMeters: 10), "32 ft, 9.701 in")
+        XCTAssertEqual(formatter.string(fromMeters: 100000000), "328,083,989 ft, 6.016 in")
+    }
+    
+    func test_stringFromMetersMetric() {
+        formatter.numberFormatter.locale = Locale(identifier: "en_UK")
+        XCTAssertEqual(formatter.string(fromMeters: -10000), "-10 km")
+        XCTAssertEqual(formatter.string(fromMeters: -1), "-0.001 km")
+        XCTAssertEqual(formatter.string(fromMeters: 0.00001), "0.01 mm")
+        XCTAssertEqual(formatter.string(fromMeters: 0.0001), "0.1 mm")
+        XCTAssertEqual(formatter.string(fromMeters: 0.001), "1 mm")
+        XCTAssertEqual(formatter.string(fromMeters: 0.01), "10 mm")
+        XCTAssertEqual(formatter.string(fromMeters: 0.1), "10 cm")
+        XCTAssertEqual(formatter.string(fromMeters: 0.5), "50 cm")
+        XCTAssertEqual(formatter.string(fromMeters: 1), "100 cm")
+        XCTAssertEqual(formatter.string(fromMeters: 10), "10 m")
+        XCTAssertEqual(formatter.string(fromMeters: 10000), "10 km")
+        XCTAssertEqual(formatter.string(fromMeters: 1000000), "1,000 km")
+        XCTAssertEqual(formatter.string(fromMeters: 10000000), "10,000 km")
+        XCTAssertEqual(formatter.string(fromMeters: 100000000), "100,000 km")
+    }
+    
+    func test_stringFromMetersMetricPersonHeight() {
+        formatter.numberFormatter.locale = Locale(identifier: "en_UK")
+        formatter.isForPersonHeightUse = true
+        XCTAssertEqual(formatter.string(fromMeters: -1), "-100 cm")
+        XCTAssertEqual(formatter.string(fromMeters: 0.001), "0.1 cm")
+        XCTAssertEqual(formatter.string(fromMeters: 0.1), "10 cm")
+        XCTAssertEqual(formatter.string(fromMeters: 10), "1,000 cm")
+        XCTAssertEqual(formatter.string(fromMeters: 1000000), "100,000,000 cm")
+    }
+    
+    func test_stringFromValue() {
+        formatter.unitStyle = Formatter.UnitStyle.long
+        //Commented out due to [SR-3391] which causes NumberFormatter to strip leading integer 0
+        //XCTAssertEqual(formatter.string(fromValue: 0.002, unit: LengthFormatter.Unit.millimeter),"0.002 millimeters")
+        XCTAssertEqual(formatter.string(fromValue:0, unit:LengthFormatter.Unit.centimeter), "0 centimeters")
+        
+        formatter.unitStyle = Formatter.UnitStyle.short
+        XCTAssertEqual(formatter.string(fromValue: 0.00000001, unit:LengthFormatter.Unit.foot), "0′")
+        XCTAssertEqual(formatter.string(fromValue: 2.4, unit: LengthFormatter.Unit.inch), "2.4\"")
+        XCTAssertEqual(formatter.string(fromValue: 123456, unit: LengthFormatter.Unit.yard), "123,456yd")
+        
+        formatter.unitStyle = Formatter.UnitStyle.medium
+        formatter.isForPersonHeightUse = true
+        XCTAssertEqual(formatter.string(fromValue: 0.00000001, unit: LengthFormatter.Unit.foot), "0 ft")
+        XCTAssertEqual(formatter.string(fromValue: 987654321, unit: LengthFormatter.Unit.yard), "987,654,321 yd")
+        
+        formatter.isForPersonHeightUse = false
+        XCTAssertEqual(formatter.string(fromValue: 5.3, unit: LengthFormatter.Unit.millimeter), "5.3 mm")
+        XCTAssertEqual(formatter.string(fromValue: 873.2345, unit: LengthFormatter.Unit.centimeter), "873.234 cm")
+    }
+    
+    func test_unitStringFromMeters() {
+        var unit = LengthFormatter.Unit.meter
+        XCTAssertEqual(formatter.unitString(fromMeters: -100000, usedUnit: &unit), "mi")
+        XCTAssertEqual(unit, LengthFormatter.Unit.mile)
+        
+        XCTAssertEqual(formatter.unitString(fromMeters: -1, usedUnit: &unit), "mi")
+        XCTAssertEqual(unit, LengthFormatter.Unit.mile)
+        
+        XCTAssertEqual(formatter.unitString(fromMeters: 0.00001, usedUnit: &unit), "in")
+        XCTAssertEqual(unit, LengthFormatter.Unit.inch)
+        
+        XCTAssertEqual(formatter.unitString(fromMeters: 0.0001, usedUnit: &unit), "in")
+        XCTAssertEqual(unit, LengthFormatter.Unit.inch)
+        
+        XCTAssertEqual(formatter.unitString(fromMeters: 0.001, usedUnit: &unit), "in")
+        XCTAssertEqual(unit, LengthFormatter.Unit.inch)
+        
+        XCTAssertEqual(formatter.unitString(fromMeters: 0.01, usedUnit: &unit), "in")
+        XCTAssertEqual(unit, LengthFormatter.Unit.inch)
+        
+        XCTAssertEqual(formatter.unitString(fromMeters: 0.1, usedUnit: &unit), "in")
+        XCTAssertEqual(unit, LengthFormatter.Unit.inch)
+        
+        XCTAssertEqual(formatter.unitString(fromMeters: 1, usedUnit: &unit), "yd")
+        XCTAssertEqual(unit, LengthFormatter.Unit.yard)
+        
+        XCTAssertEqual(formatter.unitString(fromMeters: 10, usedUnit: &unit), "yd")
+        XCTAssertEqual(unit, LengthFormatter.Unit.yard)
+        
+        XCTAssertEqual(formatter.unitString(fromMeters: 10000, usedUnit: &unit), "mi")
+        XCTAssertEqual(unit, LengthFormatter.Unit.mile)
+        
+        XCTAssertEqual(formatter.unitString(fromMeters: 1000000, usedUnit: &unit),"mi")
+        XCTAssertEqual(unit, LengthFormatter.Unit.mile)
+        
+        XCTAssertEqual(formatter.unitString(fromMeters: 10000000, usedUnit: &unit), "mi")
+        XCTAssertEqual(unit, LengthFormatter.Unit.mile)
+        
+        XCTAssertEqual(formatter.unitString(fromMeters: 100000000, usedUnit: &unit), "mi")
+        XCTAssertEqual(unit, LengthFormatter.Unit.mile)
+    }
+    
+    func test_unitStringFromValue() {
+        formatter.unitStyle = Formatter.UnitStyle.long
+        XCTAssertEqual(formatter.unitString(fromValue: 0.002, unit: LengthFormatter.Unit.millimeter), "millimeters")
+        XCTAssertEqual(formatter.unitString(fromValue: 0, unit: LengthFormatter.Unit.centimeter), "centimeters")
+        
+        formatter.unitStyle = Formatter.UnitStyle.short
+        XCTAssertEqual(formatter.unitString(fromValue: 0.00000001, unit: LengthFormatter.Unit.foot), "′")
+        XCTAssertEqual(formatter.unitString(fromValue: 123456, unit: LengthFormatter.Unit.yard), "yd")
+        
+        formatter.unitStyle = Formatter.UnitStyle.medium
+        formatter.isForPersonHeightUse = true
+        XCTAssertEqual(formatter.unitString(fromValue: 0.00000001, unit: LengthFormatter.Unit.foot), "ft")
+        XCTAssertEqual(formatter.unitString(fromValue: 987654321, unit: LengthFormatter.Unit.yard), "yd")
+        
+        formatter.isForPersonHeightUse = false
+        XCTAssertEqual(formatter.unitString(fromValue: 5.3, unit: LengthFormatter.Unit.millimeter), "mm")
+        XCTAssertEqual(formatter.unitString(fromValue: 873.2345, unit: LengthFormatter.Unit.centimeter), "cm")
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -42,6 +42,7 @@ XCTMain([
     testCase(TestNSJSONSerialization.allTests),
     testCase(TestNSKeyedArchiver.allTests),
     testCase(TestNSKeyedUnarchiver.allTests),
+    testCase(TestNSLengthFormatter.allTests),
     testCase(TestNSLocale.allTests),
     testCase(TestNSNotificationCenter.allTests),
     testCase(TestNSNotificationQueue.allTests),


### PR DESCRIPTION
- Implementation of all unimplemented functions in `NSLengthFormatter.swift`
- Test cases covering all functions, including paths for US, metric system, and `isForPersonHeightUse`
- Includes workaround for [issue](https://bugs.swift.org/browse/SR-3202) in which Locale attributes are not populated
