### PR TITLE
Foundation: update `index` -> `firstIndex` (NFCI)

### DIFF
--- a/Foundation/HTTPCookie.swift
+++ b/Foundation/HTTPCookie.swift
@@ -481,7 +481,7 @@ open class HTTPCookie : NSObject {
     //Cookie attribute names are case-insensitive as per RFC6265: https://tools.ietf.org/html/rfc6265
     //but HTTPCookie needs only the first letter of each attribute in uppercase
     private class func canonicalize(_ name: String) -> HTTPCookiePropertyKey {
-        let idx = _attributes.index(where: {$0.rawValue.caseInsensitiveCompare(name) == .orderedSame})!
+        let idx = _attributes.firstIndex(where: {$0.rawValue.caseInsensitiveCompare(name) == .orderedSame})!
         return _attributes[idx]
     }
 

--- a/Foundation/JSONEncoder.swift
+++ b/Foundation/JSONEncoder.swift
@@ -1001,7 +1001,7 @@ open class JSONDecoder {
             guard !stringKey.isEmpty else { return stringKey }
             
             // Find the first non-underscore character
-            guard let firstNonUnderscore = stringKey.index(where: { $0 != "_" }) else {
+            guard let firstNonUnderscore = stringKey.firstIndex(where: { $0 != "_" }) else {
                 // Reached the end without finding an _
                 return stringKey
             }

--- a/Foundation/NSCFSet.swift
+++ b/Foundation/NSCFSet.swift
@@ -117,7 +117,7 @@ internal func _CFSwiftSetGetValues(_ set: AnyObject, _ values: UnsafeMutablePoin
 internal func _CFSwiftSetGetValue(_ set: AnyObject, value: AnyObject, key: AnyObject) -> Unmanaged<AnyObject>? {
     let set = set as! NSSet
     if type(of: set) === NSSet.self || type(of: set) === NSMutableSet.self {
-        if let idx = set._storage.index(of: value as! NSObject){
+        if let idx = set._storage.firstIndex(of: value as! NSObject){
             return Unmanaged<AnyObject>.passUnretained(set._storage[idx])
         }
         

--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -72,7 +72,7 @@ open class NSOrderedSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     }
 
     open func index(of object: Any) -> Int {
-        return _orderedStorage.index(of: __SwiftValue.store(object)) ?? NSNotFound
+        return _orderedStorage.firstIndex(of: __SwiftValue.store(object)) ?? NSNotFound
     }
 
     public convenience override init() {


### PR DESCRIPTION
Update a few instances of `index` to `firstIndex` as per the deprecation
warnings.  NFCI