### PR TITLE
Foundation: fix build on Windows

### DIFF
--- a/Foundation/NSPlatform.swift
+++ b/Foundation/NSPlatform.swift
@@ -12,6 +12,7 @@ fileprivate let _NSPageSize = Int(vm_page_size)
 #elseif os(Linux) || os(Android)
 fileprivate let _NSPageSize = Int(getpagesize())
 #elseif os(Windows)
+import WinSDK
 fileprivate var _NSPageSize: Int {
   var siInfo: SYSTEM_INFO = SYSTEM_INFO()
   GetSystemInfo(&siInfo)

--- a/Foundation/Thread.swift
+++ b/Foundation/Thread.swift
@@ -189,7 +189,7 @@ open class Thread : NSObject {
 
 #if os(Windows) && !CYGWIN
     internal var _attr: _CFThreadAttributes =
-        _CFThreadAttributes(dwSizeOfAttributes: MemoryLayout<_CFThreadAttributes>.size,
+        _CFThreadAttributes(dwSizeOfAttributes: DWORD(MemoryLayout<_CFThreadAttributes>.size),
                             dwThreadStackReservation: 0)
 #elseif CYGWIN
     internal var _attr : pthread_attr_t? = nil
@@ -264,7 +264,7 @@ open class Thread : NSObject {
         return Int(ulLowLimit)
       }
       set {
-        _attr.dwThreadStackReservation = newValue
+        _attr.dwThreadStackReservation = DWORD(newValue)
       }
     }
 #else


### PR DESCRIPTION
Fix various casting issues.  Fix the dereferencing code in Host to
be more correct.  Clean builds revealed a number of issues, including an
insufficiently complete modulemap.