### PR TITLE
Calendar fixes.

### DIFF
--- a/Foundation/Calendar.swift
+++ b/Foundation/Calendar.swift
@@ -1156,7 +1156,7 @@ extension Calendar : CustomDebugStringConvertible, CustomStringConvertible, Cust
             (label: "kind", value: _kindDescription),
             (label: "locale", value: locale as Any),
             (label: "timeZone", value: timeZone),
-            (label: "firstWeekDay", value: firstWeekday),
+            (label: "firstWeekday", value: firstWeekday),
             (label: "minimumDaysInFirstWeek", value: minimumDaysInFirstWeek)
         ]
         return Mirror(self, children: children, displayStyle: Mirror.DisplayStyle.struct)

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -298,7 +298,7 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     private func _symbol(_ key: CFString) -> String {
         let dateFormatter = CFDateFormatterCreate(kCFAllocatorSystemDefault, locale?._bridgeToObjectiveC()._cfObject, kCFDateFormatterNoStyle, kCFDateFormatterNoStyle)
         CFDateFormatterSetProperty(dateFormatter, kCFDateFormatterCalendarKey, self._cfObject)
-        return (CFDateFormatterCopyProperty(dateFormatter, key) as! CFString)._swiftObject
+        return (CFDateFormatterCopyProperty(dateFormatter, key) as! NSString)._swiftObject
     }
     
     open var eraSymbols: [String] {

--- a/TestFoundation/TestCalendar.swift
+++ b/TestFoundation/TestCalendar.swift
@@ -28,9 +28,9 @@ class TestCalendar: XCTestCase {
             ("test_addingDates", test_addingDates),
             ("test_datesNotOnWeekend", test_datesNotOnWeekend),
             ("test_datesOnWeekend", test_datesOnWeekend),
-            ("test_customMirror", test_customMirror)
-            // Disabled because this fails on linux https://bugs.swift.org/browse/SR-320
-            // ("test_currentCalendarRRstability", test_currentCalendarRRstability),
+            ("test_customMirror", test_customMirror),
+            ("test_ampmSymbols", test_ampmSymbols),
+            ("test_currentCalendarRRstability", test_currentCalendarRRstability),
         ]
     }
     
@@ -125,7 +125,13 @@ class TestCalendar: XCTestCase {
         XCTAssertEqual(components.isLeapMonth, true)
     }
 
-    func test_currentRRstability() {
+    func test_ampmSymbols() {
+        let calendar = Calendar(identifier: .gregorian)
+        XCTAssertEqual(calendar.amSymbol, "AM")
+        XCTAssertEqual(calendar.pmSymbol, "PM")
+    }
+
+    func test_currentCalendarRRstability() {
         var AMSymbols = [String]()
         for _ in 1...10 {
             let cal = Calendar.current
@@ -191,7 +197,7 @@ class TestCalendar: XCTestCase {
         XCTAssertEqual(calendar.identifier, calendarMirror.descendant("identifier") as? Calendar.Identifier)
         XCTAssertEqual(calendar.locale, calendarMirror.descendant("locale") as? Locale)
         XCTAssertEqual(calendar.timeZone, calendarMirror.descendant("timeZone") as? TimeZone)
-        XCTAssertEqual(calendar.firstWeekday, calendarMirror.descendant("firstWeekDay") as? Int)
+        XCTAssertEqual(calendar.firstWeekday, calendarMirror.descendant("firstWeekday") as? Int)
         XCTAssertEqual(calendar.minimumDaysInFirstWeek, calendarMirror.descendant("minimumDaysInFirstWeek") as? Int)
     }
 }


### PR DESCRIPTION
- Fix Calendar.customMirror() to match behaviour on Darwin native
  Foundation (10.13.3) for firstWeekDay.

- Update NSCalendar._symbol() to cast the CFDateFormatterCopyProperty()
  to a NSString not a CFString to fix NSCalendar.{amSymbol,pmSymbol}.
  This also allows un-XFAILing test_currentCalendarRRstability() which
  was failing on Linux because of this cast, not a refcounting issue
  as mentioned in SR-320.