### PR TITLE
[NSArray] Add check to `isEqual(to:)` whether values is `_ObjectBridgeable`

### DIFF
--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -312,6 +312,13 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
                 if val1 != val2 {
                     return false
                 }
+            } else if let val1 = object(at: idx) as? _ObjectBridgeable,
+                let val2 = otherArray[idx] as? _ObjectBridgeable {
+                if !(val1._bridgeToAnyObject() as! NSObject).isEqual(val2._bridgeToAnyObject()) {
+                    return false
+                }
+            } else {
+                return false
             }
         }
         

--- a/TestFoundation/TestNSArray.swift
+++ b/TestFoundation/TestNSArray.swift
@@ -421,6 +421,12 @@ class TestNSArray : XCTestCase {
 
         XCTAssertFalse(array1.isEqual(nil))
         XCTAssertFalse(array1.isEqual(NSObject()))
+
+        let objectsArray1 = NSArray(array: [NSArray(array: [0])])
+        let objectsArray2 = NSArray(array: [NSArray(array: [1])])
+        XCTAssertFalse(objectsArray1 == objectsArray2)
+        XCTAssertFalse(objectsArray1.isEqual(objectsArray2))
+        XCTAssertFalse(objectsArray1.isEqual(to: Array(objectsArray2)))
     }
 
     /// - Note: value type conversion will destroy identity. So use index(of:) instead of indexOfObjectIdentical(to:)

--- a/TestFoundation/TestNSDictionary.swift
+++ b/TestFoundation/TestNSDictionary.swift
@@ -134,6 +134,24 @@ class TestNSDictionary : XCTestCase {
 
         XCTAssertFalse(dict1.isEqual(nil))
         XCTAssertFalse(dict1.isEqual(NSObject()))
+
+        let nestedDict1 = NSDictionary(dictionary: [
+            "key.entities": [
+                ["key": 0]
+            ]
+        ])
+        let nestedDict2 = NSDictionary(dictionary: [
+            "key.entities": [
+                ["key": 1]
+            ]
+        ])
+        XCTAssertFalse(nestedDict1 == nestedDict2)
+        XCTAssertFalse(nestedDict1.isEqual(nestedDict2))
+        XCTAssertFalse(nestedDict1.isEqual(to: [
+            "key.entities": [
+                ["key": 1]
+            ]
+        ]))
     }
 
     func test_copying() {


### PR DESCRIPTION
When `NSArray` are compared for equality, `NSArray` only checks if the element can be casted as `AnyHashable`. Therefore, the result was incorrect when the `NSArray` contained instances which are not `Hashable` but are subclasses of NSObject (eg `NSArray` and `NSDictionary`) .
This PR fixes that.

Fixes [SR-4903](https://bugs.swift.org/browse/SR-4903)