### PR TITLE
Updated NotificationCenter API to reflect current Apple's syntax

### DIFF
--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -183,6 +183,10 @@ open class NotificationCenter: NSObject {
     }
     
     open func addObserver(forName name: Notification.Name?, object obj: Any?, queue: OperationQueue?, usingBlock block: @escaping (Notification) -> Void) -> NSObjectProtocol {
+        return self.addObserver(forName:name, object:obj, queue:queue, using:block)
+    }
+    
+    open func addObserver(forName name: Notification.Name?, object obj: Any?, queue: OperationQueue?, using block: @escaping (Notification) -> Void) -> NSObjectProtocol {
         if queue != nil {
             NSUnimplemented()
         }


### PR DESCRIPTION
Current documented NotificationCenter's syntax does not match the Open Source version.
https://developer.apple.com/documentation/foundation/notificationcenter/1411723-addobserver

To enforce code compatibility between Linux and Mac, this PR fix the API and keep the old syntax to avoid compatibility issue with existing code.