### PR TITLE
Deprecate the `CustomPlaygroundQuickLookable` conformances

### DIFF
--- a/Foundation/Date.swift
+++ b/Foundation/Date.swift
@@ -261,7 +261,8 @@ extension Date : CustomPlaygroundQuickLookable {
         df.timeStyle = .short
         return df.string(from: self)
     }
-    
+
+    @available(*, deprecated, message: "Date.customPlaygroundQuickLook will be removed in a future Swift version") 
     public var customPlaygroundQuickLook: PlaygroundQuickLook {
         return .text(summary)
     }

--- a/Foundation/NSRange.swift
+++ b/Foundation/NSRange.swift
@@ -310,6 +310,7 @@ extension NSRange : CustomReflectable {
 }
 
 extension NSRange : CustomPlaygroundQuickLookable {
+    @available(*, deprecated, message: "NSRange.customPlaygroundQuickLook will be removed in a future Swift version")
     public var customPlaygroundQuickLook: PlaygroundQuickLook {
         return .range(Int64(location), Int64(length))
     }

--- a/Foundation/URL.swift
+++ b/Foundation/URL.swift
@@ -990,6 +990,7 @@ extension URL : CustomStringConvertible, CustomDebugStringConvertible {
 }
 
 extension URL : CustomPlaygroundQuickLookable {
+    @available(*, deprecated, message: "URL.customPlaygroundQuickLook will be removed in a future Swift version")
     public var customPlaygroundQuickLook: PlaygroundQuickLook {
         return .url(absoluteString)
     }


### PR DESCRIPTION
https://github.com/apple/swift/commit/a2aacd73ddfed43e01f9b30ed94d3555b5f7ce45#diff-163048a282fa0e0a7dd7735e61c7d64e deprecates customPlaygroundQuickLook on various Foundation types.

These deprecations should be carried across to SCLF too.