### PR TITLE
[4.2] SR-1674: NSString.doubleValue doesn't support a few formats supported by Darwin

### DIFF
--- a/Foundation/Scanner.swift
+++ b/Foundation/Scanner.swift
@@ -337,7 +337,7 @@ extension String {
             buf.advance()
             buf.skip(skipSet)
         }
-        if (!isADigit(buf.currentCharacter)) {
+        if (buf.currentCharacter != ds && !isADigit(buf.currentCharacter)) {
             return false
         }
         
@@ -376,6 +376,34 @@ extension String {
                 factor = factor * T(0.1)
                 buf.advance()
             } while (isADigit(buf.currentCharacter))
+        }
+
+        if buf.currentCharacter == unichar(unicodeScalarLiteral: "e") || buf.currentCharacter == unichar(unicodeScalarLiteral: "E") {
+            var exponent = Double(0)
+            var negExponent = false
+            buf.advance()
+            if buf.currentCharacter == unichar(unicodeScalarLiteral: "-") || buf.currentCharacter == unichar(unicodeScalarLiteral: "+") {
+                negExponent = buf.currentCharacter == unichar(unicodeScalarLiteral: "-")
+                buf.advance()
+            }
+            repeat {
+                let numeral = numericValue(buf.currentCharacter)
+                buf.advance()
+                if numeral == -1 {
+                    break
+                }
+                exponent *= 10
+                exponent += Double(numeral)
+            } while (isADigit(buf.currentCharacter))
+
+            if exponent > 0 {
+                let multiplier = pow(10, exponent)
+                if negExponent {
+                    localResult /= T(multiplier)
+                } else {
+                    localResult *= T(multiplier)
+                }
+            }
         }
         
         to(neg ? T(-1) * localResult : localResult)

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -255,25 +255,25 @@ class TestNSString: LoopbackServerTest {
     }
 
     func test_doubleValue() {
-        XCTAssertEqual(NSString(".2").doubleValue, 0.2)
-        XCTAssertEqual(NSString("+.2").doubleValue, 0.2)
-        XCTAssertEqual(NSString("-.2").doubleValue, -0.2)
-        XCTAssertEqual(NSString("1.23015e+3").doubleValue, 1230.15)
-        XCTAssertEqual(NSString("12.3015e+02").doubleValue, 1230.15)
-        XCTAssertEqual(NSString("+1.23015e+3").doubleValue, 1230.15)
-        XCTAssertEqual(NSString("+12.3015e+02").doubleValue, 1230.15)
-        XCTAssertEqual(NSString("-1.23015e+3").doubleValue, -1230.15)
-        XCTAssertEqual(NSString("-12.3015e+02").doubleValue, -1230.15)
-        XCTAssertEqual(NSString("-12.3015e02").doubleValue, -1230.15)
-        XCTAssertEqual(NSString("-31.25e-04").doubleValue, -0.003125)
+        XCTAssertEqual(NSString(string: ".2").doubleValue, 0.2)
+        XCTAssertEqual(NSString(string: "+.2").doubleValue, 0.2)
+        XCTAssertEqual(NSString(string: "-.2").doubleValue, -0.2)
+        XCTAssertEqual(NSString(string: "1.23015e+3").doubleValue, 1230.15)
+        XCTAssertEqual(NSString(string: "12.3015e+02").doubleValue, 1230.15)
+        XCTAssertEqual(NSString(string: "+1.23015e+3").doubleValue, 1230.15)
+        XCTAssertEqual(NSString(string: "+12.3015e+02").doubleValue, 1230.15)
+        XCTAssertEqual(NSString(string: "-1.23015e+3").doubleValue, -1230.15)
+        XCTAssertEqual(NSString(string: "-12.3015e+02").doubleValue, -1230.15)
+        XCTAssertEqual(NSString(string: "-12.3015e02").doubleValue, -1230.15)
+        XCTAssertEqual(NSString(string: "-31.25e-04").doubleValue, -0.003125)
 
-        XCTAssertEqual(NSString(".e12").doubleValue, 0)
-        XCTAssertEqual(NSString("2e3.12").doubleValue, 2000)
-        XCTAssertEqual(NSString("1e2.3").doubleValue, 100)
-        XCTAssertEqual(NSString("12.e4").doubleValue, 120000)
-        XCTAssertEqual(NSString("1.2.3.4").doubleValue, 1.2)
-        XCTAssertEqual(NSString("1e2.3").doubleValue, 100)
-        XCTAssertEqual(NSString("1E3").doubleValue, 1000)
+        XCTAssertEqual(NSString(string: ".e12").doubleValue, 0)
+        XCTAssertEqual(NSString(string: "2e3.12").doubleValue, 2000)
+        XCTAssertEqual(NSString(string: "1e2.3").doubleValue, 100)
+        XCTAssertEqual(NSString(string: "12.e4").doubleValue, 120000)
+        XCTAssertEqual(NSString(string: "1.2.3.4").doubleValue, 1.2)
+        XCTAssertEqual(NSString(string: "1e2.3").doubleValue, 100)
+        XCTAssertEqual(NSString(string: "1E3").doubleValue, 1000)
     }
     
     func test_isEqualToStringWithSwiftString() {

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -36,6 +36,7 @@ class TestNSString: LoopbackServerTest {
             ("test_BridgeConstruction", test_BridgeConstruction ),
             ("test_integerValue", test_integerValue ),
             ("test_intValue", test_intValue ),
+            ("test_doubleValue", test_doubleValue),
             ("test_isEqualToStringWithSwiftString", test_isEqualToStringWithSwiftString ),
             ("test_isEqualToObjectWithNSString", test_isEqualToObjectWithNSString ),
             ("test_isNotEqualToObjectWithNSNumber", test_isNotEqualToObjectWithNSNumber ),
@@ -251,6 +252,28 @@ class TestNSString: LoopbackServerTest {
 
         let string10: NSString = "-999999999999999999999999999999"
         XCTAssertEqual(string10.intValue, Int32.min)
+    }
+
+    func test_doubleValue() {
+        XCTAssertEqual(NSString(".2").doubleValue, 0.2)
+        XCTAssertEqual(NSString("+.2").doubleValue, 0.2)
+        XCTAssertEqual(NSString("-.2").doubleValue, -0.2)
+        XCTAssertEqual(NSString("1.23015e+3").doubleValue, 1230.15)
+        XCTAssertEqual(NSString("12.3015e+02").doubleValue, 1230.15)
+        XCTAssertEqual(NSString("+1.23015e+3").doubleValue, 1230.15)
+        XCTAssertEqual(NSString("+12.3015e+02").doubleValue, 1230.15)
+        XCTAssertEqual(NSString("-1.23015e+3").doubleValue, -1230.15)
+        XCTAssertEqual(NSString("-12.3015e+02").doubleValue, -1230.15)
+        XCTAssertEqual(NSString("-12.3015e02").doubleValue, -1230.15)
+        XCTAssertEqual(NSString("-31.25e-04").doubleValue, -0.003125)
+
+        XCTAssertEqual(NSString(".e12").doubleValue, 0)
+        XCTAssertEqual(NSString("2e3.12").doubleValue, 2000)
+        XCTAssertEqual(NSString("1e2.3").doubleValue, 100)
+        XCTAssertEqual(NSString("12.e4").doubleValue, 120000)
+        XCTAssertEqual(NSString("1.2.3.4").doubleValue, 1.2)
+        XCTAssertEqual(NSString("1e2.3").doubleValue, 100)
+        XCTAssertEqual(NSString("1E3").doubleValue, 1000)
     }
     
     func test_isEqualToStringWithSwiftString() {


### PR DESCRIPTION
- Don't require a digit before a leading decimal separator.

- Support exponent specified by 'e' or 'E'.

(cherry picked from commit acb8cf74898775024f0269ff3dff171d80a6203f)