### PR TITLE
Remove blocks runtime when building with libdispatch

### DIFF
--- a/build.py
+++ b/build.py
@@ -210,8 +210,6 @@ project = [
 foundation.add_phase(headers)
 
 sources = CompileSources([
-    'closure/data.c',
-    'closure/runtime.c',
     'uuid/uuid.c',
 	# 'CoreFoundation/AppServices.subproj/CFUserNotification.c',
 	'CoreFoundation/Base.subproj/CFBase.c',
@@ -298,6 +296,11 @@ sources = CompileSources([
 	'CoreFoundation/String.subproj/CFRunArray.c',
 	'CoreFoundation/URL.subproj/CFURLSessionInterface.c',
 ])
+
+# This code is already in libdispatch so is only needed if libdispatch is
+# NOT being used
+if "LIBDISPATCH_SOURCE_DIR" not in Configuration.current.variables:
+    sources += (['closure/data.c', 'closure/runtime.c'])
 
 sources.add_dependency(headers)
 foundation.add_phase(sources)


### PR DESCRIPTION
- The blocks runtime is already contained in libdispatch
  so removing this 2nd copy from libFoundation removes duplicate
  code.

- The libdispatch version is also slightly more optimal as it
  doesnt compile functions only needed when HAVE_OBJC is defined.

This is also needed to avoid duplicate symbol errors when statically linking Foundation using https://github.com/apple/swift-corelibs-foundation/pull/873

Also see discussion about blocks runtime in https://github.com/apple/swift-corelibs-foundation/pull/874

An alternative, which I did test, is just to remove `data.c` and `runtime.c` although this means `libdispatch` always has to be linked in and Im not sure if it is guaranteed to always be a dependancy.