### PR TITLE
Swift 3.1 branch data fixes

### DIFF
--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -1126,7 +1126,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     @inline(__always)
     private func _copyBytesHelper(to pointer: UnsafeMutableRawPointer, from range: NSRange) {
         if range.length == 0 { return }
-        memcpy(UnsafeMutableRawPointer(pointer), _backing.bytes!.advanced(by: range.location + _sliceRange.lowerBound), range.length)
+        memcpy(UnsafeMutableRawPointer(pointer), _backing.bytes!.advanced(by: range.location), range.length)
     }
     
     /// Copy a subset of the contents of the data to a pointer.

--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -20,35 +20,28 @@ import Glibc
     
 import CoreFoundation
 
-internal func __NSDataInvokeDeallocatorUnmap(_ mem: UnsafeMutableRawPointer, _ length: Int) -> Void {
+internal func __NSDataInvokeDeallocatorUnmap(_ mem: UnsafeMutableRawPointer, _ length: Int) {
     munmap(mem, length)
 }
 
-internal func __NSDataInvokeDeallocatorFree(_ mem: UnsafeMutableRawPointer, _ length: Int) -> Void {
+internal func __NSDataInvokeDeallocatorFree(_ mem: UnsafeMutableRawPointer, _ length: Int) {
     free(mem)
 }
 
 #else
 
 @_exported import Foundation // Clang module
+import _SwiftFoundationOverlayShims
+import _SwiftCoreFoundationOverlayShims
 
-@_silgen_name("__NSDataInvokeDeallocatorVM")
-internal func __NSDataInvokeDeallocatorVM(_ mem: UnsafeMutableRawPointer, _ length: Int) -> Void
-
-@_silgen_name("__NSDataInvokeDeallocatorUnmap")
-internal func __NSDataInvokeDeallocatorUnmap(_ mem: UnsafeMutableRawPointer, _ length: Int) -> Void
-
-@_silgen_name("__NSDataInvokeDeallocatorFree")
-internal func __NSDataInvokeDeallocatorFree(_ mem: UnsafeMutableRawPointer, _ length: Int) -> Void
-
-@_silgen_name("_NSWriteDataToFile_Swift")
-internal func _NSWriteDataToFile_Swift(url: NSURL, data: NSData, options: UInt, error: NSErrorPointer) -> Bool
+@_silgen_name("__NSDataWriteToURL")
+internal func __NSDataWriteToURL(_ data: NSData, _ url: NSURL, _ options: UInt, _ error: NSErrorPointer) -> Bool
 
 #endif
 
 public final class _DataStorage {
     public enum Backing {
-        // A mirror of the objective-c implementation that is suitable to inline in swift
+        // A mirror of the Objective-C implementation that is suitable to inline in Swift
         case swift
         
         // these two storage points for immutable and mutable data are reserved for references that are returned by "known"
@@ -59,8 +52,8 @@ public final class _DataStorage {
         case immutable(NSData) // This will most often (perhaps always) be NSConcreteData
         case mutable(NSMutableData) // This will often (perhaps always) be NSConcreteMutableData
         
-        // These are reserved for foregin sources where neither Swift nor Foundation are fully certain whom they belong
-        // to from a object inheritance standpoint, this means that all bets are off and the values of bytes, mutableBytes,
+        // These are reserved for foreign sources where neither Swift nor Foundation are fully certain whom they belong
+        // to from an object inheritance standpoint, this means that all bets are off and the values of bytes, mutableBytes,
         // and length cannot be cached. This also means that all methods are expected to dynamically dispatch out to the
         // backing reference.
         case customReference(NSData) // tracks data references that are only known to be immutable
@@ -83,7 +76,7 @@ public final class _DataStorage {
         var dest = dest_
         var source = source_
         var num = num_
-        if _DataStorage.vmOpsThreshold <= num && ((unsafeBitCast(source, to: Int.self) | unsafeBitCast(dest, to: Int.self)) & (NSPageSize() - 1)) == 0 {
+        if _DataStorage.vmOpsThreshold <= num && ((unsafeBitCast(source, to: Int.self) | Int(bitPattern: dest)) & (NSPageSize() - 1)) == 0 {
             let pages = NSRoundDownToMultipleOfPageSize(num)
             NSCopyMemoryPages(source!, dest, pages)
             source = source!.advanced(by: pages)
@@ -103,7 +96,7 @@ public final class _DataStorage {
     public var _length: Int
     public var _capacity: Int
     public var _needToZero: Bool
-    public var _deallocator: ((UnsafeMutableRawPointer, Int) -> Void)? = nil
+    public var _deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?
     public var _backing: Backing = .swift
     
     public var bytes: UnsafeRawPointer? {
@@ -228,8 +221,8 @@ public final class _DataStorage {
             newBytes = _DataStorage.allocate(newCapacity, allocateCleared)
             if newBytes == nil {
                 /* Try again with minimum length */
-                allocateCleared = clear && _DataStorage.shouldAllocateCleared(newLength);
-                newBytes = _DataStorage.allocate(newLength, allocateCleared);
+                allocateCleared = clear && _DataStorage.shouldAllocateCleared(newLength)
+                newBytes = _DataStorage.allocate(newLength, allocateCleared)
             }
         } else {
             let tryCalloc = (origLength == 0 || (newLength / origLength) >= 4)
@@ -299,9 +292,9 @@ public final class _DataStorage {
             let newLength = length
             if _capacity < newLength || _bytes == nil {
                 _grow(newLength, true)
-            } else if (origLength < newLength && _needToZero) {
+            } else if origLength < newLength && _needToZero {
                 memset(_bytes! + origLength, 0, newLength - origLength)
-            } else if (newLength < origLength) {
+            } else if newLength < origLength {
                 _needToZero = true
             }
             _length = newLength
@@ -357,17 +350,17 @@ public final class _DataStorage {
     
     // fast-path for appending directly from another data storage
     @inline(__always)
-    public func append(_ otherData: _DataStorage) {
+    public func append(_ otherData: _DataStorage, startingAt start: Int) {
         let otherLength = otherData.length
         if otherLength == 0 { return }
         if let bytes = otherData.bytes {
-            append(bytes, length: otherLength)
+            append(bytes.advanced(by: start), length: otherLength)
         }
     }
     
     @inline(__always)
     public func append(_ otherData: Data) {
-        otherData.enumerateBytes { (buffer: UnsafeBufferPointer<UInt8>, location: Data.Index, stop: inout Bool) in
+        otherData.enumerateBytes { (buffer: UnsafeBufferPointer<UInt8>, _, _) in
             append(buffer.baseAddress!, length: buffer.count)
         }
     }
@@ -543,7 +536,7 @@ public final class _DataStorage {
     public init(length: Int) {
         precondition(length < _DataStorage.maxSize)
         var capacity = (length < 1024 * 1024 * 1024) ? length + (length >> 2) : length
-        if (_DataStorage.vmOpsThreshold <= capacity) {
+        if _DataStorage.vmOpsThreshold <= capacity {
             capacity = NSRoundUpToMultipleOfPageSize(capacity)
         }
         
@@ -559,7 +552,7 @@ public final class _DataStorage {
     public init(capacity capacity_: Int) {
         var capacity = capacity_
         precondition(capacity < _DataStorage.maxSize)
-        if (_DataStorage.vmOpsThreshold <= capacity) {
+        if _DataStorage.vmOpsThreshold <= capacity {
             capacity = NSRoundUpToMultipleOfPageSize(capacity)
         }
         _length = 0
@@ -583,7 +576,7 @@ public final class _DataStorage {
             _DataStorage.move(_bytes!, bytes, length)
         } else {
             var capacity = length
-            if (_DataStorage.vmOpsThreshold <= capacity) {
+            if _DataStorage.vmOpsThreshold <= capacity {
                 capacity = NSRoundUpToMultipleOfPageSize(capacity)
             }
             _length = length
@@ -622,7 +615,7 @@ public final class _DataStorage {
             }
         } else {
             var capacity = length
-            if (_DataStorage.vmOpsThreshold <= capacity) {
+            if _DataStorage.vmOpsThreshold <= capacity {
                 capacity = NSRoundUpToMultipleOfPageSize(capacity)
             }
             _length = length
@@ -678,34 +671,66 @@ public final class _DataStorage {
     }
     
     @inline(__always)
-    public func mutableCopy() -> _DataStorage {
+    public func mutableCopy(_ range: Range<Int>) -> _DataStorage {
         switch _backing {
         case .swift:
-            return _DataStorage(bytes: _bytes, length: _length, copy: true, deallocator: nil)
+            return _DataStorage(bytes: _bytes?.advanced(by: range.lowerBound), length: range.count, copy: true, deallocator: nil)
         case .immutable(let d):
-            return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData)
+            if range.lowerBound == 0 && range.upperBound == _length {
+                return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData)
+            } else {
+                return _DataStorage(mutableReference: d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC().mutableCopy() as! NSMutableData)
+            }
         case .mutable(let d):
-            return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData)
+            if range.lowerBound == 0 && range.upperBound == _length {
+                return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData)
+            } else {
+                return _DataStorage(mutableReference: d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC().mutableCopy() as! NSMutableData)
+            }
         case .customReference(let d):
-            return _DataStorage(customMutableReference: d.mutableCopy() as! NSMutableData)
+            if range.lowerBound == 0 && range.upperBound == _length {
+                return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData)
+            } else {
+                return _DataStorage(mutableReference: d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC().mutableCopy() as! NSMutableData)
+            }
         case .customMutableReference(let d):
-            return _DataStorage(customMutableReference: d.mutableCopy() as! NSMutableData)
+            if range.lowerBound == 0 && range.upperBound == _length {
+                return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData)
+            } else {
+                return _DataStorage(mutableReference: d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC().mutableCopy() as! NSMutableData)
+            }
         }
     }
     
-    public func withInteriorPointerReference<T>(_ work: (NSData) throws -> T) rethrows -> T {
+    public func withInteriorPointerReference<T>(_ range: Range<Int>, _ work: (NSData) throws -> T) rethrows -> T {
         switch _backing {
         case .swift:
-            let d = _bytes == nil ? NSData() : NSData(bytesNoCopy: _bytes!, length: _length, freeWhenDone: false)
+            let d = _bytes == nil ? NSData() : NSData(bytesNoCopy: _bytes!.advanced(by: range.lowerBound), length: range.count, freeWhenDone: false)
             return try work(d)
         case .immutable(let d):
-            return try work(d)
+            if range.lowerBound == 0 && range.upperBound == _length {
+                return try work(d)
+            } else {
+                return try work(d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC())
+            }
         case .mutable(let d):
-            return try work(d)
+            if range.lowerBound == 0 && range.upperBound == _length {
+                return try work(d)
+            } else {
+                return try work(d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC())
+            }
         case .customReference(let d):
-            return try work(d)
+            if range.lowerBound == 0 && range.upperBound == _length {
+                return try work(d)
+            } else {
+                return try work(d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC())
+            }
         case .customMutableReference(let d):
-            return try work(d)
+            if range.lowerBound == 0 && range.upperBound == _length {
+                return try work(d)
+            } else {
+                return try work(d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC())
+            }
         }
     }
     
@@ -721,73 +746,8 @@ public final class _DataStorage {
             return d
         case .customMutableReference(let d):
             // Because this is returning an object that may be mutated in the future it needs to create a copy to prevent
-            // any further mutations out from under the reciever
+            // any further mutations out from under the receiver
             return d.copy() as! NSData
-        }
-    }
-    
-    public static func ==(_ lhs: _DataStorage, _ rhs: _DataStorage) -> Bool {
-        switch (lhs._backing, rhs._backing) {
-        case (.swift, .customReference(let d)):
-            return lhs.withInteriorPointerReference {
-                return $0.isEqual(d)
-            }
-        case (.swift, .customMutableReference(let d)):
-            return lhs.withInteriorPointerReference {
-                return $0.isEqual(d)
-            }
-        case (.immutable(let d1), .customReference(let d2)):
-            return d1.isEqual(d2)
-        case (.immutable(let d1), .customMutableReference(let d2)):
-            return d1.isEqual(d2)
-        case (.mutable(let d1), .customReference(let d2)):
-            return d1.isEqual(d2)
-        case (.mutable(let d1), .customMutableReference(let d2)):
-            return d1.isEqual(d2)
-        case (.customReference(let d), .swift):
-            return rhs.withInteriorPointerReference {
-                return d.isEqual($0)
-            }
-        case (.customReference(let d1), .immutable):
-            return rhs.withInteriorPointerReference {
-                return d1.isEqual($0)
-            }
-        case (.customReference(let d1), .mutable):
-            return rhs.withInteriorPointerReference {
-                return d1.isEqual($0)
-            }
-        case (.customReference(let d1), .customReference(let d2)):
-            return d1.isEqual(d2)
-        case (.customReference(let d1), .customMutableReference(let d2)):
-            return d1.isEqual(d2)
-        case (.customMutableReference(let d), .swift):
-            return rhs.withInteriorPointerReference {
-                return d.isEqual($0)
-            }
-        case (.customMutableReference(let d1), .immutable):
-            return rhs.withInteriorPointerReference {
-                return d1.isEqual($0)
-            }
-        case (.customMutableReference(let d1), .mutable):
-            return rhs.withInteriorPointerReference {
-                return d1.isEqual($0)
-            }
-        case (.customMutableReference(let d1), .customReference(let d2)):
-            return d1.isEqual(d2)
-        case (.customMutableReference(let d1), .customMutableReference(let d2)):
-            return d1.isEqual(d2)
-        default:
-            let length1 = lhs.length
-            if length1 != rhs.length {
-                return false
-            }
-            if lhs.bytes == rhs.bytes {
-                return true
-            }
-            if length1 > 0 {
-                return memcmp(lhs._bytes!, rhs._bytes!, length1) == 0
-            }
-            return true
         }
     }
     
@@ -830,7 +790,7 @@ internal class _NSSwiftData : NSData {
     override var bytes: UnsafeRawPointer {
         // NSData's byte pointer methods are not annotated for nullability correctly
         // (but assume non-null by the wrapping macro guards). This placeholder value
-        // is to work-around this bug. Any indirection to the underlying bytes of a NSData
+        // is to work-around this bug. Any indirection to the underlying bytes of an NSData
         // with a length of zero would have been a programmer error anyhow so the actual
         // return value here is not needed to be an allocated value. This is specifically
         // needed to live like this to be source compatible with Swift3. Beyond that point
@@ -874,6 +834,8 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public typealias Indices = CountableRange<Int>
     
     @_versioned internal var _backing : _DataStorage
+    @_versioned internal var _sliceRange: Range<Index>
+    
     
     // A standard or custom deallocator for `Data`.
     ///
@@ -913,11 +875,11 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
 #else
             switch self {
             case .virtualMemory:
-                return { __NSDataInvokeDeallocatorVM($0, $1) }
+                return { NSDataDeallocatorVM($0, $1) }
             case .unmap:
-                return { __NSDataInvokeDeallocatorUnmap($0, $1) }
+                return { NSDataDeallocatorUnmap($0, $1) }
             case .free:
-                return { __NSDataInvokeDeallocatorFree($0, $1) }
+                return { NSDataDeallocatorFree($0, $1) }
             case .none:
                 return { _, _ in }
             case .custom(let b):
@@ -938,44 +900,53 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter count: The number of bytes to copy.
     public init(bytes: UnsafeRawPointer, count: Int) {
         _backing = _DataStorage(bytes: bytes, length: count)
+        _sliceRange = 0..<count
     }
     
     /// Initialize a `Data` with copied memory content.
     ///
     /// - parameter buffer: A buffer pointer to copy. The size is calculated from `SourceType` and `buffer.count`.
     public init<SourceType>(buffer: UnsafeBufferPointer<SourceType>) {
-        _backing = _DataStorage(bytes: buffer.baseAddress, length: MemoryLayout<SourceType>.stride * buffer.count)
+        let count = MemoryLayout<SourceType>.stride * buffer.count
+        _backing = _DataStorage(bytes: buffer.baseAddress, length: count)
+        _sliceRange = 0..<count
     }
     
     /// Initialize a `Data` with copied memory content.
     ///
     /// - parameter buffer: A buffer pointer to copy. The size is calculated from `SourceType` and `buffer.count`.
     public init<SourceType>(buffer: UnsafeMutableBufferPointer<SourceType>) {
-        _backing = _DataStorage(bytes: buffer.baseAddress, length: MemoryLayout<SourceType>.stride * buffer.count)
+        let count = MemoryLayout<SourceType>.stride * buffer.count
+        _backing = _DataStorage(bytes: buffer.baseAddress, length: count)
+        _sliceRange = 0..<count
     }
     
     /// Initialize a `Data` with the contents of an Array.
     ///
     /// - parameter bytes: An array of bytes to copy.
     public init(bytes: Array<UInt8>) {
+        let count = bytes.count
         _backing = bytes.withUnsafeBufferPointer {
-            return _DataStorage(bytes: $0.baseAddress, length: $0.count)
+            return _DataStorage(bytes: $0.baseAddress, length: count)
         }
+        _sliceRange = 0..<count
     }
     
     /// Initialize a `Data` with the contents of an Array.
     ///
     /// - parameter bytes: An array of bytes to copy.
     public init(bytes: ArraySlice<UInt8>) {
+        let count = bytes.count
         _backing = bytes.withUnsafeBufferPointer {
-            return _DataStorage(bytes: $0.baseAddress, length: $0.count)
+            return _DataStorage(bytes: $0.baseAddress, length: count)
         }
+        _sliceRange = 0..<count
     }
 
-    /// Initialze a `Data` with a repeating byte pattern
+    /// Initialize a `Data` with a repeating byte pattern
     ///
-    /// - parameter repeatedValue: A byte to initialze the pattern
-    /// - parameter count: The number of bytes the data initially contains initialzed to the repeatedValue
+    /// - parameter repeatedValue: A byte to initialize the pattern
+    /// - parameter count: The number of bytes the data initially contains initialized to the repeatedValue
     public init(repeating repeatedValue: UInt8, count: Int) {
         self.init(count: count)
         withUnsafeMutableBytes { (bytes: UnsafeMutablePointer<UInt8>) -> Void in
@@ -994,6 +965,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter capacity: The size of the data.
     public init(capacity: Int) {
         _backing = _DataStorage(capacity: capacity)
+        _sliceRange = 0..<0
     }
     
     /// Initialize a `Data` with the specified count of zeroed bytes.
@@ -1001,11 +973,13 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter count: The number of bytes the data initially contains.
     public init(count: Int) {
         _backing = _DataStorage(length: count)
+        _sliceRange = 0..<count
     }
     
     /// Initialize an empty `Data`.
     public init() {
         _backing = _DataStorage(length: 0)
+        _sliceRange = 0..<0
     }
     
     
@@ -1018,6 +992,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public init(bytesNoCopy bytes: UnsafeMutableRawPointer, count: Int, deallocator: Deallocator) {
         let whichDeallocator = deallocator._deallocator
         _backing = _DataStorage(bytes: bytes, length: count, copy: false, deallocator: whichDeallocator)
+        _sliceRange = 0..<count
     }
     
     /// Initialize a `Data` with the contents of a `URL`.
@@ -1026,7 +1001,9 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter options: Options for the read operation. Default value is `[]`.
     /// - throws: An error in the Cocoa domain, if `url` cannot be read.
     public init(contentsOf url: URL, options: Data.ReadingOptions = []) throws {
-        _backing = _DataStorage(immutableReference: try NSData(contentsOf: url, options: ReadingOptions(rawValue: options.rawValue)))
+        let d = try NSData(contentsOf: url, options: ReadingOptions(rawValue: options.rawValue))
+        _backing = _DataStorage(immutableReference: d)
+        _sliceRange = 0..<d.length
     }
     
     /// Initialize a `Data` from a Base-64 encoded String using the given options.
@@ -1037,6 +1014,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public init?(base64Encoded base64String: String, options: Data.Base64DecodingOptions = []) {
         if let d = NSData(base64Encoded: base64String, options: Base64DecodingOptions(rawValue: options.rawValue)) {
             _backing = _DataStorage(immutableReference: d)
+            _sliceRange = 0..<d.length
         } else {
             return nil
         }
@@ -1051,6 +1029,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public init?(base64Encoded base64Data: Data, options: Data.Base64DecodingOptions = []) {
         if let d = NSData(base64Encoded: base64Data, options: Base64DecodingOptions(rawValue: options.rawValue)) {
             _backing = _DataStorage(immutableReference: d)
+            _sliceRange = 0..<d.length
         } else {
             return nil
         }
@@ -1071,10 +1050,18 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
 #endif
         if providesConcreteBacking {
             _backing = _DataStorage(immutableReference: reference.copy() as! NSData)
+            _sliceRange = 0..<reference.length
         } else {
             _backing = _DataStorage(customReference: reference.copy() as! NSData)
+            _sliceRange = 0..<reference.length
         }
 
+    }
+    
+    @_versioned
+    internal init(backing: _DataStorage, range: Range<Index>) {
+        _backing = backing
+        _sliceRange = range
     }
     
     // -----------------------------------
@@ -1085,14 +1072,15 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public var count: Int {
         @inline(__always)
         get {
-            return _backing.length
+            return _sliceRange.count
         }
         @inline(__always)
         set {
             if !isKnownUniquelyReferenced(&_backing) {
-                _backing = _backing.mutableCopy()
+                _backing = _backing.mutableCopy(_sliceRange)
             }
             _backing.length = newValue
+            _sliceRange = _sliceRange.lowerBound..<(_sliceRange.lowerBound + newValue)
         }
     }
     
@@ -1101,7 +1089,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - warning: The byte pointer argument should not be stored and used outside of the lifetime of the call to the closure.
     @inline(__always)
     public func withUnsafeBytes<ResultType, ContentType>(_ body: (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
-        let bytes =  _backing.bytes ?? UnsafeRawPointer(bitPattern: 0xBAD0)!
+        let bytes =  _backing.bytes?.advanced(by: _sliceRange.lowerBound) ?? UnsafeRawPointer(bitPattern: 0xBAD0)!
         let contentPtr = bytes.bindMemory(to: ContentType.self, capacity: count / MemoryLayout<ContentType>.stride)
         return try body(contentPtr)
     }
@@ -1114,9 +1102,9 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     @inline(__always)
     public mutating func withUnsafeMutableBytes<ResultType, ContentType>(_ body: (UnsafeMutablePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
         if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy()
+            _backing = _backing.mutableCopy(_sliceRange)
         }
-        let mutableBytes = _backing.mutableBytes ?? UnsafeMutableRawPointer(bitPattern: 0xBAD0)!
+        let mutableBytes = _backing.mutableBytes?.advanced(by: _sliceRange.lowerBound) ?? UnsafeMutableRawPointer(bitPattern: 0xBAD0)!
         let contentPtr = mutableBytes.bindMemory(to: ContentType.self, capacity: count / MemoryLayout<ContentType>.stride)
         return try body(UnsafeMutablePointer(contentPtr))
     }
@@ -1132,13 +1120,13 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     @inline(__always)
     public func copyBytes(to pointer: UnsafeMutablePointer<UInt8>, count: Int) {
         if count == 0 { return }
-        memcpy(UnsafeMutableRawPointer(pointer), _backing.bytes!, count)
+        memcpy(UnsafeMutableRawPointer(pointer), _backing.bytes!.advanced(by: _sliceRange.lowerBound), count)
     }
     
     @inline(__always)
     private func _copyBytesHelper(to pointer: UnsafeMutableRawPointer, from range: NSRange) {
         if range.length == 0 { return }
-        memcpy(UnsafeMutableRawPointer(pointer), _backing.bytes!.advanced(by: range.location), range.length)
+        memcpy(UnsafeMutableRawPointer(pointer), _backing.bytes!.advanced(by: range.location + _sliceRange.lowerBound), range.length)
     }
     
     /// Copy a subset of the contents of the data to a pointer.
@@ -1206,15 +1194,13 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter options: Options for writing the data. Default value is `[]`.
     /// - throws: An error in the Cocoa domain, if there is an error writing to the `URL`.
     public func write(to url: URL, options: Data.WritingOptions = []) throws {
-        try _backing.withInteriorPointerReference {
+        try _backing.withInteriorPointerReference(_sliceRange) {
 #if DEPLOYMENT_RUNTIME_SWIFT
             try $0.write(to: url, options: WritingOptions(rawValue: options.rawValue))
 #else
             if _shouldUseNonAtomicWriteReimplementation(options: options) {
-                var error : NSError?
-                if !_NSWriteDataToFile_Swift(url: url._bridgeToObjectiveC(), data: $0, options: options.rawValue, error: &error) {
-                    throw error!
-                }
+                var error: NSError? = nil
+                guard __NSDataWriteToURL($0, url as NSURL, options.rawValue, &error) else { throw error! }
             } else {
                 try $0.write(to: url, options: WritingOptions(rawValue: options.rawValue))
             }
@@ -1238,7 +1224,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         } else {
             nsRange = NSMakeRange(0, _backing.length)
         }
-        let result = _backing.withInteriorPointerReference {
+        let result = _backing.withInteriorPointerReference(_sliceRange) {
             $0.range(of: dataToFind, options: options, in: nsRange)
         }
         if result.location == NSNotFound {
@@ -1259,17 +1245,19 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public mutating func append(_ bytes: UnsafePointer<UInt8>, count: Int) {
         if count == 0 { return }
         if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy()
+            _backing = _backing.mutableCopy(_sliceRange)
         }
         _backing.append(bytes, length: count)
+        _sliceRange = _sliceRange.lowerBound..<(_sliceRange.upperBound + count)
     }
     
     @inline(__always)
     public mutating func append(_ other: Data) {
         if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy()
+            _backing = _backing.mutableCopy(_sliceRange)
         }
-        _backing.append(other._backing)
+        _backing.append(other._backing, startingAt: other._sliceRange.lowerBound)
+        _sliceRange = _sliceRange.lowerBound..<(_sliceRange.upperBound + other.count)
     }
     
     /// Append a buffer of bytes to the data.
@@ -1279,34 +1267,24 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public mutating func append<SourceType>(_ buffer : UnsafeBufferPointer<SourceType>) {
         if buffer.count == 0 { return }
         if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy()
+            _backing = _backing.mutableCopy(_sliceRange)
         }
         _backing.append(buffer.baseAddress!, length: buffer.count * MemoryLayout<SourceType>.stride)
-    }
-    
-    @inline(__always)
-    public mutating func append(_ other: MutableRangeReplaceableRandomAccessSlice<Data>) {
-        let count = other.count
-        if count == 0 { return }
-        other.base.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> Void in
-            append(bytes, count: count)
-        }
+        _sliceRange = _sliceRange.lowerBound..<(_sliceRange.upperBound + buffer.count * MemoryLayout<SourceType>.stride)
     }
     
     @inline(__always)
     public mutating func append<S : Sequence>(contentsOf newElements: S) where S.Iterator.Element == Iterator.Element {
         let estimatedCount = newElements.underestimatedCount
         var idx = count
-        if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy()
-        }
         count += estimatedCount
         for byte in newElements {
-            self[idx] = byte
-            idx += 1
-            if idx > count {
-                count = idx
+            let newIndex = idx + 1
+            if newIndex > count {
+                count = newIndex
             }
+            self[idx] = byte
+            idx = newIndex
         }
     }
     
@@ -1327,9 +1305,13 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public mutating func resetBytes(in range: Range<Index>) {
         let range = NSMakeRange(range.lowerBound, range.upperBound - range.lowerBound)
         if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy()
+            _backing = _backing.mutableCopy(_sliceRange)
         }
         _backing.resetBytes(in: range)
+        if _sliceRange.count < range.location + range.length {
+            let newLength = range.location + range.length
+            _sliceRange = _sliceRange.lowerBound..<(_sliceRange.lowerBound + newLength)
+        }
     }
     
     /// Replace a region of bytes in the data with new data.
@@ -1344,11 +1326,14 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         let nsRange = NSMakeRange(subrange.lowerBound, subrange.upperBound - subrange.lowerBound)
         let cnt = data.count
         if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy()
+            _backing = _backing.mutableCopy(_sliceRange)
         }
-        data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> Void in
+        let resultingLength = data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> Int in
+            let currentLength = _backing.length
             _backing.replaceBytes(in: nsRange, with: bytes, length: cnt)
+            return currentLength - nsRange.length + cnt
         }
+        _sliceRange = _sliceRange.lowerBound..<(_sliceRange.lowerBound + resultingLength)
     }
     
     /// Replace a region of bytes in the data with new bytes from a buffer.
@@ -1364,9 +1349,12 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         let bufferCount = buffer.count * MemoryLayout<SourceType>.stride
         
         if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy()
+            _backing = _backing.mutableCopy(_sliceRange)
         }
+        let currentLength = _backing.length
         _backing.replaceBytes(in: nsRange, with: buffer.baseAddress, length: bufferCount)
+        let resultingLength = currentLength - nsRange.length + bufferCount
+        _sliceRange = _sliceRange.lowerBound..<(_sliceRange.lowerBound + resultingLength)
     }
     
     /// Replace a region of bytes in the data with new bytes from a collection.
@@ -1399,7 +1387,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
                 // In the future, if we keep the malloced pointer and count inside this struct/ref instead of deferring to NSData, we may be able to do this more efficiently.
                 self.count = resultCount
             }
-            
+
             let shift = resultCount - currentCount
             let start = subrange.lowerBound
             
@@ -1411,11 +1399,9 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
                 }
                 
                 if replacementCount != 0 {
-                  let buf = UnsafeMutableBufferPointer(start: bytes + start, 
-                                                       count: replacementCount)
-                  var (it,idx) = newElements._copyContents(initializing: buf)
-                  precondition(it.next() == nil && idx == buf.endIndex,
-                    "newElements iterator returned different count to newElements.count")
+                    let buf = UnsafeMutableBufferPointer(start: bytes + start, count: replacementCount)
+                    var (it,idx) = newElements._copyContents(initializing: buf)
+                    precondition(it.next() == nil && idx == buf.endIndex, "newElements iterator returned different count to newElements.count")
                 }
             }
     }
@@ -1424,9 +1410,12 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public mutating func replaceSubrange(_ subrange: Range<Index>, with bytes: UnsafeRawPointer, count cnt: Int) {
         let nsRange = NSMakeRange(subrange.lowerBound, subrange.upperBound - subrange.lowerBound)
         if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy()
+            _backing = _backing.mutableCopy(_sliceRange)
         }
+        let currentLength = _backing.length
         _backing.replaceBytes(in: nsRange, with: bytes, length: cnt)
+        let resultingLength = currentLength - nsRange.length + cnt
+        _sliceRange = _sliceRange.lowerBound..<(_sliceRange.lowerBound + resultingLength)
     }
 
     /// Return a new copy of the data in a specified range.
@@ -1450,7 +1439,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter options: The options to use for the encoding. Default value is `[]`.
     /// - returns: The Base-64 encoded string.
     public func base64EncodedString(options: Data.Base64EncodingOptions = []) -> String {
-        return _backing.withInteriorPointerReference {
+        return _backing.withInteriorPointerReference(_sliceRange) {
             return $0.base64EncodedString(options: options)
         }
     }
@@ -1460,7 +1449,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter options: The options to use for the encoding. Default value is `[]`.
     /// - returns: The Base-64 encoded data.
     public func base64EncodedData(options: Data.Base64EncodingOptions = []) -> Data {
-        return _backing.withInteriorPointerReference {
+        return _backing.withInteriorPointerReference(_sliceRange) {
             return $0.base64EncodedData(options: options)
         }
     }
@@ -1491,27 +1480,25 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public subscript(index: Index) -> UInt8 {
         @inline(__always)
         get {
-            return withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> UInt8 in
-                return bytes.advanced(by: index).pointee
-            }
+            return _backing.bytes!.advanced(by: _sliceRange.lowerBound + index).assumingMemoryBound(to: UInt8.self).pointee
         }
         @inline(__always)
         set {
             if !isKnownUniquelyReferenced(&_backing) {
-                _backing = _backing.mutableCopy()
+                _backing = _backing.mutableCopy(_sliceRange)
             }
             _backing.set(index, to: newValue)
         }
     }
     
-    public subscript(bounds: Range<Index>) -> MutableRangeReplaceableRandomAccessSlice<Data> {
+    public subscript(bounds: Range<Index>) -> Data {
         @inline(__always)
         get {
-            return MutableRangeReplaceableRandomAccessSlice(base: self, bounds: bounds)
+            return Data(backing: _backing, range: bounds)
         }
         @inline(__always)
         set {
-            replaceSubrange(bounds, with: newValue.base)
+            replaceSubrange(bounds, with: newValue)
         }
     }
     
@@ -1520,7 +1507,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public var startIndex: Index {
         @inline(__always)
         get {
-            return 0
+            return _sliceRange.lowerBound
         }
     }
     
@@ -1530,7 +1517,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public var endIndex: Index {
         @inline(__always)
         get {
-            return count
+            return _sliceRange.upperBound
         }
     }
     
@@ -1571,7 +1558,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         fileprivate init(_data: Data) {
             self._data = _data
             _buffer = (0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
-            _idx = 0
+            _idx = _data.startIndex
             _endIdx = _data.endIndex
         }
         
@@ -1581,7 +1568,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             let bufferSize = MemoryLayout.size(ofValue: _buffer)
             return withUnsafeMutablePointer(to: &_buffer) { ptr_ in
                 let ptr = UnsafeMutableRawPointer(ptr_).assumingMemoryBound(to: UInt8.self)
-                let bufferIdx = _idx % bufferSize
+                let bufferIdx = (_idx - _data.startIndex) % bufferSize
                 if bufferIdx == 0 {
                     // populate the buffer
                     _data.copyBytes(to: ptr, from: _idx..<(_endIdx - _idx > bufferSize ? _idx + bufferSize : _endIdx))
@@ -1621,7 +1608,11 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             return true
         }
         if length1 > 0 {
-            return memcmp(backing1.bytes!, backing2.bytes!, length1) == 0
+            return d1.withUnsafeBytes { (b1) in
+                return d2.withUnsafeBytes { (b2) in
+                    return memcmp(b1, b2, length1) == 0
+                }
+            }
         }
         return true
     }

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -91,6 +91,10 @@ class TestNSData: XCTestCase {
             ("test_initDataWithCount", test_initDataWithCount),
             ("test_emptyStringToData", test_emptyStringToData),
             ("test_repeatingValueInitialization", test_repeatingValueInitialization),
+            
+            ("test_sliceAppending", test_sliceAppending),
+            ("test_replaceSubrange", test_replaceSubrange),
+            ("test_sliceWithUnsafeBytes", test_sliceWithUnsafeBytes),
         ]
     }
     
@@ -1046,6 +1050,34 @@ extension TestNSData {
         XCTAssertEqual(d[3], 0x02)
         XCTAssertEqual(d[4], 0x02)
         XCTAssertEqual(d[5], 0x02)
+    }
+    
+    func test_sliceAppending() {
+        // https://bugs.swift.org/browse/SR-4473
+        var fooData = Data()
+        let barData = Data([0, 1, 2, 3, 4, 5])
+        let slice = barData.suffix(from: 3)
+        fooData.append(slice)
+        XCTAssertEqual(fooData[0], 0x03)
+        XCTAssertEqual(fooData[1], 0x04)
+        XCTAssertEqual(fooData[2], 0x05)
+    }
+    
+    func test_replaceSubrange() {
+        // https://bugs.swift.org/browse/SR-4462
+        let data = Data(bytes: [0x01, 0x02])
+        var dataII = Data(base64Encoded: data.base64EncodedString())!
+        dataII.replaceSubrange(0..<1, with: Data())
+        XCTAssertEqual(dataII[0], 0x02)
+    }
+    
+    func test_sliceWithUnsafeBytes() {
+        let base = Data([0, 1, 2, 3, 4, 5])
+        let slice = base[2..<4]
+        let segment = slice.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> [UInt8] in
+            return [ptr.pointee, ptr.advanced(by: 1).pointee]
+        }
+        XCTAssertEqual(segment, [UInt8(2), UInt8(3)])
     }
 }
 

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -95,6 +95,7 @@ class TestNSData: XCTestCase {
             ("test_sliceAppending", test_sliceAppending),
             ("test_replaceSubrange", test_replaceSubrange),
             ("test_sliceWithUnsafeBytes", test_sliceWithUnsafeBytes),
+            ("test_sliceIteration", test_sliceIteration),
         ]
     }
     
@@ -1078,6 +1079,17 @@ extension TestNSData {
             return [ptr.pointee, ptr.advanced(by: 1).pointee]
         }
         XCTAssertEqual(segment, [UInt8(2), UInt8(3)])
+    }
+    
+    func test_sliceIteration() {
+        let base = Data([0, 1, 2, 3, 4, 5])
+        let slice = base[2..<4]
+        var found = [UInt8]()
+        for byte in slice {
+            found.append(byte)
+        }
+        XCTAssertEqual(found[0], 2)
+        XCTAssertEqual(found[1], 3)
     }
 }
 


### PR DESCRIPTION
this cherry picks the Data fixes for indexing and slicing:

Address slice regions that incorrectly fetched from the wrong offset of the backing buffers (#929)

* Update Data to be in sync with Foundation overlay

* Account for slice starts in appending, replacing subranges and fetching unsafe byte pointers

Correct Data slice iteration to be indexed by the startIndex to the endIndex