### PR TITLE
SR-10240: Dont try to write an empty Data() if it has a nil baseAddress.

### DIFF
--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -507,7 +507,9 @@ open class FileHandle : NSObject, NSSecureCoding {
         
         for region in data.regions {
             try region.withUnsafeBytes { (bytes) in
-                try _writeBytes(buf: UnsafeRawPointer(bytes.baseAddress!), length: bytes.count)
+                if let baseAddress = bytes.baseAddress, bytes.count > 0 {
+                    try _writeBytes(buf: UnsafeRawPointer(baseAddress), length: bytes.count)
+                }
             }
         }
     }

--- a/TestFoundation/TestPipe.swift
+++ b/TestFoundation/TestPipe.swift
@@ -43,7 +43,10 @@ class TestPipe: XCTestCase {
         // First write some data into the pipe
         let stringAsData = try text.data(using: .utf8).unwrapped()
         try aPipe.fileHandleForWriting.write(contentsOf: stringAsData)
-        
+
+        // SR-10240 - Check empty Data() can be written without crashing
+        aPipe.fileHandleForWriting.write(Data())
+
         // Then read it out again
         let data = try aPipe.fileHandleForReading.read(upToCount: stringAsData.count).unwrapped()
         


### PR DESCRIPTION
This doesnt actually crash in `master` as the region passed has a non-nil `baseAddress` and `bytes.count` = 0, but eliminate the force unwrap anyway incase the `baseAddress` ever becomes `nil` in the future.