### PR TITLE
Foundation: remove deprecated `bzero`

### DIFF
--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -971,7 +971,7 @@ open class NSMutableData : NSData {
 
     /// Replaces with zeroes the contents of the data object in a given range.
     open func resetBytes(in range: NSRange) {
-        bzero(mutableBytes.advanced(by: range.location), range.length)
+        memset(mutableBytes.advanced(by: range.location), 0, range.length)
     }
 
     /// Replaces the entire contents of the data object with the contents of another data object.

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -26,13 +26,6 @@ import CoreFoundation
 import WinSDK
 #endif
 
-// shim required for bzero
-#if os(Android) || os(Windows)
-@_transparent func bzero(_ ptr: UnsafeMutableRawPointer, _ size: size_t) {
-    memset(ptr, 0, size)
-}
-#endif
-
 #if !_runtime(_ObjC)
 /// The Objective-C BOOL type.
 ///
@@ -144,7 +137,7 @@ internal func _CFSwiftIsEqual(_ cf1: AnyObject, cf2: AnyObject) -> Bool {
 // Ivars in _NSCF* types must be zeroed via an unsafe accessor to avoid deinit of potentially unsafe memory to accces as an object/struct etc since it is stored via a foreign object graph
 internal func _CFZeroUnsafeIvars<T>(_ arg: inout T) {
     withUnsafeMutablePointer(to: &arg) { (ptr: UnsafeMutablePointer<T>) -> Void in
-        bzero(UnsafeMutableRawPointer(ptr), MemoryLayout<T>.size)
+        memset(UnsafeMutableRawPointer(ptr), 0, MemoryLayout<T>.size)
     }
 }
 


### PR DESCRIPTION
The `bzero` implementation is unnecessary as it is trivially
implementable by the "modern" `memset` API.  Additionally, the use of
the type `size_t` causes trouble for Windows which tries to interpret it
as `Foundation.size_t` rather than `ucrt.size_t` which results in a
horrific deserialisation fatalError.