### PR TITLE
Unwrap potentially boxed attributes returned by NSAttributedString.attribute

### DIFF
--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -251,7 +251,9 @@ private extension NSAttributedString {
                 guard let stringKey = (key as? NSString)?._swiftObject else {
                     continue
                 }
-                results[NSAttributedStringKey(stringKey)] = _SwiftValue.fetch(value)
+
+                let unwrappedValue = _SwiftValue.fetch(value as? AnyObject) ?? value
+                results[NSAttributedStringKey(stringKey)] = unwrappedValue
             }
             
             // Update effective range and return the results

--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -263,7 +263,7 @@ private extension NSAttributedString {
     
     func _attribute(_ attrName: NSAttributedStringKey, atIndex location: Int, rangeInfo: RangeInfo) -> Any? {
         var cfRange = CFRange()
-        return withUnsafeMutablePointer(to: &cfRange) { (cfRangePointer: UnsafeMutablePointer<CFRange>) -> AnyObject? in
+        let attribute = withUnsafeMutablePointer(to: &cfRange) { (cfRangePointer: UnsafeMutablePointer<CFRange>) -> AnyObject? in
             // Get attribute value using CoreFoundation function
             let attribute: AnyObject?
             if rangeInfo.shouldFetchLongestEffectiveRange, let searchRange = rangeInfo.longestEffectiveRangeSearchRange {
@@ -277,6 +277,8 @@ private extension NSAttributedString {
             rangeInfo.rangePointer?.pointee.length = cfRangePointer.pointee.length
             return attribute
         }
+
+        return _SwiftValue.fetch(attribute)
     }
     
     func _enumerate(in enumerationRange: NSRange, reversed: Bool, using block: (Int, UnsafeMutablePointer<ObjCBool>) -> NSRange) {

--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -251,7 +251,7 @@ private extension NSAttributedString {
                 guard let stringKey = (key as? NSString)?._swiftObject else {
                     continue
                 }
-                results[NSAttributedStringKey(stringKey)] = value
+                results[NSAttributedStringKey(stringKey)] = _SwiftValue.fetch(value)
             }
             
             // Update effective range and return the results

--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -252,7 +252,7 @@ private extension NSAttributedString {
                     continue
                 }
 
-                let unwrappedValue = _SwiftValue.fetch(value as? AnyObject) ?? value
+                let unwrappedValue = __SwiftValue.fetch(value as? AnyObject) ?? value
                 results[NSAttributedStringKey(stringKey)] = unwrappedValue
             }
             
@@ -280,7 +280,7 @@ private extension NSAttributedString {
             return attribute
         }
 
-        return _SwiftValue.fetch(attribute)
+        return __SwiftValue.fetch(attribute)
     }
     
     func _enumerate(in enumerationRange: NSRange, reversed: Bool, using block: (Int, UnsafeMutablePointer<ObjCBool>) -> NSRange) {
@@ -346,7 +346,7 @@ open class NSMutableAttributedString : NSAttributedString {
     }
 
     open func addAttribute(_ name: NSAttributedStringKey, value: Any, range: NSRange) {
-        CFAttributedStringSetAttribute(_cfMutableObject, CFRange(range), name.rawValue._cfObject, _SwiftValue.store(value))
+        CFAttributedStringSetAttribute(_cfMutableObject, CFRange(range), name.rawValue._cfObject, __SwiftValue.store(value))
     }
 
     open func addAttributes(_ attrs: [NSAttributedStringKey : Any], range: NSRange) {

--- a/TestFoundation/TestNSAttributedString.swift
+++ b/TestFoundation/TestNSAttributedString.swift
@@ -27,6 +27,8 @@ class TestNSAttributedString : XCTestCase {
             ("test_initWithAttributedString", test_initWithAttributedString),
             ("test_attributedSubstring", test_attributedSubstring),
             ("test_longestEffectiveRange", test_longestEffectiveRange),
+            ("test_addSingleAttributeWithValueOfNativeSwiftType", test_addSingleAttributeWithValueOfNativeSwiftType),
+            ("test_addMultipleAttributesWithValuesOfNativeSwiftType", test_addMultipleAttributesWithValuesOfNativeSwiftType),
             ("test_enumerateAttributeWithName", test_enumerateAttributeWithName),
             ("test_enumerateAttributes", test_enumerateAttributes),
             ("test_copy", test_copy),
@@ -79,7 +81,7 @@ class TestNSAttributedString : XCTestCase {
         let attribute = attrString.attribute(NSAttributedStringKey("attribute.placeholder.key"), at: 0, effectiveRange: &range)
         XCTAssertEqual(range.location, 0)
         XCTAssertEqual(range.length, attrString.length)
-        guard let validAttribute = attribute as? NSString else {
+        guard let validAttribute = attribute as? String else {
             XCTAssert(false, "attribute not found")
             return
         }
@@ -142,6 +144,51 @@ class TestNSAttributedString : XCTestCase {
         _ = attrString.attributes(at: 0, longestEffectiveRange: &range, in: searchRange)
         XCTAssertEqual(range.location, 0)
         XCTAssertEqual(range.length, 28)
+    }
+
+    func test_addSingleAttributeWithValueOfNativeSwiftType() {
+        class DummySwiftClass {}
+
+        let attributedString = NSMutableAttributedString(string: "testing")
+
+        let attributeKey = NSAttributedStringKey("aKey")
+        let attributeValue = DummySwiftClass()
+
+        let attributeStartIndex = 0
+        attributedString.addAttribute(attributeKey, value: attributeValue, range: NSRange(location: attributeStartIndex, length: 1))
+
+        // .attribute vs. .attributes (in test below) use different paths, test both:
+        let result = attributedString.attribute(attributeKey, at: attributeStartIndex, effectiveRange: nil)
+        XCTAssertEqual(type(of: result), DummySwiftClass.self)
+        XCTAssert(result as? DummySwiftClass === attributeValue)
+    }
+
+    func test_addMultipleAttributesWithValuesOfNativeSwiftType() {
+        class DummySwiftClass1 {}
+        class DummySwiftClass2 {}
+
+        let attributedString = NSMutableAttributedString(string: "testing")
+
+        let attributeKey1 = NSAttributedStringKey("aKey")
+        let attributeKey2 = NSAttributedStringKey("anotherKey")
+        let attributeValue1 = DummySwiftClass1()
+        let attributeValue2 = DummySwiftClass2()
+
+        let attributeStartIndex = 0
+        let attributeRange = NSRange(location: attributeStartIndex, length: 1)
+
+        // addAttribute vs. addAttributes use slightly different code paths, test both:
+        attributedString.addAttribute(attributeKey1, value: attributeValue1, range: attributeRange)
+        attributedString.addAttributes([attributeKey2 : attributeValue2], range: attributeRange)
+
+        // .attributes vs. .attribute (in test above) use different paths, test both:
+        let result = attributedString.attributes(at: attributeStartIndex, effectiveRange: nil)
+
+        XCTAssertEqual(type(of: result[attributeKey1]), DummySwiftClass1.self)
+        XCTAssert(result[attributeKey1] as? DummySwiftClass1 === attributeValue1)
+
+        XCTAssertEqual(type(of: result[attributeKey2]), DummySwiftClass2.self)
+        XCTAssert(result[attributeKey2] as? DummySwiftClass2 === attributeValue2)
     }
     
     func test_enumerateAttributeWithName() {


### PR DESCRIPTION
When adding an attribute to a NSMutableAttributedString with `.addAttribute`, the Swift value provided is potentially boxed in a `_SwiftValue` via `_SwiftValue.store(value)`, as seen here: https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/NSAttributedString.swift#L345

The boxed value is never unboxed again though on retrieval. And given that `_SwiftValue` is a Foundation-internal type, it's impossible for an end-user to ever access the real raw value again (`.attribute(at: index)` always just returns the boxed version).

The current change aims to fix this (see Changed Files in this PR for details) by defensively unboxing any individual attributes returned. `_SwiftValue.fetch(value)` checks whether the value needs unboxing and is thus safe to use on any `AnyObject(?)`.

The only question is whether we should extend this change to multiple attributes (here, probably: https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/NSAttributedString.swift#L254), or whether there's a more foolproof way about this.