### PR TITLE
Remove objc_retainAutoreleasedReturnValue()

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1699,15 +1699,6 @@ const char *_NSPrintForDebugger(void *cf) {
     }
 }
 
-// For CF functions with 'Get' semantics, the compiler currently assumes that the result is autoreleased and must be retained. It does so on all platforms by emitting a call to objc_retainAutoreleasedReturnValue. On Darwin, this is implemented by the ObjC runtime. On Linux, there is no runtime, and therefore we have to stub it out here ourselves. The compiler will eventually call swift_release to balance the retain below. This is a workaround until the compiler no longer emits this callout on Linux.
-void * objc_retainAutoreleasedReturnValue(void *obj) {
-    if (obj) {
-        swift_retain(obj);
-        return obj;
-    }
-    else return NULL;
-}
-        
 CFHashCode __CFHashDouble(double d) {
     return _CFHashDouble(d);
 }


### PR DESCRIPTION
- This was a duplicate function also provided in libdispatch.
  libdispatch is now a dependancy so this duplicate can be removed.

This is the followup PR to https://github.com/apple/swift-corelibs-libdispatch/pull/258 