### PR TITLE
Fixed `addObserver`'s obsolescence

### DIFF
--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -188,8 +188,8 @@ open class NotificationCenter: NSObject {
         })
     }
 
-    @available(*, unavailable, renamed: "addObserver(forName:object:queue:using:)")
-    open func addObserver(forName name: NSNotification.Name?, object obj: Any?, queue: OperationQueue?, usingBlock block: @escaping (Notification) -> Void) -> NSObjectProtocol {
+    @available(*,obsoleted:4.0,renamed:"addObserver(forName:object:queue:using:)")
+    open func addObserver(forName name: NSNotification.Name?, object obj: Any?, queue: OperationQueue?, usingBlock block: @escaping (Notification) -> Void, _: Void = ()) -> NSObjectProtocol {
         return addObserver(forName: name, object: obj, queue: queue, using: block)
     }
 


### PR DESCRIPTION
As per [this post](https://forums.swift.org/t/found-a-bug-in-foundations-obsolescence-mechanism-in-linux/7730) in the forums.

Fixed with Xiaodi's suggestion.
It passed `ninja test` in my computer and it fixed the problem I described after I rebuilt my binaries with this patch.

I think we need to run a `ninja test` in CI, just to be sure. After that, it should be ready for merge.