### PR TITLE
Switch to using correct form for unsafe type cast

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -301,7 +301,7 @@ open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSC
         }
         if type(of: self) == NSString.self || type(of: self) == NSMutableString.self {
             if _storage._guts._isContiguousASCII {
-                return UnsafePointer<Int8>(_storage._guts.startASCII);
+                return UnsafeRawPointer(_storage._guts.startASCII).assumingMemoryBound(to: Int8.self)
             }
         }
         return nil


### PR DESCRIPTION
A bug in the standard library allowed conversion between different pointees just using the `UnsafePointer.init` but this should not have been allowed. Updating to the correct form in order to permit apple/swift#22288 to land.