### PR TITLE
SR-10611: ProcessInfo.activeProcessorCount too high in containerised Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,14 @@ include(SwiftSupport)
 include(GNUInstallDirs)
 include(ExternalProject)
 
+if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  include(CheckSymbolExists)
+  include(CheckIncludeFile)
+  list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+  check_include_file("sched.h" HAVE_SCHED_H)
+  check_symbol_exists(sched_getaffinity "sched.h" HAVE_SCHED_GETAFFINITY)
+endif()
+
 string(TOLOWER ${CMAKE_SYSTEM_NAME} swift_os)
 get_swift_host_arch(swift_arch)
 

--- a/CoreFoundation/Base.subproj/CFUtilities.c
+++ b/CoreFoundation/Base.subproj/CFUtilities.c
@@ -71,6 +71,9 @@
 #include <pthread.h>
 #endif
 
+#if DEPLOYMENT_TARGET_LINUX && __has_include(<sched.h>)
+#include <sched.h>
+#endif
 
 
 #if !defined(CF_HAVE_HW_CONFIG_COMMPAGE) && defined(_COMM_PAGE_LOGICAL_CPUS) && defined(_COMM_PAGE_PHYSICAL_CPUS) && defined(_COMM_PAGE_ACTIVE_CPUS) && !__has_feature(address_sanitizer)
@@ -451,6 +454,14 @@ CF_PRIVATE CFIndex __CFActiveProcessorCount() {
         pcnt = 0;
     }
 #elif DEPLOYMENT_TARGET_LINUX
+
+#ifdef _SCHED_H
+    cpu_set_t set;
+    if (sched_getaffinity (getpid(), sizeof(set), &set) == 0) {
+        return CPU_COUNT (&set);
+    }
+#endif
+
     pcnt = sysconf(_SC_NPROCESSORS_ONLN);
 #else
     // Assume the worst

--- a/CoreFoundation/Base.subproj/CFUtilities.c
+++ b/CoreFoundation/Base.subproj/CFUtilities.c
@@ -71,8 +71,10 @@
 #include <pthread.h>
 #endif
 
-#if DEPLOYMENT_TARGET_LINUX && __has_include(<sched.h>)
+#if DEPLOYMENT_TARGET_LINUX
+#ifdef HAVE_SCHED_GETAFFINITY
 #include <sched.h>
+#endif
 #endif
 
 
@@ -455,7 +457,7 @@ CF_PRIVATE CFIndex __CFActiveProcessorCount() {
     }
 #elif DEPLOYMENT_TARGET_LINUX
 
-#ifdef _SCHED_H
+#ifdef HAVE_SCHED_GETAFFINITY
     cpu_set_t set;
     if (sched_getaffinity (getpid(), sizeof(set), &set) == 0) {
         return CPU_COUNT (&set);

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -337,6 +337,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android)
                              PRIVATE
                                -DDEPLOYMENT_TARGET_LINUX
                                -D_GNU_SOURCE)
+  if(HAVE_SCHED_GETAFFINITY)
+    target_compile_definitions(CoreFoundation
+                               PRIVATE
+                                 -DHAVE_SCHED_GETAFFINITY)
+  endif()
 elseif(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
   target_compile_definitions(CoreFoundation
                              PRIVATE
@@ -516,4 +521,3 @@ install(DIRECTORY
           ${CMAKE_INSTALL_PREFIX}/System/Library/Frameworks
         USE_SOURCE_PERMISSIONS
         PATTERN PrivateHeaders EXCLUDE)
-


### PR DESCRIPTION
- On Linux, use sched_getaffinity() falling back to
  sysconf(_SC_NPROCESSORS_ONLN) as this should provide a better
  value for ProcessInfo.activeProcessorCount when running under
  cgroups (eg Docker).

Not sure if this is the best solution and will need an offline test in a Docker environment.