### PR TITLE
NSURL: Use the platform path style

### DIFF
--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -15,6 +15,13 @@ internal let kCFURLPOSIXPathStyle = CFURLPathStyle.cfurlposixPathStyle
 internal let kCFURLWindowsPathStyle = CFURLPathStyle.cfurlWindowsPathStyle
 #endif
 
+// NOTE: this represents PLATFORM_PATH_STYLE
+#if os(Windows)
+internal let kCFURLPlatformPathStyle = kCFURLWindowsPathStyle
+#else
+internal let kCFURLPlatformPathStyle = kCFURLPOSIXPathStyle
+#endif
+
 private func _standardizedPath(_ path: String) -> String {
     if !path.absolutePath {
         return path._nsObject.standardizingPath
@@ -298,9 +305,9 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
         let thePath = _standardizedPath(path)
         if thePath.length > 0 {
             
-            _CFURLInitWithFileSystemPathRelativeToBase(_cfObject, thePath._cfObject, kCFURLPOSIXPathStyle, isDir, baseURL?._cfObject)
+            _CFURLInitWithFileSystemPathRelativeToBase(_cfObject, thePath._cfObject, kCFURLPlatformPathStyle, isDir, baseURL?._cfObject)
         } else if let baseURL = baseURL {
-            _CFURLInitWithFileSystemPathRelativeToBase(_cfObject, baseURL.path._cfObject, kCFURLPOSIXPathStyle, baseURL.hasDirectoryPath, nil)
+            _CFURLInitWithFileSystemPathRelativeToBase(_cfObject, baseURL.path._cfObject, kCFURLPlatformPathStyle, baseURL.hasDirectoryPath, nil)
         }
     }
     
@@ -347,7 +354,7 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
             }
         }
         super.init()
-        _CFURLInitWithFileSystemPathRelativeToBase(_cfObject, thePath._cfObject, kCFURLPOSIXPathStyle, isDir.boolValue, nil)
+        _CFURLInitWithFileSystemPathRelativeToBase(_cfObject, thePath._cfObject, kCFURLPlatformPathStyle, isDir.boolValue, nil)
     }
     
     public convenience init(fileURLWithFileSystemRepresentation path: UnsafePointer<Int8>, isDirectory isDir: Bool, relativeTo baseURL: URL?) {
@@ -517,7 +524,7 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     
     open var path: String? {
         let absURL = CFURLCopyAbsoluteURL(_cfObject)
-        return CFURLCopyFileSystemPath(absURL, kCFURLPOSIXPathStyle)?._swiftObject
+        return CFURLCopyFileSystemPath(absURL, kCFURLPlatformPathStyle)?._swiftObject
     }
     
     open var fragment: String? {
@@ -534,7 +541,7 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     
     // The same as path if baseURL is nil
     open var relativePath: String? {
-        return CFURLCopyFileSystemPath(_cfObject, kCFURLPOSIXPathStyle)?._swiftObject
+        return CFURLCopyFileSystemPath(_cfObject, kCFURLPlatformPathStyle)?._swiftObject
     }
     
     /* Determines if a given URL string's path represents a directory (i.e. the path component in the URL string ends with a '/' character). This does not check the resource the URL refers to.


### PR DESCRIPTION
Not all platforms are POSIX.  Use the platform URL style when converting
the paths.  This was possible in CoreFoundation through the
`PLATFORM_PATH_STYLE` macro, but, unfortunately, that is unavailable to
us in Swift.  Emulate that and use it.