### PR TITLE
Fix plutil installation failure on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -584,7 +584,12 @@ install(FILES
           CoreFoundation/Base.subproj/module.map
         DESTINATION
           lib/swift/CoreFoundation)
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  set(plutil_executable plutil.exe)
+else()
+  set(plutil_executable plutil)
+endif()
 install(PROGRAMS
-          ${CMAKE_CURRENT_BINARY_DIR}/plutil
+          ${CMAKE_CURRENT_BINARY_DIR}/${plutil_executable}
         DESTINATION
           ${CMAKE_INSTALL_FULL_BINDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -584,12 +584,7 @@ install(FILES
           CoreFoundation/Base.subproj/module.map
         DESTINATION
           lib/swift/CoreFoundation)
-if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-  set(plutil_executable plutil.exe)
-else()
-  set(plutil_executable plutil)
-endif()
 install(PROGRAMS
-          ${CMAKE_CURRENT_BINARY_DIR}/${plutil_executable}
+          ${CMAKE_CURRENT_BINARY_DIR}/plutil${CMAKE_EXECUTABLE_SUFFIX}
         DESTINATION
           ${CMAKE_INSTALL_FULL_BINDIR})


### PR DESCRIPTION
plutil is not installed on Windows becuase ".exe" extension is missing in CMakeLists.txt.