### PR TITLE
[SR-7865] swift-corelibs-foundation does not compile on macOS after 'as' bridging was merged

### DIFF
--- a/Foundation/Bridging.swift
+++ b/Foundation/Bridging.swift
@@ -54,8 +54,13 @@ internal protocol _NSBridgeable {
 }
 
 
+#if !canImport(ObjectiveC)
+// The _NSSwiftValue protocol is in the stdlib, and only available on platforms without ObjC.
+extension _SwiftValue: _NSSwiftValue {}
+#endif
+
 /// - Note: This is an internal boxing value for containing abstract structures
-internal final class _SwiftValue : NSObject, NSCopying, _NSSwiftValue {
+internal final class _SwiftValue : NSObject, NSCopying {
     public private(set) var value: Any
     
     static func fetch(_ object: AnyObject?) -> Any? {

--- a/Foundation/Bridging.swift
+++ b/Foundation/Bridging.swift
@@ -150,7 +150,7 @@ internal final class _SwiftValue : NSObject, NSCopying {
             // as if we returned the unboxed value directly.
         }
         
-        // On Linux, case 2 is handled below, and case 3 can't happen —
+        // On Linux, case 2 is handled by the stdlib bridging machinery, and case 3 can't happen —
         // the compiler will produce SwiftFoundation._SwiftValue boxes rather than ObjC ones.
         #endif
         
@@ -158,8 +158,6 @@ internal final class _SwiftValue : NSObject, NSCopying {
             return true
         } else if object === kCFBooleanFalse {
             return false
-        } else if type(of: object) == NSNull.self {
-            return Optional<Any>.none as Any
         } else if let container = object as? _SwiftValue {
             return container.value
         } else if let val = object as? _StructBridgeable {

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -337,7 +337,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
             } else {
               let val1 = object(at: idx)
               let val2 = otherArray[idx]
-                if !((val1 as AnyObject) as! NSObject).isEqual(val2 as AnyObject) {
+                if !_SwiftValue.store(val1).isEqual(_SwiftValue.store(val2)) {
                     return false
                 }
             }

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -396,9 +396,10 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
                     return false
                 }
             } else {
-              let otherBridgeable = otherDictionary[key as! AnyHashable]
-              let bridgeable = object(forKey: key)!
-                if !((otherBridgeable as AnyObject) as! NSObject).isEqual(bridgeable as AnyObject) {
+                let otherBridgeable = otherDictionary[key as! AnyHashable]
+                let bridgeable = object(forKey: key)!
+                let equal = _SwiftValue.store(optional: otherBridgeable)?.isEqual(_SwiftValue.store(bridgeable))
+                if equal != true {
                     return false
                 }
             }

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -1383,6 +1383,8 @@ enum UnknownNSError: Error {
     case missingError
 }
 
+#if !canImport(ObjectiveC)
+
 public // COMPILER_INTRINSIC
 func _convertNSErrorToError(_ error: NSError?) -> Error {
     return error ?? UnknownNSError.missingError
@@ -1410,3 +1412,6 @@ func _convertErrorToNSError(_ error: Error) -> NSError {
         return NSError(domain: domain, code: code, userInfo: userInfo)
     }
 }
+
+#endif
+

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -597,7 +597,7 @@ open class NSKeyedArchiver : NSCoder {
         object = _replacementObject(objv)
         
         // bridge value types
-        object = object as AnyObject
+        object = _SwiftValue.store(object)
         
         objectRef = _referenceObject(object, conditional: conditional)
         guard let unwrappedObjectRef = objectRef else {

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -483,7 +483,7 @@ open class NSKeyedUnarchiver : NSCoder {
                 _cacheObject(object!, forReference: objectRef as! _NSKeyedArchiverUID)
             }
         } else {
-            object = dereferencedObject as AnyObject
+            object = _SwiftValue.store(dereferencedObject)
         }
 
         return _replacementObject(object)

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -46,7 +46,7 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
         super.init()
         let buffer = UnsafeBufferPointer(start: objects, count: cnt)
         for obj in buffer {
-            _storage.insert(obj as! NSObject)
+            _storage.insert(_SwiftValue.store(obj))
         }
     }
     


### PR DESCRIPTION
The new primitives are only available if Objective-C isn't. Guard them with `#canImport(ObjectiveC)`.

(Additionally, see below for discussion.)

Resolves [SR-7865](https://bugs.swift.org/browse/SR-7865).