### PR TITLE
Foundation: port NSThread to Windows

### DIFF
--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -1359,9 +1359,20 @@ void _CFThreadSpecificSet(_CFThreadSpecificKey key, CFTypeRef _Nullable value) {
 
 _CFThreadRef _CFThreadCreate(const _CFThreadAttributes attrs, void *_Nullable (* _Nonnull startfn)(void *_Nullable), void *_CF_RESTRICT _Nullable context) {
 #if DEPLOYMENT_TARGET_WINDOWS
-    return (_CFThreadRef)_beginthreadex(NULL, 0,
+    DWORD dwCreationFlags = 0;
+    DWORD dwStackSize = 0;
+    if (attrs.dwSizeOfAttributes >=
+            offsetof(struct _CFThreadAttributes,
+                     dwThreadStackReservation) + sizeof(dwStackSize)) {
+      dwStackSize = attrs.dwThreadStackReservation;
+      if (dwStackSize) {
+        dwCreationFlags |= STACK_SIZE_PARAM_IS_A_RESERVATION;
+      }
+    }
+
+    return (_CFThreadRef)_beginthreadex(NULL, dwStackSize,
                                         (_beginthreadex_proc_type)startfn,
-                                        context, 0, NULL);
+                                        context, dwCreationFlags, NULL);
 #else
     _CFThreadRef thread;
     pthread_create(&thread, &attrs, startfn, context);

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -347,7 +347,10 @@ CF_EXPORT void CFLog1(CFLogLevel lev, CFStringRef message);
 
 #if DEPLOYMENT_TARGET_WINDOWS
 typedef HANDLE _CFThreadRef;
-typedef DWORD _CFThreadAttributes;
+typedef struct _CFThreadAttributes {
+  DWORD dwSizeOfAttributes;
+  DWORD dwThreadStackReservation;
+} _CFThreadAttributes;
 typedef DWORD _CFThreadSpecificKey;
 #elif _POSIX_THREADS
 typedef pthread_t _CFThreadRef;

--- a/Foundation/NSLock.swift
+++ b/Foundation/NSLock.swift
@@ -133,7 +133,7 @@ extension NSLock {
 open class NSConditionLock : NSObject, NSLocking {
     internal var _cond = NSCondition()
     internal var _value: Int
-    internal var _thread: _CFThreadRef?
+    internal var _thread: _swift_CFThreadRef?
     
     public convenience override init() {
         self.init(condition: 0)

--- a/Foundation/Thread.swift
+++ b/Foundation/Thread.swift
@@ -38,7 +38,11 @@ private func NSThreadStart(_ context: UnsafeMutableRawPointer?) -> UnsafeMutable
     let thread: Thread = NSObject.unretainedReference(context!)
     Thread._currentThread.set(thread)
     if let name = thread.name {
+#if os(Windows)
+        _CFThreadSetName(GetCurrentThread(), name)
+#else
         _CFThreadSetName(pthread_self(), name)
+#endif
     }
     thread._status = .executing
     thread.main()
@@ -55,7 +59,11 @@ open class Thread : NSObject {
             if Thread.isMainThread {
                 return mainThread
             } else {
+#if os(Windows)
+                return Thread(thread: GetCurrentThread())
+#else
                 return Thread(thread: pthread_self())
+#endif
             }
         }
     }
@@ -89,6 +97,19 @@ open class Thread : NSObject {
     }
 
     open class func sleep(until date: Date) {
+#if os(Windows)
+        var hTimer: HANDLE = CreateWaitableTimerW(nil, TRUE, nil)
+        // FIXME(compnerd) how to check that hTimer is not NULL?
+        defer { CloseHandle(hTimer) }
+
+        // the timeout is in 100ns units
+        var liTimeout: LARGE_INTEGER =
+            LARGE_INTEGER(QuadPart: LONGLONG(date.timeIntervalSinceReferenceDate) * -10000000)
+        if SetWaitableTimer(hTimer, &liTimeout, 0, nil, nil, FALSE) == FALSE {
+          return
+        }
+        WaitForSingleObject(hTimer, WinSDK.INFINITE)
+#else
         let start_ut = CFGetSystemUptime()
         let start_at = CFAbsoluteTimeGetCurrent()
         let end_at = date.timeIntervalSinceReferenceDate
@@ -109,9 +130,23 @@ open class Thread : NSObject {
             }
             ti = end_ut - CFGetSystemUptime()
         }
+#endif
     }
 
     open class func sleep(forTimeInterval interval: TimeInterval) {
+#if os(Windows)
+        var hTimer: HANDLE = CreateWaitableTimerW(nil, TRUE, nil)
+        // FIXME(compnerd) how to check that hTimer is not NULL?
+        defer { CloseHandle(hTimer) }
+
+        // the timeout is in 100ns units
+        var liTimeout: LARGE_INTEGER =
+            LARGE_INTEGER(QuadPart: LONGLONG(interval) * -10000000)
+        if SetWaitableTimer(hTimer, &liTimeout, 0, nil, nil, FALSE) == FALSE {
+          return
+        }
+        WaitForSingleObject(hTimer, WinSDK.INFINITE)
+#else
         var ti = interval
         let start_ut = CFGetSystemUptime()
         let end_ut = start_ut + ti
@@ -130,37 +165,48 @@ open class Thread : NSObject {
             }
             ti = end_ut - CFGetSystemUptime()
         }
+#endif
     }
 
     open class func exit() {
         Thread.current._status = .finished
+#if os(Windows)
+        ExitThread(0)
+#else
         pthread_exit(nil)
+#endif
     }
 
     internal var _main: () -> Void = {}
-    private var _thread: pthread_t? = nil
+    private var _thread: _CFThreadRef? = nil
 
-#if CYGWIN
+#if os(Windows) && !CYGWIN
+    internal var _attr: _CFThreadAttributes =
+        _CFThreadAttributes(dwSizeOfAttributes: MemoryLayout<_CFThreadAttributes>.size,
+                            dwThreadStackReservation: 0)
+#elseif CYGWIN
     internal var _attr : pthread_attr_t? = nil
 #else
     internal var _attr = pthread_attr_t()
 #endif
     internal var _status = _NSThreadStatus.initialized
     internal var _cancelled = false
-    
+
     open private(set) var threadDictionary: NSMutableDictionary = NSMutableDictionary()
 
-    internal init(thread: pthread_t) {
-        // Note: even on Darwin this is a non-optional pthread_t; this is only used for valid threads, which are never null pointers.
+    internal init(thread: _CFThreadRef) {
+        // Note: even on Darwin this is a non-optional _CFThreadRef; this is only used for valid threads, which are never null pointers.
         _thread = thread
     }
 
     public override init() {
+#if !os(Windows)
         let _ = withUnsafeMutablePointer(to: &_attr) { attr in
             pthread_attr_init(attr)
             pthread_attr_setscope(attr, Int32(PTHREAD_SCOPE_SYSTEM))
             pthread_attr_setdetachstate(attr, Int32(PTHREAD_CREATE_DETACHED))
         }
+#endif
     }
 
     public convenience init(block: @escaping () -> Swift.Void) {
@@ -202,6 +248,19 @@ open class Thread : NSObject {
         }
     }
 
+#if os(Windows)
+    open var stackSize: Int {
+      get {
+        var ulLowLimit: ULONG_PTR = 0
+        var ulHighLimit: ULONG_PTR = 0
+        GetCurrentThreadStackLimits(&ulLowLimit, &ulHighLimit)
+        return Int(ulLowLimit)
+      }
+      set {
+        _attr.dwThreadStackReservation = newValue
+      }
+    }
+#else
     open var stackSize: Int {
         get {
             var size: Int = 0
@@ -223,6 +282,7 @@ open class Thread : NSObject {
             }
         }
     }
+#endif
 
     open var isExecuting: Bool {
         return _status == .executing
@@ -252,6 +312,9 @@ open class Thread : NSObject {
         defer { addrs.deallocate() }
 #if os(Android)
         let count = 0
+#elseif os(Windows)
+        let count = RtlCaptureStackBackTrace(0, DWORD(maxSupportedStackDepth),
+                                             addrs, nil)
 #else
         let count = backtrace(addrs, Int32(maxSupportedStackDepth))
 #endif
@@ -270,6 +333,39 @@ open class Thread : NSObject {
     open class var callStackSymbols: [String] {
 #if os(Android)
         return []
+#elseif os(Windows)
+        let hProcess: HANDLE = GetCurrentProcess()
+        SymSetOptions(DWORD(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS))
+        if SymInitializeW(hProcess, nil, TRUE) == FALSE {
+          return []
+        }
+        return backtraceAddresses { (addresses, count) in
+          var symbols: [String] = []
+
+          var buffer: UnsafeMutablePointer<Int8> =
+              UnsafeMutablePointer<Int8>
+                  .allocate(capacity: MemoryLayout<SYMBOL_INFO>.size + 128)
+          defer { buffer.deallocate() }
+
+          buffer.withMemoryRebound(to: SYMBOL_INFO.self, capacity: 1) {
+            $0.pointee.SizeOfStruct = ULONG(MemoryLayout<SYMBOL_INFO>.size)
+            $0.pointee.MaxNameLen = 128
+
+            var address = addresses
+            for _ in 1...count {
+              var dwDisplacement: DWORD64 = 0
+              if SymFromAddr(hProcess, unsafeBitCast(address.pointee,
+                                                     to: DWORD64.self),
+                             &dwDisplacement, $0) == FALSE {
+                symbols.append("\($0.pointee)")
+              } else {
+                symbols.append(String(cString: &$0.pointee.Name))
+              }
+              address = address.successor()
+            }
+          }
+          return symbols
+        }
 #else
         return backtraceAddresses({ (addrs, count) in
             var symbols: [String] = []

--- a/Foundation/Thread.swift
+++ b/Foundation/Thread.swift
@@ -9,6 +9,13 @@
 
 import CoreFoundation
 
+// WORKAROUND_SR9811
+#if os(Windows)
+internal typealias _swift_CFThreadRef = HANDLE
+#else
+internal typealias _swift_CFThreadRef = pthread_t
+#endif
+
 internal class NSThreadSpecific<T: NSObject> {
     private var key = _CFThreadSpecificKeyCreate()
 
@@ -178,7 +185,7 @@ open class Thread : NSObject {
     }
 
     internal var _main: () -> Void = {}
-    private var _thread: _CFThreadRef? = nil
+    private var _thread: _swift_CFThreadRef? = nil
 
 #if os(Windows) && !CYGWIN
     internal var _attr: _CFThreadAttributes =
@@ -194,7 +201,7 @@ open class Thread : NSObject {
 
     open private(set) var threadDictionary: NSMutableDictionary = NSMutableDictionary()
 
-    internal init(thread: _CFThreadRef) {
+    internal init(thread: _swift_CFThreadRef) {
         // Note: even on Darwin this is a non-optional _CFThreadRef; this is only used for valid threads, which are never null pointers.
         _thread = thread
     }


### PR DESCRIPTION
Implement the Thread interfaces for Windows.  Extend the CoreFoundation
interface to support thread stack reservation sizing.