### PR TITLE
Special values and initializers for some CG types

### DIFF
--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -117,6 +117,20 @@ public struct CGSize {
     }
 }
 
+extension CGSize {
+    public static var zero: CGSize {
+        return CGSize(width: CGFloat(0), height: CGFloat(0))
+    }
+    
+    public init(width: Int, height: Int) {
+        self.init(width: CGFloat(width), height: CGFloat(height))
+    }
+    
+    public init(width: Double, height: Double) {
+        self.init(width: CGFloat(width), height: CGFloat(height))
+    }
+}
+
 extension CGSize: Equatable {
     public static func ==(lhs: CGSize, rhs: CGSize) -> Bool {
         return lhs.width == rhs.width && lhs.height == rhs.height

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -209,6 +209,24 @@ public struct CGRect {
     }
 }
 
+extension CGRect {
+    public static var zero: CGRect {
+        return CGRect(origin: CGPoint(), size: CGSize())
+    }
+    
+    public init(x: CGFloat, y: CGFloat, width: CGFloat, height: CGFloat) {
+        self.init(origin: CGPoint(x: x, y: y), size: CGSize(width: width, height: height))
+    }
+    
+    public init(x: Double, y: Double, width: Double, height: Double) {
+        self.init(origin: CGPoint(x: x, y: y), size: CGSize(width: width, height: height))
+    }
+    
+    public init(x: Int, y: Int, width: Int, height: Int) {
+        self.init(origin: CGPoint(x: x, y: y), size: CGSize(width: width, height: height))
+    }
+}
+
 extension CGRect: Equatable {
     public static func ==(lhs: CGRect, rhs: CGRect) -> Bool {
         return lhs.origin == rhs.origin && lhs.size == rhs.size

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -25,6 +25,20 @@ public struct CGPoint {
     }
 }
 
+extension CGPoint {
+    public static var zero: CGPoint {
+        return CGPoint(x: CGFloat(0), y: CGFloat(0))
+    }
+    
+    public init(x: Int, y: Int) {
+        self.init(x: CGFloat(x), y: CGFloat(y))
+    }
+    
+    public init(x: Double, y: Double) {
+        self.init(x: CGFloat(x), y: CGFloat(y))
+    }
+}
+
 extension CGPoint: Equatable {
     public static func ==(lhs: CGPoint, rhs: CGPoint) -> Bool {
         return lhs.x == rhs.x && lhs.y == rhs.y

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -227,6 +227,18 @@ extension CGRect {
     }
 }
 
+extension CGRect {
+    public static let null = CGRect(x: CGFloat.infinity,
+                                    y: CGFloat.infinity,
+                                    width: CGFloat(0),
+                                    height: CGFloat(0))
+    
+    public static let infinite = CGRect(x: -CGFloat.greatestFiniteMagnitude / 2,
+                                        y: -CGFloat.greatestFiniteMagnitude / 2,
+                                        width: CGFloat.greatestFiniteMagnitude,
+                                        height: CGFloat.greatestFiniteMagnitude)
+}
+
 extension CGRect: Equatable {
     public static func ==(lhs: CGRect, rhs: CGRect) -> Bool {
         return lhs.origin == rhs.origin && lhs.size == rhs.size

--- a/TestFoundation/TestNSGeometry.swift
+++ b/TestFoundation/TestNSGeometry.swift
@@ -29,6 +29,7 @@ class TestNSGeometry : XCTestCase {
             ("test_CGPoint_BasicConstruction", test_CGPoint_BasicConstruction),
             ("test_CGPoint_ExtendedConstruction", test_CGPoint_ExtendedConstruction),
             ("test_CGSize_BasicConstruction", test_CGSize_BasicConstruction),
+            ("test_CGSize_ExtendedConstruction", test_CGSize_ExtendedConstruction),
             ("test_CGRect_BasicConstruction", test_CGRect_BasicConstruction),
             ("test_NSEdgeInsets_BasicConstruction", test_NSEdgeInsets_BasicConstruction),
             ("test_NSEdgeInsetsEqual", test_NSEdgeInsetsEqual),
@@ -136,6 +137,20 @@ class TestNSGeometry : XCTestCase {
         let s2 = CGSize(width: CGFloat(3.6), height: CGFloat(4.5))
         XCTAssertEqual(s2.width, CGFloat(3.6))
         XCTAssertEqual(s2.height, CGFloat(4.5))
+    }
+    
+    func test_CGSize_ExtendedConstruction() {
+        let s1 = CGSize.zero
+        XCTAssertEqual(s1.width, CGFloat(0))
+        XCTAssertEqual(s1.height, CGFloat(0))
+        
+        let s2 = CGSize(width: Int(3), height: Int(4))
+        XCTAssertEqual(s2.width, CGFloat(3))
+        XCTAssertEqual(s2.height, CGFloat(4))
+        
+        let s3 = CGSize(width: Double(3.6), height: Double(4.5))
+        XCTAssertEqual(s3.width, CGFloat(3.6))
+        XCTAssertEqual(s3.height, CGFloat(4.5))
     }
 
     func test_CGRect_BasicConstruction() {

--- a/TestFoundation/TestNSGeometry.swift
+++ b/TestFoundation/TestNSGeometry.swift
@@ -32,6 +32,7 @@ class TestNSGeometry : XCTestCase {
             ("test_CGSize_ExtendedConstruction", test_CGSize_ExtendedConstruction),
             ("test_CGRect_BasicConstruction", test_CGRect_BasicConstruction),
             ("test_CGRect_ExtendedConstruction", test_CGRect_ExtendedConstruction),
+            ("test_CGRect_SpecialValues", test_CGRect_SpecialValues),
             ("test_NSEdgeInsets_BasicConstruction", test_NSEdgeInsets_BasicConstruction),
             ("test_NSEdgeInsetsEqual", test_NSEdgeInsetsEqual),
             ("test_NSMakePoint", test_NSMakePoint),
@@ -194,6 +195,20 @@ class TestNSGeometry : XCTestCase {
         XCTAssertEqual(r4.origin.y, CGFloat(2))
         XCTAssertEqual(r4.size.width, CGFloat(3))
         XCTAssertEqual(r4.size.height, CGFloat(4))
+    }
+    
+    func test_CGRect_SpecialValues() {
+        let r1 = CGRect.null
+        XCTAssertEqual(r1.origin.x, CGFloat.infinity)
+        XCTAssertEqual(r1.origin.y, CGFloat.infinity)
+        XCTAssertEqual(r1.size.width, CGFloat(0.0))
+        XCTAssertEqual(r1.size.height, CGFloat(0.0))
+        
+        let r2 = CGRect.infinite
+        XCTAssertEqual(r2.origin.x, -CGFloat.greatestFiniteMagnitude / 2)
+        XCTAssertEqual(r2.origin.y, -CGFloat.greatestFiniteMagnitude / 2)
+        XCTAssertEqual(r2.size.width, CGFloat.greatestFiniteMagnitude)
+        XCTAssertEqual(r2.size.height, CGFloat.greatestFiniteMagnitude)
     }
 
     func test_NSEdgeInsets_BasicConstruction() {

--- a/TestFoundation/TestNSGeometry.swift
+++ b/TestFoundation/TestNSGeometry.swift
@@ -27,6 +27,7 @@ class TestNSGeometry : XCTestCase {
             ("test_CGFloat_LessThanOrEqual", test_CGFloat_LessThanOrEqual),
             ("test_CGFloat_GreaterThanOrEqual", test_CGFloat_GreaterThanOrEqual),
             ("test_CGPoint_BasicConstruction", test_CGPoint_BasicConstruction),
+            ("test_CGPoint_ExtendedConstruction", test_CGPoint_ExtendedConstruction),
             ("test_CGSize_BasicConstruction", test_CGSize_BasicConstruction),
             ("test_CGRect_BasicConstruction", test_CGRect_BasicConstruction),
             ("test_NSEdgeInsets_BasicConstruction", test_NSEdgeInsets_BasicConstruction),
@@ -111,6 +112,20 @@ class TestNSGeometry : XCTestCase {
         let p2 = CGPoint(x: CGFloat(3.6), y: CGFloat(4.5))
         XCTAssertEqual(p2.x, CGFloat(3.6))
         XCTAssertEqual(p2.y, CGFloat(4.5))
+    }
+    
+    func test_CGPoint_ExtendedConstruction() {
+        let p1 = CGPoint.zero
+        XCTAssertEqual(p1.x, CGFloat(0))
+        XCTAssertEqual(p1.y, CGFloat(0))
+        
+        let p2 = CGPoint(x: Int(3), y: Int(4))
+        XCTAssertEqual(p2.x, CGFloat(3))
+        XCTAssertEqual(p2.y, CGFloat(4))
+        
+        let p3 = CGPoint(x: Double(3.6), y: Double(4.5))
+        XCTAssertEqual(p3.x, CGFloat(3.6))
+        XCTAssertEqual(p3.y, CGFloat(4.5))
     }
 
     func test_CGSize_BasicConstruction() {

--- a/TestFoundation/TestNSGeometry.swift
+++ b/TestFoundation/TestNSGeometry.swift
@@ -31,6 +31,7 @@ class TestNSGeometry : XCTestCase {
             ("test_CGSize_BasicConstruction", test_CGSize_BasicConstruction),
             ("test_CGSize_ExtendedConstruction", test_CGSize_ExtendedConstruction),
             ("test_CGRect_BasicConstruction", test_CGRect_BasicConstruction),
+            ("test_CGRect_ExtendedConstruction", test_CGRect_ExtendedConstruction),
             ("test_NSEdgeInsets_BasicConstruction", test_NSEdgeInsets_BasicConstruction),
             ("test_NSEdgeInsetsEqual", test_NSEdgeInsetsEqual),
             ("test_NSMakePoint", test_NSMakePoint),
@@ -167,6 +168,32 @@ class TestNSGeometry : XCTestCase {
         XCTAssertEqual(r2.origin.y, p.y)
         XCTAssertEqual(r2.size.width, s.width)
         XCTAssertEqual(r2.size.height, s.height)
+    }
+    
+    func test_CGRect_ExtendedConstruction() {
+        let r1 = CGRect.zero
+        XCTAssertEqual(r1.origin.x, CGFloat(0.0))
+        XCTAssertEqual(r1.origin.y, CGFloat(0.0))
+        XCTAssertEqual(r1.size.width, CGFloat(0.0))
+        XCTAssertEqual(r1.size.height, CGFloat(0.0))
+        
+        let r2 = CGRect(x: CGFloat(1.2), y: CGFloat(2.3), width: CGFloat(3.4), height: CGFloat(4.5))
+        XCTAssertEqual(r2.origin.x, CGFloat(1.2))
+        XCTAssertEqual(r2.origin.y, CGFloat(2.3))
+        XCTAssertEqual(r2.size.width, CGFloat(3.4))
+        XCTAssertEqual(r2.size.height, CGFloat(4.5))
+        
+        let r3 = CGRect(x: Double(1.2), y: Double(2.3), width: Double(3.4), height: Double(4.5))
+        XCTAssertEqual(r3.origin.x, CGFloat(1.2))
+        XCTAssertEqual(r3.origin.y, CGFloat(2.3))
+        XCTAssertEqual(r3.size.width, CGFloat(3.4))
+        XCTAssertEqual(r3.size.height, CGFloat(4.5))
+        
+        let r4 = CGRect(x: Int(1), y: Int(2), width: Int(3), height: Int(4))
+        XCTAssertEqual(r4.origin.x, CGFloat(1))
+        XCTAssertEqual(r4.origin.y, CGFloat(2))
+        XCTAssertEqual(r4.size.width, CGFloat(3))
+        XCTAssertEqual(r4.size.height, CGFloat(4))
     }
 
     func test_NSEdgeInsets_BasicConstruction() {


### PR DESCRIPTION
- [x] `CGPoint.zero`
- [x] `CGPoint.init(x: Int, y: Int)`
- [x] `CGPoint.init(x: Double, y: Double)`
- [x] `CGSize.zero`
- [x] `CGSize.init(width: Int, height: Int)`
- [x] `CGSize.init(width: Double, height: Double)`
- [x] `CGRect.zero`
- [x] `CGRect.init(x: CGFloat, y: CGFloat, width: CGFloat, height: CGFloat)`
- [x] `CGRect.init(x: Double, y: Double, width: Double, height: Double)`
- [x] `CGRect.init(x: Int, y: Int, width: Int, height: Int)`
- [x] `CGRect.null`
- [x] `CGRect.infinite`