### PR TITLE
TestFoundation: excise FTPServer

### DIFF
--- a/TestFoundation/FTPServer.swift
+++ b/TestFoundation/FTPServer.swift
@@ -6,6 +6,8 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
+
+#if !os(Windows)
 //This is a very rudimentary FTP server written plainly for testing URLSession FTP Implementation.
 import Dispatch
 
@@ -283,3 +285,4 @@ class LoopbackFTPServerTest: XCTestCase {
         serverReady.wait(timeout: timeout)
     }
 }
+#endif

--- a/TestFoundation/TestURLSessionFTP.swift
+++ b/TestFoundation/TestURLSessionFTP.swift
@@ -7,6 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if !os(Windows)
 #if DEPLOYMENT_RUNTIME_OBJC || os(Linux)
     import Foundation
     import XCTest
@@ -121,3 +122,4 @@ extension FTPDataTask : URLSessionTaskDelegate {
         self.error = true
     }
 }
+#endif

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -113,7 +113,12 @@ var allTestCases = [
     testCase(TestMeasurement.allTests),
     testCase(TestNSLock.allTests),
     testCase(TestNSSortDescriptor.allTests),
-    testCase(TestURLSessionFTP.allTests),
 ]
+
+#if !os(Windows)
+allTestCases.append(contentsOf: [
+    testCase(TestURLSessionFTP.allTests),
+])
+#endif
 
 XCTMain(allTestCases)


### PR DESCRIPTION
The FTP Server is not well structured to make it easy to port to
Windows.  Simply excise all of the FTPServer for the time being until it
can be restructured to support cross-platform networking.