### PR TITLE
Remove explicit ==, hashing definitions from RawRepresentable types

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -829,14 +829,6 @@ public struct FileAttributeKey : RawRepresentable, Equatable, Hashable {
         self.rawValue = rawValue
     }
 
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(rawValue)
-    }
-
-    public static func ==(_ lhs: FileAttributeKey, _ rhs: FileAttributeKey) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
-    
     public static let type = FileAttributeKey(rawValue: "NSFileType")
     public static let size = FileAttributeKey(rawValue: "NSFileSize")
     public static let modificationDate = FileAttributeKey(rawValue: "NSFileModificationDate")
@@ -871,14 +863,6 @@ public struct FileAttributeType : RawRepresentable, Equatable, Hashable {
 
     public init(rawValue: String) {
         self.rawValue = rawValue
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(rawValue)
-    }
-
-    public static func ==(_ lhs: FileAttributeType, _ rhs: FileAttributeType) -> Bool {
-        return lhs.rawValue == rhs.rawValue
     }
 
 #if os(Windows)

--- a/Foundation/HTTPCookie.swift
+++ b/Foundation/HTTPCookie.swift
@@ -17,14 +17,6 @@ public struct HTTPCookiePropertyKey : RawRepresentable, Equatable, Hashable {
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
-    
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(rawValue)
-    }
-    
-    public static func ==(_ lhs: HTTPCookiePropertyKey, _ rhs: HTTPCookiePropertyKey) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
 }
 
 extension HTTPCookiePropertyKey {

--- a/Foundation/NSAttributedString.swift
+++ b/Foundation/NSAttributedString.swift
@@ -20,14 +20,6 @@ extension NSAttributedString {
         public init(rawValue: String) {
             self.rawValue = rawValue
         }
-
-        public func hash(into hasher: inout Hasher) {
-            hasher.combine(rawValue)
-        }
-
-        public static func ==(left: NSAttributedString.Key, right: NSAttributedString.Key) -> Bool {
-            return left.rawValue == right.rawValue
-        }
     }
 }
 

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -66,10 +66,6 @@ extension NSCalendar {
             self.rawValue = rawValue
         }
 
-        public func hash(into hasher: inout Hasher) {
-            hasher.combine(rawValue)
-        }
-        
         public static let gregorian = NSCalendar.Identifier("gregorian")
         public static let buddhist = NSCalendar.Identifier("buddhist")
         public static let chinese = NSCalendar.Identifier("chinese")
@@ -137,10 +133,6 @@ extension NSCalendar {
 }
 
 extension NSCalendar.Identifier {
-    public static func ==(_ lhs: NSCalendar.Identifier, _ rhs: NSCalendar.Identifier) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
-
     public static func <(_ lhs: NSCalendar.Identifier, _ rhs: NSCalendar.Identifier) -> Bool {
         return lhs.rawValue < rhs.rawValue
     }

--- a/Foundation/NSDecimalNumber.swift
+++ b/Foundation/NSDecimalNumber.swift
@@ -18,14 +18,6 @@ public struct NSExceptionName : RawRepresentable, Equatable, Hashable {
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(rawValue)
-    }
-    
-    public static func ==(_ lhs: NSExceptionName, _ rhs: NSExceptionName) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
 }
 
 extension NSExceptionName {

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -177,10 +177,6 @@ extension NSLocale {
             self.rawValue = rawValue
         }
 
-        public func hash(into hasher: inout Hasher) {
-            hasher.combine(rawValue)
-        }
-        
         public static let identifier = NSLocale.Key(rawValue: "kCFLocaleIdentifierKey")
         public static let languageCode = NSLocale.Key(rawValue: "kCFLocaleLanguageCodeKey")
         public static let countryCode = NSLocale.Key(rawValue: "kCFLocaleCountryCodeKey")
@@ -209,13 +205,6 @@ extension NSLocale {
         case rightToLeft
         case topToBottom
         case bottomToTop
-    }
-}
-
-
-extension NSLocale.Key {
-    public static func ==(_ lhs: NSLocale.Key, _ rhs: NSLocale.Key) -> Bool {
-        return lhs.rawValue == rhs.rawValue
     }
 }
 

