### PR TITLE
Change type of the file attributes dictionary key to match the Darwin version

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -624,7 +624,7 @@ open class FileManager : NSObject {
         }
     }
     
-    open func createFile(atPath path: String, contents data: Data?, attributes attr: [String : Any]? = [:]) -> Bool {
+    open func createFile(atPath path: String, contents data: Data?, attributes attr: [FileAttributeKey : Any]? = nil) -> Bool {
         do {
             try (data ?? Data()).write(to: URL(fileURLWithPath: path), options: .atomic)
             return true


### PR DESCRIPTION
`FileManager` already uses `FileAttributeKey` instead of `String` as key type for attribute dictionaries for all methods except `createFile`. I changed it there to make the method compatible with the Darwin version.
This is a small but API breaking change. How are such cases handled usually?