### PR TITLE
NSTimeZone: use the android path on Windows

### DIFF
--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -29,13 +29,17 @@ open class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
 
     public init?(name tzName: String, data aData: Data?) {
-#if os(Android)
+#if os(Android) || os(Windows)
         var tzName = tzName
         if tzName == "UTC" || tzName == "GMT" {
             tzName = "GMT+0000"
         }
         else if !(tzName.hasPrefix("GMT+") || tzName.hasPrefix("GMT-")) {
+#if os(Android)
             NSLog("Time zone database not available on Android")
+#else
+            NSLog("Time zone database not available on Windows")
+#endif
         }
 #endif
         super.init()


### PR DESCRIPTION
Convert `UTC` and `GMT` to `GMT+0000` for the CFTimeZone construction on
Windows as we do on Android.  This allows the Calendar tests build/run
on Windows.