### PR TITLE
Fix Foundation build error with --install-prefix

### DIFF
--- a/build.py
+++ b/build.py
@@ -65,7 +65,7 @@ foundation.CFLAGS += " ".join([
 ])
 
 swift_cflags += [
-	'-I${BUILD_DIR}/Foundation/usr/lib/swift',
+	'-I${BUILD_DIR}/Foundation/${PREFIX}/lib/swift',
 ]
 
 if "XCTEST_BUILD_DIR" in Configuration.current.variables:


### PR DESCRIPTION
This commit fixes a header-not-found build error when Foundation is
built with --install-prefix other than "/usr".