### PR TITLE
Added guard around #include <xlocale.h> for Linux

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -97,7 +97,9 @@ CF_EXTERN_C_BEGIN
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI || DEPLOYMENT_TARGET_LINUX || DEPLOYMENT_TARGET_FREEBSD
 #if TARGET_OS_CYGWIN
 #else
+#if !defined(__linux__)
 #include <xlocale.h>
+#endif
 #endif
 #include <unistd.h>
 #include <sys/time.h>


### PR DESCRIPTION
`xlocale.h` was removed in glibc 2.26 so any version of Linux with that or later versions will not be able to compile successfully. This change adds a guard to check that if we're *not* compiling on Linux, to go ahead and include it. 
