### PR TITLE
[SR-10156] Fix test_current_working_directory on macOS

### DIFF
--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -282,7 +282,11 @@ class TestProcess : XCTestCase {
     }
 
     func test_current_working_directory() {
+        #if os(macOS)
+        let tmpDir = "/private/tmp"
+        #else
         let tmpDir = "/tmp".standardizingPath
+        #endif
 
         let fm = FileManager.default
         let previousWorkingDirectory = fm.currentDirectoryPath


### PR DESCRIPTION
Resolve: https://bugs.swift.org/browse/SR-10156

## Motivation

TestProcess.test_current_working_directory fails on macOS. This fixes the test failure on macOS.

```bash
Test Case 'TestProcess.test_current_working_directory' started at 2019-03-23 12:09:37.998
/Users/nafu/Projects/swift-source/swift-corelibs-foundation/TestFoundation/TestProcess.swift:294: error: TestProcess.test_current_working_directory : XCTAssertEqual failed: ("/private/tmp") is not equal to ("/tmp") - 
Test Case 'TestProcess.test_current_working_directory' failed (0.623 seconds)
```