### PR TITLE
TestXMLDocument: Un-XFAIL DTD tests.

### DIFF
--- a/TestFoundation/HTTPServer.swift
+++ b/TestFoundation/HTTPServer.swift
@@ -332,11 +332,11 @@ struct _HTTPResponse {
 }
 
 public class TestURLSessionServer {
-    let capitals: [String:String] = ["Nepal":"Kathmandu",
-                                     "Peru":"Lima",
-                                     "Italy":"Rome",
-                                     "USA":"Washington, D.C.",
-				     "UnitedStates": "USA",
+    let capitals: [String:String] = ["Nepal": "Kathmandu",
+                                     "Peru": "Lima",
+                                     "Italy": "Rome",
+                                     "USA": "Washington, D.C.",
+                                     "UnitedStates": "USA",
                                      "country.txt": "A country is a region that is identified as a distinct national entity in political geography"]
     let httpServer: _HTTPServer
     let startDelay: TimeInterval?
@@ -395,7 +395,7 @@ public class TestURLSessionServer {
             return _HTTPResponse(response: .OK, headers: "Content-Length: \(text.data(using: .utf8)!.count)", body: text)
         }
 
-	if uri == "/UnitedStates" {
+        if uri == "/UnitedStates" {
             let value = capitals[String(uri.dropFirst())]!
             let text = request.getCommaSeparatedHeaders()
             let host = request.headers[1].components(separatedBy: " ")[1]
@@ -406,6 +406,32 @@ public class TestURLSessionServer {
             let httpResponse = _HTTPResponse(response: .REDIRECT, headers: "Location: http://\(newHost + "/" + value)", body: text)
             return httpResponse 
         }
+
+        if uri == "/DTDs/PropertyList-1.0.dtd" {
+            let dtd = """
+    <!ENTITY % plistObject "(array | data | date | dict | real | integer | string | true | false )" >
+    <!ELEMENT plist %plistObject;>
+    <!ATTLIST plist version CDATA "1.0" >
+
+    <!-- Collections -->
+    <!ELEMENT array (%plistObject;)*>
+    <!ELEMENT dict (key, %plistObject;)*>
+    <!ELEMENT key (#PCDATA)>
+
+    <!--- Primitive types -->
+    <!ELEMENT string (#PCDATA)>
+    <!ELEMENT data (#PCDATA)> <!-- Contents interpreted as Base-64 encoded -->
+    <!ELEMENT date (#PCDATA)> <!-- Contents should conform to a subset of ISO 8601 (in particular, YYYY '-' MM '-' DD 'T' HH ':' MM ':' SS 'Z'.  Smaller units may be omitted with a loss of precision) -->
+
+    <!-- Numerical primitives -->
+    <!ELEMENT true EMPTY>  <!-- Boolean constant true -->
+    <!ELEMENT false EMPTY> <!-- Boolean constant false -->
+    <!ELEMENT real (#PCDATA)> <!-- Contents should represent a floating point number matching ("+" | "-")? d+ ("."d*)? ("E" ("+" | "-") d+)? where d is a digit 0-9.  -->
+    <!ELEMENT integer (#PCDATA)> <!-- Contents should represent a (possibly signed) integer number in base 10 -->
+"""
+            return _HTTPResponse(response: .OK, body: dtd)
+        }
+
         return _HTTPResponse(response: .OK, body: capitals[String(uri.dropFirst())]!)
     }
 

--- a/TestFoundation/TestXMLDocument.swift
+++ b/TestFoundation/TestXMLDocument.swift
@@ -17,7 +17,7 @@
 #endif
 
 
-class TestXMLDocument : XCTestCase {
+class TestXMLDocument : LoopbackServerTest {
 
     static var allTests: [(String, (TestXMLDocument) -> () throws -> Void)] {
         return [
@@ -33,8 +33,8 @@ class TestXMLDocument : XCTestCase {
             ("test_processingInstruction", test_processingInstruction),
             ("test_parseXMLString", test_parseXMLString),
             ("test_prefixes", test_prefixes),
-            // XFAIL: <rdar://31567922> ("test_validation_success", test_validation_success),
-            // XFAIL: <rdar://31567922> ("test_validation_failure", test_validation_failure),
+            ("test_validation_success", test_validation_success),
+            ("test_validation_failure", test_validation_failure),
             ("test_dtd", test_dtd),
             ("test_documentWithDTD", test_documentWithDTD),
             ("test_dtd_attributes", test_dtd_attributes),
@@ -353,8 +353,6 @@ class TestXMLDocument : XCTestCase {
         XCTAssert(doc.rootElement()?.namespaces?.first?.name == "R")
     }
 
-    /*
-     * <rdar://31567922> Re-enable these tests in a way that does not depend on the internet.
     func test_validation_success() throws {
         let validString = "<?xml version=\"1.0\" standalone=\"yes\"?><!DOCTYPE foo [ <!ELEMENT foo (#PCDATA)> ]><foo>Hello world</foo>"
         do {
@@ -364,7 +362,8 @@ class TestXMLDocument : XCTestCase {
             XCTFail("\(error)")
         }
 
-        let plistDocString = "<?xml version='1.0' encoding='utf-8'?><!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\"> <plist version='1.0'><dict><key>MyKey</key><string>Hello!</string></dict></plist>"
+        let dtdUrl = "http://127.0.0.1:\(TestURLSession.serverPort)/DTDs/PropertyList-1.0.dtd"
+        let plistDocString = "<?xml version='1.0' encoding='utf-8'?><!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"\(dtdUrl)\"> <plist version='1.0'><dict><key>MyKey</key><string>Hello!</string></dict></plist>"
         let plistDoc = try XMLDocument(xmlString: plistDocString, options: [])
         do {
             try plistDoc.validate()
@@ -388,7 +387,8 @@ class TestXMLDocument : XCTestCase {
             XCTAssert((nsError.userInfo[NSLocalizedDescriptionKey] as! String).contains("Element img was declared EMPTY this one has content"))
         }
 
-        let plistDocString = "<?xml version='1.0' encoding='utf-8'?><!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\"> <plist version='1.0'><dict><key>MyKey</key><string>Hello!</string><key>MyBooleanThing</key><true>foobar</true></dict></plist>"
+        let dtdUrl = "http://127.0.0.1:\(TestURLSession.serverPort)/DTDs/PropertyList-1.0.dtd"
+        let plistDocString = "<?xml version='1.0' encoding='utf-8'?><!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"\(dtdUrl)\"> <plist version='1.0'><dict><key>MyKey</key><string>Hello!</string><key>MyBooleanThing</key><true>foobar</true></dict></plist>"
         let plistDoc = try XMLDocument(xmlString: plistDocString, options: [])
         do {
             try plistDoc.validate()
@@ -396,7 +396,7 @@ class TestXMLDocument : XCTestCase {
         } catch let error as NSError {
             XCTAssert((error.userInfo[NSLocalizedDescriptionKey] as! String).contains("Element true was declared EMPTY this one has content"))
         }
-    }*/
+    }
 
     func test_dtd() throws {
         let node = XMLNode.dtdNode(withXMLString:"<!ELEMENT foo (#PCDATA)>") as! XMLDTDNode


### PR DESCRIPTION
- Serve the DTD from the built in HTTPServer so the tests
  will work without internet access.

- Resolves rdar://31567922.