### PR TITLE
CoreFoundation: synchronize CF_EXPORT and CF_PRIVATE decorations

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -27,6 +27,9 @@
 #include <CoreFoundation/CFDateIntervalFormatter.h>
 #include <CoreFoundation/ForFoundationOnly.h>
 #include <CoreFoundation/CFCharacterSetPriv.h>
+#include <CoreFoundation/CFURLPriv.h>
+#include <CoreFoundation/CFURLComponents.h>
+#include <CoreFoundation/CFRunArray.h>
 
 #if TARGET_OS_WIN32
 #define NOMINMAX

--- a/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
+++ b/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
@@ -85,18 +85,16 @@
 #include <CoreFoundation/CFUUID.h>
 #include <CoreFoundation/CFUtilities.h>
 #include <CoreFoundation/CFBundle.h>
+
 #include <CoreFoundation/CFMessagePort.h>
 #include <CoreFoundation/CFPlugIn.h>
 #include <CoreFoundation/CFRunLoop.h>
 #include <CoreFoundation/CFStream.h>
 #include <CoreFoundation/CFSocket.h>
 #include <CoreFoundation/CFMachPort.h>
+
 #include <CoreFoundation/CFAttributedString.h>
 #include <CoreFoundation/CFNotificationCenter.h>
-
-#include <CoreFoundation/CFURLPriv.h>
-#include <CoreFoundation/CFURLComponents.h>
-#include <CoreFoundation/CFRunArray.h>
 
 #include <CoreFoundation/ForSwiftFoundationOnly.h>
 


### PR DESCRIPTION
This is needed to ensure that CoreFoundation is built with the correct
visibility to enable re-export of symbols from Foundation.  The
adjustment to the sources are needed to synchronize the headers with the
sources.

The changes to the locale constants are needed as variable declarations
cannot be aliases according to clang.