### PR TITLE
Ensure FileManager.createDirectory does not crash if directory already exists on Linux.

### DIFF
--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -49,7 +49,10 @@ class TestFileManager : XCTestCase {
         } catch _ {
             XCTFail()
         }
-        
+
+        // Ensure attempting to create the directory again fails gracefully.
+        XCTAssertNil(try? fm.createDirectory(atPath: path, withIntermediateDirectories:false, attributes:nil))
+
         var isDir = false
         let exists = fm.fileExists(atPath: path, isDirectory: &isDir)
         XCTAssertTrue(exists)


### PR DESCRIPTION
Add a test for [SR-4298](https://bugs.swift.org/browse/SR-4298) to ensure calling `FileManager.createDirectory` does not crash if the directory already exists.

The underlying issue is already fixed in tip-of-tree Swift.