### PR TITLE
Fix to NSKeyedArchiver when object not AnyHashable

### DIFF
--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -553,9 +553,11 @@ open class NSKeyedArchiver : NSCoder {
         }
         
         // check replacement cache
-        objectToEncode = self._replacementMap[object as! AnyHashable]
-        if objectToEncode != nil {
-            return objectToEncode
+        if let hashable = object as? AnyHashable {
+            objectToEncode = self._replacementMap[hashable]
+            if objectToEncode != nil {
+                return objectToEncode
+            }
         }
         
         // object replaced by NSObject.replacementObject(for:)

--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -106,6 +106,7 @@ class TestNSKeyedArchiver : XCTestCase {
             ("test_archive_user_class", test_archive_user_class),
             ("test_archive_uuid_bvref", test_archive_uuid_byref),
             ("test_archive_uuid_byvalue", test_archive_uuid_byvalue),
+            ("test_archive_unhashable", test_archive_unhashable),
         ]
     }
 
@@ -311,5 +312,31 @@ class TestNSKeyedArchiver : XCTestCase {
     func test_archive_uuid_byvalue() {
         let uuid = UUID()
         return test_archive(uuid, classes: [NSUUID.self])
+    }
+
+    func test_archive_unhashable() {
+        let data = """
+            {
+              "args": {},
+              "headers": {
+                "Accept": "*/*",
+                "Accept-Encoding": "deflate, gzip",
+                "Accept-Language": "en",
+                "Connection": "close",
+                "Host": "httpbin.org",
+                "User-Agent": "TestFoundation (unknown version) curl/7.54.0"
+              },
+              "origin": "0.0.0.0",
+              "url": "https://httpbin.org/get"
+            }
+            """.data(using: .utf8)!
+        do {
+            let json = try JSONSerialization.jsonObject(with: data)
+            _ = NSKeyedArchiver.archivedData(withRootObject: json)
+            XCTAssert(true, "NSKeyedArchiver.archivedData handles unhashable")
+        }
+        catch {
+            XCTFail("test_archive_unhashable, de-serialization error \(error)")
+        }
     }
 }


### PR DESCRIPTION
Hi Apple,

a minor fix to NSKeyedArchiver for when objects being archived are not “AnyHashable”. Without the fix the following code does not work:
```Swift
        let session = URLSession( configuration: .default )
        let url = URL(string: "https://httpbin.org/get")!
        _ = session.dataTask( with: URLRequest( url: url ) ) {
            (data, response, error) in
            if let data = data {
                do {
                    let json = try JSONSerialization.jsonObject(with: data)
                    let archive = NSKeyedArchiver.archivedData(withRootObject: json)
                    let object = NSKeyedUnarchiver.unarchiveObject(with: archive)
                    let text = try JSONSerialization.data(withJSONObject: object)
                    NSLog( String(describing: String( data: text, encoding: .utf8 )) )
                }
                catch let e {
                    NSLog( "\(e)" )
                }
            }
            else {
                NSLog( "\(String(describing: error))" )
            }
            }.resume()
```
It crashes during the archiving with the error:
```
Could not cast value of type 'Swift.Dictionary<Swift.String, Any>' (0x6000248c0038) to 'Swift.AnyHashable' (0x10262c040).
```