### PR TITLE
TestFoundation: excise tests that use private APIs

### DIFF
--- a/TestFoundation/TestBundle.swift
+++ b/TestFoundation/TestBundle.swift
@@ -252,7 +252,7 @@ class TestBundle : XCTestCase {
             ("test_bundlePreflight", test_bundlePreflight),
             ("test_bundleFindExecutable", test_bundleFindExecutable),
             ("test_bundleFindAuxiliaryExecutables", test_bundleFindAuxiliaryExecutables),
-            ("test_mainBundleExecutableURL", test_mainBundleExecutableURL),
+            // ("test_mainBundleExecutableURL", test_mainBundleExecutableURL),
         ]
     }
     
@@ -439,6 +439,7 @@ class TestBundle : XCTestCase {
         }
     }
 
+#if false
     func test_mainBundleExecutableURL() {
 #if !DARWIN_COMPATIBILITY_TESTS // _CFProcessPath() is unavailable on native Foundation
         let maybeURL = Bundle.main.executableURL
@@ -448,4 +449,5 @@ class TestBundle : XCTestCase {
         XCTAssertEqual(url.path, String(cString: _CFProcessPath()))
 #endif
     }
+#endif
 }

--- a/TestFoundation/TestNSArray.swift
+++ b/TestFoundation/TestNSArray.swift
@@ -44,7 +44,7 @@ class TestNSArray : XCTestCase {
             ("test_insertObjectsAtIndexes", test_insertObjectsAtIndexes),
             ("test_replaceObjectsAtIndexesWithObjects", test_replaceObjectsAtIndexesWithObjects),
             ("test_pathsMatchingExtensions", test_pathsMatchingExtensions),
-            ("test_arrayUsedAsCFArrayInvokesArrayMethods", test_arrayUsedAsCFArrayInvokesArrayMethods),
+            // ("test_arrayUsedAsCFArrayInvokesArrayMethods", test_arrayUsedAsCFArrayInvokesArrayMethods),
             ("test_customMirror", test_customMirror),
         ]
     }
@@ -822,6 +822,7 @@ class TestNSArray : XCTestCase {
         XCTAssertEqual(array[6] as! String, arrayMirror.descendant(6) as! String)
     }
 
+#if false
     func test_arrayUsedAsCFArrayInvokesArrayMethods() {
         let number = 789 as NSNumber
         let array = NSMutableArray(array: [123, 456])
@@ -829,6 +830,7 @@ class TestNSArray : XCTestCase {
         XCTAssertEqual(array[0] as! NSNumber, 123 as NSNumber)
         XCTAssertEqual(array[1] as! NSNumber, 789 as NSNumber)
     }
+#endif
 
     private func createTestFile(_ path: String, _contents: Data) -> String? {
         let tempDir = NSTemporaryDirectory() + "TestFoundation_Playground_" + NSUUID().uuidString + "/"

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -54,7 +54,7 @@ class TestNSString: LoopbackServerTest {
             ("test_capitalizedString", test_capitalizedString ),
             ("test_longLongValue", test_longLongValue ),
             ("test_rangeOfCharacterFromSet", test_rangeOfCharacterFromSet ),
-            ("test_CFStringCreateMutableCopy", test_CFStringCreateMutableCopy),
+            // ("test_CFStringCreateMutableCopy", test_CFStringCreateMutableCopy),
             ("test_FromContentsOfURL",test_FromContentsOfURL),
             ("test_FromContentOfFileUsedEncodingIgnored", test_FromContentOfFileUsedEncodingIgnored),
             ("test_FromContentOfFileUsedEncodingUTF8", test_FromContentOfFileUsedEncodingUTF8),
@@ -63,7 +63,7 @@ class TestNSString: LoopbackServerTest {
             ("test_FromContentsOfURLUsedEncodingUTF32BE", test_FromContentsOfURLUsedEncodingUTF32BE),
             ("test_FromContentsOfURLUsedEncodingUTF32LE", test_FromContentsOfURLUsedEncodingUTF32LE),
             ("test_FromContentOfFile",test_FromContentOfFile),
-            ("test_swiftStringUTF16", test_swiftStringUTF16),
+            // ("test_swiftStringUTF16", test_swiftStringUTF16),
             // This test takes forever on build servers; it has been seen up to 1852.084 seconds
 //            ("test_completePathIntoString", test_completePathIntoString),
             ("test_stringByTrimmingCharactersInSet", test_stringByTrimmingCharactersInSet),
@@ -582,14 +582,17 @@ class TestNSString: LoopbackServerTest {
         XCTAssertEqual(string.rangeOfCharacter(from: letters, options: .backwards).location, 2)
         XCTAssertEqual(string.rangeOfCharacter(from: letters, options: [], range: NSRange(location: 2, length: 1)).location, 2)
     }
-    
+
+#if false
     func test_CFStringCreateMutableCopy() {
         let nsstring: NSString = "абВГ"
         let mCopy = CFStringCreateMutableCopy(nil, 0, unsafeBitCast(nsstring, to: CFString.self))
         let str = unsafeBitCast(mCopy, to: NSString.self)
         XCTAssertEqual(nsstring, str)
     }
-    
+#endif
+
+#if false
     // This test verifies that CFStringGetBytes with a UTF16 encoding works on an NSString backed by a Swift string
     func test_swiftStringUTF16() {
         #if os(macOS) || os(iOS)
@@ -615,7 +618,8 @@ class TestNSString: LoopbackServerTest {
         
         XCTAssertTrue(newString.isEqual(to: testString))
     }
-    
+#endif
+
     func test_completePathIntoString() {
         let fileNames = [
             NSTemporaryDirectory() + "Test_completePathIntoString_01",


### PR DESCRIPTION
Since we do not expose the CoreFoundation APIs fully these tests are not
possible to build since the symbols cannot be resolved.  Rather than
adding additional exports to CoreFoundation for testing only, just drop
the tests.