### PR TITLE
[5.0] Import Data and DataProtocol from the overlay (and correct some incorrect CFData and NSData usages)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,15 +130,19 @@ add_swift_library(Foundation
                     Foundation/CGFloat.swift
                     Foundation/CharacterSet.swift
                     Foundation/Codable.swift
+                    Foundation/Collections+DataProtocol.swift
+                    Foundation/ContiguousBytes.swift
                     Foundation/Data.swift
-                    Foundation/DateComponentsFormatter.swift
-                    Foundation/DateComponents.swift
-                    Foundation/DateFormatter.swift
-                    Foundation/DateIntervalFormatter.swift
-                    Foundation/DateInterval.swift
+                    Foundation/DataProtocol.swift
                     Foundation/Date.swift
+                    Foundation/DateComponents.swift
+                    Foundation/DateComponentsFormatter.swift
+                    Foundation/DateFormatter.swift
+                    Foundation/DateInterval.swift
+                    Foundation/DateIntervalFormatter.swift
                     Foundation/Decimal.swift
                     Foundation/Dictionary.swift
+                    Foundation/DispatchData+DataProtocol.swift
                     Foundation/EnergyFormatter.swift
                     Foundation/ExtraStringAPIs.swift
                     Foundation/FileHandle.swift
@@ -147,8 +151,8 @@ add_swift_library(Foundation
                     Foundation/Formatter.swift
                     Foundation/FoundationErrors.swift
                     Foundation/Host.swift
-                    Foundation/HTTPCookieStorage.swift
                     Foundation/HTTPCookie.swift
+                    Foundation/HTTPCookieStorage.swift
                     Foundation/IndexPath.swift
                     Foundation/IndexSet.swift
                     Foundation/ISO8601DateFormatter.swift
@@ -157,10 +161,10 @@ add_swift_library(Foundation
                     Foundation/LengthFormatter.swift
                     Foundation/Locale.swift
                     Foundation/MassFormatter.swift
-                    Foundation/MeasurementFormatter.swift
                     Foundation/Measurement.swift
-                    Foundation/NotificationQueue.swift
+                    Foundation/MeasurementFormatter.swift
                     Foundation/Notification.swift
+                    Foundation/NotificationQueue.swift
                     Foundation/NSArray.swift
                     Foundation/NSAttributedString.swift
                     Foundation/NSCache.swift
@@ -176,6 +180,7 @@ add_swift_library(Foundation
                     Foundation/NSComparisonPredicate.swift
                     Foundation/NSCompoundPredicate.swift
                     Foundation/NSConcreteValue.swift
+                    Foundation/NSData+DataProtocol.swift
                     Foundation/NSData.swift
                     Foundation/NSDate.swift
                     Foundation/NSDecimalNumber.swift
@@ -186,8 +191,8 @@ add_swift_library(Foundation
                     Foundation/NSGeometry.swift
                     Foundation/NSIndexPath.swift
                     Foundation/NSIndexSet.swift
-                    Foundation/NSKeyedArchiverHelpers.swift
                     Foundation/NSKeyedArchiver.swift
+                    Foundation/NSKeyedArchiverHelpers.swift
                     Foundation/NSKeyedCoderOldStyleArray.swift
                     Foundation/NSKeyedUnarchiver.swift
                     Foundation/NSLocale.swift
@@ -209,68 +214,69 @@ add_swift_library(Foundation
                     Foundation/NSSet.swift
                     Foundation/NSSortDescriptor.swift
                     Foundation/NSSpecialValue.swift
-                    Foundation/NSStringAPI.swift
                     Foundation/NSString.swift
+                    Foundation/NSStringAPI.swift
                     Foundation/NSSwiftRuntime.swift
                     Foundation/NSTextCheckingResult.swift
                     Foundation/NSTimeZone.swift
+                    Foundation/NSURL.swift
                     Foundation/NSURLError.swift
                     Foundation/NSURLRequest.swift
-                    Foundation/NSURL.swift
                     Foundation/NSUUID.swift
                     Foundation/NSValue.swift
                     Foundation/NumberFormatter.swift
                     Foundation/Operation.swift
-                    Foundation/PersonNameComponentsFormatter.swift
                     Foundation/PersonNameComponents.swift
-                    Foundation/PortMessage.swift
+                    Foundation/PersonNameComponentsFormatter.swift
+                    Foundation/Pointers+DataProtocol.swift
                     Foundation/Port.swift
-                    Foundation/ProcessInfo.swift
+                    Foundation/PortMessage.swift
                     Foundation/Process.swift
-                    Foundation/ProgressFraction.swift
+                    Foundation/ProcessInfo.swift
                     Foundation/Progress.swift
+                    Foundation/ProgressFraction.swift
                     Foundation/PropertyListSerialization.swift
                     Foundation/ReferenceConvertible.swift
                     Foundation/RunLoop.swift
                     Foundation/Scanner.swift
                     Foundation/Set.swift
                     Foundation/Stream.swift
-                    Foundation/StringEncodings.swift
                     Foundation/String.swift
+                    Foundation/StringEncodings.swift
                     Foundation/Thread.swift
                     Foundation/Timer.swift
                     Foundation/TimeZone.swift
                     Foundation/Unit.swift
+                    Foundation/URL.swift
                     Foundation/URLAuthenticationChallenge.swift
                     Foundation/URLCache.swift
                     Foundation/URLComponents.swift
-                    Foundation/URLCredentialStorage.swift
                     Foundation/URLCredential.swift
+                    Foundation/URLCredentialStorage.swift
                     Foundation/URLProtectionSpace.swift
                     Foundation/URLProtocol.swift
                     Foundation/URLRequest.swift
                     Foundation/URLResponse.swift
                     Foundation/URLSession/BodySource.swift
                     Foundation/URLSession/Configuration.swift
-                    Foundation/URLSession/Message.swift
                     Foundation/URLSession/http/HTTPMessage.swift
                     Foundation/URLSession/http/HTTPURLProtocol.swift
                     Foundation/URLSession/libcurl/EasyHandle.swift
                     Foundation/URLSession/libcurl/libcurlHelpers.swift
                     Foundation/URLSession/libcurl/MultiHandle.swift
+                    Foundation/URLSession/Message.swift
                     Foundation/URLSession/NativeProtocol.swift
                     Foundation/URLSession/TaskRegistry.swift
                     Foundation/URLSession/TransferState.swift
+                    Foundation/URLSession/URLSession.swift
                     Foundation/URLSession/URLSessionConfiguration.swift
                     Foundation/URLSession/URLSessionDelegate.swift
-                    Foundation/URLSession/URLSession.swift
                     Foundation/URLSession/URLSessionTask.swift
-                    Foundation/URL.swift
                     Foundation/UserDefaults.swift
                     Foundation/UUID.swift
                     Foundation/XMLDocument.swift
-                    Foundation/XMLDTDNode.swift
                     Foundation/XMLDTD.swift
+                    Foundation/XMLDTDNode.swift
                     Foundation/XMLElement.swift
                     Foundation/XMLNode.swift
                     Foundation/XMLParser.swift

--- a/CoreFoundation/Collections.subproj/CFData.c
+++ b/CoreFoundation/Collections.subproj/CFData.c
@@ -88,9 +88,6 @@ typedef enum {
     kCFMutable = 0x3		/* changeable and variable capacity */
 } _CFDataMutableVariety;
 
-#define __CFGenericValidateMutability(variety) \
-    CFAssert1((variety != kCFFixedMutable && variety != kCFMutable), __kCFLogAssertion, "%s(): variety is not mutable", __PRETTY_FUNCTION__);
-
 CF_INLINE Boolean __CFDataIsMutable(CFDataRef data) {
     return __CFRuntimeGetFlag(data, __kCFMutable);
 }
@@ -377,7 +374,6 @@ static Boolean __CFDataShouldUseAllocator(CFAllocatorRef allocator) {
 // that there should be no deallocator, and the bytes should be copied.
 static CFMutableDataRef __CFDataInit(CFAllocatorRef allocator, _CFDataMutableVariety variety, CFIndex capacity, const uint8_t *bytes, CFIndex length, CFAllocatorRef bytesDeallocator) CF_RETURNS_RETAINED {
     CFMutableDataRef memory;
-    __CFGenericValidateMutability(variety);
     CFAssert2(0 <= capacity, __kCFLogAssertion, "%s(): capacity (%ld) cannot be less than zero", __PRETTY_FUNCTION__, capacity);
     CFAssert3(kCFFixedMutable != variety || length <= capacity, __kCFLogAssertion, "%s(): for kCFFixedMutable type, capacity (%ld) must be greater than or equal to number of initial elements (%ld)", __PRETTY_FUNCTION__, capacity, length);
     CFAssert2(0 <= length, __kCFLogAssertion, "%s(): length (%ld) cannot be less than zero", __PRETTY_FUNCTION__, length);
@@ -842,7 +838,6 @@ CFRange CFDataFind(CFDataRef data, CFDataRef dataToFind, CFRange searchRange, CF
 }
 
 #undef __CFDataValidateRange
-#undef __CFGenericValidateMutability
 #undef INLINE_BYTES_THRESHOLD
 #undef CFDATA_MAX_SIZE
 #undef REVERSE_BUFFER

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -267,6 +267,12 @@
 		5BA9BEBD1CF4F3B8009DBD6C /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA9BEBC1CF4F3B8009DBD6C /* Notification.swift */; };
 		5BB2C75F1ED9F96200B7BDBD /* CFUserNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B5D89391BBDA7AB00234F36 /* CFUserNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5BB5256C1BEC057200E63BE3 /* module.map in Headers */ = {isa = PBXBuildFile; fileRef = 5BDC3F721BCC60EF00ED97BB /* module.map */; settings = {ATTRIBUTES = (Public, ); }; };
+		5BC1B9A421F2757F00524D8C /* ContiguousBytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC1B9A321F2757F00524D8C /* ContiguousBytes.swift */; };
+		5BC1B9A621F2759C00524D8C /* DataProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC1B9A521F2759C00524D8C /* DataProtocol.swift */; };
+		5BC1B9A821F275B000524D8C /* Collections+DataProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC1B9A721F275B000524D8C /* Collections+DataProtocol.swift */; };
+		5BC1B9AA21F275C400524D8C /* DispatchData+DataProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC1B9A921F275C400524D8C /* DispatchData+DataProtocol.swift */; };
+		5BC1B9AC21F275D500524D8C /* NSData+DataProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC1B9AB21F275D500524D8C /* NSData+DataProtocol.swift */; };
+		5BC1B9AE21F275E900524D8C /* Pointers+DataProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC1B9AD21F275E900524D8C /* Pointers+DataProtocol.swift */; };
 		5BC2C00F1C07833200CC214E /* CFStringTransform.c in Sources */ = {isa = PBXBuildFile; fileRef = 5BC2C00D1C07832E00CC214E /* CFStringTransform.c */; };
 		5BC46D541D05D6D900005853 /* DateInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC46D531D05D6D900005853 /* DateInterval.swift */; };
 		5BCCA8D91CE6697F0059B963 /* URLComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCCA8D81CE6697F0059B963 /* URLComponents.swift */; };
@@ -770,6 +776,12 @@
 		5BA9BEA51CF3D747009DBD6C /* Data.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
 		5BA9BEA71CF3E7E7009DBD6C /* CharacterSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CharacterSet.swift; sourceTree = "<group>"; };
 		5BA9BEBC1CF4F3B8009DBD6C /* Notification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
+		5BC1B9A321F2757F00524D8C /* ContiguousBytes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContiguousBytes.swift; sourceTree = "<group>"; };
+		5BC1B9A521F2759C00524D8C /* DataProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataProtocol.swift; sourceTree = "<group>"; };
+		5BC1B9A721F275B000524D8C /* Collections+DataProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collections+DataProtocol.swift"; sourceTree = "<group>"; };
+		5BC1B9A921F275C400524D8C /* DispatchData+DataProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchData+DataProtocol.swift"; sourceTree = "<group>"; };
+		5BC1B9AB21F275D500524D8C /* NSData+DataProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSData+DataProtocol.swift"; sourceTree = "<group>"; };
+		5BC1B9AD21F275E900524D8C /* Pointers+DataProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Pointers+DataProtocol.swift"; sourceTree = "<group>"; };
 		5BC1D8BC1BF3ADFE009D3973 /* TestCharacterSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCharacterSet.swift; sourceTree = "<group>"; };
 		5BC2C00D1C07832E00CC214E /* CFStringTransform.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFStringTransform.c; sourceTree = "<group>"; };
 		5BC46D531D05D6D900005853 /* DateInterval.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateInterval.swift; sourceTree = "<group>"; };
@@ -1929,6 +1941,12 @@
 				EADE0B6B1BD15DFF00C49C64 /* NSNull.swift */,
 				5BDC3F331BCC5DCB00ED97BB /* NSData.swift */,
 				5BA9BEA51CF3D747009DBD6C /* Data.swift */,
+				5BC1B9A321F2757F00524D8C /* ContiguousBytes.swift */,
+				5BC1B9A721F275B000524D8C /* Collections+DataProtocol.swift */,
+				5BC1B9A921F275C400524D8C /* DispatchData+DataProtocol.swift */,
+				5BC1B9AB21F275D500524D8C /* NSData+DataProtocol.swift */,
+				5BC1B9AD21F275E900524D8C /* Pointers+DataProtocol.swift */,
+				5BC1B9A521F2759C00524D8C /* DataProtocol.swift */,
 				EADE0B741BD15DFF00C49C64 /* Progress.swift */,
 				EA0812681DA71C8A00651B70 /* ProgressFraction.swift */,
 				5BDC3F381BCC5DCB00ED97BB /* NSError.swift */,
@@ -2288,6 +2306,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				63DCE9D21EAA430100E9CB02 /* ISO8601DateFormatter.swift in Sources */,
+				5BC1B9A621F2759C00524D8C /* DataProtocol.swift in Sources */,
 				5BF7AE831BCD50CD008F214A /* NSArray.swift in Sources */,
 				B9974B971EDF4A22007F15B8 /* MultiHandle.swift in Sources */,
 				EADE0B991BD15DFF00C49C64 /* EnergyFormatter.swift in Sources */,
@@ -2301,6 +2320,7 @@
 				EADE0BC01BD15E0000C49C64 /* URLProtectionSpace.swift in Sources */,
 				5BF7AEAC1BCD51F9008F214A /* NSEnumerator.swift in Sources */,
 				5BA9BEA81CF3E7E7009DBD6C /* CharacterSet.swift in Sources */,
+				5BC1B9AA21F275C400524D8C /* DispatchData+DataProtocol.swift in Sources */,
 				61E0117E1C1B55B9000037DD /* Timer.swift in Sources */,
 				EADE0BCD1BD15E0000C49C64 /* XMLParser.swift in Sources */,
 				5BDC3FD01BCF17E600ED97BB /* NSCFSet.swift in Sources */,
@@ -2315,8 +2335,10 @@
 				EADE0BB01BD15E0000C49C64 /* Port.swift in Sources */,
 				EADE0BB91BD15E0000C49C64 /* NSTextCheckingResult.swift in Sources */,
 				EA0812691DA71C8A00651B70 /* ProgressFraction.swift in Sources */,
+				5BC1B9A821F275B000524D8C /* Collections+DataProtocol.swift in Sources */,
 				5BF7AEBE1BCD51F9008F214A /* NSTimeZone.swift in Sources */,
 				EADE0B951BD15DFF00C49C64 /* DateComponentsFormatter.swift in Sources */,
+				5BC1B9AE21F275E900524D8C /* Pointers+DataProtocol.swift in Sources */,
 				EADE0BBD1BD15E0000C49C64 /* URLCredential.swift in Sources */,
 				EADE0BCA1BD15E0000C49C64 /* XMLElement.swift in Sources */,
 				EADE0BA21BD15E0000C49C64 /* JSONSerialization.swift in Sources */,
@@ -2422,6 +2444,7 @@
 				B9974B991EDF4A22007F15B8 /* HTTPURLProtocol.swift in Sources */,
 				5BCD03821D3EE35C00E3FF9B /* TimeZone.swift in Sources */,
 				EADE0BBC1BD15E0000C49C64 /* URLCache.swift in Sources */,
+				5BC1B9AC21F275D500524D8C /* NSData+DataProtocol.swift in Sources */,
 				5B4092121D1B30B40022B067 /* ExtraStringAPIs.swift in Sources */,
 				5BC46D541D05D6D900005853 /* DateInterval.swift in Sources */,
 				EADE0BC51BD15E0000C49C64 /* UserDefaults.swift in Sources */,
@@ -2432,6 +2455,7 @@
 				5BDC3FCC1BCF177E00ED97BB /* NSCFString.swift in Sources */,
 				B9974B9A1EDF4A22007F15B8 /* HTTPMessage.swift in Sources */,
 				EADE0BAC1BD15E0000C49C64 /* NSOrderedSet.swift in Sources */,
+				5BC1B9A421F2757F00524D8C /* ContiguousBytes.swift in Sources */,
 				EADE0BC31BD15E0000C49C64 /* URLResponse.swift in Sources */,
 				EADE0B971BD15DFF00C49C64 /* Decimal.swift in Sources */,
 				EADE0B9F1BD15DFF00C49C64 /* HTTPCookieStorage.swift in Sources */,

--- a/Foundation/Collections+DataProtocol.swift
+++ b/Foundation/Collections+DataProtocol.swift
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+//===--- DataProtocol -----------------------------------------------------===//
+
+extension Array: DataProtocol where Element == UInt8 {
+    public var regions: CollectionOfOne<Array<UInt8>> {
+        return CollectionOfOne(self)
+    }
+}
+
+extension ArraySlice: DataProtocol where Element == UInt8 {
+    public var regions: CollectionOfOne<ArraySlice<UInt8>> {
+        return CollectionOfOne(self)
+    }
+}
+
+extension ContiguousArray: DataProtocol where Element == UInt8 {
+    public var regions: CollectionOfOne<ContiguousArray<UInt8>> {
+        return CollectionOfOne(self)
+    }
+}
+
+// FIXME: This currently crashes compilation in the Late Inliner.
+// extension CollectionOfOne : DataProtocol where Element == UInt8 {
+//     public typealias Regions = CollectionOfOne<Data>
+//
+//     public var regions: CollectionOfOne<Data> {
+//         return CollectionOfOne<Data>(Data(self))
+//     }
+// }
+
+extension EmptyCollection : DataProtocol where Element == UInt8 {
+    public var regions: EmptyCollection<Data> {
+        return EmptyCollection<Data>()
+    }
+}
+
+extension Repeated: DataProtocol where Element == UInt8 {
+    public typealias Regions = Repeated<Data>
+    
+    public var regions: Repeated<Data> {
+        guard self.count > 0 else { return repeatElement(Data(), count: 0) }
+        return repeatElement(Data(CollectionOfOne(self.first!)), count: self.count)
+    }
+}
+
+//===--- MutableDataProtocol ----------------------------------------------===//
+
+extension Array: MutableDataProtocol where Element == UInt8 { }
+
+extension ContiguousArray: MutableDataProtocol where Element == UInt8 { }

--- a/Foundation/ContiguousBytes.swift
+++ b/Foundation/ContiguousBytes.swift
@@ -1,0 +1,100 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+//===--- ContiguousBytes --------------------------------------------------===//
+
+/// Indicates that the conforming type is a contiguous collection of raw bytes
+/// whose underlying storage is directly accessible by withUnsafeBytes.
+public protocol ContiguousBytes {
+    /// Calls the given closure with the contents of underlying storage.
+    ///
+    /// - note: Calling `withUnsafeBytes` multiple times does not guarantee that
+    ///         the same buffer pointer will be passed in every time.
+    /// - warning: The buffer argument to the body should not be stored or used
+    ///            outside of the lifetime of the call to the closure.
+    func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R
+}
+
+//===--- Collection Conformances ------------------------------------------===//
+
+// FIXME: When possible, expand conformance to `where Element : Trivial`.
+extension Array : ContiguousBytes where Element == UInt8 { }
+
+// FIXME: When possible, expand conformance to `where Element : Trivial`.
+extension ArraySlice : ContiguousBytes where Element == UInt8 { }
+
+// FIXME: When possible, expand conformance to `where Element : Trivial`.
+extension ContiguousArray : ContiguousBytes where Element == UInt8 { }
+
+//===--- Pointer Conformances ---------------------------------------------===//
+
+extension UnsafeRawBufferPointer : ContiguousBytes {
+    @inlinable
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try body(self)
+    }
+}
+
+extension UnsafeMutableRawBufferPointer : ContiguousBytes {
+    @inlinable
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try body(UnsafeRawBufferPointer(self))
+    }
+}
+
+// FIXME: When possible, expand conformance to `where Element : Trivial`.
+extension UnsafeBufferPointer : ContiguousBytes where Element == UInt8 {
+    @inlinable
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try body(UnsafeRawBufferPointer(self))
+    }
+}
+
+// FIXME: When possible, expand conformance to `where Element : Trivial`.
+extension UnsafeMutableBufferPointer : ContiguousBytes where Element == UInt8 {
+    @inlinable
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try body(UnsafeRawBufferPointer(self))
+    }
+}
+
+// FIXME: When possible, expand conformance to `where Element : Trivial`.
+extension EmptyCollection : ContiguousBytes where Element == UInt8 {
+    @inlinable
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try body(UnsafeRawBufferPointer(start: nil, count: 0))
+    }
+}
+
+// FIXME: When possible, expand conformance to `where Element : Trivial`.
+extension CollectionOfOne : ContiguousBytes where Element == UInt8 {
+    @inlinable
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        let element = self.first!
+        return try Swift.withUnsafeBytes(of: element) {
+            return try body($0)
+        }
+    }
+}
+
+//===--- Conditional Conformances -----------------------------------------===//
+
+extension Slice : ContiguousBytes where Base : ContiguousBytes {
+    public func withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
+        let offset = base.distance(from: base.startIndex, to: self.startIndex)
+        return try base.withUnsafeBytes { ptr in
+            let slicePtr = ptr.baseAddress?.advanced(by: offset)
+            let sliceBuffer = UnsafeRawBufferPointer(start: slicePtr, count: self.count)
+            return try body(sliceBuffer)
+        }
+    }
+}

--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -11,19 +11,25 @@
 //===----------------------------------------------------------------------===//
 
 #if DEPLOYMENT_RUNTIME_SWIFT
-    
+
 #if os(macOS) || os(iOS)
 import Darwin
 #elseif os(Linux)
 import Glibc
+
+@inlinable // This is @inlinable as trivially computable.
+internal func malloc_good_size(_ size: Int) -> Int {
+    return size
+}
+
 #endif
-    
+
 import CoreFoundation
-    
+
 internal func __NSDataInvokeDeallocatorUnmap(_ mem: UnsafeMutableRawPointer, _ length: Int) {
     munmap(mem, length)
 }
-    
+
 internal func __NSDataInvokeDeallocatorFree(_ mem: UnsafeMutableRawPointer, _ length: Int) {
     free(mem)
 }
