### PR TITLE
UserDefaults: Implement volatile domains, argument domain

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0383A1751D2E558A0052E5D1 /* TestStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0383A1741D2E558A0052E5D1 /* TestStream.swift */; };
 		03B6F5841F15F339004F25AF /* TestURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B6F5831F15F339004F25AF /* TestURLProtocol.swift */; };
 		1520469B1D8AEABE00D02E36 /* HTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1520469A1D8AEABE00D02E36 /* HTTPServer.swift */; };
+		153E95162012A29900F250BE /* UserDefaults_Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153E95152012A29900F250BE /* UserDefaults_Arguments.swift */; };
 		159884921DCC877700E3314C /* TestHTTPCookieStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159884911DCC877700E3314C /* TestHTTPCookieStorage.swift */; };
 		231503DB1D8AEE5D0061694D /* TestDecimal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231503DA1D8AEE5D0061694D /* TestDecimal.swift */; };
 		294E3C1D1CC5E19300E4F44C /* TestNSAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 294E3C1C1CC5E19300E4F44C /* TestNSAttributedString.swift */; };
@@ -498,6 +499,7 @@
 		0383A1741D2E558A0052E5D1 /* TestStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestStream.swift; sourceTree = "<group>"; };
 		03B6F5831F15F339004F25AF /* TestURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestURLProtocol.swift; sourceTree = "<group>"; };
 		1520469A1D8AEABE00D02E36 /* HTTPServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPServer.swift; sourceTree = "<group>"; };
+		153E95152012A29900F250BE /* UserDefaults_Arguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults_Arguments.swift; sourceTree = "<group>"; };
 		159884911DCC877700E3314C /* TestHTTPCookieStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHTTPCookieStorage.swift; sourceTree = "<group>"; };
 		22B9C1E01C165D7A00DECFF9 /* TestDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDate.swift; sourceTree = "<group>"; };
 		231503DA1D8AEE5D0061694D /* TestDecimal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDecimal.swift; sourceTree = "<group>"; };
@@ -1787,6 +1789,7 @@
 			isa = PBXGroup;
 			children = (
 				EADE0B871BD15DFF00C49C64 /* UserDefaults.swift */,
+				153E95152012A29900F250BE /* UserDefaults_Arguments.swift */,
 				5BDC3F3B1BCC5DCB00ED97BB /* NSLocale.swift */,
 				5BD70FB11D3D4CDC003B9BF8 /* Locale.swift */,
 			);
@@ -2184,6 +2187,7 @@
 				61E0117E1C1B55B9000037DD /* Timer.swift in Sources */,
 				EADE0BCD1BD15E0000C49C64 /* XMLParser.swift in Sources */,
 				5BDC3FD01BCF17E600ED97BB /* NSCFSet.swift in Sources */,
+				153E95162012A29900F250BE /* UserDefaults_Arguments.swift in Sources */,
 				5B1FD9DE1D6D16580080E83C /* TaskRegistry.swift in Sources */,
 				EADE0B931BD15DFF00C49C64 /* NSComparisonPredicate.swift in Sources */,
 				5B1FD9DC1D6D16580080E83C /* URLSessionDelegate.swift in Sources */,
@@ -2660,7 +2664,11 @@
 				INFOPLIST_FILE = Foundation/Info.plist;
 				INIT_ROUTINE = "___CFInitialize";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				OTHER_CFLAGS = (
 					"-DCF_BUILDING_CF",
 					"-DDEPLOYMENT_TARGET_MACOSX",
@@ -2732,7 +2740,11 @@
 				INFOPLIST_FILE = Foundation/Info.plist;
 				INIT_ROUTINE = "___CFInitialize";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				OTHER_CFLAGS = (
 					"-DCF_BUILDING_CF",
 					"-DDEPLOYMENT_TARGET_MACOSX",
@@ -2880,7 +2892,11 @@
 					/usr/include/libxml2,
 				);
 				INFOPLIST_FILE = TestFoundation/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = mh_execute;
 				OTHER_SWIFT_FLAGS = "-DDEPLOYMENT_ENABLE_LIBDISPATCH -swift-version 4";
@@ -2906,7 +2922,11 @@
 					/usr/include/libxml2,
 				);
 				INFOPLIST_FILE = TestFoundation/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = mh_execute;
 				OTHER_SWIFT_FLAGS = "-DDEPLOYMENT_ENABLE_LIBDISPATCH -swift-version 4";
