### PR TITLE
Use reference type NSNumber for JSONSerialization

### DIFF
--- a/Foundation/JSONEncoder.swift
+++ b/Foundation/JSONEncoder.swift
@@ -859,7 +859,7 @@ open class JSONDecoder {
     /// - throws: `DecodingError.dataCorrupted` if values requested from the payload are corrupted, or if the given data is not valid JSON.
     /// - throws: An error if any value throws an error during decoding.
     open func decode<T : Decodable>(_ type: T.Type, from data: Data) throws -> T {
-        let topLevel = try JSONSerialization.jsonObject(with: data, options: [.useReferenceNumericTypes])
+        let topLevel = try JSONSerialization.jsonObject(with: data, options: [])
         let decoder = _JSONDecoder(referencing: topLevel, options: self.options)
         return try T(from: decoder)
     }

--- a/Foundation/JSONSerialization.swift
+++ b/Foundation/JSONSerialization.swift
@@ -23,7 +23,7 @@ extension JSONSerialization {
         public static let mutableContainers = ReadingOptions(rawValue: 1 << 0)
         public static let mutableLeaves = ReadingOptions(rawValue: 1 << 1)
         public static let allowFragments = ReadingOptions(rawValue: 1 << 2)
-        internal static let useReferenceNumericTypes = ReadingOptions(rawValue: 1 << 15)
+        internal static let useNativeNumericTypes = ReadingOptions(rawValue: 1 << 15)
     }
 
     public struct WritingOptions : OptionSet {
@@ -841,7 +841,7 @@ private struct JSONReader {
                     return nil
                 }
 
-                let shouldUseReferenceType = opt.contains(.useReferenceNumericTypes)
+                let shouldUseReferenceType = !opt.contains(.useNativeNumericTypes)
 
                 if intDistance == doubleDistance {
                     return (shouldUseReferenceType ? NSNumber(value: intResult) : intResult,
@@ -849,11 +849,6 @@ private struct JSONReader {
                 }
                 guard doubleDistance > 0 else {
                     return nil
-                }
-
-                if doubleResult == doubleResult.rounded() {
-                    return (shouldUseReferenceType ? NSNumber(value: Int(doubleResult)) : Int(doubleResult),
-                            doubleDistance)
                 }
 
                 return (shouldUseReferenceType ? NSNumber(value: doubleResult) : doubleResult,
@@ -887,11 +882,11 @@ private struct JSONReader {
             return (value, parser)
         }
         else if let parser = try consumeASCIISequence("true", input: input) {
-            let result: Any = opt.contains(.useReferenceNumericTypes) ? NSNumber(value: true) : true
+            let result: Any = opt.contains(.useNativeNumericTypes) ? true : NSNumber(value: true)
             return (result, parser)
         }
         else if let parser = try consumeASCIISequence("false", input: input) {
-            let result: Any = opt.contains(.useReferenceNumericTypes) ? NSNumber(value: false) : false
+            let result: Any = opt.contains(.useNativeNumericTypes) ? false : NSNumber(value: false)
             return (result, parser)
         }
         else if let parser = try consumeASCIISequence("null", input: input) {


### PR DESCRIPTION
As discussed in PR https://github.com/apple/swift-corelibs-foundation/pull/1443, now that NSNumber can be cast to numeric types outside Darwin, switch JSONSerialization code to use it. Also removes some ill-advised conversion to Int of double values that happen to round which will fail for double values > Int.max