### PR TITLE
appendingPathComponent(:isDirectory:) should account for isDirectory

### DIFF
--- a/Foundation/URL.swift
+++ b/Foundation/URL.swift
@@ -692,7 +692,8 @@ public struct URL : ReferenceConvertible, Equatable {
         } else {
             // Now we need to do something more expensive
             if var c = URLComponents(url: self, resolvingAgainstBaseURL: true) {
-                c.path = c.path._stringByAppendingPathComponent(pathComponent)
+                let path = c.path._stringByAppendingPathComponent(pathComponent)
+                c.path = isDirectory ? path + "/" : path
                 
                 if let result = c.url {
                     return result


### PR DESCRIPTION
Same as https://github.com/apple/swift/pull/23926.
<!-- What's in this pull request? -->
When `appendingPathComponent(:isDirectory:)` is falling back from an **NSURL**.appendingPathComponent() to an **NSString**.appendingPathComponent(), it's forgetting to take into account the `isDirectory` parameter.
