### PR TITLE
[4.2] NSDecimalNumber: Add missing init(value:) initialisers.

### DIFF
--- a/Foundation/NSDecimalNumber.swift
+++ b/Foundation/NSDecimalNumber.swift
@@ -79,29 +79,21 @@ open class NSDecimalNumber : NSNumber {
 
     fileprivate let decimal: Decimal
     public convenience init(mantissa: UInt64, exponent: Int16, isNegative: Bool) {
-        var d = Decimal()
-        d._exponent = Int32(exponent)
+        var d = Decimal(mantissa)
+        d._exponent += Int32(exponent)
         d._isNegative = isNegative ? 1 : 0
-        var man = mantissa
-        d._mantissa.0 = UInt16(man & 0xffff)
-        man >>= 4
-        d._mantissa.1 = UInt16(man & 0xffff)
-        man >>= 4
-        d._mantissa.2 = UInt16(man & 0xffff)
-        man >>= 4
-        d._mantissa.3 = UInt16(man & 0xffff)
-        d._length = 4
-        d.trimTrailingZeros()
-        // TODO more parts of the mantissa...
         self.init(decimal: d)
     }
+
     public init(decimal dcm: Decimal) {
         self.decimal = dcm
         super.init()
     }
+
     public convenience init(string numberValue: String?) {
         self.init(decimal: Decimal(string: numberValue ?? "") ?? Decimal.nan)
     }
+
     public convenience init(string numberValue: String?, locale: Any?) {
         self.init(decimal: Decimal(string: numberValue ?? "", locale: locale as? Locale) ?? Decimal.nan)
     }

--- a/TestFoundation/TestDecimal.swift
+++ b/TestFoundation/TestDecimal.swift
@@ -11,6 +11,7 @@ class TestDecimal: XCTestCase {
 
     static var allTests : [(String, (TestDecimal) -> () throws -> Void)] {
         return [
+            ("test_NSDecimalNumberInit", test_NSDecimalNumberInit),
             ("test_AdditionWithNormalization", test_AdditionWithNormalization),
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_Constants", test_Constants),
@@ -31,6 +32,18 @@ class TestDecimal: XCTestCase {
             ("test_SmallerNumbers", test_SmallerNumbers),
             ("test_ZeroPower", test_ZeroPower),
         ]
+    }
+
+    func test_NSDecimalNumberInit() {
+        XCTAssertEqual(NSDecimalNumber(mantissa: 123456789000, exponent: -2, isNegative: true), -1234567890)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal()).decimalValue, Decimal(0))
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(1)).intValue, 1)
+        XCTAssertEqual(NSDecimalNumber(string: "1.234").floatValue, 1.234)
+        XCTAssertTrue(NSDecimalNumber(string: "invalid").decimalValue.isNaN)
+        XCTAssertEqual(NSDecimalNumber(integerLiteral: 0).intValue, 0)
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: Double.pi).doubleValue, Double.pi)
+        XCTAssertEqual(NSDecimalNumber(booleanLiteral: true).boolValue, true)
+        XCTAssertEqual(NSDecimalNumber(booleanLiteral: false).boolValue, false)
     }
 
     func test_AdditionWithNormalization() {


### PR DESCRIPTION
- Fix init(mantissa:exponent:isNegative:) to set the mantissa
  correctly.

(cherry picked from commit 641e2cb52ee8fc9e75971f7a2cc030c4f1239eac)