### PR TITLE
Platform check for TestFoundation failures for Apple Swift 5 Toolchain on PowerPC64LE(SR-10255)

### DIFF
--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -865,7 +865,11 @@ class TestNSNumber : XCTestCase {
         XCTAssertEqual(nanFloat.int32Value, 0)
         XCTAssertEqual(nanFloat.uint32Value, 0)
         XCTAssertEqual(nanFloat.int64Value, Int64(bitPattern: 1 << 63))
+#if arch(powerpc64le)
+        XCTAssertEqual(nanFloat.uint64Value, UInt64(bitPattern: 1 << 63 | 1 << 31))
+#else
         XCTAssertEqual(nanFloat.uint64Value, UInt64(bitPattern: 1 << 63))
+#endif
     }
     
     func test_numberWithDouble() {
@@ -910,8 +914,11 @@ class TestNSNumber : XCTestCase {
         XCTAssertEqual(nanDouble.int32Value, 0)
         XCTAssertEqual(nanDouble.uint32Value, 0)
         XCTAssertEqual(nanDouble.int64Value, Int64(bitPattern: 1 << 63))
+#if arch(powerpc64le)
+        XCTAssertEqual(nanDouble.uint64Value, UInt64(bitPattern: 1 << 63 | 1 << 31))
+#else
         XCTAssertEqual(nanDouble.uint64Value, UInt64(bitPattern: 1 << 63))
-
+#endif
     }
 
     func test_compareNumberWithBool() {


### PR DESCRIPTION
In the file "TestFoundation/TestNSNumber.swift" I could see several sections of code having XCTAssertEqual within conditional checks for architectures and OS. For e.g.:-
#if !(os(Linux) && (arch(arm) || arch(powerpc64) || arch(powerpc64le)))
        // Linux/arm and Linux/power chars are unsigned, so Int8 in Swift, until this issue is resolved, these tests will always fail.
        XCTAssertEqual(NSNumber(value: Int8(-37)).floatValue, Float(-37))
#endif

I have introduced this PR with similar checks for powerpc64le(followed by SR number in comments) for the 2 test failures reported in this SR. This would help move ahead and make some more progress on powerpc64le, until this issue is resolved by the original contributor of the 2 tests or any other member familiar with the changes.