### PR TITLE
DateIntervalFormatter: Basic Implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,6 +381,7 @@ if(ENABLE_TESTING)
                          TestFoundation/TestCodable.swift
                          TestFoundation/TestDateComponents.swift
                          TestFoundation/TestDateFormatter.swift
+                         TestFoundation/TestDateIntervalFormatter.swift
                          TestFoundation/TestDate.swift
                          TestFoundation/TestDecimal.swift
                          TestFoundation/TestEnergyFormatter.swift

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -52,6 +52,8 @@
 #include <malloc/malloc.h>
 #endif
 
+#include <unicode/udateintervalformat.h>
+
 _CF_EXPORT_SCOPE_BEGIN
 
 CF_CROSS_PLATFORM_EXPORT Boolean _CFCalendarGetNextWeekend(CFCalendarRef calendar, _CFCalendarWeekendRange *range);
@@ -483,6 +485,25 @@ static inline unsigned int _dev_minor(dev_t rdev) {
     return minor(rdev);
 }
 #endif
+
+// ICU functions can be renamed on some platforms eg on Linux udtivfmt_open() -> udtitvfmt_open_61_swift() so wrap the functions
+// to provide a platform independent interface. These functions are used by DateIntervalFormatter.swift
+static inline UDateIntervalFormat * _Nullable
+date_interval_formatter_open(const char * _Nullable locale, const UChar * _Nonnull skeleton, int32_t skeletonLength, const UChar * _Nullable tzID, int32_t tzIDLength, UErrorCode *status) {
+    return udtitvfmt_open (locale, skeleton, skeletonLength, tzID, tzIDLength, status);
+}
+
+static inline int32_t
+date_interval_formatter_format(const UDateIntervalFormat * _Nonnull formatter, UDate fromDate, UDate toDate, UChar *result, int32_t resultCapacity, UFieldPosition * _Nullable position, UErrorCode *status) {
+
+    return udtitvfmt_format (formatter, fromDate, toDate, result, resultCapacity, position, status);
+}
+
+static inline void
+date_interval_formatter_close(UDateIntervalFormat * _Nonnull formatter) {
+    udtitvfmt_close (formatter);
+}
+
 
 _CF_EXPORT_SCOPE_END
 

--- a/DarwinCompatibilityTests.xcodeproj/project.pbxproj
+++ b/DarwinCompatibilityTests.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		B9C89FCE1F6DCAEB00087AF4 /* Test.plist in Resources */ = {isa = PBXBuildFile; fileRef = B9C89FB91F6DCAEB00087AF4 /* Test.plist */; };
 		B9F137A120B998D0000B7577 /* xdgTestHelper in CopyFiles */ = {isa = PBXBuildFile; fileRef = B917D31C20B0DB8B00728EE0 /* xdgTestHelper */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		B9F326A01FC714DD003C3599 /* DarwinShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F3269E1FC714DD003C3599 /* DarwinShims.swift */; };
+		B9FFA8CA221E96DF004CB11F /* TestDateIntervalFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FFA8C9221E96DF004CB11F /* TestDateIntervalFormatter.swift */; };
 		DAE7D0F320D8224200DC6C54 /* TestURLProtectionSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE7D0F220D8224200DC6C54 /* TestURLProtectionSpace.swift */; };
 /* End PBXBuildFile section */
 
@@ -262,6 +263,7 @@
 		B9C89FB81F6DCAEB00087AF4 /* PropertyList-1.0.dtd */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = "PropertyList-1.0.dtd"; path = "TestFoundation/Resources/PropertyList-1.0.dtd"; sourceTree = "<group>"; };
 		B9C89FB91F6DCAEB00087AF4 /* Test.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Test.plist; path = TestFoundation/Resources/Test.plist; sourceTree = "<group>"; };
 		B9F3269E1FC714DD003C3599 /* DarwinShims.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DarwinShims.swift; sourceTree = "<group>"; };
+		B9FFA8C9221E96DF004CB11F /* TestDateIntervalFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestDateIntervalFormatter.swift; path = TestFoundation/TestDateIntervalFormatter.swift; sourceTree = "<group>"; };
 		DAE7D0F220D8224200DC6C54 /* TestURLProtectionSpace.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestURLProtectionSpace.swift; path = TestFoundation/TestURLProtectionSpace.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -294,6 +296,7 @@
 		B9C89EB81F6BF47D00087AF4 = {
 			isa = PBXGroup;
 			children = (
+				B9FFA8C9221E96DF004CB11F /* TestDateIntervalFormatter.swift */,
 				B9C89FAC1F6DCAE700087AF4 /* Info.plist */,
 				B9C89FAD1F6DCAE800087AF4 /* NSKeyedUnarchiver-ArrayTest.plist */,
 				B9C89FB31F6DCAE900087AF4 /* NSKeyedUnarchiver-ComplexTest.plist */,
