### PR TITLE
FileHandle: fix OS spelling for `@available`

### DIFF
--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -13,7 +13,7 @@ open class FileHandle : NSObject, NSSecureCoding {
 #if os(Windows)
     private var _handle: HANDLE
 
-    @available(windows, unavailable, message: "Cannot perform non-owning handle to fd conversion")
+    @available(Windows, unavailable, message: "Cannot perform non-owning handle to fd conversion")
     open var fileDescriptor: Int32 {
         NSUnsupported()
     }


### PR DESCRIPTION
Fix capitalisation for OS parameter `@available`.