### PR TITLE
Parity: NSSortDescriptor & _CFSwiftArrayReplaceValues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,6 +480,7 @@ if(ENABLE_TESTING)
                          TestFoundation/TestNSRange.swift
                          TestFoundation/TestNSRegularExpression.swift
                          TestFoundation/TestNSSet.swift
+                         TestFoundation/TestNSSortDescriptor.swift
                          TestFoundation/TestNSString.swift
                          TestFoundation/TestNSTextCheckingResult.swift
                          TestFoundation/TestNSURLRequest.swift

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -94,6 +94,7 @@ struct _NSArrayBridge {
     CFIndex (*_Nonnull count)(CFTypeRef obj);
     _Nonnull CFTypeRef (*_Nonnull objectAtIndex)(CFTypeRef obj, CFIndex index);
     void (*_Nonnull getObjects)(CFTypeRef array, CFRange range, CFTypeRef _Nullable *_Nonnull values);
+    Boolean (*_Nonnull isSubclassOfNSMutableArray)(CFTypeRef array);
 };
 
 struct _NSMutableArrayBridge {

--- a/CoreFoundation/Collections.subproj/CFArray.c
+++ b/CoreFoundation/Collections.subproj/CFArray.c
@@ -966,9 +966,12 @@ void CFArraySortValues(CFMutableArrayRef array, CFRange range, CFComparatorFunct
     __CFArrayValidateRange(array, range, __PRETTY_FUNCTION__);
     CFAssert1(NULL != comparator, __kCFLogAssertion, "%s(): pointer to comparator function may not be NULL", __PRETTY_FUNCTION__);
     Boolean immutable = false;
-    if (CF_IS_OBJC(CFArrayGetTypeID(), array) || CF_IS_SWIFT(CFArrayGetTypeID(), array)) {
+    if (CF_IS_OBJC(CFArrayGetTypeID(), array)) {
         BOOL result;
-        result = CF_OBJC_CALLV((NSMutableArray *)array, isKindOfClass:[NSMutableArray class]); // TODO: Fixme for swift (we need a isKindOfClass replacement: (array as? NSMutableArray) != nil)
+        result = CF_OBJC_CALLV((NSMutableArray *)array, isKindOfClass:[NSMutableArray class]);
+        immutable = !result;
+    } else if (CF_IS_SWIFT(CFArrayGetTypeID(), array)) {
+        Boolean result = __CFSwiftBridge.NSArray.isSubclassOfNSMutableArray(array);
         immutable = !result;
     } else if (__kCFArrayImmutable == __CFArrayGetType(array)) {
         immutable = true;

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		03B6F5841F15F339004F25AF /* TestURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B6F5831F15F339004F25AF /* TestURLProtocol.swift */; };
 		1513A8432044893F00539722 /* FileManager_XDG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1513A8422044893F00539722 /* FileManager_XDG.swift */; };
 		1520469B1D8AEABE00D02E36 /* HTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1520469A1D8AEABE00D02E36 /* HTTPServer.swift */; };
+		152EF3942283457C001E1269 /* TestNSSortDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152EF3932283457B001E1269 /* TestNSSortDescriptor.swift */; };
 		153CC8352215E00200BFE8F3 /* ScannerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153CC8322214C3D100BFE8F3 /* ScannerAPI.swift */; };
 		153E951120111DC500F250BE /* CFKnownLocations.h in Headers */ = {isa = PBXBuildFile; fileRef = 153E950F20111DC500F250BE /* CFKnownLocations.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		153E951220111DC500F250BE /* CFKnownLocations.c in Sources */ = {isa = PBXBuildFile; fileRef = 153E951020111DC500F250BE /* CFKnownLocations.c */; };
@@ -556,6 +557,7 @@
 		03B6F5831F15F339004F25AF /* TestURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestURLProtocol.swift; sourceTree = "<group>"; };
 		1513A8422044893F00539722 /* FileManager_XDG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager_XDG.swift; sourceTree = "<group>"; };
 		1520469A1D8AEABE00D02E36 /* HTTPServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPServer.swift; sourceTree = "<group>"; };
+		152EF3932283457B001E1269 /* TestNSSortDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSSortDescriptor.swift; sourceTree = "<group>"; };
 		153CC8322214C3D100BFE8F3 /* ScannerAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannerAPI.swift; sourceTree = "<group>"; };
 		153E950F20111DC500F250BE /* CFKnownLocations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CFKnownLocations.h; sourceTree = "<group>"; };
 		153E951020111DC500F250BE /* CFKnownLocations.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = CFKnownLocations.c; sourceTree = "<group>"; };
@@ -1641,6 +1643,7 @@
 				EA66F6401BF1619600136161 /* TestPropertyListSerialization.swift */,
 				E876A73D1C1180E000F279EC /* TestNSRange.swift */,
 				5B0C6C211C1E07E600705A0E /* TestNSRegularExpression.swift */,
+				152EF3932283457B001E1269 /* TestNSSortDescriptor.swift */,
 				61E0117B1C1B554D000037DD /* TestRunLoop.swift */,
 				844DC3321C17584F005611F9 /* TestScanner.swift */,
 				EA66F6411BF1619600136161 /* TestNSSet.swift */,
@@ -2624,6 +2627,7 @@
 				B90C57BB1EEEEA5A005208AE /* TestFileManager.swift in Sources */,
 				A058C2021E529CF100B07AA1 /* TestMassFormatter.swift in Sources */,
 				5B13B3381C582D4C00651CE2 /* TestNotificationQueue.swift in Sources */,
+				152EF3942283457C001E1269 /* TestNSSortDescriptor.swift in Sources */,
 				CC5249C01D341D23007CB54D /* TestUnitConverter.swift in Sources */,
 				5B13B3331C582D4C00651CE2 /* TestJSONSerialization.swift in Sources */,
 				5B13B33C1C582D4C00651CE2 /* TestNSOrderedSet.swift in Sources */,

--- a/Foundation/NSCFArray.swift
+++ b/Foundation/NSCFArray.swift
@@ -125,6 +125,11 @@ internal func _CFSwiftArrayRemoveAllValues(_ array: AnyObject) {
 }
 
 internal func _CFSwiftArrayReplaceValues(_ array: AnyObject, _ range: CFRange, _ newValues: UnsafeMutablePointer<Unmanaged<AnyObject>>, _ newCount: CFIndex) {
-    NSUnimplemented()
-//    (array as! NSMutableArray).replaceObjectsInRange(NSRange(location: range.location, length: range.length), withObjectsFrom: newValues.array(newCount))
+    let buffer: UnsafeBufferPointer<Unmanaged<AnyObject>> = UnsafeBufferPointer(start: newValues, count: newCount)
+    let replacements = Array(buffer).map { $0.takeUnretainedValue() }
+    (array as! NSMutableArray).replaceObjects(in: NSRange(location: range.location, length: range.length), withObjectsFrom: replacements)
+}
+
+internal func _CFSwiftArrayIsSubclassOfNSMutableArray(_ array: AnyObject) -> _DarwinCompatibleBoolean {
+    return array is NSMutableArray ? true : false
 }

--- a/Foundation/NSDate.swift
+++ b/Foundation/NSDate.swift
@@ -427,3 +427,10 @@ extension NSDateInterval : _StructTypeBridgeable {
         return DateInterval._unconditionallyBridgeFromObjectiveC(self)
     }
 }
