### PR TITLE
Fix nsdata fails to access contents of url

### DIFF
--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -218,7 +218,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
             guard let data = resData else {
                 throw resError!
             }
-            _init(bytes: UnsafeMutableRawPointer(mutating: data._nsObject.bytes), length: length, copy: true)
+            _init(bytes: UnsafeMutableRawPointer(mutating: data._nsObject.bytes), length: data.count, copy: true)
         }
     }
 

--- a/TestFoundation/HTTPServer.swift
+++ b/TestFoundation/HTTPServer.swift
@@ -207,7 +207,7 @@ class _HTTPServer {
             deadlineTime = .now()
         }
 
-        DispatchQueue.main.asyncAfter(deadline: deadlineTime) {
+        DispatchQueue.global().asyncAfter(deadline: deadlineTime) {
             do {
                 try self.socket.writeData(header: response.header, body: response.body, sendDelay: sendDelay, bodyChunks: bodyChunks)
                 semaphore.signal()

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -15,7 +15,7 @@
     import SwiftXCTest
 #endif
 
-class TestNSData: XCTestCase {
+class TestNSData: LoopbackServerTest {
     
     class AllOnesImmutableData : NSData {
         private var _length : Int
@@ -201,6 +201,7 @@ class TestNSData: XCTestCase {
             ("test_openingNonExistentFile", test_openingNonExistentFile),
             ("test_contentsOfFile", test_contentsOfFile),
             ("test_contentsOfZeroFile", test_contentsOfZeroFile),
+            ("test_contentsOfURL", test_contentsOfURL),
             ("test_basicReadWrite", test_basicReadWrite),
             ("test_bufferSizeCalculation", test_bufferSizeCalculation),
             ("test_dataHash", test_dataHash),
@@ -1471,6 +1472,16 @@ extension TestNSData {
             XCTFail("Cannot read /proc/self/maps: \(String(describing: error))")
         }
 #endif
+    }
+
+    func test_contentsOfURL() {
+        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/country.txt"
+        let url = URL(string: urlString)!
+        let contents = NSData(contentsOf: url)
+        XCTAssertNotNil(contents)
+        if let contents = contents {
+            XCTAssertTrue(contents.length > 0)
+        }
     }
 
     func test_basicReadWrite() {


### PR DESCRIPTION
`NSData (contentsOf :)` was always initialized with length 0.
Also, Testing `NSData (contentsOf :)` on a test HTTP server(`_HTTPServer`) will cause deadlock, so I changed it to work on sub thread.
