### PR TITLE
SR-10516: TimeZone.nextDaylightSavingTimeTransition does not return nil

### DIFF
--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -176,7 +176,9 @@ open class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
         guard type(of: self) === NSTimeZone.self else {
             NSRequiresConcreteImplementation()
         }
-        return Date(timeIntervalSinceReferenceDate: CFTimeZoneGetNextDaylightSavingTimeTransition(_cfObject, aDate.timeIntervalSinceReferenceDate))
+        let ti = CFTimeZoneGetNextDaylightSavingTimeTransition(_cfObject, aDate.timeIntervalSinceReferenceDate)
+        guard ti > 0 else { return nil }
+        return Date(timeIntervalSinceReferenceDate: ti)
     }
 
     open class var system: TimeZone {


### PR DESCRIPTION
- Check the result of CFTimeZoneGetNextDaylightSavingTimeTransition()
  as 0 indicates no time transition will occur.