### PR TITLE
Revert "[SE-0193] Rename the attributes to their final names"

### DIFF
--- a/Foundation/Boxing.swift
+++ b/Foundation/Boxing.swift
@@ -14,7 +14,7 @@
 ///
 /// Note: This assumes that the result of calling copy() is mutable. The documentation says that classes which do not have a mutable/immutable distinction should just adopt NSCopying instead of NSMutableCopying.
 internal final class _MutableHandle<MutableType : NSObject> where MutableType : NSCopying {
-    @usableFromInline internal var _pointer : MutableType
+    @_versioned internal var _pointer : MutableType
     
     init(reference : MutableType) {
         _pointer = reference.copy() as! MutableType

--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -1005,8 +1005,8 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     // FIXME: switch back to Range once swift 5.0 branch has PR #13342
     public typealias Indices = CountableRange<Int>
     
-    @usableFromInline internal var _backing : _DataStorage
-    @usableFromInline internal var _sliceRange: Range<Index>
+    @_versioned internal var _backing : _DataStorage
+    @_versioned internal var _sliceRange: Range<Index>
     
     
     // A standard or custom deallocator for `Data`.
@@ -1257,18 +1257,18 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
     }
 
-    @usableFromInline
+    @_versioned
     internal init(backing: _DataStorage, range: Range<Index>) {
         _backing = backing
         _sliceRange = range
     }
     
-    @usableFromInline
+    @_versioned
     internal func _validateIndex(_ index: Int, message: String? = nil) {
         precondition(_sliceRange.contains(index), message ?? "Index \(index) is out of bounds of range \(_sliceRange)")
     }
     
-    @usableFromInline
+    @_versioned
     internal func _validateRange<R: RangeExpression>(_ range: R) where R.Bound == Int {
         let lower = R.Bound(_sliceRange.lowerBound)
         let upper = R.Bound(_sliceRange.upperBound)

--- a/Foundation/IndexSet.swift
+++ b/Foundation/IndexSet.swift
@@ -150,7 +150,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     public typealias ReferenceType = NSIndexSet
     public typealias Element = Int
     
-    @usableFromInline
+    @_versioned
     internal var _handle: _MutablePairHandle<NSIndexSet, NSMutableIndexSet>
     
     /// Initialize an `IndexSet` with a range of integers.
@@ -846,7 +846,7 @@ internal enum _MutablePair<ImmutableType, MutableType> {
 /// a.k.a. Box
 internal final class _MutablePairHandle<ImmutableType : NSObject, MutableType : NSObject>
   where ImmutableType : NSMutableCopying, MutableType : NSMutableCopying {
-    @usableFromInline
+    @_versioned
     internal var _pointer: _MutablePair<ImmutableType, MutableType>
     
     /// Initialize with an immutable reference instance.

--- a/Foundation/NSStringAPI.swift
+++ b/Foundation/NSStringAPI.swift
@@ -435,8 +435,8 @@ extension StringProtocol where Index == String.Index {
 
   // self can be a Substring so we need to subtract/add this offset when
   // passing _ns to the Foundation APIs. Will be 0 if self is String.
-  @inlinable
-  @usableFromInline
+  @_inlineable
+  @_versioned
   internal var _substringOffset: Int {
     return self.startIndex.encodedOffset
   }
@@ -447,8 +447,8 @@ extension StringProtocol where Index == String.Index {
     return Index(encodedOffset: utf16Index + _substringOffset)
   }
 
-  @inlinable
-  @usableFromInline
+  @_inlineable
+  @_versioned
   internal func _toRelativeNSRange(_ r: Range<String.Index>) -> NSRange {
     return NSRange(
       location: r.lowerBound.encodedOffset - _substringOffset,

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -140,13 +140,13 @@ internal func _CFZeroUnsafeIvars<T>(_ arg: inout T) {
     }
 }
 
-@usableFromInline
+@_versioned
 @_cdecl("__CFSwiftGetBaseClass")
 internal func __CFSwiftGetBaseClass() -> UnsafeRawPointer {
     return unsafeBitCast(__NSCFType.self, to:UnsafeRawPointer.self)
 }
 
-@usableFromInline
+@_versioned
 @_cdecl("__CFInitializeSwift")
 internal func __CFInitializeSwift() {
     


### PR DESCRIPTION
Reverts apple/swift-corelibs-foundation#1497 as it [caused problems](https://ci.swift.org/job/oss-swift-4.2-incremental-RA-linux-ubuntu-16_04/516/) for Linux builds with swift-4.2-branch, where new attributes are not yet available.

corelibs-foundation code should be compatible with both swift-4.2-branch and master branches of the main Swift repo.