### PR TITLE
[4.0] NSString: Fix malformed string test and re-enable other disabled tests

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -271,7 +271,10 @@ open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSC
     }
     
     public convenience init?(cString nullTerminatedCString: UnsafePointer<Int8>, encoding: UInt) {
-        self.init(string: CFStringCreateWithCString(kCFAllocatorSystemDefault, nullTerminatedCString, CFStringConvertNSStringEncodingToEncoding(encoding))._swiftObject)
+        guard let str = CFStringCreateWithCString(kCFAllocatorSystemDefault, nullTerminatedCString, CFStringConvertNSStringEncodingToEncoding(encoding)) else {
+            return nil
+        }
+        self.init(string: str._swiftObject)
     }
     
     internal func _fastCStringContents(_ nullTerminated: Bool) -> UnsafePointer<Int8>? {

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -49,16 +49,13 @@ class TestNSString : XCTestCase {
             ("test_isNotEqualToObjectWithNSNumber", test_isNotEqualToObjectWithNSNumber ),
             ("test_FromASCIIData", test_FromASCIIData ),
             ("test_FromUTF8Data", test_FromUTF8Data ),
-            // Swift3 updates broke the expectations of this test. disabling for now
-            // ("test_FromMalformedUTF8Data", test_FromMalformedUTF8Data ),
+            ("test_FromMalformedUTF8Data", test_FromMalformedUTF8Data ),
             ("test_FromASCIINSData", test_FromASCIINSData ),
             ("test_FromUTF8NSData", test_FromUTF8NSData ),
-            // Swift3 updates broke the expectations of this test. disabling for now
-            // ("test_FromMalformedUTF8NSData", test_FromMalformedUTF8NSData ),
+            ("test_FromMalformedUTF8NSData", test_FromMalformedUTF8NSData ),
             ("test_FromNullTerminatedCStringInASCII", test_FromNullTerminatedCStringInASCII ),
             ("test_FromNullTerminatedCStringInUTF8", test_FromNullTerminatedCStringInUTF8 ),
-            // Swift3 updates broke the expectations of this test. disabling for now
-            // ("test_FromMalformedNullTerminatedCStringInUTF8", test_FromMalformedNullTerminatedCStringInUTF8 ),
+            ("test_FromMalformedNullTerminatedCStringInUTF8", test_FromMalformedNullTerminatedCStringInUTF8 ),
             ("test_uppercaseString", test_uppercaseString ),
             ("test_lowercaseString", test_lowercaseString ),
             ("test_capitalizedString", test_capitalizedString ),


### PR DESCRIPTION
Backport fix to 4.0 branch