### PR TITLE
SR-6531: FileManager copyItem() does not preserve permissions

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -673,7 +673,7 @@ open class FileManager : NSObject {
 #endif
         result[.modificationDate] = Date(timeIntervalSinceReferenceDate: ti)
         
-        result[.posixPermissions] = NSNumber(value: UInt64(s.st_mode & 0o7777))
+        result[.posixPermissions] = NSNumber(value: UInt64(s.st_mode & ~S_IFMT))
         result[.referenceCount] = NSNumber(value: UInt64(s.st_nlink))
         result[.systemNumber] = NSNumber(value: UInt64(s.st_dev))
         result[.systemFileNumber] = NSNumber(value: UInt64(s.st_ino))
@@ -844,6 +844,13 @@ open class FileManager : NSObject {
                                     extraUserInfo: extraErrorInfo(srcPath: srcPath, dstPath: dstPath, userVariant: variant))
         }
         defer { close(dstfd) }
+
+        // Set the file permissions using fchmod() instead of when open()ing to avoid umask() issues
+        let permissions = fileInfo.st_mode & ~S_IFMT
+        guard fchmod(dstfd, permissions) == 0 else {
+            throw _NSErrorWithErrno(errno, reading: false, path: dstPath,
+                extraUserInfo: extraErrorInfo(srcPath: srcPath, dstPath: dstPath, userVariant: variant))
+        }
 
         if fileInfo.st_size == 0 {
             // no copying required
@@ -1394,7 +1401,7 @@ open class FileManager : NSObject {
 
     internal func _permissionsOfItem(atPath path: String) throws -> Int {
         let fileInfo = try _lstatFile(atPath: path)
-        return Int(fileInfo.st_mode & 0o777)
+        return Int(fileInfo.st_mode & ~S_IFMT)
     }
 
     /* -contentsEqualAtPath:andPath: does not take into account data stored in the resource fork or filesystem extended attributes.

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -41,6 +41,7 @@ class TestFileManager : XCTestCase {
             ("test_temporaryDirectoryForUser", test_temporaryDirectoryForUser),
             ("test_creatingDirectoryWithShortIntermediatePath", test_creatingDirectoryWithShortIntermediatePath),
             ("test_mountedVolumeURLs", test_mountedVolumeURLs),
+            ("test_copyItemsPermissions", test_copyItemsPermissions),
         ]
         
 #if !DEPLOYMENT_RUNTIME_OBJC && NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
@@ -1066,6 +1067,48 @@ class TestFileManager : XCTestCase {
         try? data.write(to: dataFile1)
         XCTAssertFalse(fm.contentsEqual(atPath: dataFile1.path, andPath: dataFile2.path))
         XCTAssertFalse(fm.contentsEqual(atPath: testDir1.path, andPath: testDir2.path))
+    }
+
+    func test_copyItemsPermissions() throws {
+        let fm = FileManager.default
+        let tmpDir = fm.temporaryDirectory.appendingPathComponent("test_copyItemsPermissions")
+        try fm.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(atPath: tmpDir.path) }
+
+        let srcFile = tmpDir.appendingPathComponent("file1.txt")
+        let destFile = tmpDir.appendingPathComponent("file2.txt")
+
+        try? fm.removeItem(at: srcFile)
+        try "This is the source file".write(toFile: srcFile.path, atomically: false, encoding: .utf8)
+
+        func testCopy() throws {
+            try? fm.removeItem(at: destFile)
+            try fm.copyItem(at: srcFile, to: destFile)
+
+            if let srcPerms = (try fm.attributesOfItem(atPath: srcFile.path)[.posixPermissions] as? NSNumber)?.intValue,
+                let destPerms = (try fm.attributesOfItem(atPath: destFile.path)[.posixPermissions] as? NSNumber)?.intValue {
+                XCTAssertEqual(srcPerms, destPerms)
+            } else {
+                XCTFail("Cant get file permissions")
+            }
+        }
+
+        try testCopy()
+
+        try fm.setAttributes([ .posixPermissions: 0o417], ofItemAtPath: srcFile.path)
+        try testCopy()
+
+        try fm.setAttributes([ .posixPermissions: 0o400], ofItemAtPath: srcFile.path)
+        try testCopy()
+
+        try fm.setAttributes([ .posixPermissions: 0o700], ofItemAtPath: srcFile.path)
+        try testCopy()
+
+        try fm.setAttributes([ .posixPermissions: 0o707], ofItemAtPath: srcFile.path)
+        try testCopy()
+
+        try fm.setAttributes([ .posixPermissions: 0o411], ofItemAtPath: srcFile.path)
+        try testCopy()
     }
     
 #if !DEPLOYMENT_RUNTIME_OBJC // XDG tests require swift-corelibs-foundation

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -1078,13 +1078,15 @@ class TestFileManager : XCTestCase {
         let srcFile = tmpDir.appendingPathComponent("file1.txt")
         let destFile = tmpDir.appendingPathComponent("file2.txt")
 
+        let source = "This is the source file"
         try? fm.removeItem(at: srcFile)
-        try "This is the source file".write(toFile: srcFile.path, atomically: false, encoding: .utf8)
+        try source.write(toFile: srcFile.path, atomically: false, encoding: .utf8)
 
         func testCopy() throws {
             try? fm.removeItem(at: destFile)
             try fm.copyItem(at: srcFile, to: destFile)
-
+            let copy = try String(contentsOf: destFile)
+            XCTAssertEqual(source, copy)
             if let srcPerms = (try fm.attributesOfItem(atPath: srcFile.path)[.posixPermissions] as? NSNumber)?.intValue,
                 let destPerms = (try fm.attributesOfItem(atPath: destFile.path)[.posixPermissions] as? NSNumber)?.intValue {
                 XCTAssertEqual(srcPerms, destPerms)


### PR DESCRIPTION
- Use fchmod() to set the file permissions after opening.

- Ensure all file permissions are correctly masked using ~S_IFMT.