### PR TITLE
Supported Scanner API for Swift

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,7 @@ add_swift_library(Foundation
                     Foundation/ReferenceConvertible.swift
                     Foundation/RunLoop.swift
                     Foundation/Scanner.swift
+                    Foundation/ScannerAPI.swift
                     Foundation/Set.swift
                     Foundation/Stream.swift
                     Foundation/String.swift

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		03B6F5841F15F339004F25AF /* TestURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B6F5831F15F339004F25AF /* TestURLProtocol.swift */; };
 		1513A8432044893F00539722 /* FileManager_XDG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1513A8422044893F00539722 /* FileManager_XDG.swift */; };
 		1520469B1D8AEABE00D02E36 /* HTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1520469A1D8AEABE00D02E36 /* HTTPServer.swift */; };
-		153CC8332214C3D100BFE8F3 /* ScannerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153CC8322214C3D100BFE8F3 /* ScannerAPI.swift */; };
+		153CC8352215E00200BFE8F3 /* ScannerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153CC8322214C3D100BFE8F3 /* ScannerAPI.swift */; };
 		153E951120111DC500F250BE /* CFKnownLocations.h in Headers */ = {isa = PBXBuildFile; fileRef = 153E950F20111DC500F250BE /* CFKnownLocations.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		153E951220111DC500F250BE /* CFKnownLocations.c in Sources */ = {isa = PBXBuildFile; fileRef = 153E951020111DC500F250BE /* CFKnownLocations.c */; };
 		15496CF1212CAEBA00450F5A /* CFAttributedStringPriv.h in Headers */ = {isa = PBXBuildFile; fileRef = 15496CF0212CAEBA00450F5A /* CFAttributedStringPriv.h */; };
@@ -2369,7 +2369,7 @@
 				5B23AB871CE62D17000DB898 /* Boxing.swift in Sources */,
 				5BF7AEA41BCD51F9008F214A /* Bundle.swift in Sources */,
 				5B23AB891CE62D4D000DB898 /* ReferenceConvertible.swift in Sources */,
-				153CC8332214C3D100BFE8F3 /* ScannerAPI.swift in Sources */,
+				153CC8352215E00200BFE8F3 /* ScannerAPI.swift in Sources */,
 				D3E8D6D11C367AB600295652 /* NSSpecialValue.swift in Sources */,
 				EAB57B721BD1C7A5004AC5C5 /* PortMessage.swift in Sources */,
 				5BD31D201D5CE8C400563814 /* Bridging.swift in Sources */,

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		03B6F5841F15F339004F25AF /* TestURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B6F5831F15F339004F25AF /* TestURLProtocol.swift */; };
 		1513A8432044893F00539722 /* FileManager_XDG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1513A8422044893F00539722 /* FileManager_XDG.swift */; };
 		1520469B1D8AEABE00D02E36 /* HTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1520469A1D8AEABE00D02E36 /* HTTPServer.swift */; };
+		153CC8332214C3D100BFE8F3 /* ScannerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153CC8322214C3D100BFE8F3 /* ScannerAPI.swift */; };
 		153E951120111DC500F250BE /* CFKnownLocations.h in Headers */ = {isa = PBXBuildFile; fileRef = 153E950F20111DC500F250BE /* CFKnownLocations.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		153E951220111DC500F250BE /* CFKnownLocations.c in Sources */ = {isa = PBXBuildFile; fileRef = 153E951020111DC500F250BE /* CFKnownLocations.c */; };
 		15496CF1212CAEBA00450F5A /* CFAttributedStringPriv.h in Headers */ = {isa = PBXBuildFile; fileRef = 15496CF0212CAEBA00450F5A /* CFAttributedStringPriv.h */; };
@@ -546,6 +547,7 @@
 		03B6F5831F15F339004F25AF /* TestURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestURLProtocol.swift; sourceTree = "<group>"; };
 		1513A8422044893F00539722 /* FileManager_XDG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager_XDG.swift; sourceTree = "<group>"; };
 		1520469A1D8AEABE00D02E36 /* HTTPServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPServer.swift; sourceTree = "<group>"; };
+		153CC8322214C3D100BFE8F3 /* ScannerAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannerAPI.swift; sourceTree = "<group>"; };
 		153E950F20111DC500F250BE /* CFKnownLocations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CFKnownLocations.h; sourceTree = "<group>"; };
 		153E951020111DC500F250BE /* CFKnownLocations.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = CFKnownLocations.c; sourceTree = "<group>"; };
 		15496CF0212CAEBA00450F5A /* CFAttributedStringPriv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFAttributedStringPriv.h; sourceTree = "<group>"; };
@@ -1851,6 +1853,7 @@
 			children = (
 				EADE0B751BD15DFF00C49C64 /* NSRegularExpression.swift */,
 				EADE0B771BD15DFF00C49C64 /* Scanner.swift */,
+				153CC8322214C3D100BFE8F3 /* ScannerAPI.swift */,
 				EADE0B7B1BD15DFF00C49C64 /* NSTextCheckingResult.swift */,
 				EADE0B4F1BD09E3100C49C64 /* NSAttributedString.swift */,
 				5BDC3F311BCC5DCB00ED97BB /* NSCharacterSet.swift */,
@@ -2366,6 +2369,7 @@
 				5B23AB871CE62D17000DB898 /* Boxing.swift in Sources */,
 				5BF7AEA41BCD51F9008F214A /* Bundle.swift in Sources */,
 				5B23AB891CE62D4D000DB898 /* ReferenceConvertible.swift in Sources */,
+				153CC8332214C3D100BFE8F3 /* ScannerAPI.swift in Sources */,
 				D3E8D6D11C367AB600295652 /* NSSpecialValue.swift in Sources */,
 				EAB57B721BD1C7A5004AC5C5 /* PortMessage.swift in Sources */,
 				5BD31D201D5CE8C400563814 /* Bridging.swift in Sources */,

--- a/Foundation/Decimal.swift
+++ b/Foundation/Decimal.swift
@@ -2068,6 +2068,7 @@ extension Scanner {
         }
 
     }
