### PR TITLE
[SR-9503] Match NSNull's description to Darwin's

### DIFF
--- a/Foundation/NSNull.swift
+++ b/Foundation/NSNull.swift
@@ -34,6 +34,10 @@ open class NSNull : NSObject, NSCopying, NSSecureCoding {
         return true
     }
     
+    open override var description: String {
+        return "<null>"
+    }
+    
     open override func isEqual(_ object: Any?) -> Bool {
         return object is NSNull
     }

--- a/TestFoundation/TestNSNull.swift
+++ b/TestFoundation/TestNSNull.swift
@@ -11,7 +11,8 @@ class TestNSNull : XCTestCase {
     
     static var allTests: [(String, (TestNSNull) -> () throws -> Void)] {
         return [
-            ("test_alwaysEqual", test_alwaysEqual)
+            ("test_alwaysEqual", test_alwaysEqual),
+            ("test_description", test_description),
         ]
     }
     
@@ -33,5 +34,9 @@ class TestNSNull : XCTestCase {
         
         //Make sure that NSNull() != .None
         XCTAssertNotEqual(null_1, null_4)        
+    }
+    
+    func test_description() {
+        XCTAssertEqual(NSNull().description, "<null>")
     }
 }

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -86,7 +86,6 @@ XCTMain([
     testCase(TestURLResponse.allTests),
     testCase(TestHTTPURLResponse.allTests),
     testCase(TestURLSession.allTests),
-    testCase(TestNSNull.allTests),
     testCase(TestNSUUID.allTests),
     testCase(TestNSValue.allTests),
     testCase(TestUserDefaults.allTests),


### PR DESCRIPTION
Fixes SR-9503.

NSNull has `<null>` as description on Darwin.
It had `<NSNull: 0x00000000075ce1c0>` elsewhere.

Overridden description method to match Darwin's behaviour.

I've also noticed that `testCase(TestNSNull.allTests)` was listed twice in `TestFoundation/main` and removed extra entry.