### PR TITLE
Import changes from the overlay for Data mutation of slices

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -29,6 +29,10 @@
 #include <pthread.h>
 #include <execinfo.h>
 
+#if __has_include(<malloc/malloc.h>)
+#include <malloc/malloc.h>
+#endif
+
 _CF_EXPORT_SCOPE_BEGIN
 
 struct __CFSwiftObject {
@@ -344,6 +348,54 @@ CF_EXPORT CFStringRef _CFXDGCreateCacheDirectoryPath(void);
 
 /// a single base directory relative to which user-specific runtime files and other file objects should be placed. This directory is defined by the environment variable $XDG_RUNTIME_DIR.
 CF_EXPORT CFStringRef _CFXDGCreateRuntimeDirectoryPath(void);
+
+
+typedef struct {
+    void *_Nonnull memory;
+    size_t capacity;
+    _Bool onStack;
+} _ConditionalAllocationBuffer;
+
+static inline _Bool _resizeConditionalAllocationBuffer(_ConditionalAllocationBuffer *_Nonnull buffer, size_t amt) {
+#if TARGET_OS_MAC
+    size_t amount = malloc_good_size(amt);
+#else
+    size_t amount = amt;
+#endif
+    if (amount <= buffer->capacity) { return true; }
+    void *newMemory;
+    if (buffer->onStack) {
+        newMemory = malloc(amount);
+        if (newMemory == NULL) { return false; }
+        memcpy(newMemory, buffer->memory, buffer->capacity);
+        buffer->onStack = false;
+    } else {
+        newMemory = realloc(buffer->memory, amount);
+        if (newMemory == NULL) { return false; }
+    }
+    if (newMemory == NULL) { return false; }
+    buffer->memory = newMemory;
+    buffer->capacity = amount;
+    return true;
+}
+
+static inline _Bool _withStackOrHeapBuffer(size_t amount, void (__attribute__((noescape)) ^ _Nonnull applier)(_ConditionalAllocationBuffer *_Nonnull)) {
+    _ConditionalAllocationBuffer buffer;
+#if TARGET_OS_MAC
+    buffer.capacity = malloc_good_size(amount);
+#else
+    buffer.capacity = amount;
+#endif
+    buffer.onStack = (pthread_main_np() != 0 ? buffer.capacity < 2048 : buffer.capacity < 512);
+    buffer.memory = buffer.onStack ? alloca(buffer.capacity) : malloc(buffer.capacity);
+    if (buffer.memory == NULL) { return false; }
+    applier(&buffer);
+    if (!buffer.onStack) {
+        free(buffer.memory);
+    }
+    return true;
+}
+
 
 _CF_EXPORT_SCOPE_END
 

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -386,7 +386,7 @@ static inline _Bool _withStackOrHeapBuffer(size_t amount, void (__attribute__((n
 #else
     buffer.capacity = amount;
 #endif
-    buffer.onStack = (pthread_main_np() != 0 ? buffer.capacity < 2048 : buffer.capacity < 512);
+    buffer.onStack = (_CFIsMainThread() != 0 ? buffer.capacity < 2048 : buffer.capacity < 512);
     buffer.memory = buffer.onStack ? alloca(buffer.capacity) : malloc(buffer.capacity);
     if (buffer.memory == NULL) { return false; }
     applier(&buffer);

--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -27,6 +27,10 @@ internal func __NSDataInvokeDeallocatorUnmap(_ mem: UnsafeMutableRawPointer, _ l
 internal func __NSDataInvokeDeallocatorFree(_ mem: UnsafeMutableRawPointer, _ length: Int) {
     free(mem)
 }
+
+internal func __NSDataIsCompact(_ data: NSData) -> Bool {
+    return data._isCompact()
+}
     
 #else
     
@@ -98,47 +102,140 @@ public final class _DataStorage {
     public var _needToZero: Bool
     public var _deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?
     public var _backing: Backing = .swift
+    public var _offset: Int
     
     public var bytes: UnsafeRawPointer? {
         @inline(__always)
         get {
             switch _backing {
             case .swift:
-                return UnsafeRawPointer(_bytes)
+                return UnsafeRawPointer(_bytes)?.advanced(by: -_offset)
             case .immutable:
-                return UnsafeRawPointer(_bytes)
+                return UnsafeRawPointer(_bytes)?.advanced(by: -_offset)
             case .mutable:
-                return UnsafeRawPointer(_bytes)
+                return UnsafeRawPointer(_bytes)?.advanced(by: -_offset)
             case .customReference(let d):
-                return d.bytes
+                return d.bytes.advanced(by: -_offset)
             case .customMutableReference(let d):
-                return d.bytes
+                return d.bytes.advanced(by: -_offset)
+            }
+        }
+    }
+
+    @discardableResult
+    public func withUnsafeBytes<Result>(in range: Range<Int>, apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
+        switch _backing {
+        case .swift: fallthrough
+        case .immutable: fallthrough
+        case .mutable:
+            return try apply(UnsafeRawBufferPointer(start: _bytes?.advanced(by: range.lowerBound - _offset), count: Swift.min(range.count, _length)))
+        case .customReference(let d):
+            if d._isCompact() {
+                let len = d.length
+                guard len > 0 else {
+                    return try apply(UnsafeRawBufferPointer(start: nil, count: 0))
+                }
+                return try apply(UnsafeRawBufferPointer(start: d.bytes.advanced(by: range.lowerBound - _offset), count: Swift.min(range.count, len)))
+            } else {
+                var buffer = UnsafeMutableRawBufferPointer.allocate(count: range.count)
+                defer { buffer.deallocate() }
+                let sliceRange = NSRange(location: range.lowerBound - _offset, length: range.count)
+                var enumerated = 0
+                d.enumerateBytes { (ptr, byteRange, stop) in
+                    if NSIntersectionRange(sliceRange, byteRange).length > 0 {
+                        let lower = Swift.max(byteRange.location, sliceRange.location)
+                        let upper = Swift.min(byteRange.location + byteRange.length, sliceRange.location + sliceRange.length)
+                        let offset = lower - byteRange.location
+                        let effectiveRange = NSRange(location: lower, length: upper - lower)
+                        if effectiveRange == sliceRange {
+                            memcpy(buffer.baseAddress!, ptr, effectiveRange.length)
+                            stop.pointee = true
+                        } else {
+                            memcpy(buffer.baseAddress!.advanced(by: enumerated), ptr, effectiveRange.length)
+                        }
+                        enumerated += byteRange.length
+                    } else if sliceRange.location + sliceRange.length < byteRange.location {
+                        stop.pointee = true
+                    }
+                }
+                return try apply(UnsafeRawBufferPointer(buffer))
+            }
+        case .customMutableReference(let d):
+            if d._isCompact() {
+                let len = d.length
+                guard len > 0 else {
+                    return try apply(UnsafeRawBufferPointer(start: nil, count: 0))
+                }
+                return try apply(UnsafeRawBufferPointer(start: d.bytes.advanced(by: range.lowerBound - _offset), count: Swift.min(range.count, len)))
+            } else {
+                var buffer = UnsafeMutableRawBufferPointer.allocate(count: range.count)
+                defer { buffer.deallocate() }
+                let sliceRange = NSRange(location: range.lowerBound - _offset, length: range.count)
+                var enumerated = 0
+                d.enumerateBytes { (ptr, byteRange, stop) in
+                    if NSIntersectionRange(sliceRange, byteRange).length > 0 {
+                        let lower = Swift.max(byteRange.location, sliceRange.location)
+                        let upper = Swift.min(byteRange.location + byteRange.length, sliceRange.location + sliceRange.length)
+                        let effectiveRange = NSRange(location: lower, length: upper - lower)
+                        if effectiveRange == sliceRange {
+                            memcpy(buffer.baseAddress!, ptr, effectiveRange.length)
+                            stop.pointee = true
+                        } else {
+                            memcpy(buffer.baseAddress!.advanced(by: enumerated), ptr, effectiveRange.length)
+                        }
+                        enumerated += byteRange.length
+                    } else if sliceRange.location + sliceRange.length < byteRange.location {
+                        stop.pointee = true
+                    }
+                }
+                return try apply(UnsafeRawBufferPointer(buffer))
             }
         }
     }
     
+    @discardableResult
+    public func withUnsafeMutableBytes<Result>(in range: Range<Int>, apply: (UnsafeMutableRawBufferPointer) throws -> Result) rethrows -> Result {
+        switch _backing {
+        case .swift: fallthrough
+        case .mutable:
+            return try apply(UnsafeMutableRawBufferPointer(start: _bytes!.advanced(by:range.lowerBound - _offset), count: Swift.min(range.count, _length - range.lowerBound)))
+        case .customMutableReference(let d):
+            let len = d.length
+            return try apply(UnsafeMutableRawBufferPointer(start: d.mutableBytes.advanced(by:range.lowerBound - _offset), count: Swift.min(range.count, len - range.lowerBound)))
+        case .immutable(let d):
+            let data = d.mutableCopy() as! NSMutableData
+            _backing = .mutable(data)
+            _bytes = data.mutableBytes
+            return try apply(UnsafeMutableRawBufferPointer(start: _bytes!.advanced(by:range.lowerBound - _offset), count: Swift.min(range.count, _length - range.lowerBound)))
+        case .customReference(let d):
+            let data = d.mutableCopy() as! NSMutableData
+            _backing = .customMutableReference(data)
+            let len = data.length
+            return try apply(UnsafeMutableRawBufferPointer(start: data.mutableBytes.advanced(by:range.lowerBound - _offset), count: Swift.min(range.count, len - range.lowerBound)))
+        }
+    }
+
     public var mutableBytes: UnsafeMutableRawPointer? {
         @inline(__always)
         get {
             switch _backing {
             case .swift:
-                return _bytes
+                return _bytes?.advanced(by: -_offset)
             case .immutable(let d):
                 let data = d.mutableCopy() as! NSMutableData
                 data.length = length
                 _backing = .mutable(data)
                 _bytes = data.mutableBytes
-                return data.mutableBytes
+                return _bytes?.advanced(by: -_offset)
             case .mutable:
-                return _bytes
+                return _bytes?.advanced(by: -_offset)
             case .customReference(let d):
                 let data = d.mutableCopy() as! NSMutableData
                 data.length = length
                 _backing = .customMutableReference(data)
-                _bytes = data.mutableBytes
-                return data.mutableBytes
+                return data.mutableBytes.advanced(by: -_offset)
             case .customMutableReference(let d):
-                return d.mutableBytes
+                return d.mutableBytes.advanced(by: -_offset)
             }
         }
     }
@@ -176,32 +273,34 @@ public final class _DataStorage {
         }
     }
     
-    public func enumerateBytes(_ block: (_ buffer: UnsafeBufferPointer<UInt8>, _ byteIndex: Data.Index, _ stop: inout Bool) -> Void) {
-        var stop: Bool = false
+    public func enumerateBytes(in range: Range<Int>, _ block: (_ buffer: UnsafeBufferPointer<UInt8>, _ byteIndex: Data.Index, _ stop: inout Bool) -> Void) {
+        var stopv: Bool = false
+        var data: NSData
         switch _backing {
-        case .swift:
-            block(UnsafeBufferPointer<UInt8>(start: _bytes?.assumingMemoryBound(to: UInt8.self), count: _length), 0, &stop)
-        case .immutable:
-            block(UnsafeBufferPointer<UInt8>(start: _bytes?.assumingMemoryBound(to: UInt8.self), count: _length), 0, &stop)
-        case .mutable:
-            block(UnsafeBufferPointer<UInt8>(start: _bytes?.assumingMemoryBound(to: UInt8.self), count: _length), 0, &stop)
+        case .swift: fallthrough
+        case .immutable: fallthrough
+        case .mutable: 
+            block(UnsafeBufferPointer<UInt8>(start: _bytes?.advanced(by: range.lowerBound - _offset).assumingMemoryBound(to: UInt8.self), count: Swift.min(range.count, _length)), 0, &stopv)
+            return
         case .customReference(let d):
-            d.enumerateBytes { (ptr, range, stop) in
-                var stopv = false
-                let bytePtr = ptr.bindMemory(to: UInt8.self, capacity: range.length)
-                block(UnsafeBufferPointer(start: bytePtr, count: range.length), range.location, &stopv)
-                if stopv {
-                    stop.pointee = true
-                }
-            }
+            data = d
+            break
         case .customMutableReference(let d):
-            d.enumerateBytes { (ptr, range, stop) in
-                var stopv = false
-                let bytePtr = ptr.bindMemory(to: UInt8.self, capacity: range.length)
-                block(UnsafeBufferPointer(start: bytePtr, count: range.length), range.location, &stopv)
-                if stopv {
-                    stop.pointee = true
-                }
+            data = d
+            break
+        }
+        data.enumerateBytes { (ptr, region, stop) in
+            // any region that is not in the range should be skipped
+            guard range.contains(region.lowerBound) || range.contains(region.upperBound) else { return }
+            var regionAdjustment = 0
+            if region.lowerBound < range.lowerBound {
+                regionAdjustment = range.lowerBound - (region.lowerBound - _offset)
+            }
+            let bytePtr  = ptr.advanced(by: regionAdjustment).assumingMemoryBound(to: UInt8.self)
+            let effectiveLength = Swift.min((region.location - _offset) + region.length, range.upperBound) - (region.location - _offset)
+            block(UnsafeBufferPointer(start: bytePtr, count: effectiveLength - regionAdjustment), region.location + regionAdjustment - _offset, &stopv)
+            if stopv {
+                stop.pointee = true
             }
         }
     }
@@ -319,7 +418,7 @@ public final class _DataStorage {
     
     @inline(__always)
     public func append(_ bytes: UnsafeRawPointer, length: Int) {
-        precondition(length >= 0, "Length of appending bytes must be positive")
+        precondition(length >= 0, "Length of appending bytes must not be negative")
         switch _backing {
         case .swift:
             let origLength = _length
@@ -398,6 +497,43 @@ public final class _DataStorage {
         }
         
     }
+
+    public func get(_ index: Int) -> UInt8 {
+        switch _backing {
+        case .swift: fallthrough
+        case .immutable: fallthrough
+        case .mutable:
+            return _bytes!.advanced(by: index - _offset).assumingMemoryBound(to: UInt8.self).pointee
+        case .customReference(let d):
+            if d._isCompact() {
+                return d.bytes.advanced(by: index - _offset).assumingMemoryBound(to: UInt8.self).pointee
+            } else {
+                var byte: UInt8 = 0
+                d.enumerateBytes { (ptr, range, stop) in
+                    if NSLocationInRange(index, range) {
+                        let offset = index - range.location - _offset
+                        byte = ptr.advanced(by: offset).assumingMemoryBound(to: UInt8.self).pointee
+                        stop.pointee = true
+                    }
+                }
+                return byte
+            }
+        case .customMutableReference(let d):
+            if d._isCompact() {
+                return d.bytes.advanced(by: index - _offset).assumingMemoryBound(to: UInt8.self).pointee
+            } else {
+                var byte: UInt8 = 0
+                d.enumerateBytes { (ptr, range, stop) in
+                    if NSLocationInRange(index, range) {
+                        let offset = index - range.location - _offset
+                        byte = ptr.advanced(by: offset).assumingMemoryBound(to: UInt8.self).pointee
+                        stop.pointee = true
+                    }
+                }
+                return byte
+            }
+        }
+    }
     
     @inline(__always)
     public func set(_ index: Int, to value: UInt8) {
@@ -405,7 +541,7 @@ public final class _DataStorage {
         case .swift:
             fallthrough
         case .mutable:
-            _bytes!.advanced(by: index).assumingMemoryBound(to: UInt8.self).pointee = value
+            _bytes!.advanced(by: index - _offset).assumingMemoryBound(to: UInt8.self).pointee = value
         default:
             var theByte = value
             let range = NSRange(location: index, length: 1)
@@ -427,28 +563,29 @@ public final class _DataStorage {
                 }
                 _length = newLength
             }
-            _DataStorage.move(_bytes!.advanced(by: range.location), bytes!, range.length)
+            _DataStorage.move(_bytes!.advanced(by: range.location - _offset), bytes!, range.length)
         case .immutable(let d):
             let data = d.mutableCopy() as! NSMutableData
-            data.replaceBytes(in: range, withBytes: bytes!)
+            data.replaceBytes(in: NSRange(location: range.location - _offset, length: range.length), withBytes: bytes!)
             _backing = .mutable(data)
             _length = data.length
             _bytes = data.mutableBytes
         case .mutable(let d):
-            d.replaceBytes(in: range, withBytes: bytes!)
+            d.replaceBytes(in: NSRange(location: range.location - _offset, length: range.length), withBytes: bytes!)
             _length = d.length
             _bytes = d.mutableBytes
         case .customReference(let d):
             let data = d.mutableCopy() as! NSMutableData
-            data.replaceBytes(in: range, withBytes: bytes!)
+            data.replaceBytes(in: NSRange(location: range.location - _offset, length: range.length), withBytes: bytes!)
             _backing = .customMutableReference(data)
         case .customMutableReference(let d):
-            d.replaceBytes(in: range, withBytes: bytes!)
+            d.replaceBytes(in: NSRange(location: range.location - _offset, length: range.length), withBytes: bytes!)
         }
     }
     
     @inline(__always)
-    public func replaceBytes(in range: NSRange, with replacementBytes: UnsafeRawPointer?, length replacementLength: Int) {
+    public func replaceBytes(in range_: NSRange, with replacementBytes: UnsafeRawPointer?, length replacementLength: Int) {
+        let range = NSRange(location: range_.location - _offset, length: range_.length)
         let currentLength = _length
         let resultingLength = currentLength - range.length + replacementLength
         switch _backing {
@@ -480,12 +617,12 @@ public final class _DataStorage {
             let data = d.mutableCopy() as! NSMutableData
             data.replaceBytes(in: range, withBytes: replacementBytes, length: replacementLength)
             _backing = .mutable(data)
-            _length = replacementLength
+            _length = data.length
             _bytes = data.mutableBytes
         case .mutable(let d):
             d.replaceBytes(in: range, withBytes: replacementBytes, length: replacementLength)
             _backing = .mutable(d)
-            _length = replacementLength
+            _length = d.length
             _bytes = d.mutableBytes
         case .customReference(let d):
             let data = d.mutableCopy() as! NSMutableData
@@ -497,7 +634,8 @@ public final class _DataStorage {
     }
     
     @inline(__always)
-    public func resetBytes(in range: NSRange) {
+    public func resetBytes(in range_: NSRange) {
+        let range = NSRange(location: range_.location - _offset, length: range_.length)
         if range.length == 0 { return }
         switch _backing {
         case .swift:
@@ -546,6 +684,7 @@ public final class _DataStorage {
         _capacity = capacity
         _needToZero = !clear
         _length = 0
+        _offset = 0
         setLength(length)
     }
     
@@ -560,10 +699,12 @@ public final class _DataStorage {
         _bytes = _DataStorage.allocate(capacity, false)!
         _capacity = capacity
         _needToZero = true
+        _offset = 0
     }
     
     public init(bytes: UnsafeRawPointer?, length: Int) {
         precondition(length < _DataStorage.maxSize)
+        _offset = 0
         if length == 0 {
             _capacity = 0
             _length = 0
@@ -588,8 +729,9 @@ public final class _DataStorage {
         }
     }
     
-    public init(bytes: UnsafeMutableRawPointer?, length: Int, copy: Bool, deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?) {
+    public init(bytes: UnsafeMutableRawPointer?, length: Int, copy: Bool, deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?, offset: Int) {
         precondition(length < _DataStorage.maxSize)
+        _offset = offset
         if length == 0 {
             _capacity = 0
             _length = 0
@@ -630,7 +772,8 @@ public final class _DataStorage {
         }
     }
     
-    public init(immutableReference: NSData) {
+    public init(immutableReference: NSData, offset: Int) {
+        _offset = offset
         _bytes = UnsafeMutableRawPointer(mutating: immutableReference.bytes)
         _capacity = 0
         _needToZero = false
@@ -638,7 +781,8 @@ public final class _DataStorage {
         _backing = .immutable(immutableReference)
     }
     
-    public init(mutableReference: NSMutableData) {
+    public init(mutableReference: NSMutableData, offset: Int) {
+        _offset = offset
         _bytes = mutableReference.mutableBytes
         _capacity = 0
         _needToZero = false
@@ -646,7 +790,8 @@ public final class _DataStorage {
         _backing = .mutable(mutableReference)
     }
     
-    public init(customReference: NSData) {
+    public init(customReference: NSData, offset: Int) {
+        _offset = offset
         _bytes = nil
         _capacity = 0
         _needToZero = false
@@ -654,7 +799,8 @@ public final class _DataStorage {
         _backing = .customReference(customReference)
     }
     
-    public init(customMutableReference: NSMutableData) {
+    public init(customMutableReference: NSMutableData, offset: Int) {
+        _offset = offset
         _bytes = nil
         _capacity = 0
         _needToZero = false
@@ -675,30 +821,30 @@ public final class _DataStorage {
     public func mutableCopy(_ range: Range<Int>) -> _DataStorage {
         switch _backing {
         case .swift:
-            return _DataStorage(bytes: _bytes?.advanced(by: range.lowerBound), length: range.count, copy: true, deallocator: nil)
+            return _DataStorage(bytes: _bytes?.advanced(by: range.lowerBound - _offset), length: range.count, copy: true, deallocator: nil, offset: range.lowerBound)
         case .immutable(let d):
             if range.lowerBound == 0 && range.upperBound == _length {
-                return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData)
+                return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData, offset: range.lowerBound)
             } else {
-                return _DataStorage(mutableReference: d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC().mutableCopy() as! NSMutableData)
+                return _DataStorage(mutableReference: d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC().mutableCopy() as! NSMutableData, offset: range.lowerBound)
             }
         case .mutable(let d):
             if range.lowerBound == 0 && range.upperBound == _length {
-                return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData)
+                return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData, offset: range.lowerBound)
             } else {
-                return _DataStorage(mutableReference: d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC().mutableCopy() as! NSMutableData)
+                return _DataStorage(mutableReference: d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC().mutableCopy() as! NSMutableData, offset: range.lowerBound)
             }
         case .customReference(let d):
             if range.lowerBound == 0 && range.upperBound == _length {
-                return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData)
+                return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData, offset: range.lowerBound)
             } else {
-                return _DataStorage(mutableReference: d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC().mutableCopy() as! NSMutableData)
+                return _DataStorage(mutableReference: d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC().mutableCopy() as! NSMutableData, offset: range.lowerBound)
             }
         case .customMutableReference(let d):
             if range.lowerBound == 0 && range.upperBound == _length {
-                return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData)
+                return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData, offset: range.lowerBound)
             } else {
-                return _DataStorage(mutableReference: d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC().mutableCopy() as! NSMutableData)
+                return _DataStorage(mutableReference: d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC().mutableCopy() as! NSMutableData, offset: range.lowerBound)
             }
         }
     }
@@ -710,26 +856,26 @@ public final class _DataStorage {
         
         switch _backing {
         case .swift:
-            return try work(NSData(bytesNoCopy: _bytes!.advanced(by: range.lowerBound), length: range.count, freeWhenDone: false))
+            return try work(NSData(bytesNoCopy: _bytes!.advanced(by: range.lowerBound - _offset), length: range.count, freeWhenDone: false))
         case .immutable(let d):
             guard range.lowerBound == 0 && range.upperBound == _length else {
-                return try work(NSData(bytesNoCopy: _bytes!.advanced(by: range.lowerBound), length: range.count, freeWhenDone: false))
+                return try work(NSData(bytesNoCopy: _bytes!.advanced(by: range.lowerBound - _offset), length: range.count, freeWhenDone: false))
             }
             return try work(d)
         case .mutable(let d):
             guard range.lowerBound == 0 && range.upperBound == _length else {
-                return try work(NSData(bytesNoCopy: _bytes!.advanced(by: range.lowerBound), length: range.count, freeWhenDone: false))
+                return try work(NSData(bytesNoCopy: _bytes!.advanced(by: range.lowerBound - _offset), length: range.count, freeWhenDone: false))
             }
             return try work(d)
         case .customReference(let d):
             guard range.lowerBound == 0 && range.upperBound == _length else {
                 
-                return try work(NSData(bytesNoCopy: UnsafeMutableRawPointer(mutating: d.bytes.advanced(by: range.lowerBound)), length: range.count, freeWhenDone: false))
+                return try work(NSData(bytesNoCopy: UnsafeMutableRawPointer(mutating: d.bytes.advanced(by: range.lowerBound - _offset)), length: range.count, freeWhenDone: false))
             }
             return try work(d)
         case .customMutableReference(let d):
             guard range.lowerBound == 0 && range.upperBound == _length else {
-                return try work(NSData(bytesNoCopy: UnsafeMutableRawPointer(mutating: d.bytes.advanced(by: range.lowerBound)), length: range.count, freeWhenDone: false))
+                return try work(NSData(bytesNoCopy: UnsafeMutableRawPointer(mutating: d.bytes.advanced(by: range.lowerBound - _offset)), length: range.count, freeWhenDone: false))
             }
             return try work(d)
         }
@@ -766,31 +912,18 @@ public final class _DataStorage {
         }
     }
     
-    public var hashValue: Int {
-        switch _backing {
-        case .customReference(let d):
-            return d.hash
-        case .customMutableReference(let d):
-            return d.hash
-        default:
-            let len = _length
-            return Int(bitPattern: CFHashBytes(_bytes?.assumingMemoryBound(to: UInt8.self), Swift.min(len, 80)))
-        }
-    }
-    
     public func subdata(in range: Range<Data.Index>) -> Data {
         switch _backing {
         case .customReference(let d):
-            return d.subdata(with: NSRange(location: range.lowerBound, length: range.count))
+            return d.subdata(with: NSRange(location: range.lowerBound - _offset, length: range.count))
         case .customMutableReference(let d):
-            return d.subdata(with: NSRange(location: range.lowerBound, length: range.count))
+            return d.subdata(with: NSRange(location: range.lowerBound - _offset, length: range.count))
         default:
-            return Data(bytes: _bytes!.advanced(by: range.lowerBound), count: range.count)
+            return Data(bytes: _bytes!.advanced(by: range.lowerBound - _offset), count: range.count)
         }
     }
 }
 
-@_versioned
 internal class _NSSwiftData : NSData {
     var _backing: _DataStorage!
     var _range: Range<Data.Index>!
@@ -828,7 +961,7 @@ internal class _NSSwiftData : NSData {
     }
     
 #if !DEPLOYMENT_RUNTIME_SWIFT
-    @objc
+    @objc override
     func _isCompact() -> Bool {
         return true
     }
@@ -1016,7 +1149,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter deallocator: Specifies the mechanism to free the indicated buffer, or `.none`.
     public init(bytesNoCopy bytes: UnsafeMutableRawPointer, count: Int, deallocator: Deallocator) {
         let whichDeallocator = deallocator._deallocator
-        _backing = _DataStorage(bytes: bytes, length: count, copy: false, deallocator: whichDeallocator)
+        _backing = _DataStorage(bytes: bytes, length: count, copy: false, deallocator: whichDeallocator, offset: 0)
         _sliceRange = 0..<count
     }
     
@@ -1027,7 +1160,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - throws: An error in the Cocoa domain, if `url` cannot be read.
     public init(contentsOf url: URL, options: Data.ReadingOptions = []) throws {
         let d = try NSData(contentsOf: url, options: ReadingOptions(rawValue: options.rawValue))
-        _backing = _DataStorage(immutableReference: d)
+        _backing = _DataStorage(immutableReference: d, offset: 0)
         _sliceRange = 0..<d.length
     }
     
@@ -1038,7 +1171,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter options: Encoding options. Default value is `[]`.
     public init?(base64Encoded base64String: String, options: Data.Base64DecodingOptions = []) {
         if let d = NSData(base64Encoded: base64String, options: Base64DecodingOptions(rawValue: options.rawValue)) {
-            _backing = _DataStorage(immutableReference: d)
+            _backing = _DataStorage(immutableReference: d, offset: 0)
             _sliceRange = 0..<d.length
         } else {
             return nil
@@ -1053,7 +1186,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter options: Decoding options. Default value is `[]`.
     public init?(base64Encoded base64Data: Data, options: Data.Base64DecodingOptions = []) {
         if let d = NSData(base64Encoded: base64Data, options: Base64DecodingOptions(rawValue: options.rawValue)) {
-            _backing = _DataStorage(immutableReference: d)
+            _backing = _DataStorage(immutableReference: d, offset: 0)
             _sliceRange = 0..<d.length
         } else {
             return nil
@@ -1074,10 +1207,10 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         let providesConcreteBacking = (reference as AnyObject)._providesConcreteBacking?() ?? false
 #endif
         if providesConcreteBacking {
-            _backing = _DataStorage(immutableReference: reference.copy() as! NSData)
+            _backing = _DataStorage(immutableReference: reference.copy() as! NSData, offset: 0)
             _sliceRange = 0..<reference.length
         } else {
-            _backing = _DataStorage(customReference: reference.copy() as! NSData)
+            _backing = _DataStorage(customReference: reference.copy() as! NSData, offset: 0)
             _sliceRange = 0..<reference.length
         }
         
@@ -1086,40 +1219,30 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     // slightly faster paths for common sequences
     
     public init<S: Sequence>(_ elements: S) where S.Iterator.Element == UInt8 {
-        let underestimatedCount = elements.underestimatedCount
-        self.init(count: underestimatedCount)
-        var idx = 0
-        for byte in elements {
-            if idx < underestimatedCount {
-                self[idx] = byte
-            } else {
-                self.append(byte)
+        if elements is Array<UInt8> {
+            self.init(bytes: _identityCast(elements, to: Array<UInt8>.self))
+        } else if elements is ArraySlice<UInt8> {
+            self.init(bytes: _identityCast(elements, to: ArraySlice<UInt8>.self))
+        } else if elements is UnsafeBufferPointer<UInt8> {
+            self.init(buffer: _identityCast(elements, to: UnsafeBufferPointer<UInt8>.self))
+        } else if let buffer = elements as? UnsafeMutableBufferPointer<UInt8> {
+            self.init(buffer: buffer)
+        } else if let data = elements as? Data {
+            let len = data.count
+            let backing = data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
+                return _DataStorage(bytes: bytes, length: len)
             }
-            idx += 1
+            self.init(backing: backing, range: 0..<len)
+        } else {
+            let underestimatedCount = elements.underestimatedCount
+            self.init(count: underestimatedCount)
+            
+            let (endIterator, _) = UnsafeMutableBufferPointer(start: _backing._bytes?.assumingMemoryBound(to: UInt8.self), count: underestimatedCount).initialize(from: elements)
+            var iter = endIterator
+            while let byte = iter.next() { self.append(byte) }
         }
     }
-    
-    public init(_ bytes: Array<UInt8>) {
-        self.init(bytes: bytes)
-    }
-    
-    public init(_ bytes: ArraySlice<UInt8>) {
-        self.init(bytes: bytes)
-    }
-    
-    public init(_ buffer: UnsafeBufferPointer<UInt8>) {
-        self.init(buffer: buffer)
-    }
-    
-    public init(_ buffer: UnsafeMutableBufferPointer<UInt8>) {
-        self.init(buffer: buffer)
-    }
-    
-    public init(_ data: Data) {
-        _sliceRange = 0..<data.count
-        _backing = data._backing.mutableCopy(data._sliceRange)
-    }
-    
+
     @_versioned
     internal init(backing: _DataStorage, range: Range<Index>) {
         _backing = backing
@@ -1152,7 +1275,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
         @inline(__always)
         set {
-            precondition(count >= 0, "count must be positive")
+            precondition(count >= 0, "count must not be negative")
             if !isKnownUniquelyReferenced(&_backing) {
                 _backing = _backing.mutableCopy(_sliceRange)
             }
@@ -1166,9 +1289,9 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - warning: The byte pointer argument should not be stored and used outside of the lifetime of the call to the closure.
     @inline(__always)
     public func withUnsafeBytes<ResultType, ContentType>(_ body: (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
-        let bytes =  _backing.bytes?.advanced(by: _sliceRange.lowerBound) ?? UnsafeRawPointer(bitPattern: 0xBAD0)!
-        let contentPtr = bytes.bindMemory(to: ContentType.self, capacity: count / MemoryLayout<ContentType>.stride)
-        return try body(contentPtr)
+        return try _backing.withUnsafeBytes(in: _sliceRange) {
+            return try body($0.baseAddress?.assumingMemoryBound(to: ContentType.self) ?? UnsafePointer<ContentType>(bitPattern: 0xBAD0)!)
+        }
     }
     
     
@@ -1181,9 +1304,9 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         if !isKnownUniquelyReferenced(&_backing) {
             _backing = _backing.mutableCopy(_sliceRange)
         }
-        let mutableBytes = _backing.mutableBytes?.advanced(by: _sliceRange.lowerBound) ?? UnsafeMutableRawPointer(bitPattern: 0xBAD0)!
-        let contentPtr = mutableBytes.bindMemory(to: ContentType.self, capacity: count / MemoryLayout<ContentType>.stride)
-        return try body(UnsafeMutablePointer(contentPtr))
+        return try _backing.withUnsafeMutableBytes(in: _sliceRange) {
+            return try body($0.baseAddress?.assumingMemoryBound(to: ContentType.self) ?? UnsafeMutablePointer<ContentType>(bitPattern: 0xBAD0)!)
+        }
     }
     
     // MARK: -
@@ -1196,15 +1319,19 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - warning: This method does not verify that the contents at pointer have enough space to hold `count` bytes.
     @inline(__always)
     public func copyBytes(to pointer: UnsafeMutablePointer<UInt8>, count: Int) {
-        precondition(count >= 0, "count of bytes to copy must be positive")
+        precondition(count >= 0, "count of bytes to copy must not be negative")
         if count == 0 { return }
-        memcpy(UnsafeMutableRawPointer(pointer), _backing.bytes!.advanced(by: _sliceRange.lowerBound), Swift.min(count, _sliceRange.count))
+        _backing.withUnsafeBytes(in: _sliceRange) {
+            memcpy(UnsafeMutableRawPointer(pointer), $0.baseAddress!, Swift.min(count, $0.count))
+        }
     }
     
     @inline(__always)
     private func _copyBytesHelper(to pointer: UnsafeMutableRawPointer, from range: NSRange) {
         if range.length == 0 { return }
-        memcpy(UnsafeMutableRawPointer(pointer), _backing.bytes!.advanced(by: range.location), Swift.min(range.length, _sliceRange.count))
+        _backing.withUnsafeBytes(in: range.lowerBound..<range.upperBound) {
+            memcpy(UnsafeMutableRawPointer(pointer), $0.baseAddress!, Swift.min(range.length, $0.count))
+        }
     }
     
     /// Copy a subset of the contents of the data to a pointer.
@@ -1312,27 +1439,20 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// In some cases, (for example, a `Data` backed by a `dispatch_data_t`, the bytes may be stored discontiguously. In those cases, this function invokes the closure for each contiguous region of bytes.
     /// - parameter block: The closure to invoke for each region of data. You may stop the enumeration by setting the `stop` parameter to `true`.
     public func enumerateBytes(_ block: (_ buffer: UnsafeBufferPointer<UInt8>, _ byteIndex: Index, _ stop: inout Bool) -> Void) {
-        _backing.enumerateBytes(block)
+        _backing.enumerateBytes(in: _sliceRange, block)
     }
     
     @inline(__always)
     public mutating func append(_ bytes: UnsafePointer<UInt8>, count: Int) {
-        precondition(count >= 0, "count must be positive")
         if count == 0 { return }
-        if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy(_sliceRange)
-        }
-        _backing.append(bytes, length: count)
-        _sliceRange = _sliceRange.lowerBound..<(_sliceRange.upperBound + count)
+        append(UnsafeBufferPointer(start: bytes, count: count))
     }
     
     @inline(__always)
     public mutating func append(_ other: Data) {
-        if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy(_sliceRange)
+        other.enumerateBytes { (buffer, _, _) in
+            append(buffer)
         }
-        _backing.append(other._backing, startingAt: other._sliceRange.lowerBound, endingAt: other._sliceRange.upperBound)
-        _sliceRange = _sliceRange.lowerBound..<(_sliceRange.upperBound + other.count)
     }
     
     /// Append a buffer of bytes to the data.
@@ -1344,22 +1464,26 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         if !isKnownUniquelyReferenced(&_backing) {
             _backing = _backing.mutableCopy(_sliceRange)
         }
-        _backing.append(buffer.baseAddress!, length: buffer.count * MemoryLayout<SourceType>.stride)
+        _backing.replaceBytes(in: NSRange(location: _sliceRange.upperBound, length: _backing.length - (_sliceRange.upperBound - _backing._offset)), with: buffer.baseAddress, length: buffer.count * MemoryLayout<SourceType>.stride)
         _sliceRange = _sliceRange.lowerBound..<(_sliceRange.upperBound + buffer.count * MemoryLayout<SourceType>.stride)
     }
     
     @inline(__always)
     public mutating func append<S : Sequence>(contentsOf newElements: S) where S.Iterator.Element == Iterator.Element {
         let estimatedCount = newElements.underestimatedCount
-        var idx = count
-        count += estimatedCount
-        for byte in newElements {
-            let newIndex = idx + 1
-            if newIndex > count {
-                count = newIndex
+        guard estimatedCount > 0 else {
+            for byte in newElements {
+                append(byte)
             }
-            self[idx] = byte
-            idx = newIndex
+            return
+        }
+        _withStackOrHeapBuffer(estimatedCount) { allocation in
+            let buffer = UnsafeMutableBufferPointer(start: allocation.pointee.memory.assumingMemoryBound(to: UInt8.self), count: estimatedCount)
+            var (iterator, endPoint) = newElements._copyContents(initializing: buffer)
+            append(buffer.baseAddress!, count: endPoint - buffer.startIndex)
+            while let byte = iterator.next() {
+                append(byte)
+            }
         }
     }
     
@@ -1379,16 +1503,15 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     @inline(__always)
     public mutating func resetBytes(in range: Range<Index>) {
         // it is worth noting that the range here may be out of bounds of the Data itself (which triggers a growth)
-        precondition(range.lowerBound >= 0, "Ranges must be positive bounds")
-        precondition(range.upperBound >= 0, "Ranges must be positive bounds")
+        precondition(range.lowerBound >= 0, "Ranges must not be negative bounds")
+        precondition(range.upperBound >= 0, "Ranges must not be negative bounds")
         let range = NSMakeRange(range.lowerBound, range.upperBound - range.lowerBound)
         if !isKnownUniquelyReferenced(&_backing) {
             _backing = _backing.mutableCopy(_sliceRange)
         }
         _backing.resetBytes(in: range)
-        if _sliceRange.count < range.location + range.length {
-            let newLength = range.location + range.length
-            _sliceRange = _sliceRange.lowerBound..<(_sliceRange.lowerBound + newLength)
+        if _sliceRange.upperBound < range.upperBound {
+            _sliceRange = _sliceRange.lowerBound..<range.upperBound
         }
     }
     
@@ -1401,34 +1524,16 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter data: The replacement data.
     @inline(__always)
     public mutating func replaceSubrange(_ subrange: Range<Index>, with data: Data) {
-        _validateRange(subrange)
-        let nsRange = NSMakeRange(subrange.lowerBound, subrange.upperBound - subrange.lowerBound)
         let cnt = data.count
-        if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy(_sliceRange)
+        data.withUnsafeBytes {
+            replaceSubrange(subrange, with: $0, count: cnt)
         }
-        let resultingLength = data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> Int in
-            let currentLength = _backing.length
-            _backing.replaceBytes(in: nsRange, with: bytes, length: cnt)
-            return currentLength - nsRange.length + cnt
-        }
-        _sliceRange = _sliceRange.lowerBound..<(_sliceRange.lowerBound + resultingLength)
     }
     
     @inline(__always)
     public mutating func replaceSubrange(_ subrange: CountableRange<Index>, with data: Data) {
-        _validateRange(subrange)
-        let nsRange = NSMakeRange(subrange.lowerBound, subrange.upperBound - subrange.lowerBound)
-        let cnt = data.count
-        if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy(_sliceRange)
-        }
-        let resultingLength = data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> Int in
-            let currentLength = _backing.length
-            _backing.replaceBytes(in: nsRange, with: bytes, length: cnt)
-            return currentLength - nsRange.length + cnt
-        }
-        _sliceRange = _sliceRange.lowerBound..<(_sliceRange.lowerBound + resultingLength)
+        let range: Range<Int> = subrange.lowerBound..<subrange.upperBound
+        replaceSubrange(range, with: data)
     }
     
     /// Replace a region of bytes in the data with new bytes from a buffer.
@@ -1440,17 +1545,8 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter buffer: The replacement bytes.
     @inline(__always)
     public mutating func replaceSubrange<SourceType>(_ subrange: Range<Index>, with buffer: UnsafeBufferPointer<SourceType>) {
-        _validateRange(subrange)
-        let nsRange = NSMakeRange(subrange.lowerBound, subrange.upperBound - subrange.lowerBound)
-        let bufferCount = buffer.count * MemoryLayout<SourceType>.stride
-        
-        if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy(_sliceRange)
-        }
-        let currentLength = _backing.length
-        _backing.replaceBytes(in: nsRange, with: buffer.baseAddress, length: bufferCount)
-        let resultingLength = currentLength - nsRange.length + bufferCount
-        _sliceRange = _sliceRange.lowerBound..<(_sliceRange.lowerBound + resultingLength)
+        guard buffer.count > 0  else { return }
+        replaceSubrange(subrange, with: buffer.baseAddress!, count: buffer.count * MemoryLayout<SourceType>.stride)
     }
     
     /// Replace a region of bytes in the data with new bytes from a collection.
@@ -1461,39 +1557,18 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter subrange: The range in the data to replace.
     /// - parameter newElements: The replacement bytes.
     @inline(__always)
-    public mutating func replaceSubrange<ByteCollection : Collection>(_ subrange: Range<Index>, with newElements: ByteCollection)
-        where ByteCollection.Iterator.Element == Data.Iterator.Element {
-            _validateRange(subrange)
-            // Calculate this once, it may not be O(1)
-            let replacementCount: Int = numericCast(newElements.count)
-            let currentCount = self.count
-            let subrangeCount = subrange.count
-            
-            _validateRange(subrange)
-            
-            let resultCount = currentCount - subrangeCount + replacementCount
-            if resultCount != currentCount {
-                // This may realloc.
-                // In the future, if we keep the malloced pointer and count inside this struct/ref instead of deferring to NSData, we may be able to do this more efficiently.
-                self.count = resultCount
+    public mutating func replaceSubrange<ByteCollection : Collection>(_ subrange: Range<Index>, with newElements: ByteCollection) where ByteCollection.Iterator.Element == Data.Iterator.Element {
+        _validateRange(subrange)
+        let totalCount: Int = numericCast(newElements.count)
+        _withStackOrHeapBuffer(totalCount) { conditionalBuffer in
+            let buffer = UnsafeMutableBufferPointer(start: conditionalBuffer.pointee.memory.assumingMemoryBound(to: UInt8.self), count: totalCount)
+            var (iterator, index) = newElements._copyContents(initializing: buffer)
+            while let byte = iterator.next() {
+                buffer[index] = byte
+                index = buffer.index(after: index)
             }
-            
-            let shift = resultCount - currentCount
-            let start = subrange.lowerBound
-            
-            self.withUnsafeMutableBytes { (bytes : UnsafeMutablePointer<UInt8>) -> Void in
-                if shift != 0 {
-                    let destination = bytes + start + replacementCount
-                    let source = bytes + start + subrangeCount
-                    memmove(destination, source, currentCount - start - subrangeCount)
-                }
-                
-                if replacementCount != 0 {
-                    let buf = UnsafeMutableBufferPointer(start: bytes + start, count: replacementCount)
-                    var (it,idx) = newElements._copyContents(initializing: buf)
-                    precondition(it.next() == nil && idx == buf.endIndex, "newElements iterator returned different count to newElements.count")
-                }
-            }
+            replaceSubrange(subrange, with: conditionalBuffer.pointee.memory, count: totalCount)
+        }
     }
     
     @inline(__always)
@@ -1503,10 +1578,10 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         if !isKnownUniquelyReferenced(&_backing) {
             _backing = _backing.mutableCopy(_sliceRange)
         }
-        let currentLength = _backing.length
+        let upper = _sliceRange.upperBound
         _backing.replaceBytes(in: nsRange, with: bytes, length: cnt)
-        let resultingLength = currentLength - nsRange.length + cnt
-        _sliceRange = _sliceRange.lowerBound..<(_sliceRange.lowerBound + resultingLength)
+        let resultingUpper = upper - nsRange.length + cnt
+        _sliceRange = _sliceRange.lowerBound..<resultingUpper
     }
     
     /// Return a new copy of the data in a specified range.
@@ -1515,6 +1590,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     @inline(__always)
     public func subdata(in range: Range<Index>) -> Data {
         _validateRange(range)
+        let length = count
         if count == 0 {
             return Data()
         }
@@ -1549,7 +1625,15 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     
     /// The hash value for the data.
     public var hashValue: Int {
-        return _backing.hashValue
+        var hashValue = 0
+        let hashRange: Range<Int> = _sliceRange.lowerBound..<Swift.min(_sliceRange.lowerBound + 80, _sliceRange.upperBound)
+        _withStackOrHeapBuffer(hashRange.count) { buffer in
+            _backing.withUnsafeBytes(in: hashRange) {
+                memcpy(buffer.pointee.memory, $0.baseAddress!, hashRange.count)
+            }
+            hashValue = Int(bitPattern: CFHashBytes(buffer.pointee.memory.assumingMemoryBound(to: UInt8.self), hashRange.count))
+        }
+        return hashValue
     }
     
     @inline(__always)
@@ -1572,7 +1656,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         @inline(__always)
         get {
             _validateIndex(index)
-            return _backing.bytes!.advanced(by: index).assumingMemoryBound(to: UInt8.self).pointee
+            return _backing.get(index)
         }
         @inline(__always)
         set {
@@ -1658,11 +1742,24 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
     }
     
+    public func _copyContents(initializing buffer: UnsafeMutableBufferPointer<UInt8>) -> (Iterator, UnsafeMutableBufferPointer<UInt8>.Index) {
+        guard !isEmpty else { return (makeIterator(), buffer.startIndex) }
+        guard let p = buffer.baseAddress else {
+            preconditionFailure("Attempt to copy contents into nil buffer pointer")
+        }
+        let cnt = count
+        precondition(cnt <= buffer.count, "Insufficient space allocated to copy Data contents")
+        
+        withUnsafeBytes { p.initialize(from: $0, count: cnt) }
+        
+        return (Iterator(endOf: self), buffer.index(buffer.startIndex, offsetBy: cnt))
+    }
+    
     /// An iterator over the contents of the data.
     ///
     /// The iterator will increment byte-by-byte.
     public func makeIterator() -> Data.Iterator {
-        return Iterator(_data: self)
+        return Iterator(self)
     }
     
     public struct Iterator : IteratorProtocol {
@@ -1675,11 +1772,18 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         private var _idx: Data.Index
         private let _endIdx: Data.Index
         
-        fileprivate init(_data: Data) {
-            self._data = _data
+        fileprivate init(_ data: Data) {
+            _data = data
             _buffer = (0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
-            _idx = _data.startIndex
-            _endIdx = _data.endIndex
+            _idx = data.startIndex
+            _endIdx = data.endIndex
+        }
+        
+        fileprivate init(endOf data: Data) {
+            self._data = data
+            _buffer = (0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
+            _idx = data.endIndex
+            _endIdx = data.endIndex
         }
         
         public mutating func next() -> UInt8? {
@@ -1765,7 +1869,7 @@ extension Data : CustomStringConvertible, CustomDebugStringConvertible, CustomRe
         
         // Minimal size data is output as an array
         if nBytes < 64 {
-            children.append((label: "bytes", value: Array(self[0..<nBytes])))
+            children.append((label: "bytes", value: Array(self[startIndex..<Swift.min(nBytes + startIndex, endIndex)])))
         }
         
         let m = Mirror(self, children:children, displayStyle: Mirror.DisplayStyle.struct)
@@ -1822,11 +1926,27 @@ extension NSData : _HasCustomAnyHashableRepresentation {
 
 extension Data : Codable {
     public init(from decoder: Decoder) throws {
+        // FIXME: This is a hook for bypassing a conditional conformance implementation to apply a strategy (see SR-5206). Remove this once conditional conformance is available.
+        do {
+            let singleValueContainer = try decoder.singleValueContainer()
+            if let decoder = singleValueContainer as? _JSONDecoder {
+                switch decoder.options.dataDecodingStrategy {
+                case .deferredToData:
+                    break /* fall back to default implementation below; this would recurse */
+
+                default:
+                    // _JSONDecoder has a hook for Datas; this won't recurse since we're not going to defer back to Data in _JSONDecoder.
+                    self = try singleValueContainer.decode(Data.self)
+                    return
+                }
+            }
+        } catch { /* fall back to default implementation below */ }
+
         var container = try decoder.unkeyedContainer()
         
         // It's more efficient to pre-allocate the buffer if we can.
         if let count = container.count {
-            self.init(count: count)
+            self = Data(count: count)
             
             // Loop only until count, not while !container.isAtEnd, in case count is underestimated (this is misbehavior) and we haven't allocated enough space.
             // We don't want to write past the end of what we allocated.
@@ -1835,7 +1955,7 @@ extension Data : Codable {
                 self[i] = byte
             }
         } else {
-            self.init()
+            self = Data()
         }
         
         while !container.isAtEnd {
@@ -1845,6 +1965,21 @@ extension Data : Codable {
     }
     
     public func encode(to encoder: Encoder) throws {
+        // FIXME: This is a hook for bypassing a conditional conformance implementation to apply a strategy (see SR-5206). Remove this once conditional conformance is available.
+        // We are allowed to request this container as long as we don't encode anything through it when we need the unkeyed container below.
+        var singleValueContainer = encoder.singleValueContainer()
+        if let encoder = singleValueContainer as? _JSONEncoder {
+            switch encoder.options.dataEncodingStrategy {
+            case .deferredToData:
+                break /* fall back to default implementation below; this would recurse */
+
+            default:
+                // _JSONEncoder has a hook for Datas; this won't recurse since we're not going to defer back to Data in _JSONEncoder.
+                try singleValueContainer.encode(self)
+                return
+            }
+        }
+
         var container = encoder.unkeyedContainer()
         
         // Since enumerateBytes does not rethrow, we need to catch the error, stow it away, and rethrow if we stopped.
@@ -1863,4 +1998,3 @@ extension Data : Codable {
         }
     }
 }
-

--- a/Foundation/JSONEncoder.swift
+++ b/Foundation/JSONEncoder.swift
@@ -64,6 +64,9 @@ open class JSONEncoder {
 
     /// The strategy to use for encoding `Data` values.
     public enum DataEncodingStrategy {
+        /// Defer to `Data` for choosing an encoding.
+        case deferredToData
+        
         /// Encoded the `Data` as a Base64-encoded string. This is the default strategy.
         case base64
 
@@ -98,7 +101,7 @@ open class JSONEncoder {
     open var userInfo: [CodingUserInfoKey : Any] = [:]
 
     /// Options set on the top-level encoder to pass down the encoding hierarchy.
-    fileprivate struct _Options {
+    internal struct _Options {
         let dateEncodingStrategy: DateEncodingStrategy
         let dataEncodingStrategy: DataEncodingStrategy
         let nonConformingFloatEncodingStrategy: NonConformingFloatEncodingStrategy
@@ -150,14 +153,14 @@ open class JSONEncoder {
 
 // MARK: - _JSONEncoder
 
-fileprivate class _JSONEncoder : Encoder {
+internal class _JSONEncoder : Encoder {
     // MARK: Properties
 
     /// The encoder's storage.
     fileprivate var storage: _JSONEncodingStorage
 
     /// Options set on the top-level encoder.
-    fileprivate let options: JSONEncoder._Options
+    internal let options: JSONEncoder._Options
 
     /// The path to the current point in encoding.
     public var codingPath: [CodingKey]
@@ -672,6 +675,11 @@ extension _JSONEncoder {
 
     fileprivate func box(_ data: Data) throws -> NSObject {
         switch self.options.dataEncodingStrategy {
+        case .deferredToData:
+            // Must be called with a surrounding with(pushedKey:) call.
+            try data.encode(to: self)
+            return self.storage.popContainer()
+            
         case .base64:
             return NSString(string: data.base64EncodedString())
 
@@ -826,6 +834,9 @@ open class JSONDecoder {
 
     /// The strategy to use for decoding `Data` values.
     public enum DataDecodingStrategy {
+        /// Defer to `Data` for decoding.
+        case deferredToData
+        
         /// Decode the `Data` from a Base64-encoded string. This is the default strategy.
         case base64
 
@@ -855,7 +866,7 @@ open class JSONDecoder {
     open var userInfo: [CodingUserInfoKey : Any] = [:]
 
     /// Options set on the top-level encoder to pass down the decoding hierarchy.
-    fileprivate struct _Options {
+    internal struct _Options {
         let dateDecodingStrategy: DateDecodingStrategy
         let dataDecodingStrategy: DataDecodingStrategy
         let nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy
@@ -893,14 +904,14 @@ open class JSONDecoder {
 
 // MARK: - _JSONDecoder
 
-fileprivate class _JSONDecoder : Decoder {
+internal class _JSONDecoder : Decoder {
     // MARK: Properties
 
     /// The decoder's storage.
     fileprivate var storage: _JSONDecodingStorage
 
     /// Options set on the top-level decoder.
-    fileprivate let options: JSONDecoder._Options
+    internal let options: JSONDecoder._Options
 
     /// The path to the current point in encoding.
     private(set) public var codingPath: [CodingKey]
@@ -2042,6 +2053,12 @@ extension _JSONDecoder {
         guard !(value is NSNull) else { return nil }
 
         switch self.options.dataDecodingStrategy {
+        case .deferredToData:
+            self.storage.push(container: value)
+            let data = try Data(from: self)
+            self.storage.popContainer()
+            return data
+            
         case .base64:
             guard let string = value as? String else {
                 throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -991,6 +991,19 @@ open class NSMutableData : NSData {
     }
 }
 
+extension NSData {
+    internal func _isCompact() -> Bool {
+        var regions = 0
+        enumerateBytes { (_, _, stop) in
+            regions += 1
+            if regions > 1 {
+                stop.pointee = true
+            }
+        }
+        return regions <= 1
+    }
+}
+
 extension NSData : _StructTypeBridgeable {
     public typealias _StructType = Data
     public func _bridgeToSwift() -> Data {

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -55,7 +55,7 @@ class TestNSData: XCTestCase {
                 // Need to allocate the buffer now.
                 // It doesn't matter if the buffer is uniquely referenced or not here.
                 let buffer = malloc(length)
-                memset(buffer, 1, length)
+                memset(buffer!, 1, length)
                 let bytePtr = buffer!.bindMemory(to: UInt8.self, capacity: length)
                 let result = UnsafeMutableBufferPointer(start: bytePtr, count: length)
                 _pointer = result
@@ -66,7 +66,7 @@ class TestNSData: XCTestCase {
         override func getBytes(_ buffer: UnsafeMutableRawPointer, length: Int) {
             if let d = _pointer {
                 // Get the real data from the buffer
-                memmove(buffer, d.baseAddress, length)
+                memmove(buffer, d.baseAddress!, length)
             } else {
                 // A more efficient implementation of getBytes in the case where no one has asked for our backing bytes
                 memset(buffer, 1, length)
@@ -118,9 +118,9 @@ class TestNSData: XCTestCase {
                     // Copy the data to our new length buffer
                     let newBuffer = malloc(newValue)!
                     if newValue <= _length {
-                        memmove(newBuffer, ptr.baseAddress, newValue)
+                        memmove(newBuffer, ptr.baseAddress!, newValue)
                     } else if newValue > _length {
-                        memmove(newBuffer, ptr.baseAddress, _length)
+                        memmove(newBuffer, ptr.baseAddress!, _length)
                         memset(newBuffer + _length, 1, newValue - _length)
                     }
                     let bytePtr = newBuffer.bindMemory(to: UInt8.self, capacity: newValue)
@@ -137,7 +137,7 @@ class TestNSData: XCTestCase {
                 // Need to allocate the buffer now.
                 // It doesn't matter if the buffer is uniquely referenced or not here.
                 let buffer = malloc(length)
-                memset(buffer, 1, length)
+                memset(buffer!, 1, length)
                 let bytePtr = buffer!.bindMemory(to: UInt8.self, capacity: length)
                 let result = UnsafeMutableBufferPointer(start: bytePtr, count: length)
                 _pointer = result
@@ -150,10 +150,10 @@ class TestNSData: XCTestCase {
             let newBuffer = malloc(newBufferLength)
             if let ptr = _pointer {
                 // Copy the existing data to the new box, then return its pointer
-                memmove(newBuffer, ptr.baseAddress, newBufferLength)
+                memmove(newBuffer!, ptr.baseAddress!, newBufferLength)
             } else {
                 // Set new data to 1s
-                memset(newBuffer, 1, newBufferLength)
+                memset(newBuffer!, 1, newBufferLength)
             }
             let bytePtr = newBuffer!.bindMemory(to: UInt8.self, capacity: newBufferLength)
             let result = UnsafeMutableBufferPointer(start: bytePtr, count: newBufferLength)
@@ -165,7 +165,7 @@ class TestNSData: XCTestCase {
         override func getBytes(_ buffer: UnsafeMutableRawPointer, length: Int) {
             if let d = _pointer {
                 // Get the real data from the buffer
-                memmove(buffer, d.baseAddress, length)
+                memmove(buffer, d.baseAddress!, length)
             } else {
                 // A more efficient implementation of getBytes in the case where no one has asked for our backing bytes
                 memset(buffer, 1, length)

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -17,7 +17,171 @@
 
 class TestNSData: XCTestCase {
     
-
+    class AllOnesImmutableData : NSData {
+        private var _length : Int
+        var _pointer : UnsafeMutableBufferPointer<UInt8>? {
+            willSet {
+                if let p = _pointer { free(p.baseAddress) }
+            }
+        }
+        
+        init(length : Int) {
+            _length = length
+            super.init(bytes: nil, length: 0, copy: false, deallocator: nil)
+            _length = length
+        }
+        
+        required init?(coder aDecoder: NSCoder) {
+            // Not tested
+            fatalError()
+        }
+        
+        deinit {
+            if let p = _pointer {
+                free(p.baseAddress)
+            }
+        }
+        
+        override var length : Int {
+            get {
+                return _length
+            }
+        }
+        
+        override var bytes : UnsafeRawPointer {
+            if let d = _pointer {
+                return UnsafeRawPointer(d.baseAddress!)
+            } else {
+                // Need to allocate the buffer now.
+                // It doesn't matter if the buffer is uniquely referenced or not here.
+                let buffer = malloc(length)
+                memset(buffer, 1, length)
+                let bytePtr = buffer!.bindMemory(to: UInt8.self, capacity: length)
+                let result = UnsafeMutableBufferPointer(start: bytePtr, count: length)
+                _pointer = result
+                return UnsafeRawPointer(result.baseAddress!)
+            }
+        }
+        
+        override func getBytes(_ buffer: UnsafeMutableRawPointer, length: Int) {
+            if let d = _pointer {
+                // Get the real data from the buffer
+                memmove(buffer, d.baseAddress, length)
+            } else {
+                // A more efficient implementation of getBytes in the case where no one has asked for our backing bytes
+                memset(buffer, 1, length)
+            }
+        }
+        
+        override func copy(with zone: NSZone? = nil) -> Any {
+            return self
+        }
+        
+        override func mutableCopy(with zone: NSZone? = nil) -> Any {
+            return AllOnesData(length: _length)
+        }
+    }
+    
+    
+    class AllOnesData : NSMutableData {
+        
+        private var _length : Int
+        var _pointer : UnsafeMutableBufferPointer<UInt8>? {
+            willSet {
+                if let p = _pointer { free(p.baseAddress) }
+            }
+        }
+        
+        /*override*/ init(length : Int) {
+            _length = length
+            super.init(bytes: nil, length: 0, copy: false, deallocator: nil)
+            _length = length
+        }
+        
+        required init?(coder aDecoder: NSCoder) {
+            // Not tested
+            fatalError()
+        }
+        
+        deinit {
+            if let p = _pointer {
+                free(p.baseAddress)
+            }
+        }
+        
+        override var length : Int {
+            get {
+                return _length
+            }
+            set {
+                if let ptr = _pointer {
+                    // Copy the data to our new length buffer
+                    let newBuffer = malloc(newValue)!
+                    if newValue <= _length {
+                        memmove(newBuffer, ptr.baseAddress, newValue)
+                    } else if newValue > _length {
+                        memmove(newBuffer, ptr.baseAddress, _length)
+                        memset(newBuffer + _length, 1, newValue - _length)
+                    }
+                    let bytePtr = newBuffer.bindMemory(to: UInt8.self, capacity: newValue)
+                    _pointer = UnsafeMutableBufferPointer(start: bytePtr, count: newValue)
+                }
+                _length = newValue
+            }
+        }
+        
+        override var bytes : UnsafeRawPointer {
+            if let d = _pointer {
+                return UnsafeRawPointer(d.baseAddress!)
+            } else {
+                // Need to allocate the buffer now.
+                // It doesn't matter if the buffer is uniquely referenced or not here.
+                let buffer = malloc(length)
+                memset(buffer, 1, length)
+                let bytePtr = buffer!.bindMemory(to: UInt8.self, capacity: length)
+                let result = UnsafeMutableBufferPointer(start: bytePtr, count: length)
+                _pointer = result
+                return UnsafeRawPointer(result.baseAddress!)
+            }
+        }
+        
+        override var mutableBytes: UnsafeMutableRawPointer {
+            let newBufferLength = _length
+            let newBuffer = malloc(newBufferLength)
+            if let ptr = _pointer {
+                // Copy the existing data to the new box, then return its pointer
+                memmove(newBuffer, ptr.baseAddress, newBufferLength)
+            } else {
+                // Set new data to 1s
+                memset(newBuffer, 1, newBufferLength)
+            }
+            let bytePtr = newBuffer!.bindMemory(to: UInt8.self, capacity: newBufferLength)
+            let result = UnsafeMutableBufferPointer(start: bytePtr, count: newBufferLength)
+            _pointer = result
+            _length = newBufferLength
+            return UnsafeMutableRawPointer(result.baseAddress!)
+        }
+        
+        override func getBytes(_ buffer: UnsafeMutableRawPointer, length: Int) {
+            if let d = _pointer {
+                // Get the real data from the buffer
+                memmove(buffer, d.baseAddress, length)
+            } else {
+                // A more efficient implementation of getBytes in the case where no one has asked for our backing bytes
+                memset(buffer, 1, length)
+            }
+        }
+    }
+    
+    var heldData: Data?
+    
+    // this holds a reference while applying the function which forces the internal ref type to become non-uniquely referenced
+    func holdReference(_ data: Data, apply: () -> Void) {
+        heldData = data
+        apply()
+        heldData = nil
+    }
+    
     // MARK: -
     
     // String of course has its own way to get data, but this way tests our own data struct
@@ -100,6 +264,250 @@ class TestNSData: XCTestCase {
             ("test_replaceSubrange", test_replaceSubrange),
             ("test_sliceWithUnsafeBytes", test_sliceWithUnsafeBytes),
             ("test_sliceIteration", test_sliceIteration),
+
+            ("test_validateMutation_withUnsafeMutableBytes", test_validateMutation_withUnsafeMutableBytes),
+            ("test_validateMutation_appendBytes", test_validateMutation_appendBytes),
+            ("test_validateMutation_appendData", test_validateMutation_appendData),
+            ("test_validateMutation_appendBuffer", test_validateMutation_appendBuffer),
+            ("test_validateMutation_appendSequence", test_validateMutation_appendSequence),
+            ("test_validateMutation_appendContentsOf", test_validateMutation_appendContentsOf),
+            ("test_validateMutation_resetBytes", test_validateMutation_resetBytes),
+            ("test_validateMutation_replaceSubrange", test_validateMutation_replaceSubrange),
+            ("test_validateMutation_replaceSubrangeCountableRange", test_validateMutation_replaceSubrangeCountableRange),
+            ("test_validateMutation_replaceSubrangeWithBuffer", test_validateMutation_replaceSubrangeWithBuffer),
+            ("test_validateMutation_replaceSubrangeWithCollection", test_validateMutation_replaceSubrangeWithCollection),
+            ("test_validateMutation_replaceSubrangeWithBytes", test_validateMutation_replaceSubrangeWithBytes),
+            ("test_validateMutation_slice_withUnsafeMutableBytes", test_validateMutation_slice_withUnsafeMutableBytes),
+            ("test_validateMutation_slice_appendBytes", test_validateMutation_slice_appendBytes),
+            ("test_validateMutation_slice_appendData", test_validateMutation_slice_appendData),
+            ("test_validateMutation_slice_appendBuffer", test_validateMutation_slice_appendBuffer),
+            ("test_validateMutation_slice_appendSequence", test_validateMutation_slice_appendSequence),
+            ("test_validateMutation_slice_appendContentsOf", test_validateMutation_slice_appendContentsOf),
+            ("test_validateMutation_slice_resetBytes", test_validateMutation_slice_resetBytes),
+            ("test_validateMutation_slice_replaceSubrange", test_validateMutation_slice_replaceSubrange),
+            ("test_validateMutation_slice_replaceSubrangeCountableRange", test_validateMutation_slice_replaceSubrangeCountableRange),
+            ("test_validateMutation_slice_replaceSubrangeWithBuffer", test_validateMutation_slice_replaceSubrangeWithBuffer),
+            ("test_validateMutation_slice_replaceSubrangeWithCollection", test_validateMutation_slice_replaceSubrangeWithCollection),
+            ("test_validateMutation_slice_replaceSubrangeWithBytes", test_validateMutation_slice_replaceSubrangeWithBytes),
+            ("test_validateMutation_cow_withUnsafeMutableBytes", test_validateMutation_cow_withUnsafeMutableBytes),
+            ("test_validateMutation_cow_appendBytes", test_validateMutation_cow_appendBytes),
+            ("test_validateMutation_cow_appendData", test_validateMutation_cow_appendData),
+            ("test_validateMutation_cow_appendBuffer", test_validateMutation_cow_appendBuffer),
+            ("test_validateMutation_cow_appendSequence", test_validateMutation_cow_appendSequence),
+            ("test_validateMutation_cow_appendContentsOf", test_validateMutation_cow_appendContentsOf),
+            ("test_validateMutation_cow_resetBytes", test_validateMutation_cow_resetBytes),
+            ("test_validateMutation_cow_replaceSubrange", test_validateMutation_cow_replaceSubrange),
+            ("test_validateMutation_cow_replaceSubrangeCountableRange", test_validateMutation_cow_replaceSubrangeCountableRange),
+            ("test_validateMutation_cow_replaceSubrangeWithBuffer", test_validateMutation_cow_replaceSubrangeWithBuffer),
+            ("test_validateMutation_cow_replaceSubrangeWithCollection", test_validateMutation_cow_replaceSubrangeWithCollection),
+            ("test_validateMutation_cow_replaceSubrangeWithBytes", test_validateMutation_cow_replaceSubrangeWithBytes),
+            ("test_validateMutation_slice_cow_withUnsafeMutableBytes", test_validateMutation_slice_cow_withUnsafeMutableBytes),
+            ("test_validateMutation_slice_cow_appendBytes", test_validateMutation_slice_cow_appendBytes),
+            ("test_validateMutation_slice_cow_appendData", test_validateMutation_slice_cow_appendData),
+            ("test_validateMutation_slice_cow_appendBuffer", test_validateMutation_slice_cow_appendBuffer),
+            ("test_validateMutation_slice_cow_appendSequence", test_validateMutation_slice_cow_appendSequence),
+            ("test_validateMutation_slice_cow_appendContentsOf", test_validateMutation_slice_cow_appendContentsOf),
+            ("test_validateMutation_slice_cow_resetBytes", test_validateMutation_slice_cow_resetBytes),
+            ("test_validateMutation_slice_cow_replaceSubrange", test_validateMutation_slice_cow_replaceSubrange),
+            ("test_validateMutation_slice_cow_replaceSubrangeCountableRange", test_validateMutation_slice_cow_replaceSubrangeCountableRange),
+            ("test_validateMutation_slice_cow_replaceSubrangeWithBuffer", test_validateMutation_slice_cow_replaceSubrangeWithBuffer),
+            ("test_validateMutation_slice_cow_replaceSubrangeWithCollection", test_validateMutation_slice_cow_replaceSubrangeWithCollection),
+            ("test_validateMutation_slice_cow_replaceSubrangeWithBytes", test_validateMutation_slice_cow_replaceSubrangeWithBytes),
+            ("test_validateMutation_immutableBacking_withUnsafeMutableBytes", test_validateMutation_immutableBacking_withUnsafeMutableBytes),
+            ("test_validateMutation_immutableBacking_appendBytes", test_validateMutation_immutableBacking_appendBytes),
+            ("test_validateMutation_immutableBacking_appendData", test_validateMutation_immutableBacking_appendData),
+            ("test_validateMutation_immutableBacking_appendBuffer", test_validateMutation_immutableBacking_appendBuffer),
+            ("test_validateMutation_immutableBacking_appendSequence", test_validateMutation_immutableBacking_appendSequence),
+            ("test_validateMutation_immutableBacking_appendContentsOf", test_validateMutation_immutableBacking_appendContentsOf),
+            ("test_validateMutation_immutableBacking_resetBytes", test_validateMutation_immutableBacking_resetBytes),
+            ("test_validateMutation_immutableBacking_replaceSubrange", test_validateMutation_immutableBacking_replaceSubrange),
+            ("test_validateMutation_immutableBacking_replaceSubrangeCountableRange", test_validateMutation_immutableBacking_replaceSubrangeCountableRange),
+            ("test_validateMutation_immutableBacking_replaceSubrangeWithBuffer", test_validateMutation_immutableBacking_replaceSubrangeWithBuffer),
+            ("test_validateMutation_immutableBacking_replaceSubrangeWithCollection", test_validateMutation_immutableBacking_replaceSubrangeWithCollection),
+            ("test_validateMutation_immutableBacking_replaceSubrangeWithBytes", test_validateMutation_immutableBacking_replaceSubrangeWithBytes),
+            ("test_validateMutation_slice_immutableBacking_withUnsafeMutableBytes", test_validateMutation_slice_immutableBacking_withUnsafeMutableBytes),
+            ("test_validateMutation_slice_immutableBacking_appendBytes", test_validateMutation_slice_immutableBacking_appendBytes),
+            ("test_validateMutation_slice_immutableBacking_appendData", test_validateMutation_slice_immutableBacking_appendData),
+            ("test_validateMutation_slice_immutableBacking_appendBuffer", test_validateMutation_slice_immutableBacking_appendBuffer),
+            ("test_validateMutation_slice_immutableBacking_appendSequence", test_validateMutation_slice_immutableBacking_appendSequence),
+            ("test_validateMutation_slice_immutableBacking_appendContentsOf", test_validateMutation_slice_immutableBacking_appendContentsOf),
+            ("test_validateMutation_slice_immutableBacking_resetBytes", test_validateMutation_slice_immutableBacking_resetBytes),
+            ("test_validateMutation_slice_immutableBacking_replaceSubrange", test_validateMutation_slice_immutableBacking_replaceSubrange),
+            ("test_validateMutation_slice_immutableBacking_replaceSubrangeCountableRange", test_validateMutation_slice_immutableBacking_replaceSubrangeCountableRange),
+            ("test_validateMutation_slice_immutableBacking_replaceSubrangeWithBuffer", test_validateMutation_slice_immutableBacking_replaceSubrangeWithBuffer),
+            ("test_validateMutation_slice_immutableBacking_replaceSubrangeWithCollection", test_validateMutation_slice_immutableBacking_replaceSubrangeWithCollection),
+            ("test_validateMutation_slice_immutableBacking_replaceSubrangeWithBytes", test_validateMutation_slice_immutableBacking_replaceSubrangeWithBytes),
+            ("test_validateMutation_cow_immutableBacking_withUnsafeMutableBytes", test_validateMutation_cow_immutableBacking_withUnsafeMutableBytes),
+            ("test_validateMutation_cow_immutableBacking_appendBytes", test_validateMutation_cow_immutableBacking_appendBytes),
+            ("test_validateMutation_cow_immutableBacking_appendData", test_validateMutation_cow_immutableBacking_appendData),
+            ("test_validateMutation_cow_immutableBacking_appendBuffer", test_validateMutation_cow_immutableBacking_appendBuffer),
+            ("test_validateMutation_cow_immutableBacking_appendSequence", test_validateMutation_cow_immutableBacking_appendSequence),
+            ("test_validateMutation_cow_immutableBacking_appendContentsOf", test_validateMutation_cow_immutableBacking_appendContentsOf),
+            ("test_validateMutation_cow_immutableBacking_resetBytes", test_validateMutation_cow_immutableBacking_resetBytes),
+            ("test_validateMutation_cow_immutableBacking_replaceSubrange", test_validateMutation_cow_immutableBacking_replaceSubrange),
+            ("test_validateMutation_cow_immutableBacking_replaceSubrangeCountableRange", test_validateMutation_cow_immutableBacking_replaceSubrangeCountableRange),
+            ("test_validateMutation_cow_immutableBacking_replaceSubrangeWithBuffer", test_validateMutation_cow_immutableBacking_replaceSubrangeWithBuffer),
+            ("test_validateMutation_cow_immutableBacking_replaceSubrangeWithCollection", test_validateMutation_cow_immutableBacking_replaceSubrangeWithCollection),
+            ("test_validateMutation_cow_immutableBacking_replaceSubrangeWithBytes", test_validateMutation_cow_immutableBacking_replaceSubrangeWithBytes),
+            ("test_validateMutation_slice_cow_immutableBacking_withUnsafeMutableBytes", test_validateMutation_slice_cow_immutableBacking_withUnsafeMutableBytes),
+            ("test_validateMutation_slice_cow_immutableBacking_appendBytes", test_validateMutation_slice_cow_immutableBacking_appendBytes),
+            ("test_validateMutation_slice_cow_immutableBacking_appendData", test_validateMutation_slice_cow_immutableBacking_appendData),
+            ("test_validateMutation_slice_cow_immutableBacking_appendBuffer", test_validateMutation_slice_cow_immutableBacking_appendBuffer),
+            ("test_validateMutation_slice_cow_immutableBacking_appendSequence", test_validateMutation_slice_cow_immutableBacking_appendSequence),
+            ("test_validateMutation_slice_cow_immutableBacking_appendContentsOf", test_validateMutation_slice_cow_immutableBacking_appendContentsOf),
+            ("test_validateMutation_slice_cow_immutableBacking_resetBytes", test_validateMutation_slice_cow_immutableBacking_resetBytes),
+            ("test_validateMutation_slice_cow_immutableBacking_replaceSubrange", test_validateMutation_slice_cow_immutableBacking_replaceSubrange),
+            ("test_validateMutation_slice_cow_immutableBacking_replaceSubrangeCountableRange", test_validateMutation_slice_cow_immutableBacking_replaceSubrangeCountableRange),
+            ("test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithBuffer", test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithBuffer),
+            ("test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithCollection", test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithCollection),
+            ("test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithBytes", test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithBytes),
+            ("test_validateMutation_mutableBacking_withUnsafeMutableBytes", test_validateMutation_mutableBacking_withUnsafeMutableBytes),
+            ("test_validateMutation_mutableBacking_appendBytes", test_validateMutation_mutableBacking_appendBytes),
+            ("test_validateMutation_mutableBacking_appendData", test_validateMutation_mutableBacking_appendData),
+            ("test_validateMutation_mutableBacking_appendBuffer", test_validateMutation_mutableBacking_appendBuffer),
+            ("test_validateMutation_mutableBacking_appendSequence", test_validateMutation_mutableBacking_appendSequence),
+            ("test_validateMutation_mutableBacking_appendContentsOf", test_validateMutation_mutableBacking_appendContentsOf),
+            ("test_validateMutation_mutableBacking_resetBytes", test_validateMutation_mutableBacking_resetBytes),
+            ("test_validateMutation_mutableBacking_replaceSubrange", test_validateMutation_mutableBacking_replaceSubrange),
+            ("test_validateMutation_mutableBacking_replaceSubrangeCountableRange", test_validateMutation_mutableBacking_replaceSubrangeCountableRange),
+            ("test_validateMutation_mutableBacking_replaceSubrangeWithBuffer", test_validateMutation_mutableBacking_replaceSubrangeWithBuffer),
+            ("test_validateMutation_mutableBacking_replaceSubrangeWithCollection", test_validateMutation_mutableBacking_replaceSubrangeWithCollection),
+            ("test_validateMutation_mutableBacking_replaceSubrangeWithBytes", test_validateMutation_mutableBacking_replaceSubrangeWithBytes),
+            ("test_validateMutation_slice_mutableBacking_withUnsafeMutableBytes", test_validateMutation_slice_mutableBacking_withUnsafeMutableBytes),
+            ("test_validateMutation_slice_mutableBacking_appendBytes", test_validateMutation_slice_mutableBacking_appendBytes),
+            ("test_validateMutation_slice_mutableBacking_appendData", test_validateMutation_slice_mutableBacking_appendData),
+            ("test_validateMutation_slice_mutableBacking_appendBuffer", test_validateMutation_slice_mutableBacking_appendBuffer),
+            ("test_validateMutation_slice_mutableBacking_appendSequence", test_validateMutation_slice_mutableBacking_appendSequence),
+            ("test_validateMutation_slice_mutableBacking_appendContentsOf", test_validateMutation_slice_mutableBacking_appendContentsOf),
+            ("test_validateMutation_slice_mutableBacking_resetBytes", test_validateMutation_slice_mutableBacking_resetBytes),
+            ("test_validateMutation_slice_mutableBacking_replaceSubrange", test_validateMutation_slice_mutableBacking_replaceSubrange),
+            ("test_validateMutation_slice_mutableBacking_replaceSubrangeCountableRange", test_validateMutation_slice_mutableBacking_replaceSubrangeCountableRange),
+            ("test_validateMutation_slice_mutableBacking_replaceSubrangeWithBuffer", test_validateMutation_slice_mutableBacking_replaceSubrangeWithBuffer),
+            ("test_validateMutation_slice_mutableBacking_replaceSubrangeWithCollection", test_validateMutation_slice_mutableBacking_replaceSubrangeWithCollection),
+            ("test_validateMutation_slice_mutableBacking_replaceSubrangeWithBytes", test_validateMutation_slice_mutableBacking_replaceSubrangeWithBytes),
+            ("test_validateMutation_cow_mutableBacking_withUnsafeMutableBytes", test_validateMutation_cow_mutableBacking_withUnsafeMutableBytes),
+            ("test_validateMutation_cow_mutableBacking_appendBytes", test_validateMutation_cow_mutableBacking_appendBytes),
+            ("test_validateMutation_cow_mutableBacking_appendData", test_validateMutation_cow_mutableBacking_appendData),
+            ("test_validateMutation_cow_mutableBacking_appendBuffer", test_validateMutation_cow_mutableBacking_appendBuffer),
+            ("test_validateMutation_cow_mutableBacking_appendSequence", test_validateMutation_cow_mutableBacking_appendSequence),
+            ("test_validateMutation_cow_mutableBacking_appendContentsOf", test_validateMutation_cow_mutableBacking_appendContentsOf),
+            ("test_validateMutation_cow_mutableBacking_resetBytes", test_validateMutation_cow_mutableBacking_resetBytes),
+            ("test_validateMutation_cow_mutableBacking_replaceSubrange", test_validateMutation_cow_mutableBacking_replaceSubrange),
+            ("test_validateMutation_cow_mutableBacking_replaceSubrangeCountableRange", test_validateMutation_cow_mutableBacking_replaceSubrangeCountableRange),
+            ("test_validateMutation_cow_mutableBacking_replaceSubrangeWithBuffer", test_validateMutation_cow_mutableBacking_replaceSubrangeWithBuffer),
+            ("test_validateMutation_cow_mutableBacking_replaceSubrangeWithCollection", test_validateMutation_cow_mutableBacking_replaceSubrangeWithCollection),
+            ("test_validateMutation_cow_mutableBacking_replaceSubrangeWithBytes", test_validateMutation_cow_mutableBacking_replaceSubrangeWithBytes),
+            ("test_validateMutation_slice_cow_mutableBacking_withUnsafeMutableBytes", test_validateMutation_slice_cow_mutableBacking_withUnsafeMutableBytes),
+            ("test_validateMutation_slice_cow_mutableBacking_appendBytes", test_validateMutation_slice_cow_mutableBacking_appendBytes),
+            ("test_validateMutation_slice_cow_mutableBacking_appendData", test_validateMutation_slice_cow_mutableBacking_appendData),
+            ("test_validateMutation_slice_cow_mutableBacking_appendBuffer", test_validateMutation_slice_cow_mutableBacking_appendBuffer),
+            ("test_validateMutation_slice_cow_mutableBacking_appendSequence", test_validateMutation_slice_cow_mutableBacking_appendSequence),
+            ("test_validateMutation_slice_cow_mutableBacking_appendContentsOf", test_validateMutation_slice_cow_mutableBacking_appendContentsOf),
+            ("test_validateMutation_slice_cow_mutableBacking_resetBytes", test_validateMutation_slice_cow_mutableBacking_resetBytes),
+            ("test_validateMutation_slice_cow_mutableBacking_replaceSubrange", test_validateMutation_slice_cow_mutableBacking_replaceSubrange),
+            ("test_validateMutation_slice_cow_mutableBacking_replaceSubrangeCountableRange", test_validateMutation_slice_cow_mutableBacking_replaceSubrangeCountableRange),
+            ("test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithBuffer", test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithBuffer),
+            ("test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithCollection", test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithCollection),
+            ("test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithBytes", test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithBytes),
+            ("test_validateMutation_customBacking_withUnsafeMutableBytes", test_validateMutation_customBacking_withUnsafeMutableBytes),
+//            ("test_validateMutation_customBacking_appendBytes", test_validateMutation_customBacking_appendBytes),
+//            ("test_validateMutation_customBacking_appendData", test_validateMutation_customBacking_appendData),
+//            ("test_validateMutation_customBacking_appendBuffer", test_validateMutation_customBacking_appendBuffer),
+//            ("test_validateMutation_customBacking_appendSequence", test_validateMutation_customBacking_appendSequence),
+//            ("test_validateMutation_customBacking_appendContentsOf", test_validateMutation_customBacking_appendContentsOf),
+//            ("test_validateMutation_customBacking_resetBytes", test_validateMutation_customBacking_resetBytes),
+//            ("test_validateMutation_customBacking_replaceSubrange", test_validateMutation_customBacking_replaceSubrange),
+//            ("test_validateMutation_customBacking_replaceSubrangeCountableRange", test_validateMutation_customBacking_replaceSubrangeCountableRange),
+//            ("test_validateMutation_customBacking_replaceSubrangeWithBuffer", test_validateMutation_customBacking_replaceSubrangeWithBuffer),
+//            ("test_validateMutation_customBacking_replaceSubrangeWithCollection", test_validateMutation_customBacking_replaceSubrangeWithCollection),
+//            ("test_validateMutation_customBacking_replaceSubrangeWithBytes", test_validateMutation_customBacking_replaceSubrangeWithBytes),
+//            ("test_validateMutation_slice_customBacking_withUnsafeMutableBytes", test_validateMutation_slice_customBacking_withUnsafeMutableBytes),
+//            ("test_validateMutation_slice_customBacking_appendBytes", test_validateMutation_slice_customBacking_appendBytes),
+//            ("test_validateMutation_slice_customBacking_appendData", test_validateMutation_slice_customBacking_appendData),
+//            ("test_validateMutation_slice_customBacking_appendBuffer", test_validateMutation_slice_customBacking_appendBuffer),
+//            ("test_validateMutation_slice_customBacking_appendSequence", test_validateMutation_slice_customBacking_appendSequence),
+//            ("test_validateMutation_slice_customBacking_appendContentsOf", test_validateMutation_slice_customBacking_appendContentsOf),
+//            ("test_validateMutation_slice_customBacking_resetBytes", test_validateMutation_slice_customBacking_resetBytes),
+//            ("test_validateMutation_slice_customBacking_replaceSubrange", test_validateMutation_slice_customBacking_replaceSubrange),
+//            ("test_validateMutation_slice_customBacking_replaceSubrangeCountableRange", test_validateMutation_slice_customBacking_replaceSubrangeCountableRange),
+//            ("test_validateMutation_slice_customBacking_replaceSubrangeWithBuffer", test_validateMutation_slice_customBacking_replaceSubrangeWithBuffer),
+//            ("test_validateMutation_slice_customBacking_replaceSubrangeWithCollection", test_validateMutation_slice_customBacking_replaceSubrangeWithCollection),
+//            ("test_validateMutation_slice_customBacking_replaceSubrangeWithBytes", test_validateMutation_slice_customBacking_replaceSubrangeWithBytes),
+//            ("test_validateMutation_cow_customBacking_withUnsafeMutableBytes", test_validateMutation_cow_customBacking_withUnsafeMutableBytes),
+//            ("test_validateMutation_cow_customBacking_appendBytes", test_validateMutation_cow_customBacking_appendBytes),
+//            ("test_validateMutation_cow_customBacking_appendData", test_validateMutation_cow_customBacking_appendData),
+//            ("test_validateMutation_cow_customBacking_appendBuffer", test_validateMutation_cow_customBacking_appendBuffer),
+//            ("test_validateMutation_cow_customBacking_appendSequence", test_validateMutation_cow_customBacking_appendSequence),
+//            ("test_validateMutation_cow_customBacking_appendContentsOf", test_validateMutation_cow_customBacking_appendContentsOf),
+//            ("test_validateMutation_cow_customBacking_resetBytes", test_validateMutation_cow_customBacking_resetBytes),
+//            ("test_validateMutation_cow_customBacking_replaceSubrange", test_validateMutation_cow_customBacking_replaceSubrange),
+//            ("test_validateMutation_cow_customBacking_replaceSubrangeCountableRange", test_validateMutation_cow_customBacking_replaceSubrangeCountableRange),
+//            ("test_validateMutation_cow_customBacking_replaceSubrangeWithBuffer", test_validateMutation_cow_customBacking_replaceSubrangeWithBuffer),
+//            ("test_validateMutation_cow_customBacking_replaceSubrangeWithCollection", test_validateMutation_cow_customBacking_replaceSubrangeWithCollection),
+//            ("test_validateMutation_cow_customBacking_replaceSubrangeWithBytes", test_validateMutation_cow_customBacking_replaceSubrangeWithBytes),
+//            ("test_validateMutation_slice_cow_customBacking_withUnsafeMutableBytes", test_validateMutation_slice_cow_customBacking_withUnsafeMutableBytes),
+//            ("test_validateMutation_slice_cow_customBacking_appendBytes", test_validateMutation_slice_cow_customBacking_appendBytes),
+//            ("test_validateMutation_slice_cow_customBacking_appendData", test_validateMutation_slice_cow_customBacking_appendData),
+//            ("test_validateMutation_slice_cow_customBacking_appendBuffer", test_validateMutation_slice_cow_customBacking_appendBuffer),
+//            ("test_validateMutation_slice_cow_customBacking_appendSequence", test_validateMutation_slice_cow_customBacking_appendSequence),
+//            ("test_validateMutation_slice_cow_customBacking_appendContentsOf", test_validateMutation_slice_cow_customBacking_appendContentsOf),
+//            ("test_validateMutation_slice_cow_customBacking_resetBytes", test_validateMutation_slice_cow_customBacking_resetBytes),
+//            ("test_validateMutation_slice_cow_customBacking_replaceSubrange", test_validateMutation_slice_cow_customBacking_replaceSubrange),
+//            ("test_validateMutation_slice_cow_customBacking_replaceSubrangeCountableRange", test_validateMutation_slice_cow_customBacking_replaceSubrangeCountableRange),
+//            ("test_validateMutation_slice_cow_customBacking_replaceSubrangeWithBuffer", test_validateMutation_slice_cow_customBacking_replaceSubrangeWithBuffer),
+//            ("test_validateMutation_slice_cow_customBacking_replaceSubrangeWithCollection", test_validateMutation_slice_cow_customBacking_replaceSubrangeWithCollection),
+//            ("test_validateMutation_slice_cow_customBacking_replaceSubrangeWithBytes", test_validateMutation_slice_cow_customBacking_replaceSubrangeWithBytes),
+//            ("test_validateMutation_customMutableBacking_withUnsafeMutableBytes", test_validateMutation_customMutableBacking_withUnsafeMutableBytes),
+//            ("test_validateMutation_customMutableBacking_appendBytes", test_validateMutation_customMutableBacking_appendBytes),
+//            ("test_validateMutation_customMutableBacking_appendData", test_validateMutation_customMutableBacking_appendData),
+//            ("test_validateMutation_customMutableBacking_appendBuffer", test_validateMutation_customMutableBacking_appendBuffer),
+//            ("test_validateMutation_customMutableBacking_appendSequence", test_validateMutation_customMutableBacking_appendSequence),
+//            ("test_validateMutation_customMutableBacking_appendContentsOf", test_validateMutation_customMutableBacking_appendContentsOf),
+//            ("test_validateMutation_customMutableBacking_resetBytes", test_validateMutation_customMutableBacking_resetBytes),
+//            ("test_validateMutation_customMutableBacking_replaceSubrange", test_validateMutation_customMutableBacking_replaceSubrange),
+//            ("test_validateMutation_customMutableBacking_replaceSubrangeCountableRange", test_validateMutation_customMutableBacking_replaceSubrangeCountableRange),
+//            ("test_validateMutation_customMutableBacking_replaceSubrangeWithBuffer", test_validateMutation_customMutableBacking_replaceSubrangeWithBuffer),
+//            ("test_validateMutation_customMutableBacking_replaceSubrangeWithCollection", test_validateMutation_customMutableBacking_replaceSubrangeWithCollection),
+//            ("test_validateMutation_customMutableBacking_replaceSubrangeWithBytes", test_validateMutation_customMutableBacking_replaceSubrangeWithBytes),
+//            ("test_validateMutation_slice_customMutableBacking_withUnsafeMutableBytes", test_validateMutation_slice_customMutableBacking_withUnsafeMutableBytes),
+//            ("test_validateMutation_slice_customMutableBacking_appendBytes", test_validateMutation_slice_customMutableBacking_appendBytes),
+//            ("test_validateMutation_slice_customMutableBacking_appendData", test_validateMutation_slice_customMutableBacking_appendData),
+//            ("test_validateMutation_slice_customMutableBacking_appendBuffer", test_validateMutation_slice_customMutableBacking_appendBuffer),
+//            ("test_validateMutation_slice_customMutableBacking_appendSequence", test_validateMutation_slice_customMutableBacking_appendSequence),
+//            ("test_validateMutation_slice_customMutableBacking_appendContentsOf", test_validateMutation_slice_customMutableBacking_appendContentsOf),
+//            ("test_validateMutation_slice_customMutableBacking_resetBytes", test_validateMutation_slice_customMutableBacking_resetBytes),
+//            ("test_validateMutation_slice_customMutableBacking_replaceSubrange", test_validateMutation_slice_customMutableBacking_replaceSubrange),
+//            ("test_validateMutation_slice_customMutableBacking_replaceSubrangeCountableRange", test_validateMutation_slice_customMutableBacking_replaceSubrangeCountableRange),
+//            ("test_validateMutation_slice_customMutableBacking_replaceSubrangeWithBuffer", test_validateMutation_slice_customMutableBacking_replaceSubrangeWithBuffer),
+//            ("test_validateMutation_slice_customMutableBacking_replaceSubrangeWithCollection", test_validateMutation_slice_customMutableBacking_replaceSubrangeWithCollection),
+//            ("test_validateMutation_slice_customMutableBacking_replaceSubrangeWithBytes", test_validateMutation_slice_customMutableBacking_replaceSubrangeWithBytes),
+//            ("test_validateMutation_cow_customMutableBacking_withUnsafeMutableBytes", test_validateMutation_cow_customMutableBacking_withUnsafeMutableBytes),
+//            ("test_validateMutation_cow_customMutableBacking_appendBytes", test_validateMutation_cow_customMutableBacking_appendBytes),
+//            ("test_validateMutation_cow_customMutableBacking_appendData", test_validateMutation_cow_customMutableBacking_appendData),
+//            ("test_validateMutation_cow_customMutableBacking_appendBuffer", test_validateMutation_cow_customMutableBacking_appendBuffer),
+//            ("test_validateMutation_cow_customMutableBacking_appendSequence", test_validateMutation_cow_customMutableBacking_appendSequence),
+//            ("test_validateMutation_cow_customMutableBacking_appendContentsOf", test_validateMutation_cow_customMutableBacking_appendContentsOf),
+//            ("test_validateMutation_cow_customMutableBacking_resetBytes", test_validateMutation_cow_customMutableBacking_resetBytes),
+//            ("test_validateMutation_cow_customMutableBacking_replaceSubrange", test_validateMutation_cow_customMutableBacking_replaceSubrange),
+//            ("test_validateMutation_cow_customMutableBacking_replaceSubrangeCountableRange", test_validateMutation_cow_customMutableBacking_replaceSubrangeCountableRange),
+//            ("test_validateMutation_cow_customMutableBacking_replaceSubrangeWithBuffer", test_validateMutation_cow_customMutableBacking_replaceSubrangeWithBuffer),
+//            ("test_validateMutation_cow_customMutableBacking_replaceSubrangeWithCollection", test_validateMutation_cow_customMutableBacking_replaceSubrangeWithCollection),
+//            ("test_validateMutation_cow_customMutableBacking_replaceSubrangeWithBytes", test_validateMutation_cow_customMutableBacking_replaceSubrangeWithBytes),
+//            ("test_validateMutation_slice_cow_customMutableBacking_withUnsafeMutableBytes", test_validateMutation_slice_cow_customMutableBacking_withUnsafeMutableBytes),
+//            ("test_validateMutation_slice_cow_customMutableBacking_appendBytes", test_validateMutation_slice_cow_customMutableBacking_appendBytes),
+//            ("test_validateMutation_slice_cow_customMutableBacking_appendData", test_validateMutation_slice_cow_customMutableBacking_appendData),
+//            ("test_validateMutation_slice_cow_customMutableBacking_appendBuffer", test_validateMutation_slice_cow_customMutableBacking_appendBuffer),
+//            ("test_validateMutation_slice_cow_customMutableBacking_appendSequence", test_validateMutation_slice_cow_customMutableBacking_appendSequence),
+//            ("test_validateMutation_slice_cow_customMutableBacking_appendContentsOf", test_validateMutation_slice_cow_customMutableBacking_appendContentsOf),
+//            ("test_validateMutation_slice_cow_customMutableBacking_resetBytes", test_validateMutation_slice_cow_customMutableBacking_resetBytes),
+//            ("test_validateMutation_slice_cow_customMutableBacking_replaceSubrange", test_validateMutation_slice_cow_customMutableBacking_replaceSubrange),
+//            ("test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeCountableRange", test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeCountableRange),
+//            ("test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithBuffer", test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithBuffer),
+//            ("test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithCollection", test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithCollection),
+//            ("test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithBytes", test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithBytes),
+            ("test_sliceHash", test_sliceHash),
+            ("test_slice_resize_growth", test_slice_resize_growth),
+//            ("test_sliceEnumeration", test_sliceEnumeration),
         ]
     }
     
@@ -1164,5 +1572,2385 @@ extension TestNSData {
         XCTAssertEqual(found[0], 2)
         XCTAssertEqual(found[1], 3)
     }
+
+        func test_validateMutation_withUnsafeMutableBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 5).pointee = 0xFF
+        }
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 0xFF, 6, 7, 8, 9]))
+    }
+    
+    func test_validateMutation_appendBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        data.append("hello", count: 5)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0x5)
+    }
+    
+    func test_validateMutation_appendData() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let other = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        data.append(other)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 9)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0)
+    }
+    
+    func test_validateMutation_appendBuffer() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 9)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0)
+    }
+    
+    func test_validateMutation_appendSequence() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let seq = repeatElement(UInt8(1), count: 10)
+        data.append(contentsOf: seq)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 9)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 1)
+    }
+    
+    func test_validateMutation_appendContentsOf() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        data.append(contentsOf: bytes)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 9)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0)
+    }
+    
+    func test_validateMutation_resetBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 0, 0, 0, 8, 9]))
+    }
+    
+    func test_validateMutation_replaceSubrange() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let replacement = Data(bytes: [0xFF, 0xFF])
+        data.replaceSubrange(range, with: replacement)
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_replaceSubrangeCountableRange() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let replacement = Data(bytes: [0xFF, 0xFF])
+        data.replaceSubrange(range, with: replacement)
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_replaceSubrangeWithBuffer() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer {
+            data.replaceSubrange(range, with: $0)
+        }
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_replaceSubrangeWithCollection() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        data.replaceSubrange(range, with: bytes)
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_replaceSubrangeWithBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBytes {
+            data.replaceSubrange(range, with: $0.baseAddress!, count: 2)
+        }
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_slice_withUnsafeMutableBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 1).pointee = 0xFF
+        }
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 6, 7, 8]))
+    }
+    
+    func test_validateMutation_slice_appendBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_appendData() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let other = Data(bytes: [0xFF, 0xFF])
+        data.append(other)
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_appendBuffer() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_appendSequence() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let seq = repeatElement(UInt8(0xFF), count: 2)
+        data.append(contentsOf: seq)
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_appendContentsOf() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        data.append(contentsOf: bytes)
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_resetBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data, Data(bytes: [4, 0, 0, 0, 8]))
+    }
+    
+    func test_validateMutation_slice_replaceSubrange() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let replacement = Data(bytes: [0xFF, 0xFF])
+        data.replaceSubrange(range, with: replacement)
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_slice_replaceSubrangeCountableRange() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let replacement = Data(bytes: [0xFF, 0xFF])
+        data.replaceSubrange(range, with: replacement)
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_slice_replaceSubrangeWithBuffer() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer {
+            data.replaceSubrange(range, with: $0)
+        }
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_slice_replaceSubrangeWithCollection() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        data.replaceSubrange(range, with: bytes)
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_slice_replaceSubrangeWithBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBytes {
+            data.replaceSubrange(range, with: $0.baseAddress!, count: 2)
+        }
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_cow_withUnsafeMutableBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 5).pointee = 0xFF
+            }
+            XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 0xFF, 6, 7, 8, 9]))
+        }
+    }
+    
+    func test_validateMutation_cow_appendBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            data.append("hello", count: 5)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 0x9)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x68)
+        }
+    }
+    
+    func test_validateMutation_cow_appendData() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let other = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+            data.append(other)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 9)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0)
+        }
+    }
+    
+    func test_validateMutation_cow_appendBuffer() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+            bytes.withUnsafeBufferPointer { data.append($0) }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 9)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0)
+        }
+    }
+    
+    func test_validateMutation_cow_appendSequence() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let seq = repeatElement(UInt8(1), count: 10)
+            data.append(contentsOf: seq)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 9)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 1)
+        }
+    }
+    
+    func test_validateMutation_cow_appendContentsOf() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+            data.append(contentsOf: bytes)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 9)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0)
+        }
+    }
+    
+    func test_validateMutation_cow_resetBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 0, 0, 0, 8, 9]))
+        }
+    }
+    
+    func test_validateMutation_cow_replaceSubrange() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let replacement = Data(bytes: [0xFF, 0xFF])
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+        }
+    }
+    
+    func test_validateMutation_cow_replaceSubrangeCountableRange() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let replacement = Data(bytes: [0xFF, 0xFF])
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+        }
+    }
+    
+    func test_validateMutation_cow_replaceSubrangeWithBuffer() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer {
+                data.replaceSubrange(range, with: $0)
+            }
+            XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+        }
+    }
+    
+    func test_validateMutation_cow_replaceSubrangeWithCollection() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            data.replaceSubrange(range, with: bytes)
+            XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+        }
+    }
+    
+    func test_validateMutation_cow_replaceSubrangeWithBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBytes {
+                data.replaceSubrange(range, with: $0.baseAddress!, count: 2)
+            }
+            XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_withUnsafeMutableBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 1).pointee = 0xFF
+            }
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 6, 7, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_appendBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            data.append("hello", count: 5)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 4)], 0x8)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0x68)
+        }
+    }
+    
+    func test_validateMutation_slice_cow_appendData() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let other = Data(bytes: [0xFF, 0xFF])
+            data.append(other)
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_appendBuffer() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.append($0) }
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_appendSequence() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let seq = repeatElement(UInt8(0xFF), count: 2)
+            data.append(contentsOf: seq)
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_appendContentsOf() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            data.append(contentsOf: bytes)
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_resetBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data, Data(bytes: [4, 0, 0, 0, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_replaceSubrange() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let replacement = Data(bytes: [0xFF, 0xFF])
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_replaceSubrangeCountableRange() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let replacement = Data(bytes: [0xFF, 0xFF])
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_replaceSubrangeWithBuffer() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer {
+                data.replaceSubrange(range, with: $0)
+            }
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_replaceSubrangeWithCollection() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            data.replaceSubrange(range, with: bytes)
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_replaceSubrangeWithBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBytes {
+                data.replaceSubrange(range, with: $0.baseAddress!, count: 2)
+            }
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_immutableBacking_withUnsafeMutableBytes() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 5).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0xFF)
+    }
+    
+    func test_validateMutation_immutableBacking_appendBytes() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        data.append("hello", count: 5)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 0x68)
+    }
+    
+    func test_validateMutation_immutableBacking_appendData() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        let other = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        data.append(other)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 0)
+    }
+    
+    func test_validateMutation_immutableBacking_appendBuffer() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 0)
+    }
+    
+    func test_validateMutation_immutableBacking_appendSequence() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        let seq = repeatElement(UInt8(1), count: 10)
+        data.append(contentsOf: seq)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 1)
+    }
+    
+    func test_validateMutation_immutableBacking_appendContentsOf() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        data.append(contentsOf: bytes)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 0)
+    }
+    
+    func test_validateMutation_immutableBacking_resetBytes() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x00, 0x00, 0x00, 0x72, 0x6c, 0x64]))
+    }
+    
+    func test_validateMutation_immutableBacking_replaceSubrange() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let replacement = Data(bytes: [0xFF, 0xFF])
+        data.replaceSubrange(range, with: replacement)
+        XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xFF, 0xFF, 0x6c, 0x64]))
+    }
+    
+    func test_validateMutation_immutableBacking_replaceSubrangeCountableRange() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let replacement = Data(bytes: [0xFF, 0xFF])
+        data.replaceSubrange(range, with: replacement)
+        XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xFF, 0xFF, 0x6c, 0x64]))
+    }
+    
+    func test_validateMutation_immutableBacking_replaceSubrangeWithBuffer() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer {
+            data.replaceSubrange(range, with: $0)
+        }
+        XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xFF, 0xFF, 0x6c, 0x64]))
+    }
+    
+    func test_validateMutation_immutableBacking_replaceSubrangeWithCollection() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        data.replaceSubrange(range, with: bytes)
+        XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xFF, 0xFF, 0x6c, 0x64]))
+    }
+    
+    func test_validateMutation_immutableBacking_replaceSubrangeWithBytes() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        data.replaceSubrange(range, with: bytes)
+        XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xFF, 0xFF, 0x6c, 0x64]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_withUnsafeMutableBytes() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))[4..<9]
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 1).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+    }
+    
+    func test_validateMutation_slice_immutableBacking_appendBytes() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_appendData() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        data.append(Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_appendBuffer() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_appendSequence() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        data.append(contentsOf: repeatElement(UInt8(0xFF), count: 2))
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_appendContentsOf() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        data.append(contentsOf: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_resetBytes() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data, Data(bytes: [4, 0, 0, 0, 8]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_replaceSubrange() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_replaceSubrangeCountableRange() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_replaceSubrangeWithBuffer() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        let replacement: [UInt8] = [0xFF, 0xFF]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        replacement.withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<UInt8>) in
+            data.replaceSubrange(range, with: buffer)
+        }
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_replaceSubrangeWithCollection() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let replacement: [UInt8] = [0xFF, 0xFF]
+        data.replaceSubrange(range, with:replacement)
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_replaceSubrangeWithBytes() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        let replacement: [UInt8] = [0xFF, 0xFF]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        replacement.withUnsafeBytes {
+            data.replaceSubrange(range, with: $0.baseAddress!, count: 2)
+        }
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_cow_immutableBacking_withUnsafeMutableBytes() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 5).pointee = 0xFF
+            }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0xFF)
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_appendBytes() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        holdReference(data) {
+            data.append("hello", count: 5)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 0x68)
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_appendData() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        holdReference(data) {
+            let other = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+            data.append(other)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 0)
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_appendBuffer() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        holdReference(data) {
+            let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+            bytes.withUnsafeBufferPointer { data.append($0) }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 0)
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_appendSequence() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        holdReference(data) {
+            let seq = repeatElement(UInt8(1), count: 10)
+            data.append(contentsOf: seq)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 1)
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_appendContentsOf() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        holdReference(data) {
+            let bytes: [UInt8] = [1, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+            data.append(contentsOf: bytes)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 1)
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_resetBytes() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x00, 0x00, 0x00, 0x72, 0x6c, 0x64]))
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_replaceSubrange() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let replacement = Data(bytes: [0xFF, 0xFF])
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xff, 0xff, 0x6c, 0x64]))
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_replaceSubrangeCountableRange() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        holdReference(data) {
+            let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let replacement = Data(bytes: [0xFF, 0xFF])
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xff, 0xff, 0x6c, 0x64]))
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_replaceSubrangeWithBuffer() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        holdReference(data) {
+            let replacement: [UInt8] = [0xFF, 0xFF]
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            replacement.withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<UInt8>) in
+                data.replaceSubrange(range, with: buffer)
+            }
+            XCTAssertEqual(data, Data(bytes: [0x68, 0xff, 0xff, 0x64]))
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_replaceSubrangeWithCollection() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        holdReference(data) {
+            let replacement: [UInt8] = [0xFF, 0xFF]
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [0x68, 0xff, 0xff, 0x64]))
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_replaceSubrangeWithBytes() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        holdReference(data) {
+            let replacement: [UInt8] = [0xFF, 0xFF]
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            replacement.withUnsafeBytes {
+                data.replaceSubrange(range, with: $0.baseAddress!, count: 2)
+            }
+            XCTAssertEqual(data, Data(bytes: [0x68, 0xff, 0xff, 0x64]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_withUnsafeMutableBytes() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))[4..<9]
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 1).pointee = 0xFF
+            }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_appendBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_appendData() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        holdReference(data) {
+            data.append(Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_appendBuffer() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer{ data.append($0) }
+            XCTAssertEqual(data, Data(bytes: [0x6f, 0x20, 0x77, 0x6f, 0x72, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_appendSequence() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        holdReference(data) {
+            let bytes = repeatElement(UInt8(0xFF), count: 2)
+            data.append(contentsOf: bytes)
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_appendContentsOf() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            data.append(contentsOf: bytes)
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_resetBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data, Data(bytes: [4, 0, 0, 0, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_replaceSubrange() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_replaceSubrangeCountableRange() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        holdReference(data) {
+            let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithBuffer() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0) }
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithCollection() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            data.replaceSubrange(range, with: bytes)
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))[4..<9]
+        }
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBytes { data.replaceSubrange(range, with: $0.baseAddress!, count: 2) }
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_mutableBacking_withUnsafeMutableBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        data.append(contentsOf: [7, 8, 9])
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 5).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0xFF)
+    }
+    
+    func test_validateMutation_mutableBacking_appendBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        data.append(contentsOf: [7, 8, 9])
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_mutableBacking_appendData() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        data.append(contentsOf: [7, 8, 9])
+        data.append(Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_mutableBacking_appendBuffer() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        data.append(contentsOf: [7, 8, 9])
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_mutableBacking_appendSequence() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        data.append(contentsOf: [7, 8, 9])
+        data.append(contentsOf: repeatElement(UInt8(0xFF), count: 2))
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_mutableBacking_appendContentsOf() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        data.append(contentsOf: [7, 8, 9])
+        data.append(contentsOf: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_mutableBacking_resetBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        data.append(contentsOf: [7, 8, 9])
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 0, 0, 0, 8, 9]))
+    }
+    
+    func test_validateMutation_mutableBacking_replaceSubrange() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        data.append(contentsOf: [7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let replacement = Data(bytes: [0xFF, 0xFF])
+        data.replaceSubrange(range, with: replacement)
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_mutableBacking_replaceSubrangeCountableRange() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        data.append(contentsOf: [7, 8, 9])
+        let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let replacement = Data(bytes: [0xFF, 0xFF])
+        data.replaceSubrange(range, with: replacement)
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_mutableBacking_replaceSubrangeWithBuffer() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        data.append(contentsOf: [7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer {
+            data.replaceSubrange(range, with: $0)
+        }
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_mutableBacking_replaceSubrangeWithCollection() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        data.append(contentsOf: [7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_mutableBacking_replaceSubrangeWithBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        data.append(contentsOf: [7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBytes {
+            data.replaceSubrange(range, with: $0.baseAddress!, count: $0.count)
+        }
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_withUnsafeMutableBytes() {
+        var base = Data(referencing: NSData(bytes: "hello world", length: 11))
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 1).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+    }
+    
+    func test_validateMutation_slice_mutableBacking_appendBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_appendData() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        data.append(Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_appendBuffer() {
+        var base = Data(referencing: NSData(bytes: "hello world", length: 11))
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        let bytes: [UInt8] = [1, 2, 3]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data, Data(bytes: [0x6f, 0x20, 0x77, 0x6f, 0x72, 0x1, 0x2, 0x3]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_appendSequence() {
+        var base = Data(referencing: NSData(bytes: "hello world", length: 11))
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        let seq = repeatElement(UInt8(1), count: 3)
+        data.append(contentsOf: seq)
+        XCTAssertEqual(data, Data(bytes: [0x6f, 0x20, 0x77, 0x6f, 0x72, 0x1, 0x1, 0x1]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_appendContentsOf() {
+        var base = Data(referencing: NSData(bytes: "hello world", length: 11))
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        let bytes: [UInt8] = [1, 2, 3]
+        data.append(contentsOf: bytes)
+        XCTAssertEqual(data, Data(bytes: [0x6f, 0x20, 0x77, 0x6f, 0x72, 0x1, 0x2, 0x3]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_resetBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data, Data(bytes: [4, 0, 0, 0, 8]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_replaceSubrange() {
+        var base = Data(referencing: NSData(bytes: "hello world", length: 11))
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [0x6f, 0xFF, 0xFF, 0x72]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_replaceSubrangeCountableRange() {
+        var base = Data(referencing: NSData(bytes: "hello world", length: 11))
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [0x6f, 0xFF, 0xFF, 0x72]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_replaceSubrangeWithBuffer() {
+        var base = Data(referencing: NSData(bytes: "hello world", length: 11))
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        let replacement: [UInt8] = [0xFF, 0xFF]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        replacement.withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<UInt8>) in
+            data.replaceSubrange(range, with: buffer)
+        }
+        XCTAssertEqual(data, Data(bytes: [0x6f, 0xFF, 0xFF, 0x72]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_replaceSubrangeWithCollection() {
+        var base = Data(referencing: NSData(bytes: "hello world", length: 11))
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let replacement: [UInt8] = [0xFF, 0xFF]
+        data.replaceSubrange(range, with:replacement)
+        XCTAssertEqual(data, Data(bytes: [0x6f, 0xFF, 0xFF, 0x72]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_replaceSubrangeWithBytes() {
+        var base = Data(referencing: NSData(bytes: "hello world", length: 11))
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        let replacement: [UInt8] = [0xFF, 0xFF]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        replacement.withUnsafeBytes {
+            data.replaceSubrange(range, with: $0.baseAddress!, count: 2)
+        }
+        XCTAssertEqual(data, Data(bytes: [0x6f, 0xFF, 0xFF, 0x72]))
+    }
+    
+    func test_validateMutation_cow_mutableBacking_withUnsafeMutableBytes() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 5).pointee = 0xFF
+            }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0xFF)
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_appendBytes() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            data.append("hello", count: 5)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 16)], 6)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 17)], 0x68)
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_appendData() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            data.append("hello", count: 5)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 16)], 6)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 17)], 0x68)
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_appendBuffer() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            let other = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+            data.append(other)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 16)], 6)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 17)], 0)
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_appendSequence() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            let seq = repeatElement(UInt8(1), count: 10)
+            data.append(contentsOf: seq)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 16)], 6)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 17)], 1)
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_appendContentsOf() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            let bytes: [UInt8] = [1, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+            data.append(contentsOf: bytes)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 16)], 6)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 17)], 1)
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_resetBytes() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x00, 0x00, 0x00, 0x72, 0x6c, 0x64, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]))
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_replaceSubrange() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let replacement = Data(bytes: [0xFF, 0xFF])
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xff, 0xff, 0x6c, 0x64, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]))
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_replaceSubrangeCountableRange() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let replacement = Data(bytes: [0xFF, 0xFF])
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xff, 0xff, 0x6c, 0x64, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]))
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_replaceSubrangeWithBuffer() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let replacement: [UInt8] = [0xFF, 0xFF]
+            replacement.withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<UInt8>) in
+                data.replaceSubrange(range, with: buffer)
+            }
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xff, 0xff, 0x6c, 0x64, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]))
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_replaceSubrangeWithCollection() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            let replacement: [UInt8] = [0xFF, 0xFF]
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xff, 0xff, 0x6c, 0x64, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]))
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_replaceSubrangeWithBytes() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            let replacement: [UInt8] = [0xFF, 0xFF]
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            replacement.withUnsafeBytes {
+                data.replaceSubrange(range, with: $0.baseAddress!, count: 2)
+            }
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xff, 0xff, 0x6c, 0x64, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_withUnsafeMutableBytes() {
+        var base = Data(referencing: NSData(bytes: "hello world", length: 11))
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 1).pointee = 0xFF
+            }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_appendBytes() {
+        let bytes: [UInt8] = [0, 1, 2]
+        var base = bytes.withUnsafeBytes { (ptr) in
+            return Data(referencing: NSData(bytes: ptr.baseAddress!, length: ptr.count))
+        }
+        base.append(contentsOf: [3, 4, 5])
+        var data = base[1..<4]
+        holdReference(data) {
+            let bytesToAppend: [UInt8] = [6, 7, 8]
+            bytesToAppend.withUnsafeBytes { (ptr) in
+                data.append(ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), count: ptr.count)
+            }
+            XCTAssertEqual(data, Data(bytes: [1, 2, 3, 6, 7, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_appendData() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            data.append(Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_appendBuffer() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer{ data.append($0) }
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_appendSequence() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            let bytes = repeatElement(UInt8(0xFF), count: 2)
+            data.append(contentsOf: bytes)
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_appendContentsOf() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            data.append(contentsOf: bytes)
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_resetBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data, Data(bytes: [4, 0, 0, 0, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_replaceSubrange() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_replaceSubrangeCountableRange() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: CountableRange<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithBuffer() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0) }
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithCollection() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            data.replaceSubrange(range, with: bytes)
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return Data(referencing: NSData(bytes: $0.baseAddress!, length: $0.count))
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBytes { data.replaceSubrange(range, with: $0.baseAddress!, count: 2) }
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_customBacking_withUnsafeMutableBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 5).pointee = 0xFF
+        }
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 1, 1, 1, 1]))
+    }
+    
+#if false // this requires factory patterns
+    func test_validateMutation_customBacking_appendBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customBacking_appendData() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        data.append(Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customBacking_appendBuffer() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { (buffer) in
+            data.append(buffer)
+        }
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        
+    }
+    
+    func test_validateMutation_customBacking_appendSequence() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        data.append(contentsOf: repeatElement(UInt8(0xFF), count: 2))
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customBacking_appendContentsOf() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        data.append(contentsOf: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customBacking_resetBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0, 0, 0, 1, 1]))
+    }
+    
+    func test_validateMutation_customBacking_replaceSubrange() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        let range: Range<Int> = 1..<4
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1, 1, 1, 1, 1, 1]))
+    }
+    
+    func test_validateMutation_customBacking_replaceSubrangeCountableRange() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        let range: CountableRange<Int> = 1..<4
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1, 1, 1, 1, 1, 1]))
+    }
+    
+    func test_validateMutation_customBacking_replaceSubrangeWithBuffer() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        let range: Range<Int> = 1..<4
+        bytes.withUnsafeBufferPointer { (buffer) in
+            data.replaceSubrange(range, with: buffer)
+        }
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1, 1, 1, 1, 1, 1]))
+    }
+    
+    func test_validateMutation_customBacking_replaceSubrangeWithCollection() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        let range: Range<Int> = 1..<4
+        data.replaceSubrange(range, with: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1, 1, 1, 1, 1, 1]))
+    }
+    
+    func test_validateMutation_customBacking_replaceSubrangeWithBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        let range: Range<Int> = 1..<5
+        bytes.withUnsafeBufferPointer { (buffer) in
+            data.replaceSubrange(range, with: buffer.baseAddress!, count: buffer.count)
+        }
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1, 1, 1, 1, 1]))
+    }
+    
+    func test_validateMutation_slice_customBacking_withUnsafeMutableBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 1).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+    }
+    
+    func test_validateMutation_slice_customBacking_appendBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBytes { ptr in
+            data.append(ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), count: ptr.count)
+        }
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customBacking_appendData() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        data.append(Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customBacking_appendBuffer() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { (buffer) in
+            data.append(buffer)
+        }
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customBacking_appendSequence() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        let seq = repeatElement(UInt8(0xFF), count: 2)
+        data.append(contentsOf: seq)
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customBacking_appendContentsOf() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        data.append(contentsOf: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customBacking_resetBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 1]))
+    }
+    
+    func test_validateMutation_slice_customBacking_replaceSubrange() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+    }
+    
+    func test_validateMutation_slice_customBacking_replaceSubrangeCountableRange() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        let range: CountableRange<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+    }
+    
+    func test_validateMutation_slice_customBacking_replaceSubrangeWithBuffer() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { (buffer) in
+            data.replaceSubrange(range, with: buffer)
+        }
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+    }
+    
+    func test_validateMutation_slice_customBacking_replaceSubrangeWithCollection() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+    }
+    
+    func test_validateMutation_slice_customBacking_replaceSubrangeWithBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBytes { buffer in
+            data.replaceSubrange(range, with: buffer.baseAddress!, count: 2)
+        }
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+    }
+    
+    func test_validateMutation_cow_customBacking_withUnsafeMutableBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 5).pointee = 0xFF
+            }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0xFF)
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_appendBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { (buffer) in
+                data.append(buffer.baseAddress!, count: buffer.count)
+            }
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_appendData() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            data.append(Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_appendBuffer() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.append($0) }
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_appendSequence() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            data.append(contentsOf: repeatElement(UInt8(0xFF), count: 2))
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_appendContentsOf() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            data.append(contentsOf: [0xFF, 0xFF])
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_resetBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0, 0, 0, 1, 1]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_replaceSubrange() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_replaceSubrangeCountableRange() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            let range: CountableRange<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_replaceSubrangeWithBuffer() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0) }
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_replaceSubrangeWithCollection() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: [0xFF, 0xFF])
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_replaceSubrangeWithBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            bytes.withUnsafeBytes {
+                data.replaceSubrange(range, with: $0.baseAddress!, count: $0.count)
+            }
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_withUnsafeMutableBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 1).pointee = 0xFF
+            }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_appendBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { (buffer) in
+                data.append(buffer.baseAddress!, count: buffer.count)
+            }
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_appendData() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            data.append(Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_appendBuffer() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.append($0) }
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_appendSequence() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            data.append(contentsOf: repeatElement(UInt8(0xFF), count: 2))
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_appendContentsOf() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            data.append(contentsOf: [0xFF, 0xFF])
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_resetBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 1]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_replaceSubrange() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_replaceSubrangeCountableRange() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            let range: CountableRange<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_replaceSubrangeWithBuffer() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0) }
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_replaceSubrangeWithCollection() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: [0xFF, 0xFF])
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_replaceSubrangeWithBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBytes {
+                data.replaceSubrange(range, with: $0.baseAddress!, count: $0.count)
+            }
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_customMutableBacking_withUnsafeMutableBytes() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 5).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0xFF)
+    }
+    
+    func test_validateMutation_customMutableBacking_appendBytes() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customMutableBacking_appendData() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        data.append(Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customMutableBacking_appendBuffer() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customMutableBacking_appendSequence() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        data.append(contentsOf: repeatElement(UInt8(0xFF), count: 2))
+        XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customMutableBacking_appendContentsOf() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        data.append(contentsOf: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customMutableBacking_resetBytes() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data.count, 10)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 0)], 1)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 6)], 0)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 7)], 0)
+    }
+    
+    func test_validateMutation_customMutableBacking_replaceSubrange() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_customMutableBacking_replaceSubrangeCountableRange() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        let range: CountableRange<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_customMutableBacking_replaceSubrangeWithBuffer() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0) }
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_customMutableBacking_replaceSubrangeWithCollection() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_customMutableBacking_replaceSubrangeWithBytes() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_withUnsafeMutableBytes() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 1).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_appendBytes() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_appendData() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        data.append(Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_appendBuffer() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_appendSequence() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_appendContentsOf() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        data.append(contentsOf: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_resetBytes() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        data.resetBytes(in: 5..<8)
+        
+        XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 2)], 0)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 3)], 0)
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_replaceSubrange() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_replaceSubrangeCountableRange() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        let range: CountableRange<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_replaceSubrangeWithBuffer() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0) }
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_replaceSubrangeWithCollection() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_replaceSubrangeWithBytes() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_withUnsafeMutableBytes() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 5).pointee = 0xFF
+            }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0xFF)
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_appendBytes() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+            XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_appendData() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            data.append(Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_appendBuffer() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.append($0) }
+            XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_appendSequence() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            data.append(contentsOf: repeatElement(UInt8(0xFF), count: 2))
+            XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_appendContentsOf() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            data.append(contentsOf: [0xFF, 0xFF])
+            XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_resetBytes() {
+        var data = Data(referencing: AllOnesData(length: 10))
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data.count, 10)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 0)], 1)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 6)], 0)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 7)], 0)
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_replaceSubrange() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0])) 
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_replaceSubrangeCountableRange() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            let range: CountableRange<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0])) 
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_replaceSubrangeWithBuffer() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0) }
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0])) 
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_replaceSubrangeWithCollection() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: [0xFF, 0xFF])
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0])) 
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_replaceSubrangeWithBytes() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0.baseAddress!, count: $0.count) }
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0])) 
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_withUnsafeMutableBytes() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 1).pointee = 0xFF
+            }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_appendBytes() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+            XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_appendData() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            data.append(Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_appendBuffer() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.append($0) }
+            XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_appendSequence() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            data.append(contentsOf: repeatElement(UInt8(0xFF), count: 2))
+            XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_appendContentsOf() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            data.append(contentsOf: [0xFF, 0xFF])
+            XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_resetBytes() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 2)], 0)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 3)], 0)
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_replaceSubrange() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeCountableRange() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: CountableRange<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithBuffer() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0) }
+            XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithCollection() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: [0xFF, 0xFF])
+            XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithBytes() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0.baseAddress!, count: $0.count) }
+            XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+        }
+    }
+#endif
+    
+    func test_sliceHash() {
+        let base1 = Data(bytes: [0, 0xFF, 0xFF, 0])
+        let base2 = Data(bytes: [0, 0xFF, 0xFF, 0])
+        let base3 = Data(bytes: [0xFF, 0xFF, 0xFF, 0])
+        let sliceEmulation = Data(bytes: [0xFF, 0xFF])
+        XCTAssertEqual(base1.hashValue, base2.hashValue)
+        let slice1 = base1[base1.startIndex.advanced(by: 1)..<base1.endIndex.advanced(by: -1)]
+        let slice2 = base2[base2.startIndex.advanced(by: 1)..<base2.endIndex.advanced(by: -1)]
+        let slice3 = base3[base3.startIndex.advanced(by: 1)..<base3.endIndex.advanced(by: -1)]
+        XCTAssertEqual(slice1.hashValue, sliceEmulation.hashValue)
+        XCTAssertEqual(slice1.hashValue, slice2.hashValue)
+        XCTAssertEqual(slice2.hashValue, slice3.hashValue)
+    }
+
+    func test_slice_resize_growth() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        data.resetBytes(in: data.endIndex.advanced(by: -1)..<data.endIndex.advanced(by: 1))
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 0, 0]))
+    }
+    
+    /*
+    func test_sliceEnumeration() {
+        var base = DispatchData.empty
+        let bytes: [UInt8] = [0, 1, 2, 3, 4]
+        base.append(bytes.withUnsafeBytes { DispatchData(bytes: $0) })
+        base.append(bytes.withUnsafeBytes { DispatchData(bytes: $0) })
+        base.append(bytes.withUnsafeBytes { DispatchData(bytes: $0) })
+        let data = ((base as AnyObject) as! Data)[3..<11]
+        var regionRanges: [Range<Int>] = []
+        var regionData: [Data] = []
+        data.enumerateBytes { (buffer, index, _) in
+            regionData.append(Data(bytes: buffer.baseAddress!, count: buffer.count))
+            regionRanges.append(index..<index + buffer.count)
+        }
+        XCTAssertEqual(regionRanges.count, 3)
+        XCTAssertEqual(Range<Data.Index>(3..<5), regionRanges[0])
+        XCTAssertEqual(Range<Data.Index>(5..<10), regionRanges[1])
+        XCTAssertEqual(Range<Data.Index>(10..<11), regionRanges[2])
+        XCTAssertEqual(Data(bytes: [3, 4]), regionData[0]) //fails
+        XCTAssertEqual(Data(bytes: [0, 1, 2, 3, 4]), regionData[1]) //passes
+        XCTAssertEqual(Data(bytes: [0]), regionData[2]) //fails
+    }
+ */
 }
 

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -1091,8 +1091,8 @@ class TestNSNumber : XCTestCase {
 
     func test_Equals() {
         // Booleans: false only equals 0, true only equals 1
-        XCTAssertTrue(NSNumber(value: true) == NSNumber(value: true))
-        XCTAssertTrue(NSNumber(value: true) == NSNumber(value: 1))
+        XCTAssertTrue(NSNumber(value: true) == NSNumber(value: Bool(true)))
+        XCTAssertTrue(NSNumber(value: true) == NSNumber(value: Int(1)))
         XCTAssertTrue(NSNumber(value: true) == NSNumber(value: Float(1)))
         XCTAssertTrue(NSNumber(value: true) == NSNumber(value: Double(1)))
         XCTAssertTrue(NSNumber(value: true) == NSNumber(value: Int8(1)))
@@ -1102,8 +1102,8 @@ class TestNSNumber : XCTestCase {
         XCTAssertTrue(NSNumber(value: true) != NSNumber(value: Double(1234.56)))
         XCTAssertTrue(NSNumber(value: true) != NSNumber(value: 2))
         XCTAssertTrue(NSNumber(value: true) != NSNumber(value: Int.max))
-        XCTAssertTrue(NSNumber(value: false) == NSNumber(value: false))
-        XCTAssertTrue(NSNumber(value: false) == NSNumber(value: 0))
+        XCTAssertTrue(NSNumber(value: false) == NSNumber(value: Bool(false)))
+        XCTAssertTrue(NSNumber(value: false) == NSNumber(value: Int(0)))
         XCTAssertTrue(NSNumber(value: false) == NSNumber(value: Float(0)))
         XCTAssertTrue(NSNumber(value: false) == NSNumber(value: Double(0)))
         XCTAssertTrue(NSNumber(value: false) == NSNumber(value: Int8(0)))


### PR DESCRIPTION
Mutation of Data slices had issues when it comes to re-indexing to the base slice region. Previously when a slice of Data was mutated the re-calculation of the slice region was incorrectly assigned to a relative region to the previous backing. Now the slice region will copy the specific region out creating a new data upon CoW semantics and offset the index region upon access. Mutating a non CoW slice will retain the previous region backing but adjust the remaining allocation buffer accordingly. To validate this I have added tests for combinations that should approximate all possible combinations of mutations, backing storages and CoW scenarios.

This fixes the following issues:
rdar://problem/34206043
SR-5887
SR-5873
SR-5810

tl;dr – Slicing a CoW should result in fillet mignon not ground chuck.

NOTE: Data has a failure set for custom backing mutation because NSData does not properly delegate to CFData because of missing factory pattern initializers. This prevents testing of a number of mutation cases and should be re-enabled once we have a suitable solution for factory initializers.