### PR TITLE
Add back unnecessarily redacted headers that now exist

### DIFF
--- a/CoreFoundation/Base.subproj/CoreFoundation.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation.h
@@ -77,6 +77,8 @@
 #include <CoreFoundation/CFSocket.h>
 #include <CoreFoundation/CFMachPort.h>
 
+#include <CoreFoundation/CFAttributedString.h>
+#include <CoreFoundation/CFNotificationCenter.h>
 
 #endif
 

--- a/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
+++ b/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
@@ -92,6 +92,7 @@
 #include <CoreFoundation/CFSocket.h>
 #include <CoreFoundation/CFMachPort.h>
 #include <CoreFoundation/CFAttributedString.h>
+#include <CoreFoundation/CFNotificationCenter.h>
 
 #include <CoreFoundation/CFURLPriv.h>
 #include <CoreFoundation/CFURLComponents.h>


### PR DESCRIPTION
I think this might have been an artifact of the old CFLite redactions? Either way, these headers are now available in this repository. The real CoreFoundation guards these includes with `#ifndef CF_OPEN_SOURCE` but that doesn't seem relevant here. There are also other includes guarded
by that which are not (yet? 😆) available in this repository, so I did not include them here.

cc @millenomi @parkera it's hard for me as an outsider to know the "right" thing to do around `CF_OPEN_SOURCE` avoidance. I see a little bit of it still in this repo, but it's hard for me to know if that's appropriate here (in order to be more similar to the official CF) or if it's just going to be unconditionally available from now on. Any advice if I encounter more stuff like this?

Edit: I'm also unclear on how I should be keeping this CoreFoundaiton.h in sync with the one in SwiftRuntime. Should I make the same change there?