### PR TITLE
Add custom AnyHashable representations to Foundation types with bridging

### DIFF
--- a/Foundation/AffineTransform.swift
+++ b/Foundation/AffineTransform.swift
@@ -517,6 +517,12 @@ extension NSAffineTransform : _StructTypeBridgeable {
     }
 }
 
+extension NSAffineTransform : _HasCustomAnyHashableRepresentation {
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as AffineTransform)
+    }
+}
+
 extension AffineTransform : Codable {
     public init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()

--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -1935,10 +1935,8 @@ extension Data : _ObjectiveCBridgeable {
 }
 
 extension NSData : _HasCustomAnyHashableRepresentation {
-    // Must be @nonobjc to avoid infinite recursion during bridging.
-    @nonobjc
     public func _toCustomAnyHashable() -> AnyHashable? {
-        return AnyHashable(Data._unconditionallyBridgeFromObjectiveC(self))
+        return AnyHashable(self as Data)
     }
 }
 

--- a/Foundation/IndexPath.swift
+++ b/Foundation/IndexPath.swift
@@ -800,10 +800,8 @@ extension IndexPath : _ObjectiveCBridgeable {
 }
 
 extension NSIndexPath : _HasCustomAnyHashableRepresentation {
-    // Must be @nonobjc to avoid infinite recursion during bridging.
-    @nonobjc
     public func _toCustomAnyHashable() -> AnyHashable? {
-        return AnyHashable(IndexPath(nsIndexPath: self))
+        return AnyHashable(self as IndexPath)
     }
 }
 

--- a/Foundation/IndexSet.swift
+++ b/Foundation/IndexSet.swift
@@ -824,10 +824,8 @@ extension IndexSet : _ObjectiveCBridgeable {
 }
 
 extension NSIndexSet : _HasCustomAnyHashableRepresentation {
-    // Must be @nonobjc to avoid infinite recursion during bridging.
-    @nonobjc
     public func _toCustomAnyHashable() -> AnyHashable? {
-        return AnyHashable(IndexSet(reference: self))
+        return AnyHashable(self as IndexSet)
     }
 }
 

--- a/Foundation/Measurement.swift
+++ b/Foundation/Measurement.swift
@@ -234,14 +234,8 @@ extension Measurement : _ObjectiveCBridgeable {
 
 @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
 extension NSMeasurement : _HasCustomAnyHashableRepresentation {
-    // Must be @nonobjc to avoid infinite recursion during bridging.
-    @nonobjc
     public func _toCustomAnyHashable() -> AnyHashable? {
-#if DEPLOYMENT_RUNTIME_SWIFT
-        return AnyHashable(Measurement._unconditionallyBridgeFromObjectiveC(self))
-#else
         return AnyHashable(self as Measurement)
-#endif
     }
 }
 

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -935,6 +935,12 @@ open class NSMutableArray : NSArray {
     }
 }
 
+extension NSArray : _HasCustomAnyHashableRepresentation {
+  public func _toCustomAnyHashable() -> AnyHashable? {
+    return AnyHashable(self as! Array<AnyHashable>)
+  }
+}
+
 extension NSArray : Sequence {
     final public func makeIterator() -> Iterator {
         return Iterator(self)

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -1834,3 +1834,15 @@ extension NSDateComponents : _StructTypeBridgeable {
         return DateComponents._unconditionallyBridgeFromObjectiveC(self)
     }
 }
+
+extension NSCalendar : _HasCustomAnyHashableRepresentation {
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as Calendar)
+    }
+}
+
+extension NSDateComponents : _HasCustomAnyHashableRepresentation {
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(_bridgeToSwift())
+    }
+}

--- a/Foundation/NSCharacterSet.swift
+++ b/Foundation/NSCharacterSet.swift
@@ -362,3 +362,9 @@ extension NSCharacterSet : _StructTypeBridgeable {
         return CharacterSet._unconditionallyBridgeFromObjectiveC(self)
     }
 }
+
+extension NSCharacterSet : _HasCustomAnyHashableRepresentation {
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as CharacterSet)
+    }
+}

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -246,6 +246,11 @@ extension Date : _NSBridgeable, _CFBridgeable {
     internal var _cfObject: CFType { return _nsObject._cfObject }
 }
 
