### PR TITLE
(Arm32) Fix 32-bit Variable Offset Issues with CoreFoundation

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -227,7 +227,7 @@ extern void __CFGenericValidateType_(CFTypeRef cf, CFTypeID type, const char *fu
 #define __CFBitfield64GetValue(V, N1, N2)	(((V) & __CFBitfield64Mask(N1, N2)) >> (N2))
 #define __CFBitfield64SetValue(V, N1, N2, X)	((V) = ((V) & ~__CFBitfield64Mask(N1, N2)) | ((((uint64_t)X) << (N2)) & __CFBitfield64Mask(N1, N2)))
 
-#if __LP64__ || DEPLOYMENT_TARGET_ANDROID
+#if defined(__LP64__) || defined(__LLP64__)
 typedef uint64_t __CFInfoType;
 #define __CFInfoMask(N1, N2) __CFBitfield64Mask(N1, N2)
 #else

--- a/CoreFoundation/Base.subproj/CFRuntime.h
+++ b/CoreFoundation/Base.subproj/CFRuntime.h
@@ -194,19 +194,18 @@ typedef struct __CFRuntimeBase {
     // This matches the isa and retain count storage in Swift
     uintptr_t _cfisa;
     uintptr_t _swift_rc;
-    // This is for CF's use, and must match _CFInfo layout
+    // This is for CF's use, and must match _CFInfo / _NSCFType layout
 #if defined(__LP64__) || defined(__LLP64__)
     _Atomic(uint64_t) _cfinfoa;
 #else
     _Atomic(uint32_t) _cfinfoa;
-    uint32_t          _padding;
 #endif
 } CFRuntimeBase;
 
 #if defined(__LP64__) || defined(__LLP64__)
 #define INIT_CFRUNTIME_BASE(...) {0, _CF_CONSTANT_OBJECT_STRONG_RC, 0x0000000000000080ULL}
 #else
-#define INIT_CFRUNTIME_BASE(...) {0, _CF_CONSTANT_OBJECT_STRONG_RC, 0x00000080UL, 0}
+#define INIT_CFRUNTIME_BASE(...) {0, _CF_CONSTANT_OBJECT_STRONG_RC, 0x00000080UL}
 #endif
 
 #else

--- a/CoreFoundation/Base.subproj/CFRuntime.h
+++ b/CoreFoundation/Base.subproj/CFRuntime.h
@@ -194,18 +194,19 @@ typedef struct __CFRuntimeBase {
     // This matches the isa and retain count storage in Swift
     uintptr_t _cfisa;
     uintptr_t _swift_rc;
-    // This is for CF's use, and must match _NSCFType layout
+    // This is for CF's use, and must match _CFInfo layout
 #if defined(__LP64__) || defined(__LLP64__)
     _Atomic(uint64_t) _cfinfoa;
 #else
     _Atomic(uint32_t) _cfinfoa;
+    uint32_t          _padding;
 #endif
 } CFRuntimeBase;
 
 #if defined(__LP64__) || defined(__LLP64__)
 #define INIT_CFRUNTIME_BASE(...) {0, _CF_CONSTANT_OBJECT_STRONG_RC, 0x0000000000000080ULL}
 #else
-#define INIT_CFRUNTIME_BASE(...) {0, _CF_CONSTANT_OBJECT_STRONG_RC, 0x00000080UL}
+#define INIT_CFRUNTIME_BASE(...) {0, _CF_CONSTANT_OBJECT_STRONG_RC, 0x00000080UL, 0}
 #endif
 
 #else

--- a/CoreFoundation/String.subproj/CFString.h
+++ b/CoreFoundation/String.subproj/CFString.h
@@ -160,6 +160,7 @@ struct __CFConstStr {
         uint64_t _cfinfoa;
 #else
         uint32_t _cfinfoa;
+        uint32_t _padding;
 #endif
     } _base;
     uint8_t *_ptr;

--- a/CoreFoundation/String.subproj/CFString.h
+++ b/CoreFoundation/String.subproj/CFString.h
@@ -160,7 +160,6 @@ struct __CFConstStr {
         uint64_t _cfinfoa;
 #else
         uint32_t _cfinfoa;
-        uint32_t _padding;
 #endif
     } _base;
     uint8_t *_ptr;

--- a/Foundation/NSObjCRuntime.swift
+++ b/Foundation/NSObjCRuntime.swift
@@ -215,16 +215,10 @@ internal func NSInvalidArgument(_ message: String, method: String = #function, f
 
 internal struct _CFInfo {
     // This must match _CFRuntimeBase
-    var info: UInt32
-    var pad : UInt32
+    var info: UInt
     init(typeID: CFTypeID) {
         // This matches what _CFRuntimeCreateInstance does to initialize the info value
-        info = UInt32((UInt32(typeID) << 8) | (UInt32(0x80)))
-        pad = 0
-    }
-    init(typeID: CFTypeID, extra: UInt32) {
-        info = UInt32((UInt32(typeID) << 8) | (UInt32(0x80)))
-        pad = extra
+        info = (typeID << 8) | 0x80
     }
 }
 

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -87,11 +87,11 @@ extension ObjCBool : CustomStringConvertible {
 #endif
 
 internal class __NSCFType : NSObject {
-    private var _cfinfo : Int32
+    private var _cfinfo : _CFInfo
     
     override init() {
         // This is not actually called; _CFRuntimeCreateInstance will initialize _cfinfo
-        _cfinfo = 0
+        _cfinfo = _CFInfo(typeID: 0)
     }
     
     override var hash: Int {


### PR DESCRIPTION
_CFInfo Assumes a 64-bit _cfinfoa type, when it is really 32-bit on 32-bit systems.
_NSCFType assumes a 32-bit _cfinfoa too, making things even more complicated.

This impacts Swift on arm32v7 platforms like Raspberry Pi 3, and has been causing crashes when using Foundation types that bridge between C and Swift, because shared instance variables are offset by 4 bytes (the extra padding). String being a common example. 

There's a couple approaches to addressing this:
1) Back _CFInfo with a UInt that, on paper, matches size with __CFInfoType
2) Add padding so we can guarantee that _CFInfo can always be 64-bit.

Which one you pick depends on if this is guaranteed to be true: Swift's UInt == CoreFoundation's __CFInfoType

Because Android has some interesting macros in the code that prevented me from answering this question with high confidence, this change picks option 2 which is less risky, even though it does mean an extra 4 bytes for each bridgable object. Option 1 would use less memory on 32-bit systems. 

In either case, it makes sense that __NSCFType should be backed by a _CFInfo instead
of a raw int type so that things remain consistent. Share types when possible so we have consistent, understandable behavior. Question is, does __NSCFType even get used anymore? Is it meant to back something else that always uses a 32-bit _cfinfo? 

In terms of validation, this was tested on Raspbian Stretch, using armhf architecture (armv7 specifically), using an existing project (http://github.com/Kaiede/RPiLight) that was able to produce the original bug against the swift-4.1.2-RELEASE tag doing a 'swift test' on the package. To validate against swift-4.1.2-RELEASE, I also needed to cherry-pick commit 1086b3bb8b859dae10a2a6d6fda4dbbcac2698ae which fixes another 32-bit issue. The swift RC field is 32-bit on arm32, not 64, so that commit is required for 32-bit to work as well.