### PR TITLE
[android] Implement Process and modify TestProcess to pass.

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -62,9 +62,11 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
+#include <termios.h>
 #elif TARGET_OS_LINUX
 #include <errno.h>
 #include <features.h>
+#include <termios.h>
 
 #if __GLIBC_PREREQ(2, 28) == 0
 // required for statx() system call, glibc >=2.28 wraps the kernel function
@@ -649,6 +651,18 @@ typedef struct _REPARSE_DATA_BUFFER {
         } GenericReparseBuffer;
     } DUMMYUNIONNAME;
 } REPARSE_DATA_BUFFER;
+#endif
+
+#if !TARGET_OS_WIN32
+typedef void * _CFPosixSpawnFileActionsRef;
+typedef void * _CFPosixSpawnAttrRef;
+CF_EXPORT _CFPosixSpawnFileActionsRef _CFPosixSpawnFileActionsAlloc(void);
+CF_EXPORT int _CFPosixSpawnFileActionsInit(_CFPosixSpawnFileActionsRef file_actions);
+CF_EXPORT int _CFPosixSpawnFileActionsDestroy(_CFPosixSpawnFileActionsRef file_actions);
+CF_EXPORT void _CFPosixSpawnFileActionsDealloc(_CFPosixSpawnFileActionsRef file_actions);
+CF_EXPORT int _CFPosixSpawnFileActionsAddDup2(_CFPosixSpawnFileActionsRef file_actions, int filedes, int newfiledes);
+CF_EXPORT int _CFPosixSpawnFileActionsAddClose(_CFPosixSpawnFileActionsRef file_actions, int filedes);
+CF_EXPORT int _CFPosixSpawn(pid_t *_CF_RESTRICT pid, const char *_CF_RESTRICT path, _CFPosixSpawnFileActionsRef file_actions, _CFPosixSpawnAttrRef _Nullable _CF_RESTRICT attrp, char *_Nullable const argv[_Nullable _CF_RESTRICT], char *_Nullable const envp[_Nullable _CF_RESTRICT]);
 #endif
 
 _CF_EXPORT_SCOPE_END


### PR DESCRIPTION
Until recent API levels, Android haven't provide posix_spawn and other
functions from that family, so Process was not going to work with the
branches used for other POSIX OS.

Instead of creating an specific path for Android, which will probably be
forgotten by other changes, all the POSIX OS will use private CF
functions that wrap the posix_spawn functions. For Android, we try to
figure out if posix_spawn exist, and use it in that case, but  we
implement a subset of the posix_spawn family of functions for lower API
levels, using fork and exec underneath, and other functions from the
POSIX APIs. The already code in Process is only modified slightly to
adapt to the new names have to be modified.

The tests have to be modified slightly for working on Android. Many
changes are related to the environment needing the key LD_LIBRARY_PATH,
or the xdgTestHelper will not be able to start in some of the tests. The
other change is using NSTemporaryDirectory() instead of a hardcoded
`/tmp`, which doesn't exist in Android (the code also removes the last
slash, to match the original code expectations).

It also includes a small fix for when launch() is used and a error is
thrown which is not related to the current working directory. Before the
error was ignored silently, and now it will fatalError.

Other small improvement is reporting the actual line in the helper for
the returned POSIX error codes, instead of always reporting the line of
the helper itself.

Special thanks to @spevans because without the recent changes to use exclusively xdgTestHelper, the changes in the tests would have been more complicated.