### PR TITLE
OperationQueue.main dangling pointer fix

### DIFF
--- a/Foundation/Operation.swift
+++ b/Foundation/Operation.swift
@@ -577,12 +577,13 @@ open class OperationQueue: NSObject {
 #endif
     }
     
+#if DEPLOYMENT_ENABLE_LIBDISPATCH
+    private static let _main = OperationQueue(_queue: .main, maxConcurrentOperations: 1)
+#endif
+    
     open class var main: OperationQueue {
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
-        guard let specific = DispatchQueue.main.getSpecific(key: OperationQueue.OperationQueueKey) else {
-            return OperationQueue(_queue: DispatchQueue.main, maxConcurrentOperations: 1)
-        }
-        return specific.takeUnretainedValue()
+        return _main
 #else
         fatalError("NSOperationQueue requires libdispatch")
 #endif

--- a/Foundation/Operation.swift
+++ b/Foundation/Operation.swift
@@ -563,16 +563,15 @@ open class OperationQueue: NSObject {
 
     open class var current: OperationQueue? {
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
-        let specific = DispatchQueue.getSpecific(key: OperationQueue.OperationQueueKey)
-        if specific == nil {
+        guard let specific = DispatchQueue.getSpecific(key: OperationQueue.OperationQueueKey) else {
             if pthread_main_np() == 1 {
                 return OperationQueue.main
             } else {
                 return nil
             }
-        } else {
-            return specific!.takeUnretainedValue()
         }
+        
+        return specific.takeUnretainedValue()
 #else
         return nil
 #endif
@@ -580,12 +579,10 @@ open class OperationQueue: NSObject {
     
     open class var main: OperationQueue {
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
-        let specific = DispatchQueue.main.getSpecific(key: OperationQueue.OperationQueueKey)
-        if specific == nil {
+        guard let specific = DispatchQueue.main.getSpecific(key: OperationQueue.OperationQueueKey) else {
             return OperationQueue(_queue: DispatchQueue.main, maxConcurrentOperations: 1)
-        } else {
-            return specific!.takeUnretainedValue()
         }
+        return specific.takeUnretainedValue()
 #else
         fatalError("NSOperationQueue requires libdispatch")
 #endif

--- a/TestFoundation/TestNSOperationQueue.swift
+++ b/TestFoundation/TestNSOperationQueue.swift
@@ -108,6 +108,10 @@ class TestNSOperationQueue : XCTestCase {
     func test_MainQueueGetter() {
         XCTAssertTrue(OperationQueue.main === OperationQueue.main)
         
+        /*
+         This call is only to check if OperationQueue.main returns a living instance.
+         There used to be a bug where subsequent OperationQueue.main call would return a "dangling pointer".
+         */
         XCTAssertFalse(OperationQueue.main.isSuspended)
     }
 }

--- a/TestFoundation/TestNSOperationQueue.swift
+++ b/TestFoundation/TestNSOperationQueue.swift
@@ -25,6 +25,7 @@ class TestNSOperationQueue : XCTestCase {
             ("test_OperationCount", test_OperationCount),
             ("test_AsyncOperation", test_AsyncOperation),
             ("test_isExecutingWorks", test_isExecutingWorks),
+            ("test_MainQueueGetter", test_MainQueueGetter),
         ]
     }
     
@@ -102,6 +103,12 @@ class TestNSOperationQueue : XCTestCase {
 
         XCTAssertFalse(operation.isExecuting)
         XCTAssertTrue(operation.isFinished)
+    }
+    
+    func test_MainQueueGetter() {
+        XCTAssertTrue(OperationQueue.main === OperationQueue.main)
+        
+        XCTAssertFalse(OperationQueue.main.isSuspended)
     }
 }
 


### PR DESCRIPTION
Calling `OperationQueue.main` would
instantiate an `OperationQueue`,
set an `Unmanaged` reference to it as **main queue specific**
and return `OperationQueue`.

Subsequent calls to `OperationQueue.main` would
get the `Unmanaged` reference to `OperationQueue` from **main queue specific**
 and return `OperationQueue` wrapped in `Unmanaged`.

However, there's nothing stopping the `OperationQueue` from being deallocated, so the `Unmanaged` reference from subsequent call would in fact return garbage.