### PR TITLE
[URLRequest] Copy body

### DIFF
--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -143,6 +143,7 @@ open class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopying 
         self.url = source.url
         self.mainDocumentURL = source.mainDocumentURL
         self.httpMethod = source.httpMethod
+        self._body = source._body
     }
     
     open override func mutableCopy() -> Any {


### PR DESCRIPTION
This is the behaviour in Darwin Foundation, so.. ```¯\_(ツ)_/¯```