### PR TITLE
String bridging and internal NUL [SR-2225], take four

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -1188,10 +1188,8 @@ extension NSString {
         if data.isEmpty {
             self.init("")
         } else {
-        guard let cf = data.withUnsafeBytes({ (bytes: UnsafePointer<UInt8>) -> CFString? in
-            return CFStringCreateWithBytes(kCFAllocatorDefault, bytes, data.count, CFStringConvertNSStringEncodingToEncoding(encoding), true)
-        }) else { return nil }
-        
+            guard let cf = CFStringCreateFromExternalRepresentation(kCFAllocatorDefault, data._cfObject, CFStringConvertNSStringEncodingToEncoding(encoding)) else { return nil }
+
             var str: String?
             if String._conditionallyBridgeFromObjectiveC(cf._nsObject, result: &str) {
                 self.init(str!)

--- a/Foundation/String.swift
+++ b/Foundation/String.swift
@@ -29,15 +29,20 @@ extension String : _ObjectTypeBridgeable {
             result = source._storage
         } else if type(of: source) == _NSCFString.self {
             let cf = unsafeBitCast(source, to: CFString.self)
-            let str = CFStringGetCStringPtr(cf, CFStringEncoding(kCFStringEncodingUTF8))
-            if str != nil {
-                result = String(cString: str!)
+            let length = CFStringGetLength(cf) // This value is not always the length in characters, in spite of what the documentation says
+
+            // FIXME: If we had a reliable way to determine the length of `cf`
+            //        in bytes, then we wouldn't have to allocate a new buffer
+            //        if `CFStringGetCStringPtr(_:_:)` doesn't return nil.
+            if let buffer = CFStringGetCharactersPtr(cf) {
+                result = String._fromCodeUnitSequence(UTF16.self, input: UnsafeBufferPointer(start: buffer, count: length))
             } else {
-                let length = CFStringGetLength(cf)
-                let buffer = UnsafeMutablePointer<UniChar>.allocate(capacity: length)
-                CFStringGetCharacters(cf, CFRangeMake(0, length), buffer)
-                
-                let str = String._fromCodeUnitSequence(UTF16.self, input: UnsafeBufferPointer(start: buffer, count: length))
+                // Retrieving Unicode characters is unreliable; instead retrieve UTF8-encoded bytes
+                let max = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8)
+                let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: max)
+                var count: CFIndex = -1
+                CFStringGetBytes(cf, CFRangeMake(0, length), kCFStringEncodingUTF8, 0, false, buffer, max, &count)
+                let str = String._fromCodeUnitSequence(UTF8.self, input: UnsafeBufferPointer(start: buffer, count: count))
                 buffer.deinitialize(count: length)
                 buffer.deallocate(capacity: length)
                 result = str

--- a/Foundation/String.swift
+++ b/Foundation/String.swift
@@ -38,10 +38,10 @@ extension String : _ObjectTypeBridgeable {
                 result = String._fromCodeUnitSequence(UTF16.self, input: UnsafeBufferPointer(start: buffer, count: length))
             } else {
                 // Retrieving Unicode characters is unreliable; instead retrieve UTF8-encoded bytes
-                let max = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8)
+                let max = CFStringGetMaximumSizeForEncoding(length, CFStringEncoding(kCFStringEncodingUTF8))
                 let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: max)
                 var count: CFIndex = -1
-                CFStringGetBytes(cf, CFRangeMake(0, length), kCFStringEncodingUTF8, 0, false, buffer, max, &count)
+                CFStringGetBytes(cf, CFRangeMake(0, length), CFStringEncoding(kCFStringEncodingUTF8), 0, false, buffer, max, &count)
                 let str = String._fromCodeUnitSequence(UTF8.self, input: UnsafeBufferPointer(start: buffer, count: count))
                 buffer.deinitialize(count: length)
                 buffer.deallocate(capacity: length)

--- a/TestFoundation/TestJSONSerialization.swift
+++ b/TestFoundation/TestJSONSerialization.swift
@@ -1373,8 +1373,8 @@ extension TestJSONSerialization {
             outputStream.open()
             let result = try JSONSerialization.writeJSONObject(dict, toStream: outputStream, options: [])
             outputStream.close()
-            if(result > -1) {
-                XCTAssertEqual(NSString(bytes: buffer, length: buffer.count, encoding: String.Encoding.utf8.rawValue), "{\"a\":{\"b\":1}}")
+            if result > -1 {
+                XCTAssertEqual(NSString(bytes: buffer, length: buffer.count, encoding: String.Encoding.utf8.rawValue), "{\"a\":{\"b\":1}}\0\0\0\0\0\0\0")
             }
         } catch {
             XCTFail("Error thrown: \(error)")
@@ -1390,7 +1390,7 @@ extension TestJSONSerialization {
                 outputStream?.open()
                 let result = try JSONSerialization.writeJSONObject(dict, toStream: outputStream!, options: [])
                 outputStream?.close()
-                if(result > -1) {
+                if result > -1 {
                     let fileStream: InputStream = InputStream(fileAtPath: filePath!)!
                     var buffer = [UInt8](repeating: 0, count: 20)
                     fileStream.open()
@@ -1398,7 +1398,7 @@ extension TestJSONSerialization {
                         let resultRead: Int = fileStream.read(&buffer, maxLength: buffer.count)
                         fileStream.close()
                         if(resultRead > -1){
-                            XCTAssertEqual(NSString(bytes: buffer, length: buffer.count, encoding: String.Encoding.utf8.rawValue), "{\"a\":{\"b\":1}}")
+                            XCTAssertEqual(NSString(bytes: buffer, length: buffer.count, encoding: String.Encoding.utf8.rawValue), "{\"a\":{\"b\":1}}\0\0\0\0\0\0\0")
                         }
                     }
                     removeTestFile(filePath!)
@@ -1419,8 +1419,8 @@ extension TestJSONSerialization {
         do {
             let result = try JSONSerialization.writeJSONObject(dict, toStream: outputStream, options: [])
             outputStream.close()
-            if(result > -1) {
-                XCTAssertNotEqual(NSString(bytes: buffer, length: buffer.count, encoding: String.Encoding.utf8.rawValue), "{\"a\":{\"b\":1}}")
+            if result > -1 {
+                XCTAssertNotEqual(NSString(bytes: buffer, length: buffer.count, encoding: String.Encoding.utf8.rawValue), "{\"a\":{\"b\":1}}\0\0\0\0\0\0\0")
             }
         } catch {
             XCTFail("Error occurred while writing to stream")

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -59,6 +59,7 @@ class TestNSString : XCTestCase {
             ("test_FromNullTerminatedCStringInUTF8", test_FromNullTerminatedCStringInUTF8 ),
             // Swift3 updates broke the expectations of this test. disabling for now
             // ("test_FromMalformedNullTerminatedCStringInUTF8", test_FromMalformedNullTerminatedCStringInUTF8 ),
+            ("test_FromDataWithInternalNullCharacter", test_FromDataWithInternalNullCharacter ),
             ("test_uppercaseString", test_uppercaseString ),
             ("test_lowercaseString", test_lowercaseString ),
             ("test_capitalizedString", test_capitalizedString ),
@@ -75,7 +76,7 @@ class TestNSString : XCTestCase {
             ("test_FromContentOfFile",test_FromContentOfFile),
             ("test_swiftStringUTF16", test_swiftStringUTF16),
             // This test takes forever on build servers; it has been seen up to 1852.084 seconds
-//            ("test_completePathIntoString", test_completePathIntoString),
+            // ("test_completePathIntoString", test_completePathIntoString),
             ("test_stringByTrimmingCharactersInSet", test_stringByTrimmingCharactersInSet),
             ("test_initializeWithFormat", test_initializeWithFormat),
             ("test_initializeWithFormat2", test_initializeWithFormat2),
@@ -283,6 +284,14 @@ class TestNSString : XCTestCase {
         let bytes = mockMalformedUTF8StringBytes + [0x00]
         let string = NSString(cString: bytes.map { Int8(bitPattern: $0) }, encoding: String.Encoding.utf8.rawValue)
         XCTAssertNil(string)
+    }
+
+    func test_FromDataWithInternalNullCharacter() {
+        let bytes = mockASCIIStringBytes + [0x00] + mockASCIIStringBytes
+        let length = mockASCIIStringBytes.count * 2 + 1
+        let data = Data(bytes: bytes, count: length)
+        let string = NSString(data: data, encoding: String.Encoding.ascii.rawValue)
+        XCTAssertTrue(string?.isEqual(to: mockASCIIString + "\0" + mockASCIIString) ?? false)
     }
 
     func test_FromContentsOfURL() {

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -1224,8 +1224,7 @@ let comparisonTests = [
     ComparisonTest("\r\n", "t"),
     ComparisonTest("\r\n", "\n",
         reason: "blocked on rdar://problem/19036555"),
-    ComparisonTest("\u{0}", "\u{0}\u{0}",
-        reason: "rdar://problem/19034601"),
+    ComparisonTest("\u{0}", "\u{0}\u{0}"),
 
     // Whitespace
     // U+000A LINE FEED (LF)

--- a/TestFoundation/TestStream.swift
+++ b/TestFoundation/TestStream.swift
@@ -39,7 +39,7 @@ class TestStream : XCTestCase {
         XCTAssertEqual(Stream.Status.notOpen, dataStream.streamStatus)
         dataStream.open()
         XCTAssertEqual(Stream.Status.open, dataStream.streamStatus)
-        var buffer = [UInt8](repeating: 0, count: 20)
+        var buffer = [UInt8](repeating: 0, count: 17)
         if dataStream.hasBytesAvailable {
             let result: Int = dataStream.read(&buffer, maxLength: buffer.count)
             dataStream.close()
@@ -62,7 +62,7 @@ class TestStream : XCTestCase {
             XCTAssertEqual(Stream.Status.notOpen, urlStream.streamStatus)
             urlStream.open()
             XCTAssertEqual(Stream.Status.open, urlStream.streamStatus)
-            var buffer = [UInt8](repeating: 0, count: 20)
+            var buffer = [UInt8](repeating: 0, count: 17)
             if urlStream.hasBytesAvailable {
                 let result :Int = urlStream.read(&buffer, maxLength: buffer.count)
                 urlStream.close()
@@ -89,7 +89,7 @@ class TestStream : XCTestCase {
             XCTAssertEqual(Stream.Status.notOpen, fileStream.streamStatus)
             fileStream.open()
             XCTAssertEqual(Stream.Status.open, fileStream.streamStatus)
-            var buffer = [UInt8](repeating: 0, count: 20)
+            var buffer = [UInt8](repeating: 0, count: 17)
             if fileStream.hasBytesAvailable {
                 let result: Int = fileStream.read(&buffer, maxLength: buffer.count)
                 fileStream.close()
@@ -110,7 +110,7 @@ class TestStream : XCTestCase {
         let message: NSString = "Hello, playground"
         let messageData: Data  = message.data(using: String.Encoding.utf8.rawValue)!
         let stream: InputStream = InputStream(data: messageData)
-        var buffer = [UInt8](repeating: 0, count: 20)
+        var buffer = [UInt8](repeating: 0, count: 17)
         stream.open()
         XCTAssertTrue(stream.hasBytesAvailable)
         _ = stream.read(&buffer, maxLength: buffer.count)


### PR DESCRIPTION
This PR is a rebased version of #604, itself a rebased version of #549, a revision to #496. 
It resolves SR-2225 and, apparently, rdar://problem/19034601.

## What's going on in this PR

### Existing bridging is buggy

The existing implementation of bridging from _NSCFString to String was broken in several ways:
1. The "fast path" blew away internal NUL characters because it used facilities for C strings.
2. Merely removing the "fast path" strangely caused tests to fail. Debugging revealed that the reason for failing tests was that the default "slow path" was also broken.
3. The "slow path" used CFStringGetLength() and CFStringGetCharacters(). However, if the CFString in question contains multi-byte characters _and_ was initialized using bytes, then neither of these CF functions behaves as documented:
   - CFStringGetLength() seems to return the length in bytes, not the length in UTF16 code pairs.
   - CFStringGetCharacters() seems to return the bytes, not the UTF16 code pairs.

As a consequence, if UTF8-encoded bytes that encode internal NUL characters _and_ multi-byte characters were used to initialize an NSString, the "fast path" would clobber bridging in one way, and the "slow path" would clobber bridging in a different way.

### Revised bridging

Since CF UTF16-related functions are erratic, I use a buffer to store UTF8-encoded bytes. If some way can be found to determine (reliably, not relying on the result of a buggy implementation in CF) the length **in bytes** of a CFString that uses UTF8-encoded bytes for storage, then a fast path can be restored that doesn't require allocating a buffer.

### Modified tests

After implementing this revised bridging, several tests began to fail. On further examination, these tests were found to be incorrect because they relied on multiple tandem NUL characters being lost on bridging. On a Mac, Darwin Foundation fails these tests as well. I have corrected the tests.

This PR additionally adds a test for constructing an NSString with data that contains an internal NUL character.

### Miscellaneous changes

This PR rolls in the previously discussed (#496) change in `init?(data:encoding:)`.

