### PR TITLE
Implemented FileManager.attributesOfFileSystem()

### DIFF
--- a/Foundation/NSFileManager.swift
+++ b/Foundation/NSFileManager.swift
@@ -350,10 +350,11 @@ open class FileManager : NSObject {
         
         var result = [FileAttributeKey : Any]()
         let blockSize = UInt64(s.f_bsize)
-        result[.systemSize] = NSNumber(value: blockSize * s.f_blocks)
-        result[.systemFreeSize] = NSNumber(value: blockSize * s.f_bavail)
-        result[.systemNodes] = NSNumber(value: s.f_files)
-        result[.systemFreeNodes] = NSNumber(value: s.f_ffree)
+        result[.systemNumber] = NSNumber(value: UInt64(s.f_fsid.val.0))
+        result[.systemSize] = NSNumber(value: blockSize * UInt64(s.f_blocks))
+        result[.systemFreeSize] = NSNumber(value: blockSize * UInt64(s.f_bavail))
+        result[.systemNodes] = NSNumber(value: UInt64(s.f_files))
+        result[.systemFreeNodes] = NSNumber(value: UInt64(s.f_ffree))
         
         return result
     }

--- a/Foundation/NSFileManager.swift
+++ b/Foundation/NSFileManager.swift
@@ -343,7 +343,19 @@ open class FileManager : NSObject {
         This method replaces fileSystemAttributesAtPath:.
      */
     open func attributesOfFileSystem(forPath path: String) throws -> [FileAttributeKey : Any] {
-        NSUnimplemented()
+        var s = statfs()
+        guard statfs(path, &s) == 0 else {
+            throw _NSErrorWithErrno(errno, reading: true, path: path)
+        }
+        
+        var result = [FileAttributeKey : Any]()
+        let blockSize = UInt64(s.f_bsize)
+        result[.systemSize] = NSNumber(value: blockSize * s.f_blocks)
+        result[.systemFreeSize] = NSNumber(value: blockSize * s.f_bavail)
+        result[.systemNodes] = NSNumber(value: s.f_files)
+        result[.systemFreeNodes] = NSNumber(value: s.f_ffree)
+        
+        return result
     }
     
     /* createSymbolicLinkAtPath:withDestination:error: returns YES if the symbolic link that point at 'destPath' was able to be created at the location specified by 'path'. If this method returns NO, the link was unable to be created and an NSError will be returned by reference in the 'error' parameter. This method does not traverse a terminal symlink.

--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -23,6 +23,7 @@ class TestNSFileManager : XCTestCase {
             ("test_createFile", test_createFile ),
             ("test_moveFile", test_moveFile),
             ("test_fileSystemRepresentation", test_fileSystemRepresentation),
+            ("test_fileSystemAttributes", test_fileSystemAttributes),
             ("test_fileAttributes", test_fileAttributes),
             ("test_setFileAttributes", test_setFileAttributes),
             ("test_directoryEnumerator", test_directoryEnumerator),
@@ -112,6 +113,32 @@ class TestNSFileManager : XCTestCase {
         XCTAssertEqual(UInt8(bitPattern: result[0]), 0xE2)
         XCTAssertEqual(UInt8(bitPattern: result[1]), 0x98)
         XCTAssertEqual(UInt8(bitPattern: result[2]), 0x83)
+    }
+    
+    func test_fileSystemAttributes() {
+        let fm = FileManager.default
+        let path = NSTemporaryDirectory()
+        
+        do {
+            let attrs = try fm.attributesOfFileSystem(forPath: path)
+            
+            XCTAssertTrue(attrs.count > 0)
+            
+            let systemFreeSize = attrs[.systemFreeSize] as? NSNumber
+            XCTAssertGreaterThan(systemFreeSize!.int64Value, 0)
+            
+            let systemSize = attrs[.systemSize] as? NSNumber
+            XCTAssertGreaterThan(systemSize!.int64Value, systemFreeSize!.int64Value)
+            
+            let systemFreeNodes = attrs[.systemFreeNodes] as? NSNumber
+            XCTAssertGreaterThan(systemFreeNodes!.int64Value, 0)
+            
+            let systemNodes = attrs[.systemNodes] as? NSNumber
+            XCTAssertGreaterThan(systemNodes!.int64Value, systemFreeNodes!.int64Value)
+            
+        } catch let err {
+            XCTFail("\(err)")
+        }
     }
     
     func test_fileAttributes() {

--- a/TestFoundation/TestNSFileManager.swift
+++ b/TestFoundation/TestNSFileManager.swift
@@ -124,16 +124,24 @@ class TestNSFileManager : XCTestCase {
             
             XCTAssertTrue(attrs.count > 0)
             
+            let systemNumber = attrs[.systemNumber] as? NSNumber
+            XCTAssertNotNil(systemNumber)
+            XCTAssertGreaterThan(systemNumber!.int64Value, 0)
+            
             let systemFreeSize = attrs[.systemFreeSize] as? NSNumber
+            XCTAssertNotNil(systemFreeSize)
             XCTAssertGreaterThan(systemFreeSize!.int64Value, 0)
             
             let systemSize = attrs[.systemSize] as? NSNumber
+            XCTAssertNotNil(systemSize)
             XCTAssertGreaterThan(systemSize!.int64Value, systemFreeSize!.int64Value)
             
             let systemFreeNodes = attrs[.systemFreeNodes] as? NSNumber
+            XCTAssertNotNil(systemFreeNodes)
             XCTAssertGreaterThan(systemFreeNodes!.int64Value, 0)
             
             let systemNodes = attrs[.systemNodes] as? NSNumber
+            XCTAssertNotNil(systemNodes)
             XCTAssertGreaterThan(systemNodes!.int64Value, systemFreeNodes!.int64Value)
             
         } catch let err {


### PR DESCRIPTION
Also I'm not sure I should use `fileSystemRepresentation(withPath: path)` method to get proper variable for `statfs()` or not. Because `attributesOfItem(atPath:) didn't use that, I didn't either.