### PR TITLE
Revert "https://bugs.swift.org/browse/SR-6812"

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.h
+++ b/CoreFoundation/Base.subproj/CFRuntime.h
@@ -195,31 +195,23 @@ typedef struct __CFRuntimeBase {
     uintptr_t _cfisa;
     uintptr_t _swift_rc;
     // This is for CF's use, and must match _NSCFType layout
-#if defined(__LP64__) || defined(__LLP64__)
     _Atomic(uint64_t) _cfinfoa;
-#else
-    _Atomic(uint32_t) _cfinfoa;
-#endif
 } CFRuntimeBase;
 
-#if defined(__LP64__) || defined(__LLP64__)
 #define INIT_CFRUNTIME_BASE(...) {0, _CF_CONSTANT_OBJECT_STRONG_RC, 0x0000000000000080ULL}
-#else
-#define INIT_CFRUNTIME_BASE(...) {0, _CF_CONSTANT_OBJECT_STRONG_RC, 0x00000080UL}
-#endif
 
 #else
 
 typedef struct __CFRuntimeBase {
     uintptr_t _cfisa;
-#if defined(__LP64__) || defined(__LLP64__)
+#if __LP64__
     _Atomic(uint64_t) _cfinfoa;
 #else
     _Atomic(uint32_t) _cfinfoa;
 #endif
 } CFRuntimeBase;
 
-#if defined(__LP64__) || defined(__LLP64__)
+#if __LP64__
 #define INIT_CFRUNTIME_BASE(...) {0, 0x0000000000000080ULL}
 #else
 #define INIT_CFRUNTIME_BASE(...) {0, 0x00000080UL}

--- a/CoreFoundation/String.subproj/CFString.h
+++ b/CoreFoundation/String.subproj/CFString.h
@@ -156,11 +156,7 @@ struct __CFConstStr {
     struct {
         uintptr_t _cfisa;
         uintptr_t _swift_rc;
-#if defined(__LP64__) || defined(__LLP64__)
         uint64_t _cfinfoa;
-#else
-        uint32_t _cfinfoa;
-#endif
     } _base;
     uint8_t *_ptr;
 #if defined(__LP64__) && defined(__BIG_ENDIAN__)


### PR DESCRIPTION
Reverts apple/swift-corelibs-foundation#1557 as it double solves a problem on 32 bit systems solved in https://github.com/apple/swift-corelibs-foundation/pull/1525. The two fixes are incompatible with each other. See discussion on https://github.com/apple/swift-corelibs-foundation/pull/1689#issuecomment-421002218. I’ve built the 4.2 branch which doesn’t have this double fix on 32 bit android and the foundation tests run.