### PR TITLE
CoreFoundation: remove names in function pointer (NFC)

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -179,7 +179,7 @@ struct _NSMutableStringBridge {
 
 struct _NSXMLParserBridge {
     _CFXMLInterface _Nullable (*_Nonnull currentParser)(void);
-    _CFXMLInterfaceParserInput _Nullable (*_Nonnull _xmlExternalEntityWithURL)(_CFXMLInterface interface, const char *url, const char * identifier, _CFXMLInterfaceParserContext context, _CFXMLInterfaceExternalEntityLoader originalLoaderFunction);
+    _CFXMLInterfaceParserInput _Nullable (*_Nonnull _xmlExternalEntityWithURL)(_CFXMLInterface /*interface*/, const char * /*url*/, const char * /*identifier*/, _CFXMLInterfaceParserContext /*context*/, _CFXMLInterfaceExternalEntityLoader /*originalLoaderFunction*/);
     
     _CFXMLInterfaceParserContext _Nonnull (*_Nonnull getContext)(_CFXMLInterface ctx);
     


### PR DESCRIPTION
`interface` is a problematic name on Windows where the Windows headers
will replace it with `struct` with preprocessors which break parsing of
the header.  Remove the names as they are not needed, but leave them as
comments for documentation.