### PR TITLE
Fix building NSHost.swift on macOS

### DIFF
--- a/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
+++ b/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
@@ -43,6 +43,10 @@
 #include <netdb.h> // for NSHost.swift
 #endif
 
+#if __has_include(<ifaddrs.h>)
+#include <ifaddrs.h> // for NSHost.swift
+#endif
+
 #if defined(__STDC_VERSION__) && (199901L <= __STDC_VERSION__)
 
 #include <inttypes.h>

--- a/Foundation/NSHost.swift
+++ b/Foundation/NSHost.swift
@@ -79,8 +79,8 @@ open class Host: NSObject {
         while let ifaValue = ifa?.pointee {
             if let ifa_addr = ifaValue.ifa_addr, ifaValue.ifa_flags & UInt32(IFF_LOOPBACK) == 0 {
                 let family = ifa_addr.pointee.sa_family
-                if family == UInt16(AF_INET) || family == UInt16(AF_INET6) {
-                    let sa_len: socklen_t = socklen_t((family == UInt16(AF_INET6)) ? MemoryLayout<sockaddr_in6>.size : MemoryLayout<sockaddr_in>.size)
+                if family == sa_family_t(AF_INET) || family == sa_family_t(AF_INET6) {
+                    let sa_len: socklen_t = socklen_t((family == sa_family_t(AF_INET6)) ? MemoryLayout<sockaddr_in6>.size : MemoryLayout<sockaddr_in>.size)
                     if getnameinfo(ifa_addr, sa_len, address, socklen_t(NI_MAXHOST), nil, 0, NI_NUMERICHOST) == 0 {
                         _addresses.append(String(cString: address))
                     }


### PR DESCRIPTION
Related to #638.

- Import `<ifaddrs.h>` in `SwiftRuntime/CoreFoundation.h`
- Use `sa_family_t` which is `UInt8` on macOS instead of explicit `UInt16`