### PR TITLE
Stub out new KeyPath APIs in NSSortDescriptor

### DIFF
--- a/Foundation/NSSortDescriptor.swift
+++ b/Foundation/NSSortDescriptor.swift
@@ -35,10 +35,13 @@ open class NSSortDescriptor: NSObject, NSSecureCoding, NSCopying {
     
     open var key: String? { NSUnimplemented() }
     open var ascending: Bool { NSUnimplemented() }
+    var keyPath: AnyKeyPath? { NSUnimplemented() }
     
     open func allowEvaluation() { NSUnimplemented() } // Force a sort descriptor which was securely decoded to allow evaluation
     
     public init(key: String?, ascending: Bool, comparator cmptr: Comparator) { NSUnimplemented() }
+    convenience init<Root, Value>(keyPath: KeyPath<Root, Value>, ascending: Bool) { NSUnimplemented() }
+    convenience init<Root, Value>(keyPath: KeyPath<Root, Value>, ascending: Bool, comparator cmptr: @escaping Comparator) { NSUnimplemented() }
     
     open var comparator: Comparator { NSUnimplemented() }
     


### PR DESCRIPTION
There are new KeyPath APIs in `NSSortDescriptor` which needed stubbing out in swift-corelibs-foundation. This PR adds those stubs using the declarations found [here](https://developer.apple.com/documentation/foundation/nssortdescriptor?changes=latest_minor)