### PR TITLE
Implement NSTextCheckingResult.range(withName:)

### DIFF
--- a/CoreFoundation/String.subproj/CFRegularExpression.c
+++ b/CoreFoundation/String.subproj/CFRegularExpression.c
@@ -171,6 +171,41 @@ CFIndex _CFRegularExpressionGetNumberOfCaptureGroups(_CFRegularExpressionRef reg
     return (CFIndex)uregex_groupCount(regex->regex, &errorCode);
 }
 
+CFIndex _CFRegularExpressionGetCaptureGroupNumberWithName(_CFRegularExpressionRef regex, CFStringRef groupName) {
+    UniChar stackBuffer[STACK_BUFFER_SIZE], *nameBuffer = NULL;
+    Boolean freeNameBuffer = false;
+
+    CFIndex nameLength = CFStringGetLength(groupName);
+    UErrorCode errorCode = U_ZERO_ERROR;
+
+    nameBuffer = (UniChar *)CFStringGetCharactersPtr(groupName);
+    if (!nameBuffer) {
+        if (nameLength <= STACK_BUFFER_SIZE) {
+            nameBuffer = stackBuffer;
+            CFStringGetCharacters(groupName, CFRangeMake(0, nameLength), nameBuffer);
+        } else {
+            nameBuffer = (UniChar *)malloc(sizeof(UniChar) * nameLength);
+            if (nameBuffer) {
+                CFStringGetCharacters(groupName, CFRangeMake(0, nameLength), nameBuffer);
+                freeNameBuffer = true;
+            } else {
+                HALT;
+            }
+        }
+    }
+
+    CFIndex idx = uregex_groupNumberFromName(regex->regex, nameBuffer, nameLength, &errorCode);
+    if (U_FAILURE(errorCode) || idx < 0) {
+        idx = kCFNotFound;
+    }
+
+    if (freeNameBuffer) {
+        free(nameBuffer);
+    }
+
+    return idx;
+}
+
 struct regexCallBackContext {
     void *context;
     void (*match)(void *context, CFRange *ranges, CFIndex count, _CFRegularExpressionMatchingFlags flags, Boolean *stop);

--- a/CoreFoundation/String.subproj/CFRegularExpression.h
+++ b/CoreFoundation/String.subproj/CFRegularExpression.h
@@ -57,6 +57,7 @@ _CFRegularExpressionRef _Nullable _CFRegularExpressionCreate(CFAllocatorRef allo
 void _CFRegularExpressionDestroy(_CFRegularExpressionRef regex);
 
 CFIndex _CFRegularExpressionGetNumberOfCaptureGroups(_CFRegularExpressionRef regex);
+CFIndex _CFRegularExpressionGetCaptureGroupNumberWithName(_CFRegularExpressionRef regex, CFStringRef groupName);
 void _CFRegularExpressionEnumerateMatchesInString(_CFRegularExpressionRef regexObj, CFStringRef string, _CFRegularExpressionMatchingOptions options, CFRange range, void *_Nullable context, _CFRegularExpressionMatch match);
 
 CFStringRef _CFRegularExpressionGetPattern(_CFRegularExpressionRef regex);

--- a/Foundation/NSRegularExpression.swift
+++ b/Foundation/NSRegularExpression.swift
@@ -106,7 +106,11 @@ open class NSRegularExpression: NSObject, NSCopying, NSCoding {
     open var numberOfCaptureGroups: Int {
         return _CFRegularExpressionGetNumberOfCaptureGroups(_internal)
     }
-    
+
+    internal func _captureGroupNumber(withName name: String) -> Int {
+        return _CFRegularExpressionGetCaptureGroupNumberWithName(_internal, name._cfObject)
+    }
+
     /* This class method will produce a string by adding backslash escapes as necessary to the given string, to escape any characters that would otherwise be treated as pattern metacharacters.
     */
     open class func escapedPattern(for string: String) -> String { 

--- a/Foundation/NSTextCheckingResult.swift
+++ b/Foundation/NSTextCheckingResult.swift
@@ -54,6 +54,8 @@ open class NSTextCheckingResult: NSObject, NSCopying, NSCoding {
     open var range: NSRange { return range(at: 0) }
     /* A result must have at least one range, but may optionally have more (for example, to represent regular expression capture groups).  The range at index 0 always matches the range property.  Additional ranges, if any, will have indexes from 1 to numberOfRanges-1. */
     open func range(at idx: Int) -> NSRange { NSRequiresConcreteImplementation() }
+    @available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
+    open func range(withName: String) -> NSRange { NSRequiresConcreteImplementation() }
     open var regularExpression: NSRegularExpression? { return nil }
     open var numberOfRanges: Int { return 1 }
 }
@@ -81,6 +83,15 @@ internal class _NSRegularExpressionNSTextCheckingResultResult : NSTextCheckingRe
     
     override var resultType: CheckingType { return .RegularExpression }
     override func range(at idx: Int) -> NSRange { return _ranges[idx] }
+    override func range(withName name: String) -> NSRange {
+        let idx = _regularExpression._captureGroupNumber(withName: name)
+        if idx != kCFNotFound, idx < numberOfRanges {
+            return range(at: idx)
+        }
+
+        return NSRange(location: NSNotFound, length: 0)
+    }
+
     override var numberOfRanges: Int { return _ranges.count }
     override var regularExpression: NSRegularExpression? { return _regularExpression }
 }

--- a/TestFoundation/TestNSRegularExpression.swift
+++ b/TestFoundation/TestNSRegularExpression.swift
@@ -18,9 +18,11 @@ class TestNSRegularExpression : XCTestCase {
             ("test_NSCoding", test_NSCoding),
             ("test_defaultOptions", test_defaultOptions),
             ("test_badPattern", test_badPattern),
+            ("test_unicodeNamedGroup", test_unicodeNamedGroup),
+            ("test_conflictingNamedGroups", test_conflictingNamedGroups),
         ]
     }
-    
+
     func simpleRegularExpressionTestWithPattern(_ patternString: String, target searchString: String, looking: Bool, match: Bool, file: StaticString = #file, line: UInt = #line) {
         do {
             let str = NSString(string: searchString)
@@ -371,4 +373,27 @@ class TestNSRegularExpression : XCTestCase {
             XCTAssertEqual(err, "Error Domain=NSCocoaErrorDomain Code=2048 \"(null)\" UserInfo={NSInvalidValue=(}")
         }
     }
+
+    func test_unicodeNamedGroup() {
+        let patternString = "(?<りんご>a)"
+        do {
+            _ = try NSRegularExpression(pattern: patternString, options: [])
+            XCTFail("Building regular expression for pattern with unicode group name should fail.")
+        } catch {
+            let err = String(describing: error)
+            XCTAssertEqual(err, "Error Domain=NSCocoaErrorDomain Code=2048 \"(null)\" UserInfo={NSInvalidValue=(?<りんご>a)}")
+        }
+    }
+
+    func test_conflictingNamedGroups() {
+        let patternString = "(?<name>a)(?<name>b)"
+        do {
+            _ = try NSRegularExpression(pattern: patternString, options: [])
+            XCTFail("Building regular expression for pattern with identically named groups should fail.")
+        } catch {
+            let err = String(describing: error)
+            XCTAssertEqual(err, "Error Domain=NSCocoaErrorDomain Code=2048 \"(null)\" UserInfo={NSInvalidValue=(?<name>a)(?<name>b)}")
+        }
+    }
+
 }


### PR DESCRIPTION
- Added the missing range(withName:) and corresponding CF function.
The implementation relies on uregex_groupNumberFromName which is
available as a draft API from ICU 55.

- Added tests related to named capture groups.