### PR TITLE
SR-10525: Decimal(string:locale:) different results macOS vs Linux

### DIFF
--- a/TestFoundation/TestDecimal.swift
+++ b/TestFoundation/TestDecimal.swift
@@ -34,6 +34,7 @@ class TestDecimal: XCTestCase {
             ("test_doubleValue", test_doubleValue),
             ("test_NSDecimalNumberValues", test_NSDecimalNumberValues),
             ("test_bridging", test_bridging),
+            ("test_stringWithLocale", test_stringWithLocale),
         ]
     }
 
@@ -1052,5 +1053,56 @@ class TestDecimal: XCTestCase {
 
         // NSNumber does NOT bridge to Decimal
         XCTAssertNil(NSNumber(value: 1) as? Decimal)
+    }
+
+    func test_stringWithLocale() {
+
+        let en_US = Locale(identifier: "en_US")
+        let fr_FR = Locale(identifier: "fr_FR")
+
+        XCTAssertEqual(Decimal(string: "1,234.56")! * 1000, Decimal(1000))
+        XCTAssertEqual(Decimal(string: "1,234.56", locale: en_US)! * 1000, Decimal(1000))
+        XCTAssertEqual(Decimal(string: "1,234.56", locale: fr_FR)! * 1000, Decimal(1234))
+        XCTAssertEqual(Decimal(string: "1.234,56", locale: en_US)! * 1000, Decimal(1234))
+        XCTAssertEqual(Decimal(string: "1.234,56", locale: fr_FR)! * 1000, Decimal(1000))
+
+        XCTAssertEqual(Decimal(string: "-1,234.56")! * 1000, Decimal(-1000))
+        XCTAssertEqual(Decimal(string: "+1,234.56")! * 1000, Decimal(1000))
+        XCTAssertEqual(Decimal(string: "+1234.56e3"), Decimal(1234560))
+        XCTAssertEqual(Decimal(string: "+1234.56E3"), Decimal(1234560))
+        XCTAssertEqual(Decimal(string: "+123456000E-3"), Decimal(123456))
+
+        XCTAssertNil(Decimal(string: ""))
+        XCTAssertNil(Decimal(string: "x"))
+        XCTAssertEqual(Decimal(string: "-x"), Decimal.zero)
+        XCTAssertEqual(Decimal(string: "+x"), Decimal.zero)
+        XCTAssertEqual(Decimal(string: "-"), Decimal.zero)
+        XCTAssertEqual(Decimal(string: "+"), Decimal.zero)
+        XCTAssertEqual(Decimal(string: "-."), Decimal.zero)
+        XCTAssertEqual(Decimal(string: "+."), Decimal.zero)
+
+        XCTAssertEqual(Decimal(string: "-0"), Decimal.zero)
+        XCTAssertEqual(Decimal(string: "+0"), Decimal.zero)
+        XCTAssertEqual(Decimal(string: "-0."), Decimal.zero)
+        XCTAssertEqual(Decimal(string: "+0."), Decimal.zero)
+        XCTAssertEqual(Decimal(string: "e1"), Decimal.zero)
+        XCTAssertEqual(Decimal(string: "e-5"), Decimal.zero)
+        XCTAssertEqual(Decimal(string: ".3e1"), Decimal(3))
+
+        XCTAssertEqual(Decimal(string: "."), Decimal.zero)
+        XCTAssertEqual(Decimal(string: ".", locale: en_US), Decimal.zero)
+        XCTAssertNil(Decimal(string: ".", locale: fr_FR))
+
+        XCTAssertNil(Decimal(string: ","))
+        XCTAssertEqual(Decimal(string: ",", locale: fr_FR), Decimal.zero)
+        XCTAssertNil(Decimal(string: ",", locale: en_US))
+
+        let s1 = "1234.5678"
+        XCTAssertEqual(Decimal(string: s1, locale: en_US)?.description, s1)
+        XCTAssertEqual(Decimal(string: s1, locale: fr_FR)?.description, "1234")
+
+        let s2 = "1234,5678"
+        XCTAssertEqual(Decimal(string: s2, locale: en_US)?.description, "1234")
+        XCTAssertEqual(Decimal(string: s2, locale: fr_FR)?.description, s1)
     }
 }


### PR DESCRIPTION
- Decimal: Add support for the Locale in init(string:locale:)

- Update the Decimal scanner to match the Scanner helper functions.

- Add tests for compatibility with Darwin.