### PR TITLE
[SR-9979] FileHandle class used to implement FileManager._compareFiles

### DIFF
--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -342,6 +342,14 @@ open class FileHandle : NSObject, NSSecureCoding {
         }
 #endif
     }
+    
+    internal func _readBytes(into buffer: UnsafeMutablePointer<UInt8>, length: Int) throws -> Int {
+        let amtRead = _read(_fd, buffer, length)
+        if amtRead < 0 {
+            throw _NSErrorWithErrno(errno, reading: true)
+        }
+        return amtRead
+    }
 
     internal func _writeBytes(buf: UnsafeRawPointer, length: Int) throws {
 #if os(Windows)
@@ -425,6 +433,15 @@ open class FileHandle : NSObject, NSSecureCoding {
         }
     }
 #endif
+    
+    internal init?(fileSystemRepresentation: UnsafePointer<Int8>, flags: Int32, createMode: Int) {
+        _fd = _CFOpenFileWithMode(fileSystemRepresentation, flags, mode_t(createMode))
+        _closeOnDealloc = true
+        super.init()
+        if _fd < 0 {
+            return nil
+        }
+    }
 
     deinit {
         // .close() tries to wait after operations in flight on the handle queue, if one exists, and then close. It does so by sending .sync { … } work to it.

--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -444,9 +444,15 @@ open class FileHandle : NSObject, NSSecureCoding {
 #endif
 
     internal convenience init?(fileSystemRepresentation: UnsafePointer<Int8>, flags: Int32, createMode: Int) {
+#if os(Windows)
+        var fd: Int = -1
+        if let path = String(cString: fileSystemRepresentation).cString(using: .utf16) {
+            fd = _CFOpenFileWithMode(path, flags, mode_t(createMode))
+        }
+#else
         let fd = _CFOpenFileWithMode(fileSystemRepresentation, flags, mode_t(createMode))
+#endif
         guard fd > 0 else { return nil }
-        
         self.init(fileDescriptor: fd, closeOnDealloc: true)
     }
 

--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -1729,7 +1729,6 @@ open class FileManager : NSObject {
             buffer1.deallocate()
             buffer2.deallocate()
         }
-        
         var bytesLeft = size
         while bytesLeft > 0 {
             let bytesToRead = Int(min(Int64(bufSize), bytesLeft))

--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -1737,18 +1737,14 @@ open class FileManager : NSObject {
             guard let file1BytesRead = try? file1._readBytes(into: buffer1, length: bytesToRead), file1BytesRead == bytesToRead else {
                 return false
             }
-            
             guard let file2BytesRead = try? file2._readBytes(into: buffer2, length: bytesToRead), file2BytesRead == bytesToRead else {
                 return false
             }
-            
             guard memcmp(buffer1, buffer2, bytesToRead) == 0 else {
                 return false
             }
-            
             bytesLeft -= Int64(bytesToRead)
         }
-        
         return true
 #endif
     }


### PR DESCRIPTION
`FileHandler` APIs used to replace the curret implementation of the private method
`_compareFiles(withFileSystemRepresentation:andFileSystemRepresentation:size:bufSize:)`

Bug Link: https://bugs.swift.org/browse/SR-9979