### PR TITLE
4.0: Fix memory leaks by using more specialized xml*Free functions.

### DIFF
--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -893,8 +893,8 @@ CFArrayRef _CFXMLNodesForXPath(_CFXMLNodePtr node, const unsigned char* xpath) {
         CFArrayAppendValue(results, nodes->nodeTab[i]);
     }
 
-    xmlFree(context);
-    xmlFree(evalResult);
+    xmlXPathFreeContext(context);
+    xmlXPathFreeObject(evalResult);
 
     return results;
 }


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-5256 for Swift 4.  Cherry-pick of https://github.com/apple/swift-corelibs-foundation/commit/cf17ae7c6e959ec37c77cb76377d135aed2c4540.