### PR TITLE
NSAttributedString: Rename NSAttributedStringKey to NSAttributedString.Key

### DIFF
--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -1,29 +1,35 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2016, 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
 import CoreFoundation
 
-public struct NSAttributedStringKey : RawRepresentable, Equatable, Hashable {
-    public let rawValue: String
+extension NSAttributedString {
+    public struct Key: RawRepresentable, Equatable, Hashable {
+        public let rawValue: String
 
-    public init(_ rawValue: String) {
-        self.rawValue = rawValue
-    }
+        public init(_ rawValue: String) {
+            self.rawValue = rawValue
+        }
 
-    public init(rawValue: String) {
-        self.rawValue = rawValue
-    }
+        public init(rawValue: String) {
+            self.rawValue = rawValue
+        }
 
-    public var hashValue: Int {
-        return rawValue.hashValue
+        public var hashValue: Int {
+            return rawValue.hashValue
+        }
     }
 }
+
+@available(*, unavailable, renamed: "NSAttributedString.Key")
+public typealias NSAttributedStringKey = NSAttributedString.Key
+
 
 open class NSAttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     
@@ -65,7 +71,7 @@ open class NSAttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
     }
 
     /// Returns the attributes for the character at a given index.
-    open func attributes(at location: Int, effectiveRange range: NSRangePointer?) -> [NSAttributedStringKey : Any] {
+    open func attributes(at location: Int, effectiveRange range: NSRangePointer?) -> [NSAttributedString.Key: Any] {
         let rangeInfo = RangeInfo(
             rangePointer: range,
             shouldFetchLongestEffectiveRange: false,
@@ -79,7 +85,7 @@ open class NSAttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
     }
 
     /// Returns the value for an attribute with a given name of the character at a given index, and by reference the range over which the attribute applies.
-    open func attribute(_ attrName: NSAttributedStringKey, at location: Int, effectiveRange range: NSRangePointer?) -> Any? {
+    open func attribute(_ attrName: NSAttributedString.Key, at location: Int, effectiveRange range: NSRangePointer?) -> Any? {
         let rangeInfo = RangeInfo(
             rangePointer: range,
             shouldFetchLongestEffectiveRange: false,
@@ -94,7 +100,7 @@ open class NSAttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
     }
 
     /// Returns the attributes for the character at a given index, and by reference the range over which the attributes apply.
-    open func attributes(at location: Int, longestEffectiveRange range: NSRangePointer?, in rangeLimit: NSRange) -> [NSAttributedStringKey : Any] {
+    open func attributes(at location: Int, longestEffectiveRange range: NSRangePointer?, in rangeLimit: NSRange) -> [NSAttributedString.Key: Any] {
         let rangeInfo = RangeInfo(
             rangePointer: range,
             shouldFetchLongestEffectiveRange: true,
@@ -103,7 +109,7 @@ open class NSAttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
     }
 
     /// Returns the value for the attribute with a given name of the character at a given index, and by reference the range over which the attribute applies.
-    open func attribute(_ attrName: NSAttributedStringKey, at location: Int, longestEffectiveRange range: NSRangePointer?, in rangeLimit: NSRange) -> Any? {
+    open func attribute(_ attrName: NSAttributedString.Key, at location: Int, longestEffectiveRange range: NSRangePointer?, in rangeLimit: NSRange) -> Any? {
         let rangeInfo = RangeInfo(
             rangePointer: range,
             shouldFetchLongestEffectiveRange: true,
@@ -134,7 +140,7 @@ open class NSAttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
     }
 
     /// Returns an NSAttributedString object initialized with a given string and attributes.
-    public init(string: String, attributes attrs: [NSAttributedStringKey : Any]? = nil) {
+    public init(string: String, attributes attrs: [NSAttributedString.Key: Any]? = nil) {
         _string = string._nsObject
         _attributeArray = CFRunArrayCreate(kCFAllocatorDefault)
 
@@ -154,10 +160,10 @@ open class NSAttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
     }
 
     /// Executes the block for each attribute in the range.
-    open func enumerateAttributes(in enumerationRange: NSRange, options opts: NSAttributedString.EnumerationOptions = [], using block: ([NSAttributedStringKey : Any], NSRange, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) {
+    open func enumerateAttributes(in enumerationRange: NSRange, options opts: NSAttributedString.EnumerationOptions = [], using block: ([NSAttributedString.Key: Any], NSRange, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) {
         _enumerate(in: enumerationRange, reversed: opts.contains(.reverse)) { currentIndex, stop in
             var attributesEffectiveRange = NSRange(location: NSNotFound, length: 0)
-            let attributesInRange: [NSAttributedStringKey : Any]
+            let attributesInRange: [NSAttributedString.Key: Any]
             if opts.contains(.longestEffectiveRangeNotRequired) {
                 attributesInRange = attributes(at: currentIndex, effectiveRange: &attributesEffectiveRange)
             } else {
@@ -173,7 +179,7 @@ open class NSAttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
     }
 
     /// Executes the block for the specified attribute run in the specified range.
-    open func enumerateAttribute(_ attrName: NSAttributedStringKey, in enumerationRange: NSRange, options opts: NSAttributedString.EnumerationOptions = [], using block: (Any?, NSRange, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) {
+    open func enumerateAttribute(_ attrName: NSAttributedString.Key, in enumerationRange: NSRange, options opts: NSAttributedString.EnumerationOptions = [], using block: (Any?, NSRange, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) {
         _enumerate(in: enumerationRange, reversed: opts.contains(.reverse)) { currentIndex, stop in
             var attributeEffectiveRange = NSRange(location: NSNotFound, length: 0)
             let attributeInRange: Any?
@@ -233,9 +239,9 @@ private extension NSAttributedString {
         let longestEffectiveRangeSearchRange: NSRange?
     }
     
-    func _attributes(at location: Int, rangeInfo: RangeInfo) -> [NSAttributedStringKey : Any] {
+    func _attributes(at location: Int, rangeInfo: RangeInfo) -> [NSAttributedString.Key: Any] {
         var cfRange = CFRange()
-        return withUnsafeMutablePointer(to: &cfRange) { (cfRangePointer: UnsafeMutablePointer<CFRange>) -> [NSAttributedStringKey : Any] in
+        return withUnsafeMutablePointer(to: &cfRange) { (cfRangePointer: UnsafeMutablePointer<CFRange>) -> [NSAttributedString.Key: Any] in
             // Get attributes value using CoreFoundation function
             let value: CFDictionary
             if rangeInfo.shouldFetchLongestEffectiveRange, let searchRange = rangeInfo.longestEffectiveRangeSearchRange {
@@ -246,12 +252,12 @@ private extension NSAttributedString {
             
             // Convert the value to [String : AnyObject]
             let dictionary = unsafeBitCast(value, to: NSDictionary.self)
-            var results = [NSAttributedStringKey : Any]()
+            var results = [NSAttributedString.Key: Any]()
             for (key, value) in dictionary {
                 guard let stringKey = (key as? NSString)?._swiftObject else {
                     continue
                 }
-                results[NSAttributedStringKey(stringKey)] = value
+                results[NSAttributedString.Key(stringKey)] = value
             }
             
             // Update effective range and return the results
@@ -261,7 +267,7 @@ private extension NSAttributedString {
         }
     }
     
-    func _attribute(_ attrName: NSAttributedStringKey, atIndex location: Int, rangeInfo: RangeInfo) -> Any? {
+    func _attribute(_ attrName: NSAttributedString.Key, atIndex location: Int, rangeInfo: RangeInfo) -> Any? {
         var cfRange = CFRange()
         return withUnsafeMutablePointer(to: &cfRange) { (cfRangePointer: UnsafeMutablePointer<CFRange>) -> AnyObject? in
             // Get attribute value using CoreFoundation function
@@ -291,7 +297,7 @@ private extension NSAttributedString {
         }
     }
     
-    func addAttributesToAttributeArray(attrs: [NSAttributedStringKey : Any]?) {
+    func addAttributesToAttributeArray(attrs: [NSAttributedString.Key: Any]?) {
         guard _string.length > 0 else {
             return
         }
@@ -329,7 +335,7 @@ open class NSMutableAttributedString : NSAttributedString {
         CFAttributedStringReplaceString(_cfMutableObject, CFRange(range), str._cfObject)
     }
     
-    open func setAttributes(_ attrs: [NSAttributedStringKey : Any]?, range: NSRange) {
+    open func setAttributes(_ attrs: [NSAttributedString.Key: Any]?, range: NSRange) {
         guard let attrs = attrs else {
             CFAttributedStringSetAttributes(_cfMutableObject, CFRange(range), nil, true)
             return
@@ -341,15 +347,15 @@ open class NSMutableAttributedString : NSAttributedString {
         return _string as! NSMutableString
     }
 
-    open func addAttribute(_ name: NSAttributedStringKey, value: Any, range: NSRange) {
+    open func addAttribute(_ name: NSAttributedString.Key, value: Any, range: NSRange) {
         CFAttributedStringSetAttribute(_cfMutableObject, CFRange(range), name.rawValue._cfObject, __SwiftValue.store(value))
     }
 
-    open func addAttributes(_ attrs: [NSAttributedStringKey : Any], range: NSRange) {
+    open func addAttributes(_ attrs: [NSAttributedString.Key: Any], range: NSRange) {
         CFAttributedStringSetAttributes(_cfMutableObject, CFRange(range), attributesCFDictionary(from: attrs), false)
     }
     
-    open func removeAttribute(_ name: NSAttributedStringKey, range: NSRange) {
+    open func removeAttribute(_ name: NSAttributedString.Key, range: NSRange) {
         CFAttributedStringRemoveAttribute(_cfMutableObject, CFRange(range), name.rawValue._cfObject)
     }
     
@@ -395,7 +401,7 @@ open class NSMutableAttributedString : NSAttributedString {
         _string = NSMutableString(string: string)
     }
     
-    public override init(string: String, attributes attrs: [NSAttributedStringKey : Any]? = nil) {
+    public override init(string: String, attributes attrs: [NSAttributedString.Key: Any]? = nil) {
         super.init(string: string, attributes: attrs)
         _string = NSMutableString(string: string)
     }
@@ -417,7 +423,7 @@ extension NSMutableAttributedString {
 
 private extension NSMutableAttributedString {
     
-    func attributesCFDictionary(from attrs: [NSAttributedStringKey : Any]) -> CFDictionary {
+    func attributesCFDictionary(from attrs: [NSAttributedString.Key: Any]) -> CFDictionary {
         var attributesDictionary = [String : Any]()
         for (key, value) in attrs {
             attributesDictionary[key.rawValue] = value

--- a/TestFoundation/TestNSAttributedString.swift
+++ b/TestFoundation/TestNSAttributedString.swift
@@ -36,7 +36,7 @@ class TestNSAttributedString : XCTestCase {
         XCTAssertEqual(range.length, string.utf16.count)
         XCTAssertEqual(attrs.count, 0)
 
-        let attribute = attrString.attribute(NSAttributedStringKey("invalid"), at: 0, effectiveRange: &range)
+        let attribute = attrString.attribute(NSAttributedString.Key("invalid"), at: 0, effectiveRange: &range)
         XCTAssertNil(attribute)
         XCTAssertEqual(range.location, 0)
         XCTAssertEqual(range.length, string.utf16.count)
@@ -44,7 +44,7 @@ class TestNSAttributedString : XCTestCase {
     
     func test_initWithStringAndAttributes() {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur et sem vitae consectetur. Nam venenatis lectus a laoreet blandit."
-        let attributes: [NSAttributedStringKey : Any] = [NSAttributedStringKey("attribute.placeholder.key") : "attribute.placeholder.value"]
+        let attributes: [NSAttributedString.Key: Any] = [NSAttributedString.Key("attribute.placeholder.key") : "attribute.placeholder.value"]
         
         let attrString = NSAttributedString(string: string, attributes: attributes)
         XCTAssertEqual(attrString.string, string)
@@ -52,7 +52,7 @@ class TestNSAttributedString : XCTestCase {
         
         var range = NSRange()
         let attrs = attrString.attributes(at: 0, effectiveRange: &range)
-        guard let value = attrs[NSAttributedStringKey("attribute.placeholder.key")] as? String else {
+        guard let value = attrs[NSAttributedString.Key("attribute.placeholder.key")] as? String else {
             XCTAssert(false, "attribute value not found")
             return
         }
@@ -60,12 +60,12 @@ class TestNSAttributedString : XCTestCase {
         XCTAssertEqual(range.length, attrString.length)
         XCTAssertEqual(value, "attribute.placeholder.value")
 
-        let invalidAttribute = attrString.attribute(NSAttributedStringKey("invalid"), at: 0, effectiveRange: &range)
+        let invalidAttribute = attrString.attribute(NSAttributedString.Key("invalid"), at: 0, effectiveRange: &range)
         XCTAssertNil(invalidAttribute)
         XCTAssertEqual(range.location, 0)
         XCTAssertEqual(range.length, string.utf16.count)
 
-        let attribute = attrString.attribute(NSAttributedStringKey("attribute.placeholder.key"), at: 0, effectiveRange: &range)
+        let attribute = attrString.attribute(NSAttributedString.Key("attribute.placeholder.key"), at: 0, effectiveRange: &range)
         XCTAssertEqual(range.location, 0)
         XCTAssertEqual(range.length, attrString.length)
         guard let validAttribute = attribute as? NSString else {
@@ -77,7 +77,7 @@ class TestNSAttributedString : XCTestCase {
     
     func test_initWithAttributedString() {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        let attributes: [NSAttributedStringKey : Any] = [NSAttributedStringKey("attribute.placeholder.key") : "attribute.placeholder.value"]
+        let attributes: [NSAttributedString.Key: Any] = [NSAttributedString.Key("attribute.placeholder.key") : "attribute.placeholder.value"]
         let mutableAttrString = NSMutableAttributedString(string: string, attributes: attributes)
 
         let initializedAttrString = NSAttributedString(attributedString: mutableAttrString)
@@ -90,7 +90,7 @@ class TestNSAttributedString : XCTestCase {
     
     func test_attributedSubstring() {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur et sem vitae consectetur. Nam venenatis lectus a laoreet blandit."
-        let attributes: [NSAttributedStringKey : Any] = [NSAttributedStringKey("attribute.placeholder.key") : "attribute.placeholder.value"]
+        let attributes: [NSAttributedString.Key: Any] = [NSAttributedString.Key("attribute.placeholder.key") : "attribute.placeholder.value"]
         
         let attrString = NSAttributedString(string: string, attributes: attributes)
         let subStringRange = NSRange(location: 0, length: 26)
@@ -99,7 +99,7 @@ class TestNSAttributedString : XCTestCase {
         
         var range = NSRange()
         let attrs = attrString.attributes(at: 0, effectiveRange: &range)
-        guard let value = attrs[NSAttributedStringKey("attribute.placeholder.key")] as? String else {
+        guard let value = attrs[NSAttributedString.Key("attribute.placeholder.key")] as? String else {
             XCTAssert(false, "attribute value not found")
             return
         }
@@ -111,7 +111,7 @@ class TestNSAttributedString : XCTestCase {
     func test_longestEffectiveRange() {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur et sem vitae consectetur. Nam venenatis lectus a laoreet blandit."
         
-        let attrKey = NSAttributedStringKey("attribute.placeholder.key")
+        let attrKey = NSAttributedString.Key("attribute.placeholder.key")
         let attrValue = "attribute.placeholder.value"
         
         let attrRange1 = NSRange(location: 0, length: 20)
@@ -136,12 +136,12 @@ class TestNSAttributedString : XCTestCase {
     func test_enumerateAttributeWithName() {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur et sem vitae consectetur. Nam venenatis lectus a laoreet blandit."
         
-        let attrKey1 = NSAttributedStringKey("attribute.placeholder.key1")
+        let attrKey1 = NSAttributedString.Key("attribute.placeholder.key1")
         let attrValue1 = "attribute.placeholder.value1"
         let attrRange1 = NSRange(location: 0, length: 20)
         let attrRange2 = NSRange(location: 18, length: 10)
         
-        let attrKey3 = NSAttributedStringKey("attribute.placeholder.key3")
+        let attrKey3 = NSAttributedString.Key("attribute.placeholder.key3")
         let attrValue3 = "attribute.placeholder.value3"
         let attrRange3 = NSRange(location: 40, length: 5)
         
@@ -183,15 +183,15 @@ class TestNSAttributedString : XCTestCase {
     func test_enumerateAttributes() {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur et sem vitae consectetur. Nam venenatis lectus a laoreet blandit."
         
-        let attrKey1 = NSAttributedStringKey("attribute.placeholder.key1")
+        let attrKey1 = NSAttributedString.Key("attribute.placeholder.key1")
         let attrValue1 = "attribute.placeholder.value1"
         let attrRange1 = NSRange(location: 0, length: 20)
         
-        let attrKey2 = NSAttributedStringKey("attribute.placeholder.key2")
+        let attrKey2 = NSAttributedString.Key("attribute.placeholder.key2")
         let attrValue2 = "attribute.placeholder.value2"
         let attrRange2 = NSRange(location: 18, length: 10)
         
-        let attrKey3 = NSAttributedStringKey("attribute.placeholder.key3")
+        let attrKey3 = NSAttributedString.Key("attribute.placeholder.key3")
         let attrValue3 = "attribute.placeholder.value3"
         let attrRange3 = NSRange(location: 40, length: 5)
         
@@ -243,7 +243,7 @@ class TestNSAttributedString : XCTestCase {
     
     func test_copy() {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        let attributes: [NSAttributedStringKey : Any] = [NSAttributedStringKey("attribute.placeholder.key") : "attribute.placeholder.value"]
+        let attributes: [NSAttributedString.Key: Any] = [NSAttributedString.Key("attribute.placeholder.key") : "attribute.placeholder.value"]
         
         let originalAttrString = NSAttributedString(string: string, attributes: attributes)
         let attrStringCopy = originalAttrString.copy()
@@ -260,7 +260,7 @@ class TestNSAttributedString : XCTestCase {
     
     func test_mutableCopy() {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        let attributes: [NSAttributedStringKey : Any] = [NSAttributedStringKey("attribute.placeholder.key") : "attribute.placeholder.value"]
+        let attributes: [NSAttributedString.Key: Any] = [NSAttributedString.Key("attribute.placeholder.key") : "attribute.placeholder.value"]
 
         let originalAttrString = NSAttributedString(string: string, attributes: attributes)
         let attrStringMutableCopy = originalAttrString.mutableCopy()
@@ -275,7 +275,7 @@ class TestNSAttributedString : XCTestCase {
     
     func test_isEqual() {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        let attributes: [NSAttributedStringKey : Any] = [NSAttributedStringKey("attribute.placeholder.key") : "attribute.placeholder.value"]
+        let attributes: [NSAttributedString.Key: Any] = [NSAttributedString.Key("attribute.placeholder.key") : "attribute.placeholder.value"]
 
         let attrString = NSAttributedString(string: string, attributes: attributes)
         
@@ -286,7 +286,7 @@ class TestNSAttributedString : XCTestCase {
         XCTAssertTrue(attrString.isEqual(to: mutableAttrString))
         XCTAssertTrue(mutableAttrString.isEqual(to: attrString))
         
-        let newAttrs: [NSAttributedStringKey : Any] = [NSAttributedStringKey("attribute.placeholder.key2") : "attribute.placeholder.value2"]
+        let newAttrs: [NSAttributedString.Key: Any] = [NSAttributedString.Key("attribute.placeholder.key2") : "attribute.placeholder.value2"]
         let newAttrsRange = NSRange(string.startIndex..., in: string)
         mutableAttrString.addAttributes(newAttrs, range: newAttrsRange)
         XCTAssertFalse(attrString.isEqual(to: mutableAttrString))
@@ -308,7 +308,7 @@ fileprivate extension TestNSAttributedString {
         }
     }
     
-    func describe(attrs: [NSAttributedStringKey : Any]) -> String {
+    func describe(attrs: [NSAttributedString.Key: Any]) -> String {
         if attrs.count > 0 {
             let mapped: [String] = attrs.map({ "\($0.rawValue):\($1)" })
             let sorted: [String] = mapped.sorted(by: { $0 < $1 })
@@ -347,7 +347,7 @@ class TestNSMutableAttributedString : XCTestCase {
     
     func test_initWithStringAndAttributes() {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur et sem vitae consectetur. Nam venenatis lectus a laoreet blandit."
-        let attributes: [NSAttributedStringKey : Any] = [NSAttributedStringKey("attribute.placeholder.key") : "attribute.placeholder.value"]
+        let attributes: [NSAttributedString.Key: Any] = [NSAttributedString.Key("attribute.placeholder.key") : "attribute.placeholder.value"]
         
         let mutableAttrString = NSMutableAttributedString(string: string, attributes: attributes)
         XCTAssertEqual(mutableAttrString.mutableString, NSMutableString(string: string))
@@ -355,7 +355,7 @@ class TestNSMutableAttributedString : XCTestCase {
         
         var range = NSRange()
         let attrs = mutableAttrString.attributes(at: 0, effectiveRange: &range)
-        guard let value = attrs[NSAttributedStringKey("attribute.placeholder.key")] as? String else {
+        guard let value = attrs[NSAttributedString.Key("attribute.placeholder.key")] as? String else {
             XCTAssert(false, "attribute value not found")
             return
         }
@@ -363,12 +363,12 @@ class TestNSMutableAttributedString : XCTestCase {
         XCTAssertEqual(range.length, mutableAttrString.length)
         XCTAssertEqual(value, "attribute.placeholder.value")
         
-        let invalidAttribute = mutableAttrString.attribute(NSAttributedStringKey("invalid"), at: 0, effectiveRange: &range)
+        let invalidAttribute = mutableAttrString.attribute(NSAttributedString.Key("invalid"), at: 0, effectiveRange: &range)
         XCTAssertNil(invalidAttribute)
         XCTAssertEqual(range.location, 0)
         XCTAssertEqual(range.length, string.utf16.count)
         
-        let attribute = mutableAttrString.attribute(NSAttributedStringKey("attribute.placeholder.key"), at: 0, effectiveRange: &range)
+        let attribute = mutableAttrString.attribute(NSAttributedString.Key("attribute.placeholder.key"), at: 0, effectiveRange: &range)
         XCTAssertEqual(range.location, 0)
         XCTAssertEqual(range.length, mutableAttrString.length)
         guard let validAttribute = attribute as? NSString else {
@@ -380,7 +380,7 @@ class TestNSMutableAttributedString : XCTestCase {
     
     func test_initWithAttributedString() {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        let attributes: [NSAttributedStringKey : Any] = [NSAttributedStringKey("attribute.placeholder.key") : "attribute.placeholder.value"]
+        let attributes: [NSAttributedString.Key: Any] = [NSAttributedString.Key("attribute.placeholder.key") : "attribute.placeholder.value"]
 
         let mutableAttrString = NSMutableAttributedString(string: string, attributes: attributes)
         
@@ -396,7 +396,7 @@ class TestNSMutableAttributedString : XCTestCase {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur et sem vitae consectetur. Nam venenatis lectus a laoreet blandit."
         let mutableAttrString = NSMutableAttributedString(string: string)
         
-        let attrKey1 = NSAttributedStringKey("attribute.placeholder.key1")
+        let attrKey1 = NSAttributedString.Key("attribute.placeholder.key1")
         let attrValue1 = "attribute.placeholder.value1"
         let attrRange1 = NSRange(location: 0, length: 20)
         mutableAttrString.addAttribute(attrKey1, value: attrValue1, range: attrRange1)
@@ -413,23 +413,23 @@ class TestNSMutableAttributedString : XCTestCase {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur et sem vitae consectetur. Nam venenatis lectus a laoreet blandit."
         let mutableAttrString = NSMutableAttributedString(string: string)
         
-        let attrKey1 = NSAttributedStringKey("attribute.placeholder.key1")
+        let attrKey1 = NSAttributedString.Key("attribute.placeholder.key1")
         let attrValue1 = "attribute.placeholder.value1"
         let attrRange1 = NSRange(location: 0, length: 20)
         mutableAttrString.addAttribute(attrKey1, value: attrValue1, range: attrRange1)
 
         let attrs2 = [
-            NSAttributedStringKey("attribute.placeholder.key2") : "attribute.placeholder.value2",
-            NSAttributedStringKey("attribute.placeholder.key3") : "attribute.placeholder.value3",
+            NSAttributedString.Key("attribute.placeholder.key2") : "attribute.placeholder.value2",
+            NSAttributedString.Key("attribute.placeholder.key3") : "attribute.placeholder.value3",
         ]
         let attrRange2 = NSRange(location: 0, length: 20)
         mutableAttrString.addAttributes(attrs2, range: attrRange2)
         
-        let result = mutableAttrString.attributes(at: 10, effectiveRange: nil) as? [NSAttributedStringKey : String]
-        let expectedResult: [NSAttributedStringKey : String] = [
-            NSAttributedStringKey("attribute.placeholder.key1") : "attribute.placeholder.value1",
-            NSAttributedStringKey("attribute.placeholder.key2") : "attribute.placeholder.value2",
-            NSAttributedStringKey("attribute.placeholder.key3") : "attribute.placeholder.value3",
+        let result = mutableAttrString.attributes(at: 10, effectiveRange: nil) as? [NSAttributedString.Key: String]
+        let expectedResult: [NSAttributedString.Key: String] = [
+            NSAttributedString.Key("attribute.placeholder.key1") : "attribute.placeholder.value1",
+            NSAttributedString.Key("attribute.placeholder.key2") : "attribute.placeholder.value2",
+            NSAttributedString.Key("attribute.placeholder.key3") : "attribute.placeholder.value3",
         ]
         XCTAssertEqual(result, expectedResult)
     }
@@ -438,22 +438,22 @@ class TestNSMutableAttributedString : XCTestCase {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur et sem vitae consectetur. Nam venenatis lectus a laoreet blandit."
         let mutableAttrString = NSMutableAttributedString(string: string)
         
-        let attrKey1 = NSAttributedStringKey("attribute.placeholder.key1")
+        let attrKey1 = NSAttributedString.Key("attribute.placeholder.key1")
         let attrValue1 = "attribute.placeholder.value1"
         let attrRange1 = NSRange(location: 0, length: 20)
         mutableAttrString.addAttribute(attrKey1, value: attrValue1, range: attrRange1)
         
         let attrs2 = [
-            NSAttributedStringKey("attribute.placeholder.key2") : "attribute.placeholder.value2",
-            NSAttributedStringKey("attribute.placeholder.key3") : "attribute.placeholder.value3",
+            NSAttributedString.Key("attribute.placeholder.key2") : "attribute.placeholder.value2",
+            NSAttributedString.Key("attribute.placeholder.key3") : "attribute.placeholder.value3",
         ]
         let attrRange2 = NSRange(location: 0, length: 20)
         mutableAttrString.setAttributes(attrs2, range: attrRange2)
         
-        let result = mutableAttrString.attributes(at: 10, effectiveRange: nil) as? [NSAttributedStringKey : String]
-        let expectedResult: [NSAttributedStringKey : String] = [
-            NSAttributedStringKey("attribute.placeholder.key2") : "attribute.placeholder.value2",
-            NSAttributedStringKey("attribute.placeholder.key3") : "attribute.placeholder.value3",
+        let result = mutableAttrString.attributes(at: 10, effectiveRange: nil) as? [NSAttributedString.Key: String]
+        let expectedResult: [NSAttributedString.Key: String] = [
+            NSAttributedString.Key("attribute.placeholder.key2") : "attribute.placeholder.value2",
+            NSAttributedString.Key("attribute.placeholder.key3") : "attribute.placeholder.value3",
         ]
         XCTAssertEqual(result, expectedResult)
         
@@ -464,7 +464,7 @@ class TestNSMutableAttributedString : XCTestCase {
     
     func test_replaceCharactersWithString() {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur et sem vitae consectetur. Nam venenatis lectus a laoreet blandit."
-        let attrKey1 = NSAttributedStringKey("attribute.placeholder.key1")
+        let attrKey1 = NSAttributedString.Key("attribute.placeholder.key1")
         let attrValue1 = "attribute.placeholder.value1"
         let mutableAttrString = NSMutableAttributedString(string: string, attributes: [attrKey1 : attrValue1])
 
@@ -486,13 +486,13 @@ class TestNSMutableAttributedString : XCTestCase {
 
     func test_replaceCharactersWithAttributedString() {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur et sem vitae consectetur. Nam venenatis lectus a laoreet blandit."
-        let attrKey1 = NSAttributedStringKey("attribute.placeholder.key1")
+        let attrKey1 = NSAttributedString.Key("attribute.placeholder.key1")
         let attrValue1 = "attribute.placeholder.value1"
         let mutableAttrString = NSMutableAttributedString(string: string, attributes: [attrKey1 : attrValue1])
 
         let replacement = "Sample replacement "
-        let replacementAttrKey = NSAttributedStringKey("attribute.replacement.key")
-        let replacementAttributes: [NSAttributedStringKey : Any] = [replacementAttrKey : "attribute.replacement.value"]
+        let replacementAttrKey = NSAttributedString.Key("attribute.replacement.key")
+        let replacementAttributes: [NSAttributedString.Key: Any] = [replacementAttrKey : "attribute.replacement.value"]
         
         let replacementAttrString = NSAttributedString(string: replacement, attributes: replacementAttributes)
         let replacementRange = NSRange(location: 0, length: replacementAttrString.length)
@@ -514,13 +514,13 @@ class TestNSMutableAttributedString : XCTestCase {
 
     func test_insert() {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        let attrKey1 = NSAttributedStringKey("attribute.placeholder.key1")
+        let attrKey1 = NSAttributedString.Key("attribute.placeholder.key1")
         let attrValue1 = "attribute.placeholder.value1"
         let mutableAttrString = NSMutableAttributedString(string: string, attributes: [attrKey1 : attrValue1])
 
         let insertString = "Sample insertion. "
-        let insertAttrKey = NSAttributedStringKey("attribute.insertion.key")
-        let insertAttributes: [NSAttributedStringKey : Any] = [insertAttrKey : "attribute.insertion.value"]
+        let insertAttrKey = NSAttributedString.Key("attribute.insertion.key")
+        let insertAttributes: [NSAttributedString.Key: Any] = [insertAttrKey : "attribute.insertion.value"]
         let insertAttrString = NSAttributedString(string: insertString, attributes: insertAttributes)
         
         mutableAttrString.insert(insertAttrString, at: 0)
@@ -528,24 +528,24 @@ class TestNSMutableAttributedString : XCTestCase {
         let expectedString = insertString + string
         XCTAssertEqual(mutableAttrString.string, expectedString)
         
-        let insertedAttributes = mutableAttrString.attributes(at: 0, effectiveRange: nil) as? [NSAttributedStringKey : String]
+        let insertedAttributes = mutableAttrString.attributes(at: 0, effectiveRange: nil) as? [NSAttributedString.Key: String]
         let expectedInserted = [insertAttrKey : "attribute.insertion.value"]
         XCTAssertEqual(insertedAttributes, expectedInserted)
         
-        let originalAttributes = mutableAttrString.attributes(at: insertAttrString.length, effectiveRange: nil) as? [NSAttributedStringKey : String]
+        let originalAttributes = mutableAttrString.attributes(at: insertAttrString.length, effectiveRange: nil) as? [NSAttributedString.Key: String]
         let expectedOriginal = [attrKey1 : attrValue1]
         XCTAssertEqual(originalAttributes, expectedOriginal)
     }
 
     func test_append() {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        let attrKey1 = NSAttributedStringKey("attribute.placeholder.key1")
+        let attrKey1 = NSAttributedString.Key("attribute.placeholder.key1")
         let attrValue1 = "attribute.placeholder.value1"
         let mutableAttrString = NSMutableAttributedString(string: string, attributes: [attrKey1 : attrValue1])
         
         let appendString = " Sample appending."
-        let appendAttrKey = NSAttributedStringKey("attribute.appending.key")
-        let appendAttributes : [NSAttributedStringKey : Any] = [appendAttrKey : "attribute.appending.value"]
+        let appendAttrKey = NSAttributedString.Key("attribute.appending.key")
+        let appendAttributes : [NSAttributedString.Key: Any] = [appendAttrKey : "attribute.appending.value"]
         let appendAttrString = NSAttributedString(string: appendString, attributes: appendAttributes)
         
         mutableAttrString.append(appendAttrString)
@@ -553,18 +553,18 @@ class TestNSMutableAttributedString : XCTestCase {
         let expectedString = string + appendString
         XCTAssertEqual(mutableAttrString.string, expectedString)
         
-        let originalAttributes = mutableAttrString.attributes(at: 0, effectiveRange: nil) as? [NSAttributedStringKey : String]
+        let originalAttributes = mutableAttrString.attributes(at: 0, effectiveRange: nil) as? [NSAttributedString.Key: String]
         let expectedOriginal = [attrKey1 : attrValue1]
         XCTAssertEqual(originalAttributes, expectedOriginal)
         
-        let appendedAttributes = mutableAttrString.attributes(at: string.utf16.count, effectiveRange: nil) as? [NSAttributedStringKey : String]
+        let appendedAttributes = mutableAttrString.attributes(at: string.utf16.count, effectiveRange: nil) as? [NSAttributedString.Key: String]
         let expectedAppended = [appendAttrKey : "attribute.appending.value"]
         XCTAssertEqual(appendedAttributes, expectedAppended)
     }
 
     func test_deleteCharacters() {
         let string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        let attrKey1 = NSAttributedStringKey("attribute.placeholder.key1")
+        let attrKey1 = NSAttributedString.Key("attribute.placeholder.key1")
         let attrValue1 = "attribute.placeholder.value1"
         let mutableAttrString = NSMutableAttributedString(string: string, attributes: [attrKey1 : attrValue1])
 
@@ -588,11 +588,11 @@ class TestNSMutableAttributedString : XCTestCase {
     
     func test_setAttributedString() {
         let string1 = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        let attributes1: [NSAttributedStringKey : Any] = [NSAttributedStringKey("attribute.placeholder.key1") : "attribute.placeholder.value1"]
+        let attributes1: [NSAttributedString.Key: Any] = [NSAttributedString.Key("attribute.placeholder.key1") : "attribute.placeholder.value1"]
         let mutableAttrString = NSMutableAttributedString(string: string1, attributes: attributes1)
         
         let string2 = "Sample set attributed string."
-        let attributes2: [NSAttributedStringKey : Any] = [NSAttributedStringKey("attribute.placeholder.key2") : "attribute.placeholder.value2"]
+        let attributes2: [NSAttributedString.Key: Any] = [NSAttributedString.Key("attribute.placeholder.key2") : "attribute.placeholder.value2"]
         let replacementAttrString = NSMutableAttributedString(string: string2, attributes: attributes2)
         
         mutableAttrString.setAttributedString(replacementAttrString)


### PR DESCRIPTION
- Also add an `@available()` deprecate the old name.

- Matches Darwin for Swift 5.0