### PR TITLE
[CoreFoundation] Fix incorrect cast in _CFRuntimeCreateInstance.

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -443,10 +443,10 @@ CFTypeRef _CFRuntimeCreateInstance(CFAllocatorRef allocator, CFTypeID typeID, CF
     memset(&memory->_cfinfoa, 0, size - (sizeof(memory->_cfisa) + sizeof(memory->_swift_rc)));
 
     // Set up the cfinfo struct
-    uint32_t *cfinfop = (uint32_t *)&(memory->_cfinfoa);
+    uint64_t *cfinfop = (uint64_t *)&(memory->_cfinfoa);
     // The 0x80 means we use the default allocator
-    *cfinfop = (uint32_t)(((uint32_t)typeID << 8) | (0x80));
-    
+    *cfinfop = ((typeID << 8) | (0x80));
+
     return memory;
 #else
     if (__CFRuntimeClassTableSize <= typeID) HALT;


### PR DESCRIPTION
_cfinfoa field of CFRuntimeBase is an _Atomic(uint64_t), but for some
reason it was being accessed from a uint32_t pointer (which I think
violates strict aliasing rules). This was working for little endian
architectures, but would have failed for big endian architectures when
writing the value back into the MSB instead of the LSB.

The fix uses the right size (64 bits) and removes the castings where
possible. However, to avoid the _Atomic to be honored, the field is
still casted to an uint64_t, which might hide future errors (like the
situation this is trying to fix).