### PR TITLE
Use strongSelf instead of `self`

### DIFF
--- a/Foundation/URLSession/URLSession.swift
+++ b/Foundation/URLSession/URLSession.swift
@@ -295,10 +295,10 @@ open class URLSession : NSObject {
 
            let invalidateSessionCallback = { [weak self] in
                //invoke the delegate method and break the delegate link
-               guard let `self` = self, let sessionDelegate = self.delegate else { return }
-               self.delegateQueue.addOperation {
-                   sessionDelegate.urlSession(self, didBecomeInvalidWithError: nil)
-                   self.delegate = nil
+               guard let strongSelf = self, let sessionDelegate = strongSelf.delegate else { return }
+               strongSelf.delegateQueue.addOperation {
+                   sessionDelegate.urlSession(strongSelf, didBecomeInvalidWithError: nil)
+                   strongSelf.delegate = nil
                }
            }
 


### PR DESCRIPTION
Replace using:
```swift
`self`
```
which is relying on a [compiler bug](https://github.com/apple/swift-evolution/blob/master/proposals/0079-upgrade-self-from-weak-to-strong.md#relying-on-a-compiler-bug) with `strongSelf`.

Unwrapping `self` by using `strongSelf` is already used in [other places](https://github.com/search?q=org%3Aapple+strongSelf&type=Code) so this will make the code consistent across the projects.