### PR TITLE
Initial setup: Consolidate building setup to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,13 @@ option(FOUNDATION_PATH_TO_LIBDISPATCH_SOURCE "Path to libdispatch source" "")
 option(FOUNDATION_PATH_TO_LIBDISPATCH_BUILD "Path to libdispatch build" "")
 option(FOUNDATION_PATH_TO_XCTEST_BUILD "Path to XCTest build" "")
 
+set(icu_darwin_libraries)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin) 
+  find_package(ICU COMPONENTS uc i18n REQUIRED)
+else()
+  set(icu_darwin_libraries -licucore)
+endif()
 find_package(CURL REQUIRED)
-find_package(ICU COMPONENTS uc i18n REQUIRED)
 find_package(LibXml2 REQUIRED)
 find_package(UUID REQUIRED)
 
@@ -62,10 +67,12 @@ set(libdispatch_cflags)
 set(libdispatch_ldflags)
 if(FOUNDATION_ENABLE_LIBDISPATCH)
   set(deployment_enable_libdispatch -DDEPLOYMENT_ENABLE_LIBDISPATCH)
-  set(libdispatch_cflags -I;${FOUNDATION_PATH_TO_LIBDISPATCH_SOURCE};-I;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src/swift;-Xcc;-fblocks)
-  set(libdispatch_ldflags -L;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD};-L;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src;-ldispatch)
-  if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
-    list(APPEND libdispatch_ldflags -Xlinker;-rpath;-Xlinker;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(libdispatch_cflags -I;${FOUNDATION_PATH_TO_LIBDISPATCH_SOURCE};-I;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src/swift;-Xcc;-fblocks)
+    set(libdispatch_ldflags -L;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD};-L;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src;-ldispatch)
+    if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+      list(APPEND libdispatch_ldflags -Xlinker;-rpath;-Xlinker;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src)
+    endif()
   endif()
 endif()
 
@@ -79,13 +86,20 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
   set(deployment_target -DDEPLOYMENT_TARGET_WINDOWS)
 endif()
 
