### PR TITLE
Fix FileHandle.swift compilation filure on Windows

### DIFF
--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -445,7 +445,7 @@ open class FileHandle : NSObject, NSSecureCoding {
 
     internal convenience init?(fileSystemRepresentation: UnsafePointer<Int8>, flags: Int32, createMode: Int) {
 #if os(Windows)
-        var fd: Int = -1
+        var fd: Int32 = -1
         if let path = String(cString: fileSystemRepresentation).cString(using: .utf16) {
             fd = _CFOpenFileWithMode(path, flags, mode_t(createMode))
         }


### PR DESCRIPTION
Becuase of a type mismatch, a compilation error occurs:
```
C:/swift/swift-corelibs-foundation/Foundation/FileHandle.swift:450:18: error: cannot assign value of type 'Int32' to type 'Int'
            fd = _CFOpenFileWithMode(path, flags, mode_t(createMode))
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 Int(                                                )
C:/swift/swift-corelibs-foundation/Foundation/FileHandle.swift:456:35: error: cannot convert value of type 'Int' to expected argument type 'Int32'
        self.init(fileDescriptor: fd, closeOnDealloc: true)
                                  ^~
                                  Int32( )
```

This PR fixes this error.