### PR TITLE
Don't assume the size when allocating a CFNumber

### DIFF
--- a/CoreFoundation/NumberDate.subproj/CFNumber.c
+++ b/CoreFoundation/NumberDate.subproj/CFNumber.c
@@ -1205,7 +1205,8 @@ CFNumberRef CFNumberCreate(CFAllocatorRef allocator, CFNumberType type, const vo
 	}
     }
 
-    CFIndex size = 8 + ((!__CFNumberTypeTable[type].floatBit && __CFNumberTypeTable[type].storageBit) ? 8 : 0);
+    CFIndex size = sizeof(struct __CFNumber) - sizeof(CFRuntimeBase);
+    if (!__CFNumberTypeTable[type].floatBit && __CFNumberTypeTable[type].storageBit) size += 8;
 #if OLD_CRAP_TOO
     size += 2 * sizeof(void *);
 #endif


### PR DESCRIPTION
CoreFoundation assumed the size of a `struct __CFNumber` (which contains a `CFRuntimeBase` and an `int64_t`) would be the size of a `CFRuntimeBase` plus 8 bytes.

This assumption may be true on some platforms, but on my Raspberry Pi, the size of a `CFRuntimeBase` was 20 bytes.  The compiler inserted four bytes of padding before the `int64_t` to align it to an 8-byte boundary, causing the structure to take up 32 bytes instead of the 28 bytes the code allocated.  Writing to the `int64_t` overwrote some of `malloc`'s internal bookkeeping information and caused a crash.

I changed the code to use a couple of `sizeof`s to calculate the extra space to allocate, like the rest of CoreFoundation does (see [this search](https://github.com/apple/swift-corelibs-foundation/search?utf8=✓&q=_CFRuntimeCreateInstance&type=)).