### PR TITLE
Revert "<SR-9930> Swift CI: TestProcess.test_passthrough_environment : failed - Test failed: InvalidEnvironmentVariable("swift_xcode")"

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -3124,7 +3124,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -3144,7 +3144,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = org.swift.xdgTestHelper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -248,38 +248,37 @@ class TestProcess : XCTestCase {
         }
     }
     
-    func helperToolEnvironment(from environment: [String: String]) -> [String: String] {
-        var result = environment
-        let importantEnvVars = ProcessInfo.processInfo.environment.filter {
-            $0.key.hasPrefix("LD_") || $0.key.hasPrefix("DYLD_")
+    func test_passthrough_environment() {
+        do {
+            let (output, _) = try runTask(["/usr/bin/env"], environment: nil)
+            let env = try parseEnv(output)
+            XCTAssertGreaterThan(env.count, 0)
+        } catch {
+            // FIXME: SR-9930 parseEnv fails if an environment variable contains
+            // a newline.
+            // XCTFail("Test failed: \(error)")
         }
-        for entry in importantEnvVars {
-            result[entry.key] = entry.value
-        }
-        return result
-    }
-    
-    func test_passthrough_environment() throws {
-        let helper = xdgTestHelperURL()
-        let (output, _) = try runTask([helper.path, "--env"], environment: nil)
-        let env = try parseEnv(output)
-        XCTAssertGreaterThan(env.count, 0)
     }
 
-    func test_no_environment() throws {
-        let helper = xdgTestHelperURL()
-        let input = helperToolEnvironment(from: [:])
-        let (output, _) = try runTask([helper.path, "--env"], environment: input)
-        let env = try parseEnv(output)
-        XCTAssertEqual(env, input)
+    func test_no_environment() {
+        do {
+            let (output, _) = try runTask(["/usr/bin/env"], environment: [:])
+            let env = try parseEnv(output)
+            XCTAssertEqual(env.count, 0)
+        } catch {
+            XCTFail("Test failed: \(error)")
+        }
     }
 
-    func test_custom_environment() throws {
-        let helper = xdgTestHelperURL()
-        let input = helperToolEnvironment(from: ["HELLO": "WORLD", "HOME": "CUPERTINO"])
-        let (output, _) = try runTask([helper.path, "--env"], environment: input)
-        let env = try parseEnv(output)
-        XCTAssertEqual(env, input)
+    func test_custom_environment() {
+        do {
+            let input = ["HELLO": "WORLD", "HOME": "CUPERTINO"]
+            let (output, _) = try runTask(["/usr/bin/env"], environment: input)
+            let env = try parseEnv(output)
+            XCTAssertEqual(env, input)
+        } catch {
+            XCTFail("Test failed: \(error)")
+        }
     }
 
     private func realpathOf(path: String) -> String? {
@@ -655,8 +654,14 @@ internal func runTask(_ arguments: [String], environment: [String: String]? = ni
 }
 
 private func parseEnv(_ env: String) throws -> [String: String] {
-    let dictionary = try PropertyListSerialization.propertyList(from: try env.data(using: .utf8).unwrapped(), format: nil) as? [String: String]
-    return try dictionary.unwrapped()
+    var result = [String: String]()
+    for line in env.components(separatedBy: "\n") where line != "" {
+        guard let range = line.range(of: "=") else {
+            throw Error.InvalidEnvironmentVariable(line)
+        }
+        result[String(line[..<range.lowerBound])] = String(line[range.upperBound...])
+    }
+    return result
 }
 #endif
 

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -168,9 +168,6 @@ guard let arg = arguments.next() else {
 }
 
 switch arg {
-case "--env":
-    try! FileHandle.standardOutput.write(contentsOf: PropertyListSerialization.data(fromPropertyList: ProcessInfo.processInfo.environment, format: .xml, options: 0))
-    
 case "--xdgcheck":
     XDGCheck.run()
     


### PR DESCRIPTION
Reverts apple/swift-corelibs-foundation#1920