### PR TITLE
Fix `NSNumber.objCType` crashes, make it returns same values with darwin platform version

### DIFF
--- a/Foundation/NSCFBoolean.swift
+++ b/Foundation/NSCFBoolean.swift
@@ -78,7 +78,7 @@ internal class __NSCFBoolean : NSNumber {
     override var objCType: UnsafePointer<Int8> {
         // This must never be fixed to be "B", although that would
         // cause correct old-style archiving when this is unarchived.
-        return UnsafePointer<Int8>(bitPattern: UInt(_NSSimpleObjCType.Char.rawValue.value))!
+        return String(_NSSimpleObjCType.Char.rawValue)._bridgeToObjectiveC().utf8String!
     }
     
     internal override func _cfNumberType() -> CFNumberType  {

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -458,8 +458,8 @@ private struct JSONWriter {
             throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.propertyListReadCorrupt.rawValue, userInfo: ["NSDebugDescription" : "Number cannot be infinity or NaN"])
         }
         
-        switch num._objCType {
-        case .Bool:
+        switch num._cfTypeID {
+        case CFBooleanGetTypeID():
             serializeBool(num.boolValue)
         default:
             writer(_serializationString(for: num))

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -683,10 +683,10 @@ open class NSKeyedUnarchiver : NSCoder {
     }
     
     open override func decodeBool(forKey key: String) -> Bool {
-        guard let result : NSNumber = _decodeValue(forKey: key) else {
+        guard let result : Bool = _decodeValue(forKey: key) else {
             return false
         }
-        return result.boolValue
+        return result
     }
     
     open override func decodeInt32(forKey key: String) -> Int32 {

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -244,7 +244,7 @@ open class NSNumber : NSValue {
     }
     
     public init(value: UInt8) {
-        _objCType = .UChar
+        _objCType = .Short
         super.init()
         _CFNumberInitUInt8(_cfObject, value)
     }
@@ -256,19 +256,19 @@ open class NSNumber : NSValue {
     }
     
     public init(value: UInt16) {
-        _objCType = .UShort
+        _objCType = .Int
         super.init()
         _CFNumberInitUInt16(_cfObject, value)
     }
     
     public init(value: Int32) {
-        _objCType = .Long
+        _objCType = .Int
         super.init()
         _CFNumberInitInt32(_cfObject, value)
     }
     
     public init(value: UInt32) {
-        _objCType = .ULong
+        _objCType = .LongLong
         super.init()
         _CFNumberInitUInt32(_cfObject, value)
     }
@@ -292,7 +292,7 @@ open class NSNumber : NSValue {
     }
     
     public init(value: UInt64) {
-        _objCType = .ULongLong
+        _objCType = .LongLong
         super.init()
         _CFNumberInitUInt64(_cfObject, value)
     }

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -309,12 +309,6 @@ open class NSNumber : NSValue {
         _CFNumberInitDouble(_cfObject, value)
     }
     
-    public init(value: Bool) {
-        _objCType = .Bool
-        super.init()
-        _CFNumberInitBool(_cfObject, value)
-    }
-
     override internal init() {
         _objCType = .Undef
         super.init()
@@ -611,6 +605,12 @@ open class NSNumber : NSValue {
     }
     
     open override var classForCoder: AnyClass { return NSNumber.self }
+}
+
+extension NSNumber {
+    public convenience init(value: Bool) {
+        self.init(factory: value._bridgeToObjectiveC)
+    }
 }
 
 extension CFNumber : _NSBridgeable {

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -276,7 +276,7 @@ open class NSNumber : NSValue {
     public init(value: Int) {
         #if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
             _objCType = .LongLong
-        #elseif arch(i386) || arch(arm) || arch(powerpc)
+        #elseif arch(i386) || arch(arm)
             _objCType = .Int
         #endif
         super.init()
@@ -287,7 +287,7 @@ open class NSNumber : NSValue {
         #if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
             // When value is lower equal to `Int.max`, it uses '.LongLong' even if using `UInt`
             _objCType = value <= UInt(Int.max) ? .LongLong : .ULongLong
-        #elseif arch(i386) || arch(arm) || arch(powerpc)
+        #elseif arch(i386) || arch(arm)
             _objCType = .LongLong
         #endif
         super.init()

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -230,7 +230,7 @@ open class NSNumber : NSValue {
     }
 
     open override var objCType: UnsafePointer<Int8> {
-        return UnsafePointer<Int8>(bitPattern: UInt(_objCType.rawValue.value))!
+        return String(_objCType.rawValue)._bridgeToObjectiveC().utf8String!
     }
     
     deinit {

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -274,13 +274,22 @@ open class NSNumber : NSValue {
     }
     
     public init(value: Int) {
-        _objCType = .Int
+        #if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+            _objCType = .LongLong
+        #elseif arch(i386) || arch(arm) || arch(powerpc)
+            _objCType = .Int
+        #endif
         super.init()
         _CFNumberInitInt(_cfObject, value)
     }
     
     public init(value: UInt) {
-        _objCType = .UInt
+        #if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+            // When value is lower equal to `Int.max`, it uses '.LongLong' even if using `UInt`
+            _objCType = value <= UInt(Int.max) ? .LongLong : .ULongLong
+        #elseif arch(i386) || arch(arm) || arch(powerpc)
+            _objCType = .LongLong
+        #endif
         super.init()
         _CFNumberInitUInt(_cfObject, value)
     }
@@ -292,7 +301,8 @@ open class NSNumber : NSValue {
     }
     
     public init(value: UInt64) {
-        _objCType = .LongLong
+        // When value is lower equal to `Int64.max`, it uses '.LongLong' even if using `UInt64`
+        _objCType = value <= UInt64(Int64.max) ? .LongLong : .ULongLong
         super.init()
         _CFNumberInitUInt64(_cfObject, value)
     }

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -494,7 +494,24 @@ open class NSNumber : NSValue {
     }
 
     open func compare(_ otherNumber: NSNumber) -> ComparisonResult {
-        return ._fromCF(CFNumberCompare(_cfObject, otherNumber._cfObject, nil))
+        switch (objCType.pointee, otherNumber.objCType.pointee) {
+        case (0x66, _), (_, 0x66), (0x66, 0x66): fallthrough // 'f' float
+        case (0x64, _), (_, 0x64), (0x64, 0x64):             // 'd' double
+            let (lhs, rhs) = (doubleValue, otherNumber.doubleValue)
+            if lhs < rhs { return .orderedAscending }
+            if lhs > rhs { return .orderedDescending }
+            return .orderedSame
+        case (0x51, _), (_, 0x51), (0x51, 0x51):             // 'q' unsigned long long
+            let (lhs, rhs) = (uint64Value, otherNumber.uint64Value)
+            if lhs < rhs { return .orderedAscending }
+            if lhs > rhs { return .orderedDescending }
+            return .orderedSame
+        case (_, _):
+            let (lhs, rhs) = (int64Value, otherNumber.int64Value)
+            if lhs < rhs { return .orderedAscending }
+            if lhs > rhs { return .orderedDescending }
+            return .orderedSame
+        }
     }
 
     open func description(withLocale locale: Locale?) -> String {

--- a/Foundation/NSValue.swift
+++ b/Foundation/NSValue.swift
@@ -154,3 +154,14 @@ open class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
 }
 
+extension NSValue : _Factory {}
+
+protocol _Factory {
+    init(factory: () -> Self)
+}
+
+extension _Factory {
+    init(factory: () -> Self) {
+        self = factory()
+    }
+}

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -21,6 +21,7 @@ class TestNSNumber : XCTestCase {
     static var allTests: [(String, (TestNSNumber) -> () throws -> Void)] {
         return [
             ("test_NumberWithBool", test_NumberWithBool ),
+            ("test_CFBoolean", test_CFBoolean ),
             ("test_numberWithChar", test_numberWithChar ),
             ("test_numberWithUnsignedChar", test_numberWithUnsignedChar ),
             ("test_numberWithShort", test_numberWithShort ),

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -34,6 +34,7 @@ class TestNSNumber : XCTestCase {
             ("test_compareNumberWithDouble", test_compareNumberWithDouble ),
             ("test_description", test_description ),
             ("test_descriptionWithLocale", test_descriptionWithLocale ),
+            ("test_objCType", test_objCType ),
         ]
     }
     
@@ -437,5 +438,23 @@ class TestNSNumber : XCTestCase {
             let receivedDesc = nsnumber.description(withLocale: locale)
             XCTAssertEqual(receivedDesc, expectedDesc, "expected \(expectedDesc) but received \(receivedDesc)")
         }
+    }
+
+    func test_objCType() {
+        let objCType: (NSNumber) -> UnicodeScalar = { number in
+            return UnicodeScalar(UInt8(number.objCType.pointee))
+        }
+
+        XCTAssertEqual(objCType(NSNumber(value: Bool())),   "c") // 0x63
+        XCTAssertEqual(objCType(NSNumber(value: Int8())),   "c") // 0x63
+        XCTAssertEqual(objCType(NSNumber(value: UInt8())),  "s") // 0x73
+        XCTAssertEqual(objCType(NSNumber(value: Int16())),  "s") // 0x73
+        XCTAssertEqual(objCType(NSNumber(value: UInt16())), "i") // 0x69
+        XCTAssertEqual(objCType(NSNumber(value: Int32())),  "i") // 0x69
+        XCTAssertEqual(objCType(NSNumber(value: UInt32())), "q") // 0x71
+        XCTAssertEqual(objCType(NSNumber(value: Int64())),  "q") // 0x71
+        XCTAssertEqual(objCType(NSNumber(value: UInt64())), "q") // 0x71
+        XCTAssertEqual(objCType(NSNumber(value: Float())),  "f") // 0x66
+        XCTAssertEqual(objCType(NSNumber(value: Double())), "d") // 0x64
     }
 }

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -446,16 +446,38 @@ class TestNSNumber : XCTestCase {
             return UnicodeScalar(UInt8(number.objCType.pointee))
         }
 
-        XCTAssertEqual(objCType(NSNumber(value: Bool())),   "c") // 0x63
-        XCTAssertEqual(objCType(NSNumber(value: Int8())),   "c") // 0x63
-        XCTAssertEqual(objCType(NSNumber(value: UInt8())),  "s") // 0x73
-        XCTAssertEqual(objCType(NSNumber(value: Int16())),  "s") // 0x73
-        XCTAssertEqual(objCType(NSNumber(value: UInt16())), "i") // 0x69
-        XCTAssertEqual(objCType(NSNumber(value: Int32())),  "i") // 0x69
-        XCTAssertEqual(objCType(NSNumber(value: UInt32())), "q") // 0x71
-        XCTAssertEqual(objCType(NSNumber(value: Int64())),  "q") // 0x71
-        XCTAssertEqual(objCType(NSNumber(value: UInt64())), "q") // 0x71
-        XCTAssertEqual(objCType(NSNumber(value: Float())),  "f") // 0x66
-        XCTAssertEqual(objCType(NSNumber(value: Double())), "d") // 0x64
+        XCTAssertEqual("c" /* 0x63 */, objCType(NSNumber(value: true)))
+
+        XCTAssertEqual("c" /* 0x63 */, objCType(NSNumber(value: Int8.max)))
+        XCTAssertEqual("s" /* 0x73 */, objCType(NSNumber(value: UInt8(Int8.max))))
+        XCTAssertEqual("s" /* 0x73 */, objCType(NSNumber(value: UInt8(Int8.max) + 1)))
+
+        XCTAssertEqual("s" /* 0x73 */, objCType(NSNumber(value: Int16.max)))
+        XCTAssertEqual("i" /* 0x69 */, objCType(NSNumber(value: UInt16(Int16.max))))
+        XCTAssertEqual("i" /* 0x69 */, objCType(NSNumber(value: UInt16(Int16.max) + 1)))
+
+        XCTAssertEqual("i" /* 0x69 */, objCType(NSNumber(value: Int32.max)))
+        XCTAssertEqual("q" /* 0x71 */, objCType(NSNumber(value: UInt32(Int32.max))))
+        XCTAssertEqual("q" /* 0x71 */, objCType(NSNumber(value: UInt32(Int32.max) + 1)))
+
+        XCTAssertEqual("q" /* 0x71 */, objCType(NSNumber(value: Int64.max)))
+        // When value is lower equal to `Int64.max`, it returns 'q' even if using `UInt64`
+        XCTAssertEqual("q" /* 0x71 */, objCType(NSNumber(value: UInt64(Int64.max))))
+        XCTAssertEqual("Q" /* 0x51 */, objCType(NSNumber(value: UInt64(Int64.max) + 1)))
+
+        // Depends on architectures
+        #if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+            XCTAssertEqual("q" /* 0x71 */, objCType(NSNumber(value: Int.max)))
+            // When value is lower equal to `Int.max`, it returns 'q' even if using `UInt`
+            XCTAssertEqual("q" /* 0x71 */, objCType(NSNumber(value: UInt(Int.max))))
+            XCTAssertEqual("Q" /* 0x51 */, objCType(NSNumber(value: UInt(Int.max) + 1)))
+        #elseif arch(i386) || arch(arm) || arch(powerpc)
+            XCTAssertEqual("i" /* 0x71 */, objCType(NSNumber(value: Int.max)))
+            XCTAssertEqual("q" /* 0x71 */, objCType(NSNumber(value: UInt(Int.max))))
+            XCTAssertEqual("q" /* 0x51 */, objCType(NSNumber(value: UInt(Int.max) + 1)))
+        #endif
+
+        XCTAssertEqual("f" /* 0x66 */, objCType(NSNumber(value: Float.greatestFiniteMagnitude)))
+        XCTAssertEqual("d" /* 0x64 */, objCType(NSNumber(value: Double.greatestFiniteMagnitude)))
     }
 }

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -471,7 +471,7 @@ class TestNSNumber : XCTestCase {
             // When value is lower equal to `Int.max`, it returns 'q' even if using `UInt`
             XCTAssertEqual("q" /* 0x71 */, objCType(NSNumber(value: UInt(Int.max))))
             XCTAssertEqual("Q" /* 0x51 */, objCType(NSNumber(value: UInt(Int.max) + 1)))
-        #elseif arch(i386) || arch(arm) || arch(powerpc)
+        #elseif arch(i386) || arch(arm)
             XCTAssertEqual("i" /* 0x71 */, objCType(NSNumber(value: Int.max)))
             XCTAssertEqual("q" /* 0x71 */, objCType(NSNumber(value: UInt(Int.max))))
             XCTAssertEqual("q" /* 0x51 */, objCType(NSNumber(value: UInt(Int.max) + 1)))

--- a/TestFoundation/TestNSPredicate.swift
+++ b/TestFoundation/TestNSPredicate.swift
@@ -101,6 +101,9 @@ class TestNSPredicate: XCTestCase {
         let predicateA = NSPredicate(value: true)
         let predicateB = NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: predicateA)) as! NSPredicate
         XCTAssertEqual(predicateA, predicateB, "Archived then unarchived uuid must be equal.")
+        let predicateC = NSPredicate(value: false)
+        let predicateD = NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: predicateC)) as! NSPredicate
+        XCTAssertEqual(predicateC, predicateD, "Archived then unarchived uuid must be equal.")
     }
     
     func test_copy() {


### PR DESCRIPTION
### Fixes [SR-4907](https://bugs.swift.org/browse/SR-4907)
- Add `TestNSNumber.test_objCType()` reproducing crash
  Expected results are sampled from macOS
- Fix crash on accessing `objCType` property of `NSNumber`  

### Change `NSNumber.objCType` to returning same values with darwin platform version
- Change `NSNumber.objCType` to returning same values with darwin
- Change `NSNumber.init(value: Bool)` to returning `__NSCFBoolean` by using `_Factory` protocol

Since `NSNumber.objCType` returns `c` with both of `Bool` and `Int8` on darwin platform, `NSNumber.init(value: Bool)` is changed to returns `__NSCFBoolean` by using `_Factory` protocol, and it changed to use `_cfTypeID` to distinguish between Bool and Int8.

- Change `JSONSerialization` to use `_cfTypeID` for checking whether `NSNumber` is Boolean or not
- Change `NSNumber.compare(_:)` to use `objCType`
- Add missing entry to `TestNumber.allTests`
- Fix `NSKeyedUnarchiver.decodeBool(forKey:)` and add test to `TestNSPredicate.test_NSCoding()`
