### PR TITLE
Foundation: remove future fixes

### DIFF
--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -493,7 +493,7 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     
     open var password: String? {
         let absoluteURL = CFURLCopyAbsoluteURL(_cfObject)
-#if os(Linux) || os(Android) || CYGWIN
+#if os(Linux) || os(Android) || os(Windows)
         let passwordRange = CFURLGetByteRangeForComponent(absoluteURL, kCFURLComponentPassword, nil)
 #else
         let passwordRange = CFURLGetByteRangeForComponent(absoluteURL, .password, nil)

--- a/Foundation/Stream.swift
+++ b/Foundation/Stream.swift
@@ -153,11 +153,7 @@ open class InputStream: Stream {
     }
     
     open override var streamStatus: Status {
-#if os(Windows)
-        return Stream.Status(rawValue: UInt(CFReadStreamGetStatus(_stream).rawValue))!
-#else
         return Stream.Status(rawValue: UInt(CFReadStreamGetStatus(_stream)))!
-#endif
     }
     
     open override var streamError: Error? {
@@ -209,11 +205,7 @@ open class OutputStream : Stream {
     }
     
     open override var streamStatus: Status {
-#if os(Windows)
-        return Stream.Status(rawValue: UInt(CFWriteStreamGetStatus(_stream).rawValue))!
-#else
         return Stream.Status(rawValue: UInt(CFWriteStreamGetStatus(_stream)))!
-#endif
     }
     
     open class func toMemory() -> Self {


### PR DESCRIPTION
These changes will be needed in the future.  They accidentally snuck
into the previous changes.  They are caused by running a custom build of
clang with changes from the future in the past.