### PR TITLE
Make sure that os_log is turned off for both Darwin and Linux

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -104,14 +104,14 @@ CF_EXTERN_C_BEGIN
 #endif
 #include <pthread.h>
 
-#if __has_include(<os/log.h>)
+#if !DEPLOYMENT_RUNTIME_SWIFT && __has_include(<os/log.h>)
 #import <os/log.h>
 #else
 typedef struct os_log_s *os_log_t;
-#define os_log(...)
-#define os_log_info(...)
-#define os_log_debug(...)
-#define os_log_error(...)
+#define os_log(...) do { } while (0)
+#define os_log_info(...) do { } while (0)
+#define os_log_debug(...) do { } while (0)
+#define os_log_error(...) do { } while (0)
 #define os_log_create(...) (NULL)
 #endif
 

--- a/CoreFoundation/RunLoop.subproj/CFMachPort.c
+++ b/CoreFoundation/RunLoop.subproj/CFMachPort.c
@@ -20,7 +20,6 @@
 #include <stdio.h>
 #include "CFInternal.h"
 #include <os/lock.h>
-#include <os/log.h>
 
 
 // This queue is used for the cancel/event handler for dead name notification.


### PR DESCRIPTION
`os_log` calls back into CF on Darwin (for the ability to print `NSObject` types). However, this CF that we're testing in `swift-corelibs-foundation` is not the system one, and the types don't implement the expected forwarding protocols. Better to just disable this on all platforms.

Fixes SR-3703.