### PR TITLE
test: use bridging rather than CoreFoundation

### DIFF
--- a/TestFoundation/TestTimeZone.swift
+++ b/TestFoundation/TestTimeZone.swift
@@ -198,13 +198,12 @@ class TestTimeZone: XCTestCase {
         // Ensure that the system time zone creates names the same way as creating them with an identifier.
         // If it isn't the same, bugs in DateFormat can result, but in this specific case, the bad length
         // is only visible to CoreFoundation APIs, and the Swift versions hide it, making it hard to detect.
-        let timeZone = CFTimeZoneCopySystem()
-        let timeZoneName = CFTimeZoneGetName(timeZone)
+        let timeZoneName = NSTimeZone.system.identifier as NSString
 
         let createdTimeZone = TimeZone(identifier: TimeZone.current.identifier)!
 
-        XCTAssertEqual(CFStringGetLength(timeZoneName), TimeZone.current.identifier.count)
-        XCTAssertEqual(CFStringGetLength(timeZoneName), createdTimeZone.identifier.count)
+        XCTAssertEqual(timeZoneName.length, TimeZone.current.identifier.count)
+        XCTAssertEqual(timeZoneName.length, createdTimeZone.identifier.count)
     }
     
     func test_autoupdatingTimeZone() {


### PR DESCRIPTION
Bridge the return CFString object to NSObject via the private
`_nsObject` and use the `length` property to get the length rather than
using the `CFStringGetLength` method in the tests.  This reduces the use
of CoreFoundation private interfaces in the tests, which is needed for
Windows.