--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -13,14 +13,6 @@ open class NSNotification: NSObject, NSCopying, NSCoding {
         public init(rawValue: String) {
             self.rawValue = rawValue
         }
-
-        public func hash(into hasher: inout Hasher) {
-            hasher.combine(rawValue)
-        }
-        
-        public static func ==(lhs: Name, rhs: Name) -> Bool {
-            return lhs.rawValue == rhs.rawValue
-        }
     }
 
     private(set) open var name: Name

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -115,14 +115,6 @@ extension NSString {
 
     public let rawValue: String
 
-    public var hashValue: Int {
-      return self.rawValue.hashValue
-    }
-
-    public static func ==(_ lhs: StringTransform, _ rhs: StringTransform) -> Bool {
-      return lhs.rawValue == rhs.rawValue
-    }
-
     public init(_ rawValue: String) {
       self.rawValue = rawValue
     }

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -75,14 +75,6 @@ public struct URLResourceKey : RawRepresentable, Equatable, Hashable {
     public init(_ rawValue: String) {
         self.rawValue = rawValue
     }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(rawValue)
-    }
-
-    public static func ==(lhs: URLResourceKey, rhs: URLResourceKey) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
 }
 
 extension URLResourceKey {
@@ -196,14 +188,6 @@ public struct URLFileResourceType : RawRepresentable, Equatable, Hashable {
     
     public init(_ rawValue: String) {
         self.rawValue = rawValue
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(rawValue)
-    }
-
-    public static func ==(lhs: URLFileResourceType, rhs: URLFileResourceType) -> Bool {
-        return lhs.rawValue == rhs.rawValue
     }
 }
 

--- a/Foundation/Progress.swift
+++ b/Foundation/Progress.swift
@@ -399,9 +399,7 @@ open class Progress : NSObject {
         public let rawValue: String
         public init(_ rawValue: String) { self.rawValue = rawValue }
         public init(rawValue: String) { self.rawValue = rawValue }
-        public func hash(into hasher: inout Hasher) { hasher.combine(rawValue) }
-        public static func ==(_ lhs: FileOperationKind, _ rhs: FileOperationKind) -> Bool { return lhs.rawValue == rhs.rawValue }
-        
+
         /// Use for indicating the progress represents a download.
         public static let downloading = FileOperationKind(rawValue: "NSProgressFileOperationKindDownloading")
 
@@ -478,9 +476,7 @@ public struct ProgressKind : RawRepresentable, Equatable, Hashable {
     public let rawValue: String
     public init(_ rawValue: String) { self.rawValue = rawValue }
     public init(rawValue: String) { self.rawValue = rawValue }
-    public func hash(into hasher: inout Hasher) { hasher.combine(rawValue) }
-    public static func ==(_ lhs: ProgressKind, _ rhs: ProgressKind) -> Bool { return lhs.rawValue == rhs.rawValue }
-    
+
     /// Indicates that the progress being performed is related to files.
     ///
     /// Progress of this kind is assumed to use bytes as the unit of work being done and the default implementation of `localizedDescription` takes advantage of that to return more specific text than it could otherwise.
@@ -491,9 +487,7 @@ public struct ProgressUserInfoKey : RawRepresentable, Equatable, Hashable {
     public let rawValue: String
     public init(_ rawValue: String) { self.rawValue = rawValue }
     public init(rawValue: String) { self.rawValue = rawValue }
-    public func hash(into hasher: inout Hasher) { hasher.combine(rawValue) }
-    public static func ==(_ lhs: ProgressUserInfoKey, _ rhs: ProgressUserInfoKey) -> Bool { return lhs.rawValue == rhs.rawValue }
-    
+
     /// How much time is probably left in the operation, as an NSNumber containing a number of seconds.
     ///
     /// If this value is present, then `Progress` can present a more detailed `localizedAdditionalDescription`.

--- a/Foundation/Stream.swift
+++ b/Foundation/Stream.swift
@@ -28,14 +28,6 @@ extension Stream {
         public init(rawValue: String) {
             self.rawValue = rawValue
         }
-
-        public func hash(into hasher: inout Hasher) {
-            hasher.combine(rawValue)
-        }
-
-        public static func ==(lhs: Stream.PropertyKey, rhs: Stream.PropertyKey) -> Bool {
-            return lhs.rawValue == rhs.rawValue
-        }
     }
     
     public enum Status : UInt {
@@ -303,12 +295,6 @@ public struct StreamSocketSecurityLevel : RawRepresentable, Equatable, Hashable 
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(rawValue)
-    }
-    public static func ==(lhs: StreamSocketSecurityLevel, rhs: StreamSocketSecurityLevel) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
 }
 extension StreamSocketSecurityLevel {
     public static let none = StreamSocketSecurityLevel(rawValue: "kCFStreamSocketSecurityLevelNone")
@@ -324,12 +310,6 @@ public struct StreamSOCKSProxyConfiguration : RawRepresentable, Equatable, Hasha
     public let rawValue: String
     public init(rawValue: String) {
         self.rawValue = rawValue
-    }
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(rawValue)
-    }
-    public static func ==(lhs: StreamSOCKSProxyConfiguration, rhs: StreamSOCKSProxyConfiguration) -> Bool {
-        return lhs.rawValue == rhs.rawValue
     }
 }
 extension StreamSOCKSProxyConfiguration {
@@ -347,12 +327,6 @@ public struct StreamSOCKSProxyVersion : RawRepresentable, Equatable, Hashable {
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(rawValue)
-    }
-    public static func ==(lhs: StreamSOCKSProxyVersion, rhs: StreamSOCKSProxyVersion) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
 }
 extension StreamSOCKSProxyVersion {
     public static let version4 = StreamSOCKSProxyVersion(rawValue: "kCFStreamSocketSOCKSVersion4")
@@ -365,12 +339,6 @@ public struct StreamNetworkServiceTypeValue : RawRepresentable, Equatable, Hasha
     public let rawValue: String
     public init(rawValue: String) {
         self.rawValue = rawValue
-    }
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(rawValue)
-    }
-    public static func ==(lhs: StreamNetworkServiceTypeValue, rhs: StreamNetworkServiceTypeValue) -> Bool {
-        return lhs.rawValue == rhs.rawValue
     }
 }
 extension StreamNetworkServiceTypeValue {

--- a/Foundation/StringEncodings.swift
+++ b/Foundation/StringEncodings.swift
@@ -68,13 +68,7 @@ extension String {
 }
 
 extension String.Encoding : Hashable {
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(rawValue)
-    }
-
-    public static func ==(lhs: String.Encoding, rhs: String.Encoding) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
+  // ==, hash(into:) supplied by RawRepresentable
 }
 
 extension String.Encoding : CustomStringConvertible {

--- a/TestFoundation/TestNSCache.swift
+++ b/TestFoundation/TestNSCache.swift
@@ -117,10 +117,13 @@ class TestNSCache : XCTestCase {
 
     class TestHashableCacheKey: Hashable {
         let string: String
-        var hashValue: Int { return string.hashValue }
 
         init(string: String) {
             self.string = string
+        }
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(string)
         }
 
         static func ==(lhs: TestHashableCacheKey,


### PR DESCRIPTION
This implements @millenomi's review note in https://github.com/apple/swift-corelibs-foundation/pull/2118#discussion_r275510020.

Remove explicit definitions for == and `hash(into:)` from Foundation's enum-like RawRepresentable types. The stdlib provides identical definitions in conditional extensions of RawRepresentable.

Note: This would be an ABI-breaking change in Darwin's Foundation overlays because it removes these symbols; but it seems a reasonable simplification for corelibs-foundation, where AFAIK we don't have to be compatible with Swift 5's ABI.

Note also that RawRepresentable's definitions are inlinable, while the original definitions weren't. The corresponding definitions on Darwin are already inlinable, so this is unlikely to cause *new* issues.