### PR TITLE
CharacterSet : Codable implementation

### DIFF
--- a/Foundation/CharacterSet.swift
+++ b/Foundation/CharacterSet.swift
@@ -506,3 +506,20 @@ extension CharacterSet : _ObjectTypeBridgeable {
     }
     
 }
+
+extension CharacterSet : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case bitmap
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let bitmap = try container.decode(Data.self, forKey: .bitmap)
+        self.init(bitmapRepresentation: bitmap)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.bitmapRepresentation, forKey: .bitmap)
+    }
+}

--- a/Foundation/CharacterSet.swift
+++ b/Foundation/CharacterSet.swift
@@ -475,7 +475,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     
     /// Returns true if the two `CharacterSet`s are equal.
     public static func ==(lhs : CharacterSet, rhs: CharacterSet) -> Bool {
-        return lhs._mapUnmanaged { l in rhs._mapUnmanaged { r in l.isEqual(r) } }
+        return lhs._mapUnmanaged { $0.isEqual(rhs) }
     }
 }
 

--- a/Foundation/CharacterSet.swift
+++ b/Foundation/CharacterSet.swift
@@ -94,6 +94,12 @@ internal final class _SwiftNSCharacterSet : NSCharacterSet, _SwiftNativeFoundati
     override func isSuperset(of other: CharacterSet) -> Bool {
         return _mapUnmanaged { $0.isSuperset(of: other) }
     }
