### PR TITLE
Foundation: homogenise importing C, add MSVCRT

### DIFF
--- a/Foundation/AffineTransform.swift
+++ b/Foundation/AffineTransform.swift
@@ -7,12 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if os(macOS) || os(iOS)
-    import Darwin
-#elseif os(Linux) || CYGWIN
-    import Glibc
-#endif
-
 private let ε: CGFloat = CGFloat(2.22045e-16)
 
 

--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -12,16 +12,11 @@
 
 #if DEPLOYMENT_RUNTIME_SWIFT
 
-#if os(macOS) || os(iOS)
-import Darwin
-#elseif os(Linux)
-import Glibc
-
+#if os(Linux)
 @inlinable // This is @inlinable as trivially computable.
 internal func malloc_good_size(_ size: Int) -> Int {
     return size
 }
-
 #endif
 
 import CoreFoundation

--- a/Foundation/DataProtocol.swift
+++ b/Foundation/DataProtocol.swift
@@ -10,12 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS)
-import Darwin
-#elseif os(Linux)
-import Glibc
-#endif
-
 //===--- DataProtocol -----------------------------------------------------===//
 
 public protocol DataProtocol : RandomAccessCollection where Element == UInt8, SubSequence : DataProtocol {

--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -9,12 +9,6 @@
 
 import CoreFoundation
 
-#if os(macOS) || os(iOS)
-import Darwin
-#elseif os(Linux) || CYGWIN
-import Glibc
-#endif
-
 open class FileHandle : NSObject, NSSecureCoding {
     private var _fd: Int32
     private var _closeOnDealloc: Bool

--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -7,14 +7,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if canImport(Darwin)
-    import Darwin
-#endif
-
-#if canImport(Glibc)
-    import Glibc
-#endif
-
 #if os(Android) // struct stat.st_mode is UInt32
 internal func &(left: UInt32, right: mode_t) -> mode_t {
     return mode_t(left) & right

--- a/Foundation/FoundationErrors.swift
+++ b/Foundation/FoundationErrors.swift
@@ -164,12 +164,6 @@ public var NSCoderReadCorruptError: Int                      { return CocoaError
 
 public var NSCoderValueNotFoundError: Int                    { return CocoaError.Code.coderValueNotFound.rawValue }
 
-#if os(macOS) || os(iOS)
-    import Darwin
-#elseif os(Linux) || CYGWIN
-    import Glibc
-#endif
-
 internal func _NSErrorWithErrno(_ posixErrno : Int32, reading : Bool, path : String? = nil, url : URL? = nil, extraUserInfo : [String : Any]? = nil) -> NSError {
     var cocoaError : CocoaError.Code
     if reading {

--- a/Foundation/Host.swift
+++ b/Foundation/Host.swift
@@ -7,13 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if os(macOS) || os(iOS)
-import Darwin
-#elseif os(Linux) || CYGWIN
-import Glibc
-#endif
-
 import CoreFoundation
 
 open class Host: NSObject {

--- a/Foundation/JSONSerialization.swift
+++ b/Foundation/JSONSerialization.swift
@@ -9,12 +9,6 @@
 
 import CoreFoundation
 
-#if os(macOS) || os(iOS)
-    import Darwin
-#elseif os(Linux) || CYGWIN
-    import Glibc
-#endif
-
 extension JSONSerialization {
     public struct ReadingOptions : OptionSet {
         public let rawValue: UInt

--- a/Foundation/NSConcreteValue.swift
+++ b/Foundation/NSConcreteValue.swift
@@ -9,12 +9,6 @@
 
 import CoreFoundation
 
-#if os(macOS) || os(iOS)
-    import Darwin
-#elseif os(Linux) || CYGWIN
-    import Glibc
-#endif
-
 internal class NSConcreteValue : NSValue {
     
     struct TypeInfo : Equatable {

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -9,12 +9,6 @@
 
 import CoreFoundation
 
-#if os(macOS) || os(iOS)
-import Darwin
-#elseif os(Linux) || CYGWIN
-import Glibc
-#endif
-
 #if DEPLOYMENT_ENABLE_LIBDISPATCH
 import Dispatch
 #endif

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -9,12 +9,6 @@
 
 import CoreFoundation
 
-#if os(macOS) || os(iOS)
-    import Darwin
-#elseif os(Linux) || CYGWIN
-    import Glibc
-#endif
-
 public typealias TimeInterval = Double
 
 public var NSTimeIntervalSince1970: Double {

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -7,12 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if os(macOS) || os(iOS)
-    import Darwin
-#elseif os(Linux) || CYGWIN
-    import Glibc
-#endif
-
 public struct CGPoint {
     public var x: CGFloat
     public var y: CGFloat

--- a/Foundation/NSLock.swift
+++ b/Foundation/NSLock.swift
@@ -7,13 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if os(macOS) || os(iOS)
-import Darwin
-#elseif os(Linux) || CYGWIN
-import Glibc
-#endif
-
 import CoreFoundation
 
 public protocol NSLocking {

--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -9,12 +9,6 @@
 
 import CoreFoundation
 
-#if os(macOS) || os(iOS)
-import Darwin
-#elseif os(Linux) || CYGWIN
-import Glibc
-#endif
-
 public func NSTemporaryDirectory() -> String {
     #if os(macOS) || os(iOS)
     var buf = [Int8](repeating: 0, count: 100)

--- a/Foundation/NSPlatform.swift
+++ b/Foundation/NSPlatform.swift
@@ -8,12 +8,6 @@
 //
 
 #if os(macOS) || os(iOS)
-import Darwin
-#elseif os(Linux)
-import Glibc
-#endif
-
-#if os(macOS) || os(iOS)
 fileprivate let _NSPageSize = Int(vm_page_size)
 #elseif os(Linux) || os(Android)
 fileprivate let _NSPageSize = Int(getpagesize())

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -12,10 +12,12 @@ import CoreFoundation
 
 // Re-export Darwin and Glibc by importing Foundation
 // This mimics the behavior of the swift sdk overlay on Darwin
-#if os(macOS) || os(iOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 @_exported import Darwin
 #elseif os(Linux) || os(Android) || CYGWIN
 @_exported import Glibc
+#elseif os(Windows)
+@_exported import MSVCRT
 #endif
 
 @_exported import Dispatch

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -11,12 +11,6 @@
 import CoreFoundation
 
 #if os(macOS) || os(iOS)
-import Darwin
-#elseif os(Linux) || CYGWIN
-import Glibc
-#endif
-
-#if os(macOS) || os(iOS)
 internal let kCFURLPOSIXPathStyle = CFURLPathStyle.cfurlposixPathStyle
 internal let kCFURLWindowsPathStyle = CFURLPathStyle.cfurlWindowsPathStyle
 #endif

--- a/Foundation/NSUUID.swift
+++ b/Foundation/NSUUID.swift
@@ -10,12 +10,6 @@
 
 import CoreFoundation
 
-#if os(macOS) || os(iOS)
-    import Darwin.uuid
-#elseif os(Linux) || CYGWIN
-    import Glibc
-#endif
-
 open class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
     internal var buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 16)
 

--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -10,12 +10,6 @@
 #if !os(Android) // not available
 import CoreFoundation
 
-#if os(macOS) || os(iOS)
-    import Darwin
-#elseif os(Linux) || CYGWIN
-    import Glibc
-#endif
-
 extension Process {
     public enum TerminationReason : Int {
         case exit

--- a/Foundation/ProcessInfo.swift
+++ b/Foundation/ProcessInfo.swift
@@ -7,13 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if os(macOS) || os(iOS)
-import Darwin
-#elseif os(Linux) || CYGWIN
-import Glibc
-#endif
-
 import CoreFoundation
 
 public struct OperatingSystemVersion {

--- a/Foundation/Progress.swift
+++ b/Foundation/Progress.swift
@@ -7,12 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if os(macOS) || os(iOS)
-import Darwin
-#elseif os(Linux)
-import Glibc
-#endif
-
 import Dispatch
 
 /**

--- a/Foundation/Thread.swift
+++ b/Foundation/Thread.swift
@@ -7,12 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-#if os(macOS) || os(iOS)
-import Darwin
-#elseif os(Linux) || CYGWIN
-import Glibc
-#endif
 import CoreFoundation
 
 internal class NSThreadSpecific<T: NSObject> {

--- a/Foundation/XMLParser.swift
+++ b/Foundation/XMLParser.swift
@@ -7,12 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if os(macOS) || os(iOS)
-    import Darwin
-#elseif os(Linux) || CYGWIN
-    import Glibc
-#endif
-
 import CoreFoundation
 
 extension XMLParser {


### PR DESCRIPTION
This is preliminary setup for enabling the Windows port.  Ensure that we
import MSVCRT in all the locations where we are importing the C library.
Take the opportunity to homogenise the import for linux/android/cygwin
as well.