### PR TITLE
CoreFoundation: use #include instead of #import

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -110,7 +110,7 @@ CF_EXTERN_C_BEGIN
 #include <pthread.h>
 
 #if !DEPLOYMENT_RUNTIME_SWIFT && __has_include(<os/log.h>)
-#import <os/log.h>
+#include <os/log.h>
 #else
 typedef struct os_log_s *os_log_t;
 #define os_log(...) do { } while (0)

--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -1311,7 +1311,7 @@ CF_PRIVATE int asprintf(char **ret, const char *format, ...) {
 #endif
 
 #if DEPLOYMENT_RUNTIME_SWIFT
-#import <fcntl.h>
+#include <fcntl.h>
 
 extern void swift_retain(void *);
 extern void swift_release(void *);

--- a/CoreFoundation/Base.subproj/CFUtilities.c
+++ b/CoreFoundation/Base.subproj/CFUtilities.c
@@ -46,7 +46,7 @@
 #include <crt_externs.h>
 #include <dlfcn.h>
 #include <vproc.h>
-#import <libproc.h>
+#include <libproc.h>
 #include <sys/sysctl.h>
 #include <sys/stat.h>
 #include <mach/mach.h>

--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -74,8 +74,8 @@ typedef char * Class;
 #define CRSetCrashLogMessage2(A) do {} while (0)
 
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI
-#import <libkern/OSAtomic.h>
-#import <pthread.h>
+#include <libkern/OSAtomic.h>
+#include <pthread.h>
 #endif
 
     

--- a/CoreFoundation/Collections.subproj/CFBasicHash.c
+++ b/CoreFoundation/Collections.subproj/CFBasicHash.c
@@ -8,16 +8,16 @@
 	Responsibility: Christopher Kane
 */
 
-#import "CFBasicHash.h"
-#import <CoreFoundation/CFRuntime.h>
-#import "CFRuntime_Internal.h"
-#import <CoreFoundation/CFSet.h>
-#import <Block.h>
-#import <math.h>
+#include "CFBasicHash.h"
+#include <CoreFoundation/CFRuntime.h>
+#include "CFRuntime_Internal.h"
+#include <CoreFoundation/CFSet.h>
+#include <Block.h>
+#include <math.h>
 #if __HAS_DISPATCH__
-#import <dispatch/dispatch.h>
+#include <dispatch/dispatch.h>
 #endif
-#import "CFOverflow.h"
+#include "CFOverflow.h"
 
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED
 #define __SetLastAllocationEventName(A, B) do { if (__CFOASafe && (A)) __CFSetLastAllocationEventName(A, B); } while (0)

--- a/CoreFoundation/Collections.subproj/CFData.c
+++ b/CoreFoundation/Collections.subproj/CFData.c
@@ -24,7 +24,7 @@
 #endif
 
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI
-#import <mach/mach.h>
+#include <mach/mach.h>
 CF_INLINE unsigned long __CFPageSize() { return vm_page_size; }
 #elif DEPLOYMENT_TARGET_WINDOWS
 CF_INLINE unsigned long __CFPageSize() {

--- a/CoreFoundation/Parsing.subproj/CFPropertyList_Private.h
+++ b/CoreFoundation/Parsing.subproj/CFPropertyList_Private.h
@@ -7,7 +7,7 @@
  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
  */
 
-#import <CoreFoundation/CFPropertyList.h>
+#include <CoreFoundation/CFPropertyList.h>
 
 // this is only allowed the first 8 bits
 typedef CF_OPTIONS(CFOptionFlags, CFPropertyListSupportedFormats) {

--- a/CoreFoundation/RunLoop.subproj/CFMachPort_Lifetime.c
+++ b/CoreFoundation/RunLoop.subproj/CFMachPort_Lifetime.c
@@ -5,9 +5,9 @@
     All of the functions in this file exist to orchestrate the exact time/circumstances we decrement the port references.
  */
 
-#import "CFMachPort_Lifetime.h"
-#import <mach/mach.h>
-#import "CFInternal.h"
+#include "CFMachPort_Lifetime.h"
+#include <mach/mach.h>
+#include "CFInternal.h"
 
 // Records information relevant for cleaning up after a given mach port. Here's
 // a summary of its life cycle:


### PR DESCRIPTION
`#import` when building for Windows will be treated as the import of a
type library rather than the semantics of Objective-C style `#import`
which does an include once type of operation.  Convert to the `#include`
syntax instead to allow this to be built on Windows as well (e.g. via
clang-cl).