### PR TITLE
Initialize pthread mutexes in NSRecursiveLock

### DIFF
--- a/Foundation/NSLock.swift
+++ b/Foundation/NSLock.swift
@@ -243,9 +243,14 @@ open class NSRecursiveLock: NSObject, NSLocking {
         var attrib = pthread_mutexattr_t()
 #endif
         withUnsafeMutablePointer(to: &attrib) { attrs in
+            pthread_mutexattr_init(attrs)
             pthread_mutexattr_settype(attrs, Int32(PTHREAD_MUTEX_RECURSIVE))
             pthread_mutex_init(mutex, attrs)
         }
+#if os(macOS) || os(iOS)
+        pthread_cond_init(timeoutCond, nil)
+        pthread_mutex_init(timeoutMutex, nil)
+#endif
 #endif
     }
     


### PR DESCRIPTION
I was going to suggest a test for NSRecursiveLock fix in #2269, as promised. But test turned out extremely useful from first run. Found that pthread-based implementation is also missing some initialization.

I suppose it will be ok to add this new fix and test in one PR, right?