### PR TITLE
Display absolute path for Foundation lib dir during manual testing.

### DIFF
--- a/build.py
+++ b/build.py
@@ -539,7 +539,7 @@ foundation.add_phase(plutil)
 
 script.add_product(foundation)
 
-LIBS_DIRS = ""
+LIBS_DIRS = Configuration.current.build_directory.absolute()+"/Foundation/:"
 if "XCTEST_BUILD_DIR" in Configuration.current.variables:
     LIBS_DIRS += "${XCTEST_BUILD_DIR}:"
 if "LIBDISPATCH_BUILD_DIR" in Configuration.current.variables:
@@ -566,7 +566,7 @@ build install: phony | ${BUILD_DIR}/.install
 """
 extra_script += """
 rule RunTestFoundation
-    command = echo "**** RUNNING TESTS ****\\nexecute:\\nLD_LIBRARY_PATH=${BUILD_DIR}/Foundation/:${LIBS_DIRS} ${BUILD_DIR}/TestFoundation/TestFoundation\\n**** DEBUGGING TESTS ****\\nexecute:\\nLD_LIBRARY_PATH=${BUILD_DIR}/Foundation/:${LIBS_DIRS} ${BUILD_DIR}/../lldb-${OS}-${ARCH}/bin/lldb ${BUILD_DIR}/TestFoundation/TestFoundation\\n"
+    command = echo "**** RUNNING TESTS ****\\nexecute:\\nLD_LIBRARY_PATH=${LIBS_DIRS} ${BUILD_DIR}/TestFoundation/TestFoundation\\n**** DEBUGGING TESTS ****\\nexecute:\\nLD_LIBRARY_PATH=${LIBS_DIRS} ${BUILD_DIR}/../lldb-${OS}-${ARCH}/bin/lldb ${BUILD_DIR}/TestFoundation/TestFoundation\\n"
     description = Building Tests
 
 build ${BUILD_DIR}/.test: RunTestFoundation | TestFoundation


### PR DESCRIPTION
- This path is shown when 'ninja test' is run.

- The LD_LIBRARY_PATH passed to TestFoundation via manual testing is
  inherited by xdgTestHelper. If the path is relative and the
  current directory has been changed then libraries will not be
  found. This is the case if compiled with debug and libFoundation
  is linked to libswiftSwiftOnone.