### PR TITLE
build: migrate to the new ELF registration scheme

### DIFF
--- a/lib/product.py
+++ b/lib/product.py
@@ -71,8 +71,7 @@ class Product(BuildAction):
         return Path.path(Configuration.current.build_directory.path_by_appending(self.name).absolute() + "/" + self.PROJECT_HEADERS_FOLDER_PATH)
 
 class Library(Product):
-    conformance_begin = ""
-    conformance_end = ""
+    runtime_object = ''
     rule = None
     def __init__(self, name):
         Product.__init__(self, name)
@@ -91,7 +90,7 @@ class Library(Product):
             product_flags += " -lstdc++"
 
         generated += """
-build """ + self.product.relative() + """: """ + self.rule + """ """ + self.conformance_begin + """ """ + " ".join(objects) + """ """ + self.conformance_end + """ """ + self.generate_dependencies() + """
+build """ + self.product.relative() + """: """ + self.rule + """ """ + self.runtime_object + """ """ + " ".join(objects) + """ """ + self.generate_dependencies() + """
     flags = """ + product_flags
         if self.needs_objc:
             generated += """
@@ -119,8 +118,7 @@ class DynamicLibrary(Library):
         self.rule = "Link"
         self.product_name = Configuration.current.target.dynamic_library_prefix + self.name + Configuration.current.target.dynamic_library_suffix
         if Configuration.current.target.sdk == OSType.Linux or Configuration.current.target.sdk == OSType.FreeBSD:
-            self.conformance_begin = '${SDKROOT}/lib/swift/${OS}/${ARCH}/swift_begin.o' 
-            self.conformance_end = '${SDKROOT}/lib/swift/${OS}/${ARCH}/swift_end.o' 
+            self.runtime_object = '${SDKROOT}/lib/swift/${OS}/${ARCH}/swiftrt.o'
             return Library.generate(self, ["-shared", "-Wl,-soname," + self.product_name, "-Wl,--no-undefined"], objects)
         else:
             return Library.generate(self, ["-shared"], objects)
@@ -182,8 +180,7 @@ class StaticLibrary(Library):
     def generate(self, objects = []):
         self.rule = "Archive"
         self.product_name = Configuration.current.target.static_library_prefix + self.name + Configuration.current.target.static_library_suffix
-        self.conformance_begin = ''
-        self.conformance_end = ''
+        self.runtime_object = ''
         return Library.generate(self, [], objects)
 
 class StaticAndDynamicLibrary(StaticLibrary, DynamicLibrary):


### PR DESCRIPTION
The new ELF registration scheme uses linker tables and only requires a
single object to be added to the link.