### PR TITLE
Avoid unnecessary calls to stat within NSURLDirectoryEnumerator

### DIFF
--- a/Foundation/FileManager+POSIX.swift
+++ b/Foundation/FileManager+POSIX.swift
@@ -1099,13 +1099,13 @@ internal func _contentsEqual(atPath path1: String, andPath path2: String) -> Boo
                                 fts_set(_stream, _current, FTS_SKIP)
                             }
                             if showFile {
-                                 return URL(fileURLWithPath: filename)
+                                 return URL(fileURLWithPath: filename, isDirectory: true)
                             }
 
                         case FTS_DEFAULT, FTS_F, FTS_NSOK, FTS_SL, FTS_SLNONE:
                             let (showFile, _) = match(filename: filename, to: _options, isDir: false)
                             if showFile {
-                                return URL(fileURLWithPath: filename)
+                                return URL(fileURLWithPath: filename, isDirectory: false)
                             }
                         case FTS_DNR, FTS_ERR, FTS_NS:
                             let keepGoing: Bool

--- a/Foundation/FileManager+POSIX.swift
+++ b/Foundation/FileManager+POSIX.swift
@@ -686,7 +686,7 @@ extension FileManager {
                 let ps = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>.allocate(capacity: 2)
                 ps.initialize(to: UnsafeMutablePointer(mutating: fsRep))
                 ps.advanced(by: 1).initialize(to: nil)
-                let stream = fts_open(ps, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR, nil)
+                let stream = fts_open(ps, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR | FTS_NOSTAT, nil)
                 ps.deinitialize(count: 2)
                 ps.deallocate()
 
@@ -1043,7 +1043,7 @@ internal func _contentsEqual(atPath path1: String, andPath path2: String) -> Boo
                     defer { ps.deallocate() }
                     ps.initialize(to: UnsafeMutablePointer(mutating: fsRep))
                     ps.advanced(by: 1).initialize(to: nil)
-                    return fts_open(ps, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR, nil)
+                    return fts_open(ps, FTS_PHYSICAL | FTS_XDEV | FTS_NOCHDIR | FTS_NOSTAT, nil)
                 }
                 if _stream == nil {
                     throw _NSErrorWithErrno(errno, reading: true, url: url)


### PR DESCRIPTION
`fts_read` calls `stat` internally to determine the type of each file that is visited. If `URL(fileURLWithPath:)` is called with a path that doesn't end with a slash, it calls `stat` to determine whether the path represents a file or a directory. The `FTSENT`'s `fts_info` field tells us whether the entry represents a file or a directory, so we can instead use `URL(fileURLWithPath:isDirectory:)` and avoid the second `stat`.

Additionally, the `FTS_NOSTAT` flag indicates to `fts_read` that the caller is not interested in the `fts_statp` field of the `FTSENT` structure, allowing `fts_read` to skip calling `stat` in some circumstances.

These two changes reduce the runtime of `FileManager.enumerator(at:includingPropertiesForKeys:options:errorHandler:)` by around 55%.