### PR TITLE
[SR-7861] Fix for HTTP redirect failure on Linux

### DIFF
--- a/Foundation/URLSession/http/HTTPURLProtocol.swift
+++ b/Foundation/URLSession/http/HTTPURLProtocol.swift
@@ -401,10 +401,12 @@ internal extension _HTTPURLProtocol {
 
         let scheme = request.url?.scheme
         let host = request.url?.host
+        let port = request.url?.port
 
         var components = URLComponents()
         components.scheme = scheme
         components.host = host
+        components.port = port
         //The path must either begin with "/" or be an empty string.
         if targetURL.relativeString.first != "/" {
             components.path = "/" + targetURL.relativeString


### PR DESCRIPTION
Codepaths in `HTTPURLProtocol` missed to assign the port for the new redirect request which leads to the failure in redirection.