### PR TITLE
build: silence linker warning (SR-9138)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
 elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
   set(deployment_target -DDEPLOYMENT_TARGET_WINDOWS)
   # FIXME(SR9138) Silence "locally defined symbol '…' imported in function '…'
-  set(WORKAROUND_SR9138 -Xlinker;-ignore:4217)
+  set(WORKAROUND_SR9138 -Xlinker;-ignore:4049;-Xlinker;-ignore:4217)
   set(WORKAROUND_SR9995 -Xlinker;-nodefaultlib:libcmt)
 endif()
 


### PR DESCRIPTION
We currently emit a symbol multiply when building a single module.
Ideally, we would ensure that they are marked for COMDAT and given
LinkOnceODR linkage to ensure that they are preserved.  This makes
errors in the link step more visible.