### PR TITLE
Foundation: remove an out of date comment (NFC)

### DIFF
--- a/Foundation/XMLParser.swift
+++ b/Foundation/XMLParser.swift
@@ -7,17 +7,12 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-// It is necessary to explicitly cast strlen to UInt to match the type
-// of prefixLen because currently, strlen (and other functions that
-// rely on swift_ssize_t) use the machine word size (int on 32 bit and
-// long in on 64 bit).  I've filed a bug at bugs.swift.org:
-// https://bugs.swift.org/browse/SR-314
-
 #if os(macOS) || os(iOS)
     import Darwin
 #elseif os(Linux) || CYGWIN
     import Glibc
 #endif
+
 import CoreFoundation
 
 extension XMLParser {


### PR DESCRIPTION
Remove a reference to a SR and a comment that no longer apply and the SR has
been closed as WONTFIX/NOTABUG.