### PR TITLE
Revert "Revert "[NSError] Use Error for user info providers to match the Darwin version""

### DIFF
--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -144,14 +144,14 @@ open class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
         return userInfo[NSHelpAnchorErrorKey] as? String
     }
     
-    internal typealias NSErrorProvider = (_ error: NSError, _ key: String) -> Any?
-    internal static var userInfoProviders = [String: NSErrorProvider]()
+    internal typealias UserInfoProvider = (_ error: Error, _ key: String) -> Any?
+    internal static var userInfoProviders = [String: UserInfoProvider]()
     
-    open class func setUserInfoValueProvider(forDomain errorDomain: String, provider: (/* @escaping */ (NSError, String) -> Any?)?) {
+    open class func setUserInfoValueProvider(forDomain errorDomain: String, provider: (/* @escaping */ (Error, String) -> Any?)?) {
         NSError.userInfoProviders[errorDomain] = provider
     }
 
-    open class func userInfoValueProvider(forDomain errorDomain: String) -> ((NSError, String) -> Any?)? {
+    open class func userInfoValueProvider(forDomain errorDomain: String) -> ((Error, String) -> Any?)? {
         return NSError.userInfoProviders[errorDomain]
     }
     


### PR DESCRIPTION
Reverts apple/swift-corelibs-foundation#838

https://github.com/apple/swift-corelibs-foundation/pull/833#issuecomment-277047371