### PR TITLE
Add URLSessionDownloadTask.cancel(byProducingResumeData:)

### DIFF
--- a/Docs/Status.md
+++ b/Docs/Status.md
@@ -81,7 +81,7 @@ There is no _Complete_ status for test coverage because there are always additio
     | `URLSessionTask`             | Mostly Complete | Incomplete    | `cancel()`, `createTransferState(url:)` with streams, and others remain unimplemented                              |
     | `URLSessionDataTask`         | Complete        | Incomplete    |                                                                                                                    |
     | `URLSessionUploadTask`       | Complete        | None          |                                                                                                                    |
-    | `URLSessionDownloadTask`     | Incomplete      | Incomplete    | `cancel(byProducingResumeData:)` remains unimplemented                                                             |
+    | `URLSessionDownloadTask`     | Incomplete      | Incomplete    |                                                                                                                  |
     | `URLSessionStreamTask`       | Unimplemented   | None          |                                                                                                                    |
     | `TaskRegistry`               | N/A             | N/A           | For internal use only                                                                                              |
     | `TransferState`              | N/A             | N/A           | For internal use only                                                                                              |

--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -437,11 +437,8 @@ open class URLSessionDownloadTask : URLSessionTask {
          * original behavior cannot be directly ported, here.
          *
          * Instead, we just call the completionHandler directly.
-         *
-         * A token Data value is passed to the client to prevent unexpected failures
-         * that may be caused from passing nil instead.
          */
-        completionHandler(Data())
+        completionHandler(nil)
     }
 }
 

--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -428,7 +428,13 @@ open class URLSessionDownloadTask : URLSessionTask {
      * If resume data cannot be created, the completion handler will be
      * called with nil resumeData.
      */
-    open func cancel(byProducingResumeData completionHandler: @escaping (Data?) -> Void) { NSUnimplemented() }
+    open func cancel(byProducingResumeData completionHandler: @escaping (Data?) -> Void) {
+        super.cancel()
+        
+        // A token Data value is passed to the client to prevent unexpected
+        // failures that may be caused by passing nil instead
+        completionHandler(Data())
+    }
 }
 
 /*

--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -431,8 +431,16 @@ open class URLSessionDownloadTask : URLSessionTask {
     open func cancel(byProducingResumeData completionHandler: @escaping (Data?) -> Void) {
         super.cancel()
         
-        // A token Data value is passed to the client to prevent unexpected
-        // failures that may be caused by passing nil instead
+        /*
+         * In Objective-C, this method relies on an Apple-maintained XPC process
+         * to manage the bookmarking of partially downloaded data. Therefore, the
+         * original behavior cannot be directly ported, here.
+         *
+         * Instead, we just call the completionHandler directly.
+         *
+         * A token Data value is passed to the client to prevent unexpected failures
+         * that may be caused from passing nil instead.
+         */
         completionHandler(Data())
     }
 }


### PR DESCRIPTION
This is an attempt at resolving the implementation for `URLSessionDownloadTask.cancel(byProducingResumeData:)`.

This function seems to represent an edge case in portability. After communicating with @phausler, it appears the Objective-C implementation of this relies on an Apple-maintained XPC process to manage the bookmarking of partially downloaded data. Of course, this behavior is not portable to the framework project.

One approach that was considered was serializing the `URLSessionDownloadTask` instance and returning _that_ to the caller as the opaque blob given to the completion handler. However, the Objective-C implementation of `URLSessionTask` does not implement any `NSCoding` flavor publicly, so conformance would need to be implemented in this framework with `internal` or greater access control. But, unfortunately, that functionality is not currently supported in Swift.

The approach suggested by @phausler was simply to... hardcode calling the completion block. This is what was done in this PR.

The only thing worth highlighting about the approach is that a token `Data` instance is passed to the completion block to prevent unexpected failures that may be caused from passing `nil` instead.

## Open Issues:
- [ ] `downloadTask(withResumeData:)` (and related) would remain broken by this approach. What should be done with these functions?
- [ ] Unit test(s)