### PR TITLE
[regression]libFoundation.so must also be built on issuing 'ninja test'

### DIFF
--- a/lib/product.py
+++ b/lib/product.py
@@ -179,10 +179,10 @@ class StaticLibrary(Library):
         Library.__init__(self, name)
         self.name = name
 
-    def generate(self):
+    def generate(self, objects = []):
         self.rule = "Archive"
         self.product_name = Configuration.current.target.static_library_prefix + self.name + Configuration.current.target.static_library_suffix
-        return Library.generate(self, [])
+        return Library.generate(self, [], objects)
 
 class StaticAndDynamicLibrary(StaticLibrary, DynamicLibrary):
     def __init__(self, name):
@@ -190,9 +190,9 @@ class StaticAndDynamicLibrary(StaticLibrary, DynamicLibrary):
         DynamicLibrary.__init__(self, name)
 
     def generate(self):
-        objects, generatedForStatic = StaticLibrary.generate(self)
-        _, generatedForDynamic = DynamicLibrary.generate(self, objects)
-        return generatedForStatic + generatedForDynamic
+        objects, generatedForDynamic = DynamicLibrary.generate(self)
+        _, generatedForStatic = StaticLibrary.generate(self, objects)
+        return generatedForDynamic + generatedForStatic
 
 class Executable(Product):
     def __init__(self, name):


### PR DESCRIPTION
This fixes a build behaviour change caused by #1012 which in turn was created to fix a behaviour change caused by #873 

#873 enabled building a static Foundation library. In the build scripts parlance, with this change we had two "products" - the dynamic library (`libFoundation.so`) and a new static library (`libFoundation.a`). Build rules for all the "phases" and "dependencies" were generated both these products and we hence ended in duplicates. This is what #1012 attempted to eliminate.

But there was an issue with #1012. With this, build rules for the various dependencies and phases were generated only in  the context of the static library product `libFoundation.a`. These objects generated by these for reused for the dynamic library product `libFoundation.so`. This unintended consequence of this was that dependencies like TestFoundation -> libFoundation.so were not catered to. 

This led to a behaviour change. While the command 'ninja' built `libFoundation.so`, the command `ninja test` did not. This is not the expected behaviour. We've always had libFoundation.so being built before TestFoundation on the `ninja test` command. 

This PR rectifies that particular issue in #1012 Instead of generating rules for phases & dependencies in `libFoundation.a` we do that for the product `libFoundation.so` and subsequently reuse them in building `libFoundation.a`. 

Issuing `ninja test` will now build `libFoundation.so` before `TestFoundation`. Issuing `ninja` will build both `libFoundation.so` and `libFoundation.a`.