### PR TITLE
NSDecimalNumber: Add missing init(value:) initialisers.

### DIFF
--- a/Foundation/NSDecimalNumber.swift
+++ b/Foundation/NSDecimalNumber.swift
@@ -79,29 +79,21 @@ open class NSDecimalNumber : NSNumber {
 
     fileprivate let decimal: Decimal
     public convenience init(mantissa: UInt64, exponent: Int16, isNegative: Bool) {
-        var d = Decimal()
-        d._exponent = Int32(exponent)
+        var d = Decimal(mantissa)
+        d._exponent += Int32(exponent)
         d._isNegative = isNegative ? 1 : 0
-        var man = mantissa
-        d._mantissa.0 = UInt16(man & 0xffff)
-        man >>= 4
-        d._mantissa.1 = UInt16(man & 0xffff)
-        man >>= 4
-        d._mantissa.2 = UInt16(man & 0xffff)
-        man >>= 4
-        d._mantissa.3 = UInt16(man & 0xffff)
-        d._length = 4
-        d.trimTrailingZeros()
-        // TODO more parts of the mantissa...
         self.init(decimal: d)
     }
+
     public init(decimal dcm: Decimal) {
         self.decimal = dcm
         super.init()
     }
+
     public convenience init(string numberValue: String?) {
         self.init(decimal: Decimal(string: numberValue ?? "") ?? Decimal.nan)
     }
+
     public convenience init(string numberValue: String?, locale: Any?) {
         self.init(decimal: Decimal(string: numberValue ?? "", locale: locale as? Locale) ?? Decimal.nan)
     }
@@ -133,6 +125,71 @@ open class NSDecimalNumber : NSNumber {
             UInt16(mantissaData[14]) << 8 & UInt16(mantissaData[15])
         )
         self.decimal = Decimal(_exponent: exponent, _length: length, _isNegative: isNegative, _isCompact: isCompact, _reserved: 0, _mantissa: mantissa)
+        super.init()
+    }
+
+    public init(value: Int) {
+        decimal = Decimal(value)
+        super.init()
+    }
+
+    public init(value: UInt) {
+        decimal = Decimal(value)
+        super.init()
+    }
+
+    public init(value: Int8) {
+        decimal = Decimal(value)
+        super.init()
+    }
+
+    public init(value: UInt8) {
+        decimal = Decimal(value)
+        super.init()
+    }
+
+    public init(value: Int16) {
+        decimal = Decimal(value)
+        super.init()
+    }
+
+    public init(value: UInt16) {
+        decimal = Decimal(value)
+        super.init()
+    }
+
+    public init(value: Int32) {
+        decimal = Decimal(value)
+        super.init()
+    }
+
+    public init(value: UInt32) {
+        decimal = Decimal(value)
+        super.init()
+    }
+
+    public init(value: Int64) {
+        decimal = Decimal(value)
+        super.init()
+    }
+
+    public init(value: UInt64) {
+        decimal = Decimal(value)
+        super.init()
+    }
+
+    public init(value: Bool) {
+        decimal = Decimal(value ? 1 : 0)
+        super.init()
+    }
+
+    public init(value: Float) {
+        decimal = Decimal(Double(value))
+        super.init()
+    }
+
+    public init(value: Double) {
+        decimal = Decimal(value)
         super.init()
     }
 

--- a/TestFoundation/TestDecimal.swift
+++ b/TestFoundation/TestDecimal.swift
@@ -11,6 +11,7 @@ class TestDecimal: XCTestCase {
 
     static var allTests : [(String, (TestDecimal) -> () throws -> Void)] {
         return [
+            ("test_NSDecimalNumberInit", test_NSDecimalNumberInit),
             ("test_AdditionWithNormalization", test_AdditionWithNormalization),
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_Constants", test_Constants),
@@ -31,6 +32,33 @@ class TestDecimal: XCTestCase {
             ("test_SmallerNumbers", test_SmallerNumbers),
             ("test_ZeroPower", test_ZeroPower),
         ]
+    }
+
+    func test_NSDecimalNumberInit() {
+        XCTAssertEqual(NSDecimalNumber(mantissa: 123456789000, exponent: -2, isNegative: true), -1234567890)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal()).decimalValue, Decimal(0))
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(1)).intValue, 1)
+        XCTAssertEqual(NSDecimalNumber(string: "1.234").floatValue, 1.234)
+        XCTAssertTrue(NSDecimalNumber(string: "invalid").decimalValue.isNaN)
+        XCTAssertEqual(NSDecimalNumber(value: true).boolValue, true)
+        XCTAssertEqual(NSDecimalNumber(value: false).boolValue, false)
+        XCTAssertEqual(NSDecimalNumber(value: Int.min).intValue, Int.min)
+        XCTAssertEqual(NSDecimalNumber(value: UInt.min).uintValue, UInt.min)
+        XCTAssertEqual(NSDecimalNumber(value: Int8.min).int8Value, Int8.min)
+        XCTAssertEqual(NSDecimalNumber(value: UInt8.min).uint8Value, UInt8.min)
+        XCTAssertEqual(NSDecimalNumber(value: Int16.min).int16Value, Int16.min)
+        XCTAssertEqual(NSDecimalNumber(value: UInt16.min).uint16Value, UInt16.min)
+        XCTAssertEqual(NSDecimalNumber(value: Int32.min).int32Value, Int32.min)
+        XCTAssertEqual(NSDecimalNumber(value: UInt32.min).uint32Value, UInt32.min)
+        XCTAssertEqual(NSDecimalNumber(value: Int64.min).int64Value, Int64.min)
+        XCTAssertEqual(NSDecimalNumber(value: UInt64.min).uint64Value, UInt64.min)
+        XCTAssertEqual(NSDecimalNumber(value: Float.leastNormalMagnitude).floatValue, Float.leastNormalMagnitude)
+        XCTAssertEqual(NSDecimalNumber(value: Float.greatestFiniteMagnitude).floatValue, Float.greatestFiniteMagnitude)
+        XCTAssertEqual(NSDecimalNumber(value: Double.pi).doubleValue, Double.pi)
+        XCTAssertEqual(NSDecimalNumber(integerLiteral: 0).intValue, 0)
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: Double.pi).doubleValue, Double.pi)
+        XCTAssertEqual(NSDecimalNumber(booleanLiteral: true).boolValue, true)
+        XCTAssertEqual(NSDecimalNumber(booleanLiteral: false).boolValue, false)
     }
 
     func test_AdditionWithNormalization() {


### PR DESCRIPTION
- Fix init(mantissa:exponent:isNegative:) to set the mantissa
  correctly.