### PR TITLE
Add support for compiler-managed CFSTR() on non-Darwin systems

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -421,7 +421,7 @@ CF_PRIVATE Boolean __CFProcessIsRestricted(void);
 
 CF_EXPORT void * __CFConstantStringClassReferencePtr;
 
-#if DEPLOYMENT_RUNTIME_SWIFT
+#if DEPLOYMENT_RUNTIME_SWIFT && TARGET_OS_MAC
 
 #if DEPLOYMENT_TARGET_LINUX
 #define CONST_STRING_SECTION __attribute__((section(".cfstr.data")))

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -363,6 +363,12 @@ target_compile_options(CoreFoundation
                          -fconstant-cfstrings
                          -fdollars-in-identifiers
                          -fexceptions)
+if(CF_DEPLOYMENT_SWIFT)
+  target_compile_options(CoreFoundation
+                         PRIVATE
+                           -fcf-runtime-abi=swift)
+endif()
+
 target_compile_options(CoreFoundation
                        PRIVATE
                          -Wno-shorten-64-to-32

--- a/CoreFoundation/String.subproj/CFString.h
+++ b/CoreFoundation/String.subproj/CFString.h
@@ -152,14 +152,16 @@ since it is the default choice with Mac OS X developer tools.
 #endif
 
 #if DEPLOYMENT_RUNTIME_SWIFT
-
-#if TARGET_OS_MAC
-#define _CF_CONSTANT_STRING_SWIFT_CLASS $s15SwiftFoundation19_NSCFConstantStringCN
-#else
-#define _CF_CONSTANT_STRING_SWIFT_CLASS $s10Foundation19_NSCFConstantStringCN
-#endif
+    #if TARGET_OS_MAC
+        #define _CF_CONSTANT_STRING_SWIFT_CLASS $s15SwiftFoundation19_NSCFConstantStringCN
+    #else
+        #define _CF_CONSTANT_STRING_SWIFT_CLASS $s10Foundation19_NSCFConstantStringCN
+    #endif
 
 CF_EXPORT void *_CF_CONSTANT_STRING_SWIFT_CLASS[];
+#endif
+
+#if DEPLOYMENT_RUNTIME_SWIFT && TARGET_OS_MAC
 
 struct __CFConstStr {
     struct {
@@ -175,20 +177,14 @@ struct __CFConstStr {
 #endif // defined(__LP64__) || defined(__LLP64__)
 };
 
-#if TARGET_OS_LINUX
-#define CONST_STRING_LITERAL_SECTION __attribute__((section(".cfstrlit.data")))
-#else
-#define CONST_STRING_LITERAL_SECTION
-#endif // TARGET_OS_LINUX
-
 #if __BIG_ENDIAN__
 #define CFSTR(cStr)  ({ \
-    static struct __CFConstStr str CONST_STRING_LITERAL_SECTION = {{(uintptr_t)&_CF_CONSTANT_STRING_SWIFT_CLASS, _CF_CONSTANT_OBJECT_STRONG_RC, 0x00000000C8070000}, (uint8_t *)(cStr), sizeof(cStr) - 1}; \
+    static struct __CFConstStr str = {{(uintptr_t)&_CF_CONSTANT_STRING_SWIFT_CLASS, _CF_CONSTANT_OBJECT_STRONG_RC, 0x00000000C8070000}, (uint8_t *)(cStr), sizeof(cStr) - 1}; \
     (CFStringRef)&str; \
 })
 #else // Little endian:
 #define CFSTR(cStr)  ({ \
-    static struct __CFConstStr str CONST_STRING_LITERAL_SECTION = {{(uintptr_t)&_CF_CONSTANT_STRING_SWIFT_CLASS, _CF_CONSTANT_OBJECT_STRONG_RC, 0x07C8}, (uint8_t *)(cStr), sizeof(cStr) - 1}; \
+    static struct __CFConstStr str = {{(uintptr_t)&_CF_CONSTANT_STRING_SWIFT_CLASS, _CF_CONSTANT_OBJECT_STRONG_RC, 0x07C8}, (uint8_t *)(cStr), sizeof(cStr) - 1}; \
     (CFStringRef)&str; \
 })
 #endif // __BIG_ENDIAN__

--- a/build.py
+++ b/build.py
@@ -63,6 +63,7 @@ foundation.CFLAGS += " ".join([
 	'-Wno-int-conversion',
 	'-Wno-unused-function',
 	'-I./',
+	'-fcf-runtime-abi=swift',
 ])
 
 swift_cflags += [


### PR DESCRIPTION
This gets the swift-corelibs-foundation implementation closer to the Darwin implementation by making the compiler lay out constant CFStrings produced by CFSTR(). It requires a [corresponding clang patch](https://github.com/apple/swift-clang/pull/213) to work.

This is only enabled for not-`TARGET_OS_MAC` for now, since the clang used to build Swift here is not the same as the one used by Xcode when using a Swift toolchain. When Xcode gets the new clang, we can enable this for `TARGET_OS_MAC` as well.

rdar://42898576