### PR TITLE
Update DarwinCompatibilty tests and Xcode project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,7 +424,6 @@ if(ENABLE_TESTING)
                          TestFoundation/TestIndexSet.swift
                          TestFoundation/TestISO8601DateFormatter.swift
                          TestFoundation/TestJSONEncoder.swift
-                         TestFoundation/TestPropertyListEncoder.swift
                          TestFoundation/TestJSONSerialization.swift
                          TestFoundation/TestLengthFormatter.swift
                          TestFoundation/TestMassFormatter.swift
@@ -449,7 +448,6 @@ if(ENABLE_TESTING)
                          TestFoundation/TestNSNumber.swift
                          TestFoundation/TestNSOrderedSet.swift
                          TestFoundation/TestNSPredicate.swift
-                         TestFoundation/TestNSProgressFraction.swift
                          TestFoundation/TestNSRange.swift
                          TestFoundation/TestNSRegularExpression.swift
                          TestFoundation/TestNSSet.swift
@@ -466,6 +464,8 @@ if(ENABLE_TESTING)
                          TestFoundation/TestProcessInfo.swift
                          TestFoundation/TestProcess.swift
                          TestFoundation/TestProgress.swift
+                         TestFoundation/TestProgressFraction.swift
+                         TestFoundation/TestPropertyListEncoder.swift
                          TestFoundation/TestPropertyListSerialization.swift
                          TestFoundation/TestRunLoop.swift
                          TestFoundation/TestScanner.swift

--- a/DarwinCompatibilityTests.xcodeproj/project.pbxproj
+++ b/DarwinCompatibilityTests.xcodeproj/project.pbxproj
@@ -11,8 +11,11 @@
 		B907F36F20BB188800013CBE /* NSString-ISO-8859-1-data.txt in Resources */ = {isa = PBXBuildFile; fileRef = B907F36E20BB188800013CBE /* NSString-ISO-8859-1-data.txt */; };
 		B917D32420B0DB9700728EE0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B917D32320B0DB9700728EE0 /* Foundation.framework */; };
 		B917D32620B0DE2000728EE0 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = B917D32520B0DE2000728EE0 /* main.swift */; };
+		B940492B223B13D000FB4384 /* TestProgressFraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B940492A223B13D000FB4384 /* TestProgressFraction.swift */; };
 		B94897772135E7AD00FB930E /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B94897762135E7AC00FB930E /* Utilities.swift */; };
 		B95788861F6FB9470003EB01 /* TestNSNumberBridging.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95788851F6FB9470003EB01 /* TestNSNumberBridging.swift */; };
+		B97E7854222AF973007596B0 /* TestDateIntervalFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97E7853222AF973007596B0 /* TestDateIntervalFormatter.swift */; };
+		B97E7856222AF995007596B0 /* TestPropertyListEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97E7855222AF995007596B0 /* TestPropertyListEncoder.swift */; };
 		B987C65E2093C8AF0026B50D /* TestImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = B987C65D2093C8AF0026B50D /* TestImports.swift */; };
 		B98E33E02136AC120044EBE9 /* TestFileWithZeros.txt in Resources */ = {isa = PBXBuildFile; fileRef = B98E33DF2136AC120044EBE9 /* TestFileWithZeros.txt */; };
 		B9C89F361F6BF89C00087AF4 /* TestScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C89EE61F6BF88F00087AF4 /* TestScanner.swift */; };
@@ -80,7 +83,6 @@
 		B9C89F781F6BF89C00087AF4 /* TestNSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C89F291F6BF89900087AF4 /* TestNSData.swift */; };
 		B9C89F791F6BF89C00087AF4 /* TestNSRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C89F2A1F6BF89900087AF4 /* TestNSRange.swift */; };
 		B9C89F7A1F6BF89C00087AF4 /* TestNSGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C89F2B1F6BF89900087AF4 /* TestNSGeometry.swift */; };
-		B9C89F7B1F6BF89C00087AF4 /* TestNSProgressFraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C89F2C1F6BF89900087AF4 /* TestNSProgressFraction.swift */; };
 		B9C89F7C1F6BF89C00087AF4 /* TestURLCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C89F2D1F6BF89A00087AF4 /* TestURLCredential.swift */; };
 		B9C89F7D1F6BF89C00087AF4 /* TestRunLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C89F2E1F6BF89A00087AF4 /* TestRunLoop.swift */; };
 		B9C89F7E1F6BF89C00087AF4 /* TestThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C89F2F1F6BF89B00087AF4 /* TestThread.swift */; };