+
+extension NSDateInterval : _SwiftBridgeable {
+    var _swiftObject: DateInterval {
+        return _bridgeToSwift()
+    }
+}
+

--- a/Foundation/NSIndexPath.swift
+++ b/Foundation/NSIndexPath.swift
@@ -120,3 +120,10 @@ extension NSIndexPath : _StructTypeBridgeable {
         return IndexPath._unconditionallyBridgeFromObjectiveC(self)
     }
 }
+
+extension NSIndexPath : _SwiftBridgeable {
+    var _swiftObject: IndexPath {
+        return _bridgeToSwift()
+    }
+}
+

--- a/Foundation/NSOrderedSet.swift
+++ b/Foundation/NSOrderedSet.swift
@@ -255,7 +255,7 @@ open class NSOrderedSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding, 
     // being made.
     public var array: [Any] {
         if type(of: self) === NSOrderedSet.self || type(of: self) === NSMutableOrderedSet.self {
-            return _orderedStorage._storage
+            return _orderedStorage._swiftObject
         } else {
             var result: [Any] = []
             result.reserveCapacity(self.count)
@@ -268,7 +268,7 @@ open class NSOrderedSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding, 
 
     public var set: Set<AnyHashable> {
         if type(of: self) === NSOrderedSet.self || type(of: self) === NSMutableOrderedSet.self {
-            return _storage._storage
+            return _storage._swiftObject
         } else {
             var result: Set<AnyHashable> = []
             result.reserveCapacity(self.count)
@@ -391,6 +391,10 @@ open class NSOrderedSet: NSObject, NSCopying, NSMutableCopying, NSSecureCoding, 
 
     public convenience init(set: Set<AnyHashable>, copyItems flag: Bool) {
         self.init(array: Array(set), copyItems: flag)
+    }
+    
+    open func sortedArray(using sortDescriptors: [NSSortDescriptor]) -> [Any] {
+        return self.array._nsObject.sortedArray(using: sortDescriptors)
     }
 }
 
@@ -663,6 +667,10 @@ open class NSMutableOrderedSet: NSOrderedSet {
     open func sortRange(_ range: NSRange, options opts: NSSortOptions = [], usingComparator cmptr: (Any, Any) -> ComparisonResult) {
         let sortedSubrange = _mutableOrderedStorage.sortedArray(from: range, options: opts, usingComparator: cmptr)
         _mutableOrderedStorage.replaceObjects(in: range, withObjectsFrom: sortedSubrange)
+    }
+    
+    open func sort(using sortDescriptors: [NSSortDescriptor]) {
+        _mutableOrderedStorage.sort(using: sortDescriptors)
     }
 }
 

--- a/Foundation/NSSet.swift
+++ b/Foundation/NSSet.swift
@@ -320,6 +320,10 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
         }
         return result
     }
+    
+    open func sortedArray(using sortDescriptors: [NSSortDescriptor]) -> [Any] {
+        return allObjects._nsObject.sortedArray(using: sortDescriptors)
+    }
 }
 
 extension NSSet : _CFBridgeable, _SwiftBridgeable {

--- a/Foundation/NSSortDescriptor.swift
+++ b/Foundation/NSSortDescriptor.swift
@@ -27,7 +27,7 @@ open class NSSortDescriptor: NSObject, NSCopying {
     
     
     @available(*, unavailable, message: "Key-value coding is not available in swift-corelibs-foundation. Use .keyPath instead.", renamed: "keyPath")
-    open var key: String? { NSUnimplemented() }
+    open var key: String? { NSUnsupported() }
     
     @available(*, unavailable, message: "Sort descriptors cannot be decoded from archives in swift-corelibs-foundation.")
     open func allowEvaluation() {}

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -199,6 +199,7 @@ internal func __CFInitializeSwift() {
     __CFSwiftBridge.NSArray.count = _CFSwiftArrayGetCount
     __CFSwiftBridge.NSArray.objectAtIndex = _CFSwiftArrayGetValueAtIndex
     __CFSwiftBridge.NSArray.getObjects = _CFSwiftArrayGetValues
+    __CFSwiftBridge.NSArray.isSubclassOfNSMutableArray = _CFSwiftArrayIsSubclassOfNSMutableArray
     
     __CFSwiftBridge.NSMutableArray.addObject = _CFSwiftArrayAppendValue
     __CFSwiftBridge.NSMutableArray.setObject = _CFSwiftArraySetValueAtIndex

--- a/TestFoundation/TestNSSortDescriptor.swift
+++ b/TestFoundation/TestNSSortDescriptor.swift
@@ -1,0 +1,235 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+struct IntSortable {
+    var value: Int
+}
+
+struct StringSortable {
+    var value: String
+}
+
+struct PlayerRecordSortable: Hashable {
+    var name: String
+    var victories: Int
+    var tiebreakerPoints: Int
+}
+
+class TestNSSortDescriptor: XCTestCase {
+    // Conceptually, requires a < firstCopyOfB, firstCopyOfB == secondCopyOfB, firstCopyOfB !== secondCopyOfB (if reference types)
+    private func assertObjectsPass<Root, Value: Comparable>(_ a: Root, _ firstCopyOfB: Root, _ secondCopyOfB: Root, keyPath: KeyPath<Root, Value>) {
+        do {
+            let sort = NSSortDescriptor(keyPath: keyPath, ascending: true)
+            XCTAssertEqual(sort.compare(a, to: firstCopyOfB), .orderedAscending)
+            XCTAssertEqual(sort.compare(firstCopyOfB, to: a), .orderedDescending)
+            XCTAssertEqual(sort.compare(a, to: secondCopyOfB), .orderedAscending)
+            XCTAssertEqual(sort.compare(secondCopyOfB, to: a), .orderedDescending)
+            XCTAssertEqual(sort.compare(firstCopyOfB, to: secondCopyOfB), .orderedSame)
+            XCTAssertEqual(sort.compare(secondCopyOfB, to: firstCopyOfB), .orderedSame)
+        }
+        
+        do {
+            let sort = NSSortDescriptor(keyPath: keyPath, ascending: false)
+            XCTAssertEqual(sort.compare(a, to: firstCopyOfB), .orderedDescending)
+            XCTAssertEqual(sort.compare(firstCopyOfB, to: a), .orderedAscending)
+            XCTAssertEqual(sort.compare(a, to: secondCopyOfB), .orderedDescending)
+            XCTAssertEqual(sort.compare(secondCopyOfB, to: a), .orderedAscending)
+            XCTAssertEqual(sort.compare(firstCopyOfB, to: secondCopyOfB), .orderedSame)
+            XCTAssertEqual(sort.compare(secondCopyOfB, to: firstCopyOfB), .orderedSame)
+        }
+    }
+    
+    func assertObjectsPass<Root, BridgedRoot, BaseType, Value: Comparable>(_ a: Root, _ firstCopyOfB: Root, _ secondCopyOfB: Root, _ bridgedA: BridgedRoot, _ firstCopyOfBridgedB: BridgedRoot, _ secondCopyOfBridgedB: BridgedRoot, keyPath: KeyPath<BaseType, Value>) {
+        do {
+            let sort = NSSortDescriptor(keyPath: keyPath, ascending: true)
+            XCTAssertEqual(sort.compare(bridgedA, to: firstCopyOfB), .orderedAscending)
+            XCTAssertEqual(sort.compare(a, to: firstCopyOfBridgedB), .orderedAscending)
+            XCTAssertEqual(sort.compare(firstCopyOfBridgedB, to: a), .orderedDescending)
+            XCTAssertEqual(sort.compare(firstCopyOfB, to: bridgedA), .orderedDescending)
+            XCTAssertEqual(sort.compare(bridgedA, to: secondCopyOfB), .orderedAscending)
+            XCTAssertEqual(sort.compare(a, to: secondCopyOfBridgedB), .orderedAscending)
+            XCTAssertEqual(sort.compare(secondCopyOfBridgedB, to: a), .orderedDescending)
+            XCTAssertEqual(sort.compare(secondCopyOfB, to: bridgedA), .orderedDescending)
+            XCTAssertEqual(sort.compare(firstCopyOfBridgedB, to: secondCopyOfB), .orderedSame)
+            XCTAssertEqual(sort.compare(firstCopyOfB, to: secondCopyOfBridgedB), .orderedSame)
+            XCTAssertEqual(sort.compare(secondCopyOfBridgedB, to: firstCopyOfB), .orderedSame)
+            XCTAssertEqual(sort.compare(secondCopyOfB, to: firstCopyOfBridgedB), .orderedSame)
+        }
+        
+        do {
+            let sort = NSSortDescriptor(keyPath: keyPath, ascending: false)
+            XCTAssertEqual(sort.compare(bridgedA, to: firstCopyOfB), .orderedDescending)
+            XCTAssertEqual(sort.compare(a, to: firstCopyOfBridgedB), .orderedDescending)
+            XCTAssertEqual(sort.compare(firstCopyOfBridgedB, to: a), .orderedAscending)
+            XCTAssertEqual(sort.compare(firstCopyOfB, to: bridgedA), .orderedAscending)
+            XCTAssertEqual(sort.compare(bridgedA, to: secondCopyOfB), .orderedDescending)
+            XCTAssertEqual(sort.compare(a, to: secondCopyOfBridgedB), .orderedDescending)
+            XCTAssertEqual(sort.compare(secondCopyOfBridgedB, to: a), .orderedAscending)
+            XCTAssertEqual(sort.compare(secondCopyOfB, to: bridgedA), .orderedAscending)
+            XCTAssertEqual(sort.compare(firstCopyOfBridgedB, to: secondCopyOfB), .orderedSame)
+            XCTAssertEqual(sort.compare(firstCopyOfB, to: secondCopyOfBridgedB), .orderedSame)
+            XCTAssertEqual(sort.compare(secondCopyOfBridgedB, to: firstCopyOfB), .orderedSame)
+            XCTAssertEqual(sort.compare(secondCopyOfB, to: firstCopyOfBridgedB), .orderedSame)
+        }
+    }
+    
+    private func assertObjectsPass<Root, Value>(_ a: Root, _ firstCopyOfB: Root, _ secondCopyOfB: Root, keyPath: KeyPath<Root, Value>, comparator: @escaping Comparator) {
+        do {
+            let sort = NSSortDescriptor(keyPath: keyPath, ascending: true, comparator: comparator)
+            XCTAssertEqual(sort.compare(a, to: firstCopyOfB), .orderedAscending)
+            XCTAssertEqual(sort.compare(firstCopyOfB, to: a), .orderedDescending)
+            XCTAssertEqual(sort.compare(a, to: secondCopyOfB), .orderedAscending)
+            XCTAssertEqual(sort.compare(secondCopyOfB, to: a), .orderedDescending)
+            XCTAssertEqual(sort.compare(firstCopyOfB, to: secondCopyOfB), .orderedSame)
+            XCTAssertEqual(sort.compare(secondCopyOfB, to: firstCopyOfB), .orderedSame)
+        }
+        
+        do {
+            let sort = NSSortDescriptor(keyPath: keyPath, ascending: false, comparator: comparator)
+            XCTAssertEqual(sort.compare(a, to: firstCopyOfB), .orderedDescending)
+            XCTAssertEqual(sort.compare(firstCopyOfB, to: a), .orderedAscending)
+            XCTAssertEqual(sort.compare(a, to: secondCopyOfB), .orderedDescending)
+            XCTAssertEqual(sort.compare(secondCopyOfB, to: a), .orderedAscending)
+            XCTAssertEqual(sort.compare(firstCopyOfB, to: secondCopyOfB), .orderedSame)
+            XCTAssertEqual(sort.compare(secondCopyOfB, to: firstCopyOfB), .orderedSame)
+        }
+    }
+    
+    func testComparable() {
+        let a = IntSortable(value: 42)
+        let b = IntSortable(value: 108)
+        let bAgain = IntSortable(value: 108)
+        
+        assertObjectsPass(a, b, bAgain, keyPath: \IntSortable.value)
+    }
+    
+    func testBuiltinComparableObject() {
+        let a = NSString(string: "A")
+        let b = NSString(string: "B")
+        let bAgain = NSString(string: "B")
+        
+        assertObjectsPass(a, b, bAgain, keyPath: \NSString.self)
+    }
+    
+    func testBuiltinComparableBridgeable() {
+        let a = NSString(string: "A")
+        let b = NSString(string: "B")
+        let bAgain = NSString(string: "B")
+        
+        let aString = "A"
+        let bString = "B"
+        let bStringAgain = "B"
+        
+        assertObjectsPass(a, b, bAgain, aString, bString, bStringAgain, keyPath: \NSString.self)
+        assertObjectsPass(a, b, bAgain, aString, bString, bStringAgain, keyPath: \String.self)
+    }
+    
+    func testComparatorSorting() {
+        let canonicalOrder = [ "Velma", "Daphne", "Scooby" ]
+        
+        let a = StringSortable(value: "Velma")
+        let b = StringSortable(value: "Daphne")
+        let bAgain = StringSortable(value: "Daphne")
+        
+        assertObjectsPass(a, b, bAgain, keyPath: \StringSortable.value) { (lhs, rhs) -> ComparisonResult in
+            let lhsIndex = canonicalOrder.firstIndex(of: lhs as! String)!
+            let rhsIndex = canonicalOrder.firstIndex(of: rhs as! String)!
+            
+            if lhsIndex < rhsIndex {
+                return .orderedAscending
+            } else if lhsIndex > rhsIndex {
+                return .orderedDescending
+            } else {
+                return .orderedSame
+            }
+        }
+    }
+    
+    private let runOnlySinglePermutation = false // Useful for debugging. Always keep set to false when committing.
+    
+    func permute<T>(_ array: [T]) -> [[T]] {
+        guard !runOnlySinglePermutation else {
+            return [array]
+        }
+        
+        guard !array.isEmpty else { return [[]] }
+
+        var rest = array
+        let head = rest.popLast()!
+        let subpermutations = permute(rest)
+
+        var result: [[T]] = []
+        for permutation in subpermutations {
+            for i in 0 ..< array.count {
+                var edited = permutation
+                edited.insert(head, at: i)
+                result.append(edited)
+            }
+        }
+
+        return result
+    }
+    
+    func testSortingContainers() {
+        let a = PlayerRecordSortable(name: "A", victories: 3, tiebreakerPoints: 0)
+        let b = PlayerRecordSortable(name: "B", victories: 1, tiebreakerPoints: 10)
+        let c = PlayerRecordSortable(name: "C", victories: 1, tiebreakerPoints: 10)
+        let d = PlayerRecordSortable(name: "D", victories: 1, tiebreakerPoints: 15)
+        
+        func check(_ result: [Any]) {
+            let actualResult = result as! [PlayerRecordSortable]
+            
+            XCTAssertEqual(actualResult[0].name, "A")
+            XCTAssertEqual(actualResult[1].name, "D")
+            if actualResult[2].name == "B" {
+                XCTAssertEqual(actualResult[2].name, "B")
+                XCTAssertEqual(actualResult[3].name, "C")
+            } else {
+                XCTAssertEqual(actualResult[2].name, "C")
+                XCTAssertEqual(actualResult[3].name, "B")
+            }
+        }
+        
+        let descriptors = [
+            NSSortDescriptor(keyPath: \PlayerRecordSortable.victories, ascending: false),
+            NSSortDescriptor(keyPath: \PlayerRecordSortable.tiebreakerPoints, ascending: false),
+        ]
+        
+        let permutations = permute([a, b, c, d])
+        for permutation in permutations {
+            
+            check(NSArray(array: permutation).sortedArray(using: descriptors))
+            
+            let mutable = NSMutableArray(array: permutation)
+            mutable.sort(using: descriptors)
+            check(mutable as! [PlayerRecordSortable])
+            
+            let set = NSSet(array: permutation)
+            check(set.sortedArray(using: descriptors))
+            
+            let orderedSet = NSOrderedSet(array: permutation)
+            check(orderedSet.sortedArray(using: descriptors))
+            
+            let mutableOrderedSet = orderedSet.mutableCopy() as! NSMutableOrderedSet
+            mutableOrderedSet.sort(using: descriptors)
+            check(mutableOrderedSet.array)
+            
+        }
+    }
+    
+    static var allTests: [(String, (TestNSSortDescriptor) -> () throws -> Void)] {
+        return [
+            ("testComparable", testComparable),
+            ("testBuiltinComparableObject", testBuiltinComparableObject),
+            ("testBuiltinComparableBridgeable", testBuiltinComparableBridgeable),
+            ("testComparatorSorting", testComparatorSorting),
+            ("testSortingContainers", testSortingContainers),
+        ]
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -112,6 +112,7 @@ var allTestCases = [
     testCase(TestDimension.allTests),
     testCase(TestMeasurement.allTests),
     testCase(TestNSLock.allTests),
+    testCase(TestNSSortDescriptor.allTests),
 ]
 
 XCTMain(allTestCases)


### PR DESCRIPTION
 - Implement the parts that can be implemented and annotate the rest with diagnostics.

 - Add a partially source-compatible version of `init(keyPath:ascending:)` that works with Comparable values.

 - A limited set of Cocoa model classes (the ones that have a `compare(_:)` method) now conforms to Comparable and can be used with the source-compatible initializer.

 - Implement the sort methods that take sort descriptors on the collection classes.

 - Add `_SwiftBridgeable`  protocol conformance to a couple classes that had it missing.

 - Fix `_CFSwiftArrayReplaceValues` to actually work, and ensure `CFArraySort()` can detect that the array is actually mutable.

 - Ensure that `NSOrderedSet` invokes `__SwiftValue`’s fetching setup instead of returning internal storage.