### PR TITLE
Add xdgTestHelper into the TestFoundation bundle as an auxiliaryExecutable

### DIFF
--- a/DarwinCompatibilityTests.xcodeproj/project.pbxproj
+++ b/DarwinCompatibilityTests.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		B917D32620B0DE2000728EE0 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = B917D32520B0DE2000728EE0 /* main.swift */; };
 		B95788861F6FB9470003EB01 /* TestNSNumberBridging.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95788851F6FB9470003EB01 /* TestNSNumberBridging.swift */; };
 		B987C65E2093C8AF0026B50D /* TestImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = B987C65D2093C8AF0026B50D /* TestImports.swift */; };
-		B9C89ED21F6BF67C00087AF4 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9C89ED11F6BF67C00087AF4 /* XCTest.framework */; };
 		B9C89F361F6BF89C00087AF4 /* TestScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C89EE61F6BF88F00087AF4 /* TestScanner.swift */; };
 		B9C89F371F6BF89C00087AF4 /* TestNSValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C89EE71F6BF88F00087AF4 /* TestNSValue.swift */; };
 		B9C89F381F6BF89C00087AF4 /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C89EE81F6BF88F00087AF4 /* TestUtils.swift */; };
@@ -109,9 +108,19 @@
 		B9C89FCC1F6DCAEB00087AF4 /* NSKeyedUnarchiver-NotificationTest.plist in Resources */ = {isa = PBXBuildFile; fileRef = B9C89FB71F6DCAEB00087AF4 /* NSKeyedUnarchiver-NotificationTest.plist */; };
 		B9C89FCD1F6DCAEB00087AF4 /* PropertyList-1.0.dtd in Resources */ = {isa = PBXBuildFile; fileRef = B9C89FB81F6DCAEB00087AF4 /* PropertyList-1.0.dtd */; };
 		B9C89FCE1F6DCAEB00087AF4 /* Test.plist in Resources */ = {isa = PBXBuildFile; fileRef = B9C89FB91F6DCAEB00087AF4 /* Test.plist */; };
-		B9F3269F1FC714DD003C3599 /* DarwinShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F3269E1FC714DD003C3599 /* DarwinShims.swift */; };
+		B9F137A120B998D0000B7577 /* xdgTestHelper in CopyFiles */ = {isa = PBXBuildFile; fileRef = B917D31C20B0DB8B00728EE0 /* xdgTestHelper */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		B9F326A01FC714DD003C3599 /* DarwinShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F3269E1FC714DD003C3599 /* DarwinShims.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		B9F1379E20B9984F000B7577 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B9C89EB91F6BF47D00087AF4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B917D31B20B0DB8B00728EE0;
+			remoteInfo = xdgTestHelper;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		B917D31A20B0DB8B00728EE0 /* CopyFiles */ = {
@@ -123,12 +132,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 		};
-		B9C89EBF1F6BF47D00087AF4 /* CopyFiles */ = {
+		B9F137A020B998C0000B7577 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 12;
-			dstPath = usr/share/man/man1;
-			dstSubfolderSpec = 7;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 6;
 			files = (
+				B9F137A120B998D0000B7577 /* xdgTestHelper in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -140,7 +150,6 @@
 		B917D32520B0DE2000728EE0 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = main.swift; path = TestFoundation/xdgTestHelper/main.swift; sourceTree = "<group>"; };
 		B95788851F6FB9470003EB01 /* TestNSNumberBridging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestNSNumberBridging.swift; path = TestFoundation/TestNSNumberBridging.swift; sourceTree = "<group>"; };
 		B987C65D2093C8AF0026B50D /* TestImports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestImports.swift; path = TestFoundation/TestImports.swift; sourceTree = "<group>"; };
-		B9C89EC11F6BF47D00087AF4 /* DarwinCompatibilityTests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = DarwinCompatibilityTests; sourceTree = BUILT_PRODUCTS_DIR; };
 		B9C89ED11F6BF67C00087AF4 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		B9C89ED71F6BF77E00087AF4 /* DarwinCompatibilityTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DarwinCompatibilityTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B9C89EDB1F6BF77E00087AF4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -252,14 +261,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				B917D32420B0DB9700728EE0 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		B9C89EBE1F6BF47D00087AF4 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B9C89ED21F6BF67C00087AF4 /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -394,7 +395,6 @@
 		B9C89EC21F6BF47D00087AF4 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				B9C89EC11F6BF47D00087AF4 /* DarwinCompatibilityTests */,
 				B9C89ED71F6BF77E00087AF4 /* DarwinCompatibilityTests.xctest */,
 				B917D31C20B0DB8B00728EE0 /* xdgTestHelper */,
 			);
@@ -440,23 +440,6 @@
 			productReference = B917D31C20B0DB8B00728EE0 /* xdgTestHelper */;
 			productType = "com.apple.product-type.tool";
 		};
-		B9C89EC01F6BF47D00087AF4 /* DarwinCompatibilityTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = B9C89EC81F6BF47D00087AF4 /* Build configuration list for PBXNativeTarget "DarwinCompatibilityTests" */;
-			buildPhases = (
-				B9C89EBD1F6BF47D00087AF4 /* Sources */,
-				B9C89EBE1F6BF47D00087AF4 /* Frameworks */,
-				B9C89EBF1F6BF47D00087AF4 /* CopyFiles */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = DarwinCompatibilityTests;
-			productName = DarwinCompatibilityTests;
-			productReference = B9C89EC11F6BF47D00087AF4 /* DarwinCompatibilityTests */;
-			productType = "com.apple.product-type.tool";
-		};
 		B9C89ED61F6BF77E00087AF4 /* DarwinCompatibilityTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B9C89EDC1F6BF77E00087AF4 /* Build configuration list for PBXNativeTarget "DarwinCompatibilityTests" */;
@@ -464,10 +447,12 @@
 				B9C89ED31F6BF77E00087AF4 /* Sources */,
 				B9C89ED41F6BF77E00087AF4 /* Frameworks */,
 				B9C89ED51F6BF77E00087AF4 /* Resources */,
+				B9F137A020B998C0000B7577 /* CopyFiles */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				B9F1379F20B9984F000B7577 /* PBXTargetDependency */,
 			);
 			name = DarwinCompatibilityTests;
 			productName = DarwinCompatibilityTests;
