### PR TITLE
[gardening] Address some unsafeBitCast warnings

### DIFF
--- a/Foundation/IndexSet.swift
+++ b/Foundation/IndexSet.swift
@@ -948,7 +948,7 @@ private final class _MutablePairHandle<ImmutableType : NSObject, MutableType : N
             return try whatToDo(i)
         case .Mutable(let m):
             // TODO: It should be possible to reflect the constraint that MutableType is a subtype of ImmutableType in the generics for the class, but I haven't figured out how yet. For now, cheat and unsafe bit cast.
-            return try whatToDo(unsafeBitCast(m, to: ImmutableType.self))
+            return try whatToDo(unsafeDowncast(m, to: ImmutableType.self))
         }
     }
     
@@ -958,7 +958,7 @@ private final class _MutablePairHandle<ImmutableType : NSObject, MutableType : N
             return i
         case .Mutable(let m):
             // TODO: It should be possible to reflect the constraint that MutableType is a subtype of ImmutableType in the generics for the class, but I haven't figured out how yet. For now, cheat and unsafe bit cast.
-            return unsafeBitCast(m, to: ImmutableType.self)
+            return unsafeDowncast(m, to: ImmutableType.self)
         }
     }
 }

--- a/Foundation/NSCache.swift
+++ b/Foundation/NSCache.swift
@@ -143,7 +143,7 @@ open class NSCache<KeyType : AnyObject, ObjectType : AnyObject> : NSObject {
         
         if let del = delegate {
             for entry in toRemove {
-                del.cache(unsafeBitCast(self, to:NSCache<AnyObject, AnyObject>.self), willEvictObject: entry.value)
+                del.cache(unsafeDowncast(self, to:NSCache<AnyObject, AnyObject>.self), willEvictObject: entry.value)
             }
         }
         

--- a/Foundation/NSCoder.swift
+++ b/Foundation/NSCoder.swift
@@ -103,7 +103,7 @@ open class NSCoder : NSObject {
     open func encode(_ object: Any?) {
         var object = object
         withUnsafePointer(to: &object) { (ptr: UnsafePointer<Any?>) -> Void in
-            encodeValue(ofObjCType: "@", at: unsafeBitCast(ptr, to: UnsafeRawPointer.self))
+            encodeValue(ofObjCType: "@", at: UnsafeRawPointer(ptr))
         }
     }
     

--- a/Foundation/NSCoder.swift
+++ b/Foundation/NSCoder.swift
@@ -145,7 +145,7 @@ open class NSCoder : NSObject {
         
         var obj: Any? = nil
         withUnsafeMutablePointer(to: &obj) { (ptr: UnsafeMutablePointer<Any?>) -> Void in
-            decodeValue(ofObjCType: "@", at: unsafeBitCast(ptr, to: UnsafeMutableRawPointer.self))
+            decodeValue(ofObjCType: "@", at: UnsafeMutableRawPointer(ptr))
         }
         return obj
     }

--- a/Foundation/NSConcreteValue.swift
+++ b/Foundation/NSConcreteValue.swift
@@ -177,7 +177,7 @@ internal class NSConcreteValue : NSValue {
 
     override var hash: Int {
         return self._typeInfo.name.hashValue &+
-            Int(bitPattern: CFHashBytes(unsafeBitCast(self.value, to: UnsafeMutablePointer<UInt8>.self), self._size))
+            Int(bitPattern: CFHashBytes(self.value.assumingMemoryBound(to: UInt8.self), self._size))
     }
 }
 

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -610,51 +610,51 @@ open class NSKeyedArchiver : NSCoder {
     private func _encodeValueOfObjCType(_ type: _NSSimpleObjCType, at addr: UnsafeRawPointer) {
         switch type {
         case .ID:
-            let objectp = unsafeBitCast(addr, to: UnsafePointer<Any>.self)
+            let objectp = addr.assumingMemoryBound(to: Any.self)
             encode(objectp.pointee)
             break
         case .Class:
-            let classp = unsafeBitCast(addr, to: UnsafePointer<AnyClass>.self)
+            let classp = addr.assumingMemoryBound(to: AnyClass.self)
             encode(NSStringFromClass(classp.pointee)._bridgeToObjectiveC())
             break
         case .Char:
-            let charp = unsafeBitCast(addr, to: UnsafePointer<CChar>.self)
+            let charp = addr.assumingMemoryBound(to: CChar.self)
             _encodeValue(NSNumber(value: charp.pointee))
             break
         case .UChar:
-            let ucharp = unsafeBitCast(addr, to: UnsafePointer<UInt8>.self)
+            let ucharp = addr.assumingMemoryBound(to: UInt8.self)
             _encodeValue(NSNumber(value: ucharp.pointee))
             break
         case .Int, .Long:
-            let intp = unsafeBitCast(addr, to: UnsafePointer<Int32>.self)
+            let intp = addr.assumingMemoryBound(to: Int32.self)
             _encodeValue(NSNumber(value: intp.pointee))
             break
         case .UInt, .ULong:
-            let uintp = unsafeBitCast(addr, to: UnsafePointer<UInt32>.self)
+            let uintp = addr.assumingMemoryBound(to: UInt32.self)
             _encodeValue(NSNumber(value: uintp.pointee))
             break
         case .LongLong:
-            let longlongp = unsafeBitCast(addr, to: UnsafePointer<Int64>.self)
+            let longlongp = addr.assumingMemoryBound(to: Int64.self)
             _encodeValue(NSNumber(value: longlongp.pointee))
             break
         case .ULongLong:
-            let ulonglongp = unsafeBitCast(addr, to: UnsafePointer<UInt64>.self)
+            let ulonglongp = addr.assumingMemoryBound(to: UInt64.self)
             _encodeValue(NSNumber(value: ulonglongp.pointee))
             break
         case .Float:
-            let floatp = unsafeBitCast(addr, to: UnsafePointer<Float>.self)
+            let floatp = addr.assumingMemoryBound(to: Float.self)
             _encodeValue(NSNumber(value: floatp.pointee))
             break
         case .Double:
-            let doublep = unsafeBitCast(addr, to: UnsafePointer<Double>.self)
+            let doublep = addr.assumingMemoryBound(to: Double.self)
             _encodeValue(NSNumber(value: doublep.pointee))
             break
         case .Bool:
-            let boolp = unsafeBitCast(addr, to: UnsafePointer<Bool>.self)
+            let boolp = addr.assumingMemoryBound(to: Bool.self)
             _encodeValue(NSNumber(value: boolp.pointee))
             break
         case .CharPtr:
-            let charpp = unsafeBitCast(addr, to: UnsafePointer<UnsafePointer<Int8>>.self)
+            let charpp = addr.assumingMemoryBound(to: UnsafePointer<Int8>.self)
             encode(NSString(utf8String: charpp.pointee))
             break
         default:

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -754,65 +754,65 @@ open class NSKeyedUnarchiver : NSCoder {
         case .ID:
             if let ns = decodeObject() {
                 // TODO: Pretty sure this is not 100% correct
-                unsafeBitCast(addr, to: UnsafeMutablePointer<Any>.self).pointee = ns
+                addr.assumingMemoryBound(to: Any.self).pointee = ns
             }
             break
         case .Class:
             if let ns = decodeObject() as? NSString {
                 if let nsClass = NSClassFromString(String._unconditionallyBridgeFromObjectiveC(ns)) {
-                    unsafeBitCast(addr, to: UnsafeMutablePointer<AnyClass>.self).pointee = nsClass
+                    addr.assumingMemoryBound(to: AnyClass.self).pointee = nsClass
                 }
             }
             break
         case .Char:
             if let ns : NSNumber = _decodeValue() {
-                unsafeBitCast(addr, to: UnsafeMutablePointer<CChar>.self).pointee = ns.int8Value
+                addr.assumingMemoryBound(to: CChar.self).pointee = ns.int8Value
             }
             break
         case .UChar:
             if let ns : NSNumber = _decodeValue() {
-                unsafeBitCast(addr, to: UnsafeMutablePointer<UInt8>.self).pointee = ns.uint8Value
+                addr.assumingMemoryBound(to: UInt8.self).pointee = ns.uint8Value
             }
             break
         case .Int, .Long:
             if let ns : NSNumber = _decodeValue() {
-                unsafeBitCast(addr, to: UnsafeMutablePointer<Int32>.self).pointee = ns.int32Value
+                addr.assumingMemoryBound(to: Int32.self).pointee = ns.int32Value
             }
             break
         case .UInt, .ULong:
             if let ns : NSNumber = _decodeValue() {
-                unsafeBitCast(addr, to: UnsafeMutablePointer<UInt32>.self).pointee = ns.uint32Value
+                addr.assumingMemoryBound(to: UInt32.self).pointee = ns.uint32Value
             }
             break
         case .LongLong:
             if let ns : NSNumber = _decodeValue() {
-                unsafeBitCast(addr, to: UnsafeMutablePointer<Int64>.self).pointee = ns.int64Value
+                addr.assumingMemoryBound(to: Int64.self).pointee = ns.int64Value
             }
             break
         case .ULongLong:
             if let ns : NSNumber = _decodeValue() {
-                unsafeBitCast(addr, to: UnsafeMutablePointer<UInt64>.self).pointee = ns.uint64Value
+                addr.assumingMemoryBound(to: UInt64.self).pointee = ns.uint64Value
             }
             break
         case .Float:
             if let ns : NSNumber = _decodeValue() {
-                unsafeBitCast(addr, to: UnsafeMutablePointer<Float>.self).pointee = ns.floatValue
+                addr.assumingMemoryBound(to: Float.self).pointee = ns.floatValue
             }
             break
         case .Double:
             if let ns : NSNumber = _decodeValue() {
-                unsafeBitCast(addr, to: UnsafeMutablePointer<Double>.self).pointee = ns.doubleValue
+                addr.assumingMemoryBound(to: Double.self).pointee = ns.doubleValue
             }
             break
         case .Bool:
             if let ns : NSNumber = _decodeValue() {
-                unsafeBitCast(addr, to: UnsafeMutablePointer<Bool>.self).pointee = ns.boolValue
+                addr.assumingMemoryBound(to: Bool.self).pointee = ns.boolValue
             }
             break
         case .CharPtr:
             if let ns = decodeObject() as? NSString {
                 let string = ns.utf8String! // XXX leaky
-                unsafeBitCast(addr, to: UnsafeMutablePointer<UnsafePointer<Int8>>.self).pointee = string
+                addr.assumingMemoryBound(to: UnsafePointer<Int8>.self).pointee = string
             }
             break
         default:

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -78,7 +78,7 @@ internal func _CFSwiftIsEqual(_ cf1: AnyObject, cf2: AnyObject) -> Bool {
 // Ivars in _NSCF* types must be zeroed via an unsafe accessor to avoid deinit of potentially unsafe memory to accces as an object/struct etc since it is stored via a foreign object graph
 internal func _CFZeroUnsafeIvars<T>(_ arg: inout T) {
     withUnsafeMutablePointer(to: &arg) { (ptr: UnsafeMutablePointer<T>) -> Void in
-        bzero(unsafeBitCast(ptr, to: UnsafeMutableRawPointer.self), MemoryLayout<T>.size)
+        bzero(UnsafeMutableRawPointer(ptr), MemoryLayout<T>.size)
     }
 }
 

--- a/Foundation/NSUUID.swift
+++ b/Foundation/NSUUID.swift
@@ -32,7 +32,7 @@ open class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     public init(uuidBytes bytes: UnsafePointer<UInt8>) {
-        memcpy(unsafeBitCast(buffer, to: UnsafeMutableRawPointer.self), UnsafeRawPointer(bytes), 16)
+        memcpy(UnsafeMutableRawPointer(buffer), UnsafeRawPointer(bytes), 16)
     }
     
     open func getBytes(_ uuid: UnsafeMutablePointer<UInt8>) {

--- a/Foundation/NSValue.swift
+++ b/Foundation/NSValue.swift
@@ -103,9 +103,9 @@ open class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
         if type(of: self) == NSValue.self {
             self.init()
             if NSValue._isSpecialObjCType(type) {
-                self._concreteValue = NSSpecialValue(bytes: unsafeBitCast(value, to: UnsafePointer<UInt8>.self), objCType: type)
+                self._concreteValue = NSSpecialValue(bytes: value.assumingMemoryBound(to: UInt8.self), objCType: type)
             } else {
-                self._concreteValue = NSConcreteValue(bytes: unsafeBitCast(value, to: UnsafePointer<UInt8>.self), objCType: type)
+                self._concreteValue = NSConcreteValue(bytes: value.assumingMemoryBound(to: UInt8.self), objCType: type)
             }
         } else {
             NSRequiresConcreteImplementation()

--- a/Foundation/String.swift
+++ b/Foundation/String.swift
@@ -43,7 +43,7 @@ extension String : _ObjectTypeBridgeable {
                 result = str
             }
         } else if type(of: source) == _NSCFConstantString.self {
-            let conststr = unsafeBitCast(source, to: _NSCFConstantString.self)
+            let conststr = unsafeDowncast(source, to: _NSCFConstantString.self)
             let str = String._fromCodeUnitSequence(UTF8.self, input: UnsafeBufferPointer(start: conststr._ptr, count: Int(conststr._length)))
             result = str
         } else {


### PR DESCRIPTION
Using

- `unsafeDowncast`
- `UnsafeRawPointer` initializer
- `UnsafeMutableRawPointer` initializer
- `assumingMemoryBound`

according to the warnings.