### PR TITLE
Add availability indicator to XMLElement to indicate correct function

### DIFF
--- a/Foundation/NSXMLElement.swift
+++ b/Foundation/NSXMLElement.swift
@@ -327,9 +327,10 @@ open class XMLElement: XMLNode {
 
 extension XMLElement {
     /*!
-        @method setAttributesAsDictionary:
+        @method setAttributesAs:
         @abstract Set the attributes base on a name-value dictionary.
-        @discussion This method is deprecated and does not function correctly. Use -setAttributesWithDictionary: instead.
+        @discussion This method is deprecated and does not function correctly. Use -setAttributesWith: instead.
      */
+    @available(*, unavailable, renamed:"setAttributesWith")
     public func setAttributesAs(_ attributes: [NSObject : AnyObject]) { NSUnimplemented() }
 }


### PR DESCRIPTION
The implementation of `setAttributesAs` was deprecated bfeore the API was
copied over to the Linux implementation, and won't be implemented. By
adding an availability marker coupled with a new name, we allow for a
fix-it to run and use the new name in future compiled code.
