### PR TITLE
NSURL: Dont leak the result of dataRepresentation

### DIFF
--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -405,7 +405,7 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
         let buffer = malloc(bytesNeeded)!.bindMemory(to: UInt8.self, capacity: bytesNeeded)
         let bytesFilled = CFURLGetBytes(_cfObject, buffer, bytesNeeded)
         if bytesFilled == bytesNeeded {
-            return Data(bytesNoCopy: buffer, count: bytesNeeded, deallocator: .none)
+            return Data(bytesNoCopy: buffer, count: bytesNeeded, deallocator: .free)
         } else {
             fatalError()
         }

--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -64,6 +64,7 @@ class TestURL : XCTestCase {
             ("test_reachable", test_reachable),
             ("test_copy", test_copy),
             ("test_itemNSCoding", test_itemNSCoding),
+            ("test_dataRepresentation", test_dataRepresentation),
         ]
     }
     
@@ -490,6 +491,13 @@ class TestURL : XCTestCase {
         let queryItemA = NSURLQueryItem(name: "id", value: "23")
         let queryItemB = NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: queryItemA)) as! NSURLQueryItem
         XCTAssertEqual(queryItemA, queryItemB, "Archived then unarchived query item must be equal.")
+    }
+
+    func test_dataRepresentation() {
+        let url = NSURL(fileURLWithPath: "/tmp/foo")
+        let url2 = NSURL(dataRepresentation: url.dataRepresentation,
+            relativeTo: nil)
+        XCTAssertEqual(url, url2)
     }
 }
     


### PR DESCRIPTION
Validated with valgrind.