### PR TITLE
[gardening] Remove unnecessary break and fallthrough statements

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -289,35 +289,21 @@ open class FileManager : NSObject {
             }
             
         // None of these are supported outside of Darwin:
-        case .applicationDirectory:
-            fallthrough
-        case .demoApplicationDirectory:
-            fallthrough
-        case .developerApplicationDirectory:
-            fallthrough
-        case .adminApplicationDirectory:
-            fallthrough
-        case .libraryDirectory:
-            fallthrough
-        case .developerDirectory:
-            fallthrough
-        case .documentationDirectory:
-            fallthrough
-        case .coreServiceDirectory:
-            fallthrough
-        case .inputMethodsDirectory:
-            fallthrough
-        case .preferencePanesDirectory:
-            fallthrough
-        case .applicationScriptsDirectory:
-            fallthrough
-        case .allApplicationsDirectory:
-            fallthrough
-        case .allLibrariesDirectory:
-            fallthrough
-        case .printerDescriptionDirectory:
-            fallthrough
-        case .itemReplacementDirectory:
+        case .applicationDirectory,
+             .demoApplicationDirectory,
+             .developerApplicationDirectory,
+             .adminApplicationDirectory,
+             .libraryDirectory,
+             .developerDirectory,
+             .documentationDirectory,
+             .coreServiceDirectory,
+             .inputMethodsDirectory,
+             .preferencePanesDirectory,
+             .applicationScriptsDirectory,
+             .allApplicationsDirectory,
+             .allLibrariesDirectory,
+             .printerDescriptionDirectory,
+             .itemReplacementDirectory:
             return []
         }
     }

--- a/Foundation/IndexPath.swift
+++ b/Foundation/IndexPath.swift
@@ -52,16 +52,12 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
             switch elements.count {
             case 0:
                 self = .empty
-                break
             case 1:
                 self = .single(elements[0])
-                break
             case 2:
                 self = .pair(elements[0], elements[1])
-                break
             default:
                 self = .array(elements)
-                break
             }
         }
         
@@ -87,16 +83,12 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
             switch self {
             case .empty:
                 self = .single(other)
-                break
             case .single(let first):
                 self = .pair(first, other)
-                break
             case .pair(let first, let second):
                 self = .array([first, second, other])
-                break
             case .array(let indexes):
                 self = .array(indexes + [other])
-                break
             }
         }
         
@@ -109,15 +101,11 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                     break
                 case .single(let rhsIndex):
                     self = .single(rhsIndex)
-                    break
                 case .pair(let rhsFirst, let rhsSecond):
                     self = .pair(rhsFirst, rhsSecond)
-                    break
                 case .array(let rhsIndexes):
                     self = .array(rhsIndexes)
-                    break
                 }
-                break
             case .single(let lhsIndex):
                 switch other {
                 case .empty:
@@ -125,15 +113,11 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                     break
                 case .single(let rhsIndex):
                     self = .pair(lhsIndex, rhsIndex)
-                    break
                 case .pair(let rhsFirst, let rhsSecond):
                     self = .array([lhsIndex, rhsFirst, rhsSecond])
-                    break
                 case .array(let rhsIndexes):
                     self = .array([lhsIndex] + rhsIndexes)
-                    break
                 }
-                break
             case .pair(let lhsFirst, let lhsSecond):
                 switch other {
                 case .empty:
@@ -141,15 +125,11 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                     break
                 case .single(let rhsIndex):
                     self = .array([lhsFirst, lhsSecond, rhsIndex])
-                    break
                 case .pair(let rhsFirst, let rhsSecond):
                     self = .array([lhsFirst, lhsSecond, rhsFirst, rhsSecond])
-                    break
                 case .array(let rhsIndexes):
                     self = .array([lhsFirst, lhsSecond] + rhsIndexes)
-                    break
                 }
-                break
             case .array(let lhsIndexes):
                 switch other {
                 case .empty:
@@ -157,15 +137,11 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                     break
                 case .single(let rhsIndex):
                     self = .array(lhsIndexes + [rhsIndex])
-                    break
                 case .pair(let rhsFirst, let rhsSecond):
                     self = .array(lhsIndexes + [rhsFirst, rhsSecond])
-                    break
                 case .array(let rhsIndexes):
                     self = .array(lhsIndexes + rhsIndexes)
-                    break
                 }
-                break
             }
         }
         
@@ -178,15 +154,11 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                     break
                 case 1:
                     self = .single(other[0])
-                    break
                 case 2:
                     self = .pair(other[0], other[1])
-                    break
                 default:
                     self = .array(other)
-                    break
                 }
