### PR TITLE
Android SDK name changes.

### DIFF
--- a/lib/product.py
+++ b/lib/product.py
@@ -117,8 +117,8 @@ class DynamicLibrary(Library):
 
     def generate(self):
         if Configuration.current.target.sdk == OSType.Linux or Configuration.current.target.sdk == OSType.FreeBSD:
-            self.conformance_begin = '${SDKROOT}/lib/swift/linux/${ARCH}/swift_begin.o' 
-            self.conformance_end = '${SDKROOT}/lib/swift/linux/${ARCH}/swift_end.o' 
+            self.conformance_begin = '${SDKROOT}/lib/swift/${OS}/${ARCH}/swift_begin.o' 
+            self.conformance_end = '${SDKROOT}/lib/swift/${OS}/${ARCH}/swift_end.o' 
             return Library.generate(self, ["-shared", "-Wl,-soname," + self.product_name, "-Wl,--no-undefined"])
         else:
             return Library.generate(self, ["-shared"])

--- a/lib/target.py
+++ b/lib/target.py
@@ -407,6 +407,8 @@ class Target:
     def swift_sdk_name(self):
         if self.sdk == OSType.MacOSX:
             return "macosx"
+        elif self.sdk == OSType.Linux and "android" in self.triple:
+            return "android"
         elif self.sdk == OSType.Linux:
             return "linux"
         elif self.sdk == OSType.FreeBSD:


### PR DESCRIPTION
* SDK name added for Android. The OSType remains as linux, but the platform specific files should be retrieved from the `android` directory instead of `linux`.
* conformance_begin/end was using a hardcoded `linux` directory. Now it's pulling `swift_being.o`/`swift_end.o` object files from the correct directory. 

This last point should probably be double checked in FreeBSD. I'll try to set up an environment for testing, but is there anyone I can reach to confirm this last point?