### PR TITLE
Pass -sil-merge-partial-modules flag

### DIFF
--- a/lib/script.py
+++ b/lib/script.py
@@ -189,7 +189,7 @@ rule CompileSwift
     depfile = $out.d
 
 rule MergeSwiftModule
-    command = mkdir -p `dirname $out`; ${SWIFT} -frontend -emit-module $partials ${TARGET_SWIFTCFLAGS} $flags -module-cache-path ${MODULE_CACHE_PATH} -module-link-name $module_name -o $out
+    command = mkdir -p `dirname $out`; ${SWIFT} -frontend -sil-merge-partial-modules -emit-module $partials ${TARGET_SWIFTCFLAGS} $flags -module-cache-path ${MODULE_CACHE_PATH} -module-link-name $module_name -o $out
     description = Merge $out
 """
 


### PR DESCRIPTION
The build scripts for foundation bypass the Swift driver and use
the -frontend mode directly. The command line interface for
-frontend is not officially supported and is subject to change.

A recent change was that when merging partial modules to form a
final module file, the -sil-merge-partial-modules flag must be
passed in so that serialized SIL can be preserved in the final
module file.

Preserving serialized SIL is now a requirement, since soon
default argument generators and stored property initializers
will be emitted with non-public linkage, requiring clients to
deserialize SIL when calling these entry points.