### PR TITLE
Conform URL, NSRange, and Date to CustomPlaygroundDisplayConvertible.

### DIFF
--- a/Foundation/Date.swift
+++ b/Foundation/Date.swift
@@ -254,17 +254,12 @@ extension Date : _ObjectiveCBridgeable {
     }
 }
 
-extension Date : CustomPlaygroundQuickLookable {
-    var summary: String {
+extension Date : CustomPlaygroundDisplayConvertible {
+    public var playgroundDescription: Any {
         let df = DateFormatter()
         df.dateStyle = .medium
         df.timeStyle = .short
         return df.string(from: self)
-    }
-
-    @available(*, deprecated, message: "Date.customPlaygroundQuickLook will be removed in a future Swift version") 
-    public var customPlaygroundQuickLook: PlaygroundQuickLook {
-        return .text(summary)
     }
 }
 

--- a/Foundation/NSRange.swift
+++ b/Foundation/NSRange.swift
@@ -309,10 +309,9 @@ extension NSRange : CustomReflectable {
     }
 }
 
-extension NSRange : CustomPlaygroundQuickLookable {
-    @available(*, deprecated, message: "NSRange.customPlaygroundQuickLook will be removed in a future Swift version")
-    public var customPlaygroundQuickLook: PlaygroundQuickLook {
-        return .range(Int64(location), Int64(length))
+extension NSRange : CustomPlaygroundDisplayConvertible {
+    public var playgroundDescription: Any {
+        return (Int64(location), Int64(length))
     }
 }
 

--- a/Foundation/URL.swift
+++ b/Foundation/URL.swift
@@ -991,10 +991,9 @@ extension URL : CustomStringConvertible, CustomDebugStringConvertible {
     }
 }
 
-extension URL : CustomPlaygroundQuickLookable {
-    @available(*, deprecated, message: "URL.customPlaygroundQuickLook will be removed in a future Swift version")
-    public var customPlaygroundQuickLook: PlaygroundQuickLook {
-        return .url(absoluteString)
+extension URL : CustomPlaygroundDisplayConvertible {
+    public var playgroundDescription: Any {
+        return absoluteString
     }
 }
 


### PR DESCRIPTION
Also remove conformances to deprecated CustomPlaygroundQuickLookable.

Needed for migration to Swift 5.