### PR TITLE
Foundation: sundry fixes for Windows port

### DIFF
--- a/Foundation/CGFloat.swift
+++ b/Foundation/CGFloat.swift
@@ -863,11 +863,13 @@ public func scalbn(_ x: CGFloat, _ n: Int) -> CGFloat {
     return CGFloat(scalbn(x.native, n))
 }
 
+#if !os(Windows)
 @_transparent
 public func lgamma(_ x: CGFloat) -> (CGFloat, Int) {
     let (value, sign) = lgamma(x.native)
     return (CGFloat(value), sign)
 }
+#endif
 
 @_transparent
 public func remquo(_ x: CGFloat, _ y: CGFloat) -> (CGFloat, Int) {

--- a/Foundation/FoundationErrors.swift
+++ b/Foundation/FoundationErrors.swift
@@ -179,7 +179,11 @@ internal func _NSErrorWithErrno(_ posixErrno : Int32, reading : Bool, path : Str
             case ENOENT: cocoaError = .fileNoSuchFile
             case EPERM, EACCES: cocoaError = .fileWriteNoPermission
             case ENAMETOOLONG: cocoaError = .fileWriteInvalidFileName
+#if os(Windows)
+            case ENOSPC: cocoaError = .fileWriteOutOfSpace
+#else
             case EDQUOT, ENOSPC: cocoaError = .fileWriteOutOfSpace
+#endif
             case EROFS: cocoaError = .fileWriteVolumeReadOnly
             case EEXIST: cocoaError = .fileWriteFileExists
             default: cocoaError = .fileWriteUnknown

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -15,6 +15,14 @@ public var NSTimeIntervalSince1970: Double {
     return 978307200.0
 }
 
+#if os(Windows)
+extension TimeInterval {
+  init(_ ftTime: FILETIME) {
+    self = Double((ftTime.dwHighDateTime << 32) | ftTime.dwLowDateTime) - NSTimeIntervalSince1970;
+  }
+}
+#endif
+
 open class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
     typealias CFType = CFDate
     
@@ -52,6 +60,20 @@ open class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
         return Date().timeIntervalSinceReferenceDate
     }
 
+#if os(Windows)
+    public convenience override init() {
+      var stTime: SYSTEMTIME = SYSTEMTIME()
+      var ftTime: FILETIME = FILETIME()
+
+      GetSystemTime(&stTime)
+      SystemTimeToFileTime(&stTime, &ftTime)
+
+      let timestamp: UInt64 = (UInt64(ftTime.dwLowDateTime) << 0)
+                            + (UInt64(ftTime.dwHighDateTime) << 32)
+                            - UInt64(NSTimeIntervalSince1970)
+      self.init(timeIntervalSinceReferenceDate: TimeInterval(timestamp))
+    }
+#else
     public convenience override init() {
         var tv = timeval()
         let _ = withUnsafeMutablePointer(to: &tv) { t in
@@ -61,6 +83,7 @@ open class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
         timestamp += TimeInterval(tv.tv_usec) / 1000000.0
         self.init(timeIntervalSinceReferenceDate: timestamp)
     }
+#endif
 
     public required init(timeIntervalSinceReferenceDate ti: TimeInterval) {
         _timeIntervalSinceReferenceDate = ti

--- a/Foundation/NSPlatform.swift
+++ b/Foundation/NSPlatform.swift
@@ -11,6 +11,12 @@
 fileprivate let _NSPageSize = Int(vm_page_size)
 #elseif os(Linux) || os(Android)
 fileprivate let _NSPageSize = Int(getpagesize())
+#elseif os(Windows)
+fileprivate var _NSPageSize: Int {
+  var siInfo: SYSTEM_INFO = SYSTEM_INFO()
+  GetSystemInfo(&siInfo)
+  return Int(siInfo.dwPageSize)
+}
 #endif
 
 public func NSPageSize() -> Int {

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -26,7 +26,8 @@ import CoreFoundation
 import WinSDK
 #endif
 
-#if os(Android) // shim required for bzero
+// shim required for bzero
+#if os(Android) || os(Windows)
 @_transparent func bzero(_ ptr: UnsafeMutableRawPointer, _ size: size_t) {
     memset(ptr, 0, size)
 }

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -556,9 +556,13 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     
     // Memory leak. See https://github.com/apple/swift-corelibs-foundation/blob/master/Docs/Issues.md
     open var fileSystemRepresentation: UnsafePointer<Int8> {
-        
+
+#if os(Windows)
+        let bufSize = Int(MAX_PATH + 1)
+#else
         let bufSize = Int(PATH_MAX + 1)
-        
+#endif
+
         let _fsrBuffer = UnsafeMutablePointer<Int8>.allocate(capacity: bufSize)
         _fsrBuffer.initialize(repeating: 0, count: bufSize)
 

--- a/Foundation/Stream.swift
+++ b/Foundation/Stream.swift
@@ -153,7 +153,11 @@ open class InputStream: Stream {
     }
     
     open override var streamStatus: Status {
+#if os(Windows)
+        return Stream.Status(rawValue: UInt(CFReadStreamGetStatus(_stream).rawValue))!
+#else
         return Stream.Status(rawValue: UInt(CFReadStreamGetStatus(_stream)))!
+#endif
     }
     
     open override var streamError: Error? {
@@ -205,7 +209,11 @@ open class OutputStream : Stream {
     }
     
     open override var streamStatus: Status {
+#if os(Windows)
+        return Stream.Status(rawValue: UInt(CFWriteStreamGetStatus(_stream).rawValue))!
+#else
         return Stream.Status(rawValue: UInt(CFWriteStreamGetStatus(_stream)))!
+#endif
     }
     
     open class func toMemory() -> Self {

--- a/Foundation/URLSession/Configuration.swift
+++ b/Foundation/URLSession/Configuration.swift
@@ -101,7 +101,6 @@ internal extension URLSession._Configuration {
 // Configure NSURLRequests
 internal extension URLSession._Configuration {
     func configure(request: URLRequest) -> URLRequest {
-        var request = request
         return setCookies(on: request)
     }
 

--- a/Foundation/URLSession/libcurl/EasyHandle.swift
+++ b/Foundation/URLSession/libcurl/EasyHandle.swift
@@ -374,9 +374,13 @@ internal extension _EasyHandle {
     /// errno number from last connect failure
     /// - SeeAlso: https://curl.haxx.se/libcurl/c/CURLINFO_OS_ERRNO.html
     var connectFailureErrno: Int {
+    #if os(Windows) && (arch(arm64) || arch(x86_64))
+        var errno = Int32()
+    #else
         var errno = Int()
+    #endif
         try! CFURLSession_easy_getinfo_long(rawHandle, CFURLSessionInfoOS_ERRNO, &errno).asError()
-        return errno
+        return numericCast(errno)
     }
 }
 


### PR DESCRIPTION
Adjust the source for LLP64 (Windows x64/AArch64) and account for
non-POSIX environment.  Collect them into a single change as they are
small enough to not be a problem to really inspect in a single batch.