### PR TITLE
Fix libFoundation.so being flagged as requiring executable stack

### DIFF
--- a/CoreFoundation/String.subproj/CFCharacterSetData.S
+++ b/CoreFoundation/String.subproj/CFCharacterSetData.S
@@ -22,4 +22,7 @@ _C_LABEL(__CFCharacterSetBitmapDataSize):
     .int _C_LABEL(__CFCharacterSetBitmapDataEnd) - _C_LABEL(__CFCharacterSetBitmapData)
 
 NO_EXEC_STACK_DIRECTIVE
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif
 

--- a/CoreFoundation/String.subproj/CFUniCharPropertyDatabase.S
+++ b/CoreFoundation/String.subproj/CFUniCharPropertyDatabase.S
@@ -22,4 +22,7 @@ _C_LABEL(__CFUniCharPropertyDatabaseSize):
     .int _C_LABEL(__CFUniCharPropertyDatabaseEnd) - _C_LABEL(__CFUniCharPropertyDatabase)
 
 NO_EXEC_STACK_DIRECTIVE
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif
 

--- a/CoreFoundation/String.subproj/CFUnicodeData.S
+++ b/CoreFoundation/String.subproj/CFUnicodeData.S
@@ -36,4 +36,7 @@ _C_LABEL(__CFUnicodeDataLSize):
 #endif
 
 NO_EXEC_STACK_DIRECTIVE
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif
 


### PR DESCRIPTION
libFoundation.so is flagged as requiring an executable stack on Linux, although it does not. This is due to GNU as behavior.
Please see discussion at https://bugs.swift.org/browse/SR-2700?jql=text%20~%20%22executable%20stack%22