### PR TITLE
Add icu-config invocation to linux LDFLAGS to link the correct lib

### DIFF
--- a/build.py
+++ b/build.py
@@ -16,7 +16,7 @@ foundation.GCC_PREFIX_HEADER = 'CoreFoundation/Base.subproj/CoreFoundation_Prefi
 swift_cflags = ['-DDEPLOYMENT_RUNTIME_SWIFT']
 if Configuration.current.target.sdk == OSType.Linux:
 	foundation.CFLAGS = '-DDEPLOYMENT_TARGET_LINUX -D_GNU_SOURCE -DCF_CHARACTERSET_DATA_DIR="CoreFoundation/CharacterSets"'
-	foundation.LDFLAGS = '${SWIFT_USE_LINKER} -Wl,@./CoreFoundation/linux.ld -lswiftGlibc -Wl,-Bsymbolic '
+	foundation.LDFLAGS = '${SWIFT_USE_LINKER} -Wl,@./CoreFoundation/linux.ld -lswiftGlibc -Wl,-Bsymbolic `icu-config --ldflags`'
 	Configuration.current.requires_pkg_config = True
 elif Configuration.current.target.sdk == OSType.FreeBSD:
 	foundation.CFLAGS = '-DDEPLOYMENT_TARGET_FREEBSD -I/usr/local/include -I/usr/local/include/libxml2 -I/usr/local/include/curl '
@@ -76,8 +76,6 @@ if "XCTEST_BUILD_DIR" in Configuration.current.variables:
 
 if Configuration.current.requires_pkg_config:
     pkg_config_dependencies = [
-        'icu-i18n',
-        'icu-uc',
         'libcurl',
         'libxml-2.0',
     ]


### PR DESCRIPTION
This change simply adds an invocation of icu-config to include the proper searchdir for icu.