### PR TITLE
remove an xfail from a test that will now pass

### DIFF
--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -1238,14 +1238,7 @@ let comparisonTests = [
     // ASCII cases
     ComparisonTest("t", "tt"),
     ComparisonTest("t", "Tt"),
-    ComparisonTest("\u{0}", "",
-        reason: {
-#if _runtime(_ObjC)
-    return ""
-#else
-    return "https://bugs.swift.org/browse/SR-332"
-#endif
-    }()),
+    ComparisonTest("\u{0}", ""),
     ComparisonTest("\u{0}", "\u{0}",
         reason: "https://bugs.swift.org/browse/SR-332"),
     ComparisonTest("\r\n", "t"),


### PR DESCRIPTION
We can un-xfail this test due to https://github.com/apple/swift/pull/13877