### PR TITLE
NSDateComponents.hash: Fix arithmetic overflows

### DIFF
--- a/TestFoundation/TestCalendar.swift
+++ b/TestFoundation/TestCalendar.swift
@@ -198,8 +198,24 @@ class TestNSDateComponents: XCTestCase {
 
     static var allTests: [(String, (TestNSDateComponents) -> () throws -> Void)] {
         return [
+            ("test_hash", test_hash),
             ("test_copyNSDateComponents", test_copyNSDateComponents),
         ]
+    }
+
+    func test_hash() {
+        let c1 = NSDateComponents()
+        c1.year = 2018
+        c1.month = 8
+        c1.day = 1
+
+        let c2 = NSDateComponents()
+        c2.year = 2018
+        c2.month = 8
+        c2.day = 1
+
+        XCTAssertEqual(c1, c2)
+        XCTAssertEqual(c1.hash, c2.hash)
     }
 
     func test_copyNSDateComponents() {


### PR DESCRIPTION
`NSDateComponents.hash` currently hashes 13 components, while `isEqual(_:)` compares 17 components. The expression that produces the hash value often traps because of arithmetic overflows. 

Replace the `hash` implementation with one that uses `Hasher`, feeding it with the exact same components that are compared in equality checks.

Resolves https://bugs.swift.org/browse/SR-8441