### PR TITLE
[android] Enable Thread tests were possible.

### DIFF
--- a/TestFoundation/TestThread.swift
+++ b/TestFoundation/TestThread.swift
@@ -21,17 +21,19 @@
 
 class TestThread : XCTestCase {
     static var allTests: [(String, (TestThread) -> () throws -> Void)] {
-#if os(Android)
-        return []
-#endif
-
         var tests: [(String, (TestThread) -> () throws -> Void)] = [
-            ("test_currentThread", test_currentThread ),
+            ("test_currentThread", test_currentThread),
             ("test_threadStart", test_threadStart),
             ("test_mainThread", test_mainThread),
-            ("test_callStackSymbols", test_callStackSymbols),
-            ("test_callStackReurnAddresses", test_callStackReturnAddresses),
         ]
+
+#if !os(Android)
+        // Android doesn't support backtraces at the moment.
+        tests.append(contentsOf: [
+            ("test_callStackSymbols", test_callStackSymbols),
+            ("test_callStackReturnAddresses", test_callStackReturnAddresses),
+        ])
+#endif
 
 #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
         tests.append(contentsOf: [
@@ -68,7 +70,7 @@ class TestThread : XCTestCase {
     
 #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
     func test_threadName() {
-#if os(Linux) // Linux sets the initial thread name to the process name.
+#if os(Linux) || os(Android) // Linux sets the initial thread name to the process name.
         XCTAssertEqual(Thread.current.name, "TestFoundation")
         XCTAssertEqual(Thread.current._name, "TestFoundation")
 #else
@@ -94,7 +96,7 @@ class TestThread : XCTestCase {
             XCTAssertEqual(Thread.current.name, "12345678901234567890")
 #if os(macOS) || os(iOS)
             XCTAssertEqual(Thread.current._name, Thread.current.name)
-#elseif os(Linux)
+#elseif os(Linux) || os(Android)
             // pthread_setname_np() only allows 15 characters on Linux, so setting it fails
             // and the previous name will still be there.
             XCTAssertEqual(Thread.current._name, "Thread2-2")


### PR DESCRIPTION
Enable most of the Thread test for Android. The only tests that cannot
pass right now are the ones related to backtraces, which do not use the
Linux API backtrace and would need an specific implementation.

And while Android did not get pthread_getname_np until API 26, the low
level prctl(PR_GET_NAME) works with the same restriction as in Linux
(only 15 characters). With that change, the test about thread names also
passes in Android.