### PR TITLE
ignoring AppCode artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,11 @@
 .DS_Store
 
 # Xcode user artifacts
-xcuserdata
+xcuserdata/
 project.xcworkspace
+
+# AppCode artifacts
+.idea/
 
 # python generated files
 *.pyc


### PR DESCRIPTION
AppCode is a popular IDE from https://www.jetbrains.com/objc/ and it uses the `.idea` folder like many other JetBrains products.