### PR TITLE
[SR-6419] Use `@available(*, unavailable)` instead of inappropriate `@available(*, obsoleted: 4.0)`

### DIFF
--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -188,7 +188,7 @@ open class NotificationCenter: NSObject {
         })
     }
 
-    @available(*,obsoleted:4.0,renamed:"addObserver(forName:object:queue:using:)")
+    @available(*, unavailable, renamed: "addObserver(forName:object:queue:using:)")
     open func addObserver(forName name: NSNotification.Name?, object obj: Any?, queue: OperationQueue?, usingBlock block: @escaping (Notification) -> Void) -> NSObjectProtocol {
         return addObserver(forName: name, object: obj, queue: queue, using: block)
     }


### PR DESCRIPTION
Fixes [SR-6419](https://bugs.swift.org/browse/SR-6419).