### PR TITLE
Fix String.deletingPathExtension Inconsistency

### DIFF
--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -55,26 +55,30 @@ internal extension String {
 
     internal var _startOfPathExtension : String.Index? {
         precondition(!hasSuffix("/"))
-        
-        var curPos = endIndex
-        let lastCompStartPos = _startOfLastPathComponent
-        
+
+        var currentPosition = endIndex
+        let startOfLastPathComponent = _startOfLastPathComponent
+
         // Find the beginning of the extension
-        while curPos > lastCompStartPos {
-            let prevPos = index(before: curPos)
-            let char = self[prevPos]
-            if char == "/" {
+        while currentPosition > startOfLastPathComponent {
+            let previousPosition = index(before: currentPosition)
+            let character = self[previousPosition]
+            if character == "/" {
                 return nil
-            } else if char == "." {
-                if lastCompStartPos == prevPos {
+            } else if character == "." {
+                if startOfLastPathComponent == previousPosition {
                     return nil
-                } else if case let prevPrevPos = index(before: prevPos), prevPos == index(before: endIndex) && prevPrevPos == lastCompStartPos && self[prevPrevPos] == "." {
+                } else if case let previous2Position = index(before: previousPosition),
+                    previousPosition == index(before: endIndex) &&
+                    previous2Position == startOfLastPathComponent &&
+                    self[previous2Position] == "."
+                {
                     return nil
                 } else {
-                    return curPos
+                    return currentPosition
                 }
             }
-            curPos = prevPos
+            currentPosition = previousPosition
         }
         return nil
     }

--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -68,6 +68,8 @@ internal extension String {
             } else if char == "." {
                 if lastCompStartPos == prevPos {
                     return nil
+                } else if case let prevPrevPos = index(before: prevPos), prevPos == index(before: endIndex) && prevPrevPos == lastCompStartPos && self[prevPrevPos] == "." {
+                    return nil
                 } else {
                     return curPos
                 }
@@ -262,7 +264,7 @@ public extension NSString {
         if fixedSelf.length <= 1 {
             return fixedSelf
         }
-        if let extensionPos = (fixedSelf._startOfPathExtension) {
+        if let extensionPos = fixedSelf._startOfPathExtension {
             return String(fixedSelf.prefix(upTo: fixedSelf.index(before: extensionPos)))
         } else {
             return fixedSelf

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -1078,6 +1078,7 @@ class TestNSString : XCTestCase {
             NSString(string: "scratch..tiff") : "scratch.",
             NSString(string: ".tiff") : ".tiff",
             NSString(string: "/") : "/",
+            NSString(string: "..") : "..",
         ]
         for (fileName, expectedResult) in values {
             let result = fileName.deletingPathExtension


### PR DESCRIPTION
The following code behaves differently on macOS and Linux:

```swift
NSString(string: "..").deletingPathExtension
```

On Linux, the resulting value is `.` while on macOS, it's `..`.

I think the latter make far more sense since `..` mean parent directory,
treating the last dot as "extension" is a bit of a stretch. Plus, this
logic existed on macOS longer (therefore has more existing users). So it
make sense to align Linux Foundation's behavior to that of macOS.

JIRA: https://bugs.swift.org/browse/SR-6647