### PR TITLE
[NSURL] Implementation of '.checkResourceIsReachable'

### DIFF
--- a/Docs/Status.md
+++ b/Docs/Status.md
@@ -57,7 +57,7 @@ There is no _Complete_ status for test coverage because there are always additio
     | `NSMutableURLRequest`        | Mostly Complete | Incomplete    |                                                                                                                    |
     | `URLResponse`                | Mostly Complete | Incomplete    |                                                                                                                    |
     | `NSHTTPURLResponse`          | Mostly Complete | Substantial   |                                                                                                                    |
-    | `NSURL`                      | Mostly Complete | Substantial   | `checkResourceIsReachable()`, and resource values remain unimplemented 											|
+    | `NSURL`                      | Mostly Complete | Substantial   | Resource values remain unimplemented                                                                               |
     | `NSURLQueryItem`             | Mostly Complete | N/A           |                                                                                                                    |
     | `URLResourceKey`             | Complete        | N/A           |                                                                                                                    |
     | `URLFileResourceType`        | Complete        | N/A           |                                                                                                                    |

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -610,8 +610,24 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     */
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    open func checkResourceIsReachable() throws -> Bool {
-        NSUnimplemented()
+    open func checkResourceIsReachableAndReturnError(_ error: UnsafeMutablePointer<NSError?>?) -> Bool {
+        guard isFileURL,
+            let path = path else {
+            return false
+        }
+        
+        guard FileManager.default.fileExists(atPath: path) else {
+            if let error = error {
+                error.pointee = NSError(domain: NSCocoaErrorDomain,
+                                        code: CocoaError.Code.fileReadNoSuchFile.rawValue,
+                                        userInfo: [
+                                            "NSURL" : self,
+                                            "NSFilePath" : path])
+            }
+            return false
+        }
+        
+        return true
     }
 
     /* Returns a file path URL that refers to the same resource as a specified URL. File path URLs use a file system style path. An error will occur if the url parameter is not a file URL. A file reference URL's resource must exist and be reachable to be converted to a file path URL. Symbol is present in iOS 4, but performs no operation.

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -610,25 +610,23 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     */
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    open func checkResourceIsReachableAndReturnError(_ error: UnsafeMutablePointer<NSError?>?) -> Bool {
+    // TODO: should be `checkResourceIsReachableAndReturnError` with autoreleased error parameter.
+    // Currently Autoreleased pointers is not supported on Linux.
+    open func checkResourceIsReachable() throws -> Bool {
         guard isFileURL,
             let path = path else {
-                if let error = error {
-                    error.pointee = NSError(domain: NSCocoaErrorDomain,
-                                            code: CocoaError.Code.fileNoSuchFile.rawValue)
-                }
-                return false
+                throw NSError(domain: NSCocoaErrorDomain,
+                              code: CocoaError.Code.fileNoSuchFile.rawValue)
+                //return false
         }
         
         guard FileManager.default.fileExists(atPath: path) else {
-            if let error = error {
-                error.pointee = NSError(domain: NSCocoaErrorDomain,
-                                        code: CocoaError.Code.fileReadNoSuchFile.rawValue,
-                                        userInfo: [
-                                            "NSURL" : self,
-                                            "NSFilePath" : path])
-            }
-            return false
+            throw NSError(domain: NSCocoaErrorDomain,
+                          code: CocoaError.Code.fileReadNoSuchFile.rawValue,
+                          userInfo: [
+                            "NSURL" : self,
+                            "NSFilePath" : path])
+            //return false
         }
         
         return true

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -613,7 +613,11 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     open func checkResourceIsReachableAndReturnError(_ error: UnsafeMutablePointer<NSError?>?) -> Bool {
         guard isFileURL,
             let path = path else {
-            return false
+                if let error = error {
+                    error.pointee = NSError(domain: NSCocoaErrorDomain,
+                                            code: CocoaError.Code.fileNoSuchFile.rawValue)
+                }
+                return false
         }
         
         guard FileManager.default.fileExists(atPath: path) else {

--- a/Foundation/URL.swift
+++ b/Foundation/URL.swift
@@ -931,14 +931,7 @@ public struct URL : ReferenceConvertible, Equatable {
     ///
     /// This method synchronously checks if the resource's backing store is reachable. Checking reachability is appropriate when making decisions that do not require other immediate operations on the resource, e.g. periodic maintenance of UI state that depends on the existence of a specific document. When performing operations such as opening a file or copying resource properties, it is more efficient to simply try the operation and handle failures. This method is currently applicable only to URLs for file system resources. For other URL types, `false` is returned.
     public func checkResourceIsReachable() throws -> Bool {
-        var error: NSError?
-        let result = _url.checkResourceIsReachableAndReturnError(&error)
-        
-        guard error == nil else {
-            throw error!
-        }
-        
-        return result
+        return try _url.checkResourceIsReachable()
     }
     
     // MARK: - Bridging Support

--- a/Foundation/URL.swift
+++ b/Foundation/URL.swift
@@ -927,6 +927,20 @@ public struct URL : ReferenceConvertible, Equatable {
         _url.removeCachedResourceValue(forKey: key)
     }
     
+    /// Returns whether the URL's resource exists and is reachable.
+    ///
+    /// This method synchronously checks if the resource's backing store is reachable. Checking reachability is appropriate when making decisions that do not require other immediate operations on the resource, e.g. periodic maintenance of UI state that depends on the existence of a specific document. When performing operations such as opening a file or copying resource properties, it is more efficient to simply try the operation and handle failures. This method is currently applicable only to URLs for file system resources. For other URL types, `false` is returned.
+    public func checkResourceIsReachable() throws -> Bool {
+        var error: NSError?
+        let result = _url.checkResourceIsReachableAndReturnError(&error)
+        
+        guard error == nil else {
+            throw error!
+        }
+        
+        return result
+    }
+    
     // MARK: - Bridging Support
     
     /// We must not store an NSURL without running it through this function. This makes sure that we do not hold a file reference URL, which changes the nullability of many NSURL functions.

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -429,7 +429,15 @@ class TestNSURL : XCTestCase {
         XCTAssertEqual(true, try? url.checkResourceIsReachable())
         
         url = URL(string: "https://www.swift.org")!
-        XCTAssertEqual(false, try? url.checkResourceIsReachable())
+        do {
+            _ = try url.checkResourceIsReachable()
+            XCTFail()
+        } catch let error as NSError {
+            XCTAssertEqual(NSCocoaErrorDomain, error.domain)
+            XCTAssertEqual(CocoaError.Code.fileNoSuchFile.rawValue, error.code)
+        } catch {
+            XCTFail()
+        }
         
         url = URL(fileURLWithPath: "/some_random_path")
         do {
@@ -441,6 +449,20 @@ class TestNSURL : XCTestCase {
         } catch {
             XCTFail()
         }
+        
+        var nsURL: NSURL? = NSURL(fileURLWithPath: "/usr")
+        var error: NSError?
+        XCTAssertEqual(true, nsURL?.checkResourceIsReachableAndReturnError(&error))
+        XCTAssertNil(error)
+        
+        nsURL = NSURL(string: "https://www.swift.org")
+        XCTAssertEqual(false, nsURL?.checkResourceIsReachableAndReturnError(&error))
+        XCTAssertNotNil(error)
+        error = nil
+        
+        nsURL = NSURL(fileURLWithPath: "/some_random_path")
+        XCTAssertEqual(false, nsURL?.checkResourceIsReachableAndReturnError(&error))
+        XCTAssertNotNil(error)
     }
 
     func test_copy() {

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -450,19 +450,30 @@ class TestNSURL : XCTestCase {
             XCTFail()
         }
         
-        var nsURL: NSURL? = NSURL(fileURLWithPath: "/usr")
-        var error: NSError?
-        XCTAssertEqual(true, nsURL?.checkResourceIsReachableAndReturnError(&error))
-        XCTAssertNil(error)
+        var nsURL = NSURL(fileURLWithPath: "/usr")
+        XCTAssertEqual(true, try? nsURL.checkResourceIsReachable())
         
-        nsURL = NSURL(string: "https://www.swift.org")
-        XCTAssertEqual(false, nsURL?.checkResourceIsReachableAndReturnError(&error))
-        XCTAssertNotNil(error)
-        error = nil
+        nsURL = NSURL(string: "https://www.swift.org")!
+        do {
+            _ = try nsURL.checkResourceIsReachable()
+            XCTFail()
+        } catch let error as NSError {
+            XCTAssertEqual(NSCocoaErrorDomain, error.domain)
+            XCTAssertEqual(CocoaError.Code.fileNoSuchFile.rawValue, error.code)
+        } catch {
+            XCTFail()
+        }
         
         nsURL = NSURL(fileURLWithPath: "/some_random_path")
-        XCTAssertEqual(false, nsURL?.checkResourceIsReachableAndReturnError(&error))
-        XCTAssertNotNil(error)
+        do {
+            _ = try nsURL.checkResourceIsReachable()
+            XCTFail()
+        } catch let error as NSError {
+            XCTAssertEqual(NSCocoaErrorDomain, error.domain)
+            XCTAssertEqual(CocoaError.Code.fileReadNoSuchFile.rawValue, error.code)
+        } catch {
+            XCTFail()
+        }
     }
 
     func test_copy() {

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -61,6 +61,7 @@ class TestNSURL : XCTestCase {
             ("test_fileURLWithPath", test_fileURLWithPath),
             ("test_fileURLWithPath_isDirectory", test_fileURLWithPath_isDirectory),
             ("test_URLByResolvingSymlinksInPath", test_URLByResolvingSymlinksInPath),
+            ("test_reachable", test_reachable),
             ("test_copy", test_copy),
             ("test_itemNSCoding", test_itemNSCoding),
         ]
@@ -420,6 +421,25 @@ class TestNSURL : XCTestCase {
             let url = URL(fileURLWithPath: "/tmp/ABC/..")
             let result = url.resolvingSymlinksInPath().absoluteString
             XCTAssertEqual(result, "file:///tmp/")
+        }
+    }
+    
+    func test_reachable() {
+        var url = URL(fileURLWithPath: "/usr")
+        XCTAssertEqual(true, try? url.checkResourceIsReachable())
+        
+        url = URL(string: "https://www.swift.org")!
+        XCTAssertEqual(false, try? url.checkResourceIsReachable())
+        
+        url = URL(fileURLWithPath: "/some_random_path")
+        do {
+            _ = try url.checkResourceIsReachable()
+            XCTFail()
+        } catch let error as NSError {
+            XCTAssertEqual(NSCocoaErrorDomain, error.domain)
+            XCTAssertEqual(CocoaError.Code.fileReadNoSuchFile.rawValue, error.code)
+        } catch {
+            XCTFail()
         }
     }
 


### PR DESCRIPTION
Implemented and renamed method for `NSURL` to match Darwin's version.
Added method `. checkResourceIsReachable` to `URL` that matches Darwin's Foundation.