### PR TITLE
Foundation/CoreFoundation: repair bridging for `NSLocale`

### DIFF
--- a/CoreFoundation/Base.subproj/CFLocking.h
+++ b/CoreFoundation/Base.subproj/CFLocking.h
@@ -1,0 +1,106 @@
+/*	CFInternal.h
+	Copyright (c) 1998-2018, Apple Inc. and the Swift project authors
+
+	Portions Copyright (c) 2014-2018, Apple Inc. and the Swift project authors
+	Licensed under Apache License v2.0 with Runtime Library Exception
+	See http://swift.org/LICENSE.txt for license information
+	See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+*/
+
+/*
+        NOT TO BE USED OUTSIDE CF!
+*/
+
+#if !defined(__COREFOUNDATION_CFLOCKING_H__)
+#define __COREFOUNDATION_CFLOCKING_H__ 1
+
+#include <CoreFoundation/TargetConditionals.h>
+
+#if TARGET_OS_MAC
+
+#include <pthread.h>
+
+typedef pthread_mutex_t CFLock_t;
+
+#define CFLockInit ((pthread_mutex_t)PTHREAD_ERRORCHECK_MUTEX_INITIALIZER)
+#define CF_LOCK_INIT_FOR_STRUCTS(X) (X = CFLockInit)
+
+#define __CFLock(LP) ({ (void)pthread_mutex_lock(LP); })
+
+#define __CFUnlock(LP) ({ (void)pthread_mutex_unlock(LP); })
+
+#define __CFLockTry(LP) ({ pthread_mutex_trylock(LP) == 0; })
+
+// SPI to permit initialization of values in Swift
+static inline CFLock_t __CFLockInit(void) { return CFLockInit; }
+
+#elif TARGET_OS_WIN32
+
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+#define VCEXTRALEAN
+#include <Windows.h>
+
+typedef int32_t CFLock_t;
+#define CFLockInit 0
+#define CF_LOCK_INIT_FOR_STRUCTS(X) (X = CFLockInit)
+
+CF_INLINE void __CFLock(volatile CFLock_t *lock) {
+  while (InterlockedCompareExchange((LONG volatile *)lock, ~0, 0) != 0) {
+    Sleep(0);
+  }
+}
+
+CF_INLINE void __CFUnlock(volatile CFLock_t *lock) {
+  MemoryBarrier();
+  *lock = 0;
+}
+
+CF_INLINE Boolean __CFLockTry(volatile CFLock_t *lock) {
+  return (InterlockedCompareExchange((LONG volatile *)lock, ~0, 0) == 0);
+}
+
+// SPI to permit initialization of values in Swift
+static inline CFLock_t __CFLockInit(void) { return CFLockInit; }
+
+#elif TARGET_OS_LINUX || TARGET_OS_BSD
+
+#include <stdint.h>
+
+typedef int32_t CFLock_t;
+#define CFLockInit 0
+#define CF_LOCK_INIT_FOR_STRUCTS(X) (X = CFLockInit)
+
+CF_INLINE void __CFLock(volatile CFLock_t *lock) {
+  while (__sync_val_compare_and_swap(lock, 0, ~0) != 0) {
+    sleep(0);
+  }
+}
+
+CF_INLINE void __CFUnlock(volatile CFLock_t *lock) {
+  __sync_synchronize();
+  *lock = 0;
+}
+
+CF_INLINE Boolean __CFLockTry(volatile CFLock_t *lock) {
+  return (__sync_val_compare_and_swap(lock, 0, ~0) == 0);
+}
+
+// SPI to permit initialization of values in Swift
+static inline CFLock_t __CFLockInit(void) { return CFLockInit; }
+
+typedef CFLock_t OSSpinLock;
+#define OS_SPINLOCK_INIT CFLockInit
+#define OSSpinLockLock(lock) __CFLock(lock)
+#define OSSpinLockUnlock(lock) __CFUnlock(lock)
+
+#else
+
+#warning CF locks not defined for this platform -- CF is not thread-safe
+#define __CFLock(A)     do {} while (0)
+#define __CFUnlock(A)   do {} while (0)
+
+#endif
+
+#endif
+

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -17,6 +17,7 @@
 
 #include <CoreFoundation/CFBase.h>
 #include <CoreFoundation/CFNumber.h>
