### PR TITLE
Split FileManager into Platform Dependent Files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,8 @@ add_swift_library(Foundation
                     Foundation/ExtraStringAPIs.swift
                     Foundation/FileHandle.swift
                     Foundation/FileManager.swift
+                    Foundation/FileManager+POSIX.swift
+                    Foundation/FileManager+Win32.swift
                     Foundation/FileManager_XDG.swift
                     Foundation/Formatter.swift
                     Foundation/FoundationErrors.swift

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -353,6 +353,8 @@
 		7D0DE86E211883F500540061 /* TestDateComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0DE86C211883F500540061 /* TestDateComponents.swift */; };
 		7D0DE86F211883F500540061 /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0DE86D211883F500540061 /* Utilities.swift */; };
 		90E645DF1E4C89A400D0D47C /* TestNSCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E645DE1E4C89A400D0D47C /* TestNSCache.swift */; };
+		91B668A32252B3C5001487A1 /* FileManager+POSIX.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B668A22252B3C5001487A1 /* FileManager+POSIX.swift */; };
+		91B668A52252B3E7001487A1 /* FileManager+Win32.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B668A42252B3E7001487A1 /* FileManager+Win32.swift */; };
 		9F0DD3521ECD73D000F68030 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0041781ECD5962004138BD /* main.swift */; };
 		9F0DD3571ECD783500F68030 /* SwiftFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B5D885D1BBC938800234F36 /* SwiftFoundation.framework */; };
 		A058C2021E529CF100B07AA1 /* TestMassFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A058C2011E529CF100B07AA1 /* TestMassFormatter.swift */; };
@@ -881,6 +883,8 @@
 		84BA558D1C16F90900F48C54 /* TestTimeZone.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestTimeZone.swift; sourceTree = "<group>"; };
 		88D28DE61C13AE9000494606 /* TestNSGeometry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSGeometry.swift; sourceTree = "<group>"; };
 		90E645DE1E4C89A400D0D47C /* TestNSCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSCache.swift; sourceTree = "<group>"; };
+		91B668A22252B3C5001487A1 /* FileManager+POSIX.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+POSIX.swift"; sourceTree = "<group>"; };
+		91B668A42252B3E7001487A1 /* FileManager+Win32.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+Win32.swift"; sourceTree = "<group>"; };
 		9F0041781ECD5962004138BD /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		9F0DD33F1ECD734200F68030 /* xdgTestHelper.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = xdgTestHelper.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F0DD34F1ECD737B00F68030 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1916,6 +1920,8 @@
 			children = (
 				EADE0B5D1BD15DFF00C49C64 /* FileHandle.swift */,
 				EADE0B5E1BD15DFF00C49C64 /* FileManager.swift */,
+				91B668A42252B3E7001487A1 /* FileManager+Win32.swift */,
+				91B668A22252B3C5001487A1 /* FileManager+POSIX.swift */,
 				1513A8422044893F00539722 /* FileManager_XDG.swift */,
 				EADE0B7A1BD15DFF00C49C64 /* Process.swift */,
 				5BDC3F2F1BCC5DCB00ED97BB /* Bundle.swift */,
@@ -2384,6 +2390,7 @@
 				153CC8352215E00200BFE8F3 /* ScannerAPI.swift in Sources */,
 				D3E8D6D11C367AB600295652 /* NSSpecialValue.swift in Sources */,
 				EAB57B721BD1C7A5004AC5C5 /* PortMessage.swift in Sources */,
+				91B668A32252B3C5001487A1 /* FileManager+POSIX.swift in Sources */,
 				5BD31D201D5CE8C400563814 /* Bridging.swift in Sources */,
 				3EDCE50C1EF04D8100C2EC04 /* Codable.swift in Sources */,
 				EADE0BBB1BD15E0000C49C64 /* URLAuthenticationChallenge.swift in Sources */,
@@ -2464,6 +2471,7 @@
 				5BF7AEB21BCD51F9008F214A /* NSNumber.swift in Sources */,
 				61D2F9AF1FECFB3E0033306A /* NativeProtocol.swift in Sources */,
 				1513A8432044893F00539722 /* FileManager_XDG.swift in Sources */,
+				91B668A52252B3E7001487A1 /* FileManager+Win32.swift in Sources */,
 				B9974B991EDF4A22007F15B8 /* HTTPURLProtocol.swift in Sources */,
 				5BCD03821D3EE35C00E3FF9B /* TimeZone.swift in Sources */,
 				EADE0BBC1BD15E0000C49C64 /* URLCache.swift in Sources */,

