### PR TITLE
FileManager.attributesOfItem(atPath:) - use statx() on Linux if available.

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -534,10 +534,18 @@ _stat_with_btime(const char *filename, struct stat *buffer, struct timespec *bti
             .st_mtim = { .tv_sec = statx_buffer.stx_mtime.tv_sec, .tv_nsec = statx_buffer.stx_mtime.tv_nsec },
             .st_ctim = { .tv_sec = statx_buffer.stx_ctime.tv_sec, .tv_nsec = statx_buffer.stx_ctime.tv_nsec },
         };
-        *btime = (struct timespec) {
-            .tv_sec =  statx_buffer.stx_btime.tv_sec,
-            .tv_nsec = statx_buffer.stx_btime.tv_nsec
-        };
+        // Check that stx_btime was set in the response, not all filesystems support it.
+        if (statx_buffer.stx_mask & STATX_BTIME) {
+            *btime = (struct timespec) {
+                .tv_sec = statx_buffer.stx_btime.tv_sec,
+                .tv_nsec = statx_buffer.stx_btime.tv_nsec
+            };
+        } else {
+            *btime = (struct timespec) {
+                .tv_sec = 0,
+                .tv_nsec = 0
+            };
+        }
     }
     return ret;
 }

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -52,6 +52,16 @@
 #include <malloc/malloc.h>
 #endif
 
+#if TARGET_OS_LINUX
+// required for statx() system call
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <linux/stat.h>
+#define AT_STATX_SYNC_AS_STAT   0x0000  /* - Do whatever stat() does */
+#endif
+
+
 _CF_EXPORT_SCOPE_BEGIN
 
 CF_CROSS_PLATFORM_EXPORT Boolean _CFCalendarGetNextWeekend(CFCalendarRef calendar, _CFCalendarWeekendRange *range);
