### PR TITLE
SR-7112: Fixed access to memory out of range

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -294,6 +294,10 @@ open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSC
     }
     
     internal func _fastCStringContents(_ nullTerminated: Bool) -> UnsafePointer<Int8>? {
+        guard !nullTerminated else {
+            // There is no way to fastly and safely retrieve a pointer to a null-terminated string from a String of Swift.
+            return nil
+        }
         if type(of: self) == NSString.self || type(of: self) == NSMutableString.self {
             if _storage._guts._isContiguousASCII {
                 return unsafeBitCast(_storage._core.startASCII, to: UnsafePointer<Int8>.self)


### PR DESCRIPTION
Fixed the code accessing outside the range of the character string.
When running the test in Xcode, Guard Malloc (libgmalloc) detected it and caused a runtime error.