### PR TITLE
Improve CFAsmMacros platform checking

### DIFF
--- a/CoreFoundation/Base.subproj/CFAsmMacros.h
+++ b/CoreFoundation/Base.subproj/CFAsmMacros.h
@@ -14,8 +14,14 @@
 #define CONCAT_EXPANDED(a,b) CONCAT(a,b)
 #define _C_LABEL(name) CONCAT_EXPANDED(__USER_LABEL_PREFIX__,name)
 
-#if defined(__GNU__) || defined(__GNUC__) || defined(__ANDROID__) || defined(__FreeBSD__)
+/* Use .note.GNU-stack to explicitly indicate a non-exec stack, b/c of bad   */
+/* default behaviour when translating handwritten assembly files (needed on  */
+/* GNU/* platforms, Android and FreeBSD, as tests have shown).               */
+/* Platform tests are documented at http://git.savannah.gnu.org/gitweb/?p=libffcall.git;a=blob;f=porting-tools/execstack/README */
+#if (defined(__GNUC__) || defined (__llvm__) || defined (__clang__)) && defined(__ELF__) && (defined (__linux__) || defined (__linux) || defined (__gnu_linux__) || defined(__FreeBSD__) || defined (__FreeBSD_kernel__))
 #define NO_EXEC_STACK_DIRECTIVE .section .note.GNU-stack,"",%progbits
+#elsif defined(__SUNPRO_C) && defined(__linux__)
+#define NO_EXEC_STACK_DIRECTIVE .section ".note.GNU-stack"
 #else
 #define NO_EXEC_STACK_DIRECTIVE
 #endif


### PR DESCRIPTION
The old one would actually trigger GNUisms on macOS in some circumstances.

Credit to @yorickdowne as seen in this comment:
https://github.com/apple/swift-corelibs-foundation/commit/dcc7db1fa3167c6dca1fef18dd38b820952faa49#commitcomment-30473459