### PR TITLE
CoreFoundation: fix a rare, possible race on Windows

### DIFF
--- a/CoreFoundation/NumberDate.subproj/CFTimeZone.c
+++ b/CoreFoundation/NumberDate.subproj/CFTimeZone.c
@@ -551,9 +551,9 @@ CFDictionaryRef CFTimeZoneCopyWinToOlsonDictionary(void) {
     if (NULL == __CFTimeZoneWinToOlsonDict) {
         __CFTimeZoneWinToOlsonDict = CFDictionaryCreate(kCFAllocatorSystemDefault, NULL, NULL, 0, NULL, NULL);
     }
+    dict = __CFTimeZoneWinToOlsonDict ? (CFDictionaryRef)CFRetain(__CFTimeZoneWinToOlsonDict) : NULL;
     __CFTimeZoneUnlockWinToOlson();
 
-    dict = __CFTimeZoneWinToOlsonDict ? (CFDictionaryRef)CFRetain(__CFTimeZoneWinToOlsonDict) : NULL;
     return dict;
 }
 
@@ -581,9 +581,9 @@ void CFTimeZoneSetWinToOlsonDictionary(CFDictionaryRef dict) {
     __CFGenericValidateType(dict, CFDictionaryGetTypeID());
     __CFTimeZoneLockWinToOlson();
     if (dict != __CFTimeZoneWinToOlsonDict) {
-        if (dict) CFRetain(dict);
-        if (__CFTimeZoneWinToOlsonDict) CFRelease(__CFTimeZoneWinToOlsonDict);
-        __CFTimeZoneWinToOlsonDict = dict;
+        CFDictionaryRef oldDict = __CFTimeZoneWinToOlsonDict;
+        __CFTimeZoneWinToOlsonDict = dict ? CFRetain(dict) : NULL;
+        CFRelease(oldDict);
     }
     __CFTimeZoneUnlockWinToOlson();
 }


### PR DESCRIPTION
It is in theory possible to hit a race condition with the CFTimeZone
PLIST loading as there was a small window where the object was accessed
unsynchronised.  Although unlikely, protect against it anyways.

Thread A                               | Thread B
CFTimeZoneCopyWinToOlsonDictionary()   |
  Lock                                 |
    __CFTimeZoneWinToOlsonDict != NULL |
  Unlock                               |
                                       |   CFTimeZoneSetWinToOlsonDictionary()
                                       |     Lock
                                       |       retain new dictionary
                                       |       release old dictionary
  retains "old" (invalid) dictionary   |
                                       |       swap
                                       |     Unlock