+extension NSDate : _HasCustomAnyHashableRepresentation {
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as Date)
+    }
+}
 
 open class NSDateInterval : NSObject, NSCopying, NSSecureCoding {
     
@@ -417,5 +422,11 @@ extension NSDateInterval : _StructTypeBridgeable {
     
     public func _bridgeToSwift() -> DateInterval {
         return DateInterval._unconditionallyBridgeFromObjectiveC(self)
+    }
+}
+
+extension NSDateInterval : _HasCustomAnyHashableRepresentation {
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as DateInterval)
     }
 }

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -571,6 +571,12 @@ extension Dictionary : _NSBridgeable, _CFBridgeable {
     internal var _cfObject: CFDictionary { return _nsObject._cfObject }
 }
 
+extension NSDictionary : _HasCustomAnyHashableRepresentation {
+  public func _toCustomAnyHashable() -> AnyHashable? {
+    return AnyHashable(self as! Dictionary<AnyHashable, AnyHashable>)
+  }
+}
+
 open class NSMutableDictionary : NSDictionary {
     
     open func removeObject(forKey aKey: Any) {

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -253,3 +253,9 @@ extension NSLocale : _StructTypeBridgeable {
         return Locale._unconditionallyBridgeFromObjectiveC(self)
     }
 }
+
+extension NSLocale : _HasCustomAnyHashableRepresentation {
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as Locale)
+    }
+}

--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -211,3 +211,9 @@ open class NotificationCenter: NSObject {
     }
 
 }
+
+extension NSNotification : _HasCustomAnyHashableRepresentation {
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as Notification)
+    }
+}

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -1098,3 +1098,27 @@ protocol _NSNumberCastingWithoutBridging {
 }
 
 extension NSNumber: _NSNumberCastingWithoutBridging {}
+
+extension NSNumber : _HasCustomAnyHashableRepresentation {
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        // Note: This needs to be kept in sync with the Swift stdlib.
+        // Don't reorder checks or add new cases without also updating
+        // the AnyHashable representations of Swift's native integer
+        // types.
+        if let nsDecimalNumber: NSDecimalNumber = self as? NSDecimalNumber {
+            return AnyHashable(nsDecimalNumber.decimalValue)
+        } else if self === kCFBooleanTrue {
+            return AnyHashable(true)
+        } else if self === kCFBooleanFalse {
+            return AnyHashable(false)
+        } else if NSNumber(value: int64Value) == self {
+            return AnyHashable(int64Value)
+        } else if NSNumber(value: uint64Value) == self {
+            return AnyHashable(uint64Value)
+        } else if NSNumber(value: doubleValue) == self {
+            return AnyHashable(doubleValue)
+        } else {
+            return nil
+        }
+    }
+}

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -298,6 +298,12 @@ extension Set : _NSBridgeable, _CFBridgeable {
     internal var _cfObject: CFSet { return _nsObject._cfObject }
 }
 
+extension NSSet : _HasCustomAnyHashableRepresentation {
+  public func _toCustomAnyHashable() -> AnyHashable? {
+    return AnyHashable(self as! Set<AnyHashable>)
+  }
+}
+
 extension NSSet : Sequence {
     public typealias Iterator = NSEnumerator.Iterator
     public func makeIterator() -> Iterator {

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -1324,6 +1324,12 @@ extension NSString {
 
 extension NSString : ExpressibleByStringLiteral { }
 
+extension NSString : _HasCustomAnyHashableRepresentation {
+  public func _toCustomAnyHashable() -> AnyHashable? {
+    return AnyHashable(self as String)
+  }
+}
+
 open class NSMutableString : NSString {
     open func replaceCharacters(in range: NSRange, with aString: String) {
         guard type(of: self) === NSString.self || type(of: self) === NSMutableString.self else {

--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -276,6 +276,12 @@ extension TimeZone : _NSBridgeable, _CFBridgeable {
     var _cfObject : CFTimeZone { return _nsObject._cfObject }
 }
 
+extension NSTimeZone : _HasCustomAnyHashableRepresentation {
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self._swiftObject)
+    }
+}
+
 extension NSTimeZone {
 
     public enum NameStyle : Int {

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -1321,3 +1321,21 @@ extension NSURLQueryItem : _StructTypeBridgeable {
     }
 }
 
+
+extension NSURL : _HasCustomAnyHashableRepresentation {
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as URL)
+    }
+}
+
+extension NSURLComponents : _HasCustomAnyHashableRepresentation {
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as URLComponents)
+    }
+}
+
+extension NSURLQueryItem : _HasCustomAnyHashableRepresentation {
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as URLQueryItem)
+    }
+}

--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -567,3 +567,9 @@ extension NSURLRequest : _StructTypeBridgeable {
         return URLRequest._unconditionallyBridgeFromObjectiveC(self)
     }
 }
