### PR TITLE
[string] Wean off of non-String-API.

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -273,7 +273,7 @@ open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSC
     }
     
     public init(characters: UnsafePointer<unichar>, length: Int) {
-        _storage = String.init(decoding: UnsafeBufferPointer(start: characters, count: length), as: UTF16.self)
+        _storage = String(decoding: UnsafeBufferPointer(start: characters, count: length), as: UTF16.self)
     }
     
     public required convenience init(unicodeScalarLiteral value: StaticString) {

--- a/Foundation/String.swift
+++ b/Foundation/String.swift
@@ -36,21 +36,21 @@ extension String : _ObjectTypeBridgeable {
                 let buffer = UnsafeMutablePointer<UniChar>.allocate(capacity: length)
                 CFStringGetCharacters(cf, CFRangeMake(0, length), buffer)
                 
-                let str = String._fromCodeUnitSequence(UTF16.self, input: UnsafeBufferPointer(start: buffer, count: length))
+                let str = String(decoding: UnsafeBufferPointer(start: buffer, count: length), as: UTF16.self)
                 buffer.deinitialize(count: length)
                 buffer.deallocate()
                 result = str
             }
         } else if type(of: source) == _NSCFConstantString.self {
             let conststr = unsafeDowncast(source, to: _NSCFConstantString.self)
-            let str = String._fromCodeUnitSequence(UTF8.self, input: UnsafeBufferPointer(start: conststr._ptr, count: Int(conststr._length)))
+            let str = String(decoding: UnsafeBufferPointer(start: conststr._ptr, count: Int(conststr._length)), as: UTF8.self)
             result = str
         } else {
             let len = source.length
             var characters = [unichar](repeating: 0, count: len)
             result = characters.withUnsafeMutableBufferPointer() { (buffer: inout UnsafeMutableBufferPointer<unichar>) -> String? in
                 source.getCharacters(buffer.baseAddress!, range: NSRange(location: 0, length: len))
-                return String._fromCodeUnitSequence(UTF16.self, input: buffer)
+                return String(decoding: buffer, as: UTF16.self)
             }
         }
         return result != nil

--- a/Foundation/XMLParser.swift
+++ b/Foundation/XMLParser.swift
@@ -296,8 +296,7 @@ internal func _NSXMLParserStartElementNs(_ ctx: _CFXMLInterface, localname: Unsa
             if numBytesWithoutTerminator > 0 {
                 let buffer = UnsafeBufferPointer(start: value,
                                                  count: numBytesWithoutTerminator)
-                attributeValue = String._fromCodeUnitSequence(UTF8.self,
-                                                              input: buffer)!
+                attributeValue = String(decoding: buffer, as: UTF8.self)
             }
             attrDict[attributeQName] = attributeValue
         }
@@ -352,8 +351,8 @@ internal func _NSXMLParserCharacters(_ ctx: _CFXMLInterface, ch: UnsafePointer<U
         _CFXMLInterfaceResetRecursiveState(context)
     } else {
         if let delegate = parser.delegate {
-            let str = String._fromCodeUnitSequence(UTF8.self, input: UnsafeBufferPointer(start: ch, count: Int(len)))
-            delegate.parser(parser, foundCharacters: str!)
+            let str = String(decoding: UnsafeBufferPointer(start: ch, count: Int(len)), as: UTF8.self)
+            delegate.parser(parser, foundCharacters: str)
         }
     }
 }


### PR DESCRIPTION
String._fromCodeUnits is about to disappear; use already existing
String.init calls instead.