### PR TITLE
Centralise test imports and add os(Android)

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -344,6 +344,7 @@
 		B9974B9A1EDF4A22007F15B8 /* HTTPMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B931EDF4A22007F15B8 /* HTTPMessage.swift */; };
 		B9974B9B1EDF4A22007F15B8 /* BodySource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B941EDF4A22007F15B8 /* BodySource.swift */; };
 		B9974B9C1EDF4A22007F15B8 /* EasyHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B951EDF4A22007F15B8 /* EasyHandle.swift */; };
+		BB3D7558208A1E500085CFDC /* TestImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3D7557208A1E500085CFDC /* TestImports.swift */; };
 		BD8042161E09857800487EB8 /* TestLengthFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8042151E09857800487EB8 /* TestLengthFormatter.swift */; };
 		BDBB65901E256BFA001A7286 /* TestEnergyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDBB658F1E256BFA001A7286 /* TestEnergyFormatter.swift */; };
 		BDFDF0A71DFF5B3E00C04CC5 /* TestPersonNameComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFDF0A61DFF5B3E00C04CC5 /* TestPersonNameComponents.swift */; };
@@ -825,6 +826,7 @@
 		B9974B931EDF4A22007F15B8 /* HTTPMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HTTPMessage.swift; path = http/HTTPMessage.swift; sourceTree = "<group>"; };
 		B9974B941EDF4A22007F15B8 /* BodySource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BodySource.swift; sourceTree = "<group>"; };
 		B9974B951EDF4A22007F15B8 /* EasyHandle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EasyHandle.swift; sourceTree = "<group>"; };
+		BB3D7557208A1E500085CFDC /* TestImports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestImports.swift; sourceTree = "<group>"; };
 		BD8042151E09857800487EB8 /* TestLengthFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLengthFormatter.swift; sourceTree = "<group>"; };
 		BDBB658F1E256BFA001A7286 /* TestEnergyFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEnergyFormatter.swift; sourceTree = "<group>"; };
 		BDFDF0A61DFF5B3E00C04CC5 /* TestPersonNameComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestPersonNameComponents.swift; sourceTree = "<group>"; };
@@ -1431,6 +1433,7 @@
 			children = (
 				1520469A1D8AEABE00D02E36 /* HTTPServer.swift */,
 				EA66F6381BF1619600136161 /* main.swift */,
+				BB3D7557208A1E500085CFDC /* TestImports.swift */,
 				9F4ADBCF1ECD4F56001F0B3D /* xdgTestHelper */,
 				EA66F65A1BF1976100136161 /* Tests */,
 				EA66F6391BF1619600136161 /* Resources */,
@@ -2442,6 +2445,7 @@
 				90E645DF1E4C89A400D0D47C /* TestNSCache.swift in Sources */,
 				5B13B34A1C582D4C00651CE2 /* TestURL.swift in Sources */,
 				EA54A6FB1DB16D53009E0809 /* TestObjCRuntime.swift in Sources */,
+				BB3D7558208A1E500085CFDC /* TestImports.swift in Sources */,
 				5B13B34D1C582D4C00651CE2 /* TestNSUUID.swift in Sources */,
 				5B13B3281C582D4C00651CE2 /* TestBundle.swift in Sources */,
 				5B13B32A1C582D4C00651CE2 /* TestCharacterSet.swift in Sources */,

--- a/TestFoundation/HTTPServer.swift
+++ b/TestFoundation/HTTPServer.swift
@@ -14,9 +14,9 @@
 
 import Dispatch
 
-#if os(macOS) || os(iOS)
+#if canImport(Darwin)
     import Darwin
-#elseif os(Linux)
+#elseif canImport(Glibc)
     import Glibc
 #endif
 

--- a/TestFoundation/HTTPServer.swift
+++ b/TestFoundation/HTTPServer.swift
@@ -14,14 +14,6 @@
 
 import Dispatch
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 #if os(macOS) || os(iOS)
     import Darwin
 #elseif os(Linux)

