### PR TITLE
Parity: URLSessionTask.countOfBytes…

### DIFF
--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -25,8 +25,8 @@ import Dispatch
 /// of processing a given request.
 open class URLSessionTask : NSObject, NSCopying {
     
-    public var countOfBytesClientExpectsToReceive: Int64 { NSUnimplemented() }
-    public var countOfBytesClientExpectsToSend: Int64 { NSUnimplemented() }
+    public var countOfBytesClientExpectsToReceive: Int64 = NSURLSessionTransferSizeUnknown
+    public var countOfBytesClientExpectsToSend: Int64 = NSURLSessionTransferSizeUnknown
     public var earliestBeginDate: Date? { NSUnimplemented() }
     
     /// How many times the task has been suspended, 0 indicating a running task.


### PR DESCRIPTION
Since these are advisory properties used to aid in scheduling, letting code set them has no ill effect even if they currently do not change behavior in swift-corelibs-foundation.

Fixes https://bugs.swift.org/browse/SR-10381.