### PR TITLE
Replace the --defsym linker argument with an alias in code

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -334,21 +334,17 @@ CF_PRIVATE Boolean __CFProcessIsRestricted();
 #define STACK_BUFFER_DECL(T, N, C) T N[C]
 #endif
 
-#ifdef __ANDROID__
-// Avoids crashes on Android
-// https://bugs.swift.org/browse/SR-2587
-// https://bugs.swift.org/browse/SR-2588
-// Seemed to be a linker/relocation? problem.
-// CFStrings using CONST_STRING_DECL() were not working
-// Applies reference to _NSCFConstantString's isa here
-// rather than using a linker option to create an alias.
+
+
+#if DEPLOYMENT_RUNTIME_SWIFT
+
+#if TARGET_OS_MAC
+#define __CFConstantStringClassReference _T015SwiftFoundation19_NSCFConstantStringCN
+#else
 #define __CFConstantStringClassReference _T010Foundation19_NSCFConstantStringCN
 #endif
 
 CF_EXPORT void * __CFConstantStringClassReferencePtr;
-
-#if DEPLOYMENT_RUNTIME_SWIFT
-
 CF_EXPORT void *__CFConstantStringClassReference[];
 
 #if __CF_BIG_ENDIAN__

--- a/CoreFoundation/Base.subproj/SymbolAliases
+++ b/CoreFoundation/Base.subproj/SymbolAliases
@@ -1,8 +1,3 @@
-
-
-# This is specific to Swift open source; Foundation's NSCFConstantString is used as our constant string class reference
-__T015SwiftFoundation19_NSCFConstantStringCN ___CFConstantStringClassReference
-
 _kCFCalendarIdentifierBuddhist		_kCFBuddhistCalendar
 _kCFCalendarIdentifierChinese		_kCFChineseCalendar
 _kCFCalendarIdentifierGregorian		_kCFGregorianCalendar

--- a/build.py
+++ b/build.py
@@ -16,7 +16,7 @@ foundation.GCC_PREFIX_HEADER = 'CoreFoundation/Base.subproj/CoreFoundation_Prefi
 swift_cflags = ['-DDEPLOYMENT_RUNTIME_SWIFT']
 if Configuration.current.target.sdk == OSType.Linux:
 	foundation.CFLAGS = '-DDEPLOYMENT_TARGET_LINUX -D_GNU_SOURCE -DCF_CHARACTERSET_DATA_DIR="CoreFoundation/CharacterSets"'
-	foundation.LDFLAGS = '${SWIFT_USE_LINKER} -Wl,@./CoreFoundation/linux.ld -lswiftGlibc `${PKG_CONFIG} icu-uc icu-i18n --libs` -Wl,-defsym,__CFConstantStringClassReference=_T010Foundation19_NSCFConstantStringCN -Wl,-Bsymbolic '
+	foundation.LDFLAGS = '${SWIFT_USE_LINKER} -Wl,@./CoreFoundation/linux.ld -lswiftGlibc `${PKG_CONFIG} icu-uc icu-i18n --libs` -Wl,-Bsymbolic '
 	Configuration.current.requires_pkg_config = True
 elif Configuration.current.target.sdk == OSType.FreeBSD:
 	foundation.CFLAGS = '-DDEPLOYMENT_TARGET_FREEBSD -I/usr/local/include -I/usr/local/include/libxml2 -I/usr/local/include/curl '
@@ -26,7 +26,7 @@ elif Configuration.current.target.sdk == OSType.MacOSX:
 	foundation.LDFLAGS = '-licucore -twolevel_namespace -Wl,-alias_list,CoreFoundation/Base.subproj/DarwinSymbolAliases -sectcreate __UNICODE __csbitmaps CoreFoundation/CharacterSets/CFCharacterSetBitmaps.bitmap -sectcreate __UNICODE __properties CoreFoundation/CharacterSets/CFUniCharPropertyDatabase.data -sectcreate __UNICODE __data CoreFoundation/CharacterSets/CFUnicodeData-L.mapping -segprot __UNICODE r r '
 elif Configuration.current.target.sdk == OSType.Win32 and Configuration.current.target.environ == EnvironmentType.Cygnus:
 	foundation.CFLAGS = '-DDEPLOYMENT_TARGET_LINUX -D_GNU_SOURCE -mcmodel=large '
-	foundation.LDFLAGS = '${SWIFT_USE_LINKER} -lswiftGlibc `icu-config --ldflags` -Wl,-defsym,__CFConstantStringClassReference=_T010Foundation19_NSCFConstantStringCN,--allow-multiple-definition '
+	foundation.LDFLAGS = '${SWIFT_USE_LINKER} -lswiftGlibc `icu-config --ldflags` -Wl,--allow-multiple-definition '
 	swift_cflags += ['-DCYGWIN']
 
 if Configuration.current.build_mode == Configuration.Debug:


### PR DESCRIPTION
- This has the same effect as the  
- defsym=__CFConstantStringClassReference=_T010Foundation19_NSCFConstantStringCN
  option but does it in code which allows simplifying the linker arguments.

This will help with the -static-stdlib option since less linker arguments will need to be provided by swiftpm