### PR TITLE
[SR-10374] URLCache: init method and first time sqlite database setup implemented

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		15FF00CC22934AD7004AD205 /* libCFURLSessionInterface.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 15FF00CA229348F2004AD205 /* libCFURLSessionInterface.a */; };
 		15FF00CE22934B78004AD205 /* module.map in Headers */ = {isa = PBXBuildFile; fileRef = 15FF00CD22934B49004AD205 /* module.map */; settings = {ATTRIBUTES = (Public, ); }; };
 		231503DB1D8AEE5D0061694D /* TestDecimal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231503DA1D8AEE5D0061694D /* TestDecimal.swift */; };
+		25EB1806223334D30053EE59 /* TestURLCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25EB1805223334D30053EE59 /* TestURLCache.swift */; };
 		294E3C1D1CC5E19300E4F44C /* TestNSAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 294E3C1C1CC5E19300E4F44C /* TestNSAttributedString.swift */; };
 		2EBE67A51C77BF0E006583D5 /* TestDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EBE67A31C77BF05006583D5 /* TestDateFormatter.swift */; };
 		3E55A2331F52463B00082000 /* TestUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E55A2321F52463B00082000 /* TestUnit.swift */; };
@@ -646,6 +647,7 @@
 		15FF00CD22934B49004AD205 /* module.map */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; name = module.map; path = CoreFoundation/URL.subproj/module.map; sourceTree = SOURCE_ROOT; };
 		22B9C1E01C165D7A00DECFF9 /* TestDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDate.swift; sourceTree = "<group>"; };
 		231503DA1D8AEE5D0061694D /* TestDecimal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDecimal.swift; sourceTree = "<group>"; };
+		25EB1805223334D30053EE59 /* TestURLCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestURLCache.swift; sourceTree = "<group>"; };
 		294E3C1C1CC5E19300E4F44C /* TestNSAttributedString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSAttributedString.swift; sourceTree = "<group>"; };
 		2EBE67A31C77BF05006583D5 /* TestDateFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDateFormatter.swift; sourceTree = "<group>"; };
 		3E55A2321F52463B00082000 /* TestUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUnit.swift; sourceTree = "<group>"; };
@@ -1777,6 +1779,7 @@
 				03B6F5831F15F339004F25AF /* TestURLProtocol.swift */,
 				3E55A2321F52463B00082000 /* TestUnit.swift */,
 				7D8BD738225ED1480057CF37 /* TestMeasurement.swift */,
+				25EB1805223334D30053EE59 /* TestURLCache.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -2834,6 +2837,7 @@
 				5B13B33E1C582D4C00651CE2 /* TestProcessInfo.swift in Sources */,
 				5B13B33F1C582D4C00651CE2 /* TestPropertyListSerialization.swift in Sources */,
 				5B13B32C1C582D4C00651CE2 /* TestDate.swift in Sources */,
+				25EB1806223334D30053EE59 /* TestURLCache.swift in Sources */,
 				C7DE1FCC21EEE67200174F35 /* TestUUID.swift in Sources */,
 				231503DB1D8AEE5D0061694D /* TestDecimal.swift in Sources */,
 				7900433C1CACD33E00ECCBF1 /* TestNSPredicate.swift in Sources */,

--- a/Foundation/URLCache.swift
+++ b/Foundation/URLCache.swift
@@ -12,6 +12,7 @@ import SwiftFoundation
 #else
 import Foundation
 #endif
+import SQLite3
 
 /*!
     @enum URLCache.StoragePolicy
@@ -128,6 +129,26 @@ open class CachedURLResponse : NSObject, NSSecureCoding, NSCopying {
 
 open class URLCache : NSObject {
     
+    private static let sharedSyncQ = DispatchQueue(label: "org.swift.URLCache.sharedSyncQ")
+    
+    private static var sharedCache: URLCache? {
+        willSet {
+            URLCache.sharedCache?.syncQ.sync {
+                URLCache.sharedCache?._databaseClient?.close()
+                URLCache.sharedCache?.flushDatabase()
+            }
+        }
+        didSet {
+            URLCache.sharedCache?.syncQ.sync {
+                URLCache.sharedCache?.setupCacheDatabaseIfNotExist()
+            }
+        }
+    }
+    
+    private let syncQ = DispatchQueue(label: "org.swift.URLCache.syncQ")
+    private let _baseDiskPath: String?
+    private var _databaseClient: _CacheSQLiteClient?
+    
     /*! 
         @method sharedURLCache
         @abstract Returns the shared URLCache instance.
@@ -147,10 +168,22 @@ open class URLCache : NSObject {
     */
     open class var shared: URLCache {
         get {
-            NSUnimplemented()
+            return sharedSyncQ.sync {
+                if let cache = sharedCache {
+                    return cache
+                } else {
+                    let fourMegaByte = 4 * 1024 * 1024
+                    let twentyMegaByte = 20 * 1024 * 1024
+                    let cacheDirectoryPath = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?.path ?? "\(NSHomeDirectory())/Library/Caches/"
+                    let path = "\(cacheDirectoryPath)\(Bundle.main.bundleIdentifier ?? UUID().uuidString)"
+                    let cache = URLCache(memoryCapacity: fourMegaByte, diskCapacity: twentyMegaByte, diskPath: path)
+                    sharedCache = cache
+                    return cache
+                }
+            }
         }
         set {
-            NSUnimplemented()
+            sharedSyncQ.sync { sharedCache = newValue }
         }
     }
 
