### PR TITLE
[4.2] FileHandle.truncateFile should reposition on truncate

### DIFF
--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -143,14 +143,13 @@ open class FileHandle : NSObject, NSSecureCoding {
         precondition(_fd >= 0, "Bad file descriptor")
         lseek(_fd, off_t(offset), SEEK_SET)
     }
-    
+
     open func truncateFile(atOffset offset: UInt64) {
         precondition(_fd >= 0, "Bad file descriptor")
-        if lseek(_fd, off_t(offset), SEEK_SET) == 0 {
-            ftruncate(_fd, off_t(offset))
-        }
+        if lseek(_fd, off_t(offset), SEEK_SET) < 0 { fatalError("lseek() failed.") }
+        if ftruncate(_fd, off_t(offset)) < 0 { fatalError("ftruncate() failed.") }
     }
-    
+
     open func synchronizeFile() {
         precondition(_fd >= 0, "Bad file descriptor")
         fsync(_fd)


### PR DESCRIPTION
- Accepting truncating to any position, not just 0.
- Reposition to the truncate offset.
- Darwin throws exceptions on error so we use fatalError() instead of silently failing.

(cherry picked from commit fb1e71bbe58329267b799695ff8ea1d307a752d2)