### PR TITLE
Added support for recursively resolving symlinks

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -1045,7 +1045,7 @@ open class FileManager : NSObject {
         let initialPath = initialPath ?? path
         let resolvedPath = _appendSymlinkDestination(destination, toPath: path)
         
-        // As in Darwin Foundation, after a recursion limit we return the intial path without resolution.
+        // As in Darwin Foundation, after a recursion limit we return the initial path without resolution.
         guard recursionLevel <= 100 else {
             return initialPath
         }

--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -1046,7 +1046,13 @@ open class FileManager : NSObject {
         let resolvedPath = _appendSymlinkDestination(destination, toPath: path)
         
         // As in Darwin Foundation, after a recursion limit we return the initial path without resolution.
-        guard recursionLevel <= 100 else {
+        var maximum_recursion = sysconf(Int32(_SC_SYMLOOP_MAX))
+        
+        if maximum_recursion <= 0 {
+            maximum_recursion = Int(_POSIX_SYMLOOP_MAX)
+        }
+        
+        guard recursionLevel <= maximum_recursion else {
             return initialPath
         }
         

--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -609,7 +609,7 @@ open class FileManager : NSObject {
             return
         } else if errno == ENOTEMPTY {
 
-            let fsRep = FileManager.default.fileSystemRepresentation(withPath: path)
+            let fsRep = self.fileSystemRepresentation(withPath: path)
             let ps = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>.allocate(capacity: 2)
             ps.initialize(to: UnsafeMutablePointer(mutating: fsRep))
             ps.advanced(by: 1).initialize(to: nil)
@@ -1038,7 +1038,7 @@ open class FileManager : NSObject {
             return nil
         }
         
-        guard let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: path) else {
+        guard let destination = try? self.destinationOfSymbolicLink(atPath: path) else {
             return nil
         }
         

--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -1033,7 +1033,7 @@ open class FileManager : NSObject {
         NSUnimplemented()
     }
     
-    internal func _tryToResolveTrailingSymlinkInPath(_ path: String, recursionLevel: Int = 0) -> String? {
+    internal func _tryToResolveTrailingSymlinkInPath(_ path: String, recursionLevel: Int = 0, initialPath: String? = nil) -> String? {
         guard _pathIsSymbolicLink(path) else {
             return nil
         }
@@ -1042,13 +1042,17 @@ open class FileManager : NSObject {
             return nil
         }
         
+        let initialPath = initialPath ?? path
         let resolvedPath = _appendSymlinkDestination(destination, toPath: path)
         
-        guard recursionLevel <= 50 else {
-            return resolvedPath
+        // As in Darwin Foundation, after a recursion limit we return the intial path without resolution.
+        guard recursionLevel <= 100 else {
+            return initialPath
         }
         
-        let recursivelyResolvedPath = _tryToResolveTrailingSymlinkInPath(resolvedPath, recursionLevel: recursionLevel + 1)
+        let recursivelyResolvedPath = _tryToResolveTrailingSymlinkInPath(resolvedPath,
+                                                                         recursionLevel: recursionLevel + 1,
+                                                                         initialPath: initialPath)
         
         if recursivelyResolvedPath != nil {
             return recursivelyResolvedPath

--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -1033,7 +1033,7 @@ open class FileManager : NSObject {
         NSUnimplemented()
     }
     
-    internal func _tryToResolveTrailingSymlinkInPath(_ path: String) -> String? {
+    internal func _tryToResolveTrailingSymlinkInPath(_ path: String, recursionLevel: Int = 0) -> String? {
         guard _pathIsSymbolicLink(path) else {
             return nil
         }
@@ -1042,7 +1042,20 @@ open class FileManager : NSObject {
             return nil
         }
         
-        return _appendSymlinkDestination(destination, toPath: path)
+        let resolvedPath = _appendSymlinkDestination(destination, toPath: path)
+        
+        guard recursionLevel >= 50 else {
+            return resolvedPath
+        }
+        
+        let recursivelyResolvedPath = _tryToResolveTrailingSymlinkInPath(resolvedPath, recursionLevel: recursionLevel + 1)
+        
+        if recursivelyResolvedPath != nil {
+            return recursivelyResolvedPath
+        }
+        else {
+            return resolvedPath
+        }
     }
     
     internal func _appendSymlinkDestination(_ dest: String, toPath: String) -> String {

--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -1044,7 +1044,7 @@ open class FileManager : NSObject {
         
         let resolvedPath = _appendSymlinkDestination(destination, toPath: path)
         
-        guard recursionLevel >= 50 else {
+        guard recursionLevel <= 50 else {
             return resolvedPath
         }
         

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -828,7 +828,7 @@ class TestFileManager : XCTestCase {
             
             try FileManager.default.removeItem(at: baseURL)
 
-            // D) Check infinite recursion loops are stopped and the function return the intial symlink
+            // D) Check infinite recursion loops are stopped and the function returns the intial symlink
             try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
             
             try FileManager.default.createSymbolicLink(at: link1URL, withDestinationURL: link2URL)

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -837,11 +837,8 @@ class TestFileManager : XCTestCase {
 
             let resolvedURL_D = link1URL.resolvingSymlinksInPath()
             
-            let destination_D1 = try FileManager.default.destinationOfSymbolicLink(atPath: resolvedURL_D.path)
-            let destination_D2 = try FileManager.default.destinationOfSymbolicLink(atPath: link1URL.path)
+            XCTAssertEqual(resolvedURL_D.lastPathComponent, link1URL.lastPathComponent)
 
-            XCTAssertEqual(destination_D1, destination_D2)
-            
             try FileManager.default.removeItem(at: baseURL)
         }
         catch {

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -776,7 +776,9 @@ class TestFileManager : XCTestCase {
         do {
 
             // Initialization
-            var baseURL = FileManager.default.temporaryDirectory.appendingPathComponent("test_resolvingSymlinksInPath")
+            var baseURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("test_resolvingSymlinksInPath")
+                .appendingPathComponent(UUID().uuidString)
             
             try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
 


### PR DESCRIPTION
Used by URL.resolvingSymlinksInPath().

The current Swift Foundation implementation only tries to solve the first symlink while Darwin Foundation tries to solve recursively all the symlinks.