### PR TITLE
TestFoundation: make xdgTestHelper build on Windows

### DIFF
--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -12,6 +12,9 @@ import SwiftFoundation
 #else
 import Foundation
 #endif
+#if os(Windows)
+import WinSDK
+#endif
 
 enum HelperCheckStatus : Int32 {
     case ok                 = 0
@@ -222,7 +225,11 @@ case "--sleep":
 
 case "--signal-self":
     if let signalnum = arguments.next(), let signal = Int32(signalnum) {
+#if os(Windows)
+        TerminateProcess(GetCurrentProcess(), UINT(signal))
+#else
         kill(ProcessInfo.processInfo.processIdentifier, signal)
+#endif
     }
     exit(1)
 


### PR DESCRIPTION
Windows does not have `kill` but it does have `TerminateProcess`.  This
utility is poorly named at this point and is used as a test helper
utility rather than XDG helper specifically.