### PR TITLE
Build Foundation tests in Swift 4 mode to work around @autoclosure regression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,6 +411,8 @@ if(ENABLE_TESTING)
                          ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSKeyedUnarchiver-OrderedSetTest.plist
                          ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/TestFileWithZeros.txt
                        SWIFT_FLAGS
+                         # force -swift-version 4 to work around @autoclosure bug in -swift-version 5
+                         -swift-version 4
                          ${deployment_enable_libdispatch}
                          -I;${CMAKE_CURRENT_BINARY_DIR}/swift
                          -I;${FOUNDATION_PATH_TO_XCTEST_BUILD}/swift


### PR DESCRIPTION
There is a regression in `-swift-version 5` mode when forwarding `@autoclosure` closures from
one function to another.  Temporarily build `TestFoundation` in `-swift-version 4` mode to unblock
bumping the compiler's default to `-swift-version 5`.  This should be removed later.