### PR TITLE
[5.1] Add back some elided returns

### DIFF
--- a/TestFoundation/Utilities.swift
+++ b/TestFoundation/Utilities.swift
@@ -512,11 +512,11 @@ func appendTestCaseExpectedToFail<T: XCTestCase>(_ reason: String, _ allTests: [
 }
 
 func testExpectedToFail<T>(_ test:  @escaping (T) -> () throws -> Void, _ reason: String) -> (T) -> () throws -> Void {
-    testExpectedToFailWithCheck(check: shouldAttemptXFailTests(_:), test, reason)
+    return testExpectedToFailWithCheck(check: shouldAttemptXFailTests(_:), test, reason)
 }
 
 func testExpectedToFailOnWindows<T>(_ test:  @escaping (T) -> () throws -> Void, _ reason: String) -> (T) -> () throws -> Void {
-    testExpectedToFailWithCheck(check: shouldAttemptWindowsXFailTests(_:), test, reason)
+    return testExpectedToFailWithCheck(check: shouldAttemptWindowsXFailTests(_:), test, reason)
 }
 
 func testExpectedToFailWithCheck<T>(check: (String) -> Bool, _ test:  @escaping (T) -> () throws -> Void, _ reason: String) -> (T) -> () throws -> Void {


### PR DESCRIPTION
It’s blocking PR testing on the 4/24 branch, which doesn’t appear to have the feature.