### PR TITLE
Arithmetic methods for Swift 3 compatibility

### DIFF
--- a/Foundation/NSDecimal.swift
+++ b/Foundation/NSDecimal.swift
@@ -340,6 +340,32 @@ extension Decimal : SignedNumeric {
     }
 }
 
+extension Decimal {
+    @available(swift, obsoleted: 4, message: "Please use arithmetic operators instead")
+    @_transparent
+    public mutating func add(_ other: Decimal) {
+        self += other
+    }
+
+    @available(swift, obsoleted: 4, message: "Please use arithmetic operators instead")
+    @_transparent
+    public mutating func subtract(_ other: Decimal) {
+        self -= other
+    }
+
+    @available(swift, obsoleted: 4, message: "Please use arithmetic operators instead")
+    @_transparent
+    public mutating func multiply(by other: Decimal) {
+        self *= other
+    }
+
+    @available(swift, obsoleted: 4, message: "Please use arithmetic operators instead")
+    @_transparent
+    public mutating func divide(by other: Decimal) {
+        self /= other
+    }
+}
+
 extension Decimal : Strideable {
     public func distance(to other: Decimal) -> Decimal {
         return self - other


### PR DESCRIPTION
Since `Decimal` does not conform to `FloatingPoint` protocol, [this fix](https://github.com/apple/swift/pull/3796/commits/192c11217fe0c1a1821004b34434ffe523875707) does not apply.