### PR TITLE
Use `CFNumberCreate()` as factory initializer on `NSNumber`

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -254,6 +254,8 @@ CF_PRIVATE void _CFSwiftRelease(void *_Nullable t);
 
 CF_EXPORT void _CFRuntimeBridgeTypeToClass(CFTypeID type, const void *isa);
 
+CF_EXPORT CFNumberType _CFNumberGetType2(CFNumberRef number);
+
 typedef	unsigned char __cf_uuid[16];
 typedef	char __cf_uuid_string[37];
 typedef __cf_uuid _cf_uuid_t;

--- a/Foundation/JSONEncoder.swift
+++ b/Foundation/JSONEncoder.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import CoreFoundation
+
 //===----------------------------------------------------------------------===//
 // JSON Encoder
 //===----------------------------------------------------------------------===//
@@ -1742,7 +1744,7 @@ extension _JSONDecoder {
         }
 
         // TODO: Add a flag to coerce non-boolean numbers into Bools?
-        guard number._objCType == .Bool else {
+        guard number._cfTypeID == CFBooleanGetTypeID() else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 

--- a/Foundation/NSCFBoolean.swift
+++ b/Foundation/NSCFBoolean.swift
@@ -78,7 +78,10 @@ internal class __NSCFBoolean : NSNumber {
     override var objCType: UnsafePointer<Int8> {
         // This must never be fixed to be "B", although that would
         // cause correct old-style archiving when this is unarchived.
-        return UnsafePointer<Int8>(bitPattern: UInt(_NSSimpleObjCType.Char.rawValue.value))!
+        func _objCType(_ staticString: StaticString) -> UnsafePointer<Int8> {
+            return UnsafeRawPointer(staticString.utf8Start).assumingMemoryBound(to: Int8.self)
+        }
+        return _objCType("c")
     }
     
     internal override func _cfNumberType() -> CFNumberType  {

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -459,8 +459,8 @@ private struct JSONWriter {
             throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.propertyListReadCorrupt.rawValue, userInfo: ["NSDebugDescription" : "Number cannot be infinity or NaN"])
         }
         
-        switch num._objCType {
-        case .Bool:
+        switch num._cfTypeID {
+        case CFBooleanGetTypeID():
             serializeBool(num.boolValue)
         default:
             writer(_serializationString(for: num))

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -683,10 +683,10 @@ open class NSKeyedUnarchiver : NSCoder {
     }
     
     open override func decodeBool(forKey key: String) -> Bool {
-        guard let result : NSNumber = _decodeValue(forKey: key) else {
+        guard let result : Bool = _decodeValue(forKey: key) else {
             return false
         }
-        return result.boolValue
+        return result
     }
     
     open override func decodeInt32(forKey key: String) -> Int32 {

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -205,9 +205,6 @@ private struct CFSInt128Struct {
 
 open class NSNumber : NSValue {
     typealias CFType = CFNumber
-    // This layout MUST be the same as CFNumber so that they are bridgeable
-    private var _base = _CFInfo(typeID: CFNumberGetTypeID())
-    private var _pad: UInt64 = 0
 
     internal var _cfObject: CFType {
         return unsafeBitCast(self, to: CFType.self)

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -309,12 +309,6 @@ open class NSNumber : NSValue {
         _CFNumberInitDouble(_cfObject, value)
     }
     
-    public init(value: Bool) {
-        _objCType = .Bool
-        super.init()
-        _CFNumberInitBool(_cfObject, value)
-    }
-
     override internal init() {
         _objCType = .Undef
         super.init()
@@ -614,6 +608,12 @@ open class NSNumber : NSValue {
     }
     
     open override var classForCoder: AnyClass { return NSNumber.self }
+}
+
+extension NSNumber {
+    public convenience init(value: Bool) {
+        self.init(factory: value._bridgeToObjectiveC)
+    }
 }
 
 extension CFNumber : _NSBridgeable {

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -247,26 +247,6 @@ open class NSNumber : NSValue {
             return _objCType("f")
         case kCFNumberFloat64Type:
             return _objCType("d")
-        case kCFNumberCharType:
-            return _objCType("c")
-        case kCFNumberShortType:
-            return _objCType("s")
-        case kCFNumberIntType:
-            return _objCType("i")
-        case kCFNumberLongType:
-            return _objCType("q")
-        case kCFNumberLongLongType:
-            return _objCType("q")
-        case kCFNumberFloatType:
-            return _objCType("f")
-        case kCFNumberDoubleType:
-            return _objCType("d")
-        case kCFNumberCFIndexType:
-            return _objCType("q")
-        case kCFNumberNSIntegerType:
-            return _objCType("q")
-        case kCFNumberCGFloatType:
-            return _objCType("d")
         case kCFNumberSInt128Type:
             return _objCType("Q")
         default:

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -205,6 +205,9 @@ private struct CFSInt128Struct {
 
 open class NSNumber : NSValue {
     typealias CFType = CFNumber
+    // This layout MUST be the same as CFNumber so that they are bridgeable
+    private var _base = _CFInfo(typeID: CFNumberGetTypeID())
+    private var _pad: UInt64 = 0
 
     internal var _cfObject: CFType {
         return unsafeBitCast(self, to: CFType.self)

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -198,9 +198,6 @@ extension NSNumber : ExpressibleByFloatLiteral, ExpressibleByIntegerLiteral, Exp
 
 }
 
-@_silgen_name("_CFNumberGetType2")
-func _CFNumberGetType2(_ number: CFNumber!) -> CFNumberType
-
 private struct CFSInt128Struct {
     var high: Int64
     var low: UInt64

--- a/Foundation/NSValue.swift
+++ b/Foundation/NSValue.swift
@@ -154,3 +154,14 @@ open class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
 }
 
+extension NSValue : _Factory {}
+
+protocol _Factory {
+    init(factory: () -> Self)
+}
+
+extension _Factory {
+    init(factory: () -> Self) {
+        self = factory()
+    }
+}

--- a/Foundation/NSValue.swift
+++ b/Foundation/NSValue.swift
@@ -156,7 +156,7 @@ open class NSValue : NSObject, NSCopying, NSSecureCoding, NSCoding {
 
 extension NSValue : _Factory {}
 
-protocol _Factory {
+internal protocol _Factory {
     init(factory: () -> Self)
 }
 

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -21,6 +21,7 @@ class TestNSNumber : XCTestCase {
     static var allTests: [(String, (TestNSNumber) -> () throws -> Void)] {
         return [
             ("test_NumberWithBool", test_NumberWithBool ),
+            ("test_CFBoolean", test_CFBoolean ),
             ("test_numberWithChar", test_numberWithChar ),
             ("test_numberWithUnsignedChar", test_numberWithUnsignedChar ),
             ("test_numberWithShort", test_numberWithShort ),

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -41,6 +41,7 @@ class TestNSNumber : XCTestCase {
             ("test_compareNumberWithDouble", test_compareNumberWithDouble ),
             ("test_description", test_description ),
             ("test_descriptionWithLocale", test_descriptionWithLocale ),
+            ("test_objCType", test_objCType ),
         ]
     }
     
@@ -976,5 +977,23 @@ class TestNSNumber : XCTestCase {
             let receivedDesc = nsnumber.description(withLocale: locale)
             XCTAssertEqual(receivedDesc, expectedDesc, "expected \(expectedDesc) but received \(receivedDesc)")
         }
+    }
+
+    func test_objCType() {
+        let objCType: (NSNumber) -> UnicodeScalar = { number in
+            return UnicodeScalar(UInt8(number.objCType.pointee))
+        }
+
+        XCTAssertEqual(objCType(NSNumber(value: Bool())),   "c") // 0x63
+        XCTAssertEqual(objCType(NSNumber(value: Int8())),   "c") // 0x63
+        XCTAssertEqual(objCType(NSNumber(value: UInt8())),  "s") // 0x73
+        XCTAssertEqual(objCType(NSNumber(value: Int16())),  "s") // 0x73
+        XCTAssertEqual(objCType(NSNumber(value: UInt16())), "i") // 0x69
+        XCTAssertEqual(objCType(NSNumber(value: Int32())),  "i") // 0x69
+        XCTAssertEqual(objCType(NSNumber(value: UInt32())), "q") // 0x71
+        XCTAssertEqual(objCType(NSNumber(value: Int64())),  "q") // 0x71
+        XCTAssertEqual(objCType(NSNumber(value: UInt64())), "q") // 0x71
+        XCTAssertEqual(objCType(NSNumber(value: Float())),  "f") // 0x66
+        XCTAssertEqual(objCType(NSNumber(value: Double())), "d") // 0x64
     }
 }

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -985,16 +985,38 @@ class TestNSNumber : XCTestCase {
             return UnicodeScalar(UInt8(number.objCType.pointee))
         }
 
-        XCTAssertEqual(objCType(NSNumber(value: Bool())),   "c") // 0x63
-        XCTAssertEqual(objCType(NSNumber(value: Int8())),   "c") // 0x63
-        XCTAssertEqual(objCType(NSNumber(value: UInt8())),  "s") // 0x73
-        XCTAssertEqual(objCType(NSNumber(value: Int16())),  "s") // 0x73
-        XCTAssertEqual(objCType(NSNumber(value: UInt16())), "i") // 0x69
-        XCTAssertEqual(objCType(NSNumber(value: Int32())),  "i") // 0x69
-        XCTAssertEqual(objCType(NSNumber(value: UInt32())), "q") // 0x71
-        XCTAssertEqual(objCType(NSNumber(value: Int64())),  "q") // 0x71
-        XCTAssertEqual(objCType(NSNumber(value: UInt64())), "q") // 0x71
-        XCTAssertEqual(objCType(NSNumber(value: Float())),  "f") // 0x66
-        XCTAssertEqual(objCType(NSNumber(value: Double())), "d") // 0x64
+        XCTAssertEqual("c" /* 0x63 */, objCType(NSNumber(value: true)))
+
+        XCTAssertEqual("c" /* 0x63 */, objCType(NSNumber(value: Int8.max)))
+        XCTAssertEqual("s" /* 0x73 */, objCType(NSNumber(value: UInt8(Int8.max))))
+        XCTAssertEqual("s" /* 0x73 */, objCType(NSNumber(value: UInt8(Int8.max) + 1)))
+
+        XCTAssertEqual("s" /* 0x73 */, objCType(NSNumber(value: Int16.max)))
+        XCTAssertEqual("i" /* 0x69 */, objCType(NSNumber(value: UInt16(Int16.max))))
+        XCTAssertEqual("i" /* 0x69 */, objCType(NSNumber(value: UInt16(Int16.max) + 1)))
+
+        XCTAssertEqual("i" /* 0x69 */, objCType(NSNumber(value: Int32.max)))
+        XCTAssertEqual("q" /* 0x71 */, objCType(NSNumber(value: UInt32(Int32.max))))
+        XCTAssertEqual("q" /* 0x71 */, objCType(NSNumber(value: UInt32(Int32.max) + 1)))
+
+        XCTAssertEqual("q" /* 0x71 */, objCType(NSNumber(value: Int64.max)))
+        // When value is lower equal to `Int64.max`, it returns 'q' even if using `UInt64`
+        XCTAssertEqual("q" /* 0x71 */, objCType(NSNumber(value: UInt64(Int64.max))))
+        XCTAssertEqual("Q" /* 0x51 */, objCType(NSNumber(value: UInt64(Int64.max) + 1)))
+
+        // Depends on architectures
+        #if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+            XCTAssertEqual("q" /* 0x71 */, objCType(NSNumber(value: Int.max)))
+            // When value is lower equal to `Int.max`, it returns 'q' even if using `UInt`
+            XCTAssertEqual("q" /* 0x71 */, objCType(NSNumber(value: UInt(Int.max))))
+            XCTAssertEqual("Q" /* 0x51 */, objCType(NSNumber(value: UInt(Int.max) + 1)))
+        #elseif arch(i386) || arch(arm)
+            XCTAssertEqual("i" /* 0x71 */, objCType(NSNumber(value: Int.max)))
+            XCTAssertEqual("q" /* 0x71 */, objCType(NSNumber(value: UInt(Int.max))))
+            XCTAssertEqual("q" /* 0x51 */, objCType(NSNumber(value: UInt(Int.max) + 1)))
+        #endif
+
+        XCTAssertEqual("f" /* 0x66 */, objCType(NSNumber(value: Float.greatestFiniteMagnitude)))
+        XCTAssertEqual("d" /* 0x64 */, objCType(NSNumber(value: Double.greatestFiniteMagnitude)))
     }
 }

--- a/TestFoundation/TestNSPredicate.swift
+++ b/TestFoundation/TestNSPredicate.swift
@@ -101,6 +101,9 @@ class TestNSPredicate: XCTestCase {
         let predicateA = NSPredicate(value: true)
         let predicateB = NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: predicateA)) as! NSPredicate
         XCTAssertEqual(predicateA, predicateB, "Archived then unarchived uuid must be equal.")
+        let predicateC = NSPredicate(value: false)
+        let predicateD = NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: predicateC)) as! NSPredicate
+        XCTAssertEqual(predicateC, predicateD, "Archived then unarchived uuid must be equal.")
     }
     
     func test_copy() {


### PR DESCRIPTION
This replaces #1025 by further utilizing the Factory Initializer Method ([SR-5255](https://bugs.swift.org/browse/SR-5255)).

---
### Use `CFNumberCreate()` as factory initializer on `NSNumber.init(value:)`
- Change `NSNumber.init(value:)` to returning instance created by `CFNumberCreate()`
- Remove `NSNumber._objCType`

### Change the properties of `NSNumber` to call `CFNumberGetValue ()` in the same way as `Foundation`.

### Fixes [SR-4907](https://bugs.swift.org/browse/SR-4907)
- Add `TestNSNumber.test_objCType()` reproducing crash
  Expected results are sampled from macOS
- Fix crash on accessing `objCType` property of `NSNumber`  

### Change `NSNumber.objCType` to returning same values with darwin platform version
- Change `NSNumber.objCType` to returning same values with darwin
- Change `NSNumber.init(value: Bool)` to returning `__NSCFBoolean` by using `_Factory` protocol

Since `NSNumber.objCType` returns `c` with both of `Bool` and `Int8` on darwin platform, `NSNumber.init(value: Bool)` is changed to returns `__NSCFBoolean` by using `_Factory` protocol, and it changed to use `_cfTypeID` to distinguish between Bool and Int8.

- Change `JSONSerialization` to use `_cfTypeID` for checking whether `NSNumber` is Boolean or not
- Change `_JSONDecoder` to use `_cfTypeID` for checking whether `NSNumber` is Boolean or not
- Change `NSNumber.compare(_:)` to use `objCType`
- Add missing entry to `TestNumber.allTests`
- Fix `NSKeyedUnarchiver.decodeBool(forKey:)` and add test to `TestNSPredicate.test_NSCoding()`
