### PR TITLE
Fix crashes when creating directories at single component relative paths

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -150,7 +150,7 @@ open class FileManager : NSObject {
             var isDir: ObjCBool = false
             if !fileExists(atPath: path, isDirectory: &isDir) {
                 let parent = path._nsObject.deletingLastPathComponent
-                if !fileExists(atPath: parent, isDirectory: &isDir) {
+                if !parent.isEmpty && !fileExists(atPath: parent, isDirectory: &isDir) {
                     try createDirectory(atPath: parent, withIntermediateDirectories: true, attributes: attributes)
                 }
                 if mkdir(path, S_IRWXU | S_IRWXG | S_IRWXO) != 0 {

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -33,6 +33,7 @@ class TestFileManager : XCTestCase {
             ("test_copyItemAtPathToPath", test_copyItemAtPathToPath),
             ("test_homedirectoryForUser", test_homedirectoryForUser),
             ("test_temporaryDirectoryForUser", test_temporaryDirectoryForUser),
+            ("test_creatingDirectoryWithShortIntermediatePath", test_creatingDirectoryWithShortIntermediatePath),
         ]
     }
     
@@ -108,6 +109,20 @@ class TestFileManager : XCTestCase {
             try fm.removeItem(atPath: path)
         } catch {
             XCTFail("Failed to clean up file")
+        }
+    }
+
+    func test_creatingDirectoryWithShortIntermediatePath() {
+        let fileManager = FileManager.default
+        fileManager.changeCurrentDirectoryPath(NSTemporaryDirectory())
+
+        let relativePath = NSUUID().uuidString
+
+        do {
+            try fileManager.createDirectory(atPath: relativePath, withIntermediateDirectories: true, attributes: nil)
+            try fileManager.removeItem(atPath: relativePath)
+        } catch {
+            XCTFail("Failed to create and clean up directory")
         }
     }
 


### PR DESCRIPTION
Bail early if after calling `deletingLastPathComponent` the path is empty. There is
no point in doing a traversal and trying to create an empty directory at the parent
path. In addition, this ends up tripping a pre-condition when we try finding the next
parent path component again.

This addresses SR-4570.