### PR TITLE
Fix bug [SR-4391]: index check should be `||` instead of `&&`

### DIFF
--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -148,7 +148,7 @@ extension NSOrderedSet {
     open func objects(at indexes: IndexSet) -> [Any] {
         var entries = [Any]()
         for idx in indexes {
-            if idx >= count && idx < 0 {
+            if idx >= count || idx < 0 {
                 fatalError("\(self): Index out of bounds")
             }
             entries.append(object(at: idx))

--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -148,7 +148,7 @@ extension NSOrderedSet {
     open func objects(at indexes: IndexSet) -> [Any] {
         var entries = [Any]()
         for idx in indexes {
-            if idx >= count || idx < 0 {
+            guard idx < count && idx >= 0 else {
                 fatalError("\(self): Index out of bounds")
             }
             entries.append(object(at: idx))
@@ -338,12 +338,12 @@ extension NSOrderedSet {
 open class NSMutableOrderedSet : NSOrderedSet {
     
     open func insert(_ object: Any, at idx: Int) {
-        guard idx < count && idx >= 0 else {
+        guard idx <= count && idx >= 0 else {
             fatalError("\(self): Index out of bounds")
         }
 
         let value = _SwiftValue.store(object)
-        
+
         if contains(value) {
             return
         }

--- a/TestFoundation/TestNSOrderedSet.swift
+++ b/TestFoundation/TestNSOrderedSet.swift
@@ -43,7 +43,8 @@ class TestNSOrderedSet : XCTestCase {
             ("test_ReplaceObject", test_ReplaceObject),
             ("test_ExchangeObjects", test_ExchangeObjects),
             ("test_MoveObjects", test_MoveObjects),
-            ("test_InserObjects", test_InsertObjects),
+            ("test_InsertObjects", test_InsertObjects),
+            ("test_Insert", test_Insert),
             ("test_SetObjectAtIndex", test_SetObjectAtIndex),
             ("test_RemoveObjectsInRange", test_RemoveObjectsInRange),
             ("test_ReplaceObjectsAtIndexes", test_ReplaceObjectsAtIndexes),
@@ -250,6 +251,16 @@ class TestNSOrderedSet : XCTestCase {
         XCTAssertEqual(set[2] as? String, "bar")
         XCTAssertEqual(set[3] as? String, "456")
         XCTAssertEqual(set[4] as? String, "baz")
+    }
+
+    func test_Insert() {
+        let set = NSMutableOrderedSet()
+        set.insert("foo", at: 0)
+        XCTAssertEqual(set.count, 1)
+        XCTAssertEqual(set[0] as? String, "foo")
+        set.insert("bar", at: 1)
+        XCTAssertEqual(set.count, 2)
+        XCTAssertEqual(set[1] as? String, "bar")
     }
 
     func test_SetObjectAtIndex() {


### PR DESCRIPTION
Bug in NSOrderedSet index check