### PR TITLE
[4.2] _BodyFileSource: Fix use after free in init()

### DIFF
--- a/Foundation/URLSession/BodySource.swift
+++ b/Foundation/URLSession/BodySource.swift
@@ -100,11 +100,12 @@ extension _BodyDataSource : _BodySource {
 /// have to be thread safe.
 internal final class _BodyFileSource {
     fileprivate let fileURL: URL
-    fileprivate let channel: DispatchIO 
-    fileprivate let workQueue: DispatchQueue 
+    fileprivate let channel: DispatchIO
+    fileprivate let workQueue: DispatchQueue
     fileprivate let dataAvailableHandler: () -> Void
     fileprivate var hasActiveReadHandler = false
     fileprivate var availableChunk: _Chunk = .empty
+
     /// Create a new data source backed by a file.
     ///
     /// - Parameter fileURL: the file to read from
@@ -121,13 +122,13 @@ internal final class _BodyFileSource {
         self.fileURL = fileURL
         self.workQueue = workQueue
         self.dataAvailableHandler = dataAvailableHandler
-        var fileSystemRepresentation: UnsafePointer<Int8>! = nil
-        fileURL.withUnsafeFileSystemRepresentation {
-            fileSystemRepresentation = $0
-        }
-        guard let channel = DispatchIO(type: .stream, path: fileSystemRepresentation,
-                                       oflag: O_RDONLY, mode: 0, queue: workQueue,
-                                       cleanupHandler: {_ in }) else {
+
+        guard let channel = fileURL.withUnsafeFileSystemRepresentation({
+            // DisptachIO (dispatch_io_create_with_path) makes a copy of the path
+            DispatchIO(type: .stream, path: $0!,
+                       oflag: O_RDONLY, mode: 0, queue: workQueue,
+                       cleanupHandler: {_ in })
+        }) else {
             fatalError("Cant create DispatchIO channel")
         }
         self.channel = channel


### PR DESCRIPTION
- init(fileURL:workQueue:dataAvailableHandler:) was using the closure
  argument for the buffer pointer outside of the closure, after
  .deallocate() was called.

(cherry picked from commit 21549ff34a9cc0137ee48d842bcc28cbb675deb5)