### PR TITLE
Fix warning: overlapping access to 'self'

### DIFF
--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -583,8 +583,9 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         var at: CFAbsoluteTime = date.timeIntervalSinceReferenceDate
         
         let res: Bool = withUnsafeMutablePointer(to: &at) { t in
+            let copy = vector
             return vector.withUnsafeMutableBufferPointer { (vectorBuffer: inout UnsafeMutableBufferPointer<Int32>) in
-                return _CFCalendarAddComponentsV(_cfObject, t, CFOptionFlags(opts.rawValue), compDesc, vectorBuffer.baseAddress!, Int32(vector.count))
+                return _CFCalendarAddComponentsV(_cfObject, t, CFOptionFlags(opts.rawValue), compDesc, vectorBuffer.baseAddress!, Int32(copy.count))
             }
         }
         
@@ -603,8 +604,9 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
                 return intArrayBuffer.baseAddress!.advanced(by: idx)
             }
 
+            let copy = vector
             return vector.withUnsafeMutableBufferPointer { (vecBuffer: inout UnsafeMutableBufferPointer<UnsafeMutablePointer<Int32>>) in
-                return _CFCalendarGetComponentDifferenceV(_cfObject, startingDate.timeIntervalSinceReferenceDate, resultDate.timeIntervalSinceReferenceDate, CFOptionFlags(opts.rawValue), compDesc, vecBuffer.baseAddress!, Int32(vector.count))
+                return _CFCalendarGetComponentDifferenceV(_cfObject, startingDate.timeIntervalSinceReferenceDate, resultDate.timeIntervalSinceReferenceDate, CFOptionFlags(opts.rawValue), compDesc, vecBuffer.baseAddress!, Int32(copy.count))
             }
         }
         if res {

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -583,9 +583,9 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         var at: CFAbsoluteTime = date.timeIntervalSinceReferenceDate
         
         let res: Bool = withUnsafeMutablePointer(to: &at) { t in
-            let copy = vector
+            let count = Int32(vector.count)
             return vector.withUnsafeMutableBufferPointer { (vectorBuffer: inout UnsafeMutableBufferPointer<Int32>) in
-                return _CFCalendarAddComponentsV(_cfObject, t, CFOptionFlags(opts.rawValue), compDesc, vectorBuffer.baseAddress!, Int32(copy.count))
+                return _CFCalendarAddComponentsV(_cfObject, t, CFOptionFlags(opts.rawValue), compDesc, vectorBuffer.baseAddress!, count)
             }
         }
         
@@ -604,9 +604,9 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
                 return intArrayBuffer.baseAddress!.advanced(by: idx)
             }
 
-            let copy = vector
+            let count = Int32(vector.count)
             return vector.withUnsafeMutableBufferPointer { (vecBuffer: inout UnsafeMutableBufferPointer<UnsafeMutablePointer<Int32>>) in
-                return _CFCalendarGetComponentDifferenceV(_cfObject, startingDate.timeIntervalSinceReferenceDate, resultDate.timeIntervalSinceReferenceDate, CFOptionFlags(opts.rawValue), compDesc, vecBuffer.baseAddress!, Int32(copy.count))
+                return _CFCalendarGetComponentDifferenceV(_cfObject, startingDate.timeIntervalSinceReferenceDate, resultDate.timeIntervalSinceReferenceDate, CFOptionFlags(opts.rawValue), compDesc, vecBuffer.baseAddress!, count)
             }
         }
         if res {

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -924,13 +924,14 @@ extension TestNSData {
         XCTAssertEqual(mutatingHello.count, helloLength * 2, "The length should have changed")
         
         // Get the underlying data for hello2
+        let copy = mutatingHello
         mutatingHello.withUnsafeMutableBytes { (bytes : UnsafeMutablePointer<UInt8>) in
             XCTAssertEqual(bytes.pointee, 0x68, "First byte should be 0x68")
             
             // Mutate it
             bytes.pointee = 0x67
             XCTAssertEqual(bytes.pointee, 0x67, "First byte should be 0x67")
-            XCTAssertEqual(mutatingHello[0], 0x67, "First byte accessed via other method should still be 0x67")
+            XCTAssertEqual(copy[0], 0x67, "First byte accessed via other method should still be 0x67")
             
             // Verify that the first data is still correct
             XCTAssertEqual(hello[0], 0x68, "The first byte should still be 0x68")

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -924,18 +924,17 @@ extension TestNSData {
         XCTAssertEqual(mutatingHello.count, helloLength * 2, "The length should have changed")
         
         // Get the underlying data for hello2
-        let copy = mutatingHello
         mutatingHello.withUnsafeMutableBytes { (bytes : UnsafeMutablePointer<UInt8>) in
             XCTAssertEqual(bytes.pointee, 0x68, "First byte should be 0x68")
             
             // Mutate it
             bytes.pointee = 0x67
             XCTAssertEqual(bytes.pointee, 0x67, "First byte should be 0x67")
-            XCTAssertEqual(copy[0], 0x67, "First byte accessed via other method should still be 0x67")
-            
-            // Verify that the first data is still correct
-            XCTAssertEqual(hello[0], 0x68, "The first byte should still be 0x68")
         }
+        XCTAssertEqual(mutatingHello[0], 0x67, "First byte accessed via other method should still be 0x67")
+
+        // Verify that the first data is still correct
+        XCTAssertEqual(hello[0], 0x68, "The first byte should still be 0x68")
     }
     
 


### PR DESCRIPTION
> Warning: Overlapping accesses to 'self', but modification requires exclusive access; consider copying to a local variable

There are more of these in the codebase, but here's a fix for a few.