### PR TITLE
Provide CustomNSError default implementation

### DIFF
--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -274,10 +274,51 @@ public protocol CustomNSError : Error {
     var errorUserInfo: [String : Any] { get }
 }
 
+public extension CustomNSError {
+    /// Default domain of the error.
+    static var errorDomain: String {
+        return String(reflecting: self)
+    }
+
+    /// The error code within the given domain.
+    var errorCode: Int {
+        return _swift_getDefaultErrorCode(self)
+    }
+
+    /// The default user-info dictionary.
+    var errorUserInfo: [String : Any] {
+        return [:]
+    }
+}
+
+extension CustomNSError where Self: RawRepresentable, Self.RawValue: SignedInteger {
+    // The error code of Error with integral raw values is the raw value.
+    public var errorCode: Int {
+        return numericCast(self.rawValue)
+    }
+}
+
+extension CustomNSError where Self: RawRepresentable, Self.RawValue: UnsignedInteger {
+    // The error code of Error with integral raw values is the raw value.
+    public var errorCode: Int {
+        return numericCast(self.rawValue)
+    }
+}
+
 public extension Error where Self : CustomNSError {
     /// Default implementation for customized NSErrors.
     var _domain: String { return Self.errorDomain }
 
+    /// Default implementation for customized NSErrors.
+    var _code: Int { return self.errorCode }
+}
+
+public extension Error where Self: CustomNSError, Self: RawRepresentable, Self.RawValue: SignedInteger {
+    /// Default implementation for customized NSErrors.
+    var _code: Int { return self.errorCode }
+}
+
+public extension Error where Self: CustomNSError, Self: RawRepresentable, Self.RawValue: UnsignedInteger {
     /// Default implementation for customized NSErrors.
     var _code: Int { return self.errorCode }
 }

--- a/TestFoundation/TestNSError.swift
+++ b/TestFoundation/TestNSError.swift
@@ -16,6 +16,8 @@
     import SwiftXCTest
 #endif
 
+struct SwiftCustomNSError: Error, CustomNSError {
+}
 
 class TestNSError : XCTestCase {
     
@@ -23,6 +25,11 @@ class TestNSError : XCTestCase {
         return [
             ("test_LocalizedError_errorDescription", test_LocalizedError_errorDescription),
             ("test_NSErrorAsError_localizedDescription", test_NSErrorAsError_localizedDescription),
+            ("test_CustomNSError_domain", test_CustomNSError_domain),
+            ("test_CustomNSError_userInfo", test_CustomNSError_userInfo),
+            ("test_CustomNSError_errorCode", test_CustomNSError_errorCode),
+            ("test_CustomNSError_errorCodeRawInt", test_CustomNSError_errorCodeRawInt),
+            ("test_CustomNSError_errorCodeRawUInt", test_CustomNSError_errorCodeRawUInt),
         ]
     }
     
@@ -39,5 +46,46 @@ class TestNSError : XCTestCase {
         let nsError = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Localized!"])
         let error = nsError as Error
         XCTAssertEqual(error.localizedDescription, "Localized!")
+    }
+
+    func test_CustomNSError_domain() {
+        XCTAssertEqual(SwiftCustomNSError.errorDomain, "TestFoundation.SwiftCustomNSError")
+    }
+
+    func test_CustomNSError_userInfo() {
+        let userInfo = SwiftCustomNSError().errorUserInfo
+        XCTAssertTrue(userInfo.isEmpty)
+    }
+
+    func test_CustomNSError_errorCode() {
+        enum SwiftError : Error, CustomNSError {
+            case zero
+            case one
+            case two
+        }
+
+        XCTAssertEqual(SwiftCustomNSError().errorCode, 1)
+
+        XCTAssertEqual(SwiftError.zero.errorCode, 0)
+        XCTAssertEqual(SwiftError.one.errorCode,  1)
+        XCTAssertEqual(SwiftError.two.errorCode,  2)
+    }
+
+    func test_CustomNSError_errorCodeRawInt() {
+        enum SwiftError : Int, Error, CustomNSError {
+            case minusOne  = -1
+            case fortyTwo = 42
+        }
+
+        XCTAssertEqual(SwiftError.minusOne.errorCode,  -1)
+        XCTAssertEqual(SwiftError.fortyTwo.errorCode, 42)
+    }
+
+    func test_CustomNSError_errorCodeRawUInt() {
+        enum SwiftError : UInt, Error, CustomNSError {
+            case fortyTwo = 42
+        }
+
+        XCTAssertEqual(SwiftError.fortyTwo.errorCode, 42)
     }
 }


### PR DESCRIPTION
Pull default CustomNSError implementation from https://github.com/apple/swift/blob/master/stdlib/public/SDK/Foundation/NSError.swift