### PR TITLE
StringsEncoding: correct bitmap loading

### DIFF
--- a/CoreFoundation/StringEncodings.subproj/CFUniChar.c
+++ b/CoreFoundation/StringEncodings.subproj/CFUniChar.c
@@ -42,7 +42,7 @@ extern void _CFGetFrameworkPath(wchar_t *path, int maxLength);
 
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED
 #define USE_MACHO_SEGMENT 1
-#elif DEPLOYMENT_RUNTIME_SWIFT && (DEPLOYMENT_TARGET_LINUX || DEPLOYMENT_TARGET_FREEBSD)
+#elif DEPLOYMENT_RUNTIME_SWIFT && (DEPLOYMENT_TARGET_LINUX || DEPLOYMENT_TARGET_FREEBSD || DEPLOYMENT_TARGET_WINDOWS)
 #define USE_RAW_SYMBOL 1
 #endif
 
@@ -301,46 +301,38 @@ static bool __CFUniCharLoadBytesFromFile(const wchar_t *fileName, const void **b
 #else
 #error Unknown or unspecified DEPLOYMENT_TARGET
 #endif
-    
+
+#if __CF_BIG_ENDIAN__
+#define CF_UNICODE_DATA_SYM __CFUnicodeDataB
+#else
+#define CF_UNICODE_DATA_SYM __CFUnicodeDataL
+#endif
+
 #if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI || DEPLOYMENT_TARGET_LINUX || DEPLOYMENT_TARGET_FREEBSD
 static bool __CFUniCharLoadFile(const char *bitmapName, const void **bytes, int64_t *fileSize) {
-#elif DEPLOYMENT_TARGET_WINDOWS
-static bool __CFUniCharLoadFile(const wchar_t *bitmapName, const void **bytes, int64_t *fileSize) {
-#else
-#error Unknown or unspecified DEPLOYMENT_TARGET
-#endif
 #if USE_MACHO_SEGMENT
-	*bytes = __CFGetSectDataPtr("__UNICODE", bitmapName, NULL);
+    *bytes = __CFGetSectDataPtr("__UNICODE", bitmapName, NULL);
 
     if (NULL != fileSize) *fileSize = 0;
 
     return *bytes ? true : false;
 #elif USE_RAW_SYMBOL
     extern void *__CFCharacterSetBitmapData;
-#if __CF_BIG_ENDIAN__
-    extern void *__CFUnicodeDataB;
-#else
-    extern void *__CFUnicodeDataL;
-#endif
+    extern void *CF_UNICODE_DATA_SYM;
     extern void *__CFUniCharPropertyDatabase;
-    
+
     if (strcmp(bitmapName, CF_UNICHAR_BITMAP_FILE) == 0) {
         *bytes = &__CFCharacterSetBitmapData;
     } else if (strcmp(bitmapName, MAPPING_TABLE_FILE) == 0) {
-#if __CF_BIG_ENDIAN__
-        *bytes = &__CFUnicodeDataB;
-#else
-        *bytes = &__CFUnicodeDataL;
-#endif
+        *bytes = &CF_UNICODE_DATA_SYM;
     } else if (strcmp(bitmapName, PROP_DB_FILE) == 0) {
         *bytes = &__CFUniCharPropertyDatabase;
     }
-    
+
     if (NULL != fileSize) *fileSize = 0;
-    
+
     return *bytes ? true : false;
 #else
-#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI || DEPLOYMENT_TARGET_LINUX || DEPLOYMENT_TARGET_FREEBSD
     char cpath[MAXPATHLEN];
     __CFUniCharCharacterSetPath(cpath);
     strlcat(cpath, bitmapName, MAXPATHLEN);
@@ -349,16 +341,36 @@ static bool __CFUniCharLoadFile(const wchar_t *bitmapName, const void **bytes, i
     bool result = __CFUniCharLoadBytesFromFile(possiblyFrameworkRootedCPath, bytes, fileSize);
     if (needToFree) free((void *)possiblyFrameworkRootedCPath);
     return result;
+#endif
+}
 #elif DEPLOYMENT_TARGET_WINDOWS
+static bool __CFUniCharLoadFile(const wchar_t *bitmapName, const void **bytes, int64_t *fileSize) {
+#if USE_RAW_SYMBOL
+    extern void *__CFCharacterSetBitmapData;
+    extern void *CF_UNICODE_DATA_SYM;
+    extern void *__CFUniCharPropertyDatabase;
+
+    if (wcscmp(bitmapName, CF_UNICHAR_BITMAP_FILE) == 0) {
+        *bytes = &__CFCharacterSetBitmapData;
+    } else if (wcscmp(bitmapName, MAPPING_TABLE_FILE) == 0) {
+        *bytes = &CF_UNICODE_DATA_SYM;
+    } else if (wcscmp(bitmapName, PROP_DB_FILE) == 0) {
+        *bytes = &__CFUniCharPropertyDatabase;
+    }
+
+    if (NULL != fileSize) *fileSize = 0;
+
+    return *bytes ? true : false;
+#else
     wchar_t wpath[MAXPATHLEN];
     __CFUniCharCharacterSetPath(wpath);
     wcsncat(wpath, bitmapName, MAXPATHLEN);
     return __CFUniCharLoadBytesFromFile(wpath, bytes, fileSize);
+#endif
+}
 #else
 #error Unknown or unspecified DEPLOYMENT_TARGET
 #endif
-#endif
-}
 
 // Bitmap functions
 /*


### PR DESCRIPTION
This fixes the bitmap loading on Windows.  Windows uses the "Unicode"
(UTF-16) file paths as that is the native representation.  However, we
were using `strcmp` which would not yield the correct check.  This
allows us to load the bitmap data on Windows as well.