### PR TITLE
Change another convenience initializer to use a runtime cast.

### DIFF
--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -762,7 +762,7 @@ open class NSNumber : NSValue {
     }
 
     public convenience init(value: Bool) {
-        self.init(factory: value._bridgeToObjectiveC)
+        self.init(factory: cast(value._bridgeToObjectiveC))
     }
 
     override internal init() {


### PR DESCRIPTION
This enforces requirement of Self return value; addresses an error in Swift 5 mode.