### PR TITLE
SR-9758: `XMLParser.parse()` should return `false` if `abortParsing()` is called.

### DIFF
--- a/Foundation/XMLParser.swift
+++ b/Foundation/XMLParser.swift
@@ -465,16 +465,18 @@ open class XMLParser : NSObject {
     }
     
     internal func _handleParseResult(_ parseResult: Int32) -> Bool {
-        return true
-        /*
         var result = true
         if parseResult != 0 {
             if parseResult != -1 {
                 // TODO: determine if this result is a fatal error from libxml via the CF implementations
             }
+            
+            if _parserError == nil {
+                _parserError = NSError(domain: XMLParser.errorDomain, code: Int(parseResult))
+            }
+            result = false
         }
         return result
-        */
     }
 
     internal func parseData(_ data: Data) -> Bool {

--- a/Foundation/XMLParser.swift
+++ b/Foundation/XMLParser.swift
@@ -465,18 +465,14 @@ open class XMLParser : NSObject {
     }
     
     internal func _handleParseResult(_ parseResult: Int32) -> Bool {
-        var result = true
-        if parseResult != 0 {
-            if parseResult != -1 {
-                // TODO: determine if this result is a fatal error from libxml via the CF implementations
-            }
-            
+        if parseResult == 0 {
+            return true
+        } else {
             if _parserError == nil {
                 _parserError = NSError(domain: XMLParser.errorDomain, code: Int(parseResult))
             }
-            result = false
         }
-        return result
+        return false
     }
 
     internal func parseData(_ data: Data) -> Bool {

--- a/TestFoundation/TestXMLParser.swift
+++ b/TestFoundation/TestXMLParser.swift
@@ -65,6 +65,7 @@ class TestXMLParser : XCTestCase {
             ("test_withData", test_withData),
             ("test_withDataEncodings", test_withDataEncodings),
             ("test_withDataOptions", test_withDataOptions),
+            ("test_sr9758_abortParsing", test_sr9758_abortParsing),
         ]
     }
 
@@ -139,6 +140,18 @@ class TestXMLParser : XCTestCase {
         let res = parser.parse()
         XCTAssertEqual(stream.events, TestXMLParser.xmlUnderTestExpectedEvents(namespaces: true)  )
         XCTAssertTrue(res)
+    }
+
+    func test_sr9758_abortParsing() {
+        class Delegate: NSObject, XMLParserDelegate {
+            func parserDidStartDocument(_ parser: XMLParser) { parser.abortParsing() }
+        }
+        let xml = TestXMLParser.xmlUnderTest(encoding: .utf8)
+        let parser = XMLParser(data: xml.data(using: .utf8)!)
+        let delegate = Delegate()
+        parser.delegate = delegate
+        XCTAssertFalse(parser.parse())
+        XCTAssertNotNil(parser.parserError)
     }
 
 }


### PR DESCRIPTION
As [the Apple's document says](https://developer.apple.com/documentation/foundation/xmlparser/1411778-parse), `parse()` should return false in there is an error or if the parsing operation is aborted.

Resolves [SR-9758](https://bugs.swift.org/browse/SR-9758).