### PR TITLE
Fix ld warning

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0383A1751D2E558A0052E5D1 /* TestNSStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0383A1741D2E558A0052E5D1 /* TestNSStream.swift */; };
-                03B6F5841F15F339004F25AF /* TestNSURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B6F5831F15F339004F25AF /* TestNSURLProtocol.swift */; };
+		03B6F5841F15F339004F25AF /* TestNSURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B6F5831F15F339004F25AF /* TestNSURLProtocol.swift */; };
 		1520469B1D8AEABE00D02E36 /* HTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1520469A1D8AEABE00D02E36 /* HTTPServer.swift */; };
 		159884921DCC877700E3314C /* TestNSHTTPCookieStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159884911DCC877700E3314C /* TestNSHTTPCookieStorage.swift */; };
 		231503DB1D8AEE5D0061694D /* TestNSDecimal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231503DA1D8AEE5D0061694D /* TestNSDecimal.swift */; };
@@ -481,7 +481,7 @@
 
 /* Begin PBXFileReference section */
 		0383A1741D2E558A0052E5D1 /* TestNSStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSStream.swift; sourceTree = "<group>"; };
-                03B6F5831F15F339004F25AF /* TestNSURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNSURLProtocol.swift; sourceTree = "<group>"; };
+		03B6F5831F15F339004F25AF /* TestNSURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNSURLProtocol.swift; sourceTree = "<group>"; };
 		1520469A1D8AEABE00D02E36 /* HTTPServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPServer.swift; sourceTree = "<group>"; };
 		159884911DCC877700E3314C /* TestNSHTTPCookieStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNSHTTPCookieStorage.swift; sourceTree = "<group>"; };
 		22B9C1E01C165D7A00DECFF9 /* TestNSDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSDate.swift; sourceTree = "<group>"; };
@@ -1487,7 +1487,7 @@
 				CC5249BF1D341D23007CB54D /* TestUnitConverter.swift */,
 				D4FE895A1D703D1100DA7986 /* TestURLRequest.swift */,
 				5B6F17961C48631C00935030 /* TestUtils.swift */,
-                                03B6F5831F15F339004F25AF /* TestNSURLProtocol.swift */,
+				03B6F5831F15F339004F25AF /* TestNSURLProtocol.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -2376,7 +2376,7 @@
 				BF8E65311DC3B3CB005AB5C3 /* TestNotification.swift in Sources */,
 				63DCE9D41EAA432400E9CB02 /* TestISO8601DateFormatter.swift in Sources */,
 				EA01AAEC1DA839C4008F4E07 /* TestProgress.swift in Sources */,
-                                03B6F5841F15F339004F25AF /* TestNSURLProtocol.swift in Sources */,
+				03B6F5841F15F339004F25AF /* TestNSURLProtocol.swift in Sources */,
 				5B13B3411C582D4C00651CE2 /* TestNSRegularExpression.swift in Sources */,
 				5B13B3491C582D4C00651CE2 /* TestNSTimeZone.swift in Sources */,
 				5B13B34B1C582D4C00651CE2 /* TestNSURLRequest.swift in Sources */,
@@ -2797,7 +2797,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = "../swift-corelibs-xctest/build/Debug";
+				FRAMEWORK_SEARCH_PATHS = "";
 				HEADER_SEARCH_PATHS = (
 					"$(CONFIGURATION_BUILD_DIR)/usr/local/include",
 					/usr/include/libxml2,
@@ -2823,7 +2823,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = "../swift-corelibs-xctest/build/Release";
+				FRAMEWORK_SEARCH_PATHS = "";
 				HEADER_SEARCH_PATHS = (
 					"$(CONFIGURATION_BUILD_DIR)/usr/local/include",
 					/usr/include/libxml2,


### PR DESCRIPTION
When building the `TestFoundation` target in Xcode 9 beta 4, `ld` reports the following warning:

```
Ld /Users/ipartrid/Library/Developer/Xcode/DerivedData/Foundation-dlbuoxyagtlausbjtyopapynebeb/Build/Products/Debug/TestFoundation.app/Contents/MacOS/TestFoundation normal x86_64
    cd /Users/ipartrid/swift-corelibs-foundation
    export MACOSX_DEPLOYMENT_TARGET=10.11
    /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -arch x86_64 -isysroot /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -L/Users/ipartrid/Library/Developer/Xcode/DerivedData/Foundation-dlbuoxyagtlausbjtyopapynebeb/Build/Products/Debug -F/Users/ipartrid/Library/Developer/Xcode/DerivedData/Foundation-dlbuoxyagtlausbjtyopapynebeb/Build/Products/Debug -F../swift-corelibs-xctest/build/Debug -filelist /Users/ipartrid/Library/Developer/Xcode/DerivedData/Foundation-dlbuoxyagtlausbjtyopapynebeb/Build/Intermediates.noindex/Foundation.build/Debug/TestFoundation.build/Objects-normal/x86_64/TestFoundation.LinkFileList -Xlinker -rpath -Xlinker @executable_path/../Frameworks -Xlinker -rpath -Xlinker @loader_path/../Frameworks -mmacosx-version-min=10.11 -Xlinker -object_path_lto -Xlinker /Users/ipartrid/Library/Developer/Xcode/DerivedData/Foundation-dlbuoxyagtlausbjtyopapynebeb/Build/Intermediates.noindex/Foundation.build/Debug/TestFoundation.build/Objects-normal/x86_64/TestFoundation_lto.o -Xlinker -export_dynamic -Xlinker -no_deduplicate -fobjc-link-runtime -L/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx -Xlinker -add_ast_path -Xlinker /Users/ipartrid/Library/Developer/Xcode/DerivedData/Foundation-dlbuoxyagtlausbjtyopapynebeb/Build/Intermediates.noindex/Foundation.build/Debug/TestFoundation.build/Objects-normal/x86_64/TestFoundation.swiftmodule -framework SwiftFoundation -Xlinker -dependency_info -Xlinker /Users/ipartrid/Library/Developer/Xcode/DerivedData/Foundation-dlbuoxyagtlausbjtyopapynebeb/Build/Intermediates.noindex/Foundation.build/Debug/TestFoundation.build/Objects-normal/x86_64/TestFoundation_dependency_info.dat -o /Users/ipartrid/Library/Developer/Xcode/DerivedData/Foundation-dlbuoxyagtlausbjtyopapynebeb/Build/Products/Debug/TestFoundation.app/Contents/MacOS/TestFoundation

ld: warning: directory not found for option '-F../swift-corelibs-xctest/build/Debug'
```

As far as I can tell, this directory is just not used by the build system and I'm not sure why it's been added to the Framework Search Paths for that target.

This PR removes the references, and hence the warning. Also minor whitespace fixes which Xcode did at the same time as removing the references.