### PR TITLE
Support for custom protocols in URLSession [WIP]

### DIFF
--- a/Foundation/NSURLSession/NSURLSessionTask.swift
+++ b/Foundation/NSURLSession/NSURLSessionTask.swift
@@ -149,7 +149,13 @@ open class URLSessionTask : NSObject, NSCopying {
         set { taskAttributesIsolation.async(flags: .barrier) { self._response = newValue } }
     }
     fileprivate var _response: URLResponse? = nil
-    
+
+    internal var setResponse : URLResponse? {
+        get {
+            return taskAttributesIsolation.sync { self._response }
+        }
+        set { taskAttributesIsolation.async(flags: .barrier) { self._response = newValue } }
+    }
     /* Byte count properties may be zero if no body is expected,
      * or URLSessionTransferSizeUnknown if it is not possible
      * to know how many bytes will be transferred.


### PR DESCRIPTION
This is **work in progress**

The implementation of URLSession does not seem to be supporting custom protocols. Reference is added in the test case ` test_customProtocol `. For supporting custom URL protocols we need the following : 

- [ ] Implementing URLProtocol

- [ ] Implementing URLProtocolClient

- [ ] Adding support for custom protocols in URLSession

I have begun work on the above (with few methods implemented) and would keep this PR updated with the progress. I will highly appreciate any inputs or feedback.