### PR TITLE
Create malloc_good_size for platforms other than Linux.

### DIFF
--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -12,7 +12,7 @@
 
 #if DEPLOYMENT_RUNTIME_SWIFT
 
-#if os(Linux)
+#if !os(iOS) && !os(macOS) && !os(watchOS) && !os(tvOS)
 @inlinable // This is @inlinable as trivially computable.
 internal func malloc_good_size(_ size: Int) -> Int {
     return size


### PR DESCRIPTION
Other platforms besides Linux do not define malloc_good_size (not even
BSD, it seems), so for everything but the Darwin platforms, create the
trivial malloc_good_size function.

/cc @phausler 