### PR TITLE
Reapply "Update for AnyObject nukage"

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1008,9 +1008,9 @@ void __CFInitialize(void) {
         
 #ifndef __CFSwiftGetBaseClass
 #if TARGET_OS_LINUX
-#define __CFSwiftGetBaseClass _T010Foundation21__CFSwiftGetBaseClasss9AnyObject_pXpyF
+#define __CFSwiftGetBaseClass _T010Foundation21__CFSwiftGetBaseClassyXlXpyF
 #elif TARGET_OS_MAC
-#define __CFSwiftGetBaseClass _T015SwiftFoundation21__CFSwiftGetBaseClasss9AnyObject_pXpyF
+#define __CFSwiftGetBaseClass _T015SwiftFoundation21__CFSwiftGetBaseClassyXlXpyF
 #endif
 #endif
         extern uintptr_t __CFSwiftGetBaseClass();


### PR DESCRIPTION
Reverts apple/swift-corelibs-foundation#976

After the rebranch of swift-4.0-branch from master, we need this update.