### PR TITLE
Foundation: initialize CFSocket on startup

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -566,6 +566,10 @@ _stat_with_btime(const char *filename, struct stat *buffer, struct timespec *bti
 #warning "Enabling statx"
 #endif
 
+#if DEPLOYMENT_TARGET_WINDOWS
+CF_EXPORT void __CFSocketInitializeWinSock(void);
+#endif
+
 _CF_EXPORT_SCOPE_END
 
 #endif /* __COREFOUNDATION_FORSWIFTFOUNDATIONONLY__ */

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -150,7 +150,10 @@ internal func __CFSwiftGetBaseClass() -> UnsafeRawPointer {
 @usableFromInline
 @_cdecl("__CFInitializeSwift")
 internal func __CFInitializeSwift() {
-    
+#if os(Windows)
+    __CFInitializeWinSock()
+#endif
+
     _CFRuntimeBridgeTypeToClass(CFStringGetTypeID(), unsafeBitCast(_NSCFString.self, to: UnsafeRawPointer.self))
     _CFRuntimeBridgeTypeToClass(CFArrayGetTypeID(), unsafeBitCast(_NSCFArray.self, to: UnsafeRawPointer.self))
     _CFRuntimeBridgeTypeToClass(CFDictionaryGetTypeID(), unsafeBitCast(_NSCFDictionary.self, to: UnsafeRawPointer.self))


### PR DESCRIPTION
Windows requires the networking subsystem (WinSock) to be initialized.
However, the user expects to be able to use the networking APIs in
Foundation without performing any one-time initialization.  Furthermore,
due to the macro usage in the initialization path, it is easier to
perform the initialization in C than in Swift.  CoreFoundation has a SPI
for this (`__CFSocketInitializeWinSock`).