### PR TITLE
TestFoundation: add `-D_DLL` to the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,6 +473,7 @@ if(ENABLE_TESTING)
                          ${deployment_target}
                          ${deployment_enable_libdispatch}
                          -F${CMAKE_CURRENT_BINARY_DIR}
+                         -D_DLL
                        LINK_FLAGS
                          ${libdispatch_ldflags}
                          -L${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
Declare `_DLL` when building TestFoundation to ensure that the system
functions are imported correctly with the proper DLL storage.