### PR TITLE
Update Swift-mangled NSCFConstantString class name

### DIFF
--- a/CoreFoundation/Base.subproj/SymbolAliases
+++ b/CoreFoundation/Base.subproj/SymbolAliases
@@ -1,7 +1,7 @@
 
 
 # This is specific to Swift open source; Foundation's NSCFConstantString is used as our constant string class reference
-__TMC15SwiftFoundation19_NSCFConstantString ___CFConstantStringClassReference
+__T015SwiftFoundation19_NSCFConstantStringCN ___CFConstantStringClassReference
 
 _kCFCalendarIdentifierBuddhist		_kCFBuddhistCalendar
 _kCFCalendarIdentifierChinese		_kCFChineseCalendar


### PR DESCRIPTION
Fixing:
~~~~
ld: warning: undefined base symbol '__TMC15SwiftFoundation19_NSCFConstantString' for alias '___CFConstantStringClassReference'
Undefined symbols for architecture x86_64:
  "__T015SwiftFoundation21__CFSwiftGetBaseClassyXlXpyF", referenced from:
      ___CFInitialize in libCoreFoundation.a(CFRuntime.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
~~~~
Split from https://github.com/apple/swift-corelibs-foundation/pull/988 (this has somewhat higher risk of breaking on some Macs, maybe)