### PR TITLE
Improved performance of isSubset for NSOrderedSet and NSSet

### DIFF
--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -210,6 +210,10 @@ extension NSOrderedSet {
     }
     
     open func isSubset(of other: NSOrderedSet) -> Bool {
+        if count > other.count {
+            return false
+        }
+
         for item in self {
             if !other.contains(item) {
                 return false
@@ -219,6 +223,10 @@ extension NSOrderedSet {
     }
 
     open func isSubset(of set: Set<AnyHashable>) -> Bool {
+        if count > set.count {
+            return false
+        }
+
         for item in self {
             if !set.contains(item as! AnyHashable) {
                 return false

--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -210,6 +210,7 @@ extension NSOrderedSet {
     }
     
     open func isSubset(of other: NSOrderedSet) -> Bool {
+        // If self is larger then self cannot be a subset of other
         if count > other.count {
             return false
         }
@@ -223,6 +224,7 @@ extension NSOrderedSet {
     }
 
     open func isSubset(of set: Set<AnyHashable>) -> Bool {
+        // If self is larger then self cannot be a subset of set
         if count > set.count {
             return false
         }

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -208,6 +208,7 @@ extension NSSet {
     }
     
     open func isSubset(of otherSet: Set<AnyHashable>) -> Bool {
+        // If self is larger then self cannot be a subset of otherSet
         if count > otherSet.count {
             return false
         }

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -208,6 +208,10 @@ extension NSSet {
     }
     
     open func isSubset(of otherSet: Set<AnyHashable>) -> Bool {
+        if count > otherSet.count {
+            return false
+        }
+        
         // `true` if we don't contain any object that `otherSet` doesn't contain.
         for item in self {
             if !otherSet.contains(item as! AnyHashable) {

--- a/TestFoundation/TestNSSet.swift
+++ b/TestFoundation/TestNSSet.swift
@@ -25,6 +25,7 @@ class TestNSSet : XCTestCase {
             ("test_CountedSetRemoveObject", test_CountedSetRemoveObject),
             ("test_CountedSetCopying", test_CountedSetCopying),
             ("test_mutablesetWithDictionary", test_mutablesetWithDictionary),
+            ("test_Subsets", test_Subsets)
         ]
     }
     
@@ -223,5 +224,17 @@ class TestNSSet : XCTestCase {
         aSet.add(["world": "again"])
         dictionary.setObject(aSet, forKey: key)
         XCTAssertNotNil(dictionary.description) //should not crash
+    }
+
+    func test_Subsets() {
+        let set = NSSet(array: ["foo", "bar", "baz"])
+        let otherSet = NSSet(array: ["foo", "bar"])
+        let otherOtherSet = Set<AnyHashable>(["foo", "bar", "baz", "123"])
+        let newSet = Set<AnyHashable>(["foo", "bin"])
+        XCTAssert(otherSet.isSubset(of: set as! Set<AnyHashable>))
+        XCTAssertFalse(set.isSubset(of: otherSet as! Set<AnyHashable>))
+        XCTAssert(set.isSubset(of: otherOtherSet))
+        XCTAssert(otherSet.isSubset(of: otherOtherSet))
+        XCTAssertFalse(newSet.isSubset(of: otherSet as! Set<AnyHashable>))
     }
 }


### PR DESCRIPTION
Improve performance by exiting early if self is larger than the potential containing set, since a larger set cannot be contained by a smaller set.