### PR TITLE
Parity: NSKeyedArchiver: Secure initializers

### DIFF
--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -33,6 +33,7 @@ public let NSLocalizedRecoverySuggestionErrorKey: String = "NSLocalizedRecoveryS
 public let NSLocalizedRecoveryOptionsErrorKey: String = "NSLocalizedRecoveryOptions"
 public let NSRecoveryAttempterErrorKey: String = "NSRecoveryAttempter"
 public let NSHelpAnchorErrorKey: String = "NSHelpAnchor"
+public let NSDebugDescriptionErrorKey = "NSDebugDescription"
 
 // Other standard keys in userInfo, for various error codes
 public let NSStringEncodingErrorKey: String = "NSStringEncodingErrorKey"

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -105,6 +105,16 @@ open class NSKeyedArchiver : NSCoder {
         }
     }
     
+    open class func archivedData(withRootObject object: Any, requiringSecureCoding: Bool) throws -> Data {
+        let archiver = NSKeyedArchiver(requiringSecureCoding: requiringSecureCoding)
+        archiver.encode(object, forKey: NSKeyedArchiveRootObjectKey)
+        if let error = archiver.error {
+            throw error
+        } else {
+            return archiver.encodedData
+        }
+    }
+    
     /// Returns an `NSData` object containing the encoded form of the object graph
     /// whose root object is given.
     ///
