### PR TITLE
<rdar://problem/43884430> Allow C code to link NSCFConstantString

### DIFF
--- a/Foundation/NSCFString.swift
+++ b/Foundation/NSCFString.swift
@@ -57,6 +57,7 @@ internal class _NSCFString : NSMutableString {
     }
 }
 
+@usableFromInline
 internal final class _NSCFConstantString : _NSCFString {
     internal var _ptr : UnsafePointer<UInt8> {
         // FIXME: Split expression as a work-around for slow type


### PR DESCRIPTION
When C code links against Foundation, it can't link to the NSCFConstantString because the symbol isn't exposed by the library. Using this attribute makes it visible, but not usable from Swift.