### PR TITLE
Reduce test compile times.

### DIFF
--- a/TestFoundation/TestDecimal.swift
+++ b/TestFoundation/TestDecimal.swift
@@ -180,13 +180,15 @@ class TestDecimal: XCTestCase {
     }
 
     func test_ExplicitConstruction() {
+        let reserved: UInt32 = (1<<18 as UInt32) + (1<<17 as UInt32) + 1
+        let mantissa: (UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16) = (6, 7, 8, 9, 10, 11, 12, 13)
         var explicit = Decimal(
             _exponent: 0x17f,
             _length: 0xff,
             _isNegative: 3,
             _isCompact: 4,
-            _reserved: 1<<18 + 1<<17 + 1,
-            _mantissa: (6, 7, 8, 9, 10, 11, 12, 13)
+            _reserved: reserved,
+            _mantissa: mantissa
         )
         XCTAssertEqual(0x7f, explicit._exponent)
         XCTAssertEqual(0x7f, explicit.exponent)
@@ -195,7 +197,9 @@ class TestDecimal: XCTestCase {
         XCTAssertEqual(FloatingPointSign.minus, explicit.sign)
         XCTAssertTrue(explicit.isSignMinus)
         XCTAssertEqual(0, explicit._isCompact)
-        XCTAssertEqual(UInt32(1<<17 + 1), explicit._reserved)
+        let i = 1 << 17 + 1
+        let expectedReserved: UInt32 = UInt32(i)
+        XCTAssertEqual(expectedReserved, explicit._reserved)
         let (m0, m1, m2, m3, m4, m5, m6, m7) = explicit._mantissa
         XCTAssertEqual(6, m0)
         XCTAssertEqual(7, m1)

--- a/TestFoundation/TestNSAttributedString.swift
+++ b/TestFoundation/TestNSAttributedString.swift
@@ -236,7 +236,10 @@ fileprivate extension TestNSAttributedString {
     
     fileprivate func describe(attrs: [NSAttributedStringKey : Any]) -> String {
         if attrs.count > 0 {
-            return "[" + attrs.map({ "\($0.rawValue):\($1)" }).sorted(by: { $0 < $1 }).joined(separator: ",") + "]"
+            let mapped: [String] = attrs.map({ "\($0.rawValue):\($1)" })
+            let sorted: [String] = mapped.sorted(by: { $0 < $1 })
+            let joined: String = sorted.joined(separator: ",")
+            return "[" + joined + "]"
         } else {
             return "[:]"
         }

--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -221,12 +221,15 @@ class TestNSKeyedArchiver : XCTestCase {
     }
 
     func test_archive_mutable_dictionary() {
-        let mdictionary = NSMutableDictionary(dictionary: [
-            "one": NSNumber(value: Int(1)),
-            "two": NSNumber(value: Int(2)),
-            "three": NSNumber(value: Int(3)),
-        ])
-        
+        let one: NSNumber = NSNumber(value: Int(1))
+        let two: NSNumber = NSNumber(value: Int(2))
+        let three: NSNumber = NSNumber(value: Int(3))
+        let dict: [String : Any] = [
+            "one": one,
+            "two": two,
+            "three": three,
+        ]
+        let mdictionary = NSMutableDictionary(dictionary: dict)
         test_archive(mdictionary)
     }
     

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -1157,8 +1157,12 @@ class TestNSNumber : XCTestCase {
         XCTAssertTrue(NSNumber(value: true) == NSNumber(value: Int8(1)))
         XCTAssertTrue(NSNumber(value: true) != NSNumber(value: false))
         XCTAssertTrue(NSNumber(value: true) != NSNumber(value: Int8(-1)))
-        XCTAssertTrue(NSNumber(value: true) != NSNumber(value: Float(1.01)))
-        XCTAssertTrue(NSNumber(value: true) != NSNumber(value: Double(1234.56)))
+        let f: Float = 1.01
+        let floatNum = NSNumber(value: f)
+        XCTAssertTrue(NSNumber(value: true) != floatNum)
+        let d: Double = 1234.56
+        let doubleNum = NSNumber(value: d)
+        XCTAssertTrue(NSNumber(value: true) != doubleNum)
         XCTAssertTrue(NSNumber(value: true) != NSNumber(value: 2))
         XCTAssertTrue(NSNumber(value: true) != NSNumber(value: Int.max))
         XCTAssertTrue(NSNumber(value: false) == NSNumber(value: Bool(false)))

--- a/TestFoundation/TestNumberFormatter.swift
+++ b/TestFoundation/TestNumberFormatter.swift
@@ -172,7 +172,8 @@ class TestNumberFormatter: XCTestCase {
         let noPlusString = numberFormatter.string(from: -0.420)
         XCTAssertNotNil(noPlusString)
         if let fmt = noPlusString {
-            XCTAssertFalse(fmt.contains(sign), "Expected format of -0.420 (-4.2E-1) shouldn't have a plus sign which was set as \(sign)")
+            let contains: Bool = fmt.contains(sign)
+            XCTAssertFalse(contains, "Expected format of -0.420 (-4.2E-1) shouldn't have a plus sign which was set as \(sign)")
         }
     }
 

--- a/TestFoundation/TestURLSession.swift
+++ b/TestFoundation/TestURLSession.swift
@@ -471,12 +471,8 @@ class TestURLSession : LoopbackServerTest {
     }
 
     func test_concurrentRequests() {
-#if os(Android)
+        // "10 tasks ought to be enough for anybody"
         let tasks = 10
-        XCTFail("640 tasks causes other tests to fail on Android")
-#else
-        let tasks = 640
-#endif
         let syncQ = dispatchQueueMake("test_dataTaskWithURL.syncQ")
         var dataTasks: [DataTask] = []
         let g = dispatchGroupMake()

--- a/TestFoundation/TestXMLDocument.swift
+++ b/TestFoundation/TestXMLDocument.swift
@@ -355,7 +355,10 @@ class TestXMLDocument : XCTestCase {
         let otherDoc = XMLDocument(rootElement: XMLElement(name: "Bar"))
         otherDoc.rootElement()?.namespaces = [XMLNode.namespace(withName: "R", stringValue: "http://example.com/rnamespace") as! XMLNode, XMLNode.namespace(withName: "F", stringValue: "http://example.com/fakenamespace") as! XMLNode]
         XCTAssert(otherDoc.rootElement()?.namespaces?.count == 2)
-        XCTAssert(otherDoc.rootElement()?.namespaces?.flatMap({ $0.name })[0] == "R" && otherDoc.rootElement()?.namespaces?.flatMap({ $0.name })[1] == "F")
+        let namespaces: [XMLNode]? = otherDoc.rootElement()?.namespaces
+        let names: [String]? = namespaces?.flatMap { $0.name }
+        XCTAssertNotNil(names)
+        XCTAssert(names![0] == "R" && names![1] == "F")
         otherDoc.rootElement()?.namespaces = nil
         XCTAssert((otherDoc.rootElement()?.namespaces?.count ?? 0) == 0)
     }

--- a/TestFoundation/TestXMLParser.swift
+++ b/TestFoundation/TestXMLParser.swift
@@ -84,7 +84,8 @@ class TestXMLParser : XCTestCase {
             return xmlUnderTest
         }
         if let open = encoding.range(of: "(") {
-            encoding = String(encoding[open.upperBound...])
+            let range: Range<String.Index> = open.upperBound..<encoding.endIndex
+            encoding = String(encoding[range])
         }
         if let close = encoding.range(of: ")") {
             encoding = String(encoding[..<close.lowerBound])


### PR DESCRIPTION
I noticed that the tests were taking quite a while to compile.

Using the "-warn-long-expression-type-checking" flag, I measured the compile time of the test project. The total of types over 100ms was around 27 seconds before this change and around 25 seconds after (on my build configuration), so it shaves off a few seconds there.

I also took the opportunity to reduce the number of attempted threads in the URL test from 640 to 10. There isn't much value add in going above the number of cores we're going to find on most machines, and that dramatically reduces the run time of that test.

The tests still take quite a while to build, so I'd like to continue this investigation. But this is a reasonable start.