### PR TITLE
DateComponents, URLRequest, URLComponents: Fix hashing

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -324,6 +324,8 @@
 		6EB768281D18C12C00D4B719 /* UUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB768271D18C12C00D4B719 /* UUID.swift */; };
 		7900433B1CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790043391CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift */; };
 		7900433C1CACD33E00ECCBF1 /* TestNSPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900433A1CACD33E00ECCBF1 /* TestNSPredicate.swift */; };
+		7D0DE86E211883F500540061 /* TestDateComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0DE86C211883F500540061 /* TestDateComponents.swift */; };
+		7D0DE86F211883F500540061 /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0DE86D211883F500540061 /* Utilities.swift */; };
 		90E645DF1E4C89A400D0D47C /* TestNSCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E645DE1E4C89A400D0D47C /* TestNSCache.swift */; };
 		9F0DD3521ECD73D000F68030 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0041781ECD5962004138BD /* main.swift */; };
 		9F0DD3571ECD783500F68030 /* SwiftFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B5D885D1BBC938800234F36 /* SwiftFoundation.framework */; };
@@ -815,6 +817,8 @@
 		790043391CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSCompoundPredicate.swift; sourceTree = "<group>"; };
 		7900433A1CACD33E00ECCBF1 /* TestNSPredicate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSPredicate.swift; sourceTree = "<group>"; };
 		7A7D6FBA1C16439400957E2E /* TestURLResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestURLResponse.swift; sourceTree = "<group>"; };
+		7D0DE86C211883F500540061 /* TestDateComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDateComponents.swift; sourceTree = "<group>"; };
+		7D0DE86D211883F500540061 /* Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
 		83712C8D1C1684900049AD49 /* TestNSURLRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSURLRequest.swift; sourceTree = "<group>"; };
 		844DC3321C17584F005611F9 /* TestScanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestScanner.swift; sourceTree = "<group>"; };
 		848A30571C137B3500C83206 /* TestHTTPCookie.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestHTTPCookie.swift; path = TestFoundation/TestHTTPCookie.swift; sourceTree = SOURCE_ROOT; };
@@ -1489,6 +1493,8 @@
 		EA66F65A1BF1976100136161 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				7D0DE86D211883F500540061 /* Utilities.swift */,
+				7D0DE86C211883F500540061 /* TestDateComponents.swift */,
 				6E203B8C1C1303BB003B2576 /* TestBundle.swift */,
 				A5A34B551C18C85D00FD972B /* TestByteCountFormatter.swift */,
 				2EBE67A31C77BF05006583D5 /* TestDateFormatter.swift */,
@@ -2521,6 +2527,7 @@
 				D5C40F331CDA1D460005690C /* TestOperationQueue.swift in Sources */,
 				BDBB65901E256BFA001A7286 /* TestEnergyFormatter.swift in Sources */,
 				5B13B32F1C582D4C00651CE2 /* TestNSGeometry.swift in Sources */,
+				7D0DE86E211883F500540061 /* TestDateComponents.swift in Sources */,
 				EA08126C1DA810BE00651B70 /* ProgressFraction.swift in Sources */,
 				5B13B3351C582D4C00651CE2 /* TestNSKeyedUnarchiver.swift in Sources */,
 				5B13B33D1C582D4C00651CE2 /* TestPipe.swift in Sources */,
@@ -2547,6 +2554,7 @@
 				B951B5EC1F4E2A2000D8B332 /* TestNSLock.swift in Sources */,
 				5B13B33A1C582D4C00651CE2 /* TestNSNumber.swift in Sources */,
 				5B13B3521C582D4C00651CE2 /* TestNSValue.swift in Sources */,
+				7D0DE86F211883F500540061 /* Utilities.swift in Sources */,
 				5B13B3311C582D4C00651CE2 /* TestIndexPath.swift in Sources */,
 				5B13B3271C582D4C00651CE2 /* TestNSArray.swift in Sources */,
 				5B13B3461C582D4C00651CE2 /* TestProcess.swift in Sources */,

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -983,6 +983,19 @@ open class NSURLComponents: NSObject, NSCopying {
                 && fragment == other.fragment)
     }
 
+    open override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(scheme)
+        hasher.combine(user)
+        hasher.combine(password)
+        hasher.combine(host)
+        hasher.combine(port)
+        hasher.combine(path)
+        hasher.combine(query)
+        hasher.combine(fragment)
+        return hasher.finalize()
+    }
+
     open func copy(with zone: NSZone? = nil) -> Any {
         let copy = NSURLComponents()
         copy.scheme = self.scheme

--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -259,7 +259,18 @@ open class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopying 
                 && other.allowsCellularAccess == self.allowsCellularAccess
                 && other.httpShouldHandleCookies == self.httpShouldHandleCookies)
     }
-    
+
+    open override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(url)
+        hasher.combine(mainDocumentURL)
+        hasher.combine(httpMethod)
+        hasher.combine(httpBodyStream)
+        hasher.combine(allowsCellularAccess)
+        hasher.combine(httpShouldHandleCookies)
+        return hasher.finalize()
+    }
+
     /// Indicates that NSURLRequest implements the NSSecureCoding protocol.
     open class  var supportsSecureCoding: Bool { return true }
     

