### PR TITLE
Fix mixup with _CFRegularExpressionMatchingOptions and Flags.

### DIFF
--- a/CoreFoundation/String.subproj/CFRegularExpression.c
+++ b/CoreFoundation/String.subproj/CFRegularExpression.c
@@ -333,7 +333,7 @@ void _CFRegularExpressionEnumerateMatchesInString(_CFRegularExpressionRef regexO
     void *bufferToFree = NULL, *utextToFree = NULL;
     struct regexCallBackContext context;
     CFIndex offset, length = CFStringGetLength(string);
-    _CFRegularExpressionMatchingOptions flags;
+    _CFRegularExpressionMatchingFlags flags;
     Boolean checkedOutRegex = true;
     Boolean stop = false;
     Boolean reportProgress = ((options & _kCFRegularExpressionMatchingReportProgress) != 0);

--- a/CoreFoundation/String.subproj/CFRegularExpression.h
+++ b/CoreFoundation/String.subproj/CFRegularExpression.h
@@ -50,7 +50,7 @@ typedef CF_OPTIONS(CFOptionFlags, _CFRegularExpressionMatchingFlags) {
 
 typedef const struct CF_BRIDGED_TYPE(_NSCFRegex) ___CFRegularExpression * _CFRegularExpressionRef;
 
-typedef void (*_CFRegularExpressionMatch)(void *_Nullable context, CFRange * _Nullable ranges, CFIndex count, _CFRegularExpressionMatchingOptions options, Boolean *stop);
+typedef void (*_CFRegularExpressionMatch)(void *_Nullable context, CFRange * _Nullable ranges, CFIndex count, _CFRegularExpressionMatchingFlags flags, Boolean *stop);
 
 CFStringRef _CFRegularExpressionCreateEscapedPattern(CFStringRef pattern);
 _CFRegularExpressionRef _Nullable _CFRegularExpressionCreate(CFAllocatorRef allocator, CFStringRef pattern, _CFRegularExpressionOptions options, CFErrorRef *errorPtr);

--- a/Foundation/NSRegularExpression.swift
+++ b/Foundation/NSRegularExpression.swift
@@ -149,30 +149,19 @@ internal class _NSRegularExpressionMatcher {
     }
 }
 
-internal func _NSRegularExpressionMatch(_ context: UnsafeMutableRawPointer?, ranges: UnsafeMutablePointer<CFRange>?, count: CFIndex, options: _CFRegularExpressionMatchingOptions, stop: UnsafeMutablePointer<_DarwinCompatibleBoolean>) -> Void {
+internal func _NSRegularExpressionMatch(_ context: UnsafeMutableRawPointer?, ranges: UnsafeMutablePointer<CFRange>?, count: CFIndex, flags: _CFRegularExpressionMatchingFlags, stop: UnsafeMutablePointer<_DarwinCompatibleBoolean>) -> Void {
     let matcher = unsafeBitCast(context, to: _NSRegularExpressionMatcher.self)
-    if ranges == nil {
 #if os(macOS) || os(iOS)
-        let opts = options.rawValue
+    let flags = NSRegularExpression.MatchingFlags(rawValue: flags.rawValue)
 #else
-        let opts = options
+    let flags = NSRegularExpression.MatchingFlags(rawValue: flags)
 #endif
-        stop.withMemoryRebound(to: ObjCBool.self, capacity: 1, {
-            matcher.block(nil, NSRegularExpression.MatchingFlags(rawValue: opts), $0)
-        })
-    } else {
-        let result = ranges!.withMemoryRebound(to: NSRange.self, capacity: count) { rangePtr in
-            NSTextCheckingResult.regularExpressionCheckingResultWithRanges(rangePtr, count: count, regularExpression: matcher.regex)
-        }
-#if os(macOS) || os(iOS)
-        let flags = NSRegularExpression.MatchingFlags(rawValue: options.rawValue)
-#else
-        let flags = NSRegularExpression.MatchingFlags(rawValue: options)
-#endif
-        stop.withMemoryRebound(to: ObjCBool.self, capacity: 1, {
-            matcher.block(result, flags, $0)
-        })
+    let result = ranges?.withMemoryRebound(to: NSRange.self, capacity: count) { rangePtr in
+        NSTextCheckingResult.regularExpressionCheckingResultWithRanges(rangePtr, count: count, regularExpression: matcher.regex)
     }
+    stop.withMemoryRebound(to: ObjCBool.self, capacity: 1, {
+        matcher.block(result, flags, $0)
+    })
 }
 
 extension NSRegularExpression {


### PR DESCRIPTION
The Swift function
`NSRegularExpression.enumerateMatches(in:options:range:using:)` receives
a `NSRegularExpression.MatchingOptions`, but the `using:` block receives
a `NSRegularExpression.MatchingFlags`. At one point in the code of
CoreFoundation, the results of a call the obtained `Flags` were shoved
into an `Options` variable, instead of a `Flags` one. This error was
perpetuated in the function points signature in the header, which Swift
imported, forcing Swift to do a conversion between
`_CFRegularExpressionMatchingOptions` into
`NSRegularExpression.MatchingFlags` using the raw value.