### PR TITLE
Use precondition instead of fatalError in DateInterval initializer

### DIFF
--- a/Foundation/DateInterval.swift
+++ b/Foundation/DateInterval.swift
@@ -52,10 +52,7 @@ public struct DateInterval : ReferenceConvertible, Comparable, Hashable {
     ///
     /// - precondition: `end >= start`
     public init(start: Date, end: Date) {
-        if end < start {
-            fatalError("Reverse intervals are not allowed")
-        }
-        
+        precondition(end >= start, "Reverse intervals are not allowed")
         self.start = start
         duration = end.timeIntervalSince(start)
     }


### PR DESCRIPTION
Comment of the function says:

> /// - precondition: `end >= start`

but it actually uses `if -> fatalError` instead of `precondition`,

Other functions of `DateInterval` use `precondition`-s, only this one uses 'fatalError', probably makes sense to change it as well.