### PR TITLE
TestFoundation: tm_zone does not exist on Windows

### DIFF
--- a/TestFoundation/TestTimeZone.swift
+++ b/TestFoundation/TestTimeZone.swift
@@ -12,7 +12,7 @@ import CoreFoundation
 class TestTimeZone: XCTestCase {
 
     static var allTests: [(String, (TestTimeZone) -> () throws -> Void)] {
-        return [
+        var tests: [(String, (TestTimeZone) -> () throws -> Void)] = [
             ("test_abbreviation", test_abbreviation),
 
             // Disabled because `CFTimeZoneSetAbbreviationDictionary()` attempts
@@ -25,11 +25,18 @@ class TestTimeZone: XCTestCase {
             ("test_initializingTimeZoneWithOffset", test_initializingTimeZoneWithOffset),
             ("test_initializingTimeZoneWithAbbreviation", test_initializingTimeZoneWithAbbreviation),
             ("test_localizedName", test_localizedName),
-            ("test_systemTimeZoneUsesSystemTime", test_systemTimeZoneUsesSystemTime),
             ("test_customMirror", test_tz_customMirror),
             ("test_knownTimeZones", test_knownTimeZones),
             ("test_systemTimeZoneName", test_systemTimeZoneName),
         ]
+
+#if !os(Windows)
+      tests.append(contentsOf: [
+            ("test_systemTimeZoneUsesSystemTime", test_systemTimeZoneUsesSystemTime),
+      ])
+#endif
+
+        return tests
     }
 
     func test_abbreviation() {
@@ -165,6 +172,7 @@ class TestTimeZone: XCTestCase {
         XCTAssertEqual(actualIdentifier, expectedIdentifier, "expected identifier \"\(expectedIdentifier)\" is not equal to \"\(actualIdentifier as Optional)\"")
     }
 
+#if !os(Windows)
     func test_systemTimeZoneUsesSystemTime() {
         tzset()
         var t = time(nil)
@@ -174,6 +182,7 @@ class TestTimeZone: XCTestCase {
         let expectedName = String(cString: lt.tm_zone, encoding: .ascii) ?? "Invalid Zone"
         XCTAssertEqual(zoneName, expectedName, "expected name \"\(expectedName)\" is not equal to \"\(zoneName)\"")
     }
+#endif
 
     func test_tz_customMirror() {
         let tz = TimeZone.current


### PR DESCRIPTION
There is no equivalent for tm_zone on Windows.  Simply ignore the test.