### PR TITLE
Supported FileHandle API for Swift

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -2889,7 +2889,7 @@
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -2963,7 +2963,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -3072,7 +3072,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -3097,7 +3097,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.swift.TestFoundation;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -9,6 +9,18 @@
 
 import CoreFoundation
 
+// FileHandle has a .read(upToCount:) method. Just invoking read() will cause an ambiguity warning. Use _read instead.
+// Same with close()/.close().
+#if canImport(Darwin)
+import Darwin
+fileprivate let _read = Darwin.read(_:_:_:)
+fileprivate let _close = Darwin.close(_:)
+#elseif canImport(Glibc)
+import Glibc
+fileprivate let _read = Glibc.read(_:_:_:)
+fileprivate let _close = Glibc.close(_:)
+#endif
+
 open class FileHandle : NSObject, NSSecureCoding {
 #if os(Windows)
     private var _handle: HANDLE
@@ -55,24 +67,10 @@ open class FileHandle : NSObject, NSSecureCoding {
         }
     }
     
-    open func readDataToEndOfFile() -> Data {
-        _checkFileHandle()
-        return readData(ofLength: Int.max)
-    }
-
-    open func readData(ofLength length: Int) -> Data {
-        _checkFileHandle()
-        do {
-            let readResult = try _readDataOfLength(length, untilEOF: true)
-            return readResult.toData()
-        } catch {
-            fatalError("\(error)")
-        }
-    }
-
     internal func _readDataOfLength(_ length: Int, untilEOF: Bool, options: NSData.ReadingOptions = []) throws -> NSData.NSDataReadResult {
+        guard _isPlatformHandleValid else { throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileReadUnknown.rawValue) }
+        
 #if os(Windows)
