### PR TITLE
Foundation: remove duplicated conformance (NFC)

### DIFF
--- a/Foundation/NSRange.swift
+++ b/Foundation/NSRange.swift
@@ -258,7 +258,7 @@ extension NSRange {
     }
     
     public init<R: RangeExpression, S: StringProtocol>(_ region: R, in target: S)
-        where R.Bound == S.Index, S.Index == String.Index {
+        where R.Bound == S.Index {
             let r = region.relative(to: target)
             self = NSRange(
                 location: r.lowerBound.encodedOffset - target.startIndex.encodedOffset,


### PR DESCRIPTION
Remove the duplicated conformance specification which causes a warning
to be emitted.