### PR TITLE
NSData: fix an errno stomp

### DIFF
--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -517,8 +517,9 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
             if let auxFilePath = auxFilePath {
                 try fm._fileSystemRepresentation(withPath: auxFilePath, { auxFilePathFsRep in
                     if rename(auxFilePathFsRep, pathFsRep) != 0 {
+                        let savedErrno = errno
                         try? FileManager.default.removeItem(atPath: auxFilePath)
-                        throw _NSErrorWithErrno(errno, reading: false, path: path)
+                        throw _NSErrorWithErrno(savedErrno, reading: false, path: path)
                     }
                     if let mode = mode {
                         chmod(pathFsRep, mode)


### PR DESCRIPTION
We would attempt to remove the temporary file.  However, that will
result in calls which can destroy the original errno.  Save the previous
errno before performing the cleanup.