### PR TITLE
[gardening] Update tests to non-deprecated Process API.

### DIFF
--- a/TestFoundation/TestHTTPCookieStorage.swift
+++ b/TestFoundation/TestHTTPCookieStorage.swift
@@ -307,7 +307,7 @@ class TestHTTPCookieStorage: XCTestCase {
         XCTAssertEqual(storage.cookies(for: superSwiftOrgUrl)!, [])
     }
 
-    func test_cookieInXDGSpecPath() {
+    func test_cookieInXDGSpecPath() throws {
 #if !os(Android) && !DARWIN_COMPATIBILITY_TESTS // No XDG on native Foundation
         //Test without setting the environment variable
         let testCookie = HTTPCookie(properties: [
@@ -341,7 +341,7 @@ class TestHTTPCookieStorage: XCTestCase {
         task.environment = environment
 
         // Launch the task
-        task.launch()
+        try task.run()
         task.waitUntilExit()
         let status = task.terminationStatus
         XCTAssertEqual(status, 0)


### PR DESCRIPTION
Some pieces of the Process API has been deprecated (paths have been
turned into URLs, launch has been renamed run and make throwing,...).
These changes update the tests to use the new API.

Since we also want to test the deprecated APIs, a new set of test is
created that specifically test the API still behaves. This set of test
are marked as deprecated themselves, so they don't produce warnings in
their contents. However, they produce warning when used in `allTests`,
which cannot be avoided, but at least those warnings point to a piece of
code that clearly says `test_deprecated`.

There's also some other clean ups in the file, like removing a lot of
`try?` which might have been masking errors (there's no need for marking
the test method as `throws` if you later do `try?`). I have also removed
a lot of `XCTFail`, since they are better served with either `throws`
test methods (and XCTest will report better about the exception than
XCTFail), or use `XCTAssertThrowsError`.

This should remove a lot of warnings while compiling the tests.