### PR TITLE
build: correctly handle dependencies

### DIFF
--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -81,6 +81,7 @@ function(add_swift_target target)
                          ${doc}
                        DEPENDS
                          ${source}
+                         ${AST_DEPENDS}
                        COMMAND
                          ${CMAKE_SWIFT_COMPILER} -frontend ${flags} -emit-module-path ${mod} -emit-module-doc-path ${doc} -o ${obj} -c ${all_sources})
 
@@ -103,6 +104,7 @@ function(add_swift_target target)
                        DEPENDS
                          ${mods}
                          ${docs}
+                         ${AST_DEPENDS}
                        COMMAND
                          ${CMAKE_SWIFT_COMPILER} -frontend ${flags} -sil-merge-partial-modules -emit-module ${mods} -o ${module} -emit-module-doc-path ${documentation})
   endif()
@@ -114,6 +116,7 @@ function(add_swift_target target)
                        ${AST_OUTPUT}
                      DEPENDS
                        ${objs}
+                       ${AST_DEPENDS}
                      COMMAND
                        ${CMAKE_SWIFT_COMPILER} ${emit_library} ${link_flags} -o ${AST_OUTPUT} ${objs})
   add_custom_target(${target}


### PR DESCRIPTION
Ensure that the dependencies are wired up to the build commands.  We
would previously not track them correctly.