### PR TITLE
Windows Port Continuation

### DIFF
--- a/CoreFoundation/Base.subproj/CFFileUtilities.c
+++ b/CoreFoundation/Base.subproj/CFFileUtilities.c
@@ -1024,7 +1024,6 @@ CF_PRIVATE void _CFIterateDirectory(CFStringRef directoryPath, Boolean appendSla
     if (!CFStringGetFileSystemRepresentation(directoryPath, directoryPathBuf, CFMaxPathSize)) return;
     
 #if DEPLOYMENT_TARGET_WINDOWS
-#error this path does not support calculateFullResultPath but it must do so someday
     CFIndex cpathLen = strlen(directoryPathBuf);
     // Make sure there is room for the additional space we need in the win32 api
     if (cpathLen + 2 < CFMaxPathSize) {

--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -558,15 +558,14 @@ CF_EXPORT void _NS_pthread_setname_np(const char *name) {
     }
 }
 
-static _CFThreadRef __initialPthread = { NULL, 0 };
+static _CFThreadRef __initialPthread = INVALID_HANDLE_VALUE;
 
 CF_EXPORT int _NS_pthread_main_np() {
-    _CFThreadRef me = pthread_self();
-    if (NULL == __initialPthread.p) {
-        __initialPthread.p = me.p;
-        __initialPthread.x = me.x;
-    }
-    return (pthread_equal(__initialPthread, me));
+    if (__initialPthread == INVALID_HANDLE_VALUE)
+      DuplicateHandle(GetCurrentProcess(), GetCurrentThread(),
+                      GetCurrentProcess(), &__initialPthread, 0, FALSE,
+                      DUPLICATE_SAME_ACCESS);
+    return CompareObjectHandles(__initialPthread, GetCurrentThread());
 }
 
 #endif

--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -558,10 +558,10 @@ CF_EXPORT void _NS_pthread_setname_np(const char *name) {
     }
 }
 
