### PR TITLE
Fix some more warnings

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -882,8 +882,10 @@ extension NSString {
         if type(of: self) == NSString.self || type(of: self) == NSMutableString.self {
             if _storage._core.isASCII {
                 used = min(self.length, maxBufferCount - 1)
-                buffer.moveAssign(from: unsafeBitCast(_storage._core.startASCII, to: UnsafeMutablePointer<Int8>.self)
-                    , count: used)
+                _storage._core.startASCII.withMemoryRebound(to: Int8.self,
+                                                            capacity: used) {
+                    buffer.moveAssign(from: $0, count: used)
+                }
                 buffer.advanced(by: used).initialize(to: 0)
                 return true
             }

--- a/Foundation/NSURLSession/http/HTTPBodySource.swift
+++ b/Foundation/NSURLSession/http/HTTPBodySource.swift
@@ -23,10 +23,9 @@ import Dispatch
 /// Turn `NSData` into `dispatch_data_t`
 internal func createDispatchData(_ data: Data) -> DispatchData {
     //TODO: Avoid copying data
-    let count = data.count
-    return data.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> DispatchData in    
-               return DispatchData(bytes: UnsafeBufferPointer<UInt8>(start: ptr, count: count)) 
-           }
+    let buffer = UnsafeRawBufferPointer(start: data._backing.bytes,
+                                        count: data.count)
+    return DispatchData(bytes: buffer)
 }
 
 /// Copy data from `dispatch_data_t` into memory pointed to by an `UnsafeMutableBufferPointer`.


### PR DESCRIPTION
Remove more uses of unsafeBitCast()

- NSXMLParser.swift: Remove all calls to strlen() except for a
  single use in UTF8String().

- Replace _colonSeparatedStringFromPrefixAndSuffix() with direct
  string construction.

- Replace a call to strncpy() with String._fromCodeUnitSequence()
  to simplify extracting a non-null terminated string from a
  buffer.

swift4: DispatchData(bytes:) is deprecated

- Use init(bytes: UnsafeRawBufferPointer) instead.

Tested on Linux and macOS