### PR TITLE
XML: correct API signatures

### DIFF
--- a/Foundation/NSXMLDTD.swift
+++ b/Foundation/NSXMLDTD.swift
@@ -22,7 +22,7 @@ open class XMLDTD : XMLNode {
         NSUnimplemented()
     }
     
-    public convenience init(contentsOf url: URL, options: Options = []) throws {
+    public convenience init(contentsOf url: URL, options mask: XMLNode.Options = []) throws {
         let urlString = url.absoluteString
 
         guard let node = _CFXMLParseDTD(urlString) else {
@@ -32,7 +32,7 @@ open class XMLDTD : XMLNode {
         self.init(ptr: node)
     }
 
-    public convenience init(data: Data, options: Options = []) throws {
+    public convenience init(data: Data, options mask: XMLNode.Options = []) throws {
         var unmanagedError: Unmanaged<CFError>? = nil
         
         guard let node = _CFXMLParseDTDFromData(data._cfObject, &unmanagedError) else {

--- a/Foundation/NSXMLDTDNode.swift
+++ b/Foundation/NSXMLDTDNode.swift
@@ -80,7 +80,7 @@ open class XMLDTDNode: XMLNode {
         super.init(ptr: ptr)
     } //primitive
     
-    public override init(kind: Kind, options: Options = []) {
+    public override init(kind: XMLNode.Kind, options: XMLNode.Options = []) {
         let ptr: _CFXMLNodePtr
 
         switch kind {
@@ -99,7 +99,7 @@ open class XMLDTDNode: XMLNode {
         @method dtdKind
         @abstract Sets the DTD sub kind.
     */
-    open var dtdKind: DTDKind {
+    open var dtdKind: XMLDTDNode.DTDKind {
         switch _CFXMLNodeGetType(_xmlNode) {
         case _kCFXMLDTDNodeTypeElement:
             switch _CFXMLDTDElementNodeGetType(_xmlNode) {

--- a/Foundation/NSXMLDocument.swift
+++ b/Foundation/NSXMLDocument.swift
@@ -68,34 +68,34 @@ open class XMLDocument : XMLNode {
         @method initWithXMLString:options:error:
         @abstract Returns a document created from either XML or HTML, if the HTMLTidy option is set. Parse errors are returned in <tt>error</tt>.
     */
-    public convenience init(xmlString string: String, options: Options) throws {
+    public convenience init(xmlString string: String, options mask: XMLNode.Options = []) throws {
         guard let data = string.data(using: .utf8) else {
             // TODO: Throw an error
             fatalError("String: '\(string)' could not be converted to NSData using UTF-8 encoding")
         }
 
-        try self.init(data: data, options: options)
+        try self.init(data: data, options: mask)
     }
 
     /*!
         @method initWithContentsOfURL:options:error:
         @abstract Returns a document created from the contents of an XML or HTML URL. Connection problems such as 404, parse errors are returned in <tt>error</tt>.
     */
-    public convenience init(contentsOf url: URL, options: Options) throws {
+    public convenience init(contentsOf url: URL, options mask: XMLNode.Options = []) throws {
         let data = try Data(contentsOf: url, options: .mappedIfSafe)
 
-        try self.init(data: data, options: options)
+        try self.init(data: data, options: mask)
     }
 
     /*!
         @method initWithData:options:error:
         @abstract Returns a document created from data. Parse errors are returned in <tt>error</tt>.
     */
-    public init(data: Data, options: Options) throws {
-        let docPtr = _CFXMLDocPtrFromDataWithOptions(data._cfObject, Int32(options.rawValue))
+    public init(data: Data, options mask: XMLNode.Options = []) throws {
+        let docPtr = _CFXMLDocPtrFromDataWithOptions(data._cfObject, Int32(mask.rawValue))
         super.init(ptr: _CFXMLNodePtr(docPtr))
 
-        if options.contains(.documentValidate) {
+        if mask.contains(.documentValidate) {
             try validate()
         }
     }
@@ -170,7 +170,7 @@ open class XMLDocument : XMLNode {
         @method documentContentKind
         @abstract The kind of document.
     */
-    open var documentContentKind: ContentKind  {
+    open var documentContentKind: XMLDocument.ContentKind  {
         get {
             let properties = _CFXMLDocProperties(_xmlDoc)
 
@@ -311,14 +311,14 @@ open class XMLDocument : XMLNode {
         @method XMLData
         @abstract Invokes XMLDataWithOptions with NSXMLNodeOptionsNone.
     */
-    /*@NSCopying*/ open var xmlData: Data { return xmlData(withOptions: []) }
+    /*@NSCopying*/ open var xmlData: Data { return xmlData() }
 
     /*!
         @method XMLDataWithOptions:
         @abstract The representation of this node as it would appear in an XML document, encoded based on characterEncoding.
     */
-    open func xmlData(withOptions options: Options) -> Data {
-        let string = xmlString(withOptions: options)
+    open func xmlData(options: XMLNode.Options = []) -> Data {
+        let string = xmlString(options: options)
         // TODO: support encodings other than UTF-8
 
         return string.data(using: .utf8) ?? Data()

--- a/Foundation/NSXMLElement.swift
+++ b/Foundation/NSXMLElement.swift
@@ -27,9 +27,9 @@ open class XMLElement: XMLNode {
         @method initWithName:URI:
         @abstract Returns an element whose full QName is specified.
     */
-    public init(name: String, uri: String?) {
+    public init(name: String, uri URI: String?) {
         super.init(kind: .element, options: [])
-        self.uri = uri
+        self.uri = URI
         self.name = name
     }
 
@@ -53,7 +53,7 @@ open class XMLElement: XMLNode {
         NSUnimplemented()
     }
 
-    public convenience override init(kind: Kind, options: Options = []) {
+    public convenience override init(kind: XMLNode.Kind, options: XMLNode.Options = []) {
         self.init(name: "", uri: nil)
     }
 
@@ -69,7 +69,7 @@ open class XMLElement: XMLNode {
         @method elementsForLocalName:URI
         @abstract Returns all of the child elements that match this localname URI pair.
     */
-    open func elements(forLocalName localName: String, uri: String?) -> [XMLElement] { NSUnimplemented() }
+    open func elements(forLocalName localName: String, uri URI: String?) -> [XMLElement] { NSUnimplemented() }
 
     /*!
         @method addAttribute:
@@ -169,7 +169,7 @@ open class XMLElement: XMLNode {
         @method attributeForLocalName:URI:
         @abstract Returns an attribute matching this localname URI pair.
     */
-    open func attribute(forLocalName localName: String, uri: String?) -> XMLNode? {
+    open func attribute(forLocalName localName: String, uri URI: String?) -> XMLNode? {
         NSUnimplemented()
     }
 

--- a/Foundation/NSXMLNode.swift
+++ b/Foundation/NSXMLNode.swift
@@ -42,7 +42,7 @@ open class XMLNode: NSObject, NSCopying {
         case processingInstruction
         case comment
         case text
-        case dtd
+        case DTDKind
         case entityDeclaration
         case attributeDeclaration
         case elementDeclaration
@@ -101,7 +101,7 @@ open class XMLNode: NSObject, NSCopying {
         @method initWithKind:
         @abstract Invokes @link initWithKind:options: @/link with options set to NSXMLNodeOptionsNone
     */
-    public convenience init(kind: Kind) {
+    public convenience init(kind: XMLNode.Kind) {
         self.init(kind: kind, options: [])
     }
 
@@ -109,7 +109,7 @@ open class XMLNode: NSObject, NSCopying {
         @method initWithKind:options:
         @abstract Inits a node with fidelity options as description NSXMLNodeOptions.h
     */
-    public init(kind: Kind, options: Options = []) {
+    public init(kind: XMLNode.Kind, options: XMLNode.Options = []) {
 
         switch kind {
         case .document:
@@ -123,7 +123,7 @@ open class XMLNode: NSObject, NSCopying {
         case .attribute:
             _xmlNode = _CFXMLNodePtr(_CFXMLNewProperty(nil, "", ""))
 
-        case .dtd:
+        case .DTDKind:
             _xmlNode = _CFXMLNewDTD(nil, "", "", "")
             
         default:
@@ -260,7 +260,7 @@ open class XMLNode: NSObject, NSCopying {
         @method kind
         @abstract Returns an element, attribute, entity, or notation DTD node based on the full XML string.
     */
-    open var kind: Kind  {
+    open var kind: XMLNode.Kind  {
         switch _CFXMLNodeGetType(_xmlNode) {
         case _kCFXMLTypeElement:
             return .element
@@ -272,7 +272,7 @@ open class XMLNode: NSObject, NSCopying {
             return .document
 
         case _kCFXMLTypeDTD:
-            return .dtd
+            return .DTDKind
 
         case _kCFXMLDTDNodeTypeElement:
             return .elementDeclaration
@@ -503,7 +503,7 @@ open class XMLNode: NSObject, NSCopying {
             fallthrough
         case .element:
             fallthrough
-        case .dtd:
+        case .DTDKind:
             return Array<XMLNode>(self as XMLNode)
 
         default:
@@ -546,7 +546,7 @@ open class XMLNode: NSObject, NSCopying {
         @method previousNode:
         @abstract Returns the previous node in document order. This can be used to walk the tree backwards.
     */
-    /*@NSCopying*/ open var previousNode: XMLNode? {
+    /*@NSCopying*/ open var previous: XMLNode? {
         if let previousSibling = self.previousSibling {
             if let lastChild = _CFXMLNodeGetLastChild(previousSibling._xmlNode) {
                 return XMLNode._objectNodeForNode(lastChild)
@@ -564,7 +564,7 @@ open class XMLNode: NSObject, NSCopying {
         @method nextNode:
         @abstract Returns the next node in document order. This can be used to walk the tree forwards.
     */
-    /*@NSCopying*/ open var nextNode: XMLNode? {
+    /*@NSCopying*/ open var next: XMLNode? {
         if let children = _CFXMLNodeGetFirstChild(_xmlNode) {
             return XMLNode._objectNodeForNode(children)
         } else if let next = nextSibling {
@@ -728,14 +728,14 @@ open class XMLNode: NSObject, NSCopying {
         @abstract The representation of this node as it would appear in an XML document.
     */
     open var xmlString: String {
-        return xmlString(withOptions: [])
+        return xmlString()
     }
 
     /*!
         @method XMLStringWithOptions:
         @abstract The representation of this node as it would appear in an XML document, with various output options available.
     */
-    open func xmlString(withOptions options: Options) -> String {
+    open func xmlString(options: XMLNode.Options = []) -> String {
         return _CFXMLStringWithOptions(_xmlNode, UInt32(options.rawValue))._swiftObject
     }
 
@@ -788,7 +788,7 @@ open class XMLNode: NSObject, NSCopying {
         case .document:
             _CFXMLFreeDocument(_CFXMLDocPtr(_xmlNode))
 
-        case .dtd:
+        case .DTDKind:
             _CFXMLFreeDTD(_CFXMLDTDPtr(_xmlNode))
 
         case .attribute:

--- a/TestFoundation/TestNSXMLDocument.swift
+++ b/TestFoundation/TestNSXMLDocument.swift
@@ -93,15 +93,15 @@ class TestNSXMLDocument : XCTestCase {
         fooNode.addChild(bazNode)
         node.addChild(barNode)
 
-        XCTAssert(doc.nextNode === node)
-        XCTAssert(doc.nextNode?.nextNode === fooNode)
-        XCTAssert(doc.nextNode?.nextNode?.nextNode === bazNode)
-        XCTAssert(doc.nextNode?.nextNode?.nextNode?.nextNode === barNode)
+        XCTAssert(doc.next === node)
+        XCTAssert(doc.next?.next === fooNode)
+        XCTAssert(doc.next?.next?.next === bazNode)
+        XCTAssert(doc.next?.next?.next?.next === barNode)
 
-        XCTAssert(barNode.previousNode === bazNode)
-        XCTAssert(barNode.previousNode?.previousNode === fooNode)
-        XCTAssert(barNode.previousNode?.previousNode?.previousNode === node)
-        XCTAssert(barNode.previousNode?.previousNode?.previousNode?.previousNode === doc)
+        XCTAssert(barNode.previous === bazNode)
+        XCTAssert(barNode.previous?.previous === fooNode)
+        XCTAssert(barNode.previous?.previous?.previous === node)
+        XCTAssert(barNode.previous?.previous?.previous?.previous === doc)
     }
 
     func test_xpath() {


### PR DESCRIPTION
This PR improves the accuracy of the public API signatures in the XML classes, in comparison with Darwin.

https://developer.apple.com/documentation/foundation/archives_and_serialization/xml_processing_and_modeling was used as a reference.

CC: @rothomp3 