### PR TITLE
[4.2] NSIndexPath: Make compatible with Darwin.

### DIFF
--- a/Foundation/NSIndexPath.swift
+++ b/Foundation/NSIndexPath.swift
@@ -1,21 +1,27 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2016, 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
 
 open class NSIndexPath : NSObject, NSCopying, NSSecureCoding {
     
-    internal var _indexes : [Int]
+    private var _indexes : [Int]
+
     override public init() {
         _indexes = []
     }
-    public init(indexes: UnsafePointer<Int>!, length: Int) {
-        _indexes = Array(UnsafeBufferPointer(start: indexes, count: length))
+
+    public init(indexes: UnsafePointer<Int>?, length: Int) {
+        if length == 0 {
+            _indexes = []
+        } else {
+            _indexes = Array(UnsafeBufferPointer(start: indexes!, count: length))
+        }
     }
     
     private init(indexes: [Int]) {
@@ -26,7 +32,10 @@ open class NSIndexPath : NSObject, NSCopying, NSSecureCoding {
         return copy(with: nil)
     }
     
-    open func copy(with zone: NSZone? = nil) -> Any { NSUnimplemented() }
+    open func copy(with zone: NSZone? = nil) -> Any {
+        return self
+    }
+
     public convenience init(index: Int) {
         self.init(indexes: [index])
     }
@@ -44,6 +53,7 @@ open class NSIndexPath : NSObject, NSCopying, NSSecureCoding {
     open func adding(_ index: Int) -> IndexPath {
         return IndexPath(indexes: _indexes + [index])
     }
+
     open func removingLastIndex() -> IndexPath {
         if _indexes.count <= 1 {
             return IndexPath(indexes: [])
@@ -55,6 +65,7 @@ open class NSIndexPath : NSObject, NSCopying, NSSecureCoding {
     open func index(atPosition position: Int) -> Int {
         return _indexes[position]
     }
+
     open var length: Int {
         return _indexes.count
     }
@@ -71,7 +82,12 @@ open class NSIndexPath : NSObject, NSCopying, NSSecureCoding {
             indexes.advanced(by: pos).pointee = idx
         }
     }
-    
+
+    @available(*, unavailable, renamed: "getIndex(_:range:)")
+    open func getIndexes(_ indexes: UnsafeMutablePointer<Int>) {
+        NSUnsupported()
+    }
+
     // comparison support
     // sorting an array of indexPaths using this comparison results in an array representing nodes in depth-first traversal order
     open func compare(_ otherObject: IndexPath) -> ComparisonResult {
@@ -94,10 +110,6 @@ open class NSIndexPath : NSObject, NSCopying, NSSecureCoding {
         }
         return .orderedSame
     }
-}
-
-extension NSIndexPath {
-    open func getIndexes(_ indexes: UnsafeMutablePointer<Int>) { NSUnimplemented() }
 }
 
 

--- a/TestFoundation/TestIndexPath.swift
+++ b/TestFoundation/TestIndexPath.swift
@@ -1,10 +1,10 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2016, 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
 class TestIndexPath: XCTestCase {
@@ -59,12 +59,19 @@ class TestIndexPath: XCTestCase {
             ("test_AnyHashableCreatedFromNSIndexPath", test_AnyHashableCreatedFromNSIndexPath),
             ("test_unconditionallyBridgeFromObjectiveC", test_unconditionallyBridgeFromObjectiveC),
             ("test_slice_1ary", test_slice_1ary),
+            ("test_copy", test_copy)
         ]
     }
 
     func testEmpty() {
         let ip = IndexPath()
         XCTAssertEqual(ip.count, 0)
+
+        // Darwin allows nil if length is 0
+        let nsip = NSIndexPath(indexes: nil, length: 0)
+        XCTAssertEqual(nsip.length, 0)
+        let newIp = nsip.adding(1)
+        XCTAssertEqual(newIp.count, 1)
     }
     
     func testSingleIndex() {
@@ -764,4 +771,12 @@ class TestIndexPath: XCTestCase {
         XCTAssertEqual(0, slice.count)
     }
 
+    func test_copy() {
+        var indexes = [1, 2, 3]
+        let nip1 = NSIndexPath(indexes: &indexes, length: 3)
+        let nip2 = nip1
+        XCTAssertEqual(nip1.length, 3)
+        XCTAssertEqual(nip2.length, 3)
+        XCTAssertEqual(nip1, nip2)
+    }
 }


### PR DESCRIPTION
- init(indexes:length:): Fix method signatue and allow nil pointer
  with 0 length to match Darwin.

- Implement copy(with:)

- Mark getIndex(_:range:) as unavailable (deprecated in Darwin).

(cherry picked from commit c0bac193c3f9abd2c34139acd946bb8fe7fe6581)