### PR TITLE
Parity: Bundle(for: AnyClass)

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -410,6 +410,8 @@ CF_EXPORT _Nullable CFErrorRef CFWriteStreamCopyError(CFWriteStreamRef _Null_uns
 CF_CROSS_PLATFORM_EXPORT CFStringRef _Nullable _CFBundleCopyExecutablePath(CFBundleRef bundle);
 CF_CROSS_PLATFORM_EXPORT Boolean _CFBundleSupportsFHSBundles(void);
 CF_CROSS_PLATFORM_EXPORT Boolean _CFBundleSupportsFreestandingBundles(void);
+CF_CROSS_PLATFORM_EXPORT CFStringRef _Nullable _CFBundleCopyLoadedImagePathForAddress(const void *p);
+
 CF_CROSS_PLATFORM_EXPORT CFStringRef __CFTimeZoneCopyDataVersionString(void);
 
 CF_CROSS_PLATFORM_EXPORT void *_Nullable _CFURLCopyResourceInfo(CFURLRef url);

--- a/CoreFoundation/PlugIn.subproj/CFBundle_Binary.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Binary.c
@@ -746,6 +746,11 @@ CF_PRIVATE void *_CFBundleDLLGetSymbolByName(CFBundleRef bundle, CFStringRef sym
 
 #endif /* BINARY_SUPPORT_DLL */
 
+// For Swift:
+CF_CROSS_PLATFORM_EXPORT CFStringRef _CFBundleCopyLoadedImagePathForAddress(const void *p) {
+    return _CFBundleCopyLoadedImagePathForPointer((void *)p);
+}
+
 CF_PRIVATE CFStringRef _CFBundleCopyLoadedImagePathForPointer(void *p) {
     CFStringRef imagePath = NULL;
 #if defined(BINARY_SUPPORT_DYLD)

--- a/TestFoundation/TestBundle.swift
+++ b/TestFoundation/TestBundle.swift
@@ -338,31 +338,6 @@ class BundlePlayground {
 }
 
 class TestBundle : XCTestCase {
-    
-    static var allTests: [(String, (TestBundle) -> () throws -> Void)] {
-        var tests: [(String, (TestBundle) -> () throws -> Void)] = [
-            ("test_paths", test_paths),
-            ("test_resources", test_resources),
-            ("test_infoPlist", test_infoPlist),
-            ("test_localizations", test_localizations),
-            ("test_URLsForResourcesWithExtension", test_URLsForResourcesWithExtension),
-            ("test_bundleLoad", test_bundleLoad),
-            ("test_bundleLoadWithError", test_bundleLoadWithError),
-            ("test_bundleWithInvalidPath", test_bundleWithInvalidPath),
-            ("test_bundlePreflight", test_bundlePreflight),
-            ("test_bundleFindExecutable", test_bundleFindExecutable),
-            ("test_bundleFindAuxiliaryExecutables", test_bundleFindAuxiliaryExecutables),
-            ("test_bundleReverseBundleLookup", test_bundleReverseBundleLookup),
-        ]
-
-#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
-        tests.append(contentsOf: [
-            ("test_mainBundleExecutableURL", test_mainBundleExecutableURL),
-        ])
-#endif
-
-        return tests
-    }
 
     func test_paths() {
         let bundle = testBundle()
@@ -578,4 +553,34 @@ class TestBundle : XCTestCase {
 #endif
     }
 #endif
+    
+    func test_bundleForClass() {
+        XCTAssertEqual(testBundle(), Bundle(for: type(of: self)))
+    }
+    
+    static var allTests: [(String, (TestBundle) -> () throws -> Void)] {
+        var tests: [(String, (TestBundle) -> () throws -> Void)] = [
+            ("test_paths", test_paths),
+            ("test_resources", test_resources),
+            ("test_infoPlist", test_infoPlist),
+            ("test_localizations", test_localizations),
+            ("test_URLsForResourcesWithExtension", test_URLsForResourcesWithExtension),
+            ("test_bundleLoad", test_bundleLoad),
+            ("test_bundleLoadWithError", test_bundleLoadWithError),
+            ("test_bundleWithInvalidPath", test_bundleWithInvalidPath),
+            ("test_bundlePreflight", test_bundlePreflight),
+            ("test_bundleFindExecutable", test_bundleFindExecutable),
+            ("test_bundleFindAuxiliaryExecutables", test_bundleFindAuxiliaryExecutables),
+            ("test_bundleReverseBundleLookup", test_bundleReverseBundleLookup),
+            ("test_bundleForClass", testExpectedToFailOnWindows(test_bundleForClass, "Functionality not yet implemented on Windows. SR-XXXX")),
+        ]
+        
+        #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+        tests.append(contentsOf: [
+            ("test_mainBundleExecutableURL", test_mainBundleExecutableURL),
+            ])
+        #endif
+        
+        return tests
+    }
 }


### PR DESCRIPTION
 - Use dladdr() with a symbol guaranteed to be in the source image of the class.

 - We cannot replace the Bundle object init() returns, but we can implement equality correctly so that at least `==` can compare bundles correctly if they refer to the same CFBundle.

 - Add testExpectedToFailOnWindows() and associated infrastructure.