### PR TITLE
Correct a typo for thread-specific set [NFC]

### DIFF
--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -1301,7 +1301,7 @@ CFTypeRef _Nullable _CFThreadSpecificGet(_CFThreadSpecificKey key) {
     return (CFTypeRef)pthread_getspecific(key);
 }
 
-void _CThreadSpecificSet(_CFThreadSpecificKey key, CFTypeRef _Nullable value) {
+void _CFThreadSpecificSet(_CFThreadSpecificKey key, CFTypeRef _Nullable value) {
     if (value != NULL) {
         swift_retain((void *)value);
         pthread_setspecific(key, value);

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -301,7 +301,7 @@ CF_EXPORT CFHashCode __CFHashDouble(double d);
 
 typedef pthread_key_t _CFThreadSpecificKey;
 CF_EXPORT CFTypeRef _Nullable _CFThreadSpecificGet(_CFThreadSpecificKey key);
-CF_EXPORT void _CThreadSpecificSet(_CFThreadSpecificKey key, CFTypeRef _Nullable value);
+CF_EXPORT void _CFThreadSpecificSet(_CFThreadSpecificKey key, CFTypeRef _Nullable value);
 CF_EXPORT _CFThreadSpecificKey _CFThreadSpecificKeyCreate(void);
 
 typedef pthread_attr_t _CFThreadAttributes;

--- a/Foundation/Thread.swift
+++ b/Foundation/Thread.swift
@@ -23,13 +23,13 @@ internal class NSThreadSpecific<T: NSObject> {
             return specific as! T
         } else {
             let value = generator()
-            _CThreadSpecificSet(key, value)
+            _CFThreadSpecificSet(key, value)
             return value
         }
     }
 
     internal func set(_ value: T) {
-        _CThreadSpecificSet(key, value)
+        _CFThreadSpecificSet(key, value)
     }
 }
 


### PR DESCRIPTION
I was reading through `Thread.swift` and found the name of an internal function to be confusing. After some head scratching, it's pretty clear that `_CThreadSpecificSet` should be `_CFThreadSpecificSet`. This PR updates the name so as to improve clarity.