### PR TITLE
Codable conformance to some Foundation types

### DIFF
--- a/Foundation/Calendar.swift
+++ b/Foundation/Calendar.swift
@@ -1189,3 +1189,36 @@ extension Calendar: _ObjectTypeBridgeable {
         return result!
     }
 }
+
+extension Calendar : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case identifier
+        case locale
+        case timeZone
+        case firstWeekday
+        case minimumDaysInFirstWeek
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let identifierString = try container.decode(String.self, forKey: .identifier)
+        let identifier = Calendar._fromNSCalendarIdentifier(NSCalendar.Identifier(rawValue: identifierString))
+        self.init(identifier: identifier)
+
+        self.locale = try container.decodeIfPresent(Locale.self, forKey: .locale)
+        self.timeZone = try container.decode(TimeZone.self, forKey: .timeZone)
+        self.firstWeekday = try container.decode(Int.self, forKey: .firstWeekday)
+        self.minimumDaysInFirstWeek = try container.decode(Int.self, forKey: .minimumDaysInFirstWeek)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        let identifier = Calendar._toNSCalendarIdentifier(self.identifier).rawValue
+        try container.encode(identifier, forKey: .identifier)
+        try container.encode(self.locale, forKey: .locale)
+        try container.encode(self.timeZone, forKey: .timeZone)
+        try container.encode(self.firstWeekday, forKey: .firstWeekday)
+        try container.encode(self.minimumDaysInFirstWeek, forKey: .minimumDaysInFirstWeek)
+    }
+}

--- a/Foundation/DateComponents.swift
+++ b/Foundation/DateComponents.swift
@@ -341,3 +341,83 @@ extension DateComponents : _ObjectTypeBridgeable {
     }
 }
 
+extension DateComponents : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case calendar
+        case timeZone
+        case era
+        case year
+        case month
+        case day
+        case hour
+        case minute
+        case second
+        case nanosecond
+        case weekday
+        case weekdayOrdinal
+        case quarter
+        case weekOfMonth
+        case weekOfYear
+        case yearForWeekOfYear
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container  = try decoder.container(keyedBy: CodingKeys.self)
+        let calendar   = try container.decodeIfPresent(Calendar.self, forKey: .calendar)
+        let timeZone   = try container.decodeIfPresent(TimeZone.self, forKey: .timeZone)
+        let era        = try container.decodeIfPresent(Int.self, forKey: .era)
+        let year       = try container.decodeIfPresent(Int.self, forKey: .year)
+        let month      = try container.decodeIfPresent(Int.self, forKey: .month)
+        let day        = try container.decodeIfPresent(Int.self, forKey: .day)
+        let hour       = try container.decodeIfPresent(Int.self, forKey: .hour)
+        let minute     = try container.decodeIfPresent(Int.self, forKey: .minute)
+        let second     = try container.decodeIfPresent(Int.self, forKey: .second)
+        let nanosecond = try container.decodeIfPresent(Int.self, forKey: .nanosecond)
+
+        let weekday           = try container.decodeIfPresent(Int.self, forKey: .weekday)
+        let weekdayOrdinal    = try container.decodeIfPresent(Int.self, forKey: .weekdayOrdinal)
+        let quarter           = try container.decodeIfPresent(Int.self, forKey: .quarter)
+        let weekOfMonth       = try container.decodeIfPresent(Int.self, forKey: .weekOfMonth)
+        let weekOfYear        = try container.decodeIfPresent(Int.self, forKey: .weekOfYear)
+        let yearForWeekOfYear = try container.decodeIfPresent(Int.self, forKey: .yearForWeekOfYear)
+
+        self.init(calendar: calendar,
+                  timeZone: timeZone,
+                  era: era,
+                  year: year,
+                  month: month,
+                  day: day,
+                  hour: hour,
+                  minute: minute,
+                  second: second,
+                  nanosecond: nanosecond,
+                  weekday: weekday,
+                  weekdayOrdinal: weekdayOrdinal,
+                  quarter: quarter,
+                  weekOfMonth: weekOfMonth,
+                  weekOfYear: weekOfYear,
+                  yearForWeekOfYear: yearForWeekOfYear)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        // TODO: Replace all with encodeIfPresent, when added.
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        if self.calendar   != nil { try container.encode(self.calendar!, forKey: .calendar) }
+        if self.timeZone   != nil { try container.encode(self.timeZone!, forKey: .timeZone) }
+        if self.era        != nil { try container.encode(self.era!, forKey: .era) }
+        if self.year       != nil { try container.encode(self.year!, forKey: .year) }
+        if self.month      != nil { try container.encode(self.month!, forKey: .month) }
+        if self.day        != nil { try container.encode(self.day!, forKey: .day) }
+        if self.hour       != nil { try container.encode(self.hour!, forKey: .hour) }
+        if self.minute     != nil { try container.encode(self.minute!, forKey: .minute) }
+        if self.second     != nil { try container.encode(self.second!, forKey: .second) }
+        if self.nanosecond != nil { try container.encode(self.nanosecond!, forKey: .nanosecond) }
+
+        if self.weekday           != nil { try container.encode(self.weekday!, forKey: .weekday) }
+        if self.weekdayOrdinal    != nil { try container.encode(self.weekdayOrdinal!, forKey: .weekdayOrdinal) }
+        if self.quarter           != nil { try container.encode(self.quarter!, forKey: .quarter) }
+        if self.weekOfMonth       != nil { try container.encode(self.weekOfMonth!, forKey: .weekOfMonth) }
+        if self.weekOfYear        != nil { try container.encode(self.weekOfYear!, forKey: .weekOfYear) }
+        if self.yearForWeekOfYear != nil { try container.encode(self.yearForWeekOfYear!, forKey: .yearForWeekOfYear) }
+    }
+}

