### PR TITLE
Bundle: add SPI for FHS style bundles for testing

### DIFF
--- a/Foundation/Bundle.swift
+++ b/Foundation/Bundle.swift
@@ -12,6 +12,14 @@ import CoreFoundation
 open class Bundle: NSObject {
     private var _bundle : CFBundle!
 
+    internal static var _supportsFHSStyle: Bool {
+    #if DEPLOYMENT_RUNTIME_OBJC
+      return false
+    #else
+      return _CFBundleSupportsFHSBundles()
+    #endif
+    }
+
     private static var _mainBundle : Bundle = {
         return Bundle(cfBundle: CFBundleGetMainBundle())
     }()

--- a/TestFoundation/TestBundle.swift
+++ b/TestFoundation/TestBundle.swift
@@ -43,18 +43,16 @@ class BundlePlayground {
         
         static var allApplicable: [Layout] {
             let layouts: [Layout] = [ .flat, .fhsInstalled, .fhsFreestanding ]
-            
-            #if DEPLOYMENT_RUNTIME_OBJC
-            let supportsFHS = false
-            #else
-            let supportsFHS = _CFBundleSupportsFHSBundles()
-            #endif
-            
-            if supportsFHS {
+
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+            if Bundle._supportsFHSStyle {
                 return layouts
             } else {
                 return layouts.filter { !$0.isFHS }
             }
+#else
+            return layouts.filter { !$0.isFHS }
+#endif
         }
         var isFHS: Bool {
             return self == .fhsInstalled || self == .fhsFreestanding


### PR DESCRIPTION
The FHS bundles are an extension for the CoreFoundation implementation
for Swift.  Expose the interface through Bundle interface so that we do
not need to use private CF interfaces in the tests.