### PR TITLE
Always use FS representation of String when calling FS syscalls

### DIFF
--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -603,11 +603,10 @@ internal func _NSCreateTemporaryFile(_ filePath: String) throws -> (Int32, Strin
 }
 
 internal func _NSCleanupTemporaryFile(_ auxFilePath: String, _ filePath: String) throws  {
-    if rename(auxFilePath, filePath) != 0 {
-        do {
-            try FileManager.default.removeItem(atPath: auxFilePath)
-        } catch _ {
+    try FileManager.default._fileSystemRepresentation(withPath: auxFilePath, andPath: filePath, {
+        if rename($0, $1) != 0 {
+            try? FileManager.default.removeItem(atPath: auxFilePath)
+            throw _NSErrorWithErrno(errno, reading: false, path: filePath)
         }
-        throw _NSErrorWithErrno(errno, reading: false, path: filePath)
-    }
+    })
 }

--- a/Foundation/URL.swift
+++ b/Foundation/URL.swift
@@ -668,7 +668,9 @@ public struct URL : ReferenceConvertible, Equatable {
     /// File system representation is a null-terminated C string with canonical UTF-8 encoding.
     /// - note: The pointer is not valid outside the context of the block.
     public func withUnsafeFileSystemRepresentation<ResultType>(_ block: (UnsafePointer<Int8>?) throws -> ResultType) rethrows -> ResultType {
-        return try block(_url.fileSystemRepresentation)
+        let fsRep = _url.fileSystemRepresentation
+        defer { fsRep.deallocate() }
+        return try block(fsRep)
     }
     
     // MARK: -


### PR DESCRIPTION
- Update calls to stat(), lstat(), access(), link(), unlink(),
  symlink(), readlink(), rename(), chmod(),  mkdir() and chdir().

- Fix deallocating the fs representation in FileManager._lstatFile(withPath:)
  and URL.withUnsafeFileSystemRepresentation().

- Add FileManager._copySymlink(atPath:toPath:) to copy a symlink
  without the roundtrip via String.