### PR TITLE
ExtraStringAPI: Sync with the overlay version

### DIFF
--- a/Foundation/ExtraStringAPIs.swift
+++ b/Foundation/ExtraStringAPIs.swift
@@ -2,21 +2,28 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
-// Random access for String.UTF16View, only when Foundation is
-// imported.  Making this API dependent on Foundation decouples the
-// Swift core from a UTF16 representation.
 extension String.UTF16View.Index {
-    public func advanced(by n: Int) -> String.UTF16View.Index {
-        return String.UTF16View.Index(encodedOffset: encodedOffset.advanced(by: n))
-    }
+  /// Construct from an integer offset.
+  @available(swift, obsoleted: 4.0)
+  public init(_ offset: Int) {
+    fatalError("Unavailable")
+  }
+
+  @available(swift, obsoleted: 4.0)
+  public func distance(to other: String.UTF16View.Index?) -> Int {
+    fatalError("Unavailable")
+  }
+
+  @available(swift, obsoleted: 4.0)
+  public func advanced(by n: Int) -> String.UTF16View.Index {
+    fatalError("Unavailable")
+  }
 }
-
-

--- a/Foundation/NSCFString.swift
+++ b/Foundation/NSCFString.swift
@@ -167,7 +167,7 @@ internal func _CFSwiftStringGetBytes(_ str: AnyObject, encoding: CFStringEncodin
         if let buffer = buffer {
             for idx in 0..<range.length {
                 // Since character is 2 bytes but the buffer is in term of 1 byte values, we have to split it up
-                let character = encodingView[start.advanced(by: idx + range.location)]
+                let character = encodingView[encodingView.index(start, offsetBy: idx + range.location)]
 #if _endian(big)
                 let byte0 = UInt8((character >> 8) & 0x00ff)
                 let byte1 = UInt8(character & 0x00ff)

--- a/Foundation/NSRegularExpression.swift
+++ b/Foundation/NSRegularExpression.swift
@@ -258,8 +258,8 @@ extension NSRegularExpression {
             let currentRange = result.range
             let replacement = replacementString(for: result, in: string, offset: 0, template: templ)
             if currentRange.location > NSMaxRange(previousRange) {
-                let min = start.advanced(by: NSMaxRange(previousRange))
-                let max = start.advanced(by: currentRange.location)
+                let min = string.utf16.index(start, offsetBy: NSMaxRange(previousRange))
+                let max = string.utf16.index(start, offsetBy: currentRange.location)
                 str += String(string.utf16[min..<max])!
             }
             str += replacement
@@ -267,8 +267,8 @@ extension NSRegularExpression {
         }
         
         if length > NSMaxRange(previousRange) {
-            let min = start.advanced(by: NSMaxRange(previousRange))
-            let max = start.advanced(by: length)
+            let min = string.utf16.index(start, offsetBy: NSMaxRange(previousRange))
+            let max = string.utf16.index(start, offsetBy: length)
             str += String(string.utf16[min..<max])!
         }
         
@@ -344,8 +344,8 @@ extension NSRegularExpression {
                         }
                         if substringRange.location != NSNotFound && substringRange.length > 0 {
                             let start = string.utf16.startIndex
-                            let min = start.advanced(by: substringRange.location)
-                            let max = start.advanced(by: substringRange.location + substringRange.length)
+                            let min = string.utf16.index(start, offsetBy: substringRange.location)
+                            let max = string.utf16.index(start, offsetBy: substringRange.location + substringRange.length)
                             substring = String(string.utf16[min..<max])!
                         }
                         str.replaceCharacters(in: rangeToReplace, with: substring)

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -193,7 +193,7 @@ open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSC
             NSRequiresConcreteImplementation()
         }
         let start = _storage.utf16.startIndex
-        return _storage.utf16[start.advanced(by: index)]
+        return _storage.utf16[_storage.utf16.index(start, offsetBy: index)]
     }
     
     public override convenience init() {
@@ -347,7 +347,7 @@ extension NSString {
     
     public func substring(from: Int) -> String {
         if type(of: self) == NSString.self || type(of: self) == NSMutableString.self {
-            return String(_storage.utf16.suffix(from: _storage.utf16.startIndex.advanced(by: from)))!
+            return String(_storage.utf16.suffix(from: _storage.utf16.index(_storage.utf16.startIndex, offsetBy: from)))!
         } else {
             return substring(with: NSRange(location: from, length: length - from))
         }
@@ -355,8 +355,7 @@ extension NSString {
     
     public func substring(to: Int) -> String {
         if type(of: self) == NSString.self || type(of: self) == NSMutableString.self {
-            return String(_storage.utf16.prefix(upTo: _storage.utf16.startIndex
-            .advanced(by: to)))!
+            return String(_storage.utf16.prefix(upTo: _storage.utf16.index(_storage.utf16.startIndex, offsetBy: to)))!
         } else {
             return substring(with: NSRange(location: 0, length: to))
         }
@@ -365,8 +364,8 @@ extension NSString {
     public func substring(with range: NSRange) -> String {
         if type(of: self) == NSString.self || type(of: self) == NSMutableString.self {
             let start = _storage.utf16.startIndex
-            let min = start.advanced(by: range.location)
-            let max = start.advanced(by: range.location + range.length)
+            let min = _storage.utf16.index(start, offsetBy: range.location)
+            let max = _storage.utf16.index(start, offsetBy: range.location + range.length)
             return String(decoding: _storage.utf16[min..<max], as: UTF16.self)
         } else {
             let buff = UnsafeMutablePointer<unichar>.allocate(capacity: range.length)

--- a/TestFoundation/TestNSAttributedString.swift
+++ b/TestFoundation/TestNSAttributedString.swift
@@ -587,7 +587,7 @@ class TestNSMutableAttributedString : XCTestCase {
         let deleteRange = NSRange(location: 0, length: 10)
         mutableAttrString.deleteCharacters(in: deleteRange)
         
-        let expectedString = String(string[string.startIndex.advanced(by: 10)...])
+        let expectedString = String(string[string.index(string.startIndex, offsetBy: 10)...])
         XCTAssertEqual(mutableAttrString.string, expectedString)
         
         let expectedLongestEffectiveRange = NSRange(expectedString.startIndex..., in: expectedString)


### PR DESCRIPTION
- The three functions are obsoleted in Swift 4.0. The bodies from
  the overlay wont compile due to use of internal symbols so replace
  with a fatalError() call which isnt used anyway.

- Update callers of advanced(by:) to use index(offsetBy:).