### PR TITLE
Foundation: use `numericCast` in places for LLP64

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -775,7 +775,7 @@ open class FileManager : NSObject {
         var bytesRead = 0
 
         repeat {
-            bytesRead = read(fd, buffer, bytesToRead)
+            bytesRead = numericCast(read(fd, buffer, numericCast(bytesToRead)))
         } while bytesRead < 0 && errno == EINTR
         guard bytesRead >= 0 else {
             throw _NSErrorWithErrno(errno, reading: true, path: filename)
@@ -789,7 +789,9 @@ open class FileManager : NSObject {
             var written = 0
             let bytesLeftToWrite = bytesToWrite - bytesWritten
             repeat {
-                written = write(fd, buffer.advanced(by: bytesWritten), bytesLeftToWrite)
+                written =
+                    numericCast(write(fd, buffer.advanced(by: bytesWritten),
+                                      numericCast(bytesLeftToWrite)))
             } while written < 0 && errno == EINTR
             guard written >= 0 else {
                 throw _NSErrorWithErrno(errno, reading: false, path: filename)

--- a/Foundation/NSCFString.swift
+++ b/Foundation/NSCFString.swift
@@ -213,7 +213,8 @@ internal func _CFSwiftStringFastContents(_ str: AnyObject) -> UnsafePointer<UniC
 }
 
 internal func _CFSwiftStringGetCString(_ str: AnyObject, buffer: UnsafeMutablePointer<Int8>, maxLength: Int, encoding: CFStringEncoding) -> Bool {
-    return (str as! NSString).getCString(buffer, maxLength: maxLength, encoding: CFStringConvertEncodingToNSStringEncoding(encoding))
+    return (str as! NSString).getCString(buffer, maxLength: maxLength,
+                                         encoding: numericCast(CFStringConvertEncodingToNSStringEncoding(encoding)))
 }
 
 internal func _CFSwiftStringIsUnicode(_ str: AnyObject) -> Bool {

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -1226,7 +1226,7 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         var tempComp = components
         tempComp.isLeapMonth = comp.isLeapMonth
         if let nanosecond = comp.value(for: .nanosecond) {
-            if labs(nanosecond - tempComp.value(for: .nanosecond)!) > 500 {
+            if labs(numericCast(nanosecond - tempComp.value(for: .nanosecond)!)) > 500 {
                 return false
             } else {
                 compareComp.nanosecond = 0

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -285,7 +285,10 @@ open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSC
     }
     
     public convenience init?(cString nullTerminatedCString: UnsafePointer<Int8>, encoding: UInt) {
-        guard let str = CFStringCreateWithCString(kCFAllocatorSystemDefault, nullTerminatedCString, CFStringConvertNSStringEncodingToEncoding(encoding)) else {
+        guard let str =
+            CFStringCreateWithCString(kCFAllocatorSystemDefault,
+                                      nullTerminatedCString,
+                                      CFStringConvertNSStringEncodingToEncoding(numericCast(encoding))) else {
             return nil
         }
         self.init(string: str._swiftObject)
@@ -801,7 +804,7 @@ extension NSString {
         let len = length
         var reqSize = 0
         
-        let cfStringEncoding = CFStringConvertNSStringEncodingToEncoding(encoding)
+        let cfStringEncoding = CFStringConvertNSStringEncodingToEncoding(numericCast(encoding))
         if !CFStringIsEncodingAvailable(cfStringEncoding) {
             return nil
         }
@@ -834,7 +837,9 @@ extension NSString {
         if encoding == String.Encoding.unicode.rawValue || encoding == String.Encoding.nonLossyASCII.rawValue || encoding == String.Encoding.utf8.rawValue {
             return true
         }
-        return __CFStringEncodeByteStream(_cfObject, 0, length, false, CFStringConvertNSStringEncodingToEncoding(encoding), 0, nil, 0, nil) == length
+        return __CFStringEncodeByteStream(_cfObject, 0, length, false,
+                                          CFStringConvertNSStringEncodingToEncoding(numericCast(encoding)),
+                                          0, nil, 0, nil) == length
     }
    
     public func cString(using encoding: UInt) -> UnsafePointer<Int8>? { 
@@ -864,7 +869,8 @@ extension NSString {
     public func getBytes(_ buffer: UnsafeMutableRawPointer?, maxLength maxBufferCount: Int, usedLength usedBufferCount: UnsafeMutablePointer<Int>?, encoding: UInt, options: EncodingConversionOptions = [], range: NSRange, remaining leftover: NSRangePointer?) -> Bool {
         var totalBytesWritten = 0
         var numCharsProcessed = 0
-        let cfStringEncoding = CFStringConvertNSStringEncodingToEncoding(encoding)
+        let cfStringEncoding =
+            CFStringConvertNSStringEncodingToEncoding(numericCast(encoding))
         var result = true
         if length > 0 {
             if CFStringIsEncodingAvailable(cfStringEncoding) {
@@ -886,7 +892,7 @@ extension NSString {
     }
     
     public func maximumLengthOfBytes(using enc: UInt) -> Int {
-        let cfEnc = CFStringConvertNSStringEncodingToEncoding(enc)
+        let cfEnc = CFStringConvertNSStringEncodingToEncoding(numericCast(enc))
         let result = CFStringGetMaximumSizeForEncoding(length, cfEnc)
         return result == kCFNotFound ? 0 : result
     }
@@ -894,7 +900,7 @@ extension NSString {
     public func lengthOfBytes(using enc: UInt) -> Int {
         let len = length
         var numBytes: CFIndex = 0
-        let cfEnc = CFStringConvertNSStringEncodingToEncoding(enc)
+        let cfEnc = CFStringConvertNSStringEncodingToEncoding(numericCast(enc))
         let convertedLen = __CFStringEncodeByteStream(_cfObject, 0, len, false, cfEnc, 0, nil, 0, &numBytes)
         return convertedLen != len ? 0 : numBytes
     }
@@ -916,7 +922,8 @@ extension NSString {
                 
                 numEncodings -= 1
                 while numEncodings >= 0 {
-                    theEncodingList.advanced(by: numEncodings).pointee = CFStringConvertEncodingToNSStringEncoding(cfEncodings.advanced(by: numEncodings).pointee)
+                    theEncodingList.advanced(by: numEncodings).pointee =
+                        numericCast(CFStringConvertEncodingToNSStringEncoding(cfEncodings.advanced(by: numEncodings).pointee))
                     numEncodings -= 1
                 }
                 
@@ -927,7 +934,7 @@ extension NSString {
     }
     
     open class func localizedName(of encoding: UInt) -> String {
-        if let theString = CFStringGetNameOfEncoding(CFStringConvertNSStringEncodingToEncoding(encoding)) {
+        if let theString = CFStringGetNameOfEncoding(CFStringConvertNSStringEncodingToEncoding(numericCast(encoding))) {
             // TODO: read the localized version from the Foundation "bundle"
             return theString._swiftObject
         }
@@ -936,7 +943,7 @@ extension NSString {
     }
     
     open class var defaultCStringEncoding: UInt {
-        return CFStringConvertEncodingToNSStringEncoding(CFStringGetSystemEncoding())
+        return numericCast(CFStringConvertEncodingToNSStringEncoding(CFStringGetSystemEncoding()))
     }
     
     open var decomposedStringWithCanonicalMapping: String {
@@ -1187,7 +1194,8 @@ extension NSString {
             self.init("")
         } else {
         guard let cf = data.withUnsafeBytes({ (bytes: UnsafePointer<UInt8>) -> CFString? in
-            return CFStringCreateWithBytes(kCFAllocatorDefault, bytes, data.count, CFStringConvertNSStringEncodingToEncoding(encoding), true)
+            return CFStringCreateWithBytes(kCFAllocatorDefault, bytes, data.count,
+                                           CFStringConvertNSStringEncodingToEncoding(numericCast(encoding)), true)
         }) else { return nil }
         
             var str: String?
@@ -1201,7 +1209,7 @@ extension NSString {
     
     public convenience init?(bytes: UnsafeRawPointer, length len: Int, encoding: UInt) {
         let bytePtr = bytes.bindMemory(to: UInt8.self, capacity: len)
-        guard let cf = CFStringCreateWithBytes(kCFAllocatorDefault, bytePtr, len, CFStringConvertNSStringEncodingToEncoding(encoding), true) else {
+        guard let cf = CFStringCreateWithBytes(kCFAllocatorDefault, bytePtr, len, CFStringConvertNSStringEncodingToEncoding(numericCast(encoding)), true) else {
             return nil
         }
         var str: String?
@@ -1224,7 +1232,7 @@ extension NSString {
         let readResult = try NSData(contentsOf: url, options: [])
 
         let bytePtr = readResult.bytes.bindMemory(to: UInt8.self, capacity: readResult.length)
-        guard let cf = CFStringCreateWithBytes(kCFAllocatorDefault, bytePtr, readResult.length, CFStringConvertNSStringEncodingToEncoding(enc), true) else {
+        guard let cf = CFStringCreateWithBytes(kCFAllocatorDefault, bytePtr, readResult.length, CFStringConvertNSStringEncodingToEncoding(numericCast(enc)), true) else {
             throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileReadInapplicableStringEncoding.rawValue, userInfo: [
                 "NSDebugDescription" : "Unable to create a string using the specified encoding."
                 ])
@@ -1279,7 +1287,7 @@ extension NSString {
         // Since the encoding being passed includes the byte order the BOM wont be checked or skipped, so pass offset to
         // manually skip the BOM header.
         guard let cf = CFStringCreateWithBytes(kCFAllocatorDefault, bytePtr + offset, readResult.length - offset,
-                                               CFStringConvertNSStringEncodingToEncoding(encoding), true) else {
+                                               CFStringConvertNSStringEncodingToEncoding(numericCast(encoding)), true) else {
             throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileReadInapplicableStringEncoding.rawValue, userInfo: [
                 "NSDebugDescription" : "Unable to create a string using the specified encoding."
                 ])

--- a/Foundation/URLSession/libcurl/EasyHandle.swift
+++ b/Foundation/URLSession/libcurl/EasyHandle.swift
@@ -203,7 +203,7 @@ extension _EasyHandle {
     /// set preferred receive buffer size
     /// - SeeAlso: https://curl.haxx.se/libcurl/c/CURLOPT_BUFFERSIZE.html
     func set(preferredReceiveBufferSize size: Int) {
-        try! CFURLSession_easy_setopt_long(rawHandle, CFURLSessionOptionBUFFERSIZE, min(size, Int(CFURLSessionMaxWriteSize))).asError()
+        try! CFURLSession_easy_setopt_long(rawHandle, CFURLSessionOptionBUFFERSIZE, numericCast(min(size, Int(CFURLSessionMaxWriteSize)))).asError()
     }
     /// Set custom HTTP headers
     /// - SeeAlso: https://curl.haxx.se/libcurl/c/CURLOPT_HTTPHEADER.html
@@ -264,7 +264,7 @@ extension _EasyHandle {
     }
 
     func set(timeout value: Int) {
-       try! CFURLSession_easy_setopt_long(rawHandle, CFURLSessionOptionTIMEOUT, value).asError()
+       try! CFURLSession_easy_setopt_long(rawHandle, CFURLSessionOptionTIMEOUT, numericCast(value)).asError()
     }
 
     func getTimeoutIntervalSpent() -> Double {

--- a/Foundation/URLSession/libcurl/MultiHandle.swift
+++ b/Foundation/URLSession/libcurl/MultiHandle.swift
@@ -57,7 +57,7 @@ extension URLSession {
 
 extension URLSession._MultiHandle {
     func configure(with configuration: URLSession._Configuration) {
-        try! CFURLSession_multi_setopt_l(rawHandle, CFURLSessionMultiOptionMAX_HOST_CONNECTIONS, configuration.httpMaximumConnectionsPerHost).asError()
+        try! CFURLSession_multi_setopt_l(rawHandle, CFURLSessionMultiOptionMAX_HOST_CONNECTIONS, numericCast(configuration.httpMaximumConnectionsPerHost)).asError()
         try! CFURLSession_multi_setopt_l(rawHandle, CFURLSessionMultiOptionPIPELINING, configuration.httpShouldUsePipelining ? 3 : 2).asError()
         //TODO: We may want to set
         //    CFURLSessionMultiOptionMAXCONNECTS


### PR DESCRIPTION
LLP64 causes the `Int` type to be different on LLP64 hosts and LP64 as
Swift does not have `intptr_t`.  This prepares for some of those changes
by using `numericCast` to hide the type checks.