### PR TITLE
SR-8999: NSData contentsOf expects st_size to be the size of the file.

### DIFF
--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -35,7 +35,7 @@ open class FileHandle : NSObject, NSSecureCoding {
             let readResult = try _readDataOfLength(Int.max, untilEOF: false)
             return readResult.toData()
         } catch {
-            return Data()
+            fatalError("\(error)")
         }
     }
     
@@ -48,7 +48,7 @@ open class FileHandle : NSObject, NSSecureCoding {
             let readResult = try _readDataOfLength(length, untilEOF: true)
             return readResult.toData()
         } catch {
-            return Data()
+            fatalError("\(error)")
         }
     }
 

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -206,7 +206,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
 
         if url.isFileURL {
             let data = try NSData.readBytesFromFileWithExtendedAttributes(url.path, options: readOptionsMask)
-            readResult = NSData(bytesNoCopy: data.bytes, length: data.length, deallocator: data.deallocator)
+            readResult = data.toNSData()
         } else {
             let session = URLSession(configuration: URLSessionConfiguration.default)
             let cond = NSCondition()
@@ -410,102 +410,33 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
 
     // MARK: - IO
     internal struct NSDataReadResult {
-        var bytes: UnsafeMutableRawPointer
+        var bytes: UnsafeMutableRawPointer?
         var length: Int
-        var deallocator: ((_ buffer: UnsafeMutableRawPointer, _ length: Int) -> Void)?
+        var deallocator: ((_ buffer: UnsafeMutableRawPointer, _ length: Int) -> Void)!
+
+        func toNSData() -> NSData {
+            if bytes == nil {
+                return NSData()
+            }
+            return NSData(bytesNoCopy: bytes!, length: length, deallocator: deallocator)
+        }
+
+        func toData() -> Data {
+            guard let bytes = bytes else {
+                return Data()
+            }
+            return Data(bytesNoCopy: bytes, count: length, deallocator: Data.Deallocator.custom(deallocator))
+        }
     }
-    
+
     internal static func readBytesFromFileWithExtendedAttributes(_ path: String, options: ReadingOptions) throws -> NSDataReadResult {
-        let fd = _CFOpenFile(path, O_RDONLY)
-        if fd < 0 {
+        guard let handle = FileHandle(path: path, flags: O_RDONLY, createMode: 0) else {
             throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: nil)
         }
-        defer {
-            close(fd)
-        }
-
-        var info = stat()
-        let ret = withUnsafeMutablePointer(to: &info) { infoPointer -> Bool in
-            if fstat(fd, infoPointer) < 0 {
-                return false
-            }
-            return true
-        }
-        
-        if !ret {
-            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: nil)
-        }
-        
-        let length = Int(info.st_size)
-        if length == 0 && (info.st_mode & S_IFMT == S_IFREG) {
-            return try readZeroSizeFile(fd)
-        }
-
-        if options.contains(.alwaysMapped) {
-            let data = mmap(nil, length, PROT_READ, MAP_PRIVATE, fd, 0)
-            
-            // Swift does not currently expose MAP_FAILURE
-            if data != UnsafeMutableRawPointer(bitPattern: -1) {
-                return NSDataReadResult(bytes: data!, length: length) { buffer, length in
-                    munmap(buffer, length)
-                }
-            }
-            
-        }
-        
-        let data = malloc(length)!
-        var remaining = Int(info.st_size)
-        var total = 0
-        while remaining > 0 {
-            let amt = read(fd, data.advanced(by: total), remaining)
-            if amt < 0 {
-                break
-            }
-            remaining -= amt
-            total += amt
-        }
-
-        if remaining != 0 {
-            free(data)
-            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: nil)
-        }
-        
-        return NSDataReadResult(bytes: data, length: length) { buffer, length in
-            free(buffer)
-        }
+        let result = try handle._readDataOfLength(Int.max, untilEOF: true)
+        return result
     }
 
-    internal static func readZeroSizeFile(_ fd: Int32) throws -> NSDataReadResult {
-        let blockSize = 1024 * 1024 // 1MB
-        var data: UnsafeMutableRawPointer? = nil
-        var bytesRead = 0
-        var amt = 0
-
-        repeat {
-            data = realloc(data, bytesRead + blockSize)
-            amt = read(fd, data!.advanced(by: bytesRead), blockSize)
-
-            // Dont continue on EINTR or EAGAIN as the file position may not
-            // have changed, see read(2).
-            if amt < 0 {
-                free(data!)
-                throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: nil)
-            }
-            bytesRead += amt
-        } while amt > 0
-
-        if bytesRead == 0 {
-            free(data!)
-            data = malloc(0)
-        } else {
-            data = realloc(data, bytesRead) // shrink down the allocated block.
-        }
-
-        return NSDataReadResult(bytes: data!, length: bytesRead) { buffer, length in
-            free(buffer)
-        }
-    }
-    
     internal func makeTemporaryFile(inDirectory dirPath: String) throws -> (Int32, String) {
         let template = dirPath._nsObject.appendingPathComponent("tmp.XXXXXX")
         let maxLength = Int(PATH_MAX) + 1

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -185,6 +185,7 @@ class TestNSData: LoopbackServerTest {
             ("test_openingNonExistentFile", test_openingNonExistentFile),
             ("test_contentsOfFile", test_contentsOfFile),
             ("test_contentsOfZeroFile", test_contentsOfZeroFile),
+            ("test_wrongSizedFile", test_wrongSizedFile),
             ("test_contentsOfURL", test_contentsOfURL),
             ("test_basicReadWrite", test_basicReadWrite),
             ("test_bufferSizeCalculation", test_bufferSizeCalculation),
@@ -1491,6 +1492,17 @@ extension TestNSData {
         } catch {
             XCTFail("Cannot read /proc/self/maps: \(String(describing: error))")
         }
+#endif
+    }
+
+    func test_wrongSizedFile() {
+#if os(Linux)
+        // Some files in /sys report a non-zero st_size often bigger than the contents
+        guard let data = NSData.init(contentsOfFile: "/sys/kernel/profiling") else {
+            XCTFail("Cant read /sys/kernel/profiling")
+            return
+        }
+        XCTAssert(data.length > 0)
 #endif
     }
 


### PR DESCRIPTION
- Modify FileHandle._readDataOfLength(untilEOF:options:) to ignore
  stat.st_size and just use the result of read() to determine whether
  to keep reading.

- Also convert syscall error handling to throw instead of calling
  fatalError().

- NSData.readBytesFromFileWithExtendedAttributes(options:) now uses
  FileHandle._readDataOfLength(untilEOF:options:) to read from a file
  rather than duplicating the file reading logic.

- (Linux) Add a test to read a file in /sys which reports
  stat.st_size > size of the file's contents.