### PR TITLE
[4.2] Fix a bug in format localized number on s390x and ARM

### DIFF
--- a/CoreFoundation/String.subproj/CFString.c
+++ b/CoreFoundation/String.subproj/CFString.c
@@ -6009,7 +6009,7 @@ static Boolean __CFStringFormatLocalizedNumber(CFMutableStringRef output, CFLoca
     static SInt32 secondaryGroupingSize = 0;
     
     // !!! This code should be removed before shipping
-    static char disableLocalizedFormatting = -1;
+    static int disableLocalizedFormatting = -1;
     if (disableLocalizedFormatting == -1) disableLocalizedFormatting = (getenv("CFStringDisableLocalizedNumberFormatting") != NULL) ? 1 : 0;
     if (disableLocalizedFormatting) return false;
 


### PR DESCRIPTION
(cherry picked from commit f9f75d25acd91741b9833c4697b8a47fcecad457)

This should fix the issue that broke #1929 on ARM