### PR TITLE
Remove unused queue from URLSession

### DIFF
--- a/Foundation/URLSession/URLSession.swift
+++ b/Foundation/URLSession/URLSession.swift
@@ -137,11 +137,6 @@
 /// - SeeAlso: https://curl.haxx.se/libcurl/c/threadsafe.html
 /// - SeeAlso: URLSession+libcurl.swift
 ///
-/// The (publicly accessible) attributes of an `URLSessionTask` are made thread
-/// safe by using a concurrent libdispatch queue and only doing writes with a
-/// barrier while allowing concurrent reads. A single queue is shared for all
-/// tasks of a given session for this isolation. C.f. `taskAttributesIsolation`.
-///
 /// ## HTTP and RFC 2616
 ///
 /// Most of HTTP is defined in [RFC 2616](https://tools.ietf.org/html/rfc2616).
@@ -194,9 +189,6 @@ open class URLSession : NSObject {
     fileprivate let multiHandle: _MultiHandle
     fileprivate var nextTaskIdentifier = 1
     internal let workQueue: DispatchQueue 
-    /// This queue is used to make public attributes on `URLSessionTask` instances thread safe.
-    /// - Note: It's a **concurrent** queue.
-    internal let taskAttributesIsolation: DispatchQueue 
     internal let taskRegistry = URLSession._TaskRegistry()
     fileprivate let identifier: Int32
     fileprivate var invalidated = false
@@ -222,7 +214,6 @@ open class URLSession : NSObject {
         initializeLibcurl()
         identifier = nextSessionIdentifier()
         self.workQueue = DispatchQueue(label: "URLSession<\(identifier)>")
-        self.taskAttributesIsolation = DispatchQueue(label: "URLSession<\(identifier)>.taskAttributes", attributes: DispatchQueue.Attributes.concurrent)
         self.delegateQueue = OperationQueue()
         self.delegateQueue.maxConcurrentOperationCount = 1
         self.delegate = nil
@@ -245,7 +236,6 @@ open class URLSession : NSObject {
         initializeLibcurl()
         identifier = nextSessionIdentifier()
         self.workQueue = DispatchQueue(label: "URLSession<\(identifier)>")
-        self.taskAttributesIsolation = DispatchQueue(label: "URLSession<\(identifier)>.taskAttributes", attributes: DispatchQueue.Attributes.concurrent)
         if let _queue = queue {
            self.delegateQueue = _queue
         } else {


### PR DESCRIPTION
In wake of some recent fixes to improve thread safety in URLSession, I found one of the queues in URLSession not used anymore. We can remove it.