### PR TITLE
NotificationCenter should us NSNotification.Name per docs

### DIFF
--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -178,7 +178,7 @@ open class NotificationCenter: NSObject {
         removeObserver(observer, name: nil, object: nil)
     }
 
-    open func removeObserver(_ observer: Any, name aName: NSNotification.Name?, object: Any?) {
+    open func removeObserver(_ observer: Any, name aName: Notification.Name?, object: Any?) {
         guard let observer = observer as? NSObject else {
             return
         }

--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -169,7 +169,7 @@ open class NotificationCenter: NSObject {
         }
     }
 
-    open func post(name aName: Notification.Name, object anObject: Any?, userInfo aUserInfo: [AnyHashable : Any]? = nil) {
+    open func post(name aName: NSNotification.Name, object anObject: Any?, userInfo aUserInfo: [AnyHashable : Any]? = nil) {
         let notification = Notification(name: aName, object: anObject, userInfo: aUserInfo)
         post(notification)
     }
@@ -178,7 +178,7 @@ open class NotificationCenter: NSObject {
         removeObserver(observer, name: nil, object: nil)
     }
 
-    open func removeObserver(_ observer: Any, name aName: Notification.Name?, object: Any?) {
+    open func removeObserver(_ observer: Any, name aName: NSNotification.Name?, object: Any?) {
         guard let observer = observer as? NSObject else {
             return
         }
@@ -189,11 +189,11 @@ open class NotificationCenter: NSObject {
     }
 
     @available(*,obsoleted:4.0,renamed:"addObserver(forName:object:queue:using:)")
-    open func addObserver(forName name: Notification.Name?, object obj: Any?, queue: OperationQueue?, usingBlock block: @escaping (Notification) -> Void) -> NSObjectProtocol {
+    open func addObserver(forName name: NSNotification.Name?, object obj: Any?, queue: OperationQueue?, usingBlock block: @escaping (Notification) -> Void) -> NSObjectProtocol {
         return addObserver(forName: name, object: obj, queue: queue, using: block)
     }
 
-    open func addObserver(forName name: Notification.Name?, object obj: Any?, queue: OperationQueue?, using block: @escaping (Notification) -> Void) -> NSObjectProtocol {
+    open func addObserver(forName name: NSNotification.Name?, object obj: Any?, queue: OperationQueue?, using block: @escaping (Notification) -> Void) -> NSObjectProtocol {
         let object = NSObject()
         
         let newObserver = NSNotificationReceiver()


### PR DESCRIPTION
Per [Apple docs](https://developer.apple.com/documentation/foundation/notificationcenter), `addObserver` and `post` use `NSNotification.Name`