### PR TITLE
Remove macOS @available version restrictions.

### DIFF
--- a/Foundation/Calendar.swift
+++ b/Foundation/Calendar.swift
@@ -1051,83 +1051,45 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     }
     
     internal static func _toNSCalendarIdentifier(_ identifier: Identifier) -> NSCalendar.Identifier {
-        if #available(OSX 10.10, iOS 8.0, *) {
-            let identifierMap: [Identifier : NSCalendar.Identifier] =
-                [.gregorian: .gregorian,
-                 .buddhist: .buddhist,
-                 .chinese: .chinese,
-                 .coptic: .coptic,
-                 .ethiopicAmeteMihret: .ethiopicAmeteMihret,
-                 .ethiopicAmeteAlem: .ethiopicAmeteAlem,
-                 .hebrew: .hebrew,
-                 .iso8601: .ISO8601,
-                 .indian: .indian,
-                 .islamic: .islamic,
-                 .islamicCivil: .islamicCivil,
-                 .japanese: .japanese,
-                 .persian: .persian,
-                 .republicOfChina: .republicOfChina,
-                 .islamicTabular: .islamicTabular,
-                 .islamicUmmAlQura: .islamicUmmAlQura]
-            return identifierMap[identifier]!
-        } else {
-            let identifierMap: [Identifier : NSCalendar.Identifier] =
-                [.gregorian: .gregorian,
-                 .buddhist: .buddhist,
-                 .chinese: .chinese,
-                 .coptic: .coptic,
-                 .ethiopicAmeteMihret: .ethiopicAmeteMihret,
-                 .ethiopicAmeteAlem: .ethiopicAmeteAlem,
-                 .hebrew: .hebrew,
-                 .iso8601: .ISO8601,
-                 .indian: .indian,
-                 .islamic: .islamic,
-                 .islamicCivil: .islamicCivil,
-                 .japanese: .japanese,
-                 .persian: .persian,
-                 .republicOfChina: .republicOfChina]
-            return identifierMap[identifier]!
-        }
+        let identifierMap: [Identifier : NSCalendar.Identifier] =
+            [.gregorian: .gregorian,
+             .buddhist: .buddhist,
+             .chinese: .chinese,
+             .coptic: .coptic,
+             .ethiopicAmeteMihret: .ethiopicAmeteMihret,
+             .ethiopicAmeteAlem: .ethiopicAmeteAlem,
+             .hebrew: .hebrew,
+             .iso8601: .ISO8601,
+             .indian: .indian,
+             .islamic: .islamic,
+             .islamicCivil: .islamicCivil,
+             .japanese: .japanese,
+             .persian: .persian,
+             .republicOfChina: .republicOfChina,
+             .islamicTabular: .islamicTabular,
+             .islamicUmmAlQura: .islamicUmmAlQura]
+        return identifierMap[identifier]!
     }
     
     internal static func _fromNSCalendarIdentifier(_ identifier: NSCalendar.Identifier) -> Identifier {
-        if #available(OSX 10.10, iOS 8.0, *) {
-            let identifierMap: [NSCalendar.Identifier : Identifier] =
-                [.gregorian: .gregorian,
-                 .buddhist: .buddhist,
-                 .chinese: .chinese,
-                 .coptic: .coptic,
-                 .ethiopicAmeteMihret: .ethiopicAmeteMihret,
-                 .ethiopicAmeteAlem: .ethiopicAmeteAlem,
-                 .hebrew: .hebrew,
-                 .ISO8601: .iso8601,
-                 .indian: .indian,
-                 .islamic: .islamic,
-                 .islamicCivil: .islamicCivil,
-                 .japanese: .japanese,
-                 .persian: .persian,
-                 .republicOfChina: .republicOfChina,
-                 .islamicTabular: .islamicTabular,
-                 .islamicUmmAlQura: .islamicUmmAlQura]
-            return identifierMap[identifier]!
-        } else {
-            let identifierMap: [NSCalendar.Identifier : Identifier] =
-                [.gregorian: .gregorian,
-                 .buddhist: .buddhist,
-                 .chinese: .chinese,
-                 .coptic: .coptic,
-                 .ethiopicAmeteMihret: .ethiopicAmeteMihret,
-                 .ethiopicAmeteAlem: .ethiopicAmeteAlem,
-                 .hebrew: .hebrew,
-                 .ISO8601: .iso8601,
-                 .indian: .indian,
-                 .islamic: .islamic,
-                 .islamicCivil: .islamicCivil,
-                 .japanese: .japanese,
-                 .persian: .persian,
-                 .republicOfChina: .republicOfChina]
-            return identifierMap[identifier]!
-        }
+        let identifierMap: [NSCalendar.Identifier : Identifier] =
+            [.gregorian: .gregorian,
+             .buddhist: .buddhist,
+             .chinese: .chinese,
+             .coptic: .coptic,
+             .ethiopicAmeteMihret: .ethiopicAmeteMihret,
+             .ethiopicAmeteAlem: .ethiopicAmeteAlem,
+             .hebrew: .hebrew,
+             .ISO8601: .iso8601,
+             .indian: .indian,
+             .islamic: .islamic,
+             .islamicCivil: .islamicCivil,
+             .japanese: .japanese,
+             .persian: .persian,
+             .republicOfChina: .republicOfChina,
+             .islamicTabular: .islamicTabular,
+             .islamicUmmAlQura: .islamicUmmAlQura]
+        return identifierMap[identifier]!
     }
 }
 

