### PR TITLE
Fix FileHandle.truncateFile()

### DIFF
--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -144,9 +144,7 @@ open class FileHandle : NSObject, NSSecureCoding {
     }
     
     open func truncateFile(atOffset offset: UInt64) {
-        if lseek(_fd, off_t(offset), SEEK_SET) == 0 {
-            ftruncate(_fd, off_t(offset))
-        }
+        ftruncate(_fd, off_t(offset))
     }
     
     open func synchronizeFile() {


### PR DESCRIPTION
FileHandle.truncateFile() currently does not work. It attempts to do a lseek() to the requested file size, which is not required before calling ftruncate. Furthermore, it expects this call to lseek() to return 0, which only happens if truncateFile() is called with a 0 size. Thus, the function will only succeed if called to truncate the file to zero bytes. In other cases, it will silently fail.