### PR TITLE
Fix Xcode build

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -3092,7 +3092,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -3112,7 +3112,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = org.swift.xdgTestHelper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -35,7 +35,7 @@ private func getTestData() -> [Any]? {
         XCTFail("Unable to deserialize property list data")
         return nil
     }
-    guard let parsingTests = testRoot[kURLTestParsingTestsKey] as? [Any] else {
+    guard let parsingTests = testRoot?[kURLTestParsingTestsKey] as? [Any] else {
         XCTFail("Unable to create the parsingTests dictionary")
         return nil
     }


### PR DESCRIPTION
Using latest master (60651e26396c968a3a70159dc2bf912826da265f) and same toolchain that this commits points to (swift-DEVELOPMENT-SNAPSHOT-2019-01-10-a) I'm unable to build using Xcode unless I make the following changes.

Not sure if those fixes goes through PR's too. 