### PR TITLE
NSLock: fix warnings on macOS

### DIFF
--- a/Foundation/NSLock.swift
+++ b/Foundation/NSLock.swift
@@ -303,12 +303,12 @@ private func timeSpecFrom(date: Date) -> timespec? {
 
 private func deallocateTimedLockData(cond: _PthreadCondPointer, mutex: _PthreadMutexPointer) {
     pthread_cond_destroy(cond)
-    cond.deinitialize()
-    cond.deallocate(capacity: 1)
+    cond.deinitialize(count: 1)
+    cond.deallocate()
 
     pthread_mutex_destroy(mutex)
-    mutex.deinitialize()
-    mutex.deallocate(capacity: 1)
+    mutex.deinitialize(count: 1)
+    mutex.deallocate()
 }
 
 // Emulate pthread_mutex_timedlock using pthread_cond_timedwait.


### PR DESCRIPTION
In https://github.com/apple/swift-corelibs-foundation/commit/6476c4fdae88e00688d743af5130179a5b2329d8 changes were made for compatibility with SE-0184.

A function in `NSLock` was missed though, probably because it is only compiled when building the project in Xcode on macOS.

Fix these warnings too.