### PR TITLE
Align the UserDefaults implementation with Darwin Foundation

### DIFF
--- a/CoreFoundation/Preferences.subproj/CFApplicationPreferences.c
+++ b/CoreFoundation/Preferences.subproj/CFApplicationPreferences.c
@@ -17,7 +17,7 @@
 #include <CoreFoundation/CFNumberFormatter.h>
 #include <CoreFoundation/CFDateFormatter.h>
 #include <sys/types.h>
-#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED
+#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_LINUX
 #include <unistd.h>
 #endif
 

--- a/CoreFoundation/Preferences.subproj/CFPreferences.c
+++ b/CoreFoundation/Preferences.subproj/CFPreferences.c
@@ -445,7 +445,7 @@ static CFStringRef  _CFPreferencesStandardDomainCacheKey(CFStringRef  domainName
 static CFURLRef _CFPreferencesURLForStandardDomainWithSafetyLevel(CFStringRef domainName, CFStringRef userName, CFStringRef hostName, unsigned long safeLevel) {
     CFURLRef theURL = NULL;
     CFAllocatorRef prefAlloc = __CFPreferencesAllocator();
-#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_WINDOWS
+#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_LINUX || DEPLOYMENT_TARGET_WINDOWS
     CFURLRef prefDir = _preferencesDirectoryForUserHostSafetyLevel(userName, hostName, safeLevel);
     CFStringRef  appName;
     CFStringRef  fileName;
@@ -479,7 +479,7 @@ static CFURLRef _CFPreferencesURLForStandardDomainWithSafetyLevel(CFStringRef do
 	CFRelease(appName);
     }
     if (fileName) {
-#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED
+#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_LINUX
         theURL = CFURLCreateWithFileSystemPathRelativeToBase(prefAlloc, fileName, kCFURLPOSIXPathStyle, false, prefDir);
 #elif DEPLOYMENT_TARGET_WINDOWS
 		theURL = CFURLCreateWithFileSystemPathRelativeToBase(prefAlloc, fileName, kCFURLWindowsPathStyle, false, prefDir);
@@ -496,10 +496,6 @@ static CFURLRef _CFPreferencesURLForStandardDomainWithSafetyLevel(CFStringRef do
 static CFURLRef _CFPreferencesURLForStandardDomain(CFStringRef domainName, CFStringRef userName, CFStringRef hostName) {
     return _CFPreferencesURLForStandardDomainWithSafetyLevel(domainName, userName, hostName, __CFSafeLaunchLevel);
 }
-
-const _CFPreferencesDomainCallBacks __kCFXMLPropertyListDomainCallBacks = {
-    
-};
 
 CFPreferencesDomainRef _CFPreferencesStandardDomain(CFStringRef  domainName, CFStringRef  userName, CFStringRef  hostName) {
     CFPreferencesDomainRef domain;

--- a/CoreFoundation/Preferences.subproj/CFXMLPreferencesDomain.c
+++ b/CoreFoundation/Preferences.subproj/CFXMLPreferencesDomain.c
@@ -16,10 +16,12 @@
 #include <CoreFoundation/CFDate.h>
 #include "CFInternal.h"
 #include <time.h>
-#if DEPLOYMENT_TARGET_MACOSX
+#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_LINUX
 #include <unistd.h>
 #include <stdio.h>
 #include <sys/stat.h>
+#endif
+#if DEPLOYMENT_TARGET_MACOSX
 #include <mach/mach.h>
 #include <mach/mach_syscalls.h>
 #endif
@@ -102,7 +104,7 @@ static Boolean _createDirectory(CFURLRef dirURL, Boolean worldReadable) {
     if (parentURL) CFRelease(parentURL);
     if (!parentExists) return false;
 
-#if DEPLOYMENT_TARGET_MACOSX
+#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_LINUX
     mode = worldReadable ? S_IRWXU|S_IRWXG|S_IROTH|S_IXOTH : S_IRWXU;
 #else
     mode = 0666;
@@ -306,7 +308,7 @@ static Boolean _writeXMLFile(CFURLRef url, CFMutableDictionaryRef dict, Boolean 
         CFDataRef data = CFPropertyListCreateData(alloc, dict, desiredFormat, 0, NULL);
         if (data) {
             SInt32 mode;
-#if DEPLOYMENT_TARGET_MACOSX
+#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_LINUX
             mode = isWorldReadable ? S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH : S_IRUSR|S_IWUSR;
 #else
 	    mode = 0666;

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		528776141BF2629700CB0090 /* FoundationErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522C253A1BF16E1600804FC6 /* FoundationErrors.swift */; };
 		528776191BF27D9500CB0090 /* Test.plist in Resources */ = {isa = PBXBuildFile; fileRef = 528776181BF27D9500CB0090 /* Test.plist */; };
 		555683BD1C1250E70041D4C6 /* TestUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555683BC1C1250E70041D4C6 /* TestUserDefaults.swift */; };
+		559451EC1F706BFA002807FB /* CFXMLPreferencesDomain.c in Sources */ = {isa = PBXBuildFile; fileRef = 559451EA1F706BF5002807FB /* CFXMLPreferencesDomain.c */; };
 		5B0163BB1D024EB7003CCD96 /* DateComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0163BA1D024EB7003CCD96 /* DateComponents.swift */; };
 		5B13B3251C582D4700651CE2 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA66F6381BF1619600136161 /* main.swift */; };
 		5B13B3261C582D4C00651CE2 /* TestAffineTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93559281C12C49F009FD6A9 /* TestAffineTransform.swift */; };
@@ -504,6 +505,7 @@
 		52829AD61C160D64003BC4EF /* TestCalendar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCalendar.swift; sourceTree = "<group>"; };
 		528776181BF27D9500CB0090 /* Test.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Test.plist; sourceTree = "<group>"; };
 		555683BC1C1250E70041D4C6 /* TestUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUserDefaults.swift; sourceTree = "<group>"; usesTabs = 1; };
+		559451EA1F706BF5002807FB /* CFXMLPreferencesDomain.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFXMLPreferencesDomain.c; sourceTree = "<group>"; };
 		5B0163BA1D024EB7003CCD96 /* DateComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateComponents.swift; sourceTree = "<group>"; };
 		5B0C6C211C1E07E600705A0E /* TestNSRegularExpression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSRegularExpression.swift; sourceTree = "<group>"; };
 		5B1FD9C11D6D160F0080E83C /* CFURLSessionInterface.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFURLSessionInterface.c; sourceTree = "<group>"; };
@@ -1034,6 +1036,7 @@
 			isa = PBXGroup;
 			children = (
 				5B5D886A1BBC948300234F36 /* CFApplicationPreferences.c */,
+				559451EA1F706BF5002807FB /* CFXMLPreferencesDomain.c */,
 				5B5D898B1BBDBF6500234F36 /* CFPreferences.c */,
 				5B5D886C1BBC94C400234F36 /* CFPreferences.h */,
 			);
@@ -2027,7 +2030,7 @@
 				TargetAttributes = {
 					5B5D885C1BBC938800234F36 = {
 						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 						LastSwiftUpdateCheck = 0800;
 						ProvisioningStyle = Manual;
 					};
@@ -2306,6 +2309,7 @@
 				5B7C8A8B1BEA7FE200C5B690 /* CFBigNumber.c in Sources */,
 				5B7C8A7D1BEA7FCE00C5B690 /* CFBinaryHeap.c in Sources */,
 				5B7C8A7E1BEA7FCE00C5B690 /* CFBitVector.c in Sources */,
+				559451EC1F706BFA002807FB /* CFXMLPreferencesDomain.c in Sources */,
 				5B7C8A8F1BEA7FEC00C5B690 /* CFBinaryPList.c in Sources */,
 				5B7C8A911BEA7FEC00C5B690 /* CFPropertyList.c in Sources */,
 				5B7C8AB41BEA801700C5B690 /* CFStringEncodingDatabase.c in Sources */,

--- a/TestFoundation/TestUserDefaults.swift
+++ b/TestFoundation/TestUserDefaults.swift
@@ -18,9 +18,26 @@
 class TestUserDefaults : XCTestCase {
 	static var allTests : [(String, (TestUserDefaults) -> () throws -> ())] {
 		return [
-			// __kCFXMLPropertyListDomainCallBacks is causing a failure
-			// ("test_createUserDefaults", test_createUserDefaults ),
-			// ("test_getRegisteredDefaultItem", test_getRegisteredDefaultItem ),
+			("test_createUserDefaults", test_createUserDefaults ),
+			("test_getRegisteredDefaultItem", test_getRegisteredDefaultItem ),
+			("test_getRegisteredDefaultItem_NSString", test_getRegisteredDefaultItem_NSString ),
+			("test_getRegisteredDefaultItem_String", test_getRegisteredDefaultItem_String ),
+			("test_getRegisteredDefaultItem_NSURL", test_getRegisteredDefaultItem_NSURL ),
+			("test_getRegisteredDefaultItem_URL", test_getRegisteredDefaultItem_URL ),
+			("test_getRegisteredDefaultItem_NSData", test_getRegisteredDefaultItem_NSData ),
+			("test_getRegisteredDefaultItem_Data)", test_getRegisteredDefaultItem_Data ),
+			("test_getRegisteredDefaultItem_BoolFromString", test_getRegisteredDefaultItem_BoolFromString ),
+			("test_getRegisteredDefaultItem_IntFromString", test_getRegisteredDefaultItem_IntFromString ),
+			("test_getRegisteredDefaultItem_DoubleFromString", test_getRegisteredDefaultItem_DoubleFromString ),
+			("test_setValue_NSString", test_setValue_NSString ),
+			("test_setValue_String", test_setValue_String ),
+			("test_setValue_NSURL", test_setValue_NSURL ),
+			("test_setValue_URL", test_setValue_URL ),
+			("test_setValue_NSData", test_setValue_NSData ),
+			("test_setValue_Data", test_setValue_Data ),
+			("test_setValue_BoolFromString", test_setValue_BoolFromString ),
+			("test_setValue_IntFromString", test_setValue_IntFromString ),
+			("test_setValue_DoubleFromString", test_setValue_DoubleFromString ),
 		]
 	}
 
@@ -39,5 +56,198 @@ class TestUserDefaults : XCTestCase {
 		defaults.removeObject(forKey: "key1")
 		
 		XCTAssertEqual(defaults.integer(forKey: "key1"), 5)
+	}
+	
+	func test_getRegisteredDefaultItem_NSString() {
+		let defaults = UserDefaults.standard
+		
+		// Register a NSString value. UserDefaults.string(forKey:) is supposed to return the NSString as a String
+		defaults.register(defaults: ["key1": "hello" as NSString])
+		
+		//make sure we don't have anything in the saved plist.
+		defaults.removeObject(forKey: "key1")
+		
+		XCTAssertEqual(defaults.string(forKey: "key1"), "hello")
+	}
+
+	func test_getRegisteredDefaultItem_String() {
+		let defaults = UserDefaults.standard
+		
+		// Register a String value. UserDefaults.string(forKey:) is supposed to return the String
+		defaults.register(defaults: ["key1": "hello"])
+		
+		//make sure we don't have anything in the saved plist.
+		defaults.removeObject(forKey: "key1")
+		
+		XCTAssertEqual(defaults.string(forKey: "key1"), "hello")
+	}
+
+	func test_getRegisteredDefaultItem_NSURL() {
+		let defaults = UserDefaults.standard
+		
+		// Register an NSURL value. UserDefaults.url(forKey:) is supposed to return the URL
+		defaults.register(defaults: ["key1": NSURL(fileURLWithPath: "/hello/world")])
+		
+		//make sure we don't have anything in the saved plist.
+		defaults.removeObject(forKey: "key1")
+		
+		XCTAssertEqual(defaults.url(forKey: "key1"), URL(fileURLWithPath: "/hello/world"))
+	}
+
+	func test_getRegisteredDefaultItem_URL() {
+		let defaults = UserDefaults.standard
+		
+		// Register an URL value. UserDefaults.url(forKey:) is supposed to return the URL
+		defaults.register(defaults: ["key1": URL(fileURLWithPath: "/hello/world")])
+		
+		//make sure we don't have anything in the saved plist.
+		defaults.removeObject(forKey: "key1")
+		
+		XCTAssertEqual(defaults.url(forKey: "key1"), URL(fileURLWithPath: "/hello/world"))
+	}
+
+	func test_getRegisteredDefaultItem_NSData() {
+		let defaults = UserDefaults.standard
+		let bytes = [0, 1, 2, 3, 4] as [UInt8]
+		
+		// Register an NSData value. UserDefaults.data(forKey:) is supposed to return the Data
+		defaults.register(defaults: ["key1": NSData(bytes: bytes, length: bytes.count)])
+		
+		//make sure we don't have anything in the saved plist.
+		defaults.removeObject(forKey: "key1")
+		
+		XCTAssertEqual(defaults.data(forKey: "key1"), Data(bytes: bytes))
+	}
+	
+	func test_getRegisteredDefaultItem_Data() {
+		let defaults = UserDefaults.standard
+		let bytes = [0, 1, 2, 3, 4] as [UInt8]
+		
+		// Register a Data value. UserDefaults.data(forKey:) is supposed to return the Data
+		defaults.register(defaults: ["key1": Data(bytes: bytes)])
+		
+		//make sure we don't have anything in the saved plist.
+		defaults.removeObject(forKey: "key1")
+		
+		XCTAssertEqual(defaults.data(forKey: "key1"), Data(bytes: bytes))
+	}
+
+	func test_getRegisteredDefaultItem_BoolFromString() {
+		let defaults = UserDefaults.standard
+		
+		// Register a boolean default value as a string. UserDefaults.bool(forKey:) is supposed to return the parsed Bool value
+		defaults.register(defaults: ["key1": "YES"])
+		
+		//make sure we don't have anything in the saved plist.
+		defaults.removeObject(forKey: "key1")
+		
+		XCTAssertEqual(defaults.bool(forKey: "key1"), true)
+	}
+	
+	func test_getRegisteredDefaultItem_IntFromString() {
+		let defaults = UserDefaults.standard
+		
+		// Register an int default value as a string. UserDefaults.integer(forKey:) is supposed to return the parsed Int value
+		defaults.register(defaults: ["key1": "1234"])
+		
+		//make sure we don't have anything in the saved plist.
+		defaults.removeObject(forKey: "key1")
+		
+		XCTAssertEqual(defaults.integer(forKey: "key1"), 1234)
+	}
+	
+	func test_getRegisteredDefaultItem_DoubleFromString() {
+		let defaults = UserDefaults.standard
+		
+		// Register a double default value as a string. UserDefaults.double(forKey:) is supposed to return the parsed Double value
+		defaults.register(defaults: ["key1": "12.34"])
+		
+		//make sure we don't have anything in the saved plist.
+		defaults.removeObject(forKey: "key1")
+		
+		XCTAssertEqual(defaults.double(forKey: "key1"), 12.34)
+	}
+	
+	func test_setValue_NSString() {
+		let defaults = UserDefaults.standard
+		
+		// Set a NSString value. UserDefaults.string(forKey:) is supposed to return the NSString as a String
+		defaults.set("hello" as NSString, forKey: "key1")
+		
+		XCTAssertEqual(defaults.string(forKey: "key1"), "hello")
+	}
+	
+	func test_setValue_String() {
+		let defaults = UserDefaults.standard
+		
+		// Register a String value. UserDefaults.string(forKey:) is supposed to return the String
+		defaults.set("hello", forKey: "key1")
+		
+		XCTAssertEqual(defaults.string(forKey: "key1"), "hello")
+	}
+
+	func test_setValue_NSURL() {
+		let defaults = UserDefaults.standard
+		
+		// Set a NSURL value. UserDefaults.url(forKey:) is supposed to return the NSURL as a URL
+		defaults.set(NSURL(fileURLWithPath: "/hello/world"), forKey: "key1")
+		
+		XCTAssertEqual(defaults.url(forKey: "key1"), URL(fileURLWithPath: "/hello/world"))
+	}
+
+	func test_setValue_URL() {
+		let defaults = UserDefaults.standard
+		
+		// Set a URL value. UserDefaults.url(forKey:) is supposed to return the URL
+		defaults.set(URL(fileURLWithPath: "/hello/world"), forKey: "key1")
+		
+		XCTAssertEqual(defaults.url(forKey: "key1"), URL(fileURLWithPath: "/hello/world"))
+	}
+
+	func test_setValue_NSData() {
+		let defaults = UserDefaults.standard
+		let bytes = [0, 1, 2, 3, 4] as [UInt8]
+		
+		// Set a NSData value. UserDefaults.data(forKey:) is supposed to return the Data
+		defaults.set(NSData(bytes: bytes, length: bytes.count), forKey: "key1")
+		
+		XCTAssertEqual(defaults.data(forKey: "key1"), Data(bytes: bytes))
+	}
+	
+	func test_setValue_Data() {
+		let defaults = UserDefaults.standard
+		let bytes = [0, 1, 2, 3, 4] as [UInt8]
+		
+		// Set a Data value. UserDefaults.data(forKey:) is supposed to return the Data
+		defaults.set(Data(bytes: bytes), forKey: "key1")
+		
+		XCTAssertEqual(defaults.data(forKey: "key1"), Data(bytes: bytes))
+	}
+
+	func test_setValue_BoolFromString() {
+		let defaults = UserDefaults.standard
+		
+		// Register a boolean default value as a string. UserDefaults.bool(forKey:) is supposed to return the parsed Bool value
+		defaults.set("YES", forKey: "key1")
+		
+		XCTAssertEqual(defaults.bool(forKey: "key1"), true)
+	}
+	
+	func test_setValue_IntFromString() {
+		let defaults = UserDefaults.standard
+		
+		// Register an int default value as a string. UserDefaults.integer(forKey:) is supposed to return the parsed Int value
+		defaults.set("1234", forKey: "key1")
+		
+		XCTAssertEqual(defaults.integer(forKey: "key1"), 1234)
+	}
+	
+	func test_setValue_DoubleFromString() {
+		let defaults = UserDefaults.standard
+		
+		// Register a double default value as a string. UserDefaults.double(forKey:) is supposed to return the parsed Double value
+		defaults.set("12.34", forKey: "key1")
+		
+		XCTAssertEqual(defaults.double(forKey: "key1"), 12.34)
 	}
 }

--- a/build.py
+++ b/build.py
@@ -282,6 +282,7 @@ sources = CompileSources([
 	'CoreFoundation/PlugIn.subproj/CFPlugIn_PlugIn.c',
 	'CoreFoundation/Preferences.subproj/CFApplicationPreferences.c',
 	'CoreFoundation/Preferences.subproj/CFPreferences.c',
+    'CoreFoundation/Preferences.subproj/CFXMLPreferencesDomain.c',
 	# 'CoreFoundation/RunLoop.subproj/CFMachPort.c',
 	# 'CoreFoundation/RunLoop.subproj/CFMessagePort.c',
 	'CoreFoundation/RunLoop.subproj/CFRunLoop.c',


### PR DESCRIPTION
- the register(defaults:) function now ensures that values are stored in the internal registration dictionary as NSObject objects which allows object(forKey:) and friends to actually find those values
- the bool(forKey:), integer(forKey:), double(forKey:) and float(forKey:) functions now implicitly convert string represetations to the requested type
- the set(_:forKey:) function now ensures that values of type String, Int and Double are first converted to the proper CFType before they are stored in the CFPreferences object
- register(defaults:) and set(_:forKey:) now cause a fatalError() if an attempt is made to pass an unsupported type. This more closely resembles what the ObjC Foundation does and makes bugs in the code obvious
- added unit tests to cover the above problems
- added the CFXMLPreferencesDomain.c file to the macOS project and enabled the UserDefaults unit tests on macOS
- enabled support for CFXMLPreferencesDomain on Linux, added it to the Linux build process and enabled the UserDefaults unit tests on Linux