### PR TITLE
Cherry-picking some URLSession fixes on to 3.1

### DIFF
--- a/Foundation/NSURLSession/MultiHandle.swift
+++ b/Foundation/NSURLSession/MultiHandle.swift
@@ -302,11 +302,15 @@ fileprivate extension URLSession._MultiHandle._SocketRegisterAction {
 
 /// A helper class that wraps a libdispatch timer.
 ///
-/// Used to implement the timeout of `URLSession.MultiHandle`.
-fileprivate class _TimeoutSource {
+/// Used to implement the timeout of `URLSession.MultiHandle` and `URLSession.EasyHandle`
+class _TimeoutSource {
     let rawSource: DispatchSource 
     let milliseconds: Int
+    let queue: DispatchQueue        //needed to restart the timer for EasyHandles
+    let handler: DispatchWorkItem   //needed to restart the timer for EasyHandles
     init(queue: DispatchQueue, milliseconds: Int, handler: DispatchWorkItem) {
+        self.queue = queue
+        self.handler = handler
         self.milliseconds = milliseconds
         self.rawSource = DispatchSource.makeTimerSource(queue: queue) as! DispatchSource
         

--- a/Foundation/NSURLSession/NSURLSessionTask.swift
+++ b/Foundation/NSURLSession/NSURLSessionTask.swift
@@ -548,7 +548,16 @@ fileprivate extension URLSessionTask {
         
         // HTTP Options:
         easyHandle.set(followLocation: false)
-        easyHandle.set(customHeaders: curlHeaders(for: request))
+
+        let customHeaders: [String]
+        let headersForRequest = curlHeaders(for: request)
+        if ((request.httpMethod == "POST") && (request.value(forHTTPHeaderField: "Content-Type") == nil)) {
+            customHeaders = headersForRequest + ["Content-Type:application/x-www-form-urlencoded"]
+        } else {
+            customHeaders = headersForRequest
+        }
+
+        easyHandle.set(customHeaders: customHeaders)
 
         //Options unavailable on Ubuntu 14.04 (libcurl 7.36)
         //TODO: Introduce something like an #if
@@ -571,8 +580,6 @@ fileprivate extension URLSessionTask {
         easyHandle.set(requestMethod: request.httpMethod ?? "GET")
         if request.httpMethod == "HEAD" {
             easyHandle.set(noBody: true)
-        } else if ((request.httpMethod == "POST") && (request.value(forHTTPHeaderField: "Content-Type") == nil)) {
-            easyHandle.set(customHeaders: ["Content-Type:application/x-www-form-urlencoded"])
         }
     }
 }

--- a/Foundation/NSURLSession/NSURLSessionTask.swift
+++ b/Foundation/NSURLSession/NSURLSessionTask.swift
@@ -558,7 +558,14 @@ fileprivate extension URLSessionTask {
         //set the request timeout
         //TODO: the timeout value needs to be reset on every data transfer
         let s = session as! URLSession
-        easyHandle.set(timeout: Int(s.configuration.timeoutIntervalForRequest))
+        let timeoutInterval = Int(s.configuration.timeoutIntervalForRequest) * 1000
+        let timeoutHandler = DispatchWorkItem { [weak self] in
+            guard let currentTask = self else { fatalError("Timeout on a task that doesn't exist") } //this guard must always pass
+            currentTask.internalState = .transferFailed
+            let urlError = URLError(_nsError: NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil))
+            currentTask.completeTask(withError: urlError)
+        }
+        easyHandle.timeoutTimer = _TimeoutSource(queue: workQueue, milliseconds: timeoutInterval, handler: timeoutHandler)
 
         easyHandle.set(automaticBodyDecompression: true)
         easyHandle.set(requestMethod: request.httpMethod ?? "GET")
@@ -819,6 +826,9 @@ extension URLSessionTask {
         }
         self.response = response
 
+        //We don't want a timeout to be triggered after this. The timeout timer needs to be cancelled.
+        easyHandle.timeoutTimer = nil
+
         //because we deregister the task with the session on internalState being set to taskCompleted
         //we need to do the latter after the delegate/handler was notified/invoked
         switch session.behaviour(for: self) {
@@ -870,6 +880,10 @@ extension URLSessionTask {
         guard case .transferFailed = internalState else {
             fatalError("Trying to complete the task, but its transfer isn't complete / failed.")
         }
+
+        //We don't want a timeout to be triggered after this. The timeout timer needs to be cancelled.
+        easyHandle.timeoutTimer = nil
+
         switch session.behaviour(for: self) {
         case .taskDelegate(let delegate):
             guard let s = session as? URLSession else { fatalError() }

--- a/TestFoundation/HTTPServer.swift
+++ b/TestFoundation/HTTPServer.swift
@@ -191,6 +191,14 @@ struct _HTTPRequest {
         body = lines.last!
     }
 
+    public func getCommaSeparatedHeaders() -> String {
+        var allHeaders = ""
+        for header in headers {
+            allHeaders += header + ","
+        }
+        return allHeaders
+    }
+
 }
 
 struct _HTTPResponse {
@@ -240,16 +248,22 @@ public class TestURLSessionServer {
     }
 
     func process(request: _HTTPRequest) -> _HTTPResponse {
-        if request.method == .GET {
-            return getResponse(uri: request.uri)
+        if request.method == .GET || request.method == .POST {
+            return getResponse(request: request)
         } else {
             fatalError("Unsupported method!")
         }
     }
 
-    func getResponse(uri: String) -> _HTTPResponse {
+    func getResponse(request: _HTTPRequest) -> _HTTPResponse {
+        let uri = request.uri
         if uri == "/country.txt" {
             let text = capitals[String(uri.characters.dropFirst())]!
+            return _HTTPResponse(response: .OK, headers: "Content-Length: \(text.characters.count)", body: text)
+        }
+
+        if uri == "/requestHeaders" {
+            let text = request.getCommaSeparatedHeaders()
             return _HTTPResponse(response: .OK, headers: "Content-Length: \(text.characters.count)", body: text)
         }
         return _HTTPResponse(response: .OK, body: capitals[String(uri.characters.dropFirst())]!) 

--- a/TestFoundation/HTTPServer.swift
+++ b/TestFoundation/HTTPServer.swift
@@ -92,10 +92,33 @@ class _TCPSocket {
         _ = try attempt("read", valid: isNotNegative, CInt(read(connectionSocket, &buffer, 4096)))
         return String(cString: &buffer)
     }
+    
+    func split(_ str: String, _ count: Int) -> [String] {
+        return stride(from: 0, to: str.characters.count, by: count).map { i -> String in
+            let startIndex = str.index(str.startIndex, offsetBy: i)
+            let endIndex   = str.index(startIndex, offsetBy: count, limitedBy: str.endIndex) ?? str.endIndex
+            return str[startIndex..<endIndex]
+        }
+    }
    
-    func writeData(data: String) throws {
-        var bytes = Array(data.utf8)
-        _  = try attempt("write", valid: isNotNegative, CInt(write(connectionSocket, &bytes, data.utf8.count))) 
+    func writeData(header: String, body: String, sendDelay: TimeInterval? = nil, bodyChunks: Int? = nil) throws {
+        var header = Array(header.utf8)
+        _  = try attempt("write", valid: isNotNegative, CInt(write(connectionSocket, &header, header.count)))
+        
+        if let sendDelay = sendDelay, let bodyChunks = bodyChunks {
+            let count = max(1, Int(Double(body.utf8.count) / Double(bodyChunks)))
+            let texts = split(body, count)
+            
+            for item in texts {
+                sleep(UInt32(sendDelay))
+                var bytes = Array(item.utf8)
+                print(item)
+                _  = try attempt("write", valid: isNotNegative, CInt(write(connectionSocket, &bytes, bytes.count)))
+            }
+        } else {
+            var bytes = Array(body.utf8)
+            _  = try attempt("write", valid: isNotNegative, CInt(write(connectionSocket, &bytes, bytes.count)))
+        }
     }
 
     func shutdown() {
@@ -128,8 +151,24 @@ class _HTTPServer {
        return _HTTPRequest(request: try socket.readData()) 
     }
 
-    public func respond(with response: _HTTPResponse) throws {
-        try socket.writeData(data: response.description)
+    public func respond(with response: _HTTPResponse, startDelay: TimeInterval? = nil, sendDelay: TimeInterval? = nil, bodyChunks: Int? = nil) throws {
+        let semaphore = DispatchSemaphore(value: 0)
+        let deadlineTime: DispatchTime
+            
+        if let startDelay = startDelay {
+           deadlineTime = .now() + .seconds(Int(startDelay))
+        } else {
+            deadlineTime = .now()
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: deadlineTime) {
+            do {
+                try self.socket.writeData(header: response.header, body: response.body, sendDelay: sendDelay, bodyChunks: bodyChunks)
+                semaphore.signal()
+            } catch { }
+        }
+        semaphore.wait()
+        
     } 
 }
 
@@ -160,7 +199,7 @@ struct _HTTPResponse {
     }
     private let responseCode: Response
     private let headers: String
-    private let body: String
+    public let body: String
 
     public init(response: Response, headers: String = _HTTPUtils.EMPTY, body: String) {
         self.responseCode = response
@@ -168,9 +207,9 @@ struct _HTTPResponse {
         self.body = body
     }
    
-    public var description: String {
+    public var header: String {
         let statusLine = _HTTPUtils.VERSION + _HTTPUtils.SPACE + "\(responseCode.rawValue)" + _HTTPUtils.SPACE + "\(responseCode)"
-        return statusLine + (headers != _HTTPUtils.EMPTY ? _HTTPUtils.CRLF + headers : _HTTPUtils.EMPTY) + _HTTPUtils.CRLF2 + body
+        return statusLine + (headers != _HTTPUtils.EMPTY ? _HTTPUtils.CRLF + headers : _HTTPUtils.EMPTY) + _HTTPUtils.CRLF2
     }
 }
 
@@ -181,9 +220,15 @@ public class TestURLSessionServer {
                                      "USA":"Washington, D.C.",
                                      "country.txt": "A country is a region that is identified as a distinct national entity in political geography"]
     let httpServer: _HTTPServer
+    let startDelay: TimeInterval?
+    let sendDelay: TimeInterval?
+    let bodyChunks: Int?
     
-    public init (port: UInt16) throws {
+    public init (port: UInt16, startDelay: TimeInterval? = nil, sendDelay: TimeInterval? = nil, bodyChunks: Int? = nil) throws {
         httpServer = try _HTTPServer.create(port: port)
+        self.startDelay = startDelay
+        self.sendDelay = sendDelay
+        self.bodyChunks = bodyChunks
     }
     public func start(started: ServerSemaphore) throws {
         started.signal()
@@ -191,8 +236,8 @@ public class TestURLSessionServer {
     }
    
     public func readAndRespond() throws {
-        try httpServer.respond(with: process(request: httpServer.request()))
-    } 
+        try httpServer.respond(with: process(request: httpServer.request()), startDelay: self.startDelay, sendDelay: self.sendDelay, bodyChunks: self.bodyChunks)
+    }
 
     func process(request: _HTTPRequest) -> _HTTPResponse {
         if request.method == .GET {

--- a/TestFoundation/HTTPServer.swift
+++ b/TestFoundation/HTTPServer.swift
@@ -77,6 +77,7 @@ class _TCPSocket {
             return sockaddr_in(sin_len: 0, sin_family: sa_family_t(AF_INET), sin_port: CFSwapInt16HostToBig(port), sin_addr: in_addr(s_addr: INADDR_ANY), sin_zero: (0,0,0,0,0,0,0,0) )
         #endif
     }
+
     func acceptConnection(notify: ServerSemaphore) throws {
         _ = try attempt("listen", valid: isZero, listen(listenSocket, SOMAXCONN))
         try socketAddress.withMemoryRebound(to: sockaddr.self, capacity: MemoryLayout<sockaddr>.size, {
@@ -112,7 +113,6 @@ class _TCPSocket {
             for item in texts {
                 sleep(UInt32(sendDelay))
                 var bytes = Array(item.utf8)
-                print(item)
                 _  = try attempt("write", valid: isNotNegative, CInt(write(connectionSocket, &bytes, bytes.count)))
             }
         } else {
@@ -160,7 +160,7 @@ class _HTTPServer {
         } else {
             deadlineTime = .now()
         }
-        
+
         DispatchQueue.main.asyncAfter(deadline: deadlineTime) {
             do {
                 try self.socket.writeData(header: response.header, body: response.body, sendDelay: sendDelay, bodyChunks: bodyChunks)

--- a/TestFoundation/TestNSURLSession.swift
+++ b/TestFoundation/TestNSURLSession.swift
@@ -34,6 +34,7 @@ class TestURLSession : XCTestCase {
             ("test_taskCopy", test_taskCopy),
             ("test_taskTimeout", test_taskTimeout),
             ("test_verifyRequestHeaders", test_verifyRequestHeaders),
+            ("test_verifyHttpAdditionalHeaders", test_verifyHttpAdditionalHeaders),
         ]
     }
 
@@ -326,6 +327,41 @@ class TestURLSession : XCTestCase {
         }
         task.resume()
 
+        waitForExpectations(timeout: 30)
+    }
+
+    // Verify httpAdditionalHeaders from session configuration are added to the request
+    // and whether it is overriden by Request.allHTTPHeaderFields.
+    
+    func test_verifyHttpAdditionalHeaders() {
+        let serverReady = ServerSemaphore()
+        globalDispatchQueue.async {
+            do {
+                try self.runServer(with: serverReady)
+            } catch {
+                XCTAssertTrue(true)
+                return
+            }
+        }
+        serverReady.wait()
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 5
+        config.httpAdditionalHeaders = ["header2": "svalue2", "header3": "svalue3"]
+        let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
+        var expect = expectation(description: "download task with handler")
+        var req = URLRequest(url: URL(string: "http://127.0.0.1:\(serverPort)/requestHeaders")!)
+        let headers = ["header1": "rvalue1", "header2": "rvalue2"]
+        req.httpMethod = "POST"
+        req.allHTTPHeaderFields = headers
+        var task = session.dataTask(with: req) { (data, _, error) -> Void in
+            defer { expect.fulfill() }
+            let headers = String(data: data!, encoding: String.Encoding.utf8)!
+            XCTAssertNotNil(headers.range(of: "header1: rvalue1"))
+            XCTAssertNotNil(headers.range(of: "header2: rvalue2"))
+            XCTAssertNotNil(headers.range(of: "header3: svalue3"))
+        }
+        task.resume()
+        
         waitForExpectations(timeout: 30)
     }
 

--- a/TestFoundation/TestNSURLSession.swift
+++ b/TestFoundation/TestNSURLSession.swift
@@ -33,6 +33,7 @@ class TestURLSession : XCTestCase {
             ("test_taskError", test_taskError),
             ("test_taskCopy", test_taskCopy),
             ("test_taskTimeout", test_taskTimeout),
+            ("test_verifyRequestHeaders", test_verifyRequestHeaders),
         ]
     }
 
@@ -65,14 +66,14 @@ class TestURLSession : XCTestCase {
         serverReady.wait()
         let urlString = "http://127.0.0.1:\(serverPort)/Nepal"
         let url = URL(string: urlString)!
-        let d = DataTask(with: expectation(description: "data task"))                         
+        let d = DataTask(with: expectation(description: "data task"))
         d.run(with: url)
         waitForExpectations(timeout: 12)
         if !d.error {
             XCTAssertEqual(d.capital, "Kathmandu", "test_dataTaskWithURLRequest returned an unexpected result")
         }
     }
-    
+
     func test_dataTaskWithURLCompletionHandler() {
         let serverReady = ServerSemaphore()
         globalDispatchQueue.async {
@@ -80,7 +81,7 @@ class TestURLSession : XCTestCase {
                 try self.runServer(with: serverReady)
             } catch {
                 XCTAssertTrue(true)
-                return 
+                return
             }
         }
         serverReady.wait()
@@ -99,7 +100,7 @@ class TestURLSession : XCTestCase {
             }
 
             let httpResponse = response as! HTTPURLResponse?
-            XCTAssertEqual(200, httpResponse!.statusCode, "HTTP response code is not 200") 
+            XCTAssertEqual(200, httpResponse!.statusCode, "HTTP response code is not 200")
             expectedResult = String(data: data!, encoding: String.Encoding.utf8)!
             XCTAssertEqual("Washington, D.C.", expectedResult, "Did not receive expected value")
             expect.fulfill()
@@ -121,7 +122,7 @@ class TestURLSession : XCTestCase {
         serverReady.wait()
         let urlString = "http://127.0.0.1:\(serverPort)/Peru"
         let urlRequest = URLRequest(url: URL(string: urlString)!)
-        let d = DataTask(with: expectation(description: "data task"))     
+        let d = DataTask(with: expectation(description: "data task"))
         d.run(with: urlRequest)
         waitForExpectations(timeout: 12)
         if !d.error {
@@ -175,7 +176,7 @@ class TestURLSession : XCTestCase {
         }
         serverReady.wait()
         let urlString = "http://127.0.0.1:\(serverPort)/country.txt"
-        let url = URL(string: urlString)!   
+        let url = URL(string: urlString)!
         let d = DownloadTask(with: expectation(description: "download task with delegate"))
         d.run(with: url)
         waitForExpectations(timeout: 12)
@@ -250,7 +251,7 @@ class TestURLSession : XCTestCase {
         task.resume()
         waitForExpectations(timeout: 12)
     }
-    
+
     func test_finishTasksAndInvalidate() {
         let invalidateExpectation = expectation(description: "URLSession wasn't invalidated")
         let delegate = SessionDelegate(invalidateExpectation: invalidateExpectation)
@@ -265,7 +266,7 @@ class TestURLSession : XCTestCase {
         session.finishTasksAndInvalidate()
         waitForExpectations(timeout: 12)
     }
-    
+
     func test_taskError() {
         let url = URL(string: "http://127.0.0.1:\(serverPort)/Nepal")!
         let session = URLSession(configuration: URLSessionConfiguration.default,
@@ -280,23 +281,52 @@ class TestURLSession : XCTestCase {
         }
         //should result in Bad URL error
         task.resume()
-        
+
         waitForExpectations(timeout: 5) { error in
             XCTAssertNil(error)
-            
+
             XCTAssertNotNil(task.error)
             XCTAssertEqual((task.error as? URLError)?.code, .badURL)
         }
     }
-    
+
     func test_taskCopy() {
         let url = URL(string: "http://127.0.0.1:\(serverPort)/Nepal")!
         let session = URLSession(configuration: URLSessionConfiguration.default,
                                  delegate: nil,
                                  delegateQueue: nil)
         let task = session.dataTask(with: url)
-        
+
         XCTAssert(task.isEqual(task.copy()))
+    }
+
+    func test_verifyRequestHeaders() {
+        let serverReady = ServerSemaphore()
+        globalDispatchQueue.async {
+            do {
+                try self.runServer(with: serverReady)
+            } catch {
+                XCTAssertTrue(true)
+                return
+            }
+        }
+        serverReady.wait()
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 5
+        let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
+        var expect = expectation(description: "download task with handler")
+        var req = URLRequest(url: URL(string: "http://127.0.0.1:\(serverPort)/requestHeaders")!)
+        let headers = ["header1": "value1"]
+        req.httpMethod = "POST"
+        req.allHTTPHeaderFields = headers
+        var task = session.dataTask(with: req) { (data, _, error) -> Void in
+            defer { expect.fulfill() }
+            let headers = String(data: data!, encoding: String.Encoding.utf8)!
+            XCTAssertNotNil(headers.range(of: "header1: value1"))
+        }
+        task.resume()
+
+        waitForExpectations(timeout: 30)
     }
 
     func test_taskTimeout() {
@@ -320,7 +350,7 @@ class TestURLSession : XCTestCase {
             XCTAssertNil(error)
         }
         task.resume()
-        
+
         waitForExpectations(timeout: 30)
     }
 }
@@ -343,7 +373,7 @@ class DataTask : NSObject {
     public var error = false
 
     init(with expectation: XCTestExpectation) {
-       dataTaskExpectation = expectation 
+       dataTaskExpectation = expectation
     }
 
     func run(with request: URLRequest) {
@@ -353,7 +383,7 @@ class DataTask : NSObject {
         task = session.dataTask(with: request)
         task.resume()
     }
-    
+
     func run(with url: URL) {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 8
@@ -377,7 +407,7 @@ extension DataTask : URLSessionTaskDelegate {
          dataTaskExpectation.fulfill()
          self.error = true
      }
-} 
+}
 
 class DownloadTask : NSObject {
     var totalBytesWritten: Int64 = 0
@@ -407,12 +437,12 @@ class DownloadTask : NSObject {
 }
 
 extension DownloadTask : URLSessionDownloadDelegate {
-    
+
     public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64,
                            totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) -> Void {
         self.totalBytesWritten = totalBytesWritten
     }
-    
+
     public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         do {
             let attr = try FileManager.default.attributesOfItem(atPath: location.path)

--- a/TestFoundation/TestNSURLSession.swift
+++ b/TestFoundation/TestNSURLSession.swift
@@ -32,7 +32,7 @@ class TestURLSession : XCTestCase {
             ("test_finishTaskAndInvalidate", test_finishTasksAndInvalidate),
             ("test_taskError", test_taskError),
             ("test_taskCopy", test_taskCopy),
-//            ("test_taskTimeout", test_taskTimeout),
+            ("test_taskTimeout", test_taskTimeout),
         ]
     }
 
@@ -46,7 +46,7 @@ class TestURLSession : XCTestCase {
                 try test.readAndRespond()
                 test.stop()
             } catch let e as ServerError {
-                if e.operation != "bind" { continue }
+                if e.operation == "bind" { continue }
                 throw e
             }
         }


### PR DESCRIPTION
Please don't merge for now. URLSession tests are disabled. We'll first have to get them enabled.

Cherry-picking led to some conflicts which have been manually fixed. 