### PR TITLE
SR-6405: URLRequest: Implement normalization for httpMethod

### DIFF
--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -159,6 +159,8 @@ open class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopying 
         guard aDecoder.allowsKeyedCoding else {
             preconditionFailure("Unkeyed coding is unsupported.")
         }
+
+        super.init()
         
         if let encodedURL = aDecoder.decodeObject(forKey: "NS.url") as? NSURL {
             self.url = encodedURL._swiftObject
@@ -267,8 +269,28 @@ open class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopying 
     
     open internal(set) var timeoutInterval: TimeInterval = 60.0
 
+    internal var _httpMethod: String? = "GET"
+
     /// Returns the HTTP request method of the receiver.
-    open fileprivate(set) var httpMethod: String? = "GET"
+    open fileprivate(set) var httpMethod: String? {
+        get { return _httpMethod }
+        set { _httpMethod = NSURLRequest._normalized(newValue) }
+    }
+
+    private class func _normalized(_ raw: String?) -> String {
+        guard let raw = raw else {
+            return "GET"
+        }
+
+        let nsMethod = NSString(raw)
+
+        for method in ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT"] {
+            if nsMethod.caseInsensitiveCompare(method) == .orderedSame {
+                return method
+            }
+        }
+        return raw
+    }
     
     /// A dictionary containing all the HTTP header fields
     /// of the receiver.

--- a/TestFoundation/TestNSURLRequest.swift
+++ b/TestFoundation/TestNSURLRequest.swift
@@ -29,7 +29,8 @@ class TestNSURLRequest : XCTestCase {
             ("test_mutableCopy_3", test_mutableCopy_3),
             ("test_NSCoding_1", test_NSCoding_1),
             ("test_NSCoding_2", test_NSCoding_2),
-            ("test_NSCoding_3", test_NSCoding_3)
+            ("test_NSCoding_3", test_NSCoding_3),
+            ("test_methodNormalization", test_methodNormalization),
         ]
     }
     
@@ -239,5 +240,47 @@ class TestNSURLRequest : XCTestCase {
         XCTAssertNotNil(requestB.httpBody)
         XCTAssertEqual(3, requestB.httpBody!.count)
         XCTAssertEqual(requestB.httpBody, requestA.httpBody)
+    }
+
+    func test_methodNormalization() {
+        let expectedNormalizations = [
+            "GET": "GET",
+            "get": "GET",
+            "gEt": "GET",
+            "HEAD": "HEAD",
+            "hEAD": "HEAD",
+            "head": "HEAD",
+            "HEAd": "HEAD",
+            "POST": "POST",
+            "post": "POST",
+            "pOST": "POST",
+            "POSt": "POST",
+            "PUT": "PUT",
+            "put": "PUT",
+            "PUt": "PUT",
+            "DELETE": "DELETE",
+            "delete": "DELETE",
+            "DeleTE": "DELETE",
+            "dELETe": "DELETE",
+            "CONNECT": "CONNECT",
+            "connect": "CONNECT",
+            "Connect": "CONNECT",
+            "cOnNeCt": "CONNECT",
+            "OPTIONS": "OPTIONS",
+            "options": "options",
+            "TRACE": "TRACE",
+            "trace": "trace",
+            "PATCH": "PATCH",
+            "patch": "patch",
+            "foo": "foo",
+            "BAR": "BAR",
+        ]
+
+        let request = NSMutableURLRequest(url: url)
+
+        for n in expectedNormalizations {
+            request.httpMethod = n.key
+            XCTAssertEqual(request.httpMethod, n.value)
+        }
     }
 }

--- a/TestFoundation/TestURLRequest.swift
+++ b/TestFoundation/TestURLRequest.swift
@@ -27,6 +27,7 @@ class TestURLRequest : XCTestCase {
             ("test_mutableCopy_1", test_mutableCopy_1),
             ("test_mutableCopy_2", test_mutableCopy_2),
             ("test_mutableCopy_3", test_mutableCopy_3),
+            ("test_methodNormalization", test_methodNormalization),
         ]
     }
     
@@ -193,6 +194,48 @@ class TestURLRequest : XCTestCase {
         XCTAssertEqual(originalRequest.httpMethod, "GET")
         XCTAssertEqual(originalRequest.url, urlA)
         XCTAssertNil(originalRequest.allHTTPHeaderFields)
+    }
+
+    func test_methodNormalization() {
+        let expectedNormalizations = [
+            "GET": "GET",
+            "get": "GET",
+            "gEt": "GET",
+            "HEAD": "HEAD",
+            "hEAD": "HEAD",
+            "head": "HEAD",
+            "HEAd": "HEAD",
+            "POST": "POST",
+            "post": "POST",
+            "pOST": "POST",
+            "POSt": "POST",
+            "PUT": "PUT",
+            "put": "PUT",
+            "PUt": "PUT",
+            "DELETE": "DELETE",
+            "delete": "DELETE",
+            "DeleTE": "DELETE",
+            "dELETe": "DELETE",
+            "CONNECT": "CONNECT",
+            "connect": "CONNECT",
+            "Connect": "CONNECT",
+            "cOnNeCt": "CONNECT",
+            "OPTIONS": "OPTIONS",
+            "options": "options",
+            "TRACE": "TRACE",
+            "trace": "trace",
+            "PATCH": "PATCH",
+            "patch": "patch",
+            "foo": "foo",
+            "BAR": "BAR",
+            ]
+
+        var request = URLRequest(url: url)
+
+        for n in expectedNormalizations {
+            request.httpMethod = n.key
+            XCTAssertEqual(request.httpMethod, n.value)
+        }
     }
 }
 


### PR DESCRIPTION
Darwin performs normalization of `httpMethod` for 6 specific HTTP methods. Match this behaviour.