### PR TITLE
Disable TestXMLDocument.test_xpath which crashes sometimes in CI

### DIFF
--- a/TestFoundation/TestXMLDocument.swift
+++ b/TestFoundation/TestXMLDocument.swift
@@ -13,7 +13,8 @@ class TestXMLDocument : LoopbackServerTest {
         return [
             ("test_basicCreation", test_basicCreation),
             ("test_nextPreviousNode", test_nextPreviousNode),
-            ("test_xpath", test_xpath),
+            // Disabled because of https://bugs.swift.org/browse/SR-10098
+            // ("test_xpath", test_xpath),
             ("test_elementCreation", test_elementCreation),
             ("test_elementChildren", test_elementChildren),
             ("test_stringValue", test_stringValue),


### PR DESCRIPTION
    Test Case 'TestXMLDocument.test_xpath' started at 2019-03-29 17:27:41.139

    0% tests passed, 1 tests failed out of 1

    Total Test time (real) =  23.90 sec

    The following tests FAILED:
    	  1 - TestFoundation (SEGFAULT)

https://bugs.swift.org/browse/SR-10098