### PR TITLE
build: adjust for split libdispatch SDK overlay

### DIFF
--- a/build.py
+++ b/build.py
@@ -126,7 +126,7 @@ if "LIBDISPATCH_SOURCE_DIR" in Configuration.current.variables:
 		'-I'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src/swift',
 		'-Xcc -fblocks'
 	])
-	foundation.LDFLAGS += '-ldispatch -L'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src -rpath \$$ORIGIN '
+	foundation.LDFLAGS += '-ldispatch -lswiftDispatch -L'+Configuration.current.variables["LIBDISPATCH_BUILD_DIR"]+'/src -rpath \$$ORIGIN '
 	foundation.LDFLAGS += '-L' + Configuration.current.variables['LIBDISPATCH_BUILD_DIR'] + ' -lBlocksRuntime '
 
 foundation.SWIFTCFLAGS = " ".join(swift_cflags)


### PR DESCRIPTION
This adjust the build to explicitly link against swiftDispatch to enable
the split SDK overlay on non-Darwin targets.  This would be fixed when
we switch over to the CMake based build which uses the swift driver to
link which will use the auto-link-extract functionality to make the ELF
targets build.