### PR TITLE
[android] Enable tests for FileManager in Android.

### DIFF
--- a/Foundation/FileManager+POSIX.swift
+++ b/Foundation/FileManager+POSIX.swift
@@ -19,7 +19,7 @@ extension FileManager {
     internal func _mountedVolumeURLs(includingResourceValuesForKeys propertyKeys: [URLResourceKey]?, options: VolumeEnumerationOptions = []) -> [URL]? {
         var urls: [URL] = []
 
-#if os(Linux)
+#if os(Linux) || os(Android)
         guard let procMounts = try? String(contentsOfFile: "/proc/mounts", encoding: .utf8) else {
             return nil
         }

--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -399,16 +399,9 @@ open class FileManager : NSObject {
      
         This method replaces fileSystemAttributesAtPath:.
      */
- #if os(Android)
-    @available(*, unavailable, message: "Unsuppported on this platform")
-    open func attributesOfFileSystem(forPath path: String) throws -> [FileAttributeKey : Any] {
-        NSUnsupported()
-    }
- #else
     open func attributesOfFileSystem(forPath path: String) throws -> [FileAttributeKey : Any] {
         return try _attributesOfFileSystem(forPath: path)
     }
-#endif
 
     /* createSymbolicLinkAtPath:withDestination:error: returns YES if the symbolic link that point at 'destPath' was able to be created at the location specified by 'path'. If this method returns NO, the link was unable to be created and an NSError will be returned by reference in the 'error' parameter. This method does not traverse a terminal symlink.
 

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -348,7 +348,6 @@ class TestFileManager : XCTestCase {
     }
     
     func test_fileSystemAttributes() {
-#if !os(Android)
         let fm = FileManager.default
         let path = NSTemporaryDirectory()
         
@@ -379,7 +378,6 @@ class TestFileManager : XCTestCase {
         } catch {
             XCTFail("\(error)")
         }
-#endif
     }
     
     func test_setFileAttributes() {
@@ -1084,7 +1082,7 @@ class TestFileManager : XCTestCase {
         try testCopy()
     }
     
-#if !DEPLOYMENT_RUNTIME_OBJC // XDG tests require swift-corelibs-foundation
+#if !DEPLOYMENT_RUNTIME_OBJC && !os(Android) // XDG tests require swift-corelibs-foundation
     
     #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT // These are white box tests for the internals of XDG parsing:
     func test_xdgStopgapsCoverAllConstants() {
@@ -1201,16 +1199,9 @@ VIDEOS=StopgapVideos
     #endif // NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
     
     // This test below is a black box test, and does not require @testable import.
-    
-    enum TestError: Error {
-        case notImplementedOnThisPlatform
-    }
-    
+
+    #if !os(Android)
     func printPathByRunningHelper(withConfiguration config: String, method: String, identifier: String) throws -> String {
-        #if os(Android)
-            throw TestError.notImplementedOnThisPlatform
-        #endif
-        
         let uuid = UUID().uuidString
         let path = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("org.swift.Foundation.XDGTestHelper").appendingPathComponent(uuid)
         try FileManager.default.createDirectory(at: path, withIntermediateDirectories: true)
@@ -1268,6 +1259,7 @@ VIDEOS=StopgapVideos
         assertFetchingPath(withConfiguration: configuration, identifier: "pictures", yields: "\(prefix)/Pictures")
         assertFetchingPath(withConfiguration: configuration, identifier: "videos", yields: "\(prefix)/Videos")
     }
+    #endif // !os(Android)
 #endif // !DEPLOYMENT_RUNTIME_OBJC
 
     func test_emptyFilename() {
@@ -1565,7 +1557,7 @@ VIDEOS=StopgapVideos
             ("test_displayNames", test_displayNames),
         ]
         
-        #if !DEPLOYMENT_RUNTIME_OBJC && NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+        #if !DEPLOYMENT_RUNTIME_OBJC && NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT && !os(Android)
         tests.append(contentsOf: [
             ("test_xdgStopgapsCoverAllConstants", test_xdgStopgapsCoverAllConstants),
             ("test_parseXDGConfiguration", test_parseXDGConfiguration),
@@ -1573,7 +1565,7 @@ VIDEOS=StopgapVideos
             ])
         #endif
         
-        #if !DEPLOYMENT_RUNTIME_OBJC
+        #if !DEPLOYMENT_RUNTIME_OBJC && !os(Android)
         tests.append(contentsOf: [
             ("test_fetchXDGPathsFromHelper", test_fetchXDGPathsFromHelper),
             ])


### PR DESCRIPTION
Many tests were disabled in Android, but they actually work without
almost changes.

- Android uses /proc/mounts as Linux. Enabling that code path gives good
  results in Android.
- `attributesOfFileSystem` works on Android once glibc.modulemap
  includes the right headers (see apple/swift#24286).
- However, since Process is still not available in Android, the test
  that relies on xdgTestHelper tool will not work, and have been
  disabled (but instead of causing the test to fail, they are simply not
  run in Android, which probably will never conform to XDG).