### PR TITLE
Force tests to build as Swift 3.

### DIFF
--- a/lib/phases.py
+++ b/lib/phases.py
@@ -431,10 +431,10 @@ class SwiftExecutable(BuildPhase):
             if resource is None:
                 continue
             swiftSources += " " + resource.relative()
-
+        # Note: Fix -swift-version 3 for now.
         return """
 build """ + appName + """: SwiftExecutable """ + swiftSources + self.generate_dependencies(libDependencyName) + """
-    flags = -I""" + Configuration.current.build_directory.path_by_appending(self.product.name).relative() + self.product.ROOT_HEADERS_FOLDER_PATH + " -I" + Configuration.current.build_directory.path_by_appending(self.product.name).relative() + " -L" + Configuration.current.build_directory.path_by_appending(self.product.name).relative() + " " + TargetConditional.value(self.product.SWIFTCFLAGS) + """
+    flags = -swift-version 3 -I""" + Configuration.current.build_directory.path_by_appending(self.product.name).relative() + self.product.ROOT_HEADERS_FOLDER_PATH + " -I" + Configuration.current.build_directory.path_by_appending(self.product.name).relative() + " -L" + Configuration.current.build_directory.path_by_appending(self.product.name).relative() + " " + TargetConditional.value(self.product.SWIFTCFLAGS) + """
 build """ + self.executableName + """: phony | """ + appName + """
 """
 


### PR DESCRIPTION
This technically changes anything that uses the SwiftExecutable to build
as Swift 3 as well.