### PR TITLE
Adds support for NSUnsupported to indicate non-availiability, and use annotations

### DIFF
--- a/Foundation/NSObjCRuntime.swift
+++ b/Foundation/NSObjCRuntime.swift
@@ -202,6 +202,13 @@ internal func NSUnimplemented(_ fn: String = #function, file: StaticString = #fi
     fatalError("\(fn) is not yet implemented", file: file, line: line)
 }
 
+internal func NSUnsupported(_ fn: String = #function, file: StaticString = #file, line: UInt = #line) -> Never {
+    #if os(Android)
+    NSLog("\(fn) is not supported on this platform. \(file):\(line)")
+    #endif
+    fatalError("\(fn) is not supported on this platform", file: file, line: line)
+}
+
 internal func NSInvalidArgument(_ message: String, method: String = #function, file: StaticString = #file, line: UInt = #line) -> Never {
     fatalError("\(method): \(message)", file: file, line: line)
 }


### PR DESCRIPTION
As suggested in https://lists.swift.org/pipermail/swift-corelibs-dev/Week-of-Mon-20170724/001254.html it would be desirable to have a differential macro (rather than `NSUnimplemented()`) to indicate whether the functionality is missing by design in this library, to distinguish it from things that are not yet implemented.

This change adds `NSUnsupported()` as a variant of `NSUnimplemented()` that has a different error message, and allows the code to be differentiated at the point of definition, as well as uses availability macros on specific methods and types known to not exist on other platforms.

Note that marking the APIs as `unavailable` instead of `deprecated` would mean that they would cause compile-time errors. We may want to do that in a future release.