### PR TITLE
Revert "Add ICU version check to ensure minimum of version 61 is used."

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,12 +20,6 @@ find_package(CURL REQUIRED)
 find_package(ICU COMPONENTS uc i18n REQUIRED)
 find_package(LibXml2 REQUIRED)
 
-set(ICU_MINIMUM_VERSION 61)
-if(ICU_VERSION VERSION_LESS ${ICU_MINIMUM_VERSION})
-  message(FATAL_ERROR "ICU version ${ICU_VERSION} is less than required version ${ICU_MINIMUM_VERSION}")
-endif()
-
-
 include(SwiftSupport)
 include(GNUInstallDirs)
 include(ExternalProject)

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -381,12 +381,6 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
                              PRIVATE
                                ${CURL_INCLUDE_DIRS})
   find_package(ICU COMPONENTS uc i18n REQUIRED)
-
-  set(ICU_MINIMUM_VERSION 61)
-  if(ICU_VERSION VERSION_LESS ${ICU_MINIMUM_VERSION})
-    message(FATAL_ERROR "ICU version ${ICU_VERSION} is less than required version ${ICU_MINIMUM_VERSION}")
-  endif()
-  message(STATUS "ICU_INCLUDE_DIR: ${ICU_INCLUDE_DIR}")
   target_include_directories(CoreFoundation
                              PRIVATE
                                ${ICU_INCLUDE_DIR})


### PR DESCRIPTION
This reverts commit 021533bcc19e49cb7f373ed096caa1adfd03b862.
It broke lldb PR testing, as the version of `ubuntu` on the builders is 55.
It looks like I have an `icu` directory in my checkout, so I think the build might have moved to build its own version of `libicu` (although I'm not confident about this).

cc ing: @spevans 