### PR TITLE
Fix a Couple Darwin Build Breaks on Xcode 10

### DIFF
--- a/TestFoundation/TestNSError.swift
+++ b/TestFoundation/TestNSError.swift
@@ -46,7 +46,7 @@ class TestNSError : XCTestCase {
         let nsdictionary = ["error": error] as NSDictionary
         let dictionary = nsdictionary as? Dictionary<String, Error>
         XCTAssertNotNil(dictionary)
-        XCTAssertEqual(error, dictionary?["error"] as NSError?)
+        XCTAssertEqual(error, dictionary?["error"] as? NSError)
     }
 
     func test_CustomNSError_domain() {

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -190,25 +190,25 @@ class TestNSString: LoopbackServerTest {
     }
 
     func test_doubleValue() {
-        XCTAssertEqual(NSString(".2").doubleValue, 0.2)
-        XCTAssertEqual(NSString("+.2").doubleValue, 0.2)
-        XCTAssertEqual(NSString("-.2").doubleValue, -0.2)
-        XCTAssertEqual(NSString("1.23015e+3").doubleValue, 1230.15)
-        XCTAssertEqual(NSString("12.3015e+02").doubleValue, 1230.15)
-        XCTAssertEqual(NSString("+1.23015e+3").doubleValue, 1230.15)
-        XCTAssertEqual(NSString("+12.3015e+02").doubleValue, 1230.15)
-        XCTAssertEqual(NSString("-1.23015e+3").doubleValue, -1230.15)
-        XCTAssertEqual(NSString("-12.3015e+02").doubleValue, -1230.15)
-        XCTAssertEqual(NSString("-12.3015e02").doubleValue, -1230.15)
-        XCTAssertEqual(NSString("-31.25e-04").doubleValue, -0.003125)
+        XCTAssertEqual(NSString(string: ".2").doubleValue, 0.2)
+        XCTAssertEqual(NSString(string: "+.2").doubleValue, 0.2)
+        XCTAssertEqual(NSString(string: "-.2").doubleValue, -0.2)
+        XCTAssertEqual(NSString(string: "1.23015e+3").doubleValue, 1230.15)
+        XCTAssertEqual(NSString(string: "12.3015e+02").doubleValue, 1230.15)
+        XCTAssertEqual(NSString(string: "+1.23015e+3").doubleValue, 1230.15)
+        XCTAssertEqual(NSString(string: "+12.3015e+02").doubleValue, 1230.15)
+        XCTAssertEqual(NSString(string: "-1.23015e+3").doubleValue, -1230.15)
+        XCTAssertEqual(NSString(string: "-12.3015e+02").doubleValue, -1230.15)
+        XCTAssertEqual(NSString(string: "-12.3015e02").doubleValue, -1230.15)
+        XCTAssertEqual(NSString(string: "-31.25e-04").doubleValue, -0.003125)
 
-        XCTAssertEqual(NSString(".e12").doubleValue, 0)
-        XCTAssertEqual(NSString("2e3.12").doubleValue, 2000)
-        XCTAssertEqual(NSString("1e2.3").doubleValue, 100)
-        XCTAssertEqual(NSString("12.e4").doubleValue, 120000)
-        XCTAssertEqual(NSString("1.2.3.4").doubleValue, 1.2)
-        XCTAssertEqual(NSString("1e2.3").doubleValue, 100)
-        XCTAssertEqual(NSString("1E3").doubleValue, 1000)
+        XCTAssertEqual(NSString(string: ".e12").doubleValue, 0)
+        XCTAssertEqual(NSString(string: "2e3.12").doubleValue, 2000)
+        XCTAssertEqual(NSString(string: "1e2.3").doubleValue, 100)
+        XCTAssertEqual(NSString(string: "12.e4").doubleValue, 120000)
+        XCTAssertEqual(NSString(string: "1.2.3.4").doubleValue, 1.2)
+        XCTAssertEqual(NSString(string: "1e2.3").doubleValue, 100)
+        XCTAssertEqual(NSString(string: "1E3").doubleValue, 1000)
     }
     
     func test_isEqualToStringWithSwiftString() {


### PR DESCRIPTION
A couple build break fixes for 10.14 + Xcode 10. Doesn't get Darwin completely building at master, but really helps clear out the noise. 

- NSString(_:) is internal, use NSString(string:) instead. Probably a better test as well.
- Clean up the cast for NSError. 