### PR TITLE
Process: correct environment block handling on Windows

### DIFF
--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -445,7 +445,10 @@ open class Process: NSObject {
           environment["PWD"] = currentDirectoryURL.path
         }
 
-        let szEnvironment: String = environment.map { $0.key + "=" + $0.value }.joined(separator: "\0")
+        // NOTE(compnerd) the environment string must be terminated by a double
+        // null-terminator.  Otherwise, CreateProcess will fail with
+        // INVALID_PARMETER.
+        let szEnvironment: String = environment.map { $0.key + "=" + $0.value }.joined(separator: "\0") + "\0\0"
 
         let sockets: (first: SOCKET, second: SOCKET) = _socketpair()
 


### PR DESCRIPTION
Adjust the Windows environment creation to ensure that we properly form
the string that represents the child's environment.