### PR TITLE
Fix bug of "/" crashing `NSPathUtilities.resolvingSymlinksInPath`

### DIFF
--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -317,7 +317,7 @@ public extension NSString {
         }
         
         // TODO: pathComponents keeps final path separator if any. Check that logic.
-        if components.last == "/" {
+        if components.last == "/" && components.count > 1 {
             components.removeLast()
         }
         


### PR DESCRIPTION
Details of the bug: https://bugs.swift.org/browse/SR-7526.

Tested on Linux 16.04 under Debug configuration.