### PR TITLE
FileManager: `GetFileAttributesExW` returns `FALSE` on failure

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -857,9 +857,9 @@ open class FileManager : NSObject {
       var faAttributes: WIN32_FILE_ATTRIBUTE_DATA = WIN32_FILE_ATTRIBUTE_DATA()
       return try path.withCString(encodedAs: UTF16.self) {
         if GetFileAttributesExW($0, GetFileExInfoStandard, &faAttributes) == FALSE {
-          return faAttributes
+          throw _NSErrorWithWindowsError(GetLastError(), reading: true)
         }
-        throw _NSErrorWithWindowsError(GetLastError(), reading: true)
+        return faAttributes
       }
     }
 #endif


### PR DESCRIPTION
As per the MSDN documentation, `GetFileAttributesExW` returns a non-zero
value on success.  Correct the boolean logic here.