### PR TITLE
NSMutableData compatiblity with macOS

### DIFF
--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -954,6 +954,9 @@ open class NSMutableData : NSData {
             let bytePtr = replacementBytes.bindMemory(to: UInt8.self, capacity: replacementLength)
             CFDataReplaceBytes(_cfMutableObject, CFRangeMake(range.location, range.length), bytePtr, replacementLength)
         }
+        else {
+            CFDataDeleteBytes(_cfMutableObject, CFRangeMake(range.location, range.length))
+        }
     }
 }
 

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -950,13 +950,8 @@ open class NSMutableData : NSData {
     }
     
     open func replaceBytes(in range: NSRange, withBytes replacementBytes: UnsafeRawPointer?, length replacementLength: Int) {
-        if let replacementBytes = replacementBytes {
-            let bytePtr = replacementBytes.bindMemory(to: UInt8.self, capacity: replacementLength)
-            CFDataReplaceBytes(_cfMutableObject, CFRangeMake(range.location, range.length), bytePtr, replacementLength)
-        }
-        else {
-            CFDataDeleteBytes(_cfMutableObject, CFRangeMake(range.location, range.length))
-        }
+        let bytePtr = replacementBytes?.bindMemory(to: UInt8.self, capacity: replacementLength)
+        CFDataReplaceBytes(_cfMutableObject, CFRangeMake(range.location, range.length), bytePtr, replacementLength)
     }
 }
 

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -87,6 +87,7 @@ class TestNSData: XCTestCase {
             ("test_rangeOfData",test_rangeOfData),
             ("test_initMutableDataWithLength", test_initMutableDataWithLength),
             ("test_replaceBytes", test_replaceBytes),
+            ("test_replaceBytesWithNil", test_replaceBytesWithNil),
             ("test_initDataWithCapacity", test_initDataWithCapacity),
             ("test_initDataWithCount", test_initDataWithCount),
             ("test_emptyStringToData", test_emptyStringToData),
@@ -423,6 +424,17 @@ class TestNSData: XCTestCase {
         mData.replaceBytes(in: NSMakeRange(1, 3), withBytes: replacement.bytes,
             length: 3)
         let expected = makeData([0, 8, 9, 10, 0])
+        XCTAssertEqual(mData, expected)
+    }
+
+    func test_replaceBytesWithNil() {
+        func makeData(_ data: [UInt8]) -> NSMutableData {
+            return NSMutableData(bytes: data, length: data.count)
+        }
+
+        let mData = makeData([1, 2, 3, 4, 5])
+        mData.replaceBytes(in: NSMakeRange(1, 3), withBytes: nil, length: 0)
+        let expected = makeData([1, 5])
         XCTAssertEqual(mData, expected)
     }
 


### PR DESCRIPTION
Came across this using NSMutableData on Linux. Replace range with nil pointer and length 0 does nothing when it should delete bytes in the range.