### PR TITLE
[4.2] FileManager: setAttributes(ofItemAtPath:) should throw if chmod fails.

### DIFF
--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -326,6 +326,15 @@ class TestFileManager : XCTestCase {
         } catch {
             XCTFail("Failed to clean up files")
         }
+
+        // test non existant file
+        let noSuchFile = NSTemporaryDirectory() + "fileThatDoesntExist"
+        try? fm.removeItem(atPath: noSuchFile)
+        do {
+            try fm.setAttributes([.posixPermissions: 0], ofItemAtPath: noSuchFile)
+            XCTFail("Setting permissions of non-existant file should throw")
+        } catch {
+        }
     }
     
     func test_pathEnumerator() {


### PR DESCRIPTION
- chmod() failing should throw an error and not call fatalError().

- Behaviour now matches Darwin.

(cherry picked from commit 5995272b8f80a3910eef4fe8e00237f097fdc9eb)