### PR TITLE
SR-5837: Fix dateFormat bug in DateFormatter

### DIFF
--- a/Foundation/DateFormatter.swift
+++ b/Foundation/DateFormatter.swift
@@ -142,9 +142,23 @@ open class DateFormatter : Formatter {
         }
     }
 
-    open var dateStyle: Style = .none { willSet { _dateFormat = nil; _reset() } }
+    open var dateStyle: Style = .none {
+        willSet {
+            _dateFormat = nil
+        }
+        didSet {
+            _dateFormat = CFDateFormatterGetFormat(_cfObject)._swiftObject
+        }
+    }
 
-    open var timeStyle: Style = .none { willSet { _dateFormat = nil; _reset() } }
+    open var timeStyle: Style = .none {
+        willSet {
+            _dateFormat = nil
+        }
+        didSet {
+            _dateFormat = CFDateFormatterGetFormat(_cfObject)._swiftObject
+        }
+    }
 
     /*@NSCopying*/ open var locale: Locale! = .current { willSet { _reset() } }
 

--- a/TestFoundation/TestDateFormatter.swift
+++ b/TestFoundation/TestDateFormatter.swift
@@ -300,25 +300,34 @@ class TestDateFormatter: XCTestCase {
         let f = DateFormatter()
         f.timeZone = TimeZone(abbreviation: DEFAULT_TIMEZONE)
         
-        //.full cases have been omitted as they're not working correctly on Linux
+        //.full cases have been commented out as they're not working correctly on Linux
         let formats: [String: (DateFormatter.Style, DateFormatter.Style)] = [
             "": (.none, .none),
             "h:mm a": (.none, .short),
             "h:mm:ss a": (.none, .medium),
             "h:mm:ss a z": (.none, .long),
+//            "h:mm:ss a zzzz": (.none, .full),
             "M/d/yy": (.short, .none),
             "M/d/yy, h:mm a": (.short, .short),
             "M/d/yy, h:mm:ss a": (.short, .medium),
             "M/d/yy, h:mm:ss a z": (.short, .long),
+//            "M/d/yy, h:mm:ss a zzzz": (.short, .full),
             "MMM d, y": (.medium, .none),
             //These tests currently fail, there seems to be a difference in behavior in the CoreFoundation methods called to construct the format strings.
 //            "MMM d, y 'at' h:mm a": (.medium, .short),
 //            "MMM d, y 'at' h:mm:ss a": (.medium, .medium),
 //            "MMM d, y 'at' h:mm:ss a z": (.medium, .long),
+//            "MMM d, y 'at' h:mm:ss a zzzz": (.medium, .full),
             "MMMM d, y": (.long, .none),
             "MMMM d, y 'at' h:mm a": (.long, .short),
             "MMMM d, y 'at' h:mm:ss a": (.long, .medium),
             "MMMM d, y 'at' h:mm:ss a z": (.long, .long),
+//            "MMMM d, y 'at' h:mm:ss a zzzz": (.long, .full),
+//            "EEEE, MMMM d, y": (.full, .none),
+//            "EEEE, MMMM d, y 'at' h:mm a": (.full, .short),
+//            "EEEE, MMMM d, y 'at' h:mm:ss a": (.full, .medium),
+//            "EEEE, MMMM d, y 'at' h:mm:ss a z": (.full, .long),
+//            "EEEE, MMMM d, y 'at' h:mm:ss a zzzz": (.full, .full),
         ]
         
         for (dateFormat, styles) in formats {

--- a/TestFoundation/TestDateFormatter.swift
+++ b/TestFoundation/TestDateFormatter.swift
@@ -29,6 +29,7 @@ class TestDateFormatter: XCTestCase {
             ("test_dateStyleFull",     test_dateStyleFull),
             ("test_customDateFormat", test_customDateFormat),
             ("test_setLocalizedDateFormatFromTemplate", test_setLocalizedDateFormatFromTemplate),
+            ("test_dateFormatString", test_dateFormatString),
         ]
     }
     
@@ -295,4 +296,36 @@ class TestDateFormatter: XCTestCase {
         XCTAssertEqual(f.dateFormat, dateFormat)
     }
 
+    func test_dateFormatString() {
+        let f = DateFormatter()
+        f.timeZone = TimeZone(abbreviation: DEFAULT_TIMEZONE)
+        
+        //.full cases have been omitted as they're not working correctly on Linux
+        let formats: [String: (DateFormatter.Style, DateFormatter.Style)] = [
+            "": (.none, .none),
+            "h:mm a": (.none, .short),
+            "h:mm:ss a": (.none, .medium),
+            "h:mm:ss a z": (.none, .long),
+            "M/d/yy": (.short, .none),
+            "M/d/yy, h:mm a": (.short, .short),
+            "M/d/yy, h:mm:ss a": (.short, .medium),
+            "M/d/yy, h:mm:ss a z": (.short, .long),
+            "MMM d, y": (.medium, .none),
+            //These tests currently fail, there seems to be a difference in behavior in the CoreFoundation methods called to construct the format strings.
+//            "MMM d, y 'at' h:mm a": (.medium, .short),
+//            "MMM d, y 'at' h:mm:ss a": (.medium, .medium),
+//            "MMM d, y 'at' h:mm:ss a z": (.medium, .long),
+            "MMMM d, y": (.long, .none),
+            "MMMM d, y 'at' h:mm a": (.long, .short),
+            "MMMM d, y 'at' h:mm:ss a": (.long, .medium),
+            "MMMM d, y 'at' h:mm:ss a z": (.long, .long),
+        ]
+        
+        for (dateFormat, styles) in formats {
+            f.dateStyle = styles.0
+            f.timeStyle = styles.1
+            
+            XCTAssertEqual(f.dateFormat, dateFormat)
+        }
+    }
 }


### PR DESCRIPTION
In a playground if you do the following: 

```swift
let f = DateFormatter()
f.dateStyle = .long
f.timeStyle = .long
f.dateFormat
```
`f.dateFormat` at this point is equal to "MMMM d, y 'at' h:mm:ss a z" 

However if you do the same in Foundation the f.dateFormat is equal to "" this is because whenever you set the Style properties dateFormat is being set to nil but it's not then reassigned a new value at that point. The code handles this nil value by assigning dateFormat the value of "" but this is not the correct value.  

The expected behaviour is that when you set the Style properties the dateFormat property is then also reassigned the correct value based on the value you assigned to the Style properties. 

This PR fixes this behaviour and ensures dateFormat is being set whenever the the Style properties are being set. I've also opened a bug for this which you can find [here](https://bugs.swift.org/browse/SR-5837) 