### PR TITLE
[5.0] URLSessionTask: implement InputStream.

### DIFF
--- a/Foundation/Stream.swift
+++ b/Foundation/Stream.swift
@@ -114,7 +114,7 @@ open class Stream: NSObject {
 // InputStream is an abstract class representing the base functionality of a read stream.
 // Subclassers are required to implement these methods.
 open class InputStream: Stream {
-    enum _Error: Error {
+    enum Error: Swift.Error {
         case cantSeekInputStream
     }
     
@@ -159,7 +159,7 @@ open class InputStream: Stream {
         return Stream.Status(rawValue: UInt(CFReadStreamGetStatus(_stream)))!
     }
     
-    open override var streamError: Error? {
+    open override var streamError: Swift.Error? {
         return CFReadStreamCopyError(_stream)
     }
 }
@@ -234,7 +234,7 @@ extension InputStream {
             return
         }
         
-        guard position < Int.max else { throw _Error.cantSeekInputStream }
+        guard position < Int.max else { throw Error.cantSeekInputStream }
         
         let bufferSize = 1024
         var remainingBytes = Int(position)
@@ -243,7 +243,7 @@ extension InputStream {
         
         guard let pointer = buffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
             buffer.deallocate()
-            throw _Error.cantSeekInputStream
+            throw Error.cantSeekInputStream
         }
         
         if self.streamStatus == .notOpen {
@@ -253,14 +253,14 @@ extension InputStream {
         while remainingBytes > 0 && self.hasBytesAvailable {
             let read = self.read(pointer, maxLength: min(bufferSize, remainingBytes))
             if read == -1 {
-                throw _Error.cantSeekInputStream
+                throw Error.cantSeekInputStream
             }
             remainingBytes -= read
         }
         
         buffer.deallocate()
         if remainingBytes != 0 {
-            throw _Error.cantSeekInputStream
+            throw Error.cantSeekInputStream
         }
     }
 }

--- a/Foundation/Stream.swift
+++ b/Foundation/Stream.swift
@@ -114,7 +114,10 @@ open class Stream: NSObject {
 // InputStream is an abstract class representing the base functionality of a read stream.
 // Subclassers are required to implement these methods.
 open class InputStream: Stream {
-
+    enum _Error: Error {
+        case cantSeekInputStream
+    }
+    
     internal let _stream: CFReadStream!
 
     // reads up to length bytes into the supplied buffer, which must be at least of size len. Returns the actual number of bytes read.
@@ -222,6 +225,43 @@ open class OutputStream : Stream {
     
     open override var streamError: Error? {
         return CFWriteStreamCopyError(_stream)
+    }
+}
+
+extension InputStream {
+    func seek(to position: UInt64) throws {
+        guard position > 0 else {
+            return
+        }
+        
+        guard position < Int.max else { throw _Error.cantSeekInputStream }
+        
+        let bufferSize = 1024
+        var remainingBytes = Int(position)
+        
+        let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: bufferSize, alignment: MemoryLayout<UInt8>.alignment)
+        
+        guard let pointer = buffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+            buffer.deallocate()
+            throw _Error.cantSeekInputStream
+        }
+        
+        if self.streamStatus == .notOpen {
+            self.open()
+        }
+        
+        while remainingBytes > 0 && self.hasBytesAvailable {
+            let read = self.read(pointer, maxLength: min(bufferSize, remainingBytes))
+            if read == -1 {
+                throw _Error.cantSeekInputStream
+            }
+            remainingBytes -= read
+        }
+        
+        buffer.deallocate()
+        if remainingBytes != 0 {
+            throw _Error.cantSeekInputStream
+        }
     }
 }
 

--- a/Foundation/URLSession/BodySource.swift
+++ b/Foundation/URLSession/BodySource.swift
@@ -65,25 +65,25 @@ internal final class _BodyStreamSource {
 
 extension _BodyStreamSource : _BodySource {
     func getNextChunk(withLength length: Int) -> _BodySourceDataChunk {
-        if inputStream.hasBytesAvailable {
-            let buffer = UnsafeMutableRawBufferPointer.allocate(count: length)
-            guard let pointer = buffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
-                return .error
-            }
-            let readBytes = self.inputStream.read(pointer, maxLength: length)
-            if readBytes > 0 {
-                let dispatchData = DispatchData(bytes: UnsafeRawBufferPointer(buffer))
-                return .data(dispatchData.subdata(in: 0 ..< readBytes))
-            }
-            else if readBytes == 0 {
-                return .done
-            }
-            else {
-                return .error
-            }
+        guard inputStream.hasBytesAvailable else {
+            return .done
+        }
+        
+
+        let buffer = UnsafeMutableRawBufferPointer.allocate(count: length)
+        guard let pointer = buffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+            return .error
+        }
+        let readBytes = self.inputStream.read(pointer, maxLength: length)
+        if readBytes > 0 {
+            let dispatchData = DispatchData(bytes: UnsafeRawBufferPointer(buffer))
+            return .data(dispatchData.subdata(in: 0 ..< readBytes))
+        }
+        else if readBytes == 0 {
+            return .done
         }
         else {
-            return .done
+            return .error
         }
     }
 }

--- a/Foundation/URLSession/BodySource.swift
+++ b/Foundation/URLSession/BodySource.swift
@@ -72,17 +72,20 @@ extension _BodyStreamSource : _BodySource {
 
         let buffer = UnsafeMutableRawBufferPointer.allocate(count: length)
         guard let pointer = buffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+            buffer.deallocate()
             return .error
         }
         let readBytes = self.inputStream.read(pointer, maxLength: length)
         if readBytes > 0 {
-            let dispatchData = DispatchData(bytes: UnsafeRawBufferPointer(buffer))
+            let dispatchData = DispatchData(bytesNoCopy: UnsafeRawBufferPointer(buffer), deallocator: .free)
             return .data(dispatchData.subdata(in: 0 ..< readBytes))
         }
         else if readBytes == 0 {
+            buffer.deallocate()
             return .done
         }
         else {
+            buffer.deallocate()
             return .error
         }
     }

--- a/Foundation/URLSession/BodySource.swift
+++ b/Foundation/URLSession/BodySource.swift
@@ -68,11 +68,9 @@ extension _BodyStreamSource : _BodySource {
         guard inputStream.hasBytesAvailable else {
             return .done
         }
-
-        let buffer = UnsafeMutableRawBufferPointer.allocate(count: length)
-        defer {
-            buffer.deallocate()
-        }
+        
+        let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: length, alignment: MemoryLayout<UInt8>.alignment)
+        defer { buffer.deallocate() }
         
         guard let pointer = buffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
             return .error

--- a/Foundation/URLSession/BodySource.swift
+++ b/Foundation/URLSession/BodySource.swift
@@ -68,24 +68,25 @@ extension _BodyStreamSource : _BodySource {
         guard inputStream.hasBytesAvailable else {
             return .done
         }
-        
 
         let buffer = UnsafeMutableRawBufferPointer.allocate(count: length)
-        guard let pointer = buffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+        defer {
             buffer.deallocate()
+        }
+        
+        guard let pointer = buffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
             return .error
         }
+        
         let readBytes = self.inputStream.read(pointer, maxLength: length)
         if readBytes > 0 {
-            let dispatchData = DispatchData(bytesNoCopy: UnsafeRawBufferPointer(buffer), deallocator: .free)
+            let dispatchData = DispatchData(bytes: UnsafeRawBufferPointer(buffer))
             return .data(dispatchData.subdata(in: 0 ..< readBytes))
         }
         else if readBytes == 0 {
-            buffer.deallocate()
             return .done
         }
         else {
-            buffer.deallocate()
             return .error
         }
     }

--- a/Foundation/URLSession/BodySource.swift
+++ b/Foundation/URLSession/BodySource.swift
@@ -55,6 +55,39 @@ internal enum _BodySourceDataChunk {
     case error
 }
 
+internal final class _BodyStreamSource {
+    let inputStream: InputStream
+    
+    init(inputStream: InputStream) {
+        self.inputStream = inputStream
+    }
+}
+
+extension _BodyStreamSource : _BodySource {
+    func getNextChunk(withLength length: Int) -> _BodySourceDataChunk {
+        if inputStream.hasBytesAvailable {
+            let buffer = UnsafeMutableRawBufferPointer.allocate(count: length)
+            guard let pointer = buffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+                return .error
+            }
+            let readBytes = self.inputStream.read(pointer, maxLength: length)
+            if readBytes > 0 {
+                let dispatchData = DispatchData(bytes: UnsafeRawBufferPointer(buffer))
+                return .data(dispatchData.subdata(in: 0 ..< readBytes))
+            }
+            else if readBytes == 0 {
+                return .done
+            }
+            else {
+                return .error
+            }
+        }
+        else {
+            return .done
+        }
+    }
+}
+
 /// A body data source backed by `DispatchData`.
 internal final class _BodyDataSource {
     var data: DispatchData! 

--- a/Foundation/URLSession/NativeProtocol.swift
+++ b/Foundation/URLSession/NativeProtocol.swift
@@ -269,6 +269,7 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
                     case .transferInProgress(let currentTransferState):
                         switch currentTransferState.requestBodySource {
                         case is _BodyStreamSource:
+                            try inputStream.seek(to: position)
                             let drain = strongSelf.createTransferBodyDataDrain()
                             let source = _BodyStreamSource(inputStream: inputStream)
                             let transferState = _TransferState(url: url, bodyDataDrain: drain, bodySource: source)

--- a/Foundation/URLSession/NativeProtocol.swift
+++ b/Foundation/URLSession/NativeProtocol.swift
@@ -260,7 +260,7 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
     }
 
     func seekInputStream(to position: UInt64) throws {
-        // We will reset the body sourse and seek forward.
+        // We will reset the body source and seek forward.
         guard let session = task?.session as? URLSession else { fatalError() }
         if let delegate = session.delegate as? URLSessionTaskDelegate {
             delegate.urlSession(session, task: task!, needNewBodyStream: { [weak self] inputStream in

--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -57,7 +57,7 @@ open class URLSessionTask : NSObject, NSCopying {
     internal convenience init(session: URLSession, request: URLRequest, taskIdentifier: Int) {
         if let bodyData = request.httpBody {
             self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: _Body.data(createDispatchData(bodyData)))
-        }else if let bodyStream = request.httpBodyStream {
+        } else if let bodyStream = request.httpBodyStream {
             self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: _Body.stream(bodyStream))
         } else {
             self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: .none)

--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -57,6 +57,8 @@ open class URLSessionTask : NSObject, NSCopying {
     internal convenience init(session: URLSession, request: URLRequest, taskIdentifier: Int) {
         if let bodyData = request.httpBody {
             self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: _Body.data(createDispatchData(bodyData)))
+        }else if let bodyStream = request.httpBodyStream {
+            self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: _Body.stream(bodyStream))
         } else {
             self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: .none)
         }

--- a/TestFoundation/TestStream.swift
+++ b/TestFoundation/TestStream.swift
@@ -6,6 +6,13 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+    #if (os(Linux) || os(Android))
+        @testable import Foundation
+    #else
+        @testable import SwiftFoundation
+    #endif
+#endif
 
 private extension Data {
     init(reading input: InputStream) {
@@ -18,7 +25,7 @@ private extension Data {
             let read = input.read(buffer, maxLength: bufferSize)
             self.append(buffer, count: read)
         }
-        buffer.deallocate(capacity: bufferSize)
+        buffer.deallocate()
         
         input.close()
     }
@@ -150,7 +157,7 @@ class TestStream : XCTestCase {
             try stream.seek(to: pos)
             let streamData = Data(reading: stream)
             
-            let subdata = data.subdata(in: Range(Int(pos)..<data.count))
+            let subdata = data[Int(pos)..<data.count]
             XCTAssertEqual(streamData, subdata)
             
             return subdata

--- a/TestFoundation/TestStream.swift
+++ b/TestFoundation/TestStream.swift
@@ -7,6 +7,23 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+private extension Data {
+    init(reading input: InputStream) {
+        self.init()
+        input.open()
+        
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        while input.hasBytesAvailable {
+            let read = input.read(buffer, maxLength: bufferSize)
+            self.append(buffer, count: read)
+        }
+        buffer.deallocate(capacity: bufferSize)
+        
+        input.close()
+    }
+}
+
 class TestStream : XCTestCase {
     static var allTests: [(String, (TestStream) -> () throws -> Void)] {
         return [
@@ -15,6 +32,7 @@ class TestStream : XCTestCase {
             ("test_InputStreamWithFile", test_InputStreamWithFile),
             ("test_InputStreamHasBytesAvailable", test_InputStreamHasBytesAvailable),
             ("test_InputStreamInvalidPath", test_InputStreamInvalidPath),
+            ("test_InputStreamSeekToPosition", test_InputStreamSeekToPosition),
             ("test_outputStreamCreationToFile", test_outputStreamCreationToFile),
             ("test_outputStreamCreationToBuffer", test_outputStreamCreationToBuffer),
             ("test_outputStreamCreationWithUrl", test_outputStreamCreationWithUrl),
@@ -114,6 +132,50 @@ class TestStream : XCTestCase {
         XCTAssertEqual(.notOpen, fileStream.streamStatus)
         fileStream.open()
         XCTAssertEqual(.error, fileStream.streamStatus)
+    }
+    
+    func test_InputStreamSeekToPosition() {
+        let str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras congue laoreet facilisis. Sed porta tristique orci. Fusce ut nisl dignissim, tempor tortor id, molestie neque. Nam non tincidunt mi. Integer ac diam quis leo aliquam congue et non magna. In porta mauris suscipit erat pulvinar, sed fringilla quam ornare. Nulla vulputate et ligula vitae sollicitudin. Nulla vel vehicula risus. Quisque eu urna ullamcorper, tincidunt ante vitae, aliquet sem. Suspendisse nec turpis placerat, porttitor ex vel, tristique orci. Maecenas pretium, augue non elementum imperdiet, diam ex vestibulum tortor, non ultrices ante enim iaculis ex. Fusce ut nisl dignissim, tempor tortor id, molestie neque. Nam non tincidunt mi. Integer ac diam quis leo aliquam congue et non magna. In porta mauris suscipit erat pulvinar, sed fringilla quam ornare. Nulla vulputate et ligula vitae sollicitudin. Nulla vel vehicula risus. Quisque eu urna ullamcorper, tincidunt ante vitae, aliquet sem. Suspendisse nec turpis placerat, porttitor ex vel, tristique orci. Maecenas pretium, augue non elementum imperdiet, diam ex vestibulum tortor, non ultrices ante enim iaculis ex.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras congue laoreet facilisis. Sed porta tristique orci. Fusce ut nisl dignissim, tempor tortor id, molestie neque. Nam non tincidunt mi. Integer ac diam quis leo aliquam congue et non magna. In porta mauris suscipit erat pulvinar, sed fringilla quam ornare. Nulla vulputate et ligula vitae sollicitudin. Nulla vel vehicula risus. Quisque eu urna ullamcorper, tincidunt ante vitae, aliquet sem. Suspendisse nec turpis placerat, porttitor ex vel."
+        XCTAssert(str.count > 1024) // str.count must be bigger than buffersize inside InputStream.seek func.
+        
+        func testSubdata(_ pos: UInt64) throws -> Data? {
+            guard let data = str.data(using: .utf8) else {
+                XCTFail()
+                return nil
+            }
+            
+            let stream = InputStream(data: data)
+            stream.open()
+            
+            try stream.seek(to: pos)
+            let streamData = Data(reading: stream)
+            
+            let subdata = data.subdata(in: Range(Int(pos)..<data.count))
+            XCTAssertEqual(streamData, subdata)
+            
+            return subdata
+        }
+        
+        var sum = 0
+        for i in 0...str.count {
+            do {
+                sum += try testSubdata(UInt64(i))!.count
+            } catch _ {
+                XCTFail()
+            }
+        }
+        
+        XCTAssertEqual(((1 + str.count) * str.count)/2, sum) // Test on sum of arithmetic sequence :)
+        XCTAssertEqual(try testSubdata(UInt64(str.count))!.count, 0) // It shouldbe end
+        
+        do {
+            try testSubdata(UInt64(str.count + 1)) // out of boundaries
+            XCTFail()
+        } catch let error as InputStream._Error {
+            XCTAssertEqual(error, .cantSeekInputStream)
+        } catch {
+            XCTFail()
+        }
     }
     
     func test_outputStreamCreationToFile() {

--- a/TestFoundation/TestStream.swift
+++ b/TestFoundation/TestStream.swift
@@ -6,13 +6,13 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
-#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
-    #if (os(Linux) || os(Android))
-        @testable import Foundation
-    #else
-        @testable import SwiftFoundation
-    #endif
+
+#if (os(Linux) || os(Android))
+    @testable import Foundation
+#else
+    @testable import SwiftFoundation
 #endif
+
 
 private extension Data {
     init(reading input: InputStream) {

--- a/TestFoundation/TestStream.swift
+++ b/TestFoundation/TestStream.swift
@@ -7,12 +7,13 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if (os(Linux) || os(Android))
-    @testable import Foundation
-#else
-    @testable import SwiftFoundation
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+    #if (os(Linux) || os(Android))
+        @testable import Foundation
+    #else
+        @testable import SwiftFoundation
+    #endif
 #endif
-
 
 private extension Data {
     init(reading input: InputStream) {
@@ -142,6 +143,7 @@ class TestStream : XCTestCase {
     }
     
     func test_InputStreamSeekToPosition() {
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
         let str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras congue laoreet facilisis. Sed porta tristique orci. Fusce ut nisl dignissim, tempor tortor id, molestie neque. Nam non tincidunt mi. Integer ac diam quis leo aliquam congue et non magna. In porta mauris suscipit erat pulvinar, sed fringilla quam ornare. Nulla vulputate et ligula vitae sollicitudin. Nulla vel vehicula risus. Quisque eu urna ullamcorper, tincidunt ante vitae, aliquet sem. Suspendisse nec turpis placerat, porttitor ex vel, tristique orci. Maecenas pretium, augue non elementum imperdiet, diam ex vestibulum tortor, non ultrices ante enim iaculis ex. Fusce ut nisl dignissim, tempor tortor id, molestie neque. Nam non tincidunt mi. Integer ac diam quis leo aliquam congue et non magna. In porta mauris suscipit erat pulvinar, sed fringilla quam ornare. Nulla vulputate et ligula vitae sollicitudin. Nulla vel vehicula risus. Quisque eu urna ullamcorper, tincidunt ante vitae, aliquet sem. Suspendisse nec turpis placerat, porttitor ex vel, tristique orci. Maecenas pretium, augue non elementum imperdiet, diam ex vestibulum tortor, non ultrices ante enim iaculis ex.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras congue laoreet facilisis. Sed porta tristique orci. Fusce ut nisl dignissim, tempor tortor id, molestie neque. Nam non tincidunt mi. Integer ac diam quis leo aliquam congue et non magna. In porta mauris suscipit erat pulvinar, sed fringilla quam ornare. Nulla vulputate et ligula vitae sollicitudin. Nulla vel vehicula risus. Quisque eu urna ullamcorper, tincidunt ante vitae, aliquet sem. Suspendisse nec turpis placerat, porttitor ex vel."
         XCTAssert(str.count > 1024) // str.count must be bigger than buffersize inside InputStream.seek func.
         
@@ -178,11 +180,14 @@ class TestStream : XCTestCase {
         do {
             try testSubdata(UInt64(str.count + 1)) // out of boundaries
             XCTFail()
-        } catch let error as InputStream._Error {
+        } catch let error as InputStream.Error {
             XCTAssertEqual(error, .cantSeekInputStream)
         } catch {
             XCTFail()
         }
+#else
+        print("NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT is not defined, skip it")
+#endif
     }
     
     func test_outputStreamCreationToFile() {

--- a/TestFoundation/TestURLSession.swift
+++ b/TestFoundation/TestURLSession.swift
@@ -125,13 +125,6 @@ class TestURLSession : LoopbackServerTest {
     }
     
     func test_dataTaskWithHttpInputStream() {
-        func uniformRandom(_ max: Int) -> Int {
-#if os(Linux)
-            return Int(random() % max)
-#else
-            return Int(arc4random_uniform(UInt32(max)))
-#endif
-        }
         func randomString(length: Int) -> String {
             let letters = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
             let len = letters.count
@@ -139,8 +132,8 @@ class TestURLSession : LoopbackServerTest {
             var randomString = ""
             
             for _ in 0 ..< length {
-                let rand = uniformRandom(len)
-                let nextChar = letters[Int(rand)]
+                let rand = Int.random(in: 0..<len)
+                let nextChar = letters[rand]
                 randomString += String(nextChar)
             }
             return randomString

--- a/TestFoundation/TestURLSession.swift
+++ b/TestFoundation/TestURLSession.swift
@@ -125,16 +125,23 @@ class TestURLSession : LoopbackServerTest {
     }
     
     func test_dataTaskWithHttpInputStream() {
+        func uniformRandom(_ max: Int) -> Int {
+#if os(Linux)
+            return Int(random() % max)
+#else
+            return Int(arc4random_uniform(UInt32(max)))
+#endif
+        }
         func randomString(length: Int) -> String {
-            let letters : NSString = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-            let len = UInt32(letters.length)
+            let letters = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+            let len = letters.count
             
             var randomString = ""
             
             for _ in 0 ..< length {
-                let rand = arc4random_uniform(len)
-                var nextChar = letters.character(at: Int(rand))
-                randomString += NSString(characters: &nextChar, length: 1) as String
+                let rand = uniformRandom(len)
+                let nextChar = letters[Int(rand)]
+                randomString += String(nextChar)
             }
             return randomString
         }


### PR DESCRIPTION
>Allows using InputStream in _URLRequest_ as `httpBodyStream`. Also, implement `seekInputStream` in _NativeProtocol_.

This is a cherry-pick of the #1629 