+
+extension NSURLRequest : _HasCustomAnyHashableRepresentation {
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as URLRequest)
+    }
+}

--- a/Foundation/PersonNameComponents.swift
+++ b/Foundation/PersonNameComponents.swift
@@ -131,10 +131,8 @@ extension PersonNameComponents : _ObjectiveCBridgeable {
 }
 
 extension NSPersonNameComponents : _HasCustomAnyHashableRepresentation {
-    // Must be @nonobjc to avoid infinite recursion during bridging.
-    @nonobjc
     public func _toCustomAnyHashable() -> AnyHashable? {
-        return AnyHashable(self._bridgeToSwift())
+        return AnyHashable(self as PersonNameComponents)
     }
 }
 

--- a/Foundation/UUID.swift
+++ b/Foundation/UUID.swift
@@ -156,10 +156,8 @@ extension UUID : _ObjectiveCBridgeable {
 }
 
 extension NSUUID : _HasCustomAnyHashableRepresentation {
-    // Must be @nonobjc to avoid infinite recursion during bridging.
-    @nonobjc
     public func _toCustomAnyHashable() -> AnyHashable? {
-        return AnyHashable(UUID._unconditionallyBridgeFromObjectiveC(self))
+        return AnyHashable(self as UUID)
     }
 }
 

--- a/TestFoundation/TestAffineTransform.swift
+++ b/TestFoundation/TestAffineTransform.swift
@@ -321,6 +321,8 @@ class TestAffineTransform : XCTestCase {
         let ref = NSAffineTransform()
         let val = AffineTransform.identity
         XCTAssertEqual(ref.hashValue, val.hashValue)
+        XCTAssertEqual(ref as AnyHashable, val as AnyHashable)
+        XCTAssertEqual((ref as AnyHashable).hashValue, (val as AnyHashable).hashValue)
     }
 
     func test_hashing_values() {
@@ -336,6 +338,8 @@ class TestAffineTransform : XCTestCase {
             let ref = NSAffineTransform()
             ref.transformStruct = NSAffineTransformStruct(m11: val.m11, m12: val.m12, m21: val.m21, m22: val.m22, tX: val.tX, tY: val.tY)
             XCTAssertEqual(ref.hashValue, val.hashValue)
+            XCTAssertEqual(ref as AnyHashable, val as AnyHashable)
+            XCTAssertEqual((ref as AnyHashable).hashValue, (val as AnyHashable).hashValue)
         }
     }
 

--- a/TestFoundation/TestCalendar.swift
+++ b/TestFoundation/TestCalendar.swift
@@ -23,9 +23,10 @@ class TestCalendar: XCTestCase {
             ("test_customMirror", test_customMirror),
             ("test_ampmSymbols", test_ampmSymbols),
             ("test_currentCalendarRRstability", test_currentCalendarRRstability),
+            ("test_AnyHashable", test_AnyHashable),
         ]
     }
