### PR TITLE
NSOrderedSet: Implement more functionality

### DIFF
--- a/TestFoundation/TestNSOrderedSet.swift
+++ b/TestFoundation/TestNSOrderedSet.swift
@@ -247,6 +247,7 @@ class TestNSOrderedSet : XCTestCase {
         set.add("2")
         XCTAssertEqual(set[0] as? String, "1")
         XCTAssertEqual(set[1] as? String, "2")
+        XCTAssertEqual(set.count, 2)
     }
 
     func test_AddObjects() {


### PR DESCRIPTION
- Add copy() and mutableCopy().

- Add .set and .array to return immumtable views of the current
  contents.

- Implement index(of:inSortedRange:options:usingComparator cmp:)
  by calling NSArray()'s version on ._orderedStorage.

- Implement description(withLocale:), description(withLocale:indent:),
  .description and .customMirror.

- NSCoding still needs to be implemented.