@@ -167,7 +200,13 @@ open class URLCache : NSObject {
         @result an initialized URLCache, with the given capacity, backed
         by disk.
     */
-    public init(memoryCapacity: Int, diskCapacity: Int, diskPath path: String?) { NSUnimplemented() }
+    public init(memoryCapacity: Int, diskCapacity: Int, diskPath path: String?) {
+        self.memoryCapacity = memoryCapacity
+        self.diskCapacity = diskCapacity
+        self._baseDiskPath = path
+        
+        super.init()
+    }
     
     /*! 
         @method cachedResponseForRequest:
@@ -249,10 +288,132 @@ open class URLCache : NSObject {
         @result the current usage of the on-disk cache of the receiver.
     */
     open var currentDiskUsage: Int { NSUnimplemented() }
+    
+    private func flushDatabase() {
+        guard let path = _baseDiskPath else { return }
+        
+        do {
+            let dbPath = path.appending("/Cache.db")
+            try FileManager.default.removeItem(atPath: dbPath)
+        } catch {
+            fatalError("Unable to flush database for URLCache: \(error.localizedDescription)")
+        }
+    }
+    
 }
 
 extension URLCache {
     public func storeCachedResponse(_ cachedResponse: CachedURLResponse, for dataTask: URLSessionDataTask) { NSUnimplemented() }
     public func getCachedResponse(for dataTask: URLSessionDataTask, completionHandler: (CachedURLResponse?) -> Void) { NSUnimplemented() }
     public func removeCachedResponse(for dataTask: URLSessionDataTask) { NSUnimplemented() }
+}
+
+extension URLCache {
+    
+    private func setupCacheDatabaseIfNotExist() {
+        guard let path = _baseDiskPath else { return }
+        
+        if !FileManager.default.fileExists(atPath: path) {
+            do {
+                try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+            } catch {
+                fatalError("Unable to create directories for URLCache: \(error.localizedDescription)")
+            }
+        }
+        
+        // Close the currently opened database connection(if any), before creating/replacing the db file
+        _databaseClient?.close()
+        
+        let dbPath = path.appending("/Cache.db")
+        if !FileManager.default.createFile(atPath: dbPath, contents: nil, attributes: nil) {
+            fatalError("Unable to setup database for URLCache")
+        }
+        
+        _databaseClient = _CacheSQLiteClient(databasePath: dbPath)
+        if _databaseClient == nil {
+            _databaseClient?.close()
+            flushDatabase()
+            fatalError("Unable to setup database for URLCache")
+        }
+        
+        if !createTables() {
+            _databaseClient?.close()
+            flushDatabase()
+            fatalError("Unable to setup database for URLCache: Tables not created")
+        }
+        
+        if !createIndicesForTables() {
+            _databaseClient?.close()
+            flushDatabase()
+            fatalError("Unable to setup database for URLCache: Indices not created for tables")
+        }
+    }
+    
+    private func createTables() -> Bool {
+        guard _databaseClient != nil else {
+            fatalError("Cannot create table before database setup")
+        }
+        
+        let tableSQLs = [
+            "CREATE TABLE cfurl_cache_response(entry_ID INTEGER PRIMARY KEY, version INTEGER, hash_value VARCHAR, storage_policy INTEGER, request_key VARCHAR, time_stamp DATETIME, partition VARCHAR)",
+            "CREATE TABLE cfurl_cache_receiver_data(entry_ID INTEGER PRIMARY KEY, isDataOnFS INTEGER, receiver_data BLOB)",
+            "CREATE TABLE cfurl_cache_blob_data(entry_ID INTEGER PRIMARY KEY, response_object BLOB, request_object BLOB, proto_props BLOB, user_info BLOB)",
+            "CREATE TABLE cfurl_cache_schema_version(schema_version INTEGER)"
+        ]
+        
+        for sql in tableSQLs {
+            if let isSuccess = _databaseClient?.execute(sql: sql), !isSuccess {
+                return false
+            }
+        }
+        
+        return true
+    }
+    
+    private func createIndicesForTables() -> Bool {
+        guard _databaseClient != nil else {
+            fatalError("Cannot create table before database setup")
+        }
+        
+        let indicesSQLs = [
+            "CREATE INDEX proto_props_index ON cfurl_cache_blob_data(entry_ID)",
+            "CREATE INDEX receiver_data_index ON cfurl_cache_receiver_data(entry_ID)",
+            "CREATE INDEX request_key_index ON cfurl_cache_response(request_key)",
+            "CREATE INDEX time_stamp_index ON cfurl_cache_response(time_stamp)"
+        ]
+        
+        for sql in indicesSQLs {
+            if let isSuccess = _databaseClient?.execute(sql: sql), !isSuccess {
+                return false
+            }
+        }
+        
+        return true
+    }
+    
+}
+
+fileprivate struct _CacheSQLiteClient {
+    
+    private var database: OpaquePointer?
+    
+    init?(databasePath: String) {
+        if sqlite3_open_v2(databasePath, &database, SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE, nil) != SQLITE_OK {
+            return nil
+        }
+    }
+    
+    func execute(sql: String) -> Bool {
+        guard let db = database else { return false }
+        
+        return sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK
+    }
+    
+    mutating func close() {
+        guard let db = database else { return }
+        
+        sqlite3_close_v2(db)
+        database = nil
+    }
+    
 }

