### PR TITLE
Require gold on linux and freebsd by default.

### DIFF
--- a/configure
+++ b/configure
@@ -71,6 +71,8 @@ def reconfigure(config, path):
                 config.toolchain = Path(info['toolchain'])
             if 'linker' in info and info['linker'] is not None:
                 config.linker = info['linker']
+            elif config.target is not None:
+                config.linker = config.target.linker
             if 'build_directory' in info and info['build_directory'] is not None:
                 config.build_directory = Path(info['build_directory'])
             if 'intermediate_directory' in info and info['intermediate_directory'] is not None:
@@ -181,7 +183,10 @@ def main():
             config.swift_sdk = "/usr"
         config.toolchain = Path.path(args.toolchain)
         config.pkg_config = args.pkg_config
-        config.linker = args.linker
+        if args.linker is not None:
+            config.linker = args.linker
+        else:
+            config.linker = config.target.linker
         config.bootstrap_directory = Path.path(args.bootstrap)
         config.verbose = args.verbose
         if config.toolchain is not None:

--- a/lib/script.py
+++ b/lib/script.py
@@ -142,6 +142,9 @@ TARGET_LDFLAGS       = --target=${TARGET} ${EXTRA_LD_FLAGS} -L${SDKROOT}/lib/swi
         if Configuration.current.bootstrap_directory is not None:
             ld_flags += """ -L${TARGET_BOOTSTRAP_DIR}/usr/lib"""
 
+        if Configuration.current.build_mode == Configuration.Debug:
+            ld_flags += """  -rpath ${SDKROOT}/lib/swift/""" + Configuration.current.target.swift_sdk_name + """ """
+
         if Configuration.current.linker is not None:
             ld_flags += " -fuse-ld=" + Configuration.current.linker
 

--- a/lib/target.py
+++ b/lib/target.py
@@ -331,14 +331,17 @@ class Target:
     dynamic_library_suffix = ".dylib"
     static_library_prefix = "lib"
     static_library_suffix = ".a"
+    linker = None
 
     def __init__(self, triple):
         if "linux" in triple:
             self.sdk = OSType.Linux
             self.dynamic_library_suffix = ".so"
+            self.linker = "gold"
         elif "freebsd" in triple:
             self.sdk = OSType.FreeBSD
             self.dynamic_library_suffix = ".so"
+            self.linker = "gold"
         elif "windows" in triple or "win32" in triple:
             self.sdk = OSType.Win32
             self.dynamic_library_suffix = ".dll"


### PR DESCRIPTION
This commit just changes the default to require gold. The user can still override from the command line if they choose to.

The reason why I am making this change is to match Swift's behavior here. There
really isn't any good reason to have separate linkers compiling separate parts
of the same build.

rdar://39456714