### PR TITLE
[plutil] Rename enum cases to follow API Design Guidelines

### DIFF
--- a/Tools/plutil/main.swift
+++ b/Tools/plutil/main.swift
@@ -44,9 +44,9 @@ enum ExecutionMode {
 }
 
 enum ConversionFormat {
-    case XML1
-    case Binary1
-    case JSON
+    case xml1
+    case binary1
+    case json
 }
 
 struct Options {
@@ -90,13 +90,13 @@ func parseArguments(_ args: [String]) throws -> Options {
                 if let format = iterator.next() {
                     switch format {
                         case "xml1":
-                            opts.conversionFormat = ConversionFormat.XML1
+                            opts.conversionFormat = .xml1
                             break
                         case "binary1":
-                            opts.conversionFormat = ConversionFormat.Binary1
+                            opts.conversionFormat = .binary1
                             break
                         case "json":
-                            opts.conversionFormat = ConversionFormat.JSON
+                            opts.conversionFormat = .json
                             break
                         default:
                             throw OptionParseError.InvalidFormat(format)

--- a/Tools/plutil/main.swift
+++ b/Tools/plutil/main.swift
@@ -37,10 +37,10 @@ func help() -> Int32 {
 }
 
 enum ExecutionMode {
-    case Help
-    case Lint
-    case Convert
-    case Print
+    case help
+    case lint
+    case convert
+    case print
 }
 
 enum ConversionFormat {
@@ -50,7 +50,7 @@ enum ConversionFormat {
 }
 
 struct Options {
-    var mode: ExecutionMode = .Lint
+    var mode: ExecutionMode = .lint
     var silent: Bool = false
     var output: String?
     var fileExtension: String?
@@ -86,7 +86,7 @@ func parseArguments(_ args: [String]) throws -> Options {
                 }
                 break
             case "-convert":
-                opts.mode = ExecutionMode.Convert
+                opts.mode = .convert
                 if let format = iterator.next() {
                     switch format {
                         case "xml1":
@@ -112,13 +112,13 @@ func parseArguments(_ args: [String]) throws -> Options {
                     throw OptionParseError.MissingArgument("-e requires an extension argument")
                 }
             case "-help":
-                opts.mode = ExecutionMode.Help
+                opts.mode = .help
                 break
             case "-lint":
-                opts.mode = ExecutionMode.Lint
+                opts.mode = .lint
                 break
             case "-p":
-                opts.mode = ExecutionMode.Print
+                opts.mode = .print
                 break
             default:
                 if arg.hasPrefix("-") && arg.utf8.count > 1 {
@@ -366,13 +366,13 @@ func main() -> Int32 {
     do {
         let opts = try parseArguments(args)
         switch opts.mode {
-            case .Lint:
+            case .lint:
                 return lint(opts)
-            case .Convert:
+            case .convert:
                 return convert(opts)
-            case .Print:
+            case .print:
                 return display(opts)
-            case .Help:
+            case .help:
                 return help()
         }
     } catch let err {

--- a/Tools/plutil/main.swift
+++ b/Tools/plutil/main.swift
@@ -60,9 +60,9 @@ struct Options {
 }
 
 enum OptionParseError : Swift.Error {
-    case UnrecognizedArgument(String)
-    case MissingArgument(String)
-    case InvalidFormat(String)
+    case unrecognizedArgument(String)
+    case missingArgument(String)
+    case invalidFormat(String)
 }
 
 func parseArguments(_ args: [String]) throws -> Options {
@@ -82,7 +82,7 @@ func parseArguments(_ args: [String]) throws -> Options {
                 if let path = iterator.next() {
                     opts.output = path
                 } else {
-                    throw OptionParseError.MissingArgument("-o requires a path argument")
+                    throw OptionParseError.missingArgument("-o requires a path argument")
                 }
                 break
             case "-convert":
@@ -99,17 +99,17 @@ func parseArguments(_ args: [String]) throws -> Options {
                             opts.conversionFormat = .json
                             break
                         default:
-                            throw OptionParseError.InvalidFormat(format)
+                            throw OptionParseError.invalidFormat(format)
                     }
                 } else {
-                    throw OptionParseError.MissingArgument("-convert requires a format argument of xml1 binary1 json")
+                    throw OptionParseError.missingArgument("-convert requires a format argument of xml1 binary1 json")
                 }
                 break
             case "-e":
                 if let ext = iterator.next() {
                     opts.fileExtension = ext
                 } else {
-                    throw OptionParseError.MissingArgument("-e requires an extension argument")
+                    throw OptionParseError.missingArgument("-e requires an extension argument")
                 }
             case "-help":
                 opts.mode = .help
@@ -122,7 +122,7 @@ func parseArguments(_ args: [String]) throws -> Options {
                 break
             default:
                 if arg.hasPrefix("-") && arg.utf8.count > 1 {
-                    throw OptionParseError.UnrecognizedArgument(arg)
+                    throw OptionParseError.unrecognizedArgument(arg)
                 }
                 break
         }
@@ -377,14 +377,14 @@ func main() -> Int32 {
         }
     } catch let err {
         switch err as! OptionParseError {
-            case .UnrecognizedArgument(let arg):
+            case .unrecognizedArgument(let arg):
                 print("unrecognized option: \(arg)")
                 let _ = help()
                 break
-            case .InvalidFormat(let format):
+            case .invalidFormat(let format):
                 print("unrecognized format \(format)\nformat should be one of: xml1 binary1 json")
                 break
-            case .MissingArgument(let errorStr):
+            case .missingArgument(let errorStr):
                 print(errorStr)
                 break
         }

--- a/Tools/plutil/main.swift
+++ b/Tools/plutil/main.swift
@@ -183,28 +183,29 @@ func convert(_ options: Options) -> Int32 {
 }
 
 enum DisplayType {
-    case Primary
-    case Key
-    case Value
+    case primary
+    case key
+    case value
 }
 
 extension Dictionary {
-    func display(_ indent: Int = 0, type: DisplayType = .Primary) {
+    func display(_ indent: Int = 0, type: DisplayType = .primary) {
         let indentation = String(repeating: " ", count: indent * 2)
-        if type == .Primary || type == .Key {
+        switch type {
+        case .primary, .key:
             print("\(indentation)[\n", terminator: "")
-        } else {
+        case .value:
             print("[\n", terminator: "")
         }
-        
+
         forEach() {
             if let key = $0.0 as? String {
-                key.display(indent + 1, type: .Key)
+                key.display(indent + 1, type: .key)
             } else {
                 fatalError("plists should have strings as keys but got a \(type(of: $0.0))")
             }
             print(" => ", terminator: "")
-            displayPlist($0.1, indent: indent + 1, type: .Value)
+            displayPlist($0.1, indent: indent + 1, type: .value)
         }
         
         print("\(indentation)]\n", terminator: "")
@@ -212,17 +213,18 @@ extension Dictionary {
 }
 
 extension Array {
-    func display(_ indent: Int = 0, type: DisplayType = .Primary) {
+    func display(_ indent: Int = 0, type: DisplayType = .primary) {
         let indentation = String(repeating: " ", count: indent * 2)
-        if type == .Primary || type == .Key {
+        switch type {
+        case .primary, .key:
             print("\(indentation)[\n", terminator: "")
-        } else {
+        case .value:
             print("[\n", terminator: "")
         }
-        
+
         for idx in 0..<count {
             print("\(indentation)  \(idx) => ", terminator: "")
-            displayPlist(self[idx], indent: indent + 1, type: .Value)
+            displayPlist(self[idx], indent: indent + 1, type: .value)
         }
         
         print("\(indentation)]\n", terminator: "")
@@ -230,62 +232,62 @@ extension Array {
 }
 
 extension String {
-    func display(_ indent: Int = 0, type: DisplayType = .Primary) {
+    func display(_ indent: Int = 0, type: DisplayType = .primary) {
         let indentation = String(repeating: " ", count: indent * 2)
-        if type == .Primary {
+        switch type {
+        case .primary:
             print("\(indentation)\"\(self)\"\n", terminator: "")
-        }
-        else if type == .Key {
+        case .key:
             print("\(indentation)\"\(self)\"", terminator: "")
-        } else {
+        case .value:
             print("\"\(self)\"\n", terminator: "")
         }
     }
 }
 
 extension Bool {
-    func display(_ indent: Int = 0, type: DisplayType = .Primary) {
+    func display(_ indent: Int = 0, type: DisplayType = .primary) {
         let indentation = String(repeating: " ", count: indent * 2)
-        if type == .Primary {
+        switch type {
+        case .primary:
             print("\(indentation)\"\(self ? "1" : "0")\"\n", terminator: "")
-        }
-        else if type == .Key {
+        case .key:
             print("\(indentation)\"\(self ? "1" : "0")\"", terminator: "")
-        } else {
+        case .value:
             print("\"\(self ? "1" : "0")\"\n", terminator: "")
         }
     }
 }
 
 extension NSNumber {
-    func display(_ indent: Int = 0, type: DisplayType = .Primary) {
+    func display(_ indent: Int = 0, type: DisplayType = .primary) {
         let indentation = String(repeating: " ", count: indent * 2)
-        if type == .Primary {
+        switch type {
+        case .primary:
             print("\(indentation)\"\(self)\"\n", terminator: "")
-        }
-        else if type == .Key {
+        case .key:
             print("\(indentation)\"\(self)\"", terminator: "")
-        } else {
+        case .value:
             print("\"\(self)\"\n", terminator: "")
         }
     }
 }
 
 extension NSData {
-    func display(_ indent: Int = 0, type: DisplayType = .Primary) {
+    func display(_ indent: Int = 0, type: DisplayType = .primary) {
         let indentation = String(repeating: " ", count: indent * 2)
-        if type == .Primary {
+        switch type {
+        case .primary:
             print("\(indentation)\"\(self)\"\n", terminator: "")
-        }
-        else if type == .Key {
+        case .key:
             print("\(indentation)\"\(self)\"", terminator: "")
-        } else {
+        case .value:
             print("\"\(self)\"\n", terminator: "")
         }
     }
 }
 
-func displayPlist(_ plist: Any, indent: Int = 0, type: DisplayType = .Primary) {
+func displayPlist(_ plist: Any, indent: Int = 0, type: DisplayType = .primary) {
     if let val = plist as? Dictionary<String, Any> {
         val.display(indent, type: type)
     } else if let val = plist as? Array<Any> {

--- a/Tools/plutil/main.swift
+++ b/Tools/plutil/main.swift
@@ -74,37 +74,30 @@ func parseArguments(_ args: [String]) throws -> Options {
                 while let path = iterator.next() {
                     opts.inputs.append(path)
                 }
-                break
             case "-s":
                 opts.silent = true
-                break
             case "-o":
                 if let path = iterator.next() {
                     opts.output = path
                 } else {
                     throw OptionParseError.missingArgument("-o requires a path argument")
                 }
-                break
             case "-convert":
                 opts.mode = .convert
                 if let format = iterator.next() {
                     switch format {
                         case "xml1":
                             opts.conversionFormat = .xml1
-                            break
                         case "binary1":
                             opts.conversionFormat = .binary1
-                            break
                         case "json":
                             opts.conversionFormat = .json
-                            break
                         default:
                             throw OptionParseError.invalidFormat(format)
                     }
                 } else {
                     throw OptionParseError.missingArgument("-convert requires a format argument of xml1 binary1 json")
                 }
-                break
             case "-e":
                 if let ext = iterator.next() {
                     opts.fileExtension = ext
@@ -113,18 +106,14 @@ func parseArguments(_ args: [String]) throws -> Options {
                 }
             case "-help":
                 opts.mode = .help
-                break
             case "-lint":
                 opts.mode = .lint
-                break
             case "-p":
                 opts.mode = .print
-                break
             default:
                 if arg.hasPrefix("-") && arg.utf8.count > 1 {
                     throw OptionParseError.unrecognizedArgument(arg)
                 }
-                break
         }
     }
     
@@ -380,13 +369,10 @@ func main() -> Int32 {
             case .unrecognizedArgument(let arg):
                 print("unrecognized option: \(arg)")
                 let _ = help()
-                break
             case .invalidFormat(let format):
                 print("unrecognized format \(format)\nformat should be one of: xml1 binary1 json")
-                break
             case .missingArgument(let errorStr):
                 print(errorStr)
-                break
         }
         return EXIT_FAILURE
     }


### PR DESCRIPTION
- `ExecutionMode`
- `ConversionFormat`
- `OptionParseError`
- `DisplayType`
