### PR TITLE
Parity: NSKeyedArchiver: Consider response to setting an output format other than .xml or .binary

### DIFF
--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -99,9 +99,8 @@ open class NSKeyedArchiver : NSCoder {
     /// The available formats are `xml` and `binary`.
     open var outputFormat = PropertyListSerialization.PropertyListFormat.binary {
         willSet {
-            if outputFormat != .xml &&
-                outputFormat != .binary {
-                NSUnimplemented()
+            guard (newValue == .xml || newValue == .binary) else {
+                fatalError("Unsupported format: \(newValue)")
             }
         }
     }


### PR DESCRIPTION
`NSUnimplemented()` is a marker for yet-to-be-implemented functionality. We do not support `.openStep` as a format at all; move this to `fatalError()` instead, since setting `.openStep` is a programmer error on Darwin.

https://bugs.swift.org/browse/SR-10416