--- a/Foundation/URLCache.swift
+++ b/Foundation/URLCache.swift
@@ -132,7 +132,7 @@ open class URLCache : NSObject {
     private static var sharedCache: URLCache?
     
     private let syncQ = DispatchQueue(label: "org.swift.URLCache.syncQ")
-    private var persistence: CachePersistence?
+    private var persistence: _CachePersistence?
     
     /*! 
         @method sharedURLCache
@@ -202,7 +202,7 @@ open class URLCache : NSObject {
         self.diskCapacity = diskCapacity
 
         if let _path = path {
-            self.persistence = CachePersistence(path: _path)
+            self.persistence = _CachePersistence(path: _path)
         }
 
         super.init()
@@ -301,7 +301,7 @@ extension URLCache {
     public func removeCachedResponse(for dataTask: URLSessionDataTask) { NSUnimplemented() }
 }
 
-fileprivate struct CachePersistence {
+fileprivate struct _CachePersistence {
 
     let path: String
 

--- a/TestFoundation/TestURLCache.swift
+++ b/TestFoundation/TestURLCache.swift
@@ -1,0 +1,91 @@
+//
+//  TestURLCache.swift
+//  TestFoundation
+//
+//  Created by Karthikkeyan Bala Sundaram on 3/8/19.
+//  Copyright © 2019 Apple. All rights reserved.
+//
+
+import SQLite3
+
+class TestURLCache: XCTestCase {
+
+    static var allTests: [(String, (TestURLCache) -> () throws -> Void)] {
+        return [
+            ("test_cacheFileAndDirectorySetup", test_cacheFileAndDirectorySetup),
+            ("test_cacheDatabaseTables", test_cacheDatabaseTables),
+            ("test_cacheDatabaseIndices", test_cacheDatabaseIndices),
+        ]
+    }
+    
+    private var cacheDirectoryPath: String {
+        if let path = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?.path {
+            return "\(path)/org.swift.TestFoundation"
+        } else {
+            return "\(NSHomeDirectory())/Library/Caches/org.swift.TestFoundation"
+        }
+    }
+    
+    private var cacheDatabasePath: String {
+        return "\(cacheDirectoryPath)/Cache.db"
+    }
+    
+    func test_cacheFileAndDirectorySetup() {
+        let _ = URLCache.shared
+        
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cacheDirectoryPath))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cacheDatabasePath))
+    }
+    
+    func test_cacheDatabaseTables() {
+        let _ = URLCache.shared
+        
+        var db: OpaquePointer? = nil
+        let openDBResult = sqlite3_open_v2(cacheDatabasePath, &db, SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE, nil)
+        XCTAssertTrue(openDBResult == SQLITE_OK, "Unable to open database")
+        
+        var statement: OpaquePointer? = nil
+        let prepareResult = sqlite3_prepare_v2(db!, "select tbl_name from sqlite_master where type='table'", -1, &statement, nil)
+        XCTAssertTrue(prepareResult == SQLITE_OK, "Unable to prepare list tables statement")
+        
+        var tables = ["cfurl_cache_response": false, "cfurl_cache_receiver_data": false, "cfurl_cache_blob_data": false, "cfurl_cache_schema_version": false]
+        while sqlite3_step(statement!) == SQLITE_ROW {
+            let tableName = String(cString: sqlite3_column_text(statement!, 0))
+            tables[tableName] = true
+        }
+        
+        let tablesNotExist = tables.filter({ !$0.value })
+        if tablesNotExist.count == tables.count {
+            XCTFail("No tables created for URLCache")
+        }
+        
+        XCTAssertTrue(tablesNotExist.count == 0, "Table(s) not created: \(tablesNotExist.map({ $0.key }).joined(separator: ", "))")
+        sqlite3_close_v2(db!)
+    }
+    
+    func test_cacheDatabaseIndices() {
+        let _ = URLCache.shared
+        
+        var db: OpaquePointer? = nil
+        let openDBResult = sqlite3_open_v2(cacheDatabasePath, &db, SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE, nil)
+        XCTAssertTrue(openDBResult == SQLITE_OK, "Unable to open database")
+        
+        var statement: OpaquePointer? = nil
+        let prepareResult = sqlite3_prepare_v2(db!, "select name from sqlite_master where type='index'", -1, &statement, nil)
+        XCTAssertTrue(prepareResult == SQLITE_OK, "Unable to prepare list tables statement")
+        
+        var indices = ["proto_props_index": false, "receiver_data_index": false, "request_key_index": false, "time_stamp_index": false]
+        while sqlite3_step(statement!) == SQLITE_ROW {
+            let name = String(cString: sqlite3_column_text(statement!, 0))
+            indices[name] = true
+        }
+        
+        let indicesNotExist = indices.filter({ !$0.value })
+        if indicesNotExist.count == indices.count {
+            XCTFail("No index created for URLCache")
+        }
+        
+        XCTAssertTrue(indicesNotExist.count == 0, "Indices not created: \(indicesNotExist.map({ $0.key }).joined(separator: ", "))")
+    }
+    
+}

--- a/TestFoundation/TestURLCache.swift
+++ b/TestFoundation/TestURLCache.swift
@@ -86,6 +86,7 @@ class TestURLCache: XCTestCase {
         }
         
         XCTAssertTrue(indicesNotExist.count == 0, "Indices not created: \(indicesNotExist.map({ $0.key }).joined(separator: ", "))")
+        sqlite3_close_v2(db!)
     }
     
 }

--- a/TestFoundation/TestURLCache.swift
+++ b/TestFoundation/TestURLCache.swift
@@ -16,11 +16,12 @@ class TestURLCache: XCTestCase {
     }
 
     private var cacheDirectoryPath: String {
-        if let path = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?.path {
-            return "\(path)/org.swift.TestFoundation"
-        } else {
-            return "\(NSHomeDirectory())/Library/Caches/org.swift.TestFoundation"
+        guard var cacheDirectoryUrl = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            fatalError("Unable to find cache directory")
         }
+
+        cacheDirectoryUrl.appendPathComponent(ProcessInfo.processInfo.processName)
+        return cacheDirectoryUrl.path
     }
 
     func test_cacheFileAndDirectorySetup() {
@@ -35,7 +36,7 @@ class TestURLCache: XCTestCase {
         let newPath = cacheDirectoryPath + ".test_cacheFileAndDirectorySetup/"
         URLCache.shared = URLCache(memoryCapacity: fourMegaByte, diskCapacity: twentyMegaByte, diskPath: newPath)
         XCTAssertTrue(FileManager.default.fileExists(atPath: newPath))
-        XCTAssertFalse(FileManager.default.fileExists(atPath: cacheDirectoryPath))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cacheDirectoryPath))
     }
 
 }

--- a/TestFoundation/TestURLCache.swift
+++ b/TestFoundation/TestURLCache.swift
@@ -1,23 +1,20 @@
+// This source file is part of the Swift.org open source project
 //
-//  TestURLCache.swift
-//  TestFoundation
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
 //
-//  Created by Karthikkeyan Bala Sundaram on 3/8/19.
-//  Copyright © 2019 Apple. All rights reserved.
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
-
-import SQLite3
 
 class TestURLCache: XCTestCase {
 
     static var allTests: [(String, (TestURLCache) -> () throws -> Void)] {
         return [
             ("test_cacheFileAndDirectorySetup", test_cacheFileAndDirectorySetup),
-            ("test_cacheDatabaseTables", test_cacheDatabaseTables),
-            ("test_cacheDatabaseIndices", test_cacheDatabaseIndices),
         ]
     }
-    
+
     private var cacheDirectoryPath: String {
         if let path = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?.path {
             return "\(path)/org.swift.TestFoundation"
@@ -25,68 +22,20 @@ class TestURLCache: XCTestCase {
             return "\(NSHomeDirectory())/Library/Caches/org.swift.TestFoundation"
         }
     }
-    
-    private var cacheDatabasePath: String {
-        return "\(cacheDirectoryPath)/Cache.db"
-    }
-    
+
     func test_cacheFileAndDirectorySetup() {
+        // Test default directory
         let _ = URLCache.shared
-        
         XCTAssertTrue(FileManager.default.fileExists(atPath: cacheDirectoryPath))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: cacheDatabasePath))
+
+        let fourMegaByte = 4 * 1024 * 1024
+        let twentyMegaByte = 20 * 1024 * 1024
+
+        // Test with a custom directory
+        let newPath = cacheDirectoryPath + ".test_cacheFileAndDirectorySetup/"
+        URLCache.shared = URLCache(memoryCapacity: fourMegaByte, diskCapacity: twentyMegaByte, diskPath: newPath)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: newPath))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cacheDirectoryPath))
     }
-    
-    func test_cacheDatabaseTables() {
-        let _ = URLCache.shared
-        
-        var db: OpaquePointer? = nil
-        let openDBResult = sqlite3_open_v2(cacheDatabasePath, &db, SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE, nil)
-        XCTAssertTrue(openDBResult == SQLITE_OK, "Unable to open database")
-        
-        var statement: OpaquePointer? = nil
-        let prepareResult = sqlite3_prepare_v2(db!, "select tbl_name from sqlite_master where type='table'", -1, &statement, nil)
-        XCTAssertTrue(prepareResult == SQLITE_OK, "Unable to prepare list tables statement")
-        
-        var tables = ["cfurl_cache_response": false, "cfurl_cache_receiver_data": false, "cfurl_cache_blob_data": false, "cfurl_cache_schema_version": false]
-        while sqlite3_step(statement!) == SQLITE_ROW {
-            let tableName = String(cString: sqlite3_column_text(statement!, 0))
-            tables[tableName] = true
-        }
-        
-        let tablesNotExist = tables.filter({ !$0.value })
-        if tablesNotExist.count == tables.count {
-            XCTFail("No tables created for URLCache")
-        }
-        
-        XCTAssertTrue(tablesNotExist.count == 0, "Table(s) not created: \(tablesNotExist.map({ $0.key }).joined(separator: ", "))")
-        sqlite3_close_v2(db!)
-    }
-    
-    func test_cacheDatabaseIndices() {
-        let _ = URLCache.shared
-        
-        var db: OpaquePointer? = nil
-        let openDBResult = sqlite3_open_v2(cacheDatabasePath, &db, SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE, nil)
-        XCTAssertTrue(openDBResult == SQLITE_OK, "Unable to open database")
-        
-        var statement: OpaquePointer? = nil
-        let prepareResult = sqlite3_prepare_v2(db!, "select name from sqlite_master where type='index'", -1, &statement, nil)
-        XCTAssertTrue(prepareResult == SQLITE_OK, "Unable to prepare list tables statement")
-        
-        var indices = ["proto_props_index": false, "receiver_data_index": false, "request_key_index": false, "time_stamp_index": false]
-        while sqlite3_step(statement!) == SQLITE_ROW {
-            let name = String(cString: sqlite3_column_text(statement!, 0))
-            indices[name] = true
-        }
-        
-        let indicesNotExist = indices.filter({ !$0.value })
-        if indicesNotExist.count == indices.count {
-            XCTFail("No index created for URLCache")
-        }
-        
-        XCTAssertTrue(indicesNotExist.count == 0, "Indices not created: \(indicesNotExist.map({ $0.key }).joined(separator: ", "))")
-        sqlite3_close_v2(db!)
-    }
-    
+
 }

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -81,6 +81,7 @@ var allTestCases = [
     testCase(TestTimer.allTests),
     testCase(TestTimeZone.allTests),
     testCase(TestURL.allTests),
+    testCase(TestURLCache.allTests),
     testCase(TestURLComponents.allTests),
     testCase(TestURLCredential.allTests),
     testCase(TestURLProtectionSpace.allTests),


### PR DESCRIPTION
* `init` method implemented
* `URLCache.shared` singleton object created with 4MB of memory space and 20MB of disk space
* Directory and database file Cache.db file created under the local directory
* Sqlite Tables and Indices created in the database
* Unit tests added for `URLCache` to verify directory, file, tables, and indices

Bug Link: https://bugs.swift.org/browse/SR-10374