### PR TITLE
Return Self instead of UnitLength in UnitLength override method

### DIFF
--- a/Foundation/Unit.swift
+++ b/Foundation/Unit.swift
@@ -206,7 +206,7 @@ open class Dimension : Unit {
      e.g.
      NSUnitSpeed *metersPerSecond = [NSUnitSpeed baseUnit];
      */
-    open class func baseUnit() -> Self {
+    open class func baseUnit() -> Dimension {
         fatalError("*** You must override baseUnit in your class to define its base unit.")
     }
     
@@ -1398,7 +1398,7 @@ open class UnitLength : Dimension {
         }
     }
     
-    open override class func baseUnit() -> Self {
+    open override class func baseUnit() -> UnitLength {
         return .meters
     }
     

--- a/Foundation/Unit.swift
+++ b/Foundation/Unit.swift
@@ -1398,7 +1398,7 @@ open class UnitLength : Dimension {
         }
     }
     
-    open override class func baseUnit() -> UnitLength {
+    open override class func baseUnit() -> Self {
         return .meters
     }
     


### PR DESCRIPTION
Fixes “cannot override a Self return type with a non-Self return type” error in Swift 5 compiler.