### PR TITLE
Update HTTPCookiePropertyKey.path comment

### DIFF
--- a/Foundation/NSHTTPCookie.swift
+++ b/Foundation/NSHTTPCookie.swift
@@ -184,10 +184,8 @@ open class HTTPCookie : NSObject {
     /// <tr>
     ///     <td>HTTPCookiePropertyKey.path</td>
     ///     <td>NSString</td>
-    ///     <td>NO</td>
-    ///     <td>Path for the cookie. Inferred from the value for
-    ///     HTTPCookiePropertyKey.originURL if not provided. Default is "/".
-    ///     </td>
+    ///     <td>YES</td>
+    ///     <td>Path for the cookie</td>
     /// </tr>
     /// <tr>
     ///     <td>HTTPCookiePropertyKey.port</td>


### PR DESCRIPTION
This PR is relating to [SR-3821](https://bugs.swift.org/browse/SR-3821)

The comment seems to suggest that supplying a value for `path` is optional and if a value isn't provided it'll either infer from `HTTPCookiePropertyKey.originURL` or use a default of "/". None of those seem to be the case though, and `HTTPCookie([...])` will return `nil` if you haven't provided a value for `path`. 

Tracked down some [documentation](https://developer.apple.com/reference/foundation/httpcookie/1392975-init) to support this as well. 