### PR TITLE
Account for kCFBooleanTrue and kCFBooleanFalse being present in bridged payloads

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -224,6 +224,12 @@ struct _NSMutableCharacterSetBridge {
     void (*_Nonnull invert)(CFTypeRef cset);
 };
 
+struct _NSNumberBridge {
+    CFNumberType (*_Nonnull _cfNumberGetType)(CFTypeRef number);
+    bool (*_Nonnull boolValue)(CFTypeRef number);
+    bool (*_Nonnull _getValue)(CFTypeRef number, void *value, CFNumberType type);
+};
+
 struct _CFSwiftBridge {
     struct _NSObjectBridge NSObject;
     struct _NSArrayBridge NSArray;
@@ -238,6 +244,7 @@ struct _CFSwiftBridge {
     struct _NSRunLoop NSRunLoop;
     struct _NSCharacterSetBridge NSCharacterSet;
     struct _NSMutableCharacterSetBridge NSMutableCharacterSet;
+    struct _NSNumberBridge NSNumber;
 };
 
 CF_EXPORT struct _CFSwiftBridge __CFSwiftBridge;

--- a/CoreFoundation/NumberDate.subproj/CFNumber.c
+++ b/CoreFoundation/NumberDate.subproj/CFNumber.c
@@ -82,6 +82,7 @@ CFTypeID CFBooleanGetTypeID(void) {
 
 Boolean CFBooleanGetValue(CFBooleanRef boolean) {
     CF_OBJC_FUNCDISPATCHV(CFBooleanGetTypeID(), Boolean, (NSNumber *)boolean, boolValue);
+    CF_SWIFT_FUNCDISPATCHV(CFBooleanGetTypeID(), Boolean, (CFSwiftRef)boolean, NSNumber.boolValue);
     return (boolean == kCFBooleanTrue) ? true : false;
 }
 
@@ -1063,6 +1064,10 @@ CF_PRIVATE void __CFNumberInitialize(void) {
     _CFRuntimeSetInstanceTypeIDAndIsa(& __kCFNumberFloat64One, __kCFNumberTypeID);
     __CFBitfieldSetValue(__kCFNumberFloat64One._base._cfinfo[CF_INFO_BITS], 4, 0, kCFNumberFloat64Type);
     __kCFNumberFloat64One._pad = BITSFORDOUBLEONE;
+#if DEPLOYMENT_RUNTIME_SWIFT
+    _CFRuntimeSetInstanceTypeIDAndIsa(& __kCFBooleanTrue, __kCFBooleanTypeID);
+    _CFRuntimeSetInstanceTypeIDAndIsa(& __kCFBooleanFalse, __kCFBooleanTypeID);
+#endif
 }
 
 CFTypeID CFNumberGetTypeID(void) {
@@ -1256,6 +1261,7 @@ CFLog(kCFLogLevelWarning, CFSTR("+++ Create old number '%@'"), __CFNumberCopyDes
 CFNumberType CFNumberGetType(CFNumberRef number) {
 //printf("+ [%p] CFNumberGetType(%p)\n", pthread_self(), number);
     CF_OBJC_FUNCDISPATCHV(CFNumberGetTypeID(), CFNumberType, (NSNumber *)number, _cfNumberType);
+    CF_SWIFT_FUNCDISPATCHV(CFNumberGetTypeID(), CFNumberType, (CFSwiftRef)number, NSNumber._cfNumberGetType);
     __CFAssertIsNumber(number);
     CFNumberType type = __CFNumberGetType(number);
     if (kCFNumberSInt128Type == type) type = kCFNumberSInt64Type; // must hide this type, since it is not public
@@ -1275,6 +1281,7 @@ CFLog(kCFLogLevelWarning, CFSTR("*** TEST FAIL in CFNumberGetType: '%d' '%d'"), 
 
 CF_EXPORT CFNumberType _CFNumberGetType2(CFNumberRef number) {
     CF_OBJC_FUNCDISPATCHV(CFNumberGetTypeID(), CFNumberType, (NSNumber *)number, _cfNumberType);
+    CF_SWIFT_FUNCDISPATCHV(CFNumberGetTypeID(), CFNumberType, (CFSwiftRef)number, NSNumber._cfNumberGetType);
     __CFAssertIsNumber(number);
     return __CFNumberGetType(number);
 }
@@ -1319,6 +1326,7 @@ Boolean CFNumberGetValue(CFNumberRef number, CFNumberType type, void *valuePtr) 
 //printf("+ [%p] CFNumberGetValue(%p, %d, %p)\n", pthread_self(), number, type, valuePtr);
 
     CF_OBJC_FUNCDISPATCHV(CFNumberGetTypeID(), Boolean, (NSNumber *)number, _getValue:(void *)valuePtr forType:(CFNumberType)__CFNumberTypeTable[type].canonicalType);
+    CF_SWIFT_FUNCDISPATCHV(CFNumberGetTypeID(), Boolean, (CFSwiftRef)number, NSNumber._getValue, valuePtr, (CFNumberType)__CFNumberTypeTable[type].canonicalType);
     __CFAssertIsNumber(number);
     __CFAssertIsValidNumberType(type);
     uint8_t localMemory[128];

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		5B40F9F01C125011000E72E3 /* CFXMLInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B40F9EC1C124F45000E72E3 /* CFXMLInterface.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5B40F9F41C12524C000E72E3 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B40F9F31C12524C000E72E3 /* libxml2.dylib */; };
 		5B424C761D0B6E5B007B39C8 /* IndexPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B424C751D0B6E5B007B39C8 /* IndexPath.swift */; };
+		5B5BFEAC1E6CC0C200AC8D9E /* NSCFBoolean.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5BFEAB1E6CC0C200AC8D9E /* NSCFBoolean.swift */; };
 		5B5C5EF01CE61FA4001346BD /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5C5EEF1CE61FA4001346BD /* Date.swift */; };
 		5B5D89761BBDADD300234F36 /* libicucore.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B5D89751BBDADD300234F36 /* libicucore.dylib */; };
 		5B5D89781BBDADDB00234F36 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B5D89771BBDADDB00234F36 /* libz.dylib */; };
