### PR TITLE
Sync stdlib CocoaError convenience method

### DIFF
--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -690,6 +690,16 @@ public extension CocoaError {
     }
 }
 
+public extension CocoaError {
+    public static func error(_ code: CocoaError.Code, userInfo: [AnyHashable: Any]? = nil, url: URL? = nil) -> Error {
+        var info: [String: Any] = userInfo as? [String: Any] ?? [:]
+        if let url = url {
+            info[NSURLErrorKey] = url
+        }
+        return NSError(domain: NSCocoaErrorDomain, code: code.rawValue, userInfo: info)
+    }
+}
+
 extension CocoaError.Code {
 }
 

--- a/TestFoundation/TestNSError.swift
+++ b/TestFoundation/TestNSError.swift
@@ -30,6 +30,7 @@ class TestNSError : XCTestCase {
             ("test_CustomNSError_errorCode", test_CustomNSError_errorCode),
             ("test_CustomNSError_errorCodeRawInt", test_CustomNSError_errorCodeRawInt),
             ("test_CustomNSError_errorCodeRawUInt", test_CustomNSError_errorCodeRawUInt),
+            ("test_errorConvenience", test_errorConvenience)
         ]
     }
     
@@ -87,5 +88,21 @@ class TestNSError : XCTestCase {
         }
 
         XCTAssertEqual(SwiftError.fortyTwo.errorCode, 42)
+    }
+
+    func test_errorConvenience() {
+        let error = CocoaError.error(.fileReadNoSuchFile, url: URL(fileURLWithPath: #file))
+
+        if let nsError = error as? NSError {
+            XCTAssertEqual(nsError._domain, NSCocoaErrorDomain)
+            XCTAssertEqual(nsError._code, CocoaError.fileReadNoSuchFile.rawValue)
+            if let filePath = nsError.userInfo[NSURLErrorKey] as? URL {
+                XCTAssertEqual(filePath, URL(fileURLWithPath: #file))
+            } else {
+                XCTFail()
+            }
+        } else {
+            XCTFail()
+        }
     }
 }


### PR DESCRIPTION
A convenience method to create a Swift `Error` from an error code has been added to stdlib `NSError.swift` (https://github.com/apple/swift/blob/master/stdlib/public/SDK/Foundation/NSError.swift#L644) some time ago. This PR also adds this method (and a unit test) to corelibs `NSError.swift`.