### PR TITLE
Restore use of #include

### DIFF
--- a/CoreFoundation/Base.subproj/ForFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForFoundationOnly.h
@@ -63,7 +63,7 @@ CF_IMPLICIT_BRIDGING_DISABLED
 #endif
 
 #if (INCLUDE_OBJC || DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_WINDOWS) && !DEPLOYMENT_RUNTIME_SWIFT
-#import <objc/message.h>
+#include <objc/message.h>
 #endif
 
 // ---- CFBundle material ----------------------------------------


### PR DESCRIPTION
A change made in #663 was overwritten by #709. This change restores the switch from `#import` to `#include`.

The reason for this change is: Clang's MSVC compatibility does not handle `#import` statements outside of of objc.

> `#import` of type library is an unsupported Microsoft feature