### PR TITLE
Update NSKeyedArchiver.swift

### DIFF
--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -487,7 +487,7 @@ open class NSKeyedArchiver : NSCoder {
         let className = NSStringFromClass(clsv)
         let mappedClassName = _classNameForClass(clsv)
         
-        if mappedClassName != nil && mappedClassName != className {
+        if let mappedClassName = mappedClassName && mappedClassName != className {
             // If we have a mapped class name, OS X only encodes the mapped name
             classDict["$classname"] = mappedClassName
         } else {
@@ -552,7 +552,7 @@ open class NSKeyedArchiver : NSCoder {
         // check replacement cache
         if let hashable = object as? AnyHashable {
             objectToEncode = self._replacementMap[hashable]
-            if objectToEncode != nil {
+            if let objectToEncode = objectToEncode {
                 return objectToEncode
             }
         }

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -487,7 +487,7 @@ open class NSKeyedArchiver : NSCoder {
         let className = NSStringFromClass(clsv)
         let mappedClassName = _classNameForClass(clsv)
         
-        if let mappedClassName = mappedClassName && mappedClassName != className {
+        if let mappedClassName = mappedClassName, && mappedClassName != className {
             // If we have a mapped class name, OS X only encodes the mapped name
             classDict["$classname"] = mappedClassName
         } else {


### PR DESCRIPTION
Similar to [this commit](https://github.com/apple/swift-corelibs-foundation/commit/f753b1c94c806109f01196d7060c0731cad9cd48) implementing a pull request I created, this PR changes occurrences of `if x != nil { /* use x! */ }` to `if let x = x { /* use x */ }`. It is arguably more "Swifty" in terms of syntax.