### PR TITLE
Foundation: add SPI for XCTest

### DIFF
--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -165,6 +165,15 @@ open class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
 }
 
+// SPI for XCTest
+#if os(Windows)
+extension NSDate {
+  public static func _currentAbsoluteTime() -> TimeInterval {
+    return CFAbsoluteTimeGetCurrent()
+  }
+}
+#endif
+
 extension NSDate {
     
     open func timeIntervalSince(_ anotherDate: Date) -> TimeInterval {

--- a/Foundation/RunLoop.swift
+++ b/Foundation/RunLoop.swift
@@ -158,3 +158,13 @@ extension RunLoop {
         perform(inModes: [.default], block: block)
     }
 }
+
+// SPI for XCTest
+#if os(Windows)
+extension RunLoop {
+  public func _stop() {
+    CFRunLoopStop(getCFRunLoop())
+  }
+}
+#endif
+


### PR DESCRIPTION
Foundation does not re-expose CoreFoundation interfaces on Windows.
This is desirable on Linux as well, however, in the interest of not
breaking existing applications, we have not yet done this.  For now
interfaces required are only available on Windows.