### PR TITLE
Replace XCTAssertNotNil with enhanced tests on TestDate and TestTimer

### DIFF
--- a/TestFoundation/TestDate.swift
+++ b/TestFoundation/TestDate.swift
@@ -42,26 +42,27 @@ class TestDate : XCTestCase {
     
     func test_BasicConstruction() {
         let d = Date()
-        XCTAssertNotNil(d)
+        XCTAssert(d.timeIntervalSince1970 != 0)
+        XCTAssert(d.timeIntervalSinceReferenceDate != 0)
     }
 
     func test_descriptionWithLocale() {
         let d = NSDate(timeIntervalSince1970: 0)
         XCTAssertEqual(d.description(with: nil), "1970-01-01 00:00:00 +0000")
-        XCTAssertNotNil(d.description(with: Locale(identifier: "ja_JP")))
+        XCTAssertFalse(d.description(with: Locale(identifier: "ja_JP")).isEmpty)
     }
     
     func test_InitTimeIntervalSince1970() {
         let ti: TimeInterval = 1
         let d = Date(timeIntervalSince1970: ti)
-        XCTAssertNotNil(d)
+        XCTAssert(d.timeIntervalSince1970 == ti)
     }
     
     func test_InitTimeIntervalSinceSinceDate() {
         let ti: TimeInterval = 1
         let d1 = Date()
         let d2 = Date(timeInterval: ti, since: d1)
-        XCTAssertNotNil(d2)
+        XCTAssertNotNil(d2.timeIntervalSince1970 == d1.timeIntervalSince1970 + ti)
     }
     
     func test_TimeIntervalSinceSinceDate() {
@@ -73,19 +74,22 @@ class TestDate : XCTestCase {
     
     func test_DistantFuture() {
         let d = Date.distantFuture
-        XCTAssertNotNil(d)
+        let now = Date()
+        XCTAssertGreaterThan(d, now)
     }
     
     func test_DistantPast() {
+        let now = Date()
         let d = Date.distantPast
-        XCTAssertNotNil(d)
+
+        XCTAssertLessThan(d, now)
     }
     
     func test_DateByAddingTimeInterval() {
         let ti: TimeInterval = 1
         let d1 = Date()
         let d2 = d1 + ti
-        XCTAssertNotNil(d2)
+        XCTAssertNotNil(d2.timeIntervalSince1970 == d1.timeIntervalSince1970 + ti)
     }
     
     func test_EarlierDate() {

--- a/TestFoundation/TestTimer.swift
+++ b/TestFoundation/TestTimer.swift
@@ -28,8 +28,18 @@ class TestTimer : XCTestCase {
     }
     
     func test_timerInit() {
-        let timer = Timer(fire: Date(), interval: 0.3, repeats: false) { _ in }
-        XCTAssertNotNil(timer)
+        let fireDate = Date()
+        let timeInterval: TimeInterval = 0.3
+
+        let timer = Timer(fire: fireDate, interval: timeInterval, repeats: false) { _ in }
+        XCTAssertEqual(timer.fireDate, fireDate)
+        XCTAssertEqual(timer.timeInterval, 0, "Time interval should be 0 for a non repeating Timer")
+        XCTAssert(timer.isValid)
+
+        let repeatingTimer = Timer(fire: fireDate, interval: timeInterval, repeats: true) { _ in }
+        XCTAssertEqual(repeatingTimer.fireDate, fireDate)
+        XCTAssertEqual(repeatingTimer.timeInterval, timeInterval)
+        XCTAssert(timer.isValid)
     }
     
     func test_timerTickOnce() {


### PR DESCRIPTION
Similar to #1516 but in cases where simply removing the `XCTAssertNotNil` would not bring any benefit or even harm the test suite.