### PR TITLE
Foundation: avoid unsafe allocations

### DIFF
--- a/Foundation/FileManager+Win32.swift
+++ b/Foundation/FileManager+Win32.swift
@@ -27,35 +27,33 @@ extension FileManager {
     internal func _mountedVolumeURLs(includingResourceValuesForKeys propertyKeys: [URLResourceKey]?, options: VolumeEnumerationOptions = []) -> [URL]? {
         var urls: [URL] = []
 
-        var wszVolumeName: UnsafeMutableBufferPointer<WCHAR> = UnsafeMutableBufferPointer<WCHAR>.allocate(capacity: Int(MAX_PATH))
-        defer { wszVolumeName.deallocate() }
+        var wszVolumeName: [WCHAR] = Array<WCHAR>(repeating: 0, count: Int(MAX_PATH))
 
-        var hVolumes: HANDLE = FindFirstVolumeW(wszVolumeName.baseAddress, DWORD(wszVolumeName.count))
+        var hVolumes: HANDLE = FindFirstVolumeW(&wszVolumeName, DWORD(wszVolumeName.count))
         guard hVolumes != INVALID_HANDLE_VALUE else { return nil }
         defer { FindVolumeClose(hVolumes) }
 
         repeat {
             var dwCChReturnLength: DWORD = 0
-            GetVolumePathNamesForVolumeNameW(wszVolumeName.baseAddress, nil, 0, &dwCChReturnLength)
+            GetVolumePathNamesForVolumeNameW(&wszVolumeName, nil, 0, &dwCChReturnLength)
 
-            var wszPathNames: UnsafeMutableBufferPointer<WCHAR> = UnsafeMutableBufferPointer<WCHAR>.allocate(capacity: Int(dwCChReturnLength + 1))
-            defer { wszPathNames.deallocate() }
-
-            if !GetVolumePathNamesForVolumeNameW(wszVolumeName.baseAddress, wszPathNames.baseAddress, DWORD(wszPathNames.count), &dwCChReturnLength) {
+            var wszPathNames: [WCHAR] = Array<WCHAR>(repeating: 0, count: Int(dwCChReturnLength + 1))
+            if !GetVolumePathNamesForVolumeNameW(&wszVolumeName, &wszPathNames, DWORD(wszPathNames.count), &dwCChReturnLength) {
                 // TODO(compnerd) handle error
                 continue
             }
 
             var pPath: DWORD = 0
             repeat {
-                let path: String = String(decodingCString: wszPathNames.baseAddress! + Int(pPath), as: UTF16.self)
+                let path: String = String(decodingCString: &wszPathNames[Int(pPath)], as: UTF16.self)
                 if path.length == 0 {
                     break
                 }
                 urls.append(URL(fileURLWithPath: path, isDirectory: true))
                 pPath += DWORD(path.length + 1)
             } while pPath < dwCChReturnLength
-        } while FindNextVolumeW(hVolumes, wszVolumeName.baseAddress, DWORD(wszVolumeName.count))
+        } while FindNextVolumeW(hVolumes, &wszVolumeName, DWORD(wszVolumeName.count))
+
         return urls
     }
     internal func _urls(for directory: SearchPathDirectory, in domainMask: SearchPathDomainMask) -> [URL] {
@@ -241,17 +239,16 @@ extension FileManager {
 
         try path.withCString(encodedAs: UTF16.self) {
             let dwLength: DWORD = GetFullPathNameW($0, 0, nil, nil)
-            let szVolumePath: UnsafeMutableBufferPointer<WCHAR> = UnsafeMutableBufferPointer<WCHAR>.allocate(capacity: Int(dwLength + 1))
-            defer { szVolumePath.deallocate() }
+            var szVolumePath: [WCHAR] = Array<WCHAR>(repeating: 0, count: Int(dwLength + 1))
 
-            guard GetVolumePathNameW($0, szVolumePath.baseAddress, dwLength) else {
+            guard GetVolumePathNameW($0, &szVolumePath, dwLength) else {
                 throw _NSErrorWithWindowsError(GetLastError(), reading: true)
             }
 
             var liTotal: ULARGE_INTEGER = ULARGE_INTEGER()
             var liFree: ULARGE_INTEGER = ULARGE_INTEGER()
 
-            guard GetDiskFreeSpaceExW(szVolumePath.baseAddress, nil, &liTotal, &liFree) else {
+            guard GetDiskFreeSpaceExW(&szVolumePath, nil, &liTotal, &liFree) else {
                 throw _NSErrorWithWindowsError(GetLastError(), reading: true)
             }
 
@@ -293,11 +290,10 @@ extension FileManager {
         }
 
         let dwLength: DWORD = GetFinalPathNameByHandleW(hFile, nil, 0, DWORD(FILE_NAME_NORMALIZED))
-        let szPath: UnsafeMutableBufferPointer<WCHAR> = UnsafeMutableBufferPointer<WCHAR>.allocate(capacity: Int(dwLength + 1))
-        defer { szPath.deallocate() }
+        var szPath: [WCHAR] = Array<WCHAR>(repeating: 0, count: Int(dwLength + 1))
 
-        GetFinalPathNameByHandleW(hFile, szPath.baseAddress, dwLength, DWORD(FILE_NAME_NORMALIZED))
-        return String(decodingCString: szPath.baseAddress!, as: UTF16.self)
+        GetFinalPathNameByHandleW(hFile, &szPath, dwLength, DWORD(FILE_NAME_NORMALIZED))
+        return String(decodingCString: &szPath, as: UTF16.self)
     }
 
     internal func _copyRegularFile(atPath srcPath: String, toPath dstPath: String, variant: String = "Copy") throws {
@@ -465,11 +461,10 @@ extension FileManager {
 
     internal func _currentDirectoryPath() -> String {
         let dwLength: DWORD = GetCurrentDirectoryW(0, nil)
-        var szDirectory: UnsafeMutableBufferPointer<WCHAR> = UnsafeMutableBufferPointer.allocate(capacity: Int(dwLength + 1))
-        defer { szDirectory.deallocate() }
+        var szDirectory: [WCHAR] = Array<WCHAR>(repeating: 0, count: Int(dwLength + 1))
 
-        GetCurrentDirectoryW(dwLength, szDirectory.baseAddress)
-        return String(decodingCString: szDirectory.baseAddress!, as: UTF16.self)
+        GetCurrentDirectoryW(dwLength, &szDirectory)
+        return String(decodingCString: &szDirectory, as: UTF16.self)
     }
 
     @discardableResult

--- a/Foundation/Host.swift
+++ b/Foundation/Host.swift
@@ -105,9 +105,7 @@ open class Host: NSObject {
 
         ulResult = GetAdaptersAddresses(ULONG(AF_UNSPEC), 0, nil, arAdapterInfo, &ulSize)
 
-        var buffer: UnsafeMutablePointer<WCHAR> =
-            UnsafeMutablePointer<WCHAR>.allocate(capacity: Int(NI_MAXHOST))
-        defer { buffer.deallocate() }
+        var buffer: [WCHAR] = Array<WCHAR>(repeating: 0, count: Int(NI_MAXHOST))
 
         var arCurrentAdapterInfo: UnsafeMutablePointer<IP_ADAPTER_ADDRESSES>? =
           arAdapterInfo
@@ -120,9 +118,9 @@ open class Host: NSObject {
             case ADDRESS_FAMILY(AF_INET), ADDRESS_FAMILY(AF_INET6):
               if GetNameInfoW(arCurrentAddress.Address.lpSockaddr,
                               arCurrentAddress.Address.iSockaddrLength,
-                              buffer, DWORD(NI_MAXHOST),
+                              &buffer, DWORD(NI_MAXHOST),
                               nil, 0, NI_NUMERICHOST) == 0 {
-                _addresses.append(String(decodingCString: buffer,
+                _addresses.append(String(decodingCString: &buffer,
                                          as: UTF16.self))
               }
             default: break
@@ -190,9 +188,7 @@ open class Host: NSObject {
           guard bSucceeded == true else { return }
           defer { FreeAddrInfoW(aiResult) }
 
-          let wszHostName =
-              UnsafeMutablePointer<WCHAR>.allocate(capacity: Int(NI_MAXHOST))
-          defer { wszHostName.deallocate() }
+          var wszHostName: [WCHAR] = Array<WCHAR>(repeating: 0, count: Int(NI_MAXHOST))
 
           while aiResult != nil {
             let aiInfo: ADDRINFOW = aiResult!.pointee
@@ -209,9 +205,9 @@ open class Host: NSObject {
             }
 
             let lookup = { (content: inout [String], flags: Int32) in
-              if GetNameInfoW(aiInfo.ai_addr, sa_len, wszHostName,
+              if GetNameInfoW(aiInfo.ai_addr, sa_len, &wszHostName,
                               DWORD(NI_MAXHOST), nil, 0, flags) == 0 {
-                content.append(String(decodingCString: wszHostName,
+                content.append(String(decodingCString: &wszHostName,
                                       as: UTF16.self))
               }
             }


### PR DESCRIPTION
Replace unsafe mutable pointer allocations for strings, opting to use
arrays.  This avoids unnecessary raw malloc/free handling.