### PR TITLE
Change NSURL.description to match Darwin

### DIFF
--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -254,7 +254,7 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     }
     
     open override var description: String {
-        return CFCopyDescription(_cfObject)._swiftObject
+        return self.absoluteString
     }
 
     deinit {

--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -65,6 +65,7 @@ class TestURL : XCTestCase {
             ("test_copy", test_copy),
             ("test_itemNSCoding", test_itemNSCoding),
             ("test_dataRepresentation", test_dataRepresentation),
+            ("test_description", test_description),
         ]
     }
     
@@ -513,6 +514,11 @@ class TestURL : XCTestCase {
         let url2 = NSURL(dataRepresentation: url.dataRepresentation,
             relativeTo: nil)
         XCTAssertEqual(url, url2)
+    }
+
+   func test_description() {
+        let url = URL(string: "http://amazon.in")!
+        XCTAssertEqual(url.description, "http://amazon.in")
     }
 }
     


### PR DESCRIPTION
Consider this program
```swift
import Foundation

let nsurl = NSURL(string: "http://google.com")!
let url = URL(string: "http://amazon.in")!

print(url)
print(nsurl)
```

Output on Darwin
```
http://amazon.in
http://google.com
```

Output on Linux
```
<CFURL 0x8eb3ed0 [0x7f7f63d54c38]>{string = http://amazon.in, encoding = 134217984, base = (null)}
<CFURL 0x8e41620 [0x7f7f63d54c38]>{string = http://google.com, encoding = 134217984, base = (null)}
```

This PR makes the output on Linux same as that on Darwin. 