### PR TITLE
Enable Foundation to build against a new libicu

### DIFF
--- a/build.py
+++ b/build.py
@@ -106,6 +106,15 @@ if "LIBDISPATCH_SOURCE_DIR" in Configuration.current.variables:
 	])
 	foundation.LDFLAGS += '-ldispatch -L'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src/.libs -rpath \$$ORIGIN '
 
+if "LIBICU_SOURCE_DIR" in Configuration.current.variables:
+        foundation.CFLAGS += " "+" ".join([
+                '-I'+Configuration.current.variables["ICU_TMPINSTALL"]+'/include'
+        ])
+        swift_cflags += ([
+                '-I'+Configuration.current.variables["ICU_TMPINSTALL"]+'/include'
+        ])
+        foundation.LDFLAGS += '-L'+Configuration.current.variables["LIBICU_BUILD_DIR"]+'/lib '
+
 foundation.SWIFTCFLAGS = " ".join(swift_cflags)
 
 if "XCTEST_BUILD_DIR" in Configuration.current.variables:


### PR DESCRIPTION
The Swift build system has existing support for building a new version of ICU, via the `--libicu` flag, or by specifying the `libicu=true` and `install-libicu` targets in a preset.

It may be desirable to be able to do this on Linux in order to match the version of ICU used on the OSX platform, for two reasons:
- Equivalence of behavior across platforms: differences in the implementation of ICU on OSX versus Linux can otherwise lead to different results from Foundation (see: https://bugs.swift.org/browse/SR-5591)
- Performance: the level of ICU that ships on earlier distros such as Ubuntu 14.04 performs poorly when comparing ASCII strings (see apple/swift#7339).

However, the plumbing to make Foundation build against the newly built libicu is missing: it currently picks up the system version, which causes the build to fail with messages such as:
```
../build/buildbot_linux/foundation-linux-x86_64/Foundation/CoreFoundation/Locale.subproj/CFCalendar.c.o: In function `__CFCalendarCreateUCalendar':
CoreFoundation/Locale.subproj/CFCalendar.c:(.text+0x15f): undefined reference to `ucal_open_55'
../build/buildbot_linux/foundation-linux-x86_64/Foundation/CoreFoundation/Locale.subproj/CFCalendar.c.o: In function `_CFCalendarIsWeekend':
CoreFoundation/Locale.subproj/CFCalendar.c:(.text+0x1eb): undefined reference to `ucal_isWeekend_55'
```

This PR adds the necessary flags to build against the new libicu.  I replicated the style of the existing solution for the Dispatch libraries.  

This has no prereqs, however changes to the build-script (https://github.com/apple/swift/pull/11266) are required before it will have any effect.