### PR TITLE
[4.1] SR-7017: JSONDecoder will decode booleans as numbers.

### DIFF
--- a/Foundation/Codable.swift
+++ b/Foundation/Codable.swift
@@ -39,6 +39,8 @@ internal extension DecodingError {
             return "an array"
         } else if value is [String : Any] {
             return "a dictionary"
+        } else if value is Bool {
+            return "a boolean"
         } else {
             // This should never happen -- we somehow have a non-JSON type here.
             preconditionFailure("Invalid storage type \(type(of: value)).")

--- a/Foundation/JSONEncoder.swift
+++ b/Foundation/JSONEncoder.swift
@@ -1746,6 +1746,7 @@ extension _JSONDecoder : SingleValueDecodingContainer {
 // MARK: - Concrete Value Representations
 
 extension _JSONDecoder {
+
     /// Returns the given value unboxed from a container.
     fileprivate func unbox(_ value: Any, as type: Bool.Type) throws -> Bool? {
         guard !(value is NSNull) else { return nil }
@@ -1765,7 +1766,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: Int.Type) throws -> Int? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = value as? NSNumber else {
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -1780,7 +1781,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: Int8.Type) throws -> Int8? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = value as? NSNumber else {
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -1795,7 +1796,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: Int16.Type) throws -> Int16? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = value as? NSNumber else {
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -1810,7 +1811,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: Int32.Type) throws -> Int32? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = value as? NSNumber else {
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -1825,7 +1826,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: Int64.Type) throws -> Int64? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = value as? NSNumber else {
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -1840,7 +1841,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: UInt.Type) throws -> UInt? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = value as? NSNumber else {
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -1855,7 +1856,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: UInt8.Type) throws -> UInt8? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = value as? NSNumber else {
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -1870,7 +1871,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: UInt16.Type) throws -> UInt16? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = value as? NSNumber else {
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -1885,7 +1886,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: UInt32.Type) throws -> UInt32? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = value as? NSNumber else {
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -1900,7 +1901,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: UInt64.Type) throws -> UInt64? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = value as? NSNumber else {
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -1915,7 +1916,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: Float.Type) throws -> Float? {
         guard !(value is NSNull) else { return nil }
 
-        if let number = value as? NSNumber {
+        if let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse {
             // We are willing to return a Float by losing precision:
             // * If the original value was integral,
             //   * and the integral value was > Float.greatestFiniteMagnitude, we will fail
@@ -1961,7 +1962,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: Double.Type) throws -> Double? {
         guard !(value is NSNull) else { return nil }
 
-        if let number = value as? NSNumber {
+        if let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse {
             // We are always willing to return the number as a Double:
             // * If the original value was integral, it is guaranteed to fit in a Double; we are willing to lose precision past 2^53 if you encoded a UInt64 but requested a Double
             // * If it was a Float or Double, you will get back the precise value

--- a/TestFoundation/TestJSONEncoder.swift
+++ b/TestFoundation/TestJSONEncoder.swift
@@ -334,6 +334,65 @@ class TestJSONEncoder : XCTestCase {
             _ = try JSONDecoder().decode([Bool].self, from: "[1]".data(using: .utf8)!)
             XCTFail("Coercing non-boolean numbers into Bools was expected to fail")
         } catch { }
+
+
+        // Check that a Bool false or true isnt converted to 0 or 1
+        struct Foo: Decodable {
+            var intValue: Int?
+            var int8Value: Int8?
+            var int16Value: Int16?
+            var int32Value: Int32?
+            var int64Value: Int64?
+            var uintValue: UInt?
+            var uint8Value: UInt8?
+            var uint16Value: UInt16?
+            var uint32Value: UInt32?
+            var uint64Value: UInt64?
+            var floatValue: Float?
+            var doubleValue: Double?
+            var decimalValue: Decimal?
+            let boolValue: Bool
+        }
+
+        func testValue(_ valueName: String) {
+            do {
+                let jsonData = "{ \"\(valueName)\": false }".data(using: .utf8)!
+                _ = try JSONDecoder().decode(Foo.self, from: jsonData)
+                XCTFail("Decoded 'false' as non Bool for \(valueName)")
+            } catch {}
+            do {
+                let jsonData = "{ \"\(valueName)\": true }".data(using: .utf8)!
+                _ = try JSONDecoder().decode(Foo.self, from: jsonData)
+                XCTFail("Decoded 'true' as non Bool for \(valueName)")
+            } catch {}
+        }
+
+        testValue("intValue")
+        testValue("int8Value")
+        testValue("int16Value")
+        testValue("int32Value")
+        testValue("int64Value")
+        testValue("uintValue")
+        testValue("uint8Value")
+        testValue("uint16Value")
+        testValue("uint32Value")
+        testValue("uint64Value")
+        testValue("floatValue")
+        testValue("doubleValue")
+        testValue("decimalValue")
+        let falseJsonData = "{ \"boolValue\": false }".data(using: .utf8)!
+        if let falseFoo = try? JSONDecoder().decode(Foo.self, from: falseJsonData) {
+            XCTAssertFalse(falseFoo.boolValue)
+        } else {
+            XCTFail("Could not decode 'false' as a Bool")
+        }
+
+        let trueJsonData = "{ \"boolValue\": true }".data(using: .utf8)!
+        if let trueFoo = try? JSONDecoder().decode(Foo.self, from: trueJsonData) {
+            XCTAssertTrue(trueFoo.boolValue)
+        } else {
+            XCTFail("Could not decode 'true' as a Bool")
+        }
     }
 
     func test_codingOfInt8() {


### PR DESCRIPTION
- If an NSNumber was initialised from a boolean then dont allow it
  to be converted to a numeric value.

- Use same boolean check as Foundation overlay method.