### PR TITLE
build: remove unnecessary CMake include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ find_package(LibXml2 REQUIRED)
 
 include(SwiftSupport)
 include(GNUInstallDirs)
-include(ExternalProject)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   include(CheckSymbolExists)


### PR DESCRIPTION
We no longer use `ExternalProject` to build CoreFoundation and opt to
use `add_subdirectory` for it to get better dependency resolution.
Remove the vestigial include.