### PR TITLE
SR-7196: Fix for Redirects crash in HTTPURLProtocol

### DIFF
--- a/Foundation/URLSession/http/HTTPURLProtocol.swift
+++ b/Foundation/URLSession/http/HTTPURLProtocol.swift
@@ -402,7 +402,13 @@ internal extension _HTTPURLProtocol {
         var components = URLComponents()
         components.scheme = scheme
         components.host = host
-        components.path = targetURL.relativeString
+        //The path must either begin with "/" or be an empty string.
+        if targetURL.relativeString.first != "/" {
+            components.path = "/" + targetURL.relativeString
+        } else {
+            components.path = targetURL.relativeString
+        }
+
         guard let urlString = components.string else { fatalError("Invalid URL") }
         request.url = URL(string: urlString)
         let timeSpent = easyHandle.getTimeoutIntervalSpent()

--- a/TestFoundation/HTTPServer.swift
+++ b/TestFoundation/HTTPServer.swift
@@ -337,6 +337,8 @@ public class TestURLSessionServer {
                                      "Italy": "Rome",
                                      "USA": "Washington, D.C.",
                                      "UnitedStates": "USA",
+                                     "UnitedKingdom": "UK",
+                                     "UK": "London",
                                      "country.txt": "A country is a region that is identified as a distinct national entity in political geography"]
     let httpServer: _HTTPServer
     let startDelay: TimeInterval?
@@ -432,6 +434,13 @@ public class TestURLSessionServer {
             return _HTTPResponse(response: .OK, body: dtd)
         }
 
+        if uri == "/UnitedKingdom" {
+            let value = capitals[String(uri.dropFirst())]!
+            let text = request.getCommaSeparatedHeaders()
+            //Response header with only path to the location to redirect.
+            let httpResponse = _HTTPResponse(response: .REDIRECT, headers: "Location: \(value)", body: text)
+            return httpResponse
+        }
         return _HTTPResponse(response: .OK, body: capitals[String(uri.dropFirst())]!)
     }
 

--- a/TestFoundation/TestURLSession.swift
+++ b/TestFoundation/TestURLSession.swift
@@ -35,7 +35,8 @@ class TestURLSession : LoopbackServerTest {
             ("test_verifyRequestHeaders", test_verifyRequestHeaders),
             ("test_verifyHttpAdditionalHeaders", test_verifyHttpAdditionalHeaders),
             ("test_timeoutInterval", test_timeoutInterval),
-            ("test_httpRedirection", test_httpRedirection),
+            ("test_httpRedirectionWithCompleteRelativePath", test_httpRedirectionWithCompleteRelativePath),
+            //("test_httpRedirectionWithInCompleteRelativePath", test_httpRedirectionWithInCompleteRelativePath), /* temporarily disabled. Needs HTTPServer rework */
             //("test_httpRedirectionTimeout", test_httpRedirectionTimeout), /* temporarily disabled (https://bugs.swift.org/browse/SR-5751) */
             ("test_http0_9SimpleResponses", test_http0_9SimpleResponses),
             ("test_outOfRangeButCorrectlyFormattedHTTPCode", test_outOfRangeButCorrectlyFormattedHTTPCode),
@@ -325,8 +326,16 @@ class TestURLSession : LoopbackServerTest {
         waitForExpectations(timeout: 30)
     }
     
-    func test_httpRedirection() {
+    func test_httpRedirectionWithCompleteRelativePath() {
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/UnitedStates"
+        let url = URL(string: urlString)!
+        let d = HTTPRedirectionDataTask(with: expectation(description: "GET \(urlString): with HTTP redirection"))
+        d.run(with: url)
+        waitForExpectations(timeout: 12)
+    }
+
+    func test_httpRedirectionWithInCompleteRelativePath() {
+        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/UnitedKingdom"
         let url = URL(string: urlString)!
         let d = HTTPRedirectionDataTask(with: expectation(description: "GET \(urlString): with HTTP redirection"))
         d.run(with: url)


### PR DESCRIPTION
URLComponents expects relative string to either begin with "/" or to be an empty string.