### PR TITLE
Remove deprecated (Sub)String .characters and CharacterView

### DIFF
--- a/Foundation/HTTPCookie.swift
+++ b/Foundation/HTTPCookie.swift
@@ -249,7 +249,7 @@ open class HTTPCookie : NSObject {
         _domain = canonicalDomain
 
         if let
-            secureString = properties[.secure] as? String, !secureString.characters.isEmpty
+            secureString = properties[.secure] as? String, !secureString.isEmpty
         {
             _secure = true
         } else {
@@ -267,8 +267,7 @@ open class HTTPCookie : NSObject {
         _version = version
 
         if let portString = properties[.port] as? String, _version == 1 {
-            _portList = portString.characters
-                .split(separator: ",")
+            _portList = portString.split(separator: ",")
                 .flatMap { Int(String($0)) }
                 .map { NSNumber(value: $0) }
         } else {
@@ -361,8 +360,8 @@ open class HTTPCookie : NSObject {
         }
         //Remove the final trailing semicolon and whitespace
         if ( cookieString.length > 0 ) {
-            cookieString.characters.removeLast()
-            cookieString.characters.removeLast()
+            cookieString.removeLast()
+            cookieString.removeLast()
         }
         return ["Cookie": cookieString]
     }
@@ -624,7 +623,7 @@ fileprivate extension String {
     }
 
     func insertComma(at index:Int) -> String {
-        return  String(self.characters.prefix(index)) + ","  + String(self.characters.suffix(self.characters.count-index))
+        return  String(self.prefix(index)) + ","  + String(self.suffix(self.count-index))
     }
 }
 

--- a/Foundation/JSONSerialization.swift
+++ b/Foundation/JSONSerialization.swift
@@ -286,8 +286,8 @@ internal extension JSONSerialization {
 //MARK: - JSONSerializer
 private struct JSONWriter {
     
-    private let maxUIntLength = String(describing: UInt.max).characters.count
-    private let maxIntLength = String(describing: Int.max).characters.count
+    private let maxUIntLength = String(describing: UInt.max).count
+    private let maxIntLength = String(describing: Int.max).count
     var indent = 0
     let pretty: Bool
     let sortedKeys: Bool

--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -35,18 +35,16 @@ public func NSTemporaryDirectory() -> String {
 
 internal extension String {
     
-    internal var _startOfLastPathComponent : String.CharacterView.Index {
+    internal var _startOfLastPathComponent : String.Index {
         precondition(!hasSuffix("/") && length > 1)
         
-        let characterView = characters
-        let startPos = characterView.startIndex
-        let endPos = characterView.endIndex
-        var curPos = endPos
+        let startPos = startIndex
+        var curPos = endIndex
         
         // Find the beginning of the component
         while curPos > startPos {
-            let prevPos = characterView.index(before: curPos)
-            if characterView[prevPos] == "/" {
+            let prevPos = index(before: curPos)
+            if self[prevPos] == "/" {
                 break
             }
             curPos = prevPos
@@ -55,19 +53,16 @@ internal extension String {
 
     }
 
-    internal var _startOfPathExtension : String.CharacterView.Index? {
+    internal var _startOfPathExtension : String.Index? {
         precondition(!hasSuffix("/"))
         
-        let characterView = self.characters
-        let endPos = characterView.endIndex
-        var curPos = endPos
-        
+        var curPos = endIndex
         let lastCompStartPos = _startOfLastPathComponent
         
         // Find the beginning of the extension
         while curPos > lastCompStartPos {
-            let prevPos = characterView.index(before: curPos)
-            let char = characterView[prevPos]
+            let prevPos = index(before: curPos)
+            let char = self[prevPos]
             if char == "/" {
                 return nil
             } else if char == "." {
@@ -125,7 +120,7 @@ internal extension String {
             }
         }
         if stripTrailing && result.length > 1 && result.hasSuffix("/") {
-            result.remove(at: result.characters.index(before: result.characters.endIndex))
+            result.remove(at: result.index(before: result.endIndex))
         }
         return result
     }
@@ -181,7 +176,7 @@ public extension NSString {
             return fixedSelf
         }
         
-        return String(fixedSelf.characters.suffix(from: fixedSelf._startOfLastPathComponent))
+        return String(fixedSelf.suffix(from: fixedSelf._startOfLastPathComponent))
     }
     
     public var deletingLastPathComponent : String {
@@ -202,7 +197,7 @@ public extension NSString {
         
         // all common cases
         case let startOfLast:
-            return String(fixedSelf.characters.prefix(upTo: fixedSelf.index(before: startOfLast)))
+            return String(fixedSelf.prefix(upTo: fixedSelf.index(before: startOfLast)))
         }
     }
     
@@ -236,7 +231,7 @@ public extension NSString {
             }
         }
         if stripTrailing && result.hasSuffix("/") {
-            result.remove(at: result.characters.index(before: result.characters.endIndex))
+            result.remove(at: result.index(before: result.endIndex))
         }
         return result
     }
@@ -265,7 +260,7 @@ public extension NSString {
         }
 
         if let extensionPos = fixedSelf._startOfPathExtension {
-            return String(fixedSelf.characters.suffix(from: extensionPos))
+            return String(fixedSelf.suffix(from: extensionPos))
         } else {
             return ""
         }
@@ -277,7 +272,7 @@ public extension NSString {
             return fixedSelf
         }
         if let extensionPos = (fixedSelf._startOfPathExtension) {
-            return String(fixedSelf.characters.prefix(upTo: fixedSelf.characters.index(before: extensionPos)))
+            return String(fixedSelf.prefix(upTo: fixedSelf.index(before: extensionPos)))
         } else {
             return fixedSelf
         }
@@ -297,9 +292,9 @@ public extension NSString {
             return _swiftObject
         }
 
-        let endOfUserName = _swiftObject.characters.index(of: "/") ?? _swiftObject.endIndex
-        let startOfUserName = _swiftObject.characters.index(after: _swiftObject.characters.startIndex)
-        let userName = String(_swiftObject.characters[startOfUserName..<endOfUserName])
+        let endOfUserName = _swiftObject.index(of: "/") ?? _swiftObject.endIndex
+        let startOfUserName = _swiftObject.index(after: _swiftObject.startIndex)
+        let userName = String(_swiftObject[startOfUserName..<endOfUserName])
         let optUserName: String? = userName.isEmpty ? nil : userName
         
         guard let homeDir = NSHomeDirectoryForUser(optUserName) else {
@@ -478,7 +473,7 @@ public extension NSString {
             return strings.first
         }
         
-        var sequences = strings.map({ $0.characters.makeIterator() })
+        var sequences = strings.map({ $0.makeIterator() })
         var prefix: [Character] = []
         loop: while true {
             var char: Character? = nil
@@ -490,8 +485,8 @@ public extension NSString {
                 }
                 
                 if char != nil {
-                    let lhs = caseSensitive ? char : String(char!).lowercased().characters.first!
-                    let rhs = caseSensitive ? c : String(c).lowercased().characters.first!
+                    let lhs = caseSensitive ? char : String(char!).lowercased().first!
+                    let rhs = caseSensitive ? c : String(c).lowercased().first!
                     if lhs != rhs {
                         break loop
                     }

--- a/Foundation/NSStringAPI.swift
+++ b/Foundation/NSStringAPI.swift
@@ -292,7 +292,7 @@ extension String {
       aString,
       options: mask,
       range: _toNSRange(
-        range ?? self.characters.startIndex..<self.characters.endIndex
+        range ?? self.startIndex..<self.endIndex
       ),
       locale: locale?._bridgeToObjectiveC()
     )
@@ -1060,7 +1060,7 @@ extension String {
         from: aSet,
         options: mask,
         range: _toNSRange(
-          aRange ?? self.characters.startIndex..<self.characters.endIndex
+          aRange ?? self.startIndex..<self.endIndex
         )
       )
     )
@@ -1120,7 +1120,7 @@ extension String {
         of: aString,
         options: mask,
         range: _toNSRange(
-          searchRange ?? self.characters.startIndex..<self.characters.endIndex
+          searchRange ?? self.startIndex..<self.endIndex
         ),
         locale: locale
       )
@@ -1343,7 +1343,7 @@ extension String {
       with: replacement,
       options: options,
       range: _toNSRange(
-        searchRange ?? self.characters.startIndex..<self.characters.endIndex
+        searchRange ?? self.startIndex..<self.endIndex
       )
     )
     : _ns.replacingOccurrences(of: target, with: replacement)

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -34,7 +34,7 @@ internal func _pathComponents(_ path: String?) -> [String]? {
         if p.length == 0 {
             return result
         } else {
-            let characterView = p.characters
+            let characterView = p
             var curPos = characterView.startIndex
             let endPos = characterView.endIndex
             if characterView[curPos] == "/" {
@@ -738,7 +738,7 @@ extension NSURL {
                 }
             }
             if stripTrailing && result.hasSuffix("/") {
-                result.remove(at: result.characters.index(before: result.characters.endIndex))
+                result.remove(at: result.index(before: result.endIndex))
             }
             return result
         }
@@ -757,7 +757,7 @@ extension NSURL {
             return fixedSelf
         }
         
-        return String(fixedSelf.characters.suffix(from: fixedSelf._startOfLastPathComponent))
+        return String(fixedSelf.suffix(from: fixedSelf._startOfLastPathComponent))
     }
     
     open var pathExtension: String? {
@@ -769,7 +769,7 @@ extension NSURL {
         }
         
         if let extensionPos = fixedSelf._startOfPathExtension {
-            return String(fixedSelf.characters.suffix(from: extensionPos))
+            return String(fixedSelf.suffix(from: extensionPos))
         } else {
             return ""
         }

--- a/Foundation/ProcessInfo.swift
+++ b/Foundation/ProcessInfo.swift
@@ -92,7 +92,7 @@ open class ProcessInfo: NSObject {
             return OperatingSystemVersion(majorVersion: fallbackMajor, minorVersion: fallbackMinor, patchVersion: fallbackPatch)
         }
         
-        let versionComponents = productVersion._swiftObject.characters.split(separator: ".").map(String.init).flatMap({ Int($0) })
+        let versionComponents = productVersion._swiftObject.split(separator: ".").map(String.init).flatMap({ Int($0) })
         let majorVersion = versionComponents.dropFirst(0).first ?? fallbackMajor
         let minorVersion = versionComponents.dropFirst(1).first ?? fallbackMinor
         let patchVersion = versionComponents.dropFirst(2).first ?? fallbackPatch

--- a/Foundation/XMLNode.swift
+++ b/Foundation/XMLNode.swift
@@ -421,7 +421,7 @@ open class XMLNode: NSObject, NSCopying {
         var entityChars: [Character] = []
         var inEntity = false
         var startIndex = 0
-        for (index, char) in string.characters.enumerated() {
+        for (index, char) in string.enumerated() {
             if char == "&" {
                 inEntity = true
                 startIndex = index
@@ -440,7 +440,7 @@ open class XMLNode: NSObject, NSCopying {
             }
         }
 
-        var result: [Character] = Array(string.characters)
+        var result: [Character] = Array(string)
         let doc = _CFXMLNodeGetDocument(_xmlNode)!
         for (range, entity) in entities {
             var entityPtr = _CFXMLGetDocEntity(doc, entity)
@@ -452,7 +452,7 @@ open class XMLNode: NSObject, NSCopying {
             }
             if let validEntity = entityPtr {
                 let replacement = _CFXMLCopyEntityContent(validEntity)?._swiftObject ?? ""
-                result.replaceSubrange(range, with: replacement.characters)
+                result.replaceSubrange(range, with: replacement)
             } else {
                 result.replaceSubrange(range, with: []) // This appears to be how Darwin Foundation does it
             }

--- a/TestFoundation/HTTPServer.swift
+++ b/TestFoundation/HTTPServer.swift
@@ -100,7 +100,7 @@ class _TCPSocket {
     }
     
     func split(_ str: String, _ count: Int) -> [String] {
-        return stride(from: 0, to: str.characters.count, by: count).map { i -> String in
+        return stride(from: 0, to: str.count, by: count).map { i -> String in
             let startIndex = str.index(str.startIndex, offsetBy: i)
             let endIndex   = str.index(startIndex, offsetBy: count, limitedBy: str.endIndex) ?? str.endIndex
             return String(str[startIndex..<endIndex])
@@ -346,7 +346,7 @@ public class TestURLSessionServer {
         }
 
         if uri == "/country.txt" {
-            let text = capitals[String(uri.characters.dropFirst())]!
+            let text = capitals[String(uri.dropFirst())]!
             return _HTTPResponse(response: .OK, headers: "Content-Length: \(text.data(using: .utf8)!.count)", body: text)
         }
 
@@ -356,7 +356,7 @@ public class TestURLSessionServer {
         }
 
 	if uri == "/UnitedStates" {
-            let value = capitals[String(uri.characters.dropFirst())]!
+            let value = capitals[String(uri.dropFirst())]!
             let text = request.getCommaSeparatedHeaders()
             let host = request.headers[1].components(separatedBy: " ")[1]
             let ip = host.components(separatedBy: ":")[0]
@@ -366,7 +366,7 @@ public class TestURLSessionServer {
             let httpResponse = _HTTPResponse(response: .REDIRECT, headers: "Location: http://\(newHost + "/" + value)", body: text)
             return httpResponse 
         }
-        return _HTTPResponse(response: .OK, body: capitals[String(uri.characters.dropFirst())]!) 
+        return _HTTPResponse(response: .OK, body: capitals[String(uri.dropFirst())]!)
     }
 
     func stop() {

--- a/TestFoundation/TestDecimal.swift
+++ b/TestFoundation/TestDecimal.swift
@@ -260,7 +260,7 @@ class TestDecimal: XCTestCase {
                     var failed: Bool = false
                     var count = 0
                     let SIG_FIG = 14
-                    for (a, b) in zip(answerDescription.characters, approximationDescription.characters) {
+                    for (a, b) in zip(answerDescription, approximationDescription) {
                         if a != b {
                             failed = true
                             break

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -1298,11 +1298,11 @@ func checkHasPrefixHasSuffix(_ lhs: String, _ rhs: String, _ stack: [UInt]) -> I
     // To determine the expected results, compare grapheme clusters,
     // scalar-to-scalar, of the NFD form of the strings.
     let lhsNFDGraphemeClusters =
-        lhs.decomposedStringWithCanonicalMapping.characters.map {
+        lhs.decomposedStringWithCanonicalMapping.map {
             Array(String($0).unicodeScalars)
     }
     let rhsNFDGraphemeClusters =
-        rhs.decomposedStringWithCanonicalMapping.characters.map {
+        rhs.decomposedStringWithCanonicalMapping.map {
             Array(String($0).unicodeScalars)
     }
     let expectHasPrefix = lhsNFDGraphemeClusters.starts(

--- a/TestFoundation/TestPipe.swift
+++ b/TestFoundation/TestPipe.swift
@@ -35,7 +35,7 @@ class TestPipe : XCTestCase {
         aPipe.fileHandleForWriting.write(stringAsData!)
         
         // Then read it out again
-        let data = aPipe.fileHandleForReading.readData(ofLength: text.characters.count)
+        let data = aPipe.fileHandleForReading.readData(ofLength: text.count)
         
         // Confirm that we did read data
         XCTAssertNotNil(data)

--- a/TestFoundation/TestStream.swift
+++ b/TestFoundation/TestStream.swift
@@ -135,7 +135,7 @@ class TestStream : XCTestCase {
             XCTAssertEqual(Stream.Status.open, outputStream!.streamStatus)
             let result: Int? = outputStream?.write(encodedData, maxLength: encodedData.count)
             outputStream?.close()
-            XCTAssertEqual(myString.characters.count, result)
+            XCTAssertEqual(myString.count, result)
             XCTAssertEqual(Stream.Status.closed, outputStream!.streamStatus)
             removeTestFile(filePath!)
         } else {
@@ -154,7 +154,7 @@ class TestStream : XCTestCase {
         let result: Int? = outputStream.write(encodedData, maxLength: encodedData.count)
         outputStream.close()
         XCTAssertEqual(Stream.Status.closed, outputStream.streamStatus)
-        XCTAssertEqual(myString.characters.count, result)
+        XCTAssertEqual(myString.count, result)
         XCTAssertEqual(NSString(bytes: &buffer, length: buffer.count, encoding: String.Encoding.utf8.rawValue), NSString(string: myString))
     }
     
@@ -169,7 +169,7 @@ class TestStream : XCTestCase {
             XCTAssertEqual(Stream.Status.open, outputStream!.streamStatus)
             let result: Int? = outputStream?.write(encodedData, maxLength: encodedData.count)
             outputStream?.close()
-            XCTAssertEqual(myString.characters.count, result)
+            XCTAssertEqual(myString.count, result)
             XCTAssertEqual(Stream.Status.closed, outputStream!.streamStatus)
             removeTestFile(filePath!)
         } else {
@@ -186,7 +186,7 @@ class TestStream : XCTestCase {
         outputStream.open()
         XCTAssertEqual(Stream.Status.open, outputStream.streamStatus)
         let result: Int? = outputStream.write(encodedData, maxLength: encodedData.count)
-        XCTAssertEqual(myString.characters.count, result)
+        XCTAssertEqual(myString.count, result)
         //verify the data written
         let dataWritten  = outputStream.property(forKey: Stream.PropertyKey.dataWrittenToMemoryStreamKey)
         if let nsdataWritten = dataWritten as? NSData {


### PR DESCRIPTION
Already deprecated in Swift4 so this just tidies up the warnings.