### PR TITLE
Complete Freestanding Bundles support in all platforms

### DIFF
--- a/CoreFoundation/PlugIn.subproj/CFBundle_Internal.h
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Internal.h
@@ -30,20 +30,32 @@ CF_EXTERN_C_BEGIN
 #define PLATFORM_PATH_STYLE kCFURLPOSIXPathStyle
 #endif
 
-// FHS bundles are supported on the Swift and C runtimes, except on Windows.
-#if !DEPLOYMENT_RUNTIME_OBJC && !TARGET_OS_WIN32
+// Freestanding bundles are not supported with the Objective-C Runtime.
+// !DEPLOYMENT_RUNTIME_OBJC /* FREESTANDING_BUNDLES */
+
+// FHS bundles are not supported with the Objective-C Runtime nor on Windows or Android.
+// !(DEPLOYMENT_RUNTIME_OBJC || TARGET_OS_WINDOWS || TARGET_OS_ANDROID) /* FHS_BUNDLES */
+
+#if !DEPLOYMENT_RUNTIME_OBJC /* FREESTANDING_BUNDLES || FHS_BUNDLES */
 
 #if TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_ANDROID
-#define _CFBundleFHSSharedLibraryFilenamePrefix CFSTR("lib")
-#define _CFBundleFHSSharedLibraryFilenameSuffix CFSTR(".so")
-#elif TARGET_OS_MAC
-#define _CFBundleFHSSharedLibraryFilenamePrefix CFSTR("lib")
-#define _CFBundleFHSSharedLibraryFilenameSuffix CFSTR(".dylib")
+#define _CFBundleSharedLibraryFilenamePrefix CFSTR("lib")
+#define _CFBundleSharedLibraryFilenameSuffix CFSTR(".so")
+#elif TARGET_OS_DARWIN
+#define _CFBundleSharedLibraryFilenamePrefix CFSTR("lib")
+#define _CFBundleSharedLibraryFilenameSuffix CFSTR(".dylib")
+#elif TARGET_OS_WINDOWS
+#define _CFBundleSharedLibraryFilenamePrefix CFSTR("")
+#define _CFBundleSharedLibraryFilenameSuffix CFSTR(".dll")
+#define _CFBundleExecutableFilenamePrefix CFSTR("")
+#define _CFBundleExecutableFilenameSuffix CFSTR(".exe")
+#define _CFBundleFilenameDebugPrefix CFSTR("")
+#define _CFBundleFilenameDebugSuffix CFSTR("_debug")
 #else // a non-covered DEPLOYMENT_TARGET…
-#error Disable FHS bundles or specify shared library prefixes and suffixes for this platform.
-#endif // DEPLOYMENT_TARGET_…
+#error Disable Freestanding and FHS bundles or specify shared library / executable prefixes and suffixes for this platform.
+#endif
 
-#endif // !DEPLOYMENT_RUNTIME_OBJC && !TARGET_OS_WIN32
+#endif /* FREESTANDING_BUNDLES || FHS_BUNDLES */
 
 #define CFBundleExecutableNotFoundError             4
 #define CFBundleExecutableNotLoadableError          3584
@@ -80,9 +92,9 @@ struct __CFBundle {
     
     CFURLRef _url;
     
-#if !DEPLOYMENT_RUNTIME_OBJC && !TARGET_OS_WIN32 && !TARGET_OS_ANDROID
+#if !(DEPLOYMENT_RUNTIME_OBJC || TARGET_OS_WINDOWS || TARGET_OS_ANDROID) /* FHS_BUNDLES */
     Boolean _isFHSInstalledBundle;
-#endif
+#endif /* FHS_BUNDLES */
     
     CFDictionaryRef _infoDict;
     CFDictionaryRef _localInfoDict;

--- a/TestFoundation/TestBundle.swift
+++ b/TestFoundation/TestBundle.swift
@@ -242,7 +242,7 @@ class BundlePlayground {
                 // Create a FHS /usr/local-style hierarchy:
                 try FileManager.default.createDirectory(atPath: temporaryDirectory.path, withIntermediateDirectories: false, attributes: nil)
                 try FileManager.default.createDirectory(atPath: temporaryDirectory.appendingPathComponent("share").path, withIntermediateDirectories: false, attributes: nil)
-                try FileManager.default.createDirectory(atPath: temporaryDirectory.appendingPathComponent("lib").path, withIntermediateDirectories: false, attributes: nil)
+                try FileManager.default.createDirectory(atPath: temporaryDirectory.appendingPathComponent(executableType.fhsPrefix).path, withIntermediateDirectories: false, attributes: nil)
                 
                 // Make a main and an auxiliary executable:
                 self.mainExecutableURL = temporaryDirectory
@@ -462,6 +462,9 @@ class TestBundle : XCTestCase {
                 try execute(playground)
                 playground.destroy()
             }
+            else {
+                XCTFail("Error creating playground bundle for layout '\(layout)'.")
+            }
         }
     }
     
@@ -541,14 +544,7 @@ class TestBundle : XCTestCase {
     }
     
     func test_bundleReverseBundleLookup() {
-        _withEachPlaygroundLayout { (playground) in
-            #if !os(Windows)
-            if playground.layout.isFreestanding {
-                // TODO: Freestanding bundles reverse lookup pending to be implemented on non-Windows platforms.
-                return
-            }
-            #endif
-            
+        _withEachPlaygroundLayout { (playground) in            
             if playground.layout.isFHS {
                 // TODO: FHS bundles reverse lookup pending to be implemented on all platforms.
                 return


### PR DESCRIPTION
- Adds support for finding the bundle path for implicitly loaded bundles (for which we only know the executable path).
- Unifies Windows and other platforms implementation.
- Enables Freestanding Bundles tests.

(This simplifies and minimizes the changes proposed at #1570)
