### PR TITLE
NSDictionary, NSIndexSet: Fix withoutAcutallyEscaping usage

### DIFF
--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -483,7 +483,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         let lock = NSLock()
         
         getObjects(&objects, andKeys: &keys, count: count)
-        withoutActuallyEscaping(block) { (closure: @escaping (Any, Any, UnsafeMutablePointer<ObjCBool>) -> Void) -> (Int) -> Void in
+        withoutActuallyEscaping(block) { (closure: @escaping (Any, Any, UnsafeMutablePointer<ObjCBool>) -> Void) -> () in
             let iteration: (Int) -> Void = { (idx) in
                 lock.lock()
                 var stop = sharedStop

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -483,8 +483,8 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         let lock = NSLock()
         
         getObjects(&objects, andKeys: &keys, count: count)
-        let iteration: (Int) -> Void = withoutActuallyEscaping(block) { (closure: @escaping (Any, Any, UnsafeMutablePointer<ObjCBool>) -> Void) -> (Int) -> Void in
-            return { (idx) in
+        withoutActuallyEscaping(block) { (closure: @escaping (Any, Any, UnsafeMutablePointer<ObjCBool>) -> Void) -> (Int) -> Void in
+            let iteration: (Int) -> Void = { (idx) in
                 lock.lock()
                 var stop = sharedStop
                 lock.unlock()
@@ -499,13 +499,13 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
                     return
                 }
             }
-        }
-        
-        if opts.contains(.concurrent) {
-            DispatchQueue.concurrentPerform(iterations: count, execute: iteration)
-        } else {
-            for idx in 0..<count {
-                iteration(idx)
+
+            if opts.contains(.concurrent) {
+                DispatchQueue.concurrentPerform(iterations: count, execute: iteration)
+            } else {
+                for idx in 0..<count {
+                    iteration(idx)
+                }
             }
         }
     }

--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -390,7 +390,7 @@ open class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         let ranges = _ranges[startRangeIndex...endRangeIndex]
         let rangeSequence = (reverse ? AnyCollection(ranges.reversed()) : AnyCollection(ranges))
         withoutActuallyEscaping(block) { (closure: @escaping (P, UnsafeMutablePointer<ObjCBool>) -> R) -> () in
-            let iteration = { (rangeIdx) in
+            let iteration : (Int) -> Void = { (rangeIdx) in
                 lock.lock()
                 var stop = ObjCBool(sharedStop)
                 lock.unlock()

--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -389,7 +389,7 @@ open class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         let lock = NSLock()
         let ranges = _ranges[startRangeIndex...endRangeIndex]
         let rangeSequence = (reverse ? AnyCollection(ranges.reversed()) : AnyCollection(ranges))
-        withoutActuallyEscaping(block) { (closure: @escaping (P, UnsafeMutablePointer<ObjCBool>) -> R) -> (Int) -> Void in
+        withoutActuallyEscaping(block) { (closure: @escaping (P, UnsafeMutablePointer<ObjCBool>) -> R) -> () in
             let iteration = { (rangeIdx) in
                 lock.lock()
                 var stop = ObjCBool(sharedStop)

--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -389,8 +389,8 @@ open class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         let lock = NSLock()
         let ranges = _ranges[startRangeIndex...endRangeIndex]
         let rangeSequence = (reverse ? AnyCollection(ranges.reversed()) : AnyCollection(ranges))
-        let iteration = withoutActuallyEscaping(block) { (closure: @escaping (P, UnsafeMutablePointer<ObjCBool>) -> R) -> (Int) -> Void in
-            return { (rangeIdx) in
+        withoutActuallyEscaping(block) { (closure: @escaping (P, UnsafeMutablePointer<ObjCBool>) -> R) -> (Int) -> Void in
+            let iteration = { (rangeIdx) in
                 lock.lock()
                 var stop = ObjCBool(sharedStop)
                 lock.unlock()
@@ -431,13 +431,12 @@ open class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
                     }
                 }
             }
-        }
-        
-        if opts.contains(.concurrent) {
-            DispatchQueue.concurrentPerform(iterations: Int(rangeSequence.count), execute: iteration)
-        } else {
-            for idx in 0..<Int(rangeSequence.count) {
-                iteration(idx)
+            if opts.contains(.concurrent) {
+                DispatchQueue.concurrentPerform(iterations: Int(rangeSequence.count), execute: iteration)
+            } else {
+                for idx in 0..<Int(rangeSequence.count) {
+                    iteration(idx)
+                }
             }
         }
         


### PR DESCRIPTION
The block must not escape the withoutAcutallyEscaping closure parameter scope.

With https://github.com/apple/swift/pull/15046 such loose usages of withoutActuallyEscaping are no longer allowed. The ``block`` must not escape the scope of the withoutActuallyEscaping closure parameter.