### PR TITLE
CFError: fix compile warning

### DIFF
--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -395,8 +395,8 @@ extension CFError : Error {
         return CFErrorGetCode(self)
     }
 
-    public var _userInfo: Any? {
-        return CFErrorCopyUserInfo(self) as Any
+    public var _userInfo: AnyObject? {
+        return CFErrorCopyUserInfo(self) as AnyObject
     }
 }
 


### PR DESCRIPTION
`CFError` conforms to `Error` and contains a `public var _userInfo`.

In https://github.com/apple/swift/commit/77a360907f7d04f253c8a707f61a3de55516a887 the type of this var was changed from `Any?` to `AnyObject?` but this change was not made in SCLF too.

Consequently there is currently a compiler warning:

> Var '_userInfo' nearly matches defaulted requirement '_userInfo' of
> protocol 'Error'

Fix this warning by adjusting the type of the `_userInfo` var.