### PR TITLE
Fix cast that is disallowed by SE-0054.

### DIFF
--- a/Foundation/NSKeyedArchiverHelpers.swift
+++ b/Foundation/NSKeyedArchiverHelpers.swift
@@ -29,7 +29,7 @@ internal class _NSKeyedArchiverUID : NSObject {
     }
 
     open override var hash: Int {
-        return Int(bitPattern: CFHash(_cfObject as CFTypeRef!))
+        return Int(bitPattern: CFHash(_cfObject as CFTypeRef?))
     }
     
     open override func isEqual(_ object: Any?) -> Bool {


### PR DESCRIPTION
SE-0054 (Abolish ImplicitlyUnwrappedOptionalType) substantially reduced
the number of places that '!' can be used, but the implementation missed
certain cases like this one. That implementation is being overhauled to
catch all the illegal cases.