### PR TITLE
[4.2] SR-7011: Fatal Error when Using Calendar.current.dateComponents(_:from:to:)

### DIFF
--- a/CoreFoundation/Locale.subproj/CFCalendar.c
+++ b/CoreFoundation/Locale.subproj/CFCalendar.c
@@ -950,14 +950,23 @@ Boolean _CFCalendarGetComponentDifferenceV(CFCalendarRef calendar, CFAbsoluteTim
     int direction = (startingAT <= resultAT) ? 1 : -1;
     char ch = *componentDesc;
     while (ch) {
+        if (count < 1) {
+            // Output vector has no more free entries
+            return false;
+        }
+
         UCalendarDateFields field = __CFCalendarGetICUFieldCodeFromChar(ch);
-        const int multiple_table[] = {0, 0, 16, 19, 24, 26, 24, 28, 14, 14, 14};
+        const int multiple_table[] = {0, 0, 16, 19, 24, 26, 24, 28, 14, 14, 14, 0, 0, 0, 0};
         int unit = __CFCalendarGetCalendarUnitFromChar(ch);
         if (unit < 0) {
             // Not a valid calendar unit character
             return false;
         }
-        int multiple = direction * (1 << multiple_table[flsl(unit) - 1]);
+        int idx = flsl(unit) - 1;
+        if (idx < 0 || idx >= (sizeof(multiple_table) / sizeof(int))) {
+            return false;
+        }
+        int multiple = direction * (1 << multiple_table[idx]);
         Boolean divide = false, alwaysDivide = false;
         int result = 0;
         while ((direction > 0 && curr < goal) || (direction < 0 && goal < curr)) {
@@ -983,10 +992,6 @@ Boolean _CFCalendarGetComponentDifferenceV(CFCalendarRef calendar, CFAbsoluteTim
             if (0 == multiple) break;
             divide = alwaysDivide;
         }
-        }
-        if (count < 1) {
-            // Output vector has no free entries
-            return false;
         }
         *(*vector) = result;
         vector++;

--- a/CoreFoundation/Locale.subproj/CFCalendar.c
+++ b/CoreFoundation/Locale.subproj/CFCalendar.c
@@ -952,7 +952,12 @@ Boolean _CFCalendarGetComponentDifferenceV(CFCalendarRef calendar, CFAbsoluteTim
     while (ch) {
         UCalendarDateFields field = __CFCalendarGetICUFieldCodeFromChar(ch);
         const int multiple_table[] = {0, 0, 16, 19, 24, 26, 24, 28, 14, 14, 14};
-        int multiple = direction * (1 << multiple_table[flsl(__CFCalendarGetCalendarUnitFromChar(ch)) - 1]);
+        int unit = __CFCalendarGetCalendarUnitFromChar(ch);
+        if (unit < 0) {
+            // Not a valid calendar unit character
+            return false;
+        }
+        int multiple = direction * (1 << multiple_table[flsl(unit) - 1]);
         Boolean divide = false, alwaysDivide = false;
         int result = 0;
         while ((direction > 0 && curr < goal) || (direction < 0 && goal < curr)) {
@@ -979,8 +984,13 @@ Boolean _CFCalendarGetComponentDifferenceV(CFCalendarRef calendar, CFAbsoluteTim
             divide = alwaysDivide;
         }
         }
+        if (count < 1) {
+            // Output vector has no free entries
+            return false;
+        }
         *(*vector) = result;
         vector++;
+        count--;
         componentDesc++;
         ch = *componentDesc;
     }

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -497,13 +497,15 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    private func _setup(_ unitFlags: Unit) -> [Int8] {
+    private func _setup(_ unitFlags: Unit, addIsLeapMonth: Bool = true) -> [Int8] {
         var compDesc = [Int8]()
         _setup(unitFlags, field: .era, type: "G", compDesc: &compDesc)
         _setup(unitFlags, field: .year, type: "y", compDesc: &compDesc)
         _setup(unitFlags, field: .quarter, type: "Q", compDesc: &compDesc)
         _setup(unitFlags, field: .month, type: "M", compDesc: &compDesc)
-        _setup(unitFlags, field: .month, type: "l", compDesc: &compDesc)
+        if addIsLeapMonth {
+            _setup(unitFlags, field: .month, type: "l", compDesc: &compDesc)
+        }
         _setup(unitFlags, field: .day, type: "d", compDesc: &compDesc)
         _setup(unitFlags, field: .weekOfYear, type: "w", compDesc: &compDesc)
         _setup(unitFlags, field: .weekOfMonth, type: "W", compDesc: &compDesc)
@@ -527,14 +529,16 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    private func _components(_ unitFlags: Unit, vector: [Int32]) -> DateComponents {
+    private func _components(_ unitFlags: Unit, vector: [Int32], addIsLeapMonth: Bool = true) -> DateComponents {
         var compIdx = 0
         var comps = DateComponents()
         _setComp(unitFlags, field: .era, vector: vector, compIndex: &compIdx) { comps.era = Int($0) }
         _setComp(unitFlags, field: .year, vector: vector, compIndex: &compIdx) { comps.year = Int($0) }
         _setComp(unitFlags, field: .quarter, vector: vector, compIndex: &compIdx) { comps.quarter = Int($0) }
         _setComp(unitFlags, field: .month, vector: vector, compIndex: &compIdx) { comps.month = Int($0) }
-        _setComp(unitFlags, field: .month, vector: vector, compIndex: &compIdx) { comps.isLeapMonth = $0 != 0 }
+        if addIsLeapMonth {
+            _setComp(unitFlags, field: .month, vector: vector, compIndex: &compIdx) { comps.isLeapMonth = $0 != 0 }
+        }
         _setComp(unitFlags, field: .day, vector: vector, compIndex: &compIdx) { comps.day = Int($0) }
         _setComp(unitFlags, field: .weekOfYear, vector: vector, compIndex: &compIdx) { comps.weekOfYear = Int($0) }
         _setComp(unitFlags, field: .weekOfMonth, vector: vector, compIndex: &compIdx) { comps.weekOfMonth = Int($0) }
@@ -599,7 +603,7 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     }
     
     open func components(_ unitFlags: Unit, from startingDate: Date, to resultDate: Date, options opts: Options = []) -> DateComponents {
-        let compDesc = _setup(unitFlags)
+        let compDesc = _setup(unitFlags, addIsLeapMonth: false)
         var ints = [Int32](repeating: 0, count: 20)
         let res = ints.withUnsafeMutableBufferPointer { (intArrayBuffer: inout UnsafeMutableBufferPointer<Int32>) -> Bool in
             var vector: [UnsafeMutablePointer<Int32>] = (0..<20).map { idx in
@@ -612,7 +616,7 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
             }
         }
         if res {
-            return _components(unitFlags, vector: ints)
+            return _components(unitFlags, vector: ints, addIsLeapMonth: false)
         }
         fatalError()
     }

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -457,11 +457,11 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         } else {
             // _convert(comps.week, type: "^", vector: &vector, compDesc: &compDesc)
         }
+        _convert(comps.month, type: "M", vector: &vector, compDesc: &compDesc)
         _convert(comps.weekOfMonth, type: "W", vector: &vector, compDesc: &compDesc)
         _convert(comps.yearForWeekOfYear, type: "Y", vector: &vector, compDesc: &compDesc)
         _convert(comps.weekday, type: "E", vector: &vector, compDesc: &compDesc)
         _convert(comps.weekdayOrdinal, type: "F", vector: &vector, compDesc: &compDesc)
-        _convert(comps.month, type: "M", vector: &vector, compDesc: &compDesc)
         _convert(comps.isLeapMonth, type: "l", vector: &vector, compDesc: &compDesc)
         _convert(comps.day, type: "d", vector: &vector, compDesc: &compDesc)
         _convert(comps.hour, type: "H", vector: &vector, compDesc: &compDesc)
@@ -502,16 +502,16 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         _setup(unitFlags, field: .era, type: "G", compDesc: &compDesc)
         _setup(unitFlags, field: .year, type: "y", compDesc: &compDesc)
         _setup(unitFlags, field: .quarter, type: "Q", compDesc: &compDesc)
+        _setup(unitFlags, field: .weekOfYear, type: "w", compDesc: &compDesc)
         _setup(unitFlags, field: .month, type: "M", compDesc: &compDesc)
         if addIsLeapMonth {
             _setup(unitFlags, field: .month, type: "l", compDesc: &compDesc)
         }
-        _setup(unitFlags, field: .day, type: "d", compDesc: &compDesc)
-        _setup(unitFlags, field: .weekOfYear, type: "w", compDesc: &compDesc)
         _setup(unitFlags, field: .weekOfMonth, type: "W", compDesc: &compDesc)
         _setup(unitFlags, field: .yearForWeekOfYear, type: "Y", compDesc: &compDesc)
         _setup(unitFlags, field: .weekday, type: "E", compDesc: &compDesc)
         _setup(unitFlags, field: .weekdayOrdinal, type: "F", compDesc: &compDesc)
+        _setup(unitFlags, field: .day, type: "d", compDesc: &compDesc)
         _setup(unitFlags, field: .hour, type: "H", compDesc: &compDesc)
         _setup(unitFlags, field: .minute, type: "m", compDesc: &compDesc)
         _setup(unitFlags, field: .second, type: "s", compDesc: &compDesc)
@@ -522,9 +522,7 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     
     private func _setComp(_ unitFlags: Unit, field: Unit, vector: [Int32], compIndex: inout Int, setter: (Int32) -> Void) {
         if unitFlags.contains(field) {
-            if vector[compIndex] != -1 {
-                setter(vector[compIndex])
-            }
+            setter(vector[compIndex])
             compIndex += 1
         }
     }
@@ -535,16 +533,16 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         _setComp(unitFlags, field: .era, vector: vector, compIndex: &compIdx) { comps.era = Int($0) }
         _setComp(unitFlags, field: .year, vector: vector, compIndex: &compIdx) { comps.year = Int($0) }
         _setComp(unitFlags, field: .quarter, vector: vector, compIndex: &compIdx) { comps.quarter = Int($0) }
+        _setComp(unitFlags, field: .weekOfYear, vector: vector, compIndex: &compIdx) { comps.weekOfYear = Int($0) }
         _setComp(unitFlags, field: .month, vector: vector, compIndex: &compIdx) { comps.month = Int($0) }
         if addIsLeapMonth {
             _setComp(unitFlags, field: .month, vector: vector, compIndex: &compIdx) { comps.isLeapMonth = $0 != 0 }
         }
-        _setComp(unitFlags, field: .day, vector: vector, compIndex: &compIdx) { comps.day = Int($0) }
-        _setComp(unitFlags, field: .weekOfYear, vector: vector, compIndex: &compIdx) { comps.weekOfYear = Int($0) }
         _setComp(unitFlags, field: .weekOfMonth, vector: vector, compIndex: &compIdx) { comps.weekOfMonth = Int($0) }
         _setComp(unitFlags, field: .yearForWeekOfYear, vector: vector, compIndex: &compIdx) { comps.yearForWeekOfYear = Int($0) }
         _setComp(unitFlags, field: .weekday, vector: vector, compIndex: &compIdx) { comps.weekday = Int($0) }
         _setComp(unitFlags, field: .weekdayOrdinal, vector: vector, compIndex: &compIdx) { comps.weekdayOrdinal = Int($0) }
+        _setComp(unitFlags, field: .day, vector: vector, compIndex: &compIdx) { comps.day = Int($0) }
         _setComp(unitFlags, field: .hour, vector: vector, compIndex: &compIdx) { comps.hour = Int($0) }
         _setComp(unitFlags, field: .minute, vector: vector, compIndex: &compIdx) { comps.minute = Int($0) }
         _setComp(unitFlags, field: .second, vector: vector, compIndex: &compIdx) { comps.second = Int($0) }
@@ -603,7 +601,14 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     }
     
     open func components(_ unitFlags: Unit, from startingDate: Date, to resultDate: Date, options opts: Options = []) -> DateComponents {
-        let compDesc = _setup(unitFlags, addIsLeapMonth: false)
+        let validUnitFlags: NSCalendar.Unit = [
+            .era, .year, .month, .day, .hour, .minute, .second, .weekOfYear, .weekOfMonth, .yearForWeekOfYear, .weekday, .weekdayOrdinal ]
+
+        let invalidUnitFlags: NSCalendar.Unit = [ .quarter, .nanosecond, .timeZone, .calendar]
+
+        // Mask off the unsupported fields
+        let newUnitFlags = Unit(rawValue: unitFlags.rawValue & validUnitFlags.rawValue)
+        let compDesc = _setup(newUnitFlags, addIsLeapMonth: false)
         var ints = [Int32](repeating: 0, count: 20)
         let res = ints.withUnsafeMutableBufferPointer { (intArrayBuffer: inout UnsafeMutableBufferPointer<Int32>) -> Bool in
             var vector: [UnsafeMutablePointer<Int32>] = (0..<20).map { idx in
@@ -616,7 +621,19 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
             }
         }
         if res {
-            return _components(unitFlags, vector: ints, addIsLeapMonth: false)
+            let emptyUnitFlags = Unit(rawValue: unitFlags.rawValue & invalidUnitFlags.rawValue)
+            var components = _components(newUnitFlags, vector: ints, addIsLeapMonth: false)
+
+            // nanosecond and quarter always get set to zero if requested in the output
+            if emptyUnitFlags.contains(.nanosecond) {
+                components.nanosecond = 0
+            }
+            if emptyUnitFlags.contains(.quarter) {
+                components.quarter = 0
+            }
+            // isLeapMonth is always set
+            components.isLeapMonth = false
+            return components
         }
         fatalError()
     }

--- a/TestFoundation/TestCalendar.swift
+++ b/TestFoundation/TestCalendar.swift
@@ -199,6 +199,7 @@ class TestNSDateComponents: XCTestCase {
     static var allTests: [(String, (TestNSDateComponents) -> () throws -> Void)] {
         return [
             ("test_copyNSDateComponents", test_copyNSDateComponents),
+            ("test_dateDifferenceComponents", test_dateDifferenceComponents),
         ]
     }
 
@@ -222,5 +223,17 @@ class TestNSDateComponents: XCTestCase {
         components.hour = 12
         XCTAssertEqual(components.hour, 12)
         XCTAssertEqual(copy.hour, 14)
+    }
+
+    func test_dateDifferenceComponents() {
+        let date1 = Date(timeIntervalSince1970: 0)
+
+        // 1971-06-21
+        let date2 = Date(timeIntervalSince1970:  46310400)
+        let difference = Calendar.current.dateComponents([.month, .year, .day], from: date1, to: date2)
+        XCTAssertEqual(difference.year, 1)
+        XCTAssertEqual(difference.month, 5)
+        XCTAssertEqual(difference.day, 20)
+
     }
 }

--- a/TestFoundation/TestCalendar.swift
+++ b/TestFoundation/TestCalendar.swift
@@ -226,14 +226,91 @@ class TestNSDateComponents: XCTestCase {
     }
 
     func test_dateDifferenceComponents() {
+        // 1970-01-01 00:00:00
         let date1 = Date(timeIntervalSince1970: 0)
 
-        // 1971-06-21
-        let date2 = Date(timeIntervalSince1970:  46310400)
-        let difference = Calendar.current.dateComponents([.month, .year, .day], from: date1, to: date2)
-        XCTAssertEqual(difference.year, 1)
-        XCTAssertEqual(difference.month, 5)
-        XCTAssertEqual(difference.day, 20)
+        // 1971-06-21 00:00:00
+        let date2 = Date(timeIntervalSince1970: 46310400)
 
+        // 2286-11-20 17:46:40
+        let date3 = Date(timeIntervalSince1970: 10_000_000_000)
+
+        // 2286-11-20 17:46:41
+        let date4 = Date(timeIntervalSince1970: 10_000_000_001)
+
+        let diff1 = Calendar.current.dateComponents([.month, .year, .day], from: date1, to: date2)
+        XCTAssertEqual(diff1.year, 1)
+        XCTAssertEqual(diff1.month, 5)
+        XCTAssertEqual(diff1.isLeapMonth, false)
+        XCTAssertEqual(diff1.day, 20)
+        XCTAssertNil(diff1.era)
+        XCTAssertNil(diff1.yearForWeekOfYear)
+        XCTAssertNil(diff1.quarter)
+        XCTAssertNil(diff1.weekOfYear)
+        XCTAssertNil(diff1.weekOfMonth)
+        XCTAssertNil(diff1.weekdayOrdinal)
+        XCTAssertNil(diff1.weekday)
+        XCTAssertNil(diff1.hour)
+        XCTAssertNil(diff1.minute)
+        XCTAssertNil(diff1.second)
+        XCTAssertNil(diff1.nanosecond)
+        XCTAssertNil(diff1.calendar)
+        XCTAssertNil(diff1.timeZone)
+
+        let diff2 = Calendar.current.dateComponents([.weekOfMonth], from: date2, to: date1)
+        XCTAssertEqual(diff2.weekOfMonth, -76)
+        XCTAssertEqual(diff2.isLeapMonth, false)
+
+        let diff3 = Calendar.current.dateComponents([.weekday], from: date2, to: date1)
+        XCTAssertEqual(diff3.weekday, -536)
+        XCTAssertEqual(diff3.isLeapMonth, false)
+
+        let diff4 = Calendar.current.dateComponents([.weekday, .weekOfMonth], from: date1, to: date2)
+        XCTAssertEqual(diff4.weekday, 4)
+        XCTAssertEqual(diff4.weekOfMonth, 76)
+        XCTAssertEqual(diff4.isLeapMonth, false)
+
+        let diff5 = Calendar.current.dateComponents([.weekday, .weekOfYear], from: date1, to: date2)
+        XCTAssertEqual(diff5.weekday, 4)
+        XCTAssertEqual(diff5.weekOfYear, 76)
+        XCTAssertEqual(diff5.isLeapMonth, false)
+
+        let diff6 = Calendar.current.dateComponents([.month, .weekOfMonth], from: date1, to: date2)
+        XCTAssertEqual(diff6.month, 17)
+        XCTAssertEqual(diff6.weekOfMonth, 2)
+        XCTAssertEqual(diff6.isLeapMonth, false)
+
+        let diff7 = Calendar.current.dateComponents([.weekOfYear, .weekOfMonth], from: date2, to: date1)
+        XCTAssertEqual(diff7.weekOfYear, -76)
+        XCTAssertEqual(diff7.weekOfMonth, 0)
+        XCTAssertEqual(diff7.isLeapMonth, false)
+
+        let diff8 = Calendar.current.dateComponents([.era, .quarter, .year, .month, .day, .hour, .minute, .second, .nanosecond, .calendar, .timeZone], from: date2, to: date3)
+        XCTAssertEqual(diff8.era, 0)
+        XCTAssertEqual(diff8.year, 315)
+        XCTAssertEqual(diff8.quarter, 0)
+        XCTAssertEqual(diff8.month, 4)
+        XCTAssertEqual(diff8.day, 30)
+        XCTAssertEqual(diff8.hour, 17)
+        XCTAssertEqual(diff8.minute, 46)
+        XCTAssertEqual(diff8.second, 40)
+        XCTAssertEqual(diff8.nanosecond, 0)
+        XCTAssertEqual(diff8.isLeapMonth, false)
+        XCTAssertNil(diff8.calendar)
+        XCTAssertNil(diff8.timeZone)
+
+        let diff9 = Calendar.current.dateComponents([.era, .quarter, .year, .month, .day, .hour, .minute, .second, .nanosecond, .calendar, .timeZone], from: date4, to: date3)
+        XCTAssertEqual(diff9.era, 0)
+        XCTAssertEqual(diff9.year, 0)
+        XCTAssertEqual(diff9.quarter, 0)
+        XCTAssertEqual(diff9.month, 0)
+        XCTAssertEqual(diff9.day, 0)
+        XCTAssertEqual(diff9.hour, 0)
+        XCTAssertEqual(diff9.minute, 0)
+        XCTAssertEqual(diff9.second, -1)
+        XCTAssertEqual(diff9.nanosecond, 0)
+        XCTAssertEqual(diff9.isLeapMonth, false)
+        XCTAssertNil(diff9.calendar)
+        XCTAssertNil(diff9.timeZone)
     }
 }


### PR DESCRIPTION
- _CFCalendarGetComponentDifferenceV() doesn't support a component
  character of 'l' (leap year) as it make no sense for the difference between two dates.
    
- Dont add 'l' to the component string or parse the result into the .isLeapMonth property when called
   from NSCalendar.components(_:from:to:options)

- _CFCalendarGetComponentDifferenceV: Add validation of datetime
  format character and bounds check multiple_table array lookup.
    
- Allow -1 as a component value.
    
- Reorder datetime fields from largest to smallest when creating
   datetime format and constructing components from response.
    
- Add tests validated against Darwin's Foundation.

master PR #1658