### PR TITLE
Foundation: fix a couple of compile errors

### DIFF
--- a/Foundation/FoundationErrors.swift
+++ b/Foundation/FoundationErrors.swift
@@ -7,6 +7,10 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(Windows)
+import WinSDK
+#endif
+
 /// File-system operation attempted on non-existent file.
 public var NSFileNoSuchFileError: Int                        { return CocoaError.Code.fileNoSuchFile.rawValue }
 

--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -777,7 +777,7 @@ open class Process: NSObject {
     // status
 #if os(Windows)
     open private(set) var processHandle: HANDLE = INVALID_HANDLE_VALUE
-    open private(set) var processIdentifier: Int32 {
+    open var processIdentifier: Int32 {
       return Int32(GetProcessId(processHandle))
     }
     open private(set) var isRunning: Bool = false


### PR DESCRIPTION
FoundationErrors does not depend on NSSwiftRuntime and thus does not
transitively get the WinSDK import when not building in whole program
mode.  Add an import to get a definition of `DWORD`.

Remoe the `private(set)` from the computed `processIdentifier` property
which is already readonly due to the definition of the computed
property.