### PR TITLE
Foundation: allow failure in attribute query

### DIFF
--- a/Foundation/FileManager+Win32.swift
+++ b/Foundation/FileManager+Win32.swift
@@ -406,7 +406,7 @@ extension FileManager {
         guard alreadyConfirmed || shouldRemoveItemAtPath(path, isURL: isURL) else {
             return
         }
-        let faAttributes = try! windowsFileAttributes(atPath: path)
+        let faAttributes = try windowsFileAttributes(atPath: path)
         if faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY) == 0 {
             if !path.withCString(encodedAs: UTF16.self, DeleteFileW) {
                 throw _NSErrorWithWindowsError(GetLastError(), reading: false)


### PR DESCRIPTION
The path being removed may not exist.  Permit the `attributes(of:)` to
fail and propagate the exception.