### PR TITLE
[gardening] Remove explicit use of .some & .none when dealing with optionals

### DIFF
--- a/Foundation/IndexSet.swift
+++ b/Foundation/IndexSet.swift
@@ -82,15 +82,15 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
                     case (nil, nil):
                         startIndex = 0
                         endIndex = 0
-                    case (nil, .some(let max)):
+                    case (nil, let max?):
                         // Start is before our first range
                         startIndex = 0
                         endIndex = max + 1
-                    case (.some(let min), nil):
+                    case (let min?, nil):
                         // End is after our last range
                         startIndex = min
                         endIndex = indexSet._rangeCount
-                    case (.some(let min), .some(let max)):
+                    case (let min?, let max?):
                         startIndex = min
                         endIndex = max + 1
                     }

--- a/Foundation/JSONSerialization.swift
+++ b/Foundation/JSONSerialization.swift
@@ -685,7 +685,7 @@ private struct JSONReader {
     func consumeASCII(_ ascii: UInt8) -> (Index) throws -> Index? {
         return { (input: Index) throws -> Index? in
             switch self.source.takeASCII(input) {
-            case .none:
+            case nil:
                 throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.propertyListReadCorrupt.rawValue, userInfo: [
                     "NSDebugDescription" : "Unexpected end of file during JSON parse."
                     ])

--- a/Foundation/URLSession/BodySource.swift
+++ b/Foundation/URLSession/BodySource.swift
@@ -167,11 +167,11 @@ fileprivate extension _BodyFileSource {
             switch (done, data, errno) {
             case (true, _, errno) where errno != 0:
                 self.availableChunk = .errorDetected(Int(errno))
-            case (true, .some(let d), 0) where d.isEmpty:
+            case (true, let d?, 0) where d.isEmpty:
                 self.append(data: d, endOfFile: true)
-            case (true, .some(let d), 0):
+            case (true, let d?, 0):
                 self.append(data: d, endOfFile: false)
-            case (false, .some(let d), 0):
+            case (false, let d?, 0):
                 self.append(data: d, endOfFile: false)
             default:
                 fatalError("Invalid arguments to read(3) callback.")
@@ -202,8 +202,8 @@ fileprivate extension _BodyFileSource {
         case .empty: return 0
         case .errorDetected: return 0
         case .data(let d): return d.count
-        case .done(.some(let d)): return d.count
-        case .done(.none): return 0
+        case .done(let d?): return d.count
+        case .done(nil): return 0
         }
     }
 }
@@ -228,7 +228,7 @@ extension _BodyFileSource : _BodySource {
             } else {
                 return .data(head)
             }
-        case .done(.some(let data)):
+        case .done(let data?):
             let l = min(length, data.count)
             let (head, tail) = splitData(dispatchData: data, atPosition: l)
             availableChunk = tail.isEmpty ? .done(nil) : .done(tail)
@@ -237,7 +237,7 @@ extension _BodyFileSource : _BodySource {
             } else {
                 return .data(head)
             }
-        case .done(.none):
+        case .done(nil):
             return .done
         }
     }

--- a/Foundation/URLSession/URLSession.swift
+++ b/Foundation/URLSession/URLSession.swift
@@ -535,11 +535,10 @@ internal extension URLSession {
         case .dataCompletionHandler(let c): return .dataCompletionHandler(c)
         case .downloadCompletionHandler(let c): return .downloadCompletionHandler(c)
         case .callDelegate:
-            switch delegate {
-            case .none: return .noDelegate
-            case .some(let d as URLSessionTaskDelegate): return .taskDelegate(d)
-            case .some: return .noDelegate
+            guard let d = delegate as? URLSessionTaskDelegate else {
+                return .noDelegate
             }
+            return .taskDelegate(d)
         }
     }
 }

