### PR TITLE
Implement forced keys in UserDefaults.

### DIFF
--- a/Foundation/UserDefaults.swift
+++ b/Foundation/UserDefaults.swift
@@ -326,8 +326,17 @@ open class UserDefaults: NSObject {
         return CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
     }
     
-    open func objectIsForced(forKey key: String) -> Bool { NSUnimplemented() }
-    open func objectIsForced(forKey key: String, inDomain domain: String) -> Bool { NSUnimplemented() }
+    open func objectIsForced(forKey key: String) -> Bool {
+        // If you're using this version of Foundation, there is nothing in particular that can force a key.
+        // So:
+        return false
+    }
+    
+    open func objectIsForced(forKey key: String, inDomain domain: String) -> Bool {
+        // If you're using this version of Foundation, there is nothing in particular that can force a key.
+        // So:
+        return false
+    }
 }
 
 extension UserDefaults {


### PR DESCRIPTION
If we’re running this version of Foundation, there is no MCX nor configuration profiles that can force a defaults key. Therefore, by definition, unless in the future we want to introduce such a facility in non-Apple OSes, this is always false.