### PR TITLE
Mark _MutablePairHandle and _MutablePair as @usableFromInline

### DIFF
--- a/Foundation/IndexSet.swift
+++ b/Foundation/IndexSet.swift
@@ -837,6 +837,7 @@ extension NSIndexSet : _HasCustomAnyHashableRepresentation {
 /// Holds either the immutable or mutable version of a Foundation type.
 ///
 /// In many cases, the immutable type has optimizations which make it preferred when we know we do not need mutation.
+@usableFromInline
 internal enum _MutablePair<ImmutableType, MutableType> {
     case Default(ImmutableType)
     case Mutable(MutableType)
@@ -845,6 +846,7 @@ internal enum _MutablePair<ImmutableType, MutableType> {
 /// A class type which acts as a handle (pointer-to-pointer) to a Foundation reference type which has both an immutable and mutable class (e.g., NSData, NSMutableData).
 ///
 /// a.k.a. Box
+@usableFromInline
 internal final class _MutablePairHandle<ImmutableType : NSObject, MutableType : NSObject>
   where ImmutableType : NSMutableCopying, MutableType : NSMutableCopying {
     @usableFromInline

--- a/Foundation/NSCFString.swift
+++ b/Foundation/NSCFString.swift
@@ -10,6 +10,7 @@
 
 import CoreFoundation
 
+@usableFromInline
 internal class _NSCFString : NSMutableString {
     required init(characters: UnsafePointer<unichar>, length: Int) {
         fatalError()


### PR DESCRIPTION
Under Swift 5 mode we currently get the following error:

```
IndexSet.swift:154:18: error: type referenced from a '@usableFromInline' property must be '@usableFromInline' or public
01:12:50     internal var _handle: _MutablePairHandle<NSIndexSet, NSMutableIndexSet>
```

This change is technically ABI impacting for corelibs-Foundation.