### PR TITLE
[5.0] SR-10619: Order in which DateFormatter settings are set up matters on…

### DIFF
--- a/Foundation/DateFormatter.swift
+++ b/Foundation/DateFormatter.swift
@@ -21,7 +21,7 @@ open class DateFormatter : Formatter {
                 let dateStyle = CFDateFormatterStyle(self.dateStyle.rawValue)
                 let timeStyle = CFDateFormatterStyle(self.timeStyle.rawValue)
             #endif
-            
+
             let obj = CFDateFormatterCreate(kCFAllocatorSystemDefault, locale._cfObject, dateStyle, timeStyle)!
             _setFormatterAttributes(obj)
             if let dateFormat = _dateFormat {
@@ -139,7 +139,7 @@ open class DateFormatter : Formatter {
     open var dateFormat: String! {
         get {
             guard let format = _dateFormat else {
-                return __cfObject.map { CFDateFormatterGetFormat($0)._swiftObject } ?? ""
+                return CFDateFormatterGetFormat(_cfObject)._swiftObject
             }
             return format
         }
@@ -152,17 +152,11 @@ open class DateFormatter : Formatter {
         willSet {
             _dateFormat = nil
         }
-        didSet {
-            _dateFormat = CFDateFormatterGetFormat(_cfObject)._swiftObject
-        }
     }
 
     open var timeStyle: Style = .none {
         willSet {
             _dateFormat = nil
-        }
-        didSet {
-            _dateFormat = CFDateFormatterGetFormat(_cfObject)._swiftObject
         }
     }
 


### PR DESCRIPTION
… Linux

- Ensure the setting of .dateStyle and .timeStyle isnt dependant on the
  current setting of .locale.

(cherry picked from commit 3ceecb1)
original PR #2265 