### PR TITLE
Delete redundant constraints in NSData.swift causing warnings

### DIFF
--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -587,7 +587,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         }
         return location.map {NSRange(location: $0, length: search.count)} ?? NSRange(location: NSNotFound, length: 0)
     }
-    private static func searchSubSequence<T : Collection, T2 : Sequence>(_ subSequence : T2, inSequence seq: T,anchored : Bool) -> T.Index? where T.Iterator.Element : Equatable, T.Iterator.Element == T2.Iterator.Element, T.SubSequence.Iterator.Element == T.Iterator.Element, T.Indices.Iterator.Element == T.Index {
+    private static func searchSubSequence<T : Collection, T2 : Sequence>(_ subSequence : T2, inSequence seq: T,anchored : Bool) -> T.Index? where T.Iterator.Element : Equatable, T.Iterator.Element == T2.Iterator.Element {
         for index in seq.indices {
             if seq.suffix(from: index).starts(with: subSequence) {
                 return index


### PR DESCRIPTION
Delete 2 constraints causing warnings in NSData.swift introduced from https://github.com/apple/swift/commit/ddc2775530bb45cd3231677909ee4d06361ebd0d

Compiler warnings suggest redundant last 2 constraints are implied by Collection:

~~~~
Foundation/NSData.swift:590:253: warning: redundant same-type constraint 'T.Iterator.Element' == 'T.SubSequence.Iterator.Element'
    private static func searchSubSequence<T : Collection, T2 : Sequence>(_ subSequence : T2, inSequence seq: T,anchored : Bool) -> T.Index? where T.Iterator.Element : Equatable, T.Iterator.Element == T2.Iterator.Element, T.SubSequence.Iterator.Element == T.Iterator.Element, T.Indices.Iterator.Element == T.Index {
                                                                                                                                                                                                                                                            ^
Foundation/NSData.swift:590:47: note: previous same-type constraint 'T._Element' == 'T.Iterator.Element' implied here
    private static func searchSubSequence<T : Collection, T2 : Sequence>(_ subSequence : T2, inSequence seq: T,anchored : Bool) -> T.Index? where T.Iterator.Element : Equatable, T.Iterator.Element == T2.Iterator.Element, T.SubSequence.Iterator.Element == T.Iterator.Element, T.Indices.Iterator.Element == T.Index {
                                              ^
Foundation/NSData.swift:590:303: warning: redundant same-type constraint 'T.Index' == 'T.Indices.Iterator.Element'
    private static func searchSubSequence<T : Collection, T2 : Sequence>(_ subSequence : T2, inSequence seq: T,anchored : Bool) -> T.Index? where T.Iterator.Element : Equatable, T.Iterator.Element == T2.Iterator.Element, T.SubSequence.Iterator.Element == T.Iterator.Element, T.Indices.Iterator.Element == T.Index {
                                                                                                                                                                                                                                                                                                              ^
Foundation/NSData.swift:590:47: note: previous same-type constraint 'T.Index' == 'T.Indices.Index' implied here
    private static func searchSubSequence<T : Collection, T2 : Sequence>(_ subSequence : T2, inSequence seq: T,anchored : Bool) -> T.Index? where T.Iterator.Element : Equatable, T.Iterator.Element == T2.Iterator.Element, T.SubSequence.Iterator.Element == T.Iterator.Element, T.Indices.Iterator.Element == T.Index {
~~~~