-    
+
     func test_allCalendars() {
         for identifier in [
             Calendar.Identifier.buddhist,
@@ -192,6 +193,22 @@ class TestCalendar: XCTestCase {
         XCTAssertEqual(calendar.firstWeekday, calendarMirror.descendant("firstWeekday") as? Int)
         XCTAssertEqual(calendar.minimumDaysInFirstWeek, calendarMirror.descendant("minimumDaysInFirstWeek") as? Int)
     }
+
+    func test_AnyHashable() {
+        let a1: AnyHashable = Calendar(identifier: Calendar.Identifier.buddhist)
+        let a2: AnyHashable = NSCalendar(identifier: NSCalendar.Identifier.buddhist)!
+        let b1: AnyHashable = Calendar(identifier: Calendar.Identifier.chinese)
+        let b2: AnyHashable = NSCalendar(identifier: NSCalendar.Identifier.chinese)!
+        XCTAssertEqual(a1, a2)
+        XCTAssertEqual(b1, b2)
+        XCTAssertNotEqual(a1, b1)
+        XCTAssertNotEqual(a1, b2)
+        XCTAssertNotEqual(a2, b1)
+        XCTAssertNotEqual(a2, b2)
+
+        XCTAssertEqual(a1.hashValue, a2.hashValue)
+        XCTAssertEqual(b1.hashValue, b2.hashValue)
+    }
 }
 
 class TestNSDateComponents: XCTestCase {
@@ -199,6 +216,7 @@ class TestNSDateComponents: XCTestCase {
     static var allTests: [(String, (TestNSDateComponents) -> () throws -> Void)] {
         return [
             ("test_copyNSDateComponents", test_copyNSDateComponents),
+            ("test_AnyHashable", test_AnyHashable),
         ]
     }
 
@@ -222,5 +240,23 @@ class TestNSDateComponents: XCTestCase {
         components.hour = 12
         XCTAssertEqual(components.hour, 12)
         XCTAssertEqual(copy.hour, 14)
+    }
+
+    func test_AnyHashable() {
+        let d1 = DateComponents(year: 2018, month: 8, day: 1)
+        let d2 = DateComponents(year: 2014, month: 6, day: 2)
+        let a1: AnyHashable = d1
+        let a2: AnyHashable = d1._bridgeToObjectiveC()
+        let b1: AnyHashable = d2
+        let b2: AnyHashable = d2._bridgeToObjectiveC()
+        XCTAssertEqual(a1, a2)
+        XCTAssertEqual(b1, b2)
+        XCTAssertNotEqual(a1, b1)
+        XCTAssertNotEqual(a1, b2)
+        XCTAssertNotEqual(a2, b1)
+        XCTAssertNotEqual(a2, b2)
+
+        XCTAssertEqual(a1.hashValue, a2.hashValue)
+        XCTAssertEqual(b1.hashValue, b2.hashValue)
     }
 }

--- a/TestFoundation/TestCharacterSet.swift
+++ b/TestFoundation/TestCharacterSet.swift
@@ -74,6 +74,7 @@ class TestCharacterSet : XCTestCase {
             ("test_formUnion", test_formUnion),
             ("test_union", test_union),
             ("test_SR5971", test_SR5971),
+            ("test_AnyHashable", test_AnyHashable),
         ]
     }
     
@@ -367,5 +368,20 @@ class TestCharacterSet : XCTestCase {
         let charset2 = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789&+")
         XCTAssertTrue(charset2.contains("+"))
     }
-    
+
+    func test_AnyHashable() {
+        let a1: AnyHashable = CharacterSet.letters
+        let a2: AnyHashable = NSCharacterSet.letters
+        let b1: AnyHashable = CharacterSet.alphanumerics
+        let b2: AnyHashable = CharacterSet.alphanumerics
+        XCTAssertEqual(a1, a2)
+        XCTAssertEqual(b1, b2)
+        XCTAssertNotEqual(a1, b1)
+        XCTAssertNotEqual(a1, b2)
+        XCTAssertNotEqual(a2, b1)
+        XCTAssertNotEqual(a2, b2)
+
+        XCTAssertEqual(a1.hashValue, a2.hashValue)
+        XCTAssertEqual(b1.hashValue, b2.hashValue)
+    }
 }

--- a/TestFoundation/TestDate.swift
+++ b/TestFoundation/TestDate.swift
@@ -25,6 +25,7 @@ class TestDate : XCTestCase {
             ("test_IsEqualToDate", test_IsEqualToDate),
             ("test_timeIntervalSinceReferenceDate", test_timeIntervalSinceReferenceDate),
             ("test_recreateDateComponentsFromDate", test_recreateDateComponentsFromDate),
+            ("test_AnyHashable", test_AnyHashable),
         ]
     }
     
@@ -151,5 +152,21 @@ class TestDate : XCTestCase {
         XCTAssertEqual(recreatedComponents.weekOfMonth, 2)
         XCTAssertEqual(recreatedComponents.weekOfYear, 45)
         XCTAssertEqual(recreatedComponents.yearForWeekOfYear, 2017)
+    }
+
+    func test_AnyHashable() {
+        let a1: AnyHashable = Date(timeIntervalSinceReferenceDate: 1000)
+        let a2: AnyHashable = NSDate(timeIntervalSinceReferenceDate: 1000)
+        let b1: AnyHashable = Date(timeIntervalSinceReferenceDate: 5000)
+        let b2: AnyHashable = NSDate(timeIntervalSinceReferenceDate: 5000)
+        XCTAssertEqual(a1, a2)
+        XCTAssertEqual(b1, b2)
+        XCTAssertNotEqual(a1, b1)
+        XCTAssertNotEqual(a1, b2)
+        XCTAssertNotEqual(a2, b1)
+        XCTAssertNotEqual(a2, b2)
+
+        XCTAssertEqual(a1.hashValue, a2.hashValue)
+        XCTAssertEqual(b1.hashValue, b2.hashValue)
     }
 }