@@ -558,6 +561,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B9FFA8CA221E96DF004CB11F /* TestDateIntervalFormatter.swift in Sources */,
 				B94897772135E7AD00FB930E /* Utilities.swift in Sources */,
 				B987C65E2093C8AF0026B50D /* TestImports.swift in Sources */,
 				B95788861F6FB9470003EB01 /* TestNSNumberBridging.swift in Sources */,

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -372,6 +372,7 @@
 		B9974B9A1EDF4A22007F15B8 /* HTTPMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B931EDF4A22007F15B8 /* HTTPMessage.swift */; };
 		B9974B9B1EDF4A22007F15B8 /* BodySource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B941EDF4A22007F15B8 /* BodySource.swift */; };
 		B9974B9C1EDF4A22007F15B8 /* EasyHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B951EDF4A22007F15B8 /* EasyHandle.swift */; };
+		B99DA247221B643800E44F3F /* TestDateIntervalFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99DA246221B643800E44F3F /* TestDateIntervalFormatter.swift */; };
 		B9C0E89620C31AB60064C68C /* CFInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B5D888A1BBC963C00234F36 /* CFInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BB3D7558208A1E500085CFDC /* TestImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3D7557208A1E500085CFDC /* TestImports.swift */; };
 		BD8042161E09857800487EB8 /* TestLengthFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8042151E09857800487EB8 /* TestLengthFormatter.swift */; };
@@ -899,6 +900,7 @@
 		B9974B931EDF4A22007F15B8 /* HTTPMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HTTPMessage.swift; path = http/HTTPMessage.swift; sourceTree = "<group>"; };
 		B9974B941EDF4A22007F15B8 /* BodySource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BodySource.swift; sourceTree = "<group>"; };
 		B9974B951EDF4A22007F15B8 /* EasyHandle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EasyHandle.swift; sourceTree = "<group>"; };
+		B99DA246221B643800E44F3F /* TestDateIntervalFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestDateIntervalFormatter.swift; path = TestFoundation/TestDateIntervalFormatter.swift; sourceTree = "<group>"; };
 		BB3D7557208A1E500085CFDC /* TestImports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestImports.swift; sourceTree = "<group>"; };
 		BD8042151E09857800487EB8 /* TestLengthFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLengthFormatter.swift; sourceTree = "<group>"; };
 		BDBB658F1E256BFA001A7286 /* TestEnergyFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEnergyFormatter.swift; sourceTree = "<group>"; };
@@ -1113,6 +1115,7 @@
 		5B5D88531BBC938800234F36 = {
 			isa = PBXGroup;
 			children = (
+				B99DA246221B643800E44F3F /* TestDateIntervalFormatter.swift */,
 				B167A6641ED7303F0040B09A /* README.md */,
 				5BDC3F2C1BCC5DB500ED97BB /* Foundation */,
 				EAB57B681BD1A255004AC5C5 /* CoreFoundation */,
@@ -2630,6 +2633,7 @@
 				5B13B3261C582D4C00651CE2 /* TestAffineTransform.swift in Sources */,
 				2EBE67A51C77BF0E006583D5 /* TestDateFormatter.swift in Sources */,
 				5B13B3291C582D4C00651CE2 /* TestCalendar.swift in Sources */,
+				B99DA247221B643800E44F3F /* TestDateIntervalFormatter.swift in Sources */,
 				5B13B34F1C582D4C00651CE2 /* TestXMLParser.swift in Sources */,
 				BF85E9D81FBDCC2000A79793 /* TestHost.swift in Sources */,
 				D5C40F331CDA1D460005690C /* TestOperationQueue.swift in Sources */,
