### PR TITLE
[for stdlib] Switch _sanityCheck for assert

### DIFF
--- a/Foundation/NSStringAPI.swift
+++ b/Foundation/NSStringAPI.swift
@@ -1637,7 +1637,7 @@ extension StringProtocol where Index == String.Index {
   public func contains<T : StringProtocol>(_ other: T) -> Bool {
     let r = self.range(of: other) != nil
     if #available(macOS 10.10, iOS 8.0, *) {
-      _sanityCheck(r == _ns.contains(other._ephemeralString))
+      assert(r == _ns.contains(other._ephemeralString))
     }
     return r
   }
@@ -1660,7 +1660,7 @@ extension StringProtocol where Index == String.Index {
       of: other, options: .caseInsensitive, locale: Locale.current
     ) != nil
     if #available(macOS 10.10, iOS 8.0, *) {
-      _sanityCheck(r ==
+      assert(r ==
         _ns.localizedCaseInsensitiveContains(other._ephemeralString))
     }
     return r


### PR DESCRIPTION
In support of #18134 which takes `_sanityCheck` private. `assert` should fulfill the same needs.
