### PR TITLE
CoreFoundation: reference CFNumber by the canonical name

### DIFF
--- a/CoreFoundation/String.subproj/CFBurstTrie.c
+++ b/CoreFoundation/String.subproj/CFBurstTrie.c
@@ -11,7 +11,7 @@
 #include "CFInternal.h"
 #include "CFBurstTrie.h"
 #include <CoreFoundation/CFByteOrder.h>
-#include "CFNumber.h"
+#include <CoreFoundation/CFNumber.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
CFNumber is a public header in the CoreFoundation framework.  Reference
it as `<CoreFoundation/CFNumber.h>` rather than `"CFNumber.h"`.