### PR TITLE
Foundation: port `ProcessInfo.processIdentifier` to Win32

### DIFF
--- a/Foundation/ProcessInfo.swift
+++ b/Foundation/ProcessInfo.swift
@@ -68,7 +68,11 @@ open class ProcessInfo: NSObject {
     open var processName: String = _CFProcessNameString()._swiftObject
     
     open var processIdentifier: Int32 {
+#if os(Windows)
+        return Int32(GetProcessId(GetCurrentProcess()))
+#else
         return Int32(getpid())
+#endif
     }
     
     open var globallyUniqueString: String {


### PR DESCRIPTION
Windows does not support `getpid`.  Add a Windows specific path for
this.  Thanks to Lily Vulcano for pointing out that this was missed.