### PR TITLE
NSString: add test for substring of unpaired surrogate

### DIFF
--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -1134,6 +1134,10 @@ class TestNSString : XCTestCase {
 
         let s5 = NSString(string: "\r\ncats😺")
         XCTAssertEqual(s5.substring(with: NSMakeRange(1,6)), "\ncats�")
+
+        // SR-3363
+        let s6 = NSString(string: "Beyonce\u{301} and Tay")
+        XCTAssertEqual(s6.substring(with: NSMakeRange(7, 9)), "\u{301} and Tay")
     }
 }
 


### PR DESCRIPTION
I have recently been investigating [SR-3363](https://bugs.swift.org/browse/SR-3363) which described a crash on Linux when splitting a String.  The crash has been already fixed but there was still a difference in behaviour between Darwin and Linux with the testcase.

```swift
let str = "Beyonce\u{301} and Tay"
let nsStr = NSString(string: str)
print(str)

let range = NSMakeRange(7, 9)
let substr = nsStr.substring(with: range)
print(substr)

for char in substr.utf16 {
    print(String(format:"%2x", char))
}
```

Darwin output:

```
Beyoncé and Tay
́ and Tay
301
20
61
6e
64
20
54
61
79
```

Linux output:

```
Beyoncé and Tay
� and Tay
fffd
20
61
6e
64
20
54
61
79
```

@dabrahams has now merged https://github.com/apple/swift-corelibs-foundation/pull/1130 which fixes this bug - thanks @dabrahams!

This PR adds the testcase from SR-3363 to the TestFoundation bucket to avoid regressions in this area in future.