### PR TITLE
TestFoundation: ensure that `NSValue` is preserved

### DIFF
--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -289,13 +289,16 @@ class TestNSKeyedArchiver : XCTestCase {
                 guard let value = unarchiver.decodeObject(of: NSValue.self, forKey: "root") else {
                     return false
                 }
-                var expectedCharPtr: UnsafeMutablePointer<CChar>? = nil
-                value.getValue(&expectedCharPtr)
-                
-                let s1 = String(cString: charPtr)
-                let s2 = String(cString: expectedCharPtr!)
 
-                return s1 == s2
+                return withExtendedLifetime(value) { value in
+                    var expectedCharPtr: UnsafeMutablePointer<CChar>? = nil
+                    value.getValue(&expectedCharPtr)
+
+                    let s1 = String(cString: charPtr)
+                    let s2 = String(cString: expectedCharPtr!)
+
+                    return s1 == s2
+                }
         })
     }
     


### PR DESCRIPTION
Extend the lifetime of the `NSValue` object as we retrieve a pointer to
the data owned by it.  Since the data is owned by the `NSValue`
instance, we need to ensure that the `NSValue` has its lifetime extended
throughout the usage.