### PR TITLE
Make `POSIXError` use `POSIXErrorCode` from Swift Stdlib

### DIFF
--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -10,6 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS)
+    import Darwin
+#elseif os(Linux) || os(Android)
+    import Glibc
+#endif
 
 import CoreFoundation
 

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -865,6 +865,9 @@ public extension URLError {
 
 /// Describes an error in the POSIX error domain.
 public struct POSIXError : _BridgedStoredNSError {
+    
+    public typealias Code = POSIXErrorCode
+    
     public let _nsError: NSError
 
     public init(_nsError error: NSError) {
@@ -873,117 +876,11 @@ public struct POSIXError : _BridgedStoredNSError {
     }
 
     public static var _nsErrorDomain: String { return NSPOSIXErrorDomain }
+}
 
-    public enum Code : Int, _ErrorCodeProtocol {
-        public typealias _ErrorType = POSIXError
-
-        case EPERM
-        case ENOENT
-        case ESRCH
-        case EINTR
-        case EIO
-        case ENXIO
-        case E2BIG
-        case ENOEXEC
-        case EBADF
-        case ECHILD
-        case EDEADLK
-        case ENOMEM
-        case EACCES
-        case EFAULT
-        case ENOTBLK
-        case EBUSY
-        case EEXIST
-        case EXDEV
-        case ENODEV
-        case ENOTDIR
-        case EISDIR
-        case EINVAL
-        case ENFILE
-        case EMFILE
-        case ENOTTY
-        case ETXTBSY
-        case EFBIG
-        case ENOSPC
-        case ESPIPE
-        case EROFS
-        case EMLINK
-        case EPIPE
-        case EDOM
-        case ERANGE
-        case EAGAIN
-        case EWOULDBLOCK
-        case EINPROGRESS
-        case EALREADY
-        case ENOTSOCK
-        case EDESTADDRREQ
-        case EMSGSIZE
-        case EPROTOTYPE
-        case ENOPROTOOPT
-        case EPROTONOSUPPORT
-        case ESOCKTNOSUPPORT
-        case ENOTSUP
-        case EPFNOSUPPORT
-        case EAFNOSUPPORT
-        case EADDRINUSE
-        case EADDRNOTAVAIL
-        case ENETDOWN
-        case ENETUNREACH
-        case ENETRESET
-        case ECONNABORTED
-        case ECONNRESET
-        case ENOBUFS
-        case EISCONN
-        case ENOTCONN
-        case ESHUTDOWN
-        case ETOOMANYREFS
-        case ETIMEDOUT
-        case ECONNREFUSED
-        case ELOOP
-        case ENAMETOOLONG
-        case EHOSTDOWN
-        case EHOSTUNREACH
-        case ENOTEMPTY
-        case EPROCLIM
-        case EUSERS
-        case EDQUOT
-        case ESTALE
-        case EREMOTE
-        case EBADRPC
-        case ERPCMISMATCH
-        case EPROGUNAVAIL
-        case EPROGMISMATCH
-        case EPROCUNAVAIL
-        case ENOLCK
-        case ENOSYS
-        case EFTYPE
-        case EAUTH
-        case ENEEDAUTH
-        case EPWROFF
-        case EDEVERR
-        case EOVERFLOW
-        case EBADEXEC
-        case EBADARCH
-        case ESHLIBVERS
-        case EBADMACHO
-        case ECANCELED
-        case EIDRM
-        case ENOMSG
-        case EILSEQ
-        case ENOATTR
-        case EBADMSG
-        case EMULTIHOP
-        case ENODATA
-        case ENOLINK
-        case ENOSR
-        case ENOSTR
-        case EPROTO
-        case ETIME
-        case ENOPOLICY
-        case ENOTRECOVERABLE
-        case EOWNERDEAD
-        case EQFULL
-    }
+extension POSIXErrorCode: _ErrorCodeProtocol {
+    
+    public typealias _ErrorType = POSIXError
 }
 
 extension POSIXError {


### PR DESCRIPTION
Right now POSIXError is broken on Linux, with Foundation defining `POSIXError.Code` that is valid for Darwin, not Linux. The Swift Standard Library already has a properly defined and unit tested [`POSIXErrorCode`](https://github.com/apple/swift/blob/master/stdlib/public/Platform/POSIXError.swift) that is platform specific for Darwin and Linux. Foundation should use this `enum` and not define an invalid duplicate.