### PR TITLE
NSRange: fix init from region RangeExpression in target String

### DIFF
--- a/Foundation/NSRange.swift
+++ b/Foundation/NSRange.swift
@@ -260,11 +260,7 @@ extension NSRange {
     public init<R: RangeExpression, S: StringProtocol>(_ region: R, in target: S)
         where R.Bound == S.Index {
             let r = region.relative(to: target)
-            let u = target.utf16
-            self = NSRange(
-                location: u.distance(from: target.startIndex, to: r.lowerBound),
-                length: u.distance(from: r.lowerBound, to: r.upperBound)
-            )
+            self.init(target._toUTF16Offsets(r))
     }
     
     @available(swift, deprecated: 4, renamed: "Range.init(_:)")

--- a/Foundation/NSRange.swift
+++ b/Foundation/NSRange.swift
@@ -260,9 +260,10 @@ extension NSRange {
     public init<R: RangeExpression, S: StringProtocol>(_ region: R, in target: S)
         where R.Bound == S.Index {
             let r = region.relative(to: target)
+            let u = target.utf16
             self = NSRange(
-                location: r.lowerBound.encodedOffset - target.startIndex.encodedOffset,
-                length: r.upperBound.encodedOffset - r.lowerBound.encodedOffset
+                location: u.distance(from: target.startIndex, to: r.lowerBound),
+                length: u.distance(from: r.lowerBound, to: r.upperBound)
             )
     }
     

--- a/TestFoundation/TestNSRange.swift
+++ b/TestFoundation/TestNSRange.swift
@@ -129,51 +129,52 @@ class TestNSRange : XCTestCase {
         }
     }
     
-    private func _assert<S: StringProtocol, R: RangeExpression>(
+    /// Specialized for the below tests.
+    private func _assertNSRangeInit<S: StringProtocol, R: RangeExpression>(
         _ region: R, in target: S, is rangeString: String
     ) where R.Bound == S.Index {
-        XCTAssertEqual(NSStringFromRange(NSRange(region, in: target)), rangeString)
+        XCTAssert(NSEqualRanges(NSRangeFromString(rangeString), NSRange(region, in: target)))
     }
     
     func test_init_region_in_ascii_string() {
         // all count = 18
         let normalString = "1;DROP TABLE users"
         
-        _assert(normalString.index(normalString.startIndex, offsetBy: 2)..<normalString.index(normalString.endIndex, offsetBy: -6), in: normalString, is: "{2, 10}")
-        _assert(normalString.index(after: normalString.startIndex)...normalString.index(before: normalString.endIndex), in: normalString, is: "{1, 17}")
-        _assert(normalString.startIndex..., in: normalString, is: "{0, 18}")
-        _assert(...normalString.firstIndex(of: " ")!, in: normalString, is: "{0, 7}")
-        _assert(..<normalString.lastIndex(of: " ")!, in: normalString, is: "{0, 12}")
+        _assertNSRangeInit(normalString.index(normalString.startIndex, offsetBy: 2)..<normalString.index(normalString.endIndex, offsetBy: -6), in: normalString, is: "{2, 10}")
+        _assertNSRangeInit(normalString.index(after: normalString.startIndex)...normalString.index(before: normalString.endIndex), in: normalString, is: "{1, 17}")
+        _assertNSRangeInit(normalString.startIndex..., in: normalString, is: "{0, 18}")
+        _assertNSRangeInit(...normalString.firstIndex(of: " ")!, in: normalString, is: "{0, 7}")
+        _assertNSRangeInit(..<normalString.lastIndex(of: " ")!, in: normalString, is: "{0, 12}")
         
         let normalSubstring: Substring = normalString.split(separator: ";")[1]
         
-        _assert(normalSubstring.range(of: "TABLE")!, in: normalSubstring, is: "{5, 5}")
-        _assert(normalSubstring.index(after: normalSubstring.firstIndex(of: " ")!)..<normalSubstring.lastIndex(of: " ")!, in: normalString, is: "{7, 5}")
-        _assert(normalSubstring.firstIndex(of: "u")!...normalSubstring.lastIndex(of: "u")!, in: normalSubstring, is: "{11, 1}")
-        _assert(normalSubstring.startIndex..., in: normalSubstring, is: "{0, 16}")
-        _assert(normalSubstring.startIndex..., in: normalString, is: "{2, 16}")
-        _assert(...normalSubstring.lastIndex(of: " ")!, in: normalSubstring, is: "{0, 11}")
-        _assert(..<normalSubstring.lastIndex(of: " ")!, in: normalString, is: "{0, 12}")
+        _assertNSRangeInit(normalSubstring.range(of: "TABLE")!, in: normalSubstring, is: "{5, 5}")
+        _assertNSRangeInit(normalSubstring.index(after: normalSubstring.firstIndex(of: " ")!)..<normalSubstring.lastIndex(of: " ")!, in: normalString, is: "{7, 5}")
+        _assertNSRangeInit(normalSubstring.firstIndex(of: "u")!...normalSubstring.lastIndex(of: "u")!, in: normalSubstring, is: "{11, 1}")
+        _assertNSRangeInit(normalSubstring.startIndex..., in: normalSubstring, is: "{0, 16}")
+        _assertNSRangeInit(normalSubstring.startIndex..., in: normalString, is: "{2, 16}")
+        _assertNSRangeInit(...normalSubstring.lastIndex(of: " ")!, in: normalSubstring, is: "{0, 11}")
+        _assertNSRangeInit(..<normalSubstring.lastIndex(of: " ")!, in: normalString, is: "{0, 12}")
     }
     
     func test_init_region_in_unicode_string() {
         // count: 46, utf8: 90, utf16: 54
         let unicodeString = "This  is a #naughty👻 string (╯°□°）╯︵ ┻━┻👨‍👩‍👧‍👦)"
         
-        _assert(unicodeString.index(unicodeString.startIndex, offsetBy: 10)..<unicodeString.index(unicodeString.startIndex, offsetBy: 28), in: unicodeString, is: "{10, 19}")
-        _assert(unicodeString.index(after: unicodeString.startIndex)...unicodeString.index(before: unicodeString.endIndex), in: unicodeString, is: "{1, 53}")
-        _assert(unicodeString.startIndex..., in: unicodeString, is: "{0, 54}")
-        _assert(...unicodeString.firstIndex(of: "👻")!, in: unicodeString, is: "{0, 22}")
-        _assert(..<unicodeString.range(of: "👨‍👩‍👧‍👦")!.lowerBound, in: unicodeString, is: "{0, 42}")
+        _assertNSRangeInit(unicodeString.index(unicodeString.startIndex, offsetBy: 10)..<unicodeString.index(unicodeString.startIndex, offsetBy: 28), in: unicodeString, is: "{10, 19}")
+        _assertNSRangeInit(unicodeString.index(after: unicodeString.startIndex)...unicodeString.index(before: unicodeString.endIndex), in: unicodeString, is: "{1, 53}")
+        _assertNSRangeInit(unicodeString.startIndex..., in: unicodeString, is: "{0, 54}")
+        _assertNSRangeInit(...unicodeString.firstIndex(of: "👻")!, in: unicodeString, is: "{0, 22}")
+        _assertNSRangeInit(..<unicodeString.range(of: "👨‍👩‍👧‍👦")!.lowerBound, in: unicodeString, is: "{0, 42}")
         
         let unicodeSubstring: Substring = unicodeString[unicodeString.firstIndex(of: "👻")!...]
         
-        _assert(unicodeSubstring.range(of: "👨‍👩‍👧‍👦")!, in: unicodeSubstring, is: "{22, 11}")
-        _assert(unicodeSubstring.range(of: "👨")!.lowerBound..<unicodeSubstring.range(of: "👦")!.upperBound, in: unicodeString, is: "{42, 11}")
-        _assert(unicodeSubstring.index(after: unicodeSubstring.startIndex)...unicodeSubstring.index(before: unicodeSubstring.endIndex), in: unicodeSubstring, is: "{2, 32}")
-        _assert(unicodeSubstring.startIndex..., in: unicodeSubstring, is: "{0, 34}")
-        _assert(unicodeSubstring.startIndex..., in: unicodeString, is: "{20, 34}")
-        _assert(...unicodeSubstring.firstIndex(of: "╯")!, in: unicodeSubstring, is: "{0, 12}")
-        _assert(..<unicodeSubstring.firstIndex(of: "╯")!, in: unicodeString, is: "{0, 31}")
+        _assertNSRangeInit(unicodeSubstring.range(of: "👨‍👩‍👧‍👦")!, in: unicodeSubstring, is: "{22, 11}")
+        _assertNSRangeInit(unicodeSubstring.range(of: "👨")!.lowerBound..<unicodeSubstring.range(of: "👦")!.upperBound, in: unicodeString, is: "{42, 11}")
+        _assertNSRangeInit(unicodeSubstring.index(after: unicodeSubstring.startIndex)...unicodeSubstring.index(before: unicodeSubstring.endIndex), in: unicodeSubstring, is: "{2, 32}")
+        _assertNSRangeInit(unicodeSubstring.startIndex..., in: unicodeSubstring, is: "{0, 34}")
+        _assertNSRangeInit(unicodeSubstring.startIndex..., in: unicodeString, is: "{20, 34}")
+        _assertNSRangeInit(...unicodeSubstring.firstIndex(of: "╯")!, in: unicodeSubstring, is: "{0, 12}")
+        _assertNSRangeInit(..<unicodeSubstring.firstIndex(of: "╯")!, in: unicodeString, is: "{0, 31}")
     }
 }


### PR DESCRIPTION
Prior to Swift 5, String uses UTF-16 for its Index and encodedOffset. However, this assumption is no longer valid and encodedOffset might be in UTF-8 for native contents in Swift 5.

This change should make the initializer work as expected under either circumstances.