### PR TITLE
[SR-464] _cfTypeID property's access modifier changed to internal as intended

### DIFF
--- a/Sources/Foundation/NSArray.swift
+++ b/Sources/Foundation/NSArray.swift
@@ -703,7 +703,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
         } as! [String]
     }
 
-    override open var _cfTypeID: CFTypeID {
+    override internal var _cfTypeID: CFTypeID {
         return CFArrayGetTypeID()
     }
     

--- a/Sources/Foundation/NSCFBoolean.swift
+++ b/Sources/Foundation/NSCFBoolean.swift
@@ -71,7 +71,7 @@ internal class __NSCFBoolean : NSNumber {
         return CFBooleanGetValue(unsafeBitCast(self, to: CFBoolean.self))
     }
     
-    override var _cfTypeID: CFTypeID {
+    override internal var _cfTypeID: CFTypeID {
         return CFBooleanGetTypeID()
     }
     

--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -88,7 +88,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         return type(of: self) === NSData.self || type(of: self) === NSMutableData.self
     }
 
-    override open var _cfTypeID: CFTypeID {
+    override internal var _cfTypeID: CFTypeID {
         return CFDataGetTypeID()
     }
 

--- a/Sources/Foundation/NSDate.swift
+++ b/Sources/Foundation/NSDate.swift
@@ -151,7 +151,7 @@ open class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
         return CFDateFormatterCreateStringWithDate(kCFAllocatorSystemDefault, dateFormatterRef, _cfObject)._swiftObject
     }
     
-    override open var _cfTypeID: CFTypeID {
+    override internal var _cfTypeID: CFTypeID {
         return CFDateGetTypeID()
     }
 }

--- a/Sources/Foundation/NSDictionary.swift
+++ b/Sources/Foundation/NSDictionary.swift
@@ -573,7 +573,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         return matching
     }
     
-    override open var _cfTypeID: CFTypeID {
+    override internal var _cfTypeID: CFTypeID {
         return CFDictionaryGetTypeID()
     }
 }

--- a/Sources/Foundation/NSKeyedArchiverHelpers.swift
+++ b/Sources/Foundation/NSKeyedArchiverHelpers.swift
@@ -24,7 +24,7 @@ internal class _NSKeyedArchiverUID : NSObject {
         return unsafeBitCast(self, to: CFType.self)
     }
     
-    override open var _cfTypeID: CFTypeID {
+    override internal var _cfTypeID: CFTypeID {
         return _CFKeyedArchiverUIDGetTypeID()
     }
 

--- a/Sources/Foundation/NSNumber.swift
+++ b/Sources/Foundation/NSNumber.swift
@@ -1005,7 +1005,7 @@ open class NSNumber : NSValue {
         }
     }
     
-    override open var _cfTypeID: CFTypeID {
+    override internal var _cfTypeID: CFTypeID {
         return CFNumberGetTypeID()
     }
     

--- a/Sources/Foundation/NSObject.swift
+++ b/Sources/Foundation/NSObject.swift
@@ -239,7 +239,7 @@ open class NSObject : NSObjectProtocol, Equatable, Hashable {
         return description
     }
     
-    open var _cfTypeID: CFTypeID {
+    internal var _cfTypeID: CFTypeID {
         return 0
     }
     

--- a/Sources/Foundation/NSSet.swift
+++ b/Sources/Foundation/NSSet.swift
@@ -190,7 +190,7 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
         return result
     }
     
-    override open var _cfTypeID: CFTypeID {
+    override internal var _cfTypeID: CFTypeID {
         return CFSetGetTypeID()
     }
 

--- a/Sources/Foundation/NSString.swift
+++ b/Sources/Foundation/NSString.swift
@@ -359,7 +359,7 @@ open class NSString : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSC
         return false
     }
     
-    override open var _cfTypeID: CFTypeID {
+    override internal var _cfTypeID: CFTypeID {
         return CFStringGetTypeID()
     }
   

--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -689,7 +689,7 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
         return URL(string: absoluteString)
     }
     
-    override open var _cfTypeID: CFTypeID {
+    override internal var _cfTypeID: CFTypeID {
         return CFURLGetTypeID()
     }
 


### PR DESCRIPTION
Bug Link: https://bugs.swift.org/browse/SR-464