### PR TITLE
Implement part of the value(forKey) method

### DIFF
--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -33,7 +33,12 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     }
     
     open func value(forKey key: String) -> Any? {
-        NSUnsupported()
+        if key.hasPrefix("@") {
+            NSUnsupported()
+        } else {
+            return object(forKey: key)
+        }
+        
     }
     
     open func keyEnumerator() -> NSEnumerator {

--- a/TestFoundation/TestNSDictionary.swift
+++ b/TestFoundation/TestNSDictionary.swift
@@ -21,6 +21,8 @@ class TestNSDictionary : XCTestCase {
             ("test_writeToFile", test_writeToFile),
             ("test_initWithContentsOfFile", test_initWithContentsOfFile),
             ("test_settingWithStringKey", test_settingWithStringKey),
+            ("test_valueForKey", test_valueForKey),
+            ("test_valueForKeyWithNestedDict", test_valueForKeyWithNestedDict),
         ]
     }
         
@@ -216,6 +218,19 @@ class TestNSDictionary : XCTestCase {
         let dict = NSMutableDictionary()
         // has crashed in the past
         dict["stringKey"] = "value"
+    }
+    
+    func test_valueForKey() {
+        let dict: NSDictionary = ["foo": "bar"]
+        let result = dict.value(forKey: "foo")
+        XCTAssert(result as? String == "bar")
+    }
+    
+    func test_valueForKeyWithNestedDict() {
+        let dict: NSDictionary = ["foo": ["bar": "baz"]]
+        let result = dict.value(forKey: "foo")
+        let expectedResult: NSDictionary = ["bar": "baz"]
+        XCTAssert(result as? NSDictionary == expectedResult)
     }
 
     private func createTestFile(_ path: String, _contents: Data) -> String? {

--- a/TestFoundation/TestNSDictionary.swift
+++ b/TestFoundation/TestNSDictionary.swift
@@ -223,14 +223,14 @@ class TestNSDictionary : XCTestCase {
     func test_valueForKey() {
         let dict: NSDictionary = ["foo": "bar"]
         let result = dict.value(forKey: "foo")
-        XCTAssert(result as? String == "bar")
+        XCTAssertEqual(result as? String, "bar")
     }
     
     func test_valueForKeyWithNestedDict() {
         let dict: NSDictionary = ["foo": ["bar": "baz"]]
         let result = dict.value(forKey: "foo")
         let expectedResult: NSDictionary = ["bar": "baz"]
-        XCTAssert(result as? NSDictionary == expectedResult)
+        XCTAssertEqual(result as? NSDictionary, expectedResult)
     }
 
     private func createTestFile(_ path: String, _contents: Data) -> String? {


### PR DESCRIPTION
In [NSDictionary](https://developer.apple.com/documentation/foundation/nsdictionary) the `value(forKey)` method is currently unsupported. 

This PR aims to implement part of this method based on the following [documentation](https://developer.apple.com/documentation/foundation/nsdictionary/1410210-value). That is the non-KVC path which calls out to the already implemented `object(forKey)` method. 

I've added a unit test for the new method which tests that `value(forKey)` does return the value we expect. I've also added a test for nested dictionaries. 

The KVC path, where the key has a `@` prefix, has been left unsupported. 