### PR TITLE
SR-5591: Update broken DateFormatter tests

### DIFF
--- a/TestFoundation/TestDateFormatter.swift
+++ b/TestFoundation/TestDateFormatter.swift
@@ -192,19 +192,21 @@ class TestDateFormatter: XCTestCase {
     // FullStyle
     // locale  stringFromDate                       example
     // ------  --------------                       -------------------------
-    // en_US   EEEE, MMMM d, y 'at' h:mm:ss a zzzz  Friday, December 25, 2015 at 12:00:00 AM GMT
+    // en_US   EEEE, MMMM d, y 'at' h:mm:ss a zzzz  Friday, December 25, 2015 at 12:00:00 AM Greenwich Mean Time
     func test_dateStyleFull() {
-        
-        let timestamps = [
-            -31536000 : "Wednesday, January 1, 1969 at 12:00:00 AM GMT" , 0.0 : "Thursday, January 1, 1970 at 12:00:00 AM GMT",
-            31536000 : "Friday, January 1, 1971 at 12:00:00 AM GMT", 2145916800 : "Friday, January 1, 2038 at 12:00:00 AM GMT",
-            1456272000 : "Wednesday, February 24, 2016 at 12:00:00 AM GMT", 1456358399 : "Wednesday, February 24, 2016 at 11:59:59 PM GMT",
-            1452574638 : "Tuesday, January 12, 2016 at 4:57:18 AM GMT", 1455685038 : "Wednesday, February 17, 2016 at 4:57:18 AM GMT",
-            1458622638 : "Tuesday, March 22, 2016 at 4:57:18 AM GMT", 1459745838 : "Monday, April 4, 2016 at 4:57:18 AM GMT",
-            1462597038 : "Saturday, May 7, 2016 at 4:57:18 AM GMT", 1465534638 : "Friday, June 10, 2016 at 4:57:18 AM GMT",
-            1469854638 : "Saturday, July 30, 2016 at 4:57:18 AM GMT", 1470718638 : "Tuesday, August 9, 2016 at 4:57:18 AM GMT",
-            1473915438 : "Thursday, September 15, 2016 at 4:57:18 AM GMT", 1477285038 : "Monday, October 24, 2016 at 4:57:18 AM GMT",
-            1478062638 : "Wednesday, November 2, 2016 at 4:57:18 AM GMT", 1482641838 : "Sunday, December 25, 2016 at 4:57:18 AM GMT"
+
+#if os(OSX) // timestyle .full is currently broken on Linux, the timezone should be 'Greenwich Mean Time' not 'GMT'
+        let timestamps: [TimeInterval:String] = [
+            // Negative time offsets are still buggy on macOS
+            -31536000 : "Wednesday, January 1, 1969 at 12:00:00 AM GMT", 0.0 : "Thursday, January 1, 1970 at 12:00:00 AM Greenwich Mean Time",
+            31536000 : "Friday, January 1, 1971 at 12:00:00 AM Greenwich Mean Time", 2145916800 : "Friday, January 1, 2038 at 12:00:00 AM Greenwich Mean Time",
+            1456272000 : "Wednesday, February 24, 2016 at 12:00:00 AM Greenwich Mean Time", 1456358399 : "Wednesday, February 24, 2016 at 11:59:59 PM Greenwich Mean Time",
+            1452574638 : "Tuesday, January 12, 2016 at 4:57:18 AM Greenwich Mean Time", 1455685038 : "Wednesday, February 17, 2016 at 4:57:18 AM Greenwich Mean Time",
+            1458622638 : "Tuesday, March 22, 2016 at 4:57:18 AM Greenwich Mean Time", 1459745838 : "Monday, April 4, 2016 at 4:57:18 AM Greenwich Mean Time",
+            1462597038 : "Saturday, May 7, 2016 at 4:57:18 AM Greenwich Mean Time", 1465534638 : "Friday, June 10, 2016 at 4:57:18 AM Greenwich Mean Time",
+            1469854638 : "Saturday, July 30, 2016 at 4:57:18 AM Greenwich Mean Time", 1470718638 : "Tuesday, August 9, 2016 at 4:57:18 AM Greenwich Mean Time",
+            1473915438 : "Thursday, September 15, 2016 at 4:57:18 AM Greenwich Mean Time", 1477285038 : "Monday, October 24, 2016 at 4:57:18 AM Greenwich Mean Time",
+            1478062638 : "Wednesday, November 2, 2016 at 4:57:18 AM Greenwich Mean Time", 1482641838 : "Sunday, December 25, 2016 at 4:57:18 AM Greenwich Mean Time"
         ]
         
         let f = DateFormatter()
@@ -220,32 +222,33 @@ class TestDateFormatter: XCTestCase {
 
             XCTAssertEqual(sf, stringResult)
         }
-        
+#endif
     }
     
     // Custom Style
     // locale  stringFromDate                        example
     // ------  --------------                        -------------------------
-    // en_US   EEEE, MMMM d, y 'at' hh:mm:ss a zzzz  Friday, December 25, 2015 at 12:00:00 AM GMT
+    // en_US   EEEE, MMMM d, y 'at' hh:mm:ss a zzzz  Friday, December 25, 2015 at 12:00:00 AM Greenwich Mean Time
     func test_customDateFormat() {
-
         let timestamps = [
-             -31536000 : "Wednesday, January 1, 1969 at 12:00:00 AM GMT" , 0.0 : "Thursday, January 1, 1970 at 12:00:00 AM GMT",
-             31536000 : "Friday, January 1, 1971 at 12:00:00 AM GMT", 2145916800 : "Friday, January 1, 2038 at 12:00:00 AM GMT",
-             1456272000 : "Wednesday, February 24, 2016 at 12:00:00 AM GMT", 1456358399 : "Wednesday, February 24, 2016 at 11:59:59 PM GMT",
-             1452574638 : "Tuesday, January 12, 2016 at 04:57:18 AM GMT", 1455685038 : "Wednesday, February 17, 2016 at 04:57:18 AM GMT",
-             1458622638 : "Tuesday, March 22, 2016 at 04:57:18 AM GMT", 1459745838 : "Monday, April 4, 2016 at 04:57:18 AM GMT",
-             1462597038 : "Saturday, May 7, 2016 at 04:57:18 AM GMT", 1465534638 : "Friday, June 10, 2016 at 04:57:18 AM GMT",
-             1469854638 : "Saturday, July 30, 2016 at 04:57:18 AM GMT", 1470718638 : "Tuesday, August 9, 2016 at 04:57:18 AM GMT",
-             1473915438 : "Thursday, September 15, 2016 at 04:57:18 AM GMT", 1477285038 : "Monday, October 24, 2016 at 04:57:18 AM GMT",
-             1478062638 : "Wednesday, November 2, 2016 at 04:57:18 AM GMT", 1482641838 : "Sunday, December 25, 2016 at 04:57:18 AM GMT"
+             // Negative time offsets are still buggy on macOS
+             -31536000 : "Wednesday, January 1, 1969 at 12:00:00 AM GMT", 0.0 : "Thursday, January 1, 1970 at 12:00:00 AM Greenwich Mean Time",
+             31536000 : "Friday, January 1, 1971 at 12:00:00 AM Greenwich Mean Time", 2145916800 : "Friday, January 1, 2038 at 12:00:00 AM Greenwich Mean Time",
+             1456272000 : "Wednesday, February 24, 2016 at 12:00:00 AM Greenwich Mean Time", 1456358399 : "Wednesday, February 24, 2016 at 11:59:59 PM Greenwich Mean Time",
+             1452574638 : "Tuesday, January 12, 2016 at 04:57:18 AM Greenwich Mean Time", 1455685038 : "Wednesday, February 17, 2016 at 04:57:18 AM Greenwich Mean Time",
+             1458622638 : "Tuesday, March 22, 2016 at 04:57:18 AM Greenwich Mean Time", 1459745838 : "Monday, April 4, 2016 at 04:57:18 AM Greenwich Mean Time",
+             1462597038 : "Saturday, May 7, 2016 at 04:57:18 AM Greenwich Mean Time", 1465534638 : "Friday, June 10, 2016 at 04:57:18 AM Greenwich Mean Time",
+             1469854638 : "Saturday, July 30, 2016 at 04:57:18 AM Greenwich Mean Time", 1470718638 : "Tuesday, August 9, 2016 at 04:57:18 AM Greenwich Mean Time",
+             1473915438 : "Thursday, September 15, 2016 at 04:57:18 AM Greenwich Mean Time", 1477285038 : "Monday, October 24, 2016 at 04:57:18 AM Greenwich Mean Time",
+             1478062638 : "Wednesday, November 2, 2016 at 04:57:18 AM Greenwich Mean Time", 1482641838 : "Sunday, December 25, 2016 at 04:57:18 AM Greenwich Mean Time"
         ]
         
         let f = DateFormatter()
-        f.dateFormat = "EEEE, MMMM d, y 'at' hh:mm:ss a zzzz"
         f.timeZone = TimeZone(identifier: DEFAULT_TIMEZONE)
         f.locale = Locale(identifier: DEFAULT_LOCALE)
-        
+
+#if os(OSX) // timestyle zzzz is currently broken on Linux
+        f.dateFormat = "EEEE, MMMM d, y 'at' hh:mm:ss a zzzz"
         for (timestamp, stringResult) in timestamps {
             
             let testDate = Date(timeIntervalSince1970: timestamp)
@@ -253,7 +256,8 @@ class TestDateFormatter: XCTestCase {
             
             XCTAssertEqual(sf, stringResult)
         }
-        
+#endif
+
         let quarterTimestamps: [Double : String] = [
             1451679712 : "1", 1459542112 : "2", 1467404512 : "3", 1475353312 : "4"
         ]


### PR DESCRIPTION
- The tests were broken for timestyle .full and failed on macOS.
  Fix the tests so that they work correctly on macOS.

- DateFormatter is still broken on Linux so disable the tests for
  now until the Linux implementation can be fixed.