### PR TITLE
Restore android workaround for CONST_STRING_DECL

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -334,6 +334,16 @@ CF_PRIVATE Boolean __CFProcessIsRestricted();
 #define STACK_BUFFER_DECL(T, N, C) T N[C]
 #endif
 
+#ifdef __ANDROID__
+// Avoids crashes on Android
+// https://bugs.swift.org/browse/SR-2587
+// https://bugs.swift.org/browse/SR-2588
+// Seemed to be a linker/relocation? problem.
+// CFStrings using CONST_STRING_DECL() were not working
+// Applies reference to _NSCFConstantString's isa here
+// rather than using a linker option to create an alias.
+#define __CFConstantStringClassReference _TMC10Foundation19_NSCFConstantString
+#endif
 
 CF_EXPORT void * __CFConstantStringClassReferencePtr;
 


### PR DESCRIPTION
Restore workaround for android initially introduced int https://github.com/apple/swift-corelibs-foundation/pull/622
https://github.com/SwiftJava/swift-corelibs-foundation/commit/6213cbabce1a4c3d9ac1573aef4aaaa8b102953b

Refix: https://bugs.swift.org/browse/SR-2587 https://bugs.swift.org/browse/SR-2588