### PR TITLE
[gardening] Remove conditional casts from Error to NSError.

### DIFF
--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -1321,81 +1321,81 @@ VIDEOS=StopgapVideos
         XCTAssertNil(NSHomeDirectoryForUser(""))
 
         XCTAssertThrowsError(try fm.contentsOfDirectory(atPath: "")) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
 
         XCTAssertNil(fm.enumerator(atPath: ""))
         XCTAssertNil(fm.subpaths(atPath: ""))
         XCTAssertThrowsError(try fm.subpathsOfDirectory(atPath: "")) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
 
         XCTAssertThrowsError(try fm.createDirectory(atPath: "", withIntermediateDirectories: true)) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
         XCTAssertFalse(fm.createFile(atPath: "", contents: Data()))
         XCTAssertThrowsError(try fm.removeItem(atPath: "")) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
 
         XCTAssertThrowsError(try fm.copyItem(atPath: "", toPath: "/tmp/t"))  {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
         XCTAssertThrowsError(try fm.copyItem(atPath: "", toPath: ""))  {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
         XCTAssertThrowsError(try fm.copyItem(atPath: "/tmp/t", toPath: "")) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadNoSuchFile)
         }
 
         XCTAssertThrowsError(try fm.moveItem(atPath: "", toPath: "/tmp/t")) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
         XCTAssertThrowsError(try fm.moveItem(atPath: "", toPath: "")) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
         XCTAssertThrowsError(try fm.moveItem(atPath: "/tmp/t", toPath: "")) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
 
         XCTAssertThrowsError(try fm.linkItem(atPath: "", toPath: "/tmp/t")) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
         XCTAssertThrowsError(try fm.linkItem(atPath: "", toPath: "")) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
         XCTAssertThrowsError(try fm.linkItem(atPath: "/tmp/t", toPath: "")) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadNoSuchFile)
         }
 
         XCTAssertThrowsError(try fm.createSymbolicLink(atPath: "", withDestinationPath: "")) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
         XCTAssertThrowsError(try fm.createSymbolicLink(atPath: "", withDestinationPath: "/tmp/t")) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
         XCTAssertThrowsError(try fm.createSymbolicLink(atPath: "/tmp/t", withDestinationPath: "")) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
 
         XCTAssertThrowsError(try fm.destinationOfSymbolicLink(atPath: "")) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
         XCTAssertFalse(fm.fileExists(atPath: ""))
@@ -1406,15 +1406,15 @@ VIDEOS=StopgapVideos
         XCTAssertTrue(fm.isDeletableFile(atPath: ""))
 
         XCTAssertThrowsError(try fm.attributesOfItem(atPath: "")) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
         XCTAssertThrowsError(try fm.attributesOfFileSystem(forPath: "")) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
         XCTAssertThrowsError(try fm.setAttributes([:], ofItemAtPath: "")) {
-            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            let code = CocoaError.Code(rawValue: $0.asNSError().code)
             XCTAssertEqual(code, .fileReadInvalidFileName)
         }
 

--- a/TestFoundation/TestNSError.swift
+++ b/TestFoundation/TestNSError.swift
@@ -46,7 +46,7 @@ class TestNSError : XCTestCase {
         let nsdictionary = ["error": error] as NSDictionary
         let dictionary = nsdictionary as? Dictionary<String, Error>
         XCTAssertNotNil(dictionary)
-        XCTAssertEqual(error, dictionary?["error"] as? NSError)
+        XCTAssertEqual(error, dictionary?["error"]?.asNSError())
     }
 
     func test_CustomNSError_domain() {
@@ -94,14 +94,11 @@ class TestNSError : XCTestCase {
     func test_errorConvenience() {
         let error = CocoaError.error(.fileReadNoSuchFile, url: URL(fileURLWithPath: #file))
 
-        if let nsError = error as? NSError {
-            XCTAssertEqual(nsError._domain, NSCocoaErrorDomain)
-            XCTAssertEqual(nsError._code, CocoaError.fileReadNoSuchFile.rawValue)
-            if let filePath = nsError.userInfo[NSURLErrorKey] as? URL {
-                XCTAssertEqual(filePath, URL(fileURLWithPath: #file))
-            } else {
-                XCTFail()
-            }
+        let nsError = error.asNSError()
+        XCTAssertEqual(nsError.domain, NSCocoaErrorDomain)
+        XCTAssertEqual(nsError.code, CocoaError.fileReadNoSuchFile.rawValue)
+        if let filePath = nsError.userInfo[NSURLErrorKey] as? URL {
+            XCTAssertEqual(filePath, URL(fileURLWithPath: #file))
         } else {
             XCTFail()
         }

--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -297,7 +297,7 @@ class TestURL : XCTestCase {
           try FileManager.default.removeItem(atPath: gFileDoesNotExistPath)
         } catch {
           // The error code is a CocoaError
-          if (error as? NSError)?.code != CocoaError.fileNoSuchFile.rawValue {
+          if error.asNSError().code != CocoaError.fileNoSuchFile.rawValue {
             return false
           }
         }
@@ -306,7 +306,7 @@ class TestURL : XCTestCase {
           try FileManager.default.createDirectory(atPath: gDirectoryExistsPath, withIntermediateDirectories: false)
         } catch {
             // The error code is a CocoaError
-            if (error as? NSError)?.code != CocoaError.fileWriteFileExists.rawValue {
+            if error.asNSError().code != CocoaError.fileWriteFileExists.rawValue {
                 return false
             }
         }
@@ -315,7 +315,7 @@ class TestURL : XCTestCase {
           try FileManager.default.removeItem(atPath: gDirectoryDoesNotExistPath)
         } catch {
             // The error code is a CocoaError
-            if (error as? NSError)?.code != CocoaError.fileNoSuchFile.rawValue {
+            if error.asNSError().code != CocoaError.fileNoSuchFile.rawValue {
                 return false
             }
         }
@@ -624,11 +624,8 @@ class TestURL : XCTestCase {
                 assertRelevantValuesAreEqual(in: newValues)
             }
         } catch {
-            if let error = error as? NSError {
-                print("error: \(error.description) - \(error.userInfo)")
-            } else {
-                print("error: \(error)")
-            }
+            let error = error.asNSError()
+            print("error: \(error.description) - \(error.userInfo)")
             throw error
         }
     }

--- a/TestFoundation/Utilities.swift
+++ b/TestFoundation/Utilities.swift
@@ -133,6 +133,17 @@ func _checkHashing<Source: Hashable, Target: Hashable, S: Sequence>(
     }
 }
 
+extension Error {
+    func asNSError() -> NSError {
+        // The cast will never fail, and this will create a warning during
+        // compilation, but since it is SwiftFoundation.NSError (and not ObjC
+        // NSError) the macOS build cannot detect that and might fail indicating
+        // some catch is not exhaustive. This avoid the compilation problem,
+        // but centralizes all the warnings in only this point.
+        return (self as? NSError)!
+    }
+}
+
 enum TestError: Error {
     case unexpectedNil
 }


### PR DESCRIPTION
Since Swift 3 (IIRC) Error can always be casted to NSError, so the
conditional casts are always going to succeed and they produce warnings.
However because in macOS SwiftFoundation.NSError is not the ObjC
NSError, the compiler misses this, and might fail to mark some catch as
exhaustives.

To avoid one warning per use of NSError, move all the warnings into a
single one in a utility function, used from all the places when Error
needs to be transformed into NSError. In a couple of cases, the code is
simplified because a branch disappears.

This should remove a lot of warnings while compiling the tests.