### PR TITLE
CoreFoundation: fix CoreFoundation for Foundation static builds

### DIFF
--- a/CoreFoundation/Base.subproj/CFBase.h
+++ b/CoreFoundation/Base.subproj/CFBase.h
@@ -134,7 +134,7 @@
     #endif
 
     #if defined(_USRDLL)
-        #if defined(CoreFoundation_EXPORTS)
+        #if defined(CoreFoundation_EXPORTS) || defined(CF_BUILDING_CF)
             #define CF_EXPORT _CF_EXTERN __declspec(dllexport)
         #else
             #define CF_EXPORT _CF_EXTERN __declspec(dllimport)


### PR DESCRIPTION
CoreFoundation built statically for Foundation is used as an objects
library.  We want to re-export the symbols.  This requires that exports
are enabled for the target, but CMake defines _EXPORT symbols only for
shared libraries and `-rdynamic` executables.  Use the custom macro for
the static case for Foundation.