### PR TITLE
[SR-6303] Handle non-existing UCalendarDateFields without crashing

### DIFF
--- a/CoreFoundation/Locale.subproj/CFCalendar.c
+++ b/CoreFoundation/Locale.subproj/CFCalendar.c
@@ -868,10 +868,12 @@ Boolean _CFCalendarComposeAbsoluteTimeV(CFCalendarRef calendar, /* out */ CFAbso
     ch = *desc;
     while (ch) {
         UCalendarDateFields field = __CFCalendarGetICUFieldCodeFromChar(ch);
-        int value = *vector;
-        if (UCAL_YEAR == field && doWOY) field = UCAL_YEAR_WOY;
-        if (UCAL_MONTH == field) value--;
-        ucal_set(calendar->_cal, field, value);
+        if (field != (UCalendarDateFields)-1) {
+            int value = *vector;
+            if (UCAL_YEAR == field && doWOY) field = UCAL_YEAR_WOY;
+            if (UCAL_MONTH == field) value--;
+            ucal_set(calendar->_cal, field, value);
+        }
         vector++;
         desc++;
         ch = *desc;
@@ -894,9 +896,13 @@ Boolean _CFCalendarDecomposeAbsoluteTimeV(CFCalendarRef calendar, CFAbsoluteTime
     char ch = *componentDesc;
     while (ch) {
         UCalendarDateFields field = __CFCalendarGetICUFieldCodeFromChar(ch);
-        int value = ucal_get(calendar->_cal, field, &status);
-        if (UCAL_MONTH == field) value++;
-        *(*vector) = value;
+        if (field == (UCalendarDateFields)-1) {
+            *(*vector) = -1;
+        } else {
+            int value = ucal_get(calendar->_cal, field, &status);
+            if (UCAL_MONTH == field) value++;
+            *(*vector) = value;
+        }
         vector++;
         componentDesc++;
         ch = *componentDesc;

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -449,7 +449,7 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     private func _convert(_ comps: DateComponents) -> (Array<Int32>, Array<Int8>) {
         var vector = [Int32]()
         var compDesc = [Int8]()
-        _convert(comps.era, type: "E", vector: &vector, compDesc: &compDesc)
+        _convert(comps.era, type: "G", vector: &vector, compDesc: &compDesc)
         _convert(comps.year, type: "y", vector: &vector, compDesc: &compDesc)
         _convert(comps.quarter, type: "Q", vector: &vector, compDesc: &compDesc)
         if comps.weekOfYear != NSDateComponentUndefined {
@@ -520,7 +520,9 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     
     private func _setComp(_ unitFlags: Unit, field: Unit, vector: [Int32], compIndex: inout Int, setter: (Int32) -> Void) {
         if unitFlags.contains(field) {
-            setter(vector[compIndex])
+            if vector[compIndex] != -1 {
+                setter(vector[compIndex])
+            }
             compIndex += 1
         }
     }

--- a/TestFoundation/TestDate.swift
+++ b/TestFoundation/TestDate.swift
@@ -36,6 +36,7 @@ class TestDate : XCTestCase {
             ("test_Compare", test_Compare),
             ("test_IsEqualToDate", test_IsEqualToDate),
             ("test_timeIntervalSinceReferenceDate", test_timeIntervalSinceReferenceDate),
+            ("test_recreateDateComponentsFromDate", test_recreateDateComponentsFromDate),
         ]
     }
     
@@ -122,5 +123,41 @@ class TestDate : XCTestCase {
         let d2 = Date().timeIntervalSinceReferenceDate
         XCTAssertTrue(d1 <= sinceReferenceDate)
         XCTAssertTrue(d2 >= sinceReferenceDate)
+    }
+    
+    func test_recreateDateComponentsFromDate() {
+        let components = DateComponents(calendar: Calendar(identifier: .gregorian),
+                                        timeZone: .current,
+                                        era: 1,
+                                        year: 2017,
+                                        month: 11,
+                                        day: 5,
+                                        hour: 20,
+                                        minute: 38,
+                                        second: 11,
+                                        nanosecond: 40)
+        guard let date = Calendar(identifier: .gregorian).date(from: components) else {
+            XCTFail()
+            return
+        }
+        let recreatedComponents = Calendar(identifier: .gregorian).dateComponents(in: .current, from: date)
+        XCTAssertEqual(recreatedComponents.era, 1)
+        XCTAssertEqual(recreatedComponents.year, 2017)
+        XCTAssertEqual(recreatedComponents.month, 11)
+        XCTAssertEqual(recreatedComponents.hour, 20)
+        XCTAssertEqual(recreatedComponents.minute, 38)
+        
+        // Nanoseconds are currently not supported by UCalendar C API, returns nil
+        // XCTAssertEqual(recreatedComponents.nanosecond, 40)
+        
+        XCTAssertEqual(recreatedComponents.weekday, 1)
+        XCTAssertEqual(recreatedComponents.weekdayOrdinal, 1)
+        
+        // Quarter is currently not supported by UCalendar C API, returns nil
+        // XCTAssertEqual(recreatedComponents.quarter, 3)
+        
+        XCTAssertEqual(recreatedComponents.weekOfMonth, 2)
+        XCTAssertEqual(recreatedComponents.weekOfYear, 45)
+        XCTAssertEqual(recreatedComponents.yearForWeekOfYear, 2017)
     }
 }


### PR DESCRIPTION
Resolves: [SR-6303](https://bugs.swift.org/browse/SR-6303)

Running this code:
```
let components = DateComponents(calendar: Calendar(identifier: .gregorian),
                                        timeZone: .current,
                                        era: 1,
                                        year: 2017,
                                        month: 11,
                                        day: 5,
                                        hour: 20,
                                        minute: 38,
                                        second: 11,
                                        nanosecond: 40)
        guard let date = Calendar(identifier: .gregorian).date(from: components) else {
           return
        }
        let recreatedComponents = Calendar(identifier: .gregorian).dateComponents(in: .current, from: date)
```
causes Thread 1: EXC_BAD_ACCESS (code=1, address=0x608a12c5cd78)
in: CFCalendar._CFCalendarComposeAbsoluteTimeV() 
on the line: ucal_set(calendar->_cal, field, value);

After investigating the issue, I found out that -1 is returned for UCalendarDateFields for nanoseconds and quarter calendar components. Also, one typo for the “era” components type was found.
 
I tried to handle this issue without crashing by moving -1 one level higher and handling this case so nil would be assigned to the nanoseconds and quarter fields instead of crashing.

Please let me know what you think.