### PR TITLE
Fix memory leaks by using more specialized xml*Free functions.

### DIFF
--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -893,8 +893,8 @@ CFArrayRef _CFXMLNodesForXPath(_CFXMLNodePtr node, const unsigned char* xpath) {
         CFArrayAppendValue(results, nodes->nodeTab[i]);
     }
 
-    xmlFree(context);
-    xmlFree(evalResult);
+    xmlXPathFreeContext(context);
+    xmlXPathFreeObject(evalResult);
 
     return results;
 }


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-5256.