### PR TITLE
TestFoundation: use `Thread.sleep(forTimeInterval:)` rather than `sleep`

### DIFF
--- a/TestFoundation/TestOperationQueue.swift
+++ b/TestFoundation/TestOperationQueue.swift
@@ -120,7 +120,7 @@ class TestOperationQueue : XCTestCase {
         for i in 0..<5 {
             let operation = BlockOperation {
                 valueOperations.append(i)
-                sleep(2)
+                Thread.sleep(forTimeInterval: 2)
             }
             operations.append(operation)
         }
@@ -139,14 +139,14 @@ class TestOperationQueue : XCTestCase {
         
         let operation1 = BlockOperation {
             valueOperations.append(0)
-            sleep(2)
+            Thread.sleep(forTimeInterval: 2)
         }
         operation1.queuePriority = .high
         operations.append(operation1)
         
         let operation2 = BlockOperation {
             valueOperations.append(1)
-            sleep(2)
+            Thread.sleep(forTimeInterval: 2)
         }
         operation2.queuePriority = .high
         operations.append(operation2)


### PR DESCRIPTION
`sleep` is not portable; use `Thread.sleep(forTimeInterval:)`.