### PR TITLE
NSError: add a test for bridging an NSDictionary containing an NSError to a Dictionary containing an Error.

### DIFF
--- a/TestFoundation/TestNSError.swift
+++ b/TestFoundation/TestNSError.swift
@@ -16,6 +16,7 @@ class TestNSError : XCTestCase {
         return [
             ("test_LocalizedError_errorDescription", test_LocalizedError_errorDescription),
             ("test_NSErrorAsError_localizedDescription", test_NSErrorAsError_localizedDescription),
+            ("test_NSError_inDictionary", test_NSError_inDictionary),
             ("test_CustomNSError_domain", test_CustomNSError_domain),
             ("test_CustomNSError_userInfo", test_CustomNSError_userInfo),
             ("test_CustomNSError_errorCode", test_CustomNSError_errorCode),
@@ -38,6 +39,14 @@ class TestNSError : XCTestCase {
         let nsError = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Localized!"])
         let error = nsError as Error
         XCTAssertEqual(error.localizedDescription, "Localized!")
+    }
+    
+    func test_NSError_inDictionary() {
+        let error = NSError(domain: "domain", code: 42, userInfo: nil)
+        let nsdictionary = ["error": error] as NSDictionary
+        let dictionary = nsdictionary as? Dictionary<String, Error>
+        XCTAssertNotNil(dictionary)
+        XCTAssertEqual(error, dictionary?["error"] as NSError?)
     }
 
     func test_CustomNSError_domain() {


### PR DESCRIPTION
rdar://problem/39349762