### PR TITLE
Fix another case of potential overload ambiguity.

### DIFF
--- a/Foundation/NSCFDictionary.swift
+++ b/Foundation/NSCFDictionary.swift
@@ -39,7 +39,7 @@ internal final class _NSCFDictionary : NSMutableDictionary {
     override func object(forKey aKey: Any) -> Any? {
         let value = CFDictionaryGetValue(_cfObject, unsafeBitCast(_SwiftValue.store(aKey), to: UnsafeRawPointer.self))
         if value != nil {
-            return _SwiftValue.fetch(unsafeBitCast(value, to: AnyObject.self))
+            return _SwiftValue.fetch(unsafeBitCast(value, to: AnyObject.self) as AnyObject?)
         } else {
             return nil
         }


### PR DESCRIPTION
Apply the same fix that went into
d9cdc7ecdb91fdfd738b7347c69a6fa3b6d5d2be to another location.

After an upcoming type checker change the previous code would be
considered ambiguous.