@@ -112,6 +122,7 @@ open class NSKeyedArchiver : NSCoder {
     /// - Returns:              An `NSData` object containing the encoded form of the object graph
     ///                         whose root object is rootObject. The format of the archive is
     ///                         `NSPropertyListBinaryFormat_v1_0`.
+    @available(swift, deprecated: 9999, renamed: "archivedData(withRootObject:requiringSecureCoding:)")
     open class func archivedData(withRootObject rootObject: Any) -> Data {
         let data = NSMutableData()
         let keyedArchiver = NSKeyedArchiver(forWritingWith: data)
@@ -130,6 +141,7 @@ open class NSKeyedArchiver : NSCoder {
     ///   - rootObject: The root of the object graph to archive.
     ///   - path:       The path of the file in which to write the archive.
     /// - Returns:      `true` if the operation was successful, otherwise `false`.
+    @available(swift, deprecated: 9999, renamed: "archivedData(withRootObject:requiringSecureCoding:)")
     open class func archiveRootObject(_ rootObject: Any, toFile path: String) -> Bool {
         var fd : Int32 = -1
         var auxFilePath : String
@@ -166,8 +178,14 @@ open class NSKeyedArchiver : NSCoder {
         return finishedEncoding
     }
     
+    public convenience init(requiringSecureCoding: Bool) {
+        self.init(output: NSMutableData())
+        self.requiresSecureCoding = requiringSecureCoding
+    }
+    
+    @available(swift, deprecated: 9999, renamed: "init(requiringSecureCoding:)")
     public override convenience init() {
-        self.init(forWritingWith: NSMutableData())
+        self.init(output: NSMutableData())
     }
     
     private init(output: AnyObject) {
@@ -181,6 +199,7 @@ open class NSKeyedArchiver : NSCoder {
     /// is filled. The format of the archive is `NSPropertyListBinaryFormat_v1_0`.
     ///
     /// - Parameter data: The mutable-data object into which the archive is written.
+    @available(swift, deprecated: 9999, renamed: "init(requiringSecureCoding:)")
     public convenience init(forWritingWith data: NSMutableData) {
         self.init(output: data)
     }

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -57,10 +57,24 @@ open class NSKeyedUnarchiver : NSCoder {
         return _error
     }
     
+    static func unarchivedObject<DecodedObjectType>(ofClass cls: DecodedObjectType.Type, from data: Data) throws -> DecodedObjectType? where DecodedObjectType : NSObject, DecodedObjectType : NSCoding {
+        return try unarchivedObject(ofClasses: [cls], from: data) as? DecodedObjectType
+    }
+    
+    static func unarchivedObject(ofClasses classes: [AnyClass], from data: Data) throws -> Any? {
+        let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+        unarchiver.requiresSecureCoding = true
+        unarchiver.decodingFailurePolicy = .setErrorAndReturn
+        
+        return try unarchiver.decodeTopLevelObject(of: classes, forKey: NSKeyedArchiveRootObjectKey)
+    }
+    
+    @available(swift, deprecated: 9999, renamed: "unarchivedObject(ofClass:from:)")
     open class func unarchiveObject(with data: Data) -> Any? {
         return try? unarchiveTopLevelObjectWithData(data)
     }
     
+    @available(swift, deprecated: 9999, renamed: "unarchivedObject(ofClass:from:)")
     open class func unarchiveObject(withFile path: String) -> Any? {
         let url = URL(fileURLWithPath: path)
         let readStream = CFReadStreamCreateWithFile(kCFAllocatorSystemDefault, url._cfObject)!
@@ -82,6 +96,13 @@ open class NSKeyedUnarchiver : NSCoder {
         return root
     }
     
+    public init(forReadingFrom data: Data) throws {
+        self._stream = .data(data)
+        super.init()
+        try _readPropertyList()
+    }
+    
+    @available(swift, deprecated: 9999, renamed: "init(forReadingFrom:)")
     public convenience init(forReadingWith data: Data) {
         self.init(stream: Stream.data(data))
     }

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -57,11 +57,11 @@ open class NSKeyedUnarchiver : NSCoder {
         return _error
     }
     
-    static func unarchivedObject<DecodedObjectType>(ofClass cls: DecodedObjectType.Type, from data: Data) throws -> DecodedObjectType? where DecodedObjectType : NSObject, DecodedObjectType : NSCoding {
+    static public func unarchivedObject<DecodedObjectType>(ofClass cls: DecodedObjectType.Type, from data: Data) throws -> DecodedObjectType? where DecodedObjectType : NSObject, DecodedObjectType : NSCoding {
         return try unarchivedObject(ofClasses: [cls], from: data) as? DecodedObjectType
     }
     
-    static func unarchivedObject(ofClasses classes: [AnyClass], from data: Data) throws -> Any? {
+    static public func unarchivedObject(ofClasses classes: [AnyClass], from data: Data) throws -> Any? {
         let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
         unarchiver.requiresSecureCoding = true
         unarchiver.decodingFailurePolicy = .setErrorAndReturn
@@ -866,12 +866,8 @@ open class NSKeyedUnarchiver : NSCoder {
     }
     
     open override var decodingFailurePolicy: NSCoder.DecodingFailurePolicy {
-        get {
-            return .setErrorAndReturn
-        }
-        set {
-            NSUnimplemented();
-        }
+        get { return .setErrorAndReturn }
+        set {}
     }
 
     open class func unarchiveTopLevelObjectWithData(_ data: Data) throws -> Any? {

--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -125,6 +125,15 @@ class TestNSKeyedArchiver : XCTestCase {
         
         let unarchiver1 = NSKeyedUnarchiver(forReadingWith: archivedData)
         XCTAssertTrue(decode(unarchiver1))
+        
+        // Archiving using the secure initializer
+        let archiver2 = NSKeyedArchiver(requiringSecureCoding: true)
+        
+        XCTAssertTrue(encode(archiver2))
+        let archivedData2 = archiver2.encodedData
+        
+        let unarchiver2 = NSKeyedUnarchiver(forReadingWith: archivedData2)
+        XCTAssertTrue(decode(unarchiver2))
     }
 
     private func test_archive(_ object: Any, classes: [AnyClass], allowsSecureCoding: Bool = true, outputFormat: PropertyListSerialization.PropertyListFormat) {

--- a/TestFoundation/TestNSKeyedUnarchiver.swift
+++ b/TestFoundation/TestNSKeyedUnarchiver.swift
@@ -23,27 +23,61 @@ class TestNSKeyedUnarchiver : XCTestCase {
         ]
     }
     
-    private func test_unarchive_from_file(_ filename : String, _ expectedObject : NSObject) {
+    private enum SecureTest {
+        case skip
+        case performWithDefaultClass
+        case performWithClasses([AnyClass])
+    }
+    
+    private func test_unarchive_from_file(_ filename : String, _ expectedObject : NSObject, _ secureTest: SecureTest = .skip) throws {
         guard let testFilePath = testBundle().path(forResource: filename, ofType: "plist") else {
             XCTFail("Could not find \(filename)")
             return
         }
-        let object = NSKeyedUnarchiver.unarchiveObject(withFile: testFilePath) as? NSObject
-        if let obj = object {
-            if expectedObject != obj {
-                print("\(expectedObject) != \(obj)")
+        do {
+            // Use the path method:
+            let object = NSKeyedUnarchiver.unarchiveObject(withFile: testFilePath) as? NSObject
+            if let obj = object {
+                if expectedObject != obj {
+                    print("\(expectedObject) != \(obj)")
+                }
             }
+            
+            XCTAssertEqual(expectedObject, object)
         }
         
-        XCTAssertEqual(expectedObject, object)
+        let classes: [AnyClass]
+        
+        switch secureTest {
+        case .skip:
+            classes = []
+        case .performWithDefaultClass:
+            classes = [ type(of: expectedObject as AnyObject) ]
+        case .performWithClasses(let specifiedClasses):
+            classes = specifiedClasses
+        }
+
+        if !classes.isEmpty {
+            // Use the secure method:
+            let data = try Data(contentsOf: URL(fileURLWithPath: testFilePath))
+            
+            let object = try NSKeyedUnarchiver.unarchivedObject(ofClasses: classes, from: data) as? NSObject
+            if let obj = object {
+                if expectedObject != obj {
+                    print("\(expectedObject) != \(obj)")
+                }
+            }
+            
+            XCTAssertEqual(expectedObject, object)
+        }
     }
 
-    func test_unarchive_array() {
+    func test_unarchive_array() throws {
         let array = NSArray(array: ["baa", "baa", "black", "sheep"])
-        test_unarchive_from_file("NSKeyedUnarchiver-ArrayTest", array)
+        try test_unarchive_from_file("NSKeyedUnarchiver-ArrayTest", array)
     }
     
-    func test_unarchive_complex() {
+    func test_unarchive_complex() throws {
         let uuid = NSUUID(uuidString: "71DC068E-3420-45FF-919E-3A267D55EC22")!
         let url = URL(string: "index.xml", relativeTo: URL(string: "https://www.swift.org"))!
         let array = NSArray(array: [ NSNull(), NSString(string: "hello"), NSNumber(value: 34545), NSDictionary(dictionary: ["key" : "val"])])
@@ -53,53 +87,53 @@ class TestNSKeyedUnarchiver : XCTestCase {
             "string" : "hello",
             "array" : array
         ]
-        test_unarchive_from_file("NSKeyedUnarchiver-ComplexTest", NSDictionary(dictionary: dict))
+        try test_unarchive_from_file("NSKeyedUnarchiver-ComplexTest", NSDictionary(dictionary: dict), .performWithClasses([NSDictionary.self, NSArray.self, NSURL.self, NSUUID.self, NSNull.self]))
     }
     
-    func test_unarchive_concrete_value() {
+    func test_unarchive_concrete_value() throws {
         let array: Array<Int32> = [1, 2, 3]
         let objctype = "[3i]"
-        array.withUnsafeBufferPointer { cArray in
+        try array.withUnsafeBufferPointer { cArray in
             let concrete = NSValue(bytes: cArray.baseAddress!, objCType: objctype)
-            test_unarchive_from_file("NSKeyedUnarchiver-ConcreteValueTest", concrete)
+            try test_unarchive_from_file("NSKeyedUnarchiver-ConcreteValueTest", concrete, .skip)
         }
     }
 
-//    func test_unarchive_notification() {
+//    func test_unarchive_notification() throws {
 //        let notification = Notification(name: Notification.Name(rawValue:"notification-name"), object: "notification-object".bridge(),
 //                                          userInfo: ["notification-key": "notification-val"])
-//        test_unarchive_from_file("NSKeyedUnarchiver-NotificationTest", notification)
+//        try test_unarchive_from_file("NSKeyedUnarchiver-NotificationTest", notification)
 //    }
     
-    func test_unarchive_nsedgeinsets_value() {
+    func test_unarchive_nsedgeinsets_value() throws {
         let edgeinsets = NSEdgeInsets(top: CGFloat(1.0), left: CGFloat(2.0), bottom: CGFloat(3.0), right: CGFloat(4.0))
-        test_unarchive_from_file("NSKeyedUnarchiver-EdgeInsetsTest", NSValue(edgeInsets: edgeinsets))
+        try test_unarchive_from_file("NSKeyedUnarchiver-EdgeInsetsTest", NSValue(edgeInsets: edgeinsets))
     }
     
-    func test_unarchive_nsrange_value() {
+    func test_unarchive_nsrange_value() throws {
         let range = NSRange(location: 97345, length: 98345)
-        test_unarchive_from_file("NSKeyedUnarchiver-RangeTest", NSValue(range: range))
+        try test_unarchive_from_file("NSKeyedUnarchiver-RangeTest", NSValue(range: range))
     }
     
-    func test_unarchive_nsrect_value() {
+    func test_unarchive_nsrect_value() throws {
         let origin = NSPoint(x: CGFloat(400.0), y: CGFloat(300.0))
         let size = NSSize(width: CGFloat(200.0), height: CGFloat(300.0))
         let rect = NSRect(origin: origin, size: size)
-        test_unarchive_from_file("NSKeyedUnarchiver-RectTest", NSValue(rect: rect))
+        try test_unarchive_from_file("NSKeyedUnarchiver-RectTest", NSValue(rect: rect))
     }
     
-    func test_unarchive_ordered_set() {
+    func test_unarchive_ordered_set() throws {
         let set = NSOrderedSet(array: ["valgeir", "nico", "puzzle"])
-        test_unarchive_from_file("NSKeyedUnarchiver-OrderedSetTest", set)
+        try test_unarchive_from_file("NSKeyedUnarchiver-OrderedSetTest", set)
     }
     
-    func test_unarchive_url() {
+    func test_unarchive_url() throws {
         let url = NSURL(string: "foo.xml", relativeTo: URL(string: "https://www.example.com"))
-        test_unarchive_from_file("NSKeyedUnarchiver-URLTest", url!)
+        try test_unarchive_from_file("NSKeyedUnarchiver-URLTest", url!)
     }
     
-    func test_unarchive_uuid() {
+    func test_unarchive_uuid() throws {
         let uuid = NSUUID(uuidString: "0AD863BA-7584-40CF-8896-BD87B3280C34")
-        test_unarchive_from_file("NSKeyedUnarchiver-UUIDTest", uuid!)
+        try test_unarchive_from_file("NSKeyedUnarchiver-UUIDTest", uuid!)
     }
 }


### PR DESCRIPTION
- Added missing API: `NSDebugDescriptionErrorKey`
- Added secure initializers and one-shot factory methods to `NSKeyed{A,Una}rchiver`
- Deprecated existing initializers and factory methods