### PR TITLE
SR-6449: FileManager.removeItem(atPath) leaks

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -461,6 +461,7 @@ open class FileManager : NSObject {
             let stream = fts_open(ps, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR, nil)
             ps.deinitialize(count: 2)
             ps.deallocate()
+            fsRep.deallocate()
 
             if stream != nil {
                 defer {
@@ -1037,6 +1038,7 @@ extension FileManager {
                 _stream = fts_open(ps, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR, nil)
                 ps.deinitialize(count: 2)
                 ps.deallocate()
+                fsRep.deallocate()
             } else {
                 _rootError = _NSErrorWithErrno(ENOENT, reading: true, url: url)
             }

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -140,6 +140,7 @@ class TestFileManager : XCTestCase {
         XCTAssertEqual(UInt8(bitPattern: result[0]), 0xE2)
         XCTAssertEqual(UInt8(bitPattern: result[1]), 0x98)
         XCTAssertEqual(UInt8(bitPattern: result[2]), 0x83)
+        result.deallocate()
     }
     
     func test_fileAttributes() {


### PR DESCRIPTION
- FileManager.fileSystemRepresentation returns a heap allocated
  pointer that needs to be freed by the caller.