### PR TITLE
replace for-loop based initialization

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -985,9 +985,7 @@ open class FileManager : NSObject {
             fatalError("string could not be converted")
         }
         let buf = UnsafeMutablePointer<Int8>.allocate(capacity: len)
-        for i in 0..<len {
-            buf.advanced(by: i).initialize(to: 0)
-        }
+        buf.initialize(repeating: 0, count: len)
         if !path._nsObject.getFileSystemRepresentation(buf, maxLength: len) {
             buf.deinitialize(count: len)
             buf.deallocate()

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -566,10 +566,8 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
         let bufSize = Int(PATH_MAX + 1)
         
         let _fsrBuffer = UnsafeMutablePointer<Int8>.allocate(capacity: bufSize)
-        for i in 0..<bufSize {
-            _fsrBuffer.advanced(by: i).initialize(to: 0)
-        }
-        
+        _fsrBuffer.initialize(repeating: 0, count: bufSize)
+
         if getFileSystemRepresentation(_fsrBuffer, maxLength: bufSize) {
             return UnsafePointer(_fsrBuffer)
         }


### PR DESCRIPTION
replace structures like:

``` swift
for i in 0..<len {
    buf.advanced(by: i).initialize(to: 0)
}
```

with:

``` swift
buf.initialize(repeating: 0, count: len)
```

should bring small performance improvements