### PR TITLE
Package.swift for testing foundation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+    name: "TestFoundation",
+    products: [
+        .executable(name: "TestFoundation", targets: ["TestFoundation"])
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(
+            name: "TestFoundation",
+            dependencies: [],
+            path: "TestFoundation",
+            exclude: ["XDGTestHelper.swift", "xdgTestHelper"]
+        ),
+    ]
+)

--- a/TestFoundation/TestNSProgressFraction.swift
+++ b/TestFoundation/TestNSProgressFraction.swift
@@ -17,6 +17,11 @@ import SwiftXCTest
 
 #if !DARWIN_COMPATIBILITY_TESTS
 class TestProgressFraction : XCTestCase {
+#if os(Android)
+    static var allTests: [(String, (TestProgressFraction) -> () throws -> Void)] {
+        return []
+    }
+#else
     static var allTests: [(String, (TestProgressFraction) -> () throws -> Void)] {
         return [
             ("test_equal", test_equal ),
@@ -159,6 +164,7 @@ class TestProgressFraction : XCTestCase {
         let r = f1 + f2
         XCTAssertFalse(r.overflowed)
     }
+#endif
 }
 #endif
 


### PR DESCRIPTION
Hi Apple,

As a step toward ci, this PR adds a Package.swift that can be used to build “TestFoundation”. This needs to relax the access control on the “internal” _ProgressFraction class to “public" for tests to compile as, as far as I understand @testable is not available on Linux.