### PR TITLE
URLProtocolClient doesn't deliver response and data to URLSession delegates

### DIFF
--- a/TestFoundation/TestNSURLSession.swift
+++ b/TestFoundation/TestNSURLSession.swift
@@ -38,6 +38,7 @@ class TestURLSession : XCTestCase {
             ("test_verifyHttpAdditionalHeaders", test_verifyHttpAdditionalHeaders),
             ("test_timeoutInterval", test_timeoutInterval),
             ("test_customProtocol", test_customProtocol),
+	    ("test_customProtocolResponseWithDelegate", test_customProtocolResponseWithDelegate),
             ("test_httpRedirection", test_httpRedirection),
             ("test_httpRedirectionTimeout", test_httpRedirectionTimeout),
         ]
@@ -344,6 +345,14 @@ class TestURLSession : XCTestCase {
         task.resume()
         waitForExpectations(timeout: 12)
     }
+
+    func test_customProtocolResponseWithDelegate() {
+        let url = URL(string: "http://127.0.0.1:\(TestURLSession.serverPort)/Peru")!
+        let d = DataTask(with: expectation(description: "Custom protocol with delegate"), protocolClasses: [CustomProtocol.self])
+        d.responseReceivedExpectation = expectation(description: "A response wasn't received")
+        d.run(with: url)
+        waitForExpectations(timeout: 12)
+    }
     
     func test_httpRedirection() {
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/UnitedStates"
@@ -387,16 +396,22 @@ class DataTask : NSObject {
     var session: URLSession! = nil
     var task: URLSessionDataTask! = nil
     var cancelExpectation: XCTestExpectation?
+    var responseReceivedExpectation: XCTestExpectation?
+    var protocols: [AnyClass]?
     
     public var error = false
     
-    init(with expectation: XCTestExpectation) {
+    init(with expectation: XCTestExpectation, protocolClasses: [AnyClass]? = nil) {
         dataTaskExpectation = expectation
+	protocols = protocolClasses
     }
     
     func run(with request: URLRequest) {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 8
+        if let customProtocols = protocols {
+            config.protocolClasses = customProtocols
+        }
         session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
         task = session.dataTask(with: request)
         task.resume()
@@ -405,6 +420,9 @@ class DataTask : NSObject {
     func run(with url: URL) {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 8
+        if let customProtocols = protocols {
+            config.protocolClasses = customProtocols
+        }
         session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
         task = session.dataTask(with: url)
         task.resume()
@@ -418,6 +436,14 @@ class DataTask : NSObject {
 extension DataTask : URLSessionDataDelegate {
     public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         capital = String(data: data, encoding: String.Encoding.utf8)!
+    }
+
+    public func urlSession(_ session: URLSession,
+                    dataTask: URLSessionDataTask,
+                    didReceive response: URLResponse,
+                    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+        guard responseReceivedExpectation != nil else { return }
+        responseReceivedExpectation!.fulfill()
     }
 }
 


### PR DESCRIPTION
Custom URLProtocols using task delegates doesn't deliver data and response received to the URLSession delegates. This fix would delegate the data and response to url session delegates. 