### PR TITLE
Add NSISO8601DateFormatter stub

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -308,6 +308,8 @@
 		61E0117F1C1B5990000037DD /* CFRunLoop.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B5D88D81BBC9AD800234F36 /* CFRunLoop.c */; };
 		61E011811C1B5998000037DD /* CFMessagePort.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B5D88DC1BBC9AEC00234F36 /* CFMessagePort.c */; };
 		61E011821C1B599A000037DD /* CFMachPort.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B5D88D01BBC9AAC00234F36 /* CFMachPort.c */; };
+		63DCE9D21EAA430100E9CB02 /* NSISO8601DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DCE9D11EAA430100E9CB02 /* NSISO8601DateFormatter.swift */; };
+		63DCE9D41EAA432400E9CB02 /* TestNSISO8601DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DCE9D31EAA432400E9CB02 /* TestNSISO8601DateFormatter.swift */; };
 		6EB768281D18C12C00D4B719 /* UUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB768271D18C12C00D4B719 /* UUID.swift */; };
 		7900433B1CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790043391CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift */; };
 		7900433C1CACD33E00ECCBF1 /* TestNSPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900433A1CACD33E00ECCBF1 /* TestNSPredicate.swift */; };
@@ -746,6 +748,8 @@
 		61D6C9EE1C1DFE9500DEF583 /* TestNSTimer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSTimer.swift; sourceTree = "<group>"; };
 		61E0117B1C1B554D000037DD /* TestNSRunLoop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSRunLoop.swift; sourceTree = "<group>"; };
 		61F8AE7C1C180FC600FB62F0 /* TestNSNotificationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSNotificationCenter.swift; sourceTree = "<group>"; };
+		63DCE9D11EAA430100E9CB02 /* NSISO8601DateFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSISO8601DateFormatter.swift; sourceTree = "<group>"; };
+		63DCE9D31EAA432400E9CB02 /* TestNSISO8601DateFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSISO8601DateFormatter.swift; sourceTree = "<group>"; };
 		6E203B8C1C1303BB003B2576 /* TestNSBundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSBundle.swift; sourceTree = "<group>"; };
 		6EB768271D18C12C00D4B719 /* UUID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UUID.swift; sourceTree = "<group>"; };
 		790043391CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSCompoundPredicate.swift; sourceTree = "<group>"; };
@@ -1406,6 +1410,7 @@
 				BDFDF0A61DFF5B3E00C04CC5 /* TestNSPersonNameComponents.swift */,
 				CD1C7F7C1E303B47008E331C /* TestNSError.swift */,
 				90E645DE1E4C89A400D0D47C /* TestNSCache.swift */,
+				63DCE9D31EAA432400E9CB02 /* TestNSISO8601DateFormatter.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -1501,6 +1506,7 @@
 				5BDC3F351BCC5DCB00ED97BB /* NSDateFormatter.swift */,
 				5BDC3F391BCC5DCB00ED97BB /* NSFormatter.swift */,
 				5B628EDE1D1C995C00CA9570 /* NSMeasurementFormatter.swift */,
+				63DCE9D11EAA430100E9CB02 /* NSISO8601DateFormatter.swift */,
 			);
 			name = Formatters;
 			sourceTree = "<group>";
@@ -1994,6 +2000,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				63DCE9D21EAA430100E9CB02 /* NSISO8601DateFormatter.swift in Sources */,
 				5BF7AE831BCD50CD008F214A /* NSArray.swift in Sources */,
 				EADE0B991BD15DFF00C49C64 /* NSEnergyFormatter.swift in Sources */,
 				EADE0BBF1BD15E0000C49C64 /* NSURLError.swift in Sources */,
@@ -2251,6 +2258,7 @@
 				5B13B3281C582D4C00651CE2 /* TestNSBundle.swift in Sources */,
 				5B13B32A1C582D4C00651CE2 /* TestNSCharacterSet.swift in Sources */,
 				BF8E65311DC3B3CB005AB5C3 /* TestNotification.swift in Sources */,
+				63DCE9D41EAA432400E9CB02 /* TestNSISO8601DateFormatter.swift in Sources */,
 				EA01AAEC1DA839C4008F4E07 /* TestProgress.swift in Sources */,
 				5B13B3411C582D4C00651CE2 /* TestNSRegularExpression.swift in Sources */,
 				5B13B3491C582D4C00651CE2 /* TestNSTimeZone.swift in Sources */,