--- a/Foundation/FileManager+POSIX.swift
+++ b/Foundation/FileManager+POSIX.swift
@@ -1,0 +1,1157 @@
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+#if !os(Windows)
+
+#if os(Android) // struct stat.st_mode is UInt32
+internal func &(left: UInt32, right: mode_t) -> mode_t {
+    return mode_t(left) & right
+}
+#endif
+
+import CoreFoundation
+
+extension FileManager {
+    internal func _mountedVolumeURLs(includingResourceValuesForKeys propertyKeys: [URLResourceKey]?, options: VolumeEnumerationOptions = []) -> [URL]? {
+        var urls: [URL] = []
+
+#if os(Linux)
+        guard let procMounts = try? String(contentsOfFile: "/proc/mounts", encoding: .utf8) else {
+            return nil
+        }
+        urls = []
+        for line in procMounts.components(separatedBy: "\n") {
+            let mountPoint = line.components(separatedBy: " ")
+            if mountPoint.count > 2 {
+                urls.append(URL(fileURLWithPath: mountPoint[1], isDirectory: true))
+            }
+        }
+#elseif canImport(Darwin)
+        func mountPoints(_ statBufs: UnsafePointer<statfs>, _ fsCount: Int) -> [URL] {
+            var urls: [URL] = []
+
+            for fsIndex in 0..<fsCount {
+                var fs = statBufs.advanced(by: fsIndex).pointee
+
+                if options.contains(.skipHiddenVolumes) && fs.f_flags & UInt32(MNT_DONTBROWSE) != 0 {
+                    continue
+                }
+
+                let mountPoint = withUnsafePointer(to: &fs.f_mntonname.0) { (ptr: UnsafePointer<Int8>) -> String in
+                    return string(withFileSystemRepresentation: ptr, length: strlen(ptr))
+                }
+                urls.append(URL(fileURLWithPath: mountPoint, isDirectory: true))
+            }
+            return urls
+        }
+
+        if #available(OSX 10.13, *) {
+            var statBufPtr: UnsafeMutablePointer<statfs>?
+            let fsCount = getmntinfo_r_np(&statBufPtr, MNT_WAIT)
+            guard let statBuf = statBufPtr, fsCount > 0 else {
+                return nil
+            }
+            urls = mountPoints(statBuf, Int(fsCount))
+            free(statBufPtr)
+        } else {
+            var fsCount = getfsstat(nil, 0, MNT_WAIT)
+            guard fsCount > 0 else {
+                return nil
+            }
+            let statBuf = UnsafeMutablePointer<statfs>.allocate(capacity: Int(fsCount))
+            defer { statBuf.deallocate() }
+            fsCount = getfsstat(statBuf, fsCount * Int32(MemoryLayout<statfs>.stride), MNT_WAIT)
+            guard fsCount > 0 else {
+                return nil
+            }
+            urls = mountPoints(statBuf, Int(fsCount))
+        }
+#else
+#error("Requires a platform-specific implementation")
+#endif
+        return urls
+    }
+
+    internal func darwinPathURLs(for domain: _SearchPathDomain, system: String?, local: String?, network: String?, userHomeSubpath: String?) -> [URL] {
+        switch domain {
+        case .system:
+            guard let path = system else { return [] }
+            return [ URL(fileURLWithPath: path, isDirectory: true) ]
+        case .local:
+            guard let path = local else { return [] }
+            return [ URL(fileURLWithPath: path, isDirectory: true) ]
+        case .network:
+            guard let path = network else { return [] }
+            return [ URL(fileURLWithPath: path, isDirectory: true) ]
+        case .user:
+            guard let path = userHomeSubpath else { return [] }
+            return [ URL(fileURLWithPath: path, isDirectory: true, relativeTo: URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)) ]
+        }
+    }
+
+    internal func darwinPathURLs(for domain: _SearchPathDomain, all: String, useLocalDirectoryForSystem: Bool = false) -> [URL] {
+        switch domain {
+        case .system:
+            return [ URL(fileURLWithPath: useLocalDirectoryForSystem ? "/\(all)" : "/System/\(all)", isDirectory: true) ]
+        case .local:
+            return [ URL(fileURLWithPath: "/\(all)", isDirectory: true) ]
+        case .network:
+            return [ URL(fileURLWithPath: "/Network/\(all)", isDirectory: true) ]
+        case .user:
+            return [ URL(fileURLWithPath: all, isDirectory: true, relativeTo: URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)) ]
+        }
+    }
+
+    internal func _urls(for directory: SearchPathDirectory, in domainMask: SearchPathDomainMask) -> [URL] {
+        let domains = _SearchPathDomain.allInSearchOrder(from: domainMask)
+
+        var urls: [URL] = []
+
+        // We are going to return appropriate paths on Darwin, but [] on platforms that do not have comparable locations.
+        // For example, on FHS/XDG systems, applications are not installed in a single path.
+
+        let useDarwinPaths: Bool
+        if let envVar = ProcessInfo.processInfo.environment["_NSFileManagerUseXDGPathsForDirectoryDomains"] {
+            useDarwinPaths = !NSString(string: envVar).boolValue
+        } else {
+            #if canImport(Darwin)
+            useDarwinPaths = true
+            #else
+            useDarwinPaths = false
+            #endif
+        }
+
+        for domain in domains {
+            if useDarwinPaths {
+                urls.append(contentsOf: darwinURLs(for: directory, in: domain))
+            } else {
+                urls.append(contentsOf: xdgURLs(for: directory, in: domain))
+            }
+        }
+
+        return urls
+    }
+
+    internal func xdgURLs(for directory: SearchPathDirectory, in domain: _SearchPathDomain) -> [URL] {
+        // FHS/XDG-compliant OSes:
+        switch directory {
+        case .autosavedInformationDirectory:
+            let runtimePath = __SwiftValue.fetch(nonOptional: _CFXDGCreateDataHomePath()) as! String
+            return [ URL(fileURLWithPath: "Autosave Information", isDirectory: true, relativeTo: URL(fileURLWithPath: runtimePath, isDirectory: true)) ]
+
+        case .desktopDirectory:
+            guard domain == .user else { return [] }
+            return [ _XDGUserDirectory.desktop.url ]
+
+        case .documentDirectory:
+            guard domain == .user else { return [] }
+            return [ _XDGUserDirectory.documents.url ]
+
+        case .cachesDirectory:
+            guard domain == .user else { return [] }
+            let path = __SwiftValue.fetch(nonOptional: _CFXDGCreateCacheDirectoryPath()) as! String
+            return [ URL(fileURLWithPath: path, isDirectory: true) ]
+
+        case .applicationSupportDirectory:
+            guard domain == .user else { return [] }
+            let path = __SwiftValue.fetch(nonOptional: _CFXDGCreateDataHomePath()) as! String
+            return [ URL(fileURLWithPath: path, isDirectory: true) ]
+
+        case .downloadsDirectory:
+            guard domain == .user else { return [] }
+            return [ _XDGUserDirectory.download.url ]
+
+        case .userDirectory:
+            guard domain == .local else { return [] }
+            return [ URL(fileURLWithPath: xdgHomeDirectory, isDirectory: true) ]
+
+        case .moviesDirectory:
+            return [ _XDGUserDirectory.videos.url ]
+
+        case .musicDirectory:
+            guard domain == .user else { return [] }
+            return [ _XDGUserDirectory.music.url ]
+
+        case .picturesDirectory:
+            guard domain == .user else { return [] }
+            return [ _XDGUserDirectory.pictures.url ]
+
+        case .sharedPublicDirectory:
+            guard domain == .user else { return [] }
+            return [ _XDGUserDirectory.publicShare.url ]
+
+        case .trashDirectory:
+            let userTrashURL = URL(fileURLWithPath: ".Trash", isDirectory: true, relativeTo: URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true))
+            if domain == .user || domain == .local {
+                return [ userTrashURL ]
+            } else {
+                return []
+            }
+
+        // None of these are supported outside of Darwin:
+        case .applicationDirectory:
+            fallthrough
+        case .demoApplicationDirectory:
+            fallthrough
+        case .developerApplicationDirectory:
+            fallthrough
+        case .adminApplicationDirectory:
+            fallthrough
+        case .libraryDirectory:
+            fallthrough
+        case .developerDirectory:
+            fallthrough
+        case .documentationDirectory:
+            fallthrough
+        case .coreServiceDirectory:
+            fallthrough
+        case .inputMethodsDirectory:
+            fallthrough
+        case .preferencePanesDirectory:
+            fallthrough
+        case .applicationScriptsDirectory:
+            fallthrough
+        case .allApplicationsDirectory:
+            fallthrough
+        case .allLibrariesDirectory:
+            fallthrough
+        case .printerDescriptionDirectory:
+            fallthrough
+        case .itemReplacementDirectory:
+            return []
+        }
+    }
+
+    internal func darwinURLs(for directory: SearchPathDirectory, in domain: _SearchPathDomain) -> [URL] {
+        switch directory {
+        case .applicationDirectory:
+            return darwinPathURLs(for: domain, all: "Applications", useLocalDirectoryForSystem: true)
+
+        case .demoApplicationDirectory:
+            return darwinPathURLs(for: domain, all: "Demos", useLocalDirectoryForSystem: true)
+
+        case .developerApplicationDirectory:
+            return darwinPathURLs(for: domain, all: "Developer/Applications", useLocalDirectoryForSystem: true)
+
+        case .adminApplicationDirectory:
+            return darwinPathURLs(for: domain, all: "Applications/Utilities", useLocalDirectoryForSystem: true)
+
+        case .libraryDirectory:
+            return darwinPathURLs(for: domain, all: "Library")
+
+        case .developerDirectory:
+            return darwinPathURLs(for: domain, all: "Developer", useLocalDirectoryForSystem: true)
+
+        case .documentationDirectory:
+            return darwinPathURLs(for: domain, all: "Library/Documentation")
+
+        case .coreServiceDirectory:
+            return darwinPathURLs(for: domain, system: "/System/Library/CoreServices", local: nil, network: nil, userHomeSubpath: nil)
+
+        case .autosavedInformationDirectory:
+            return darwinPathURLs(for: domain, system: nil, local: nil, network: nil, userHomeSubpath: "Library/Autosave Information")
+
+        case .inputMethodsDirectory:
+            return darwinPathURLs(for: domain, all: "Library/Input Methods")
+
+        case .preferencePanesDirectory:
+            return darwinPathURLs(for: domain, system: "/System/Library/PreferencePanes", local: "/Library/PreferencePanes", network: nil, userHomeSubpath: "Library/PreferencePanes")
+
+        case .applicationScriptsDirectory:
+            // Only the ObjC Foundation can know where this is.
+            return []
+
+        case .allApplicationsDirectory:
+            var directories: [URL] = []
+            directories.append(contentsOf: darwinPathURLs(for: domain, all: "Applications", useLocalDirectoryForSystem: true))
+            directories.append(contentsOf: darwinPathURLs(for: domain, all: "Demos", useLocalDirectoryForSystem: true))
+            directories.append(contentsOf: darwinPathURLs(for: domain, all: "Developer/Applications", useLocalDirectoryForSystem: true))
+            directories.append(contentsOf: darwinPathURLs(for: domain, all: "Applications/Utilities", useLocalDirectoryForSystem: true))
+            return directories
+
+        case .allLibrariesDirectory:
+            var directories: [URL] = []
+            directories.append(contentsOf: darwinPathURLs(for: domain, all: "Library"))
+            directories.append(contentsOf: darwinPathURLs(for: domain, all: "Developer"))
+            return directories
+
+        case .printerDescriptionDirectory:
+            guard domain == .system else { return [] }
+            return [ URL(fileURLWithPath: "/System/Library/Printers/PPD", isDirectory: true) ]
+
+        case .desktopDirectory:
+            guard domain == .user else { return [] }
+            return [ URL(fileURLWithPath: "Desktop", isDirectory: true, relativeTo: URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)) ]
+
+        case .documentDirectory:
+            guard domain == .user else { return [] }
+            return [ URL(fileURLWithPath: "Documents", isDirectory: true, relativeTo: URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)) ]
+
+        case .cachesDirectory:
+            guard domain == .user else { return [] }
+            return [ URL(fileURLWithPath: "Library/Caches", isDirectory: true, relativeTo: URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)) ]
+
+        case .applicationSupportDirectory:
+            guard domain == .user else { return [] }
+            return [ URL(fileURLWithPath: "Library/Application Support", isDirectory: true, relativeTo: URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)) ]
+
+        case .downloadsDirectory:
+            guard domain == .user else { return [] }
+            return [ URL(fileURLWithPath: "Downloads", isDirectory: true, relativeTo: URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)) ]
+
+        case .userDirectory:
+            return darwinPathURLs(for: domain, system: nil, local: "/Users", network: "/Network/Users", userHomeSubpath: nil)
+
+        case .moviesDirectory:
+            guard domain == .user else { return [] }
+            return [ URL(fileURLWithPath: "Movies", isDirectory: true, relativeTo: URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)) ]
+
+        case .musicDirectory:
+            guard domain == .user else { return [] }
+            return [ URL(fileURLWithPath: "Music", isDirectory: true, relativeTo: URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)) ]
+
+        case .picturesDirectory:
+            guard domain == .user else { return [] }
+            return [ URL(fileURLWithPath: "Pictures", isDirectory: true, relativeTo: URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)) ]
+
+        case .sharedPublicDirectory:
+            guard domain == .user else { return [] }
+            return [ URL(fileURLWithPath: "Public", isDirectory: true, relativeTo: URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)) ]
+
+        case .trashDirectory:
+            let userTrashURL = URL(fileURLWithPath: ".Trash", isDirectory: true, relativeTo: URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true))
+            if domain == .user || domain == .local {
+                return [ userTrashURL ]
+            } else {
+                return []
+            }
+
+        case .itemReplacementDirectory:
+            // This directory is only returned by url(for:in:appropriateFor:create:)
+            return []
+        }
+    }
+
+    internal func _createDirectory(atPath path: String, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey : Any]? = [:]) throws {
+        try _fileSystemRepresentation(withPath: path, { pathFsRep in
+            if createIntermediates {
+                var isDir: ObjCBool = false
+                if !fileExists(atPath: path, isDirectory: &isDir) {
+                    let parent = path._nsObject.deletingLastPathComponent
+                    if !parent.isEmpty && !fileExists(atPath: parent, isDirectory: &isDir) {
+                        try createDirectory(atPath: parent, withIntermediateDirectories: true, attributes: attributes)
+                    }
+                    if mkdir(pathFsRep, S_IRWXU | S_IRWXG | S_IRWXO) != 0 {
+                        throw _NSErrorWithErrno(errno, reading: false, path: path)
+                    } else if let attr = attributes {
+                        try self.setAttributes(attr, ofItemAtPath: path)
+                    }
+                } else if isDir.boolValue {
+                    return
+                } else {
+                    throw _NSErrorWithErrno(EEXIST, reading: false, path: path)
+                }
+            } else {
+                if mkdir(pathFsRep, S_IRWXU | S_IRWXG | S_IRWXO) != 0 {
+                    throw _NSErrorWithErrno(errno, reading: false, path: path)
+                } else if let attr = attributes {
+                    try self.setAttributes(attr, ofItemAtPath: path)
+                }
+            }
+        })
+    }
+
+    internal func _contentsOfDir(atPath path: String, _ closure: (String, Int32) throws -> () ) throws {
+        try _fileSystemRepresentation(withPath: path) { fsRep in
+            guard let dir = opendir(fsRep) else {
+                throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileReadNoSuchFile.rawValue,
+                              userInfo: [NSFilePathErrorKey: path, "NSUserStringVariant": NSArray(object: "Folder")])
+            }
+            defer { closedir(dir) }
+
+            var entry = dirent()
+            var result: UnsafeMutablePointer<dirent>? = nil
+
+            while readdir_r(dir, &entry, &result) == 0 {
+                guard result != nil else {
+                    return
+                }
+                let length = Int(_direntNameLength(&entry))
+                let entryName = withUnsafePointer(to: &entry.d_name) { (ptr) -> String in
+                    let namePtr = UnsafeRawPointer(ptr).assumingMemoryBound(to: CChar.self)
+                    return string(withFileSystemRepresentation: namePtr, length: length)
+                }
+                if entryName != "." && entryName != ".." {
+                    let entryType = Int32(entry.d_type)
+                    try closure(entryName, entryType)
+                }
+            }
+        }
+    }
+
+    internal func _subpathsOfDirectory(atPath path: String) throws -> [String] {
+        var contents: [String] = []
+
+        try _contentsOfDir(atPath: path, { (entryName, entryType) throws in
+            contents.append(entryName)
+            if entryType == DT_DIR {
+                let subPath: String = path + "/" + entryName
+                let entries = try subpathsOfDirectory(atPath: subPath)
+                contents.append(contentsOf: entries.map({file in "\(entryName)/\(file)"}))
+            }
+        })
+        return contents
+    }
+
+    internal func _attributesOfFileSystem(forPath path: String) throws -> [FileAttributeKey : Any] {
+        var result: [FileAttributeKey:Any] = [:]
+
+        try _fileSystemRepresentation(withPath: path) { fsRep in
+            // statvfs(2) doesn't support 64bit inode on Darwin (apfs), fallback to statfs(2)
+    #if os(macOS) || os(iOS)
+            var s = statfs()
+            guard statfs(fsRep, &s) == 0 else {
+                throw _NSErrorWithErrno(errno, reading: true, path: path)
+            }
+    #else
+            var s = statvfs()
+            guard statvfs(fsRep, &s) == 0 else {
+                throw _NSErrorWithErrno(errno, reading: true, path: path)
+            }
+    #endif
+
+    #if os(macOS) || os(iOS)
+            let blockSize = UInt64(s.f_bsize)
+            result[.systemNumber] = NSNumber(value: UInt64(s.f_fsid.val.0))
+    #else
+            let blockSize = UInt64(s.f_frsize)
+            result[.systemNumber] = NSNumber(value: UInt64(s.f_fsid))
+    #endif
+            result[.systemSize] = NSNumber(value: blockSize * UInt64(s.f_blocks))
+            result[.systemFreeSize] = NSNumber(value: blockSize * UInt64(s.f_bavail))
+            result[.systemNodes] = NSNumber(value: UInt64(s.f_files))
+            result[.systemFreeNodes] = NSNumber(value: UInt64(s.f_ffree))
+        }
+        return result
+    }
+
+    internal func _createSymbolicLink(atPath path: String, withDestinationPath destPath: String) throws {
+        try _fileSystemRepresentation(withPath: path, andPath: destPath, {
+            guard symlink($1, $0) == 0 else {
+                throw _NSErrorWithErrno(errno, reading: false, path: path)
+            }
+       })
+    }
+
+    /* destinationOfSymbolicLinkAtPath:error: returns a String containing the path of the item pointed at by the symlink specified by 'path'. If this method returns 'nil', an NSError will be thrown.
+
+        This method replaces pathContentOfSymbolicLinkAtPath:
+     */
+    internal func _destinationOfSymbolicLink(atPath path: String) throws -> String {
+        let bufSize = Int(PATH_MAX + 1)
+        var buf = [Int8](repeating: 0, count: bufSize)
+        let len = try _fileSystemRepresentation(withPath: path) {
+            readlink($0, &buf, bufSize)
+        }
+        if len < 0 {
+            throw _NSErrorWithErrno(errno, reading: true, path: path)
+        }
+
+        return self.string(withFileSystemRepresentation: buf, length: Int(len))
+    }
+
+    internal func _readFrom(fd: Int32, toBuffer buffer: UnsafeMutablePointer<UInt8>, length bytesToRead: Int, filename: String) throws -> Int {
+        var bytesRead = 0
+
+        repeat {
+            bytesRead = numericCast(read(fd, buffer, numericCast(bytesToRead)))
+        } while bytesRead < 0 && errno == EINTR
+        guard bytesRead >= 0 else {
+            throw _NSErrorWithErrno(errno, reading: true, path: filename)
+        }
+        return bytesRead
+    }
+
+    internal func _writeTo(fd: Int32, fromBuffer buffer : UnsafeMutablePointer<UInt8>, length bytesToWrite: Int, filename: String) throws {
+        var bytesWritten = 0
+        while bytesWritten < bytesToWrite {
+            var written = 0
+            let bytesLeftToWrite = bytesToWrite - bytesWritten
+            repeat {
+                written =
+                    numericCast(write(fd, buffer.advanced(by: bytesWritten),
+                                      numericCast(bytesLeftToWrite)))
+            } while written < 0 && errno == EINTR
+            guard written >= 0 else {
+                throw _NSErrorWithErrno(errno, reading: false, path: filename)
+            }
+            bytesWritten += written
+        }
+    }
+
+    internal func _copyRegularFile(atPath srcPath: String, toPath dstPath: String, variant: String = "Copy") throws {
+        let srcRep = try __fileSystemRepresentation(withPath: srcPath)
+        defer { srcRep.deallocate() }
+        let dstRep = try __fileSystemRepresentation(withPath: dstPath)
+        defer { dstRep.deallocate() }
+
+        var fileInfo = stat()
+        guard stat(srcRep, &fileInfo) >= 0 else {
+            throw _NSErrorWithErrno(errno, reading: true, path: srcPath,
+                                    extraUserInfo: extraErrorInfo(srcPath: srcPath, dstPath: dstPath, userVariant: variant))
+        }
+
+        let srcfd = open(srcRep, O_RDONLY)
+        guard srcfd >= 0 else {
+            throw _NSErrorWithErrno(errno, reading: true, path: srcPath,
+                                    extraUserInfo: extraErrorInfo(srcPath: srcPath, dstPath: dstPath, userVariant: variant))
+        }
+        defer { close(srcfd) }
+
+        let dstfd = open(dstRep, O_WRONLY | O_CREAT | O_TRUNC, 0o666)
+        guard dstfd >= 0 else {
+            throw _NSErrorWithErrno(errno, reading: false, path: dstPath,
+                                    extraUserInfo: extraErrorInfo(srcPath: srcPath, dstPath: dstPath, userVariant: variant))
+        }
+        defer { close(dstfd) }
+
+        // Set the file permissions using fchmod() instead of when open()ing to avoid umask() issues
+        let permissions = fileInfo.st_mode & ~S_IFMT
+        guard fchmod(dstfd, permissions) == 0 else {
+            throw _NSErrorWithErrno(errno, reading: false, path: dstPath,
+                extraUserInfo: extraErrorInfo(srcPath: srcPath, dstPath: dstPath, userVariant: variant))
+        }
+
+        if fileInfo.st_size == 0 {
+            // no copying required
+            return
+        }
+
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: Int(fileInfo.st_blksize))
+        defer { buffer.deallocate() }
+
+        // Casted to Int64 because fileInfo.st_size is 64 bits long even on 32 bit platforms
+        var bytesRemaining = Int64(fileInfo.st_size)
+        while bytesRemaining > 0 {
+            let bytesToRead = min(bytesRemaining, Int64(fileInfo.st_blksize))
+            let bytesRead = try _readFrom(fd: srcfd, toBuffer: buffer, length: Int(bytesToRead), filename: srcPath)
+            if bytesRead == 0 {
+                // Early EOF
+                return
+            }
+            try _writeTo(fd: dstfd, fromBuffer: buffer, length: bytesRead, filename: dstPath)
+            bytesRemaining -= Int64(bytesRead)
+        }
+    }
+
+    internal func _copySymlink(atPath srcPath: String, toPath dstPath: String, variant: String = "Copy") throws {
+        let bufSize = Int(PATH_MAX) + 1
+        var buf = [Int8](repeating: 0, count: bufSize)
+
+        try _fileSystemRepresentation(withPath: srcPath) { srcFsRep in
+            let len = readlink(srcFsRep, &buf, bufSize)
+            if len < 0 {
+                throw _NSErrorWithErrno(errno, reading: true, path: srcPath,
+                                        extraUserInfo: extraErrorInfo(srcPath: srcPath, dstPath: dstPath, userVariant: variant))
+            }
+            try _fileSystemRepresentation(withPath: dstPath) { dstFsRep in
+                if symlink(buf, dstFsRep) == -1 {
+                    throw _NSErrorWithErrno(errno, reading: false, path: dstPath,
+                                            extraUserInfo: extraErrorInfo(srcPath: srcPath, dstPath: dstPath, userVariant: variant))
+                }
+            }
+        }
+    }
+
+    internal func _copyOrLinkDirectoryHelper(atPath srcPath: String, toPath dstPath: String, variant: String = "Copy", _ body: (String, String, FileAttributeType) throws -> ()) throws {
+        let stat = try _lstatFile(atPath: srcPath)
+
+        let fileType = FileAttributeType(statMode: stat.st_mode)
+        if fileType == .typeDirectory {
+            try createDirectory(atPath: dstPath, withIntermediateDirectories: false, attributes: nil)
+
+            guard let enumerator = enumerator(atPath: srcPath) else {
+                throw _NSErrorWithErrno(ENOENT, reading: true, path: srcPath)
+            }
+
+            while let item = enumerator.nextObject() as? String {
+                let src = srcPath + "/" + item
+                let dst = dstPath + "/" + item
+                if let stat = try? _lstatFile(atPath: src) {
+                    let fileType = FileAttributeType(statMode: stat.st_mode)
+                    if fileType == .typeDirectory {
+                        try createDirectory(atPath: dst, withIntermediateDirectories: false, attributes: nil)
+                    } else {
+                        try body(src, dst, fileType)
+                    }
+                }
+            }
+        } else {
+            try body(srcPath, dstPath, fileType)
+        }
+    }
+
+    internal func _moveItem(atPath srcPath: String, toPath dstPath: String, isURL: Bool) throws {
+        guard shouldMoveItemAtPath(srcPath, toPath: dstPath, isURL: isURL) else {
+            return
+        }
+
+        guard !self.fileExists(atPath: dstPath) else {
+            throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileWriteFileExists.rawValue, userInfo: [NSFilePathErrorKey : NSString(dstPath)])
+        }
+
+        try _fileSystemRepresentation(withPath: srcPath, andPath: dstPath, {
+            if rename($0, $1) != 0 {
+                if errno == EXDEV {
+                    try _copyOrLinkDirectoryHelper(atPath: srcPath, toPath: dstPath, variant: "Move") { (srcPath, dstPath, fileType) in
+                        do {
+                            switch fileType {
+                            case .typeRegular:
+                                try _copyRegularFile(atPath: srcPath, toPath: dstPath, variant: "Move")
+                            case .typeSymbolicLink:
+                                try _copySymlink(atPath: srcPath, toPath: dstPath, variant: "Move")
+                            default:
+                                break
+                            }
+                        } catch {
+                            if !shouldProceedAfterError(error, movingItemAtPath: srcPath, toPath: dstPath, isURL: isURL) {
+                                throw error
+                            }
+                        }
+                    }
+
+                    // Remove source directory/file after successful moving
+                    try _removeItem(atPath: srcPath, isURL: isURL, alreadyConfirmed: true)
+                } else {
+                    throw _NSErrorWithErrno(errno, reading: false, path: srcPath,
+                                            extraUserInfo: extraErrorInfo(srcPath: srcPath, dstPath: dstPath, userVariant: "Move"))
+                }
+            }
+        })
+    }
+
+    internal func _linkItem(atPath srcPath: String, toPath dstPath: String, isURL: Bool) throws {
+        try _copyOrLinkDirectoryHelper(atPath: srcPath, toPath: dstPath) { (srcPath, dstPath, fileType) in
+            guard shouldLinkItemAtPath(srcPath, toPath: dstPath, isURL: isURL) else {
+                return
+            }
+
+            do {
+                switch fileType {
+                case .typeRegular:
+                    try _fileSystemRepresentation(withPath: srcPath, andPath: dstPath, {
+                        if link($0, $1) == -1 {
+                            throw _NSErrorWithErrno(errno, reading: false, path: srcPath)
+                        }
+                    })
+                case .typeSymbolicLink:
+                    try _copySymlink(atPath: srcPath, toPath: dstPath)
+                default:
+                    break
+                }
+            } catch {
+                if !shouldProceedAfterError(error, linkingItemAtPath: srcPath, toPath: dstPath, isURL: isURL) {
+                    throw error
+                }
+            }
+        }
+    }
+
+    internal func _removeItem(atPath path: String, isURL: Bool, alreadyConfirmed: Bool = false) throws {
+        guard alreadyConfirmed || shouldRemoveItemAtPath(path, isURL: isURL) else {
+            return
+        }
+        try _fileSystemRepresentation(withPath: path, { fsRep in
+            if rmdir(fsRep) == 0 {
+                return
+            } else if errno == ENOTEMPTY {
+                let ps = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>.allocate(capacity: 2)
+                ps.initialize(to: UnsafeMutablePointer(mutating: fsRep))
+                ps.advanced(by: 1).initialize(to: nil)
+                let stream = fts_open(ps, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR, nil)
+                ps.deinitialize(count: 2)
+                ps.deallocate()
+
+                if stream != nil {
+                    defer {
+                        fts_close(stream)
+                    }
+
+                    while let current = fts_read(stream)?.pointee {
+                        let itemPath = string(withFileSystemRepresentation: current.fts_path, length: Int(current.fts_pathlen))
+                        guard alreadyConfirmed || shouldRemoveItemAtPath(itemPath, isURL: isURL) else {
+                            continue
+                        }
+
+                        do {
+                            switch Int32(current.fts_info) {
+                            case FTS_DEFAULT, FTS_F, FTS_NSOK, FTS_SL, FTS_SLNONE:
+                                if unlink(current.fts_path) == -1 {
+                                    throw _NSErrorWithErrno(errno, reading: false, path: itemPath)
+                                }
+                            case FTS_DP:
+                                if rmdir(current.fts_path) == -1 {
+                                    throw _NSErrorWithErrno(errno, reading: false, path: itemPath)
+                                }
+                            case FTS_DNR, FTS_ERR, FTS_NS:
+                                throw _NSErrorWithErrno(current.fts_errno, reading: false, path: itemPath)
+                            default:
+                                break
+                            }
+                        } catch {
+                            if !shouldProceedAfterError(error, removingItemAtPath: itemPath, isURL: isURL) {
+                                throw error
+                            }
+                        }
+                    }
+                } else {
+                    let _ = _NSErrorWithErrno(ENOTEMPTY, reading: false, path: path)
+                }
+            } else if errno != ENOTDIR {
+                throw _NSErrorWithErrno(errno, reading: false, path: path)
+            } else if unlink(fsRep) != 0 {
+                throw _NSErrorWithErrno(errno, reading: false, path: path)
+            }
+        })
+
+    }
+
+    internal func _currentDirectoryPath() -> String {
+        let length = Int(PATH_MAX) + 1
+        var buf = [Int8](repeating: 0, count: length)
+        getcwd(&buf, length)
+        return string(withFileSystemRepresentation: buf, length: Int(strlen(buf)))
+    }
+
+    @discardableResult
+    internal func _changeCurrentDirectoryPath(_ path: String) -> Bool {
+        do {
+            return try _fileSystemRepresentation(withPath: path, { chdir($0) == 0 })
+        }
+        catch {
+            return false
+        }
+    }
+
+    internal func _fileExists(atPath path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) -> Bool {
+        do {
+            return try _fileSystemRepresentation(withPath: path, { fsRep in
+                var s = try _lstatFile(atPath: path, withFileSystemRepresentation: fsRep)
+                if (s.st_mode & S_IFMT) == S_IFLNK {
+                    // don't chase the link for this magic case -- we might be /Net/foo
+                    // which is a symlink to /private/Net/foo which is not yet mounted...
+                    if isDirectory == nil && (s.st_mode & S_ISVTX) == S_ISVTX {
+                        return true
+                    }
+                    // chase the link; too bad if it is a slink to /Net/foo
+                    guard stat(fsRep, &s) >= 0 else {
+                        return false
+                    }
+                }
+
+                if let isDirectory = isDirectory {
+                    isDirectory.pointee = ObjCBool((s.st_mode & S_IFMT) == S_IFDIR)
+                }
+
+                return true
+            })
+        } catch {
+            return false
+        }
+    }
+
+    internal func _isReadableFile(atPath path: String) -> Bool {
+        do {
+            return try _fileSystemRepresentation(withPath: path, {
+                access($0, R_OK) == 0
+            })
+        } catch {
+            return false
+        }
+    }
+
+    internal func _isWritableFile(atPath path: String) -> Bool {
+        do {
+            return try _fileSystemRepresentation(withPath: path, {
+                access($0, W_OK) == 0
+            })
+        } catch {
+            return false
+        }
+    }
+
+    internal func _isExecutableFile(atPath path: String) -> Bool {
+        do {
+            return try _fileSystemRepresentation(withPath: path, {
+                access($0, X_OK) == 0
+            })
+        } catch {
+            return false
+        }
+    }
+
+    /**
+     - parameters:
+        - path: The path to the file we are trying to determine is deletable.
+
+      - returns: `true` if the file is deletable, `false` otherwise.
+     */
+    internal func _isDeletableFile(atPath path: String) -> Bool {
+        guard path != "" else { return true }   // This matches Darwin even though its probably the wrong response
+
+        // Get the parent directory of supplied path
+        let parent = path._nsObject.deletingLastPathComponent
+
+        do {
+            return try _fileSystemRepresentation(withPath: parent, andPath: path, { parentFsRep, fsRep  in
+                // Check the parent directory is writeable, else return false.
+                guard access(parentFsRep, W_OK) == 0 else {
+                    return false
+                }
+
+                // Stat the parent directory, if that fails, return false.
+                let parentS = try _lstatFile(atPath: path, withFileSystemRepresentation: parentFsRep)
+
+                // Check if the parent is 'sticky' if it exists.
+                if (parentS.st_mode & S_ISVTX) == S_ISVTX {
+                    let s = try _lstatFile(atPath: path, withFileSystemRepresentation: fsRep)
+
+                    // If the current user owns the file, return true.
+                    return s.st_uid == getuid()
+                }
+
+                // Return true as the best guess.
+                return true
+            })
+        } catch {
+            return false
+        }
+    }
+
+    private func _compareFiles(withFileSystemRepresentation file1Rep: UnsafePointer<Int8>, andFileSystemRepresentation file2Rep: UnsafePointer<Int8>, size: Int64, bufSize: Int) -> Bool {
+        guard let file1 = FileHandle(fileSystemRepresentation: file1Rep, flags: O_RDONLY, createMode: 0) else { return false }
+        guard let file2 = FileHandle(fileSystemRepresentation: file2Rep, flags: O_RDONLY, createMode: 0) else { return false }
+
+        var buffer1 = UnsafeMutablePointer<UInt8>.allocate(capacity: bufSize)
+        var buffer2 = UnsafeMutablePointer<UInt8>.allocate(capacity: bufSize)
+        defer {
+            buffer1.deallocate()
+            buffer2.deallocate()
+        }
+        var bytesLeft = size
+        while bytesLeft > 0 {
+            let bytesToRead = Int(min(Int64(bufSize), bytesLeft))
+
+            guard let file1BytesRead = try? file1._readBytes(into: buffer1, length: bytesToRead), file1BytesRead == bytesToRead else {
+                return false
+            }
+            guard let file2BytesRead = try? file2._readBytes(into: buffer2, length: bytesToRead), file2BytesRead == bytesToRead else {
+                return false
+            }
+            guard memcmp(buffer1, buffer2, bytesToRead) == 0 else {
+                return false
+            }
+            bytesLeft -= Int64(bytesToRead)
+        }
+        return true
+    }
+
+    private func _compareSymlinks(withFileSystemRepresentation file1Rep: UnsafePointer<Int8>, andFileSystemRepresentation file2Rep: UnsafePointer<Int8>, size: Int64) -> Bool {
+        let bufSize = Int(size)
+        let buffer1 = UnsafeMutablePointer<CChar>.allocate(capacity: bufSize)
+        let buffer2 = UnsafeMutablePointer<CChar>.allocate(capacity: bufSize)
+
+        let size1 = readlink(file1Rep, buffer1, bufSize)
+        let size2 = readlink(file2Rep, buffer2, bufSize)
+
+        let compare: Bool
+        if size1 < 0 || size2 < 0 || size1 != size || size1 != size2 {
+            compare = false
+        } else {
+            compare = memcmp(buffer1, buffer2, size1) == 0
+        }
+
+        buffer1.deallocate()
+        buffer2.deallocate()
+        return compare
+    }
+
+    internal func _lstatFile(atPath path: String, withFileSystemRepresentation fsRep: UnsafePointer<Int8>? = nil) throws -> stat {
+        let _fsRep: UnsafePointer<Int8>
+        if fsRep == nil {
+            _fsRep = try __fileSystemRepresentation(withPath: path)
+        } else {
+            _fsRep = fsRep!
+        }
+
+        defer {
+            if fsRep == nil { _fsRep.deallocate() }
+        }
+
+        var statInfo = stat()
+        guard lstat(_fsRep, &statInfo) == 0 else {
+            throw _NSErrorWithErrno(errno, reading: true, path: path)
+        }
+        return statInfo
+    }
+
+#if os(Linux)
+    // This is only used on Linux and the only extra information it returns in addition
+    // to a normal stat() call is the file creation date (stx_btime). It is only
+    // used by attributesOfItem(atPath:) which is why the return is a simple stat()
+    // structure and optional creation date.
+
+    internal func _statxFile(atPath path: String) throws -> (stat, Date?) {
+        return try _fileSystemRepresentation(withPath: path) { fsRep in
+
+            if supportsStatx {
+                var statInfo = stat()
+                var btime = timespec()
+                guard _stat_with_btime(fsRep, &statInfo, &btime) == 0 else {
+                    throw _NSErrorWithErrno(errno, reading: true, path: path)
+                }
+
+                let sec = btime.tv_sec
+                let nsec = btime.tv_nsec
+                let creationDate: Date?
+                if sec == 0 && nsec == 0 {
+                    creationDate = nil
+                } else {
+                    let ti = (TimeInterval(sec) - kCFAbsoluteTimeIntervalSince1970) + (1.0e-9 * TimeInterval(nsec))
+                    creationDate = Date(timeIntervalSinceReferenceDate: ti)
+                }
+                return (statInfo, creationDate)
+            } else {
+                // fallback if statx() is unavailable or fails
+                let statInfo = try _lstatFile(atPath: path, withFileSystemRepresentation: fsRep)
+                return (statInfo, nil)
+            }
+        }
+    }
+#endif
+
+    /* -contentsEqualAtPath:andPath: does not take into account data stored in the resource fork or filesystem extended attributes.
+     */
+internal func _contentsEqual(atPath path1: String, andPath path2: String) -> Bool {
+        do {
+            let fsRep1 = try __fileSystemRepresentation(withPath: path1)
+            defer { fsRep1.deallocate() }
+
+            let file1 = try _lstatFile(atPath: path1, withFileSystemRepresentation: fsRep1)
+            let file1Type = file1.st_mode & S_IFMT
+
+            // Don't use access() for symlinks as only the contents should be checked even
+            // if the symlink doesnt point to an actual file, but access() will always try
+            // to resolve the link and fail if the destination is not found
+            if path1 == path2 && file1Type != S_IFLNK {
+                return access(fsRep1, R_OK) == 0
+            }
+
+            let fsRep2 = try __fileSystemRepresentation(withPath: path2)
+            defer { fsRep2.deallocate() }
+            let file2 = try _lstatFile(atPath: path2, withFileSystemRepresentation: fsRep2)
+            let file2Type = file2.st_mode & S_IFMT
+
+            // Are paths the same type: file, directory, symbolic link etc.
+            guard file1Type == file2Type else {
+                return false
+            }
+
+            if file1Type == S_IFCHR || file1Type == S_IFBLK {
+                // For character devices, just check the major/minor pair is the same.
+                return _dev_major(file1.st_rdev) == _dev_major(file2.st_rdev)
+                    && _dev_minor(file1.st_rdev) == _dev_minor(file2.st_rdev)
+            }
+
+            // If both paths point to the same device/inode or they are both zero length
+            // then they are considered equal so just check readability.
+            if (file1.st_dev == file2.st_dev && file1.st_ino == file2.st_ino)
+                || (file1.st_size == 0 && file2.st_size == 0) {
+                return access(fsRep1, R_OK) == 0 && access(fsRep2, R_OK) == 0
+            }
+
+            if file1Type == S_IFREG {
+                // Regular files and symlinks should at least have the same filesize if contents are equal.
+                guard file1.st_size == file2.st_size else {
+                    return false
+                }
+                return _compareFiles(withFileSystemRepresentation: path1, andFileSystemRepresentation: path2, size: Int64(file1.st_size), bufSize: Int(file1.st_blksize))
+            }
+            else if file1Type == S_IFLNK {
+                return _compareSymlinks(withFileSystemRepresentation: fsRep1, andFileSystemRepresentation: fsRep2, size: Int64(file1.st_size))
+            }
+            else if file1Type == S_IFDIR {
+                return _compareDirectories(atPath: path1, andPath: path2)
+            }
+
+            // Don't know how to compare other file types.
+            return false
+        } catch {
+            return false
+        }
+}
+
+    internal func _appendSymlinkDestination(_ dest: String, toPath: String) -> String {
+        let isAbsolutePath: Bool = dest.hasPrefix("/")
+
+        if isAbsolutePath {
+            return dest
+        }
+        let temp = toPath._bridgeToObjectiveC().deletingLastPathComponent
+        return temp._bridgeToObjectiveC().appendingPathComponent(dest)
+    }
+
+    internal class NSURLDirectoryEnumerator : DirectoryEnumerator {
+        var _url : URL
+        var _options : FileManager.DirectoryEnumerationOptions
+        var _errorHandler : ((URL, Error) -> Bool)?
+        var _stream : UnsafeMutablePointer<FTS>? = nil
+        var _current : UnsafeMutablePointer<FTSENT>? = nil
+        var _rootError : Error? = nil
+        var _gotRoot : Bool = false
+
+
+        // See @escaping comments above.
+        init(url: URL, options: FileManager.DirectoryEnumerationOptions, errorHandler: (/* @escaping */ (URL, Error) -> Bool)?) {
+            _url = url
+            _options = options
+            _errorHandler = errorHandler
+
+            let fm = FileManager.default
+            do {
+                guard fm.fileExists(atPath: _url.path) else { throw _NSErrorWithErrno(ENOENT, reading: true, url: url) }
+                _stream = try FileManager.default._fileSystemRepresentation(withPath: _url.path) { fsRep in
+                    let ps = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>.allocate(capacity: 2)
+                    defer { ps.deallocate() }
+                    ps.initialize(to: UnsafeMutablePointer(mutating: fsRep))
+                    ps.advanced(by: 1).initialize(to: nil)
+                    return fts_open(ps, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR, nil)
+                }
+                if _stream == nil {
+                    throw _NSErrorWithErrno(errno, reading: true, url: url)
+                }
+            } catch {
+                _rootError = error
+            }
+        }
+
+        deinit {
+            if let stream = _stream {
+                fts_close(stream)
+            }
+        }
+
+        override func nextObject() -> Any? {
+            func match(filename: String, to options: DirectoryEnumerationOptions, isDir: Bool) -> (Bool, Bool) {
+                var showFile = true
+                var skipDescendants = false
+
+                if isDir {
+                    if options.contains(.skipsSubdirectoryDescendants) {
+                        skipDescendants = true
+                    }
+                    // Ignore .skipsPackageDescendants
+                }
+                if options.contains(.skipsHiddenFiles) && (filename[filename._startOfLastPathComponent] == ".") {
+                    showFile = false
+                    skipDescendants = true
+                }
+
+                return (showFile, skipDescendants)
+            }
+
+
+            if let stream = _stream {
+
+                if !_gotRoot  {
+                    _gotRoot = true
+
+                    // Skip the root.
+                    _current = fts_read(stream)
+                }
+
+                _current = fts_read(stream)
+                while let current = _current {
+                    let filename = FileManager.default.string(withFileSystemRepresentation: current.pointee.fts_path, length: Int(current.pointee.fts_pathlen))
+
+                    switch Int32(current.pointee.fts_info) {
+                        case FTS_D:
+                            let (showFile, skipDescendants) = match(filename: filename, to: _options, isDir: true)
+                            if skipDescendants {
+                                fts_set(_stream, _current, FTS_SKIP)
+                            }
+                            if showFile {
+                                 return URL(fileURLWithPath: filename)
+                            }
+
+                        case FTS_DEFAULT, FTS_F, FTS_NSOK, FTS_SL, FTS_SLNONE:
+                            let (showFile, _) = match(filename: filename, to: _options, isDir: false)
+                            if showFile {
+                                return URL(fileURLWithPath: filename)
+                            }
+                        case FTS_DNR, FTS_ERR, FTS_NS:
+                            let keepGoing: Bool
+                            if let handler = _errorHandler {
+                                keepGoing = handler(URL(fileURLWithPath: filename), _NSErrorWithErrno(current.pointee.fts_errno, reading: true))
+                            } else {
+                                keepGoing = true
+                            }
+                            if !keepGoing {
+                                fts_close(stream)
+                                _stream = nil
+                                return nil
+                            }
+                        default:
+                            break
+                    }
+                    _current = fts_read(stream)
+                }
+                // TODO: Error handling if fts_read fails.
+            } else if let error = _rootError {
+                // Was there an error opening the stream?
+                if let handler = _errorHandler {
+                    let _ = handler(_url, error)
+                }
+            }
+            return nil
+        }
+
+        override var level: Int {
+            return Int(_current?.pointee.fts_level ?? 0)
+        }
+
+        override func skipDescendants() {
+            if let stream = _stream, let current = _current {
+                fts_set(stream, current, FTS_SKIP)
+            }
+        }
+
+        override var directoryAttributes : [FileAttributeKey : Any]? {
+            return nil
+        }
+
+        override var fileAttributes: [FileAttributeKey : Any]? {
+            return nil
+        }
+    }
+}
+
+extension FileManager.NSPathDirectoryEnumerator {
+    internal func _nextObject() -> Any? {
+        let o = innerEnumerator.nextObject()
+        guard let url = o as? URL else {
+            return nil
+        }
+
+        let path = url.path.replacingOccurrences(of: baseURL.path+"/", with: "")
+        _currentItemPath = path
+        return _currentItemPath
+    }
+}
+
+
+#endif

