### PR TITLE
[5.0] NSDecimalValue: Dont use .doubleValue for integer properties.

### DIFF
--- a/Foundation/NSDecimalNumber.swift
+++ b/Foundation/NSDecimalNumber.swift
@@ -1,10 +1,10 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
 /***************	Exceptions		***********/
@@ -358,43 +358,55 @@ open class NSDecimalNumber : NSNumber {
     // return 'd' for double
     
     open override var int8Value: Int8 {
-        return Int8(exactly: decimal.doubleValue) ?? 0 as Int8
+        return Int8(truncatingIfNeeded: decimal.int64Value)
     }
+
     open override var uint8Value: UInt8 {
-        return UInt8(exactly: decimal.doubleValue) ?? 0 as UInt8
+        return UInt8(truncatingIfNeeded: decimal.uint64Value)
     }
+
     open override var int16Value: Int16 {
-        return Int16(exactly: decimal.doubleValue) ?? 0 as Int16
+        return Int16(truncatingIfNeeded: decimal.int64Value)
     }
+
     open override var uint16Value: UInt16 {
-        return UInt16(exactly: decimal.doubleValue) ?? 0 as UInt16
+        return UInt16(truncatingIfNeeded: decimal.uint64Value)
     }
+
     open override var int32Value: Int32 {
-        return Int32(exactly: decimal.doubleValue) ?? 0 as Int32
+        return Int32(truncatingIfNeeded: decimal.int64Value)
     }
+
     open override var uint32Value: UInt32 {
-        return UInt32(exactly: decimal.doubleValue) ?? 0 as UInt32
+        return UInt32(truncatingIfNeeded: decimal.uint64Value)
     }
+
     open override var int64Value: Int64 {
-        return Int64(exactly: decimal.doubleValue) ?? 0 as Int64
+        return decimal.int64Value
     }
+
     open override var uint64Value: UInt64 {
-        return UInt64(exactly: decimal.doubleValue) ?? 0 as UInt64
+        return decimal.uint64Value
     }
+
     open override var floatValue: Float {
         return Float(decimal.doubleValue)
     }
+
     open override var doubleValue: Double {
         return decimal.doubleValue
     }
+
     open override var boolValue: Bool {
         return !decimal.isZero
     }
+
     open override var intValue: Int {
-        return Int(exactly: decimal.doubleValue) ?? 0 as Int
+        return Int(truncatingIfNeeded: decimal.int64Value)
     }
+
     open override var uintValue: UInt {
-        return UInt(exactly: decimal.doubleValue) ?? 0 as UInt
+        return UInt(truncatingIfNeeded: decimal.uint64Value)
     }
 
     open override func isEqual(_ value: Any?) -> Bool {

--- a/TestFoundation/TestDecimal.swift
+++ b/TestFoundation/TestDecimal.swift
@@ -31,7 +31,8 @@ class TestDecimal: XCTestCase {
             ("test_SimpleMultiplication", test_SimpleMultiplication),
             ("test_SmallerNumbers", test_SmallerNumbers),
             ("test_ZeroPower", test_ZeroPower),
-            ("test_doubleValue", test_doubleValue)
+            ("test_doubleValue", test_doubleValue),
+            ("test_NSDecimalNumberValues", test_NSDecimalNumberValues),
         ]
     }
 
@@ -821,5 +822,197 @@ class TestDecimal: XCTestCase {
         XCTAssertEqual(nf.string(from: NSDecimalNumber(decimal: z)), "1.50")
         XCTAssertEqual(nf.string(from: NSDecimalNumber(decimal: a)), "0.00")
         XCTAssertEqual(nf.string(from: NSDecimalNumber(decimal: b)), "0.00")
+    }
+
+    func test_NSDecimalNumberValues() {
+        let uint64MaxDecimal = Decimal(string: UInt64.max.description)!
+
+        // int8Value
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(0)).int8Value, 0)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(-1)).int8Value, -1)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(1)).int8Value, 1)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(-129)).int8Value, 127)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(128)).int8Value, -128)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.min)).int8Value, Int8.min)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.min)).int8Value, 0)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.min)).int8Value, 0)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.min)).int8Value, 0)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.max)).int8Value, Int8.max)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.max)).int8Value, -1)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.max)).int8Value, -1)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.max)).int8Value, -1)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt8.max)).int8Value, -1)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt16.max)).int8Value, -1)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt32.max)).int8Value, -1)
+        XCTAssertEqual(NSDecimalNumber(decimal: uint64MaxDecimal).int8Value, -1)
+
+        // uint8Value
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(0)).uint8Value, 0)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(-1)).uint8Value, UInt8.max)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(1)).uint8Value, 1)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(-129)).uint8Value, 127)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(128)).uint8Value, 128)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(256)).uint8Value, 0)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.min)).uint8Value, 128)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.min)).uint8Value, 0)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.min)).uint8Value, 0)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.min)).uint8Value, 0)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.max)).uint8Value, 127)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.max)).uint8Value, UInt8.max)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.max)).uint8Value, UInt8.max)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.max)).uint8Value, UInt8.max)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt8.max)).uint8Value, UInt8.max)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt16.max)).uint8Value, UInt8.max)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt32.max)).uint8Value, UInt8.max)
+        XCTAssertEqual(NSDecimalNumber(decimal: uint64MaxDecimal).uint8Value, UInt8.max)
+
+        // int16Value
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(0)).int16Value, 0)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(-1)).int16Value, -1)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(1)).int16Value, 1)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(-32769)).int16Value, 32767)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(32768)).int16Value, -32768)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.min)).int16Value, -128)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.min)).int16Value, Int16.min)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.min)).int16Value, 0)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.min)).int16Value, 0)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.max)).int16Value, 127)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.max)).int16Value, Int16.max)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.max)).int16Value, -1)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.max)).int16Value, -1)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt8.max)).int16Value, 255)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt16.max)).int16Value, -1)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt32.max)).int16Value, -1)
+        XCTAssertEqual(NSDecimalNumber(decimal: uint64MaxDecimal).int16Value, -1)
+
+        // uint16Value
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(0)).uint16Value, 0)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(-1)).uint16Value, UInt16.max)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(1)).uint16Value, 1)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(-32769)).uint16Value, 32767)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(32768)).uint16Value, 32768)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(65536)).uint16Value, 0)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.min)).uint16Value, 65408)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.min)).uint16Value, 32768)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.min)).uint16Value, 0)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.min)).uint16Value, 0)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.max)).uint16Value, 127)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.max)).uint16Value, 32767)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.max)).uint16Value, UInt16.max)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.max)).uint16Value, UInt16.max)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt8.max)).uint16Value, 255)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt16.max)).uint16Value, UInt16.max)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt32.max)).uint16Value, UInt16.max)
+        XCTAssertEqual(NSDecimalNumber(decimal: uint64MaxDecimal).uint16Value, UInt16.max)
+
+        // int32Value
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(0)).int32Value, 0)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(-1)).int32Value, -1)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(1)).int32Value, 1)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(-32769)).int32Value, -32769)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(32768)).int32Value, 32768)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.min)).int32Value, -128)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.min)).int32Value, -32768)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.min)).int32Value, Int32.min)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.min)).int32Value, 0)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.max)).int32Value, 127)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.max)).int32Value, 32767)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.max)).int32Value, Int32.max)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.max)).int32Value, -1)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt8.max)).int32Value, 255)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt16.max)).int32Value, 65535)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt32.max)).int32Value, -1)
+        XCTAssertEqual(NSDecimalNumber(decimal: uint64MaxDecimal).int32Value, -1)
+
+        // uint32Value
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(0)).uint32Value, 0)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(-1)).uint32Value, UInt32.max)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(1)).uint32Value, 1)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(-32769)).uint32Value, 4294934527)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(32768)).uint32Value, 32768)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(65536)).uint32Value, 65536)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.min)).uint32Value, 4294967168)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.min)).uint32Value, 4294934528)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.min)).uint32Value, 2147483648)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.min)).uint32Value, 0)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.max)).uint32Value, 127)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.max)).uint32Value, 32767)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.max)).uint32Value, UInt32(Int32.max))
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.max)).uint32Value, UInt32.max)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt8.max)).uint32Value, 255)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt16.max)).uint32Value, 65535)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt32.max)).uint32Value, UInt32.max)
+        XCTAssertEqual(NSDecimalNumber(decimal: uint64MaxDecimal).uint32Value, UInt32.max)
+
+        // int64Value
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(0)).int64Value, 0)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(-1)).int64Value, -1)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(1)).int64Value, 1)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(-32769)).int64Value, -32769)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(32768)).int64Value, 32768)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.min)).int64Value, -128)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.min)).int64Value, -32768)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.min)).int64Value, -2147483648)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.min)).int64Value, Int64.min)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.max)).int64Value, 127)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.max)).int64Value, 32767)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.max)).int64Value, 2147483647)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.max)).int64Value, Int64.max)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt8.max)).int64Value, 255)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt16.max)).int64Value, 65535)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt32.max)).int64Value, 4294967295)
+        XCTAssertEqual(NSDecimalNumber(decimal: uint64MaxDecimal).int64Value, -1)
+
+        // uint64Value
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(0)).uint64Value, 0)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(-1)).uint64Value, UInt64.max)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(1)).uint64Value, 1)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(-32769)).uint64Value, 18446744073709518847)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(32768)).uint64Value, 32768)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(65536)).uint64Value, 65536)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.min)).uint64Value, 18446744073709551488)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.min)).uint64Value, 18446744073709518848)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.min)).uint64Value, 18446744071562067968)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.min)).uint64Value, 9223372036854775808)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.max)).uint64Value, 127)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.max)).uint64Value, 32767)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.max)).uint64Value, UInt64(Int32.max))
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.max)).uint64Value, UInt64(Int64.max))
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt8.max)).uint64Value, 255)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt16.max)).uint64Value, 65535)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt32.max)).uint64Value, 4294967295)
+        XCTAssertEqual(NSDecimalNumber(decimal: uint64MaxDecimal).uint64Value, UInt64.max)
     }
 }


### PR DESCRIPTION
- Decimal: Add an internal .int64Value and .uint64Value.

- NSDecimalValue: For the .int*Value and .uint*Value properties
  use a truncated value from .int64Value and .uint64Value.

- Using .doubleValue lost information when returning large numbers
  > 2e53 due to Double to Int conversion.

- The returned values mostly match Darwin, moreso than just returning 0
  when an exact conversion cannot be made.

(cherry picked from commit f369d31f91b267b2a57141eb610cf1cbda5bedde)