### PR TITLE
add support to s390x platform 

### DIFF
--- a/Foundation/NSRange.swift
+++ b/Foundation/NSRange.swift
@@ -126,7 +126,7 @@ extension NSRange : Hashable {
     public var hashValue: Int {
         #if arch(i386) || arch(arm)
             return Int(bitPattern: (UInt(bitPattern: location) | (UInt(bitPattern: length) << 16)))
-        #elseif arch(x86_64) || arch(arm64)
+        #elseif arch(x86_64) || arch(arm64) || arch(s390x)
             return Int(bitPattern: (UInt(bitPattern: location) | (UInt(bitPattern: length) << 32)))
         #endif
     }


### PR DESCRIPTION
When build on LinuxOne (s390x) found the error : 
   "Foundation/NSRange.swift:133:5: error: missing return in a function expected to return 'Int'"

Please also update branch "swift-4.0-branch"

Thanks,


