### PR TITLE
Parity: NSPredicate and NSExpression

### DIFF
--- a/Foundation/NSComparisonPredicate.swift
+++ b/Foundation/NSComparisonPredicate.swift
@@ -7,8 +7,28 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-// Flags(s) that can be passed to the factory to indicate that a operator operating on strings should do so in a case insensitive fashion.
-extension NSComparisonPredicate {
+// Comparison predicates are predicates which do some form of comparison between the results of two expressions and return a BOOL. They take an operator, a left expression, and a right expression, and return the result of invoking the operator with the results of evaluating the expressions.
+@available(*, deprecated, message: "NSExpression and classes that rely on its functionality are unsupported in swift-corelibs-foundation: NSComparisonPredicate is unavailable.")
+open class NSComparisonPredicate : NSPredicate {
+    
+    @available(*, unavailable, message: "NSComparisonPredicate is unsupported in swift-corelibs-foundation. Use a closure-based NSPredicate instead if possible.")
+    public init(leftExpression lhs: NSExpression, rightExpression rhs: NSExpression, modifier: Modifier, type: Operator, options: Options) { NSUnsupported() }
+    
+    @available(*, unavailable, message: "NSComparisonPredicate is unavailable.")
+    open var predicateOperatorType: Operator { NSUnsupported() }
+
+    @available(*, unavailable, message: "NSComparisonPredicate is unavailable.")
+    open var comparisonPredicateModifier: Modifier { NSUnsupported() }
+
+    @available(*, unavailable, message: "NSComparisonPredicate is unavailable.")
+    open var leftExpression: NSExpression { NSUnsupported() }
+
+    @available(*, unavailable, message: "NSComparisonPredicate is unavailable.")
+    open var rightExpression: NSExpression { NSUnsupported() }
+
+    @available(*, unavailable, message: "NSComparisonPredicate is unavailable.")
+    open var options: Options { NSUnsupported() }
+
     public struct Options : OptionSet {
         public let rawValue : UInt
         public init(rawValue: UInt) { self.rawValue = rawValue }
@@ -17,14 +37,14 @@ extension NSComparisonPredicate {
         public static let diacriticInsensitive = Options(rawValue : 0x2)
         public static let normalized = Options(rawValue : 0x4) /* Indicate that the strings to be compared have been preprocessed; this supersedes other options and is intended as a performance optimization option */
     }
-
+    
     // Describes how the operator is modified: can be direct, ALL, or ANY
     public enum Modifier : UInt {
         case direct // Do a direct comparison
         case all // ALL toMany.x = y
         case any // ANY toMany.x = y
     }
-
+    
     // Type basic set of operators defined. Most are obvious
     public enum Operator : UInt {
         case lessThan // compare: returns NSOrderedAscending
@@ -41,18 +61,5 @@ extension NSComparisonPredicate {
         case contains // lhs contains rhs returns true
         case between
     }
-}
-
-// Comparison predicates are predicates which do some form of comparison between the results of two expressions and return a BOOL. They take an operator, a left expression, and a right expression, and return the result of invoking the operator with the results of evaluating the expressions.
-open class NSComparisonPredicate : NSPredicate {
-    
-    public init(leftExpression lhs: NSExpression, rightExpression rhs: NSExpression, modifier: Modifier, type: Operator, options: Options) { NSUnimplemented() }
-    public required init?(coder: NSCoder) { NSUnimplemented() }
-    
-    open var predicateOperatorType: Operator { NSUnimplemented() }
-    open var comparisonPredicateModifier: Modifier { NSUnimplemented() }
-    open var leftExpression: NSExpression { NSUnimplemented() }
-    open var rightExpression: NSExpression { NSUnimplemented() }
-    open var options: Options { NSUnimplemented() }
 }
 

--- a/Foundation/NSCompoundPredicate.swift
+++ b/Foundation/NSCompoundPredicate.swift
@@ -28,8 +28,6 @@ open class NSCompoundPredicate : NSPredicate {
         self.subpredicates = subpredicates
         super.init(value: false)
     }
-
-    public required init?(coder: NSCoder) { NSUnimplemented() }
     
     open var compoundPredicateType: LogicalType
     open var subpredicates: [NSPredicate]

--- a/Foundation/NSExpression.swift
+++ b/Foundation/NSExpression.swift
@@ -28,36 +28,36 @@ extension NSExpression {
     }
 }
 
-open class NSExpression : NSObject, NSSecureCoding, NSCopying {
-    
-    public static var supportsSecureCoding: Bool {
-        return true
-    }
-    
-    public required init?(coder aDecoder: NSCoder) {
-        NSUnimplemented()
-    }
-    
-    open func encode(with aCoder: NSCoder) {
-        NSUnimplemented()
-    }
+@available(*, deprecated, message: "NSExpression is not available in swift-corelibs-foundation")
+open class NSExpression : NSObject, NSCopying {
     
     open override func copy() -> Any {
         return copy(with: nil)
     }
     
     open func copy(with zone: NSZone? = nil) -> Any {
-        NSUnimplemented()
+        NSUnsupported()
     }
-
-    public /*not inherited*/ init(format expressionFormat: String, argumentArray arguments: [Any]) { NSUnimplemented() }
-    public /*not inherited*/ init(format expressionFormat: String, arguments argList: CVaListPointer) { NSUnimplemented() }
     
-    public /*not inherited*/ init(forConstantValue obj: Any?) { NSUnimplemented() } // Expression that returns a constant value
-    open class func expressionForEvaluatedObject() -> NSExpression { NSUnimplemented() } // Expression that returns the object being evaluated
-    public /*not inherited*/ init(forVariable string: String) { NSUnimplemented() } // Expression that pulls a value from the variable bindings dictionary
-    public /*not inherited*/ init(forKeyPath keyPath: String) { NSUnimplemented() } // Expression that invokes valueForKeyPath with keyPath
-    public /*not inherited*/ init(forFunction name: String, arguments parameters: [Any]) { NSUnimplemented() } // Expression that invokes one of the predefined functions. Will throw immediately if the selector is bad; will throw at runtime if the parameters are incorrect.
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    public convenience init(format expressionFormat: String, argumentArray arguments: [Any]) { NSUnsupported() }
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    public convenience init(format expressionFormat: String, arguments argList: CVaListPointer) { NSUnsupported() }
+    
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    public convenience init(forConstantValue obj: Any?) { NSUnsupported() } // Expression that returns a constant value
+
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    open class func expressionForEvaluatedObject() -> NSExpression { NSUnsupported() } // Expression that returns the object being evaluated
+
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    public convenience init(forVariable string: String) { NSUnsupported() } // Expression that pulls a value from the variable bindings dictionary
+
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    public convenience init(forKeyPath keyPath: String) { NSUnsupported() } // Expression that invokes valueForKeyPath with keyPath
+
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    public convenience init(forFunction name: String, arguments parameters: [Any]) { NSUnsupported() } // Expression that invokes one of the predefined functions. Will throw immediately if the selector is bad; will throw at runtime if the parameters are incorrect.
     // Predefined functions are:
     // name              parameter array contents				returns
     //-------------------------------------------------------------------------------------------------------------------------------------
@@ -99,43 +99,77 @@ open class NSExpression : NSObject, NSSecureCoding, NSCopying {
     //                   two NSExpression instances representing CLLocations    NSNumber
     // length:           an NSExpression instance representing a string         NSNumber
     
-    public /*not inherited*/ init(forAggregate subexpressions: [Any]) { NSUnimplemented() } // Expression that returns a collection containing the results of other expressions
-    public /*not inherited*/ init(forUnionSet left: NSExpression, with right: NSExpression) { NSUnimplemented() } // return an expression that will return the union of the collections expressed by left and right
-    public /*not inherited*/ init(forIntersectSet left: NSExpression, with right: NSExpression) { NSUnimplemented() } // return an expression that will return the intersection of the collections expressed by left and right
-    public /*not inherited*/ init(forMinusSet left: NSExpression, with right: NSExpression) { NSUnimplemented() } // return an expression that will return the disjunction of the collections expressed by left and right
-    public /*not inherited*/ init(forSubquery expression: NSExpression, usingIteratorVariable variable: String, predicate: Any) { NSUnimplemented() } // Expression that filters a collection by storing elements in the collection in the variable variable and keeping the elements for which qualifer returns true; variable is used as a local variable, and will shadow any instances of variable in the bindings dictionary, the variable is removed or the old value replaced once evaluation completes
-    public /*not inherited*/ init(forFunction target: NSExpression, selectorName name: String, arguments parameters: [Any]?) { NSUnimplemented() } // Expression that invokes the selector on target with parameters. Will throw at runtime if target does not implement selector or if parameters are wrong.
-    open class func expressionForAnyKey() -> NSExpression { NSUnimplemented() }
-    public /*not inherited*/ init(block: @escaping (Any?, [Any], NSMutableDictionary?) -> Any, arguments: [NSExpression]?) { NSUnimplemented() } // Expression that invokes the block with the parameters; note that block expressions are not encodable or representable as parseable strings.
-    public /*not inherited*/ init(forConditional predicate: Any, trueExpression: NSExpression, falseExpression: NSExpression) { NSUnimplemented() } // Expression that will return the result of trueExpression or falseExpression depending on the value of predicate
+
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    public convenience init(forAggregate subexpressions: [Any]) { NSUnsupported() } // Expression that returns a collection containing the results of other expressions
+
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    public convenience init(forUnionSet left: NSExpression, with right: NSExpression) { NSUnsupported() } // return an expression that will return the union of the collections expressed by left and right
+
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    public convenience init(forIntersectSet left: NSExpression, with right: NSExpression) { NSUnsupported() } // return an expression that will return the intersection of the collections expressed by left and right
+
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    public convenience init(forMinusSet left: NSExpression, with right: NSExpression) { NSUnsupported() } // return an expression that will return the disjunction of the collections expressed by left and right
+
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    public convenience init(forSubquery expression: NSExpression, usingIteratorVariable variable: String, predicate: Any) { NSUnsupported() } // Expression that filters a collection by storing elements in the collection in the variable variable and keeping the elements for which qualifer returns true; variable is used as a local variable, and will shadow any instances of variable in the bindings dictionary, the variable is removed or the old value replaced once evaluation completes
+
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    public convenience init(forFunction target: NSExpression, selectorName name: String, arguments parameters: [Any]?) { NSUnsupported() } // Expression that invokes the selector on target with parameters. Will throw at runtime if target does not implement selector or if parameters are wrong.
+
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    open class func expressionForAnyKey() -> NSExpression { NSUnsupported() }
+
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    public convenience init(block: @escaping (Any?, [Any], NSMutableDictionary?) -> Any, arguments: [NSExpression]?) { NSUnsupported() } // Expression that invokes the block with the parameters; note that block expressions are not encodable or representable as parseable strings.
+
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    public convenience init(forConditional predicate: Any, trueExpression: NSExpression, falseExpression: NSExpression) { NSUnsupported() } // Expression that will return the result of trueExpression or falseExpression depending on the value of predicate
     
-    public init(expressionType type: ExpressionType) { NSUnimplemented() }
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    public init(expressionType type: ExpressionType) { NSUnsupported() }
     
     // accessors for individual parameters - raise if not applicable
-    open var expressionType: ExpressionType { NSUnimplemented() }
-    open var constantValue: Any { NSUnimplemented() }
-    open var keyPath: String { NSUnimplemented() }
-    open var function: String { NSUnimplemented() }
-    open var variable: String { NSUnimplemented() }
-    /*@NSCopying*/ open var operand: NSExpression { NSUnimplemented() } // the object on which the selector will be invoked (the result of evaluating a key path or one of the defined functions)
-    open var arguments: [NSExpression]? { NSUnimplemented() } // array of expressions which will be passed as parameters during invocation of the selector on the operand of a function expression
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    open var expressionType: ExpressionType { NSUnsupported() }
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    open var constantValue: Any { NSUnsupported() }
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    open var keyPath: String { NSUnsupported() }
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    open var function: String { NSUnsupported() }
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    open var variable: String { NSUnsupported() }
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    /*@NSCopying*/ open var operand: NSExpression { NSUnsupported() } // the object on which the selector will be invoked (the result of evaluating a key path or one of the defined functions)
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    open var arguments: [NSExpression]? { NSUnsupported() } // array of expressions which will be passed as parameters during invocation of the selector on the operand of a function expression
     
-    open var collection: Any { NSUnimplemented() }
-    /*@NSCopying*/ open var predicate: NSPredicate { NSUnimplemented() }
-    /*@NSCopying*/ open var left: NSExpression { NSUnimplemented() } // expression which represents the left side of a set expression
-    /*@NSCopying*/ open var right: NSExpression { NSUnimplemented() } // expression which represents the right side of a set expression
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    open var collection: Any { NSUnsupported() }
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    /*@NSCopying*/ open var predicate: NSPredicate { NSUnsupported() }
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    /*@NSCopying*/ open var left: NSExpression { NSUnsupported() } // expression which represents the left side of a set expression
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    /*@NSCopying*/ open var right: NSExpression { NSUnsupported() } // expression which represents the right side of a set expression
     
-    /*@NSCopying*/ open var `true`: NSExpression { NSUnimplemented() } // expression which will be evaluated if a conditional expression's predicate evaluates to true
-    /*@NSCopying*/ open var `false`: NSExpression { NSUnimplemented() } // expression which will be evaluated if a conditional expression's predicate evaluates to false
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    /*@NSCopying*/ open var `true`: NSExpression { NSUnsupported() } // expression which will be evaluated if a conditional expression's predicate evaluates to true
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    /*@NSCopying*/ open var `false`: NSExpression { NSUnsupported() } // expression which will be evaluated if a conditional expression's predicate evaluates to false
     
-    open var expressionBlock: (Any?, [Any], NSMutableDictionary?) -> Any { NSUnimplemented() }
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    open var expressionBlock: (Any?, [Any], NSMutableDictionary?) -> Any { NSUnsupported() }
     
     // evaluate the expression using the object and bindings- note that context is mutable here and can be used by expressions to store temporary state for one predicate evaluation
-    open func expressionValue(with object: Any?, context: NSMutableDictionary?) -> Any? { NSUnimplemented() }
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    open func expressionValue(with object: Any?, context: NSMutableDictionary?) -> Any? { NSUnsupported() }
     
-    open func allowEvaluation() { NSUnimplemented() } // Force an expression which was securely decoded to allow evaluation
-}
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    open func allowEvaluation() { NSUnsupported() } // Force an expression which was securely decoded to allow evaluation
 
-extension NSExpression {
-    public convenience init(format expressionFormat: String, _ args: CVarArg...) { NSUnimplemented() }
+    @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
+    public convenience init(format expressionFormat: String, _ args: CVarArg...) { NSUnsupported() }
 }

--- a/TestFoundation/TestNSPredicate.swift
+++ b/TestFoundation/TestNSPredicate.swift
@@ -19,7 +19,6 @@ class TestNSPredicate: XCTestCase {
             ("test_filterNSMutableSet", test_filterNSMutableSet),
             ("test_filterNSOrderedSet", test_filterNSOrderedSet),
             ("test_filterNSMutableOrderedSet", test_filterNSMutableOrderedSet),
-            ("test_NSCoding", test_NSCoding),
             ("test_copy", test_copy),
         ]
     }
@@ -87,15 +86,6 @@ class TestNSPredicate: XCTestCase {
         let expectedOrderedSet = NSMutableOrderedSet()
         expectedOrderedSet.addObjects(from: expectedArray)
         XCTAssertEqual(expectedOrderedSet, orderedSet)
-    }
-    
-    func test_NSCoding() {
-        let predicateA = NSPredicate(value: true)
-        let predicateB = NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: predicateA)) as! NSPredicate
-        XCTAssertEqual(predicateA, predicateB, "Archived then unarchived uuid must be equal.")
-        let predicateC = NSPredicate(value: false)
-        let predicateD = NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: predicateC)) as! NSPredicate
-        XCTAssertEqual(predicateC, predicateD, "Archived then unarchived uuid must be equal.")
     }
     
     func test_copy() {


### PR DESCRIPTION
 - Add diagnostics for features not supported by swift-corelibs-foundation, including format strings (which rely on key-value coding for most of their usefulness).

 - `NSComparisonPredicate` relies on `NSExpression`, which is not going to be available. Mark it as unavailable.

 - Predicate archival relies on format strings. Remove the `NSSecureCoding` conformance of `NSPredicate`, since we cannot safely assert to be able to encode or decode arbitrary predicates.