### PR TITLE
Fixed comment on Calendar's compare method.

### DIFF
--- a/Foundation/Calendar.swift
+++ b/Foundation/Calendar.swift
@@ -588,7 +588,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     public func compare(_ date1: Date, to date2: Date, toUnitGranularity unit: NSCalendar.Unit) -> ComparisonResult { fatalError() }
     
     
-    /// Compares the given dates down to the given component, reporting them `orderedSame` if they are the same in the given component and all larger components, otherwise either `orderedAscending` or `orderedAscending`.
+    /// Compares the given dates down to the given component, reporting them `orderedSame` if they are the same in the given component and all larger components, otherwise either `orderedAscending` or `orderedDescending`.
     ///
     /// - parameter date1: A date to compare.
     /// - parameter date2: A date to compare.


### PR DESCRIPTION
The `compare` method on `Calendar` said `orderedAscending` twice, when it meant to say `orderedAscending` and `orderedDescending`. 

This PR supercedes #1417.

cc @alblue & @parkera  