### PR TITLE
SR-3658 – Fix error in importing Foundation

### DIFF
--- a/CoreFoundation/Base.subproj/CFBase.h
+++ b/CoreFoundation/Base.subproj/CFBase.h
@@ -68,10 +68,6 @@
 #include <stdbool.h>
 #endif
 
-#if __BLOCKS__
-#include <Block.h>
-#endif
-
   #if ((TARGET_OS_MAC && !(TARGET_OS_EMBEDDED || TARGET_OS_IPHONE)) || (TARGET_OS_EMBEDDED || TARGET_OS_IPHONE)) && !DEPLOYMENT_RUNTIME_SWIFT
     #include <libkern/OSTypes.h>
   #endif


### PR DESCRIPTION
SR-3658 – Fix error in importing Foundation under Linux. This commit may resolve the described error.

Honestly, I have no idea if this'll work. My machine does not have the horsepower to compile this project, but at the very least maybe the CI can take a crack at it. From a cursory review this line seems unnecessary.