@@ -155,8 +157,11 @@
 		B917D31C20B0DB8B00728EE0 /* xdgTestHelper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = xdgTestHelper; sourceTree = BUILT_PRODUCTS_DIR; };
 		B917D32320B0DB9700728EE0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		B917D32520B0DE2000728EE0 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = main.swift; path = TestFoundation/xdgTestHelper/main.swift; sourceTree = "<group>"; };
+		B940492A223B13D000FB4384 /* TestProgressFraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestProgressFraction.swift; path = TestFoundation/TestProgressFraction.swift; sourceTree = "<group>"; };
 		B94897762135E7AC00FB930E /* Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Utilities.swift; path = TestFoundation/Utilities.swift; sourceTree = "<group>"; };
 		B95788851F6FB9470003EB01 /* TestNSNumberBridging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestNSNumberBridging.swift; path = TestFoundation/TestNSNumberBridging.swift; sourceTree = "<group>"; };
+		B97E7853222AF973007596B0 /* TestDateIntervalFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestDateIntervalFormatter.swift; path = TestFoundation/TestDateIntervalFormatter.swift; sourceTree = "<group>"; };
+		B97E7855222AF995007596B0 /* TestPropertyListEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestPropertyListEncoder.swift; path = TestFoundation/TestPropertyListEncoder.swift; sourceTree = "<group>"; };
 		B987C65D2093C8AF0026B50D /* TestImports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestImports.swift; path = TestFoundation/TestImports.swift; sourceTree = "<group>"; };
 		B98E33DF2136AC120044EBE9 /* TestFileWithZeros.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = TestFileWithZeros.txt; path = TestFoundation/Resources/TestFileWithZeros.txt; sourceTree = "<group>"; };
 		B9C89ED11F6BF67C00087AF4 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -294,6 +299,9 @@
 		B9C89EB81F6BF47D00087AF4 = {
 			isa = PBXGroup;
 			children = (
+				B940492A223B13D000FB4384 /* TestProgressFraction.swift */,
+				B97E7855222AF995007596B0 /* TestPropertyListEncoder.swift */,
+				B97E7853222AF973007596B0 /* TestDateIntervalFormatter.swift */,
 				B9C89FAC1F6DCAE700087AF4 /* Info.plist */,
 				B9C89FAD1F6DCAE800087AF4 /* NSKeyedUnarchiver-ArrayTest.plist */,
 				B9C89FB31F6DCAE900087AF4 /* NSKeyedUnarchiver-ComplexTest.plist */,
@@ -558,6 +566,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B940492B223B13D000FB4384 /* TestProgressFraction.swift in Sources */,
+				B97E7856222AF995007596B0 /* TestPropertyListEncoder.swift in Sources */,
+				B97E7854222AF973007596B0 /* TestDateIntervalFormatter.swift in Sources */,
 				B94897772135E7AD00FB930E /* Utilities.swift in Sources */,
 				B987C65E2093C8AF0026B50D /* TestImports.swift in Sources */,
 				B95788861F6FB9470003EB01 /* TestNSNumberBridging.swift in Sources */,
@@ -632,7 +643,6 @@
 				B9C89F781F6BF89C00087AF4 /* TestNSData.swift in Sources */,
 				B9C89F791F6BF89C00087AF4 /* TestNSRange.swift in Sources */,
 				B9C89F7A1F6BF89C00087AF4 /* TestNSGeometry.swift in Sources */,
-				B9C89F7B1F6BF89C00087AF4 /* TestNSProgressFraction.swift in Sources */,
 				B9C89F7C1F6BF89C00087AF4 /* TestURLCredential.swift in Sources */,
 				B9C89F7D1F6BF89C00087AF4 /* TestRunLoop.swift in Sources */,
 				B9C89F7E1F6BF89C00087AF4 /* TestThread.swift in Sources */,
