### PR TITLE
[4.2] SR-8407: NSNumber as? Bool should only work for 0 or 1

### DIFF
--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -541,8 +541,13 @@ extension Bool : _ObjectiveCBridgeable {
     }
     
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Bool?) -> Bool {
-        result = x.boolValue
-        return true
+        if x.intValue == 0 || x.intValue == 1 {
+            result = x.boolValue
+            return true
+        } else {
+            result = nil
+            return false
+        }
     }
     
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> Bool {

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -35,6 +35,7 @@ class TestNSNumber : XCTestCase {
             ("test_objCType", test_objCType ),
             ("test_stringValue", test_stringValue),
             ("test_Equals", test_Equals),
+            ("test_boolValue", test_boolValue),
         ]
     }
     
@@ -1213,5 +1214,52 @@ class TestNSNumber : XCTestCase {
         XCTAssertEqual(NSNumber(value: Double.leastNonzeroMagnitude).compare(NSNumber(value: 0)), ComparisonResult.orderedDescending)
         XCTAssertEqual(NSNumber(value: Double.greatestFiniteMagnitude).compare(NSNumber(value: 0)), ComparisonResult.orderedDescending)
         XCTAssertTrue(NSNumber(value: Double(-0.0)) == NSNumber(value: Double(0.0)))
+    }
+
+    func test_boolValue() {
+        XCTAssertEqual(NSNumber(value: UInt8.max).boolValue, true)
+        XCTAssertEqual(NSNumber(value: UInt8.min).boolValue, false)
+
+        XCTAssertEqual(NSNumber(value: UInt16.max).boolValue, true)
+        XCTAssertEqual(NSNumber(value: UInt16.min).boolValue, false)
+
+        XCTAssertEqual(NSNumber(value: UInt32.max).boolValue, true)
+        XCTAssertEqual(NSNumber(value: UInt32.min).boolValue, false)
+
+        XCTAssertEqual(NSNumber(value: UInt64.max).boolValue, true)
+        XCTAssertEqual(NSNumber(value: UInt64.min).boolValue, false)
+
+        XCTAssertEqual(NSNumber(value: UInt.max).boolValue, true)
+        XCTAssertEqual(NSNumber(value: UInt.min).boolValue, false)
+
+        XCTAssertEqual(NSNumber(value: Int8.max).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int8.max - 1).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int8.min).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int8.min + 1).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int8(-1)).boolValue, true)
+
+        XCTAssertEqual(NSNumber(value: Int16.max).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int16.max - 1).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int16.min).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int16.min + 1).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int16(-1)).boolValue, true)
+
+        XCTAssertEqual(NSNumber(value: Int32.max).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int32.max - 1).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int32.min).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int32.min + 1).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int32(-1)).boolValue, true)
+
+        XCTAssertEqual(NSNumber(value: Int64.max).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int64.max - 1).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int64.min).boolValue, false) // Darwin compatibility
+        XCTAssertEqual(NSNumber(value: Int64.min + 1).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int64(-1)).boolValue, true)
+
+        XCTAssertEqual(NSNumber(value: Int.max).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int.max - 1).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int.min).boolValue, false)   // Darwin compatibility
+        XCTAssertEqual(NSNumber(value: Int.min + 1).boolValue, true)
+        XCTAssertEqual(NSNumber(value: Int(-1)).boolValue, true)
     }
 }

--- a/TestFoundation/TestNSNumberBridging.swift
+++ b/TestFoundation/TestNSNumberBridging.swift
@@ -24,6 +24,7 @@ class TestNSNumberBridging : XCTestCase {
             ("testNSNumberBridgeFromDouble", testNSNumberBridgeFromDouble),
             ("test_numericBitPatterns_to_floatingPointTypes", test_numericBitPatterns_to_floatingPointTypes),
             ("testNSNumberBridgeAnyHashable", testNSNumberBridgeAnyHashable),
+            ("testNSNumberToBool", testNSNumberToBool),
         ]
     }
 
@@ -622,6 +623,37 @@ class TestNSNumberBridging : XCTestCase {
 
             XCTAssertEqual(value, ns_value)
         }
+    }
+
+    func testNSNumberToBool() {
+        let b0 = NSNumber(value: 0) as? Bool
+        XCTAssertNotNil(b0)
+        XCTAssertEqual(b0, false)
+
+        let b1 = NSNumber(value: false) as? Bool
+        XCTAssertNotNil(b1)
+        XCTAssertEqual(b1, false)
+
+        let b2 = NSNumber(value: 1) as? Bool
+        XCTAssertNotNil(b2)
+        XCTAssertEqual(b2, true)
+
+        let b3 = NSNumber(value: true) as? Bool
+        XCTAssertNotNil(b3)
+        XCTAssertEqual(b3, true)
+
+        XCTAssertNil(NSNumber(value: -1) as? Bool)
+        XCTAssertNil(NSNumber(value: 2) as? Bool)
+        XCTAssertNil(NSNumber(value: Int8.min) as? Bool)
+        XCTAssertNil(NSNumber(value: Int8.max) as? Bool)
+        XCTAssertNil(NSNumber(value: Int16.min) as? Bool)
+        XCTAssertNil(NSNumber(value: Int16.max) as? Bool)
+        XCTAssertNil(NSNumber(value: Int32.min) as? Bool)
+        XCTAssertNil(NSNumber(value: Int32.max) as? Bool)
+        XCTAssertNil(NSNumber(value: Int64.min) as? Bool)
+        XCTAssertNil(NSNumber(value: Int64.max) as? Bool)
+        XCTAssertNil(NSNumber(value: Int.min) as? Bool)
+        XCTAssertNil(NSNumber(value: Int.max) as? Bool)
     }
 }
 


### PR DESCRIPTION
- NSNumber as? Bool should only work for NSNumber values 0 and 1 to
  match Darwin.