### PR TITLE
[android] Removing explicit castings for unsigned integers.

### DIFF
--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -1237,41 +1237,37 @@ class TestNSNumber : XCTestCase {
     }
 
     func test_stringValue() {
-
-        // The following casts on subtraction are required for an Android compile
-        // https://bugs.swift.org/browse/SR-7469
-
         if UInt.max == UInt32.max {
             XCTAssertEqual(NSNumber(value: UInt.min).stringValue, "0")
             XCTAssertEqual(NSNumber(value: UInt.min + 1).stringValue, "1")
             XCTAssertEqual(NSNumber(value: UInt.max).stringValue, "4294967295")
-            XCTAssertEqual(NSNumber(value: UInt.max - 1 as UInt).stringValue, "4294967294")
+            XCTAssertEqual(NSNumber(value: UInt.max - 1).stringValue, "4294967294")
         } else if UInt.max == UInt64.max {
             XCTAssertEqual(NSNumber(value: UInt.min).stringValue, "0")
             XCTAssertEqual(NSNumber(value: UInt.min + 1).stringValue, "1")
             XCTAssertEqual(NSNumber(value: UInt.max).stringValue, "18446744073709551615")
-            XCTAssertEqual(NSNumber(value: UInt.max - 1 as UInt).stringValue, "18446744073709551614")
+            XCTAssertEqual(NSNumber(value: UInt.max - 1).stringValue, "18446744073709551614")
         }
 
         XCTAssertEqual(NSNumber(value: UInt8.min).stringValue, "0")
         XCTAssertEqual(NSNumber(value: UInt8.min + 1).stringValue, "1")
         XCTAssertEqual(NSNumber(value: UInt8.max).stringValue, "255")
-        XCTAssertEqual(NSNumber(value: UInt8.max - 1 as UInt8).stringValue, "254")
+        XCTAssertEqual(NSNumber(value: UInt8.max - 1).stringValue, "254")
 
         XCTAssertEqual(NSNumber(value: UInt16.min).stringValue, "0")
         XCTAssertEqual(NSNumber(value: UInt16.min + 1).stringValue, "1")
         XCTAssertEqual(NSNumber(value: UInt16.max).stringValue, "65535")
-        XCTAssertEqual(NSNumber(value: UInt16.max - 1 as UInt16).stringValue, "65534")
+        XCTAssertEqual(NSNumber(value: UInt16.max - 1).stringValue, "65534")
 
         XCTAssertEqual(NSNumber(value: UInt32.min).stringValue, "0")
         XCTAssertEqual(NSNumber(value: UInt32.min + 1).stringValue, "1")
         XCTAssertEqual(NSNumber(value: UInt32.max).stringValue, "4294967295")
-        XCTAssertEqual(NSNumber(value: UInt32.max - 1 as UInt32).stringValue, "4294967294")
+        XCTAssertEqual(NSNumber(value: UInt32.max - 1).stringValue, "4294967294")
 
         XCTAssertEqual(NSNumber(value: UInt64.min).stringValue, "0")
         XCTAssertEqual(NSNumber(value: UInt64.min + 1).stringValue, "1")
         XCTAssertEqual(NSNumber(value: UInt64.max).stringValue, "18446744073709551615")
-        XCTAssertEqual(NSNumber(value: UInt64.max - 1 as UInt64).stringValue, "18446744073709551614")
+        XCTAssertEqual(NSNumber(value: UInt64.max - 1).stringValue, "18446744073709551614")
 
         if Int.max == Int32.max {
             XCTAssertEqual(NSNumber(value: Int.min).stringValue, "-2147483648")


### PR DESCRIPTION
Fixes SR-7469.

Seems that the explicit castings are not longer needed in the current
tree compiling for Android.