### PR TITLE
Avoid FP arithmetic if unnecessary in CGRect.intersection(_:)

### DIFF
--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -347,7 +347,7 @@ extension CGRect {
         let height: CGFloat
         if overlapV == rect1SpanV {
             height = rect1.height
-        } else if overlapH == rect2SpanH {
+        } else if overlapV == rect2SpanV {
             height = rect2.height
         } else {
             height = overlapV.upperBound - overlapV.lowerBound

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -335,10 +335,28 @@ extension CGRect {
         let overlapH = rect1SpanH.clamped(to: rect2SpanH)
         let overlapV = rect1SpanV.clamped(to: rect2SpanV)
 
+        let width: CGFloat
+        if overlapH == rect1SpanH {
+            width = rect1.width
+        } else if overlapH == rect2SpanH {
+            width = rect2.width
+        } else {
+            width = overlapH.upperBound - overlapH.lowerBound
+        }
+
+        let height: CGFloat
+        if overlapV == rect1SpanV {
+            height = rect1.height
+        } else if overlapH == rect2SpanH {
+            height = rect2.height
+        } else {
+            height = overlapV.upperBound - overlapV.lowerBound
+        }
+
         return CGRect(x: overlapH.lowerBound,
                       y: overlapV.lowerBound,
-                      width: overlapH.upperBound - overlapH.lowerBound,
-                      height: overlapV.upperBound - overlapV.lowerBound)
+                      width: width,
+                      height: height)
     }
 
     public func intersects(_ r2: CGRect) -> Bool {

--- a/TestFoundation/TestNSGeometry.swift
+++ b/TestFoundation/TestNSGeometry.swift
@@ -653,6 +653,13 @@ class TestNSGeometry : XCTestCase {
         XCTAssertEqual(i9.origin.y, 0)
         XCTAssertEqual(i9.size.width, 0)
         XCTAssertEqual(i9.size.height, 0)
+
+        let r8 = CGRect(x: 10.33333333333333333, y: 0, width: 10, height: 10)
+        let i10 = CGRect.infinite.intersection(r8)
+        XCTAssertEqual(r8.origin.x, i10.origin.x)
+        XCTAssertEqual(r8.origin.y, i10.origin.y)
+        XCTAssertEqual(r8.size.width, i10.size.width)
+        XCTAssertEqual(r8.size.height, i10.size.height)
     }
 
     func test_CGRect_Intersects() {


### PR DESCRIPTION
See [SR-10056](https://bugs.swift.org/browse/SR-10056) for a summary of this issue with example. The floating point arithmetic in `CGRect.intersection(_:)` results in a rectangle not equal to its intersection with `CGRect.infinity`.