### PR TITLE
NSLocale.hash: Implement

### DIFF
--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -69,7 +69,11 @@ open class NSLocale: NSObject, NSCopying, NSSecureCoding {
         
         return locale.localeIdentifier == localeIdentifier
     }
-    
+
+    override open var hash: Int {
+        return localeIdentifier.hash
+    }
+
     open func encode(with aCoder: NSCoder) {
         guard aCoder.allowsKeyedCoding else {
             preconditionFailure("Unkeyed coding is unsupported.")

--- a/TestFoundation/TestNSLocale.swift
+++ b/TestFoundation/TestNSLocale.swift
@@ -13,6 +13,7 @@ class TestNSLocale : XCTestCase {
             ("test_constants", test_constants),
             ("test_Identifier", test_Identifier),
             ("test_copy", test_copy),
+            ("test_hash", test_hash),
             ("test_staticProperties", test_staticProperties),
             ("test_localeProperties", test_localeProperties),
         ]
@@ -100,6 +101,14 @@ class TestNSLocale : XCTestCase {
         let localeCopy = locale
 
         XCTAssertTrue(locale == localeCopy)
+    }
+
+    func test_hash() {
+        let a1 = Locale(identifier: "en_US")
+        let a2 = Locale(identifier: "en_US")
+
+        XCTAssertEqual(a1, a2)
+        XCTAssertEqual(a1.hashValue, a2.hashValue)
     }
 
     func test_staticProperties() {


### PR DESCRIPTION
`NSLocale` inherits hash from `NSObject`, but overrides `isEqual(_:)` to compare contents. The default hash uses object identity, so two `NSLocale` instances that compare equal under `isEqual(_:)` can produce non-equal hash values. This also breaks hashing for `Locale`, which calls into `NSLocale.hash`.

Add an implementation for `NSLocale.hash` that matches `isEqual(_:)`.

Resolves https://bugs.swift.org/browse/SR-8448