### PR TITLE
[URLSession]Fix a crash in _HTTPBodyDataSource.getNextChunk()

### DIFF
--- a/Foundation/NSURLSession/HTTPBodySource.swift
+++ b/Foundation/NSURLSession/HTTPBodySource.swift
@@ -81,7 +81,7 @@ extension _HTTPBodyDataSource : _HTTPBodySource {
             return .done
         } else if remaining <= length {
             let r: DispatchData! = data
-            data = nil
+            data = DispatchData.empty 
             return .data(r)
         } else {
             let (chunk, remainder) = splitData(dispatchData: data, atPosition: length)


### PR DESCRIPTION
I came across this bug while investigating another URLSession failure. URLSession uses the CURLOPT_READFUNCTION callback to write data to a socket during uploads. This writing happens in chunks of 16K. The `getNextChunk` is used to split the body which is wrapped in DispatchData into a writable chunk (typically 16K with libcurl) and the remaining data. When the remaining data is lesser than 16K, we do not split the data and send it as is, making sure that the next call to `getNextChunk` will indicate completion (return length = 0). However, because we set data to `nil`, the last call to `getNextChunk` in a large transfer is bound to crash [here](https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/NSURLSession/HTTPBodySource.swift#L79). 

Instead of setting data to `nil` we can set it to `DispatchData.empty`.  It looks like this was the intention in the [original PR](https://github.com/apple/swift-corelibs-foundation/pull/299/files#diff-cd8689db2e798d85d6904857d8a52e92R105) but we seemed to have introduced this bug while updating PR 299 for the new Dispatch API in Swift 3. 