### PR TITLE
[SR-3403] Rename a few URLSession related constants to match the Darwin version

### DIFF
--- a/Foundation/NSURLSession/NSURLSession.swift
+++ b/Foundation/NSURLSession/NSURLSession.swift
@@ -179,7 +179,7 @@ fileprivate func nextSessionIdentifier() -> Int32 {
     sessionCounter += 1
     return sessionCounter
 }
-public let URLSessionTransferSizeUnknown: Int64 = -1
+public let NSURLSessionTransferSizeUnknown: Int64 = -1
 
 open class URLSession : NSObject {
     fileprivate let _configuration: _Configuration

--- a/Foundation/NSURLSession/NSURLSessionDelegate.swift
+++ b/Foundation/NSURLSession/NSURLSessionDelegate.swift
@@ -227,7 +227,7 @@ public protocol URLSessionDownloadDelegate : URLSessionTaskDelegate {
     
     /* Sent when a download has been resumed. If a download failed with an
      * error, the -userInfo dictionary of the error will contain an
-     * URLSessionDownloadTaskResumeData key, whose value is the resume
+     * NSURLSessionDownloadTaskResumeData key, whose value is the resume
      * data.
      */
      func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didResumeAtOffset fileOffset: Int64, expectedTotalBytes: Int64)

--- a/Foundation/NSURLSession/NSURLSessionTask.swift
+++ b/Foundation/NSURLSession/NSURLSessionTask.swift
@@ -159,7 +159,7 @@ open class URLSessionTask : NSObject, NSCopying {
     fileprivate var _response: URLResponse? = nil
     
     /* Byte count properties may be zero if no body is expected,
-     * or URLSessionTransferSizeUnknown if it is not possible
+     * or NSURLSessionTransferSizeUnknown if it is not possible
      * to know how many bytes will be transferred.
      */
     
@@ -1231,7 +1231,7 @@ open class URLSessionStreamTask : URLSessionTask {
 }
 
 /* Key in the userInfo dictionary of an NSError received during a failed download. */
-public let URLSessionDownloadTaskResumeData: String = "" // NSUnimplemented
+public let NSURLSessionDownloadTaskResumeData: String = "NSURLSessionDownloadTaskResumeData"
 
 
 extension URLSession {


### PR DESCRIPTION
Fixes [SR-3403](https://bugs.swift.org/browse/SR-3403).

- Rename `URLSessionTransferSizeUnknown` to `NSURLSessionTransferSizeUnknown`
- Rename `URLSessionDownloadTaskResumeData` to `NSURLSessionDownloadTaskResumeData`
- Implement `NSURLSessionDownloadTaskResumeData`