### PR TITLE
Refactors NSOrderedSet.objects(at:) to use map(_:)

### DIFF
--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -156,12 +156,18 @@ extension NSOrderedSet {
         }
     }
 
+    /// Returns an array with the objects at the specified indexes in the
+    /// ordered set.
+    ///
+    /// - Parameter indexes: The indexes.
+    /// - Returns: An array of objects in the ascending order of their indexes
+    /// in `indexes`.
+    ///
+    /// - Complexity: O(*n*), where *n* is the number of indexes in `indexes`.
+    /// - Precondition: The indexes in `indexes` are within the
+    /// bounds of the ordered set.
     open func objects(at indexes: IndexSet) -> [Any] {
-        var entries = [Any]()
-        for idx in indexes {
-            entries.append(object(at: idx))
-        }
-        return entries
+        return indexes.map { object(at: $0) }
     }
 
     public var firstObject: Any? {

--- a/TestFoundation/TestNSOrderedSet.swift
+++ b/TestFoundation/TestNSOrderedSet.swift
@@ -109,11 +109,8 @@ class TestNSOrderedSet : XCTestCase {
 
     func test_ObjectsAtIndexes() {
         let set = NSOrderedSet(array: ["foo", "bar", "baz", "1", "2", "3"])
-        var indexSet = IndexSet()
-        indexSet.insert(1)
-        indexSet.insert(3)
-        indexSet.insert(5)
-        let objects = set.objects(at: indexSet)
+        let objects = set.objects(at: [1, 3, 5])
+        XCTAssertEqual(objects.count, 3)
         XCTAssertEqual(objects[0] as? String, "bar")
         XCTAssertEqual(objects[1] as? String, "1")
         XCTAssertEqual(objects[2] as? String, "3")


### PR DESCRIPTION
Also adds documentation comments for the method.