### PR TITLE
FileHandle: create invalid handle properly on Windows

### DIFF
--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -740,7 +740,11 @@ extension FileHandle {
             deinit {}
         }
 
+#if os(Windows)
+        return NullDevice(handle: INVALID_HANDLE_VALUE, closeOnDealloc: false)
+#else
         return NullDevice(fileDescriptor: -1, closeOnDealloc: false)
+#endif
     }()
 
     open class var nullDevice: FileHandle {


### PR DESCRIPTION
Use the FileHandle(handle:closeOnDealloc:) initializer rather than
passing the fd as `-1` which causes a failure in the C runtime due to an
invalid fd being passed to `_get_ofshandle`.