### PR TITLE
Drop RandomAccessCollection conformance for String.UTF16View

### DIFF
--- a/Foundation/ExtraStringAPIs.swift
+++ b/Foundation/ExtraStringAPIs.swift
@@ -29,6 +29,4 @@ extension String.UTF16View.Index : Strideable {
     }
 }
 
-extension String.UTF16View : RandomAccessCollection {}
-extension String.UTF16View.Indices : RandomAccessCollection {}
 


### PR DESCRIPTION
This is consistent with what we've done in the foundation overlay for
OSX.