### PR TITLE
[build.py] Change the option of rsync to the same one used in other projects

### DIFF
--- a/build.py
+++ b/build.py
@@ -523,7 +523,7 @@ rule InstallFoundation
     cp "${BUILD_DIR}/Foundation/Foundation.swiftmodule" "${DSTROOT}/${PREFIX}/lib/swift/${OS}/${ARCH}/"; $
     cp "${BUILD_DIR}/Foundation/Foundation.swiftdoc" "${DSTROOT}/${PREFIX}/lib/swift/${OS}/${ARCH}/"; $
     mkdir -p "${DSTROOT}/${PREFIX}/local/include"; $
-    rsync -r "${BUILD_DIR}/Foundation/${PREFIX}/lib/swift/CoreFoundation" "${DSTROOT}/${PREFIX}/lib/swift/"
+    rsync -a "${BUILD_DIR}/Foundation/${PREFIX}/lib/swift/CoreFoundation" "${DSTROOT}/${PREFIX}/lib/swift/"
 
 build ${BUILD_DIR}/.install: InstallFoundation ${BUILD_DIR}/Foundation/${DYLIB_PREFIX}Foundation${DYLIB_SUFFIX}
 


### PR DESCRIPTION
This may fix the bad permission of CoreFoundation on Linux.
https://bugs.swift.org/browse/SR-2783
https://bugs.swift.org/browse/SR-2929
https://bugs.swift.org/browse/SR-4423

Even if this won't fix, this is harmless.