### PR TITLE
Fix CoreFoundation.h header in standalone CF build

### DIFF
--- a/CoreFoundation/build.py
+++ b/CoreFoundation/build.py
@@ -110,7 +110,7 @@ module = 'Base.subproj/module.modulemap',
 public = [
 	'Stream.subproj/CFStream.h',
 	'String.subproj/CFStringEncodingExt.h',
-	'Base.subproj/SwiftRuntime/CoreFoundation.h',
+	'Base.subproj/CoreFoundation.h',
 	'Base.subproj/SwiftRuntime/TargetConditionals.h',
 	'RunLoop.subproj/CFMessagePort.h',
 	'Collections.subproj/CFBinaryHeap.h',


### PR DESCRIPTION
The SwiftRuntime header has a big warning in it saying not to use it unless you're building with the swift runtime, which this build.py doesn't do.

cc @millenomi 

Also, as a related aside: does this CoreFoundation/build.py get exercised by @swift-ci? I couldn't find any information on how to affect its behavior but I'd love to add a skeleton build to avoid it getting broken in future