### PR TITLE
Decimal: Fix init(_ value: Double) to bounds check the exponent

### DIFF
--- a/TestFoundation/TestDecimal.swift
+++ b/TestFoundation/TestDecimal.swift
@@ -9,35 +9,6 @@
 
 class TestDecimal: XCTestCase {
 
-    static var allTests : [(String, (TestDecimal) -> () throws -> Void)] {
-        return [
-            ("test_NSDecimalNumberInit", test_NSDecimalNumberInit),
-            ("test_AdditionWithNormalization", test_AdditionWithNormalization),
-            ("test_BasicConstruction", test_BasicConstruction),
-            ("test_Constants", test_Constants),
-            ("test_Description", test_Description),
-            ("test_ExplicitConstruction", test_ExplicitConstruction),
-            ("test_Maths", test_Maths),
-            ("test_Misc", test_Misc),
-            ("test_MultiplicationOverflow", test_MultiplicationOverflow),
-            ("test_NaNInput", test_NaNInput),
-            ("test_NegativeAndZeroMultiplication", test_NegativeAndZeroMultiplication),
-            ("test_Normalise", test_Normalise),
-            ("test_NSDecimal", test_NSDecimal),
-            ("test_PositivePowers", test_PositivePowers),
-            ("test_RepeatingDivision", test_RepeatingDivision),
-            ("test_Round", test_Round),
-            ("test_ScanDecimal", test_ScanDecimal),
-            ("test_SimpleMultiplication", test_SimpleMultiplication),
-            ("test_SmallerNumbers", test_SmallerNumbers),
-            ("test_ZeroPower", test_ZeroPower),
-            ("test_doubleValue", test_doubleValue),
-            ("test_NSDecimalNumberValues", test_NSDecimalNumberValues),
-            ("test_bridging", test_bridging),
-            ("test_stringWithLocale", test_stringWithLocale),
-        ]
-    }
-
     func test_NSDecimalNumberInit() {
         XCTAssertEqual(NSDecimalNumber(mantissa: 123456789000, exponent: -2, isNegative: true), -1234567890)
         XCTAssertEqual(NSDecimalNumber(decimal: Decimal()).decimalValue, Decimal(0))
@@ -161,6 +132,7 @@ class TestDecimal: XCTestCase {
         XCTAssertEqual(d1._exponent, 0)
         XCTAssertEqual(d1._length, 4)
     }
+
     func test_Constants() {
         XCTAssertEqual(8, NSDecimalMaxSize)
         XCTAssertEqual(32767, NSDecimalNoScale)
@@ -211,8 +183,8 @@ class TestDecimal: XCTestCase {
         let reserved: UInt32 = (1<<18 as UInt32) + (1<<17 as UInt32) + 1
         let mantissa: (UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16) = (6, 7, 8, 9, 10, 11, 12, 13)
         var explicit = Decimal(
-            _exponent: 0x17f,
-            _length: 0xff,
+            _exponent: 0x7f,
+            _length: 0x0f,
             _isNegative: 3,
             _isCompact: 4,
             _reserved: reserved,
@@ -478,6 +450,11 @@ class TestDecimal: XCTestCase {
         XCTAssertTrue(NSDecimalIsNotANumber(&result), "NaN e5")
 
         XCTAssertFalse(Double(truncating: NSDecimalNumber(decimal: Decimal(0))).isNaN)
+        XCTAssertTrue(Decimal(Double.leastNonzeroMagnitude).isNaN)
+        XCTAssertTrue(Decimal(Double.leastNormalMagnitude).isNaN)
+        XCTAssertTrue(Decimal(Double.greatestFiniteMagnitude).isNaN)
+        XCTAssertTrue(Decimal(Double("1e-129")!).isNaN)
+        XCTAssertTrue(Decimal(Double("0.1e-128")!).isNaN)
     }
 
     func test_NegativeAndZeroMultiplication() {
@@ -1115,5 +1092,35 @@ class TestDecimal: XCTestCase {
         let s2 = "1234,5678"
         XCTAssertEqual(Decimal(string: s2, locale: en_US)?.description, "1234")
         XCTAssertEqual(Decimal(string: s2, locale: fr_FR)?.description, s1)
+    }
+
+
+    static var allTests : [(String, (TestDecimal) -> () throws -> Void)] {
+        return [
+            ("test_NSDecimalNumberInit", test_NSDecimalNumberInit),
+            ("test_AdditionWithNormalization", test_AdditionWithNormalization),
+            ("test_BasicConstruction", test_BasicConstruction),
+            ("test_Constants", test_Constants),
+            ("test_Description", test_Description),
+            ("test_ExplicitConstruction", test_ExplicitConstruction),
+            ("test_Maths", test_Maths),
+            ("test_Misc", test_Misc),
+            ("test_MultiplicationOverflow", test_MultiplicationOverflow),
+            ("test_NaNInput", test_NaNInput),
+            ("test_NegativeAndZeroMultiplication", test_NegativeAndZeroMultiplication),
+            ("test_Normalise", test_Normalise),
+            ("test_NSDecimal", test_NSDecimal),
+            ("test_PositivePowers", test_PositivePowers),
+            ("test_RepeatingDivision", test_RepeatingDivision),
+            ("test_Round", test_Round),
+            ("test_ScanDecimal", test_ScanDecimal),
+            ("test_SimpleMultiplication", test_SimpleMultiplication),
+            ("test_SmallerNumbers", test_SmallerNumbers),
+            ("test_ZeroPower", test_ZeroPower),
+            ("test_doubleValue", test_doubleValue),
+            ("test_NSDecimalNumberValues", test_NSDecimalNumberValues),
+            ("test_bridging", test_bridging),
+            ("test_stringWithLocale", test_stringWithLocale),
+        ]
     }
 }

--- a/TestFoundation/TestJSONSerialization.swift
+++ b/TestFoundation/TestJSONSerialization.swift
@@ -960,8 +960,9 @@ extension TestJSONSerialization {
         XCTAssertTrue(JSONSerialization.isValidJSONObject([NSNumber(value: true), NSNumber(value: Float.greatestFiniteMagnitude), NSNumber(value: Double.greatestFiniteMagnitude)]))
         XCTAssertTrue(JSONSerialization.isValidJSONObject([NSNumber(value: Int.max), NSNumber(value: Int8.max), NSNumber(value: Int16.max), NSNumber(value: Int32.max), NSNumber(value: Int64.max)]))
         XCTAssertTrue(JSONSerialization.isValidJSONObject([NSNumber(value: UInt.max), NSNumber(value: UInt8.max), NSNumber(value: UInt16.max), NSNumber(value: UInt32.max), NSNumber(value: UInt64.max)]))
-        XCTAssertTrue(JSONSerialization.isValidJSONObject([NSDecimalNumber(booleanLiteral: true), NSDecimalNumber(decimal: Decimal.greatestFiniteMagnitude), NSDecimalNumber(floatLiteral: Double.greatestFiniteMagnitude), NSDecimalNumber(integerLiteral: Int.min)]))
-        XCTAssertTrue(JSONSerialization.isValidJSONObject([Decimal(123), Decimal(Double.leastNonzeroMagnitude)]))
+        XCTAssertTrue(JSONSerialization.isValidJSONObject([NSDecimalNumber(booleanLiteral: true), NSDecimalNumber(decimal: Decimal.greatestFiniteMagnitude)]))
+        XCTAssertTrue(JSONSerialization.isValidJSONObject([NSDecimalNumber(floatLiteral: Double(Float.greatestFiniteMagnitude)), NSDecimalNumber(integerLiteral: Int.min)]))
+        XCTAssertTrue(JSONSerialization.isValidJSONObject([Decimal(123), Decimal(Double(Float.leastNonzeroMagnitude))]))
 
         XCTAssertFalse(JSONSerialization.isValidJSONObject(Float.nan))
         XCTAssertFalse(JSONSerialization.isValidJSONObject(Float.infinity))
@@ -1310,19 +1311,19 @@ extension TestJSONSerialization {
     }
 
     func test_serialize_NSDecimalNumber() {
-        let dn0: [Any] = [NSDecimalNumber(floatLiteral: -Double.leastNonzeroMagnitude)]
-        let dn1: [Any] = [NSDecimalNumber(floatLiteral: Double.leastNonzeroMagnitude)]
-        let dn2: [Any] = [NSDecimalNumber(floatLiteral: -Double.leastNormalMagnitude)]
-        let dn3: [Any] = [NSDecimalNumber(floatLiteral: Double.leastNormalMagnitude)]
-        let dn4: [Any] = [NSDecimalNumber(floatLiteral: -Double.greatestFiniteMagnitude)]
-        let dn5: [Any] = [NSDecimalNumber(floatLiteral: Double.greatestFiniteMagnitude)]
+        let dn0: [Any] = [NSDecimalNumber(floatLiteral: Double(-Float.leastNonzeroMagnitude))]
+        let dn1: [Any] = [NSDecimalNumber(floatLiteral: Double(Float.leastNonzeroMagnitude))]
+        let dn2: [Any] = [NSDecimalNumber(floatLiteral: Double(-Float.leastNormalMagnitude))]
+        let dn3: [Any] = [NSDecimalNumber(floatLiteral: Double(Float.leastNormalMagnitude))]
+        let dn4: [Any] = [NSDecimalNumber(floatLiteral: Double(-Float.greatestFiniteMagnitude))]
+        let dn5: [Any] = [NSDecimalNumber(floatLiteral: Double(Float.greatestFiniteMagnitude))]
 
-        XCTAssertEqual(try trySerialize(dn0), "[-0.00000000000000000000000000000000000000000000000000000000000000000004940656458412464128]")
-        XCTAssertEqual(try trySerialize(dn1), "[0.00000000000000000000000000000000000000000000000000000000000000000004940656458412464128]")
-        XCTAssertEqual(try trySerialize(dn2), "[-0.0000000000000000000000000000000000000000000000000002225073858507201792]")
-        XCTAssertEqual(try trySerialize(dn3), "[0.0000000000000000000000000000000000000000000000000002225073858507201792]")
-        XCTAssertEqual(try trySerialize(dn4), "[-17976931348623167488000000000000000000000000000000000]")
-        XCTAssertEqual(try trySerialize(dn5), "[17976931348623167488000000000000000000000000000000000]")
+        XCTAssertEqual(try trySerialize(dn0), "[-0.0000000000000000000000000000000000000000000014012984643248173056]")
+        XCTAssertEqual(try trySerialize(dn1), "[0.0000000000000000000000000000000000000000000014012984643248173056]")
+        XCTAssertEqual(try trySerialize(dn2), "[-0.000000000000000000000000000000000000011754943508222875648]")
+        XCTAssertEqual(try trySerialize(dn3), "[0.000000000000000000000000000000000000011754943508222875648]")
+        XCTAssertEqual(try trySerialize(dn4), "[-340282346638528921600000000000000000000]")
+        XCTAssertEqual(try trySerialize(dn5), "[340282346638528921600000000000000000000]")
         XCTAssertEqual(try trySerialize([NSDecimalNumber(string: "0.0001"), NSDecimalNumber(string: "0.00"), NSDecimalNumber(string: "-0.0")]), "[0.0001,0,0]")
         XCTAssertEqual(try trySerialize([NSDecimalNumber(integerLiteral: Int(Int16.min)), NSDecimalNumber(integerLiteral: 0), NSDecimalNumber(integerLiteral: Int(Int16.max))]), "[-32768,0,32767]")
         XCTAssertEqual(try trySerialize([NSDecimalNumber(booleanLiteral: true), NSDecimalNumber(booleanLiteral: false)]), "[1,0]")


### PR DESCRIPTION
- This prevents initialising from Double values that cannot be
  stored correctly.

- Add extra checks when passing _length and _exponent to initializers.