### PR TITLE
[Linux] Remove swift_begin/swift_end from libFoundation.a

### DIFF
--- a/lib/product.py
+++ b/lib/product.py
@@ -182,6 +182,8 @@ class StaticLibrary(Library):
     def generate(self, objects = []):
         self.rule = "Archive"
         self.product_name = Configuration.current.target.static_library_prefix + self.name + Configuration.current.target.static_library_suffix
+        self.conformance_begin = ''
+        self.conformance_end = ''
         return Library.generate(self, [], objects)
 
 class StaticAndDynamicLibrary(StaticLibrary, DynamicLibrary):


### PR DESCRIPTION
- swift_begin.o and swift_end.o should only be added to dynamic
  libraries and to the executable, which covers any static libraries
  that are linked in.