### PR TITLE
NumberFormatter: Fix the pattern default .nostyle pattern for ICU62+

### DIFF
--- a/CoreFoundation/Locale.subproj/CFNumberFormatter.c
+++ b/CoreFoundation/Locale.subproj/CFNumberFormatter.c
@@ -133,11 +133,13 @@ CFNumberFormatterRef CFNumberFormatterCreate(CFAllocatorRef allocator, CFLocaleR
 	CFRelease(memory);
 	return NULL;
     }
-    UChar ubuff[4];
+
     if (kCFNumberFormatterNoStyle == style) {
+        UChar ubuff[1];
         status = U_ZERO_ERROR;
-	ubuff[0] = '#'; ubuff[1] = ';'; ubuff[2] = '#';
-        __cficu_unum_applyPattern(memory->_nf, false, ubuff, 3, NULL, &status);
+        ubuff[0] = '#';
+
+        __cficu_unum_applyPattern(memory->_nf, false, ubuff, 1, NULL, &status);
 	__cficu_unum_setAttribute(memory->_nf, UNUM_MAX_INTEGER_DIGITS, 42);
 	__cficu_unum_setAttribute(memory->_nf, UNUM_MAX_FRACTION_DIGITS, 0);
     }

--- a/Foundation/NumberFormatter.swift
+++ b/Foundation/NumberFormatter.swift
@@ -889,7 +889,7 @@ open class NumberFormatter : Formatter {
     internal var _format: String?
     open var format: String {
         get {
-            return _format ?? "#;0;#"
+            return _format ?? "#"
         }
         set {
             _reset()


### PR DESCRIPTION
- When using NumberFormatter with .nostyle (UNUM_PATTERN_DECIMAL) the
  default pattern '#;#' omits the '-' symbol when formatting negative
  numbers using ICU versions 62 or later.

- Use a default pattern of '#' which lets ICU automatically set the
  format for negative numbers. This pattern is the default used by
  ICU62.

- Tested on Ubuntu14.04 with ICU 52 and Ubuntu18.04 with ICU 63.1.