--- a/TestFoundation/TestDateInterval.swift
+++ b/TestFoundation/TestDateInterval.swift
@@ -1,0 +1,34 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+class TestDateInterval : XCTestCase {
+
+    static var allTests: [(String, (TestDateInterval) -> () throws -> Void)] {
+        return [
+            ("test_AnyHashable", test_AnyHashable),
+        ]
+    }
+
+    func test_AnyHashable() {
+        let start = Date(timeIntervalSinceReferenceDate: 1000)
+        let a1: AnyHashable = DateInterval(start: start, duration: 1000)
+        let a2: AnyHashable = NSDateInterval(start: start, duration: 1000)
+        let b1: AnyHashable = DateInterval(start: start, duration: 5000)
+        let b2: AnyHashable = NSDateInterval(start: start, duration: 5000)
+        XCTAssertEqual(a1, a2)
+        XCTAssertEqual(b1, b2)
+        XCTAssertNotEqual(a1, b1)
+        XCTAssertNotEqual(a1, b2)
+        XCTAssertNotEqual(a2, b1)
+        XCTAssertNotEqual(a2, b2)
+
+        XCTAssertEqual(a1.hashValue, a2.hashValue)
+        XCTAssertEqual(b1.hashValue, b2.hashValue)
+    }
+}

--- a/TestFoundation/TestNSArray.swift
+++ b/TestFoundation/TestNSArray.swift
@@ -31,6 +31,7 @@ class TestNSArray : XCTestCase {
             ("test_sortUsingFunction", test_sortUsingFunction),
             ("test_sortUsingComparator", test_sortUsingComparator),
             ("test_equality", test_equality),
+            ("test_AnyHashable", test_AnyHashable),
             ("test_copying", test_copying),
             ("test_mutableCopying", test_mutableCopying),
             ("test_writeToFile", test_writeToFile),
@@ -584,6 +585,16 @@ class TestNSArray : XCTestCase {
         XCTAssertFalse(objectsArray1 == objectsArray2)
         XCTAssertFalse(objectsArray1.isEqual(objectsArray2))
         XCTAssertFalse(objectsArray1.isEqual(to: Array(objectsArray2)))
+    }
+
+    func test_AnyHashable() {
+        let a1: AnyHashable = [1, 2, 3]
+        let a2: AnyHashable = NSArray(array: [
+                NSNumber(value: 1),
+                NSNumber(value: 2),
+                NSNumber(value: 3)])
+        XCTAssertEqual(a1, a2)
+        XCTAssertEqual(a1.hashValue, a2.hashValue)
     }
 
     /// - Note: value type conversion will destroy identity. So use index(of:) instead of indexOfObjectIdentical(to:)

--- a/TestFoundation/TestNSDictionary.swift
+++ b/TestFoundation/TestNSDictionary.swift
@@ -21,6 +21,7 @@ class TestNSDictionary : XCTestCase {
             ("test_writeToFile", test_writeToFile),
             ("test_initWithContentsOfFile", test_initWithContentsOfFile),
             ("test_settingWithStringKey", test_settingWithStringKey),
+            ("test_AnyHashable", test_AnyHashable),
         ]
     }
         
@@ -241,4 +242,23 @@ class TestNSDictionary : XCTestCase {
         }
     }
 
+    func test_AnyHashable() {
+        let a1: AnyHashable = ["foo": 1, "bar": 2]
+        let a2: AnyHashable = NSDictionary(
+            objects: [NSNumber(1), NSNumber(2)],
+            forKeys: [NSString(string: "foo"), NSString(string: "bar")])
+        let b1: AnyHashable = ["foo": 2, "bar": 1]
+        let b2: AnyHashable = NSDictionary(
+            objects: [NSNumber(2), NSNumber(1)],
+            forKeys: [NSString(string: "foo"), NSString(string: "bar")])
+        XCTAssertEqual(a1, a2)
+        XCTAssertEqual(b1, b2)
+        XCTAssertNotEqual(a1, b1)
+        XCTAssertNotEqual(a1, b2)
+        XCTAssertNotEqual(a2, b1)
+        XCTAssertNotEqual(a2, b2)
+
+        XCTAssertEqual(a1.hashValue, a2.hashValue)
+        XCTAssertEqual(b1.hashValue, b2.hashValue)
+    }
 }

--- a/TestFoundation/TestNSLocale.swift
+++ b/TestFoundation/TestNSLocale.swift
@@ -15,6 +15,7 @@ class TestNSLocale : XCTestCase {
             ("test_copy", test_copy),
             ("test_staticProperties", test_staticProperties),
             ("test_localeProperties", test_localeProperties),
+            ("test_AnyHashable", test_AnyHashable),
         ]
     }
 
