### PR TITLE
build: ensure that we build CoreFoundation for re-export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ ExternalProject_Add(CoreFoundation
                       -DBUILD_SHARED_LIBS=NO
                       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                       -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                      $<$<BOOL:BUILD_SHARED_LIBS>:-DCMAKE_C_FLAGS=-D_WINDLL>
                       -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
                       -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                       -DCMAKE_INSTALL_LIBDIR=usr/lib


### PR DESCRIPTION
We wish to re-export CoreFoundation from Foundation.  In order to
accomplish this, the objects need to be built as if they are being built
for a DLL as they will be subsumed into the Foundation DLL.  We do not
necessarily wish to do this if we are building Foundation static
however.  Doing this ensures that we can re-export the symbols from
CoreFoundation on Windows.