-static pthread_t __initialPthread = { NULL, 0 };
+static _CFThreadRef __initialPthread = { NULL, 0 };
 
 CF_EXPORT int _NS_pthread_main_np() {
-    pthread_t me = pthread_self();
+    _CFThreadRef me = pthread_self();
     if (NULL == __initialPthread.p) {
         __initialPthread.p = me.p;
         __initialPthread.x = me.x;
@@ -1242,7 +1242,7 @@ CF_INLINE void _CF_put_thread_semaphore(_CF_sema_t s) {
 typedef struct _CF_dispatch_once_waiter_s {
     volatile struct _CF_dispatch_once_waiter_s *volatile dow_next;
     _CF_sema_t dow_sema;
-    pthread_t dow_thread;
+    _CFThreadRef dow_thread;
 } *_CF_dispatch_once_waiter_t;
 
 #if defined(__x86_64__) || defined(__i386__)
@@ -1369,12 +1369,12 @@ void _CFThreadSpecificSet(_CFThreadSpecificKey key, CFTypeRef _Nullable value) {
 }
 
 _CFThreadRef _CFThreadCreate(const _CFThreadAttributes attrs, void *_Nullable (* _Nonnull startfn)(void *_Nullable), void *_CF_RESTRICT _Nullable context) {
-    pthread_t thread;
+    _CFThreadRef thread;
     pthread_create(&thread, &attrs, startfn, context);
     return thread;
 }
 
-CF_CROSS_PLATFORM_EXPORT int _CFThreadSetName(pthread_t thread, const char *_Nonnull name) {
+CF_CROSS_PLATFORM_EXPORT int _CFThreadSetName(_CFThreadRef thread, const char *_Nonnull name) {
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI
     if (pthread_equal(pthread_self(), thread)) {
         return pthread_setname_np(name);

--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -27,6 +27,7 @@
 #include <shlobj.h>
 #include <WinIoCtl.h>
 #include <direct.h>
+#include <process.h>
 #define SECURITY_WIN32
 #include <Security.h>
 
@@ -1368,9 +1369,15 @@ void _CFThreadSpecificSet(_CFThreadSpecificKey key, CFTypeRef _Nullable value) {
 }
 
 _CFThreadRef _CFThreadCreate(const _CFThreadAttributes attrs, void *_Nullable (* _Nonnull startfn)(void *_Nullable), void *_CF_RESTRICT _Nullable context) {
+#if DEPLOYMENT_TARGET_WINDOWS
+    return (_CFThreadRef)_beginthreadex(NULL, 0,
+                                        (_beginthreadex_proc_type)startfn,
+                                        context, 0, NULL);
+#else
     _CFThreadRef thread;
     pthread_create(&thread, &attrs, startfn, context);
     return thread;
+#endif
 }
 
 CF_CROSS_PLATFORM_EXPORT int _CFThreadSetName(_CFThreadRef thread, const char *_Nonnull name) {

--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1117,9 +1117,14 @@ void __CFInitialize(void) {
 
 #if DEPLOYMENT_TARGET_WINDOWS
         if (!pthread_main_np()) HALT;   // CoreFoundation must be initialized on the main thread
-#endif
+
+        DuplicateHandle(GetCurrentProcess(), GetCurrentThread(),
+                        GetCurrentProcess(), &_CFMainPThread, 0, FALSE,
+                        DUPLICATE_SAME_ACCESS);
+#else
         // move this next line up into the #if above after Foundation gets off this symbol. Also: <rdar://problem/39622745> Stop using _CFMainPThread
         _CFMainPThread = pthread_self();
+#endif
 
 #if DEPLOYMENT_TARGET_WINDOWS
         // Must not call any CF functions

--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1073,7 +1073,7 @@ CF_PRIVATE Boolean __CFProcessIsRestricted() {
 #if DEPLOYMENT_TARGET_WINDOWS
 #define kNilPthreadT  { nil, nil }
 #else
-#define kNilPthreadT  (pthread_t)0
+#define kNilPthreadT  (_CFThreadRef)0
 #endif
 
 
@@ -1090,12 +1090,12 @@ static Boolean __CFInitializing = 0;
 Boolean __CFInitialized = 0;
 
 // move the next 2 lines down into the #if below, and make it static, after Foundation gets off this symbol on other platforms. 
-CF_EXPORT pthread_t _CFMainPThread;
-pthread_t _CFMainPThread = kNilPthreadT;
+CF_EXPORT _CFThreadRef _CFMainPThread;
+_CFThreadRef _CFMainPThread = kNilPthreadT;
 #if DEPLOYMENT_TARGET_WINDOWS || DEPLOYMENT_TARGET_LINUX
 
-CF_EXPORT pthread_t _CF_pthread_main_thread_np(void);
-pthread_t _CF_pthread_main_thread_np(void) {
+CF_EXPORT _CFThreadRef _CF_pthread_main_thread_np(void);
+_CFThreadRef _CF_pthread_main_thread_np(void) {
     return _CFMainPThread;
 }
 #define pthread_main_thread_np() _CF_pthread_main_thread_np()

--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1071,7 +1071,7 @@ CF_PRIVATE Boolean __CFProcessIsRestricted() {
 }
 
 #if DEPLOYMENT_TARGET_WINDOWS
-#define kNilPthreadT  { nil, nil }
+#define kNilPthreadT  INVALID_HANDLE_VALUE
 #else
 #define kNilPthreadT  (_CFThreadRef)0
 #endif

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -345,22 +345,22 @@ CF_EXPORT char *_Nullable *_Nonnull _CFEnviron(void);
 
 CF_EXPORT void CFLog1(CFLogLevel lev, CFStringRef message);
 
+typedef pthread_attr_t _CFThreadAttributes;
+typedef pthread_t _CFThreadRef;
+typedef pthread_key_t _CFThreadSpecificKey;
+
 CF_CROSS_PLATFORM_EXPORT Boolean _CFIsMainThread(void);
-CF_EXPORT pthread_t _CFMainPThread;
+CF_EXPORT _CFThreadRef _CFMainPThread;
 
 CF_EXPORT CFHashCode __CFHashDouble(double d);
 
-typedef pthread_key_t _CFThreadSpecificKey;
 CF_EXPORT CFTypeRef _Nullable _CFThreadSpecificGet(_CFThreadSpecificKey key);
 CF_EXPORT void _CFThreadSpecificSet(_CFThreadSpecificKey key, CFTypeRef _Nullable value);
 CF_EXPORT _CFThreadSpecificKey _CFThreadSpecificKeyCreate(void);
 
-typedef pthread_attr_t _CFThreadAttributes;
-typedef pthread_t _CFThreadRef;
-
 CF_EXPORT _CFThreadRef _CFThreadCreate(const _CFThreadAttributes attrs, void *_Nullable (* _Nonnull startfn)(void *_Nullable), void *_CF_RESTRICT _Nullable context);
 
-CF_CROSS_PLATFORM_EXPORT int _CFThreadSetName(pthread_t thread, const char *_Nonnull name);
+CF_CROSS_PLATFORM_EXPORT int _CFThreadSetName(_CFThreadRef thread, const char *_Nonnull name);
 CF_CROSS_PLATFORM_EXPORT int _CFThreadGetName(char *_Nonnull buf, int length);
 
 CF_EXPORT Boolean _CFCharacterSetIsLongCharacterMember(CFCharacterSetRef theSet, UTF32Char theChar);

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -345,9 +345,15 @@ CF_EXPORT char *_Nullable *_Nonnull _CFEnviron(void);
 
 CF_EXPORT void CFLog1(CFLogLevel lev, CFStringRef message);
 
-typedef pthread_attr_t _CFThreadAttributes;
+#if DEPLOYMENT_TARGET_WINDOWS
+typedef HANDLE _CFThreadRef;
+typedef DWORD _CFThreadAttributes;
+typedef DWORD _CFThreadSpecificKey;
+#elif _POSIX_THREADS
 typedef pthread_t _CFThreadRef;
+typedef pthread_attr_t _CFThreadAttributes;
 typedef pthread_key_t _CFThreadSpecificKey;
+#endif
 
 CF_CROSS_PLATFORM_EXPORT Boolean _CFIsMainThread(void);
 CF_EXPORT _CFThreadRef _CFMainPThread;

--- a/CoreFoundation/PlugIn.subproj/CFBundle_Executable.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Executable.c
@@ -119,7 +119,7 @@ static CFURLRef _CFBundleCopyExecutableURLRaw(CFURLRef urlPath, CFStringRef exeN
 #elif DEPLOYMENT_TARGET_WINDOWS
     if (!executableURL) {
         executableURL = CFURLCreateWithFileSystemPathRelativeToBase(kCFAllocatorSystemDefault, exeName, kCFURLWindowsPathStyle, false, urlPath);
-        if (executableURL && !_urlExists(executableURL)) {
+        if (executableURL && !_binaryLoadable(executableURL)) {
             CFRelease(executableURL);
             executableURL = NULL;
         }

--- a/CoreFoundation/RunLoop.subproj/CFSocket.c
+++ b/CoreFoundation/RunLoop.subproj/CFSocket.c
@@ -1026,17 +1026,17 @@ static void timeradd(struct timeval *a, struct timeval *b, struct timeval *res) 
 
 #include <sys/syslog.h>
 
-static pthread_t __cfSocketTid()
+static _CFThreadRef __cfSocketTid()
 {
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED
     uint64_t tid = 0;
     if (0 != pthread_threadid_np(NULL, &tid))
         tid = pthread_mach_thread_np(pthread_self());
-    return (pthread_t) tid;
+    return (_CFThreadRef) tid;
 #elif DEPLOYMENT_TARGET_WINDOWS
-    return (pthread_t) GetCurrentThreadId();
+    return (_CFThreadRef) GetCurrentThreadId();
 #else
-    return (pthread_t) pthread_self();
+    return (_CFThreadRef) pthread_self();
 #endif
 }
 
@@ -2615,7 +2615,7 @@ static CFSocketRef _CFSocketCreateWithNative(CFAllocatorRef allocator, CFSocketN
     if (INVALID_SOCKET != sock) CFDictionaryAddValue(__CFAllSockets, (void *)(uintptr_t)sock, memory);
     if (NULL == __CFSocketManagerThread) {
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI || DEPLOYMENT_TARGET_LINUX || DEPLOYMENT_TARGET_FREEBSD
-        pthread_t tid = 0;
+        _CFThreadRef tid = 0;
         pthread_attr_t attr;
         pthread_attr_init(&attr);
         pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM);
@@ -2625,7 +2625,7 @@ static CFSocketRef _CFSocketCreateWithNative(CFAllocatorRef allocator, CFSocketN
 #endif
         pthread_create(&tid, &attr, __CFSocketManager, 0);
         pthread_attr_destroy(&attr);
-//warning CF: we dont actually know that a pthread_t is the same size as void *
+//warning CF: we dont actually know that a _CFThreadRef is the same size as void *
         __CFSocketManagerThread = (void *)tid;
 #elif DEPLOYMENT_TARGET_WINDOWS
         unsigned tid;

--- a/CoreFoundation/RunLoop.subproj/CFSocket.c
+++ b/CoreFoundation/RunLoop.subproj/CFSocket.c
@@ -2625,7 +2625,7 @@ static CFSocketRef _CFSocketCreateWithNative(CFAllocatorRef allocator, CFSocketN
 #endif
         pthread_create(&tid, &attr, __CFSocketManager, 0);
         pthread_attr_destroy(&attr);
-//warning CF: we dont actually know that a _CFThreadRef is the same size as void *
+        _Static_assert(sizeof(_CFThreadRef) == sizeof(void *), "_CFThreadRef is not pointer sized");
         __CFSocketManagerThread = (void *)tid;
 #elif DEPLOYMENT_TARGET_WINDOWS
         unsigned tid;

--- a/CoreFoundation/Stream.subproj/CFStream.c
+++ b/CoreFoundation/Stream.subproj/CFStream.c
@@ -1745,7 +1745,7 @@ static CFRunLoopRef _legacyStreamRunLoop()
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED
             pthread_attr_set_qos_class_np(&attr, qos_class_main(), 0);
 #endif
-            pthread_t workThread;
+            _CFThreadRef workThread;
             (void) pthread_create(&workThread, &attr, _legacyStreamRunLoop_workThread, &sem);
             pthread_attr_destroy(&attr);
 #endif


### PR DESCRIPTION
This replaces some of the threading types to allow us to use the Windows threading model rather than POSIX threads.  This is still incomplete, but these should also be pretty safe without changing the semantics for the other platforms.