### PR TITLE
 Fix for handling of post with empty post body

### DIFF
--- a/Foundation/URLSession/http/HTTPURLProtocol.swift
+++ b/Foundation/URLSession/http/HTTPURLProtocol.swift
@@ -133,7 +133,8 @@ internal class _HTTPURLProtocol: _NativeProtocol {
         }
         let customHeaders: [String]
         let headersForRequest = curlHeaders(for: httpHeaders)
-        if ((request.httpMethod == "POST") && (request.value(forHTTPHeaderField: "Content-Type") == nil)) {
+        if ((request.httpMethod == "POST") && (request.httpBody?.count ?? 0 > 0)
+            && (request.value(forHTTPHeaderField: "Content-Type") == nil)) {
             customHeaders = headersForRequest + ["Content-Type:application/x-www-form-urlencoded"]
         } else {
             customHeaders = headersForRequest

--- a/TestFoundation/HTTPServer.swift
+++ b/TestFoundation/HTTPServer.swift
@@ -426,6 +426,13 @@ public class TestURLSessionServer {
             return _HTTPResponse(response: .OK, headers: "Content-Length: \(text.data(using: .utf8)!.count)", body: text)
         }
 
+        if uri == "/emptyPost" {
+            if request.body.count == 0 && request.getHeader(for: "Content-Type") == nil {
+                return _HTTPResponse(response: .OK, body: "")
+            }
+            return _HTTPResponse(response: .NOTFOUND, body: "")
+        }
+
         if uri == "/requestCookies" {
             let text = request.getCommaSeparatedHeaders()
             return _HTTPResponse(response: .OK, headers: "Content-Length: \(text.data(using: .utf8)!.count)\r\nSet-Cookie: fr=anjd&232; Max-Age=7776000; path=/\r\nSet-Cookie: nm=sddf&232; Max-Age=7776000; path=/; domain=.swift.org; secure; httponly\r\n", body: text)


### PR DESCRIPTION
This PR makes a small fix to the URLSession code for handling POST requests that avoids adding a `content-type` header when the POST body is empty.