### PR TITLE
Disable TestNSString#test_FromContentsOfURL as being flaky

### DIFF
--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -365,6 +365,7 @@ class TestNSString: LoopbackServerTest {
         XCTAssertNil(string)
     }
 
+    /* FIXME: https://bugs.swift.org/browse/SR-10505
     func test_FromContentsOfURL() {
         guard let testFileURL = testBundle().url(forResource: "NSStringTestData", withExtension: "txt") else {
             XCTFail("URL for NSStringTestData.txt is nil")
@@ -404,6 +405,7 @@ class TestNSString: LoopbackServerTest {
         }
         XCTAssertEqual(zeroString, "Some\u{00}text\u{00}with\u{00}NUL\u{00}bytes\u{00}instead\u{00}of\u{00}spaces.\u{00}\n")
     }
+    */
 
     func test_FromContentOfFileUsedEncodingIgnored() {
         let testFilePath = testBundle().path(forResource: "NSStringTestData", ofType: "txt")

--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -55,7 +55,7 @@ class TestNSString: LoopbackServerTest {
             ("test_longLongValue", test_longLongValue ),
             ("test_rangeOfCharacterFromSet", test_rangeOfCharacterFromSet ),
             ("test_CFStringCreateMutableCopy", test_CFStringCreateMutableCopy),
-            ("test_FromContentsOfURL",test_FromContentsOfURL),
+//            ("test_FromContentsOfURL",test_FromContentsOfURL),
             ("test_FromContentOfFileUsedEncodingIgnored", test_FromContentOfFileUsedEncodingIgnored),
             ("test_FromContentOfFileUsedEncodingUTF8", test_FromContentOfFileUsedEncodingUTF8),
             ("test_FromContentsOfURLUsedEncodingUTF16BE", test_FromContentsOfURLUsedEncodingUTF16BE),


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-10505