### PR TITLE
JSONSerialization: Improve parsing of numbers

### DIFF
--- a/TestFoundation/TestJSONEncoder.swift
+++ b/TestFoundation/TestJSONEncoder.swift
@@ -598,11 +598,11 @@ class TestJSONEncoder : XCTestCase {
         }
 
         // Invalid JSON number formats
-        testErrorThrown("Int8", "0000000000000000000000000000001", errorMessage: "The operation could not be completed")
-        testErrorThrown("Double", "-.1", errorMessage: "The operation could not be completed")
-        testErrorThrown("Int32", "+1", errorMessage: "The operation could not be completed")
-        testErrorThrown("Int", ".012", errorMessage: "The operation could not be completed")
-        testErrorThrown("Double", "2.7976931348623158e+308", errorMessage: "The operation could not be completed")
+        testErrorThrown("Int8", "0000000000000000000000000000001", errorMessage: "The given data was not valid JSON.")
+        testErrorThrown("Double", "-.1", errorMessage: "The given data was not valid JSON.")
+        testErrorThrown("Int32", "+1", errorMessage: "The given data was not valid JSON.")
+        testErrorThrown("Int", ".012", errorMessage: "The given data was not valid JSON.")
+        testErrorThrown("Double", "2.7976931348623158e+308", errorMessage: "The given data was not valid JSON.")
     }
 
 

--- a/TestFoundation/TestJSONEncoder.swift
+++ b/TestFoundation/TestJSONEncoder.swift
@@ -513,6 +513,7 @@ class TestJSONEncoder : XCTestCase {
             let uint64Value: UInt64?
             let floatValue: Float?
             let doubleValue: Double?
+            let decimalValue: Decimal?
         }
 
         func decode(_ type: String, _ value: String) throws {
@@ -553,6 +554,13 @@ class TestJSONEncoder : XCTestCase {
 
             ("Int64", "0"), ("Int64", "1"), ("Int64", "-1"), ("Int64", "-9223372036854775808"), ("Int64", "9223372036854775807"),
             ("UInt64", "0"), ("UInt64", "1"), ("UInt64", "18446744073709551615"),
+
+            ("Double", "0"), ("Double", "1"), ("Double", "-1"), ("Double", "2.2250738585072014e-308"), ("Double", "1.7976931348623157e+308"),
+            ("Double", "5e-324"), ("Double", "3.141592653589793"),
+
+            ("Decimal", "1.2"), ("Decimal", "3.14159265358979323846264338327950288419"),
+            ("Decimal", "3402823669209384634633746074317682114550000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"),
+            ("Decimal", "-3402823669209384634633746074317682114550000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"),
         ]
 
         if Int.max == Int64.max {
@@ -589,11 +597,12 @@ class TestJSONEncoder : XCTestCase {
             testErrorThrown(type, value, errorMessage: "Parsed JSON number <\(value)> does not fit in \(type).")
         }
 
-        // Leading zeros are invalid
+        // Invalid JSON number formats
         testErrorThrown("Int8", "0000000000000000000000000000001", errorMessage: "The operation could not be completed")
         testErrorThrown("Double", "-.1", errorMessage: "The operation could not be completed")
         testErrorThrown("Int32", "+1", errorMessage: "The operation could not be completed")
         testErrorThrown("Int", ".012", errorMessage: "The operation could not be completed")
+        testErrorThrown("Double", "2.7976931348623158e+308", errorMessage: "The operation could not be completed")
     }
 
 

--- a/TestFoundation/TestJSONEncoder.swift
+++ b/TestFoundation/TestJSONEncoder.swift
@@ -499,6 +499,104 @@ class TestJSONEncoder : XCTestCase {
         }
     }
 
