### PR TITLE
[string] Wean off of no-longer-supported String non-API

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -297,7 +297,7 @@ open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSC
     
     internal func _fastCStringContents(_ nullTerminated: Bool) -> UnsafePointer<Int8>? {
         if type(of: self) == NSString.self || type(of: self) == NSMutableString.self {
-            if _storage._core.isASCII {
+            if _storage._guts._isContiguousASCII {
                 return unsafeBitCast(_storage._core.startASCII, to: UnsafePointer<Int8>.self)
             }
         }
@@ -306,7 +306,7 @@ open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSC
     
     internal var _fastContents: UnsafePointer<UniChar>? {
         if type(of: self) == NSString.self || type(of: self) == NSMutableString.self {
-            if !_storage._core.isASCII {
+            if _storage._guts._isContiguousUTF16 {
                 return UnsafePointer<UniChar>(_storage._core.startUTF16)
             }
         }
@@ -315,7 +315,7 @@ open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSC
     
     internal var _encodingCantBeStoredInEightBitCFString: Bool {
         if type(of: self) == NSString.self || type(of: self) == NSMutableString.self {
-            return !_storage._core.isASCII
+            return !_storage._guts._isContiguousASCII
         }
         return false
     }
@@ -858,7 +858,7 @@ extension NSString {
     public func getCString(_ buffer: UnsafeMutablePointer<Int8>, maxLength maxBufferCount: Int, encoding: UInt) -> Bool {
         var used = 0
         if type(of: self) == NSString.self || type(of: self) == NSMutableString.self {
-            if _storage._core.isASCII {
+            if _storage._guts._isContiguousASCII {
                 used = min(self.length, maxBufferCount - 1)
                 _storage._core.startASCII.withMemoryRebound(to: Int8.self,
                                                             capacity: used) {


### PR DESCRIPTION
String's _core disappeared, but we kept around a mock-up of it as a
faux-SPI to avoid breaking Foundation. However, it does not fully
model String, and the illusion is broken from small string support.