### PR TITLE
Use bundled UUID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ option(FOUNDATION_PATH_TO_XCTEST_BUILD "Path to XCTest build" "")
 find_package(CURL REQUIRED)
 find_package(ICU COMPONENTS uc i18n REQUIRED)
 find_package(LibXml2 REQUIRED)
-find_package(UUID REQUIRED)
 
 include(SwiftSupport)
 include(GNUInstallDirs)
@@ -61,6 +60,9 @@ add_library(uuid
             STATIC
               uuid/uuid.h
               uuid/uuid.c)
+set_target_properties(uuid
+                      PROPERTIES
+                        POSITION_INDEPENDENT_CODE YES)
 # Add an include directory for the CoreFoundation framework headers to satisfy
 # the dependency on TargetConditionals.h
 target_compile_options(uuid
@@ -273,7 +275,8 @@ add_swift_library(Foundation
                     ${ICU_UC_LIBRARY} ${ICU_I18N_LIBRARY}
                     ${LIBXML2_LIBRARIES}
                     ${libdispatch_ldflags}
-                    ${uuid_LIBRARIES}
+                    -L${CMAKE_CURRENT_BINARY_DIR}
+                    -luuid
                     -Xlinker;-rpath;-Xlinker;"\\\$\$ORIGIN"
                   SWIFT_FLAGS
                     -DDEPLOYMENT_RUNTIME_SWIFT
@@ -289,11 +292,12 @@ if(NOT BUILD_SHARED_LIBS)
   set(Foundation_INTERFACE_LIBRARIES
       -L${install_dir}/usr/lib
       -lCoreFoundation
+      -L${CMAKE_CURRENT_BINARY_DIR}
+      -luuid
       ${CURL_LIBRARIES}
       ${ICU_UC_LIBRARY}
       ${ICU_I18N_LIBRARY}
-      ${LIBXML2_LIBRARIES}
-      ${uuid_LIBRARIES})
+      ${LIBXML2_LIBRARIES})
 endif()
 
 add_swift_executable(plutil
@@ -304,8 +308,8 @@ add_swift_executable(plutil
                        ${deployment_enable_libdispatch}
                        -F${install_dir}/System/Library/Frameworks
                      LINK_FLAGS
-                       -L${CMAKE_CURRENT_BINARY_DIR}
                        ${libdispatch_ldflags}
+                       -L${CMAKE_CURRENT_BINARY_DIR}
                        -lFoundation
                        ${Foundation_INTERFACE_LIBRARIES}
                        -Xlinker;-rpath;-Xlinker;"\\\$\$ORIGIN/../lib/swift/${swift_os}"
@@ -318,6 +322,7 @@ add_swift_executable(plutil
                        ${swift_enable_testing}
                        ${swift_optimization_flags}
                      DEPENDS
+                       uuid
                        Foundation
                        CoreFoundation)
 
@@ -339,6 +344,7 @@ if(ENABLE_TESTING)
                          -I;${ICU_INCLUDE_DIR}
                          ${libdispatch_cflags}
                        DEPENDS
+                         uuid
                          Foundation
                          CoreFoundation)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,17 @@ ExternalProject_Add(CoreFoundation
                       ${CMAKE_COMMAND} -E env --unset=DESTDIR ${CMAKE_COMMAND} --build . --target install)
 ExternalProject_Get_Property(CoreFoundation install_dir)
 
+add_library(uuid
+            STATIC
+              uuid/uuid.h
+              uuid/uuid.c)
+# Add an include directory for the CoreFoundation framework headers to satisfy
+# the dependency on TargetConditionals.h
+target_compile_options(uuid
+                       PUBLIC
+                         -I${install_dir}/System/Library/Frameworks/CoreFoundation.framework/Headers)
+add_dependencies(uuid CoreFoundation)
+
 set(swift_optimization_flags)
 if(CMAKE_BUILD_TYPE MATCHES Release)
   set(swift_optimization_flags -O)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,13 @@ set_target_properties(uuid
 target_compile_options(uuid
                        PUBLIC
                          -I${install_dir}/System/Library/Frameworks/CoreFoundation.framework/Headers)
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  target_compile_definitions(uuid
+                             PRIVATE
+                               _CRT_NONSTDC_NO_WARNINGS
+                               _CRT_SECURE_NO_DEPRECATE
+                               _CRT_SECURE_NO_WARNINGS)
+endif()
 add_dependencies(uuid CoreFoundation)
 
 set(swift_optimization_flags)

--- a/uuid/uuid.c
+++ b/uuid/uuid.c
@@ -35,7 +35,11 @@
 #include <stdint.h>
 #include <string.h>
 #include <fcntl.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#elif defined(_WIN32)
+#include <io.h>
+#endif
 #include <stdio.h>
 
 #if TARGET_OS_MAC
@@ -61,9 +65,25 @@ static inline void nanotime(struct timespec *tv) {
 	clock_gettime(CLOCK_MONOTONIC, tv);
 }
 
+#elif TARGET_OS_WINDOWS
+#include <time.h>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+static inline void nanotime(struct timespec *tv) {
+  FILETIME ftTime;
+
+  GetSystemTimePreciseAsFileTime(&ftTime);
+
+  uint64_t Value = (((uint64_t)ftTime.dwHighDateTime << 32) | ftTime.dwLowDateTime);
+
+  tv->tv_sec = Value / 1000000000;
+  tv->tv_nsec = Value - (tv->tv_sec * 1000000000);
+}
 #endif
 
-static inline void read_random(void *buffer, u_int numBytes) {
+static inline void read_random(void *buffer, unsigned numBytes) {
     int fd = open("/dev/urandom", O_RDONLY);
     read(fd, buffer, numBytes);
     close(fd);


### PR DESCRIPTION
Setup the build to build the bundled UUID and port to windows in preparation for supporting Windows as a build target.