### PR TITLE
JSONSerialization: add WritingOptions.sortedKeys

### DIFF
--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -532,7 +532,7 @@ private struct JSONWriter {
                         throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.propertyListReadCorrupt.rawValue, userInfo: ["NSDebugDescription" : "NSDictionary key must be NSString"])
                 }
                 let options: NSString.CompareOptions = [.numeric, .caseInsensitive, .forcedOrdering]
-                let range = a.startIndex ..< a.endIndex
+                let range: Range<String.Index>  = a.startIndex..<a.endIndex
                 let locale = NSLocale.systemLocale()
 
                 return a.compare(b, options: options, range: range, locale: locale) == .orderedAscending

--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -531,7 +531,11 @@ private struct JSONWriter {
                     let b = b.key as? String else {
                         throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.propertyListReadCorrupt.rawValue, userInfo: ["NSDebugDescription" : "NSDictionary key must be NSString"])
                 }
-                return a < b
+                let options: NSString.CompareOptions = [.numeric, .caseInsensitive, .forcedOrdering]
+                let range = a.startIndex ..< a.endIndex
+                let locale = NSLocale.systemLocale()
+
+                return a.compare(b, options: options, range: range, locale: locale) == .orderedAscending
             })
             for elem in elems {
                 try serializeDictionaryElement(key: elem.key, value: elem.value)

--- a/TestFoundation/TestNSJSONSerialization.swift
+++ b/TestFoundation/TestNSJSONSerialization.swift
@@ -945,11 +945,12 @@ extension TestNSJSONSerialization {
             ("test_booleanJSONObject", test_booleanJSONObject),
             ("test_serialize_dictionaryWithDecimal", test_serialize_dictionaryWithDecimal),
             ("test_serializeDecimalNumberJSONObject", test_serializeDecimalNumberJSONObject),
+            ("test_serializeSortedKeys", test_serializeSortedKeys),
         ]
     }
 
-    func trySerialize(_ obj: Any) throws -> String {
-        let data = try JSONSerialization.data(withJSONObject: obj, options: [])
+    func trySerialize(_ obj: Any, options: JSONSerialization.WritingOptions = []) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: obj, options: options)
         guard let string = String(data: data, encoding: .utf8) else {
             XCTFail("Unable to create string")
             return ""
@@ -1334,6 +1335,19 @@ extension TestNSJSONSerialization {
         } catch {
             XCTFail("Failed during serialization")
         }
+    } 
+    
+    func test_serializeSortedKeys() {
+        var dict: [String: Any]
+
+        dict = ["z": 1, "y": 1, "x": 1, "w": 1, "v": 1, "u": 1, "t": 1, "s": 1, "r": 1, "q": 1, ]
+        XCTAssertEqual(try trySerialize(dict, options: .sortedKeys), "{\"q\":1,\"r\":1,\"s\":1,\"t\":1,\"u\":1,\"v\":1,\"w\":1,\"x\":1,\"y\":1,\"z\":1}")
+
+        dict = ["aaaa": 1, "aaa": 1, "aa": 1, "a": 1]
+        XCTAssertEqual(try trySerialize(dict, options: .sortedKeys), "{\"a\":1,\"aa\":1,\"aaa\":1,\"aaaa\":1}")
+
+        dict = ["c": ["c":1,"b":1,"a":1],"b":["c":1,"b":1,"a":1],"a":["c":1,"b":1,"a":1]]
+        XCTAssertEqual(try trySerialize(dict, options: .sortedKeys), "{\"a\":{\"a\":1,\"b\":1,\"c\":1},\"b\":{\"a\":1,\"b\":1,\"c\":1},\"c\":{\"a\":1,\"b\":1,\"c\":1}}")
     }
 
     fileprivate func createTestFile(_ path: String,_contents: Data) -> String? {


### PR DESCRIPTION
This implements the new `sortedKeys` constant in `JSONSerialization.WritingOptions` and adds some tests.  This constant is documented at https://developer.apple.com/documentation/foundation/jsonserialization.writingoptions - it is new in the macOS 10.13 SDK.

This option is used by the new Swift 4 `JSONEncoder` which has been [recently implemented](https://github.com/apple/swift-corelibs-foundation/pull/1048).

**Note: I am still doing performance testing on this to check it doesn't regress the non-sorted case, but I'm opening the PR for review and comment now.**

CC: @bubski @itaiferber 