--- a/Foundation/FileManager+Win32.swift
+++ b/Foundation/FileManager+Win32.swift
@@ -1,0 +1,662 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+import CoreFoundation
+
+#if os(Windows)
+internal func joinPath(prefix: String, suffix: String) -> String {
+    var pszPath: PWSTR?
+    _ = prefix.withCString(encodedAs: UTF16.self) { prefix in
+        _ = suffix.withCString(encodedAs: UTF16.self) { suffix in
+            PathAllocCombine(prefix, suffix, ULONG(PATHCCH_ALLOW_LONG_PATHS.rawValue), &pszPath)
+        }
+    }
+
+    let path: String = String(decodingCString: pszPath!, as: UTF16.self)
+    LocalFree(pszPath)
+    return path
+}
+
+extension FileManager {
+    internal func _mountedVolumeURLs(includingResourceValuesForKeys propertyKeys: [URLResourceKey]?, options: VolumeEnumerationOptions = []) -> [URL]? {
+        var urls: [URL] = []
+
+        var wszVolumeName: UnsafeMutableBufferPointer<WCHAR> = UnsafeMutableBufferPointer<WCHAR>.allocate(capacity: Int(MAX_PATH))
+        defer { wszVolumeName.deallocate() }
+
+        var hVolumes: HANDLE = FindFirstVolumeW(wszVolumeName.baseAddress, DWORD(wszVolumeName.count))
+        guard hVolumes != INVALID_HANDLE_VALUE else { return nil }
+        defer { FindVolumeClose(hVolumes) }
+
+        repeat {
+            var dwCChReturnLength: DWORD = 0
+            GetVolumePathNamesForVolumeNameW(wszVolumeName.baseAddress, nil, 0, &dwCChReturnLength)
+
+            var wszPathNames: UnsafeMutableBufferPointer<WCHAR> = UnsafeMutableBufferPointer<WCHAR>.allocate(capacity: Int(dwCChReturnLength + 1))
+            defer { wszPathNames.deallocate() }
+
+            if GetVolumePathNamesForVolumeNameW(wszVolumeName.baseAddress, wszPathNames.baseAddress, DWORD(wszPathNames.count), &dwCChReturnLength) == FALSE {
+                // TODO(compnerd) handle error
+                continue
+            }
+
+            var pPath: DWORD = 0
+            repeat {
+                let path: String = String(decodingCString: wszPathNames.baseAddress! + Int(pPath), as: UTF16.self)
+                if path.length == 0 {
+                    break
+                }
+                urls.append(URL(fileURLWithPath: path, isDirectory: true))
+                pPath += DWORD(path.length + 1)
+            } while pPath < dwCChReturnLength
+        } while FindNextVolumeW(hVolumes, wszVolumeName.baseAddress, DWORD(wszVolumeName.count)) != FALSE
+        return urls
+    }
+    internal func _urls(for directory: SearchPathDirectory, in domainMask: SearchPathDomainMask) -> [URL] {
+        let domains = _SearchPathDomain.allInSearchOrder(from: domainMask)
+
+        var urls: [URL] = []
+
+        for domain in domains {
+            urls.append(contentsOf: windowsURLs(for: directory, in: domain))
+        }
+
+        return urls
+    }
+
+    private class func url(for id: KNOWNFOLDERID) -> URL {
+        var pszPath: PWSTR?
+        let hResult: HRESULT = withUnsafePointer(to: id) { id in
+            SHGetKnownFolderPath(id, DWORD(KF_FLAG_DEFAULT.rawValue), nil, &pszPath)
+        }
+        precondition(hResult >= 0, "SHGetKnownFolderpath failed \(GetLastError())")
+        let url: URL = URL(fileURLWithPath: String(decodingCString: pszPath!, as: UTF16.self), isDirectory: true)
+        CoTaskMemFree(pszPath)
+        return url
+    }
+
+    private func windowsURLs(for directory: SearchPathDirectory, in domain: _SearchPathDomain) -> [URL] {
+        switch directory {
+        case .autosavedInformationDirectory:
+            // FIXME(compnerd) where should this go?
+            return []
+
+        case .desktopDirectory:
+            guard domain == .user else { return [] }
+            return [FileManager.url(for: FOLDERID_Desktop)]
+
+        case .documentDirectory:
+            guard domain == .user else { return [] }
+            return [FileManager.url(for: FOLDERID_Documents)]
+
+        case .cachesDirectory:
+            guard domain == .user else { return [] }
+            return [URL(fileURLWithPath: NSTemporaryDirectory())]
+
+        case .applicationSupportDirectory:
+            switch domain {
+            case .local:
+                return [FileManager.url(for: FOLDERID_ProgramData)]
+            case .user:
+                return [FileManager.url(for: FOLDERID_LocalAppData)]
+            default:
+                return []
+            }
+
+            case .downloadsDirectory:
+                guard domain == .user else { return [] }
+                return [FileManager.url(for: FOLDERID_Downloads)]
+
+            case .userDirectory:
+                guard domain == .user else { return [] }
+                return [FileManager.url(for: FOLDERID_UserProfiles)]
+
+            case .moviesDirectory:
+                guard domain == .user else { return [] }
+                return [FileManager.url(for: FOLDERID_Videos)]
+
+            case .musicDirectory:
+                guard domain == .user else { return [] }
+                return [FileManager.url(for: FOLDERID_Music)]
+
+            case .picturesDirectory:
+                guard domain == .user else { return [] }
+                return [FileManager.url(for: FOLDERID_PicturesLibrary)]
+
+            case .sharedPublicDirectory:
+                guard domain == .user else { return [] }
+                return [FileManager.url(for: FOLDERID_Public)]
+
+            case .trashDirectory:
+                guard domain == .user else { return [] }
+                return [FileManager.url(for: FOLDERID_RecycleBinFolder)]
+
+                // None of these are supported outside of Darwin:
+            case .applicationDirectory,
+                 .demoApplicationDirectory,
+                 .developerApplicationDirectory,
+                 .adminApplicationDirectory,
+                 .libraryDirectory,
+                 .developerDirectory,
+                 .documentationDirectory,
+                 .coreServiceDirectory,
+                 .inputMethodsDirectory,
+                 .preferencePanesDirectory,
+                 .applicationScriptsDirectory,
+                 .allApplicationsDirectory,
+                 .allLibrariesDirectory,
+                 .printerDescriptionDirectory,
+                 .itemReplacementDirectory:
+                return []
+        }
+    }
+
+    internal func _createDirectory(atPath path: String, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey : Any]? = [:]) throws {
+        if createIntermediates {
+            var isDir: ObjCBool = false
+            if fileExists(atPath: path, isDirectory: &isDir) {
+                guard isDir.boolValue else { throw _NSErrorWithErrno(EEXIST, reading: false, path: path) }
+                return
+            }
+
+            let parent = path._nsObject.deletingLastPathComponent
+            if !parent.isEmpty && !fileExists(atPath: parent, isDirectory: &isDir) {
+                try createDirectory(atPath: parent, withIntermediateDirectories: true, attributes: attributes)
+            }
+        }
+
+        var saAttributes: SECURITY_ATTRIBUTES =
+          SECURITY_ATTRIBUTES(nLength: DWORD(MemoryLayout<SECURITY_ATTRIBUTES>.size),
+                              lpSecurityDescriptor: nil,
+                              bInheritHandle: FALSE)
+        let psaAttributes: UnsafeMutablePointer<SECURITY_ATTRIBUTES> =
+          UnsafeMutablePointer<SECURITY_ATTRIBUTES>(&saAttributes)
+
+
+        try path.withCString(encodedAs: UTF16.self) {
+            if CreateDirectoryW($0, psaAttributes) == FALSE {
+                // FIXME(compnerd) pass along path
+                throw _NSErrorWithWindowsError(GetLastError(), reading: false)
+            }
+        }
+        if let attr = attributes {
+            try self.setAttributes(attr, ofItemAtPath: path)
+        }
+    }
+
+    internal func _contentsOfDir(atPath path: String, _ closure: (String, Int32) throws -> () ) throws {
+        try path.withCString(encodedAs: UTF16.self) {
+            var ffd: WIN32_FIND_DATAW = WIN32_FIND_DATAW()
+
+            let hDirectory: HANDLE = FindFirstFileW($0, &ffd)
+            if hDirectory == INVALID_HANDLE_VALUE {
+                throw _NSErrorWithWindowsError(GetLastError(), reading: true)
+            }
+            defer { FindClose(hDirectory) }
+
+            repeat {
+                let path: String = withUnsafePointer(to: &ffd.cFileName) {
+                    $0.withMemoryRebound(to: UInt16.self, capacity: MemoryLayout.size(ofValue: $0) / MemoryLayout<WCHAR>.size) {
+                        String(decodingCString: $0, as: UTF16.self)
+                    }
+                }
+
+                try closure(path, Int32(ffd.dwFileAttributes))
+            } while FindNextFileW(hDirectory, &ffd) != FALSE
+        }
+    }
+
+    internal func _subpathsOfDirectory(atPath path: String) throws -> [String] {
+        var contents: [String] = []
+
+        try _contentsOfDir(atPath: path, { (entryName, entryType) throws in
+            contents.append(entryName)
+            if entryType & FILE_ATTRIBUTE_DIRECTORY == FILE_ATTRIBUTE_DIRECTORY {
+                let subPath: String = joinPath(prefix: path, suffix: entryName)
+                let entries = try subpathsOfDirectory(atPath: subPath)
+                contents.append(contentsOf: entries.map { joinPath(prefix: entryName, suffix: $0) })
+            }
+        })
+        return contents
+    }
+
+    internal func windowsFileAttributes(atPath path: String) throws -> WIN32_FILE_ATTRIBUTE_DATA {
+        var faAttributes: WIN32_FILE_ATTRIBUTE_DATA = WIN32_FILE_ATTRIBUTE_DATA()
+        return try path.withCString(encodedAs: UTF16.self) {
+            if GetFileAttributesExW($0, GetFileExInfoStandard, &faAttributes) == FALSE {
+                throw _NSErrorWithWindowsError(GetLastError(), reading: true)
+            }
+            return faAttributes
+        }
+    }
+
+    internal func _attributesOfFileSystem(forPath path: String) throws -> [FileAttributeKey : Any] {
+        var result: [FileAttributeKey:Any] = [:]
+
+        try path.withCString(encodedAs: UTF16.self) {
+            let dwLength: DWORD = GetFullPathNameW($0, 0, nil, nil)
+            let szVolumePath: UnsafeMutableBufferPointer<WCHAR> = UnsafeMutableBufferPointer<WCHAR>.allocate(capacity: Int(dwLength + 1))
+            defer { szVolumePath.deallocate() }
+
+            guard GetVolumePathNameW($0, szVolumePath.baseAddress, dwLength) != FALSE else {
+                throw _NSErrorWithWindowsError(GetLastError(), reading: true)
+            }
+
+            var liTotal: ULARGE_INTEGER = ULARGE_INTEGER()
+            var liFree: ULARGE_INTEGER = ULARGE_INTEGER()
+
+            guard GetDiskFreeSpaceExW(szVolumePath.baseAddress, nil, &liTotal, &liFree) != FALSE else {
+                throw _NSErrorWithWindowsError(GetLastError(), reading: true)
+            }
+
+            result[.systemSize] = NSNumber(value: liTotal.QuadPart)
+            result[.systemFreeSize] = NSNumber(value: liFree.QuadPart)
+            // FIXME(compnerd): what about .systemNodes, .systemFreeNodes?
+        }
+        return result
+    }
+
+    internal func _createSymbolicLink(atPath path: String, withDestinationPath destPath: String) throws {
+        let faAttributes: WIN32_FILE_ATTRIBUTE_DATA = try windowsFileAttributes(atPath: path)
+        var dwFlags: DWORD = DWORD(SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE)
+        if faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY) == DWORD(FILE_ATTRIBUTE_DIRECTORY) {
+            dwFlags |= DWORD(SYMBOLIC_LINK_FLAG_DIRECTORY)
+        }
+
+        try path.withCString(encodedAs: UTF16.self) { name in
+            try destPath.withCString(encodedAs: UTF16.self) { dest in
+                guard CreateSymbolicLinkW(name, dest, dwFlags) != FALSE else {
+                    throw _NSErrorWithWindowsError(GetLastError(), reading: false)
+                }
+            }
+        }
+    }
+
+    internal func _destinationOfSymbolicLink(atPath path: String) throws -> String {
+        var hFile: HANDLE = INVALID_HANDLE_VALUE
+        path.withCString(encodedAs: UTF16.self) { link in
+            hFile = CreateFileW(link, GENERIC_READ, DWORD(FILE_SHARE_WRITE), nil, DWORD(OPEN_EXISTING), DWORD(FILE_FLAG_BACKUP_SEMANTICS), nil)
+        }
+        if hFile == INVALID_HANDLE_VALUE {
+            throw _NSErrorWithWindowsError(GetLastError(), reading: true)
+        }
+
+        let dwLength: DWORD = GetFinalPathNameByHandleW(hFile, nil, 0, DWORD(FILE_NAME_NORMALIZED))
+        let szPath: UnsafeMutableBufferPointer<WCHAR> = UnsafeMutableBufferPointer<WCHAR>.allocate(capacity: Int(dwLength + 1))
+        defer { szPath.deallocate() }
+
+        GetFinalPathNameByHandleW(hFile, szPath.baseAddress, dwLength, DWORD(FILE_NAME_NORMALIZED))
+        return String(decodingCString: szPath.baseAddress!, as: UTF16.self)
+    }
+
+    internal func _copyRegularFile(atPath srcPath: String, toPath dstPath: String, variant: String = "Copy") throws {
+        try srcPath.withCString(encodedAs: UTF16.self) { src in
+            try dstPath.withCString(encodedAs: UTF16.self) { dst in
+                if CopyFileW(src, dst, FALSE) == FALSE {
+                    throw _NSErrorWithWindowsError(GetLastError(), reading: false)
+                }
+            }
+        }
+    }
+
+    internal func _copySymlink(atPath srcPath: String, toPath dstPath: String, variant: String = "Copy") throws {
+        let faAttributes: WIN32_FILE_ATTRIBUTE_DATA = try windowsFileAttributes(atPath: srcPath)
+        guard faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_REPARSE_POINT) == DWORD(FILE_ATTRIBUTE_REPARSE_POINT) else {
+            throw _NSErrorWithErrno(EINVAL, reading: true, path: srcPath, extraUserInfo: extraErrorInfo(srcPath: srcPath, dstPath: dstPath, userVariant: variant))
+        }
+
+        let destination = try FileManager.default.destinationOfSymbolicLink(atPath: srcPath)
+
+        var dwFlags: DWORD = DWORD(SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE)
+        if try windowsFileAttributes(atPath: destination).dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY) == DWORD(FILE_ATTRIBUTE_DIRECTORY) {
+            dwFlags |= DWORD(SYMBOLIC_LINK_FLAG_DIRECTORY)
+        }
+
+        try FileManager.default.createSymbolicLink(atPath: dstPath, withDestinationPath: destination)
+    }
+
+    internal func _copyOrLinkDirectoryHelper(atPath srcPath: String, toPath dstPath: String, variant: String = "Copy", _ body: (String, String, FileAttributeType) throws -> ()) throws {
+        var faAttributes: WIN32_FILE_ATTRIBUTE_DATA = WIN32_FILE_ATTRIBUTE_DATA()
+        do { faAttributes = try windowsFileAttributes(atPath: srcPath) } catch { return }
+
+        var fileType = FileAttributeType(attributes: faAttributes)
+        if fileType == .typeDirectory {
+          try createDirectory(atPath: dstPath, withIntermediateDirectories: false, attributes: nil)
+          guard let enumerator = enumerator(atPath: srcPath) else {
+            throw _NSErrorWithErrno(ENOENT, reading: true, path: srcPath)
+          }
+
+          while let item = enumerator.nextObject() as? String {
+            let src = joinPath(prefix: srcPath, suffix: item)
+            let dst = joinPath(prefix: dstPath, suffix: item)
+
+            do { faAttributes = try windowsFileAttributes(atPath: src) } catch { return }
+            fileType = FileAttributeType(attributes: faAttributes)
+            if fileType == .typeDirectory {
+              try createDirectory(atPath: dst, withIntermediateDirectories: false, attributes: nil)
+            } else {
+              try body(src, dst, fileType)
+            }
+          }
+        } else {
+          try body(srcPath, dstPath, fileType)
+        }
+    }
+
+    internal func _moveItem(atPath srcPath: String, toPath dstPath: String, isURL: Bool) throws {
+        guard shouldMoveItemAtPath(srcPath, toPath: dstPath, isURL: isURL) else {
+            return
+        }
+
+        guard !self.fileExists(atPath: dstPath) else {
+            throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileWriteFileExists.rawValue, userInfo: [NSFilePathErrorKey : NSString(dstPath)])
+        }
+
+        try srcPath.withCString(encodedAs: UTF16.self) { src in
+            try dstPath.withCString(encodedAs: UTF16.self) { dst in
+                if MoveFileExW(src, dst, DWORD(MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH)) == FALSE {
+                    throw _NSErrorWithWindowsError(GetLastError(), reading: false)
+                }
+            }
+        }
+    }
+
+    internal func _linkItem(atPath srcPath: String, toPath dstPath: String, isURL: Bool) throws {
+        try _copyOrLinkDirectoryHelper(atPath: srcPath, toPath: dstPath) { (srcPath, dstPath, fileType) in
+            guard shouldLinkItemAtPath(srcPath, toPath: dstPath, isURL: isURL) else {
+                return
+            }
+
+            do {
+                switch fileType {
+                case .typeRegular:
+                    try srcPath.withCString(encodedAs: UTF16.self) { src in
+                        try dstPath.withCString(encodedAs: UTF16.self) { dst in
+                            if CreateHardLinkW(src, dst, nil) == FALSE {
+                                throw _NSErrorWithWindowsError(GetLastError(), reading: false)
+                            }
+                        }
+                    }
+                case .typeSymbolicLink:
+                    try _copySymlink(atPath: srcPath, toPath: dstPath)
+                default:
+                    break
+                }
+            } catch {
+                if !shouldProceedAfterError(error, linkingItemAtPath: srcPath, toPath: dstPath, isURL: isURL) {
+                    throw error
+                }
+            }
+        }
+    }
+
+    @available(Windows, deprecated, message: "Not Yet Implemented")
+    internal func _removeItem(atPath path: String, isURL: Bool, alreadyConfirmed: Bool = false) throws {
+        guard alreadyConfirmed || shouldRemoveItemAtPath(path, isURL: isURL) else {
+            return
+        }
+
+        NSUnimplemented()
+    }
+
+    internal func _currentDirectoryPath() -> String {
+        let dwLength: DWORD = GetCurrentDirectoryW(0, nil)
+        var szDirectory: UnsafeMutableBufferPointer<WCHAR> = UnsafeMutableBufferPointer.allocate(capacity: Int(dwLength + 1))
+        defer { szDirectory.deallocate() }
+
+        GetCurrentDirectoryW(dwLength, szDirectory.baseAddress)
+        return String(decodingCString: szDirectory.baseAddress!, as: UTF16.self)
+    }
+
+    @discardableResult
+    internal func _changeCurrentDirectoryPath(_ path: String) -> Bool {
+        return path.withCString(encodedAs: UTF16.self) { SetCurrentDirectoryW($0) != FALSE }
+    }
+
+    internal func _fileExists(atPath path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) -> Bool {
+        var faAttributes: WIN32_FILE_ATTRIBUTE_DATA = WIN32_FILE_ATTRIBUTE_DATA()
+        do { faAttributes = try windowsFileAttributes(atPath: path) } catch { return false }
+        if faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_REPARSE_POINT) == DWORD(FILE_ATTRIBUTE_REPARSE_POINT) {
+            do { try faAttributes = windowsFileAttributes(atPath: destinationOfSymbolicLink(atPath: path)) } catch { return false }
+        }
+        if let isDirectory = isDirectory {
+            isDirectory.pointee = ObjCBool(faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY) == DWORD(FILE_ATTRIBUTE_DIRECTORY))
+        }
+        return true
+    }
+
+
+    internal func _isReadableFile(atPath path: String) -> Bool {
+        do { let _ = try windowsFileAttributes(atPath: path) } catch { return false }
+        return true
+    }
+
+    internal func _isWritableFile(atPath path: String) -> Bool {
+        guard let faAttributes: WIN32_FILE_ATTRIBUTE_DATA = try? windowsFileAttributes(atPath: path) else { return false }
+        return faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_READONLY) != DWORD(FILE_ATTRIBUTE_READONLY)
+    }
+
+    internal func _isExecutableFile(atPath path: String) -> Bool {
+        // FIXME(compnerd) is there some test that we can perform here?
+        return true
+    }
+
+    internal func _isDeletableFile(atPath path: String) -> Bool {
+        guard path != "" else { return true }
+
+        // Get the parent directory of supplied path
+        let parent = path._nsObject.deletingLastPathComponent
+        var faAttributes: WIN32_FILE_ATTRIBUTE_DATA = WIN32_FILE_ATTRIBUTE_DATA()
+        do { faAttributes = try windowsFileAttributes(atPath: parent) } catch { return false }
+        if faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_READONLY) == DWORD(FILE_ATTRIBUTE_READONLY) {
+            return false
+        }
+
+        do { faAttributes = try windowsFileAttributes(atPath: path) } catch { return false }
+        if faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_READONLY) == DWORD(FILE_ATTRIBUTE_READONLY) {
+            return false
+        }
+
+        return true
+    }
+
+    internal func _compareFiles(withFileSystemRepresentation file1Rep: UnsafePointer<Int8>, andFileSystemRepresentation file2Rep: UnsafePointer<Int8>, size: Int64, bufSize: Int) -> Bool {
+        NSUnimplemented()
+    }
+
+    internal func _lstatFile(atPath path: String, withFileSystemRepresentation fsRep: UnsafePointer<Int8>? = nil) throws -> stat {
+        let _fsRep: UnsafePointer<Int8>
+        if fsRep == nil {
+            _fsRep = try __fileSystemRepresentation(withPath: path)
+        } else {
+            _fsRep = fsRep!
+        }
+
+        defer {
+            if fsRep == nil { _fsRep.deallocate() }
+        }
+
+        var statInfo = stat()
+        let h = path.withCString(encodedAs: UTF16.self) {
+            CreateFileW(/*lpFileName=*/$0,
+                        /*dwDesiredAccess=*/DWORD(0),
+                        /*dwShareMode=*/DWORD(FILE_SHARE_READ),
+                        /*lpSecurityAttributes=*/nil,
+                        /*dwCreationDisposition=*/DWORD(OPEN_EXISTING),
+                        /*dwFlagsAndAttributes=*/DWORD(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS),
+                        /*hTemplateFile=*/nil)
+        }
+        if h == INVALID_HANDLE_VALUE {
+            throw _NSErrorWithWindowsError(GetLastError(), reading: false)
+        }
+        var info: BY_HANDLE_FILE_INFORMATION = BY_HANDLE_FILE_INFORMATION()
+        GetFileInformationByHandle(h, &info)
+        // Group id is always 0 on Windows
+        statInfo.st_gid = 0
+        statInfo.st_atime = info.ftLastAccessTime.time_t
+        statInfo.st_ctime = info.ftCreationTime.time_t
+        statInfo.st_dev = info.dwVolumeSerialNumber
+        // inodes have meaning on FAT/HPFS/NTFS
+        statInfo.st_ino = 0
+        statInfo.st_rdev = info.dwVolumeSerialNumber
+
+        let isReparsePoint = info.dwFileAttributes & DWORD(FILE_ATTRIBUTE_REPARSE_POINT) != 0
+        let isDir = info.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY) != 0
+        let fileMode = isDir ? _S_IFDIR : _S_IFREG
+        // On a symlink to a directory, Windows sets both the REPARSE_POINT and
+        // DIRECTORY attributes. Since Windows doesn't provide S_IFLNK and we
+        // want unix style "symlinks to directories are not directories
+        // themselves, we say symlinks are regular files
+        statInfo.st_mode = UInt16(isReparsePoint ? _S_IFREG : fileMode)
+        let isReadOnly = info.dwFileAttributes & DWORD(FILE_ATTRIBUTE_READONLY) != 0
+        statInfo.st_mode |= UInt16(isReadOnly ? _S_IREAD : (_S_IREAD | _S_IWRITE))
+        statInfo.st_mode |= UInt16(_S_IEXEC)
+
+        statInfo.st_mtime = info.ftLastWriteTime.time_t
+        statInfo.st_nlink = Int16(info.nNumberOfLinks)
+        if info.nFileSizeHigh != 0 {
+            throw _NSErrorWithErrno(EOVERFLOW, reading: true, path: path)
+        }
+        statInfo.st_size = Int32(info.nFileSizeLow)
+        // Uid is always 0 on Windows systems
+        statInfo.st_uid = 0
+        CloseHandle(h)
+        return statInfo
+    }
+
+    internal func _contentsEqual(atPath path1: String, andPath path2: String) -> Bool {
+        NSUnimplemented()
+    }
+
+    internal func _appendSymlinkDestination(_ dest: String, toPath: String) -> String {
+        var isAbsolutePath: Bool = false
+        dest.withCString(encodedAs: UTF16.self) {
+            isAbsolutePath = PathIsRelativeW($0) == FALSE
+        }
+
+        if isAbsolutePath {
+            return dest
+        }
+        let temp = toPath._bridgeToObjectiveC().deletingLastPathComponent
+        return temp._bridgeToObjectiveC().appendingPathComponent(dest)
+    }
+
+    internal class NSURLDirectoryEnumerator : DirectoryEnumerator {
+        var _options : FileManager.DirectoryEnumerationOptions
+        var _errorHandler : ((URL, Error) -> Bool)?
+        var _stack: [URL]
+        var _current: URL?
+        var _rootDepth : Int
+
+        init(url: URL, options: FileManager.DirectoryEnumerationOptions, errorHandler: (/* @escaping */ (URL, Error) -> Bool)?) {
+            _options = options
+            _errorHandler = errorHandler
+            _stack = [url]
+            _rootDepth = url.pathComponents.count
+        }
+
+        override func nextObject() -> Any? {
+            func contentsOfDir(directory: URL) -> [URL]? {
+                var ffd: WIN32_FIND_DATAW = WIN32_FIND_DATAW()
+                guard let dirFSR = directory.withUnsafeFileSystemRepresentation({ $0.flatMap { fsr in String(utf8String: fsr) } })
+                else { return nil }
+                let dirPath = joinPath(prefix: dirFSR, suffix: "*")
+                let h: HANDLE = dirPath.withCString(encodedAs: UTF16.self) {
+                  FindFirstFileW($0, &ffd)
+                }
+                guard h != INVALID_HANDLE_VALUE else { return nil }
+                defer { FindClose(h) }
+
+                var files: [URL] = []
+                repeat {
+                    let fileArr = Array<WCHAR>(
+                      UnsafeBufferPointer(start: &ffd.cFileName.0,
+                                          count: MemoryLayout.size(ofValue: ffd.cFileName)))
+                    let file = String(decodingCString: fileArr, as: UTF16.self)
+                    if file != "."
+                        && file != ".."
+                        && (!_options.contains(.skipsHiddenFiles)
+                            || (ffd.dwFileAttributes & DWORD(FILE_ATTRIBUTE_HIDDEN) == 0)) {
+                        files.append(URL(fileURLWithPath: joinPath(prefix: dirFSR, suffix: file)))
+                      }
+                } while(FindNextFileW(h, &ffd) != 0)
+                return files
+            }
+            while let url = _stack.popLast() {
+                if url.hasDirectoryPath && !_options.contains(.skipsSubdirectoryDescendants) {
+                    guard let dirContents = contentsOfDir(directory: url)?.reversed() else {
+                        if let handler = _errorHandler {
+                           let dirFSR = url.withUnsafeFileSystemRepresentation { $0.flatMap { fsr in String(utf8String: fsr) } }
+                           let keepGoing = handler(URL(fileURLWithPath: dirFSR ?? ""),
+                               _NSErrorWithWindowsError(GetLastError(), reading: true))
+                           if !keepGoing { return nil }
+                        }
+                        continue
+                    }
+                    _stack.append(contentsOf: dirContents)
+                }
+                _current = url
+                return url
+            }
+            return nil
+        }
+
+        override var level: Int {
+            return _rootDepth - (_current?.pathComponents.count ?? _rootDepth)
+        }
+
+        override func skipDescendants() {
+            _options.insert(.skipsSubdirectoryDescendants)
+        }
+
+        override var directoryAttributes : [FileAttributeKey : Any]? {
+            return nil
+        }
+
+        override var fileAttributes: [FileAttributeKey : Any]? {
+            return nil
+        }
+    }
+}
+
+extension FileManager.NSPathDirectoryEnumerator {
+    internal func _nextObject() -> Any? {
+        let o = innerEnumerator.nextObject()
+        guard let url = o as? URL else {
+            return nil
+        }
+
+        var relativePath = UnsafeMutableBufferPointer<WCHAR>.allocate(capacity: Int(MAX_PATH))
+        defer { relativePath.deallocate() }
+        func withURLCString<Result>(url: URL, _ f: (UnsafePointer<WCHAR>) -> Result?) -> Result? {
+            return url.withUnsafeFileSystemRepresentation { fsr in
+                (fsr.flatMap { String(utf8String: $0) })?.withCString(encodedAs: UTF16.self) { f($0) }
+            }
+        }
+        let result = withURLCString(url: baseURL) { pszFrom -> BOOL? in
+            withURLCString(url: url) { pszTo in
+                let fromAttrs = GetFileAttributesW(pszFrom)
+                let toAttrs = GetFileAttributesW(pszTo)
+                guard fromAttrs != INVALID_FILE_ATTRIBUTES, toAttrs != INVALID_FILE_ATTRIBUTES else {
+                    return FALSE
+                }
+                return PathRelativePathToW(relativePath.baseAddress, pszFrom, fromAttrs, pszTo, toAttrs)
+            }
+        }
+
+        guard result == TRUE, let (path, _) = String.decodeCString(relativePath.baseAddress, as: UTF16.self) else {
+            return nil
+        }
+        _currentItemPath = path
+        return _currentItemPath
+    }
+
+}
+
+#endif


### PR DESCRIPTION
Splits the Windows and POSIX specific File Manager implementations into their own files. See https://github.com/apple/swift-corelibs-foundation/pull/2002#issuecomment-477242876

Not sure if there's a way to make the diff more readable, but in general, what I've done is copy over the function to win32/POSIX, prefixed the name with an underscore, removed the non applicable #if branch, and have the FileManager version pass through to it.