### PR TITLE
Refactor the CFTimeZone initialization

### DIFF
--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -316,6 +316,15 @@ add_framework(CoreFoundation
                 URL.subproj/CFURLComponents.c
                 URL.subproj/CFURLComponents_URIParser.c
                 URL.subproj/CFURLSessionInterface.c)
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  # NOTE(compnerd) the WindowsOlsonMapping.plist and OlsonWindowsMapping.plist
+  # are embedded Windows resources that we use to map the Windows timezone to
+  # the Olson name.  Ensure that we rebuild on regeneration of the files.
+  add_custom_target(CoreFoundationWindowsTimeZonesPLists DEPENDS
+    WindowsOlsonMapping.plist
+    OlsonWindowsMapping.plist)
+  add_dependencies(CoreFoundation CoreFoundationWindowsTimeZonesPLists)
+endif()
 if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android)
   target_compile_definitions(CoreFoundation
                              PRIVATE

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -205,6 +205,7 @@ add_framework(CoreFoundation
                 URL.subproj/CFURLAccess.h
                 URL.subproj/CFURLComponents.h
               SOURCES
+                $<$<PLATFORM_ID:Windows>:CoreFoundation.rc>
                 # Base
                 Base.subproj/CFBase.c
                 Base.subproj/CFFileUtilities.c

--- a/CoreFoundation/CoreFoundation.rc
+++ b/CoreFoundation/CoreFoundation.rc
@@ -1,0 +1,4 @@
+
+#include "WindowsResources.h"
+
+IDR_WINDOWS_OLSON_MAPPING       PLIST           "WindowsOlsonMapping.plist"

--- a/CoreFoundation/CoreFoundation.rc
+++ b/CoreFoundation/CoreFoundation.rc
@@ -2,3 +2,5 @@
 #include "WindowsResources.h"
 
 IDR_WINDOWS_OLSON_MAPPING       PLIST           "WindowsOlsonMapping.plist"
+IDR_OLSON_WINDOWS_MAPPING       PLIST           "OlsonWindowsMapping.plist"
+

--- a/CoreFoundation/NumberDate.subproj/CFTimeZone.c
+++ b/CoreFoundation/NumberDate.subproj/CFTimeZone.c
@@ -34,12 +34,17 @@
 #endif
 #if TARGET_OS_WIN32
 #include <tchar.h>
+
+#include "WindowsResources.h"
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+#include "Windows.h"
 #endif
+
 #if TARGET_OS_MAC
 #include <tzfile.h>
 #define MACOS_TZDIR1 "/usr/share/zoneinfo/"          // 10.12 and earlier
 #define MACOS_TZDIR2 "/var/db/timezone/zoneinfo/"    // 10.13 onwards
-
 #elif TARGET_OS_LINUX || TARGET_OS_BSD
 #ifndef TZDIR
 #define TZDIR	"/usr/share/zoneinfo/" /* Time zone object file directory */
@@ -463,172 +468,6 @@ CFTypeID CFTimeZoneGetTypeID(void) {
 }
 
 #if TARGET_OS_WIN32
-static const char *__CFTimeZoneWinToOlsonDefaults =
-/* Mappings to time zones in Windows Registry are best-guess */
-"<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-" <!DOCTYPE plist SYSTEM \"file://localhost/System/Library/DTDs/PropertyList.dtd\">"
-" <plist version=\"1.0\">"
-" <dict>"
-"    <key>Afghanistan</key>                 <string>Asia/Kabul</string>"
-"    <key>Afghanistan Standard Time</key>   <string>Asia/Kabul</string>"
-"    <key>Alaskan</key>                     <string>America/Anchorage</string>"
-"    <key>Alaskan Standard Time</key>       <string>America/Anchorage</string>"
-"    <key>Arab</key>                        <string>Asia/Riyadh</string>"
-"    <key>Arab Standard Time</key>          <string>Asia/Riyadh</string>"
-"    <key>Arabian</key>                     <string>Asia/Muscat</string>"
-"    <key>Arabian Standard Time</key>       <string>Asia/Muscat</string>"
-"    <key>Arabic Standard Time</key>        <string>Asia/Baghdad</string>"
-"    <key>Atlantic</key>                    <string>America/Halifax</string>"
-"    <key>Atlantic Standard Time</key>      <string>America/Halifax</string>"
-"    <key>AUS Central</key>                 <string>Australia/Darwin</string>"
-"    <key>AUS Central Standard Time</key>	<string>Australia/Darwin</string>"
-"    <key>AUS Eastern</key>                 <string>Australia/Sydney</string>"
-"    <key>AUS Eastern Standard Time</key>	<string>Australia/Sydney</string>"
-"    <key>Azerbaijan Standard Time</key>	<string>Asia/Baku</string>"
-"    <key>Azores</key>                      <string>Atlantic/Azores</string>"
-"    <key>Azores Standard Time</key>        <string>Atlantic/Azores</string>"
-"    <key>Bangkok</key>                     <string>Asia/Bangkok</string>"
-"    <key>Bangkok Standard Time</key>       <string>Asia/Bangkok</string>"
-"    <key>Beijing</key>                     <string>Asia/Shanghai</string>"
-"    <key>Canada Central</key>              <string>America/Regina</string>"
-"    <key>Canada Central Standard Time</key> <string>America/Regina</string>"
-"    <key>Cape Verde Standard Time</key>    <string>Atlantic/Cape_Verde</string>"
-"    <key>Caucasus</key>                    <string>Asia/Yerevan</string>"
-"    <key>Caucasus Standard Time</key>      <string>Asia/Yerevan</string>"
-"    <key>Cen. Australia</key>              <string>Australia/Adelaide</string>"
-"    <key>Cen. Australia Standard Time</key> <string>Australia/Adelaide</string>"
-"    <key>Central</key>                     <string>America/Chicago</string>"
-"    <key>Central America Standard Time</key> <string>America/Regina</string>"
-"    <key>Central Asia</key>                <string>Asia/Dhaka</string>"
-"    <key>Central Asia Standard Time</key>	<string>Asia/Dhaka</string>"
-"    <key>Central Brazilian Standard Time</key>	<string>America/Manaus</string>"
-"    <key>Central Europe</key>              <string>Europe/Prague</string>"
-"    <key>Central Europe Standard Time</key> <string>Europe/Prague</string>"
-"    <key>Central European</key>            <string>Europe/Belgrade</string>"
-"    <key>Central European Standard Time</key>	<string>Europe/Belgrade</string>"
-"    <key>Central Pacific</key>             <string>Pacific/Guadalcanal</string>"
-"    <key>Central Pacific Standard Time</key>	<string>Pacific/Guadalcanal</string>"
-"    <key>Central Standard Time</key>       <string>America/Chicago</string>"
-"    <key>Central Standard Time (Mexico)</key> <string>America/Mexico_City</string>"
-"    <key>China</key>                       <string>Asia/Shanghai</string>"
-"    <key>China Standard Time</key>         <string>Asia/Shanghai</string>"
-"    <key>Dateline</key>                    <string>GMT-1200</string>"
-"    <key>Dateline Standard Time</key>      <string>GMT-1200</string>"
-"    <key>E. Africa</key>                   <string>Africa/Nairobi</string>"
-"    <key>E. Africa Standard Time</key>     <string>Africa/Nairobi</string>"
-"    <key>E. Australia</key>                <string>Australia/Brisbane</string>"
-"    <key>E. Australia Standard Time</key>	<string>Australia/Brisbane</string>"
-"    <key>E. Europe</key>                   <string>Europe/Minsk</string>"
-"    <key>E. Europe Standard Time</key>     <string>Europe/Minsk</string>"
-"    <key>E. South America</key>            <string>America/Sao_Paulo</string>"
-"    <key>E. South America Standard Time</key>	<string>America/Sao_Paulo</string>"
-"    <key>Eastern</key>                     <string>America/New_York</string>"
-"    <key>Eastern Standard Time</key>       <string>America/New_York</string>"
-"    <key>Egypt</key>       <string>Africa/Cairo</string>"
-"    <key>Egypt Standard Time</key> <string>Africa/Cairo</string>"
-"    <key>Ekaterinburg</key>                <string>Asia/Yekaterinburg</string>"
-"    <key>Ekaterinburg Standard Time</key>	<string>Asia/Yekaterinburg</string>"
-"    <key>Fiji</key>	<string>Pacific/Fiji</string>"
-"    <key>Fiji Standard Time</key>	<string>Pacific/Fiji</string>"
-"    <key>FLE</key>	<string>Europe/Helsinki</string>"
-"    <key>FLE Standard Time</key>	<string>Europe/Helsinki</string>"
-"    <key>Georgian Standard Time</key>	<string>Asia/Tbilisi</string>"
-"    <key>GFT</key>	<string>Europe/Athens</string>"
-"    <key>GFT Standard Time</key>	<string>Europe/Athens</string>"
-"    <key>GMT</key>	<string>Europe/London</string>"
-"    <key>GMT Standard Time</key>	<string>Europe/London</string>"
-"    <key>Greenland Standard Time</key>	<string>America/Godthab</string>"
-"    <key>Greenwich</key>	<string>GMT</string>"
-"    <key>Greenwich Standard Time</key>	<string>GMT</string>"
-"    <key>GTB</key>	<string>Europe/Athens</string>"
-"    <key>GTB Standard Time</key>	<string>Europe/Athens</string>"
-"    <key>Hawaiian</key>	<string>Pacific/Honolulu</string>"
-"    <key>Hawaiian Standard Time</key>	<string>Pacific/Honolulu</string>"
-"    <key>India</key>	<string>Asia/Calcutta</string>"
-"    <key>India Standard Time</key>	<string>Asia/Calcutta</string>"
-"    <key>Iran</key>	<string>Asia/Tehran</string>"
-"    <key>Iran Standard Time</key>	<string>Asia/Tehran</string>"
-"    <key>Israel</key>	<string>Asia/Jerusalem</string>"
-"    <key>Israel Standard Time</key>	<string>Asia/Jerusalem</string>"
-"    <key>Jordan Standard Time</key>	<string>Asia/Amman</string>"
-"    <key>Korea</key>	<string>Asia/Seoul</string>"
-"    <key>Korea Standard Time</key>	<string>Asia/Seoul</string>"
-"    <key>Mexico</key>	<string>America/Mexico_City</string>"
-"    <key>Mexico Standard Time</key>	<string>America/Mexico_City</string>"
-"    <key>Mexico Standard Time 2</key>	<string>America/Chihuahua</string>"
-"    <key>Mid-Atlantic</key>	<string>Atlantic/South_Georgia</string>"
-"    <key>Mid-Atlantic Standard Time</key>	<string>Atlantic/South_Georgia</string>"
-"    <key>Middle East Standard Time</key>	<string>Asia/Beirut</string>"
-"    <key>Mountain</key>	<string>America/Denver</string>"
-"    <key>Mountain Standard Time</key>	<string>America/Denver</string>"
-"    <key>Mountain Standard Time (Mexico)</key>	<string>America/Chihuahua</string>"
-"    <key>Myanmar Standard Time</key>	<string>Asia/Rangoon</string>"
-"    <key>N. Central Asia Standard Time</key>   <string>Asia/Novosibirsk</string>"
-"    <key>Namibia Standard Time</key>   <string>Africa/Windhoek</string>"
-"    <key>Nepal Standard Time</key>	<string>Asia/Katmandu</string>"
-"    <key>New Zealand</key>	<string>Pacific/Auckland</string>"
-"    <key>New Zealand Standard Time</key>	<string>Pacific/Auckland</string>"
-"    <key>Newfoundland</key>	<string>America/St_Johns</string>"
-"    <key>Newfoundland Standard Time</key>	<string>America/St_Johns</string>"
-"    <key>North Asia East Standard Time</key>	<string>Asia/Ulaanbaatar</string>"
-"    <key>North Asia Standard Time</key>	<string>Asia/Krasnoyarsk</string>"
-"    <key>Pacific</key>	<string>America/Los_Angeles</string>"
-"    <key>Pacific SA</key>	<string>America/Santiago</string>"
-"    <key>Pacific SA Standard Time</key>	<string>America/Santiago</string>"
-"    <key>Pacific Standard Time</key>	<string>America/Los_Angeles</string>"
-"    <key>Pacific Standard Time (Mexico)</key>	<string>America/Tijuana</string>"
-"    <key>Prague Bratislava</key>	<string>Europe/Prague</string>"
-"    <key>Romance</key>	<string>Europe/Paris</string>"
-"    <key>Romance Standard Time</key>	<string>Europe/Paris</string>"
-"    <key>Russian</key>	<string>Europe/Moscow</string>"
-"    <key>Russian Standard Time</key>	<string>Europe/Moscow</string>"
-"    <key>SA Eastern</key>	<string>America/Buenos_Aires</string>"
-"    <key>SA Eastern Standard Time</key>	<string>America/Buenos_Aires</string>"
-"    <key>SA Pacific</key>	<string>America/Bogota</string>"
-"    <key>SA Pacific Standard Time</key>	<string>America/Bogota</string>"
-"    <key>SA Western</key>	<string>America/Caracas</string>"
-"    <key>SA Western Standard Time</key>	<string>America/Caracas</string>"
-"    <key>Samoa</key>	<string>Pacific/Apia</string>"
-"    <key>Samoa Standard Time</key>	<string>Pacific/Apia</string>"
-"    <key>Saudi Arabia</key>	<string>Asia/Riyadh</string>"
-"    <key>Saudi Arabia Standard Time</key>	<string>Asia/Riyadh</string>"
-"    <key>SE Asia Standard Time</key>	<string>Asia/Bangkok</string>"
-"    <key>Singapore</key>	<string>Asia/Singapore</string>"
-"    <key>Singapore Standard Time</key>	<string>Asia/Singapore</string>"
-"    <key>South Africa</key>	<string>Africa/Harare</string>"
-"    <key>South Africa Standard Time</key>	<string>Africa/Harare</string>"
-"    <key>Sri Lanka</key>	<string>Asia/Colombo</string>"
-"    <key>Sri Lanka Standard Time</key>	<string>Asia/Colombo</string>"
-"    <key>Sydney Standard Time</key>	<string>Australia/Sydney</string>"
-"    <key>Taipei</key>	<string>Asia/Taipei</string>"
-"    <key>Taipei Standard Time</key>	<string>Asia/Taipei</string>"
-"    <key>Tasmania</key>	<string>Australia/Hobart</string>"
-"    <key>Tasmania Standard Time</key>	<string>Australia/Hobart</string>"
-"    <key>Tasmania Standard Time</key>	<string>Australia/Hobart</string>"
-"    <key>Tokyo</key>	<string>Asia/Tokyo</string>"
-"    <key>Tokyo Standard Time</key>	<string>Asia/Tokyo</string>"
-"    <key>Tonga Standard Time</key>	<string>Pacific/Tongatapu</string>"
-"    <key>US Eastern</key>	<string>America/Indianapolis</string>"
-"    <key>US Eastern Standard Time</key>	<string>America/Indianapolis</string>"
-"    <key>US Mountain</key>	<string>America/Phoenix</string>"
-"    <key>US Mountain Standard Time</key>	<string>America/Phoenix</string>"
-"    <key>Vladivostok</key>	<string>Asia/Vladivostok</string>"
-"    <key>Vladivostok Standard Time</key>	<string>Asia/Vladivostok</string>"
-"    <key>W. Australia</key>	<string>Australia/Perth</string>"
-"    <key>W. Australia Standard Time</key>	<string>Australia/Perth</string>"
-"    <key>W. Central Africa Standard Time</key>	<string>Africa/Luanda</string>"
-"    <key>W. Europe</key>	<string>Europe/Berlin</string>"
-"    <key>W. Europe Standard Time</key>	<string>Europe/Berlin</string>"
-"    <key>Warsaw</key>	<string>Europe/Warsaw</string>"
-"    <key>West Asia</key>	<string>Asia/Karachi</string>"
-"    <key>West Asia Standard Time</key>	<string>Asia/Karachi</string>"
-"    <key>West Pacific</key>	<string>Pacific/Guam</string>"
-"    <key>West Pacific Standard Time</key>	<string>Pacific/Guam</string>"
-"    <key>Western Brazilian Standard Time</key>	<string>America/Rio_Branco</string>"
-"    <key>Yakutsk</key>	<string>Asia/Yakutsk</string>"
-" </dict>"
-" </plist>";
-
 CF_INLINE void __CFTimeZoneLockWinToOlson(void) {
     __CFLock(&__CFTimeZoneWinToOlsonLock);
 }
@@ -637,19 +476,46 @@ CF_INLINE void __CFTimeZoneUnlockWinToOlson(void) {
     __CFUnlock(&__CFTimeZoneWinToOlsonLock);
 }
 
+static Boolean CFTimeZoneLoadWindowsOlsonPlist(LPVOID *ppResource, LPDWORD pdwSize) {
+    HRSRC hResource;
+    HGLOBAL hMemory;
+
+    hResource = FindResourceA(NULL, MAKEINTRESOURCEA(IDR_WINDOWS_OLSON_MAPPING), "PLIST");
+    if (hResource == NULL) {
+        return FALSE;
+    }
+
+    hMemory = LoadResource(NULL, hResource);
+    if (hMemory == NULL) {
+        return FALSE;
+    }
+
+    *pdwSize = SizeofResource(NULL, hResource);
+    *ppResource = LockResource(hMemory);
+
+    return *pdwSize && *ppResource;
+}
+
 CFDictionaryRef CFTimeZoneCopyWinToOlsonDictionary(void) {
     CFDictionaryRef dict;
+
     __CFTimeZoneLockWinToOlson();
     if (NULL == __CFTimeZoneWinToOlsonDict) {
-        CFDataRef data = CFDataCreate(kCFAllocatorSystemDefault, (uint8_t *)__CFTimeZoneWinToOlsonDefaults, strlen(__CFTimeZoneWinToOlsonDefaults));
-        __CFTimeZoneWinToOlsonDict = (CFDictionaryRef)CFPropertyListCreateFromXMLData(kCFAllocatorSystemDefault, data, kCFPropertyListImmutable, NULL);
-        CFRelease(data);
+        const uint8_t *plist;
+        DWORD dwSize;
+
+        if (CFTimeZoneLoadWindowsOlsonPlist(&plist, &dwSize)) {
+            CFDataRef data = CFDataCreate(kCFAllocatorSystemDefault, plist, dwSize);
+            __CFTimeZoneWinToOlsonDict = (CFDictionaryRef)CFPropertyListCreateFromXMLData(kCFAllocatorSystemDefault, data, kCFPropertyListImmutable, NULL);
+            CFRelease(data);
+        }
     }
     if (NULL == __CFTimeZoneWinToOlsonDict) {
         __CFTimeZoneWinToOlsonDict = CFDictionaryCreate(kCFAllocatorSystemDefault, NULL, NULL, 0, NULL, NULL);
     }
-    dict = __CFTimeZoneWinToOlsonDict ? (CFDictionaryRef)CFRetain(__CFTimeZoneWinToOlsonDict) : NULL;
     __CFTimeZoneUnlockWinToOlson();
+
+    dict = __CFTimeZoneWinToOlsonDict ? (CFDictionaryRef)CFRetain(__CFTimeZoneWinToOlsonDict) : NULL;
     return dict;
 }
 

--- a/CoreFoundation/NumberDate.subproj/CFTimeZone.c
+++ b/CoreFoundation/NumberDate.subproj/CFTimeZone.c
@@ -1132,103 +1132,77 @@ Boolean _CFTimeZoneInitWithTimeIntervalFromGMT(CFTimeZoneRef result, CFTimeInter
     return true;
 }
 
+Boolean _CFTimeZoneInitInternal(CFTimeZoneRef timezone, CFStringRef name, CFDataRef data) {
+    CFTZPeriod *tzp = NULL;
+    CFIndex cnt = 0;
+    Boolean success = false;
+
+    __CFTimeZoneLockGlobal();
+    success = __CFParseTimeZoneData(kCFAllocatorSystemDefault, data, &tzp, &cnt);
+    __CFTimeZoneUnlockGlobal();
+
+    if (success) {
+        ((struct __CFTimeZone *)timezone)->_name = (CFStringRef)CFStringCreateCopy(kCFAllocatorSystemDefault, name);
+        ((struct __CFTimeZone *)timezone)->_data = CFDataCreateCopy(kCFAllocatorSystemDefault, data);
+        ((struct __CFTimeZone *)timezone)->_periods = tzp;
+        ((struct __CFTimeZone *)timezone)->_periodCnt = cnt;
+    }
+
+    return success;
+}
+
 Boolean _CFTimeZoneInit(CFTimeZoneRef timeZone, CFStringRef name, CFDataRef data) {
     if (!name || !__nameStringOK(name)) {
         return false;
     }
 
     if (data) {
-        CFTZPeriod *tzp = NULL;
-        CFIndex cnt = 0;
-        __CFTimeZoneLockGlobal();
-        if (__CFParseTimeZoneData(kCFAllocatorSystemDefault, data, &tzp, &cnt)) {
-            __CFTimeZoneUnlockGlobal();
-            
-        } else {
-            __CFTimeZoneUnlockGlobal();
-            return false;
-        }
-        ((struct __CFTimeZone *)timeZone)->_name = (CFStringRef)CFStringCreateCopy(kCFAllocatorSystemDefault, name);
-        ((struct __CFTimeZone *)timeZone)->_data = CFDataCreateCopy(kCFAllocatorSystemDefault, data);
-        ((struct __CFTimeZone *)timeZone)->_periods = tzp;
-        ((struct __CFTimeZone *)timeZone)->_periodCnt = cnt;
-        return true;
-    } else {
-        CFStringRef tzName = NULL;
-        CFDataRef data = NULL;
-        
-        CFIndex len = CFStringGetLength(name);
-        if (6 == len || 8 == len) {
-            UniChar buffer[8];
-            CFStringGetCharacters(name, CFRangeMake(0, len), buffer);
-            if ('G' == buffer[0] && 'M' == buffer[1] && 'T' == buffer[2] && ('+' == buffer[3] || '-' == buffer[3])) {
-                if (('0' <= buffer[4] && buffer[4] <= '9') && ('0' <= buffer[5] && buffer[5] <= '9')) {
-                    int32_t hours = (buffer[4] - '0') * 10 + (buffer[5] - '0');
-                    if (-14 <= hours && hours <= 14) {
-                        CFTimeInterval ti = hours * 3600.0;
-                        if (6 == len) {
-                            return _CFTimeZoneInitWithTimeIntervalFromGMT(timeZone, ('-' == buffer[3] ? -1.0 : 1.0) * ti);
-                        } else {
-                            if (('0' <= buffer[6] && buffer[6] <= '9') && ('0' <= buffer[7] && buffer[7] <= '9')) {
-                                int32_t minutes = (buffer[6] - '0') * 10 + (buffer[7] - '0');
-                                if ((-14 == hours && 0 == minutes) || (14 == hours && 0 == minutes) || (0 <= minutes && minutes <= 59)) {
-                                    ti = ti + minutes * 60.0;
-                                    return _CFTimeZoneInitWithTimeIntervalFromGMT(timeZone, ('-' == buffer[3] ? -1.0 : 1.0) * ti);
-                                }
+        return _CFTimeZoneInitInternal(timeZone, name, data);
+    }
+
+    CFIndex len = CFStringGetLength(name);
+    if (6 == len || 8 == len) {
+        UniChar buffer[8];
+        CFStringGetCharacters(name, CFRangeMake(0, len), buffer);
+        if ('G' == buffer[0] && 'M' == buffer[1] && 'T' == buffer[2] && ('+' == buffer[3] || '-' == buffer[3])) {
+            if (('0' <= buffer[4] && buffer[4] <= '9') && ('0' <= buffer[5] && buffer[5] <= '9')) {
+                int32_t hours = (buffer[4] - '0') * 10 + (buffer[5] - '0');
+                if (-14 <= hours && hours <= 14) {
+                    CFTimeInterval ti = hours * 3600.0;
+                    if (6 == len) {
+                        return _CFTimeZoneInitWithTimeIntervalFromGMT(timeZone, ('-' == buffer[3] ? -1.0 : 1.0) * ti);
+                    } else {
+                        if (('0' <= buffer[6] && buffer[6] <= '9') && ('0' <= buffer[7] && buffer[7] <= '9')) {
+                            int32_t minutes = (buffer[6] - '0') * 10 + (buffer[7] - '0');
+                            if ((-14 == hours && 0 == minutes) || (14 == hours && 0 == minutes) || (0 <= minutes && minutes <= 59)) {
+                                ti = ti + minutes * 60.0;
+                                return _CFTimeZoneInitWithTimeIntervalFromGMT(timeZone, ('-' == buffer[3] ? -1.0 : 1.0) * ti);
                             }
                         }
                     }
                 }
             }
         }
-        Boolean tryAbbrev = true;
-        CFURLRef baseURL, tempURL;
-        void *bytes;
-        CFIndex length;
-        Boolean result = false;
-        
-        if (!__tzZoneInfo) __InitTZStrings();
-        if (!__tzZoneInfo) return NULL;
+    }
+
+    CFStringRef tzName = NULL;
+    Boolean tryAbbrev = true;
+    CFURLRef baseURL, tempURL;
+    void *bytes;
+    CFIndex length;
+    Boolean result = false;
+    
+    if (!__tzZoneInfo) __InitTZStrings();
+    if (!__tzZoneInfo) return NULL;
 #if TARGET_OS_WIN32
-        baseURL = CFURLCreateWithFileSystemPath(kCFAllocatorSystemDefault, __tzZoneInfo, kCFURLWindowsPathStyle, true);
+    baseURL = CFURLCreateWithFileSystemPath(kCFAllocatorSystemDefault, __tzZoneInfo, kCFURLWindowsPathStyle, true);
 #else
-        baseURL = CFURLCreateWithFileSystemPath(kCFAllocatorSystemDefault, __tzZoneInfo, kCFURLPOSIXPathStyle, true);
+    baseURL = CFURLCreateWithFileSystemPath(kCFAllocatorSystemDefault, __tzZoneInfo, kCFURLPOSIXPathStyle, true);
 #endif
-        if (tryAbbrev) {
-            CFDictionaryRef abbrevs = CFTimeZoneCopyAbbreviationDictionary();
-            tzName = CFDictionaryGetValue(abbrevs, name);
-            if (NULL != tzName) {
-                tempURL = CFURLCreateCopyAppendingPathComponent(kCFAllocatorSystemDefault, baseURL, tzName, false);
-                if (NULL != tempURL) {
-                    if (_CFReadBytesFromFile(kCFAllocatorSystemDefault, tempURL, &bytes, &length, 0, 0)) {
-                        data = CFDataCreateWithBytesNoCopy(kCFAllocatorSystemDefault, bytes, length, kCFAllocatorSystemDefault);
-                    }
-                    CFRelease(tempURL);
-                }
-            }
-            CFRelease(abbrevs);
-        }
-        if (NULL == data) {
-            CFDictionaryRef dict = __CFTimeZoneCopyCompatibilityDictionary();
-            CFStringRef mapping = CFDictionaryGetValue(dict, name);
-            if (mapping) {
-                name = mapping;
-            } else if (CFStringHasPrefix(name, __tzZoneInfo)) {
-                CFMutableStringRef unprefixed = CFStringCreateMutableCopy(kCFAllocatorSystemDefault, CFStringGetLength(name), name);
-                CFStringDelete(unprefixed, CFRangeMake(0, CFStringGetLength(__tzZoneInfo)));
-                mapping = CFDictionaryGetValue(dict, unprefixed);
-                if (mapping) {
-                    name = mapping;
-                }
-                CFRelease(unprefixed);
-            }
-            CFRelease(dict);
-            if (CFEqual(CFSTR(""), name)) {
-                return false;
-            }
-        }
-        if (NULL == data) {
-            tzName = name;
+    if (tryAbbrev) {
+        CFDictionaryRef abbrevs = CFTimeZoneCopyAbbreviationDictionary();
+        tzName = CFDictionaryGetValue(abbrevs, name);
+        if (NULL != tzName) {
             tempURL = CFURLCreateCopyAppendingPathComponent(kCFAllocatorSystemDefault, baseURL, tzName, false);
             if (NULL != tempURL) {
                 if (_CFReadBytesFromFile(kCFAllocatorSystemDefault, tempURL, &bytes, &length, 0, 0)) {
@@ -1237,13 +1211,43 @@ Boolean _CFTimeZoneInit(CFTimeZoneRef timeZone, CFStringRef name, CFDataRef data
                 CFRelease(tempURL);
             }
         }
-        CFRelease(baseURL);
-        if (NULL != data) {
-            result = _CFTimeZoneInit(timeZone, tzName, data);
-            CFRelease(data);
-        }
-        return result;
+        CFRelease(abbrevs);
     }
+    if (NULL == data) {
+        CFDictionaryRef dict = __CFTimeZoneCopyCompatibilityDictionary();
+        CFStringRef mapping = CFDictionaryGetValue(dict, name);
+        if (mapping) {
+            name = mapping;
+        } else if (CFStringHasPrefix(name, __tzZoneInfo)) {
+            CFMutableStringRef unprefixed = CFStringCreateMutableCopy(kCFAllocatorSystemDefault, CFStringGetLength(name), name);
+            CFStringDelete(unprefixed, CFRangeMake(0, CFStringGetLength(__tzZoneInfo)));
+            mapping = CFDictionaryGetValue(dict, unprefixed);
+            if (mapping) {
+                name = mapping;
+            }
+            CFRelease(unprefixed);
+        }
+        CFRelease(dict);
+        if (CFEqual(CFSTR(""), name)) {
+            return false;
+        }
+    }
+    if (NULL == data) {
+        tzName = name;
+        tempURL = CFURLCreateCopyAppendingPathComponent(kCFAllocatorSystemDefault, baseURL, tzName, false);
+        if (NULL != tempURL) {
+            if (_CFReadBytesFromFile(kCFAllocatorSystemDefault, tempURL, &bytes, &length, 0, 0)) {
+                data = CFDataCreateWithBytesNoCopy(kCFAllocatorSystemDefault, bytes, length, kCFAllocatorSystemDefault);
+            }
+            CFRelease(tempURL);
+        }
+    }
+    CFRelease(baseURL);
+    if (NULL != data) {
+        result = _CFTimeZoneInitInternal(timeZone, tzName, data);
+        CFRelease(data);
+    }
+    return result;
 }
 
 CFTimeZoneRef CFTimeZoneCreate(CFAllocatorRef allocator, CFStringRef name, CFDataRef data) {

--- a/CoreFoundation/NumberDate.subproj/CFTimeZone.c
+++ b/CoreFoundation/NumberDate.subproj/CFTimeZone.c
@@ -1186,7 +1186,6 @@ Boolean _CFTimeZoneInit(CFTimeZoneRef timeZone, CFStringRef name, CFDataRef data
     }
 
     CFStringRef tzName = NULL;
-    Boolean tryAbbrev = true;
     CFURLRef baseURL, tempURL;
     void *bytes;
     CFIndex length;
@@ -1199,20 +1198,20 @@ Boolean _CFTimeZoneInit(CFTimeZoneRef timeZone, CFStringRef name, CFDataRef data
 #else
     baseURL = CFURLCreateWithFileSystemPath(kCFAllocatorSystemDefault, __tzZoneInfo, kCFURLPOSIXPathStyle, true);
 #endif
-    if (tryAbbrev) {
-        CFDictionaryRef abbrevs = CFTimeZoneCopyAbbreviationDictionary();
-        tzName = CFDictionaryGetValue(abbrevs, name);
-        if (NULL != tzName) {
-            tempURL = CFURLCreateCopyAppendingPathComponent(kCFAllocatorSystemDefault, baseURL, tzName, false);
-            if (NULL != tempURL) {
-                if (_CFReadBytesFromFile(kCFAllocatorSystemDefault, tempURL, &bytes, &length, 0, 0)) {
-                    data = CFDataCreateWithBytesNoCopy(kCFAllocatorSystemDefault, bytes, length, kCFAllocatorSystemDefault);
-                }
-                CFRelease(tempURL);
+
+    CFDictionaryRef abbrevs = CFTimeZoneCopyAbbreviationDictionary();
+    tzName = CFDictionaryGetValue(abbrevs, name);
+    if (NULL != tzName) {
+        tempURL = CFURLCreateCopyAppendingPathComponent(kCFAllocatorSystemDefault, baseURL, tzName, false);
+        if (NULL != tempURL) {
+            if (_CFReadBytesFromFile(kCFAllocatorSystemDefault, tempURL, &bytes, &length, 0, 0)) {
+                data = CFDataCreateWithBytesNoCopy(kCFAllocatorSystemDefault, bytes, length, kCFAllocatorSystemDefault);
             }
+            CFRelease(tempURL);
         }
-        CFRelease(abbrevs);
     }
+    CFRelease(abbrevs);
+
     if (NULL == data) {
         CFDictionaryRef dict = __CFTimeZoneCopyCompatibilityDictionary();
         CFStringRef mapping = CFDictionaryGetValue(dict, name);

--- a/CoreFoundation/OlsonWindowsMapping.plist
+++ b/CoreFoundation/OlsonWindowsMapping.plist
@@ -1,0 +1,738 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE plist SYSTEM "file:///localhost/System/Library/DTDs/PropertyList.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Etc/GMT+12</key>
+    <string>Dateline Standard Time</string>
+    <key>Pacific/Pago_Pago</key>
+    <string>UTC-11</string>
+    <key>Pacific/Niue</key>
+    <string>UTC-11</string>
+    <key>Pacific/Midway</key>
+    <string>UTC-11</string>
+    <key>Etc/GMT+11</key>
+    <string>UTC-11</string>
+    <key>America/Adak</key>
+    <string>Aleutian Standard Time</string>
+    <key>Pacific/Rarotonga</key>
+    <string>Hawaiian Standard Time</string>
+    <key>Pacific/Tahiti</key>
+    <string>Hawaiian Standard Time</string>
+    <key>Pacific/Johnston</key>
+    <string>Hawaiian Standard Time</string>
+    <key>Pacific/Honolulu</key>
+    <string>Hawaiian Standard Time</string>
+    <key>Etc/GMT+10</key>
+    <string>Hawaiian Standard Time</string>
+    <key>Pacific/Marquesas</key>
+    <string>Marquesas Standard Time</string>
+    <key>America/Anchorage</key>
+    <string>Alaskan Standard Time</string>
+    <key>Pacific/Gambier</key>
+    <string>UTC-09</string>
+    <key>Etc/GMT+9</key>
+    <string>UTC-09</string>
+    <key>America/Tijuana</key>
+    <string>Pacific Standard Time (Mexico)</string>
+    <key>Pacific/Pitcairn</key>
+    <string>UTC-08</string>
+    <key>Etc/GMT+8</key>
+    <string>UTC-08</string>
+    <key>America/Vancouver</key>
+    <string>Pacific Standard Time</string>
+    <key>America/Los_Angeles</key>
+    <string>Pacific Standard Time</string>
+    <key>PST8PDT</key>
+    <string>Pacific Standard Time</string>
+    <key>America/Dawson_Creek</key>
+    <string>US Mountain Standard Time</string>
+    <key>America/Hermosillo</key>
+    <string>US Mountain Standard Time</string>
+    <key>America/Phoenix</key>
+    <string>US Mountain Standard Time</string>
+    <key>Etc/GMT+7</key>
+    <string>US Mountain Standard Time</string>
+    <key>America/Chihuahua</key>
+    <string>Mountain Standard Time (Mexico)</string>
+    <key>America/Edmonton</key>
+    <string>Mountain Standard Time</string>
+    <key>America/Ojinaga</key>
+    <string>Mountain Standard Time</string>
+    <key>America/Denver</key>
+    <string>Mountain Standard Time</string>
+    <key>MST7MDT</key>
+    <string>Mountain Standard Time</string>
+    <key>America/Belize</key>
+    <string>Central America Standard Time</string>
+    <key>America/Costa_Rica</key>
+    <string>Central America Standard Time</string>
+    <key>Pacific/Galapagos</key>
+    <string>Central America Standard Time</string>
+    <key>America/Guatemala</key>
+    <string>Central America Standard Time</string>
+    <key>America/Tegucigalpa</key>
+    <string>Central America Standard Time</string>
+    <key>America/Managua</key>
+    <string>Central America Standard Time</string>
+    <key>America/El_Salvador</key>
+    <string>Central America Standard Time</string>
+    <key>Etc/GMT+6</key>
+    <string>Central America Standard Time</string>
+    <key>America/Winnipeg</key>
+    <string>Central Standard Time</string>
+    <key>America/Matamoros</key>
+    <string>Central Standard Time</string>
+    <key>America/Chicago</key>
+    <string>Central Standard Time</string>
+    <key>CST6CDT</key>
+    <string>Central Standard Time</string>
+    <key>Pacific/Easter</key>
+    <string>Easter Island Standard Time</string>
+    <key>America/Mexico_City</key>
+    <string>Central Standard Time (Mexico)</string>
+    <key>America/Regina</key>
+    <string>Canada Central Standard Time</string>
+    <key>America/Rio_Branco</key>
+    <string>SA Pacific Standard Time</string>
+    <key>America/Coral_Harbour</key>
+    <string>SA Pacific Standard Time</string>
+    <key>America/Bogota</key>
+    <string>SA Pacific Standard Time</string>
+    <key>America/Guayaquil</key>
+    <string>SA Pacific Standard Time</string>
+    <key>America/Jamaica</key>
+    <string>SA Pacific Standard Time</string>
+    <key>America/Cayman</key>
+    <string>SA Pacific Standard Time</string>
+    <key>America/Panama</key>
+    <string>SA Pacific Standard Time</string>
+    <key>America/Lima</key>
+    <string>SA Pacific Standard Time</string>
+    <key>Etc/GMT+5</key>
+    <string>SA Pacific Standard Time</string>
+    <key>America/Cancun</key>
+    <string>Eastern Standard Time (Mexico)</string>
+    <key>America/Nassau</key>
+    <string>Eastern Standard Time</string>
+    <key>America/Toronto</key>
+    <string>Eastern Standard Time</string>
+    <key>America/New_York</key>
+    <string>Eastern Standard Time</string>
+    <key>EST5EDT</key>
+    <string>Eastern Standard Time</string>
+    <key>America/Port-au-Prince</key>
+    <string>Haiti Standard Time</string>
+    <key>America/Havana</key>
+    <string>Cuba Standard Time</string>
+    <key>America/Indianapolis</key>
+    <string>US Eastern Standard Time</string>
+    <key>America/Asuncion</key>
+    <string>Paraguay Standard Time</string>
+    <key>Atlantic/Bermuda</key>
+    <string>Atlantic Standard Time</string>
+    <key>America/Halifax</key>
+    <string>Atlantic Standard Time</string>
+    <key>America/Thule</key>
+    <string>Atlantic Standard Time</string>
+    <key>America/Caracas</key>
+    <string>Venezuela Standard Time</string>
+    <key>America/Cuiaba</key>
+    <string>Central Brazilian Standard Time</string>
+    <key>America/Antigua</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Anguilla</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Aruba</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Barbados</key>
+    <string>SA Western Standard Time</string>
+    <key>America/St_Barthelemy</key>
+    <string>SA Western Standard Time</string>
+    <key>America/La_Paz</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Kralendijk</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Manaus</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Blanc-Sablon</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Curacao</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Dominica</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Santo_Domingo</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Grenada</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Guadeloupe</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Guyana</key>
+    <string>SA Western Standard Time</string>
+    <key>America/St_Kitts</key>
+    <string>SA Western Standard Time</string>
+    <key>America/St_Lucia</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Marigot</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Martinique</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Montserrat</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Puerto_Rico</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Lower_Princes</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Port_of_Spain</key>
+    <string>SA Western Standard Time</string>
+    <key>America/St_Vincent</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Tortola</key>
+    <string>SA Western Standard Time</string>
+    <key>America/St_Thomas</key>
+    <string>SA Western Standard Time</string>
+    <key>Etc/GMT+4</key>
+    <string>SA Western Standard Time</string>
+    <key>America/Santiago</key>
+    <string>Pacific SA Standard Time</string>
+    <key>America/Grand_Turk</key>
+    <string>Turks And Caicos Standard Time</string>
+    <key>America/St_Johns</key>
+    <string>Newfoundland Standard Time</string>
+    <key>America/Araguaina</key>
+    <string>Tocantins Standard Time</string>
+    <key>America/Sao_Paulo</key>
+    <string>E. South America Standard Time</string>
+    <key>Antarctica/Rothera</key>
+    <string>SA Eastern Standard Time</string>
+    <key>America/Fortaleza</key>
+    <string>SA Eastern Standard Time</string>
+    <key>Atlantic/Stanley</key>
+    <string>SA Eastern Standard Time</string>
+    <key>America/Cayenne</key>
+    <string>SA Eastern Standard Time</string>
+    <key>America/Paramaribo</key>
+    <string>SA Eastern Standard Time</string>
+    <key>Etc/GMT+3</key>
+    <string>SA Eastern Standard Time</string>
+    <key>America/Buenos_Aires</key>
+    <string>Argentina Standard Time</string>
+    <key>America/Godthab</key>
+    <string>Greenland Standard Time</string>
+    <key>America/Montevideo</key>
+    <string>Montevideo Standard Time</string>
+    <key>Antarctica/Palmer</key>
+    <string>Magallanes Standard Time</string>
+    <key>America/Punta_Arenas</key>
+    <string>Magallanes Standard Time</string>
+    <key>America/Miquelon</key>
+    <string>Saint Pierre Standard Time</string>
+    <key>America/Bahia</key>
+    <string>Bahia Standard Time</string>
+    <key>America/Noronha</key>
+    <string>UTC-02</string>
+    <key>Atlantic/South_Georgia</key>
+    <string>UTC-02</string>
+    <key>Etc/GMT+2</key>
+    <string>UTC-02</string>
+    <key>America/Scoresbysund</key>
+    <string>Azores Standard Time</string>
+    <key>Atlantic/Azores</key>
+    <string>Azores Standard Time</string>
+    <key>Atlantic/Cape_Verde</key>
+    <string>Cape Verde Standard Time</string>
+    <key>Etc/GMT+1</key>
+    <string>Cape Verde Standard Time</string>
+    <key>America/Danmarkshavn</key>
+    <string>UTC</string>
+    <key>Etc/GMT</key>
+    <string>UTC</string>
+    <key>Atlantic/Canary</key>
+    <string>GMT Standard Time</string>
+    <key>Atlantic/Faeroe</key>
+    <string>GMT Standard Time</string>
+    <key>Europe/London</key>
+    <string>GMT Standard Time</string>
+    <key>Europe/Guernsey</key>
+    <string>GMT Standard Time</string>
+    <key>Europe/Dublin</key>
+    <string>GMT Standard Time</string>
+    <key>Europe/Isle_of_Man</key>
+    <string>GMT Standard Time</string>
+    <key>Europe/Jersey</key>
+    <string>GMT Standard Time</string>
+    <key>Europe/Lisbon</key>
+    <string>GMT Standard Time</string>
+    <key>Africa/Ouagadougou</key>
+    <string>Greenwich Standard Time</string>
+    <key>Africa/Abidjan</key>
+    <string>Greenwich Standard Time</string>
+    <key>Africa/Accra</key>
+    <string>Greenwich Standard Time</string>
+    <key>Africa/Banjul</key>
+    <string>Greenwich Standard Time</string>
+    <key>Africa/Conakry</key>
+    <string>Greenwich Standard Time</string>
+    <key>Africa/Bissau</key>
+    <string>Greenwich Standard Time</string>
+    <key>Atlantic/Reykjavik</key>
+    <string>Greenwich Standard Time</string>
+    <key>Africa/Monrovia</key>
+    <string>Greenwich Standard Time</string>
+    <key>Africa/Bamako</key>
+    <string>Greenwich Standard Time</string>
+    <key>Africa/Nouakchott</key>
+    <string>Greenwich Standard Time</string>
+    <key>Atlantic/St_Helena</key>
+    <string>Greenwich Standard Time</string>
+    <key>Africa/Freetown</key>
+    <string>Greenwich Standard Time</string>
+    <key>Africa/Dakar</key>
+    <string>Greenwich Standard Time</string>
+    <key>Africa/Lome</key>
+    <string>Greenwich Standard Time</string>
+    <key>Europe/Andorra</key>
+    <string>W. Europe Standard Time</string>
+    <key>Europe/Vienna</key>
+    <string>W. Europe Standard Time</string>
+    <key>Europe/Zurich</key>
+    <string>W. Europe Standard Time</string>
+    <key>Europe/Berlin</key>
+    <string>W. Europe Standard Time</string>
+    <key>Europe/Gibraltar</key>
+    <string>W. Europe Standard Time</string>
+    <key>Europe/Rome</key>
+    <string>W. Europe Standard Time</string>
+    <key>Europe/Vaduz</key>
+    <string>W. Europe Standard Time</string>
+    <key>Europe/Luxembourg</key>
+    <string>W. Europe Standard Time</string>
+    <key>Europe/Monaco</key>
+    <string>W. Europe Standard Time</string>
+    <key>Europe/Malta</key>
+    <string>W. Europe Standard Time</string>
+    <key>Europe/Amsterdam</key>
+    <string>W. Europe Standard Time</string>
+    <key>Europe/Oslo</key>
+    <string>W. Europe Standard Time</string>
+    <key>Europe/Stockholm</key>
+    <string>W. Europe Standard Time</string>
+    <key>Arctic/Longyearbyen</key>
+    <string>W. Europe Standard Time</string>
+    <key>Europe/San_Marino</key>
+    <string>W. Europe Standard Time</string>
+    <key>Europe/Vatican</key>
+    <string>W. Europe Standard Time</string>
+    <key>Europe/Tirane</key>
+    <string>Central Europe Standard Time</string>
+    <key>Europe/Prague</key>
+    <string>Central Europe Standard Time</string>
+    <key>Europe/Budapest</key>
+    <string>Central Europe Standard Time</string>
+    <key>Europe/Podgorica</key>
+    <string>Central Europe Standard Time</string>
+    <key>Europe/Belgrade</key>
+    <string>Central Europe Standard Time</string>
+    <key>Europe/Ljubljana</key>
+    <string>Central Europe Standard Time</string>
+    <key>Europe/Bratislava</key>
+    <string>Central Europe Standard Time</string>
+    <key>Europe/Brussels</key>
+    <string>Romance Standard Time</string>
+    <key>Europe/Copenhagen</key>
+    <string>Romance Standard Time</string>
+    <key>Europe/Madrid</key>
+    <string>Romance Standard Time</string>
+    <key>Europe/Paris</key>
+    <string>Romance Standard Time</string>
+    <key>Africa/El_Aaiun</key>
+    <string>Morocco Standard Time</string>
+    <key>Africa/Casablanca</key>
+    <string>Morocco Standard Time</string>
+    <key>Africa/Sao_Tome</key>
+    <string>Sao Tome Standard Time</string>
+    <key>Europe/Sarajevo</key>
+    <string>Central European Standard Time</string>
+    <key>Europe/Zagreb</key>
+    <string>Central European Standard Time</string>
+    <key>Europe/Skopje</key>
+    <string>Central European Standard Time</string>
+    <key>Europe/Warsaw</key>
+    <string>Central European Standard Time</string>
+    <key>Africa/Luanda</key>
+    <string>W. Central Africa Standard Time</string>
+    <key>Africa/Porto-Novo</key>
+    <string>W. Central Africa Standard Time</string>
+    <key>Africa/Kinshasa</key>
+    <string>W. Central Africa Standard Time</string>
+    <key>Africa/Bangui</key>
+    <string>W. Central Africa Standard Time</string>
+    <key>Africa/Brazzaville</key>
+    <string>W. Central Africa Standard Time</string>
+    <key>Africa/Douala</key>
+    <string>W. Central Africa Standard Time</string>
+    <key>Africa/Algiers</key>
+    <string>W. Central Africa Standard Time</string>
+    <key>Africa/Libreville</key>
+    <string>W. Central Africa Standard Time</string>
+    <key>Africa/Malabo</key>
+    <string>W. Central Africa Standard Time</string>
+    <key>Africa/Niamey</key>
+    <string>W. Central Africa Standard Time</string>
+    <key>Africa/Lagos</key>
+    <string>W. Central Africa Standard Time</string>
+    <key>Africa/Ndjamena</key>
+    <string>W. Central Africa Standard Time</string>
+    <key>Africa/Tunis</key>
+    <string>W. Central Africa Standard Time</string>
+    <key>Etc/GMT-1</key>
+    <string>W. Central Africa Standard Time</string>
+    <key>Asia/Amman</key>
+    <string>Jordan Standard Time</string>
+    <key>Asia/Famagusta</key>
+    <string>GTB Standard Time</string>
+    <key>Europe/Athens</key>
+    <string>GTB Standard Time</string>
+    <key>Europe/Bucharest</key>
+    <string>GTB Standard Time</string>
+    <key>Asia/Beirut</key>
+    <string>Middle East Standard Time</string>
+    <key>Africa/Cairo</key>
+    <string>Egypt Standard Time</string>
+    <key>Europe/Chisinau</key>
+    <string>E. Europe Standard Time</string>
+    <key>Asia/Damascus</key>
+    <string>Syria Standard Time</string>
+    <key>Asia/Hebron</key>
+    <string>West Bank Standard Time</string>
+    <key>Africa/Bujumbura</key>
+    <string>South Africa Standard Time</string>
+    <key>Africa/Gaborone</key>
+    <string>South Africa Standard Time</string>
+    <key>Africa/Lubumbashi</key>
+    <string>South Africa Standard Time</string>
+    <key>Africa/Maseru</key>
+    <string>South Africa Standard Time</string>
+    <key>Africa/Blantyre</key>
+    <string>South Africa Standard Time</string>
+    <key>Africa/Maputo</key>
+    <string>South Africa Standard Time</string>
+    <key>Africa/Kigali</key>
+    <string>South Africa Standard Time</string>
+    <key>Africa/Mbabane</key>
+    <string>South Africa Standard Time</string>
+    <key>Africa/Johannesburg</key>
+    <string>South Africa Standard Time</string>
+    <key>Africa/Lusaka</key>
+    <string>South Africa Standard Time</string>
+    <key>Africa/Harare</key>
+    <string>South Africa Standard Time</string>
+    <key>Etc/GMT-2</key>
+    <string>South Africa Standard Time</string>
+    <key>Europe/Mariehamn</key>
+    <string>FLE Standard Time</string>
+    <key>Europe/Sofia</key>
+    <string>FLE Standard Time</string>
+    <key>Europe/Tallinn</key>
+    <string>FLE Standard Time</string>
+    <key>Europe/Helsinki</key>
+    <string>FLE Standard Time</string>
+    <key>Europe/Vilnius</key>
+    <string>FLE Standard Time</string>
+    <key>Europe/Riga</key>
+    <string>FLE Standard Time</string>
+    <key>Europe/Kiev</key>
+    <string>FLE Standard Time</string>
+    <key>Asia/Jerusalem</key>
+    <string>Israel Standard Time</string>
+    <key>Europe/Kaliningrad</key>
+    <string>Kaliningrad Standard Time</string>
+    <key>Africa/Khartoum</key>
+    <string>Sudan Standard Time</string>
+    <key>Africa/Tripoli</key>
+    <string>Libya Standard Time</string>
+    <key>Africa/Windhoek</key>
+    <string>Namibia Standard Time</string>
+    <key>Asia/Baghdad</key>
+    <string>Arabic Standard Time</string>
+    <key>Europe/Istanbul</key>
+    <string>Turkey Standard Time</string>
+    <key>Asia/Bahrain</key>
+    <string>Arab Standard Time</string>
+    <key>Asia/Kuwait</key>
+    <string>Arab Standard Time</string>
+    <key>Asia/Qatar</key>
+    <string>Arab Standard Time</string>
+    <key>Asia/Riyadh</key>
+    <string>Arab Standard Time</string>
+    <key>Asia/Aden</key>
+    <string>Arab Standard Time</string>
+    <key>Europe/Minsk</key>
+    <string>Belarus Standard Time</string>
+    <key>Europe/Moscow</key>
+    <string>Russian Standard Time</string>
+    <key>Europe/Simferopol</key>
+    <string>Russian Standard Time</string>
+    <key>Antarctica/Syowa</key>
+    <string>E. Africa Standard Time</string>
+    <key>Africa/Djibouti</key>
+    <string>E. Africa Standard Time</string>
+    <key>Africa/Asmera</key>
+    <string>E. Africa Standard Time</string>
+    <key>Africa/Addis_Ababa</key>
+    <string>E. Africa Standard Time</string>
+    <key>Africa/Nairobi</key>
+    <string>E. Africa Standard Time</string>
+    <key>Indian/Comoro</key>
+    <string>E. Africa Standard Time</string>
+    <key>Indian/Antananarivo</key>
+    <string>E. Africa Standard Time</string>
+    <key>Africa/Mogadishu</key>
+    <string>E. Africa Standard Time</string>
+    <key>Africa/Juba</key>
+    <string>E. Africa Standard Time</string>
+    <key>Africa/Dar_es_Salaam</key>
+    <string>E. Africa Standard Time</string>
+    <key>Africa/Kampala</key>
+    <string>E. Africa Standard Time</string>
+    <key>Indian/Mayotte</key>
+    <string>E. Africa Standard Time</string>
+    <key>Etc/GMT-3</key>
+    <string>E. Africa Standard Time</string>
+    <key>Asia/Tehran</key>
+    <string>Iran Standard Time</string>
+    <key>Asia/Dubai</key>
+    <string>Arabian Standard Time</string>
+    <key>Asia/Muscat</key>
+    <string>Arabian Standard Time</string>
+    <key>Etc/GMT-4</key>
+    <string>Arabian Standard Time</string>
+    <key>Europe/Astrakhan</key>
+    <string>Astrakhan Standard Time</string>
+    <key>Asia/Baku</key>
+    <string>Azerbaijan Standard Time</string>
+    <key>Europe/Samara</key>
+    <string>Russia Time Zone 3</string>
+    <key>Indian/Mauritius</key>
+    <string>Mauritius Standard Time</string>
+    <key>Indian/Reunion</key>
+    <string>Mauritius Standard Time</string>
+    <key>Indian/Mahe</key>
+    <string>Mauritius Standard Time</string>
+    <key>Europe/Saratov</key>
+    <string>Saratov Standard Time</string>
+    <key>Asia/Tbilisi</key>
+    <string>Georgian Standard Time</string>
+    <key>Asia/Yerevan</key>
+    <string>Caucasus Standard Time</string>
+    <key>Asia/Kabul</key>
+    <string>Afghanistan Standard Time</string>
+    <key>Antarctica/Mawson</key>
+    <string>West Asia Standard Time</string>
+    <key>Asia/Oral</key>
+    <string>West Asia Standard Time</string>
+    <key>Indian/Maldives</key>
+    <string>West Asia Standard Time</string>
+    <key>Indian/Kerguelen</key>
+    <string>West Asia Standard Time</string>
+    <key>Asia/Dushanbe</key>
+    <string>West Asia Standard Time</string>
+    <key>Asia/Ashgabat</key>
+    <string>West Asia Standard Time</string>
+    <key>Asia/Tashkent</key>
+    <string>West Asia Standard Time</string>
+    <key>Etc/GMT-5</key>
+    <string>West Asia Standard Time</string>
+    <key>Asia/Yekaterinburg</key>
+    <string>Ekaterinburg Standard Time</string>
+    <key>Asia/Karachi</key>
+    <string>Pakistan Standard Time</string>
+    <key>Asia/Calcutta</key>
+    <string>India Standard Time</string>
+    <key>Asia/Colombo</key>
+    <string>Sri Lanka Standard Time</string>
+    <key>Asia/Katmandu</key>
+    <string>Nepal Standard Time</string>
+    <key>Antarctica/Vostok</key>
+    <string>Central Asia Standard Time</string>
+    <key>Asia/Urumqi</key>
+    <string>Central Asia Standard Time</string>
+    <key>Indian/Chagos</key>
+    <string>Central Asia Standard Time</string>
+    <key>Asia/Bishkek</key>
+    <string>Central Asia Standard Time</string>
+    <key>Asia/Almaty</key>
+    <string>Central Asia Standard Time</string>
+    <key>Etc/GMT-6</key>
+    <string>Central Asia Standard Time</string>
+    <key>Asia/Dhaka</key>
+    <string>Bangladesh Standard Time</string>
+    <key>Asia/Thimphu</key>
+    <string>Bangladesh Standard Time</string>
+    <key>Asia/Omsk</key>
+    <string>Omsk Standard Time</string>
+    <key>Indian/Cocos</key>
+    <string>Myanmar Standard Time</string>
+    <key>Asia/Rangoon</key>
+    <string>Myanmar Standard Time</string>
+    <key>Antarctica/Davis</key>
+    <string>SE Asia Standard Time</string>
+    <key>Indian/Christmas</key>
+    <string>SE Asia Standard Time</string>
+    <key>Asia/Jakarta</key>
+    <string>SE Asia Standard Time</string>
+    <key>Asia/Phnom_Penh</key>
+    <string>SE Asia Standard Time</string>
+    <key>Asia/Vientiane</key>
+    <string>SE Asia Standard Time</string>
+    <key>Asia/Bangkok</key>
+    <string>SE Asia Standard Time</string>
+    <key>Asia/Saigon</key>
+    <string>SE Asia Standard Time</string>
+    <key>Etc/GMT-7</key>
+    <string>SE Asia Standard Time</string>
+    <key>Asia/Barnaul</key>
+    <string>Altai Standard Time</string>
+    <key>Asia/Hovd</key>
+    <string>W. Mongolia Standard Time</string>
+    <key>Asia/Krasnoyarsk</key>
+    <string>North Asia Standard Time</string>
+    <key>Asia/Novosibirsk</key>
+    <string>N. Central Asia Standard Time</string>
+    <key>Asia/Tomsk</key>
+    <string>Tomsk Standard Time</string>
+    <key>Asia/Shanghai</key>
+    <string>China Standard Time</string>
+    <key>Asia/Hong_Kong</key>
+    <string>China Standard Time</string>
+    <key>Asia/Macau</key>
+    <string>China Standard Time</string>
+    <key>Asia/Irkutsk</key>
+    <string>North Asia East Standard Time</string>
+    <key>Asia/Brunei</key>
+    <string>Singapore Standard Time</string>
+    <key>Asia/Makassar</key>
+    <string>Singapore Standard Time</string>
+    <key>Asia/Kuala_Lumpur</key>
+    <string>Singapore Standard Time</string>
+    <key>Asia/Manila</key>
+    <string>Singapore Standard Time</string>
+    <key>Asia/Singapore</key>
+    <string>Singapore Standard Time</string>
+    <key>Etc/GMT-8</key>
+    <string>Singapore Standard Time</string>
+    <key>Antarctica/Casey</key>
+    <string>W. Australia Standard Time</string>
+    <key>Australia/Perth</key>
+    <string>W. Australia Standard Time</string>
+    <key>Asia/Taipei</key>
+    <string>Taipei Standard Time</string>
+    <key>Asia/Ulaanbaatar</key>
+    <string>Ulaanbaatar Standard Time</string>
+    <key>Australia/Eucla</key>
+    <string>Aus Central W. Standard Time</string>
+    <key>Asia/Chita</key>
+    <string>Transbaikal Standard Time</string>
+    <key>Asia/Jayapura</key>
+    <string>Tokyo Standard Time</string>
+    <key>Asia/Tokyo</key>
+    <string>Tokyo Standard Time</string>
+    <key>Pacific/Palau</key>
+    <string>Tokyo Standard Time</string>
+    <key>Asia/Dili</key>
+    <string>Tokyo Standard Time</string>
+    <key>Etc/GMT-9</key>
+    <string>Tokyo Standard Time</string>
+    <key>Asia/Pyongyang</key>
+    <string>North Korea Standard Time</string>
+    <key>Asia/Seoul</key>
+    <string>Korea Standard Time</string>
+    <key>Asia/Yakutsk</key>
+    <string>Yakutsk Standard Time</string>
+    <key>Australia/Adelaide</key>
+    <string>Cen. Australia Standard Time</string>
+    <key>Australia/Darwin</key>
+    <string>AUS Central Standard Time</string>
+    <key>Australia/Brisbane</key>
+    <string>E. Australia Standard Time</string>
+    <key>Australia/Sydney</key>
+    <string>AUS Eastern Standard Time</string>
+    <key>Antarctica/DumontDUrville</key>
+    <string>West Pacific Standard Time</string>
+    <key>Pacific/Truk</key>
+    <string>West Pacific Standard Time</string>
+    <key>Pacific/Guam</key>
+    <string>West Pacific Standard Time</string>
+    <key>Pacific/Saipan</key>
+    <string>West Pacific Standard Time</string>
+    <key>Pacific/Port_Moresby</key>
+    <string>West Pacific Standard Time</string>
+    <key>Etc/GMT-10</key>
+    <string>West Pacific Standard Time</string>
+    <key>Australia/Hobart</key>
+    <string>Tasmania Standard Time</string>
+    <key>Asia/Vladivostok</key>
+    <string>Vladivostok Standard Time</string>
+    <key>Australia/Lord_Howe</key>
+    <string>Lord Howe Standard Time</string>
+    <key>Pacific/Bougainville</key>
+    <string>Bougainville Standard Time</string>
+    <key>Asia/Srednekolymsk</key>
+    <string>Russia Time Zone 10</string>
+    <key>Asia/Magadan</key>
+    <string>Magadan Standard Time</string>
+    <key>Pacific/Norfolk</key>
+    <string>Norfolk Standard Time</string>
+    <key>Asia/Sakhalin</key>
+    <string>Sakhalin Standard Time</string>
+    <key>Antarctica/Macquarie</key>
+    <string>Central Pacific Standard Time</string>
+    <key>Pacific/Ponape</key>
+    <string>Central Pacific Standard Time</string>
+    <key>Pacific/Noumea</key>
+    <string>Central Pacific Standard Time</string>
+    <key>Pacific/Guadalcanal</key>
+    <string>Central Pacific Standard Time</string>
+    <key>Pacific/Efate</key>
+    <string>Central Pacific Standard Time</string>
+    <key>Etc/GMT-11</key>
+    <string>Central Pacific Standard Time</string>
+    <key>Asia/Kamchatka</key>
+    <string>Russia Time Zone 11</string>
+    <key>Antarctica/McMurdo</key>
+    <string>New Zealand Standard Time</string>
+    <key>Pacific/Auckland</key>
+    <string>New Zealand Standard Time</string>
+    <key>Pacific/Tarawa</key>
+    <string>UTC+12</string>
+    <key>Pacific/Majuro</key>
+    <string>UTC+12</string>
+    <key>Pacific/Nauru</key>
+    <string>UTC+12</string>
+    <key>Pacific/Funafuti</key>
+    <string>UTC+12</string>
+    <key>Pacific/Wake</key>
+    <string>UTC+12</string>
+    <key>Pacific/Wallis</key>
+    <string>UTC+12</string>
+    <key>Etc/GMT-12</key>
+    <string>UTC+12</string>
+    <key>Pacific/Fiji</key>
+    <string>Fiji Standard Time</string>
+    <key>Pacific/Chatham</key>
+    <string>Chatham Islands Standard Time</string>
+    <key>Pacific/Enderbury</key>
+    <string>UTC+13</string>
+    <key>Pacific/Fakaofo</key>
+    <string>UTC+13</string>
+    <key>Etc/GMT-13</key>
+    <string>UTC+13</string>
+    <key>Pacific/Tongatapu</key>
+    <string>Tonga Standard Time</string>
+    <key>Pacific/Apia</key>
+    <string>Samoa Standard Time</string>
+    <key>Pacific/Kiritimati</key>
+    <string>Line Islands Standard Time</string>
+    <key>Etc/GMT-14</key>
+    <string>Line Islands Standard Time</string>
+  </dict>
+</plist>

--- a/CoreFoundation/Tools/OlsonWindowsDatabase.xsl
+++ b/CoreFoundation/Tools/OlsonWindowsDatabase.xsl
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  This XSL transforms the Windows Timezone list from the Unicode CLDR to a plist
+  which is consumable by CoreFoundation.  You need to fetch the lastest mapping
+  from the Unicode consortium from:
+    https://unicode.org/repos/cldr/trunk/common/supplemental/windowsZones.xml
+  The XSL can be applied to this data via the `xsltproc` command.
+  Running
+    `xsltproc &dash;&dash;novalid OlsonWindowsDatabase.xsl windowsZones.xml`
+  will generate the mapping plist.
+-->
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:ext="http://exslt.org/common"
+                exclude-result-prefixes="ext">
+  <xsl:output encoding="utf-8" indent="yes" />
+
+  <xsl:template name="tokenize">
+    <xsl:param name="string" />
+    <xsl:param name="delimiter" />
+
+    <xsl:choose>
+      <xsl:when test="not($string)"><items><item/></items></xsl:when>
+      <xsl:when test="not(contains($string, $delimiter))" ><items><item><xsl:value-of select="$string" /></item></items></xsl:when>
+      <xsl:otherwise><items><item><xsl:value-of select="normalize-space(substring-before($string, $delimiter))" /></item><xsl:call-template name="tokenize">
+  <xsl:with-param name="string" select="substring-after($string, $delimiter)" />
+  <xsl:with-param name="delimiter" select="$delimiter" />
+</xsl:call-template></items>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="/">
+    <xsl:text disable-output-escaping="yes">&lt;!DOCTYPE plist SYSTEM "file:///localhost/System/Library/DTDs/PropertyList.dtd"&gt;
+</xsl:text>
+<plist version="1.0">
+  <dict>
+    <xsl:for-each select="supplementalData/windowsZones/mapTimezones/mapZone[not(@territory='001')]">
+<xsl:variable name="names">
+  <xsl:call-template name="tokenize">
+    <xsl:with-param name="string" select="@type" />
+    <xsl:with-param name="delimiter" select="' '" />
+  </xsl:call-template>
+</xsl:variable>
+    <key><xsl:value-of select="ext:node-set($names)/items/*" /></key>
+    <string><xsl:value-of select="@other" /></string>
+    </xsl:for-each>
+  </dict>
+</plist>
+  </xsl:template>
+</xsl:stylesheet>

--- a/CoreFoundation/Tools/WindowsOlsonDatabase.xsl
+++ b/CoreFoundation/Tools/WindowsOlsonDatabase.xsl
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  This XSL transforms the Windows Timezone list from the Unicode CLDR to a plist
+  which is consumable by CoreFoundation.  You need to fetch the lastest mapping
+  from the Unicode consortium from:
+    https://unicode.org/repos/cldr/trunk/common/supplemental/windowsZones.xml
+  The XSL can be applied to this data via the `xsltproc` command.
+  Running
+    `xsltproc &dash;&dash;novalid WindowsOlsonDatabase.xsl windowsZones.xml`
+  will generate the mapping plist.
+-->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output encoding="utf-8" indent="yes" />
+
+  <xsl:template match="/">
+    <xsl:text disable-output-escaping="yes">&lt;!DOCTYPE plist SYSTEM "file:///localhost/System/Library/DTDs/PropertyList.dtd"&gt;
+</xsl:text>
+<plist version="1.0">
+  <dict>
+    <xsl:for-each select="supplementalData/windowsZones/mapTimezones/mapZone[@territory='001']">
+    <key><xsl:value-of select="@other" /></key>
+    <string><xsl:value-of select="@type" /></string>
+    </xsl:for-each>
+  </dict>
+</plist>
+  </xsl:template>
+</xsl:stylesheet>

--- a/CoreFoundation/WindowsOlsonMapping.plist
+++ b/CoreFoundation/WindowsOlsonMapping.plist
@@ -1,0 +1,276 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE plist SYSTEM "file:///localhost/System/Library/DTDs/PropertyList.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Dateline Standard Time</key>
+    <string>Etc/GMT+12</string>
+    <key>UTC-11</key>
+    <string>Etc/GMT+11</string>
+    <key>Aleutian Standard Time</key>
+    <string>America/Adak</string>
+    <key>Hawaiian Standard Time</key>
+    <string>Pacific/Honolulu</string>
+    <key>Marquesas Standard Time</key>
+    <string>Pacific/Marquesas</string>
+    <key>Alaskan Standard Time</key>
+    <string>America/Anchorage</string>
+    <key>UTC-09</key>
+    <string>Etc/GMT+9</string>
+    <key>Pacific Standard Time (Mexico)</key>
+    <string>America/Tijuana</string>
+    <key>UTC-08</key>
+    <string>Etc/GMT+8</string>
+    <key>Pacific Standard Time</key>
+    <string>America/Los_Angeles</string>
+    <key>US Mountain Standard Time</key>
+    <string>America/Phoenix</string>
+    <key>Mountain Standard Time (Mexico)</key>
+    <string>America/Chihuahua</string>
+    <key>Mountain Standard Time</key>
+    <string>America/Denver</string>
+    <key>Central America Standard Time</key>
+    <string>America/Guatemala</string>
+    <key>Central Standard Time</key>
+    <string>America/Chicago</string>
+    <key>Easter Island Standard Time</key>
+    <string>Pacific/Easter</string>
+    <key>Central Standard Time (Mexico)</key>
+    <string>America/Mexico_City</string>
+    <key>Canada Central Standard Time</key>
+    <string>America/Regina</string>
+    <key>SA Pacific Standard Time</key>
+    <string>America/Bogota</string>
+    <key>Eastern Standard Time (Mexico)</key>
+    <string>America/Cancun</string>
+    <key>Eastern Standard Time</key>
+    <string>America/New_York</string>
+    <key>Haiti Standard Time</key>
+    <string>America/Port-au-Prince</string>
+    <key>Cuba Standard Time</key>
+    <string>America/Havana</string>
+    <key>US Eastern Standard Time</key>
+    <string>America/Indianapolis</string>
+    <key>Paraguay Standard Time</key>
+    <string>America/Asuncion</string>
+    <key>Atlantic Standard Time</key>
+    <string>America/Halifax</string>
+    <key>Venezuela Standard Time</key>
+    <string>America/Caracas</string>
+    <key>Central Brazilian Standard Time</key>
+    <string>America/Cuiaba</string>
+    <key>SA Western Standard Time</key>
+    <string>America/La_Paz</string>
+    <key>Pacific SA Standard Time</key>
+    <string>America/Santiago</string>
+    <key>Turks And Caicos Standard Time</key>
+    <string>America/Grand_Turk</string>
+    <key>Newfoundland Standard Time</key>
+    <string>America/St_Johns</string>
+    <key>Tocantins Standard Time</key>
+    <string>America/Araguaina</string>
+    <key>E. South America Standard Time</key>
+    <string>America/Sao_Paulo</string>
+    <key>SA Eastern Standard Time</key>
+    <string>America/Cayenne</string>
+    <key>Argentina Standard Time</key>
+    <string>America/Buenos_Aires</string>
+    <key>Greenland Standard Time</key>
+    <string>America/Godthab</string>
+    <key>Montevideo Standard Time</key>
+    <string>America/Montevideo</string>
+    <key>Magallanes Standard Time</key>
+    <string>America/Punta_Arenas</string>
+    <key>Saint Pierre Standard Time</key>
+    <string>America/Miquelon</string>
+    <key>Bahia Standard Time</key>
+    <string>America/Bahia</string>
+    <key>UTC-02</key>
+    <string>Etc/GMT+2</string>
+    <key>Azores Standard Time</key>
+    <string>Atlantic/Azores</string>
+    <key>Cape Verde Standard Time</key>
+    <string>Atlantic/Cape_Verde</string>
+    <key>UTC</key>
+    <string>Etc/GMT</string>
+    <key>GMT Standard Time</key>
+    <string>Europe/London</string>
+    <key>Greenwich Standard Time</key>
+    <string>Atlantic/Reykjavik</string>
+    <key>W. Europe Standard Time</key>
+    <string>Europe/Berlin</string>
+    <key>Central Europe Standard Time</key>
+    <string>Europe/Budapest</string>
+    <key>Romance Standard Time</key>
+    <string>Europe/Paris</string>
+    <key>Morocco Standard Time</key>
+    <string>Africa/Casablanca</string>
+    <key>Sao Tome Standard Time</key>
+    <string>Africa/Sao_Tome</string>
+    <key>Central European Standard Time</key>
+    <string>Europe/Warsaw</string>
+    <key>W. Central Africa Standard Time</key>
+    <string>Africa/Lagos</string>
+    <key>Jordan Standard Time</key>
+    <string>Asia/Amman</string>
+    <key>GTB Standard Time</key>
+    <string>Europe/Bucharest</string>
+    <key>Middle East Standard Time</key>
+    <string>Asia/Beirut</string>
+    <key>Egypt Standard Time</key>
+    <string>Africa/Cairo</string>
+    <key>E. Europe Standard Time</key>
+    <string>Europe/Chisinau</string>
+    <key>Syria Standard Time</key>
+    <string>Asia/Damascus</string>
+    <key>West Bank Standard Time</key>
+    <string>Asia/Hebron</string>
+    <key>South Africa Standard Time</key>
+    <string>Africa/Johannesburg</string>
+    <key>FLE Standard Time</key>
+    <string>Europe/Kiev</string>
+    <key>Israel Standard Time</key>
+    <string>Asia/Jerusalem</string>
+    <key>Kaliningrad Standard Time</key>
+    <string>Europe/Kaliningrad</string>
+    <key>Sudan Standard Time</key>
+    <string>Africa/Khartoum</string>
+    <key>Libya Standard Time</key>
+    <string>Africa/Tripoli</string>
+    <key>Namibia Standard Time</key>
+    <string>Africa/Windhoek</string>
+    <key>Arabic Standard Time</key>
+    <string>Asia/Baghdad</string>
+    <key>Turkey Standard Time</key>
+    <string>Europe/Istanbul</string>
+    <key>Arab Standard Time</key>
+    <string>Asia/Riyadh</string>
+    <key>Belarus Standard Time</key>
+    <string>Europe/Minsk</string>
+    <key>Russian Standard Time</key>
+    <string>Europe/Moscow</string>
+    <key>E. Africa Standard Time</key>
+    <string>Africa/Nairobi</string>
+    <key>Iran Standard Time</key>
+    <string>Asia/Tehran</string>
+    <key>Arabian Standard Time</key>
+    <string>Asia/Dubai</string>
+    <key>Astrakhan Standard Time</key>
+    <string>Europe/Astrakhan</string>
+    <key>Azerbaijan Standard Time</key>
+    <string>Asia/Baku</string>
+    <key>Russia Time Zone 3</key>
+    <string>Europe/Samara</string>
+    <key>Mauritius Standard Time</key>
+    <string>Indian/Mauritius</string>
+    <key>Saratov Standard Time</key>
+    <string>Europe/Saratov</string>
+    <key>Georgian Standard Time</key>
+    <string>Asia/Tbilisi</string>
+    <key>Caucasus Standard Time</key>
+    <string>Asia/Yerevan</string>
+    <key>Afghanistan Standard Time</key>
+    <string>Asia/Kabul</string>
+    <key>West Asia Standard Time</key>
+    <string>Asia/Tashkent</string>
+    <key>Ekaterinburg Standard Time</key>
+    <string>Asia/Yekaterinburg</string>
+    <key>Pakistan Standard Time</key>
+    <string>Asia/Karachi</string>
+    <key>India Standard Time</key>
+    <string>Asia/Calcutta</string>
+    <key>Sri Lanka Standard Time</key>
+    <string>Asia/Colombo</string>
+    <key>Nepal Standard Time</key>
+    <string>Asia/Katmandu</string>
+    <key>Central Asia Standard Time</key>
+    <string>Asia/Almaty</string>
+    <key>Bangladesh Standard Time</key>
+    <string>Asia/Dhaka</string>
+    <key>Omsk Standard Time</key>
+    <string>Asia/Omsk</string>
+    <key>Myanmar Standard Time</key>
+    <string>Asia/Rangoon</string>
+    <key>SE Asia Standard Time</key>
+    <string>Asia/Bangkok</string>
+    <key>Altai Standard Time</key>
+    <string>Asia/Barnaul</string>
+    <key>W. Mongolia Standard Time</key>
+    <string>Asia/Hovd</string>
+    <key>North Asia Standard Time</key>
+    <string>Asia/Krasnoyarsk</string>
+    <key>N. Central Asia Standard Time</key>
+    <string>Asia/Novosibirsk</string>
+    <key>Tomsk Standard Time</key>
+    <string>Asia/Tomsk</string>
+    <key>China Standard Time</key>
+    <string>Asia/Shanghai</string>
+    <key>North Asia East Standard Time</key>
+    <string>Asia/Irkutsk</string>
+    <key>Singapore Standard Time</key>
+    <string>Asia/Singapore</string>
+    <key>W. Australia Standard Time</key>
+    <string>Australia/Perth</string>
+    <key>Taipei Standard Time</key>
+    <string>Asia/Taipei</string>
+    <key>Ulaanbaatar Standard Time</key>
+    <string>Asia/Ulaanbaatar</string>
+    <key>Aus Central W. Standard Time</key>
+    <string>Australia/Eucla</string>
+    <key>Transbaikal Standard Time</key>
+    <string>Asia/Chita</string>
+    <key>Tokyo Standard Time</key>
+    <string>Asia/Tokyo</string>
+    <key>North Korea Standard Time</key>
+    <string>Asia/Pyongyang</string>
+    <key>Korea Standard Time</key>
+    <string>Asia/Seoul</string>
+    <key>Yakutsk Standard Time</key>
+    <string>Asia/Yakutsk</string>
+    <key>Cen. Australia Standard Time</key>
+    <string>Australia/Adelaide</string>
+    <key>AUS Central Standard Time</key>
+    <string>Australia/Darwin</string>
+    <key>E. Australia Standard Time</key>
+    <string>Australia/Brisbane</string>
+    <key>AUS Eastern Standard Time</key>
+    <string>Australia/Sydney</string>
+    <key>West Pacific Standard Time</key>
+    <string>Pacific/Port_Moresby</string>
+    <key>Tasmania Standard Time</key>
+    <string>Australia/Hobart</string>
+    <key>Vladivostok Standard Time</key>
+    <string>Asia/Vladivostok</string>
+    <key>Lord Howe Standard Time</key>
+    <string>Australia/Lord_Howe</string>
+    <key>Bougainville Standard Time</key>
+    <string>Pacific/Bougainville</string>
+    <key>Russia Time Zone 10</key>
+    <string>Asia/Srednekolymsk</string>
+    <key>Magadan Standard Time</key>
+    <string>Asia/Magadan</string>
+    <key>Norfolk Standard Time</key>
+    <string>Pacific/Norfolk</string>
+    <key>Sakhalin Standard Time</key>
+    <string>Asia/Sakhalin</string>
+    <key>Central Pacific Standard Time</key>
+    <string>Pacific/Guadalcanal</string>
+    <key>Russia Time Zone 11</key>
+    <string>Asia/Kamchatka</string>
+    <key>New Zealand Standard Time</key>
+    <string>Pacific/Auckland</string>
+    <key>UTC+12</key>
+    <string>Etc/GMT-12</string>
+    <key>Fiji Standard Time</key>
+    <string>Pacific/Fiji</string>
+    <key>Chatham Islands Standard Time</key>
+    <string>Pacific/Chatham</string>
+    <key>UTC+13</key>
+    <string>Etc/GMT-13</string>
+    <key>Tonga Standard Time</key>
+    <string>Pacific/Tongatapu</string>
+    <key>Samoa Standard Time</key>
+    <string>Pacific/Apia</string>
+    <key>Line Islands Standard Time</key>
+    <string>Pacific/Kiritimati</string>
+  </dict>
+</plist>

--- a/CoreFoundation/WindowsResources.h
+++ b/CoreFoundation/WindowsResources.h
@@ -1,2 +1,4 @@
 
 #define IDR_WINDOWS_OLSON_MAPPING       101
+#define IDR_OLSON_WINDOWS_MAPPING       102
+

--- a/CoreFoundation/WindowsResources.h
+++ b/CoreFoundation/WindowsResources.h
@@ -1,0 +1,2 @@
+
+#define IDR_WINDOWS_OLSON_MAPPING       101

--- a/CoreFoundation/cmake/modules/CoreFoundationAddFramework.cmake
+++ b/CoreFoundation/cmake/modules/CoreFoundationAddFramework.cmake
@@ -63,7 +63,7 @@ function(add_framework NAME)
   endif()
   target_compile_options(${NAME}
                          PRIVATE
-                           -I;${CMAKE_BINARY_DIR}/${NAME}.framework/PrivateHeaders)
+                           $<$<OR:$<COMPILE_LANGUAGE:ASM>,$<COMPILE_LANGUAGE:C>>:-I;${CMAKE_BINARY_DIR}/${NAME}.framework/PrivateHeaders>)
   add_dependencies(${NAME} ${NAME}_POPULATE_HEADERS)
 
   if(AF_FRAMEWORK_DIRECTORY)


### PR DESCRIPTION
Refactor the initialization codepath a bit to make it more obvious how to modify this to support Windows and alter to query the information from the system.