### PR TITLE
Serialize floats with decimal point and don't assume Int if rounds

### DIFF
--- a/Foundation/JSONSerialization.swift
+++ b/Foundation/JSONSerialization.swift
@@ -305,7 +305,7 @@ private struct JSONWriter {
         let formatter: CFNumberFormatter
         formatter = CFNumberFormatterCreate(nil, CFLocaleCopyCurrent(), kCFNumberFormatterNoStyle)
         CFNumberFormatterSetProperty(formatter, kCFNumberFormatterMaxFractionDigits, NSNumber(value: 15))
-        CFNumberFormatterSetFormat(formatter, "0.###############"._cfObject)
+        CFNumberFormatterSetFormat(formatter, "0.0##############"._cfObject)
         return formatter
     }()
 
@@ -840,11 +840,6 @@ private struct JSONReader {
                 }
                 guard doubleDistance > 0 else {
                     return nil
-                }
-
-                if doubleResult == doubleResult.rounded() {
-                    return (shouldUseReferenceType ? NSNumber(value: Int(doubleResult)) : Int(doubleResult),
-                            doubleDistance)
                 }
 
                 return (shouldUseReferenceType ? NSNumber(value: doubleResult) : doubleResult,

--- a/TestFoundation/TestJSONSerialization.swift
+++ b/TestFoundation/TestJSONSerialization.swift
@@ -1447,8 +1447,8 @@ extension TestJSONSerialization {
             let data = decimalArray.data(using: String.Encoding.utf8)
             let result = try JSONSerialization.jsonObject(with: data!, options: []) as? [Any]
             XCTAssertEqual(result?[0] as! Double, 12.1)
-            XCTAssertEqual(result?[1] as! Int, 10)
-            XCTAssertEqual(result?[2] as! Int, 0)
+            XCTAssertEqual(result?[1] as! Double, 10.0)
+            XCTAssertEqual(result?[2] as! Double, 0.0)
             XCTAssertEqual(result?[3] as! Double, 0.0001)
             XCTAssertEqual(result?[4] as! Int, 20)
             XCTAssertEqual(result?[5] as! Int, Int.max)


### PR DESCRIPTION
Hi Apple,

I’ve been having some problems encoding and then decoding Doubles using JSONSerialization on Linux which do not occur using the same code on Darwin. The problem seems to be due to the value being serialized without a decimal point so deserialization threats it is as Int. This causes problems with a cast to Double further down the line. The fix is to make sure floating point values are serialised with a decimal point and also removes the code which assumes a number is Int if it happens to round. I’ve adjusted the test so it continues to run. Not sure what the wider effects of this change might be but it resolves the problem I’m seeing and seems more in the spirit of JSON. Oddly, Darwin doesn’t serialize with the decimal point and the deserialization is fine though it seems to use CFNumber rather than Any.

Backs out https://github.com/apple/swift-corelibs-foundation/pull/914 so the following works on Linux:
```Swift
import Foundation

let json = try! JSONSerialization.data(withJSONObject: [10.0])
print(String(data: json, encoding: .utf8)!)
let array = try! JSONSerialization.jsonObject(with: json) as! [Any]
print(array[0] as! Double)
```