### PR TITLE
Restore .concurrent for block-based enumerateObjects(…) methods in NSArray

### DIFF
--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -377,10 +377,6 @@ open class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     }
     
     internal func _enumerateWithOptions<P, R>(_ opts : NSEnumerationOptions, range: NSRange, paramType: P.Type, returnType: R.Type, block: (P, UnsafeMutablePointer<ObjCBool>) -> R) -> Int? {
-        guard !opts.contains(.concurrent) else {
-            NSUnimplemented()
-        }
-        
         guard let startRangeIndex = self._indexOfRangeAfterOrContainingIndex(range.location), let endRangeIndex = _indexOfRangeBeforeOrContainingIndex(NSMaxRange(range) - 1) else {
             return nil
         }


### PR DESCRIPTION
 - These methods are implemented as (relevant NSIndexSet).enumerate(options: options…), so the fix goes in NSIndexSet.

 - Includes NSArray tests.