### PR TITLE
Moving HTTPBodySource out of http folder and renaming to BodySource

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -332,7 +332,7 @@
 		B9974B981EDF4A22007F15B8 /* libcurlHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B911EDF4A22007F15B8 /* libcurlHelpers.swift */; };
 		B9974B991EDF4A22007F15B8 /* HTTPURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B921EDF4A22007F15B8 /* HTTPURLProtocol.swift */; };
 		B9974B9A1EDF4A22007F15B8 /* HTTPMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B931EDF4A22007F15B8 /* HTTPMessage.swift */; };
-		B9974B9B1EDF4A22007F15B8 /* HTTPBodySource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B941EDF4A22007F15B8 /* HTTPBodySource.swift */; };
+		B9974B9B1EDF4A22007F15B8 /* BodySource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B941EDF4A22007F15B8 /* BodySource.swift */; };
 		B9974B9C1EDF4A22007F15B8 /* EasyHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B951EDF4A22007F15B8 /* EasyHandle.swift */; };
 		BD8042161E09857800487EB8 /* TestLengthFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8042151E09857800487EB8 /* TestLengthFormatter.swift */; };
 		BDBB65901E256BFA001A7286 /* TestEnergyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDBB658F1E256BFA001A7286 /* TestEnergyFormatter.swift */; };
@@ -803,7 +803,7 @@
 		B9974B911EDF4A22007F15B8 /* libcurlHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = libcurlHelpers.swift; sourceTree = "<group>"; };
 		B9974B921EDF4A22007F15B8 /* HTTPURLProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HTTPURLProtocol.swift; path = http/HTTPURLProtocol.swift; sourceTree = "<group>"; };
 		B9974B931EDF4A22007F15B8 /* HTTPMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HTTPMessage.swift; path = http/HTTPMessage.swift; sourceTree = "<group>"; };
-		B9974B941EDF4A22007F15B8 /* HTTPBodySource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HTTPBodySource.swift; path = http/HTTPBodySource.swift; sourceTree = "<group>"; };
+		B9974B941EDF4A22007F15B8 /* BodySource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BodySource.swift; sourceTree = "<group>"; };
 		B9974B951EDF4A22007F15B8 /* EasyHandle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EasyHandle.swift; sourceTree = "<group>"; };
 		BD8042151E09857800487EB8 /* TestLengthFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLengthFormatter.swift; sourceTree = "<group>"; };
 		BDBB658F1E256BFA001A7286 /* TestEnergyFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEnergyFormatter.swift; sourceTree = "<group>"; };
@@ -998,6 +998,7 @@
 				614732781FC2DEB7005B5E61 /* libcurl */,
 				E4F889331E9CF04D008A70EB /* http */,
 				5B1FD9C81D6D16580080E83C /* Configuration.swift */,
+				B9974B941EDF4A22007F15B8 /* BodySource.swift */,
 				5B1FD9CE1D6D16580080E83C /* URLSession.swift */,
 				5B1FD9CF1D6D16580080E83C /* URLSessionConfiguration.swift */,
 				5B1FD9D01D6D16580080E83C /* URLSessionDelegate.swift */,
@@ -1381,7 +1382,6 @@
 				B9974B921EDF4A22007F15B8 /* HTTPURLProtocol.swift */,
 				B9974B8F1EDF4A22007F15B8 /* TransferState.swift */,
 				B9974B931EDF4A22007F15B8 /* HTTPMessage.swift */,
-				B9974B941EDF4A22007F15B8 /* HTTPBodySource.swift */,
 			);
 			name = http;
 			sourceTree = "<group>";
@@ -2236,7 +2236,7 @@
 				EADE0BB81BD15E0000C49C64 /* Process.swift in Sources */,
 				5BF7AEB31BCD51F9008F214A /* NSObjCRuntime.swift in Sources */,
 				5BD31D3F1D5D19D600563814 /* Dictionary.swift in Sources */,
