### PR TITLE
Revert "Update for AnyObject nukage"

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1008,9 +1008,9 @@ void __CFInitialize(void) {
         
 #ifndef __CFSwiftGetBaseClass
 #if TARGET_OS_LINUX
-#define __CFSwiftGetBaseClass _T010Foundation21__CFSwiftGetBaseClassyXlXpyF
+#define __CFSwiftGetBaseClass _T010Foundation21__CFSwiftGetBaseClasss9AnyObject_pXpyF
 #elif TARGET_OS_MAC
-#define __CFSwiftGetBaseClass _T015SwiftFoundation21__CFSwiftGetBaseClassyXlXpyF
+#define __CFSwiftGetBaseClass _T015SwiftFoundation21__CFSwiftGetBaseClasss9AnyObject_pXpyF
 #endif
 #endif
         extern uintptr_t __CFSwiftGetBaseClass();


### PR DESCRIPTION
This reverts commit 57331473713ca5f6196519bc91e38041379a31ea.

Swift changed the mangling for AnyObject in master, but not yet in swift-4.0-branch.

Foundation recently did not have a swift-4.0-branch. Now that it does, revert the change so that Foundation matches Swift across the two swift-4.0-branch branches.