-
         if length == 0 && !untilEOF {
           // Nothing requested, return empty response
           return NSData.NSDataReadResult(bytes: nil, length: 0, deallocator: nil)
@@ -80,8 +78,7 @@ open class FileHandle : NSObject, NSSecureCoding {
 
         var fiFileInfo: BY_HANDLE_FILE_INFORMATION = BY_HANDLE_FILE_INFORMATION()
         if GetFileInformationByHandle(_handle, &fiFileInfo) == FALSE {
-          throw NSError(domain: NSPOSIXErrorDomain, code: Int(GetLastError()),
-                        userInfo: nil)
+            throw _NSErrorWithWindowsError(GetLastError(), reading: true)
         }
 
         if fiFileInfo.dwFileAttributes & DWORD(FILE_ATTRIBUTE_NORMAL) == FILE_ATTRIBUTE_NORMAL {
@@ -125,7 +122,7 @@ open class FileHandle : NSObject, NSSecureCoding {
           var BytesRead: DWORD = 0
           if ReadFile(_handle, buffer.advanced(by: total), BytesToRead, &BytesRead, nil) == FALSE {
             free(buffer)
-            throw NSError(domain: NSPOSIXErrorDomain, code: Int(GetLastError()), userInfo: nil)
+            throw _NSErrorWithWindowsError(GetLastError(), reading: true)
           }
           total += Int(BytesRead)
           if BytesRead == 0 || !untilEOF {
@@ -151,7 +148,7 @@ open class FileHandle : NSObject, NSSecureCoding {
 
         var statbuf = stat()
         if fstat(_fd, &statbuf) < 0 {
-            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: nil)
+            throw _NSErrorWithErrno(errno, reading: true)
         }
 
         let readBlockSize: Int
@@ -190,10 +187,10 @@ open class FileHandle : NSObject, NSSecureCoding {
                 currentAllocationSize *= 2
                 dynamicBuffer = _CFReallocf(dynamicBuffer, currentAllocationSize)
             }
-            let amtRead = read(_fd, dynamicBuffer.advanced(by: total), amountToRead)
+            let amtRead = _read(_fd, dynamicBuffer.advanced(by: total), amountToRead)
             if amtRead < 0 {
                 free(dynamicBuffer)
-                throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: nil)
+                throw _NSErrorWithErrno(errno, reading: true)
             }
             total += amtRead
             if amtRead == 0 || !untilEOF { // If there is nothing more to read or we shouldnt keep reading then exit
@@ -209,115 +206,6 @@ open class FileHandle : NSObject, NSSecureCoding {
         let bytePtr = dynamicBuffer.bindMemory(to: UInt8.self, capacity: total)
         return NSData.NSDataReadResult(bytes: bytePtr, length: total) { buffer, length in
             free(buffer)
-        }
-#endif
-    }
-
-    open func write(_ data: Data) {
-        _checkFileHandle()
-#if os(Windows)
-      data.enumerateBytes() { (bytes, range, stop) in
-        do {
-          try NSData.write(toHandle: self._handle, path: nil,
-                           buf: UnsafeRawPointer(bytes.baseAddress!),
-                           length: bytes.count)
-        } catch {
-          fatalError("Write failure")
-        }
-      }
-#else
-        data.enumerateBytes() { (bytes, range, stop) in
-            do {
-                try NSData.write(toFileDescriptor: self._fd, path: nil, buf: UnsafeRawPointer(bytes.baseAddress!), length: bytes.count)
-            } catch {
-                fatalError("Write failure")
-            }
-        }
-#endif
-    }
-
-    // TODO: Error handling.
-
-    open var offsetInFile: UInt64 {
-        _checkFileHandle()
-#if os(Windows)
-        var liPointer: LARGE_INTEGER = LARGE_INTEGER(QuadPart: 0)
-        if SetFilePointerEx(_handle, LARGE_INTEGER(QuadPart: 0),
-                            &liPointer, DWORD(FILE_CURRENT)) == FALSE {
-          fatalError("SetFilePointerEx failed")
-        }
-        return UInt64(liPointer.QuadPart)
-#else
-        return UInt64(lseek(_fd, 0, SEEK_CUR))
-#endif
-    }
-
-    @discardableResult
-    open func seekToEndOfFile() -> UInt64 {
-        _checkFileHandle()
-#if os(Windows)
-        var liPointer: LARGE_INTEGER = LARGE_INTEGER(QuadPart: 0)
-        if SetFilePointerEx(_handle, LARGE_INTEGER(QuadPart: 0),
-                            &liPointer, DWORD(FILE_END)) == FALSE {
-          fatalError("SetFilePointerEx failed")
-        }
-        return UInt64(liPointer.QuadPart)
-#else
-        return UInt64(lseek(_fd, 0, SEEK_END))
-#endif
-    }
-
-    open func seek(toFileOffset offset: UInt64) {
-        _checkFileHandle()
-#if os(Windows)
-        if SetFilePointerEx(_handle, LARGE_INTEGER(QuadPart: LONGLONG(offset)),
-                            nil, DWORD(FILE_BEGIN)) == FALSE {
-          fatalError("SetFilePointerEx failed")
-        }
-#else
-        lseek(_fd, off_t(offset), SEEK_SET)
-#endif
-    }
-
-    open func truncateFile(atOffset offset: UInt64) {
-        _checkFileHandle()
-#if os(Windows)
-        if SetFilePointerEx(_handle, LARGE_INTEGER(QuadPart: LONGLONG(offset)),
-                            nil, DWORD(FILE_BEGIN)) == FALSE {
-          fatalError("SetFilePointerEx failed")
-        }
-        if SetEndOfFile(_handle) == FALSE {
-          fatalError("SetEndOfFile failed")
-        }
-#else
-        if lseek(_fd, off_t(offset), SEEK_SET) < 0 { fatalError("lseek() failed.") }
-        if ftruncate(_fd, off_t(offset)) < 0 { fatalError("ftruncate() failed.") }
-#endif
-    }
-
-    open func synchronizeFile() {
-        _checkFileHandle()
-#if os(Windows)
-        if FlushFileBuffers(_handle) == FALSE {
-          fatalError("FlushFileBuffers failed: \(GetLastError())")
-        }
-#else
-        fsync(_fd)
-#endif
-    }
-
-    open func closeFile() {
-#if os(Windows)
-        if _handle != INVALID_HANDLE_VALUE {
-          if CloseHandle(_handle) == FALSE {
-            fatalError("CloseHandle failed")
-          }
-          _handle = INVALID_HANDLE_VALUE
-        }
-#else
-        if _fd >= 0 {
-            close(_fd)
-            _fd = -1
         }
 #endif
     }
@@ -378,20 +266,7 @@ open class FileHandle : NSObject, NSSecureCoding {
 #endif
 
     deinit {
-      guard _closeOnDealloc == true else { return }
-#if os(Windows)
-        if _handle != INVALID_HANDLE_VALUE {
-          if CloseHandle(_handle) == FALSE {
-            fatalError("CloseHandle failed")
-          }
-          _handle = INVALID_HANDLE_VALUE
-        }
-#else
-        if _fd >= 0 {
-            close(_fd)
-            _fd = -1
-        }
-#endif
+      try? self.close()
     }
 
     public required init?(coder: NSCoder) {
@@ -404,6 +279,213 @@ open class FileHandle : NSObject, NSSecureCoding {
     
     public static var supportsSecureCoding: Bool {
         return true
+    }
+    
+    private var _isPlatformHandleValid: Bool {
+        #if os(Windows)
+        return _handle != INVALID_HANDLE_VALUE
+        #else
+        return fileDescriptor >= 0
+        #endif
+    }
+
+    // MARK: -
+    // MARK: New API.
+    
+    @available(swift 5.0)
+    public func readToEnd() throws -> Data? {
+        return try read(upToCount: Int.max)
+    }
+    
+    @available(swift 5.0)
+    public func read(upToCount count: Int) throws -> Data? {
+        let result = try _readDataOfLength(count, untilEOF: true)
+        return result.length == 0 ? nil : result.toData()
+    }
+    
+    @available(swift 5.0)
+    public func write<T: DataProtocol>(contentsOf data: T) throws {
+        guard _isPlatformHandleValid else { throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileWriteUnknown.rawValue) }
+        
+        for region in data.regions {
+            try region.withUnsafeBytes { (bytes) in
+                #if os(Windows)
+                try NSData.write(toHandle: self._handle, path: nil,
+                                 buf: UnsafeRawPointer(bytes.baseAddress!),
+                                 length: bytes.count)
+                #else
+                try NSData.write(toFileDescriptor: self._fd, path: nil, buf: UnsafeRawPointer(bytes.baseAddress!), length: bytes.count)
+                #endif
+            }
+        }
+    }
+    
+    @available(swift 5.0)
+    public func offset() throws -> UInt64 {
+        guard _isPlatformHandleValid else { throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileReadUnknown.rawValue) }
+
+        #if os(Windows)
+        var liPointer: LARGE_INTEGER = LARGE_INTEGER(QuadPart: 0)
+        guard SetFilePointerEx(_handle, LARGE_INTEGER(QuadPart: 0), &liPointer, DWORD(FILE_CURRENT)) != FALSE else {
+            throw _NSErrorWithWindowsError(GetLastError(), reading: true)
+        }
+        return UInt64(liPointer.QuadPart)
+        #else
+        let offset = lseek(_fd, 0, SEEK_CUR)
+        guard offset >= 0 else { throw _NSErrorWithErrno(errno, reading: true) }
+        return UInt64(offset)
+        #endif
+    }
+    
+    @available(swift 5.0)
+    @discardableResult
+    public func seekToEnd() throws -> UInt64 {
+        guard _isPlatformHandleValid else { throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileReadUnknown.rawValue) }
+
+        #if os(Windows)
+        var liPointer: LARGE_INTEGER = LARGE_INTEGER(QuadPart: 0)
+        guard SetFilePointerEx(_handle, LARGE_INTEGER(QuadPart: 0), &liPointer, DWORD(FILE_END)) != FALSE else {
+            throw _NSErrorWithWindowsError(GetLastError(), reading: true)
+        }
+        return UInt64(liPointer.QuadPart)
+        #else
+        let offset = lseek(_fd, 0, SEEK_END)
+        guard offset >= 0 else { throw _NSErrorWithErrno(errno, reading: true) }
+        return UInt64(offset)
+        #endif
+    }
+    
+    @available(swift 5.0)
+    public func seek(toOffset offset: UInt64) throws {
+        guard _isPlatformHandleValid else { throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileReadUnknown.rawValue) }
+
+        #if os(Windows)
+        guard SetFilePointerEx(_handle, LARGE_INTEGER(QuadPart: LONGLONG(offset)), nil, DWORD(FILE_BEGIN)) != FALSE else {
+            throw _NSErrorWithWindowsError(GetLastError(), reading: true)
+        }
+        #else
+        guard lseek(_fd, off_t(offset), SEEK_SET) >= 0 else { throw _NSErrorWithErrno(errno, reading: true) }
+        #endif
+    }
+    
+    @available(swift 5.0)
+    public func truncate(toOffset offset: UInt64) throws {
+        guard _isPlatformHandleValid else { throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileWriteUnknown.rawValue) }
+
+        #if os(Windows)
+        guard SetFilePointerEx(_handle, LARGE_INTEGER(QuadPart: LONGLONG(offset)),
+                            nil, DWORD(FILE_BEGIN)) != FALSE else {
+            throw _NSErrorWithWindowsError(GetLastError(), reading: false)
+        }
+        guard SetEndOfFile(_handle) != FALSE else {
+            throw _NSErrorWithWindowsError(GetLastError(), reading: false)
+        }
+        #else
+        guard lseek(_fd, off_t(offset), SEEK_SET) >= 0 else { throw _NSErrorWithErrno(errno, reading: false) }
+        guard ftruncate(_fd, off_t(offset)) >= 0 else { throw _NSErrorWithErrno(errno, reading: false) }
+        #endif
+    }
+    
+    @available(swift 5.0)
+    public func synchronize() throws {
+        #if os(Windows)
+        guard FlushFileBuffers(_handle) != FALSE else {
+            throw _NSErrorWithWindowsError(GetLastError(), reading: false)
+        }
+        #else
+        guard fsync(_fd) >= 0 else { throw _NSErrorWithErrno(errno, reading: false) }
+        #endif
+    }
+    
+    @available(swift 5.0)
+    public func close() throws {
+        #if os(Windows)
+        if _handle != INVALID_HANDLE_VALUE {
+            guard CloseHandle(_handle) != FALSE else {
+                throw _NSErrorWithWindowsError(GetLastError(), reading: true)
+            }
+            _handle = INVALID_HANDLE_VALUE
+        }
+        #else
+        if _fd >= 0 {
+            guard _close(_fd) >= 0 else { throw _NSErrorWithErrno(errno, reading: true) }
+            _fd = -1
+        }
+        #endif
+    }
+    
+    // MARK: -
+    // MARK: To-be-deprecated API.
+    
+    // This matches the effect of API_TO_BE_DEPRECATED in ObjC headers:
+    @available(swift, deprecated: 100000, renamed: "readToEnd()")
+    open func readDataToEndOfFile() -> Data {
+        return try! readToEnd() ?? Data()
+    }
+    
+    @available(swift, deprecated: 100000, renamed: "read(upToCount:)")
+    open func readData(ofLength length: Int) -> Data {
+        return try! read(upToCount: length) ?? Data()
+    }
+    
+    @available(swift, deprecated: 100000, renamed: "write(contentsOf:)")
+    open func write(_ data: Data) {
+        #if os(Windows)
+        precondition(_handle != INVALID_HANDLE_VALUE, "invalid file handle")
+        for region in data.regions {
+            region.withUnsafeBytes { (bytes) in
+                do {
+                    try NSData.write(toHandle: self._handle, path: nil,
+                                     buf: UnsafeRawPointer(bytes.baseAddress!),
+                                     length: bytes.count)
+                } catch {
+                    fatalError("Write failure")
+                }
+            }
+        }
+        #else
+        guard _fd >= 0 else { return }
+        for region in data.regions {
+            region.withUnsafeBytes { (bytes) in
+                do {
+                    try NSData.write(toFileDescriptor: self._fd, path: nil, buf: UnsafeRawPointer(bytes.baseAddress!), length: bytes.count)
+                } catch {
+                    fatalError("Write failure")
+                }
+            }
+        }
+        #endif
+    }
+    
+    @available(swift, deprecated: 100000, renamed: "offset()")
+    open var offsetInFile: UInt64 {
+        return try! offset()
+    }
+    
+    @available(swift, deprecated: 100000, renamed: "seekToEnd()")
+    @discardableResult
+    open func seekToEndOfFile() -> UInt64 {
+        return try! seekToEnd()
+    }
+    
+    @available(swift, deprecated: 100000, renamed: "seek(toOffset:)")
+    open func seek(toFileOffset offset: UInt64) {
+        try! seek(toOffset: offset)
+    }
+    
+    @available(swift, deprecated: 100000, renamed: "truncate(toOffset:)")
+    open func truncateFile(atOffset offset: UInt64) {
+        try! truncate(toOffset: offset)
+    }
+    
+    @available(swift, deprecated: 100000, renamed: "synchronize()")
+    open func synchronizeFile() {
+        try! synchronize()
+    }
+    
+    @available(swift, deprecated: 100000, renamed: "close()")
+    open func closeFile() {
+        try! self.close()
     }
 }
 
@@ -604,3 +686,4 @@ open class Pipe: NSObject {
         super.init()
     }
 }
+

--- a/Foundation/FoundationErrors.swift
+++ b/Foundation/FoundationErrors.swift
@@ -197,5 +197,21 @@ internal func _NSErrorWithErrno(_ posixErrno : Int32, reading : Bool, path : Str
         userInfo[NSURLErrorKey] = url
     }
     
+    userInfo[NSUnderlyingErrorKey] = NSError(domain: NSPOSIXErrorDomain, code: Int(posixErrno))
+    
     return NSError(domain: NSCocoaErrorDomain, code: cocoaError.rawValue, userInfo: userInfo)
 }
