### PR TITLE
CoreFoundation: correct an over-release in `CFTimeZone`

### DIFF
--- a/CoreFoundation/NumberDate.subproj/CFTimeZone.c
+++ b/CoreFoundation/NumberDate.subproj/CFTimeZone.c
@@ -1125,7 +1125,6 @@ Boolean _CFTimeZoneInit(CFTimeZoneRef timeZone, CFStringRef name, CFDataRef data
     if (tzName) {
         int32_t offset;
         __CFTimeZoneGetOffset(tzName, &offset);
-        CFRelease(tzName);
         // TODO(compnerd) handle DST
         __CFTimeZoneInitFixed(timeZone, offset, name, 0);
         return TRUE;
@@ -1328,7 +1327,6 @@ CFTimeZoneRef CFTimeZoneCreateWithName(CFAllocatorRef allocator, CFStringRef nam
     if (tzName) {
         int32_t offset;
         __CFTimeZoneGetOffset(tzName, &offset);
-        CFRelease(tzName);
         // TODO(compnerd) handle DST
         result = __CFTimeZoneCreateFixed(allocator, offset, name, 0);
     }


### PR DESCRIPTION
We would release a value obtained through a `CFDictionaryGetValue` which
would result in the value being over-released as the returned object is
returned at `+0`.  This fixes the use-after-free on Windows.

Thanks to Gwynne Raskind for identifying the mismanagement of the retain
counts!