### PR TITLE
Rename various ObjC-visible classes

### DIFF
--- a/Foundation/Array.swift
+++ b/Foundation/Array.swift
@@ -12,7 +12,7 @@ extension Array : _ObjectiveCBridgeable {
     public typealias _ObjectType = NSArray
     public func _bridgeToObjectiveC() -> _ObjectType {
         return NSArray(array: map { (element: Element) -> AnyObject in
-            return _SwiftValue.store(element)
+            return __SwiftValue.store(element)
         })
     }
     

--- a/Foundation/Bundle.swift
+++ b/Foundation/Bundle.swift
@@ -276,12 +276,12 @@ open class Bundle: NSObject {
     
     open var infoDictionary: [String : Any]? {
         let cfDict: CFDictionary? = CFBundleGetInfoDictionary(_bundle)
-        return _SwiftValue.fetch(cfDict) as? [String : Any]
+        return __SwiftValue.fetch(cfDict) as? [String : Any]
     }
     
     open var localizedInfoDictionary: [String : Any]? {
         let cfDict: CFDictionary? = CFBundleGetLocalInfoDictionary(_bundle)
-        return _SwiftValue.fetch(cfDict) as? [String : Any]
+        return __SwiftValue.fetch(cfDict) as? [String : Any]
     }
     
     open func object(forInfoDictionaryKey key: String) -> Any? {
@@ -299,7 +299,7 @@ open class Bundle: NSObject {
     }
     open var localizations: [String] {
         let cfLocalizations: CFArray? = CFBundleCopyBundleLocalizations(_bundle)
-        let nsLocalizations = _SwiftValue.fetch(cfLocalizations) as? [Any]
+        let nsLocalizations = __SwiftValue.fetch(cfLocalizations) as? [Any]
         return nsLocalizations?.map { $0 as! String } ?? []
     }
 
@@ -310,7 +310,7 @@ open class Bundle: NSObject {
 
     open class func preferredLocalizations(from localizationsArray: [String]) -> [String] {
         let cfLocalizations: CFArray? = CFBundleCopyPreferredLocalizationsFromArray(localizationsArray._cfObject)
-        let nsLocalizations = _SwiftValue.fetch(cfLocalizations) as? [Any]
+        let nsLocalizations = __SwiftValue.fetch(cfLocalizations) as? [Any]
         return nsLocalizations?.map { $0 as! String } ?? []
     }
     

--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -908,20 +908,20 @@ public final class _DataStorage {
         
         switch _backing {
         case .swift:
-            return _NSSwiftData(backing: self, range: range)
+            return __NSSwiftData(backing: self, range: range)
         case .immutable(let d):
             guard range.lowerBound == 0 && range.upperBound == _length else {
-                return _NSSwiftData(backing: self, range: range)
+                return __NSSwiftData(backing: self, range: range)
             }
             return d
         case .mutable(let d):
             guard range.lowerBound == 0 && range.upperBound == _length else {
-                return _NSSwiftData(backing: self, range: range)
+                return __NSSwiftData(backing: self, range: range)
             }
             return d
         case .customReference(let d):
             guard range.lowerBound == 0 && range.upperBound == d.length else {
-                return _NSSwiftData(backing: self, range: range)
+                return __NSSwiftData(backing: self, range: range)
             }
             return d
         case .customMutableReference(let d):
@@ -944,7 +944,7 @@ public final class _DataStorage {
     }
 }
 
-internal class _NSSwiftData : NSData {
+internal class __NSSwiftData : NSData {
     var _backing: _DataStorage!
     var _range: Range<Data.Index>!
     

--- a/Foundation/Dictionary.swift
+++ b/Foundation/Dictionary.swift
@@ -19,8 +19,8 @@ extension Dictionary : _ObjectiveCBridgeable {
         var idx = 0
         
         self.forEach { (keyItem, valueItem) in
-            let key = _SwiftValue.store(keyItem)
-            let value = _SwiftValue.store(valueItem)
+            let key = __SwiftValue.store(keyItem)
+            let value = __SwiftValue.store(valueItem)
             keyBuffer.advanced(by: idx).initialize(to: key)
             valueBuffer.advanced(by: idx).initialize(to: value)
             idx += 1
@@ -65,8 +65,8 @@ extension Dictionary : _ObjectiveCBridgeable {
             CFDictionaryGetKeysAndValues(cf, keys, values)
 
             for idx in 0..<cnt {
-                let key = _SwiftValue.fetch(nonOptional: unsafeBitCast(keys.advanced(by: idx).pointee!, to: AnyObject.self))
-                let value = _SwiftValue.fetch(nonOptional: unsafeBitCast(values.advanced(by: idx).pointee!, to: AnyObject.self))
+                let key = __SwiftValue.fetch(nonOptional: unsafeBitCast(keys.advanced(by: idx).pointee!, to: AnyObject.self))
+                let value = __SwiftValue.fetch(nonOptional: unsafeBitCast(values.advanced(by: idx).pointee!, to: AnyObject.self))
                 guard let k = key as? Key, let v = value as? Value else {
                     failedConversion = true
                     break

--- a/Foundation/HTTPCookieStorage.swift
+++ b/Foundation/HTTPCookieStorage.swift
@@ -216,7 +216,7 @@ open class HTTPCookieStorage: NSObject {
             persistDictionary[key] = cookie.persistableDictionary()
         }
 
-        let nsdict = _SwiftValue.store(persistDictionary) as! NSDictionary
+        let nsdict = __SwiftValue.store(persistDictionary) as! NSDictionary
         _ = nsdict.write(toFile: cookieFilePath, atomically: true)
     }
 

--- a/Foundation/JSONEncoder.swift
+++ b/Foundation/JSONEncoder.swift
@@ -2010,7 +2010,7 @@ extension _JSONDecoder {
 
         #if DEPLOYMENT_RUNTIME_SWIFT
         // Bridging differences require us to split implementations here
-        guard let number = _SwiftValue.store(value) as? NSNumber else {
+        guard let number = __SwiftValue.store(value) as? NSNumber else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -2043,7 +2043,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: Int.Type) throws -> Int? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = _SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+        guard let number = __SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -2058,7 +2058,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: Int8.Type) throws -> Int8? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = _SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+        guard let number = __SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -2073,7 +2073,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: Int16.Type) throws -> Int16? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = _SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+        guard let number = __SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -2088,7 +2088,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: Int32.Type) throws -> Int32? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = _SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+        guard let number = __SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -2103,7 +2103,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: Int64.Type) throws -> Int64? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = _SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+        guard let number = __SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -2118,7 +2118,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: UInt.Type) throws -> UInt? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = _SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+        guard let number = __SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -2133,7 +2133,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: UInt8.Type) throws -> UInt8? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = _SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+        guard let number = __SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -2148,7 +2148,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: UInt16.Type) throws -> UInt16? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = _SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+        guard let number = __SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -2163,7 +2163,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: UInt32.Type) throws -> UInt32? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = _SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+        guard let number = __SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -2178,7 +2178,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: UInt64.Type) throws -> UInt64? {
         guard !(value is NSNull) else { return nil }
 
-        guard let number = _SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+        guard let number = __SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
@@ -2193,7 +2193,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: Float.Type) throws -> Float? {
         guard !(value is NSNull) else { return nil }
 
-        if let number = _SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse {
+        if let number = __SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse {
             // We are willing to return a Float by losing precision:
             // * If the original value was integral,
             //   * and the integral value was > Float.greatestFiniteMagnitude, we will fail
@@ -2238,7 +2238,7 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: Double.Type) throws -> Double? {
         guard !(value is NSNull) else { return nil }
 
-        if let number = _SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse {
+        if let number = __SwiftValue.store(value) as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse {
             // We are always willing to return the number as a Double:
             // * If the original value was integral, it is guaranteed to fit in a Double; we are willing to lose precision past 2^53 if you encoded a UInt64 but requested a Double
             // * If it was a Float or Double, you will get back the precise value

--- a/Foundation/JSONSerialization.swift
+++ b/Foundation/JSONSerialization.swift
@@ -104,7 +104,7 @@ open class JSONSerialization : NSObject {
 
             // object is NSNumber and is not NaN or infinity
             // For better performance, this (most expensive) test should be last.
-            if let number = _SwiftValue.store(obj) as? NSNumber {
+            if let number = __SwiftValue.store(obj) as? NSNumber {
                 if CFNumberIsFloatType(number._cfObject) {
                     let dv = number.doubleValue
                     let invalid = dv.isInfinite || dv.isNaN
@@ -369,8 +369,8 @@ private struct JSONWriter {
             writer(num.description)
         case is NSNull:
             try serializeNull()
-        case _ where _SwiftValue.store(obj) is NSNumber:
-            try serializeNumber(_SwiftValue.store(obj) as! NSNumber)
+        case _ where __SwiftValue.store(obj) is NSNumber:
+            try serializeNumber(__SwiftValue.store(obj) as! NSNumber)
         default:
             throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.propertyListReadCorrupt.rawValue, userInfo: ["NSDebugDescription" : "Invalid object cannot be serialized"])
         }

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -24,7 +24,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         guard type(of: self) === NSArray.self || type(of: self) === NSMutableArray.self else {
            NSRequiresConcreteImplementation()
         }
-        return _SwiftValue.fetch(nonOptional: _storage[index])
+        return __SwiftValue.fetch(nonOptional: _storage[index])
     }
     
     public override init() {
@@ -136,8 +136,8 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         
         let optionalArray : [AnyObject] =
             copyItems ?
-                array.map { return _SwiftValue.store($0).copy() as! NSObject } :
-                array.map { return _SwiftValue.store($0) }
+                array.map { return __SwiftValue.store($0).copy() as! NSObject } :
+                array.map { return __SwiftValue.store($0) }
         
         // This would have been nice, but "initializer delegation cannot be nested in another expression"
 //        optionalArray.withUnsafeBufferPointer { ptr in
@@ -168,7 +168,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
 
     internal var allObjects: [Any] {
         if type(of: self) === NSArray.self || type(of: self) === NSMutableArray.self {
-            return _storage.map { _SwiftValue.fetch(nonOptional: $0) }
+            return _storage.map { __SwiftValue.fetch(nonOptional: $0) }
         } else {
             return (0..<count).map { idx in
                 return self[idx]
@@ -245,12 +245,12 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
     }
     
     open func firstObjectCommon(with otherArray: [Any]) -> Any? {
-        let set = otherArray.map { _SwiftValue.store($0) }
+        let set = otherArray.map { __SwiftValue.store($0) }
 
         for idx in 0..<count {
-            let item = _SwiftValue.store(self[idx])
+            let item = __SwiftValue.store(self[idx])
             if set.contains(item) {
-                return _SwiftValue.fetch(nonOptional: item)
+                return __SwiftValue.fetch(nonOptional: item)
             }
         }
         return nil
@@ -260,7 +260,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         objects.reserveCapacity(objects.count + range.length)
 
         if type(of: self) === NSArray.self || type(of: self) === NSMutableArray.self {
-            objects += _storage[Range(range)!].map { _SwiftValue.fetch(nonOptional: $0) }
+            objects += _storage[Range(range)!].map { __SwiftValue.fetch(nonOptional: $0) }
             return
         }
         
@@ -337,7 +337,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
             } else {
               let val1 = object(at: idx)
               let val2 = otherArray[idx]
-                if !_SwiftValue.store(val1).isEqual(_SwiftValue.store(val2)) {
+                if !__SwiftValue.store(val1).isEqual(__SwiftValue.store(val2)) {
                     return false
                 }
             }
@@ -731,7 +731,7 @@ open class NSMutableArray : NSArray {
         guard type(of: self) === NSMutableArray.self else {
             NSRequiresConcreteImplementation()
         }
-        _storage.insert(_SwiftValue.store(anObject), at: index)
+        _storage.insert(__SwiftValue.store(anObject), at: index)
     }
 
     open func insert(_ objects: [Any], at indexes: IndexSet) {
@@ -767,7 +767,7 @@ open class NSMutableArray : NSArray {
         }
         let min = index
         let max = index + 1
-        _storage.replaceSubrange(min..<max, with: [_SwiftValue.store(anObject) as AnyObject])
+        _storage.replaceSubrange(min..<max, with: [__SwiftValue.store(anObject) as AnyObject])
     }
     
     public override init() {
@@ -804,7 +804,7 @@ open class NSMutableArray : NSArray {
     
     open func addObjects(from otherArray: [Any]) {
         if type(of: self) === NSMutableArray.self {
-            _storage += otherArray.map { _SwiftValue.store($0) as AnyObject }
+            _storage += otherArray.map { __SwiftValue.store($0) as AnyObject }
         } else {
             for obj in otherArray {
                 add(obj)
@@ -888,10 +888,10 @@ open class NSMutableArray : NSArray {
         if type(of: self) === NSMutableArray.self {
             _storage.reserveCapacity(count - range.length + otherArray.count)
             for idx in 0..<range.length {
-                _storage[idx + range.location] = _SwiftValue.store(otherArray[idx])
+                _storage[idx + range.location] = __SwiftValue.store(otherArray[idx])
             }
             for idx in range.length..<otherArray.count {
-                _storage.insert(_SwiftValue.store(otherArray[idx]), at: idx + range.location)
+                _storage.insert(__SwiftValue.store(otherArray[idx]), at: idx + range.location)
             }
         } else {
             NSUnimplemented()
@@ -900,7 +900,7 @@ open class NSMutableArray : NSArray {
     
     open func setArray(_ otherArray: [Any]) {
         if type(of: self) === NSMutableArray.self {
-            _storage = otherArray.map { _SwiftValue.store($0) }
+            _storage = otherArray.map { __SwiftValue.store($0) }
         } else {
             replaceObjects(in: NSRange(location: 0, length: count), withObjectsFrom: otherArray)
         }

--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -342,7 +342,7 @@ open class NSMutableAttributedString : NSAttributedString {
     }
 
     open func addAttribute(_ name: NSAttributedStringKey, value: Any, range: NSRange) {
-        CFAttributedStringSetAttribute(_cfMutableObject, CFRange(range), name.rawValue._cfObject, _SwiftValue.store(value))
+        CFAttributedStringSetAttribute(_cfMutableObject, CFRange(range), name.rawValue._cfObject, __SwiftValue.store(value))
     }
 
     open func addAttributes(_ attrs: [NSAttributedStringKey : Any], range: NSRange) {

--- a/Foundation/NSCFArray.swift
+++ b/Foundation/NSCFArray.swift
@@ -34,11 +34,11 @@ internal final class _NSCFArray : NSMutableArray {
     
     override func object(at index: Int) -> Any {
         let value = CFArrayGetValueAtIndex(_cfObject, index)
-        return _SwiftValue.fetch(nonOptional: unsafeBitCast(value, to: AnyObject.self))
+        return __SwiftValue.fetch(nonOptional: unsafeBitCast(value, to: AnyObject.self))
     }
     
     override func insert(_ value: Any, at index: Int) {
-        let anObject = _SwiftValue.store(value)
+        let anObject = __SwiftValue.store(value)
         CFArrayInsertValueAtIndex(_cfMutableObject, index, unsafeBitCast(anObject, to: UnsafeRawPointer.self))
     }
     
@@ -60,7 +60,7 @@ internal func _CFSwiftArrayGetValueAtIndex(_ array: AnyObject, _ index: CFIndex)
     if type(of: array) === NSArray.self || type(of: array) === NSMutableArray.self {
         return Unmanaged.passUnretained(arr._storage[index])
     } else {
-        let value = _SwiftValue.store(arr.object(at: index))
+        let value = __SwiftValue.store(arr.object(at: index))
         let container: NSMutableDictionary
         if arr._storage.isEmpty {
             container = NSMutableDictionary()
@@ -82,7 +82,7 @@ internal func _CFSwiftArrayGetValues(_ array: AnyObject, _ range: CFRange, _ val
     } else {
         for idx in 0..<range.length {
             let index = idx + range.location
-            let value = _SwiftValue.store(arr.object(at: index))
+            let value = __SwiftValue.store(arr.object(at: index))
             let container: NSMutableDictionary
             if arr._storage.isEmpty {
                 container = NSMutableDictionary()

--- a/Foundation/NSCFDictionary.swift
+++ b/Foundation/NSCFDictionary.swift
@@ -37,9 +37,9 @@ internal final class _NSCFDictionary : NSMutableDictionary {
     }
     
     override func object(forKey aKey: Any) -> Any? {
-        let value = CFDictionaryGetValue(_cfObject, unsafeBitCast(_SwiftValue.store(aKey), to: UnsafeRawPointer.self))
+        let value = CFDictionaryGetValue(_cfObject, unsafeBitCast(__SwiftValue.store(aKey), to: UnsafeRawPointer.self))
         if value != nil {
-            return _SwiftValue.fetch(nonOptional: unsafeBitCast(value, to: AnyObject.self))
+            return __SwiftValue.fetch(nonOptional: unsafeBitCast(value, to: AnyObject.self))
         } else {
             return nil
         }
@@ -81,11 +81,11 @@ internal final class _NSCFDictionary : NSMutableDictionary {
     }
 
     override func removeObject(forKey aKey: Any) {
-        CFDictionaryRemoveValue(_cfMutableObject, unsafeBitCast(_SwiftValue.store(aKey), to: UnsafeRawPointer.self))
+        CFDictionaryRemoveValue(_cfMutableObject, unsafeBitCast(__SwiftValue.store(aKey), to: UnsafeRawPointer.self))
     }
     
     override func setObject(_ anObject: Any, forKey aKey: AnyHashable) {
-        CFDictionarySetValue(_cfMutableObject, unsafeBitCast(_SwiftValue.store(aKey), to: UnsafeRawPointer.self), unsafeBitCast(_SwiftValue.store(anObject), to: UnsafeRawPointer.self))
+        CFDictionarySetValue(_cfMutableObject, unsafeBitCast(__SwiftValue.store(aKey), to: UnsafeRawPointer.self), unsafeBitCast(__SwiftValue.store(anObject), to: UnsafeRawPointer.self))
     }
     
     override var classForCoder: AnyClass {
@@ -117,9 +117,9 @@ internal func _CFSwiftDictionaryGetValue(_ dictionary: AnyObject, key: AnyObject
             return Unmanaged<AnyObject>.passUnretained(obj)
         }
     } else {
-        let k = _SwiftValue.fetch(nonOptional: key)
+        let k = __SwiftValue.fetch(nonOptional: key)
         let value = dict.object(forKey: k)
-        let v = _SwiftValue.store(value)
+        let v = __SwiftValue.store(value)
         dict._storage[key as! NSObject] = v
         if let obj = v {
             return Unmanaged<AnyObject>.passUnretained(obj)
@@ -178,8 +178,8 @@ internal func _CFSwiftDictionaryGetValuesAndKeys(_ dictionary: AnyObject, valueb
         }
     } else {
         dict.enumerateKeysAndObjects(options: []) { k, v, _ in
-            let key = _SwiftValue.store(k)
-            let value = _SwiftValue.store(v)
+            let key = __SwiftValue.store(k)
+            let value = __SwiftValue.store(v)
             valuebuf?[idx] = Unmanaged<AnyObject>.passUnretained(value)
             keybuf?[idx] = Unmanaged<AnyObject>.passUnretained(key)
             dict._storage[key] = value
@@ -190,7 +190,7 @@ internal func _CFSwiftDictionaryGetValuesAndKeys(_ dictionary: AnyObject, valueb
 
 internal func _CFSwiftDictionaryApplyFunction(_ dictionary: AnyObject, applier: @convention(c) (AnyObject, AnyObject, UnsafeMutableRawPointer) -> Void, context: UnsafeMutableRawPointer) {
     (dictionary as! NSDictionary).enumerateKeysAndObjects(options: []) { key, value, _ in
-        applier(_SwiftValue.store(key), _SwiftValue.store(value), context)
+        applier(__SwiftValue.store(key), __SwiftValue.store(value), context)
     }
 }
 

--- a/Foundation/NSCFSet.swift
+++ b/Foundation/NSCFSet.swift
@@ -38,10 +38,10 @@ internal final class _NSCFSet : NSMutableSet {
     
     override func member(_ object: Any) -> Any? {
         
-        guard let value = CFSetGetValue(_cfObject, unsafeBitCast(_SwiftValue.store(object), to: UnsafeRawPointer.self)) else {
+        guard let value = CFSetGetValue(_cfObject, unsafeBitCast(__SwiftValue.store(object), to: UnsafeRawPointer.self)) else {
             return nil
         }
-        return _SwiftValue.fetch(nonOptional: unsafeBitCast(value, to: AnyObject.self))
+        return __SwiftValue.fetch(nonOptional: unsafeBitCast(value, to: AnyObject.self))
         
     }
     
@@ -66,11 +66,11 @@ internal final class _NSCFSet : NSMutableSet {
     }
     
     override func add(_ object: Any) {
-        CFSetAddValue(_cfMutableObject, unsafeBitCast(_SwiftValue.store(object), to: UnsafeRawPointer.self))
+        CFSetAddValue(_cfMutableObject, unsafeBitCast(__SwiftValue.store(object), to: UnsafeRawPointer.self))
     }
     
     override func remove(_ object: Any) {
-        CFSetRemoveValue(_cfMutableObject, unsafeBitCast(_SwiftValue.store(object), to: UnsafeRawPointer.self))
+        CFSetRemoveValue(_cfMutableObject, unsafeBitCast(__SwiftValue.store(object), to: UnsafeRawPointer.self))
     }
     
 }
@@ -106,7 +106,7 @@ internal func _CFSwiftSetGetValues(_ set: AnyObject, _ values: UnsafeMutablePoin
         }
     } else {
         set.enumerateObjects( { v, _ in
-            let value = _SwiftValue.store(v)
+            let value = __SwiftValue.store(v)
             values?[idx] = Unmanaged<AnyObject>.passUnretained(value)
             set._storage.update(with: value)
             idx += 1
@@ -122,7 +122,7 @@ internal func _CFSwiftSetGetValue(_ set: AnyObject, value: AnyObject, key: AnyOb
         }
         
     } else {
-        let v = _SwiftValue.store(set.member(value))
+        let v = __SwiftValue.store(set.member(value))
         if let obj = v {
             set._storage.update(with: obj)
             return Unmanaged<AnyObject>.passUnretained(obj)
@@ -143,7 +143,7 @@ internal func _CFSwiftSetGetValueIfPresent(_ set: AnyObject, object: AnyObject, 
 
 internal func _CFSwiftSetApplyFunction(_ set: AnyObject, applier: @convention(c) (AnyObject, UnsafeMutableRawPointer) -> Void, context: UnsafeMutableRawPointer) {
     (set as! NSSet).enumerateObjects({ value, _ in
-        applier(_SwiftValue.store(value), context)
+        applier(__SwiftValue.store(value), context)
     })
 }
 

--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -26,8 +26,8 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         guard type(of: self) === NSDictionary.self || type(of: self) === NSMutableDictionary.self else {
             NSRequiresConcreteImplementation()
         }
-        if let val = _storage[_SwiftValue.store(aKey)] {
-            return _SwiftValue.fetch(nonOptional: val)
+        if let val = _storage[__SwiftValue.store(aKey)] {
+            return __SwiftValue.fetch(nonOptional: val)
         }
         return nil
     }
@@ -41,7 +41,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
             NSRequiresConcreteImplementation()
         }
         
-        return NSGeneratorEnumerator(_storage.keys.map { _SwiftValue.fetch(nonOptional: $0) }.makeIterator())
+        return NSGeneratorEnumerator(_storage.keys.map { __SwiftValue.fetch(nonOptional: $0) }.makeIterator())
     }
     
     @available(*, deprecated)
@@ -136,7 +136,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
             mutableDictionary._storage = self._storage
             return mutableDictionary
         }
-        return NSMutableDictionary(objects: self.allValues, forKeys: self.allKeys.map { _SwiftValue.store($0) } )
+        return NSMutableDictionary(objects: self.allValues, forKeys: self.allKeys.map { __SwiftValue.store($0) } )
     }
 
     public convenience init(object: Any, forKey key: NSCopying) {
@@ -148,7 +148,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         keyBuffer.initialize(from: keys, count: keys.count)
 
         let valueBuffer = UnsafeMutablePointer<AnyObject>.allocate(capacity: objects.count)
-        valueBuffer.initialize(from: objects.map { _SwiftValue.store($0) }, count: objects.count)
+        valueBuffer.initialize(from: objects.map { __SwiftValue.store($0) }, count: objects.count)
 
         self.init(objects: valueBuffer, forKeys:keyBuffer, count: keys.count)
         
@@ -159,7 +159,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     }
     
     public convenience init(dictionary otherDictionary: [AnyHashable : Any]) {
-        self.init(objects: Array(otherDictionary.values), forKeys: otherDictionary.keys.map { _SwiftValue.store($0) })
+        self.init(objects: Array(otherDictionary.values), forKeys: otherDictionary.keys.map { __SwiftValue.store($0) })
     }
 
     open override func isEqual(_ value: Any?) -> Bool {
@@ -209,8 +209,8 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     open func getObjects(_ objects: inout [Any], andKeys keys: inout [Any], count: Int) {
         if type(of: self) === NSDictionary.self || type(of: self) === NSMutableDictionary.self {
             for (key, value) in _storage {
-                keys.append(_SwiftValue.fetch(nonOptional: key))
-                objects.append(_SwiftValue.fetch(nonOptional: value))
+                keys.append(__SwiftValue.fetch(nonOptional: key))
+                objects.append(__SwiftValue.fetch(nonOptional: value))
             }
         } else {
             
@@ -398,7 +398,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
             } else {
                 let otherBridgeable = otherDictionary[key as! AnyHashable]
                 let bridgeable = object(forKey: key)!
-                let equal = _SwiftValue.store(optional: otherBridgeable)?.isEqual(_SwiftValue.store(bridgeable))
+                let equal = __SwiftValue.store(optional: otherBridgeable)?.isEqual(__SwiftValue.store(bridgeable))
                 if equal != true {
                     return false
                 }
@@ -544,7 +544,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         var values = [Any]()
 
         for (key, value) in elements {
-            keys.append(_SwiftValue.store(key))
+            keys.append(__SwiftValue.store(key))
             values.append(value)
         }
         
@@ -578,7 +578,7 @@ open class NSMutableDictionary : NSDictionary {
             NSRequiresConcreteImplementation()
         }
 
-        _storage.removeValue(forKey: _SwiftValue.store(aKey))
+        _storage.removeValue(forKey: __SwiftValue.store(aKey))
     }
     
     /// - Note: this diverges from the darwin version that requires NSCopying (this differential preserves allowing strings and such to be used as keys)
@@ -586,7 +586,7 @@ open class NSMutableDictionary : NSDictionary {
         guard type(of: self) === NSDictionary.self || type(of: self) === NSMutableDictionary.self else {
             NSRequiresConcreteImplementation()
         }
-        _storage[_SwiftValue.store(aKey)] = _SwiftValue.store(anObject)
+        _storage[__SwiftValue.store(aKey)] = __SwiftValue.store(anObject)
     }
     
     public convenience required init() {

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -352,7 +352,7 @@ open class NSKeyedArchiver : NSCoder {
             return NSKeyedArchiveNullObjectReference
         }
         
-        let value = _SwiftValue.store(objv)!
+        let value = __SwiftValue.store(objv)!
         
         uid = self._objRefMap[value]
         if uid == nil {
@@ -376,7 +376,7 @@ open class NSKeyedArchiver : NSCoder {
         if objv == nil {
             return true // always have a null reference
         } else {
-            return self._objRefMap[_SwiftValue.store(objv!)] != nil
+            return self._objRefMap[__SwiftValue.store(objv!)] != nil
         }
     }
     
@@ -448,7 +448,7 @@ open class NSKeyedArchiver : NSCoder {
             unwrappedDelegate.archiver(self, willReplace: object, with: replacement)
         }
         
-        self._replacementMap[_SwiftValue.store(object)] = replacement
+        self._replacementMap[__SwiftValue.store(object)] = replacement
     }
    
     /**
@@ -597,7 +597,7 @@ open class NSKeyedArchiver : NSCoder {
         object = _replacementObject(objv)
         
         // bridge value types
-        object = _SwiftValue.store(object)
+        object = __SwiftValue.store(object)
         
         objectRef = _referenceObject(object, conditional: conditional)
         guard let unwrappedObjectRef = objectRef else {
@@ -852,7 +852,7 @@ open class NSKeyedArchiver : NSCoder {
         objectRefs.reserveCapacity(objects.count)
         
         for object in objects {
-            let objectRef = _encodeObject(_SwiftValue.store(object))!
+            let objectRef = _encodeObject(__SwiftValue.store(object))!
 
             objectRefs.append(objectRef)
         }

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -370,7 +370,7 @@ open class NSKeyedUnarchiver : NSCoder {
             unwrappedDelegate.unarchiver(self, willReplace: object, with: replacement)
         }
         
-        self._replacementMap[_SwiftValue.store(object)] = replacement
+        self._replacementMap[__SwiftValue.store(object)] = replacement
     }
     
     private func _decodingError(_ code: CocoaError.Code, withDescription description: String) -> NSError {
@@ -387,7 +387,7 @@ open class NSKeyedUnarchiver : NSCoder {
         }
         
         // check replacement cache
-        object = self._replacementMap[_SwiftValue.store(decodedObject!)]
+        object = self._replacementMap[__SwiftValue.store(decodedObject!)]
         if object != nil {
             return object
         }
@@ -483,7 +483,7 @@ open class NSKeyedUnarchiver : NSCoder {
                 _cacheObject(object!, forReference: objectRef as! _NSKeyedArchiverUID)
             }
         } else {
-            object = _SwiftValue.store(dereferencedObject)
+            object = __SwiftValue.store(dereferencedObject)
         }
 
         return _replacementObject(object)

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -28,7 +28,7 @@ open class NSLocale: NSObject, NSCopying, NSSecureCoding {
     }
     
     open func object(forKey key: NSLocale.Key) -> Any? {
-        return _SwiftValue.fetch(CFLocaleGetValue(_cfObject, key.rawValue._cfObject))
+        return __SwiftValue.fetch(CFLocaleGetValue(_cfObject, key.rawValue._cfObject))
     }
     
     open func displayName(forKey key: Key, value: String) -> String? {
@@ -103,31 +103,31 @@ extension NSLocale {
     }
     
     open class var availableLocaleIdentifiers: [String] {
-        return _SwiftValue.fetch(CFLocaleCopyAvailableLocaleIdentifiers()) as? [String] ?? []
+        return __SwiftValue.fetch(CFLocaleCopyAvailableLocaleIdentifiers()) as? [String] ?? []
     }
     
     open class var isoLanguageCodes: [String] {
-        return _SwiftValue.fetch(CFLocaleCopyISOLanguageCodes()) as? [String] ?? []
+        return __SwiftValue.fetch(CFLocaleCopyISOLanguageCodes()) as? [String] ?? []
     }
     
     open class var isoCountryCodes: [String] {
-        return _SwiftValue.fetch(CFLocaleCopyISOCountryCodes()) as? [String] ?? []
+        return __SwiftValue.fetch(CFLocaleCopyISOCountryCodes()) as? [String] ?? []
     }
     
     open class var isoCurrencyCodes: [String] {
-        return _SwiftValue.fetch(CFLocaleCopyISOCurrencyCodes()) as? [String] ?? []
+        return __SwiftValue.fetch(CFLocaleCopyISOCurrencyCodes()) as? [String] ?? []
     }
     
     open class var commonISOCurrencyCodes: [String] {
-        return _SwiftValue.fetch(CFLocaleCopyCommonISOCurrencyCodes()) as? [String] ?? []
+        return __SwiftValue.fetch(CFLocaleCopyCommonISOCurrencyCodes()) as? [String] ?? []
     }
     
     open class var preferredLanguages: [String] {
-        return _SwiftValue.fetch(CFLocaleCopyPreferredLanguages()) as? [String] ?? []
+        return __SwiftValue.fetch(CFLocaleCopyPreferredLanguages()) as? [String] ?? []
     }
     
     open class func components(fromLocaleIdentifier string: String) -> [String : String] {
-        return _SwiftValue.fetch(CFLocaleCreateComponentsFromLocaleIdentifier(kCFAllocatorSystemDefault, string._cfObject)) as? [String : String] ?? [:] 
+        return __SwiftValue.fetch(CFLocaleCreateComponentsFromLocaleIdentifier(kCFAllocatorSystemDefault, string._cfObject)) as? [String : String] ?? [:] 
     }
     
     open class func localeIdentifier(fromComponents dict: [String : String]) -> String {

--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -109,7 +109,7 @@ extension Sequence where Iterator.Element : NSNotificationReceiver {
             let nameSpecified = name != nil
             let differentName = observer.name != name
             let objectSpecified = object != nil
-            let differentSender = observer.sender !== _SwiftValue.store(object)
+            let differentSender = observer.sender !== __SwiftValue.store(object)
 
             return differentObserver || (nameSpecified  && differentName) || (objectSpecified && differentSender)
         }
@@ -127,7 +127,7 @@ extension Sequence where Iterator.Element : NSNotificationReceiver {
             let emptyName = observer.name == nil
             let sameName = observer.name == name
             let emptySender = observer.sender == nil
-            let sameSender = observer.sender === _SwiftValue.store(sender)
+            let sameSender = observer.sender === __SwiftValue.store(sender)
 
             return (emptySender || sameSender) && (emptyName || sameName)
         }
@@ -200,7 +200,7 @@ open class NotificationCenter: NSObject {
         newObserver.object = object
         newObserver.name = name
         newObserver.block = block
-        newObserver.sender = _SwiftValue.store(obj)
+        newObserver.sender = __SwiftValue.store(obj)
         newObserver.queue = queue
 
         _observersLock.synchronized({

--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -42,7 +42,7 @@ open class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
             preconditionFailure("Unkeyed coding is unsupported.")
         }
         for idx in 0..<self.count {
-            aCoder.encode(_SwiftValue.store(self.object(at: idx)), forKey:"NS.object.\(idx)")
+            aCoder.encode(__SwiftValue.store(self.object(at: idx)), forKey:"NS.object.\(idx)")
         }
     }
     
@@ -67,11 +67,11 @@ open class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     }
 
     open func object(at idx: Int) -> Any {
-        return _SwiftValue.fetch(nonOptional: _orderedStorage[idx])
+        return __SwiftValue.fetch(nonOptional: _orderedStorage[idx])
     }
 
     open func index(of object: Any) -> Int {
-        return _orderedStorage.index(of: _SwiftValue.store(object)) ?? NSNotFound
+        return _orderedStorage.index(of: __SwiftValue.store(object)) ?? NSNotFound
     }
 
     public convenience override init() {
@@ -100,7 +100,7 @@ open class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     }
 
     fileprivate func _insertObject(_ object: Any) {
-        let value = _SwiftValue.store(object)
+        let value = __SwiftValue.store(object)
         guard !contains(value) else {
             return
         }
@@ -118,7 +118,7 @@ open class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     
     internal var allObjects: [Any] {
         if type(of: self) === NSOrderedSet.self || type(of: self) === NSMutableOrderedSet.self {
-            return _orderedStorage.map { _SwiftValue.fetch(nonOptional: $0) }
+            return _orderedStorage.map { __SwiftValue.fetch(nonOptional: $0) }
         } else {
             return (0..<count).map { idx in
                 return self[idx]
@@ -158,7 +158,7 @@ extension NSOrderedSet {
 
     public var firstObject: Any? {
         if let value = _orderedStorage.first {
-            return _SwiftValue.fetch(nonOptional: value)
+            return __SwiftValue.fetch(nonOptional: value)
         } else {
             return nil
         }
@@ -166,7 +166,7 @@ extension NSOrderedSet {
 
     public var lastObject: Any? {
         if let value = _orderedStorage.last {
-            return _SwiftValue.fetch(nonOptional: value)
+            return __SwiftValue.fetch(nonOptional: value)
         } else {
             return nil
         }
@@ -190,7 +190,7 @@ extension NSOrderedSet {
     }
     
     open func contains(_ object: Any) -> Bool {
-        return _storage.contains(_SwiftValue.store(object))
+        return _storage.contains(__SwiftValue.store(object))
     }
 
     open func intersects(_ other: NSOrderedSet) -> Bool {
@@ -231,19 +231,19 @@ extension NSOrderedSet {
         guard type(of: self) === NSOrderedSet.self || type(of: self) === NSMutableOrderedSet.self else {
             NSRequiresConcreteImplementation()
         }
-        return NSGeneratorEnumerator(_orderedStorage.map { _SwiftValue.fetch(nonOptional: $0) }.makeIterator())
+        return NSGeneratorEnumerator(_orderedStorage.map { __SwiftValue.fetch(nonOptional: $0) }.makeIterator())
     }
 
     public func reverseObjectEnumerator() -> NSEnumerator { 
         guard type(of: self) === NSOrderedSet.self || type(of: self) === NSMutableOrderedSet.self else {
             NSRequiresConcreteImplementation()
         }
-        return NSGeneratorEnumerator(_orderedStorage.map { _SwiftValue.fetch(nonOptional: $0) }.reversed().makeIterator())
+        return NSGeneratorEnumerator(_orderedStorage.map { __SwiftValue.fetch(nonOptional: $0) }.reversed().makeIterator())
     }
     
     /*@NSCopying*/ 
     public var reversed: NSOrderedSet {
-        return NSOrderedSet(array: _orderedStorage.map { _SwiftValue.fetch(nonOptional: $0) }.reversed())
+        return NSOrderedSet(array: _orderedStorage.map { __SwiftValue.fetch(nonOptional: $0) }.reversed())
     }
     
     // These two methods return a facade object for the receiving ordered set,
@@ -298,7 +298,7 @@ extension NSOrderedSet {
     public convenience init(array: [Any]) {
         let buffer = UnsafeMutablePointer<AnyObject>.allocate(capacity: array.count)
         for (idx, element) in array.enumerated() {
-            buffer.advanced(by: idx).initialize(to: _SwiftValue.store(element))
+            buffer.advanced(by: idx).initialize(to: __SwiftValue.store(element))
         }
         self.init(objects: buffer, count: array.count)
         buffer.deinitialize(count: array.count)
@@ -342,7 +342,7 @@ open class NSMutableOrderedSet : NSOrderedSet {
             fatalError("\(self): Index out of bounds")
         }
 
-        let value = _SwiftValue.store(object)
+        let value = __SwiftValue.store(object)
 
         if contains(value) {
             return
@@ -362,8 +362,8 @@ open class NSMutableOrderedSet : NSOrderedSet {
             fatalError("\(self): Index out of bounds")
         }
         
-        let value = _SwiftValue.store(obj)
-        let objectToReplace = _SwiftValue.store(object(at: idx))
+        let value = __SwiftValue.store(obj)
+        let objectToReplace = __SwiftValue.store(object(at: idx))
         _orderedStorage[idx] = value
         _storage.remove(objectToReplace)
         _storage.insert(value)
@@ -382,7 +382,7 @@ open class NSMutableOrderedSet : NSOrderedSet {
     public required init?(coder aDecoder: NSCoder) { NSUnimplemented() }
 
     fileprivate func _removeObject(_ object: Any) {
-        let value = _SwiftValue.store(object)
+        let value = __SwiftValue.store(object)
         
         guard contains(object) else {
             return
@@ -426,8 +426,8 @@ extension NSMutableOrderedSet {
 
         let object1 = self.object(at: idx1)
         let object2 = self.object(at: idx2)
-        _orderedStorage[idx1] = _SwiftValue.store(object2)
-        _orderedStorage[idx2] = _SwiftValue.store(object1)
+        _orderedStorage[idx1] = __SwiftValue.store(object2)
+        _orderedStorage[idx2] = __SwiftValue.store(object1)
     }
 
     open func moveObjects(at indexes: IndexSet, to idx: Int) {
@@ -451,7 +451,7 @@ extension NSMutableOrderedSet {
     }
     
     open func setObject(_ obj: Any, at idx: Int) {
-        let object = _SwiftValue.store(obj)
+        let object = __SwiftValue.store(obj)
         _storage.insert(object)
         if idx == _orderedStorage.count {
             _orderedStorage.append(object)
@@ -497,7 +497,7 @@ extension NSMutableOrderedSet {
     }
     
     open func remove(_ val: Any) {
-        let object = _SwiftValue.store(val)
+        let object = __SwiftValue.store(val)
         
         _storage.remove(object)
         _orderedStorage.remove(at: index(of: val))
@@ -555,7 +555,7 @@ extension NSMutableOrderedSet {
 
         let swiftRange = Range(range)!
         _orderedStorage[swiftRange].sort { lhs, rhs in
-            return cmptr(_SwiftValue.fetch(nonOptional: lhs), _SwiftValue.fetch(nonOptional: rhs)) == .orderedAscending
+            return cmptr(__SwiftValue.fetch(nonOptional: lhs), __SwiftValue.fetch(nonOptional: rhs)) == .orderedAscending
         }
     }
 }

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -25,7 +25,7 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
         guard type(of: self) === NSSet.self || type(of: self) === NSMutableSet.self || type(of: self) === NSCountedSet.self else {
             NSRequiresConcreteImplementation()
         }
-        let value = _SwiftValue.store(object)
+        let value = __SwiftValue.store(object)
         guard let idx = _storage.index(of: value) else { return nil }
         return _storage[idx]
     }
@@ -34,7 +34,7 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
         guard type(of: self) === NSSet.self || type(of: self) === NSMutableSet.self || type(of: self) === NSCountedSet.self else {
             NSRequiresConcreteImplementation()
         }
-        return NSGeneratorEnumerator(_storage.map { _SwiftValue.fetch(nonOptional: $0) }.makeIterator())
+        return NSGeneratorEnumerator(_storage.map { __SwiftValue.fetch(nonOptional: $0) }.makeIterator())
     }
 
     public convenience override init() {
@@ -46,7 +46,7 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
         super.init()
         let buffer = UnsafeBufferPointer(start: objects, count: cnt)
         for obj in buffer {
-            _storage.insert(_SwiftValue.store(obj))
+            _storage.insert(__SwiftValue.store(obj))
         }
     }
     
@@ -134,7 +134,7 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
     public convenience init(array: [Any]) {
         let buffer = UnsafeMutablePointer<AnyObject>.allocate(capacity: array.count)
         for (idx, element) in array.enumerated() {
-            buffer.advanced(by: idx).initialize(to: _SwiftValue.store(element))
+            buffer.advanced(by: idx).initialize(to: __SwiftValue.store(element))
         }
         self.init(objects: buffer, count: array.count)
         buffer.deinitialize(count: array.count)
@@ -171,7 +171,7 @@ extension NSSet {
     
     open var allObjects: [Any] {
         if type(of: self) === NSSet.self || type(of: self) === NSMutableSet.self {
-            return _storage.map { _SwiftValue.fetch(nonOptional: $0) }
+            return _storage.map { __SwiftValue.fetch(nonOptional: $0) }
         } else {
             let enumerator = objectEnumerator()
             var items = [Any]()
@@ -224,7 +224,7 @@ extension NSSet {
     open func addingObjects(from other: Set<AnyHashable>) -> Set<AnyHashable> {
         var result = Set<AnyHashable>(minimumCapacity: Swift.max(count, other.count))
         if type(of: self) === NSSet.self || type(of: self) === NSMutableSet.self {
-            result.formUnion(_storage.map { _SwiftValue.fetch(nonOptional: $0) as! AnyHashable })
+            result.formUnion(_storage.map { __SwiftValue.fetch(nonOptional: $0) as! AnyHashable })
         } else {
             for case let obj as NSObject in self {
                 _ = result.insert(obj)
@@ -236,7 +236,7 @@ extension NSSet {
     open func addingObjects(from other: [Any]) -> Set<AnyHashable> {
         var result = Set<AnyHashable>(minimumCapacity: count)
         if type(of: self) === NSSet.self || type(of: self) === NSMutableSet.self {
-            result.formUnion(_storage.map { _SwiftValue.fetch(nonOptional: $0) as! AnyHashable })
+            result.formUnion(_storage.map { __SwiftValue.fetch(nonOptional: $0) as! AnyHashable })
         } else {
             for case let obj as AnyHashable in self {
                 result.insert(obj)
@@ -315,7 +315,7 @@ open class NSMutableSet : NSSet {
         guard type(of: self) === NSMutableSet.self else {
             NSRequiresConcreteImplementation()
         }
-        _storage.insert(_SwiftValue.store(object))
+        _storage.insert(__SwiftValue.store(object))
     }
     
     open func remove(_ object: Any) {
@@ -323,7 +323,7 @@ open class NSMutableSet : NSSet {
             NSRequiresConcreteImplementation()
         }
 
-        _storage.remove(_SwiftValue.store(object))
+        _storage.remove(__SwiftValue.store(object))
     }
     
     override public init(objects: UnsafePointer<AnyObject>!, count cnt: Int) {
@@ -345,7 +345,7 @@ open class NSMutableSet : NSSet {
     open func addObjects(from array: [Any]) {
         if type(of: self) === NSMutableSet.self {
             for case let obj in array {
-                _storage.insert(_SwiftValue.store(obj))
+                _storage.insert(__SwiftValue.store(obj))
             }
         } else {
             array.forEach(add)
@@ -354,7 +354,7 @@ open class NSMutableSet : NSSet {
     
     open func intersect(_ otherSet: Set<AnyHashable>) {
         if type(of: self) === NSMutableSet.self {
-            _storage.formIntersection(otherSet.map { _SwiftValue.store($0) })
+            _storage.formIntersection(otherSet.map { __SwiftValue.store($0) })
         } else {
             for obj in self {
                 if !otherSet.contains(obj as! AnyHashable) {
@@ -366,7 +366,7 @@ open class NSMutableSet : NSSet {
     
     open func minus(_ otherSet: Set<AnyHashable>) {
         if type(of: self) === NSMutableSet.self {
-            _storage.subtract(otherSet.map { _SwiftValue.store($0) })
+            _storage.subtract(otherSet.map { __SwiftValue.store($0) })
         } else {
             otherSet.forEach(remove)
         }
@@ -382,7 +382,7 @@ open class NSMutableSet : NSSet {
     
     open func union(_ otherSet: Set<AnyHashable>) {
         if type(of: self) === NSMutableSet.self {
-            _storage.formUnion(otherSet.map { _SwiftValue.store($0) })
+            _storage.formUnion(otherSet.map { __SwiftValue.store($0) })
         } else {
             otherSet.forEach(add)
         }
@@ -390,7 +390,7 @@ open class NSMutableSet : NSSet {
     
     open func setSet(_ otherSet: Set<AnyHashable>) {
         if type(of: self) === NSMutableSet.self {
-            _storage = Set(otherSet.map { _SwiftValue.store($0) })
+            _storage = Set(otherSet.map { __SwiftValue.store($0) })
         } else {
             removeAllObjects()
             union(otherSet)
@@ -415,7 +415,7 @@ open class NSCountedSet : NSMutableSet {
     public convenience init(array: [Any]) {
         self.init(capacity: array.count)
         for object in array {
-            let value = _SwiftValue.store(object)
+            let value = __SwiftValue.store(object)
             if let count = _table[value] {
                 _table[value] = count + 1
             } else {
@@ -455,7 +455,7 @@ open class NSCountedSet : NSMutableSet {
         guard type(of: self) === NSCountedSet.self else {
             NSRequiresConcreteImplementation()
         }
-        let value = _SwiftValue.store(object)
+        let value = __SwiftValue.store(object)
         guard let count = _table[value] else {
             return 0
         }
@@ -466,7 +466,7 @@ open class NSCountedSet : NSMutableSet {
         guard type(of: self) === NSCountedSet.self else {
             NSRequiresConcreteImplementation()
         }
-        let value = _SwiftValue.store(object)
+        let value = __SwiftValue.store(object)
         if let count = _table[value] {
             _table[value] = count + 1
         } else {
@@ -479,7 +479,7 @@ open class NSCountedSet : NSMutableSet {
         guard type(of: self) === NSCountedSet.self else {
             NSRequiresConcreteImplementation()
         }
-        let value = _SwiftValue.store(object)
+        let value = __SwiftValue.store(object)
         guard let count = _table[value] else {
             return
         }

--- a/Foundation/Notification.swift
+++ b/Foundation/Notification.swift
@@ -61,7 +61,7 @@ public struct Notification : ReferenceConvertible, Equatable, Hashable {
         }
         if let lhsObj = lhs.object {
             if let rhsObj = rhs.object {
-                if _SwiftValue.store(lhsObj) !== _SwiftValue.store(rhsObj) {
+                if __SwiftValue.store(lhsObj) !== __SwiftValue.store(rhsObj) {
                     return false
                 }
             } else {

--- a/Foundation/NotificationQueue.swift
+++ b/Foundation/NotificationQueue.swift
@@ -110,7 +110,7 @@ open class NotificationQueue: NSObject {
         switch coalesceMask {
         case [.onName, .onSender]:
             predicate = { entry in
-                return _SwiftValue.store(notification.object) !== _SwiftValue.store(entry.0.object) || notification.name != entry.0.name
+                return __SwiftValue.store(notification.object) !== __SwiftValue.store(entry.0.object) || notification.name != entry.0.name
             }
         case [.onName]:
             predicate = { entry in
@@ -118,7 +118,7 @@ open class NotificationQueue: NSObject {
             }
         case [.onSender]:
             predicate = { entry in
-                return _SwiftValue.store(notification.object) !== _SwiftValue.store(entry.0.object)
+                return __SwiftValue.store(notification.object) !== __SwiftValue.store(entry.0.object)
             }
         default:
             return

--- a/Foundation/NumberFormatter.swift
+++ b/Foundation/NumberFormatter.swift
@@ -89,7 +89,7 @@ open class NumberFormatter : Formatter {
     
     open override func string(for obj: Any) -> String? {
         //we need to allow Swift's numeric types here - Int, Double et al.
-        guard let number = _SwiftValue.store(obj) as? NSNumber else { return nil }
+        guard let number = __SwiftValue.store(obj) as? NSNumber else { return nil }
         return string(from: number)
     }
     

--- a/Foundation/PropertyListSerialization.swift
+++ b/Foundation/PropertyListSerialization.swift
@@ -44,7 +44,7 @@ open class PropertyListSerialization : NSObject {
 #else
         let fmt = CFPropertyListFormat(format.rawValue)
 #endif
-        let plistObj = _SwiftValue.store(plist)
+        let plistObj = __SwiftValue.store(plist)
         return CFPropertyListIsValid(plistObj, fmt)
     }
 
@@ -57,7 +57,7 @@ open class PropertyListSerialization : NSObject {
             let fmt = CFPropertyListFormat(format.rawValue)
 #endif
             let options = CFOptionFlags(opt)
-            let plistObj = _SwiftValue.store(plist)
+            let plistObj = __SwiftValue.store(plist)
             let d = CFPropertyListCreateData(kCFAllocatorSystemDefault, plistObj, fmt, options, outErr)
             return d?.takeRetainedValue()
         }
@@ -84,7 +84,7 @@ open class PropertyListSerialization : NSObject {
         if let err = error {
             throw err.takeUnretainedValue()._nsObject
         } else {
-            return _SwiftValue.fetch(nonOptional: decoded!)
+            return __SwiftValue.fetch(nonOptional: decoded!)
         }
     }
     
@@ -104,7 +104,7 @@ open class PropertyListSerialization : NSObject {
         if let err = error {
             throw err.takeUnretainedValue()._nsObject
         } else {
-            return _SwiftValue.fetch(nonOptional: decoded!)
+            return __SwiftValue.fetch(nonOptional: decoded!)
         }
     }
     

--- a/Foundation/Set.swift
+++ b/Foundation/Set.swift
@@ -41,7 +41,7 @@ extension Set : _ObjectiveCBridgeable {
                     set.insert(o)
                 } else {
                     // here obj must be a swift type
-                    if let nsObject = _SwiftValue.store(obj) as? Element {
+                    if let nsObject = __SwiftValue.store(obj) as? Element {
                         set.insert(nsObject)
                     } else {
                         failedConversion = true

--- a/Foundation/UserDefaults.swift
+++ b/Foundation/UserDefaults.swift
@@ -16,7 +16,7 @@ fileprivate func bridgeFromNSCFTypeIfNeeded(_ value: Any) -> Any {
     // This line will produce a 'Conditional cast always succeeds' warning if compoiled on Darwin, since Darwin has bridging casts of any value to an object,
     // but is required for non-Darwin to work correctly, since that platform _doesn't_ have bridging casts of that kind for now.
     if let object = value as? AnyObject {
-        return _SwiftValue.fetch(nonOptional: object)
+        return __SwiftValue.fetch(nonOptional: object)
     } else {
         return value
     }
@@ -118,7 +118,7 @@ open class UserDefaults: NSObject {
             return getFromRegistered()
         }
         
-        if let fetched = _SwiftValue.fetch(anObj) {
+        if let fetched = __SwiftValue.fetch(anObj) {
             return UserDefaults._unboxingNSNumbers(fetched)
         } else {
             return nil
@@ -145,7 +145,7 @@ open class UserDefaults: NSObject {
             fatalError("This value is not supported by set(_:forKey:)")
         }
         
-        CFPreferencesSetAppValue(defaultName._cfObject, _SwiftValue.store(value), suite?._cfObject ?? kCFPreferencesCurrentApplication)
+        CFPreferencesSetAppValue(defaultName._cfObject, __SwiftValue.store(value), suite?._cfObject ?? kCFPreferencesCurrentApplication)
     }
     open func removeObject(forKey defaultName: String) {
         CFPreferencesSetAppValue(defaultName._cfObject, nil, suite?._cfObject ?? kCFPreferencesCurrentApplication)
@@ -299,7 +299,7 @@ open class UserDefaults: NSObject {
             return registeredDefaultsIfAllowed
         }
         
-        let defaultsFromDiskWithNumbersBoxed = _SwiftValue.fetch(defaultsFromDiskCF) as? [String: Any] ?? [:]
+        let defaultsFromDiskWithNumbersBoxed = __SwiftValue.fetch(defaultsFromDiskCF) as? [String: Any] ?? [:]
         
         if registeredDefaultsIfAllowed.isEmpty {
             return UserDefaults._unboxingNSNumbers(defaultsFromDiskWithNumbersBoxed) as! [String: Any]


### PR DESCRIPTION
Swift is renaming some classes that are visible to Objective-C to avoid conflicts between older versions and ABI-stable versions. Change those names here as well.

This goes with this Swift PR: https://github.com/apple/swift/pull/19295

rdar://problem/35768222