### PR TITLE
[SR-6396] URLSessionConfiguration, renamed discretionary to isDiscretionary

### DIFF
--- a/Foundation/URLSession/Configuration.swift
+++ b/Foundation/URLSession/Configuration.swift
@@ -39,7 +39,7 @@ internal extension URLSession {
         let allowsCellularAccess: Bool
         
         /// allows background tasks to be scheduled at the discretion of the system for optimal performance.
-        let discretionary: Bool
+        let isDiscretionary: Bool
         
         /// The proxy dictionary, as described by <CFNetwork/CFHTTPStream.h>
         let connectionProxyDictionary: [AnyHashable : Any]?
@@ -83,7 +83,7 @@ internal extension URLSession._Configuration {
         timeoutIntervalForResource = config.timeoutIntervalForResource
         networkServiceType = config.networkServiceType
         allowsCellularAccess = config.allowsCellularAccess
-        discretionary = config.discretionary
+        isDiscretionary = config.isDiscretionary
         connectionProxyDictionary = config.connectionProxyDictionary
         httpShouldUsePipelining = config.httpShouldUsePipelining
         httpShouldSetCookies = config.httpShouldSetCookies

--- a/Foundation/URLSession/URLSessionConfiguration.swift
+++ b/Foundation/URLSession/URLSessionConfiguration.swift
@@ -38,7 +38,7 @@ open class URLSessionConfiguration : NSObject, NSCopying {
         self.timeoutIntervalForResource = 604800
         self.networkServiceType = .default
         self.allowsCellularAccess = true
-        self.discretionary = false
+        self.isDiscretionary = false
         self.httpShouldUsePipelining = false
         self.httpShouldSetCookies = true
         self.httpCookieAcceptPolicy = .onlyFromMainDocumentDomain
@@ -57,7 +57,7 @@ open class URLSessionConfiguration : NSObject, NSCopying {
                  timeoutIntervalForResource: TimeInterval,
                  networkServiceType: URLRequest.NetworkServiceType,
                  allowsCellularAccess: Bool,
-                 discretionary: Bool,
+                 isDiscretionary: Bool,
                  connectionProxyDictionary: [AnyHashable:Any]?,
                  httpShouldUsePipelining: Bool,
                  httpShouldSetCookies: Bool,
@@ -76,7 +76,7 @@ open class URLSessionConfiguration : NSObject, NSCopying {
         self.timeoutIntervalForResource = timeoutIntervalForResource
         self.networkServiceType = networkServiceType
         self.allowsCellularAccess = allowsCellularAccess
-        self.discretionary = discretionary
+        self.isDiscretionary = isDiscretionary
         self.connectionProxyDictionary = connectionProxyDictionary
         self.httpShouldUsePipelining = httpShouldUsePipelining
         self.httpShouldSetCookies = httpShouldSetCookies
@@ -102,7 +102,7 @@ open class URLSessionConfiguration : NSObject, NSCopying {
             timeoutIntervalForResource: timeoutIntervalForResource,
             networkServiceType: networkServiceType,
             allowsCellularAccess: allowsCellularAccess,
-            discretionary: discretionary,
+            isDiscretionary: isDiscretionary,
             connectionProxyDictionary: connectionProxyDictionary,
             httpShouldUsePipelining: httpShouldUsePipelining,
             httpShouldSetCookies: httpShouldSetCookies,
@@ -142,7 +142,7 @@ open class URLSessionConfiguration : NSObject, NSCopying {
     open var allowsCellularAccess: Bool
     
     /* allows background tasks to be scheduled at the discretion of the system for optimal performance. */
-    open var discretionary: Bool
+    open var isDiscretionary: Bool
     
     /* The identifier of the shared data container into which files in background sessions should be downloaded.
      * App extensions wishing to use background sessions *must* set this property to a valid container identifier, or

--- a/TestFoundation/TestURLSession.swift
+++ b/TestFoundation/TestURLSession.swift
@@ -41,6 +41,7 @@ class TestURLSession : LoopbackServerTest {
             ("test_cookiesStorage", test_cookiesStorage),
             ("test_setCookies", test_setCookies),
             ("test_dontSetCookies", test_dontSetCookies),
+            ("test_initURLSessionConfiguration", test_initURLSessionConfiguration),
         ]
     }
     
@@ -596,6 +597,40 @@ class TestURLSession : LoopbackServerTest {
         }
         task.resume()
         waitForExpectations(timeout: 30)
+    }
+
+    // Validate that the properties are correctly set
+    func test_initURLSessionConfiguration() {
+        let config = URLSessionConfiguration.default
+        config.requestCachePolicy = .useProtocolCachePolicy
+        config.timeoutIntervalForRequest = 30
+        config.timeoutIntervalForResource = 604800
+        config.networkServiceType = .default
+        config.allowsCellularAccess = false
+        config.isDiscretionary = true
+        config.httpShouldUsePipelining = true
+        config.httpShouldSetCookies = true
+        config.httpCookieAcceptPolicy = .always
+        config.httpMaximumConnectionsPerHost = 2
+        config.httpCookieStorage = HTTPCookieStorage.shared
+        config.urlCredentialStorage = nil
+        config.urlCache = nil
+        config.shouldUseExtendedBackgroundIdleMode = true
+
+        XCTAssertEqual(config.requestCachePolicy, NSURLRequest.CachePolicy.useProtocolCachePolicy)
+        XCTAssertEqual(config.timeoutIntervalForRequest, 30)
+        XCTAssertEqual(config.timeoutIntervalForResource, 604800)
+        XCTAssertEqual(config.networkServiceType, NSURLRequest.NetworkServiceType.default)
+        XCTAssertEqual(config.allowsCellularAccess, false)
+        XCTAssertEqual(config.isDiscretionary, true)
+        XCTAssertEqual(config.httpShouldUsePipelining, true)
+        XCTAssertEqual(config.httpShouldSetCookies, true)
+        XCTAssertEqual(config.httpCookieAcceptPolicy, HTTPCookie.AcceptPolicy.always)
+        XCTAssertEqual(config.httpMaximumConnectionsPerHost, 2)
+        XCTAssertEqual(config.httpCookieStorage, HTTPCookieStorage.shared)
+        XCTAssertEqual(config.urlCredentialStorage, nil)
+        XCTAssertEqual(config.urlCache, nil)
+        XCTAssertEqual(config.shouldUseExtendedBackgroundIdleMode, true)
     }
 }
 


### PR DESCRIPTION
Have the property name match Darwin