### PR TITLE
“qualityOfService” for “Thread”

### DIFF
--- a/Foundation/Thread.swift
+++ b/Foundation/Thread.swift
@@ -199,6 +199,9 @@ open class Thread : NSObject {
     internal var _status = _NSThreadStatus.initialized
     internal var _cancelled = false
 
+    /// - Note: This property is available on all platforms, but on some it may have no effect.
+    open var qualityOfService: QualityOfService = .default
+
     open private(set) var threadDictionary: NSMutableDictionary = NSMutableDictionary()
 
     internal init(thread: _swift_CFThreadRef) {

--- a/TestFoundation/TestThread.swift
+++ b/TestFoundation/TestThread.swift
@@ -58,6 +58,7 @@ class TestThread : XCTestCase {
             condition.broadcast()
             condition.unlock()
         }
+        XCTAssertEqual(thread.qualityOfService, .default)
         thread.start()
 
         let ok = condition.wait(until: Date(timeIntervalSinceNow: 2))


### PR DESCRIPTION
This adds a missing property that is a available on macOS.

Like the corresponding properties on `Operation` and `Process`, it does nothing. It simply improves source compatibility between operating systems.

This was first mentioned in the forums [here](https://forums.swift.org/t/qualityofservice-for-thread/23359).