### PR TITLE
Disable toll-free bridging for CFRunLoopTimer

### DIFF
--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -173,8 +173,8 @@ internal func __CFInitializeSwift() {
     _CFRuntimeBridgeTypeToClass(CFAttributedStringGetTypeID(), unsafeBitCast(NSMutableAttributedString.self, to: UnsafeRawPointer.self))
 //    _CFRuntimeBridgeTypeToClass(CFReadStreamGetTypeID(), unsafeBitCast(InputStream.self, UnsafeRawPointer.self))
 //    _CFRuntimeBridgeTypeToClass(CFWriteStreamGetTypeID(), unsafeBitCast(OutputStream.self, UnsafeRawPointer.self))
-   _CFRuntimeBridgeTypeToClass(CFRunLoopTimerGetTypeID(), unsafeBitCast(Timer.self, to: UnsafeRawPointer.self))
-    
+   //_CFRuntimeBridgeTypeToClass(CFRunLoopTimerGetTypeID(), unsafeBitCast(Timer.self, to: UnsafeRawPointer.self))
+
     __CFSwiftBridge.NSObject.isEqual = _CFSwiftIsEqual
     __CFSwiftBridge.NSObject.hash = _CFSwiftGetHash
     __CFSwiftBridge.NSObject._cfTypeID = _CFSwiftGetTypeID

--- a/Foundation/Timer.swift
+++ b/Foundation/Timer.swift
@@ -16,9 +16,7 @@ internal func __NSFireTimer(_ timer: CFRunLoopTimer?, info: UnsafeMutableRawPoin
 }
 
 open class Timer : NSObject {
-    typealias CFType = CFRunLoopTimer
-    
-    internal var _cfObject: CFType {
+    internal var _cfObject: CFRunLoopTimer {
         get {
             return _timer!
         }


### PR DESCRIPTION
Foundation.Timer is not currently implemented with a compatible memory layout
so attempt to bridge these classes will fail. Disabling bridging allows
code using CFRunLoopTimer to work until Foundation.Timer is reimplemented.
Fixes https://bugs.swift.org/browse/SR-10465