### PR TITLE
SR-9454: StringProtocol.lineRange(for:) returns invalid range on Linux

### DIFF
--- a/Foundation/NSStringAPI.swift
+++ b/Foundation/NSStringAPI.swift
@@ -443,7 +443,7 @@ extension StringProtocol where Index == String.Index {
   /// Return an `Index` corresponding to the given offset in our UTF-16
   /// representation.
   func _index(_ utf16Index: Int) -> Index {
-    return Index(encodedOffset: utf16Index + _substringOffset)
+    return self.utf16.index(self.utf16.startIndex, offsetBy: utf16Index)
   }
 
   @inlinable

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -94,7 +94,8 @@ class TestNSString: LoopbackServerTest {
             ("test_substringWithRange", test_substringWithRange),
             ("test_substringFromCFString", test_substringFromCFString),
             ("test_createCopy", test_createCopy),
-            ("test_commonPrefix", test_commonPrefix)
+            ("test_commonPrefix", test_commonPrefix),
+            ("test_lineRangeFor", test_lineRangeFor)
         ]
     }
 
@@ -1329,6 +1330,18 @@ class TestNSString: LoopbackServerTest {
         XCTAssertEqual("Ma\u{308}dchen".commonPrefix(with: "M\u{E4}dchenschule", options: [.literal]), "M")
         XCTAssertEqual("m\u{E4}dchen".commonPrefix(with: "M\u{E4}dchenschule", options: [.caseInsensitive, .literal]), "mädchen")
         XCTAssertEqual("ma\u{308}dchen".commonPrefix(with: "M\u{E4}dchenschule", options: [.caseInsensitive, .literal]), "m")
+    }
+
+    func test_lineRangeFor() {
+        // column     1 2 3 4 5 6 7 8 9  10 11
+        // line 1     L I N E 1 _ 6 7 あ \n
+        // line 2     L I N E 2 _ 7 8 9  0 \n
+        // line 3     L I N E 3 _ 8 9 0  1 \n
+        let string = "LINE1_67あ\nLINE2_7890\nLINE3_8901\n"
+        let rangeOfFirstLine = string.lineRange(for: string.startIndex..<string.startIndex)
+        XCTAssertEqual(string.distance(from: rangeOfFirstLine.lowerBound, to: rangeOfFirstLine.upperBound), 10)
+        let firstLine = string[rangeOfFirstLine]
+        XCTAssertEqual(firstLine, "LINE1_67あ\n")
     }
 }
 


### PR DESCRIPTION
Fixes [SR-9454](https://bugs.swift.org/browse/SR-9454)