### PR TITLE
[3.1] [Process] Implement `terminationReason`

### DIFF
--- a/Docs/Status.md
+++ b/Docs/Status.md
@@ -271,10 +271,10 @@ There is no _Complete_ status for test coverage because there are always additio
 
     | Entity Name      | Status          | Test Coverage | Notes                                                                                                                     |
     |------------------|-----------------|---------------|---------------------------------------------------------------------------------------------------------------------------|
-    | `FileHandle`     | Mostly Complete | Incomplete    | `NSCoding`, `nullDevice`, and background operations remain unimplemented                                                  |
+    | `FileHandle`     | Mostly Complete | Incomplete    | `NSCoding`, and background operations remain unimplemented                                                                |
     | `Pipe`           | Complete        | Incomplete    |                                                                                                                           |
     | `FileManager`    | Incomplete      | Incomplete    | URL searches, relationship lookups, item copying, cross-device moving, recursive linking, and others remain unimplemented |
-    | `Task`           | Mostly Complete | Substantial   | `interrupt()`, `terminate()`, `suspend()`, `resume()`, and `terminationReason` remain unimplemented                       |
+    | `Process`        | Mostly Complete | Substantial   | `interrupt()`, `terminate()`, `suspend()`, and `resume()` remain unimplemented                                            |
     | `Bundle`         | Mostly Complete | Incomplete    | `allBundles`, `init(for:)`, `unload()`, `classNamed()`, and `principalClass` remain unimplemented                         |
     | `ProcessInfo`    | Complete        | Substantial   |                                                                                                                           |
     | `Thread`         | Incomplete      | Incomplete    | `isMainThread`, `mainThread`, `name`, `callStackReturnAddresses`, and `callStackSymbols` remain unimplemented             |

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -24,6 +24,7 @@ class TestProcess : XCTestCase {
                    ("test_exit100" , test_exit100),
                    ("test_sleep2", test_sleep2),
                    ("test_sleep2_exit1", test_sleep2_exit1),
+                   ("test_terminationReason_uncaughtSignal", test_terminationReason_uncaughtSignal),
                    ("test_pipe_stdin", test_pipe_stdin),
                    ("test_pipe_stdout", test_pipe_stdout),
                    ("test_pipe_stderr", test_pipe_stderr),
@@ -47,6 +48,7 @@ class TestProcess : XCTestCase {
         process.launch()
         process.waitUntilExit()
         XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertEqual(process.terminationReason, .exit)
     }
     
     func test_exit1() {
@@ -59,6 +61,7 @@ class TestProcess : XCTestCase {
         process.launch()
         process.waitUntilExit()
         XCTAssertEqual(process.terminationStatus, 1)
+        XCTAssertEqual(process.terminationReason, .exit)
     }
     
     func test_exit100() {
@@ -71,6 +74,7 @@ class TestProcess : XCTestCase {
         process.launch()
         process.waitUntilExit()
         XCTAssertEqual(process.terminationStatus, 100)
+        XCTAssertEqual(process.terminationReason, .exit)
     }
     
     func test_sleep2() {
@@ -83,6 +87,7 @@ class TestProcess : XCTestCase {
         process.launch()
         process.waitUntilExit()
         XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertEqual(process.terminationReason, .exit)
     }
     
     func test_sleep2_exit1() {
@@ -95,8 +100,20 @@ class TestProcess : XCTestCase {
         process.launch()
         process.waitUntilExit()
         XCTAssertEqual(process.terminationStatus, 1)
+        XCTAssertEqual(process.terminationReason, .exit)
     }
 
+    func test_terminationReason_uncaughtSignal() {
+        let process = Process()
+
+        process.launchPath = "/bin/bash"
+        process.arguments = ["-c", "kill -TERM $$"]
+
+        process.launch()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 15)
+        XCTAssertEqual(process.terminationReason, .uncaughtSignal)
+    }
 
     func test_pipe_stdin() {
         let process = Process()


### PR DESCRIPTION
This is needed before #963 can be backported to the 3.1 branch. It is a cherry-pick of #844.