### PR TITLE
Update access controls in NSSortDescriptor

### DIFF
--- a/Foundation/NSSortDescriptor.swift
+++ b/Foundation/NSSortDescriptor.swift
@@ -35,13 +35,13 @@ open class NSSortDescriptor: NSObject, NSSecureCoding, NSCopying {
     
     open var key: String? { NSUnimplemented() }
     open var ascending: Bool { NSUnimplemented() }
-    var keyPath: AnyKeyPath? { NSUnimplemented() }
+    public var keyPath: AnyKeyPath? { NSUnimplemented() }
     
     open func allowEvaluation() { NSUnimplemented() } // Force a sort descriptor which was securely decoded to allow evaluation
     
     public init(key: String?, ascending: Bool, comparator cmptr: Comparator) { NSUnimplemented() }
-    convenience init<Root, Value>(keyPath: KeyPath<Root, Value>, ascending: Bool) { NSUnimplemented() }
-    convenience init<Root, Value>(keyPath: KeyPath<Root, Value>, ascending: Bool, comparator cmptr: @escaping Comparator) { NSUnimplemented() }
+    public convenience init<Root, Value>(keyPath: KeyPath<Root, Value>, ascending: Bool) { NSUnimplemented() }
+    public convenience init<Root, Value>(keyPath: KeyPath<Root, Value>, ascending: Bool, comparator cmptr: @escaping Comparator) { NSUnimplemented() }
     
     open var comparator: Comparator { NSUnimplemented() }
     


### PR DESCRIPTION
Fixes incorrect access controls with the new keyPath APIs in NSSortDescriptor. 