### PR TITLE
Crash in URLSessionTask while handling non HTTPURLResponse

### DIFF
--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -570,8 +570,8 @@ extension _ProtocolClient : URLProtocolClient {
     func urlProtocolDidFinishLoading(_ protocol: URLProtocol) {
         guard let task = `protocol`.task else { fatalError() }
         guard let session = task.session as? URLSession else { fatalError() }
-        guard let response = task.response as? HTTPURLResponse else { fatalError("No response") }
-        if response.statusCode == 401 {
+        guard let urlResponse = task.response else { fatalError("No response") }
+        if let response = urlResponse as? HTTPURLResponse, response.statusCode == 401 {
             if let protectionSpace = createProtectionSpace(response) {
                 //TODO: Fetch and set proposed credentials if they exist
                 let authenticationChallenge = URLAuthenticationChallenge(protectionSpace: protectionSpace, proposedCredential: nil,


### PR DESCRIPTION
The current code in ```URLSessionTask.urlProtocolDidFinishLoading```   casts ```URLResponse``` to ```HTTPURLResponse```. and fails with ```FatatlError``` if the response is not cast-able to ```HTTURLResponse```