### PR TITLE
[android] Enable locale test which actually works on Android.

### DIFF
--- a/TestFoundation/TestNSLocale.swift
+++ b/TestFoundation/TestNSLocale.swift
@@ -135,16 +135,12 @@ class TestNSLocale : XCTestCase {
     }
     
     func test_localeProperties(){
-#if os(Android)
-        XCTFail("Locale lookup unavailable on Android")
-#else
         let enUSID = "en_US"
         let locale = Locale(identifier: enUSID)
         XCTAssertEqual(String(describing: locale.languageCode!), "en")
         XCTAssertEqual(String(describing: locale.decimalSeparator!), ".")
         XCTAssertEqual(String(describing: locale.currencyCode!), "USD")
         XCTAssertEqual(String(describing: locale.collatorIdentifier!), enUSID)
-#endif
     }
 
 }


### PR DESCRIPTION
Maybe the test was disabled because ICU wasn't available then, but
currently the test simply works.

This should not affect Darwin or Linux in any way.