### PR TITLE
Add fast paths for Data initialization for common sequences

### DIFF
--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -1058,6 +1058,43 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
 
     }
     
+    // slightly faster paths for common sequences
+    
+    public init<S: Sequence>(_ elements: S) where S.Iterator.Element == UInt8 {
+        let underestimatedCount = elements.underestimatedCount
+        self.init(count: underestimatedCount)
+        var idx = 0
+        for byte in elements {
+            if idx < underestimatedCount {
+                self[idx] = byte
+            } else {
+                self.append(byte)
+            }
+            idx += 1
+        }
+    }
+    
+    public init(_ bytes: Array<UInt8>) {
+        self.init(bytes: bytes)
+    }
+    
+    public init(_ bytes: ArraySlice<UInt8>) {
+        self.init(bytes: bytes)
+    }
+    
+    public init(_ buffer: UnsafeBufferPointer<UInt8>) {
+        self.init(buffer: buffer)
+    }
+    
+    public init(_ buffer: UnsafeMutableBufferPointer<UInt8>) {
+        self.init(buffer: buffer)
+    }
+    
+    public init(_ data: Data) {
+        _sliceRange = 0..<data.count
+        _backing = data._backing.mutableCopy(data._sliceRange)
+    }
+    
     @_versioned
     internal init(backing: _DataStorage, range: Range<Index>) {
         _backing = backing


### PR DESCRIPTION
There were some unfortunate slower than expected initializers on Data that were inherited from Collection adoption. This allows Data initialization to take the fast path in a select group of initializations; previously it would create a Data and then iterate byte by byte appending. Albeit that was relatively quick, we have faster options available.