### PR TITLE
[5.0] NSStringAPI: perf: UTF8 String -> Data

### DIFF
--- a/Foundation/NSStringAPI.swift
+++ b/Foundation/NSStringAPI.swift
@@ -800,9 +800,14 @@ extension StringProtocol where Index == String.Index {
         using encoding: String.Encoding,
         allowLossyConversion: Bool = false
         ) -> Data? {
-        return _ns.data(
-            using: encoding.rawValue,
-            allowLossyConversion: allowLossyConversion)
+        switch encoding {
+        case .utf8:
+            return Data(self.utf8)
+        default:
+            return _ns.data(
+                using: encoding.rawValue,
+                allowLossyConversion: allowLossyConversion)
+        }
     }
 
     // @property NSString* decomposedStringWithCanonicalMapping;


### PR DESCRIPTION
Currently, str.data(using:allowLossyConversion:) always bridges via
NSString.

As String is now natively UTF-8 we can fastpath this conversion in the
case where the user requests UTF-8 encoding.

Port of
https://github.com/apple/swift/commit/a6fbc40e761f106cae7192288d920a17c7351669
from the overlay.

Backport of https://github.com/apple/swift-corelibs-foundation/commit/7704c94c212e76db4db1a718268e64c171a5e788.