### PR TITLE
Fix warnings in the Foundation build

### DIFF
--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -1590,7 +1590,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     @inline(__always)
     public func subdata(in range: Range<Index>) -> Data {
         _validateRange(range)
-        let length = count
         if count == 0 {
             return Data()
         }

--- a/Foundation/HTTPCookieStorage.swift
+++ b/Foundation/HTTPCookieStorage.swift
@@ -77,8 +77,9 @@ open class HTTPCookieStorage: NSObject {
     }
 
     private func loadPersistedCookies() {
-        guard let cookies = NSMutableDictionary(contentsOfFile: cookieFilePath) else { return }
-        var cookies0 = _SwiftValue.fetch(cookies) as? [String: [String: Any]] ?? [:]
+        guard let cookiesData = try? Data(contentsOf: URL(fileURLWithPath: cookieFilePath)) else { return }
+        guard let cookies = try? PropertyListSerialization.propertyList(from: cookiesData, format: nil) else { return }
+        var cookies0 = cookies as? [String: [String: Any]] ?? [:]
         self.syncQ.sync {
             for key in cookies0.keys {
                 if let cookie = createCookie(cookies0[key]!) {


### PR DESCRIPTION
```
Foundation/HTTPCookieStorage.swift:80:29: warning: 'init(contentsOfFile:)' is deprecated
        guard let cookies = NSMutableDictionary(contentsOfFile: cookieFilePath) else { return }

```
and

```
Foundation/Data.swift:1593:13: warning: initialization of immutable value 'length' was never used; consider replacing with assignment to '_' or removing it
        let length = count
```