### PR TITLE
Implementing HTTPCookieStorage.description

### DIFF
--- a/Foundation/HTTPCookieStorage.swift
+++ b/Foundation/HTTPCookieStorage.swift
@@ -182,6 +182,10 @@ open class HTTPCookieStorage: NSObject {
         }
     }
     
+    open override var description: String {
+        return "<HTTPCookieStorage cookies count:\(cookies?.count ?? 0)>"
+    }
+
     private func createCookie(_ properties: [String: Any]) -> HTTPCookie? {
         var cookieProperties: [HTTPCookiePropertyKey: Any] = [:]
         for (key, value) in properties {

--- a/Foundation/HTTPCookieStorage.swift
+++ b/Foundation/HTTPCookieStorage.swift
@@ -183,7 +183,7 @@ open class HTTPCookieStorage: NSObject {
     }
     
     open override var description: String {
-        return "<HTTPCookieStorage cookies count:\(cookies?.count ?? 0)>"
+        return "<NSHTTPCookieStorage cookies count:\(cookies?.count ?? 0)>"
     }
 
     private func createCookie(_ properties: [String: Any]) -> HTTPCookie? {

--- a/TestFoundation/TestHTTPCookieStorage.swift
+++ b/TestFoundation/TestHTTPCookieStorage.swift
@@ -109,7 +109,7 @@ class TestHTTPCookieStorage: XCTestCase {
 
         storage.setCookie(simpleCookie)
         XCTAssertEqual(storage.cookies!.count, 0)
-        XCTAssertEqual(storage.description, "<HTTPCookieStorage cookies count:0>")
+        XCTAssertEqual(storage.description, "<NSHTTPCookieStorage cookies count:0>")
 
         let simpleCookie0 = HTTPCookie(properties: [   //no expiry date
            .name: "TestCookie1",
@@ -120,7 +120,7 @@ class TestHTTPCookieStorage: XCTestCase {
 
         storage.setCookie(simpleCookie0)
         XCTAssertEqual(storage.cookies!.count, 1)
-        XCTAssertEqual(storage.description, "<HTTPCookieStorage cookies count:1>")
+        XCTAssertEqual(storage.description, "<NSHTTPCookieStorage cookies count:1>")
 
         let simpleCookie1 = HTTPCookie(properties: [
            .name: "TestCookie1",
@@ -141,7 +141,7 @@ class TestHTTPCookieStorage: XCTestCase {
 
         storage.setCookie(simpleCookie2)
         XCTAssertEqual(storage.cookies!.count, 2)
-        XCTAssertEqual(storage.description, "<HTTPCookieStorage cookies count:2>")
+        XCTAssertEqual(storage.description, "<NSHTTPCookieStorage cookies count:2>")
     }
 
     func deleteCookie(with storageType: _StorageType) {

--- a/TestFoundation/TestHTTPCookieStorage.swift
+++ b/TestFoundation/TestHTTPCookieStorage.swift
@@ -109,6 +109,7 @@ class TestHTTPCookieStorage: XCTestCase {
 
         storage.setCookie(simpleCookie)
         XCTAssertEqual(storage.cookies!.count, 0)
+        XCTAssertEqual(storage.description, "<HTTPCookieStorage cookies count:0>")
 
         let simpleCookie0 = HTTPCookie(properties: [   //no expiry date
            .name: "TestCookie1",
@@ -119,6 +120,7 @@ class TestHTTPCookieStorage: XCTestCase {
 
         storage.setCookie(simpleCookie0)
         XCTAssertEqual(storage.cookies!.count, 1)
+        XCTAssertEqual(storage.description, "<HTTPCookieStorage cookies count:1>")
 
         let simpleCookie1 = HTTPCookie(properties: [
            .name: "TestCookie1",
@@ -139,6 +141,7 @@ class TestHTTPCookieStorage: XCTestCase {
 
         storage.setCookie(simpleCookie2)
         XCTAssertEqual(storage.cookies!.count, 2)
+        XCTAssertEqual(storage.description, "<HTTPCookieStorage cookies count:2>")
     }
 
     func deleteCookie(with storageType: _StorageType) {


### PR DESCRIPTION
Implementation of the description property for HTTPCookieStorage, to remain as close as possible to its behavior on darwin.
For this program:
```
import Foundation

print(HTTPCookieStorage.shared)
print(HTTPCookieStorage.sharedCookieStorage(forGroupContainerIdentifier: "test"))
```
... the output on Darwin is:
```
<NSHTTPCookieStorage cookies count:12>
<NSHTTPCookieStorage cookies count:1>
```
With this PR the output on Linux will be
```
<HTTPCookieStorage cookies count:12>
<HTTPCookieStorage cookies count:1>
```