### PR TITLE
SR-8915: Remove redundant conformance constraints

### DIFF
--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -1696,7 +1696,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     }
     
     public subscript<R: RangeExpression>(_ rangeExpression: R) -> Data
-        where R.Bound: FixedWidthInteger, R.Bound.Stride : SignedInteger {
+        where R.Bound: FixedWidthInteger {
         @inline(__always)
         get {
             let lower = R.Bound(_sliceRange.lowerBound)

--- a/Foundation/NSRange.swift
+++ b/Foundation/NSRange.swift
@@ -251,7 +251,7 @@ extension NSRange {
 
 extension NSRange {
     public init<R: RangeExpression>(_ region: R)
-        where R.Bound: FixedWidthInteger, R.Bound.Stride : SignedInteger {
+        where R.Bound: FixedWidthInteger {
             let r = region.relative(to: 0..<R.Bound.max)
             location = numericCast(r.lowerBound)
             length = numericCast(r.count)


### PR DESCRIPTION
…'SignedInteger'

Remove the redundant conformance constraints on `Data[RangeExpression]`
and `NSRange.init<RangeExpression>(_:)`, silencing the compiler warning.