### PR TITLE
Fix NSRect init invocation on 32bit platforms

### DIFF
--- a/Foundation/NSGeometry.swift
+++ b/Foundation/NSGeometry.swift
@@ -704,7 +704,7 @@ public func NSInsetRect(_ aRect: NSRect, _ dX: CGFloat, _ dY: CGFloat) -> NSRect
     let y = aRect.origin.y.native + dY.native
     let w = aRect.size.width.native - (dX.native * 2)
     let h = aRect.size.height.native - (dY.native * 2)
-    return NSRect(x: x, y: y, width: w, height: h)
+    return NSRect(x: CGFloat(x), y: CGFloat(y), width: CGFloat(w), height: CGFloat(h))
 }
 
 public func NSIntegralRect(_ aRect: NSRect) -> NSRect {


### PR DESCRIPTION
This fixes an issue in NSGeometry on 32bit platforms selecting the `(x: CGFloat, y: CGFloat, width: CGFloat, height: CGFloat)` overload, that will just cast a `CGFloat::NativeType` to, again, a `CGFloat::NativeType`, platform dependent (either Float or Double).

The error I'm getting right now:
```
/mnt/buildSwiftOnARM/swift-corelibs-foundation/Foundation/NSGeometry.swift:689:12: error: cannot invoke initializer for type 'NSRect' with an argument list of type '(x: Float, y: Float, width: Float, height: Float)'
    return NSRect(x: x, y: y, width: w, height: h)
           ^
/mnt/buildSwiftOnARM/swift-corelibs-foundation/Foundation/NSGeometry.swift:689:12: note: overloads for 'NSRect' exist with these partially matching parameter lists: (x: CGFloat, y: CGFloat, width: CGFloat, height: CGFloat), (x: Double, y: Double, width: Double, height: Double), (x: Int, y: Int, width: Int, height: Int)
    return NSRect(x: x, y: y, width: w, height: h)
           ^
ninja: build stopped: subcommand failed.
./swift/utils/build-script: fatal error: command terminated with a non-zero exit status 1, aborting
```