### PR TITLE
[5.0] Implement DateIntervalFormatter.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,7 @@ if(ENABLE_TESTING)
                          TestFoundation/TestCodable.swift
                          TestFoundation/TestDateComponents.swift
                          TestFoundation/TestDateFormatter.swift
+                         TestFoundation/TestDateIntervalFormatter.swift
                          TestFoundation/TestDate.swift
                          TestFoundation/TestDecimal.swift
                          TestFoundation/TestEnergyFormatter.swift

--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -213,6 +213,7 @@ static CFRuntimeClass const * __CFRuntimeClassTable[__CFRuntimeClassTableSize] _
     [_kCFRuntimeIDCFDateFormatter] = &__CFDateFormatterClass,
     [_kCFRuntimeIDCFNumberFormatter] = &__CFNumberFormatterClass,
     [_kCFRuntimeIDCFCalendar] = &__CFCalendarClass,
+    [_kCFRuntimeIDCFDateIntervalFormatter] = &__CFDateIntervalFormatterClass,
     [_kCFRuntimeIDCFDate] = &__CFDateClass,
     [_kCFRuntimeIDCFTimeZone] = &__CFTimeZoneClass,
     [_kCFRuntimeIDCFKeyedArchiverUID] = &__CFKeyedArchiverUIDClass,

