### PR TITLE
[5.0] DateFormatter(and CFDateFormatter), Fix date string parse with Japane…

### DIFF
--- a/CoreFoundation/Locale.subproj/CFDateFormatter.c
+++ b/CoreFoundation/Locale.subproj/CFDateFormatter.c
@@ -1557,7 +1557,7 @@ static UDate __CFDateFormatterCorrectTimeToARangeAroundCurrentDate(UCalendar *ca
     return __CFDateFormatterCorrectTimeWithTarget(calendar, at, currEraOrCentury+offset, isEra, status);
 }
 
-#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI || DEPLOYMENT_TARGET_WINDOWS
+#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI || DEPLOYMENT_TARGET_WINDOWS || DEPLOYMENT_TARGET_LINUX
 static int32_t __CFDateFormatterGetMaxYearGivenJapaneseEra(UCalendar *calendar, int32_t era, UErrorCode *status) {
     int32_t years = 0;
     __cficu_ucal_clear(calendar);
@@ -1610,7 +1610,7 @@ static Boolean __CFDateFormatterHandleAmbiguousYear(CFDateFormatterRef formatter
             }
         }
     } else if (calendar_id == kCFCalendarIdentifierJapanese) { // ??? need more work
-#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI || DEPLOYMENT_TARGET_WINDOWS
+#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED || DEPLOYMENT_TARGET_EMBEDDED_MINI || DEPLOYMENT_TARGET_WINDOWS || DEPLOYMENT_TARGET_LINUX
         __cficu_ucal_clear(cal);
         __cficu_ucal_set(cal, UCAL_ERA, 1);
         __cficu_udat_parseCalendar(df, cal, ustr, length, NULL, status);

--- a/TestFoundation/TestDateFormatter.swift
+++ b/TestFoundation/TestDateFormatter.swift
@@ -27,6 +27,7 @@ class TestDateFormatter: XCTestCase {
             ("test_setTimeZone", test_setTimeZone),
             ("test_expectedTimeZone", test_expectedTimeZone),
             ("test_dateFrom", test_dateFrom),
+            ("test_dateParseAndFormatWithJapaneseCalendar", test_dateParseAndFormatWithJapaneseCalendar),
         ]
     }
     
@@ -424,5 +425,22 @@ class TestDateFormatter: XCTestCase {
         XCTAssertNil(formatter.date(from: "2018-03-09"))
         let d2 = try formatter.date(from: "2018-03-09T10:25:16+01:00").unwrapped()
         XCTAssertEqual(d2.description, "2018-03-09 09:25:16 +0000")
+    }
+    
+    func test_dateParseAndFormatWithJapaneseCalendar() throws {
+        let formatter = DateFormatter()
+        
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.calendar = Calendar(identifier: .japanese)
+        formatter.dateFormat = "Gy年M月dd日 HH:mm"
+        formatter.timeZone = TimeZone(abbreviation: "JST")
+        
+        // parse test
+        let parsed = formatter.date(from: "平成31年4月30日 23:10")
+        XCTAssertEqual(parsed?.timeIntervalSince1970, 1556633400) // April 30, 2019, 11:10 PM (JST)
+        
+        // format test
+        let dateString = formatter.string(from: Date(timeIntervalSince1970: 1556633400)) // April 30, 2019, 11:10 PM (JST)
+        XCTAssertEqual(dateString, "平成31年4月30日 23:10")
     }
 }


### PR DESCRIPTION
…se calendar

This changes fix that DateFormatter with Japanese calendar does not parse Japanese era name and years correctly on Linux environment.

(cherry picked from commit ca967d77b704ec07e152557baf393755331d457c)
original PR #2179 