### PR TITLE
SR-5596: TimeZone.current returns wrong value

### DIFF
--- a/CoreFoundation/NumberDate.subproj/CFTimeZone.c
+++ b/CoreFoundation/NumberDate.subproj/CFTimeZone.c
@@ -793,7 +793,7 @@ static CFTimeZoneRef __CFTimeZoneCreateSystem(void) {
         size_t zoneInfoDirLen = CFStringGetLength(__tzZoneInfo);
         if (strncmp(linkbuf, tzZoneInfo, zoneInfoDirLen) == 0) {
             name = CFStringCreateWithBytes(kCFAllocatorSystemDefault, (uint8_t *)linkbuf + zoneInfoDirLen,
-                                           strlen(linkbuf) - zoneInfoDirLen + 2, kCFStringEncodingUTF8, false);
+                                           strlen(linkbuf) - zoneInfoDirLen + 1, kCFStringEncodingUTF8, false);
         } else {
             name = CFStringCreateWithBytes(kCFAllocatorSystemDefault, (uint8_t *)linkbuf, strlen(linkbuf), kCFStringEncodingUTF8, false);
         }


### PR DESCRIPTION
- The length passed to CFStringCreateWithBytes() included an extra
  random byte after the NUL. This meant the string was sometimes
  interpreted as non-ASCII (if the byte was >= 0x80) and the
  timezone would come back as NULL thus defaulting to GMT.

This was broken in https://github.com/apple/swift-corelibs-foundation/pull/1126 which dealt with the macOS timezone directory