### PR TITLE
Thread safety for URLSession

### DIFF
--- a/Foundation/URLSession/URLSession.swift
+++ b/Foundation/URLSession/URLSession.swift
@@ -192,7 +192,6 @@ public let NSURLSessionTransferSizeUnknown: Int64 = -1
 open class URLSession : NSObject {
     fileprivate let _configuration: _Configuration
     fileprivate let multiHandle: _MultiHandle
-    fileprivate let taskIdentifierLock = NSLock()
     fileprivate var nextTaskIdentifier = 1
     internal let workQueue: DispatchQueue 
     /// This queue is used to make public attributes on `URLSessionTask` instances thread safe.
@@ -407,7 +406,7 @@ extension URLSession._Request {
 
 fileprivate extension URLSession {
     func createNextTaskIdentifier() -> Int {
-        return taskIdentifierLock.synchronized {
+        return workQueue.sync {
             let i = nextTaskIdentifier
             nextTaskIdentifier += 1
             return i

--- a/Foundation/URLSession/URLSession.swift
+++ b/Foundation/URLSession/URLSession.swift
@@ -192,6 +192,7 @@ public let NSURLSessionTransferSizeUnknown: Int64 = -1
 open class URLSession : NSObject {
     fileprivate let _configuration: _Configuration
     fileprivate let multiHandle: _MultiHandle
+    fileprivate let taskIdentifierLock = NSLock()
     fileprivate var nextTaskIdentifier = 1
     internal let workQueue: DispatchQueue 
     /// This queue is used to make public attributes on `URLSessionTask` instances thread safe.
@@ -406,9 +407,11 @@ extension URLSession._Request {
 
 fileprivate extension URLSession {
     func createNextTaskIdentifier() -> Int {
-        let i = nextTaskIdentifier
-        nextTaskIdentifier += 1
-        return i
+        return taskIdentifierLock.synchronized {
+            let i = nextTaskIdentifier
+            nextTaskIdentifier += 1
+            return i
+        }
     }
 }
 


### PR DESCRIPTION
Hi Apple,

I’ve been seeing assertion failures using a URLSession from multiple threads on [this line](https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/URLSession/TaskRegistry.swift#L63). This PR makes a small change so allocation of the taskIdentifier in URLSession is thread safe.

Thanks.