### PR TITLE
Codable conformance added to some CG types

### DIFF
--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -187,6 +187,21 @@ extension CGRect: Equatable {
     }
 }
 
+extension CGRect : Codable {
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        let origin = try container.decode(CGPoint.self)
+        let size = try container.decode(CGSize.self)
+        self.init(origin: origin, size: size)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(origin)
+        try container.encode(size)
+    }
+}
+
 public typealias NSPoint = CGPoint
 
 public typealias NSPointPointer = UnsafeMutablePointer<NSPoint>

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -154,6 +154,21 @@ extension CGSize: NSSpecialValueCoding {
     }
 }
 
+extension CGSize : Codable {
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        let width = try container.decode(CGFloat.self)
+        let height = try container.decode(CGFloat.self)
+        self.init(width: width, height: height)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(width)
+        try container.encode(height)
+    }
+}
+
 public struct CGRect {
     public var origin: CGPoint
     public var size: CGSize

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -76,6 +76,21 @@ extension CGPoint: NSSpecialValueCoding {
     }
 }
 
+extension CGPoint : Codable {
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        let x = try container.decode(CGFloat.self)
+        let y = try container.decode(CGFloat.self)
+        self.init(x: x, y: y)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(x)
+        try container.encode(y)
+    }
+}
+
 public struct CGSize {
     public var width: CGFloat
     public var height: CGFloat

--- a/TestFoundation/TestCodable.swift
+++ b/TestFoundation/TestCodable.swift
@@ -235,6 +235,21 @@ class TestCodable : XCTestCase {
             expectRoundTripEqualityThroughJSON(for: point)
         }
     }
+    
+    // MARK: - CGSize
+    lazy var cgsizeValues: [CGSize] = [
+        CGSize(),
+        CGSize(width: 30, height: 40),
+        CGSize(width: -30, height: -40),
+        // Disabled due to limit on magnitude in JSON. See SR-5346
+        // CGSize(width: .greatestFiniteMagnitude, height: .greatestFiniteMagnitude),
+    ]
+    
+    func test_CGSize_JSON() {
+        for size in cgsizeValues {
+            expectRoundTripEqualityThroughJSON(for: size)
+        }
+    }
 
 }
 
@@ -251,6 +266,7 @@ extension TestCodable {
             ("test_AffineTransform_JSON", test_AffineTransform_JSON),
             ("test_Decimal_JSON", test_Decimal_JSON),
             ("test_CGPoint_JSON", test_CGPoint_JSON),
+            ("test_CGSize_JSON", test_CGSize_JSON),
         ]
     }
 }

--- a/TestFoundation/TestCodable.swift
+++ b/TestFoundation/TestCodable.swift
@@ -250,6 +250,24 @@ class TestCodable : XCTestCase {
             expectRoundTripEqualityThroughJSON(for: size)
         }
     }
+    
+    // MARK: - CGRect
+    lazy var cgrectValues: [CGRect] = [
+        CGRect(),
+        CGRect(origin: CGPoint(x: 10, y: 20), size: CGSize(width: 30, height: 40)),
+        CGRect(origin: CGPoint(x: -10, y: -20), size: CGSize(width: -30, height: -40)),
+        // Disabled due to limit on magnitude in JSON. See SR-5346
+        // CGRect(origin: CGPoint(x: -.greatestFiniteMagnitude / 2,
+        //                        y: -.greatestFiniteMagnitude / 2),
+        //        size: CGSize(width: .greatestFiniteMagnitude,
+        //                     height: .greatestFiniteMagnitude)),
+    ]
+    
+    func test_CGRect_JSON() {
+        for rect in cgrectValues {
+            expectRoundTripEqualityThroughJSON(for: rect)
+        }
+    }
 
 }
 
@@ -267,6 +285,7 @@ extension TestCodable {
             ("test_Decimal_JSON", test_Decimal_JSON),
             ("test_CGPoint_JSON", test_CGPoint_JSON),
             ("test_CGSize_JSON", test_CGSize_JSON),
+            ("test_CGRect_JSON", test_CGRect_JSON),
         ]
     }
 }

--- a/TestFoundation/TestCodable.swift
+++ b/TestFoundation/TestCodable.swift
@@ -220,6 +220,21 @@ class TestCodable : XCTestCase {
             expectRoundTripEqualityThroughJSON(for: decimal)
         }
     }
+    
+    // MARK: - CGPoint
+    lazy var cgpointValues: [CGPoint] = [
+        CGPoint(),
+        CGPoint(x: 10, y: 20),
+        CGPoint(x: -10, y: -20),
+        // Disabled due to limit on magnitude in JSON. See SR-5346
+        // CGPoint(x: .greatestFiniteMagnitude, y: .greatestFiniteMagnitude),
+    ]
+    
+    func test_CGPoint_JSON() {
+        for point in cgpointValues {
+            expectRoundTripEqualityThroughJSON(for: point)
+        }
+    }
 
 }
 
@@ -235,6 +250,7 @@ extension TestCodable {
             ("test_IndexPath_JSON", test_IndexPath_JSON),
             ("test_AffineTransform_JSON", test_AffineTransform_JSON),
             ("test_Decimal_JSON", test_Decimal_JSON),
+            ("test_CGPoint_JSON", test_CGPoint_JSON),
         ]
     }
 }


### PR DESCRIPTION
This PR mirrors some changes from https://github.com/apple/swift/pull/10404

---

### Added conformances + unit tests for

- CGPoint
- CGSize
- CGRect

### Not mirrored from https://github.com/apple/swift/pull/10404

- CGVector 📝
- CGAffineTransform 📝

📝 I've stumbled across [this](https://github.com/apple/swift-corelibs-foundation/pull/135), which leads me to believe that `CGVector` is not supposed to be implemented in `swift-corelibs-foundation`.
I suppose same goes for `CGAffineTransform`, since we already have `AffineTransform`/`NSAffineTransform` implemented.