### PR TITLE
Implement FileManager.url{s,}(for:…) and NSSearchPathForDirectoriesInDomains.

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0383A1751D2E558A0052E5D1 /* TestStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0383A1741D2E558A0052E5D1 /* TestStream.swift */; };
 		03B6F5841F15F339004F25AF /* TestURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B6F5831F15F339004F25AF /* TestURLProtocol.swift */; };
+		1513A8432044893F00539722 /* FileManager_XDG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1513A8422044893F00539722 /* FileManager_XDG.swift */; };
 		1520469B1D8AEABE00D02E36 /* HTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1520469A1D8AEABE00D02E36 /* HTTPServer.swift */; };
 		153E951120111DC500F250BE /* CFKnownLocations.h in Headers */ = {isa = PBXBuildFile; fileRef = 153E950F20111DC500F250BE /* CFKnownLocations.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		153E951220111DC500F250BE /* CFKnownLocations.c in Sources */ = {isa = PBXBuildFile; fileRef = 153E951020111DC500F250BE /* CFKnownLocations.c */; };
@@ -515,6 +516,7 @@
 /* Begin PBXFileReference section */
 		0383A1741D2E558A0052E5D1 /* TestStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestStream.swift; sourceTree = "<group>"; };
 		03B6F5831F15F339004F25AF /* TestURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestURLProtocol.swift; sourceTree = "<group>"; };
+		1513A8422044893F00539722 /* FileManager_XDG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager_XDG.swift; sourceTree = "<group>"; };
 		1520469A1D8AEABE00D02E36 /* HTTPServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPServer.swift; sourceTree = "<group>"; };
 		153E950F20111DC500F250BE /* CFKnownLocations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CFKnownLocations.h; sourceTree = "<group>"; };
 		153E951020111DC500F250BE /* CFKnownLocations.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = CFKnownLocations.c; sourceTree = "<group>"; };
@@ -1822,6 +1824,7 @@
 			children = (
 				EADE0B5D1BD15DFF00C49C64 /* FileHandle.swift */,
 				EADE0B5E1BD15DFF00C49C64 /* FileManager.swift */,
+				1513A8422044893F00539722 /* FileManager_XDG.swift */,
 				EADE0B7A1BD15DFF00C49C64 /* Process.swift */,
 				5BDC3F2F1BCC5DCB00ED97BB /* Bundle.swift */,
 				5BDC3F411BCC5DCB00ED97BB /* ProcessInfo.swift */,
@@ -2344,6 +2347,7 @@
 				5BECBA3A1D1CAE9A00B39B1F /* NSMeasurement.swift in Sources */,
 				5BF7AEB21BCD51F9008F214A /* NSNumber.swift in Sources */,
 				61D2F9AF1FECFB3E0033306A /* NativeProtocol.swift in Sources */,
+				1513A8432044893F00539722 /* FileManager_XDG.swift in Sources */,
 				B9974B991EDF4A22007F15B8 /* HTTPURLProtocol.swift in Sources */,
 				5BCD03821D3EE35C00E3FF9B /* TimeZone.swift in Sources */,
 				EADE0BBC1BD15E0000C49C64 /* URLCache.swift in Sources */,
@@ -2708,6 +2712,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 150;
 				DYLIB_CURRENT_VERSION = 1303;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_VERSION = A;
 				GCC_PREFIX_HEADER = CoreFoundation/Base.subproj/CoreFoundation_Prefix.h;
 				HEADER_SEARCH_PATHS = (
@@ -2780,6 +2785,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 150;
 				DYLIB_CURRENT_VERSION = 1303;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_VERSION = A;
 				GCC_PREFIX_HEADER = CoreFoundation/Base.subproj/CoreFoundation_Prefix.h;
 				HEADER_SEARCH_PATHS = (

--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -337,7 +337,7 @@ open class FileManager : NSObject {
             return [ URL(fileURLWithPath: "/home", isDirectory: true) ]
             
         case .moviesDirectory:
-            return []
+            return [ _XDGUserDirectory.videos.url ]
             
         case .musicDirectory:
             guard domain == .user else { return [] }

--- a/Foundation/FileManager_XDG.swift
+++ b/Foundation/FileManager_XDG.swift
@@ -1,0 +1,109 @@
+//
+//  FileManager_XDG.swift
+//  SwiftFoundation
+//
+//  Created by Lily Vulcano on 2/26/18.
+//  Copyright © 2018 Apple. All rights reserved.
+//
+
+import CoreFoundation
+
+enum _XDGUserDirectory: String {
+    case desktop = "DESKTOP"
+    case download = "DOWNLOAD"
+    case publicShare = "PUBLICSHARE"
+    case documents = "DOCUMENTS"
+    case music = "MUSIC"
+    case pictures = "PICTURES"
+    case videos = "VIDEOS"
+    
+    static let allDirectories: [_XDGUserDirectory] = [
+        .desktop,
+        .download,
+        .publicShare,
+        .documents,
+        .music,
+        .pictures,
+        .videos,
+        ]
+    
+    var url: URL {
+        if let url = _XDGUserDirectory.configuredDirectoryURLs[self] {
+            return url
+        } else if let url = _XDGUserDirectory.osDefaultDirectoryURLs[self] {
+            return url
+        } else {
+            return _XDGUserDirectory.stopgapDefaultDirectoryURLs[self]!
+        }
+    }
+    
+    static let stopgapDefaultDirectoryURLs: [_XDGUserDirectory: URL] = {
+        let home = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+        return [
+            .desktop: home.appendingPathComponent("Desktop"),
+            .download: home.appendingPathComponent("Downloads"),
+            .publicShare: home.appendingPathComponent("Public"),
+            .documents: home.appendingPathComponent("Documents"),
+            .music: home.appendingPathComponent("Music"),
+            .pictures: home.appendingPathComponent("Pictures"),
+            .videos: home.appendingPathComponent("Videos"),
+        ]
+    }()
+    
+    static func userDirectories(fromConfigurationFileAt url: URL) -> [_XDGUserDirectory: URL]? {
+        if let configuration = try? String(contentsOf: url, encoding: .utf8) {
+            var entries: [_XDGUserDirectory: URL] = [:]
+            
+            // Parse it:
+            let lines = configuration.split(separator: "\n")
+            for line in lines {
+                if let range = line.range(of: "=") {
+                    var variable = String(line[line.startIndex ..< range.lowerBound].trimmingCharacters(in: .whitespaces))
+                    
+                    let prefix = "XDG_"
+                    let suffix = "_DIR"
+                    if variable.hasPrefix(prefix) && variable.hasSuffix(suffix) {
+                        let endOfPrefix = variable.index(variable.startIndex, offsetBy: prefix.length)
+                        let startOfSuffix = variable.index(variable.endIndex, offsetBy: -suffix.length)
+                        
+                        variable = String(variable[endOfPrefix ..< startOfSuffix])
+                    }
+                    
+                    guard let directory = _XDGUserDirectory(rawValue: variable) else {
+                        continue
+                    }
+                    
+                    let path = String(line[range.upperBound ..< line.endIndex]).trimmingCharacters(in: .whitespaces)
+                    if path.isEmpty {
+                        entries[directory] = URL(fileURLWithPath: path, isDirectory: true)
+                    }
+                }
+            }
+            
+            return entries
+        } else {
+            return nil
+        }
+    }
+    
+    static let configuredDirectoryURLs: [_XDGUserDirectory: URL] = {
+        let configurationHome = _SwiftValue.fetch(nonOptional: _CFXDGCreateConfigHomePath()) as! String
+        let configurationFile = URL(fileURLWithPath: "user-dirs.dirs", isDirectory: false, relativeTo: URL(fileURLWithPath: configurationHome, isDirectory: true))
+        
+        return userDirectories(fromConfigurationFileAt: configurationFile) ?? [:]
+    }()
+    
+    static let osDefaultDirectoryURLs: [_XDGUserDirectory: URL] = {
+        let configurationDirs = _SwiftValue.fetch(nonOptional: _CFXDGCreateConfigDirectoriesPaths()) as! [String]
+        
+        for directory in configurationDirs {
+            let configurationFile = URL(fileURLWithPath: directory, isDirectory: true).appendingPathComponent("user-dirs.defaults")
+            
+            if let result = userDirectories(fromConfigurationFileAt: configurationFile) {
+                return result
+            }
+        }
+        
+        return [:]
+    }()
+}

--- a/Foundation/FileManager_XDG.swift
+++ b/Foundation/FileManager_XDG.swift
@@ -1,9 +1,10 @@
+// This source file is part of the Swift.org open source project
 //
-//  FileManager_XDG.swift
-//  SwiftFoundation
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
 //
-//  Created by Lily Vulcano on 2/26/18.
-//  Copyright © 2018 Apple. All rights reserved.
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
 import CoreFoundation

--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -578,7 +578,7 @@ public func NSSearchPathForDirectoriesInDomains(_ directory: FileManager.SearchP
     }
     
     return result.map { (url) in
-        var path = url.path
+        var path = url.absoluteURL.path
         if expandTilde {
             path = NSString(string: path).expandingTildeInPath
         }

--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -562,7 +562,29 @@ extension FileManager {
 }
 
 public func NSSearchPathForDirectoriesInDomains(_ directory: FileManager.SearchPathDirectory, _ domainMask: FileManager.SearchPathDomainMask, _ expandTilde: Bool) -> [String] {
-    NSUnimplemented()
+    let knownDomains: [FileManager.SearchPathDomainMask] = [
+        .userDomainMask,
+        .networkDomainMask,
+        .localDomainMask,
+        .systemDomainMask,
+    ]
+    
+    var result: [URL] = []
+    
+    for domain in knownDomains {
+        if domainMask.contains(domain) {
+            result.append(contentsOf: FileManager.default.urls(for: directory, in: domain))
+        }
+    }
+    
+    return result.map { (url) in
+        var path = url.path
+        if expandTilde {
+            path = NSString(string: path).expandingTildeInPath
+        }
+        
+        return path
+    }
 }
 
 public func NSHomeDirectory() -> String {

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -29,7 +29,6 @@ class TestFileManager : XCTestCase {
             ("test_temporaryDirectoryForUser", test_temporaryDirectoryForUser),
             ("test_creatingDirectoryWithShortIntermediatePath", test_creatingDirectoryWithShortIntermediatePath),
             ("test_mountedVolumeURLs", test_mountedVolumeURLs),
-            ("test_contentsEqual", test_contentsEqual)
             ("test_XDGStopgapsCoverAllConstants", test_XDGStopgapsCoverAllConstants),
             ("test_parseXDGConfiguration", test_parseXDGConfiguration),
             ("test_xdgURLSelection", test_xdgURLSelection),

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -7,6 +7,10 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if !(DEPLOYMENT_RUNTIME_OBJC || os(Linux) || os(Android))
+@testable import SwiftFoundation
+#endif
+
 class TestFileManager : XCTestCase {
     
     static var allTests: [(String, (TestFileManager) -> () throws -> Void)] {

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -30,6 +30,8 @@ class TestFileManager : XCTestCase {
             ("test_creatingDirectoryWithShortIntermediatePath", test_creatingDirectoryWithShortIntermediatePath),
             ("test_mountedVolumeURLs", test_mountedVolumeURLs),
             ("test_contentsEqual", test_contentsEqual)
+            ("test_XDGStopgapsCoverAllConstants", test_XDGStopgapsCoverAllConstants),
+            ("test_parseXDGConfiguration", test_parseXDGConfiguration),
         ]
     }
     
@@ -946,5 +948,16 @@ class TestFileManager : XCTestCase {
         try? data.write(to: dataFile1)
         XCTAssertFalse(fm.contentsEqual(atPath: dataFile1.path, andPath: dataFile2.path))
         XCTAssertFalse(fm.contentsEqual(atPath: testDir1.path, andPath: testDir2.path))
+    }
+    
+    func test_XDGStopgapsCoverAllConstants() {
+        let stopgaps = _XDGUserDirectory.stopgapDefaultDirectoryURLs
+        for directory in _XDGUserDirectory.allDirectories {
+            XCTAssertNotNil(stopgaps[directory])
+        }
+    }
+    
+    func test_parseXDGConfiguration() {
+        
     }
 }

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -7,7 +7,9 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if !DEPLOYMENT_RUNTIME_OBJC
+#if !DEPLOYMENT_RUNTIME_OBJC && (os(Linux) || os(Android))
+@testable import Foundation
+#else
 @testable import SwiftFoundation
 #endif
 

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -395,7 +395,7 @@ private enum Error: Swift.Error {
 }
 
 #if !os(Android)
-private func runTask(_ arguments: [String], environment: [String: String]? = nil, currentDirectoryPath: String? = nil) throws -> (String, String) {
+internal func runTask(_ arguments: [String], environment: [String: String]? = nil, currentDirectoryPath: String? = nil) throws -> (String, String) {
     let process = Process()
 
     var arguments = arguments

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -7,10 +7,12 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux) || os(Android)
+#if DEPLOYMENT_RUNTIME_OBJC
 import Foundation
+#elseif os(Linux) || os(Android)
+@testable import Foundation
 #else
-import SwiftFoundation
+@testable import SwiftFoundation
 #endif
 
 enum HelperCheckStatus : Int32 {
@@ -55,15 +57,93 @@ class XDGCheck {
     }
 }
 
-if let arg = ProcessInfo.processInfo.arguments.last {
-    if arg == "--xdgcheck" {
-        XDGCheck.run()
+// -----
+
+#if !DEPLOYMENT_RUNTIME_OBJC
+struct NSURLForPrintTest {
+    enum Method: String {
+        case NSSearchPath
+        case FileManagerDotURLFor
+        case FileManagerDotURLsFor
     }
-    if arg == "--getcwd" {
-        print(FileManager.default.currentDirectoryPath)
+    
+    enum Identifier: String {
+        case desktop
+        case download
+        case publicShare
+        case documents
+        case music
+        case pictures
+        case videos
     }
-    if arg == "--echo-PWD" {
-        print(ProcessInfo.processInfo.environment["PWD"] ?? "")
+    
+    let method: Method
+    let identifier: Identifier
+    
+    func run() {
+        let directory: FileManager.SearchPathDirectory
+        
+        switch identifier {
+        case .desktop:
+            directory = .desktopDirectory
+        case .download:
+            directory = .downloadsDirectory
+        case .publicShare:
+            directory = .sharedPublicDirectory
+        case .documents:
+            directory = .documentDirectory
+        case .music:
+            directory = .musicDirectory
+        case .pictures:
+            directory = .picturesDirectory
+        case .videos:
+            directory = .moviesDirectory
+        }
+        
+        switch method {
+        case .NSSearchPath:
+            print(NSSearchPathForDirectoriesInDomains(directory, .userDomainMask, true).first!)
+        case .FileManagerDotURLFor:
+            print(try! FileManager.default.url(for: directory, in: .userDomainMask, appropriateFor: nil, create: false).path)
+        case .FileManagerDotURLsFor:
+            print(FileManager.default.urls(for: directory, in: .userDomainMask).first!.path)
+        }
     }
+}
+#endif
+
+// -----
+
+var arguments = ProcessInfo.processInfo.arguments.dropFirst().makeIterator()
+
+guard let arg = arguments.next() else {
+    fatalError("The unit test must specify the correct number of flags and arguments.")
+}
+
+switch arg {
+case "--xdgcheck":
+    XDGCheck.run()
+    
+case "--getcwd":
+    print(FileManager.default.currentDirectoryPath)
+
+case "--echo-PWD":
+    print(ProcessInfo.processInfo.environment["PWD"] ?? "")
+    
+#if !DEPLOYMENT_RUNTIME_OBJC
+case "--nspathfor":
+    guard let methodString = arguments.next(),
+        let method = NSURLForPrintTest.Method(rawValue: methodString),
+        let identifierString = arguments.next(),
+        let identifier = NSURLForPrintTest.Identifier(rawValue: identifierString) else {
+        fatalError("Usage: --nspathfor <METHOD> <DIRECTORY NAME>")
+    }
+    
+    let test = NSURLForPrintTest(method: method, identifier: identifier)
+    test.run()
+#endif
+    
+default:
+    fatalError("These arguments are not recognized. Only run this from a unit test.")
 }
 

--- a/build.py
+++ b/build.py
@@ -30,7 +30,8 @@ elif Configuration.current.target.sdk == OSType.Win32 and Configuration.current.
 	swift_cflags += ['-DCYGWIN']
 
 if Configuration.current.build_mode == Configuration.Debug:
-        foundation.LDFLAGS += ' -lswiftSwiftOnoneSupport '
+    foundation.LDFLAGS += ' -lswiftSwiftOnoneSupport '
+    swift_cflags += ['-enable-testing']
 
 foundation.ASFLAGS = " ".join([
         '-DCF_CHARACTERSET_BITMAP=\\"CoreFoundation/CharacterSets/CFCharacterSetBitmaps.bitmap\\"',
@@ -367,6 +368,7 @@ swift_sources = CompileSwiftSources([
 	'Foundation/NSExpression.swift',
 	'Foundation/FileHandle.swift',
 	'Foundation/FileManager.swift',
+	'Foundation/FileManager_XDG.swift',
 	'Foundation/Formatter.swift',
 	'Foundation/NSGeometry.swift',
 	'Foundation/Host.swift',
@@ -488,6 +490,9 @@ swift_sources = CompileSwiftSources([
 	'Foundation/Codable.swift',
 	'Foundation/JSONEncoder.swift',
 ])
+
+if Configuration.current.build_mode == Configuration.Debug:
+    swift_sources.enable_testable_import = True
 
 swift_sources.add_dependency(headers)
 foundation.add_phase(swift_sources)

--- a/lib/phases.py
+++ b/lib/phases.py
@@ -348,6 +348,7 @@ class CompileSwiftSources(BuildPhase):
         BuildPhase.__init__(self, "CompileSwiftSources")
         if sources is not None:
             self._sources = sources
+        self.enable_testable_import = False
 
     @property
     def product(self):
@@ -396,11 +397,15 @@ class CompileSwiftSources(BuildPhase):
             partial_modules += compiled.relative() + ".~partial.swiftmodule "
             partial_docs += compiled.relative() + ".~partial.swiftdoc "
 
+        testable_import_flags = ""
+        if self.enable_testable_import:
+            testable_import_flags = "-enable-testing"
+
         generated += """
 build """ + self._module.relative() + ": MergeSwiftModule " + objects + """
     partials = """ + partial_modules + """
     module_name = """ + self.product.name + """
-    flags = -I""" + self.product.public_module_path.relative() + """ """ + TargetConditional.value(self.product.SWIFTCFLAGS) + """ -emit-module-doc-path """ + self._module.parent().path_by_appending(self.product.name).relative() + """.swiftdoc 
+    flags = """ + testable_import_flags + " -I" + self.product.public_module_path.relative() + """ """ + TargetConditional.value(self.product.SWIFTCFLAGS) + """ -emit-module-doc-path """ + self._module.parent().path_by_appending(self.product.name).relative() + """.swiftdoc 
 """
         return generated
 


### PR DESCRIPTION
Implement urls(for:…) as the primitive directory method:
 - In Darwin, match paths with the Objective-C implementation wherever possible.
 - On platforms that use FHS/XDG, implement reading user-dirs.* files to determine XDG directories;

This patch also enables the `@testable import` syntax in TestFoundation in the Debug configuration.