### PR TITLE
Un-XFAIL TestURL

### DIFF
--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -225,7 +225,7 @@ class TestURL : XCTestCase {
         
     }
     
-    static let gBaseTemporaryDirectoryPath = NSTemporaryDirectory()
+    static let gBaseTemporaryDirectoryPath = (NSTemporaryDirectory() as NSString).appendingPathComponent("org.swift.foundation.TestFoundation.TestURL.\(ProcessInfo.processInfo.processIdentifier)")
     static var gBaseCurrentWorkingDirectoryPath : String {
         return FileManager.default.currentDirectoryPath
     }
@@ -239,6 +239,19 @@ class TestURL : XCTestCase {
     static let gDirectoryExistsPath = gBaseTemporaryDirectoryPath + gDirectoryExistsName
     static let gDirectoryDoesNotExistPath = gBaseTemporaryDirectoryPath + gDirectoryDoesNotExistName
 
+    override class func tearDown() {
+        let path = TestURL.gBaseTemporaryDirectoryPath
+        if (try? FileManager.default.attributesOfItem(atPath: path)) != nil {
+            do {
+                try FileManager.default.removeItem(atPath: path)
+            } catch {
+                NSLog("Could not remove test directory at path \(path): \(error)")
+            }
+        }
+        
+        super.tearDown()
+    }
+    
     static func setup_test_paths() -> Bool {
         _ = FileManager.default.createFile(atPath: gFileExistsPath, contents: nil)
 
@@ -255,7 +268,7 @@ class TestURL : XCTestCase {
           try FileManager.default.createDirectory(atPath: gDirectoryExistsPath, withIntermediateDirectories: false)
         } catch {
             // The error code is a CocoaError
-            if (error as? NSError)?.code != CocoaError.fileNoSuchFile.rawValue {
+            if (error as? NSError)?.code != CocoaError.fileWriteFileExists.rawValue {
                 return false
             }
         }

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -80,7 +80,7 @@ var allTestCases = [
     testCase(TestNSTextCheckingResult.allTests),
     testCase(TestTimer.allTests),
     testCase(TestTimeZone.allTests),
-    /* ⚠️ */ // testCase(TestURL.allTests),
+    testCase(TestURL.allTests),
     testCase(TestURLComponents.allTests),
     testCase(TestURLCredential.allTests),
     testCase(TestURLProtectionSpace.allTests),
@@ -113,9 +113,5 @@ var allTestCases = [
     testCase(TestMeasurement.allTests),
     testCase(TestNSLock.allTests),
 ]
-
-appendTestCaseExpectedToFail("TestURL is not deleting its temporary directory correctly. https://bugs.swift.org/browse/SR-10538",
-                             TestURL.allTests,
-                             into: &allTestCases)
 
 XCTMain(allTestCases)


### PR DESCRIPTION
 - Ensure that the temporary directory has a unique name per run.
 - Fix error checking in `setup_test_paths()`