### PR TITLE
Fix UB when hashing some doubles in 32bits.

### DIFF
--- a/CoreFoundation/Base.subproj/ForFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForFoundationOnly.h
@@ -542,7 +542,7 @@ CF_INLINE CFHashCode _CFHashDouble(const double d) {
         result += -((CFHashCode)(fabs(fractional)));
     } else if (fractional > 0) {
         // Caveat: the > 0 is incredibly important [28612173]
-        result += fractional;
+        result += (CFHashCode)fractional;
     }
     return result;
 }

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -36,6 +36,7 @@ class TestNSNumber : XCTestCase {
             ("test_stringValue", test_stringValue),
             ("test_Equals", test_Equals),
             ("test_boolValue", test_boolValue),
+            ("test_hash", test_hash),
         ]
     }
     
@@ -1261,5 +1262,27 @@ class TestNSNumber : XCTestCase {
         XCTAssertEqual(NSNumber(value: Int.min).boolValue, false)   // Darwin compatibility
         XCTAssertEqual(NSNumber(value: Int.min + 1).boolValue, true)
         XCTAssertEqual(NSNumber(value: Int(-1)).boolValue, true)
+    }
+
+    func test_hash() {
+        // A zero double hashes as zero.
+        XCTAssertEqual(NSNumber(value: 0 as Double).hash, 0)
+
+        // A positive double without fractional part should hash the same as the
+        // equivalent 64 bit number.
+        XCTAssertEqual(NSNumber(value: 123456 as Double).hash, NSNumber(value: 123456 as Int64).hash)
+
+        // A negative double without fractional part should hash the same as the
+        // equivalent 64 bit number.
+        XCTAssertEqual(NSNumber(value: -123456 as Double).hash, NSNumber(value: -123456 as Int64).hash)
+
+        #if arch(i386) || arch(arm)
+            // This test used to fail in 32 bit platforms.
+            XCTAssertNotEqual(NSNumber(value: 551048378.24883795 as Double).hash, 0)
+
+            // Some hashes are correctly zero, though. Like the following which
+            // was found by trial and error.
+            XCTAssertEqual(NSNumber(value: 1.3819660135 as Double).hash, 0)
+        #endif
     }
 }


### PR DESCRIPTION
In 32 bits platforms, for some doubles the hash result could be
incorrectly zero (or whatever undefined behaviour happens to be).

The problem happens when the non fractional part of the double is high
and the fractional part is between 0 and 0.5 and high enough to make the
sum of both not fit into 32 bits. In that case, the use of += promotes
result to double to add it to the fractional double, but when it gets
converted back into CFHashCode, since it is outside the 32 bit range, it
might end up as zero.

Casting fractional to CFHashCode avoids the hidden promotion, and should
not fail, since fractional is at most ULONG_MAX/2.

The problem doesn't exist in 64 bits, since CFHashCode is 64 bits wide
there.