### PR TITLE
CoreFoundatin: remove option to disable libdispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,7 +316,6 @@ add_swift_library(Foundation
                     ${CMAKE_C_COMPILER_TARGET}
                   CFLAGS
                     ${MSVCRT_C_FLAGS}
-                    ${deployment_target}
                     ${deployment_enable_libdispatch}
                     -F${CMAKE_CURRENT_BINARY_DIR}
                   LINK_FLAGS
@@ -367,7 +366,6 @@ add_swift_executable(plutil
                        Tools/plutil/main.swift
                      CFLAGS
                        ${MSVCRT_C_FLAGS}
-                       ${deployment_target}
                        ${deployment_enable_libdispatch}
                        -F${CMAKE_CURRENT_BINARY_DIR}
                      LINK_FLAGS
@@ -395,7 +393,6 @@ if(ENABLE_TESTING)
   add_swift_executable(xdgTestHelper
                        CFLAGS
                          ${MSVCRT_C_FLAGS}
-                         ${deployment_target}
                          ${deployment_enable_libdispatch}
                          -F${CMAKE_CURRENT_BINARY_DIR}
                        LINK_FLAGS
@@ -517,10 +514,8 @@ if(ENABLE_TESTING)
                          TestFoundation/TestXMLParser.swift
                        CFLAGS
                          ${MSVCRT_C_FLAGS}
-                         ${deployment_target}
                          ${deployment_enable_libdispatch}
                          -F${CMAKE_CURRENT_BINARY_DIR}
-                         -D_DLL
                        LINK_FLAGS
                          ${MSVCRT_LINK_FLAGS}
                          ${libdispatch_ldflags}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,11 +73,9 @@ if(ENABLE_TESTING)
   set(swift_enable_testing -enable-testing)
 endif()
 
-set(deployment_enable_libdispatch)
 set(libdispatch_cflags)
 set(libdispatch_ldflags)
 if(FOUNDATION_ENABLE_LIBDISPATCH)
-  set(deployment_enable_libdispatch -DDEPLOYMENT_ENABLE_LIBDISPATCH)
   set(libdispatch_cflags -I;${FOUNDATION_PATH_TO_LIBDISPATCH_SOURCE};-I;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src/swift;-Xcc;-fblocks)
   set(libdispatch_ldflags -L;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD};-L;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src;-ldispatch;-lswiftDispatch)
   if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
@@ -316,7 +314,6 @@ add_swift_library(Foundation
                     ${CMAKE_C_COMPILER_TARGET}
                   CFLAGS
                     ${MSVCRT_C_FLAGS}
-                    ${deployment_enable_libdispatch}
                     -F${CMAKE_CURRENT_BINARY_DIR}
                   LINK_FLAGS
                     ${MSVCRT_LINK_FLAGS}
@@ -339,7 +336,7 @@ add_swift_library(Foundation
                     $<$<PLATFORM_ID:Windows>:$<TARGET_OBJECTS:CoreFoundationResources>>
                   SWIFT_FLAGS
                     -DDEPLOYMENT_RUNTIME_SWIFT
-                    ${deployment_enable_libdispatch}
+                    $<$<BOOL:FOUNDATION_ENABLE_LIBDISPATCH>:-DDEPLOYMENT_ENABLE_LIBDISPATCH>
                     -I;${ICU_INCLUDE_DIR}
                     ${libdispatch_cflags}
                     ${swift_enable_testing}
@@ -366,7 +363,6 @@ add_swift_executable(plutil
                        Tools/plutil/main.swift
                      CFLAGS
                        ${MSVCRT_C_FLAGS}
-                       ${deployment_enable_libdispatch}
                        -F${CMAKE_CURRENT_BINARY_DIR}
                      LINK_FLAGS
                        ${MSVCRT_LINK_FLAGS}
@@ -378,7 +374,6 @@ add_swift_executable(plutil
                        ${WORKAROUND_SR9995}
                      SWIFT_FLAGS
                        -DDEPLOYMENT_RUNTIME_SWIFT
-                       ${deployment_enable_libdispatch}
                        -I;${CMAKE_CURRENT_BINARY_DIR}/swift
                        -I;${ICU_INCLUDE_DIR}
                        ${libdispatch_cflags}
@@ -393,7 +388,6 @@ if(ENABLE_TESTING)
   add_swift_executable(xdgTestHelper
                        CFLAGS
                          ${MSVCRT_C_FLAGS}
-                         ${deployment_enable_libdispatch}
                          -F${CMAKE_CURRENT_BINARY_DIR}
                        LINK_FLAGS
                          ${MSVCRT_LINK_FLAGS}
@@ -514,7 +508,6 @@ if(ENABLE_TESTING)
                          TestFoundation/TestXMLParser.swift
                        CFLAGS
                          ${MSVCRT_C_FLAGS}
-                         ${deployment_enable_libdispatch}
                          -F${CMAKE_CURRENT_BINARY_DIR}
                        LINK_FLAGS
                          ${MSVCRT_LINK_FLAGS}
@@ -553,7 +546,6 @@ if(ENABLE_TESTING)
                          ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/TestFileWithZeros.txt
                          ${CMAKE_SOURCE_DIR}/TestFoundation/Fixtures
                        SWIFT_FLAGS
-                         ${deployment_enable_libdispatch}
                          -I;${CMAKE_CURRENT_BINARY_DIR}/swift
                          -I;${FOUNDATION_PATH_TO_XCTEST_BUILD}/swift
                          -I;${ICU_INCLUDE_DIR}

--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -14,17 +14,7 @@
 
 #include <CoreFoundation/CFAvailability.h>
 
-#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_WIN32
-#if DEPLOYMENT_RUNTIME_SWIFT
-#if DEPLOYMENT_ENABLE_LIBDISPATCH
 #define __HAS_DISPATCH__ 1
-#else
-#define __HAS_DISPATCH__ 0
-#endif
-#else
-#define __HAS_DISPATCH__ 1
-#endif
-#endif
 
 #include <CoreFoundation/CFBase.h>
 

--- a/CoreFoundation/Base.subproj/module.private.modulemap
+++ b/CoreFoundation/Base.subproj/module.private.modulemap
@@ -1,0 +1,8 @@
+framework module CoreFoundation_Private [extern_c] [system] {
+  umbrella header "ForSwitFoundationOnly.h"
+  export *
+  module * {
+    export *
+  }
+}
+

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -39,7 +39,6 @@ find_package(Threads)
 include(GNUInstallDirs)
 include(CoreFoundationAddFramework)
 
-option(CF_ENABLE_LIBDISPATCH "Enable GCD Support" YES)
 option(CF_PATH_TO_LIBDISPATCH_SOURCE "Path to libdispatch source")
 option(CF_PATH_TO_LIBDISPATCH_BUILD "Path to libdispatch build")
 option(CF_DEPLOYMENT_SWIFT "Build for swift" NO)
@@ -362,11 +361,6 @@ target_compile_definitions(CoreFoundation
                            PRIVATE
                              -DU_SHOW_DRAFT_API
                              -DCF_BUILDING_CF)
-if(CF_ENABLE_LIBDISPATCH)
-  target_compile_definitions(CoreFoundation
-                             PRIVATE
-                               -DDEPLOYMENT_ENABLE_LIBDISPATCH)
-endif()
 if(CF_DEPLOYMENT_SWIFT)
   target_compile_definitions(CoreFoundation
                              PRIVATE
@@ -400,16 +394,14 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
                              PRIVATE
                                ${ICU_INCLUDE_DIR})
 endif()
-if(CF_ENABLE_LIBDISPATCH)
+target_include_directories(CoreFoundation
+                           PRIVATE
+                             ${CF_PATH_TO_LIBDISPATCH_SOURCE}
+                             ${CF_PATH_TO_LIBDISPATCH_BUILD}/tests)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_include_directories(CoreFoundation
-                             PRIVATE
-                               ${CF_PATH_TO_LIBDISPATCH_SOURCE}
-                               ${CF_PATH_TO_LIBDISPATCH_BUILD}/tests)
-  if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    target_include_directories(CoreFoundation
-                               SYSTEM PRIVATE
-                                 ${CF_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
-  endif()
+                             SYSTEM PRIVATE
+                               ${CF_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
 endif()
 
 if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
@@ -487,11 +479,9 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows AND NOT CMAKE_SYSTEM_NAME STREQUAL Dar
                         PRIVATE
                           m)
 endif()
-if(CF_ENABLE_LIBDISPATCH)
-  target_link_libraries(CoreFoundation
-                        PRIVATE
-                          dispatch)
-endif()
+target_link_libraries(CoreFoundation
+                      PRIVATE
+                        dispatch)
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(CoreFoundation
                         PRIVATE

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -55,11 +55,13 @@ add_framework(CoreFoundation
                 CoreFoundation_FRAMEWORK_DIRECTORY
               MODULE_MAP
                 Base.subproj/module.modulemap
+                Base.subproj/module.private.modulemap
               PRIVATE_HEADERS
                 # Base
                 Base.subproj/CFAsmMacros.h
                 Base.subproj/CFInternal.h
                 Base.subproj/CFKnownLocations.h
+                Base.subproj/CFLocking.h
                 Base.subproj/CFLogUtilities.h
                 Base.subproj/CFPriv.h
                 Base.subproj/CFOverflow.h
@@ -124,30 +126,6 @@ add_framework(CoreFoundation
                 URL.subproj/CFURLPriv.h
                 URL.subproj/CFURLSessionInterface.h
               PUBLIC_HEADERS
-                # FIXME: PrivateHeaders referenced by public headers
-                Base.subproj/CFKnownLocations.h
-                Base.subproj/CFLocking.h
-                Base.subproj/CFLogUtilities.h
-                Base.subproj/CFPriv.h
-                Base.subproj/CFRuntime.h
-                Base.subproj/ForFoundationOnly.h
-                Base.subproj/ForSwiftFoundationOnly.h
-                Locale.subproj/CFCalendar_Internal.h
-                Locale.subproj/CFDateComponents.h
-                Locale.subproj/CFDateInterval.h
-                Locale.subproj/CFLocaleInternal.h
-                Parsing.subproj/CFXMLInterface.h
-                PlugIn.subproj/CFBundlePriv.h
-                Stream.subproj/CFStreamPriv.h
-                String.subproj/CFCharacterSetPriv.h
-                String.subproj/CFRegularExpression.h
-                String.subproj/CFRunArray.h
-                StringEncodings.subproj/CFStringEncodingConverter.h
-                StringEncodings.subproj/CFStringEncodingConverterExt.h
-                URL.subproj/CFURLPriv.h
-                URL.subproj/CFURLSessionInterface.h
-                Locale.subproj/CFDateIntervalFormatter.h
-
                 # AppServices
                 AppServices.subproj/CFNotificationCenter.h
                 AppServices.subproj/CFUserNotification.h


### PR DESCRIPTION
CoreFoundation requires libdispatch.  It is available on all targets
currently supported, so remove the option to disable it.  It was only
possible to disable it on the Swift deployment.