### PR TITLE
Add initial implementation of URLSession.shared

### DIFF
--- a/Foundation/URLProtocol.swift
+++ b/Foundation/URLProtocol.swift
@@ -386,6 +386,8 @@ open class URLProtocol : NSObject {
     }
 
     internal class func getProtocols() -> [AnyClass]? {
+        _classesLock.lock()
+        defer { _classesLock.unlock() }
         return _registeredProtocolClasses
     }
     /*! 

--- a/Foundation/URLSession/URLSession.swift
+++ b/Foundation/URLSession/URLSession.swift
@@ -201,8 +201,19 @@ open class URLSession : NSObject {
      * The shared session uses the currently set global URLCache,
      * HTTPCookieStorage and URLCredential.Storage objects.
      */
-    open class var shared: URLSession { NSUnimplemented() }
-    
+    open class var shared: URLSession {
+        return _shared
+    }
+
+    fileprivate static let _shared: URLSession = {
+        var configuration = URLSessionConfiguration.default
+        configuration.httpCookieStorage = HTTPCookieStorage.shared
+        //TODO: Set urlCache to URLCache.shared. Needs implementation of URLCache.
+        //TODO: Set urlCredentialStorage to `URLCredentialStorage.shared`. Needs implementation of URLCredentialStorage.
+        configuration.protocolClasses = URLProtocol.getProtocols()
+        return URLSession(configuration: configuration, delegate: nil, delegateQueue: nil)
+    }()
+
     /*
      * Customization of URLSession occurs during creation of a new session.
      * If you only need to use the convenience routines with custom

--- a/TestFoundation/TestURLSession.swift
+++ b/TestFoundation/TestURLSession.swift
@@ -59,11 +59,19 @@ class TestURLSession : LoopbackServerTest {
     }
     
     func test_dataTaskWithURLCompletionHandler() {
-        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/USA"
-        let url = URL(string: urlString)!
+        //shared session
+        dataTaskWithURLCompletionHandler(with: URLSession.shared)
+
+        //new session
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 8
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
+        dataTaskWithURLCompletionHandler(with: session)
+    }
+
+    func dataTaskWithURLCompletionHandler(with session: URLSession) {
+        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/USA"
+        let url = URL(string: urlString)!
         let expect = expectation(description: "GET \(urlString): with a completion handler")
         var expectedResult = "unknown"
         let task = session.dataTask(with: url) { data, response, error in
@@ -130,10 +138,18 @@ class TestURLSession : LoopbackServerTest {
     }
     
     func test_downloadTaskWithRequestAndHandler() {
+        //shared session
+        downloadTaskWithRequestAndHandler(with: URLSession.shared)
+
+        //newly created session
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 8
-        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/country.txt"
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
+        downloadTaskWithRequestAndHandler(with: session)
+    }
+
+    func downloadTaskWithRequestAndHandler(with session: URLSession) {
+        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/country.txt"
         let expect = expectation(description: "Download GET \(urlString): with a completion handler")
         let req = URLRequest(url: URL(string: urlString)!)
         let task = session.downloadTask(with: req) { (_, _, error) -> Void in


### PR DESCRIPTION
Basic users of URLSession may want to use the shared URLSession instance`URLSession.shared`. 

The shared URLSession instance uses shared instances of HTTPCookieStorage, URLCache and URLCredentialStorage, the last two still remain unimplemented. It is likely that some of the users that want to use `URLSession.shared` aren't interested in using the shared storages and cache! So, we need not wait for URLCache and URLCredentialStorage to be fully available here (we can plug them in later, see the TODOS). In that way, we are offering `URLSession.shared` to at least those users!