### PR TITLE
Use an argument label to disambiguate calls to _SwiftValue.fetch.

### DIFF
--- a/Foundation/Bridging.swift
+++ b/Foundation/Bridging.swift
@@ -77,12 +77,12 @@ internal final class _SwiftValue : NSObject, NSCopying {
     
     static func fetch(_ object: AnyObject?) -> Any? {
         if let obj = object {
-            return fetch(obj)
+            return fetch(nonOptional: obj)
         }
         return nil
     }
     
-    static func fetch(_ object: AnyObject) -> Any {
+    static func fetch(nonOptional object: AnyObject) -> Any {
         if let container = object as? _SwiftValue {
             return container.value
         } else if let val = object as? _StructBridgeable {

--- a/Foundation/Dictionary.swift
+++ b/Foundation/Dictionary.swift
@@ -65,8 +65,8 @@ extension Dictionary : _ObjectTypeBridgeable {
             CFDictionaryGetKeysAndValues(cf, keys, values)
 
             for idx in 0..<cnt {
-                let key = _SwiftValue.fetch(unsafeBitCast(keys.advanced(by: idx).pointee!, to: AnyObject.self))
-                let value = _SwiftValue.fetch(unsafeBitCast(values.advanced(by: idx).pointee!, to: AnyObject.self))
+                let key = _SwiftValue.fetch(nonOptional: unsafeBitCast(keys.advanced(by: idx).pointee!, to: AnyObject.self))
+                let value = _SwiftValue.fetch(nonOptional: unsafeBitCast(values.advanced(by: idx).pointee!, to: AnyObject.self))
                 guard let k = key as? Key, let v = value as? Value else {
                     failedConversion = true
                     break

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -24,7 +24,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         guard type(of: self) === NSArray.self || type(of: self) === NSMutableArray.self else {
            NSRequiresConcreteImplementation()
         }
-        return _SwiftValue.fetch(_storage[index])
+        return _SwiftValue.fetch(nonOptional: _storage[index])
     }
     
     public convenience override init() {
@@ -151,7 +151,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
 
     internal var allObjects: [Any] {
         if type(of: self) === NSArray.self || type(of: self) === NSMutableArray.self {
-            return _storage.map { _SwiftValue.fetch($0) }
+            return _storage.map { _SwiftValue.fetch(nonOptional: $0) }
         } else {
             return (0..<count).map { idx in
                 return self[idx]
@@ -226,7 +226,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         for idx in 0..<count {
             let item = _SwiftValue.store(self[idx])
             if set.contains(item) {
-                return _SwiftValue.fetch(item)
+                return _SwiftValue.fetch(nonOptional: item)
             }
         }
         return nil
@@ -236,7 +236,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         objects.reserveCapacity(objects.count + range.length)
 
         if type(of: self) === NSArray.self || type(of: self) === NSMutableArray.self {
-            objects += _storage[range.toRange()!].map { _SwiftValue.fetch($0) }
+            objects += _storage[range.toRange()!].map { _SwiftValue.fetch(nonOptional: $0) }
             return
         }
         

--- a/Foundation/NSCFArray.swift
+++ b/Foundation/NSCFArray.swift
@@ -34,7 +34,7 @@ internal final class _NSCFArray : NSMutableArray {
     
     override func object(at index: Int) -> Any {
         let value = CFArrayGetValueAtIndex(_cfObject, index)
-        return _SwiftValue.fetch(unsafeBitCast(value, to: AnyObject.self))
+        return _SwiftValue.fetch(nonOptional: unsafeBitCast(value, to: AnyObject.self))
     }
     
     override func insert(_ value: Any, at index: Int) {

--- a/Foundation/NSCFDictionary.swift
+++ b/Foundation/NSCFDictionary.swift
@@ -39,7 +39,7 @@ internal final class _NSCFDictionary : NSMutableDictionary {
     override func object(forKey aKey: Any) -> Any? {
         let value = CFDictionaryGetValue(_cfObject, unsafeBitCast(_SwiftValue.store(aKey), to: UnsafeRawPointer.self))
         if value != nil {
-            return _SwiftValue.fetch(unsafeBitCast(value, to: AnyObject.self) as AnyObject?)
+            return _SwiftValue.fetch(nonOptional: unsafeBitCast(value, to: AnyObject.self))
         } else {
             return nil
         }
@@ -117,7 +117,7 @@ internal func _CFSwiftDictionaryGetValue(_ dictionary: AnyObject, key: AnyObject
             return Unmanaged<AnyObject>.passUnretained(obj)
         }
     } else {
-        let k = _SwiftValue.fetch(key)
+        let k = _SwiftValue.fetch(nonOptional: key)
         let value = dict.object(forKey: k)
         let v = _SwiftValue.store(value)
         dict._storage[key as! NSObject] = v

--- a/Foundation/NSCFSet.swift
+++ b/Foundation/NSCFSet.swift
@@ -41,7 +41,7 @@ internal final class _NSCFSet : NSMutableSet {
         guard let value = CFSetGetValue(_cfObject, unsafeBitCast(_SwiftValue.store(object), to: UnsafeRawPointer.self)) else {
             return nil
         }
-        return _SwiftValue.fetch(unsafeBitCast(value, to: AnyObject.self) as AnyObject?)
+        return _SwiftValue.fetch(nonOptional: unsafeBitCast(value, to: AnyObject.self))
         
     }
     

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -27,7 +27,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
             NSRequiresConcreteImplementation()
         }
         if let val = _storage[_SwiftValue.store(aKey)] {
-            return _SwiftValue.fetch(val)
+            return _SwiftValue.fetch(nonOptional: val)
         }
         return nil
     }
@@ -37,7 +37,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
             NSRequiresConcreteImplementation()
         }
         
-        return NSGeneratorEnumerator(_storage.keys.map { _SwiftValue.fetch($0) }.makeIterator())
+        return NSGeneratorEnumerator(_storage.keys.map { _SwiftValue.fetch(nonOptional: $0) }.makeIterator())
     }
     
     public override convenience init() {
@@ -186,8 +186,8 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     open func getObjects(_ objects: inout [Any], andKeys keys: inout [Any], count: Int) {
         if type(of: self) === NSDictionary.self || type(of: self) === NSMutableDictionary.self {
             for (key, value) in _storage {
-                keys.append(_SwiftValue.fetch(key))
-                objects.append(_SwiftValue.fetch(value))
+                keys.append(_SwiftValue.fetch(nonOptional: key))
+                objects.append(_SwiftValue.fetch(nonOptional: value))
             }
         } else {
             

--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -70,7 +70,7 @@ open class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     }
 
     open func object(at idx: Int) -> Any {
-        return _SwiftValue.fetch(_orderedStorage[idx])
+        return _SwiftValue.fetch(nonOptional: _orderedStorage[idx])
     }
 
     open func index(of object: Any) -> Int {
@@ -121,7 +121,7 @@ open class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     
     internal var allObjects: [Any] {
         if type(of: self) === NSOrderedSet.self || type(of: self) === NSMutableOrderedSet.self {
-            return _orderedStorage.map { _SwiftValue.fetch($0) }
+            return _orderedStorage.map { _SwiftValue.fetch(nonOptional: $0) }
         } else {
             return (0..<count).map { idx in
                 return self[idx]
@@ -161,7 +161,7 @@ extension NSOrderedSet {
 
     public var firstObject: Any? {
         if let value = _orderedStorage.first {
-            return _SwiftValue.fetch(value)
+            return _SwiftValue.fetch(nonOptional: value)
         } else {
             return nil
         }
@@ -169,7 +169,7 @@ extension NSOrderedSet {
 
     public var lastObject: Any? {
         if let value = _orderedStorage.last {
-            return _SwiftValue.fetch(value)
+            return _SwiftValue.fetch(nonOptional: value)
         } else {
             return nil
         }
@@ -234,19 +234,19 @@ extension NSOrderedSet {
         guard type(of: self) === NSOrderedSet.self || type(of: self) === NSMutableOrderedSet.self else {
             NSRequiresConcreteImplementation()
         }
-        return NSGeneratorEnumerator(_orderedStorage.map { _SwiftValue.fetch($0) }.makeIterator())
+        return NSGeneratorEnumerator(_orderedStorage.map { _SwiftValue.fetch(nonOptional: $0) }.makeIterator())
     }
 
     public func reverseObjectEnumerator() -> NSEnumerator { 
         guard type(of: self) === NSOrderedSet.self || type(of: self) === NSMutableOrderedSet.self else {
             NSRequiresConcreteImplementation()
         }
-        return NSGeneratorEnumerator(_orderedStorage.map { _SwiftValue.fetch($0) }.reversed().makeIterator())
+        return NSGeneratorEnumerator(_orderedStorage.map { _SwiftValue.fetch(nonOptional: $0) }.reversed().makeIterator())
     }
     
     /*@NSCopying*/ 
     public var reversed: NSOrderedSet {
-        return NSOrderedSet(array: _orderedStorage.map { _SwiftValue.fetch($0) }.reversed())
+        return NSOrderedSet(array: _orderedStorage.map { _SwiftValue.fetch(nonOptional: $0) }.reversed())
     }
     
     // These two methods return a facade object for the receiving ordered set,
@@ -548,7 +548,7 @@ extension NSMutableOrderedSet {
 
         let swiftRange = range.toRange()!
         _orderedStorage[swiftRange].sort { lhs, rhs in
-            return cmptr(_SwiftValue.fetch(lhs), _SwiftValue.fetch(rhs)) == .orderedAscending
+            return cmptr(_SwiftValue.fetch(nonOptional: lhs), _SwiftValue.fetch(nonOptional: rhs)) == .orderedAscending
         }
     }
 }

--- a/Foundation/NSPropertyList.swift
+++ b/Foundation/NSPropertyList.swift
@@ -84,7 +84,7 @@ open class PropertyListSerialization : NSObject {
         if let err = error {
             throw err.takeUnretainedValue()._nsObject
         } else {
-            return _SwiftValue.fetch(decoded!)
+            return _SwiftValue.fetch(nonOptional: decoded!)
         }
     }
     
@@ -104,7 +104,7 @@ open class PropertyListSerialization : NSObject {
         if let err = error {
             throw err.takeUnretainedValue()._nsObject
         } else {
-            return _SwiftValue.fetch(decoded!)
+            return _SwiftValue.fetch(nonOptional: decoded!)
         }
     }
     

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -34,7 +34,7 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
         guard type(of: self) === NSSet.self || type(of: self) === NSMutableSet.self || type(of: self) === NSCountedSet.self else {
             NSRequiresConcreteImplementation()
         }
-        return NSGeneratorEnumerator(_storage.map { _SwiftValue.fetch($0) }.makeIterator())
+        return NSGeneratorEnumerator(_storage.map { _SwiftValue.fetch(nonOptional: $0) }.makeIterator())
     }
 
     public convenience override init() {
@@ -166,7 +166,7 @@ extension NSSet {
     
     open var allObjects: [Any] {
         if type(of: self) === NSSet.self || type(of: self) === NSMutableSet.self {
-            return _storage.map { _SwiftValue.fetch($0) }
+            return _storage.map { _SwiftValue.fetch(nonOptional: $0) }
         } else {
             let enumerator = objectEnumerator()
             var items = [Any]()
@@ -219,7 +219,7 @@ extension NSSet {
     open func addingObjects(from other: Set<AnyHashable>) -> Set<AnyHashable> {
         var result = Set<AnyHashable>(minimumCapacity: Swift.max(count, other.count))
         if type(of: self) === NSSet.self || type(of: self) === NSMutableSet.self {
-            result.formUnion(_storage.map { _SwiftValue.fetch($0) as! AnyHashable })
+            result.formUnion(_storage.map { _SwiftValue.fetch(nonOptional: $0) as! AnyHashable })
         } else {
             for case let obj as NSObject in self {
                 _ = result.insert(obj)
@@ -231,7 +231,7 @@ extension NSSet {
     open func addingObjects(from other: [Any]) -> Set<AnyHashable> {
         var result = Set<AnyHashable>(minimumCapacity: count)
         if type(of: self) === NSSet.self || type(of: self) === NSMutableSet.self {
-            result.formUnion(_storage.map { _SwiftValue.fetch($0) as! AnyHashable })
+            result.formUnion(_storage.map { _SwiftValue.fetch(nonOptional: $0) as! AnyHashable })
         } else {
             for case let obj as AnyHashable in self {
                 result.insert(obj)

--- a/Foundation/NSUserDefaults.swift
+++ b/Foundation/NSUserDefaults.swift
@@ -150,7 +150,7 @@ open class UserDefaults: NSObject {
               let bVal = aVal as? NSArray else {
             return nil
         }
-        return _SwiftValue.fetch(bVal) as? [String]
+        return _SwiftValue.fetch(nonOptional: bVal) as? [String]
     }
     open func integer(forKey defaultName: String) -> Int {
         guard let aVal = object(forKey: defaultName),


### PR DESCRIPTION
Back out the changes from d9cdc7ecdb91fdfd738b7347c69a6fa3b6d5d2be and
15769584ce4b4e450e893f33a550e2c23f55db30, and instead use an argument
label to disambiguate calls to `fetch`.