### PR TITLE
Delete `_os_log_set_nscf_formatter` related lines to make the framework run on macOS 10.11

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -955,14 +955,6 @@ pthread_t _CF_pthread_main_thread_np(void) {
 
 #endif
 
-#if DEPLOYMENT_RUNTIME_SWIFT && (DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED)
-typedef bool (*_os_log_NSCF_callback)(const void *obj, char *string_value, size_t string_sz, bool *publicData);
-extern void _os_log_set_nscf_formatter(_os_log_NSCF_callback function) OS_WEAK_IMPORT;
-bool os_log_callback(const void *obj, char *string_value, size_t string_sz, bool *publicData) {
-    return false;
-}
-#endif
-
 
 #if DEPLOYMENT_TARGET_LINUX || DEPLOYMENT_TARGET_FREEBSD
 static void __CFInitialize(void) __attribute__ ((constructor));
@@ -1187,10 +1179,6 @@ void __CFInitialize(void) {
 
         __CFProphylacticAutofsAccess = false;
 
-#if DEPLOYMENT_RUNTIME_SWIFT && (DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED)
-        if (_os_log_set_nscf_formatter != NULL) _os_log_set_nscf_formatter(&os_log_callback);
-#endif
-        
         __CFInitializing = 0;
         __CFInitialized = 1;
     }

--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -957,7 +957,7 @@ pthread_t _CF_pthread_main_thread_np(void) {
 
 #if DEPLOYMENT_RUNTIME_SWIFT && (DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED)
 typedef bool (*_os_log_NSCF_callback)(const void *obj, char *string_value, size_t string_sz, bool *publicData);
-extern void _os_log_set_nscf_formatter(_os_log_NSCF_callback function);
+extern void _os_log_set_nscf_formatter(_os_log_NSCF_callback function) OS_WEAK_IMPORT;
 bool os_log_callback(const void *obj, char *string_value, size_t string_sz, bool *publicData) {
     return false;
 }
@@ -1188,7 +1188,7 @@ void __CFInitialize(void) {
         __CFProphylacticAutofsAccess = false;
 
 #if DEPLOYMENT_RUNTIME_SWIFT && (DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED)
-        _os_log_set_nscf_formatter(&os_log_callback);
+        if (_os_log_set_nscf_formatter != NULL) _os_log_set_nscf_formatter(&os_log_callback);
 #endif
         
         __CFInitializing = 0;


### PR DESCRIPTION
The symbol does exist in `libSystem.B.dylib` on 10.12 but does not on 10.11 (which was introduced in #709).

The issue should have been happening in https://github.com/apple/swift-corelibs-xctest/pull/176 and https://github.com/apple/swift-corelibs-xctest/pull/182.

~~The fix is based on this: https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/WeakLinking.html.~~