### PR TITLE
Disable URLSession tests (SR-4677 and timeouts)

### DIFF
--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -79,7 +79,8 @@ XCTMain([
     testCase(TestURLRequest.allTests),
     testCase(TestNSURLResponse.allTests),
     testCase(TestNSHTTPURLResponse.allTests),
-    testCase(TestURLSession.allTests),
+//Disabling to avoid https://bugs.swift.org/browse/SR-4677 and a timeout failure
+//    testCase(TestURLSession.allTests),
     testCase(TestNSNull.allTests),
     testCase(TestNSUUID.allTests),
     testCase(TestNSValue.allTests),


### PR DESCRIPTION
After enabling URLSession tests through #982 we still saw two CI failures yesterday:
1. A [timeout](https://ci.swift.org/job/oss-swift-4.0-incremental-RA-linux-ubuntu-16_04/442/) - reason still unknown because this is not reproducible locally even in ~20k runs
2. [A crash](https://ci.swift.org/job/oss-swift-4.0-incremental-RA-linux-ubuntu-16_04/449/) - the reason may be this [open dispatch bug](https://bugs.swift.org/browse/SR-4677). 

To avoid CI failures, disabling seems to be our only resort for now.