### PR TITLE
[SR-5989] Added missing call to _CFDeinit for NSLocale

### DIFF
--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -50,6 +50,10 @@ open class NSLocale: NSObject, NSCopying, NSSecureCoding {
         self.init(localeIdentifier: String._unconditionallyBridgeFromObjectiveC(identifier))
     }
     
+    deinit {
+        _CFDeinit(self)
+    }
+    
     open override func copy() -> Any {
         return copy(with: nil)
     }


### PR DESCRIPTION
Resolves  [SR-5989](https://bugs.swift.org/browse/SR-5989)

Added `deinit` to NSLocale that calls to `_CFDeinit` to release identifier and other resources.

I also wanted to add test cases for this, but could not figure it out how to do it.

I wanted to create a `weak` reference to an identifier of the locale and check if it becomes nil after `Locale` goes out of scope, but ...

`Locale` / `NSLocale` returns `Swift String` and as its a `struct`, we won't be able to test with it.
Another idea was to get this directly from `CFLocaleGetValue` but as CoreFoundation objects are automatically memory managed in Swift, I am not sure if this would work. 

Any ideas ?