### PR TITLE
Foundation: fix `Process.run()` handle handling for Windows

### DIFF
--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -519,15 +519,12 @@ open class Process: NSObject {
 
         if let pipe = standardInput as? Pipe {
           pipe.fileHandleForReading.closeFile()
-          pipe.fileHandleForWriting.closeFile()
         }
         if let pipe = standardOutput as? Pipe {
-          pipe.fileHandleForReading.closeFile()
           pipe.fileHandleForWriting.closeFile()
         }
         if let pipe = standardError as? Pipe {
           pipe.fileHandleForWriting.closeFile()
-          pipe.fileHandleForReading.closeFile()
         }
 
         self.runLoop = RunLoop.current


### PR DESCRIPTION
Do not close both sides of the pipe.  The pipes are half-duplex and the
parent side of the pipe need to be valid to permit communication with
the child.