### PR TITLE
Update for new rules on @inline(__always) function bodies

### DIFF
--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -911,7 +911,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public typealias Index = Int
     public typealias Indices = CountableRange<Int>
     
-    internal var _backing : _DataStorage
+    @_versioned internal var _backing : _DataStorage
     
     // A standard or custom deallocator for `Data`.
     ///


### PR DESCRIPTION
Referencing private or internal declarations from an @inline(__always)
body can lead to SIL verifier and linker failures, so now we diagnose
and prohibit it.

Mark the entity in question public, or if it is not part of user-visible
API, internal and @_versioned.

See <https://github.com/apple/swift/pull/6669>.