### PR TITLE
Uncomment NSUserDefaults dictionaryRepresentation

### DIFF
--- a/CoreFoundation/Preferences.subproj/CFPreferences.h
+++ b/CoreFoundation/Preferences.subproj/CFPreferences.h
@@ -93,7 +93,7 @@ keysToFetch that are not present in the returned dictionary
 are not present in the domain.  If keysToFetch is NULL, all
 keys are fetched. */
 CF_EXPORT
-CFDictionaryRef CFPreferencesCopyMultiple(_Nullable CFArrayRef keysToFetch, CFStringRef applicationID, CFStringRef userName, CFStringRef hostName);
+_Nullable CFDictionaryRef CFPreferencesCopyMultiple(_Nullable CFArrayRef keysToFetch, CFStringRef applicationID, CFStringRef userName, CFStringRef hostName);
 
 /* The primitive set function; all arguments except value must be
 non-NULL.  If value is NULL, the given key is removed */

--- a/Foundation/NSUserDefaults.swift
+++ b/Foundation/NSUserDefaults.swift
@@ -239,11 +239,8 @@ open class UserDefaults: NSObject {
     }
     
     open func dictionaryRepresentation() -> [String : Any] {
-        NSUnimplemented()
-        /*
-        Currently crashes the compiler.
         guard let aPref = CFPreferencesCopyMultiple(nil, kCFPreferencesCurrentApplication, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost),
-            bPref = (aPref._swiftObject) as? [NSString: Any] else {
+            let bPref = (aPref._swiftObject) as? [NSString: Any] else {
                 return registeredDefaults
         }
         var allDefaults = registeredDefaults
@@ -253,7 +250,6 @@ open class UserDefaults: NSObject {
         }
         
         return allDefaults
-        */
     }
     
     open var volatileDomainNames: [String] { NSUnimplemented() }


### PR DESCRIPTION
The compiler no longer crashes for this method. Tested on macOS & Ubuntu 16.04