### PR TITLE
swift4: Fixes for bit shifting

### DIFF
--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -60,7 +60,7 @@ public final class _DataStorage {
         case customMutableReference(NSMutableData) // tracks data references that are known to be mutable
     }
     
-    public static let maxSize = Int.max >> 1
+    public static let maxSize = Int.max / 2
     public static let vmOpsThreshold = NSPageSize() * 4
     
     public static func allocate(_ size: Int, _ clear: Bool) -> UnsafeMutableRawPointer? {
@@ -209,7 +209,7 @@ public final class _DataStorage {
     @inline(never)
     public func _grow(_ newLength: Int, _ clear: Bool) {
         let cap = _capacity
-        var additionalCapacity = (newLength >> (_DataStorage.vmOpsThreshold <= newLength ? 2 : 1))
+        var additionalCapacity = (newLength / (_DataStorage.vmOpsThreshold <= newLength ? 4 : 2))
         if Int.max - additionalCapacity < newLength {
             additionalCapacity = 0
         }
@@ -535,7 +535,7 @@ public final class _DataStorage {
     
     public init(length: Int) {
         precondition(length < _DataStorage.maxSize)
-        var capacity = (length < 1024 * 1024 * 1024) ? length + (length >> 2) : length
+        var capacity = (length < 1024 * 1024 * 1024) ? length + (length / 4) : length
         if _DataStorage.vmOpsThreshold <= capacity {
             capacity = NSRoundUpToMultipleOfPageSize(capacity)
         }

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -84,9 +84,9 @@ extension NSCalendar {
         public static let weekOfYear = Unit(rawValue: UInt(kCFCalendarUnitWeekOfYear))
         public static let yearForWeekOfYear = Unit(rawValue: UInt(kCFCalendarUnitYearForWeekOfYear))
 
-        public static let nanosecond = Unit(rawValue: UInt(1 << 15))
-        public static let calendar = Unit(rawValue: UInt(1 << 20))
-        public static let timeZone = Unit(rawValue: UInt(1 << 21))
+        public static let nanosecond = Unit(rawValue: UInt(1) << 15)
+        public static let calendar = Unit(rawValue: UInt(1) << 20)
+        public static let timeZone = Unit(rawValue: UInt(1) << 21)
 
         internal var _cfValue: CFCalendarUnit {
 #if os(OSX) || os(iOS)
@@ -1309,7 +1309,7 @@ open class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         if NSDateComponentUndefined == yy {
             yy = 0
         }
-        return calHash + (32832013 * (y + yy) + 2678437 * m + 86413 * d + 3607 * h + 61 * mm + s) + (41 * weekOfYear + 11 * weekOfMonth + 7 * weekday + 3 * weekdayOrdinal + quarter) * (1 << 5)
+        return calHash + (32832013 * (y + yy) + 2678437 * m + 86413 * d + 3607 * h + 61 * mm + s) + (41 * weekOfYear + 11 * weekOfMonth + 7 * weekday + 3 * weekdayOrdinal + quarter) * 32
     }
     
     open override func isEqual(_ object: Any?) -> Bool {

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -24,42 +24,42 @@ extension NSData {
         public let rawValue : UInt
         public init(rawValue: UInt) { self.rawValue = rawValue }
         
-        public static let mappedIfSafe = ReadingOptions(rawValue: UInt(1 << 0))
-        public static let uncached = ReadingOptions(rawValue: UInt(1 << 1))
-        public static let alwaysMapped = ReadingOptions(rawValue: UInt(1 << 2))
+        public static let mappedIfSafe = ReadingOptions(rawValue: UInt(1) << 0)
+        public static let uncached = ReadingOptions(rawValue: UInt(1) << 1)
+        public static let alwaysMapped = ReadingOptions(rawValue: UInt(1) << 2)
     }
 
     public struct WritingOptions : OptionSet {
         public let rawValue : UInt
         public init(rawValue: UInt) { self.rawValue = rawValue }
         
-        public static let atomic = WritingOptions(rawValue: UInt(1 << 0))
-        public static let withoutOverwriting = WritingOptions(rawValue: UInt(1 << 1))
+        public static let atomic = WritingOptions(rawValue: UInt(1) << 0)
+        public static let withoutOverwriting = WritingOptions(rawValue: UInt(1) << 1)
     }
 
     public struct SearchOptions : OptionSet {
         public let rawValue : UInt
         public init(rawValue: UInt) { self.rawValue = rawValue }
         
-        public static let backwards = SearchOptions(rawValue: UInt(1 << 0))
-        public static let anchored = SearchOptions(rawValue: UInt(1 << 1))
+        public static let backwards = SearchOptions(rawValue: UInt(1) << 0)
+        public static let anchored = SearchOptions(rawValue: UInt(1) << 1)
     }
 
     public struct Base64EncodingOptions : OptionSet {
         public let rawValue : UInt
         public init(rawValue: UInt) { self.rawValue = rawValue }
         
-        public static let lineLength64Characters = Base64EncodingOptions(rawValue: UInt(1 << 0))
-        public static let lineLength76Characters = Base64EncodingOptions(rawValue: UInt(1 << 1))
-        public static let endLineWithCarriageReturn = Base64EncodingOptions(rawValue: UInt(1 << 4))
-        public static let endLineWithLineFeed = Base64EncodingOptions(rawValue: UInt(1 << 5))
+        public static let lineLength64Characters = Base64EncodingOptions(rawValue: UInt(1) << 0)
+        public static let lineLength76Characters = Base64EncodingOptions(rawValue: UInt(1) << 1)
+        public static let endLineWithCarriageReturn = Base64EncodingOptions(rawValue: UInt(1) << 4)
+        public static let endLineWithLineFeed = Base64EncodingOptions(rawValue: UInt(1) << 5)
     }
 
     public struct Base64DecodingOptions : OptionSet {
         public let rawValue : UInt
         public init(rawValue: UInt) { self.rawValue = rawValue }
         
-        public static let ignoreUnknownCharacters = Base64DecodingOptions(rawValue: UInt(1 << 0))
+        public static let ignoreUnknownCharacters = Base64DecodingOptions(rawValue: UInt(1) << 0)
     }
 }
 

--- a/Foundation/NSDecimal.swift
+++ b/Foundation/NSDecimal.swift
@@ -68,7 +68,7 @@ public struct Decimal {
         set {
             __lengthAndFlags =
                 (__lengthAndFlags & 0b0011_1111) |
-                UInt8(UInt32(newValue & (0b11 << 16)) >> 10)
+                UInt8(UInt32(newValue & (UInt32(0b11) << 16)) >> 10)
             __reserved = UInt16(newValue & 0b1111_1111_1111_1111)
         }
     }
@@ -583,7 +583,7 @@ fileprivate func divideByShort<T:VariableLengthNumber>(_ d: inout T, _ divisor:U
     // note the below is not the same as from length to 0 by -1
     var carry: UInt32 = 0
     for i in (0..<d._length).reversed() {
-        let accumulator = UInt32(d[i]) + carry * (1<<16)
+        let accumulator = UInt32(d[i]) + carry * (UInt32(1) << 16)
         d[i] = UInt16(accumulator / UInt32(divisor))
         carry = accumulator % UInt32(divisor)
     }
@@ -842,7 +842,7 @@ fileprivate func integerDivide<T:VariableLengthNumber>(_ r: inout T,
     //
     // I could probably use something smarter to get d to be a power of 2.
     // In this case the multiply below became only a shift.
-    let d: UInt32 = UInt32((1 << 16) / Int(cv[cv._length - 1] + 1))
+    let d: UInt32 = (UInt32(1) << 16) / UInt32(cv[cv._length - 1] + 1)
 
     // This is to make the whole algorithm work and u*d/v*d == u/v
     _ = multiplyByShort(&u, UInt16(d))

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -325,29 +325,29 @@ public struct AlignmentOptions : OptionSet {
     public var rawValue : UInt64
     public init(rawValue: UInt64) { self.rawValue = rawValue }
     
-    public static let alignMinXInward = AlignmentOptions(rawValue: 1 << 0)
-    public static let alignMinYInward = AlignmentOptions(rawValue: 1 << 1)
-    public static let alignMaxXInward = AlignmentOptions(rawValue: 1 << 2)
-    public static let alignMaxYInward = AlignmentOptions(rawValue: 1 << 3)
-    public static let alignWidthInward = AlignmentOptions(rawValue: 1 << 4)
-    public static let alignHeightInward = AlignmentOptions(rawValue: 1 << 5)
-    
-    public static let alignMinXOutward = AlignmentOptions(rawValue: 1 << 8)
-    public static let alignMinYOutward = AlignmentOptions(rawValue: 1 << 9)
-    public static let alignMaxXOutward = AlignmentOptions(rawValue: 1 << 10)
-    public static let alignMaxYOutward = AlignmentOptions(rawValue: 1 << 11)
-    public static let alignWidthOutward = AlignmentOptions(rawValue: 1 << 12)
-    public static let alignHeightOutward = AlignmentOptions(rawValue: 1 << 13)
-    
-    public static let alignMinXNearest = AlignmentOptions(rawValue: 1 << 16)
-    public static let alignMinYNearest = AlignmentOptions(rawValue: 1 << 17)
-    public static let alignMaxXNearest = AlignmentOptions(rawValue: 1 << 18)
-    public static let alignMaxYNearest = AlignmentOptions(rawValue: 1 << 19)
-    public static let alignWidthNearest = AlignmentOptions(rawValue: 1 << 20)
-    public static let alignHeightNearest = AlignmentOptions(rawValue: 1 << 21)
+    public static let alignMinXInward = AlignmentOptions(rawValue: UInt64(1) << 0)
+    public static let alignMinYInward = AlignmentOptions(rawValue: UInt64(1) << 1)
+    public static let alignMaxXInward = AlignmentOptions(rawValue: UInt64(1) << 2)
+    public static let alignMaxYInward = AlignmentOptions(rawValue: UInt64(1) << 3)
+    public static let alignWidthInward = AlignmentOptions(rawValue: UInt64(1) << 4)
+    public static let alignHeightInward = AlignmentOptions(rawValue: UInt64(1) << 5)
+
+    public static let alignMinXOutward = AlignmentOptions(rawValue: UInt64(1) << 8)
+    public static let alignMinYOutward = AlignmentOptions(rawValue: UInt64(1) << 9)
+    public static let alignMaxXOutward = AlignmentOptions(rawValue: UInt64(1) << 10)
+    public static let alignMaxYOutward = AlignmentOptions(rawValue: UInt64(1) << 11)
+    public static let alignWidthOutward = AlignmentOptions(rawValue: UInt64(1) << 12)
+    public static let alignHeightOutward = AlignmentOptions(rawValue: UInt64(1) << 13)
+
+    public static let alignMinXNearest = AlignmentOptions(rawValue: UInt64(1) << 16)
+    public static let alignMinYNearest = AlignmentOptions(rawValue: UInt64(1) << 17)
+    public static let alignMaxXNearest = AlignmentOptions(rawValue: UInt64(1) << 18)
+    public static let alignMaxYNearest = AlignmentOptions(rawValue: UInt64(1) << 19)
+    public static let alignWidthNearest = AlignmentOptions(rawValue: UInt64(1) << 20)
+    public static let alignHeightNearest = AlignmentOptions(rawValue: UInt64(1) << 21)
 
     // pass this if the rect is in a flipped coordinate system. This allows 0.5 to be treated in a visually consistent way.
-    public static let alignRectFlipped = AlignmentOptions(rawValue: 1 << 63)
+    public static let alignRectFlipped = AlignmentOptions(rawValue: UInt64(1) << 63)
     
     // convenience combinations
     public static let alignAllEdgesInward: AlignmentOptions = [.alignMinXInward, .alignMaxXInward, .alignMinYInward, .alignMaxYInward]

--- a/Foundation/NSObjCRuntime.swift
+++ b/Foundation/NSObjCRuntime.swift
@@ -175,16 +175,16 @@ public struct NSSortOptions: OptionSet {
     public let rawValue : UInt
     public init(rawValue: UInt) { self.rawValue = rawValue }
     
-    public static let concurrent = NSSortOptions(rawValue: UInt(1 << 0))
-    public static let stable = NSSortOptions(rawValue: UInt(1 << 4))
+    public static let concurrent = NSSortOptions(rawValue: UInt(1) << 0)
+    public static let stable = NSSortOptions(rawValue: UInt(1) << 4)
 }
 
 public struct NSEnumerationOptions: OptionSet {
     public let rawValue : UInt
     public init(rawValue: UInt) { self.rawValue = rawValue }
     
-    public static let concurrent = NSEnumerationOptions(rawValue: UInt(1 << 0))
-    public static let reverse = NSEnumerationOptions(rawValue: UInt(1 << 1))
+    public static let concurrent = NSEnumerationOptions(rawValue: UInt(1) << 0)
+    public static let reverse = NSEnumerationOptions(rawValue: UInt(1) << 1)
 }
 
 public typealias Comparator = (Any, Any) -> ComparisonResult

--- a/Foundation/NSTextCheckingResult.swift
+++ b/Foundation/NSTextCheckingResult.swift
@@ -15,7 +15,7 @@ extension NSTextCheckingResult {
         public let rawValue: UInt64
         public init(rawValue: UInt64) { self.rawValue = rawValue }
         
-        public static let RegularExpression = CheckingType(rawValue: 1 << 10) // regular expression matches
+        public static let RegularExpression = CheckingType(rawValue: UInt64(1) << 10) // regular expression matches
     }
 }
 

--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -36,7 +36,7 @@ private func WIFSIGNALED(_ status: Int32) -> Bool {
 }
 
 private func WEXITSTATUS(_ status: Int32) -> Int32 {
-    return (status >> 8) & 0xff
+    return (status &>> 8) & 0xff
 }
 
 private func WTERMSIG(_ status: Int32) -> Int32 {

--- a/Foundation/Thread.swift
+++ b/Foundation/Thread.swift
@@ -211,8 +211,10 @@ open class Thread : NSObject {
         set {
             // just don't allow a stack size more than 1GB on any platform
             var s = newValue
-            if (1 << 30) < s {
-                s = 1 << 30
+            let oneGB = 1024 * 1024 * 1024
+
+            if oneGB < s {
+                s = oneGB
             }
             let _ = withUnsafeMutablePointer(to: &_attr) { attr in
                 pthread_attr_setstacksize(attr, s)


### PR DESCRIPTION
Fixes bitshifts used with initializers  and converts some bitshifts into divides where the meaning makes more sense.

Compatible with swift 3 & 4