### PR TITLE
NSURLComponents.hash: Implement

### DIFF
--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -983,6 +983,19 @@ open class NSURLComponents: NSObject, NSCopying {
                 && fragment == other.fragment)
     }
 
+    open override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(scheme)
+        hasher.combine(user)
+        hasher.combine(password)
+        hasher.combine(host)
+        hasher.combine(port)
+        hasher.combine(path)
+        hasher.combine(query)
+        hasher.combine(fragment)
+        return hasher.finalize()
+    }
+
     open func copy(with zone: NSZone? = nil) -> Any {
         let copy = NSURLComponents()
         copy.scheme = self.scheme

--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -521,6 +521,7 @@ class TestURLComponents : XCTestCase {
             ("test_port", test_portSetter),
             ("test_url", test_url),
             ("test_copy", test_copy),
+            ("test_hash", test_hash),
             ("test_createURLWithComponents", test_createURLWithComponents),
             ("test_path", test_path),
             ("test_percentEncodedPath", test_percentEncodedPath),
@@ -615,7 +616,15 @@ class TestURLComponents : XCTestCase {
         /* Assert that NSURLComponents.copy is actually a copy of NSURLComponents */ 
         XCTAssertTrue(copy.isEqual(urlComponent))
     }
-    
+
+    func test_hash() {
+        let c1 = URLComponents(string: "https://www.swift.org/path/to/file.html?id=name")!
+        let c2 = URLComponents(string: "https://www.swift.org/path/to/file.html?id=name")!
+
+        XCTAssertEqual(c1, c2)
+        XCTAssertEqual(c1.hashValue, c2.hashValue)
+    }
+
     func test_createURLWithComponents() {
         let urlComponents = NSURLComponents()
         urlComponents.scheme = "https";


### PR DESCRIPTION
`NSURLComponents` inherits `hash` from `NSObject`, but overrides `isEqual(_:)` to compare contents. The default hash uses object identity, so two `NSURLComponent` instances that compare equal under `isEqual(_:)` can produce non-equal hash values. This also breaks hashing for `URLComponents`, which calls into `NSURLComponents.hash`.

Add an implementation for `NSURLComponents.hash` that matches `isEqual(_:)`.

Resolves https://bugs.swift.org/browse/SR-8450