### PR TITLE
SR-5803: NSNumber no longer equates 1 and true

### DIFF
--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -226,40 +226,9 @@ open class NSNumber : NSValue {
         case let other as Bool:
             return boolValue == other
         case let other as NSNumber:
-            // CFEqual() requires both values to be the same type.
-            if _CFNumberGetType2(_cfObject) == _CFNumberGetType2(other._cfObject) {
-                return CFEqual(_cfObject, other._cfObject)
-            }
-            // If either NSNumber is a bool, use a specific test.
-            if CFGetTypeID(self) == CFBooleanGetTypeID() {
-                return testBool(self.boolValue, other)
-            } else if CFGetTypeID(other) == CFBooleanGetTypeID() {
-                return testBool(other.boolValue, self)
-            }
             return compare(other) == .orderedSame
         default:
             return false
-        }
-    }
-
-    private func testBool(_ boolean: Bool, _ nonBoolean: NSNumber) -> Bool {
-        let isOne: Bool
-        let isZero: Bool
-
-        // false is only equal to 0,
-        // true is only equal to exactly 1, not any non-zero value.
-        // isOne and isZero can both be false.
-        if !CFNumberIsFloatType(nonBoolean._cfObject) {
-            isOne = (nonBoolean.intValue == 1)
-            isZero = (nonBoolean.intValue == 0)
-        } else {
-            isOne = (nonBoolean.doubleValue == Double(1))
-            isZero = (nonBoolean.doubleValue == Double(0))
-        }
-        if boolean == true {
-            return isOne
-        } else {
-            return isZero
         }
     }
 

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -226,9 +226,40 @@ open class NSNumber : NSValue {
         case let other as Bool:
             return boolValue == other
         case let other as NSNumber:
-            return CFEqual(_cfObject, other._cfObject)
+            // CFEqual() requires both values to be the same type.
+            if _CFNumberGetType2(_cfObject) == _CFNumberGetType2(other._cfObject) {
+                return CFEqual(_cfObject, other._cfObject)
+            }
+            // If either NSNumber is a bool, use a specific test.
+            if CFGetTypeID(self) == CFBooleanGetTypeID() {
+                return testBool(self.boolValue, other)
+            } else if CFGetTypeID(other) == CFBooleanGetTypeID() {
+                return testBool(other.boolValue, self)
+            }
+            return compare(other) == .orderedSame
         default:
             return false
+        }
+    }
+
+    private func testBool(_ boolean: Bool, _ nonBoolean: NSNumber) -> Bool {
+        let isOne: Bool
+        let isZero: Bool
+
+        // false is only equal to 0,
+        // true is only equal to exactly 1, not any non-zero value.
+        // isOne and isZero can both be false.
+        if !CFNumberIsFloatType(nonBoolean._cfObject) {
+            isOne = (nonBoolean.intValue == 1)
+            isZero = (nonBoolean.intValue == 0)
+        } else {
+            isOne = (nonBoolean.doubleValue == Double(1))
+            isZero = (nonBoolean.doubleValue == Double(0))
+        }
+        if boolean == true {
+            return isOne
+        } else {
+            return isZero
         }
     }
 

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -1132,5 +1132,6 @@ class TestNSNumber : XCTestCase {
         XCTAssertTrue(NSNumber(value: Int8.max) == NSNumber(value: Double(127)))
         XCTAssertTrue(NSNumber(value: UInt16.min) == NSNumber(value: Float(0)))
         XCTAssertTrue(NSNumber(value: UInt16.max) == NSNumber(value: Double(65535)))
+        XCTAssertTrue(NSNumber(value: 1.1) != NSNumber(value: Int64(1)))
     }
 }

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -44,6 +44,7 @@ class TestNSNumber : XCTestCase {
             ("test_descriptionWithLocale", test_descriptionWithLocale ),
             ("test_objCType", test_objCType ),
             ("test_stringValue", test_stringValue),
+            ("test_Equals", test_Equals),
         ]
     }
     
