### PR TITLE
Foundation: build CoreFoundation as /MD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,6 @@ ExternalProject_Add(CoreFoundation
                       -DBUILD_SHARED_LIBS=NO
                       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                       -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-                      # NOTE(compnerd) ensure that we build it as a DLL as we
-                      # wish to re-export the symbols from Foundation
-                      -DCMAKE_C_FLAGS=-D_USRDLL
                       -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
                       -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                       -DCMAKE_INSTALL_LIBDIR=usr/lib


### PR DESCRIPTION
Use /MD and /MDd mode compilation rather than /MT or /MTd as per
Microsoft's recommendation.  This allows us to use a shared C runtime.
The static MSVCRT/ucrt cannot be intermingled with a dynamic one.