@@ -488,11 +473,6 @@
 						CreatedOnToolsVersion = 9.3.1;
 						ProvisioningStyle = Automatic;
 					};
-					B9C89EC01F6BF47D00087AF4 = {
-						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 0910;
-						ProvisioningStyle = Automatic;
-					};
 					B9C89ED61F6BF77E00087AF4 = {
 						CreatedOnToolsVersion = 9.0;
 						ProvisioningStyle = Automatic;
@@ -511,7 +491,6 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				B9C89EC01F6BF47D00087AF4 /* DarwinCompatibilityTests */,
 				B9C89ED61F6BF77E00087AF4 /* DarwinCompatibilityTests */,
 				B917D31B20B0DB8B00728EE0 /* xdgTestHelper */,
 			);
@@ -555,14 +534,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				B917D32620B0DE2000728EE0 /* main.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		B9C89EBD1F6BF47D00087AF4 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B9F3269F1FC714DD003C3599 /* DarwinShims.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -653,6 +624,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		B9F1379F20B9984F000B7577 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B917D31B20B0DB8B00728EE0 /* xdgTestHelper */;
+			targetProxy = B9F1379E20B9984F000B7577 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		B917D32020B0DB8B00728EE0 /* Debug */ = {
@@ -789,34 +768,6 @@
 			};
 			name = Release;
 		};
-		B9C89EC91F6BF47D00087AF4 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				OTHER_SWIFT_FLAGS = "";
-				"OTHER_SWIFT_FLAGS[arch=*]" = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
-			};
-			name = Debug;
-		};
-		B9C89ECA1F6BF47D00087AF4 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
-			};
-			name = Release;
-		};
 		B9C89EDD1F6BF77E00087AF4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -862,15 +813,6 @@
 			buildConfigurations = (
 				B9C89EC61F6BF47D00087AF4 /* Debug */,
 				B9C89EC71F6BF47D00087AF4 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		B9C89EC81F6BF47D00087AF4 /* Build configuration list for PBXNativeTarget "DarwinCompatibilityTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				B9C89EC91F6BF47D00087AF4 /* Debug */,
-				B9C89ECA1F6BF47D00087AF4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -343,6 +343,7 @@
 		B9974B9A1EDF4A22007F15B8 /* HTTPMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B931EDF4A22007F15B8 /* HTTPMessage.swift */; };
 		B9974B9B1EDF4A22007F15B8 /* BodySource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B941EDF4A22007F15B8 /* BodySource.swift */; };
 		B9974B9C1EDF4A22007F15B8 /* EasyHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B951EDF4A22007F15B8 /* EasyHandle.swift */; };
+		B9F1379A20B99455000B7577 /* xdgTestHelper in CopyFiles */ = {isa = PBXBuildFile; fileRef = B9F1379920B99455000B7577 /* xdgTestHelper */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		BB3D7558208A1E500085CFDC /* TestImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3D7557208A1E500085CFDC /* TestImports.swift */; };
 		BD8042161E09857800487EB8 /* TestLengthFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8042151E09857800487EB8 /* TestLengthFormatter.swift */; };
 		BDBB65901E256BFA001A7286 /* TestEnergyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDBB658F1E256BFA001A7286 /* TestEnergyFormatter.swift */; };
