### PR TITLE
isDeletableFile Implementation + Tests

### DIFF
--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -210,14 +210,17 @@ class TestFileManager : XCTestCase {
         let fm = FileManager.default
         let path = NSTemporaryDirectory() + "test_isReadableFile\(NSUUID().uuidString)"
 
-        XCTAssertTrue(fm.createFile(atPath: path, contents: Data()))
-
         do {
-            let attrs = try fm.attributesOfItem(atPath: path)
-            let permissions = attrs[FileAttributeKey.posixPermissions] as! UInt16
-            let fileIsReadableFile = (permissions & S_IRUSR == S_IRUSR)
-            let fmIsReadableFile = fm.isReadableFile(atPath: path)
-            XCTAssertTrue(fileIsReadableFile == fmIsReadableFile)
+            // create test file
+            XCTAssertTrue(fm.createFile(atPath: path, contents: Data()))
+
+            // test unReadable if file has no permissions
+            try fm.setAttributes([.posixPermissions : NSNumber(value: Int16(0o0000))], ofItemAtPath: path)
+            XCTAssertFalse(fm.isReadableFile(atPath: path))
+
+            // test readable if file has read permissions
+            try fm.setAttributes([.posixPermissions : NSNumber(value: Int16(0o0400))], ofItemAtPath: path)
+            XCTAssertTrue(fm.isReadableFile(atPath: path))
         } catch let e {
             XCTFail("\(e)")
         }
@@ -227,14 +230,17 @@ class TestFileManager : XCTestCase {
         let fm = FileManager.default
         let path = NSTemporaryDirectory() + "test_isWritableFile\(NSUUID().uuidString)"
 
-        XCTAssertTrue(fm.createFile(atPath: path, contents: Data()))
-
         do {
-            let attrs = try fm.attributesOfItem(atPath: path)
-            let permissions = attrs[FileAttributeKey.posixPermissions] as! UInt16
-            let fileIsWritableFile = (permissions & S_IWUSR == S_IWUSR)
-            let fmIsWritableFile = fm.isWritableFile(atPath: path)
-            XCTAssertTrue(fileIsWritableFile == fmIsWritableFile)
+            // create test file
+            XCTAssertTrue(fm.createFile(atPath: path, contents: Data()))
+
+            // test unWritable if file has no permissions
+            try fm.setAttributes([.posixPermissions : NSNumber(value: Int16(0o0000))], ofItemAtPath: path)
+            XCTAssertFalse(fm.isWritableFile(atPath: path))
+
+            // test writable if file has write permissions
+            try fm.setAttributes([.posixPermissions : NSNumber(value: Int16(0o0200))], ofItemAtPath: path)
+            XCTAssertTrue(fm.isWritableFile(atPath: path))
         } catch let e {
             XCTFail("\(e)")
         }
@@ -244,14 +250,17 @@ class TestFileManager : XCTestCase {
         let fm = FileManager.default
         let path = NSTemporaryDirectory() + "test_isExecutableFile\(NSUUID().uuidString)"
 
-        XCTAssertTrue(fm.createFile(atPath: path, contents: Data()))
-
         do {
-            let attrs = try fm.attributesOfItem(atPath: path)
-            let permissions = attrs[FileAttributeKey.posixPermissions] as! UInt16
-            let fileIsExecutableFile = (permissions & S_IXUSR == S_IXUSR)
-            let fmIsExecutableFile = fm.isExecutableFile(atPath: path)
-            XCTAssertTrue(fileIsExecutableFile == fmIsExecutableFile)
+            // create test file
+            XCTAssertTrue(fm.createFile(atPath: path, contents: Data()))
+
+            // test unExecutable if file has no permissions
+            try fm.setAttributes([.posixPermissions : NSNumber(value: Int16(0o0000))], ofItemAtPath: path)
+            XCTAssertFalse(fm.isExecutableFile(atPath: path))
+
+            // test executable if file has execute permissions
+            try fm.setAttributes([.posixPermissions : NSNumber(value: Int16(0o0100))], ofItemAtPath: path)
+            XCTAssertTrue(fm.isExecutableFile(atPath: path))
         } catch let e {
             XCTFail("\(e)")
         }

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -16,6 +16,10 @@ class TestFileManager : XCTestCase {
             ("test_moveFile", test_moveFile),
             ("test_fileSystemRepresentation", test_fileSystemRepresentation),
             ("test_fileExists", test_fileExists),
+            ("test_isReadableFile", test_isReadableFile),
+            ("test_isWritableFile", test_isWritableFile),
+            ("test_isExecutableFile", test_isExecutableFile),
+            ("test_isDeletableFile", test_isDeletableFile),
             ("test_fileAttributes", test_fileAttributes),
             ("test_fileSystemAttributes", test_fileSystemAttributes),
             ("test_setFileAttributes", test_setFileAttributes),
@@ -200,6 +204,62 @@ class TestFileManager : XCTestCase {
             XCTFail(String(describing: error))
         }
         ignoreError { try fm.removeItem(atPath: tmpDir.path) }
+    }
+
+    func test_isReadableFile() {
+        let fm = FileManager.default
+        let path = NSTemporaryDirectory() + "test_fileAttributes\(NSUUID().uuidString)"
+
+        XCTAssertTrue(fm.createFile(atPath: path, contents: Data(), attributes: nil))
+
+        do {
+            let attrs = try fm.attributesOfItem(atPath: path)
+            let permissions = attrs[FileAttributeKey.posixPermissions] as! UInt16
+            let fileIsReadableFile = (permissions & S_IRUSR == S_IRUSR)
+            let fmIsReadableFile = fm.isReadableFile(atPath: path)
+            XCTAssertTrue(fileIsReadableFile == fmIsReadableFile)
+        } catch let e {
+            XCTFail("\(e)")
+        }
+    }
+
+    func test_isWritableFile() {
+        let fm = FileManager.default
+        let path = NSTemporaryDirectory() + "test_fileAttributes\(NSUUID().uuidString)"
+
+        XCTAssertTrue(fm.createFile(atPath: path, contents: Data(), attributes: nil))
+
+        do {
+            let attrs = try fm.attributesOfItem(atPath: path)
+            let permissions = attrs[FileAttributeKey.posixPermissions] as! UInt16
+            let fileIsReadableFile = (permissions & S_IWUSR == S_IWUSR)
+            let fmIsReadableFile = fm.isReadableFile(atPath: path)
+            XCTAssertTrue(fileIsReadableFile == fmIsReadableFile)
+        } catch let e {
+            XCTFail("\(e)")
+        }
+    }
+
+    func test_isExecutableFile() {
+        let fm = FileManager.default
+        let path = NSTemporaryDirectory() + "test_fileAttributes\(NSUUID().uuidString)"
+
+        XCTAssertTrue(fm.createFile(atPath: path, contents: Data(), attributes: nil))
+
+        do {
+            let attrs = try fm.attributesOfItem(atPath: path)
+            let permissions = attrs[FileAttributeKey.posixPermissions] as! UInt16
+            let fileIsReadableFile = (permissions & S_IXUSR == S_IXUSR)
+            let fmIsReadableFile = fm.isReadableFile(atPath: path)
+            XCTAssertTrue(fileIsReadableFile == fmIsReadableFile)
+        } catch let e {
+            XCTFail("\(e)")
+        }
+    }
+
+    func test_isDeletableFile() {
+        // TODO: Implement test
+        // how to test?
     }
 
     func test_fileAttributes() {

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -208,9 +208,9 @@ class TestFileManager : XCTestCase {
 
     func test_isReadableFile() {
         let fm = FileManager.default
-        let path = NSTemporaryDirectory() + "test_fileAttributes\(NSUUID().uuidString)"
+        let path = NSTemporaryDirectory() + "test_isReadableFile\(NSUUID().uuidString)"
 
-        XCTAssertTrue(fm.createFile(atPath: path, contents: Data(), attributes: nil))
+        XCTAssertTrue(fm.createFile(atPath: path, contents: Data()))
 
         do {
             let attrs = try fm.attributesOfItem(atPath: path)
@@ -225,16 +225,16 @@ class TestFileManager : XCTestCase {
 
     func test_isWritableFile() {
         let fm = FileManager.default
-        let path = NSTemporaryDirectory() + "test_fileAttributes\(NSUUID().uuidString)"
+        let path = NSTemporaryDirectory() + "test_isWritableFile\(NSUUID().uuidString)"
 
-        XCTAssertTrue(fm.createFile(atPath: path, contents: Data(), attributes: nil))
+        XCTAssertTrue(fm.createFile(atPath: path, contents: Data()))
 
         do {
             let attrs = try fm.attributesOfItem(atPath: path)
             let permissions = attrs[FileAttributeKey.posixPermissions] as! UInt16
-            let fileIsReadableFile = (permissions & S_IWUSR == S_IWUSR)
-            let fmIsReadableFile = fm.isReadableFile(atPath: path)
-            XCTAssertTrue(fileIsReadableFile == fmIsReadableFile)
+            let fileIsWritableFile = (permissions & S_IWUSR == S_IWUSR)
+            let fmIsWritableFile = fm.isWritableFile(atPath: path)
+            XCTAssertTrue(fileIsWritableFile == fmIsWritableFile)
         } catch let e {
             XCTFail("\(e)")
         }
@@ -242,24 +242,44 @@ class TestFileManager : XCTestCase {
 
     func test_isExecutableFile() {
         let fm = FileManager.default
-        let path = NSTemporaryDirectory() + "test_fileAttributes\(NSUUID().uuidString)"
+        let path = NSTemporaryDirectory() + "test_isExecutableFile\(NSUUID().uuidString)"
 
-        XCTAssertTrue(fm.createFile(atPath: path, contents: Data(), attributes: nil))
+        XCTAssertTrue(fm.createFile(atPath: path, contents: Data()))
 
         do {
             let attrs = try fm.attributesOfItem(atPath: path)
             let permissions = attrs[FileAttributeKey.posixPermissions] as! UInt16
-            let fileIsReadableFile = (permissions & S_IXUSR == S_IXUSR)
-            let fmIsReadableFile = fm.isReadableFile(atPath: path)
-            XCTAssertTrue(fileIsReadableFile == fmIsReadableFile)
+            let fileIsExecutableFile = (permissions & S_IXUSR == S_IXUSR)
+            let fmIsExecutableFile = fm.isExecutableFile(atPath: path)
+            XCTAssertTrue(fileIsExecutableFile == fmIsExecutableFile)
         } catch let e {
             XCTFail("\(e)")
         }
     }
 
     func test_isDeletableFile() {
-        // TODO: Implement test
-        // how to test?
+        let fm = FileManager.default
+
+        do {
+            let dir_path = NSTemporaryDirectory() + "/test_isDeletableFile_dir/"
+            let file_path = dir_path + "test_isDeletableFile\(NSUUID().uuidString)"
+            // create test directory
+            try fm.createDirectory(atPath: dir_path, withIntermediateDirectories: true)
+            // create test file
+            XCTAssertTrue(fm.createFile(atPath: file_path, contents: Data()))
+
+            // test undeletable if parent directory has no permissions
+            try fm.setAttributes([.posixPermissions : NSNumber(value: Int16(0o0000))], ofItemAtPath: dir_path)
+            XCTAssertFalse(fm.isDeletableFile(atPath: file_path))
+
+            // test deletable if parent directory has all necessary permissions
+            try fm.setAttributes([.posixPermissions : NSNumber(value: Int16(0o0755))], ofItemAtPath: dir_path)
+            XCTAssertTrue(fm.isDeletableFile(atPath: file_path))
+        }
+        catch { XCTFail("\(error)") }
+
+        // test against known undeletable file
+        XCTAssertFalse(fm.isDeletableFile(atPath: "/dev/null"))
     }
 
     func test_fileAttributes() {


### PR DESCRIPTION
Tried to best match the suggested implementation from the [Swift Forum](https://forums.swift.org/t/swiftfoundation-filemanager-isdeletablefile-implementation/13465/7).

I wasn't exactly sure how to write tests for these methods. My tests attempt to check that the result of `isReadableFile`, `isWritableFile`, `isExecutableFile` match the value one would receive by directly checking the file's permission bits.