### PR TITLE
Enable JSONSerialization Int fastpath for boxed values

### DIFF
--- a/Foundation/JSONSerialization.swift
+++ b/Foundation/JSONSerialization.swift
@@ -475,6 +475,23 @@ private struct JSONWriter {
         switch num._cfTypeID {
         case CFBooleanGetTypeID():
             serializeBool(num.boolValue)
+        case CFNumberGetTypeID():
+            switch num._cfNumberType() {
+            case kCFNumberSInt8Type: fallthrough
+            case kCFNumberSInt16Type: fallthrough
+            case kCFNumberSInt32Type: fallthrough
+            case kCFNumberSInt64Type: fallthrough
+            case kCFNumberCharType: fallthrough
+            case kCFNumberShortType: fallthrough
+            case kCFNumberIntType: fallthrough
+            case kCFNumberLongType: fallthrough
+            case kCFNumberLongLongType:
+                try serializeInt(value: num.intValue)
+            case kCFNumberFloatType: fallthrough
+            case kCFNumberDoubleType: fallthrough
+            default:
+                writer(_serializationString(for: num))
+            }
         default:
             writer(_serializationString(for: num))
         }


### PR DESCRIPTION
Enable the `Int` serialization fastpath introduced by #923 to be used when the value has been boxed in an `NSNumber` (for example, via `JSONEncoder`).

With [a simple microbenchmark](https://github.com/djones6/swift-benchmarks/blob/master/jsonEncoderTest.swift) which serializes a struct and an equivalent dictionary containing 10 keys with `Int` values, this takes JSONEncoder from ~4x to ~2x slower than using JSONSerialization directly:

### 4.0-DEVELOPMENT-SNAPSHOT-2017-08-04-a
```
JSONEncoder (Struct) took 145227.1498 ns
JSONEncoder (Dict) took 159625.3804 ns
JSONSerialization took 43780.5796 ns
```
### With Int fastpath
```
JSONEncoder (Struct) took 75462.8424 ns
JSONEncoder (Dict) took 84936.7405 ns
JSONSerialization took 46191.5048 ns
```