### PR TITLE
Implement concurrent enumeration for NSArray, NSDictionary and NSIndexSet

### DIFF
--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -446,9 +446,6 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         self.enumerateObjects(at: IndexSet(integersIn: 0..<count), options: opts, using: block)
     }
     open func enumerateObjects(at s: IndexSet, options opts: NSEnumerationOptions = [], using block: (Any, Int, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) {
-        guard !opts.contains(.concurrent) else {
-            NSUnimplemented()
-        }
         s._bridgeToObjectiveC().enumerate(options: opts) { (idx, stop) in
             block(self.object(at: idx), idx, stop)
         }

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -9,7 +9,7 @@
 
 
 import CoreFoundation
-
+import Dispatch
 
 open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCoding {
     private let _cfinfo = _CFInfo(typeID: CFDictionaryGetTypeID())
@@ -454,19 +454,37 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         enumerateKeysAndObjects(options: [], using: block)
     }
 
-    open func enumerateKeysAndObjects(options opts: NSEnumerationOptions = [], using block: (Any, Any, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) {
+    open func enumerateKeysAndObjects(options opts: NSEnumerationOptions = [], using block: (Any, Any, UnsafeMutablePointer<ObjCBool>) -> Void) {
         let count = self.count
         var keys = [Any]()
         var objects = [Any]()
+        var sharedStop = ObjCBool(false)
+        let lock = NSLock()
+        
         getObjects(&objects, andKeys: &keys, count: count)
-        var stop = ObjCBool(false)
-        for idx in 0..<count {
-            withUnsafeMutablePointer(to: &stop, { stop in
-                block(keys[idx], objects[idx], stop)
-            })
-
-            if stop {
-                break
+        let iteration: (Int) -> Void = withoutActuallyEscaping(block) { (closure: @escaping (Any, Any, UnsafeMutablePointer<ObjCBool>) -> Void) -> (Int) -> Void in
+            return { (idx) in
+                lock.lock()
+                var stop = sharedStop
+                lock.unlock()
+                if stop { return }
+                
+                closure(keys[idx], objects[idx], &stop)
+                
+                if stop {
+                    lock.lock()
+                    sharedStop = stop
+                    lock.unlock()
+                    return
+                }
+            }
+        }
+        
+        if opts.contains(.concurrent) {
+            DispatchQueue.concurrentPerform(iterations: count, execute: iteration)
+        } else {
+            for idx in 0..<count {
+                iteration(idx)
             }
         }
     }


### PR DESCRIPTION
This implements concurrent enumeration options so that they no longer claim un-implemented.
Ideally we should use a more efficient locking mechanism like stdatomic.h style but the best we have in swift is NSLock/allocated mutex