### PR TITLE
CoreFoundation: switch to `_WINDLL` from `_USRDLL`

### DIFF
--- a/CoreFoundation/Base.subproj/CFBase.h
+++ b/CoreFoundation/Base.subproj/CFBase.h
@@ -133,7 +133,7 @@
         #define _CF_EXTERN extern
     #endif
 
-    #if defined(_USRDLL)
+    #if defined(_WINDLL)
         #if defined(CoreFoundation_EXPORTS) || defined(CF_BUILDING_CF)
             #define CF_EXPORT _CF_EXTERN __declspec(dllexport)
         #else

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -337,7 +337,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
   if(BUILD_SHARED_LIBS)
     target_compile_definitions(CoreFoundation
                                PRIVATE
-                                 -D_USRDLL)
+                                 -D_WINDLL)
   endif()
 endif()
 target_compile_definitions(CoreFoundation


### PR DESCRIPTION
`_USRDLL` is used to indicate that you are building a MFC DLL while
`_WINDLL` is specified for **ALL** DLL builds. Use the correct macro.