### PR TITLE
Uncomment NumberFormatter roundingBehavior

### DIFF
--- a/Foundation/NumberFormatter.swift
+++ b/Foundation/NumberFormatter.swift
@@ -895,16 +895,14 @@ open class NumberFormatter : Formatter {
         }
     }
     
-    // FIXME: Uncomment this when NSDecimalNumberHandler.default() gets rid of NSUnimplementend()
-    // This is currently commented out so that NSNumberFormatter instances can be tested
-//    internal var _roundingBehavior: NSDecimalNumberHandler = NSDecimalNumberHandler.default()
-//    /*@NSCopying*/ open var roundingBehavior: NSDecimalNumberHandler {
-//        get {
-//            return _roundingBehavior
-//        }
-//        set {
-//            _reset()
-//            _roundingBehavior = newValue
-//        }
-//    }
+    internal var _roundingBehavior: NSDecimalNumberHandler = NSDecimalNumberHandler.default
+    /*@NSCopying*/ open var roundingBehavior: NSDecimalNumberHandler {
+        get {
+            return _roundingBehavior
+        }
+        set {
+            _reset()
+            _roundingBehavior = newValue
+        }
+    }
 }


### PR DESCRIPTION
I think it's safe to uncomment this shiny new Swift 4 API now. Tested on macOS & Ubuntu. 