### PR TITLE
Foundation: FileHandle.swift: memory leak in _readDataOfLength

### DIFF
--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -103,13 +103,16 @@ open class FileHandle : NSObject, NSSecureCoding {
             dynamicBuffer = _CFReallocf(dynamicBuffer!, total)
         }
         
-        if (0 == total) {
+        if total == 0 {
             free(dynamicBuffer)
         }
-        
-        if total > 0 {
+        else if total > 0 {
             let bytePtr = dynamicBuffer!.bindMemory(to: UInt8.self, capacity: total)
-            return Data(bytesNoCopy: bytePtr, count: total, deallocator: .none)
+            return Data(bytesNoCopy: bytePtr, count: total, deallocator: .free)
+        }
+        else {
+            assertionFailure("The total number of read bytes must not be negative")
+            free(dynamicBuffer)
         }
         
         return Data()


### PR DESCRIPTION
`dynamicBuffer` will never be freed if `total > 0`. Fix this by giving the underlying Data a "free" destructor. This is covered by existing tests.