### PR TITLE
[4.2] SR-7608: Pipe() crashes when the underlying system call fails.

### DIFF
--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -368,9 +368,9 @@ extension FileHandle {
 }
 
 open class Pipe: NSObject {
-    private let readHandle: FileHandle
-    private let writeHandle: FileHandle
-    
+    open let fileHandleForReading: FileHandle
+    open let fileHandleForWriting: FileHandle
+
     public override init() {
         /// the `pipe` system call creates two `fd` in a malloc'ed area
         var fds = UnsafeMutablePointer<Int32>.allocate(capacity: 2)
@@ -384,19 +384,11 @@ open class Pipe: NSObject {
         /// don't need to add a `deinit` to this class
         
         /// Create the read handle from the first fd in `fds`
-        self.readHandle = FileHandle(fileDescriptor: fds.pointee, closeOnDealloc: true)
+        self.fileHandleForReading = FileHandle(fileDescriptor: fds.pointee, closeOnDealloc: true)
         
         /// Advance `fds` by one to create the write handle from the second fd
-        self.writeHandle = FileHandle(fileDescriptor: fds.successor().pointee, closeOnDealloc: true)
+        self.fileHandleForWriting = FileHandle(fileDescriptor: fds.successor().pointee, closeOnDealloc: true)
         
         super.init()
-    }
-    
-    open var fileHandleForReading: FileHandle {
-        return self.readHandle
-    }
-    
-    open var fileHandleForWriting: FileHandle {
-        return self.writeHandle
     }
 }

--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -1,10 +1,10 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2016, 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
 import CoreFoundation
@@ -16,10 +16,13 @@ import Glibc
 #endif
 
 open class FileHandle : NSObject, NSSecureCoding {
-    internal var _fd: Int32
-    internal var _closeOnDealloc: Bool
-    internal var _closed: Bool = false
-    
+    private var _fd: Int32
+    private var _closeOnDealloc: Bool
+
+    open var fileDescriptor: Int32 {
+        return _fd
+    }
+
     open var availableData: Data {
         return _readDataOfLength(Int.max, untilEOF: false)
     }
@@ -33,10 +36,11 @@ open class FileHandle : NSObject, NSSecureCoding {
     }
 
     internal func _readDataOfLength(_ length: Int, untilEOF: Bool) -> Data {
+        precondition(_fd >= 0, "Bad file descriptor")
         var statbuf = stat()
         var dynamicBuffer: UnsafeMutableRawPointer? = nil
         var total = 0
-        if _closed || fstat(_fd, &statbuf) < 0 {
+        if fstat(_fd, &statbuf) < 0 {
             fatalError("Unable to read file")
         }
         if statbuf.st_mode & S_IFMT != S_IFREG {
@@ -119,6 +123,7 @@ open class FileHandle : NSObject, NSSecureCoding {
     }
     
     open func write(_ data: Data) {
+        precondition(_fd >= 0, "Bad file descriptor")
         data.enumerateBytes() { (bytes, range, stop) in
             do {
                 try NSData.write(toFileDescriptor: self._fd, path: nil, buf: UnsafeRawPointer(bytes.baseAddress!), length: bytes.count)
@@ -131,40 +136,49 @@ open class FileHandle : NSObject, NSSecureCoding {
     // TODO: Error handling.
     
     open var offsetInFile: UInt64 {
+        precondition(_fd >= 0, "Bad file descriptor")
         return UInt64(lseek(_fd, 0, SEEK_CUR))
     }
     
     @discardableResult
     open func seekToEndOfFile() -> UInt64 {
+        precondition(_fd >= 0, "Bad file descriptor")
         return UInt64(lseek(_fd, 0, SEEK_END))
     }
     
     open func seek(toFileOffset offset: UInt64) {
+        precondition(_fd >= 0, "Bad file descriptor")
         lseek(_fd, off_t(offset), SEEK_SET)
     }
     
     open func truncateFile(atOffset offset: UInt64) {
+        precondition(_fd >= 0, "Bad file descriptor")
         if lseek(_fd, off_t(offset), SEEK_SET) == 0 {
             ftruncate(_fd, off_t(offset))
         }
     }
     
     open func synchronizeFile() {
+        precondition(_fd >= 0, "Bad file descriptor")
         fsync(_fd)
     }
     
     open func closeFile() {
-        if !_closed {
+        if _fd >= 0 {
             close(_fd)
-            _closed = true
+            _fd = -1
         }
     }
-    
+
     public init(fileDescriptor fd: Int32, closeOnDealloc closeopt: Bool) {
         _fd = fd
         _closeOnDealloc = closeopt
     }
-    
+
+    public convenience init(fileDescriptor fd: Int32) {
+        self.init(fileDescriptor: fd, closeOnDealloc: false)
+    }
+
     internal init?(path: String, flags: Int32, createMode: Int) {
         _fd = _CFOpenFileWithMode(path, flags, mode_t(createMode))
         _closeOnDealloc = true
@@ -175,8 +189,9 @@ open class FileHandle : NSObject, NSSecureCoding {
     }
     
     deinit {
-        if _fd >= 0 && _closeOnDealloc && !_closed {
+        if _fd >= 0 && _closeOnDealloc {
             close(_fd)
+            _fd = -1
         }
     }
     
@@ -357,38 +372,32 @@ extension FileHandle {
     }
 }
 
-extension FileHandle {
-    public convenience init(fileDescriptor fd: Int32) {
-        self.init(fileDescriptor: fd, closeOnDealloc: false)
-    }
-    
-    open var fileDescriptor: Int32 {
-        return _fd
-    }
-}
-
 open class Pipe: NSObject {
-    open let fileHandleForReading: FileHandle
-    open let fileHandleForWriting: FileHandle
+    public let fileHandleForReading: FileHandle
+    public let fileHandleForWriting: FileHandle
 
     public override init() {
         /// the `pipe` system call creates two `fd` in a malloc'ed area
         var fds = UnsafeMutablePointer<Int32>.allocate(capacity: 2)
         defer {
-            free(fds)
+            fds.deallocate()
         }
         /// If the operating system prevents us from creating file handles, stop
-        guard pipe(fds) == 0 else { fatalError("Could not open pipe file handles") }
-        
-        /// The handles below auto-close when the `NSFileHandle` is deallocated, so we
-        /// don't need to add a `deinit` to this class
-        
-        /// Create the read handle from the first fd in `fds`
-        self.fileHandleForReading = FileHandle(fileDescriptor: fds.pointee, closeOnDealloc: true)
-        
-        /// Advance `fds` by one to create the write handle from the second fd
-        self.fileHandleForWriting = FileHandle(fileDescriptor: fds.successor().pointee, closeOnDealloc: true)
-        
+        let ret = pipe(fds)
+        switch (ret, errno) {
+        case (0, _):
+            self.fileHandleForReading = FileHandle(fileDescriptor: fds.pointee, closeOnDealloc: true)
+            self.fileHandleForWriting = FileHandle(fileDescriptor: fds.successor().pointee, closeOnDealloc: true)
+
+        case (-1, EMFILE), (-1, ENFILE):
+            // Unfortunately this initializer does not throw and isnt failable so this is only
+            // way of handling this situation.
+            self.fileHandleForReading = FileHandle(fileDescriptor: -1, closeOnDealloc: false)
+            self.fileHandleForWriting = FileHandle(fileDescriptor: -1, closeOnDealloc: false)
+
+        default:
+            fatalError("Error calling pipe(): \(errno)")
+        }
         super.init()
     }
 }

--- a/TestFoundation/TestFileHandle.swift
+++ b/TestFoundation/TestFileHandle.swift
@@ -1,17 +1,16 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2016, 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
 class TestFileHandle : XCTestCase {
     static var allTests : [(String, (TestFileHandle) -> () throws -> ())] {
         return [
             ("test_constants", test_constants),
-            ("test_pipe", test_pipe),
             ("test_nullDevice", test_nullDevice),
         ]
     }
@@ -19,23 +18,6 @@ class TestFileHandle : XCTestCase {
     func test_constants() {
         XCTAssertEqual(FileHandle.readCompletionNotification.rawValue, "NSFileHandleReadCompletionNotification",
                        "\(FileHandle.readCompletionNotification.rawValue) is not equal to NSFileHandleReadCompletionNotification")
-    }
-
-    func test_pipe() {
-        let pipe = Pipe()
-        let inputs = ["Hello", "world", "🐶"]
-
-        for input in inputs {
-            let inputData = input.data(using: .utf8)!
-
-            // write onto pipe
-            pipe.fileHandleForWriting.write(inputData)
-
-            let outputData = pipe.fileHandleForReading.availableData
-            let output = String(data: outputData, encoding: .utf8)
-
-            XCTAssertEqual(output, input)
-        }
     }
 
     func test_nullDevice() {

--- a/TestFoundation/TestPipe.swift
+++ b/TestFoundation/TestPipe.swift
@@ -1,21 +1,41 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2016. 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-class TestPipe : XCTestCase {
+class TestPipe: XCTestCase {
     
     static var allTests: [(String, (TestPipe) -> () throws -> Void)] {
         return [
-             ("test_NSPipe", test_NSPipe)
+            ("test_MaxPipes", test_MaxPipes),
+            ("test_Pipe", test_Pipe),
         ]
     }
-    
-    func test_NSPipe() {
+
+    func test_MaxPipes() {
+        // Try and create enough pipes to exhaust the process's limits. 1024 is a reasonable
+        // hard limit for the test. This is reached when testing on Linux (at around 488 pipes)
+        // but not on macOS.
+
+        var pipes: [Pipe] = []
+        let maxPipes = 1024
+        pipes.reserveCapacity(maxPipes)
+        for _ in 1...maxPipes {
+            let pipe = Pipe()
+            if pipe.fileHandleForReading.fileDescriptor == -1 {
+                XCTAssertEqual(pipe.fileHandleForReading.fileDescriptor, pipe.fileHandleForWriting.fileDescriptor)
+                break
+            }
+            pipes.append(pipe)
+        }
+        pipes = []
+    }
+
+    func test_Pipe() {
         let aPipe = Pipe()
         let text = "test-pipe"
         


### PR DESCRIPTION
- Pipe does not have a failable or throwable initializer but currently
   calls fatalError() for all errors returned from pipe().
    
- If pipe() returns EMFILE or ENFILE then set the fileDescriptor
   to -1 for both .fileHandleForReading and .fileHandleForWriting.
   For all other errors call fatalError().
    
- TestFileHandle.swift: Remove duplicate test_pipe().
    
- TestPipe.swift: Add extra test to try and exhaust the process's pipes.
    
- Test the file descriptor is valid and open for certain methods
   and properties to match Darwin.
    
(cherry picked from commit 870d4259c9d6a7f33a0eadc0c0c214f53f9c550d)

NSPipe: make fileHandleFor{Reading,Writing} mutable
    
    In Objective-C, the fileHandleFor{Reading,Writing} property is mutable even on a
    const instance.  Change the property to read/write.
    
(cherry picked from commit 09cfc2105a752b215fc808e2005f080fd5a05758)