### PR TITLE
Remove Strideable conformance from String.UTF16View.Index

### DIFF
--- a/Foundation/ExtraStringAPIs.swift
+++ b/Foundation/ExtraStringAPIs.swift
@@ -13,19 +13,9 @@
 // Random access for String.UTF16View, only when Foundation is
 // imported.  Making this API dependent on Foundation decouples the
 // Swift core from a UTF16 representation.
-extension String.UTF16View.Index : Strideable {
-    /// Construct from an integer offset.
-    public init(_ offset: Int) {
-        _precondition(offset >= 0, "Negative UTF16 index offset not allowed")
-        self.init(encodedOffset: offset)
-    }
-    
-    public func distance(to other: String.UTF16View.Index) -> Int {
-        return encodedOffset.distance(to: other.encodedOffset)
-    }
-    
+extension String.UTF16View.Index {
     public func advanced(by n: Int) -> String.UTF16View.Index {
-        return String.UTF16View.Index(encodedOffset.advanced(by: n))
+        return String.UTF16View.Index(encodedOffset: encodedOffset.advanced(by: n))
     }
 }
 

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -96,7 +96,6 @@ class TestNSString : XCTestCase {
             ("test_mutableStringConstructor", test_mutableStringConstructor),
             ("test_emptyStringPrefixAndSuffix",test_emptyStringPrefixAndSuffix),
             ("test_PrefixSuffix", test_PrefixSuffix),
-            ("test_utf16StringRangeCount", test_StringUTF16ViewIndexStrideableRange),
             ("test_reflection", { _ in test_reflection }),
             ("test_replacingOccurrences", test_replacingOccurrences),
             ("test_getLineStart", test_getLineStart),
@@ -1067,34 +1066,6 @@ class TestNSString : XCTestCase {
             
             let ISOLatin1Data = CFStringCreateExternalRepresentation(kCFAllocatorDefault, string, ISOLatin1Encoding, 0)
             XCTAssertNil(ISOLatin1Data)
-        }
-    }
-    
-    //[SR-1988] Ranges of String.UTF16View.Index have negative count
-    func test_StringUTF16ViewIndexStrideableRange(){
-        let testStrings = ["", "\u{0000}", "a", "aa", "ab", "\u{007f}", "\u{0430}", "\u{0430}\u{0431}\u{0432}","\u{1f425}"]
-        
-        func checkStrideable<S : Strideable>(
-            instances: [S],
-            distances: [S.Stride],
-            distanceOracle: (Int, Int) -> S.Stride
-            ) {
-            for i in instances.indices {
-                let first = instances[i]
-                for j in instances.indices {
-                    let second = instances[j]
-                    XCTAssertTrue(distanceOracle(i, j) == first.distance(to: second))
-                    XCTAssertTrue(second == first.advanced(by: distanceOracle(i, j)))
-                }
-            }
-        }
-        testStrings.forEach{
-            let utf16 = $0.utf16
-            var indicies = Array(utf16.indices)
-            indicies.append(utf16.indices.endIndex)
-            checkStrideable(instances: indicies,
-                            distances: Array(0..<utf16.count),
-                       distanceOracle: {$1 - $0})
         }
     }
     


### PR DESCRIPTION
I've noticed the following discrepancy in the behaviour of Range/CountableRange.
 
macOS:
```
$ swift
Welcome to Apple Swift version 4.0-dev (LLVM 2dedb62a0b, Clang b9d76a314c,
Swift 6b4756bd93). Type :help for assistance.
  1> import Foundation
  2> "abc".range(of: "a")!.lowerBound..<"abc".range(of: "a")!.upperBound
$R0: Range<String.Index> = {
  lowerBound = {
    _compoundOffset = 0
    _cache = utf16
  }
  upperBound = {
    _compoundOffset = 4
    _cache = utf16
  }
}
```

Linux:

```
$ swift
Welcome to Swift version 4.0-dev (LLVM 2dedb62a0b, Clang b9d76a314c, Swift
6b4756bd93). Type :help for assistance.
  1> import Foundation
  2> "abc".range(of: "a")!.lowerBound..<"abc".range(of: "a")!.upperBound
$R0: CountableRange<String.Index> = {
  lowerBound = {
    _compoundOffset = 0
    _cache = utf16
  }
  upperBound = {
    _compoundOffset = 4
    _cache = utf16
  }
}
```

This is caused by

https://github.com/apple/swift-corelibs-foundation/blob/f65a3c14986f8c950dbc5ac709bc76b21e49498d/Foundation/ExtraStringAPIs.swift#L16

which adds a `Strideable` conformance to `String.UTF16View.Index`.

In Swift 4 this conformance is no longer correct, so remove it.  Also remove an associated test (which was already removed in the stdlib tests [here](https://github.com/apple/swift/commit/2e0bb2f5335d748c22e36fbe6b7ec820bb2c99dc#diff-0496d31d9614b298551b0232e92f21dbL746)).

The `advanced(by:)` extension on `String.UTF16View.Index` remains because it is used at https://github.com/apple/swift-corelibs-foundation/blob/179afd9096603f77150a9b2112f2dd06ac96c2ae/Foundation/NSCFString.swift#L170