### PR TITLE
[stdlib] Implement SE-147: Move initialize(from:) from Pointer to BufferPointer

### DIFF
--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -1436,7 +1436,11 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
                 }
                 
                 if replacementCount != 0 {
-                    newElements._copyContents(initializing: bytes + start)
+                  let buf = UnsafeMutableBufferPointer(start: bytes + start, 
+                                                       count: replacementCount)
+                  var (it,idx) = newElements._copyContents(initializing: buf)
+                  precondition(it.next() == nil && idx == buf.endIndex,
+                    "newElements iterator returned different count to newElements.count")
                 }
             }
     }


### PR DESCRIPTION
This is a coordinated change with [this PR](https://github.com/apple/swift/pull/6601) on the Swift repo.

Since `UnsafeMutablePointer.initialize(from:)` is memory-unsafe with collections that underreport their count, it is being migrated to be on `UnsafeMutableBufferPointer` to avoid buffer overruns.

As part of this, `Sequence. _copyContents(initializing:)` is being altered to take a buffer not a pointer. This is an internal underscore protocol so not user-impacting, but corelibs-foundation does use it and needs to change at the same time.
