### PR TITLE
Use the file attribute dictionary passed to createFile

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -627,6 +627,9 @@ open class FileManager : NSObject {
     open func createFile(atPath path: String, contents data: Data?, attributes attr: [FileAttributeKey : Any]? = nil) -> Bool {
         do {
             try (data ?? Data()).write(to: URL(fileURLWithPath: path), options: .atomic)
+            if let attr = attr {
+                try self.setAttributes(attr, ofItemAtPath: path)
+            }
             return true
         } catch _ {
             return false

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -84,6 +84,29 @@ class TestFileManager : XCTestCase {
         } catch {
             XCTFail("Failed to clean up file")
         }
+
+        let permissions = NSNumber(value: Int16(0o753))
+        let attributes = [FileAttributeKey.posixPermissions: permissions]
+        XCTAssertTrue(fm.createFile(atPath: path, contents: Data(),
+                                    attributes: attributes))
+        guard let retrievedAtributes = try? fm.attributesOfItem(atPath: path) else {
+            XCTFail("Failed to retrieve file attributes from created file")
+            return
+        }
+
+        XCTAssertTrue(retrievedAtributes.contains(where: { (attribute) -> Bool in
+            guard let attributeValue = attribute.value as? NSNumber else {
+                return false
+            }
+            return (attribute.key == .posixPermissions)
+                && (attributeValue == permissions)
+        }))
+
+        do {
+            try fm.removeItem(atPath: path)
+        } catch {
+            XCTFail("Failed to clean up file")
+        }
     }
 
     func test_moveFile() {


### PR DESCRIPTION
Currently the optional `attributes` parameter is ignored in `createFile`.  
I added a call to `setAttributes` (if applicable) to the implementation and some test code to the existing `test_createFile` case.