--- a/Foundation/URLSession/http/HTTPURLProtocol.swift
+++ b/Foundation/URLSession/http/HTTPURLProtocol.swift
@@ -85,12 +85,12 @@ internal class _HTTPURLProtocol: _NativeProtocol {
         easyHandle.set(preferredReceiveBufferSize: Int.max)
         do {
             switch (task?.body, try task?.body.getBodyLength()) {
-            case (.none, _):
+            case (nil, _):
                 set(requestBodyLength: .noBody)
-            case (_, .some(let length)):
+            case (_, let length?):
                 set(requestBodyLength: .length(length))
                 task!.countOfBytesExpectedToSend = Int64(length)
-            case (_, .none):
+            case (_, nil):
                 set(requestBodyLength: .unknown)
             }
         } catch let e {
@@ -289,7 +289,7 @@ fileprivate extension _HTTPURLProtocol {
     /// Any header values that should be removed from the ones set by libcurl
     /// - SeeAlso: https://curl.haxx.se/libcurl/c/CURLOPT_HTTPHEADER.html
     var curlHeadersToRemove: [String] {
-        if case .none = task?.body {
+        if task?.body == nil  {
             return []
         } else {
             return ["Expect"]

--- a/Foundation/URLSession/libcurl/EasyHandle.swift
+++ b/Foundation/URLSession/libcurl/EasyHandle.swift
@@ -503,12 +503,12 @@ fileprivate extension _EasyHandle {
         let d: Int = {
             let buffer = Data(bytes: data, count: size*nmemb)
             switch delegate?.didReceive(data: buffer) {
-            case .some(.proceed): return size * nmemb
-            case .some(.abort): return 0
-            case .some(.pause):
+            case .proceed?: return size * nmemb
+            case .abort?: return 0
+            case .pause?:
                 pauseState.insert(.receivePaused)
                 return Int(CFURLSessionWriteFuncPause)
-            case .none:
+            case nil:
                 /* the delegate disappeared */
                 return 0
             }
@@ -523,12 +523,12 @@ fileprivate extension _EasyHandle {
         let buffer = Data(bytes: data, count: size*nmemb)
         let d: Int = {
             switch delegate?.didReceive(headerData: buffer, contentLength: Int64(contentLength)) {
-            case .some(.proceed): return size * nmemb
-            case .some(.abort): return 0
-            case .some(.pause):
+            case .proceed?: return size * nmemb
+            case .abort?: return 0
+            case .pause?:
                 pauseState.insert(.receivePaused)
                 return Int(CFURLSessionWriteFuncPause)
-            case .none:
+            case nil:
                 /* the delegate disappeared */
                 return 0
             }
@@ -563,14 +563,14 @@ fileprivate extension _EasyHandle {
         let d: Int = {
             let buffer = UnsafeMutableBufferPointer(start: data, count: size * nmemb)
             switch delegate?.fill(writeBuffer: buffer) {
-            case .some(.pause):
+            case .pause?:
                 pauseState.insert(.sendPaused)
                 return Int(CFURLSessionReadFuncPause)
-            case .some(.abort):
+            case .abort?:
                 return Int(CFURLSessionReadFuncAbort)
-            case .some(.bytes(let length)):
-                return length 
-            case .none:
+            case .bytes(let length)?:
+                return length
+            case nil:
                 /* the delegate disappeared */
                 return Int(CFURLSessionReadFuncAbort)
             }

--- a/TestFoundation/TestJSONEncoder.swift
+++ b/TestFoundation/TestJSONEncoder.swift
@@ -590,11 +590,11 @@ func expectEqualPaths(_ lhs: [CodingKey?], _ rhs: [CodingKey?], _ prefix: String
 
     for (k1, k2) in zip(lhs, rhs) {
         switch (k1, k2) {
-        case (.none, .none): continue
-        case (.some(let _k1), .none):
+        case (nil, nil): continue
+        case (let _k1?, nil):
             XCTFail("\(prefix) CodingKey mismatch: \(type(of: _k1)) != nil")
             return
-        case (.none, .some(let _k2)):
+        case (nil, let _k2?):
             XCTFail("\(prefix) CodingKey mismatch: nil != \(type(of: _k2))")
             return
         default: break
@@ -604,14 +604,14 @@ func expectEqualPaths(_ lhs: [CodingKey?], _ rhs: [CodingKey?], _ prefix: String
         let key2 = k2!
 
         switch (key1.intValue, key2.intValue) {
-        case (.none, .none): break
-        case (.some(let i1), .none):
+        case (nil, nil): break
+        case (let i1?, nil):
             XCTFail("\(prefix) CodingKey.intValue mismatch: \(type(of: key1))(\(i1)) != nil")
             return
-        case (.none, .some(let i2)):
+        case (nil, let i2?):
             XCTFail("\(prefix) CodingKey.intValue mismatch: nil != \(type(of: key2))(\(i2))")
             return
-        case (.some(let i1), .some(let i2)):
+        case (let i1?, let i2?):
             guard i1 == i2 else {
                 XCTFail("\(prefix) CodingKey.intValue mismatch: \(type(of: key1))(\(i1)) != \(type(of: key2))(\(i2))")
                 return


### PR DESCRIPTION
The codebase _seems_ to not make much use of `.some`/`.none` explicit syntax.

So the main idea of this PR is just to make it more consistent.