### PR TITLE
NSLocalizedDescription for http errors taken from libcurl

### DIFF
--- a/CoreFoundation/URL.subproj/CFURLSessionInterface.c
+++ b/CoreFoundation/URL.subproj/CFURLSessionInterface.c
@@ -19,6 +19,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "CFURLSessionInterface.h"
+#include <CoreFoundation/CFString.h>
 #include <curl/curl.h>
 
 FILE* aa = NULL;
@@ -31,6 +32,11 @@ static CFURLSessionMultiCode MakeMultiCode(CURLMcode value) {
     return (CFURLSessionMultiCode) { value };
 }
 
+CFStringRef CFURLSessionCreateErrorDescription(int value) {
+    const char *description = curl_easy_strerror(value);
+    return CFStringCreateWithBytes(kCFAllocatorSystemDefault,
+        (const uint8_t *)description, strlen(description), kCFStringEncodingUTF8, NO);
+}
 
 CFURLSessionEasyHandle _Nonnull CFURLSessionEasyHandleInit() {
     return curl_easy_init();
@@ -135,6 +141,7 @@ CFURLSessionEasyCode CFURLSessionInit(void) {
     return MakeEasyCode(curl_global_init(CURL_GLOBAL_SSL));
 }
 
+int const CFURLSessionEasyErrorSize = { CURL_ERROR_SIZE + 1 };
 
 CFURLSessionEasyCode const CFURLSessionEasyCodeOK = { CURLE_OK };
 CFURLSessionEasyCode const CFURLSessionEasyCodeUNSUPPORTED_PROTOCOL = { CURLE_UNSUPPORTED_PROTOCOL };

--- a/CoreFoundation/URL.subproj/CFURLSessionInterface.h
+++ b/CoreFoundation/URL.subproj/CFURLSessionInterface.h
@@ -48,6 +48,10 @@ typedef struct CFURLSessionEasyCode {
     int value;
 } CFURLSessionEasyCode;
 
+CF_EXPORT CFStringRef _Nonnull CFURLSessionCreateErrorDescription(int value);
+
+CF_EXPORT int const CFURLSessionEasyErrorSize;
+
 /// CURLcode
 CF_EXPORT CFURLSessionEasyCode const CFURLSessionEasyCodeOK; // CURLE_OK
 CF_EXPORT CFURLSessionEasyCode const CFURLSessionEasyCodeUNSUPPORTED_PROTOCOL; // CURLE_UNSUPPORTED_PROTOCOL

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -20,7 +20,7 @@ extension unichar : ExpressibleByUnicodeScalarLiteral {
     }
 }
 
-// Placeholder for a future implementation
+/// Returns a localized string, using the main bundle if one is not specified.
 public
 func NSLocalizedString(_ key: String,
                        tableName: String? = nil,

--- a/Foundation/URLSession/http/HTTPURLProtocol.swift
+++ b/Foundation/URLSession/http/HTTPURLProtocol.swift
@@ -134,7 +134,9 @@ fileprivate extension _HTTPURLProtocol {
             //     NSURLErrorNoPermissionsToReadFile
             //     NSURLErrorFileDoesNotExist
             self.internalState = .transferFailed
-            failWith(errorCode: errorCode(fileSystemError: e), request: request)
+            let error = NSError(domain: NSURLErrorDomain, code: errorCode(fileSystemError: e),
+                                userInfo: [NSLocalizedDescriptionKey: "File system error"])
+            failWith(error: error, request: request)
             return
         }
 
@@ -328,17 +330,19 @@ internal extension _HTTPURLProtocol {
         case stream(InputStream)
     }
 
-    func failWith(errorCode: Int, request: URLRequest) {
+    func failWith(error: NSError, request: URLRequest) {
         //TODO: Error handling
         let userInfo: [String : Any]? = request.url.map {
             [
+                NSUnderlyingErrorKey: error,
                 NSURLErrorFailingURLErrorKey: $0,
                 NSURLErrorFailingURLStringErrorKey: $0.absoluteString,
+                NSLocalizedDescriptionKey: NSLocalizedString(error.localizedDescription, comment: "N/A")
                 ]
         }
-        let error = URLError(_nsError: NSError(domain: NSURLErrorDomain, code: errorCode, userInfo: userInfo))
-        completeTask(withError: error)
-        self.client?.urlProtocol(self, didFailWithError: error)
+        let urlError = URLError(_nsError: NSError(domain: NSURLErrorDomain, code: error.code, userInfo: userInfo))
+        completeTask(withError: urlError)
+        self.client?.urlProtocol(self, didFailWithError: urlError)
     }
 }
 
@@ -528,16 +532,16 @@ extension _HTTPURLProtocol: _EasyHandleDelegate {
         }
     }
 
