### PR TITLE
Update UUID to take advantage of SE-0205

### DIFF
--- a/Foundation/UUID.swift
+++ b/Foundation/UUID.swift
@@ -62,7 +62,7 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     /// Returns a string created from the UUID, such as "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"
     public var uuidString: String {
         var bytes: uuid_string_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        return withUnsafePointer(to: uuid) {
+        return withUnsafePointer(to: uuid) { valPtr in
             valPtr.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<uuid_t>.size) { val in
                 withUnsafeMutablePointer(to: &bytes) { strPtr in
                     strPtr.withMemoryRebound(to: CChar.self, capacity: MemoryLayout<uuid_string_t>.size) { str in

--- a/Foundation/UUID.swift
+++ b/Foundation/UUID.swift
@@ -62,8 +62,7 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     /// Returns a string created from the UUID, such as "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"
     public var uuidString: String {
         var bytes: uuid_string_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        var localValue = uuid
-        return withUnsafeMutablePointer(to: &localValue) { valPtr in
+        return withUnsafePointer(to: uuid) {
             valPtr.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<uuid_t>.size) { val in
                 withUnsafeMutablePointer(to: &bytes) { strPtr in
                     strPtr.withMemoryRebound(to: CChar.self, capacity: MemoryLayout<uuid_string_t>.size) { str in
@@ -76,10 +75,9 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     }
     
     public var hashValue: Int {
-        var localValue = uuid
-        return withUnsafeMutablePointer(to: &localValue) {
+        return withUnsafePointer(to: uuid) {
             $0.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<uuid_t>.size) {
-                return Int(bitPattern: CFHashBytes($0, CFIndex(MemoryLayout<uuid_t>.size)))
+                return Int(bitPattern: CFHashBytes(UnsafeMutablePointer(mutating: $0), CFIndex(MemoryLayout<uuid_t>.size)))
             }
         }
     }
@@ -95,8 +93,7 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     // MARK: - Bridging Support
     
     fileprivate var reference: NSUUID {
-        var bytes = uuid
-        return withUnsafePointer(to: &bytes) {
+        return withUnsafePointer(to: uuid) {
             $0.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<uuid_t>.size) {
                 return NSUUID(uuidBytes: $0)
             }


### PR DESCRIPTION
This updates UUID to use `withUnsafePointer` for `let`s

Now that SE-0205 has landed, we don't need to make local copies of the uuid byte tuples, in order to get pointers to them. We can use the new `withUnsafePointer` that works with `let`s.

This matches apple/swift#19775