### PR TITLE
TestFoundation: give preference to SwiftFoundation, SwiftXCTest

### DIFF
--- a/TestFoundation/TestDateIntervalFormatter.swift
+++ b/TestFoundation/TestDateIntervalFormatter.swift
@@ -8,10 +8,10 @@
 //
 
 #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
-    #if (os(Linux) || os(Android))
-        @testable import Foundation
-    #else
+    #if canImport(SwiftFoundation) && !DEPLOYMENT_RUNTIME_OBJC
         @testable import SwiftFoundation
+    #else
+        @testable import Foundation
     #endif
 #endif
 

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -8,10 +8,10 @@
 //
 
 #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
-    #if (os(Linux) || os(Android))
-        @testable import Foundation
-    #else
+    #if canImport(SwiftFoundation) && !DEPLOYMENT_RUNTIME_OBJC
         @testable import SwiftFoundation
+    #else
+        @testable import Foundation
     #endif
 #endif
 

--- a/TestFoundation/TestImports.swift
+++ b/TestFoundation/TestImports.swift
@@ -9,10 +9,10 @@
 
 // Centralized conditional imports for all test sources
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux) || os(Android)
-@_exported import Foundation
-@_exported import XCTest
-#else
+#if !DEPLOYMENT_RUNTIME_OBJC && canImport(SwiftFoundation) && canImport(SwiftXCTest)
 @_exported import SwiftFoundation
 @_exported import SwiftXCTest
+#else
+@_exported import Foundation
+@_exported import XCTest
 #endif

--- a/TestFoundation/TestStream.swift
+++ b/TestFoundation/TestStream.swift
@@ -7,12 +7,10 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
-    #if canImport(SwiftFoundation)
-        @testable import SwiftFoundation
-    #else
-        @testable import Foundation
-    #endif
+#if canImport(SwiftFoundation) && !DEPLOYMENT_RUNTIME_OBJC
+    @testable import SwiftFoundation
+#else
+    @testable import Foundation
 #endif
 
 

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -7,10 +7,10 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux) || os(Android)
-import Foundation
-#else
+#if canImport(SwiftFoundation) && !DEPLOYMENT_RUNTIME_OBJC
 import SwiftFoundation
+#else
+import Foundation
 #endif
 
 enum HelperCheckStatus : Int32 {


### PR DESCRIPTION
Alter the importing to use `canImport` and prefer the Swift prefixed
variants of the modules.  This avoids us from maintaining an ever
growing list of OSes, particularly when the Swift variants are less
widely available.