### PR TITLE
Allow header files to be parsed by C++ parsers

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -82,6 +82,17 @@
 #define _CF_RELEASES_ARGUMENT_OBJ
 #endif
 
+#if DEPLOYMENT_TARGET_WINDOWS
+  // No C99 support
+  #define _CF_RESTRICT
+#else
+  #if defined(__cplusplus)
+    #define _CF_RESTRICT __restrict__
+  #else
+    #define _CF_RESTRICT restrict
+  #endif
+#endif
+
 CF_EXTERN_C_BEGIN
 
 #include <CoreFoundation/CFBase.h>

--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -1337,7 +1337,7 @@ void _CFThreadSpecificSet(_CFThreadSpecificKey key, CFTypeRef _Nullable value) {
     }
 }
 
-_CFThreadRef _CFThreadCreate(const _CFThreadAttributes attrs, void *_Nullable (* _Nonnull startfn)(void *_Nullable), void *restrict _Nullable context) {
+_CFThreadRef _CFThreadCreate(const _CFThreadAttributes attrs, void *_Nullable (* _Nonnull startfn)(void *_Nullable), void *_CF_RESTRICT _Nullable context) {
     pthread_t thread;
     pthread_create(&thread, &attrs, startfn, context);
     return thread;

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -315,7 +315,11 @@ CF_EXPORT _CFThreadSpecificKey _CFThreadSpecificKeyCreate(void);
 typedef pthread_attr_t _CFThreadAttributes;
 typedef pthread_t _CFThreadRef;
 
+#if defined(__cplusplus)
+CF_EXPORT _CFThreadRef _CFThreadCreate(const _CFThreadAttributes attrs, void *_Nullable (* _Nonnull startfn)(void *_Nullable), void *__restrict__ _Nullable context);
+#else
 CF_EXPORT _CFThreadRef _CFThreadCreate(const _CFThreadAttributes attrs, void *_Nullable (* _Nonnull startfn)(void *_Nullable), void *restrict _Nullable context);
+#endif
 
 CF_CROSS_PLATFORM_EXPORT int _CFThreadSetName(pthread_t thread, const char *_Nonnull name);
 CF_CROSS_PLATFORM_EXPORT int _CFThreadGetName(char *_Nonnull buf, int length);

--- a/CoreFoundation/Collections.subproj/CFStorage.c
+++ b/CoreFoundation/Collections.subproj/CFStorage.c
@@ -37,8 +37,6 @@
 #endif
 
 #if DEPLOYMENT_TARGET_WINDOWS
-// No C99 support
-#define restrict
 
 // Replace bzero
 #define bzero(dst, size)    ZeroMemory(dst, size)
@@ -244,7 +242,7 @@ static inline void __CFStorageSetChild(CFStorageNode *parentNode, CFIndex childI
     *((void **)&parentNode->info.notLeaf.child[childIndex]) = newChild;
 }
 
-static inline void __CFStorageGetChildren(const CFStorageNode *parent, CFStorageNode ** restrict resultArray, bool shouldRetain, bool shouldFreeze) {
+static inline void __CFStorageGetChildren(const CFStorageNode *parent, CFStorageNode ** _CF_RESTRICT resultArray, bool shouldRetain, bool shouldFreeze) {
     ASSERT(! parent->isLeaf);
     CFIndex i;
     for (i=0; i < 3; i++) {
@@ -272,7 +270,7 @@ CF_INLINE void __CFStorageSetCache(CFStorageRef storage, CFStorageNode *node, CF
 /* Gets the location for the specified absolute loc from the cached info.
  Returns NULL if the location is not in the cache.
  */
-CF_INLINE uint8_t *__CFStorageGetFromCache(CFStorageRef storage, CFIndex loc, CFRange * restrict validConsecutiveValueRange, bool requireUnfrozenNode) {
+CF_INLINE uint8_t *__CFStorageGetFromCache(CFStorageRef storage, CFIndex loc, CFRange * _CF_RESTRICT validConsecutiveValueRange, bool requireUnfrozenNode) {
     CFStorageNode * const cachedNode = storage->cacheNode; /* It's important we read from this field no more than once, for thread safety with other concurrent reads; that is why the field is marked volatile. */
     if (! cachedNode) return NULL; /* No cache */
     
@@ -307,7 +305,7 @@ CF_INLINE uint8_t *__CFStorageGetFromCache(CFStorageRef storage, CFIndex loc, CF
  relativeByteNum (not optional, for performance reasons) returns the relative byte number of the specified byte in the child.
  Don't call with leaf nodes!
  */
-CF_INLINE CFStorageNode *__CFStorageFindChild(const CFStorageNode * restrict node, CFIndex byteNum, bool forInsertionOrDeletion, CFIndex * restrict childNum, CFIndex * restrict relativeByteNum) {
+CF_INLINE CFStorageNode *__CFStorageFindChild(const CFStorageNode * _CF_RESTRICT node, CFIndex byteNum, bool forInsertionOrDeletion, CFIndex * _CF_RESTRICT childNum, CFIndex * _CF_RESTRICT relativeByteNum) {
     if (forInsertionOrDeletion) byteNum--;	/* If for insertion, we do <= checks, not <, so this accomplishes the same thing */
     CFStorageNode *result;
     result = node->info.notLeaf.child[0];

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.h
@@ -137,7 +137,7 @@ typedef void* _CFXMLEntityPtr;
 typedef void* _CFXMLDTDPtr;
 typedef void* _CFXMLDTDNodePtr;
 
-_CFXMLNodePtr _CFXMLNewNode(_CFXMLNamespacePtr _Nullable namespace, const char* name);
+_CFXMLNodePtr _CFXMLNewNode(_CFXMLNamespacePtr _Nullable name_space, const char* name);
 _CFXMLNodePtr _CFXMLCopyNode(_CFXMLNodePtr node, bool recursive);
 
 _CFXMLDocPtr _CFXMLNewDoc(const unsigned char* version);


### PR DESCRIPTION
By replacing `namspace` with `name_space` and changing the `restrict` into `__restrict__` in C++ mode, the headers can now be parsed by clang++ as well as clang.