--- a/Foundation/NSISO8601DateFormatter.swift
+++ b/Foundation/NSISO8601DateFormatter.swift
@@ -1,0 +1,79 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+import CoreFoundation
+
+extension ISO8601DateFormatter {
+    
+    
+    public struct Options : OptionSet {
+        public private(set) var rawValue: UInt
+        public init(rawValue: UInt) { self.rawValue = rawValue }
+        
+        public static var withYear = ISO8601DateFormatter.Options(rawValue: 1 << 0)
+        
+        public static var withMonth = ISO8601DateFormatter.Options(rawValue: 1 << 1)
+        
+        public static var withWeekOfYear = ISO8601DateFormatter.Options(rawValue: 1 << 2)
+        
+        public static var withDay = ISO8601DateFormatter.Options(rawValue: 1 << 3)
+        
+        public static var withTime = ISO8601DateFormatter.Options(rawValue: 1 << 4)
+        
+        public static var withTimeZone = ISO8601DateFormatter.Options(rawValue: 1 << 5)
+        
+        public static var withSpaceBetweenDateAndTime = ISO8601DateFormatter.Options(rawValue: 1 << 6)
+        
+        public static var withDashSeparatorInDate = ISO8601DateFormatter.Options(rawValue: 1 << 7)
+        
+        public static var withColonSeparatorInTime = ISO8601DateFormatter.Options(rawValue: 1 << 8)
+        
+        public static var withColonSeparatorInTimeZone = ISO8601DateFormatter.Options(rawValue: 1 << 9)
+        
+        public static var withFullDate = ISO8601DateFormatter.Options(rawValue: 1 << 10)
+        
+        public static var withFullTime = ISO8601DateFormatter.Options(rawValue: 1 << 11)
+        
+        public static var withInternetDateTime = ISO8601DateFormatter.Options(rawValue: 1 << 12)
+    }
+}
+
+open class ISO8601DateFormatter : Formatter, NSSecureCoding {
+    
+    
+    /* Please note that there can be a significant performance cost when resetting these properties. Resetting each property can result in regenerating the entire CFDateFormatterRef, which can be very expensive. */
+    open var timeZone: TimeZone! // The default time zone is GMT.
+    
+    
+    open var formatOptions: ISO8601DateFormatter.Options
+    
+    
+    /* This init method creates a formatter object set to the GMT time zone and preconfigured with the RFC 3339 standard format ("yyyy-MM-dd'T'HH:mm:ssXXXXX") using the following options:
+     NSISO8601DateFormatWithInternetDateTime | NSISO8601DateFormatWithDashSeparatorInDate | NSISO8601DateFormatWithColonSeparatorInTime | NSISO8601DateFormatWithColonSeparatorInTimeZone
+     */
+    public override init() { NSUnimplemented() }
+    
+    public required init?(coder aDecoder: NSCoder) { NSUnimplemented() }
+    open override func encode(with aCoder: NSCoder) { NSUnimplemented() }
+    public static var supportsSecureCoding: Bool { return true }
+    
+    
+    open func string(from date: Date) -> String {
+        NSUnimplemented()
+    }
+    
+    open func date(from string: String) -> Date? {
+        NSUnimplemented()
+    }
+    
+    
+    open class func string(from date: Date, timeZone: TimeZone, formatOptions: ISO8601DateFormatter.Options = []) -> String {
+        NSUnimplemented()
+    }
+}

--- a/TestFoundation/TestNSISO8601DateFormatter.swift
+++ b/TestFoundation/TestNSISO8601DateFormatter.swift
@@ -1,0 +1,28 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
+    import Foundation
+    import XCTest
+#else
+    import SwiftFoundation
+    import SwiftXCTest
+#endif
+
+class TestNSISO8601DateFormatter: XCTestCase {
+    
+    let DEFAULT_LOCALE = "en_US"
+    let DEFAULT_TIMEZONE = "GMT"
+    
+    static var allTests : [(String, (TestNSISO8601DateFormatter) -> () throws -> Void)] {
+        return [
+
+        ]
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -93,4 +93,5 @@ XCTMain([
     testCase(TestProgress.allTests),
     testCase(TestObjCRuntime.allTests),
     testCase(TestNotification.allTests),
+    testCase(TestNSISO8601DateFormatter.allTests),
 ])


### PR DESCRIPTION
This is a class that was recently added to Darwin and would be great if it was added into swift-corelibs-foundation as well to keep Darwin and Linux more in sync. 