### PR TITLE
NSIndexset isEqual performance enhancement

### DIFF
--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -115,11 +115,13 @@ open class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         if _ranges.count != indexSet.rangeView.count {
             return false
         }
-        
+
         // Iterate over indexes to compare each
-        for (r1, r2) in zip(_ranges, indexSet.rangeView) {
+        for (range, element) in zip(_ranges, indexSet.rangeView) {
+            let elementLength = element.upperBound - element.lowerBound
+
             // Return false if the ranges do not match
-            if r1.location != r2.lowerBound || r1.length != r2.upperBound - r2.lowerBound {
+            if range.location != element.lowerBound || range.length != elementLength {
                 return false
             }
         }

--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -111,16 +111,19 @@ open class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     }
     
     open func isEqual(to indexSet: IndexSet) -> Bool {
-        
-        let otherRanges = indexSet.rangeView.map { NSRange(location: $0.lowerBound, length: $0.upperBound - $0.lowerBound) }
-        if _ranges.count != otherRanges.count {
+        // Exit early if the IndexSets do not have the same number of intervals
+        if _ranges.count != indexSet.rangeView.count {
             return false
         }
-        for (r1, r2) in zip(_ranges, otherRanges) {
-            if r1.length != r2.length || r1.location != r2.location {
+        
+        // Iterate over indexes to compare each
+        for (r1, r2) in zip(_ranges, indexSet.rangeView) {
+            // Return false if the ranges do not match
+            if r1.location != r2.lowerBound || r1.length != r2.upperBound - r2.lowerBound {
                 return false
             }
         }
+
         return true
     }
     


### PR DESCRIPTION
Remove expensive map and exit earlier. Should achieve performance improvement, significantly in cases where the indexSet has many intervals.