### PR TITLE
TestFoundation: Add infrastructure to assert that a test should crash

### DIFF
--- a/TestFoundation/Utilities.swift
+++ b/TestFoundation/Utilities.swift
@@ -521,3 +521,38 @@ func testExpectedToFail<T>(_ test:  @escaping (T) -> () throws -> Void, _ reason
         return { _ in return { } }
     }
 }
+
+extension XCTest {
+    func assertCrashes(within block: () throws -> Void) rethrows {
+        let childProcessEnvVariable = "NS_FOUNDATION_TEST_PERFORM_ASSERT_CRASHES_BLOCKS"
+        let childProcessEnvVariableOnValue = "YES"
+        
+        let isChildProcess = ProcessInfo.processInfo.environment[childProcessEnvVariable] == childProcessEnvVariableOnValue
+        
+        if isChildProcess {
+            try block()
+        } else {
+            var arguments = ProcessInfo.processInfo.arguments
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: arguments[0])
+            
+            arguments.remove(at: 0)
+            arguments.removeAll(where: { $0.hasPrefix("TestFoundation.") })
+            arguments.append("TestFoundation." + self.name.replacingOccurrences(of: ".", with: "/"))
+            process.arguments = arguments
+            
+            var environment = ProcessInfo.processInfo.environment
+            environment[childProcessEnvVariable] = childProcessEnvVariableOnValue
+            process.environment = environment
+            
+            do {
+                try process.run()
+                process.waitUntilExit()
+                XCTAssertEqual(process.terminationReason, .uncaughtSignal, "Child process should have crashed: \(process)")
+            } catch {
+                XCTFail("Couldn't start child process for testing crash: \(process) - \(error)")
+            }
+            
+        }
+    }
+}


### PR DESCRIPTION
You can now define tests as follows:

```
func testCrashes() {
     assertCrashes {
          fatalError()
     }
}
```

These tests will spawn a child process and will assert that the child process crashes while executing the code in the block. Wrap the entire body of the test this way.