### PR TITLE
Thread: Implement more functionality

### DIFF
--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -180,6 +180,12 @@ const char *_CFProcessPath(void) {
     }
     return __CFProcessPath;
 }
+
+#else
+
+Boolean _CFIsMainThread(void) {
+    return pthread_main_np() == 1;
+}
 #endif
 
 CF_PRIVATE CFStringRef _CFProcessNameString(void) {

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -27,6 +27,7 @@
 #include <CoreFoundation/ForFoundationOnly.h>
 #include <fts.h>
 #include <pthread.h>
+#include <execinfo.h>
 
 _CF_EXPORT_SCOPE_BEGIN
 
@@ -294,6 +295,7 @@ CF_EXPORT char *_Nullable *_Nonnull _CFEnviron(void);
 CF_EXPORT void CFLog1(CFLogLevel lev, CFStringRef message);
 
 CF_EXPORT Boolean _CFIsMainThread(void);
+CF_EXPORT pthread_t _CFMainPThread;
 
 CF_EXPORT CFHashCode __CFHashDouble(double d);
 

--- a/Docs/Status.md
+++ b/Docs/Status.md
@@ -278,7 +278,7 @@ There is no _Complete_ status for test coverage because there are always additio
     | `Process`        | Mostly Complete | Substantial   | `interrupt()`, `terminate()`, `suspend()`, and `resume()` remain unimplemented                                            |
     | `Bundle`         | Mostly Complete | Incomplete    | `allBundles`, `init(for:)`, `unload()`, `classNamed()`, and `principalClass` remain unimplemented                         |
     | `ProcessInfo`    | Complete        | Substantial   |                                                                                                                           |
-    | `Thread`         | Incomplete      | Incomplete    | `isMainThread`, `mainThread`, `name`, `callStackReturnAddresses`, and `callStackSymbols` remain unimplemented             |
+    | `Thread`         | Complete        | Incomplete    |                                                                                                                           |
     | `Operation`      | Complete        | Incomplete    |                                                                                                                           |
     | `BlockOperation` | Complete        | Incomplete    |                                                                                                                           |
     | `OperationQueue` | Complete        | Incomplete    |                                                                                                                           |

--- a/Foundation/NSLock.swift
+++ b/Foundation/NSLock.swift
@@ -230,12 +230,16 @@ open class NSCondition: NSObject, NSLocking {
         }
         var ts = timespec()
         ts.tv_sec = Int(floor(ti))
-        ts.tv_nsec = Int((ti - Double(ts.tv_sec)) * 1000000000.0)
+        ts.tv_nsec = Int((ti - Double(ts.tv_sec)) * 1_000_000_000.0)
         var tv = timeval()
         withUnsafeMutablePointer(to: &tv) { t in
             gettimeofday(t, nil)
             ts.tv_sec += t.pointee.tv_sec
-            ts.tv_nsec += Int((t.pointee.tv_usec * 1000000) / 1000000000)
+            ts.tv_nsec += Int(t.pointee.tv_usec) * 1000
+            if ts.tv_nsec >= 1_000_000_000 {
+                ts.tv_sec += ts.tv_nsec / 1_000_000_000
+                ts.tv_nsec = ts.tv_nsec % 1_000_000_000
+            }
         }
         let retVal: Int32 = withUnsafePointer(to: &ts) { t in
             return pthread_cond_timedwait(cond, mutex, t)

--- a/Foundation/Operation.swift
+++ b/Foundation/Operation.swift
@@ -9,13 +9,8 @@
 
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
 import Dispatch
-#if os(Linux) || os(Android)
+#endif
 import CoreFoundation
-private func pthread_main_np() -> Int32 {
-    return _CFIsMainThread() ? 1 : 0
-}
-#endif
-#endif
 
 open class Operation : NSObject {
     let lock = NSLock()
@@ -570,7 +565,7 @@ open class OperationQueue: NSObject {
     open class var current: OperationQueue? {
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
         guard let specific = DispatchQueue.getSpecific(key: OperationQueue.OperationQueueKey) else {
-            if pthread_main_np() == 1 {
+            if _CFIsMainThread() {
                 return OperationQueue.main
             } else {
                 return nil

--- a/TestFoundation/TestThread.swift
+++ b/TestFoundation/TestThread.swift
@@ -24,6 +24,9 @@ class TestThread : XCTestCase {
             ("test_currentThread", test_currentThread ),
             ("test_threadStart", test_threadStart),
             ("test_threadName", test_threadName),
+            ("test_mainThread", test_mainThread),
+            ("test_callStackSymbols", test_callStackSymbols),
+            ("test_callStackReurnAddresses", test_callStackReturnAddresses),
         ]
     }
 
@@ -33,6 +36,7 @@ class TestThread : XCTestCase {
         XCTAssertNotNil(thread1)
         XCTAssertNotNil(thread2)
         XCTAssertEqual(thread1, thread2)
+        XCTAssertEqual(thread1, Thread.mainThread)
     }
     
     func test_threadStart() {
@@ -83,5 +87,45 @@ class TestThread : XCTestCase {
         thread3.name = "Thread3"
         XCTAssertEqual(thread3.name, "Thread3")
         XCTAssertNotEqual(thread3.name, getPThreadName())
+    }
+
+    func test_mainThread() {
+        XCTAssertTrue(Thread.isMainThread)
+        let t = Thread.mainThread
+        XCTAssertTrue(t.isMainThread)
+        let c = Thread.current
+        XCTAssertTrue(c.isMainThread)
+        XCTAssertTrue(c.isExecuting)
+        XCTAssertTrue(c.isEqual(t))
+
+        var started = false
+        let condition = NSCondition()
+        let thread = Thread() {
+            condition.lock()
+            started = true
+            XCTAssertFalse(Thread.isMainThread)
+            XCTAssertFalse(Thread.mainThread == Thread.current)
+            condition.broadcast()
+            condition.unlock()
+        }
+        thread.start()
+
+        condition.lock()
+        if !started {
+            condition.wait()
+        }
+        condition.unlock()
+    }
+
+    func test_callStackSymbols() {
+        let symbols = Thread.callStackSymbols
+        XCTAssertTrue(symbols.count > 0)
+        XCTAssertTrue(symbols.count <= 128)
+    }
+
+    func test_callStackReturnAddresses() {
+        let addresses = Thread.callStackReturnAddresses
+        XCTAssertTrue(addresses.count > 0)
+        XCTAssertTrue(addresses.count <= 128)
     }
 }

--- a/TestFoundation/TestThread.swift
+++ b/TestFoundation/TestThread.swift
@@ -40,22 +40,18 @@ class TestThread : XCTestCase {
     }
     
     func test_threadStart() {
-        var started = false
         let condition = NSCondition()
         let thread = Thread() {
             condition.lock()
-            started = true
             condition.broadcast()
             condition.unlock()
         }
         thread.start()
         
         condition.lock()
-        if !started {
-            condition.wait()
-        }
+        let ok = condition.wait(until: Date(timeIntervalSinceNow: 10))
         condition.unlock()
-        XCTAssertTrue(started)
+        XCTAssertTrue(ok, "NSCondition wait timed out")
     }
     
     func test_threadName() {
@@ -98,11 +94,9 @@ class TestThread : XCTestCase {
         XCTAssertTrue(c.isExecuting)
         XCTAssertTrue(c.isEqual(t))
 
-        var started = false
         let condition = NSCondition()
         let thread = Thread() {
             condition.lock()
-            started = true
             XCTAssertFalse(Thread.isMainThread)
             XCTAssertFalse(Thread.mainThread == Thread.current)
             condition.broadcast()
@@ -111,10 +105,9 @@ class TestThread : XCTestCase {
         thread.start()
 
         condition.lock()
-        if !started {
-            condition.wait()
-        }
+        let ok = condition.wait(until: Date(timeIntervalSinceNow: 10))
         condition.unlock()
+        XCTAssertTrue(ok, "NSCondition wait timed out")
     }
 
     func test_callStackSymbols() {

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -73,7 +73,7 @@ XCTMain([
     testCase(TestNSSet.allTests),
     testCase(TestStream.allTests),
     testCase(TestNSString.allTests),
-//    testCase(TestThread.allTests),
+    testCase(TestThread.allTests),
     testCase(TestProcess.allTests),
     testCase(TestNSTextCheckingResult.allTests),
     testCase(TestTimer.allTests),


### PR DESCRIPTION
- Eliminate _compiler_crash_fix() as no crashes are observed anymore.

- Re-enable TestThread.swift test cases.

I exposed `_CFMainPThread` since `pthread_main_thread_np()` is a `#define` and not a real function on linux and so doesn't export to swift correctly.

I used `_CFIsMainThread` instead of `pthread_main_np` for consistency and to avoid the local definition of `pthread_main_np()` in `Operation.swift` not having the same semantics as `pthread_main_np()` on macOS where it can return -1.