### PR TITLE
[SR-9887] HTTPCookie on Linux does not accept Substring values

### DIFF
--- a/Foundation/HTTPCookie.swift
+++ b/Foundation/HTTPCookie.swift
@@ -255,10 +255,16 @@ open class HTTPCookie : NSObject {
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
     public init?(properties: [HTTPCookiePropertyKey : Any]) {
+        func stringValue(_ strVal: Any?) -> String? {
+            if let subStr = strVal as? Substring {
+                return String(subStr)
+            }
+            return strVal as? String
+        }
         guard
-            let path = properties[.path] as? String,
-            let name = properties[.name] as? String,
-            let value = properties[.value] as? String
+            let path = stringValue(properties[.path]),
+            let name = stringValue(properties[.name]),
+            let value = stringValue(properties[.value])
         else {
             return nil
         }
@@ -659,4 +665,3 @@ fileprivate extension String {
         return self.replacingOccurrences(of: "&comma", with: ",")
     }
 }
-

--- a/TestFoundation/TestHTTPCookie.swift
+++ b/TestFoundation/TestHTTPCookie.swift
@@ -19,6 +19,7 @@ class TestHTTPCookie: XCTestCase {
             ("test_cookiesWithResponseHeaderNoDomain", test_cookiesWithResponseHeaderNoDomain),
             ("test_cookiesWithResponseHeaderNoPathNoDomain", test_cookiesWithResponseHeaderNoPathNoDomain),
             ("test_cookieExpiresDateFormats", test_cookieExpiresDateFormats),
+            ("test_httpCookieWithSubstring", test_httpCookieWithSubstring),
         ]
     }
 
@@ -189,6 +190,15 @@ class TestHTTPCookie: XCTestCase {
             XCTAssertEqual(cookie.expiresDate, testDate)
             XCTAssertEqual(cookie.domain, "swift.org")
             XCTAssertEqual(cookie.path, "/")
+        }
+    }
+
+    func test_httpCookieWithSubstring() {
+        let cookie = HTTPCookie(properties: [.domain: ".", .path: "/", .name: "davesy".dropLast(), .value: "Jonesy".dropLast()])
+        if let cookie = cookie {
+            XCTAssertEqual(cookie.name, "daves")
+        } else {
+            XCTFail("Unable to create cookie with substring")
         }
     }
 }


### PR DESCRIPTION
The HTTPCookie  initializer takes values as ```Any ```  but fails to create cookie when Substring is passed to it. Casting from ```Substring``` to String returns ```nil``` due to which the initializer is failing silently.