### PR TITLE
Use URLSessionTask.count* properties to track upload/download progress 

### DIFF
--- a/Foundation/NSURLSession/NSURLSession.swift
+++ b/Foundation/NSURLSession/NSURLSession.swift
@@ -178,7 +178,7 @@ fileprivate func nextSessionIdentifier() -> Int32 {
     sessionCounter += 1
     return sessionCounter
 }
-public let URLSessionTransferSizeUnknown: Int64 = -1
+public let NSURLSessionTransferSizeUnknown: Int64 = -1
 
 open class URLSession : NSObject {
     fileprivate let _configuration: _Configuration

--- a/Foundation/NSURLSession/NSURLSessionTask.swift
+++ b/Foundation/NSURLSession/NSURLSessionTask.swift
@@ -143,7 +143,7 @@ open class URLSessionTask : NSObject, NSCopying {
      */
     
     /// Number of body bytes already received
-    open fileprivate(set) var countOfBytesReceived: Int64 {
+    open internal(set) var countOfBytesReceived: Int64 {
         get {
             semaphore.wait()
             defer {
@@ -160,7 +160,7 @@ open class URLSessionTask : NSObject, NSCopying {
     fileprivate var _countOfBytesReceived: Int64 = 0
     
     /// Number of body bytes already sent */
-    open fileprivate(set) var countOfBytesSent: Int64 {
+    open internal(set) var countOfBytesSent: Int64 {
         get {
             semaphore.wait()
             defer {
@@ -178,10 +178,10 @@ open class URLSessionTask : NSObject, NSCopying {
     fileprivate var _countOfBytesSent: Int64 = 0
     
     /// Number of body bytes we expect to send, derived from the Content-Length of the HTTP request */
-    open fileprivate(set) var countOfBytesExpectedToSend: Int64 = 0
+    open internal(set) var countOfBytesExpectedToSend: Int64 = 0
     
     /// Number of byte bytes we expect to receive, usually derived from the Content-Length header of an HTTP response. */
-    open fileprivate(set) var countOfBytesExpectedToReceive: Int64 = 0
+    open internal(set) var countOfBytesExpectedToReceive: Int64 = 0
     
     /// The taskDescription property is available for the developer to
     /// provide a descriptive label for the task.


### PR DESCRIPTION
This is a kind of an extension to #1121 

We had defined three private properties in URLSessionTask to track upload & download progress and make delegate calls. It turns out that the URLSessionTask API defines [four properties](https://developer.apple.com/documentation/foundation/urlsessiontask/1410663-countofbytesexpectedtoreceive) to do the same. This PR replaces the uses of the private properties with these.

Also, the constant `URLSessionTransferSizeUnknown` is changed to `NSURLSessionTransferSizeUnknown` to match Darwin.