### PR TITLE
Fix more tests to run correctly on Darwin's native Foundation

### DIFF
--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -611,8 +611,7 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
         guard isFileURL,
             let path = path else {
                 throw NSError(domain: NSCocoaErrorDomain,
-                              code: CocoaError.Code.fileNoSuchFile.rawValue)
-                //return false
+                              code: CocoaError.Code.fileReadUnsupportedScheme.rawValue)
         }
         
         guard FileManager.default.fileExists(atPath: path) else {
@@ -621,7 +620,6 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
                           userInfo: [
                             "NSURL" : self,
                             "NSFilePath" : path])
-            //return false
         }
         
         return true

--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -454,11 +454,13 @@ open class NSMutableURLRequest : NSURLRequest {
     /// - Parameter value: the header field value.
     /// - Parameter field: the header field name (case-insensitive).
     open func setValue(_ value: String?, forHTTPHeaderField field: String) {
+        // Store the field name capitalized to match native Foundation
+        let capitalizedFieldName = field.capitalized
         var f: [String : String] = allHTTPHeaderFields ?? [:]
-        if let old = existingHeaderField(field, inHeaderFields: f) {
+        if let old = existingHeaderField(capitalizedFieldName, inHeaderFields: f) {
             f.removeValue(forKey: old.0)
         }
-        f[field] = value
+        f[capitalizedFieldName] = value
         allHTTPHeaderFields = f
     }
     
@@ -474,11 +476,13 @@ open class NSMutableURLRequest : NSURLRequest {
     /// - Parameter value: the header field value.
     /// - Parameter field: the header field name (case-insensitive).
     open func addValue(_ value: String, forHTTPHeaderField field: String) {
+        // Store the field name capitalized to match native Foundation
+        let capitalizedFieldName = field.capitalized
         var f: [String : String] = allHTTPHeaderFields ?? [:]
-        if let old = existingHeaderField(field, inHeaderFields: f) {
+        if let old = existingHeaderField(capitalizedFieldName, inHeaderFields: f) {
             f[old.0] = old.1 + "," + value
         } else {
-            f[field] = value
+            f[capitalizedFieldName] = value
         }
         allHTTPHeaderFields = f
     }

--- a/Foundation/URLSession/Configuration.swift
+++ b/Foundation/URLSession/Configuration.swift
@@ -102,10 +102,6 @@ internal extension URLSession._Configuration {
 internal extension URLSession._Configuration {
     func configure(request: URLRequest) -> URLRequest {
         var request = request
-        httpAdditionalHeaders?.forEach {
-            guard request.value(forHTTPHeaderField: $0.0) == nil else { return }
-            request.setValue($0.1, forHTTPHeaderField: $0.0)
-        }
         return setCookies(on: request)
     }
 

--- a/Foundation/URLSession/http/HTTPURLProtocol.swift
+++ b/Foundation/URLSession/http/HTTPURLProtocol.swift
@@ -125,6 +125,14 @@ internal class _HTTPURLProtocol: _NativeProtocol {
                 httpHeaders = hh
             } else {
                 hh.forEach {
+                    // When adding a header, remove any current entry with the same header name regardless of case
+                    let newKey = $0.lowercased()
+                    for key in httpHeaders!.keys {
+                        if newKey == (key as! String).lowercased() {
+                            httpHeaders?.removeValue(forKey: key)
+                            break
+                        }
+                    }
                     httpHeaders![$0] = $1
                 }
             }

--- a/TestFoundation/TestBundle.swift
+++ b/TestFoundation/TestBundle.swift
@@ -432,7 +432,7 @@ class TestBundle : XCTestCase {
             XCTAssertNotNil(bundle.executableURL)
         }
     }
-    
+
     func test_bundleFindAuxiliaryExecutables() {
         _withEachPlaygroundLayout { (playground) in
             let bundle = Bundle(path: playground.bundlePath)!
@@ -440,12 +440,14 @@ class TestBundle : XCTestCase {
             XCTAssertNil(bundle.url(forAuxiliaryExecutable: "does_not_exist_at_all"))
         }
     }
-    
+
     func test_mainBundleExecutableURL() {
+#if !DARWIN_COMPATIBILITY_TESTS // _CFProcessPath() is unavailable on native Foundation
         let maybeURL = Bundle.main.executableURL
         XCTAssertNotNil(maybeURL)
         guard let url = maybeURL else { return }
         
         XCTAssertEqual(url.path, String(cString: _CFProcessPath()))
+#endif
     }
 }

--- a/TestFoundation/TestHTTPCookieStorage.swift
+++ b/TestFoundation/TestHTTPCookieStorage.swift
@@ -273,7 +273,7 @@ class TestHTTPCookieStorage: XCTestCase {
     }
 
     func test_cookieInXDGSpecPath() {
-#if !os(Android)
+#if !os(Android) && !DARWIN_COMPATIBILITY_TESTS // No XDG on native Foundation
         //Test without setting the environment variable
         let testCookie = HTTPCookie(properties: [
            .name: "TestCookie0",

--- a/TestFoundation/TestNSURLRequest.swift
+++ b/TestFoundation/TestNSURLRequest.swift
@@ -65,14 +65,14 @@ class TestNSURLRequest : XCTestCase {
         XCTAssertNotNil(request.allHTTPHeaderFields)
         XCTAssertEqual(request.allHTTPHeaderFields?["Accept"], "application/json")
         
-        // Setting "accept" should remove "Accept"
+        // Setting "accept" should update "Accept"
         request.setValue("application/xml", forHTTPHeaderField: "accept")
-        XCTAssertNil(request.allHTTPHeaderFields?["Accept"])
-        XCTAssertEqual(request.allHTTPHeaderFields?["accept"], "application/xml")
+        XCTAssertNil(request.allHTTPHeaderFields?["accept"])
+        XCTAssertEqual(request.allHTTPHeaderFields?["Accept"], "application/xml")
         
-        // Adding to "Accept" should add to "accept"
+        // Adding to "Accept" should add to "Accept"
         request.addValue("text/html", forHTTPHeaderField: "Accept")
-        XCTAssertEqual(request.allHTTPHeaderFields?["accept"], "application/xml,text/html")
+        XCTAssertEqual(request.allHTTPHeaderFields?["Accept"], "application/xml,text/html")
     }
     
     func test_copy() {

--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -432,7 +432,7 @@ class TestURL : XCTestCase {
             XCTFail()
         } catch let error as NSError {
             XCTAssertEqual(NSCocoaErrorDomain, error.domain)
-            XCTAssertEqual(CocoaError.Code.fileNoSuchFile.rawValue, error.code)
+            XCTAssertEqual(CocoaError.Code.fileReadUnsupportedScheme.rawValue, error.code)
         } catch {
             XCTFail()
         }
@@ -461,7 +461,7 @@ class TestURL : XCTestCase {
             XCTFail()
         } catch let error as NSError {
             XCTAssertEqual(NSCocoaErrorDomain, error.domain)
-            XCTAssertEqual(CocoaError.Code.fileNoSuchFile.rawValue, error.code)
+            XCTAssertEqual(CocoaError.Code.fileReadUnsupportedScheme.rawValue, error.code)
         } catch {
             XCTFail()
         }

--- a/TestFoundation/TestURLRequest.swift
+++ b/TestFoundation/TestURLRequest.swift
@@ -60,16 +60,17 @@ class TestURLRequest : XCTestCase {
         
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         XCTAssertNotNil(request.allHTTPHeaderFields)
+        XCTAssertNil(request.allHTTPHeaderFields?["accept"])
         XCTAssertEqual(request.allHTTPHeaderFields?["Accept"], "application/json")
         
-        // Setting "accept" should remove "Accept"
+        // Setting "accept" should update "Accept"
         request.setValue("application/xml", forHTTPHeaderField: "accept")
-        XCTAssertNil(request.allHTTPHeaderFields?["Accept"])
-        XCTAssertEqual(request.allHTTPHeaderFields?["accept"], "application/xml")
+        XCTAssertNil(request.allHTTPHeaderFields?["accept"])
+        XCTAssertEqual(request.allHTTPHeaderFields?["Accept"], "application/xml")
         
-        // Adding to "Accept" should add to "accept"
+        // Adding to "Accept" should add to "Accept"
         request.addValue("text/html", forHTTPHeaderField: "Accept")
-        XCTAssertEqual(request.allHTTPHeaderFields?["accept"], "application/xml,text/html")
+        XCTAssertEqual(request.allHTTPHeaderFields?["Accept"], "application/xml,text/html")
     }
     
     func test_copy() {

--- a/TestFoundation/TestURLSession.swift
+++ b/TestFoundation/TestURLSession.swift
@@ -268,12 +268,12 @@ class TestURLSession : LoopbackServerTest {
     func test_verifyHttpAdditionalHeaders() {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 5
-        config.httpAdditionalHeaders = ["header2": "svalue2", "header3": "svalue3"]
+        config.httpAdditionalHeaders = ["header2": "svalue2", "header3": "svalue3", "header4": "svalue4"]
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/requestHeaders"
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
         var expect = expectation(description: "POST \(urlString) with additional headers")
         var req = URLRequest(url: URL(string: urlString)!)
-        let headers = ["header1": "rvalue1", "header2": "rvalue2"]
+        let headers = ["header1": "rvalue1", "header2": "rvalue2", "Header4": "rvalue4"]
         req.httpMethod = "POST"
         req.allHTTPHeaderFields = headers
         var task = session.dataTask(with: req) { (data, _, error) -> Void in
@@ -284,6 +284,8 @@ class TestURLSession : LoopbackServerTest {
             XCTAssertNotNil(headers.range(of: "header1: rvalue1"))
             XCTAssertNotNil(headers.range(of: "header2: rvalue2"))
             XCTAssertNotNil(headers.range(of: "header3: svalue3"))
+            XCTAssertNotNil(headers.range(of: "Header4: rvalue4"))
+            XCTAssertNil(headers.range(of: "header4: svalue"))
         }
         task.resume()
         


### PR DESCRIPTION
HTTPCookie fixes for version 0 cookies

- For expiry date, prefer maximum-age over expires-date but only
  use maximum-age for version 1 cookies.

- For version 0 cookies only return the first port number,
  if available.

NSURLRequest: Capitalise header names
    
- Correctly override httpAdditionalHeaders headers with
  allHTTPHeaderFields.

NSURL fix checkResourceIsReachable()
    
- If URL is a file, throw error with code .fileReadUnsupportedScheme
  instead of .fileNoSuchFile to match Darwin.

Disable tests that wont work on native Foundation

