### PR TITLE
[SR-6139] Implement NSString.copy() method

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -231,7 +231,15 @@ open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSC
     }
     
     open func copy(with zone: NSZone? = nil) -> Any {
-        return self
+        if type(of: self) === NSString.self {
+            return self
+        }
+        let characters = UnsafeMutablePointer<unichar>.allocate(capacity: length)
+        getCharacters(characters, range: NSMakeRange(0, length))
+        let result = NSString(characters: characters, length: length)
+        characters.deinitialize()
+        characters.deallocate(capacity: length)
+        return result
     }
     
     open override func mutableCopy() -> Any {

--- a/TestFoundation/TestNSArray.swift
+++ b/TestFoundation/TestNSArray.swift
@@ -90,12 +90,9 @@ class TestNSArray : XCTestCase {
 
         XCTAssertEqual(array1[0] as! String, "foo")
         XCTAssertEqual(array2[0] as! String, "foo")
-
-        // Disable this test for now as it fails, althought it works against Darwin Foundation.
-        // The test may not acutally be correct anyway.
-        //foo.append("1")
-        //XCTAssertEqual(array1[0] as! String, "foo1")
-        //XCTAssertEqual(array2[0] as! String, "foo")
+        foo.append("1")
+        XCTAssertEqual(array1[0] as! String, "foo1")
+        XCTAssertEqual(array2[0] as! String, "foo")
     }
     
     func test_enumeration() {

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -99,6 +99,7 @@ class TestNSString : XCTestCase {
             ("test_replacingOccurrences", test_replacingOccurrences),
             ("test_getLineStart", test_getLineStart),
             ("test_substringWithRange", test_substringWithRange),
+            ("test_createCopy", test_createCopy),
         ]
     }
 
@@ -1168,6 +1169,16 @@ class TestNSString : XCTestCase {
         // SR-3363
         let s6 = NSString(string: "Beyonce\u{301} and Tay")
         XCTAssertEqual(s6.substring(with: NSMakeRange(7, 9)), "\u{301} and Tay")
+    }
+    
+    func test_createCopy() {
+        let string: NSMutableString = "foo"
+        let stringCopy = string.copy() as! NSString
+        XCTAssertEqual(string, stringCopy)
+        string.append("bar")
+        XCTAssertNotEqual(string, stringCopy)
+        XCTAssertEqual(string, "foobar")
+        XCTAssertEqual(stringCopy, "foo")
     }
 }
 


### PR DESCRIPTION
A potential fix for this issue: 
https://bugs.swift.org/browse/SR-6139

Before, the method that is responsible to create the immutable copy of NSString was simply
returning self, that’s why copying didn’t happen and this test was failing: 

```
func test_constructorWithCopyItems() {
        let foo = "foo" as NSMutableString

        let array1 = NSArray(array: [foo], copyItems: false)
        let array2 = NSArray(array: [foo], copyItems: true)

        XCTAssertEqual(array1[0] as! String, "foo")
        XCTAssertEqual(array2[0] as! String, "foo")

        foo.append("1")
        XCTAssertEqual(array1[0] as! String, "foo1")
        // The below test fails on sclf
        XCTAssertEqual(array2[0] as! String, "foo")
    }

```

Please, let me know what you think.