### PR TITLE
Fix linkage for Linux and BSD symbol declarations that use `CF_PRIVATE`

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -229,10 +229,10 @@ static CFRuntimeClass const * __CFRuntimeClassTable[__CFRuntimeClassTableSize] _
 
 #if TARGET_OS_MAC
     [_kCFRuntimeIDCFMachPort] = &__CFMachPortClass,
+    [_kCFRuntimeIDCFMessagePort] = &__CFMessagePortClass,
 #endif
 
 
-    [_kCFRuntimeIDCFMessagePort] = &__CFMessagePortClass,
     [_kCFRuntimeIDCFRunLoopMode] = &__CFRunLoopModeClass,
     [_kCFRuntimeIDCFRunLoop] = &__CFRunLoopClass,
     [_kCFRuntimeIDCFRunLoopSource] = &__CFRunLoopSourceClass,

--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -145,7 +145,7 @@ typedef int		boolean_t;
 
 #if DEPLOYMENT_TARGET_LINUX
     
-#define CF_PRIVATE __attribute__((visibility("hidden")))
+#define CF_PRIVATE extern __attribute__((visibility("hidden")))
 #define __weak
 
 #define strtod_l(a,b,locale) strtod(a,b)
@@ -235,7 +235,7 @@ CF_INLINE uint64_t mach_absolute_time() {
 #if DEPLOYMENT_TARGET_FREEBSD
 #define HAVE_STRUCT_TIMESPEC 1
 
-#define CF_PRIVATE __attribute__((visibility("hidden")))
+#define CF_PRIVATE extern __attribute__((visibility("hidden")))
 #define __strong
 #define __weak
 
@@ -455,7 +455,7 @@ CF_EXPORT int64_t OSAtomicAdd64Barrier( int64_t __theAmount, volatile int64_t *_
 #endif
 
 #if !defined(CF_PRIVATE)
-#define CF_PRIVATE __attribute__((__visibility__("hidden"))) extern
+#define CF_PRIVATE extern __attribute__((__visibility__("hidden")))
 #endif
     
     // [FIXED_35517899] We can't currently support this, but would like to leave things annotated

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -12,7 +12,7 @@
 #define __COREFOUNDATION_FORSWIFTFOUNDATIONONLY__ 1
 
 #if !defined(CF_PRIVATE)
-#define CF_PRIVATE __attribute__((__visibility__("hidden")))
+#define CF_PRIVATE extern __attribute__((__visibility__("hidden")))
 #endif
 
 #include <CoreFoundation/CFBase.h>

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -362,7 +362,8 @@ target_compile_options(CoreFoundation
                          -fblocks
                          -fconstant-cfstrings
                          -fdollars-in-identifiers
-                         -fexceptions)
+                         -fexceptions
+                         -fno-common)
 if(CF_DEPLOYMENT_SWIFT)
   target_compile_options(CoreFoundation
                          PRIVATE

--- a/CoreFoundation/Stream.subproj/CFStreamPriv.h
+++ b/CoreFoundation/Stream.subproj/CFStreamPriv.h
@@ -56,7 +56,7 @@ struct _CFStream;
 CF_EXPORT void* _CFStreamGetInfoPointer(struct _CFStream* stream);
 
 #if !defined(CF_PRIVATE)
-#define CF_PRIVATE __attribute__((__visibility__("hidden")))
+#define CF_PRIVATE extern __attribute__((__visibility__("hidden")))
 #endif
 
 // cb version must be > 0

--- a/build.py
+++ b/build.py
@@ -63,6 +63,7 @@ foundation.CFLAGS += " ".join([
 	'-Wno-int-conversion',
 	'-Wno-unused-function',
 	'-I./',
+	'-fno-common',
 	'-fcf-runtime-abi=swift',
 ])
 


### PR DESCRIPTION
Symbols using `CF_PRIVATE` are meant to be available outside the compilation unit where they're declared, but not outside Core Foundation. Headers that use `CF_PRIVATE` thus mean to declare, not define, these symbols. Match Darwin by adding `extern` to the `CF_PRIVATE` definition, and then add `-fno-common` to also match how Darwin compiles and detect double symbol definitions.

This fixes Linux crashes in CFString encoding introduced by the Mojave merge.