### PR TITLE
Support Swift 4.2 Hashable

### DIFF
--- a/Foundation/Date.swift
+++ b/Foundation/Date.swift
@@ -137,9 +137,15 @@ public struct Date : ReferenceConvertible, Comparable, Equatable {
      */
     public static let distantPast = Date(timeIntervalSinceReferenceDate: -63114076800.0)
     
+    #if swift(>=4.2)
+    public func hash(into hasher: inout Hasher) {
+        _time.hash(into: &hasher)
+    }
+    #else
     public var hashValue: Int {
         return Int(bitPattern: __CFHashDouble(_time))
     }
+    #endif
     
     /// Compare two `Date` values.
     public func compare(_ other: Date) -> ComparisonResult {

--- a/Foundation/IndexPath.swift
+++ b/Foundation/IndexPath.swift
@@ -37,7 +37,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
     public typealias Index = Array<Int>.Index
     public typealias Indices = DefaultIndices<IndexPath>
     
-    fileprivate enum Storage : ExpressibleByArrayLiteral {
+    fileprivate enum Storage : ExpressibleByArrayLiteral, Equatable, Hashable {
         typealias Element = Int
         case empty
         case single(Int)
@@ -676,6 +676,11 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
         return .orderedSame
     }
     
+    #if swift(>=4.2)
+    public func hash(into hasher: inout Hasher) {
+        _indexes.hash(into: &hasher)
+    }
+    #else
     public var hashValue: Int {
         func hashIndexes(first: Int, last: Int, count: Int) -> Int {
             let totalBits = MemoryLayout<Int>.size * 8
@@ -694,6 +699,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                 return hashIndexes(first: _indexes[0], last: _indexes[cnt - 1], count: cnt)
         }
     }
+    #endif
     
     // MARK: - Bridging Helpers
     

--- a/Foundation/Measurement.swift
+++ b/Foundation/Measurement.swift
@@ -35,10 +35,17 @@ public struct Measurement<UnitType : Unit> : ReferenceConvertible, Comparable, E
         self.value = value
         self.unit = unit
     }
-
+    
+    #if swift(>=4.2)
+    public func hash(into hasher: inout Hasher) {
+        unit.hash(into: &hasher)
+        value.hash(into: &hasher)
+    }
+    #else
     public var hashValue: Int {
         return Int(bitPattern: __CFHashDouble(value))
     }
+    #endif
 }
 
 @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -532,9 +532,16 @@ public extension _BridgedStoredNSError {
 
 /// Implementation of Hashable for all _BridgedStoredNSErrors.
 public extension _BridgedStoredNSError {
+    
+    #if swift(>=4.2)
+    func hash(into hasher: inout Hasher) {
+        _nsError.hash(into: &hasher)
+    }
+    #else
     var hashValue: Int {
         return _nsError.hashValue
     }
+    #endif
 }
 
 /// Describes the code of an error.

--- a/Foundation/NSRange.swift
+++ b/Foundation/NSRange.swift
@@ -123,6 +123,13 @@ public func NSRangeFromString(_ aString: String) -> NSRange {
 #endif
 
 extension NSRange : Hashable {
+    
+    #if swift(>=4.2)
+    public func hash(into hasher: inout Hasher) {
+        location.hash(into: &hasher)
+        length.hash(into: &hasher)
+    }
+    #else
     public var hashValue: Int {
         #if arch(i386) || arch(arm)
             return Int(bitPattern: (UInt(bitPattern: location) | (UInt(bitPattern: length) << 16)))
@@ -130,8 +137,9 @@ extension NSRange : Hashable {
             return Int(bitPattern: (UInt(bitPattern: location) | (UInt(bitPattern: length) << 32)))
         #endif
     }
+    #endif
     
-    public static func==(_ lhs: NSRange, _ rhs: NSRange) -> Bool {
+    public static func == (_ lhs: NSRange, _ rhs: NSRange) -> Bool {
         return lhs.location == rhs.location && lhs.length == rhs.length
     }
 }


### PR DESCRIPTION
Updates implementation of `Hashable` in Foundation types to properly support Swift 4.2 and 5.