### PR TITLE
[IMPROVEMENT] Double linked list used to improve performance of dequeue and remove operations in OperationQueue

### DIFF
--- a/Foundation/Operation.swift
+++ b/Foundation/Operation.swift
@@ -288,7 +288,7 @@ internal class _IndexedOperationLinkedList {
         }
         
         if node === unwrappedRoot {
-            let next = unwrappedTail.next
+            let next = node.next
             next?.previous = nil
             root = next
             count -= 1

--- a/TestFoundation/TestOperationQueue.swift
+++ b/TestFoundation/TestOperationQueue.swift
@@ -17,6 +17,8 @@ class TestOperationQueue : XCTestCase {
             ("test_AsyncOperation", test_AsyncOperation),
             ("test_isExecutingWorks", test_isExecutingWorks),
             ("test_MainQueueGetter", test_MainQueueGetter),
+            ("test_CancelOneOperation", test_CancelOneOperation),
+            ("test_CancelOperationsOfSpecificQueuePriority", test_CancelOperationsOfSpecificQueuePriority),
             ("test_CurrentQueueOnMainQueue", test_CurrentQueueOnMainQueue),
             ("test_CurrentQueueOnBackgroundQueue", test_CurrentQueueOnBackgroundQueue),
             ("test_CurrentQueueOnBackgroundQueueWithSelfCancel", test_CurrentQueueOnBackgroundQueueWithSelfCancel),
@@ -110,6 +112,73 @@ class TestOperationQueue : XCTestCase {
          There used to be a bug where subsequent OperationQueue.main call would return a "dangling pointer".
          */
         XCTAssertFalse(OperationQueue.main.isSuspended)
+    }
+    
+    func test_CancelOneOperation() {
+        var operations = [Operation]()
+        var valueOperations = [Int]()
+        for i in 0..<5 {
+            let operation = BlockOperation {
+                valueOperations.append(i)
+                sleep(2)
+            }
+            operations.append(operation)
+        }
+        
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+        queue.addOperations(operations, waitUntilFinished: false)
+        operations.remove(at: 2).cancel()
+        queue.waitUntilAllOperationsAreFinished()
+        XCTAssertTrue(!valueOperations.contains(2))
+    }
+    
+    func test_CancelOperationsOfSpecificQueuePriority() {
+        var operations = [Operation]()
+        var valueOperations = [Int]()
+        
+        let operation1 = BlockOperation {
+            valueOperations.append(0)
+        }
+        operation1.queuePriority = .high
+        operations.append(operation1)
+        
+        let operation2 = BlockOperation {
+            valueOperations.append(1)
+        }
+        operation2.queuePriority = .high
+        operations.append(operation2)
+        
+        let operation3 = BlockOperation {
+            valueOperations.append(2)
+        }
+        operation3.queuePriority = .normal
+        operations.append(operation3)
+        
+        let operation4 = BlockOperation {
+            valueOperations.append(3)
+        }
+        operation4.queuePriority = .normal
+        operations.append(operation4)
+        
+        let operation5 = BlockOperation {
+            valueOperations.append(4)
+        }
+        operation5.queuePriority = .normal
+        operations.append(operation5)
+        
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+        queue.addOperations(operations, waitUntilFinished: false)
+        for operation in queue.operations {
+            if operation.queuePriority == .normal {
+                operation.cancel()
+            }
+        }
+        queue.waitUntilAllOperationsAreFinished()
+        XCTAssertTrue(valueOperations.count == 2)
+        XCTAssertTrue(valueOperations[0] == 0)
+        XCTAssertTrue(valueOperations[1] == 1)
     }
     
     func test_CurrentQueueOnMainQueue() {

--- a/TestFoundation/TestOperationQueue.swift
+++ b/TestFoundation/TestOperationQueue.swift
@@ -139,12 +139,14 @@ class TestOperationQueue : XCTestCase {
         
         let operation1 = BlockOperation {
             valueOperations.append(0)
+            sleep(2)
         }
         operation1.queuePriority = .high
         operations.append(operation1)
         
         let operation2 = BlockOperation {
             valueOperations.append(1)
+            sleep(2)
         }
         operation2.queuePriority = .high
         operations.append(operation2)


### PR DESCRIPTION
- `remove()` and `dequeue()` methods time complexity reduces to **O(1)** from **O(n)**.
- All arrays, veryHigh, high, normal, low, veryLow, all, converted to _DoubleLinkedList_.
- New internal class `_IndexedOperationLinkedList` introduced specifically to work with `Operation`.
- _HashMap_ used to index, node by it's operation, in the linked list, in order to avoid traversing the list to find a node, which in return reduces the time complexity to **O(1)**.
- Unit Test added to test cancel one operation and cancel operations of a specific queue priority

**Discussion Link**
https://forums.swift.org/t/operationqueue-dequeue-and-remove-operations-performance-improvement/20370/9