### PR TITLE
[android] Provide correct temporary directory path.

### DIFF
--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -57,7 +57,13 @@ public func NSTemporaryDirectory() -> String {
             return tmpdir
         }
     }
+#if os(Android)
+    // Bionic uses /data/local/tmp/ as temporary directory. TMPDIR is rarely
+    // defined.
+    return "/data/local/tmp/"
+#else
     return "/tmp/"
+#endif
 #endif
 }
 


### PR DESCRIPTION
Android Bionic uses /data/local/tmp as the temporary writable directory.
TMPDIR is rarely set and /tmp doesn't exist.

There's some usage of /tmp/ in the tests that might be wrong and might
need to be fixed in the future, but I have to check one by one and right
now I don't have a device to test on.