### PR TITLE
Fix libFoundation.so being flagged as requiring executable stack

### DIFF
--- a/CoreFoundation/Base.subproj/CFAsmMacros.h
+++ b/CoreFoundation/Base.subproj/CFAsmMacros.h
@@ -14,7 +14,7 @@
 #define CONCAT_EXPANDED(a,b) CONCAT(a,b)
 #define _C_LABEL(name) CONCAT_EXPANDED(__USER_LABEL_PREFIX__,name)
 
-#if defined(__GNU__) || defined(__ANDROID__) || defined(__FreeBSD__)
+#if defined(__GNU__) || defined(__GNUC__) || defined(__ANDROID__) || defined(__FreeBSD__)
 #define NO_EXEC_STACK_DIRECTIVE .section .note.GNU-stack,"",%progbits
 #else
 #define NO_EXEC_STACK_DIRECTIVE


### PR DESCRIPTION
libFoundation.so is flagged as requiring an executable stack on Linux, although it does not. This is due to GNU as behavior.
Please see discussion at https://bugs.swift.org/browse/SR-2700?jql=text%20~%20%22executable%20stack%22

This was already intended to be solved by https://github.com/apple/swift-corelibs-foundation/pull/649/, but did not work as intended in Ubuntu. Checking for \_\_GNUC\_\_ in addition resolves the issue.