### PR TITLE
Make JSON pretty-printing consistent with Darwin.

### DIFF
--- a/Foundation/JSONSerialization.swift
+++ b/Foundation/JSONSerialization.swift
@@ -512,7 +512,7 @@ private struct JSONWriter {
             } else {
                 throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.propertyListReadCorrupt.rawValue, userInfo: ["NSDebugDescription" : "NSDictionary key must be NSString"])
             }
-            pretty ? writer(": ") : writer(":")
+            pretty ? writer(" : ") : writer(":")
             try serializeJSON(value)
         }
 

--- a/TestFoundation/TestJSONSerialization.swift
+++ b/TestFoundation/TestJSONSerialization.swift
@@ -989,6 +989,7 @@ extension TestJSONSerialization {
             ("test_serialize_dictionaryWithDecimal", test_serialize_dictionaryWithDecimal),
             ("test_serializeDecimalNumberJSONObject", test_serializeDecimalNumberJSONObject),
             ("test_serializeSortedKeys", test_serializeSortedKeys),
+            ("test_colonPrettyPrintingMatchesDarwin", test_colonPrettyPrintingMatchesDarwin),
         ]
     }
 
@@ -1477,6 +1478,11 @@ extension TestJSONSerialization {
 
         dict = ["c": ["c":1,"b":1,"a":1],"b":["c":1,"b":1,"a":1],"a":["c":1,"b":1,"a":1]]
         XCTAssertEqual(try trySerialize(dict, options: .sortedKeys), "{\"a\":{\"a\":1,\"b\":1,\"c\":1},\"b\":{\"a\":1,\"b\":1,\"c\":1},\"c\":{\"a\":1,\"b\":1,\"c\":1}}")
+    }
+
+    func test_colonPrettyPrintingMatchesDarwin() {
+        let dictionary = ["key": 4]
+        XCTAssertEqual(try trySerialize(dictionary, options: .prettyPrinted), "{\n  \"key\" : 4\n}")
     }
 
     fileprivate func createTestFile(_ path: String,_contents: Data) -> String? {

--- a/TestFoundation/TestJSONSerialization.swift
+++ b/TestFoundation/TestJSONSerialization.swift
@@ -989,7 +989,7 @@ extension TestJSONSerialization {
             ("test_serialize_dictionaryWithDecimal", test_serialize_dictionaryWithDecimal),
             ("test_serializeDecimalNumberJSONObject", test_serializeDecimalNumberJSONObject),
             ("test_serializeSortedKeys", test_serializeSortedKeys),
-            ("test_colonPrettyPrintingMatchesDarwin", test_colonPrettyPrintingMatchesDarwin),
+            ("test_serializePrettyPrinted", test_serializePrettyPrinted),
         ]
     }
 
@@ -1480,7 +1480,7 @@ extension TestJSONSerialization {
         XCTAssertEqual(try trySerialize(dict, options: .sortedKeys), "{\"a\":{\"a\":1,\"b\":1,\"c\":1},\"b\":{\"a\":1,\"b\":1,\"c\":1},\"c\":{\"a\":1,\"b\":1,\"c\":1}}")
     }
 
-    func test_colonPrettyPrintingMatchesDarwin() {
+    func test_serializePrettyPrinted() {
         let dictionary = ["key": 4]
         XCTAssertEqual(try trySerialize(dictionary, options: .prettyPrinted), "{\n  \"key\" : 4\n}")
     }


### PR DESCRIPTION
On macOS, pretty-printing JSON results in a space before the colon, e.g.:

	{
	  "key" : 4
	}

Addresses [SR-5570](https://bugs.swift.org/browse/SR-5570).