### PR TITLE
Fix for SR-6849 and SR-6962 leak in NSData and NSMutableData

### DIFF
--- a/CoreFoundation/Collections.subproj/CFData.c
+++ b/CoreFoundation/Collections.subproj/CFData.c
@@ -330,10 +330,11 @@ CFTypeID CFDataGetTypeID(void) {
 void _CFDataInit(CFMutableDataRef memory, CFOptionFlags variety, CFIndex capacity, const uint8_t *bytes, CFIndex length, Boolean noCopy) {
     Boolean isMutable = ((variety & __kCFMutableMask) != 0);
     Boolean isGrowable = ((variety & __kCFGrowableMask) != 0);
+    Boolean isDontDeallocate = ((variety & __kCFDontDeallocate) != 0);
     
     __CFDataSetNumBytesUsed(memory, 0);
     __CFDataSetLength(memory, 0);
-    __CFDataSetDontDeallocate(memory, true);
+    __CFDataSetDontDeallocate(memory, isDontDeallocate);
     
     if (isMutable && isGrowable) {
         __CFDataSetCapacity(memory, __CFDataRoundUpCapacity(1));

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -69,11 +69,10 @@ private final class _NSDataDeallocator {
 
 private let __kCFMutable: CFOptionFlags = 0x01
 private let __kCFGrowable: CFOptionFlags = 0x02
-private let __kCFMutableVarietyMask: CFOptionFlags = 0x03
-private let __kCFBytesInline: CFOptionFlags = 0x04
-private let __kCFUseAllocator: CFOptionFlags = 0x08
-private let __kCFDontDeallocate: CFOptionFlags = 0x10
-private let __kCFAllocatesCollectable: CFOptionFlags = 0x20
+
+private let __kCFBytesInline: CFOptionFlags = 2
+private let __kCFUseAllocator: CFOptionFlags = 3
+private let __kCFDontDeallocate: CFOptionFlags = 4
 
 open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     typealias CFType = CFData


### PR DESCRIPTION
Test case:
```
import Foundation

for _ in 0..<10 {
        let data = Data(base64Encoded: "UE9TVCAvIEhUVFAvMS4wDQpDb250ZW50LUxlbmd0aDoNCg0K")!
}
```

Valgrind memcheck tool output before the fix (as reported in SR-6849):
```
==7078== LEAK SUMMARY:
==7078==    definitely lost: 360 bytes in 10 blocks
```

Valgrind memcheck tool output after the fix:
```
==20265== LEAK SUMMARY:
==20265==    definitely lost: 0 bytes in 0 blocks
==20265==    indirectly lost: 0 bytes in 0 blocks
==20265==      possibly lost: 0 bytes in 0 blocks
```

Summary:
This is a regression from the https://github.com/apple/swift-corelibs-foundation/commit/df3ec55fe6c162d590a7653d89ad669c2b9716b1 commit  for the High Sierra changes. 

Previously, PR: https://github.com/apple/swift-corelibs-foundation/pull/380 had a fix for NSData leak where  `__CFDataGetInfoBit` for `__kCFDontDeallocate` (then equivalent of `__CFDataDontDeallocate` before PR for High Sierra changes) was set on an ‘if’ condition in `_CFDataInit` method and it was in turn checked in the `__CFDataDeallocate` method of `CFData` during deallocation. 
 
However, with the HighSierra PR 1338 changes now,  the value for ` __CFDataDontDeallocate` is hardcoded to `'true'`
`__CFDataSetDontDeallocate(memory, true);`
With this, data is never deallocated and hence the leak. 
