### PR TITLE
Decimal: NSDecimalNormalize() - avoid overflow/underflow on exponent difference

### DIFF
--- a/Foundation/Decimal.swift
+++ b/Foundation/Decimal.swift
@@ -1105,7 +1105,7 @@ public func NSDecimalRound(_ result: UnsafeMutablePointer<Decimal>, _ number: Un
 // scale indicates number of significant digits after the decimal point
 
 public func NSDecimalNormalize(_ a: UnsafeMutablePointer<Decimal>, _ b: UnsafeMutablePointer<Decimal>, _ roundingMode: NSDecimalNumber.RoundingMode) -> NSDecimalNumber.CalculationError {
-    var diffexp = a.pointee.__exponent - b.pointee.__exponent
+    var diffexp = Int(a.pointee.__exponent) - Int(b.pointee.__exponent)
     var result = Decimal()
 
     //
@@ -1142,7 +1142,7 @@ public func NSDecimalNormalize(_ a: UnsafeMutablePointer<Decimal>, _ b: UnsafeMu
     // Try to multiply aa to reach the same exponent level than bb
     //
 
-    if integerMultiplyByPowerOf10(&result, aa.pointee, Int(diffexp)) == .noError {
+    if integerMultiplyByPowerOf10(&result, aa.pointee, diffexp) == .noError {
         // Succeed. Adjust the length/exponent info
         // and return no errorNSDecimalNormalize
         aa.pointee.copyMantissa(from: result)
@@ -1165,10 +1165,10 @@ public func NSDecimalNormalize(_ a: UnsafeMutablePointer<Decimal>, _ b: UnsafeMu
     //
     // Divide bb by this value
     //
-    _ = integerMultiplyByPowerOf10(&result, bb.pointee, Int(maxpow10 - diffexp))
+    _ = integerMultiplyByPowerOf10(&result, bb.pointee, Int(maxpow10) - diffexp)
 
     bb.pointee.copyMantissa(from: result)
-    bb.pointee._exponent -= Int32(maxpow10 - diffexp);
+    bb.pointee._exponent -= (Int32(maxpow10) - Int32(diffexp))
 
     //
     // If bb > 0 multiply aa by the same value

--- a/TestFoundation/TestDecimal.swift
+++ b/TestFoundation/TestDecimal.swift
@@ -517,6 +517,27 @@ class TestDecimal: XCTestCase {
         XCTAssertEqual(Decimal(10), ten)
         XCTAssertEqual(1, one._length)
         XCTAssertEqual(1, ten._length)
+
+        // Check equality with numbers with large exponent difference
+        var small = Decimal.leastNonzeroMagnitude
+        var large = Decimal.greatestFiniteMagnitude
+        XCTAssertTrue(Int(large.exponent) - Int(small.exponent) > Int(Int8.max))
+        XCTAssertTrue(Int(small.exponent) - Int(large.exponent) < Int(Int8.min))
+        XCTAssertNotEqual(small, large)
+
+        XCTAssertEqual(small.exponent, -127)
+        XCTAssertEqual(large.exponent, 127)
+        XCTAssertEqual(.lossOfPrecision, NSDecimalNormalize(&small, &large, .plain))
+        XCTAssertEqual(small.exponent, 127)
+        XCTAssertEqual(large.exponent, 127)
+
+        small = Decimal.leastNonzeroMagnitude
+        large = Decimal.greatestFiniteMagnitude
+        XCTAssertEqual(small.exponent, -127)
+        XCTAssertEqual(large.exponent, 127)
+        XCTAssertEqual(.lossOfPrecision, NSDecimalNormalize(&large, &small, .plain))
+        XCTAssertEqual(small.exponent, 127)
+        XCTAssertEqual(large.exponent, 127)
     }
 
     func test_NSDecimal() throws {


### PR DESCRIPTION
- The difference of the expoents could exceed Int8.min / Int8.max, so
  convert to Int first.

- This avoids a crash if comparing numbers with a large exponent
  difference.