### PR TITLE
[FileHandle] Update NSFileHandleReadCompletion to match the Darwin version

### DIFF
--- a/Foundation/NSFileHandle.swift
+++ b/Foundation/NSFileHandle.swift
@@ -302,7 +302,10 @@ extension Notification.Name {
     public static let NSFileHandleReadToEndOfFileCompletion = Notification.Name(rawValue: "") // NSUnimplemented
     public static let NSFileHandleConnectionAccepted = Notification.Name(rawValue: "") // NSUnimplemented
     public static let NSFileHandleDataAvailable = Notification.Name(rawValue: "") // NSUnimplemented
-    public static let NSFileHandleReadCompletion = Notification.Name(rawValue: "") // NSUnimplemented
+}
+
+extension FileHandle {
+    public static let readCompletionNotification = Notification.Name(rawValue: "NSFileHandleReadCompletionNotification")
 }
 
 public let NSFileHandleNotificationDataItem: String = "" // NSUnimplemented

--- a/TestFoundation/TestNSFileHandle.swift
+++ b/TestFoundation/TestNSFileHandle.swift
@@ -18,9 +18,15 @@
 class TestNSFileHandle : XCTestCase {
     static var allTests : [(String, (TestNSFileHandle) -> () throws -> ())] {
         return [
-                   ("test_pipe", test_pipe),
-                   ("test_nullDevice", test_nullDevice),
+            ("test_constants", test_constants),
+            ("test_pipe", test_pipe),
+            ("test_nullDevice", test_nullDevice),
         ]
+    }
+
+    func test_constants() {
+        XCTAssertEqual(FileHandle.readCompletionNotification.rawValue, "NSFileHandleReadCompletionNotification",
+                       "\(FileHandle.readCompletionNotification.rawValue) is not equal to NSFileHandleReadCompletionNotification")
     }
 
     func test_pipe() {


### PR DESCRIPTION
I'm not sure why only `readCompletionNotification` is defined in Foundation APINotes on Darwin: https://github.com/apple/swift/blob/swift-DEVELOPMENT-SNAPSHOT-2017-01-05-a/apinotes/Foundation.apinotes#L1356-L1357.