### PR TITLE
[SR-1702] NSJSONSerialization.data(...) fatalErrors on bad input

### DIFF
--- a/Foundation/JSONSerialization.swift
+++ b/Foundation/JSONSerialization.swift
@@ -139,13 +139,7 @@ open class JSONSerialization : NSObject {
         } else if let container = value as? Dictionary<AnyHashable, Any> {
             try writer.serializeJSON(container)
         } else {
-            if stream {
-                throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.propertyListReadCorrupt.rawValue, userInfo: [
-                    "NSDebugDescription" : "Top-level object was not NSArray or NSDictionary"
-                    ])
-            } else {
-                fatalError("Top-level object was not NSArray or NSDictionary") // This is a fatal error in objective-c too (it is an NSInvalidArgumentException)
-            }
+            fatalError("Top-level object was not NSArray or NSDictionary") // This is a fatal error in objective-c too (it is an NSInvalidArgumentException)
         }
         
         let count = jsonStr.lengthOfBytes(using: .utf8)

--- a/TestFoundation/TestJSONSerialization.swift
+++ b/TestFoundation/TestJSONSerialization.swift
@@ -945,7 +945,6 @@ extension TestJSONSerialization {
             ("test_jsonReadingOffTheEndOfBuffers", test_jsonReadingOffTheEndOfBuffers),
             ("test_jsonObjectToOutputStreamBuffer", test_jsonObjectToOutputStreamBuffer),
             ("test_jsonObjectToOutputStreamFile", test_jsonObjectToOutputStreamFile),
-            ("test_invalidJsonObjectToStreamBuffer", test_invalidJsonObjectToStreamBuffer),
             ("test_jsonObjectToOutputStreamInsufficientBuffer", test_jsonObjectToOutputStreamInsufficientBuffer),
             ("test_booleanJSONObject", test_booleanJSONObject),
             ("test_serialize_dictionaryWithDecimal", test_serialize_dictionaryWithDecimal),
@@ -1313,14 +1312,6 @@ extension TestJSONSerialization {
         } catch {
             XCTFail("Error occurred while writing to stream")
         }
-    }
-    
-    func test_invalidJsonObjectToStreamBuffer() {
-        let str = "Invalid JSON"
-        let buffer = Array<UInt8>(repeating: 0, count: 10)
-        let outputStream = OutputStream(toBuffer: UnsafeMutablePointer(mutating: buffer), capacity: buffer.count)
-        outputStream.open()
-        XCTAssertThrowsError(try JSONSerialization.writeJSONObject(str, toStream: outputStream, options: []))
     }
     
     func test_booleanJSONObject() {


### PR DESCRIPTION
[SR-1702](https://bugs.swift.org/browse/SR-1702) NSJSONSerialization.data(withJSONObject:options:) should fatalError on bad input not throw

-removed the `throw` in the case of using a stream: in both cases in objc it is an `NSInvalidArgumentException`

-removed the test checking for the `throw` in the case of the stream (and, AFAIK, there's no good way to test for fatalErrors, but happy to be corrected on that fact)
