### PR TITLE
Disable URLSession tests (SR-4655)

### DIFF
--- a/TestFoundation/TestNSURLSession.swift
+++ b/TestFoundation/TestNSURLSession.swift
@@ -28,10 +28,7 @@ class TestURLSession : XCTestCase {
             ("test_downloadTaskWithURL", test_downloadTaskWithURL),
             ("test_downloadTaskWithURLRequest", test_downloadTaskWithURLRequest),
             ("test_downloadTaskWithRequestAndHandler", test_downloadTaskWithRequestAndHandler),
-
-            // Disabled because of https://bugs.swift.org/browse/SR-4647
-            // ("test_downloadTaskWithURLAndHandler", test_downloadTaskWithURLAndHandler),
-
+            ("test_downloadTaskWithURLAndHandler", test_downloadTaskWithURLAndHandler),
             ("test_finishTaskAndInvalidate", test_finishTasksAndInvalidate),
             ("test_taskError", test_taskError),
             ("test_taskCopy", test_taskCopy),

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -78,7 +78,8 @@ XCTMain([
     testCase(TestURLRequest.allTests),
     testCase(TestNSURLResponse.allTests),
     testCase(TestNSHTTPURLResponse.allTests),
-    testCase(TestURLSession.allTests),
+//Disabling because of https://bugs.swift.org/browse/SR-4655 and https://bugs.swift.org/browse/SR-4647
+//    testCase(TestURLSession.allTests),
     testCase(TestNSNull.allTests),
     testCase(TestNSUUID.allTests),
     testCase(TestNSValue.allTests),


### PR DESCRIPTION
@parkera @phausler 

URLSession tests seem to be breaking the CI frequently - [SR-4647](https://bugs.swift.org/browse/SR-4647) and [SR-4655](https://bugs.swift.org/browse/SR-4655)

While working on [SR-4647](https://bugs.swift.org/browse/SR-4647), I've seen some very intermittent failures (reproducing almost 1/100 runs). Initial investigation did not lead me to suspect any of the recent fixes - #949, #927 or #916 - so, I can't be sure we are seeing a regression.

Would it be acceptable to disable URLSession tests while we investigate  [SR-4647](https://bugs.swift.org/browse/SR-4647) and [SR-4655](https://bugs.swift.org/browse/SR-4655) ?