### PR TITLE
Performance regression in NSMutableData[SR-3966]

### DIFF
--- a/CoreFoundation/Collections.subproj/CFData.c
+++ b/CoreFoundation/Collections.subproj/CFData.c
@@ -312,10 +312,13 @@ CFTypeID CFDataGetTypeID(void) {
 void _CFDataInit(CFMutableDataRef memory, CFOptionFlags flags, CFIndex capacity, const uint8_t *bytes, CFIndex length, Boolean noCopy) {
     Boolean isMutable = ((flags & __kCFMutable) != 0);
     Boolean isGrowable = ((flags & __kCFGrowable) != 0);
+    Boolean isDontDeallocate = ((flags & __kCFDontDeallocate) != 0);
     
     __CFDataSetNumBytesUsed(memory, 0);
     __CFDataSetLength(memory, 0);
-    __CFDataSetInfoBits(memory, __kCFDontDeallocate);
+    if (isDontDeallocate) {
+        __CFDataSetInfoBits(memory, __kCFDontDeallocate);
+    }
     
     if (isMutable && isGrowable) {
         __CFDataSetCapacity(memory, __CFDataRoundUpCapacity(1));


### PR DESCRIPTION
PR which addressed the memory leak in NSMutableData  through  apple/swift-corelibs-foundation#380  is missing in the latest code as well as the Swift-3.1 branch.Hence it resulted in the regression with latest code base.Please merge this on priority .