### PR TITLE
Fix bit shift math in CFCharacterSet equality code

### DIFF
--- a/CoreFoundation/String.subproj/CFCharacterSet.c
+++ b/CoreFoundation/String.subproj/CFCharacterSet.c
@@ -216,10 +216,10 @@ static Boolean __CFCSetIsBitmapEqualToRange(const UInt32 *bits, UniChar firstCha
         UInt32 lastCharMask;
 
         length = firstCharIndex % sizeof(UInt32);
-        firstCharMask = (((((UInt32)0xFF) << (firstChar & (BITSPERBYTE - 1))) & 0xFF) << (((sizeof(UInt32) - 1) - length) * BITSPERBYTE)) | (((UInt32)0xFFFFFFFF) >> ((length + 1) * BITSPERBYTE));
+        firstCharMask = (((((UInt32)0xFF) << (firstChar & (BITSPERBYTE - 1))) & 0xFF) << (((sizeof(UInt32) - 1) - length) * BITSPERBYTE)) | (UInt32)(((UInt64)0xFFFFFFFF) >> ((length + 1) * BITSPERBYTE));
         
         length = lastCharIndex % sizeof(UInt32);
-        lastCharMask = ((((UInt32)0xFF) >> ((BITSPERBYTE - 1) - (lastChar & (BITSPERBYTE - 1)))) << (((sizeof(UInt32) - 1) - length) * BITSPERBYTE)) | (((UInt32)0xFFFFFFFF) << ((sizeof(UInt32) - length) * BITSPERBYTE));
+        lastCharMask = ((((UInt32)0xFF) >> ((BITSPERBYTE - 1) - (lastChar & (BITSPERBYTE - 1)))) << (((sizeof(UInt32) - 1) - length) * BITSPERBYTE)) | (UInt32)(((UInt64)0xFFFFFFFF) << ((sizeof(UInt32) - length) * BITSPERBYTE));
 
         firstCharIndex = firstChar >> LOG_BPLW;
         lastCharIndex = lastChar >> LOG_BPLW;


### PR DESCRIPTION
The code was originally shifting a 32-bit value by 32 bits in
some cases, which is undefined behavior. The intent was that
all bits would be shifted out, leaving a value of 0 to perform
computation with. We now treat the value as 64-bits for the shift
and re-cast to 32-bits for the computation.