@@ -138,4 +139,19 @@ class TestNSLocale : XCTestCase {
 #endif
     }
 
+    func test_AnyHashable() {
+        let a1: AnyHashable = Locale(identifier: "en_US")
+        let a2: AnyHashable = NSLocale(localeIdentifier: "en_US")
+        let b1: AnyHashable = Locale(identifier: "de_DE")
+        let b2: AnyHashable = NSLocale(localeIdentifier: "de_DE")
+        XCTAssertEqual(a1, a2)
+        XCTAssertEqual(b1, b2)
+        XCTAssertNotEqual(a1, b1)
+        XCTAssertNotEqual(a1, b2)
+        XCTAssertNotEqual(a2, b1)
+        XCTAssertNotEqual(a2, b2)
+
+        XCTAssertEqual(a1.hashValue, a2.hashValue)
+        XCTAssertEqual(b1.hashValue, b2.hashValue)
+    }
 }

--- a/TestFoundation/TestNSSet.swift
+++ b/TestFoundation/TestNSSet.swift
@@ -25,6 +25,7 @@ class TestNSSet : XCTestCase {
             ("test_CountedSetRemoveObject", test_CountedSetRemoveObject),
             ("test_CountedSetCopying", test_CountedSetCopying),
             ("test_mutablesetWithDictionary", test_mutablesetWithDictionary),
+            ("test_AnyHashable", test_AnyHashable),
         ]
     }
     
@@ -223,5 +224,21 @@ class TestNSSet : XCTestCase {
         aSet.add(["world": "again"])
         dictionary.setObject(aSet, forKey: key)
         XCTAssertNotNil(dictionary.description) //should not crash
+    }
+
+    func test_AnyHashable() {
+        let a1: AnyHashable = [1, 2] as Set<Int>
+        let a2: AnyHashable = NSSet(array: [NSNumber(value: 1), NSNumber(value: 2)])
+        let b1: AnyHashable = [3, 4] as Set<Int>
+        let b2: AnyHashable = NSSet(array: [NSNumber(value: 3), NSNumber(value: 4)])
+        XCTAssertEqual(a1, a2)
+        XCTAssertEqual(b1, b2)
+        XCTAssertNotEqual(a1, b1)
+        XCTAssertNotEqual(a1, b2)
+        XCTAssertNotEqual(a2, b1)
+        XCTAssertNotEqual(a2, b2)
+
+        XCTAssertEqual(a1.hashValue, a2.hashValue)
+        XCTAssertEqual(b1.hashValue, b2.hashValue)
     }
 }

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -92,6 +92,7 @@ class TestNSString: LoopbackServerTest {
             ("test_getLineStart", test_getLineStart),
             ("test_substringWithRange", test_substringWithRange),
             ("test_createCopy", test_createCopy),
+            ("test_AnyHashable", test_AnyHashable),
         ]
     }
 
@@ -1230,6 +1231,22 @@ class TestNSString: LoopbackServerTest {
         XCTAssertNotEqual(string, stringCopy)
         XCTAssertEqual(string, "foobar")
         XCTAssertEqual(stringCopy, "foo")
+    }
+
+    func test_AnyHashable() {
+        let a1: AnyHashable = "Hello"
+        let a2: AnyHashable = NSString(string: "Hello")
+        let b1: AnyHashable = "world"
+        let b2: AnyHashable = NSString(string: "world")
+        XCTAssertEqual(a1, a2)
+        XCTAssertEqual(b1, b2)
+        XCTAssertNotEqual(a1, b1)
+        XCTAssertNotEqual(a1, b2)
+        XCTAssertNotEqual(a2, b1)
+        XCTAssertNotEqual(a2, b2)
+
+        XCTAssertEqual(a1.hashValue, a2.hashValue)
+        XCTAssertEqual(b1.hashValue, b2.hashValue)
     }
 }
 