@@ -661,10 +671,10 @@
 				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CODE_SIGN_STYLE = Automatic;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				OTHER_SWIFT_FLAGS = "-DDEPLOYMENT_RUNTIME_OBJC -DDARWIN_COMPATIBILITY_TESTS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -675,10 +685,10 @@
 				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CODE_SIGN_STYLE = Automatic;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				OTHER_SWIFT_FLAGS = "-DDEPLOYMENT_RUNTIME_OBJC -DDARWIN_COMPATIBILITY_TESTS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -730,7 +740,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -781,7 +791,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -795,10 +805,11 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = DarwinCompatibilityTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				"OTHER_SWIFT_FLAGS[arch=*]" = "-DDEPLOYMENT_RUNTIME_OBJC -DDARWIN_COMPATIBILITY_TESTS";
 				PRODUCT_BUNDLE_IDENTIFIER = org.swift.DarwinCompatibilityTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -809,10 +820,11 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = DarwinCompatibilityTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				"OTHER_SWIFT_FLAGS[arch=*]" = "-DDEPLOYMENT_RUNTIME_OBJC -DDARWIN_COMPATIBILITY_TESTS";
 				PRODUCT_BUNDLE_IDENTIFIER = org.swift.DarwinCompatibilityTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/DarwinCompatibilityTests.xcodeproj/xcshareddata/xcschemes/xdgTestHelper.xcscheme
+++ b/DarwinCompatibilityTests.xcodeproj/xcshareddata/xcschemes/xdgTestHelper.xcscheme
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B917D31B20B0DB8B00728EE0"
+               BuildableName = "xdgTestHelper"
+               BlueprintName = "xdgTestHelper"
+               ReferencedContainer = "container:DarwinCompatibilityTests.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B9C89ED61F6BF77E00087AF4"
+               BuildableName = "DarwinCompatibilityTests.xctest"
+               BlueprintName = "DarwinCompatibilityTests"
+               ReferencedContainer = "container:DarwinCompatibilityTests.xcodeproj">
+            </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "TestFileHandle">
+               </Test>
+               <Test
+                  Identifier = "TestPipe">
+               </Test>
+               <Test
+                  Identifier = "TestURLSession">
+               </Test>
+            </SkippedTests>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B917D31B20B0DB8B00728EE0"
+            BuildableName = "xdgTestHelper"
+            BlueprintName = "xdgTestHelper"
+            ReferencedContainer = "container:DarwinCompatibilityTests.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B917D31B20B0DB8B00728EE0"
+            BuildableName = "xdgTestHelper"
+            BlueprintName = "xdgTestHelper"
+            ReferencedContainer = "container:DarwinCompatibilityTests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B917D31B20B0DB8B00728EE0"
+            BuildableName = "xdgTestHelper"
+            BlueprintName = "xdgTestHelper"
+            ReferencedContainer = "container:DarwinCompatibilityTests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -366,6 +366,7 @@
 		B910957B1EEF237800A71930 /* NSString-UTF16-BE-data.txt in Resources */ = {isa = PBXBuildFile; fileRef = B91095791EEF237800A71930 /* NSString-UTF16-BE-data.txt */; };
 		B933A79E1F3055F700FE6846 /* NSString-UTF32-BE-data.txt in Resources */ = {isa = PBXBuildFile; fileRef = B933A79C1F3055F600FE6846 /* NSString-UTF32-BE-data.txt */; };
 		B933A79F1F3055F700FE6846 /* NSString-UTF32-LE-data.txt in Resources */ = {isa = PBXBuildFile; fileRef = B933A79D1F3055F600FE6846 /* NSString-UTF32-LE-data.txt */; };
+		B940492D223B146800FB4384 /* TestProgressFraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B940492C223B146800FB4384 /* TestProgressFraction.swift */; };
 		B951B5EC1F4E2A2000D8B332 /* TestNSLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B951B5EB1F4E2A2000D8B332 /* TestNSLock.swift */; };
 		B98E33DD2136AA740044EBE9 /* TestFileWithZeros.txt in Resources */ = {isa = PBXBuildFile; fileRef = B98E33DC2136AA740044EBE9 /* TestFileWithZeros.txt */; };
 		B9974B961EDF4A22007F15B8 /* TransferState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B8F1EDF4A22007F15B8 /* TransferState.swift */; };
