### PR TITLE
Mark Bundle.unload as unsupported

### DIFF
--- a/Foundation/Bundle.swift
+++ b/Foundation/Bundle.swift
@@ -77,7 +77,8 @@ open class Bundle: NSObject {
     open var isLoaded: Bool {
         return CFBundleIsExecutableLoaded(_bundle)
     }
-    open func unload() -> Bool { NSUnimplemented() }
+    @available(*,deprecated,message:"Not available on non-Darwin platforms")
+    open func unload() -> Bool { NSUnsupported() }
     
     open func preflight() throws {
         var unmanagedError:Unmanaged<CFError>? = nil


### PR DESCRIPTION
Since NSBundle's unload mechanism is a Mach-specific concept, which
is not relevant on non-Darwin platforms, mark it as deprecated
and change the unavailability macro so that they are distinguishable
from implementations that are not yet available.