--- a/CoreFoundation/Base.subproj/CFRuntime_Internal.h
+++ b/CoreFoundation/Base.subproj/CFRuntime_Internal.h
@@ -76,6 +76,7 @@ enum {
     _kCFRuntimeIDCFSocket = 61,
     _kCFRuntimeIDCFAttributedString = 62,
     _kCFRuntimeIDCFRunArray = 63,
+    _kCFRuntimeIDCFDateIntervalFormatter = 64,
     // If you are adding a new value, it goes below this line.
     
     // Stuff not in CF goes here. This value should be one more than the last one above.
@@ -124,7 +125,6 @@ CF_PRIVATE const CFRuntimeClass __CFPreferencesDomainClass;
 
 CF_PRIVATE const CFRuntimeClass __CFMachPortClass;
 
-
 #if (TARGET_OS_MAC || TARGET_OS_WIN32 || DEPLOYMENT_RUNTIME_SWIFT)
 CF_PRIVATE const CFRuntimeClass __CFMessagePortClass;
 #endif
@@ -143,6 +143,7 @@ CF_PRIVATE const CFRuntimeClass __CFWindowsNamedPipeClass;
 #endif
 CF_PRIVATE const CFRuntimeClass __CFTimeZoneClass;
 CF_PRIVATE const CFRuntimeClass __CFCalendarClass;
+CF_PRIVATE const CFRuntimeClass __CFDateIntervalFormatterClass;
 
 #pragma mark - Private initialiers to run at process start time
 

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -24,6 +24,7 @@
 #include <CoreFoundation/CFRegularExpression.h>
 #include <CoreFoundation/CFLogUtilities.h>
 #include <CoreFoundation/CFURLSessionInterface.h>
+#include <CoreFoundation/CFDateIntervalFormatter.h>
 #include <CoreFoundation/ForFoundationOnly.h>
 #if DEPLOYMENT_TARGET_WINDOWS
 #define NOMINMAX

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -78,6 +78,7 @@ add_framework(CoreFoundation
                 Locale.subproj/CFCalendar_Internal.h
                 Locale.subproj/CFDateComponents.h
                 Locale.subproj/CFDateFormatter_Private.h
+                Locale.subproj/CFDateIntervalFormatter.h
                 Locale.subproj/CFDateInterval.h
                 Locale.subproj/CFICULogging.h
                 Locale.subproj/CFLocaleInternal.h
@@ -144,6 +145,7 @@ add_framework(CoreFoundation
                 StringEncodings.subproj/CFStringEncodingConverterExt.h
                 URL.subproj/CFURLPriv.h
                 URL.subproj/CFURLSessionInterface.h
+                Locale.subproj/CFDateIntervalFormatter.h
 
                 # AppServices
                 AppServices.subproj/CFNotificationCenter.h
@@ -232,6 +234,7 @@ add_framework(CoreFoundation
                 Locale.subproj/CFCalendar_Enumerate.c
                 Locale.subproj/CFDateComponents.c
                 Locale.subproj/CFDateFormatter.c
+                Locale.subproj/CFDateIntervalFormatter.c
                 Locale.subproj/CFDateInterval.c
                 Locale.subproj/CFLocale.c
                 Locale.subproj/CFLocaleIdentifier.c

--- a/CoreFoundation/Locale.subproj/CFDateIntervalFormatter.c
+++ b/CoreFoundation/Locale.subproj/CFDateIntervalFormatter.c
@@ -1,0 +1,464 @@
+/*	CFDateIntervalFormatter.c
+	Copyright (c) 1998-2018, Apple Inc. and the Swift project authors
+ 
+	Portions Copyright (c) 2019, Apple Inc. and the Swift project authors
+	Licensed under Apache License v2.0 with Runtime Library Exception
+	See http://swift.org/LICENSE.txt for license information
+	See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+*/
+
+#include <CoreFoundation/CFDateIntervalFormatter.h>
+#include <CoreFoundation/CFRuntime.h>
+#include "CFInternal.h"
+#include "CFRuntime_Internal.h"
+
+#include <CoreFoundation/CFCalendar.h>
+#include <CoreFoundation/CFDate.h>
+#include <CoreFoundation/CFDateFormatter.h>
+#include <CoreFoundation/CFDateInterval.h>
+#include <CoreFoundation/CFLocale.h>
+#include <CoreFoundation/CFTimeZone.h>
+
+#include <unicode/udateintervalformat.h>
+
+#include <dispatch/dispatch.h>
+
+#define LOCK() do { dispatch_semaphore_wait(formatter->_lock, DISPATCH_TIME_FOREVER); } while(0)
+#define UNLOCK() do { dispatch_semaphore_signal(formatter->_lock); } while(0)
+
+CF_INLINE void __CFReleaseIfNotNull(CFTypeRef object) {
+    if (object) {
+        CFRelease(object);
+    }
+}
+
+struct __CFDateIntervalFormatter {
+    CFRuntimeBase _base;
+    CFLocaleRef _locale;
+    CFCalendarRef _calendar;
+    CFTimeZoneRef _timeZone;
+    CFStringRef _dateTemplateFromStyles;
+    CFStringRef _dateTemplate;
+    void *_formatter;
+    CFDateIntervalFormatterStyle _dateStyle;
+    CFDateIntervalFormatterStyle _timeStyle;
+    _CFDateIntervalFormatterBoundaryStyle _boundaryStyle;
+    dispatch_semaphore_t _lock;
+    bool _modified:1;
+    bool _useTemplate:1;
+};
+
+static void __CFDateIntervalFormatterDeallocate(CFTypeRef object);
+const CFRuntimeClass __CFDateIntervalFormatterClass = {
+    0,
+    "CFDateIntervalFormatter",
+    NULL,    // init
+    NULL,    // copy
+    &__CFDateIntervalFormatterDeallocate,    // dealloc
+    NULL,    // equals
+    NULL,    // hash
+    NULL,    // copyFormattingDescription
+    NULL,    // copyDescription
+};
+
+static CFStringRef createLocaleIDFromLocaleAndCalendar(CFLocaleRef locale, CFCalendarRef calendar) {
+    CFMutableDictionaryRef dict;
+    
+    {
+        CFDictionaryRef immutableDict = CFLocaleCreateComponentsFromLocaleIdentifier(kCFAllocatorSystemDefault, CFLocaleGetIdentifier(locale));
+        dict = CFDictionaryCreateMutableCopy(kCFAllocatorSystemDefault, 0, immutableDict);
+        CFRelease(immutableDict);
+    }
+    
+    if (calendar) {
+        CFDictionarySetValue(dict, kCFLocaleCalendar, calendar);
+    }
+    CFStringRef localeID = CFLocaleCreateLocaleIdentifierFromComponents(kCFAllocatorSystemDefault, dict);
+    CFRelease(dict);
+    
+    return localeID;
+}
+
+static void updateDateTemplate(CFDateIntervalFormatterRef dif, CFDateIntervalFormatterStyle dateStyle, CFDateIntervalFormatterStyle timeStyle);
+static void updateDateTemplateFromCurrentSettings(CFDateIntervalFormatterRef dif) {
+    updateDateTemplate(dif, dif->_dateStyle, dif->_timeStyle);
+}
+
+static void updateDateTemplate(CFDateIntervalFormatterRef dif, CFDateIntervalFormatterStyle dateStyle, CFDateIntervalFormatterStyle timeStyle) {
+    CFDateFormatterRef formatter;
+    {
+        CFLocaleRef locale = dif->_locale ? CFRetain(dif->_locale) : CFLocaleCopyCurrent();
+        CFCalendarRef unretainedCalendar = dif->_calendar ?: (CFCalendarRef)CFLocaleGetValue(locale, kCFLocaleCalendar);
+        formatter = CFDateFormatterCreate(kCFAllocatorSystemDefault, locale, (CFDateFormatterStyle)dateStyle, (CFDateFormatterStyle)timeStyle);
+        CFDateFormatterSetProperty(formatter, kCFDateFormatterCalendar, unretainedCalendar);
+        CFRelease(locale);
+    }
+    
+    CFStringRef template = CFDateFormatterGetFormat(formatter);
+    __CFReleaseIfNotNull(dif->_dateTemplateFromStyles);
+    dif->_dateTemplateFromStyles = CFStringCreateCopy(kCFAllocatorSystemDefault, template);
+    CFRelease(formatter);
+}
+
+static void updateFormatter(CFDateIntervalFormatterRef dif) {
+    if (dif->_modified && dif->_formatter != NULL) {
+        udtitvfmt_close(dif->_formatter);
+        dif->_formatter = NULL;
+        dif->_modified = false;
+    }
+    
+    if (dif->_formatter == NULL) {
+        CFLocaleRef locale = dif->_locale;
+        if (locale) {
+            CFRetain(locale);
+        } else {
+            locale = CFLocaleCopyCurrent();
+        }
+        
+        CFCalendarRef unretainedCalendar = dif->_calendar;
+        if (unretainedCalendar == NULL) {
+            unretainedCalendar = (CFCalendarRef)CFLocaleGetValue(locale, kCFDateFormatterCalendar);
+        }
+        
+        CFStringRef localeID = createLocaleIDFromLocaleAndCalendar(locale, unretainedCalendar);
+        
+        char localeBuffer[100] = {0};
+        CFStringGetCString(localeID, localeBuffer, 100, kCFStringEncodingUTF8);
+        
+        UniChar timeZoneID[100] = {0};
+        CFTimeZoneRef timeZone = dif->_timeZone;
+        if (timeZone) {
+            CFRetain(timeZone);
+        } else {
+            timeZone = CFTimeZoneCopyDefault();
+        }
+        CFStringRef unretainedTimeZoneName = CFTimeZoneGetName(timeZone);
+        CFStringGetCharacters(unretainedTimeZoneName, CFRangeMake(0, MIN(CFStringGetLength(unretainedTimeZoneName), 100)), timeZoneID);
+        
+        CFStringRef unretainedTemplate = dif->_dateTemplateFromStyles;
+        if (dif->_useTemplate) {
+            unretainedTemplate = dif->_dateTemplate;
+        }
+        UniChar templateStr[100] = {0};
+        CFStringGetCharacters(unretainedTemplate, CFRangeMake(0, MIN(CFStringGetLength(unretainedTemplate), 100)), templateStr);
+        
+        UErrorCode status = U_ZERO_ERROR;
+        dif->_formatter = udtitvfmt_open(localeBuffer, templateStr, CFStringGetLength(unretainedTemplate), timeZoneID, CFStringGetLength(unretainedTimeZoneName), &status);
+        if (U_FAILURE(status)) {
+            CFLog(kCFLogLevelError, CFSTR("udtitvfmt_open failed!  Tried to set template: %@ for locale %s and timezone %@ and got status code: %s"), unretainedTemplate, localeBuffer, unretainedTimeZoneName, u_errorName(status));
+        }
+        if (!(dif->_formatter)) {
+            CFLog(kCFLogLevelError, CFSTR("udtitvfmt_open failed!  Formatter is NULL! -- locale: %s, template: %@, timezone: %@, status: %s"), localeBuffer, unretainedTemplate, unretainedTimeZoneName, u_errorName(status));
+        }
+        
+#if TARGET_OS_MAC
+        UDateIntervalFormatAttributeValue uDateIntervalMinimizationStyle = UDTITVFMT_MINIMIZE_NONE;
+        const _CFDateIntervalFormatterBoundaryStyle type = dif->_boundaryStyle;
+        switch (type) {
+            case kCFDateIntervalFormatterBoundaryStyleMinimizeAdjacentMonths:
+                uDateIntervalMinimizationStyle = UDTITVFMT_MINIMIZE_ADJACENT_MONTHS;
+                
+            default:
+                break;
+        }
+        
+        if (dif->_formatter) {
+            udtitvfmt_setAttribute(dif->_formatter, UDTITVFMT_MINIMIZE_TYPE, uDateIntervalMinimizationStyle, &status);
+            if (U_FAILURE(status)) {
+                CFLog(kCFLogLevelError, CFSTR("udtitvfmt_setAttribute failed!  Tried to set minimize type: %d and got status code: %s"), (int)dif->_boundaryStyle, u_errorName(status));
+            }
+        }
+#endif
+        
+        CFRelease(locale);
+        CFRelease(timeZone);
+    }
+}
+
+CFDateIntervalFormatterRef CFDateIntervalFormatterCreate(CFAllocatorRef allocator, CFLocaleRef locale, CFDateIntervalFormatterStyle dateStyle, CFDateIntervalFormatterStyle timeStyle) {
+    struct __CFDateIntervalFormatter *memory;
+    uint32_t size = sizeof(struct __CFDateIntervalFormatter) - sizeof(CFRuntimeBase);
+    if (!allocator) {
+        allocator = __CFGetDefaultAllocator();
+    }
+    __CFGenericValidateType(allocator, CFAllocatorGetTypeID());
+    memory = (struct __CFDateIntervalFormatter *)_CFRuntimeCreateInstance(allocator, _kCFRuntimeIDCFDateIntervalFormatter, size, NULL);
+    if (!memory) {
+        return NULL;
+    }
+    
+    switch (dateStyle) {
+        case kCFDateIntervalFormatterNoStyle:
+        case kCFDateIntervalFormatterShortStyle:
+        case kCFDateIntervalFormatterMediumStyle:
+        case kCFDateIntervalFormatterLongStyle:
+        case kCFDateIntervalFormatterFullStyle: break;
+        default:
+            CFAssert2(0, __kCFLogAssertion, "%s(): unknown date style %ld", __PRETTY_FUNCTION__, dateStyle);
+            memory->_dateStyle = kCFDateIntervalFormatterMediumStyle;
+            break;
+    }
+    switch (timeStyle) {
+        case kCFDateIntervalFormatterNoStyle:
+        case kCFDateIntervalFormatterShortStyle:
+        case kCFDateIntervalFormatterMediumStyle:
+        case kCFDateIntervalFormatterLongStyle:
+        case kCFDateIntervalFormatterFullStyle: break;
+        default:
+            CFAssert2(0, __kCFLogAssertion, "%s(): unknown time style %ld", __PRETTY_FUNCTION__, dateStyle);
+            memory->_timeStyle = kCFDateIntervalFormatterMediumStyle;
+            break;
+    }
+    
+    memory->_locale = locale ? CFRetain(locale) : NULL;
+    
+    memory->_calendar = NULL;
+    memory->_timeZone = NULL;
+    memory->_dateTemplateFromStyles = NULL;
+    memory->_dateTemplate = CFRetain(CFSTR(""));
+    memory->_formatter = NULL;
+    memory->_boundaryStyle = kCFDateIntervalFormatterBoundaryStyleDefault;
+    memory->_lock = dispatch_semaphore_create(1);
+    memory->_modified = false;
+    memory->_useTemplate = false;
+    
+    return (CFDateIntervalFormatterRef)memory;
+}
+
+CFDateIntervalFormatterRef CFDateIntervalFormatterCreateCopy(CFAllocatorRef _Nullable allocator, CFDateIntervalFormatterRef formatter) {
+    LOCK();
+    CFDateIntervalFormatterRef newFormatter = CFDateIntervalFormatterCreate(allocator, formatter->_locale, formatter->_dateStyle, formatter->_timeStyle);
+    
+    if (formatter->_calendar) {
+        newFormatter->_calendar = _CFCalendarCreateCopy(allocator, formatter->_calendar);
+    }
+    if (formatter->_timeZone) {
+        newFormatter->_timeZone = CFRetain(formatter->_timeZone);
+    }
+    if (formatter->_dateTemplateFromStyles) {
+        newFormatter->_dateTemplateFromStyles = CFStringCreateCopy(allocator, formatter->_dateTemplateFromStyles);
+    }
+    if (formatter->_dateTemplate) {
+        newFormatter->_dateTemplate = CFStringCreateCopy(allocator, formatter->_dateTemplate);
+    }
+    
+    newFormatter->_dateStyle = formatter->_dateStyle;
+    newFormatter->_timeStyle = formatter->_timeStyle;
+    newFormatter->_modified = formatter->_modified;
+    newFormatter->_useTemplate = formatter->_useTemplate;
+    UNLOCK();
+    
+    return newFormatter;
+}
+
+static void __CFDateIntervalFormatterDeallocate(CFTypeRef object) {
+    CFDateIntervalFormatterRef formatter = (CFDateIntervalFormatterRef)object;
+    
+    __CFReleaseIfNotNull(formatter->_locale);
+    __CFReleaseIfNotNull(formatter->_calendar);
+    __CFReleaseIfNotNull(formatter->_timeZone);
+    __CFReleaseIfNotNull(formatter->_dateTemplateFromStyles);
+    __CFReleaseIfNotNull(formatter->_dateTemplate);
+    
+    if (formatter->_formatter) {
+        udtitvfmt_close(formatter->_formatter);
+    }
+    
+    dispatch_release(formatter->_lock);
+}
+
+CFLocaleRef CFDateIntervalFormatterCopyLocale(CFDateIntervalFormatterRef formatter) {
+    LOCK();
+    CFLocaleRef locale = formatter->_locale;
+    if (locale) {
+        CFRetain(locale);
+    }
+    UNLOCK();
+    
+    if (!locale) {
+        locale = CFLocaleCopyCurrent();
+    }
+    return locale;
+}
+
+void CFDateIntervalFormatterSetLocale(CFDateIntervalFormatterRef formatter, CFLocaleRef locale) {
+    LOCK();
+    if (locale != formatter->_locale) {
+        __CFReleaseIfNotNull(formatter->_locale);
+        formatter->_locale = locale ? CFLocaleCreateCopy(kCFAllocatorSystemDefault, locale) : NULL;
+        formatter->_modified = true;
+        updateDateTemplateFromCurrentSettings(formatter);
+    }
+    UNLOCK();
+}
+
+CFCalendarRef CFDateIntervalFormatterCopyCalendar(CFDateIntervalFormatterRef formatter) {
+    LOCK();
+    CFCalendarRef calendar = formatter->_calendar;
+    if (!calendar) {
+        if (formatter->_locale) {
+            calendar = (CFCalendarRef)CFLocaleGetValue(formatter->_locale, kCFLocaleCalendar);
+            CFRetain(calendar);
+        } else {
+            calendar = CFCalendarCopyCurrent();
+        }
+    }
+    UNLOCK();
+    return calendar;
+}
+
+void CFDateIntervalFormatterSetCalendar(CFDateIntervalFormatterRef formatter, CFCalendarRef calendar) {
+    LOCK();
+    if (calendar != formatter->_calendar) {
+        __CFReleaseIfNotNull(formatter->_calendar);
+        formatter->_calendar = calendar ? _CFCalendarCreateCopy(kCFAllocatorSystemDefault, calendar) : NULL;
+        formatter->_modified = true;
+        updateDateTemplateFromCurrentSettings(formatter);
+    }
+    UNLOCK();
+}
+
+CFTimeZoneRef CFDateIntervalFormatterCopyTimeZone(CFDateIntervalFormatterRef formatter) {
+    LOCK();
+    CFTimeZoneRef timeZone = formatter->_timeZone;
+    if (timeZone) {
+        CFRetain(timeZone);
+    }
+    UNLOCK();
+    
+    if (!timeZone) {
+        timeZone = CFTimeZoneCopyDefault();
+    }
+    return timeZone;
+}
+
+void CFDateIntervalFormatterSetTimeZone(CFDateIntervalFormatterRef formatter, CFTimeZoneRef timeZone) {
+    LOCK();
+    if (timeZone != formatter->_timeZone) {
+        __CFReleaseIfNotNull(formatter->_timeZone);
+        formatter->_timeZone = timeZone ? CFRetain(timeZone) : NULL;
+        formatter->_modified = true;
+        updateDateTemplateFromCurrentSettings(formatter);
+    }
+    UNLOCK();
+}
+
+CFStringRef CFDateIntervalFormatterCopyDateTemplate(CFDateIntervalFormatterRef formatter) {
+    LOCK();
+    CFStringRef dateTemplate = formatter->_dateTemplate;
+    if (dateTemplate) {
+        CFRetain(dateTemplate);
+    } else {
+        dateTemplate = formatter->_dateTemplateFromStyles;
+        if (dateTemplate) {
+            CFRetain(dateTemplate);
+        }
+    }
+    UNLOCK();
+    
+    return dateTemplate;
+}
+
+void CFDateIntervalFormatterSetDateTemplate(CFDateIntervalFormatterRef formatter, CFStringRef dateTemplate) {
+    if (!dateTemplate) {
+        dateTemplate = CFSTR("");
+    }
+    
+    LOCK();
+    if (!CFEqual(dateTemplate, formatter->_dateTemplate)) {
+        __CFReleaseIfNotNull(formatter->_dateTemplate);
+        formatter->_dateTemplate = CFStringCreateCopy(kCFAllocatorSystemDefault, dateTemplate);
+        formatter->_modified = true;
+        formatter->_useTemplate = true;
+    }
+    UNLOCK();
+}
+
+CFDateIntervalFormatterStyle CFDateIntervalFormatterGetDateStyle(CFDateIntervalFormatterRef formatter) {
+    LOCK();
+    CFDateIntervalFormatterStyle result = formatter->_dateStyle;
+    UNLOCK();
+    return result;
+}
+
+void CFDateIntervalFormatterSetDateStyle(CFDateIntervalFormatterRef formatter, CFDateIntervalFormatterStyle dateStyle) {
+    LOCK();
+    formatter->_dateStyle = dateStyle;
+    formatter->_modified = true;
+    formatter->_useTemplate = false;
+    updateDateTemplateFromCurrentSettings(formatter);
+    UNLOCK();
+}
+
+CFDateIntervalFormatterStyle CFDateIntervalFormatterGetTimeStyle(CFDateIntervalFormatterRef formatter) {
+    LOCK();
+    CFDateIntervalFormatterStyle result = formatter->_timeStyle;
+    UNLOCK();
+    return result;
+}
+
+void CFDateIntervalFormatterSetTimeStyle(CFDateIntervalFormatterRef formatter, CFDateIntervalFormatterStyle timeStyle) {
+    LOCK();
+    formatter->_timeStyle = timeStyle;
+    formatter->_modified = true;
+    formatter->_useTemplate = false;
+    updateDateTemplateFromCurrentSettings(formatter);
+    UNLOCK();
+}
+
+_CFDateIntervalFormatterBoundaryStyle _CFDateIntervalFormatterGetBoundaryStyle(CFDateIntervalFormatterRef formatter) {
+    LOCK();
+    CFDateIntervalFormatterStyle result = formatter->_boundaryStyle;
+    UNLOCK();
+    return result;
+}
+
+void _CFDateIntervalFormatterSetBoundaryStyle(CFDateIntervalFormatterRef formatter, _CFDateIntervalFormatterBoundaryStyle boundaryStyle) {
+    LOCK();
+    formatter->_boundaryStyle = boundaryStyle;
+    formatter->_modified = true;
+    UNLOCK();
+}
+
+CFStringRef CFDateIntervalFormatterCreateStringFromDateToDate(CFDateIntervalFormatterRef formatter, CFDateRef fromDate, CFDateRef toDate) {
+    LOCK();
+    
+    CFStringRef resultStr = CFSTR("");
+    updateFormatter(formatter);
+    
+    if (formatter->_formatter) {
+        UDate fromUDate = (CFDateGetAbsoluteTime(fromDate) + kCFAbsoluteTimeIntervalSince1970) * 1000.0;
+        UDate toUDate = (CFDateGetAbsoluteTime(toDate) + kCFAbsoluteTimeIntervalSince1970) * 1000.0;
+        
+#define BUFFER_LENGTH 1000
+        
+        UChar result[BUFFER_LENGTH];
+        memset(result, '\0', BUFFER_LENGTH * sizeof(UChar));
+        UErrorCode status = U_ZERO_ERROR;
+        int32_t len = udtitvfmt_format(formatter->_formatter, fromUDate, toUDate, result, BUFFER_LENGTH, 0, &status);
+        
+        if (len > BUFFER_LENGTH) {
+            UChar *resultp = (UChar *)calloc(len, sizeof(UChar));
+            status = U_ZERO_ERROR;
+            len = udtitvfmt_format(formatter->_formatter, fromUDate, toUDate, resultp, len, 0, &status);
+            resultStr = CFStringCreateWithCharacters(kCFAllocatorSystemDefault, resultp, len);
+            free(resultp);
+        } else {
+            resultStr = CFStringCreateWithCharacters(kCFAllocatorSystemDefault, result, len);
+        }
+    } else {
+        resultStr = CFSTR("");
+    }
+    UNLOCK();
+    
+    return resultStr;
+}
+
+CFStringRef CFDateIntervalFormatterCreateStringFromDateInterval(CFDateIntervalFormatterRef formatter, CFDateIntervalRef interval) {
+    CFDateRef start = CFDateIntervalCopyStartDate(interval);
+    CFDateRef end = CFDateIntervalCopyEndDate(interval);
+    CFStringRef result = CFDateIntervalFormatterCreateStringFromDateToDate(formatter, start, end);
+    CFRelease(start);
+    CFRelease(end);
+    return result;
+}

--- a/CoreFoundation/Locale.subproj/CFDateIntervalFormatter.h
+++ b/CoreFoundation/Locale.subproj/CFDateIntervalFormatter.h
@@ -1,0 +1,74 @@
+/*	CFDateIntervalFormatter.h
+	Copyright (c) 1998-2018, Apple Inc. and the Swift project authors
+ 
+	Portions Copyright (c) 2019, Apple Inc. and the Swift project authors
+	Licensed under Apache License v2.0 with Runtime Library Exception
+	See http://swift.org/LICENSE.txt for license information
+	See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+*/
+
+#if !defined(__COREFOUNDATION_CFDATEINTERVALFORMATTER__)
+#define __COREFOUNDATION_CFDATEINTERVALFORMATTER__ 1
+
+#include <CoreFoundation/CFBase.h>
+#include <CoreFoundation/CFCalendar.h>
+#include <CoreFoundation/CFDateInterval.h>
+#include <CoreFoundation/CFLocale.h>
+#include <CoreFoundation/CFString.h>
+#include <CoreFoundation/CFTimeZone.h>
+
+CF_ASSUME_NONNULL_BEGIN
+CF_IMPLICIT_BRIDGING_ENABLED
+CF_EXTERN_C_BEGIN
+
+typedef struct CF_BRIDGED_TYPE(id) __CFDateIntervalFormatter * CFDateIntervalFormatterRef;
+
+typedef CF_ENUM(CFIndex, CFDateIntervalFormatterStyle) {
+    kCFDateIntervalFormatterNoStyle = 0,
+    kCFDateIntervalFormatterShortStyle = 1,
+    kCFDateIntervalFormatterMediumStyle = 2,
+    kCFDateIntervalFormatterLongStyle = 3,
+    kCFDateIntervalFormatterFullStyle = 4,
+};
+
+typedef CF_ENUM(CFIndex, _CFDateIntervalFormatterBoundaryStyle) {
+    kCFDateIntervalFormatterBoundaryStyleDefault = 0,
+#if TARGET_OS_MAC
+    kCFDateIntervalFormatterBoundaryStyleMinimizeAdjacentMonths = 1,
+#endif
+};
+
+CF_EXPORT CFDateIntervalFormatterRef CFDateIntervalFormatterCreate(CFAllocatorRef _Nullable allocator, CFLocaleRef _Nullable locale, CFDateIntervalFormatterStyle dateStyle, CFDateIntervalFormatterStyle timeStyle);
+CF_EXPORT CFDateIntervalFormatterRef CFDateIntervalFormatterCreateCopy(CFAllocatorRef _Nullable allocator, CFDateIntervalFormatterRef formatter);
+
+CF_EXPORT CFLocaleRef CFDateIntervalFormatterCopyLocale(CFDateIntervalFormatterRef formatter);
+CF_EXPORT void CFDateIntervalFormatterSetLocale(CFDateIntervalFormatterRef formatter, CFLocaleRef _Nullable locale);
+
+CF_EXPORT CFCalendarRef CFDateIntervalFormatterCopyCalendar(CFDateIntervalFormatterRef formatter);
+CF_EXPORT void CFDateIntervalFormatterSetCalendar(CFDateIntervalFormatterRef formatter, CFCalendarRef _Nullable calendar);
+
+CF_EXPORT CFTimeZoneRef CFDateIntervalFormatterCopyTimeZone(CFDateIntervalFormatterRef formatter);
+CF_EXPORT void CFDateIntervalFormatterSetTimeZone(CFDateIntervalFormatterRef formatter, CFTimeZoneRef _Nullable timeZone);
+
+CF_EXPORT CFStringRef CFDateIntervalFormatterCopyDateTemplate(CFDateIntervalFormatterRef formatter);
+CF_EXPORT void CFDateIntervalFormatterSetDateTemplate(CFDateIntervalFormatterRef formatter, CFStringRef _Nullable dateTemplate);
+
+CF_EXPORT CFDateIntervalFormatterStyle CFDateIntervalFormatterGetDateStyle(CFDateIntervalFormatterRef formatter);
+CF_EXPORT void CFDateIntervalFormatterSetDateStyle(CFDateIntervalFormatterRef formatter, CFDateIntervalFormatterStyle dateStyle);
+
+CF_EXPORT CFDateIntervalFormatterStyle CFDateIntervalFormatterGetTimeStyle(CFDateIntervalFormatterRef formatter);
+CF_EXPORT void CFDateIntervalFormatterSetTimeStyle(CFDateIntervalFormatterRef formatter, CFDateIntervalFormatterStyle timeStyle);
+
+CF_EXPORT CFStringRef CFDateIntervalFormatterCreateStringFromDateToDate(CFDateIntervalFormatterRef formatter, CFDateRef fromDate, CFDateRef toDate);
+CF_EXPORT CFStringRef CFDateIntervalFormatterCreateStringFromDateInterval(CFDateIntervalFormatterRef formatter, CFDateIntervalRef interval);
+
+// SPI:
+CF_EXPORT _CFDateIntervalFormatterBoundaryStyle _CFDateIntervalFormatterGetBoundaryStyle(CFDateIntervalFormatterRef formatter);
+CF_EXPORT void _CFDateIntervalFormatterSetBoundaryStyle(CFDateIntervalFormatterRef formatter, _CFDateIntervalFormatterBoundaryStyle boundaryStyle);
+
+CF_EXTERN_C_END
+CF_IMPLICIT_BRIDGING_DISABLED
+CF_ASSUME_NONNULL_END
+
+#endif /* !defined(__COREFOUNDATION_CFDATEINTERVALFORMATTER__) */
+

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		1578DA11212B407B003C9516 /* CFString_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1578DA10212B407B003C9516 /* CFString_Internal.h */; };
 		1578DA13212B4C35003C9516 /* CFOverflow.h in Headers */ = {isa = PBXBuildFile; fileRef = 1578DA12212B4C35003C9516 /* CFOverflow.h */; };
 		1578DA15212B6F33003C9516 /* CFCollections_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1578DA14212B6F33003C9516 /* CFCollections_Internal.h */; };
+		158BCCAA2220A12600750239 /* TestDateIntervalFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158BCCA92220A12600750239 /* TestDateIntervalFormatter.swift */; };
+		158BCCAD2220A18F00750239 /* CFDateIntervalFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 158BCCAB2220A18F00750239 /* CFDateIntervalFormatter.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		158BCCAE2220A18F00750239 /* CFDateIntervalFormatter.c in Sources */ = {isa = PBXBuildFile; fileRef = 158BCCAC2220A18F00750239 /* CFDateIntervalFormatter.c */; };
 		159884921DCC877700E3314C /* TestHTTPCookieStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159884911DCC877700E3314C /* TestHTTPCookieStorage.swift */; };
 		15F10CDC218909BF00D88114 /* TestNSCalendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F10CDB218909BF00D88114 /* TestNSCalendar.swift */; };
 		231503DB1D8AEE5D0061694D /* TestDecimal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231503DA1D8AEE5D0061694D /* TestDecimal.swift */; };
