### PR TITLE
Initialize TSD on macOS even without Swift runtime

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -910,7 +910,7 @@ extern void __CFNumberInitialize(void);
 extern void __CFCharacterSetInitialize(void);
 extern void __CFPFactoryInitialize(void);
 extern void __CFPlugInInitialize(void);
-#if DEPLOYMENT_TARGET_LINUX || (DEPLOYMENT_TARGET_MACOSX && DEPLOYMENT_RUNTIME_SWIFT)
+#if DEPLOYMENT_TARGET_LINUX || DEPLOYMENT_TARGET_MACOSX
 CF_PRIVATE void __CFTSDInitialize(void);
 #endif
 #if DEPLOYMENT_TARGET_WINDOWS
@@ -1076,7 +1076,7 @@ void __CFInitialize(void) {
 #if DEPLOYMENT_TARGET_WINDOWS
         // Must not call any CF functions
         __CFTSDWindowsInitialize();
-#elif DEPLOYMENT_TARGET_LINUX || (DEPLOYMENT_TARGET_MACOSX && DEPLOYMENT_RUNTIME_SWIFT)
+#elif DEPLOYMENT_TARGET_LINUX || DEPLOYMENT_TARGET_MACOSX
         __CFTSDInitialize();
 #endif
         __CFProphylacticAutofsAccess = true;


### PR DESCRIPTION
Without this, you get some really fun to debug segfaults at runtime because (among other things I assume) `CFRunLoopGetCurrent` queries TSD to avoid doing the heavier `_CFRunLoopGet0` (which then sets the TSD to avoid later work). But if we don't initialize the TSD machinery, the `_CFGetTSD` function returns garbage and we never get a valid `CFRunLoopRef`.

cc @parkera @millenomi 

For context, I have the standalone framework working just fine for most things, but was getting some really weird runtime crashes whenever someone used a `CFRunLoop` 😄