--- a/Foundation/DateComponents.swift
+++ b/Foundation/DateComponents.swift
@@ -400,24 +400,23 @@ extension DateComponents : Codable {
     }
 
     public func encode(to encoder: Encoder) throws {
-        // TODO: Replace all with encodeIfPresent, when added.
         var container = encoder.container(keyedBy: CodingKeys.self)
-        if self.calendar   != nil { try container.encode(self.calendar!, forKey: .calendar) }
-        if self.timeZone   != nil { try container.encode(self.timeZone!, forKey: .timeZone) }
-        if self.era        != nil { try container.encode(self.era!, forKey: .era) }
-        if self.year       != nil { try container.encode(self.year!, forKey: .year) }
-        if self.month      != nil { try container.encode(self.month!, forKey: .month) }
-        if self.day        != nil { try container.encode(self.day!, forKey: .day) }
-        if self.hour       != nil { try container.encode(self.hour!, forKey: .hour) }
-        if self.minute     != nil { try container.encode(self.minute!, forKey: .minute) }
-        if self.second     != nil { try container.encode(self.second!, forKey: .second) }
-        if self.nanosecond != nil { try container.encode(self.nanosecond!, forKey: .nanosecond) }
+        try container.encodeIfPresent(self.calendar, forKey: .calendar)
+        try container.encodeIfPresent(self.timeZone, forKey: .timeZone)
+        try container.encodeIfPresent(self.era, forKey: .era)
+        try container.encodeIfPresent(self.year, forKey: .year)
+        try container.encodeIfPresent(self.month, forKey: .month)
+        try container.encodeIfPresent(self.day, forKey: .day)
+        try container.encodeIfPresent(self.hour, forKey: .hour)
+        try container.encodeIfPresent(self.minute, forKey: .minute)
+        try container.encodeIfPresent(self.second, forKey: .second)
+        try container.encodeIfPresent(self.nanosecond, forKey: .nanosecond)
 
-        if self.weekday           != nil { try container.encode(self.weekday!, forKey: .weekday) }
-        if self.weekdayOrdinal    != nil { try container.encode(self.weekdayOrdinal!, forKey: .weekdayOrdinal) }
-        if self.quarter           != nil { try container.encode(self.quarter!, forKey: .quarter) }
-        if self.weekOfMonth       != nil { try container.encode(self.weekOfMonth!, forKey: .weekOfMonth) }
-        if self.weekOfYear        != nil { try container.encode(self.weekOfYear!, forKey: .weekOfYear) }
-        if self.yearForWeekOfYear != nil { try container.encode(self.yearForWeekOfYear!, forKey: .yearForWeekOfYear) }
+        try container.encodeIfPresent(self.weekday, forKey: .weekday)
+        try container.encodeIfPresent(self.weekdayOrdinal, forKey: .weekdayOrdinal)
+        try container.encodeIfPresent(self.quarter, forKey: .quarter)
+        try container.encodeIfPresent(self.weekOfMonth, forKey: .weekOfMonth)
+        try container.encodeIfPresent(self.weekOfYear, forKey: .weekOfYear)
+        try container.encodeIfPresent(self.yearForWeekOfYear, forKey: .yearForWeekOfYear)
     }
 }

--- a/Foundation/TimeZone.swift
+++ b/Foundation/TimeZone.swift
@@ -280,3 +280,26 @@ extension TimeZone {
         return result!
     }
 }
+
+extension TimeZone : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case identifier
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let identifier = try container.decode(String.self, forKey: .identifier)
+
+        guard let timeZone = TimeZone(identifier: identifier) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Invalid TimeZone identifier."))
+        }
+
+        self = timeZone
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.identifier, forKey: .identifier)
+    }
+}

--- a/TestFoundation/TestCodable.swift
+++ b/TestFoundation/TestCodable.swift
@@ -317,6 +317,30 @@ class TestCodable : XCTestCase {
             expectRoundTripEqualityThroughJSON(for: timeZone)
         }
     }
