### PR TITLE
Modernize hashing in Foundation's Swift-only types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,6 +390,7 @@ if(ENABLE_TESTING)
                          TestFoundation/TestCodable.swift
                          TestFoundation/TestDateComponents.swift
                          TestFoundation/TestDateFormatter.swift
+                         TestFoundation/TestDateInterval.swift
                          TestFoundation/TestDateIntervalFormatter.swift
                          TestFoundation/TestDate.swift
                          TestFoundation/TestDecimal.swift
@@ -407,6 +408,7 @@ if(ENABLE_TESTING)
                          TestFoundation/TestJSONSerialization.swift
                          TestFoundation/TestLengthFormatter.swift
                          TestFoundation/TestMassFormatter.swift
+                         TestFoundation/TestMeasurement.swift
                          TestFoundation/TestNotificationCenter.swift
                          TestFoundation/TestNotificationQueue.swift
                          TestFoundation/TestNotification.swift

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -354,6 +354,7 @@
 		7900433C1CACD33E00ECCBF1 /* TestNSPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900433A1CACD33E00ECCBF1 /* TestNSPredicate.swift */; };
 		7D0DE86E211883F500540061 /* TestDateComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0DE86C211883F500540061 /* TestDateComponents.swift */; };
 		7D0DE86F211883F500540061 /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0DE86D211883F500540061 /* Utilities.swift */; };
+		7D8BD739225ED1480057CF37 /* TestMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8BD738225ED1480057CF37 /* TestMeasurement.swift */; };
 		90E645DF1E4C89A400D0D47C /* TestNSCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E645DE1E4C89A400D0D47C /* TestNSCache.swift */; };
 		91B668A32252B3C5001487A1 /* FileManager+POSIX.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B668A22252B3C5001487A1 /* FileManager+POSIX.swift */; };
 		91B668A52252B3E7001487A1 /* FileManager+Win32.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B668A42252B3E7001487A1 /* FileManager+Win32.swift */; };
@@ -881,6 +882,7 @@
 		7A7D6FBA1C16439400957E2E /* TestURLResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestURLResponse.swift; sourceTree = "<group>"; };
 		7D0DE86C211883F500540061 /* TestDateComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDateComponents.swift; sourceTree = "<group>"; };
 		7D0DE86D211883F500540061 /* Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
+		7D8BD738225ED1480057CF37 /* TestMeasurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestMeasurement.swift; sourceTree = "<group>"; };
 		83712C8D1C1684900049AD49 /* TestNSURLRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSURLRequest.swift; sourceTree = "<group>"; };
 		844DC3321C17584F005611F9 /* TestScanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestScanner.swift; sourceTree = "<group>"; };
 		848A30571C137B3500C83206 /* TestHTTPCookie.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestHTTPCookie.swift; path = TestFoundation/TestHTTPCookie.swift; sourceTree = SOURCE_ROOT; };
@@ -1668,6 +1670,7 @@
 				5B6F17961C48631C00935030 /* TestUtils.swift */,
 				03B6F5831F15F339004F25AF /* TestURLProtocol.swift */,
 				3E55A2321F52463B00082000 /* TestUnit.swift */,
+				7D8BD738225ED1480057CF37 /* TestMeasurement.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -2678,6 +2681,7 @@
 				5B13B3511C582D4C00651CE2 /* TestByteCountFormatter.swift in Sources */,
 				BDFDF0A71DFF5B3E00C04CC5 /* TestPersonNameComponents.swift in Sources */,
 				5B13B3501C582D4C00651CE2 /* TestUtils.swift in Sources */,
+				7D8BD739225ED1480057CF37 /* TestMeasurement.swift in Sources */,
 				CD1C7F7D1E303B47008E331C /* TestNSError.swift in Sources */,
 				294E3C1D1CC5E19300E4F44C /* TestNSAttributedString.swift in Sources */,
 				5B13B3431C582D4C00651CE2 /* TestScanner.swift in Sources */,

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -355,6 +355,7 @@
 		7D0DE86E211883F500540061 /* TestDateComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0DE86C211883F500540061 /* TestDateComponents.swift */; };
 		7D0DE86F211883F500540061 /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0DE86D211883F500540061 /* Utilities.swift */; };
 		7D8BD739225ED1480057CF37 /* TestMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8BD738225ED1480057CF37 /* TestMeasurement.swift */; };
+		7D8BD737225EADB80057CF37 /* TestDateInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8BD736225EADB80057CF37 /* TestDateInterval.swift */; };
 		90E645DF1E4C89A400D0D47C /* TestNSCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E645DE1E4C89A400D0D47C /* TestNSCache.swift */; };
 		91B668A32252B3C5001487A1 /* FileManager+POSIX.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B668A22252B3C5001487A1 /* FileManager+POSIX.swift */; };
 		91B668A52252B3E7001487A1 /* FileManager+Win32.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B668A42252B3E7001487A1 /* FileManager+Win32.swift */; };
@@ -883,6 +884,7 @@
 		7D0DE86C211883F500540061 /* TestDateComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDateComponents.swift; sourceTree = "<group>"; };
 		7D0DE86D211883F500540061 /* Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
 		7D8BD738225ED1480057CF37 /* TestMeasurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestMeasurement.swift; sourceTree = "<group>"; };
+		7D8BD736225EADB80057CF37 /* TestDateInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDateInterval.swift; sourceTree = "<group>"; };
 		83712C8D1C1684900049AD49 /* TestNSURLRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSURLRequest.swift; sourceTree = "<group>"; };
 		844DC3321C17584F005611F9 /* TestScanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestScanner.swift; sourceTree = "<group>"; };
 		848A30571C137B3500C83206 /* TestHTTPCookie.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestHTTPCookie.swift; path = TestFoundation/TestHTTPCookie.swift; sourceTree = SOURCE_ROOT; };
@@ -1588,6 +1590,7 @@
 				7D0DE86D211883F500540061 /* Utilities.swift */,
 				155D3BBB22401D1100B0D38E /* FixtureValues.swift */,
 				7D0DE86C211883F500540061 /* TestDateComponents.swift */,
+				7D8BD736225EADB80057CF37 /* TestDateInterval.swift */,
 				6E203B8C1C1303BB003B2576 /* TestBundle.swift */,
 				A5A34B551C18C85D00FD972B /* TestByteCountFormatter.swift */,
 				2EBE67A31C77BF05006583D5 /* TestDateFormatter.swift */,
@@ -2664,6 +2667,7 @@
 				2EBE67A51C77BF0E006583D5 /* TestDateFormatter.swift in Sources */,
 				5B13B3291C582D4C00651CE2 /* TestCalendar.swift in Sources */,
 				158BCCAA2220A12600750239 /* TestDateIntervalFormatter.swift in Sources */,
+				7D8BD737225EADB80057CF37 /* TestDateInterval.swift in Sources */,
 				5B13B34F1C582D4C00651CE2 /* TestXMLParser.swift in Sources */,
 				BF85E9D81FBDCC2000A79793 /* TestHost.swift in Sources */,
 				D5C40F331CDA1D460005690C /* TestOperationQueue.swift in Sources */,

--- a/Foundation/AffineTransform.swift
+++ b/Foundation/AffineTransform.swift
@@ -253,9 +253,13 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
         return newSize
     }
 
-    /// The computed hash value for the transform.
-    public var hashValue : Int {
-        return Int((m11 + m12 + m21 + m22 + tX + tY).native)
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(m11)
+        hasher.combine(m12)
+        hasher.combine(m21)
+        hasher.combine(m22)
+        hasher.combine(tX)
+        hasher.combine(tY)
     }
 
     /// A textual description of the transform.

