### PR TITLE
Small cleanup: Use () -> ... instead of (Void) -> ... for no-argument closures

### DIFF
--- a/Foundation/Thread.swift
+++ b/Foundation/Thread.swift
@@ -24,7 +24,7 @@ private func _compiler_crash_fix(_ key: _CFThreadSpecificKey, _ value: AnyObject
 internal class NSThreadSpecific<T: NSObject> {
     private var key = _CFThreadSpecificKeyCreate()
     
-    internal func get(_ generator: (Void) -> T) -> T {
+    internal func get(_ generator: () -> T) -> T {
         if let specific = _CFThreadSpecificGet(key) {
             return specific as! T
         } else {
@@ -130,7 +130,7 @@ open class Thread : NSObject {
         pthread_exit(nil)
     }
     
-    internal var _main: (Void) -> Void = {}
+    internal var _main: () -> Void = {}
 #if os(OSX) || os(iOS) || CYGWIN
     private var _thread: pthread_t? = nil
 #elseif os(Linux) || os(Android)


### PR DESCRIPTION
In Swift, (Void) -> Void is actually a function that takes
a single value of empty-tuple type, and not a function that
takes no arguments.

Swift 3 largely ignored the distinction because of the implicit
'tuple splat' behavior; in Swift 4, this behavior has been
eliminated as part of implementing SE-0110, so calling a function
of type (Void) -> () now requires passing in an empty tuple,
like foo(()).

I believe this is not intended behavior, so this patch changes
the functions in question to be written as () -> Void.