### PR TITLE
Make Range-from-NSRange generic over StringProtocol

### DIFF
--- a/Foundation/NSRange.swift
+++ b/Foundation/NSRange.swift
@@ -290,17 +290,14 @@ extension Range where Bound == Int {
 }
 
 extension Range where Bound == String.Index {
-    public init?(_ range: NSRange, in string: String) {
-        let u = string.utf16
-        guard range.location != NSNotFound,
-            let start = u.index(u.startIndex, offsetBy: range.location, limitedBy: u.endIndex),
-            let end = u.index(u.startIndex, offsetBy: range.location + range.length, limitedBy: u.endIndex),
-            let lowerBound = String.Index(start, within: string),
-            let upperBound = String.Index(end, within: string)
-            else { return nil }
-        
-        self = lowerBound..<upperBound
-    }
+  public init?<S: StringProtocol>(_ range: NSRange, in string: S) where S.UTF16View.Index == String.Index {
+    let u = string.utf16
+    guard range.location != NSNotFound,
+      let start = u.index(u.startIndex, offsetBy: range.location, limitedBy: u.endIndex),
+      let end = u.index(u.startIndex, offsetBy: range.location + range.length, limitedBy: u.endIndex)
+      else { return nil }
+    self = start..<end
+  }
 }
 
 extension NSRange : CustomReflectable {


### PR DESCRIPTION
This means you can take an NSRange and resolve it relative to a Substring.

This can come up sometimes when working with Substrings on the Swift level and working with Objective-C APIs which return NSRange (e.g. NSRegularExpression). You need to copy to a String when performing matching, but the matched ranges can be resolved relative to the original String.