### PR TITLE
NSDecimalNumberHandler: default is now a property

### DIFF
--- a/Foundation/NSDecimalNumber.swift
+++ b/Foundation/NSDecimalNumber.swift
@@ -408,7 +408,7 @@ open class NSDecimalNumberHandler : NSObject, NSDecimalNumberBehaviors, NSCoding
         }
     }
     
-    open class func `default`() -> NSDecimalNumberHandler {
+    open class var `default`: NSDecimalNumberHandler {
         return defaultBehavior
     }
     // rounding mode: NSRoundPlain


### PR DESCRIPTION
The change is shown at https://developer.apple.com/documentation/foundation/nsdecimalnumberhandler/1407825-default?changes=latest_minor

I haven't been able to test this yet because the Xcode build is currently broken.  But it looks fairly simple.