--- a/TestFoundation/TestNotification.swift
+++ b/TestFoundation/TestNotification.swift
@@ -12,6 +12,7 @@ class TestNotification : XCTestCase {
     static var allTests: [(String, (TestNotification) -> () throws -> Void)] {
         return [
             ("test_customReflection", test_customReflection),
+            ("test_AnyHashable", test_AnyHashable),
         ]
     }
 
@@ -41,4 +42,28 @@ class TestNotification : XCTestCase {
 
     }
 
+    func test_AnyHashable() {
+        let n1 = Notification(
+            name: Notification.Name(rawValue: "foo"),
+            object: NSObject(),
+            userInfo: ["a": 1, "b": 2])
+        let n2 = Notification(
+            name: Notification.Name(rawValue: "bar"),
+            object: NSObject(),
+            userInfo: ["c": 1, "d": 2])
+
+        let a1: AnyHashable = n1
+        let a2: AnyHashable = NSNotification(name: n1.name, object: n1.object, userInfo: n1.userInfo)
+        let b1: AnyHashable = n2
+        let b2: AnyHashable = NSNotification(name: n2.name, object: n2.object, userInfo: n2.userInfo)
+        XCTAssertEqual(a1, a2)
+        XCTAssertEqual(b1, b2)
+        XCTAssertNotEqual(a1, b1)
+        XCTAssertNotEqual(a1, b2)
+        XCTAssertNotEqual(a2, b1)
+        XCTAssertNotEqual(a2, b2)
+
+        XCTAssertEqual(a1.hashValue, a2.hashValue)
+        XCTAssertEqual(b1.hashValue, b2.hashValue)
+    }
 }

--- a/TestFoundation/TestTimeZone.swift
+++ b/TestFoundation/TestTimeZone.swift
@@ -29,6 +29,7 @@ class TestTimeZone: XCTestCase {
 
             ("test_customMirror", test_tz_customMirror),
             ("test_knownTimeZones", test_knownTimeZones),
+            ("test_AnyHashable", test_AnyHashable),
         ]
     }
 
@@ -197,5 +198,21 @@ class TestTimeZone: XCTestCase {
         for tz in timeZones {
             XCTAssertNotNil(TimeZone(identifier: tz), "Cant instantiate valid timeZone: \(tz)")
         }
+    }
+
+    func test_AnyHashable() {
+        let a1: AnyHashable = TimeZone(identifier: "GMT+0000")!
+        let a2: AnyHashable = NSTimeZone(name: "GMT+0000")!
+        let b1: AnyHashable = TimeZone(identifier: "GMT-0400")!
+        let b2: AnyHashable = NSTimeZone(name: "GMT-0400")!
+        XCTAssertEqual(a1, a2)
+        XCTAssertEqual(b1, b2)
+        XCTAssertNotEqual(a1, b1)
+        XCTAssertNotEqual(a1, b2)
+        XCTAssertNotEqual(a2, b1)
+        XCTAssertNotEqual(a2, b2)
+
+        XCTAssertEqual(a1.hashValue, a2.hashValue)
+        XCTAssertEqual(b1.hashValue, b2.hashValue)
     }
 }

--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -56,6 +56,7 @@ class TestURL : XCTestCase {
             ("test_itemNSCoding", test_itemNSCoding),
             ("test_dataRepresentation", test_dataRepresentation),
             ("test_description", test_description),
+            ("test_AnyHashable", test_AnyHashable),
         ]
     }
     
@@ -511,6 +512,22 @@ class TestURL : XCTestCase {
         let relativeURL = urlComponents.url(relativeTo: url)
         XCTAssertEqual(relativeURL?.description, "//:abcd@amazon.in:8080 -- http://amazon.in")
     }
+
+    func test_AnyHashable() {
+        let a1: AnyHashable = URL(string: "https://swift.org")!
+        let a2: AnyHashable = NSURL(string: "https://swift.org")!
+        let b1: AnyHashable = URL(string: "https://github.org/apple/swift")!
+        let b2: AnyHashable = NSURL(string: "https://github.org/apple/swift")!
+        XCTAssertEqual(a1, a2)
+        XCTAssertEqual(b1, b2)
+        XCTAssertNotEqual(a1, b1)
+        XCTAssertNotEqual(a1, b2)
+        XCTAssertNotEqual(a2, b1)
+        XCTAssertNotEqual(a2, b2)
+
+        XCTAssertEqual(a1.hashValue, a2.hashValue)
+        XCTAssertEqual(b1.hashValue, b2.hashValue)
+    }
 }
     
 class TestURLComponents : XCTestCase {
@@ -524,6 +541,7 @@ class TestURLComponents : XCTestCase {
             ("test_createURLWithComponents", test_createURLWithComponents),
             ("test_path", test_path),
             ("test_percentEncodedPath", test_percentEncodedPath),
+            ("test_AnyHashable", test_AnyHashable),
         ]
     }
     