@@ -560,6 +563,9 @@
 		1578DA10212B407B003C9516 /* CFString_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFString_Internal.h; sourceTree = "<group>"; };
 		1578DA12212B4C35003C9516 /* CFOverflow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFOverflow.h; sourceTree = "<group>"; };
 		1578DA14212B6F33003C9516 /* CFCollections_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFCollections_Internal.h; sourceTree = "<group>"; };
+		158BCCA92220A12600750239 /* TestDateIntervalFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDateIntervalFormatter.swift; sourceTree = "<group>"; };
+		158BCCAB2220A18F00750239 /* CFDateIntervalFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFDateIntervalFormatter.h; sourceTree = "<group>"; };
+		158BCCAC2220A18F00750239 /* CFDateIntervalFormatter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFDateIntervalFormatter.c; sourceTree = "<group>"; };
 		159884911DCC877700E3314C /* TestHTTPCookieStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHTTPCookieStorage.swift; sourceTree = "<group>"; };
 		15F10CDB218909BF00D88114 /* TestNSCalendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNSCalendar.swift; sourceTree = "<group>"; };
 		22B9C1E01C165D7A00DECFF9 /* TestDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDate.swift; sourceTree = "<group>"; };
@@ -1284,6 +1290,8 @@
 				1569BFAC2187D529009518FA /* CFDateComponents.h */,
 				5B5D890B1BBC9BEF00234F36 /* CFDateFormatter.c */,
 				5B5D89091BBC9BEF00234F36 /* CFDateFormatter.h */,
