### PR TITLE
Rename CF_SWIFT_EXPORT

### DIFF
--- a/CoreFoundation/Base.subproj/CFFileUtilities.c
+++ b/CoreFoundation/Base.subproj/CFFileUtilities.c
@@ -1198,7 +1198,7 @@ static CFStringRef _CFXDGCreateHome(void) {
 }
 
 /// a single base directory relative to which user-specific data files should be written. This directory is defined by the environment variable $XDG_DATA_HOME.
-CF_SWIFT_EXPORT
+CF_CROSS_PLATFORM_EXPORT
 CFStringRef _CFXDGCreateDataHomePath(void) {
     // $XDG_DATA_HOME defines the base directory relative to which user specific data files should be stored. If $XDG_DATA_HOME is either not set or empty, a default equal to $HOME/.local/share should be used.
     const char *dataHome = __CFgetenv("XDG_DATA_HOME");
@@ -1213,7 +1213,7 @@ CFStringRef _CFXDGCreateDataHomePath(void) {
 }
 
 /// a single base directory relative to which user-specific configuration files should be written. This directory is defined by the environment variable $XDG_CONFIG_HOME.
-CF_SWIFT_EXPORT
+CF_CROSS_PLATFORM_EXPORT
 CFStringRef _CFXDGCreateConfigHomePath(void) {
     // $XDG_CONFIG_HOME defines the base directory relative to which user specific configuration files should be stored. If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used.
     const char *configHome = __CFgetenv("XDG_CONFIG_HOME");
@@ -1228,7 +1228,7 @@ CFStringRef _CFXDGCreateConfigHomePath(void) {
 }
 
 /// a set of preference ordered base directories relative to which data files should be searched. This set of directories is defined by the environment variable $XDG_DATA_DIRS.
-CF_SWIFT_EXPORT
+CF_CROSS_PLATFORM_EXPORT
 CFArrayRef _CFXDGCreateDataDirectoriesPaths(void) {
     // $XDG_DATA_DIRS defines the preference-ordered set of base directories to search for data files in addition to the $XDG_DATA_HOME base directory. The directories in $XDG_DATA_DIRS should be seperated with a colon ':'.
     // If $XDG_DATA_DIRS is either not set or empty, a value equal to /usr/local/share/:/usr/share/ should be used.
@@ -1252,7 +1252,7 @@ CFArrayRef _CFXDGCreateDataDirectoriesPaths(void) {
 
 
 /// a set of preference ordered base directories relative to which configuration files should be searched. This set of directories is defined by the environment variable $XDG_CONFIG_DIRS.
-CF_SWIFT_EXPORT
+CF_CROSS_PLATFORM_EXPORT
 CFArrayRef _CFXDGCreateConfigDirectoriesPaths(void) {
     // $XDG_CONFIG_DIRS defines the preference-ordered set of base directories to search for configuration files in addition to the $XDG_CONFIG_HOME base directory. The directories in $XDG_CONFIG_DIRS should be seperated with a colon ':'.
     // If $XDG_CONFIG_DIRS is either not set or empty, a value equal to /etc/xdg should be used.
@@ -1274,7 +1274,7 @@ CFArrayRef _CFXDGCreateConfigDirectoriesPaths(void) {
 }
 
 /// a single base directory relative to which user-specific non-essential (cached) data should be written. This directory is defined by the environment variable $XDG_CACHE_HOME.
-CF_SWIFT_EXPORT
+CF_CROSS_PLATFORM_EXPORT
 CFStringRef _CFXDGCreateCacheDirectoryPath(void) {
     //$XDG_CACHE_HOME defines the base directory relative to which user specific non-essential data files should be stored. If $XDG_CACHE_HOME is either not set or empty, a default equal to $HOME/.cache should be used.
     const char *cacheHome = __CFgetenv("XDG_CACHE_HOME");
@@ -1290,7 +1290,7 @@ CFStringRef _CFXDGCreateCacheDirectoryPath(void) {
 }
 
 /// a single base directory relative to which user-specific runtime files and other file objects should be placed. This directory is defined by the environment variable $XDG_RUNTIME_DIR.
-CF_SWIFT_EXPORT
+CF_CROSS_PLATFORM_EXPORT
 CFStringRef _CFXDGCreateRuntimeDirectoryPath(void) {
     const char *runtimeDir = __CFgetenv("XDG_RUNTIME_DIR");
     if (runtimeDir && strnlen(runtimeDir, CFMaxPathSize) > 1 && runtimeDir[0] == '/') {

--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -1319,7 +1319,7 @@ _CFThreadRef _CFThreadCreate(const _CFThreadAttributes attrs, void *_Nullable (*
     return thread;
 }
 
-CF_SWIFT_EXPORT int _CFThreadSetName(pthread_t thread, const char *_Nonnull name) {
+CF_CROSS_PLATFORM_EXPORT int _CFThreadSetName(pthread_t thread, const char *_Nonnull name) {
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI
     if (pthread_equal(pthread_self(), thread)) {
         return pthread_setname_np(name);
@@ -1330,7 +1330,7 @@ CF_SWIFT_EXPORT int _CFThreadSetName(pthread_t thread, const char *_Nonnull name
 #endif
 }
 
-CF_SWIFT_EXPORT int _CFThreadGetName(char *_Nonnull buf, int length) {
+CF_CROSS_PLATFORM_EXPORT int _CFThreadGetName(char *_Nonnull buf, int length) {
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI
     return pthread_getname_np(pthread_self(), buf, length);
 #elif DEPLOYMENT_TARGET_ANDROID

--- a/CoreFoundation/Base.subproj/CFPriv.h
+++ b/CoreFoundation/Base.subproj/CFPriv.h
@@ -26,7 +26,13 @@
 #include <CoreFoundation/CFSet.h>
 #include <math.h>
 
-
+#ifndef CF_CROSS_PLATFORM_EXPORT
+    #if !DEPLOYMENT_RUNTIME_OBJC
+        #define CF_CROSS_PLATFORM_EXPORT extern
+    #else
+        #define CF_CROSS_PLATFORM_EXPORT static __attribute__((used))
+    #endif
+#endif
 
 #if (TARGET_OS_MAC && !(TARGET_OS_EMBEDDED || TARGET_OS_IPHONE || TARGET_OS_LINUX)) || (TARGET_OS_EMBEDDED || TARGET_OS_IPHONE)
 #include <CoreFoundation/CFMachPort.h>

--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1652,7 +1652,7 @@ static void _CFRelease(CFTypeRef CF_RELEASES_ARGUMENT cf) {
 struct _CFSwiftBridge __CFSwiftBridge = { { NULL } };
 
 // Call out to the CF-level finalizer, because the object is going to go away.
-CF_SWIFT_EXPORT void _CFDeinit(CFTypeRef cf) {
+CF_CROSS_PLATFORM_EXPORT void _CFDeinit(CFTypeRef cf) {
     __CFInfoType info = atomic_load(&(((CFRuntimeBase *)cf)->_cfinfoa));
     CFTypeID typeID = __CFTypeIDFromInfo(info);
     CFRuntimeClass *cfClass = __CFRuntimeClassTable[typeID];

--- a/CoreFoundation/Base.subproj/ForFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForFoundationOnly.h
@@ -30,14 +30,6 @@
 #include <math.h>
 #include <limits.h>
 
-#ifndef CF_SWIFT_EXPORT
-#if DEPLOYMENT_RUNTIME_SWIFT
-#define CF_SWIFT_EXPORT extern
-#else
-#define CF_SWIFT_EXPORT static __attribute__((used))
-#endif
-#endif
-
 #define _CF_EXPORT_SCOPE_BEGIN \
 CF_EXTERN_C_BEGIN \
 CF_ASSUME_NONNULL_BEGIN \
@@ -556,19 +548,19 @@ CF_INLINE CFHashCode _CFHashDouble(const double d) {
 }
 
 
-CF_SWIFT_EXPORT void _CFNumberInitBool(CFNumberRef result, Boolean value);
-CF_SWIFT_EXPORT void _CFNumberInitInt8(CFNumberRef result, int8_t value);
-CF_SWIFT_EXPORT void _CFNumberInitUInt8(CFNumberRef result, uint8_t value);
-CF_SWIFT_EXPORT void _CFNumberInitInt16(CFNumberRef result, int16_t value);
-CF_SWIFT_EXPORT void _CFNumberInitUInt16(CFNumberRef result, uint16_t value);
-CF_SWIFT_EXPORT void _CFNumberInitInt32(CFNumberRef result, int32_t value);
-CF_SWIFT_EXPORT void _CFNumberInitUInt32(CFNumberRef result, uint32_t value);
-CF_SWIFT_EXPORT void _CFNumberInitInt(CFNumberRef result, long value);
-CF_SWIFT_EXPORT void _CFNumberInitUInt(CFNumberRef result, unsigned long value);
-CF_SWIFT_EXPORT void _CFNumberInitInt64(CFNumberRef result, int64_t value);
-CF_SWIFT_EXPORT void _CFNumberInitUInt64(CFNumberRef result, uint64_t value);
-CF_SWIFT_EXPORT void _CFNumberInitFloat(CFNumberRef result, float value);
-CF_SWIFT_EXPORT void _CFNumberInitDouble(CFNumberRef result, double value);
+CF_CROSS_PLATFORM_EXPORT void _CFNumberInitBool(CFNumberRef result, Boolean value);
+CF_CROSS_PLATFORM_EXPORT void _CFNumberInitInt8(CFNumberRef result, int8_t value);
+CF_CROSS_PLATFORM_EXPORT void _CFNumberInitUInt8(CFNumberRef result, uint8_t value);
+CF_CROSS_PLATFORM_EXPORT void _CFNumberInitInt16(CFNumberRef result, int16_t value);
+CF_CROSS_PLATFORM_EXPORT void _CFNumberInitUInt16(CFNumberRef result, uint16_t value);
+CF_CROSS_PLATFORM_EXPORT void _CFNumberInitInt32(CFNumberRef result, int32_t value);
+CF_CROSS_PLATFORM_EXPORT void _CFNumberInitUInt32(CFNumberRef result, uint32_t value);
+CF_CROSS_PLATFORM_EXPORT void _CFNumberInitInt(CFNumberRef result, long value);
+CF_CROSS_PLATFORM_EXPORT void _CFNumberInitUInt(CFNumberRef result, unsigned long value);
+CF_CROSS_PLATFORM_EXPORT void _CFNumberInitInt64(CFNumberRef result, int64_t value);
+CF_CROSS_PLATFORM_EXPORT void _CFNumberInitUInt64(CFNumberRef result, uint64_t value);
+CF_CROSS_PLATFORM_EXPORT void _CFNumberInitFloat(CFNumberRef result, float value);
+CF_CROSS_PLATFORM_EXPORT void _CFNumberInitDouble(CFNumberRef result, double value);
 
 /* These four functions are used by NSError in formatting error descriptions. They take NS or CFError as arguments and return a retained CFString or NULL.
 */ 
@@ -581,9 +573,9 @@ CF_EXPORT void *__CFURLReservedPtr(CFURLRef  url);
 CF_EXPORT void __CFURLSetReservedPtr(CFURLRef  url, void *_Nullable ptr);
 CF_EXPORT CFStringEncoding _CFURLGetEncoding(CFURLRef url);
 
-CF_SWIFT_EXPORT void _CFURLInitWithFileSystemPathRelativeToBase(CFURLRef url, CFStringRef fileSystemPath, CFURLPathStyle pathStyle, Boolean isDirectory, _Nullable CFURLRef baseURL);
-CF_SWIFT_EXPORT Boolean _CFURLInitWithURLString(CFURLRef url, CFStringRef string, Boolean checkForLegalCharacters, _Nullable CFURLRef baseURL);
-CF_SWIFT_EXPORT Boolean _CFURLInitAbsoluteURLWithBytes(CFURLRef url, const UInt8 *relativeURLBytes, CFIndex length, CFStringEncoding encoding, _Nullable CFURLRef baseURL);
+CF_CROSS_PLATFORM_EXPORT void _CFURLInitWithFileSystemPathRelativeToBase(CFURLRef url, CFStringRef fileSystemPath, CFURLPathStyle pathStyle, Boolean isDirectory, _Nullable CFURLRef baseURL);
+CF_CROSS_PLATFORM_EXPORT Boolean _CFURLInitWithURLString(CFURLRef url, CFStringRef string, Boolean checkForLegalCharacters, _Nullable CFURLRef baseURL);
+CF_CROSS_PLATFORM_EXPORT Boolean _CFURLInitAbsoluteURLWithBytes(CFURLRef url, const UInt8 *relativeURLBytes, CFIndex length, CFStringEncoding encoding, _Nullable CFURLRef baseURL);
 
 CF_EXPORT Boolean _CFRunLoopFinished(CFRunLoopRef rl, CFStringRef mode);
 CF_EXPORT CFTypeRef _CFRunLoopGet2(CFRunLoopRef rl);
@@ -615,7 +607,7 @@ enum {
 // This is for NSNumberFormatter use only!
 CF_EXPORT void *_CFNumberFormatterGetFormatter(CFNumberFormatterRef formatter);
 
-CF_SWIFT_EXPORT void _CFDataInit(CFMutableDataRef memory, CFOptionFlags variety, CFIndex capacity, const uint8_t *_Nullable bytes, CFIndex length, Boolean noCopy);
+CF_CROSS_PLATFORM_EXPORT void _CFDataInit(CFMutableDataRef memory, CFOptionFlags variety, CFIndex capacity, const uint8_t *_Nullable bytes, CFIndex length, Boolean noCopy);
 CF_EXPORT CFRange _CFDataFindBytes(CFDataRef data, CFDataRef dataToFind, CFRange searchRange, CFDataSearchFlags compareOptions);
 
 
@@ -660,7 +652,7 @@ CF_EXPORT CFTimeInterval CFGetSystemUptime(void);
 CF_EXPORT CFStringRef CFCopySystemVersionString(void);
 CF_EXPORT CFDictionaryRef _CFCopySystemVersionDictionary(void);
 
-CF_SWIFT_EXPORT Boolean _CFCalendarInitWithIdentifier(CFCalendarRef calendar, CFStringRef identifier);
+CF_CROSS_PLATFORM_EXPORT Boolean _CFCalendarInitWithIdentifier(CFCalendarRef calendar, CFStringRef identifier);
 CF_EXPORT Boolean _CFCalendarComposeAbsoluteTimeV(CFCalendarRef calendar, /* out */ CFAbsoluteTime *atp, const char *componentDesc, int32_t *vector, int32_t count);
 CF_EXPORT Boolean _CFCalendarDecomposeAbsoluteTimeV(CFCalendarRef calendar, CFAbsoluteTime at, const char *componentDesc, int32_t *_Nonnull * _Nonnull vector, int32_t count);
 CF_EXPORT Boolean _CFCalendarAddComponentsV(CFCalendarRef calendar, /* inout */ CFAbsoluteTime *atp, CFOptionFlags options, const char *componentDesc, int32_t *vector, int32_t count);
@@ -676,14 +668,14 @@ typedef struct {
 
 CF_EXPORT Boolean _CFCalendarGetNextWeekend(CFCalendarRef calendar, _CFCalendarWeekendRange *range);
 
-CF_SWIFT_EXPORT Boolean _CFLocaleInit(CFLocaleRef locale, CFStringRef identifier);
+CF_CROSS_PLATFORM_EXPORT Boolean _CFLocaleInit(CFLocaleRef locale, CFStringRef identifier);
 
-CF_SWIFT_EXPORT Boolean _CFTimeZoneInit(CFTimeZoneRef timeZone, CFStringRef name, _Nullable CFDataRef data);
+CF_CROSS_PLATFORM_EXPORT Boolean _CFTimeZoneInit(CFTimeZoneRef timeZone, CFStringRef name, _Nullable CFDataRef data);
 
-CF_SWIFT_EXPORT Boolean _CFCharacterSetInitWithCharactersInRange(CFMutableCharacterSetRef cset, CFRange theRange);
-CF_SWIFT_EXPORT Boolean _CFCharacterSetInitWithCharactersInString(CFMutableCharacterSetRef cset, CFStringRef theString);
-CF_SWIFT_EXPORT Boolean _CFCharacterSetInitMutable(CFMutableCharacterSetRef cset);
-CF_SWIFT_EXPORT Boolean _CFCharacterSetInitWithBitmapRepresentation(CFMutableCharacterSetRef cset, CFDataRef theData);
+CF_CROSS_PLATFORM_EXPORT Boolean _CFCharacterSetInitWithCharactersInRange(CFMutableCharacterSetRef cset, CFRange theRange);
+CF_CROSS_PLATFORM_EXPORT Boolean _CFCharacterSetInitWithCharactersInString(CFMutableCharacterSetRef cset, CFStringRef theString);
+CF_CROSS_PLATFORM_EXPORT Boolean _CFCharacterSetInitMutable(CFMutableCharacterSetRef cset);
+CF_CROSS_PLATFORM_EXPORT Boolean _CFCharacterSetInitWithBitmapRepresentation(CFMutableCharacterSetRef cset, CFDataRef theData);
 CF_EXPORT CFIndex __CFCharDigitValue(UniChar ch);
 
 CF_EXPORT int _CFOpenFileWithMode(const char *path, int opts, mode_t mode);

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -316,8 +316,8 @@ typedef pthread_t _CFThreadRef;
 
 CF_EXPORT _CFThreadRef _CFThreadCreate(const _CFThreadAttributes attrs, void *_Nullable (* _Nonnull startfn)(void *_Nullable), void *restrict _Nullable context);
 
-CF_SWIFT_EXPORT int _CFThreadSetName(pthread_t thread, const char *_Nonnull name);
-CF_SWIFT_EXPORT int _CFThreadGetName(char *_Nonnull buf, int length);
+CF_CROSS_PLATFORM_EXPORT int _CFThreadSetName(pthread_t thread, const char *_Nonnull name);
+CF_CROSS_PLATFORM_EXPORT int _CFThreadGetName(char *_Nonnull buf, int length);
 
 CF_EXPORT Boolean _CFCharacterSetIsLongCharacterMember(CFCharacterSetRef theSet, UTF32Char theChar);
 CF_EXPORT CFCharacterSetRef _CFCharacterSetCreateCopy(CFAllocatorRef alloc, CFCharacterSetRef theSet);
@@ -327,7 +327,7 @@ CF_EXPORT _Nullable CFErrorRef CFReadStreamCopyError(CFReadStreamRef stream);
 
 CF_EXPORT _Nullable CFErrorRef CFWriteStreamCopyError(CFWriteStreamRef stream);
 
-CF_SWIFT_EXPORT Boolean _CFBundleSupportsFHSBundles(void);
+CF_CROSS_PLATFORM_EXPORT Boolean _CFBundleSupportsFHSBundles(void);
 
 // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 // Version 0.8

--- a/CoreFoundation/String.subproj/CFCharacterSet.c
+++ b/CoreFoundation/String.subproj/CFCharacterSet.c
@@ -1708,11 +1708,11 @@ CFMutableCharacterSetRef CFCharacterSetCreateMutableCopy(CFAllocatorRef alloc, C
     return __CFCharacterSetCreateCopy(alloc, theSet, true, true);
 }
 
-CF_SWIFT_EXPORT CFCharacterSetRef _CFCharacterSetCreateCopy(CFAllocatorRef alloc, CFCharacterSetRef theSet) {
+CF_CROSS_PLATFORM_EXPORT CFCharacterSetRef _CFCharacterSetCreateCopy(CFAllocatorRef alloc, CFCharacterSetRef theSet) {
     return __CFCharacterSetCreateCopy(alloc, theSet, false, false);
 }
 
-CF_SWIFT_EXPORT CFMutableCharacterSetRef _CFCharacterSetCreateMutableCopy(CFAllocatorRef alloc, CFCharacterSetRef theSet) {
+CF_CROSS_PLATFORM_EXPORT CFMutableCharacterSetRef _CFCharacterSetCreateMutableCopy(CFAllocatorRef alloc, CFCharacterSetRef theSet) {
     return __CFCharacterSetCreateCopy(alloc, theSet, true, false);
 }
 
@@ -1758,7 +1758,7 @@ Boolean CFCharacterSetIsCharacterMember(CFCharacterSetRef theSet, UniChar theCha
     return result;
 }
 
-CF_SWIFT_EXPORT Boolean _CFCharacterSetIsLongCharacterMember(CFCharacterSetRef theSet, UTF32Char theChar) {
+CF_CROSS_PLATFORM_EXPORT Boolean _CFCharacterSetIsLongCharacterMember(CFCharacterSetRef theSet, UTF32Char theChar) {
     CFIndex length;
     UInt32 plane = (theChar >> 16);
     Boolean isAnnexInverted = false;

--- a/CoreFoundation/URL.subproj/CFURLComponents.c
+++ b/CoreFoundation/URL.subproj/CFURLComponents.c
@@ -66,7 +66,7 @@ static CFStringRef __CFURLComponentsCopyDescription(CFTypeRef cf) {
     return CFRetain(CFSTR("A really nice CFURLComponents object"));
 }
 
-CF_SWIFT_EXPORT void __CFURLComponentsDeallocate(CFURLComponentsRef instance) {
+CF_CROSS_PLATFORM_EXPORT void __CFURLComponentsDeallocate(CFURLComponentsRef instance) {
     __CFGenericValidateType(instance, _CFURLComponentsGetTypeID());
     
     if (instance->_urlString) CFRelease(instance->_urlString);

--- a/CoreFoundation/URL.subproj/CFURLComponents.h
+++ b/CoreFoundation/URL.subproj/CFURLComponents.h
@@ -26,11 +26,11 @@ CF_IMPLICIT_BRIDGING_ENABLED
 CF_EXTERN_C_BEGIN
 CF_ASSUME_NONNULL_BEGIN
 
-#ifndef CF_SWIFT_EXPORT
+#ifndef CF_CROSS_PLATFORM_EXPORT
 #if DEPLOYMENT_RUNTIME_SWIFT
-#define CF_SWIFT_EXPORT extern
+#define CF_CROSS_PLATFORM_EXPORT extern
 #else
-#define CF_SWIFT_EXPORT static __attribute__((used))
+#define CF_CROSS_PLATFORM_EXPORT static __attribute__((used))
 #endif
 #endif
 
@@ -38,7 +38,7 @@ typedef struct __CFURLComponents *CFURLComponentsRef;
 
 CF_EXPORT CFTypeID _CFURLComponentsGetTypeID(void);
 
-CF_SWIFT_EXPORT void __CFURLComponentsDeallocate(CFURLComponentsRef);
+CF_CROSS_PLATFORM_EXPORT void __CFURLComponentsDeallocate(CFURLComponentsRef);
 
 // URLComponents are always mutable.
 CF_EXPORT _Nullable CFURLComponentsRef _CFURLComponentsCreate(CFAllocatorRef alloc);


### PR DESCRIPTION
This was sometimes used in the codebase to mean 'using the Swift runtime' and sometimes to mean 'not on Darwin'. This name reflects both uses.