### PR TITLE
Add additional shims for Operation that mimic the KeyPath<> KVC methods.

### DIFF
--- a/Foundation/Operation.swift
+++ b/Foundation/Operation.swift
@@ -186,6 +186,16 @@ extension Operation {
             finish()
         }
     }
+    
+    public func willChangeValue<Value>(for keyPath: KeyPath<Operation, Value>) {
+        // do nothing
+    }
+    
+    public func didChangeValue<Value>(for keyPath: KeyPath<Operation, Value>) {
+        if keyPath == \Operation.isFinished {
+            finish()
+        }
+    }
 }
 
 extension Operation {


### PR DESCRIPTION
Some implementations use these methods for implementing their `Operation`s. We probably still need generalized shims, but these are important to the functionality of the class.