### PR TITLE
Add Support for i686 Targets

### DIFF
--- a/lib/target.py
+++ b/lib/target.py
@@ -53,6 +53,7 @@ class ArchType:
     shave       = 39
     armv6       = 40
     s390x       = 41
+    i686        = 42
 # Do not assume that these are 1:1 mapping.  This should follow
 # canonical naming conventions for arm, etc. architectures.
 # See apple/swift PR #608    
@@ -110,6 +111,8 @@ class ArchType:
             return "thumbeb"
         if value == ArchType.x86:
             return "i386"
+        if value == ArchType.i686:
+            return "i686"
         if value == ArchType.x86_64:
             return "x86_64"
         if value == ArchType.xcore:
@@ -202,6 +205,8 @@ class ArchType:
             return ArchType.thumbeb
         if string == "x86":
             return ArchType.x86
+        if string == "i686":
+            return ArchType.i686
         if string == "x86_64":
             return ArchType.x86_64
         if string == "xcore":


### PR DESCRIPTION
This enables build support for 32-bit Linux, specifically tested on Debian Stretch, which uses 'i686' as the architecture triple.