### PR TITLE
FIX variable naming change in HTTPMessage.swift

### DIFF
--- a/Foundation/URLSession/http/HTTPMessage.swift
+++ b/Foundation/URLSession/http/HTTPMessage.swift
@@ -91,9 +91,9 @@ extension _HTTPURLProtocol._ParsedResponseHeader {
 private extension _HTTPURLProtocol._ResponseHeaderLines {
     /// Returns a copy of the lines with the new line appended to it.
     func byAppending(headerLine line: String) -> _HTTPURLProtocol._ResponseHeaderLines {
-        var l = self.lines
-        l.append(line)
-        return _HTTPURLProtocol._ResponseHeaderLines(headerLines: l)
+        var lines = self.lines
+        lines.append(line)
+        return _HTTPURLProtocol._ResponseHeaderLines(headerLines: lines)
     }
 }
 internal extension _HTTPURLProtocol._ResponseHeaderLines {


### PR DESCRIPTION
var "l" can have ambiguous meaning.
while this function(func byAppending) scope is not broad now, it may be okay.
However, changing this ambiguous variable name to more obvious meaning such as "var lines" would be better in the long term purpose.