### PR TITLE
NSMutableArray: remove init?(contentsOf{File,URL}:) override

### DIFF
--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -934,9 +934,6 @@ open class NSMutableArray : NSArray {
     open func sort(options opts: NSSortOptions = [], usingComparator cmptr: Comparator) {
         self.setArray(self.sortedArray(options: opts, usingComparator: cmptr))
     }
-    
-    public convenience init?(contentsOfFile path: String) { NSUnimplemented() }
-    public convenience init?(contentsOfURL url: URL) { NSUnimplemented() }
 }
 
 extension NSArray : Sequence {

--- a/TestFoundation/TestNSArray.swift
+++ b/TestFoundation/TestNSArray.swift
@@ -47,6 +47,8 @@ class TestNSArray : XCTestCase {
             ("test_mutableCopying", test_mutableCopying),
             ("test_writeToFile", test_writeToFile),
             ("test_initWithContentsOfFile", test_initWithContentsOfFile),
+            ("test_initMutableWithContentsOfFile", test_initMutableWithContentsOfFile),
+            ("test_initMutableWithContentsOfURL", test_initMutableWithContentsOfURL),
             ("test_readWriteURL", test_readWriteURL),
             ("test_insertObjectAtIndex", test_insertObjectAtIndex),
             ("test_insertObjectsAtIndexes", test_insertObjectsAtIndexes),
@@ -647,7 +649,46 @@ class TestNSArray : XCTestCase {
             XCTFail("Temporary file creation failed")
         }
     }
-    
+
+    func test_initMutableWithContentsOfFile() {
+        if let testFilePath = createTestFile("TestFileOut.txt", _contents: Data(capacity: 234)) {
+            let a1: NSArray = ["foo", "bar"]
+            let isWritten = a1.write(toFile: testFilePath, atomically: true)
+            if isWritten {
+                let array = NSMutableArray.init(contentsOfFile: testFilePath)
+                XCTAssert(array == a1)
+                XCTAssertEqual(array?.count, 2)
+                array?.removeAllObjects()
+                XCTAssertEqual(array?.count, 0)
+            } else {
+                XCTFail("Write to file failed")
+            }
+            removeTestFile(testFilePath)
+        } else {
+            XCTFail("Temporary file creation failed")
+        }
+    }
+
+    func test_initMutableWithContentsOfURL() {
+        if let testFilePath = createTestFile("TestFileOut.txt", _contents: Data(capacity: 234)) {
+            let a1: NSArray = ["foo", "bar"]
+            let isWritten = a1.write(toFile: testFilePath, atomically: true)
+            if isWritten {
+                let url = URL(fileURLWithPath: testFilePath, isDirectory: false)
+                let array = NSMutableArray.init(contentsOf: url)
+                XCTAssert(array == a1)
+                XCTAssertEqual(array?.count, 2)
+                array?.removeAllObjects()
+                XCTAssertEqual(array?.count, 0)
+            } else {
+                XCTFail("Write to file failed")
+            }
+            removeTestFile(testFilePath)
+        } else {
+            XCTFail("Temporary file creation failed")
+        }
+    }
+
     func test_writeToFile() {
         let testFilePath = createTestFile("TestFileOut.txt", _contents: Data(capacity: 234))
         if let _ = testFilePath {


### PR DESCRIPTION
- The methods in NSMutableArray were NSUnimplemented but the NSArray
  versions were fully implemented so inherit those.

- Add tests for init?(contentsOfFile:) and init?(contentsOfURL:)