### PR TITLE
Add support for custom JSON values

### DIFF
--- a/Foundation/JSONEncoder.swift
+++ b/Foundation/JSONEncoder.swift
@@ -900,6 +900,12 @@ open class JSONDecoder {
         let decoder = _JSONDecoder(referencing: topLevel, options: self.options)
         return try T(from: decoder)
     }
+    
+    open func decode<T : Decodable>(_ type: T.Type, from data: Data, customValueParser cvp : JSONSerialization.CustomValueParser?) throws -> T {
+        let topLevel = try JSONSerialization.jsonObject(with: data, options: [.useReferenceNumericTypes], customValueParser: cvp)
+        let decoder = _JSONDecoder(referencing: topLevel, options: self.options)
+        return try T(from: decoder)
+    }
 }
 
 // MARK: - _JSONDecoder


### PR DESCRIPTION
A small change to show how custom values in JSON data could be supported by the JSON decoder.

For example one could use

struct MyData : Codable {
      let test : String
}

with

{"test":<"my""strange""data">}

and easily get 

"\"my\"\"strange\"\"data\"\"

into test. 

This can be used to bypass JSON validation and decode for some data e.g. to have JSON as String inside of JSON without double quotes escape madness.