### PR TITLE
DateFormatter: disable testing of medium date style

### DIFF
--- a/TestFoundation/TestDateFormatter.swift
+++ b/TestFoundation/TestDateFormatter.swift
@@ -24,7 +24,7 @@ class TestDateFormatter: XCTestCase {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_dateStyleShort",    test_dateStyleShort),
-            ("test_dateStyleMedium",   test_dateStyleMedium),
+            //("test_dateStyleMedium",   test_dateStyleMedium),
             ("test_dateStyleLong",     test_dateStyleLong),
             ("test_dateStyleFull",     test_dateStyleFull),
             ("test_customDateFormat", test_customDateFormat),
@@ -274,10 +274,12 @@ class TestDateFormatter: XCTestCase {
         
         // Check .dateFormat resets when style changes
         let testDate = Date(timeIntervalSince1970: 1457738454)
-        f.dateStyle = .medium
-        f.timeStyle = .medium
-        XCTAssertEqual(f.string(from: testDate), "Mar 11, 2016, 11:20:54 PM")
-        XCTAssertEqual(f.dateFormat, "MMM d, y, h:mm:ss a")
+
+        // Fails on High Sierra
+        //f.dateStyle = .medium
+        //f.timeStyle = .medium
+        //XCTAssertEqual(f.string(from: testDate), "Mar 11, 2016, 11:20:54 PM")
+        //XCTAssertEqual(f.dateFormat, "MMM d, y, h:mm:ss a")
         
         f.dateFormat = "dd-MM-yyyy"
         XCTAssertEqual(f.string(from: testDate), "11-03-2016")


### PR DESCRIPTION
Currently, some of the `DateFormatter` tests fail on High Sierra because the format of the `.medium` date style has changed.  This is likely due to changes in the underlying platform ICU.

@parkera expressed the opinion to me that we shouldn't be testing the appearance of the `DateFormatter` presets because they are subject to change and not precisely documented.

I don't entirely agree with that point of view as if the format does change on Darwin platforms then we want to reflect those changes in SCLF, and having our tests start failing is the best way to detect that.

However, there is a whole separate discussion about whether Swift on Linux should use the platform ICU at all, or whether we should ship Apple's fork of ICU (which is used on Darwin) with Swift on Linux to sidestep all these problems.

As fixing the behaviour of SCLF on Linux in this regard is not practical in the short term (we don't want to diverge our CF code further from Darwin's), this PR just disables the currently failing tests.  We could go further and remove/disable all the date style tests but I leave that ~~argument~~discussion for another day.