### PR TITLE
Revert "[SR-6420] Ensure that the pthread_key is initialised once"

### DIFF
--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -580,14 +580,9 @@ CF_PRIVATE void __CFFinalizeWindowsThreadData() {
 #endif
 
 static pthread_key_t __CFTSDIndexKey;
-static pthread_once_t __CFTSDIndexKey_once = PTHREAD_ONCE_INIT;
-
-CF_PRIVATE void __CFTSDInitializeOnce() {
-    (void)pthread_key_create(&__CFTSDIndexKey, __CFTSDFinalize);
-}
 
 CF_PRIVATE void __CFTSDInitialize() {
-    (void)pthread_once(&__CFTSDIndexKey_once, __CFTSDInitializeOnce);
+    (void)pthread_key_create(&__CFTSDIndexKey, __CFTSDFinalize);
 }
 
 static void __CFTSDSetSpecific(void *arg) {


### PR DESCRIPTION
Reverts apple/swift-corelibs-foundation#1325

I am leaving this open temporarily, as a placeholder for figuring out the root cause of the original regression.