### PR TITLE
[cmake] Add runpath for libBlocksRuntime.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,18 +92,27 @@ set(libdispatch_ldflags)
 if(FOUNDATION_ENABLE_LIBDISPATCH)
   set(libdispatch_cflags -I;${FOUNDATION_PATH_TO_LIBDISPATCH_SOURCE};-I;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src/swift;-Xcc;-fblocks)
   set(libdispatch_ldflags -L;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD};-L;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src;-ldispatch;-lswiftDispatch)
-  if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
-    file(TO_CMAKE_PATH "${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}" FOUNDATION_PATH_TO_LIBDISPATCH_BUILD)
-    list(APPEND libdispatch_ldflags -Xlinker;-rpath;-Xlinker;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src)
-  endif()
 endif()
 
-set(plutil_rpath)
-if(CMAKE_SYSTEM_NAME STREQUAL Android OR CMAKE_SYSTEM_NAME STREQUAL Linux OR
-    CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
-  set(Foundation_RPATH -Xlinker;-rpath;-Xlinker;"\\\$\$ORIGIN")
-  set(XDG_TEST_HELPER_RPATH -Xlinker;-rpath;-Xlinker;${CMAKE_CURRENT_BINARY_DIR})
-  set(plutil_rpath -Xlinker;-rpath;-Xlinker;"\\\$\$ORIGIN/../lib/swift/${swift_os}")
+
+if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+  append_linker_rpath(Foundation_RPATH "\\\$\$ORIGIN")
+  append_linker_rpath(TestFoundation_RPATH ${CMAKE_CURRENT_BINARY_DIR})
+  append_linker_rpath(TestFoundation_RPATH ${FOUNDATION_PATH_TO_XCTEST_BUILD})
+  append_linker_rpath(XDG_TEST_HELPER_RPATH ${CMAKE_CURRENT_BINARY_DIR})
+  append_linker_rpath(plutil_rpath "\\\$\$ORIGIN/../lib/swift/${swift_os}")
+  if (FOUNDATION_ENABLE_LIBDISPATCH)
+    file(TO_CMAKE_PATH "${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}" FOUNDATION_PATH_TO_LIBDISPATCH_BUILD)
+    # NOTE: the following two are for testing LLDB and others, but should be removed
+    append_linker_rpath(Foundation_RPATH ${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src)
+    append_linker_rpath(Foundation_RPATH ${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD})
+    append_linker_rpath(TestFoundation_RPATH ${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src)
+    append_linker_rpath(TestFoundation_RPATH ${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD})
+    append_linker_rpath(XDG_TEST_HELPER_RPATH ${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src)
+    append_linker_rpath(XDG_TEST_HELPER_RPATH ${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD})
+  endif()
+elseif(CMAKE_SYSTEM_NAME STREQUAL Android)
+  append_linker_rpath(Foundation_RPATH "\\\$\$ORIGIN")
 elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
   # FIXME(SR9138) Silence "locally defined symbol '…' imported in function '…'
   set(WORKAROUND_SR9138 -Xlinker;-ignore:4049;-Xlinker;-ignore:4217)
@@ -535,6 +544,7 @@ if(ENABLE_TESTING)
                          -L${FOUNDATION_PATH_TO_XCTEST_BUILD}
                          -lXCTest
                          ${WORKAROUND_SR9138}
+                         ${TestFoundation_RPATH}
                        RESOURCES
                          ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/Info.plist
                          ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/NSURLTestData.plist

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -273,3 +273,20 @@ function(get_swift_host_arch result_var_name)
     message(FATAL_ERROR "Unrecognized architecture on host system: ${CMAKE_SYSTEM_PROCESSOR}")
   endif()
 endfunction()
+
+
+# Appends an the given path as an rpath prefixed by the -Xlinker arguments for
+# the Swift compiler to pass to the linker.
+#
+# Usage:
+#   append_linker_rpath(MyTarget_RPATH one)
+#   append_linker_rpath(MyTarget_RPATH two)
+#   # MyTarget_RPATH=-Xlinker;-rpath;-Xlinker;one;-Xlinker;-rpath;-Xlinker;two
+#
+function(append_linker_rpath result_var_name rpath)
+  set(tmp ${${result_var_name}})
+
+  list(APPEND tmp -Xlinker -rpath -Xlinker "${rpath}")
+
+  set(${result_var_name} ${tmp} PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
Dispatch build leaves artifacts in both the root directory and the src
directory, but only the src directory was being added to the runpath, so
the libBlocksRuntime.so library might not have been found.

Additionally, remove the rpath flags from libdispatch_ldflags, which are
used to compile Foundation, but will point to the build directory
results. Add those flags instead to a list used for the test binaries.

In the end Foundation ends up with a path of `$ORIGIN`; TestFoundation
has paths to Foundation, to Dispatch and BlocksRuntime, and to XCTest;
while xdgTestHelper points to Foundation, and Dispatch and
BlocksRuntime.

Extract a small function for adding rpaths to a list, to make the rpath
easier to read.

Also, remove Android from the rpath flags, since Android will not work
with the build tree rpaths, and will need its own solution. For the time
being, do not set any rpath.
