### PR TITLE
Make public to doubleValue property SR-4396

### DIFF
--- a/Foundation/NSDecimal.swift
+++ b/Foundation/NSDecimal.swift
@@ -200,7 +200,7 @@ extension Decimal {
 }
 
 extension Decimal : Hashable, Comparable {
-    internal var doubleValue: Double {
+    public var doubleValue: Double {
         var d = 0.0
         if _length == 0 && _isNegative == 1 {
             return Double.nan


### PR DESCRIPTION
closes #SR-4396

[\[SR\-4396\] Decimal\.doubleValue should be public \- Swift](https://bugs.swift.org/browse/SR-4396?filter=10813&jql=issuetype%20%3D%20Bug%20AND%20status%20%3D%20Open%20AND%20component%20%3D%20Foundation%20AND%20assignee%20in%20(EMPTY)%20ORDER%20BY%20createdDate%20DESC)

`doubleValue` property of `Decimal` should be `public`. However, it is `internal`.