### PR TITLE
Moving init?(ContentsOfFile:) to NSDictionary

### DIFF
--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -39,13 +39,14 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         
         return NSGeneratorEnumerator(_storage.keys.map { _SwiftValue.fetch(nonOptional: $0) }.makeIterator())
     }
+    
     @available(*, deprecated)
     public convenience init?(contentsOfFile path: String) {
-        self.init(contentsOfURL: URL(fileURLWithPath: path))
+        self.init(contentsOf: URL(fileURLWithPath: path))
     }
     
     @available(*, deprecated)
-    public convenience init?(contentsOfURL url: URL) {
+    public convenience init?(contentsOf url: URL) {
         do {
             guard let plistDoc = try? Data(contentsOf: url) else { return nil }
             let plistDict = try PropertyListSerialization.propertyList(from: plistDoc, options: [], format: nil) as? Dictionary<AnyHashable,Any>

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -39,6 +39,22 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         
         return NSGeneratorEnumerator(_storage.keys.map { _SwiftValue.fetch(nonOptional: $0) }.makeIterator())
     }
+    @available(*, deprecated)
+    public convenience init?(contentsOfFile path: String) {
+        self.init(contentsOfURL: URL(fileURLWithPath: path))
+    }
+    
+    @available(*, deprecated)
+    public convenience init?(contentsOfURL url: URL) {
+        do {
+            guard let plistDoc = try? Data(contentsOf: url) else { return nil }
+            let plistDict = try PropertyListSerialization.propertyList(from: plistDoc, options: [], format: nil) as? Dictionary<AnyHashable,Any>
+            guard let plistDictionary = plistDict else { return nil }
+            self.init(dictionary: plistDictionary)
+        } catch {
+            return nil
+        }
+    }
     
     public override convenience init() {
         self.init(objects: [], forKeys: [], count: 0)
@@ -583,20 +599,6 @@ open class NSMutableDictionary : NSDictionary {
         super.init(objects: objects, forKeys: keys, count: cnt)
     }
     
-    public convenience init?(contentsOfFile path: String) {
-        self.init(contentsOfURL: URL(fileURLWithPath: path))
-    }
-    
-    public convenience init?(contentsOfURL url: URL) {
-        do {
-            guard let plistDoc = try? Data(contentsOf: url) else { return nil }
-            let plistDict = try PropertyListSerialization.propertyList(from: plistDoc, options: [], format: nil) as? Dictionary<AnyHashable,Any>
-            guard let plistDictionary = plistDict else { return nil }
-            self.init(dictionary: plistDictionary)
-        } catch {
-            return nil
-        }
-    }
 }
 
 extension NSMutableDictionary {

--- a/TestFoundation/TestNSDictionary.swift
+++ b/TestFoundation/TestNSDictionary.swift
@@ -211,7 +211,7 @@ class TestNSDictionary : XCTestCase {
             let d1: NSDictionary = ["Hello":["world":"again"]]
             let isWritten = d1.write(toFile: testFilePath!, atomically: true)
             if(isWritten) {
-                let dict = NSMutableDictionary.init(contentsOfFile: testFilePath!)
+                let dict = NSDictionary(contentsOfFile: testFilePath!)
                 XCTAssert(dict == d1)
             } else {
                 XCTFail("Write to file failed")


### PR DESCRIPTION
The initialiser `init?(ContentsOfFile: String)` and `init?(contentsOf: URL)` were incorrectly defined in NSMutableDictionary. According to the [docs](https://developer.apple.com/documentation/foundation/nsdictionary) it should be defined in NSDictionary instead, this PR resolves this. 

I've also updated the tests to check for this initialiser in NSDictionary rather than NSMutableDictionary.  