### PR TITLE
build static foundation

### DIFF
--- a/build.py
+++ b/build.py
@@ -9,7 +9,7 @@
 
 script = Script()
 
-foundation = DynamicLibrary("Foundation")
+foundation = StaticAndDynamicLibrary("Foundation")
 
 foundation.GCC_PREFIX_HEADER = 'CoreFoundation/Base.subproj/CoreFoundation_Prefix.h'
 
@@ -504,6 +504,8 @@ extra_script = """
 rule InstallFoundation
     command = mkdir -p "${DSTROOT}/${PREFIX}/lib/swift/${OS}"; $
     cp "${BUILD_DIR}/Foundation/${DYLIB_PREFIX}Foundation${DYLIB_SUFFIX}" "${DSTROOT}/${PREFIX}/lib/swift/${OS}"; $
+    mkdir -p "${DSTROOT}/${PREFIX}/lib/swift_static/${OS}"; $
+    cp "${BUILD_DIR}/Foundation/${STATICLIB_PREFIX}Foundation${STATICLIB_SUFFIX}" "${DSTROOT}/${PREFIX}/lib/swift_static/${OS}"; $
     mkdir -p "${DSTROOT}/${PREFIX}/lib/swift/${OS}/${ARCH}"; $
     cp "${BUILD_DIR}/Foundation/Foundation.swiftmodule" "${DSTROOT}/${PREFIX}/lib/swift/${OS}/${ARCH}/"; $
     cp "${BUILD_DIR}/Foundation/Foundation.swiftdoc" "${DSTROOT}/${PREFIX}/lib/swift/${OS}/${ARCH}/"; $

--- a/configure
+++ b/configure
@@ -28,6 +28,7 @@ from lib.phases import SwiftExecutable
 from lib.product import DynamicLibrary
 from lib.product import Framework
 from lib.product import StaticLibrary
+from lib.product import StaticAndDynamicLibrary
 from lib.product import Application
 from lib.product import Executable
 

--- a/lib/script.py
+++ b/lib/script.py
@@ -206,7 +206,7 @@ rule Link
     description = Link: $out
 
 rule Archive
-    command = mkdir -p `dirname $out`; ${AR} ${AR_FLAGS} $flags $out $in
+    command = mkdir -p `dirname $out`; ${AR} ${AR_FLAGS} $out $in
     description = Archive: $out
 """
         

--- a/lib/script.py
+++ b/lib/script.py
@@ -63,6 +63,8 @@ OS                    = """ + Configuration.current.target.swift_sdk_name + """
 ARCH                  = """ + Configuration.current.target.swift_arch + """
 DYLIB_PREFIX          = """ + Configuration.current.target.dynamic_library_prefix + """
 DYLIB_SUFFIX          = """ + Configuration.current.target.dynamic_library_suffix + """
+STATICLIB_PREFIX      = """ + Configuration.current.target.static_library_prefix + """
+STATICLIB_SUFFIX      = """ + Configuration.current.target.static_library_suffix + """
 PREFIX                = """ + Configuration.current.prefix + """
 """
         if Configuration.current.requires_pkg_config:


### PR DESCRIPTION
the first commit introduces a `StaticAndDynamicLibrary` product (sorry about the multiple inheritance 😨, more than happy to change if someone has a better idea) and which builds `libFoundation.a` on top of `libFoundation.so`.

The other commit is just a simple fix, the `ar` command shouldn't be given the compiler flags. 