### PR TITLE
[HTTPCookie] Make cookies(withResponseHeaderFields:for:) signature match Darwin

### DIFF
--- a/Foundation/NSHTTPCookie.swift
+++ b/Foundation/NSHTTPCookie.swift
@@ -380,7 +380,7 @@ open class HTTPCookie : NSObject {
     /// - Parameter headerFields: The response header fields to check for cookies.
     /// - Parameter URL: The URL that the cookies came from - relevant to how the cookies are interpeted.
     /// - Returns: An array of NSHTTPCookie objects
-    open class func cookies(withResponseHeaderFields headerFields: [String : String], forURL url: URL) -> [HTTPCookie] {
+    open class func cookies(withResponseHeaderFields headerFields: [String : String], for URL: URL) -> [HTTPCookie] {
 
         //HTTP Cookie parsing based on RFC 6265: https://tools.ietf.org/html/rfc6265
         //Though RFC6265 suggests that multiple cookies cannot be folded into a single Set-Cookie field, this is
@@ -405,7 +405,7 @@ open class HTTPCookie : NSObject {
         //bake the cookies
         var httpCookies: [HTTPCookie] = []
         for i in 0..<cookieIndices.count-1 {
-            if let aCookie = createHttpCookie(url: url, pairs: nameValuePairs[cookieIndices[i]..<cookieIndices[i+1]]) {
+            if let aCookie = createHttpCookie(url: URL, pairs: nameValuePairs[cookieIndices[i]..<cookieIndices[i+1]]) {
                 httpCookies.append(aCookie)
             }
         }

--- a/TestFoundation/TestNSHTTPCookie.swift
+++ b/TestFoundation/TestNSHTTPCookie.swift
@@ -125,7 +125,7 @@ class TestNSHTTPCookie: XCTestCase {
                       "Set-Cookie": "fr=anjd&232; Max-Age=7776000; path=/; domain=.example.com; secure; httponly",
                       "header2":"value2",
                       "header3":"value3"]
-        let cookies = HTTPCookie.cookies(withResponseHeaderFields: header, forURL: URL(string: "http://example.com")!)
+        let cookies = HTTPCookie.cookies(withResponseHeaderFields: header, for: URL(string: "http://example.com")!)
         XCTAssertEqual(cookies.count, 1)
         XCTAssertEqual(cookies[0].name, "fr")
         XCTAssertEqual(cookies[0].value, "anjd&232")
@@ -133,7 +133,7 @@ class TestNSHTTPCookie: XCTestCase {
 
     func test_cookiesWithResponseHeader0cookies() {
         let header = ["header1":"value1", "header2":"value2", "header3":"value3"]
-        let cookies =  HTTPCookie.cookies(withResponseHeaderFields: header, forURL: URL(string: "http://example.com")!)
+        let cookies =  HTTPCookie.cookies(withResponseHeaderFields: header, for: URL(string: "http://example.com")!)
         XCTAssertEqual(cookies.count, 0)
     }
 
@@ -142,7 +142,7 @@ class TestNSHTTPCookie: XCTestCase {
                       "Set-Cookie": "fr=a&2@#; Max-Age=1186000; path=/; domain=.example.com; secure, xd=plm!@#;path=/;domain=.example2.com", 
                       "header2":"value2",
                       "header3":"value3"]
-        let cookies =  HTTPCookie.cookies(withResponseHeaderFields: header, forURL: URL(string: "http://example.com")!)
+        let cookies =  HTTPCookie.cookies(withResponseHeaderFields: header, for: URL(string: "http://example.com")!)
         XCTAssertEqual(cookies.count, 2)
         XCTAssertTrue(cookies[0].isSecure)
         XCTAssertFalse(cookies[1].isSecure)
@@ -153,7 +153,7 @@ class TestNSHTTPCookie: XCTestCase {
                        "Set-Cookie": "fr=anjd&232; expires=Wed, 21 Sep 2016 05:33:00 GMT; Max-Age=7776000; path=/; secure; httponly",
                        "header2":"value2",
                        "header3":"value3"]
-        let cookies =  HTTPCookie.cookies(withResponseHeaderFields: header, forURL: URL(string: "http://example.com")!)
+        let cookies =  HTTPCookie.cookies(withResponseHeaderFields: header, for: URL(string: "http://example.com")!)
         XCTAssertEqual(cookies[0].domain, "http://example.com")
         XCTAssertNotNil(cookies[0].expiresDate)
 
@@ -173,7 +173,7 @@ class TestNSHTTPCookie: XCTestCase {
                       "Set-Cookie": "fr=tx; expires=Wed, 21-Sep-2016 05:33:00 GMT; Max-Age=7776000; secure; httponly", 
                       "header2":"value2",
                       "header3":"value3"]
-        let cookies =  HTTPCookie.cookies(withResponseHeaderFields: header, forURL: URL(string: "http://example.com")!)
+        let cookies =  HTTPCookie.cookies(withResponseHeaderFields: header, for: URL(string: "http://example.com")!)
         XCTAssertEqual(cookies[0].domain, "http://example.com")
         XCTAssertEqual(cookies[0].path, "/")
     }


### PR DESCRIPTION
I'd be grateful if this API signature fix could make it into Swift 3.1.  Thanks.