### PR TITLE
NSURLRequest.hash: Implement

### DIFF
--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -259,7 +259,18 @@ open class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopying 
                 && other.allowsCellularAccess == self.allowsCellularAccess
                 && other.httpShouldHandleCookies == self.httpShouldHandleCookies)
     }
-    
+
+    open override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(url)
+        hasher.combine(mainDocumentURL)
+        hasher.combine(httpMethod)
+        hasher.combine(httpBodyStream)
+        hasher.combine(allowsCellularAccess)
+        hasher.combine(httpShouldHandleCookies)
+        return hasher.finalize()
+    }
+
     /// Indicates that NSURLRequest implements the NSSecureCoding protocol.
     open class  var supportsSecureCoding: Bool { return true }
     

--- a/TestFoundation/TestURLRequest.swift
+++ b/TestFoundation/TestURLRequest.swift
@@ -18,6 +18,7 @@ class TestURLRequest : XCTestCase {
             ("test_mutableCopy_1", test_mutableCopy_1),
             ("test_mutableCopy_2", test_mutableCopy_2),
             ("test_mutableCopy_3", test_mutableCopy_3),
+            ("test_hash", test_hash),
             ("test_methodNormalization", test_methodNormalization),
             ("test_description", test_description),
         ]
@@ -192,6 +193,15 @@ class TestURLRequest : XCTestCase {
         XCTAssertEqual(originalRequest.httpMethod, "GET")
         XCTAssertEqual(originalRequest.url, urlA)
         XCTAssertNil(originalRequest.allHTTPHeaderFields)
+    }
+
+    func test_hash() {
+        let url = URL(string: "https://swift.org")!
+        let r1 = URLRequest(url: url)
+        let r2 = URLRequest(url: url)
+
+        XCTAssertEqual(r1, r2)
+        XCTAssertEqual(r1.hashValue, r2.hashValue)
     }
 
     func test_methodNormalization() {


### PR DESCRIPTION
`NSURLRequest` inherits `hash` from `NSObject`, but overrides `isEqual(_:)` to compare contents. The default hash uses object identity, so two `NSURLRequest` instances that compare equal under `isEqual(_:)` can produce non-equal hash values. This also breaks hashing for `URLRequest`, which calls into `NSURLRequest.hash`.

Add an implementation for `NSURLRequest.hash` that matches `isEqual(_:)`.

Resolves https://bugs.swift.org/browse/SR-8449