@@ -669,5 +687,45 @@ class TestURLComponents : XCTestCase {
 
         let c6 = URLComponents(string: "http://swift.org:80/foo/b%20r")
         XCTAssertEqual(c6?.percentEncodedPath, "/foo/b%20r")
+    }
+
+    func test_AnyHashable() {
+        let a1: AnyHashable = URLComponents(string: "https://swift.org/about/#swiftorg-and-open-source")!
+        let a2: AnyHashable = NSURLComponents(string: "https://swift.org/about/#swiftorg-and-open-source")!
+        let b1: AnyHashable = URLComponents(string: "https://swift.org/blog/welcome/")!
+        let b2: AnyHashable = NSURLComponents(string: "https://swift.org/blog/welcome/")!
+        XCTAssertEqual(a1, a2)
+        XCTAssertEqual(b1, b2)
+        XCTAssertNotEqual(a1, b1)
+        XCTAssertNotEqual(a1, b2)
+        XCTAssertNotEqual(a2, b1)
+        XCTAssertNotEqual(a2, b2)
+
+        XCTAssertEqual(a1.hashValue, a2.hashValue)
+        XCTAssertEqual(b1.hashValue, b2.hashValue)
+    }
+}
+
+class TestURLQueryItem : XCTestCase {
+    static var allTests: [(String, (TestURLQueryItem) -> () throws -> Void)] {
+        return [
+            ("test_AnyHashable", test_AnyHashable),
+        ]
+    }
+
+    func test_AnyHashable() {
+        let a1: AnyHashable = URLQueryItem(name: "foo", value: "bar")
+        let a2: AnyHashable = NSURLQueryItem(name: "foo", value: "bar")
+        let b1: AnyHashable = URLQueryItem(name: "bumfuzzle", value: "brompfen")
+        let b2: AnyHashable = NSURLQueryItem(name: "bumfuzzle", value: "brompfen")
+        XCTAssertEqual(a1, a2)
+        XCTAssertEqual(b1, b2)
+        XCTAssertNotEqual(a1, b1)
+        XCTAssertNotEqual(a1, b2)
+        XCTAssertNotEqual(a2, b1)
+        XCTAssertNotEqual(a2, b2)
+
+        XCTAssertEqual(a1.hashValue, a2.hashValue)
+        XCTAssertEqual(b1.hashValue, b2.hashValue)
     }
 }

--- a/TestFoundation/TestURLRequest.swift
+++ b/TestFoundation/TestURLRequest.swift
@@ -20,6 +20,7 @@ class TestURLRequest : XCTestCase {
             ("test_mutableCopy_3", test_mutableCopy_3),
             ("test_methodNormalization", test_methodNormalization),
             ("test_description", test_description),
+            ("test_AnyHashable", test_AnyHashable),
         ]
     }
     
@@ -244,5 +245,23 @@ class TestURLRequest : XCTestCase {
 
         request.url = nil
         XCTAssertEqual(request.description, "url: nil")
+    }
+
+    func test_AnyHashable() {
+        let url1 = URL(string: "https://swift.org")!
+        let url2 = URL(string: "https://github.com/apple/swift")!
+        let a1: AnyHashable = URLRequest(url: url1)
+        let a2: AnyHashable = NSURLRequest(url: url1)
+        let b1: AnyHashable = URLRequest(url: url2)
+        let b2: AnyHashable = NSURLRequest(url: url2)
+        XCTAssertEqual(a1, a2)
+        XCTAssertEqual(b1, b2)
+        XCTAssertNotEqual(a1, b1)
+        XCTAssertNotEqual(a1, b2)
+        XCTAssertNotEqual(a2, b1)
+        XCTAssertNotEqual(a2, b2)
+
+        XCTAssertEqual(a1.hashValue, a2.hashValue)
+        XCTAssertEqual(b1.hashValue, b2.hashValue)
     }
 }

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -30,6 +30,7 @@ XCTMain([
     testCase(TestNSCompoundPredicate.allTests),
     testCase(TestNSData.allTests),
     testCase(TestDate.allTests),
+    testCase(TestDateInterval.allTests),
     testCase(TestNSDateComponents.allTests),
     testCase(TestDateFormatter.allTests),
     testCase(TestDecimal.allTests),


### PR DESCRIPTION
When converted to `AnyHashable`, both forms of bridged types should hash the same way and compare as identical. To implement this, we need to add `_HasCustomAnyHashableRepresentation` conformances to all bridgable `NSObject` subclasses.

This PR brings the set of types with custom `AnyHashable` representations in swift-corelibs-foundation in sync with the Foundation overlay in apple/swift.

Resolves https://bugs.swift.org/browse/SR-7436

Note that the new tests require the hashing fixes in #1645, #1646, #1647 and #1648.