### PR TITLE
[4.2] FileSystemRepresentation: Avoid leak and over early free.

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -817,10 +817,14 @@ open class FileManager : NSObject {
         let _fsRep: UnsafePointer<Int8>
         if fsRep == nil {
             _fsRep = fileSystemRepresentation(withPath: path)
-            defer { _fsRep.deallocate() }
         } else {
             _fsRep = fsRep!
         }
+
+        defer {
+            if fsRep == nil { _fsRep.deallocate() }
+        }
+
         var statInfo = stat()
         guard lstat(_fsRep, &statInfo) == 0 else {
             throw _NSErrorWithErrno(errno, reading: true, path: path)

--- a/Foundation/URL.swift
+++ b/Foundation/URL.swift
@@ -668,7 +668,9 @@ public struct URL : ReferenceConvertible, Equatable {
     /// File system representation is a null-terminated C string with canonical UTF-8 encoding.
     /// - note: The pointer is not valid outside the context of the block.
     public func withUnsafeFileSystemRepresentation<ResultType>(_ block: (UnsafePointer<Int8>?) throws -> ResultType) rethrows -> ResultType {
-        return try block(_url.fileSystemRepresentation)
+        let fsRep = _url.fileSystemRepresentation
+        defer { fsRep.deallocate() }
+        return try block(fsRep)
     }
     
     // MARK: -


### PR DESCRIPTION
- Fix deallocating the fs representation in FileManager._lstatFile(withPath:)
  and URL.withUnsafeFileSystemRepresentation().

- This is a subset of the changes in #1540 just fixing 2 memory issues.

(cherry picked from commit 38b155b1e2fc4666a2d9f934d312ce1753929d7c)