### PR TITLE
build: default to hidden visibility

### DIFF
--- a/CoreFoundation/Base.subproj/CFBase.h
+++ b/CoreFoundation/Base.subproj/CFBase.h
@@ -142,6 +142,18 @@
     #else
         #define CF_EXPORT _CF_EXTERN
     #endif
+#elif TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_ANDROID
+
+#if 0
+#if defined(CoreFoundation_EXPORTS)
+#define CF_EXPORT extern __attribute__((__visibility__("default")))
+#else
+#define CF_EXPORT extern
+#endif
+#else
+#define CF_EXPORT extern __attribute__((__visibility__("default")))
+#endif
+
 #else
 #define CF_EXPORT extern
 #endif

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -12,14 +12,8 @@ project(CoreFoundation
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED YES)
 
-# TODO(compnerd): this should be re-enabled once CoreFoundation annotations have
-# been reconciled.  Hidden visibility should ensure that internal interfaces are
-# not accidentally exposed on platforms without exports lists and explicit
-# annotations (i.e. ELFish and MachO targets).
-if(0)
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_C_VISIBILITY_INLINES_HIDDEN ON)
-endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE YES)
 


### PR DESCRIPTION
This will ensure that the internal implementation details of
CoreFoundation do not leak out from the generated library.