### PR TITLE
Clean up libdispatch handling for CoreFoundation/Foundation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,11 +90,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   endif()
 endif()
 
-set(deployment_enable_libdispatch)
 set(libdispatch_cflags)
 set(libdispatch_ldflags)
 if(FOUNDATION_ENABLE_LIBDISPATCH)
-  set(deployment_enable_libdispatch -DDEPLOYMENT_ENABLE_LIBDISPATCH)
   set(libdispatch_cflags -I;${FOUNDATION_PATH_TO_LIBDISPATCH_SOURCE};-I;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src/swift;-Xcc;-fblocks)
   set(libdispatch_ldflags -L;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD};-L;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src;-ldispatch;-lswiftDispatch)
   if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
@@ -302,7 +300,6 @@ add_swift_library(Foundation
                   TARGET
                     ${CMAKE_C_COMPILER_TARGET}
                   CFLAGS
-                    ${deployment_enable_libdispatch}
                     -F${CMAKE_CURRENT_BINARY_DIR}
                   LINK_FLAGS
                     ${CoreFoundation_LIBRARIES}
@@ -323,7 +320,7 @@ add_swift_library(Foundation
                     $<$<PLATFORM_ID:Windows>:$<TARGET_OBJECTS:CoreFoundationResources>>
                   SWIFT_FLAGS
                     -DDEPLOYMENT_RUNTIME_SWIFT
-                    ${deployment_enable_libdispatch}
+                    $<$<BOOL:FOUNDATION_ENABLE_LIBDISPATCH>:-DDEPLOYMENT_ENABLE_LIBDISPATCH>
                     -I;${ICU_INCLUDE_DIR}
                     ${libdispatch_cflags}
                     ${swift_enable_testing}
@@ -350,7 +347,6 @@ add_swift_executable(plutil
                      SOURCES
                        Tools/plutil/main.swift
                      CFLAGS
-                       ${deployment_enable_libdispatch}
                        -F${CMAKE_CURRENT_BINARY_DIR}
                      LINK_FLAGS
                        ${libdispatch_ldflags}
@@ -360,7 +356,6 @@ add_swift_executable(plutil
                        ${Foundation_RPATH}
                      SWIFT_FLAGS
                        -DDEPLOYMENT_RUNTIME_SWIFT
-                       ${deployment_enable_libdispatch}
                        -I;${CMAKE_CURRENT_BINARY_DIR}/swift
                        -I;${ICU_INCLUDE_DIR}
                        ${libdispatch_cflags}
@@ -375,7 +370,6 @@ add_swift_executable(plutil
 if(ENABLE_TESTING)
   add_swift_executable(xdgTestHelper
                        CFLAGS
-                         ${deployment_enable_libdispatch}
                          -F${CMAKE_CURRENT_BINARY_DIR}
                        LINK_FLAGS
                          ${libdispatch_ldflags}
@@ -493,7 +487,6 @@ if(ENABLE_TESTING)
                          TestFoundation/TestXMLDocument.swift
                          TestFoundation/TestXMLParser.swift
                        CFLAGS
-                         ${deployment_enable_libdispatch}
                          -F${CMAKE_CURRENT_BINARY_DIR}
                        LINK_FLAGS
                          ${libdispatch_ldflags}
@@ -530,7 +523,6 @@ if(ENABLE_TESTING)
                          ${CMAKE_SOURCE_DIR}/TestFoundation/Resources/TestFileWithZeros.txt
                          ${CMAKE_SOURCE_DIR}/TestFoundation/Fixtures
                        SWIFT_FLAGS
-                         ${deployment_enable_libdispatch}
                          -I;${CMAKE_CURRENT_BINARY_DIR}/swift
                          -I;${FOUNDATION_PATH_TO_XCTEST_BUILD}/swift
                          -I;${ICU_INCLUDE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,7 +302,6 @@ add_swift_library(Foundation
                   TARGET
                     ${CMAKE_C_COMPILER_TARGET}
                   CFLAGS
-                    ${deployment_target}
                     ${deployment_enable_libdispatch}
                     -F${CMAKE_CURRENT_BINARY_DIR}
                   LINK_FLAGS
@@ -351,7 +350,6 @@ add_swift_executable(plutil
                      SOURCES
                        Tools/plutil/main.swift
                      CFLAGS
-                       ${deployment_target}
                        ${deployment_enable_libdispatch}
                        -F${CMAKE_CURRENT_BINARY_DIR}
                      LINK_FLAGS
@@ -377,7 +375,6 @@ add_swift_executable(plutil
 if(ENABLE_TESTING)
   add_swift_executable(xdgTestHelper
                        CFLAGS
-                         ${deployment_target}
                          ${deployment_enable_libdispatch}
                          -F${CMAKE_CURRENT_BINARY_DIR}
                        LINK_FLAGS
@@ -496,7 +493,6 @@ if(ENABLE_TESTING)
                          TestFoundation/TestXMLDocument.swift
                          TestFoundation/TestXMLParser.swift
                        CFLAGS
-                         ${deployment_target}
                          ${deployment_enable_libdispatch}
                          -F${CMAKE_CURRENT_BINARY_DIR}
                        LINK_FLAGS

--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -14,17 +14,7 @@
 
 #include <CoreFoundation/CFAvailability.h>
 
-#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_WIN32
-#if DEPLOYMENT_RUNTIME_SWIFT
-#if DEPLOYMENT_ENABLE_LIBDISPATCH
 #define __HAS_DISPATCH__ 1
-#else
-#define __HAS_DISPATCH__ 0
-#endif
-#else
-#define __HAS_DISPATCH__ 1
-#endif
-#endif
 
 #include <CoreFoundation/CFBase.h>
 

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -39,7 +39,6 @@ find_package(Threads)
 include(GNUInstallDirs)
 include(CoreFoundationAddFramework)
 
-option(CF_ENABLE_LIBDISPATCH "Enable GCD Support" YES)
 option(CF_PATH_TO_LIBDISPATCH_SOURCE "Path to libdispatch source")
 option(CF_PATH_TO_LIBDISPATCH_BUILD "Path to libdispatch build")
 option(CF_DEPLOYMENT_SWIFT "Build for swift" NO)
@@ -362,11 +361,6 @@ target_compile_definitions(CoreFoundation
                            PRIVATE
                              -DU_SHOW_DRAFT_API
                              -DCF_BUILDING_CF)
-if(CF_ENABLE_LIBDISPATCH)
-  target_compile_definitions(CoreFoundation
-                             PRIVATE
-                               -DDEPLOYMENT_ENABLE_LIBDISPATCH)
-endif()
 if(CF_DEPLOYMENT_SWIFT)
   target_compile_definitions(CoreFoundation
                              PRIVATE
@@ -400,16 +394,14 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
                              PRIVATE
                                ${ICU_INCLUDE_DIR})
 endif()
-if(CF_ENABLE_LIBDISPATCH)
+target_include_directories(CoreFoundation
+                           PRIVATE
+                             ${CF_PATH_TO_LIBDISPATCH_SOURCE}
+                             ${CF_PATH_TO_LIBDISPATCH_BUILD}/tests)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_include_directories(CoreFoundation
-                             PRIVATE
-                               ${CF_PATH_TO_LIBDISPATCH_SOURCE}
-                               ${CF_PATH_TO_LIBDISPATCH_BUILD}/tests)
-  if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    target_include_directories(CoreFoundation
-                               SYSTEM PRIVATE
-                                 ${CF_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
-  endif()
+                             SYSTEM PRIVATE
+                               ${CF_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
 endif()
 
 if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
@@ -487,11 +479,9 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows AND NOT CMAKE_SYSTEM_NAME STREQUAL Dar
                         PRIVATE
                           m)
 endif()
-if(CF_ENABLE_LIBDISPATCH)
-  target_link_libraries(CoreFoundation
-                        PRIVATE
-                          dispatch)
-endif()
+target_link_libraries(CoreFoundation
+                      PRIVATE
+                        dispatch)
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(CoreFoundation
                         PRIVATE


### PR DESCRIPTION
Clean up the libdispatch handling in CoreFoundation.  All deployments of CoreFoundation have libdispatch and CoreFoundation has required libdispatch for some time now.  Now that libdispatch is available on all the deployments even under the swift deployment, remove the option to disable libdispatch portions.  This enables us to remove the dependency of the prefix header on the `-DDEPLOYMENT_ENABLE_LIBDISPATCH` flag which means that we no longer need to pass that as a CFLAG to the clang importer when building Foundation.  This also reduces the complexity in the build of CoreFoundation.

As a result of the flag no longer being needed by the clang importer, we can now simplify the build rules for Foundation, passing the `DEPLOYMENT_ENABLE_LIBDISPATCH` flag to exactly the location that needs it - the build of Foundation.  This sets the stage for removing the option to disable libdispatch in the Foundation build.  This then enables simplifying the build rules for Foundation.