### PR TITLE
Adding String->Data fastpath for utf8

### DIFF
--- a/Foundation/NSStringAPI.swift
+++ b/Foundation/NSStringAPI.swift
@@ -759,6 +759,16 @@ extension StringProtocol where Index == String.Index {
     using encoding: String.Encoding,
     allowLossyConversion: Bool = false
   ) -> Data? {
+    let ephemeralString = _ephemeralString
+    if ephemeralString._core.isASCII {
+        switch encoding {
+                case .utf8: return Data(
+                    bytes: UnsafeRawPointer(ephemeralString._core.startASCII), count: ephemeralString._core.count)
+                default:  return _ns.data(
+                    using: encoding.rawValue,
+                    allowLossyConversion: allowLossyConversion)
+        }
+    }
     return _ns.data(
       using: encoding.rawValue,
       allowLossyConversion: allowLossyConversion)

--- a/Foundation/NSStringAPI.swift
+++ b/Foundation/NSStringAPI.swift
@@ -762,6 +762,8 @@ extension StringProtocol where Index == String.Index {
     let ephemeralString = _ephemeralString
     if ephemeralString._core.isASCII {
         switch encoding {
+                case .ascii: fallthrough
+                case .nonLossyASCII: fallthrough
                 case .utf8: return Data(
                     bytes: UnsafeRawPointer(ephemeralString._core.startASCII), count: ephemeralString._core.count)
                 default:  return _ns.data(

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -34,6 +34,10 @@ class TestNSData: XCTestCase {
     static var allTests: [(String, (TestNSData) -> () throws -> Void)] {
         return [
             ("testBasicConstruction", testBasicConstruction),
+            ("test_asciiString_utf8Encoding", test_asciiString_utf8Encoding),
+            ("test_asciiString_asciiEncoding", test_asciiString_asciiEncoding),
+            ("test_asciiSubstring_utf8Encoding", test_asciiSubstring_utf8Encoding),
+            ("test_asciiSubstring_asciiEncoding", test_asciiSubstring_asciiEncoding),
             ("test_base64Data_medium", test_base64Data_medium),
             ("test_base64Data_small", test_base64Data_small),
             ("test_openingNonExistentFile", test_openingNonExistentFile),
@@ -896,6 +900,35 @@ extension TestNSData {
         let data = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut at tincidunt arcu. Suspendisse nec sodales erat, sit amet imperdiet ipsum. Etiam sed ornare felis. Nunc mauris turpis, bibendum non lectus quis, malesuada placerat turpis. Nam adipiscing non massa et semper. Nulla convallis semper bibendum. Aliquam dictum nulla cursus mi ultricies, at tincidunt mi sagittis. Nulla faucibus at dui quis sodales. Morbi rutrum, dui id ultrices venenatis, arcu urna egestas felis, vel suscipit mauris arcu quis risus. Nunc venenatis ligula at orci tristique, et mattis purus pulvinar. Etiam ultricies est odio. Nunc eleifend malesuada justo, nec euismod sem ultrices quis. Etiam nec nibh sit amet lorem faucibus dapibus quis nec leo. Praesent sit amet mauris vel lacus hendrerit porta mollis consectetur mi. Donec eget tortor dui. Morbi imperdiet, arcu sit amet elementum interdum, quam nisl tempor quam, vitae feugiat augue purus sed lacus. In ac urna adipiscing purus venenatis volutpat vel et metus. Nullam nec auctor quam. Phasellus porttitor felis ac nibh gravida suscipit tempus at ante. Nunc pellentesque iaculis sapien a mattis. Aenean eleifend dolor non nunc laoreet, non dictum massa aliquam. Aenean quis turpis augue. Praesent augue lectus, mollis nec elementum eu, dignissim at velit. Ut congue neque id ullamcorper pellentesque. Maecenas euismod in elit eu vehicula. Nullam tristique dui nulla, nec convallis metus suscipit eget. Cras semper augue nec cursus blandit. Nulla rhoncus et odio quis blandit. Praesent lobortis dignissim velit ut pulvinar. Duis interdum quam adipiscing dolor semper semper. Nunc bibendum convallis dui, eget mollis magna hendrerit et. Morbi facilisis, augue eu fringilla convallis, mauris est cursus dolor, eu posuere odio nunc quis orci. Ut eu justo sem. Phasellus ut erat rhoncus, faucibus arcu vitae, vulputate erat. Aliquam nec magna viverra, interdum est vitae, rhoncus sapien. Duis tincidunt tempor ipsum ut dapibus. Nullam commodo varius metus, sed sollicitudin eros. Etiam nec odio et dui tempor blandit posuere.".data(using: .utf8)!
         let base64 = data.base64EncodedString()
         XCTAssertEqual("TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gVXQgYXQgdGluY2lkdW50IGFyY3UuIFN1c3BlbmRpc3NlIG5lYyBzb2RhbGVzIGVyYXQsIHNpdCBhbWV0IGltcGVyZGlldCBpcHN1bS4gRXRpYW0gc2VkIG9ybmFyZSBmZWxpcy4gTnVuYyBtYXVyaXMgdHVycGlzLCBiaWJlbmR1bSBub24gbGVjdHVzIHF1aXMsIG1hbGVzdWFkYSBwbGFjZXJhdCB0dXJwaXMuIE5hbSBhZGlwaXNjaW5nIG5vbiBtYXNzYSBldCBzZW1wZXIuIE51bGxhIGNvbnZhbGxpcyBzZW1wZXIgYmliZW5kdW0uIEFsaXF1YW0gZGljdHVtIG51bGxhIGN1cnN1cyBtaSB1bHRyaWNpZXMsIGF0IHRpbmNpZHVudCBtaSBzYWdpdHRpcy4gTnVsbGEgZmF1Y2lidXMgYXQgZHVpIHF1aXMgc29kYWxlcy4gTW9yYmkgcnV0cnVtLCBkdWkgaWQgdWx0cmljZXMgdmVuZW5hdGlzLCBhcmN1IHVybmEgZWdlc3RhcyBmZWxpcywgdmVsIHN1c2NpcGl0IG1hdXJpcyBhcmN1IHF1aXMgcmlzdXMuIE51bmMgdmVuZW5hdGlzIGxpZ3VsYSBhdCBvcmNpIHRyaXN0aXF1ZSwgZXQgbWF0dGlzIHB1cnVzIHB1bHZpbmFyLiBFdGlhbSB1bHRyaWNpZXMgZXN0IG9kaW8uIE51bmMgZWxlaWZlbmQgbWFsZXN1YWRhIGp1c3RvLCBuZWMgZXVpc21vZCBzZW0gdWx0cmljZXMgcXVpcy4gRXRpYW0gbmVjIG5pYmggc2l0IGFtZXQgbG9yZW0gZmF1Y2lidXMgZGFwaWJ1cyBxdWlzIG5lYyBsZW8uIFByYWVzZW50IHNpdCBhbWV0IG1hdXJpcyB2ZWwgbGFjdXMgaGVuZHJlcml0IHBvcnRhIG1vbGxpcyBjb25zZWN0ZXR1ciBtaS4gRG9uZWMgZWdldCB0b3J0b3IgZHVpLiBNb3JiaSBpbXBlcmRpZXQsIGFyY3Ugc2l0IGFtZXQgZWxlbWVudHVtIGludGVyZHVtLCBxdWFtIG5pc2wgdGVtcG9yIHF1YW0sIHZpdGFlIGZldWdpYXQgYXVndWUgcHVydXMgc2VkIGxhY3VzLiBJbiBhYyB1cm5hIGFkaXBpc2NpbmcgcHVydXMgdmVuZW5hdGlzIHZvbHV0cGF0IHZlbCBldCBtZXR1cy4gTnVsbGFtIG5lYyBhdWN0b3IgcXVhbS4gUGhhc2VsbHVzIHBvcnR0aXRvciBmZWxpcyBhYyBuaWJoIGdyYXZpZGEgc3VzY2lwaXQgdGVtcHVzIGF0IGFudGUuIE51bmMgcGVsbGVudGVzcXVlIGlhY3VsaXMgc2FwaWVuIGEgbWF0dGlzLiBBZW5lYW4gZWxlaWZlbmQgZG9sb3Igbm9uIG51bmMgbGFvcmVldCwgbm9uIGRpY3R1bSBtYXNzYSBhbGlxdWFtLiBBZW5lYW4gcXVpcyB0dXJwaXMgYXVndWUuIFByYWVzZW50IGF1Z3VlIGxlY3R1cywgbW9sbGlzIG5lYyBlbGVtZW50dW0gZXUsIGRpZ25pc3NpbSBhdCB2ZWxpdC4gVXQgY29uZ3VlIG5lcXVlIGlkIHVsbGFtY29ycGVyIHBlbGxlbnRlc3F1ZS4gTWFlY2VuYXMgZXVpc21vZCBpbiBlbGl0IGV1IHZlaGljdWxhLiBOdWxsYW0gdHJpc3RpcXVlIGR1aSBudWxsYSwgbmVjIGNvbnZhbGxpcyBtZXR1cyBzdXNjaXBpdCBlZ2V0LiBDcmFzIHNlbXBlciBhdWd1ZSBuZWMgY3Vyc3VzIGJsYW5kaXQuIE51bGxhIHJob25jdXMgZXQgb2RpbyBxdWlzIGJsYW5kaXQuIFByYWVzZW50IGxvYm9ydGlzIGRpZ25pc3NpbSB2ZWxpdCB1dCBwdWx2aW5hci4gRHVpcyBpbnRlcmR1bSBxdWFtIGFkaXBpc2NpbmcgZG9sb3Igc2VtcGVyIHNlbXBlci4gTnVuYyBiaWJlbmR1bSBjb252YWxsaXMgZHVpLCBlZ2V0IG1vbGxpcyBtYWduYSBoZW5kcmVyaXQgZXQuIE1vcmJpIGZhY2lsaXNpcywgYXVndWUgZXUgZnJpbmdpbGxhIGNvbnZhbGxpcywgbWF1cmlzIGVzdCBjdXJzdXMgZG9sb3IsIGV1IHBvc3VlcmUgb2RpbyBudW5jIHF1aXMgb3JjaS4gVXQgZXUganVzdG8gc2VtLiBQaGFzZWxsdXMgdXQgZXJhdCByaG9uY3VzLCBmYXVjaWJ1cyBhcmN1IHZpdGFlLCB2dWxwdXRhdGUgZXJhdC4gQWxpcXVhbSBuZWMgbWFnbmEgdml2ZXJyYSwgaW50ZXJkdW0gZXN0IHZpdGFlLCByaG9uY3VzIHNhcGllbi4gRHVpcyB0aW5jaWR1bnQgdGVtcG9yIGlwc3VtIHV0IGRhcGlidXMuIE51bGxhbSBjb21tb2RvIHZhcml1cyBtZXR1cywgc2VkIHNvbGxpY2l0dWRpbiBlcm9zLiBFdGlhbSBuZWMgb2RpbyBldCBkdWkgdGVtcG9yIGJsYW5kaXQgcG9zdWVyZS4=", base64, "medium base64 conversion should work")
+    }
+    
+    func test_asciiString_utf8Encoding() {
+        let bytes = "Hello World".utf8
+        let utf8String = String(bytes: bytes, encoding: .utf8)!
+        let data = utf8String.data(using: .utf8)!
+        XCTAssertEqual(String(data: data, encoding: .utf8), "Hello World", "trivial utf8 String conversion should work")
+    }
+    
+    func test_asciiString_asciiEncoding() {
+        let data = "Hello World".data(using: .ascii)!
+        XCTAssertEqual(String(data: data, encoding: .ascii), "Hello World", "trivial ASCII String conversion should work")
+    }
+    
+    func test_asciiSubstring_utf8Encoding() {
+        let bytes = "Hello World".utf8
+        let utf8String = String(bytes: bytes, encoding: .utf8)!
+        let index = utf8String.index(of: "W")!
+        let utf8Substring = utf8String[index...]
+        let data = utf8Substring.data(using: .utf8)!
+        XCTAssertEqual(String(data: data, encoding: .utf8), "World", "trivial utf8 Substring conversion should work")
+    }
+    
+    func test_asciiSubstring_asciiEncoding() {
+        let asciiString = "Hello World"
+        let index = asciiString.index(of: "W")!
+        let asciiSubstring = asciiString[index...]
+        let data = asciiSubstring.data(using: .ascii)!
+        XCTAssertEqual(String(data: data, encoding: .ascii), "World", "trivial ASCII Substring conversion should work")
     }
 
     func test_openingNonExistentFile() {


### PR DESCRIPTION
The swift-server [http project](https://github.com/swift-server/http) makes heavy use of the String and Data APIs for converting between representations of the same utf8 encoded data. Profiling it using microbenchmarks showed a lot of time being spent in this area. I have implemented the utf8 fastpath, based on @phausler's work in this [PR](https://github.com/apple/swift/pull/10953). The changes were run against this [microbenchmark](https://github.com/djones6/swift-benchmarks/blob/master/StringToData.swift) and showed noticeable performance improvements on Linux:
Performance without change:

> Concurrency 1: completed 911 loops (4555.00k ops) in 5.00 seconds, 910.19k ops/sec
> Concurrency 2: completed 1167 loops (5835.00k ops) in 5.00 seconds, 1166.57k ops/sec
> Concurrency 3: completed 1181 loops (5905.00k ops) in 5.01 seconds, 1179.74k ops/sec
> Concurrency 4: completed 1470 loops (7350.00k ops) in 5.01 seconds, 1468.04k ops/sec
> Concurrency 5: completed 1432 loops (7160.00k ops) in 5.01 seconds, 1428.46k ops/sec
> Concurrency 6: completed 1588 loops (7940.00k ops) in 5.01 seconds, 1584.07k ops/sec
> Concurrency 7: completed 1588 loops (7940.00k ops) in 5.01 seconds, 1584.37k ops/sec
> Concurrency 8: completed 1571 loops (7855.00k ops) in 5.02 seconds, 1565.02k ops/sec
> Concurrency 9: completed 1605 loops (8025.00k ops) in 5.01 seconds, 1600.37k ops/sec
> Concurrency 10: completed 1602 loops (8010.00k ops) in 5.02 seconds, 1596.28k ops/sec

Performance with change:

> Concurrency 1: completed 5192 loops (25960.00k ops) in 5.00 seconds, 5191.14k ops/sec
> Concurrency 2: completed 9674 loops (48370.00k ops) in 5.00 seconds, 9672.96k ops/sec
> Concurrency 3: completed 13663 loops (68315.00k ops) in 5.00 seconds, 13660.55k ops/sec
> Concurrency 4: completed 17825 loops (89125.00k ops) in 5.00 seconds, 17821.83k ops/sec
> Concurrency 5: completed 21388 loops (106.94m ops) in 5.00 seconds, 21.38m ops/sec
> Concurrency 6: completed 25791 loops (128.96m ops) in 5.00 seconds, 25.79m ops/sec
> Concurrency 7: completed 29370 loops (146.85m ops) in 5.00 seconds, 29.36m ops/sec
> Concurrency 8: completed 33349 loops (166.75m ops) in 5.00 seconds, 33.34m ops/sec
> Concurrency 9: completed 36188 loops (180.94m ops) in 5.00 seconds, 36.18m ops/sec
> Concurrency 10: completed 37536 loops (187.68m ops) in 5.00 seconds, 37.53m ops/sec