### PR TITLE
SR-6403: NSURLRequest: implement `description` and add tests

### DIFF
--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -346,6 +346,11 @@ open class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopying 
     open internal(set) var httpShouldHandleCookies: Bool = true
     
     open internal(set) var httpShouldUsePipelining: Bool = true
+
+    open override var description: String {
+        let url = self.url?.description ?? "(null)"
+        return super.description + " { URL: \(url) }"
+    }
 }
 
 /// An `NSMutableURLRequest` object represents a mutable URL load

--- a/TestFoundation/TestNSURLRequest.swift
+++ b/TestFoundation/TestNSURLRequest.swift
@@ -31,6 +31,7 @@ class TestNSURLRequest : XCTestCase {
             ("test_NSCoding_2", test_NSCoding_2),
             ("test_NSCoding_3", test_NSCoding_3),
             ("test_methodNormalization", test_methodNormalization),
+            ("test_description", test_description),
         ]
     }
     
@@ -281,6 +282,20 @@ class TestNSURLRequest : XCTestCase {
         for n in expectedNormalizations {
             request.httpMethod = n.key
             XCTAssertEqual(request.httpMethod, n.value)
+        }
+    }
+
+    func test_description() {
+        let url = URL(string: "http://swift.org")!
+        let request = NSMutableURLRequest(url: url)
+
+        if request.description.range(of: "http://swift.org") == nil {
+            XCTFail("description should contain URL")
+        }
+
+        request.url = nil
+        if request.description.range(of: "(null)") == nil {
+            XCTFail("description of nil URL should contain (null)")
         }
     }
 }

--- a/TestFoundation/TestURLRequest.swift
+++ b/TestFoundation/TestURLRequest.swift
@@ -28,6 +28,7 @@ class TestURLRequest : XCTestCase {
             ("test_mutableCopy_2", test_mutableCopy_2),
             ("test_mutableCopy_3", test_mutableCopy_3),
             ("test_methodNormalization", test_methodNormalization),
+            ("test_description", test_description),
         ]
     }
     
@@ -236,6 +237,16 @@ class TestURLRequest : XCTestCase {
             request.httpMethod = n.key
             XCTAssertEqual(request.httpMethod, n.value)
         }
+    }
+
+    func test_description() {
+        let url = URL(string: "http://swift.org")!
+
+        var request = URLRequest(url: url)
+        XCTAssertEqual(request.description, "http://swift.org")
+
+        request.url = nil
+        XCTAssertEqual(request.description, "url: nil")
     }
 }
 


### PR DESCRIPTION
Implement `NSURLRequest.description` to match Darwin. Add tests.

Also add a test for `URLRequest.description` which was already correct but untested.