### PR TITLE
[android] Fix some parts of Bundle in Android.

### DIFF
--- a/CoreFoundation/PlugIn.subproj/CFBundle_Executable.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Executable.c
@@ -74,7 +74,7 @@ static CFURLRef _CFBundleCopyExecutableURLRaw(CFURLRef urlPath, CFStringRef exeN
     CFURLRef executableURL = NULL;
     if (!urlPath || !exeName) return NULL;
     
-#if !DEPLOYMENT_RUNTIME_OBJC && !DEPLOYMENT_TARGET_WINDOWS && !DEPLOYMENT_TARGET_ANDROID
+#if !DEPLOYMENT_RUNTIME_OBJC && !DEPLOYMENT_TARGET_WINDOWS
     if (!executableURL) {
         executableURL = CFURLCreateWithFileSystemPathRelativeToBase(kCFAllocatorSystemDefault, exeName, kCFURLPOSIXPathStyle, false, urlPath);
         if (!_binaryLoadable(executableURL)) {

--- a/CoreFoundation/PlugIn.subproj/CFBundle_Internal.h
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Internal.h
@@ -31,9 +31,9 @@ CF_EXTERN_C_BEGIN
 #endif
 
 // FHS bundles are supported on the Swift and C runtimes, except on Windows.
-#if !DEPLOYMENT_RUNTIME_OBJC && !TARGET_OS_WIN32 && !TARGET_OS_ANDROID
+#if !DEPLOYMENT_RUNTIME_OBJC && !TARGET_OS_WIN32
 
-#if TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_ANDROID
 #define _CFBundleFHSSharedLibraryFilenamePrefix CFSTR("lib")
 #define _CFBundleFHSSharedLibraryFilenameSuffix CFSTR(".so")
 #elif TARGET_OS_MAC
@@ -43,7 +43,7 @@ CF_EXTERN_C_BEGIN
 #error Disable FHS bundles or specify shared library prefixes and suffixes for this platform.
 #endif // DEPLOYMENT_TARGET_…
 
-#endif // !DEPLOYMENT_RUNTIME_OBJC && !TARGET_OS_WIN32 && !TARGET_OS_ANDROID
+#endif // !DEPLOYMENT_RUNTIME_OBJC && !TARGET_OS_WIN32
 
 #define CFBundleExecutableNotFoundError             4
 #define CFBundleExecutableNotLoadableError          3584

--- a/TestFoundation/TestObjCRuntime.swift
+++ b/TestFoundation/TestObjCRuntime.swift
@@ -43,10 +43,10 @@ class TestObjCRuntime: XCTestCase {
         let name = testBundleName()
         XCTAssertEqual(NSStringFromClass(NSObject.self), "NSObject")
         XCTAssertEqual(NSStringFromClass(SwiftClass.self), "\(name).SwiftClass")
-#if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
-        XCTAssertEqual(NSStringFromClass(XCTestCase.self), "XCTest.XCTestCase");
-#else
+#if canImport(SwiftXCTest) && !DEPLOYMENT_RUNTIME_OBJC
         XCTAssertEqual(NSStringFromClass(XCTestCase.self), "SwiftXCTest.XCTestCase");
+#else
+        XCTAssertEqual(NSStringFromClass(XCTestCase.self), "XCTest.XCTestCase");
 #endif
     }
 


### PR DESCRIPTION
While Android does not follow FHS, and it doesn't seem to have something
similar published, it follows some conventions of Unix. One of them
is that libraries are normally named prefixed with "lib" and suffixed
with ".so" like Linux. Executables are also normally named without any
prefix nor suffix.

The changes in this commit lift up restrictions that were in place for
Android, and allow some of the Bundle tests to pass on Android (and lift
another restriction in TestObjCRuntime).

While bundles might never be a common construct in Android, these
changes at least allow to test some of the scenarios, in case someone
needs this behaviour.

This allows `TestBundle`, `TestNSError`, `TestPropertyListSerialization`, `TestObjCRuntime`, and `TestNSKeyedUnarchiver` to pass on Android devices.