@@ -507,6 +508,7 @@
 		5B40F9F11C125187000E72E3 /* TestNSXMLParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSXMLParser.swift; sourceTree = "<group>"; };
 		5B40F9F31C12524C000E72E3 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
 		5B424C751D0B6E5B007B39C8 /* IndexPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndexPath.swift; sourceTree = "<group>"; };
+		5B5BFEAB1E6CC0C200AC8D9E /* NSCFBoolean.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSCFBoolean.swift; sourceTree = "<group>"; };
 		5B5C5EEF1CE61FA4001346BD /* Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
 		5B5D885D1BBC938800234F36 /* SwiftFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B5D886A1BBC948300234F36 /* CFApplicationPreferences.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFApplicationPreferences.c; sourceTree = "<group>"; };
@@ -1633,6 +1635,7 @@
 				5B7818591D6CB5CD004A01F2 /* CGFloat.swift */,
 				EADE0B4D1BD09E0800C49C64 /* NSAffineTransform.swift */,
 				5BDC3F3D1BCC5DCB00ED97BB /* NSNumber.swift */,
+				5B5BFEAB1E6CC0C200AC8D9E /* NSCFBoolean.swift */,
 				D31302001C30CEA900295652 /* NSConcreteValue.swift */,
 				D3E8D6D01C367AB600295652 /* NSSpecialValue.swift */,
 				5BDC3F4C1BCC5DCB00ED97BB /* NSValue.swift */,
@@ -2077,6 +2080,7 @@
 				5B1FD9D61D6D16580080E83C /* HTTPBodySource.swift in Sources */,
 				EADE0BB21BD15E0000C49C64 /* Progress.swift in Sources */,
 				EADE0B961BD15DFF00C49C64 /* NSDateIntervalFormatter.swift in Sources */,
+				5B5BFEAC1E6CC0C200AC8D9E /* NSCFBoolean.swift in Sources */,
 				6EB768281D18C12C00D4B719 /* UUID.swift in Sources */,
 				5B1FD9D41D6D16580080E83C /* Configuration.swift in Sources */,
 				5BF7AEA51BCD51F9008F214A /* NSCalendar.swift in Sources */,

