### PR TITLE
Implement URLSessionConfiguration.ephemeral

### DIFF
--- a/Foundation/URLSession/URLSessionConfiguration.swift
+++ b/Foundation/URLSession/URLSessionConfiguration.swift
@@ -119,7 +119,15 @@ open class URLSessionConfiguration : NSObject, NSCopying {
     open class var `default`: URLSessionConfiguration {
         return URLSessionConfiguration()
     }
-    open class var ephemeral: URLSessionConfiguration { NSUnimplemented() }
+
+    open class var ephemeral: URLSessionConfiguration {
+        // Return a new ephemeral URLSessionConfiguration every time this property is invoked
+        // TODO: urlCache and urlCredentialStorage should also be ephemeral/in-memory
+        // URLCache and URLCredentialStorage are still unimplemented
+        let ephemeralConfiguration = URLSessionConfiguration()
+        ephemeralConfiguration.httpCookieStorage = HTTPCookieStorage.ephemeralStorage()
+        return ephemeralConfiguration
+    }
 
     open class func background(withIdentifier identifier: String) -> URLSessionConfiguration { NSUnimplemented() }
     


### PR DESCRIPTION
The difference between `default` and `ephemeral` `URLSessionConfiguration`s
is in the storage aspect. There are three kinds of stores related to a `URLSession`
 - a `URLCache`
 - a `URLCredentialStorage`
 - an `HTTPCookieStorage`

While the `default` configuration mandates persistent stores, the `ephemeral`
configuration mandates only in-memory, ephemeral stores. As of today, `URLCache`
and `URLCredentialStorage` are unimplemented and not configured in the `default`
configuration. `HTTPCookieStorage` is implemented and we use the `shared` storage
in the `default` configuration.

This commit includes:
 - an ephemeral `HTTPCookieStorage` that does not read from, and write to, a persistent
   store
 - an initial `URLSessionConfiguration.ephemeral` implementation which configures an
   ephmeral `HTTPCookieStorage`, but no `URLCache` and `URLCredentialStorage`