### PR TITLE
[test] Remove temporary files after test.

### DIFF
--- a/TestFoundation/TestFileHandle.swift
+++ b/TestFoundation/TestFileHandle.swift
@@ -303,6 +303,7 @@ class TestFileHandle : XCTestCase {
     func test_truncateFile() {
         let url: URL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString, isDirectory: false)
         _ = FileManager.default.createFile(atPath: url.path, contents: Data())
+        defer { _ = try? FileManager.default.removeItem(at: url) }
 
         let fh: FileHandle = FileHandle(forUpdatingAtPath: url.path)!
 

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -233,6 +233,7 @@ class TestProcess : XCTestCase {
 
         let url: URL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString, isDirectory: false)
         _ = FileManager.default.createFile(atPath: url.path, contents: Data())
+        defer { _ = try? FileManager.default.removeItem(at: url) }
 
         let handle: FileHandle = FileHandle(forUpdatingAtPath: url.path)!
 


### PR DESCRIPTION
A previous change replaced the usage of mkstemp for creating files with
UUID file names, but was missing the unlink call present in the previous
version.

This change will take care of cleaning after the tests and try not to
pile garbage files in the temporary directory.