### PR TITLE
Fix for NSKeyedArchiver.archiveRootObject api failure on Linux

### DIFF
--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -590,7 +590,7 @@ public func NSFullUserName() -> String {
 }
 
 internal func _NSCreateTemporaryFile(_ filePath: String) throws -> (Int32, String) {
-    let template = "." + filePath + ".tmp.XXXXXX"
+    let template = filePath + ".tmp.XXXXXX"
     let maxLength = Int(PATH_MAX) + 1
     var buf = [Int8](repeating: 0, count: maxLength)
     let _ = template._nsObject.getFileSystemRepresentation(&buf, maxLength: maxLength)

--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -107,6 +107,8 @@ class TestNSKeyedArchiver : XCTestCase {
             ("test_archive_uuid_bvref", test_archive_uuid_byref),
             ("test_archive_uuid_byvalue", test_archive_uuid_byvalue),
             ("test_archive_unhashable", test_archive_unhashable),
+            ("test_archiveRootObject_String", test_archiveRootObject_String),
+            ("test_archiveRootObject_URLRequest()", test_archiveRootObject_URLRequest),
         ]
     }
 
@@ -345,4 +347,29 @@ class TestNSKeyedArchiver : XCTestCase {
             XCTFail("test_archive_unhashable, de-serialization error \(error)")
         }
     }
+
+    func test_archiveRootObject_String() {
+        let filePath = NSTemporaryDirectory() + "testdir\(NSUUID().uuidString)"
+        let result = NSKeyedArchiver.archiveRootObject("Hello", toFile: filePath)
+        XCTAssertTrue(result)
+        do {
+            try FileManager.default.removeItem(atPath: filePath)
+        } catch {
+            XCTFail("Failed to clean up file")
+        }
+    }
+
+    func test_archiveRootObject_URLRequest() {
+        let filePath = NSTemporaryDirectory() + "testdir\(NSUUID().uuidString)"
+        let url = URL(string: "http://swift.org")!
+        let request = URLRequest(url: url)._bridgeToObjectiveC()
+        let result = NSKeyedArchiver.archiveRootObject(request, toFile: filePath)
+        XCTAssertTrue(result)
+        do {
+            try FileManager.default.removeItem(atPath: filePath)
+        } catch {
+            XCTFail("Failed to clean up file")
+        }
+    }
+
 }


### PR DESCRIPTION
Test case:
```
        let filePath = NSTemporaryDirectory() + "testdir\(NSUUID().uuidString)"
        let result = NSKeyedArchiver.archiveRootObject("Hello", toFile: filePath)
        print(result)
```

Expected Result:  `true`
Actual result on Linux: `false`
Actual result on Darwin: `true`


