### PR TITLE
Remove deprecated (now an error) conversion to Range.

### DIFF
--- a/Foundation/URLSession/Message.swift
+++ b/Foundation/URLSession/Message.swift
@@ -55,7 +55,7 @@ extension _NativeProtocol._ParsedResponseHeader {
             data[data.endIndex - 2] == _Delimiters.CR &&
             data[data.endIndex - 1] == _Delimiters.LF
             else { return nil }
-        let lineBuffer = data.subdata(in: Range(data.startIndex..<data.endIndex-2))
+        let lineBuffer = data.subdata(in: data.startIndex..<data.endIndex-2)
         guard let line = String(data: lineBuffer, encoding: .utf8) else { return nil}
         return byAppending(headerLine: line)
     }


### PR DESCRIPTION
Needed to build Foundation with Swift 5.