### PR TITLE
SR-8560: XMLDocument on Linux crashes with a Segmentation Fault

### DIFF
--- a/Foundation/XMLNode.swift
+++ b/Foundation/XMLNode.swift
@@ -91,6 +91,7 @@ open class XMLNode: NSObject, NSCopying {
     }
 
     internal let _xmlNode: _CFXMLNodePtr
+    internal var _xmlDocument: XMLDocument?
 
     open func copy(with zone: NSZone? = nil) -> Any {
         let newNode = _CFXMLCopyNode(_xmlNode, true)
@@ -761,6 +762,8 @@ open class XMLNode: NSObject, NSCopying {
             node.detach()
         }
 
+        _xmlDocument = nil
+
         switch kind {
         case .document:
             _CFXMLFreeDocument(_CFXMLDocPtr(_xmlNode))
@@ -789,6 +792,11 @@ open class XMLNode: NSObject, NSCopying {
 
         withUnretainedReference {
             _CFXMLNodeSetPrivateData(_xmlNode, $0)
+        }
+        if let documentPtr = _CFXMLNodeGetDocument(_xmlNode) {
+            if documentPtr != ptr {
+                _xmlDocument = XMLDocument._objectNodeForNode(documentPtr)
+            }
         }
     }
 

--- a/TestFoundation/TestXMLDocument.swift
+++ b/TestFoundation/TestXMLDocument.swift
@@ -34,6 +34,7 @@ class TestXMLDocument : LoopbackServerTest {
             ("test_addNamespace", test_addNamespace),
             ("test_removeNamespace", test_removeNamespace),
             ("test_optionPreserveAll", test_optionPreserveAll),
+            ("test_rootElementRetainsDocument", test_rootElementRetainsDocument),
         ]
     }
 
@@ -526,6 +527,22 @@ class TestXMLDocument : LoopbackServerTest {
         }
         let expected = xmlString.lowercased() + "\n"
         XCTAssertEqual(expected, String(describing: document))
+    }
+
+    func test_rootElementRetainsDocument() {
+        let str = """
+<?xml version="1.0" encoding="UTF-8"?>
+<plans></plans>
+"""
+
+        let data = str.data(using: .utf8)!
+
+        func test() throws -> String? {
+            let doc = try XMLDocument(data: data, options: []).rootElement()
+            return doc?.name
+        }
+
+        XCTAssertEqual(try? test(), "plans")
     }
 }
 


### PR DESCRIPTION
- When returning an XMLNode, take a reference to the parent
  XMLDocument to prevent the underlying libxml xml document
  from being freed.

- This prevents the document being freed if a reference is still
  held to a XMLNode but not the XMLDocument.