### PR TITLE
Added fast path for Int and UInt

### DIFF
--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -309,6 +309,10 @@ private struct JSONWriter {
             try serializeString(str)
         case let boolValue as Bool:
             serializeBool(boolValue)
+        case let num as Int:
+            try serializeInt(value: num)
+        case let num as UInt:
+            try serializeUInt(value: num)
         case let array as Array<Any>:
             try serializeArray(array)
         case let dict as Dictionary<AnyHashable, Any>:
@@ -322,6 +326,93 @@ private struct JSONWriter {
         }
     }
 
+    private func serializeUInt(value: UInt) throws {
+        if value == 0 {
+            writer("0")
+            return
+        }
+        var array: [UInt] = []
+        var stringResult = ""
+        //Maximum length of an UInt
+        array.reserveCapacity(20)
+        stringResult.reserveCapacity(20)
+        var number = value
+        
+        while number != 0 {
+            array.append(number % 10)
+            number /= 10
+        }
+        
+        /*
+         Step backwards through the array and append the values to the string. This way the values are appended in the correct order.
+         */
+        var counter = array.count
+        while counter > 0 {
+            counter -= 1
+            let digit: UInt = array[counter]
+            switch digit {
+            case 0: stringResult.append("0")
+            case 1: stringResult.append("1")
+            case 2: stringResult.append("2")
+            case 3: stringResult.append("3")
+            case 4: stringResult.append("4")
+            case 5: stringResult.append("5")
+            case 6: stringResult.append("6")
+            case 7: stringResult.append("7")
+            case 8: stringResult.append("8")
+            case 9: stringResult.append("9")
+            default: fatalError()
+            }
+        }
+        
+        writer(stringResult)
+    }
+    
+    private func serializeInt(value: Int) throws {
+        if value == 0 {
+            writer("0")
+            return
+        }
+        var array: [Int] = []
+        var stringResult = ""
+        //Maximum length of an Int
+        array.reserveCapacity(19)
+        //Account for a negative sign
+        stringResult.reserveCapacity(20)
+        var number = value
+        
+        while number != 0 {
+            array.append(number % 10)
+            number /= 10
+        }
+        //If negative add minus sign before adding any values
+        if value < 0 {
+            stringResult.append("-")
+        }
+        /*
+         Step backwards through the array and append the values to the string. This way the values are appended in the correct order.
+         */
+        var counter = array.count
+        while counter > 0 {
+            counter -= 1
+            let digit = array[counter]
+            switch digit {
+            case 0: stringResult.append("0")
+            case 1, -1: stringResult.append("1")
+            case 2, -2: stringResult.append("2")
+            case 3, -3: stringResult.append("3")
+            case 4, -4: stringResult.append("4")
+            case 5, -5: stringResult.append("5")
+            case 6, -6: stringResult.append("6")
+            case 7, -7: stringResult.append("7")
+            case 8, -8: stringResult.append("8")
+            case 9, -9: stringResult.append("9")
+            default: fatalError()
+            }
+        }
+        writer(stringResult)
+    }
+    
     func serializeString(_ str: String) throws {
         writer("\"")
         for scalar in str.unicodeScalars {

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -284,6 +284,8 @@ internal extension JSONSerialization {
 //MARK: - JSONSerializer
 private struct JSONWriter {
     
+    private let maxUIntLength = String(describing: UInt.max).characters.count
+    private let maxIntLength = String(describing: Int.max).characters.count
     var indent = 0
     let pretty: Bool
     let writer: (String?) -> Void
@@ -334,8 +336,8 @@ private struct JSONWriter {
         var array: [UInt] = []
         var stringResult = ""
         //Maximum length of an UInt
-        array.reserveCapacity(20)
-        stringResult.reserveCapacity(20)
+        array.reserveCapacity(maxUIntLength)
+        stringResult.reserveCapacity(maxUIntLength)
         var number = value
         
         while number != 0 {
@@ -375,10 +377,9 @@ private struct JSONWriter {
         }
         var array: [Int] = []
         var stringResult = ""
-        //Maximum length of an Int
-        array.reserveCapacity(19)
+        array.reserveCapacity(maxIntLength)
         //Account for a negative sign
-        stringResult.reserveCapacity(20)
+        stringResult.reserveCapacity(maxIntLength + 1)
         var number = value
         
         while number != 0 {

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -863,6 +863,10 @@ extension TestNSJSONSerialization {
             ("test_nested_array", test_nested_array),
             ("test_nested_dictionary", test_nested_dictionary),
             ("test_serialize_number", test_serialize_number),
+            ("test_serialize_IntMax", test_serialize_IntMax),
+            ("test_serialize_IntMin", test_serialize_IntMin),
+            ("test_serialize_UIntMax", test_serialize_UIntMax),
+            ("test_serialize_UIntMin", test_serialize_UIntMin),
             ("test_serialize_stringEscaping", test_serialize_stringEscaping),
             ("test_jsonReadingOffTheEndOfBuffers", test_jsonReadingOffTheEndOfBuffers),
             ("test_jsonObjectToOutputStreamBuffer", test_jsonObjectToOutputStreamBuffer),
@@ -1052,6 +1056,26 @@ extension TestNSJSONSerialization {
         // Cannot generate "true"/"false" currently
         json = [NSNumber(value:false),NSNumber(value:true)]
         XCTAssertEqual(try trySerialize(json), "[false,true]")
+    }
+    
+    func test_serialize_IntMax() {
+        let json: [Any] = [Int.max]
+        XCTAssertEqual(try trySerialize(json), "[9223372036854775807]")
+    }
+    
+    func test_serialize_IntMin() {
+        let json: [Any] = [Int.min]
+        XCTAssertEqual(try trySerialize(json), "[-9223372036854775808]")
+    }
+    
+    func test_serialize_UIntMax() {
+        let json: [Any] = [UInt.max]
+        XCTAssertEqual(try trySerialize(json), "[18446744073709551615]")
+    }
+    
+    func test_serialize_UIntMin() {
+        let json: [Any] = [UInt.min]
+        XCTAssertEqual(try trySerialize(json), "[0]")
     }
     
     func test_serialize_stringEscaping() {

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -1060,22 +1060,22 @@ extension TestNSJSONSerialization {
     
     func test_serialize_IntMax() {
         let json: [Any] = [Int.max]
-        XCTAssertEqual(try trySerialize(json), "[9223372036854775807]")
+        XCTAssertEqual(try trySerialize(json), "[\(Int.max)]")
     }
     
     func test_serialize_IntMin() {
         let json: [Any] = [Int.min]
-        XCTAssertEqual(try trySerialize(json), "[-9223372036854775808]")
+        XCTAssertEqual(try trySerialize(json), "[\(Int.min)]")
     }
     
     func test_serialize_UIntMax() {
         let json: [Any] = [UInt.max]
-        XCTAssertEqual(try trySerialize(json), "[18446744073709551615]")
+        XCTAssertEqual(try trySerialize(json), "[\(Int.max)]")
     }
     
     func test_serialize_UIntMin() {
         let json: [Any] = [UInt.min]
-        XCTAssertEqual(try trySerialize(json), "[0]")
+        XCTAssertEqual(try trySerialize(json), "[\(Int.min)]")
     }
     
     func test_serialize_stringEscaping() {

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -1070,12 +1070,12 @@ extension TestNSJSONSerialization {
     
     func test_serialize_UIntMax() {
         let json: [Any] = [UInt.max]
-        XCTAssertEqual(try trySerialize(json), "[\(Int.max)]")
+        XCTAssertEqual(try trySerialize(json), "[\(UInt.max)]")
     }
     
     func test_serialize_UIntMin() {
         let json: [Any] = [UInt.min]
-        XCTAssertEqual(try trySerialize(json), "[\(Int.min)]")
+        XCTAssertEqual(try trySerialize(json), "[\(UInt.min)]")
     }
     
     func test_serialize_stringEscaping() {


### PR DESCRIPTION
As a follow on from #723 I've created fast path options for Int and UInt to further improve the performance of JSON Serialization. 

Below are some results I obtained by using a slightly modified version of the [benchmark](https://github.com/djones6/swift-corelibs-foundation/commit/867109e253550e4d1bcb99cfc681fdb02ce0f566) @djones6 developed, increased to 1000 repetitions and varying the payload size. I've included times for `String(describing:)` as that was the original proposed solution in #723 and felt it would offer a good comparative view.  

| Payload type:              |  Average Time (2 digit numbers) | Average Time (10 digit numbers)        | 
|------|:-------:|:------:|
| Baseline (current `master`)     | 1.932 | 2.631
| With String(describing:) (as rejected in #723 ) | 0.877 | 1.572 |
| Int/UInt fast Path (this PR) | 0.984 (2.0x faster than baseline) | 1.653 (1.6x faster than baseline) |

@djones6 and I also ran some tests against Kitura, these tests showed we are slightly better than `String(describing:)` for shorter numbers and on par with `String(describing:)` for longer numbers.

I've also added a few extra tests for serialization of the min/max values for Int and UInt as I felt these offered good values for testing the correct result is produced, also the current master implementation fails on max UInt. 

I haven't started work on Double/Floats yet but may do so if this fix is acceptable. 