### PR TITLE
Changes done to align NSURL.description with Darwin code

### DIFF
--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -255,7 +255,11 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     }
     
     open override var description: String {
-        return self.absoluteString
+        if self.relativeString != self.absoluteString {
+            return "\(self.relativeString) -- \(self.baseURL!)"
+        } else {
+            return self.absoluteString
+        }
     }
 
     deinit {

--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -519,6 +519,12 @@ class TestURL : XCTestCase {
    func test_description() {
         let url = URL(string: "http://amazon.in")!
         XCTAssertEqual(url.description, "http://amazon.in")
+        var urlComponents = URLComponents()
+        urlComponents.port = 8080
+        urlComponents.host = "amazon.in"
+        urlComponents.password = "abcd"
+        let relativeURL = urlComponents.url(relativeTo: url)
+        XCTAssertEqual(relativeURL?.description, "//:abcd@amazon.in:8080 -- http://amazon.in")
     }
 }
     


### PR DESCRIPTION
On Linux , the URL.description seems to be incomplete with respect to Darwin, when the URL has a component string associated with it .