### PR TITLE
SR-10619: Order in which DateFormatter settings are set up matters on Linux

### DIFF
--- a/Foundation/DateFormatter.swift
+++ b/Foundation/DateFormatter.swift
@@ -21,7 +21,7 @@ open class DateFormatter : Formatter {
                 let dateStyle = CFDateFormatterStyle(self.dateStyle.rawValue)
                 let timeStyle = CFDateFormatterStyle(self.timeStyle.rawValue)
             #endif
-            
+
             let obj = CFDateFormatterCreate(kCFAllocatorSystemDefault, locale._cfObject, dateStyle, timeStyle)!
             _setFormatterAttributes(obj)
             if let dateFormat = _dateFormat {
@@ -144,7 +144,7 @@ open class DateFormatter : Formatter {
     open var dateFormat: String! {
         get {
             guard let format = _dateFormat else {
-                return __cfObject.map { CFDateFormatterGetFormat($0)._swiftObject } ?? ""
+                return CFDateFormatterGetFormat(_cfObject)._swiftObject
             }
             return format
         }
@@ -157,17 +157,11 @@ open class DateFormatter : Formatter {
         willSet {
             _dateFormat = nil
         }
-        didSet {
-            _dateFormat = CFDateFormatterGetFormat(_cfObject)._swiftObject
-        }
     }
 
     open var timeStyle: Style = .none {
         willSet {
             _dateFormat = nil
-        }
-        didSet {
-            _dateFormat = CFDateFormatterGetFormat(_cfObject)._swiftObject
         }
     }
 


### PR DESCRIPTION
- Ensure the setting of .dateStyle and .timeStyle isnt dependant on the
  current setting of .locale.