### PR TITLE
Remove hasPrefix/Suffix as they are now on String for Linux 

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -1479,36 +1479,6 @@ extension String : _NSBridgeable, _CFBridgeable {
     internal var _cfObject: CFType { return _nsObject._cfObject }
 }
 
-#if !(os(OSX) || os(iOS))
-extension String {
-    public func hasPrefix(_ prefix: String) -> Bool {
-        if prefix.isEmpty {
-            return true
-        }
-
-        let cfstring = self._cfObject
-        let range = CFRangeMake(0, CFStringGetLength(cfstring))
-        let opts = CFStringCompareFlags(
-            kCFCompareAnchored | kCFCompareNonliteral)
-        return CFStringFindWithOptions(cfstring, prefix._cfObject,
-                                   range, opts, nil)
-    }
-    
-    public func hasSuffix(_ suffix: String) -> Bool {
-        if suffix.isEmpty {
-            return true
-        }
-
-        let cfstring = self._cfObject
-        let range = CFRangeMake(0, CFStringGetLength(cfstring))
-        let opts = CFStringCompareFlags(
-            kCFCompareAnchored | kCFCompareBackwards | kCFCompareNonliteral)
-        return CFStringFindWithOptions(cfstring, suffix._cfObject,
-                                   range, opts, nil)
-    }
-}
-#endif
-
 extension NSString : _StructTypeBridgeable {
     public typealias _StructType = String
     

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -1328,8 +1328,7 @@ let comparisonTests: [ComparisonTest] = [
 
     // U+1F1E7 REGIONAL INDICATOR SYMBOL LETTER B
     // \u{1F1E7}\u{1F1E7} Flag of Barbados
-    ComparisonTest("\u{1F1E7}", "\u{1F1E7}\u{1F1E7}",
-        expectedFailure: "https://bugs.swift.org/browse/SR-367"),
+    ComparisonTest("\u{1F1E7}", "\u{1F1E7}\u{1F1E7}"),
 
     // Test that Unicode collation is performed in deterministic mode.
     //
@@ -1344,8 +1343,7 @@ let comparisonTests: [ComparisonTest] = [
     //
     // U+0301 and U+0954 don't decompose in the canonical decomposition mapping.
     // U+0341 has a canonical decomposition mapping of U+0301.
-    ComparisonTest("\u{0301}", "\u{0341}",
-        expectedFailure: "https://bugs.swift.org/browse/SR-243"),
+    ComparisonTest("\u{0301}", "\u{0341}"),
     ComparisonTest("\u{0301}", "\u{0954}"),
     ComparisonTest("\u{0341}", "\u{0954}"),
 ]


### PR DESCRIPTION
Needs coordination with apple/swift#14390, which introduces the `String` versions.