### PR TITLE
Parity: Bundle.allBundles/.allFrameworks

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -391,6 +391,7 @@ CF_EXPORT _Nullable CFErrorRef CFReadStreamCopyError(CFReadStreamRef _Null_unspe
 
 CF_EXPORT _Nullable CFErrorRef CFWriteStreamCopyError(CFWriteStreamRef _Null_unspecified stream);
 
+CF_CROSS_PLATFORM_EXPORT CFStringRef _Nullable _CFBundleCopyExecutablePath(CFBundleRef bundle);
 CF_CROSS_PLATFORM_EXPORT Boolean _CFBundleSupportsFHSBundles(void);
 
 // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

--- a/CoreFoundation/PlugIn.subproj/CFBundle.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle.c
@@ -952,11 +952,9 @@ CFURLRef _CFBundleCopyAppStoreReceiptURL(CFBundleRef bundle) {
     return _CFBundleCopyAppStoreReceiptURLInDirectory(bundle->_url, bundle->_version);
 }
 
-#ifdef CF_OPEN_SOURCE
 CF_CROSS_PLATFORM_EXPORT CFStringRef _CFBundleCopyExecutablePath(CFBundleRef bundle) {
     return _CFBundleCopyExecutableName(bundle, NULL, NULL);
 }
-#endif
 
 CF_PRIVATE CFStringRef _CFBundleCopyExecutableName(CFBundleRef bundle, CFURLRef url, CFDictionaryRef infoDict) {
     CFStringRef executableName = NULL;

--- a/CoreFoundation/PlugIn.subproj/CFBundle.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle.c
@@ -951,7 +951,13 @@ CF_PRIVATE CFURLRef _CFBundleCopyAppStoreReceiptURLInDirectory(CFURLRef bundleUR
 CFURLRef _CFBundleCopyAppStoreReceiptURL(CFBundleRef bundle) {
     return _CFBundleCopyAppStoreReceiptURLInDirectory(bundle->_url, bundle->_version);
 }
-        
+
+#ifdef CF_OPEN_SOURCE
+CF_CROSS_PLATFORM_EXPORT CFStringRef _CFBundleCopyExecutablePath(CFBundleRef bundle) {
+    return _CFBundleCopyExecutableName(bundle, NULL, NULL);
+}
+#endif
+
 CF_PRIVATE CFStringRef _CFBundleCopyExecutableName(CFBundleRef bundle, CFURLRef url, CFDictionaryRef infoDict) {
     CFStringRef executableName = NULL;
     

--- a/Foundation/Bundle.swift
+++ b/Foundation/Bundle.swift
@@ -23,7 +23,7 @@ open class Bundle: NSObject {
     }
     
     private class var allBundlesRegardlessOfType: [Bundle] {
-        // FIXME: This doesn't return bundles that weren't loaded using CFBundle or class Bundle. SR-XXXX.
+        // FIXME: This doesn't return bundles that weren't loaded using CFBundle or class Bundle. https://bugs.swift.org/browse/SR-10433
         guard let bundles = CFBundleGetAllBundles()?._swiftObject as? [CFBundle] else { return [] }
         return bundles.map(Bundle.init(cfBundle:))
     }

--- a/Foundation/Bundle.swift
+++ b/Foundation/Bundle.swift
@@ -22,10 +22,41 @@ open class Bundle: NSObject {
         }
     }
     
-    open class var allBundles: [Bundle] {
-        NSUnimplemented()
+    private class var allBundlesRegardlessOfType: [Bundle] {
+        // FIXME: This doesn't return bundles that weren't loaded using CFBundle or class Bundle. SR-XXXX.
+        guard let bundles = CFBundleGetAllBundles()?._swiftObject as? [CFBundle] else { return [] }
+        return bundles.map(Bundle.init(cfBundle:))
     }
 
+    private var isFramework: Bool {
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        return bundleURL.pathExtension == "framework"
+        #else
+        
+            #if os(Windows)
+            if let name = _CFBundleCopyExecutablePath(_bundle)?._nsObject {
+                return name.pathExtension.lowercased == "dll"
+            }
+            #else
+        
+            // We're assuming this is an OS like Linux or BSD that uses FHS-style library names (lib….so or lib….so.2.3.4)
+            if let name = _CFBundleCopyExecutablePath(_bundle)?._nsObject {
+                return name.hasPrefix("lib") && (name.pathExtension == "so" || name.range(of: ".so.").location != NSNotFound)
+            }
+        
+            #endif
+        
+        return false
+        #endif
+    }
+    
+    open class var allBundles: [Bundle] {
+        return allBundlesRegardlessOfType.filter { !$0.isFramework }
+    }
+    
+    open class var allFrameworks: [Bundle] {
+        return allBundlesRegardlessOfType.filter { $0.isFramework }
+    }
     
     internal init(cfBundle: CFBundle) {
         super.init()


### PR DESCRIPTION
Implement this as a function of `CFBundleGetAllBundles()`. Add `.allFrameworks`, which is API that was missed.

Fixes https://bugs.swift.org/browse/SR-10360