### PR TITLE
Place a time limit on TestFileHandle.test_readWriteHandlers()

### DIFF
--- a/TestFoundation/TestFileHandle.swift
+++ b/TestFoundation/TestFileHandle.swift
@@ -488,7 +488,7 @@ class TestFileHandle : XCTestCase {
                 try? handle.write(contentsOf: self.content)
             }
             
-            let result = semaphore.wait(timeout: .distantFuture)
+            let result = semaphore.wait(timeout: .now() + .seconds(30))
             XCTAssertEqual(result, .success, "Waiting on the semaphore should not have had time to time out")
             XCTAssertTrue(notificationReceived, "Notification should be sent")
         }


### PR DESCRIPTION
This test seems to sometimes fail, which can make it hang forever. Give it a still-generous-but-not-infinite timeout so it at least fails gracefully when it fails.

Fixes [SR-10680](https://bugs.swift.org/browse/SR-10680) and rdar://problem/50735595.