@@ -455,6 +456,13 @@
 			remoteGlobalIDString = 5B5D885C1BBC938800234F36;
 			remoteInfo = SwiftFoundation;
 		};
+		B9F1379620B99357000B7577 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9F0DD33E1ECD734200F68030;
+			remoteInfo = xdgTestHelper;
+		};
 		EA993CE21BEACD8E000969A2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
@@ -482,6 +490,16 @@
 			dstSubfolderSpec = 10;
 			files = (
 				5BDC406E1BD6D8C400ED97BB /* SwiftFoundation.framework in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B9F1379820B99363000B7577 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 6;
+			files = (
+				B9F1379A20B99455000B7577 /* xdgTestHelper in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -824,6 +842,7 @@
 		B9974B931EDF4A22007F15B8 /* HTTPMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HTTPMessage.swift; path = http/HTTPMessage.swift; sourceTree = "<group>"; };
 		B9974B941EDF4A22007F15B8 /* BodySource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BodySource.swift; sourceTree = "<group>"; };
 		B9974B951EDF4A22007F15B8 /* EasyHandle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EasyHandle.swift; sourceTree = "<group>"; };
+		B9F1379920B99455000B7577 /* xdgTestHelper */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; name = xdgTestHelper; path = DerivedData/Foundation/Build/Products/Debug/xdgTestHelper.app/Contents/MacOS/xdgTestHelper; sourceTree = "<group>"; };
 		BB3D7557208A1E500085CFDC /* TestImports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestImports.swift; sourceTree = "<group>"; };
 		BD8042151E09857800487EB8 /* TestLengthFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLengthFormatter.swift; sourceTree = "<group>"; };
 		BDBB658F1E256BFA001A7286 /* TestEnergyFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEnergyFormatter.swift; sourceTree = "<group>"; };
@@ -1035,6 +1054,7 @@
 		5B5D88531BBC938800234F36 = {
 			isa = PBXGroup;
 			children = (
+				B9F1379920B99455000B7577 /* xdgTestHelper */,
 				B167A6641ED7303F0040B09A /* README.md */,
 				5BDC3F2C1BCC5DB500ED97BB /* Foundation */,
 				EAB57B681BD1A255004AC5C5 /* CoreFoundation */,
@@ -2019,10 +2039,12 @@
 				5BDC40591BD6D83B00ED97BB /* Frameworks */,
 				5BDC405A1BD6D83B00ED97BB /* Resources */,
 				5BDC406D1BD6D8B300ED97BB /* CopyFiles */,
+				B9F1379820B99363000B7577 /* CopyFiles */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				B9F1379720B99357000B7577 /* PBXTargetDependency */,
 				AE2FC5951CFEFC70008F7981 /* PBXTargetDependency */,
 			);
 			name = TestFoundation;
@@ -2537,6 +2559,11 @@
 			target = 5B5D885C1BBC938800234F36 /* SwiftFoundation */;
 			targetProxy = AE2FC5941CFEFC70008F7981 /* PBXContainerItemProxy */;
 		};
+		B9F1379720B99357000B7577 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9F0DD33E1ECD734200F68030 /* xdgTestHelper */;
+			targetProxy = B9F1379620B99357000B7577 /* PBXContainerItemProxy */;
+		};
 		EA993CE31BEACD8E000969A2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 5B7C8A6D1BEA7F8F00C5B690 /* CoreFoundation */;
@@ -2668,11 +2695,7 @@
 				INFOPLIST_FILE = Foundation/Info.plist;
 				INIT_ROUTINE = "___CFInitialize";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				OTHER_CFLAGS = (
 					"-DCF_BUILDING_CF",
 					"-DDEPLOYMENT_TARGET_MACOSX",
@@ -2744,11 +2767,7 @@
 				INFOPLIST_FILE = Foundation/Info.plist;
 				INIT_ROUTINE = "___CFInitialize";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				OTHER_CFLAGS = (
 					"-DCF_BUILDING_CF",
 					"-DDEPLOYMENT_TARGET_MACOSX",
@@ -2896,11 +2915,7 @@
 					/usr/include/libxml2,
 				);
 				INFOPLIST_FILE = TestFoundation/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-					"@loader_path/../Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = mh_execute;
 				OTHER_SWIFT_FLAGS = "-DDEPLOYMENT_ENABLE_LIBDISPATCH -swift-version 4";
@@ -2926,11 +2941,7 @@
 					/usr/include/libxml2,
 				);
 				INFOPLIST_FILE = TestFoundation/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-					"@loader_path/../Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = mh_execute;
 				OTHER_SWIFT_FLAGS = "-DDEPLOYMENT_ENABLE_LIBDISPATCH -swift-version 4";
