### PR TITLE
Add test for CharacterSet.isSubset() crash on Linux.

### DIFF
--- a/TestFoundation/TestCharacterSet.swift
+++ b/TestFoundation/TestCharacterSet.swift
@@ -75,6 +75,7 @@ class TestCharacterSet : XCTestCase {
             ("test_Planes", test_Planes),
             ("test_InlineBuffer", test_InlineBuffer),
             ("test_Equatable", test_Equatable),
+            ("test_EmptySubset", test_EmptySubset),
             // The following tests must remain disabled until SR-2509 is resolved.
             // ("test_Subtracting", test_Subtracting),
             // ("test_SubtractEmptySet", test_SubtractEmptySet),
@@ -353,4 +354,9 @@ class TestCharacterSet : XCTestCase {
         XCTAssertNotEqual(Box.alphanumerics, Box.decimalDigits)
     }
 
+    func test_EmptySubset() {
+        let set = CharacterSet()
+        XCTAssertTrue(set.isSubset(of: set))
+        XCTAssertFalse(set.isStrictSubset(of: set))
+    }
 }


### PR DESCRIPTION
Add a test for a crash that would occur when checking whether an empty character
set is a subset of an empty set - [SR-4922](https://bugs.swift.org/browse/SR-4922).