--- a/TestFoundation/TestAffineTransform.swift
+++ b/TestFoundation/TestAffineTransform.swift
@@ -7,17 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
 class TestAffineTransform : XCTestCase {
     private let accuracyThreshold = 0.001
 

--- a/TestFoundation/TestBundle.swift
+++ b/TestFoundation/TestBundle.swift
@@ -7,15 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
 import CoreFoundation
 
 internal func testBundle() -> Bundle {

--- a/TestFoundation/TestByteCountFormatter.swift
+++ b/TestFoundation/TestByteCountFormatter.swift
@@ -7,18 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
-
 class TestByteCountFormatter : XCTestCase {
     
     static var allTests: [(String, (TestByteCountFormatter) -> () throws -> Void)] {

--- a/TestFoundation/TestCalendar.swift
+++ b/TestFoundation/TestCalendar.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
 class TestCalendar: XCTestCase {
     
     static var allTests: [(String, (TestCalendar) -> () throws -> Void)] {

--- a/TestFoundation/TestCharacterSet.swift
+++ b/TestFoundation/TestCharacterSet.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
 private struct Box: Equatable {
     private let ns: NSCharacterSet
     private let swift: CharacterSet

--- a/TestFoundation/TestCodable.swift
+++ b/TestFoundation/TestCodable.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
 // MARK: - Helper Functions
 
 private func makePersonNameComponents(namePrefix: String? = nil,

--- a/TestFoundation/TestDate.swift
+++ b/TestFoundation/TestDate.swift
@@ -7,18 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
-
 class TestDate : XCTestCase {
     
     static var allTests: [(String, (TestDate) -> () throws -> Void)] {

--- a/TestFoundation/TestDateFormatter.swift
+++ b/TestFoundation/TestDateFormatter.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestDateFormatter: XCTestCase {
     
     let DEFAULT_LOCALE = "en_US"

--- a/TestFoundation/TestDecimal.swift
+++ b/TestFoundation/TestDecimal.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestDecimal: XCTestCase {
 
     static var allTests : [(String, (TestDecimal) -> () throws -> Void)] {

--- a/TestFoundation/TestEnergyFormatter.swift
+++ b/TestFoundation/TestEnergyFormatter.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestEnergyFormatter: XCTestCase {
     let formatter: EnergyFormatter = EnergyFormatter()
     

--- a/TestFoundation/TestFileHandle.swift
+++ b/TestFoundation/TestFileHandle.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestFileHandle : XCTestCase {
     static var allTests : [(String, (TestFileHandle) -> () throws -> ())] {
         return [

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestFileManager : XCTestCase {
     
     static var allTests: [(String, (TestFileManager) -> () throws -> Void)] {

--- a/TestFoundation/TestHTTPCookie.swift
+++ b/TestFoundation/TestHTTPCookie.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestHTTPCookie: XCTestCase {
 
     static var allTests: [(String, (TestHTTPCookie) -> () throws -> Void)] {

--- a/TestFoundation/TestHTTPCookieStorage.swift
+++ b/TestFoundation/TestHTTPCookieStorage.swift
@@ -7,13 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
 import Dispatch
 
 class TestHTTPCookieStorage: XCTestCase {

--- a/TestFoundation/TestHost.swift
+++ b/TestFoundation/TestHost.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
 class TestHost: XCTestCase {
     
     static var allTests: [(String, (TestHost) -> () throws -> Void)] {

--- a/TestFoundation/TestISO8601DateFormatter.swift
+++ b/TestFoundation/TestISO8601DateFormatter.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestISO8601DateFormatter: XCTestCase {
     
     static var allTests : [(String, (TestISO8601DateFormatter) -> () throws -> Void)] {

--- a/TestFoundation/TestImports.swift
+++ b/TestFoundation/TestImports.swift
@@ -1,0 +1,18 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+// Centralized conditional imports for all test sources
+
+#if DEPLOYMENT_RUNTIME_OBJC || os(Linux) || os(Android)
+@_exported import Foundation
+@_exported import XCTest
+#else
+@_exported import SwiftFoundation
+@_exported import SwiftXCTest
+#endif

--- a/TestFoundation/TestIndexPath.swift
+++ b/TestFoundation/TestIndexPath.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
 class TestIndexPath: XCTestCase {
     
     static var allTests: [(String, (TestIndexPath) -> () throws -> Void)] {

--- a/TestFoundation/TestIndexSet.swift
+++ b/TestFoundation/TestIndexSet.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
-
 class TestIndexSet : XCTestCase {
     
     static var allTests: [(String, (TestIndexSet) -> () throws -> Void)] {

--- a/TestFoundation/TestJSONEncoder.swift
+++ b/TestFoundation/TestJSONEncoder.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 struct TopLevelObjectWrapper<T: Codable & Equatable>: Codable, Equatable {
     var value: T
 

--- a/TestFoundation/TestJSONSerialization.swift
+++ b/TestFoundation/TestJSONSerialization.swift
@@ -7,15 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 // Exposing internal ReadingOptions for tests.
 extension JSONSerialization.ReadingOptions {
     fileprivate static let useReferenceNumericTypes = JSONSerialization.ReadingOptions(rawValue: 1 << 15)

--- a/TestFoundation/TestLengthFormatter.swift
+++ b/TestFoundation/TestLengthFormatter.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestLengthFormatter: XCTestCase {
     let formatter: LengthFormatter = LengthFormatter()
     

--- a/TestFoundation/TestMassFormatter.swift
+++ b/TestFoundation/TestMassFormatter.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestMassFormatter: XCTestCase {
     let formatter: MassFormatter = MassFormatter()
     

--- a/TestFoundation/TestNSArray.swift
+++ b/TestFoundation/TestNSArray.swift
@@ -7,18 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
-
-
 class TestNSArray : XCTestCase {
     
     static var allTests: [(String, (TestNSArray) -> () throws -> Void)] {

--- a/TestFoundation/TestNSAttributedString.swift
+++ b/TestFoundation/TestNSAttributedString.swift
@@ -7,17 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
 class TestNSAttributedString : XCTestCase {
     
     static var allTests: [(String, (TestNSAttributedString) -> () throws -> Void)] {

--- a/TestFoundation/TestNSCache.swift
+++ b/TestFoundation/TestNSCache.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestNSCache : XCTestCase {
     
     static var allTests: [(String, (TestNSCache) -> () throws -> Void)] {

--- a/TestFoundation/TestNSCompoundPredicate.swift
+++ b/TestFoundation/TestNSCompoundPredicate.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestNSCompoundPredicate: XCTestCase {
     
     static var allTests: [(String, (TestNSCompoundPredicate) -> () throws -> Void)] {

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestNSData: LoopbackServerTest {
     
     class AllOnesImmutableData : NSData {

--- a/TestFoundation/TestNSDictionary.swift
+++ b/TestFoundation/TestNSDictionary.swift
@@ -7,18 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
-
-
 class TestNSDictionary : XCTestCase {
     
     static var allTests: [(String, (TestNSDictionary) -> () throws -> Void)] {

--- a/TestFoundation/TestNSError.swift
+++ b/TestFoundation/TestNSError.swift
@@ -7,15 +7,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 struct SwiftCustomNSError: Error, CustomNSError {
 }
 

--- a/TestFoundation/TestNSGeometry.swift
+++ b/TestFoundation/TestNSGeometry.swift
@@ -7,15 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 private func assertEqual(_ rect: CGRect,
                          x: CGFloat,
                          y: CGFloat,

--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -7,15 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 public class NSUserClass : NSObject, NSSecureCoding {
     var ivar : Int
     

--- a/TestFoundation/TestNSKeyedUnarchiver.swift
+++ b/TestFoundation/TestNSKeyedUnarchiver.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
 class TestNSKeyedUnarchiver : XCTestCase {
     static var allTests: [(String, (TestNSKeyedUnarchiver) -> () throws -> Void)] {
         return [

--- a/TestFoundation/TestNSLocale.swift
+++ b/TestFoundation/TestNSLocale.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestNSLocale : XCTestCase {
     static var allTests: [(String, (TestNSLocale) -> () throws -> Void)] {
         return [

--- a/TestFoundation/TestNSLock.swift
+++ b/TestFoundation/TestNSLock.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
 class TestNSLock: XCTestCase {
     static var allTests: [(String, (TestNSLock) -> () throws -> Void)] {
         return [

--- a/TestFoundation/TestNSNull.swift
+++ b/TestFoundation/TestNSNull.swift
@@ -7,18 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
-
 class TestNSNull : XCTestCase {
     
     static var allTests: [(String, (TestNSNull) -> () throws -> Void)] {

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
-
 class TestNSNumber : XCTestCase {
     static var allTests: [(String, (TestNSNumber) -> () throws -> Void)] {
         return [

--- a/TestFoundation/TestNSNumberBridging.swift
+++ b/TestFoundation/TestNSNumberBridging.swift
@@ -7,15 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
 class TestNSNumberBridging : XCTestCase {
     static var allTests: [(String, (TestNSNumberBridging) -> () throws -> Void)] {
         return [

--- a/TestFoundation/TestNSOrderedSet.swift
+++ b/TestFoundation/TestNSOrderedSet.swift
@@ -7,18 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
-
 class TestNSOrderedSet : XCTestCase {
 
     static var allTests: [(String, (TestNSOrderedSet) -> () throws -> Void)] {

--- a/TestFoundation/TestNSPredicate.swift
+++ b/TestFoundation/TestNSPredicate.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestNSPredicate: XCTestCase {
 
     static var allTests : [(String, (TestNSPredicate) -> () throws -> Void)] {

--- a/TestFoundation/TestNSProgressFraction.swift
+++ b/TestFoundation/TestNSProgressFraction.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
 #if !DARWIN_COMPATIBILITY_TESTS
 class TestProgressFraction : XCTestCase {
     static var allTests: [(String, (TestProgressFraction) -> () throws -> Void)] {

--- a/TestFoundation/TestNSRange.swift
+++ b/TestFoundation/TestNSRange.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
-
 class TestNSRange : XCTestCase {
     
     static var allTests: [(String, (TestNSRange) -> () throws -> Void)] {

--- a/TestFoundation/TestNSRegularExpression.swift
+++ b/TestFoundation/TestNSRegularExpression.swift
@@ -7,18 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
-
-
 class TestNSRegularExpression : XCTestCase {
     
     static var allTests : [(String, (TestNSRegularExpression) -> () throws -> Void)] {

--- a/TestFoundation/TestNSSet.swift
+++ b/TestFoundation/TestNSSet.swift
@@ -7,18 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
-
-
 class TestNSSet : XCTestCase {
     
     static var allTests: [(String, (TestNSSet) -> () throws -> Void)] {

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -7,15 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
 import CoreFoundation
 
 #if os(macOS) || os(iOS)

--- a/TestFoundation/TestNSTextCheckingResult.swift
+++ b/TestFoundation/TestNSTextCheckingResult.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestNSTextCheckingResult: XCTestCase {
     static var allTests: [(String, (TestNSTextCheckingResult) -> () throws -> Void)] {
         return [

--- a/TestFoundation/TestNSURLRequest.swift
+++ b/TestFoundation/TestNSURLRequest.swift
@@ -7,15 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestNSURLRequest : XCTestCase {
     
     static var allTests: [(String, (TestNSURLRequest) -> () throws -> Void)] {

--- a/TestFoundation/TestNSUUID.swift
+++ b/TestFoundation/TestNSUUID.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
 class TestNSUUID : XCTestCase {
     
     static var allTests: [(String, (TestNSUUID) -> () throws -> Void)] {

--- a/TestFoundation/TestNSValue.swift
+++ b/TestFoundation/TestNSValue.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
 class TestNSValue : XCTestCase {
     static var allTests: [(String, (TestNSValue) -> () throws -> Void)] {
         return [

--- a/TestFoundation/TestNotification.swift
+++ b/TestFoundation/TestNotification.swift
@@ -7,18 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
-
 class TestNotification : XCTestCase {
 
     static var allTests: [(String, (TestNotification) -> () throws -> Void)] {

--- a/TestFoundation/TestNotificationCenter.swift
+++ b/TestFoundation/TestNotificationCenter.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
 class TestNotificationCenter : XCTestCase {
     static var allTests: [(String, (TestNotificationCenter) -> () throws -> Void)] {
         return [

--- a/TestFoundation/TestNotificationQueue.swift
+++ b/TestFoundation/TestNotificationQueue.swift
@@ -7,15 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
 class TestNotificationQueue : XCTestCase {
     static var allTests : [(String, (TestNotificationQueue) -> () throws -> Void)] {
         return [

--- a/TestFoundation/TestNumberFormatter.swift
+++ b/TestFoundation/TestNumberFormatter.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestNumberFormatter: XCTestCase {
 
     static var allTests: [(String, (TestNumberFormatter) -> () throws -> Void)] {

--- a/TestFoundation/TestObjCRuntime.swift
+++ b/TestFoundation/TestObjCRuntime.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class SwiftClass {
     class InnerClass {}
 }

--- a/TestFoundation/TestOperationQueue.swift
+++ b/TestFoundation/TestOperationQueue.swift
@@ -7,15 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
 import Dispatch
 
 class TestOperationQueue : XCTestCase {

--- a/TestFoundation/TestPersonNameComponents.swift
+++ b/TestFoundation/TestPersonNameComponents.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 private func assertEqual(_ lhs:PersonNameComponents,
                          _ rhs: PersonNameComponents,
                          file: StaticString = #file,

--- a/TestFoundation/TestPipe.swift
+++ b/TestFoundation/TestPipe.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
-
 class TestPipe : XCTestCase {
     
     static var allTests: [(String, (TestPipe) -> () throws -> Void)] {

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestProcess : XCTestCase {
     static var allTests: [(String, (TestProcess) -> () throws -> Void)] {
 #if os(Android)

--- a/TestFoundation/TestProcessInfo.swift
+++ b/TestFoundation/TestProcessInfo.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
 class TestProcessInfo : XCTestCase {
     
     static var allTests: [(String, (TestProcessInfo) -> () throws -> Void)] {

--- a/TestFoundation/TestProgress.swift
+++ b/TestFoundation/TestProgress.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
 import Dispatch
 
 class TestProgress : XCTestCase {

--- a/TestFoundation/TestPropertyListSerialization.swift
+++ b/TestFoundation/TestPropertyListSerialization.swift
@@ -7,17 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
-
-
 class TestPropertyListSerialization : XCTestCase {
     static var allTests: [(String, (TestPropertyListSerialization) -> () throws -> Void)] {
         return [

--- a/TestFoundation/TestRunLoop.swift
+++ b/TestFoundation/TestRunLoop.swift
@@ -7,15 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
 class TestRunLoop : XCTestCase {
     static var allTests : [(String, (TestRunLoop) -> () throws -> Void)] {
         return [

--- a/TestFoundation/TestScanner.swift
+++ b/TestFoundation/TestScanner.swift
@@ -7,18 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
-
 class TestScanner : XCTestCase {
 
     static var allTests: [(String, (TestScanner) -> () throws -> Void)] {

--- a/TestFoundation/TestStream.swift
+++ b/TestFoundation/TestStream.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestStream : XCTestCase {
     static var allTests: [(String, (TestStream) -> () throws -> Void)] {
         return [

--- a/TestFoundation/TestThread.swift
+++ b/TestFoundation/TestThread.swift
@@ -7,15 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 #if !(os(macOS) || os(iOS))
     import CoreFoundation
 #endif

--- a/TestFoundation/TestTimeZone.swift
+++ b/TestFoundation/TestTimeZone.swift
@@ -7,18 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
-
 class TestTimeZone: XCTestCase {
 
     static var allTests: [(String, (TestTimeZone) -> () throws -> Void)] {

--- a/TestFoundation/TestTimer.swift
+++ b/TestFoundation/TestTimer.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
 class TestTimer : XCTestCase {
     static var allTests : [(String, (TestTimer) -> () throws -> Void)] {
         return [

--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
-
-
 let kURLTestParsingTestsKey = "ParsingTests"
 
 let kURLTestTitleKey = "In-Title"

--- a/TestFoundation/TestURLCredential.swift
+++ b/TestFoundation/TestURLCredential.swift
@@ -7,15 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestURLCredential : XCTestCase {
     
     static var allTests: [(String, (TestURLCredential) -> () throws -> Void)] {

--- a/TestFoundation/TestURLProtocol.swift
+++ b/TestFoundation/TestURLProtocol.swift
@@ -6,13 +6,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
 
 class TestURLProtocol : LoopbackServerTest {
     

--- a/TestFoundation/TestURLRequest.swift
+++ b/TestFoundation/TestURLRequest.swift
@@ -7,15 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestURLRequest : XCTestCase {
     
     static var allTests: [(String, (TestURLRequest) -> () throws -> Void)] {

--- a/TestFoundation/TestURLResponse.swift
+++ b/TestFoundation/TestURLResponse.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
 class TestURLResponse : XCTestCase {
     static var allTests: [(String, (TestURLResponse) -> () throws -> Void)] {
         return [

--- a/TestFoundation/TestURLSession.swift
+++ b/TestFoundation/TestURLSession.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestURLSession : LoopbackServerTest {
     
     static var allTests: [(String, (TestURLSession) -> () throws -> Void)] {

--- a/TestFoundation/TestUnit.swift
+++ b/TestFoundation/TestUnit.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 class TestUnit: XCTestCase {
 
     static var allTests: [(String, (TestUnit) -> () throws -> Void)] {

--- a/TestFoundation/TestUnitConverter.swift
+++ b/TestFoundation/TestUnitConverter.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
-
 class TestUnitConverter: XCTestCase {
     
     static var allTests: [(String, (TestUnitConverter) -> () throws -> Void)] {

--- a/TestFoundation/TestUserDefaults.swift
+++ b/TestFoundation/TestUserDefaults.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-	import Foundation
-	import XCTest
-#else
-	import SwiftFoundation
-	import SwiftXCTest
-#endif
-
 class TestUserDefaults : XCTestCase {
 	static var allTests : [(String, (TestUserDefaults) -> () throws -> ())] {
 		return [

--- a/TestFoundation/TestUtils.swift
+++ b/TestFoundation/TestUtils.swift
@@ -7,14 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 func ensureFiles(_ fileNames: [String]) -> Bool {
     var result = true
     let fm = FileManager.default

--- a/TestFoundation/TestXMLDocument.swift
+++ b/TestFoundation/TestXMLDocument.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
-
 class TestXMLDocument : LoopbackServerTest {
 
     static var allTests: [(String, (TestXMLDocument) -> () throws -> Void)] {

--- a/TestFoundation/TestXMLParser.swift
+++ b/TestFoundation/TestXMLParser.swift
@@ -7,15 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-    import Foundation
-    import XCTest
-#else
-    import SwiftFoundation
-    import SwiftXCTest
-#endif
-
 enum XMLParserDelegateEvent {
     case startDocument
     case endDocument

--- a/TestFoundation/XDGTestHelper.swift
+++ b/TestFoundation/XDGTestHelper.swift
@@ -7,6 +7,12 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(Linux) || os(Android)
+    import Foundation
+#else
+    import SwiftFoundation
+#endif
+
 class XDGCheck {
 
     static func run() -> Never {

--- a/TestFoundation/XDGTestHelper.swift
+++ b/TestFoundation/XDGTestHelper.swift
@@ -7,12 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if os(Linux)
-    import Foundation
-#else
-    import SwiftFoundation
-#endif
-
 class XDGCheck {
 
     static func run() -> Never {

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -7,20 +7,13 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-import Foundation
-import XCTest
-#else
-import SwiftFoundation
-import SwiftXCTest
-#endif
+// Most imports now centraized in TestImports.swift
 
 #if os(macOS) || os(iOS)
     import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || os(Android)
     import Glibc
 #endif
-
 
 // ignore SIGPIPE which is sent when writing to closed file descriptors.
 _ = signal(SIGPIPE, SIG_IGN)

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -9,9 +9,9 @@
 
 // Most imports now centraized in TestImports.swift
 
-#if os(macOS) || os(iOS)
+#if canImport(Darwin)
     import Darwin
-#elseif os(Linux) || os(Android)
+#elseif canImport(Glibc)
     import Glibc
 #endif
 

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -7,12 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if os(Linux)
-    import Foundation
-#else
-    import SwiftFoundation
-#endif
-
 enum HelperCheckStatus : Int32 {
     case ok                 = 0
     case fail               = 1

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -7,6 +7,12 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(Linux) || os(Android)
+    import Foundation
+#else
+    import SwiftFoundation
+#endif
+
 enum HelperCheckStatus : Int32 {
     case ok                 = 0
     case fail               = 1


### PR DESCRIPTION
Hi Apple,

This PR adds os(Android) to the conditional imports and centralises them to reduce some boilerplate.