### PR TITLE
Make NSObject.hashValue non-overridable

### DIFF
--- a/Foundation/AffineTransform.swift
+++ b/Foundation/AffineTransform.swift
@@ -387,7 +387,7 @@ open class NSAffineTransform : NSObject, NSCopying, NSSecureCoding {
         return other === self || (other.affineTransform == self.affineTransform)
     }
 
-    open override var hashValue: Int {
+    open override var hash: Int {
         return affineTransform.hashValue
     }
     

--- a/Foundation/NSCache.swift
+++ b/Foundation/NSCache.swift
@@ -29,7 +29,7 @@ fileprivate class NSCacheKey: NSObject {
         super.init()
     }
     
-    override var hashValue: Int {
+    override var hash: Int {
         switch self.value {
         case let nsObject as NSObject:
             return nsObject.hashValue

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -1334,7 +1334,7 @@ internal class _NSCopyOnWriteCalendar: NSCalendar {
         return backingCalendar.isEqual(value)
     }
     
-    override var hashValue: Int {
+    override var hash: Int {
         return backingCalendar.hashValue
     }
     

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -162,7 +162,7 @@ open class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
     // -- NSObject Overrides --
     // The compiler has special paths for attempting to do some bridging on NSError (and equivalent Error instances) -- in particular, in the lookup of NSError objects' superclass.
     // On platforms where we don't have bridging (i.e. Linux), this causes a silgen failure. We can avoid the issue by overriding methods inherited by NSObject ourselves.
-    override open var hashValue: Int {
+    override open var hash: Int {
         // CFHash does the appropriate casting/bridging on platforms where we support it.
         return Int(bitPattern: CFHash(self))
     }

--- a/Foundation/NSObject.swift
+++ b/Foundation/NSObject.swift
@@ -323,8 +323,31 @@ open class NSObject : NSObjectProtocol, Equatable, Hashable {
         return self
     }
 
-    open var hashValue: Int {
+    /// The hash value.
+    ///
+    /// `NSObject` implements this by returning `self.hash`.
+    ///
+    /// `NSObject.hashValue` is not overridable; subclasses can customize hashing
+    /// by overriding the `hash` property.
+    ///
+    /// **Axiom:** `x == y` implies `x.hashValue == y.hashValue`
+    ///
+    /// - Note: the hash value is not guaranteed to be stable across
+    ///   different invocations of the same program.  Do not persist the
+    ///   hash value across program runs.
+    public final var hashValue: Int {
         return hash
+    }
+
+    /// Hashes the essential components of this value by feeding them into the
+    /// given hasher.
+    ///
+    /// NSObject implements this by feeding `self.hash` to the hasher.
+    ///
+    /// `NSObject.hash(into:)` is not overridable; subclasses can customize
+    /// hashing by overriding the `hash` property.
+    public final func hash(into hasher: inout Hasher) {
+        hasher.combine(self.hash)
     }
 
     /// Returns a Boolean value indicating whether two values are equal.


### PR DESCRIPTION
This is cherry picked from @ikesyo's PR #1820 (commit 9ee6b02367a79b742566b575e7b9c7da36a19651).

This PR fixes an NSObject API inconsistency between Swift 5's SDK overlays on Darwin and swift-corelibs-foundation. It also fixes several NSObject subclasses to customize hashing through the correct API, `NSObject.hash`.

`NSObject.hashValue` is currently declared `open`, which matches Darwin SDK overlays in Swift 4.2 and below. Unfortunately, `hashValue` was never supposed to be overridden -- `NSObject` subclasses are expected to customize hashing by overriding `NSObject.hash`, which is a distinct property. To help clear up the confusion resulting from this subtle gotcha, last year we decided to change `NSObject.hashValue` to be non-overridable.

- The Swift 4.2 compiler started emitting deprecation warnings for overrides of `NSObject.hashValue` (https://github.com/apple/swift/pull/18407). 
- In Swift 5, the declaration of `NSObject.hashValue` was changed from `@objc open` to `@nonobjc public`. (https://github.com/apple/swift/pull/20129)
- To help migrating existing (subtly broken) code, we plan to add a dedicated fix-it soon. (https://github.com/apple/swift/pull/22081)
