### PR TITLE
Truncate fix

### DIFF
--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -142,13 +142,12 @@ open class FileHandle : NSObject, NSSecureCoding {
     open func seek(toFileOffset offset: UInt64) {
         lseek(_fd, off_t(offset), SEEK_SET)
     }
-    
+
     open func truncateFile(atOffset offset: UInt64) {
-        if lseek(_fd, off_t(offset), SEEK_SET) == 0 {
-            ftruncate(_fd, off_t(offset))
-        }
+        if lseek(_fd, off_t(offset), SEEK_SET) < 0 { fatalError("lseek() failed.") }
+        if ftruncate(_fd, off_t(offset)) < 0 { fatalError("ftruncate() failed.") }
     }
-    
+
     open func synchronizeFile() {
         fsync(_fd)
     }

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -297,20 +297,6 @@ class TestProcess : XCTestCase {
 #endif
 }
 
-private func mkstemp(template: String, body: (FileHandle) throws -> Void) rethrows {
-    let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("TestProcess.XXXXXX")
-    
-    try url.withUnsafeFileSystemRepresentation {
-        switch mkstemp(UnsafeMutablePointer(mutating: $0!)) {
-        case -1: XCTFail("Could not create temporary file")
-        case let fd:
-            defer { url.withUnsafeFileSystemRepresentation { _ = unlink($0!) } }
-            try body(FileHandle(fileDescriptor: fd, closeOnDealloc: true))
-        }
-    }
-    
-}
-
 private enum Error: Swift.Error {
     case TerminationStatus(Int32)
     case UnicodeDecodingError(Data)

--- a/TestFoundation/TestUtils.swift
+++ b/TestFoundation/TestUtils.swift
@@ -50,3 +50,16 @@ func ensureFiles(_ fileNames: [String]) -> Bool {
     }
     return result
 }
+
+func mkstemp(template: String, body: (FileHandle) throws -> Void) rethrows {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(template)
+
+    try url.withUnsafeFileSystemRepresentation {
+        switch mkstemp(UnsafeMutablePointer(mutating: $0!)) {
+        case -1: XCTFail("Could not create temporary file")
+        case let fd:
+            defer { url.withUnsafeFileSystemRepresentation { _ = unlink($0!) } }
+            try body(FileHandle(fileDescriptor: fd, closeOnDealloc: true))
+        }
+    }
+}


### PR DESCRIPTION
Originally reported by @DagAgren here https://github.com/apple/swift-corelibs-foundation/pull/1297

- Accepting truncating to any position, not just 0.
- Reposition to the truncate offset.
- Darwin throws exceptions on error so we use fatalError() instead of silently failing.

