### PR TITLE
Implicit import of Dispatch when importing Foundation?

### DIFF
--- a/Foundation/NSObject.swift
+++ b/Foundation/NSObject.swift
@@ -8,6 +8,7 @@
 //
 
 import CoreFoundation
+@_exported import Dispatch
 
 /// The `NSObjectProtocol` groups methods that are fundamental to all Foundation objects.
 ///

--- a/Foundation/NSObject.swift
+++ b/Foundation/NSObject.swift
@@ -7,8 +7,12 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-import CoreFoundation
+// @_exported import of Dispatch here makes it available to all
+// classes in Foundation and all sources that import Foundation.
+// This brings it into line with Darwin usage for compatbility.
 @_exported import Dispatch
+
+import CoreFoundation
 
 /// The `NSObjectProtocol` groups methods that are fundamental to all Foundation objects.
 ///


### PR DESCRIPTION
Hi Apple,

With apologies for the rash of controversial PRs this week, I’m getting to the end the preparation of a release candidate for the Android/Swift toolchain that I’ve been working on and testing with a wide range of Open Source packages (Alamofire, Moya, RxSwift etc.) for portability. One assumption that commonly comes up in these projects is that importing Foundation is enough to have Dispatch classes available to the Swift source i.e it is imported implicitly when you import Foundation.

You must have considered this, and for compatibility with Darwin I would have thought this was the way to go so I’ve added an @_exported import of Dispatch to NSObject.swift in the toolchain for want of a better place to put it. I had also experimented with exporting CoreFoundation but functions like bind() and accept() seem to leak from CoreFoundation.h and are defined in Glibc causing ambiguity errors.

What are your thoughts?