### PR TITLE
Misc warnings fixes

### DIFF
--- a/Foundation/IndexPath.swift
+++ b/Foundation/IndexPath.swift
@@ -35,7 +35,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
     public typealias ReferenceType = NSIndexPath
     public typealias Element = Int
     public typealias Index = Array<Int>.Index
-    public typealias Indices = DefaultRandomAccessIndices<IndexPath>
+    public typealias Indices = DefaultIndices<IndexPath>
     
     fileprivate enum Storage : ExpressibleByArrayLiteral {
         typealias Element = Int

--- a/Foundation/IndexSet.swift
+++ b/Foundation/IndexSet.swift
@@ -114,8 +114,8 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
             }
         }
         
-        public subscript(bounds: Range<Index>) -> BidirectionalSlice<RangeView> {
-            return BidirectionalSlice(base: self, bounds: bounds)
+        public subscript(bounds: Range<Index>) -> Slice<RangeView> {
+            return Slice(base: self, bounds: bounds)
         }
         
         public func index(after i: Index) -> Index {
@@ -273,8 +273,8 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         return index.value
     }
     
-    public subscript(bounds: Range<Index>) -> BidirectionalSlice<IndexSet> {
-        return BidirectionalSlice(base: self, bounds: bounds)
+    public subscript(bounds: Range<Index>) -> Slice<IndexSet> {
+        return Slice(base: self, bounds: bounds)
     }
     
     // We adopt the default implementation of subscript(range: Range<Index>) from MutableCollection

--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -396,7 +396,7 @@ open class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
                 lock.unlock()
                 if stop.boolValue { return }
                 
-                let idx = rangeSequence.index(rangeSequence.startIndex, offsetBy: Int64(rangeIdx))
+                let idx = rangeSequence.index(rangeSequence.startIndex, offsetBy: rangeIdx)
                 let curRange = rangeSequence[idx]
                 let intersection = NSIntersectionRange(curRange, range)
                 if passRanges {

--- a/Foundation/NSRange.swift
+++ b/Foundation/NSRange.swift
@@ -342,8 +342,8 @@ extension NSRange {
     
 extension CFRange {
     internal init(_ range: NSRange) {
-        location = range.location == NSNotFound ? kCFNotFound : range.location
-        length = range.length
+        let _location = range.location == NSNotFound ? kCFNotFound : range.location
+        self.init(location: _location, length: range.length)
     }
 }
     

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -237,8 +237,8 @@ open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSC
         let characters = UnsafeMutablePointer<unichar>.allocate(capacity: length)
         getCharacters(characters, range: NSRange(location: 0, length: length))
         let result = NSString(characters: characters, length: length)
-        characters.deinitialize()
-        characters.deallocate(capacity: length)
+        characters.deinitialize(count: length)
+        characters.deallocate()
         return result
     }
     


### PR DESCRIPTION
- Fixes for the following warnings:

  'BidirectionalSlice' is deprecated: renamed to 'Slice'
  'DefaultRandomAccessIndices' is deprecated: renamed to 'DefaultIndices'
  'index(_:offsetBy:)' is deprecated: all index distances are now of type Int
  initializer for struct 'CFRange' must use "self.init(...)" or "self = ..." because the struct was imported from C
  deinitialize()' is deprecated: the default argument to deinitialize(count:) has been removed, please specify the count explicitly
  'deallocate(capacity:)' is deprecated: Swift currently only supports freeing entire heap blocks, use deallocate() instead