### PR TITLE
[4.2] Adopt ‘as’ bridging on Linux

### DIFF
--- a/Foundation/AffineTransform.swift
+++ b/Foundation/AffineTransform.swift
@@ -476,7 +476,7 @@ open class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
     }
 }
 
-extension AffineTransform : _ObjectTypeBridgeable {
+extension AffineTransform : _ObjectiveCBridgeable {
     public static func _isBridgedToObjectiveC() -> Bool {
         return true
     }

--- a/Foundation/Array.swift
+++ b/Foundation/Array.swift
@@ -7,7 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-extension Array : _ObjectTypeBridgeable {
+extension Array : _ObjectiveCBridgeable {
     
     public typealias _ObjectType = NSArray
     public func _bridgeToObjectiveC() -> _ObjectType {

--- a/Foundation/Calendar.swift
+++ b/Foundation/Calendar.swift
@@ -1163,7 +1163,7 @@ extension Calendar : CustomDebugStringConvertible, CustomStringConvertible, Cust
     }
 }
 
-extension Calendar: _ObjectTypeBridgeable {
+extension Calendar: _ObjectiveCBridgeable {
     public typealias _ObjectType = NSCalendar
     
     @_semantics("convertToObjectiveC")

--- a/Foundation/CharacterSet.swift
+++ b/Foundation/CharacterSet.swift
@@ -481,7 +481,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
 
 
 // MARK: Objective-C Bridging
-extension CharacterSet : _ObjectTypeBridgeable {
+extension CharacterSet : _ObjectiveCBridgeable {
     public static func _isBridgedToObjectiveC() -> Bool {
         return true
     }

--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -1893,13 +1893,7 @@ extension Data {
 
 /// Provides bridging functionality for struct Data to class NSData and vice-versa.
 
-#if DEPLOYMENT_RUNTIME_SWIFT
-internal typealias DataBridgeType = _ObjectTypeBridgeable
-#else
-internal typealias DataBridgeType = _ObjectiveCBridgeable
-#endif
-
-extension Data : DataBridgeType {
+extension Data : _ObjectiveCBridgeable {
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSData {
         return _backing.bridgedReference(_sliceRange)

--- a/Foundation/Date.swift
+++ b/Foundation/Date.swift
@@ -230,7 +230,7 @@ extension Date : CustomDebugStringConvertible, CustomStringConvertible, CustomRe
     }
 }
 
-extension Date : _ObjectTypeBridgeable {
+extension Date : _ObjectiveCBridgeable {
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSDate {
         return NSDate(timeIntervalSinceReferenceDate: _time)

--- a/Foundation/DateComponents.swift
+++ b/Foundation/DateComponents.swift
@@ -352,7 +352,7 @@ extension DateComponents : CustomStringConvertible, CustomDebugStringConvertible
 
 // MARK: - Bridging
 
-extension DateComponents : _ObjectTypeBridgeable {
+extension DateComponents : _ObjectiveCBridgeable {
     public static func _isBridgedToObjectiveC() -> Bool {
         return true
     }

--- a/Foundation/DateInterval.swift
+++ b/Foundation/DateInterval.swift
@@ -187,7 +187,7 @@ extension DateInterval : CustomStringConvertible, CustomDebugStringConvertible, 
     }
 }
 
-extension DateInterval : _ObjectTypeBridgeable {
+extension DateInterval : _ObjectiveCBridgeable {
     public static func _isBridgedToObjectiveC() -> Bool {
         return true
     }

--- a/Foundation/Dictionary.swift
+++ b/Foundation/Dictionary.swift
@@ -9,7 +9,7 @@
 
 import CoreFoundation
 
-extension Dictionary : _ObjectTypeBridgeable {
+extension Dictionary : _ObjectiveCBridgeable {
     
     public typealias _ObjectType = NSDictionary
     public func _bridgeToObjectiveC() -> _ObjectType {

--- a/Foundation/IndexPath.swift
+++ b/Foundation/IndexPath.swift
@@ -774,13 +774,7 @@ extension IndexPath : CustomStringConvertible, CustomDebugStringConvertible, Cus
     }
 }
 
-#if DEPLOYMENT_RUNTIME_SWIFT
-internal typealias IndexPathBridgeType = _ObjectTypeBridgeable
-#else
-internal typealias IndexPathBridgeType = _ObjectiveCBridgeable
-#endif
-
-extension IndexPath : IndexPathBridgeType {
+extension IndexPath : _ObjectiveCBridgeable {
     public static func _getObjectiveCType() -> Any.Type {
         return NSIndexPath.self
     }

--- a/Foundation/IndexSet.swift
+++ b/Foundation/IndexSet.swift
@@ -790,13 +790,7 @@ private func _toNSRange(_ r: Range<IndexSet.Element>) -> NSRange {
     return NSRange(location: r.lowerBound, length: r.upperBound - r.lowerBound)
 }
 
-#if DEPLOYMENT_RUNTIME_SWIFT
-internal typealias IndexSetBridgeType = _ObjectTypeBridgeable
-#else
-internal typealias IndexSetBridgeType = _ObjectiveCBridgeable
-#endif
-
-extension IndexSet : IndexSetBridgeType {
+extension IndexSet : _ObjectiveCBridgeable {
     public static func _getObjectiveCType() -> Any.Type {
         return NSIndexSet.self
     }

--- a/Foundation/JSONSerialization.swift
+++ b/Foundation/JSONSerialization.swift
@@ -62,10 +62,12 @@ open class JSONSerialization : NSObject {
                 return true
             }
             
-            if obj is String || obj is NSNull || obj is Int || obj is Bool || obj is UInt ||
-                obj is Int8 || obj is Int16 || obj is Int32 || obj is Int64 ||
-                obj is UInt8 || obj is UInt16 || obj is UInt32 || obj is UInt64 {
-                return true
+            if !(obj is _NSNumberCastingWithoutBridging) {
+              if obj is String || obj is NSNull || obj is Int || obj is Bool || obj is UInt ||
+                  obj is Int8 || obj is Int16 || obj is Int32 || obj is Int64 ||
+                  obj is UInt8 || obj is UInt16 || obj is UInt32 || obj is UInt64 {
+                  return true
+              }
             }
 
             // object is a Double and is not NaN or infinity
@@ -315,12 +317,19 @@ private struct JSONWriter {
         self.writer = writer
     }
     
-    mutating func serializeJSON(_ obj: Any?) throws {
+    mutating func serializeJSON(_ object: Any?) throws {
 
-        guard let obj = obj else {
+        var toSerialize = object
+
+        if let number = toSerialize as? _NSNumberCastingWithoutBridging {
+            toSerialize = number._swiftValueOfOptimalType
+        }
+        
+        guard let obj = toSerialize else {
             try serializeNull()
             return
         }
+        
         // For better performance, the most expensive conditions to evaluate should be last.
         switch (obj) {
         case let str as String:

--- a/Foundation/Locale.swift
+++ b/Foundation/Locale.swift
@@ -439,7 +439,7 @@ public struct Locale : CustomStringConvertible, CustomDebugStringConvertible, Ha
 }
 
 
-extension Locale : _ObjectTypeBridgeable {
+extension Locale : _ObjectiveCBridgeable {
     public static func _isBridgedToObjectiveC() -> Bool {
         return true
     }

--- a/Foundation/Measurement.swift
+++ b/Foundation/Measurement.swift
@@ -206,14 +206,8 @@ extension Measurement {
 
 // Implementation note: similar to NSArray, NSDictionary, etc., NSMeasurement's import as an ObjC generic type is suppressed by the importer. Eventually we will need a more general purpose mechanism to correctly import generic types.
 
-#if DEPLOYMENT_RUNTIME_SWIFT
-internal typealias MeasurementBridgeType = _ObjectTypeBridgeable
-#else
-internal typealias MeasurementBridgeType = _ObjectiveCBridgeable
-#endif
-
 @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-extension Measurement : MeasurementBridgeType {
+extension Measurement : _ObjectiveCBridgeable {
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSMeasurement {
         return NSMeasurement(doubleValue: value, unit: unit)

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -334,13 +334,12 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
                 if val1 != val2 {
                     return false
                 }
-            } else if let val1 = object(at: idx) as? _ObjectBridgeable,
-                let val2 = otherArray[idx] as? _ObjectBridgeable {
-                if !(val1._bridgeToAnyObject() as! NSObject).isEqual(val2._bridgeToAnyObject()) {
+            } else {
+              let val1 = object(at: idx)
+              let val2 = otherArray[idx]
+                if !((val1 as AnyObject) as! NSObject).isEqual(val2 as AnyObject) {
                     return false
                 }
-            } else {
-                return false
             }
         }
         

--- a/Foundation/NSDecimalNumber.swift
+++ b/Foundation/NSDecimalNumber.swift
@@ -297,28 +297,28 @@ open class NSDecimalNumber : NSNumber {
     // return 'd' for double
     
     open override var int8Value: Int8 {
-        return Int8(decimal.doubleValue)
+        return Int8(exactly: decimal.doubleValue) ?? 0 as Int8
     }
     open override var uint8Value: UInt8 {
-        return UInt8(decimal.doubleValue)
+        return UInt8(exactly: decimal.doubleValue) ?? 0 as UInt8
     }
     open override var int16Value: Int16 {
-        return Int16(decimal.doubleValue)
+        return Int16(exactly: decimal.doubleValue) ?? 0 as Int16
     }
     open override var uint16Value: UInt16 {
-        return UInt16(decimal.doubleValue)
+        return UInt16(exactly: decimal.doubleValue) ?? 0 as UInt16
     }
     open override var int32Value: Int32 {
-        return Int32(decimal.doubleValue)
+        return Int32(exactly: decimal.doubleValue) ?? 0 as Int32
     }
     open override var uint32Value: UInt32 {
-        return UInt32(decimal.doubleValue)
+        return UInt32(exactly: decimal.doubleValue) ?? 0 as UInt32
     }
     open override var int64Value: Int64 {
-        return Int64(decimal.doubleValue)
+        return Int64(exactly: decimal.doubleValue) ?? 0 as Int64
     }
     open override var uint64Value: UInt64 {
-        return UInt64(decimal.doubleValue)
+        return UInt64(exactly: decimal.doubleValue) ?? 0 as UInt64
     }
     open override var floatValue: Float {
         return Float(decimal.doubleValue)
@@ -330,10 +330,10 @@ open class NSDecimalNumber : NSNumber {
         return !decimal.isZero
     }
     open override var intValue: Int {
-        return Int(decimal.doubleValue)
+        return Int(exactly: decimal.doubleValue) ?? 0 as Int
     }
     open override var uintValue: UInt {
-        return UInt(decimal.doubleValue)
+        return UInt(exactly: decimal.doubleValue) ?? 0 as UInt
     }
 
     open override func isEqual(_ value: Any?) -> Bool {
@@ -341,6 +341,9 @@ open class NSDecimalNumber : NSNumber {
         return self.decimal == other.decimal
     }
 
+    override var _swiftValueOfOptimalType: Any {
+      return decimal
+    }
 }
 
 // return an approximate double value

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -395,13 +395,12 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
                 if otherValue != value {
                     return false
                 }
-            } else if let otherBridgeable = otherDictionary[key as! AnyHashable] as? _ObjectBridgeable,
-                      let bridgeable = object(forKey: key)! as? _ObjectBridgeable {
-                if !(otherBridgeable._bridgeToAnyObject() as! NSObject).isEqual(bridgeable._bridgeToAnyObject()) {
+            } else {
+              let otherBridgeable = otherDictionary[key as! AnyHashable]
+              let bridgeable = object(forKey: key)!
+                if !((otherBridgeable as AnyObject) as! NSObject).isEqual(bridgeable as AnyObject) {
                     return false
                 }
-            } else {
-                return false
             }
         }
         

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -597,9 +597,7 @@ open class NSKeyedArchiver : NSCoder {
         object = _replacementObject(objv)
         
         // bridge value types
-        if let bridgedObject = object as? _ObjectBridgeable {
-            object = bridgedObject._bridgeToAnyObject()
-        }
+        object = object as AnyObject
         
         objectRef = _referenceObject(object, conditional: conditional)
         guard let unwrappedObjectRef = objectRef else {

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -483,12 +483,7 @@ open class NSKeyedUnarchiver : NSCoder {
                 _cacheObject(object!, forReference: objectRef as! _NSKeyedArchiverUID)
             }
         } else {
-            // reference to a non-container object
-            if let bridgedObject = dereferencedObject as? _ObjectBridgeable {
-                object = bridgedObject._bridgeToAnyObject()
-            } else {
-                object = dereferencedObject
-            }
+            object = dereferencedObject as AnyObject
         }
 
         return _replacementObject(object)

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -32,7 +32,7 @@ internal let kCFNumberSInt128Type = CFNumberType(rawValue: 17)!
 internal let kCFNumberSInt128Type: CFNumberType = 17
 #endif
 
-extension Int8 : _ObjectTypeBridgeable {
+extension Int8 : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.int8Value
@@ -70,7 +70,7 @@ extension Int8 : _ObjectTypeBridgeable {
     }
 }
 
-extension UInt8 : _ObjectTypeBridgeable {
+extension UInt8 : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.uint8Value
@@ -108,7 +108,7 @@ extension UInt8 : _ObjectTypeBridgeable {
     }
 }
 
-extension Int16 : _ObjectTypeBridgeable {
+extension Int16 : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.int16Value
@@ -146,7 +146,7 @@ extension Int16 : _ObjectTypeBridgeable {
     }
 }
 
-extension UInt16 : _ObjectTypeBridgeable {
+extension UInt16 : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.uint16Value
@@ -184,7 +184,7 @@ extension UInt16 : _ObjectTypeBridgeable {
     }
 }
 
-extension Int32 : _ObjectTypeBridgeable {
+extension Int32 : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.int32Value
@@ -222,7 +222,7 @@ extension Int32 : _ObjectTypeBridgeable {
     }
 }
 
-extension UInt32 : _ObjectTypeBridgeable {
+extension UInt32 : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.uint32Value
@@ -260,7 +260,7 @@ extension UInt32 : _ObjectTypeBridgeable {
     }
 }
 
-extension Int64 : _ObjectTypeBridgeable {
+extension Int64 : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.int64Value
@@ -298,7 +298,7 @@ extension Int64 : _ObjectTypeBridgeable {
     }
 }
 
-extension UInt64 : _ObjectTypeBridgeable {
+extension UInt64 : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.uint64Value
@@ -336,7 +336,7 @@ extension UInt64 : _ObjectTypeBridgeable {
     }
 }
 
-extension Int : _ObjectTypeBridgeable {
+extension Int : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.intValue
@@ -374,7 +374,7 @@ extension Int : _ObjectTypeBridgeable {
     }
 }
 
-extension UInt : _ObjectTypeBridgeable {
+extension UInt : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.uintValue
@@ -412,7 +412,7 @@ extension UInt : _ObjectTypeBridgeable {
     }
 }
 
-extension Float : _ObjectTypeBridgeable {
+extension Float : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.floatValue
@@ -461,7 +461,7 @@ extension Float : _ObjectTypeBridgeable {
     }
 }
 
-extension Double : _ObjectTypeBridgeable {
+extension Double : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.doubleValue
@@ -512,7 +512,7 @@ extension Double : _ObjectTypeBridgeable {
     }
 }
 
-extension Bool : _ObjectTypeBridgeable {
+extension Bool : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.boolValue
@@ -584,6 +584,13 @@ open class NSNumber : NSValue {
     }
     
     open override func isEqual(_ value: Any?) -> Bool {
+        // IMPORTANT:
+        // .isEqual() is invoked by the bridging machinery that gets triggered whenever you use '(-a NSNumber value-) as{,?,!} Int', so using a refutable pattern ('case let other as NSNumber') below will cause an infinite loop if value is an Int, and similarly for other types we can bridge to.
+        // To prevent this, _this check must come first._ If you change it, _do not use the 'as' operator_ or any of its variants _unless_ you know that value _is_ actually a NSNumber to avoid infinite loops. ('is' is fine.)
+        if let value = value, value is NSNumber {
+            return compare(value as! NSNumber) == .orderedSame
+        }
+        
         switch value {
         case let other as Int:
             return intValue == other
@@ -591,8 +598,6 @@ open class NSNumber : NSValue {
             return doubleValue == other
         case let other as Bool:
             return boolValue == other
-        case let other as NSNumber:
-            return compare(other) == .orderedSame
         default:
             return false
         }
@@ -645,7 +650,12 @@ open class NSNumber : NSValue {
         case kCFNumberFloat64Type:
             return doubleValue
         case kCFNumberSInt128Type:
-            return int128Value
+            // If the high portion is 0, return just the low portion as a UInt64, which reasonably fixes trying to roundtrip UInt.max and UInt64.max.
+            if int128Value.high == 0 {
+                return int128Value.low
+            } else {
+                return int128Value                
+            }
         default:
             fatalError("unsupported CFNumberType: '\(numberType)'")
         }
@@ -1077,3 +1087,9 @@ internal func _CFSwiftNumberGetValue(_ obj: CFTypeRef, _ valuePtr: UnsafeMutable
 internal func _CFSwiftNumberGetBoolValue(_ obj: CFTypeRef) -> Bool {
     return unsafeBitCast(obj, to: NSNumber.self).boolValue
 }
+
+protocol _NSNumberCastingWithoutBridging {
+  var _swiftValueOfOptimalType: Any { get }
+}
+
+extension NSNumber: _NSNumberCastingWithoutBridging {}

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -107,7 +107,10 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
         return true
     }
     
-    open func description(withLocale locale: Locale?) -> String { NSUnimplemented() }
+    open func description(withLocale locale: Locale?) -> String { 
+      // NSUnimplemented() 
+      return description
+    }
     
     override open var _cfTypeID: CFTypeID {
         return CFSetGetTypeID()

--- a/Foundation/Notification.swift
+++ b/Foundation/Notification.swift
@@ -91,7 +91,7 @@ extension Notification : CustomReflectable {
 }
 
 
-extension Notification : _ObjectTypeBridgeable {
+extension Notification : _ObjectiveCBridgeable {
     public static func _getObjectiveCType() -> Any.Type {
         return NSNotification.self
     }

--- a/Foundation/PersonNameComponents.swift
+++ b/Foundation/PersonNameComponents.swift
@@ -102,7 +102,7 @@ extension PersonNameComponents : CustomStringConvertible, CustomDebugStringConve
     }
 }
 
-extension PersonNameComponents : _ObjectTypeBridgeable {
+extension PersonNameComponents : _ObjectiveCBridgeable {
     public static func _getObjectiveCType() -> Any.Type {
         return NSPersonNameComponents.self
     }

--- a/Foundation/Set.swift
+++ b/Foundation/Set.swift
@@ -9,13 +9,13 @@
 
 import CoreFoundation
 
-extension Set : _ObjectTypeBridgeable {
+extension Set : _ObjectiveCBridgeable {
     public typealias _ObjectType = NSSet
     public func _bridgeToObjectiveC() -> _ObjectType {
         let buffer = UnsafeMutablePointer<AnyObject>.allocate(capacity: count)
         
         for (idx, obj) in enumerated() {
-            buffer.advanced(by: idx).initialize(to: (obj as! _ObjectBridgeable)._bridgeToAnyObject())
+            buffer.advanced(by: idx).initialize(to: obj as AnyObject)
         }
         
         let set = NSSet(objects: buffer, count: count)

--- a/Foundation/String.swift
+++ b/Foundation/String.swift
@@ -12,7 +12,7 @@
 
 import CoreFoundation
 
-extension String : _ObjectTypeBridgeable {
+extension String : _ObjectiveCBridgeable {
     
     public typealias _ObjectType = NSString
     public func _bridgeToObjectiveC() -> _ObjectType {

--- a/Foundation/URL.swift
+++ b/Foundation/URL.swift
@@ -955,7 +955,7 @@ public struct URL : ReferenceConvertible, Equatable {
     }
 }
 
-extension URL : _ObjectTypeBridgeable {
+extension URL : _ObjectiveCBridgeable {
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSURL {
         return _url

--- a/Foundation/URLComponents.swift
+++ b/Foundation/URLComponents.swift
@@ -395,7 +395,7 @@ extension URLQueryItem : _NSBridgeable {
     internal var _nsObject: NSType { return _queryItem }
 }
 
-extension URLComponents : _ObjectTypeBridgeable {
+extension URLComponents : _ObjectiveCBridgeable {
     public typealias _ObjectType = NSURLComponents
     
     public static func _getObjectiveCType() -> Any.Type {
@@ -425,7 +425,7 @@ extension URLComponents : _ObjectTypeBridgeable {
     }
 }
 
-extension URLQueryItem : _ObjectTypeBridgeable {
+extension URLQueryItem : _ObjectiveCBridgeable {
     public typealias _ObjectType = NSURLQueryItem
     
     public static func _getObjectiveCType() -> Any.Type {

--- a/Foundation/URLRequest.swift
+++ b/Foundation/URLRequest.swift
@@ -267,7 +267,7 @@ extension URLRequest : CustomStringConvertible, CustomDebugStringConvertible, Cu
     }
 }
 
-extension URLRequest : _ObjectTypeBridgeable {
+extension URLRequest : _ObjectiveCBridgeable {
     public static func _getObjectiveCType() -> Any.Type {
         return NSURLRequest.self
     }

--- a/Foundation/UUID.swift
+++ b/Foundation/UUID.swift
@@ -131,7 +131,7 @@ extension UUID : CustomReflectable {
     }
 }
 
-extension UUID : _ObjectTypeBridgeable {
+extension UUID : _ObjectiveCBridgeable {
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSUUID {
         return reference

--- a/TestFoundation/TestJSONSerialization.swift
+++ b/TestFoundation/TestJSONSerialization.swift
@@ -1207,7 +1207,8 @@ extension TestJSONSerialization {
     }
     
     func test_serialize_UIntMin() {
-        let json: [Any] = [UInt.min]
+        let array: [UInt] = [UInt.min]
+        let json = array as [Any]
         XCTAssertEqual(try trySerialize(json), "[\(UInt.min)]")
     }
 

--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -50,7 +50,7 @@ public class NSUserClass : NSObject, NSSecureCoding {
     }
 }
 
-public class UserClass : CustomStringConvertible, Equatable, Hashable, NSSecureCoding {
+public class UserClass : NSObject, NSSecureCoding {
     var ivar : Int
     
     public class var supportsSecureCoding: Bool {
@@ -63,24 +63,26 @@ public class UserClass : CustomStringConvertible, Equatable, Hashable, NSSecureC
     
     init(_ value: Int) {
         self.ivar = value
+        super.init()
     }
     
     public required init?(coder aDecoder: NSCoder) {
         self.ivar = aDecoder.decodeInteger(forKey: "$ivar")
+        super.init()
     }
     
-    public var description: String {
+    public override var description: String {
         get {
             return "UserClass \(ivar)"
         }
     }
     
-    public static func ==(lhs: UserClass, rhs: UserClass) -> Bool {
-        return lhs.ivar == rhs.ivar
-    }
-    
-    public var hashValue: Int {
-        return ivar
+    public override func isEqual(_ other: Any?) -> Bool {
+      guard let other = other as? UserClass else {
+        return false
+      }
+      
+      return ivar == other.ivar
     }
 }
 


### PR DESCRIPTION
This is a cherry-pick without changes to `swift-4.2-branch` of 1da6fc8ccbce77bfc4cc4fffa6de260ee8589708, which enables 'as' bridging between value types and Foundation reference types and some other forms of bridging. Full discussion and history is at https://github.com/apple/swift-corelibs-foundation/pull/1526.