### PR TITLE
re-enable building without libblocksruntime-dev (Blocks.h)

### DIFF
--- a/CoreFoundation/Error.subproj/CFError.c
+++ b/CoreFoundation/Error.subproj/CFError.c
@@ -13,6 +13,9 @@
 #include "CFInternal.h"
 #include <CoreFoundation/CFPriv.h>
 #include <CoreFoundation/ForFoundationOnly.h>
+#if __BLOCKS__
+#include <Block.h>
+#endif
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED
 #include <mach/mach_error.h>
 #endif

--- a/build.py
+++ b/build.py
@@ -64,6 +64,7 @@ foundation.CFLAGS += " ".join([
 	'-I${SYSROOT}/usr/include/libxml2',
 	'-I${SYSROOT}/usr/include/curl',
 	'-I./',
+	'-I./closure',
 ])
 
 swift_cflags += [


### PR DESCRIPTION
Add -I./closure to foundation.CFLAGS so that Block.h
can be found from closure/Block.h instead of assuming
that it will be available in the system includes.
This simplifies building Foundation on platforms where
libblocksruntime-dev is not easily available as a
pre-built package.