@@ -482,6 +492,69 @@ static inline unsigned int _dev_major(dev_t rdev) {
 static inline unsigned int _dev_minor(dev_t rdev) {
     return minor(rdev);
 }
+
+static inline dev_t _dev_makedev(unsigned int major, unsigned int minor) {
+    return makedev(major, minor);
+}
+#endif
+
+
+#if TARGET_OS_LINUX
+#ifdef __NR_statx
+
+// There is no glibc statx() function, it must be called using syscall().
+
+static inline ssize_t
+_statx(int dfd, const char *filename, unsigned int flags, unsigned int mask, struct statx *buffer) {
+    return syscall(__NR_statx, dfd, filename, flags, mask, buffer);
+}
+
+// At the moment the only extra information statx() is used for is to get the btime (file creation time).
+// This function is here instead of in FileManager.swift because there is no way of setting a conditional
+// define that could be used with a #if in the Swift code.
+static inline ssize_t
+_stat_with_btime(const char *filename, struct stat *buffer, struct timespec *btime) {
+    struct statx statx_buffer = {0};
+    *btime = (struct timespec) {0};
+
+    ssize_t ret = _statx(AT_FDCWD, filename, AT_SYMLINK_NOFOLLOW | AT_STATX_SYNC_AS_STAT, STATX_ALL, &statx_buffer);
+    if (ret == 0) {
+        *buffer = (struct stat) {
+            .st_dev = makedev(statx_buffer.stx_dev_major, statx_buffer.stx_dev_minor),
+            .st_ino = statx_buffer.stx_ino,
+            .st_mode = statx_buffer.stx_mode,
+            .st_nlink = statx_buffer.stx_nlink,
+            .st_uid = statx_buffer.stx_uid,
+            .st_gid = statx_buffer.stx_gid,
+            .st_rdev = makedev(statx_buffer.stx_rdev_major, statx_buffer.stx_rdev_minor),
+            .st_size = statx_buffer.stx_size,
+            .st_blksize = statx_buffer.stx_blksize,
+            .st_blocks = statx_buffer.stx_blocks,
+            .st_atim = { .tv_sec = statx_buffer.stx_atime.tv_sec, .tv_nsec = statx_buffer.stx_atime.tv_nsec },
+            .st_mtim = { .tv_sec = statx_buffer.stx_mtime.tv_sec, .tv_nsec = statx_buffer.stx_mtime.tv_nsec },
+            .st_ctim = { .tv_sec = statx_buffer.stx_ctime.tv_sec, .tv_nsec = statx_buffer.stx_ctime.tv_nsec },
+        };
+        *btime = (struct timespec) {
+            .tv_sec =  statx_buffer.stx_btime.tv_sec,
+            .tv_nsec = statx_buffer.stx_btime.tv_nsec
+        };
+    }
+    return ret;
+}
+#else
+
+// Dummy version when compiled where struct statx is not defined in the headers.
+// Just calles lstat() instead.
+static inline ssize_t
+_stat_with_btime(const char *filename, struct stat *buffer, struct timespec *btime) {
+    *btime = (struct timespec) {0};
+    return lstat(filename, buffer);
+}
+#endif // __NR_statx
+#endif // TARGET_OS_LINUX
+
+#if __HAS_STATX
+#warning "Enabling statx"
 #endif
 
 _CF_EXPORT_SCOPE_END

--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -660,8 +660,13 @@ open class FileManager : NSObject {
         This method replaces fileAttributesAtPath:traverseLink:.
      */
     open func attributesOfItem(atPath path: String) throws -> [FileAttributeKey : Any] {
-        let s = try _lstatFile(atPath: path)
         var result = [FileAttributeKey : Any]()
+#if os(Linux)
+        let (s, creationDate) = try _statxFile(atPath: path)
+        result[.creationDate] = creationDate
+#else
+        let s = try _lstatFile(atPath: path)
+#endif
         result[.size] = NSNumber(value: UInt64(s.st_size))
 
 #if os(macOS) || os(iOS)
@@ -1396,6 +1401,43 @@ open class FileManager : NSObject {
         let fileInfo = try _lstatFile(atPath: path)
         return Int(fileInfo.st_mode & 0o777)
     }
+
+
+#if os(Linux)
+    // statx() is only supported by Linux kernels >= 4.11.0
+    private lazy var supportsStatx: Bool = {
+        let requiredVersion = OperatingSystemVersion(majorVersion: 4, minorVersion: 11, patchVersion: 0)
+        return ProcessInfo.processInfo.isOperatingSystemAtLeast(requiredVersion)
+    }()
+
+    // This is only used on Linux and the only extra information it returns in addition
+    // to a normal stat() call is the file creation date (stx_btime). It is only
+    // used by attributesOfItem(atPath:) which is why the return is a simple stat()
+    // structure and optional creation date.
+
+    private func _statxFile(atPath path: String) throws -> (stat, Date?) {
+        let fsRep = fileSystemRepresentation(withPath: path)
+        defer { fsRep.deallocate() }
+
+        if supportsStatx {
+            var statInfo = stat()
+            var btime = timespec()
+            guard _stat_with_btime(fsRep, &statInfo, &btime) == 0 else {
+                throw _NSErrorWithErrno(errno, reading: true, path: path)
+            }
+
+            let sec = btime.tv_sec
+            let nsec = btime.tv_nsec
+            let ti = (TimeInterval(sec) - kCFAbsoluteTimeIntervalSince1970) + (1.0e-9 * TimeInterval(nsec))
+            let creationDate = Date(timeIntervalSinceReferenceDate: ti)
+            return (statInfo, creationDate)
+        } else {
+            // fallback if statx() is unavailable or fails
+            let statInfo = try _lstatFile(atPath: path, withFileSystemRepresentation: fsRep)
+            return (statInfo, nil)
+        }
+    }
+#endif
 
     /* -contentsEqualAtPath:andPath: does not take into account data stored in the resource fork or filesystem extended attributes.
      */

--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -1428,8 +1428,13 @@ open class FileManager : NSObject {
 
             let sec = btime.tv_sec
             let nsec = btime.tv_nsec
-            let ti = (TimeInterval(sec) - kCFAbsoluteTimeIntervalSince1970) + (1.0e-9 * TimeInterval(nsec))
-            let creationDate = Date(timeIntervalSinceReferenceDate: ti)
+            let creationDate: Date?
+            if sec == 0 && nsec == 0 {
+                creationDate = nil
+            } else {
+                let ti = (TimeInterval(sec) - kCFAbsoluteTimeIntervalSince1970) + (1.0e-9 * TimeInterval(nsec))
+                creationDate = Date(timeIntervalSinceReferenceDate: ti)
+            }
             return (statInfo, creationDate)
         } else {
             // fallback if statx() is unavailable or fails

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -310,7 +310,7 @@ class TestFileManager : XCTestCase {
         XCTAssertFalse(fm.isDeletableFile(atPath: "/dev/null"))
     }
 
-    func test_fileAttributes() {
+    func test_fileAttributes() throws {
         let fm = FileManager.default
         let path = NSTemporaryDirectory() + "test_fileAttributes\(NSUUID().uuidString)"
 
@@ -349,7 +349,17 @@ class TestFileManager : XCTestCase {
             
             let fileGroupOwnerAccountID = attrs[.groupOwnerAccountID] as? NSNumber
             XCTAssertNotNil(fileGroupOwnerAccountID)
-            
+
+#if os(Linux)
+            let requiredVersion = OperatingSystemVersion(majorVersion: 4, minorVersion: 11, patchVersion: 0)
+            let creationDate = attrs[.creationDate] as? Date
+            if ProcessInfo.processInfo.isOperatingSystemAtLeast(requiredVersion) {
+                XCTAssertNotNil(creationDate)
+                XCTAssertGreaterThan(Date().timeIntervalSince1970, try creationDate.unwrapped().timeIntervalSince1970)
+            } else {
+                XCTAssertNil(creationDate)
+            }
+#endif
             if let fileOwnerAccountName = attrs[.ownerAccountName] {
                 XCTAssertNotNil(fileOwnerAccountName as? String)
                 if let fileOwnerAccountNameStr = fileOwnerAccountName as? String {

--- a/TestFoundation/TestProcessInfo.swift
+++ b/TestFoundation/TestProcessInfo.swift
@@ -25,6 +25,11 @@ class TestProcessInfo : XCTestCase {
         
         let version = processInfo.operatingSystemVersion
         XCTAssert(version.majorVersion != 0)
+
+#if os(Linux) || canImport(Darwin)
+        let minVersion = OperatingSystemVersion(majorVersion: 1, minorVersion: 0, patchVersion: 0)
+        XCTAssertTrue(processInfo.isOperatingSystemAtLeast(minVersion))
+#endif
     }
     
     func test_processName() {


### PR DESCRIPTION
- Linux kernel >= 4.11.0 has a statx() call for extended file stat
   information and this can be used to set .creationDate
