### PR TITLE
Fix a bug in format localized number on s390x

### DIFF
--- a/CoreFoundation/String.subproj/CFString.c
+++ b/CoreFoundation/String.subproj/CFString.c
@@ -6028,7 +6028,7 @@ static Boolean __CFStringFormatLocalizedNumber(CFMutableStringRef output, CFLoca
     static SInt32 secondaryGroupingSize = 0;
     
     // !!! This code should be removed before shipping
-    static char disableLocalizedFormatting = -1;
+    static int disableLocalizedFormatting = -1;
     if (disableLocalizedFormatting == -1) disableLocalizedFormatting = (getenv("CFStringDisableLocalizedNumberFormatting") != NULL) ? 1 : 0;
     if (disableLocalizedFormatting) return false;
 


### PR DESCRIPTION
When building Foundation test on s390x, there is a warning:
    
       CoreFoundation/String.subproj/CFString.c:6030:36: warning: result of comparison of constant -1 with expression of type 'char' is always false [-Wtautological-constant-out-of-range-compare]

The debugging shows  `(disableLocalizedFormatting == -1)` is never `true` because `disableLocalizedFormatting` is defined as `char`, and  then the logic of format localized number is not correct on s390x.

Changing `disableLocalizedFormatting` to `short` to make the logic works on all platforms