### PR TITLE
Fix Dimension.encode(with:) to use same key as init(coder:).

### DIFF
--- a/Foundation/Unit.swift
+++ b/Foundation/Unit.swift
@@ -232,7 +232,7 @@ open class Dimension : Unit {
         guard aCoder.allowsKeyedCoding else {
             preconditionFailure("Unkeyed coding is unsupported.")
         }
-        aCoder.encode(self.converter, forKey:"converter")
+        aCoder.encode(self.converter, forKey:"NS.converter")
     }
     
     open override func isEqual(_ object: Any?) -> Bool {

--- a/TestFoundation/TestUnit.swift
+++ b/TestFoundation/TestUnit.swift
@@ -93,3 +93,26 @@ class TestUnit: XCTestCase {
     }
 
 }
+
+class TestDimension: XCTestCase {
+    static var allTests: [(String, (TestDimension) -> () throws -> Void)] {
+        return [
+            ("test_encodeDecode", test_encodeDecode),
+        ]
+    }
+
+    func test_encodeDecode() {
+        let original = Dimension(symbol: "symbol", converter: UnitConverterLinear(coefficient: 1.0))
+
+        let encodedData = NSMutableData()
+        let archiver = NSKeyedArchiver(forWritingWith: encodedData)
+        original.encode(with: archiver)
+        archiver.finishEncoding()
+
+        let unarchiver = NSKeyedUnarchiver(forReadingWith: encodedData as Data)
+        let decoded = Dimension(coder: unarchiver)
+
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(original, decoded)
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -103,5 +103,6 @@ XCTMain([
     testCase(TestJSONEncoder.allTests),
     testCase(TestCodable.allTests),
     testCase(TestUnit.allTests),
+    testCase(TestDimension.allTests),
     testCase(TestNSLock.allTests),
 ])


### PR DESCRIPTION
The encoding method and the decoding method used slightly different
keys. The incorrect key made Dimension (and the subtypes) impossible to
decode (and with Swift Foundation a crash since decoding cannot fail).

Includes a test to check for correctly encoding/decoding cycle.