### PR TITLE
Avoid crashing when XPath queries return no results.

### DIFF
--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -885,8 +885,7 @@ CFArrayRef _CFXMLNodesForXPath(_CFXMLNodePtr node, const unsigned char* xpath) {
     xmlXPathObjectPtr evalResult = xmlXPathNodeEval(node, xpath, context);
 
     xmlNodeSetPtr nodes = evalResult->nodesetval;
-    
-    int count = nodes->nodeNr;
+    int count = nodes ? nodes->nodeNr : 0;
 
     CFMutableArrayRef results = CFArrayCreateMutable(NULL, count, NULL);
     for (int i = 0; i < count; i++) {

--- a/TestFoundation/TestXMLDocument.swift
+++ b/TestFoundation/TestXMLDocument.swift
@@ -158,7 +158,10 @@ class TestXMLDocument : XCTestCase {
         XCTAssertEqual(nodes[0], bar1)
         XCTAssertEqual(nodes[1], bar2)
         XCTAssertEqual(nodes[2], bar3)
-        
+
+        let emptyResults = try! doc.nodes(forXPath: "/items/item/name[@type='alternate']/@value")
+        XCTAssertEqual(emptyResults.count, 0)
+
         let xmlString = """
         <?xml version="1.0" encoding="utf-8" standalone="yes"?>
             <D:propfind xmlns:D="DAV:">


### PR DESCRIPTION
Check before dereferencing `nodesetval` because it may be `NULL` if an XPath query
returns no results (but is a valid query).

Fixes SR-4628.