### PR TITLE
SR-7011: Fatal Error when Using Calendar.current.dateComponents(_:from:to:)

### DIFF
--- a/CoreFoundation/Locale.subproj/CFCalendar.c
+++ b/CoreFoundation/Locale.subproj/CFCalendar.c
@@ -953,7 +953,12 @@ Boolean _CFCalendarGetComponentDifferenceV(CFCalendarRef calendar, CFAbsoluteTim
     while (ch) {
         UCalendarDateFields field = __CFCalendarGetICUFieldCodeFromChar(ch);
         const int multiple_table[] = {0, 0, 16, 19, 24, 26, 24, 28, 14, 14, 14};
-        int multiple = direction * (1 << multiple_table[flsl(__CFCalendarGetCalendarUnitFromChar(ch)) - 1]);
+        int unit = __CFCalendarGetCalendarUnitFromChar(ch);
+        if (unit < 0) {
+            // Not a valid calendar unit character
+            return false;
+        }
+        int multiple = direction * (1 << multiple_table[flsl(unit) - 1]);
         Boolean divide = false, alwaysDivide = false;
         int result = 0;
         while ((direction > 0 && curr < goal) || (direction < 0 && goal < curr)) {
@@ -980,8 +985,13 @@ Boolean _CFCalendarGetComponentDifferenceV(CFCalendarRef calendar, CFAbsoluteTim
             divide = alwaysDivide;
         }
         }
+        if (count < 1) {
+            // Output vector has no free entries
+            return false;
+        }
         *(*vector) = result;
         vector++;
+        count--;
         componentDesc++;
         ch = *componentDesc;
     }

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -497,13 +497,15 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    private func _setup(_ unitFlags: Unit) -> [Int8] {
+    private func _setup(_ unitFlags: Unit, addIsLeapMonth: Bool = true) -> [Int8] {
         var compDesc = [Int8]()
         _setup(unitFlags, field: .era, type: "G", compDesc: &compDesc)
         _setup(unitFlags, field: .year, type: "y", compDesc: &compDesc)
         _setup(unitFlags, field: .quarter, type: "Q", compDesc: &compDesc)
         _setup(unitFlags, field: .month, type: "M", compDesc: &compDesc)
-        _setup(unitFlags, field: .month, type: "l", compDesc: &compDesc)
+        if addIsLeapMonth {
+            _setup(unitFlags, field: .month, type: "l", compDesc: &compDesc)
+        }
         _setup(unitFlags, field: .day, type: "d", compDesc: &compDesc)
         _setup(unitFlags, field: .weekOfYear, type: "w", compDesc: &compDesc)
         _setup(unitFlags, field: .weekOfMonth, type: "W", compDesc: &compDesc)
@@ -527,14 +529,16 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    private func _components(_ unitFlags: Unit, vector: [Int32]) -> DateComponents {
+    private func _components(_ unitFlags: Unit, vector: [Int32], addIsLeapMonth: Bool = true) -> DateComponents {
         var compIdx = 0
         var comps = DateComponents()
         _setComp(unitFlags, field: .era, vector: vector, compIndex: &compIdx) { comps.era = Int($0) }
         _setComp(unitFlags, field: .year, vector: vector, compIndex: &compIdx) { comps.year = Int($0) }
         _setComp(unitFlags, field: .quarter, vector: vector, compIndex: &compIdx) { comps.quarter = Int($0) }
         _setComp(unitFlags, field: .month, vector: vector, compIndex: &compIdx) { comps.month = Int($0) }
-        _setComp(unitFlags, field: .month, vector: vector, compIndex: &compIdx) { comps.isLeapMonth = $0 != 0 }
+        if addIsLeapMonth {
+            _setComp(unitFlags, field: .month, vector: vector, compIndex: &compIdx) { comps.isLeapMonth = $0 != 0 }
+        }
         _setComp(unitFlags, field: .day, vector: vector, compIndex: &compIdx) { comps.day = Int($0) }
         _setComp(unitFlags, field: .weekOfYear, vector: vector, compIndex: &compIdx) { comps.weekOfYear = Int($0) }
         _setComp(unitFlags, field: .weekOfMonth, vector: vector, compIndex: &compIdx) { comps.weekOfMonth = Int($0) }
@@ -599,7 +603,7 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     }
     
     open func components(_ unitFlags: Unit, from startingDate: Date, to resultDate: Date, options opts: Options = []) -> DateComponents {
-        let compDesc = _setup(unitFlags)
+        let compDesc = _setup(unitFlags, addIsLeapMonth: false)
         var ints = [Int32](repeating: 0, count: 20)
         let res = ints.withUnsafeMutableBufferPointer { (intArrayBuffer: inout UnsafeMutableBufferPointer<Int32>) -> Bool in
             var vector: [UnsafeMutablePointer<Int32>] = (0..<20).map { idx in
@@ -612,7 +616,7 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
             }
         }
         if res {
-            return _components(unitFlags, vector: ints)
+            return _components(unitFlags, vector: ints, addIsLeapMonth: false)
         }
         fatalError()
     }

--- a/TestFoundation/TestCalendar.swift
+++ b/TestFoundation/TestCalendar.swift
@@ -199,6 +199,7 @@ class TestNSDateComponents: XCTestCase {
     static var allTests: [(String, (TestNSDateComponents) -> () throws -> Void)] {
         return [
             ("test_copyNSDateComponents", test_copyNSDateComponents),
+            ("test_dateDifferenceComponents", test_dateDifferenceComponents),
         ]
     }
 
@@ -222,5 +223,17 @@ class TestNSDateComponents: XCTestCase {
         components.hour = 12
         XCTAssertEqual(components.hour, 12)
         XCTAssertEqual(copy.hour, 14)
+    }
+
+    func test_dateDifferenceComponents() {
+        let date1 = Date(timeIntervalSince1970: 0)
+
+        // 1971-06-21
+        let date2 = Date(timeIntervalSince1970:  46310400)
+        let difference = Calendar.current.dateComponents([.month, .year, .day], from: date1, to: date2)
+        XCTAssertEqual(difference.year, 1)
+        XCTAssertEqual(difference.month, 5)
+        XCTAssertEqual(difference.day, 20)
+
     }
 }


### PR DESCRIPTION
- _CFCalendarGetComponentDifferenceV() doesn't support a component
  character of 'l' (leap year) as it make no sense for the difference
  between two dates.

- Dont add 'l' to the component string or parse the result into the
  .isLeapMonth property when called from
  NSCalendar.components(_:from:to:options)