### PR TITLE
Parity: FileManager.getRelationship(…)

### DIFF
--- a/Foundation/FileManager+POSIX.swift
+++ b/Foundation/FileManager+POSIX.swift
@@ -463,6 +463,20 @@ extension FileManager {
 
         return self.string(withFileSystemRepresentation: buf, length: Int(len))
     }
+    
+    /* Returns a String with a canonicalized path for the element at the specified path. */
+    internal func _canonicalizedPath(toFileAtPath path: String) throws -> String {
+        let bufSize = Int(PATH_MAX + 1)
+        var buf = [Int8](repeating: 0, count: bufSize)
+        let done = try _fileSystemRepresentation(withPath: path) {
+            realpath($0, &buf) != nil
+        }
+        if !done {
+            throw _NSErrorWithErrno(errno, reading: true, path: path)
+        }
+        
+        return self.string(withFileSystemRepresentation: buf, length: strlen(buf))
+    }
 
     internal func _readFrom(fd: Int32, toBuffer buffer: UnsafeMutablePointer<UInt8>, length bytesToRead: Int, filename: String) throws -> Int {
         var bytesRead = 0

--- a/Foundation/FileManager+Win32.swift
+++ b/Foundation/FileManager+Win32.swift
@@ -279,6 +279,10 @@ extension FileManager {
     }
 
     internal func _destinationOfSymbolicLink(atPath path: String) throws -> String {
+        return try _canonicalizedPath(toFileAtPath: path)
+    }
+    
+    internal func _canonicalizedPath(toFileAtPath path: String) throws -> String {
         var hFile: HANDLE = INVALID_HANDLE_VALUE
         path.withCString(encodedAs: UTF16.self) { link in
             hFile = CreateFileW(link, GENERIC_READ, DWORD(FILE_SHARE_WRITE), nil, DWORD(OPEN_EXISTING), DWORD(FILE_FLAG_BACKUP_SEMANTICS), nil)

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -16,51 +16,6 @@
 #endif
 
 class TestFileManager : XCTestCase {
-    
-    static var allTests: [(String, (TestFileManager) -> () throws -> Void)] {
-        var tests: [(String, (TestFileManager) -> () throws -> Void)] = [
-            ("test_createDirectory", test_createDirectory ),
-            ("test_createFile", test_createFile ),
-            ("test_moveFile", test_moveFile),
-            ("test_fileSystemRepresentation", test_fileSystemRepresentation),
-            ("test_fileExists", test_fileExists),
-            ("test_isReadableFile", test_isReadableFile),
-            ("test_isWritableFile", test_isWritableFile),
-            ("test_isExecutableFile", test_isExecutableFile),
-            ("test_isDeletableFile", test_isDeletableFile),
-            ("test_fileAttributes", test_fileAttributes),
-            ("test_fileSystemAttributes", test_fileSystemAttributes),
-            ("test_setFileAttributes", test_setFileAttributes),
-            ("test_directoryEnumerator", test_directoryEnumerator),
-            ("test_pathEnumerator",test_pathEnumerator),
-            ("test_contentsOfDirectoryAtPath", test_contentsOfDirectoryAtPath),
-            ("test_subpathsOfDirectoryAtPath", test_subpathsOfDirectoryAtPath),
-            ("test_copyItemAtPathToPath", test_copyItemAtPathToPath),
-            ("test_linkItemAtPathToPath", test_linkItemAtPathToPath),
-            ("test_homedirectoryForUser", test_homedirectoryForUser),
-            ("test_temporaryDirectoryForUser", test_temporaryDirectoryForUser),
-            ("test_creatingDirectoryWithShortIntermediatePath", test_creatingDirectoryWithShortIntermediatePath),
-            ("test_mountedVolumeURLs", test_mountedVolumeURLs),
-            ("test_copyItemsPermissions", test_copyItemsPermissions),
-            ("test_emptyFilename", test_emptyFilename),
-        ]
-        
-#if !DEPLOYMENT_RUNTIME_OBJC && NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
-        tests.append(contentsOf: [
-            ("test_xdgStopgapsCoverAllConstants", test_xdgStopgapsCoverAllConstants),
-            ("test_parseXDGConfiguration", test_parseXDGConfiguration),
-            ("test_xdgURLSelection", test_xdgURLSelection),
-        ])
-#endif
-        
-#if !DEPLOYMENT_RUNTIME_OBJC
-        tests.append(contentsOf: [
-            ("test_fetchXDGPathsFromHelper", test_fetchXDGPathsFromHelper),
-        ])
-#endif
-        
-        return tests
-    }
 
     func test_createDirectory() {
         let fm = FileManager.default
@@ -1431,5 +1386,114 @@ VIDEOS=StopgapVideos
 
         // Not Implemented - XCTAssertNil(fm.componentsToDisplay(forPath: ""))
         // Not Implemented - XCTAssertEqual(fm.displayName(atPath: ""), "")
+    }
+    
+    func test_getRelationship() throws {
+        /* a/
+           a/b
+           a/bb
+           c -> symlink to a/b
+           d */
+        
+        let a        = writableTestDirectoryURL.appendingPathComponent("a")
+        let a_b      = a.appendingPathComponent("b")
+        let a_bb     = a.appendingPathComponent("bb")
+        let c        = writableTestDirectoryURL.appendingPathComponent("c")
+        let a_b_d    = a_b.appendingPathComponent("d")
+        
+        let fm = FileManager.default
+        try fm.createDirectory(at: a, withIntermediateDirectories: true)
+        try fm.createDirectory(at: a_b, withIntermediateDirectories: true)
+        try Data().write(to: a_bb)
+        try Data().write(to: c)
+        try fm.createSymbolicLink(at: a_b_d, withDestinationURL: a)
+        
+        var relationship: FileManager.URLRelationship = .other
+        
+        try fm.getRelationship(&relationship, ofDirectoryAt: writableTestDirectoryURL, toItemAt: a)
+        XCTAssertEqual(relationship, .contains)
+        
+        try fm.getRelationship(&relationship, ofDirectoryAt: a, toItemAt: a_b)
+        XCTAssertEqual(relationship, .contains)
+        
+        // The path of one is a prefix to the other, but lacks the directory separator.
+        try fm.getRelationship(&relationship, ofDirectoryAt: a_b, toItemAt: a_bb)
+        XCTAssertEqual(relationship, .other)
+        
+        try fm.getRelationship(&relationship, ofDirectoryAt: a_b, toItemAt: c)
+        XCTAssertEqual(relationship, .other)
+        
+        try fm.getRelationship(&relationship, ofDirectoryAt: a_b_d, toItemAt: a)
+        XCTAssertEqual(relationship, .same)
+    }
+    
+    // -----
+    
+    var writableTestDirectoryURL: URL!
+    
+    override func setUp() {
+        super.setUp()
+        
+        let pid = ProcessInfo.processInfo.processIdentifier
+        writableTestDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("org.swift.TestFoundation.TestFileManager.\(pid)")
+    }
+    
+    override func tearDown() {
+        if let directoryURL = writableTestDirectoryURL,
+           (try? FileManager.default.attributesOfItem(atPath: directoryURL.path)) != nil {
+            do {
+                try FileManager.default.removeItem(at: directoryURL)
+            } catch {
+                NSLog("Could not remove test directory at URL \(directoryURL): \(error)")
+            }
+        }
+        
+        super.tearDown()
+    }
+    
+    static var allTests: [(String, (TestFileManager) -> () throws -> Void)] {
+        var tests: [(String, (TestFileManager) -> () throws -> Void)] = [
+            ("test_createDirectory", test_createDirectory ),
+            ("test_createFile", test_createFile ),
+            ("test_moveFile", test_moveFile),
+            ("test_fileSystemRepresentation", test_fileSystemRepresentation),
+            ("test_fileExists", test_fileExists),
+            ("test_isReadableFile", test_isReadableFile),
+            ("test_isWritableFile", test_isWritableFile),
+            ("test_isExecutableFile", test_isExecutableFile),
+            ("test_isDeletableFile", test_isDeletableFile),
+            ("test_fileAttributes", test_fileAttributes),
+            ("test_fileSystemAttributes", test_fileSystemAttributes),
+            ("test_setFileAttributes", test_setFileAttributes),
+            ("test_directoryEnumerator", test_directoryEnumerator),
+            ("test_pathEnumerator",test_pathEnumerator),
+            ("test_contentsOfDirectoryAtPath", test_contentsOfDirectoryAtPath),
+            ("test_subpathsOfDirectoryAtPath", test_subpathsOfDirectoryAtPath),
+            ("test_copyItemAtPathToPath", test_copyItemAtPathToPath),
+            ("test_linkItemAtPathToPath", test_linkItemAtPathToPath),
+            ("test_homedirectoryForUser", test_homedirectoryForUser),
+            ("test_temporaryDirectoryForUser", test_temporaryDirectoryForUser),
+            ("test_creatingDirectoryWithShortIntermediatePath", test_creatingDirectoryWithShortIntermediatePath),
+            ("test_mountedVolumeURLs", test_mountedVolumeURLs),
+            ("test_copyItemsPermissions", test_copyItemsPermissions),
+            ("test_emptyFilename", test_emptyFilename),
+            ("test_getRelationship", test_getRelationship),
+        ]
+        
+        #if !DEPLOYMENT_RUNTIME_OBJC && NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+        tests.append(contentsOf: [
+            ("test_xdgStopgapsCoverAllConstants", test_xdgStopgapsCoverAllConstants),
+            ("test_parseXDGConfiguration", test_parseXDGConfiguration),
+            ("test_xdgURLSelection", test_xdgURLSelection),
+            ])
+        #endif
+        
+        #if !DEPLOYMENT_RUNTIME_OBJC
+        tests.append(contentsOf: [
+            ("test_fetchXDGPathsFromHelper", test_fetchXDGPathsFromHelper),
+            ])
+        #endif
+        
+        return tests
     }
 }


### PR DESCRIPTION
Implement in terms of canonicalized paths.