### PR TITLE
Fix Up FileManager Tests on Windows

### DIFF
--- a/CoreFoundation/URL.subproj/CFURL.c
+++ b/CoreFoundation/URL.subproj/CFURL.c
@@ -4292,7 +4292,7 @@ static CFStringRef URLPathToWindowsPath(CFStringRef path, CFAllocatorRef allocat
 static CFStringRef _resolveFileSystemPaths(CFStringRef relativePath, CFStringRef basePath, Boolean baseIsDir, CFURLPathStyle fsType, CFAllocatorRef alloc) CF_RETURNS_RETAINED {
     CFIndex baseLen = CFStringGetLength(basePath);
     CFIndex relLen = CFStringGetLength(relativePath);
-    UniChar pathDelimiter = '/';
+    UniChar pathDelimiter = _CFGetSlash();
     UniChar *buf = (UniChar *)CFAllocatorAllocate(alloc, sizeof(UniChar)*(relLen + baseLen + 2), 0);
     CFStringGetCharacters(basePath, CFRangeMake(0, baseLen), buf);
     if (baseIsDir) {

--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -117,8 +117,12 @@ extension String {
         return nil
     }
 
-    internal var absolutePath: Bool {
+    internal var isAbsolutePath: Bool {
+#if os(Windows)
+        return !withCString(encodedAs: UTF16.self, PathIsRelativeW)
+#else
         return hasPrefix("~") || hasPrefix("/")
+#endif
     }
     
     internal func _stringByAppendingPathComponent(_ str: String, doneAppending : Bool = true) -> String {

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -29,7 +29,7 @@ internal let kCFURLPlatformPathStyle = kCFURLPOSIXPathStyle
 #endif
 
 private func _standardizedPath(_ path: String) -> String {
-    if !path.absolutePath {
+    if !path.isAbsolutePath {
         return path._nsObject.standardizingPath
     }
     return path
@@ -1007,7 +1007,7 @@ extension NSURL {
         }
 
         let absolutePath: String
-        if selfPath.hasPrefix("/") {
+        if selfPath.isAbsolutePath {
             absolutePath = selfPath
         } else {
             let workingDir = FileManager.default.currentDirectoryPath


### PR DESCRIPTION
- Windows directory enumerator now doesn't look in a directory it
  returns until nextObject is called again
- Fixed some path handling platform issues
- Properly calculate level

See SR-10738