### PR TITLE
SR-5640:  JSONEncoder misrepresents UInt.max

### DIFF
--- a/Foundation/JSONSerialization.swift
+++ b/Foundation/JSONSerialization.swift
@@ -577,9 +577,12 @@ private struct JSONWriter {
             writer(" ")
         }
     }
-    
+
     //[SR-2151] https://bugs.swift.org/browse/SR-2151
     private mutating func _serializationString(for number: NSNumber) -> String {
+        if !CFNumberIsFloatType(number._cfObject) {
+            return number.stringValue
+        }
         return CFNumberFormatterCreateStringWithNumber(nil, _numberformatter, number._cfObject)._swiftObject
     }
 }

--- a/TestFoundation/TestJSONEncoder.swift
+++ b/TestFoundation/TestJSONEncoder.swift
@@ -401,6 +401,68 @@ class TestJSONEncoder : XCTestCase {
         test_codingOf(value: URL(string: "https://swift.org")!, toAndFrom: "\"https://swift.org\"")
     }
 
+
+    // UInt and Int
+    func test_codingOfUIntMinMax() {
+
+        let encoder = JSONEncoder()
+
+        struct MyValue: Codable {
+            let intMin:Int = Int.min
+            let intMax:Int = Int.max
+            let uintMin:UInt = UInt.min
+            let uintMax:UInt = UInt.max
+        }
+
+        let myValue = MyValue()
+        let myDictI: [String:Any] = ["intMin": myValue.intMin, "intMax": myValue.intMax]
+        let myDictU: [String:Any] = ["uintMin": myValue.uintMin, "uintMax": myValue.uintMax]
+        let myDict1: [String:Any] = ["intMin": myValue.intMin]
+        let myDict2: [String:Any] = ["intMax": myValue.intMax]
+        let myDict3: [String:Any] = ["uintMin": myValue.uintMin]
+        let myDict4: [String:Any] = ["uintMax": myValue.uintMax]
+
+        func compareJSON(_ s1: String, _ s2: String) {
+            let ss1 = s1.trimmingCharacters(in: CharacterSet(charactersIn: "{}")).split(separator: Character(",")).sorted()
+            let ss2 = s2.trimmingCharacters(in: CharacterSet(charactersIn: "{}")).split(separator: Character(",")).sorted()
+            XCTAssertEqual(ss1, ss2)
+        }
+
+        do {
+            let result = try encoder.encode(myValue)
+            let r = String(data: result, encoding: .utf8) ?? "nil"
+            compareJSON(r, "{\"uintMin\":0,\"uintMax\":18446744073709551615,\"intMin\":-9223372036854775808,\"intMax\":9223372036854775807}")
+
+            let resultI = try JSONSerialization.data(withJSONObject: myDictI)
+            let rI = String(data: resultI, encoding: .utf8) ?? "nil"
+            compareJSON(rI, "{\"intMin\":-9223372036854775808,\"intMax\":9223372036854775807}")
+
+            let resultU = try JSONSerialization.data(withJSONObject: myDictU)
+            let rU = String(data: resultU, encoding: .utf8) ?? "nil"
+            compareJSON(rU, "{\"uintMax\":18446744073709551615,\"uintMin\":0}")
+
+            let result1 = try JSONSerialization.data(withJSONObject: myDict1)
+            let r1 = String(data: result1, encoding: .utf8) ?? "nil"
+            XCTAssertEqual(r1, "{\"intMin\":-9223372036854775808}")
+
+            let result2 = try JSONSerialization.data(withJSONObject: myDict2)
+            let r2 = String(data: result2, encoding: .utf8) ?? "nil"
+            XCTAssertEqual(r2, "{\"intMax\":9223372036854775807}")
+
+            let result3 = try JSONSerialization.data(withJSONObject: myDict3)
+            let r3 = String(data: result3, encoding: .utf8) ?? "nil"
+            XCTAssertEqual(r3, "{\"uintMin\":0}")
+
+            let result4 = try JSONSerialization.data(withJSONObject: myDict4)
+            let r4 = String(data: result4, encoding: .utf8) ?? "nil"
+            XCTAssertEqual(r4, "{\"uintMax\":18446744073709551615}")
+        } catch {
+            XCTFail(String(describing: error))
+        }
+    }
+
+
+
     // MARK: - Helper Functions
     private var _jsonEmptyDictionary: Data {
         return "{}".data(using: .utf8)!
@@ -986,6 +1048,7 @@ extension TestJSONEncoder {
             ("test_codingOfUInt64", test_codingOfUInt64),
             ("test_codingOfInt", test_codingOfInt),
             ("test_codingOfUInt", test_codingOfUInt),
+            ("test_codingOfUIntMinMax", test_codingOfUIntMinMax),
             ("test_codingOfFloat", test_codingOfFloat),
             ("test_codingOfDouble", test_codingOfDouble),
             ("test_codingOfString", test_codingOfString),

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -43,6 +43,7 @@ class TestNSNumber : XCTestCase {
             ("test_description", test_description ),
             ("test_descriptionWithLocale", test_descriptionWithLocale ),
             ("test_objCType", test_objCType ),
+            ("test_stringValue", test_stringValue),
         ]
     }
     
@@ -1018,5 +1019,72 @@ class TestNSNumber : XCTestCase {
 
         XCTAssertEqual("f" /* 0x66 */, objCType(NSNumber(value: Float.greatestFiniteMagnitude)))
         XCTAssertEqual("d" /* 0x64 */, objCType(NSNumber(value: Double.greatestFiniteMagnitude)))
+    }
+
+    func test_stringValue() {
+
+        if UInt.max == UInt32.max {
+            XCTAssertEqual(NSNumber(value: UInt.min).stringValue, "0")
+            XCTAssertEqual(NSNumber(value: UInt.min + 1).stringValue, "1")
+            XCTAssertEqual(NSNumber(value: UInt.max).stringValue, "4294967295")
+            XCTAssertEqual(NSNumber(value: UInt.max - 1).stringValue, "4294967294")
+        } else if UInt.max == UInt64.max {
+            XCTAssertEqual(NSNumber(value: UInt.min).stringValue, "0")
+            XCTAssertEqual(NSNumber(value: UInt.min + 1).stringValue, "1")
+            XCTAssertEqual(NSNumber(value: UInt.max).stringValue, "18446744073709551615")
+            XCTAssertEqual(NSNumber(value: UInt.max - 1).stringValue, "18446744073709551614")
+        }
+
+        XCTAssertEqual(NSNumber(value: UInt8.min).stringValue, "0")
+        XCTAssertEqual(NSNumber(value: UInt8.min + 1).stringValue, "1")
+        XCTAssertEqual(NSNumber(value: UInt8.max).stringValue, "255")
+        XCTAssertEqual(NSNumber(value: UInt8.max - 1).stringValue, "254")
+
+        XCTAssertEqual(NSNumber(value: UInt16.min).stringValue, "0")
+        XCTAssertEqual(NSNumber(value: UInt16.min + 1).stringValue, "1")
+        XCTAssertEqual(NSNumber(value: UInt16.max).stringValue, "65535")
+        XCTAssertEqual(NSNumber(value: UInt16.max - 1).stringValue, "65534")
+
+        XCTAssertEqual(NSNumber(value: UInt32.min).stringValue, "0")
+        XCTAssertEqual(NSNumber(value: UInt32.min + 1).stringValue, "1")
+        XCTAssertEqual(NSNumber(value: UInt32.max).stringValue, "4294967295")
+        XCTAssertEqual(NSNumber(value: UInt32.max - 1).stringValue, "4294967294")
+
+        XCTAssertEqual(NSNumber(value: UInt64.min).stringValue, "0")
+        XCTAssertEqual(NSNumber(value: UInt64.min + 1).stringValue, "1")
+        XCTAssertEqual(NSNumber(value: UInt64.max).stringValue, "18446744073709551615")
+        XCTAssertEqual(NSNumber(value: UInt64.max - 1).stringValue, "18446744073709551614")
+
+        if Int.max == Int32.max {
+            XCTAssertEqual(NSNumber(value: Int.min).stringValue, "-2147483648")
+            XCTAssertEqual(NSNumber(value: Int.min + 1).stringValue, "-2147483647")
+            XCTAssertEqual(NSNumber(value: Int.max).stringValue, "2147483647")
+            XCTAssertEqual(NSNumber(value: Int.max - 1).stringValue, "2147483646")
+        } else if Int.max == Int64.max {
+            XCTAssertEqual(NSNumber(value: Int.min).stringValue, "-9223372036854775808")
+            XCTAssertEqual(NSNumber(value: Int.min + 1).stringValue, "-9223372036854775807")
+            XCTAssertEqual(NSNumber(value: Int.max).stringValue, "9223372036854775807")
+            XCTAssertEqual(NSNumber(value: Int.max - 1).stringValue, "9223372036854775806")
+        }
+
+        XCTAssertEqual(NSNumber(value: Int8.min).stringValue, "-128")
+        XCTAssertEqual(NSNumber(value: Int8.min + 1).stringValue, "-127")
+        XCTAssertEqual(NSNumber(value: Int8.max).stringValue, "127")
+        XCTAssertEqual(NSNumber(value: Int8.max - 1).stringValue, "126")
+
+        XCTAssertEqual(NSNumber(value: Int16.min).stringValue, "-32768")
+        XCTAssertEqual(NSNumber(value: Int16.min + 1).stringValue, "-32767")
+        XCTAssertEqual(NSNumber(value: Int16.max).stringValue, "32767")
+        XCTAssertEqual(NSNumber(value: Int16.max - 1).stringValue, "32766")
+
+        XCTAssertEqual(NSNumber(value: Int32.min).stringValue, "-2147483648")
+        XCTAssertEqual(NSNumber(value: Int32.min + 1).stringValue, "-2147483647")
+        XCTAssertEqual(NSNumber(value: Int32.max).stringValue, "2147483647")
+        XCTAssertEqual(NSNumber(value: Int32.max - 1).stringValue, "2147483646")
+
+        XCTAssertEqual(NSNumber(value: Int64.min).stringValue, "-9223372036854775808")
+        XCTAssertEqual(NSNumber(value: Int64.min + 1).stringValue, "-9223372036854775807")
+        XCTAssertEqual(NSNumber(value: Int64.max).stringValue, "9223372036854775807")
+        XCTAssertEqual(NSNumber(value: Int64.max - 1).stringValue, "9223372036854775806")
     }
 }


### PR DESCRIPTION
This is a workaround rather than a full fix. However it should make it easier to create the correct fix.

- NSNumber(value: UInt.max).stringValue was returning "-1"
  instead of "18446744073709551615" because NSNumber holds any
  value > Int64.max as a 128Bit quantity using a high Int and
  low UInt. It marks this type as an 'SInt128Type'.

- CFNumberFormatterCreateStringWithNumber() uses CFNumberGetType()
  to get this type however CoreFoundation wants to hide SInt128Type
  (probably for backwards compatibilty) and instead returns it
  as an SInt64Type. Thus only the low part of the NSNumber is used
  for the number and this is interpreted as an Int64.

- The workaround is simply in NSNumber.description(withLocale:)
  to test to see if the value is of type SInt128Type and if so
  use String(format: "%@") to convert it to a string instead of
  using CFNumberFormatterCreateStringWithNumber(). This should be
  ok for most situations since it is only used for positive
  integers and there are no issues with formatting leading zeros
  or decimal points.

- For JSONWriter._serializationString(for: NSNumber) the value
  is tested to see if it is an SInt128Type and if so the .stringValue
  method is used to create a string.