### PR TITLE
Calendar components from:to: date fix

### DIFF
--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -603,8 +603,7 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
             }
 
             return vector.withUnsafeMutableBufferPointer { (vecBuffer: inout UnsafeMutableBufferPointer<UnsafeMutablePointer<Int32>>) in
-                _CFCalendarGetComponentDifferenceV(_cfObject, startingDate.timeIntervalSinceReferenceDate, resultDate.timeIntervalSinceReferenceDate, CFOptionFlags(opts.rawValue), compDesc, vecBuffer.baseAddress!, Int32(vector.count))
-                return false
+                return _CFCalendarGetComponentDifferenceV(_cfObject, startingDate.timeIntervalSinceReferenceDate, resultDate.timeIntervalSinceReferenceDate, CFOptionFlags(opts.rawValue), compDesc, vecBuffer.baseAddress!, Int32(vector.count))
             }
         }
         if res {

--- a/TestFoundation/TestNSCalendar.swift
+++ b/TestFoundation/TestNSCalendar.swift
@@ -63,11 +63,29 @@ class TestNSCalendar: XCTestCase {
         
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(identifier: "UTC")!
-         let components = calendar.dateComponents([.year, .month, .day], from: date)
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
         
         XCTAssertEqual(components.year, 2015)
         XCTAssertEqual(components.month, 12)
         XCTAssertEqual(components.day, 5)
+
+        // Test for problem reported by Malcolm Barclay via swift-corelibs-dev
+        // https://lists.swift.org/pipermail/swift-corelibs-dev/Week-of-Mon-20161128/001031.html
+        let fromDate = Date()
+        let interval = 200
+        let toDate = Date(timeInterval: TimeInterval(interval), since: fromDate)
+        let fromToComponents = calendar.dateComponents([.second], from: fromDate, to: toDate)
+        XCTAssertEqual(fromToComponents.second, interval);
+
+        // Issue with 32-bit CF calendar vector on Linux
+        // Crashes on macOS 10.12.2/Foundation 1349.25
+        // (Possibly related) rdar://24384757
+        /*
+        let interval2 = Int(INT32_MAX) + 1
+        let toDate2 = Date(timeInterval: TimeInterval(interval2), since: fromDate)
+        let fromToComponents2 = calendar.dateComponents([.second], from: fromDate, to: toDate2)
+        XCTAssertEqual(fromToComponents2.second, interval2);
+        */
     }
 
     func test_gettingDatesOnISO8601Calendar() {


### PR DESCRIPTION
With basic single-component (second) test

Issue reported by Malcolm Barclay via swift-corelibs-dev