+				158BCCAC2220A18F00750239 /* CFDateIntervalFormatter.c */,
+				158BCCAB2220A18F00750239 /* CFDateIntervalFormatter.h */,
 				5B6E11A81DA45EB5009B48A3 /* CFDateFormatter_Private.h */,
 				5B5D88AC1BBC974700234F36 /* CFLocale.c */,
 				5B5D88AB1BBC974700234F36 /* CFLocale.h */,
@@ -1562,6 +1570,7 @@
 				6E203B8C1C1303BB003B2576 /* TestBundle.swift */,
 				A5A34B551C18C85D00FD972B /* TestByteCountFormatter.swift */,
 				2EBE67A31C77BF05006583D5 /* TestDateFormatter.swift */,
+				158BCCA92220A12600750239 /* TestDateIntervalFormatter.swift */,
 				BDBB658F1E256BFA001A7286 /* TestEnergyFormatter.swift */,
 				D512D17B1CD883F00032E6A5 /* TestFileHandle.swift */,
 				525AECEB1BF2C96400D15BB0 /* TestFileManager.swift */,
@@ -1998,6 +2007,7 @@
 				5B7C8ABF1BEA807A00C5B690 /* CFUtilities.h in Headers */,
 				5B7C8ADD1BEA80FC00C5B690 /* CFStream.h in Headers */,
 				5B40F9F01C125011000E72E3 /* CFXMLInterface.h in Headers */,
