### PR TITLE
Foundation: add an extension to deal with Win paths

### DIFF
--- a/Foundation/URL.swift
+++ b/Foundation/URL.swift
@@ -722,7 +722,15 @@ public struct URL : ReferenceConvertible, Equatable {
         defer { fsRep.deallocate() }
         return try block(fsRep)
     }
-    
+
+#if os(Windows)
+    internal func _withUnsafeWideFileSystemRepresentation<ResultType>(_ block: (UnsafePointer<UInt16>?) throws -> ResultType) rethrows -> ResultType {
+      let fsr: UnsafePointer<UInt16> = _url._wideFileSystemRepresentation
+      defer { fsr.deallocate() }
+      return try block(fsr)
+    }
+#endif
+
     // MARK: -
     // MARK: Path manipulation
     


### PR DESCRIPTION
Windows uses wide paths (UTF16).  Expose a similar internal API to the
CoreFoundation interfaces to aid in writing code locally and avoid
having to do the unicode conversions everywhere.