### PR TITLE
[4.2] SR-7570: Initializing XMLDocument crashes on Linux with nodePreserveAll

### DIFF
--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -909,7 +909,7 @@ _CFXMLNodePtr _CFXMLNodeHasProp(_CFXMLNodePtr node, const char* propertyName) {
     return xmlHasProp(node, (const xmlChar*)propertyName);
 }
 
-_CFXMLDocPtr _CFXMLDocPtrFromDataWithOptions(CFDataRef data, int options) {
+_CFXMLDocPtr _CFXMLDocPtrFromDataWithOptions(CFDataRef data, unsigned int options) {
     uint32_t xmlOptions = 0;
 
     if ((options & _kCFXMLNodePreserveWhitespace) == 0) {

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.h
@@ -199,7 +199,7 @@ CFStringRef _Nullable _CFXMLCopyPathForNode(_CFXMLNodePtr node);
 
 _CFXMLNodePtr _Nullable _CFXMLNodeHasProp(_CFXMLNodePtr node, const char* propertyName);
 
-_CFXMLDocPtr _CFXMLDocPtrFromDataWithOptions(CFDataRef data, int options);
+_CFXMLDocPtr _CFXMLDocPtrFromDataWithOptions(CFDataRef data, unsigned int options);
 
 CFStringRef _Nullable _CFXMLNodeCopyLocalName(_CFXMLNodePtr node);
 CFStringRef _Nullable _CFXMLNodeCopyPrefix(_CFXMLNodePtr node);

--- a/Foundation/XMLDocument.swift
+++ b/Foundation/XMLDocument.swift
@@ -92,7 +92,7 @@ open class XMLDocument : XMLNode {
         @abstract Returns a document created from data. Parse errors are returned in <tt>error</tt>.
     */
     public init(data: Data, options mask: XMLNode.Options = []) throws {
-        let docPtr = _CFXMLDocPtrFromDataWithOptions(data._cfObject, Int32(mask.rawValue))
+        let docPtr = _CFXMLDocPtrFromDataWithOptions(data._cfObject, UInt32(mask.rawValue))
         super.init(ptr: _CFXMLNodePtr(docPtr))
 
         if mask.contains(.documentValidate) {

--- a/TestFoundation/TestXMLDocument.swift
+++ b/TestFoundation/TestXMLDocument.swift
@@ -33,6 +33,7 @@ class TestXMLDocument : LoopbackServerTest {
             ("test_createElement", test_createElement),
             ("test_addNamespace", test_addNamespace),
             ("test_removeNamespace", test_removeNamespace),
+            ("test_optionPreserveAll", test_optionPreserveAll),
         ]
     }
 
@@ -509,6 +510,22 @@ class TestXMLDocument : LoopbackServerTest {
         XCTAssert(node?.localName == "prop")
         
         XCTAssert(doc.rootElement()?.elements(forLocalName: "prop", uri: "DAV:").first?.name == "D:prop", "failed to get elements, got \(doc.rootElement()?.elements(forLocalName: "prop", uri: "DAV:").first as Any)")
+    }
+
+    func test_optionPreserveAll() {
+        let xmlString = """
+<?xml version="1.0" encoding="UTF-8"?>
+<document>
+</document>
+"""
+
+        let data = xmlString.data(using: .utf8)!
+        guard let document = try? XMLDocument(data: data, options: .nodePreserveAll) else {
+            XCTFail("XMLDocument with options .nodePreserveAll")
+            return
+        }
+        let expected = xmlString.lowercased() + "\n"
+        XCTAssertEqual(expected, String(describing: document))
     }
 }
 


### PR DESCRIPTION
- Converting the options to an Int32 caused an overflow, so make
  _CFXMLDocPtrFromDataWithOptions() take the options as an
  unsigned int instead.

(cherry picked from commit fb6c82ee3eb5ce97e1b96afcee770bc48b2fba8b)