+
+    override var _cfObject: CFType {
+        // We cannot inherit super's unsafeBitCast(self, to: CFType.self) here, because layout of _SwiftNSCharacterSet
+        // is not compatible with CFCharacterSet. We need to bitcast the underlying NSCharacterSet instead.
+        return _mapUnmanaged { unsafeBitCast($0, to: CFType.self) }
+    }
 }
 
 /**
@@ -486,10 +492,7 @@ extension CharacterSet : _ObjectTypeBridgeable {
     
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSCharacterSet {
-        switch _wrapped.__wrapped {
-        case .Mutable(let wrapped): return wrapped.takeUnretainedValue()
-        case .Immutable(let wrapped): return wrapped.takeUnretainedValue()
-        }
+        return _wrapped
     }
     
     public static func _forceBridgeFromObjectiveC(_ input: NSCharacterSet, result: inout CharacterSet?) {

--- a/Foundation/CharacterSet.swift
+++ b/Foundation/CharacterSet.swift
@@ -469,7 +469,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     
     /// Returns true if the two `CharacterSet`s are equal.
     public static func ==(lhs : CharacterSet, rhs: CharacterSet) -> Bool {
-        return lhs._wrapped.isEqual(rhs._bridgeToObjectiveC()) // TODO: mlehew - as  NSCharacterSet
+        return lhs._mapUnmanaged { l in rhs._mapUnmanaged { r in l.isEqual(r) } }
     }
 }
 
@@ -486,7 +486,10 @@ extension CharacterSet : _ObjectTypeBridgeable {
     
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSCharacterSet {
-        return _wrapped
+        switch _wrapped.__wrapped {
+        case .Mutable(let wrapped): return wrapped.takeUnretainedValue()
+        case .Immutable(let wrapped): return wrapped.takeUnretainedValue()
+        }
     }
     
     public static func _forceBridgeFromObjectiveC(_ input: NSCharacterSet, result: inout CharacterSet?) {

--- a/TestFoundation/TestCodable.swift
+++ b/TestFoundation/TestCodable.swift
@@ -237,7 +237,8 @@ class TestCodable : XCTestCase {
         CharacterSet.punctuationCharacters,
         CharacterSet.capitalizedLetters,
         CharacterSet.symbols,
-        CharacterSet.newlines
+        CharacterSet.newlines,
+        CharacterSet(charactersIn: "abcd")
     ]
     
     func test_CharacterSet_JSON() {

--- a/TestFoundation/TestCodable.swift
+++ b/TestFoundation/TestCodable.swift
@@ -220,6 +220,31 @@ class TestCodable : XCTestCase {
             expectRoundTripEqualityThroughJSON(for: decimal)
         }
     }
+    
+    // MARK: - CharacterSet
+    lazy var characterSetValues: [CharacterSet] = [
+        CharacterSet.controlCharacters,
+        CharacterSet.whitespaces,
+        CharacterSet.whitespacesAndNewlines,
+        CharacterSet.decimalDigits,
+        CharacterSet.letters,
+        CharacterSet.lowercaseLetters,
+        CharacterSet.uppercaseLetters,
+        CharacterSet.nonBaseCharacters,
+        CharacterSet.alphanumerics,
+        CharacterSet.decomposables,
+        CharacterSet.illegalCharacters,
+        CharacterSet.punctuationCharacters,
+        CharacterSet.capitalizedLetters,
+        CharacterSet.symbols,
+        CharacterSet.newlines
+    ]
+    
+    func test_CharacterSet_JSON() {
+        for characterSet in characterSetValues {
+            expectRoundTripEqualityThroughJSON(for: characterSet)
+        }
+    }
 
 }
 
@@ -235,6 +260,7 @@ extension TestCodable {
             ("test_IndexPath_JSON", test_IndexPath_JSON),
             ("test_AffineTransform_JSON", test_AffineTransform_JSON),
             ("test_Decimal_JSON", test_Decimal_JSON),
+            ("test_CharacterSet_JSON", test_CharacterSet_JSON),
         ]
     }
 }

--- a/TestFoundation/TestNSCharacterSet.swift
+++ b/TestFoundation/TestNSCharacterSet.swift
@@ -15,9 +15,9 @@ import SwiftFoundation
 import SwiftXCTest
 #endif
 
-private struct Box {
-    fileprivate let ns: NSCharacterSet
-    fileprivate let swift: CharacterSet
+private struct Box: Equatable {
+    private let ns: NSCharacterSet
+    private let swift: CharacterSet
     
     private init(ns: NSCharacterSet, swift: CharacterSet) {
         self.ns = ns
@@ -38,68 +38,22 @@ private struct Box {
         return Box(ns: NSCharacterSet.decimalDigits._bridgeToObjectiveC(),
                    swift: CharacterSet.decimalDigits)
     }
-}
 
-private func assertEqual(_ lhs: Box,
-                         _ rhs: Box,
-                         _ message: @autoclosure () -> String = "",
-                         file: StaticString = #file,
-                         line: UInt = #line) {
-    
-    assert(equal: true, lhs, rhs, message, file: file, line: line)
-}
+    // MARK: Equatable
 
-private func assertNotEqual(_ lhs: Box,
-                            _ rhs: Box,
-                            _ message: @autoclosure () -> String = "",
-                            file: StaticString = #file,
-                            line: UInt = #line) {
-    
-    assert(equal: false, lhs, rhs, message, file: file, line: line)
-}
-
-private func assert<T: Equatable>(equal: Bool,
-                                  _ lhs: T,
-                                  _ rhs: T,
-                                  _ message: @autoclosure () -> String = "",
-                                  file: StaticString = #file,
-                                  line: UInt = #line) {
-    
-    if equal {
-        XCTAssertEqual(lhs, rhs, message, file: file, line: line)
-    }
-    else {
-        XCTAssertNotEqual(lhs, rhs, message, file: file, line: line)
-    }
-}
-
-private func assert(equal: Bool,
-                    _ lhs: Box,
-                    _ rhs: Box,
-                    _ message: @autoclosure () -> String = "",
-                    file: StaticString = #file,
-                    line: UInt = #line) {
-    
-    for pair in [(lhs, rhs), (rhs, lhs)] {
-        assert(equal: equal, pair.0.ns, pair.1.ns, message, file: file, line: line)
-        assert(equal: equal, pair.0.swift, pair.1.swift, message, file: file, line: line)
-        
-        assert(equal: equal,
-               pair.0.ns._bridgeToSwift(),
-               pair.1.ns._bridgeToSwift(),
-               message,
-               file: file,
-               line: line)
-        
-        assert(equal: equal,
-               pair.0.swift._bridgeToObjectiveC(),
-               pair.1.swift._bridgeToObjectiveC(),
-               message,
-               file: file,
-               line: line)
-        
-        XCTAssertTrue(pair.0.ns.isEqual(pair.1.ns) == equal, message, file: file, line: line)
-        XCTAssertTrue(pair.0.ns.isEqual(pair.1.swift) == equal, message, file: file, line: line)
+    static func ==(lhs: Box, rhs: Box) -> Bool {
+        return lhs.ns == rhs.ns
+            && lhs.swift == rhs.swift
+            && lhs.ns._bridgeToSwift() == rhs.ns._bridgeToSwift()
+            && lhs.swift._bridgeToObjectiveC() == rhs.swift._bridgeToObjectiveC()
+            && lhs.ns.isEqual(rhs.ns)
+            && lhs.ns.isEqual(rhs.swift)
+            && lhs.ns.isEqual(rhs.ns._bridgeToSwift())
+            && lhs.ns.isEqual(rhs.swift._bridgeToObjectiveC())
+            && lhs.swift._bridgeToObjectiveC().isEqual(rhs.ns)
+            && lhs.swift._bridgeToObjectiveC().isEqual(rhs.swift)
+            && lhs.swift._bridgeToObjectiveC().isEqual(rhs.ns._bridgeToSwift())
+            && lhs.swift._bridgeToObjectiveC().isEqual(rhs.swift._bridgeToObjectiveC())
     }
 }
 
@@ -389,14 +343,14 @@ class TestNSCharacterSet : XCTestCase {
         ]
         
         for pair in equalPairs {
-            assertEqual(Box(charactersIn: pair.0), Box(charactersIn: pair.1))
+            XCTAssertEqual(Box(charactersIn: pair.0), Box(charactersIn: pair.1))
         }
-        assertEqual(Box.alphanumerics, Box.alphanumerics)
+        XCTAssertEqual(Box.alphanumerics, Box.alphanumerics)
         
         for pair in notEqualPairs {
-            assertNotEqual(Box(charactersIn: pair.0), Box(charactersIn: pair.1))
+            XCTAssertNotEqual(Box(charactersIn: pair.0), Box(charactersIn: pair.1))
         }
-        assertNotEqual(Box.alphanumerics, Box.decimalDigits)
+        XCTAssertNotEqual(Box.alphanumerics, Box.decimalDigits)
     }
 
 }


### PR DESCRIPTION
Continuation of #1108
This PR mirrors _some_ changes from apple/swift#9715

---

### Added conformances + unit tests for

- CharacterSet
`CharacterSet : Equatable` was not working correctly in some cases and was fixed to make `Codable` unit tests for `CharacterSet` work.

### Not included in this PR, because of some problems that need to be solved

- Calendar
- DateComponents
- Measurement
- TimeZone

### Already implemented

- PersonNameComponents
- UUID
- URL
- NSRange
- Locale
- IndexSet
- IndexPath
- AffineTransform
- Decimal
- DateInterval
- CGFloat (unit tested indirectly)