### PR TITLE
[NSPersonNameComponents] Implementation of copy() and test

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 		7900433B1CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790043391CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift */; };
 		7900433C1CACD33E00ECCBF1 /* TestNSPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900433A1CACD33E00ECCBF1 /* TestNSPredicate.swift */; };
 		AE35A1861CBAC85E0042DB84 /* SwiftFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = AE35A1851CBAC85E0042DB84 /* SwiftFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BDFDF0A71DFF5B3E00C04CC5 /* TestNSPersonNameComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFDF0A61DFF5B3E00C04CC5 /* TestNSPersonNameComponents.swift */; };
 		BF8E65311DC3B3CB005AB5C3 /* TestNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8E65301DC3B3CB005AB5C3 /* TestNotification.swift */; };
 		CC5249C01D341D23007CB54D /* TestUnitConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5249BF1D341D23007CB54D /* TestUnitConverter.swift */; };
 		CE19A88C1C23AA2300B4CB6A /* NSStringTestData.txt in Resources */ = {isa = PBXBuildFile; fileRef = CE19A88B1C23AA2300B4CB6A /* NSStringTestData.txt */; };
@@ -749,6 +750,7 @@
 		88D28DE61C13AE9000494606 /* TestNSGeometry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSGeometry.swift; sourceTree = "<group>"; };
 		A5A34B551C18C85D00FD972B /* TestNSByteCountFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSByteCountFormatter.swift; sourceTree = "<group>"; };
 		AE35A1851CBAC85E0042DB84 /* SwiftFoundation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwiftFoundation.h; sourceTree = "<group>"; };
+		BDFDF0A61DFF5B3E00C04CC5 /* TestNSPersonNameComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSPersonNameComponents.swift; sourceTree = "<group>"; };
 		BF8E65301DC3B3CB005AB5C3 /* TestNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNotification.swift; sourceTree = "<group>"; };
 		C2A9D75B1C15C08B00993803 /* TestNSUUID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSUUID.swift; sourceTree = "<group>"; };
 		C93559281C12C49F009FD6A9 /* TestNSAffineTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSAffineTransform.swift; sourceTree = "<group>"; };
@@ -1387,6 +1389,7 @@
 				5B1FD9E21D6D17B80080E83C /* TestNSURLSession.swift */,
 				EA54A6FA1DB16D53009E0809 /* TestObjCRuntime.swift */,
 				BF8E65301DC3B3CB005AB5C3 /* TestNotification.swift */,
+				BDFDF0A61DFF5B3E00C04CC5 /* TestNSPersonNameComponents.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -2262,6 +2265,7 @@
 				5B13B3441C582D4C00651CE2 /* TestNSSet.swift in Sources */,
 				5B13B3321C582D4C00651CE2 /* TestNSIndexSet.swift in Sources */,
 				5B13B3511C582D4C00651CE2 /* TestNSByteCountFormatter.swift in Sources */,
+				BDFDF0A71DFF5B3E00C04CC5 /* TestNSPersonNameComponents.swift in Sources */,
 				5B13B3501C582D4C00651CE2 /* TestUtils.swift in Sources */,
 				294E3C1D1CC5E19300E4F44C /* TestNSAttributedString.swift in Sources */,
 				5B13B3431C582D4C00651CE2 /* TestNSScanner.swift in Sources */,

--- a/Foundation/NSPersonNameComponents.swift
+++ b/Foundation/NSPersonNameComponents.swift
@@ -44,7 +44,26 @@ open class NSPersonNameComponents : NSObject, NSCopying, NSSecureCoding {
         aCoder.encode(self.nickname?._bridgeToObjectiveC(), forKey: "NS.nickname")
     }
     
-    open func copy(with zone: NSZone? = nil) -> Any { NSUnimplemented() }
+    open func copy(with zone: NSZone? = nil) -> Any {
+        let copy = NSPersonNameComponents()
+        copy.namePrefix = namePrefix
+        copy.givenName = givenName
+        copy.middleName = middleName
+        copy.familyName = familyName
+        copy.nameSuffix = nameSuffix
+        copy.nickname = nickname
+        if let PR = phoneticRepresentation {
+            var copyPR = PersonNameComponents()
+            copyPR.namePrefix = PR.namePrefix
+            copyPR.givenName = PR.givenName
+            copyPR.middleName = PR.middleName
+            copyPR.familyName = PR.familyName
+            copyPR.nameSuffix = PR.nameSuffix
+            copyPR.nickname = PR.nickname
+            copy.phoneticRepresentation = copyPR
+        }
+        return copy
+    }
     
     /* The below examples all assume the full name Dr. Johnathan Maple Appleseed Esq., nickname "Johnny" */
     

--- a/TestFoundation/TestNSPersonNameComponents.swift
+++ b/TestFoundation/TestNSPersonNameComponents.swift
@@ -1,0 +1,44 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+
+
+class TestNSPersonNameComponents : XCTestCase {
+    
+    static var allTests: [(String, (TestNSPersonNameComponents) -> () throws -> Void)] {
+        return [
+            ("testCopy", testCopy),
+        ]
+    }
+    
+    func testCopy() {
+        let original = NSPersonNameComponents()
+        original.givenName = "Maria"
+        original.phoneticRepresentation = PersonNameComponents()
+        original.phoneticRepresentation!.givenName = "Jeff"
+        let copy = original.copy(with:nil) as! NSPersonNameComponents
+        copy.givenName = "Rebecca"
+        
+        XCTAssertNotEqual(original.givenName, copy.givenName)
+        XCTAssertEqual(original.phoneticRepresentation!.givenName,copy.phoneticRepresentation!.givenName)
+        XCTAssertNil(copy.phoneticRepresentation!.phoneticRepresentation)
+    }
+}
+
+        

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -50,6 +50,7 @@ XCTMain([
     testCase(TestNSNumberFormatter.allTests),
     testCase(TestNSOperationQueue.allTests),
     testCase(TestNSOrderedSet.allTests),
+    testCase(TestNSPersonNameComponents.allTests),
     testCase(TestNSPipe.allTests),
     testCase(TestNSPredicate.allTests),
     testCase(TestNSProcessInfo.allTests),


### PR DESCRIPTION
- Followed pattern of `NSCalendar.swift`
- Ignored `zone` parameter, which appears to be the pattern across Foundation classes
