### PR TITLE
slices of slices that use range expressions incorrectly calculated relative indexing

### DIFF
--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -351,11 +351,11 @@ public final class _DataStorage {
     
     // fast-path for appending directly from another data storage
     @inline(__always)
-    public func append(_ otherData: _DataStorage, startingAt start: Int) {
+    public func append(_ otherData: _DataStorage, startingAt start: Int, endingAt end: Int) {
         let otherLength = otherData.length
         if otherLength == 0 { return }
         if let bytes = otherData.bytes {
-            append(bytes.advanced(by: start), length: otherLength)
+            append(bytes.advanced(by: start), length: end - start)
         }
     }
     
@@ -1132,7 +1132,9 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     
     @_versioned
     internal func _validateRange<R: RangeExpression>(_ range: R) where R.Bound == Int {
-        let r = range.relative(to: 0..<R.Bound.max)
+        let lower = R.Bound(_sliceRange.lowerBound)
+        let upper = R.Bound(_sliceRange.upperBound)
+        let r = range.relative(to: lower..<upper)
         precondition(r.lowerBound >= _sliceRange.lowerBound && r.lowerBound <= _sliceRange.upperBound, "Range \(r) is out of bounds of range \(_sliceRange)")
         precondition(r.upperBound >= _sliceRange.lowerBound && r.upperBound <= _sliceRange.upperBound, "Range \(r) is out of bounds of range \(_sliceRange)")
     }
@@ -1328,7 +1330,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         if !isKnownUniquelyReferenced(&_backing) {
             _backing = _backing.mutableCopy(_sliceRange)
         }
-        _backing.append(other._backing, startingAt: other._sliceRange.lowerBound)
+        _backing.append(other._backing, startingAt: other._sliceRange.lowerBound, endingAt: other._sliceRange.upperBound)
         _sliceRange = _sliceRange.lowerBound..<(_sliceRange.upperBound + other.count)
     }
     
@@ -1598,7 +1600,9 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         where R.Bound: FixedWidthInteger, R.Bound.Stride : SignedInteger {
         @inline(__always)
         get {
-            let range = rangeExpression.relative(to: 0..<R.Bound.max)
+            let lower = R.Bound(_sliceRange.lowerBound)
+            let upper = R.Bound(_sliceRange.upperBound)
+            let range = rangeExpression.relative(to: lower..<upper)
             let start: Int = numericCast(range.lowerBound)
             let end: Int = numericCast(range.upperBound)
             let r: Range<Int> = start..<end
@@ -1607,7 +1611,9 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
         @inline(__always)
         set {
-            let range = rangeExpression.relative(to: 0..<R.Bound.max)
+            let lower = R.Bound(_sliceRange.lowerBound)
+            let upper = R.Bound(_sliceRange.upperBound)
+            let range = rangeExpression.relative(to: lower..<upper)
             let start: Int = numericCast(range.lowerBound)
             let end: Int = numericCast(range.upperBound)
             let r: Range<Int> = start..<end


### PR DESCRIPTION
The RangeExpression variants of slicing incorrectly passed 0..<R.Bounds.max which should be the slice region of the Data.

This resolves the issues:
rdar://problem/32982494
rdar://problem/32983214 aka [SR-5292]: Another Data slice-related crash