### PR TITLE
[SR-3077] Bundle.main.executableURL returns incorrect values on Linux

### DIFF
--- a/CoreFoundation/PlugIn.subproj/CFBundle_Executable.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Executable.c
@@ -182,11 +182,7 @@ static CFURLRef _CFBundleCopyExecutableURLInDirectory2(CFBundleRef bundle, CFURL
         if (executablePath) CFRetain(executablePath);
         __CFUnlock(&bundle->_lock);
         if (executablePath) {
-#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI
-            executableURL = CFURLCreateWithFileSystemPath(kCFAllocatorSystemDefault, executablePath, kCFURLPOSIXPathStyle, false);
-#elif DEPLOYMENT_TARGET_WINDOWS
-            executableURL = CFURLCreateWithFileSystemPath(kCFAllocatorSystemDefault, executablePath, kCFURLWindowsPathStyle, false);
-#endif
+            executableURL = CFURLCreateWithFileSystemPath(kCFAllocatorSystemDefault, executablePath, PLATFORM_PATH_STYLE, false);
             if (executableURL) {
                 foundIt = true;
             }

--- a/TestFoundation/TestBundle.swift
+++ b/TestFoundation/TestBundle.swift
@@ -250,6 +250,7 @@ class TestBundle : XCTestCase {
             ("test_bundlePreflight", test_bundlePreflight),
             ("test_bundleFindExecutable", test_bundleFindExecutable),
             ("test_bundleFindAuxiliaryExecutables", test_bundleFindAuxiliaryExecutables),
+            ("test_mainBundleExecutableURL", test_mainBundleExecutableURL),
         ]
     }
     
@@ -438,5 +439,13 @@ class TestBundle : XCTestCase {
             XCTAssertNotNil(bundle.url(forAuxiliaryExecutable: _auxiliaryExecutable))
             XCTAssertNil(bundle.url(forAuxiliaryExecutable: "does_not_exist_at_all"))
         }
+    }
+    
+    func test_mainBundleExecutableURL() {
+        let maybeURL = Bundle.main.executableURL
+        XCTAssertNotNil(maybeURL)
+        guard let url = maybeURL else { return }
+        
+        XCTAssertEqual(url.path, String(cString: _CFProcessPath()))
     }
 }


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-3077

We were doing nothing with the executable path here unless the platform was Darwin or Windows. Use the PLATFORM_PATH_STYLE macro here instead to ensure all platforms execute this.