### PR TITLE
 Foundation : partial port of NSFileManager for Windows

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -28,7 +28,7 @@ open class FileManager : NSObject {
     
     /// Returns an array of URLs that identify the mounted volumes available on the device.
     open func mountedVolumeURLs(includingResourceValuesForKeys propertyKeys: [URLResourceKey]?, options: VolumeEnumerationOptions = []) -> [URL]? {
-        var urls: [URL]
+        var urls: [URL] = []
 
 #if os(Linux)
         guard let procMounts = try? String(contentsOfFile: "/proc/mounts", encoding: .utf8) else {
@@ -41,6 +41,36 @@ open class FileManager : NSObject {
                 urls.append(URL(fileURLWithPath: mountPoint[1], isDirectory: true))
             }
         }
+#elseif os(Windows)
+      var wszVolumeName: UnsafeMutableBufferPointer<WCHAR> = UnsafeMutableBufferPointer<WCHAR>.allocate(capacity: Int(MAX_PATH))
+      defer { wszVolumeName.deallocate() }
+
+      var hVolumes: HANDLE = FindFirstVolumeW(wszVolumeName.baseAddress, DWORD(wszVolumeName.count))
+      guard hVolumes != INVALID_HANDLE_VALUE else { return nil }
+      defer { FindVolumeClose(hVolumes) }
+
+      repeat {
+        var dwCChReturnLength: DWORD = 0
+        GetVolumePathNamesForVolumeNameW(wszVolumeName.baseAddress, nil, 0, &dwCChReturnLength)
+
+        var wszPathNames: UnsafeMutableBufferPointer<WCHAR> = UnsafeMutableBufferPointer<WCHAR>.allocate(capacity: Int(dwCChReturnLength + 1))
+        defer { wszPathNames.deallocate() }
+
+        if GetVolumePathNamesForVolumeNameW(wszVolumeName.baseAddress, wszPathNames.baseAddress, DWORD(wszPathNames.count), &dwCChReturnLength) == FALSE {
+          // TODO(compnerd) handle error
+          continue
+        }
+
+        var pPath: DWORD = 0
+        repeat {
+          let path: String = String(decodingCString: wszPathNames.baseAddress! + Int(pPath), as: UTF16.self)
+          if path.length == 0 {
+            break
+          }
+          urls.append(URL(fileURLWithPath: path, isDirectory: true))
+          pPath += DWORD(path.length + 1)
+        } while pPath < dwCChReturnLength
+      } while FindNextVolumeW(hVolumes, wszVolumeName.baseAddress, DWORD(wszVolumeName.count)) != FALSE
 #elseif canImport(Darwin)
 
         func mountPoints(_ statBufs: UnsafePointer<statfs>, _ fsCount: Int) -> [URL] {
@@ -184,21 +214,22 @@ open class FileManager : NSObject {
             return [ URL(fileURLWithPath: all, isDirectory: true, relativeTo: URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)) ]
         }
     }
-    
-    #if os(Windows) // Non-Apple OSes that do not implement FHS/XDG are not currently supported.
-    @available(*, unavailable, message: "Not implemented for this OS")
-    open func urls(for directory: SearchPathDirectory, in domainMask: SearchPathDomainMask) -> [URL] {
-        NSUnimplemented()
-    }
-    #else
+
     /* -URLsForDirectory:inDomains: is analogous to NSSearchPathForDirectoriesInDomains(), but returns an array of NSURL instances for use with URL-taking APIs. This API is suitable when you need to search for a file or files which may live in one of a variety of locations in the domains specified.
      */
     open func urls(for directory: SearchPathDirectory, in domainMask: SearchPathDomainMask) -> [URL] {
         let domains = _SearchPathDomain.allInSearchOrder(from: domainMask)
-        
+
+        var urls: [URL] = []
+
+#if os(Windows)
+        for domain in domains {
+          urls.append(contentsOf: windowsURLs(for: directory, in: domain))
+        }
+#else
         // We are going to return appropriate paths on Darwin, but [] on platforms that do not have comparable locations.
         // For example, on FHS/XDG systems, applications are not installed in a single path.
-        
+
         let useDarwinPaths: Bool
         if let envVar = ProcessInfo.processInfo.environment["_NSFileManagerUseXDGPathsForDirectoryDomains"] {
             useDarwinPaths = !NSString(string: envVar).boolValue
@@ -209,9 +240,7 @@ open class FileManager : NSObject {
                 useDarwinPaths = false
             #endif
         }
-        
-        var urls: [URL] = []
-        
+
         for domain in domains {
             if useDarwinPaths {
                 urls.append(contentsOf: darwinURLs(for: directory, in: domain))
@@ -219,10 +248,99 @@ open class FileManager : NSObject {
                 urls.append(contentsOf: xdgURLs(for: directory, in: domain))
             }
         }
-        
+#endif
+
         return urls
     }
-    #endif
+
+#if os(Windows)
+    private class func url(for id: KNOWNFOLDERID) -> URL {
+      var pszPath: PWSTR?
+      let hResult: HRESULT = withUnsafePointer(to: id) { id in
+        SHGetKnownFolderPath(id, DWORD(KF_FLAG_DEFAULT.rawValue), nil, &pszPath)
+      }
+      precondition(hResult >= 0, "SHGetKnownFolderpath failed \(GetLastError())")
+      let url: URL = URL(fileURLWithPath: String(decodingCString: pszPath!, as: UTF16.self), isDirectory: true)
+      CoTaskMemFree(pszPath)
+      return url
+    }
+
+    private func windowsURLs(for directory: SearchPathDirectory, in domain: _SearchPathDomain) -> [URL] {
+      switch directory {
+      case .autosavedInformationDirectory:
+        // FIXME(compnerd) where should this go?
+        return []
+
+      case .desktopDirectory:
+        guard domain == .user else { return [] }
+        return [FileManager.url(for: FOLDERID_Desktop)]
+
+      case .documentDirectory:
+        guard domain == .user else { return [] }
+        return [FileManager.url(for: FOLDERID_Documents)]
+
+      case .cachesDirectory:
+        guard domain == .user else { return [] }
+        return [URL(fileURLWithPath: NSTemporaryDirectory())]
+
+      case .applicationSupportDirectory:
+        switch domain {
+        case .local:
+          return [FileManager.url(for: FOLDERID_ProgramData)]
+        case .user:
+          return [FileManager.url(for: FOLDERID_LocalAppData)]
+        default:
+          return []
+        }
+
+      case .downloadsDirectory:
+        guard domain == .user else { return [] }
+        return [FileManager.url(for: FOLDERID_Downloads)]
+
+      case .userDirectory:
+        guard domain == .user else { return [] }
+        return [FileManager.url(for: FOLDERID_UserProfiles)]
+
+      case .moviesDirectory:
+        guard domain == .user else { return [] }
+        return [FileManager.url(for: FOLDERID_Videos)]
+
+      case .musicDirectory:
+        guard domain == .user else { return [] }
+        return [FileManager.url(for: FOLDERID_Music)]
+
+      case .picturesDirectory:
+        guard domain == .user else { return [] }
+        return [FileManager.url(for: FOLDERID_PicturesLibrary)]
+
+      case .sharedPublicDirectory:
+        guard domain == .user else { return [] }
+        return [FileManager.url(for: FOLDERID_Public)]
+
+      case .trashDirectory:
+        guard domain == .user else { return [] }
+        return [FileManager.url(for: FOLDERID_RecycleBinFolder)]
+
+       // None of these are supported outside of Darwin:
+      case .applicationDirectory,
+           .demoApplicationDirectory,
+           .developerApplicationDirectory,
+           .adminApplicationDirectory,
+           .libraryDirectory,
+           .developerDirectory,
+           .documentationDirectory,
+           .coreServiceDirectory,
+           .inputMethodsDirectory,
+           .preferencePanesDirectory,
+           .applicationScriptsDirectory,
+           .allApplicationsDirectory,
+           .allLibrariesDirectory,
+           .printerDescriptionDirectory,
+           .itemReplacementDirectory:
+          return []
+      }
+    }
+#endif
 
     private lazy var xdgHomeDirectory: String = {
         let key = "HOME="
@@ -530,7 +648,7 @@ open class FileManager : NSObject {
                 }
                 #if os(macOS) || os(iOS)
                     let modeT = number.uint16Value
-                #elseif os(Linux) || os(Android) || CYGWIN
+                #elseif os(Linux) || os(Android) || os(Windows)
                     let modeT = number.uint32Value
                 #endif
                 try _fileSystemRepresentation(withPath: path, {
@@ -549,6 +667,38 @@ open class FileManager : NSObject {
         This method replaces createDirectoryAtPath:attributes:
      */
     open func createDirectory(atPath path: String, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey : Any]? = [:]) throws {
+#if os(Windows)
+        if createIntermediates {
+          var isDir: ObjCBool = false
+          if fileExists(atPath: path, isDirectory: &isDir) {
+            guard isDir.boolValue else { throw _NSErrorWithErrno(EEXIST, reading: false, path: path) }
+            return
+          }
+
+          let parent = path._nsObject.deletingLastPathComponent
+          if !parent.isEmpty && !fileExists(atPath: parent, isDirectory: &isDir) {
+            try createDirectory(atPath: parent, withIntermediateDirectories: true, attributes: attributes)
+          }
+        }
+
+        var saAttributes: SECURITY_ATTRIBUTES =
+            SECURITY_ATTRIBUTES(nLength: DWORD(MemoryLayout<SECURITY_ATTRIBUTES>.size),
+                                lpSecurityDescriptor: nil,
+                                bInheritHandle: FALSE)
+        let psaAttributes: UnsafeMutablePointer<SECURITY_ATTRIBUTES> =
+            UnsafeMutablePointer<SECURITY_ATTRIBUTES>(&saAttributes)
+
+
+        try path.withCString(encodedAs: UTF16.self) {
+          if CreateDirectoryW($0, psaAttributes) != FALSE {
+            // FIXME(compnerd) pass along path
+            throw _NSErrorWithWindowsError(GetLastError(), reading: false)
+          }
+        }
+        if let attr = attributes {
+          try self.setAttributes(attr, ofItemAtPath: path)
+        }
+#else
         try _fileSystemRepresentation(withPath: path, { pathFsRep in
             if createIntermediates {
                 var isDir: ObjCBool = false
@@ -575,9 +725,31 @@ open class FileManager : NSObject {
                 }
             }
         })
+#endif
     }
 
     private func _contentsOfDir(atPath path: String, _ closure: (String, Int32) throws -> () ) throws {
+#if os(Windows)
+        try path.withCString(encodedAs: UTF16.self) {
+          var ffd: WIN32_FIND_DATAW = WIN32_FIND_DATAW()
+
+          let hDirectory: HANDLE = FindFirstFileW($0, &ffd)
+          if hDirectory == INVALID_HANDLE_VALUE {
+            throw _NSErrorWithWindowsError(GetLastError(), reading: true)
+          }
+          defer { FindClose(hDirectory) }
+
+          repeat {
+            let path: String = withUnsafePointer(to: &ffd.cFileName) {
+              $0.withMemoryRebound(to: UInt16.self, capacity: MemoryLayout.size(ofValue: $0) / MemoryLayout<WCHAR>.size) {
+                String(decodingCString: $0, as: UTF16.self)
+              }
+            }
+
+            try closure(path, Int32(ffd.dwFileAttributes))
+          } while FindNextFileW(hDirectory, &ffd) != FALSE
+        }
+#else
         let fsRep = fileSystemRepresentation(withPath: path)
         defer { fsRep.deallocate() }
 
@@ -604,6 +776,7 @@ open class FileManager : NSObject {
                 try closure(entryName, entryType)
             }
         }
+#endif
     }
 
     /**
@@ -627,7 +800,22 @@ open class FileManager : NSObject {
         })
         return contents
     }
-    
+
+#if os(Windows)
+    private func joinPath(prefix: String, suffix: String) -> String {
+      var pszPath: PWSTR?
+      _ = prefix.withCString(encodedAs: UTF16.self) { prefix in
+        _ = suffix.withCString(encodedAs: UTF16.self) { suffix in
+          PathAllocCombine(prefix, suffix, ULONG(PATHCCH_ALLOW_LONG_PATHS.rawValue), &pszPath)
+        }
+      }
+
+      let path: String = String(decodingCString: pszPath!, as: UTF16.self)
+      LocalFree(pszPath)
+      return path
+    }
+#endif
+
     /**
     Performs a deep enumeration of the specified directory and returns the paths of all of the contained subdirectories.
     
@@ -646,22 +834,51 @@ open class FileManager : NSObject {
 
         try _contentsOfDir(atPath: path, { (entryName, entryType) throws in
             contents.append(entryName)
+#if os(Windows)
+            if entryType & FILE_ATTRIBUTE_DIRECTORY == FILE_ATTRIBUTE_DIRECTORY {
+              let subPath: String = joinPath(prefix: path, suffix: entryName)
+              let entries = try subpathsOfDirectory(atPath: subPath)
+              contents.append(contentsOf: entries.map { joinPath(prefix: entryName, suffix: $0) })
+            }
+#else
             if entryType == DT_DIR {
                 let subPath: String = path + "/" + entryName
                 let entries = try subpathsOfDirectory(atPath: subPath)
                 contents.append(contentsOf: entries.map({file in "\(entryName)/\(file)"}))
             }
+#endif
         })
         return contents
     }
-    
+
+
+#if os(Windows)
+    private func windowsFileAttributes(atPath path: String) throws -> WIN32_FILE_ATTRIBUTE_DATA {
+      var faAttributes: WIN32_FILE_ATTRIBUTE_DATA = WIN32_FILE_ATTRIBUTE_DATA()
+      return try path.withCString(encodedAs: UTF16.self) {
+        if GetFileAttributesExW($0, GetFileExInfoStandard, &faAttributes) == FALSE {
+          return faAttributes
+        }
+        throw _NSErrorWithWindowsError(GetLastError(), reading: true)
+      }
+    }
+#endif
+
     /* attributesOfItemAtPath:error: returns an NSDictionary of key/value pairs containing the attributes of the item (file, directory, symlink, etc.) at the path in question. If this method returns 'nil', an NSError will be returned by reference in the 'error' parameter. This method does not traverse a terminal symlink.
-     
+
         This method replaces fileAttributesAtPath:traverseLink:.
      */
     open func attributesOfItem(atPath path: String) throws -> [FileAttributeKey : Any] {
+        var result: [FileAttributeKey:Any] = [:]
+
+#if os(Windows)
+        let faAttributes: WIN32_FILE_ATTRIBUTE_DATA = try windowsFileAttributes(atPath: path)
+
+        result[.size] = NSNumber(value: (faAttributes.nFileSizeHigh << 32) | faAttributes.nFileSizeLow)
+        result[.modificationDate] = Date(timeIntervalSinceReferenceDate: TimeInterval(faAttributes.ftLastWriteTime))
+        // FIXME(compnerd) what about .posixPermissions, .referenceCount, .systemNumber, .systemFileNumber, .ownerAccountName, .groupOwnerAccountName, .type, .immuatable, .appendOnly, .ownerAccountID, .groupOwnerAccountID
+#else
         let s = try _lstatFile(atPath: path)
-        var result = [FileAttributeKey : Any]()
         result[.size] = NSNumber(value: UInt64(s.st_size))
 
 #if os(macOS) || os(iOS)
@@ -705,7 +922,8 @@ open class FileManager : NSObject {
 #endif
         result[.ownerAccountID] = NSNumber(value: UInt64(s.st_uid))
         result[.groupOwnerAccountID] = NSNumber(value: UInt64(s.st_gid))
-        
+#endif
+
         return result
     }
     
@@ -720,6 +938,30 @@ open class FileManager : NSObject {
     }
  #else
     open func attributesOfFileSystem(forPath path: String) throws -> [FileAttributeKey : Any] {
+      var result: [FileAttributeKey:Any] = [:]
+
+#if os(Windows)
+      try path.withCString(encodedAs: UTF16.self) {
+        let dwLength: DWORD = GetFullPathNameW($0, 0, nil, nil)
+        let szVolumePath: UnsafeMutableBufferPointer<WCHAR> = UnsafeMutableBufferPointer<WCHAR>.allocate(capacity: Int(dwLength + 1))
+        defer { szVolumePath.deallocate() }
+
+        guard GetVolumePathNameW($0, szVolumePath.baseAddress, dwLength) != FALSE else {
+          throw _NSErrorWithWindowsError(GetLastError(), reading: true)
+        }
+
+        var liTotal: ULARGE_INTEGER = ULARGE_INTEGER()
+        var liFree: ULARGE_INTEGER = ULARGE_INTEGER()
+
+        guard GetDiskFreeSpaceExW(szVolumePath.baseAddress, nil, &liTotal, &liFree) != FALSE else {
+          throw _NSErrorWithWindowsError(GetLastError(), reading: true)
+        }
+
+        result[.systemSize] = NSNumber(value: liTotal.QuadPart)
+        result[.systemFreeSize] = NSNumber(value: liFree.QuadPart)
+        // FIXME(compnerd): what about .systemNodes, .systemFreeNodes?
+      }
+#else
         // statvfs(2) doesn't support 64bit inode on Darwin (apfs), fallback to statfs(2)
         #if os(macOS) || os(iOS)
             var s = statfs()
@@ -732,9 +974,7 @@ open class FileManager : NSObject {
                 throw _NSErrorWithErrno(errno, reading: true, path: path)
             }
         #endif
-        
-        
-        var result = [FileAttributeKey : Any]()
+
         #if os(macOS) || os(iOS)
             let blockSize = UInt64(s.f_bsize)
             result[.systemNumber] = NSNumber(value: UInt64(s.f_fsid.val.0))
@@ -746,7 +986,8 @@ open class FileManager : NSObject {
         result[.systemFreeSize] = NSNumber(value: blockSize * UInt64(s.f_bavail))
         result[.systemNodes] = NSNumber(value: UInt64(s.f_files))
         result[.systemFreeNodes] = NSNumber(value: UInt64(s.f_ffree))
-        
+#endif
+
         return result
     }
 #endif
@@ -756,11 +997,27 @@ open class FileManager : NSObject {
         This method replaces createSymbolicLinkAtPath:pathContent:
      */
     open func createSymbolicLink(atPath path: String, withDestinationPath destPath: String) throws {
+#if os(Windows)
+      let faAttributes: WIN32_FILE_ATTRIBUTE_DATA = try windowsFileAttributes(atPath: path)
+      var dwFlags: DWORD = DWORD(SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE)
+      if faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY) == DWORD(FILE_ATTRIBUTE_DIRECTORY) {
+        dwFlags |= DWORD(SYMBOLIC_LINK_FLAG_DIRECTORY)
+      }
+
+      try path.withCString(encodedAs: UTF16.self) { name in
+        try destPath.withCString(encodedAs: UTF16.self) { dest in
+          guard CreateSymbolicLinkW(name, dest, dwFlags) != FALSE else {
+            throw _NSErrorWithWindowsError(GetLastError(), reading: false)
+          }
+        }
+      }
+#else
         try _fileSystemRepresentation(withPath: path, andPath: destPath, {
             guard symlink($1, $0) == 0 else {
                 throw _NSErrorWithErrno(errno, reading: false, path: path)
             }
         })
+#endif
     }
     
     /* destinationOfSymbolicLinkAtPath:error: returns a String containing the path of the item pointed at by the symlink specified by 'path'. If this method returns 'nil', an NSError will be thrown.
@@ -768,6 +1025,22 @@ open class FileManager : NSObject {
         This method replaces pathContentOfSymbolicLinkAtPath:
      */
     open func destinationOfSymbolicLink(atPath path: String) throws -> String {
+#if os(Windows)
+        var hFile: HANDLE = INVALID_HANDLE_VALUE
+        path.withCString(encodedAs: UTF16.self) { link in
+          hFile = CreateFileW(link, GENERIC_READ, DWORD(FILE_SHARE_WRITE), nil, DWORD(OPEN_EXISTING), DWORD(FILE_FLAG_BACKUP_SEMANTICS), nil)
+        }
+        if hFile == INVALID_HANDLE_VALUE {
+          throw _NSErrorWithWindowsError(GetLastError(), reading: true)
+        }
+
+        let dwLength: DWORD = GetFinalPathNameByHandleW(hFile, nil, 0, DWORD(FILE_NAME_NORMALIZED))
+        let szPath: UnsafeMutableBufferPointer<WCHAR> = UnsafeMutableBufferPointer<WCHAR>.allocate(capacity: Int(dwLength + 1))
+        defer { szPath.deallocate() }
+
+        GetFinalPathNameByHandleW(hFile, szPath.baseAddress, dwLength, DWORD(FILE_NAME_NORMALIZED))
+        return String(decodingCString: szPath.baseAddress!, as: UTF16.self)
+#else
         let bufSize = Int(PATH_MAX + 1)
         var buf = [Int8](repeating: 0, count: bufSize)
         let len = _fileSystemRepresentation(withPath: path) {
@@ -778,8 +1051,10 @@ open class FileManager : NSObject {
         }
         
         return self.string(withFileSystemRepresentation: buf, length: Int(len))
+#endif
     }
 
+#if !os(Windows)
     private func _readFrom(fd: Int32, toBuffer buffer: UnsafeMutablePointer<UInt8>, length bytesToRead: Int, filename: String) throws -> Int {
         var bytesRead = 0
 
@@ -808,7 +1083,8 @@ open class FileManager : NSObject {
             bytesWritten += written
         }
     }
-    
+#endif
+
     private func extraErrorInfo(srcPath: String?, dstPath: String?, userVariant: String?) -> [String : Any] {
         var result = [String : Any]()
         result["NSSourceFilePathErrorKey"] = srcPath
@@ -816,8 +1092,17 @@ open class FileManager : NSObject {
         result["NSUserStringVariant"] = userVariant.map(NSArray.init(object:))
         return result
     }
-    
+
     private func _copyRegularFile(atPath srcPath: String, toPath dstPath: String, variant: String = "Copy") throws {
+#if os(Windows)
+        try srcPath.withCString(encodedAs: UTF16.self) { src in
+          try dstPath.withCString(encodedAs: UTF16.self) { dst in
+            if CopyFileW(src, dst, FALSE) == FALSE {
+              throw _NSErrorWithWindowsError(GetLastError(), reading: false)
+            }
+          }
+        }
+#else
         let srcRep = fileSystemRepresentation(withPath: srcPath)
         let dstRep = fileSystemRepresentation(withPath: dstPath)
         defer {
@@ -872,9 +1157,25 @@ open class FileManager : NSObject {
             try _writeTo(fd: dstfd, fromBuffer: buffer, length: bytesRead, filename: dstPath)
             bytesRemaining -= Int64(bytesRead)
         }
+#endif
     }
 
     private func _copySymlink(atPath srcPath: String, toPath dstPath: String, variant: String = "Copy") throws {
+#if os(Windows)
+        let faAttributes: WIN32_FILE_ATTRIBUTE_DATA = try windowsFileAttributes(atPath: srcPath)
+        guard faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_REPARSE_POINT) == DWORD(FILE_ATTRIBUTE_REPARSE_POINT) else {
+          throw _NSErrorWithErrno(EINVAL, reading: true, path: srcPath, extraUserInfo: extraErrorInfo(srcPath: srcPath, dstPath: dstPath, userVariant: variant))
+        }
+
+        let destination = try FileManager.default.destinationOfSymbolicLink(atPath: srcPath)
+
+        var dwFlags: DWORD = DWORD(SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE)
+        if try windowsFileAttributes(atPath: destination).dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY) == DWORD(FILE_ATTRIBUTE_DIRECTORY) {
+          dwFlags |= DWORD(SYMBOLIC_LINK_FLAG_DIRECTORY)
+        }
+
+        try FileManager.default.createSymbolicLink(atPath: dstPath, withDestinationPath: destination)
+#else
         let bufSize = Int(PATH_MAX) + 1
         var buf = [Int8](repeating: 0, count: bufSize)
 
@@ -891,9 +1192,37 @@ open class FileManager : NSObject {
                 }
             }
         }
+#endif
     }
     
     private func _copyOrLinkDirectoryHelper(atPath srcPath: String, toPath dstPath: String, variant: String = "Copy", _ body: (String, String, FileAttributeType) throws -> ()) throws {
+    #if os(Windows)
+        var faAttributes: WIN32_FILE_ATTRIBUTE_DATA = WIN32_FILE_ATTRIBUTE_DATA()
+        do { faAttributes = try windowsFileAttributes(atPath: srcPath) } catch { return }
+
+        var fileType = FileAttributeType(attributes: faAttributes)
+        if fileType == .typeDirectory {
+          try createDirectory(atPath: dstPath, withIntermediateDirectories: false, attributes: nil)
+          guard let enumerator = enumerator(atPath: srcPath) else {
+            throw _NSErrorWithErrno(ENOENT, reading: true, path: srcPath)
+          }
+
+          while let item = enumerator.nextObject() as? String {
+            let src = joinPath(prefix: srcPath, suffix: item)
+            let dst = joinPath(prefix: dstPath, suffix: item)
+
+            do { faAttributes = try windowsFileAttributes(atPath: src) } catch { return }
+            fileType = FileAttributeType(attributes: faAttributes)
+            if fileType == .typeDirectory {
+              try createDirectory(atPath: dst, withIntermediateDirectories: false, attributes: nil)
+            } else {
+              try body(src, dst, fileType)
+            }
+          }
+        } else {
+          try body(srcPath, dstPath, fileType)
+        }
+    #else
         guard let stat = try? _lstatFile(atPath: srcPath) else {
                 return
         }
@@ -921,6 +1250,7 @@ open class FileManager : NSObject {
         } else {
             try body(srcPath, dstPath, fileType)
         }
+    #endif
     }
     
     private func shouldProceedAfterError(_ error: Error, copyingItemAtPath path: String, toPath: String, isURL: Bool) -> Bool {
@@ -990,6 +1320,16 @@ open class FileManager : NSObject {
         guard !self.fileExists(atPath: dstPath) else {
             throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileWriteFileExists.rawValue, userInfo: [NSFilePathErrorKey : NSString(dstPath)])
         }
+
+#if os(Windows)
+        try srcPath.withCString(encodedAs: UTF16.self) { src in
+          try dstPath.withCString(encodedAs: UTF16.self) { dst in
+            if MoveFileExW(src, dst, DWORD(MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH)) == FALSE {
+              throw _NSErrorWithWindowsError(GetLastError(), reading: false)
+            }
+          }
+        }
+#else
         try _fileSystemRepresentation(withPath: srcPath, andPath: dstPath, {
             if rename($0, $1) != 0 {
                 if errno == EXDEV {
@@ -1018,6 +1358,7 @@ open class FileManager : NSObject {
                 }
             }
         })
+#endif
     }
     
     private func shouldProceedAfterError(_ error: Error, linkingItemAtPath path: String, toPath: String, isURL: Bool) -> Bool {
@@ -1047,11 +1388,21 @@ open class FileManager : NSObject {
             do {
                 switch fileType {
                 case .typeRegular:
+#if os(Windows)
+                    try srcPath.withCString(encodedAs: UTF16.self) { src in
+                      try dstPath.withCString(encodedAs: UTF16.self) { dst in
+                        if CreateHardLinkW(src, dst, nil) == FALSE {
+                          throw _NSErrorWithWindowsError(GetLastError(), reading: false)
+                        }
+                      }
+                    }
+#else
                     try _fileSystemRepresentation(withPath: srcPath, andPath: dstPath, {
                         if link($0, $1) == -1 {
                             throw _NSErrorWithErrno(errno, reading: false, path: srcPath)
                         }
                     })
+#endif
                 case .typeSymbolicLink:
                     try _copySymlink(atPath: srcPath, toPath: dstPath)
                 default:
@@ -1082,12 +1433,16 @@ open class FileManager : NSObject {
             return delegate.fileManager(self, shouldRemoveItemAtPath: path)
         }
     }
-    
+
+    @available(Windows, deprecated, message: "Not Yet Implemented")
     private func _removeItem(atPath path: String, isURL: Bool, alreadyConfirmed: Bool = false) throws {
         guard alreadyConfirmed || shouldRemoveItemAtPath(path, isURL: isURL) else {
             return
         }
-        
+
+#if os(Windows)
+        NSUnimplemented()
+#else
         if rmdir(path) == 0 {
             return
         } else if errno == ENOTEMPTY {
@@ -1143,6 +1498,7 @@ open class FileManager : NSObject {
         } else if _fileSystemRepresentation(withPath: path, { unlink($0) != 0 }) {
             throw _NSErrorWithErrno(errno, reading: false, path: path)
         }
+#endif
     }
     
     open func copyItem(atPath srcPath: String, toPath dstPath: String) throws {
@@ -1201,15 +1557,28 @@ open class FileManager : NSObject {
     /* Process working directory management. Despite the fact that these are instance methods on FileManager, these methods report and change (respectively) the working directory for the entire process. Developers are cautioned that doing so is fraught with peril.
      */
     open var currentDirectoryPath: String {
+#if os(Windows)
+        let dwLength: DWORD = GetCurrentDirectoryW(0, nil)
+        var szDirectory: UnsafeMutableBufferPointer<WCHAR> = UnsafeMutableBufferPointer.allocate(capacity: Int(dwLength + 1))
+        defer { szDirectory.deallocate() }
+
+        GetCurrentDirectoryW(dwLength, szDirectory.baseAddress)
+        return String(decodingCString: szDirectory.baseAddress!, as: UTF16.self)
+#else
         let length = Int(PATH_MAX) + 1
         var buf = [Int8](repeating: 0, count: length)
         getcwd(&buf, length)
         return string(withFileSystemRepresentation: buf, length: Int(strlen(buf)))
+#endif
     }
     
     @discardableResult
     open func changeCurrentDirectoryPath(_ path: String) -> Bool {
+#if os(Windows)
+        return path.withCString(encodedAs: UTF16.self) { SetCurrentDirectoryW($0) != FALSE }
+#else
         return _fileSystemRepresentation(withPath: path, { chdir($0) == 0 })
+#endif
     }
     
     /* The following methods are of limited utility. Attempting to predicate behavior based on the current state of the filesystem or a particular file on the filesystem is encouraging odd behavior in the face of filesystem race conditions. It's far better to attempt an operation (like loading a file or creating a directory) and handle the error gracefully than it is to try to figure out ahead of time whether the operation will succeed.
@@ -1219,6 +1588,17 @@ open class FileManager : NSObject {
     }
     
     open func fileExists(atPath path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) -> Bool {
+#if os(Windows)
+        var faAttributes: WIN32_FILE_ATTRIBUTE_DATA = WIN32_FILE_ATTRIBUTE_DATA()
+        do { faAttributes = try windowsFileAttributes(atPath: path) } catch { return false }
+        if faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_REPARSE_POINT) == DWORD(FILE_ATTRIBUTE_REPARSE_POINT) {
+          do { try faAttributes = windowsFileAttributes(atPath: destinationOfSymbolicLink(atPath: path)) } catch { return false }
+        }
+        if let isDirectory = isDirectory {
+          isDirectory.pointee = ObjCBool(faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY) == DWORD(FILE_ATTRIBUTE_DIRECTORY))
+        }
+        return true
+#else
         return _fileSystemRepresentation(withPath: path, { fsRep in
             guard var s = try? _lstatFile(atPath: path, withFileSystemRepresentation: fsRep) else {
                 return false
@@ -1242,24 +1622,40 @@ open class FileManager : NSObject {
 
             return true
         })
+#endif
     }
     
     open func isReadableFile(atPath path: String) -> Bool {
+#if os(Windows)
+        do { let _ = try windowsFileAttributes(atPath: path) } catch { return false }
+        return true
+#else
         return _fileSystemRepresentation(withPath: path, {
             access($0, R_OK) == 0
         })
+#endif
     }
     
     open func isWritableFile(atPath path: String) -> Bool {
+#if os(Windows)
+        guard let faAttributes: WIN32_FILE_ATTRIBUTE_DATA = try? windowsFileAttributes(atPath: path) else { return false }
+        return faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_READONLY) != DWORD(FILE_ATTRIBUTE_READONLY)
+#else
         return _fileSystemRepresentation(withPath: path, {
             access($0, W_OK) == 0
         })
+#endif
     }
     
     open func isExecutableFile(atPath path: String) -> Bool {
+#if os(Windows)
+        // FIXME(compnerd) is there some test that we can perform here?
+        return true
+#else
         return _fileSystemRepresentation(withPath: path, {
             access($0, X_OK) == 0
         })
+#endif
     }
 
     /**
@@ -1272,6 +1668,20 @@ open class FileManager : NSObject {
         // Get the parent directory of supplied path
         let parent = path._nsObject.deletingLastPathComponent
 
+#if os(Windows)
+        var faAttributes: WIN32_FILE_ATTRIBUTE_DATA = WIN32_FILE_ATTRIBUTE_DATA()
+        do { faAttributes = try windowsFileAttributes(atPath: parent) } catch { return false }
+        if faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_READONLY) == DWORD(FILE_ATTRIBUTE_READONLY) {
+          return false
+        }
+
+        do { faAttributes = try windowsFileAttributes(atPath: path) } catch { return false }
+        if faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_READONLY) == DWORD(FILE_ATTRIBUTE_READONLY) {
+          return false
+        }
+
+        return true
+#else
         return _fileSystemRepresentation(withPath: parent, andPath: path, { parentFsRep, fsRep  in
             // Check the parent directory is writeable, else return false.
             guard access(parentFsRep, W_OK) == 0 else {
@@ -1296,9 +1706,13 @@ open class FileManager : NSObject {
             // Return true as the best guess.
             return true
         })
+#endif
     }
 
     private func _compareFiles(withFileSystemRepresentation file1Rep: UnsafePointer<Int8>, andFileSystemRepresentation file2Rep: UnsafePointer<Int8>, size: Int64, bufSize: Int) -> Bool {
+#if os(Windows)
+        NSUnimplemented()
+#else
         let fd1 = open(file1Rep, O_RDONLY)
         guard fd1 >= 0 else {
             return false
@@ -1333,8 +1747,10 @@ open class FileManager : NSObject {
             bytesLeft -= Int64(bytesToRead)
         }
         return true
+#endif
     }
 
+#if !os(Windows)
     private func _compareSymlinks(withFileSystemRepresentation file1Rep: UnsafePointer<Int8>, andFileSystemRepresentation file2Rep: UnsafePointer<Int8>, size: Int64) -> Bool {
         let bufSize = Int(size)
         let buffer1 = UnsafeMutablePointer<CChar>.allocate(capacity: bufSize)
@@ -1354,6 +1770,7 @@ open class FileManager : NSObject {
         buffer2.deallocate()
         return compare
     }
+#endif
 
     private func _compareDirectories(atPath path1: String, andPath path2: String) -> Bool {
         guard let enumerator1 = enumerator(atPath: path1) else {
@@ -1380,6 +1797,7 @@ open class FileManager : NSObject {
         return path1entries.isEmpty
     }
 
+#if !os(Windows)
     private func _lstatFile(atPath path: String, withFileSystemRepresentation fsRep: UnsafePointer<Int8>? = nil) throws -> stat {
         let _fsRep: UnsafePointer<Int8>
         if fsRep == nil {
@@ -1398,15 +1816,25 @@ open class FileManager : NSObject {
         }
         return statInfo
     }
+#endif
 
+    @available(Windows, deprecated, message: "Not Yet Implemented")
     internal func _permissionsOfItem(atPath path: String) throws -> Int {
+#if os(Windows)
+        NSUnimplemented()
+#else
         let fileInfo = try _lstatFile(atPath: path)
         return Int(fileInfo.st_mode & ~S_IFMT)
+#endif
     }
 
     /* -contentsEqualAtPath:andPath: does not take into account data stored in the resource fork or filesystem extended attributes.
      */
+    @available(Windows, deprecated, message: "Not Yet Implemented")
     open func contentsEqual(atPath path1: String, andPath path2: String) -> Bool {
+#if os(Windows)
+        NSUnimplemented()
+#else
         let fsRep1 = fileSystemRepresentation(withPath: path1)
         defer { fsRep1.deallocate() }
 
@@ -1463,6 +1891,7 @@ open class FileManager : NSObject {
 
         // Dont know how to compare other file types.
         return false
+#endif
     }
     
     /* displayNameAtPath: returns an NSString suitable for presentation to the user. For directories which have localization information, this will return the appropriate localized string. This string is not suitable for passing to anything that must interact with the filesystem.
@@ -1582,12 +2011,20 @@ open class FileManager : NSObject {
     }
     
     internal func _appendSymlinkDestination(_ dest: String, toPath: String) -> String {
-        if dest.hasPrefix("/") {
+    #if os(Windows)
+      var isAbsolutePath: Bool = false
+      dest.withCString(encodedAs: UTF16.self) {
+        isAbsolutePath = PathIsRelativeW($0) == FALSE
+      }
+    #else
+      let isAbsolutePath: Bool = dest.hasPrefix("/")
+    #endif
+
+        if isAbsolutePath {
             return dest
-        } else {
-            let temp = toPath._bridgeToObjectiveC().deletingLastPathComponent
-            return temp._bridgeToObjectiveC().appendingPathComponent(dest)
         }
+        let temp = toPath._bridgeToObjectiveC().deletingLastPathComponent
+        return temp._bridgeToObjectiveC().appendingPathComponent(dest)
     }
 }
 
@@ -1727,6 +2164,22 @@ public struct FileAttributeType : RawRepresentable, Equatable, Hashable {
         return lhs.rawValue == rhs.rawValue
     }
 
+#if os(Windows)
+    fileprivate init(attributes: WIN32_FILE_ATTRIBUTE_DATA) {
+      if attributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY) == DWORD(FILE_ATTRIBUTE_DIRECTORY) {
+        self = .typeDirectory
+      } else if attributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DEVICE) == DWORD(FILE_ATTRIBUTE_DEVICE) {
+        self = .typeCharacterSpecial
+      } else if attributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_REPARSE_POINT) == DWORD(FILE_ATTRIBUTE_REPARSE_POINT) {
+        // FIXME(compnerd) this is a lie!  It may be a junction or a hard link
+        self = .typeSymbolicLink
+      } else if attributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_NORMAL) == DWORD(FILE_ATTRIBUTE_NORMAL) {
+        self = .typeRegular
+      } else {
+        self = .typeUnknown
+      }
+    }
+#else
     fileprivate init(statMode: mode_t) {
         switch statMode & S_IFMT {
         case S_IFCHR: self = .typeCharacterSpecial
@@ -1738,6 +2191,7 @@ public struct FileAttributeType : RawRepresentable, Equatable, Hashable {
         default: self = .typeUnknown
         }
     }
+#endif
 
     public static let typeDirectory = FileAttributeType(rawValue: "NSFileTypeDirectory")
     public static let typeRegular = FileAttributeType(rawValue: "NSFileTypeRegular")
@@ -1874,17 +2328,31 @@ extension FileManager {
             self.innerEnumerator = ie
         }
         
+        @available(Windows, deprecated, message: "Not Yet Implemented")
         override func nextObject() -> Any? {
             let o = innerEnumerator.nextObject()
             guard let url = o as? URL else {
                 return nil
             }
+
+#if os(Windows)
+            NSUnimplemented()
+#else
             let path = url.path.replacingOccurrences(of: baseURL.path+"/", with: "")
             _currentItemPath = path
             return path
+#endif
         }
     }
 
+#if os(Windows)
+    internal class NSURLDirectoryEnumerator : DirectoryEnumerator {
+        internal typealias ErrorHandler = /* @escaping */ (URL, Error) -> Bool
+
+        init(url: URL, options: FileManager.DirectoryEnumerationOptions, errorHandler: ErrorHandler?) {
+        }
+    }
+#else
     internal class NSURLDirectoryEnumerator : DirectoryEnumerator {
         var _url : URL
         var _options : FileManager.DirectoryEnumerationOptions
@@ -2015,4 +2483,5 @@ extension FileManager {
             }
         }
     }
+#endif
 }


### PR DESCRIPTION
This leaves a few functions unimplemented and the DirectoryIterator unimplemented as they need to match the semantics of FTS which is not present on Windows.  The remainder of the API surface has been reimplemented in terms of the Windows API.