### PR TITLE
[5.0] XMLParser.parse()` returns different values between macOS and Linux when `abortParsing()` is called.

### DIFF
--- a/Foundation/XMLParser.swift
+++ b/Foundation/XMLParser.swift
@@ -476,16 +476,14 @@ open class XMLParser : NSObject {
     }
     
     internal func _handleParseResult(_ parseResult: Int32) -> Bool {
-        return true
-        /*
-        var result = true
-        if parseResult != 0 {
-            if parseResult != -1 {
-                // TODO: determine if this result is a fatal error from libxml via the CF implementations
+        if parseResult == 0 {
+            return true
+        } else {
+            if _parserError == nil {
+                _parserError = NSError(domain: XMLParser.errorDomain, code: Int(parseResult))
             }
         }
-        return result
-        */
+        return false
     }
 
     internal func parseData(_ data: Data) -> Bool {

--- a/TestFoundation/TestXMLParser.swift
+++ b/TestFoundation/TestXMLParser.swift
@@ -65,6 +65,7 @@ class TestXMLParser : XCTestCase {
             ("test_withData", test_withData),
             ("test_withDataEncodings", test_withDataEncodings),
             ("test_withDataOptions", test_withDataOptions),
+            ("test_sr9758_abortParsing", test_sr9758_abortParsing),
         ]
     }
 
@@ -139,6 +140,18 @@ class TestXMLParser : XCTestCase {
         let res = parser.parse()
         XCTAssertEqual(stream.events, TestXMLParser.xmlUnderTestExpectedEvents(namespaces: true)  )
         XCTAssertTrue(res)
+    }
+
+    func test_sr9758_abortParsing() {
+        class Delegate: NSObject, XMLParserDelegate {
+            func parserDidStartDocument(_ parser: XMLParser) { parser.abortParsing() }
+        }
+        let xml = TestXMLParser.xmlUnderTest(encoding: .utf8)
+        let parser = XMLParser(data: xml.data(using: .utf8)!)
+        let delegate = Delegate()
+        parser.delegate = delegate
+        XCTAssertFalse(parser.parse())
+        XCTAssertNotNil(parser.parserError)
     }
 
 }


### PR DESCRIPTION
(cherry picked from commit e724ba0a04b6bfb2257ab308b7f0f7d4a9febcb8)

XMLParser: Handle the parse result.

(cherry picked from commit 2fe37a22157503bd8ddd046a4da150344c3e07cb)

XMLParser: Simplify the code in `func _handleParseResult() -> Bool`.

(cherry picked from commit 8314ceef9d256107db15bb45ebc657aadf9bb2ab)