### PR TITLE
For https: to work on Android

### DIFF
--- a/Foundation/NSURLSession/http/EasyHandle.swift
+++ b/Foundation/NSURLSession/http/EasyHandle.swift
@@ -174,7 +174,7 @@ extension _EasyHandle {
             // at the path pointed to by the URLSessionCAInfo env var.
             // Downloadable here: https://curl.haxx.se/ca/cacert.pem
             if let caInfo = getenv("URLSessionCAInfo")  {
-                if String(cString: caInfo) == "UNSAFE_NOVERIFY" {
+                if String(cString: caInfo) == "UNSAFE_SSL_NOVERIFY" {
                     try! CFURLSession_easy_setopt_int(rawHandle, CFURLSessionOptionSSL_VERIFYPEER, 0).asError()
                 }
                 else {

--- a/Foundation/NSURLSession/http/EasyHandle.swift
+++ b/Foundation/NSURLSession/http/EasyHandle.swift
@@ -635,7 +635,7 @@ extension _EasyHandle._CurlStringList {
 #if os(Android)
 extension URLSession {
 
-    public static func setCAInfoFile( _ _CAInfoFile: String ) {
+    public static func setCAInfoFile(_ _CAInfoFile: String) {
         free(_EasyHandle._CAInfoFile)
         _CAInfoFile.withCString {
             _EasyHandle._CAInfoFile = strdup($0)

--- a/Foundation/NSURLSession/http/EasyHandle.swift
+++ b/Foundation/NSURLSession/http/EasyHandle.swift
@@ -282,7 +282,7 @@ fileprivate func printLibcurlDebug(handle: CFURLSessionEasyHandle, type: CInt, d
 
 fileprivate func printLibcurlDebug(type: CFURLSessionInfo, data: String, task: URLSessionTask) {
     // libcurl sends is data with trailing CRLF which inserts lots of newlines into our output.
-    print("[\(task.taskIdentifier)] \(type.debugHeader) \(data.mapControlToPictures)")
+    NSLog("[\(task.taskIdentifier)] \(type.debugHeader) \(data.mapControlToPictures)")
 }
 
 fileprivate extension String {


### PR DESCRIPTION
Hi, just wondering whether you would consider merging this change to allow https: fetches using NSURLSession to work on Android. It turns out there is a root certificate authorities file required by libcurl for SSL to work.

This PR gives the user the opportunity to provide one and specify it’s location in the environment variable “URLSessionCAInfo” for it to be configured correctly. As providing an absolute path to anything is spectacularly difficult in Android or if the user’s servers are self-signed it also gives the user the option to specify the value “UNSAFE_SSL_NOVERIFY” and SSL hostname verification will not be performed at all.

The advantage of an environment variable over increasing the API surface is that the value can come all the way from the Java side of the application where it is most likely to know the path.

How does this sound?