### PR TITLE
Locale: rename systemLocale() to system

### DIFF
--- a/Foundation/NSJSONSerialization.swift
+++ b/Foundation/NSJSONSerialization.swift
@@ -533,7 +533,7 @@ private struct JSONWriter {
                 }
                 let options: NSString.CompareOptions = [.numeric, .caseInsensitive, .forcedOrdering]
                 let range: Range<String.Index>  = a.startIndex..<a.endIndex
-                let locale = NSLocale.systemLocale()
+                let locale = NSLocale.system
 
                 return a.compare(b, options: options, range: range, locale: locale) == .orderedAscending
             })

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -84,7 +84,7 @@ extension NSLocale {
         return CFLocaleCopyCurrent()._swiftObject
     }
     
-    open class func systemLocale() -> Locale {
+    open class var system: Locale {
         return CFLocaleGetSystem()._swiftObject
     }
 }


### PR DESCRIPTION
As documented at https://developer.apple.com/documentation/foundation/nslocale/1407691-system