### PR TITLE
[gardening] Clean up do catch blocks

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -957,11 +957,7 @@ open class FileManager : NSObject {
     /* These methods are provided here for compatibility. The corresponding methods on NSData which return NSErrors should be regarded as the primary method of creating a file from an NSData or retrieving the contents of a file as an NSData.
      */
     open func contents(atPath path: String) -> Data? {
-        do {
-            return try Data(contentsOf: URL(fileURLWithPath: path))
-        } catch {
-            return nil
-        }
+        return try? Data(contentsOf: URL(fileURLWithPath: path))
     }
     
     open func createFile(atPath path: String, contents data: Data?, attributes attr: [FileAttributeKey : Any]? = nil) -> Bool {
@@ -971,7 +967,7 @@ open class FileManager : NSObject {
                 try self.setAttributes(attr, ofItemAtPath: path)
             }
             return true
-        } catch _ {
+        } catch {
             return false
         }
     }

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -579,22 +579,18 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
                         if fsync(fd) < 0 {
                             throw _NSErrorWithErrno(errno, reading: false, path: path)
                         }
-                    } catch let err {
+                    } catch {
                         if let auxFilePath = auxFilePath {
-                            do {
-                                try FileManager.default.removeItem(atPath: auxFilePath)
-                            } catch _ {}
+                            try? FileManager.default.removeItem(atPath: auxFilePath)
                         }
-                        throw err
+                        throw error
                     }
                 }
             }
             if let auxFilePath = auxFilePath {
                 try fm._fileSystemRepresentation(withPath: auxFilePath, { auxFilePathFsRep in
                     if rename(auxFilePathFsRep, pathFsRep) != 0 {
-                        do {
-                            try FileManager.default.removeItem(atPath: auxFilePath)
-                        } catch _ {}
+                        try? FileManager.default.removeItem(atPath: auxFilePath)
                         throw _NSErrorWithErrno(errno, reading: false, path: path)
                     }
                     if let mode = mode {
@@ -705,8 +701,8 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         self.enumerateBytes() { (buf, range, stop) -> Void in
             do {
                 try block(buf, range, stop)
-            } catch let e {
-                err = e
+            } catch {
+                err = error
             }
         }
         if let err = err {

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -138,18 +138,15 @@ open class NSKeyedArchiver : NSCoder {
 
         do {
             (fd, auxFilePath) = try _NSCreateTemporaryFile(path)
-        } catch _ {
+        } catch {
             return false
         }
         
         defer {
-            do {
-                if finishedEncoding {
-                    try _NSCleanupTemporaryFile(auxFilePath, path)
-                } else {
-                    try FileManager.default.removeItem(atPath: auxFilePath)
-                }
-            } catch _ {
+            if finishedEncoding {
+                try? _NSCleanupTemporaryFile(auxFilePath, path)
+            } else {
+                try? FileManager.default.removeItem(atPath: auxFilePath)
             }
         }
 

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -58,11 +58,7 @@ open class NSKeyedUnarchiver : NSCoder {
     }
     
     open class func unarchiveObject(with data: Data) -> Any? {
-        do {
-            return try unarchiveTopLevelObjectWithData(data)
-        } catch {
-        }
-        return nil
+        return try? unarchiveTopLevelObjectWithData(data)
     }
     
     open class func unarchiveObject(withFile path: String) -> Any? {

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -122,15 +122,13 @@ internal func _createRegexForPattern(_ pattern: String, _ options: NSRegularExpr
     if let regex = local.__NSRegularExpressionCache.object(forKey: key._nsObject) {
         return regex
     }
-    do {
-        let regex = try NSRegularExpression(pattern: pattern, options: options)
-        local.__NSRegularExpressionCache.setObject(regex, forKey: key._nsObject)
-        return regex
-    } catch {
-        
+
+    guard let regex = try? NSRegularExpression(pattern: pattern, options: options) else {
+        return nil
     }
-    
-    return nil
+
+    local.__NSRegularExpressionCache.setObject(regex, forKey: key._nsObject)
+    return regex
 }
 
 internal func _bytesInEncoding(_ str: NSString, _ encoding: String.Encoding, _ fatalOnError: Bool, _ externalRep: Bool, _ lossy: Bool) -> UnsafePointer<Int8>? {

--- a/TestFoundation/TestBundle.swift
+++ b/TestFoundation/TestBundle.swift
@@ -133,7 +133,7 @@ class BundlePlayground {
                 }
                 
                 self.bundlePath = bundleURL.path
-            } catch _ {
+            } catch {
                 return false
             }
             
@@ -176,7 +176,7 @@ class BundlePlayground {
                 }
                 
                 self.bundlePath = resourcesDirectory.path
-            } catch _ {
+            } catch {
                 return false
             }
             
@@ -210,7 +210,7 @@ class BundlePlayground {
                 }
                 
                 self.bundlePath = resourcesDirectory.path
-            } catch _ {
+            } catch {
                 return false
             }
         }
@@ -222,12 +222,8 @@ class BundlePlayground {
     func destroy() {
         guard let path = self.playgroundPath else { return }
         self.playgroundPath = nil
-        
-        do {
-            try FileManager.default.removeItem(atPath: path)
-        } catch _ {
-            // ¯\_(ツ)_/¯ We did what we could.
-        }
+
+        try? FileManager.default.removeItem(atPath: path)
     }
     
     deinit {
@@ -363,11 +359,7 @@ class TestBundle : XCTestCase {
     }
     
     private func _cleanupPlayground(_ location: String) {
-        do {
-            try FileManager.default.removeItem(atPath: location)
-        } catch _ {
-            // Oh well
-        }
+        try? FileManager.default.removeItem(atPath: location)
     }
     
     func test_URLsForResourcesWithExtension() {

--- a/TestFoundation/TestCodable.swift
+++ b/TestFoundation/TestCodable.swift
@@ -84,7 +84,7 @@ class TestCodable : XCTestCase {
         for components in personNameComponentsValues {
             do {
                 try expectRoundTripEqualityThroughJSON(for: components)
-            } catch let error {
+            } catch {
                 XCTFail("\(error) for \(components)")
             }
         }
@@ -103,7 +103,7 @@ class TestCodable : XCTestCase {
             // We have to wrap the UUID since we cannot have a top-level string.
             do {
                 try expectRoundTripEqualityThroughJSON(for: UUIDCodingWrapper(uuid))
-            } catch let error {
+            } catch {
                 XCTFail("\(error) for \(uuid)")
             }
         }
@@ -122,7 +122,7 @@ class TestCodable : XCTestCase {
         for url in urlValues {
             do {
                 try expectRoundTripEqualityThroughJSON(for: url)
-            } catch let error {
+            } catch {
                 XCTFail("\(error) for \(url)")
             }
         }
@@ -139,7 +139,7 @@ class TestCodable : XCTestCase {
         for range in nsrangeValues {
             do {
                 try expectRoundTripEqualityThroughJSON(for: range)
-            } catch let error {
+            } catch {
                 XCTFail("\(error) for \(range)")
             }
         }
@@ -161,7 +161,7 @@ class TestCodable : XCTestCase {
         for locale in localeValues {
             do {
                 try expectRoundTripEqualityThroughJSON(for: locale)
-            } catch let error {
+            } catch {
                 XCTFail("\(error) for \(locale)")
             }
         }
@@ -178,7 +178,7 @@ class TestCodable : XCTestCase {
         for indexSet in indexSetValues {
             do {
                 try expectRoundTripEqualityThroughJSON(for: indexSet)
-            } catch let error {
+            } catch {
                 XCTFail("\(error) for \(indexSet)")
             }
         }
@@ -196,7 +196,7 @@ class TestCodable : XCTestCase {
         for indexPath in indexPathValues {
             do {
                 try expectRoundTripEqualityThroughJSON(for: indexPath)
-            } catch let error {
+            } catch {
                 XCTFail("\(error) for \(indexPath)")
             }
         }
@@ -224,7 +224,7 @@ class TestCodable : XCTestCase {
         for transform in affineTransformValues {
             do {
                 try expectRoundTripEqualityThroughJSON(for: transform)
-            } catch let error {
+            } catch {
                 XCTFail("\(error) for \(transform)")
             }
         }
@@ -244,7 +244,7 @@ class TestCodable : XCTestCase {
         for decimal in decimalValues {
             do {
                 try expectRoundTripEqualityThroughJSON(for: decimal)
-            } catch let error {
+            } catch {
                 XCTFail("\(error) for \(decimal)")
             }
         }
@@ -264,7 +264,7 @@ class TestCodable : XCTestCase {
         for point in cgpointValues {
             do {
                 try expectRoundTripEqualityThroughJSON(for: point)
-            } catch let error {
+            } catch {
                 XCTFail("\(error) for \(point)")
             }
         }
@@ -284,7 +284,7 @@ class TestCodable : XCTestCase {
         for size in cgsizeValues {
             do {
                 try expectRoundTripEqualityThroughJSON(for: size)
-            } catch let error {
+            } catch {
                 XCTFail("\(error) for \(size)")
             }
         }
@@ -305,7 +305,7 @@ class TestCodable : XCTestCase {
         for rect in cgrectValues {
             do {
                 try expectRoundTripEqualityThroughJSON(for: rect)
-            } catch let error {
+            } catch {
                 XCTFail("\(error) for \(rect)")
             }
         }
@@ -335,7 +335,7 @@ class TestCodable : XCTestCase {
         for characterSet in characterSetValues {
             do {
                 try expectRoundTripEqualityThroughJSON(for: characterSet)
-            } catch let error {
+            } catch {
                 XCTFail("\(error) for \(characterSet)")
             }
         }
@@ -366,7 +366,7 @@ class TestCodable : XCTestCase {
         for timeZone in timeZoneValues {
             do {
                 try expectRoundTripEqualityThroughJSON(for: timeZone)
-            } catch let error {
+            } catch {
                 XCTFail("\(error) for \(timeZone)")
             }
         }
@@ -404,7 +404,7 @@ class TestCodable : XCTestCase {
         for calendar in calendarValues {
             do {
                 try expectRoundTripEqualityThroughJSON(for: calendar)
-            } catch let error {
+            } catch {
                 XCTFail("\(error) for \(calendar)")
             }
         }
@@ -441,7 +441,7 @@ class TestCodable : XCTestCase {
         let components = calendar.dateComponents(dateComponents, from: Date(timeIntervalSince1970: 1501283776))
         do {
             try expectRoundTripEqualityThroughJSON(for: components)
-        } catch let error {
+        } catch {
             XCTFail("\(error)")
         }
     }
@@ -452,7 +452,7 @@ class TestCodable : XCTestCase {
             try expectRoundTripEqualityThroughJSON(for: Measurement(value: 42, unit: UnitAcceleration.metersPerSecondSquared))
             try expectRoundTripEqualityThroughJSON(for: Measurement(value: 42, unit: UnitMass.kilograms))
             try expectRoundTripEqualityThroughJSON(for: Measurement(value: 42, unit: UnitLength.miles))
-        } catch let error {
+        } catch {
             XCTFail("\(error)")
         }
     }
@@ -548,7 +548,7 @@ class TestCodable : XCTestCase {
         for (components) in urlComponentsValues {
             do {
                 try expectRoundTripEqualityThroughJSON(for: components)
-            } catch let error {
+            } catch {
                 XCTFail("\(error)")
             }
         }

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -32,20 +32,16 @@ class TestFileManager : XCTestCase {
             ("test_contentsEqual", test_contentsEqual)
         ]
     }
-    
-    func ignoreError(_ block: () throws -> Void) {
-        do { try block() } catch { }
-    }
-    
+
     func test_createDirectory() {
         let fm = FileManager.default
         let path = NSTemporaryDirectory() + "testdir\(NSUUID().uuidString)"
         
-        ignoreError { try fm.removeItem(atPath: path) }
+        try? fm.removeItem(atPath: path)
         
         do {
             try fm.createDirectory(atPath: path, withIntermediateDirectories: false, attributes: nil)
-        } catch _ {
+        } catch {
             XCTFail()
         }
 
@@ -69,7 +65,7 @@ class TestFileManager : XCTestCase {
         let fm = FileManager.default
         let path = NSTemporaryDirectory() + "testfile\(NSUUID().uuidString)"
         
-        ignoreError { try fm.removeItem(atPath: path) }
+        try? fm.removeItem(atPath: path)
         
         XCTAssertTrue(fm.createFile(atPath: path, contents: Data(), attributes: nil))
         
@@ -128,8 +124,8 @@ class TestFileManager : XCTestCase {
         let path2 = NSTemporaryDirectory() + "testfile2\(NSUUID().uuidString)"
 
         func cleanup() {
-            ignoreError { try fm.removeItem(atPath: path) }
-            ignoreError { try fm.removeItem(atPath: path2) }
+            try? fm.removeItem(atPath: path)
+            try? fm.removeItem(atPath: path2)
         }
 
         cleanup()
@@ -139,7 +135,7 @@ class TestFileManager : XCTestCase {
 
         do {
             try fm.moveItem(atPath: path, toPath: path2)
-        } catch let error {
+        } catch {
             XCTFail("Failed to move file: \(error)")
         }
     }
@@ -164,7 +160,7 @@ class TestFileManager : XCTestCase {
         let badSymLink = tmpDir.appendingPathComponent("badSymLink")
         let dirSymLink = tmpDir.appendingPathComponent("dirSymlink")
 
-        ignoreError { try fm.removeItem(atPath: tmpDir.path) }
+        try? fm.removeItem(atPath: tmpDir.path)
 
         do {
             try fm.createDirectory(atPath: tmpDir.path, withIntermediateDirectories: false, attributes: nil)
@@ -199,14 +195,14 @@ class TestFileManager : XCTestCase {
         } catch {
             XCTFail(String(describing: error))
         }
-        ignoreError { try fm.removeItem(atPath: tmpDir.path) }
+        try? fm.removeItem(atPath: tmpDir.path)
     }
 
     func test_fileAttributes() {
         let fm = FileManager.default
         let path = NSTemporaryDirectory() + "test_fileAttributes\(NSUUID().uuidString)"
 
-        ignoreError { try fm.removeItem(atPath: path) }
+        try? fm.removeItem(atPath: path)
         
         XCTAssertTrue(fm.createFile(atPath: path, contents: Data(), attributes: nil))
         
@@ -256,8 +252,8 @@ class TestFileManager : XCTestCase {
                 }
             }
             
-        } catch let err {
-            XCTFail("\(err)")
+        } catch {
+            XCTFail("\(error)")
         }
         
         do {
@@ -296,8 +292,8 @@ class TestFileManager : XCTestCase {
             XCTAssertNotNil(systemNodes)
             XCTAssertGreaterThan(systemNodes!.uint64Value, systemFreeNodes!.uint64Value)
             
-        } catch let err {
-            XCTFail("\(err)")
+        } catch {
+            XCTFail("\(error)")
         }
 #endif
     }
@@ -306,7 +302,7 @@ class TestFileManager : XCTestCase {
         let path = NSTemporaryDirectory() + "test_setFileAttributes\(NSUUID().uuidString)"
         let fm = FileManager.default
         
-        ignoreError { try fm.removeItem(atPath: path) }
+        try? fm.removeItem(atPath: path)
         XCTAssertTrue(fm.createFile(atPath: path, contents: Data(), attributes: nil))
         
         do {
@@ -336,7 +332,7 @@ class TestFileManager : XCTestCase {
         let basePath2 = NSTemporaryDirectory() + "\(testDirName)/path2"
         let itemPath2 = NSTemporaryDirectory() + "\(testDirName)/path2/item"
         
-        ignoreError { try fm.removeItem(atPath: basePath) }
+        try? fm.removeItem(atPath: basePath)
         
         do {
             try fm.createDirectory(atPath: basePath, withIntermediateDirectories: false, attributes: nil)
@@ -345,7 +341,7 @@ class TestFileManager : XCTestCase {
             let _ = fm.createFile(atPath: itemPath, contents: Data(count: 123), attributes: nil)
             let _ = fm.createFile(atPath: itemPath2, contents: Data(count: 456), attributes: nil)
 
-        } catch _ {
+        } catch {
             XCTFail()
         }
 
@@ -443,8 +439,8 @@ class TestFileManager : XCTestCase {
             }
         }
 
-        ignoreError { try fm.removeItem(atPath: basePath) }
-        defer { ignoreError { try fm.removeItem(atPath: basePath) } }
+        try? fm.removeItem(atPath: basePath)
+        defer { try? fm.removeItem(atPath: basePath) }
 
         XCTAssertNotNil(try? fm.createDirectory(atPath: subDirs1, withIntermediateDirectories: true, attributes: nil))
         XCTAssertNotNil(try? fm.createDirectory(atPath: subDirs2, withIntermediateDirectories: true, attributes: nil))
@@ -518,13 +514,13 @@ class TestFileManager : XCTestCase {
         let itemPath1 = NSTemporaryDirectory() + "\(testDirName)/item"
         let itemPath2 = NSTemporaryDirectory() + "\(testDirName)/item2"
         
-        ignoreError { try fm.removeItem(atPath: path) }
+        try? fm.removeItem(atPath: path)
         
         do {
             try fm.createDirectory(atPath: path, withIntermediateDirectories: false, attributes: nil)
             let _ = fm.createFile(atPath: itemPath1, contents: Data(), attributes: nil)
             let _ = fm.createFile(atPath: itemPath2, contents: Data(), attributes: nil)
-        } catch _ {
+        } catch {
             XCTFail()
         }
         
@@ -535,7 +531,7 @@ class TestFileManager : XCTestCase {
             XCTAssertTrue(entries.contains("item"))
             XCTAssertTrue(entries.contains("item2"))
         }
-        catch _ {
+        catch {
             XCTFail()
         }
         
@@ -544,7 +540,7 @@ class TestFileManager : XCTestCase {
             let _ = try fm.contentsOfDirectory(atPath: "/...")
             XCTFail()
         }
-        catch _ {
+        catch {
             // Invalid directories should fail.
         }
         
@@ -563,7 +559,7 @@ class TestFileManager : XCTestCase {
         let itemPath2 = NSTemporaryDirectory() + "testdir/item2"
         let itemPath3 = NSTemporaryDirectory() + "testdir/sub/item3"
                 
-        ignoreError { try fm.removeItem(atPath: path) }
+        try? fm.removeItem(atPath: path)
         
         do {
             try fm.createDirectory(atPath: path, withIntermediateDirectories: false, attributes: nil)
@@ -572,7 +568,7 @@ class TestFileManager : XCTestCase {
             
             try fm.createDirectory(atPath: path2, withIntermediateDirectories: false, attributes: nil)
             let _ = fm.createFile(atPath: itemPath3, contents: Data(), attributes: nil)
-        } catch _ {
+        } catch {
             XCTFail()
         }
         
@@ -586,7 +582,7 @@ class TestFileManager : XCTestCase {
             XCTAssertTrue(entries.contains("sub/item3"))
             XCTAssertEqual(fm.subpaths(atPath: path), entries)
         }
-        catch _ {
+        catch {
             XCTFail()
         }
         
@@ -597,7 +593,7 @@ class TestFileManager : XCTestCase {
             let _ = try fm.subpathsOfDirectory(atPath: "/...")
             XCTFail()
         }
-        catch _ {
+        catch {
             // Invalid directories should fail.
         }
         
@@ -620,14 +616,14 @@ class TestFileManager : XCTestCase {
         let destPath = NSTemporaryDirectory() + "testdir\(NSUUID().uuidString)"
 
         func cleanup() {
-            ignoreError { try fm.removeItem(atPath: srcPath) }
-            ignoreError { try fm.removeItem(atPath: destPath) }
+            try? fm.removeItem(atPath: srcPath)
+            try? fm.removeItem(atPath: destPath)
         }
 
         func createDirectory(atPath path: String) {
             do {
                 try fm.createDirectory(atPath: path, withIntermediateDirectories: false, attributes: nil)
-            } catch let error {
+            } catch {
                 XCTFail("Unable to create directory: \(error)")
             }
             XCTAssertTrue(directoryExists(atPath: path))
@@ -641,7 +637,7 @@ class TestFileManager : XCTestCase {
         createFile(atPath: srcPath)
         do {
             try fm.copyItem(atPath: srcPath, toPath: destPath)
-        } catch let error {
+        } catch {
             XCTFail("Failed to copy file: \(error)")
         }
 
@@ -657,7 +653,7 @@ class TestFileManager : XCTestCase {
 
         do {
             try fm.copyItem(atPath: srcPath, toPath: destPath)
-        } catch let error {
+        } catch {
             XCTFail("Unable to copy directory: \(error)")
         }
         XCTAssertTrue(directoryExists(atPath: destPath))
@@ -701,7 +697,7 @@ class TestFileManager : XCTestCase {
         let basePath = NSTemporaryDirectory() + "linkItemAtPathToPath/"
         let srcPath = basePath + "testdir\(NSUUID().uuidString)"
         let destPath = basePath + "testdir\(NSUUID().uuidString)"
-        defer { ignoreError { try fm.removeItem(atPath: basePath) } }
+        defer { try? fm.removeItem(atPath: basePath) }
 
         func getFileInfo(atPath path: String, _ body: (String, Bool, UInt64, UInt64) -> ()) {
             guard let enumerator = fm.enumerator(atPath: path) else {
@@ -729,7 +725,7 @@ class TestFileManager : XCTestCase {
             }
         }
 
-        ignoreError { try fm.removeItem(atPath: basePath) }
+        try? fm.removeItem(atPath: basePath)
         XCTAssertNotNil(try? fm.createDirectory(atPath: "\(srcPath)/tempdir/subdir/otherdir/extradir", withIntermediateDirectories: true, attributes: nil))
         XCTAssertTrue(fm.createFile(atPath: "\(srcPath)/tempdir/tempfile", contents: Data(), attributes: nil))
         XCTAssertTrue(fm.createFile(atPath: "\(srcPath)/tempdir/tempfile2", contents: Data(), attributes: nil))

--- a/TestFoundation/TestJSONEncoder.swift
+++ b/TestFoundation/TestJSONEncoder.swift
@@ -303,7 +303,7 @@ class TestJSONEncoder : XCTestCase {
         let encoder = JSONEncoder()
         do {
             let _ = try encoder.encode(NestedContainersTestType())
-        } catch let error {
+        } catch {
             XCTFail("Caught error during encoding nested container types: \(error)")
         }
     }
@@ -312,7 +312,7 @@ class TestJSONEncoder : XCTestCase {
         let encoder = JSONEncoder()
         do {
             let _ = try encoder.encode(NestedContainersTestType(testSuperEncoder: true))
-        } catch let error {
+        } catch {
             XCTFail("Caught error during encoding nested container types: \(error)")
         }
     }

--- a/TestFoundation/TestJSONSerialization.swift
+++ b/TestFoundation/TestJSONSerialization.swift
@@ -1494,16 +1494,12 @@ extension TestJSONSerialization {
             } else {
                 return nil
             }
-        } catch _ {
+        } catch {
             return nil
         }
     }
     
     fileprivate func removeTestFile(_ location: String) {
-        do {
-            try FileManager.default.removeItem(atPath: location)
-        } catch _ {
-            
-        }
+        try? FileManager.default.removeItem(atPath: location)
     }
 }

--- a/TestFoundation/TestNSArray.swift
+++ b/TestFoundation/TestNSArray.swift
@@ -725,8 +725,8 @@ class TestNSArray : XCTestCase {
 #endif
             XCTAssertEqual(data, data2)
             removeTestFile(testFile)
-        } catch let e {
-            XCTFail("Failed to write to file: \(e)")
+        } catch {
+            XCTFail("Failed to write to file: \(error)")
         }
     }
 
@@ -803,16 +803,12 @@ class TestNSArray : XCTestCase {
             } else {
                 return nil
             }
-        } catch _ {
+        } catch {
             return nil
         }
     }
     
     private func removeTestFile(_ location: String) {
-        do {
-            try FileManager.default.removeItem(atPath: location)
-        } catch _ {
-            
-        }
+        try? FileManager.default.removeItem(atPath: location)
     }
 }

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -535,7 +535,7 @@ class TestNSData: LoopbackServerTest {
             let fileManager = FileManager.default
             XCTAssertTrue(fileManager.fileExists(atPath: savePath.path))
             try! fileManager.removeItem(atPath: savePath.path)
-        } catch _ {
+        } catch {
             XCTFail()
         }
     }
@@ -1507,11 +1507,7 @@ extension TestNSData {
             XCTFail("Should not have thrown")
         }
         
-        do {
-            try FileManager.default.removeItem(at: url)
-        } catch {
-            // ignore
-        }
+        try? FileManager.default.removeItem(at: url)
     }
     
     func test_writeFailure() {
@@ -1536,13 +1532,8 @@ extension TestNSData {
             XCTFail("unexpected error")
         }
         
-        
-        do {
-            try FileManager.default.removeItem(at: url)
-        } catch {
-            // ignore
-        }
-        
+        try? FileManager.default.removeItem(at: url)
+
         // Make sure clearing the error condition allows the write to succeed
         do {
             try data.write(to: url, options: [.withoutOverwriting])
@@ -1550,11 +1541,7 @@ extension TestNSData {
             XCTAssertTrue(false, "Should not have thrown")
         }
         
-        do {
-            try FileManager.default.removeItem(at: url)
-        } catch {
-            // ignore
-        }
+        try? FileManager.default.removeItem(at: url)
     }
     
     func test_genericBuffers() {

--- a/TestFoundation/TestNSDictionary.swift
+++ b/TestFoundation/TestNSDictionary.swift
@@ -228,17 +228,13 @@ class TestNSDictionary : XCTestCase {
             } else {
                 return nil
             }
-        } catch _ {
+        } catch {
             return nil
         }
     }
     
     private func removeTestFile(_ location: String) {
-        do {
-            try FileManager.default.removeItem(atPath: location)
-        } catch _ {
-            
-        }
+        try? FileManager.default.removeItem(atPath: location)
     }
 
 }

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -253,7 +253,7 @@ class TestProcess : XCTestCase {
             let (output, _) = try runTask(["/usr/bin/env"], environment: nil)
             let env = try parseEnv(output)
             XCTAssertGreaterThan(env.count, 0)
-        } catch let error {
+        } catch {
             XCTFail("Test failed: \(error)")
         }
     }
@@ -263,7 +263,7 @@ class TestProcess : XCTestCase {
             let (output, _) = try runTask(["/usr/bin/env"], environment: [:])
             let env = try parseEnv(output)
             XCTAssertEqual(env.count, 0)
-        } catch let error {
+        } catch {
             XCTFail("Test failed: \(error)")
         }
     }
@@ -274,7 +274,7 @@ class TestProcess : XCTestCase {
             let (output, _) = try runTask(["/usr/bin/env"], environment: input)
             let env = try parseEnv(output)
             XCTAssertEqual(env, input)
-        } catch let error {
+        } catch {
             XCTFail("Test failed: \(error)")
         }
     }
@@ -309,7 +309,7 @@ class TestProcess : XCTestCase {
             let (pwd, _) = try runTask([xdgTestHelperURL().path, "--getcwd"], currentDirectoryPath: tmpDir)
             // Check the sub-process used the correct directory
             XCTAssertEqual(pwd.trimmingCharacters(in: .newlines), resolvedTmpDir)
-        } catch let error {
+        } catch {
             XCTFail("Test failed: \(error)")
         }
 
@@ -318,7 +318,7 @@ class TestProcess : XCTestCase {
             let (pwd, _) = try runTask([xdgTestHelperURL().path, "--echo-PWD"], currentDirectoryPath: tmpDir)
             // Check the sub-process used the correct directory
             XCTAssertEqual(pwd.trimmingCharacters(in: .newlines), tmpDir)
-        } catch let error {
+        } catch {
             XCTFail("Test failed: \(error)")
         }
 
@@ -329,7 +329,7 @@ class TestProcess : XCTestCase {
             let (pwd, _) = try runTask([xdgTestHelperURL().path, "--echo-PWD"], environment: env, currentDirectoryPath: tmpDir)
             // Check the sub-process used the correct directory
             XCTAssertEqual(pwd.trimmingCharacters(in: .newlines), "/bin")
-        } catch let error {
+        } catch {
             XCTFail("Test failed: \(error)")
         }
 
@@ -340,7 +340,7 @@ class TestProcess : XCTestCase {
             let (pwd, _) = try runTask([xdgTestHelperURL().path, "--echo-PWD"], environment: env, currentDirectoryPath: tmpDir)
             // Check the sub-process used the correct directory
             XCTAssertEqual(pwd.trimmingCharacters(in: .newlines), "")
-        } catch let error {
+        } catch {
             XCTFail("Test failed: \(error)")
         }
 

--- a/TestFoundation/TestStream.swift
+++ b/TestFoundation/TestStream.swift
@@ -218,17 +218,13 @@ class TestStream : XCTestCase {
             } else {
                 return nil
             }
-        } catch _ {
+        } catch {
             return nil
         }
     }
     
     private func removeTestFile(_ location: String) {
-        do {
-            try FileManager.default.removeItem(atPath: location)
-        } catch _ {
-            
-        }
+        try? FileManager.default.removeItem(atPath: location)
     }
 }
 

--- a/TestFoundation/TestUtils.swift
+++ b/TestFoundation/TestUtils.swift
@@ -18,8 +18,8 @@ func ensureFiles(_ fileNames: [String]) -> Bool {
         if name.hasSuffix("/") {
             do {
                 try fm.createDirectory(atPath: name, withIntermediateDirectories: true, attributes: nil)
-            } catch let err {
-                print(err)
+            } catch {
+                print(error)
                 return false
             }
         } else {
@@ -29,8 +29,8 @@ func ensureFiles(_ fileNames: [String]) -> Bool {
             if !fm.fileExists(atPath: dir, isDirectory: &isDir) {
                 do {
                     try fm.createDirectory(atPath: dir, withIntermediateDirectories: true, attributes: nil)
-                } catch let err {
-                    print(err)
+                } catch {
+                    print(error)
                     return false
                 }
             } else if !isDir.boolValue {

--- a/Tools/plutil/main.swift
+++ b/Tools/plutil/main.swift
@@ -367,8 +367,8 @@ func main() -> Int32 {
             case .help:
                 return help()
         }
-    } catch let err {
-        switch err as! OptionParseError {
+    } catch {
+        switch error as! OptionParseError {
             case .unrecognizedArgument(let arg):
                 print("unrecognized option: \(arg)")
                 let _ = help()


### PR DESCRIPTION
- Remove wildcard pattern matching
- Refactor catches with empty body
- Prefer using try? to ignore errors instead of empty catch body
- Prefer not assigning a variable name