--- a/Foundation/Boxing.swift
+++ b/Foundation/Boxing.swift
@@ -75,7 +75,9 @@ internal protocol _SwiftNativeFoundationType : class {
     
     func mutableCopy(with zone : NSZone) -> Any
     
+    func hash(into hasher: inout Hasher)
     var hashValue: Int { get }
+
     var description: String { get }
     var debugDescription: String { get }
     
@@ -115,6 +117,10 @@ extension _SwiftNativeFoundationType {
         return _mapUnmanaged { ($0 as NSObject).mutableCopy() }
     }
     
+    func hash(into hasher: inout Hasher) {
+        _mapUnmanaged { hasher.combine($0) }
+    }
+
     var hashValue: Int {
         return _mapUnmanaged { return $0.hashValue }
     }

--- a/Foundation/CGFloat.swift
+++ b/Foundation/CGFloat.swift
@@ -466,6 +466,13 @@ extension CGFloat : CustomStringConvertible {
 }
 
 extension CGFloat : Hashable {
+    /// The hash value.
+    ///
+    /// **Axiom:** `x == y` implies `x.hashValue == y.hashValue`
+    ///
+    /// - Note: the hash value is not guaranteed to be stable across
+    ///   different invocations of the same program.  Do not persist the
+    ///   hash value across program runs.
     @_transparent
     public var hashValue: Int {
         return native.hashValue

--- a/Foundation/CGFloat.swift
+++ b/Foundation/CGFloat.swift
@@ -466,16 +466,19 @@ extension CGFloat : CustomStringConvertible {
 }
 
 extension CGFloat : Hashable {
-    /// The hash value.
-    ///
-    /// **Axiom:** `x == y` implies `x.hashValue == y.hashValue`
-    ///
-    /// - Note: the hash value is not guaranteed to be stable across
-    ///   different invocations of the same program.  Do not persist the
-    ///   hash value across program runs.
     @_transparent
     public var hashValue: Int {
         return native.hashValue
+    }
+
+    @_transparent
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(native)
+    }
+
+    @_transparent
+    public func _rawHashValue(seed: Int) -> Int {
+        return native._rawHashValue(seed: seed)
     }
 }
 

--- a/Foundation/Calendar.swift
+++ b/Foundation/Calendar.swift
@@ -862,8 +862,9 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     public func hash(into hasher: inout Hasher) {
         // We implement hash ourselves, because we need to make sure autoupdating calendars have the same hash
         if _autoupdating {
-            hasher.combine(1 as Int8)
+            hasher.combine(false)
         } else {
+            hasher.combine(true)
             hasher.combine(_handle.map { $0 })
         }
     }

--- a/Foundation/Date.swift
+++ b/Foundation/Date.swift
@@ -136,9 +136,9 @@ public struct Date : ReferenceConvertible, Comparable, Equatable {
      The distant past is in terms of centuries.
      */
     public static let distantPast = Date(timeIntervalSinceReferenceDate: -63114076800.0)
-    
-    public var hashValue: Int {
-        return Int(bitPattern: __CFHashDouble(_time))
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_time)
     }
     
     /// Compare two `Date` values.

--- a/Foundation/DateInterval.swift
+++ b/Foundation/DateInterval.swift
@@ -150,14 +150,9 @@ public struct DateInterval : ReferenceConvertible, Comparable, Hashable {
         return false
     }
     
-    public var hashValue: Int {
-        var buf: (UInt, UInt) = (UInt(start.timeIntervalSinceReferenceDate), UInt(end.timeIntervalSinceReferenceDate))
-        return withUnsafeMutablePointer(to: &buf) { bufferPtr in
-            let count = MemoryLayout<UInt>.size * 2
-            return bufferPtr.withMemoryRebound(to: UInt8.self, capacity: count) { bufferBytes in
-                return Int(bitPattern: CFHashBytes(bufferBytes, CFIndex(count)))
-            }
-        }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(start)
+        hasher.combine(duration)
     }
     
     public static func ==(lhs: DateInterval, rhs: DateInterval) -> Bool {

--- a/Foundation/Decimal.swift
+++ b/Foundation/Decimal.swift
@@ -286,8 +286,12 @@ extension Decimal : Hashable, Comparable {
         return Int64(bitPattern: uint64Value)
     }
 
-    public var hashValue: Int {
-        return Int(bitPattern: __CFHashDouble(doubleValue))
+    public func hash(into hasher: inout Hasher) {
+        // FIXME: This is a weak hash.  We should rather normalize self to a
+        // canonical member of the exact same equivalence relation that
+        // NSDecimalCompare implements, then simply feed all components to the
+        // hasher.
+        hasher.combine(doubleValue)
     }
 
     public static func ==(lhs: Decimal, rhs: Decimal) -> Bool {

--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -828,11 +828,11 @@ public struct FileAttributeKey : RawRepresentable, Equatable, Hashable {
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
-    
-    public var hashValue: Int {
-        return self.rawValue.hashValue
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
     }
-    
+
     public static func ==(_ lhs: FileAttributeKey, _ rhs: FileAttributeKey) -> Bool {
         return lhs.rawValue == rhs.rawValue
     }
@@ -873,8 +873,8 @@ public struct FileAttributeType : RawRepresentable, Equatable, Hashable {
         self.rawValue = rawValue
     }
 
-    public var hashValue: Int {
-        return self.rawValue.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
     }
 
     public static func ==(_ lhs: FileAttributeType, _ rhs: FileAttributeType) -> Bool {

--- a/Foundation/HTTPCookie.swift
+++ b/Foundation/HTTPCookie.swift
@@ -18,8 +18,8 @@ public struct HTTPCookiePropertyKey : RawRepresentable, Equatable, Hashable {
         self.rawValue = rawValue
     }
     
-    public var hashValue: Int {
-        return self.rawValue.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
     }
     
     public static func ==(_ lhs: HTTPCookiePropertyKey, _ rhs: HTTPCookiePropertyKey) -> Bool {

--- a/Foundation/IndexPath.swift
+++ b/Foundation/IndexPath.swift
@@ -675,23 +675,29 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
         }
         return .orderedSame
     }
-    
-    public var hashValue: Int {
-        func hashIndexes(first: Int, last: Int, count: Int) -> Int {
-            let totalBits = MemoryLayout<Int>.size * 8
-            let lengthBits = 8
-            let firstIndexBits = (totalBits - lengthBits) / 2
-            return count &+ (first << lengthBits) &+ (last << (lengthBits + firstIndexBits))
-        }
-        
+
+    public func hash(into hasher: inout Hasher) {
+        // Note: We compare all indices in ==, so for proper hashing, we must
+        // also feed them all to the hasher.
+        //
+        // To ensure we have unique hash encodings in nested hashing contexts,
+        // we combine the count of indices as well as the indices themselves.
+        // (This matches what Array does.)
         switch _indexes {
-            case .empty: return 0
-            case .single(let index): return index.hashValue
-            case .pair(let first, let second):
-                return hashIndexes(first: first, last: second, count: 2)
-            default:
-                let cnt = _indexes.count
-                return hashIndexes(first: _indexes[0], last: _indexes[cnt - 1], count: cnt)
+        case .empty:
+            hasher.combine(0)
+        case let .single(index):
+            hasher.combine(1)
+            hasher.combine(index)
+        case let .pair(first, second):
+            hasher.combine(2)
+            hasher.combine(first)
+            hasher.combine(second)
+        case let .array(indexes):
+            hasher.combine(indexes.count)
+            for index in indexes {
+                hasher.combine(index)
+            }
         }
     }
     

--- a/Foundation/Locale.swift
+++ b/Foundation/Locale.swift
@@ -423,8 +423,9 @@ public struct Locale : CustomStringConvertible, CustomDebugStringConvertible, Ha
     
     public func hash(into hasher: inout Hasher) {
         if _autoupdating {
-            hasher.combine(1 as Int8)
+            hasher.combine(false)
         } else {
+            hasher.combine(true)
             hasher.combine(_wrapped)
         }
     }

--- a/Foundation/Measurement.swift
+++ b/Foundation/Measurement.swift
@@ -36,8 +36,19 @@ public struct Measurement<UnitType : Unit> : ReferenceConvertible, Comparable, E
         self.unit = unit
     }
 
-    public var hashValue: Int {
-        return Int(bitPattern: __CFHashDouble(value))
+    public func hash(into hasher: inout Hasher) {
+        // Warning: The canonicalization performed here needs to be kept in
+        // perfect sync with the definition of == below. The floating point
+        // values that are compared there must match exactly with the values fed
+        // to the hasher here, or hashing would break.
+        if let dimension = unit as? Dimension {
+            // We don't need to feed the base unit to the hasher here; all
+            // dimensional measurements of the same type share the same unit.
+            hasher.combine(dimension.converter.baseUnitValue(fromValue: value))
+        } else {
+            hasher.combine(unit)
+            hasher.combine(value)
+        }
     }
 }
 
@@ -170,6 +181,10 @@ extension Measurement {
     /// If `lhs.unit == rhs.unit`, returns `lhs.value == rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
     /// - returns: `true` if the measurements are equal.
     public static func ==<LeftHandSideType, RightHandSideType>(_ lhs: Measurement<LeftHandSideType>, _ rhs: Measurement<RightHandSideType>) -> Bool {
+        // Warning: This defines an equivalence relation that needs to be kept
+        // in perfect sync with the hash(into:) definition above. The floating
+        // point values that are fed to the hasher there must match exactly with
+        // the values compared here, or hashing would break.
         if lhs.unit == rhs.unit {
             return lhs.value == rhs.value
         } else {

--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -21,8 +21,12 @@ extension NSAttributedString {
             self.rawValue = rawValue
         }
 
-        public var hashValue: Int {
-            return rawValue.hashValue
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(rawValue)
+        }
+
+        public static func ==(left: NSAttributedString.Key, right: NSAttributedString.Key) -> Bool {
+            return left.rawValue == right.rawValue
         }
     }
 }

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -65,9 +65,9 @@ extension NSCalendar {
         public init(rawValue: String) {
             self.rawValue = rawValue
         }
-        
-        public var hashValue: Int {
-            return rawValue.hashValue
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(rawValue)
         }
         
         public static let gregorian = NSCalendar.Identifier("gregorian")

--- a/Foundation/NSCharacterSet.swift
+++ b/Foundation/NSCharacterSet.swift
@@ -46,7 +46,7 @@ open class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSCoding {
     }
     
     open override var hash: Int {
-        return Int(bitPattern: CFHash(_cfObject))
+        return Int(bitPattern: _CFNonObjCHash(_cfObject))
     }
     
     open override func isEqual(_ value: Any?) -> Bool {

--- a/Foundation/NSDecimalNumber.swift
+++ b/Foundation/NSDecimalNumber.swift
@@ -18,9 +18,9 @@ public struct NSExceptionName : RawRepresentable, Equatable, Hashable {
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
-    
-    public var hashValue: Int {
-        return self.rawValue.hashValue
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
     }
     
     public static func ==(_ lhs: NSExceptionName, _ rhs: NSExceptionName) -> Bool {

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -455,6 +455,10 @@ extension __BridgedNSError where Self: RawRepresentable, Self.RawValue: FixedWid
     }
     
     public var hashValue: Int { return _code }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
+    }
 }
 
 /// Describes a raw representable type that is bridged to a particular
@@ -533,7 +537,11 @@ public extension _BridgedStoredNSError {
 /// Implementation of Hashable for all _BridgedStoredNSErrors.
 public extension _BridgedStoredNSError {
     var hashValue: Int {
-        return _nsError.hashValue
+        return _nsError.hash
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(_nsError)
     }
 }
 

--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -74,9 +74,10 @@ extension CGPoint: NSSpecialValueCoding {
             return false
         }
     }
-    
-    var hash: Int {
-        return self.x.hashValue &+ self.y.hashValue
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(x)
+        hasher.combine(y)
     }
     
      var description: String {
@@ -166,9 +167,10 @@ extension CGSize: NSSpecialValueCoding {
             return false
         }
     }
-    
-    var hash: Int {
-        return self.width.hashValue &+ self.height.hashValue
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(width)
+        hasher.combine(height)
     }
     
     var description: String {
@@ -488,11 +490,12 @@ extension CGRect: NSSpecialValueCoding {
             return false
         }
     }
-    
-    var hash: Int {
-        return self.origin.hash &+ self.size.hash
+
+    func hash(into hasher: inout Hasher) {
+        origin.hash(into: &hasher)
+        size.hash(into: &hasher)
     }
-    
+
     var description: String {
         return NSStringFromRect(self)
     }
@@ -588,9 +591,12 @@ extension NSEdgeInsets: NSSpecialValueCoding {
             return false
         }
     }
-    
-    var hash: Int {
-        return self.top.hashValue &+ self.left.hashValue &+ self.bottom.hashValue &+ self.right.hashValue
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(top)
+        hasher.combine(left)
+        hasher.combine(bottom)
+        hasher.combine(right)
     }
     
     var description: String {

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -176,9 +176,9 @@ extension NSLocale {
         public init(rawValue: String) {
             self.rawValue = rawValue
         }
-        
-        public var hashValue: Int {
-            return rawValue.hashValue
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(rawValue)
         }
         
         public static let identifier = NSLocale.Key(rawValue: "kCFLocaleIdentifierKey")

--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -13,9 +13,9 @@ open class NSNotification: NSObject, NSCopying, NSCoding {
         public init(rawValue: String) {
             self.rawValue = rawValue
         }
-        
-        public var hashValue: Int {
-            return self.rawValue.hashValue
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(rawValue)
         }
         
         public static func ==(lhs: Name, rhs: Name) -> Bool {

--- a/Foundation/NSRange.swift
+++ b/Foundation/NSRange.swift
@@ -123,12 +123,9 @@ public func NSRangeFromString(_ aString: String) -> NSRange {
 #endif
 
 extension NSRange : Hashable {
-    public var hashValue: Int {
-        #if arch(i386) || arch(arm)
-            return Int(bitPattern: (UInt(bitPattern: location) | (UInt(bitPattern: length) << 16)))
-        #elseif arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64le)
-            return Int(bitPattern: (UInt(bitPattern: location) | (UInt(bitPattern: length) << 32)))
-        #endif
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(location)
+        hasher.combine(length)
     }
     
     public static func==(_ lhs: NSRange, _ rhs: NSRange) -> Bool {
@@ -402,8 +399,6 @@ extension NSRange: NSSpecialValueCoding {
             return false
         }
     }
-    
-    var hash: Int { return hashValue }
 }
     
 extension NSValue {

--- a/Foundation/NSSpecialValue.swift
+++ b/Foundation/NSSpecialValue.swift
@@ -24,7 +24,7 @@ internal protocol NSSpecialValueCoding {
     //
     // So in order to implement equality and hash we have the hack below.
     func isEqual(_ value: Any) -> Bool
-    var hash: Int { get }
+    func hash(into hasher: inout Hasher)
     var description: String { get }
 }
 
@@ -145,6 +145,8 @@ internal class NSSpecialValue : NSValue {
     }
     
     override var hash: Int {
-        return _value.hash
+        var hasher = Hasher()
+        _value.hash(into: &hasher)
+        return hasher.finalize()
     }
 }

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -76,8 +76,8 @@ public struct URLResourceKey : RawRepresentable, Equatable, Hashable {
         self.rawValue = rawValue
     }
 
-    public var hashValue: Int {
-        return rawValue.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
     }
 
     public static func ==(lhs: URLResourceKey, rhs: URLResourceKey) -> Bool {
@@ -198,8 +198,8 @@ public struct URLFileResourceType : RawRepresentable, Equatable, Hashable {
         self.rawValue = rawValue
     }
 
-    public var hashValue: Int {
-        return rawValue.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
     }
 
     public static func ==(lhs: URLFileResourceType, rhs: URLFileResourceType) -> Bool {

--- a/Foundation/Notification.swift
+++ b/Foundation/Notification.swift
@@ -39,6 +39,10 @@ public struct Notification : ReferenceConvertible, Equatable, Hashable {
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(name)
+        // FIXME: We should feed the object to the hasher, but using
+        // the object identity would make the hash encoding unstable.
+
+        // FIXME: Darwin also hashes the keys in the userInfo dictionary.
     }
     
     public var description: String {
@@ -56,11 +60,13 @@ public struct Notification : ReferenceConvertible, Equatable, Hashable {
     public typealias Name = NSNotification.Name
     
     public static func ==(lhs: Notification, rhs: Notification) -> Bool {
+        // FIXME: Darwin also compares the userInfo dictionary.
         if lhs.name.rawValue != rhs.name.rawValue {
             return false
         }
         if let lhsObj = lhs.object {
             if let rhsObj = rhs.object {
+                // FIXME: This violates reflexivity if object isn't Hashable.
                 if __SwiftValue.store(lhsObj) !== __SwiftValue.store(rhsObj) {
                     return false
                 }

--- a/Foundation/Progress.swift
+++ b/Foundation/Progress.swift
@@ -399,7 +399,7 @@ open class Progress : NSObject {
         public let rawValue: String
         public init(_ rawValue: String) { self.rawValue = rawValue }
         public init(rawValue: String) { self.rawValue = rawValue }
-        public var hashValue: Int { return self.rawValue.hashValue }
+        public func hash(into hasher: inout Hasher) { hasher.combine(rawValue) }
         public static func ==(_ lhs: FileOperationKind, _ rhs: FileOperationKind) -> Bool { return lhs.rawValue == rhs.rawValue }
         
         /// Use for indicating the progress represents a download.
@@ -478,7 +478,7 @@ public struct ProgressKind : RawRepresentable, Equatable, Hashable {
     public let rawValue: String
     public init(_ rawValue: String) { self.rawValue = rawValue }
     public init(rawValue: String) { self.rawValue = rawValue }
-    public var hashValue: Int { return self.rawValue.hashValue }
+    public func hash(into hasher: inout Hasher) { hasher.combine(rawValue) }
     public static func ==(_ lhs: ProgressKind, _ rhs: ProgressKind) -> Bool { return lhs.rawValue == rhs.rawValue }
     
     /// Indicates that the progress being performed is related to files.
@@ -491,7 +491,7 @@ public struct ProgressUserInfoKey : RawRepresentable, Equatable, Hashable {
     public let rawValue: String
     public init(_ rawValue: String) { self.rawValue = rawValue }
     public init(rawValue: String) { self.rawValue = rawValue }
-    public var hashValue: Int { return self.rawValue.hashValue }
+    public func hash(into hasher: inout Hasher) { hasher.combine(rawValue) }
     public static func ==(_ lhs: ProgressUserInfoKey, _ rhs: ProgressUserInfoKey) -> Bool { return lhs.rawValue == rhs.rawValue }
     
     /// How much time is probably left in the operation, as an NSNumber containing a number of seconds.

--- a/Foundation/Stream.swift
+++ b/Foundation/Stream.swift
@@ -28,11 +28,11 @@ extension Stream {
         public init(rawValue: String) {
             self.rawValue = rawValue
         }
-        
-        public var hashValue: Int {
-            return rawValue.hashValue
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(rawValue)
         }
-        
+
         public static func ==(lhs: Stream.PropertyKey, rhs: Stream.PropertyKey) -> Bool {
             return lhs.rawValue == rhs.rawValue
         }
@@ -303,8 +303,8 @@ public struct StreamSocketSecurityLevel : RawRepresentable, Equatable, Hashable 
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
-    public var hashValue: Int {
-        return rawValue.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
     }
     public static func ==(lhs: StreamSocketSecurityLevel, rhs: StreamSocketSecurityLevel) -> Bool {
         return lhs.rawValue == rhs.rawValue
@@ -325,8 +325,8 @@ public struct StreamSOCKSProxyConfiguration : RawRepresentable, Equatable, Hasha
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
-    public var hashValue: Int {
-        return rawValue.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
     }
     public static func ==(lhs: StreamSOCKSProxyConfiguration, rhs: StreamSOCKSProxyConfiguration) -> Bool {
         return lhs.rawValue == rhs.rawValue
@@ -347,8 +347,8 @@ public struct StreamSOCKSProxyVersion : RawRepresentable, Equatable, Hashable {
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
-    public var hashValue: Int {
-        return rawValue.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
     }
     public static func ==(lhs: StreamSOCKSProxyVersion, rhs: StreamSOCKSProxyVersion) -> Bool {
         return lhs.rawValue == rhs.rawValue
@@ -366,8 +366,8 @@ public struct StreamNetworkServiceTypeValue : RawRepresentable, Equatable, Hasha
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
-    public var hashValue: Int {
-        return rawValue.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
     }
     public static func ==(lhs: StreamNetworkServiceTypeValue, rhs: StreamNetworkServiceTypeValue) -> Bool {
         return lhs.rawValue == rhs.rawValue

--- a/Foundation/StringEncodings.swift
+++ b/Foundation/StringEncodings.swift
@@ -68,8 +68,8 @@ extension String {
 }
 
 extension String.Encoding : Hashable {
-    public var hashValue : Int {
-        return rawValue.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
     }
 
     public static func ==(lhs: String.Encoding, rhs: String.Encoding) -> Bool {

--- a/Foundation/TimeZone.swift
+++ b/Foundation/TimeZone.swift
@@ -211,8 +211,9 @@ public struct TimeZone : Hashable, Equatable, ReferenceConvertible {
     
     public func hash(into hasher: inout Hasher) {
         if _autoupdating {
-            hasher.combine(1 as Int8)
+            hasher.combine(false)
         } else {
+            hasher.combine(true)
             hasher.combine(_wrapped)
         }
     }

--- a/Foundation/UUID.swift
+++ b/Foundation/UUID.swift
@@ -73,12 +73,10 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
             }
         }
     }
-    
-    public var hashValue: Int {
-        return withUnsafePointer(to: uuid) {
-            $0.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<uuid_t>.size) {
-                return Int(bitPattern: CFHashBytes(UnsafeMutablePointer(mutating: $0), CFIndex(MemoryLayout<uuid_t>.size)))
-            }
+
+    public func hash(into hasher: inout Hasher) {
+        withUnsafeBytes(of: uuid) { buffer in
+            hasher.combine(bytes: buffer)
         }
     }
     

--- a/TestFoundation/TestAffineTransform.swift
+++ b/TestFoundation/TestAffineTransform.swift
@@ -27,8 +27,7 @@ class TestAffineTransform : XCTestCase {
             ("test_AppendTransform", test_AppendTransform),
             ("test_PrependTransform", test_PrependTransform),
             ("test_TransformComposition", test_TransformComposition),
-            ("test_hashing_identity", test_hashing_identity),
-            ("test_hashing_values", test_hashing_values),
+            ("test_hashing", test_hashing),
             ("test_rotation_compose", test_rotation_compose),
             ("test_translation_and_rotation", test_translation_and_rotation),
             ("test_Equal", test_Equal),
@@ -317,26 +316,37 @@ class TestAffineTransform : XCTestCase {
         checkPointTransformation(rotateAboutCenter, point: center, expectedPoint: center)
     }
 
-    func test_hashing_identity() {
-        let ref = NSAffineTransform()
-        let val = AffineTransform.identity
-        XCTAssertEqual(ref.hashValue, val.hashValue)
-    }
+    func test_hashing() {
+        let a = AffineTransform(m11: 1.0, m12: 2.5, m21: 66.2, m22: 40.2, tX: -5.5, tY: 3.7)
+        let b = AffineTransform(m11: -55.66, m12: 22.7, m21: 1.5, m22: 0.0, tX: -22, tY: -33)
+        let c = AffineTransform(m11: 4.5, m12: 1.1, m21: 0.025, m22: 0.077, tX: -0.55, tY: 33.2)
+        let d = AffineTransform(m11: 7.0, m12: -2.3, m21: 6.7, m22: 0.25, tX: 0.556, tY: 0.99)
+        let e = AffineTransform(m11: 0.498, m12: -0.284, m21: -0.742, m22: 0.3248, tX: 12, tY: 44)
 
-    func test_hashing_values() {
-        // the transforms are made up and the values don't matter
-        let values = [
-            AffineTransform(m11: CGFloat(1.0), m12: CGFloat(2.5), m21: CGFloat(66.2), m22: CGFloat(40.2), tX: CGFloat(-5.5), tY: CGFloat(3.7)),
-            AffineTransform(m11: CGFloat(-55.66), m12: CGFloat(22.7), m21: CGFloat(1.5), m22: CGFloat(0.0), tX: CGFloat(-22.0), tY: CGFloat(-33.0)),
-            AffineTransform(m11: CGFloat(4.5), m12: CGFloat(1.1), m21: CGFloat(0.025), m22: CGFloat(0.077), tX: CGFloat(-0.55), tY: CGFloat(33.2)),
-            AffineTransform(m11: CGFloat(7.0), m12: CGFloat(-2.3), m21: CGFloat(6.7), m22: CGFloat(0.25), tX: CGFloat(0.556), tY: CGFloat(0.99)),
-            AffineTransform(m11: CGFloat(0.498), m12: CGFloat(-0.284), m21: CGFloat(-0.742), m22: CGFloat(0.3248), tX: CGFloat(12.0), tY: CGFloat(44.0))
-        ]
-        for val in values {
-            let ref = NSAffineTransform()
-            ref.transformStruct = NSAffineTransformStruct(m11: val.m11, m12: val.m12, m21: val.m21, m22: val.m22, tX: val.tX, tY: val.tY)
-            XCTAssertEqual(ref.hashValue, val.hashValue)
+        // Samples testing that every component is properly hashed
+        let x1 = AffineTransform(m11: 1.0, m12: 2.0, m21: 3.0, m22: 4.0, tX: 5.0, tY: 6.0)
+        let x2 = AffineTransform(m11: 1.5, m12: 2.0, m21: 3.0, m22: 4.0, tX: 5.0, tY: 6.0)
+        let x3 = AffineTransform(m11: 1.0, m12: 2.5, m21: 3.0, m22: 4.0, tX: 5.0, tY: 6.0)
+        let x4 = AffineTransform(m11: 1.0, m12: 2.0, m21: 3.5, m22: 4.0, tX: 5.0, tY: 6.0)
+        let x5 = AffineTransform(m11: 1.0, m12: 2.0, m21: 3.0, m22: 4.5, tX: 5.0, tY: 6.0)
+        let x6 = AffineTransform(m11: 1.0, m12: 2.0, m21: 3.0, m22: 4.0, tX: 5.5, tY: 6.0)
+        let x7 = AffineTransform(m11: 1.0, m12: 2.0, m21: 3.0, m22: 4.0, tX: 5.0, tY: 6.5)
+
+        @inline(never)
+        func bridged(_ t: AffineTransform) -> NSAffineTransform {
+            return t as NSAffineTransform
         }
+
+        let values: [[AffineTransform]] = [
+            [AffineTransform.identity, NSAffineTransform() as AffineTransform],
+            [a, bridged(a) as AffineTransform],
+            [b, bridged(b) as AffineTransform],
+            [c, bridged(c) as AffineTransform],
+            [d, bridged(d) as AffineTransform],
+            [e, bridged(e) as AffineTransform],
+            [x1], [x2], [x3], [x4], [x5], [x6], [x7]
+        ]
+        checkHashableGroups(values)
     }
 
     func test_rotation_compose() {

--- a/TestFoundation/TestCalendar.swift
+++ b/TestFoundation/TestCalendar.swift
@@ -25,6 +25,7 @@ class TestCalendar: XCTestCase {
             ("test_customMirror", test_customMirror),
             ("test_ampmSymbols", test_ampmSymbols),
             ("test_currentCalendarRRstability", test_currentCalendarRRstability),
+            ("test_hashing", test_hashing),
         ]
     }
     
@@ -205,6 +206,25 @@ class TestCalendar: XCTestCase {
         XCTAssertEqual(calendar.timeZone, calendarMirror.descendant("timeZone") as? TimeZone)
         XCTAssertEqual(calendar.firstWeekday, calendarMirror.descendant("firstWeekday") as? Int)
         XCTAssertEqual(calendar.minimumDaysInFirstWeek, calendarMirror.descendant("minimumDaysInFirstWeek") as? Int)
+    }
+
+    func test_hashing() {
+        let calendars: [Calendar] = [
+            Calendar.autoupdatingCurrent,
+            Calendar(identifier: .buddhist),
+            Calendar(identifier: .gregorian),
+            Calendar(identifier: .islamic),
+            Calendar(identifier: .iso8601),
+        ]
+        checkHashable(calendars, equalityOracle: { $0 == $1 })
+
+        // autoupdating calendar isn't equal to the current, even though it's
+        // likely to be the same.
+        let calendars2: [Calendar] = [
+            Calendar.autoupdatingCurrent,
+            Calendar.current,
+        ]
+        checkHashable(calendars2, equalityOracle: { $0 == $1 })
     }
 }
 

--- a/TestFoundation/TestCharacterSet.swift
+++ b/TestFoundation/TestCharacterSet.swift
@@ -74,6 +74,7 @@ class TestCharacterSet : XCTestCase {
             ("test_formUnion", test_formUnion),
             ("test_union", test_union),
             ("test_SR5971", test_SR5971),
+            ("test_hashing", test_hashing),
         ]
     }
     
@@ -367,5 +368,19 @@ class TestCharacterSet : XCTestCase {
         let charset2 = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789&+")
         XCTAssertTrue(charset2.contains("+"))
     }
-    
+
+    func test_hashing() {
+        let a = CharacterSet(charactersIn: "ABC")
+        let b = CharacterSet(charactersIn: "CBA")
+        let c = CharacterSet(charactersIn: "bad")
+        let d = CharacterSet(charactersIn: "abd")
+        let e = CharacterSet.capitalizedLetters
+        let f = CharacterSet.lowercaseLetters
+        checkHashableGroups(
+            [[a, b], [c, d], [e], [f]],
+            // FIXME: CharacterSet delegates equality and hashing to
+            // CFCharacterSet, which uses unseeded hashing, so it's not
+            // complete.
+            allowIncompleteHashing: true)
+    }
 }

--- a/TestFoundation/TestDate.swift
+++ b/TestFoundation/TestDate.swift
@@ -7,6 +7,14 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+func dateWithString(_ str: String) -> Date {
+    let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.locale = Locale(identifier: "en_US")
+    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+    return formatter.date(from: str)! as Date
+}
+
 class TestDate : XCTestCase {
     
     static var allTests: [(String, (TestDate) -> () throws -> Void)] {
@@ -25,6 +33,7 @@ class TestDate : XCTestCase {
             ("test_IsEqualToDate", test_IsEqualToDate),
             ("test_timeIntervalSinceReferenceDate", test_timeIntervalSinceReferenceDate),
             ("test_recreateDateComponentsFromDate", test_recreateDateComponentsFromDate),
+            ("test_Hashing", test_Hashing),
         ]
     }
     
@@ -151,5 +160,18 @@ class TestDate : XCTestCase {
         XCTAssertEqual(recreatedComponents.weekOfMonth, 2)
         XCTAssertEqual(recreatedComponents.weekOfYear, 45)
         XCTAssertEqual(recreatedComponents.yearForWeekOfYear, 2017)
+    }
+
+    func test_Hashing() {
+        let values: [Date] = [
+            dateWithString("2010-05-17 14:49:47 -0700"),
+            dateWithString("2011-05-17 14:49:47 -0700"),
+            dateWithString("2010-06-17 14:49:47 -0700"),
+            dateWithString("2010-05-18 14:49:47 -0700"),
+            dateWithString("2010-05-17 15:49:47 -0700"),
+            dateWithString("2010-05-17 14:50:47 -0700"),
+            dateWithString("2010-05-17 14:49:48 -0700"),
+        ]
+        checkHashable(values, equalityOracle: { $0 == $1 })
     }
 }

--- a/TestFoundation/TestDateInterval.swift
+++ b/TestFoundation/TestDateInterval.swift
@@ -1,0 +1,9 @@
+//
+//  TestDateInterval.swift
+//  TestFoundation
+//
+//  Created by Karoly Lorentey on 2019-04-10.
+//  Copyright © 2019 Apple. All rights reserved.
+//
+
+import Foundation

--- a/TestFoundation/TestDateInterval.swift
+++ b/TestFoundation/TestDateInterval.swift
@@ -1,9 +1,46 @@
+// This source file is part of the Swift.org open source project
 //
-//  TestDateInterval.swift
-//  TestFoundation
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
 //
-//  Created by Karoly Lorentey on 2019-04-10.
-//  Copyright © 2019 Apple. All rights reserved.
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-import Foundation
+class TestDateInterval: XCTestCase {
+    static var allTests: [(String, (TestDateInterval) -> () throws -> Void)] {
+        return [
+            ("test_hashing", test_hashing),
+        ]
+    }
+
+    func test_hashing() {
+        guard #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) else { return }
+
+        let start1a = dateWithString("2019-04-04 17:09:23 -0700")
+        let start1b = dateWithString("2019-04-04 17:09:23 -0700")
+        let start2a = Date(timeIntervalSinceReferenceDate: start1a.timeIntervalSinceReferenceDate.nextUp)
+        let start2b = Date(timeIntervalSinceReferenceDate: start1a.timeIntervalSinceReferenceDate.nextUp)
+        let duration1 = 1800.0
+        let duration2 = duration1.nextUp
+        let intervals: [[DateInterval]] = [
+            [
+                DateInterval(start: start1a, duration: duration1),
+                DateInterval(start: start1b, duration: duration1),
+            ],
+            [
+                DateInterval(start: start1a, duration: duration2),
+                DateInterval(start: start1b, duration: duration2),
+            ],
+            [
+                DateInterval(start: start2a, duration: duration1),
+                DateInterval(start: start2b, duration: duration1),
+            ],
+            [
+                DateInterval(start: start2a, duration: duration2),
+                DateInterval(start: start2b, duration: duration2),
+            ],
+        ]
+        checkHashableGroups(intervals)
+    }
+}

--- a/TestFoundation/TestDecimal.swift
+++ b/TestFoundation/TestDecimal.swift
@@ -363,9 +363,10 @@ class TestDecimal: XCTestCase {
         XCTAssertFalse(Decimal.nan.isTotallyOrdered(belowOrEqualTo: Decimal(2.3)))
         XCTAssertTrue(Decimal(2) < Decimal(3))
         XCTAssertTrue(Decimal(3) > Decimal(2))
-#if !arch(arm)
-        XCTAssertEqual(3275573729074, Decimal(1234).hashValue)
-#endif
+
+        // FIXME: This test is of questionable value. We should test hash properties.
+        XCTAssertEqual((1234 as Double).hashValue, Decimal(1234).hashValue)
+
         XCTAssertEqual(Decimal(-9), Decimal(1) - Decimal(10))
         XCTAssertEqual(Decimal(3), Decimal(2).nextUp)
         XCTAssertEqual(Decimal(2), Decimal(3).nextDown)

--- a/TestFoundation/TestIndexPath.swift
+++ b/TestFoundation/TestIndexPath.swift
@@ -270,11 +270,22 @@ class TestIndexPath: XCTestCase {
     }
     
     func testHashing() {
-        let ip1: IndexPath = [5, 1]
-        let ip2: IndexPath = [1, 1, 1]
-        
-        XCTAssertNotEqual(ip1.hashValue, ip2.hashValue)
-
+        let samples: [IndexPath] = [
+            [],
+            [1],
+            [2],
+            [Int.max],
+            [1, 1],
+            [2, 1],
+            [1, 2],
+            [1, 1, 1],
+            [2, 1, 1],
+            [1, 2, 1],
+            [1, 1, 2],
+            [Int.max, Int.max, Int.max],
+        ]
+        checkHashable(samples, equalityOracle: { $0 == $1 })
+ 
         // this should not cause an overflow crash
         let hash: Int? = IndexPath(indexes: [Int.max >> 8, 2, Int.max >> 36]).hashValue
         XCTAssertNotNil(hash)

--- a/TestFoundation/TestMeasurement.swift
+++ b/TestFoundation/TestMeasurement.swift
@@ -1,0 +1,9 @@
+//
+//  TestMeasurement.swift
+//  TestFoundation
+//
+//  Created by Karoly Lorentey on 2019-04-10.
+//  Copyright © 2019 Apple. All rights reserved.
+//
+
+import Foundation

--- a/TestFoundation/TestMeasurement.swift
+++ b/TestFoundation/TestMeasurement.swift
@@ -1,9 +1,75 @@
+// This source file is part of the Swift.org open source project
 //
-//  TestMeasurement.swift
-//  TestFoundation
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
 //
-//  Created by Karoly Lorentey on 2019-04-10.
-//  Copyright © 2019 Apple. All rights reserved.
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-import Foundation
+class CustomUnit: Unit {
+    required init(symbol: String) {
+        super.init(symbol: symbol)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    public static let bugs = CustomUnit(symbol: "bug")
+    public static let features = CustomUnit(symbol: "feature")
+}
+
+class TestMeasurement: XCTestCase {
+    static var allTests: [(String, (TestMeasurement) -> () throws -> Void)] {
+        return [
+            ("testHashing", testHashing),
+        ]
+    }
+
+    func testHashing() {
+        let lengths: [[Measurement<UnitLength>]] = [
+            [
+                Measurement(value: 5, unit: UnitLength.kilometers),
+                Measurement(value: 5000, unit: UnitLength.meters),
+                Measurement(value: 5000, unit: UnitLength.meters),
+            ],
+            [
+                Measurement(value: 1, unit: UnitLength.kilometers),
+                Measurement(value: 1000, unit: UnitLength.meters),
+            ],
+            [
+                Measurement(value: 1, unit: UnitLength.meters),
+                Measurement(value: 1000, unit: UnitLength.millimeters),
+            ],
+        ]
+        checkHashableGroups(lengths)
+
+        let durations: [[Measurement<UnitDuration>]] = [
+            [
+                Measurement(value: 3600, unit: UnitDuration.seconds),
+                Measurement(value: 60, unit: UnitDuration.minutes),
+                Measurement(value: 1, unit: UnitDuration.hours),
+            ],
+            [
+                Measurement(value: 1800, unit: UnitDuration.seconds),
+                Measurement(value: 30, unit: UnitDuration.minutes),
+                Measurement(value: 0.5, unit: UnitDuration.hours),
+            ]
+        ]
+        checkHashableGroups(durations)
+
+        let custom: [Measurement<CustomUnit>] = [
+            Measurement(value: 1, unit: CustomUnit.bugs),
+            Measurement(value: 2, unit: CustomUnit.bugs),
+            Measurement(value: 3, unit: CustomUnit.bugs),
+            Measurement(value: 4, unit: CustomUnit.bugs),
+            Measurement(value: 1, unit: CustomUnit.features),
+            Measurement(value: 2, unit: CustomUnit.features),
+            Measurement(value: 3, unit: CustomUnit.features),
+            Measurement(value: 4, unit: CustomUnit.features),
+        ]
+        checkHashable(custom, equalityOracle: { $0 == $1 })
+    }
+
+}

--- a/TestFoundation/TestNSRange.swift
+++ b/TestFoundation/TestNSRange.swift
@@ -21,9 +21,10 @@ class TestNSRange : XCTestCase {
             ("test_NSStringFromRange", test_NSStringFromRange),
             ("test_init_region_in_ascii_string", test_init_region_in_ascii_string),
             ("test_init_region_in_unicode_string", test_init_region_in_unicode_string),
+            ("test_hashing", test_hashing),
         ]
     }
-    
+
     func test_NSRangeFromString() {
         let emptyRangeStrings = [
             "",
@@ -176,5 +177,19 @@ class TestNSRange : XCTestCase {
         _assertNSRangeInit(unicodeSubstring.startIndex..., in: unicodeString, is: "{20, 34}")
         _assertNSRangeInit(...unicodeSubstring.firstIndex(of: "╯")!, in: unicodeSubstring, is: "{0, 12}")
         _assertNSRangeInit(..<unicodeSubstring.firstIndex(of: "╯")!, in: unicodeString, is: "{0, 31}")
+    }
+
+    func test_hashing() {
+        let large = Int.max >> 2
+        let samples: [NSRange] = [
+            NSRange(location: 1, length: 1),
+            NSRange(location: 1, length: 2),
+            NSRange(location: 2, length: 1),
+            NSRange(location: 2, length: 2),
+            NSRange(location: large, length: large),
+            NSRange(location: 0, length: large),
+            NSRange(location: large, length: 0),
+        ]
+        checkHashable(samples, equalityOracle: { $0 == $1 })
     }
 }

--- a/TestFoundation/TestUUID.swift
+++ b/TestFoundation/TestUUID.swift
@@ -16,6 +16,7 @@ class TestUUID : XCTestCase {
             ("test_UUIDuuidString", test_UUIDuuidString),
             ("test_UUIDdescription", test_UUIDdescription),
             ("test_UUIDNSCoding", test_UUIDNSCoding),
+            ("test_hash", test_hash),
         ]
     }
     
@@ -51,5 +52,30 @@ class TestUUID : XCTestCase {
         let uuidA = UUID()
         let uuidB = NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: uuidA)) as! UUID
         XCTAssertEqual(uuidA, uuidB, "Archived then unarchived uuid must be equal.")
+    }
+
+    func test_hash() {
+        let values: [UUID] = [
+            // This list takes a UUID and tweaks every byte while
+            // leaving the version/variant intact.
+            UUID(uuidString: "a53baa1c-b4f5-48db-9467-9786b76b256c")!,
+            UUID(uuidString: "a63baa1c-b4f5-48db-9467-9786b76b256c")!,
+            UUID(uuidString: "a53caa1c-b4f5-48db-9467-9786b76b256c")!,
+            UUID(uuidString: "a53bab1c-b4f5-48db-9467-9786b76b256c")!,
+            UUID(uuidString: "a53baa1d-b4f5-48db-9467-9786b76b256c")!,
+            UUID(uuidString: "a53baa1c-b5f5-48db-9467-9786b76b256c")!,
+            UUID(uuidString: "a53baa1c-b4f6-48db-9467-9786b76b256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-49db-9467-9786b76b256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48dc-9467-9786b76b256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48db-9567-9786b76b256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48db-9468-9786b76b256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48db-9467-9886b76b256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48db-9467-9787b76b256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48db-9467-9786b86b256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48db-9467-9786b76c256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48db-9467-9786b76b266c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48db-9467-9786b76b256d")!,
+        ]
+        checkHashable(values, equalityOracle: { $0 == $1 })
     }
 }

--- a/TestFoundation/Utilities.swift
+++ b/TestFoundation/Utilities.swift
@@ -7,8 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-
 func checkHashing_ValueType<Item: Hashable, S: Sequence>(
     initialValue item: Item,
     byMutating keyPath: WritableKeyPath<Item, S.Element>,
@@ -134,50 +132,313 @@ extension Optional {
 // You can use the FOUNDATION_XCTEST compilation condition to distinguish between tests running in XCTest
 // or in StdlibUnittest.
 
-func expectThrows<Error: Swift.Error & Equatable>(_ expectedError: Error, _ test: () throws -> Void, _ message: @autoclosure () -> String = "") {
+func expectThrows<Error: Swift.Error & Equatable>(_ expectedError: Error, _ test: () throws -> Void, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
     var caught = false
     do {
         try test()
     } catch let error as Error {
         caught = true
-        XCTAssertEqual(error, expectedError, message())
+        XCTAssertEqual(error, expectedError, message(), file: file, line: line)
     } catch {
         caught = true
-        XCTFail("Incorrect error thrown: \(error) -- \(message())")
+        XCTFail("Incorrect error thrown: \(error) -- \(message())", file: file, line: line)
     }
-    XCTAssert(caught, "No error thrown -- \(message())")
+    XCTAssert(caught, "No error thrown -- \(message())", file: file, line: line)
 }
 
-func expectDoesNotThrow(_ test: () throws -> Void, _ message: @autoclosure () -> String = "") {
-    XCTAssertNoThrow(try test(), message())
+func expectDoesNotThrow(_ test: () throws -> Void, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+    XCTAssertNoThrow(try test(), message(), file: file, line: line)
 }
 
-func expectTrue(_ actual: Bool, _ message: @autoclosure () -> String = "") {
-    XCTAssertTrue(actual, message())
+func expectTrue(_ actual: Bool, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+    XCTAssertTrue(actual, message(), file: file, line: line)
 }
 
-func expectFalse(_ actual: Bool, _ message: @autoclosure () -> String = "") {
-    XCTAssertFalse(actual, message())
+func expectFalse(_ actual: Bool, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+    XCTAssertFalse(actual, message(), file: file, line: line)
 }
 
-func expectEqual<T: Equatable>(_ expected: T, _ actual: T, _ message: @autoclosure () -> String = "") {
-    XCTAssertEqual(expected, actual, message())
+func expectEqual<T: Equatable>(_ expected: T, _ actual: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(expected, actual, message(), file: file, line: line)
 }
 
-func expectEqual<T: FloatingPoint>(_ expected: T, _ actual: T, within: T, _ message: @autoclosure () -> String = "") {
-    XCTAssertEqual(expected, actual, accuracy: within, message())
+func expectNotEqual<T: Equatable>(_ expected: T, _ actual: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+    XCTAssertNotEqual(expected, actual, message(), file: file, line: line)
 }
 
-func expectEqual<T: FloatingPoint>(_ expected: T?, _ actual: T, within: T, _ message: @autoclosure () -> String = "") {
-    XCTAssertNotNil(expected, message())
+func expectEqual<T: FloatingPoint>(_ expected: T, _ actual: T, within: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(expected, actual, accuracy: within, message(), file: file, line: line)
+}
+
+func expectEqual<T: FloatingPoint>(_ expected: T?, _ actual: T, within: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+    XCTAssertNotNil(expected, message(), file: file, line: line)
     if let expected = expected {
-        XCTAssertEqual(expected, actual, accuracy: within, message())
+        XCTAssertEqual(expected, actual, accuracy: within, message(), file: file, line: line)
     }
 }
 
+func expectEqual(
+    _ expected: Any.Type,
+    _ actual: Any.Type,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    XCTAssertTrue(expected == actual, message(), file: file, line: line)
+}
 
 extension Fixture where ValueType: NSObject & NSCoding {
     func loadEach(handler: (ValueType, FixtureVariant) throws -> Void) throws {
         try self.loadEach(fixtureRepository: try testBundle().url(forResource: "Fixtures", withExtension: nil).unwrapped(), handler: handler)
     }
+}
+
+/// Test that the elements of `instances` satisfy the semantic
+/// requirements of `Equatable`, using `oracle` to generate equality
+/// expectations from pairs of positions in `instances`.
+///
+/// - Note: `oracle` is also checked for conformance to the
+///   laws.
+public func checkEquatable<Instances: Collection>(
+    _ instances: Instances,
+    oracle: (Instances.Index, Instances.Index) -> Bool,
+    allowBrokenTransitivity: Bool = false,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #file,
+    line: UInt = #line
+) where Instances.Element: Equatable {
+    let indices = Array(instances.indices)
+    _checkEquatableImpl(
+        Array(instances),
+        oracle: { oracle(indices[$0], indices[$1]) },
+        allowBrokenTransitivity: allowBrokenTransitivity,
+        message(),
+        file: file,
+        line: line)
+}
+
+private class Box<T> {
+    var value: T
+
+    init(_ value: T) {
+        self.value = value
+    }
+}
+
+internal func _checkEquatableImpl<Instance : Equatable>(
+    _ instances: [Instance],
+    oracle: (Int, Int) -> Bool,
+    allowBrokenTransitivity: Bool = false,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    // For each index (which corresponds to an instance being tested) track the
+    // set of equal instances.
+    var transitivityScoreboard: [Box<Set<Int>>] =
+        instances.indices.map { _ in Box([]) }
+
+    for i in instances.indices {
+        let x = instances[i]
+        expectTrue(oracle(i, i), "bad oracle: broken reflexivity at index \(i)")
+
+        for j in instances.indices {
+            let y = instances[j]
+
+            let predictedXY = oracle(i, j)
+            expectEqual(
+                predictedXY, oracle(j, i),
+                "bad oracle: broken symmetry between indices \(i), \(j)",
+                file: file,
+                line: line)
+
+            let isEqualXY = x == y
+            expectEqual(
+                predictedXY, isEqualXY,
+                """
+                \((predictedXY
+                ? "expected equal, found not equal"
+                : "expected not equal, found equal"))
+                lhs (at index \(i)): \(String(reflecting: x))
+                rhs (at index \(j)): \(String(reflecting: y))
+                """,
+                file: file,
+                line: line)
+
+            // Not-equal is an inverse of equal.
+            expectNotEqual(
+                isEqualXY, x != y,
+                """
+                lhs (at index \(i)): \(String(reflecting: x))
+                rhs (at index \(j)): \(String(reflecting: y))
+                """,
+                file: file,
+                line: line)
+
+            if !allowBrokenTransitivity {
+                // Check transitivity of the predicate represented by the oracle.
+                // If we are adding the instance `j` into an equivalence set, check that
+                // it is equal to every other instance in the set.
+                if predictedXY && i < j && transitivityScoreboard[i].value.insert(j).inserted {
+                    if transitivityScoreboard[i].value.count == 1 {
+                        transitivityScoreboard[i].value.insert(i)
+                    }
+                    for k in transitivityScoreboard[i].value {
+                        expectTrue(
+                            oracle(j, k),
+                            "bad oracle: broken transitivity at indices \(i), \(j), \(k)",
+                            file: file,
+                            line: line)
+                        // No need to check equality between actual values, we will check
+                        // them with the checks above.
+                    }
+                    precondition(transitivityScoreboard[j].value.isEmpty)
+                    transitivityScoreboard[j] = transitivityScoreboard[i]
+                }
+            }
+        }
+    }
+}
+
+func hash<H: Hashable>(_ value: H, salt: Int? = nil) -> Int {
+    var hasher = Hasher()
+    if let salt = salt {
+        hasher.combine(salt)
+    }
+    hasher.combine(value)
+    return hasher.finalize()
+}
+
+public func checkHashable<Instances: Collection>(
+    _ instances: Instances,
+    equalityOracle: (Instances.Index, Instances.Index) -> Bool,
+    allowIncompleteHashing: Bool = false,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #file, line: UInt = #line
+) where Instances.Element: Hashable {
+    checkHashable(
+        instances,
+        equalityOracle: equalityOracle,
+        hashEqualityOracle: equalityOracle,
+        allowIncompleteHashing: allowIncompleteHashing,
+        message(),
+        file: file,
+        line: line)
+}
+
+
+public func checkHashable<Instances: Collection>(
+    _ instances: Instances,
+    equalityOracle: (Instances.Index, Instances.Index) -> Bool,
+    hashEqualityOracle: (Instances.Index, Instances.Index) -> Bool,
+    allowIncompleteHashing: Bool = false,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #file, line: UInt = #line
+) where Instances.Element: Hashable {
+
+    checkEquatable(
+        instances,
+        oracle: equalityOracle,
+        message(),
+        file: file,
+        line: line)
+
+    for i in instances.indices {
+        let x = instances[i]
+        for j in instances.indices {
+            let y = instances[j]
+            let predicted = hashEqualityOracle(i, j)
+            XCTAssertEqual(
+                predicted,
+                hashEqualityOracle(j, i),
+                "bad hash oracle: broken symmetry between indices \(i), \(j)",
+                file: file, line: line)
+            if x == y {
+                XCTAssertTrue(
+                    predicted,
+                    """
+                    bad hash oracle: equality must imply hash equality
+                    lhs (at index \(i)): \(x)
+                    rhs (at index \(j)): \(y)
+                    """,
+                    file: file, line: line)
+            }
+            if predicted {
+                XCTAssertEqual(
+                    hash(x), hash(y),
+                    """
+                    hash(into:) expected to match, found to differ
+                    lhs (at index \(i)): \(x)
+                    rhs (at index \(j)): \(y)
+                    """,
+                    file: file, line: line)
+                XCTAssertEqual(
+                    x.hashValue, y.hashValue,
+                    """
+                    hashValue expected to match, found to differ
+                    lhs (at index \(i)): \(x)
+                    rhs (at index \(j)): \(y)
+                    """,
+                    file: file, line: line)
+                XCTAssertEqual(
+                    x._rawHashValue(seed: 0), y._rawHashValue(seed: 0),
+                    """
+                    _rawHashValue(seed:) expected to match, found to differ
+                    lhs (at index \(i)): \(x)
+                    rhs (at index \(j)): \(y)
+                    """,
+                    file: file, line: line)
+            } else if !allowIncompleteHashing {
+                // Try a few different seeds; at least one of them should discriminate
+                // between the hashes. It is extremely unlikely this check will fail
+                // all ten attempts, unless the type's hash encoding is not unique,
+                // or unless the hash equality oracle is wrong.
+                XCTAssertTrue(
+                    (0..<10).contains { hash(x, salt: $0) != hash(y, salt: $0) },
+                    """
+                    hash(into:) expected to differ, found to match
+                    lhs (at index \(i)): \(x)
+                    rhs (at index \(j)): \(y)
+                    """,
+                    file: file, line: line)
+                XCTAssertTrue(
+                    (0..<10).contains { i in
+                        x._rawHashValue(seed: i) != y._rawHashValue(seed: i)
+                    },
+                    """
+                    _rawHashValue(seed:) expected to differ, found to match
+                    lhs (at index \(i)): \(x)
+                    rhs (at index \(j)): \(y)
+                    """,
+                    file: file, line: line)
+            }
+        }
+    }
+}
+
+/// Test that the elements of `groups` consist of instances that satisfy the
+/// semantic requirements of `Hashable`, with each group defining a distinct
+/// equivalence class under `==`.
+public func checkHashableGroups<Groups: Collection>(
+    _ groups: Groups,
+    _ message: @autoclosure () -> String = "",
+    allowIncompleteHashing: Bool = false,
+    file: StaticString = #file,
+    line: UInt = #line
+) where Groups.Element: Collection, Groups.Element.Element: Hashable {
+    let instances = groups.flatMap { $0 }
+    // groupIndices[i] is the index of the element in groups that contains
+    // instances[i].
+    let groupIndices =
+        zip(0..., groups).flatMap { i, group in group.map { _ in i } }
+    func equalityOracle(_ lhs: Int, _ rhs: Int) -> Bool {
+        return groupIndices[lhs] == groupIndices[rhs]
+    }
+    checkHashable(
+        instances,
+        equalityOracle: equalityOracle,
+        hashEqualityOracle: equalityOracle,
+        allowIncompleteHashing: allowIncompleteHashing,
+        file: file,
+        line: line)
 }

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -34,6 +34,7 @@ XCTMain([
     testCase(TestNSData.allTests),
     testCase(TestDate.allTests),
     testCase(TestDateComponents.allTests),
+    testCase(TestDateInterval.allTests),
     testCase(TestNSDateComponents.allTests),
     testCase(TestDateFormatter.allTests),
     testCase(TestDateIntervalFormatter.allTests),

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -109,5 +109,6 @@ XCTMain([
     testCase(TestCodable.allTests),
     testCase(TestUnit.allTests),
     testCase(TestDimension.allTests),
+    testCase(TestMeasurement.allTests),
     testCase(TestNSLock.allTests),
 ])


### PR DESCRIPTION
This is the corelibs-Foundation counterpart to https://github.com/apple/swift/pull/23832 for the Foundation SDK overlay. See there for a full description and rationale. 

This PR attempts to bring hashing roughly in sync in the two Foundation flavors, although some inconsistencies remain. Like in https://github.com/apple/swift/pull/23832, I'll post self-review notes below to highlight some points.