### PR TITLE
SR-5829: Fix NSString.commonPrefix(with:options:)

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -434,49 +434,31 @@ extension NSString {
     }
     
     public func commonPrefix(with str: String, options mask: CompareOptions = []) -> String {
-        var currentSubstring: CFMutableString?
-        let isLiteral = mask.contains(.literal)
-        var lastMatch = NSRange()
-        let selfLen = length
-        let otherLen = str.length
-        var low = 0
-        var high = selfLen
-        var probe = (low + high) / 2
-        if (probe > otherLen) {
-            probe = otherLen // A little heuristic to avoid some extra work
-        }
-        if selfLen == 0 || otherLen == 0 {
+
+        let receiver = self as String
+        if receiver.isEmpty || str.isEmpty {
             return ""
         }
-        var numCharsBuffered = 0
-        var arrayBuffer = [unichar](repeating: 0, count: 100)
-        let other = str._nsObject
-        return arrayBuffer.withUnsafeMutablePointerOrAllocation(selfLen, fastpath: UnsafeMutablePointer<unichar>(mutating: _fastContents)) { (selfChars: UnsafeMutablePointer<unichar>) -> String in
-            // Now do the binary search. Note that the probe value determines the length of the substring to check.
-            while true {
-                let range = NSRange(location: 0, length: isLiteral ? probe + 1 : NSMaxRange(rangeOfComposedCharacterSequence(at: probe))) // Extend the end of the composed char sequence
-                if range.length > numCharsBuffered { // Buffer more characters if needed
-                    getCharacters(selfChars, range: NSRange(location: numCharsBuffered, length: range.length - numCharsBuffered))
-                    numCharsBuffered = range.length
-                }
-                if currentSubstring == nil {
-                    currentSubstring = CFStringCreateMutableWithExternalCharactersNoCopy(kCFAllocatorSystemDefault, selfChars, range.length, range.length, kCFAllocatorNull)
-                } else {
-                    CFStringSetExternalCharactersNoCopy(currentSubstring, selfChars, range.length, range.length)
-                }
-                if other.range(of: currentSubstring!._swiftObject, options: mask.union(.anchored), range: NSRange(location: 0, length: otherLen)).length != 0 { // Match
-                    lastMatch = range
-                    low = probe + 1
-                } else {
-                    high = probe
-                }
-                if low >= high {
+        let literal = mask.contains(.literal)
+        let caseInsensitive = mask.contains(.caseInsensitive)
+
+        var result = ""
+        var otherIterator = str.makeIterator()
+
+        for ch in receiver {
+            guard let otherCh = otherIterator.next() else { break }
+
+            if ch != otherCh {
+                if !caseInsensitive || (String(otherCh).lowercased() != String(ch).lowercased()) {
                     break
                 }
-                probe = (low + high) / 2
             }
-            return lastMatch.length != 0 ? substring(with: lastMatch) : ""
+
+            if literal, otherCh.unicodeScalars.count != ch.unicodeScalars.count { break }
+            result.append(ch)
         }
+
+        return result
     }
     
     public func contains(_ str: String) -> Bool {

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -449,12 +449,10 @@ extension NSString {
             guard let otherCh = otherIterator.next() else { break }
 
             if ch != otherCh {
-                if !caseInsensitive || (String(otherCh).lowercased() != String(ch).lowercased()) {
-                    break
-                }
+                guard caseInsensitive && String(ch).lowercased() == String(otherCh).lowercased() else { break }
             }
 
-            if literal, otherCh.unicodeScalars.count != ch.unicodeScalars.count { break }
+            if literal && otherCh.unicodeScalars.count != ch.unicodeScalars.count { break }
             result.append(ch)
         }
 

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -1240,10 +1240,13 @@ class TestNSString: LoopbackServerTest {
         XCTAssertEqual("abcba".commonPrefix(with: "abcde"), "abc")
         XCTAssertEqual("/path/to/file1".commonPrefix(with: "/path/to/file2"), "/path/to/file")
         XCTAssertEqual("/a_really_long_path/to/a/file".commonPrefix(with: "/a_really_long_path/to/the/file"), "/a_really_long_path/to/")
-        XCTAssertEqual("Ma\u{308}dchen".commonPrefix(with: "Mädchenschule"), "Ma\u{308}dchen")
         XCTAssertEqual("this".commonPrefix(with: "THAT", options: [.caseInsensitive]), "th")
-        XCTAssertEqual("this".commonPrefix(with: "THAT", options: [.caseInsensitive, .literal]), "th")
-        XCTAssertEqual("Ma\u{308}dchen".commonPrefix(with: "Mädchenschule", options: [.literal]), "M")
+
+        // Both forms of ä, a\u{308} decomposed and \u{E4} precomposed, should match without .literal and not match when .literal is used
+        XCTAssertEqual("Ma\u{308}dchen".commonPrefix(with: "M\u{E4}dchenschule"), "Ma\u{308}dchen")
+        XCTAssertEqual("Ma\u{308}dchen".commonPrefix(with: "M\u{E4}dchenschule", options: [.literal]), "M")
+        XCTAssertEqual("m\u{E4}dchen".commonPrefix(with: "M\u{E4}dchenschule", options: [.caseInsensitive, .literal]), "mädchen")
+        XCTAssertEqual("ma\u{308}dchen".commonPrefix(with: "M\u{E4}dchenschule", options: [.caseInsensitive, .literal]), "m")
     }
 }
 

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -92,6 +92,7 @@ class TestNSString: LoopbackServerTest {
             ("test_getLineStart", test_getLineStart),
             ("test_substringWithRange", test_substringWithRange),
             ("test_createCopy", test_createCopy),
+            ("test_commonPrefix", test_commonPrefix)
         ]
     }
 
@@ -1230,6 +1231,19 @@ class TestNSString: LoopbackServerTest {
         XCTAssertNotEqual(string, stringCopy)
         XCTAssertEqual(string, "foobar")
         XCTAssertEqual(stringCopy, "foo")
+    }
+
+    func test_commonPrefix() {
+        XCTAssertEqual("".commonPrefix(with: ""), "")
+        XCTAssertEqual("1234567890".commonPrefix(with: ""), "")
+        XCTAssertEqual("".commonPrefix(with: "1234567890"), "")
+        XCTAssertEqual("abcba".commonPrefix(with: "abcde"), "abc")
+        XCTAssertEqual("/path/to/file1".commonPrefix(with: "/path/to/file2"), "/path/to/file")
+        XCTAssertEqual("/a_really_long_path/to/a/file".commonPrefix(with: "/a_really_long_path/to/the/file"), "/a_really_long_path/to/")
+        XCTAssertEqual("Ma\u{308}dchen".commonPrefix(with: "Mädchenschule"), "Ma\u{308}dchen")
+        XCTAssertEqual("this".commonPrefix(with: "THAT", options: [.caseInsensitive]), "th")
+        XCTAssertEqual("this".commonPrefix(with: "THAT", options: [.caseInsensitive, .literal]), "th")
+        XCTAssertEqual("Ma\u{308}dchen".commonPrefix(with: "Mädchenschule", options: [.literal]), "M")
     }
 }
 


### PR DESCRIPTION
- Also implement .caseInsensitive option.

Current implementation was buggy and would crash for some strings.
Tests now match Darwin