### PR TITLE
[gardening] Remove some optional usage from the tests.

### DIFF
--- a/TestFoundation/TestNSString.swift
+++ b/TestFoundation/TestNSString.swift
@@ -1180,34 +1180,34 @@ class TestNSString: LoopbackServerTest {
         }
     }
     
-    func test_ExternalRepresentation() {
+    func test_ExternalRepresentation() throws {
         // Ensure NSString can be used to create an external data representation
 
         do {
             let string = NSString(string: "this is an external string that should be representable by data")
 
-            let UTF8Data = string.data(using: String.Encoding.utf8.rawValue, allowLossyConversion: false) as NSData?
-            let UTF8Length = UTF8Data?.length
+            let UTF8Data = try string.data(using: String.Encoding.utf8.rawValue, allowLossyConversion: false).unwrapped() as NSData
+            let UTF8Length = UTF8Data.length
             XCTAssertEqual(UTF8Length, 63, "NSString should successfully produce an external UTF8 representation with a length of 63 but got \(UTF8Length) bytes")
 
-            let UTF16Data = string.data(using: String.Encoding.utf16.rawValue, allowLossyConversion: false) as NSData?
-            let UTF16Length = UTF16Data?.length
+            let UTF16Data = try string.data(using: String.Encoding.utf16.rawValue, allowLossyConversion: false).unwrapped() as NSData
+            let UTF16Length = UTF16Data.length
             XCTAssertEqual(UTF16Length, 128, "NSString should successfully produce an external UTF16 representation with a length of 128 but got \(UTF16Length) bytes")
 
-            let ISOLatin1Data = string.data(using: String.Encoding.isoLatin1.rawValue, allowLossyConversion: false) as NSData?
-            let ISOLatin1Length = ISOLatin1Data?.length
+            let ISOLatin1Data = try string.data(using: String.Encoding.isoLatin1.rawValue, allowLossyConversion: false).unwrapped() as NSData
+            let ISOLatin1Length = ISOLatin1Data.length
             XCTAssertEqual(ISOLatin1Length, 63, "NSString should successfully produce an external ISOLatin1 representation with a length of 63 but got \(ISOLatin1Length) bytes")
         }
 
         do {
             let string = NSString(string: "🐢 encoding all the way down. 🐢🐢🐢")
 
-            let UTF8Data = string.data(using: String.Encoding.utf8.rawValue, allowLossyConversion: false) as NSData?
-            let UTF8Length = UTF8Data?.length
+            let UTF8Data = try string.data(using: String.Encoding.utf8.rawValue, allowLossyConversion: false).unwrapped() as NSData
+            let UTF8Length = UTF8Data.length
             XCTAssertEqual(UTF8Length, 44, "NSString should successfully produce an external UTF8 representation with a length of 44 but got \(UTF8Length) bytes")
 
-            let UTF16Data = string.data(using: String.Encoding.utf16.rawValue, allowLossyConversion: false) as NSData?
-            let UTF16Length = UTF16Data?.length
+            let UTF16Data = try string.data(using: String.Encoding.utf16.rawValue, allowLossyConversion: false).unwrapped() as NSData
+            let UTF16Length = UTF16Data.length
             XCTAssertEqual(UTF16Length, 74, "NSString should successfully produce an external UTF16 representation with a length of 74 but got \(UTF16Length) bytes")
 
             let ISOLatin1Data = string.data(using: String.Encoding.isoLatin1.rawValue, allowLossyConversion: false) as NSData?

--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -670,9 +670,9 @@ class TestURLComponents : XCTestCase {
         XCTAssertEqual(receivedString, expectedString, "expected \(expectedString) but received \(receivedString as Optional)")
     }
 
-    func test_url() {
+    func test_url() throws {
 
-        let baseURL = URL(string: "https://www.example.com")
+        let baseURL = try URL(string: "https://www.example.com").unwrapped()
 
         /* test NSURLComponents without authority */
         guard var compWithAuthority = URLComponents(string: "https://www.swift.org") else {


### PR DESCRIPTION
In some cases in the tests, even if an API returns an optional, we know
that it should never be optional, and it might create warnings in later
code when the optional is interpolated into a string (for example).
Change those cases into using `.unwrapped()` to get a non-optional type,
and create a big error if a nil is actually received.

This should remove a bunch of warnings while compiling the tests.