### PR TITLE
Update NSNumberBridging test for init(exactly:)

### DIFF
--- a/TestFoundation/TestNSNumberBridging.swift
+++ b/TestFoundation/TestNSNumberBridging.swift
@@ -98,10 +98,13 @@ class TestNSNumberBridging : XCTestCase {
                 XCTAssertEqual(Int(exactly: interestingValue), int)
                 let uint = UInt(exactly: number!)
                 XCTAssertEqual(UInt(exactly: interestingValue), uint)
+
                 let float = Float(exactly: number!)
-                XCTAssertEqual(Float(interestingValue), float)
+                let expectedFloat = Float(exactly: interestingValue)
+                testFloat(expectedFloat, float)
                 let double = Double(exactly: number!)
-                XCTAssertEqual(Double(interestingValue), double)
+                let expectedDouble = Double(exactly: interestingValue)
+                testDouble(expectedDouble, double)
             }
             let bridged = interestingValue._bridgeToObjectiveC()
             testNumber(bridged)
@@ -134,10 +137,13 @@ class TestNSNumberBridging : XCTestCase {
                 XCTAssertEqual(Int(exactly: interestingValue), int)
                 let uint = UInt(exactly: number!)
                 XCTAssertEqual(UInt(exactly: interestingValue), uint)
+
                 let float = Float(exactly: number!)
-                XCTAssertEqual(Float(interestingValue), float)
+                let expectedFloat = Float(exactly: interestingValue)
+                testFloat(expectedFloat, float)
                 let double = Double(exactly: number!)
-                XCTAssertEqual(Double(interestingValue), double)
+                let expectedDouble = Double(exactly: interestingValue)
+                testDouble(expectedDouble, double)
             }
             let bridged = interestingValue._bridgeToObjectiveC()
             testNumber(bridged)
@@ -170,10 +176,13 @@ class TestNSNumberBridging : XCTestCase {
                 XCTAssertEqual(Int(exactly: interestingValue), int)
                 let uint = UInt(exactly: number!)
                 XCTAssertEqual(UInt(exactly: interestingValue), uint)
+
                 let float = Float(exactly: number!)
-                XCTAssertEqual(Float(interestingValue), float)
+                let expectedFloat = Float(exactly: interestingValue)
+                testFloat(expectedFloat, float)
                 let double = Double(exactly: number!)
-                XCTAssertEqual(Double(interestingValue), double)
+                let expectedDouble = Double(exactly: interestingValue)
+                testDouble(expectedDouble, double)
             }
             let bridged = interestingValue._bridgeToObjectiveC()
             testNumber(bridged)
@@ -206,10 +215,13 @@ class TestNSNumberBridging : XCTestCase {
                 XCTAssertEqual(Int(exactly: interestingValue), int)
                 let uint = UInt(exactly: number!)
                 XCTAssertEqual(UInt(exactly: interestingValue), uint)
+
                 let float = Float(exactly: number!)
-                XCTAssertEqual(Float(interestingValue), float)
+                let expectedFloat = Float(exactly: interestingValue)
+                testFloat(expectedFloat, float)
                 let double = Double(exactly: number!)
-                XCTAssertEqual(Double(interestingValue), double)
+                let expectedDouble = Double(exactly: interestingValue)
+                testDouble(expectedDouble, double)
             }
             let bridged = interestingValue._bridgeToObjectiveC()
             testNumber(bridged)
@@ -242,15 +254,12 @@ class TestNSNumberBridging : XCTestCase {
                 XCTAssertEqual(Int(exactly: interestingValue), int)
                 let uint = UInt(exactly: number!)
                 XCTAssertEqual(UInt(exactly: interestingValue), uint)
+
                 let float = Float(exactly: number!)
-                let expectedFloat = Float(exactly: int32!)
-                // these are disabled because of https://bugs.swift.org/browse/SR-4634
-                if (int32! != Int32.min && int32! != Int32.max &&
-                    int32! != Int32.min + 1 && int32! != Int32.max - 1) {
-                    testFloat(expectedFloat, float)
-                }
+                let expectedFloat = Float(exactly: interestingValue)
+                testFloat(expectedFloat, float)
                 let double = Double(exactly: number!)
-                let expectedDouble = Double(exactly: int32!)
+                let expectedDouble = Double(exactly: interestingValue)
                 testDouble(expectedDouble, double)
             }
             let bridged = interestingValue._bridgeToObjectiveC()
@@ -284,14 +293,12 @@ class TestNSNumberBridging : XCTestCase {
                 XCTAssertEqual(Int(exactly: interestingValue), int)
                 let uint = UInt(exactly: number!)
                 XCTAssertEqual(UInt(exactly: interestingValue), uint)
+
                 let float = Float(exactly: number!)
-                let expectedFloat = Float(exactly: uint32!)
-                // these are disabled because of https://bugs.swift.org/browse/SR-4634
-                if (uint32! != UInt32.max && uint32! != UInt32.max - 1) {
-                    testFloat(expectedFloat, float)
-                }
+                let expectedFloat = Float(exactly: interestingValue)
+                testFloat(expectedFloat, float)
                 let double = Double(exactly: number!)
-                let expectedDouble = Double(exactly: uint32!)
+                let expectedDouble = Double(exactly: interestingValue)
                 testDouble(expectedDouble, double)
             }
             let bridged = interestingValue._bridgeToObjectiveC()
