### PR TITLE
Parity: NSArray.sortedArray(…)

### DIFF
--- a/CoreFoundation/Base.subproj/CFSortFunctions.c
+++ b/CoreFoundation/Base.subproj/CFSortFunctions.c
@@ -271,8 +271,14 @@ static void __CFSortIndexesN(VALUE_TYPE listp[], INDEX_TYPE count, int32_t ncore
 }
 #endif
 
+#if DEPLOYMENT_RUNTIME_SWIFT
+#define _CF_SORT_INDEXES_EXPORT CF_CROSS_PLATFORM_EXPORT
+#else
+#define _CF_SORT_INDEXES_EXPORT
+#endif
+
 // fills an array of indexes (of length count) giving the indexes 0 - count-1, as sorted by the comparator block
-void CFSortIndexes(CFIndex *indexBuffer, CFIndex count, CFOptionFlags opts, CFComparisonResult (^cmp)(CFIndex, CFIndex)) {
+_CF_SORT_INDEXES_EXPORT void CFSortIndexes(CFIndex *indexBuffer, CFIndex count, CFOptionFlags opts, CFComparisonResult (^cmp)(CFIndex, CFIndex)) {
     if (count < 1) return;
     if (INTPTR_MAX / sizeof(CFIndex) < count) return;
     int32_t ncores = 0;

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -393,6 +393,8 @@ CF_EXPORT _CFThreadRef _CFMainPThread;
 
 CF_EXPORT CFHashCode __CFHashDouble(double d);
 
+CF_CROSS_PLATFORM_EXPORT void CFSortIndexes(CFIndex *indexBuffer, CFIndex count, CFOptionFlags opts, CFComparisonResult (^cmp)(CFIndex, CFIndex));
+
 CF_EXPORT CFTypeRef _Nullable _CFThreadSpecificGet(_CFThreadSpecificKey key);
 CF_EXPORT void _CFThreadSpecificSet(_CFThreadSpecificKey key, CFTypeRef _Nullable value);
 CF_EXPORT _CFThreadSpecificKey _CFThreadSpecificKeyCreate(void);

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -525,19 +525,31 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
     }
 
     internal func sortedArray(from range: NSRange, options: NSSortOptions, usingComparator cmptr: (Any, Any) -> ComparisonResult) -> [Any] {
-        // The sort options are not available. We use the Array's sorting algorithm. It is not stable neither concurrent.
-        guard options.isEmpty else {
-            NSUnimplemented()
-        }
-
         let count = self.count
         if range.length == 0 || count == 0 {
             return []
         }
 
-        let swiftRange = Range(range)!
-        return allObjects[swiftRange].sorted { lhs, rhs in
-            return cmptr(lhs, rhs) == .orderedAscending
+        let objects = subarray(with: range)
+        
+        let indexes = UnsafeMutableBufferPointer<CFIndex>.allocate(capacity: range.length)
+        withoutActuallyEscaping(cmptr) { (cmptr) in
+            CFSortIndexes(indexes.baseAddress!, range.length, CFOptionFlags(options.rawValue)) { (a, b) -> CFComparisonResult in
+                switch cmptr(objects[a], objects[b]) {
+                case .orderedAscending: return kCFCompareLessThan
+                case .orderedDescending: return kCFCompareGreaterThan
+                case .orderedSame: return kCFCompareEqualTo
+                }
+            }
+        }
+        
+        return Array(unsafeUninitializedCapacity: range.length) { (buffer, initializedCount) in
+            var destinationIndex = 0
+            for index in indexes {
+                buffer.baseAddress?.advanced(by: destinationIndex).initialize(to: objects[index])
+                destinationIndex += 1
+            }
+            initializedCount = range.length
         }
     }
     
@@ -828,7 +840,7 @@ open class NSMutableArray : NSArray {
         if type(of: self) === NSMutableArray.self {
             _storage.swapAt(idx1, idx2)
         } else {
-            NSUnimplemented()
+            NSRequiresConcreteImplementation()
         }
     }
     
@@ -906,7 +918,7 @@ open class NSMutableArray : NSArray {
                 _storage.insert(__SwiftValue.store(otherArray[idx]), at: idx + range.location)
             }
         } else {
-            NSUnimplemented()
+            NSRequiresConcreteImplementation()
         }
     }
     

--- a/Foundation/NSArray.swift
+++ b/Foundation/NSArray.swift
@@ -543,7 +543,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
             }
         }
         
-        return Array(unsafeUninitializedCapacity: range.length) { (buffer, initializedCount) in
+        let result = Array<Any>(unsafeUninitializedCapacity: range.length) { (buffer, initializedCount) in
             var destinationIndex = 0
             for index in indexes {
                 buffer.baseAddress?.advanced(by: destinationIndex).initialize(to: objects[index])
@@ -551,6 +551,9 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
             }
             initializedCount = range.length
         }
+        
+        indexes.deallocate()
+        return result
     }
     
     open func sortedArray(comparator cmptr: (Any, Any) -> ComparisonResult) -> [Any] {


### PR DESCRIPTION
Replace the approximate implementation with one that matches Darwin’s and supports all the options by using CFSortIndexes from NSArray.swift.