+#include <CoreFoundation/CFLocking.h>
 #include <CoreFoundation/CFLocaleInternal.h>
 #include <CoreFoundation/CFCalendar.h>
 #include <CoreFoundation/CFPriv.h>

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -127,6 +127,7 @@ add_framework(CoreFoundation
               PUBLIC_HEADERS
                 # FIXME: PrivateHeaders referenced by public headers
                 Base.subproj/CFKnownLocations.h
+                Base.subproj/CFLocking.h
                 Base.subproj/CFLogUtilities.h
                 Base.subproj/CFPriv.h
                 Base.subproj/CFRuntime.h

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -486,6 +486,7 @@
 		EADE0BCB1BD15E0000C49C64 /* XMLNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B8D1BD15DFF00C49C64 /* XMLNode.swift */; };
 		EADE0BCD1BD15E0000C49C64 /* XMLParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B8F1BD15DFF00C49C64 /* XMLParser.swift */; };
 		F03A43181D4877DD00A7791E /* CFAsmMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = F03A43161D48778200A7791E /* CFAsmMacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F085A1302283C5B700F909F9 /* CFLocking.h in Headers */ = {isa = PBXBuildFile; fileRef = F085A12E2283C50A00F909F9 /* CFLocking.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F9E0BB371CA70B8000F7FF3C /* TestURLCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E0BB361CA70B8000F7FF3C /* TestURLCredential.swift */; };
 /* End PBXBuildFile section */
 
@@ -1051,6 +1052,7 @@
 		EADE0B8D1BD15DFF00C49C64 /* XMLNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XMLNode.swift; sourceTree = "<group>"; };
 		EADE0B8F1BD15DFF00C49C64 /* XMLParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XMLParser.swift; sourceTree = "<group>"; };
 		F03A43161D48778200A7791E /* CFAsmMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFAsmMacros.h; sourceTree = "<group>"; };
+		F085A12E2283C50A00F909F9 /* CFLocking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFLocking.h; sourceTree = "<group>"; };
 		F9E0BB361CA70B8000F7FF3C /* TestURLCredential.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestURLCredential.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1176,6 +1178,7 @@
 		5B5D88711BBC951A00234F36 /* Base */ = {
 			isa = PBXGroup;
 			children = (
+				F085A12E2283C50A00F909F9 /* CFLocking.h */,
 				1578DA12212B4C35003C9516 /* CFOverflow.h */,
 				F03A43161D48778200A7791E /* CFAsmMacros.h */,
 				5BDC3F721BCC60EF00ED97BB /* module.map */,
@@ -2110,6 +2113,7 @@
 				5B7C8AF91BEA81AC00C5B690 /* CFStringEncodingDatabase.h in Headers */,
 				EA66F6361BEED03E00136161 /* TargetConditionals.h in Headers */,
 				1569BFAE2187D529009518FA /* CFDateComponents.h in Headers */,
+				F085A1302283C5B700F909F9 /* CFLocking.h in Headers */,
 				5B7C8B001BEA82ED00C5B690 /* CFRuntime.h in Headers */,
 				5BF9B7F31FABBDB900EE1A7C /* CFPropertyList_Private.h in Headers */,
 				5B7C8ABE1BEA807A00C5B690 /* CFByteOrder.h in Headers */,

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -12,17 +12,15 @@ import CoreFoundation
 
 open class NSLocale: NSObject, NSCopying, NSSecureCoding, _CFBridgeable {
     typealias CFType = CFLocale
+
+    // struct __CFLocale
     private var _base = _CFInfo(typeID: CFLocaleGetTypeID())
     private var _identifier: UnsafeMutableRawPointer? = nil
     private var _cache: UnsafeMutableRawPointer? = nil
     private var _prefs: UnsafeMutableRawPointer? = nil
-#if os(macOS) || os(iOS)
-    private var _lock = pthread_mutex_t()
-#elseif os(Linux) || os(Android) || CYGWIN
-    private var _lock = Int32(0)
-#endif
-    private var _nullLocale = false
-    
+    private var _lock: CFLock_t = __CFLockInit()
+    private var _nullLocale: Bool = false
+
     internal var _cfObject: CFType {
         return unsafeBitCast(self, to: CFType.self)
     }


### PR DESCRIPTION
`NSLocale` is toll-free bridged to `CFLocale`.  The types must match.
On many targets, the backing store for `_lock` was being elided as the
value was conditionally defined.

Extract the locking macros/types into a `CFLocking.h` and then include
that into `CFInternal.h` and `ForSwiftFoundationOnly.h`.  This allows
the underlying type information to be shared into Swift permitting the
`__CFLocale` type to be reconstructed without guessing as to the
underlying type.

This repairs the bridging of `NSLocale` on Windows and allows us to get
further in the test suite.