### PR TITLE
swift4: Minor fixes

### DIFF
--- a/Foundation/NSURLResponse.swift
+++ b/Foundation/NSURLResponse.swift
@@ -396,8 +396,8 @@ private extension String {
                 type = string
             } else {
                 if let r = string.range(of: "=") {
-                    let name = string[string.startIndex..<r.lowerBound].trimmingCharacters(in: ws)
-                    let value = string[r.upperBound..<string.endIndex].trimmingCharacters(in: ws)
+                    let name = String(string[string.startIndex..<r.lowerBound]).trimmingCharacters(in: ws)
+                    let value = String(string[r.upperBound..<string.endIndex]).trimmingCharacters(in: ws)
                     parameters.append(ValueWithParameters.Parameter(attribute: name, value: value))
                 } else {
                     let name = string.trimmingCharacters(in: ws)

--- a/Foundation/NSValue.swift
+++ b/Foundation/NSValue.swift
@@ -98,7 +98,7 @@ open class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
     
     public convenience required init(bytes value: UnsafeRawPointer, objCType type: UnsafePointer<Int8>) {
-        if type(of: self) == NSValue.self {
+        if Swift.type(of: self) == NSValue.self {
             self.init()
             if NSValue._isSpecialObjCType(type) {
                 self._concreteValue = NSSpecialValue(bytes: value.assumingMemoryBound(to: UInt8.self), objCType: type)

--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -241,7 +241,11 @@ open class Process: NSObject {
         if let env = environment {
             let nenv = env.count
             envp = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>.allocate(capacity: 1 + nenv)
-            envp.initialize(from: env.map { strdup("\($0)=\($1)") })
+            let evars = env.map { (arg) -> UnsafeMutablePointer<Int8>? in
+                let (key, value) = arg
+                return UnsafeMutablePointer(strdup("\(key)=\(value)"))
+            }
+            envp.initialize(from: evars, count: 1 + nenv)
             envp[env.count] = nil
         } else {
             envp = _CFEnviron()

--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -241,11 +241,7 @@ open class Process: NSObject {
         if let env = environment {
             let nenv = env.count
             envp = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>.allocate(capacity: 1 + nenv)
-            let evars = env.map { (arg) -> UnsafeMutablePointer<Int8>? in
-                let (key, value) = arg
-                return UnsafeMutablePointer(strdup("\(key)=\(value)"))
-            }
-            envp.initialize(from: evars, count: 1 + nenv)
+            envp.initialize(from: env.map { strdup("\($0)=\($1)") })
             envp[env.count] = nil
         } else {
             envp = _CFEnviron()


### PR DESCRIPTION
- Fix 'Cannot call value of non-function type 'UnsafePointer<Int8>'
  by fully qualifying type(of:) in NSValue.swift

Compatible with swift 3 & 4