@@ -325,10 +332,13 @@ class TestNSNumberBridging : XCTestCase {
                 XCTAssertEqual(Int(exactly: interestingValue), int)
                 let uint = UInt(exactly: number!)
                 XCTAssertEqual(UInt(exactly: interestingValue), uint)
+
                 let float = Float(exactly: number!)
-                XCTAssertEqual(Float(interestingValue), float)
+                let expectedFloat = Float(exactly: interestingValue)
+                testFloat(expectedFloat, float)
                 let double = Double(exactly: number!)
-                XCTAssertEqual(Double(interestingValue), double)
+                let expectedDouble = Double(exactly: interestingValue)
+                testDouble(expectedDouble, double)
             }
             let bridged = interestingValue._bridgeToObjectiveC()
             testNumber(bridged)
@@ -361,10 +371,13 @@ class TestNSNumberBridging : XCTestCase {
                 XCTAssertEqual(Int(exactly: interestingValue), int)
                 let uint = UInt(exactly: number!)
                 XCTAssertEqual(UInt(exactly: interestingValue), uint)
+
                 let float = Float(exactly: number!)
-                XCTAssertEqual(Float(interestingValue), float)
+                let expectedFloat = Float(exactly: interestingValue)
+                testFloat(expectedFloat, float)
                 let double = Double(exactly: number!)
-                XCTAssertEqual(Double(interestingValue), double)
+                let expectedDouble = Double(exactly: interestingValue)
+                testDouble(expectedDouble, double)
             }
             let bridged = interestingValue._bridgeToObjectiveC()
             testNumber(bridged)
@@ -397,10 +410,13 @@ class TestNSNumberBridging : XCTestCase {
                 XCTAssertEqual(Int(exactly: interestingValue), int)
                 let uint = UInt(exactly: number!)
                 XCTAssertEqual(UInt(exactly: interestingValue), uint)
+
                 let float = Float(exactly: number!)
-                XCTAssertEqual(Float(interestingValue), float)
+                let expectedFloat = Float(exactly: interestingValue)
+                testFloat(expectedFloat, float)
                 let double = Double(exactly: number!)
-                XCTAssertEqual(Double(interestingValue), double)
+                let expectedDouble = Double(exactly: interestingValue)
+                testDouble(expectedDouble, double)
             }
             let bridged = interestingValue._bridgeToObjectiveC()
             testNumber(bridged)
@@ -433,10 +449,13 @@ class TestNSNumberBridging : XCTestCase {
                 XCTAssertEqual(Int(exactly: interestingValue), int)
                 let uint = UInt(exactly: number!)
                 XCTAssertEqual(UInt(exactly: interestingValue), uint)
+
                 let float = Float(exactly: number!)
-                XCTAssertEqual(Float(interestingValue), float)
+                let expectedFloat = Float(exactly: interestingValue)
+                testFloat(expectedFloat, float)
                 let double = Double(exactly: number!)
-                XCTAssertEqual(Double(interestingValue), double)
+                let expectedDouble = Double(exactly: interestingValue)
+                testDouble(expectedDouble, double)
             }
             let bridged = interestingValue._bridgeToObjectiveC()
             testNumber(bridged)
@@ -470,12 +489,11 @@ class TestNSNumberBridging : XCTestCase {
                 let uint = UInt(exactly: number!)
                 XCTAssertEqual(UInt(exactly: interestingValue), uint)
 
-                let float = Float(truncating: number!)
-                let expectedFloat = interestingValue
+                let float = Float(exactly: number!)
+                let expectedFloat = Float(exactly: interestingValue)
                 testFloat(expectedFloat, float)
-
-                let double = Double(truncating: number!)
-                let expectedDouble = Double(reasonably: interestingValue)
+                let double = Double(exactly: number!)
+                let expectedDouble = Double(exactly: interestingValue)
                 testDouble(expectedDouble, double)
             }
             let bridged = interestingValue._bridgeToObjectiveC()
@@ -510,12 +528,11 @@ class TestNSNumberBridging : XCTestCase {
                 let uint = UInt(exactly: number!)
                 XCTAssertEqual(UInt(exactly: interestingValue), uint)
 
-                let float = Float(truncating: number!)
-                let expectedFloat = Float(reasonably: interestingValue)
+                let float = Float(exactly: number!)
+                let expectedFloat = Float(exactly: interestingValue)
                 testFloat(expectedFloat, float)
-
                 let double = Double(exactly: number!)
-                let expectedDouble = interestingValue
+                let expectedDouble = Double(exactly: interestingValue)
                 testDouble(expectedDouble, double)
             }
             let bridged = interestingValue._bridgeToObjectiveC()


### PR DESCRIPTION
A fix in the behavior of FloatingPoint.init(exactly:) means that the NSNumber bridging tests need to be updated. That fix is in apple/swift#11311, this PR replaces #1273.