### PR TITLE
RunLoop: remove incorrect usage of libdispatch queue

### DIFF
--- a/CoreFoundation/RunLoop.subproj/CFRunLoop.c
+++ b/CoreFoundation/RunLoop.subproj/CFRunLoop.c
@@ -101,13 +101,12 @@ extern mach_port_t _dispatch_get_main_queue_port_4CF(void);
 #elif TARGET_OS_WIN32 || TARGET_OS_CYGWIN
 #include <process.h>
 DISPATCH_EXPORT HANDLE _dispatch_get_main_queue_handle_4CF(void);
-DISPATCH_EXPORT void _dispatch_main_queue_callback_4CF(void);
+DISPATCH_EXPORT void _dispatch_main_queue_callback_4CF(void * _Null_unspecified);
 
 #define MACH_PORT_NULL 0
 #define mach_port_name_t HANDLE
 #define mach_port_t HANDLE
 #define _dispatch_get_main_queue_port_4CF _dispatch_get_main_queue_handle_4CF
-#define _dispatch_main_queue_callback_4CF(x) _dispatch_main_queue_callback_4CF()
 
 #elif DEPLOYMENT_TARGET_LINUX
 
@@ -121,7 +120,6 @@ dispatch_runloop_handle_t _dispatch_get_main_queue_handle_4CF(void);
 extern void _dispatch_main_queue_callback_4CF(void *_Null_unspecified msg);
 
 #define _dispatch_get_main_queue_port_4CF _dispatch_get_main_queue_handle_4CF
-#define _dispatch_main_queue_callback_4CF(x) _dispatch_main_queue_callback_4CF(x)
 #endif
 
 #if DEPLOYMENT_TARGET_WINDOWS || DEPLOYMENT_TARGET_LINUX


### PR DESCRIPTION
This has the wrong signature and is available directly.  Just use it
rather than create a macro.