### PR TITLE
Foundation: support OS version query for Windows

### DIFF
--- a/Foundation/ProcessInfo.swift
+++ b/Foundation/ProcessInfo.swift
@@ -103,6 +103,13 @@ open class ProcessInfo: NSObject {
             return OperatingSystemVersion(majorVersion: fallbackMajor, minorVersion: fallbackMinor, patchVersion: fallbackPatch)
         }
         versionString = productVersion._swiftObject
+#elseif os(Windows)
+        var siVersionInfo: OSVERSIONINFOW = OSVERSIONINFOW()
+        siVersionInfo.dwOSVersionInfoSize = DWORD(MemoryLayout<OSVERSIONINFOEXW>.size)
+        if GetVersionExW(&siVersionInfo) == FALSE {
+          return OperatingSystemVersion(majorVersion: fallbackMajor, minorVersion: fallbackMinor, patchVersion: fallbackPatch)
+        }
+        return OperatingSystemVersion(majorVersion: Int(siVersionInfo.dwMajorVersion), minorVersion: Int(siVersionInfo.dwMinorVersion), patchVersion: Int(siVersionInfo.dwBuildNumber))
 #else
         var utsNameBuffer = utsname()
         guard uname(&utsNameBuffer) == 0 else {


### PR DESCRIPTION
Fix the build after the recent changes to the ProcessInfo which
attempted to use `utsname` on Windows which does not provide that
interface.