### PR TITLE
Fixed persian calendar segmentation fault

### DIFF
--- a/CoreFoundation/Locale.subproj/CFCalendar.c
+++ b/CoreFoundation/Locale.subproj/CFCalendar.c
@@ -273,6 +273,7 @@ CFCalendarRef CFCalendarCreateWithIdentifier(CFAllocatorRef allocator, CFStringR
     else if (CFEqual(kCFIslamicCalendar, identifier)) identifier = kCFIslamicCalendar;
     else if (CFEqual(kCFIslamicCivilCalendar, identifier)) identifier = kCFIslamicCivilCalendar;
     else if (CFEqual(kCFHebrewCalendar, identifier)) identifier = kCFHebrewCalendar;
+    else if (CFEqual(kCFPersianCalendar, identifier)) identifier = kCFPersianCalendar;
        else if (CFEqual(kCFISO8601Calendar, identifier)) identifier = kCFISO8601Calendar;
 //    else if (CFEqual(kCFChineseCalendar, identifier)) identifier = kCFChineseCalendar;
     else return NULL;

--- a/TestFoundation/TestCalendar.swift
+++ b/TestFoundation/TestCalendar.swift
@@ -17,7 +17,7 @@ class TestCalendar: XCTestCase {
             ("test_gettingDatesOnChineseCalendar", test_gettingDatesOnChineseCalendar),
             ("test_gettingDatesOnISO8601Calendar", test_gettingDatesOnISO8601Calendar),
             ("test_gettingDatesOnPersianCalendar,
-                test_gettingDatesOnPersianCalendar)
+                test_gettingDatesOnPersianCalendar),
             ("test_copy",test_copy),
             ("test_addingDates", test_addingDates),
             ("test_datesNotOnWeekend", test_datesNotOnWeekend),

--- a/TestFoundation/TestCalendar.swift
+++ b/TestFoundation/TestCalendar.swift
@@ -16,7 +16,7 @@ class TestCalendar: XCTestCase {
             ("test_gettingDatesOnHebrewCalendar", test_gettingDatesOnHebrewCalendar ),
             ("test_gettingDatesOnChineseCalendar", test_gettingDatesOnChineseCalendar),
             ("test_gettingDatesOnISO8601Calendar", test_gettingDatesOnISO8601Calendar),
-            ("test_gettingDatesOnPersianCalendar,
+            ("test_gettingDatesOnPersianCalendar",
                 test_gettingDatesOnPersianCalendar),
             ("test_copy",test_copy),
             ("test_addingDates", test_addingDates),

--- a/TestFoundation/TestCalendar.swift
+++ b/TestFoundation/TestCalendar.swift
@@ -16,6 +16,8 @@ class TestCalendar: XCTestCase {
             ("test_gettingDatesOnHebrewCalendar", test_gettingDatesOnHebrewCalendar ),
             ("test_gettingDatesOnChineseCalendar", test_gettingDatesOnChineseCalendar),
             ("test_gettingDatesOnISO8601Calendar", test_gettingDatesOnISO8601Calendar),
+            ("test_gettingDatesOnPersianCalendar,
+                test_gettingDatesOnPersianCalendar)
             ("test_copy",test_copy),
             ("test_addingDates", test_addingDates),
             ("test_datesNotOnWeekend", test_datesNotOnWeekend),
@@ -115,6 +117,18 @@ class TestCalendar: XCTestCase {
         XCTAssertEqual(components.month, 4)
         XCTAssertEqual(components.day, 15)
         XCTAssertEqual(components.isLeapMonth, true)
+    }
+
+    func test_gettingDatesOnPersianCalendar() {
+        let date = Date(timeIntervalSince1970: 1539146705)
+
+        var calendar = Calendar(identifier: .persian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        XCTAssertEqual(components.year, 1397)
+        XCTAssertEqual(components.month, 7)
+        XCTAssertEqual(components.day, 18)
+
     }
 
     func test_ampmSymbols() {


### PR DESCRIPTION
Currently, initializing a calendar with `.persian` identifier results in  segmentation fault error on linux.
This PR aims to remedy that.