### PR TITLE
[5.0]  SR-6531: FileManager copyItem() does not preserve permissions

### DIFF
--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -41,6 +41,7 @@ class TestFileManager : XCTestCase {
             ("test_temporaryDirectoryForUser", test_temporaryDirectoryForUser),
             ("test_creatingDirectoryWithShortIntermediatePath", test_creatingDirectoryWithShortIntermediatePath),
             ("test_mountedVolumeURLs", test_mountedVolumeURLs),
+            ("test_copyItemsPermissions", test_copyItemsPermissions),
         ]
         
 #if !DEPLOYMENT_RUNTIME_OBJC && NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
@@ -1066,6 +1067,48 @@ class TestFileManager : XCTestCase {
         try? data.write(to: dataFile1)
         XCTAssertFalse(fm.contentsEqual(atPath: dataFile1.path, andPath: dataFile2.path))
         XCTAssertFalse(fm.contentsEqual(atPath: testDir1.path, andPath: testDir2.path))
+    }
+
+    func test_copyItemsPermissions() throws {
+        let fm = FileManager.default
+        let tmpDir = fm.temporaryDirectory.appendingPathComponent("test_copyItemsPermissions")
+        try fm.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(atPath: tmpDir.path) }
+
+        let srcFile = tmpDir.appendingPathComponent("file1.txt")
+        let destFile = tmpDir.appendingPathComponent("file2.txt")
+
+        try? fm.removeItem(at: srcFile)
+        try "This is the source file".write(toFile: srcFile.path, atomically: false, encoding: .utf8)
+
+        func testCopy() throws {
+            try? fm.removeItem(at: destFile)
+            try fm.copyItem(at: srcFile, to: destFile)
+
+            if let srcPerms = (try fm.attributesOfItem(atPath: srcFile.path)[.posixPermissions] as? NSNumber)?.intValue,
+                let destPerms = (try fm.attributesOfItem(atPath: destFile.path)[.posixPermissions] as? NSNumber)?.intValue {
+                XCTAssertEqual(srcPerms, destPerms)
+            } else {
+                XCTFail("Cant get file permissions")
+            }
+        }
+
+        try testCopy()
+
+        try fm.setAttributes([ .posixPermissions: 0o417], ofItemAtPath: srcFile.path)
+        try testCopy()
+
+        try fm.setAttributes([ .posixPermissions: 0o400], ofItemAtPath: srcFile.path)
+        try testCopy()
+
+        try fm.setAttributes([ .posixPermissions: 0o700], ofItemAtPath: srcFile.path)
+        try testCopy()
+
+        try fm.setAttributes([ .posixPermissions: 0o707], ofItemAtPath: srcFile.path)
+        try testCopy()
+
+        try fm.setAttributes([ .posixPermissions: 0o411], ofItemAtPath: srcFile.path)
+        try testCopy()
     }
     
 #if !DEPLOYMENT_RUNTIME_OBJC // XDG tests require swift-corelibs-foundation

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -1078,13 +1078,15 @@ class TestFileManager : XCTestCase {
         let srcFile = tmpDir.appendingPathComponent("file1.txt")
         let destFile = tmpDir.appendingPathComponent("file2.txt")
 
+        let source = "This is the source file"
         try? fm.removeItem(at: srcFile)
-        try "This is the source file".write(toFile: srcFile.path, atomically: false, encoding: .utf8)
+        try source.write(toFile: srcFile.path, atomically: false, encoding: .utf8)
 
         func testCopy() throws {
             try? fm.removeItem(at: destFile)
             try fm.copyItem(at: srcFile, to: destFile)
-
+            let copy = try String(contentsOf: destFile)
+            XCTAssertEqual(source, copy)
             if let srcPerms = (try fm.attributesOfItem(atPath: srcFile.path)[.posixPermissions] as? NSNumber)?.intValue,
                 let destPerms = (try fm.attributesOfItem(atPath: destFile.path)[.posixPermissions] as? NSNumber)?.intValue {
                 XCTAssertEqual(srcPerms, destPerms)


### PR DESCRIPTION
    - Use fchmod() to set the file permissions after opening.
    
- Ensure all file permissions are correctly masked using ~S_IFMT.
    
(cherry picked from commit aa5f75c30e98e7096c162d6e1aaf72aaac6cbc5c)

- Check the file copy worked in the tests
    
(cherry picked from commit a16c18c4bb2b12772d2717ee2f22872e24e0baf5)
