### PR TITLE
Performance improvement for NSIndexSet.mutableCopy

### DIFF
--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -93,8 +93,19 @@ open class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     
     open func mutableCopy(with zone: NSZone? = nil) -> Any {
         let set = NSMutableIndexSet()
-        set._ranges = _ranges
-        set._count = _count
+
+        if type(of: self as Any) == NSMutableIndexSet.self {
+            set._ranges = _ranges
+            set._count = _count
+        }
+        // On Darwin, NSMutableSet is abstract, and does not have ivars.
+        // Therefore assignment to _ranges and _count would not be correct.
+        else {
+            enumerateRanges(options: []) { (range, _) in
+                set.add(in: range)
+            }
+        }
+
         return set
     }
 

--- a/Foundation/NSIndexSet.swift
+++ b/Foundation/NSIndexSet.swift
@@ -93,9 +93,8 @@ open class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     
     open func mutableCopy(with zone: NSZone? = nil) -> Any {
         let set = NSMutableIndexSet()
-        enumerateRanges(options: []) { (range, _) in
-            set.add(in: range)
-        }
+        set._ranges = _ranges
+        set._count = _count
         return set
     }
 


### PR DESCRIPTION
Replaces repeated `add` in `mutableCopy` with faster assignment. Implementation now matches [`NSMutableIndexSet.copy` implementation](https://github.com/apple/swift-corelibs-foundation/blob/95905cf523c1a96262b3530b9662fce690bcf56c/Foundation/NSIndexSet.swift#L536).

Benchmarked using [`swift-profiling`](https://github.com/RobertPieta/swift-profiling), specifically [`test_indexset_mutable_copy.swift`](https://github.com/RobertPieta/swift-profiling/blob/master/tests/test_indexset_mutable_copy.swift).

Previous implementation: 9.95s
New implementation: 0.08s

Comparison to native Foundation:
Native Foundation: 0.06s

Since #1603 relies on `NSIndexSet.mutableCopy`, a similar speedup is observed for `IndexSet.union`.