### PR TITLE
[3.1] Fix `(nsError as Error).localizedDescription` output

### DIFF
--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -288,7 +288,11 @@ public extension Error where Self : CustomNSError {
 public extension Error {
     /// Retrieve the localized description for this error.
     var localizedDescription: String {
-        let defaultUserInfo = _swift_Foundation_getErrorDefaultUserInfo(self) as! [String : Any]
+        if let nsError = self as? NSError {
+            return nsError.localizedDescription
+        }
+
+        let defaultUserInfo = _swift_Foundation_getErrorDefaultUserInfo(self) as? [String : Any]
         return NSError(domain: _domain, code: _code, userInfo: defaultUserInfo).localizedDescription
     }
 }

--- a/TestFoundation/TestNSError.swift
+++ b/TestFoundation/TestNSError.swift
@@ -22,6 +22,7 @@ class TestNSError : XCTestCase {
     static var allTests: [(String, (TestNSError) -> () throws -> Void)] {
         return [
             ("test_LocalizedError_errorDescription", test_LocalizedError_errorDescription),
+            ("test_NSErrorAsError_localizedDescription", test_NSErrorAsError_localizedDescription),
         ]
     }
     
@@ -32,5 +33,11 @@ class TestNSError : XCTestCase {
 
         let error = Error()
         XCTAssertEqual(error.localizedDescription, "error description")
+    }
+
+    func test_NSErrorAsError_localizedDescription() {
+        let nsError = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Localized!"])
+        let error = nsError as Error
+        XCTAssertEqual(error.localizedDescription, "Localized!")
     }
 }


### PR DESCRIPTION
Backport #967 into `swift-3.1-branch`.