### PR TITLE
Decimal: Enable bridging between Decimal / NSDecimalNumber for Codable fix.

### DIFF
--- a/Foundation/Decimal.swift
+++ b/Foundation/Decimal.swift
@@ -397,6 +397,30 @@ extension Decimal : SignedNumeric {
     }
 }
 
+
+extension Decimal: _ObjectiveCBridgeable {
+    public func _bridgeToObjectiveC() -> NSDecimalNumber {
+        return NSDecimalNumber(decimal: self)
+    }
+
+    public static func _forceBridgeFromObjectiveC(_ x: NSDecimalNumber, result: inout Decimal?) {
+        result = _unconditionallyBridgeFromObjectiveC(x)
+    }
+
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSDecimalNumber, result: inout Decimal?) -> Bool {
+        result = x.decimalValue
+        return true
+    }
+
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSDecimalNumber?) -> Decimal {
+        var result: Decimal?
+        guard let src = source else { return Decimal(0) }
+        guard _conditionallyBridgeFromObjectiveC(src, result: &result) else { return Decimal(0) }
+        return result!
+    }
+}
+
+
 extension Decimal {
     @available(swift, obsoleted: 4, message: "Please use arithmetic operators instead")
     @_transparent

--- a/Foundation/JSONEncoder.swift
+++ b/Foundation/JSONEncoder.swift
@@ -818,10 +818,8 @@ extension _JSONEncoder {
             // Encode URLs as single strings.
             return self.box((value as! URL).absoluteString)
         } else if T.self == Decimal.self {
-            // On Darwin we get ((value as! Decimal) as NSDecimalNumber) since JSONSerialization can consume NSDecimalNumber values.
-            // FIXME: Attempt to create a Decimal value if JSONSerialization on Linux consume one.
-            let doubleValue = (value as! Decimal).doubleValue
-            return try self.box(doubleValue)
+            // JSONSerialization can consume NSDecimalNumber values.
+            return NSDecimalNumber(decimal: value as! Decimal)
         }
         
         #else
@@ -835,10 +833,8 @@ extension _JSONEncoder {
             // Encode URLs as single strings.
             return self.box((value as! URL).absoluteString)
         } else if T.self == Decimal.self {
-            // On Darwin we get ((value as! Decimal) as NSDecimalNumber) since JSONSerialization can consume NSDecimalNumber values.
-            // FIXME: Attempt to create a Decimal value if JSONSerialization on Linux consume one.
-            let doubleValue = (value as! Decimal).doubleValue
-            return try self.box(doubleValue)
+            // JSONSerialization can consume NSDecimalNumber values.
+            return NSDecimalNumber(decimal: value as! Decimal)
         }
         #endif
         
@@ -2368,13 +2364,6 @@ extension _JSONDecoder {
     fileprivate func unbox(_ value: Any, as type: Decimal.Type) throws -> Decimal? {
         guard !(value is NSNull) else { return nil }
 
-        #if DEPLOYMENT_RUNTIME_SWIFT
-        // Bridging differences require us to split implementations here
-        // On Darwin we get (value as? Decimal) since JSONSerialization can produce NSDecimalNumber values.
-        // FIXME: Attempt to grab a Decimal value if JSONSerialization on Linux produces one.
-        let doubleValue = try self.unbox(value, as: Double.self)!
-        return Decimal(doubleValue)
-        #else
         // Attempt to bridge from NSDecimalNumber.
         if let decimal = value as? Decimal {
             return decimal
@@ -2382,7 +2371,6 @@ extension _JSONDecoder {
             let doubleValue = try self.unbox(value, as: Double.self)!
             return Decimal(doubleValue)
         }
-        #endif
     }
 
     fileprivate func unbox<T : Decodable>(_ value: Any, as type: T.Type) throws -> T? {

--- a/TestFoundation/TestCodable.swift
+++ b/TestFoundation/TestCodable.swift
@@ -121,7 +121,8 @@ class TestCodable : XCTestCase {
     func test_URL_JSON() {
         for url in urlValues {
             do {
-                try expectRoundTripEqualityThroughJSON(for: url)
+                // Wrap in an array as URL is not a top-level type.
+                try expectRoundTripEqualityThroughJSON(for: [url.absoluteURL])
             } catch {
                 XCTFail("\(error) for \(url)")
             }
@@ -243,7 +244,8 @@ class TestCodable : XCTestCase {
     func test_Decimal_JSON() {
         for decimal in decimalValues {
             do {
-                try expectRoundTripEqualityThroughJSON(for: decimal)
+                // Wrap in an array as Decimal is not a top-level type.
+                try expectRoundTripEqualityThroughJSON(for: [decimal])
             } catch {
                 XCTFail("\(error) for \(decimal)")
             }
@@ -560,13 +562,13 @@ extension TestCodable {
         return [
             ("test_PersonNameComponents_JSON", test_PersonNameComponents_JSON),
             ("test_UUID_JSON", test_UUID_JSON),
-           // ("test_URL_JSON", test_URL_JSON),
+            ("test_URL_JSON", test_URL_JSON),
             ("test_NSRange_JSON", test_NSRange_JSON),
             ("test_Locale_JSON", test_Locale_JSON),
             ("test_IndexSet_JSON", test_IndexSet_JSON),
             ("test_IndexPath_JSON", test_IndexPath_JSON),
             ("test_AffineTransform_JSON", test_AffineTransform_JSON),
-            //("test_Decimal_JSON", test_Decimal_JSON),
+            ("test_Decimal_JSON", test_Decimal_JSON),
             ("test_CGPoint_JSON", test_CGPoint_JSON),
             ("test_CGSize_JSON", test_CGSize_JSON),
             ("test_CGRect_JSON", test_CGRect_JSON),

--- a/TestFoundation/TestDecimal.swift
+++ b/TestFoundation/TestDecimal.swift
@@ -33,6 +33,7 @@ class TestDecimal: XCTestCase {
             ("test_ZeroPower", test_ZeroPower),
             ("test_doubleValue", test_doubleValue),
             ("test_NSDecimalNumberValues", test_NSDecimalNumberValues),
+            ("test_bridging", test_bridging),
         ]
     }
 
@@ -1035,5 +1036,20 @@ class TestDecimal: XCTestCase {
         XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt16.max)).uint64Value, 65535)
         XCTAssertEqual(NSDecimalNumber(decimal: Decimal(UInt32.max)).uint64Value, 4294967295)
         XCTAssertEqual(NSDecimalNumber(decimal: uint64MaxDecimal).uint64Value, UInt64.max)
+    }
+
+    func test_bridging() {
+        let d1 = Decimal(1)
+        let nsd1 = d1 as NSDecimalNumber
+        XCTAssertEqual(nsd1 as Decimal, d1)
+
+        let d2 = nsd1 as Decimal
+        XCTAssertEqual(d1, d2)
+
+        let ns = d1 as NSNumber
+        XCTAssertTrue(type(of: ns) == NSDecimalNumber.self)
+
+        // NSNumber does NOT bridge to Decimal
+        XCTAssertNil(NSNumber(value: 1) as? Decimal)
     }
 }

--- a/TestFoundation/TestJSONEncoder.swift
+++ b/TestFoundation/TestJSONEncoder.swift
@@ -456,11 +456,15 @@ class TestJSONEncoder : XCTestCase {
     }
 
     func test_codingOfFloat() {
-        test_codingOf(value: Double(1.5), toAndFrom: "1.5")
+        test_codingOf(value: Float(1.5), toAndFrom: "1.5")
     }
 
     func test_codingOfDouble() {
-        test_codingOf(value: Float(1.5), toAndFrom: "1.5")
+        test_codingOf(value: Double(1.5), toAndFrom: "1.5")
+    }
+
+    func test_codingOfDecimal() {
+        test_codingOf(value: Decimal.pi, toAndFrom: "3.14159265358979323846264338327950288419")
     }
 
     func test_codingOfString() {
@@ -1266,6 +1270,7 @@ extension TestJSONEncoder {
             ("test_codingOfUIntMinMax", test_codingOfUIntMinMax),
             ("test_codingOfFloat", test_codingOfFloat),
             ("test_codingOfDouble", test_codingOfDouble),
+            ("test_codingOfDecimal", test_codingOfDecimal),
             ("test_codingOfString", test_codingOfString),
             ("test_codingOfURL", test_codingOfURL),
             ("test_numericLimits", test_numericLimits),


### PR DESCRIPTION
- Decoding Decimal was going via Double / NSNumber but this loses
  information for numbers with lots of digits that cant be represented
  by Double but can be by Decimal.

- TestCodable.swift: Re-enable some tests that were broken due to
  trying to JSON encode non-toplevel types.  Wrap them in an array
  to satisfy the requirement.