+				158BCCAD2220A18F00750239 /* CFDateIntervalFormatter.h in Headers */,
 				5B7C8AD71BEA80FC00C5B690 /* CFPlugInCOM.h in Headers */,
 				5B7C8AFA1BEA81AC00C5B690 /* CFUniChar.h in Headers */,
 				5B7C8AC91BEA80FC00C5B690 /* CFTree.h in Headers */,
@@ -2486,6 +2496,7 @@
 				1578DA0E212B4070003C9516 /* CFMachPort_Lifetime.c in Sources */,
 				5BF9B8001FABD5DA00EE1A7C /* CFBundle_Main.c in Sources */,
 				5B7C8AB51BEA801700C5B690 /* CFUniChar.c in Sources */,
+				158BCCAE2220A18F00750239 /* CFDateIntervalFormatter.c in Sources */,
 				61E011811C1B5998000037DD /* CFMessagePort.c in Sources */,
 				5B7C8AB61BEA801700C5B690 /* CFUnicodeDecomposition.c in Sources */,
 				5B7C8A881BEA7FDB00C5B690 /* CFLocaleIdentifier.c in Sources */,
@@ -2618,6 +2629,7 @@
 				5B13B3261C582D4C00651CE2 /* TestAffineTransform.swift in Sources */,
 				2EBE67A51C77BF0E006583D5 /* TestDateFormatter.swift in Sources */,
 				5B13B3291C582D4C00651CE2 /* TestCalendar.swift in Sources */,
