### PR TITLE
Ensure an unclosed handle gets closed

### DIFF
--- a/Foundation/FileManager+Win32.swift
+++ b/Foundation/FileManager+Win32.swift
@@ -287,6 +287,7 @@ extension FileManager {
         path.withCString(encodedAs: UTF16.self) { link in
             hFile = CreateFileW(link, GENERIC_READ, DWORD(FILE_SHARE_WRITE), nil, DWORD(OPEN_EXISTING), DWORD(FILE_FLAG_BACKUP_SEMANTICS), nil)
         }
+        defer { CloseHandle(hFile) }
         if hFile == INVALID_HANDLE_VALUE {
             throw _NSErrorWithWindowsError(GetLastError(), reading: true)
         }

--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -937,6 +937,7 @@ public struct FileAttributeType : RawRepresentable, Equatable, Hashable {
                       /*dwFlagsAndAttributes=*/DWORD(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS),
                       /*hTemplateFile=*/nil)
         }
+        defer { CloseHandle(fileHandle) }
         var tagInfo = FILE_ATTRIBUTE_TAG_INFO()
         guard 0 != GetFileInformationByHandleEx(fileHandle,
                                                 FileAttributeTagInfo,


### PR DESCRIPTION
I was a terrible, awful person in https://github.com/apple/swift-corelibs-foundation/pull/2164 and didn't cleanup my handles.

I also found another one while trying to figure out why calling things twice failed the second time.