### PR TITLE
SR-10157: XMLParser shouldn't swap the parts of the element name.

### DIFF
--- a/Foundation/XMLParser.swift
+++ b/Foundation/XMLParser.swift
@@ -296,13 +296,14 @@ internal func _NSXMLParserStartElementNs(_ ctx: _CFXMLInterface, localname: Unsa
     var qualifiedName: String? = nil
     if parser.shouldProcessNamespaces {
         namespaceURI = UTF8STRING(URI) ?? ""
-        qualifiedName = elementName
         if let prefix = UTF8STRING(prefix) {
-            qualifiedName = elementName + ":" + prefix
+            qualifiedName = prefix + ":" + elementName
+        } else {
+            qualifiedName = elementName
         }
     }
     else if let prefix = UTF8STRING(prefix) {
-        elementName = elementName + ":" + prefix
+        elementName = prefix + ":" + elementName
     }
 
     parser.delegate?.parser(parser, didStartElement: elementName, namespaceURI: namespaceURI, qualifiedName: qualifiedName, attributes: attrDict)
@@ -316,13 +317,14 @@ internal func _NSXMLParserEndElementNs(_ ctx: _CFXMLInterface , localname: Unsaf
     var qualifiedName: String? = nil
     if parser.shouldProcessNamespaces {
         namespaceURI = UTF8STRING(URI) ?? ""
-        qualifiedName = elementName
         if let prefix = UTF8STRING(prefix) {
-            qualifiedName = elementName + ":" + prefix
+            qualifiedName = prefix + ":" + elementName
+        } else {
+            qualifiedName = elementName
         }
     }
     else if let prefix = UTF8STRING(prefix) {
-        elementName = elementName + ":" + prefix
+        elementName = prefix + ":" + elementName
     }
 
     parser.delegate?.parser(parser, didEndElement: elementName, namespaceURI: namespaceURI, qualifiedName: qualifiedName)

--- a/TestFoundation/TestXMLParser.swift
+++ b/TestFoundation/TestXMLParser.swift
@@ -66,6 +66,7 @@ class TestXMLParser : XCTestCase {
             ("test_withDataEncodings", test_withDataEncodings),
             ("test_withDataOptions", test_withDataOptions),
             ("test_sr9758_abortParsing", test_sr9758_abortParsing),
+            ("test_sr10157_swappedElementNames", test_sr10157_swappedElementNames),
         ]
     }
 
@@ -154,4 +155,27 @@ class TestXMLParser : XCTestCase {
         XCTAssertNotNil(parser.parserError)
     }
 
+    func test_sr10157_swappedElementNames() {
+        class ElementNameChecker: NSObject, XMLParserDelegate {
+            let name: String
+            init(_ name: String) { self.name = name }
+            func parser(_ parser: XMLParser,
+                               didStartElement elementName: String,
+                               namespaceURI: String?,
+                               qualifiedName qName: String?,
+                               attributes attributeDict: [String: String] = [:]) {
+                XCTAssertEqual(self.name, elementName)
+            }
+            func check() {
+                let elementString = "<\(self.name) />"
+                let parser = XMLParser(data: elementString.data(using: .utf8)!)
+                parser.delegate = self
+                XCTAssertTrue(parser.parse())
+            }
+        }
+        
+        ElementNameChecker("noPrefix").check()
+        ElementNameChecker("myPrefix:myLocalName").check()
+    }
+    
 }

--- a/TestFoundation/TestXMLParser.swift
+++ b/TestFoundation/TestXMLParser.swift
@@ -160,22 +160,38 @@ class TestXMLParser : XCTestCase {
             let name: String
             init(_ name: String) { self.name = name }
             func parser(_ parser: XMLParser,
-                               didStartElement elementName: String,
-                               namespaceURI: String?,
-                               qualifiedName qName: String?,
-                               attributes attributeDict: [String: String] = [:]) {
-                XCTAssertEqual(self.name, elementName)
+                        didStartElement elementName: String,
+                        namespaceURI: String?,
+                        qualifiedName qName: String?,
+                        attributes attributeDict: [String: String] = [:])
+            {
+                if parser.shouldProcessNamespaces {
+                    XCTAssertEqual(self.name, qName)
+                } else {
+                    XCTAssertEqual(self.name, elementName)
+                }
             }
             func parser(_ parser: XMLParser,
                         didEndElement elementName: String,
                         namespaceURI: String?,
-                        qualifiedName qName: String?) {
-                XCTAssertEqual(self.name, elementName)
+                        qualifiedName qName: String?)
+            {
+                if parser.shouldProcessNamespaces {
+                    XCTAssertEqual(self.name, qName)
+                } else {
+                    XCTAssertEqual(self.name, elementName)
+                }
             }
             func check() {
                 let elementString = "<\(self.name) />"
-                let parser = XMLParser(data: elementString.data(using: .utf8)!)
+                var parser = XMLParser(data: elementString.data(using: .utf8)!)
                 parser.delegate = self
+                XCTAssertTrue(parser.parse())
+                
+                // Confirm that the parts of QName is also not swapped.
+                parser = XMLParser(data: elementString.data(using: .utf8)!)
+                parser.delegate = self
+                parser.shouldProcessNamespaces = true
                 XCTAssertTrue(parser.parse())
             }
         }

--- a/TestFoundation/TestXMLParser.swift
+++ b/TestFoundation/TestXMLParser.swift
@@ -166,6 +166,12 @@ class TestXMLParser : XCTestCase {
                                attributes attributeDict: [String: String] = [:]) {
                 XCTAssertEqual(self.name, elementName)
             }
+            func parser(_ parser: XMLParser,
+                        didEndElement elementName: String,
+                        namespaceURI: String?,
+                        qualifiedName qName: String?) {
+                XCTAssertEqual(self.name, elementName)
+            }
             func check() {
                 let elementString = "<\(self.name) />"
                 let parser = XMLParser(data: elementString.data(using: .utf8)!)


### PR DESCRIPTION
XMLParser swaps the prefix with the local name. This behavior is apparently a bug. This PR fixes it.

Resolves [SR-10157](https://bugs.swift.org/browse/SR-10157).