@@ -2930,7 +2950,12 @@
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = TestFoundation/xdgTestHelper/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../../.. @loader_path/../../.. @executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../../..",
+					"@loader_path/../../..",
+					"@executable_path/../Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = org.swift.xdgTestHelper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2952,7 +2977,12 @@
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = TestFoundation/xdgTestHelper/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../../.. @loader_path/../../.. @executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../../..",
+					"@loader_path/../../..",
+					"@executable_path/../Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = org.swift.xdgTestHelper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3044,4 +3074,3 @@
 	};
 	rootObject = 5B5D88541BBC938800234F36 /* Project object */;
 }
-

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -622,6 +622,34 @@ open class NSNumber : NSValue {
             fatalError("unsupported CFNumberType: '\(numberType)'")
         }
     }
+    
+    internal var _swiftValueOfOptimalType: Any {
+        if self === kCFBooleanTrue {
+            return true
+        } else if self === kCFBooleanFalse {
+            return false
+        }
+        
+        let numberType = _CFNumberGetType2(_cfObject)
+        switch numberType {
+        case kCFNumberSInt8Type:
+            return Int(int8Value)
+        case kCFNumberSInt16Type:
+            return Int(int16Value)
+        case kCFNumberSInt32Type:
+            return Int(int32Value)
+        case kCFNumberSInt64Type:
+            return int64Value < Int.max ? Int(int64Value) : int64Value
+        case kCFNumberFloat32Type:
+            return floatValue
+        case kCFNumberFloat64Type:
+            return doubleValue
+        case kCFNumberSInt128Type:
+            return int128Value
+        default:
+            fatalError("unsupported CFNumberType: '\(numberType)'")
+        }
+    }
 
     deinit {
         _CFDeinit(self)

--- a/Foundation/UserDefaults.swift
+++ b/Foundation/UserDefaults.swift
@@ -29,6 +29,22 @@ internal func plistValueAsNSObject(_ value: Any) -> NSObject? {
         nsValue = NSNumber(value: val)
     } else if let val = value as? Data {
         nsValue = val._nsObject
+    } else if let val = value as? Date {
+        nsValue = val._nsObject
+    } else if let val = value as? [Any] {
+        var nsValues: [NSObject] = []
+        for innerValue in val {
+            guard let nsInnerValue = plistValueAsNSObject(innerValue) else { return nil }
+            nsValues.append(nsInnerValue)
+        }
+        return NSArray(array: nsValues)
+    } else if let val = value as? [String: Any] {
+        var nsValues: [String: NSObject] = [:]
+        for (key, innerValue) in val {
+            guard let nsInnerValue = plistValueAsNSObject(innerValue) else { return nil }
+            nsValues[key] = nsInnerValue
+        }
+        return NSDictionary(dictionary: nsValues)
     } else if let val = value as? NSObject {
         nsValue = val
     } else {
@@ -36,6 +52,48 @@ internal func plistValueAsNSObject(_ value: Any) -> NSObject? {
     }
     
     return nsValue
+}
+
+internal func plistNSObjectAsValue(_ nsValue: NSObject) -> Any {
+    let value: Any
+    
+    // Converts a value to the internal representation. Internalized values are
+    // stored as NSObject derived objects in the registration dictionary.
+    if let val = nsValue as? NSString {
+        value = val._swiftObject
+    } else if let val = nsValue as? NSNumber {
+        value = val._swiftValueOfOptimalType
+    } else if let val = nsValue as? NSData {
+        value = val._swiftObject
+    } else if let val = nsValue as? NSArray {
+        value = val._swiftObject.map { plistNSObjectAsValue($0 as! NSObject) }
+    } else if let val = nsValue as? NSDictionary {
+        var values: [String: Any] = [:]
+        for (currentKey, currentInnerValue) in val {
+            let key: String
+            
+            if let swiftKey = currentKey as? String {
+                key = swiftKey
+            } else if let nsKey = currentKey as? NSString {
+                key = nsKey._swiftObject
+            } else {
+                continue
+            }
+            
+            if let nsInnerValue = currentInnerValue as? NSObject {
+                values[key] = plistNSObjectAsValue(nsInnerValue)
+            } else {
+                values[key] = currentInnerValue
+            }
+        }
+        value = values
+    } else if let val = nsValue as? NSDate {
+        value = val._swiftObject
+    } else {
+        value = nsValue
+    }
+    
+    return value
 }
 
 private extension Dictionary {
@@ -62,6 +120,14 @@ private extension Dictionary where Value == NSObject {
         } else {
             return false
         }
+    }
+    
+    func convertingValuesFromPlistNSObject() -> [Key: Any] {
+        var result: [Key: Any] = [:]
+        for (key, value) in self {
+            result[key] = plistNSObjectAsValue(value)
+        }
+        return result
     }
 }
 
