### PR TITLE
Non-Darwin SDKs product results in per-arch directories.

### DIFF
--- a/build.py
+++ b/build.py
@@ -551,12 +551,18 @@ if "LIBDISPATCH_BUILD_DIR" in Configuration.current.variables:
 
 Configuration.current.variables["LIBS_DIRS"] = LIBS_DIRS
 
-extra_script = """
+if "darwin" in triple.lower():
+    extra_script = "INSTALL_TARGET_DIR=${OS}"
+else:
+    extra_script = "INSTALL_TARGET_DIR=${OS}/${ARCH}"
+
+extra_script += """
+
 rule InstallFoundation
-    command = mkdir -p "${DSTROOT}/${PREFIX}/lib/swift/${OS}"; $
-    cp "${BUILD_DIR}/Foundation/${DYLIB_PREFIX}Foundation${DYLIB_SUFFIX}" "${DSTROOT}/${PREFIX}/lib/swift/${OS}"; $
-    mkdir -p "${DSTROOT}/${PREFIX}/lib/swift_static/${OS}"; $
-    cp "${BUILD_DIR}/Foundation/${STATICLIB_PREFIX}Foundation${STATICLIB_SUFFIX}" "${DSTROOT}/${PREFIX}/lib/swift_static/${OS}"; $
+    command = mkdir -p "${DSTROOT}/${PREFIX}/lib/swift/${INSTALL_TARGET_DIR}"; $
+    cp "${BUILD_DIR}/Foundation/${DYLIB_PREFIX}Foundation${DYLIB_SUFFIX}" "${DSTROOT}/${PREFIX}/lib/swift/${INSTALL_TARGET_DIR}"; $
+    mkdir -p "${DSTROOT}/${PREFIX}/lib/swift_static/${INSTALL_TARGET_DIR}"; $
+    cp "${BUILD_DIR}/Foundation/${STATICLIB_PREFIX}Foundation${STATICLIB_SUFFIX}" "${DSTROOT}/${PREFIX}/lib/swift_static/${INSTALL_TARGET_DIR}"; $
     mkdir -p "${DSTROOT}/${PREFIX}/lib/swift/${OS}/${ARCH}"; $
     cp "${BUILD_DIR}/Foundation/Foundation.swiftmodule" "${DSTROOT}/${PREFIX}/lib/swift/${OS}/${ARCH}/"; $
     cp "${BUILD_DIR}/Foundation/Foundation.swiftdoc" "${DSTROOT}/${PREFIX}/lib/swift/${OS}/${ARCH}/"; $


### PR DESCRIPTION
Depends on apple/swift#19432

Unix (other than Darwin) and Windows do not support fat binaries.
However, the build system was placing the build results in the
platform/OS folder, instead of the per-architecture folder. Having two
architectures side by side was impossible.

After applying the above patch in the Swift compiler, non-Darwin
platforms will look into the per-architecture folders, so the sibling
projects need to leave the products in the right place.

The change is performed in the CMakeList.txt file (which as far as I
understand is not used to build Foundation at the moment), and the
Python script.