### PR TITLE
Align __NSCFType with CFRuntimeBase / _CFInfo

### DIFF
--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -87,11 +87,11 @@ extension ObjCBool : CustomStringConvertible {
 #endif
 
 internal class __NSCFType : NSObject {
-    private var _cfinfo : Int32
+    private var _cfinfo : _CFInfo
     
     override init() {
         // This is not actually called; _CFRuntimeCreateInstance will initialize _cfinfo
-        _cfinfo = 0
+        _cfinfo = _CFInfo(typeID: 0)
     }
     
     override var hash: Int {


### PR DESCRIPTION
__NSCFType has been using Int32 for _cfinfo. More recently in Swift 4, it’s been noticed that this can cause problems on 32-bit ARM and should be aligned with _CFInfo instead.

Currently, there are no known issues on 32-bit ARM because of this. However, it'd be nice to fix this before some future change breaks because _cfinfo is an Int32.