### PR TITLE
Fix a compiler warning in URLSession

### DIFF
--- a/Foundation/NSURLSession/http/HTTPURLProtocol.swift
+++ b/Foundation/NSURLSession/http/HTTPURLProtocol.swift
@@ -16,7 +16,7 @@ internal class _HTTPURLProtocol: URLProtocol {
     fileprivate var totalDownloaded = 0
     fileprivate var tempFileURL: URL
 
-    public override required init(task: URLSessionTask, cachedResponse: CachedURLResponse?, client: URLProtocolClient?) {
+    public required init(task: URLSessionTask, cachedResponse: CachedURLResponse?, client: URLProtocolClient?) {
         self.internalState = _InternalState.initial
         let fileName = NSTemporaryDirectory() + NSUUID().uuidString + ".tmp"
         _ = FileManager.default.createFile(atPath: fileName, contents: nil)
@@ -26,7 +26,7 @@ internal class _HTTPURLProtocol: URLProtocol {
         self.easyHandle = _EasyHandle(delegate: self)
     }
 
-    public override required init(request: URLRequest, cachedResponse: CachedURLResponse?, client: URLProtocolClient?) {
+    public required init(request: URLRequest, cachedResponse: CachedURLResponse?, client: URLProtocolClient?) {
         self.internalState = _InternalState.initial
         let fileName = NSTemporaryDirectory() + NSUUID().uuidString + ".tmp"
         _ = FileManager.default.createFile(atPath: fileName, contents: nil)


### PR DESCRIPTION
```
Foundation/NSURLSession/http/HTTPURLProtocol.swift:19:30: warning: 'override' is implied when overriding a required initializer
    public override required init(task: URLSessionTask, cachedResponse: CachedURLResponse?, client: URLProtocolClient?) {
                                ^
Foundation/NSURLSession/http/HTTPURLProtocol.swift:29:30: warning: 'override' is implied when overriding a required initializer
    public override required init(request: URLRequest, cachedResponse: CachedURLResponse?, client: URLProtocolClient?) {
           ~~~~~~~~~         ^
```

You do not write the override modifier when overriding a required designated initializer.