### PR TITLE
SR-10565: Process crashes when setting standardOutput = FileHandle.nullDevice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,11 +81,13 @@ endif()
 if(CMAKE_SYSTEM_NAME STREQUAL Android OR CMAKE_SYSTEM_NAME STREQUAL Linux)
   set(deployment_target -DDEPLOYMENT_TARGET_LINUX)
   set(Foundation_RPATH -Xlinker;-rpath;-Xlinker;"\\\$\$ORIGIN")
+  set(XDG_TEST_HELPER_RPATH -Xlinker;-rpath;-Xlinker;${CMAKE_CURRENT_BINARY_DIR})
 elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   set(deployment_target -DDEPLOYMENT_TARGET_MACOSX)
 elseif(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
   set(deployment_target -DDEPLOYMENT_TARGET_FREEBSD)
   set(Foundation_RPATH -Xlinker;-rpath;-Xlinker;"\\\$\$ORIGIN")
+  set(XDG_TEST_HELPER_RPATH -Xlinker;-rpath;-Xlinker;${CMAKE_CURRENT_BINARY_DIR})
 elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
   set(deployment_target -DDEPLOYMENT_TARGET_WINDOWS)
   # FIXME(SR9138) Silence "locally defined symbol '…' imported in function '…'
@@ -399,6 +401,7 @@ if(ENABLE_TESTING)
                          -lFoundation
                          ${Foundation_INTERFACE_LIBRARIES}
                          ${WORKAROUND_SR9995}
+                         ${XDG_TEST_HELPER_RPATH}
                        SOURCES
                          TestFoundation/xdgTestHelper/main.swift
                        SWIFT_FLAGS

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -38,6 +38,7 @@ class TestProcess : XCTestCase {
                    ("test_redirect_stdin_stdout_using_null", test_redirect_stdin_stdout_using_null),
                    ("test_redirect_stderr_using_null", test_redirect_stderr_using_null),
                    ("test_redirect_all_using_null", test_redirect_all_using_null),
+                   ("test_redirect_all_using_nil", test_redirect_all_using_nil),
         ]
 #endif
     }
@@ -559,6 +560,17 @@ class TestProcess : XCTestCase {
         task.standardInput = FileHandle.nullDevice
         task.standardOutput = FileHandle.nullDevice
         task.standardError = FileHandle.nullDevice
+        XCTAssertNoThrow(try task.run())
+        task.waitUntilExit()
+    }
+
+    func test_redirect_all_using_nil() throws {
+        let url = URL(fileURLWithPath: "/bin/cat", isDirectory: false)
+        let task = Process()
+        task.executableURL = url
+        task.standardInput = nil
+        task.standardOutput = nil
+        task.standardError = nil
         XCTAssertNoThrow(try task.run())
         task.waitUntilExit()
     }

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -33,6 +33,11 @@ class TestProcess : XCTestCase {
                    ("test_interrupt", test_interrupt),
                    ("test_terminate", test_terminate),
                    ("test_suspend_resume", test_suspend_resume),
+                   ("test_redirect_stdin_using_null", test_redirect_stdin_using_null),
+                   ("test_redirect_stdout_using_null", test_redirect_stdout_using_null),
+                   ("test_redirect_stdin_stdout_using_null", test_redirect_stdin_stdout_using_null),
+                   ("test_redirect_stderr_using_null", test_redirect_stderr_using_null),
+                   ("test_redirect_all_using_null", test_redirect_all_using_null),
         ]
 #endif
     }
@@ -286,7 +291,7 @@ class TestProcess : XCTestCase {
     }
 
     func test_current_working_directory() {
-        let tmpDir = "/tmp".standardizingPath
+        let tmpDir = "/tmp" //.standardizingPath
 
         let fm = FileManager.default
         let previousWorkingDirectory = fm.currentDirectoryPath
@@ -451,6 +456,7 @@ class TestProcess : XCTestCase {
         XCTAssertEqual(process.terminationStatus, SIGTERM)
     }
 
+
     func test_suspend_resume() {
         let helper = _SignalHelperRunner()
         do {
@@ -505,6 +511,57 @@ class TestProcess : XCTestCase {
         XCTAssertTrue(helper.process.resume())
     }
 
+
+    func test_redirect_stdin_using_null() {
+        let url = URL(fileURLWithPath: "/bin/cat", isDirectory: false)
+        let task = Process()
+        task.executableURL = url
+        task.standardInput = FileHandle.nullDevice
+        XCTAssertNoThrow(try task.run())
+        task.waitUntilExit()
+    }
+
+
+    func test_redirect_stdout_using_null() {
+        let url = URL(fileURLWithPath: "/usr/bin/env", isDirectory: false)
+        let task = Process()
+        task.executableURL = url
+        task.standardOutput = FileHandle.nullDevice
+        XCTAssertNoThrow(try task.run())
+        task.waitUntilExit()
+    }
+
+    func test_redirect_stdin_stdout_using_null() {
+        let url = URL(fileURLWithPath: "/bin/cat", isDirectory: false)
+        let task = Process()
+        task.executableURL = url
+        task.standardInput = FileHandle.nullDevice
+        task.standardOutput = FileHandle.nullDevice
+        XCTAssertNoThrow(try task.run())
+        task.waitUntilExit()
+    }
+
+
+    func test_redirect_stderr_using_null() throws {
+        let url = URL(fileURLWithPath: "/usr/bin/env", isDirectory: false)
+        let task = Process()
+        task.executableURL = url
+        task.standardError = FileHandle.nullDevice
+        XCTAssertNoThrow(try task.run())
+        task.waitUntilExit()
+    }
+
+
+    func test_redirect_all_using_null() throws {
+        let url = URL(fileURLWithPath: "/bin/cat", isDirectory: false)
+        let task = Process()
+        task.executableURL = url
+        task.standardInput = FileHandle.nullDevice
+        task.standardOutput = FileHandle.nullDevice
+        task.standardError = FileHandle.nullDevice
+        XCTAssertNoThrow(try task.run())
+        task.waitUntilExit()
+    }
 #endif
 }
 


### PR DESCRIPTION
- If .standardInput, .standardOutput or .standardError are set to
  FileHandle.nullDevice then dup the filedescriptor to '/dev/null'.

Fixes https://bugs.swift.org/browse/SR-10564 and https://bugs.swift.org/browse/SR-10566