### PR TITLE
[android] Enable NumberFormatter test that actually works on Android.

### DIFF
--- a/TestFoundation/TestNumberFormatter.swift
+++ b/TestFoundation/TestNumberFormatter.swift
@@ -202,11 +202,9 @@ class TestNumberFormatter: XCTestCase {
         numberFormatter.plusSign = sign
         XCTAssertEqual(numberFormatter.plusSign, sign)
 
-#if !os(Android)
         let formattedString = numberFormatter.string(from: 420000000000000000)
         XCTAssertNotNil(formattedString)
         XCTAssertEqual(formattedString, "4.2E👍17")
-#endif
 
         // Verify a negative exponent does not have the 👍
         let noPlusString = numberFormatter.string(from: -0.420)


### PR DESCRIPTION
The original commit doesn't state why the test in particular was
disabled, but in my tests (AArch64), the test seems to work.

/cc @johnno1962 