### PR TITLE
Fix: existing attributes are not replaced

### DIFF
--- a/Foundation/XMLElement.swift
+++ b/Foundation/XMLElement.swift
@@ -82,17 +82,15 @@ open class XMLElement: XMLNode {
 
     /*!
         @method addAttribute:
-        @abstract Adds an attribute. Attributes with duplicate names are not added.
+        @abstract Adds an attribute. Attributes with duplicate names replace the old one.
     */
     open func addAttribute(_ attribute: XMLNode) {
         guard let name = _CFXMLNodeCopyName(attribute._xmlNode)?._swiftObject else {
             fatalError("Attributes must have a name!")
         }
 
-        name.cString(using: .utf8)!.withUnsafeBufferPointer() {
-            guard let ptr = $0.baseAddress, _CFXMLNodeHasProp(_xmlNode, ptr) == nil else { return }
-            addChild(attribute)
-        }
+        removeAttribute(forName: name)
+        addChild(attribute)
     }
 
     /*!

--- a/TestFoundation/TestXMLDocument.swift
+++ b/TestFoundation/TestXMLDocument.swift
@@ -232,6 +232,9 @@ class TestXMLDocument : LoopbackServerTest {
         XCTAssertEqual(element.xmlString, "<root></root>", element.xmlString)
 
         element.addAttribute(attribute)
+        let attribute2 = XMLNode.attribute(withName: "color", stringValue: "#00ff00") as! XMLNode
+        element.addAttribute(attribute2)
+        XCTAssertEqual(element.attribute(forName: "color")?.stringValue, "#00ff00")
 
         let otherAttribute = XMLNode.attribute(withName: "foo", stringValue: "bar") as! XMLNode
         element.addAttribute(otherAttribute)
@@ -242,7 +245,7 @@ class TestXMLDocument : LoopbackServerTest {
         }
 
         XCTAssertEqual(attributes.count, 2)
-        XCTAssertEqual(attributes.first, attribute)
+        XCTAssertEqual(attributes.first, attribute2)
         XCTAssertEqual(attributes.last, otherAttribute)
 
         let barAttribute = XMLNode.attribute(withName: "bar", stringValue: "buz") as! XMLNode


### PR DESCRIPTION
According to [the document of Darwin Foundation](https://developer.apple.com/documentation/foundation/xmlelement/1388336-addattribute)  of `XMLElement.addAttribute(_:)`,

> If the receiver already has an attribute with the same name, `anAttribute` replaces the old attribute.

and actually it replaces the old attribute on Darwin.

However in swift-corelibs-foundation, `addAttribute(_:)` do nothing when the attribute with the same name exists.

This patch fixes the behavior and improves compatibility with Darwin Foundation.
