### PR TITLE
Parity: objectValue(…)

### DIFF
--- a/Foundation/DateComponentsFormatter.swift
+++ b/Foundation/DateComponentsFormatter.swift
@@ -128,11 +128,5 @@ open class DateComponentsFormatter : Formatter {
        Currently unimplemented, will be removed in a future seed.
      */
     open var formattingContext: Context
-    
-    /* DateComponentsFormatter currently only implements formatting, not parsing. Until it implements parsing, this will always return NO.
-     */
-    /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
-    /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    open override func objectValue(_ string: String) throws -> Any? { return nil }
 }
 

--- a/Foundation/DateFormatter.swift
+++ b/Foundation/DateFormatter.swift
@@ -43,8 +43,13 @@ open class DateFormatter : Formatter {
 
     open var formattingContext: Context = .unknown // default is NSFormattingContextUnknown
 
-    open func objectValue(_ string: String, range rangep: UnsafeMutablePointer<NSRange>) throws -> AnyObject? { NSUnimplemented() }
-
+    @available(*, unavailable, renamed: "date(from:)")
+    func getObjectValue(_ obj: UnsafeMutablePointer<AnyObject?>?,
+                        for string: String,
+                        range rangep: UnsafeMutablePointer<NSRange>?) throws {
+        NSUnsupported()
+    }
+    
     open override func string(for obj: Any) -> String? {
         guard let date = obj as? Date else { return nil }
         return string(from: date)

--- a/Foundation/DateIntervalFormatter.swift
+++ b/Foundation/DateIntervalFormatter.swift
@@ -181,10 +181,6 @@ open class DateIntervalFormatter: Formatter {
         return nil
     }
     
-    open override func objectValue(_ string: String) throws -> Any? {
-        return nil
-    }
-    
     open override func copy(with zone: NSZone? = nil) -> Any {
         return DateIntervalFormatter(cfFormatter: CFDateIntervalFormatterCreateCopy(nil, core))
     }

--- a/Foundation/EnergyFormatter.swift
+++ b/Foundation/EnergyFormatter.swift
@@ -173,10 +173,6 @@ open class EnergyFormatter: Formatter {
         //Return the appropriate representation of the unit based on the selected unit style
         return unitString(fromValue: numberInUnit, unit: unitFromJoules)
     }
-
-    /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
-    /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    open override func objectValue(_ string: String) throws -> Any? { return nil }
     
     /// Regions that use calories
     private static let caloriesRegions: Set<String> = ["en_US", "en_US_POSIX", "haw_US", "es_US", "chr_US", "en_GB", "kw_GB", "cy_GB", "gv_GB"]

--- a/Foundation/Formatter.swift
+++ b/Foundation/Formatter.swift
@@ -73,10 +73,16 @@ open class Formatter : NSObject, NSCopying, NSCoding {
         return string(for: obj)
     }
     
-    /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
-    /// - Note: Since this API is under consideration it may be either removed or revised in the near future
+    @available(*, unavailable, message: "Use each formatter's class and instance methods instead.")
     open func objectValue(_ string: String) throws -> Any? {
-        NSRequiresConcreteImplementation()
+        NSUnsupported()
+    }
+    
+    @available(*, unavailable, message: "Use each formatter's class and instance methods instead.")
+    func getObjectValue(_ obj: UnsafeMutablePointer<AnyObject?>?,
+                        for string: String,
+                        errorDescription error: UnsafeMutablePointer<NSString?>?) -> Bool {
+        NSUnsupported()
     }
 }
 

--- a/Foundation/LengthFormatter.swift
+++ b/Foundation/LengthFormatter.swift
@@ -152,12 +152,6 @@ open class LengthFormatter : Formatter {
         }
     }
     
-    
-    /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
-    /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    open override func objectValue(_ string: String) throws -> Any? { return nil }
-    
-    
     /// Maps LengthFormatter.Unit enum to UnitLength class. Used for measurement conversion.
     private static let unitLength: [Unit:UnitLength] = [.millimeter:.millimeters,
                                                  .centimeter:.centimeters,

--- a/Foundation/MassFormatter.swift
+++ b/Foundation/MassFormatter.swift
@@ -121,11 +121,6 @@ open class MassFormatter : Formatter {
         return unitString(fromValue: numberInUnit, unit: unitFromKilograms)
     }
     
-    /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
-    /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    open override func objectValue(_ string: String) throws -> Any? { return nil }
-    
-    
     // MARK: - Private
     
     /// This method selects the appropriate unit based on the formatter’s locale,

--- a/Foundation/NumberFormatter.swift
+++ b/Foundation/NumberFormatter.swift
@@ -75,10 +75,12 @@ open class NumberFormatter : Formatter {
 
     open var formattingContext: Context = .unknown // default is NSFormattingContextUnknown
 
-    // Report the used range of the string and an NSError, in addition to the usual stuff from Formatter
-    /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
-    /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    open func objectValue(_ string: String, range: inout NSRange) throws -> Any? { NSUnimplemented() }
+    @available(*, unavailable, renamed: "number(from:)")
+    func getObjectValue(_ obj: UnsafeMutablePointer<AnyObject?>?,
+                        for string: String,
+                        range rangep: UnsafeMutablePointer<NSRange>?) throws {
+        NSUnsupported()
+    }
 
     open override func string(for obj: Any) -> String? {
         //we need to allow Swift's numeric types here - Int, Double et al.

--- a/Foundation/PersonNameComponentsFormatter.swift
+++ b/Foundation/PersonNameComponentsFormatter.swift
@@ -68,12 +68,6 @@ open class PersonNameComponentsFormatter : Formatter {
     open func annotatedString(from components: PersonNameComponents) -> NSAttributedString { NSUnimplemented() }
     
     open func personNameComponents(from string: String) -> PersonNameComponents? { NSUnimplemented() }
-    
-    /* PersonNameComponentsFormatter currently only implements formatting, not parsing. Until it implements parsing, this will always return NO.
-     */
-    /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
-    /// - Note: Since this API is under consideration it may be either removed or revised in the near future
-    open override func objectValue(_ string: String) throws -> Any? { return nil }
 }
 
 // Attributed String identifier key string


### PR DESCRIPTION
swift-corelibs-foundation’s Formatter subclasses do not have working funnel methods at the moment. Rather than advertise an experimental API that has no implementation, retire the experimental API for now and provide source compatibility stubs that aid in porting code at compile time.

Fixes https://bugs.swift.org/browse/SR-10353, https://bugs.swift.org/browse/SR-10354