### PR TITLE
FileManager: setAttributes(ofItemAtPath:) should throw if chmod fails.

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -533,9 +533,9 @@ open class FileManager : NSObject {
                 #elseif os(Linux) || os(Android) || CYGWIN
                     let modeT = number.uint32Value
                 #endif
-                _fileSystemRepresentation(withPath: path, {
-                    if chmod($0, mode_t(modeT)) != 0 {
-                        fatalError("errno \(errno)")
+                try _fileSystemRepresentation(withPath: path, {
+                    guard chmod($0, mode_t(modeT)) == 0 else {
+                        throw _NSErrorWithErrno(errno, reading: false, path: path)
                     }
                 })
             } else {

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -434,6 +434,15 @@ class TestFileManager : XCTestCase {
         } catch {
             XCTFail("Failed to clean up files")
         }
+
+        // test non existant file
+        let noSuchFile = NSTemporaryDirectory() + "fileThatDoesntExist"
+        try? fm.removeItem(atPath: noSuchFile)
+        do {
+            try fm.setAttributes([.posixPermissions: 0], ofItemAtPath: noSuchFile)
+            XCTFail("Setting permissions of non-existant file should throw")
+        } catch {
+        }
     }
     
     func test_pathEnumerator() {


### PR DESCRIPTION
- chmod() failing should throw an error and not call fatalError().

- Behaviour now matches Darwin.