--- a/Foundation/Bridging.swift
+++ b/Foundation/Bridging.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import CoreFoundation
+
 // Support protocols for casting
 public protocol _ObjectBridgeable {
     func _bridgeToAnyObject() -> AnyObject
@@ -83,7 +85,11 @@ internal final class _SwiftValue : NSObject, NSCopying {
     }
     
     static func fetch(nonOptional object: AnyObject) -> Any {
-        if let container = object as? _SwiftValue {
+        if object === kCFBooleanTrue {
+            return true
+        } else if object === kCFBooleanFalse {
+            return false
+        } else if let container = object as? _SwiftValue {
             return container.value
         } else if let val = object as? _StructBridgeable {
             return val._bridgeToAny()

--- a/Foundation/NSCFBoolean.swift
+++ b/Foundation/NSCFBoolean.swift
@@ -1,0 +1,87 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+import CoreFoundation
+
+internal class __NSCFBoolean : NSNumber {
+    override var hash: Int {
+        return Int(bitPattern: CFHash(unsafeBitCast(self, to: CFBoolean.self)))
+    }
+    
+    override func description(withLocale locale: Locale?) -> String {
+        return boolValue ? "1" : "0"
+    }
+    
+    override var int8Value: Int8 {
+        return boolValue ? 1 : 0
+    }
+    
+    override var uint8Value: UInt8 {
+        return boolValue ? 1 : 0
+    }
+
+    override var int16Value: Int16 {
+        return boolValue ? 1 : 0
+    }
+    
+    override var uint16Value: UInt16 {
+        return boolValue ? 1 : 0
+    }
+    
+    override var int32Value: Int32 {
+        return boolValue ? 1 : 0
+    }
+    
+    override var uint32Value: UInt32 {
+        return boolValue ? 1 : 0
+    }
+
+    override var intValue: Int {
+        return boolValue ? 1 : 0
+    }
+    
+    override var uintValue: UInt {
+        return boolValue ? 1 : 0
+    }
+    
+    override var int64Value: Int64 {
+        return boolValue ? 1 : 0
+    }
+    
+    override var uint64Value: UInt64 {
+        return boolValue ? 1 : 0
+    }
+    
+    override var floatValue: Float {
+        return boolValue ? 1 : 0
+    }
+    
+    override var doubleValue: Double {
+        return boolValue ? 1 : 0
+    }
+    
+    override var boolValue: Bool {
+        return CFBooleanGetValue(unsafeBitCast(self, to: CFBoolean.self))
+    }
+    
+    override var _cfTypeID: CFTypeID {
+        return CFBooleanGetTypeID()
+    }
+    
+    override var objCType: UnsafePointer<Int8> {
+        // This must never be fixed to be "B", although that would
+        // cause correct old-style archiving when this is unarchived.
+        return UnsafePointer<Int8>(bitPattern: UInt(_NSSimpleObjCType.Char.rawValue.value))!
+    }
+    
+    internal override func _cfNumberType() -> CFNumberType  {
+        return kCFNumberCharType
+    }
+}

--- a/Foundation/NSCoder.swift
+++ b/Foundation/NSCoder.swift
@@ -720,7 +720,7 @@ open class NSCoder : NSObject {
         NSRequiresConcreteImplementation()
     }
     
-    internal func _decodePropertyListForKey(_ key: String) -> Any {
+    internal func _decodePropertyListForKey(_ key: String) -> Any? {
         NSRequiresConcreteImplementation()
     }
 }

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -460,7 +460,7 @@ open class NSKeyedArchiver : NSCoder {
         guard let obj = objv else { return false }
         if obj is String { return false }
         guard let nsObject = obj as? NSObject else { return true }
-        return !(type(of: nsObject) === NSString.self || type(of: nsObject) === NSNumber.self || type(of: nsObject) === NSData.self)
+        return !(nsObject.classForCoder === NSString.self || nsObject.classForCoder === NSNumber.self || nsObject.classForCoder === NSData.self)
     }
    
     /**

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -675,11 +675,11 @@ open class NSKeyedUnarchiver : NSCoder {
     
     /**
         Note that unlike decodePropertyList(forKey:), _decodePropertyListForKey() decodes
-        a property list in the current decoding context rather than as an object. It's
-        also able to return value types.
+        a property list in the current decoding context rather than as an object. It also 
+        is able to return value types.
      */
-    internal override func _decodePropertyListForKey(_ key: String) -> Any {
-        return _decodeValue(forKey: key)!
+    internal override func _decodePropertyListForKey(_ key: String) -> Any? {
+        return _decodeValue(forKey: key)
     }
     
     open override func decodeBool(forKey key: String) -> Bool {

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -27,6 +27,9 @@ internal let kCFNumberDoubleType = CFNumberType.doubleType
 internal let kCFNumberCFIndexType = CFNumberType.cfIndexType
 internal let kCFNumberNSIntegerType = CFNumberType.nsIntegerType
 internal let kCFNumberCGFloatType = CFNumberType.cgFloatType
+internal let kCFNumberSInt128Type = CFNumberType(rawValue: 17)!
+#else
+internal let kCFNumberSInt128Type: CFNumberType = 17
 #endif
 
 extension Int : _ObjectTypeBridgeable {
@@ -160,7 +163,7 @@ extension Bool : _ObjectTypeBridgeable {
     
     public typealias _ObjectType = NSNumber
     public func _bridgeToObjectiveC() -> _ObjectType {
-        return NSNumber(value: self)
+        return unsafeBitCast(self ? kCFBooleanTrue : kCFBooleanFalse, to: NSNumber.self)
     }
     
     static public func _forceBridgeFromObjectiveC(_ source: _ObjectType, result: inout Bool?) {
@@ -520,6 +523,94 @@ open class NSNumber : NSValue {
     open override var description: String {
         return description(withLocale: nil)
     }
+    
+    internal func _cfNumberType() -> CFNumberType {
+        switch objCType.pointee {
+        case 0x42: return kCFNumberCharType
+        case 0x63: return kCFNumberCharType
+        case 0x43: return kCFNumberShortType
+        case 0x73: return kCFNumberShortType
+        case 0x53: return kCFNumberIntType
+        case 0x69: return kCFNumberIntType
+        case 0x49: return Int(uint32Value) < Int(Int32.max) ? kCFNumberIntType : kCFNumberLongLongType
+        case 0x6C: return kCFNumberLongType
+        case 0x4C: return uintValue < UInt(Int.max) ? kCFNumberLongType : kCFNumberLongLongType
+        case 0x66: return kCFNumberFloatType
+        case 0x64: return kCFNumberDoubleType
+        case 0x71: return kCFNumberLongLongType
+        case 0x51: return kCFNumberLongLongType
+        default: fatalError()
+        }
+    }
+    
+    internal func _getValue(_ valuePtr: UnsafeMutableRawPointer, forType type: CFNumberType) -> Bool {
+        switch type {
+        case kCFNumberSInt8Type:
+            valuePtr.assumingMemoryBound(to: Int8.self).pointee = int8Value
+            break
+        case kCFNumberSInt16Type:
+            valuePtr.assumingMemoryBound(to: Int16.self).pointee = int16Value
+            break
+        case kCFNumberSInt32Type:
+            valuePtr.assumingMemoryBound(to: Int32.self).pointee = int32Value
+            break
+        case kCFNumberSInt64Type:
+            valuePtr.assumingMemoryBound(to: Int64.self).pointee = int64Value
+            break
+        case kCFNumberSInt128Type:
+            struct CFSInt128Struct {
+                var high: Int64
+                var low: UInt64
+            }
+            let val = int64Value
+            valuePtr.assumingMemoryBound(to: CFSInt128Struct.self).pointee = CFSInt128Struct.init(high: (val < 0) ? -1 : 0, low: UInt64(bitPattern: val))
+            break
+        case kCFNumberFloat32Type:
+            valuePtr.assumingMemoryBound(to: Float.self).pointee = floatValue
+            break
+        case kCFNumberFloat64Type:
+            valuePtr.assumingMemoryBound(to: Double.self).pointee = doubleValue
+        default: fatalError()
+        }
+        return true
+    }
+    
+    open override func encode(with aCoder: NSCoder) {
+        if !aCoder.allowsKeyedCoding {
+            NSUnimplemented()
+        } else {
+            if let keyedCoder = aCoder as? NSKeyedArchiver {
+                keyedCoder._encodePropertyList(self)
+            } else {
+                if CFGetTypeID(self) == CFBooleanGetTypeID() {
+                    aCoder.encode(boolValue, forKey: "NS.boolval")
+                } else {
+                    switch objCType.pointee {
+                    case 0x42:
+                        aCoder.encode(boolValue, forKey: "NS.boolval")
+                        break
+                    case 0x63: fallthrough
+                    case 0x43: fallthrough
+                    case 0x73: fallthrough
+                    case 0x53: fallthrough
+                    case 0x69: fallthrough
+                    case 0x49: fallthrough
+                    case 0x6C: fallthrough
+                    case 0x4C: fallthrough
+                    case 0x71: fallthrough
+                    case 0x51:
+                        aCoder.encode(int64Value, forKey: "NS.intval")
+                    case 0x66: fallthrough
+                    case 0x64:
+                        aCoder.encode(doubleValue, forKey: "NS.dblval")
+                    default: break
+                    }
+                }
+            }
+        }
+    }
+    
+    open override var classForCoder: AnyClass { return NSNumber.self }
 }
 
 extension CFNumber : _NSBridgeable {
@@ -527,3 +618,14 @@ extension CFNumber : _NSBridgeable {
     internal var _nsObject: NSType { return unsafeBitCast(self, to: NSType.self) }
 }
 
+internal func _CFSwiftNumberGetType(_ obj: CFTypeRef) -> CFNumberType {
+    return unsafeBitCast(obj, to: NSNumber.self)._cfNumberType()
+}
+
+internal func _CFSwiftNumberGetValue(_ obj: CFTypeRef, _ valuePtr: UnsafeMutableRawPointer, _ type: CFNumberType) -> Bool {
+    return unsafeBitCast(obj, to: NSNumber.self)._getValue(valuePtr, forType: type)
+}
+
+internal func _CFSwiftNumberGetBoolValue(_ obj: CFTypeRef) -> Bool {
+    return unsafeBitCast(obj, to: NSNumber.self).boolValue
+}

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -90,6 +90,7 @@ internal func __CFInitializeSwift() {
     _CFRuntimeBridgeTypeToClass(CFArrayGetTypeID(), unsafeBitCast(_NSCFArray.self, to: UnsafeRawPointer.self))
     _CFRuntimeBridgeTypeToClass(CFDictionaryGetTypeID(), unsafeBitCast(_NSCFDictionary.self, to: UnsafeRawPointer.self))
     _CFRuntimeBridgeTypeToClass(CFSetGetTypeID(), unsafeBitCast(_NSCFSet.self, to: UnsafeRawPointer.self))
+    _CFRuntimeBridgeTypeToClass(CFBooleanGetTypeID(), unsafeBitCast(__NSCFBoolean.self, to: UnsafeRawPointer.self))
     _CFRuntimeBridgeTypeToClass(CFNumberGetTypeID(), unsafeBitCast(NSNumber.self, to: UnsafeRawPointer.self))
     _CFRuntimeBridgeTypeToClass(CFDataGetTypeID(), unsafeBitCast(NSData.self, to: UnsafeRawPointer.self))
     _CFRuntimeBridgeTypeToClass(CFDateGetTypeID(), unsafeBitCast(NSDate.self, to: UnsafeRawPointer.self))
@@ -216,6 +217,10 @@ internal func __CFInitializeSwift() {
     __CFSwiftBridge.NSMutableCharacterSet.formUnionWithCharacterSet = _CFSwiftMutableSetFormUnionWithCharacterSet
     __CFSwiftBridge.NSMutableCharacterSet.formIntersectionWithCharacterSet = _CFSwiftMutableSetFormIntersectionWithCharacterSet
     __CFSwiftBridge.NSMutableCharacterSet.invert = _CFSwiftMutableSetInvert
+    
+    __CFSwiftBridge.NSNumber._cfNumberGetType = _CFSwiftNumberGetType
+    __CFSwiftBridge.NSNumber._getValue = _CFSwiftNumberGetValue
+    __CFSwiftBridge.NSNumber.boolValue = _CFSwiftNumberGetBoolValue
     
 //    __CFDefaultEightBitStringEncoding = UInt32(kCFStringEncodingUTF8)
 }

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -65,6 +65,26 @@ class TestNSNumber : XCTestCase {
         XCTAssertEqual(NSNumber(value: false).doubleValue, Double(0))
     }
     
+    func test_CFBoolean() {
+        guard let plist = try? PropertyListSerialization.data(fromPropertyList: ["test" : true], format: .binary, options: 0) else {
+            XCTFail()
+            return
+        }
+        guard let obj = (try? PropertyListSerialization.propertyList(from: plist, format: nil)) as? [String : Any] else {
+            XCTFail()
+            return
+        }
+        guard let value = obj["test"] else {
+            XCTFail()
+            return
+        }
+        guard let boolValue = value as? Bool else {
+            XCTFail("Expected de-serialization as round-trip boolean value")
+            return
+        }
+        XCTAssertTrue(boolValue)
+    }
+    
     func test_numberWithChar() {
         XCTAssertEqual(NSNumber(value: Int8(0)).boolValue, false)
         XCTAssertEqual(NSNumber(value: Int8(0)).int8Value, Int8(0))

--- a/build.py
+++ b/build.py
@@ -312,6 +312,7 @@ swift_sources = CompileSwiftSources([
 	'Foundation/NSCache.swift',
 	'Foundation/NSCalendar.swift',
 	'Foundation/NSCFArray.swift',
+	'Foundation/NSCFBoolean.swift',
 	'Foundation/NSCFDictionary.swift',
 	'Foundation/NSCFSet.swift',
 	'Foundation/NSCFString.swift',


### PR DESCRIPTION
This converts kCFBooleanTrue and kCFBooleanFalse into true and false and adds subclassing callout hooks for CFNumber to invoke swift routines.

Additionally it corrects the class callouts for cluster types when archiving plist types such that it invokes the class for coder instead of relying on the distinct type of the object being passed.