+    func test_numericLimits() {
+        struct DataStruct: Codable {
+            let int8Value: Int8?
+            let uint8Value: UInt8?
+            let int16Value: Int16?
+            let uint16Value: UInt16?
+            let int32Value: Int32?
+            let uint32Value: UInt32?
+            let int64Value: Int64?
+            let intValue: Int?
+            let uintValue: UInt?
+            let uint64Value: UInt64?
+            let floatValue: Float?
+            let doubleValue: Double?
+        }
+
+        func decode(_ type: String, _ value: String) throws {
+            var key = type.lowercased()
+            key.append("Value")
+            _ = try JSONDecoder().decode(DataStruct.self, from: "{ \"\(key)\": \(value) }".data(using: .utf8)!)
+        }
+
+        func testGoodValue(_ type: String, _ value: String) {
+            do {
+                try decode(type, value)
+            } catch {
+                XCTFail("Unexpected error: \(error) for parsing \(value) to \(type)")
+            }
+        }
+
+        func testErrorThrown(_ type: String, _ value: String, errorMessage: String) {
+            do {
+                try decode(type, value)
+                XCTFail("Decode of \(value) to \(type) should not succeed")
+            } catch DecodingError.dataCorrupted(let context) {
+                XCTAssertEqual(context.debugDescription, errorMessage)
+            } catch {
+                XCTAssertEqual(String(describing: error), errorMessage)
+            }
+        }
+
+
+        var goodValues = [
+            ("Int8", "0"), ("Int8", "1"), ("Int8", "-1"), ("Int8", "-128"), ("Int8", "127"),
+            ("UInt8", "0"), ("UInt8", "1"), ("UInt8", "255"), ("UInt8", "-0"),
+
+            ("Int16", "0"), ("Int16", "1"), ("Int16", "-1"), ("Int16", "-32768"), ("Int16", "32767"),
+            ("UInt16", "0"), ("UInt16", "1"), ("UInt16", "65535"), ("UInt16", "34.0"),
+
+            ("Int32", "0"), ("Int32", "1"), ("Int32", "-1"), ("Int32", "-2147483648"), ("Int32", "2147483647"),
+            ("UInt32", "0"), ("UInt32", "1"), ("UInt32", "4294967295"),
+
+            ("Int64", "0"), ("Int64", "1"), ("Int64", "-1"), ("Int64", "-9223372036854775808"), ("Int64", "9223372036854775807"),
+            ("UInt64", "0"), ("UInt64", "1"), ("UInt64", "18446744073709551615"),
+        ]
+
+        if Int.max == Int64.max {
+            goodValues += [
+                ("Int", "0"), ("Int", "1"), ("Int", "-1"), ("Int", "-9223372036854775808"), ("Int", "9223372036854775807"),
+                ("UInt", "0"), ("UInt", "1"), ("UInt", "18446744073709551615"),
+                ]
+        } else {
+            goodValues += [
+                ("Int", "0"), ("Int", "1"), ("Int", "-1"), ("Int", "-2147483648"), ("Int", "2147483647"),
+                ("UInt", "0"), ("UInt", "1"), ("UInt", "4294967295"),
+            ]
+        }
+
+        let badValues = [
+            ("Int8", "-129"), ("Int8", "128"), ("Int8", "1.2"),
+            ("UInt8", "-1"), ("UInt8", "256"),
+
+            ("Int16", "-32769"), ("Int16", "32768"),
+            ("UInt16", "-1"), ("UInt16", "65536"),
+
+            ("Int32", "-2147483649"), ("Int32", "2147483648"),
+            ("UInt32", "-1"), ("UInt32", "4294967296"),
+
+            ("Int64", "9223372036854775808"), ("Int64", "9223372036854775808"), ("Int64", "-100000000000000000000"),
+            ("UInt64", "-1"), ("UInt64", "18446744073709600000"), ("Int64", "10000000000000000000000000000000000000"),
+        ]
+
+        for value in goodValues {
+            testGoodValue(value.0, value.1)
+        }
+
+        for (type, value) in badValues {
+            testErrorThrown(type, value, errorMessage: "Parsed JSON number <\(value)> does not fit in \(type).")
+        }
+
+        // Leading zeros are invalid
+        testErrorThrown("Int8", "0000000000000000000000000000001", errorMessage: "The operation could not be completed")
+        testErrorThrown("Double", "-.1", errorMessage: "The operation could not be completed")
+        testErrorThrown("Int32", "+1", errorMessage: "The operation could not be completed")
+        testErrorThrown("Int", ".012", errorMessage: "The operation could not be completed")
+    }
+
+
     // MARK: - Helper Functions
     private var _jsonEmptyDictionary: Data {
         return "{}".data(using: .utf8)!
@@ -1089,6 +1187,7 @@ extension TestJSONEncoder {
             ("test_codingOfDouble", test_codingOfDouble),
             ("test_codingOfString", test_codingOfString),
             ("test_codingOfURL", test_codingOfURL),
+            ("test_numericLimits", test_numericLimits),
         ]
     }
 }

