### PR TITLE
FileManager fixes

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -27,6 +27,7 @@
 #include <CoreFoundation/ForFoundationOnly.h>
 #include <fts.h>
 #include <pthread.h>
+#include <dirent.h>
 
 #if __has_include(<execinfo.h>)
 #include <execinfo.h>
@@ -399,6 +400,13 @@ static inline _Bool _withStackOrHeapBuffer(size_t amount, void (__attribute__((n
     return true;
 }
 
+static inline int _direntNameLength(struct dirent *entry) {
+#ifdef _D_EXACT_NAMLEN  // defined on Linux
+    return _D_EXACT_NAMLEN(entry);
+#else
+    return entry->d_namlen;
+#endif
+}
 
 _CF_EXPORT_SCOPE_END
 

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -329,7 +329,7 @@ class TestFileManager : XCTestCase {
         } catch _ {
             XCTFail()
         }
-        
+
         if let e = FileManager.default.enumerator(at: URL(fileURLWithPath: path), includingPropertiesForKeys: nil, options: [], errorHandler: nil) {
             var foundItems = [String:Int]()
             while let item = e.nextObject() as? URL {
@@ -442,8 +442,8 @@ class TestFileManager : XCTestCase {
         }
         
         do {
-            let _ = try fm.contentsOfDirectory(atPath: "")
-            
+            // Check a bad path fails
+            let _ = try fm.contentsOfDirectory(atPath: "/...")
             XCTFail()
         }
         catch _ {
@@ -492,8 +492,8 @@ class TestFileManager : XCTestCase {
         }
         
         do {
-            let _ = try fm.subpathsOfDirectory(atPath: "")
-            
+            // Check a bad path fails
+            let _ = try fm.subpathsOfDirectory(atPath: "/...")
             XCTFail()
         }
         catch _ {


### PR DESCRIPTION
- Use a common subfunction to read directory contents in
  contentsOfDirectory(atPath:) and subpathsOfDirectory(atPath:).

- Use readdir_r() instead of readdir().

- Call fileSystemRepresentation(withPath:) on the requested directory
  to match behaviour on Darwin.

- Replace the test case of a bad directory using "" with "/..." which
  now fails the precondition (to match Darwin).