@@ -354,7 +420,7 @@ open class UserDefaults: NSObject {
         return allDefaults
     }
     
-    private static let _parsedArgumentsDomain: [String: Any] = UserDefaults._parseArguments(ProcessInfo.processInfo.arguments)
+    private static let _parsedArgumentsDomain: [String: NSObject] = UserDefaults._parseArguments(ProcessInfo.processInfo.arguments).convertingValuesToNSObjects() ?? [:]
     
     private var _volatileDomains: [String: [String: NSObject]] = [:]
     private let _volatileDomainsLock = NSLock()
@@ -372,7 +438,7 @@ open class UserDefaults: NSObject {
         let domain = _volatileDomains[domainName]
         _volatileDomainsLock.unlock()
         
-        return domain ?? [:]
+        return domain?.convertingValuesFromPlistNSObject() ?? [:]
     }
     
     open func setVolatileDomain(_ domain: [String : Any], forName domainName: String) {

--- a/Foundation/UserDefaults_Arguments.swift
+++ b/Foundation/UserDefaults_Arguments.swift
@@ -32,18 +32,17 @@ internal extension UserDefaults {
                     var parsed = false
                     if let prefix = value.first, propertyListPrefixes.contains(prefix) {
                         if let data = value.data(using: .utf8),
-                            let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
-                            let plistNS = plistValueAsNSObject(plist) {
+                            let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) {
                             
                             // If we can parse that argument as a plist, use the parsed value.
                             parsed = true
-                            result[key] = plistNS
+                            result[key] = plist
                             
                         }
                     }
                     
-                    if !parsed, let valueNS = plistValueAsNSObject(value) {
-                        result[key] = valueNS
+                    if !parsed {
+                        result[key] = value
                     }
                 }
                 

--- a/Foundation/UserDefaults_Arguments.swift
+++ b/Foundation/UserDefaults_Arguments.swift
@@ -1,0 +1,58 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+import CoreFoundation
+
+fileprivate let propertyListPrefixes: Set<Character> = [ "{", "[", "(", "<", "\"" ]
+
+internal extension UserDefaults {
+    static func _parseArguments(_ arguments: [String]) -> [String: Any] {
+        var result: [String: Any] = [:]
+        
+        let count = arguments.count
+        
+        var index = 0
+        while index < count - 1 { // We're looking for pairs, so stop at the second-to-last argument.
+            let current = arguments[index]
+            let next = arguments[index + 1]
+            if current.hasPrefix("-") && !next.hasPrefix("-") {
+                // Match what Darwin does, which is to check whether the first argument is one of the characters that make up a NeXTStep-style or XML property list: open brace, open parens, open bracket, open angle bracket, or double quote. If it is, attempt parsing it as a plist; otherwise, just use the argument value as a String.
+                
+                let keySubstring = current[current.index(after: current.startIndex)...]
+                if !keySubstring.isEmpty {
+                    let key = String(keySubstring)
+                    let value = next.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+                    
+                    var parsed = false
+                    if let prefix = value.first, propertyListPrefixes.contains(prefix) {
+                        if let data = value.data(using: .utf8),
+                            let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+                            let plistNS = plistValueAsNSObject(plist) {
+                            
+                            // If we can parse that argument as a plist, use the parsed value.
+                            parsed = true
+                            result[key] = plistNS
+                            
+                        }
+                    }
+                    
+                    if !parsed, let valueNS = plistValueAsNSObject(value) {
+                        result[key] = valueNS
+                    }
+                }
+                
+                index += 1 // Skip both the key and the value on this loop.
+            }
+            
+            index += 1
+        }
+        
+        return result
+    }
+}

--- a/TestFoundation/TestUserDefaults.swift
+++ b/TestFoundation/TestUserDefaults.swift
@@ -39,6 +39,7 @@ class TestUserDefaults : XCTestCase {
 			("test_setValue_IntFromString", test_setValue_IntFromString ),
 			("test_setValue_DoubleFromString", test_setValue_DoubleFromString ),
 			("test_parseArguments", test_parseArguments),
+			("test_volatileDomains", test_volatileDomains),
 		]
 	}
 
@@ -286,5 +287,39 @@ class TestUserDefaults : XCTestCase {
 		XCTAssertEqual(result["SomeDefault1"] as! [String], [ "SomeValue1", "SomeValue2" ])
 		XCTAssertEqual(result["SomeDefault2"] as! [String: String], [ "SomeKey": "SomeValue" ])
 		XCTAssertEqual(result["SomeDefault3"] as! String, "SomeValue")
+	}
+	
+	func test_volatileDomains() {
+		let dateKey = "A Date",
+		stringKey = "A String",
+		arrayKey = "An Array",
+		dictionaryKey = "A Dictionary",
+		dataKey = "Some Data",
+		boolKey = "A Bool"
+		
+		let defaultsIn: [String: Any] = [
+			dateKey: Date(),
+			stringKey: "The String",
+			arrayKey: [1, 2, 3],
+			dictionaryKey: ["Swift": "Imperative", "Haskell": "Functional", "LISP": "LISP"],
+			dataKey: "The Data".data(using: .utf8)!,
+			boolKey: true
+		]
+		
+		let domainName = "TestDomain"
+		
+		let defaults = UserDefaults(suiteName: nil)!
+		XCTAssertFalse(defaults.volatileDomainNames.contains(domainName))
+		
+		defaults.setVolatileDomain(defaultsIn, forName: domainName)
+		let defaultsOut = defaults.volatileDomain(forName: domainName)
+		
+		XCTAssertEqual(defaultsIn.count, defaultsOut.count)
+		XCTAssertEqual(defaultsIn[dateKey] as! Date, defaultsOut[dateKey] as! Date)
+		XCTAssertEqual(defaultsIn[stringKey] as! String, defaultsOut[stringKey] as! String)
+		XCTAssertEqual(defaultsIn[arrayKey] as! [Int], defaultsOut[arrayKey] as! [Int])
+		XCTAssertEqual(defaultsIn[dictionaryKey] as! [String: String], defaultsOut[dictionaryKey] as! [String: String])
+		XCTAssertEqual(defaultsIn[dataKey] as! Data, defaultsOut[dataKey] as! Data)
+		XCTAssertEqual(defaultsIn[boolKey] as! Bool, defaultsOut[boolKey] as! Bool)
 	}
 }

