### PR TITLE
CFString: correct section for CFString section

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -416,10 +416,12 @@ CF_EXPORT void * __CFConstantStringClassReferencePtr;
 
 CF_EXPORT void *__CFConstantStringClassReference[];
 
-#if DEPLOYMENT_TARGET_LINUX
-#define CONST_STRING_SECTION __attribute__((section(".cfstr.data")))
+#if defined(__ELF__)
+#define CONST_STRING_SECTION __attribute__((__section__("cfstring")))
+#elif defined(__MACH__)
+#define CONST_STRING_SECTION __attribute__((__section__("__DATA,__cfstring")))
 #else
-#define CONST_STRING_SECTION
+#define CONST_STRING_SECTION __attribute__((__section__("cfstring")))
 #endif
 
 #define CONST_STRING_DECL(S, V) \

--- a/CoreFoundation/String.subproj/CFString.h
+++ b/CoreFoundation/String.subproj/CFString.h
@@ -170,10 +170,13 @@ struct __CFConstStr {
 #endif
 };
 
-#if DEPLOYMENT_TARGET_LINUX
-#define CONST_STRING_LITERAL_SECTION __attribute__((section(".cfstrlit.data")))
+
+#if defined(__ELF__)
+#define CONST_STRING_LITERAL_SECTION __attribute__((__section__("cfstring")))
+#elif defined(__MACH__)
+#define CONST_STRING_LITERAL_SECTION __attribute__((__section__("__DATA,__cfstring")))
 #else
-#define CONST_STRING_LITERAL_SECTION
+#define CONST_STRING_LITERAL_SECTION __attribute__((__section__("cfstring")))
 #endif
 
 #if __BIG_ENDIAN__


### PR DESCRIPTION
Re-synchronize the section that the CFString structure is emitted into
to match the behaviour of clang.  This is actually not determined by the
target OS but rather the target file format.  This makes the behaviour
match that of `__builtin___CFStringMakeConstantString`.