### PR TITLE
[Cherry Picked] SR-3658 – Fix error in importing Foundation

### DIFF
--- a/CoreFoundation/Base.subproj/CFBase.h
+++ b/CoreFoundation/Base.subproj/CFBase.h
@@ -68,10 +68,6 @@
 #include <stdbool.h>
 #endif
 
-#if __BLOCKS__
-#include <Block.h>
-#endif
-
   #if ((TARGET_OS_MAC && !(TARGET_OS_EMBEDDED || TARGET_OS_IPHONE)) || (TARGET_OS_EMBEDDED || TARGET_OS_IPHONE)) && !DEPLOYMENT_RUNTIME_SWIFT
     #include <libkern/OSTypes.h>
   #endif


### PR DESCRIPTION
SR-3658 – Fix error in importing Foundation under Linux. This commit may resolve the described error.