### PR TITLE
Minor warning fixes

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1284,6 +1284,7 @@ static bool (*CAS32)(int32_t, int32_t, volatile int32_t *) = OSAtomicCompareAndS
 
 #if DEPLOYMENT_RUNTIME_SWIFT
 extern void swift_retain(void *);
+extern void swift_release(void *);
 #endif
 
 // For "tryR==true", a return of NULL means "failed".
@@ -1399,7 +1400,6 @@ Boolean _CFIsDeallocating(CFTypeRef cf) {
 static void _CFRelease(CFTypeRef CF_RELEASES_ARGUMENT cf) {
 #if DEPLOYMENT_RUNTIME_SWIFT
     // We always call through to swift_release, since all CFTypeRefs are at least _NSCFType objects
-    extern void swift_release(void *);
     swift_release((void *)cf);
 #else
 

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -259,17 +259,17 @@ typedef	char __cf_uuid_string[37];
 typedef __cf_uuid _cf_uuid_t;
 typedef __cf_uuid_string _cf_uuid_string_t;
 
-CF_EXPORT void _cf_uuid_clear(_cf_uuid_t uu);
-CF_EXPORT int _cf_uuid_compare(const _cf_uuid_t uu1, const _cf_uuid_t uu2);
-CF_EXPORT void _cf_uuid_copy(_cf_uuid_t dst, const _cf_uuid_t src);
-CF_EXPORT void _cf_uuid_generate(_cf_uuid_t out);
-CF_EXPORT void _cf_uuid_generate_random(_cf_uuid_t out);
-CF_EXPORT void _cf_uuid_generate_time(_cf_uuid_t out);
-CF_EXPORT int _cf_uuid_is_null(const _cf_uuid_t uu);
-CF_EXPORT int _cf_uuid_parse(const _cf_uuid_string_t in, _cf_uuid_t uu);
-CF_EXPORT void _cf_uuid_unparse(const _cf_uuid_t uu, _cf_uuid_string_t out);
-CF_EXPORT void _cf_uuid_unparse_lower(const _cf_uuid_t uu, _cf_uuid_string_t out);
-CF_EXPORT void _cf_uuid_unparse_upper(const _cf_uuid_t uu, _cf_uuid_string_t out);
+CF_EXPORT void _cf_uuid_clear(_cf_uuid_t _Nonnull uu);
+CF_EXPORT int _cf_uuid_compare(const _cf_uuid_t _Nonnull uu1, const _cf_uuid_t _Nonnull uu2);
+CF_EXPORT void _cf_uuid_copy(_cf_uuid_t _Nonnull dst, const _cf_uuid_t _Nonnull src);
+CF_EXPORT void _cf_uuid_generate(_cf_uuid_t _Nonnull out);
+CF_EXPORT void _cf_uuid_generate_random(_cf_uuid_t _Nonnull out);
+CF_EXPORT void _cf_uuid_generate_time(_cf_uuid_t _Nonnull out);
+CF_EXPORT int _cf_uuid_is_null(const _cf_uuid_t _Nonnull uu);
+CF_EXPORT int _cf_uuid_parse(const _cf_uuid_string_t _Nonnull in, _cf_uuid_t _Nonnull uu);
+CF_EXPORT void _cf_uuid_unparse(const _cf_uuid_t _Nonnull uu, _cf_uuid_string_t _Nonnull out);
+CF_EXPORT void _cf_uuid_unparse_lower(const _cf_uuid_t _Nonnull uu, _cf_uuid_string_t _Nonnull out);
+CF_EXPORT void _cf_uuid_unparse_upper(const _cf_uuid_t _Nonnull uu, _cf_uuid_string_t _Nonnull out);
 
 
 extern CFWriteStreamRef _CFWriteStreamCreateFromFileDescriptor(CFAllocatorRef alloc, int fd);

--- a/Foundation/CharacterSet.swift
+++ b/Foundation/CharacterSet.swift
@@ -486,7 +486,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSCharacterSet {
-        return _wrapped
+        return unsafeBitCast(_wrapped, to: NSCharacterSet.self)
     }
     
     public static func _forceBridgeFromObjectiveC(_ input: NSCharacterSet, result: inout CharacterSet?) {

--- a/Foundation/CharacterSet.swift
+++ b/Foundation/CharacterSet.swift
@@ -486,7 +486,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSCharacterSet {
-        return unsafeBitCast(_wrapped, to: NSCharacterSet.self)
+        return _wrapped
     }
     
     public static func _forceBridgeFromObjectiveC(_ input: NSCharacterSet, result: inout CharacterSet?) {

--- a/Foundation/Measurement.swift
+++ b/Foundation/Measurement.swift
@@ -75,7 +75,7 @@ extension Measurement where UnitType : Dimension {
 /// Add two measurements of the same Unit.
 /// - precondition: The `unit` of `lhs` and `rhs` must be `isEqual`.
 /// - returns: A measurement of value `lhs.value + rhs.value` and unit `lhs.unit`.
-public func +<UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
+public func +<UnitType>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
     if lhs.unit.isEqual(rhs.unit) {
         return Measurement(value: lhs.value + rhs.value, unit: lhs.unit)
     } else {
@@ -100,7 +100,7 @@ public func +<UnitType : Dimension>(lhs: Measurement<UnitType>, rhs: Measurement
 /// Subtract two measurements of the same Unit.
 /// - precondition: The `unit` of `lhs` and `rhs` must be `isEqual`.
 /// - returns: A measurement of value `lhs.value - rhs.value` and unit `lhs.unit`.
-public func -<UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
+public func -<UnitType>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
     if lhs.unit.isEqual(rhs.unit) {
         return Measurement(value: lhs.value - rhs.value, unit: lhs.unit)
     } else {
@@ -124,31 +124,31 @@ public func -<UnitType : Dimension>(lhs: Measurement<UnitType>, rhs: Measurement
 
 /// Multiply a measurement by a scalar value.
 /// - returns: A measurement of value `lhs.value * rhs` with the same unit as `lhs`.
-public func *<UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Double) -> Measurement<UnitType> {
+public func *<UnitType>(lhs: Measurement<UnitType>, rhs: Double) -> Measurement<UnitType> {
     return Measurement(value: lhs.value * rhs, unit: lhs.unit)
 }
 
 /// Multiply a scalar value by a measurement.
 /// - returns: A measurement of value `lhs * rhs.value` with the same unit as `rhs`.
-public func *<UnitType : Unit>(lhs: Double, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
+public func *<UnitType>(lhs: Double, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
     return Measurement(value: lhs * rhs.value, unit: rhs.unit)
 }
 
 /// Divide a measurement by a scalar value.
 /// - returns: A measurement of value `lhs.value / rhs` with the same unit as `lhs`.
-public func /<UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Double) -> Measurement<UnitType> {
+public func /<UnitType>(lhs: Measurement<UnitType>, rhs: Double) -> Measurement<UnitType> {
     return Measurement(value: lhs.value / rhs, unit: lhs.unit)
 }
 
 /// Divide a scalar value by a measurement.
 /// - returns: A measurement of value `lhs / rhs.value` with the same unit as `rhs`.
-public func /<UnitType : Unit>(lhs: Double, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
+public func /<UnitType>(lhs: Double, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
     return Measurement(value: lhs / rhs.value, unit: rhs.unit)
 }
 
 /// Compare two measurements of the same `Unit`.
 /// - returns: `true` if `lhs.value == rhs.value && lhs.unit == rhs.unit`.
-public func ==<UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
+public func ==<UnitType>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
     return lhs.value == rhs.value && lhs.unit == rhs.unit
 }
 
@@ -168,7 +168,7 @@ public func ==<UnitType : Dimension>(lhs: Measurement<UnitType>, rhs: Measuremen
 /// Compare two measurements of the same `Unit`.
 /// - note: This function does not check `==` for the `unit` property of `lhs` and `rhs`.
 /// - returns: `lhs.value < rhs.value`
-public func <<UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
+public func <<UnitType>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
     return lhs.value < rhs.value
 }
 
@@ -188,7 +188,7 @@ public func <<UnitType : Dimension>(lhs: Measurement<UnitType>, rhs: Measurement
 /// Compare two measurements of the same `Unit`.
 /// - note: This function does not check `==` for the `unit` property of `lhs` and `rhs`.
 /// - returns: `lhs.value > rhs.value`
-public func ><UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
+public func ><UnitType>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
     return lhs.value > rhs.value
 }
 
@@ -208,7 +208,7 @@ public func ><UnitType : Dimension>(lhs: Measurement<UnitType>, rhs: Measurement
 /// Compare two measurements of the same `Unit`.
 /// - note: This function does not check `==` for the `unit` property of `lhs` and `rhs`.
 /// - returns: `lhs.value <= rhs.value`
-public func <=<UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
+public func <=<UnitType>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
     return lhs.value <= rhs.value
 }
 
@@ -228,7 +228,7 @@ public func <=<UnitType : Dimension>(lhs: Measurement<UnitType>, rhs: Measuremen
 /// Compare two measurements of the same `Unit`.
 /// - note: This function does not check `==` for the `unit` property of `lhs` and `rhs`.
 /// - returns: `lhs.value >= rhs.value`
-public func >=<UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
+public func >=<UnitType>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
     return lhs.value >= rhs.value
 }
 

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -376,7 +376,7 @@ open class NSKeyedArchiver : NSCoder {
         if objv == nil {
             return true // always have a null reference
         } else {
-            return self._objRefMap[_SwiftValue.store(objv)] != nil
+            return self._objRefMap[_SwiftValue.store(objv!)] != nil
         }
     }
     

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -612,7 +612,7 @@ open class NSKeyedArchiver : NSCoder {
 
             if _isContainer(object) {
                 guard let codable = object as? NSCoding else {
-                    fatalError("Object \(String(describing:object)) does not conform to NSCoding")
+                    fatalError("Object \(String(describing: object)) does not conform to NSCoding")
                 }
 
                 let innerEncodingContext = EncodingContext()

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -612,7 +612,7 @@ open class NSKeyedArchiver : NSCoder {
 
             if _isContainer(object) {
                 guard let codable = object as? NSCoding else {
-                    fatalError("Object \(object) does not conform to NSCoding")
+                    fatalError("Object \(String(describing:object)) does not conform to NSCoding")
                 }
 
                 let innerEncodingContext = EncodingContext()

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -454,7 +454,7 @@ open class NSKeyedUnarchiver : NSCoder {
 
                 guard let classReference = innerDecodingContext.dict["$class"] as? _NSKeyedArchiverUID else {
                     throw _decodingError(CocoaError.coderReadCorrupt,
-                                         withDescription: "Invalid class reference \(String(describing:innerDecodingContext.dict["$class"])). The data may be corrupt.")
+                                         withDescription: "Invalid class reference \(String(describing: innerDecodingContext.dict["$class"])). The data may be corrupt.")
                 }
 
                 var classToConstruct : AnyClass? = try _validateAndMapClassReference(classReference,

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -454,7 +454,7 @@ open class NSKeyedUnarchiver : NSCoder {
 
                 guard let classReference = innerDecodingContext.dict["$class"] as? _NSKeyedArchiverUID else {
                     throw _decodingError(CocoaError.coderReadCorrupt,
-                                         withDescription: "Invalid class reference \(innerDecodingContext.dict["$class"]). The data may be corrupt.")
+                                         withDescription: "Invalid class reference \(String(describing:innerDecodingContext.dict["$class"])). The data may be corrupt.")
                 }
 
                 var classToConstruct : AnyClass? = try _validateAndMapClassReference(classReference,

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -387,7 +387,7 @@ open class NSKeyedUnarchiver : NSCoder {
         }
         
         // check replacement cache
-        object = self._replacementMap[_SwiftValue.store(decodedObject)]
+        object = self._replacementMap[_SwiftValue.store(decodedObject!)]
         if object != nil {
             return object
         }

--- a/Foundation/NSMeasurementFormatter.swift
+++ b/Foundation/NSMeasurementFormatter.swift
@@ -79,5 +79,5 @@ open class MeasurementFormatter : Formatter, NSSecureCoding {
 }
 
 extension MeasurementFormatter {
-    public func string<UnitType : Unit>(from measurement: Measurement<UnitType>) -> String { NSUnimplemented() }
+    public func string<UnitType>(from measurement: Measurement<UnitType>) -> String { NSUnimplemented() }
 }

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -286,7 +286,7 @@ open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSC
     internal var _fastContents: UnsafePointer<UniChar>? {
         if type(of: self) == NSString.self || type(of: self) == NSMutableString.self {
             if !_storage._core.isASCII {
-                return unsafeBitCast(_storage._core.startUTF16, to: UnsafePointer<UniChar>.self)
+                return UnsafePointer<UniChar>(_storage._core.startUTF16)
             }
         }
         return nil

--- a/Foundation/ReferenceConvertible.swift
+++ b/Foundation/ReferenceConvertible.swift
@@ -11,7 +11,7 @@
 /// Decorates types which are backed by a Foundation reference type.
 ///
 /// All `ReferenceConvertible` types are hashable, equatable, and provide description functions.
-public protocol ReferenceConvertible : CustomStringConvertible, CustomDebugStringConvertible, Hashable, Equatable {
+public protocol ReferenceConvertible : CustomStringConvertible, CustomDebugStringConvertible, Hashable {
     associatedtype ReferenceType : NSObject, NSCopying
 }
 

--- a/Foundation/UUID.swift
+++ b/Foundation/UUID.swift
@@ -24,14 +24,18 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     /* Create a new UUID with RFC 4122 version 4 random bytes */
     public init() {
         withUnsafeMutablePointer(to: &uuid) {
-            _cf_uuid_generate_random(unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self))
+            $0.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<uuid_t>.size) {
+                _cf_uuid_generate_random($0)
+            }
         }
     }
     
     fileprivate init(reference: NSUUID) {
         var bytes: uuid_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         withUnsafeMutablePointer(to: &bytes) {
-            reference.getBytes(unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self))
+            $0.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<uuid_t>.size) {
+                reference.getBytes($0)
+            }
         }
         uuid = bytes
     }
@@ -41,7 +45,9 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     /// Returns nil for invalid strings.
     public init?(uuidString string: String) {
         let res = withUnsafeMutablePointer(to: &uuid) {
-            return _cf_uuid_parse(string, unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self))
+            $0.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<uuid_t>.size) {
+                return _cf_uuid_parse(string, $0)
+            }
         }
         if res != 0 {
             return nil
@@ -57,10 +63,14 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     public var uuidString: String {
         var bytes: uuid_string_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         var localValue = uuid
-        return withUnsafeMutablePointer(to: &localValue) { val in
-            withUnsafeMutablePointer(to: &bytes) { str in
-                _cf_uuid_unparse(unsafeBitCast(val, to: UnsafePointer<UInt8>.self), unsafeBitCast(str, to: UnsafeMutablePointer<Int8>.self))
-                return String(cString: unsafeBitCast(str, to: UnsafePointer<CChar>.self), encoding: .utf8)!
+        return withUnsafeMutablePointer(to: &localValue) { valPtr in
+            valPtr.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<uuid_t>.size) { val in
+                withUnsafeMutablePointer(to: &bytes) { strPtr in
+                    strPtr.withMemoryRebound(to: CChar.self, capacity: MemoryLayout<uuid_string_t>.size) { str in
+                        _cf_uuid_unparse(val, str)
+                        return String(cString: str, encoding: .utf8)!
+                    }
+                }
             }
         }
     }
@@ -68,7 +78,9 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     public var hashValue: Int {
         var localValue = uuid
         return withUnsafeMutablePointer(to: &localValue) {
-            return Int(bitPattern: CFHashBytes(unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self), CFIndex(MemoryLayout<uuid_t>.size)))
+            $0.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<uuid_t>.size) {
+                return Int(bitPattern: CFHashBytes($0, CFIndex(MemoryLayout<uuid_t>.size)))
+            }
         }
     }
     
@@ -85,7 +97,9 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     fileprivate var reference: NSUUID {
         var bytes = uuid
         return withUnsafePointer(to: &bytes) {
-            return NSUUID(uuidBytes: unsafeBitCast($0, to: UnsafePointer<UInt8>.self))
+            $0.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<uuid_t>.size) {
+                return NSUUID(uuidBytes: $0)
+            }
         }
     }
     

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -158,7 +158,7 @@ class TestNSURL : XCTestCase {
                         differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(testedValue)'")
                     }
                 } else {
-                    differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(got[key])'")
+                    differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(String(describing:got[key]))'")
                 }
             } else if let expectedValue = obj as? [String] {
                 if let testedValue = got[key] as? [String] {
@@ -166,7 +166,7 @@ class TestNSURL : XCTestCase {
                         differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(testedValue)'")
                     }
                 } else {
-                    differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(got[key])'")
+                    differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(String(describing:got[key]))'")
                 }
             } else if let expectedValue = obj as? Int {
                 if let testedValue = got[key] as? Int {
@@ -174,7 +174,7 @@ class TestNSURL : XCTestCase {
                         differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(testedValue)'")
                     }
                 } else {
-                    differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(got[key])'")
+                    differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(String(describing:got[key]))'")
                 }
             }
             

--- a/TestFoundation/TestNSURL.swift
+++ b/TestFoundation/TestNSURL.swift
@@ -158,7 +158,7 @@ class TestNSURL : XCTestCase {
                         differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(testedValue)'")
                     }
                 } else {
-                    differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(String(describing:got[key]))'")
+                    differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(String(describing: got[key]))'")
                 }
             } else if let expectedValue = obj as? [String] {
                 if let testedValue = got[key] as? [String] {
@@ -166,7 +166,7 @@ class TestNSURL : XCTestCase {
                         differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(testedValue)'")
                     }
                 } else {
-                    differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(String(describing:got[key]))'")
+                    differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(String(describing: got[key]))'")
                 }
             } else if let expectedValue = obj as? Int {
                 if let testedValue = got[key] as? Int {
@@ -174,7 +174,7 @@ class TestNSURL : XCTestCase {
                         differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(testedValue)'")
                     }
                 } else {
-                    differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(String(describing:got[key]))'")
+                    differences.append(" \(key)  Expected = '\(expectedValue)',  Got = '\(String(describing: got[key]))'")
                 }
             }
             

--- a/TestFoundation/TestNSURLSession.swift
+++ b/TestFoundation/TestNSURLSession.swift
@@ -428,7 +428,7 @@ extension DataTask : URLSessionDataDelegate {
 
 extension DataTask : URLSessionTaskDelegate {
     public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-         guard let e = error as? URLError else { return }
+         guard (error as? URLError) != nil else { return }
          dataTaskExpectation.fulfill()
          if let cancellation = cancelExpectation {
              cancellation.fulfill()

--- a/TestFoundation/TestNSXMLDocument.swift
+++ b/TestFoundation/TestNSXMLDocument.swift
@@ -67,9 +67,9 @@ class TestNSXMLDocument : XCTestCase {
 
     func test_basicCreation() {
         let doc = XMLDocument(rootElement: nil)
-        XCTAssert(doc.version == "1.0", "expected 1.0, got \(String(describing:doc.version))")
+        XCTAssert(doc.version == "1.0", "expected 1.0, got \(String(describing: doc.version))")
         doc.version = "1.1"
-        XCTAssert(doc.version == "1.1", "expected 1.1, got \(String(describing:doc.version))")
+        XCTAssert(doc.version == "1.1", "expected 1.1, got \(String(describing: doc.version))")
         let node = XMLElement(name: "Hello", uri: "http://www.example.com")
 
         doc.setRootElement(node)

--- a/TestFoundation/TestNSXMLDocument.swift
+++ b/TestFoundation/TestNSXMLDocument.swift
@@ -67,9 +67,9 @@ class TestNSXMLDocument : XCTestCase {
 
     func test_basicCreation() {
         let doc = XMLDocument(rootElement: nil)
-        XCTAssert(doc.version == "1.0", "expected 1.0, got \(doc.version)")
+        XCTAssert(doc.version == "1.0", "expected 1.0, got \(String(describing:doc.version))")
         doc.version = "1.1"
-        XCTAssert(doc.version == "1.1", "expected 1.1, got \(doc.version)")
+        XCTAssert(doc.version == "1.1", "expected 1.1, got \(String(describing:doc.version))")
         let node = XMLElement(name: "Hello", uri: "http://www.example.com")
 
         doc.setRootElement(node)


### PR DESCRIPTION
Reduce the noise from excessive warnings. Most of these are based on the fixits emitted by the compiler