### PR TITLE
Fix URLRequest copying

### DIFF
--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -139,10 +139,17 @@ open class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopying 
     }
     
     private func setValues(from source: NSURLRequest) {
-        self.allHTTPHeaderFields = source.allHTTPHeaderFields
         self.url = source.url
         self.mainDocumentURL = source.mainDocumentURL
+        self.cachePolicy = source.cachePolicy
+        self.timeoutInterval = source.timeoutInterval
         self.httpMethod = source.httpMethod
+        self.allHTTPHeaderFields = source.allHTTPHeaderFields
+        self._body = source._body
+        self.networkServiceType = source.networkServiceType
+        self.allowsCellularAccess = source.allowsCellularAccess
+        self.httpShouldHandleCookies = source.httpShouldHandleCookies
+        self.httpShouldUsePipelining = source.httpShouldUsePipelining
     }
     
     open override func mutableCopy() -> Any {

--- a/TestFoundation/TestNSURLRequest.swift
+++ b/TestFoundation/TestNSURLRequest.swift
@@ -80,10 +80,13 @@ class TestNSURLRequest : XCTestCase {
         
         let urlA = URL(string: "http://swift.org")!
         let urlB = URL(string: "http://github.com")!
+        let postBody = "here is body".data(using: .utf8)
+
         mutableRequest.mainDocumentURL = urlA
         mutableRequest.url = urlB
         mutableRequest.httpMethod = "POST"
         mutableRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        mutableRequest.httpBody = postBody
 
         guard let requestCopy1 = mutableRequest.copy() as? NSURLRequest else {
             XCTFail(); return
@@ -99,6 +102,8 @@ class TestNSURLRequest : XCTestCase {
         XCTAssertEqual(requestCopy1.url, urlB)
         XCTAssertEqual(mutableRequest.allHTTPHeaderFields?["Accept"], "application/json")
         XCTAssertEqual(requestCopy1.allHTTPHeaderFields?["Accept"], "application/json")
+        XCTAssertEqual(mutableRequest.httpBody, postBody)
+        XCTAssertEqual(requestCopy1.httpBody, postBody)
 
         // Change the original, and check that the copy has unchanged
         // values:
@@ -128,6 +133,7 @@ class TestNSURLRequest : XCTestCase {
         
         let urlA = URL(string: "http://swift.org")!
         let urlB = URL(string: "http://github.com")!
+
         originalRequest.mainDocumentURL = urlA
         originalRequest.url = urlB
         originalRequest.httpMethod = "POST"

--- a/TestFoundation/TestURLRequest.swift
+++ b/TestFoundation/TestURLRequest.swift
@@ -77,10 +77,13 @@ class TestURLRequest : XCTestCase {
         
         let urlA = URL(string: "http://swift.org")!
         let urlB = URL(string: "http://github.com")!
+        let postBody = "here is body".data(using: .utf8)
+
         mutableRequest.mainDocumentURL = urlA
         mutableRequest.url = urlB
         mutableRequest.httpMethod = "POST"
         mutableRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        mutableRequest.httpBody = postBody
         
         let requestCopy1 = mutableRequest
         
@@ -94,6 +97,8 @@ class TestURLRequest : XCTestCase {
         XCTAssertEqual(requestCopy1.url, urlB)
         XCTAssertEqual(mutableRequest.allHTTPHeaderFields?["Accept"], "application/json")
         XCTAssertEqual(requestCopy1.allHTTPHeaderFields?["Accept"], "application/json")
+        XCTAssertEqual(mutableRequest.httpBody, postBody)
+        XCTAssertEqual(requestCopy1.httpBody, postBody)
         
         // Change the original, and check that the copy has unchanged
         // values:
@@ -107,6 +112,7 @@ class TestURLRequest : XCTestCase {
         XCTAssertEqual(requestCopy1.httpMethod, "POST")
         XCTAssertEqual(requestCopy1.url, urlB)
         XCTAssertEqual(requestCopy1.allHTTPHeaderFields?["Accept"], "application/json")
+        XCTAssertEqual(requestCopy1.httpBody, postBody)
         
         // Check that we can copy the copy:
         let requestCopy2 = requestCopy1
@@ -115,6 +121,7 @@ class TestURLRequest : XCTestCase {
         XCTAssertEqual(requestCopy2.httpMethod, "POST")
         XCTAssertEqual(requestCopy2.url, urlB)
         XCTAssertEqual(requestCopy2.allHTTPHeaderFields?["Accept"], "application/json")
+        XCTAssertEqual(requestCopy2.httpBody, postBody)
     }
     
     func test_mutableCopy_1() {


### PR DESCRIPTION
A lot of fields not copied
It works very bad when `Content-Length` set but `httpBody` loosed after COW