### PR TITLE
Use `Hashable.hash(into:)` over `hashValue` to silence the deprecation warnings

### DIFF
--- a/Foundation/AffineTransform.swift
+++ b/Foundation/AffineTransform.swift
@@ -393,7 +393,7 @@ open class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
         return other === self || (other.affineTransform == self.affineTransform)
     }
 
-    open override var hashValue: Int {
+    open override var hash: Int {
         return affineTransform.hashValue
     }
     

--- a/Foundation/Calendar.swift
+++ b/Foundation/Calendar.swift
@@ -862,9 +862,9 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     public func hash(into hasher: inout Hasher) {
         // We implement hash ourselves, because we need to make sure autoupdating calendars have the same hash
         if _autoupdating {
-            hasher.combine(1)
+            hasher.combine(1 as Int8)
         } else {
-            hasher.combine(_handle.map { $0.hash })
+            hasher.combine(_handle.map { $0 })
         }
     }
     

--- a/Foundation/Calendar.swift
+++ b/Foundation/Calendar.swift
@@ -859,12 +859,12 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     
     // MARK: -
     
-    public var hashValue: Int {
+    public func hash(into hasher: inout Hasher) {
         // We implement hash ourselves, because we need to make sure autoupdating calendars have the same hash
         if _autoupdating {
-            return 1
+            hasher.combine(1)
         } else {
-            return _handle.map { $0.hash }
+            hasher.combine(_handle.map { $0.hash })
         }
     }
     

--- a/Foundation/CharacterSet.swift
+++ b/Foundation/CharacterSet.swift
@@ -169,8 +169,8 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
         }
     }
     
-    public var hashValue: Int {
-        return _mapUnmanaged { $0.hashValue }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_mapUnmanaged { $0.hashValue })
     }
     
     public var description: String {

--- a/Foundation/CharacterSet.swift
+++ b/Foundation/CharacterSet.swift
@@ -170,7 +170,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     }
     
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(_mapUnmanaged { $0.hashValue })
+        hasher.combine(_mapUnmanaged { $0 })
     }
     
     public var description: String {

--- a/Foundation/DateComponents.swift
+++ b/Foundation/DateComponents.swift
@@ -303,7 +303,7 @@ public struct DateComponents : ReferenceConvertible, Hashable, Equatable, _Mutab
     // MARK: -
     
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(_handle.map { $0.hash })
+        hasher.combine(_handle.map { $0 })
     }
     
     public static func ==(lhs: DateComponents, rhs: DateComponents) -> Bool {

--- a/Foundation/DateComponents.swift
+++ b/Foundation/DateComponents.swift
@@ -302,8 +302,8 @@ public struct DateComponents : ReferenceConvertible, Hashable, Equatable, _Mutab
     
     // MARK: -
     
-    public var hashValue: Int {
-        return _handle.map { $0.hash }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_handle.map { $0.hash })
     }
     
     public static func ==(lhs: DateComponents, rhs: DateComponents) -> Bool {

--- a/Foundation/IndexSet.swift
+++ b/Foundation/IndexSet.swift
@@ -174,7 +174,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     }
     
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(_handle.map { $0.hash })
+        hasher.combine(_handle.map { $0 })
     }
 
     /// Returns the number of integers in `self`.

--- a/Foundation/IndexSet.swift
+++ b/Foundation/IndexSet.swift
@@ -173,10 +173,10 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         _handle = _MutablePairHandle(NSIndexSet(), copying: false)
     }
     
-    public var hashValue: Int {
-        return _handle.map { $0.hash }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_handle.map { $0.hash })
     }
-    
+
     /// Returns the number of integers in `self`.
     public var count: Int {
         return _handle.map { $0.count }

--- a/Foundation/Locale.swift
+++ b/Foundation/Locale.swift
@@ -423,9 +423,9 @@ public struct Locale : CustomStringConvertible, CustomDebugStringConvertible, Ha
     
     public func hash(into hasher: inout Hasher) {
         if _autoupdating {
-            hasher.combine(1)
+            hasher.combine(1 as Int8)
         } else {
-            hasher.combine(_wrapped.hash)
+            hasher.combine(_wrapped)
         }
     }
 

--- a/Foundation/Locale.swift
+++ b/Foundation/Locale.swift
@@ -421,11 +421,11 @@ public struct Locale : CustomStringConvertible, CustomDebugStringConvertible, Ha
         return _wrapped.debugDescription
     }
     
