### PR TITLE
Added missing __checkint macros for 32bit systems

### DIFF
--- a/CoreFoundation/Base.subproj/CFSortFunctions.c
+++ b/CoreFoundation/Base.subproj/CFSortFunctions.c
@@ -52,6 +52,8 @@ enum {
 
 #define __checkint_int64_mul(x, y, err)         (x * y)
 #define __checkint_uint64_add(x, y, err)        (x + y)
+#define __checkint_int32_mul(x,y,err)           (x * y)
+#define __checkint_uint32_add(x,y,err)          (x + y)
 
 #endif
 


### PR DESCRIPTION
These two defines, similar to the int64 variants already present, are required on 32bit systems (e.g. linux-arm).