### PR TITLE
[gardening] Switch non mutated vars into lets.

### DIFF
--- a/TestFoundation/TestIndexPath.swift
+++ b/TestFoundation/TestIndexPath.swift
@@ -721,16 +721,16 @@ class TestIndexPath: XCTestCase {
         let ip1: IndexPath = IndexPath._unconditionallyBridgeFromObjectiveC(nsip1)
         XCTAssertEqual(ip1.count, 0)
         
-        var ip2: IndexPath = IndexPath._unconditionallyBridgeFromObjectiveC(nsip2)
+        let ip2: IndexPath = IndexPath._unconditionallyBridgeFromObjectiveC(nsip2)
         XCTAssertEqual(ip2.count, 1)
         XCTAssertEqual(ip2[0], 1)
         
-        var ip3: IndexPath = IndexPath._unconditionallyBridgeFromObjectiveC(nsip3)
+        let ip3: IndexPath = IndexPath._unconditionallyBridgeFromObjectiveC(nsip3)
         XCTAssertEqual(ip3.count, 2)
         XCTAssertEqual(ip3[0], 1)
         XCTAssertEqual(ip3[1], 2)
         
-        var ip4: IndexPath = IndexPath._unconditionallyBridgeFromObjectiveC(nsip4)
+        let ip4: IndexPath = IndexPath._unconditionallyBridgeFromObjectiveC(nsip4)
         XCTAssertEqual(ip4.count, 3)
         XCTAssertEqual(ip4[0], 1)
         XCTAssertEqual(ip4[1], 2)

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -1293,7 +1293,7 @@ extension TestNSData {
     
     func testCopyBytes_undersized() {
         let a : [UInt8] = [1, 2, 3, 4, 5]
-        var data = a.withUnsafeBufferPointer {
+        let data = a.withUnsafeBufferPointer {
             return Data(buffer: $0)
         }
         let expectedSize = MemoryLayout<UInt8>.stride * a.count
@@ -1318,7 +1318,7 @@ extension TestNSData {
     
     func testCopyBytes_oversized() {
         let a : [Int32] = [1, 0, 1, 0, 1]
-        var data = a.withUnsafeBufferPointer {
+        let data = a.withUnsafeBufferPointer {
             return Data(buffer: $0)
         }
         let expectedSize = MemoryLayout<Int32>.stride * a.count
@@ -1339,7 +1339,7 @@ extension TestNSData {
         do {
             // Equal sized buffer, data
             let a : [UInt8] = [1, 2, 3, 4, 5]
-            var data = a.withUnsafeBufferPointer {
+            let data = a.withUnsafeBufferPointer {
                 return Data(buffer: $0)
             }
 
@@ -4333,7 +4333,7 @@ extension TestNSData {
     }
 
     func test_dropFirst() {
-        var data = Data([0, 1, 2, 3, 4, 5])
+        let data = Data([0, 1, 2, 3, 4, 5])
         let sliced = data.dropFirst()
         XCTAssertEqual(data.count - 1, sliced.count)
         XCTAssertEqual(UInt8(1), sliced[1])
@@ -4344,7 +4344,7 @@ extension TestNSData {
     }
 
     func test_dropFirst2() {
-        var data = Data([0, 1, 2, 3, 4, 5])
+        let data = Data([0, 1, 2, 3, 4, 5])
         let sliced = data.dropFirst(2)
         XCTAssertEqual(data.count - 2, sliced.count)
         XCTAssertEqual(UInt8(2), sliced[2])
@@ -4355,7 +4355,7 @@ extension TestNSData {
 
     func test_copyBytes1() {
         var array: [UInt8] = [0, 1, 2, 3]
-        var data = Data(array)
+        let data = Data(array)
 
         array.withUnsafeMutableBufferPointer {
             data[1..<3].copyBytes(to: $0.baseAddress!, from: 1..<3)
@@ -4365,7 +4365,7 @@ extension TestNSData {
 
     func test_copyBytes2() {
         let array: [UInt8] = [0, 1, 2, 3]
-        var data = Data(array)
+        let data = Data(array)
 
         let expectedSlice = array[1..<3]
 

--- a/TestFoundation/TestStream.swift
+++ b/TestFoundation/TestStream.swift
@@ -201,7 +201,7 @@ class TestStream : XCTestCase {
 
         let outputStream = OutputStream(toFileAtPath: filePath, append: true)
         XCTAssertEqual(.notOpen, outputStream!.streamStatus)
-        var myString = "Hello world!"
+        let myString = "Hello world!"
         let encodedData = [UInt8](myString.utf8)
         outputStream?.open()
         XCTAssertEqual(.open, outputStream!.streamStatus)
@@ -214,7 +214,7 @@ class TestStream : XCTestCase {
     
     func  test_outputStreamCreationToBuffer() {
         var buffer = Array<UInt8>(repeating: 0, count: 12)
-        var myString = "Hello world!"
+        let myString = "Hello world!"
         let encodedData = [UInt8](myString.utf8)
         let outputStream = OutputStream(toBuffer: UnsafeMutablePointer(mutating: buffer), capacity: 12)
         XCTAssertEqual(.notOpen, outputStream.streamStatus)
@@ -235,7 +235,7 @@ class TestStream : XCTestCase {
 
         let outputStream = OutputStream(url: URL(fileURLWithPath: filePath), append: true)
         XCTAssertEqual(.notOpen, outputStream!.streamStatus)
-        var myString = "Hello world!"
+        let myString = "Hello world!"
         let encodedData = [UInt8](myString.utf8)
         outputStream!.open()
         XCTAssertEqual(.open, outputStream!.streamStatus)
@@ -248,7 +248,7 @@ class TestStream : XCTestCase {
     
     func test_outputStreamCreationToMemory(){
         var buffer = Array<UInt8>(repeating: 0, count: 12)
-        var myString = "Hello world!"
+        let myString = "Hello world!"
         let encodedData = [UInt8](myString.utf8)
         let outputStream = OutputStream.toMemory()
         XCTAssertEqual(.notOpen, outputStream.streamStatus)
@@ -269,7 +269,7 @@ class TestStream : XCTestCase {
 
     func test_outputStreamHasSpaceAvailable() {
         let buffer = Array<UInt8>(repeating: 0, count: 12)
-        var myString = "Welcome To Hello world  !"
+        let myString = "Welcome To Hello world  !"
         let encodedData = [UInt8](myString.utf8)
         let outputStream = OutputStream(toBuffer: UnsafeMutablePointer(mutating: buffer), capacity: 12)
         outputStream.open()


### PR DESCRIPTION
The mutability is not necessary in any of these cases, according to the
compiler.

Should remove a lot of warnings while compiling the tests.