### PR TITLE
build: correct dependencies for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,8 @@ add_swift_library(Foundation
                     ${swift_optimization_flags}
                   DEPENDS
                     uuid
-                    CoreFoundation)
+                    CoreFoundation
+                    $<$<PLATFORM_ID:Windows>:CoreFoundationResources>)
 
 if(NOT BUILD_SHARED_LIBS)
   set(Foundation_INTERFACE_LIBRARIES


### PR DESCRIPTION
When building Foundation, ensure that we build CoreFoundationResources
as we need to incorporate the build artifacts.