### PR TITLE
Enable building TestFoundation for profiling in Xcode

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -2686,6 +2686,7 @@
 				OTHER_LDFLAGS = (
 					"-twolevel_namespace",
 					"-Wl,-alias_list,CoreFoundation/Base.subproj/SymbolAliases",
+					"-Wl,-all_load",
 					"-sectcreate",
 					__UNICODE,
 					__csbitmaps,

--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -790,6 +790,7 @@ public final class _DataStorage {
     }
 }
 
+@_versioned
 internal class _NSSwiftData : NSData {
     var _backing: _DataStorage!
     var _range: Range<Data.Index>!

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -80,11 +80,13 @@ internal func _CFZeroUnsafeIvars<T>(_ arg: inout T) {
     }
 }
 
+@_versioned
 @_cdecl("__CFSwiftGetBaseClass")
 internal func __CFSwiftGetBaseClass() -> UnsafeRawPointer {
     return unsafeBitCast(__NSCFType.self, to:UnsafeRawPointer.self)
 }
 
+@_versioned
 @_cdecl("__CFInitializeSwift")
 internal func __CFInitializeSwift() {
     


### PR DESCRIPTION
This change enables building the TestFoundation executable in Release mode so that it can be profiled in Instruments.

Some symbols have been changed to `public` as they need to be exported to CoreFoundation and used for ObjCBridging.

To profile, the TestFoundation scheme needs to be edited and the 'Profile(Release)' scheme set to 'Ask on Launch' for the executable. The Xcode project has not been updated as Xcode adds the full path to the executable and the path it adds in `TestFoundation.xcscheme` is an absolute path including my homedir so it would not be applicable to anyone else.
