### PR TITLE
CoreFoundation: optimize TimeZone PLIST loading on Windows

### DIFF
--- a/CoreFoundation/NumberDate.subproj/CFTimeZone.c
+++ b/CoreFoundation/NumberDate.subproj/CFTimeZone.c
@@ -567,7 +567,7 @@ static CFDictionaryRef CFTimeZoneCopyOlsonToWindowsDictionary(void) {
       DWORD dwSize;
 
       if (CFTimeZoneLoadPlistResource(MAKEINTRESOURCEA(IDR_OLSON_WINDOWS_MAPPING), (LPVOID *)&plist, &dwSize)) {
-          CFDataRef data = CFDataCreate(kCFAllocatorSystemDefault, plist, dwSize);
+          CFDataRef data = CFDataCreateWithBytesNoCopy(kCFAllocatorSystemDefault, plist, dwSize, kCFAllocatorNull);
           dict = CFPropertyListCreateFromXMLData(kCFAllocatorSystemDefault, data, kCFPropertyListImmutable, NULL);
           CFRelease(data);
       }


### PR DESCRIPTION
Use `CFDataCreateWithBytesNoCopy` to avoid the memory copy for the
construction of the `CFData`.

Thanks to Gwynne Raskind for educating me on the fact that
`CFDataCreate` will actually perform a copy which I was trying to avoid.