### PR TITLE
Revert "Adapt to renaming of _getDefaultErrorCode() SPI."

### DIFF
--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -282,7 +282,7 @@ public extension CustomNSError {
 
     /// The error code within the given domain.
     var errorCode: Int {
-        return _getDefaultErrorCode(self)
+        return _swift_getDefaultErrorCode(self)
     }
 
     /// The default user-info dictionary.


### PR DESCRIPTION
This reverts commit 14e9a795ac0baa82daeae2ffe588310007a9008d. We don't want this change in the 4.1 branch, since the corresponding Swift runtime change is not there yet either.