### PR TITLE
Change threadDictionary to NSMutableDictionary

### DIFF
--- a/Foundation/Progress.swift
+++ b/Foundation/Progress.swift
@@ -537,7 +537,7 @@ public struct ProgressUserInfoKey : RawRepresentable, Equatable, Hashable {
     public static let fileCompletedCountKey = ProgressUserInfoKey(rawValue: "NSProgressFileCompletedCountKey")
 }
 
-fileprivate class _ProgressTSD {
+fileprivate class _ProgressTSD : NSObject {
     /// The thread's default progress.
     fileprivate var currentProgress : Progress
     

--- a/Foundation/Thread.swift
+++ b/Foundation/Thread.swift
@@ -153,8 +153,8 @@ open class Thread : NSObject {
 #endif
     internal var _status = _NSThreadStatus.initialized
     internal var _cancelled = false
-    /// - Note: this differs from the Darwin implementation in that the keys must be Strings
-    open var threadDictionary = [String : Any]()
+    
+    open private(set) var threadDictionary: NSMutableDictionary = NSMutableDictionary()
 
     internal init(thread: pthread_t) {
         // Note: even on Darwin this is a non-optional pthread_t; this is only used for valid threads, which are never null pointers.

--- a/Foundation/XMLParser.swift
+++ b/Foundation/XMLParser.swift
@@ -471,7 +471,7 @@ open class XMLParser : NSObject {
         if let p = parser {
             Thread.current.threadDictionary["__CurrentNSXMLParser"] = p
         } else {
-            Thread.current.threadDictionary.removeValue(forKey: "__CurrentNSXMLParser")
+            Thread.current.threadDictionary.removeObject(forKey: "__CurrentNSXMLParser")
         }
     }
     


### PR DESCRIPTION
This PR changes type of `Thread.threadDictionary` to `NSMutableDictionary` from `Dictionary<String, Any>`.
The reasons are below.

1. Because apple's implementation for macOS/iOS is so.
   A current implementation is hard to write code which can be shared between Linux and iOS.
   I need to do for my project which has server side and client app.

2. `Key` which has `String` type is hard to avoid conflict among some independent modules.
   Though I can do by giving prefix like domain, 
   but this needs more runtime access cost to test equality of key in dictionary.
   With `NSMutableDictionary`, I can use `ObjectIdentifier` or `UnsafeRawPointer` of static key object.
   It is more safe from unexpected key conflict and cheap to test equality.

In original source, comment what about a implementation differs from Apple's is written.

```
/// - Note: this differs from the Darwin implementation in that the keys must be Strings
```

But the reason of this is not written.
So I worry about some intention in it.

And if some reason about not able to use `NSMutableDictionary`,
I think that `Dictionary<AnyHashable, Any>` is better for my 2nd reason.