### PR TITLE
Fix and reenable tests that depend on specific hash values

### DIFF
--- a/TestFoundation/TestNSCache.swift
+++ b/TestFoundation/TestNSCache.swift
@@ -20,7 +20,7 @@ class TestNSCache : XCTestCase {
     static var allTests: [(String, (TestNSCache) -> () throws -> Void)] {
         return [
             ("test_setWithUnmutableKeys", test_setWithUnmutableKeys),
-            // FIXME: https://bugs.swift.org/browse/SR-7161 ("test_setWithMutableKeys", test_setWithMutableKeys),
+            ("test_setWithMutableKeys", test_setWithMutableKeys),
             ("test_costLimit", test_costLimit),
             ("test_countLimit", test_countLimit),
             ("test_hashableKey", test_hashableKey),
@@ -72,9 +72,21 @@ class TestNSCache : XCTestCase {
         XCTAssertEqual(cache.object(forKey: key2), value, "should be equal to \(value) when using second key")
         
         key1.append("1")
-        
-        XCTAssertEqual(cache.object(forKey: key1), value, "should be equal to \(value) when using first key")
+
+        // Mutating the key probably changes the hash value, which often makes
+        // the value inaccessible by sorting the key into a different bucket.
+        // On the other hand, the bucket may remain the same by coincidence.
+        // Therefore, `cache.object(forKey: key1)` may or may not be nil at 
+        // this point -- no useful check can be made.
+        // The object can definitely not be reached via the original key,
+        // though.
         XCTAssertNil(cache.object(forKey: key2), "should be nil")
+
+		// Restoring key1 to the original string will make the value 
+		// accessible again.
+        key1.setString("key")
+        XCTAssertEqual(cache.object(forKey: key1), value, "should be equal to \(value) when using first key")
+        XCTAssertEqual(cache.object(forKey: key2), value, "should be equal to \(value) when using second key")        
     }
     
     func test_costLimit() {

--- a/TestFoundation/TestNSDictionary.swift
+++ b/TestFoundation/TestNSDictionary.swift
@@ -25,8 +25,7 @@ class TestNSDictionary : XCTestCase {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_ArrayConstruction", test_ArrayConstruction),
-            // XFAIL test https://bugs.swift.org/browse/SR-7166
-            //("test_description", test_description),
+            ("test_description", test_description),
             ("test_enumeration", test_enumeration),
             ("test_equality", test_equality),
             ("test_copying", test_copying),
@@ -47,7 +46,8 @@ class TestNSDictionary : XCTestCase {
 
     func test_description() {
         let d1: NSDictionary = [ "foo": "bar", "baz": "qux"]
-        XCTAssertEqual(d1.description, "{\n    baz = qux;\n    foo = bar;\n}")
+        XCTAssertTrue(d1.description == "{\n    baz = qux;\n    foo = bar;\n}" ||
+                      d1.description == "{\n    foo = bar;\n    baz = qux;\n}")
         let d2: NSDictionary = ["1" : ["1" : ["1" : "1"]]]
         XCTAssertEqual(d2.description, "{\n    1 =     {\n        1 =         {\n            1 = 1;\n        };\n    };\n}")
     }


### PR DESCRIPTION
Hash values are now randomly seeded, and the hash algorithm may change between any two releases of the standard library — code should not depend on specific hash values or Set/Dictionary orderings.