### PR TITLE
Parity: TimeZone.local, TimeZone.timeZoneDataVersion

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -392,6 +392,7 @@ CF_EXPORT _Nullable CFErrorRef CFReadStreamCopyError(CFReadStreamRef _Null_unspe
 CF_EXPORT _Nullable CFErrorRef CFWriteStreamCopyError(CFWriteStreamRef _Null_unspecified stream);
 
 CF_CROSS_PLATFORM_EXPORT Boolean _CFBundleSupportsFHSBundles(void);
+CF_CROSS_PLATFORM_EXPORT CFStringRef __CFTimeZoneCopyDataVersionString(void);
 
 // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 // Version 0.8

--- a/CoreFoundation/NumberDate.subproj/CFTimeZone.c
+++ b/CoreFoundation/NumberDate.subproj/CFTimeZone.c
@@ -1537,4 +1537,8 @@ static CFDictionaryRef __CFTimeZoneCopyCompatibilityDictionary(void) {
     return dict;
 }
 
-
+CF_CROSS_PLATFORM_EXPORT CFStringRef __CFTimeZoneCopyDataVersionString(void) {
+    UErrorCode err = U_ZERO_ERROR;
+    const char *cstr = ucal_getTZDataVersion(&err);
+    return (U_SUCCESS(err)) ? CFStringCreateWithCString(kCFAllocatorSystemDefault, cstr, kCFStringEncodingUTF8) : CFRetain(CFSTR(""));
+}

--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -178,9 +178,6 @@ open class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
         }
         return Date(timeIntervalSinceReferenceDate: CFTimeZoneGetNextDaylightSavingTimeTransition(_cfObject, aDate.timeIntervalSinceReferenceDate))
     }
-}
-
-extension NSTimeZone {
 
     open class var system: TimeZone {
         return CFTimeZoneCopySystem()._swiftObject
@@ -199,7 +196,9 @@ extension NSTimeZone {
         }
     }
 
-    open class var local: TimeZone { NSUnimplemented() }
+    open class var local: TimeZone {
+        return TimeZone(adoptingReference: __NSLocalTimeZone.shared, autoupdating: true)
+    }
 
     open class var knownTimeZoneNames: [String] {
         guard let knownNames = CFTimeZoneCopyKnownNames() else { return [] }
@@ -212,12 +211,17 @@ extension NSTimeZone {
             return dictionary._nsObject._bridgeToSwift() as! [String : String]
         }
         set {
-            // CFTimeZoneSetAbbreviationDictionary(newValue._cfObject)
-            NSUnimplemented()
+            CFTimeZoneSetAbbreviationDictionary(newValue._cfObject)
         }
     }
 
-    open class var timeZoneDataVersion: String { NSUnimplemented() }
+    open class var timeZoneDataVersion: String {
+        #if os(Windows)
+            return "" // We do not source timezone data from ICU. The empty string is what Darwin would return if ICU isn't able to give a time zone data version.
+        #else
+            return __CFTimeZoneCopyDataVersionString()._swiftObject
+        #endif
+    }
 
     open var secondsFromGMT: Int {
         let currentDate = Date()
@@ -295,4 +299,54 @@ extension NSTimeZone {
 
 extension NSNotification.Name {
     public static let NSSystemTimeZoneDidChange = NSNotification.Name(rawValue: kCFTimeZoneSystemTimeZoneDidChangeNotification._swiftObject)
+}
+
+internal class __NSLocalTimeZone: NSTimeZone {
+    static var shared = __NSLocalTimeZone()
+    
+    private init() {
+        super.init(_name: "GMT+0000")
+    }
+    
+    public convenience required init?(coder aDecoder: NSCoder) {
+        // We do not encode details of the local time zone, merely the placeholder object.
+        self.init()
+    }
+    
+    override func encode(with aCoder: NSCoder) {
+        // We do not encode details of the local time zone, merely the placeholder object.
+    }
+    
+    private var system: NSTimeZone {
+        return NSTimeZone.system._nsObject
+    }
+    
+    override var name: String { return system.name }
+    override var data: Data { return system.data }
+    override func secondsFromGMT(for aDate: Date) -> Int {
+        return system.secondsFromGMT(for: aDate)
+    }
+    override func abbreviation(for aDate: Date) -> String? {
+        return system.abbreviation(for: aDate)
+    }
+    override func isDaylightSavingTime(for aDate: Date) -> Bool {
+        return system.isDaylightSavingTime(for: aDate)
+    }
+    override func daylightSavingTimeOffset(for aDate: Date) -> TimeInterval {
+        return system.daylightSavingTimeOffset(for: aDate)
+    
+    }
+    override func nextDaylightSavingTimeTransition(after aDate: Date) -> Date? {
+        return system.nextDaylightSavingTimeTransition(after: aDate)
+    }
+    override func localizedName(_ style: NSTimeZone.NameStyle, locale: Locale?) -> String? {
+        return system.localizedName(style, locale: locale)
+    }
+    override var description: String {
+        return "Local Time Zone (\(system.description))"
+    }
+    
+    override func copy(with zone: NSZone? = nil) -> Any {
+        return self
+    }
 }

--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -216,11 +216,7 @@ open class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
 
     open class var timeZoneDataVersion: String {
-        #if os(Windows)
-            return "" // We do not source timezone data from ICU. The empty string is what Darwin would return if ICU isn't able to give a time zone data version.
-        #else
-            return __CFTimeZoneCopyDataVersionString()._swiftObject
-        #endif
+        return __CFTimeZoneCopyDataVersionString()._swiftObject
     }
 
     open var secondsFromGMT: Int {

--- a/Foundation/TimeZone.swift
+++ b/Foundation/TimeZone.swift
@@ -49,8 +49,7 @@ public struct TimeZone : Hashable, Equatable, ReferenceConvertible {
     ///
     /// The autoupdating time zone only compares equal to itself.
     public static var autoupdatingCurrent : TimeZone {
-        // swift-corelibs-foundation does not yet support autoupdating, but we can return the current time zone (which will not change).
-        return TimeZone(adoptingReference: __NSTimeZoneAutoupdating(), autoupdating: true)
+        return NSTimeZone.local
     }
     
     // MARK: -
@@ -118,7 +117,7 @@ public struct TimeZone : Hashable, Equatable, ReferenceConvertible {
         }
     }
     
-    private init(adoptingReference reference: NSTimeZone, autoupdating: Bool) {
+    internal init(adoptingReference reference: NSTimeZone, autoupdating: Bool) {
         // this path is only used for types we do not need to copy (we are adopting the ref)
         _wrapped = reference
         _autoupdating = autoupdating


### PR DESCRIPTION
Add `__NSLocalTimeZone`; the name is chosen so as to be `NSCoding`-compatible with Darwin. Make sure `NSTimeZone.local` and `TimeZone.autoupdatingCurrent` return it.

Implement `.timeZoneDataVersion` the same way as it is in Darwin.

Re-enable the setter for `.abbreviationDictionary`. We'll fix its bugs rather than crashing.

Fixes https://bugs.swift.org/browse/SR-10348, https://bugs.swift.org/browse/SR-10349