### PR TITLE
[5.0] SR-10240: Dont try to write an empty Data() as it has a nil baseAddress.

### DIFF
--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -126,7 +126,9 @@ open class FileHandle : NSObject, NSSecureCoding {
         guard _fd >= 0 else { return }
         data.enumerateBytes() { (bytes, range, stop) in
             do {
-                try NSData.write(toFileDescriptor: self._fd, path: nil, buf: UnsafeRawPointer(bytes.baseAddress!), length: bytes.count)
+                if let baseAddress = bytes.baseAddress, bytes.count > 0 {
+                    try NSData.write(toFileDescriptor: self._fd, path: nil, buf: UnsafeRawPointer(baseAddress), length: bytes.count)
+                }
             } catch {
                 fatalError("Write failure")
             }

--- a/TestFoundation/TestPipe.swift
+++ b/TestFoundation/TestPipe.swift
@@ -43,7 +43,10 @@ class TestPipe: XCTestCase {
         let stringAsData = text.data(using: .utf8)
         XCTAssertNotNil(stringAsData)
         aPipe.fileHandleForWriting.write(stringAsData!)
-        
+
+        // SR-10240 - Check empty Data() can be written without crashing
+        aPipe.fileHandleForWriting.write(Data())
+
         // Then read it out again
         let data = aPipe.fileHandleForReading.readData(ofLength: text.count)
         


### PR DESCRIPTION
5.0 version of #2053. This crashes in 5.0 as the region has `baseAddress = nil`