### PR TITLE
[gardening] Fix assign to a weak variable releasing immediately.

### DIFF
--- a/TestFoundation/TestNotificationQueue.swift
+++ b/TestFoundation/TestNotificationQueue.swift
@@ -205,8 +205,9 @@ FIXME SR-4280 timeouts in TestNSNotificationQueue tests
         weak var notificationQueue: NotificationQueue?
 
         self.executeInBackgroundThread() {
-            notificationQueue = NotificationQueue(notificationCenter: NotificationCenter())
-            XCTAssertNotNil(notificationQueue)
+            let nq = NotificationQueue(notificationCenter: NotificationCenter())
+            notificationQueue = nq
+            XCTAssertNotNil(nq)
         }
         
         XCTAssertNil(notificationQueue)


### PR DESCRIPTION
The compiler was warning about this assign to a weak variable, where the
value was going to be released immediately. Modify the code to hold the
value in a strong variable during the block to avoid the warning (and
probably a failing test).

This test is actually disabled, so nothing should change.