### PR TITLE
[android] Fix tilde/home directory tests.

### DIFF
--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -1014,25 +1014,30 @@ class TestNSString: LoopbackServerTest {
     }
     
     func test_expandingTildeInPath() {
+        // Android home directory is the root directory, so the result of ~ may
+        // actually have a trailing path separator, but only if it is the root
+        // directory itself.
+        let rootDirectory = "/"
+
         do {
             let path: NSString = "~"
             let result = path.expandingTildeInPath
             XCTAssert(result == NSHomeDirectory(), "Could resolve home directory for current user")
-            XCTAssertFalse(result.hasSuffix("/"), "Result have no trailing path separator")
+            XCTAssertFalse(result.hasSuffix("/") && result != rootDirectory, "Result should not have a trailing path separator")
         }
         
         do {
             let path: NSString = "~/"
             let result = path.expandingTildeInPath
             XCTAssert(result == NSHomeDirectory(), "Could resolve home directory for current user")
-            XCTAssertFalse(result.hasSuffix("/"), "Result have no trailing path separator")
+            XCTAssertFalse(result.hasSuffix("/") && result != rootDirectory, "Result should not have a trailing path separator")
         }
         
         do {
             let path = NSString(string: "~\(NSUserName())")
             let result = path.expandingTildeInPath
             XCTAssert(result == NSHomeDirectory(), "Could resolve home directory for specific user")
-            XCTAssertFalse(result.hasSuffix("/"), "Result have no trailing path separator")
+            XCTAssertFalse(result.hasSuffix("/") && result != rootDirectory, "Result should not have a trailing path separator")
         }
         
         do {
@@ -1064,7 +1069,7 @@ class TestNSString: LoopbackServerTest {
         do {
             let path: NSString =  "~/foo/bar/"
             let result = path.standardizingPath
-            let expected = NSHomeDirectory() + "/foo/bar"
+            let expected = NSHomeDirectory().appendingPathComponent("foo/bar")
             XCTAssertEqual(result, expected, "standardizingPath expanding initial tilde.")
         }
         


### PR DESCRIPTION
In Android, the home directory is the root directory. Foundation returns
the right one, but the tests where checking against having a final
trailing slash, which is not true if the home directory is the root
directory.

The change adds an extra check to avoid the failure in case the
resulting tilde expansion is just the root directory. The comment
explains why the change is needed.

Additionally, instead of using `+` to add two strings,
`appendingPathComponent` is used to build an expected value from the
result of `NSHomeDirectory()`, in order to deal with cases where the
`NSHomeDirectory()` has a trailing slash.