### PR TITLE
NSPathUtilities: correct `isAbsolutePath` for Win32

### DIFF
--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -184,7 +184,13 @@ extension String {
 extension NSString {
     
     public var isAbsolutePath: Bool {
+#if os(Windows)
+        return self._swiftObject.withCString(encodedAs: UTF16.self) {
+          PathIsRelativeW($0) == FALSE
+        }
+#else
         return hasPrefix("~") || hasPrefix("/")
+#endif
     }
     
     public static func pathWithComponents(_ components: [String]) -> String {


### PR DESCRIPTION
Use the shlwapi API `PathIsRelative` to determine if the path is
absolute or not.