### PR TITLE
[SR-5582] Changed NSString.appendingPathComponent implementation on Lin…

### DIFF
--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -82,13 +82,13 @@ internal extension String {
     }
     
     internal func _stringByAppendingPathComponent(_ str: String, doneAppending : Bool = true) -> String {
-        if str.length == 0 {
+        if str.isEmpty {
             return self
         }
-        if self == "" {
-            return "/" + str
+        if isEmpty {
+            return str
         }
-        if self == "/" {
+        if hasSuffix("/") {
             return self + str
         }
         return self + "/" + str
@@ -237,16 +237,7 @@ public extension NSString {
     }
     
     internal func _stringByAppendingPathComponent(_ str: String, doneAppending : Bool = true) -> String {
-        if str.length == 0 {
-            return _swiftObject
-        }
-        if self == "" {
-            return "/" + str
-        }
-        if self == "/" {
-            return _swiftObject + str
-        }
-        return _swiftObject + "/" + str
+        return _swiftObject._stringByAppendingPathComponent(str, doneAppending: doneAppending)
     }
     
     public func appendingPathComponent(_ str: String) -> String {

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -77,6 +77,7 @@ class TestNSString : XCTestCase {
             ("test_initializeWithFormat", test_initializeWithFormat),
             ("test_initializeWithFormat2", test_initializeWithFormat2),
             ("test_initializeWithFormat3", test_initializeWithFormat3),
+            ("test_appendingPathComponent", test_appendingPathComponent),
             ("test_deletingLastPathComponent", test_deletingLastPathComponent),
             ("test_getCString_simple", test_getCString_simple),
             ("test_getCString_nonASCII_withASCIIAccessor", test_getCString_nonASCII_withASCIIAccessor),
@@ -751,6 +752,32 @@ class TestNSString : XCTestCase {
             let string = NSString(format: "NSDictionary value is %d (%.1f)", locale: loc, arguments: pointer)
             XCTAssertEqual(string, "NSDictionary value is 1000 (42&0)")
         }
+    }
+
+    func test_appendingPathComponent() {
+        do {
+            let path: NSString = "/tmp"
+            let result = path.appendingPathComponent("scratch.tiff")
+            XCTAssertEqual(result, "/tmp/scratch.tiff")
+        }
+
+        do {
+            let path: NSString = "/tmp/"
+            let result = path.appendingPathComponent("scratch.tiff")
+            XCTAssertEqual(result, "/tmp/scratch.tiff")
+        }
+
+        do {
+            let path: NSString = "/"
+            let result = path.appendingPathComponent("scratch.tiff")
+            XCTAssertEqual(result, "/scratch.tiff")
+        }
+
+        do {
+            let path: NSString = ""
+            let result = path.appendingPathComponent("scratch.tiff")
+            XCTAssertEqual(result, "scratch.tiff")
+        }                        
     }
     
     func test_deletingLastPathComponent() {


### PR DESCRIPTION
Resolves [SR-5582](https://bugs.swift.org/browse/SR-5582)

Changed NSString.appendingPathComponent implementation on Linux to match [Darwin's](https://developer.apple.com/documentation/foundation/nsstring/1417069-appendingpathcomponent)

Fixed following issues where path.appendingPathComponent(component) would produce incorrect result:

path was empty and component did not start with /
or
path ended with / and component started with /

Before: 

	"/tmp/".appendingPathComponent("scratch.tiff") == "/tmp//scratch.tiff"
 	"".appendingPathComponent("scratch.tiff") == "/scratch.tiff"

After:  

	"/tmp/".appendingPathComponent("scratch.tiff") == "/tmp/scratch.tiff"
	"".appendingPathComponent("scratch.tiff") == "scratch.tiff"

Added `test_appendingPathComponent`.
Moved `test_deletingLastPathComponent` close to related tests ( `test_stringByAppendingPathExtension`, `test_deletingPathExtension`)


Before this commit, NSString and String had their own implementation and code was duplicated.
In this change, `NSString._stringByAppendingPathComponent` directly calls `String`'s internal function ( `_swiftObject._stringByAppendingPathComponent` ). Is this okay? @phausler 


