### PR TITLE
Fix redundant access-level modifiers.

### DIFF
--- a/Foundation/Codable.swift
+++ b/Foundation/Codable.swift
@@ -11,7 +11,7 @@
 // Error Utilities
 //===----------------------------------------------------------------------===//
 
-internal extension DecodingError {
+extension DecodingError {
     /// Returns a `.typeMismatch` error describing the expected type.
     ///
     /// - parameter path: The path of `CodingKey`s taken to decode a value of this type.

--- a/Foundation/HTTPCookieStorage.swift
+++ b/Foundation/HTTPCookieStorage.swift
@@ -325,7 +325,7 @@ open class HTTPCookieStorage: NSObject {
     open func sortedCookies(using sortOrder: [NSSortDescriptor]) -> [HTTPCookie] { NSUnimplemented() }
 }
 
-public extension Notification.Name {
+extension Notification.Name {
     /*!
      @const NSHTTPCookieManagerCookiesChangedNotification
      @abstract Notification sent when the set of cookies changes

--- a/Foundation/JSONEncoder.swift
+++ b/Foundation/JSONEncoder.swift
@@ -2148,7 +2148,7 @@ fileprivate var _iso8601Formatter: ISO8601DateFormatter = {
 // Error Utilities
 //===----------------------------------------------------------------------===//
 
-fileprivate extension EncodingError {
+extension EncodingError {
     /// Returns a `.invalidValue` error describing the given invalid floating-point value.
     ///
     ///

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -421,7 +421,7 @@ extension __BridgedNSError where Self: RawRepresentable, Self.RawValue: SignedIn
     }
 }
 
-public extension __BridgedNSError where Self: RawRepresentable, Self.RawValue: SignedInteger {
+extension __BridgedNSError where Self: RawRepresentable, Self.RawValue: SignedInteger {
     public var _domain: String { return Self._nsErrorDomain }
     public var _code: Int { return Int(rawValue) }
     
@@ -447,7 +447,7 @@ extension __BridgedNSError where Self: RawRepresentable, Self.RawValue: Unsigned
     }
 }
 
-public extension __BridgedNSError where Self: RawRepresentable, Self.RawValue: UnsignedInteger {
+extension __BridgedNSError where Self: RawRepresentable, Self.RawValue: UnsignedInteger {
     public var _domain: String { return Self._nsErrorDomain }
     public var _code: Int {
         return Int(bitPattern: UInt(rawValue))
@@ -499,7 +499,7 @@ public protocol _BridgedStoredNSError : __BridgedNSError, _ObjectiveCBridgeableE
 }
 
 /// Various helper implementations for _BridgedStoredNSError
-public extension _BridgedStoredNSError where Code: RawRepresentable, Code.RawValue: SignedInteger {
+extension _BridgedStoredNSError where Code: RawRepresentable, Code.RawValue: SignedInteger {
     // FIXME: Generalize to Integer.
     public var code: Code {
         return Code(rawValue: numericCast(_nsError.code))!
@@ -515,11 +515,11 @@ public extension _BridgedStoredNSError where Code: RawRepresentable, Code.RawVal
 
     /// The user-info dictionary for an error that was bridged from
     /// NSError.
-    var userInfo: [String : Any] { return errorUserInfo }
+    public var userInfo: [String : Any] { return errorUserInfo }
 }
 
 /// Various helper implementations for _BridgedStoredNSError
-public extension _BridgedStoredNSError where Code: RawRepresentable, Code.RawValue: UnsignedInteger {
+extension _BridgedStoredNSError where Code: RawRepresentable, Code.RawValue: UnsignedInteger {
     // FIXME: Generalize to Integer.
     public var code: Code {
         return Code(rawValue: numericCast(_nsError.code))!
@@ -535,7 +535,7 @@ public extension _BridgedStoredNSError where Code: RawRepresentable, Code.RawVal
 }
 
 /// Implementation of __BridgedNSError for all _BridgedStoredNSErrors.
-public extension _BridgedStoredNSError {
+extension _BridgedStoredNSError {
     /// Default implementation of ``init(_bridgedNSError)`` to provide
     /// bridging from NSError.
     public init?(_bridgedNSError error: NSError) {
@@ -690,7 +690,7 @@ public extension CocoaError {
     }
 }
 
-public extension CocoaError {
+extension CocoaError {
     public static func error(_ code: CocoaError.Code, userInfo: [AnyHashable: Any]? = nil, url: URL? = nil) -> Error {
         var info: [String: Any] = userInfo as? [String: Any] ?? [:]
         if let url = url {
@@ -855,7 +855,7 @@ public struct URLError : _BridgedStoredNSError {
     }
 }
 
-public extension URLError {
+extension URLError {
     private var _nsUserInfo: [AnyHashable : Any] {
         return _nsError.userInfo
     }
@@ -871,7 +871,7 @@ public extension URLError {
     }
 }
 
-public extension URLError {
+extension URLError {
     public static var unknown:                                  URLError.Code { return .unknown }
     public static var cancelled:                                URLError.Code { return .cancelled }
     public static var badURL:                                   URLError.Code { return .badURL }

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -220,7 +220,7 @@ extension NSLocale.Key {
 }
 
 
-public extension NSLocale {
+extension NSLocale {
     public static let currentLocaleDidChangeNotification = NSNotification.Name(rawValue: "kCFLocaleCurrentLocaleDidChangeNotification")
 }
 

--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -33,7 +33,7 @@ public func NSTemporaryDirectory() -> String {
     return "/tmp/"
 }
 
-internal extension String {
+extension String {
     
     internal var _startOfLastPathComponent : String.Index {
         precondition(!hasSuffix("/") && length > 1)
@@ -153,7 +153,7 @@ internal extension String {
     }
 }
 
-public extension NSString {
+extension NSString {
     
     public var isAbsolutePath: Bool {
         return hasPrefix("~") || hasPrefix("/")

--- a/Foundation/Operation.swift
+++ b/Foundation/Operation.swift
@@ -230,7 +230,7 @@ open class BlockOperation: Operation {
     }
 }
 
-public extension OperationQueue {
+extension OperationQueue {
     public static let defaultMaxConcurrentOperationCount: Int = Int.max
 }
 

--- a/Foundation/URLCredentialStorage.swift
+++ b/Foundation/URLCredentialStorage.swift
@@ -98,7 +98,7 @@ extension URLCredentialStorage {
     public func setDefaultCredential(_ credential: URLCredential, for protectionSpace: URLProtectionSpace, task: URLSessionTask) { NSUnimplemented() }
 }
 
-public extension Notification.Name {
+extension Notification.Name {
     /*!
         @const NSURLCredentialStorageChangedNotification
         @abstract This notification is sent on the main thread whenever

--- a/Foundation/URLSession/BodySource.swift
+++ b/Foundation/URLSession/BodySource.swift
@@ -146,7 +146,7 @@ internal final class _BodyFileSource {
     }
 }
 
-fileprivate extension _BodyFileSource {
+extension _BodyFileSource {
     fileprivate var desiredBufferLength: Int { return 3 * CFURLSessionMaxWriteSize }
     /// Enqueue a dispatch I/O read to fill the buffer.
     ///

--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -321,7 +321,7 @@ extension URLSessionTask : ProgressReporting {
     }
 }
 
-internal extension URLSessionTask {
+extension URLSessionTask {
     /// Updates the (public) state based on private / internal state.
     ///
     /// - Note: This must be called on the `workQueue`.
@@ -389,7 +389,7 @@ fileprivate func errorCode(fileSystemError error: Error) -> Int {
     }
 }
 
-public extension URLSessionTask {
+extension URLSessionTask {
     /// The default URL session task priority, used implicitly for any task you
     /// have not prioritized. The floating point value of this constant is 0.5.
     public static let defaultPriority: Float = 0.5

--- a/Foundation/URLSession/libcurl/EasyHandle.swift
+++ b/Foundation/URLSession/libcurl/EasyHandle.swift
@@ -537,7 +537,7 @@ fileprivate extension _EasyHandle {
         return d
     }
 
-    fileprivate func setCookies(headerData data: Data) {
+    func setCookies(headerData data: Data) {
         guard let config = _config, config.httpCookieAcceptPolicy !=  HTTPCookie.AcceptPolicy.never else { return }
         guard let headerData = String(data: data, encoding: String.Encoding.utf8) else { return }
         //Convert headerData from a string to a dictionary.

--- a/Foundation/Unit.swift
+++ b/Foundation/Unit.swift
@@ -97,7 +97,7 @@ open class UnitConverterLinear : UnitConverter, NSSecureCoding {
 private class UnitConverterReciprocal : UnitConverter, NSSecureCoding {
     
     
-    private private(set) var reciprocal: Double
+    private var reciprocal: Double
     
     
     fileprivate init(reciprocal: Double) {


### PR DESCRIPTION
This patch aims at making corelibs-foundation adapted to [this PR](https://github.com/apple/swift/pull/18623),  which warns for redundant access-level modifiers.

@phausler Hi Philippe, would you help take a look at this, please?