### PR TITLE
Fix more warnings for deprecation and unsafeBitCast()

### DIFF
--- a/Foundation/DateInterval.swift
+++ b/Foundation/DateInterval.swift
@@ -155,10 +155,10 @@ public struct DateInterval : ReferenceConvertible, Comparable, Hashable {
     
     public var hashValue: Int {
         var buf: (UInt, UInt) = (UInt(start.timeIntervalSinceReferenceDate), UInt(end.timeIntervalSinceReferenceDate))
-        return withUnsafeMutablePointer(to: &buf) {
+        return withUnsafeMutablePointer(to: &buf) { bufferPtr in
             let count = MemoryLayout<UInt>.size * 2
-            return $0.withMemoryRebound(to: UInt8.self, capacity: count) {
-                return Int(bitPattern: CFHashBytes($0, CFIndex(count)))
+            return bufferPtr.withMemoryRebound(to: UInt8.self, capacity: count) { bufferBytes in
+                return Int(bitPattern: CFHashBytes(bufferBytes, CFIndex(count)))
             }
         }
     }

--- a/Foundation/DateInterval.swift
+++ b/Foundation/DateInterval.swift
@@ -156,7 +156,10 @@ public struct DateInterval : ReferenceConvertible, Comparable, Hashable {
     public var hashValue: Int {
         var buf: (UInt, UInt) = (UInt(start.timeIntervalSinceReferenceDate), UInt(end.timeIntervalSinceReferenceDate))
         return withUnsafeMutablePointer(to: &buf) {
-            return Int(bitPattern: CFHashBytes(unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self), CFIndex(MemoryLayout<UInt>.size * 2)))
+            let count = MemoryLayout<UInt>.size * 2
+            return $0.withMemoryRebound(to: UInt8.self, capacity: count) {
+                return Int(bitPattern: CFHashBytes($0, CFIndex(count)))
+            }
         }
     }
     

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -130,7 +130,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
 //        }
         let cnt = array.count
         let buffer = UnsafeMutablePointer<AnyObject>.allocate(capacity: cnt)
-        buffer.initialize(from: optionalArray)
+        _ = UnsafeMutableBufferPointer(start: buffer, count: cnt).initialize(from: optionalArray)
         self.init(objects: buffer, count: cnt)
         buffer.deinitialize(count: cnt)
         buffer.deallocate(capacity: cnt)

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -130,7 +130,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
 //        }
         let cnt = array.count
         let buffer = UnsafeMutablePointer<AnyObject>.allocate(capacity: cnt)
-        _ = UnsafeMutableBufferPointer(start: buffer, count: cnt).initialize(from: optionalArray)
+        buffer.initialize(from: optionalArray, count: cnt)
         self.init(objects: buffer, count: cnt)
         buffer.deinitialize(count: cnt)
         buffer.deallocate(capacity: cnt)

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -124,12 +124,10 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     
     public convenience init(objects: [Any], forKeys keys: [NSObject]) {
         let keyBuffer = UnsafeMutablePointer<NSObject>.allocate(capacity: keys.count)
-        _ = UnsafeMutableBufferPointer(start: keyBuffer, count: keys.count).initialize(from: keys)
+        keyBuffer.initialize(from: keys, count: keys.count)
 
         let valueBuffer = UnsafeMutablePointer<AnyObject>.allocate(capacity: objects.count)
-        _ = UnsafeMutableBufferPointer(start: valueBuffer, count: objects.count).initialize(from: objects.map {
-            _SwiftValue.store($0)
-        })
+        valueBuffer.initialize(from: objects.map { _SwiftValue.store($0) }, count: objects.count)
 
         self.init(objects: valueBuffer, forKeys:keyBuffer, count: keys.count)
         

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -124,10 +124,12 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     
     public convenience init(objects: [Any], forKeys keys: [NSObject]) {
         let keyBuffer = UnsafeMutablePointer<NSObject>.allocate(capacity: keys.count)
-        keyBuffer.initialize(from: keys)
+        _ = UnsafeMutableBufferPointer(start: keyBuffer, count: keys.count).initialize(from: keys)
 
         let valueBuffer = UnsafeMutablePointer<AnyObject>.allocate(capacity: objects.count)
-        valueBuffer.initialize(from: objects.map { _SwiftValue.store($0) })
+        _ = UnsafeMutableBufferPointer(start: valueBuffer, count: objects.count).initialize(from: objects.map {
+            _SwiftValue.store($0)
+        })
 
         self.init(objects: valueBuffer, forKeys:keyBuffer, count: keys.count)
         

--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -223,7 +223,9 @@ open class Process: NSObject {
         let argv : UnsafeMutablePointer<UnsafeMutablePointer<Int8>?> = args.withUnsafeBufferPointer {
             let array : UnsafeBufferPointer<String> = $0
             let buffer = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>.allocate(capacity: array.count + 1)
-            buffer.initialize(from: array.map { $0.withCString(strdup) })
+            _ = UnsafeMutableBufferPointer(start: buffer, count: array.count + 1).initialize(from: array.map {
+                $0.withCString(strdup)
+            })
             buffer[array.count] = nil
             return buffer
         }
@@ -241,7 +243,9 @@ open class Process: NSObject {
         if let env = environment {
             let nenv = env.count
             envp = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>.allocate(capacity: 1 + nenv)
-            envp.initialize(from: env.map { strdup("\($0)=\($1)") })
+            _ = UnsafeMutableBufferPointer(start: envp, count: 1 + nenv).initialize(from: env.map {
+                strdup("\($0)=\($1)")
+            })
             envp[env.count] = nil
         } else {
             envp = _CFEnviron()

--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -223,9 +223,7 @@ open class Process: NSObject {
         let argv : UnsafeMutablePointer<UnsafeMutablePointer<Int8>?> = args.withUnsafeBufferPointer {
             let array : UnsafeBufferPointer<String> = $0
             let buffer = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>.allocate(capacity: array.count + 1)
-            _ = UnsafeMutableBufferPointer(start: buffer, count: array.count + 1).initialize(from: array.map {
-                $0.withCString(strdup)
-            })
+            buffer.initialize(from: array.map { $0.withCString(strdup) }, count: array.count)
             buffer[array.count] = nil
             return buffer
         }
@@ -243,9 +241,7 @@ open class Process: NSObject {
         if let env = environment {
             let nenv = env.count
             envp = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>.allocate(capacity: 1 + nenv)
-            _ = UnsafeMutableBufferPointer(start: envp, count: 1 + nenv).initialize(from: env.map {
-                strdup("\($0)=\($1)")
-            })
+            envp.initialize(from: env.map { strdup("\($0)=\($1)") }, count: 1 + nenv)
             envp[env.count] = nil
         } else {
             envp = _CFEnviron()

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -760,8 +760,9 @@ extension TestNSData {
         let expectedSize = MemoryLayout<UInt8>.stride * a.count
         XCTAssertEqual(expectedSize, data.count)
         
-        let underlyingBuffer = unsafeBitCast(malloc(expectedSize - 1)!, to: UnsafeMutablePointer<UInt8>.self)
-        let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer, count: expectedSize - 1)
+        let size = expectedSize - 1
+        let underlyingBuffer = malloc(size)!
+        let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer.bindMemory(to: UInt8.self, capacity: size), count: size)
         
         // We should only copy in enough bytes that can fit in the buffer
         let copiedCount = data.copyBytes(to: buffer)
@@ -783,9 +784,10 @@ extension TestNSData {
         }
         let expectedSize = MemoryLayout<Int32>.stride * a.count
         XCTAssertEqual(expectedSize, data.count)
-        
-        let underlyingBuffer = unsafeBitCast(malloc(expectedSize + 1)!, to: UnsafeMutablePointer<UInt8>.self)
-        let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer, count: expectedSize + 1)
+
+        let size = expectedSize + 1
+        let underlyingBuffer = malloc(size)!
+        let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer.bindMemory(to: UInt8.self, capacity: size), count: size)
         
         let copiedCount = data.copyBytes(to: buffer)
         XCTAssertEqual(expectedSize, copiedCount)
@@ -801,9 +803,10 @@ extension TestNSData {
             var data = a.withUnsafeBufferPointer {
                 return Data(buffer: $0)
             }
-            
-            let underlyingBuffer = unsafeBitCast(malloc(data.count)!, to: UnsafeMutablePointer<UInt8>.self)
-            let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer, count: data.count)
+
+            let size = data.count
+            let underlyingBuffer = malloc(size)!
+            let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer.bindMemory(to: UInt8.self, capacity: size), count: size)
             
             var copiedCount : Int
             
@@ -830,10 +833,11 @@ extension TestNSData {
             let data = a.withUnsafeBufferPointer {
                 return Data(buffer: $0)
             }
-            
-            let underlyingBuffer = unsafeBitCast(malloc(10)!, to: UnsafeMutablePointer<UInt8>.self)
-            let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer, count: 10)
-            
+
+            let size = 10
+            let underlyingBuffer = malloc(size)!
+            let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer.bindMemory(to: UInt8.self, capacity: size), count: size)
+
             var copiedCount : Int
             
             copiedCount = data.copyBytes(to: buffer, from: 0..<3)
@@ -853,9 +857,10 @@ extension TestNSData {
             let data = a.withUnsafeBufferPointer {
                 return Data(buffer: $0)
             }
-            
-            let underlyingBuffer = unsafeBitCast(malloc(4)!, to: UnsafeMutablePointer<UInt8>.self)
-            let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer, count: 4)
+
+            let size = 4
+            let underlyingBuffer = malloc(size)!
+            let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer.bindMemory(to: UInt8.self, capacity: size), count: size)
             
             var copiedCount : Int
             
@@ -970,9 +975,9 @@ extension TestNSData {
         expectedSize += MemoryLayout<Bool>.stride * 2
         XCTAssertEqual(expectedSize, data.count)
         
-        let underlyingBuffer = unsafeBitCast(malloc(expectedSize)!, to: UnsafeMutablePointer<UInt8>.self)
-        
-        let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer, count: expectedSize)
+        let size = expectedSize
+        let underlyingBuffer = malloc(size)!
+        let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer.bindMemory(to: UInt8.self, capacity: size), count: size)
         let copiedCount = data.copyBytes(to: buffer)
         XCTAssertEqual(copiedCount, expectedSize)
         


### PR DESCRIPTION
Convert unsafeBitCast() to bindMemory()/withMemoryRebound()

Convert deprecated initialize(from:) to UnsafeMutableBufferPointer.initialize(from:)