### PR TITLE
swift4: String fixes

### DIFF
--- a/Foundation/NSURLSession/http/HTTPMessage.swift
+++ b/Foundation/NSURLSession/http/HTTPMessage.swift
@@ -294,7 +294,7 @@ private extension _HTTPURLProtocol._HTTPMessage._Header {
         if !line.isEmpty {
             if line.hasSPHTPrefix && line.count == 1 {
                 // to handle empty headers i.e header without value
-                value = String("")
+                value = ""
             } else {
                 guard let v = line.trimSPHTPrefix else { return nil }
                 value = String(v)

--- a/TestFoundation/HTTPServer.swift
+++ b/TestFoundation/HTTPServer.swift
@@ -98,7 +98,7 @@ class _TCPSocket {
         return stride(from: 0, to: str.characters.count, by: count).map { i -> String in
             let startIndex = str.index(str.startIndex, offsetBy: i)
             let endIndex   = str.index(startIndex, offsetBy: count, limitedBy: str.endIndex) ?? str.endIndex
-            return str[startIndex..<endIndex]
+            return String(str[startIndex..<endIndex])
         }
     }
    


### PR DESCRIPTION
- Failable String initialiser has been obsoleted in swift4.

- Subscripts returning String were obsoleted in Swift 4,
  explicitly construct a String from subscripted result.

Tested on swift 3 and 4.