### PR TITLE
Implement CachedURLResponse.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,6 +443,7 @@ if(ENABLE_TESTING)
                          TestFoundation/TestAffineTransform.swift
                          TestFoundation/TestBundle.swift
                          TestFoundation/TestByteCountFormatter.swift
+                         TestFoundation/TestCachedURLResponse.swift
                          TestFoundation/TestCalendar.swift
                          TestFoundation/TestCharacterSet.swift
                          TestFoundation/TestCodable.swift

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		03B6F5841F15F339004F25AF /* TestURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B6F5831F15F339004F25AF /* TestURLProtocol.swift */; };
 		1513A8432044893F00539722 /* FileManager_XDG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1513A8422044893F00539722 /* FileManager_XDG.swift */; };
 		1520469B1D8AEABE00D02E36 /* HTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1520469A1D8AEABE00D02E36 /* HTTPServer.swift */; };
-		152EF3942283457C001E1269 /* TestNSSortDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152EF3932283457B001E1269 /* TestNSSortDescriptor.swift */; };
+		1539391422A07007006DFF4F /* TestCachedURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1539391322A07007006DFF4F /* TestCachedURLResponse.swift */; };
 		153CC8352215E00200BFE8F3 /* ScannerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153CC8322214C3D100BFE8F3 /* ScannerAPI.swift */; };
 		153E951120111DC500F250BE /* CFKnownLocations.h in Headers */ = {isa = PBXBuildFile; fileRef = 153E950F20111DC500F250BE /* CFKnownLocations.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		153E951220111DC500F250BE /* CFKnownLocations.c in Sources */ = {isa = PBXBuildFile; fileRef = 153E951020111DC500F250BE /* CFKnownLocations.c */; };
@@ -616,6 +616,7 @@
 		1513A8422044893F00539722 /* FileManager_XDG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager_XDG.swift; sourceTree = "<group>"; };
 		1520469A1D8AEABE00D02E36 /* HTTPServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPServer.swift; sourceTree = "<group>"; };
 		152EF3932283457B001E1269 /* TestNSSortDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSSortDescriptor.swift; sourceTree = "<group>"; };
+		1539391322A07007006DFF4F /* TestCachedURLResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCachedURLResponse.swift; sourceTree = "<group>"; };
 		153CC8322214C3D100BFE8F3 /* ScannerAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannerAPI.swift; sourceTree = "<group>"; };
 		153E950F20111DC500F250BE /* CFKnownLocations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CFKnownLocations.h; sourceTree = "<group>"; };
 		153E951020111DC500F250BE /* CFKnownLocations.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = CFKnownLocations.c; sourceTree = "<group>"; };
@@ -1711,6 +1712,7 @@
 				EA66F63C1BF1619600136161 /* TestNSArray.swift */,
 				294E3C1C1CC5E19300E4F44C /* TestNSAttributedString.swift */,
 				90E645DE1E4C89A400D0D47C /* TestNSCache.swift */,
+				1539391322A07007006DFF4F /* TestCachedURLResponse.swift */,
 				52829AD61C160D64003BC4EF /* TestCalendar.swift */,
 				15F10CDB218909BF00D88114 /* TestNSCalendar.swift */,
 				5BC1D8BC1BF3ADFE009D3973 /* TestCharacterSet.swift */,
@@ -2877,6 +2879,7 @@
 				7D8BD739225ED1480057CF37 /* TestMeasurement.swift in Sources */,
 				CD1C7F7D1E303B47008E331C /* TestNSError.swift in Sources */,
 				294E3C1D1CC5E19300E4F44C /* TestNSAttributedString.swift in Sources */,
+				1539391422A07007006DFF4F /* TestCachedURLResponse.swift in Sources */,
 				5B13B3431C582D4C00651CE2 /* TestScanner.swift in Sources */,
 				5B13B3401C582D4C00651CE2 /* TestNSRange.swift in Sources */,
 				5B13B3371C582D4C00651CE2 /* TestNotificationCenter.swift in Sources */,

--- a/Foundation/URLCache.swift
+++ b/Foundation/URLCache.swift
@@ -47,51 +47,7 @@ extension URLCache {
     It is used to maintain characteristics and attributes of a cached 
     object. 
 */
-open class CachedURLResponse : NSObject, NSSecureCoding, NSCopying {
-    
-    public required init?(coder aDecoder: NSCoder) {
-        guard aDecoder.allowsKeyedCoding else {
-            /* Unkeyed unarchiving is not supported. */
-            return nil
-        }
-
-        guard let data = aDecoder.decodeObject(of: NSData.self, forKey: "Data") else {
-            return nil
-        }
-        guard let response = aDecoder.decodeObject(of: URLResponse.self, forKey: "URLResponse") else {
-            return nil
-        }
-        guard let storagePolicyValue = aDecoder.decodeObject(of: NSNumber.self, forKey: "StoragePolicy") else {
-            return nil
-        }
-        guard let storagePolicy = URLCache.StoragePolicy(rawValue: storagePolicyValue.uintValue) else {
-            return nil
-        }
-        let userInfo = aDecoder.decodeObject(of: NSDictionary.self, forKey: "UserInfo")
-
-        self.data = data as Data
-        self.response = response
-        self.storagePolicy = storagePolicy
-        self.userInfo = userInfo?._swiftObject
-    }
-    
-    open func encode(with aCoder: NSCoder) {
-        guard aCoder.allowsKeyedCoding else {
-            fatalError("We do not support saving to a non-keyed coder.")
-        }
-
-        aCoder.encode(data as NSData, forKey: "Data")
-        aCoder.encode(response, forKey: "URLResponse")
-        aCoder.encode(NSNumber(value: storagePolicy.rawValue), forKey: "StoragePolicy")
-        if let userInfo = userInfo {
-            aCoder.encode(userInfo._nsObject, forKey: "UserInfo")
-        }
-    }
-    
-    static public var supportsSecureCoding: Bool {
-        return true
-    }
-    
+open class CachedURLResponse : NSObject, NSCopying {
     open override func copy() -> Any {
         return copy(with: nil)
     }

--- a/Foundation/URLCache.swift
+++ b/Foundation/URLCache.swift
@@ -50,11 +50,42 @@ extension URLCache {
 open class CachedURLResponse : NSObject, NSSecureCoding, NSCopying {
     
     public required init?(coder aDecoder: NSCoder) {
-        NSUnimplemented()
+        guard aDecoder.allowsKeyedCoding else {
+            /* Unkeyed unarchiving is not supported. */
+            return nil
+        }
+
+        guard let data = aDecoder.decodeObject(of: NSData.self, forKey: "Data") else {
+            return nil
+        }
+        guard let response = aDecoder.decodeObject(of: URLResponse.self, forKey: "URLResponse") else {
+            return nil
+        }
+        guard let storagePolicyValue = aDecoder.decodeObject(of: NSNumber.self, forKey: "StoragePolicy") else {
+            return nil
+        }
+        guard let storagePolicy = URLCache.StoragePolicy(rawValue: storagePolicyValue.uintValue) else {
+            return nil
+        }
+        let userInfo = aDecoder.decodeObject(of: NSDictionary.self, forKey: "UserInfo")
+
+        self.data = data as Data
+        self.response = response
+        self.storagePolicy = storagePolicy
+        self.userInfo = userInfo?._swiftObject
     }
     
     open func encode(with aCoder: NSCoder) {
-        NSUnimplemented()
+        guard aCoder.allowsKeyedCoding else {
+            fatalError("We do not support saving to a non-keyed coder.")
+        }
+
+        aCoder.encode(data as NSData, forKey: "Data")
+        aCoder.encode(response, forKey: "URLResponse")
+        aCoder.encode(NSNumber(value: storagePolicy.rawValue), forKey: "StoragePolicy")
+        if let userInfo = userInfo {
+            aCoder.encode(userInfo._nsObject, forKey: "UserInfo")
+        }
     }
     
     static public var supportsSecureCoding: Bool {
@@ -66,7 +97,7 @@ open class CachedURLResponse : NSObject, NSSecureCoding, NSCopying {
     }
     
     open func copy(with zone: NSZone? = nil) -> Any {
-        NSUnimplemented()
+        return self
     }
 
     /*!
@@ -81,7 +112,12 @@ open class CachedURLResponse : NSObject, NSSecureCoding, NSCopying {
         corresponding to the given response.
         @result an initialized CachedURLResponse.
     */
-    public init(response: URLResponse, data: Data) { NSUnimplemented() }
+    public init(response: URLResponse, data: Data) {
+        self.response = response.copy() as! URLResponse
+        self.data = data
+        self.userInfo = nil
+        self.storagePolicy = .allowed
+    }
     
     /*! 
         @method initWithResponse:data:userInfo:storagePolicy:
@@ -95,35 +131,69 @@ open class CachedURLResponse : NSObject, NSSecureCoding, NSCopying {
         @param storagePolicy an URLCache.StoragePolicy constant.
         @result an initialized CachedURLResponse.
     */
-    public init(response: URLResponse, data: Data, userInfo: [AnyHashable : Any]? = [:], storagePolicy: URLCache.StoragePolicy) { NSUnimplemented() }
+    public init(response: URLResponse, data: Data, userInfo: [AnyHashable : Any]? = nil, storagePolicy: URLCache.StoragePolicy) {
+        self.response = response.copy() as! URLResponse
+        self.data = data
+        self.userInfo = userInfo
+        self.storagePolicy = storagePolicy
+    }
     
     /*! 
         @method response
         @abstract Returns the response wrapped by this instance. 
         @result The response wrapped by this instance. 
     */
-    /*@NSCopying*/ open var response: URLResponse { NSUnimplemented() }
+    /*@NSCopying*/ open private(set) var response: URLResponse
     
     /*! 
         @method data
         @abstract Returns the data of the receiver. 
         @result The data of the receiver. 
     */
-    /*@NSCopying*/ open var data: Data { NSUnimplemented() }
+    /*@NSCopying*/ open private(set) var data: Data
     
     /*! 
         @method userInfo
         @abstract Returns the userInfo dictionary of the receiver. 
         @result The userInfo dictionary of the receiver. 
     */
-    open var userInfo: [AnyHashable : Any]? { NSUnimplemented() }
+    open private(set) var userInfo: [AnyHashable : Any]?
     
     /*! 
         @method storagePolicy
         @abstract Returns the URLCache.StoragePolicy constant of the receiver.
         @result The URLCache.StoragePolicy constant of the receiver.
     */
-    open var storagePolicy: URLCache.StoragePolicy { NSUnimplemented() }
+    open private(set) var storagePolicy: URLCache.StoragePolicy
+
+    open override func isEqual(_ value: Any?) -> Bool {
+        switch value {
+        case let other as CachedURLResponse:
+            return self.isEqual(to: other)
+        default:
+            return false
+        }
+    }
+
+    private func isEqual(to other: CachedURLResponse) -> Bool {
+        if self === other {
+            return true
+        }
+
+        // We cannot compare userInfo because of the values are Any, which
+        // doesn't conform to Equatable.
+        return self.response == other.response &&
+                self.data == other.data &&
+                self.storagePolicy == other.storagePolicy
+    }
+
+    open override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(response)
+        hasher.combine(data)
+        hasher.combine(storagePolicy)
+        return hasher.finalize()
+    }
 }
 
 open class URLCache : NSObject {

--- a/Foundation/URLResponse.swift
+++ b/Foundation/URLResponse.swift
@@ -138,6 +138,35 @@ open class URLResponse : NSObject, NSSecureCoding, NSCopying {
     ///
     /// This method always returns a valid filename.
     open fileprivate(set) var suggestedFilename: String?
+
+    open override func isEqual(_ value: Any?) -> Bool {
+        switch value {
+        case let other as URLResponse:
+            return self.isEqual(to: other)
+        default:
+            return false
+        }
+    }
+
+    private func isEqual(to other: URLResponse) -> Bool {
+        if self === other {
+            return true
+        }
+
+        return self.url == other.url &&
+                self.expectedContentLength == other.expectedContentLength &&
+                self.mimeType == other.mimeType &&
+                self.textEncodingName == other.textEncodingName
+    }
+
+    open override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(url)
+        hasher.combine(expectedContentLength)
+        hasher.combine(mimeType)
+        hasher.combine(textEncodingName)
+        return hasher.finalize()
+    }
 }
 
 /// A Response to an HTTP URL load.

--- a/TestFoundation/TestCachedURLResponse.swift
+++ b/TestFoundation/TestCachedURLResponse.swift
@@ -1,0 +1,224 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+class TestCachedURLResponse : XCTestCase {
+    func test_NSCoding() throws {
+        let url = try URL(string: "http://example.com/").unwrapped()
+        let response = URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let data = Data(bytes: bytes, count: bytes.count)
+        let userInfo: [AnyHashable: Any] = ["Key1": "Value1", "Key2": "Value2"]
+        let storagePolicy = URLCache.StoragePolicy.allowedInMemoryOnly
+        let cachedResponse = CachedURLResponse(response: response, data: data, userInfo: userInfo, storagePolicy: storagePolicy)
+
+        let unarchivedResponse = NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: cachedResponse)) as! CachedURLResponse
+
+        XCTAssertEqual(cachedResponse.response, unarchivedResponse.response)
+        XCTAssertEqual(cachedResponse.data, unarchivedResponse.data)
+        XCTAssertEqual(cachedResponse.userInfo?.keys, unarchivedResponse.userInfo?.keys)
+        XCTAssertEqual(cachedResponse.storagePolicy, unarchivedResponse.storagePolicy)
+    }
+
+    func test_copy() throws {
+        let url = try URL(string: "http://example.com/").unwrapped()
+        let response = URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let data = Data(bytes: bytes, count: bytes.count)
+        let userInfo: [AnyHashable: Any] = ["Key1": "Value1", "Key2": "Value2"]
+        let storagePolicy = URLCache.StoragePolicy.allowedInMemoryOnly
+        let cachedResponse = CachedURLResponse(response: response, data: data, userInfo: userInfo, storagePolicy: storagePolicy)
+
+        let copiedResponse = cachedResponse.copy() as! CachedURLResponse
+
+        XCTAssertEqual(cachedResponse.response, copiedResponse.response)
+        XCTAssertEqual(cachedResponse.data, copiedResponse.data)
+        XCTAssertEqual(cachedResponse.userInfo?.keys, copiedResponse.userInfo?.keys)
+        XCTAssertEqual(cachedResponse.storagePolicy, copiedResponse.storagePolicy)
+    }
+
+    func test_initDefaultUserInfoAndStoragePolicy() throws {
+        let url = try URL(string: "http://example.com/").unwrapped()
+        let response = URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let data = Data(bytes: bytes, count: bytes.count)
+        let cachedResponse = CachedURLResponse(response: response, data: data)
+
+        XCTAssertEqual(response, cachedResponse.response)
+        XCTAssertEqual(data, cachedResponse.data)
+        XCTAssertNil(cachedResponse.userInfo)
+        XCTAssertEqual(.allowed, cachedResponse.storagePolicy)
+    }
+
+    func test_initDefaultUserInfo() throws {
+        let url = try URL(string: "http://example.com/").unwrapped()
+        let response = URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let data = Data(bytes: bytes, count: bytes.count)
+        let storagePolicy = URLCache.StoragePolicy.allowedInMemoryOnly
+        let cachedResponse = CachedURLResponse(response: response, data: data, storagePolicy: storagePolicy)
+
+        XCTAssertEqual(response, cachedResponse.response)
+        XCTAssertEqual(data, cachedResponse.data)
+        XCTAssertNil(cachedResponse.userInfo)
+        XCTAssertEqual(storagePolicy, cachedResponse.storagePolicy)
+    }
+
+    func test_initWithoutDefaults() throws {
+        let url = try URL(string: "http://example.com/").unwrapped()
+        let response = URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let data = Data(bytes: bytes, count: bytes.count)
+        let userInfo: [AnyHashable: Any] = ["Key1": "Value1", "Key2": "Value2"]
+        let storagePolicy = URLCache.StoragePolicy.allowedInMemoryOnly
+        let cachedResponse = CachedURLResponse(response: response, data: data, userInfo: userInfo, storagePolicy: storagePolicy)
+
+        XCTAssertEqual(response, cachedResponse.response)
+        XCTAssertEqual(data, cachedResponse.data)
+        XCTAssertEqual(userInfo.keys, cachedResponse.userInfo?.keys)
+        XCTAssertEqual(storagePolicy, cachedResponse.storagePolicy)
+    }
+
+    func test_equalWithTheSameInstance() throws {
+        let url = try URL(string: "http://example.com/").unwrapped()
+        let response = URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let data = Data(bytes: bytes, count: bytes.count)
+        let userInfo: [AnyHashable: Any] = ["Key1": "Value1", "Key2": "Value2"]
+        let storagePolicy = URLCache.StoragePolicy.allowedInMemoryOnly
+        let cachedResponse = CachedURLResponse(response: response, data: data, userInfo: userInfo, storagePolicy: storagePolicy)
+
+        XCTAssertTrue(cachedResponse.isEqual(cachedResponse))
+    }
+
+    func test_equalWithUnrelatedObject() throws {
+        let url = try URL(string: "http://example.com/").unwrapped()
+        let response = URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let data = Data(bytes: bytes, count: bytes.count)
+        let userInfo: [AnyHashable: Any] = ["Key1": "Value1", "Key2": "Value2"]
+        let storagePolicy = URLCache.StoragePolicy.allowedInMemoryOnly
+        let cachedResponse = CachedURLResponse(response: response, data: data, userInfo: userInfo, storagePolicy: storagePolicy)
+
+        XCTAssertFalse(cachedResponse.isEqual(NSObject()))
+    }
+
+    func test_equalCheckingResponse() throws {
+        let url1 = try URL(string: "http://example.com/").unwrapped()
+        let response1 = URLResponse(url: url1, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let data = Data(bytes: bytes, count: bytes.count)
+        let userInfo: [AnyHashable: Any] = ["Key1": "Value1", "Key2": "Value2"]
+        let storagePolicy = URLCache.StoragePolicy.allowedInMemoryOnly
+        let cachedResponse1 = CachedURLResponse(response: response1, data: data, userInfo: userInfo, storagePolicy: storagePolicy)
+
+        let url2 = try URL(string: "http://example.com/second").unwrapped()
+        let response2 = URLResponse(url: url2, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+        let cachedResponse2 = CachedURLResponse(response: response2, data: data, userInfo: userInfo, storagePolicy: storagePolicy)
+
+        let url3 = try URL(string: "http://example.com/").unwrapped()
+        let response3 = URLResponse(url: url3, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+        let cachedResponse3 = CachedURLResponse(response: response3, data: data, userInfo: userInfo, storagePolicy: storagePolicy)
+
+        XCTAssertFalse(cachedResponse1.isEqual(cachedResponse2))
+        XCTAssertFalse(cachedResponse2.isEqual(cachedResponse1))
+        XCTAssertTrue(cachedResponse1.isEqual(cachedResponse3))
+        XCTAssertTrue(cachedResponse3.isEqual(cachedResponse1))
+    }
+
+    func test_equalCheckingData() throws {
+        let url = try URL(string: "http://example.com/").unwrapped()
+        let response = URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+        let bytes1: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let data1 = Data(bytes: bytes1, count: bytes1.count)
+        let userInfo: [AnyHashable: Any] = ["Key1": "Value1", "Key2": "Value2"]
+        let storagePolicy = URLCache.StoragePolicy.allowedInMemoryOnly
+        let cachedResponse1 = CachedURLResponse(response: response, data: data1, userInfo: userInfo, storagePolicy: storagePolicy)
+
+        let bytes2: [UInt8] = [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+        let data2 = Data(bytes: bytes2, count: bytes2.count)
+        let cachedResponse2 = CachedURLResponse(response: response, data: data2, userInfo: userInfo, storagePolicy: storagePolicy)
+
+        let bytes3: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let data3 = Data(bytes: bytes3, count: bytes3.count)
+        let cachedResponse3 = CachedURLResponse(response: response, data: data3, userInfo: userInfo, storagePolicy: storagePolicy)
+
+        XCTAssertFalse(cachedResponse1.isEqual(cachedResponse2))
+        XCTAssertFalse(cachedResponse2.isEqual(cachedResponse1))
+        XCTAssertTrue(cachedResponse1.isEqual(cachedResponse3))
+        XCTAssertTrue(cachedResponse3.isEqual(cachedResponse1))
+    }
+
+    func test_equalCheckingStoragePolicy() throws {
+        let url = try URL(string: "http://example.com/").unwrapped()
+        let response = URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let data = Data(bytes: bytes, count: bytes.count)
+        let userInfo: [AnyHashable: Any] = ["Key1": "Value1", "Key2": "Value2"]
+        let storagePolicy1 = URLCache.StoragePolicy.allowedInMemoryOnly
+        let cachedResponse1 = CachedURLResponse(response: response, data: data, userInfo: userInfo, storagePolicy: storagePolicy1)
+
+        let storagePolicy2 = URLCache.StoragePolicy.notAllowed
+        let cachedResponse2 = CachedURLResponse(response: response, data: data, userInfo: userInfo, storagePolicy: storagePolicy2)
+
+        let storagePolicy3 = URLCache.StoragePolicy.allowedInMemoryOnly
+        let cachedResponse3 = CachedURLResponse(response: response, data: data, userInfo: userInfo, storagePolicy: storagePolicy3)
+
+        XCTAssertFalse(cachedResponse1.isEqual(cachedResponse2))
+        XCTAssertFalse(cachedResponse2.isEqual(cachedResponse1))
+        XCTAssertTrue(cachedResponse1.isEqual(cachedResponse3))
+        XCTAssertTrue(cachedResponse3.isEqual(cachedResponse1))
+    }
+
+    func test_hash() throws {
+        let url1 = try URL(string: "http://example.com/").unwrapped()
+        let response1 = URLResponse(url: url1, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+        let bytes1: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let data1 = Data(bytes: bytes1, count: bytes1.count)
+        let userInfo1: [AnyHashable: Any] = ["Key1": "Value1", "Key2": "Value2"]
+        let storagePolicy1 = URLCache.StoragePolicy.allowedInMemoryOnly
+        let cachedResponse1 = CachedURLResponse(response: response1, data: data1, userInfo: userInfo1, storagePolicy: storagePolicy1)
+
+        let url2 = try URL(string: "http://example.com/").unwrapped()
+        let response2 = URLResponse(url: url2, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+        let bytes2: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let data2 = Data(bytes: bytes2, count: bytes2.count)
+        let userInfo2: [AnyHashable: Any] = ["Key1": "Value1", "Key2": "Value2"]
+        let storagePolicy2 = URLCache.StoragePolicy.allowedInMemoryOnly
+        let cachedResponse2 = CachedURLResponse(response: response2, data: data2, userInfo: userInfo2, storagePolicy: storagePolicy2)
+
+        // Ideally, this cached response should have a different hash.
+        let url3 = try URL(string: "http://example.com/second").unwrapped()
+        let response3 = URLResponse(url: url3, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+        let bytes3: [UInt8] = [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+        let data3 = Data(bytes: bytes3, count: bytes3.count)
+        let userInfo3: [AnyHashable: Any] = ["Key3": "Value3", "Key2": "Value2"]
+        let storagePolicy3 = URLCache.StoragePolicy.notAllowed
+        let cachedResponse3 = CachedURLResponse(response: response3, data: data3, userInfo: userInfo3, storagePolicy: storagePolicy3)
+
+        XCTAssertEqual(cachedResponse1.hash, cachedResponse2.hash)
+        XCTAssertNotEqual(cachedResponse1.hash, cachedResponse3.hash)
+        XCTAssertNotEqual(cachedResponse2.hash, cachedResponse3.hash)
+    }
+
+    static var allTests: [(String, (TestCachedURLResponse) -> () throws -> Void)] {
+        return [
+            ("test_NSCoding", test_NSCoding),
+            ("test_copy", test_copy),
+            ("test_initDefaultUserInfoAndStoragePolicy", test_initDefaultUserInfoAndStoragePolicy),
+            ("test_initDefaultUserInfo", test_initDefaultUserInfo),
+            ("test_initWithoutDefaults", test_initWithoutDefaults),
+            ("test_equalWithTheSameInstance", test_equalWithTheSameInstance),
+            ("test_equalWithUnrelatedObject", test_equalWithUnrelatedObject),
+            ("test_equalCheckingResponse", test_equalCheckingResponse),
+            ("test_equalCheckingData", test_equalCheckingData),
+            ("test_equalCheckingStoragePolicy", test_equalCheckingStoragePolicy),
+            ("test_hash", test_hash),
+        ]
+    }
+}

--- a/TestFoundation/TestCachedURLResponse.swift
+++ b/TestFoundation/TestCachedURLResponse.swift
@@ -8,23 +8,6 @@
 //
 
 class TestCachedURLResponse : XCTestCase {
-    func test_NSCoding() throws {
-        let url = try URL(string: "http://example.com/").unwrapped()
-        let response = URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
-        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-        let data = Data(bytes: bytes, count: bytes.count)
-        let userInfo: [AnyHashable: Any] = ["Key1": "Value1", "Key2": "Value2"]
-        let storagePolicy = URLCache.StoragePolicy.allowedInMemoryOnly
-        let cachedResponse = CachedURLResponse(response: response, data: data, userInfo: userInfo, storagePolicy: storagePolicy)
-
-        let unarchivedResponse = NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: cachedResponse)) as! CachedURLResponse
-
-        XCTAssertEqual(cachedResponse.response, unarchivedResponse.response)
-        XCTAssertEqual(cachedResponse.data, unarchivedResponse.data)
-        XCTAssertEqual(cachedResponse.userInfo?.keys, unarchivedResponse.userInfo?.keys)
-        XCTAssertEqual(cachedResponse.storagePolicy, unarchivedResponse.storagePolicy)
-    }
-
     func test_copy() throws {
         let url = try URL(string: "http://example.com/").unwrapped()
         let response = URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
@@ -208,7 +191,6 @@ class TestCachedURLResponse : XCTestCase {
 
     static var allTests: [(String, (TestCachedURLResponse) -> () throws -> Void)] {
         return [
-            ("test_NSCoding", test_NSCoding),
             ("test_copy", test_copy),
             ("test_initDefaultUserInfoAndStoragePolicy", test_initDefaultUserInfoAndStoragePolicy),
             ("test_initDefaultUserInfo", test_initDefaultUserInfo),

--- a/TestFoundation/TestURLResponse.swift
+++ b/TestFoundation/TestURLResponse.swift
@@ -19,6 +19,13 @@ class TestURLResponse : XCTestCase {
             ("test_suggestedFilename_3", test_suggestedFilename_3),
             ("test_copywithzone", test_copyWithZone),
             ("test_NSCoding", test_NSCoding),
+            ("test_equalWithTheSameInstance", test_equalWithTheSameInstance),
+            ("test_equalWithUnrelatedObject", test_equalWithUnrelatedObject),
+            ("test_equalCheckingURL", test_equalCheckingURL),
+            ("test_equalCheckingMimeType", test_equalCheckingMimeType),
+            ("test_equalCheckingExpectedContentLength", test_equalCheckingExpectedContentLength),
+            ("test_equalCheckingTextEncodingName", test_equalCheckingTextEncodingName),
+            ("test_hash", test_hash),
         ]
     }
     
@@ -102,6 +109,92 @@ class TestURLResponse : XCTestCase {
         XCTAssertEqual(responseA.expectedContentLength, responseB.expectedContentLength, "Archived then unarchived url response must be equal.")
         XCTAssertEqual(responseA.textEncodingName, responseB.textEncodingName, "Archived then unarchived url response must be equal.")
         XCTAssertEqual(responseA.suggestedFilename, responseB.suggestedFilename, "Archived then unarchived url response must be equal.")
+    }
+
+    func test_equalWithTheSameInstance() throws {
+        let url = try URL(string: "http://example.com/").unwrapped()
+        let response = URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+
+        XCTAssertTrue(response.isEqual(response))
+    }
+
+    func test_equalWithUnrelatedObject() throws {
+        let url = try URL(string: "http://example.com/").unwrapped()
+        let response = URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+
+        XCTAssertFalse(response.isEqual(NSObject()))
+    }
+
+    func test_equalCheckingURL() throws {
+        let url1 = try URL(string: "http://example.com/").unwrapped()
+        let response1 = URLResponse(url: url1, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+
+        let url2 = try URL(string: "http://example.com/second").unwrapped()
+        let response2 = URLResponse(url: url2, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+
+        let response3 = URLResponse(url: url1, mimeType: nil, expectedContentLength: -1, textEncodingName: nil)
+
+        XCTAssertFalse(response1.isEqual(response2))
+        XCTAssertFalse(response2.isEqual(response1))
+        XCTAssertTrue(response1.isEqual(response3))
+        XCTAssertTrue(response3.isEqual(response1))
+    }
+
+    func test_equalCheckingMimeType() throws {
+        let url = try URL(string: "http://example.com/").unwrapped()
+        let response1 = URLResponse(url: url, mimeType: "mimeType1", expectedContentLength: -1, textEncodingName: nil)
+
+        let response2 = URLResponse(url: url, mimeType: "mimeType2", expectedContentLength: -1, textEncodingName: nil)
+
+        let response3 = URLResponse(url: url, mimeType: "mimeType1", expectedContentLength: -1, textEncodingName: nil)
+
+        XCTAssertFalse(response1.isEqual(response2))
+        XCTAssertFalse(response2.isEqual(response1))
+        XCTAssertTrue(response1.isEqual(response3))
+        XCTAssertTrue(response3.isEqual(response1))
+    }
+
+    func test_equalCheckingExpectedContentLength() throws {
+        let url = try URL(string: "http://example.com/").unwrapped()
+        let response1 = URLResponse(url: url, mimeType: nil, expectedContentLength: 100, textEncodingName: nil)
+
+        let response2 = URLResponse(url: url, mimeType: nil, expectedContentLength: 200, textEncodingName: nil)
+
+        let response3 = URLResponse(url: url, mimeType: nil, expectedContentLength: 100, textEncodingName: nil)
+
+        XCTAssertFalse(response1.isEqual(response2))
+        XCTAssertFalse(response2.isEqual(response1))
+        XCTAssertTrue(response1.isEqual(response3))
+        XCTAssertTrue(response3.isEqual(response1))
+    }
+
+    func test_equalCheckingTextEncodingName() throws {
+        let url = try URL(string: "http://example.com/").unwrapped()
+        let response1 = URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: "textEncodingName1")
+
+        let response2 = URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: "textEncodingName2")
+
+        let response3 = URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: "textEncodingName1")
+
+        XCTAssertFalse(response1.isEqual(response2))
+        XCTAssertFalse(response2.isEqual(response1))
+        XCTAssertTrue(response1.isEqual(response3))
+        XCTAssertTrue(response3.isEqual(response1))
+    }
+
+    func test_hash() throws {
+        let url1 = try URL(string: "http://example.com/").unwrapped()
+        let response1 = URLResponse(url: url1, mimeType: "mimeType1", expectedContentLength: 100, textEncodingName: "textEncodingName1")
+
+        let url2 = try URL(string: "http://example.com/").unwrapped()
+        let response2 = URLResponse(url: url2, mimeType: "mimeType1", expectedContentLength: 100, textEncodingName: "textEncodingName1")
+
+        let url3 = try URL(string: "http://example.com/second").unwrapped()
+        let response3 = URLResponse(url: url3, mimeType: "mimeType3", expectedContentLength: 200, textEncodingName: "textEncodingName3")
+
+        XCTAssertEqual(response1.hash, response2.hash)
+        XCTAssertNotEqual(response1.hash, response3.hash)
+        XCTAssertNotEqual(response2.hash, response3.hash)
     }
 }
 

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -27,6 +27,7 @@ var allTestCases = [
     testCase(TestBundle.allTests),
     testCase(TestByteCountFormatter.allTests),
     testCase(TestNSCache.allTests),
+    testCase(TestCachedURLResponse.allTests),
     testCase(TestCalendar.allTests),
     testCase(TestNSCalendar.allTests),
     testCase(TestCharacterSet.allTests),


### PR DESCRIPTION
Simple implementation for CachedURLResponse. The type seems to mostly be
a data container with little behaviour.

Implement the missing equality and hashing for URLResponse, which is
used by CachedURLResponse.

Implement tests for CachedURLResponse and the missing tests for
equality and hashing in URLResponse.

https://bugs.swift.org/browse/SR-10373