### PR TITLE
TestFoundation: fix a double free

### DIFF
--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -295,11 +295,6 @@ class TestNSKeyedArchiver : XCTestCase {
                 let s1 = String(cString: charPtr)
                 let s2 = String(cString: expectedCharPtr!)
 
-#if !DEPLOYMENT_RUNTIME_OBJC
-                // On Darwin decoded strings would belong to the autorelease pool, but as we don't have
-                // one in SwiftFoundation let's explicitly deallocate it here.
-                expectedCharPtr!.deallocate()
-#endif
                 return s1 == s2
         })
     }


### PR DESCRIPTION
No allocation was made to perform the explicit deallocation.  Doing so
causes a double free which the Windows C library caught.