### PR TITLE
Change `rangeOfString(other)` to `range(of: other)` in the docs

### DIFF
--- a/Foundation/NSStringAPI.swift
+++ b/Foundation/NSStringAPI.swift
@@ -1633,7 +1633,7 @@ extension StringProtocol where Index == String.Index {
   /// Returns `true` iff `other` is non-empty and contained within
   /// `self` by case-sensitive, non-literal search.
   ///
-  /// Equivalent to `self.rangeOfString(other) != nil`
+  /// Equivalent to `self.range(of: other) != nil`
   public func contains<T : StringProtocol>(_ other: T) -> Bool {
     let r = self.range(of: other) != nil
     if #available(macOS 10.10, iOS 8.0, *) {


### PR DESCRIPTION
In the `NSStringAPI.swift` there was still a reference to the old `rangeOfString()` method. This method was renamed to `range(to:)` so I fixed the documentation otherwise it can create some confusion 🙂

I did the same fix here https://github.com/apple/swift/pull/20860