### PR TITLE
build: strip DESTDIR when performing subinstall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,9 @@ ExternalProject_Add(CoreFoundation
                       -DCF_DEPLOYMENT_SWIFT=YES
                       -DCF_ENABLE_LIBDISPATCH=${FOUNDATION_ENABLE_LIBDISPATCH}
                       -DCF_PATH_TO_LIBDISPATCH_SOURCE=${FOUNDATION_PATH_TO_LIBDISPATCH_SOURCE}
-                      -DCF_PATH_TO_LIBDISPATCH_BUILD=${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD})
+                      -DCF_PATH_TO_LIBDISPATCH_BUILD=${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}
+                    INSTALL_COMMAND
+                      ${CMAKE_COMMAND} -E env --unset=DESTDIR ${CMAKE_COMMAND} --build . --target install)
 ExternalProject_Get_Property(CoreFoundation install_dir)
 
 set(swift_optimization_flags)


### PR DESCRIPTION
When setting up CoreFoundation for the Foundation build, we need to
strip out any preset DESTDIR to ensure that the installation is not
redirected to the install location for the Foundation build.