### PR TITLE
Notification: fix addObserver(forName:object:queue:using:) signature

### DIFF
--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -187,8 +187,13 @@ open class NotificationCenter: NSObject {
             self._observers = _observers.filterOutObserver(observer, name: aName, object: object)
         })
     }
-    
+
+    @available(swift, obsoleted: 4.0)
     open func addObserver(forName name: Notification.Name?, object obj: Any?, queue: OperationQueue?, usingBlock block: @escaping (Notification) -> Void) -> NSObjectProtocol {
+        return addObserver(forName: name, object: obj, queue: queue, using: block)
+    }
+
+    open func addObserver(forName name: Notification.Name?, object obj: Any?, queue: OperationQueue?, using block: @escaping (Notification) -> Void) -> NSObjectProtocol {
         let object = NSObject()
         
         let newObserver = NSNotificationReceiver()

--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -188,7 +188,7 @@ open class NotificationCenter: NSObject {
         })
     }
 
-    @available(swift, obsoleted: 4.0)
+    @available(*,obsoleted:4.0,renamed:"addObserver(forName:object:queue:using:)")
     open func addObserver(forName name: Notification.Name?, object obj: Any?, queue: OperationQueue?, usingBlock block: @escaping (Notification) -> Void) -> NSObjectProtocol {
         return addObserver(forName: name, object: obj, queue: queue, using: block)
     }


### PR DESCRIPTION
This is a pickup of https://github.com/apple/swift-corelibs-foundation/pull/1060 which has gone stale.

Correct the API signature of 
https://developer.apple.com/documentation/foundation/notificationcenter/1411723-addobserver