@@ -2840,6 +2844,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(CONFIGURATION_BUILD_DIR)/usr/local/include",
 					/usr/include/libxml2,
+					"$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/local/include",
 				);
 				INFOPLIST_FILE = Foundation/Info.plist;
 				INIT_ROUTINE = "___CFInitialize";
@@ -2914,6 +2919,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(CONFIGURATION_BUILD_DIR)/usr/local/include",
 					/usr/include/libxml2,
+					"$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/local/include",
 				);
 				INFOPLIST_FILE = Foundation/Info.plist;
 				INIT_ROUTINE = "___CFInitialize";

--- a/Foundation/DateIntervalFormatter.swift
+++ b/Foundation/DateIntervalFormatter.swift
@@ -1,44 +1,133 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2016, 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+import CoreFoundation
 
 extension DateIntervalFormatter {
-    public enum Style : UInt {
-        
-        case noStyle
-        case shortStyle
-        case mediumStyle
-        case longStyle
-        case fullStyle
+    public enum Style: UInt {
+        case none
+        case short
+        case medium
+        case long
+        case full
     }
 }
 
-// DateIntervalFormatter is used to format the range between two NSDates in a locale-sensitive way.
-// DateIntervalFormatter returns nil and NO for all methods in Formatter.
+// DateIntervalFormatter is used to format the range between two Dates in a locale-sensitive way.
 
 open class DateIntervalFormatter : Formatter {
-    
+    private let _dateFormatter: DateFormatter
+    private var _formatter: OpaquePointer? = nil
+    private var _dateTemplate: String?
+
+    open var calendar: Calendar! {
+        get { return _dateFormatter.calendar }
+        set {
+            if let newValue = newValue {
+                _dateFormatter.calendar = newValue
+                setTemplateFromProperties()
+            }
+        }
+    }
+
+    open var locale: Locale! {
+        get { return _dateFormatter.locale }
+        set {
+            if let newValue = newValue {
+                _dateFormatter.locale = newValue
+                setTemplateFromProperties()
+            }
+        }
+    }
+
+    open var timeZone: TimeZone! {
+        get { return _dateFormatter.timeZone }
+        set {
+            if let newValue = newValue {
+                _dateFormatter.timeZone = newValue
+                setTemplateFromProperties()
+            }
+        }
+    }
+
+    open var dateStyle: Style {
+        get {
+            switch _dateFormatter.dateStyle {
+            case .none:     return .none
+            case .short:    return .short
+            case .medium:   return .medium
+            case .long:     return .long
+            case .full:     return .full
+            }
+        }
+        set {
+            switch newValue {
+            case .none:     _dateFormatter.dateStyle = .none
+            case .short:    _dateFormatter.dateStyle = .short
+            case .medium:   _dateFormatter.dateStyle = .medium
+            case .long:     _dateFormatter.dateStyle = .long
+            case .full:     _dateFormatter.dateStyle = .full
+            }
+            setTemplateFromProperties()
+        }
+    }
+
+    open var timeStyle: Style {
+        get {
+            switch _dateFormatter.timeStyle {
+            case .none:     return .none
+            case .short:    return .short
+            case .medium:   return .medium
+            case .long:     return .long
+            case .full:     return .full
+            }
+        }
+
+        set {
+            switch newValue {
+            case .none:     _dateFormatter.timeStyle = .none
+            case .short:    _dateFormatter.timeStyle = .short
+            case .medium:   _dateFormatter.timeStyle = .medium
+            case .long:     _dateFormatter.timeStyle = .long
+            case .full:     _dateFormatter.timeStyle = .full
+            }
+            setTemplateFromProperties()
+        }
+    }
+
+    open var dateTemplate: String! {
+        get { return _dateTemplate }
+        set {
+            _dateTemplate = newValue
+            resetFormatter()
+        }
+    }
+
     public override init() {
-        NSUnimplemented()
+        _dateFormatter = DateFormatter()
+        _dateFormatter.locale = Locale.current
+        _dateFormatter.timeZone = NSTimeZone.default
+        _dateFormatter.calendar = Locale.current.calendar
+        _dateFormatter.dateStyle = .short
+        _dateFormatter.timeStyle = .short
+        _dateTemplate = _dateFormatter.dateFormat
+        super.init()
     }
 
     public required init?(coder: NSCoder) {
         NSUnimplemented()
     }
-    
-    /*@NSCopying*/ open var locale: Locale! // default is [NSLocale currentLocale]
-    /*@NSCopying*/ open var calendar: Calendar! // default is the calendar of the locale
-    /*@NSCopying*/ open var timeZone: TimeZone! // default is [NSTimeZone defaultTimeZone]
-    open var dateTemplate: String! // default is an empty string
-    open var dateStyle: Style // default is .noStyle
-    open var timeStyle: Style // default is .noStyle
-    
+
+    deinit {
+        resetFormatter()
+    }
+
     /*
          If the range smaller than the resolution specified by the dateTemplate, a single date format will be produced. If the range is larger than the format specified by the dateTemplate, a locale-specific fallback will be used to format the items missing from the pattern.
          
@@ -57,7 +146,74 @@ open class DateIntervalFormatter : Formatter {
             for en_US, "Mar 4-8"
             for en_GB, "4-8 Mar"
     */
-    open func string(from fromDate: Date, to toDate: Date) -> String { NSUnimplemented() }
-    
-    open func string(from dateInterval: DateInterval) -> String? { NSUnimplemented() }
+
+
+    open func string(from dateInterval: DateInterval) -> String? {
+        return _string(from: dateInterval) ?? ""
+    }
+
+    open func string(from fromDate: Date, to toDate: Date) -> String {
+        return _string(from: DateInterval(start: fromDate, end: toDate)) ?? ""
+    }
+
+    private func _string(from dateInterval: DateInterval) -> String? {
+        if _formatter == nil {
+            _formatter = createFormatter()
+        }
+        guard let formatter = _formatter else { return nil }
+
+        var outputBufferLength = 32
+        while outputBufferLength < 1024 { // Hard limit to growing buffer
+            let outputBuffer = UnsafeMutablePointer<unichar>.allocate(capacity: outputBufferLength)
+            defer { outputBuffer.deallocate() }
+
+            var status = U_ZERO_ERROR
+            let startDate = dateInterval.start.timeIntervalSince1970 * 1000
+            let endDate = dateInterval.end.timeIntervalSince1970 * 1000
+            let length = date_interval_formatter_format(formatter, startDate, endDate, outputBuffer, Int32(outputBufferLength), nil, &status)
+            if status.rawValue <= 0 && length <= outputBufferLength {
+                return String(utf16CodeUnits: outputBuffer, count: Int(length))
+            }
+            if status != U_BUFFER_OVERFLOW_ERROR {
+                break
+            }
+            outputBufferLength = Int(length) + 1
+        }
+        return nil
+    }
+
+    private func setTemplateFromProperties() {
+        resetFormatter()
+        _dateTemplate = _dateFormatter.dateFormat
+    }
+
+    private func createFormatter() -> OpaquePointer? {
+        guard let template = dateTemplate else { return nil }
+
+        var status = UErrorCode(rawValue: 0)
+        // ICU requires some of its inputs to be UTF-16
+        let formatter = template.utf16.map { $0 }.withUnsafeBufferPointer { skeleton -> OpaquePointer? in
+            guard let skeletonBaseAddress = skeleton.baseAddress else { return nil }
+            if let tz = timeZone {
+                return tz.identifier.utf16.map { $0 }.withUnsafeBufferPointer { tzId in
+                    date_interval_formatter_open(locale.identifier, skeletonBaseAddress, Int32(skeleton.count), tzId.baseAddress, Int32(tzId.count), &status)
+                }
+            } else {
+                return date_interval_formatter_open(locale.identifier, skeletonBaseAddress, Int32(skeleton.count), nil, 0, &status)
+            }
+        }
+        if status.rawValue > U_ZERO_ERROR.rawValue && formatter != nil {
+            // If there was an error creating the formatter but it still returned one then release it as it could be in an inconsistent state
+            date_interval_formatter_close(formatter!)
+            return nil
+        }
+        return formatter
+    }
+
+    private func resetFormatter() {
+        if let formatter = _formatter {
+            date_interval_formatter_close(formatter)
+            _formatter = nil
+        }
+    }
 }

--- a/TestFoundation/TestDateIntervalFormatter.swift
+++ b/TestFoundation/TestDateIntervalFormatter.swift
@@ -1,0 +1,61 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+class TestDateIntervalFormatter: XCTestCase {
+    static let allTests = [
+        ("testBasics", testBasics)
+    ]
+
+    // Apple's ICU variant uses a THIN SPACE instead of a normal space around the separator.
+#if canImport(Darwin)
+    let separator = "\u{2009}\u{2013}\u{2009}"     // " – "  {THIN SPACE} {EN DASH} {THIN SPACE}
+#else
+    let separator = "\u{20}\u{2013}\u{20}"         // " – "  {SPACE} {EN DASH} {SPACE}
+#endif
+
+    func testBasics() throws {
+        let dif = DateIntervalFormatter()
+        dif.locale = Locale(identifier: "en_GB")
+        dif.dateStyle = .short
+        XCTAssertEqual(dif.dateTemplate, "dd/MM/y, HH:mm")
+
+        let f = ISO8601DateFormatter()
+        let date1 = try f.date(from: "2019-12-18T20:00:00Z").unwrapped()
+        let date2 = try f.date(from: "2019-12-19T22:15:00Z").unwrapped()
+
+        dif.timeZone = TimeZone(identifier: "Europe/London")
+        dif.locale = Locale(identifier: "en_GB")
+        XCTAssertEqual(dif.string(from: date1, to: date2), "18/12/2019, 20:00\(separator)19/12/2019, 22:15")
+        dif.locale = Locale(identifier: "en_US")
+        XCTAssertEqual(dif.string(from: date1, to: date2), "12/18/19, 8:00 PM\(separator)12/19/19, 10:15 PM")
+        dif.timeZone = TimeZone(identifier: "Europe/Paris")
+        XCTAssertEqual(dif.string(from: date1, to: date2), "12/18/19, 9:00 PM\(separator)12/19/19, 11:15 PM")
+
+        dif.dateTemplate = "jm"
+        dif.timeZone = TimeZone(identifier: "Europe/London")
+        dif.locale = Locale(identifier: "en_GB")
+        XCTAssertEqual(dif.string(from: date1, to: date2), "18/12/2019, 20:00\(separator)19/12/2019, 22:15")
+        dif.locale = Locale(identifier: "en_US")
+        XCTAssertEqual(dif.string(from: date1, to: date2), "12/18/2019, 8:00 PM\(separator)12/19/2019, 10:15 PM")
+        dif.timeZone = TimeZone(identifier: "Europe/Paris")
+        XCTAssertEqual(dif.string(from: date1, to: date2), "12/18/2019, 9:00 PM\(separator)12/19/2019, 11:15 PM")
+
+        dif.dateTemplate = "MMMd"
+        dif.timeZone = TimeZone(identifier: "Europe/London")
+        dif.locale = Locale(identifier: "en_GB")
+        XCTAssertEqual(dif.string(from: date1, to: date2), "18–19 Dec")
+        dif.locale = Locale(identifier: "en_US")
+        XCTAssertEqual(dif.string(from: date1, to: date2), "Dec 18\(separator)19")
+        dif.timeZone = TimeZone(identifier: "Europe/Paris")
+        XCTAssertEqual(dif.string(from: date1, to: date2), "Dec 18\(separator)19")
+
+        dif.dateTemplate = nil
+        XCTAssertEqual(dif.string(from: date1, to: date2), "")
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -34,6 +34,7 @@ XCTMain([
     testCase(TestDateComponents.allTests),
     testCase(TestNSDateComponents.allTests),
     testCase(TestDateFormatter.allTests),
+    testCase(TestDateIntervalFormatter.allTests),
     testCase(TestDecimal.allTests),
     testCase(TestNSDictionary.allTests),
     testCase(TestNSError.allTests),


### PR DESCRIPTION
- Set the dateTemplate from the dateStyle and timeStyle.
    
- Cache the formatter unless one of the properties changes.

- Add wrapper functions to work around ICU function rename

- Update tests for differences with Apple's ICU
