### PR TITLE
[SR-10574] Add tests for new Japanese calendar era name

### DIFF
--- a/Tests/Foundation/Tests/TestCalendar.swift
+++ b/Tests/Foundation/Tests/TestCalendar.swift
@@ -111,6 +111,31 @@ class TestCalendar: XCTestCase {
         XCTAssertEqual(components.day, 18)
 
     }
+    
+    func test_gettingDatesOnJapaneseCalendar() throws {
+        var calendar = Calendar(identifier: .japanese)
+        calendar.timeZone = try XCTUnwrap( TimeZone(identifier: "UTC") )
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        
+        do {
+            let date = Date(timeIntervalSince1970: 1556633400) // April 30, 2019
+            let components = calendar.dateComponents([.era, .year, .month, .day], from: date)
+            XCTAssertEqual(calendar.eraSymbols[try XCTUnwrap(components.era)], "Heisei")
+            XCTAssertEqual(components.year, 31)
+            XCTAssertEqual(components.month, 4)
+            XCTAssertEqual(components.day, 30)
+        }
+        
+        // Test for new Japanese calendar era (starting from May 1, 2019)
+        do {
+            let date = Date(timeIntervalSince1970: 1556719800) // May 1, 2019
+            let components = calendar.dateComponents([.era, .year, .month, .day], from: date)
+            XCTAssertEqual(calendar.eraSymbols[try XCTUnwrap(components.era)], "Reiwa")
+            XCTAssertEqual(components.year, 1)
+            XCTAssertEqual(components.month, 5)
+            XCTAssertEqual(components.day, 1)
+        }
+    }
 
     func test_ampmSymbols() {
         let calendar = Calendar(identifier: .gregorian)
@@ -249,6 +274,7 @@ class TestCalendar: XCTestCase {
             ("test_gettingDatesOnChineseCalendar", test_gettingDatesOnChineseCalendar),
             ("test_gettingDatesOnISO8601Calendar", test_gettingDatesOnISO8601Calendar),
             ("test_gettingDatesOnPersianCalendar", test_gettingDatesOnPersianCalendar),
+            ("test_gettingDatesOnJapaneseCalendar", test_gettingDatesOnJapaneseCalendar),
             ("test_copy",test_copy),
             ("test_addingDates", test_addingDates),
             ("test_datesNotOnWeekend", test_datesNotOnWeekend),

--- a/Tests/Foundation/Tests/TestDateFormatter.swift
+++ b/Tests/Foundation/Tests/TestDateFormatter.swift
@@ -430,16 +430,33 @@ class TestDateFormatter: XCTestCase {
         
         formatter.locale = Locale(identifier: "ja_JP")
         formatter.calendar = Calendar(identifier: .japanese)
-        formatter.dateFormat = "Gy年M月dd日 HH:mm"
+        formatter.dateFormat = "Gy年M月d日 HH:mm"
         formatter.timeZone = TimeZone(abbreviation: "JST")
         
-        // parse test
-        let parsed = formatter.date(from: "平成31年4月30日 23:10")
-        XCTAssertEqual(parsed?.timeIntervalSince1970, 1556633400) // April 30, 2019, 11:10 PM (JST)
+        do {
+            // Parse test
+            let parsed = formatter.date(from: "平成31年4月30日 23:10")
+            XCTAssertEqual(parsed?.timeIntervalSince1970, 1556633400) // April 30, 2019, 11:10 PM (JST)
+            
+            // Format test
+            let dateString = formatter.string(from: Date(timeIntervalSince1970: 1556633400)) // April 30, 2019, 11:10 PM (JST)
+            XCTAssertEqual(dateString, "平成31年4月30日 23:10")
+        }
         
-        // format test
-        let dateString = formatter.string(from: Date(timeIntervalSince1970: 1556633400)) // April 30, 2019, 11:10 PM (JST)
-        XCTAssertEqual(dateString, "平成31年4月30日 23:10")
+        // Test for new Japanese era (starting from May 1, 2019)
+        do {
+            // Parse test
+            let parsed = formatter.date(from: "令和1年5月1日 23:10")
+            XCTAssertEqual(parsed?.timeIntervalSince1970, 1556719800) // May 1st, 2019, 11:10 PM (JST)
+            
+            // Test for 元年(Gannen) representaion of 1st year
+            let parsedAlt = formatter.date(from: "令和元年5月1日 23:10")
+            XCTAssertEqual(parsedAlt?.timeIntervalSince1970, 1556719800) // May 1st, 2019, 11:10 PM (JST)
+
+            // Format test
+            let dateString = formatter.string(from: Date(timeIntervalSince1970: 1556719800)) // May 1st, 2019, 11:10 PM (JST)
+            XCTAssertEqual(dateString, "令和元年5月1日 23:10")
+        }
     }
 
     func test_orderOfPropertySetters() throws {


### PR DESCRIPTION
- Add Calendar test
- Add DateFormatter test


Test Calendar and DateFormatter with new era name ([SR-10574](https://bugs.swift.org/browse/SR-10574)).
Related https://github.com/apple/swift/pull/24387.