### PR TITLE
Foundation: replace `unsafeBitCast` (NFC)

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -298,7 +298,7 @@ open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSC
         }
         if type(of: self) == NSString.self || type(of: self) == NSMutableString.self {
             if _storage._guts._isContiguousASCII {
-                return unsafeBitCast(_storage._guts.startASCII, to: UnsafePointer<Int8>.self)
+                return UnsafePointer<Int8>(_storage._guts.startASCII);
             }
         }
         return nil


### PR DESCRIPTION
Use the `UnsafePointer<Int8>` constructor rather than the
`unsafeBitCast`.  NFCI.