-				B9974B9B1EDF4A22007F15B8 /* HTTPBodySource.swift in Sources */,
+				B9974B9B1EDF4A22007F15B8 /* BodySource.swift in Sources */,
 				5B94E8821C430DE70055C035 /* NSStringAPI.swift in Sources */,
 				5B0163BB1D024EB7003CCD96 /* DateComponents.swift in Sources */,
 				5BF7AEAB1BCD51F9008F214A /* NSDictionary.swift in Sources */,

--- a/Foundation/URLSession/BodySource.swift
+++ b/Foundation/URLSession/BodySource.swift
@@ -1,4 +1,4 @@
-// Foundation/URLSession/HTTPBodySource.swift - URLSession & libcurl
+// Foundation/URLSession/BodySource.swift - URLSession & libcurl
 //
 // This source file is part of the Swift.org open source project
 //
@@ -39,16 +39,16 @@ internal func splitData(dispatchData data: DispatchData, atPosition position: In
     return (data.subdata(in: 0..<position), data.subdata(in: position..<data.count))
 }
 
-/// A (non-blocking) source for HTTP body data.
-internal protocol _HTTPBodySource: class {
+/// A (non-blocking) source for body data.
+internal protocol _BodySource: class {
     /// Get the next chunck of data.
     ///
     /// - Returns: `.data` until the source is exhausted, at which point it will
     /// return `.done`. Since this is non-blocking, it will return `.retryLater`
     /// if no data is available at this point, but will be available later.
-    func getNextChunk(withLength length: Int) -> _HTTPBodySourceDataChunk
+    func getNextChunk(withLength length: Int) -> _BodySourceDataChunk
 }
-internal enum _HTTPBodySourceDataChunk {
+internal enum _BodySourceDataChunk {
     case data(DispatchData)
     /// The source is depleted.
     case done
@@ -57,20 +57,20 @@ internal enum _HTTPBodySourceDataChunk {
     case error
 }
 
-/// A HTTP body data source backed by `DispatchData`.
-internal final class _HTTPBodyDataSource {
+/// A body data source backed by `DispatchData`.
+internal final class _BodyDataSource {
     var data: DispatchData! 
     init(data: DispatchData) {
         self.data = data
     }
 }
 
-extension _HTTPBodyDataSource : _HTTPBodySource {
+extension _BodyDataSource : _BodySource {
     enum _Error : Error {
         case unableToRewindData
     }
 
-    func getNextChunk(withLength length: Int) -> _HTTPBodySourceDataChunk {
+    func getNextChunk(withLength length: Int) -> _BodySourceDataChunk {
         let remaining = data.count
         if remaining == 0 {
             return .done
@@ -98,7 +98,7 @@ extension _HTTPBodyDataSource : _HTTPBodySource {
 /// - Note: Calls to `getNextChunk(withLength:)` and callbacks from libdispatch
 /// should all happen on the same (serial) queue, and hence this code doesn't
 /// have to be thread safe.
-internal final class _HTTPBodyFileSource {
+internal final class _BodyFileSource {
     fileprivate let fileURL: URL
     fileprivate let channel: DispatchIO 
     fileprivate let workQueue: DispatchQueue 
@@ -146,7 +146,7 @@ internal final class _HTTPBodyFileSource {
     }
 }
 
-fileprivate extension _HTTPBodyFileSource {
+fileprivate extension _BodyFileSource {
     fileprivate var desiredBufferLength: Int { return 3 * CFURLSessionMaxWriteSize }
     /// Enqueue a dispatch I/O read to fill the buffer.
     ///
@@ -208,8 +208,8 @@ fileprivate extension _HTTPBodyFileSource {
     }
 }
 
-extension _HTTPBodyFileSource : _HTTPBodySource {
-    func getNextChunk(withLength length: Int) -> _HTTPBodySourceDataChunk {    
+extension _BodyFileSource : _BodySource {
+    func getNextChunk(withLength length: Int) -> _BodySourceDataChunk {    
         switch availableChunk {
         case .empty:
             readNextChunk()

--- a/Foundation/URLSession/http/HTTPURLProtocol.swift
+++ b/Foundation/URLSession/http/HTTPURLProtocol.swift
@@ -424,10 +424,10 @@ extension _HTTPURLProtocol {
         case .none:
             return _HTTPTransferState(url: url, bodyDataDrain: drain)
         case .data(let data):
-            let source = _HTTPBodyDataSource(data: data)
+            let source = _BodyDataSource(data: data)
             return _HTTPTransferState(url: url, bodyDataDrain: drain, bodySource: source)
         case .file(let fileURL):
-            let source = _HTTPBodyFileSource(fileURL: fileURL, workQueue: workQueue, dataAvailableHandler: { [weak self] in
+            let source = _BodyFileSource(fileURL: fileURL, workQueue: workQueue, dataAvailableHandler: { [weak self] in
                 // Unpause the easy handle
                 self?.easyHandle.unpauseSend()
             })

--- a/Foundation/URLSession/http/TransferState.swift
+++ b/Foundation/URLSession/http/TransferState.swift
@@ -39,7 +39,7 @@ extension _HTTPURLProtocol {
         /// Once the headers is complete, this will contain the response
         var response: HTTPURLResponse?
         /// The body data to be sent in the request
-        let requestBodySource: _HTTPBodySource?
+        let requestBodySource: _BodySource?
         /// Body data received
         let bodyDataDrain: _DataDrain
         /// Describes what to do with received body data for this transfer:
@@ -67,7 +67,7 @@ extension _HTTPURLProtocol._HTTPTransferState {
         self.bodyDataDrain = bodyDataDrain
     }
     /// Transfer state that sends body data and can receive body data.
-    init(url: URL, bodyDataDrain: _HTTPURLProtocol._DataDrain, bodySource: _HTTPBodySource) {
+    init(url: URL, bodyDataDrain: _HTTPURLProtocol._DataDrain, bodySource: _BodySource) {
         self.url = url
         self.parsedResponseHeader = _HTTPURLProtocol._ParsedResponseHeader()
         self.response = nil
@@ -131,7 +131,7 @@ extension _HTTPURLProtocol._HTTPTransferState {
     ///
     /// This can be used to either set the initial body source, or to reset it
     /// e.g. when restarting a transfer.
-    func bySetting(bodySource newSource: _HTTPBodySource) -> _HTTPURLProtocol._HTTPTransferState {
+    func bySetting(bodySource newSource: _BodySource) -> _HTTPURLProtocol._HTTPTransferState {
         return _HTTPURLProtocol._HTTPTransferState(url: url, parsedResponseHeader: parsedResponseHeader, response: response, requestBodySource: newSource, bodyDataDrain: bodyDataDrain)
     }
 }

--- a/build.py
+++ b/build.py
@@ -425,7 +425,7 @@ swift_sources = CompileSwiftSources([
 	'Foundation/URLResponse.swift',
 	'Foundation/URLSession/Configuration.swift',
 	'Foundation/URLSession/libcurl/EasyHandle.swift',
-	'Foundation/URLSession/http/HTTPBodySource.swift',
+	'Foundation/URLSession/BodySource.swift',
 	'Foundation/URLSession/http/HTTPMessage.swift',
 	'Foundation/URLSession/libcurl/MultiHandle.swift',
 	'Foundation/URLSession/URLSession.swift',


### PR DESCRIPTION
HTTPBodySource.swift should be platform agnostic. Basically this class deals with conversion of ```DispatchData```   to ```Data ``` and vice-versa. Hence this functionality is not protocol specific.

For eg:
It can be used to read the data received  from data port in case of FTP too.

Hence, moving out and renaming it  .

This PR was actually part of #1216 