### PR TITLE
[DO NOT MERGE] Deleted CustomPlaygroundQuickLookable conformances from Foundation types.

### DIFF
--- a/Foundation/Date.swift
+++ b/Foundation/Date.swift
@@ -254,19 +254,6 @@ extension Date : _ObjectTypeBridgeable {
     }
 }
 
-extension Date : CustomPlaygroundQuickLookable {
-    var summary: String {
-        let df = DateFormatter()
-        df.dateStyle = .medium
-        df.timeStyle = .short
-        return df.string(from: self)
-    }
-    
-    public var customPlaygroundQuickLook: PlaygroundQuickLook {
-        return .text(summary)
-    }
-}
-
 extension Date : Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()

--- a/Foundation/NSRange.swift
+++ b/Foundation/NSRange.swift
@@ -309,12 +309,6 @@ extension NSRange : CustomReflectable {
     }
 }
 
-extension NSRange : CustomPlaygroundQuickLookable {
-    public var customPlaygroundQuickLook: PlaygroundQuickLook {
-        return .range(Int64(location), Int64(length))
-    }
-}
-
 extension NSRange : Codable {
     public init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()

--- a/Foundation/URL.swift
+++ b/Foundation/URL.swift
@@ -989,12 +989,6 @@ extension URL : CustomStringConvertible, CustomDebugStringConvertible {
     }
 }
 
-extension URL : CustomPlaygroundQuickLookable {
-    public var customPlaygroundQuickLook: PlaygroundQuickLook {
-        return .url(absoluteString)
-    }
-}
-
 extension URL : Codable {
     private enum CodingKeys : Int, CodingKey {
         case base


### PR DESCRIPTION
I'm planning on making a [swift-evolution proposal](https://github.com/cwakamo/swift-evolution/blob/playground-quicklook-api-revamp/proposals/nnnn-playground-quicklook-api-revamp.md) to remove this protocol from the standard library.

This goes with apple/swift#14252, which removes the protocol from the standard library.