### PR TITLE
closure: make `Block_descriptor_1` conform to the ABI

### DIFF
--- a/closure/Block_private.h
+++ b/closure/Block_private.h
@@ -38,8 +38,8 @@ enum {
 
 #define BLOCK_DESCRIPTOR_1 1
 struct Block_descriptor_1 {
-    uintptr_t reserved;
-    uintptr_t size;
+    unsigned long int reserved;
+    unsigned long int size;
 };
 
 #define BLOCK_DESCRIPTOR_2 1


### PR DESCRIPTION
The Blocks ABI v1 used `unsigned long int` for the `size` and `reserved`
fields.  On LLP64 targets (e.g. Windows x86_64), `uintptr_t` is larger
than `unsigned long int`.  Adjust the types to make the definition
conform to the ABI specification.