@@ -31,13 +37,13 @@ internal func __NSDataInvokeDeallocatorFree(_ mem: UnsafeMutableRawPointer, _ le
 internal func __NSDataIsCompact(_ data: NSData) -> Bool {
     return data._isCompact()
 }
-    
+
 #else
-    
+
 @_exported import Foundation // Clang module
 import _SwiftFoundationOverlayShims
 import _SwiftCoreFoundationOverlayShims
-    
+
 internal func __NSDataIsCompact(_ data: NSData) -> Bool {
     if #available(OSX 10.10, iOS 8.0, tvOS 9.0, watchOS 2.0, *) {
         return data._isCompact()
@@ -56,31 +62,18 @@ internal func __NSDataIsCompact(_ data: NSData) -> Bool {
 
 #endif
 
-public final class _DataStorage {
-    public enum Backing {
-        // A mirror of the Objective-C implementation that is suitable to inline in Swift
-        case swift
-        
-        // these two storage points for immutable and mutable data are reserved for references that are returned by "known"
-        // cases from Foundation in which implement the backing of struct Data, these have signed up for the concept that
-        // the backing bytes/mutableBytes pointer does not change per call (unless mutated) as well as the length is ok
-        // to be cached, this means that as long as the backing reference is retained no further objc_msgSends need to be
-        // dynamically dispatched out to the reference.
-        case immutable(NSData) // This will most often (perhaps always) be NSConcreteData
-        case mutable(NSMutableData) // This will often (perhaps always) be NSConcreteMutableData
-        
-        // These are reserved for foreign sources where neither Swift nor Foundation are fully certain whom they belong
-        // to from an object inheritance standpoint, this means that all bets are off and the values of bytes, mutableBytes,
-        // and length cannot be cached. This also means that all methods are expected to dynamically dispatch out to the
-        // backing reference.
-        case customReference(NSData) // tracks data references that are only known to be immutable
-        case customMutableReference(NSMutableData) // tracks data references that are known to be mutable
-    }
+// Underlying storage representation for medium and large data.
+// Inlinability strategy: methods from here should not inline into InlineSlice or LargeSlice unless trivial.
+// NOTE: older overlays called this class _DataStorage. The two must
+// coexist without a conflicting ObjC class name, so it was renamed.
+// The old name must not be used in the new runtime.
+@usableFromInline
+internal final class __DataStorage {
+    @usableFromInline static let maxSize = Int.max >> 1
+    @usableFromInline static let vmOpsThreshold = NSPageSize() * 4
     
-    public static let maxSize = Int.max >> 1
-    public static let vmOpsThreshold = NSPageSize() * 4
-    
-    public static func allocate(_ size: Int, _ clear: Bool) -> UnsafeMutableRawPointer? {
+    @inlinable // This is @inlinable as trivially forwarding, and does not escape the _DataStorage boundary layer.
+    static func allocate(_ size: Int, _ clear: Bool) -> UnsafeMutableRawPointer? {
         if clear {
             return calloc(1, size)
         } else {
@@ -88,12 +81,12 @@ public final class _DataStorage {
         }
     }
     
-    
-    public static func move(_ dest_: UnsafeMutableRawPointer, _ source_: UnsafeRawPointer?, _ num_: Int) {
+    @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
+    static func move(_ dest_: UnsafeMutableRawPointer, _ source_: UnsafeRawPointer?, _ num_: Int) {
         var dest = dest_
         var source = source_
         var num = num_
-        if _DataStorage.vmOpsThreshold <= num && ((unsafeBitCast(source, to: Int.self) | Int(bitPattern: dest)) & (NSPageSize() - 1)) == 0 {
+        if __DataStorage.vmOpsThreshold <= num && ((unsafeBitCast(source, to: Int.self) | Int(bitPattern: dest)) & (NSPageSize() - 1)) == 0 {
             let pages = NSRoundDownToMultipleOfPageSize(num)
             NSCopyMemoryPages(source!, dest, pages)
             source = source!.advanced(by: pages)
@@ -105,185 +98,165 @@ public final class _DataStorage {
         }
     }
     
-    public static func shouldAllocateCleared(_ size: Int) -> Bool {
+    @inlinable // This is @inlinable as trivially forwarding, and does not escape the _DataStorage boundary layer.
+    static func shouldAllocateCleared(_ size: Int) -> Bool {
         return (size > (128 * 1024))
     }
     
-    public var _bytes: UnsafeMutableRawPointer?
-    public var _length: Int
-    public var _capacity: Int
-    public var _needToZero: Bool
-    public var _deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?
-    public var _backing: Backing = .swift
-    public var _offset: Int
+    @usableFromInline var _bytes: UnsafeMutableRawPointer?
+    @usableFromInline var _length: Int
+    @usableFromInline var _capacity: Int
+    @usableFromInline var _needToZero: Bool
+    @usableFromInline var _deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?
+    @usableFromInline var _offset: Int
     
-    public var bytes: UnsafeRawPointer? {
-        @inline(__always)
-        get {
-            switch _backing {
-            case .swift:
-                return UnsafeRawPointer(_bytes)?.advanced(by: -_offset)
-            case .immutable:
-                return UnsafeRawPointer(_bytes)?.advanced(by: -_offset)
-            case .mutable:
-                return UnsafeRawPointer(_bytes)?.advanced(by: -_offset)
-            case .customReference(let d):
-                return d.bytes.advanced(by: -_offset)
-            case .customMutableReference(let d):
-                return d.bytes.advanced(by: -_offset)
-            }
-        }
+    @inlinable // This is @inlinable as trivially computable.
+    var bytes: UnsafeRawPointer? {
+        return UnsafeRawPointer(_bytes)?.advanced(by: -_offset)
     }
 
+    @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is generic and trivially forwarding.
     @discardableResult
-    public func withUnsafeBytes<Result>(in range: Range<Int>, apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
-        switch _backing {
-        case .swift: fallthrough
-        case .immutable: fallthrough
-        case .mutable:
-            return try apply(UnsafeRawBufferPointer(start: _bytes?.advanced(by: range.lowerBound - _offset), count: Swift.min(range.count, _length)))
-        case .customReference(let d):
-            if __NSDataIsCompact(d) {
-                let len = d.length
-                guard len > 0 else {
-                    return try apply(UnsafeRawBufferPointer(start: nil, count: 0))
-                }
-                return try apply(UnsafeRawBufferPointer(start: d.bytes.advanced(by: range.lowerBound - _offset), count: Swift.min(range.count, len)))
-            } else {
-                var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: range.count, alignment: MemoryLayout<UInt>.alignment)
-                defer { buffer.deallocate() }
-
-                let sliceRange = NSRange(location: range.lowerBound - _offset, length: range.count)
-                var enumerated = 0
-                d.enumerateBytes { (ptr, byteRange, stop) in
-                    if byteRange.upperBound - _offset < range.lowerBound {
-                        // before the range that we are looking for...
-                    } else if byteRange.lowerBound - _offset > range.upperBound {
-                        stop.pointee = true // we are past the range in question so we need to stop
-                    } else {
-                        // the byteRange somehow intersects the range in question that we are looking for...
-                        let lower = Swift.max(byteRange.lowerBound - _offset, range.lowerBound)
-                        let upper = Swift.min(byteRange.upperBound - _offset, range.upperBound)
-
-                        let len = upper - lower
-                        memcpy(buffer.baseAddress!.advanced(by: enumerated), ptr.advanced(by: lower - (byteRange.lowerBound - _offset)), len)
-                        enumerated += len
-
-                        if upper == range.upperBound {
-                            stop.pointee = true
-                        }
-                    }
-                }
-                return try apply(UnsafeRawBufferPointer(buffer))
-            }
-        case .customMutableReference(let d):
-            if __NSDataIsCompact(d) {
-                let len = d.length
-                guard len > 0 else {
-                    return try apply(UnsafeRawBufferPointer(start: nil, count: 0))
-                }
-                return try apply(UnsafeRawBufferPointer(start: d.bytes.advanced(by: range.lowerBound - _offset), count: Swift.min(range.count, len)))
-            } else {
-                var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: range.count, alignment: MemoryLayout<UInt>.alignment)
-                defer { buffer.deallocate() }
-
-                let sliceRange = NSRange(location: range.lowerBound - _offset, length: range.count)
-                var enumerated = 0
-                d.enumerateBytes { (ptr, byteRange, stop) in
-                    if byteRange.upperBound - _offset < range.lowerBound {
-                        // before the range that we are looking for...
-                    } else if byteRange.lowerBound - _offset > range.upperBound {
-                        stop.pointee = true // we are past the range in question so we need to stop
-                    } else {
-                        // the byteRange somehow intersects the range in question that we are looking for...
-                        let lower = Swift.max(byteRange.lowerBound - _offset, range.lowerBound)
-                        let upper = Swift.min(byteRange.upperBound - _offset, range.upperBound)
-
-                        let len = upper - lower
-                        memcpy(buffer.baseAddress!.advanced(by: enumerated), ptr.advanced(by: lower - (byteRange.lowerBound - _offset)), len)
-                        enumerated += len
-
-                        if upper == range.upperBound {
-                            stop.pointee = true
-                        }
-                    }
-                }
-                return try apply(UnsafeRawBufferPointer(buffer))
-            }
-        }
+    func withUnsafeBytes<Result>(in range: Range<Int>, apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
+        return try apply(UnsafeRawBufferPointer(start: _bytes?.advanced(by: range.lowerBound - _offset), count: Swift.min(range.upperBound - range.lowerBound, _length)))
     }
     
+    @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is generic and trivially forwarding.
     @discardableResult
-    public func withUnsafeMutableBytes<Result>(in range: Range<Int>, apply: (UnsafeMutableRawBufferPointer) throws -> Result) rethrows -> Result {
-        switch _backing {
-        case .swift: fallthrough
-        case .mutable:
-            return try apply(UnsafeMutableRawBufferPointer(start: _bytes!.advanced(by:range.lowerBound - _offset), count: Swift.min(range.count, _length)))
-        case .customMutableReference(let d):
-            let len = d.length
-            return try apply(UnsafeMutableRawBufferPointer(start: d.mutableBytes.advanced(by:range.lowerBound - _offset), count: Swift.min(range.count, len)))
-        case .immutable(let d):
-            let data = d.mutableCopy() as! NSMutableData
-            _backing = .mutable(data)
-            _bytes = data.mutableBytes
-            return try apply(UnsafeMutableRawBufferPointer(start: _bytes!.advanced(by:range.lowerBound - _offset), count: Swift.min(range.count, _length)))
-        case .customReference(let d):
-            let data = d.mutableCopy() as! NSMutableData
-            _backing = .customMutableReference(data)
-            let len = data.length
-            return try apply(UnsafeMutableRawBufferPointer(start: data.mutableBytes.advanced(by:range.lowerBound - _offset), count: Swift.min(range.count, len)))
-        }
+    func withUnsafeMutableBytes<Result>(in range: Range<Int>, apply: (UnsafeMutableRawBufferPointer) throws -> Result) rethrows -> Result {
+        return try apply(UnsafeMutableRawBufferPointer(start: _bytes!.advanced(by:range.lowerBound - _offset), count: Swift.min(range.upperBound - range.lowerBound, _length)))
     }
 
-    public var mutableBytes: UnsafeMutableRawPointer? {
-        @inline(__always)
-        get {
-            switch _backing {
-            case .swift:
-                return _bytes?.advanced(by: -_offset)
-            case .immutable(let d):
-                let data = d.mutableCopy() as! NSMutableData
-                data.length = length
-                _backing = .mutable(data)
-                _bytes = data.mutableBytes
-                return _bytes?.advanced(by: -_offset)
-            case .mutable:
-                return _bytes?.advanced(by: -_offset)
-            case .customReference(let d):
-                let data = d.mutableCopy() as! NSMutableData
-                data.length = length
-                _backing = .customMutableReference(data)
-                return data.mutableBytes.advanced(by: -_offset)
-            case .customMutableReference(let d):
-                return d.mutableBytes.advanced(by: -_offset)
-            }
-        }
+    @inlinable // This is @inlinable as trivially computable.
+    var mutableBytes: UnsafeMutableRawPointer? {
+        return _bytes?.advanced(by: -_offset)
+    }
+
+    @inlinable // This is @inlinable as trivially computable.
+    var capacity: Int {
+        return _capacity
     }
     
-    public var length: Int {
-        @inline(__always)
+    @inlinable // This is @inlinable as trivially computable.
+    var length: Int {
         get {
-            switch _backing {
-            case .swift:
-                return _length
-            case .immutable:
-                return _length
-            case .mutable:
-                return _length
-            case .customReference(let d):
-                return d.length
-            case .customMutableReference(let d):
-                return d.length
-            }
+            return _length
         }
-        @inline(__always)
         set {
             setLength(newValue)
         }
     }
     
+    @inlinable // This is inlinable as trivially computable.
+    var isExternallyOwned: Bool {
+        // all __DataStorages will have some sort of capacity, because empty cases hit the .empty enum _Representation
+        // anything with 0 capacity means that we have not allocated this pointer and concequently mutation is not ours to make.
+        return _capacity == 0
+    }
     
-    public func _freeBytes() {
+    @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
+    func ensureUniqueBufferReference(growingTo newLength: Int = 0, clear: Bool = false) {
+        guard isExternallyOwned || newLength > _capacity else { return }
+
+        if newLength == 0 {
+            if isExternallyOwned {
+                let newCapacity = malloc_good_size(_length)
+                let newBytes = __DataStorage.allocate(newCapacity, false)
+                __DataStorage.move(newBytes!, _bytes!, _length)
+                _freeBytes()
+                _bytes = newBytes
+                _capacity = newCapacity
+                _needToZero = false
+            }
+        } else if isExternallyOwned {
+            let newCapacity = malloc_good_size(newLength)
+            let newBytes = __DataStorage.allocate(newCapacity, clear)
+            if let bytes = _bytes {
+                __DataStorage.move(newBytes!, bytes, _length)
+            }
+            _freeBytes()
+            _bytes = newBytes
+            _capacity = newCapacity
+            _length = newLength
+            _needToZero = true
+        } else {
+            let cap = _capacity
+            var additionalCapacity = (newLength >> (__DataStorage.vmOpsThreshold <= newLength ? 2 : 1))
+            if Int.max - additionalCapacity < newLength {
+                additionalCapacity = 0
+            }
+            var newCapacity = malloc_good_size(Swift.max(cap, newLength + additionalCapacity))
+            let origLength = _length
+            var allocateCleared = clear && __DataStorage.shouldAllocateCleared(newCapacity)
+            var newBytes: UnsafeMutableRawPointer? = nil
+            if _bytes == nil {
+                newBytes = __DataStorage.allocate(newCapacity, allocateCleared)
+                if newBytes == nil {
+                    /* Try again with minimum length */
+                    allocateCleared = clear && __DataStorage.shouldAllocateCleared(newLength)
+                    newBytes = __DataStorage.allocate(newLength, allocateCleared)
+                }
+            } else {
+                let tryCalloc = (origLength == 0 || (newLength / origLength) >= 4)
+                if allocateCleared && tryCalloc {
+                    newBytes = __DataStorage.allocate(newCapacity, true)
+                    if let newBytes = newBytes {
+                        __DataStorage.move(newBytes, _bytes!, origLength)
+                        _freeBytes()
+                    }
+                }
+                /* Where calloc/memmove/free fails, realloc might succeed */
+                if newBytes == nil {
+                    allocateCleared = false
+                    if _deallocator != nil {
+                        newBytes = __DataStorage.allocate(newCapacity, true)
+                        if let newBytes = newBytes {
+                            __DataStorage.move(newBytes, _bytes!, origLength)
+                            _freeBytes()
+                        }
+                    } else {
+                        newBytes = realloc(_bytes!, newCapacity)
+                    }
+                }
+                /* Try again with minimum length */
+                if newBytes == nil {
+                    newCapacity = malloc_good_size(newLength)
+                    allocateCleared = clear && __DataStorage.shouldAllocateCleared(newCapacity)
+                    if allocateCleared && tryCalloc {
+                        newBytes = __DataStorage.allocate(newCapacity, true)
+                        if let newBytes = newBytes {
+                            __DataStorage.move(newBytes, _bytes!, origLength)
+                            _freeBytes()
+                        }
+                    }
+                    if newBytes == nil {
+                        allocateCleared = false
+                        newBytes = realloc(_bytes!, newCapacity)
+                    }
+                }
+            }
+
+            if newBytes == nil {
+                /* Could not allocate bytes */
+                // At this point if the allocation cannot occur the process is likely out of memory
+                // and Bad-Things™ are going to happen anyhow
+                fatalError("unable to allocate memory for length (\(newLength))")
+            }
+
+            if origLength < newLength && clear && !allocateCleared {
+                memset(newBytes!.advanced(by: origLength), 0, newLength - origLength)
+            }
+
+            /* _length set by caller */
+            _bytes = newBytes
+            _capacity = newCapacity
+            /* Realloc/memset doesn't zero out the entire capacity, so we must be safe and clear next time we grow the length */
+            _needToZero = !allocateCleared
+        }
+    }
+
+    @inlinable // This is @inlinable as it does not escape the _DataStorage boundary layer.
+    func _freeBytes() {
         if let bytes = _bytes {
             if let dealloc = _deallocator {
                 dealloc(bytes, length)
@@ -291,416 +264,117 @@ public final class _DataStorage {
                 free(bytes)
             }
         }
-    }
-    
-    public func enumerateBytes(in range: Range<Int>, _ block: (_ buffer: UnsafeBufferPointer<UInt8>, _ byteIndex: Data.Index, _ stop: inout Bool) -> Void) {
-        var stopv: Bool = false
-        var data: NSData
-        switch _backing {
-        case .swift: fallthrough
-        case .immutable: fallthrough
-        case .mutable: 
-            block(UnsafeBufferPointer<UInt8>(start: _bytes?.advanced(by: range.lowerBound - _offset).assumingMemoryBound(to: UInt8.self), count: Swift.min(range.count, _length)), 0, &stopv)
-            return
-        case .customReference(let d):
-            data = d
-            break
-        case .customMutableReference(let d):
-            data = d
-            break
-        }
-        data.enumerateBytes { (ptr, region, stop) in
-            // any region that is not in the range should be skipped
-            guard range.contains(region.lowerBound) || range.contains(region.upperBound) else { return }
-            var regionAdjustment = 0
-            if region.lowerBound < range.lowerBound {
-                regionAdjustment = range.lowerBound - (region.lowerBound - _offset)
-            }
-            let bytePtr  = ptr.advanced(by: regionAdjustment).assumingMemoryBound(to: UInt8.self)
-            let effectiveLength = Swift.min((region.location - _offset) + region.length, range.upperBound) - (region.location - _offset)
-            block(UnsafeBufferPointer(start: bytePtr, count: effectiveLength - regionAdjustment), region.location + regionAdjustment - _offset, &stopv)
-            if stopv {
-                stop.pointee = true
-            }
-        }
-    }
-    
-    @inline(never)
-    public func _grow(_ newLength: Int, _ clear: Bool) {
-        let cap = _capacity
-        var additionalCapacity = (newLength >> (_DataStorage.vmOpsThreshold <= newLength ? 2 : 1))
-        if Int.max - additionalCapacity < newLength {
-            additionalCapacity = 0
-        }
-        var newCapacity = Swift.max(cap, newLength + additionalCapacity)
-        let origLength = _length
-        var allocateCleared = clear && _DataStorage.shouldAllocateCleared(newCapacity)
-        var newBytes: UnsafeMutableRawPointer? = nil
-        if _bytes == nil {
-            newBytes = _DataStorage.allocate(newCapacity, allocateCleared)
-            if newBytes == nil {
-                /* Try again with minimum length */
-                allocateCleared = clear && _DataStorage.shouldAllocateCleared(newLength)
-                newBytes = _DataStorage.allocate(newLength, allocateCleared)
-            }
-        } else {
-            let tryCalloc = (origLength == 0 || (newLength / origLength) >= 4)
-            if allocateCleared && tryCalloc {
-                newBytes = _DataStorage.allocate(newCapacity, true)
-                if let newBytes = newBytes {
-                    _DataStorage.move(newBytes, _bytes!, origLength)
-                    _freeBytes()
-                }
-            }
-            /* Where calloc/memmove/free fails, realloc might succeed */
-            if newBytes == nil {
-                allocateCleared = false
-                if _deallocator != nil {
-                    newBytes = _DataStorage.allocate(newCapacity, true)
-                    if let newBytes = newBytes {
-                        _DataStorage.move(newBytes, _bytes!, origLength)
-                        _freeBytes()
-                        _deallocator = nil
-                    }
-                } else {
-                    newBytes = realloc(_bytes!, newCapacity)
-                }
-            }
-            
-            /* Try again with minimum length */
-            if newBytes == nil {
-                newCapacity = newLength
-                allocateCleared = clear && _DataStorage.shouldAllocateCleared(newCapacity)
-                if allocateCleared && tryCalloc {
-                    newBytes = _DataStorage.allocate(newCapacity, true)
-                    if let newBytes = newBytes {
-                        _DataStorage.move(newBytes, _bytes!, origLength)
-                        _freeBytes()
-                    }
-                }
-                if newBytes == nil {
-                    allocateCleared = false
-                    newBytes = realloc(_bytes!, newCapacity)
-                }
-            }
-        }
-        
-        if newBytes == nil {
-            /* Could not allocate bytes */
-            // At this point if the allocation cannot occur the process is likely out of memory
-            // and Bad-Things™ are going to happen anyhow
-            fatalError("unable to allocate memory for length (\(newLength))")
-        }
-        
-        if origLength < newLength && clear && !allocateCleared {
-            memset(newBytes!.advanced(by: origLength), 0, newLength - origLength)
-        }
-        
-        /* _length set by caller */
-        _bytes = newBytes
-        _capacity = newCapacity
-        /* Realloc/memset doesn't zero out the entire capacity, so we must be safe and clear next time we grow the length */
-        _needToZero = !allocateCleared
-    }
-    
-    @inline(__always)
-    public func setLength(_ length: Int) {
-        switch _backing {
-        case .swift:
-            let origLength = _length
-            let newLength = length
-            if _capacity < newLength || _bytes == nil {
-                _grow(newLength, true)
-            } else if origLength < newLength && _needToZero {
-                memset(_bytes! + origLength, 0, newLength - origLength)
-            } else if newLength < origLength {
-                _needToZero = true
-            }
-            _length = newLength
-        case .immutable(let d):
-            let data = d.mutableCopy() as! NSMutableData
-            data.length = length
-            _backing = .mutable(data)
-            _length = length
-            _bytes = data.mutableBytes
-        case .mutable(let d):
-            d.length = length
-            _length = length
-            _bytes = d.mutableBytes
-        case .customReference(let d):
-            let data = d.mutableCopy() as! NSMutableData
-            data.length = length
-            _backing = .customMutableReference(data)
-        case .customMutableReference(let d):
-            d.length = length
-        }
-    }
-    
-    @inline(__always)
-    public func append(_ bytes: UnsafeRawPointer, length: Int) {
-        precondition(length >= 0, "Length of appending bytes must not be negative")
-        switch _backing {
-        case .swift:
-            let origLength = _length
-            let newLength = origLength + length
-            if _capacity < newLength || _bytes == nil {
-                _grow(newLength, false)
-            }
-            _length = newLength
-            _DataStorage.move(_bytes!.advanced(by: origLength), bytes, length)
-        case .immutable(let d):
-            let data = d.mutableCopy() as! NSMutableData
-            data.append(bytes, length: length)
-            _backing = .mutable(data)
-            _length = data.length
-            _bytes = data.mutableBytes
-        case .mutable(let d):
-            d.append(bytes, length: length)
-            _length = d.length
-            _bytes = d.mutableBytes
-        case .customReference(let d):
-            let data = d.mutableCopy() as! NSMutableData
-            data.append(bytes, length: length)
-            _backing = .customMutableReference(data)
-        case .customMutableReference(let d):
-            d.append(bytes, length: length)
-        }
-        
-    }
-    
-    // fast-path for appending directly from another data storage
-    @inline(__always)
-    public func append(_ otherData: _DataStorage, startingAt start: Int, endingAt end: Int) {
-        let otherLength = otherData.length
-        if otherLength == 0 { return }
-        if let bytes = otherData.bytes {
-            append(bytes.advanced(by: start), length: end - start)
-        }
-    }
-    
-    @inline(__always)
-    public func append(_ otherData: Data) {
-        otherData.enumerateBytes { (buffer: UnsafeBufferPointer<UInt8>, _, _) in
-            append(buffer.baseAddress!, length: buffer.count)
-        }
-    }
-    
-    @inline(__always)
-    public func increaseLength(by extraLength: Int) {
-        if extraLength == 0 { return }
-        switch _backing {
-        case .swift:
-            let origLength = _length
-            let newLength = origLength + extraLength
-            if _capacity < newLength || _bytes == nil {
-                _grow(newLength, true)
-            } else if _needToZero {
-                memset(_bytes!.advanced(by: origLength), 0, extraLength)
-            }
-            _length = newLength
-        case .immutable(let d):
-            let data = d.mutableCopy() as! NSMutableData
-            data.increaseLength(by: extraLength)
-            _backing = .mutable(data)
-            _length += extraLength
-            _bytes = data.mutableBytes
-        case .mutable(let d):
-            d.increaseLength(by: extraLength)
-            _length += extraLength
-            _bytes = d.mutableBytes
-        case .customReference(let d):
-            let data = d.mutableCopy() as! NSMutableData
-            data.increaseLength(by: extraLength)
-            _backing = .customReference(data)
-        case .customMutableReference(let d):
-            d.increaseLength(by: extraLength)
-        }
-        
+        _deallocator = nil
     }
 
-    public func get(_ index: Int) -> UInt8 {
-        switch _backing {
-        case .swift: fallthrough
-        case .immutable: fallthrough
-        case .mutable:
-            return _bytes!.advanced(by: index - _offset).assumingMemoryBound(to: UInt8.self).pointee
-        case .customReference(let d):
-            if __NSDataIsCompact(d) {
-                return d.bytes.advanced(by: index - _offset).assumingMemoryBound(to: UInt8.self).pointee
-            } else {
-                var byte: UInt8 = 0
-                d.enumerateBytes { (ptr, range, stop) in
-                    if NSLocationInRange(index, range) {
-                        let offset = index - range.location - _offset
-                        byte = ptr.advanced(by: offset).assumingMemoryBound(to: UInt8.self).pointee
-                        stop.pointee = true
-                    }
-                }
-                return byte
-            }
-        case .customMutableReference(let d):
-            if __NSDataIsCompact(d) {
-                return d.bytes.advanced(by: index - _offset).assumingMemoryBound(to: UInt8.self).pointee
-            } else {
-                var byte: UInt8 = 0
-                d.enumerateBytes { (ptr, range, stop) in
-                    if NSLocationInRange(index, range) {
-                        let offset = index - range.location - _offset
-                        byte = ptr.advanced(by: offset).assumingMemoryBound(to: UInt8.self).pointee
-                        stop.pointee = true
-                    }
-                }
-                return byte
-            }
-        }
+    @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is trivially computed.
+    func enumerateBytes(in range: Range<Int>, _ block: (_ buffer: UnsafeBufferPointer<UInt8>, _ byteIndex: Data.Index, _ stop: inout Bool) -> Void) {
+        var stopv: Bool = false
+        block(UnsafeBufferPointer<UInt8>(start: _bytes?.advanced(by: range.lowerBound - _offset).assumingMemoryBound(to: UInt8.self), count: Swift.min(range.upperBound - range.lowerBound, _length)), 0, &stopv)
     }
     
-    @inline(__always)
-    public func set(_ index: Int, to value: UInt8) {
-        switch _backing {
-        case .swift:
-            fallthrough
-        case .mutable:
-            _bytes!.advanced(by: index - _offset).assumingMemoryBound(to: UInt8.self).pointee = value
-        default:
-            var theByte = value
-            let range = NSRange(location: index, length: 1)
-            replaceBytes(in: range, with: &theByte, length: 1)
+    @inlinable // This is @inlinable as it does not escape the _DataStorage boundary layer.
+    func setLength(_ length: Int) {
+        let origLength = _length
+        let newLength = length
+        if _capacity < newLength || _bytes == nil {
+            ensureUniqueBufferReference(growingTo: newLength, clear: true)
+        } else if origLength < newLength && _needToZero {
+            memset(_bytes! + origLength, 0, newLength - origLength)
+        } else if newLength < origLength {
+            _needToZero = true
         }
-        
+        _length = newLength
     }
     
-    @inline(__always)
-    public func replaceBytes(in range: NSRange, with bytes: UnsafeRawPointer?) {
-        if range.length == 0 { return }
-        switch _backing {
-        case .swift:
-            if _length < range.location + range.length {
-                let newLength = range.location + range.length
-                if _capacity < newLength {
-                    
-                    _grow(newLength, false)
-                }
-                _length = newLength
-            }
-            _DataStorage.move(_bytes!.advanced(by: range.location - _offset), bytes!, range.length)
-        case .immutable(let d):
-            let data = d.mutableCopy() as! NSMutableData
-            data.replaceBytes(in: NSRange(location: range.location - _offset, length: range.length), withBytes: bytes!)
-            _backing = .mutable(data)
-            _length = data.length
-            _bytes = data.mutableBytes
-        case .mutable(let d):
-            d.replaceBytes(in: NSRange(location: range.location - _offset, length: range.length), withBytes: bytes!)
-            _length = d.length
-            _bytes = d.mutableBytes
-        case .customReference(let d):
-            let data = d.mutableCopy() as! NSMutableData
-            data.replaceBytes(in: NSRange(location: range.location - _offset, length: range.length), withBytes: bytes!)
-            _backing = .customMutableReference(data)
-        case .customMutableReference(let d):
-            d.replaceBytes(in: NSRange(location: range.location - _offset, length: range.length), withBytes: bytes!)
+    @inlinable // This is @inlinable as it does not escape the _DataStorage boundary layer.
+    func append(_ bytes: UnsafeRawPointer, length: Int) {
+        precondition(length >= 0, "Length of appending bytes must not be negative")
+        let origLength = _length
+        let newLength = origLength + length
+        if _capacity < newLength || _bytes == nil {
+            ensureUniqueBufferReference(growingTo: newLength, clear: false)
         }
+        _length = newLength
+        __DataStorage.move(_bytes!.advanced(by: origLength), bytes, length)
     }
     
-    @inline(__always)
-    public func replaceBytes(in range_: NSRange, with replacementBytes: UnsafeRawPointer?, length replacementLength: Int) {
+    @inlinable // This is @inlinable despite escaping the __DataStorage boundary layer because it is trivially computed.
+    func get(_ index: Int) -> UInt8 {
+        return _bytes!.advanced(by: index - _offset).assumingMemoryBound(to: UInt8.self).pointee
+    }
+    
+    @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is trivially computed.
+    func set(_ index: Int, to value: UInt8) {
+        ensureUniqueBufferReference()
+        _bytes!.advanced(by: index - _offset).assumingMemoryBound(to: UInt8.self).pointee = value
+    }
+
+    @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is trivially computed.
+    func copyBytes(to pointer: UnsafeMutableRawPointer, from range: Range<Int>) {
+        let offsetPointer = UnsafeRawBufferPointer(start: _bytes?.advanced(by: range.lowerBound - _offset), count: Swift.min(range.upperBound - range.lowerBound, _length))
+        UnsafeMutableRawBufferPointer(start: pointer, count: range.upperBound - range.lowerBound).copyMemory(from: offsetPointer)
+    }
+
+    @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
+    func replaceBytes(in range_: NSRange, with replacementBytes: UnsafeRawPointer?, length replacementLength: Int) {
         let range = NSRange(location: range_.location - _offset, length: range_.length)
         let currentLength = _length
         let resultingLength = currentLength - range.length + replacementLength
-        switch _backing {
-        case .swift:
-            let shift = resultingLength - currentLength
-            var mutableBytes = _bytes
-            if resultingLength > currentLength {
-                setLength(resultingLength)
-                mutableBytes = _bytes!
-            }
-            /* shift the trailing bytes */
-            let start = range.location
-            let length = range.length
-            if shift != 0 {
-                memmove(mutableBytes! + start + replacementLength, mutableBytes! + start + length, currentLength - start - length)
-            }
-            if replacementLength != 0 {
-                if let replacementBytes = replacementBytes {
-                    memmove(mutableBytes! + start, replacementBytes, replacementLength)
-                } else {
-                    memset(mutableBytes! + start, 0, replacementLength)
-                }
-            }
-            
-            if resultingLength < currentLength {
-                setLength(resultingLength)
-            }
-        case .immutable(let d):
-            let data = d.mutableCopy() as! NSMutableData
-            data.replaceBytes(in: range, withBytes: replacementBytes, length: replacementLength)
-            _backing = .mutable(data)
-            _length = data.length
-            _bytes = data.mutableBytes
-        case .mutable(let d):
-            d.replaceBytes(in: range, withBytes: replacementBytes, length: replacementLength)
-            _backing = .mutable(d)
-            _length = d.length
-            _bytes = d.mutableBytes
-        case .customReference(let d):
-            let data = d.mutableCopy() as! NSMutableData
-            data.replaceBytes(in: range, withBytes: replacementBytes, length: replacementLength)
-            _backing = .customMutableReference(data)
-        case .customMutableReference(let d):
-            d.replaceBytes(in: range, withBytes: replacementBytes, length: replacementLength)
+        let shift = resultingLength - currentLength
+        let mutableBytes: UnsafeMutableRawPointer
+        if resultingLength > currentLength {
+            ensureUniqueBufferReference(growingTo: resultingLength)
+            _length = resultingLength
+        } else {
+            ensureUniqueBufferReference()
         }
-    }
-    
-    @inline(__always)
-    public func resetBytes(in range_: NSRange) {
-        let range = NSRange(location: range_.location - _offset, length: range_.length)
-        if range.length == 0 { return }
-        switch _backing {
-        case .swift:
-            if _length < range.location + range.length {
-                let newLength = range.location + range.length
-                if _capacity < newLength {
-                    _grow(newLength, false)
-                }
-                _length = newLength
+        mutableBytes = _bytes!
+        /* shift the trailing bytes */
+        let start = range.location
+        let length = range.length
+        if shift != 0 {
+            memmove(mutableBytes + start + replacementLength, mutableBytes + start + length, currentLength - start - length)
+        }
+        if replacementLength != 0 {
+            if let replacementBytes = replacementBytes {
+                memmove(mutableBytes + start, replacementBytes, replacementLength)
+            } else {
+                memset(mutableBytes + start, 0, replacementLength)
             }
-            memset(_bytes!.advanced(by: range.location), 0, range.length)
-        case .immutable(let d):
-            let data = d.mutableCopy() as! NSMutableData
-            data.resetBytes(in: range)
-            _backing = .mutable(data)
-            _length = data.length
-            _bytes = data.mutableBytes
-        case .mutable(let d):
-            d.resetBytes(in: range)
-            _length = d.length
-            _bytes = d.mutableBytes
-        case .customReference(let d):
-            let data = d.mutableCopy() as! NSMutableData
-            data.resetBytes(in: range)
-            _backing = .customMutableReference(data)
-        case .customMutableReference(let d):
-            d.resetBytes(in: range)
         }
         
+        if resultingLength < currentLength {
+            setLength(resultingLength)
+        }
     }
     
-    
-    public convenience init() {
-        self.init(capacity: 0)
+    @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
+    func resetBytes(in range_: Range<Int>) {
+        let range = NSRange(location: range_.lowerBound - _offset, length: range_.upperBound - range_.lowerBound)
+        if range.length == 0 { return }
+        if _length < range.location + range.length {
+            let newLength = range.location + range.length
+            if _capacity <= newLength {
+                ensureUniqueBufferReference(growingTo: newLength, clear: false)
+            }
+            _length = newLength
+        } else {
+            ensureUniqueBufferReference()
+        }
+        memset(_bytes!.advanced(by: range.location), 0, range.length)
     }
-    
-    public init(length: Int) {
-        precondition(length < _DataStorage.maxSize)
+
+    @usableFromInline // This is not @inlinable as a non-trivial, non-convenience initializer.
+    init(length: Int) {
+        precondition(length < __DataStorage.maxSize)
         var capacity = (length < 1024 * 1024 * 1024) ? length + (length >> 2) : length
-        if _DataStorage.vmOpsThreshold <= capacity {
+        if __DataStorage.vmOpsThreshold <= capacity {
             capacity = NSRoundUpToMultipleOfPageSize(capacity)
         }
         
-        let clear = _DataStorage.shouldAllocateCleared(length)
-        _bytes = _DataStorage.allocate(capacity, clear)!
+        let clear = __DataStorage.shouldAllocateCleared(length)
+        _bytes = __DataStorage.allocate(capacity, clear)!
         _capacity = capacity
         _needToZero = !clear
         _length = 0
@@ -708,49 +382,51 @@ public final class _DataStorage {
         setLength(length)
     }
     
-    
-    public init(capacity capacity_: Int) {
+    @usableFromInline // This is not @inlinable as a non-convience initializer.
+    init(capacity capacity_: Int = 0) {
         var capacity = capacity_
-        precondition(capacity < _DataStorage.maxSize)
-        if _DataStorage.vmOpsThreshold <= capacity {
+        precondition(capacity < __DataStorage.maxSize)
+        if __DataStorage.vmOpsThreshold <= capacity {
             capacity = NSRoundUpToMultipleOfPageSize(capacity)
         }
         _length = 0
-        _bytes = _DataStorage.allocate(capacity, false)!
+        _bytes = __DataStorage.allocate(capacity, false)!
         _capacity = capacity
         _needToZero = true
         _offset = 0
     }
     
-    public init(bytes: UnsafeRawPointer?, length: Int) {
-        precondition(length < _DataStorage.maxSize)
+    @usableFromInline // This is not @inlinable as a non-convience initializer.
+    init(bytes: UnsafeRawPointer?, length: Int) {
+        precondition(length < __DataStorage.maxSize)
         _offset = 0
         if length == 0 {
             _capacity = 0
             _length = 0
             _needToZero = false
             _bytes = nil
-        } else if _DataStorage.vmOpsThreshold <= length {
+        } else if __DataStorage.vmOpsThreshold <= length {
             _capacity = length
             _length = length
             _needToZero = true
-            _bytes = _DataStorage.allocate(length, false)!
-            _DataStorage.move(_bytes!, bytes, length)
+            _bytes = __DataStorage.allocate(length, false)!
+            __DataStorage.move(_bytes!, bytes, length)
         } else {
             var capacity = length
-            if _DataStorage.vmOpsThreshold <= capacity {
+            if __DataStorage.vmOpsThreshold <= capacity {
                 capacity = NSRoundUpToMultipleOfPageSize(capacity)
             }
             _length = length
-            _bytes = _DataStorage.allocate(capacity, false)!
+            _bytes = __DataStorage.allocate(capacity, false)!
             _capacity = capacity
             _needToZero = true
-            _DataStorage.move(_bytes!, bytes, length)
+            __DataStorage.move(_bytes!, bytes, length)
         }
     }
     
-    public init(bytes: UnsafeMutableRawPointer?, length: Int, copy: Bool, deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?, offset: Int) {
-        precondition(length < _DataStorage.maxSize)
+    @usableFromInline // This is not @inlinable as a non-convience initializer.
+    init(bytes: UnsafeMutableRawPointer?, length: Int, copy: Bool, deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?, offset: Int) {
+        precondition(length < __DataStorage.maxSize)
         _offset = offset
         if length == 0 {
             _capacity = 0
@@ -767,196 +443,123 @@ public final class _DataStorage {
             _needToZero = false
             _bytes = bytes
             _deallocator = deallocator
-        } else if _DataStorage.vmOpsThreshold <= length {
+        } else if __DataStorage.vmOpsThreshold <= length {
             _capacity = length
             _length = length
             _needToZero = true
-            _bytes = _DataStorage.allocate(length, false)!
-            _DataStorage.move(_bytes!, bytes, length)
+            _bytes = __DataStorage.allocate(length, false)!
+            __DataStorage.move(_bytes!, bytes, length)
             if let dealloc = deallocator {
                 dealloc(bytes!, length)
             }
         } else {
             var capacity = length
-            if _DataStorage.vmOpsThreshold <= capacity {
+            if __DataStorage.vmOpsThreshold <= capacity {
                 capacity = NSRoundUpToMultipleOfPageSize(capacity)
             }
             _length = length
-            _bytes = _DataStorage.allocate(capacity, false)!
+            _bytes = __DataStorage.allocate(capacity, false)!
             _capacity = capacity
             _needToZero = true
-            _DataStorage.move(_bytes!, bytes, length)
+            __DataStorage.move(_bytes!, bytes, length)
             if let dealloc = deallocator {
                 dealloc(bytes!, length)
             }
         }
     }
-    
-    public init(immutableReference: NSData, offset: Int) {
+
+    @usableFromInline // This is not @inlinable as a non-convience initializer.
+    init(immutableReference: NSData, offset: Int) {
         _offset = offset
         _bytes = UnsafeMutableRawPointer(mutating: immutableReference.bytes)
         _capacity = 0
         _needToZero = false
         _length = immutableReference.length
-        _backing = .immutable(immutableReference)
+        _deallocator = { _, _ in
+            _fixLifetime(immutableReference)
+        }
     }
     
-    public init(mutableReference: NSMutableData, offset: Int) {
+    @usableFromInline // This is not @inlinable as a non-convience initializer.
+    init(mutableReference: NSMutableData, offset: Int) {
         _offset = offset
         _bytes = mutableReference.mutableBytes
         _capacity = 0
         _needToZero = false
         _length = mutableReference.length
-        _backing = .mutable(mutableReference)
+        _deallocator = { _, _ in
+            _fixLifetime(mutableReference)
+        }
     }
     
-    public init(customReference: NSData, offset: Int) {
+    @usableFromInline // This is not @inlinable as a non-convience initializer.
+    init(customReference: NSData, offset: Int) {
         _offset = offset
-        _bytes = nil
+        _bytes = UnsafeMutableRawPointer(mutating: customReference.bytes)
         _capacity = 0
         _needToZero = false
-        _length = 0
-        _backing = .customReference(customReference)
+        _length = customReference.length
+        _deallocator = { _, _ in
+            _fixLifetime(customReference)
+        }
     }
     
-    public init(customMutableReference: NSMutableData, offset: Int) {
+    @usableFromInline // This is not @inlinable as a non-convience initializer.
+    init(customMutableReference: NSMutableData, offset: Int) {
         _offset = offset
-        _bytes = nil
+        _bytes = customMutableReference.mutableBytes
         _capacity = 0
         _needToZero = false
-        _length = 0
-        _backing = .customMutableReference(customMutableReference)
+        _length = customMutableReference.length
+        _deallocator = { _, _ in
+            _fixLifetime(customMutableReference)
+        }
     }
     
     deinit {
-        switch _backing {
-        case .swift:
-            _freeBytes()
-        default:
-            break
-        }
+        _freeBytes()
     }
     
-    @inline(__always)
-    public func mutableCopy(_ range: Range<Int>) -> _DataStorage {
-        switch _backing {
-        case .swift:
-            return _DataStorage(bytes: _bytes?.advanced(by: range.lowerBound - _offset), length: range.count, copy: true, deallocator: nil, offset: range.lowerBound)
-        case .immutable(let d):
-            if range.lowerBound == 0 && range.upperBound == _length {
-                return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData, offset: range.lowerBound)
-            } else {
-                return _DataStorage(mutableReference: d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC().mutableCopy() as! NSMutableData, offset: range.lowerBound)
-            }
-        case .mutable(let d):
-            if range.lowerBound == 0 && range.upperBound == _length {
-                return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData, offset: range.lowerBound)
-            } else {
-                return _DataStorage(mutableReference: d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC().mutableCopy() as! NSMutableData, offset: range.lowerBound)
-            }
-        case .customReference(let d):
-            if range.lowerBound == 0 && range.upperBound == _length {
-                return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData, offset: range.lowerBound)
-            } else {
-                return _DataStorage(mutableReference: d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC().mutableCopy() as! NSMutableData, offset: range.lowerBound)
-            }
-        case .customMutableReference(let d):
-            if range.lowerBound == 0 && range.upperBound == _length {
-                return _DataStorage(mutableReference: d.mutableCopy() as! NSMutableData, offset: range.lowerBound)
-            } else {
-                return _DataStorage(mutableReference: d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC().mutableCopy() as! NSMutableData, offset: range.lowerBound)
-            }
-        }
+    @inlinable // This is @inlinable despite escaping the __DataStorage boundary layer because it is trivially computed.
+    func mutableCopy(_ range: Range<Int>) -> __DataStorage {
+        return __DataStorage(bytes: _bytes?.advanced(by: range.lowerBound - _offset), length: range.upperBound - range.lowerBound, copy: true, deallocator: nil, offset: range.lowerBound)
     }
-    
-    public func withInteriorPointerReference<T>(_ range: Range<Int>, _ work: (NSData) throws -> T) rethrows -> T {
+
+    @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is generic and trivially computed.
+    func withInteriorPointerReference<T>(_ range: Range<Int>, _ work: (NSData) throws -> T) rethrows -> T {
         if range.isEmpty {
             return try work(NSData()) // zero length data can be optimized as a singleton
         }
-        
-        switch _backing {
-        case .swift:
-            return try work(NSData(bytesNoCopy: _bytes!.advanced(by: range.lowerBound - _offset), length: range.count, freeWhenDone: false))
-        case .immutable(let d):
-            guard range.lowerBound == 0 && range.upperBound == _length else {
-                return try work(NSData(bytesNoCopy: _bytes!.advanced(by: range.lowerBound - _offset), length: range.count, freeWhenDone: false))
-            }
-            return try work(d)
-        case .mutable(let d):
-            guard range.lowerBound == 0 && range.upperBound == _length else {
-                return try work(NSData(bytesNoCopy: _bytes!.advanced(by: range.lowerBound - _offset), length: range.count, freeWhenDone: false))
-            }
-            return try work(d)
-        case .customReference(let d):
-            guard range.lowerBound == 0 && range.upperBound == _length else {
-                
-                return try work(NSData(bytesNoCopy: UnsafeMutableRawPointer(mutating: d.bytes.advanced(by: range.lowerBound - _offset)), length: range.count, freeWhenDone: false))
-            }
-            return try work(d)
-        case .customMutableReference(let d):
-            guard range.lowerBound == 0 && range.upperBound == _length else {
-                return try work(NSData(bytesNoCopy: UnsafeMutableRawPointer(mutating: d.bytes.advanced(by: range.lowerBound - _offset)), length: range.count, freeWhenDone: false))
-            }
-            return try work(d)
-        }
+        return try work(NSData(bytesNoCopy: _bytes!.advanced(by: range.lowerBound - _offset), length: range.upperBound - range.lowerBound, freeWhenDone: false))
     }
-    
-    public func bridgedReference(_ range: Range<Int>) -> NSData {
+
+    @inline(never) // This is not @inlinable to avoid emission of the private `__NSSwiftData` class name into clients.
+    @usableFromInline
+    func bridgedReference(_ range: Range<Int>) -> NSData {
         if range.isEmpty {
             return NSData() // zero length data can be optimized as a singleton
         }
-        
-        switch _backing {
-        case .swift:
-            return __NSSwiftData(backing: self, range: range)
-        case .immutable(let d):
-            guard range.lowerBound == 0 && range.upperBound == _length else {
-                return __NSSwiftData(backing: self, range: range)
-            }
-            return d
-        case .mutable(let d):
-            guard range.lowerBound == 0 && range.upperBound == _length else {
-                return __NSSwiftData(backing: self, range: range)
-            }
-            return d
-        case .customReference(let d):
-            guard range.lowerBound == 0 && range.upperBound == d.length else {
-                return __NSSwiftData(backing: self, range: range)
-            }
-            return d
-        case .customMutableReference(let d):
-            guard range.lowerBound == 0 && range.upperBound == d.length else {
-                return d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC()
-            }
-            return d.copy() as! NSData
-        }
-    }
-    
-    public func subdata(in range: Range<Data.Index>) -> Data {
-        switch _backing {
-        case .customReference(let d):
-            return d.subdata(with: NSRange(location: range.lowerBound - _offset, length: range.count))
-        case .customMutableReference(let d):
-            return d.subdata(with: NSRange(location: range.lowerBound - _offset, length: range.count))
-        default:
-            return Data(bytes: _bytes!.advanced(by: range.lowerBound - _offset), count: range.count)
-        }
+
+        return __NSSwiftData(backing: self, range: range)
     }
 }
 
+// NOTE: older overlays called this _NSSwiftData. The two must
+// coexist, so it was renamed. The old name must not be used in the new
+// runtime.
 internal class __NSSwiftData : NSData {
-    var _backing: _DataStorage!
+    var _backing: __DataStorage!
     var _range: Range<Data.Index>!
-    
-    convenience init(backing: _DataStorage, range: Range<Data.Index>) {
+
+    convenience init(backing: __DataStorage, range: Range<Data.Index>) {
         self.init()
         _backing = backing
         _range = range
     }
     override var length: Int {
-        return _range.count
+        return _range.upperBound - _range.lowerBound
     }
-    
+
     override var bytes: UnsafeRawPointer {
         // NSData's byte pointer methods are not annotated for nullability correctly
         // (but assume non-null by the wrapping macro guards). This placeholder value
@@ -968,10 +571,10 @@ internal class __NSSwiftData : NSData {
         guard let bytes = _backing.bytes else {
             return UnsafeRawPointer(bitPattern: 0xBAD0)!
         }
-        
+
         return bytes.advanced(by: _range.lowerBound)
     }
-    
+
     override func copy(with zone: NSZone? = nil) -> Any {
         return self
     }
@@ -979,14 +582,14 @@ internal class __NSSwiftData : NSData {
     override func mutableCopy(with zone: NSZone? = nil) -> Any {
         return NSMutableData(bytes: bytes, length: length)
     }
-    
+
 #if !DEPLOYMENT_RUNTIME_SWIFT
     @objc override
     func _isCompact() -> Bool {
         return true
     }
 #endif
-    
+
 #if DEPLOYMENT_RUNTIME_SWIFT
     override func _providesConcreteBacking() -> Bool {
         return true
@@ -999,21 +602,1248 @@ internal class __NSSwiftData : NSData {
 #endif
 }
 
-public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessCollection, MutableCollection, RangeReplaceableCollection {
+@_fixed_layout
+public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessCollection, MutableCollection, RangeReplaceableCollection, MutableDataProtocol, ContiguousBytes {
     public typealias ReferenceType = NSData
-    
+
     public typealias ReadingOptions = NSData.ReadingOptions
     public typealias WritingOptions = NSData.WritingOptions
     public typealias SearchOptions = NSData.SearchOptions
     public typealias Base64EncodingOptions = NSData.Base64EncodingOptions
     public typealias Base64DecodingOptions = NSData.Base64DecodingOptions
-    
+
     public typealias Index = Int
     public typealias Indices = Range<Int>
+
+    // A small inline buffer of bytes suitable for stack-allocation of small data.
+    // Inlinability strategy: everything here should be inlined for direct operation on the stack wherever possible.
+    @usableFromInline
+    @_fixed_layout
+    internal struct InlineData {
+#if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+        @usableFromInline typealias Buffer = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+                                              UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) //len  //enum
+        @usableFromInline var bytes: Buffer
+#elseif arch(i386) || arch(arm)
+        @usableFromInline typealias Buffer = (UInt8, UInt8, UInt8, UInt8,
+                                              UInt8, UInt8) //len  //enum
+        @usableFromInline var bytes: Buffer
+#endif
+        @usableFromInline var length: UInt8
+
+        @inlinable // This is @inlinable as trivially computable.
+        static func canStore(count: Int) -> Bool {
+            return count <= MemoryLayout<Buffer>.size
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ srcBuffer: UnsafeRawBufferPointer) {
+            self.init(count: srcBuffer.count)
+            if srcBuffer.count > 0 {
+                Swift.withUnsafeMutableBytes(of: &bytes) { dstBuffer in
+                    dstBuffer.baseAddress?.copyMemory(from: srcBuffer.baseAddress!, byteCount: srcBuffer.count)
+                }
+            }
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(count: Int = 0) {
+            assert(count <= MemoryLayout<Buffer>.size)
+#if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+            bytes = (UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0))
+#elseif arch(i386) || arch(arm)
+            bytes = (UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0))
+#endif
+            length = UInt8(count)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ slice: InlineSlice, count: Int) {
+            self.init(count: count)
+            Swift.withUnsafeMutableBytes(of: &bytes) { dstBuffer in
+                slice.withUnsafeBytes { srcBuffer in
+                    dstBuffer.copyMemory(from: UnsafeRawBufferPointer(start: srcBuffer.baseAddress, count: count))
+                }
+            }
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ slice: LargeSlice, count: Int) {
+            self.init(count: count)
+            Swift.withUnsafeMutableBytes(of: &bytes) { dstBuffer in
+                slice.withUnsafeBytes { srcBuffer in
+                    dstBuffer.copyMemory(from: UnsafeRawBufferPointer(start: srcBuffer.baseAddress, count: count))
+                }
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var capacity: Int {
+            return MemoryLayout<Buffer>.size
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var count: Int {
+            get {
+                return Int(length)
+            }
+            set(newValue) {
+                precondition(newValue <= MemoryLayout<Buffer>.size)
+                length = UInt8(newValue)
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var startIndex: Int {
+            return 0
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var endIndex: Int {
+            return count
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        func withUnsafeBytes<Result>(_ apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
+            let count = Int(length)
+            return try Swift.withUnsafeBytes(of: bytes) { (rawBuffer) throws -> Result in
+                return try apply(UnsafeRawBufferPointer(start: rawBuffer.baseAddress, count: count))
+            }
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        mutating func withUnsafeMutableBytes<Result>(_ apply: (UnsafeMutableRawBufferPointer) throws -> Result) rethrows -> Result {
+            let count = Int(length)
+            return try Swift.withUnsafeMutableBytes(of: &bytes) { (rawBuffer) throws -> Result in
+                return try apply(UnsafeMutableRawBufferPointer(start: rawBuffer.baseAddress, count: count))
+            }
+        }
+
+        @inlinable // This is @inlinable as tribially computable.
+        mutating func append(byte: UInt8) {
+            let count = self.count
+            assert(count + 1 <= MemoryLayout<Buffer>.size)
+            Swift.withUnsafeMutableBytes(of: &bytes) { $0[count] = byte }
+            self.length += 1
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        mutating func append(contentsOf buffer: UnsafeRawBufferPointer) {
+            guard buffer.count > 0 else { return }
+            assert(count + buffer.count <= MemoryLayout<Buffer>.size)
+            let cnt = count
+            _ = Swift.withUnsafeMutableBytes(of: &bytes) { rawBuffer in
+                rawBuffer.baseAddress?.advanced(by: cnt).copyMemory(from: buffer.baseAddress!, byteCount: buffer.count)
+            }
+
+            length += UInt8(buffer.count)
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        subscript(index: Index) -> UInt8 {
+            get {
+                assert(index <= MemoryLayout<Buffer>.size)
+                precondition(index < length, "index \(index) is out of bounds of 0..<\(length)")
+                return Swift.withUnsafeBytes(of: bytes) { rawBuffer -> UInt8 in
+                    return rawBuffer[index]
+                }
+            }
+            set(newValue) {
+                assert(index <= MemoryLayout<Buffer>.size)
+                precondition(index < length, "index \(index) is out of bounds of 0..<\(length)")
+                Swift.withUnsafeMutableBytes(of: &bytes) { rawBuffer in
+                    rawBuffer[index] = newValue
+                }
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        mutating func resetBytes(in range: Range<Index>) {
+            assert(range.lowerBound <= MemoryLayout<Buffer>.size)
+            assert(range.upperBound <= MemoryLayout<Buffer>.size)
+            precondition(range.lowerBound <= length, "index \(range.lowerBound) is out of bounds of 0..<\(length)")
+            if count < range.upperBound {
+                count = range.upperBound
+            }
+
+            let _ = Swift.withUnsafeMutableBytes(of: &bytes) { rawBuffer in
+              memset(rawBuffer.baseAddress!.advanced(by: range.lowerBound), 0, range.upperBound - range.lowerBound)
+            }
+        }
+
+        @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
+        mutating func replaceSubrange(_ subrange: Range<Index>, with replacementBytes: UnsafeRawPointer?, count replacementLength: Int) {
+            assert(subrange.lowerBound <= MemoryLayout<Buffer>.size)
+            assert(subrange.upperBound <= MemoryLayout<Buffer>.size)
+            assert(count - (subrange.upperBound - subrange.lowerBound) + replacementLength <= MemoryLayout<Buffer>.size)
+            precondition(subrange.lowerBound <= length, "index \(subrange.lowerBound) is out of bounds of 0..<\(length)")
+            precondition(subrange.upperBound <= length, "index \(subrange.lowerBound) is out of bounds of 0..<\(length)")
+            let currentLength = count
+            let resultingLength = currentLength - (subrange.upperBound - subrange.lowerBound) + replacementLength
+            let shift = resultingLength - currentLength
+            Swift.withUnsafeMutableBytes(of: &bytes) { mutableBytes in
+                /* shift the trailing bytes */
+                let start = subrange.lowerBound
+                let length = subrange.upperBound - subrange.lowerBound
+                if shift != 0 {
+                    memmove(mutableBytes.baseAddress!.advanced(by: start + replacementLength), mutableBytes.baseAddress!.advanced(by: start + length), currentLength - start - length)
+                }
+                if replacementLength != 0 {
+                    memmove(mutableBytes.baseAddress!.advanced(by: start), replacementBytes!, replacementLength)
+                }
+            }
+            count = resultingLength
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        func copyBytes(to pointer: UnsafeMutableRawPointer, from range: Range<Int>) {
+            precondition(startIndex <= range.lowerBound, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(startIndex <= range.upperBound, "index \(range.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(range.upperBound <= endIndex, "index \(range.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+
+            Swift.withUnsafeBytes(of: bytes) {
+                let cnt = Swift.min($0.count, range.upperBound - range.lowerBound)
+                guard cnt > 0 else { return }
+                pointer.copyMemory(from: $0.baseAddress!.advanced(by: range.lowerBound), byteCount: cnt)
+            }
+        }
+
+        @inline(__always) // This should always be inlined into _Representation.hash(into:).
+        func hash(into hasher: inout Hasher) {
+            // **NOTE**: this uses `count` (an Int) and NOT `length` (a UInt8)
+            //           Despite having the same value, they hash differently. InlineSlice and LargeSlice both use `count` (an Int); if you combine the same bytes but with `length` over `count`, you can get a different hash.
+            //
+            // This affects slices, which are InlineSlice and not InlineData:
+            //
+            //   let d = Data([0xFF, 0xFF])                // InlineData
+            //   let s = Data([0, 0xFF, 0xFF]).dropFirst() // InlineSlice
+            //   assert(s == d)
+            //   assert(s.hashValue == d.hashValue)
+            hasher.combine(count)
+
+            Swift.withUnsafeBytes(of: bytes) {
+                // We have access to the full byte buffer here, but not all of it is meaningfully used (bytes past self.length may be garbage).
+                let bytes = UnsafeRawBufferPointer(start: $0.baseAddress, count: self.count)
+                hasher.combine(bytes: bytes)
+            }
+        }
+    }
+
+#if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+    @usableFromInline internal typealias HalfInt = Int32
+#elseif arch(i386) || arch(arm)
+    @usableFromInline internal typealias HalfInt = Int16
+#endif
+
+    // A buffer of bytes too large to fit in an InlineData, but still small enough to fit a storage pointer + range in two words.
+    // Inlinability strategy: everything here should be easily inlinable as large _DataStorage methods should not inline into here.
+    @usableFromInline
+    @_fixed_layout
+    internal struct InlineSlice {
+        // ***WARNING***
+        // These ivars are specifically laid out so that they cause the enum _Representation to be 16 bytes on 64 bit platforms. This means we _MUST_ have the class type thing last
+        @usableFromInline var slice: Range<HalfInt>
+        @usableFromInline var storage: __DataStorage
+
+        @inlinable // This is @inlinable as trivially computable.
+        static func canStore(count: Int) -> Bool {
+            return count < HalfInt.max
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ buffer: UnsafeRawBufferPointer) {
+            assert(buffer.count < HalfInt.max)
+            self.init(__DataStorage(bytes: buffer.baseAddress, length: buffer.count), count: buffer.count)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(capacity: Int) {
+            assert(capacity < HalfInt.max)
+            self.init(__DataStorage(capacity: capacity), count: 0)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(count: Int) {
+            assert(count < HalfInt.max)
+            self.init(__DataStorage(length: count), count: count)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ inline: InlineData) {
+            assert(inline.count < HalfInt.max)
+            self.init(inline.withUnsafeBytes { return __DataStorage(bytes: $0.baseAddress, length: $0.count) }, count: inline.count)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ inline: InlineData, range: Range<Int>) {
+            assert(range.lowerBound < HalfInt.max)
+            assert(range.upperBound < HalfInt.max)
+            self.init(inline.withUnsafeBytes { return __DataStorage(bytes: $0.baseAddress, length: $0.count) }, range: range)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ large: LargeSlice) {
+            assert(large.range.lowerBound < HalfInt.max)
+            assert(large.range.upperBound < HalfInt.max)
+            self.init(large.storage, range: large.range)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ large: LargeSlice, range: Range<Int>) {
+            assert(range.lowerBound < HalfInt.max)
+            assert(range.upperBound < HalfInt.max)
+            self.init(large.storage, range: range)
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(_ storage: __DataStorage, count: Int) {
+            assert(count < HalfInt.max)
+            self.storage = storage
+            slice = 0..<HalfInt(count)
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(_ storage: __DataStorage, range: Range<Int>) {
+            assert(range.lowerBound < HalfInt.max)
+            assert(range.upperBound < HalfInt.max)
+            self.storage = storage
+            slice = HalfInt(range.lowerBound)..<HalfInt(range.upperBound)
+        }
+
+        @inlinable // This is @inlinable as trivially computable (and inlining may help avoid retain-release traffic).
+        mutating func ensureUniqueReference() {
+            if !isKnownUniquelyReferenced(&storage) {
+                storage = storage.mutableCopy(self.range)
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var startIndex: Int {
+            return Int(slice.lowerBound)
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var endIndex: Int {
+            return Int(slice.upperBound)
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var capacity: Int {
+            return storage.capacity
+        }
+
+        @inlinable // This is @inlinable as trivially computable (and inlining may help avoid retain-release traffic).
+        mutating func reserveCapacity(_ minimumCapacity: Int) {
+            ensureUniqueReference()
+            // the current capacity can be zero (representing externally owned buffer), and count can be greater than the capacity
+            storage.ensureUniqueBufferReference(growingTo: Swift.max(minimumCapacity, count))
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var count: Int {
+            get {
+                return Int(slice.upperBound - slice.lowerBound)
+            }
+            set(newValue) {
+                assert(newValue < HalfInt.max)
+                ensureUniqueReference()
+                storage.length = newValue
+                slice = slice.lowerBound..<(slice.lowerBound + HalfInt(newValue))
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var range: Range<Int> {
+            get {
+                return Int(slice.lowerBound)..<Int(slice.upperBound)
+            }
+            set(newValue) {
+                assert(newValue.lowerBound < HalfInt.max)
+                assert(newValue.upperBound < HalfInt.max)
+                slice = HalfInt(newValue.lowerBound)..<HalfInt(newValue.upperBound)
+            }
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        func withUnsafeBytes<Result>(_ apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
+            return try storage.withUnsafeBytes(in: range, apply: apply)
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        mutating func withUnsafeMutableBytes<Result>(_ apply: (UnsafeMutableRawBufferPointer) throws -> Result) rethrows -> Result {
+            ensureUniqueReference()
+            return try storage.withUnsafeMutableBytes(in: range, apply: apply)
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        mutating func append(contentsOf buffer: UnsafeRawBufferPointer) {
+            assert(endIndex + buffer.count < HalfInt.max)
+            ensureUniqueReference()
+            storage.replaceBytes(in: NSRange(location: range.upperBound, length: storage.length - (range.upperBound - storage._offset)), with: buffer.baseAddress, length: buffer.count)
+            slice = slice.lowerBound..<HalfInt(Int(slice.upperBound) + buffer.count)
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        subscript(index: Index) -> UInt8 {
+            get {
+                assert(index < HalfInt.max)
+                precondition(startIndex <= index, "index \(index) is out of bounds of \(startIndex)..<\(endIndex)")
+                precondition(index < endIndex, "index \(index) is out of bounds of \(startIndex)..<\(endIndex)")
+                return storage.get(index)
+            }
+            set(newValue) {
+                assert(index < HalfInt.max)
+                precondition(startIndex <= index, "index \(index) is out of bounds of \(startIndex)..<\(endIndex)")
+                precondition(index < endIndex, "index \(index) is out of bounds of \(startIndex)..<\(endIndex)")
+                ensureUniqueReference()
+                storage.set(index, to: newValue)
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        func bridgedReference() -> NSData {
+            return storage.bridgedReference(self.range)
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        mutating func resetBytes(in range: Range<Index>) {
+            assert(range.lowerBound < HalfInt.max)
+            assert(range.upperBound < HalfInt.max)
+            precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            ensureUniqueReference()
+            storage.resetBytes(in: range)
+            if slice.upperBound < range.upperBound {
+                slice = slice.lowerBound..<HalfInt(range.upperBound)
+            }
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        mutating func replaceSubrange(_ subrange: Range<Index>, with bytes: UnsafeRawPointer?, count cnt: Int) {
+            precondition(startIndex <= subrange.lowerBound, "index \(subrange.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(subrange.lowerBound <= endIndex, "index \(subrange.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(startIndex <= subrange.upperBound, "index \(subrange.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(subrange.upperBound <= endIndex, "index \(subrange.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+
+            let nsRange = NSRange(location: subrange.lowerBound, length: subrange.upperBound - subrange.lowerBound)
+            ensureUniqueReference()
+            let upper = range.upperBound
+            storage.replaceBytes(in: nsRange, with: bytes, length: cnt)
+            let resultingUpper = upper - nsRange.length + cnt
+            slice = slice.lowerBound..<HalfInt(resultingUpper)
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        func copyBytes(to pointer: UnsafeMutableRawPointer, from range: Range<Int>) {
+            precondition(startIndex <= range.lowerBound, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(startIndex <= range.upperBound, "index \(range.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(range.upperBound <= endIndex, "index \(range.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            storage.copyBytes(to: pointer, from: range)
+        }
+
+        @inline(__always) // This should always be inlined into _Representation.hash(into:).
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(count)
+
+            // At most, hash the first 80 bytes of this data.
+            let range = startIndex ..< Swift.min(startIndex + 80, endIndex)
+            storage.withUnsafeBytes(in: range) {
+                hasher.combine(bytes: $0)
+            }
+        }
+    }
+
+    // A reference wrapper around a Range<Int> for when the range of a data buffer is too large to whole in a single word.
+    // Inlinability strategy: everything should be inlinable as trivial.
+    @usableFromInline
+    @_fixed_layout
+    internal final class RangeReference {
+        @usableFromInline var range: Range<Int>
+
+        @inlinable @inline(__always) // This is @inlinable as trivially forwarding.
+        var lowerBound: Int {
+            return range.lowerBound
+        }
+
+        @inlinable @inline(__always) // This is @inlinable as trivially forwarding.
+        var upperBound: Int {
+            return range.upperBound
+        }
+
+        @inlinable @inline(__always) // This is @inlinable as trivially computable.
+        var count: Int {
+            return range.upperBound - range.lowerBound
+        }
+
+        @inlinable @inline(__always) // This is @inlinable as a trivial initializer.
+        init(_ range: Range<Int>) {
+            self.range = range
+        }
+    }
+
+    // A buffer of bytes whose range is too large to fit in a signle word. Used alongside a RangeReference to make it fit into _Representation's two-word size.
+    // Inlinability strategy: everything here should be easily inlinable as large _DataStorage methods should not inline into here.
+    @usableFromInline
+    @_fixed_layout
+    internal struct LargeSlice {
+        // ***WARNING***
+        // These ivars are specifically laid out so that they cause the enum _Representation to be 16 bytes on 64 bit platforms. This means we _MUST_ have the class type thing last
+        @usableFromInline var slice: RangeReference
+        @usableFromInline var storage: __DataStorage
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ buffer: UnsafeRawBufferPointer) {
+            self.init(__DataStorage(bytes: buffer.baseAddress, length: buffer.count), count: buffer.count)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(capacity: Int) {
+            self.init(__DataStorage(capacity: capacity), count: 0)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(count: Int) {
+            self.init(__DataStorage(length: count), count: count)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ inline: InlineData) {
+            let storage = inline.withUnsafeBytes { return __DataStorage(bytes: $0.baseAddress, length: $0.count) }
+            self.init(storage, count: inline.count)
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(_ slice: InlineSlice) {
+            self.storage = slice.storage
+            self.slice = RangeReference(slice.range)
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(_ storage: __DataStorage, count: Int) {
+            self.storage = storage
+            self.slice = RangeReference(0..<count)
+        }
+
+        @inlinable // This is @inlinable as trivially computable (and inlining may help avoid retain-release traffic).
+        mutating func ensureUniqueReference() {
+            if !isKnownUniquelyReferenced(&storage) {
+                storage = storage.mutableCopy(range)
+            }
+            if !isKnownUniquelyReferenced(&slice) {
+                slice = RangeReference(range)
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        var startIndex: Int {
+            return slice.range.lowerBound
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        var endIndex: Int {
+          return slice.range.upperBound
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        var capacity: Int {
+            return storage.capacity
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        mutating func reserveCapacity(_ minimumCapacity: Int) {
+            ensureUniqueReference()
+            // the current capacity can be zero (representing externally owned buffer), and count can be greater than the capacity
+            storage.ensureUniqueBufferReference(growingTo: Swift.max(minimumCapacity, count))
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var count: Int {
+            get {
+                return slice.count
+            }
+            set(newValue) {
+                ensureUniqueReference()
+                storage.length = newValue
+                slice.range = slice.range.lowerBound..<(slice.range.lowerBound + newValue)
+            }
+        }
+
+        @inlinable // This is @inlinable as it is trivially forwarding.
+        var range: Range<Int> {
+            return slice.range
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        func withUnsafeBytes<Result>(_ apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
+            return try storage.withUnsafeBytes(in: range, apply: apply)
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        mutating func withUnsafeMutableBytes<Result>(_ apply: (UnsafeMutableRawBufferPointer) throws -> Result) rethrows -> Result {
+            ensureUniqueReference()
+            return try storage.withUnsafeMutableBytes(in: range, apply: apply)
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        mutating func append(contentsOf buffer: UnsafeRawBufferPointer) {
+            ensureUniqueReference()
+            storage.replaceBytes(in: NSRange(location: range.upperBound, length: storage.length - (range.upperBound - storage._offset)), with: buffer.baseAddress, length: buffer.count)
+            slice.range = slice.range.lowerBound..<slice.range.upperBound + buffer.count
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        subscript(index: Index) -> UInt8 {
+            get {
+                precondition(startIndex <= index, "index \(index) is out of bounds of \(startIndex)..<\(endIndex)")
+                precondition(index < endIndex, "index \(index) is out of bounds of \(startIndex)..<\(endIndex)")
+                return storage.get(index)
+            }
+            set(newValue) {
+                precondition(startIndex <= index, "index \(index) is out of bounds of \(startIndex)..<\(endIndex)")
+                precondition(index < endIndex, "index \(index) is out of bounds of \(startIndex)..<\(endIndex)")
+                ensureUniqueReference()
+                storage.set(index, to: newValue)
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        func bridgedReference() -> NSData {
+            return storage.bridgedReference(self.range)
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        mutating func resetBytes(in range: Range<Int>) {
+            precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            ensureUniqueReference()
+            storage.resetBytes(in: range)
+            if slice.range.upperBound < range.upperBound {
+                slice.range = slice.range.lowerBound..<range.upperBound
+            }
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        mutating func replaceSubrange(_ subrange: Range<Index>, with bytes: UnsafeRawPointer?, count cnt: Int) {
+            precondition(startIndex <= subrange.lowerBound, "index \(subrange.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(subrange.lowerBound <= endIndex, "index \(subrange.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(startIndex <= subrange.upperBound, "index \(subrange.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(subrange.upperBound <= endIndex, "index \(subrange.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+
+            let nsRange = NSRange(location: subrange.lowerBound, length: subrange.upperBound - subrange.lowerBound)
+            ensureUniqueReference()
+            let upper = range.upperBound
+            storage.replaceBytes(in: nsRange, with: bytes, length: cnt)
+            let resultingUpper = upper - nsRange.length + cnt
+            slice.range = slice.range.lowerBound..<resultingUpper
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        func copyBytes(to pointer: UnsafeMutableRawPointer, from range: Range<Int>) {
+            precondition(startIndex <= range.lowerBound, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(startIndex <= range.upperBound, "index \(range.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(range.upperBound <= endIndex, "index \(range.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            storage.copyBytes(to: pointer, from: range)
+        }
+
+        @inline(__always) // This should always be inlined into _Representation.hash(into:).
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(count)
+
+            // Hash at most the first 80 bytes of this data.
+            let range = startIndex ..< Swift.min(startIndex + 80, endIndex)
+            storage.withUnsafeBytes(in: range) {
+                hasher.combine(bytes: $0)
+            }
+        }
+    }
+
+    // The actual storage for Data's various representations.
+    // Inlinability strategy: almost everything should be inlinable as forwarding the underlying implementations. (Inlining can also help avoid retain-release traffic around pulling values out of enums.)
+    @usableFromInline
+    @_frozen
+    internal enum _Representation {
+        case empty
+        case inline(InlineData)
+        case slice(InlineSlice)
+        case large(LargeSlice)
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(_ buffer: UnsafeRawBufferPointer) {
+            if buffer.count == 0 {
+                self = .empty
+            } else if InlineData.canStore(count: buffer.count) {
+                self = .inline(InlineData(buffer))
+            } else if InlineSlice.canStore(count: buffer.count) {
+                self = .slice(InlineSlice(buffer))
+            } else {
+                self = .large(LargeSlice(buffer))
+            }
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(_ buffer: UnsafeRawBufferPointer, owner: AnyObject) {
+            if buffer.count == 0 {
+                self = .empty
+            } else if InlineData.canStore(count: buffer.count) {
+                self = .inline(InlineData(buffer))
+            } else {
+                let count = buffer.count
+                let storage = __DataStorage(bytes: UnsafeMutableRawPointer(mutating: buffer.baseAddress), length: count, copy: false, deallocator: { _, _ in
+                    _fixLifetime(owner)
+                }, offset: 0)
+                if InlineSlice.canStore(count: count) {
+                    self = .slice(InlineSlice(storage, count: count))
+                } else {
+                    self = .large(LargeSlice(storage, count: count))
+                }
+            }
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(capacity: Int) {
+            if capacity == 0 {
+                self = .empty
+            } else if InlineData.canStore(count: capacity) {
+                self = .inline(InlineData())
+            } else if InlineSlice.canStore(count: capacity) {
+                self = .slice(InlineSlice(capacity: capacity))
+            } else {
+                self = .large(LargeSlice(capacity: capacity))
+            }
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(count: Int) {
+            if count == 0 {
+                self = .empty
+            } else if InlineData.canStore(count: count) {
+                self = .inline(InlineData(count: count))
+            } else if InlineSlice.canStore(count: count) {
+                self = .slice(InlineSlice(count: count))
+            } else {
+                self = .large(LargeSlice(count: count))
+            }
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(_ storage: __DataStorage, count: Int) {
+            if count == 0 {
+                self = .empty
+            } else if InlineData.canStore(count: count) {
+                self = .inline(storage.withUnsafeBytes(in: 0..<count) { InlineData($0) })
+            } else if InlineSlice.canStore(count: count) {
+                self = .slice(InlineSlice(storage, count: count))
+            } else {
+                self = .large(LargeSlice(storage, count: count))
+            }
+        }
+
+        @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
+        mutating func reserveCapacity(_ minimumCapacity: Int) {
+            guard minimumCapacity > 0 else { return }
+            switch self {
+            case .empty:
+                if InlineData.canStore(count: minimumCapacity) {
+                    self = .inline(InlineData())
+                } else if InlineSlice.canStore(count: minimumCapacity) {
+                    self = .slice(InlineSlice(capacity: minimumCapacity))
+                } else {
+                    self = .large(LargeSlice(capacity: minimumCapacity))
+                }
+            case .inline(let inline):
+                guard minimumCapacity > inline.capacity else { return }
+                // we know we are going to be heap promoted
+                if InlineSlice.canStore(count: minimumCapacity) {
+                    var slice = InlineSlice(inline)
+                    slice.reserveCapacity(minimumCapacity)
+                    self = .slice(slice)
+                } else {
+                    var slice = LargeSlice(inline)
+                    slice.reserveCapacity(minimumCapacity)
+                    self = .large(slice)
+                }
+            case .slice(var slice):
+                guard minimumCapacity > slice.capacity else { return }
+                if InlineSlice.canStore(count: minimumCapacity) {
+                    self = .empty
+                    slice.reserveCapacity(minimumCapacity)
+                    self = .slice(slice)
+                } else {
+                    var large = LargeSlice(slice)
+                    large.reserveCapacity(minimumCapacity)
+                    self = .large(large)
+                }
+            case .large(var slice):
+                guard minimumCapacity > slice.capacity else { return }
+                self = .empty
+                slice.reserveCapacity(minimumCapacity)
+                self = .large(slice)
+            }
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        var count: Int {
+            get {
+                switch self {
+                case .empty: return 0
+                case .inline(let inline): return inline.count
+                case .slice(let slice): return slice.count
+                case .large(let slice): return slice.count
+                }
+            }
+            set(newValue) {
+                // HACK: The definition of this inline function takes an inout reference to self, giving the optimizer a unique referencing guarantee.
+                //       This allows us to avoid excessive retain-release traffic around modifying enum values, and inlining the function then avoids the additional frame.
+                @inline(__always)
+                func apply(_ representation: inout _Representation, _ newValue: Int) -> _Representation? {
+                    switch representation {
+                    case .empty:
+                        if newValue == 0 {
+                            return nil
+                        } else if InlineData.canStore(count: newValue) {
+                            return .inline(InlineData())
+                        } else if InlineSlice.canStore(count: newValue) {
+                            return .slice(InlineSlice(count: newValue))
+                        } else {
+                            return .large(LargeSlice(count: newValue))
+                        }
+                    case .inline(var inline):
+                        if newValue == 0 {
+                            return .empty
+                        } else if InlineData.canStore(count: newValue) {
+                            guard inline.count != newValue else { return nil }
+                            inline.count = newValue
+                            return .inline(inline)
+                        } else if InlineSlice.canStore(count: newValue) {
+                            var slice = InlineSlice(inline)
+                            slice.count = newValue
+                            return .slice(slice)
+                        } else {
+                            var slice = LargeSlice(inline)
+                            slice.count = newValue
+                            return .large(slice)
+                        }
+                    case .slice(var slice):
+                        if newValue == 0 && slice.startIndex == 0 {
+                            return .empty
+                        } else if slice.startIndex == 0 && InlineData.canStore(count: newValue) {
+                            return .inline(InlineData(slice, count: newValue))
+                        } else if InlineSlice.canStore(count: newValue + slice.startIndex) {
+                            guard slice.count != newValue else { return nil }
+                            representation = .empty // TODO: remove this when mgottesman lands optimizations
+                            slice.count = newValue
+                            return .slice(slice)
+                        } else {
+                            var newSlice = LargeSlice(slice)
+                            newSlice.count = newValue
+                            return .large(newSlice)
+                        }
+                    case .large(var slice):
+                        if newValue == 0 && slice.startIndex == 0 {
+                            return .empty
+                        } else if slice.startIndex == 0 && InlineData.canStore(count: newValue) {
+                            return .inline(InlineData(slice, count: newValue))
+                        } else {
+                            guard slice.count != newValue else { return nil}
+                            representation = .empty // TODO: remove this when mgottesman lands optimizations
+                            slice.count = newValue
+                            return .large(slice)
+                        }
+                    }
+                }
+
+                if let rep = apply(&self, newValue) {
+                    self = rep
+                }
+            }
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        func withUnsafeBytes<Result>(_ apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
+            switch self {
+            case .empty:
+                let empty = InlineData()
+                return try empty.withUnsafeBytes(apply)
+            case .inline(let inline):
+                return try inline.withUnsafeBytes(apply)
+            case .slice(let slice):
+                return try slice.withUnsafeBytes(apply)
+            case .large(let slice):
+                return try slice.withUnsafeBytes(apply)
+            }
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        mutating func withUnsafeMutableBytes<Result>(_ apply: (UnsafeMutableRawBufferPointer) throws -> Result) rethrows -> Result {
+            switch self {
+            case .empty:
+                var empty = InlineData()
+                return try empty.withUnsafeMutableBytes(apply)
+            case .inline(var inline):
+                defer { self = .inline(inline) }
+                return try inline.withUnsafeMutableBytes(apply)
+            case .slice(var slice):
+                self = .empty
+                defer { self = .slice(slice) }
+                return try slice.withUnsafeMutableBytes(apply)
+            case .large(var slice):
+                self = .empty
+                defer { self = .large(slice) }
+                return try slice.withUnsafeMutableBytes(apply)
+            }
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        func withInteriorPointerReference<T>(_ work: (NSData) throws -> T) rethrows -> T {
+            switch self {
+            case .empty:
+                return try work(NSData())
+            case .inline(let inline):
+                return try inline.withUnsafeBytes {
+                    return try work(NSData(bytesNoCopy: UnsafeMutableRawPointer(mutating: $0.baseAddress ?? UnsafeRawPointer(bitPattern: 0xBAD0)!), length: $0.count, freeWhenDone: false))
+                }
+            case .slice(let slice):
+                return try slice.storage.withInteriorPointerReference(slice.range, work)
+            case .large(let slice):
+                return try slice.storage.withInteriorPointerReference(slice.range, work)
+            }
+        }
+
+        @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
+        func enumerateBytes(_ block: (_ buffer: UnsafeBufferPointer<UInt8>, _ byteIndex: Index, _ stop: inout Bool) -> Void) {
+            switch self {
+            case .empty:
+                var stop = false
+                block(UnsafeBufferPointer<UInt8>(start: nil, count: 0), 0, &stop)
+            case .inline(let inline):
+                inline.withUnsafeBytes {
+                    var stop = false
+                    block(UnsafeBufferPointer<UInt8>(start: $0.baseAddress?.assumingMemoryBound(to: UInt8.self), count: $0.count), 0, &stop)
+                }
+            case .slice(let slice):
+                slice.storage.enumerateBytes(in: slice.range, block)
+            case .large(let slice):
+                slice.storage.enumerateBytes(in: slice.range, block)
+            }
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        mutating func append(contentsOf buffer: UnsafeRawBufferPointer) {
+            switch self {
+            case .empty:
+                self = _Representation(buffer)
+            case .inline(var inline):
+                if InlineData.canStore(count: inline.count + buffer.count) {
+                    inline.append(contentsOf: buffer)
+                    self = .inline(inline)
+                } else if InlineSlice.canStore(count: inline.count + buffer.count) {
+                    var newSlice = InlineSlice(inline)
+                    newSlice.append(contentsOf: buffer)
+                    self = .slice(newSlice)
+                } else {
+                    var newSlice = LargeSlice(inline)
+                    newSlice.append(contentsOf: buffer)
+                    self = .large(newSlice)
+                }
+            case .slice(var slice):
+                if InlineSlice.canStore(count: slice.range.upperBound + buffer.count) {
+                    self = .empty
+                    defer { self = .slice(slice) }
+                    slice.append(contentsOf: buffer)
+                } else {
+                    self = .empty
+                    var newSlice = LargeSlice(slice)
+                    newSlice.append(contentsOf: buffer)
+                    self = .large(newSlice)
+                }
+            case .large(var slice):
+                self = .empty
+                defer { self = .large(slice) }
+                slice.append(contentsOf: buffer)
+            }
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        mutating func resetBytes(in range: Range<Index>) {
+            switch self {
+            case .empty:
+                if range.upperBound == 0 {
+                    self = .empty
+                } else if InlineData.canStore(count: range.upperBound) {
+                    precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+                    self = .inline(InlineData(count: range.upperBound))
+                } else if InlineSlice.canStore(count: range.upperBound) {
+                    precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+                    self = .slice(InlineSlice(count: range.upperBound))
+                } else {
+                    precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+                    self = .large(LargeSlice(count: range.upperBound))
+                }
+                break
+            case .inline(var inline):
+                if inline.count < range.upperBound {
+                    if InlineSlice.canStore(count: range.upperBound) {
+                        var slice = InlineSlice(inline)
+                        slice.resetBytes(in: range)
+                        self = .slice(slice)
+                    } else {
+                        var slice = LargeSlice(inline)
+                        slice.resetBytes(in: range)
+                        self = .large(slice)
+                    }
+                } else {
+                    inline.resetBytes(in: range)
+                    self = .inline(inline)
+                }
+                break
+            case .slice(var slice):
+                if InlineSlice.canStore(count: range.upperBound) {
+                    self = .empty
+                    slice.resetBytes(in: range)
+                    self = .slice(slice)
+                } else {
+                    self = .empty
+                    var newSlice = LargeSlice(slice)
+                    newSlice.resetBytes(in: range)
+                    self = .large(newSlice)
+                }
+                break
+            case .large(var slice):
+                self = .empty
+                slice.resetBytes(in: range)
+                self = .large(slice)
+            }
+        }
+
+        @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
+        mutating func replaceSubrange(_ subrange: Range<Index>, with bytes: UnsafeRawPointer?, count cnt: Int) {
+            switch self {
+            case .empty:
+                precondition(subrange.lowerBound == 0 && subrange.upperBound == 0, "range \(subrange) out of bounds of 0..<0")
+                if cnt == 0 {
+                    return
+                } else if InlineData.canStore(count: cnt) {
+                    self = .inline(InlineData(UnsafeRawBufferPointer(start: bytes, count: cnt)))
+                } else if InlineSlice.canStore(count: cnt) {
+                    self = .slice(InlineSlice(UnsafeRawBufferPointer(start: bytes, count: cnt)))
+                } else {
+                    self = .large(LargeSlice(UnsafeRawBufferPointer(start: bytes, count: cnt)))
+                }
+                break
+            case .inline(var inline):
+                let resultingCount = inline.count + cnt - (subrange.upperBound - subrange.lowerBound)
+                if resultingCount == 0 {
+                    self = .empty
+                } else if InlineData.canStore(count: resultingCount) {
+                    inline.replaceSubrange(subrange, with: bytes, count: cnt)
+                    self = .inline(inline)
+                } else if InlineSlice.canStore(count: resultingCount) {
+                    var slice = InlineSlice(inline)
+                    slice.replaceSubrange(subrange, with: bytes, count: cnt)
+                    self = .slice(slice)
+                } else {
+                    var slice = LargeSlice(inline)
+                    slice.replaceSubrange(subrange, with: bytes, count: cnt)
+                    self = .large(slice)
+                }
+                break
+            case .slice(var slice):
+                let resultingUpper = slice.endIndex + cnt - (subrange.upperBound - subrange.lowerBound)
+                if slice.startIndex == 0 && resultingUpper == 0 {
+                    self = .empty
+                } else if slice.startIndex == 0 && InlineData.canStore(count: resultingUpper) {
+                    self = .empty
+                    slice.replaceSubrange(subrange, with: bytes, count: cnt)
+                    self = .inline(InlineData(slice, count: slice.count))
+                } else if InlineSlice.canStore(count: resultingUpper) {
+                    self = .empty
+                    slice.replaceSubrange(subrange, with: bytes, count: cnt)
+                    self = .slice(slice)
+                } else {
+                    self = .empty
+                    var newSlice = LargeSlice(slice)
+                    newSlice.replaceSubrange(subrange, with: bytes, count: cnt)
+                    self = .large(newSlice)
+                }
+            case .large(var slice):
+                let resultingUpper = slice.endIndex + cnt - (subrange.upperBound - subrange.lowerBound)
+                if slice.startIndex == 0 && resultingUpper == 0 {
+                    self = .empty
+                } else if slice.startIndex == 0 && InlineData.canStore(count: resultingUpper) {
+                    var inline = InlineData(count: resultingUpper)
+                    inline.withUnsafeMutableBytes { inlineBuffer in
+                        if cnt > 0 {
+                            inlineBuffer.baseAddress?.advanced(by: subrange.lowerBound).copyMemory(from: bytes!, byteCount: cnt)
+                        }
+                        slice.withUnsafeBytes { buffer in
+                            if subrange.lowerBound > 0 {
+                                inlineBuffer.baseAddress?.copyMemory(from: buffer.baseAddress!, byteCount: subrange.lowerBound)
+                            }
+                            if subrange.upperBound < resultingUpper {
+                                inlineBuffer.baseAddress?.advanced(by: subrange.upperBound).copyMemory(from: buffer.baseAddress!.advanced(by: subrange.upperBound), byteCount: resultingUpper - subrange.upperBound)
+                            }
+                        }
+                    }
+                    self = .inline(inline)
+                } else if InlineSlice.canStore(count: slice.startIndex) && InlineSlice.canStore(count: resultingUpper) {
+                    self = .empty
+                    var newSlice = InlineSlice(slice)
+                    newSlice.replaceSubrange(subrange, with: bytes, count: cnt)
+                    self = .slice(newSlice)
+                } else {
+                    self = .empty
+                    slice.replaceSubrange(subrange, with: bytes, count: cnt)
+                    self = .large(slice)
+                }
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        subscript(index: Index) -> UInt8 {
+            get {
+                switch self {
+                case .empty: preconditionFailure("index \(index) out of range of 0")
+                case .inline(let inline): return inline[index]
+                case .slice(let slice): return slice[index]
+                case .large(let slice): return slice[index]
+                }
+            }
+            set(newValue) {
+                switch self {
+                case .empty: preconditionFailure("index \(index) out of range of 0")
+                case .inline(var inline):
+                    inline[index] = newValue
+                    self = .inline(inline)
+                case .slice(var slice):
+                    self = .empty
+                    slice[index] = newValue
+                    self = .slice(slice)
+                case .large(var slice):
+                    self = .empty
+                    slice[index] = newValue
+                    self = .large(slice)
+                }
+            }
+        }
+        
+        @inlinable // This is @inlinable as reasonably small.
+        subscript(bounds: Range<Index>) -> Data {
+            get {
+                switch self {
+                case .empty:
+                    precondition(bounds.lowerBound == 0 && (bounds.upperBound - bounds.lowerBound) == 0, "Range \(bounds) out of bounds 0..<0")
+                    return Data()
+                case .inline(let inline):
+                    precondition(bounds.upperBound <= inline.count, "Range \(bounds) out of bounds 0..<\(inline.count)")
+                    if bounds.lowerBound == 0 {
+                        var newInline = inline
+                        newInline.count = bounds.upperBound
+                        return Data(representation: .inline(newInline))
+                    } else {
+                        return Data(representation: .slice(InlineSlice(inline, range: bounds)))
+                    }
+                case .slice(let slice):
+                    precondition(slice.startIndex <= bounds.lowerBound, "Range \(bounds) out of bounds \(slice.range)")
+                    precondition(bounds.lowerBound <= slice.endIndex, "Range \(bounds) out of bounds \(slice.range)")
+                    precondition(slice.startIndex <= bounds.upperBound, "Range \(bounds) out of bounds \(slice.range)")
+                    precondition(bounds.upperBound <= slice.endIndex, "Range \(bounds) out of bounds \(slice.range)")
+                    if bounds.lowerBound == 0 && bounds.upperBound == 0 {
+                        return Data()
+                    } else if bounds.lowerBound == 0 && InlineData.canStore(count: bounds.count) {
+                        return Data(representation: .inline(InlineData(slice, count: bounds.count)))
+                    } else {
+                        var newSlice = slice
+                        newSlice.range = bounds
+                        return Data(representation: .slice(newSlice))
+                    }
+                case .large(let slice):
+                    precondition(slice.startIndex <= bounds.lowerBound, "Range \(bounds) out of bounds \(slice.range)")
+                    precondition(bounds.lowerBound <= slice.endIndex, "Range \(bounds) out of bounds \(slice.range)")
+                    precondition(slice.startIndex <= bounds.upperBound, "Range \(bounds) out of bounds \(slice.range)")
+                    precondition(bounds.upperBound <= slice.endIndex, "Range \(bounds) out of bounds \(slice.range)")
+                    if bounds.lowerBound == 0 && bounds.upperBound == 0 {
+                        return Data()
+                    } else if bounds.lowerBound == 0 && InlineData.canStore(count: bounds.upperBound) {
+                        return Data(representation: .inline(InlineData(slice, count: bounds.upperBound)))
+                    } else if InlineSlice.canStore(count: bounds.lowerBound) && InlineSlice.canStore(count: bounds.upperBound) {
+                        return Data(representation: .slice(InlineSlice(slice, range: bounds)))
+                    } else {
+                        var newSlice = slice
+                        newSlice.slice = RangeReference(bounds)
+                        return Data(representation: .large(newSlice))
+                    }
+                }
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        var startIndex: Int {
+            switch self {
+            case .empty: return 0
+            case .inline: return 0
+            case .slice(let slice): return slice.startIndex
+            case .large(let slice): return slice.startIndex
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        var endIndex: Int {
+            switch self {
+            case .empty: return 0
+            case .inline(let inline): return inline.count
+            case .slice(let slice): return slice.endIndex
+            case .large(let slice): return slice.endIndex
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        func bridgedReference() -> NSData {
+            switch self {
+            case .empty: return NSData()
+            case .inline(let inline):
+                return inline.withUnsafeBytes {
+                    return NSData(bytes: $0.baseAddress, length: $0.count)
+                }
+            case .slice(let slice):
+                return slice.bridgedReference()
+            case .large(let slice):
+                return slice.bridgedReference()
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        func copyBytes(to pointer: UnsafeMutableRawPointer, from range: Range<Int>) {
+            switch self {
+            case .empty:
+                precondition(range.lowerBound == 0 && range.upperBound == 0, "Range \(range) out of bounds 0..<0")
+                return
+            case .inline(let inline):
+                inline.copyBytes(to: pointer, from: range)
+                break
+            case .slice(let slice):
+                slice.copyBytes(to: pointer, from: range)
+            case .large(let slice):
+                slice.copyBytes(to: pointer, from: range)
+            }
+        }
+        
+        @inline(__always) // This should always be inlined into Data.hash(into:).
+        func hash(into hasher: inout Hasher) {
+            switch self {
+            case .empty:
+                hasher.combine(0)
+            case .inline(let inline):
+                inline.hash(into: &hasher)
+            case .slice(let slice):
+                slice.hash(into: &hasher)
+            case .large(let large):
+                large.hash(into: &hasher)
+            }
+        }
+    }
     
-    @usableFromInline internal var _backing : _DataStorage
-    @usableFromInline internal var _sliceRange: Range<Index>
-    
+    @usableFromInline internal var _representation: _Representation
     
     // A standard or custom deallocator for `Data`.
     ///
@@ -1036,7 +1866,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         /// A custom deallocator.
         case custom((UnsafeMutableRawPointer, Int) -> Void)
         
-        fileprivate var _deallocator : ((UnsafeMutableRawPointer, Int) -> Void) {
+        @usableFromInline internal var _deallocator : ((UnsafeMutableRawPointer, Int) -> Void) {
 #if DEPLOYMENT_RUNTIME_SWIFT
             switch self {
             case .unmap:
@@ -1046,9 +1876,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             case .none:
                 return { _, _ in }
             case .custom(let b):
-                return { (ptr, len) in
-                    b(ptr, len)
-                }
+                return b
             }
 #else
             switch self {
@@ -1061,9 +1889,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             case .none:
                 return { _, _ in }
             case .custom(let b):
-                return { (ptr, len) in
-                    b(ptr, len)
-                }
+                return b
             }
 #endif
         }
@@ -1076,59 +1902,38 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     ///
     /// - parameter bytes: A pointer to the memory. It will be copied.
     /// - parameter count: The number of bytes to copy.
+    @inlinable // This is @inlinable as a trivial initializer.
     public init(bytes: UnsafeRawPointer, count: Int) {
-        _backing = _DataStorage(bytes: bytes, length: count)
-        _sliceRange = 0..<count
+        _representation = _Representation(UnsafeRawBufferPointer(start: bytes, count: count))
     }
-    
+
     /// Initialize a `Data` with copied memory content.
     ///
     /// - parameter buffer: A buffer pointer to copy. The size is calculated from `SourceType` and `buffer.count`.
+    @inlinable // This is @inlinable as a trivial, generic initializer.
     public init<SourceType>(buffer: UnsafeBufferPointer<SourceType>) {
-        let count = MemoryLayout<SourceType>.stride * buffer.count
-        _backing = _DataStorage(bytes: buffer.baseAddress, length: count)
-        _sliceRange = 0..<count
+        _representation = _Representation(UnsafeRawBufferPointer(buffer))
     }
     
     /// Initialize a `Data` with copied memory content.
     ///
     /// - parameter buffer: A buffer pointer to copy. The size is calculated from `SourceType` and `buffer.count`.
+    @inlinable // This is @inlinable as a trivial, generic initializer.
     public init<SourceType>(buffer: UnsafeMutableBufferPointer<SourceType>) {
-        let count = MemoryLayout<SourceType>.stride * buffer.count
-        _backing = _DataStorage(bytes: buffer.baseAddress, length: count)
-        _sliceRange = 0..<count
-    }
-    
-    /// Initialize a `Data` with the contents of an Array.
-    ///
-    /// - parameter bytes: An array of bytes to copy.
-    public init(bytes: Array<UInt8>) {
-        let count = bytes.count
-        _backing = bytes.withUnsafeBufferPointer {
-            return _DataStorage(bytes: $0.baseAddress, length: count)
-        }
-        _sliceRange = 0..<count
-    }
-    
-    /// Initialize a `Data` with the contents of an Array.
-    ///
-    /// - parameter bytes: An array of bytes to copy.
-    public init(bytes: ArraySlice<UInt8>) {
-        let count = bytes.count
-        _backing = bytes.withUnsafeBufferPointer {
-            return _DataStorage(bytes: $0.baseAddress, length: count)
-        }
-        _sliceRange = 0..<count
+        _representation = _Representation(UnsafeRawBufferPointer(buffer))
     }
     
     /// Initialize a `Data` with a repeating byte pattern
     ///
     /// - parameter repeatedValue: A byte to initialize the pattern
     /// - parameter count: The number of bytes the data initially contains initialized to the repeatedValue
+    @inlinable // This is @inlinable as a convenience initializer.
     public init(repeating repeatedValue: UInt8, count: Int) {
         self.init(count: count)
-        withUnsafeMutableBytes { (bytes: UnsafeMutablePointer<UInt8>) -> Void in
-            memset(bytes, Int32(repeatedValue), count)
+        if count > 0 {
+            withUnsafeMutableBytes { (buffer: UnsafeMutableRawBufferPointer) -> Void in
+                memset(buffer.baseAddress!, Int32(repeatedValue), buffer.count)
+            }
         }
     }
     
@@ -1141,23 +1946,23 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// If the capacity specified in `capacity` is greater than four memory pages in size, this may round the amount of requested memory up to the nearest full page.
     ///
     /// - parameter capacity: The size of the data.
+    @inlinable // This is @inlinable as a trivial initializer.
     public init(capacity: Int) {
-        _backing = _DataStorage(capacity: capacity)
-        _sliceRange = 0..<0
+        _representation = _Representation(capacity: capacity)
     }
     
     /// Initialize a `Data` with the specified count of zeroed bytes.
     ///
     /// - parameter count: The number of bytes the data initially contains.
+    @inlinable // This is @inlinable as a trivial initializer.
     public init(count: Int) {
-        _backing = _DataStorage(length: count)
-        _sliceRange = 0..<count
+        _representation = _Representation(count: count)
     }
     
     /// Initialize an empty `Data`.
+    @inlinable // This is @inlinable as a trivial initializer.
     public init() {
-        _backing = _DataStorage(length: 0)
-        _sliceRange = 0..<0
+        _representation = .empty
     }
     
     
@@ -1167,10 +1972,15 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter bytes: A pointer to the bytes.
     /// - parameter count: The size of the bytes.
     /// - parameter deallocator: Specifies the mechanism to free the indicated buffer, or `.none`.
+    @inlinable // This is @inlinable as a trivial initializer.
     public init(bytesNoCopy bytes: UnsafeMutableRawPointer, count: Int, deallocator: Deallocator) {
         let whichDeallocator = deallocator._deallocator
-        _backing = _DataStorage(bytes: bytes, length: count, copy: false, deallocator: whichDeallocator, offset: 0)
-        _sliceRange = 0..<count
+        if count == 0 {
+            deallocator._deallocator(bytes, count)
+            _representation = .empty
+        } else {
+            _representation = _Representation(__DataStorage(bytes: bytes, length: count, copy: false, deallocator: whichDeallocator, offset: 0), count: count)
+        }
     }
     
     /// Initialize a `Data` with the contents of a `URL`.
@@ -1178,10 +1988,10 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter url: The `URL` to read.
     /// - parameter options: Options for the read operation. Default value is `[]`.
     /// - throws: An error in the Cocoa domain, if `url` cannot be read.
-    public init(contentsOf url: URL, options: Data.ReadingOptions = []) throws {
+    @inlinable // This is @inlinable as a convenience initializer.
+    public init(contentsOf url: __shared URL, options: Data.ReadingOptions = []) throws {
         let d = try NSData(contentsOf: url, options: ReadingOptions(rawValue: options.rawValue))
-        _backing = _DataStorage(immutableReference: d, offset: 0)
-        _sliceRange = 0..<d.length
+        self.init(bytes: d.bytes, count: d.length)
     }
     
     /// Initialize a `Data` from a Base-64 encoded String using the given options.
@@ -1189,10 +1999,10 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// Returns nil when the input is not recognized as valid Base-64.
     /// - parameter base64String: The string to parse.
     /// - parameter options: Encoding options. Default value is `[]`.
-    public init?(base64Encoded base64String: String, options: Data.Base64DecodingOptions = []) {
+    @inlinable // This is @inlinable as a convenience initializer.
+    public init?(base64Encoded base64String: __shared String, options: Data.Base64DecodingOptions = []) {
         if let d = NSData(base64Encoded: base64String, options: Base64DecodingOptions(rawValue: options.rawValue)) {
-            _backing = _DataStorage(immutableReference: d, offset: 0)
-            _sliceRange = 0..<d.length
+            self.init(bytes: d.bytes, count: d.length)
         } else {
             return nil
         }
@@ -1204,10 +2014,10 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     ///
     /// - parameter base64Data: Base-64, UTF-8 encoded input data.
     /// - parameter options: Decoding options. Default value is `[]`.
-    public init?(base64Encoded base64Data: Data, options: Data.Base64DecodingOptions = []) {
+    @inlinable // This is @inlinable as a convenience initializer.
+    public init?(base64Encoded base64Data: __shared Data, options: Data.Base64DecodingOptions = []) {
         if let d = NSData(base64Encoded: base64Data, options: Base64DecodingOptions(rawValue: options.rawValue)) {
-            _backing = _DataStorage(immutableReference: d, offset: 0)
-            _sliceRange = 0..<d.length
+            self.init(bytes: d.bytes, count: d.length)
         } else {
             return nil
         }
@@ -1220,113 +2030,154 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// If the resulting value is mutated, then `Data` will invoke the `mutableCopy()` function on the reference to copy the contents. You may customize the behavior of that function if you wish to return a specialized mutable subclass.
     ///
     /// - parameter reference: The instance of `NSData` that you wish to wrap. This instance will be copied by `struct Data`.
-    public init(referencing reference: NSData) {
-#if DEPLOYMENT_RUNTIME_SWIFT
-        let providesConcreteBacking = reference._providesConcreteBacking()
-#else
-        let providesConcreteBacking = (reference as AnyObject)._providesConcreteBacking?() ?? false
-#endif
-        if providesConcreteBacking {
-            _backing = _DataStorage(immutableReference: reference.copy() as! NSData, offset: 0)
-            _sliceRange = 0..<reference.length
+    public init(referencing reference: __shared NSData) {
+        // This is not marked as inline because _providesConcreteBacking would need to be marked as usable from inline however that is a dynamic lookup in objc contexts.
+        let length = reference.length
+        if length == 0 {
+            _representation = .empty
         } else {
-            _backing = _DataStorage(customReference: reference.copy() as! NSData, offset: 0)
-            _sliceRange = 0..<reference.length
+#if DEPLOYMENT_RUNTIME_SWIFT
+            let providesConcreteBacking = reference._providesConcreteBacking()
+#else
+            let providesConcreteBacking = (reference as AnyObject)._providesConcreteBacking?() ?? false
+#endif
+            if providesConcreteBacking {
+                _representation = _Representation(__DataStorage(immutableReference: reference.copy() as! NSData, offset: 0), count: length)
+            } else {
+                _representation = _Representation(__DataStorage(customReference: reference.copy() as! NSData, offset: 0), count: length)
+            }
         }
         
     }
     
     // slightly faster paths for common sequences
-    
-    public init<S: Sequence>(_ elements: S) where S.Iterator.Element == UInt8 {
-        if elements is Array<UInt8> {
-            self.init(bytes: _identityCast(elements, to: Array<UInt8>.self))
-        } else if elements is ArraySlice<UInt8> {
-            self.init(bytes: _identityCast(elements, to: ArraySlice<UInt8>.self))
-        } else if elements is UnsafeBufferPointer<UInt8> {
-            self.init(buffer: _identityCast(elements, to: UnsafeBufferPointer<UInt8>.self))
-        } else if let buffer = elements as? UnsafeMutableBufferPointer<UInt8> {
-            self.init(buffer: buffer)
-        } else if let data = elements as? Data {
-            let len = data.count
-            let backing = data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
-                return _DataStorage(bytes: bytes, length: len)
-            }
-            self.init(backing: backing, range: 0..<len)
+    @inlinable // This is @inlinable as an important generic funnel point, despite being a non-trivial initializer.
+    public init<S: Sequence>(_ elements: S) where S.Element == UInt8 {
+        // If the sequence is already contiguous, access the underlying raw memory directly.
+        if let contiguous = elements as? ContiguousBytes {
+            _representation = contiguous.withUnsafeBytes { return _Representation($0) }
+            return
+        }
+
+        // The sequence might still be able to provide direct access to typed memory.
+        // NOTE: It's safe to do this because we're already guarding on S's element as `UInt8`. This would not be safe on arbitrary sequences.
+        let representation = elements.withContiguousStorageIfAvailable {
+            return _Representation(UnsafeRawBufferPointer($0))
+        }
+
+        if let representation = representation {
+            _representation = representation
         } else {
-            let underestimatedCount = elements.underestimatedCount
-            self.init(count: underestimatedCount)
-            
-            let (endIterator, _) = UnsafeMutableBufferPointer(start: _backing._bytes?.assumingMemoryBound(to: UInt8.self), count: underestimatedCount).initialize(from: elements)
-            var iter = endIterator
-            while let byte = iter.next() { self.append(byte) }
+            // Dummy assignment so we can capture below.
+            _representation = _Representation(capacity: 0)
+
+            // Copy as much as we can in one shot from the sequence.
+            let underestimatedCount = Swift.max(elements.underestimatedCount, 1)
+            _withStackOrHeapBuffer(underestimatedCount) { (buffer) in
+                // In order to copy from the sequence, we have to bind the buffer to UInt8.
+                // This is safe since we'll copy out of this buffer as raw memory later.
+                let capacity = buffer.pointee.capacity
+                let base = buffer.pointee.memory.bindMemory(to: UInt8.self, capacity: capacity)
+                var (iter, endIndex) = elements._copyContents(initializing: UnsafeMutableBufferPointer(start: base, count: capacity))
+
+                // Copy the contents of buffer...
+                _representation = _Representation(UnsafeRawBufferPointer(start: base, count: endIndex))
+
+                // ... and append the rest byte-wise, buffering through an InlineData.
+                var buffer = InlineData()
+                while let element = iter.next() {
+                    if buffer.count < buffer.capacity {
+                        buffer.append(byte: element)
+                    } else {
+                        buffer.withUnsafeBytes { _representation.append(contentsOf: $0) }
+                        buffer.count = 0
+                    }
+                }
+
+                // If we've still got bytes left in the buffer (i.e. the loop ended before we filled up the buffer and cleared it out), append them.
+                if buffer.count > 0 {
+                    buffer.withUnsafeBytes { _representation.append(contentsOf: $0) }
+                    buffer.count = 0
+                }
+            }
         }
     }
+    
+    @available(swift, introduced: 4.2)
+    @available(swift, deprecated: 5, message: "use `init(_:)` instead")
+    public init<S: Sequence>(bytes elements: S) where S.Iterator.Element == UInt8 {
+        self.init(elements)
+    }
 
-    @usableFromInline
-    internal init(backing: _DataStorage, range: Range<Index>) {
-        _backing = backing
-        _sliceRange = range
+    @available(swift, obsoleted: 4.2)
+    public init(bytes: Array<UInt8>) {
+       self.init(bytes)
     }
     
-    @usableFromInline
-    internal func _validateIndex(_ index: Int, message: String? = nil) {
-        precondition(_sliceRange.contains(index), message ?? "Index \(index) is out of bounds of range \(_sliceRange)")
+    @available(swift, obsoleted: 4.2)
+    public init(bytes: ArraySlice<UInt8>) {
+       self.init(bytes)
     }
     
-    @usableFromInline
-    internal func _validateRange<R: RangeExpression>(_ range: R) where R.Bound == Int {
-        let lower = R.Bound(_sliceRange.lowerBound)
-        let upper = R.Bound(_sliceRange.upperBound)
-        let r = range.relative(to: lower..<upper)
-        precondition(r.lowerBound >= _sliceRange.lowerBound && r.lowerBound <= _sliceRange.upperBound, "Range \(r) is out of bounds of range \(_sliceRange)")
-        precondition(r.upperBound >= _sliceRange.lowerBound && r.upperBound <= _sliceRange.upperBound, "Range \(r) is out of bounds of range \(_sliceRange)")
+    @inlinable // This is @inlinable as a trivial initializer.
+    internal init(representation: _Representation) {
+        _representation = representation
     }
     
     // -----------------------------------
     // MARK: - Properties and Functions
+
+    @inlinable // This is @inlinable as trivially forwarding.
+    public mutating func reserveCapacity(_ minimumCapacity: Int) {
+        _representation.reserveCapacity(minimumCapacity)
+    }
     
     /// The number of bytes in the data.
-    
+    @inlinable // This is @inlinable as trivially forwarding.
     public var count: Int {
-        @inline(__always)
         get {
-            return _sliceRange.count
+            return _representation.count
         }
-        @inline(__always)
-        set {
-            precondition(count >= 0, "count must not be negative")
-            if !isKnownUniquelyReferenced(&_backing) {
-                _backing = _backing.mutableCopy(_sliceRange)
-            }
-            _backing.length = newValue
-            _sliceRange = _sliceRange.lowerBound..<(_sliceRange.lowerBound + newValue)
+        set(newValue) {
+            precondition(newValue >= 0, "count must not be negative")
+            _representation.count = newValue
         }
+    }
+
+    @inlinable // This is @inlinable as trivially computable.
+    public var regions: CollectionOfOne<Data> {
+        return CollectionOfOne(self)
     }
     
     /// Access the bytes in the data.
     ///
     /// - warning: The byte pointer argument should not be stored and used outside of the lifetime of the call to the closure.
-    @inline(__always)
+    @available(swift, deprecated: 5, message: "use `withUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) rethrows -> R` instead")
     public func withUnsafeBytes<ResultType, ContentType>(_ body: (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
-        return try _backing.withUnsafeBytes(in: _sliceRange) {
+        return try _representation.withUnsafeBytes {
             return try body($0.baseAddress?.assumingMemoryBound(to: ContentType.self) ?? UnsafePointer<ContentType>(bitPattern: 0xBAD0)!)
         }
     }
     
-    
+    @inlinable // This is @inlinable as a generic, trivially forwarding function.
+    public func withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
+        return try _representation.withUnsafeBytes(body)
+    }
+
     /// Mutate the bytes in the data.
     ///
     /// This function assumes that you are mutating the contents.
     /// - warning: The byte pointer argument should not be stored and used outside of the lifetime of the call to the closure.
-    @inline(__always)
+    @available(swift, deprecated: 5, message: "use `withUnsafeMutableBytes<R>(_: (UnsafeMutableRawBufferPointer) throws -> R) rethrows -> R` instead")
     public mutating func withUnsafeMutableBytes<ResultType, ContentType>(_ body: (UnsafeMutablePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
-        if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy(_sliceRange)
-        }
-        return try _backing.withUnsafeMutableBytes(in: _sliceRange) {
+        return try _representation.withUnsafeMutableBytes {
             return try body($0.baseAddress?.assumingMemoryBound(to: ContentType.self) ?? UnsafeMutablePointer<ContentType>(bitPattern: 0xBAD0)!)
         }
+    }
+
+    @inlinable // This is @inlinable as a generic, trivially forwarding function.
+    public mutating func withUnsafeMutableBytes<ResultType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
+        return try _representation.withUnsafeMutableBytes(body)
     }
     
     // MARK: -
@@ -1337,21 +2188,17 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter pointer: A pointer to the buffer you wish to copy the bytes into.
     /// - parameter count: The number of bytes to copy.
     /// - warning: This method does not verify that the contents at pointer have enough space to hold `count` bytes.
-    @inline(__always)
+    @inlinable // This is @inlinable as trivially forwarding.
     public func copyBytes(to pointer: UnsafeMutablePointer<UInt8>, count: Int) {
         precondition(count >= 0, "count of bytes to copy must not be negative")
         if count == 0 { return }
-        _backing.withUnsafeBytes(in: _sliceRange) {
-            memcpy(UnsafeMutableRawPointer(pointer), $0.baseAddress!, Swift.min(count, $0.count))
-        }
+        _copyBytesHelper(to: UnsafeMutableRawPointer(pointer), from: startIndex..<(startIndex + count))
     }
     
-    @inline(__always)
-    private func _copyBytesHelper(to pointer: UnsafeMutableRawPointer, from range: NSRange) {
-        if range.length == 0 { return }
-        _backing.withUnsafeBytes(in: range.lowerBound..<range.upperBound) {
-            memcpy(UnsafeMutableRawPointer(pointer), $0.baseAddress!, Swift.min(range.length, $0.count))
-        }
+    @inlinable // This is @inlinable as trivially forwarding.
+    internal func _copyBytesHelper(to pointer: UnsafeMutableRawPointer, from range: Range<Int>) {
+        if range.upperBound - range.lowerBound == 0 { return }
+        _representation.copyBytes(to: pointer, from: range)
     }
     
     /// Copy a subset of the contents of the data to a pointer.
@@ -1359,8 +2206,9 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter pointer: A pointer to the buffer you wish to copy the bytes into.
     /// - parameter range: The range in the `Data` to copy.
     /// - warning: This method does not verify that the contents at pointer have enough space to hold the required number of bytes.
+    @inlinable // This is @inlinable as trivially forwarding.
     public func copyBytes(to pointer: UnsafeMutablePointer<UInt8>, from range: Range<Index>) {
-        _copyBytesHelper(to: pointer, from: NSRange(range))
+        _copyBytesHelper(to: pointer, from: range)
     }
     
     // Copy the contents of the data into a buffer.
@@ -1370,6 +2218,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter buffer: A buffer to copy the data into.
     /// - parameter range: A range in the data to copy into the buffer. If the range is empty, this function will return 0 without copying anything. If the range is nil, as much data as will fit into `buffer` is copied.
     /// - returns: Number of bytes copied into the destination buffer.
+    @inlinable // This is @inlinable as generic and reasonably small.
     public func copyBytes<DestinationType>(to buffer: UnsafeMutableBufferPointer<DestinationType>, from range: Range<Index>? = nil) -> Int {
         let cnt = count
         guard cnt > 0 else { return 0 }
@@ -1377,22 +2226,19 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         let copyRange : Range<Index>
         if let r = range {
             guard !r.isEmpty else { return 0 }
-            copyRange = r.lowerBound..<(r.lowerBound + Swift.min(buffer.count * MemoryLayout<DestinationType>.stride, r.count))
+            copyRange = r.lowerBound..<(r.lowerBound + Swift.min(buffer.count * MemoryLayout<DestinationType>.stride, r.upperBound - r.lowerBound))
         } else {
             copyRange = 0..<Swift.min(buffer.count * MemoryLayout<DestinationType>.stride, cnt)
         }
-        _validateRange(copyRange)
         
         guard !copyRange.isEmpty else { return 0 }
         
-        let nsRange = NSRange(location: copyRange.lowerBound, length: copyRange.upperBound - copyRange.lowerBound)
-        _copyBytesHelper(to: buffer.baseAddress!, from: nsRange)
-        return copyRange.count
+        _copyBytesHelper(to: buffer.baseAddress!, from: copyRange)
+        return copyRange.upperBound - copyRange.lowerBound
     }
     
     // MARK: -
 #if !DEPLOYMENT_RUNTIME_SWIFT
-    @inline(__always)
     private func _shouldUseNonAtomicWriteReimplementation(options: Data.WritingOptions = []) -> Bool {
     
         // Avoid a crash that happens on OS X 10.11.x and iOS 9.x or before when writing a bridged Data non-atomically with Foundation's standard write() implementation.
@@ -1414,7 +2260,8 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter options: Options for writing the data. Default value is `[]`.
     /// - throws: An error in the Cocoa domain, if there is an error writing to the `URL`.
     public func write(to url: URL, options: Data.WritingOptions = []) throws {
-        try _backing.withInteriorPointerReference(_sliceRange) {
+        // this should not be marked as inline since in objc contexts we correct atomicity via _shouldUseNonAtomicWriteReimplementation
+        try _representation.withInteriorPointerReference {
 #if DEPLOYMENT_RUNTIME_SWIFT
             try $0.write(to: url, options: WritingOptions(rawValue: options.rawValue))
 #else
@@ -1440,12 +2287,11 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public func range(of dataToFind: Data, options: Data.SearchOptions = [], in range: Range<Index>? = nil) -> Range<Index>? {
         let nsRange : NSRange
         if let r = range {
-            _validateRange(r)
             nsRange = NSRange(location: r.lowerBound - startIndex, length: r.upperBound - r.lowerBound)
         } else {
             nsRange = NSRange(location: 0, length: count)
         }
-        let result = _backing.withInteriorPointerReference(_sliceRange) {
+        let result = _representation.withInteriorPointerReference {
             $0.range(of: dataToFind, options: options, in: nsRange)
         }
         if result.location == NSNotFound {
@@ -1458,59 +2304,95 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     ///
     /// In some cases, (for example, a `Data` backed by a `dispatch_data_t`, the bytes may be stored discontiguously. In those cases, this function invokes the closure for each contiguous region of bytes.
     /// - parameter block: The closure to invoke for each region of data. You may stop the enumeration by setting the `stop` parameter to `true`.
+    @available(swift, deprecated: 5, message: "use `regions` or `for-in` instead")
     public func enumerateBytes(_ block: (_ buffer: UnsafeBufferPointer<UInt8>, _ byteIndex: Index, _ stop: inout Bool) -> Void) {
-        _backing.enumerateBytes(in: _sliceRange, block)
+        _representation.enumerateBytes(block)
+    }
+
+    @inlinable // This is @inlinable as a generic, trivially forwarding function.
+    internal mutating func _append<SourceType>(_ buffer : UnsafeBufferPointer<SourceType>) {
+        if buffer.isEmpty { return }
+        _representation.append(contentsOf: UnsafeRawBufferPointer(buffer))
     }
     
-    @inline(__always)
+    @inlinable // This is @inlinable as a generic, trivially forwarding function.
     public mutating func append(_ bytes: UnsafePointer<UInt8>, count: Int) {
         if count == 0 { return }
-        append(UnsafeBufferPointer(start: bytes, count: count))
+        _append(UnsafeBufferPointer(start: bytes, count: count))
     }
     
-    @inline(__always)
     public mutating func append(_ other: Data) {
-        other.enumerateBytes { (buffer, _, _) in
-            append(buffer)
+        guard other.count > 0 else { return }
+        other.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
+            _representation.append(contentsOf: buffer)
         }
     }
     
     /// Append a buffer of bytes to the data.
     ///
     /// - parameter buffer: The buffer of bytes to append. The size is calculated from `SourceType` and `buffer.count`.
-    @inline(__always)
+    @inlinable // This is @inlinable as a generic, trivially forwarding function.
     public mutating func append<SourceType>(_ buffer : UnsafeBufferPointer<SourceType>) {
-        if buffer.isEmpty { return }
-        if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy(_sliceRange)
-        }
-        _backing.replaceBytes(in: NSRange(location: _sliceRange.upperBound, length: _backing.length - (_sliceRange.upperBound - _backing._offset)), with: buffer.baseAddress, length: buffer.count * MemoryLayout<SourceType>.stride)
-        _sliceRange = _sliceRange.lowerBound..<(_sliceRange.upperBound + buffer.count * MemoryLayout<SourceType>.stride)
+        _append(buffer)
     }
-    
-    @inline(__always)
-    public mutating func append<S : Sequence>(contentsOf newElements: S) where S.Iterator.Element == Iterator.Element {
-        let estimatedCount = newElements.underestimatedCount
-        guard estimatedCount > 0 else {
-            for byte in newElements {
-                append(byte)
-            }
-            return
-        }
-        _withStackOrHeapBuffer(estimatedCount) { allocation in
-            let buffer = UnsafeMutableBufferPointer(start: allocation.pointee.memory.assumingMemoryBound(to: UInt8.self), count: estimatedCount)
-            var (iterator, endPoint) = newElements._copyContents(initializing: buffer)
-            append(buffer.baseAddress!, count: endPoint - buffer.startIndex)
-            while let byte = iterator.next() {
-                append(byte)
-            }
-        }
-    }
-    
-    @inline(__always)
+
+    @inlinable // This is @inlinable as trivially forwarding.
     public mutating func append(contentsOf bytes: [UInt8]) {
         bytes.withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<UInt8>) -> Void in
-            append(buffer)
+            _append(buffer)
+        }
+    }
+
+    @inlinable // This is @inlinable as an important generic funnel point, despite being non-trivial.
+    public mutating func append<S: Sequence>(contentsOf elements: S) where S.Element == Element {
+        // If the sequence is already contiguous, access the underlying raw memory directly.
+        if let contiguous = elements as? ContiguousBytes {
+            contiguous.withUnsafeBytes {
+                _representation.append(contentsOf: $0)
+            }
+
+            return
+        }
+
+        // The sequence might still be able to provide direct access to typed memory.
+        // NOTE: It's safe to do this because we're already guarding on S's element as `UInt8`. This would not be safe on arbitrary sequences.
+        var appended = false
+        elements.withContiguousStorageIfAvailable {
+            _representation.append(contentsOf: UnsafeRawBufferPointer($0))
+            appended = true
+        }
+
+        guard !appended else { return }
+
+        // The sequence is really not contiguous.
+        // Copy as much as we can in one shot.
+        let underestimatedCount = Swift.max(elements.underestimatedCount, 1)
+        _withStackOrHeapBuffer(underestimatedCount) { (buffer) in
+            // In order to copy from the sequence, we have to bind the temporary buffer to `UInt8`.
+            // This is safe since we're the only owners of the buffer and we copy out as raw memory below anyway.
+            let capacity = buffer.pointee.capacity
+            let base = buffer.pointee.memory.bindMemory(to: UInt8.self, capacity: capacity)
+            var (iter, endIndex) = elements._copyContents(initializing: UnsafeMutableBufferPointer(start: base, count: capacity))
+
+            // Copy the contents of the buffer...
+            _representation.append(contentsOf: UnsafeRawBufferPointer(start: base, count: endIndex))
+
+            // ... and append the rest byte-wise, buffering through an InlineData.
+            var buffer = InlineData()
+            while let element = iter.next() {
+                if buffer.count < buffer.capacity {
+                    buffer.append(byte: element)
+                } else {
+                    buffer.withUnsafeBytes { _representation.append(contentsOf: $0) }
+                    buffer.count = 0
+                }
+            }
+
+            // If we've still got bytes left in the buffer (i.e. the loop ended before we filled up the buffer and cleared it out), append them.
+            if buffer.count > 0 {
+                buffer.withUnsafeBytes { _representation.append(contentsOf: $0) }
+                buffer.count = 0
+            }
         }
     }
     
@@ -1520,19 +2402,12 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     ///
     /// If `range` exceeds the bounds of the data, then the data is resized to fit.
     /// - parameter range: The range in the data to set to `0`.
-    @inline(__always)
+    @inlinable // This is @inlinable as trivially forwarding.
     public mutating func resetBytes(in range: Range<Index>) {
         // it is worth noting that the range here may be out of bounds of the Data itself (which triggers a growth)
         precondition(range.lowerBound >= 0, "Ranges must not be negative bounds")
         precondition(range.upperBound >= 0, "Ranges must not be negative bounds")
-        let range = NSRange(location: range.lowerBound, length: range.upperBound - range.lowerBound)
-        if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy(_sliceRange)
-        }
-        _backing.resetBytes(in: range)
-        if _sliceRange.upperBound < range.upperBound {
-            _sliceRange = _sliceRange.lowerBound..<range.upperBound
-        }
+        _representation.resetBytes(in: range)
     }
     
     /// Replace a region of bytes in the data with new data.
@@ -1542,11 +2417,10 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - precondition: The bounds of `subrange` must be valid indices of the collection.
     /// - parameter subrange: The range in the data to replace. If `subrange.lowerBound == data.count && subrange.count == 0` then this operation is an append.
     /// - parameter data: The replacement data.
-    @inline(__always)
+    @inlinable // This is @inlinable as trivially forwarding.
     public mutating func replaceSubrange(_ subrange: Range<Index>, with data: Data) {
-        let cnt = data.count
-        data.withUnsafeBytes {
-            replaceSubrange(subrange, with: $0, count: cnt)
+        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
+            _representation.replaceSubrange(subrange, with: buffer.baseAddress, count: buffer.count)
         }
     }
     
@@ -1557,7 +2431,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - precondition: The bounds of `subrange` must be valid indices of the collection.
     /// - parameter subrange: The range in the data to replace.
     /// - parameter buffer: The replacement bytes.
-    @inline(__always)
+    @inlinable // This is @inlinable as a generic, trivially forwarding function.
     public mutating func replaceSubrange<SourceType>(_ subrange: Range<Index>, with buffer: UnsafeBufferPointer<SourceType>) {
         guard !buffer.isEmpty  else { return }
         replaceSubrange(subrange, with: buffer.baseAddress!, count: buffer.count * MemoryLayout<SourceType>.stride)
@@ -1570,10 +2444,9 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - precondition: The bounds of `subrange` must be valid indices of the collection.
     /// - parameter subrange: The range in the data to replace.
     /// - parameter newElements: The replacement bytes.
-    @inline(__always)
+    @inlinable // This is @inlinable as generic and reasonably small.
     public mutating func replaceSubrange<ByteCollection : Collection>(_ subrange: Range<Index>, with newElements: ByteCollection) where ByteCollection.Iterator.Element == Data.Iterator.Element {
-        _validateRange(subrange)
-        let totalCount: Int = numericCast(newElements.count)
+        let totalCount = Int(newElements.count)
         _withStackOrHeapBuffer(totalCount) { conditionalBuffer in
             let buffer = UnsafeMutableBufferPointer(start: conditionalBuffer.pointee.memory.assumingMemoryBound(to: UInt8.self), count: totalCount)
             var (iterator, index) = newElements._copyContents(initializing: buffer)
@@ -1585,29 +2458,23 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
     }
     
-    @inline(__always)
+    @inlinable // This is @inlinable as trivially forwarding.
     public mutating func replaceSubrange(_ subrange: Range<Index>, with bytes: UnsafeRawPointer, count cnt: Int) {
-        _validateRange(subrange)
-        let nsRange = NSRange(location: subrange.lowerBound, length: subrange.upperBound - subrange.lowerBound)
-        if !isKnownUniquelyReferenced(&_backing) {
-            _backing = _backing.mutableCopy(_sliceRange)
-        }
-        let upper = _sliceRange.upperBound
-        _backing.replaceBytes(in: nsRange, with: bytes, length: cnt)
-        let resultingUpper = upper - nsRange.length + cnt
-        _sliceRange = _sliceRange.lowerBound..<resultingUpper
+        _representation.replaceSubrange(subrange, with: bytes, count: cnt)
     }
     
     /// Return a new copy of the data in a specified range.
     ///
     /// - parameter range: The range to copy.
-    @inline(__always)
     public func subdata(in range: Range<Index>) -> Data {
-        _validateRange(range)
-        if isEmpty {
+        if isEmpty || range.upperBound - range.lowerBound == 0 {
             return Data()
         }
-        return _backing.subdata(in: range)
+        let slice = self[range]
+
+        return slice.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Data in
+            return Data(bytes: buffer.baseAddress!, count: buffer.count)
+        }
     }
     
     // MARK: -
@@ -1617,8 +2484,9 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     ///
     /// - parameter options: The options to use for the encoding. Default value is `[]`.
     /// - returns: The Base-64 encoded string.
+    @inlinable // This is @inlinable as trivially forwarding.
     public func base64EncodedString(options: Data.Base64EncodingOptions = []) -> String {
-        return _backing.withInteriorPointerReference(_sliceRange) {
+        return _representation.withInteriorPointerReference {
             return $0.base64EncodedString(options: options)
         }
     }
@@ -1627,8 +2495,9 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     ///
     /// - parameter options: The options to use for the encoding. Default value is `[]`.
     /// - returns: The Base-64 encoded data.
+    @inlinable // This is @inlinable as trivially forwarding.
     public func base64EncodedData(options: Data.Base64EncodingOptions = []) -> Data {
-        return _backing.withInteriorPointerReference(_sliceRange) {
+        return _representation.withInteriorPointerReference {
             return $0.base64EncodedData(options: options)
         }
     }
@@ -1637,27 +2506,16 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     //
     
     /// The hash value for the data.
-    public var hashValue: Int {
-        var hashValue = 0
-        let hashRange: Range<Int> = _sliceRange.lowerBound..<Swift.min(_sliceRange.lowerBound + 80, _sliceRange.upperBound)
-        _withStackOrHeapBuffer(hashRange.count + 1) { buffer in
-            if !hashRange.isEmpty {
-                _backing.withUnsafeBytes(in: hashRange) {
-                    memcpy(buffer.pointee.memory, $0.baseAddress!, hashRange.count)
-                }
-            }
-            hashValue = Int(bitPattern: CFHashBytes(buffer.pointee.memory.assumingMemoryBound(to: UInt8.self), hashRange.count))
-        }
-        return hashValue
+    @inline(never) // This is not inlinable as emission into clients could cause cross-module inconsistencies if they are not all recompiled together.
+    public func hash(into hasher: inout Hasher) {
+        _representation.hash(into: &hasher)
     }
     
-    @inline(__always)
     public func advanced(by amount: Int) -> Data {
-        _validateIndex(startIndex + amount)
         let length = count - amount
         precondition(length > 0)
-        return withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> Data in
-            return Data(bytes: ptr.advanced(by: amount), count: length)
+        return withUnsafeBytes { (ptr: UnsafeRawBufferPointer) -> Data in
+            return Data(bytes: ptr.baseAddress!.advanced(by: amount), count: length)
         }
     }
     
@@ -1667,160 +2525,157 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     // MARK: Index and Subscript
     
     /// Sets or returns the byte at the specified index.
+    @inlinable // This is @inlinable as trivially forwarding.
     public subscript(index: Index) -> UInt8 {
-        @inline(__always)
         get {
-            _validateIndex(index)
-            return _backing.get(index)
+            return _representation[index]
         }
-        @inline(__always)
-        set {
-            _validateIndex(index)
-            if !isKnownUniquelyReferenced(&_backing) {
-                _backing = _backing.mutableCopy(_sliceRange)
-            }
-            _backing.set(index, to: newValue)
+        set(newValue) {
+            _representation[index] = newValue
         }
     }
     
+    @inlinable // This is @inlinable as trivially forwarding.
     public subscript(bounds: Range<Index>) -> Data {
-        @inline(__always)
         get {
-            _validateRange(bounds)
-            return Data(backing: _backing, range: bounds)
+            return _representation[bounds]
         }
-        @inline(__always)
         set {
             replaceSubrange(bounds, with: newValue)
         }
     }
     
+    @inlinable // This is @inlinable as a generic, trivially forwarding function.
     public subscript<R: RangeExpression>(_ rangeExpression: R) -> Data
         where R.Bound: FixedWidthInteger {
-        @inline(__always)
         get {
-            let lower = R.Bound(_sliceRange.lowerBound)
-            let upper = R.Bound(_sliceRange.upperBound)
+            let lower = R.Bound(startIndex)
+            let upper = R.Bound(endIndex)
             let range = rangeExpression.relative(to: lower..<upper)
-            let start: Int = numericCast(range.lowerBound)
-            let end: Int = numericCast(range.upperBound)
+            let start = Int(range.lowerBound)
+            let end = Int(range.upperBound)
             let r: Range<Int> = start..<end
-            _validateRange(r)
-            return Data(backing: _backing, range: r)
+            return _representation[r]
         }
-        @inline(__always)
         set {
-            let lower = R.Bound(_sliceRange.lowerBound)
-            let upper = R.Bound(_sliceRange.upperBound)
+            let lower = R.Bound(startIndex)
+            let upper = R.Bound(endIndex)
             let range = rangeExpression.relative(to: lower..<upper)
-            let start: Int = numericCast(range.lowerBound)
-            let end: Int = numericCast(range.upperBound)
+            let start = Int(range.lowerBound)
+            let end = Int(range.upperBound)
             let r: Range<Int> = start..<end
-            _validateRange(r)
             replaceSubrange(r, with: newValue)
         }
         
     }
     
     /// The start `Index` in the data.
+    @inlinable // This is @inlinable as trivially forwarding.
     public var startIndex: Index {
-        @inline(__always)
         get {
-            return _sliceRange.lowerBound
+            return _representation.startIndex
         }
     }
     
     /// The end `Index` into the data.
     ///
     /// This is the "one-past-the-end" position, and will always be equal to the `count`.
+    @inlinable // This is @inlinable as trivially forwarding.
     public var endIndex: Index {
-        @inline(__always)
         get {
-            return _sliceRange.upperBound
+            return _representation.endIndex
         }
     }
     
-    @inline(__always)
+    @inlinable // This is @inlinable as trivially computable.
     public func index(before i: Index) -> Index {
         return i - 1
     }
     
-    @inline(__always)
+    @inlinable // This is @inlinable as trivially computable.
     public func index(after i: Index) -> Index {
         return i + 1
     }
     
+    @inlinable // This is @inlinable as trivially computable.
     public var indices: Range<Int> {
-        @inline(__always)
         get {
             return startIndex..<endIndex
         }
     }
     
+    @inlinable // This is @inlinable as a fast-path for emitting into generic Sequence usages.
     public func _copyContents(initializing buffer: UnsafeMutableBufferPointer<UInt8>) -> (Iterator, UnsafeMutableBufferPointer<UInt8>.Index) {
         guard !isEmpty else { return (makeIterator(), buffer.startIndex) }
-        guard let p = buffer.baseAddress else {
-            preconditionFailure("Attempt to copy contents into nil buffer pointer")
+        let cnt = Swift.min(count, buffer.count)
+        if cnt > 0 {
+            withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
+                _ = memcpy(UnsafeMutableRawPointer(buffer.baseAddress!), bytes.baseAddress!, cnt)
+            }
         }
-        let cnt = count
-        precondition(cnt <= buffer.count, "Insufficient space allocated to copy Data contents")
         
-        withUnsafeBytes { p.initialize(from: $0, count: cnt) }
-        
-        return (Iterator(endOf: self), buffer.index(buffer.startIndex, offsetBy: cnt))
+        return (Iterator(self, at: startIndex + cnt), buffer.index(buffer.startIndex, offsetBy: cnt))
     }
     
     /// An iterator over the contents of the data.
     ///
     /// The iterator will increment byte-by-byte.
+    @inlinable // This is @inlinable as trivially computable.
     public func makeIterator() -> Data.Iterator {
-        return Iterator(self)
+        return Iterator(self, at: startIndex)
     }
     
     public struct Iterator : IteratorProtocol {
-        // Both _data and _endIdx should be 'let' rather than 'var'.
-        // They are 'var' so that the stored properties can be read
-        // independently of the other contents of the struct. This prevents
-        // an exclusivity violation when reading '_endIdx' and '_data'
-        // while simultaneously mutating '_buffer' with the call to
-        // withUnsafeMutablePointer(). Once we support accessing struct
-        // let properties independently we should make these variables
-        // 'let' again.
+        @usableFromInline
+        internal typealias Buffer = (
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
 
-        private var _data: Data
-        private var _buffer: (
-        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
-        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
-        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
-        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
-        private var _idx: Data.Index
-        private var _endIdx: Data.Index
+        @usableFromInline internal let _data: Data
+        @usableFromInline internal var _buffer: Buffer
+        @usableFromInline internal var _idx: Data.Index
+        @usableFromInline internal let _endIdx: Data.Index
         
-        fileprivate init(_ data: Data) {
+        @usableFromInline // This is @usableFromInline as a non-trivial initializer.
+        internal init(_ data: Data, at loc: Data.Index) {
+            // The let vars prevent this from being marked as @inlinable
             _data = data
             _buffer = (0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
-            _idx = data.startIndex
+            _idx = loc
             _endIdx = data.endIndex
-        }
-        
-        fileprivate init(endOf data: Data) {
-            self._data = data
-            _buffer = (0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
-            _idx = data.endIndex
-            _endIdx = data.endIndex
+
+            let bufferSize = MemoryLayout<Buffer>.size
+            Swift.withUnsafeMutableBytes(of: &_buffer) {
+                let ptr = $0.bindMemory(to: UInt8.self)
+                let bufferIdx = (loc - data.startIndex) % bufferSize
+                data.copyBytes(to: ptr, from: (loc - bufferIdx)..<(data.endIndex - (loc - bufferIdx) > bufferSize ? (loc - bufferIdx) + bufferSize : data.endIndex))
+            }
         }
         
         public mutating func next() -> UInt8? {
-            guard _idx < _endIdx else { return nil }
-            defer { _idx += 1 }
-            let bufferSize = MemoryLayout.size(ofValue: _buffer)
-            return withUnsafeMutablePointer(to: &_buffer) { ptr_ in
-                let ptr = UnsafeMutableRawPointer(ptr_).assumingMemoryBound(to: UInt8.self)
-                let bufferIdx = (_idx - _data.startIndex) % bufferSize
-                if bufferIdx == 0 {
+            let idx = _idx
+            let bufferSize = MemoryLayout<Buffer>.size
+
+            guard idx < _endIdx else { return nil }
+            _idx += 1
+
+            let bufferIdx = (idx - _data.startIndex) % bufferSize
+
+
+            if bufferIdx == 0 {
+                var buffer = _buffer
+                Swift.withUnsafeMutableBytes(of: &buffer) {
+                    let ptr = $0.bindMemory(to: UInt8.self)
                     // populate the buffer
-                    _data.copyBytes(to: ptr, from: _idx..<(_endIdx - _idx > bufferSize ? _idx + bufferSize : _endIdx))
+                    _data.copyBytes(to: ptr, from: idx..<(_endIdx - idx > bufferSize ? idx + bufferSize : _endIdx))
                 }
+                _buffer = buffer
+            }
+
+            return Swift.withUnsafeMutableBytes(of: &_buffer) {
+                let ptr = $0.bindMemory(to: UInt8.self)
                 return ptr[bufferIdx]
             }
         }
@@ -1842,27 +2697,16 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public var mutableBytes: UnsafeMutableRawPointer { fatalError() }
     
     /// Returns `true` if the two `Data` arguments are equal.
+    @inlinable // This is @inlinable as emission into clients is safe -- the concept of equality on Data will not change.
     public static func ==(d1 : Data, d2 : Data) -> Bool {
-        let backing1 = d1._backing
-        let backing2 = d2._backing
-        if backing1 === backing2 {
-            if d1._sliceRange == d2._sliceRange {
-                return true
-            }
-        }
         let length1 = d1.count
         if length1 != d2.count {
             return false
         }
-        if backing1.bytes == backing2.bytes {
-            if d1._sliceRange == d2._sliceRange {
-                return true
-            }
-        }
         if length1 > 0 {
-            return d1.withUnsafeBytes { (b1) in
-                return d2.withUnsafeBytes { (b2) in
-                    return memcmp(b1, b2, length1) == 0
+            return d1.withUnsafeBytes { (b1: UnsafeRawBufferPointer) in
+                return d2.withUnsafeBytes { (b2: UnsafeRawBufferPointer) in
+                    return memcmp(b1.baseAddress!, b2.baseAddress!, b2.count) == 0
                 }
             }
         }
@@ -1887,8 +2731,8 @@ extension Data : CustomStringConvertible, CustomDebugStringConvertible, CustomRe
         var children: [(label: String?, value: Any)] = []
         children.append((label: "count", value: nBytes))
         
-        self.withUnsafeBytes { (bytes : UnsafePointer<UInt8>) in
-            children.append((label: "pointer", value: bytes))
+        self.withUnsafeBytes { (bytes : UnsafeRawBufferPointer) in
+            children.append((label: "pointer", value: bytes.baseAddress!))
         }
         
         // Minimal size data is output as an array
@@ -1896,7 +2740,7 @@ extension Data : CustomStringConvertible, CustomDebugStringConvertible, CustomRe
             children.append((label: "bytes", value: Array(self[startIndex..<Swift.min(nBytes + startIndex, endIndex)])))
         }
         
-        let m = Mirror(self, children:children, displayStyle: .struct)
+        let m = Mirror(self, children:children, displayStyle: Mirror.DisplayStyle.struct)
         return m
     }
 }
@@ -1914,7 +2758,7 @@ extension Data {
 extension Data : _ObjectiveCBridgeable {
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSData {
-        return _backing.bridgedReference(_sliceRange)
+        return _representation.bridgedReference()
     }
     
     public static func _forceBridgeFromObjectiveC(_ input: NSData, result: inout Data?) {
@@ -1927,7 +2771,8 @@ extension Data : _ObjectiveCBridgeable {
         result = Data(referencing: input)
         return true
     }
-    
+
+//    @_effects(readonly)
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSData?) -> Data {
         guard let src = source else { return Data() }
         return Data(referencing: src)
@@ -1968,20 +2813,9 @@ extension Data : Codable {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
-        
-        // Since enumerateBytes does not rethrow, we need to catch the error, stow it away, and rethrow if we stopped.
-        var caughtError: Error? = nil
-        self.enumerateBytes { (buffer: UnsafeBufferPointer<UInt8>, byteIndex: Data.Index, stop: inout Bool) in
-            do {
-                try container.encode(contentsOf: buffer)
-            } catch {
-                caughtError = error
-                stop = true
-            }
-        }
-        
-        if let error = caughtError {
-            throw error
+        try withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
+            try container.encode(contentsOf: buffer)
         }
     }
 }
+

--- a/Foundation/DataProtocol.swift
+++ b/Foundation/DataProtocol.swift
@@ -1,0 +1,299 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(macOS) || os(iOS)
+import Darwin
+#elseif os(Linux)
+import Glibc
+#endif
+
+//===--- DataProtocol -----------------------------------------------------===//
+
+public protocol DataProtocol : RandomAccessCollection where Element == UInt8, SubSequence : DataProtocol {
+    // FIXME: Remove in favor of opaque type on `regions`.
+    associatedtype Regions: BidirectionalCollection where Regions.Element : DataProtocol & ContiguousBytes, Regions.Element.SubSequence : ContiguousBytes
+    
+    /// A `BidirectionalCollection` of `DataProtocol` elements which compose a
+    /// discontiguous buffer of memory.  Each region is a contiguous buffer of
+    /// bytes.
+    ///
+    /// The sum of the lengths of the associated regions must equal `self.count`
+    /// (such that iterating `regions` and iterating `self` produces the same
+    /// sequence of indices in the same number of index advancements).
+    var regions: Regions { get }
+    
+    /// Returns the first found range of the given data buffer.
+    ///
+    /// A default implementation is given in terms of `self.regions`.
+    func firstRange<D: DataProtocol, R: RangeExpression>(of: D, in: R) -> Range<Index>? where R.Bound == Index
+    
+    /// Returns the last found range of the given data buffer.
+    ///
+    /// A default implementation is given in terms of `self.regions`.
+    func lastRange<D: DataProtocol, R: RangeExpression>(of: D, in: R) -> Range<Index>? where R.Bound == Index
+    
+    /// Copies `count` bytes from the start of the buffer to the destination
+    /// buffer.
+    ///
+    /// A default implementation is given in terms of `copyBytes(to:from:)`.
+    @discardableResult
+    func copyBytes(to: UnsafeMutableRawBufferPointer, count: Int) -> Int
+    
+    /// Copies `count` bytes from the start of the buffer to the destination
+    /// buffer.
+    ///
+    /// A default implementation is given in terms of `copyBytes(to:from:)`.
+    @discardableResult
+    func copyBytes<DestinationType>(to: UnsafeMutableBufferPointer<DestinationType>, count: Int) -> Int
+    
+    /// Copies the bytes from the given range to the destination buffer.
+    ///
+    /// A default implementation is given in terms of `self.regions`.
+    @discardableResult
+    func copyBytes<R: RangeExpression>(to: UnsafeMutableRawBufferPointer, from: R) -> Int where R.Bound == Index
+    
+    /// Copies the bytes from the given range to the destination buffer.
+    ///
+    /// A default implementation is given in terms of `self.regions`.
+    @discardableResult
+    func copyBytes<DestinationType, R: RangeExpression>(to: UnsafeMutableBufferPointer<DestinationType>, from: R) -> Int where R.Bound == Index
+}
+
+//===--- MutableDataProtocol ----------------------------------------------===//
+
+public protocol MutableDataProtocol : DataProtocol, MutableCollection, RangeReplaceableCollection {
+    /// Replaces the contents of the buffer at the given range with zeroes.
+    ///
+    /// A default implementation is given in terms of
+    /// `replaceSubrange(_:with:)`.
+    mutating func resetBytes<R: RangeExpression>(in range: R) where R.Bound == Index
+}
+
+//===--- DataProtocol Extensions ------------------------------------------===//
+
+extension DataProtocol {
+    public func firstRange<D: DataProtocol>(of data: D) -> Range<Index>? {
+        return self.firstRange(of: data, in: self.startIndex ..< self.endIndex)
+    }
+    
+    public func lastRange<D: DataProtocol>(of data: D) -> Range<Index>? {
+        return self.firstRange(of: data, in: self.startIndex ..< self.endIndex)
+    }
+    
+    @discardableResult
+    public func copyBytes(to ptr: UnsafeMutableRawBufferPointer) -> Int {
+        return copyBytes(to: ptr, from: self.startIndex ..< self.endIndex)
+    }
+    
+    @discardableResult
+    public func copyBytes<DestinationType>(to ptr: UnsafeMutableBufferPointer<DestinationType>) -> Int {
+        return copyBytes(to: ptr, from: self.startIndex ..< self.endIndex)
+    }
+    
+    @discardableResult
+    public func copyBytes(to ptr: UnsafeMutableRawBufferPointer, count: Int) -> Int {
+        return copyBytes(to: ptr, from: self.startIndex ..< self.index(self.startIndex, offsetBy: count))
+    }
+    
+    @discardableResult
+    public func copyBytes<DestinationType>(to ptr: UnsafeMutableBufferPointer<DestinationType>, count: Int) -> Int {
+        return copyBytes(to: ptr, from: self.startIndex ..< self.index(self.startIndex, offsetBy: count))
+    }
+    
+    @discardableResult
+    public func copyBytes<R: RangeExpression>(to ptr: UnsafeMutableRawBufferPointer, from range: R) -> Int where R.Bound == Index {
+        precondition(ptr.baseAddress != nil)
+        
+        let concreteRange = range.relative(to: self)
+        let slice = self[concreteRange]
+        
+        // The type isn't contiguous, so we need to copy one region at a time.
+        var offset = 0
+        let rangeCount = distance(from: concreteRange.lowerBound, to: concreteRange.upperBound)
+        var amountToCopy = Swift.min(ptr.count, rangeCount)
+        for region in slice.regions {
+            guard amountToCopy > 0 else {
+                break
+            }
+            
+            region.withUnsafeBytes { buffer in
+                let offsetPtr = UnsafeMutableRawBufferPointer(rebasing: ptr[offset...])
+                let buf = UnsafeRawBufferPointer(start: buffer.baseAddress, count: Swift.min(buffer.count, amountToCopy))
+                offsetPtr.copyMemory(from: buf)
+                offset += buf.count
+                amountToCopy -= buf.count
+            }
+        }
+        
+        return offset
+    }
+    
+    @discardableResult
+    public func copyBytes<DestinationType, R: RangeExpression>(to ptr: UnsafeMutableBufferPointer<DestinationType>, from range: R) -> Int where R.Bound == Index {
+        return self.copyBytes(to: UnsafeMutableRawBufferPointer(start: ptr.baseAddress, count: ptr.count * MemoryLayout<DestinationType>.stride), from: range)
+    }
+    
+    public func firstRange<D: DataProtocol, R: RangeExpression>(of data: D, in range: R) -> Range<Index>? where R.Bound == Index {
+        let r = range.relative(to: self)
+        let rangeCount = distance(from: r.lowerBound, to: r.upperBound)
+        if rangeCount < data.count {
+            return nil
+        }
+        var haystackIndex = r.lowerBound
+        let haystackEnd = index(r.upperBound, offsetBy: -data.count)
+        while haystackIndex < haystackEnd {
+            var compareIndex = haystackIndex
+            var needleIndex = data.startIndex
+            let needleEnd = data.endIndex
+            var matched = true
+            while compareIndex < haystackEnd && needleIndex < needleEnd {
+                if self[compareIndex] != data[needleIndex] {
+                    matched = false
+                    break
+                }
+                needleIndex = data.index(after: needleIndex)
+                compareIndex = index(after: compareIndex)
+            }
+            if matched {
+                return haystackIndex..<compareIndex
+            }
+            haystackIndex = index(after: haystackIndex)
+        }
+        return nil
+    }
+    
+    public func lastRange<D: DataProtocol, R: RangeExpression>(of data: D, in range: R) -> Range<Index>? where R.Bound == Index {
+        let r = range.relative(to: self)
+        let rangeCount = distance(from: r.lowerBound, to: r.upperBound)
+        if rangeCount < data.count {
+            return nil
+        }
+        var haystackIndex = r.upperBound
+        let haystackStart = index(r.lowerBound, offsetBy: data.count)
+        while haystackIndex > haystackStart {
+            var compareIndex = haystackIndex
+            var needleIndex = data.endIndex
+            let needleStart = data.startIndex
+            var matched = true
+            while compareIndex > haystackStart && needleIndex > needleStart {
+                if self[compareIndex] != data[needleIndex] {
+                    matched = false
+                    break
+                }
+                needleIndex = data.index(before: needleIndex)
+                compareIndex = index(before: compareIndex)
+            }
+            if matched {
+                return compareIndex..<haystackIndex
+            }
+            haystackIndex = index(before: haystackIndex)
+        }
+        return nil
+    }
+}
+
+extension DataProtocol where Self : ContiguousBytes {
+    public func copyBytes<DestinationType, R: RangeExpression>(to ptr: UnsafeMutableBufferPointer<DestinationType>, from range: R) where R.Bound == Index {
+        precondition(ptr.baseAddress != nil)
+        
+        let concreteRange = range.relative(to: self)
+        withUnsafeBytes { fullBuffer in
+            let adv = distance(from: startIndex, to: concreteRange.lowerBound)
+            let delta = distance(from: concreteRange.lowerBound, to: concreteRange.upperBound)
+            memcpy(ptr.baseAddress!, fullBuffer.baseAddress!.advanced(by: adv), delta)
+        }
+    }
+}
+
+//===--- MutableDataProtocol Extensions -----------------------------------===//
+
+extension MutableDataProtocol {
+    public mutating func resetBytes<R: RangeExpression>(in range: R) where R.Bound == Index {
+        let r = range.relative(to: self)
+        let count = distance(from: r.lowerBound, to: r.upperBound)
+        replaceSubrange(r, with: repeatElement(UInt8(0), count: count))
+    }
+}
+
+//===--- DataProtocol Conditional Conformances ----------------------------===//
+
+extension Slice : DataProtocol where Base : DataProtocol {
+    public typealias Regions = [Base.Regions.Element.SubSequence]
+    
+    public var regions: [Base.Regions.Element.SubSequence] {
+        let sliceLowerBound = startIndex
+        let sliceUpperBound = endIndex
+        var regionUpperBound = base.startIndex
+        
+        return base.regions.compactMap { (region) -> Base.Regions.Element.SubSequence? in
+            let regionLowerBound = regionUpperBound
+            regionUpperBound = base.index(regionUpperBound, offsetBy: region.count)
+            
+            /*
+             [------ Region ------]
+             [--- Slice ---] =>
+             
+             OR
+             
+             [------ Region ------]
+             <= [--- Slice ---]
+             */
+            if sliceLowerBound >= regionLowerBound && sliceUpperBound <= regionUpperBound {
+                let regionRelativeSliceLowerBound = region.index(region.startIndex, offsetBy: base.distance(from: regionLowerBound, to: sliceLowerBound))
+                let regionRelativeSliceUpperBound = region.index(region.startIndex, offsetBy: base.distance(from: regionLowerBound, to: sliceUpperBound))
+                return region[regionRelativeSliceLowerBound..<regionRelativeSliceUpperBound]
+            }
+            
+            /*
+             [--- Region ---] =>
+             [------ Slice ------]
+             
+             OR
+             
+             <= [--- Region ---]
+             [------ Slice ------]
+             */
+            if regionLowerBound >= sliceLowerBound && regionUpperBound <= sliceUpperBound {
+                return region[region.startIndex..<region.endIndex]
+            }
+            
+            /*
+             [------ Region ------]
+             [------ Slice ------]
+             */
+            if sliceLowerBound >= regionLowerBound && sliceLowerBound <= regionUpperBound {
+                let regionRelativeSliceLowerBound = region.index(region.startIndex, offsetBy: base.distance(from: regionLowerBound, to: sliceLowerBound))
+                return region[regionRelativeSliceLowerBound..<region.endIndex]
+            }
+            
+            /*
+             [------ Region ------]
+             [------ Slice ------]
+             */
+            if regionLowerBound >= sliceLowerBound && regionLowerBound <= sliceUpperBound {
+                let regionRelativeSliceUpperBound = region.index(region.startIndex, offsetBy: base.distance(from: regionLowerBound, to: sliceUpperBound))
+                return region[region.startIndex..<regionRelativeSliceUpperBound]
+            }
+            
+            /*
+             [--- Region ---]
+             [--- Slice ---]
+             
+             OR
+             
+             [--- Region ---]
+             [--- Slice ---]
+             */
+            return nil
+        }
+    }
+}

--- a/Foundation/DispatchData+DataProtocol.swift
+++ b/Foundation/DispatchData+DataProtocol.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+
+import Dispatch
+
+extension DispatchData : DataProtocol {
+    public struct Region : DataProtocol, ContiguousBytes {
+        internal let bytes: UnsafeBufferPointer<UInt8>
+        internal let index: DispatchData.Index
+        internal let owner: DispatchData
+        internal init(bytes: UnsafeBufferPointer<UInt8>, index: DispatchData.Index, owner: DispatchData) {
+            self.bytes = bytes
+            self.index = index
+            self.owner = owner
+        }
+        
+        public var regions: CollectionOfOne<Region> {
+            return CollectionOfOne(self)
+        }
+        
+        public subscript(position: DispatchData.Index) -> UInt8 {
+            precondition(index <= position && position <= index + bytes.count)
+            return bytes[position - index]
+        }
+        
+        public var startIndex: DispatchData.Index {
+            return index
+        }
+        
+        public var endIndex: DispatchData.Index {
+            return index + bytes.count
+        }
+        
+        public func withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
+            return try body(UnsafeRawBufferPointer(bytes))
+        }
+    }
+    
+    public var regions: [Region] {
+        var regions = [Region]()
+        enumerateBytes { (bytes, index, stop) in
+            regions.append(Region(bytes: bytes, index: index, owner: self))
+        }
+        return regions
+    }
+}

--- a/Foundation/NSData+DataProtocol.swift
+++ b/Foundation/NSData+DataProtocol.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+
+extension NSData : DataProtocol {
+    
+    @nonobjc
+    public var startIndex: Int { return 0 }
+    
+    @nonobjc
+    public var endIndex: Int { return length }
+    
+    @nonobjc
+    public func lastRange<D, R>(of data: D, in r: R) -> Range<Int>? where D : DataProtocol, R : RangeExpression, NSData.Index == R.Bound {
+        return Range<Int>(range(of: Data(data), options: .backwards, in: NSRange(r)))
+    }
+    
+    @nonobjc
+    public func firstRange<D, R>(of data: D, in r: R) -> Range<Int>? where D : DataProtocol, R : RangeExpression, NSData.Index == R.Bound {
+        return Range<Int>(range(of: Data(data), in: NSRange(r)))
+    }
+    
+    @nonobjc
+    public var regions: [Data] {
+        var datas = [Data]()
+        enumerateBytes { (ptr, range, stop) in
+            datas.append(Data(bytesNoCopy: UnsafeMutableRawPointer(mutating: ptr), count: range.length, deallocator: .custom({ (ptr: UnsafeMutableRawPointer, count: Int) -> Void in
+                withExtendedLifetime(self) { }
+            })))
+        }
+        return datas
+    }
+    
+    @nonobjc
+    public subscript(position: Int) -> UInt8 {
+        var byte = UInt8(0)
+        enumerateBytes { (ptr, range, stop) in
+            if range.location <= position && position < range.upperBound {
+                byte = ptr.load(fromByteOffset: range.location - position, as: UInt8.self)
+                stop.pointee = true
+            }
+        }
+        return byte
+    }
+}

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -179,7 +179,9 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     /// Initializes a data object with the contents of another data object.
     public init(data: Data) {
         super.init()
-        _init(bytes: UnsafeMutableRawPointer(mutating: data._nsObject.bytes), length: data.count, copy: true)
+        data.withUnsafeBytes {
+            _init(bytes: UnsafeMutableRawPointer(mutating: $0.baseAddress), length: $0.count, copy: true)
+        }
     }
 
     /// Initializes a data object with the data from the location specified by a given URL.

--- a/Foundation/Pointers+DataProtocol.swift
+++ b/Foundation/Pointers+DataProtocol.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+
+extension UnsafeRawBufferPointer : DataProtocol {
+    public var regions: CollectionOfOne<UnsafeRawBufferPointer> {
+        return CollectionOfOne(self)
+    }
+}
+
+extension UnsafeBufferPointer : DataProtocol where Element == UInt8 {
+    public var regions: CollectionOfOne<UnsafeBufferPointer<Element>> {
+        return CollectionOfOne(self)
+    }
+}

--- a/Foundation/URLSession/BodySource.swift
+++ b/Foundation/URLSession/BodySource.swift
@@ -23,9 +23,7 @@ import Dispatch
 /// Turn `Data` into `DispatchData`
 internal func createDispatchData(_ data: Data) -> DispatchData {
     //TODO: Avoid copying data
-    let buffer = UnsafeRawBufferPointer(start: data._backing.bytes,
-                                        count: data.count)
-    return DispatchData(bytes: buffer)
+    return data.withUnsafeBytes { DispatchData(bytes: $0) }
 }
 
 /// Copy data from `DispatchData` into memory pointed to by an `UnsafeMutableBufferPointer`.

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -1421,10 +1421,6 @@ extension TestNSData {
     }
     
     func test_dataHash() {
-        let dataStruct = "Hello World".data(using: .utf8)!
-        let dataObj = dataStruct._bridgeToObjectiveC()
-        XCTAssertEqual(dataObj.hashValue, dataStruct.hashValue, "Data and NSData should have the same hash value")
-
         XCTAssertEqual(NSData().hash, 0)
         XCTAssertEqual(NSMutableData().hash, 0)
 

--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -31,7 +31,11 @@ let kNullString = "<null>"
 private func getTestData() -> [Any]? {
     let testFilePath = testBundle().url(forResource: "NSURLTestData", withExtension: "plist")
     let data = try! Data(contentsOf: testFilePath!)
-    guard let testRoot = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String : Any] else {
+    guard let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) else {
+        XCTFail("Unable to deserialize property list data")
+        return nil
+    }
+    guard let testRoot = plist as? [String : Any] else {
         XCTFail("Unable to deserialize property list data")
         return nil
     }


### PR DESCRIPTION
This releases [this PR](https://github.com/apple/swift-corelibs-foundation/pull/1834) to Swift 5.0 (cherry picked from commit 4a255655c298450416d388a58c2b50f4057c3346).