--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -39,19 +39,7 @@ import _SwiftFoundationOverlayShims
 import _SwiftCoreFoundationOverlayShims
     
 internal func __NSDataIsCompact(_ data: NSData) -> Bool {
-    if #available(OSX 10.10, iOS 9.0, tvOS 9.0, watchOS 2.0, *) {
-        return data._isCompact()
-    } else {
-        var compact = true
-        let len = data.length
-        data.enumerateBytes { (_, byteRange, stop) in
-            if byteRange.length != len {
-                compact = false
-            }
-            stop.pointee = true
-        }
-        return compact
-    }
+    return data._isCompact()
 }
 
 @_silgen_name("__NSDataWriteToURL")

--- a/Foundation/JSONEncoder.swift
+++ b/Foundation/JSONEncoder.swift
@@ -34,7 +34,6 @@ open class JSONEncoder {
         public static let prettyPrinted = OutputFormatting(rawValue: 1 << 0)
 
         /// Produce JSON with dictionary keys sorted in lexicographic order.
-        @available(OSX 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
         public static let sortedKeys    = OutputFormatting(rawValue: 1 << 1)
     }
 
@@ -50,7 +49,6 @@ open class JSONEncoder {
         case millisecondsSince1970
 
         /// Encode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
-        @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
         case iso8601
 
         /// Encode the `Date` as a string formatted by the given formatter.
@@ -650,11 +648,7 @@ extension _JSONEncoder {
             return NSNumber(value: 1000.0 * date.timeIntervalSince1970)
 
         case .iso8601:
-            if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
-                return NSString(string: _iso8601Formatter.string(from: date))
-            } else {
-                fatalError("ISO8601DateFormatter is unavailable on this platform.")
-            }
+            return NSString(string: _iso8601Formatter.string(from: date))
 
         case .formatted(let formatter):
             return NSString(string: formatter.string(from: date))
@@ -822,7 +816,6 @@ open class JSONDecoder {
         case millisecondsSince1970
 
         /// Decode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
-        @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
         case iso8601
 
         /// Decode the `Date` as a string parsed by the given formatter.
@@ -2022,16 +2015,11 @@ extension _JSONDecoder {
             return Date(timeIntervalSince1970: double / 1000.0)
 
         case .iso8601:
-            if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
-                let string = try self.unbox(value, as: String.self)!
-                guard let date = _iso8601Formatter.date(from: string) else {
-                    throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected date string to be ISO8601-formatted."))
-                }
-
-                return date
-            } else {
-                fatalError("ISO8601DateFormatter is unavailable on this platform.")
+            let string = try self.unbox(value, as: String.self)!
+            guard let date = _iso8601Formatter.date(from: string) else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected date string to be ISO8601-formatted."))
             }
+            return date
 
         case .formatted(let formatter):
             let string = try self.unbox(value, as: String.self)!
@@ -2150,7 +2138,6 @@ fileprivate struct _JSONKey : CodingKey {
 //===----------------------------------------------------------------------===//
 
 // NOTE: This value is implicitly lazy and _must_ be lazy. We're compiled against the latest SDK (w/ ISO8601DateFormatter), but linked against whichever Foundation the user has. ISO8601DateFormatter might not exist, so we better not hit this code path on an older OS.
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
 fileprivate var _iso8601Formatter: ISO8601DateFormatter = {
     let formatter = ISO8601DateFormatter()
     formatter.formatOptions = .withInternetDateTime

--- a/Foundation/NSStringAPI.swift
+++ b/Foundation/NSStringAPI.swift
@@ -542,7 +542,6 @@ extension StringProtocol where Index == String.Index {
 
   /// A capitalized representation of the string that is produced
   /// using the current locale.
-  @available(OSX 10.11, iOS 9.0, *)
   public var localizedCapitalized: String {
     return _ns.localizedCapitalized
   }
@@ -888,7 +887,6 @@ extension StringProtocol where Index == String.Index {
 
   /// A lowercase version of the string that is produced using the current
   /// locale.
-  @available(OSX 10.11, iOS 9.0, *)
   public var localizedLowercase: String {
     return _ns.localizedLowercase
   }
@@ -953,7 +951,6 @@ extension StringProtocol where Index == String.Index {
   /// similar to how searches are done generally in the system.  The search is
   /// locale-aware, case and diacritic insensitive.  The exact list of search
   /// options applied may change over time.
-  @available(OSX 10.11, iOS 9.0, *)
   public func localizedStandardContains<
     T : StringProtocol
   >(_ string: T) -> Bool {
@@ -1128,7 +1125,6 @@ extension StringProtocol where Index == String.Index {
 
   /// An uppercase version of the string that is produced using the current
   /// locale.
-  @available(OSX 10.11, iOS 9.0, *)
   public var localizedUppercase: String {
     return _ns.localizedUppercase as String
   }
@@ -1185,7 +1181,6 @@ extension StringProtocol where Index == String.Index {
 
 #if !DEPLOYMENT_RUNTIME_SWIFT
   /// Perform string transliteration.
-  @available(OSX 10.11, iOS 9.0, *)
   public func applyingTransform(
     _ transform: StringTransform, reverse: Bool
   ) -> String? {
@@ -1604,7 +1599,6 @@ extension StringProtocol where Index == String.Index {
   /// similar to how searches are done generally in the system.  The search is
   /// locale-aware, case and diacritic insensitive.  The exact list of search
   /// options applied may change over time.
-  @available(OSX 10.11, iOS 9.0, *)
   public func localizedStandardRange<
     T : StringProtocol
   >(of string: T) -> Range<Index>? {
@@ -1638,9 +1632,7 @@ extension StringProtocol where Index == String.Index {
   /// Equivalent to `self.rangeOfString(other) != nil`
   public func contains<T : StringProtocol>(_ other: T) -> Bool {
     let r = self.range(of: other) != nil
-    if #available(OSX 10.10, iOS 8.0, *) {
-      _sanityCheck(r == _ns.contains(other._ephemeralString))
-    }
+    _sanityCheck(r == _ns.contains(other._ephemeralString))
     return r
   }
 
@@ -1661,10 +1653,7 @@ extension StringProtocol where Index == String.Index {
     let r = self.range(
       of: other, options: .caseInsensitive, locale: Locale.current
     ) != nil
-    if #available(OSX 10.10, iOS 8.0, *) {
-      _sanityCheck(r ==
-        _ns.localizedCaseInsensitiveContains(other._ephemeralString))
-    }
+    _sanityCheck(r == _ns.localizedCaseInsensitiveContains(other._ephemeralString))
     return r
   }
 }

--- a/Foundation/URLComponents.swift
+++ b/Foundation/URLComponents.swift
@@ -315,9 +315,7 @@ extension URLComponents : CustomStringConvertible, CustomDebugStringConvertible,
         if let p = self.port { c.append((label: "port", value: p)) }
         
         c.append((label: "path", value: self.path))
-        if #available(OSX 10.10, iOS 8.0, *) {
-            if let qi = self.queryItems { c.append((label: "queryItems", value: qi )) }
-        }
+        if let qi = self.queryItems { c.append((label: "queryItems", value: qi )) }
         if let f = self.fragment { c.append((label: "fragment", value: f)) }
         let m = Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
         return m


### PR DESCRIPTION
Im not sure if this is valid, but restricting some methods to certain versions of macOS doesn't seem necessary here.

At the same time, some of there `if #available` that rely on Foundation don't seem to be needed given that they are contained in this version of Foundation.

Tested on linux and macOS 10.12

@parkera @phausler Is this ok or am I on the wrong track here?