### PR TITLE
Locale: support building with older ICU

### DIFF
--- a/CoreFoundation/Locale.subproj/CFLocale.c
+++ b/CoreFoundation/Locale.subproj/CFLocale.c
@@ -32,7 +32,9 @@
 #include <unicode/putil.h>          // ICU low-level utilities
 #include <unicode/umsg.h>           // ICU message formatting
 #include <unicode/ucol.h>
+#if __has_include(<unicode/unumsys.h>)
 #include <unicode/unumsys.h>        // ICU numbering systems
+#endif
 #include <unicode/uvernum.h>
 #if U_ICU_VERSION_MAJOR_NUM > 53 && __has_include(<unicode/uameasureformat.h>)
 #include <unicode/uameasureformat.h>


### PR DESCRIPTION
The ICU header was not present on the older versions of ICU, but is sufficient
to build against.  Guard the inclusion.