### PR TITLE
Foundation: update for API change

### DIFF
--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -285,7 +285,7 @@ extension NSString {
             return _swiftObject
         }
 
-        let endOfUserName = _swiftObject.index(of: "/") ?? _swiftObject.endIndex
+        let endOfUserName = _swiftObject.firstIndex(of: "/") ?? _swiftObject.endIndex
         let startOfUserName = _swiftObject.index(after: _swiftObject.startIndex)
         let userName = String(_swiftObject[startOfUserName..<endOfUserName])
         let optUserName: String? = userName.isEmpty ? nil : userName

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -26,7 +26,7 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
             NSRequiresConcreteImplementation()
         }
         let value = __SwiftValue.store(object)
-        guard let idx = _storage.index(of: value) else { return nil }
+        guard let idx = _storage.firstIndex(of: value) else { return nil }
         return _storage[idx]
     }
     

--- a/Foundation/Operation.swift
+++ b/Foundation/Operation.swift
@@ -130,7 +130,7 @@ open class Operation : NSObject {
         _dependencies.remove(op)
         op.lock.lock()
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
-        let groupIndex = op._groups.index(where: { $0 === self._depGroup })
+        let groupIndex = op._groups.firstIndex(where: { $0 === self._depGroup })
         if let idx = groupIndex {
             let group = op._groups.remove(at: idx)
             group.leave()
@@ -259,28 +259,28 @@ internal struct _OperationList {
     }
     
     mutating func remove(_ operation: Operation) {
-        if let idx = all.index(of: operation) {
+        if let idx = all.firstIndex(of: operation) {
             all.remove(at: idx)
         }
         switch operation.queuePriority {
         case .veryLow:
-            if let idx = veryLow.index(of: operation) {
+            if let idx = veryLow.firstIndex(of: operation) {
                 veryLow.remove(at: idx)
             }
         case .low:
-            if let idx = low.index(of: operation) {
+            if let idx = low.firstIndex(of: operation) {
                 low.remove(at: idx)
             }
         case .normal:
-            if let idx = normal.index(of: operation) {
+            if let idx = normal.firstIndex(of: operation) {
                 normal.remove(at: idx)
             }
         case .high:
-            if let idx = high.index(of: operation) {
+            if let idx = high.firstIndex(of: operation) {
                 high.remove(at: idx)
             }
         case .veryHigh:
-            if let idx = veryHigh.index(of: operation) {
+            if let idx = veryHigh.firstIndex(of: operation) {
                 veryHigh.remove(at: idx)
             }
         }

--- a/Foundation/ProcessInfo.swift
+++ b/Foundation/ProcessInfo.swift
@@ -49,7 +49,8 @@ open class ProcessInfo: NSObject {
         var idx = 0
 
         while let entry = envp.advanced(by: idx).pointee {
-            if let entry = String(cString: entry, encoding: strEncoding), let i = entry.index(of: equalSign) {
+            if let entry = String(cString: entry, encoding: strEncoding),
+               let i = entry.firstIndex(of: equalSign) {
                 let key = String(entry.prefix(upTo: i))
                 let value = String(entry.suffix(from: i).dropFirst())
                 env[key] = value

--- a/Foundation/URLProtocol.swift
+++ b/Foundation/URLProtocol.swift
@@ -399,7 +399,7 @@ open class URLProtocol : NSObject {
     */
     open class func unregisterClass(_ protocolClass: AnyClass) {
         _classesLock.lock()
-        if let idx = _registeredProtocolClasses.index(where: { $0 === protocolClass }) {
+        if let idx = _registeredProtocolClasses.firstIndex(where: { $0 === protocolClass }) {
             _registeredProtocolClasses.remove(at: idx)
         }
         _classesLock.unlock()

--- a/Foundation/URLSession/http/HTTPMessage.swift
+++ b/Foundation/URLSession/http/HTTPMessage.swift
@@ -117,7 +117,7 @@ private extension _HTTPURLProtocol._HTTPMessage._StartLine {
         } else if let version = _HTTPURLProtocol._HTTPMessage._Version(versionString: r.2),
             let URI = URL(string: r.1) {
             // The request method must be a token (i.e. without seperators):
-            let seperatorIdx = r.0.unicodeScalars.index(where: { !$0.isValidMessageToken } )
+            let seperatorIdx = r.0.unicodeScalars.firstIndex(where: { !$0.isValidMessageToken } )
             guard seperatorIdx == nil else { return nil }
             self = .requestLine(method: r.0, uri: URI, version: version)
         } else {
@@ -241,7 +241,7 @@ private extension String.UnicodeScalarView.SubSequence {
     /// The range of space (U+0020) characters.
     var rangeOfSpace: Range<Index>? {
         guard !isEmpty else { return startIndex..<startIndex }
-        guard let idx = index(of: _Delimiters.Space!) else { return nil }
+        guard let idx = firstIndex(of: _Delimiters.Space!) else { return nil }
         return idx..<self.index(after: idx)
     }
     // Has a space (SP) or horizontal tab (HT) prefix

--- a/Foundation/URLSession/libcurl/MultiHandle.swift
+++ b/Foundation/URLSession/libcurl/MultiHandle.swift
@@ -152,7 +152,7 @@ internal extension URLSession._MultiHandle {
     }
     /// Remove an easy handle -- stop its transfer.
     func remove(_ handle: _EasyHandle) {
-        guard let idx = self.easyHandles.index(of: handle) else {
+        guard let idx = self.easyHandles.firstIndex(of: handle) else {
             fatalError("Handle not in list.")
         }
         self.easyHandles.remove(at: idx)
@@ -197,7 +197,7 @@ fileprivate extension URLSession._MultiHandle {
     /// Transfer completed.
     func completedTransfer(forEasyHandle handle: CFURLSessionEasyHandle, easyCode: CFURLSessionEasyCode) {
         // Look up the matching wrapper:
-        guard let idx = easyHandles.index(where: { $0.rawHandle == handle }) else {
+        guard let idx = easyHandles.firstIndex(where: { $0.rawHandle == handle }) else {
             fatalError("Tansfer completed for easy handle, but it is not in the list of added handles.")
         }
         let easyHandle = easyHandles[idx]

--- a/Foundation/XMLNode.swift
+++ b/Foundation/XMLNode.swift
@@ -467,7 +467,7 @@ open class XMLNode: NSObject, NSCopying {
     */
     open var index: Int {
         if let siblings = self.parent?.children,
-            let index = siblings.index(of: self) {
+            let index = siblings.firstIndex(of: self) {
             return index
         }
 


### PR DESCRIPTION
Update use of `index(of:)` to `firstIndex(of:)` and `index(where:)` to
`firstIndex(where:)`.  NFCI.