### PR TITLE
Only call pthread_key_create once in __CFTSDInitialize

### DIFF
--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -612,7 +612,10 @@ CF_PRIVATE void __CFFinalizeWindowsThreadData() {
 static pthread_key_t __CFTSDIndexKey;
 
 CF_PRIVATE void __CFTSDInitialize() {
-    (void)pthread_key_create(&__CFTSDIndexKey, __CFTSDFinalize);
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        (void)pthread_key_create(&__CFTSDIndexKey, __CFTSDFinalize);
+    });
 }
 
 static void __CFTSDSetSpecific(void *arg) {


### PR DESCRIPTION
We were calling pthread_key_create more than PTHREAD_KEYS_MAX times
(1024 on the version of Linux I tested with). It should only need to be
called once.

Fixes https://bugs.swift.org/browse/SR-9241