### PR TITLE
build: add CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,424 @@
+
+cmake_minimum_required(VERSION 3.4.3)
+
+list(APPEND CMAKE_MODULE_PATH
+     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+
+project(Foundation
+        LANGUAGES
+          C)
+enable_testing()
+
+option(FOUNDATION_ENABLE_LIBDISPATCH "Enable GCD Support" YES)
+option(FOUNDATION_PATH_TO_LIBDISPATCH_SOURCE "Path to libdispatch source" "")
+option(FOUNDATION_PATH_TO_LIBDISPATCH_BUILD "Path to libdispatch build" "")
+option(FOUNDATION_PATH_TO_XCTEST_BUILD "Path to XCTest build" "")
+
+find_package(CURL REQUIRED)
+find_package(ICU COMPONENTS uc i18n REQUIRED)
+find_package(LibXml2 REQUIRED)
+find_package(UUID REQUIRED)
+
+include(SwiftSupport)
+include(GNUInstallDirs)
+include(ExternalProject)
+
+ExternalProject_Add(CoreFoundation
+                    SOURCE_DIR
+                      ${CMAKE_CURRENT_SOURCE_DIR}/CoreFoundation
+                    CMAKE_COMMAND
+                      ${CMAKE_COMMAND}
+                    CMAKE_ARGS
+                      -DBUILD_SHARED_LIBS=NO
+                      -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                      -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
+                      -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                      -DCMAKE_INSTALL_LIBDIR=usr/lib
+                      -DCF_DEPLOYMENT_SWIFT=YES
+                      -DCF_ENABLE_LIBDISPATCH=${FOUNDATION_ENABLE_LIBDISPATCH}
+                      -DCF_PATH_TO_LIBDISPATCH_SOURCE=${FOUNDATION_PATH_TO_LIBDISPATCH_SOURCE}
+                      -DCF_PATH_TO_LIBDISPATCH_BUILD=${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD})
+ExternalProject_Get_Property(CoreFoundation install_dir)
+
+set(swift_optimization_flags)
+if(CMAKE_BUILD_TYPE MATCHES Release)
+  set(swift_optimization_flags -O)
+endif()
+
+set(deployment_enable_libdispatch)
+set(libdispatch_cflags)
+set(libdispatch_ldflags)
+if(FOUNDATION_ENABLE_LIBDISPATCH)
+  set(deployment_enable_libdispatch -DDEPLOYMENT_ENABLE_LIBDISPATCH)
+  set(libdispatch_cflags -I;${FOUNDATION_PATH_TO_LIBDISPATCH_SOURCE};-I;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src/swift;-Xcc;-fblocks)
+  set(libdispatch_ldflags -L;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src;-ldispatch)
+endif()
+
+add_swift_library(Foundation
+                  MODULE_NAME
+                    Foundation
+                  MODULE_LINK_NAME
+                    Foundation
+                  MODULE_PATH
+                    ${CMAKE_CURRENT_BINARY_DIR}/swift/Foundation.swiftmodule
+                  OUTPUT
+                    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}Foundation${CMAKE_SHARED_LIBRARY_SUFFIX}
+                  SOURCES
+                    Foundation/AffineTransform.swift
+                    Foundation/Array.swift
+                    Foundation/Boxing.swift
+                    Foundation/Bridging.swift
+                    Foundation/Bundle.swift
+                    Foundation/ByteCountFormatter.swift
+                    Foundation/Calendar.swift
+                    Foundation/CGFloat.swift
+                    Foundation/CharacterSet.swift
+                    Foundation/Codable.swift
+                    Foundation/Data.swift
+                    Foundation/DateComponentsFormatter.swift
+                    Foundation/DateComponents.swift
+                    Foundation/DateFormatter.swift
+                    Foundation/DateIntervalFormatter.swift
+                    Foundation/DateInterval.swift
+                    Foundation/Date.swift
+                    Foundation/Decimal.swift
+                    Foundation/Dictionary.swift
+                    Foundation/EnergyFormatter.swift
+                    Foundation/ExtraStringAPIs.swift
+                    Foundation/FileHandle.swift
+                    Foundation/FileManager.swift
+                    Foundation/Formatter.swift
+                    Foundation/FoundationErrors.swift
+                    Foundation/Host.swift
+                    Foundation/HTTPCookieStorage.swift
+                    Foundation/HTTPCookie.swift
+                    Foundation/IndexPath.swift
+                    Foundation/IndexSet.swift
+                    Foundation/ISO8601DateFormatter.swift
+                    Foundation/JSONEncoder.swift
+                    Foundation/JSONSerialization.swift
+                    Foundation/LengthFormatter.swift
+                    Foundation/Locale.swift
+                    Foundation/MassFormatter.swift
+                    Foundation/MeasurementFormatter.swift
+                    Foundation/Measurement.swift
+                    Foundation/NotificationQueue.swift
+                    Foundation/Notification.swift
+                    Foundation/NSArray.swift
+                    Foundation/NSAttributedString.swift
+                    Foundation/NSCache.swift
+                    Foundation/NSCalendar.swift
+                    Foundation/NSCFArray.swift
+                    Foundation/NSCFBoolean.swift
+                    Foundation/NSCFCharacterSet.swift
+                    Foundation/NSCFDictionary.swift
+                    Foundation/NSCFSet.swift
+                    Foundation/NSCFString.swift
+                    Foundation/NSCharacterSet.swift
+                    Foundation/NSCoder.swift
+                    Foundation/NSComparisonPredicate.swift
+                    Foundation/NSCompoundPredicate.swift
+                    Foundation/NSConcreteValue.swift
+                    Foundation/NSData.swift
+                    Foundation/NSDate.swift
+                    Foundation/NSDecimalNumber.swift
+                    Foundation/NSDictionary.swift
+                    Foundation/NSEnumerator.swift
+                    Foundation/NSError.swift
+                    Foundation/NSExpression.swift
+                    Foundation/NSGeometry.swift
+                    Foundation/NSIndexPath.swift
+                    Foundation/NSIndexSet.swift
+                    Foundation/NSKeyedArchiverHelpers.swift
+                    Foundation/NSKeyedArchiver.swift
+                    Foundation/NSKeyedCoderOldStyleArray.swift
+                    Foundation/NSKeyedUnarchiver.swift
+                    Foundation/NSLocale.swift
+                    Foundation/NSLock.swift
+                    Foundation/NSLog.swift
+                    Foundation/NSMeasurement.swift
+                    Foundation/NSNotification.swift
+                    Foundation/NSNull.swift
+                    Foundation/NSNumber.swift
+                    Foundation/NSObjCRuntime.swift
+                    Foundation/NSObject.swift
+                    Foundation/NSOrderedSet.swift
+                    Foundation/NSPathUtilities.swift
+                    Foundation/NSPersonNameComponents.swift
+                    Foundation/NSPlatform.swift
+                    Foundation/NSPredicate.swift
+                    Foundation/NSRange.swift
+                    Foundation/NSRegularExpression.swift
+                    Foundation/NSSet.swift
+                    Foundation/NSSortDescriptor.swift
+                    Foundation/NSSpecialValue.swift
+                    Foundation/NSStringAPI.swift
+                    Foundation/NSString.swift
+                    Foundation/NSSwiftRuntime.swift
+                    Foundation/NSTextCheckingResult.swift
+                    Foundation/NSTimeZone.swift
+                    Foundation/NSURLError.swift
+                    Foundation/NSURLRequest.swift
+                    Foundation/NSURL.swift
+                    Foundation/NSUUID.swift
+                    Foundation/NSValue.swift
+                    Foundation/NumberFormatter.swift
+                    Foundation/Operation.swift
+                    Foundation/PersonNameComponentsFormatter.swift
+                    Foundation/PersonNameComponents.swift
+                    Foundation/PortMessage.swift
+                    Foundation/Port.swift
+                    Foundation/ProcessInfo.swift
+                    Foundation/Process.swift
+                    Foundation/ProgressFraction.swift
+                    Foundation/Progress.swift
+                    Foundation/PropertyListSerialization.swift
+                    Foundation/ReferenceConvertible.swift
+                    Foundation/RunLoop.swift
+                    Foundation/Scanner.swift
+                    Foundation/Set.swift
+                    Foundation/Stream.swift
+                    Foundation/StringEncodings.swift
+                    Foundation/String.swift
+                    Foundation/Thread.swift
+                    Foundation/Timer.swift
+                    Foundation/TimeZone.swift
+                    Foundation/Unit.swift
+                    Foundation/URLAuthenticationChallenge.swift
+                    Foundation/URLCache.swift
+                    Foundation/URLComponents.swift
+                    Foundation/URLCredentialStorage.swift
+                    Foundation/URLCredential.swift
+                    Foundation/URLProtectionSpace.swift
+                    Foundation/URLProtocol.swift
+                    Foundation/URLRequest.swift
+                    Foundation/URLResponse.swift
+                    # NOTE: must precede HTTPMessage.swift
+                    Foundation/URLSession/Message.swift
+                    Foundation/URLSession/http/HTTPMessage.swift
+                    Foundation/URLSession/http/HTTPURLProtocol.swift
+                    Foundation/URLSession/libcurl/EasyHandle.swift
+                    Foundation/URLSession/libcurl/libcurlHelpers.swift
+                    Foundation/URLSession/libcurl/MultiHandle.swift
+                    Foundation/URLSession/BodySource.swift
+                    Foundation/URLSession/Configuration.swift
+                    # Foundation/URLSession/Message.swift
+                    Foundation/URLSession/NativeProtocol.swift
+                    Foundation/URLSession/TaskRegistry.swift
+                    Foundation/URLSession/TransferState.swift
+                    Foundation/URLSession/URLSessionConfiguration.swift
+                    Foundation/URLSession/URLSessionDelegate.swift
+                    Foundation/URLSession/URLSession.swift
+                    Foundation/URLSession/URLSessionTask.swift
+                    Foundation/URL.swift
+                    Foundation/UserDefaults.swift
+                    Foundation/UUID.swift
+                    Foundation/XMLDocument.swift
+                    Foundation/XMLDTDNode.swift
+                    Foundation/XMLDTD.swift
+                    Foundation/XMLElement.swift
+                    Foundation/XMLNode.swift
+                    Foundation/XMLParser.swift
+                  TARGET
+                    ${CMAKE_C_COMPILER_TARGET}
+                  CFLAGS
+                    ${deployment_enable_libdispatch}
+                  LINK_FLAGS
+                    -L${install_dir}/usr/lib
+                    -lCoreFoundation
+                    ${CURL_LIBRARIES}
+                    ${ICU_UC_LIBRARIES} ${ICU_I18N_LIBRARIES}
+                    ${LIBXML2_LIBRARIES}
+                    ${libdispatch_ldflags}
+                    ${uuid_LIBRARIES}
+                  SWIFT_FLAGS
+                    -DDEPLOYMENT_RUNTIME_SWIFT
+                    ${deployment_enable_libdispatch}
+                    -Fsystem;${install_dir}/System/Library/Frameworks
+                    ${libdispatch_cflags}
+                    ${swift_optimization_flags})
+add_dependencies(Foundation CoreFoundation)
+
+add_swift_executable(plutil
+                     SOURCES
+                       Tools/plutil/main.swift
+                     CFLAGS
+                       ${deployment_enable_libdispatch}
+                     LINK_FLAGS
+                       -L${CMAKE_CURRENT_BINARY_DIR}
+                       -lFoundation
+                     SWIFT_FLAGS
+                       -DDEPLOYMENT_RUNTIME_SWIFT
+                       ${deployment_enable_libdispatch}
+                       -Fsystem;${install_dir}/System/Library/Frameworks
+                       -I;${CMAKE_CURRENT_BINARY_DIR}/swift
+                       ${libdispatch_cflags}
+                       ${swift_optimization_flags})
+add_dependencies(plutil Foundation CoreFoundation)
+
+if(ENABLE_TESTING)
+  add_swift_executable(TestFoundation
+                       SOURCES
+                         TestFoundation/main.swift
+                         TestFoundation/HTTPServer.swift
+                         Foundation/ProgressFraction.swift
+                         # Test Cases
+                         TestFoundation/TestAffineTransform.swift
+                         TestFoundation/TestBundle.swift
+                         TestFoundation/TestByteCountFormatter.swift
+                         TestFoundation/TestCalendar.swift
+                         TestFoundation/TestCharacterSet.swift
+                         TestFoundation/TestCodable.swift
+                         TestFoundation/TestDateFormatter.swift
+                         TestFoundation/TestDate.swift
+                         TestFoundation/TestDecimal.swift
+                         TestFoundation/TestEnergyFormatter.swift
+                         TestFoundation/TestFileHandle.swift
+                         TestFoundation/TestFileManager.swift
+                         TestFoundation/TestHost.swift
+                         TestFoundation/TestHTTPCookieStorage.swift
+                         TestFoundation/TestHTTPCookie.swift
+                         TestFoundation/TestImports.swift
+                         TestFoundation/TestIndexPath.swift
+                         TestFoundation/TestIndexSet.swift
+                         TestFoundation/TestISO8601DateFormatter.swift
+                         TestFoundation/TestJSONEncoder.swift
+                         TestFoundation/TestJSONSerialization.swift
+                         TestFoundation/TestLengthFormatter.swift
+                         TestFoundation/TestMassFormatter.swift
+                         TestFoundation/TestNotificationCenter.swift
+                         TestFoundation/TestNotificationQueue.swift
+                         TestFoundation/TestNotification.swift
+                         TestFoundation/TestNSArray.swift
+                         TestFoundation/TestNSAttributedString.swift
+                         TestFoundation/TestNSCache.swift
+                         TestFoundation/TestNSCompoundPredicate.swift
+                         TestFoundation/TestNSData.swift
+                         TestFoundation/TestNSDictionary.swift
+                         TestFoundation/TestNSError.swift
+                         TestFoundation/TestNSGeometry.swift
+                         TestFoundation/TestNSKeyedArchiver.swift
+                         TestFoundation/TestNSKeyedUnarchiver.swift
+                         TestFoundation/TestNSLocale.swift
+                         TestFoundation/TestNSLock.swift
+                         TestFoundation/TestNSNull.swift
+                         TestFoundation/TestNSNumberBridging.swift
+                         TestFoundation/TestNSNumber.swift
+                         TestFoundation/TestNSOrderedSet.swift
+                         TestFoundation/TestNSPredicate.swift
+                         TestFoundation/TestNSProgressFraction.swift
+                         TestFoundation/TestNSRange.swift
+                         TestFoundation/TestNSRegularExpression.swift
+                         TestFoundation/TestNSSet.swift
+                         TestFoundation/TestNSString.swift
+                         TestFoundation/TestNSTextCheckingResult.swift
+                         TestFoundation/TestNSURLRequest.swift
+                         TestFoundation/TestNSUUID.swift
+                         TestFoundation/TestNSValue.swift
+                         TestFoundation/TestNumberFormatter.swift
+                         TestFoundation/TestObjCRuntime.swift
+                         TestFoundation/TestOperationQueue.swift
+                         TestFoundation/TestPersonNameComponents.swift
+                         TestFoundation/TestPipe.swift
+                         TestFoundation/TestProcessInfo.swift
+                         TestFoundation/TestProcess.swift
+                         TestFoundation/TestProgress.swift
+                         TestFoundation/TestPropertyListSerialization.swift
+                         TestFoundation/TestRunLoop.swift
+                         TestFoundation/TestScanner.swift
+                         TestFoundation/TestStream.swift
+                         TestFoundation/TestThread.swift
+                         TestFoundation/TestTimer.swift
+                         TestFoundation/TestTimeZone.swift
+                         TestFoundation/TestUnitConverter.swift
+                         TestFoundation/TestUnit.swift
+                         TestFoundation/TestURLCredential.swift
+                         TestFoundation/TestURLProtocol.swift
+                         TestFoundation/TestURLRequest.swift
+                         TestFoundation/TestURLResponse.swift
+                         TestFoundation/TestURLSession.swift
+                         TestFoundation/TestURL.swift
+                         TestFoundation/TestUserDefaults.swift
+                         TestFoundation/TestUtils.swift
+                         TestFoundation/TestXMLDocument.swift
+                         TestFoundation/TestXMLParser.swift
+                       CFLAGS
+                         ${deployment_enable_libdispatch}
+                       LINK_FLAGS
+                         ${libdispatch_ldflags}
+                         -L${CMAKE_CURRENT_BINARY_DIR}
+                         -lFoundation
+                         -L${FOUNDATION_PATH_TO_XCTEST_BUILD}
+                       RESOURCES
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/Info.plist
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSURLTestData.plist
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/Test.plist
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSStringTestData.txt
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSString-UTF16-BE-data.txt
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSString-UTF16-LE-data.txt
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSString-UTF32-BE-data.txt
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSString-UTF32-LE-data.txt
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSString-ISO-8859-1-data.txt
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSXMLDocumentTestData.xml
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/PropertyList-1.0.dtd
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSXMLDTDTestData.xml
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSKeyedUnarchiver-ArrayTest.plist
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSKeyedUnarchiver-ComplexTest.plist
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSKeyedUnarchiver-ConcreteValueTest.plist
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSKeyedUnarchiver-EdgeInsetsTest.plist
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSKeyedUnarchiver-NotificationTest.plist
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSKeyedUnarchiver-RangeTest.plist
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSKeyedUnarchiver-RectTest.plist
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSKeyedUnarchiver-URLTest.plist
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSKeyedUnarchiver-UUIDTest.plist
+                         ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSKeyedUnarchiver-OrderedSetTest.plist
+                       SWIFT_FLAGS
+                         ${deployment_enable_libdispatch}
+                         -Fsystem;${install_dir}/System/Library/Frameworks
+                         -I;${CMAKE_CURRENT_BINARY_DIR}/swift
+                         -I;${FOUNDATION_PATH_TO_XCTEST_BUILD}/swift
+                         ${libdispatch_cflags}
+                         ${swift_optimization_flags})
+  add_dependencies(TestFoundation Foundation CoreFoundation)
+
+  add_swift_executable(xdgTestHelper
+                       SOURCES
+                         TestFoundation/xdgTestHelper/main.swift
+                       CFLAGS
+                         ${deployment_enable_libdispatch}
+                       LINK_FLAGS
+                         -L${CMAKE_CURRENT_BINARY_DIR}
+                         -lFoundation
+                       SWIFT_FLAGS
+                         -Fsystem;${install_dir}/System/Library/Frameworks
+                         -I;${CMAKE_CURRENT_BINARY_DIR}/swift
+                         ${libdispatch_cflags})
+  add_dependencies(xdgTestHelper Foundation CoreFoundation)
+
+  add_test(NAME
+             TestFoundation
+           COMMAND
+             ${CMAKE_CURRENT_BINARY_DIR}/TestFoundation/TestFoundation
+           WORKING_DIRECTORY
+             ${CMAKE_CURRENT_BINARY_DIR}/TestFoundation)
+  set_tests_properties(TestFoundation
+                       PROPERTIES
+                         ENVIRONMENT
+                           LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:${FOUNDATION_PATH_TO_XCTEST_BUILD}:${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src)
+endif()
+
+install(FILES
+          ${CMAKE_CURRENT_BINARY_DIR}/swift/Foundation.swiftdoc
+          ${CMAKE_CURRENT_BINARY_DIR}/swift/Foundation.swiftmodule
+        DESTINATION
+          ${CMAKE_INSTALL_FULL_LIBDIR}/swift/${CMAKE_SYSTEM_NAME}/${CMAKE_SYSTEM_PROCESSOR})
+install(FILES
+          ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}Foundation${CMAKE_SHARED_LIBRARY_SUFFIX}
+        DESTINATION
+          ${CMAKE_INSTALL_FULL_LIBDIR})
+install(FILES
+          ${CMAKE_CURRENT_BINARY_DIR}/plutil
+        DESTINATION
+          ${CMAKE_INSTALL_FULL_BINDIR})
+

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -1,0 +1,430 @@
+
+cmake_minimum_required(VERSION 3.4.3)
+list(APPEND CMAKE_MODULE_PATH
+     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+
+project(CoreFoundation
+        VERSION
+          1338
+        LANGUAGES
+          ASM C)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED YES)
+
+# TODO(compnerd): this should be re-enabled once CoreFoundation annotations have
+# been reconciled.  Hidden visibility should ensure that internal interfaces are
+# not accidentally exposed on platforms without exports lists and explicit
+# annotations (i.e. ELFish and MachO targets).
+if(0)
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_C_VISIBILITY_INLINES_HIDDEN ON)
+endif()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE YES)
+
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads)
+
+include(GNUInstallDirs)
+include(CoreFoundationAddFramework)
+
+option(CF_ENABLE_LIBDISPATCH "Enable GCD Support" YES)
+option(CF_PATH_TO_LIBDISPATCH_SOURCE "Path to libdispatch source")
+option(CF_PATH_TO_LIBDISPATCH_BUILD "Path to libdispatch build")
+option(CF_DEPLOYMENT_SWIFT "Build for swift" NO)
+
+if(BUILD_SHARED_LIBS)
+  set(FRAMEWORK_LIBRARY_TYPE SHARED)
+else()
+  set(FRAMEWORK_LIBRARY_TYPE STATIC)
+endif()
+
+add_framework(CoreFoundation
+                ${FRAMEWORK_LIBRARY_TYPE}
+              FRAMEWORK_DIRECTORY
+                CoreFoundation_FRAMEWORK_DIRECTORY
+              MODULE_MAP
+                Base.subproj/module.modulemap
+              PRIVATE_HEADERS
+                # Base
+                Base.subproj/CFAsmMacros.h
+                Base.subproj/CFInternal.h
+                Base.subproj/CFKnownLocations.h
+                Base.subproj/CFLogUtilities.h
+                Base.subproj/CFPriv.h
+                Base.subproj/CFRuntime.h
+                Base.subproj/ForFoundationOnly.h
+                Base.subproj/ForSwiftFoundationOnly.h
+                # Collections
+                Collections.subproj/CFBasicHash.h
+                Collections.subproj/CFStorage.h
+                # Error
+                Error.subproj//CFError_Private.h
+                # Locale
+                Locale.subproj/CFDateFormatter_Private.h
+                Locale.subproj/CFICULogging.h
+                Locale.subproj/CFLocaleInternal.h
+                Locale.subproj/CFLocale_Private.h
+                # NumberDate
+                NumberDate.subproj/CFBigNumber.h
+                # Parsing
+                Parsing.subproj/CFPropertyList_Private.h
+                Parsing.subproj/CFXMLInputStream.h
+                Parsing.subproj/CFXMLInterface.h
+                # PlugIn
+                PlugIn.subproj/CFBundlePriv.h
+                PlugIn.subproj/CFBundle_BinaryTypes.h
+                PlugIn.subproj/CFBundle_Internal.h
+                PlugIn.subproj/CFPlugIn_Factory.h
+                # Stream
+                Stream.subproj/CFStreamAbstract.h
+                Stream.subproj/CFStreamInternal.h
+                Stream.subproj/CFStreamPriv.h
+                # String
+                String.subproj/CFBurstTrie.h
+                String.subproj/CFCharacterSetPriv.h
+                String.subproj/CFRegularExpression.h
+                String.subproj/CFRunArray.h
+                String.subproj/CFStringDefaultEncoding.h
+                String.subproj/CFStringLocalizedFormattingInternal.h
+                # StringEncodings
+                StringEncodings.subproj/CFICUConverters.h
+                StringEncodings.subproj/CFStringEncodingConverter.h
+                StringEncodings.subproj/CFStringEncodingConverterExt.h
+                StringEncodings.subproj/CFStringEncodingConverterPriv.h
+                StringEncodings.subproj/CFStringEncodingDatabase.h
+                StringEncodings.subproj/CFUniChar.h
+                StringEncodings.subproj/CFUniCharPriv.h
+                StringEncodings.subproj/CFUnicodeDecomposition.h
+                StringEncodings.subproj/CFUnicodePrecomposition.h
+                # URL
+                URL.subproj/CFURL.inc.h
+                URL.subproj/CFURLPriv.h
+                URL.subproj/CFURLSessionInterface.h
+              PUBLIC_HEADERS
+                # FIXME: PrivateHeaders referenced by public headers
+                Base.subproj/CFKnownLocations.h
+                Base.subproj/CFLogUtilities.h
+                Base.subproj/CFPriv.h
+                Base.subproj/CFRuntime.h
+                Base.subproj/ForFoundationOnly.h
+                Base.subproj/ForSwiftFoundationOnly.h
+                Locale.subproj/CFLocaleInternal.h
+                Parsing.subproj/CFXMLInterface.h
+                PlugIn.subproj/CFBundlePriv.h
+                Stream.subproj/CFStreamPriv.h
+                String.subproj/CFRegularExpression.h
+                String.subproj/CFRunArray.h
+                URL.subproj/CFURLPriv.h
+                URL.subproj/CFURLSessionInterface.h
+
+                # AppServices
+                AppServices.subproj/CFNotificationCenter.h
+                AppServices.subproj/CFUserNotification.h
+                # Base
+                Base.subproj/CFAvailability.h
+                Base.subproj/CFBase.h
+                Base.subproj/CFByteOrder.h
+                Base.subproj/CFUUID.h
+                Base.subproj/CFUtilities.h
+                Base.subproj/SwiftRuntime/CoreFoundation.h
+                Base.subproj/SwiftRuntime/TargetConditionals.h
+                # Collections
+                Collections.subproj/CFArray.h
+                Collections.subproj/CFBag.h
+                Collections.subproj/CFBinaryHeap.h
+                Collections.subproj/CFBitVector.h
+                Collections.subproj/CFData.h
+                Collections.subproj/CFDictionary.h
+                Collections.subproj/CFSet.h
+                Collections.subproj/CFTree.h
+                # Error
+                Error.subproj/CFError.h
+                # Locale
+                Locale.subproj/CFCalendar.h
+                Locale.subproj/CFDateFormatter.h
+                Locale.subproj/CFLocale.h
+                Locale.subproj/CFNumberFormatter.h
+                # NumberDate
+                NumberDate.subproj/CFDate.h
+                NumberDate.subproj/CFNumber.h
+                NumberDate.subproj/CFTimeZone.h
+                # Parsing
+                Parsing.subproj/CFPropertyList.h
+                Parsing.subproj/CFXMLNode.h
+                Parsing.subproj/CFXMLParser.h
+                # PlugIn
+                PlugIn.subproj/CFBundle.h
+                PlugIn.subproj/CFPlugIn.h
+                PlugIn.subproj/CFPlugInCOM.h
+                # Preferences
+                Preferences.subproj/CFPreferences.h
+                # RunLoop
+                RunLoop.subproj/CFMachPort.h
+                RunLoop.subproj/CFMessagePort.h
+                RunLoop.subproj/CFRunLoop.h
+                RunLoop.subproj/CFSocket.h
+                # Stream
+                Stream.subproj/CFStream.h
+                # String
+                String.subproj/CFAttributedString.h
+                String.subproj/CFCharacterSet.h
+                String.subproj/CFString.h
+                String.subproj/CFStringEncodingExt.h
+                # URL
+                URL.subproj/CFURL.h
+                URL.subproj/CFURLAccess.h
+                URL.subproj/CFURLComponents.h
+              SOURCES
+                # Base
+                Base.subproj/CFBase.c
+                Base.subproj/CFFileUtilities.c
+                Base.subproj/CFKnownLocations.c
+                Base.subproj/CFPlatform.c
+                Base.subproj/CFRuntime.c
+                Base.subproj/CFSortFunctions.c
+                Base.subproj/CFSystemDirectories.c
+                Base.subproj/CFUtilities.c
+                Base.subproj/CFUUID.c
+                # Collections
+                Collections.subproj/CFArray.c
+                Collections.subproj/CFBag.c
+                Collections.subproj/CFBasicHash.c
+                Collections.subproj/CFBinaryHeap.c
+                Collections.subproj/CFBitVector.c
+                Collections.subproj/CFData.c
+                Collections.subproj/CFDictionary.c
+                Collections.subproj/CFSet.c
+                Collections.subproj/CFStorage.c
+                Collections.subproj/CFTree.c
+                # Error
+                Error.subproj/CFError.c
+                # Locale
+                Locale.subproj/CFCalendar.c
+                Locale.subproj/CFDateFormatter.c
+                Locale.subproj/CFLocale.c
+                Locale.subproj/CFLocaleIdentifier.c
+                Locale.subproj/CFLocaleKeys.c
+                Locale.subproj/CFNumberFormatter.c
+                # NumberData
+                NumberDate.subproj/CFBigNumber.c
+                NumberDate.subproj/CFDate.c
+                NumberDate.subproj/CFNumber.c
+                NumberDate.subproj/CFTimeZone.c
+                # Parsring
+                Parsing.subproj/CFBinaryPList.c
+                Parsing.subproj/CFOldStylePList.c
+                Parsing.subproj/CFPropertyList.c
+                Parsing.subproj/CFXMLInputStream.c
+                Parsing.subproj/CFXMLNode.c
+                Parsing.subproj/CFXMLParser.c
+                Parsing.subproj/CFXMLTree.c
+                Parsing.subproj/CFXMLInterface.c
+                # PlugIn
+                PlugIn.subproj/CFBundle_Binary.c
+                PlugIn.subproj/CFBundle.c
+                PlugIn.subproj/CFBundle_DebugStrings.c
+                PlugIn.subproj/CFBundle_Executable.c
+                PlugIn.subproj/CFBundle_Grok.c
+                PlugIn.subproj/CFBundle_InfoPlist.c
+                PlugIn.subproj/CFBundle_Locale.c
+                PlugIn.subproj/CFBundle_Main.c
+                PlugIn.subproj/CFBundle_ResourceFork.c
+                PlugIn.subproj/CFBundle_Resources.c
+                PlugIn.subproj/CFBundle_Strings.c
+                PlugIn.subproj/CFPlugIn.c
+                PlugIn.subproj/CFPlugIn_Factory.c
+                PlugIn.subproj/CFPlugIn_Instance.c
+                PlugIn.subproj/CFPlugIn_PlugIn.c
+                # Preferences
+                Preferences.subproj/CFApplicationPreferences.c
+                Preferences.subproj/CFPreferences.c
+                Preferences.subproj/CFXMLPreferencesDomain.c
+                # RunLoop
+                RunLoop.subproj/CFRunLoop.c
+                RunLoop.subproj/CFSocket.c
+                # Stream
+                Stream.subproj/CFConcreteStreams.c
+                Stream.subproj/CFSocketStream.c
+                Stream.subproj/CFStream.c
+                # String
+                String.subproj/CFAttributedString.c
+                String.subproj/CFBurstTrie.c
+                String.subproj/CFCharacterSet.c
+                String.subproj/CFCharacterSetData.S
+                String.subproj/CFRegularExpression.c
+                String.subproj/CFRunArray.c
+                String.subproj/CFString.c
+                String.subproj/CFStringEncodings.c
+                String.subproj/CFStringScanner.c
+                String.subproj/CFStringTransform.c
+                String.subproj/CFStringUtilities.c
+                String.subproj/CFUniCharPropertyDatabase.S
+                String.subproj/CFUnicodeData.S
+                # StringEncodings
+                StringEncodings.subproj/CFBuiltinConverters.c
+                StringEncodings.subproj/CFICUConverters.c
+                StringEncodings.subproj/CFPlatformConverters.c
+                StringEncodings.subproj/CFStringEncodingConverter.c
+                StringEncodings.subproj/CFStringEncodingDatabase.c
+                StringEncodings.subproj/CFUniChar.c
+                StringEncodings.subproj/CFUnicodeDecomposition.c
+                StringEncodings.subproj/CFUnicodePrecomposition.c
+                # URL
+                URL.subproj/CFURL.c
+                URL.subproj/CFURLAccess.c
+                URL.subproj/CFURLComponents.c
+                URL.subproj/CFURLComponents_URIParser.c
+                URL.subproj/CFURLSessionInterface.c)
+if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android)
+  target_compile_definitions(CoreFoundation
+                             PRIVATE
+                               -DDEPLOYMENT_TARGET_LINUX
+                               -D_GNU_SOURCE)
+elseif(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+  target_compile_definitions(CoreFoundation
+                             PRIVATE
+                               -DDEPLOYMENT_TARGET_FREEBSD)
+elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_compile_definitions(CoreFoundation
+                             PRIVATE
+                               -DDEPLOYMENT_TARGET_MACOSX)
+endif()
+target_compile_definitions(CoreFoundation
+                           PRIVATE
+                             -DU_SHOW_DRAFT_API
+                             -DCF_BUILDING_CF)
+if(CF_ENABLE_LIBDISPATCH)
+  target_compile_definitions(CoreFoundation
+                             PRIVATE
+                               -DDEPLOYMENT_ENABLE_LIBDISPATCH)
+endif()
+if(CF_DEPLOYMENT_SWIFT)
+  target_compile_definitions(CoreFoundation
+                             PRIVATE
+                               -DDEPLOYMENT_RUNTIME_SWIFT)
+else()
+  target_compile_definitions(CoreFoundation
+                             PRIVATE
+                               -DDEPLOYMENT_RUNTIME_C)
+endif()
+target_compile_definitions(CoreFoundation
+                           PRIVATE
+                              $<$<COMPILE_LANGUAGE:ASM>:CF_CHARACTERSET_BITMAP="CharacterSets/CFCharacterSetBitmaps.bitmap">
+                              $<$<COMPILE_LANGUAGE:ASM>:CF_CHARACTERSET_UNICHAR_DB="CharacterSets/CFUniCharPropertyDatabase.data">
+                              $<$<COMPILE_LANGUAGE:ASM>:CF_CHARACTERSET_UNICODE_DATA_B="CharacterSets/CFUnicodeData-B.mapping">
+                              $<$<COMPILE_LANGUAGE:ASM>:CF_CHARACTERSET_UNICODE_DATA_L="CharacterSets/CFUnicodeData-L.mapping">)
+if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+  # FIXME(compnerd) why is /usr/local/include added manually?  clang will do so
+  target_include_directories(CoreFoundation
+                             PRIVATE
+                               "/usr/local/include"
+                               "/usr/local/include/libxml2"
+                               "/usr/local/include/curl")
+endif()
+target_include_directories(CoreFoundation
+                           PRIVATE
+                             ${CMAKE_SOURCE_DIR})
+if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android)
+  find_package(LibXml2 REQUIRED)
+  target_include_directories(CoreFoundation
+                             PRIVATE
+                               ${LIBXML2_INCLUDE_DIR})
+  find_package(CURL REQUIRED)
+  target_include_directories(CoreFoundation
+                             PRIVATE
+                               ${CURL_INCLUDE_DIRS})
+else()
+  target_include_directories(CoreFoundation
+                             PRIVATE
+                               "/usr/include"
+                               "/usr/include/libxml2")
+endif()
+target_compile_options(CoreFoundation
+                       PRIVATE
+                         $<$<COMPILE_LANGUAGE:C>:-include;${CMAKE_SOURCE_DIR}/Base.subproj/CoreFoundation_Prefix.h>)
+target_compile_options(CoreFoundation
+                       PRIVATE
+                         -fblocks
+                         -fconstant-cfstrings
+                         -fdollars-in-identifiers
+                         -fexceptions)
+target_compile_options(CoreFoundation
+                       PRIVATE
+                         -Wno-shorten-64-to-32
+                         -Wno-deprecated-declarations
+                         -Wno-unreachable-code
+                         -Wno-conditional-uninitialized
+                         -Wno-unused-variable
+                         -Wno-int-conversion
+                         -Wno-unused-function)
+if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android)
+  target_link_libraries(CoreFoundation
+                        PRIVATE
+                          ${CURL_LIBRARIES}
+                          ${LIBXML2_LIBRARIES})
+else()
+  target_link_libraries(CoreFoundation
+                        PRIVATE
+                          curl
+                          xml2)
+endif()
+if(CMAKE_SYSTEM_NAME STREQUAL Android)
+  target_link_libraries(CoreFoundation
+                        PRIVATE
+                          log)
+endif()
+target_link_libraries(CoreFoundation
+                      PRIVATE
+                        Threads::Threads
+                        ${CMAKE_DL_LIBS})
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
+  target_link_libraries(CoreFoundation
+                        PRIVATE
+                          m)
+endif()
+if(CF_ENABLE_LIBDISPATCH)
+  target_link_libraries(CoreFoundation
+                        PRIVATE
+                          dispatch)
+endif()
+if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android)
+  set_target_properties(CoreFoundation
+                        PROPERTIES LINK_FLAGS
+                          -Xlinker;@${CMAKE_SOURCE_DIR}/linux.ld;-Bsymbolic)
+elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_libraries(CoreFoundation
+                        PRIVATE
+                          icucore)
+  set_target_properties(CoreFoundation
+                        PROPERTIES LINK_FLAGS
+                          -Xlinker;-alias_list;-Xlinker;Base.subproj/DarwinSymbolAliases;-twolevel_namespace;-sectcreate;__UNICODE;__csbitmaps;CharacterSets/CFCharacterSetBitmaps.bitmap;-sectcreate;__UNICODE;__properties;CharacterSets/CFUniCharPropertyDatabase.data;-sectcreate;__UNICODE;__data;CharacterSets/CFUnicodeData-L.mapping;-segprot;__UNICODE;r;r)
+endif()
+
+install(TARGETS
+          CoreFoundation
+        DESTINATION
+          "${CMAKE_INSTALL_FULL_LIBDIR}")
+install(DIRECTORY
+          ${CoreFoundation_FRAMEWORK_DIRECTORY}
+        DESTINATION
+          ${CMAKE_INSTALL_PREFIX}/System/Library/Frameworks
+        USE_SOURCE_PERMISSIONS
+        PATTERN PrivateHeaders EXCLUDE)
+
+
+# TODO(compnerd) formalize this
+if(CF_ENABLE_LIBDISPATCH)
+  target_include_directories(CoreFoundation
+                             PRIVATE
+                               ${CF_PATH_TO_LIBDISPATCH_SOURCE}
+                               ${CF_PATH_TO_LIBDISPATCH_BUILD}/tests)
+  if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android)
+    target_include_directories(CoreFoundation
+                               SYSTEM PRIVATE
+                                 ${CF_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
+  endif()
+endif()
+

--- a/CoreFoundation/cmake/modules/CoreFoundationAddFramework.cmake
+++ b/CoreFoundation/cmake/modules/CoreFoundationAddFramework.cmake
@@ -1,0 +1,65 @@
+
+include(CMakeParseArguments)
+
+function(add_framework NAME)
+  set(options STATIC SHARED)
+  set(single_value_args MODULE_MAP FRAMEWORK_DIRECTORY)
+  set(multiple_value_args PRIVATE_HEADERS PUBLIC_HEADERS SOURCES)
+  cmake_parse_arguments(AF "${options}" "${single_value_args}" "${multiple_value_args}" ${ARGN})
+
+  set(AF_TYPE)
+  if(AF_STATIC)
+    set(AF_TYPE STATIC)
+  elseif(AF_SHARED)
+    set(AF_TYPE SHARED)
+  endif()
+
+  if(AF_MODULE_MAP)
+    file(COPY
+           ${AF_MODULE_MAP}
+         DESTINATION
+           ${CMAKE_BINARY_DIR}/${NAME}.framework/Modules
+         NO_SOURCE_PERMISSIONS)
+  endif()
+  if(AF_PUBLIC_HEADERS)
+    file(COPY
+           ${AF_PUBLIC_HEADERS}
+         DESTINATION
+           ${CMAKE_BINARY_DIR}/${NAME}.framework/Headers
+         NO_SOURCE_PERMISSIONS)
+  endif()
+  if(AF_PRIVATE_HEADERS)
+    file(COPY
+           ${AF_PRIVATE_HEADERS}
+         DESTINATION
+           ${CMAKE_BINARY_DIR}/${NAME}.framework/PrivateHeaders
+         NO_SOURCE_PERMISSIONS)
+  endif()
+  add_custom_target(${NAME}_POPULATE_HEADERS
+                    DEPENDS
+                      ${AF_MODULE_MAP}
+                      ${AF_PUBLIC_HEADERS}
+                      ${AF_PRIVATE_HEADERS}
+                    SOURCES
+                      ${AF_MODULE_MAP}
+                      ${AF_PUBLIC_HEADERS}
+                      ${AF_PRIVATE_HEADERS})
+
+  add_library(${NAME}
+              ${AF_TYPE}
+              ${AF_SOURCES})
+  set_target_properties(${NAME}
+                        PROPERTIES
+                          LIBRARY_OUTPUT_DIRECTORY
+                              ${CMAKE_BINARY_DIR}/${NAME}.framework)
+  target_compile_options(${NAME}
+                         PRIVATE
+                           -F;${CMAKE_BINARY_DIR}
+                           -I;${CMAKE_BINARY_DIR}/${NAME}.framework/PrivateHeaders)
+  add_dependencies(${NAME} ${NAME}_POPULATE_HEADERS)
+
+  if(AF_FRAMEWORK_DIRECTORY)
+    set(${AF_FRAMEWORK_DIRECTORY} ${CMAKE_BINARY_DIR}/${NAME}.framework PARENT_SCOPE)
+  endif()
+endfunction()
+

--- a/Docs/GettingStarted.md
+++ b/Docs/GettingStarted.md
@@ -81,3 +81,16 @@ When new source files or flags are added to the `build.py` script, the project w
 % ninja reconfigure
 % ninja
 ```
+
+It is possible to build Foundation without the use of `build-script`.  You can
+build with cmake.  It currently requires clang, swift, and libdispatch (which
+are generally built as part of the swift build).
+
+```
+cmake -G Ninja ../../../swift-corelibs-foundation                               \
+ -DCMAKE_C_COMPILER=../../llvm-linux-x86_64/bin/clang                           \
+ -DCMAKE_SWIFT_COMPILER=../../swift-linux-x86_64/bin/swiftc                     \
+ -DFOUNDATION_PATH_TO_LIBDISPATCH_SOURCE=../../../swift-corelibs-libdispatch    \
+ -DFOUNDATION_PATH_TO_LIBDISPATCH_BUILD=../../libdispatch-linux-x86_64
+```
+

--- a/cmake/modules/FindUUID.cmake
+++ b/cmake/modules/FindUUID.cmake
@@ -1,0 +1,52 @@
+#.rst
+# FindUUID
+# --------
+#
+# Find libuuid library and headers
+#
+# The module defines the following variables:
+#
+# ::
+#
+#   uuid_FOUND        - true if libuuid was found
+#   uuid_INCLUDE_DIRS - include search path
+#   uuid_LIBRARIES    - libraries to link
+
+if(uuid_INCLUDE_DIRS AND uuid_LIBRARIES)
+  set(uuid_FOUND TRUE)
+else()
+  find_package(PkgConfig QUIET)
+  pkg_check_modules(PC_UUID QUIET uuid)
+
+  find_path(uuid_INCLUDE_DIRS
+            NAMES
+              uuid.h
+              uuid/uuid.h
+            HINTS
+              ${PC_UUID_INCLUDEDIR}
+              ${PC_UUID_INCLUDE_DIRS}
+              ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    find_library(uuid_LIBRARIES
+                 NAMES
+                   uuid
+                 HINTS
+                   ${PC_UUID_LIBDIR}
+                   ${PC_UUID_LIBRARY_DIRS}
+                   ${CMAKE_INSTALL_FULL_LIBDIR})
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    find_package_handle_standard_args(uuid
+                                      REQUIRED_VARS
+                                        uuid_INCLUDE_DIRS)
+  else()
+    find_package_handle_standard_args(uuid
+                                      REQUIRED_VARS
+                                        uuid_INCLUDE_DIRS
+                                        uuid_LIBRARIES)
+  endif()
+  mark_as_advanced(uuid_INCLUDE_DIRS uuid_LIBRARIES)
+endif()
+

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -1,0 +1,154 @@
+
+include(CMakeParseArguments)
+
+function(add_swift_target target)
+  set(options LIBRARY)
+  set(single_value_options MODULE_NAME;MODULE_LINK_NAME;MODULE_PATH;MODULE_CACHE_PATH;OUTPUT;TARGET)
+  set(multiple_value_options CFLAGS;DEPENDS;LINK_FLAGS;RESOURCES;SOURCES;SWIFT_FLAGS)
+
+  cmake_parse_arguments(AST "${options}" "${single_value_options}" "${multiple_value_options}" ${ARGN})
+
+  set(flags ${CMAKE_SWIFT_FLAGS})
+  set(link_flags)
+
+  if(AST_TARGET)
+    list(APPEND flags -target;${AST_TARGET})
+  endif()
+  if(AST_MODULE_NAME)
+    list(APPEND flags -module-name;${AST_MODULE_NAME})
+  else()
+    list(APPEND flags -module-name;${target})
+  endif()
+  if(AST_MODULE_LINK_NAME)
+    list(APPEND flags -module-link-name;${AST_MODULE_LINK_NAME})
+  endif()
+  if(AST_MODULE_CACHE_PATH)
+    list(APPEND flags -module-cache-path;${AST_MODULE_CACHE_PATH})
+  endif()
+  if(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
+    list(APPEND flags -g)
+  endif()
+  if(AST_SWIFT_FLAGS)
+    foreach(flag ${AST_SWIFT_FLAGS})
+      list(APPEND flags ${flag})
+    endforeach()
+  endif()
+  if(AST_CFLAGS)
+    foreach(flag ${AST_CFLAGS})
+      list(APPEND flags -Xcc;${flag})
+    endforeach()
+  endif()
+  if(AST_LINK_FLAGS)
+    foreach(flag ${AST_LINK_FLAGS})
+      list(APPEND link_flags ${flag})
+    endforeach()
+  endif()
+  if(NOT AST_OUTPUT)
+    if(AST_LIBRARY)
+      set(AST_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${target}.dir/${CMAKE_SHARED_LIBRARY_PREFIX}${target}${CMAKE_SHARED_LIBRARY_SUFFIX})
+    else()
+      set(AST_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${target}.dir/${target}${CMAKE_EXECUTABLE_SUFFIX})
+    endif()
+  endif()
+
+  set(sources)
+  foreach(source ${AST_SOURCES})
+    get_filename_component(location ${source} PATH)
+    if(IS_ABSOLUTE ${location})
+      list(APPEND sources ${source})
+    else()
+      list(APPEND sources ${CMAKE_CURRENT_SOURCE_DIR}/${source})
+    endif()
+  endforeach()
+
+  set(objs)
+  set(mods)
+  set(docs)
+  set(i 0)
+  foreach(source ${sources})
+    get_filename_component(name ${source} NAME)
+
+    set(obj ${CMAKE_CURRENT_BINARY_DIR}/${target}.dir/${name}${CMAKE_C_OUTPUT_EXTENSION})
+    set(mod ${CMAKE_CURRENT_BINARY_DIR}/${target}.dir/${name}.swiftmodule)
+    set(doc ${CMAKE_CURRENT_BINARY_DIR}/${target}.dir/${name}.swiftdoc)
+
+    set(all_sources ${sources})
+    list(INSERT all_sources ${i} -primary-file)
+
+    add_custom_command(OUTPUT
+                         ${obj}
+                         ${mod}
+                         ${doc}
+                       DEPENDS
+                         ${source}
+                       COMMAND
+                         ${CMAKE_SWIFT_COMPILER} -frontend ${flags} -emit-module-path ${mod} -emit-module-doc-path ${doc} -o ${obj} -c ${all_sources})
+
+    list(APPEND objs ${obj})
+    list(APPEND mods ${mod})
+    list(APPEND docs ${doc})
+
+    math(EXPR i "${i}+1")
+  endforeach()
+
+  if(AST_LIBRARY)
+    get_filename_component(module_directory ${AST_MODULE_PATH} DIRECTORY)
+
+    set(module ${AST_MODULE_PATH})
+    set(documentation ${module_directory}/${AST_MODULE_NAME}.swiftdoc)
+
+    add_custom_command(OUTPUT
+                         ${module}
+                         ${documentation}
+                       DEPENDS
+                         ${mods}
+                         ${docs}
+                       COMMAND
+                         ${CMAKE_SWIFT_COMPILER} -frontend ${flags} -sil-merge-partial-modules -emit-module ${mods} -o ${module} -emit-module-doc-path ${documentation})
+  endif()
+
+  if(AST_LIBRARY)
+    set(emit_library -emit-library)
+  endif()
+  add_custom_command(OUTPUT
+                       ${AST_OUTPUT}
+                     DEPENDS
+                       ${objs}
+                     COMMAND
+                       ${CMAKE_SWIFT_COMPILER} ${emit_library} ${link_flags} -o ${AST_OUTPUT} ${objs})
+  add_custom_target(${target}
+                    ALL
+                    DEPENDS
+                       ${AST_OUTPUT}
+                       ${module}
+                       ${documentation})
+
+  if(AST_RESOURCES)
+    add_custom_command(TARGET
+                         ${target}
+                       POST_BUILD
+                       COMMAND
+                         ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${target}
+                       COMMAND
+                         ${CMAKE_COMMAND} -E copy ${AST_OUTPUT} ${CMAKE_CURRENT_BINARY_DIR}/${target}
+                       COMMAND
+                         ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${target}/Resources
+                       COMMAND
+                         ${CMAKE_COMMAND} -E copy ${AST_RESOURCES} ${CMAKE_CURRENT_BINARY_DIR}/${target}/Resources)
+  else()
+    add_custom_command(TARGET
+                         ${target}
+                       POST_BUILD
+                       COMMAND
+                         ${CMAKE_COMMAND} -E copy ${AST_OUTPUT} ${CMAKE_CURRENT_BINARY_DIR})
+  endif()
+endfunction()
+
+function(add_swift_library library)
+  add_swift_target(${library} LIBRARY ${ARGN})
+endfunction()
+
+function(add_swift_executable executable)
+  add_swift_target(${executable} ${ARGN})
+endfunction()
+


### PR DESCRIPTION
Add a CMake based build system for CoreFoundation.  This helps moves to
a single unified build for swift and the corelibs.  It also makes it
easier to cross-compile.