### PR TITLE
SR-8689: Fix crash with NSMutableString.replaceOccurrences(of:with:options:)

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -1331,12 +1331,14 @@ open class NSMutableString : NSString {
         }
 
         let start = _storage.utf16.startIndex
-        let min = _storage.utf16.index(start, offsetBy: range.location).samePosition(in: _storage) ??
-            _storage.utf16.index(start, offsetBy: _storage.rangeOfComposedCharacterSequence(at: range.location).location)
+        let min = _storage.utf16.index(start, offsetBy: range.location).samePosition(in: _storage) ?? {
+            let characterRange = _storage.rangeOfComposedCharacterSequence(at: range.location)
+            return _storage.utf16.index(start, offsetBy: characterRange.location)
+        }()
 
         let max = _storage.utf16.index(start, offsetBy: range.location + range.length).samePosition(in: _storage) ?? {
-            let range = _storage.rangeOfComposedCharacterSequence(at: range.location + range.length)
-            return _storage.utf16.index(start, offsetBy: range.location)
+            let characterRange = _storage.rangeOfComposedCharacterSequence(at: range.location + range.length)
+            return _storage.utf16.index(start, offsetBy: characterRange.location)
         }()
         _storage.replaceSubrange(min..<max, with: aString)
     }

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -1331,8 +1331,13 @@ open class NSMutableString : NSString {
         }
 
         let start = _storage.utf16.startIndex
-        let min = _storage.utf16.index(start, offsetBy: range.location).samePosition(in: _storage)!
-        let max = _storage.utf16.index(start, offsetBy: range.location + range.length).samePosition(in: _storage)!
+        let min = _storage.utf16.index(start, offsetBy: range.location).samePosition(in: _storage) ??
+            _storage.utf16.index(start, offsetBy: _storage.rangeOfComposedCharacterSequence(at: range.location).location)
+
+        let max = _storage.utf16.index(start, offsetBy: range.location + range.length).samePosition(in: _storage) ?? {
+            let range = _storage.rangeOfComposedCharacterSequence(at: range.location + range.length)
+            return _storage.utf16.index(start, offsetBy: range.location)
+        }()
         _storage.replaceSubrange(min..<max, with: aString)
     }
     

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -1272,5 +1272,37 @@ extension TestNSString {
 
         let replaceSuffixWithMultibyte = testString.replacingOccurrences(of: testSuffix, with: testReplacementEmoji)
         XCTAssertEqual(replaceSuffixWithMultibyte, testPrefix + testEmoji + testReplacementEmoji)
+
+        let str1 = "Hello\r\nworld."
+        XCTAssertEqual(str1.replacingOccurrences(of: "\n", with: " "), "Hello\r world.")
+        XCTAssertEqual(str1.replacingOccurrences(of: "\r", with: " "), "Hello \nworld.")
+        XCTAssertEqual(str1.replacingOccurrences(of: "\r\n", with: " "), "Hello world.")
+        XCTAssertEqual(str1.replacingOccurrences(of: "\r\n", with: "\n\r"), "Hello\n\rworld.")
+        XCTAssertEqual(str1.replacingOccurrences(of: "\r\n", with: "\r\n"), "Hello\r\nworld.")
+        XCTAssertEqual(str1.replacingOccurrences(of: "\n\r", with: " "), "Hello\r\nworld.")
+
+        let str2 = "Hello\n\rworld."
+        XCTAssertEqual(str2.replacingOccurrences(of: "\n", with: " "), "Hello \rworld.")
+        XCTAssertEqual(str2.replacingOccurrences(of: "\r", with: " "), "Hello\n world.")
+        XCTAssertEqual(str2.replacingOccurrences(of: "\r\n", with: " "), "Hello\n\rworld.")
+        XCTAssertEqual(str2.replacingOccurrences(of: "\n\r", with: " "), "Hello world.")
+        XCTAssertEqual(str2.replacingOccurrences(of: "\n\r", with: "\r\n"), "Hello\r\nworld.")
+        XCTAssertEqual(str2.replacingOccurrences(of: "\n\r", with: "\n\r"), "Hello\n\rworld.")
+
+        let str3 = "Hello\n\nworld."
+        XCTAssertEqual(str3.replacingOccurrences(of: "\n", with: " "), "Hello  world.")
+        XCTAssertEqual(str3.replacingOccurrences(of: "\r", with: " "), "Hello\n\nworld.")
+        XCTAssertEqual(str3.replacingOccurrences(of: "\r\n", with: " "), "Hello\n\nworld.")
+        XCTAssertEqual(str3.replacingOccurrences(of: "\r\n", with: "\n\r"), "Hello\n\nworld.")
+        XCTAssertEqual(str3.replacingOccurrences(of: "\r\n", with: "\r\n"), "Hello\n\nworld.")
+        XCTAssertEqual(str3.replacingOccurrences(of: "\n\r", with: " "), "Hello\n\nworld.")
+
+        let str4 = "Hello\r\rworld."
+        XCTAssertEqual(str4.replacingOccurrences(of: "\n", with: " "), "Hello\r\rworld.")
+        XCTAssertEqual(str4.replacingOccurrences(of: "\r", with: " "), "Hello  world.")
+        XCTAssertEqual(str4.replacingOccurrences(of: "\r\n", with: " "), "Hello\r\rworld.")
+        XCTAssertEqual(str4.replacingOccurrences(of: "\r\n", with: "\n\r"), "Hello\r\rworld.")
+        XCTAssertEqual(str4.replacingOccurrences(of: "\r\n", with: "\r\n"), "Hello\r\rworld.")
+        XCTAssertEqual(str4.replacingOccurrences(of: "\n\r", with: " "), "Hello\r\rworld.")
     }
 }


### PR DESCRIPTION
- "\r\n" is treated as a single character, but so are "\r" and "\n"
  so use rangeOfComposedCharacterSequence(at:) to find the range of the
  decomposed character.