--- a/TestFoundation/TestCalendar.swift
+++ b/TestFoundation/TestCalendar.swift
@@ -198,8 +198,72 @@ class TestNSDateComponents: XCTestCase {
 
     static var allTests: [(String, (TestNSDateComponents) -> () throws -> Void)] {
         return [
+            ("test_hash", test_hash),
             ("test_copyNSDateComponents", test_copyNSDateComponents),
         ]
+    }
+
+    func test_hash() {
+        let c1 = NSDateComponents()
+        c1.year = 2018
+        c1.month = 8
+        c1.day = 1
+
+        let c2 = NSDateComponents()
+        c2.year = 2018
+        c2.month = 8
+        c2.day = 1
+
+        XCTAssertEqual(c1, c2)
+        XCTAssertEqual(c1.hash, c2.hash)
+
+        checkHashableMutations_NSCopying(
+            NSDateComponents(),
+            \NSDateComponents.calendar,
+            [Calendar(identifier: .gregorian),
+                Calendar(identifier: .buddhist),
+                Calendar(identifier: .chinese),
+                Calendar(identifier: .coptic),
+                Calendar(identifier: .hebrew),
+                Calendar(identifier: .indian),
+                Calendar(identifier: .islamic),
+                Calendar(identifier: .iso8601),
+                Calendar(identifier: .japanese),
+                Calendar(identifier: .persian)])
+        checkHashableMutations_NSCopying(
+            NSDateComponents(),
+            \NSDateComponents.timeZone,
+            (-10...10).map { TimeZone(secondsFromGMT: 3600 * $0) })
+        // Note: These assume components aren't range checked.
+        checkHashableMutations_NSCopying(
+            NSDateComponents(), \NSDateComponents.era, 0...20)
+        checkHashableMutations_NSCopying(
+            NSDateComponents(), \NSDateComponents.year, 0...20)
+        checkHashableMutations_NSCopying(
+            NSDateComponents(), \NSDateComponents.quarter, 0...20)
+        checkHashableMutations_NSCopying(
+            NSDateComponents(), \NSDateComponents.month, 0...20)
+        checkHashableMutations_NSCopying(
+            NSDateComponents(), \NSDateComponents.day, 0...20)
+        checkHashableMutations_NSCopying(
+            NSDateComponents(), \NSDateComponents.hour, 0...20)
+        checkHashableMutations_NSCopying(
+            NSDateComponents(), \NSDateComponents.minute, 0...20)
+        checkHashableMutations_NSCopying(
+            NSDateComponents(), \NSDateComponents.second, 0...20)
+        checkHashableMutations_NSCopying(
+            NSDateComponents(), \NSDateComponents.nanosecond, 0...20)
+        checkHashableMutations_NSCopying(
+            NSDateComponents(), \NSDateComponents.weekOfYear, 0...20)
+        checkHashableMutations_NSCopying(
+            NSDateComponents(), \NSDateComponents.weekOfMonth, 0...20)
+        checkHashableMutations_NSCopying(
+            NSDateComponents(), \NSDateComponents.yearForWeekOfYear, 0...20)
+        checkHashableMutations_NSCopying(
+            NSDateComponents(), \NSDateComponents.weekday, 0...20)
+        checkHashableMutations_NSCopying(
+            NSDateComponents(), \NSDateComponents.weekdayOrdinal, 0...20)
+        // isLeapMonth does not have enough values to test it here.
     }
 
     func test_copyNSDateComponents() {

--- a/TestFoundation/TestCalendar.swift
+++ b/TestFoundation/TestCalendar.swift
@@ -217,10 +217,11 @@ class TestNSDateComponents: XCTestCase {
         XCTAssertEqual(c1, c2)
         XCTAssertEqual(c1.hash, c2.hash)
 
-        checkHashableMutations_NSCopying(
-            NSDateComponents(),
-            \NSDateComponents.calendar,
-            [Calendar(identifier: .gregorian),
+        checkHashing_NSCopying(
+            initialValue: NSDateComponents(),
+            byMutating: \NSDateComponents.calendar,
+            throughValues: [
+                Calendar(identifier: .gregorian),
                 Calendar(identifier: .buddhist),
                 Calendar(identifier: .chinese),
                 Calendar(identifier: .coptic),
@@ -230,39 +231,67 @@ class TestNSDateComponents: XCTestCase {
                 Calendar(identifier: .iso8601),
                 Calendar(identifier: .japanese),
                 Calendar(identifier: .persian)])
-        checkHashableMutations_NSCopying(
-            NSDateComponents(),
-            \NSDateComponents.timeZone,
-            (-10...10).map { TimeZone(secondsFromGMT: 3600 * $0) })
+        checkHashing_NSCopying(
+            initialValue: NSDateComponents(),
+            byMutating: \NSDateComponents.timeZone,
+            throughValues: (-10...10).map { TimeZone(secondsFromGMT: 3600 * $0) })
         // Note: These assume components aren't range checked.
-        checkHashableMutations_NSCopying(
-            NSDateComponents(), \NSDateComponents.era, 0...20)
-        checkHashableMutations_NSCopying(
-            NSDateComponents(), \NSDateComponents.year, 0...20)
-        checkHashableMutations_NSCopying(
-            NSDateComponents(), \NSDateComponents.quarter, 0...20)
-        checkHashableMutations_NSCopying(
-            NSDateComponents(), \NSDateComponents.month, 0...20)
-        checkHashableMutations_NSCopying(
-            NSDateComponents(), \NSDateComponents.day, 0...20)
-        checkHashableMutations_NSCopying(
-            NSDateComponents(), \NSDateComponents.hour, 0...20)
-        checkHashableMutations_NSCopying(
-            NSDateComponents(), \NSDateComponents.minute, 0...20)
-        checkHashableMutations_NSCopying(
-            NSDateComponents(), \NSDateComponents.second, 0...20)
-        checkHashableMutations_NSCopying(
-            NSDateComponents(), \NSDateComponents.nanosecond, 0...20)
-        checkHashableMutations_NSCopying(
-            NSDateComponents(), \NSDateComponents.weekOfYear, 0...20)
-        checkHashableMutations_NSCopying(
-            NSDateComponents(), \NSDateComponents.weekOfMonth, 0...20)
-        checkHashableMutations_NSCopying(
-            NSDateComponents(), \NSDateComponents.yearForWeekOfYear, 0...20)
-        checkHashableMutations_NSCopying(
-            NSDateComponents(), \NSDateComponents.weekday, 0...20)
-        checkHashableMutations_NSCopying(
-            NSDateComponents(), \NSDateComponents.weekdayOrdinal, 0...20)
+        checkHashing_NSCopying(
+            initialValue: NSDateComponents(),
+            byMutating: \NSDateComponents.era,
+            throughValues: 0...20)
+        checkHashing_NSCopying(
+            initialValue: NSDateComponents(),
+            byMutating: \NSDateComponents.year,
+            throughValues: 0...20)
+        checkHashing_NSCopying(
+            initialValue: NSDateComponents(),
+            byMutating: \NSDateComponents.quarter,
+            throughValues: 0...20)
+        checkHashing_NSCopying(
+            initialValue: NSDateComponents(),
+            byMutating: \NSDateComponents.month,
+            throughValues: 0...20)
+        checkHashing_NSCopying(
+            initialValue: NSDateComponents(),
+            byMutating: \NSDateComponents.day,
+            throughValues: 0...20)
+        checkHashing_NSCopying(
+            initialValue: NSDateComponents(),
+            byMutating: \NSDateComponents.hour,
+            throughValues: 0...20)
+        checkHashing_NSCopying(
+            initialValue: NSDateComponents(),
+            byMutating: \NSDateComponents.minute,
+            throughValues: 0...20)
+        checkHashing_NSCopying(
+            initialValue: NSDateComponents(),
+            byMutating: \NSDateComponents.second,
+            throughValues: 0...20)
+        checkHashing_NSCopying(
+            initialValue: NSDateComponents(),
+            byMutating: \NSDateComponents.nanosecond,
+            throughValues: 0...20)
+        checkHashing_NSCopying(
+            initialValue: NSDateComponents(),
+            byMutating: \NSDateComponents.weekOfYear,
+            throughValues: 0...20)
+        checkHashing_NSCopying(
+            initialValue: NSDateComponents(),
+            byMutating: \NSDateComponents.weekOfMonth,
+            throughValues: 0...20)
+        checkHashing_NSCopying(
+            initialValue: NSDateComponents(),
+            byMutating: \NSDateComponents.yearForWeekOfYear,
+            throughValues: 0...20)
+        checkHashing_NSCopying(
+            initialValue: NSDateComponents(),
+            byMutating: \NSDateComponents.weekday,
+            throughValues: 0...20)
+        checkHashing_NSCopying(
+            initialValue: NSDateComponents(),
+            byMutating: \NSDateComponents.weekdayOrdinal,
+            throughValues: 0...20)
         // isLeapMonth does not have enough values to test it here.
     }
 

--- a/TestFoundation/TestDateComponents.swift
+++ b/TestFoundation/TestDateComponents.swift
@@ -1,0 +1,61 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+class TestDateComponents: XCTestCase {
+    static var allTests: [(String, (TestDateComponents) -> () throws -> Void)] {
+        return [
+            ("test_hash", test_hash),
+        ]
+    }
+
+    func test_hash() {
+        let c1 = DateComponents(year: 2018, month: 8, day: 1)
+        let c2 = DateComponents(year: 2018, month: 8, day: 1)
+
+        XCTAssertEqual(c1, c2)
+        XCTAssertEqual(c1.hashValue, c2.hashValue)
+
+        checkHashableMutations_ValueType(
+            DateComponents(),
+            \DateComponents.calendar,
+            [
+                Calendar(identifier: .gregorian),
+                Calendar(identifier: .buddhist),
+                Calendar(identifier: .chinese),
+                Calendar(identifier: .coptic),
+                Calendar(identifier: .hebrew),
+                Calendar(identifier: .indian),
+                Calendar(identifier: .islamic),
+                Calendar(identifier: .iso8601),
+                Calendar(identifier: .japanese),
+                Calendar(identifier: .persian)
+            ])
+        checkHashableMutations_ValueType(
+            DateComponents(),
+            \DateComponents.timeZone,
+            (-10...10).map { TimeZone(secondsFromGMT: 3600 * $0) })
+        // Note: These assume components aren't range checked.
+        let integers: [Int?] = (0..<20).map { $0 as Int? }
+        checkHashableMutations_ValueType(DateComponents(), \DateComponents.era, integers)
+        checkHashableMutations_ValueType(DateComponents(), \DateComponents.year, integers)
+        checkHashableMutations_ValueType(DateComponents(), \DateComponents.quarter, integers)
+        checkHashableMutations_ValueType(DateComponents(), \DateComponents.month, integers)
+        checkHashableMutations_ValueType(DateComponents(), \DateComponents.day, integers)
+        checkHashableMutations_ValueType(DateComponents(), \DateComponents.hour, integers)
+        checkHashableMutations_ValueType(DateComponents(), \DateComponents.minute, integers)
+        checkHashableMutations_ValueType(DateComponents(), \DateComponents.second, integers)
+        checkHashableMutations_ValueType(DateComponents(), \DateComponents.nanosecond, integers)
+        checkHashableMutations_ValueType(DateComponents(), \DateComponents.weekOfYear, integers)
+        checkHashableMutations_ValueType(DateComponents(), \DateComponents.weekOfMonth, integers)
+        checkHashableMutations_ValueType(DateComponents(), \DateComponents.yearForWeekOfYear, integers)
+        checkHashableMutations_ValueType(DateComponents(), \DateComponents.weekday, integers)
+        checkHashableMutations_ValueType(DateComponents(), \DateComponents.weekdayOrdinal, integers)
+        // isLeapMonth does not have enough values to test it here.
+    }
+}

--- a/TestFoundation/TestDateComponents.swift
+++ b/TestFoundation/TestDateComponents.swift
@@ -21,10 +21,10 @@ class TestDateComponents: XCTestCase {
         XCTAssertEqual(c1, c2)
         XCTAssertEqual(c1.hashValue, c2.hashValue)
 
-        checkHashableMutations_ValueType(
-            DateComponents(),
-            \DateComponents.calendar,
-            [
+        checkHashing_ValueType(
+            initialValue: DateComponents(),
+            byMutating: \DateComponents.calendar,
+            throughValues: [
                 Calendar(identifier: .gregorian),
                 Calendar(identifier: .buddhist),
                 Calendar(identifier: .chinese),
@@ -36,26 +36,68 @@ class TestDateComponents: XCTestCase {
                 Calendar(identifier: .japanese),
                 Calendar(identifier: .persian)
             ])
-        checkHashableMutations_ValueType(
-            DateComponents(),
-            \DateComponents.timeZone,
-            (-10...10).map { TimeZone(secondsFromGMT: 3600 * $0) })
+        checkHashing_ValueType(
+            initialValue: DateComponents(),
+            byMutating: \DateComponents.timeZone,
+            throughValues: (-10...10).map { TimeZone(secondsFromGMT: 3600 * $0) })
         // Note: These assume components aren't range checked.
         let integers: [Int?] = (0..<20).map { $0 as Int? }
-        checkHashableMutations_ValueType(DateComponents(), \DateComponents.era, integers)
-        checkHashableMutations_ValueType(DateComponents(), \DateComponents.year, integers)
-        checkHashableMutations_ValueType(DateComponents(), \DateComponents.quarter, integers)
-        checkHashableMutations_ValueType(DateComponents(), \DateComponents.month, integers)
-        checkHashableMutations_ValueType(DateComponents(), \DateComponents.day, integers)
-        checkHashableMutations_ValueType(DateComponents(), \DateComponents.hour, integers)
-        checkHashableMutations_ValueType(DateComponents(), \DateComponents.minute, integers)
-        checkHashableMutations_ValueType(DateComponents(), \DateComponents.second, integers)
-        checkHashableMutations_ValueType(DateComponents(), \DateComponents.nanosecond, integers)
-        checkHashableMutations_ValueType(DateComponents(), \DateComponents.weekOfYear, integers)
-        checkHashableMutations_ValueType(DateComponents(), \DateComponents.weekOfMonth, integers)
-        checkHashableMutations_ValueType(DateComponents(), \DateComponents.yearForWeekOfYear, integers)
-        checkHashableMutations_ValueType(DateComponents(), \DateComponents.weekday, integers)
-        checkHashableMutations_ValueType(DateComponents(), \DateComponents.weekdayOrdinal, integers)
+        checkHashing_ValueType(
+            initialValue: DateComponents(),
+            byMutating: \DateComponents.era,
+            throughValues: integers)
+        checkHashing_ValueType(
+            initialValue: DateComponents(),
+            byMutating: \DateComponents.year,
+            throughValues: integers)
+        checkHashing_ValueType(
+            initialValue: DateComponents(),
+            byMutating: \DateComponents.quarter,
+            throughValues: integers)
+        checkHashing_ValueType(
+            initialValue: DateComponents(),
+            byMutating: \DateComponents.month,
+            throughValues: integers)
+        checkHashing_ValueType(
+            initialValue: DateComponents(),
+            byMutating: \DateComponents.day,
+            throughValues: integers)
+        checkHashing_ValueType(
+            initialValue: DateComponents(),
+            byMutating: \DateComponents.hour,
+            throughValues: integers)
+        checkHashing_ValueType(
+            initialValue: DateComponents(),
+            byMutating: \DateComponents.minute,
+            throughValues: integers)
+        checkHashing_ValueType(
+            initialValue: DateComponents(),
+            byMutating: \DateComponents.second,
+            throughValues: integers)
+        checkHashing_ValueType(
+            initialValue: DateComponents(),
+            byMutating: \DateComponents.nanosecond,
+            throughValues: integers)
+        checkHashing_ValueType(
+            initialValue: DateComponents(),
+            byMutating: \DateComponents.weekOfYear,
+            throughValues: integers)
+        checkHashing_ValueType(
+            initialValue: DateComponents(),
+            byMutating: \DateComponents.weekOfMonth,
+            throughValues: integers)
+        checkHashing_ValueType(
+            initialValue: DateComponents(),
+            byMutating: \DateComponents.yearForWeekOfYear,
+            throughValues: integers)
+        checkHashing_ValueType(
+            initialValue: DateComponents(),
+            byMutating: \DateComponents.weekday,
+            throughValues: integers)
+        checkHashing_ValueType(
+            initialValue: DateComponents(),
+            byMutating: \DateComponents.weekdayOrdinal,
+            throughValues: integers)
         // isLeapMonth does not have enough values to test it here.
     }
 }

--- a/TestFoundation/TestNSURLRequest.swift
+++ b/TestFoundation/TestNSURLRequest.swift
@@ -18,6 +18,7 @@ class TestNSURLRequest : XCTestCase {
             ("test_mutableCopy_1", test_mutableCopy_1),
             ("test_mutableCopy_2", test_mutableCopy_2),
             ("test_mutableCopy_3", test_mutableCopy_3),
+            ("test_hash", test_hash),
             ("test_NSCoding_1", test_NSCoding_1),
             ("test_NSCoding_2", test_NSCoding_2),
             ("test_NSCoding_3", test_NSCoding_3),
@@ -203,7 +204,41 @@ class TestNSURLRequest : XCTestCase {
         XCTAssertEqual(originalRequest.url, urlA)
         XCTAssertNil(originalRequest.allHTTPHeaderFields)
     }
-    
+
+    func test_hash() {
+        let url = URL(string: "https://example.org")!
+
+        let r1 = NSURLRequest(url: url)
+        let r2 = NSURLRequest(url: url)
+        XCTAssertEqual(r1, r2)
+        XCTAssertEqual(r1.hashValue, r2.hashValue)
+
+        let urls: [URL?] = (0..<100).map { URL(string: "https://example.org/\($0)") }
+        checkHashableMutations_NSMutableCopying(
+            NSURLRequest(url: URL(string: "https://example.org")!),
+            \NSMutableURLRequest.url,
+            urls)
+        checkHashableMutations_NSMutableCopying(
+            NSURLRequest(url: URL(string: "https://example.org")!),
+            \NSMutableURLRequest.mainDocumentURL,
+            urls)
+        checkHashableMutations_NSMutableCopying(
+            NSURLRequest(url: URL(string: "https://example.org")!),
+            \NSMutableURLRequest.httpMethod,
+            ["HEAD", "POST", "PUT", "DELETE", "CONNECT", "TWIZZLE",
+                "REFUDIATE", "BUY", "REJECT", "UNDO", "SYNERGIZE",
+                "BUMFUZZLE", "ELUCIDATE"])
+        let inputStreams: [InputStream?] = (0..<100).map { value in
+            InputStream(data: Data("\(value)".utf8))
+        }
+        checkHashableMutations_NSMutableCopying(
+            NSURLRequest(url: URL(string: "https://example.org")!),
+            \NSMutableURLRequest.httpBodyStream as ReferenceWritableKeyPath<NSMutableURLRequest, InputStream?>,
+            inputStreams as [InputStream?])
+        // allowsCellularAccess and httpShouldHandleCookies do
+        // not have enough values to test them here.
+    }
+
     func test_NSCoding_1() {
         let url = URL(string: "https://apple.com")!
         let requestA = NSURLRequest(url: url)

--- a/TestFoundation/TestNSURLRequest.swift
+++ b/TestFoundation/TestNSURLRequest.swift
@@ -214,27 +214,28 @@ class TestNSURLRequest : XCTestCase {
         XCTAssertEqual(r1.hashValue, r2.hashValue)
 
         let urls: [URL?] = (0..<100).map { URL(string: "https://example.org/\($0)") }
-        checkHashableMutations_NSMutableCopying(
-            NSURLRequest(url: URL(string: "https://example.org")!),
-            \NSMutableURLRequest.url,
-            urls)
-        checkHashableMutations_NSMutableCopying(
-            NSURLRequest(url: URL(string: "https://example.org")!),
-            \NSMutableURLRequest.mainDocumentURL,
-            urls)
-        checkHashableMutations_NSMutableCopying(
-            NSURLRequest(url: URL(string: "https://example.org")!),
-            \NSMutableURLRequest.httpMethod,
-            ["HEAD", "POST", "PUT", "DELETE", "CONNECT", "TWIZZLE",
+        checkHashing_NSMutableCopying(
+            initialValue: NSURLRequest(url: URL(string: "https://example.org")!),
+            byMutating: \NSMutableURLRequest.url,
+            throughValues: urls)
+        checkHashing_NSMutableCopying(
+            initialValue: NSURLRequest(url: URL(string: "https://example.org")!),
+            byMutating: \NSMutableURLRequest.mainDocumentURL,
+            throughValues: urls)
+        checkHashing_NSMutableCopying(
+            initialValue: NSURLRequest(url: URL(string: "https://example.org")!),
+            byMutating: \NSMutableURLRequest.httpMethod,
+            throughValues: [
+                "HEAD", "POST", "PUT", "DELETE", "CONNECT", "TWIZZLE",
                 "REFUDIATE", "BUY", "REJECT", "UNDO", "SYNERGIZE",
                 "BUMFUZZLE", "ELUCIDATE"])
         let inputStreams: [InputStream?] = (0..<100).map { value in
             InputStream(data: Data("\(value)".utf8))
         }
-        checkHashableMutations_NSMutableCopying(
-            NSURLRequest(url: URL(string: "https://example.org")!),
-            \NSMutableURLRequest.httpBodyStream as ReferenceWritableKeyPath<NSMutableURLRequest, InputStream?>,
-            inputStreams as [InputStream?])
+        checkHashing_NSMutableCopying(
+            initialValue: NSURLRequest(url: URL(string: "https://example.org")!),
+            byMutating: \NSMutableURLRequest.httpBodyStream,
+            throughValues: inputStreams)
         // allowsCellularAccess and httpShouldHandleCookies do
         // not have enough values to test them here.
     }

--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -521,6 +521,7 @@ class TestURLComponents : XCTestCase {
             ("test_port", test_portSetter),
             ("test_url", test_url),
             ("test_copy", test_copy),
+            ("test_hash", test_hash),
             ("test_createURLWithComponents", test_createURLWithComponents),
             ("test_path", test_path),
             ("test_percentEncodedPath", test_percentEncodedPath),
@@ -615,7 +616,34 @@ class TestURLComponents : XCTestCase {
         /* Assert that NSURLComponents.copy is actually a copy of NSURLComponents */ 
         XCTAssertTrue(copy.isEqual(urlComponent))
     }
-    
+
+    func test_hash() {
+        let c1 = URLComponents(string: "https://www.swift.org/path/to/file.html?id=name")!
+        let c2 = URLComponents(string: "https://www.swift.org/path/to/file.html?id=name")!
+
+        XCTAssertEqual(c1, c2)
+        XCTAssertEqual(c1.hashValue, c2.hashValue)
+
+        let strings: [String?] = (0..<20).map { "s\($0)" as String? }
+        checkHashableMutations_ValueType(URLComponents(), \URLComponents.scheme, strings)
+        checkHashableMutations_ValueType(URLComponents(), \URLComponents.user, strings)
+        checkHashableMutations_ValueType(URLComponents(), \URLComponents.password, strings)
+        checkHashableMutations_ValueType(URLComponents(), \URLComponents.host, strings)
+        checkHashableMutations_ValueType(URLComponents(), \URLComponents.port, (0..<20).map { $0 as Int? })
+        checkHashableMutations_ValueType(URLComponents(), \URLComponents.path, strings.compactMap { $0 })
+        checkHashableMutations_ValueType(URLComponents(), \URLComponents.query, strings)
+        checkHashableMutations_ValueType(URLComponents(), \URLComponents.fragment, strings)
+
+        checkHashableMutations_NSCopying(NSURLComponents(), \NSURLComponents.scheme, strings)
+        checkHashableMutations_NSCopying(NSURLComponents(), \NSURLComponents.user, strings)
+        checkHashableMutations_NSCopying(NSURLComponents(), \NSURLComponents.password, strings)
+        checkHashableMutations_NSCopying(NSURLComponents(), \NSURLComponents.host, strings)
+        checkHashableMutations_NSCopying(NSURLComponents(), \NSURLComponents.port, (0..<20).map { $0 as NSNumber? })
+        checkHashableMutations_NSCopying(NSURLComponents(), \NSURLComponents.path, strings)
+        checkHashableMutations_NSCopying(NSURLComponents(), \NSURLComponents.query, strings)
+        checkHashableMutations_NSCopying(NSURLComponents(), \NSURLComponents.fragment, strings)
+    }
+
     func test_createURLWithComponents() {
         let urlComponents = NSURLComponents()
         urlComponents.scheme = "https";

--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -625,23 +625,71 @@ class TestURLComponents : XCTestCase {
         XCTAssertEqual(c1.hashValue, c2.hashValue)
 
         let strings: [String?] = (0..<20).map { "s\($0)" as String? }
-        checkHashableMutations_ValueType(URLComponents(), \URLComponents.scheme, strings)
-        checkHashableMutations_ValueType(URLComponents(), \URLComponents.user, strings)
-        checkHashableMutations_ValueType(URLComponents(), \URLComponents.password, strings)
-        checkHashableMutations_ValueType(URLComponents(), \URLComponents.host, strings)
-        checkHashableMutations_ValueType(URLComponents(), \URLComponents.port, (0..<20).map { $0 as Int? })
-        checkHashableMutations_ValueType(URLComponents(), \URLComponents.path, strings.compactMap { $0 })
-        checkHashableMutations_ValueType(URLComponents(), \URLComponents.query, strings)
-        checkHashableMutations_ValueType(URLComponents(), \URLComponents.fragment, strings)
+        checkHashing_ValueType(
+            initialValue: URLComponents(),
+            byMutating: \URLComponents.scheme,
+            throughValues: strings)
+        checkHashing_ValueType(
+            initialValue: URLComponents(),
+            byMutating: \URLComponents.user,
+            throughValues: strings)
+        checkHashing_ValueType(
+            initialValue: URLComponents(),
+            byMutating: \URLComponents.password,
+            throughValues: strings)
+        checkHashing_ValueType(
+            initialValue: URLComponents(),
+            byMutating: \URLComponents.host,
+            throughValues: strings)
+        checkHashing_ValueType(
+            initialValue: URLComponents(),
+            byMutating: \URLComponents.port,
+            throughValues: (0..<20).map { $0 as Int? })
+        checkHashing_ValueType(
+            initialValue: URLComponents(),
+            byMutating: \URLComponents.path,
+            throughValues: strings.compactMap { $0 })
+        checkHashing_ValueType(
+            initialValue: URLComponents(),
+            byMutating: \URLComponents.query,
+            throughValues: strings)
+        checkHashing_ValueType(
+            initialValue: URLComponents(),
+            byMutating: \URLComponents.fragment,
+            throughValues: strings)
 
-        checkHashableMutations_NSCopying(NSURLComponents(), \NSURLComponents.scheme, strings)
-        checkHashableMutations_NSCopying(NSURLComponents(), \NSURLComponents.user, strings)
-        checkHashableMutations_NSCopying(NSURLComponents(), \NSURLComponents.password, strings)
-        checkHashableMutations_NSCopying(NSURLComponents(), \NSURLComponents.host, strings)
-        checkHashableMutations_NSCopying(NSURLComponents(), \NSURLComponents.port, (0..<20).map { $0 as NSNumber? })
-        checkHashableMutations_NSCopying(NSURLComponents(), \NSURLComponents.path, strings)
-        checkHashableMutations_NSCopying(NSURLComponents(), \NSURLComponents.query, strings)
-        checkHashableMutations_NSCopying(NSURLComponents(), \NSURLComponents.fragment, strings)
+        checkHashing_NSCopying(
+            initialValue: NSURLComponents(),
+            byMutating: \NSURLComponents.scheme,
+            throughValues: strings)
+        checkHashing_NSCopying(
+            initialValue: NSURLComponents(),
+            byMutating: \NSURLComponents.user,
+            throughValues: strings)
+        checkHashing_NSCopying(
+            initialValue: NSURLComponents(),
+            byMutating: \NSURLComponents.password,
+            throughValues: strings)
+        checkHashing_NSCopying(
+            initialValue: NSURLComponents(),
+            byMutating: \NSURLComponents.host,
+            throughValues: strings)
+        checkHashing_NSCopying(
+            initialValue: NSURLComponents(),
+            byMutating: \NSURLComponents.port,
+            throughValues: (0..<20).map { $0 as NSNumber? })
+        checkHashing_NSCopying(
+            initialValue: NSURLComponents(),
+            byMutating: \NSURLComponents.path,
+            throughValues: strings)
+        checkHashing_NSCopying(
+            initialValue: NSURLComponents(),
+            byMutating: \NSURLComponents.query,
+            throughValues: strings)
+        checkHashing_NSCopying(
+            initialValue: NSURLComponents(),
+            byMutating: \NSURLComponents.fragment,
+            throughValues: strings)
     }
 
     func test_createURLWithComponents() {

--- a/TestFoundation/TestURLRequest.swift
+++ b/TestFoundation/TestURLRequest.swift
@@ -18,6 +18,7 @@ class TestURLRequest : XCTestCase {
             ("test_mutableCopy_1", test_mutableCopy_1),
             ("test_mutableCopy_2", test_mutableCopy_2),
             ("test_mutableCopy_3", test_mutableCopy_3),
+            ("test_hash", test_hash),
             ("test_methodNormalization", test_methodNormalization),
             ("test_description", test_description),
         ]
@@ -192,6 +193,39 @@ class TestURLRequest : XCTestCase {
         XCTAssertEqual(originalRequest.httpMethod, "GET")
         XCTAssertEqual(originalRequest.url, urlA)
         XCTAssertNil(originalRequest.allHTTPHeaderFields)
+    }
+
+    func test_hash() {
+        let url = URL(string: "https://swift.org")!
+        let r1 = URLRequest(url: url)
+        let r2 = URLRequest(url: url)
+
+        XCTAssertEqual(r1, r2)
+        XCTAssertEqual(r1.hashValue, r2.hashValue)
+
+        checkHashableMutations_ValueType(
+            URLRequest(url: url),
+            \URLRequest.url,
+            (0..<20).map { URL(string: "https://example.org/\($0)")! })
+        checkHashableMutations_ValueType(
+            URLRequest(url: url),
+            \URLRequest.mainDocumentURL,
+            (0..<20).map { URL(string: "https://example.org/\($0)")! })
+        checkHashableMutations_ValueType(
+            URLRequest(url: url),
+            \URLRequest.httpMethod,
+            ["HEAD", "POST", "PUT", "DELETE", "CONNECT", "TWIZZLE",
+                "REFUDIATE", "BUY", "REJECT", "UNDO", "SYNERGIZE",
+                "BUMFUZZLE", "ELUCIDATE"])
+        let inputStreams: [InputStream] = (0..<100).map { value in
+            InputStream(data: Data("\(value)".utf8))
+        }
+        checkHashableMutations_ValueType(
+            URLRequest(url: url),
+            \URLRequest.httpBodyStream,
+            inputStreams)
+        // allowsCellularAccess and httpShouldHandleCookies do
+        // not have enough values to test them here.
     }
 
     func test_methodNormalization() {

--- a/TestFoundation/TestURLRequest.swift
+++ b/TestFoundation/TestURLRequest.swift
@@ -203,27 +203,28 @@ class TestURLRequest : XCTestCase {
         XCTAssertEqual(r1, r2)
         XCTAssertEqual(r1.hashValue, r2.hashValue)
 
-        checkHashableMutations_ValueType(
-            URLRequest(url: url),
-            \URLRequest.url,
-            (0..<20).map { URL(string: "https://example.org/\($0)")! })
-        checkHashableMutations_ValueType(
-            URLRequest(url: url),
-            \URLRequest.mainDocumentURL,
-            (0..<20).map { URL(string: "https://example.org/\($0)")! })
-        checkHashableMutations_ValueType(
-            URLRequest(url: url),
-            \URLRequest.httpMethod,
-            ["HEAD", "POST", "PUT", "DELETE", "CONNECT", "TWIZZLE",
+        checkHashing_ValueType(
+            initialValue: URLRequest(url: url),
+            byMutating: \URLRequest.url,
+            throughValues: (0..<20).map { URL(string: "https://example.org/\($0)")! })
+        checkHashing_ValueType(
+            initialValue: URLRequest(url: url),
+            byMutating: \URLRequest.mainDocumentURL,
+            throughValues: (0..<20).map { URL(string: "https://example.org/\($0)")! })
+        checkHashing_ValueType(
+            initialValue: URLRequest(url: url),
+            byMutating: \URLRequest.httpMethod,
+            throughValues: [
+                "HEAD", "POST", "PUT", "DELETE", "CONNECT", "TWIZZLE",
                 "REFUDIATE", "BUY", "REJECT", "UNDO", "SYNERGIZE",
                 "BUMFUZZLE", "ELUCIDATE"])
         let inputStreams: [InputStream] = (0..<100).map { value in
             InputStream(data: Data("\(value)".utf8))
         }
-        checkHashableMutations_ValueType(
-            URLRequest(url: url),
-            \URLRequest.httpBodyStream,
-            inputStreams)
+        checkHashing_ValueType(
+            initialValue: URLRequest(url: url),
+            byMutating: \URLRequest.httpBodyStream,
+            throughValues: inputStreams)
         // allowsCellularAccess and httpShouldHandleCookies do
         // not have enough values to test them here.
     }

--- a/TestFoundation/Utilities.swift
+++ b/TestFoundation/Utilities.swift
@@ -1,0 +1,105 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+
+func checkHashableMutations_ValueType<Item: Hashable, S: Sequence>(
+    _ item: Item,
+    _ keyPath: WritableKeyPath<Item, S.Element>,
+    _ values: S,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    _checkHashableMutations(
+        Item.self, Item.self,
+        item,
+        { $0 },
+        keyPath,
+        values)
+}
+
+func checkHashableMutations_NSCopying<Item: NSObject & NSCopying, S: Sequence>(
+    _ item: Item,
+    _ keyPath: ReferenceWritableKeyPath<Item, S.Element>,
+    _ values: S,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    _checkHashableMutations(
+        Item.self, Item.self,
+        item,
+        { $0.copy() as! Item },
+        keyPath,
+        values)
+}
+
+func checkHashableMutations_NSMutableCopying<
+  Source: NSObject & NSMutableCopying,
+  Target: NSObject & NSMutableCopying,
+  S: Sequence
+>(
+    _ item: Source,
+    _ keyPath: ReferenceWritableKeyPath<Target, S.Element>,
+    _ values: S,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    _checkHashableMutations(
+        Source.self, Target.self,
+        item,
+        { $0.mutableCopy() as! Target },
+        keyPath,
+        values)
+}
+
+// Check that mutating `object` via the specified key path affects its
+// hash value.
+func _checkHashableMutations<Source: Hashable, Target: Hashable, S: Sequence>(
+    _ source: Source.Type,
+    _ target: Target.Type,
+    _ object: Source,
+    _ copyBlock: (Source) -> Target,
+    _ keyPath: WritableKeyPath<Target, S.Element>,
+    _ values: S,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    let reference = copyBlock(object)
+    let referenceHash = reference.hashValue
+
+    XCTAssertEqual(
+        reference.hashValue, referenceHash,
+        "\(type(of: reference)).hashValue is nondeterministic",
+        file: file, line: line)
+
+    var found = false
+    for value in values {
+        var copy = copyBlock(object)
+        XCTAssertEqual(
+            copy, reference,
+            "Invalid copy operation",
+            file: file, line: line)
+        XCTAssertEqual(
+            copy.hashValue, referenceHash,
+            "Invalid copy operation",
+            file: file, line: line)
+        copy[keyPath: keyPath] = value
+        XCTAssertNotEqual(
+            reference, copy,
+            "\(keyPath) did not affect object equality",
+            file: file, line: line)
+        if referenceHash != copy.hashValue {
+            found = true
+        }
+    }
+    if !found {
+        XCTFail(
+            "\(keyPath) does not seem to contribute to the hash value",
+            file: file, line: line)
+    }
+}

--- a/TestFoundation/Utilities.swift
+++ b/TestFoundation/Utilities.swift
@@ -8,64 +8,74 @@
 //
 
 
-func checkHashableMutations_ValueType<Item: Hashable, S: Sequence>(
-    _ item: Item,
-    _ keyPath: WritableKeyPath<Item, S.Element>,
-    _ values: S,
+
+func checkHashing_ValueType<Item: Hashable, S: Sequence>(
+    initialValue item: Item,
+    byMutating keyPath: WritableKeyPath<Item, S.Element>,
+    throughValues values: S,
     file: StaticString = #file,
     line: UInt = #line
 ) {
-    _checkHashableMutations(
-        Item.self, Item.self,
-        item,
-        { $0 },
-        keyPath,
-        values)
+    _checkHashing(
+        ofType: Item.self,
+        withMutableCounterpart: Item.self,
+        initialValue: item,
+        mutableCopyBlock: { $0 },
+        byMutating: keyPath,
+        throughValues: values,
+        file: file,
+        line: line)
 }
 
-func checkHashableMutations_NSCopying<Item: NSObject & NSCopying, S: Sequence>(
-    _ item: Item,
-    _ keyPath: ReferenceWritableKeyPath<Item, S.Element>,
-    _ values: S,
+func checkHashing_NSCopying<Item: NSObject & NSCopying, S: Sequence>(
+    initialValue item: Item,
+    byMutating keyPath: ReferenceWritableKeyPath<Item, S.Element>,
+    throughValues values: S,
     file: StaticString = #file,
     line: UInt = #line
 ) {
-    _checkHashableMutations(
-        Item.self, Item.self,
-        item,
-        { $0.copy() as! Item },
-        keyPath,
-        values)
+    _checkHashing(
+        ofType: Item.self,
+        withMutableCounterpart: Item.self,
+        initialValue: item,
+        mutableCopyBlock: { $0.copy() as! Item },
+        byMutating: keyPath,
+        throughValues: values,
+        file: file,
+        line: line)
 }
 
-func checkHashableMutations_NSMutableCopying<
+func checkHashing_NSMutableCopying<
   Source: NSObject & NSMutableCopying,
   Target: NSObject & NSMutableCopying,
   S: Sequence
 >(
-    _ item: Source,
-    _ keyPath: ReferenceWritableKeyPath<Target, S.Element>,
-    _ values: S,
+    initialValue item: Source,
+    byMutating keyPath: ReferenceWritableKeyPath<Target, S.Element>,
+    throughValues values: S,
     file: StaticString = #file,
     line: UInt = #line
 ) {
-    _checkHashableMutations(
-        Source.self, Target.self,
-        item,
-        { $0.mutableCopy() as! Target },
-        keyPath,
-        values)
+    _checkHashing(
+        ofType: Source.self,
+        withMutableCounterpart: Target.self,
+        initialValue: item,
+        mutableCopyBlock: { $0.mutableCopy() as! Target },
+        byMutating: keyPath,
+        throughValues: values,
+        file: file,
+        line: line)
 }
 
 // Check that mutating `object` via the specified key path affects its
 // hash value.
-func _checkHashableMutations<Source: Hashable, Target: Hashable, S: Sequence>(
-    _ source: Source.Type,
-    _ target: Target.Type,
-    _ object: Source,
-    _ copyBlock: (Source) -> Target,
-    _ keyPath: WritableKeyPath<Target, S.Element>,
-    _ values: S,
+func _checkHashing<Source: Hashable, Target: Hashable, S: Sequence>(
+    ofType source: Source.Type,
+    withMutableCounterpart target: Target.Type,
+    initialValue object: Source,
+    mutableCopyBlock copyBlock: (Source) -> Target,
+    byMutating keyPath: WritableKeyPath<Target, S.Element>,
+    throughValues values: S,
     file: StaticString = #file,
     line: UInt = #line
 ) {

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -30,6 +30,7 @@ XCTMain([
     testCase(TestNSCompoundPredicate.allTests),
     testCase(TestNSData.allTests),
     testCase(TestDate.allTests),
+    testCase(TestDateComponents.allTests),
     testCase(TestNSDateComponents.allTests),
     testCase(TestDateFormatter.allTests),
     testCase(TestDecimal.allTests),

--- a/build.py
+++ b/build.py
@@ -523,6 +523,7 @@ foundation_tests = SwiftExecutable('TestFoundation', [
 	'TestFoundation/main.swift',
         'TestFoundation/HTTPServer.swift',
         'Foundation/ProgressFraction.swift',
+        'TestFoundation/Utilities.swift',
 ] + glob.glob('./TestFoundation/Test*.swift')) # all TestSomething.swift are considered sources to the test project in the TestFoundation directory
 
 Configuration.current.extra_ld_flags += ' -L'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src/.libs'


### PR DESCRIPTION
This PR collects fixes previously submitted separately as #1645, #1646 and #1648, fixing the implementation of hashing for the following Foundation types:

- `DateComponents`
- `NSDateComponents`
- `URLRequest`
- `NSURLRequest`
- `URLComponents`
- `NSURLComponents`

Note that this isn't a full audit of Foundation hashing -- this was the bare minimum necessary for #1649. I suspect there may be more types with issues similar to these.

Resolves:
- https://bugs.swift.org/browse/SR-8441
- https://bugs.swift.org/browse/SR-8449
- https://bugs.swift.org/browse/SR-8450