+
+#if os(Windows)
+// The codes in this domain are codes returned by GetLastError in the Windows SDK (in WinError.h):
+// https://docs.microsoft.com/en-us/windows/desktop/Debug/system-error-codes
+internal let _NSWindowsErrorDomain = "org.swift.Foundation.WindowsError"
+
+internal func _NSErrorWithWindowsError(_ windowsError: Int32, reading: Bool) -> NSError {
+    // <#TODO#> os(Windows): Map Win32 errors to Cocoa errors as _NSErrorWithErrno() does.
+    let code: CocoaError.Code = reading ? .fileReadUnknown : .fileWriteUnknown
+    return NSError(domain: NSCocoaErrorDomain, code: code.rawValue, userInfo: [
+        NSUnderlyingErrorKey: NSError(domain: _NSWindowsErrorDomain, code: Int(windowsError))
+    ])
+}
+#endif

--- a/TestFoundation/TestPipe.swift
+++ b/TestFoundation/TestPipe.swift
@@ -35,20 +35,19 @@ class TestPipe: XCTestCase {
         pipes = []
     }
 
-    func test_Pipe() {
+    func test_Pipe() throws {
         let aPipe = Pipe()
         let text = "test-pipe"
         
         // First write some data into the pipe
-        let stringAsData = text.data(using: .utf8)
-        XCTAssertNotNil(stringAsData)
-        aPipe.fileHandleForWriting.write(stringAsData!)
+        let stringAsData = try text.data(using: .utf8).unwrapped()
+        try aPipe.fileHandleForWriting.write(contentsOf: stringAsData)
         
         // Then read it out again
-        let data = aPipe.fileHandleForReading.readData(ofLength: text.count)
+        let data = try aPipe.fileHandleForReading.read(upToCount: stringAsData.count).unwrapped()
         
         // Confirm that we did read data
-        XCTAssertEqual(data.count, stringAsData?.count, "Expected to read \(String(describing:stringAsData?.count)) from pipe but read \(data.count) instead")
+        XCTAssertEqual(data.count, stringAsData.count, "Expected to read \(String(describing:stringAsData.count)) from pipe but read \(data.count) instead")
         
         // Confirm the data can be converted to a String
         let convertedData = String(data: data, encoding: .utf8)


### PR DESCRIPTION
Adds API to FileHandle that allows clients to catch and handle errors, rather than panic with `fatalError` on I/O issues. This API will be supported going forward and is not experimental.