### PR TITLE
Fix build on ARM: Undefined NativeType

### DIFF
--- a/Foundation/CGFloat.swift
+++ b/Foundation/CGFloat.swift
@@ -9,7 +9,7 @@
 
 @_fixed_layout
 public struct CGFloat {
-#if arch(i386) || arch(arm) || arch(powerpc)
+#if arch(i386) || arch(arm)
     /// The native type used to store the CGFloat, which is Float on
     /// 32-bit architectures and Double on 64-bit architectures.
     public typealias NativeType = Float
@@ -183,7 +183,7 @@ extension CGFloat : BinaryFloatingPoint {
 
     @_transparent
     public init(bitPattern: UInt) {
-#if arch(i386) || arch(arm) || arch(powerpc)
+#if arch(i386) || arch(arm)
         native = NativeType(bitPattern: UInt32(bitPattern))
 #elseif arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
         native = NativeType(bitPattern: UInt64(bitPattern))


### PR DESCRIPTION
It looks like that `arch(powerpc)` is not available anymore (and it's never used in swift or any other repository).
Using it in the first of these two conditionals was breaking the build (swift-4.0-branch, this is not an issue when compiling swift-3.1.1-RELEASE) on ARM because NativeType was never being defined.

I've verified that *powerpc* is not available also with the Swift 3.1.1 build shipped with Xcode on macOS with this simple example:

```swift
#if arch(powerpc)
      print("test")
#endif
```
This is the output of swiftc:

```
ppc.swift:1:10: warning: unknown architecture for build configuration 'arch'
#if arch(powerpc)
         ^
ppc.swift:1:10: note: did you mean 'powerpc64'?
#if arch(powerpc)
         ^~~~~~~
         powerpc64
```

I wonder why this wasn't a problem for other platforms.