### PR TITLE
UUID.uuidString should return an upper String like on Darwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,6 +410,7 @@ if(ENABLE_TESTING)
                          TestFoundation/TestURL.swift
                          TestFoundation/TestUserDefaults.swift
                          TestFoundation/TestUtils.swift
+                         TestFoundation/TestUUID.swift
                          TestFoundation/TestXMLDocument.swift
                          TestFoundation/TestXMLParser.swift
                        CFLAGS

--- a/Foundation/UUID.swift
+++ b/Foundation/UUID.swift
@@ -66,7 +66,7 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
             valPtr.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<uuid_t>.size) { val in
                 withUnsafeMutablePointer(to: &bytes) { strPtr in
                     strPtr.withMemoryRebound(to: CChar.self, capacity: MemoryLayout<uuid_string_t>.size) { str in
-                        _cf_uuid_unparse(val, str)
+                        _cf_uuid_unparse_upper(val, str)
                         return String(cString: str, encoding: .utf8)!
                     }
                 }

--- a/TestFoundation/TestUUID.swift
+++ b/TestFoundation/TestUUID.swift
@@ -1,0 +1,55 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+class TestUUID : XCTestCase {
+    
+    static var allTests: [(String, (TestUUID) -> () throws -> Void)] {
+        return [
+            ("test_UUIDEquality", test_UUIDEquality),
+            ("test_UUIDInvalid", test_UUIDInvalid),
+            ("test_UUIDuuidString", test_UUIDuuidString),
+            ("test_UUIDdescription", test_UUIDdescription),
+            ("test_UUIDNSCoding", test_UUIDNSCoding),
+        ]
+    }
+    
+    func test_UUIDEquality() {
+        let uuidA = UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")
+        let uuidB = UUID(uuidString: "e621e1f8-c36c-495a-93fc-0c247a3e6e5f")
+        let uuidC = UUID(uuid: (0xe6,0x21,0xe1,0xf8,0xc3,0x6c,0x49,0x5a,0x93,0xfc,0x0c,0x24,0x7a,0x3e,0x6e,0x5f))
+        let uuidD = UUID()
+        
+        XCTAssertEqual(uuidA, uuidB, "String case must not matter.")
+        XCTAssertEqual(uuidA, uuidC, "A UUID initialized with a string must be equal to the same UUID initialized with its UnsafePointer<UInt8> equivalent representation.")
+        XCTAssertNotEqual(uuidC, uuidD, "Two different UUIDs must not be equal.")
+    }
+    
+    func test_UUIDInvalid() {
+        let uuid = UUID(uuidString: "Invalid UUID")
+        XCTAssertNil(uuid, "The convenience initializer `init?(uuidString string:)` must return nil for an invalid UUID string.")
+    }
+    
+    // `uuidString` should return an uppercase string
+    // See: https://bugs.swift.org/browse/SR-865
+    func test_UUIDuuidString() {
+        let uuid = UUID(uuid: (0xe6,0x21,0xe1,0xf8,0xc3,0x6c,0x49,0x5a,0x93,0xfc,0x0c,0x24,0x7a,0x3e,0x6e,0x5f))
+        XCTAssertEqual(uuid.uuidString, "E621E1F8-C36C-495A-93FC-0C247A3E6E5F", "The uuidString representation must be uppercase.")
+    }
+    
+    func test_UUIDdescription() {
+        let uuid = UUID()
+        XCTAssertEqual(uuid.description, uuid.uuidString, "The description must be the same as the uuidString.")
+    }
+    
+    func test_UUIDNSCoding() {
+        let uuidA = UUID()
+        let uuidB = NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: uuidA)) as! UUID
+        XCTAssertEqual(uuidA, uuidB, "Archived then unarchived uuid must be equal.")
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -88,6 +88,7 @@ XCTMain([
     testCase(TestURLSession.allTests),
     testCase(TestNSNull.allTests),
     testCase(TestNSUUID.allTests),
+    testCase(TestUUID.allTests),
     testCase(TestNSValue.allTests),
     testCase(TestUserDefaults.allTests),
     testCase(TestXMLParser.allTests),


### PR DESCRIPTION
Report for NSUUID: https://bugs.swift.org/browse/SR-865