### PR TITLE
[Decimal] Make a minor edit to synchronize with overlay

### DIFF
--- a/Foundation/Decimal.swift
+++ b/Foundation/Decimal.swift
@@ -455,8 +455,8 @@ extension Decimal {
         var compactValue = value
         var exponent: Int32 = 0
         while compactValue % 10 == 0 {
-            compactValue = compactValue / 10
-            exponent = exponent + 1
+            compactValue /= 10
+            exponent += 1
         }
         _isCompact = 1
         _exponent = exponent
@@ -470,11 +470,9 @@ extension Decimal {
     }
 
     public init(_ value: Int64) {
+        self.init(value.magnitude)
         if value < 0 {
-            self.init(value == Int64.min ? UInt64(Int64.max) + 1 : UInt64(abs(value)))
             _isNegative = 1
-        } else {
-            self.init(UInt64(value))
         }
     }
 


### PR DESCRIPTION
This PR applies [a minor edit](https://github.com/apple/swift/pull/18486/commits/89b26a7f653e3fca1830dd33909ac71ba024cd0c) to swift-corelibs-foundation to synchronize with the overlay. No functional change is intended.

Although it ought to be purely cosmetic, the original motivation for the change was that the Swift compiler that day on the master branch refused to accept `UInt64(abs(value))`. Therefore, since there's a cleaner way to express the operation anyway, I made minor edits mostly for the sake of allowing compilation to proceed. Now, these changes are made here for the sake of synchrony.

No new tests are required.