### PR TITLE
[4.2] SR-8078: Some time zone identifiers are not supported by TimeZone on Linux

### DIFF
--- a/CoreFoundation/NumberDate.subproj/CFTimeZone.c
+++ b/CoreFoundation/NumberDate.subproj/CFTimeZone.c
@@ -891,6 +891,7 @@ void CFTimeZoneSetDefault(CFTimeZoneRef tz) {
 }
 
 static CFDictionaryRef __CFTimeZoneCopyCompatibilityDictionary(void);
+static Boolean __nameStringOK(CFStringRef name);
 
 CFArrayRef CFTimeZoneCopyKnownNames(void) {
     CFArrayRef tzs;
@@ -906,7 +907,7 @@ CFArrayRef CFTimeZoneCopyKnownNames(void) {
 	CFIndex idx;
 	for (idx = CFArrayGetCount(list); idx--; ) {
 	    CFStringRef item = (CFStringRef)CFArrayGetValueAtIndex(list, idx);
-	    if (CFDictionaryContainsKey(dict, item)) {
+	    if (CFDictionaryContainsKey(dict, item) || !__nameStringOK(item)) {
 		CFArrayRemoveValueAtIndex(list, idx);
 	    }
 	}

--- a/TestFoundation/TestTimeZone.swift
+++ b/TestFoundation/TestTimeZone.swift
@@ -28,6 +28,7 @@ class TestTimeZone: XCTestCase {
             // ("test_systemTimeZoneUsesSystemTime", test_systemTimeZoneUsesSystemTime),
 
             ("test_customMirror", test_tz_customMirror),
+            ("test_knownTimeZones", test_knownTimeZones),
         ]
     }
 
@@ -188,5 +189,13 @@ class TestTimeZone: XCTestCase {
         XCTAssertNotNil(children["kind"])
         XCTAssertNotNil(children["secondsFromGMT"])
         XCTAssertNotNil(children["isDaylightSavingTime"])
+    }
+
+    func test_knownTimeZones() {
+        let timeZones = TimeZone.knownTimeZoneIdentifiers.sorted()
+        XCTAssertTrue(timeZones.count > 0, "No known timezones")
+        for tz in timeZones {
+            XCTAssertNotNil(TimeZone(identifier: tz), "Cant instantiate valid timeZone: \(tz)")
+        }
     }
 }


### PR DESCRIPTION
- TimeZone.knownTimeZoneIdentifiers was returning time zone names
  that could not be instantiated by TimeZone(identifier:) due to
  CFTimeZone.c:__nameStringOK() filtering out some names.

- Make CFTimeZoneCopyKnownNames(), used by .knownTimeZoneIdentifiers,
  also filter these names using __nameStringOK().

- __nameStringOK calls ICU function ucal_getCanonicalTimeZoneID
  which ultimately decides if the time zone is valid.

(cherry picked from commit 7972ce4bd18b2b42bfa42bcbbbe76855ebf5cba5)