@@ -2954,12 +2965,7 @@
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = TestFoundation/xdgTestHelper/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../../..",
-					"@loader_path/../../..",
-					"@executable_path/../Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../../.. @loader_path/../../.. @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = org.swift.xdgTestHelper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2981,12 +2987,7 @@
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = TestFoundation/xdgTestHelper/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../../..",
-					"@loader_path/../../..",
-					"@executable_path/../Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../../.. @loader_path/../../.. @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = org.swift.xdgTestHelper;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/TestFoundation/TestBundle.swift
+++ b/TestFoundation/TestBundle.swift
@@ -28,17 +28,10 @@ internal func testBundleName() -> String {
 }
 
 internal func xdgTestHelperURL() -> URL {
-#if DARWIN_COMPATIBILITY_TESTS
-    let exeName = "/xdgTestHelper"
-#elseif os(macOS)
-    let exeName = "/xdgTestHelper.app/Contents/MacOS/xdgTestHelper"
-#else
-    let exeName = "/xdgTestHelper/xdgTestHelper"
-#endif
-
-    var path = testBundle().bundleURL.deletingLastPathComponent()
-    path.appendPathComponent(exeName)
-    return path
+    guard let url = testBundle().url(forAuxiliaryExecutable: "xdgTestHelper") else {
+        fatalError("Cant find xdgTestHelper")
+    }
+    return url
 }
 
 

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -30,16 +30,21 @@ class XDGCheck {
             .path: "/",
             .domain: "example.com",
             ]
+
         guard let simpleCookie = HTTPCookie(properties: properties) else {
             exit(HelperCheckStatus.cookieStorageNil.rawValue)
         }
-        guard let rawValue = getenv("XDG_DATA_HOME") else {
+        guard let rawValue = getenv("XDG_DATA_HOME"), let xdg_data_home = String(utf8String: rawValue) else {
             exit(HelperCheckStatus.fail.rawValue)
         }
-        let xdg_data_home = String(utf8String: rawValue)
+
         storage.setCookie(simpleCookie)
         let fm = FileManager.default
-        let destPath = xdg_data_home! + "/xdgTestHelper/.cookies.shared"
+
+        guard let bundleName = Bundle.main.infoDictionary?["CFBundleName"] as? String else {
+            exit(HelperCheckStatus.fail.rawValue)
+        }
+        let destPath = xdg_data_home + "/" + bundleName + "/.cookies.shared"
         var isDir: ObjCBool = false
         let exists = fm.fileExists(atPath: destPath, isDirectory: &isDir)
         if (!exists) {

--- a/build.py
+++ b/build.py
@@ -528,6 +528,7 @@ Configuration.current.extra_ld_flags += ' -L'+Configuration.current.variables["L
 foundation_tests.add_dependency(foundation_tests_resources)
 xdgTestHelper = SwiftExecutable('xdgTestHelper',
  ['TestFoundation/xdgTestHelper/main.swift'])
+xdgTestHelper.outputDirectory = 'TestFoundation'
 foundation_tests.add_dependency(xdgTestHelper)
 foundation.add_phase(xdgTestHelper)
 foundation.add_phase(foundation_tests_resources)

--- a/lib/phases.py
+++ b/lib/phases.py
@@ -414,6 +414,7 @@ build """ + self._module.relative() + ": MergeSwiftModule " + objects + """
 # This builds a Swift executable using one invocation of swiftc (no partial compilation)
 class SwiftExecutable(BuildPhase):
     executableName = None
+    outputDirectory = None
     sources = []
     
     def __init__(self, executableName, sources):
@@ -421,9 +422,10 @@ class SwiftExecutable(BuildPhase):
         self.executableName = executableName
         self.name = executableName
         self.sources = sources
+        self.outputDirectory = executableName
     
     def generate(self):
-        appName = Configuration.current.build_directory.relative() + """/""" + self.executableName + """/""" + self.executableName
+        appName = Configuration.current.build_directory.relative() + """/""" + self.outputDirectory + """/""" + self.executableName
         libDependencyName = self.product.product_name
         swiftSources = ""
         for value in self.sources:


### PR DESCRIPTION
- For Linux, set the output executable from the swiftc to go into
  the TestFoundation application directory.

- For DarwinCompatibiltyTests, build xdgTestHelper as a command
  line tool then add a build phase to copy it to the 'Executables'
  destination.

- For TestFoundation.app, build xdgTestHelper as a cocoa .app so
  that Xcode doesnt statically link it to the Foundation from the
  Swift toolchain, then copy the binary.

This is a followup to https://github.com/apple/swift-corelibs-foundation/pull/1562 which made `xdgTestHelper` into a standalone single `.swift` file.