### PR TITLE
Cast a function argument in order to disambiguate the intended overload.

### DIFF
--- a/Foundation/NSCFSet.swift
+++ b/Foundation/NSCFSet.swift
@@ -41,7 +41,7 @@ internal final class _NSCFSet : NSMutableSet {
         guard let value = CFSetGetValue(_cfObject, unsafeBitCast(_SwiftValue.store(object), to: UnsafeRawPointer.self)) else {
             return nil
         }
-        return _SwiftValue.fetch(unsafeBitCast(value, to: AnyObject.self))
+        return _SwiftValue.fetch(unsafeBitCast(value, to: AnyObject.self) as AnyObject?)
         
     }
     


### PR DESCRIPTION
An upcoming change in the type checker will result in this call to
fetch() becoming ambiguous, so we need to explicitly cast the argument
to make it unambiguous.

The overloads for fetch are:
  fetch(_ object: AnyObject?) -> Any?
  fetch(_ object: AnyObject) -> Any

but the current call here is taking an AnyObject and returning it as an
Any? which means that both overload options would result in a
value-to-optional conversion. A current quick of the type checker
disambiguates this by chosing the version that returns an optional, but
that quirk will go away (at least under -swift-version 4).