### PR TITLE
CoreFoundation: simplify target computation

### DIFF
--- a/CoreFoundation/Base.subproj/CFSystemDirectories.c
+++ b/CoreFoundation/Base.subproj/CFSystemDirectories.c
@@ -18,7 +18,7 @@
 #include <CoreFoundation/CFPriv.h>
 #include "CFInternal.h"
 
-#if TARGET_OS_OSX || TARGET_OS_IPHONE
+#if TARGET_OS_MAC
 
 /* We use the System framework implementation on Mach.
 */


### PR DESCRIPTION
Fold `TARGET_OS_OSX || TARGET_OS_IPHONE` to `TARGET_OS_MAC`.