--- a/TestFoundation/TestUserDefaults.swift
+++ b/TestFoundation/TestUserDefaults.swift
@@ -8,10 +8,10 @@
 //
 
 #if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-	@testable import Foundation
+	import Foundation
 	import XCTest
 #else
-	@testable import SwiftFoundation
+	import SwiftFoundation
 	import SwiftXCTest
 #endif
 
@@ -38,7 +38,6 @@ class TestUserDefaults : XCTestCase {
 			("test_setValue_BoolFromString", test_setValue_BoolFromString ),
 			("test_setValue_IntFromString", test_setValue_IntFromString ),
 			("test_setValue_DoubleFromString", test_setValue_DoubleFromString ),
-			("test_parseArguments", test_parseArguments),
 			("test_volatileDomains", test_volatileDomains),
 		]
 	}
@@ -255,38 +254,6 @@ class TestUserDefaults : XCTestCase {
 		defaults.set("12.34", forKey: "key1")
 		
 		XCTAssertEqual(defaults.double(forKey: "key1"), 12.34)
-	}
-	
-	func test_parseArguments() {
-		var shouldBeEmpty: [String: Any]
-			
-		shouldBeEmpty = UserDefaults._parseArguments([])
-		XCTAssert(shouldBeEmpty.isEmpty)
-
-		shouldBeEmpty = UserDefaults._parseArguments([ "There are", "no arguments", "here that", "should be", "parsed into", "stuff", "-wowThisIsTheLastAndShouldNotProduceAKey"])
-		XCTAssert(shouldBeEmpty.isEmpty)
-		
-		XCTAssertEqual(UserDefaults._parseArguments([ "-SomeDefault", "SomeValue"]) as! [String: String], ["SomeDefault": "SomeValue"])
-
-		XCTAssertEqual(UserDefaults._parseArguments([ "-SomeDefault", "SomeValue", "-Whoa", "1234", "This isn't parsed", "-WhoaAgain", "2345", "-wowThisIsTheLastAndShouldNotProduceAKey"]) as! [String: String], [
-			"SomeDefault": "SomeValue",
-			"Whoa": "1234",
-			"WhoaAgain": "2345",
-		])
-		
-		XCTAssertEqual(UserDefaults._parseArguments([ "-SomeDefault", "(\"SomeValue\")"]) as! [String: [String]], ["SomeDefault": [ "SomeValue" ]])
-		XCTAssertEqual(UserDefaults._parseArguments([ "-SomeDefault", "{\"SomeKey\" = \"SomeValue\";}"]) as! [String: [String: String]], ["SomeDefault": [ "SomeKey": "SomeValue" ]])
-		XCTAssertEqual(UserDefaults._parseArguments([ "-SomeDefault", "\"SomeValue\"" ]) as! [String: String], ["SomeDefault": "SomeValue"])
-		
-		let result = UserDefaults._parseArguments([ "-SomeDefault1", "(\"SomeValue1\", \"SomeValue2\")",
-													"-SomeDefault2", "{\"SomeKey\" = \"SomeValue\";}",
-													"This isn't parsed",
-													"-SomeDefault3", "\"SomeValue\"",
-													"-wowThisIsTheLastAndShouldNotProduceAKey" ])
-		XCTAssertEqual(result.count, 3)
-		XCTAssertEqual(result["SomeDefault1"] as! [String], [ "SomeValue1", "SomeValue2" ])
-		XCTAssertEqual(result["SomeDefault2"] as! [String: String], [ "SomeKey": "SomeValue" ])
-		XCTAssertEqual(result["SomeDefault3"] as! String, "SomeValue")
 	}
 	
 	func test_volatileDomains() {

--- a/TestFoundation/TestUserDefaults.swift
+++ b/TestFoundation/TestUserDefaults.swift
@@ -301,7 +301,7 @@ class TestUserDefaults : XCTestCase {
 			dateKey: Date(),
 			stringKey: "The String",
 			arrayKey: [1, 2, 3],
-			dictionaryKey: ["Swift": "Imperative", "Haskell": "Functional", "LISP": "LISP"],
+			dictionaryKey: ["Swift": "Imperative", "Haskell": "Functional", "LISP": "LISP", "Today": Date()],
 			dataKey: "The Data".data(using: .utf8)!,
 			boolKey: true
 		]
@@ -318,7 +318,7 @@ class TestUserDefaults : XCTestCase {
 		XCTAssertEqual(defaultsIn[dateKey] as! Date, defaultsOut[dateKey] as! Date)
 		XCTAssertEqual(defaultsIn[stringKey] as! String, defaultsOut[stringKey] as! String)
 		XCTAssertEqual(defaultsIn[arrayKey] as! [Int], defaultsOut[arrayKey] as! [Int])
-		XCTAssertEqual(defaultsIn[dictionaryKey] as! [String: String], defaultsOut[dictionaryKey] as! [String: String])
+		XCTAssertEqual(defaultsIn[dictionaryKey] as! [String: AnyHashable], defaultsOut[dictionaryKey] as! [String: AnyHashable])
 		XCTAssertEqual(defaultsIn[dataKey] as! Data, defaultsOut[dataKey] as! Data)
 		XCTAssertEqual(defaultsIn[boolKey] as! Bool, defaultsOut[boolKey] as! Bool)
 	}

--- a/build.py
+++ b/build.py
@@ -444,6 +444,7 @@ swift_sources = CompileSwiftSources([
 	'Foundation/URLSession/libcurl/libcurlHelpers.swift',
     'Foundation/URLSession/http/HTTPURLProtocol.swift',
 	'Foundation/UserDefaults.swift',
+	'Foundation/UserDefaults_Arguments.swift',
 	'Foundation/NSUUID.swift',
 	'Foundation/NSValue.swift',
 	'Foundation/XMLDocument.swift',


### PR DESCRIPTION
This implements:
 - The `.volatileDomain(forName:)` API and related calls.
 - The volatile argument domain, `UserDefaults.argumentDomain`.

A note: since there is no language-supported bridging in Swift Foundation, we opt to accept and return value types (Array<_>, Dictionary<_,_>, Date, URL…) rather than reference types (NSArray, NSDictionary, NSDate, NSURL…). We internally convert to reference types them to a. check that you are only saving plist types and b. to support existing persistent domain API (since these objects go to CF and need to be reference types).