### PR TITLE
SR-7608: Pipe() crashes when the underlying system call fails.

### DIFF
--- a/TestFoundation/TestFileHandle.swift
+++ b/TestFoundation/TestFileHandle.swift
@@ -1,17 +1,16 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2016, 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
 class TestFileHandle : XCTestCase {
     static var allTests : [(String, (TestFileHandle) -> () throws -> ())] {
         return [
             ("test_constants", test_constants),
-            ("test_pipe", test_pipe),
             ("test_nullDevice", test_nullDevice),
             ("test_truncateFile", test_truncateFile)
         ]
@@ -20,23 +19,6 @@ class TestFileHandle : XCTestCase {
     func test_constants() {
         XCTAssertEqual(FileHandle.readCompletionNotification.rawValue, "NSFileHandleReadCompletionNotification",
                        "\(FileHandle.readCompletionNotification.rawValue) is not equal to NSFileHandleReadCompletionNotification")
-    }
-
-    func test_pipe() {
-        let pipe = Pipe()
-        let inputs = ["Hello", "world", "🐶"]
-
-        for input in inputs {
-            let inputData = input.data(using: .utf8)!
-
-            // write onto pipe
-            pipe.fileHandleForWriting.write(inputData)
-
-            let outputData = pipe.fileHandleForReading.availableData
-            let output = String(data: outputData, encoding: .utf8)
-
-            XCTAssertEqual(output, input)
-        }
     }
 
     func test_nullDevice() {

--- a/TestFoundation/TestPipe.swift
+++ b/TestFoundation/TestPipe.swift
@@ -1,21 +1,41 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2016. 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-class TestPipe : XCTestCase {
+class TestPipe: XCTestCase {
     
     static var allTests: [(String, (TestPipe) -> () throws -> Void)] {
         return [
-             ("test_NSPipe", test_NSPipe)
+            ("test_MaxPipes", test_MaxPipes),
+            ("test_Pipe", test_Pipe),
         ]
     }
-    
-    func test_NSPipe() {
+
+    func test_MaxPipes() {
+        // Try and create enough pipes to exhaust the process's limits. 1024 is a reasonable
+        // hard limit for the test. This is reached when testing on Linux (at around 488 pipes)
+        // but not on macOS.
+
+        var pipes: [Pipe] = []
+        let maxPipes = 1024
+        pipes.reserveCapacity(maxPipes)
+        for _ in 1...maxPipes {
+            let pipe = Pipe()
+            if pipe.fileHandleForReading.fileDescriptor == -1 {
+                XCTAssertEqual(pipe.fileHandleForReading.fileDescriptor, pipe.fileHandleForWriting.fileDescriptor)
+                break
+            }
+            pipes.append(pipe)
+        }
+        pipes = []
+    }
+
+    func test_Pipe() {
         let aPipe = Pipe()
         let text = "test-pipe"
         


### PR DESCRIPTION
- Pipe does not have a failable or throwable initializer but currently
  calls fatalError() for all errors returned from pipe().

- If pipe() returns EMFILE or ENFILE then set the fileDescriptor
  to -1 for both .fileHandleForReading and .fileHandleForWriting.
  For all other errors call fatalError().

- TestFileHandle.swift: Remove duplicate test_pipe().

- TestPipe.swift: Add extra test to try and exhaust the process's pipes.

- Test the file descriptor is valid and open for certain methods
  and properties to match Darwin.