### PR TITLE
plutil: make `plutil` build on Windows

### DIFF
--- a/Tools/plutil/main.swift
+++ b/Tools/plutil/main.swift
@@ -12,6 +12,9 @@ import SwiftFoundation
 #elseif os(Linux)
 import Foundation
 import Glibc
+#elseif os(Windows)
+import Foundation
+import MSVCRT
 #endif
 
 func help() -> Int32 {


### PR DESCRIPTION
plutil uses the C runtime, make sure that we import `MSVCRT`.