### PR TITLE
Foundation: correct `Thread.sleep(until:)` on Windows

### DIFF
--- a/Foundation/Thread.swift
+++ b/Foundation/Thread.swift
@@ -106,12 +106,12 @@ open class Thread : NSObject {
     open class func sleep(until date: Date) {
 #if os(Windows)
         var hTimer: HANDLE = CreateWaitableTimerW(nil, true, nil)
-        // FIXME(compnerd) how to check that hTimer is not NULL?
+        if hTimer == HANDLE(bitPattern: 0) { fatalError("unable to create timer: \(GetLastError())") }
         defer { CloseHandle(hTimer) }
 
         // the timeout is in 100ns units
         var liTimeout: LARGE_INTEGER =
-            LARGE_INTEGER(QuadPart: LONGLONG(date.timeIntervalSinceReferenceDate) * -10000000)
+            LARGE_INTEGER(QuadPart: LONGLONG(date.timeIntervalSinceNow) * -10000000)
         if !SetWaitableTimer(hTimer, &liTimeout, 0, nil, nil, false) {
           return
         }


### PR DESCRIPTION
We were computing the duration incorrectly, using the time since the
Cocoa epoch rather than now resulting in what appeared to be an infinite
sleep.  Correct the duration which is relative to *now* in 100ns
intervals.  This allows the NSLock tests to succeed.