### PR TITLE
[JSONSerialization] Use Int64 and UInt64 for integer parsing

### DIFF
--- a/TestFoundation/TestJSONSerialization.swift
+++ b/TestFoundation/TestJSONSerialization.swift
@@ -487,7 +487,7 @@ extension TestJSONSerialization {
 
     //MARK: - Number parsing
     func deserialize_numbers(objectType: ObjectType) {
-        let subject = "[1, -1, 1.3, -1.3, 1e3, 1E-3, 10]"
+        let subject = "[1, -1, 1.3, -1.3, 1e3, 1E-3, 10, \(UInt64.max)]"
 
         do {
             for encoding in supportedEncodings {
@@ -504,6 +504,8 @@ extension TestJSONSerialization {
                 XCTAssertEqual(result?[5] as? Double, 0.001)
                 XCTAssertEqual(result?[6] as? Int,    10)
                 XCTAssertEqual(result?[6] as? Double, 10.0)
+                XCTAssertEqual(result?[7] as? Int64,  nil)
+                XCTAssertEqual(result?[7] as? UInt64, UInt64.max)
             }
         } catch {
             XCTFail("Unexpected error: \(error)")


### PR DESCRIPTION
A follow-up to #1634 to expand the range of integers parsed to align behavior more closely with Darwin, as suggested by @itaiferber.

(There will still be residual differences in parsing between macOS and Linux owing to use of `Decimal` in the former.)
