### PR TITLE
[4.2]  SR-1464: NSNumber.description is not compatible between OS X and linux

### DIFF
--- a/CoreFoundation/String.subproj/CFString.c
+++ b/CoreFoundation/String.subproj/CFString.c
@@ -5996,7 +5996,7 @@ enum {
     CFFormatDummyPointerType = 42	/* special case for %n */
 };
 
-#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_WINDOWS
+#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_WINDOWS || DEPLOYMENT_TARGET_LINUX
 /* Only come in here if spec->type is CFFormatLongType or CFFormatDoubleType. Pass in 0 for width or precision if not specified. Returns false if couldn't do the format (with the assumption the caller falls back to unlocalized).
 */
 static Boolean __CFStringFormatLocalizedNumber(CFMutableStringRef output, CFLocaleRef locale, const CFPrintValue *values, const CFFormatSpec *spec, SInt32 width, SInt32 precision, Boolean hasPrecision) {
@@ -6980,7 +6980,7 @@ static void __CFStringAppendFormatCore(CFMutableStringRef outputString, CFString
 	switch (specs[curSpec].type) {
 	case CFFormatLongType:
 	case CFFormatDoubleType:
-#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_WINDOWS
+#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_WINDOWS || DEPLOYMENT_TARGET_LINUX
             if (localizedFormatting && (specs[curSpec].flags & kCFStringFormatLocalizable)) {    // We have a locale, so we do localized formatting
                 if (__CFStringFormatLocalizedNumber(outputString, (CFLocaleRef)formatOptions, values, &specs[curSpec], width, precision, hasPrecision)) break;
             }

--- a/Foundation/NSDecimalNumber.swift
+++ b/Foundation/NSDecimalNumber.swift
@@ -147,7 +147,11 @@ open class NSDecimalNumber : NSNumber {
     public required convenience init(bytes buffer: UnsafeRawPointer, objCType type: UnsafePointer<Int8>) {
         NSRequiresConcreteImplementation()
     }
-    
+
+    open override var description: String {
+        return self.decimal.description
+    }
+
     open override func description(withLocale locale: Locale?) -> String {
         guard locale == nil else {
             fatalError("Locale not supported: \(locale!)")

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -915,7 +915,7 @@ open class NSNumber : NSValue {
     }
     
     open var stringValue: String {
-        return description(withLocale: nil)
+        return self.description
     }
     
     /// Create an instance initialized to `value`.
@@ -958,29 +958,47 @@ open class NSNumber : NSValue {
         }
     }
 
-    private static let _numberFormatterForNilLocale: CFNumberFormatter = {
-        let formatter: CFNumberFormatter
-        formatter = CFNumberFormatterCreate(nil, CFLocaleCopyCurrent(), kCFNumberFormatterNoStyle)
-        CFNumberFormatterSetProperty(formatter, kCFNumberFormatterMaxFractionDigits, 15._bridgeToObjectiveC())
-        return formatter
-    }()
-
     open func description(withLocale locale: Locale?) -> String {
-        // CFNumberFormatterCreateStringWithNumber() does not like numbers of type
-        // SInt128Type, as it loses the type when looking it up and treats it as
-        // an SInt64Type, so special case them.
-        if _CFNumberGetType2(_cfObject) == kCFNumberSInt128Type {
-            return String(format: "%@", unsafeBitCast(_cfObject, to: UnsafePointer<CFNumber>.self))
-        }
+        guard let locale = locale else { return self.description }
+        switch _CFNumberGetType2(_cfObject) {
+        case kCFNumberSInt8Type, kCFNumberCharType:
+            return String(format: "%d", locale: locale, self.int8Value)
 
-        let aLocale = locale
-        let formatter: CFNumberFormatter
-        if (aLocale == nil) {
-            formatter = NSNumber._numberFormatterForNilLocale
-        } else {
-            formatter = CFNumberFormatterCreate(nil, aLocale?._cfObject, kCFNumberFormatterDecimalStyle)
+        case kCFNumberSInt16Type, kCFNumberShortType:
+            return String(format: "%hi", locale: locale, self.int16Value)
+
+        case kCFNumberSInt32Type:
+            return String(format: "%d", locale: locale, self.int32Value)
+
+        case kCFNumberIntType, kCFNumberLongType, kCFNumberNSIntegerType, kCFNumberCFIndexType:
+            return String(format: "%ld", locale: locale, self.intValue)
+
+        case kCFNumberSInt64Type, kCFNumberLongLongType:
+            return String(format: "%lld", locale: locale, self.int64Value)
+
+        case kCFNumberSInt128Type:
+            let value = self.int128Value
+            if value.high == 0 {
+                return value.low.description    // BUG: "%llu" doesnt work correctly and treats number as signed
+            } else {
+                // BUG: Note the locale is actually ignored here as this is converted using CFNumber.c:emit128()
+                return String(format: "%@", locale: locale, unsafeBitCast(_cfObject, to: UnsafePointer<CFNumber>.self))
+            }
+
+        case kCFNumberFloatType, kCFNumberFloat32Type:
+            return String(format: "%0.7g", locale: locale, self.floatValue)
+
+        case kCFNumberFloat64Type, kCFNumberDoubleType:
+            return String(format: "%0.16g", locale: locale, self.doubleValue)
+
+        case kCFNumberCGFloatType:
+            if Int.max == Int32.max {
+                return String(format: "%0.7g", locale: locale, self.floatValue)
+            } else {
+                return String(format: "%0.16g", locale: locale, self.doubleValue)
+            }
+        default: fatalError("Unknown NSNumber Type")
         }
-        return CFNumberFormatterCreateStringWithNumber(nil, formatter, self._cfObject)._swiftObject
     }
     
     override open var _cfTypeID: CFTypeID {
@@ -988,9 +1006,38 @@ open class NSNumber : NSValue {
     }
     
     open override var description: String {
-        return description(withLocale: nil)
+        switch _CFNumberGetType2(_cfObject) {
+        case kCFNumberSInt8Type, kCFNumberCharType, kCFNumberSInt16Type, kCFNumberShortType,
+             kCFNumberSInt32Type, kCFNumberIntType, kCFNumberLongType, kCFNumberNSIntegerType, kCFNumberCFIndexType:
+            return self.intValue.description
+
+        case kCFNumberSInt64Type, kCFNumberLongLongType:
+            return self.int64Value.description
+
+        case kCFNumberSInt128Type:
+            let value = self.int128Value
+            if value.high == 0 {
+                return value.low.description
+            } else {
+                return String(format: "%@", locale: nil, unsafeBitCast(_cfObject, to: UnsafePointer<CFNumber>.self))
+            }
+
+        case kCFNumberFloatType, kCFNumberFloat32Type:
+            return self.floatValue.description
+
+        case kCFNumberFloat64Type, kCFNumberDoubleType:
+            return self.doubleValue.description
+
+        case kCFNumberCGFloatType:
+            if Int.max == Int32.max {
+                return self.floatValue.description
+            } else {
+                return self.doubleValue.description
+            }
+        default: fatalError("Unknown NSNumber Type")
+        }
     }
-    
+
     internal func _cfNumberType() -> CFNumberType {
         switch objCType.pointee {
         case 0x42: return kCFNumberCharType

--- a/TestFoundation/TestDecimal.swift
+++ b/TestFoundation/TestDecimal.swift
@@ -503,7 +503,7 @@ class TestDecimal: XCTestCase {
         XCTAssertEqual(1, ten._length)
     }
 
-    func test_NSDecimal() {
+    func test_NSDecimal() throws {
         var nan = Decimal.nan
         XCTAssertTrue(NSDecimalIsNotANumber(&nan))
         var zero = Decimal()
@@ -524,6 +524,31 @@ class TestDecimal: XCTestCase {
         let nsd1 = NSDecimalNumber(decimal: Decimal(2657.6))
         let nsd2 = NSDecimalNumber(floatLiteral: 2657.6)
         XCTAssertEqual(nsd1, nsd2)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.min)).description, Int8.min.description)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int8.max)).description, Int8.max.description)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt8.min)).description, UInt8.min.description)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt8.max)).description, UInt8.max.description)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.min)).description, Int16.min.description)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int16.max)).description, Int16.max.description)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt16.min)).description, UInt16.min.description)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt16.max)).description, UInt16.max.description)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.min)).description, Int32.min.description)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int32.max)).description, Int32.max.description)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt32.min)).description, UInt32.min.description)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt32.max)).description, UInt32.max.description)
