### PR TITLE
[SR-4242] Add NSMutableOrderedSet subscript setter that is missing from non-Darwin

### DIFF
--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -391,6 +391,16 @@ open class NSMutableOrderedSet : NSOrderedSet {
         _storage.remove(value)
         _orderedStorage.remove(at: index(of: object))
     }
+
+    open override subscript(idx: Int) -> Any {
+        get {
+            return object(at: idx)
+        }
+        set {
+            replaceObject(at: idx, with: newValue)
+        }
+    }
+    
 }
 
 extension NSMutableOrderedSet {

--- a/TestFoundation/TestNSOrderedSet.swift
+++ b/TestFoundation/TestNSOrderedSet.swift
@@ -207,10 +207,11 @@ class TestNSOrderedSet : XCTestCase {
     func test_ReplaceObject() {
         let set = NSMutableOrderedSet(arrayLiteral: "foo", "bar", "baz")
         set.replaceObject(at: 1, with: "123")
+        set[2] = "456"
         XCTAssertEqual(set.count, 3)
         XCTAssertEqual(set[0] as? String, "foo")
         XCTAssertEqual(set[1] as? String, "123")
-        XCTAssertEqual(set[2] as? String, "baz")
+        XCTAssertEqual(set[2] as? String, "456")
     }
 
     func test_ExchangeObjects() {


### PR DESCRIPTION
`NSMutableOrderedSet` has a subscript setter imported to Darwin platforms, but the setter doesn't exist on Linux. 

This PR adds a subscript setter to `NSMutableOrderedSet` as a shortcut to `replaceObject(at:with:)`