### PR TITLE
Remove extra installed copy of libFoundation.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,9 +59,6 @@ if(FOUNDATION_ENABLE_LIBDISPATCH)
   set(deployment_enable_libdispatch -DDEPLOYMENT_ENABLE_LIBDISPATCH)
   set(libdispatch_cflags -I;${FOUNDATION_PATH_TO_LIBDISPATCH_SOURCE};-I;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src/swift;-Xcc;-fblocks)
   set(libdispatch_ldflags -L;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD};-L;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src;-ldispatch)
-  if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
-    list(APPEND libdispatch_ldflags -Xlinker;-rpath;-Xlinker;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src)
-  endif()
 endif()
 
 add_swift_library(Foundation
@@ -465,12 +462,6 @@ install(FILES
           CoreFoundation/Base.subproj/module.map
         DESTINATION
           lib/swift/CoreFoundation)
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  install(FILES
-            ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}Foundation${CMAKE_SHARED_LIBRARY_SUFFIX}
-          DESTINATION
-            lib/swift/${swift_os}/${swift_arch})
-endif()
 install(FILES
           ${CMAKE_CURRENT_BINARY_DIR}/plutil
         DESTINATION


### PR DESCRIPTION
- Currently libFoundation.so exists in 2 places in the distribution
  tarfile:

  ./usr/lib/swift/linux/x86_64/libFoundation.so
  ./usr/lib/swift/linux/libFoundation.so

- ld.so will load the first one located in x86_64 subdirectory which
  will then set $ORIGIN to this directory. Consequently, the libICU
  shared libraries required by libFoundation.so will not be found.

- Update CMakeLists.txt to not install libFoundation.so in the x86_64
  directory.

- Also remove an unneeded RUNPATH pointing to the build directory for
  libdispatch. This is already reached using LD_LIBRARY_PATH during
  testing.