+    
     public func scanDecimal() -> Decimal? {
 
         var result = Decimal()
@@ -2076,7 +2077,7 @@ extension Scanner {
         let length = string.length
         var buf = _NSStringBuffer(string: string, start: self._scanLocation, end: length)
 
-        let ds_chars = decimalSep(locale).utf16
+        let ds_chars = decimalSep(locale as? Locale).utf16
         let ds = ds_chars[ds_chars.startIndex]
         buf.skip(_skipSet)
         var neg = false

--- a/Foundation/Scanner.swift
+++ b/Foundation/Scanner.swift
@@ -7,8 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
 import CoreFoundation
 
 open class Scanner: NSObject, NSCopying {
@@ -499,120 +497,53 @@ extension String {
     }
 }
 
-/// Revised API for avoiding usage of AutoreleasingUnsafeMutablePointer and better Optional usage.
-/// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
-/// - Note: Since this API is under consideration it may be either removed or revised in the near future
+// This extension used to house the experimental API for Scanner. This is all deprecated in favor of API with newer semantics. Some of the experimental API have been promoted to full API with slightly different semantics; see ScannerAPI.swift.
 extension Scanner {
-    public func scanInt32() -> Int32? {
-        var value: Int32 = 0
-        return withUnsafeMutablePointer(to: &value) { (ptr: UnsafeMutablePointer<Int32>) -> Int32? in
-            if scanInt32(ptr) {
-                return ptr.pointee
-            } else {
-                return nil
-            }
-        }
-    }
+    // These methods are in a special bit of mess:
+    // - They used to exist here; but
+    // - They have all been replaced by methods called scan<Type>(representation:); but
+    // - The representation parameter has a default value, so scan<Type>() is still valid and has the same semantics as the below.
+    // This means that the new methods _aren't_ fully source compatible — most source will correctly pick up the new .scan<Type>(representation:) with the default, but things like let method = scanner.scanInt32 may or may not work any longer.
+    // Make sure that the signatures exist here so that in case the compiler would pick them up, we can direct people to the new ones. This should be rare.
     
-    public func scanInt() -> Int? {
-        var value: Int = 0
-        return withUnsafeMutablePointer(to: &value) { (ptr: UnsafeMutablePointer<Int>) -> Int? in
-            if scanInt(ptr) {
-                return ptr.pointee
-            } else {
-                return nil
-            }
-        }
-    }
+    // scanDecimal() is not among these methods and has not changed at all, though it has been promoted to non-experimental API.
     
-    public func scanInt64() -> Int64? {
-        var value: Int64 = 0
-        return withUnsafeMutablePointer(to: &value) { (ptr: UnsafeMutablePointer<Int64>) -> Int64? in
-            if scanInt64(ptr) {
-                return ptr.pointee
-            } else {
-                return nil
-            }
-        }
-    }
+    @available(swift, obsoleted: 5.0, renamed: "scanInt(representation:)")
+    public func scanInt() -> Int? { return scanInt(representation: .decimal) }
     
-    public func scanUnsignedLongLong() -> UInt64? {
-        var value: UInt64 = 0
-        return withUnsafeMutablePointer(to: &value) { (ptr: UnsafeMutablePointer<UInt64>) -> UInt64? in
-            if scanUnsignedLongLong(ptr) {
-                return ptr.pointee
-            } else {
-                return nil
-            }
-        }
-    }
+    @available(swift, obsoleted: 5.0, renamed: "scanInt32(representation:)")
+    public func scanInt32() -> Int32? { return scanInt32(representation: .decimal) }
     
-    public func scanFloat() -> Float? {
-        var value: Float = 0.0
-        return withUnsafeMutablePointer(to: &value) { (ptr: UnsafeMutablePointer<Float>) -> Float? in
-            if scanFloat(ptr) {
-                return ptr.pointee
-            } else {
-                return nil
-            }
-        }
-    }
+    @available(swift, obsoleted: 5.0, renamed: "scanInt64(representation:)")
+    public func scanInt64() -> Int64? { return scanInt64(representation: .decimal) }
     
-    public func scanDouble() -> Double? {
-        var value: Double = 0.0
-        return withUnsafeMutablePointer(to: &value) { (ptr: UnsafeMutablePointer<Double>) -> Double? in
-            if scanDouble(ptr) {
-                return ptr.pointee
-            } else {
-                return nil
-            }
-        }
-    }
+    @available(swift, obsoleted: 5.0, renamed: "scanUInt64(representation:)")
+    public func scanUInt64() -> UInt64? { return scanUInt64(representation: .decimal) }
     
+    @available(swift, obsoleted: 5.0, renamed: "scanFloat(representation:)")
+    public func scanFloat() -> Float? { return scanFloat(representation: .decimal) }
+    
+    @available(swift, obsoleted: 5.0, renamed: "scanDouble(representation:)")
+    public func scanDouble() -> Double? { return scanDouble(representation: .decimal) }
+    
+    // These existed but are now deprecated in favor of the new methods:
+    
+    @available(swift, deprecated: 5.0, renamed: "scanUInt64(representation:)")
     public func scanHexInt32() -> UInt32? {
-        var value: UInt32 = 0
-        return withUnsafeMutablePointer(to: &value) { (ptr: UnsafeMutablePointer<UInt32>) -> UInt32? in
-            if scanHexInt32(ptr) {
-                return ptr.pointee
-            } else {
-                return nil
-            }
-        }
+        guard let value = scanUInt64(representation: .hexadecimal) else { return nil }
+        return UInt32(min(value, UInt64(UInt32.max)))
     }
     
-    public func scanHexInt64() -> UInt64? {
-        var value: UInt64 = 0
-        return withUnsafeMutablePointer(to: &value) { (ptr: UnsafeMutablePointer<UInt64>) -> UInt64? in
-            if scanHexInt64(ptr) {
-                return ptr.pointee
-            } else {
-                return nil
-            }
-        }
-    }
+    @available(swift, deprecated: 5.0, renamed: "scanUInt64(representation:)")
+    public func scanHexInt64() -> UInt64? { return scanUInt64(representation: .hexadecimal) }
     
-    public func scanHexFloat() -> Float? {
-        var value: Float = 0.0
-        return withUnsafeMutablePointer(to: &value) { (ptr: UnsafeMutablePointer<Float>) -> Float? in
-            if scanHexFloat(ptr) {
-                return ptr.pointee
-            } else {
-                return nil
-            }
-        }
-    }
+    @available(swift, deprecated: 5.0, renamed: "scanFloat(representation:)")
+    public func scanHexFloat() -> Float? { return scanFloat(representation: .hexadecimal) }
     
-    public func scanHexDouble() -> Double? {
-        var value: Double = 0.0
-        return withUnsafeMutablePointer(to: &value) { (ptr: UnsafeMutablePointer<Double>) -> Double? in
-            if scanHexDouble(ptr) {
-                return ptr.pointee
-            } else {
-                return nil
-            }
-        }
-    }
+    @available(swift, deprecated: 5.0, renamed: "scanDouble(representation:)")
+    public func scanHexDouble() -> Double? { return scanDouble(representation: .hexadecimal) }
     
+    @available(swift, deprecated: 5.0, renamed: "scanString(_:)")
     @discardableResult
     public func scanString(_ string:String, into ptr: UnsafeMutablePointer<String?>?) -> Bool {
         if let str = _scanStringSplittingGraphemes(string) {
@@ -647,6 +578,19 @@ extension Scanner {
     
     @available(swift, deprecated: 5.0, renamed: "scanCharacters(from:)")
     public func scanCharactersFromSet(_ set: CharacterSet) -> String? {
+        return _scanCharactersSplittingGraphemes(from: set)
+    }
+    
+    @available(swift, deprecated: 5.0, renamed: "scanCharacters(from:)")
+    public func scanCharacters(from set: CharacterSet, into ptr: UnsafeMutablePointer<String?>?) -> Bool {
+        if let str = _scanCharactersSplittingGraphemes(from: set) {
+            ptr?.pointee = str
+            return true
+        }
+        return false
+    }
+    
+    private func _scanCharactersSplittingGraphemes(from set: CharacterSet) -> String? {
         let str = self.string._bridgeToObjectiveC()
         var stringLoc = scanLocation
         let stringLen = str.length
@@ -667,6 +611,7 @@ extension Scanner {
         return nil
     }
     
+    @available(swift, deprecated: 5.0, renamed: "scanUpToString(_:)")
     @discardableResult
     public func scanUpTo(_ string:String, into ptr: UnsafeMutablePointer<String?>?) -> Bool {
         if let str = _scanUpToStringSplittingGraphemes(string) {
@@ -697,9 +642,10 @@ extension Scanner {
         return nil
     }
     
+    @available(swift, deprecated: 5.0, renamed: "scanUpToCharacters(from:)")
     @discardableResult
     public func scanUpToCharacters(from set: CharacterSet, into ptr: UnsafeMutablePointer<String?>?) -> Bool {
-        if let result = scanUpToCharactersFromSet(set) {
+        if let result = _scanSplittingGraphemesUpToCharacters(from: set) {
             ptr?.pointee = result
             return true
         }
@@ -708,6 +654,10 @@ extension Scanner {
     
     @available(swift, deprecated: 5.0, renamed: "scanUpToCharacters(from:)")
     public func scanUpToCharactersFromSet(_ set: CharacterSet) -> String? {
+        return _scanSplittingGraphemesUpToCharacters(from: set)
+    }
+    
+    private func _scanSplittingGraphemesUpToCharacters(from set: CharacterSet) -> String? {
         let str = self.string._bridgeToObjectiveC()
         var stringLoc = scanLocation
         let stringLen = str.length

--- a/Foundation/Scanner.swift
+++ b/Foundation/Scanner.swift
@@ -63,7 +63,7 @@ open class Scanner: NSObject, NSCopying {
     }
     
     open var caseSensitive: Bool = false
-    open var locale: Locale?
+    open var locale: Any?
     
     internal static let defaultSkipSet = CharacterSet.whitespacesAndNewlines
     
@@ -72,6 +72,89 @@ open class Scanner: NSObject, NSCopying {
         _skipSet = Scanner.defaultSkipSet
         _scanLocation = 0
     }
+    
+    // On overflow, the below methods will return success and clamp
+    @discardableResult
+    open func scanInt32(_ result: UnsafeMutablePointer<Int32>) -> Bool {
+        return _scanString.scan(_skipSet, locationToScanFrom: &_scanLocation) { (value: Int32) -> Void in
+            result.pointee = value
+        }
+    }
+    
+    @discardableResult
+    open func scanInt(_ result: UnsafeMutablePointer<Int>) -> Bool {
+        return _scanString.scan(_skipSet, locationToScanFrom: &_scanLocation) { (value: Int) -> Void in
+            result.pointee = value
+        }
+    }
+    
+    @discardableResult
+    open func scanInt64(_ result: UnsafeMutablePointer<Int64>) -> Bool {
+        return _scanString.scan(_skipSet, locationToScanFrom: &_scanLocation) { (value: Int64) -> Void in
+            result.pointee = value
+        }
+    }
+    
+    @discardableResult
+    open func scanUnsignedLongLong(_ result: UnsafeMutablePointer<UInt64>) -> Bool {
+        return _scanString.scan(_skipSet, locationToScanFrom: &_scanLocation) { (value: UInt64) -> Void in
+            result.pointee = value
+        }
+    }
+    
+    @discardableResult
+    open func scanFloat(_ result: UnsafeMutablePointer<Float>) -> Bool {
+        return _scanString.scan(_skipSet, locale: locale as? Locale, locationToScanFrom: &_scanLocation) { (value: Float) -> Void in
+            result.pointee = value
+        }
+    }
+    
+    @discardableResult
+    open func scanDouble(_ result: UnsafeMutablePointer<Double>) -> Bool {
+        return _scanString.scan(_skipSet, locale: locale as? Locale, locationToScanFrom: &_scanLocation) { (value: Double) -> Void in
+            result.pointee = value
+        }
+    }
+    
+    @discardableResult
+    open func scanHexInt32(_ result: UnsafeMutablePointer<UInt32>) -> Bool {
+        return _scanString.scanHex(_skipSet, locationToScanFrom: &_scanLocation) { (value: UInt32) -> Void in
+            result.pointee = value
+        }
+    }
+    
+    @discardableResult
+    open func scanHexInt64(_ result: UnsafeMutablePointer<UInt64>) -> Bool {
+        return _scanString.scanHex(_skipSet, locationToScanFrom: &_scanLocation) { (value: UInt64) -> Void in
+            result.pointee = value
+        }
+    }
+    
+    @discardableResult
+    open func scanHexFloat(_ result: UnsafeMutablePointer<Float>) -> Bool {
+        return _scanString.scanHex(_skipSet, locale: locale as? Locale, locationToScanFrom: &_scanLocation) { (value: Float) -> Void in
+            result.pointee = value
+        }
+    }
+    
+    @discardableResult
+    open func scanHexDouble(_ result: UnsafeMutablePointer<Double>) -> Bool {
+        return _scanString.scanHex(_skipSet, locale: locale as? Locale, locationToScanFrom: &_scanLocation) { (value: Double) -> Void in
+            result.pointee = value
+        }
+    }
+    
+    open var isAtEnd: Bool {
+        var stringLoc = scanLocation
+        let stringLen = string.length
+        if let invSet = invertedSkipSet {
+            let range = string._nsObject.rangeOfCharacter(from: invSet, options: [], range: NSRange(location: stringLoc, length: stringLen - stringLoc))
+            stringLoc = range.length > 0 ? range.location : stringLen
+        }
+        return stringLoc == stringLen
+    }
+    
+    open class func localizedScannerWithString(_ string: String) -> AnyObject { NSUnimplemented() }
 }
 
 internal struct _NSStringBuffer {
@@ -416,93 +499,6 @@ extension String {
     }
 }
 
-extension Scanner {
-    
-    // On overflow, the below methods will return success and clamp
-    @discardableResult
-    public func scanInt32(_ result: UnsafeMutablePointer<Int32>) -> Bool {
-        return _scanString.scan(_skipSet, locationToScanFrom: &_scanLocation) { (value: Int32) -> Void in
-            result.pointee = value
-        }
-    }
-    
-    @discardableResult
-    public func scanInt(_ result: UnsafeMutablePointer<Int>) -> Bool {
-        return _scanString.scan(_skipSet, locationToScanFrom: &_scanLocation) { (value: Int) -> Void in
-            result.pointee = value
-        }
-    }
-    
-    @discardableResult
-    public func scanInt64(_ result: UnsafeMutablePointer<Int64>) -> Bool {
-        return _scanString.scan(_skipSet, locationToScanFrom: &_scanLocation) { (value: Int64) -> Void in
-            result.pointee = value
-        }
-    }
-    
-    @discardableResult
-    public func scanUnsignedLongLong(_ result: UnsafeMutablePointer<UInt64>) -> Bool {
-        return _scanString.scan(_skipSet, locationToScanFrom: &_scanLocation) { (value: UInt64) -> Void in
-            result.pointee = value
-        }
-    }
-    
-    @discardableResult
-    public func scanFloat(_ result: UnsafeMutablePointer<Float>) -> Bool {
-        return _scanString.scan(_skipSet, locale: locale, locationToScanFrom: &_scanLocation) { (value: Float) -> Void in
-            result.pointee = value
-        }
-    }
-    
-    @discardableResult
-    public func scanDouble(_ result: UnsafeMutablePointer<Double>) -> Bool {
-        return _scanString.scan(_skipSet, locale: locale, locationToScanFrom: &_scanLocation) { (value: Double) -> Void in
-            result.pointee = value
-        }
-    }
-    
-    @discardableResult
-    public func scanHexInt32(_ result: UnsafeMutablePointer<UInt32>) -> Bool {
-        return _scanString.scanHex(_skipSet, locationToScanFrom: &_scanLocation) { (value: UInt32) -> Void in
-            result.pointee = value
-        }
-    }
-    
-    @discardableResult
-    public func scanHexInt64(_ result: UnsafeMutablePointer<UInt64>) -> Bool {
-        return _scanString.scanHex(_skipSet, locationToScanFrom: &_scanLocation) { (value: UInt64) -> Void in
-            result.pointee = value
-        }
-    }
-    
-    @discardableResult
-    public func scanHexFloat(_ result: UnsafeMutablePointer<Float>) -> Bool {
-        return _scanString.scanHex(_skipSet, locale: locale, locationToScanFrom: &_scanLocation) { (value: Float) -> Void in
-            result.pointee = value
-        }
-    }
-    
-    @discardableResult
-    public func scanHexDouble(_ result: UnsafeMutablePointer<Double>) -> Bool {
-        return _scanString.scanHex(_skipSet, locale: locale, locationToScanFrom: &_scanLocation) { (value: Double) -> Void in
-            result.pointee = value
-        }
-    }
-    
-    public var isAtEnd: Bool {
-        var stringLoc = scanLocation
-        let stringLen = string.length
-        if let invSet = invertedSkipSet {
-            let range = string._nsObject.rangeOfCharacter(from: invSet, options: [], range: NSRange(location: stringLoc, length: stringLen - stringLoc))
-            stringLoc = range.length > 0 ? range.location : stringLen
-        }
-        return stringLoc == stringLen
-    }
-    
-    open class func localizedScannerWithString(_ string: String) -> AnyObject { NSUnimplemented() }
-}
-
-
 /// Revised API for avoiding usage of AutoreleasingUnsafeMutablePointer and better Optional usage.
 /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
 /// - Note: Since this API is under consideration it may be either removed or revised in the near future
@@ -619,7 +615,7 @@ extension Scanner {
     
     @discardableResult
     public func scanString(_ string:String, into ptr: UnsafeMutablePointer<String?>?) -> Bool {
-        if let str = scanString(string) {
+        if let str = _scanStringSplittingGraphemes(string) {
             ptr?.pointee = str
             return true
         }
@@ -628,7 +624,7 @@ extension Scanner {
     
     // These methods avoid calling the private API for _invertedSkipSet and manually re-construct them so that it is only usage of public API usage
     // Future implementations on Darwin of these methods will likely be more optimized to take advantage of the cached values.
-    public func scanString(_ searchString: String) -> String? {
+    private func _scanStringSplittingGraphemes(_ searchString: String) -> String? {
         let str = self.string._bridgeToObjectiveC()
         var stringLoc = scanLocation
         let stringLen = str.length
@@ -649,6 +645,7 @@ extension Scanner {
         return nil
     }
     
+    @available(swift, deprecated: 5.0, renamed: "scanCharacters(from:)")
     public func scanCharactersFromSet(_ set: CharacterSet) -> String? {
         let str = self.string._bridgeToObjectiveC()
         var stringLoc = scanLocation
@@ -670,7 +667,16 @@ extension Scanner {
         return nil
     }
     
-    public func scanUpToString(_ string: String) -> String? {
+    @discardableResult
+    public func scanUpTo(_ string:String, into ptr: UnsafeMutablePointer<String?>?) -> Bool {
+        if let str = _scanUpToStringSplittingGraphemes(string) {
+            ptr?.pointee = str
+            return true
+        }
+        return false
+    }
+    
+    public func _scanUpToStringSplittingGraphemes(_ string: String) -> String? {
         let str = self.string._bridgeToObjectiveC()
         var stringLoc = scanLocation
         let stringLen = str.length
@@ -700,6 +706,7 @@ extension Scanner {
         return false
     }
     
+    @available(swift, deprecated: 5.0, renamed: "scanUpToCharacters(from:)")
     public func scanUpToCharactersFromSet(_ set: CharacterSet) -> String? {
         let str = self.string._bridgeToObjectiveC()
         var stringLoc = scanLocation

--- a/Foundation/ScannerAPI.swift
+++ b/Foundation/ScannerAPI.swift
@@ -1,0 +1,198 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+extension CharacterSet {
+    fileprivate func contains(_ character: Character) -> Bool {
+        return character.unicodeScalars.allSatisfy(self.contains(_:))
+    }
+}
+
+// -----
+
+@available(swift 5.0)
+extension Scanner {
+    public enum NumberRepresentation {
+        case decimal // See the %d, %f and %F format conversions.
+        case hexadecimal // See the %x, %X, %a and %A format conversions. For integers, a leading 0x or 0X is optional; for floating-point numbers, it is required.
+    }
+    
+    public var currentIndex: String.Index {
+        get {
+            let string = self.string
+            var index = string._toUTF16Index(scanLocation)
+            
+            var delta = 0
+            while index != string.endIndex && index.samePosition(in: string) == nil {
+                delta += 1
+                index = string._toUTF16Index(scanLocation + delta)
+            }
+            
+            return index
+        }
+        set { scanLocation = string._toUTF16Offset(newValue) }
+    }
+    
+    public func scanInt(representation: NumberRepresentation = .decimal) -> Int? {
+        #if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+        if let value = scanInt64(representation: representation) {
+            return Int(value)
+        }
+        #elseif arch(i386) || arch(arm)
+        if let value = scanInt32(representation: representation) {
+            return Int(value)
+        }
+        #else
+        #error("This architecture isn't known. Add it to the 32-bit or 64-bit line; if the machine word isn't either of those, you need to implement appropriate scanning and handle the potential overflow here.")
+        #endif
+        return nil
+    }
+    
+    public func scanInt32(representation: NumberRepresentation = .decimal) -> Int32? {
+        var value = Int32.max
+        switch representation {
+        case .decimal: guard self.scanInt32(&value) else { return nil }
+        default:
+            var overflowingValue = UInt32.max
+            guard self.scanHexInt32(&overflowingValue) else { return nil }
+            if overflowingValue < Int32.max {
+                value = Int32(overflowingValue)
+            }
+        }
+        return value
+    }
+    
+    public func scanInt64(representation: NumberRepresentation = .decimal) -> Int64? {
+        var value = Int64.max
+        switch representation {
+        case .decimal: guard self.scanInt64(&value) else { return nil }
+        case .hexadecimal:
+            var overflowingValue = UInt64.max
+            guard self.scanHexInt64(&overflowingValue) else { return nil }
+            if overflowingValue < Int64.max {
+                value = Int64(overflowingValue)
+            }
+        }
+        return value
+    }
+    
+    public func scanUInt64(representation: NumberRepresentation = .decimal) -> UInt64? {
+        var value = UInt64.max
+        switch representation {
+        case .decimal: guard self.scanUnsignedLongLong(&value) else { return nil }
+        case .hexadecimal: guard self.scanHexInt64(&value) else { return nil }
+        }
+        return value
+    }
+    
+    public func scanFloat(representation: NumberRepresentation = .decimal) -> Float? {
+        var value = Float.greatestFiniteMagnitude
+        switch representation {
+        case .decimal: guard self.scanFloat(&value) else { return nil }
+        case .hexadecimal: guard self.scanHexFloat(&value) else { return nil }
+        }
+        return value
+    }
+    
+    public func scanDouble(representation: NumberRepresentation = .decimal) -> Double? {
+        var value = Double.greatestFiniteMagnitude
+        switch representation {
+        case .decimal: guard self.scanDouble(&value) else { return nil }
+        case .hexadecimal: guard self.scanHexDouble(&value) else { return nil }
+        }
+        return value
+    }
+    
+    fileprivate var _currentIndexAfterSkipping: String.Index {
+        guard let skips = charactersToBeSkipped else { return currentIndex }
+        
+        let index = string[currentIndex...].firstIndex(where: { !skips.contains($0) })
+        return index ?? string.endIndex
+    }
+    
+    public func scanString(_ searchString: String) -> String? {
+        let currentIndex = _currentIndexAfterSkipping
+        
+        guard let substringEnd = string.index(currentIndex, offsetBy: searchString.count, limitedBy: string.endIndex) else { return nil }
+        
+        if string.compare(searchString, options: self.caseSensitive ? [] : .caseInsensitive, range: currentIndex ..< substringEnd, locale: self.locale as? Locale) == .orderedSame {
+            let it = string[currentIndex ..< substringEnd]
+            self.currentIndex = substringEnd
+            return String(it)
+        } else {
+            return nil
+        }
+    }
+    
+    public func scanCharacters(from set: CharacterSet) -> String? {
+        let currentIndex = _currentIndexAfterSkipping
+        
+        let substringEnd = string[currentIndex...].firstIndex(where: { !set.contains($0) }) ?? string.endIndex
+        guard currentIndex != substringEnd else { return nil }
+        
+        let substring = string[currentIndex ..< substringEnd]
+        self.currentIndex = substringEnd
+        return String(substring)
+    }
+    
+    public func scanUpToString(_ substring: String) -> String? {
+        guard !substring.isEmpty else { return nil }
+        let string = self.string
+        let startIndex = _currentIndexAfterSkipping
+        
+        var beginningOfNewString = string.endIndex
+        var currentSearchIndex = startIndex
+        
+        repeat {
+            guard let range = string.range(of: substring, options: self.caseSensitive ? [] : .caseInsensitive, range: currentSearchIndex ..< string.endIndex, locale: self.locale as? Locale) else {
+                // If the string isn't found at all, it means it's not in the string. Just take everything to the end.
+                beginningOfNewString = string.endIndex
+                break
+            }
+            
+            // range(of:…) can return partial grapheme ranges when dealing with emoji.
+            // Make sure we take a range only if it doesn't split a grapheme in the string.
+            if let maybeBeginning = range.lowerBound.samePosition(in: string),
+                range.upperBound.samePosition(in: string) != nil {
+                beginningOfNewString = maybeBeginning
+                break
+            }
+            
+            // If we got here, we need to search again starting from just after the location we found.
+            currentSearchIndex = range.upperBound
+        } while beginningOfNewString == string.endIndex && currentSearchIndex < string.endIndex
+        
+        guard startIndex != beginningOfNewString else { return nil }
+        
+        let foundSubstring = string[startIndex ..< beginningOfNewString]
+        self.currentIndex = beginningOfNewString
+        return String(foundSubstring)
+    }
+    
+    public func scanUpToCharacters(from set: CharacterSet) -> String? {
+        let currentIndex = _currentIndexAfterSkipping
+        let string = self.string
+        
+        let firstCharacterInSet = string[currentIndex...].firstIndex(where: { set.contains($0) }) ?? string.endIndex
+        guard currentIndex != firstCharacterInSet else { return nil }
+        self.currentIndex = firstCharacterInSet
+        return String(string[currentIndex ..< firstCharacterInSet])
+    }
+    
+    public func scanCharacter() -> Character? {
+        let currentIndex = _currentIndexAfterSkipping
+        
+        let string = self.string
+        
+        guard currentIndex != string.endIndex else { return nil }
+        
+        let character = string[currentIndex]
+        self.currentIndex = string.index(after: currentIndex)
+        return character
+    }
+}

--- a/TestFoundation/TestScanner.swift
+++ b/TestFoundation/TestScanner.swift
@@ -1,58 +1,483 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-class TestScanner : XCTestCase {
+fileprivate func withScanner(for string: String, invoking block: ((Scanner) throws -> Void)? = nil) rethrows {
+    let scanner = Scanner(string: string)
+    scanner.locale = Locale(identifier: "en_US_POSIX")
+    try block?(scanner)
+}
 
+extension CharacterSet {
+    fileprivate init(unicodeScalarsIn string: String) {
+        // Needed because: rdar://47615913
+        var set = CharacterSet()
+        for character in string {
+            for scalar in character.unicodeScalars {
+                set.insert(scalar)
+            }
+        }
+        
+        self = set
+    }
+}
+
+class TestScanner : XCTestCase {
+    func testScanFloatingPoint() {
+        // Leading whitespace:
+        withScanner(for: "    1.2345") {
+            expectEqual($0.scanFloat(), 1.2345 as Float, within: 0.0001 as Float, "Parsing with leading whitespace should work")
+        }
+        
+        // Test all digits and numbers 0..9 + - E e:
+        withScanner(for: "-1.23456789E123") {
+            expectEqual($0.scanDouble(), atof("-1.23456789E123"), within: 0.00000001e123, "Parsing double with uppercase exponential notation")
+        }
+        
+        withScanner(for: "+1.23456789e0") {
+            expectEqual($0.scanDouble(), atof("+1.23456789e0"), within: 0.000000001, "Parsing double with lowercase exponential notation")
+        }
+        
+        // Large magnitude:
+        let largeA = "1234567890123456789012345678901234567890123456789012345678901234"
+        withScanner(for: largeA) {
+            expectEqual($0.scanDouble(), atof(largeA), within: 0.0000000000000001e64, "Parsing large magnitude double")
+            
+        }
+        
+        let largeB = "\(largeA)\(largeA)"
+        withScanner(for: largeB) {
+            expectEqual($0.scanDouble(), atof(largeB), within: 0.0000000000000001e128, "Parsing large magnitude double")
+            
+        }
+        
+        // Doubles and ints:
+        withScanner(for: " 3.14   -89.1 0.0 0.0 -4.E-4 128 100.99  ") {
+            expectEqual($0.scanDouble(), atof("3.14"), "Doubles and ints: 1")
+            expectEqual($0.scanDouble(), atof("-89.1"), "Doubles and ints: 2")
+            expectEqual($0.scanDouble(), atof("0.0"), "Doubles and ints: 3")
+            expectEqual($0.scanDouble(), atof("0.0"), "Doubles and ints: 4")
+            expectEqual($0.scanDouble(), atof("-4.E-4"), "Doubles and ints: 5")
+            expectEqual($0.scanDouble(), atof("128"), "Doubles and ints: 6")
+            expectEqual($0.scanInt(), 100, "Doubles and ints: 7") // Make sure scanning ints does not consume the decimal separator
+            expectEqual($0.scanDouble(), atof(".99"), "Doubles and ints: 8")
+        }
+        
+        // Roundtrip:
+        withScanner(for: String(format: " %3.5f %3.5f ", 3.14 as Double, -100.00 as Double)) {
+            expectEqual($0.scanDouble(), atof("3.14"), "Roundtrip: 1")
+            expectEqual($0.scanDouble(), atof("-100"), "Roundtrip: 2")
+        }
+    }
+    
+    func testHexRepresentation() {
+        // Long sequence:
+        withScanner(for: " 9 F 0xF 98 0x98 0x00098 0x980000000 0x980000000 acdcg0xacdcg0XACDCg0xg fFfffffE 0?777\t\n 004321X ") {
+            expectEqual($0.scanInt32(representation: .hexadecimal), 9, "Same as decimal")
+            expectEqual($0.scanInt32(representation: .hexadecimal), 0xF, "Single digit")
+            expectEqual($0.scanInt32(representation: .hexadecimal), 0xF, "Single digit with 0x prefix")
+            expectEqual($0.scanInt32(representation: .hexadecimal), 0x98, "Two digits")
+            expectEqual($0.scanInt32(representation: .hexadecimal), 0x98, "Two digits with 0x prefix")
+            expectEqual($0.scanInt32(representation: .hexadecimal), 0x98, "Two digits with 0x prefix and leading zeros")
+            
+            expectEqual($0.scanInt32(representation: .hexadecimal), Int32.max, "Overflow")
+            expectEqual($0.scanUInt64(representation: .hexadecimal), 0x980000000 as UInt64, "Unsigned 64-bit")
+            
+            expectEqual($0.scanInt32(representation: .hexadecimal), 0xacdc, "Followed by non-hex-digit without space")
+            expectEqual($0.scanString("g"), "g", "Consume non-hex-digit")
+            expectEqual($0.scanInt32(representation: .hexadecimal), 0xacdc, "Followed by non-hex-digit without space, with 0x prefix")
+            expectEqual($0.scanString("g"), "g", "Consume non-hex-digit (2)")
+            expectEqual($0.scanInt32(representation: .hexadecimal), 0xacdc, "Followed by non-hex-digit without space, with 0X prefix")
+            expectEqual($0.scanString("g"), "g", "Consume non-hex-digit (3)")
+            expectEqual($0.scanInt32(representation: .hexadecimal), 0, "'0x' followed by non-hex-digit without space")
+            expectEqual($0.scanInt32(representation: .hexadecimal), nil, "'x' (after trying to parse '0xg' as hexadecimal) isn't parsed as hex int itself")
+            expectEqual($0.scanString("xg"), "xg", "Consume non-hex-digits (4)")
+            
+            expectEqual($0.scanInt64(representation: .hexadecimal), 0xfffffffe, "Mixed case, 64-bit")
+            
+            expectEqual($0.scanInt32(representation: .hexadecimal), 0, "0 prefixing complex whitespace sequence")
+            expectEqual($0.scanString("?"), "?", "Consume complex whitespace sequence (1)")
+            expectEqual($0.scanInt32(representation: .hexadecimal), 0x777, "777 inside complex whitespace sequence")
+            expectEqual($0.scanInt32(representation: .hexadecimal), 0x4321, "4321 with leading zeros inside complex whitespace sequence")
+            expectFalse($0.isAtEnd, "The X was not consumed")
+            expectEqual($0.scanString("X"), "X", "Consume the X")
+            expectTrue($0.isAtEnd, "The X was not consumed")
+        }
+    }
+    
+    func testUInt64() {
+        // UInt64 long sequence:
+        withScanner(for: String(format: "%llu %llu %llu 42 + 42 0 %llu", UInt64.max / 10, UInt64.max - 1, UInt64.max, UInt64.max)) {
+            expectEqual($0.scanUInt64(), UInt64.max / 10, "Order of magnitude close to max")
+            expectEqual($0.scanUInt64(), UInt64.max - 1, "One less than max")
+            expectEqual($0.scanUInt64(), UInt64.max, "Max")
+            expectEqual($0.scanUInt64(), 42 as UInt64, "Short-sized integer")
+            expectEqual($0.scanUInt64(), 42 as UInt64, "Short-sized integer, with sign, ignoring whitespace")
+            expectEqual($0.scanUInt64(), 0 as UInt64, "Zero")
+            expectEqual($0.scanUInt64(), UInt64.max, "Max again after zero (ignoring prefix whitespace without merging this with the zero)")
+        }
+        
+        // Overflow:
+        withScanner(for: "\(UInt64.max)0") {
+            expectEqual($0.scanUInt64(), UInt64.max, "Overflow")
+        }
+    }
+    
+    func testInt64() {
+        // Int64 long sequence:
+        withScanner(for: String(format: "%lld %lld %lld 42 - 42 0 -1 -1 %lld %lld", Int64.max / 10, Int64.max - 1, Int64.max, Int64.min, Int64.max)) {
+            expectEqual($0.scanInt64(), Int64.max / 10, "Order of magnitude close to max")
+            expectEqual($0.scanInt64(), Int64.max - 1, "One less than max")
+            expectEqual($0.scanInt64(), Int64.max, "Max")
+            expectEqual($0.scanInt64(), 42 as Int64, "Short-sized integer")
+            expectEqual($0.scanInt64(), -42 as Int64, "Short-sized integer, with sign, ignoring whitespace")
+            expectEqual($0.scanInt64(), 0 as Int64, "Zero")
+            expectEqual($0.scanInt64(), -1 as Int64, "Minus one")
+            expectEqual($0.scanInt64(), -1 as Int64, "Minus one after whitespace")
+            expectEqual($0.scanInt64(), Int64.min, "Min")
+            expectEqual($0.scanInt64(), Int64.max, "Max again after min (no joining it with preceding min even with ignroed whitespace)")
+        }
+        
+        // Overflow:
+        withScanner(for: "\(Int64.max)0") {
+            expectEqual($0.scanInt64(), Int64.max, "Overflow")
+        }
+    }
+    
+    func testInt32() {
+        // Int32 long sequence:
+        withScanner(for: String(format: "%d %d %d 42 - 42 0 -1 -1 %d %d", Int32.max / 10, Int32.max - 1, Int32.max, Int32.min, Int32.max)) {
+            expectEqual($0.scanInt32(), Int32.max / 10, "Order of magnitude close to max")
+            expectEqual($0.scanInt32(), Int32.max - 1, "One less than max")
+            expectEqual($0.scanInt32(), Int32.max, "Max")
+            expectEqual($0.scanInt32(), 42 as Int32, "Short-sized integer")
+            expectEqual($0.scanInt32(), -42 as Int32, "Short-sized integer, with sign, ignoring whitespace")
+            expectEqual($0.scanInt32(), 0 as Int32, "Zero")
+            expectEqual($0.scanInt32(), -1 as Int32, "Minus one")
+            expectEqual($0.scanInt32(), -1 as Int32, "Minus one after whitespace")
+            expectEqual($0.scanInt32(), Int32.min, "Min")
+            expectEqual($0.scanInt32(), Int32.max, "Max again after min (no joining it with preceding min even with ignroed whitespace)")
+        }
+        
+        // Overflow:
+        withScanner(for: "\(Int32.max)0") {
+            expectEqual($0.scanInt32(), Int32.max, "Overflow")
+        }
+    }
+    
+    func testScanCharacter() {
+        withScanner(for: " hello ") {
+            expectEqual($0.scanCharacter(), "h", "Hello! (h)")
+            expectEqual($0.scanCharacter(), "e", "Hello! (e)")
+            expectEqual($0.scanCharacter(), "l", "Hello! (l)")
+            expectEqual($0.scanCharacter(), "l", "Hello! (l)")
+            expectFalse($0.isAtEnd, "Not at end yet")
+            expectEqual($0.scanCharacter(), "o", "Hello! (o)")
+            expectTrue($0.isAtEnd, "At end (ignores trailing whitespace)")
+        }
+        
+        withScanner(for: " \tde\u{0301}mode\u{0301}\n\t\n ") {
+            expectEqual($0.scanCharacter(), "d", "Démodé! (d)")
+            expectEqual($0.scanCharacter(), "é", "Démodé! (é)") // Two code points in original, comparing to é (single code point)
+            expectEqual($0.scanCharacter(), "m", "Démodé! (m)")
+            expectEqual($0.scanCharacter(), "o", "Démodé! (o)")
+            expectEqual($0.scanCharacter(), "d", "Démodé! (d)")
+            expectFalse($0.isAtEnd, "Not at end yet")
+            expectEqual($0.scanCharacter(), "é", "Démodé! (é)") // Two code points in original, comparing to é (single code point)
+            expectTrue($0.isAtEnd, "At end (ignores trailing whitespace)")
+        }
+        
+        withScanner(for: "  \t\n❤️   \t\t\n") {
+            expectFalse($0.isAtEnd, "Not at end yet")
+            expectEqual($0.scanCharacter(), "❤️", "Scan single grapheme (made of single code point)")
+            expectTrue($0.isAtEnd, "At end (ignores trailing whitespace)")
+        }
+        
+        withScanner(for: " \t👩‍👩‍👧‍👧\n\t\n ") {
+            expectFalse($0.isAtEnd, "Not at end yet")
+            expectEqual($0.scanCharacter(), "👩‍👩‍👧‍👧", "Scan single grapheme (made of multiple code points)")
+            expectTrue($0.isAtEnd, "At end (ignores trailing whitespace)")
+        }
+        
+        // Unicode 10.0 emoji:
+        withScanner(for: " \t\u{1f9db}\u{200d}\u{2640}\u{fe0f}\n\t\n ") { // VAMPIRE, ZERO-WIDTH JOINER, FEMALE SIGN, VARIATION SELECTOR-16
+            expectFalse($0.isAtEnd, "Not at end yet")
+            expectEqual($0.scanCharacter(), "🧛‍♀️", "Scan single grapheme (made of multiple code points)")
+            expectTrue($0.isAtEnd, "At end (ignores trailing whitespace)")
+        }
+    }
+    
+    func testScanString() {
+        // Scan skipping whitespace:
+        withScanner(for: "h el lo ") {
+            expectEqual($0.scanString("hello"), nil, "Split 'hello': Cannot scan the whole word in one go")
+            expectEqual($0.scanString("h"), "h",   "Split 'hello' (h)")
+            expectEqual($0.scanString("el"), "el", "Split 'hello' (el)")
+            expectEqual($0.scanString("lo"), "lo", "Split 'hello' (lo)")
+            expectTrue($0.isAtEnd, "Split 'hello': should be at end.")
+        }
+        
+        // Scan without whitespace to skip:
+        withScanner(for: "hello ") {
+            expectEqual($0.scanString("hello"), "hello", "Joined 'hello': Can scan the whole word in one go")
+            $0.currentIndex = $0.string.startIndex
+            expectEqual($0.scanString("h"), "h",   "Joined 'hello' (h)")
+            expectEqual($0.scanString("el"), "el", "Joined 'hello' (el)")
+            expectEqual($0.scanString("lo"), "lo", "Joined 'hello' (lo)")
+            expectTrue($0.isAtEnd, "Joined 'hello': should be at end.")
+        }
+        
+        // Scan without skipping whitespace:
+        withScanner(for: "h el lo ") {
+            $0.charactersToBeSkipped = nil
+            expectEqual($0.scanString("h"), "h",   "Split 'hello', without skipping whitespace (h)")
+            expectEqual($0.scanString("el"), nil,  "Split 'hello', without skipping whitespace (el can't be scanned without consuming whitespace)")
+            expectEqual($0.scanString(" "),  " ",  "Split 'hello', without skipping whitespace (consume whitespace 1)")
+            expectEqual($0.scanString("el"), "el", "Split 'hello', without skipping whitespace (el)")
+            expectEqual($0.scanString("lo"), nil,  "Split 'hello', without skipping whitespace (lo can't be scanned without consuming whitespace)")
+            expectEqual($0.scanString(" "),  " ",  "Split 'hello', without skipping whitespace (consume whitespace 2)")
+            expectEqual($0.scanString("lo"), "lo", "Split 'hello', without skipping whitespace (lo)")
+            expectFalse($0.isAtEnd, "Split 'hello', without skipping whitespace: should not be at end without consuming trailing whitespace")
+            expectEqual($0.scanString(" "),  " ",  "Split 'hello', without skipping whitespace (consume whitespace 3)")
+            expectTrue($0.isAtEnd, "Split 'hello', without skipping whitespace: should be at end")
+        }
+        
+        // Case-insensitive scanning:
+        withScanner(for: "H eL lO ") {
+            $0.caseSensitive = false
+            expectEqual($0.scanString("h"), "H",   "Case-insensitive split 'hello' (h)")
+            expectEqual($0.scanString("el"), "eL", "Case-insensitive split 'hello' (el)")
+            expectEqual($0.scanString("lo"), "lO", "Case-insensitive split 'hello' (lo)")
+            expectTrue($0.isAtEnd, "Case-insensitive split 'hello': should be at end.")
+        }
+        
+        // Equivalent graphemes:
+        withScanner(for: "e\u{0300}") { // 'e' with a combining grave accent, two code points
+            expectEqual($0.scanString("\u{00E8}" /* U+00E8 LATIN SMALL LETTER E WITH GRAVE, one code point */), $0.string, "Can scan different string to get original as long as all graphemes are equivalent")
+        }
+        
+        // Partial graphemes:
+        withScanner(for: "e\u{0301}\u{031A}\u{032B}") {
+            // We do not assert here that the legacy methods don't work because they behave inconsistently wrt graphemes, and are able to actually discern that a combination code point plus a sequence of combining diacriticals is actually not OK to scan. Check just the newer behavior here.
+            expectEqual($0.scanString("e"), nil, "New method must not split graphemes while scanning")
+            expectEqual($0.scanString("e\u{0301}"), nil, "New method must not split graphemes while scanning")
+            expectEqual($0.scanString("e\u{0301}\u{031A}"), nil, "New method must not split graphemes while scanning")
+            expectEqual($0.scanString("e\u{0301}\u{031A}\u{032B}"), "e\u{0301}\u{031A}\u{032B}", "New method must not split graphemes while scanning")
+        }
+        
+        withScanner(for: "Lily is a 👩🏻‍💻") { // That's: [ U+1F469 WOMAN, U+1F3FB EMOJI MODIFIER FITZPATRICK SCALE 1-2, U+200D ZERO-WIDTH JOINER, U+1F4BB PERSONAL COMPUTER ]
+            // The deprecated API can scan a string that's a prefix of the code point sequence of this string, but the new method cannot do so if it would split the final character.
+            // .scanString(_:into:) interacts inconsistently with emoji. U+1F469 WOMAN will not scan by itself, but U+1F469 WOMAN, U+1F3FB EMOJI MODIFIER FITZPATRICK SCALE 1-2 will scan even though it's only part of a grapheme.
+            // .scanString() is designed to work on graphemes, so it will not scan either of these sequences.
+            expectEqual($0.scanString("Lily is a \u{1F469}\u{1F3FB}", into: nil), true, "Legacy method can split graphemes while scanning")
+            $0.currentIndex = $0.string.startIndex
+            expectEqual($0.scanString("Lily is a \u{1F469}\u{1F3FB}"), nil,             "New method must not split graphemes while scanning")
+            expectEqual($0.scanString("Lily is a \u{1F469}\u{1F3FB}\u{200D}"), nil,     "New method must not split graphemes while scanning")
+            
+            expectEqual($0.scanString("Lily is a \u{1F469}\u{1F3FB}\u{200D}\u{1F4BB}"), "Lily is a 👩🏻‍💻", "New method must work if graphemes would not be split while scanning")
+            expectTrue($0.isAtEnd, "After scanning the last grapheme, we are at end")
+        }
+        
+        // Legacy method interaction with partial grapheme scanning:
+        withScanner(for: "Lily is a 👩🏻‍💻!") {
+            expectEqual($0.scanString("Lily is a \u{1F469}\u{1F3FB}", into: nil), true, "Legacy method can split graphemes while scanning")
+            expectEqual(String($0.string[$0.currentIndex...]), "!", "The index to scan from is the one after the end of the grapheme")
+            expectEqual($0.scanString("!"), "!", "Scanning starts correctly from there")
+        }
+        
+        withScanner(for: "Lily is a 👩🏻‍💻") {
+            expectEqual($0.scanString("Lily is a \u{1F469}\u{1F3FB}", into: nil), true, "Legacy method can split graphemes while scanning")
+            expectFalse($0.isAtEnd, "The scanner can scan more using legacy methods, even though no whole graphemes are left to scan. This can only happen when legacy methods are invoked or the deprecated .scanLocation property is set directly.")
+            expectEqual($0.currentIndex, $0.string.endIndex, "The Swift.String.Index we will resume scanning from for new methods is correctly pointing to the end of the string")
+        }
+    }
+    
+    func testScanUpToString() {
+        // Scan skipping whitespace:
+        withScanner(for: "  hel lo") {
+            expectEqual($0.scanUpToString("lo"), "hel ", "Leading whitespace is skipped but not trailing whitespace before the stop point")
+            expectEqual($0.scanString("lo"), "lo", "The up-to string can be scanned immediately afterwards")
+        }
+        
+        // Scan without skipping whitespace:
+        withScanner(for: "  hel lo") {
+            $0.charactersToBeSkipped = nil
+            expectEqual($0.scanUpToString("lo"), "  hel ", "No whitespace is skipped")
+            expectEqual($0.scanString("lo"), "lo", "The up-to string can be scanned immediately afterwards")
+        }
+        
+        // Case-insensitive:
+        withScanner(for: "  hel LOo!") {
+            $0.caseSensitive = false
+            expectEqual($0.scanUpToString("lo"), "hel ", "Leading whitespace is skipped but not trailing whitespace before the stop point")
+            expectEqual($0.scanString("lo"), "LO", "The up-to string can be scanned immediately afterwards (and actual case is returned)")
+        }
+        
+        // Equivalent graphemes:
+        withScanner(for: "wow e\u{0300}") { // 'e' with a combining grave accent, two code points
+            expectEqual($0.scanUpToString("\u{00E8}" /* U+00E8 LATIN SMALL LETTER E WITH GRAVE, one code point */), "wow ", "Can scan different string to get original as long as all graphemes are equivalent")
+            expectEqual($0.scanString("\u{00E8}"), "e\u{0300}", "The up-to string can be scanned immediately afterwards (and actual source form is returned)")
+        }
+        
+        // Partial graphemes (diacritics):
+        withScanner(for: "wow e\u{0301}\u{031A}\u{032B} NOT FOUND") {
+            // We do not assert here that the legacy methods don't work because they behave inconsistently wrt graphemes, and are able to actually discern that a combination code point plus a sequence of combining diacriticals is actually not OK to scan. Check just the newer behavior here.
+            // The correct failure mode here is that the whole string should be returned on failure to match — the partial grapheme match won't stop scanUpToString(_:), which will keep looking later. This means that on failure to find, the methods will succeed -- this is why we reset .currentIndex after every invocation.
+            expectEqual($0.scanUpToString("e"), $0.string, "New method must go past graphemes that match part of the scan-up-to string while scanning")
+            $0.currentIndex = $0.string.startIndex
+            expectEqual($0.scanUpToString("e\u{0301}"), $0.string, "New method must go past graphemes that match part of the scan-up-to string while scanning")
+            $0.currentIndex = $0.string.startIndex
+            expectEqual($0.scanUpToString("e\u{0301}\u{031A}"), $0.string, "New method must go past graphemes that match part of the scan-up-to string while scanning")
+            $0.currentIndex = $0.string.startIndex
+            expectEqual($0.scanUpToString("e\u{0301}\u{031A}\u{032B}"), "wow ", "New method must match a full grapheme and stop there")
+            expectEqual($0.scanString("e\u{0301}\u{031A}\u{032B}"), "e\u{0301}\u{031A}\u{032B}", "The up-to string can be scanned immediately afterwards")
+        }
+        
+        // Partial graphemes (emoji):
+        withScanner(for: "Lily is a 👩🏻‍💻 NOT FOUND") { // That's: [ U+1F469 WOMAN, U+1F3FB EMOJI MODIFIER FITZPATRICK SCALE 1-2, U+200D ZERO-WIDTH JOINER, U+1F4BB PERSONAL COMPUTER ]
+            expectEqual($0.scanUpToString("\u{1F469}"), $0.string, "New method must go past graphemes that match part of the scan-up-to string while scanning")
+            $0.currentIndex = $0.string.startIndex
+            expectEqual($0.scanUpToString("\u{1F469}\u{1F3FB}"), $0.string, "New method must go past graphemes that match part of the scan-up-to string while scanning")
+            $0.currentIndex = $0.string.startIndex
+            expectEqual($0.scanUpToString("\u{1F469}\u{1F3FB}\u{200D}"), $0.string, "New method must go past graphemes that match part of the scan-up-to string while scanning")
+            
+            $0.currentIndex = $0.string.startIndex
+            expectEqual($0.scanUpToString("\u{1F469}\u{1F3FB}\u{200D}\u{1F4BB}"), "Lily is a ", "New method must work if graphemes would not be split while scanning")
+            expectEqual($0.scanString("👩🏻‍💻"), "👩🏻‍💻", "The up-to string can be scanned immediately afterwards")
+        }
+    }
+    
+    func testScanCharactersFromSet() {
+        // Scan skipping whitespace:
+        withScanner(for: "   doremifasol123 whoa") {
+            expectEqual($0.scanCharacters(from: .alphanumerics), "doremifasol123", "Skip leading whitespace, but do stop when new whitespace occurs")
+        }
+        
+        // Scan without skipping whitespace:
+        withScanner(for: "   doremifasol123 !!") {
+            $0.charactersToBeSkipped = nil
+            expectEqual($0.scanCharacters(from: .alphanumerics), nil, "Do not skip leading whitespace")
+            let combined = CharacterSet.alphanumerics.union(.whitespaces)
+            expectEqual($0.scanCharacters(from: combined), "   doremifasol123 ", "Pick up whitespace when explicitly requested, including trailing whitespace, and stop before the final characters outside the set")
+        }
+        
+        // Case sensitivity does not impact .scanCharacters(from:)
+        withScanner(for: "wowWOW") {
+            $0.caseSensitive = false
+            expectEqual($0.scanCharacters(from: CharacterSet(charactersIn: "wo")), "wow", ".caseSensitive does not change which characters are found by scanCharacters(from:)")
+        }
+        
+        // Scan only full graphemes (diacritics):
+        withScanner(for: " e\u{0301}\u{031A}\u{032B} wow") {
+            expectEqual($0.scanCharacters(from: CharacterSet(charactersIn: "e")), nil, "Cannot scan a grapheme that contains one or more code points not in the set")
+            expectEqual($0.scanCharacters(from: CharacterSet(charactersIn: "e\u{0301}")), nil, "Cannot scan a grapheme that contains one or more code points not in the set")
+            expectEqual($0.scanCharacters(from: CharacterSet(charactersIn: "e\u{0301}\u{031A}")), nil, "Cannot scan a grapheme that contains one or more code points not in the set")
+            expectEqual($0.scanCharacters(from: CharacterSet(charactersIn: "e\u{0301}\u{031A}\u{032B}")), "e\u{0301}\u{031A}\u{032B}", "Can scan a grapheme if all of its code points are in the character set")
+        }
+        
+        // Scan only full graphemes (emoji):
+        withScanner(for: "Lily is a 👩🏻‍💻") { // That's: [ U+1F469 WOMAN, U+1F3FB EMOJI MODIFIER FITZPATRICK SCALE 1-2, U+200D ZERO-WIDTH JOINER, U+1F4BB PERSONAL COMPUTER ]
+            $0.currentIndex = $0.string.startIndex
+            expectEqual($0.scanCharacters(from: CharacterSet(unicodeScalarsIn: "Lily is a \u{1F469}")), "Lily is a ", "Cannot scan a grapheme that contains one or more code points not in the set")
+            
+            $0.currentIndex = $0.string.startIndex
+            expectEqual($0.scanCharacters(from: CharacterSet(unicodeScalarsIn: "Lily is a \u{1F469}\u{1F3FB}")), "Lily is a ", "Cannot scan a grapheme that contains one or more code points not in the set")
+            
+            $0.currentIndex = $0.string.startIndex
+            expectEqual($0.scanCharacters(from: CharacterSet(unicodeScalarsIn: "Lily is a \u{1F469}\u{1F3FB}\u{200D}")), "Lily is a ","Cannot scan a grapheme that contains one or more code points not in the set")
+            
+            $0.currentIndex = $0.string.startIndex
+            let set = CharacterSet(unicodeScalarsIn: "Lily is a \u{1F469}\u{1F3FB}\u{200D}\u{1F4BB}")
+            expectEqual($0.scanCharacters(from: set), "Lily is a 👩🏻‍💻", "Can scan a grapheme if all of its code points are in the character set")
+        }
+    }
+    
+    func testScanUpToCharactersFromSet() {
+        // Scan skipping whitespace:
+        withScanner(for: "   hel- lo ") {
+            let hyphen = CharacterSet(unicodeScalarsIn: "-")
+            
+            expectEqual($0.scanUpToCharacters(from: .alphanumerics), nil, "Whitespace should be skipped, and we should already be at a place where alphanumerics match 'hel'")
+            expectEqual($0.scanUpToCharacters(from: hyphen), "hel", "Whitespace should be skipped, and the rest captured until the separator")
+            expectEqual($0.scanCharacters(from: hyphen), "-", "You should be able to scan the up-to string immediately")
+            expectEqual($0.scanUpToCharacters(from: .alphanumerics), nil, "Whitespace should be skipped, and we should already be at a place where alphanumerics match 'lo'")
+        }
+        
+        // Scan without skipping whitespace:
+        withScanner(for: "   hel- lo ") {
+            let hyphen = CharacterSet(unicodeScalarsIn: "-")
+            $0.charactersToBeSkipped = nil
+            
+            expectEqual($0.scanUpToCharacters(from: .alphanumerics), "   ", "Whitespace should not be skipped.")
+            expectEqual($0.scanUpToCharacters(from: hyphen), "hel", "Move to the hyphen and scan the 'hel' in the process")
+            expectEqual($0.scanUpToCharacters(from: .whitespaces), "-", "Scan hyphen, to the whitespace")
+            expectEqual($0.scanUpToCharacters(from: .alphanumerics), " ", "Whitespace should not be skipped, and we should move at a place where alphanumerics match 'lo'")
+            expectEqual($0.scanString("lo"), "lo", "Consume the 'lo'")
+        }
+        
+        withScanner(for: "so, HELLO") {
+            $0.caseSensitive = false
+            expectEqual($0.scanUpToCharacters(from: CharacterSet(unicodeScalarsIn: "h")), "so, HELLO", ".caseSensitive should not affect .scanUpToCharacters(from:); a set of only 'h' should not match 'H'")
+        }
+        
+        // Equivalent graphemes:
+        withScanner(for: "wow e\u{0300}") { // 'e' with a combining grave accent, two code points
+            let set = CharacterSet(unicodeScalarsIn: "\u{00E8}" /* U+00E8 LATIN SMALL LETTER E WITH GRAVE, one code point */)
+            expectEqual($0.scanUpToCharacters(from: set), "wow e\u{0300}", "Scanning using a character set should only match graphemes if the specific code points they are composed of are in the character set. 'e' + combining accent is not matched by a set with just 'è', even though they make equivalent graphemes")
+            
+            $0.currentIndex = $0.string.startIndex
+            expectEqual($0.scanUpToCharacters(from: CharacterSet(unicodeScalarsIn: "e\u{0300}")), "wow ", "Scanning does match if the specific code points are in the set")
+            
+        }
+        
+        // Partial graphemes (diacritics):
+        withScanner(for: "wow e\u{0301}\u{031A}\u{032B} NOT FOUND") {
+            // The correct failure mode here is that the whole string should be returned on failure to match — the partial grapheme match won't stop scanUpToCharacters(from:), which will keep looking later. This means that on failure to find, the methods will succeed -- this is why we reset .currentIndex after every invocation.
+            expectEqual($0.scanUpToCharacters(from: CharacterSet(unicodeScalarsIn: "e")), $0.string, "New method must go past graphemes that match part of the scan-up-to string while scanning")
+            
+            $0.currentIndex = $0.string.startIndex
+            expectEqual($0.scanUpToCharacters(from: CharacterSet(unicodeScalarsIn: "e\u{0301}")), $0.string, "New method must go past graphemes that match part of the scan-up-to string while scanning")
+            
+            $0.currentIndex = $0.string.startIndex
+            expectEqual($0.scanUpToCharacters(from: CharacterSet(unicodeScalarsIn: "e\u{0301}\u{031A}")), $0.string, "New method must go past graphemes that match part of the scan-up-to string while scanning")
+            
+            $0.currentIndex = $0.string.startIndex
+            expectEqual($0.scanUpToCharacters(from: CharacterSet(unicodeScalarsIn: "e\u{0301}\u{031A}\u{032B}")), "wow ", "Scanning does match if the specific code points are in the set")
+            expectEqual($0.scanCharacters(from: CharacterSet(unicodeScalarsIn: "e\u{0301}\u{031A}\u{032B}")), "e\u{0301}\u{031A}\u{032B}", "The up-to character set can be scanned immediately afterwards")
+        }
+        
+        // Partial graphemes (emoji):
+        withScanner(for: "Lily is a 👩🏻‍💻 NOT FOUND") { // That's: [ U+1F469 WOMAN, U+1F3FB EMOJI MODIFIER FITZPATRICK SCALE 1-2, U+200D ZERO-WIDTH JOINER, U+1F4BB PERSONAL COMPUTER ]
+            expectEqual($0.scanUpToCharacters(from: CharacterSet(unicodeScalarsIn: "\u{1F469}")), $0.string, "New method must go past graphemes that match part of the scan-up-to string while scanning")
+            $0.currentIndex = $0.string.startIndex
+            expectEqual($0.scanUpToCharacters(from: CharacterSet(unicodeScalarsIn: "\u{1F469}\u{1F3FB}")), $0.string, "New method must go past graphemes that match part of the scan-up-to string while scanning")
+            $0.currentIndex = $0.string.startIndex
+            expectEqual($0.scanUpToCharacters(from: CharacterSet(unicodeScalarsIn: "\u{1F469}\u{1F3FB}\u{200D}")), $0.string, "New method must go past graphemes that match part of the scan-up-to string while scanning")
+            
+            $0.currentIndex = $0.string.startIndex
+            let finalSet = CharacterSet(unicodeScalarsIn: "\u{1F469}\u{1F3FB}\u{200D}\u{1F4BB}")
+            expectEqual($0.scanUpToCharacters(from: finalSet), "Lily is a ", "New method must work if graphemes would not be split while scanning")
+            expectEqual($0.scanCharacters(from: finalSet), "👩🏻‍💻", "The up-to character set can be scanned immediately afterwards")
+        }
+    }
+    
     static var allTests: [(String, (TestScanner) -> () throws -> Void)] {
         return [
-            ("test_scanInteger", test_scanInteger),
-            ("test_scanFloat", test_scanFloat),
-            ("test_scanString", test_scanString),
-            ("test_charactersToBeSkipped", test_charactersToBeSkipped),
+            ("testScanFloatingPoint", testScanFloatingPoint),
+            ("testHexRepresentation", testHexRepresentation),
+            ("testUInt64", testUInt64),
+            ("testInt64", testInt64),
+            ("testInt32", testInt32),
+            ("testScanCharacter", testScanCharacter),
+            ("testScanString", testScanString),
+            ("testScanUpToString", testScanUpToString),
+            ("testScanCharactersFromSet", testScanCharactersFromSet),
+            ("testScanUpToCharactersFromSet", testScanUpToCharactersFromSet),
         ]
-    }
-
-    func test_scanInteger() {
-        let scanner = Scanner(string: "123")
-        var value: Int = 0
-        XCTAssert(scanner.scanInt(&value), "An Integer should be found in the string `123`.")
-        XCTAssertEqual(value, 123, "Scanned Integer value of the string `123` should be `123`.")
-        XCTAssertTrue(scanner.isAtEnd)
-    }
-
-    func test_scanFloat() {
-        let scanner = Scanner(string: "-350000000000000000000000000000000000000000")
-        var value: Float = 0
-        XCTAssert(scanner.scanFloat(&value), "A Float should be found in the string `-350000000000000000000000000000000000000000`.")
-        XCTAssert(value.isInfinite, "Scanned Float value of the string `-350000000000000000000000000000000000000000` should be infinite`.")
-    }
-
-    func test_scanString() {
-        let scanner = Scanner(string: "apple sauce")
-
-        guard let firstPart = scanner.scanString("apple ") else {
-            XCTFail()
-            return
-        }
-
-        XCTAssertEqual(firstPart, "apple ")
-        XCTAssertFalse(scanner.isAtEnd)
-
-        let _ = scanner.scanString("sauce")
-        XCTAssertTrue(scanner.isAtEnd)
-    }
-
-    func test_charactersToBeSkipped() {
-        let scanner = Scanner(string: "xyz  ")
-        scanner.charactersToBeSkipped = .whitespaces
-
-        let _ = scanner.scanString("xyz")
-        XCTAssertTrue(scanner.isAtEnd)
     }
 }

--- a/TestFoundation/Utilities.swift
+++ b/TestFoundation/Utilities.swift
@@ -156,6 +156,22 @@ func expectTrue(_ actual: Bool, _ message: @autoclosure () -> String = "") {
     XCTAssertTrue(actual, message())
 }
 
+func expectFalse(_ actual: Bool, _ message: @autoclosure () -> String = "") {
+    XCTAssertFalse(actual, message())
+}
+
 func expectEqual<T: Equatable>(_ expected: T, _ actual: T, _ message: @autoclosure () -> String = "") {
     XCTAssertEqual(expected, actual, message())
 }
+
+func expectEqual<T: FloatingPoint>(_ expected: T, _ actual: T, within: T, _ message: @autoclosure () -> String = "") {
+    XCTAssertEqual(expected, actual, accuracy: within, message())
+}
+
+func expectEqual<T: FloatingPoint>(_ expected: T?, _ actual: T, within: T, _ message: @autoclosure () -> String = "") {
+    XCTAssertNotNil(expected, message())
+    if let expected = expected {
+        XCTAssertEqual(expected, actual, accuracy: within, message())
+    }
+}
+


### PR DESCRIPTION
Add API on Scanner that's more idiomatic for use in Swift. This promotes some of the existing experimental API and deprecates the rest. The new API is intended to operate on graphemes, not single UTF-16 code units. This API is not experimental and will be supported going forward.