### PR TITLE
<SR-9930> Swift CI: TestProcess.test_passthrough_environment : failed - Test failed: InvalidEnvironmentVariable("swift_xcode")

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -3120,7 +3120,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -3140,7 +3140,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = org.swift.xdgTestHelper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -248,37 +248,38 @@ class TestProcess : XCTestCase {
         }
     }
     
-    func test_passthrough_environment() {
-        do {
-            let (output, _) = try runTask(["/usr/bin/env"], environment: nil)
-            let env = try parseEnv(output)
-            XCTAssertGreaterThan(env.count, 0)
-        } catch {
-            // FIXME: SR-9930 parseEnv fails if an environment variable contains
-            // a newline.
-            // XCTFail("Test failed: \(error)")
+    func helperToolEnvironment(from environment: [String: String]) -> [String: String] {
+        var result = environment
+        let importantEnvVars = ProcessInfo.processInfo.environment.filter {
+            $0.key.hasPrefix("LD_") || $0.key.hasPrefix("DYLD_")
         }
+        for entry in importantEnvVars {
+            result[entry.key] = entry.value
+        }
+        return result
+    }
+    
+    func test_passthrough_environment() throws {
+        let helper = xdgTestHelperURL()
+        let (output, _) = try runTask([helper.path, "--env"], environment: nil)
+        let env = try parseEnv(output)
+        XCTAssertGreaterThan(env.count, 0)
     }
 
-    func test_no_environment() {
-        do {
-            let (output, _) = try runTask(["/usr/bin/env"], environment: [:])
-            let env = try parseEnv(output)
-            XCTAssertEqual(env.count, 0)
-        } catch {
-            XCTFail("Test failed: \(error)")
-        }
+    func test_no_environment() throws {
+        let helper = xdgTestHelperURL()
+        let input = helperToolEnvironment(from: [:])
+        let (output, _) = try runTask([helper.path, "--env"], environment: input)
+        let env = try parseEnv(output)
+        XCTAssertEqual(env, input)
     }
 
-    func test_custom_environment() {
-        do {
-            let input = ["HELLO": "WORLD", "HOME": "CUPERTINO"]
-            let (output, _) = try runTask(["/usr/bin/env"], environment: input)
-            let env = try parseEnv(output)
-            XCTAssertEqual(env, input)
-        } catch {
-            XCTFail("Test failed: \(error)")
-        }
+    func test_custom_environment() throws {
+        let helper = xdgTestHelperURL()
+        let input = helperToolEnvironment(from: ["HELLO": "WORLD", "HOME": "CUPERTINO"])
+        let (output, _) = try runTask([helper.path, "--env"], environment: input)
+        let env = try parseEnv(output)
+        XCTAssertEqual(env, input)
     }
 
     private func realpathOf(path: String) -> String? {
@@ -654,14 +655,8 @@ internal func runTask(_ arguments: [String], environment: [String: String]? = ni
 }
 
 private func parseEnv(_ env: String) throws -> [String: String] {
-    var result = [String: String]()
-    for line in env.components(separatedBy: "\n") where line != "" {
-        guard let range = line.range(of: "=") else {
-            throw Error.InvalidEnvironmentVariable(line)
-        }
-        result[String(line[..<range.lowerBound])] = String(line[range.upperBound...])
-    }
-    return result
+    let dictionary = try PropertyListSerialization.propertyList(from: try env.data(using: .utf8).unwrapped(), format: nil) as? [String: String]
+    return try dictionary.unwrapped()
 }
 #endif
 

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -168,6 +168,9 @@ guard let arg = arguments.next() else {
 }
 
 switch arg {
+case "--env":
+    try! FileHandle.standardOutput.write(contentsOf: PropertyListSerialization.data(fromPropertyList: ProcessInfo.processInfo.environment, format: .xml, options: 0))
+    
 case "--xdgcheck":
     XDGCheck.run()
     


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-9930:

Some environment variables can contain \n. Instead of trying to parse env’s output, have the helper tool return the environment as a property list and deserialize that.