### PR TITLE
Restore the .concurrent option for NSArray's enumerateObjects(…)

### DIFF
--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -377,10 +377,6 @@ open class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     }
     
     internal func _enumerateWithOptions<P, R>(_ opts : NSEnumerationOptions, range: NSRange, paramType: P.Type, returnType: R.Type, block: (P, UnsafeMutablePointer<ObjCBool>) -> R) -> Int? {
-        guard !opts.contains(.concurrent) else {
-            NSUnimplemented()
-        }
-        
         guard let startRangeIndex = self._indexOfRangeAfterOrContainingIndex(range.location), let endRangeIndex = _indexOfRangeBeforeOrContainingIndex(NSMaxRange(range) - 1) else {
             return nil
         }

--- a/TestFoundation/TestNSArray.swift
+++ b/TestFoundation/TestNSArray.swift
@@ -218,14 +218,26 @@ class TestNSArray : XCTestCase {
             var indexesForStaggeredEnumeration = indexesForHalfEnumeration
             indexesForStaggeredEnumeration.formIntersection(evenIndexes)
             
+            let finalCount = indexesForStaggeredEnumeration.count
+            
+            let lockForSeenCount = NSLock()
+            var seenCount = 0
+            
             testExpectingToSee(indexesForStaggeredEnumeration) { (indexesSeen) in
                 array.enumerateObjects(at: evenIndexes, options: options, using: { (value, index, stop) in
                     XCTAssertEqual(value as! NSNumber, array[index] as! NSNumber)
                     
                     if (indexesForStaggeredEnumeration.contains(index)) {
                         indexesSeen[index] = true
-                    } else {
-                        stop.pointee = true
+                        
+                        lockForSeenCount.lock()
+                        seenCount += 1
+                        let currentCount = seenCount
+                        lockForSeenCount.unlock()
+                        
+                        if currentCount == finalCount {
+                            stop.pointee = true
+                        }
                     }
                 })
             }


### PR DESCRIPTION
(Let's try this again. The previous attempt had an issue in the test for enumerateObjects(at:options:using:) where it could've set the stop flag to true before all indexes corresponding to our expectation had been set to true, which could lead it to inconsistently failing.)

NSArray implements these methods as: `someIndexSet.enumerate(options: options) { block(self[$0]…) }`, so the fix goes in NSIndexSet.

Includes NSArray tests.