### PR TITLE
Fix NSString.boolValue not matching Darwin Foundation

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -633,13 +633,19 @@ extension NSString {
         let scanner = Scanner(string: _swiftObject)
         // skip initial whitespace if present
         let _ = scanner.scanCharactersFromSet(.whitespaces)
+
+        if scanner.scanCharactersFromSet(CharacterSet(charactersIn: "tTyY")) != nil {
+            return true
+        }
+
         // scan a single optional '+' or '-' character, followed by zeroes
         if scanner.scanString("+") == nil {
             let _ = scanner.scanString("-")
         }
+        
         // scan any following zeroes
         let _ = scanner.scanCharactersFromSet(CharacterSet(charactersIn: "0"))
-        return scanner.scanCharactersFromSet(CharacterSet(charactersIn: "tTyY123456789")) != nil
+        return scanner.scanCharactersFromSet(CharacterSet(charactersIn: "123456789")) != nil
     }
 
     public var uppercased: String {

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -99,7 +99,7 @@ class TestNSString : XCTestCase {
         for string in trueStrings {
             XCTAssert(string.boolValue)
         }
-        let falseStrings: [NSString] = ["false", "FALSE", "fAlSe", "no", "NO", "0", "<true>", "_true", "-00000"]
+        let falseStrings: [NSString] = ["false", "FALSE", "fAlSe", "no", "NO", "0", "<true>", "_true", "-00000", "+t", "+", "0t", "++"]
         for string in falseStrings {
             XCTAssertFalse(string.boolValue)
         }


### PR DESCRIPTION
There were some cases which were being evaluated to `true` but on Darwin/Objective-C they evaluate to `false`.