### PR TITLE
Cherry Pick Conditional Bridge Behavior for Swift 4.2 Branch

### DIFF
--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -541,13 +541,16 @@ extension Bool : _ObjectiveCBridgeable {
     }
     
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Bool?) -> Bool {
-        if x.intValue == 0 || x.intValue == 1 {
-            result = x.boolValue
+        if x === kCFBooleanTrue || NSNumber(value: 1) == x {
+            result = true
             return true
-        } else {
-            result = nil
-            return false
+        } else if x === kCFBooleanFalse || NSNumber(value: 0) == x {
+            result = false
+            return true
         }
+
+        result = nil
+        return false
     }
     
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> Bool {

--- a/TestFoundation/TestNSNumberBridging.swift
+++ b/TestFoundation/TestNSNumberBridging.swift
@@ -642,6 +642,16 @@ class TestNSNumberBridging : XCTestCase {
         XCTAssertNotNil(b3)
         XCTAssertEqual(b3, true)
 
+        let b4 = NSNumber(value: 0.0) as? Bool
+        XCTAssertNotNil(b4)
+        XCTAssertEqual(b4, false)
+
+        let b5 = NSNumber(value: 1.0) as? Bool
+        XCTAssertNotNil(b5)
+        XCTAssertEqual(b5, true)
+
+        XCTAssertNil(NSNumber(value: 0.25) as? Bool)
+        XCTAssertNil(NSNumber(value: 1.25) as? Bool)
         XCTAssertNil(NSNumber(value: -1) as? Bool)
         XCTAssertNil(NSNumber(value: 2) as? Bool)
         XCTAssertNil(NSNumber(value: Int8.min) as? Bool)


### PR DESCRIPTION
See PR #1703 for the original details around the fix.

Work for 4.2 originally regressed this behavior from 4.1 and earlier, so this really should be fixed in 4.2 for Linux as well as the original commit to master.