### PR TITLE
[SR-953] Implement Bundle(for: class)

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -353,6 +353,9 @@ CF_EXPORT CFStringRef _CFXDGCreateCacheDirectoryPath(void);
 /// a single base directory relative to which user-specific runtime files and other file objects should be placed. This directory is defined by the environment variable $XDG_RUNTIME_DIR.
 CF_EXPORT CFStringRef _CFXDGCreateRuntimeDirectoryPath(void);
 
+// The argument is the unsafeBitCast(<the AnyClass>, to: UnsafeRawPointer.self)
+CF_EXPORT __attribute__((visibility("default")))
+CFStringRef _Nullable _CFBundleDlfcnCopyPathToBinaryContainingSwiftClass(const void *_Nullable swiftClass);
 
 typedef struct {
     void *_Nonnull memory;

--- a/CoreFoundation/PlugIn.subproj/CFBundle.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle.c
@@ -1753,7 +1753,7 @@ CF_EXPORT CFURLRef CFBundleCopyBuiltInPlugInsURL(CFBundleRef bundle) {
 #if DEPLOYMENT_RUNTIME_SWIFT
 
 // SPI from the Swift runtime:
-extern const void *_swift_getTypeContextDescriptor(const void *swiftClass);
+extern const void *swift_getTypeContextDescriptor(const void *swiftClass);
 
 CF_EXPORT __attribute__((visibility("default")))
 CFStringRef _CFBundleDlfcnCopyPathToBinaryContainingSwiftClass(const void *swiftClass) {
@@ -1764,7 +1764,7 @@ CFStringRef _CFBundleDlfcnCopyPathToBinaryContainingSwiftClass(const void *swift
     Dl_info info = { 0 };
     
     // For AOT classes, the type context descriptor is guaranteed to come from the binary that has the symbols for that class. Thus, dladdr() can place it.
-    const void *descriptor = _swift_getTypeContextDescriptor(swiftClass);
+    const void *descriptor = swift_getTypeContextDescriptor(swiftClass);
     int result = dladdr(descriptor, &info);
     
     if (result == 0 || !info.dli_fname) {

--- a/Foundation/Bundle.swift
+++ b/Foundation/Bundle.swift
@@ -57,20 +57,11 @@ open class Bundle: NSObject {
         let pointer = unsafeBitCast(aClass, to: UnsafeRawPointer.self)
         
         if let path = _CFBundleDlfcnCopyPathToBinaryContainingSwiftClass(pointer) {
-            
-            // dladdr() on Linux is documented to return argv[0]
-            // If this is argv[0], do not create a new bundle (which will use the main bundle below).
-            let pathNS = unsafeBitCast(path, to: NSString.self)
-            let pathString = pathNS as String
-            if ProcessInfo.processInfo.arguments.first != pathString {
-                
-                let url = unsafeBitCast(NSURL(fileURLWithPath: pathString), to: CFURL.self)
-                if let bundleURL = _CFBundleCopyBundleURLForExecutableURL(url) {
-                    _bundle = CFBundleCreate(kCFAllocatorSystemDefault, bundleURL.takeRetainedValue())
-                } else {
-                    fatalError("Class '\(aClass)' resolved to path \(pathNS) but couldn't find a bundle associated with that executable.")
-                }
-                
+            let url = unsafeBitCast(NSURL(fileURLWithPath: pathString), to: CFURL.self)
+            if let bundleURL = _CFBundleCopyBundleURLForExecutableURL(url)?.takeRetainedValue() {
+                _bundle = CFBundleCreate(kCFAllocatorSystemDefault, bundleURL())
+            } else {
+                fatalError("Class '\(aClass)' resolved to path \(pathNS) but couldn't find a bundle associated with that executable.")
             }
         }
         


### PR DESCRIPTION
Implements Bundle(for:) by using `dladdr()` on the type descriptor of a class. For further discussion, see https://github.com/apple/swift/pull/16964, which is a dependency of this patch.

Resolves [SR-953](https://bugs.swift.org/browse/SR-953).