### PR TITLE
Fix for [SR-3448] Crash in String.replacingOccurrences(of:with:) with…

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -1272,10 +1272,9 @@ open class NSMutableString : NSString {
             NSRequiresConcreteImplementation()
         }
 
-        // this is incorrectly calculated for grapheme clusters that have a size greater than a single unichar
-        let start = _storage.startIndex
-        let min = _storage.index(start, offsetBy: range.location)
-        let max = _storage.index(start, offsetBy: range.location + range.length)
+        let start = _storage.utf16.startIndex
+        let min = _storage.utf16.index(start, offsetBy: range.location).samePosition(in: _storage)!
+        let max = _storage.utf16.index(start, offsetBy: range.location + range.length).samePosition(in: _storage)!
         _storage.replaceSubrange(min..<max, with: aString)
     }
     

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -93,6 +93,7 @@ class TestNSString : XCTestCase {
             ("test_PrefixSuffix", test_PrefixSuffix),
             ("test_utf16StringRangeCount", test_StringUTF16ViewIndexStrideableRange),
             ("test_reflection", { _ in test_reflection }),
+            ("test_replacingOccurrences", test_replacingOccurrences),
         ]
     }
 
@@ -1228,4 +1229,43 @@ extension TestNSString {
 }
 
 func test_reflection() {
+}
+
+extension TestNSString {
+    func test_replacingOccurrences() {
+        let testPrefix = "ab"
+        let testSuffix = "cd"
+        let testEmoji = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}"
+        let testString = testPrefix + testEmoji + testSuffix
+
+        let testReplacement = "xyz"
+        let testReplacementEmoji = "\u{01F468}\u{200D}\u{002764}\u{00FE0F}\u{200D}\u{01F48B}\u{200D}\u{01F468}"
+
+        let noChange = testString.replacingOccurrences(of: testReplacement, with: "")
+        XCTAssertEqual(noChange, testString)
+
+        let removePrefix = testString.replacingOccurrences(of: testPrefix, with: "")
+        XCTAssertEqual(removePrefix, testEmoji + testSuffix)
+        let replacePrefix = testString.replacingOccurrences(of: testPrefix, with: testReplacement)
+        XCTAssertEqual(replacePrefix, testReplacement + testEmoji + testSuffix)
+
+        let removeSuffix = testString.replacingOccurrences(of: testSuffix, with: "")
+        XCTAssertEqual(removeSuffix, testPrefix + testEmoji)
+        let replaceSuffix = testString.replacingOccurrences(of: testSuffix, with: testReplacement)
+        XCTAssertEqual(replaceSuffix, testPrefix + testEmoji + testReplacement)
+
+        let removeMultibyte = testString.replacingOccurrences(of: testEmoji, with: "")
+        XCTAssertEqual(removeMultibyte, testPrefix + testSuffix)
+        let replaceMultibyte = testString.replacingOccurrences(of: testEmoji, with: testReplacement)
+        XCTAssertEqual(replaceMultibyte, testPrefix + testReplacement + testSuffix)
+
+        let replaceMultibyteWithMultibyte = testString.replacingOccurrences(of: testEmoji, with: testReplacementEmoji)
+        XCTAssertEqual(replaceMultibyteWithMultibyte, testPrefix + testReplacementEmoji + testSuffix)
+
+        let replacePrefixWithMultibyte = testString.replacingOccurrences(of: testPrefix, with: testReplacementEmoji)
+        XCTAssertEqual(replacePrefixWithMultibyte, testReplacementEmoji + testEmoji + testSuffix)
+
+        let replaceSuffixWithMultibyte = testString.replacingOccurrences(of: testSuffix, with: testReplacementEmoji)
+        XCTAssertEqual(replaceSuffixWithMultibyte, testPrefix + testEmoji + testReplacementEmoji)
+    }
 }


### PR DESCRIPTION
… emoji on Linux

Foundation.NSMutableString.replaceCharacters assumed that the passed-in NSRange was character-based but it's UTF-16 based.

The fix was to use the UTF-16 view and then convert the indexes back to characters.

---

All credit to @allevato for coming up with the fix.

This also resolves [SR-3449].