+				158BCCAA2220A12600750239 /* TestDateIntervalFormatter.swift in Sources */,
 				5B13B34F1C582D4C00651CE2 /* TestXMLParser.swift in Sources */,
 				BF85E9D81FBDCC2000A79793 /* TestHost.swift in Sources */,
 				D5C40F331CDA1D460005690C /* TestOperationQueue.swift in Sources */,
@@ -2750,11 +2762,14 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT DEBUG";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FOUNDATION_XCTEST NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT DEBUG";
+				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
+				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2802,9 +2817,12 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
+				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
+				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/TestFoundation/TestDateIntervalFormatter.swift
+++ b/TestFoundation/TestDateIntervalFormatter.swift
@@ -1,0 +1,247 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+    #if (os(Linux) || os(Android))
+        @testable import Foundation
+    #else
+        @testable import SwiftFoundation
+    #endif
+#endif
+
+enum ContainsInOrderResult: Equatable {
+    case success
+    case missed(String)
+    case doesNotEndWithLastElement
+}
+
+extension String {
+    func containsInOrder(requiresLastToBeAtEnd: Bool = false, _ substrings: [String]) -> ContainsInOrderResult {
+        var foundRange: Range<String.Index> = startIndex ..< startIndex
+        for substring in substrings {
+            if let newRange = range(of: substring, options: [], range: foundRange.upperBound..<endIndex, locale: nil) {
+                foundRange = newRange
+            } else {
+                return .missed(substring)
+            }
+        }
+        
+        if requiresLastToBeAtEnd {
+            return foundRange.upperBound == endIndex ? .success : .doesNotEndWithLastElement
+        } else {
+            return .success
+        }
+    }
+    
+    func assertContainsInOrder(requiresLastToBeAtEnd: Bool = false, _ substrings: String...) {
+        let result = containsInOrder(requiresLastToBeAtEnd: requiresLastToBeAtEnd, substrings)
+        XCTAssert(result == .success, "String '\(self)' (must end with: \(requiresLastToBeAtEnd)) does not contain in sequence: \(substrings) — reason: \(result)")
+    }
+}
+
+class TestDateIntervalFormatter: XCTestCase {
+    private var formatter: DateIntervalFormatter!
+    
+    override func setUp() {
+        super.setUp()
+        
+        formatter = DateIntervalFormatter()
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateStyle = .long
+        formatter.timeStyle = .full
+    }
+    
+    override func tearDown() {
+        formatter = nil
+        
+        super.tearDown()
+    }
+    
+    func testStringFromDateToDateAcrossThreeBillionSeconds() {
+        let older = Date(timeIntervalSinceReferenceDate: 0)
+        let newer = Date(timeIntervalSinceReferenceDate: 3e9)
+        
+        let result = formatter.string(from: older, to: newer)
+        result.assertContainsInOrder("January 1",  "2001", "12:00:00 AM", "Greenwich Mean Time",
+                                     "January 25", "2096", "5:20:00 AM",  "Greenwich Mean Time")
+    }
+    
+    func testStringFromDateToDateAcrossThreeMillionSeconds() {
+        let older = Date(timeIntervalSinceReferenceDate: 0)
+        let newer = Date(timeIntervalSinceReferenceDate: 3e6)
+        
+        let result = formatter.string(from: older, to: newer)
+        result.assertContainsInOrder("January 1",  "2001", "12:00:00 AM", "Greenwich Mean Time",
+                                     "February 4", "2001", "5:20:00 PM",  "Greenwich Mean Time")
+    }
+    
+    func testStringFromDateToDateAcrossThreeBillionSecondsReversed() {
+        let older = Date(timeIntervalSinceReferenceDate: 0)
+        let newer = Date(timeIntervalSinceReferenceDate: 3e9)
+        
+        let result = formatter.string(from: newer, to: older)
+        result.assertContainsInOrder("January 25", "2096", "5:20:00 AM",  "Greenwich Mean Time",
+                                     "January 1",  "2001", "12:00:00 AM", "Greenwich Mean Time")
+    }
+    
+    func testStringFromDateToDateAcrossThreeMillionSecondsReversed() {
+        let older = Date(timeIntervalSinceReferenceDate: 0)
+        let newer = Date(timeIntervalSinceReferenceDate: 3e6)
+        
+        let result = formatter.string(from: newer, to: older)
+        result.assertContainsInOrder("February 4", "2001", "5:20:00 PM",  "Greenwich Mean Time",
+                                     "January 1",  "2001", "12:00:00 AM", "Greenwich Mean Time")
+    }
+    
+    func testStringFromDateToSameDate() throws {
+        let date = Date(timeIntervalSinceReferenceDate: 3e6)
+        
+        // For a range from a date to itself, we represent the date only once, with no interdate separator.
+        let result = formatter.string(from: date, to: date)
+        result.assertContainsInOrder(requiresLastToBeAtEnd: true, "February 4", "2001", "5:20:00 PM",  "Greenwich Mean Time")
+        
+        let firstFebruary = try result.range(of: "February").unwrapped()
+        XCTAssertNil(result[firstFebruary.upperBound...].range(of: "February")) // February appears only once.
+    }
+    
+    func testStringFromDateIntervalAcrossThreeMillionSeconds() throws {
+        let interval = DateInterval(start: Date(timeIntervalSinceReferenceDate: 0), duration: 3e6)
+        
+        let result = try formatter.string(from: interval).unwrapped()
+        result.assertContainsInOrder("January 1",  "2001", "12:00:00 AM", "Greenwich Mean Time",
+                                     "February 4", "2001", "5:20:00 PM",  "Greenwich Mean Time")
+    }
+    
+    func testStringFromDateToDateAcrossOneWeek() {
+        formatter.dateTemplate = "MMMd"
+        
+        do {
+            let older = Date(timeIntervalSinceReferenceDate: 0)
+            let newer = Date(timeIntervalSinceReferenceDate: 3600 * 24 * 7)
+            
+            let result = formatter.string(from: older, to: newer)
+            result.assertContainsInOrder(requiresLastToBeAtEnd: true, "Jan", "1", "8")
+        }
+        
+        do {
+            let older = Date(timeIntervalSinceReferenceDate: 3600 * 24 * 28)
+            let newer = Date(timeIntervalSinceReferenceDate: 3600 * 24 * 34)
+            
+            let result = formatter.string(from: older, to: newer)
+            result.assertContainsInOrder(requiresLastToBeAtEnd: true, "Jan", "29", "Feb", "4")
+        }
+    }
+    
+    #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
+    func testStringFromDateToDateAcrossOneWeekWithMonthMinimization() {
+        formatter.dateTemplate = "MMMd"
+        formatter.boundaryStyle = .minimizeAdjacentMonths
+        
+        do {
+            let older = Date(timeIntervalSinceReferenceDate: 0)
+            let newer = Date(timeIntervalSinceReferenceDate: 3600 * 24 * 7)
+            
+            let result = formatter.string(from: older, to: newer)
+            result.assertContainsInOrder(requiresLastToBeAtEnd: true, "Jan", "1", "8")
+        }
+        
+        do {
+            let older = Date(timeIntervalSinceReferenceDate: 3600 * 24 * 28)
+            let newer = Date(timeIntervalSinceReferenceDate: 3600 * 24 * 34)
+            
+            let result = formatter.string(from: older, to: newer)
+            result.assertContainsInOrder(requiresLastToBeAtEnd: true, "Jan", "29", "4")
+            XCTAssertNil(result.range(of: "Feb"))
+        }
+    }
+    #endif
+    
+    func testStringFromDateToDateAcrossSixtyDays() {
+        formatter.dateTemplate = "MMMd"
+        
+        let older = Date(timeIntervalSinceReferenceDate: 0)
+        let newer = Date(timeIntervalSinceReferenceDate: 3600 * 24 * 60)
+        
+        let result = formatter.string(from: older, to: newer)
+        result.assertContainsInOrder(requiresLastToBeAtEnd: true, "Jan", "1", "Mar", "2")
+    }
+    
+    #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
+    func testStringFromDateToDateAcrossSixtyDaysWithMonthMinimization() {
+        formatter.dateTemplate = "MMMd"
+        formatter.boundaryStyle = .minimizeAdjacentMonths
+        
+        let older = Date(timeIntervalSinceReferenceDate: 0)
+        let newer = Date(timeIntervalSinceReferenceDate: 3600 * 24 * 60)
+        
+        // Minimization shouldn't do anything since this spans more than a month
+        let result = formatter.string(from: older, to: newer)
+        result.assertContainsInOrder(requiresLastToBeAtEnd: true, "Jan", "1", "Mar", "2")
+    }
+    #endif
+    
+    func testStringFromDateToDateAcrossFiveHours() throws {
+        do {
+            let older = Date(timeIntervalSinceReferenceDate: 0)
+            let newer = Date(timeIntervalSinceReferenceDate: 3600 * 5)
+            
+            let result = formatter.string(from: older, to: newer)
+            result.assertContainsInOrder(requiresLastToBeAtEnd: true, "January", "1", "2001", "12:00:00 AM", "5:00:00 AM", "GMT")
+            
+            let firstJanuary = try result.range(of: "January").unwrapped()
+            XCTAssertNil(result[firstJanuary.upperBound...].range(of: "January")) // January appears only once.
+        }
+        
+        do {
+            let older = Date(timeIntervalSinceReferenceDate: 3600 * 22)
+            let newer = Date(timeIntervalSinceReferenceDate: 3600 * 27)
+            
+            let result = formatter.string(from: older, to: newer)
+            result.assertContainsInOrder(requiresLastToBeAtEnd: true,
+                                         "January", "1", "2001", "10:00:00 PM", "Greenwich Mean Time",
+                                         "January", "2", "2001", "3:00:00 AM",  "Greenwich Mean Time")
+        }
+    }
+    
+    func testStringFromDateToDateAcrossEighteenHours() throws {
+        let older = Date(timeIntervalSinceReferenceDate: 0)
+        let newer = Date(timeIntervalSinceReferenceDate: 3600 * 18)
+        
+        let result = formatter.string(from: older, to: newer)
+        result.assertContainsInOrder(requiresLastToBeAtEnd: true, "January", "1", "2001", "12:00:00 AM", "6:00:00 PM", "GMT")
+        
+        let firstJanuary = try result.range(of: "January").unwrapped()
+        XCTAssertNil(result[firstJanuary.upperBound...].range(of: "January")) // January appears only once.
+    }
+    
+    static var allTests: [(String, (TestDateIntervalFormatter) -> () throws -> Void)] {
+        var tests: [(String, (TestDateIntervalFormatter) -> () throws -> Void)] = [
+            ("testStringFromDateToDateAcrossThreeBillionSeconds", testStringFromDateToDateAcrossThreeBillionSeconds),
+            ("testStringFromDateToDateAcrossThreeMillionSeconds", testStringFromDateToDateAcrossThreeMillionSeconds),
+            ("testStringFromDateToDateAcrossThreeBillionSecondsReversed", testStringFromDateToDateAcrossThreeBillionSecondsReversed),
+            ("testStringFromDateToDateAcrossThreeMillionSecondsReversed", testStringFromDateToDateAcrossThreeMillionSecondsReversed),
+            ("testStringFromDateToSameDate", testStringFromDateToSameDate),
+            ("testStringFromDateIntervalAcrossThreeMillionSeconds", testStringFromDateIntervalAcrossThreeMillionSeconds),
+            ("testStringFromDateToDateAcrossOneWeek", testStringFromDateToDateAcrossOneWeek),
+            ("testStringFromDateToDateAcrossSixtyDays", testStringFromDateToDateAcrossSixtyDays),
+            ("testStringFromDateToDateAcrossFiveHours", testStringFromDateToDateAcrossFiveHours),
+            ("testStringFromDateToDateAcrossEighteenHours", testStringFromDateToDateAcrossEighteenHours),
+        ]
+        
+        #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
+        tests.append(contentsOf: [
+            ("testStringFromDateToDateAcrossOneWeekWithMonthMinimization", testStringFromDateToDateAcrossOneWeekWithMonthMinimization),
+            ("testStringFromDateToDateAcrossSixtyDaysWithMonthMinimization", testStringFromDateToDateAcrossSixtyDaysWithMonthMinimization),
+        ])
+        #endif
+        
+        return tests
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -34,6 +34,7 @@ XCTMain([
     testCase(TestDateComponents.allTests),
     testCase(TestNSDateComponents.allTests),
     testCase(TestDateFormatter.allTests),
+    testCase(TestDateIntervalFormatter.allTests),
     testCase(TestDecimal.allTests),
     testCase(TestNSDictionary.allTests),
     testCase(TestNSError.allTests),


### PR DESCRIPTION
(cherry picked from commit 988d5f89126bd79d705584fb8ae19a086d230c07)

Add the new files to the `CMakeLists.txt`s.

(cherry picked from commit 0eed327211feaa131a28590b5a28a286130a15e8)

Fix boundary styles outside of Darwin.

(cherry picked from commit ff070d603405ace93adbb13f6362707141f5021d)

Guard the tests as well.

(cherry picked from commit 32cfcf1d8ed62e0877b7247d70558ba66f1f81cf)

Make tests fuzzier so they work on both Darwin and Linux ICUs.

(cherry picked from commit b342e5f05c3288ee50758f7792523fb55f339bd2)

Better assertion failure messages in the fuzzy matching.

(cherry picked from commit 0c69d1a049e50e9e198bbe3f104fa63464b2e8f2)

Even more info.

(cherry picked from commit e395327f358fa8a5c709f674a04caf702705d3a9)

Actually fix all the missed copy-paste changes after fuzzification.

(cherry picked from commit 16000803194dd1575ad17ac9cebb53be83a0b8c4)