### PR TITLE
Change StreamDelegate signature to match Darwin's

### DIFF
--- a/Foundation/Stream.swift
+++ b/Foundation/Stream.swift
@@ -241,11 +241,11 @@ extension Stream {
 #endif
 
 extension StreamDelegate {
-    func stream(_ aStream: Stream, handleEvent eventCode: Stream.Event) { }
+    func stream(_ aStream: Stream, handle eventCode: Stream.Event) { }
 }
 
 public protocol StreamDelegate : class {
-    func stream(_ aStream: Stream, handleEvent eventCode: Stream.Event)
+    func stream(_ aStream: Stream, handle eventCode: Stream.Event)
 }
 
 // MARK: -


### PR DESCRIPTION
change StreamDelegate protocol signature to match https://developer.apple.com/documentation/foundation/streamdelegate/1410079-stream

Issue: https://bugs.swift.org/browse/SR-6088