### PR TITLE
CoreFoundation: introduce `_CFMutex`, `_CFRecursiveMutex`

### DIFF
--- a/CoreFoundation/Locale.subproj/CFDateFormatter.c
+++ b/CoreFoundation/Locale.subproj/CFDateFormatter.c
@@ -58,7 +58,7 @@ CFArrayRef CFDateFormatterCreateDateFormatsFromTemplates(CFAllocatorRef allocato
 
 static Boolean useTemplatePatternGenerator(CFLocaleRef locale, void(^work)(UDateTimePatternGenerator *ptg)) {
     static UDateTimePatternGenerator *ptg;
-    static pthread_mutex_t ptgLock = PTHREAD_MUTEX_INITIALIZER;
+    static _CFMutex ptgLock = _CF_MUTEX_STATIC_INITIALIZER;
     static const char *ptgLocaleName;
     CFStringRef ln = locale ? CFLocaleGetIdentifier(locale) : CFSTR("");
     char buffer[BUFFER_SIZE];
@@ -73,7 +73,7 @@ static Boolean useTemplatePatternGenerator(CFLocaleRef locale, void(^work)(UDate
         free((void *)ptgLocaleName);
         ptgLocaleName = NULL;
     };
-    pthread_mutex_lock(&ptgLock);
+    _CFMutexLock(&ptgLock);
     if (ptgLocaleName && strcmp(ptgLocaleName, localeName) != 0) {
         flushCache();
     }
@@ -88,7 +88,7 @@ static Boolean useTemplatePatternGenerator(CFLocaleRef locale, void(^work)(UDate
     if (result && work) {
         work(ptg);
     }
-    pthread_mutex_unlock(&ptgLock);
+    _CFMutexUnlock(&ptgLock);
     return result;
 }
 

--- a/CoreFoundation/PlugIn.subproj/CFBundle_Internal.h
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Internal.h
@@ -109,7 +109,7 @@ struct __CFBundle {
     
     _CFPlugInData _plugInData;
     
-    pthread_mutex_t _bundleLoadingLock;
+    _CFMutex _bundleLoadingLock;
     
     CFStringRef _executablePath; // Calculated and cached here
     CFStringRef _developmentRegion; // Calculated and cached here

--- a/CoreFoundation/PlugIn.subproj/CFBundle_Main.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Main.c
@@ -24,7 +24,7 @@ static Boolean _initedMainBundle = false;
 static CFBundleRef _mainBundle = NULL;
 static char __CFBundleMainID__[1026] = {0};
 char *__CFBundleMainID = __CFBundleMainID__;
-static pthread_mutex_t _mainBundleLock = PTHREAD_MUTEX_INITIALIZER;
+static _CFMutex _mainBundleLock = _CF_MUTEX_STATIC_INITIALIZER;
 
 #pragma mark -
 
@@ -124,9 +124,9 @@ static CFBundleRef _CFBundleGetMainBundleAlreadyLocked(void) {
                 // Perform delayed final processing steps.
                 // This must be done after _isLoaded has been set, for security reasons (3624341).
                 // It is safe to unlock and re-lock here because we don't really do anything under the lock after we are done. It is just re-locked to satisfy the 'already locked' contract.
-                pthread_mutex_unlock(&_mainBundleLock);
+                _CFMutexUnlock(&_mainBundleLock);
                 _CFBundleInitPlugIn(_mainBundle);
-                pthread_mutex_lock(&_mainBundleLock);
+                _CFMutexLock(&_mainBundleLock);
             }
         }
         if (bundleURL) CFRelease(bundleURL);
@@ -164,8 +164,8 @@ CF_EXPORT CFURLRef _CFBundleCopyMainBundleExecutableURL(Boolean *looksLikeBundle
 
 CF_EXPORT CFBundleRef CFBundleGetMainBundle(void) {
     CFBundleRef mainBundle;
-    pthread_mutex_lock(&_mainBundleLock);
+    _CFMutexLock(&_mainBundleLock);
     mainBundle = _CFBundleGetMainBundleAlreadyLocked();
-    pthread_mutex_unlock(&_mainBundleLock);
+    _CFMutexUnlock(&_mainBundleLock);
     return mainBundle;
 }


### PR DESCRIPTION
Introduce the `_CFMutex` and `_CFRecursiveMutex` types to allow us to
differentiate between recursive and non-recursive mutexes and be able to replace
them on different platforms.  This codepath does not use `CFLock_t` as these are
expected to be full mutexes rather than unfair locks.