### PR TITLE
[SR-10086] Use glibc-provided statx() wrapper if available

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -54,13 +54,17 @@
 #endif
 
 #if TARGET_OS_LINUX
-// required for statx() system call
+#include <features.h>
+
+#if __GLIBC_PREREQ(2, 28) == 0
+// required for statx() system call, glibc >=2.28 wraps the kernel function
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <linux/stat.h>
 #define AT_STATX_SYNC_AS_STAT   0x0000  /* - Do whatever stat() does */
-#endif
+#endif //__GLIBC_PREREQ(2. 28)
+#endif // TARGET_OS_LINUX
 
 
 _CF_EXPORT_SCOPE_BEGIN


### PR DESCRIPTION
Glibc >= 2.28 provides statx() as a wrapper for the kernel syscall
(added in Linux 4.11) which conflicts with the kernel headers. This
allows compilation on systems which provide a recent glibc
(Fedora 30 etc).