### PR TITLE
 Fixed SR-5971

### DIFF
--- a/CoreFoundation/String.subproj/CFCharacterSet.c
+++ b/CoreFoundation/String.subproj/CFCharacterSet.c
@@ -1401,6 +1401,7 @@ Boolean _CFCharacterSetInitWithCharactersInString(CFMutableCharacterSetRef cset,
     
     length = CFStringGetLength(theString);
     if (length < __kCFStringCharSetMax) {
+        bool csetIsReady = true;
         if (!__CFCSetGenericInit(cset, __kCFCharSetClassString, false)) return false;
         __CFCSetPutStringBuffer(cset, (UniChar *)CFAllocatorAllocate(kCFAllocatorSystemDefault, __kCFStringCharSetMax * sizeof(UniChar), 0));
         __CFCSetPutStringLength(cset, length);
@@ -1417,15 +1418,14 @@ Boolean _CFCharacterSetInitWithCharactersInString(CFMutableCharacterSetRef cset,
             if ((*characters < 0xDC00UL) && (*(charactersLimit - 1) > 0xDBFFUL)) { // might have surrogate chars
                 while (characters < charactersLimit) {
                     if (CFStringIsSurrogateHighCharacter(*characters) || CFStringIsSurrogateLowCharacter(*characters)) {
-                        CFRelease(cset);
-                        cset = NULL;
+                        csetIsReady = false;
                         break;
                     }
                     ++characters;
                 }
             }
         }
-        if (NULL != cset) return cset;
+        if (csetIsReady) return true;
     }
     
     if (!_CFCharacterSetInitMutable(cset)) return false;

--- a/TestFoundation/TestCharacterSet.swift
+++ b/TestFoundation/TestCharacterSet.swift
@@ -81,6 +81,7 @@ class TestCharacterSet : XCTestCase {
             ("test_SymmetricDifference", test_SymmetricDifference),
             ("test_formUnion", test_formUnion),
             ("test_union", test_union),
+            ("test_SR5971", test_SR5971),
         ]
     }
     
@@ -364,6 +365,12 @@ class TestCharacterSet : XCTestCase {
         let charset = CharacterSet(charactersIn: "a")
         let union = charset.union(CharacterSet(charactersIn: "A"))
         XCTAssertTrue(union.contains("A" as UnicodeScalar))
+    }
+
+    func test_SR5971() {
+        let problematicString = "\u{10000}"
+        let charset = CharacterSet(charactersIn:problematicString) // this should not crash
+        XCTAssertTrue(charset.contains("\u{10000}"))
     }
     
 }


### PR DESCRIPTION
CFCharacterSetInitWithCharactersInString crashed on strings with surrogate characters. Now _CFCharacterSetInitWithCharactersInString is semantically equivalent to CFCharacterSetInitWithCharactersInString  from core foundation.