### PR TITLE
Update symbols to match new swift mangling

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1001,7 +1001,7 @@ void __CFInitialize(void) {
 #if TARGET_OS_LINUX
 #define __CFSwiftGetBaseClass _T010Foundation21__CFSwiftGetBaseClasss9AnyObject_pXpyF
 #elif TARGET_OS_MAC
-#define __CFSwiftGetBaseClass _T015SwiftFoundation21__CFSwiftGetBaseClasss9AnyObject_pXpyF
+#define __CFSwiftGetBaseClass _TF15SwiftFoundation21__CFSwiftGetBaseClassFT_PMPs9AnyObject_
 #endif
 #endif
         extern uintptr_t __CFSwiftGetBaseClass();
@@ -1110,7 +1110,7 @@ void __CFInitialize(void) {
 #if TARGET_OS_LINUX
 #define __CFInitializeSwift _T010Foundation19__CFInitializeSwiftyyF
 #elif TARGET_OS_MAC
-#define __CFInitializeSwift _T015SwiftFoundation014__CFInitializeA0yyF
+#define __CFInitializeSwift _TF15SwiftFoundation19__CFInitializeSwiftFT_T_
 #endif
 #endif
         extern void __CFInitializeSwift();


### PR DESCRIPTION
When attempting to link SwiftFoundation into TestFoundation,
these symbols were not found, and needed to be updated.