### PR TITLE
Improve flags handling for Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,7 @@ add_swift_library(Foundation
                     ${deployment_target}
                     ${deployment_enable_libdispatch}
                     -F${install_dir}/System/Library/Frameworks
+                    -D_DLL
                   LINK_FLAGS
                     -L${install_dir}/usr/lib
                     -lCoreFoundation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,10 +102,12 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Android OR CMAKE_SYSTEM_NAME STREQUAL Linux)
   set(deployment_target -DDEPLOYMENT_TARGET_LINUX)
+  set(Foundation_rpath_flags -Xlinker;-rpath;-Xlinker;"\\\$\$ORIGIN")
 elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   set(deployment_target -DDEPLOYMENT_TARGET_MACOSX)
 elseif(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
   set(deployment_target -DDEPLOYMENT_TARGET_FREEBSD)
+  set(Foundation_rpath_flags -Xlinker;-rpath;-Xlinker;"\\\$\$ORIGIN")
 elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
   set(deployment_target -DDEPLOYMENT_TARGET_WINDOWS)
 endif()
@@ -287,7 +289,7 @@ add_swift_library(Foundation
                     ${libdispatch_ldflags}
                     -L${CMAKE_CURRENT_BINARY_DIR}
                     -luuid
-                    -Xlinker;-rpath;-Xlinker;"\\\$\$ORIGIN"
+                    ${Foundation_rpath_flags}
                   SWIFT_FLAGS
                     -DDEPLOYMENT_RUNTIME_SWIFT
                     ${deployment_enable_libdispatch}


### PR DESCRIPTION
Update the flags handling to enable building for the Windows target which does not support `-rpath` and requires an indication that the shared C library is being used.