### PR TITLE
[4.1] SR-6968: ProcessInfo.processInfo.environment only gets once

### DIFF
--- a/Foundation/ProcessInfo.swift
+++ b/Foundation/ProcessInfo.swift
@@ -41,13 +41,22 @@ open class ProcessInfo: NSObject {
         
     }
     
-    
-    internal static var _environment: [String : String] = {
-        return Dictionary<String, String>._unconditionallyBridgeFromObjectiveC(__CFGetEnvironment()._nsObject)
-    }()
-    
     open var environment: [String : String] {
-        return ProcessInfo._environment
+        let equalSign = Character("=")
+        let strEncoding = String.defaultCStringEncoding
+        let envp = _CFEnviron()
+        var env: [String : String] = [:]
+        var idx = 0
+
+        while let entry = envp.advanced(by: idx).pointee {
+            if let entry = String(cString: entry, encoding: strEncoding), let i = entry.index(of: equalSign) {
+                let key = String(entry.prefix(upTo: i))
+                let value = String(entry.suffix(from: i).dropFirst())
+                env[key] = value
+            }
+            idx += 1
+        }
+        return env
     }
     
     open var arguments: [String] {

--- a/TestFoundation/TestProcessInfo.swift
+++ b/TestFoundation/TestProcessInfo.swift
@@ -24,6 +24,7 @@ class TestProcessInfo : XCTestCase {
             ("test_operatingSystemVersion", test_operatingSystemVersion ),
             ("test_processName", test_processName ),
             ("test_globallyUniqueString", test_globallyUniqueString ),
+            ("test_environment", test_environment),
         ]
     }
     
@@ -66,5 +67,41 @@ class TestProcessInfo : XCTestCase {
         XCTAssertEqual(parts[3].utf16.count, 4)
         XCTAssertEqual(parts[4].utf16.count, 12)
     }
-    
+
+    func test_environment() {
+        let preset = ProcessInfo.processInfo.environment["test"]
+        setenv("test", "worked", 1)
+        let postset = ProcessInfo.processInfo.environment["test"]
+        XCTAssertNil(preset)
+        XCTAssertEqual(postset, "worked")
+
+        // Bad values that wont be stored
+        XCTAssertEqual(setenv("", "", 1), -1)
+        XCTAssertEqual(setenv("bad1=", "", 1), -1)
+        XCTAssertEqual(setenv("bad2=", "1", 1) ,-1)
+        XCTAssertEqual(setenv("bad3=", "=2", 1), -1)
+
+        // Good values that will be, check splitting on '='
+        XCTAssertEqual(setenv("var1", "",1 ), 0)
+        XCTAssertEqual(setenv("var2", "=", 1), 0)
+        XCTAssertEqual(setenv("var3", "=x", 1), 0)
+        XCTAssertEqual(setenv("var4", "x=", 1), 0)
+        XCTAssertEqual(setenv("var5", "=x=", 1), 0)
+
+        let env = ProcessInfo.processInfo.environment
+
+        XCTAssertNil(env[""])
+        XCTAssertNil(env["bad1"])
+        XCTAssertNil(env["bad1="])
+        XCTAssertNil(env["bad2"])
+        XCTAssertNil(env["bad2="])
+        XCTAssertNil(env["bad3"])
+        XCTAssertNil(env["bad3="])
+
+        XCTAssertEqual(env["var1"], "")
+        XCTAssertEqual(env["var2"], "=")
+        XCTAssertEqual(env["var3"], "=x")
+        XCTAssertEqual(env["var4"], "x=")
+        XCTAssertEqual(env["var5"], "=x=")
+    }
 }


### PR DESCRIPTION
- Reparse the environment variables each time ProcessInfo.processinfo.enviroment is read.

- Use _CFEnviron() instead of environ as it is more portable.

- Use more portable string decoding, dont assume UTF-8.