### PR TITLE
[NotificationQueue] Rename APIs to match the Darwin version

### DIFF
--- a/Foundation/NSNotificationQueue.swift
+++ b/Foundation/NSNotificationQueue.swift
@@ -87,7 +87,7 @@ open class NotificationQueue: NSObject {
         }
 
         if !coalesceMask.isEmpty {
-            self.dequeueNotificationsMatching(notification, coalesceMask: coalesceMask)
+            self.dequeueNotifications(matching: notification, coalesceMask: coalesceMask)
         }
 
         switch postingStyle {
@@ -105,7 +105,7 @@ open class NotificationQueue: NSObject {
         }
     }
     
-    open func dequeueNotificationsMatching(_ notification: Notification, coalesceMask: NotificationCoalescing) {
+    open func dequeueNotifications(matching notification: Notification, coalesceMask: NotificationCoalescing) {
         var predicate: (NSNotificationListEntry) -> Bool
         switch coalesceMask {
         case [.onName, .onSender]:

--- a/Foundation/NSNotificationQueue.swift
+++ b/Foundation/NSNotificationQueue.swift
@@ -58,7 +58,7 @@ open class NotificationQueue: NSObject {
 
     // The default notification queue for the current thread.
     private static var _defaultQueue = NSThreadSpecific<NotificationQueue>()
-    open class func defaultQueue() -> NotificationQueue {
+    open class var `default`: NotificationQueue {
         return _defaultQueue.get() {
             return NotificationQueue(notificationCenter: NotificationCenter.default)
         }

--- a/Foundation/NSNotificationQueue.swift
+++ b/Foundation/NSNotificationQueue.swift
@@ -76,11 +76,11 @@ open class NotificationQueue: NSObject {
         removeRunloopObserver(self.asapRunloopObserver)
     }
 
-    open func enqueueNotification(_ notification: Notification, postingStyle: PostingStyle) {
-        enqueueNotification(notification, postingStyle: postingStyle, coalesceMask: [.onName, .onSender], forModes: nil)
+    open func enqueue(_ notification: Notification, postingStyle: PostingStyle) {
+        enqueue(notification, postingStyle: postingStyle, coalesceMask: [.onName, .onSender], forModes: nil)
     }
 
-    open func enqueueNotification(_ notification: Notification, postingStyle: PostingStyle, coalesceMask: NotificationCoalescing, forModes modes: [RunLoopMode]?) {
+    open func enqueue(_ notification: Notification, postingStyle: PostingStyle, coalesceMask: NotificationCoalescing, forModes modes: [RunLoopMode]?) {
         var runloopModes: [RunLoopMode] = [.defaultRunLoopMode]
         if let modes = modes  {
             runloopModes = modes

--- a/TestFoundation/TestNSNotificationQueue.swift
+++ b/TestFoundation/TestNSNotificationQueue.swift
@@ -33,15 +33,15 @@ class TestNSNotificationQueue : XCTestCase {
     }
 
     func test_defaultQueue() {
-        let defaultQueue1 = NotificationQueue.defaultQueue()
+        let defaultQueue1 = NotificationQueue.default
         XCTAssertNotNil(defaultQueue1)
-        let defaultQueue2 = NotificationQueue.defaultQueue()
+        let defaultQueue2 = NotificationQueue.default
         XCTAssertEqual(defaultQueue1, defaultQueue2)
 
         executeInBackgroundThread() {
-            let defaultQueueForBackgroundThread = NotificationQueue.defaultQueue()
+            let defaultQueueForBackgroundThread = NotificationQueue.default
             XCTAssertNotNil(defaultQueueForBackgroundThread)
-            XCTAssertEqual(defaultQueueForBackgroundThread, NotificationQueue.defaultQueue())
+            XCTAssertEqual(defaultQueueForBackgroundThread, NotificationQueue.default)
             XCTAssertNotEqual(defaultQueueForBackgroundThread, defaultQueue1)
         }
     }
@@ -54,7 +54,7 @@ class TestNSNotificationQueue : XCTestCase {
         let obs = NotificationCenter.default.addObserver(forName: notificationName, object: dummyObject, queue: nil) { notification in
             numberOfCalls += 1
         }
-        let queue = NotificationQueue.defaultQueue()
+        let queue = NotificationQueue.default
         queue.enqueueNotification(notification, postingStyle: .postNow)
         XCTAssertEqual(numberOfCalls, 1)
         NotificationCenter.default.removeObserver(obs)
@@ -68,7 +68,7 @@ class TestNSNotificationQueue : XCTestCase {
         let obs = NotificationCenter.default.addObserver(forName: notificationName, object: dummyObject, queue: nil) { notification in
             numberOfCalls += 1
         }
-        let queue = NotificationQueue.defaultQueue()
+        let queue = NotificationQueue.default
         queue.enqueueNotification(notification, postingStyle: .postNow)
         queue.enqueueNotification(notification, postingStyle: .postNow)
         queue.enqueueNotification(notification, postingStyle: .postNow)
@@ -100,7 +100,7 @@ class TestNSNotificationQueue : XCTestCase {
         let obs = NotificationCenter.default.addObserver(forName: notificationName, object: dummyObject, queue: nil) { notification in
             numberOfCalls += 1
         }
-        let queue = NotificationQueue.defaultQueue()
+        let queue = NotificationQueue.default
 
         let runLoop = RunLoop.current
         let endDate = Date(timeInterval: TimeInterval(0.05), since: Date())
@@ -131,7 +131,7 @@ class TestNSNotificationQueue : XCTestCase {
         let obs = NotificationCenter.default.addObserver(forName: notificationName, object: dummyObject, queue: nil) { notification in
             numberOfCalls += 1
         }
-        let queue = NotificationQueue.defaultQueue()
+        let queue = NotificationQueue.default
         queue.enqueueNotification(notification, postingStyle: .postASAP)
 
         scheduleTimer(withInterval: 0.001) // run timer trigger the notifications
@@ -147,7 +147,7 @@ class TestNSNotificationQueue : XCTestCase {
         let obs = NotificationCenter.default.addObserver(forName: notificationName, object: notification.object, queue: nil) { notification in
             numberOfCalls += 1
         }
-        let queue = NotificationQueue.defaultQueue()
+        let queue = NotificationQueue.default
         queue.enqueueNotification(notification, postingStyle: .postASAP)
         queue.enqueueNotification(notification, postingStyle: .postASAP)
         queue.enqueueNotification(notification, postingStyle: .postASAP)
@@ -171,7 +171,7 @@ class TestNSNotificationQueue : XCTestCase {
             numberOfObjectCoalescingCalls += 1
         }
 
-        let queue = NotificationQueue.defaultQueue()
+        let queue = NotificationQueue.default
         // #1
         queue.enqueueNotification(notification1, postingStyle: .postASAP,  coalesceMask: .onName, forModes: nil)
         // #2
@@ -200,7 +200,7 @@ class TestNSNotificationQueue : XCTestCase {
         let obs = NotificationCenter.default.addObserver(forName: notificationName, object: dummyObject, queue: nil) { notification in
             numberOfCalls += 1
         }
-        NotificationQueue.defaultQueue().enqueueNotification(notification, postingStyle: .postWhenIdle)
+        NotificationQueue.default.enqueueNotification(notification, postingStyle: .postWhenIdle)
         // add a timer to wakeup the runloop, process the timer and call the observer awaiting for any input sources/timers
         scheduleTimer(withInterval: 0.001)
         XCTAssertEqual(numberOfCalls, 1)

--- a/TestFoundation/TestNSNotificationQueue.swift
+++ b/TestFoundation/TestNSNotificationQueue.swift
@@ -55,7 +55,7 @@ class TestNSNotificationQueue : XCTestCase {
             numberOfCalls += 1
         }
         let queue = NotificationQueue.default
-        queue.enqueueNotification(notification, postingStyle: .postNow)
+        queue.enqueue(notification, postingStyle: .postNow)
         XCTAssertEqual(numberOfCalls, 1)
         NotificationCenter.default.removeObserver(obs)
     }
@@ -69,9 +69,9 @@ class TestNSNotificationQueue : XCTestCase {
             numberOfCalls += 1
         }
         let queue = NotificationQueue.default
-        queue.enqueueNotification(notification, postingStyle: .postNow)
-        queue.enqueueNotification(notification, postingStyle: .postNow)
-        queue.enqueueNotification(notification, postingStyle: .postNow)
+        queue.enqueue(notification, postingStyle: .postNow)
+        queue.enqueue(notification, postingStyle: .postNow)
+        queue.enqueue(notification, postingStyle: .postNow)
         // Coalescing doesn't work for the NSPostingStyle.PostNow. That is why we expect 3 calls here
         XCTAssertEqual(numberOfCalls, 3)
         NotificationCenter.default.removeObserver(obs)
@@ -87,7 +87,7 @@ class TestNSNotificationQueue : XCTestCase {
             numberOfCalls += 1
         }
         let notificationQueue = NotificationQueue(notificationCenter: notificationCenter)
-        notificationQueue.enqueueNotification(notification, postingStyle: .postNow)
+        notificationQueue.enqueue(notification, postingStyle: .postNow)
         XCTAssertEqual(numberOfCalls, 1)
         NotificationCenter.default.removeObserver(obs)
     }
@@ -111,11 +111,11 @@ class TestNSNotificationQueue : XCTestCase {
             }
 
             // post 2 notifications for the NSDefaultRunLoopMode mode
-            queue.enqueueNotification(notification, postingStyle: .postNow, coalesceMask: [], forModes: [runLoopMode])
-            queue.enqueueNotification(notification, postingStyle: .postNow)
+            queue.enqueue(notification, postingStyle: .postNow, coalesceMask: [], forModes: [runLoopMode])
+            queue.enqueue(notification, postingStyle: .postNow)
             // here we post notification for the NSRunLoopCommonModes. It shouldn't have any affect, because the timer is scheduled in NSDefaultRunLoopMode.
             // The notification queue will only post the notification to its notification center if the run loop is in one of the modes provided in the array.
-            queue.enqueueNotification(notification, postingStyle: .postNow, coalesceMask: [], forModes: [.commonModes])
+            queue.enqueue(notification, postingStyle: .postNow, coalesceMask: [], forModes: [.commonModes])
         }
         runLoop.add(dummyTimer, forMode: .defaultRunLoopMode)
         let _ = runLoop.run(mode: .defaultRunLoopMode, before: endDate)
@@ -132,7 +132,7 @@ class TestNSNotificationQueue : XCTestCase {
             numberOfCalls += 1
         }
         let queue = NotificationQueue.default
-        queue.enqueueNotification(notification, postingStyle: .postASAP)
+        queue.enqueue(notification, postingStyle: .postASAP)
 
         scheduleTimer(withInterval: 0.001) // run timer trigger the notifications
         XCTAssertEqual(numberOfCalls, 1)
@@ -148,9 +148,9 @@ class TestNSNotificationQueue : XCTestCase {
             numberOfCalls += 1
         }
         let queue = NotificationQueue.default
-        queue.enqueueNotification(notification, postingStyle: .postASAP)
-        queue.enqueueNotification(notification, postingStyle: .postASAP)
-        queue.enqueueNotification(notification, postingStyle: .postASAP)
+        queue.enqueue(notification, postingStyle: .postASAP)
+        queue.enqueue(notification, postingStyle: .postASAP)
+        queue.enqueue(notification, postingStyle: .postASAP)
 
         scheduleTimer(withInterval: 0.001)
         XCTAssertEqual(numberOfCalls, 1)
@@ -173,15 +173,15 @@ class TestNSNotificationQueue : XCTestCase {
 
         let queue = NotificationQueue.default
         // #1
-        queue.enqueueNotification(notification1, postingStyle: .postASAP,  coalesceMask: .onName, forModes: nil)
+        queue.enqueue(notification1, postingStyle: .postASAP,  coalesceMask: .onName, forModes: nil)
         // #2
-        queue.enqueueNotification(notification2, postingStyle: .postASAP,  coalesceMask: .onSender, forModes: nil)
+        queue.enqueue(notification2, postingStyle: .postASAP,  coalesceMask: .onSender, forModes: nil)
         // #3, coalesce with 1 & 2
-        queue.enqueueNotification(notification1, postingStyle: .postASAP,  coalesceMask: .onName, forModes: nil)
+        queue.enqueue(notification1, postingStyle: .postASAP,  coalesceMask: .onName, forModes: nil)
         // #4, coalesce with #3
-        queue.enqueueNotification(notification2, postingStyle: .postASAP,  coalesceMask: .onName, forModes: nil)
+        queue.enqueue(notification2, postingStyle: .postASAP,  coalesceMask: .onName, forModes: nil)
         // #5
-        queue.enqueueNotification(notification1, postingStyle: .postASAP,  coalesceMask: .onSender, forModes: nil)
+        queue.enqueue(notification1, postingStyle: .postASAP,  coalesceMask: .onSender, forModes: nil)
         scheduleTimer(withInterval: 0.001)
         // check that we received notifications #4 and #5
         XCTAssertEqual(numberOfNameCoalescingCalls, 1)
@@ -200,7 +200,7 @@ class TestNSNotificationQueue : XCTestCase {
         let obs = NotificationCenter.default.addObserver(forName: notificationName, object: dummyObject, queue: nil) { notification in
             numberOfCalls += 1
         }
-        NotificationQueue.default.enqueueNotification(notification, postingStyle: .postWhenIdle)
+        NotificationQueue.default.enqueue(notification, postingStyle: .postWhenIdle)
         // add a timer to wakeup the runloop, process the timer and call the observer awaiting for any input sources/timers
         scheduleTimer(withInterval: 0.001)
         XCTAssertEqual(numberOfCalls, 1)


### PR DESCRIPTION
- `defaultQueue()` -> `default`
- `enqueueNotification()` -> `enqueue()`
- `dequeueNotificationsMatching()` -> `dequeueNotifications()`
