### PR TITLE
[SR-7338] Handle cookies in URLSession

### DIFF
--- a/Foundation/URLSession/Configuration.swift
+++ b/Foundation/URLSession/Configuration.swift
@@ -100,19 +100,29 @@ internal extension URLSession._Configuration {
 
 // Configure NSURLRequests
 internal extension URLSession._Configuration {
-    func configure(request: URLRequest) {
+    func configure(request: URLRequest) -> URLRequest {
         var request = request
         httpAdditionalHeaders?.forEach {
             guard request.value(forHTTPHeaderField: $0.0) == nil else { return }
             request.setValue($0.1, forHTTPHeaderField: $0.0)
         }
+        return setCookies(on: request)
     }
-    func setCookies(on request: URLRequest) {
+
+     func setCookies(on request: URLRequest) -> URLRequest {
+        var request = request
         if httpShouldSetCookies {
-            //TODO: Ask the cookie storage what cookie to set.
+            if let cookieStorage = self.httpCookieStorage, let url = request.url, let cookies = cookieStorage.cookies(for: url) {
+                let cookiesHeaderFields =  HTTPCookie.requestHeaderFields(with: cookies)
+                if let cookieValue = cookiesHeaderFields["Cookie"], cookieValue != "" {
+                    request.addValue(cookieValue, forHTTPHeaderField: "Cookie")
+                }
+            }
         }
+        return request
     }
 }
+
 // Cache Management
 private extension URLSession._Configuration {
     func cachedResponse(forRequest request: URLRequest) -> CachedURLResponse? {

--- a/Foundation/URLSession/URLSession.swift
+++ b/Foundation/URLSession/URLSession.swift
@@ -185,7 +185,7 @@ fileprivate func nextSessionIdentifier() -> Int32 {
 public let NSURLSessionTransferSizeUnknown: Int64 = -1
 
 open class URLSession : NSObject {
-    fileprivate let _configuration: _Configuration
+    internal let _configuration: _Configuration
     fileprivate let multiHandle: _MultiHandle
     fileprivate var nextTaskIdentifier = 1
     internal let workQueue: DispatchQueue 
@@ -384,8 +384,7 @@ fileprivate extension URLSession {
     }
     func createConfiguredRequest(from request: URLSession._Request) -> URLRequest {
         let r = request.createMutableURLRequest()
-        _configuration.configure(request: r)
-        return r
+        return _configuration.configure(request: r)
     }
 }
 extension URLSession._Request {

--- a/Foundation/URLSession/URLSessionConfiguration.swift
+++ b/Foundation/URLSession/URLSessionConfiguration.swift
@@ -43,7 +43,7 @@ open class URLSessionConfiguration : NSObject, NSCopying {
         self.httpShouldSetCookies = true
         self.httpCookieAcceptPolicy = .onlyFromMainDocumentDomain
         self.httpMaximumConnectionsPerHost = 6
-        self.httpCookieStorage = nil
+        self.httpCookieStorage = HTTPCookieStorage.shared
         self.urlCredentialStorage = nil
         self.urlCache = nil
         self.shouldUseExtendedBackgroundIdleMode = false

--- a/Foundation/URLSession/http/HTTPURLProtocol.swift
+++ b/Foundation/URLSession/http/HTTPURLProtocol.swift
@@ -78,6 +78,9 @@ internal class _HTTPURLProtocol: _NativeProtocol {
             fatalError("No URL in request.")
         }
         easyHandle.set(url: url)
+        let session = task?.session as! URLSession
+        let _config = session._configuration
+        easyHandle.set(sessionConfig: _config)
         easyHandle.setAllowedProtocolsToHTTPAndHTTPS()
         easyHandle.set(preferredReceiveBufferSize: Int.max)
         do {

--- a/TestFoundation/HTTPServer.swift
+++ b/TestFoundation/HTTPServer.swift
@@ -389,6 +389,16 @@ public class TestURLSessionServer {
             return _HTTPResponse(response: .OK, headers: "Content-Length: \(text.data(using: .utf8)!.count)", body: text)
         }
 
+        if uri == "/requestCookies" {
+            let text = request.getCommaSeparatedHeaders()
+            return _HTTPResponse(response: .OK, headers: "Content-Length: \(text.data(using: .utf8)!.count)\r\nSet-Cookie: fr=anjd&232; Max-Age=7776000; path=/; domain=127.0.0.1; secure; httponly\r\nSet-Cookie: nm=sddf&232; Max-Age=7776000; path=/; domain=.swift.org; secure; httponly\r\n", body: text)
+        }
+
+        if uri == "/setCookies" {
+            let text = request.getCommaSeparatedHeaders()
+            return _HTTPResponse(response: .OK, headers: "Content-Length: \(text.data(using: .utf8)!.count)", body: text)
+        }
+
         if uri == "/UnitedStates" {
             let value = capitals[String(uri.dropFirst())]!
             let text = request.getCommaSeparatedHeaders()


### PR DESCRIPTION
This PR implements storage of HTTP cookies received as part of the response from the server and setting of appropriate cookies on the URLRequest of the URLSession.  