### PR TITLE
AffineTransform: implement hashValue and improve tests

### DIFF
--- a/Foundation/AffineTransform.swift
+++ b/Foundation/AffineTransform.swift
@@ -338,6 +338,10 @@ open class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
         return other === self
             || (other.transformStruct == self.transformStruct)
     }
+
+    open override var hashValue: Int {
+        return transformStruct.hashValue
+    }
     
     public static var supportsSecureCoding: Bool {
         return true

--- a/TestFoundation/TestAffineTransform.swift
+++ b/TestFoundation/TestAffineTransform.swift
@@ -40,6 +40,7 @@ class TestAffineTransform : XCTestCase {
             ("test_TransformComposition", test_TransformComposition),
             ("test_hashing_identity", test_hashing_identity),
             ("test_hashing_values", test_hashing_values),
+            ("test_rotation_compose", test_rotation_compose),
             ("test_Equal", test_Equal),
             ("test_NSCoding", test_NSCoding),
         ]
@@ -346,6 +347,16 @@ class TestAffineTransform : XCTestCase {
             ref.transformStruct = val
             XCTAssertEqual(ref.hashValue, val.hashValue)
         }
+    }
+
+    func test_rotation_compose() {
+        var t = AffineTransform.identity
+        t.translate(x: 1.0, y: 1.0)
+        t.rotate(byDegrees: 90)
+        t.translate(x: -1.0, y: -1.0)
+        let result = t.transform(NSPoint(x: 1.0, y: 2.0))
+        XCTAssertEqual(0.0, Double(result.x), accuracy: accuracyThreshold)
+        XCTAssertEqual(1.0, Double(result.y), accuracy: accuracyThreshold)
     }
     
     func test_Equal() {

--- a/TestFoundation/TestAffineTransform.swift
+++ b/TestFoundation/TestAffineTransform.swift
@@ -38,6 +38,8 @@ class TestAffineTransform : XCTestCase {
             ("test_AppendTransform", test_AppendTransform),
             ("test_PrependTransform", test_PrependTransform),
             ("test_TransformComposition", test_TransformComposition),
+            ("test_hashing_identity", test_hashing_identity),
+            ("test_hashing_values", test_hashing_values),
             ("test_Equal", test_Equal),
             ("test_NSCoding", test_NSCoding),
         ]


### PR DESCRIPTION
1. Implement `NSAffineTransform.hashValue` and enable two tests which were previously disabled.

2. Add `test_rotation_compose()` to test composition of rotation. Test taken from [here](https://github.com/apple/swift/blob/d2926cfb05177d4db0ec89e8609cad1aee14fba1/test/stdlib/TestAffineTransform.swift#L376).