### PR TITLE
[SR-2509] Add tests to assure that the issue is fixed

### DIFF
--- a/TestFoundation/TestCharacterSet.swift
+++ b/TestFoundation/TestCharacterSet.swift
@@ -75,11 +75,12 @@ class TestCharacterSet : XCTestCase {
             ("test_Planes", test_Planes),
             ("test_InlineBuffer", test_InlineBuffer),
             ("test_Equatable", test_Equatable),
-            // The following tests must remain disabled until SR-2509 is resolved.
             ("test_Subtracting", test_Subtracting),
             ("test_SubtractEmptySet", test_SubtractEmptySet),
             ("test_SubtractNonEmptySet", test_SubtractNonEmptySet),
             ("test_SymmetricDifference", test_SymmetricDifference),
+            ("test_formUnion", test_formUnion),
+            ("test_union", test_union),
         ]
     }
     
@@ -353,4 +354,16 @@ class TestCharacterSet : XCTestCase {
         XCTAssertNotEqual(Box.alphanumerics, Box.decimalDigits)
     }
 
+    func test_formUnion() {
+        var charset = CharacterSet(charactersIn: "a")
+        charset.formUnion(CharacterSet(charactersIn: "A"))
+        XCTAssertTrue(charset.contains("A" as UnicodeScalar))
+    }
+    
+    func test_union() {
+        let charset = CharacterSet(charactersIn: "a")
+        let union = charset.union(CharacterSet(charactersIn: "A"))
+        XCTAssertTrue(union.contains("A" as UnicodeScalar))
+    }
+    
 }


### PR DESCRIPTION
It seems like [SR-2509](https://bugs.swift.org/browse/SR-2509) is already fixed. I added a couple of additional tests to make sure that the CharacterSet.union() works as expected. 
I tested it on **macOS 10.12.6 + Xcode 9.0 + Swift 4.0** and also on **Ubuntu 14.04 + swift-4.0.2-RELEASE-ubuntu14.04**