### PR TITLE
Better namespace support for XML

### DIFF
--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -362,7 +362,7 @@ _CFXMLNodePtr _CFXMLNewProperty(_CFXMLNodePtr node, const unsigned char* name, c
     return xmlNewProp(node, name, value);
 }
 
-CF_RETURNS_RETAINED CFStringRef _CFXMLNodeURI(_CFXMLNodePtr node) {
+CFStringRef _CFXMLNodeCopyURI(_CFXMLNodePtr node) {
     xmlNodePtr nodePtr = (xmlNodePtr)node;
     switch (nodePtr->type) {
         case XML_ATTRIBUTE_NODE:
@@ -469,7 +469,7 @@ static inline xmlChar* _getQName(xmlNodePtr node) {
     return xmlBuildQName(ncname, prefix, NULL, 0);
 }
 
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNodeGetName(_CFXMLNodePtr node) {
+CFStringRef _Nullable _CFXMLNodeCopyName(_CFXMLNodePtr node) {
     xmlNodePtr xmlNode = (xmlNodePtr)node;
     
     xmlChar* qName = _getQName(xmlNode);
@@ -489,7 +489,7 @@ void _CFXMLNodeSetName(_CFXMLNodePtr node, const char* name) {
     xmlNodeSetName(node, (const xmlChar*)name);
 }
 
-CFStringRef _CFXMLNodeGetContent(_CFXMLNodePtr node) {
+CFStringRef _CFXMLNodeCopyContent(_CFXMLNodePtr node) {
     switch (((xmlNodePtr)node)->type) {
         case XML_ELEMENT_DECL:
         {
@@ -681,7 +681,7 @@ void _CFXMLDocSetRootElement(_CFXMLDocPtr doc, _CFXMLNodePtr node) {
     xmlDocSetRootElement(doc, node);
 }
 
-CF_RETURNS_RETAINED CFStringRef _CFXMLDocCharacterEncoding(_CFXMLDocPtr doc) {
+CFStringRef _CFXMLDocCopyCharacterEncoding(_CFXMLDocPtr doc) {
     return CFStringCreateWithCString(NULL, (const char*)((xmlDocPtr)doc)->encoding, kCFStringEncodingUTF8);
 }
 
@@ -695,7 +695,7 @@ void _CFXMLDocSetCharacterEncoding(_CFXMLDocPtr doc,  const unsigned char* _Null
     docPtr->encoding = xmlStrdup(encoding);
 }
 
-CF_RETURNS_RETAINED CFStringRef _CFXMLDocVersion(_CFXMLDocPtr doc) {
+CFStringRef _CFXMLDocCopyVersion(_CFXMLDocPtr doc) {
     return CFStringCreateWithCString(NULL, (const char*)((xmlDocPtr)doc)->version, kCFStringEncodingUTF8);
 }
 
@@ -782,7 +782,7 @@ _CFXMLEntityPtr _CFXMLGetParameterEntity(_CFXMLDocPtr doc, const char* entity) {
     return xmlGetParameterEntity(doc, (const xmlChar*)entity);
 }
 
-CFStringRef _CFXMLGetEntityContent(_CFXMLEntityPtr entity) {
+CFStringRef _CFXMLCopyEntityContent(_CFXMLEntityPtr entity) {
     const xmlChar* content = ((xmlEntityPtr)entity)->content;
     if (!content) {
         return NULL;
@@ -794,7 +794,7 @@ CFStringRef _CFXMLGetEntityContent(_CFXMLEntityPtr entity) {
     return result;
 }
 
-CFStringRef _CFXMLStringWithOptions(_CFXMLNodePtr node, uint32_t options) {
+CFStringRef _CFXMLCopyStringWithOptions(_CFXMLNodePtr node, uint32_t options) {
     if (((xmlNodePtr)node)->type == XML_ENTITY_DECL &&
         ((xmlEntityPtr)node)->etype == XML_INTERNAL_PREDEFINED_ENTITY) {
         // predefined entities need special handling, libxml2 just tosses an error and returns a NULL string
@@ -866,7 +866,7 @@ CFStringRef _CFXMLStringWithOptions(_CFXMLNodePtr node, uint32_t options) {
     return result;
 }
 
-CF_RETURNS_RETAINED CFArrayRef _CFXMLNodesForXPath(_CFXMLNodePtr node, const unsigned char* xpath) {
+CFArrayRef _CFXMLNodesForXPath(_CFXMLNodePtr node, const unsigned char* xpath) {
 
     if (((xmlNodePtr)node)->doc == NULL) {
         return NULL;
@@ -899,7 +899,7 @@ CF_RETURNS_RETAINED CFArrayRef _CFXMLNodesForXPath(_CFXMLNodePtr node, const uns
     return results;
 }
 
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLPathForNode(_CFXMLNodePtr node) {
+CFStringRef _Nullable _CFXMLCopyPathForNode(_CFXMLNodePtr node) {
     xmlChar* path = xmlGetNodePath(node);
     CFStringRef result = CFStringCreateWithCString(NULL, (const char*)path, kCFStringEncodingUTF8);
     xmlFree(path);
@@ -933,7 +933,7 @@ _CFXMLDocPtr _CFXMLDocPtrFromDataWithOptions(CFDataRef data, int options) {
     return xmlReadMemory((const char*)CFDataGetBytePtr(data), CFDataGetLength(data), NULL, NULL, xmlOptions);
 }
 
-CF_RETURNS_RETAINED CFStringRef _CFXMLNodeLocalName(_CFXMLNodePtr node) {
+CFStringRef _CFXMLNodeCopyLocalName(_CFXMLNodePtr node) {
     xmlChar* prefix = NULL;
     const xmlChar* result = xmlSplitQName2(_getQName((xmlNodePtr)node), &prefix);
     if (result == NULL) {
@@ -943,7 +943,7 @@ CF_RETURNS_RETAINED CFStringRef _CFXMLNodeLocalName(_CFXMLNodePtr node) {
     return CFStringCreateWithCString(NULL, (const char*)result, kCFStringEncodingUTF8);
 }
 
-CF_RETURNS_RETAINED CFStringRef _CFXMLNodePrefix(_CFXMLNodePtr node) {
+CFStringRef _CFXMLNodeCopyPrefix(_CFXMLNodePtr node) {
     xmlChar* result = NULL;
     xmlChar* unused = xmlSplitQName2(_getQName((xmlNodePtr)node), &result);
 
@@ -1040,7 +1040,7 @@ _CFXMLDTDPtr _Nullable _CFXMLParseDTDFromData(CFDataRef data, CFErrorRef _Nullab
     return dtd;
 }
 
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDExternalID(_CFXMLDTDPtr dtd) {
+CFStringRef _Nullable _CFXMLDTDCopyExternalID(_CFXMLDTDPtr dtd) {
     const unsigned char* externalID = ((xmlDtdPtr)dtd)->ExternalID;
     if (externalID) {
         return CFStringCreateWithCString(NULL, (const char*)externalID, kCFStringEncodingUTF8);
@@ -1065,7 +1065,7 @@ void _CFXMLDTDSetExternalID(_CFXMLDTDPtr dtd, const unsigned char* externalID) {
     dtdPtr->ExternalID = xmlStrdup(externalID);
 }
 
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDSystemID(_CFXMLDTDPtr dtd) {
+CFStringRef _Nullable _CFXMLDTDCopySystemID(_CFXMLDTDPtr dtd) {
     const unsigned char* systemID = ((xmlDtdPtr)dtd)->SystemID;
     if (systemID) {
         return CFStringCreateWithCString(NULL, (const char*)systemID, kCFStringEncodingUTF8);
@@ -1152,7 +1152,7 @@ CFIndex _CFXMLDTDAttributeNodeGetType(_CFXMLDTDNodePtr node) {
     return ((xmlAttributePtr)node)->atype;
 }
 
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDNodeGetSystemID(_CFXMLDTDNodePtr node) {
+CFStringRef _Nullable _CFXMLDTDNodeCopySystemID(_CFXMLDTDNodePtr node) {
     switch (((xmlNodePtr)node)->type) {
         case XML_ENTITY_DECL:
             return CFStringCreateWithCString(NULL, (const char*)((xmlEntityPtr)node)->SystemID, kCFStringEncodingUTF8);
@@ -1194,7 +1194,7 @@ void _CFXMLDTDNodeSetSystemID(_CFXMLDTDNodePtr node, const unsigned char* system
     }
 }
 
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDNodeGetPublicID(_CFXMLDTDNodePtr node) {
+CFStringRef _Nullable _CFXMLDTDNodeCopyPublicID(_CFXMLDTDNodePtr node) {
     switch (((xmlNodePtr)node)->type) {
         case XML_ENTITY_DECL:
             return CFStringCreateWithCString(NULL, (const char*)((xmlEntityPtr)node)->ExternalID, kCFStringEncodingUTF8);
@@ -1237,7 +1237,7 @@ void _CFXMLDTDNodeSetPublicID(_CFXMLDTDNodePtr node, const unsigned char* public
 }
 
 // Namespaces
-CF_RETURNS_RETAINED _CFXMLNodePtr _Nonnull * _Nullable _CFXMLNamespaces(_CFXMLNodePtr node, CFIndex* count) {
+_CFXMLNodePtr _Nonnull * _Nullable _CFXMLNamespaces(_CFXMLNodePtr node, CFIndex* count) {
     *count = 0;
     xmlNs* ns = ((xmlNode*)node)->ns;
     while (ns != NULL) {
@@ -1282,7 +1282,7 @@ void _CFXMLSetNamespaces(_CFXMLNodePtr node, _CFXMLNodePtr* _Nullable nodes, CFI
     }
 }
 
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNamespaceGetValue(_CFXMLNodePtr node) {
+CFStringRef _Nullable _CFXMLNamespaceCopyValue(_CFXMLNodePtr node) {
     xmlNsPtr ns = ((xmlNode*)node)->ns;
     
     if (ns->href == NULL) {
@@ -1297,7 +1297,7 @@ void _CFXMLNamespaceSetValue(_CFXMLNodePtr node, const char* value, int64_t leng
     ns->href = xmlStrndup((const xmlChar*)value, length);
 }
 
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNamespaceGetPrefix(_CFXMLNodePtr node) {
+CFStringRef _Nullable _CFXMLNamespaceCopyPrefix(_CFXMLNodePtr node) {
     xmlNsPtr ns = ((xmlNodePtr)node)->ns;
     
     if (ns->prefix == NULL) {

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.h
@@ -234,7 +234,7 @@ CFStringRef _Nullable _CFXMLDTDNodeCopyPublicID(_CFXMLDTDNodePtr node);
 void _CFXMLDTDNodeSetPublicID(_CFXMLDTDNodePtr node, const unsigned char* _Nullable publicID);
 
 // Namespaces
-CF_RETURNS_RETAINED _CFXMLNodePtr _Nonnull * _Nullable _CFXMLNamespaces(_CFXMLNodePtr node, CFIndex* count);
+_CFXMLNodePtr _Nonnull * _Nullable _CFXMLNamespaces(_CFXMLNodePtr node, CFIndex* count);
 void _CFXMLSetNamespaces(_CFXMLNodePtr node, _CFXMLNodePtr _Nonnull * _Nullable nodes, CFIndex count);
 CFStringRef _Nullable _CFXMLNamespaceCopyValue(_CFXMLNodePtr node);
 void _CFXMLNamespaceSetValue(_CFXMLNodePtr node, const char* _Nullable value, int64_t length);

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.h
@@ -146,16 +146,16 @@ _CFXMLNodePtr _CFXMLNewTextNode(const unsigned char* value);
 _CFXMLNodePtr _CFXMLNewComment(const unsigned char* value);
 _CFXMLNodePtr _CFXMLNewProperty(_CFXMLNodePtr _Nullable node, const unsigned char* name, const unsigned char* value);
 
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNodeURI(_CFXMLNodePtr node);
+CFStringRef _Nullable _CFXMLNodeCopyURI(_CFXMLNodePtr node);
 void _CFXMLNodeSetURI(_CFXMLNodePtr node, const unsigned char* _Nullable URI);
 
 void _CFXMLNodeSetPrivateData(_CFXMLNodePtr node, void* data);
 void* _Nullable  _CFXMLNodeGetPrivateData(_CFXMLNodePtr node);
 _CFXMLNodePtr _Nullable _CFXMLNodeProperties(_CFXMLNodePtr node);
 CFIndex _CFXMLNodeGetType(_CFXMLNodePtr node);
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNodeGetName(_CFXMLNodePtr node);
+CFStringRef _Nullable _CFXMLNodeCopyName(_CFXMLNodePtr node);
 void _CFXMLNodeSetName(_CFXMLNodePtr node, const char* name);
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNodeGetContent(_CFXMLNodePtr node);
+CFStringRef _Nullable _CFXMLNodeCopyContent(_CFXMLNodePtr node);
 void _CFXMLNodeSetContent(_CFXMLNodePtr node,  const unsigned char* _Nullable content);
 void _CFXMLUnlinkNode(_CFXMLNodePtr node);
 
@@ -176,9 +176,9 @@ bool _CFXMLDocStandalone(_CFXMLDocPtr doc);
 void _CFXMLDocSetStandalone(_CFXMLDocPtr doc, bool standalone);
 _CFXMLNodePtr _Nullable _CFXMLDocRootElement(_CFXMLDocPtr doc);
 void _CFXMLDocSetRootElement(_CFXMLDocPtr doc, _CFXMLNodePtr node);
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDocCharacterEncoding(_CFXMLDocPtr doc);
+CFStringRef _Nullable _CFXMLDocCopyCharacterEncoding(_CFXMLDocPtr doc);
 void _CFXMLDocSetCharacterEncoding(_CFXMLDocPtr doc,  const unsigned char* _Nullable  encoding);
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDocVersion(_CFXMLDocPtr doc);
+CFStringRef _Nullable _CFXMLDocCopyVersion(_CFXMLDocPtr doc);
 void _CFXMLDocSetVersion(_CFXMLDocPtr doc, const unsigned char* _Nullable version);
 int _CFXMLDocProperties(_CFXMLDocPtr doc);
 void _CFXMLDocSetProperties(_CFXMLDocPtr doc, int newProperties);
@@ -190,19 +190,19 @@ _CFXMLEntityPtr _Nullable _CFXMLGetDocEntity(_CFXMLDocPtr doc, const char* entit
 _CFXMLEntityPtr _Nullable _CFXMLGetDTDEntity(_CFXMLDocPtr doc, const char* entity);
 _CFXMLEntityPtr _Nullable _CFXMLGetParameterEntity(_CFXMLDocPtr doc, const char* entity);
 
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLGetEntityContent(_CFXMLEntityPtr entity);
+CFStringRef _Nullable _CFXMLCopyEntityContent(_CFXMLEntityPtr entity);
 
-CF_RETURNS_RETAINED CFStringRef _CFXMLStringWithOptions(_CFXMLNodePtr node, uint32_t options);
+CFStringRef _CFXMLCopyStringWithOptions(_CFXMLNodePtr node, uint32_t options);
 
 CF_RETURNS_RETAINED CFArrayRef _Nullable _CFXMLNodesForXPath(_CFXMLNodePtr node, const unsigned char* xpath);
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLPathForNode(_CFXMLNodePtr node);
+CFStringRef _Nullable _CFXMLCopyPathForNode(_CFXMLNodePtr node);
 
 _CFXMLNodePtr _Nullable _CFXMLNodeHasProp(_CFXMLNodePtr node, const char* propertyName);
 
 _CFXMLDocPtr _CFXMLDocPtrFromDataWithOptions(CFDataRef data, int options);
 
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNodeLocalName(_CFXMLNodePtr node);
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNodePrefix(_CFXMLNodePtr node);
+CFStringRef _Nullable _CFXMLNodeCopyLocalName(_CFXMLNodePtr node);
+CFStringRef _Nullable _CFXMLNodeCopyPrefix(_CFXMLNodePtr node);
 
 bool _CFXMLDocValidate(_CFXMLDocPtr doc, CFErrorRef _Nullable * error);
 
@@ -210,9 +210,9 @@ _CFXMLDTDPtr _CFXMLNewDTD(_CFXMLDocPtr _Nullable doc, const unsigned char* name,
 _CFXMLDTDNodePtr _Nullable _CFXMLParseDTDNode(const unsigned char* xmlString);
 _CFXMLDTDPtr _Nullable _CFXMLParseDTD(const unsigned char* URL);
 _CFXMLDTDPtr _Nullable _CFXMLParseDTDFromData(CFDataRef data, CFErrorRef _Nullable * error);
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDExternalID(_CFXMLDTDPtr dtd);
+CFStringRef _Nullable _CFXMLDTDCopyExternalID(_CFXMLDTDPtr dtd);
 void _CFXMLDTDSetExternalID(_CFXMLDTDPtr dtd, const unsigned char* _Nullable externalID);
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDSystemID(_CFXMLDTDPtr dtd);
+CFStringRef _Nullable _CFXMLDTDCopySystemID(_CFXMLDTDPtr dtd);
 void _CFXMLDTDSetSystemID(_CFXMLDTDPtr dtd, const unsigned char* _Nullable systemID);
 
 _CFXMLDTDNodePtr _Nullable _CFXMLDTDGetElementDesc(_CFXMLDTDPtr dtd, const unsigned char* name);
@@ -228,17 +228,17 @@ CFIndex _CFXMLDTDElementNodeGetType(_CFXMLDTDNodePtr node);
 CFIndex _CFXMLDTDEntityNodeGetType(_CFXMLDTDNodePtr node);
 CFIndex _CFXMLDTDAttributeNodeGetType(_CFXMLDTDNodePtr node);
 
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDNodeGetSystemID(_CFXMLDTDNodePtr node);
+CFStringRef _Nullable _CFXMLDTDNodeCopySystemID(_CFXMLDTDNodePtr node);
 void _CFXMLDTDNodeSetSystemID(_CFXMLDTDNodePtr node, const unsigned char* _Nullable systemID);
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDNodeGetPublicID(_CFXMLDTDNodePtr node);
+CFStringRef _Nullable _CFXMLDTDNodeCopyPublicID(_CFXMLDTDNodePtr node);
 void _CFXMLDTDNodeSetPublicID(_CFXMLDTDNodePtr node, const unsigned char* _Nullable publicID);
 
 // Namespaces
 CF_RETURNS_RETAINED _CFXMLNodePtr _Nonnull * _Nullable _CFXMLNamespaces(_CFXMLNodePtr node, CFIndex* count);
 void _CFXMLSetNamespaces(_CFXMLNodePtr node, _CFXMLNodePtr _Nonnull * _Nullable nodes, CFIndex count);
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNamespaceGetValue(_CFXMLNodePtr node);
+CFStringRef _Nullable _CFXMLNamespaceCopyValue(_CFXMLNodePtr node);
 void _CFXMLNamespaceSetValue(_CFXMLNodePtr node, const char* _Nullable value, int64_t length);
-CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNamespaceGetPrefix(_CFXMLNodePtr node);
+CFStringRef _Nullable _CFXMLNamespaceCopyPrefix(_CFXMLNodePtr node);
 void _CFXMLNamespaceSetPrefix(_CFXMLNodePtr node, const char* _Nullable prefix, int64_t length);
 _CFXMLNodePtr _CFXMLNewNamespace(const char* name, const char* stringValue);
 void _CFXMLAddNamespace(_CFXMLNodePtr node, _CFXMLNodePtr nsNode);

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.h
@@ -55,6 +55,7 @@ extern CFIndex _kCFXMLTypeElement;
 extern CFIndex _kCFXMLTypeAttribute;
 extern CFIndex _kCFXMLTypeDTD;
 extern CFIndex _kCFXMLDocTypeHTML;
+extern CFIndex _kCFXMLTypeNamespace;
 
 extern CFIndex _kCFXMLDTDNodeTypeEntity;
 extern CFIndex _kCFXMLDTDNodeTypeAttribute;
@@ -144,7 +145,6 @@ _CFXMLNodePtr _CFXMLNewProcessingInstruction(const unsigned char* name, const un
 _CFXMLNodePtr _CFXMLNewTextNode(const unsigned char* value);
 _CFXMLNodePtr _CFXMLNewComment(const unsigned char* value);
 _CFXMLNodePtr _CFXMLNewProperty(_CFXMLNodePtr _Nullable node, const unsigned char* name, const unsigned char* value);
-_CFXMLNamespacePtr _CFXMLNewNamespace(_CFXMLNodePtr _Nullable node, const unsigned char* uri, const unsigned char* prefix);
 
 CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNodeURI(_CFXMLNodePtr node);
 void _CFXMLNodeSetURI(_CFXMLNodePtr node, const unsigned char* _Nullable URI);
@@ -153,7 +153,7 @@ void _CFXMLNodeSetPrivateData(_CFXMLNodePtr node, void* data);
 void* _Nullable  _CFXMLNodeGetPrivateData(_CFXMLNodePtr node);
 _CFXMLNodePtr _Nullable _CFXMLNodeProperties(_CFXMLNodePtr node);
 CFIndex _CFXMLNodeGetType(_CFXMLNodePtr node);
-const char* _Nullable _CFXMLNodeGetName(_CFXMLNodePtr node);
+CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNodeGetName(_CFXMLNodePtr node);
 void _CFXMLNodeSetName(_CFXMLNodePtr node, const char* name);
 CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNodeGetContent(_CFXMLNodePtr node);
 void _CFXMLNodeSetContent(_CFXMLNodePtr node,  const unsigned char* _Nullable content);
@@ -195,8 +195,9 @@ CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLGetEntityContent(_CFXMLEntityPtr
 CF_RETURNS_RETAINED CFStringRef _CFXMLStringWithOptions(_CFXMLNodePtr node, uint32_t options);
 
 CF_RETURNS_RETAINED CFArrayRef _Nullable _CFXMLNodesForXPath(_CFXMLNodePtr node, const unsigned char* xpath);
+CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLPathForNode(_CFXMLNodePtr node);
 
-_CFXMLNodePtr _Nullable _CFXMLNodeHasProp(_CFXMLNodePtr node, const unsigned char* propertyName);
+_CFXMLNodePtr _Nullable _CFXMLNodeHasProp(_CFXMLNodePtr node, const char* propertyName);
 
 _CFXMLDocPtr _CFXMLDocPtrFromDataWithOptions(CFDataRef data, int options);
 
@@ -231,6 +232,17 @@ CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDNodeGetSystemID(_CFXMLDTDNode
 void _CFXMLDTDNodeSetSystemID(_CFXMLDTDNodePtr node, const unsigned char* _Nullable systemID);
 CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLDTDNodeGetPublicID(_CFXMLDTDNodePtr node);
 void _CFXMLDTDNodeSetPublicID(_CFXMLDTDNodePtr node, const unsigned char* _Nullable publicID);
+
+// Namespaces
+CF_RETURNS_RETAINED _CFXMLNodePtr _Nonnull * _Nullable _CFXMLNamespaces(_CFXMLNodePtr node, CFIndex* count);
+void _CFXMLSetNamespaces(_CFXMLNodePtr node, _CFXMLNodePtr _Nonnull * _Nullable nodes, CFIndex count);
+CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNamespaceGetValue(_CFXMLNodePtr node);
+void _CFXMLNamespaceSetValue(_CFXMLNodePtr node, const char* _Nullable value, int64_t length);
+CF_RETURNS_RETAINED CFStringRef _Nullable _CFXMLNamespaceGetPrefix(_CFXMLNodePtr node);
+void _CFXMLNamespaceSetPrefix(_CFXMLNodePtr node, const char* _Nullable prefix, int64_t length);
+_CFXMLNodePtr _CFXMLNewNamespace(const char* name, const char* stringValue);
+void _CFXMLAddNamespace(_CFXMLNodePtr node, _CFXMLNodePtr nsNode);
+void _CFXMLRemoveNamespace(_CFXMLNodePtr node, const char* prefix);
 
 void _CFXMLFreeNode(_CFXMLNodePtr node);
 void _CFXMLFreeDocument(_CFXMLDocPtr doc);

--- a/Foundation.xcodeproj/xcshareddata/xcschemes/TestFoundation.xcscheme
+++ b/Foundation.xcodeproj/xcshareddata/xcschemes/TestFoundation.xcscheme
@@ -85,8 +85,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Foundation.xcodeproj/xcshareddata/xcschemes/TestFoundation.xcscheme
+++ b/Foundation.xcodeproj/xcshareddata/xcschemes/TestFoundation.xcscheme
@@ -85,8 +85,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Foundation/NSXMLDTD.swift
+++ b/Foundation/NSXMLDTD.swift
@@ -52,7 +52,7 @@ open class XMLDTD : XMLNode {
     */
     open var publicID: String? {
         get {
-            return _CFXMLDTDExternalID(_xmlDTD)?._swiftObject
+            return _CFXMLDTDCopyExternalID(_xmlDTD)?._swiftObject
         }
 
         set {
@@ -70,7 +70,7 @@ open class XMLDTD : XMLNode {
     */
     open var systemID: String? {
         get {
-            return _CFXMLDTDSystemID(_xmlDTD)?._swiftObject
+            return _CFXMLDTDCopySystemID(_xmlDTD)?._swiftObject
         }
 
         set {

--- a/Foundation/NSXMLDTDNode.swift
+++ b/Foundation/NSXMLDTDNode.swift
@@ -200,7 +200,7 @@ open class XMLDTDNode: XMLNode {
     */
     open var publicID: String? {
         get {
-            return _CFXMLDTDNodeGetPublicID(_xmlNode)?._swiftObject
+            return _CFXMLDTDNodeCopyPublicID(_xmlNode)?._swiftObject
         }
         set {
             if let value = newValue {
@@ -217,7 +217,7 @@ open class XMLDTDNode: XMLNode {
     */
     open var systemID: String? {
         get {
-            return _CFXMLDTDNodeGetSystemID(_xmlNode)?._swiftObject
+            return _CFXMLDTDNodeCopySystemID(_xmlNode)?._swiftObject
         }
         set {
             if let value = newValue {
@@ -238,7 +238,7 @@ open class XMLDTDNode: XMLNode {
                 return nil
             }
 
-            return _CFXMLGetEntityContent(_xmlNode)?._swiftObject
+            return _CFXMLCopyEntityContent(_xmlNode)?._swiftObject
         }
         set {
             guard dtdKind == .unparsed else {

--- a/Foundation/NSXMLDocument.swift
+++ b/Foundation/NSXMLDocument.swift
@@ -124,7 +124,7 @@ open class XMLDocument : XMLNode {
     */
     open var characterEncoding: String? {
         get {
-            return _CFXMLDocCharacterEncoding(_xmlDoc)?._swiftObject
+            return _CFXMLDocCopyCharacterEncoding(_xmlDoc)?._swiftObject
         }
         set {
             if let value = newValue {
@@ -141,7 +141,7 @@ open class XMLDocument : XMLNode {
     */
     open var version: String? {
         get {
-            return _CFXMLDocVersion(_xmlDoc)?._swiftObject
+            return _CFXMLDocCopyVersion(_xmlDoc)?._swiftObject
         }
         set {
             if let value = newValue {

--- a/Foundation/NSXMLElement.swift
+++ b/Foundation/NSXMLElement.swift
@@ -52,7 +52,7 @@ open class XMLElement: XMLNode {
     public convenience init(xmlString string: String) throws {
         // If we prepend the XML line to the string
         let docString = """
-        <?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>\(string)
+        <?xml version="1.0" encoding="utf-8" standalone="yes"?>\(string)
         """
         // we can use the document string parser to get the element
         let doc = try XMLDocument(xmlString: docString, options: [])
@@ -85,7 +85,7 @@ open class XMLElement: XMLNode {
         @abstract Adds an attribute. Attributes with duplicate names are not added.
     */
     open func addAttribute(_ attribute: XMLNode) {
-        guard let name = _CFXMLNodeGetName(attribute._xmlNode)?._swiftObject else {
+        guard let name = _CFXMLNodeCopyName(attribute._xmlNode)?._swiftObject else {
             fatalError("Attributes must have a name!")
         }
 

--- a/Foundation/NSXMLNode.swift
+++ b/Foundation/NSXMLNode.swift
@@ -705,7 +705,7 @@ open class XMLNode: NSObject, NSCopying {
         @abstract The representation of this node as it would appear in an XML document.
     */
     open var xmlString: String {
-        return xmlString()
+        return xmlString(options: [])
     }
 
     /*!


### PR DESCRIPTION
So I wrote most of this to begin with, and when I went to actually try and use it for a little project (playing around with WebDAV), it crashed! Turns out I never went back and did namespace support. Well, here is more of (but still not all of) namespace support.

Fix one place was still expecting C String

XPath works with namespaces

implement XMLElement(xmlString:)

Add some tests, re-enable all tests

Implement more namespaces support