### PR TITLE
Android: Fixed prepare.sh to download the toolchain instead from http…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ Build
 *.swp
 *.orig
 .arcconfig
+
+*.tgz

--- a/android/prepare.sh
+++ b/android/prepare.sh
@@ -6,12 +6,17 @@
 BUILD_DIR="build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift"
 
 cd "$(dirname $0)" &&
-TAR_FILE="$(pwd)/android_dispatch.tgz" &&
+TAR_FILE="$(pwd)/android_toolchain.tgz" &&
 
 if [[ ! -f "${TAR_FILE}" ]]; then
-    echo "Fetching binaries and headers for libxml2, libcurl and libdispatch"
-    curl "https://raw.githubusercontent.com/SwiftJava/SwiftJava/master/android_dispatch.tgz" > "${TAR_FILE}"
+echo "Fetching binaries and headers for libxml2, libcurl and libdispatch"
+curl http://johnholdsworth.com/android_toolchain.tgz > "${TAR_FILE}"
 fi
 
-cd "../.." && mkdir -p "${BUILD_DIR}" &&
-cd "${BUILD_DIR}" && tar xfvz "${TAR_FILE}"
+tar xfvz "${TAR_FILE}"
+
+mkdir -p "../../${BUILD_DIR}/android/armv7" &&
+
+cp -r swift-install/usr/lib/swift/android/{libxml2.so,libcurl.so,libdispatch.so} ../../${BUILD_DIR}/android
+cp -r swift-install/usr/lib/swift/android/armv7/Dispatch.swiftmodule ../../${BUILD_DIR}/android/armv7
+rm -rf swift-install

--- a/android/prepare.sh
+++ b/android/prepare.sh
@@ -9,8 +9,8 @@ cd "$(dirname $0)" &&
 TAR_FILE="$(pwd)/android_toolchain.tgz" &&
 
 if [[ ! -f "${TAR_FILE}" ]]; then
-echo "Fetching binaries and headers for libxml2, libcurl and libdispatch"
-curl http://johnholdsworth.com/android_toolchain.tgz > "${TAR_FILE}"
+    echo "Fetching binaries and headers for libxml2, libcurl and libdispatch"
+    curl http://johnholdsworth.com/android_toolchain.tgz > "${TAR_FILE}"
 fi
 
 tar xfvz "${TAR_FILE}"
@@ -19,4 +19,7 @@ mkdir -p "../../${BUILD_DIR}/android/armv7" &&
 
 cp -r swift-install/usr/lib/swift/android/{libxml2.so,libcurl.so,libdispatch.so} ../../${BUILD_DIR}/android
 cp -r swift-install/usr/lib/swift/android/armv7/Dispatch.swiftmodule ../../${BUILD_DIR}/android/armv7
+cp -r swift-install/usr/lib/swift/{curl,dispatch,libxml} ../../${BUILD_DIR}
+
 rm -rf swift-install
+


### PR DESCRIPTION
Android: Fixed prepare.sh to download the toolchain instead from http://johnholdsworth.com/android_toolchain.tgz as the old link is not working anymore.