### PR TITLE
Restore two more instances of CountableRange

### DIFF
--- a/Foundation/IndexSet.swift
+++ b/Foundation/IndexSet.swift
@@ -105,7 +105,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
             return IndexingIterator(_elements: self)
         }
         
-        public subscript(index : Index) -> Range<IndexSet.Element> {
+        public subscript(index : Index) -> CountableRange<IndexSet.Element> {
             let indexSetRange = indexSet._range(at: index)
             if let intersectingRange = intersectingRange {
                 return Swift.max(intersectingRange.lowerBound, indexSetRange.lowerBound)..<Swift.min(intersectingRange.upperBound, indexSetRange.upperBound)
@@ -461,9 +461,8 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
             let rangeIndex = rangeIndex
             return Index(value: value, extent: extent, rangeIndex: rangeIndex, rangeCount: rangeCount)
         } else {
-            let extent = 0..<0
             let rangeIndex = 0
-            return Index(value: value, extent: extent, rangeIndex: rangeIndex, rangeCount: rangeCount)
+            return Index(value: value, extent: 0..<0, rangeIndex: rangeIndex, rangeCount: rangeCount)
         }
     }
     
@@ -723,8 +722,8 @@ private struct IndexSetBoundaryIterator : IteratorProtocol {
     
     private var i1: IndexSet.RangeView.Iterator
     private var i2: IndexSet.RangeView.Iterator
-    private var i1Range: Range<Element>?
-    private var i2Range: Range<Element>?
+    private var i1Range: CountableRange<Element>?
+    private var i2Range: CountableRange<Element>?
     private var i1UsedLower: Bool
     private var i2UsedLower: Bool
     


### PR DESCRIPTION
Similar to #1423 to keep compatibility with both the 5.0 branch and master. To be reverted once swift rebranches 5.0.