### PR TITLE
Split up a couple expressions to work around slow type checking.

### DIFF
--- a/Foundation/NSCFString.swift
+++ b/Foundation/NSCFString.swift
@@ -59,13 +59,19 @@ internal class _NSCFString : NSMutableString {
 
 internal final class _NSCFConstantString : _NSCFString {
     internal var _ptr : UnsafePointer<UInt8> {
-        let offset = MemoryLayout<OpaquePointer>.size + MemoryLayout<Int32>.size + MemoryLayout<Int32>.size + MemoryLayout<_CFInfo>.size
+        // FIXME: Split expression as a work-around for slow type checking.
+        let offTemp1 = MemoryLayout<OpaquePointer>.size + MemoryLayout<Int32>.size
+        let offTemp2 = MemoryLayout<Int32>.size + MemoryLayout<_CFInfo>.size
+        let offset = offTemp1 + offTemp2
         let ptr = Unmanaged.passUnretained(self).toOpaque()
         return ptr.load(fromByteOffset: offset, as: UnsafePointer<UInt8>.self)
     }
 
     private var _lenOffset : Int {
-        return MemoryLayout<OpaquePointer>.size + MemoryLayout<Int32>.size + MemoryLayout<Int32>.size + MemoryLayout<_CFInfo>.size + MemoryLayout<UnsafePointer<UInt8>>.size
+        // FIXME: Split expression as a work-around for slow type checking.
+        let offTemp1 = MemoryLayout<OpaquePointer>.size + MemoryLayout<Int32>.size
+        let offTemp2 = MemoryLayout<Int32>.size + MemoryLayout<_CFInfo>.size
+        return offTemp1 + offTemp2 + MemoryLayout<UnsafePointer<UInt8>>.size
     }
 
     private var _lenPtr :  UnsafeMutableRawPointer {

--- a/Foundation/NSCFString.swift
+++ b/Foundation/NSCFString.swift
@@ -59,7 +59,8 @@ internal class _NSCFString : NSMutableString {
 
 internal final class _NSCFConstantString : _NSCFString {
     internal var _ptr : UnsafePointer<UInt8> {
-        // FIXME: Split expression as a work-around for slow type checking.
+        // FIXME: Split expression as a work-around for slow type
+        //        checking (tracked by SR-5322).
         let offTemp1 = MemoryLayout<OpaquePointer>.size + MemoryLayout<Int32>.size
         let offTemp2 = MemoryLayout<Int32>.size + MemoryLayout<_CFInfo>.size
         let offset = offTemp1 + offTemp2
@@ -68,7 +69,8 @@ internal final class _NSCFConstantString : _NSCFString {
     }
 
     private var _lenOffset : Int {
-        // FIXME: Split expression as a work-around for slow type checking.
+        // FIXME: Split expression as a work-around for slow type
+        //        checking (tracked by SR-5322).
         let offTemp1 = MemoryLayout<OpaquePointer>.size + MemoryLayout<Int32>.size
         let offTemp2 = MemoryLayout<Int32>.size + MemoryLayout<_CFInfo>.size
         return offTemp1 + offTemp2 + MemoryLayout<UnsafePointer<UInt8>>.size


### PR DESCRIPTION
The type checker is particularly slow on these expressions. I've opened
`https://bugs.swift.org/browse/SR-5322` to investigate the type checker
issue, but in the meantime it would be nice to speed up builds. This
cuts more than a minute from my unoptimized asserts-enabled build.