### PR TITLE
Foundation: update for `BOOL` bridging

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -997,10 +997,7 @@ public struct FileAttributeType : RawRepresentable, Equatable, Hashable {
         }
         defer { CloseHandle(fileHandle) }
         var tagInfo = FILE_ATTRIBUTE_TAG_INFO()
-        guard 0 != GetFileInformationByHandleEx(fileHandle,
-                                                FileAttributeTagInfo,
-                                                &tagInfo,
-                                                DWORD(MemoryLayout<FILE_ATTRIBUTE_TAG_INFO>.size)) else {
+        guard GetFileInformationByHandleEx(fileHandle, FileAttributeTagInfo, &tagInfo, DWORD(MemoryLayout<FILE_ATTRIBUTE_TAG_INFO>.size)) else {
           self = .typeUnknown
           return
         }

--- a/Foundation/Host.swift
+++ b/Foundation/Host.swift
@@ -45,7 +45,7 @@ open class Host: NSObject {
         return "localhost"
       }
       defer { hostname.deallocate() }
-      guard GetComputerNameExA(ComputerNameDnsHostname, hostname, &dwLength) != FALSE else {
+      guard GetComputerNameExA(ComputerNameDnsHostname, hostname, &dwLength) else {
         return "localhost"
       }
       return String(cString: hostname)

--- a/Foundation/NSLock.swift
+++ b/Foundation/NSLock.swift
@@ -92,7 +92,7 @@ open class NSLock: NSObject, NSLocking {
 
     open func `try`() -> Bool {
 #if os(Windows)
-        return TryAcquireSRWLockExclusive(mutex) != FALSE
+        return TryAcquireSRWLockExclusive(mutex) != 0
 #else
         return pthread_mutex_trylock(mutex) == 0
 #endif
@@ -100,7 +100,7 @@ open class NSLock: NSObject, NSLocking {
     
     open func lock(before limit: Date) -> Bool {
 #if os(Windows)
-        if TryAcquireSRWLockExclusive(mutex) != FALSE {
+        if TryAcquireSRWLockExclusive(mutex) != 0 {
           return true
         }
 #else
@@ -287,7 +287,7 @@ open class NSRecursiveLock: NSObject, NSLocking {
     
     open func `try`() -> Bool {
 #if os(Windows)
-        return TryEnterCriticalSection(mutex) != FALSE
+        return TryEnterCriticalSection(mutex)
 #else
         return pthread_mutex_trylock(mutex) == 0
 #endif
@@ -295,7 +295,7 @@ open class NSRecursiveLock: NSObject, NSLocking {
     
     open func lock(before limit: Date) -> Bool {
 #if os(Windows)
-        if TryEnterCriticalSection(mutex) != FALSE {
+        if TryEnterCriticalSection(mutex) {
             return true
         }
 #else
@@ -370,8 +370,7 @@ open class NSCondition: NSObject, NSLocking {
 
     open func wait(until limit: Date) -> Bool {
 #if os(Windows)
-        return SleepConditionVariableSRW(cond, mutex, timeoutFrom(date: limit),
-                                         0) != FALSE
+        return SleepConditionVariableSRW(cond, mutex, timeoutFrom(date: limit), 0)
 #else
         guard var timeout = timeSpecFrom(date: limit) else {
             return false
@@ -450,7 +449,7 @@ private func timedLock(mutex: _MutexPointer, endTime: Date,
       SleepConditionVariableSRW(timeoutCond, timeoutMutex,
                                 timeoutFrom(date: endTime), 0)
       ReleaseSRWLockExclusive(timeoutMutex)
-      if TryAcquireSRWLockExclusive(mutex) != FALSE {
+      if TryAcquireSRWLockExclusive(mutex) != 0 {
         return true
       }
     } while timeoutFrom(date: endTime) != 0
@@ -465,7 +464,7 @@ private func timedLock(mutex: _RecursiveMutexPointer, endTime: Date,
       SleepConditionVariableSRW(timeoutCond, timeoutMutex,
                                 timeoutFrom(date: endTime), 0)
       ReleaseSRWLockExclusive(timeoutMutex)
-      if TryEnterCriticalSection(mutex) != FALSE {
+      if TryEnterCriticalSection(mutex) {
         return true
       }
     } while timeoutFrom(date: endTime) != 0

--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -474,11 +474,11 @@ open class Process: NSObject {
         try quoteWindowsCommandLine(command).withCString(encodedAs: UTF16.self) { wszCommandLine in
           try currentDirectoryURL.path.withCString(encodedAs: UTF16.self) { wszCurrentDirectory in
             try szEnvironment.withCString(encodedAs: UTF16.self) { wszEnvironment in
-              if CreateProcessW(nil, UnsafeMutablePointer<WCHAR>(mutating: wszCommandLine),
-                                nil, nil, TRUE,
-                                DWORD(CREATE_UNICODE_ENVIRONMENT), UnsafeMutableRawPointer(mutating: wszEnvironment),
-                                wszCurrentDirectory,
-                                &siStartupInfo, &piProcessInfo) == FALSE {
+              if !CreateProcessW(nil, UnsafeMutablePointer<WCHAR>(mutating: wszCommandLine),
+                                 nil, nil, true,
+                                 DWORD(CREATE_UNICODE_ENVIRONMENT), UnsafeMutableRawPointer(mutating: wszEnvironment),
+                                 wszCurrentDirectory,
+                                 &siStartupInfo, &piProcessInfo) {
                 throw NSError(domain: _NSWindowsErrorDomain, code: Int(GetLastError()))
               }
             }
@@ -486,7 +486,7 @@ open class Process: NSObject {
         }
 
         self.processHandle = piProcessInfo.hProcess
-        if CloseHandle(piProcessInfo.hThread) == FALSE {
+        if !CloseHandle(piProcessInfo.hThread) {
           throw NSError(domain: _NSWindowsErrorDomain, code: Int(GetLastError()))
         }
 

--- a/Foundation/Thread.swift
+++ b/Foundation/Thread.swift
@@ -105,14 +105,14 @@ open class Thread : NSObject {
 
     open class func sleep(until date: Date) {
 #if os(Windows)
-        var hTimer: HANDLE = CreateWaitableTimerW(nil, TRUE, nil)
+        var hTimer: HANDLE = CreateWaitableTimerW(nil, true, nil)
         // FIXME(compnerd) how to check that hTimer is not NULL?
         defer { CloseHandle(hTimer) }
 
         // the timeout is in 100ns units
         var liTimeout: LARGE_INTEGER =
             LARGE_INTEGER(QuadPart: LONGLONG(date.timeIntervalSinceReferenceDate) * -10000000)
-        if SetWaitableTimer(hTimer, &liTimeout, 0, nil, nil, FALSE) == FALSE {
+        if !SetWaitableTimer(hTimer, &liTimeout, 0, nil, nil, false) {
           return
         }
         WaitForSingleObject(hTimer, WinSDK.INFINITE)
@@ -142,14 +142,14 @@ open class Thread : NSObject {
 
     open class func sleep(forTimeInterval interval: TimeInterval) {
 #if os(Windows)
-        var hTimer: HANDLE = CreateWaitableTimerW(nil, TRUE, nil)
+        var hTimer: HANDLE = CreateWaitableTimerW(nil, true, nil)
         // FIXME(compnerd) how to check that hTimer is not NULL?
         defer { CloseHandle(hTimer) }
 
         // the timeout is in 100ns units
         var liTimeout: LARGE_INTEGER =
             LARGE_INTEGER(QuadPart: LONGLONG(interval) * -10000000)
-        if SetWaitableTimer(hTimer, &liTimeout, 0, nil, nil, FALSE) == FALSE {
+        if !SetWaitableTimer(hTimer, &liTimeout, 0, nil, nil, false) {
           return
         }
         WaitForSingleObject(hTimer, WinSDK.INFINITE)
@@ -362,7 +362,7 @@ open class Thread : NSObject {
 #elseif os(Windows)
         let hProcess: HANDLE = GetCurrentProcess()
         SymSetOptions(DWORD(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS))
-        if SymInitializeW(hProcess, nil, TRUE) == FALSE {
+        if !SymInitializeW(hProcess, nil, true) {
           return []
         }
         return backtraceAddresses { (addresses, count) in
@@ -380,9 +380,7 @@ open class Thread : NSObject {
             var address = addresses
             for _ in 1...count {
               var dwDisplacement: DWORD64 = 0
-              if SymFromAddr(hProcess, unsafeBitCast(address.pointee,
-                                                     to: DWORD64.self),
-                             &dwDisplacement, $0) == FALSE {
+              if !SymFromAddr(hProcess, unsafeBitCast(address.pointee, to: DWORD64.self), &dwDisplacement, $0) {
                 symbols.append("\($0.pointee)")
               } else {
                 symbols.append(String(cString: &$0.pointee.Name))

--- a/TestFoundation/HTTPServer.swift
+++ b/TestFoundation/HTTPServer.swift
@@ -86,7 +86,7 @@ class _TCPSocket {
 #if os(Windows)
         listenSocket = try attempt("WSASocketW", valid: { $0 != INVALID_SOCKET }, WSASocketW(AF_INET, SOCK_STREAM, IPPROTO_TCP.rawValue, nil, 0, 0))
 
-        var value: Int8 = Int8(TRUE)
+        var value: Int8 = 1
         _ = try attempt("setsockopt", valid: { $0 == 0 }, setsockopt(listenSocket, SOL_SOCKET, SO_REUSEADDR, &value, Int32(MemoryLayout.size(ofValue: value))))
 #else
 #if os(Linux) && !os(Android)


### PR DESCRIPTION
Now that `BOOL` is bridged to `WindowsBOOL` and `Bool`, clean up the
instances of `BOOL` values since they will no longer be available.