### PR TITLE
NSRegularExpression: Add default value to init() `options` parameter

### DIFF
--- a/Foundation/NSRegularExpression.swift
+++ b/Foundation/NSRegularExpression.swift
@@ -75,7 +75,7 @@ open class NSRegularExpression: NSObject, NSCopying, NSCoding {
     /* An instance of NSRegularExpression is created from a regular expression pattern and a set of options.  If the pattern is invalid, nil will be returned and an NSError will be returned by reference.  The pattern syntax currently supported is that specified by ICU.
     */
     
-    public init(pattern: String, options: Options) throws {
+    public init(pattern: String, options: Options = []) throws {
         var error: Unmanaged<CFError>?
 #if os(OSX) || os(iOS)
         let opt =  _CFRegularExpressionOptions(rawValue: options.rawValue)

--- a/TestFoundation/TestNSRegularExpression.swift
+++ b/TestFoundation/TestNSRegularExpression.swift
@@ -35,7 +35,7 @@ class TestNSRegularExpression : XCTestCase {
         do {
             let str = NSString(string: searchString)
             var range = NSMakeRange(0, str.length)
-            let regex = try NSRegularExpression(pattern: patternString, options: [])
+            let regex = try NSRegularExpression(pattern: patternString)
             do {
                 let lookingRange = regex.rangeOfFirstMatch(in: searchString, options: .anchored, range: range)
                 let matchRange = regex.rangeOfFirstMatch(in: searchString, options: [], range: range)


### PR DESCRIPTION
According to the [documentation](https://developer.apple.com/reference/foundation/nsregularexpression/1410900-init), the `options` parameter to the `NSRegularExpression` initializer should have a default value of `[]`.  This was not correct in swift-corelibs-foundation.

Correct the signature of the initializer and update one of the existing tests to cover this case.