### PR TITLE
SR-5557: Fix NSRegularExpression errors with invalid pattern

### DIFF
--- a/CoreFoundation/String.subproj/CFRegularExpression.c
+++ b/CoreFoundation/String.subproj/CFRegularExpression.c
@@ -133,8 +133,9 @@ _CFRegularExpressionRef _CFRegularExpressionCreate(CFAllocatorRef allocator, CFS
     if (regex == NULL || U_FAILURE(errorCode)) {
         // ??? do we need more detailed errors here?
         if (errorPtr) {
-            CFStringRef keys[] = {
-                CFSTR("NSInvalidValue")
+            CFStringRef key = CFSTR("NSInvalidValue");
+            CFTypeRef keys[] = {
+                key
             };
             CFTypeRef values[] = {
                 pattern

--- a/Foundation/NSRegularExpression.swift
+++ b/Foundation/NSRegularExpression.swift
@@ -85,7 +85,7 @@ open class NSRegularExpression: NSObject, NSCopying, NSCoding {
         if let regex = _CFRegularExpressionCreate(kCFAllocatorSystemDefault, pattern._cfObject, opt, &error) {
             _internal = regex
         } else {
-            throw error!.takeRetainedValue()._nsObject
+            throw error!.takeRetainedValue()
         }
     }
     

--- a/TestFoundation/TestNSRegularExpression.swift
+++ b/TestFoundation/TestNSRegularExpression.swift
@@ -29,6 +29,7 @@ class TestNSRegularExpression : XCTestCase {
             ("test_Equal", test_Equal),
             ("test_NSCoding", test_NSCoding),
             ("test_defaultOptions", test_defaultOptions),
+            ("test_badPattern", test_badPattern),
         ]
     }
     
@@ -371,5 +372,15 @@ class TestNSRegularExpression : XCTestCase {
                       "Some message-/tmp/foo.swift-123")
         let str = NSMutableString(string: text)
         XCTAssertEqual(regex!.replaceMatches(in: str, range: range, withTemplate: "$1-$2-$3"), 1)
+    }
+
+    func test_badPattern() {
+        do {
+            _ = try NSRegularExpression(pattern: "(", options: [])
+            XCTFail()
+        } catch {
+            let err = String(describing: error)
+            XCTAssertEqual(err, "Error Domain=NSCocoaErrorDomain Code=2048 \"(null)\" UserInfo={NSInvalidValue=(}")
+        }
     }
 }


### PR DESCRIPTION
- The error dictionary in CFRegularExpression was failing with the
  error key being a CFSTR inside an array so initialiase it outside
  of the array.

I removed the `_nsObject` as I think throwing the error dictionary is more useful as it gave a better error message when stringified.

Should a description be added to the error dictionary to eliminate the '(null)'?