### PR TITLE
[4.2] Fix PropertyListSerialization not doing a roundtrip of Data correctly.

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -239,6 +239,13 @@ struct _NSNumberBridge {
     bool (*_Nonnull _getValue)(CFTypeRef number, void *value, CFNumberType type);
 };
 
+struct _NSDataBridge {
+    _Nonnull CFTypeRef (*_Nonnull copy)(CFTypeRef obj);
+    CFIndex (*_Nonnull length)(CFTypeRef obj);
+    const void *_Nonnull (*_Nonnull bytePtr)(CFTypeRef obj);
+    void (*_Nonnull getBytes)(CFTypeRef obj, CFRange range, void *_Nonnull buffer);
+};
+
 struct _CFSwiftBridge {
     struct _NSObjectBridge NSObject;
     struct _NSArrayBridge NSArray;
@@ -254,6 +261,7 @@ struct _CFSwiftBridge {
     struct _NSCharacterSetBridge NSCharacterSet;
     struct _NSMutableCharacterSetBridge NSMutableCharacterSet;
     struct _NSNumberBridge NSNumber;
+    struct _NSDataBridge NSData;
 };
 
 CF_EXPORT struct _CFSwiftBridge __CFSwiftBridge;
@@ -422,6 +430,14 @@ static inline unsigned int _dev_major(dev_t rdev) {
 static inline unsigned int _dev_minor(dev_t rdev) {
     return minor(rdev);
 }
+
+#pragma mark - Data Functions
+
+CF_CROSS_PLATFORM_EXPORT CFDataRef _CFDataCreateCopyNoBridging(CFAllocatorRef allocator, CFDataRef data);
+CF_CROSS_PLATFORM_EXPORT const uint8_t *_CFDataGetBytePtrNoBridging(CFDataRef data);
+CF_CROSS_PLATFORM_EXPORT uint8_t *_CFDataGetMutableBytePtrNoBridging(CFDataRef data);
+CF_CROSS_PLATFORM_EXPORT void _CFDataGetBytesNoBridging(CFDataRef data, CFRange range, void *buffer);
+CF_CROSS_PLATFORM_EXPORT CFIndex _CFDataGetLengthNoBridging(CFDataRef data);
 
 _CF_EXPORT_SCOPE_END
 

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -286,6 +286,11 @@ internal func __CFInitializeSwift() {
     __CFSwiftBridge.NSNumber._getValue = _CFSwiftNumberGetValue
     __CFSwiftBridge.NSNumber.boolValue = _CFSwiftNumberGetBoolValue
     
+    __CFSwiftBridge.NSData.copy = _CFSwiftDataCreateCopy
+    __CFSwiftBridge.NSData.bytePtr = _CFSwiftDataGetBytePtr
+    __CFSwiftBridge.NSData.length = _CFSwiftDataGetLength
+    __CFSwiftBridge.NSData.getBytes = _CFSwiftDataGetBytes
+    
 //    __CFDefaultEightBitStringEncoding = UInt32(kCFStringEncodingUTF8)
 }
 

--- a/TestFoundation/TestPropertyListSerialization.swift
+++ b/TestFoundation/TestPropertyListSerialization.swift
@@ -8,14 +8,6 @@
 //
 
 class TestPropertyListSerialization : XCTestCase {
-    static var allTests: [(String, (TestPropertyListSerialization) -> () throws -> Void)] {
-        return [
-            ("test_BasicConstruction", test_BasicConstruction),
-            ("test_decodeData", test_decodeData),
-            ("test_decodeStream", test_decodeStream),
-        ]
-    }
-    
     func test_BasicConstruction() {
         let dict = NSMutableDictionary(capacity: 0)
 //        dict["foo"] = "bar"
@@ -78,5 +70,45 @@ class TestPropertyListSerialization : XCTestCase {
         } else {
             XCTFail("value stored is not a string")
         }
+    }
+    
+    func test_roundtripBasicTypes() throws {
+        let name: String = "my name"
+        let age: Int = 100
+        let data: Data = "helloworld".data(using: .utf8)!
+        
+        let properties: [String: Any] = [
+            "name": name,
+            "age": age,
+            "data": data
+        ]
+        
+        // pack
+        let serialized = try PropertyListSerialization.data(fromPropertyList: properties, format: .binary, options: 0)
+        
+        // unpack
+        let deserialized = try PropertyListSerialization.propertyList(from: serialized, options: [], format: nil)
+        let dictionary = try (deserialized as? [String: Any]).unwrapped()
+        
+        XCTAssertNotNil(dictionary["name"])
+        XCTAssertNotNil(dictionary["name"] as? String)
+        XCTAssertEqual(name, dictionary["name"] as? String)
+        
+        XCTAssertNotNil(dictionary["age"])
+        XCTAssertNotNil(dictionary["age"] as? Int)
+        XCTAssertEqual(age, dictionary["age"] as? Int)
+        
+        XCTAssertNotNil(dictionary["data"])
+        XCTAssertNotNil(dictionary["data"] as? Data)
+        XCTAssertEqual(data, dictionary["data"] as? Data)
+    }
+    
+    static var allTests: [(String, (TestPropertyListSerialization) -> () throws -> Void)] {
+        return [
+            ("test_BasicConstruction", test_BasicConstruction),
+            ("test_decodeData", test_decodeData),
+            ("test_decodeStream", test_decodeStream),
+            ("test_roundtripBasicTypes", test_roundtripBasicTypes),
+        ]
     }
 }


### PR DESCRIPTION
In 4.x, bridging `Data` to an object produces a `_NSSwiftData`, a `NSData` subclass. `CFData…` functions weren’t set up for it, so now they must be. Unfortunately, due to the way the implementation of s-c-f differs from Darwin’s — since we have no class clusters in Swift — there’s some wrangling needed in NSMutableData to prevent infinite recursion when its base class’s methods are invoked. rdar://48420798