### PR TITLE
Correct sequence initializers for Data when repeating:count: is called and add a memset fast-path

### DIFF
--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -1009,6 +1009,17 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             return _DataStorage(bytes: $0.baseAddress, length: $0.count)
         }
     }
+
+    /// Initialze a `Data` with a repeating byte pattern
+    ///
+    /// - parameter repeatedValue: A byte to initialze the pattern
+    /// - parameter count: The number of bytes the data initially contains initialzed to the repeatedValue
+    public init(repeating repeatedValue: UInt8, count: Int) {
+        self.init(count: count)
+        withUnsafeMutableBytes { (bytes: UnsafeMutablePointer<UInt8>) -> Void in
+            memset(bytes, Int32(repeatedValue), count)
+        }
+    }
     
     /// Initialize a `Data` with the specified size.
     ///
@@ -1331,7 +1342,9 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         for byte in newElements {
             self[idx] = byte
             idx += 1
-            count = idx
+            if idx > count {
+                count = idx
+            }
         }
     }
     

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -90,6 +90,7 @@ class TestNSData: XCTestCase {
             ("test_initDataWithCapacity", test_initDataWithCapacity),
             ("test_initDataWithCount", test_initDataWithCount),
             ("test_emptyStringToData", test_emptyStringToData),
+            ("test_repeatingValueInitialization", test_repeatingValueInitialization),
         ]
     }
     
@@ -1031,6 +1032,20 @@ extension TestNSData {
             let byteCount = data.copyBytes(to: buffer)
             XCTAssertEqual(6 * MemoryLayout<MyStruct>.stride, byteCount)
         }
+    }
+
+    func test_repeatingValueInitialization() {
+        var d = Data(repeating: 0x01, count: 3)
+        let elements = repeatElement(UInt8(0x02), count: 3) // ensure we fall into the sequence case
+        d.append(contentsOf: elements)
+
+        XCTAssertEqual(d[0], 0x01)
+        XCTAssertEqual(d[1], 0x01)
+        XCTAssertEqual(d[2], 0x01)
+
+        XCTAssertEqual(d[3], 0x02)
+        XCTAssertEqual(d[4], 0x02)
+        XCTAssertEqual(d[5], 0x02)
     }
 }
 


### PR DESCRIPTION
Resolves SR-3566.