@@ -412,7 +413,6 @@
 		E1A3726F1C31EBFB0023AF4D /* NSXMLDocumentTestData.xml in Resources */ = {isa = PBXBuildFile; fileRef = E1A3726E1C31EBFB0023AF4D /* NSXMLDocumentTestData.xml */; };
 		EA01AAEC1DA839C4008F4E07 /* TestProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA01AAEB1DA839C4008F4E07 /* TestProgress.swift */; };
 		EA0812691DA71C8A00651B70 /* ProgressFraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0812681DA71C8A00651B70 /* ProgressFraction.swift */; };
-		EA08126B1DA80C3600651B70 /* TestNSProgressFraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA08126A1DA80C3600651B70 /* TestNSProgressFraction.swift */; };
 		EA08126C1DA810BE00651B70 /* ProgressFraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0812681DA71C8A00651B70 /* ProgressFraction.swift */; };
 		EA418C261D57257D005EAD0D /* NSKeyedArchiverHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA418C251D57257D005EAD0D /* NSKeyedArchiverHelpers.swift */; };
 		EA54A6FB1DB16D53009E0809 /* TestObjCRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA54A6FA1DB16D53009E0809 /* TestObjCRuntime.swift */; };
@@ -896,6 +896,7 @@
 		B91095791EEF237800A71930 /* NSString-UTF16-BE-data.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "NSString-UTF16-BE-data.txt"; sourceTree = "<group>"; };
 		B933A79C1F3055F600FE6846 /* NSString-UTF32-BE-data.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "NSString-UTF32-BE-data.txt"; sourceTree = "<group>"; };
 		B933A79D1F3055F600FE6846 /* NSString-UTF32-LE-data.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "NSString-UTF32-LE-data.txt"; sourceTree = "<group>"; };
+		B940492C223B146800FB4384 /* TestProgressFraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestProgressFraction.swift; path = TestFoundation/TestProgressFraction.swift; sourceTree = "<group>"; };
 		B951B5EB1F4E2A2000D8B332 /* TestNSLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNSLock.swift; sourceTree = "<group>"; };
 		B98E33DC2136AA740044EBE9 /* TestFileWithZeros.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TestFileWithZeros.txt; sourceTree = "<group>"; };
 		B9974B8F1EDF4A22007F15B8 /* TransferState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransferState.swift; sourceTree = "<group>"; };
@@ -1119,6 +1120,7 @@
 		5B5D88531BBC938800234F36 = {
 			isa = PBXGroup;
 			children = (
+				B940492C223B146800FB4384 /* TestProgressFraction.swift */,
 				B167A6641ED7303F0040B09A /* README.md */,
 				5BDC3F2C1BCC5DB500ED97BB /* Foundation */,
 				EAB57B681BD1A255004AC5C5 /* CoreFoundation */,
@@ -2592,6 +2594,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B940492D223B146800FB4384 /* TestProgressFraction.swift in Sources */,
 				159884921DCC877700E3314C /* TestHTTPCookieStorage.swift in Sources */,
 				5FE52C951D147D1C00F7D270 /* TestNSTextCheckingResult.swift in Sources */,
 				5B13B3451C582D4C00651CE2 /* TestNSString.swift in Sources */,
@@ -2618,7 +2621,6 @@
 				5B13B3411C582D4C00651CE2 /* TestNSRegularExpression.swift in Sources */,
 				5B13B3491C582D4C00651CE2 /* TestTimeZone.swift in Sources */,
 				5B13B34B1C582D4C00651CE2 /* TestNSURLRequest.swift in Sources */,
-				EA08126B1DA80C3600651B70 /* TestNSProgressFraction.swift in Sources */,
 				5B13B33E1C582D4C00651CE2 /* TestProcessInfo.swift in Sources */,
 				5B13B33F1C582D4C00651CE2 /* TestPropertyListSerialization.swift in Sources */,
 				5B13B32C1C582D4C00651CE2 /* TestDate.swift in Sources */,

--- a/TestFoundation/TestFileHandle.swift
+++ b/TestFoundation/TestFileHandle.swift
@@ -7,6 +7,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if !DARWIN_COMPATIBILITY_TESTS // Disable until Foundation has the new FileHandle API
+
 import Dispatch
 
 class TestFileHandle : XCTestCase {
@@ -484,3 +486,5 @@ class TestFileHandle : XCTestCase {
         ]
     }
 }
