### PR TITLE
Add Support for '\' in Windows Paths

### DIFF
--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -957,6 +957,8 @@ extension NSURL {
     
     open func appendingPathComponent(_ pathComponent: String) -> URL? {
         var result : URL? = appendingPathComponent(pathComponent, isDirectory: false)
+        // Since we are appending to a URL, path seperators should
+        // always be '/', even if we're on Windows
         if !pathComponent.hasSuffix("/") && isFileURL {
             if let urlWithoutDirectory = result {
                 var isDir: ObjCBool = false


### PR DESCRIPTION
While URLs get converted to forward slashes on Windows, strings are
handled as is and thus need to be able to handle \ separators. Since
many Windows apis also support /, we'll handle that as well, but default
to \ if required.