### PR TITLE
Fix comment for parameters

### DIFF
--- a/Foundation/Calendar.swift
+++ b/Foundation/Calendar.swift
@@ -592,7 +592,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     ///
     /// - parameter date1: A date to compare.
     /// - parameter date2: A date to compare.
-    /// - parameter: component: A granularity to compare. For example, pass `.hour` to check if two dates are in the same hour.
+    /// - parameter component: A granularity to compare. For example, pass `.hour` to check if two dates are in the same hour.
     public func compare(_ date1: Date, to date2: Date, toGranularity component: Component) -> ComparisonResult {
         return _handle.map { $0.compare(date1, to: date2, toUnitGranularity: Calendar._toCalendarUnit([component])) }
     }

--- a/Foundation/NSTimer.swift
+++ b/Foundation/NSTimer.swift
@@ -56,9 +56,9 @@ open class Timer : NSObject {
     // !!! That doesn't make sense as init(fire date: Date, ...) is more general than this constructor, which can be implemented in terms of init(fire date: Date, ...).
     // !!! The convenience here has been switched around and deliberately does not match what is exposed by Darwin Foundation.
     /// Creates and returns a new Timer object initialized with the specified block object.
-    /// - parameter:  timeInterval  The number of seconds between firings of the timer. If seconds is less than or equal to 0.0, this method chooses the nonnegative value of 0.1 milliseconds instead
-    /// - parameter:  repeats  If YES, the timer will repeatedly reschedule itself until invalidated. If NO, the timer will be invalidated after it fires.
-    /// - parameter:  block  The execution body of the timer; the timer itself is passed as the parameter to this block when executed to aid in avoiding cyclical references
+    /// - parameter timeInterval: The number of seconds between firings of the timer. If seconds is less than or equal to 0.0, this method chooses the nonnegative value of 0.1 milliseconds instead
+    /// - parameter repeats: If YES, the timer will repeatedly reschedule itself until invalidated. If NO, the timer will be invalidated after it fires.
+    /// - parameter block: The execution body of the timer; the timer itself is passed as the parameter to this block when executed to aid in avoiding cyclical references
     public convenience init(timeInterval interval: TimeInterval, repeats: Bool, block: @escaping (Timer) -> Swift.Void) {
         self.init(fire: Date(), interval: interval, repeats: repeats, block: block)
     }

--- a/Foundation/URLRequest.swift
+++ b/Foundation/URLRequest.swift
@@ -29,9 +29,9 @@ public struct URLRequest : ReferenceConvertible, Equatable, Hashable {
     }
     
     /// Creates and initializes a URLRequest with the given URL and cache policy.
-    /// - parameter: url The URL for the request.
-    /// - parameter: cachePolicy The cache policy for the request. Defaults to `.useProtocolCachePolicy`
-    /// - parameter: timeoutInterval The timeout interval for the request. See the commentary for the `timeoutInterval` for more information on timeout intervals. Defaults to 60.0
+    /// - parameter url: The URL for the request.
+    /// - parameter cachePolicy: The cache policy for the request. Defaults to `.useProtocolCachePolicy`
+    /// - parameter timeoutInterval: The timeout interval for the request. See the commentary for the `timeoutInterval` for more information on timeout intervals. Defaults to 60.0
     public init(url: URL, cachePolicy: CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 60.0) {
         _handle = _MutableHandle(adoptingReference: NSMutableURLRequest(url: url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval))
     }
@@ -145,7 +145,7 @@ public struct URLRequest : ReferenceConvertible, Equatable, Hashable {
     /// The value which corresponds to the given header
     /// field. Note that, in keeping with the HTTP RFC, HTTP header field
     /// names are case-insensitive.
-    /// - parameter: field the header field name to use for the lookup (case-insensitive).
+    /// - parameter field: the header field name to use for the lookup (case-insensitive).
     public func value(forHTTPHeaderField field: String) -> String? {
         return _handle.map { $0.value(forHTTPHeaderField: field) }
     }


### PR DESCRIPTION
Invalid syntax in `parameter` comment for quick help.
![screen shot 2016-12-22 at 18 04 08](https://cloud.githubusercontent.com/assets/1780156/21420509/80172436-c871-11e6-82d8-702885b4aa34.png)
