### PR TITLE
Revert "Merge pull request #1379 from spevans/pr_flatmap_to_compactmap"

### DIFF
--- a/Foundation/HTTPCookie.swift
+++ b/Foundation/HTTPCookie.swift
@@ -268,7 +268,7 @@ open class HTTPCookie : NSObject {
 
         if let portString = properties[.port] as? String, _version == 1 {
             _portList = portString.split(separator: ",")
-                .compactMap { Int(String($0)) }
+                .flatMap { Int(String($0)) }
                 .map { NSNumber(value: $0) }
         } else {
             _portList = nil

--- a/Foundation/JSONEncoder.swift
+++ b/Foundation/JSONEncoder.swift
@@ -1043,7 +1043,7 @@ fileprivate struct _JSONKeyedDecodingContainer<K : CodingKey> : KeyedDecodingCon
     // MARK: - KeyedDecodingContainerProtocol Methods
 
     public var allKeys: [Key] {
-        return self.container.keys.compactMap { Key(stringValue: $0) }
+        return self.container.keys.flatMap { Key(stringValue: $0) }
     }
 
     public func contains(_ key: Key) -> Bool {

--- a/Foundation/ProcessInfo.swift
+++ b/Foundation/ProcessInfo.swift
@@ -92,7 +92,7 @@ open class ProcessInfo: NSObject {
             return OperatingSystemVersion(majorVersion: fallbackMajor, minorVersion: fallbackMinor, patchVersion: fallbackPatch)
         }
         
-        let versionComponents = productVersion._swiftObject.split(separator: ".").map(String.init).compactMap({ Int($0) })
+        let versionComponents = productVersion._swiftObject.split(separator: ".").map(String.init).flatMap({ Int($0) })
         let majorVersion = versionComponents.dropFirst(0).first ?? fallbackMajor
         let minorVersion = versionComponents.dropFirst(1).first ?? fallbackMinor
         let patchVersion = versionComponents.dropFirst(2).first ?? fallbackPatch

--- a/Foundation/XMLElement.swift
+++ b/Foundation/XMLElement.swift
@@ -69,7 +69,7 @@ open class XMLElement: XMLNode {
         @abstract Returns all of the child elements that match this name.
     */
     open func elements(forName name: String) -> [XMLElement] {
-        return self.filter({ _CFXMLNodeGetType($0._xmlNode) == _kCFXMLTypeElement }).filter({ $0.name == name }).compactMap({ $0 as? XMLElement })
+        return self.filter({ _CFXMLNodeGetType($0._xmlNode) == _kCFXMLTypeElement }).filter({ $0.name == name }).flatMap({ $0 as? XMLElement })
     }
 
     /*!
@@ -77,7 +77,7 @@ open class XMLElement: XMLNode {
         @abstract Returns all of the child elements that match this localname URI pair.
     */
     open func elements(forLocalName localName: String, uri URI: String?) -> [XMLElement] {
-        return self.filter({ _CFXMLNodeGetType($0._xmlNode) == _kCFXMLTypeElement }).filter({ $0.localName == localName && $0.uri == uri }).compactMap({ $0 as? XMLElement })
+        return self.filter({ _CFXMLNodeGetType($0._xmlNode) == _kCFXMLTypeElement }).filter({ $0.localName == localName && $0.uri == uri }).flatMap({ $0 as? XMLElement })
     }
 
     /*!
@@ -189,7 +189,7 @@ open class XMLElement: XMLNode {
         @abstract Adds a namespace. Namespaces with duplicate names are not added.
     */
     open func addNamespace(_ aNamespace: XMLNode) {
-        if ((namespaces ?? []).compactMap({ $0.name }).contains(aNamespace.name ?? "")) {
+        if ((namespaces ?? []).flatMap({ $0.name }).contains(aNamespace.name ?? "")) {
             return
         }
         _CFXMLAddNamespace(_xmlNode, aNamespace._xmlNode)

--- a/TestFoundation/TestJSONSerialization.swift
+++ b/TestFoundation/TestJSONSerialization.swift
@@ -552,7 +552,7 @@ extension TestJSONSerialization {
                 return
             }
             let res = try getjsonObjectResult(data, objectType) as? [Any]
-            let result = res?.compactMap { $0 as? String }
+            let result = res?.flatMap { $0 as? String }
             XCTAssertEqual(result?[0], "\"")
             XCTAssertEqual(result?[1], "\\")
             XCTAssertEqual(result?[2], "/")

--- a/TestFoundation/TestXMLDocument.swift
+++ b/TestFoundation/TestXMLDocument.swift
@@ -356,7 +356,7 @@ class TestXMLDocument : XCTestCase {
         otherDoc.rootElement()?.namespaces = [XMLNode.namespace(withName: "R", stringValue: "http://example.com/rnamespace") as! XMLNode, XMLNode.namespace(withName: "F", stringValue: "http://example.com/fakenamespace") as! XMLNode]
         XCTAssert(otherDoc.rootElement()?.namespaces?.count == 2)
         let namespaces: [XMLNode]? = otherDoc.rootElement()?.namespaces
-        let names: [String]? = namespaces?.compactMap { $0.name }
+        let names: [String]? = namespaces?.flatMap { $0.name }
         XCTAssertNotNil(names)
         XCTAssert(names![0] == "R" && names![1] == "F")
         otherDoc.rootElement()?.namespaces = nil


### PR DESCRIPTION
This reverts commit 4c8932b44762413da37533145ae2c6ed42134557, reversing
changes made to 9cb8ca1029650c0f3b3933210d61a6f3efe7f7b7.

This was auto-merged onto the `swift-4.1-branch` but that branch doesn't support `compactMap`. This is breaking the build for swift-4.1, so revert it from the `swift-4.1-branch`