### PR TITLE
Build Foundation with DEPLOYMENT_RUNTIME_SWIFT disabled

### DIFF
--- a/CoreFoundation/Locale.subproj/CFCalendar.c
+++ b/CoreFoundation/Locale.subproj/CFCalendar.c
@@ -10,6 +10,7 @@
 
 
 #include <CoreFoundation/CFCalendar.h>
+#include <CoreFoundation/CFLocaleInternal.h>
 #include <CoreFoundation/CFRuntime.h>
 #include "CFInternal.h"
 #include "CFPriv.h"

--- a/CoreFoundation/Locale.subproj/CFLocale.c
+++ b/CoreFoundation/Locale.subproj/CFLocale.c
@@ -10,6 +10,7 @@
 
 // Note the header file is in the OpenSource set (stripped to almost nothing), but not the .c file
 
+#include <CoreFoundation/CFInternal.h>
 #include <CoreFoundation/CFLocale.h>
 #include <CoreFoundation/CFLocale_Private.h>
 #include <CoreFoundation/CFString.h>

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -176,8 +176,6 @@ _CFXMLInterfaceSAXHandler _CFXMLInterfaceCreateSAXHandler() {
     saxHandler->externalSubset = (externalSubsetSAXFunc)__CFSwiftBridge.NSXMLParser.externalSubset;
     
     saxHandler->initialized = XML_SAX2_MAGIC; // make sure start/endElementNS are used
-#else
-    memset(&saxHandler, 0, sizeof(saxHandler));
 #endif //if DEPLOYMENT_RUNTIME_SWIFT
     return saxHandler;
 }

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -12,6 +12,7 @@
  */
 
 #include <CoreFoundation/CFRuntime.h>
+#include <CoreFoundation/CFInternal.h>
 #include <libxml/globals.h>
 #include <libxml/xmlerror.h>
 #include <libxml/parser.h>
@@ -22,7 +23,7 @@
 #include <libxml/xpath.h>
 #include <libxml/xpathInternals.h>
 #include <libxml/dict.h>
-#include "CFInternal.h"
+#include "CFXMLInterface.h"
 
 /*
  libxml2 does not have nullability annotations and does not import well into swift when given potentially differing versions of the library that might be installed on the host operating system. This is a simple C wrapper to simplify some of that interface layer to libxml2.
@@ -110,6 +111,7 @@ typedef struct {
     xmlNotationPtr notation;
 } _cfxmlNotation;
 
+#if DEPLOYMENT_RUNTIME_SWIFT
 static xmlExternalEntityLoader __originalLoader = NULL;
 
 static xmlParserInputPtr _xmlExternalEntityLoader(const char *urlStr, const char * ID, xmlParserCtxtPtr context) {
@@ -119,8 +121,10 @@ static xmlParserInputPtr _xmlExternalEntityLoader(const char *urlStr, const char
     }
     return __originalLoader(urlStr, ID, context);
 }
+#endif // DEPLOYMENT_RUNTIME_SWIFT
 
 void _CFSetupXMLInterface(void) {
+#if DEPLOYMENT_RUNTIME_SWIFT
     static dispatch_once_t xmlInitGuard;
     dispatch_once(&xmlInitGuard, ^{
         xmlInitParser();
@@ -128,21 +132,25 @@ void _CFSetupXMLInterface(void) {
         __originalLoader = xmlGetExternalEntityLoader();
         xmlSetExternalEntityLoader(_xmlExternalEntityLoader);
     });
+#endif // DEPLOYMENT_RUNTIME_SWIFT
 }
 
 _CFXMLInterfaceParserInput _CFXMLInterfaceNoNetExternalEntityLoader(const char *URL, const char *ID, _CFXMLInterfaceParserContext ctxt) {
     return xmlNoNetExternalEntityLoader(URL, ID, ctxt);
 }
 
+#if DEPLOYMENT_RUNTIME_SWIFT
 static void _errorCallback(void *ctx, const char *msg, ...) {
     xmlParserCtxtPtr context = __CFSwiftBridge.NSXMLParser.getContext((_CFXMLInterface)ctx);
     xmlErrorPtr error = xmlCtxtGetLastError(context);
 // TODO: reporting
 //    _reportError(error, (_CFXMLInterface)ctx);
 }
+#endif // DEPLOYMENT_RUNTIME_SWIFT
 
 _CFXMLInterfaceSAXHandler _CFXMLInterfaceCreateSAXHandler() {
     _CFXMLInterfaceSAXHandler saxHandler = (_CFXMLInterfaceSAXHandler)calloc(1, sizeof(struct _xmlSAXHandler));
+#if DEPLOYMENT_RUNTIME_SWIFT
     saxHandler->internalSubset = (internalSubsetSAXFunc)__CFSwiftBridge.NSXMLParser.internalSubset;
     saxHandler->isStandalone = (isStandaloneSAXFunc)__CFSwiftBridge.NSXMLParser.isStandalone;
     
@@ -168,6 +176,9 @@ _CFXMLInterfaceSAXHandler _CFXMLInterfaceCreateSAXHandler() {
     saxHandler->externalSubset = (externalSubsetSAXFunc)__CFSwiftBridge.NSXMLParser.externalSubset;
     
     saxHandler->initialized = XML_SAX2_MAGIC; // make sure start/endElementNS are used
+#else
+    memset(&saxHandler, 0, sizeof(saxHandler));
+#endif //if DEPLOYMENT_RUNTIME_SWIFT
     return saxHandler;
 }
 

--- a/CoreFoundation/build.py
+++ b/CoreFoundation/build.py
@@ -293,7 +293,7 @@ sources_list = [
 	'String.subproj/CFRegularExpression.c',
 	'String.subproj/CFAttributedString.c',
 	'String.subproj/CFRunArray.c',
-	'Base.subproj/CFKnownLocations.h',
+	'Base.subproj/CFKnownLocations.c',
 ]
 
 sources = CompileSources(sources_list)

--- a/lib/script.py
+++ b/lib/script.py
@@ -226,15 +226,7 @@ rule SwiftExecutable
         script = flags + commands
 
         for product in self.products:
-            items = product.generate()
-            for item in items:
-                if isinstance(item, list):
-                    for subitem in item:
-                        #TODO: What to do with this elements?
-                        #script += subitem
-                        continue
-                else:
-                    script += item
+            script += "".join([product_build_command for product_build_command in product.generate() if not isinstance(product_build_command, list)])
 
         script += """
 

--- a/lib/script.py
+++ b/lib/script.py
@@ -226,7 +226,15 @@ rule SwiftExecutable
         script = flags + commands
 
         for product in self.products:
-            script += product.generate()
+            items = product.generate()
+            for item in items:
+                if isinstance(item, list):
+                    for subitem in item:
+                        #TODO: What to do with this elements?
+                        #script += subitem
+                        continue
+                else:
+                    script += item
 
         script += """
 


### PR DESCRIPTION

Expand Linux platforms supported under DEPLOYMENT_RUNTIME_SWIFT=0 umbrella.
