### PR TITLE
Enable URLSession tests in TestFoundation

### DIFF
--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -77,8 +77,7 @@ XCTMain([
     testCase(TestURLRequest.allTests),
     testCase(TestNSURLResponse.allTests),
     testCase(TestNSHTTPURLResponse.allTests),
-    // FIXME: SR-3464 Assertion failure in TestURLSession.test_dataTaskWithURL
-    // testCase(TestURLSession.allTests),
+    testCase(TestURLSession.allTests),
     testCase(TestNSNull.allTests),
     testCase(TestNSUUID.allTests),
     testCase(TestNSValue.allTests),


### PR DESCRIPTION
URLSessions tests had been disabled because of a libkqueue failure seen in CI. See: https://bugs.swift.org/browse/SR-3464

Given that we've done away with libkqueue in Dispatch and SR-3464 is no longer relevant, can we re-enable the URLSession tests in TestFoundation? 

cc @gparker42 