### PR TITLE
Fix CFInfo on 64-bit big endian platforms.

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -434,11 +434,7 @@ CF_EXPORT void * __CFConstantStringClassReferencePtr;
 #define CONST_STRING_SECTION
 #endif
 
-#if __BIG_ENDIAN__
-#define _CF_CONST_STR_CFINFOA 0x00000000C8070000
-#else // Little endian:
 #define _CF_CONST_STR_CFINFOA 0x07C8
-#endif // __BIG_ENDIAN__
 
 #define _CF_CONST_STR_CONTENTS(cStr) {{(uintptr_t)&_CF_CONSTANT_STRING_SWIFT_CLASS, _CF_CONSTANT_OBJECT_STRONG_RC, _CF_CONST_STR_CFINFOA}, (uint8_t *)(cStr), sizeof(cStr) - 1}
 

--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -362,17 +362,10 @@ void _CFEnableZombies(void) {
  On 64 bit, also includes 32 bits more of retain count from 32-63
  */
 
-#if __CF_BIG_ENDIAN__
-#define RC_INCREMENT		(1ULL)
-#define RC_CUSTOM_RC_BIT	(0x800000ULL << 32)
-#define RC_DEALLOCATING_BIT	(0x400000ULL << 32)
-#define RC_DEALLOCATED_BIT	(0x200000ULL << 32)
-#else
 #define RC_INCREMENT		(1ULL << 32)
 #define RC_CUSTOM_RC_BIT	(0x800000ULL)
 #define RC_DEALLOCATING_BIT	(0x400000ULL)
 #define RC_DEALLOCATED_BIT	(0x200000ULL)
-#endif
 
 #if TARGET_RT_64_BIT
 #define HIGH_RC_START 32

--- a/CoreFoundation/String.subproj/CFString.h
+++ b/CoreFoundation/String.subproj/CFString.h
@@ -167,24 +167,21 @@ struct __CFConstStr {
         uint64_t _cfinfoa;
     } _base;
     uint8_t *_ptr;
-#if TARGET_RT_64_BIT && defined(__BIG_ENDIAN__)
-    uint64_t _length;
-#else // 32-bit:
     uint32_t _length;
-#endif // TARGET_RT_64_BIT && defined(__BIG_ENDIAN__)
 };
 
-#if __BIG_ENDIAN__
 #define CFSTR(cStr)  ({ \
-    static struct __CFConstStr str = {{(uintptr_t)&_CF_CONSTANT_STRING_SWIFT_CLASS, _CF_CONSTANT_OBJECT_STRONG_RC, 0x00000000C8070000}, (uint8_t *)(cStr), sizeof(cStr) - 1}; \
+    static struct __CFConstStr str = { \
+        _base: { \
+            _cfisa: (uintptr_t)(&_CF_CONSTANT_STRING_SWIFT_CLASS), \
+            _swift_rc: _CF_CONSTANT_OBJECT_STRONG_RC, \
+            _cfinfoa: _CF_CONST_STR_CFINFOA \
+        }, \
+        _ptr: (uint8_t *)(cStr), \
+        _length: sizeof(cStr) - 1 \
+    }; \
     (CFStringRef)&str; \
 })
-#else // Little endian:
-#define CFSTR(cStr)  ({ \
-    static struct __CFConstStr str = {{(uintptr_t)&_CF_CONSTANT_STRING_SWIFT_CLASS, _CF_CONSTANT_OBJECT_STRONG_RC, 0x07C8}, (uint8_t *)(cStr), sizeof(cStr) - 1}; \
-    (CFStringRef)&str; \
-})
-#endif // __BIG_ENDIAN__
 
 #else
 

--- a/Foundation/NSObjCRuntime.swift
+++ b/Foundation/NSObjCRuntime.swift
@@ -215,17 +215,33 @@ internal func NSInvalidArgument(_ message: String, method: String = #function, f
 
 internal struct _CFInfo {
     // This must match _CFRuntimeBase
+#if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+    // 64-bit
+    var info: UInt64
+    init(typeID: CFTypeID) {
+        // This matches what _CFRuntimeCreateInstance does to initialize the info value
+        info = UInt64((UInt32(typeID) << 8) | 0x80)
+    }
+    init(typeID: CFTypeID, extra: UInt32) {
+        info = UInt64((UInt32(typeID) << 8) | 0x80)
+        info |= UInt64(extra) << 32
+    }
+#elseif arch(arm) || arch(i386)
+    // 32-bit
     var info: UInt32
     var pad : UInt32
     init(typeID: CFTypeID) {
         // This matches what _CFRuntimeCreateInstance does to initialize the info value
-        info = UInt32((UInt32(typeID) << 8) | (UInt32(0x80)))
+        info = (UInt32(typeID) << 8) | 0x80
         pad = 0
     }
     init(typeID: CFTypeID, extra: UInt32) {
-        info = UInt32((UInt32(typeID) << 8) | (UInt32(0x80)))
+        info = (UInt32(typeID) << 8) | 0x80
         pad = extra
     }
+#else
+#error("unknown architecture")
+#endif
 }
 
 // MARK: Classes to strings


### PR DESCRIPTION
Prior to this change 64-bit platforms treated _cfinfoa as both a
64-bit and 32-bit variable. When accessing _cfinfoa as a 32-bit
variable the code makes the assumption that it is accessing the
lowest (or rightmost) bits of _cfinfoa. Unfortunately on big-endian
platforms it is actually accessing the high (or leftmost) bits.

Fix this issue by unconditionally treating _cfinfoa as a 64-bit
value when targeting a 64-bit platform.