-                break
             case .single(let first):
                 switch other.count {
                 case 0:
@@ -194,12 +166,9 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                     break
                 case 1:
                     self = .pair(first, other[0])
-                    break
                 default:
                     self = .array([first] + other)
-                    break
                 }
-                break
             case .pair(let first, let second):
                 switch other.count {
                 case 0:
@@ -207,12 +176,9 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                     break
                 default:
                     self = .array([first, second] + other)
-                    break
                 }
-                break
             case .array(let indexes):
                 self = .array(indexes + other)
-                break
             }
         }
         
@@ -221,7 +187,6 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                 switch self {
                 case .empty:
                     fatalError("index \(index) out of bounds of count 0")
-                    break
                 case .single(let first):
                     precondition(index == 0, "index \(index) out of bounds of count 1")
                     return first
@@ -236,11 +201,9 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                 switch self {
                 case .empty:
                     fatalError("index \(index) out of bounds of count 0")
-                    break
                 case .single:
                     precondition(index == 0, "index \(index) out of bounds of count 1")
                     self = .single(newValue)
-                    break
                 case .pair(let first, let second):
                     precondition(index >= 0 && index < 2, "index \(index) out of bounds of count 2")
                     if index == 0 {
@@ -248,12 +211,10 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                     } else {
                         self = .pair(first, newValue)
                     }
-                    break
                 case .array(let indexes_):
                     var indexes = indexes_
                     indexes[index] = newValue
                     self = .array(indexes)
-                    break
                 }
             }
         }
@@ -270,8 +231,8 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                     }
                 case .single(let index):
                     switch (range.lowerBound, range.upperBound) {
-                    case (0, 0): fallthrough
-                    case (1, 1):
+                    case (0, 0),
+                         (1, 1):
                         return .empty
                     case (0, 1):
                         return .single(index)
@@ -282,11 +243,9 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                 case .pair(let first, let second):
                     
                     switch (range.lowerBound, range.upperBound) {
-                    case (0, 0):
-                        fallthrough
-                    case (1, 1):
-                        fallthrough
-                    case (2, 2):
+                    case (0, 0),
+                         (1, 1),
+                         (2, 2):
                         return .empty
                     case (0, 1):
                         return .single(first)
@@ -316,39 +275,28 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                 case .empty:
                     precondition(range.lowerBound == 0 && range.upperBound == 0, "range \(range) is out of bounds of count 0")
                     self = newValue
-                    break
                 case .single(let index):
                     switch (range.lowerBound, range.upperBound, newValue) {
-                    case (0, 0, .empty):
-                        fallthrough
-                    case (1, 1, .empty):
+                    case (0, 0, .empty),
+                         (1, 1, .empty):
                         break
                     case (0, 0, .single(let other)):
                         self = .pair(other, index)
-                        break
                     case (0, 0, .pair(let first, let second)):
                         self = .array([first, second, index])
-                        break
                     case (0, 0, .array(let other)):
                         self = .array(other + [index])
-                        break
-                    case (0, 1, .empty):
-                        fallthrough
-                    case (0, 1, .single):
-                        fallthrough
-                    case (0, 1, .pair):
-                        fallthrough
-                    case (0, 1, .array):
+                    case (0, 1, .empty),
+                         (0, 1, .single),
+                         (0, 1, .pair),
+                         (0, 1, .array):
                         self = newValue
                     case (1, 1, .single(let other)):
                         self = .pair(index, other)
-                        break
                     case (1, 1, .pair(let first, let second)):
                         self = .array([index, first, second])
-                        break
                     case (1, 1, .array(let other)):
                         self = .array([index] + other)
-                        break
                     default:
                         fatalError("range \(range) is out of bounds of count 1")
                     }
@@ -360,63 +308,46 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                             break
                         case .single(let other):
                             self = .array([other, first, second])
-                            break
                         case .pair(let otherFirst, let otherSecond):
                             self = .array([otherFirst, otherSecond, first, second])
-                            break
                         case .array(let other):
                             self = .array(other + [first, second])
-                            break
                         }
-                        break
                     case (0, 1):
                         switch newValue {
                         case .empty:
                             self = .single(second)
-                            break
                         case .single(let other):
                             self = .pair(other, second)
-                            break
                         case .pair(let otherFirst, let otherSecond):
                             self = .array([otherFirst, otherSecond, second])
-                            break
                         case .array(let other):
                             self = .array(other + [second])
-                            break
                         }
-                        break
                     case (0, 2):
                         self = newValue
-                        break
                     case (1, 2):
                         switch newValue {
                         case .empty:
                             self = .single(first)
-                            break
                         case .single(let other):
                             self = .pair(first, other)
-                            break
                         case .pair(let otherFirst, let otherSecond):
                             self = .array([first, otherFirst, otherSecond])
-                            break
                         case .array(let other):
                             self = .array([first] + other)
                         }
-                        break
                     case (2, 2):
                         switch newValue {
                         case .empty:
                             break
                         case .single(let other):
                             self = .array([first, second, other])
-                            break
                         case .pair(let otherFirst, let otherSecond):
                             self = .array([first, second, otherFirst, otherSecond])
-                            break
                         case .array(let other):
                             self = .array([first, second] + other)
                         }
-                        break
                     default:
                         fatalError("range \(range) is out of bounds of count 2")
                     }
