### PR TITLE
Fix TestFoundation Imports

### DIFF
--- a/TestFoundation/TestCalendar.swift
+++ b/TestFoundation/TestCalendar.swift
@@ -14,7 +14,6 @@ import XCTest
 import SwiftFoundation
 import SwiftXCTest
 #endif
-import CoreFoundation
 
 class TestCalendar: XCTestCase {
     

--- a/TestFoundation/TestNSGeometry.swift
+++ b/TestFoundation/TestNSGeometry.swift
@@ -11,7 +11,6 @@
 #if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
     import Foundation
     import XCTest
-    import CoreFoundation
 #else
     import SwiftFoundation
     import SwiftXCTest

--- a/TestFoundation/TestNumberFormatter.swift
+++ b/TestFoundation/TestNumberFormatter.swift
@@ -14,7 +14,6 @@
     import SwiftFoundation
     import SwiftXCTest
 #endif
-import CoreFoundation
 
 class TestNumberFormatter: XCTestCase {
 

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -14,7 +14,6 @@
     import SwiftFoundation
     import SwiftXCTest
 #endif
-import CoreFoundation
 
 class TestProcess : XCTestCase {
     static var allTests: [(String, (TestProcess) -> () throws -> Void)] {

--- a/TestFoundation/TestXMLDocument.swift
+++ b/TestFoundation/TestXMLDocument.swift
@@ -17,7 +17,6 @@
     import SwiftXCTest
 #endif
 
-import CoreFoundation
 
 class TestXMLDocument : XCTestCase {
 

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -10,12 +10,17 @@
 #if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
 import Foundation
 import XCTest
-import Glibc
 #else
 import SwiftFoundation
 import SwiftXCTest
-import Darwin
 #endif
+
+#if os(OSX) || os(iOS)
+    import Darwin
+#elseif os(Linux)
+    import Glibc
+#endif
+
 
 internal func testBundle() -> Bundle {
     return Bundle.main


### PR DESCRIPTION
As part of getting the swift-corelibs-foundation tests running against the system Foundation and XCTest, some issues have shown up with module imports.

- Fix `Glibc` and `Darwin` to only be imported on the appropriate OS.
- Remove unneeded `import CoreFoundation`.