### PR TITLE
Parity: NSDictionary: Shared key sets

### DIFF
--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -669,7 +669,12 @@ extension NSDictionary : Sequence {
 
 // MARK - Shared Key Sets
 
+// We implement this as a shim for now. It is legal to call these methods and the behavior of the resulting NSDictionary will match Darwin's; however, the performance characteristics will be unmodified for the returned dictionary vs. a NSMutableDictionary created without a shared key set.
+// SR-XXXX.
+
 extension NSDictionary {
+    
+    static let sharedKeySetPlaceholder = NSObject()
     
     /*  Use this method to create a key set to pass to +dictionaryWithSharedKeySet:.
     The keys are copied from the array and must be copyable.
@@ -679,7 +684,9 @@ extension NSDictionary {
     As for any usage of hashing, is recommended that the keys have a well-distributed implementation of -hash, and the hash codes must satisfy the hash/isEqual: invariant.
     Keys with duplicate hash codes are allowed, but will cause lower performance and increase memory usage.
     */
-    open class func sharedKeySet(forKeys keys: [NSCopying]) -> Any { NSUnimplemented() }
+    open class func sharedKeySet(forKeys keys: [NSCopying]) -> Any {
+        return sharedKeySetPlaceholder
+    }
 }
 
 extension NSMutableDictionary {
@@ -690,7 +697,10 @@ extension NSMutableDictionary {
     If keyset is nil, an exception is thrown.
     If keyset is not an object returned by +sharedKeySetForKeys:, an exception is thrown.
     */
-    public convenience init(sharedKeySet keyset: Any) { NSUnimplemented() }
+    public convenience init(sharedKeySet keyset: Any) {
+        precondition(keyset as? NSObject == NSDictionary.sharedKeySetPlaceholder)
+        self.init()
+    }
 }
 
 extension NSDictionary: CustomReflectable {

--- a/TestFoundation/TestNSDictionary.swift
+++ b/TestFoundation/TestNSDictionary.swift
@@ -8,24 +8,6 @@
 //
 
 class TestNSDictionary : XCTestCase {
-    
-    static var allTests: [(String, (TestNSDictionary) -> () throws -> Void)] {
-        return [
-            ("test_BasicConstruction", test_BasicConstruction),
-            ("test_ArrayConstruction", test_ArrayConstruction),
-            ("test_description", test_description),
-            ("test_enumeration", test_enumeration),
-            ("test_equality", test_equality),
-            ("test_copying", test_copying),
-            ("test_mutableCopying", test_mutableCopying),
-            ("test_writeToFile", test_writeToFile),
-            ("test_initWithContentsOfFile", test_initWithContentsOfFile),
-            ("test_settingWithStringKey", test_settingWithStringKey),
-            ("test_valueForKey", test_valueForKey),
-            ("test_valueForKeyWithNestedDict", test_valueForKeyWithNestedDict),
-        ]
-    }
-        
     func test_BasicConstruction() {
         let dict = NSDictionary()
         let dict2: NSDictionary = ["foo": "bar"]
@@ -252,4 +234,42 @@ class TestNSDictionary : XCTestCase {
         try? FileManager.default.removeItem(atPath: location)
     }
 
+    func test_sharedKeySets() {
+        let keys: [NSCopying] = [ "a" as NSString, "b" as NSString, 1 as NSNumber, 2 as NSNumber ]
+        let keySet = NSDictionary.sharedKeySet(forKeys: keys)
+        
+        let dictionary = NSMutableDictionary(sharedKeySet: keySet)
+        dictionary["a" as NSString] = "w"
+        XCTAssertEqual(dictionary["a" as NSString] as? String, "w")
+        dictionary["b" as NSString] = "x"
+        XCTAssertEqual(dictionary["b" as NSString] as? String, "x")
+        dictionary[1 as NSNumber] = "y"
+        XCTAssertEqual(dictionary[1 as NSNumber] as? String, "y")
+        dictionary[2 as NSNumber] = "z"
+        XCTAssertEqual(dictionary[2 as NSNumber] as? String, "z")
+        
+        // Keys not in the key set must be supported.
+        dictionary["c" as NSString] = "h"
+        XCTAssertEqual(dictionary["c" as NSString] as? String, "h")
+        dictionary[3 as NSNumber] = "k"
+        XCTAssertEqual(dictionary[3 as NSNumber] as? String, "k")
+    }
+    
+    static var allTests: [(String, (TestNSDictionary) -> () throws -> Void)] {
+        return [
+            ("test_BasicConstruction", test_BasicConstruction),
+            ("test_ArrayConstruction", test_ArrayConstruction),
+            ("test_description", test_description),
+            ("test_enumeration", test_enumeration),
+            ("test_equality", test_equality),
+            ("test_copying", test_copying),
+            ("test_mutableCopying", test_mutableCopying),
+            ("test_writeToFile", test_writeToFile),
+            ("test_initWithContentsOfFile", test_initWithContentsOfFile),
+            ("test_settingWithStringKey", test_settingWithStringKey),
+            ("test_valueForKey", test_valueForKey),
+            ("test_valueForKeyWithNestedDict", test_valueForKeyWithNestedDict),
+            ("test_sharedKeySets", test_sharedKeySets),
+        ]
+    }
 }


### PR DESCRIPTION
Shim these out for this release. This technically obeys all parts of the contract, modulo obviously the performance increase.

Fixes https://bugs.swift.org/browse/SR-10397