--- a/TestFoundation/TestJSONSerialization.swift
+++ b/TestFoundation/TestJSONSerialization.swift
@@ -487,7 +487,7 @@ extension TestJSONSerialization {
 
     //MARK: - Number parsing
     func deserialize_numbers(objectType: ObjectType) {
-        let subject = "[1, -1, 1.3, -1.3, 1e3, 1E-3, 10]"
+        let subject = "[1, -1, 1.3, -1.3, 1e3, 1E-3, 10, -12.34e56, 12.34e-56, 12.34e+6, 0.002, 0.0043e+4]"
 
         do {
             for encoding in supportedEncodings {
@@ -504,6 +504,11 @@ extension TestJSONSerialization {
                 XCTAssertEqual(result?[5] as? Double, 0.001)
                 XCTAssertEqual(result?[6] as? Int,    10)
                 XCTAssertEqual(result?[6] as? Double, 10.0)
+                XCTAssertEqual(result?[7] as? Double, -12.34e56)
+                XCTAssertEqual(result?[8] as? Double, 12.34e-56)
+                XCTAssertEqual(result?[9] as? Double, 12.34e6)
+                XCTAssertEqual(result?[10] as? Double, 2e-3)
+                XCTAssertEqual(result?[11] as? Double, 43)
             }
         } catch {
             XCTFail("Unexpected error: \(error)")
@@ -511,7 +516,7 @@ extension TestJSONSerialization {
     }
 
     func deserialize_numbers_as_reference_types(objectType: ObjectType) {
-        let subject = "[1, -1, 1.3, -1.3, 1e3, 1E-3, 10]"
+        let subject = "[1, -1, 1.3, -1.3, 1e3, 1E-3, 10, -12.34e56, 12.34e-56, 12.34e+6, 0.002, 0.0043e+4]"
 
         do {
             for encoding in supportedEncodings {
@@ -528,6 +533,12 @@ extension TestJSONSerialization {
                 XCTAssertEqual(result?[5] as? NSNumber, 0.001)
                 XCTAssertEqual(result?[6] as? NSNumber, 10)
                 XCTAssertEqual(result?[6] as? NSNumber, 10.0)
+                XCTAssertEqual(result?[7] as? NSNumber, -12.34e56)
+                XCTAssertEqual(result?[8] as? NSNumber, 12.34e-56)
+                XCTAssertEqual(result?[9] as? NSNumber, 12.34e6)
+                XCTAssertEqual(result?[10] as? NSNumber, 2e-3)
+                XCTAssertEqual(result?[11] as? NSNumber, 43)
+
             }
         } catch {
             XCTFail("Unexpected error: \(error)")


### PR DESCRIPTION
- Check the number looks like a JSON number and exit early if not.

- Use the native Int64(), UInt64(), Double() parsers to avoid creating
  a C string and passing to strtol()/strtod(). This also eliminates a
  memcpy() and removes the 63 digit restriction which would fail to
  parse numbers expressible by Double's full exponent.

- For numbers with a leading '-' sign, parse using Int64() falling
  back to Double(), otherwise parse using UInt64() failling back to
  Double().