### PR TITLE
add a linker search path to account for library path changes to platforms without fat binaries

### DIFF
--- a/lib/script.py
+++ b/lib/script.py
@@ -135,7 +135,7 @@ TARGET_SWIFTEXE_FLAGS = -I${SDKROOT}/lib/swift/""" + Configuration.current.targe
 EXTRA_LD_FLAGS       = """ + Configuration.current.extra_ld_flags
 
         ld_flags += """
-TARGET_LDFLAGS       = --target=${TARGET} ${EXTRA_LD_FLAGS} -L${SDKROOT}/lib/swift/""" + Configuration.current.target.swift_sdk_name + """ """
+TARGET_LDFLAGS       = --target=${TARGET} ${EXTRA_LD_FLAGS} -L ${SDKROOT}/lib/swift/""" + Configuration.current.target.swift_sdk_name + """/${ARCH} -L${SDKROOT}/lib/swift/""" + Configuration.current.target.swift_sdk_name + """ """
         if Configuration.current.system_root is not None:
             ld_flags += "--sysroot=${SYSROOT}"
 


### PR DESCRIPTION
https://github.com/apple/swift/pull/14243 changes paths for libraries to `oldpath/arch/libxyz`. This path adds a search path to account for it.

Requires
https://github.com/apple/swift/pull/14243