### PR TITLE
Fixed file's groupOwnerName in attributesOfItem()

### DIFF
--- a/Foundation/NSFileManager.swift
+++ b/Foundation/NSFileManager.swift
@@ -305,7 +305,7 @@ open class FileManager : NSObject {
         let grd = getgrgid(s.st_gid)
         if grd != nil && grd!.pointee.gr_name != nil {
             let name = String(cString: grd!.pointee.gr_name)
-            result[.groupOwnerAccountID] = name
+            result[.groupOwnerAccountName] = name
         }
 
         var type : FileAttributeType

--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -151,6 +151,23 @@ class TestNSFileManager : XCTestCase {
             let fileOwnerAccountID = attrs[.ownerAccountID] as? NSNumber
             XCTAssertNotNil(fileOwnerAccountID)
             
+            let fileGroupOwnerAccountID = attrs[.groupOwnerAccountID] as? NSNumber
+            XCTAssertNotNil(fileGroupOwnerAccountID)
+            
+            if let fileOwnerAccountName = attrs[.ownerAccountName] {
+                XCTAssertNotNil(fileOwnerAccountName as? String)
+                if let fileOwnerAccountNameStr = fileOwnerAccountName as? String {
+                    XCTAssertFalse(fileOwnerAccountNameStr.isEmpty)
+                }
+            }
+            
+            if let fileGroupOwnerAccountName = attrs[.groupOwnerAccountName] {
+                XCTAssertNotNil(fileGroupOwnerAccountName as? String)
+                if let fileGroupOwnerAccountNameStr = fileGroupOwnerAccountName as? String {
+                    XCTAssertFalse(fileGroupOwnerAccountNameStr.isEmpty)
+                }
+            }
+            
         } catch let err {
             XCTFail("\(err)")
         }


### PR DESCRIPTION
Fixed group owner name assigned to `.groupOwnerAccountID` instead of `.groupOwnerAccountName` in `FileManager.attributesOfItem(atPath:)`