### PR TITLE
Update from deprecated .withUnsafeBytes

### DIFF
--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -284,8 +284,9 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
             return false
         }
         
-        return other.withUnsafeBytes { (bytes2: UnsafePointer<UInt8>) -> Bool in
+        return other.withUnsafeBytes { (rawBuffer: UnsafeRawBufferPointer) -> Bool in
             let bytes1 = bytes
+            let bytes2 = rawBuffer.baseAddress!
             return memcmp(bytes1, bytes2, length) == 0
         }
     }
@@ -980,8 +981,9 @@ open class NSMutableData : NSData {
     /// Appends the content of another data object to the data object.
     open func append(_ other: Data) {
         let otherLength = other.count
-        other.withUnsafeBytes {
-            append($0, length: otherLength)
+        other.withUnsafeBytes { (rawBuffer: UnsafeRawBufferPointer) in
+            let bytes = rawBuffer.baseAddress!
+            append(bytes, length: otherLength)
         }
     }
 
@@ -1012,8 +1014,9 @@ open class NSMutableData : NSData {
     /// Replaces the entire contents of the data object with the contents of another data object.
     open func setData(_ data: Data) {
         length = data.count
-        data.withUnsafeBytes {
-            replaceBytes(in: NSRange(location: 0, length: length), withBytes: $0)
+        data.withUnsafeBytes { (rawBuffer: UnsafeRawBufferPointer) in
+            let bytes = rawBuffer.baseAddress!
+            replaceBytes(in: NSRange(location: 0, length: length), withBytes: bytes)
         }
     }
 

--- a/Sources/Foundation/NSKeyedUnarchiver.swift
+++ b/Sources/Foundation/NSKeyedUnarchiver.swift
@@ -770,8 +770,9 @@ open class NSKeyedUnarchiver : NSCoder {
     open override func withDecodedUnsafeBufferPointer<ResultType>(forKey key: String, body: (UnsafeBufferPointer<UInt8>?) throws -> ResultType) rethrows -> ResultType {
         let ns : Data? = _decodeValue(forKey: key)
         if let value = ns {
-            return try value.withUnsafeBytes {
-                try body(UnsafeBufferPointer(start: $0, count: value.count))
+            return try value.withUnsafeBytes { (rawBuffer: UnsafeRawBufferPointer) -> ResultType in
+                let ptr = rawBuffer.baseAddress!.assumingMemoryBound(to: UInt8.self)
+                return try body(UnsafeBufferPointer(start: ptr, count: value.count))
             }
         } else {
             return try body(nil)

--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -395,7 +395,8 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
         super.init()
         
         // _CFURLInitWithURLString does not fail if checkForLegalCharacters == false
-        data.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> Void in
+        data.withUnsafeBytes { (rawBuffer: UnsafeRawBufferPointer) -> Void in
+            let ptr = rawBuffer.baseAddress!.assumingMemoryBound(to: UInt8.self)
             if let str = CFStringCreateWithBytes(kCFAllocatorSystemDefault, ptr, data.count, CFStringEncoding(kCFStringEncodingUTF8), false) {
                 _CFURLInitWithURLString(_cfObject, str, false, baseURL?._cfObject)
             } else if let str = CFStringCreateWithBytes(kCFAllocatorSystemDefault, ptr, data.count, CFStringEncoding(kCFStringEncodingISOLatin1), false) {
@@ -404,14 +405,13 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
                 fatalError()
             }
         }
-        
-        
     }
     
     public init(absoluteURLWithDataRepresentation data: Data, relativeTo baseURL: URL?) {
         super.init()
         
-        data.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> Void in
+        data.withUnsafeBytes { (rawBuffer: UnsafeRawBufferPointer) -> Void in
+            let ptr = rawBuffer.baseAddress!.assumingMemoryBound(to: UInt8.self)
             if _CFURLInitAbsoluteURLWithBytes(_cfObject, ptr, data.count, CFStringEncoding(kCFStringEncodingUTF8), baseURL?._cfObject) {
                 return
             }

--- a/Tests/Foundation/FTPServer.swift
+++ b/Tests/Foundation/FTPServer.swift
@@ -117,14 +117,16 @@ class _FTPSocket {
     }
 
     func writeRawData(_ data: Data) throws {
-        _ = try data.withUnsafeBytes { ptr in
-            try attempt("write", valid: isNotMinusOne, CInt(write(connectionSocket, ptr, data.count)))
+        _ = try data.withUnsafeBytes { (rawBuffer: UnsafeRawBufferPointer) in
+            let ptr = rawBuffer.baseAddress
+            _ = try attempt("write", valid: isNotMinusOne, CInt(write(connectionSocket, ptr, data.count)))
         }
     }
 
     func writeRawData(socket data: Data) throws -> Int32 {
         var bytesWritten: Int32 = 0
-        _ = try data.withUnsafeBytes { ptr in
+        _ = try data.withUnsafeBytes { (rawBuffer: UnsafeRawBufferPointer) in
+            let ptr = rawBuffer.baseAddress
             bytesWritten = try attempt("write", valid: isNotMinusOne, CInt(write(dataSocket, ptr, data.count)))
         }
         return bytesWritten


### PR DESCRIPTION
- use `withUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) rethrows -> R` instead