### PR TITLE
Foundation: remove stale NYI

### DIFF
--- a/Foundation/FileManager+Win32.swift
+++ b/Foundation/FileManager+Win32.swift
@@ -401,7 +401,6 @@ extension FileManager {
         }
     }
 
-    @available(Windows, deprecated, message: "Not Yet Implemented")
     internal func _removeItem(atPath path: String, isURL: Bool, alreadyConfirmed: Bool = false) throws {
         guard alreadyConfirmed || shouldRemoveItemAtPath(path, isURL: isURL) else {
             return


### PR DESCRIPTION
This removes the attribute on a function which is now implemented.