### PR TITLE
Add more tests to NSMutableIndexSet's removal APIs

### DIFF
--- a/TestFoundation/TestIndexSet.swift
+++ b/TestFoundation/TestIndexSet.swift
@@ -147,11 +147,11 @@ class TestIndexSet : XCTestCase {
         XCTAssertEqual(removalSet.firstIndex, 1)
         XCTAssertEqual(removalSet.lastIndex, 8)
         
-        var additionSet = IndexSet()
-        additionSet.insert(1)
-        additionSet.insert(integersIn: 6..<9)
+        var expected = IndexSet()
+        expected.insert(1)
+        expected.insert(integersIn: 6..<9)
+        XCTAssertTrue(removalSet.isEqual(to: expected))
         
-        XCTAssertTrue(removalSet.isEqual(to: additionSet))
         
     }
     

--- a/TestFoundation/TestIndexSet.swift
+++ b/TestFoundation/TestIndexSet.swift
@@ -156,7 +156,10 @@ class TestIndexSet : XCTestCase {
         removalSet.remove(9)
         XCTAssertTrue(removalSet.isEqual(to: expected))
         
+        removalSet.removeAllIndexes()
         
+        expected = IndexSet()
+        XCTAssertTrue(removalSet.isEqual(to: expected))
     }
     
     func test_addition() {

--- a/TestFoundation/TestIndexSet.swift
+++ b/TestFoundation/TestIndexSet.swift
@@ -152,6 +152,10 @@ class TestIndexSet : XCTestCase {
         expected.insert(integersIn: 6..<9)
         XCTAssertTrue(removalSet.isEqual(to: expected))
         
+        // Removing a non-existent element has no effect
+        removalSet.remove(9)
+        XCTAssertTrue(removalSet.isEqual(to: expected))
+        
         
     }
     

--- a/TestFoundation/TestIndexSet.swift
+++ b/TestFoundation/TestIndexSet.swift
@@ -139,7 +139,7 @@ class TestIndexSet : XCTestCase {
     }
     
     func test_removal() {
-        let removalSet = NSMutableIndexSet(indexesIn: NSRange(location: 0, length: 10))
+        var removalSet = NSMutableIndexSet(indexesIn: NSRange(location: 0, length: 10))
         removalSet.remove(0)
         removalSet.remove(in: NSRange(location: 9, length: 5))
         removalSet.remove(in: NSRange(location: 2, length: 4))
@@ -159,6 +159,28 @@ class TestIndexSet : XCTestCase {
         removalSet.removeAllIndexes()
         
         expected = IndexSet()
+        XCTAssertTrue(removalSet.isEqual(to: expected))
+        
+        // Set removal
+        removalSet = NSMutableIndexSet(indexesIn: NSRange(location: 0, length: 10))
+        removalSet.remove(IndexSet(integersIn: 8..<11))
+        removalSet.remove(IndexSet(integersIn: 0..<2))
+        removalSet.remove(IndexSet(integersIn: 4..<6))
+        XCTAssertEqual(removalSet.count, 4)
+        XCTAssertEqual(removalSet.firstIndex, 2)
+        XCTAssertEqual(removalSet.lastIndex, 7)
+
+        expected = IndexSet()
+        expected.insert(integersIn: 2..<4)
+        expected.insert(integersIn: 6..<8)
+        XCTAssertTrue(removalSet.isEqual(to: expected))
+        
+        // Removing an empty set has no effect
+        removalSet.remove(IndexSet())
+        XCTAssertTrue(removalSet.isEqual(to: expected))
+        
+        // Removing non-existent elements has no effect
+        removalSet.remove(IndexSet(integersIn: 0..<2))
         XCTAssertTrue(removalSet.isEqual(to: expected))
     }
     


### PR DESCRIPTION
This PR namely adds tests to `NSMutableIndexSet.removeAllIndexes()` and `NSMutableIndexSet.remove(indexSet:)`.