### PR TITLE
CoreFoundation: correct CreateStringFromFileSystemRepresentationByAdd…

### DIFF
--- a/CoreFoundation/URL.subproj/CFURL.c
+++ b/CoreFoundation/URL.subproj/CFURL.c
@@ -894,15 +894,34 @@ static CFStringRef CreateStringFromFileSystemRepresentationByAddingPercentEscape
         if ( idx == numBytes ) {
             if ( isDirectory ) {
                 // if it is a directory and it doesn't end with PATH_SEP, append a PATH_SEP.
-                if ( bytes[numBytes-1] != '/' ) {
-                    *bufBytePtr++ = '/';
+                if ( windowsPath ) {
+                    if ( bufBytePtr - bufStartPtr > 3 ) {
+                        if ( strncmp((const char *)(bufBytePtr - 3), "%2F", 3) ) {
+                            *bufBytePtr++ = '%';
+                            *bufBytePtr++ = '2';
+                            *bufBytePtr++ = 'F';
+                        }
+                    }
+                }
+                else {
+                    if ( bytes[numBytes-1] != '/' ) {
+                        *bufBytePtr++ = '/';
+                    }
                 }
             }
             else {
                 // it is not a directory: remove any pathDelim characters at end (leaving at least one character)
-                while ( (numBytes > 1) && (bytes[numBytes-1] == '/') ) {
-                    --bufBytePtr;
-                    --numBytes;
+                if ( windowsPath ) {
+                    while ( (numBytes > 1) && (bufBytePtr - bufStartPtr > 3) && (strncmp((const char *)(bufBytePtr - 3), "%2F", 3) == 0) ) {
+                        bufBytePtr -= 3;
+                        --numBytes;
+                    }
+                }
+                else {
+                    while ( (numBytes > 1) && (bytes[numBytes-1] == '/') ) {
+                        --bufBytePtr;
+                        --numBytes;
+                    }
                 }
             }
             


### PR DESCRIPTION
…ingPercentEscapes

On Windows,
`CreateStringFromFileSystemRepresentationByAddingPercentEscapes` would
only partially convert the slash character to %2F.  This would result in
paths being truncated.  Fix this behaviour to canonicalise the separator
properly always.  Unfortunately, this uncovered some new cases of file
path handling being broken on Windows.  Add tests to record those cases
so that we can fix them subsequently.