### PR TITLE
Remove temporary workaround for SR-3202

### DIFF
--- a/Foundation/LengthFormatter.swift
+++ b/Foundation/LengthFormatter.swift
@@ -69,7 +69,7 @@ open class LengthFormatter : Formatter {
         //Extract the number from the measurement
         let numberInUnit = unitMeasurement.value
         
-        if isForPersonHeightUse && !numberFormatter.locale.sr3202_fix_isMetricSystemLocale() {
+        if isForPersonHeightUse && !numberFormatter.locale.usesMetricSystem {
             let feet = numberInUnit.rounded(.towardZero)
             let feetString = string(fromValue: feet, unit: .foot)
             
@@ -123,7 +123,7 @@ open class LengthFormatter : Formatter {
     /// - Parameter numberInMeters: the magnitude in terms of meters
     /// - Returns: Returns the appropriate unit
     private func unit(fromMeters numberInMeters: Double) -> Unit {
-        if numberFormatter.locale.sr3202_fix_isMetricSystemLocale() {
+        if numberFormatter.locale.usesMetricSystem {
             //Person height is always returned in cm for metric system
             if isForPersonHeightUse { return .centimeter }
             

--- a/Foundation/Locale.swift
+++ b/Foundation/Locale.swift
@@ -221,7 +221,7 @@ public struct Locale : CustomStringConvertible, CustomDebugStringConvertible, Ha
     /// -seealso: MeasurementFormatter
     public var usesMetricSystem: Bool {
         // NSLocale should not return nil here, but just in case
-        if let result = (_wrapped.object(forKey: .usesMetricSystem) as? NSNumber)?.boolValue {
+        if let result = _wrapped.object(forKey: .usesMetricSystem) as? Bool {
             return result
         } else {
             return false

--- a/Foundation/MassFormatter.swift
+++ b/Foundation/MassFormatter.swift
@@ -134,7 +134,7 @@ open class MassFormatter : Formatter {
     /// - Parameter numberInKilograms: the magnitude in terms of kilograms
     /// - Returns: Returns the appropriate unit
     private func convertedUnit(fromKilograms numberInKilograms: Double) -> Unit {
-        if numberFormatter.locale.sr3202_fix_isMetricSystemLocale() {
+        if numberFormatter.locale.usesMetricSystem {
             if numberInKilograms > 1.0 || numberInKilograms <= 0.0 {
                 return .kilogram
             } else {
@@ -235,23 +235,4 @@ open class MassFormatter : Formatter {
                                                             .ounce: "ounces",
                                                             .pound: "pounds",
                                                             .stone: "stones"]
-}
-
-internal extension Locale {
-    /// TODO: Replace calls to the below function to use Locale.usesMetricSystem
-    /// Temporary workaround due to unpopulated Locale attributes
-    /// See https://bugs.swift.org/browse/SR-3202
-    internal func sr3202_fix_isMetricSystemLocale() -> Bool {
-        switch self.identifier {
-        case "en_US": return false
-        case "en_US_POSIX": return false
-        case "haw_US": return false
-        case "es_US": return false
-        case "chr_US": return false
-        case "my_MM": return false
-        case "en_LR": return false
-        case "vai_LR": return false
-        default: return true
-        }
-    }
 }

--- a/TestFoundation/TestLengthFormatter.swift
+++ b/TestFoundation/TestLengthFormatter.swift
@@ -67,7 +67,7 @@ class TestLengthFormatter: XCTestCase {
     }
     
     func test_stringFromMetersMetric() {
-        formatter.numberFormatter.locale = Locale(identifier: "en_UK")
+        formatter.numberFormatter.locale = Locale(identifier: "en_GB")
         XCTAssertEqual(formatter.string(fromMeters: -10000), "-10 km")
         XCTAssertEqual(formatter.string(fromMeters: -1), "-0.001 km")
         XCTAssertEqual(formatter.string(fromMeters: 0.00001), "0.01 mm")
@@ -85,7 +85,7 @@ class TestLengthFormatter: XCTestCase {
     }
     
     func test_stringFromMetersMetricPersonHeight() {
-        formatter.numberFormatter.locale = Locale(identifier: "en_UK")
+        formatter.numberFormatter.locale = Locale(identifier: "en_GB")
         formatter.isForPersonHeightUse = true
         XCTAssertEqual(formatter.string(fromMeters: -1), "-100 cm")
         XCTAssertEqual(formatter.string(fromMeters: 0.001), "0.1 cm")


### PR DESCRIPTION
This succeeds #1043 which was merged and later reverted. This PR has more love for Linux.

Turns out on Linux `Swift.Bool` can not be converted to `Foundation.NSNumber`. On Darwin the conversion works fine. That's why the tests failed on Linux.

For the test cases, `en_UK` isn't really a valid locale identifier. For `en_UK` libicu actually returns a fallback value for measurement system(`UMS_SI`) instead of `UMS_UK`. To prevent further confusion I'd say `en_GB` is a better option. 