### PR TITLE
[NotificationQueue] Rename Coalescing constants to match the Darwin version

### DIFF
--- a/Foundation/NSNotificationQueue.swift
+++ b/Foundation/NSNotificationQueue.swift
@@ -22,8 +22,8 @@ extension NotificationQueue {
         public let rawValue : UInt
         public init(rawValue: UInt) { self.rawValue = rawValue }
         
-        public static let CoalescingOnName = Coalescing(rawValue: 1 << 0)
-        public static let CoalescingOnSender = Coalescing(rawValue: 1 << 1)
+        public static let onName = Coalescing(rawValue: 1 << 0)
+        public static let onSender = Coalescing(rawValue: 1 << 1)
     }
 }
 
@@ -77,7 +77,7 @@ open class NotificationQueue: NSObject {
     }
 
     open func enqueueNotification(_ notification: Notification, postingStyle: PostingStyle) {
-        enqueueNotification(notification, postingStyle: postingStyle, coalesceMask: [.CoalescingOnName, .CoalescingOnSender], forModes: nil)
+        enqueueNotification(notification, postingStyle: postingStyle, coalesceMask: [.onName, .onSender], forModes: nil)
     }
 
     open func enqueueNotification(_ notification: Notification, postingStyle: PostingStyle, coalesceMask: Coalescing, forModes modes: [RunLoopMode]?) {
@@ -108,15 +108,15 @@ open class NotificationQueue: NSObject {
     open func dequeueNotificationsMatching(_ notification: Notification, coalesceMask: Coalescing) {
         var predicate: (NSNotificationListEntry) -> Bool
         switch coalesceMask {
-        case [.CoalescingOnName, .CoalescingOnSender]:
+        case [.onName, .onSender]:
             predicate = { (entryNotification, _) in
                 return _SwiftValue.store(notification.object) !== _SwiftValue.store(entryNotification.object) || notification.name != entryNotification.name
             }
-        case [.CoalescingOnName]:
+        case [.onName]:
             predicate = { (entryNotification, _) in
                 return notification.name != entryNotification.name
             }
-        case [.CoalescingOnSender]:
+        case [.onSender]:
             predicate = { (entryNotification, _) in
                 return _SwiftValue.store(notification.object) !== _SwiftValue.store(entryNotification.object)
             }

--- a/TestFoundation/TestNSNotificationQueue.swift
+++ b/TestFoundation/TestNSNotificationQueue.swift
@@ -173,15 +173,15 @@ class TestNSNotificationQueue : XCTestCase {
 
         let queue = NotificationQueue.defaultQueue()
         // #1
-        queue.enqueueNotification(notification1, postingStyle: .postASAP,  coalesceMask: .CoalescingOnName, forModes: nil)
+        queue.enqueueNotification(notification1, postingStyle: .postASAP,  coalesceMask: .onName, forModes: nil)
         // #2
-        queue.enqueueNotification(notification2, postingStyle: .postASAP,  coalesceMask: .CoalescingOnSender, forModes: nil)
+        queue.enqueueNotification(notification2, postingStyle: .postASAP,  coalesceMask: .onSender, forModes: nil)
         // #3, coalesce with 1 & 2
-        queue.enqueueNotification(notification1, postingStyle: .postASAP,  coalesceMask: .CoalescingOnName, forModes: nil)
+        queue.enqueueNotification(notification1, postingStyle: .postASAP,  coalesceMask: .onName, forModes: nil)
         // #4, coalesce with #3
-        queue.enqueueNotification(notification2, postingStyle: .postASAP,  coalesceMask: .CoalescingOnName, forModes: nil)
+        queue.enqueueNotification(notification2, postingStyle: .postASAP,  coalesceMask: .onName, forModes: nil)
         // #5
-        queue.enqueueNotification(notification1, postingStyle: .postASAP,  coalesceMask: .CoalescingOnSender, forModes: nil)
+        queue.enqueueNotification(notification1, postingStyle: .postASAP,  coalesceMask: .onSender, forModes: nil)
         scheduleTimer(withInterval: 0.001)
         // check that we received notifications #4 and #5
         XCTAssertEqual(numberOfNameCoalescingCalls, 1)


### PR DESCRIPTION
`Coalescing` itself should be renamed as well in a separate pull request.
