### PR TITLE
Fix CFCharacterSet equality detection

### DIFF
--- a/TestFoundation/TestCharacterSet.swift
+++ b/TestFoundation/TestCharacterSet.swift
@@ -330,16 +330,11 @@ class TestCharacterSet : XCTestCase {
             ("12345", "12345")
         ]
         
-        /*
-         Tests disabled due to CoreFoundation bug?
-         These NSCharacterSet pairs are (wrongly?) evaluated to be equal. Same behaviour can be observed on macOS 10.12.
-         Interestingly, on iOS 11 Simulator, they are evaluted to be _not_ equal,
-         while on iOS 10.3.1 Simulator, they are evaluted to be equal.
-         */
         let notEqualPairs = [
             ("abc", "123"),
-//            ("ab", "abc"),
-//            ("abc", "")
+            ("ab", "abc"),
+            ("abc", ""),
+            ("abc", "abd")
         ]
         
         for pair in equalPairs {


### PR DESCRIPTION
I was investigating why the test checking the CharacterSet equality was failing.

Firstly, I found out that the _hashValue of the CFCharacterSet is always 0. The method that checks equality(__CFCharacterSetEqual) is checking the _hashValue, which is correct and the method calculating hash(__CFCharacterSetHash) seemed to do it properly but it seemed that it was simply never called to set the _hashValue field. 
So, as the solution for it, I decided to add this method call at the step of CFCharacterSet initialization when _hashValue should not be 0. After that the tests started to execute correctly, but I'm not sure if it's a correct solution, maybe there is a better way to do it.

Nevertheless, __CFCharacterSetEqual shouldn't rely only on hash but it also should check the contents, which it did, but most likely not correctly. I found out that here: 
```
const UniChar *buf1 = __CFCSetStringBuffer((CFCharacterSetRef)cf1);
const UniChar *buf1End = buf1 + __CFCSetStringLength((CFCharacterSetRef)cf1);
const UniChar *buf2 = __CFCSetStringBuffer((CFCharacterSetRef)cf2);
const UniChar *buf2End = buf2 + __CFCSetStringLength((CFCharacterSetRef)cf2);

 while ((buf1 < buf1End) && (buf2 < buf2End)) {
                        UniChar char1 = *buf1;
                        UniChar char2 = *buf2;

                        if (char1 != char2) return false;

                        do { ++buf1; } while ((buf1 < buf1End) && (char1 == *buf1));
                        do { ++buf2; } while ((buf2 < buf2End) && (char2 == *buf2));
                    }
```
because of `&&` operator in `while ((buf1 < buf1End) && (buf2 < buf2End)) `
 it was not comparing all the characters in both string buffers and replacing it with `||` fixes the issue. 
Also, for some cases we can make the comparison here easier simply by checking the length of the strings beforehand, which is also implemented in this PR.

Please, let me know what you think
