### PR TITLE
Enable building on powerpc

### DIFF
--- a/Foundation/CGFloat.swift
+++ b/Foundation/CGFloat.swift
@@ -9,11 +9,11 @@
 
 @_fixed_layout
 public struct CGFloat {
-#if arch(i386) || arch(arm)
+#if arch(i386) || arch(arm) || arch(powerpc)
     /// The native type used to store the CGFloat, which is Float on
     /// 32-bit architectures and Double on 64-bit architectures.
     public typealias NativeType = Float
-#elseif arch(x86_64) || arch(arm64) || arch(s390x)
+#elseif arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
     /// The native type used to store the CGFloat, which is Float on
     /// 32-bit architectures and Double on 64-bit architectures.
     public typealias NativeType = Double
@@ -170,9 +170,9 @@ extension CGFloat : BinaryFloatingPoint {
 
     @_transparent
     public init(bitPattern: UInt) {
-#if arch(i386) || arch(arm)
+#if arch(i386) || arch(arm) || arch(powerpc)
         native = NativeType(bitPattern: UInt32(bitPattern))
-#elseif arch(x86_64) || arch(arm64) || arch(s390x)
+#elseif arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
         native = NativeType(bitPattern: UInt64(bitPattern))
 #endif
     }

--- a/build.py
+++ b/build.py
@@ -81,7 +81,7 @@ if "XCTEST_BUILD_DIR" in Configuration.current.variables:
 	]
 
 triple = Configuration.current.target.triple
-if triple == "x86_64-linux-gnu" or triple == "armv7-none-linux-androideabi" or triple == "s390x-linux-gnu":
+if triple.endswith("-linux-gnu") or triple == "armv7-none-linux-androideabi":
 	foundation.LDFLAGS += '-lcurl '
 
 if triple == "armv7-none-linux-androideabi":

--- a/lib/target.py
+++ b/lib/target.py
@@ -85,11 +85,11 @@ class ArchType:
         if value == ArchType.msp430:
             return "msp430"
         if value == ArchType.ppc:
-            return "ppc"
+            return "powerpc"
         if value == ArchType.ppc64:
-            return "ppc64"
+            return "powerpc64"
         if value == ArchType.ppc64le:
-            return "ppc64le"
+            return "powerpc64le"
         if value == ArchType.r600:
             return "r600"
         if value == ArchType.amdgcn:
@@ -176,11 +176,11 @@ class ArchType:
             return ArchType.mips64el
         if string == "msp430":
             return ArchType.msp430
-        if string == "ppc":
+        if string == "ppc" or string == "powerpc":
             return ArchType.ppc
-        if string == "ppc64":
+        if string == "ppc64" or string == "powerpc64":
             return ArchType.ppc64
-        if string == "ppc64le":
+        if string == "ppc64le" or string == "powerpc64le":
             return ArchType.ppc64le
         if string == "r600":
             return ArchType.r600


### PR DESCRIPTION
These changes enable building on the powerpc family of targets - powerpc (32bit BE), powerpc64 (64bit BE) and powerpc64le (64bit LE).  Only tested on powerpc64le since that's the only target properly supported in Swift overall.