### PR TITLE
fix URLSession crashing on HTTP/0.9 simple-responses

### DIFF
--- a/TestFoundation/TestNSURLSession.swift
+++ b/TestFoundation/TestNSURLSession.swift
@@ -41,6 +41,10 @@ class TestURLSession : XCTestCase {
 	    ("test_customProtocolResponseWithDelegate", test_customProtocolResponseWithDelegate),
             ("test_httpRedirection", test_httpRedirection),
             ("test_httpRedirectionTimeout", test_httpRedirectionTimeout),
+            ("test_http0_9SimpleResponses", test_http0_9SimpleResponses),
+            ("test_outOfRangeButCorrectlyFormattedHTTPCode", test_outOfRangeButCorrectlyFormattedHTTPCode),
+            ("test_missingContentLengthButStillABody", test_missingContentLengthButStillABody),
+            ("test_illegalHTTPServerResponses", test_illegalHTTPServerResponses),
         ]
     }
     
@@ -377,6 +381,108 @@ class TestURLSession : XCTestCase {
         }
         task.resume()
         waitForExpectations(timeout: 12)
+    }
+
+    func test_http0_9SimpleResponses() {
+        for brokenCity in ["Pompeii", "Sodom"] {
+            let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/LandOfTheLostCities/\(brokenCity)"
+            let url = URL(string: urlString)!
+
+            let config = URLSessionConfiguration.default
+            config.timeoutIntervalForRequest = 8
+            let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
+            let expect = expectation(description: "URL test with completion handler for \(brokenCity)")
+            var expectedResult = "unknown"
+            let task = session.dataTask(with: url) { data, response, error in
+                XCTAssertNotNil(data)
+                XCTAssertNotNil(response)
+                XCTAssertNil(error)
+
+                defer { expect.fulfill() }
+
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    XCTFail("response (\(response.debugDescription)) invalid")
+                    return
+                }
+                XCTAssertEqual(200, httpResponse.statusCode, "HTTP response code is not 200")
+            }
+            task.resume()
+            waitForExpectations(timeout: 12)
+        }
+    }
+
+    func test_outOfRangeButCorrectlyFormattedHTTPCode() {
+        let brokenCity = "Kameiros"
+        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/LandOfTheLostCities/\(brokenCity)"
+        let url = URL(string: urlString)!
+
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 8
+        let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
+        let expect = expectation(description: "URL test with completion handler for \(brokenCity)")
+        let task = session.dataTask(with: url) { data, response, error in
+            XCTAssertNotNil(data)
+            XCTAssertNotNil(response)
+            XCTAssertNil(error)
+
+            defer { expect.fulfill() }
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                XCTFail("response (\(response.debugDescription)) invalid")
+                return
+            }
+            XCTAssertEqual(999, httpResponse.statusCode, "HTTP response code is not 999")
+        }
+        task.resume()
+        waitForExpectations(timeout: 12)
+    }
+
+    func test_missingContentLengthButStillABody() {
+        let brokenCity = "Myndus"
+        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/LandOfTheLostCities/\(brokenCity)"
+        let url = URL(string: urlString)!
+
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 8
+        let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
+        let expect = expectation(description: "URL test with completion handler for \(brokenCity)")
+        let task = session.dataTask(with: url) { data, response, error in
+            XCTAssertNotNil(data)
+            XCTAssertNotNil(response)
+            XCTAssertNil(error)
+
+            defer { expect.fulfill() }
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                XCTFail("response (\(response.debugDescription)) invalid")
+                return
+            }
+            XCTAssertEqual(200, httpResponse.statusCode, "HTTP response code is not 200")
+        }
+        task.resume()
+        waitForExpectations(timeout: 12)
+    }
+
+
+    func test_illegalHTTPServerResponses() {
+        for brokenCity in ["Gomorrah", "Dinavar", "Kuhikugu"] {
+            let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/LandOfTheLostCities/\(brokenCity)"
+            let url = URL(string: urlString)!
+
+            let config = URLSessionConfiguration.default
+            config.timeoutIntervalForRequest = 8
+            let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
+            let expect = expectation(description: "URL test with completion handler for \(brokenCity)")
+            let task = session.dataTask(with: url) { data, response, error in
+                XCTAssertNil(data)
+                XCTAssertNil(response)
+                XCTAssertNotNil(error)
+
+                defer { expect.fulfill() }
+            }
+            task.resume()
+            waitForExpectations(timeout: 12)
+        }
     }
 }
 


### PR DESCRIPTION
also add tests for misbehaving HTTP servers.

we discovered that if the server is just returning random bytes, the whole app would crash with `fatalError("Received body data, but the header is not complete, yet.")` . The reason we can get into that state is that CURL support HTTP/0.9 [simple-responses](https://www.w3.org/Protocols/HTTP/1.0/spec.html#Message-Types) which are just the body bytes...

The issue is [also discussed on CURL's github](https://github.com/curl/curl/issues/467).

To make sure we don't regress and to document the current behaviour, I also wrote tests for a few other cases when the HTTP server is misbehaving or behaving oddly.
