### PR TITLE
[SR-6581] Mark FileManager.attributesOfFileSystem unavailable on Android

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -340,10 +340,13 @@ open class FileManager : NSObject {
      
         This method replaces fileSystemAttributesAtPath:.
      */
-    open func attributesOfFileSystem(forPath path: String) throws -> [FileAttributeKey : Any] {
 #if os(Android)
+    @available(*, unavailable, message: "Not available on Android")
+    open func attributesOfFileSystem(forPath path: String) throws -> [FileAttributeKey : Any] {
         NSUnimplemented()
+    }
 #else
+    open func attributesOfFileSystem(forPath path: String) throws -> [FileAttributeKey : Any] {
         // statvfs(2) doesn't support 64bit inode on Darwin (apfs), fallback to statfs(2)
         #if os(OSX) || os(iOS)
             var s = statfs()
@@ -372,8 +375,8 @@ open class FileManager : NSObject {
         result[.systemFreeNodes] = NSNumber(value: UInt64(s.f_ffree))
         
         return result
-#endif
     }
+#endif
     
     /* createSymbolicLinkAtPath:withDestination:error: returns YES if the symbolic link that point at 'destPath' was able to be created at the location specified by 'path'. If this method returns NO, the link was unable to be created and an NSError will be returned by reference in the 'error' parameter. This method does not traverse a terminal symlink.
      


### PR DESCRIPTION
Fixes [SR-6581](https://bugs.swift.org/browse/SR-6581).