### PR TITLE
Mark FileManager.createFile as @discardableResult

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -1319,7 +1319,8 @@ open class FileManager : NSObject {
     open func contents(atPath path: String) -> Data? {
         return try? Data(contentsOf: URL(fileURLWithPath: path))
     }
-    
+
+    @discardableResult
     open func createFile(atPath path: String, contents data: Data?, attributes attr: [FileAttributeKey : Any]? = nil) -> Bool {
         do {
             try (data ?? Data()).write(to: URL(fileURLWithPath: path), options: .atomic)


### PR DESCRIPTION
On iOS / macOS this API comes from Objective-C which is implicitly
@discardableResult, this means it doesn't warn on those platforms, but
previously did on Linux