### PR TITLE
CoreFoundation: handle LLP64 as LP64

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -229,7 +229,7 @@ extern void __CFGenericValidateType_(CFTypeRef cf, CFTypeID type, const char *fu
 #define __CFBitfield64GetValue(V, N1, N2)	(((V) & __CFBitfield64Mask(N1, N2)) >> (N2))
 #define __CFBitfield64SetValue(V, N1, N2, X)	((V) = ((V) & ~__CFBitfield64Mask(N1, N2)) | ((((uint64_t)X) << (N2)) & __CFBitfield64Mask(N1, N2)))
 
-#if __LP64__ || DEPLOYMENT_TARGET_ANDROID
+#if TARGET_RT_64_BIT || DEPLOYMENT_TARGET_ANDROID
 typedef uint64_t __CFInfoType;
 #define __CFInfoMask(N1, N2) __CFBitfield64Mask(N1, N2)
 #else
@@ -291,13 +291,13 @@ CF_PRIVATE void __CFRuntimeSetRC(CFTypeRef cf, uint32_t rc);
 // On systems where we have ObjC support (DEPLOYMENT_RUNTIME_OBJC), STATIC_CLASS_REF(…) can statically produce a reference to the ObjC class symbol that ties into this particular type.
 // When compiling for Swift Foundation, STATIC_CLASS_REF returns a Swift class. There's a mapping of ObjC name classes to Swift symbols in the header that defines it that should be kept up to date if more constant objects are defined.
 // On all other platforms, it returns NULL, which is okay; we only need the type ID if CF is to be used by itself.
-#if __LP64__
+#if TARGET_RT_64_BIT
     #define INIT_CFRUNTIME_BASE_WITH_CLASS(CLASS, TYPEID) {  ._cfisa = (uintptr_t)STATIC_CLASS_REF(CLASS) , ._cfinfoa = 0x0000000000000080ULL | ((TYPEID) << 8), _CFRUNTIME_BASE_INIT_SWIFT_RETAIN_COUNT }
     #define INIT_CFRUNTIME_BASE_WITH_CLASS_AND_FLAGS(CLASS, TYPEID, FLAGS) {  ._cfisa = (uintptr_t)STATIC_CLASS_REF(CLASS) , ._cfinfoa = 0x0000000000000080ULL | ((TYPEID) << 8) | (FLAGS), _CFRUNTIME_BASE_INIT_SWIFT_RETAIN_COUNT }
-#else // if !__LP64__
+#else // if !TARGET_RT_64_BIT
     #define INIT_CFRUNTIME_BASE_WITH_CLASS(CLASS, TYPEID) { ._cfisa = (uintptr_t)STATIC_CLASS_REF(CLASS) , ._cfinfoa = 0x00000080UL | ((TYPEID) << 8), _CFRUNTIME_BASE_INIT_SWIFT_RETAIN_COUNT }
     #define INIT_CFRUNTIME_BASE_WITH_CLASS_AND_FLAGS(CLASS, TYPEID, FLAGS) {  ._cfisa = (uintptr_t)STATIC_CLASS_REF(CLASS), ._cfinfoa = 0x0000000000000080ULL | ((TYPEID) << 8) | (FLAGS), _CFRUNTIME_BASE_INIT_SWIFT_RETAIN_COUNT }
-#endif // __LP64__
+#endif // TARGET_RT_64_BIT
 
 #define __CFBitIsSet(V, N)  (((V) & (1UL << (N))) != 0)
 #define __CFBitSet(V, N)  ((V) |= (1UL << (N)))

--- a/CoreFoundation/Base.subproj/CFOverflow.h
+++ b/CoreFoundation/Base.subproj/CFOverflow.h
@@ -10,6 +10,8 @@
 #ifndef CFOverflow_h
 #define CFOverflow_h
 
+#include <CoreFoundation/CFBase.h>
+
 #if __has_include(<os/overflow.h>)
 #include <os/overflow.h>
 #else
@@ -55,7 +57,7 @@ CF_INLINE _CFOverflowResult _CFPositiveIntegerProductWouldOverflow(CFIndex si_a,
 
 CF_INLINE _CFOverflowResult _CFPointerSumWouldOverflow(void const *p, size_t n, void * /*_Nullable*/ * /*_Nullable*/ outSum) {
     _CFOverflowResult result = _CFOverflowResultOK;
-#if __LP64__
+#if TARGET_RT_64_BIT
     uint64_t sum = 0;
     uint64_t const lhs = (uint64_t)p;
     uint64_t const rhs = (uint64_t)n;

--- a/CoreFoundation/Base.subproj/CFPriv.h
+++ b/CoreFoundation/Base.subproj/CFPriv.h
@@ -90,7 +90,7 @@ CF_EXPORT void CFPreferencesFlushCaches(void);
 CF_EXPORT Boolean _CFURLGetWideFileSystemRepresentation(CFURLRef url, Boolean resolveAgainstBase, wchar_t *buffer, CFIndex bufferLength);
 #endif
 
-#if !__LP64__
+#if !TARGET_RT_64_BIT
 #if TARGET_OS_OSX
 struct FSSpec;
 CF_EXPORT

--- a/CoreFoundation/Base.subproj/CFRuntime.h
+++ b/CoreFoundation/Base.subproj/CFRuntime.h
@@ -204,14 +204,14 @@ typedef struct __CFRuntimeBase {
 
 typedef struct __CFRuntimeBase {
     uintptr_t _cfisa;
-#if defined(__LP64__) || defined(__LLP64__)
+#if TARGET_RT_64_BIT
     _Atomic(uint64_t) _cfinfoa;
 #else
     _Atomic(uint32_t) _cfinfoa;
 #endif
 } CFRuntimeBase;
 
-#if defined(__LP64__) || defined(__LLP64__)
+#if TARGET_RT_64_BIT
 #define INIT_CFRUNTIME_BASE(...) {0, 0x0000000000000080ULL}
 #else
 #define INIT_CFRUNTIME_BASE(...) {0, 0x00000080UL}

--- a/CoreFoundation/Base.subproj/CFSortFunctions.c
+++ b/CoreFoundation/Base.subproj/CFSortFunctions.c
@@ -333,7 +333,7 @@ CF_INLINE _CFOverflowResult _CFIntegerProductWouldOverflow(CFIndex si_a, CFIndex
         result = _CFOverflowResultNegativeParameters;
     } else {
         int32_t err = CHECKINT_NO_ERROR;
-#if __LP64__
+#if TARGET_RT_64_BIT
         __checkint_int64_mul(si_a, si_b, &err);
 #else
         __checkint_int32_mul(si_a, si_b, &err);
@@ -347,7 +347,7 @@ CF_INLINE _CFOverflowResult _CFIntegerProductWouldOverflow(CFIndex si_a, CFIndex
 CF_INLINE _CFOverflowResult _CFPointerSumWouldOverflow(void *p, size_t n) {
     _CFOverflowResult result = _CFOverflowResultOK;
     int32_t err = CHECKINT_NO_ERROR;
-#if __LP64__
+#if TARGET_RT_64_BIT
     __checkint_uint64_add((uint64_t)p, (uint64_t)n, &err);
 #else
     __checkint_uint32_add((uint32_t)p, (uint32_t)n, &err);

--- a/CoreFoundation/Base.subproj/CFUtilities.c
+++ b/CoreFoundation/Base.subproj/CFUtilities.c
@@ -8,6 +8,7 @@
 	Responsibility: Tony Parker
 */
 
+#include <CoreFoundation/CFBase.h>
 #include <CoreFoundation/CFPriv.h>
 #include "CFInternal.h"
 #include "CFLocaleInternal.h"
@@ -1213,7 +1214,7 @@ CF_PRIVATE Boolean _CFReadMappedFromFile(CFStringRef path, Boolean map, Boolean 
         if (errorPtr) *errorPtr = _CFErrorWithFilePathCodeDomain(kCFErrorDomainPOSIX, ENOMEM, path);
         return false;
     }
-#if __LP64__
+#if TARGET_RT_64_BIT
 #else
     if (statBuf.st_size > (1ull << 31)) {	// refuse to do more than 2GB
         close(fd);

--- a/CoreFoundation/Base.subproj/SwiftRuntime/TargetConditionals.h
+++ b/CoreFoundation/Base.subproj/SwiftRuntime/TargetConditionals.h
@@ -224,7 +224,7 @@
 #error unknown endian
 #endif
 
-#if __LP64__
+#if __LP64__ || __LLP64__ || __POINTER_WIDTH__-0 == 64
 #define TARGET_RT_64_BIT        1
 #else
 #define TARGET_RT_64_BIT        0

--- a/CoreFoundation/Collections.subproj/CFBasicHash.c
+++ b/CoreFoundation/Collections.subproj/CFBasicHash.c
@@ -9,6 +9,7 @@
 */
 
 #include "CFBasicHash.h"
+#include <CoreFoundation/CFBase.h>
 #include <CoreFoundation/CFRuntime.h>
 #include "CFRuntime_Internal.h"
 #include <CoreFoundation/CFSet.h>
@@ -199,10 +200,6 @@ extern int __dtrace_isenabled$Cocoa_HashTable$test_equal$v1(void);
 #endif
 
 
-#if !defined(__LP64__)
-#define __LP64__ 0
-#endif
-
 // Prime numbers. Values above 100 have been adjusted up so that the
 // malloced block size will be just below a multiple of 512; values
 // above 1200 have been adjusted up to just below a multiple of 4096.
@@ -212,7 +209,7 @@ static const uintptr_t __CFBasicHashTableSizes[64] = {
     214519, 346607, 561109, 907759, 1468927, 2376191, 3845119,
     6221311, 10066421, 16287743, 26354171, 42641881, 68996069,
     111638519, 180634607, 292272623, 472907251,
-#if __LP64__
+#if TARGET_RT_64_BIT
     765180413UL, 1238087663UL, 2003267557UL, 3241355263UL, 5244622819UL,
 #if 0
     8485977589UL, 13730600407UL, 22216578047UL, 35947178479UL,
@@ -230,7 +227,7 @@ static const uintptr_t __CFBasicHashTableCapacities[64] = {
     132580, 214215, 346784, 561026, 907847, 1468567, 2376414,
     3844982, 6221390, 10066379, 16287773, 26354132, 42641916,
     68996399, 111638327, 180634415, 292272755,
-#if __LP64__
+#if TARGET_RT_64_BIT
     472907503UL, 765180257UL, 1238087439UL, 2003267722UL, 3241355160UL,
 #if 0
     5244622578UL, 8485977737UL, 13730600347UL, 22216578100UL,
@@ -249,7 +246,7 @@ static const uintptr_t __CFBasicHashPrimitiveRoots[64] = {
     3, 5, 10, 3, 3, 22, 3,
     3, 3, 5, 2, 22, 2,
     11, 5, 5, 2,
-#if __LP64__
+#if TARGET_RT_64_BIT
     3, 10, 2, 3, 10,
     2, 3, 5, 3,
     3, 2, 7, 2,

--- a/CoreFoundation/Collections.subproj/CFData.c
+++ b/CoreFoundation/Collections.subproj/CFData.c
@@ -8,6 +8,7 @@
 	Responsibility: Kevin Perry
 */
 
+#include <CoreFoundation/CFBase.h>
 #include <CoreFoundation/CFData.h>
 #include <CoreFoundation/CFPriv.h>
 #include "CFInternal.h"
@@ -17,7 +18,7 @@
 
 
 
-#if __LP64__
+#if TARGET_RT_64_BIT
 #define CFDATA_MAX_SIZE	    ((1ULL << 42) - 1)
 #else
 #define CFDATA_MAX_SIZE	    ((1ULL << 31) - 1)
@@ -161,7 +162,7 @@ CF_INLINE void __CFDataSetNumBytes(CFMutableDataRef data, CFIndex v) {
     data->_capacity = v;
 }
 
-#if __LP64__
+#if TARGET_RT_64_BIT
 #define CHUNK_SIZE (1ULL << 29)
 #define LOW_THRESHOLD (1ULL << 20)
 #define HIGH_THRESHOLD (1ULL << 32)
@@ -183,7 +184,7 @@ CF_INLINE CFIndex __CFDataRoundUpCapacity(CFIndex capacity) {
 	return (1L << (long)flsl(capacity));
     } else {
 	/* Round up to next multiple of CHUNK_SIZE */
-	unsigned long newCapacity = CHUNK_SIZE * (1+(capacity >> ((long)flsl(CHUNK_SIZE)-1)));
+	unsigned long long newCapacity = CHUNK_SIZE * (1+(capacity >> ((long)flsl(CHUNK_SIZE)-1)));
 	return __CFMin(newCapacity, CFDATA_MAX_SIZE);
     }
 }

--- a/CoreFoundation/Locale.subproj/CFNumberFormatter.c
+++ b/CoreFoundation/Locale.subproj/CFNumberFormatter.c
@@ -8,6 +8,7 @@
 	Responsibility: David Smith
 */
 
+#include <CoreFoundation/CFBase.h>
 #include <CoreFoundation/CFNumberFormatter.h>
 #include <CoreFoundation/ForFoundationOnly.h>
 #include <CoreFoundation/CFBigNumber.h>
@@ -488,7 +489,7 @@ CFStringRef CFNumberFormatterCreateStringWithValue(CFAllocatorRef allocator, CFN
     } else if (numberType == kCFNumberSInt64Type || numberType == kCFNumberLongLongType) {
 	FORMAT_INT(int64_t, _CFBigNumInitWithInt64)
     } else if (numberType == kCFNumberLongType || numberType == kCFNumberCFIndexType) {
-#if __LP64__
+#if TARGET_RT_64_BIT
 	FORMAT_INT(int64_t, _CFBigNumInitWithInt64)
 #else
 	FORMAT_INT(int32_t, _CFBigNumInitWithInt32)
@@ -733,7 +734,7 @@ Boolean CFNumberFormatterGetValueFromString(CFNumberFormatterRef formatter, CFSt
 	}
 	break;
     case kCFNumberSInt32Type: case kCFNumberIntType:
-#if !__LP64__
+#if !TARGET_RT_64_BIT
     case kCFNumberLongType: case kCFNumberCFIndexType:
 #endif
 	if (INT32_MIN <= dreti && dreti <= INT32_MAX) {
@@ -742,7 +743,7 @@ Boolean CFNumberFormatterGetValueFromString(CFNumberFormatterRef formatter, CFSt
 	}
 	break;
     case kCFNumberSInt64Type: case kCFNumberLongLongType:
-#if __LP64__
+#if TARGET_RT_64_BIT
     case kCFNumberLongType: case kCFNumberCFIndexType:
 #endif
 	if (INT64_MIN <= dreti && dreti <= INT64_MAX) {

--- a/CoreFoundation/NumberDate.subproj/CFBigNumber.c
+++ b/CoreFoundation/NumberDate.subproj/CFBigNumber.c
@@ -9,6 +9,7 @@
 	Original author: Zhi Feng Huang
 */
 
+#include <CoreFoundation/CFBase.h>
 #include <CoreFoundation/CFBigNumber.h>
 #include <limits.h>
 #include <stdlib.h>
@@ -26,7 +27,7 @@ typedef struct {
 
 CF_EXPORT CFNumberType _CFNumberGetType2(CFNumberRef number);
 
-#if __LP64__
+#if TARGET_RT_64_BIT
 
 #ifndef _INT128_T
 #define _INT128_T
@@ -116,7 +117,7 @@ void _CFBigNumInitWithInt64(_CFBigNum *r, int64_t inNum) {
     r->digits[2] = dig2;
 }
 
-#ifdef __LP64__
+#if TARGET_RT_64_BIT
 void _CFBigNumInitWithInt128(_CFBigNum *r, __int128_t inNum) {
     memset(r, 0, sizeof(*r));
     __uint128_t unsignInNum = inNum;
@@ -170,7 +171,7 @@ void _CFBigNumInitWithUInt64(_CFBigNum *r, uint64_t inNum) {
     r->digits[2] = dig2;
 }
 
-#ifdef __LP64__
+#if TARGET_RT_64_BIT
 void _CFBigNumInitWithUInt128(_CFBigNum *r, __uint128_t inNum) {
     memset(r, 0, sizeof(*r));
     __uint128_t unsignInNum = inNum;
@@ -225,7 +226,7 @@ int64_t _CFBigNumGetInt64(const _CFBigNum *num) {
     return result;
 }
 
-#if __LP64__
+#if TARGET_RT_64_BIT
 __int128_t _CFBigNumGetInt128(const _CFBigNum *num) {
     __int128_t result = num->digits[0];
     result += (__int128_t)num->digits[1] * BIG_DIGITS_LIMIT;
@@ -262,7 +263,7 @@ uint64_t _CFBigNumGetUInt64(const _CFBigNum *num) {
     return result;
 }
 
-#if __LP64__
+#if TARGET_RT_64_BIT
 __uint128_t _CFBigNumGetUInt128(const _CFBigNum *num) {
     __uint128_t result = num->digits[0];
     result += (__uint128_t)num->digits[1] * BIG_DIGITS_LIMIT;
@@ -331,7 +332,7 @@ void _CFBigNumInitWithBytes(_CFBigNum *r, const void *bytes, CFNumberType type) 
             _CFBigNumInitWithInt32(r, *(int32_t *)bytes);
         }
         return;
-#if __LP64__
+#if TARGET_RT_64_BIT
     case kCFNumberSInt128Type: {
         CFSInt128Struct s;
         memmove(&s, bytes, sizeof(CFSInt128Struct)); // the hard way because bytes might not be aligned
@@ -381,7 +382,7 @@ CFNumberRef _CFNumberCreateWithBigNum(const _CFBigNum *input) {
             return result;
         }
     }
-#if __LP64__
+#if TARGET_RT_64_BIT
     _CFBigNumInitWithInt128(&maxlimit, INT128_MAX);
     _CFBigNumInitWithInt128(&minlimit, INT128_MIN);
     CFComparisonResult cr = _CFBigNumCompare(input, &maxlimit);

--- a/CoreFoundation/NumberDate.subproj/CFBigNumber.h
+++ b/CoreFoundation/NumberDate.subproj/CFBigNumber.h
@@ -25,7 +25,7 @@ void _CFBigNumInitWithInt8(_CFBigNum *r, int8_t inNum);
 void _CFBigNumInitWithInt16(_CFBigNum *r, int16_t inNum);
 void _CFBigNumInitWithInt32(_CFBigNum *r, int32_t inNum);
 void _CFBigNumInitWithInt64(_CFBigNum *r, int64_t inNum);
-#ifdef __LP64__
+#if TARGET_RT_64_BIT
 void _CFBigNumInitWithInt128(_CFBigNum *r, __int128_t inNum);
 #endif
 
@@ -33,7 +33,7 @@ void _CFBigNumInitWithUInt8(_CFBigNum *r, uint8_t inNum);
 void _CFBigNumInitWithUInt16(_CFBigNum *r, uint16_t inNum);
 void _CFBigNumInitWithUInt32(_CFBigNum *r, uint32_t inNum);
 void _CFBigNumInitWithUInt64(_CFBigNum *r, uint64_t inNum);
-#ifdef __LP64__
+#if TARGET_RT_64_BIT
 void _CFBigNumInitWithUInt128(_CFBigNum *r, __uint128_t inNum);
 #endif
 
@@ -41,7 +41,7 @@ int8_t  _CFBigNumGetInt8(const _CFBigNum *num);
 int16_t _CFBigNumGetInt16(const _CFBigNum *num);
 int32_t _CFBigNumGetInt32(const _CFBigNum *num);
 int64_t _CFBigNumGetInt64(const _CFBigNum *num);
-#ifdef __LP64__
+#if TARGET_RT_64_BIT
 __int128_t _CFBigNumGetInt128(const _CFBigNum *num);
 #endif
 
@@ -49,7 +49,7 @@ uint8_t  _CFBigNumGetUInt8(const _CFBigNum *num);
 uint16_t _CFBigNumGetUInt16(const _CFBigNum *num);
 uint32_t _CFBigNumGetUInt32(const _CFBigNum *num);
 uint64_t _CFBigNumGetUInt64(const _CFBigNum *num);
-#ifdef __LP64__
+#if TARGET_RT_64_BIT
 __uint128_t _CFBigNumGetUInt128(const _CFBigNum *num);
 #endif
 

--- a/CoreFoundation/NumberDate.subproj/CFNumber.c
+++ b/CoreFoundation/NumberDate.subproj/CFNumber.c
@@ -8,6 +8,7 @@
 	Responsibility: Ali Ozer
 */
 
+#include <CoreFoundation/CFBase.h>
 #include <CoreFoundation/CFNumber.h>
 #include "CFInternal.h"
 #include "CFRuntime_Internal.h"
@@ -451,7 +452,7 @@ static const struct {
     /* kCFNumberCharType */	{kCFNumberSInt8Type, 0, 0, 0, 0},
     /* kCFNumberShortType */	{kCFNumberSInt16Type, 0, 0, 1, 0},
     /* kCFNumberIntType */	{kCFNumberSInt32Type, 0, 0, 2, 0},
-#if __LP64__
+#if TARGET_RT_64_BIT
     /* kCFNumberLongType */	{kCFNumberSInt64Type, 0, 0, 3, 0},
 #else
     /* kCFNumberLongType */	{kCFNumberSInt32Type, 0, 0, 2, 0},
@@ -460,7 +461,7 @@ static const struct {
     /* kCFNumberFloatType */	{kCFNumberFloat32Type, 1, 0, 2, 0},
     /* kCFNumberDoubleType */	{kCFNumberFloat64Type, 1, 1, 3, 0},
 
-#if __LP64__
+#if TARGET_RT_64_BIT
     /* kCFNumberCFIndexType */	{kCFNumberSInt64Type, 0, 0, 3, 0},
     /* kCFNumberNSIntegerType */ {kCFNumberSInt64Type, 0, 0, 3, 0},
     /* kCFNumberCGFloatType */	{kCFNumberFloat64Type, 1, 1, 3, 0},

--- a/CoreFoundation/Parsing.subproj/CFBinaryPList.c
+++ b/CoreFoundation/Parsing.subproj/CFBinaryPList.c
@@ -9,6 +9,7 @@
 */
 
 
+#include <CoreFoundation/CFBase.h>
 #include <CoreFoundation/CFString.h>
 #include <CoreFoundation/CFNumber.h>
 #include <CoreFoundation/CFDate.h>
@@ -56,7 +57,7 @@ CF_INLINE uint64_t __check_uint64_mul_unsigned_unsigned(uint64_t x, uint64_t y, 
   return x * y;
 };
 
-#if __LP64__
+#if TARGET_RT_64_BIT
 #define check_ptr_add(p, a, err)	(const uint8_t *)__check_uint64_add_unsigned_unsigned((uintptr_t)p, (uintptr_t)a, err)
 #define check_size_t_mul(b, a, err)	(size_t)__check_uint64_mul_unsigned_unsigned((size_t)b, (size_t)a, err)
 #else

--- a/CoreFoundation/Parsing.subproj/CFOldStylePList.c
+++ b/CoreFoundation/Parsing.subproj/CFOldStylePList.c
@@ -8,6 +8,7 @@
  Responsibility: Tony Parker
  */
 
+#include <CoreFoundation/CFBase.h>
 #include <CoreFoundation/CFPropertyList.h>
 #include <CoreFoundation/CFDate.h>
 #include <CoreFoundation/CFNumber.h>
@@ -368,7 +369,7 @@ static CFStringRef parsePlistString(_CFStringsFileParseInfo *pInfo, bool require
 // when this returns yes, pInfo->error will be set
 static BOOL depthIsInvalid(_CFStringsFileParseInfo *pInfo, const uint32_t depth) {
     BOOL invalid = NO;
-#if __LP64__
+#if TARGET_RT_64_BIT
 #define MAX_DEPTH 512
 #else
 #define MAX_DEPTH 256

--- a/CoreFoundation/PlugIn.subproj/CFBundle.h
+++ b/CoreFoundation/PlugIn.subproj/CFBundle.h
@@ -304,7 +304,7 @@ CFPlugInRef CFBundleGetPlugIn(CFBundleRef bundle);
 
 /* ==================== Resource Manager-Related API ==================== */
 
-#if __LP64__
+#if TARGET_RT_64_BIT
 typedef int CFBundleRefNum;
 #else
 typedef SInt16 CFBundleRefNum;

--- a/CoreFoundation/PlugIn.subproj/CFBundle_Binary.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Binary.c
@@ -167,7 +167,7 @@ static CFStringRef _CFBundleDYLDCopyLoadedImagePathForPointer(void *p) {
         uint32_t i, j, n = _dyld_image_count();
         Boolean foundit = false;
         const char *name;
-#if __LP64__
+#if TARGET_RT_64_BIT
 #define MACH_HEADER_TYPE struct mach_header_64
 #define MACH_SEGMENT_CMD_TYPE struct segment_command_64
 #define MACH_SEGMENT_FLAVOR LC_SEGMENT_64

--- a/CoreFoundation/PlugIn.subproj/CFBundle_Executable.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Executable.c
@@ -8,6 +8,7 @@
         Responsibility: Tony Parker
 */
 
+#include <CoreFoundation/CFBase.h>
 #include <CoreFoundation/CFBundle.h>
 #include "CFBundle_Internal.h"
 
@@ -18,11 +19,11 @@
 #if !DEPLOYMENT_RUNTIME_OBJC && !DEPLOYMENT_TARGET_WINDOWS && !DEPLOYMENT_TARGET_ANDROID
 
     #if DEPLOYMENT_TARGET_LINUX
-        #if __LP64__
+        #if TARGET_RT_64_BIT
             #define _CFBundleFHSArchDirectorySuffix "64"
-        #else // !__LP64__
+        #else // !TARGET_RT_64_BIT
             #define _CFBundleFHSArchDirectorySuffix "32"
-        #endif // __LP64__
+        #endif // TARGET_RT_64_BIT
     #endif // DEPLOYMENT_TARGET_LINUX
 
     CONST_STRING_DECL(_kCFBundleFHSDirectory_bin, "bin");

--- a/CoreFoundation/PlugIn.subproj/CFBundle_Grok.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Grok.c
@@ -138,19 +138,19 @@ static char *_CFBundleGetSectData(const char *segname, const char *sectname, uns
     
     for (i = 0; i < numImages; i++) {
         if (mhp == (void *)_dyld_get_image_header(i)) {
-#if __LP64__
+#if TARGET_RT_64_BIT
             const struct section_64 *sp = getsectbynamefromheader_64((const struct mach_header_64 *)mhp, segname, sectname);
             if (sp) {
                 retval = (char *)(sp->addr + _dyld_get_image_vmaddr_slide(i));
                 localSize = (unsigned long)sp->size;
             }
-#else /* __LP64__ */
+#else /* TARGET_RT_64_BIT */
             const struct section *sp = getsectbynamefromheader((const struct mach_header *)mhp, segname, sectname);
             if (sp) {
                 retval = (char *)(sp->addr + _dyld_get_image_vmaddr_slide(i));
                 localSize = (unsigned long)sp->size;
             }
-#endif /* __LP64__ */
+#endif /* TARGET_RT_64_BIT */
             break;
         }
     }
@@ -170,11 +170,11 @@ CF_PRIVATE Boolean _CFBundleGrokObjCImageInfoFromMainExecutable(uint32_t *objcVe
     uint32_t localVersion = 0, localFlags = 0;
     char *bytes = NULL;
     unsigned long length = 0;
-#if __LP64__
+#if TARGET_RT_64_BIT
     if (getsegbyname(OBJC_SEGMENT_64)) bytes = _CFBundleGetSectData(OBJC_SEGMENT_64, IMAGE_INFO_SECTION_64, &length);
-#else /* __LP64__ */
+#else /* TARGET_RT_64_BIT */
     if (getsegbyname(OBJC_SEGMENT)) bytes = _CFBundleGetSectData(OBJC_SEGMENT, IMAGE_INFO_SECTION, &length);
-#endif /* __LP64__ */
+#endif /* TARGET_RT_64_BIT */
     if (bytes && length >= 8) {
         localVersion = *(uint32_t *)bytes;
         localFlags = *(uint32_t *)(bytes + 4);

--- a/CoreFoundation/RunLoop.subproj/CFMessagePort.c
+++ b/CoreFoundation/RunLoop.subproj/CFMessagePort.c
@@ -8,6 +8,7 @@
 	Responsibility: Christopher Kane
 */
 
+#include <CoreFoundation/CFBase.h>
 #include <CoreFoundation/CFMessagePort.h>
 #include <CoreFoundation/CFRunLoop.h>
 #include <CoreFoundation/CFMachPort.h>
@@ -132,10 +133,6 @@ CF_INLINE void __CFMessagePortUnlock(CFMessagePortRef ms) {
     __CFUnlock(&(ms->_lock));
 }
 
-#if !defined(__LP64__)
-#define __LP64__ 0
-#endif
-
 // Just a heuristic
 #define __CFMessagePortMaxInlineBytes ((int32_t)4000)
 
@@ -153,14 +150,14 @@ struct __CFMessagePortMachMessage {
 
 #define CFMP_MSGH_ID_64 0x63666d70 // 'cfmp'
 #define CFMP_MSGH_ID_32 0x43464d50 // 'CFMP'
-#if __LP64__
+#if TARGET_RT_64_BIT
 #define CFMP_MSGH_ID CFMP_MSGH_ID_64
 #else
 #define CFMP_MSGH_ID CFMP_MSGH_ID_32
 #endif
 
 // NOTE: mach_msg_ool_descriptor_t has different sizes based on 32/64-bit for send/receive
-#define __INNARD_OFFSET (((!(msgp->header.msgh_bits & MACH_MSGH_BITS_COMPLEX) && ((mach_msg_header_t *)msgp)->msgh_id == CFMP_MSGH_ID_32) || ( (msgp->header.msgh_bits & MACH_MSGH_BITS_COMPLEX) && !__LP64__)) ? 40 : 44)
+#define __INNARD_OFFSET (((!(msgp->header.msgh_bits & MACH_MSGH_BITS_COMPLEX) && ((mach_msg_header_t *)msgp)->msgh_id == CFMP_MSGH_ID_32) || ( (msgp->header.msgh_bits & MACH_MSGH_BITS_COMPLEX) && !TARGET_RT_64_BIT)) ? 40 : 44)
 
 #define MAGIC 0xF0F2F4F8
 

--- a/CoreFoundation/String.subproj/CFString.c
+++ b/CoreFoundation/String.subproj/CFString.c
@@ -138,6 +138,8 @@ struct __notInlineMutable {
     unsigned int capacityProvidedExternally:1;
 #if __LP64__
     unsigned long desiredCapacity:60;
+#elif __LLP64__
+    unsigned long long desiredCapacity:60;
 #else
     unsigned long desiredCapacity:28;
 #endif
@@ -533,7 +535,7 @@ CFStringEncoding __CFStringComputeEightBitStringEncoding(void) {
 /* Returns whether the provided bytes can be stored in ASCII
 */
 CF_INLINE Boolean __CFBytesInASCII(const uint8_t *bytes, CFIndex len) {
-#if __LP64__
+#if TARGET_RT_64_BIT
     /* A bit of unrolling; go by 32s, 16s, and 8s first */
     while (len >= 32) {
         uint64_t val = *(const uint64_t *)bytes;
@@ -621,7 +623,7 @@ Additional complications are applied in the following order:
 */
 #define SHRINKFACTOR(c) (c / 2)
 
-#if __LP64__
+#if TARGET_RT_64_BIT
 #define GROWFACTOR(c) ((c * 3 + 1) / 2)
 #else
 #define GROWFACTOR(c) (((c) >= (ULONG_MAX / 3UL)) ? __CFMax(LONG_MAX - 4095, (c)) : (((unsigned long)c * 3 + 1) / 2))
@@ -5984,7 +5986,7 @@ enum {
     CFFormatSize4 = 3,
     CFFormatSize8 = 4,
     CFFormatSize16 = 5,
-#if __LP64__
+#if TARGET_RT_64_BIT
     CFFormatSizeLong = CFFormatSize8,
     CFFormatSizePointer = CFFormatSize8
 #else

--- a/CoreFoundation/String.subproj/CFString.h
+++ b/CoreFoundation/String.subproj/CFString.h
@@ -167,11 +167,11 @@ struct __CFConstStr {
         uint64_t _cfinfoa;
     } _base;
     uint8_t *_ptr;
-#if defined(__LP64__) && defined(__BIG_ENDIAN__)
+#if TARGET_RT_64_BIT && defined(__BIG_ENDIAN__)
     uint64_t _length;
 #else // 32-bit:
     uint32_t _length;
-#endif // defined(__LP64__) || defined(__LLP64__)
+#endif // TARGET_RT_64_BIT && defined(__BIG_ENDIAN__)
 };
 
 #if __BIG_ENDIAN__

--- a/CoreFoundation/StringEncodings.subproj/CFUniChar.c
+++ b/CoreFoundation/StringEncodings.subproj/CFUniChar.c
@@ -8,6 +8,7 @@
 	Responsibility: Foundation Team
 */
 
+#include <CoreFoundation/CFBase.h>
 #include <CoreFoundation/CFByteOrder.h>
 #include "CFInternal.h"
 #include "CFUniChar.h" 
@@ -88,7 +89,7 @@ static const void *__CFGetSectDataPtr(const char *segname, const char *sectname,
     for (idx = 0; idx < cnt; idx++) {
        void *mh = (void *)_dyld_get_image_header(idx);
        if (mh != &_mh_dylib_header) continue;
-#if __LP64__
+#if TARGET_RT_64_BIT
        const struct section_64 *sect = getsectbynamefromheader_64((struct mach_header_64 *)mh, segname, sectname);
 #else
        const struct section *sect = getsectbynamefromheader((struct mach_header *)mh, segname, sectname);


### PR DESCRIPTION
Adjust the various sites that consider LP64 to also consider LLP64
environments.  This is needed to support Windows x86_64.  Normalize the checks
across the code base to use `TARGET_RT_64_BIT` which is defined in
TargetConditionals.h.