### PR TITLE
CoreFoundation: make CFURLSessionInterface Win32 friendly

### DIFF
--- a/CoreFoundation/URL.subproj/CFURLSessionInterface.c
+++ b/CoreFoundation/URL.subproj/CFURLSessionInterface.c
@@ -602,7 +602,7 @@ int const CFURLSessionReadFuncPause = CURL_READFUNC_PAUSE;
 int const CFURLSessionReadFuncAbort = CURL_READFUNC_ABORT;
 
 
-int const CFURLSessionSocketTimeout = CURL_SOCKET_TIMEOUT;
+CFURLSession_socket_t const CFURLSessionSocketTimeout = CURL_SOCKET_TIMEOUT;
 
 int const CFURLSessionSeekOk = CURL_SEEKFUNC_OK;
 int const CFURLSessionSeekCantSeek = CURL_SEEKFUNC_CANTSEEK;

--- a/CoreFoundation/URL.subproj/CFURLSessionInterface.h
+++ b/CoreFoundation/URL.subproj/CFURLSessionInterface.h
@@ -28,6 +28,9 @@
 #define __COREFOUNDATION_URLSESSIONINTERFACE__ 1
 
 #include <stdio.h>
+#if defined(_WIN32)
+#include <winsock2.h>
+#endif
 
 CF_IMPLICIT_BRIDGING_ENABLED
 CF_EXTERN_C_BEGIN
@@ -40,7 +43,11 @@ typedef void * CFURLSessionEasyHandle;
 typedef void * CFURLSessionMultiHandle;
 
 // This must match libcurl's curl_socket_t
+#if defined(_WIN32)
+typedef SOCKET CFURLSession_socket_t;
+#else
 typedef int CFURLSession_socket_t;
+#endif
 
 
 
@@ -544,7 +551,7 @@ CF_EXPORT int const CFURLSessionWriteFuncPause;
 CF_EXPORT int const CFURLSessionReadFuncPause;
 CF_EXPORT int const CFURLSessionReadFuncAbort;
 
-CF_EXPORT int const CFURLSessionSocketTimeout;
+CF_EXPORT CFURLSession_socket_t const CFURLSessionSocketTimeout;
 
 CF_EXPORT int const CFURLSessionSeekOk;
 CF_EXPORT int const CFURLSessionSeekCantSeek;


### PR DESCRIPTION
The socket type on Windows is `SOCKET`, not `int`.  This was mismatched
with CURL.

The timeout value is an alias for invalid socket which is of type
`SOCKET` not `int`.  Adjust the type accordingly and plumb it through.