+
+    // MARK: - Calendar
+    lazy var calendarValues: [Calendar] = [
+        Calendar(identifier: .gregorian),
+        Calendar(identifier: .buddhist),
+        Calendar(identifier: .chinese),
+        Calendar(identifier: .coptic),
+        Calendar(identifier: .ethiopicAmeteMihret),
+        Calendar(identifier: .ethiopicAmeteAlem),
+        Calendar(identifier: .hebrew),
+        Calendar(identifier: .iso8601),
+        Calendar(identifier: .indian),
+        Calendar(identifier: .islamic),
+        Calendar(identifier: .islamicCivil),
+        Calendar(identifier: .japanese),
+        Calendar(identifier: .persian),
+        Calendar(identifier: .republicOfChina),
+        ]
+
+    func test_Calendar_JSON() {
+        for calendar in calendarValues {
+            expectRoundTripEqualityThroughJSON(for: calendar)
+        }
+    }
 }
 
 extension TestCodable {
@@ -336,6 +360,7 @@ extension TestCodable {
             ("test_CGRect_JSON", test_CGRect_JSON),
             ("test_CharacterSet_JSON", test_CharacterSet_JSON),
             ("test_TimeZone_JSON", test_TimeZone_JSON),
+            ("test_Calendar_JSON", test_Calendar_JSON),
         ]
     }
 }

--- a/TestFoundation/TestCodable.swift
+++ b/TestFoundation/TestCodable.swift
@@ -305,6 +305,18 @@ class TestCodable : XCTestCase {
         }
     }
 
+    // MARK: - TimeZone
+    lazy var timeZoneValues: [TimeZone] = [
+        TimeZone(identifier: "America/Los_Angeles")!,
+        TimeZone(identifier: "UTC")!,
+        TimeZone.current
+    ]
+
+    func test_TimeZone_JSON() {
+        for timeZone in timeZoneValues {
+            expectRoundTripEqualityThroughJSON(for: timeZone)
+        }
+    }
 }
 
 extension TestCodable {
@@ -323,6 +335,7 @@ extension TestCodable {
             ("test_CGSize_JSON", test_CGSize_JSON),
             ("test_CGRect_JSON", test_CGRect_JSON),
             ("test_CharacterSet_JSON", test_CharacterSet_JSON),
+            ("test_TimeZone_JSON", test_TimeZone_JSON),
         ]
     }
 }

--- a/TestFoundation/TestCodable.swift
+++ b/TestFoundation/TestCodable.swift
@@ -358,8 +358,8 @@ class TestCodable : XCTestCase {
         .yearForWeekOfYear,
         .timeZone,
         .calendar,
-        // Disabled due to a bug in Calendar.dateComponents(_:from:)
-        // crashing if components include .nanosecond or .quarter
+        // [SR-5576] Disabled due to a bug in Calendar.dateComponents(_:from:) which crashes on Darwin and returns
+        // invalid values on Linux if components include .nanosecond or .quarter.
         // .nanosecond,
         // .quarter,
     ]

--- a/TestFoundation/TestCodable.swift
+++ b/TestFoundation/TestCodable.swift
@@ -341,6 +341,34 @@ class TestCodable : XCTestCase {
             expectRoundTripEqualityThroughJSON(for: calendar)
         }
     }
+
+    // MARK: - DateComponents
+    lazy var dateComponents: Set<Calendar.Component> = [
+        .era,
+        .year,
+        .month,
+        .day,
+        .hour,
+        .minute,
+        .second,
+        .weekday,
+        .weekdayOrdinal,
+        .weekOfMonth,
+        .weekOfYear,
+        .yearForWeekOfYear,
+        .timeZone,
+        .calendar,
+        // Disabled due to a bug in Calendar.dateComponents(_:from:)
+        // crashing if components include .nanosecond or .quarter
+        // .nanosecond,
+        // .quarter,
+    ]
+
+    func test_DateComponents_JSON() {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = calendar.dateComponents(dateComponents, from: Date(timeIntervalSince1970: 1501283776))
+        expectRoundTripEqualityThroughJSON(for: components)
+    }
 }
 
 extension TestCodable {
@@ -361,6 +389,7 @@ extension TestCodable {
             ("test_CharacterSet_JSON", test_CharacterSet_JSON),
             ("test_TimeZone_JSON", test_TimeZone_JSON),
             ("test_Calendar_JSON", test_Calendar_JSON),
+            ("test_DateComponents_JSON", test_DateComponents_JSON),
         ]
     }
 }


### PR DESCRIPTION
Continuation of #1108 & #1127
This PR mirrors _some_ changes from apple/swift#9715

---

### Added conformances + unit tests for

- Calendar
- DateComponents
- TimeZone

📝 I had to disable or work around some issues on Linux caused by https://bugs.swift.org/browse/SR-5598.
Broken `TimeZone.current == TimeZone(identifier: TimeZone.current.identifier)` equality causes **encode -> decode -> compare** roundtrip tests to fail.

### Not included in this PR

- Measurement

### Already implemented

- PersonNameComponents
- UUID
- URL
- NSRange
- Locale
- IndexSet
- IndexPath
- AffineTransform
- Decimal
- DateInterval
- CGFloat (unit tested indirectly)
- CharacterSet