### PR TITLE
Stub out value(forKey key: String)

### DIFF
--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -32,6 +32,10 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         return nil
     }
     
+    open func value(forKey key: String) -> Any? {
+        NSUnsupported()
+    }
+    
     open func keyEnumerator() -> NSEnumerator {
         guard type(of: self) === NSDictionary.self || type(of: self) === NSMutableDictionary.self else {
             NSRequiresConcreteImplementation()


### PR DESCRIPTION
I noticed this method doesn't exist on Linux however apparently this was deliberately omitted from sclf as it relies on KVC which is not supported on Linux.

This PR stubs out the method as NSUnsupported().