+set(foundation_module_name Foundation)
+set(foundation_darwin_link_flags)
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  set(foundation_module_name SwiftFoundation)
+  set(foundation_darwin_link_flags -Xlinker;-twolevel_namespace;-Xlinker;-alias_list;-Xlinker;${CMAKE_CURRENT_SOURCE_DIR}/CoreFoundation/Base.subproj/DarwinSymbolAliases;-Xlinker;-all_load;-Xlinker;-sectcreate;-Xlinker;__UNICODE;-Xlinker;__csbitmaps;-Xlinker;${CMAKE_CURRENT_SOURCE_DIR}/CoreFoundation/CharacterSets/CFCharacterSetBitmaps.bitmap;-Xlinker;-sectcreate;-Xlinker;__UNICODE;-Xlinker;__properties;-Xlinker;${CMAKE_CURRENT_SOURCE_DIR}/CoreFoundation/CharacterSets/CFUniCharPropertyDatabase.data;-Xlinker;-sectcreate;-Xlinker;__UNICODE;-Xlinker;__data;-Xlinker;${CMAKE_CURRENT_SOURCE_DIR}/CoreFoundation/CharacterSets/CFUnicodeData-L.mapping;-Xlinker;-segprot;-Xlinker;__UNICODE;-Xlinker;r;-Xlinker;r)
+endif()
+
 add_swift_library(Foundation
                   MODULE_NAME
-                    Foundation
+                    ${foundation_module_name}
                   MODULE_LINK_NAME
-                    Foundation
+                    ${foundation_module_name}
                   MODULE_PATH
-                    ${CMAKE_CURRENT_BINARY_DIR}/swift/Foundation.swiftmodule
+                    ${CMAKE_CURRENT_BINARY_DIR}/swift/${foundation_module_name}.swiftmodule
                   SOURCES
                     Foundation/AffineTransform.swift
                     Foundation/Array.swift
@@ -251,11 +265,12 @@ add_swift_library(Foundation
                     -L${install_dir}/usr/lib
                     -lCoreFoundation
                     ${CURL_LIBRARIES}
-                    ${ICU_UC_LIBRARY} ${ICU_I18N_LIBRARY}
+                    ${ICU_UC_LIBRARY} ${ICU_I18N_LIBRARY} ${icu_darwin_libraries}
                     ${LIBXML2_LIBRARIES}
                     ${libdispatch_ldflags}
                     ${uuid_LIBRARIES}
                     -Xlinker;-rpath;-Xlinker;"\\\$\$ORIGIN"
+                    ${foundation_darwin_link_flags}
                   SWIFT_FLAGS
                     -DDEPLOYMENT_RUNTIME_SWIFT
                     ${deployment_enable_libdispatch}
@@ -287,7 +302,7 @@ add_swift_executable(plutil
                      LINK_FLAGS
                        -L${CMAKE_CURRENT_BINARY_DIR}
                        ${libdispatch_ldflags}
-                       -lFoundation
+                       -l${foundation_module_name}
                        ${Foundation_INTERFACE_LIBRARIES}
                        -Xlinker;-rpath;-Xlinker;"\\\$\$ORIGIN/../lib/swift/${swift_os}"
                      SWIFT_FLAGS
@@ -311,7 +326,7 @@ if(ENABLE_TESTING)
                        LINK_FLAGS
                          ${libdispatch_ldflags}
                          -L${CMAKE_CURRENT_BINARY_DIR}
-                         -lFoundation
+                         -l${foundation_module_name}
                          ${Foundation_INTERFACE_LIBRARIES}
                        SOURCES
                          TestFoundation/xdgTestHelper/main.swift
@@ -418,7 +433,7 @@ if(ENABLE_TESTING)
                        LINK_FLAGS
                          ${libdispatch_ldflags}
                          -L${CMAKE_CURRENT_BINARY_DIR}
-                         -lFoundation
+                         -l${foundation_module_name}
                          ${Foundation_INTERFACE_LIBRARIES}
                          -L${FOUNDATION_PATH_TO_XCTEST_BUILD}
                          -lXCTest

--- a/CoreFoundation/Base.subproj/CFAsmMacros.h
+++ b/CoreFoundation/Base.subproj/CFAsmMacros.h
@@ -16,7 +16,7 @@
 
 /* Use .note.GNU-stack to explicitly indicate a non-exec stack, b/c of bad   */
 /* default behaviour when translating handwritten assembly files (needed on  */
-/* GNU/* platforms, Android and FreeBSD, as tests have shown).               */
+/* GNU/<etc> platforms, Android and FreeBSD, as tests have shown).           */
 /* Platform tests are documented at http://git.savannah.gnu.org/gitweb/?p=libffcall.git;a=blob;f=porting-tools/execstack/README */
 #if (defined(__GNUC__) || defined (__llvm__) || defined (__clang__)) && defined(__ELF__) && (defined (__linux__) || defined (__linux) || defined (__gnu_linux__) || defined(__FreeBSD__) || defined (__FreeBSD_kernel__))
 #define NO_EXEC_STACK_DIRECTIVE .section .note.GNU-stack,"",%progbits

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -41,8 +41,18 @@ else()
   set(FRAMEWORK_LIBRARY_TYPE STATIC)
 endif()
 
+set(cf_swift_runtime_abi_flags)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  set(cf_swift_runtime_abi_flags -fcf-runtime-abi=swift)
+endif()
+
+set(cf_darwin_only_mach_port_sources)
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  set(cf_darwin_only_mach_port_sources RunLoop.subproj/CFMachPort.c;RunLoop.subproj/CFMachPort_Lifetime.c;RunLoop.subproj/CFMessagePort.c)
+endif()
+
 add_framework(CoreFoundation
-                ${FRAMEWORK_LIBRARY_TYPE}
+              ${FRAMEWORK_LIBRARY_TYPE}
               FRAMEWORK_DIRECTORY
                 CoreFoundation_FRAMEWORK_DIRECTORY
               MODULE_MAP
@@ -264,10 +274,7 @@ add_framework(CoreFoundation
                 Preferences.subproj/CFPreferences.c
                 Preferences.subproj/CFXMLPreferencesDomain.c
                 # RunLoop
-                # TODO(compnerd) make this empty on non-Mach targets
-                # RunLoop.subproj/CFMachPort.c
-                # RunLoop.subproj/CFMachPort_Lifetime.c
-                # RunLoop.subproj/CFMessagePort.c
+                ${cf_darwin_only_mach_port_sources}
                 RunLoop.subproj/CFRunLoop.c
                 RunLoop.subproj/CFSocket.c
                 # Stream
@@ -278,7 +285,6 @@ add_framework(CoreFoundation
                 String.subproj/CFAttributedString.c
                 String.subproj/CFBurstTrie.c
                 String.subproj/CFCharacterSet.c
-                String.subproj/CFCharacterSetData.S
                 String.subproj/CFRegularExpression.c
                 String.subproj/CFRunArray.c
                 String.subproj/CFString.c
@@ -286,8 +292,6 @@ add_framework(CoreFoundation
                 String.subproj/CFStringScanner.c
                 String.subproj/CFStringTransform.c
                 String.subproj/CFStringUtilities.c
-                String.subproj/CFUniCharPropertyDatabase.S
-                String.subproj/CFUnicodeData.S
                 # StringEncodings
                 StringEncodings.subproj/CFBuiltinConverters.c
                 StringEncodings.subproj/CFICUConverters.c
@@ -303,6 +307,33 @@ add_framework(CoreFoundation
                 URL.subproj/CFURLComponents.c
                 URL.subproj/CFURLComponents_URIParser.c
                 URL.subproj/CFURLSessionInterface.c)
+
+
+add_library(CFUnicodeAsm
+            STATIC
+              String.subproj/CFCharacterSetData.S
+              String.subproj/CFUniCharPropertyDatabase.S
+              String.subproj/CFUnicodeData.S)
+target_include_directories(CFUnicodeAsm
+                           PRIVATE
+                             .)
+add_dependencies(CFUnicodeAsm CoreFoundation_POPULATE_HEADERS)
+add_dependencies(CoreFoundation CFUnicodeAsm)
+target_link_libraries(CoreFoundation
+                      PRIVATE
+                        CFUnicodeAsm)
+
+target_compile_definitions(CFUnicodeAsm
+                           PRIVATE
+                              CF_CHARACTERSET_BITMAP="CharacterSets/CFCharacterSetBitmaps.bitmap"
+                              CF_CHARACTERSET_UNICHAR_DB="CharacterSets/CFUniCharPropertyDatabase.data"
+                              CF_CHARACTERSET_UNICODE_DATA_B="CharacterSets/CFUnicodeData-B.mapping"
+                              CF_CHARACTERSET_UNICODE_DATA_L="CharacterSets/CFUnicodeData-L.mapping")
+target_compile_options(CFUnicodeAsm
+                       PRIVATE
+                         -F;${CoreFoundation_FRAMEWORK_DIRECTORY}/..)
+set(CMAKE_XCODE_ATTRIBUTE_FRAMEWORK_SEARCH_PATHS "${CoreFoundation_FRAMEWORK_DIRECTORY}/..")
+
 if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android)
   target_compile_definitions(CoreFoundation
                              PRIVATE
@@ -339,21 +370,30 @@ else()
                              PRIVATE
                                -DDEPLOYMENT_RUNTIME_C)
 endif()
-target_compile_definitions(CoreFoundation
-                           PRIVATE
-                              $<$<COMPILE_LANGUAGE:ASM>:CF_CHARACTERSET_BITMAP="CharacterSets/CFCharacterSetBitmaps.bitmap">
-                              $<$<COMPILE_LANGUAGE:ASM>:CF_CHARACTERSET_UNICHAR_DB="CharacterSets/CFUniCharPropertyDatabase.data">
-                              $<$<COMPILE_LANGUAGE:ASM>:CF_CHARACTERSET_UNICODE_DATA_B="CharacterSets/CFUnicodeData-B.mapping">
-                              $<$<COMPILE_LANGUAGE:ASM>:CF_CHARACTERSET_UNICODE_DATA_L="CharacterSets/CFUnicodeData-L.mapping">)
+
+if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+  # FIXME(compnerd) why is /usr/local/include added manually?  clang will do so
+  target_include_directories(CoreFoundation
+                             PRIVATE
+                               "/usr/local/include"
+                               "/usr/local/include/libxml2"
+                               "/usr/local/include/curl")
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_include_directories(CoreFoundation
+                             PRIVATE
+                              "../bootstrap/x86_64-apple-darwin/usr/local/include")
+endif()
 
 target_include_directories(CoreFoundation
                            PRIVATE
                              ${CMAKE_SOURCE_DIR})
+find_package(LibXml2 REQUIRED)
+target_include_directories(CoreFoundation
+                           PRIVATE
+                             ${LIBXML2_INCLUDE_DIR})
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  find_package(LibXml2 REQUIRED)
-  target_include_directories(CoreFoundation
-                             PRIVATE
-                               ${LIBXML2_INCLUDE_DIR})
   find_package(CURL REQUIRED)
   target_include_directories(CoreFoundation
                              PRIVATE
@@ -402,7 +442,7 @@ endif()
 if(CF_DEPLOYMENT_SWIFT)
   target_compile_options(CoreFoundation
                          PRIVATE
-                           -fcf-runtime-abi=swift)
+                           ${cf_swift_runtime_abi_flags})
 endif()
 
 target_compile_options(CoreFoundation

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -38,6 +38,9 @@ function(add_swift_target target)
     foreach(flag ${AST_CFLAGS})
       list(APPEND compile_flags -Xcc;${flag})
     endforeach()
+    if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+      list(APPEND compile_flags -sdk;`xcrun --show-sdk-path -sdk macosx`)
+    endif()
   endif()
   if(AST_LINK_FLAGS)
     foreach(flag ${AST_LINK_FLAGS})
@@ -73,6 +76,9 @@ function(add_swift_target target)
       set(IMPORT_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/${target}.dir/${CMAKE_IMPORT_LIBRARY_PREFIX}${target}${CMAKE_IMPORT_LIBRARY_SUFFIX})
     endif()
   endif()
+  
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${target}.dir)
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/swift)
 
   set(sources)
   foreach(source ${AST_SOURCES})
@@ -83,7 +89,7 @@ function(add_swift_target target)
       list(APPEND sources ${CMAKE_CURRENT_SOURCE_DIR}/${source})
     endif()
   endforeach()
-
+  
   set(objs)
   set(mods)
   set(docs)
@@ -148,7 +154,9 @@ function(add_swift_target target)
                       DEPENDS
                          ${AST_OUTPUT}
                          ${module}
-                         ${documentation})
+                         ${documentation}
+                      SOURCES
+                         ${sources})
   else()
     add_library(${target}-static STATIC ${objs})
     if(AST_DEPENDS)
@@ -169,7 +177,9 @@ function(add_swift_target target)
                       DEPENDS
                         ${target}-static
                         ${module}
-                        ${documentation})
+                        ${documentation}
+                      SOURCES
+                        ${sources})
   endif()
 
   if(AST_RESOURCES)

--- a/utils/create-build-files
+++ b/utils/create-build-files
@@ -1,0 +1,163 @@
+#!/bin/bash
+
+HERE="`dirname "$0"`"
+HERE="`(cd "$HERE"; pwd)`"
+ME="`basename "$0"`"
+
+SRCROOT="`(cd "$HERE"/..; pwd)`"
+if [ "$SWIFT_BUILD_ROOT" == "" ]; then
+	SWIFT_BUILD_ROOT="`(cd "$HERE"/../..; pwd)`"/build
+fi
+
+EMIT_FOUNDATION=YES
+EMIT_CORE_FOUNDATION=YES
+EMIT_CLEAN=NO
+DEFAULT_PARTIAL_PROJECTS_DIR="$SWIFT_BUILD_ROOT/FoundationDev-"
+
+if [ "`uname -s`" == "Darwin" ]; then
+	DEFAULT_GENERATOR=Xcode
+else
+	DEFAULT_GENERATOR=Ninja
+fi
+GENERATOR="$DEFAULT_GENERATOR"
+
+function end() {
+	echo "$@" >&2
+	exit 1
+}
+
+function echo_sh() {
+	echo " \$ $@"
+	"$@"
+}
+
+DEFAULT_SWIFTC=/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/swiftc
+if [ -x "$DEFAULT_SWIFTC" ]; then
+	SWIFTC="$DEFAULT_SWIFTC"
+fi
+
+function usage() {
+	echo "Usage: $ME [{--xcode,-x}|{--ninja,-N}] [{--generator,-G} GENERATOR] [--swiftc <PATH TO SWIFTC>] [--{enable,disable}-foundation] [--{enable,disable}-core-foundation] [{--projects-dir,-o} PROJECTS_DIR] [{--clean,-K}]" >&2
+	echo "  The default generator is '$DEFAULT_GENERATOR'." >&2
+	echo "  Build files will be generated in subdirectories of PROJECTS_DIR, " >&2
+	echo "  which defaults to: $DEFAULT_PARTIAL_PROJECTS_DIR[GENERATOR], e.g.:" >&2
+	echo "   $DEFAULT_PARTIAL_PROJECTS_DIR$GENERATOR" >&2
+	echo "  (this default respects the SWIFT_BUILD_ROOT environment variable.)" >&2
+	if [ "$SWIFTC" == "" ]; then
+		echo "  You must specify the path to swiftc with the --swiftc flag." >&2
+	else
+		echo "  If the path to swiftc is not specified, it will build with:" >&2
+		echo "   $SWIFTC"
+	fi
+}
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+	--xcode|-x)
+		GENERATOR=Xcode
+		;;
+	--ninja|-N)
+		GENERATOR=Ninja
+		;;
+	--generator|-G)
+		shift
+		GENERATOR="$1"
+		if [ "$GENERATOR" == "" ]; then
+			end "error: Expected a CMake generator name after --generator/-G."
+		fi
+		;;
+		
+	--enable-foundation)
+		EMIT_FOUNDATION=YES
+		;;
+	--disable-foundation)
+		EMIT_FOUNDATION=NO
+		;;
+	--enable-core-foundation)
+		EMIT_CORE_FOUNDATION=YES
+		;;
+	--disable-core-foundation)
+		EMIT_CORE_FOUNDATION=NO
+		;;
+	--projects-dir|-o)
+		shift
+		PROJECTS_DIR="$1"
+		if [ "$PROJECTS_DIR" == "" ]; then
+			end "error: Expected a project directory path after -o/--projects-dir."
+		fi
+		;;
+	--clean|-K)
+		EMIT_CLEAN=YES
+		;;
+	--swiftc)
+		shift
+		SWIFTC="$1"
+		if [ ! -x "$SWIFTC" ]; then
+			end "error: Couldn't find an executable swiftc at: $SWIFTC"
+		fi
+		;;
+		
+	--help)
+		usage
+		exit 0
+		;;
+	*)
+		usage
+		exit 1
+		;;
+	esac
+	
+	shift
+done
+
+if [ "$PROJECTS_DIR" == "" ]; then
+	PROJECTS_DIR="$DEFAULT_PARTIAL_PROJECTS_DIR$GENERATOR"
+fi
+
+echo "note: == Creating build files with configuration:" 
+echo "note:  Generator: $GENERATOR"
+echo "note:  Create Foundation build setup? $EMIT_FOUNDATION"
+echo "note:  Create Core Foundation build setup? $EMIT_CORE_FOUNDATION"
+echo "note:  Create build setups at subdirectories of: $PROJECTS_DIR"
+echo "note:  Use swiftc at: $SWIFTC"
+
+if [ "$EMIT_FOUNDATION" == "NO" -a "$EMIT_CORE_FOUNDATION" == "NO" ]; then
+	end "error: You must enable at least one project to emit."
+fi
+
+echo_sh mkdir -p "$PROJECTS_DIR" || end "error: Could not create directory at $PROJECTS_DIR"
+
+if [ "$EMIT_FOUNDATION" == "YES" ]; then
+	echo
+	echo "note: == Generating Foundation"
+
+	FOUNDATION_PROJECT_DIR="$PROJECTS_DIR"/Foundation
+	if [ "$EMIT_CLEAN" == "YES" -a -d "$FOUNDATION_PROJECT_DIR" ]; then
+		echo "note: Removing existing files at $FOUNDATION_PROJECT_DIR"
+		echo_sh rm -rfv "$FOUNDATION_PROJECT_DIR" || end "error: Could not delete directory at $FOUNDATION_PROJECT_DIR"
+	fi
+	echo_sh mkdir -p "$FOUNDATION_PROJECT_DIR" || end "error: Could not create Foundation directory at $FOUNDATION_PROJECT_DIR"
+
+	(echo_sh cd "$FOUNDATION_PROJECT_DIR" && echo_sh \
+		cmake -G "$GENERATOR" \
+			-DCMAKE_SWIFT_COMPILER="$SWIFTC" \
+			-DENABLE_TESTING=YES \
+			-DCMAKE_BUILD_TYPE=Debug \
+			-DCMAKE_INSTALL_PREFIX="$PWD"/Install \
+			-DBUILD_SHARED_LIBS=YES \
+		"$SRCROOT") || end "error: CMake could not generate the build setup for Foundation."
+fi
+
+if [ "$EMIT_CORE_FOUNDATION" == "YES" ]; then
+	echo
+	echo "note: == Generating Core Foundation"
+
+	CORE_FOUNDATION_PROJECT_DIR="$PROJECTS_DIR"/CoreFoundation
+	if [ "$EMIT_CLEAN" == "YES" -a -d "$CORE_FOUNDATION_PROJECT_DIR" ]; then
+		echo "note: Removing existing files at $CORE_FOUNDATION_PROJECT_DIR"
+		echo_sh rm -rfv "$CORE_FOUNDATION_PROJECT_DIR" || end "error: Could not delete directory at $CORE_FOUNDATION_PROJECT_DIR"
+	fi
+	echo_sh mkdir -p "$CORE_FOUNDATION_PROJECT_DIR" || end "error: Could not create Foundation directory at $CORE_FOUNDATION_PROJECT_DIR"
+
+	(echo_sh cd "$CORE_FOUNDATION_PROJECT_DIR" && echo_sh cmake -G "$GENERATOR" -DBUILD_SHARED_LIBS=NO -DCF_DEPLOYMENT_SWIFT=YES -DCF_ENABLE_LIBDISPATCH=YES "$SRCROOT"/CoreFoundation) || end "error: CMake could not generate the build setup for Core Foundation."
+fi


### PR DESCRIPTION
This adds a new `utils/create-build-files` script that can be used, via `cmake`, to produce build setups meant to replace `build.py` and the Xcode workspace and projects to build swift-corelibs-foundation without building the rest of the Swift codebase.

This isn’t fully done, but allows the Foundation and CoreFoundation targets to build in a generated Xcode (`utils/create-build-files --xcode`) or Ninja setup (`utils/create-build-files --ninja`).