### PR TITLE
[CoreFoundation] Fix enum name in function body.

### DIFF
--- a/CoreFoundation/Locale.subproj/CFDateIntervalFormatter.c
+++ b/CoreFoundation/Locale.subproj/CFDateIntervalFormatter.c
@@ -408,7 +408,7 @@ void CFDateIntervalFormatterSetTimeStyle(CFDateIntervalFormatterRef formatter, C
 
 _CFDateIntervalFormatterBoundaryStyle _CFDateIntervalFormatterGetBoundaryStyle(CFDateIntervalFormatterRef formatter) {
     LOCK();
-    CFDateIntervalFormatterStyle result = formatter->_boundaryStyle;
+    _CFDateIntervalFormatterBoundaryStyle result = formatter->_boundaryStyle;
     UNLOCK();
     return result;
 }


### PR DESCRIPTION
The enum name was probably autocompleted wrong. There should be no
functional change. LLVM 8 seems to raise a new warning here.