### PR TITLE
Adjust for 'try?' changes in Swift 5

### DIFF
--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -35,7 +35,7 @@ private func getTestData() -> [Any]? {
         XCTFail("Unable to deserialize property list data")
         return nil
     }
-    guard let parsingTests = testRoot![kURLTestParsingTestsKey] as? [Any] else {
+    guard let parsingTests = testRoot[kURLTestParsingTestsKey] as? [Any] else {
         XCTFail("Unable to create the parsingTests dictionary")
         return nil
     }


### PR DESCRIPTION
When 'try?' has an optional sub-expression, it no longer produces a nested optional.