@@ -428,17 +359,13 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                         break
                     case .single(let index):
                         newIndexes.insert(index, at: range.lowerBound)
-                        break
                     case .pair(let first, let second):
                         newIndexes.insert(first, at: range.lowerBound)
                         newIndexes.insert(second, at: range.lowerBound + 1)
-                        break
                     case .array(let other):
                         newIndexes.insert(contentsOf: other, at: range.lowerBound)
-                        break
                     }
                     self = Storage(newIndexes)
-                    break
                 }
             }
         }

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -797,8 +797,8 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
                 return .orderedSame
             case .timeZone:
                 return .orderedSame
-            case .day: fallthrough
-            case .hour:
+            case .day,
+                 .hour:
                 let range = self.range(of: unit, for: date1)
                 let ats = range!.start.timeIntervalSinceReferenceDate
                 let at2 = date2.timeIntervalSinceReferenceDate

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -376,23 +376,25 @@ extension CGRect {
         var rect2 = rect
 
         switch fromEdge {
-        case .minXEdge: fallthrough
-        case .maxXEdge:
+        case .minXEdge,
+             .maxXEdge:
             rect1.size.width = splitLocation
             rect2.origin.x = rect1.maxX
             rect2.size.width = rect.width - splitLocation
-        case .minYEdge: fallthrough
-        case .maxYEdge:
+        case .minYEdge,
+             .maxYEdge:
             rect1.size.height = splitLocation
             rect2.origin.y = rect1.maxY
             rect2.size.height = rect.height - splitLocation
         }
 
         switch fromEdge {
-        case .minXEdge: fallthrough
-        case .minYEdge: return (rect1, rect2)
-        case .maxXEdge: fallthrough
-        case .maxYEdge: return (rect2, rect1)
+        case .minXEdge,
+             .minYEdge:
+            return (rect1, rect2)
+        case .maxXEdge,
+             .maxYEdge:
+            return (rect2, rect1)
         }
     }
 }

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -939,8 +939,8 @@ open class NSNumber : NSValue {
 
     open func compare(_ otherNumber: NSNumber) -> ComparisonResult {
         switch (_cfNumberType(), otherNumber._cfNumberType()) {
-        case (kCFNumberFloatType, _), (_, kCFNumberFloatType): fallthrough
-        case (kCFNumberDoubleType, _), (_, kCFNumberDoubleType):
+        case (kCFNumberFloatType, _), (_, kCFNumberFloatType),
+             (kCFNumberDoubleType, _), (_, kCFNumberDoubleType):
             let (lhs, rhs) = (doubleValue, otherNumber.doubleValue)
             // Apply special handling for NaN as <, >, == always return false
             // when comparing with NaN
@@ -1065,16 +1065,12 @@ open class NSNumber : NSValue {
         switch type {
         case kCFNumberSInt8Type:
             valuePtr.assumingMemoryBound(to: Int8.self).pointee = int8Value
-            break
         case kCFNumberSInt16Type:
             valuePtr.assumingMemoryBound(to: Int16.self).pointee = int16Value
-            break
         case kCFNumberSInt32Type:
             valuePtr.assumingMemoryBound(to: Int32.self).pointee = int32Value
-            break
         case kCFNumberSInt64Type:
             valuePtr.assumingMemoryBound(to: Int64.self).pointee = int64Value
-            break
         case kCFNumberSInt128Type:
             struct CFSInt128Struct {
                 var high: Int64
@@ -1082,10 +1078,8 @@ open class NSNumber : NSValue {
             }
             let val = int64Value
             valuePtr.assumingMemoryBound(to: CFSInt128Struct.self).pointee = CFSInt128Struct.init(high: (val < 0) ? -1 : 0, low: UInt64(bitPattern: val))
-            break
         case kCFNumberFloat32Type:
             valuePtr.assumingMemoryBound(to: Float.self).pointee = floatValue
-            break
         case kCFNumberFloat64Type:
             valuePtr.assumingMemoryBound(to: Double.self).pointee = doubleValue
         default: fatalError()
@@ -1106,20 +1100,13 @@ open class NSNumber : NSValue {
                 switch objCType.pointee {
                 case 0x42:
                     aCoder.encode(boolValue, forKey: "NS.boolval")
-                    break
-                case 0x63: fallthrough
-                case 0x43: fallthrough
-                case 0x73: fallthrough
-                case 0x53: fallthrough
-                case 0x69: fallthrough
-                case 0x49: fallthrough
-                case 0x6C: fallthrough
-                case 0x4C: fallthrough
-                case 0x71: fallthrough
-                case 0x51:
+                case 0x63, 0x43,
+                     0x73, 0x53,
+                     0x69, 0x49,
+                     0x6C, 0x4C,
+                     0x71, 0x51:
                     aCoder.encode(int64Value, forKey: "NS.intval")
-                case 0x66: fallthrough
-                case 0x64:
+                case 0x66, 0x64:
                     aCoder.encode(doubleValue, forKey: "NS.dblval")
                 default: break
                 }

--- a/Foundation/URLSession/http/HTTPURLProtocol.swift
+++ b/Foundation/URLSession/http/HTTPURLProtocol.swift
@@ -347,8 +347,6 @@ internal extension _HTTPURLProtocol {
         guard let response = ts.response as? HTTPURLResponse else { fatalError("Header complete, but not URL response.") }
         guard let session = task?.session as? URLSession else { fatalError() }
         switch session.behaviour(for: self.task!) {
-        case .noDelegate:
-            break
         case .taskDelegate:
             //TODO: There's a problem with libcurl / with how we're using it.
             // We're currently unable to pause the transfer / the easy handle:
@@ -362,9 +360,9 @@ internal extension _HTTPURLProtocol {
             default:
                 self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
             }
-        case .dataCompletionHandler:
-            break
-        case .downloadCompletionHandler:
+        case .noDelegate,
+             .dataCompletionHandler,
+             .downloadCompletionHandler:
             break
         }
     }

--- a/Foundation/XMLDTDNode.swift
+++ b/Foundation/XMLDTDNode.swift
@@ -127,9 +127,8 @@ open class XMLDTDNode: XMLNode {
             case _kCFXMLDTDNodeEntityTypeExternalGeneralUnparsed:
                 return .unparsed
                 
-            case _kCFXMLDTDNodeEntityTypeExternalParameter:
-                fallthrough
-            case _kCFXMLDTDNodeEntityTypeInternalParameter:
+            case _kCFXMLDTDNodeEntityTypeExternalParameter,
+                 _kCFXMLDTDNodeEntityTypeInternalParameter:
                 return .parameter
                 
             case _kCFXMLDTDNodeEntityTypeInternalPredefined:

--- a/Foundation/XMLNode.swift
+++ b/Foundation/XMLNode.swift
@@ -523,11 +523,9 @@ open class XMLNode: NSObject, NSCopying {
     */
     open var children: [XMLNode]? {
         switch kind {
-        case .document:
-            fallthrough
-        case .element:
-            fallthrough
-        case .DTDKind:
+        case .document,
+             .element,
+             .DTDKind:
             return Array<XMLNode>(self as XMLNode)
 
         default:
@@ -811,13 +809,10 @@ open class XMLNode: NSObject, NSCopying {
         case _kCFXMLTypeDTD:
             return XMLDTD._objectNodeForNode(node)
 
-        case _kCFXMLDTDNodeTypeEntity:
-            fallthrough
-        case _kCFXMLDTDNodeTypeElement:
-            fallthrough
-        case _kCFXMLDTDNodeTypeNotation:
-            fallthrough
-        case _kCFXMLDTDNodeTypeAttribute:
+        case _kCFXMLDTDNodeTypeEntity,
+             _kCFXMLDTDNodeTypeElement,
+             _kCFXMLDTDNodeTypeNotation,
+             _kCFXMLDTDNodeTypeAttribute:
             return XMLDTDNode._objectNodeForNode(node)
 
         default:

--- a/TestFoundation/TestJSONEncoder.swift
+++ b/TestFoundation/TestJSONEncoder.swift
@@ -723,8 +723,6 @@ func expectEqualPaths(_ lhs: [CodingKey?], _ rhs: [CodingKey?], _ prefix: String
                 XCTFail("\(prefix) CodingKey.intValue mismatch: \(type(of: key1))(\(i1)) != \(type(of: key2))(\(i2))")
                 return
             }
-
-            break
         }
 
         XCTAssertEqual(key1.stringValue,


### PR DESCRIPTION
The intention of the changes is to clean switch control flow statement by

1. Grouping together cases that only `break` the flow
2. Grouping together cases where the flow is just passed to next matching case using `fallthrough`
3. Removing `break` statements from where it is redundant due Swift break by default behavior

`Data.swift` file is out of scope due it is being merged from the overlay as pointed by @parkera .