### PR TITLE
Fixed TimeZone.init(secondsFromGMT:) failability

### DIFF
--- a/Foundation/TimeZone.swift
+++ b/Foundation/TimeZone.swift
@@ -78,8 +78,15 @@ public struct TimeZone : Hashable, Equatable, ReferenceConvertible {
     /// Time zones created with this never have daylight savings and the offset is constant no matter the date. The identifier and abbreviation do NOT follow the POSIX convention (of minutes-west).
     ///
     /// - parameter seconds: The number of seconds from GMT.
-    /// - returns: A time zone.
-    public init(secondsFromGMT seconds: Int) {
+    /// - returns: A time zone, or `nil` if a valid time zone could not be created from `seconds`.
+    public init?(secondsFromGMT seconds: Int) {
+        // Seconds boundaries check should actually be placed in NSTimeZone.init(forSecondsFromGMT:) which should return
+        // nil if the check fails. However, NSTimeZone.init(forSecondsFromGMT:) is not a failable initializer, so it
+        // cannot return nil.
+        // It is not a failable initializer because we want to have parity with Darwin's NSTimeZone, which is
+        // Objective-C and has a wrong _Nonnull annotation.
+        if (seconds < -18 * 3600 || 18 * 3600 < seconds) { return nil }
+
         _wrapped = NSTimeZone(forSecondsFromGMT: seconds)
         _autoupdating = false
     }

--- a/Foundation/TimeZone.swift
+++ b/Foundation/TimeZone.swift
@@ -78,14 +78,10 @@ public struct TimeZone : Hashable, Equatable, ReferenceConvertible {
     /// Time zones created with this never have daylight savings and the offset is constant no matter the date. The identifier and abbreviation do NOT follow the POSIX convention (of minutes-west).
     ///
     /// - parameter seconds: The number of seconds from GMT.
-    /// - returns: A time zone, or `nil` if a valid time zone could not be created from `seconds`.
-    public init?(secondsFromGMT seconds: Int) {
-        if let r = NSTimeZone(forSecondsFromGMT: seconds) as NSTimeZone? {
-            _wrapped = r
-            _autoupdating = false
-        } else {
-            return nil
-        }
+    /// - returns: A time zone.
+    public init(secondsFromGMT seconds: Int) {
+        _wrapped = NSTimeZone(forSecondsFromGMT: seconds)
+        _autoupdating = false
     }
     
     /// Returns a time zone identified by a given abbreviation.

--- a/TestFoundation/TestNSTimeZone.swift
+++ b/TestFoundation/TestNSTimeZone.swift
@@ -143,16 +143,22 @@ class TestNSTimeZone: XCTestCase {
         let tz2 = TimeZone(secondsFromGMT: -14400)
         XCTAssertNotNil(tz2)
         let expectedName = "GMT-0400"
-        let actualName = tz2.identifier
+        let actualName = tz2?.identifier
         XCTAssertEqual(actualName, expectedName, "expected name \"\(expectedName)\" is not equal to \"\(actualName as Optional)\"")
         let expectedLocalizedName = "GMT-04:00"
-        let actualLocalizedName = tz2.localizedName(for: .generic, locale: Locale(identifier: "en_US"))
+        let actualLocalizedName = tz2?.localizedName(for: .generic, locale: Locale(identifier: "en_US"))
         XCTAssertEqual(actualLocalizedName, expectedLocalizedName, "expected name \"\(expectedLocalizedName)\" is not equal to \"\(actualLocalizedName as Optional)\"")
-        let seconds2 = tz2.secondsFromGMT()
+        let seconds2 = tz2?.secondsFromGMT() ?? 0
         XCTAssertEqual(seconds2, -14400, "GMT-0400 should be -14400 seconds but got \(seconds2) instead")
 
         let tz3 = TimeZone(identifier: "GMT-9999")
         XCTAssertNil(tz3)
+
+        XCTAssertNotNil(TimeZone(secondsFromGMT:  -18 * 3600))
+        XCTAssertNotNil(TimeZone(secondsFromGMT:  18 * 3600))
+
+        XCTAssertNil(TimeZone(secondsFromGMT:  -18 * 3600 - 1))
+        XCTAssertNil(TimeZone(secondsFromGMT:  18 * 3600 + 1))
     }
 
     func test_initializingTimeZoneWithAbbreviation() {

--- a/TestFoundation/TestNSTimeZone.swift
+++ b/TestFoundation/TestNSTimeZone.swift
@@ -143,12 +143,12 @@ class TestNSTimeZone: XCTestCase {
         let tz2 = TimeZone(secondsFromGMT: -14400)
         XCTAssertNotNil(tz2)
         let expectedName = "GMT-0400"
-        let actualName = tz2?.identifier
+        let actualName = tz2.identifier
         XCTAssertEqual(actualName, expectedName, "expected name \"\(expectedName)\" is not equal to \"\(actualName as Optional)\"")
         let expectedLocalizedName = "GMT-04:00"
-        let actualLocalizedName = tz2?.localizedName(for: .generic, locale: Locale(identifier: "en_US"))
+        let actualLocalizedName = tz2.localizedName(for: .generic, locale: Locale(identifier: "en_US"))
         XCTAssertEqual(actualLocalizedName, expectedLocalizedName, "expected name \"\(expectedLocalizedName)\" is not equal to \"\(actualLocalizedName as Optional)\"")
-        let seconds2 = tz2?.secondsFromGMT() ?? 0
+        let seconds2 = tz2.secondsFromGMT()
         XCTAssertEqual(seconds2, -14400, "GMT-0400 should be -14400 seconds but got \(seconds2) instead")
 
         let tz3 = TimeZone(identifier: "GMT-9999")


### PR DESCRIPTION
~`TimeZone.init(secondsFromGMT:)` made not failable.~

~Aligns with https://developer.apple.com/documentation/foundation/nstimezone/1387199-init~

Fixed `TimeZone.init(secondsFromGMT:)` failability