-    public var hashValue : Int {
+    public func hash(into hasher: inout Hasher) {
         if _autoupdating {
-            return 1
+            hasher.combine(1)
         } else {
-            return _wrapped.hash
+            hasher.combine(_wrapped.hash)
         }
     }
 

--- a/Foundation/NSCache.swift
+++ b/Foundation/NSCache.swift
@@ -29,7 +29,7 @@ fileprivate class NSCacheKey: NSObject {
         super.init()
     }
     
-    override var hashValue: Int {
+    override var hash: Int {
         switch self.value {
         case let nsObject as NSObject:
             return nsObject.hashValue

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -1334,7 +1334,7 @@ internal class _NSCopyOnWriteCalendar: NSCalendar {
         return backingCalendar.isEqual(value)
     }
     
-    override var hashValue: Int {
+    override var hash: Int {
         return backingCalendar.hashValue
     }
     

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -162,7 +162,7 @@ open class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
     // -- NSObject Overrides --
     // The compiler has special paths for attempting to do some bridging on NSError (and equivalent Error instances) -- in particular, in the lookup of NSError objects' superclass.
     // On platforms where we don't have bridging (i.e. Linux), this causes a silgen failure. We can avoid the issue by overriding methods inherited by NSObject ourselves.
-    override open var hashValue: Int {
+    override open var hash: Int {
         // CFHash does the appropriate casting/bridging on platforms where we support it.
         return Int(bitPattern: CFHash(self))
     }

--- a/Foundation/NSObject.swift
+++ b/Foundation/NSObject.swift
@@ -323,8 +323,8 @@ open class NSObject : NSObjectProtocol, Equatable, Hashable {
         return self
     }
 
-    open var hashValue: Int {
-        return hash
+    open func hash(into hasher: inout Hasher) {
+        hasher.combine(hash)
     }
 
     /// Returns a Boolean value indicating whether two values are equal.

--- a/Foundation/NSObject.swift
+++ b/Foundation/NSObject.swift
@@ -323,8 +323,31 @@ open class NSObject : NSObjectProtocol, Equatable, Hashable {
         return self
     }
 
-    open func hash(into hasher: inout Hasher) {
-        hasher.combine(hash)
+    /// The hash value.
+    ///
+    /// `NSObject` implements this by returning `self.hash`.
+    ///
+    /// `NSObject.hashValue` is not overridable; subclasses can customize hashing
+    /// by overriding the `hash` property.
+    ///
+    /// **Axiom:** `x == y` implies `x.hashValue == y.hashValue`
+    ///
+    /// - Note: the hash value is not guaranteed to be stable across
+    ///   different invocations of the same program.  Do not persist the
+    ///   hash value across program runs.
+    public final var hashValue: Int {
+        return hash
+    }
+
+    /// Hashes the essential components of this value by feeding them into the
+    /// given hasher.
+    ///
+    /// NSObject implements this by feeding `self.hash` to the hasher.
+    ///
+    /// `NSObject.hash(into:)` is not overridable; subclasses can customize
+    /// hashing by overriding the `hash` property.
+    public final func hash(into hasher: inout Hasher) {
+        hasher.combine(self.hash)
     }
 
     /// Returns a Boolean value indicating whether two values are equal.

--- a/Foundation/Notification.swift
+++ b/Foundation/Notification.swift
@@ -36,11 +36,11 @@ public struct Notification : ReferenceConvertible, Equatable, Hashable {
         self.object = object
         self.userInfo = userInfo
     }
-    
-    public var hashValue: Int {
-        return name.rawValue.hash
-    }
 
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+    }
+    
     public var description: String {
         var description = "name = \(name.rawValue)"
         if let obj = object { description += ", object = \(obj)" }

--- a/Foundation/PersonNameComponents.swift
+++ b/Foundation/PersonNameComponents.swift
@@ -68,10 +68,10 @@ public struct PersonNameComponents : ReferenceConvertible, Hashable, Equatable, 
         set { _applyMutation { $0.phoneticRepresentation = newValue } }
     }
     
-    public var hashValue : Int {
-        return _handle.map { $0.hash }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_handle.map { $0.hash })
     }
-    
+
     public static func ==(lhs : PersonNameComponents, rhs: PersonNameComponents) -> Bool {
         // Don't copy references here; no one should be storing anything
         return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())

--- a/Foundation/PersonNameComponents.swift
+++ b/Foundation/PersonNameComponents.swift
@@ -69,7 +69,7 @@ public struct PersonNameComponents : ReferenceConvertible, Hashable, Equatable, 
     }
     
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(_handle.map { $0.hash })
+        hasher.combine(_handle.map { $0 })
     }
 
     public static func ==(lhs : PersonNameComponents, rhs: PersonNameComponents) -> Bool {

--- a/Foundation/TimeZone.swift
+++ b/Foundation/TimeZone.swift
@@ -212,9 +212,9 @@ public struct TimeZone : Hashable, Equatable, ReferenceConvertible {
     
     public func hash(into hasher: inout Hasher) {
         if _autoupdating {
-            hasher.combine(1)
+            hasher.combine(1 as Int8)
         } else {
-            hasher.combine(_wrapped.hash)
+            hasher.combine(_wrapped)
         }
     }
 

--- a/Foundation/TimeZone.swift
+++ b/Foundation/TimeZone.swift
@@ -210,11 +210,11 @@ public struct TimeZone : Hashable, Equatable, ReferenceConvertible {
     
     // MARK: -
     
-    public var hashValue : Int {
+    public func hash(into hasher: inout Hasher) {
         if _autoupdating {
-            return 1
+            hasher.combine(1)
         } else {
-            return _wrapped.hash
+            hasher.combine(_wrapped.hash)
         }
     }
 

--- a/Foundation/URL.swift
+++ b/Foundation/URL.swift
@@ -504,7 +504,7 @@ public struct URL : ReferenceConvertible, Equatable {
     }
     
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(_url.hash)
+        hasher.combine(_url)
     }
     
     // MARK: -

--- a/Foundation/URL.swift
+++ b/Foundation/URL.swift
@@ -503,8 +503,8 @@ public struct URL : ReferenceConvertible, Equatable {
         _url = URL._converted(from: NSURL(fileURLWithFileSystemRepresentation: path, isDirectory: isDirectory, relativeTo: baseURL))
     }
     
-    public var hashValue: Int {
-        return _url.hash
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_url.hash)
     }
     
     // MARK: -

--- a/Foundation/URLComponents.swift
+++ b/Foundation/URLComponents.swift
@@ -274,10 +274,10 @@ public struct URLComponents : ReferenceConvertible, Hashable, Equatable, _Mutabl
         set { _applyMutation { $0.queryItems = newValue } }
     }
     
-    public var hashValue: Int {
-        return _handle.map { $0.hash }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_handle.map { $0.hash })
     }
-    
+
     // MARK: - Bridging
     
     fileprivate init(reference: NSURLComponents) {
@@ -346,9 +346,11 @@ public struct URLQueryItem : ReferenceConvertible, Hashable, Equatable {
         get { return _queryItem.value }
         set { _queryItem = NSURLQueryItem(name: name, value: newValue) }
     }
-    
-    public var hashValue: Int { return _queryItem.hash }
-    
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_queryItem.hash)
+    }
+
     public static func ==(lhs: URLQueryItem, rhs: URLQueryItem) -> Bool {
         return lhs._queryItem.isEqual(rhs._queryItem)
     }

--- a/Foundation/URLComponents.swift
+++ b/Foundation/URLComponents.swift
@@ -275,7 +275,7 @@ public struct URLComponents : ReferenceConvertible, Hashable, Equatable, _Mutabl
     }
     
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(_handle.map { $0.hash })
+        hasher.combine(_handle.map { $0 })
     }
 
     // MARK: - Bridging
@@ -348,7 +348,7 @@ public struct URLQueryItem : ReferenceConvertible, Hashable, Equatable {
     }
 
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(_queryItem.hash)
+        hasher.combine(_queryItem)
     }
 
     public static func ==(lhs: URLQueryItem, rhs: URLQueryItem) -> Bool {

--- a/Foundation/URLRequest.swift
+++ b/Foundation/URLRequest.swift
@@ -227,8 +227,8 @@ public struct URLRequest : ReferenceConvertible, Equatable, Hashable {
         }
     }
     
-    public var hashValue: Int {
-        return _handle.map { $0.hashValue }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_handle.map { $0.hashValue })
     }
     
     public static func ==(lhs: URLRequest, rhs: URLRequest) -> Bool {

--- a/Foundation/URLRequest.swift
+++ b/Foundation/URLRequest.swift
@@ -228,7 +228,7 @@ public struct URLRequest : ReferenceConvertible, Equatable, Hashable {
     }
     
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(_handle.map { $0.hashValue })
+        hasher.combine(_handle.map { $0 })
     }
     
     public static func ==(lhs: URLRequest, rhs: URLRequest) -> Bool {


### PR DESCRIPTION
There are some remaining warnings, but this should be a good start.