### PR TITLE
TestFoundation: disable a couple of FileManager tests on Win32

### DIFF
--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -366,15 +366,16 @@ class TestFileManager : XCTestCase {
             let systemSize = attrs[.systemSize] as? NSNumber
             XCTAssertNotNil(systemSize)
             XCTAssertGreaterThan(systemSize!.uint64Value, systemFreeSize!.uint64Value)
-            
-            let systemFreeNodes = attrs[.systemFreeNodes] as? NSNumber
-            XCTAssertNotNil(systemFreeNodes)
-            XCTAssertNotEqual(systemFreeNodes!.uint64Value, 0)
-            
-            let systemNodes = attrs[.systemNodes] as? NSNumber
-            XCTAssertNotNil(systemNodes)
-            XCTAssertGreaterThan(systemNodes!.uint64Value, systemFreeNodes!.uint64Value)
-            
+
+            if shouldAttemptWindowsXFailTests("FileAttributes[.systemFreeNodes], FileAttributes[.systemNodes] not implemented") {
+              let systemFreeNodes = attrs[.systemFreeNodes] as? NSNumber
+              XCTAssertNotNil(systemFreeNodes)
+              XCTAssertNotEqual(systemFreeNodes!.uint64Value, 0)
+
+              let systemNodes = attrs[.systemNodes] as? NSNumber
+              XCTAssertNotNil(systemNodes)
+              XCTAssertGreaterThan(systemNodes!.uint64Value, systemFreeNodes!.uint64Value)
+            }
         } catch {
             XCTFail("\(error)")
         }

--- a/TestFoundation/Utilities.swift
+++ b/TestFoundation/Utilities.swift
@@ -497,6 +497,17 @@ func shouldAttemptXFailTests(_ reason: String) -> Bool {
     }
 }
 
+func shouldAttemptWindowsXFailTests(_ reason: String) -> Bool {
+  var isOSWindows: Bool = false
+#if os(Windows)
+  isOSWindows = true
+#endif
+
+  if !isOSWindows || shouldRunXFailTests { return true }
+  try? FileHandle.standardError.write(contentsOf: Data("warning: Skipping test expected to fail with reason '\(reason)'\n".utf8))
+  return false
+}
+
 func appendTestCaseExpectedToFail<T: XCTestCase>(_ reason: String, _ allTests: [(String, (T) -> () throws -> Void)], into array: inout [XCTestCaseEntry]) {
     if shouldAttemptXFailTests(reason) {
         array.append(testCase(allTests))


### PR DESCRIPTION
The FileManager implementation currently does not provide some
attributes.  Disable the tests on Windows.