### PR TITLE
Fix unnecessary (and broken) preprocessor exclusion

### DIFF
--- a/CoreFoundation/NumberDate.subproj/CFTimeZone.c
+++ b/CoreFoundation/NumberDate.subproj/CFTimeZone.c
@@ -1013,8 +1013,6 @@ void CFTimeZoneSetAbbreviationDictionary(CFDictionaryRef dict) {
     __CFTimeZoneUnlockGlobal();
 }
 
-#if DEPLOYMENT_RUNTIME_SWIFT
-
 CF_INLINE const UChar *STRING_to_UTF16(CFStringRef S) { // UTF16String
     CFIndex length = CFStringGetLength((CFStringRef)S);
     UChar *buffer = (UChar *)malloc((length + 1) * sizeof(UChar));
@@ -1244,7 +1242,6 @@ Boolean _CFTimeZoneInit(CFTimeZoneRef timeZone, CFStringRef name, CFDataRef data
     }
     return false;
 }
-#endif
 
 CFTimeZoneRef CFTimeZoneCreate(CFAllocatorRef allocator, CFStringRef name, CFDataRef data) {
 // assert:    (NULL != name && NULL != data);


### PR DESCRIPTION
I'm not 100% sure this is the correct fix, but the `__nameStringOK` static function gets used even if `DEPLOYMENT_RUNTIME_SWIFT` is unset, so this just breaks the build (linkage) if this block of code gets excluded. It also just doesn't seem very Swift-specific, to my uneducated eye.

cc @DougGregor or anyone willing to suggest a better fix