### PR TITLE
[SR-10428] URLSession: Methods invalidateAndCancel and getAllTasks implemented

### DIFF
--- a/Foundation/URLSession/TaskRegistry.swift
+++ b/Foundation/URLSession/TaskRegistry.swift
@@ -94,6 +94,10 @@ extension URLSession._TaskRegistry {
     var isEmpty: Bool {
         return tasks.isEmpty
     }
+    
+    var allTasks: [URLSessionTask] {
+        return tasks.map { $0.value }
+    }
 }
 extension URLSession._TaskRegistry {
     /// The behaviour that's registered for the given task.

--- a/TestFoundation/TestURLSession.swift
+++ b/TestFoundation/TestURLSession.swift
@@ -825,15 +825,11 @@ class TestURLSession : LoopbackServerTest {
     }
 
     func test_sessionDelegateAfterInvalidateAndCancel() {
-        let expect = expectation(description: "Check nillify 'sessionDelegate' after invalidateAndCancel")
-        
         let delegate = SessionDelegate()
         let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
         session.invalidateAndCancel()
         sleep(2)
         XCTAssertNil(session.delegate)
-        expect.fulfill()
-        waitForExpectations(timeout: 5)
     }
 
 }

--- a/TestFoundation/TestURLSession.swift
+++ b/TestFoundation/TestURLSession.swift
@@ -48,6 +48,9 @@ class TestURLSession : LoopbackServerTest {
             ("test_redirectionWithSetCookies", test_redirectionWithSetCookies),
             ("test_postWithEmptyBody", test_postWithEmptyBody),
             ("test_basicAuthWithUnauthorizedHeader", test_basicAuthWithUnauthorizedHeader),
+            ("test_checkErrorTypeAfterInvalidateAndCancel", test_checkErrorTypeAfterInvalidateAndCancel),
+            ("test_taskCountAfterInvalidateAndCancel", test_taskCountAfterInvalidateAndCancel),
+            ("test_sessionDelegateAfterInvalidateAndCancel", test_sessionDelegateAfterInvalidateAndCancel),
         ]
     }
     
@@ -773,6 +776,66 @@ class TestURLSession : LoopbackServerTest {
         task.resume()
         waitForExpectations(timeout: 12, handler: nil)
     }
+
+    func test_checkErrorTypeAfterInvalidateAndCancel() {
+        let urlString = "https://developer.apple.com"
+        let expect = expectation(description: "Check error code of tasks after invalidateAndCancel")
+        let delegate = SessionDelegate()
+        let url = URL(string: urlString)!
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        let task = session.dataTask(with: url) { (_, _, error) in
+            XCTAssertNotNil(error as? URLError)
+            if let urlError = error as? URLError {
+                XCTAssertEqual(urlError._nsError.code, NSURLErrorCancelled)
+            }
+            
+            expect.fulfill()
+        }
+        task.resume()
+        session.invalidateAndCancel()
+        waitForExpectations(timeout: 5)
+    }
+    
+    func test_taskCountAfterInvalidateAndCancel() {
+        let expect = expectation(description: "Check task count after invalidateAndCancel")
+        
+        let session = URLSession(configuration: .default)
+        let task1 = session.dataTask(with: URL(string: "https://www.apple.com")!)
+        let task2 = session.dataTask(with: URL(string: "https://developer.apple.com")!)
+        let task3 = session.dataTask(with: URL(string: "https://developer.apple.com/swift")!)
+        
+        task1.resume()
+        task2.resume()
+        session.invalidateAndCancel()
+        sleep(1)
+        
+        session.getAllTasks { tasksBeforeResume in
+            XCTAssertEqual(tasksBeforeResume.count, 0)
+            
+            // Resume a task after invalidating a session shouldn't change the task's status
+            task3.resume()
+            
+            session.getAllTasks { tasksAfterResume in
+                XCTAssertEqual(tasksAfterResume.count, 0)
+                expect.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 5)
+    }
+
+    func test_sessionDelegateAfterInvalidateAndCancel() {
+        let expect = expectation(description: "Check nillify 'sessionDelegate' after invalidateAndCancel")
+        
+        let delegate = SessionDelegate()
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        session.invalidateAndCancel()
+        sleep(2)
+        XCTAssertNil(session.delegate)
+        expect.fulfill()
+        waitForExpectations(timeout: 5)
+    }
+
 }
 
 class SharedDelegate: NSObject {
@@ -792,12 +855,16 @@ extension SharedDelegate: URLSessionDownloadDelegate {
 
 
 class SessionDelegate: NSObject, URLSessionDelegate {
-    let invalidateExpectation: XCTestExpectation
-    init(invalidateExpectation: XCTestExpectation){
+    let invalidateExpectation: XCTestExpectation?
+    override init() {
+        invalidateExpectation = nil
+        super.init()
+    }
+    init(invalidateExpectation: XCTestExpectation) {
         self.invalidateExpectation = invalidateExpectation
     }
     func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
-        invalidateExpectation.fulfill()
+        invalidateExpectation?.fulfill()
     }
 }
 


### PR DESCRIPTION
- `invalidateAndCancel` method implemented.
- `getAllTasks` methods implemented.
- New computed property `allTasks` added in `URLSession._TaskRegistry`, to return an array of all the existing tasks added in `_TaskRegistry`.

Update:
Bug Link: https://bugs.swift.org/browse/SR-10428