### PR TITLE
[DarwinCompatibility] Minor fixes for DarwinCompatibility tests

### DIFF
--- a/DarwinCompatibilityTests.xcodeproj/project.pbxproj
+++ b/DarwinCompatibilityTests.xcodeproj/project.pbxproj
@@ -702,7 +702,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_SWIFT_FLAGS = "";
 				"OTHER_SWIFT_FLAGS[arch=*]" = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -717,7 +717,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;

--- a/DarwinCompatibilityTests/DarwinShims.swift
+++ b/DarwinCompatibilityTests/DarwinShims.swift
@@ -50,7 +50,7 @@ extension Thread {
 extension Scanner {
     public func scanString(_ searchString: String) -> String? {
         var result: NSString? = nil
-        if scanString(string, into: &result), let str = result {
+        if scanString(searchString, into: &result), let str = result {
             return str as String
         }
         return nil

--- a/TestFoundation/TestBundle.swift
+++ b/TestFoundation/TestBundle.swift
@@ -31,6 +31,11 @@ internal func testBundle() -> Bundle {
     #endif
 }
 
+internal func testBundleName() -> String {
+    // Either 'TestFoundation' or 'DarwinCompatibilityTests'
+    return testBundle().infoDictionary!["CFBundleName"] as! String
+}
+
 class BundlePlayground {
     enum Layout {
         case flat

--- a/TestFoundation/TestCodable.swift
+++ b/TestFoundation/TestCodable.swift
@@ -561,7 +561,6 @@ class TestCodable : XCTestCase {
     ]
 
     func test_URLComponents_JSON() {
-#if !DARWIN_COMPATIBILITY_TESTS // crashes on native Darwin
         for (components) in urlComponentsValues {
             do {
                 try expectRoundTripEqualityThroughJSON(for: components)
@@ -569,7 +568,6 @@ class TestCodable : XCTestCase {
                 XCTFail("\(error)")
             }
         }
-#endif
     }
 }
 

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -155,7 +155,10 @@ class TestFileManager : XCTestCase {
         XCTAssertEqual(UInt8(bitPattern: result[0]), 0xE2)
         XCTAssertEqual(UInt8(bitPattern: result[1]), 0x98)
         XCTAssertEqual(UInt8(bitPattern: result[2]), 0x83)
+
+#if !DARWIN_COMPATIBILITY_TESTS // auto-released by Darwin's Foundation
         result.deallocate()
+#endif
     }
     
     func test_fileAttributes() {

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -4110,7 +4110,6 @@ extension TestNSData {
     }
 
     func test_validateMutation_slice_mutableBacking_withUnsafeMutableBytes_lengthLessThanLowerBound() {
-#if !DARWIN_COMPATIBILITY_TESTS // Crashes on native Darwin
         var base = Data(referencing: NSData(bytes: "hello world", length: 11))
         base.append(contentsOf: [1, 2, 3, 4, 5, 6])
         var data = base[4..<6]
@@ -4118,7 +4117,6 @@ extension TestNSData {
             ptr.advanced(by: 1).pointee = 0xFF
         }
         XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
-#endif
     }
 
     func test_validateMutation_slice_customBacking_withUnsafeMutableBytes_lengthLessThanLowerBound() {
@@ -4130,7 +4128,6 @@ extension TestNSData {
     }
 
     func test_validateMutation_slice_customMutableBacking_withUnsafeMutableBytes_lengthLessThanLowerBound() {
-#if !DARWIN_COMPATIBILITY_TESTS // Crashes on native Darwin
         var base = Data(referencing: AllOnesData(length: 1))
         base.count = 10
         var data = base[4..<6]
@@ -4138,7 +4135,6 @@ extension TestNSData {
             ptr.advanced(by: 1).pointee = 0xFF
         }
         XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
-#endif
     }
 }
 

--- a/TestFoundation/TestNSError.swift
+++ b/TestFoundation/TestNSError.swift
@@ -50,7 +50,8 @@ class TestNSError : XCTestCase {
     }
 
     func test_CustomNSError_domain() {
-        XCTAssertEqual(SwiftCustomNSError.errorDomain, "TestFoundation.SwiftCustomNSError")
+        let name = testBundleName()
+        XCTAssertEqual(SwiftCustomNSError.errorDomain, "\(name).SwiftCustomNSError")
     }
 
     func test_CustomNSError_userInfo() {

--- a/TestFoundation/TestObjCRuntime.swift
+++ b/TestFoundation/TestObjCRuntime.swift
@@ -32,8 +32,9 @@ class TestObjCRuntime: XCTestCase {
     }
 
     func testStringFromClass() {
+        let name = testBundleName()
         XCTAssertEqual(NSStringFromClass(NSObject.self), "NSObject")
-        XCTAssertEqual(NSStringFromClass(SwiftClass.self), "TestFoundation.SwiftClass")
+        XCTAssertEqual(NSStringFromClass(SwiftClass.self), "\(name).SwiftClass")
 #if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
         XCTAssertEqual(NSStringFromClass(XCTestCase.self), "XCTest.XCTestCase");
 #else
@@ -42,9 +43,10 @@ class TestObjCRuntime: XCTestCase {
     }
 
     func testClassFromString() {
+        let name = testBundleName()
         XCTAssertNotNil(NSClassFromString("NSObject"))
-        XCTAssertNotNil(NSClassFromString("TestFoundation.SwiftClass"))
-        XCTAssertNil(NSClassFromString("TestFoundation.SwiftClass.InnerClass"))
+        XCTAssertNotNil(NSClassFromString("\(name).SwiftClass"))
+        XCTAssertNil(NSClassFromString("\(name).SwiftClass.InnerClass"))
         XCTAssertNil(NSClassFromString("SwiftClass"))
         XCTAssertNil(NSClassFromString("MadeUpClassName"))
         XCTAssertNil(NSClassFromString("SwiftStruct"));

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -46,10 +46,14 @@ class TestProcess : XCTestCase {
         let process = Process()
         
         let executablePath = "/bin/bash"
-        process.executableURL = URL(fileURLWithPath: executablePath)
-        
+        if #available(OSX 10.13, *) {
+            process.executableURL = URL(fileURLWithPath: executablePath)
+        } else {
+            // Fallback on earlier versions
+            process.launchPath = executablePath
+        }
         XCTAssertEqual(executablePath, process.launchPath)
-        
+
         process.arguments = ["-c", "exit 0"]
         process.launch()
         process.waitUntilExit()

--- a/TestFoundation/TestProcessInfo.swift
+++ b/TestFoundation/TestProcessInfo.swift
@@ -41,8 +41,12 @@ class TestProcessInfo : XCTestCase {
         // Assert that the original process name is "TestFoundation". This test
         // will fail if the test target ever gets renamed, so maybe it should
         // just test that the initial name is not empty or something?
-        let processInfo = ProcessInfo.processInfo
+#if DARWIN_COMPATIBILITY_TESTS
+        let targetName = "xctest"
+#else
         let targetName = "TestFoundation"
+#endif
+        let processInfo = ProcessInfo.processInfo
         let originalProcessName = processInfo.processName
         XCTAssertEqual(originalProcessName, targetName, "\"\(originalProcessName)\" not equal to \"TestFoundation\"")
         

--- a/TestFoundation/TestUserDefaults.swift
+++ b/TestFoundation/TestUserDefaults.swift
@@ -180,14 +180,12 @@ class TestUserDefaults : XCTestCase {
 	}
 	
 	func test_setValue_String() {
-#if !DARWIN_COMPATIBILITY_TESTS  // Works if run on its own, hangs if all tests in class are run
 		let defaults = UserDefaults.standard
 		
 		// Register a String value. UserDefaults.string(forKey:) is supposed to return the String
 		defaults.set("hello", forKey: "key1")
 		
 		XCTAssertEqual(defaults.string(forKey: "key1"), "hello")
-#endif
 	}
 
 	func test_setValue_NSURL() {
@@ -200,14 +198,12 @@ class TestUserDefaults : XCTestCase {
 	}
 
 	func test_setValue_URL() {
-#if !DARWIN_COMPATIBILITY_TESTS  // Works if run on its own, hangs if all tests in class are run
 		let defaults = UserDefaults.standard
 		
 		// Set a URL value. UserDefaults.url(forKey:) is supposed to return the URL
 		defaults.set(URL(fileURLWithPath: "/hello/world"), forKey: "key1")
 		
 		XCTAssertEqual(defaults.url(forKey: "key1"), URL(fileURLWithPath: "/hello/world"))
-#endif
 	}
 
 	func test_setValue_NSData() {


### PR DESCRIPTION
- un-XFAIL some Darwin tests that run on 10.13.3

- Process.executableURL only available on 10.13

- Dont deallocate an autoreleasing pointer on Darwin.

- Add TestBundle.testBundleName() to handle 'TestFoundation' v
  'DarwinCompatibiltyTests' naming.