### PR TITLE
SR-7154: Make swiftpm tests work when building with --debug-foundation

### DIFF
--- a/lib/script.py
+++ b/lib/script.py
@@ -142,6 +142,9 @@ TARGET_LDFLAGS       = --target=${TARGET} ${EXTRA_LD_FLAGS} -L ${SDKROOT}/lib/sw
         if Configuration.current.bootstrap_directory is not None:
             ld_flags += """ -L${TARGET_BOOTSTRAP_DIR}/usr/lib"""
 
+        if Configuration.current.build_mode == Configuration.Debug:
+            ld_flags += """  -rpath ${SDKROOT}/lib/swift/""" + Configuration.current.target.swift_sdk_name + """ """
+
         if Configuration.current.linker is not None:
             ld_flags += " -fuse-ld=" + Configuration.current.linker
 


### PR DESCRIPTION
- If building in debug mode, add an RPATH to the build lib dir of
  swift so that libFoundation.so can find libswiftSwiftOnone.so,
  required when using -Onone.

- See discussion in https://github.com/apple/swift-package-manager/pull/1544