-    func transferCompleted(withErrorCode errorCode: Int?) {
+    func transferCompleted(withError error: NSError?) {
         // At this point the transfer is complete and we can decide what to do.
         // If everything went well, we will simply forward the resulting data
         // to the delegate. But in case of redirects etc. we might send another
         // request.
         guard case .transferInProgress(let ts) = internalState else { fatalError("Transfer completed, but it wasn't in progress.") }
         guard let request = task?.currentRequest else { fatalError("Transfer completed, but there's no current request.") }
-        guard errorCode == nil else {
+        guard error == nil else {
             internalState = .transferFailed
-            failWith(errorCode: errorCode!, request: request)
+            failWith(error: error!, request: request)
             return
         }
 
@@ -555,7 +559,9 @@ extension _HTTPURLProtocol: _EasyHandleDelegate {
             completeTask()
         case .failWithError(let errorCode):
             internalState = .transferFailed
-            failWith(errorCode: errorCode, request: request)
+            let error = NSError(domain: NSURLErrorDomain, code: errorCode,
+                                userInfo: [NSLocalizedDescriptionKey: "Completion failure"])
+            failWith(error: error, request: request)
         case .redirectWithRequest(let newRequest):
             redirectFor(request: newRequest)
         }

--- a/Foundation/URLSession/http/MultiHandle.swift
+++ b/Foundation/URLSession/http/MultiHandle.swift
@@ -202,12 +202,20 @@ fileprivate extension URLSession._MultiHandle {
         }
         let easyHandle = easyHandles[idx]
         // Find the NSURLError code
-        let errorCode = easyHandle.urlErrorCode(for: easyCode)
-        completedTransfer(forEasyHandle: easyHandle, errorCode: errorCode)
+        var error: NSError?
+        if let errorCode = easyHandle.urlErrorCode(for: easyCode) {
+            let errorDescription = easyHandle.errorBuffer[0] != 0 ?
+                String(cString: easyHandle.errorBuffer) :
+                CFURLSessionCreateErrorDescription(easyCode.value)._swiftObject
+            error = NSError(domain: NSURLErrorDomain, code: errorCode, userInfo: [
+                NSLocalizedDescriptionKey: errorDescription
+            ])
+        }
+        completedTransfer(forEasyHandle: easyHandle, error: error)
     }
     /// Transfer completed.
-    func completedTransfer(forEasyHandle handle: _EasyHandle, errorCode: Int?) {
-        handle.completedTransfer(withErrorCode: errorCode)
+    func completedTransfer(forEasyHandle handle: _EasyHandle, error: NSError?) {
+        handle.completedTransfer(withError: error)
     }
 }
 


### PR DESCRIPTION
Hi Apple,

At the moment any network error using a URLSession contains only the default "The operation could not be completed” as its NSLocalizedDescription. This PR conveys the value of curl_easy_strerror through the implementation so something more specific is reported such as "Foundation.URLError(_nsError: Peer certificate cannot be authenticated with given CA certificates)"

Thanks.