### PR TITLE
Match types when calculating remaining in FileHandle's _readDataOfLength

### DIFF
--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -76,7 +76,7 @@ open class FileHandle : NSObject, NSSecureCoding {
                 fatalError("Unable to fetch current file offset")
             }
             if off_t(statbuf.st_size) > offset {
-                var remaining = size_t(statbuf.st_size - offset)
+                var remaining = size_t(off_t(statbuf.st_size) - offset)
                 remaining = min(remaining, size_t(length))
                 
                 dynamicBuffer = malloc(remaining)


### PR DESCRIPTION
This was causing an error when trying to get the remaining amount of data.