+
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.min)).description, Int64.min.description)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(Int64.max)).description, Int64.max.description)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt64.min)).description, UInt64.min.description)
+        XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt64.max)).description, UInt64.max.description)
+
+        XCTAssertEqual(try NSDecimalNumber(decimal: Decimal(string: "12.34").unwrapped()).description, "12.34")
+        XCTAssertEqual(try NSDecimalNumber(decimal: Decimal(string: "0.0001").unwrapped()).description, "0.0001")
+        XCTAssertEqual(try NSDecimalNumber(decimal: Decimal(string: "-1.0002").unwrapped()).description, "-1.0002")
+        XCTAssertEqual(try NSDecimalNumber(decimal: Decimal(string: "0.0").unwrapped()).description, "0")
     }
 
     func test_PositivePowers() {

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -1015,21 +1015,180 @@ class TestNSNumber : XCTestCase {
 
     
     func test_description() {
-        let nsnumber: NSNumber = 1000
-        let expectedDesc = "1000"
-        XCTAssertEqual(nsnumber.description, expectedDesc, "expected \(expectedDesc) but received \(nsnumber.description)")
+        XCTAssertEqual(NSNumber(value: 1000).description, "1000")
+        XCTAssertEqual(NSNumber(value: 0.001).description, "0.001")
+
+        XCTAssertEqual(NSNumber(value: Int8.min).description, "-128")
+        XCTAssertEqual(NSNumber(value: Int8.max).description, "127")
+        XCTAssertEqual(NSNumber(value: Int16.min).description, "-32768")
+        XCTAssertEqual(NSNumber(value: Int16.max).description, "32767")
+        XCTAssertEqual(NSNumber(value: Int32.min).description, "-2147483648")
+        XCTAssertEqual(NSNumber(value: Int32.max).description, "2147483647")
+        XCTAssertEqual(NSNumber(value: Int64.min).description, "-9223372036854775808")
+        XCTAssertEqual(NSNumber(value: Int64.max).description, "9223372036854775807")
+
+        XCTAssertEqual(NSNumber(value: UInt8.min).description, "0")
+        XCTAssertEqual(NSNumber(value: UInt8.max).description, "255")
+        XCTAssertEqual(NSNumber(value: UInt16.min).description, "0")
+        XCTAssertEqual(NSNumber(value: UInt16.max).description, "65535")
+        XCTAssertEqual(NSNumber(value: UInt32.min).description, "0")
+        XCTAssertEqual(NSNumber(value: UInt32.max).description, "4294967295")
+        XCTAssertEqual(NSNumber(value: UInt64.min).description, "0")
+        XCTAssertEqual(NSNumber(value: UInt64.max).description, "18446744073709551615")
+
+        XCTAssertEqual(NSNumber(value: 1.2 as Float).description, "1.2")
+        XCTAssertEqual(NSNumber(value: 1000_000_000 as Float).description, "1e+09")
+        XCTAssertEqual(NSNumber(value: -0.99 as Float).description, "-0.99")
+        XCTAssertEqual(NSNumber(value: Float(0)).description, "0.0")
+        XCTAssertEqual(NSNumber(value: Float.nan).description, "nan")
+        XCTAssertEqual(NSNumber(value: Float.leastNormalMagnitude).description, "1.1754944e-38")
+        XCTAssertEqual(NSNumber(value: Float.leastNonzeroMagnitude).description, "1e-45")
+        XCTAssertEqual(NSNumber(value: Float.greatestFiniteMagnitude).description, "3.4028235e+38")
+        XCTAssertEqual(NSNumber(value: Float.pi).description, "3.1415925")
+
+        XCTAssertEqual(NSNumber(value: 1.2 as Double).description, "1.2")
+        XCTAssertEqual(NSNumber(value: 1000_000_000 as Double).description, "1000000000.0")
+        XCTAssertEqual(NSNumber(value: -0.99 as Double).description, "-0.99")
+        XCTAssertEqual(NSNumber(value: Double(0)).description, "0.0")
+        XCTAssertEqual(NSNumber(value: Double.nan).description, "nan")
+        XCTAssertEqual(NSNumber(value: Double.leastNormalMagnitude).description, "2.2250738585072014e-308")
+        XCTAssertEqual(NSNumber(value: Double.leastNonzeroMagnitude).description, "5e-324")
+        XCTAssertEqual(NSNumber(value: Double.greatestFiniteMagnitude).description, "1.7976931348623157e+308")
+        XCTAssertEqual(NSNumber(value: Double.pi).description, "3.141592653589793")
     }
-    
+
     func test_descriptionWithLocale() {
-        let nsnumber: NSNumber = 1000
-        let values : Dictionary = [
-                Locale(identifier: "en_GB") : "1,000",
-                Locale(identifier: "de_DE") : "1.000",
-        ]
-        for (locale, expectedDesc) in values {
-            let receivedDesc = nsnumber.description(withLocale: locale)
-            XCTAssertEqual(receivedDesc, expectedDesc, "expected \(expectedDesc) but received \(receivedDesc)")
-        }
+        // nil Locale
+        XCTAssertEqual(NSNumber(value: 1000).description(withLocale: nil), "1000")
+        XCTAssertEqual(NSNumber(value: 0.001).description(withLocale: nil), "0.001")
+
+        XCTAssertEqual(NSNumber(value: Int8.min).description(withLocale: nil), "-128")
+        XCTAssertEqual(NSNumber(value: Int8.max).description(withLocale: nil), "127")
+        XCTAssertEqual(NSNumber(value: Int16.min).description(withLocale: nil), "-32768")
+        XCTAssertEqual(NSNumber(value: Int16.max).description(withLocale: nil), "32767")
+        XCTAssertEqual(NSNumber(value: Int32.min).description(withLocale: nil), "-2147483648")
+        XCTAssertEqual(NSNumber(value: Int32.max).description(withLocale: nil), "2147483647")
+        XCTAssertEqual(NSNumber(value: Int64.min).description(withLocale: nil), "-9223372036854775808")
+        XCTAssertEqual(NSNumber(value: Int64.max).description(withLocale: nil), "9223372036854775807")
+
+        XCTAssertEqual(NSNumber(value: UInt8.min).description(withLocale: nil), "0")
+        XCTAssertEqual(NSNumber(value: UInt8.max).description(withLocale: nil), "255")
+        XCTAssertEqual(NSNumber(value: UInt16.min).description(withLocale: nil), "0")
+        XCTAssertEqual(NSNumber(value: UInt16.max).description(withLocale: nil), "65535")
+        XCTAssertEqual(NSNumber(value: UInt32.min).description(withLocale: nil), "0")
+        XCTAssertEqual(NSNumber(value: UInt32.max).description(withLocale: nil), "4294967295")
+        XCTAssertEqual(NSNumber(value: UInt64.min).description(withLocale: nil), "0")
+        XCTAssertEqual(NSNumber(value: UInt64.max).description(withLocale: nil), "18446744073709551615")
+
+        XCTAssertEqual(NSNumber(value: 1.2 as Float).description(withLocale: nil), "1.2")
+        XCTAssertEqual(NSNumber(value: 1000_000_000 as Float).description(withLocale: nil), "1e+09")
+        XCTAssertEqual(NSNumber(value: -0.99 as Float).description(withLocale: nil), "-0.99")
+        XCTAssertEqual(NSNumber(value: Float(0)).description(withLocale: nil), "0.0")
+        XCTAssertEqual(NSNumber(value: Float.nan).description(withLocale: nil), "nan")
+        XCTAssertEqual(NSNumber(value: Float.leastNormalMagnitude).description(withLocale: nil), "1.1754944e-38")
+        XCTAssertEqual(NSNumber(value: Float.leastNonzeroMagnitude).description(withLocale: nil), "1e-45")
+        XCTAssertEqual(NSNumber(value: Float.greatestFiniteMagnitude).description(withLocale: nil), "3.4028235e+38")
+        XCTAssertEqual(NSNumber(value: Float.pi).description(withLocale: nil), "3.1415925")
+
+        XCTAssertEqual(NSNumber(value: 1.2 as Double).description(withLocale: nil), "1.2")
+        XCTAssertEqual(NSNumber(value: 1000_000_000 as Double).description(withLocale: nil), "1000000000.0")
+        XCTAssertEqual(NSNumber(value: -0.99 as Double).description(withLocale: nil), "-0.99")
+        XCTAssertEqual(NSNumber(value: Double(0)).description(withLocale: nil), "0.0")
+        XCTAssertEqual(NSNumber(value: Double.nan).description(withLocale: nil), "nan")
+        XCTAssertEqual(NSNumber(value: Double.leastNormalMagnitude).description(withLocale: nil), "2.2250738585072014e-308")
+        XCTAssertEqual(NSNumber(value: Double.leastNonzeroMagnitude).description(withLocale: nil), "5e-324")
+        XCTAssertEqual(NSNumber(value: Double.greatestFiniteMagnitude).description(withLocale: nil), "1.7976931348623157e+308")
+        XCTAssertEqual(NSNumber(value: Double.pi).description(withLocale: nil), "3.141592653589793")
+
+        // en_GB Locale
+        XCTAssertEqual(NSNumber(value: 1000).description(withLocale: Locale(identifier: "en_GB")), "1,000")
+        XCTAssertEqual(NSNumber(value: 0.001).description(withLocale: Locale(identifier: "en_GB")), "0.001")
+
+        XCTAssertEqual(NSNumber(value: Int8.min).description(withLocale: Locale(identifier: "en_GB")), "-128")
+        XCTAssertEqual(NSNumber(value: Int8.max).description(withLocale: Locale(identifier: "en_GB")), "127")
+        XCTAssertEqual(NSNumber(value: Int16.min).description(withLocale: Locale(identifier: "en_GB")), "-32,768")
+        XCTAssertEqual(NSNumber(value: Int16.max).description(withLocale: Locale(identifier: "en_GB")), "32,767")
+        XCTAssertEqual(NSNumber(value: Int32.min).description(withLocale: Locale(identifier: "en_GB")), "-2,147,483,648")
+        XCTAssertEqual(NSNumber(value: Int32.max).description(withLocale: Locale(identifier: "en_GB")), "2,147,483,647")
+        XCTAssertEqual(NSNumber(value: Int64.min).description(withLocale: Locale(identifier: "en_GB")), "-9,223,372,036,854,775,808")
+        XCTAssertEqual(NSNumber(value: Int64.max).description(withLocale: Locale(identifier: "en_GB")), "9,223,372,036,854,775,807")
+
+        XCTAssertEqual(NSNumber(value: UInt8.min).description(withLocale: Locale(identifier: "en_GB")), "0")
+        XCTAssertEqual(NSNumber(value: UInt8.max).description(withLocale: Locale(identifier: "en_GB")), "255")
+        XCTAssertEqual(NSNumber(value: UInt16.min).description(withLocale: Locale(identifier: "en_GB")), "0")
+        XCTAssertEqual(NSNumber(value: UInt16.max).description(withLocale: Locale(identifier: "en_GB")), "65,535")
+        XCTAssertEqual(NSNumber(value: UInt32.min).description(withLocale: Locale(identifier: "en_GB")), "0")
+        XCTAssertEqual(NSNumber(value: UInt32.max).description(withLocale: Locale(identifier: "en_GB")), "4,294,967,295")
+        XCTAssertEqual(NSNumber(value: UInt64.min).description(withLocale: Locale(identifier: "en_GB")), "0")
+
+        // This is the correct value but currently buggy and the locale is not used
+        // XCTAssertEqual(NSNumber(value: UInt64.max).description(withLocale: Locale(identifier: "en_GB")), "18,446,744,073,709,551,615")
+        XCTAssertEqual(NSNumber(value: UInt64.max).description(withLocale: Locale(identifier: "en_GB")), "18446744073709551615")
+
+        XCTAssertEqual(NSNumber(value: 1.2 as Float).description(withLocale: Locale(identifier: "en_GB")), "1.2")
+        XCTAssertEqual(NSNumber(value: 1000_000_000 as Float).description(withLocale: Locale(identifier: "en_GB")), "1E+09")
+        XCTAssertEqual(NSNumber(value: -0.99 as Float).description(withLocale: Locale(identifier: "en_GB")), "-0.99")
+        XCTAssertEqual(NSNumber(value: Float(0)).description(withLocale: Locale(identifier: "en_GB")), "0")
+        XCTAssertEqual(NSNumber(value: Float.nan).description(withLocale: Locale(identifier: "en_GB")), "NaN")
+        XCTAssertEqual(NSNumber(value: Float.leastNormalMagnitude).description(withLocale: Locale(identifier: "en_GB")), "1.175494E-38")
+        XCTAssertEqual(NSNumber(value: Float.leastNonzeroMagnitude).description(withLocale: Locale(identifier: "en_GB")), "1.401298E-45")
+        XCTAssertEqual(NSNumber(value: Float.greatestFiniteMagnitude).description(withLocale: Locale(identifier: "en_GB")), "3.402823E+38")
+        XCTAssertEqual(NSNumber(value: Float.pi).description(withLocale: Locale(identifier: "en_GB")), "3.141593")
+
+        XCTAssertEqual(NSNumber(value: 1.2 as Double).description(withLocale: Locale(identifier: "en_GB")), "1.2")
+        XCTAssertEqual(NSNumber(value: 1000_000_000 as Double).description(withLocale: Locale(identifier: "en_GB")), "1,000,000,000")
+        XCTAssertEqual(NSNumber(value: -0.99 as Double).description(withLocale: Locale(identifier: "en_GB")), "-0.99")
+        XCTAssertEqual(NSNumber(value: Double(0)).description(withLocale: Locale(identifier: "en_GB")), "0")
+        XCTAssertEqual(NSNumber(value: Double.nan).description(withLocale: Locale(identifier: "en_GB")), "NaN")
+        // Disable following three tests due to SR-9699 - ICU not built for CI testing for Foundation pull requests
+        //XCTAssertEqual(NSNumber(value: Double.leastNormalMagnitude).description(withLocale: Locale(identifier: "en_GB")), "2.225073858507201E-308")
+        //XCTAssertEqual(NSNumber(value: Double.leastNonzeroMagnitude).description(withLocale: Locale(identifier: "en_GB")), "5E-324")
+        //XCTAssertEqual(NSNumber(value: Double.greatestFiniteMagnitude).description(withLocale: Locale(identifier: "en_GB")), "1.797693134862316E+308")
+
+        // de_DE Locale
+        XCTAssertEqual(NSNumber(value: 1000).description(withLocale: Locale(identifier: "de_DE")), "1.000")
+        XCTAssertEqual(NSNumber(value: 0.001).description(withLocale: Locale(identifier: "de_DE")), "0,001")
+
+        XCTAssertEqual(NSNumber(value: Int8.min).description(withLocale: Locale(identifier: "de_DE")), "-128")
+        XCTAssertEqual(NSNumber(value: Int8.max).description(withLocale: Locale(identifier: "de_DE")), "127")
+        XCTAssertEqual(NSNumber(value: Int16.min).description(withLocale: Locale(identifier: "de_DE")), "-32.768")
+        XCTAssertEqual(NSNumber(value: Int16.max).description(withLocale: Locale(identifier: "de_DE")), "32.767")
+        XCTAssertEqual(NSNumber(value: Int32.min).description(withLocale: Locale(identifier: "de_DE")), "-2.147.483.648")
+        XCTAssertEqual(NSNumber(value: Int32.max).description(withLocale: Locale(identifier: "de_DE")), "2.147.483.647")
+        XCTAssertEqual(NSNumber(value: Int64.min).description(withLocale: Locale(identifier: "de_DE")), "-9.223.372.036.854.775.808")
+        XCTAssertEqual(NSNumber(value: Int64.max).description(withLocale: Locale(identifier: "de_DE")), "9.223.372.036.854.775.807")
+
+        XCTAssertEqual(NSNumber(value: UInt8.min).description(withLocale: Locale(identifier: "de_DE")), "0")
+        XCTAssertEqual(NSNumber(value: UInt8.max).description(withLocale: Locale(identifier: "de_DE")), "255")
+        XCTAssertEqual(NSNumber(value: UInt16.min).description(withLocale: Locale(identifier: "de_DE")), "0")
+        XCTAssertEqual(NSNumber(value: UInt16.max).description(withLocale: Locale(identifier: "de_DE")), "65.535")
+        XCTAssertEqual(NSNumber(value: UInt32.min).description(withLocale: Locale(identifier: "de_DE")), "0")
+        XCTAssertEqual(NSNumber(value: UInt32.max).description(withLocale: Locale(identifier: "de_DE")), "4.294.967.295")
+        XCTAssertEqual(NSNumber(value: UInt64.min).description(withLocale: Locale(identifier: "de_DE")), "0")
+
+        // This is the correct value but currently buggy and the locale is not used
+        //XCTAssertEqual(NSNumber(value: UInt64.max).description(withLocale: Locale(identifier: "de_DE")), "18.446.744.073.709.551.615")
+        XCTAssertEqual(NSNumber(value: UInt64.max).description(withLocale: Locale(identifier: "de_DE")), "18446744073709551615")
+
+        XCTAssertEqual(NSNumber(value: 1.2 as Float).description(withLocale: Locale(identifier: "de_DE")), "1,2")
+        XCTAssertEqual(NSNumber(value: 1000_000_000 as Float).description(withLocale: Locale(identifier: "de_DE")), "1E+09")
+        XCTAssertEqual(NSNumber(value: -0.99 as Float).description(withLocale: Locale(identifier: "de_DE")), "-0,99")
+        XCTAssertEqual(NSNumber(value: Float.pi).description(withLocale: Locale(identifier: "de_DE")), "3,141593")
+        XCTAssertEqual(NSNumber(value: Float(0)).description(withLocale: Locale(identifier: "de_DE")), "0")
+        XCTAssertEqual(NSNumber(value: Float.nan).description(withLocale: Locale(identifier: "de_DE")), "NaN")
+        XCTAssertEqual(NSNumber(value: Float.leastNormalMagnitude).description(withLocale: Locale(identifier: "de_DE")), "1,175494E-38")
+        XCTAssertEqual(NSNumber(value: Float.leastNonzeroMagnitude).description(withLocale: Locale(identifier: "de_DE")), "1,401298E-45")
+        XCTAssertEqual(NSNumber(value: Float.greatestFiniteMagnitude).description(withLocale: Locale(identifier: "de_DE")), "3,402823E+38")
+
+        XCTAssertEqual(NSNumber(value: 1.2 as Double).description(withLocale: Locale(identifier: "de_DE")), "1,2")
+        XCTAssertEqual(NSNumber(value: 1000_000_000 as Double).description(withLocale: Locale(identifier: "de_DE")), "1.000.000.000")
+        XCTAssertEqual(NSNumber(value: -0.99 as Double).description(withLocale: Locale(identifier: "de_DE")), "-0,99")
+        XCTAssertEqual(NSNumber(value: Double(0)).description(withLocale: Locale(identifier: "de_DE")), "0")
+        XCTAssertEqual(NSNumber(value: Double.nan).description(withLocale: Locale(identifier: "de_DE")), "NaN")
+        // Disable following three tests due to SR-9699 - ICU not built for CI testing for Foundation pull requests
+        //XCTAssertEqual(NSNumber(value: Double.leastNormalMagnitude).description(withLocale: Locale(identifier: "de_DE")), "2,225073858507201E-308")
+        //XCTAssertEqual(NSNumber(value: Double.leastNonzeroMagnitude).description(withLocale: Locale(identifier: "de_DE")), "5E-324")
+        //XCTAssertEqual(NSNumber(value: Double.greatestFiniteMagnitude).description(withLocale: Locale(identifier: "de_DE")), "1,797693134862316E+308")
     }
 
     func test_objCType() {

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -809,19 +809,17 @@ class TestNSString: LoopbackServerTest {
             XCTAssertEqual(string, "Default value is 1000 (42.0)")
         }
         
-#if false // these two tests expose bugs in icu4c's localization on some linux builds (disable until we can get a uniform fix for this)
         withVaList(argument) {
             pointer in
-            let string = NSString(format: "en_GB value is %d (%.1f)", locale: Locale.init(localeIdentifier: "en_GB"), arguments: pointer)
+            let string = NSString(format: "en_GB value is %d (%.1f)", locale: Locale.init(identifier: "en_GB") as AnyObject, arguments: pointer)
             XCTAssertEqual(string, "en_GB value is 1,000 (42.0)")
         }
 
         withVaList(argument) {
             pointer in
-            let string = NSString(format: "de_DE value is %d (%.1f)", locale: Locale.init(localeIdentifier: "de_DE"), arguments: pointer)
+            let string = NSString(format: "de_DE value is %d (%.1f)", locale: Locale.init(identifier: "de_DE") as AnyObject, arguments: pointer)
             XCTAssertEqual(string, "de_DE value is 1.000 (42,0)")
         }
-#endif
         
         withVaList(argument) {
             pointer in


### PR DESCRIPTION
- Use Swift's stringification of numbers for .description and .stringValue
    
- Use String(format:locale:...) with the correct format for the
   NSNumber type if locale is not nil.
    
- Enable use of __CFStringFormatLocalizedNumber() on
   DEPLOYMENT_TARGET_LINUX.
    
(cherry picked from commit 6450221c7fea77b8c458ca7baac953cc939c41ae)

- Add NSDecimalNumber.description
    
(cherry picked from commit 7cb608f2d0d666223f5fd340eaa686c769b30bb4)