### PR TITLE
Remove `Comparable` conformance from several types

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -774,7 +774,7 @@ extension FileManager {
     }
 }
 
-public struct FileAttributeKey : RawRepresentable, Equatable, Hashable, Comparable {
+public struct FileAttributeKey : RawRepresentable, Equatable, Hashable {
     public let rawValue: String
     
     public init(_ rawValue: String) {
@@ -793,10 +793,6 @@ public struct FileAttributeKey : RawRepresentable, Equatable, Hashable, Comparab
         return lhs.rawValue == rhs.rawValue
     }
     
-    public static func <(_ lhs: FileAttributeKey, _ rhs: FileAttributeKey) -> Bool {
-        return lhs.rawValue < rhs.rawValue
-    }
-
     public static let type = FileAttributeKey(rawValue: "NSFileType")
     public static let size = FileAttributeKey(rawValue: "NSFileSize")
     public static let modificationDate = FileAttributeKey(rawValue: "NSFileModificationDate")
@@ -822,7 +818,7 @@ public struct FileAttributeKey : RawRepresentable, Equatable, Hashable, Comparab
     public static let systemFreeNodes = FileAttributeKey(rawValue: "NSFileSystemFreeNodes")
 }
 
-public struct FileAttributeType : RawRepresentable, Equatable, Hashable, Comparable {
+public struct FileAttributeType : RawRepresentable, Equatable, Hashable {
     public let rawValue: String
 
     public init(_ rawValue: String) {
@@ -839,10 +835,6 @@ public struct FileAttributeType : RawRepresentable, Equatable, Hashable, Compara
 
     public static func ==(_ lhs: FileAttributeType, _ rhs: FileAttributeType) -> Bool {
         return lhs.rawValue == rhs.rawValue
-    }
-
-    public static func <(_ lhs: FileAttributeType, _ rhs: FileAttributeType) -> Bool {
-        return lhs.rawValue < rhs.rawValue
     }
 
     public static let typeDirectory = FileAttributeType(rawValue: "NSFileTypeDirectory")

--- a/Foundation/NSDecimalNumber.swift
+++ b/Foundation/NSDecimalNumber.swift
@@ -8,7 +8,7 @@
 //
 
 /***************	Exceptions		***********/
-public struct NSExceptionName : RawRepresentable, Equatable, Hashable, Comparable {
+public struct NSExceptionName : RawRepresentable, Equatable, Hashable {
     public private(set) var rawValue: String
     
     public init(_ rawValue: String) {
@@ -25,10 +25,6 @@ public struct NSExceptionName : RawRepresentable, Equatable, Hashable, Comparabl
     
     public static func ==(_ lhs: NSExceptionName, _ rhs: NSExceptionName) -> Bool {
         return lhs.rawValue == rhs.rawValue
-    }
-    
-    public static func <(_ lhs: NSExceptionName, _ rhs: NSExceptionName) -> Bool {
-        return lhs.rawValue < rhs.rawValue
     }
 }
 

--- a/Foundation/NSHTTPCookie.swift
+++ b/Foundation/NSHTTPCookie.swift
@@ -7,7 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-public struct HTTPCookiePropertyKey : RawRepresentable, Equatable, Hashable, Comparable {
+public struct HTTPCookiePropertyKey : RawRepresentable, Equatable, Hashable {
     public private(set) var rawValue: String
     
     public init(_ rawValue: String) {
@@ -24,10 +24,6 @@ public struct HTTPCookiePropertyKey : RawRepresentable, Equatable, Hashable, Com
     
     public static func ==(_ lhs: HTTPCookiePropertyKey, _ rhs: HTTPCookiePropertyKey) -> Bool {
         return lhs.rawValue == rhs.rawValue
-    }
-    
-    public static func <(_ lhs: HTTPCookiePropertyKey, _ rhs: HTTPCookiePropertyKey) -> Bool {
-        return rhs.rawValue == rhs.rawValue
     }
 }
 

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -194,7 +194,7 @@ extension NSLocale {
 
 extension NSLocale {
 
-    public struct Key : RawRepresentable, Equatable, Hashable, Comparable {
+    public struct Key : RawRepresentable, Equatable, Hashable {
         public private(set) var rawValue: String
         public init(rawValue: String) {
             self.rawValue = rawValue
@@ -239,10 +239,6 @@ extension NSLocale {
 extension NSLocale.Key {
     public static func ==(_ lhs: NSLocale.Key, _ rhs: NSLocale.Key) -> Bool {
         return lhs.rawValue == rhs.rawValue
-    }
-
-    public static func <(_ lhs: NSLocale.Key, _ rhs: NSLocale.Key) -> Bool {
-        return lhs.rawValue < rhs.rawValue
     }
 }
 

--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -8,7 +8,7 @@
 //
 
 open class NSNotification: NSObject, NSCopying, NSCoding {
-    public struct Name : RawRepresentable, Equatable, Hashable, Comparable {
+    public struct Name : RawRepresentable, Equatable, Hashable {
         public private(set) var rawValue: String
         public init(rawValue: String) {
             self.rawValue = rawValue
@@ -20,10 +20,6 @@ open class NSNotification: NSObject, NSCopying, NSCoding {
         
         public static func ==(lhs: Name, rhs: Name) -> Bool {
             return lhs.rawValue == rhs.rawValue
-        }
-        
-        public static func <(lhs: Name, rhs: Name) -> Bool {
-            return lhs.rawValue < rhs.rawValue
         }
     }
 

--- a/Foundation/NSRunLoop.swift
+++ b/Foundation/NSRunLoop.swift
@@ -19,7 +19,7 @@ import CoreFoundation
     internal let kCFRunLoopAllActivities = CFRunLoopActivity.allActivities.rawValue
 #endif
 
-public struct RunLoopMode : RawRepresentable, Equatable, Hashable, Comparable {
+public struct RunLoopMode : RawRepresentable, Equatable, Hashable {
     public private(set) var rawValue: String
     
     public init(_ rawValue: String) {
@@ -36,10 +36,6 @@ public struct RunLoopMode : RawRepresentable, Equatable, Hashable, Comparable {
 
     public static func ==(_ lhs: RunLoopMode, _ rhs: RunLoopMode) -> Bool {
         return lhs.rawValue == rhs.rawValue
-    }
-
-    public static func <(_ lhs: RunLoopMode, _ rhs: RunLoopMode) -> Bool {
-        return lhs.rawValue < rhs.rawValue
     }
 }
 

--- a/Foundation/NSStream.swift
+++ b/Foundation/NSStream.swift
@@ -18,7 +18,7 @@ internal extension UInt {
 #endif
 
 extension Stream {
-    public struct PropertyKey : RawRepresentable, Equatable, Hashable, Comparable {
+    public struct PropertyKey : RawRepresentable, Equatable, Hashable {
         public private(set) var rawValue: String
         
         public init(_ rawValue: String) {
@@ -35,10 +35,6 @@ extension Stream {
         
         public static func ==(lhs: Stream.PropertyKey, rhs: Stream.PropertyKey) -> Bool {
             return lhs.rawValue == rhs.rawValue
-        }
-        
-        public static func <(lhs: Stream.PropertyKey, rhs: Stream.PropertyKey) -> Bool {
-            return lhs.rawValue < rhs.rawValue
         }
     }
     
@@ -262,7 +258,7 @@ extension Stream.PropertyKey {
 }
 
 // MARK: -
-public struct StreamSocketSecurityLevel : RawRepresentable, Equatable, Hashable, Comparable {
+public struct StreamSocketSecurityLevel : RawRepresentable, Equatable, Hashable {
     public let rawValue: String
     public init(rawValue: String) {
         self.rawValue = rawValue
@@ -272,9 +268,6 @@ public struct StreamSocketSecurityLevel : RawRepresentable, Equatable, Hashable,
     }
     public static func ==(lhs: StreamSocketSecurityLevel, rhs: StreamSocketSecurityLevel) -> Bool {
         return lhs.rawValue == rhs.rawValue
-    }
-    public static func <(lhs: StreamSocketSecurityLevel, rhs: StreamSocketSecurityLevel) -> Bool {
-        return lhs.rawValue < rhs.rawValue
     }
 }
 extension StreamSocketSecurityLevel {
@@ -287,7 +280,7 @@ extension StreamSocketSecurityLevel {
 
 
 // MARK: -
-public struct StreamSOCKSProxyConfiguration : RawRepresentable, Equatable, Hashable, Comparable {
+public struct StreamSOCKSProxyConfiguration : RawRepresentable, Equatable, Hashable {
     public let rawValue: String
     public init(rawValue: String) {
         self.rawValue = rawValue
@@ -297,9 +290,6 @@ public struct StreamSOCKSProxyConfiguration : RawRepresentable, Equatable, Hasha
     }
     public static func ==(lhs: StreamSOCKSProxyConfiguration, rhs: StreamSOCKSProxyConfiguration) -> Bool {
         return lhs.rawValue == rhs.rawValue
-    }
-    public static func <(lhs: StreamSOCKSProxyConfiguration, rhs: StreamSOCKSProxyConfiguration) -> Bool {
-        return lhs.rawValue < rhs.rawValue
     }
 }
 extension StreamSOCKSProxyConfiguration {
@@ -312,7 +302,7 @@ extension StreamSOCKSProxyConfiguration {
 
 
 // MARK: -
-public struct StreamSOCKSProxyVersion : RawRepresentable, Equatable, Hashable, Comparable {
+public struct StreamSOCKSProxyVersion : RawRepresentable, Equatable, Hashable {
     public let rawValue: String
     public init(rawValue: String) {
         self.rawValue = rawValue
@@ -323,9 +313,6 @@ public struct StreamSOCKSProxyVersion : RawRepresentable, Equatable, Hashable, C
     public static func ==(lhs: StreamSOCKSProxyVersion, rhs: StreamSOCKSProxyVersion) -> Bool {
         return lhs.rawValue == rhs.rawValue
     }
-    public static func <(lhs: StreamSOCKSProxyVersion, rhs: StreamSOCKSProxyVersion) -> Bool {
-        return lhs.rawValue < rhs.rawValue
-    }
 }
 extension StreamSOCKSProxyVersion {
     public static let version4 = StreamSOCKSProxyVersion(rawValue: "kCFStreamSocketSOCKSVersion4")
@@ -334,7 +321,7 @@ extension StreamSOCKSProxyVersion {
 
 
 // MARK: - Supported network service types
-public struct StreamNetworkServiceTypeValue : RawRepresentable, Equatable, Hashable, Comparable {
+public struct StreamNetworkServiceTypeValue : RawRepresentable, Equatable, Hashable {
     public let rawValue: String
     public init(rawValue: String) {
         self.rawValue = rawValue
@@ -344,9 +331,6 @@ public struct StreamNetworkServiceTypeValue : RawRepresentable, Equatable, Hasha
     }
     public static func ==(lhs: StreamNetworkServiceTypeValue, rhs: StreamNetworkServiceTypeValue) -> Bool {
         return lhs.rawValue == rhs.rawValue
-    }
-    public static func <(lhs: StreamNetworkServiceTypeValue, rhs: StreamNetworkServiceTypeValue) -> Bool {
-        return lhs.rawValue < rhs.rawValue
     }
 }
 extension StreamNetworkServiceTypeValue {

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -64,7 +64,7 @@ internal func _pathComponents(_ path: String?) -> [String]? {
     return nil
 }
 
-public struct URLResourceKey : RawRepresentable, Equatable, Hashable, Comparable {
+public struct URLResourceKey : RawRepresentable, Equatable, Hashable {
     public private(set) var rawValue: String
     public init(rawValue: String) {
         self.rawValue = rawValue
@@ -80,10 +80,6 @@ public struct URLResourceKey : RawRepresentable, Equatable, Hashable, Comparable
 
     public static func ==(lhs: URLResourceKey, rhs: URLResourceKey) -> Bool {
         return lhs.rawValue == rhs.rawValue
-    }
-
-    public static func <(lhs: URLResourceKey, rhs: URLResourceKey) -> Bool {
-        return lhs.rawValue < rhs.rawValue
     }
 }
 
@@ -190,7 +186,7 @@ extension URLResourceKey {
 }
 
 
-public struct URLFileResourceType : RawRepresentable, Equatable, Hashable, Comparable {
+public struct URLFileResourceType : RawRepresentable, Equatable, Hashable {
     public private(set) var rawValue: String
     public init(rawValue: String) {
         self.rawValue = rawValue
@@ -206,10 +202,6 @@ public struct URLFileResourceType : RawRepresentable, Equatable, Hashable, Compa
 
     public static func ==(lhs: URLFileResourceType, rhs: URLFileResourceType) -> Bool {
         return lhs.rawValue == rhs.rawValue
-    }
-
-    public static func <(lhs: URLFileResourceType, rhs: URLFileResourceType) -> Bool {
-        return lhs.rawValue < rhs.rawValue
     }
 }
 

--- a/Foundation/Progress.swift
+++ b/Foundation/Progress.swift
@@ -401,13 +401,12 @@ open class Progress : NSObject {
     /// If the value of the `localizedDescription` property has not been set, then the default implementation of `localizedDescription` uses the progress kind to determine how to use the values of other properties, as well as values in the user info dictionary, to create a string that is presentable to the user.
     open var kind: ProgressKind?
     
-    public struct FileOperationKind : RawRepresentable, Equatable, Hashable, Comparable {
+    public struct FileOperationKind : RawRepresentable, Equatable, Hashable {
         public let rawValue: String
         public init(_ rawValue: String) { self.rawValue = rawValue }
         public init(rawValue: String) { self.rawValue = rawValue }
         public var hashValue: Int { return self.rawValue.hashValue }
         public static func ==(_ lhs: FileOperationKind, _ rhs: FileOperationKind) -> Bool { return lhs.rawValue == rhs.rawValue }
-        public static func <(_ lhs: FileOperationKind, _ rhs: FileOperationKind) -> Bool { return lhs.rawValue < rhs.rawValue }
         
         /// Use for indicating the progress represents a download.
         public static let downloading = FileOperationKind(rawValue: "NSProgressFileOperationKindDownloading")
@@ -481,13 +480,12 @@ public protocol ProgressReporting : NSObjectProtocol {
     var progress: Progress { get }
 }
 
-public struct ProgressKind : RawRepresentable, Equatable, Hashable, Comparable {
+public struct ProgressKind : RawRepresentable, Equatable, Hashable {
     public let rawValue: String
     public init(_ rawValue: String) { self.rawValue = rawValue }
     public init(rawValue: String) { self.rawValue = rawValue }
     public var hashValue: Int { return self.rawValue.hashValue }
     public static func ==(_ lhs: ProgressKind, _ rhs: ProgressKind) -> Bool { return lhs.rawValue == rhs.rawValue }
-    public static func <(_ lhs: ProgressKind, _ rhs: ProgressKind) -> Bool { return lhs.rawValue < rhs.rawValue }
     
     /// Indicates that the progress being performed is related to files.
     ///
@@ -495,13 +493,12 @@ public struct ProgressKind : RawRepresentable, Equatable, Hashable, Comparable {
     public static let file = ProgressKind(rawValue: "NSProgressKindFile")
 }
 
-public struct ProgressUserInfoKey : RawRepresentable, Equatable, Hashable, Comparable {
+public struct ProgressUserInfoKey : RawRepresentable, Equatable, Hashable {
     public let rawValue: String
     public init(_ rawValue: String) { self.rawValue = rawValue }
     public init(rawValue: String) { self.rawValue = rawValue }
     public var hashValue: Int { return self.rawValue.hashValue }
     public static func ==(_ lhs: ProgressUserInfoKey, _ rhs: ProgressUserInfoKey) -> Bool { return lhs.rawValue == rhs.rawValue }
-    public static func <(_ lhs: ProgressUserInfoKey, _ rhs: ProgressUserInfoKey) -> Bool { return lhs.rawValue < rhs.rawValue }
     
     /// How much time is probably left in the operation, as an NSNumber containing a number of seconds.
     ///


### PR DESCRIPTION
Now that automatic `Comparable` inference for swift_wrapper types is removed.
https://github.com/apple/swift/commit/de969c66c62bf42ee271ed4c27868fa31ee99c7b

Removed `Comparable` and `func <` from:
* `FileAttributeKey`
* `FileAttributeType`
* `NSExceptionName`
* `HTTPCookiePropertyKey`
* `NSLocale.Key`
* `NSNotification.Name`
* `RunLoopMode`
* `Stream.PropertyKey`
* `StreamSocketSecurityLevel`
* `StreamSOCKSProxyConfiguration`
* `StreamSOCKSProxyVersion`
* `StreamNetworkServiceTypeValue`
* `URLResourceKey`
* `URLFileResourceType`
* `Progress.FileOperationKind`
* `ProgressKind`
* `ProgressUserInfoKey`