### PR TITLE
Use pkg-config to find libxml2 and libcurl on Linux [SR-5603]

### DIFF
--- a/configure
+++ b/configure
@@ -32,6 +32,8 @@ from lib.product import StaticAndDynamicLibrary
 from lib.product import Application
 from lib.product import Executable
 
+from lib.pkg_config import PkgConfig
+
 from lib.script import Script
 
 from lib.target import ArchSubType

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "config",
     "path",
     "phases",
+    "pkg_config",
     "product",
     "script",
     "target",

--- a/lib/pkg_config.py
+++ b/lib/pkg_config.py
@@ -1,0 +1,65 @@
+from __future__ import print_function
+
+import shlex
+import subprocess
+import sys
+
+from .config import Configuration
+
+
+class PkgConfig(object):
+    class Error(Exception):
+        """Raised when information could not be obtained from pkg-config."""
+
+    def __init__(self, package_name):
+        """Query pkg-config for information about a package.
+
+        :type package_name: str
+        :param package_name: The name of the package to query.
+        :raises PkgConfig.Error: When a call to pkg-config fails.
+        """
+        self.package_name = package_name
+        self._cflags = self._call("--cflags")
+        self._cflags_only_I = self._call("--cflags-only-I")
+        self._cflags_only_other = self._call("--cflags-only-other")
+        self._libs = self._call("--libs")
+        self._libs_only_l = self._call("--libs-only-l")
+        self._libs_only_L = self._call("--libs-only-L")
+        self._libs_only_other = self._call("--libs-only-other")
+
+    def _call(self, *pkg_config_args):
+        try:
+            cmd = [Configuration.current.pkg_config] + list(pkg_config_args) + [self.package_name]
+            print("Executing command '{}'".format(cmd), file=sys.stderr)
+            return shlex.split(subprocess.check_output(cmd))
+        except subprocess.CalledProcessError as e:
+            raise self.Error("pkg-config exited with error code {}".format(e.returncode))
+
+    @property
+    def swiftc_flags(self):
+        """Flags for this package in a format suitable for passing to `swiftc`.
+
+        :rtype: list[str]
+        """
+        return (
+                ["-Xcc {}".format(s) for s in self._cflags_only_other]
+                + ["-Xlinker {}".format(s) for s in self._libs_only_other]
+                + self._cflags_only_I
+                + self._libs_only_L
+                + self._libs_only_l)
+
+    @property
+    def cflags(self):
+        """CFLAGS for this package.
+
+        :rtype: list[str]
+        """
+        return self._cflags
+
+    @property
+    def ldflags(self):
+        """LDFLAGS for this package.
+
+        :rtype: list[str]
+        """
+        return self._libs


### PR DESCRIPTION
This allows linking swift-corelibs-foundation to packages with flags
defined by `pkg-config`, rather than hardcoded ones. There are a couple
of structural changes as well, namely that `pkg-config` will now be
executed during `configure` rather than later by `ninja`. This seems
acceptable as it's how cmake and autoconf work, but means a reconfigure
will be required if any transitive dependency of a package we depend on changes.

The other structural change is that `-lcurl` will be passed
unconditionally on platforms without pkg-config support (technically the
`pkg_config_required` variable set). This makes curl a harder dependency
on those platforms, but that seems unavoidable given that it's the only
implementation of `URLSession`.