### PR TITLE
[4.2] SR-9322: DateFormatter difference between macOS and Linux

### DIFF
--- a/Foundation/DateFormatter.swift
+++ b/Foundation/DateFormatter.swift
@@ -62,6 +62,12 @@ open class DateFormatter : Formatter {
             }
             return res._swiftObject
         }
+
+        // range.length is updated with the last position of the input string that was parsed
+        guard range.length == string.length else {
+            // The whole string was not parsed
+            return nil
+        }
         return date
     }
 

--- a/TestFoundation/TestDateFormatter.swift
+++ b/TestFoundation/TestDateFormatter.swift
@@ -22,6 +22,7 @@ class TestDateFormatter: XCTestCase {
             ("test_customDateFormat", test_customDateFormat),
             ("test_setLocalizedDateFormatFromTemplate", test_setLocalizedDateFormatFromTemplate),
             ("test_dateFormatString", test_dateFormatString),
+            ("test_dateFrom", test_dateFrom),
         ]
     }
     
@@ -329,5 +330,20 @@ class TestDateFormatter: XCTestCase {
             
             XCTAssertEqual(f.dateFormat, dateFormat)
         }
+    }
+
+    func test_dateFrom() throws {
+        let formatter = DateFormatter()
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.dateFormat = "yyyy-MM-dd"
+
+        XCTAssertNil(formatter.date(from: "2018-03-09T10:25:16+01:00"))
+        let d1 = try formatter.date(from: "2018-03-09").unwrapped()
+        XCTAssertEqual(d1.description, "2018-03-09 00:00:00 +0000")
+
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        XCTAssertNil(formatter.date(from: "2018-03-09"))
+        let d2 = try formatter.date(from: "2018-03-09T10:25:16+01:00").unwrapped()
+        XCTAssertEqual(d2.description, "2018-03-09 09:25:16 +0000")
     }
 }

--- a/TestFoundation/TestUtils.swift
+++ b/TestFoundation/TestUtils.swift
@@ -42,3 +42,19 @@ func ensureFiles(_ fileNames: [String]) -> Bool {
     }
     return result
 }
+
+
+enum TestError: Error {
+    case unexpectedNil
+}
+
+extension Optional {
+    func unwrapped(_ fn: String = #function, file: StaticString = #file, line: UInt = #line) throws -> Wrapped {
+        if let x = self {
+            return x
+        } else {
+            XCTFail("Tried to invoke .unwrapped() on nil in \(file):\(line):\(fn)")
+            throw TestError.unexpectedNil
+        }
+    }
+}


### PR DESCRIPTION
- When parsing a date, return nil if the date to be parsed was not
  fully consumed by the parse format.

(cherry picked from commit 8747de5134aba1281d5c641ea1bcb0d6b5f6e31d)