### PR TITLE
Foundation/CoreFoundation: correctly link resources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,7 @@ add_swift_library(Foundation
                     $<$<PLATFORM_ID:Windows>:-lWS2_32>
                     $<$<PLATFORM_ID:Windows>:-liphlpapi>
                     $<$<PLATFORM_ID:Windows>:-lpathcch>
+                    $<$<PLATFORM_ID:Windows>:$<TARGET_OBJECTS:CoreFoundationResources>>
                   SWIFT_FLAGS
                     -DDEPLOYMENT_RUNTIME_SWIFT
                     ${deployment_enable_libdispatch}

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -205,7 +205,6 @@ add_framework(CoreFoundation
                 URL.subproj/CFURLAccess.h
                 URL.subproj/CFURLComponents.h
               SOURCES
-                $<$<PLATFORM_ID:Windows>:CoreFoundation.rc>
                 # Base
                 Base.subproj/CFBase.c
                 Base.subproj/CFFileUtilities.c
@@ -317,6 +316,14 @@ add_framework(CoreFoundation
                 URL.subproj/CFURLComponents_URIParser.c
                 URL.subproj/CFURLSessionInterface.c)
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  add_library(CoreFoundationResources OBJECT
+    CoreFoundation.rc)
+  if(BUILD_SHARED_LIBS)
+    target_link_libraries(CoreFoundation PRIVATE CoreFoundationResources)
+  else()
+    target_link_libraries(CoreFoundation INTERFACE CoreFoundationResources)
+  endif()
+
   # NOTE(compnerd) the WindowsOlsonMapping.plist and OlsonWindowsMapping.plist
   # are embedded Windows resources that we use to map the Windows timezone to
   # the Olson name.  Ensure that we rebuild on regeneration of the files.


### PR DESCRIPTION
If CoreFoundation is built statically, the resources will be dropped.
Instead, create an OBJECT library for CoreFoundationResources for the
Windows target.  This allows the resources to be incorporated into an
external consumer of CoreFoundation (i.e. Foundation).  This corrects
the resources handling for the timezone tests.