+
+#endif

--- a/TestFoundation/TestNSCalendar.swift
+++ b/TestFoundation/TestNSCalendar.swift
@@ -751,6 +751,7 @@ class TestNSCalendar: XCTestCase {
     }
     
     func test_rangeOfWeekendStartDate_interval_containingDate() throws {
+#if !DARWIN_COMPATIBILITY_TESTS // NSCalender range(ofWeekendContaining:) is experimental
         try enumerateTestWeekends() { (calendar, interval) in
             let startDateResult = calendar.range(ofWeekendContaining: interval.start)
             XCTAssertEqual(startDateResult, interval)
@@ -764,6 +765,7 @@ class TestNSCalendar: XCTestCase {
             let oneSecondBeforeEndResult = calendar.range(ofWeekendContaining: interval.end - 1)
             XCTAssertEqual(oneSecondBeforeEndResult, interval)
         }
+#endif
     }
     
     func test_enumerateDatesStartingAfterDate_chineseEra_matchYearOne() throws {

--- a/TestFoundation/TestPipe.swift
+++ b/TestFoundation/TestPipe.swift
@@ -7,6 +7,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if !DARWIN_COMPATIBILITY_TESTS     // Disable until Foundation has the new FileHandle API
 class TestPipe: XCTestCase {
     
     static var allTests: [(String, (TestPipe) -> () throws -> Void)] {
@@ -57,3 +58,4 @@ class TestPipe: XCTestCase {
         XCTAssertEqual(text, convertedData)
     }
 }
+#endif

--- a/TestFoundation/TestProgressFraction.swift
+++ b/TestFoundation/TestProgressFraction.swift
@@ -1,16 +1,19 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2016, 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if !DARWIN_COMPATIBILITY_TESTS
+
 class TestProgressFraction : XCTestCase {
-    static var allTests: [(String, (TestProgressFraction) -> () throws -> Void)] {
-        return [
+
+#if !NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT    // _ProgressFraction is an internal type
+    static let allTests: [(String, (TestProgressFraction) -> () throws -> Void)] = []
+#else
+    static let allTests: [(String, (TestProgressFraction) -> () throws -> Void)] = [
             ("test_equal", test_equal ),
             ("test_subtract", test_subtract),
             ("test_multiply", test_multiply),
@@ -21,7 +24,6 @@ class TestProgressFraction : XCTestCase {
             ("test_fractionFromDouble", test_fractionFromDouble),
             ("test_unnecessaryOverflow", test_unnecessaryOverflow),
         ]
-    }
 
     func test_equal() {
         let f1 = _ProgressFraction(completed: 5, total: 10)
@@ -151,6 +153,7 @@ class TestProgressFraction : XCTestCase {
         let r = f1 + f2
         XCTAssertFalse(r.overflowed)
     }
-}
 #endif
+}
+
 

--- a/TestFoundation/TestScanner.swift
+++ b/TestFoundation/TestScanner.swift
@@ -7,6 +7,8 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if !DARWIN_COMPATIBILITY_TESTS     // Disable until Foundation has the new Scanner API
+
 fileprivate func withScanner(for string: String, invoking block: ((Scanner) throws -> Void)? = nil) rethrows {
     let scanner = Scanner(string: string)
     scanner.locale = Locale(identifier: "en_US_POSIX")
@@ -481,3 +483,5 @@ class TestScanner : XCTestCase {
         ]
     }
 }
+
+#endif

--- a/TestFoundation/TestStream.swift
+++ b/TestFoundation/TestStream.swift
@@ -7,10 +7,12 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if (os(Linux) || os(Android))
-    @testable import Foundation
-#else
-    @testable import SwiftFoundation
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+    #if canImport(SwiftFoundation)
+        @testable import SwiftFoundation
+    #else
+        @testable import Foundation
+    #endif
 #endif
 
 
@@ -33,13 +35,12 @@ private extension Data {
 
 class TestStream : XCTestCase {
     static var allTests: [(String, (TestStream) -> () throws -> Void)] {
-        return [
+        var tests: [(String, (TestStream) -> () throws -> Void)] = [
             ("test_InputStreamWithData", test_InputStreamWithData),
             ("test_InputStreamWithUrl", test_InputStreamWithUrl),
             ("test_InputStreamWithFile", test_InputStreamWithFile),
             ("test_InputStreamHasBytesAvailable", test_InputStreamHasBytesAvailable),
             ("test_InputStreamInvalidPath", test_InputStreamInvalidPath),
-            ("test_InputStreamSeekToPosition", test_InputStreamSeekToPosition),
             ("test_outputStreamCreationToFile", test_outputStreamCreationToFile),
             ("test_outputStreamCreationToBuffer", test_outputStreamCreationToBuffer),
             ("test_outputStreamCreationWithUrl", test_outputStreamCreationWithUrl),
@@ -47,6 +48,11 @@ class TestStream : XCTestCase {
             ("test_outputStreamHasSpaceAvailable", test_outputStreamHasSpaceAvailable),
             ("test_ouputStreamWithInvalidPath", test_ouputStreamWithInvalidPath),
         ]
+
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+        tests.append(("test_InputStreamSeekToPosition", test_InputStreamSeekToPosition))
+#endif
+        return tests
     }
     
     func test_InputStreamWithData(){
@@ -140,7 +146,8 @@ class TestStream : XCTestCase {
         fileStream.open()
         XCTAssertEqual(.error, fileStream.streamStatus)
     }
-    
+
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT        // Stream.seek(to:) is an internal API method
     func test_InputStreamSeekToPosition() {
         let str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras congue laoreet facilisis. Sed porta tristique orci. Fusce ut nisl dignissim, tempor tortor id, molestie neque. Nam non tincidunt mi. Integer ac diam quis leo aliquam congue et non magna. In porta mauris suscipit erat pulvinar, sed fringilla quam ornare. Nulla vulputate et ligula vitae sollicitudin. Nulla vel vehicula risus. Quisque eu urna ullamcorper, tincidunt ante vitae, aliquet sem. Suspendisse nec turpis placerat, porttitor ex vel, tristique orci. Maecenas pretium, augue non elementum imperdiet, diam ex vestibulum tortor, non ultrices ante enim iaculis ex. Fusce ut nisl dignissim, tempor tortor id, molestie neque. Nam non tincidunt mi. Integer ac diam quis leo aliquam congue et non magna. In porta mauris suscipit erat pulvinar, sed fringilla quam ornare. Nulla vulputate et ligula vitae sollicitudin. Nulla vel vehicula risus. Quisque eu urna ullamcorper, tincidunt ante vitae, aliquet sem. Suspendisse nec turpis placerat, porttitor ex vel, tristique orci. Maecenas pretium, augue non elementum imperdiet, diam ex vestibulum tortor, non ultrices ante enim iaculis ex.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras congue laoreet facilisis. Sed porta tristique orci. Fusce ut nisl dignissim, tempor tortor id, molestie neque. Nam non tincidunt mi. Integer ac diam quis leo aliquam congue et non magna. In porta mauris suscipit erat pulvinar, sed fringilla quam ornare. Nulla vulputate et ligula vitae sollicitudin. Nulla vel vehicula risus. Quisque eu urna ullamcorper, tincidunt ante vitae, aliquet sem. Suspendisse nec turpis placerat, porttitor ex vel."
         XCTAssert(str.count > 1024) // str.count must be bigger than buffersize inside InputStream.seek func.
@@ -184,6 +191,7 @@ class TestStream : XCTestCase {
             XCTFail()
         }
     }
+#endif
     
     func test_outputStreamCreationToFile() {
         guard let filePath = createTestFile("TestFileOut.txt", _contents: Data(capacity: 256)) else {


### PR DESCRIPTION
- DarwinCompatibility: TestStream.seek(to:) is internal API

- DarwinCompatibility: Disable tests that use new API not yet in Foundation

- Update Swift version to 5.0 and target deployment version to 10.14.
    
- Rename TestNSProgressFraction.swift to TestProgressFraction.swift
  to reflect name of test class.
    
- Wrap file in NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT as the type is
  internal and cant be tested by DarwinCompaitibilityTests.
    
- Add TestPropertyListEncoder.swift and TestDateIntervalFormatter.swift
  to DarwinCompatibilityTests.
