### PR TITLE
Revert Attempted Fix of SR6812

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.h
+++ b/CoreFoundation/Base.subproj/CFRuntime.h
@@ -194,19 +194,11 @@ typedef struct __CFRuntimeBase {
     // This matches the isa and retain count storage in Swift
     uintptr_t _cfisa;
     uintptr_t _swift_rc;
-    // This is for CF's use, and must match _NSCFType layout
-#if defined(__LP64__) || defined(__LLP64__)
+    // This is for CF's use, and must match __NSCFType/_CFInfo layout
     _Atomic(uint64_t) _cfinfoa;
-#else
-    _Atomic(uint32_t) _cfinfoa;
-#endif
 } CFRuntimeBase;
 
-#if defined(__LP64__) || defined(__LLP64__)
 #define INIT_CFRUNTIME_BASE(...) {0, _CF_CONSTANT_OBJECT_STRONG_RC, 0x0000000000000080ULL}
-#else
-#define INIT_CFRUNTIME_BASE(...) {0, _CF_CONSTANT_OBJECT_STRONG_RC, 0x00000080UL}
-#endif
 
 #else
 

--- a/CoreFoundation/String.subproj/CFString.h
+++ b/CoreFoundation/String.subproj/CFString.h
@@ -165,11 +165,7 @@ struct __CFConstStr {
     struct {
         uintptr_t _cfisa;
         uintptr_t _swift_rc;
-#if defined(__LP64__) || defined(__LLP64__)
         uint64_t _cfinfoa;
-#else // 32-bit:
-        uint32_t _cfinfoa;
-#endif // defined(__LP64__) || defined(__LLP64__)
     } _base;
     uint8_t *_ptr;
 #if defined(__LP64__) && defined(__BIG_ENDIAN__)


### PR DESCRIPTION
The original fix being reverted was #1557 made _cfinfoa 32-bit, which is generally correct, but it was really attempting to fix the same issue that #1525 had fixed. Historically, _cfinfoa has been 64-bit on Linux dating back to at least Swift 3.

In the short term, because forward fixing the issues with #1557 uncover other lurking 32-bit alignment issues on Linux, it is safer to revert #1557. But because it did make for some cleaner ifdefs on the Darwin side as well, the Darwin pieces are being left alone. Going forward, it will take some investigation to uncover the reasons behind the other 32-bit alongment issues.

Original context around this problem and previous attempted fixes/reverts:
#1689 
#1693 

This does not attempt to fix PPC Big-Endian Issues also present here, brought up in #1709. That PR will need to be brought into alignment with this one and #1694 