@@ -1086,5 +1087,50 @@ class TestNSNumber : XCTestCase {
         XCTAssertEqual(NSNumber(value: Int64.min + 1).stringValue, "-9223372036854775807")
         XCTAssertEqual(NSNumber(value: Int64.max).stringValue, "9223372036854775807")
         XCTAssertEqual(NSNumber(value: Int64.max - 1).stringValue, "9223372036854775806")
+    }
+
+    func test_Equals() {
+        // Booleans: false only equals 0, true only equals 1
+        XCTAssertTrue(NSNumber(value: true) == NSNumber(value: true))
+        XCTAssertTrue(NSNumber(value: true) == NSNumber(value: 1))
+        XCTAssertTrue(NSNumber(value: true) == NSNumber(value: Float(1)))
+        XCTAssertTrue(NSNumber(value: true) == NSNumber(value: Double(1)))
+        XCTAssertTrue(NSNumber(value: true) == NSNumber(value: Int8(1)))
+        XCTAssertTrue(NSNumber(value: true) != NSNumber(value: false))
+        XCTAssertTrue(NSNumber(value: true) != NSNumber(value: Int8(-1)))
+        XCTAssertTrue(NSNumber(value: true) != NSNumber(value: Float(1.01)))
+        XCTAssertTrue(NSNumber(value: true) != NSNumber(value: Double(1234.56)))
+        XCTAssertTrue(NSNumber(value: true) != NSNumber(value: 2))
+        XCTAssertTrue(NSNumber(value: true) != NSNumber(value: Int.max))
+        XCTAssertTrue(NSNumber(value: false) == NSNumber(value: false))
+        XCTAssertTrue(NSNumber(value: false) == NSNumber(value: 0))
+        XCTAssertTrue(NSNumber(value: false) == NSNumber(value: Float(0)))
+        XCTAssertTrue(NSNumber(value: false) == NSNumber(value: Double(0)))
+        XCTAssertTrue(NSNumber(value: false) == NSNumber(value: Int8(0)))
+        XCTAssertTrue(NSNumber(value: false) == NSNumber(value: UInt64(0)))
+        XCTAssertTrue(NSNumber(value: false) != NSNumber(value: 1))
+        XCTAssertTrue(NSNumber(value: false) != NSNumber(value: 2))
+        XCTAssertTrue(NSNumber(value: false) != NSNumber(value: Int.max))
+
+        XCTAssertTrue(NSNumber(value: Int8(-1)) == NSNumber(value: Int16(-1)))
+        XCTAssertTrue(NSNumber(value: Int16(-1)) == NSNumber(value: Int32(-1)))
+        XCTAssertTrue(NSNumber(value: Int32(-1)) == NSNumber(value: Int64(-1)))
+        XCTAssertTrue(NSNumber(value: Int8.max) != NSNumber(value: Int16.max))
+        XCTAssertTrue(NSNumber(value: Int16.max) != NSNumber(value: Int32.max))
+        XCTAssertTrue(NSNumber(value: Int32.max) != NSNumber(value: Int64.max))
+        XCTAssertTrue(NSNumber(value: UInt8.min) == NSNumber(value: UInt16.min))
+        XCTAssertTrue(NSNumber(value: UInt16.min) == NSNumber(value: UInt32.min))
+        XCTAssertTrue(NSNumber(value: UInt32.min) == NSNumber(value: UInt64.min))
+        XCTAssertTrue(NSNumber(value: UInt8.max) != NSNumber(value: UInt16.max))
+        XCTAssertTrue(NSNumber(value: UInt16.max) != NSNumber(value: UInt32.max))
+        XCTAssertTrue(NSNumber(value: UInt32.max) != NSNumber(value: UInt64.max))
+        XCTAssertTrue(NSNumber(value: Int8(0)) == NSNumber(value: UInt16(0)))
+        XCTAssertTrue(NSNumber(value: UInt16(0)) == NSNumber(value: Int32(0)))
+        XCTAssertTrue(NSNumber(value: Int32(0)) == NSNumber(value: UInt64(0)))
+        XCTAssertTrue(NSNumber(value: Int(0)) == NSNumber(value: UInt(0)))
+        XCTAssertTrue(NSNumber(value: Int8.min) == NSNumber(value: Float(-128)))
+        XCTAssertTrue(NSNumber(value: Int8.max) == NSNumber(value: Double(127)))
+        XCTAssertTrue(NSNumber(value: UInt16.min) == NSNumber(value: Float(0)))
+        XCTAssertTrue(NSNumber(value: UInt16.max) == NSNumber(value: Double(65535)))
     }
 }


### PR DESCRIPTION
- Fix isEqual to work with NSNumbers initialised with different types
  (eg, float and UInt).

- Match the behaviour of Darwin where true can only equal an NSNumber
  with a value of exactly 1.

I essentially added tests that worked correctly on Darwin and then fixed the current code until all of the tests passed.