### PR TITLE
FoundationNetworking: Split networking into its own module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,27 +346,22 @@ add_swift_library(FoundationNetworking
                     ${CMAKE_C_COMPILER_TARGET}
                   CFLAGS
                     ${MSVCRT_C_FLAGS}
-                    ${deployment_target}
-                    ${deployment_enable_libdispatch}
                     -F${CMAKE_CURRENT_BINARY_DIR}
                   LINK_FLAGS
                     ${MSVCRT_LINK_FLAGS}
                     -L${CMAKE_CURRENT_BINARY_DIR}
-                    ${ICU_UC_LIBRARY} ${ICU_I18N_LIBRARY}
                     ${libdispatch_ldflags}
                     -lFoundation
                     ${Foundation_INTERFACE_LIBRARIES}
-					${CFURLSessionInterface_LIBRARIES}
+                    ${CFURLSessionInterface_LIBRARIES}
                     ${CURL_LIBRARIES}
                     ${Foundation_RPATH}
                     ${WORKAROUND_SR9138}
                     ${WORKAROUND_SR9995}
-                    $<$<PLATFORM_ID:Windows>:$<TARGET_OBJECTS:CoreFoundationResources>>
                   SWIFT_FLAGS
                     -DDEPLOYMENT_RUNTIME_SWIFT
-					-DNS_BUILDING_FOUNDATION_NETWORKING
+                    -DNS_BUILDING_FOUNDATION_NETWORKING
                     ${deployment_enable_libdispatch}
-                    -I;${ICU_INCLUDE_DIR}
                     -I;${CMAKE_CURRENT_BINARY_DIR}/swift
                     ${libdispatch_cflags}
                     ${swift_enable_testing}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,7 +370,7 @@ add_swift_library(FoundationNetworking
                     uuid
                     CoreFoundation
                     $<$<PLATFORM_ID:Windows>:CoreFoundationResources>
-				    Foundation)
+                    Foundation)
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,10 +117,12 @@ endif()
 # be able to remove this and just use
 # `target_link_libraries(Foundation PRIVATE CoreFoundation)`.
 set(CoreFoundation_LIBRARIES $<TARGET_FILE:CoreFoundation>)
+set(CFURLSessionInterface_LIBRARIES $<TARGET_FILE:CFURLSessionInterface>)
 get_target_property(CoreFoundation_LINK_LIBRARIES CoreFoundation LINK_LIBRARIES)
 foreach(library ${CoreFoundation_LINK_LIBRARIES})
   if(NOT library STREQUAL Threads::Threads)
     list(APPEND CoreFoundation_LIBRARIES -l${library})
+    list(APPEND CFURLSessionInterface_LIBRARIES -l${library})
   endif()
 endforeach()
 
@@ -165,8 +167,6 @@ add_swift_library(Foundation
                     Foundation/Formatter.swift
                     Foundation/FoundationErrors.swift
                     Foundation/Host.swift
-                    Foundation/HTTPCookie.swift
-                    Foundation/HTTPCookieStorage.swift
                     Foundation/IndexPath.swift
                     Foundation/IndexSet.swift
                     Foundation/ISO8601DateFormatter.swift
@@ -235,7 +235,6 @@ add_swift_library(Foundation
                     Foundation/NSTimeZone.swift
                     Foundation/NSURL.swift
                     Foundation/NSURLError.swift
-                    Foundation/NSURLRequest.swift
                     Foundation/NSUUID.swift
                     Foundation/NSValue.swift
                     Foundation/NumberFormatter.swift
@@ -264,31 +263,7 @@ add_swift_library(Foundation
                     Foundation/TimeZone.swift
                     Foundation/Unit.swift
                     Foundation/URL.swift
-                    Foundation/URLAuthenticationChallenge.swift
-                    Foundation/URLCache.swift
                     Foundation/URLComponents.swift
-                    Foundation/URLCredential.swift
-                    Foundation/URLCredentialStorage.swift
-                    Foundation/URLProtectionSpace.swift
-                    Foundation/URLProtocol.swift
-                    Foundation/URLRequest.swift
-                    Foundation/URLResponse.swift
-                    Foundation/URLSession/BodySource.swift
-                    Foundation/URLSession/Configuration.swift
-                    Foundation/URLSession/http/HTTPMessage.swift
-                    Foundation/URLSession/http/HTTPURLProtocol.swift
-                    Foundation/URLSession/libcurl/EasyHandle.swift
-                    Foundation/URLSession/libcurl/libcurlHelpers.swift
-                    Foundation/URLSession/libcurl/MultiHandle.swift
-                    Foundation/URLSession/Message.swift
-                    Foundation/URLSession/NativeProtocol.swift
-                    Foundation/URLSession/ftp/FTPURLProtocol.swift
-                    Foundation/URLSession/TaskRegistry.swift
-                    Foundation/URLSession/TransferState.swift
-                    Foundation/URLSession/URLSession.swift
-                    Foundation/URLSession/URLSessionConfiguration.swift
-                    Foundation/URLSession/URLSessionDelegate.swift
-                    Foundation/URLSession/URLSessionTask.swift
                     Foundation/UserDefaults.swift
                     Foundation/UUID.swift
                     Foundation/XMLDocument.swift
@@ -303,7 +278,6 @@ add_swift_library(Foundation
                     -F${CMAKE_CURRENT_BINARY_DIR}
                   LINK_FLAGS
                     ${CoreFoundation_LIBRARIES}
-                    ${CURL_LIBRARIES}
                     ${ICU_UC_LIBRARY} ${ICU_I18N_LIBRARY}
                     ${LIBXML2_LIBRARIES}
                     ${libdispatch_ldflags}
@@ -330,6 +304,80 @@ add_swift_library(Foundation
                     uuid
                     CoreFoundation
                     $<$<PLATFORM_ID:Windows>:CoreFoundationResources>)
+
+add_swift_library(FoundationNetworking
+                  MODULE_NAME
+                    FoundationNetworking
+                  MODULE_LINK_NAME
+                    FoundationNetworking
+                  MODULE_PATH
+                    ${CMAKE_CURRENT_BINARY_DIR}/swift/FoundationNetworking.swiftmodule
+                  SOURCES
+                  Foundation/Boxing.swift
+                  Foundation/NSURLRequest.swift
+                  Foundation/HTTPCookie.swift
+                  Foundation/HTTPCookieStorage.swift
+                  Foundation/URLAuthenticationChallenge.swift
+                  Foundation/URLCache.swift
+                  Foundation/URLCredential.swift
+                  Foundation/URLCredentialStorage.swift
+                  Foundation/URLProtectionSpace.swift
+                  Foundation/URLProtocol.swift
+                  Foundation/URLRequest.swift
+                  Foundation/URLResponse.swift
+                  Foundation/URLSession/BodySource.swift
+                  Foundation/URLSession/Configuration.swift
+                  Foundation/URLSession/http/HTTPMessage.swift
+                  Foundation/URLSession/http/HTTPURLProtocol.swift
+                  Foundation/URLSession/libcurl/EasyHandle.swift
+                  Foundation/URLSession/libcurl/libcurlHelpers.swift
+                  Foundation/URLSession/libcurl/MultiHandle.swift
+                  Foundation/URLSession/Message.swift
+                  Foundation/URLSession/NativeProtocol.swift
+                  Foundation/URLSession/NetworkingSpecific.swift
+                  Foundation/URLSession/ftp/FTPURLProtocol.swift
+                  Foundation/URLSession/TaskRegistry.swift
+                  Foundation/URLSession/TransferState.swift
+                  Foundation/URLSession/URLSession.swift
+                  Foundation/URLSession/URLSessionConfiguration.swift
+                  Foundation/URLSession/URLSessionDelegate.swift
+                  Foundation/URLSession/URLSessionTask.swift
+                  TARGET
+                    ${CMAKE_C_COMPILER_TARGET}
+                  CFLAGS
+                    ${MSVCRT_C_FLAGS}
+                    ${deployment_target}
+                    ${deployment_enable_libdispatch}
+                    -F${CMAKE_CURRENT_BINARY_DIR}
+                  LINK_FLAGS
+                    ${MSVCRT_LINK_FLAGS}
+                    -L${CMAKE_CURRENT_BINARY_DIR}
+                    ${ICU_UC_LIBRARY} ${ICU_I18N_LIBRARY}
+                    ${libdispatch_ldflags}
+                    -lFoundation
+                    ${Foundation_INTERFACE_LIBRARIES}
+					${CFURLSessionInterface_LIBRARIES}
+                    ${CURL_LIBRARIES}
+                    ${Foundation_RPATH}
+                    ${WORKAROUND_SR9138}
+                    ${WORKAROUND_SR9995}
+                    $<$<PLATFORM_ID:Windows>:$<TARGET_OBJECTS:CoreFoundationResources>>
+                  SWIFT_FLAGS
+                    -DDEPLOYMENT_RUNTIME_SWIFT
+					-DNS_BUILDING_FOUNDATION_NETWORKING
+                    ${deployment_enable_libdispatch}
+                    -I;${ICU_INCLUDE_DIR}
+                    -I;${CMAKE_CURRENT_BINARY_DIR}/swift
+                    ${libdispatch_cflags}
+                    ${swift_enable_testing}
+                    ${swift_optimization_flags}
+                  DEPENDS
+                    uuid
+                    CoreFoundation
+                    $<$<PLATFORM_ID:Windows>:CoreFoundationResources>
+				    Foundation)
+
+
 
 if(NOT BUILD_SHARED_LIBS)
   set(Foundation_INTERFACE_LIBRARIES

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -24,7 +24,6 @@
 #include <CoreFoundation/CFXMLInterface.h>
 #include <CoreFoundation/CFRegularExpression.h>
 #include <CoreFoundation/CFLogUtilities.h>
-#include <CoreFoundation/CFURLSessionInterface.h>
 #include <CoreFoundation/CFDateIntervalFormatter.h>
 #include <CoreFoundation/ForFoundationOnly.h>
 #include <CoreFoundation/CFCharacterSetPriv.h>

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -316,6 +316,21 @@ add_framework(CoreFoundation
                 URL.subproj/CFURLComponents.c
                 URL.subproj/CFURLComponents_URIParser.c
                 URL.subproj/CFURLSessionInterface.c)
+				
+add_framework(CFURLSessionInterface
+                ${FRAMEWORK_LIBRARY_TYPE}
+              FRAMEWORK_DIRECTORY
+                CoreFoundation_FRAMEWORK_DIRECTORY
+              MODULE_MAP
+                URL.subproj/module.modulemap
+              PRIVATE_HEADERS
+                URL.subproj/CFURLSessionInterface.h
+              PUBLIC_HEADERS
+                URL.subproj/CFURLSessionInterface.h
+              SOURCES
+                URL.subproj/CFURLSessionInterface.c)
+add_dependencies(CFURLSessionInterface CoreFoundation)
+
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   add_library(CoreFoundationResources OBJECT
     CoreFoundation.rc)
@@ -337,8 +352,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android)
   target_compile_definitions(CoreFoundation
                              PRIVATE
                                -D_GNU_SOURCE)
+  target_compile_definitions(CFURLSessionInterface
+                             PRIVATE
+                               -D_GNU_SOURCE)
   if(HAVE_SCHED_GETAFFINITY)
     target_compile_definitions(CoreFoundation
+                               PRIVATE
+                                 -DHAVE_SCHED_GETAFFINITY)
+    target_compile_definitions(CFURLSessionInterface
                                PRIVATE
                                  -DHAVE_SCHED_GETAFFINITY)
   endif()
@@ -348,12 +369,21 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
   target_compile_definitions(CoreFoundation
                              PRIVATE
                                -D_DLL)
+  target_compile_definitions(CFURLSessionInterface
+                             PRIVATE
+                               -D_DLL)
   if(BUILD_SHARED_LIBS)
     target_compile_definitions(CoreFoundation
                                PRIVATE
                                  -D_WINDLL)
+    target_compile_definitions(CFURLSessionInterface
+                               PRIVATE
+                                 -D_WINDLL)
   endif()
   target_compile_definitions(CoreFoundation
+                             PRIVATE
+                               -DCURL_STATICLIB)
+  target_compile_definitions(CFURLSessionInterface
                              PRIVATE
                                -DCURL_STATICLIB)
 endif()
@@ -361,12 +391,22 @@ target_compile_definitions(CoreFoundation
                            PRIVATE
                              -DU_SHOW_DRAFT_API
                              -DCF_BUILDING_CF)
+target_compile_definitions(CFURLSessionInterface
+                           PRIVATE
+                             -DU_SHOW_DRAFT_API
+                             -DCF_BUILDING_CF)
 if(CF_DEPLOYMENT_SWIFT)
   target_compile_definitions(CoreFoundation
                              PRIVATE
                                -DDEPLOYMENT_RUNTIME_SWIFT)
+  target_compile_definitions(CFURLSessionInterface
+                             PRIVATE
+                               -DDEPLOYMENT_RUNTIME_SWIFT)
 else()
   target_compile_definitions(CoreFoundation
+                             PRIVATE
+                               -DDEPLOYMENT_RUNTIME_C)
+  target_compile_definitions(CFURLSessionInterface
                              PRIVATE
                                -DDEPLOYMENT_RUNTIME_C)
 endif()
@@ -386,7 +426,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
                              PRIVATE
                                ${LIBXML2_INCLUDE_DIR})
   find_package(CURL REQUIRED)
-  target_include_directories(CoreFoundation
+  target_include_directories(CFURLSessionInterface
                              PRIVATE
                                ${CURL_INCLUDE_DIRS})
   find_package(ICU COMPONENTS uc i18n REQUIRED)
@@ -398,8 +438,15 @@ target_include_directories(CoreFoundation
                            PRIVATE
                              ${CF_PATH_TO_LIBDISPATCH_SOURCE}
                              ${CF_PATH_TO_LIBDISPATCH_BUILD}/tests)
+target_include_directories(CFURLSessionInterface
+                           PRIVATE
+                             ${CF_PATH_TO_LIBDISPATCH_SOURCE}
+                             ${CF_PATH_TO_LIBDISPATCH_BUILD}/tests)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_include_directories(CoreFoundation
+                             SYSTEM PRIVATE
+                               ${CF_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
+  target_include_directories(CFURLSessionInterface
                              SYSTEM PRIVATE
                                ${CF_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
 endif()
@@ -408,8 +455,14 @@ if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
   target_compile_options(CoreFoundation
                          PRIVATE
                            $<$<COMPILE_LANGUAGE:C>:/FI${PROJECT_SOURCE_DIR}/Base.subproj/CoreFoundation_Prefix.h>)
+  target_compile_options(CFURLSessionInterface
+                         PRIVATE
+                           $<$<COMPILE_LANGUAGE:C>:/FI${PROJECT_SOURCE_DIR}/Base.subproj/CoreFoundation_Prefix.h>)
 else()
   target_compile_options(CoreFoundation
+                         PRIVATE
+                           $<$<COMPILE_LANGUAGE:C>:-include;${PROJECT_SOURCE_DIR}/Base.subproj/CoreFoundation_Prefix.h>)
+  target_compile_options(CFURLSessionInterface
                          PRIVATE
                            $<$<COMPILE_LANGUAGE:C>:-include;${PROJECT_SOURCE_DIR}/Base.subproj/CoreFoundation_Prefix.h>)
 endif()
@@ -419,8 +472,19 @@ if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
                          PRIVATE
                            -fblocks
                            /EHsc)
+  target_compile_options(CFURLSessionInterface
+                         PRIVATE
+                           -fblocks
+                           /EHsc)
 else()
   target_compile_options(CoreFoundation
+                         PRIVATE
+                           -fblocks
+                           -fconstant-cfstrings
+                           -fdollars-in-identifiers
+                           -fexceptions
+                           -fno-common)
+  target_compile_options(CFURLSessionInterface
                          PRIVATE
                            -fblocks
                            -fconstant-cfstrings
@@ -433,8 +497,14 @@ if(CF_DEPLOYMENT_SWIFT)
     target_compile_options(CoreFoundation
                            PRIVATE
                              /clang:-fcf-runtime-abi=swift)
+    target_compile_options(CFURLSessionInterface
+                           PRIVATE
+                             /clang:-fcf-runtime-abi=swift)
   else()
     target_compile_options(CoreFoundation
+                           PRIVATE
+                             -fcf-runtime-abi=swift)
+    target_compile_options(CFURLSessionInterface
                            PRIVATE
                              -fcf-runtime-abi=swift)
   endif()
@@ -450,19 +520,38 @@ target_compile_options(CoreFoundation
                          -Wno-int-conversion
                          -Wno-unused-function
                          -Wno-microsoft-enum-forward-reference)
+target_compile_options(CFURLSessionInterface
+                       PRIVATE
+                         -Wno-shorten-64-to-32
+                         -Wno-deprecated-declarations
+                         -Wno-unreachable-code
+                         -Wno-conditional-uninitialized
+                         -Wno-unused-variable
+                         -Wno-int-conversion
+                         -Wno-unused-function
+                         -Wno-microsoft-enum-forward-reference)
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(CoreFoundation
                         PRIVATE
-                          ${CURL_LIBRARIES}
                           ${LIBXML2_LIBRARIES})
+  target_link_libraries(CFURLSessionInterface
+                        PRIVATE
+                          ${CURL_LIBRARIES})
 endif()
 if(CMAKE_SYSTEM_NAME STREQUAL Android)
   target_link_libraries(CoreFoundation
                         PRIVATE
                           log)
+  target_link_libraries(CFURLSessionInterface
+                        PRIVATE
+                          log)
 endif()
 target_link_libraries(CoreFoundation
+                      PRIVATE
+                        Threads::Threads
+                        ${CMAKE_DL_LIBS})
+target_link_libraries(CFURLSessionInterface
                       PRIVATE
                         Threads::Threads
                         ${CMAKE_DL_LIBS})
@@ -473,26 +562,45 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
                           Secur32
                           User32
                           mincore)
+  target_link_libraries(CFURLSessionInterface
+                        PRIVATE
+                          AdvAPI32
+                          Secur32
+                          User32
+                          mincore)
 endif()
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows AND NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(CoreFoundation
+                        PRIVATE
+                          m)
+  target_link_libraries(CFURLSessionInterface
                         PRIVATE
                           m)
 endif()
 target_link_libraries(CoreFoundation
                       PRIVATE
                         dispatch)
+target_link_libraries(CFURLSessionInterface
+                      PRIVATE
+                        dispatch)
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(CoreFoundation
                         PRIVATE
                           icucore)
+  target_link_libraries(CFURLSessionInterface
+                        PRIVATE
+                          icucore)
   set_target_properties(CoreFoundation
+                        PROPERTIES LINK_FLAGS
+                          -Xlinker;-alias_list;-Xlinker;Base.subproj/DarwinSymbolAliases;-twolevel_namespace;-sectcreate;__UNICODE;__csbitmaps;CharacterSets/CFCharacterSetBitmaps.bitmap;-sectcreate;__UNICODE;__properties;CharacterSets/CFUniCharPropertyDatabase.data;-sectcreate;__UNICODE;__data;CharacterSets/CFUnicodeData-L.mapping;-segprot;__UNICODE;r;r)
+  set_target_properties(CFURLSessionInterface
                         PROPERTIES LINK_FLAGS
                           -Xlinker;-alias_list;-Xlinker;Base.subproj/DarwinSymbolAliases;-twolevel_namespace;-sectcreate;__UNICODE;__csbitmaps;CharacterSets/CFCharacterSetBitmaps.bitmap;-sectcreate;__UNICODE;__properties;CharacterSets/CFUniCharPropertyDatabase.data;-sectcreate;__UNICODE;__data;CharacterSets/CFUnicodeData-L.mapping;-segprot;__UNICODE;r;r)
 endif()
 
 install(TARGETS
           CoreFoundation
+		  CFURLSessionInterface
         DESTINATION
           "${CMAKE_INSTALL_FULL_LIBDIR}")
 install(DIRECTORY

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -543,15 +543,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL Android)
   target_link_libraries(CoreFoundation
                         PRIVATE
                           log)
-  target_link_libraries(CFURLSessionInterface
-                        PRIVATE
-                          log)
 endif()
 target_link_libraries(CoreFoundation
-                      PRIVATE
-                        Threads::Threads
-                        ${CMAKE_DL_LIBS})
-target_link_libraries(CFURLSessionInterface
                       PRIVATE
                         Threads::Threads
                         ${CMAKE_DL_LIBS})
@@ -591,9 +584,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
                         PRIVATE
                           icucore)
   set_target_properties(CoreFoundation
-                        PROPERTIES LINK_FLAGS
-                          -Xlinker;-alias_list;-Xlinker;Base.subproj/DarwinSymbolAliases;-twolevel_namespace;-sectcreate;__UNICODE;__csbitmaps;CharacterSets/CFCharacterSetBitmaps.bitmap;-sectcreate;__UNICODE;__properties;CharacterSets/CFUniCharPropertyDatabase.data;-sectcreate;__UNICODE;__data;CharacterSets/CFUnicodeData-L.mapping;-segprot;__UNICODE;r;r)
-  set_target_properties(CFURLSessionInterface
                         PROPERTIES LINK_FLAGS
                           -Xlinker;-alias_list;-Xlinker;Base.subproj/DarwinSymbolAliases;-twolevel_namespace;-sectcreate;__UNICODE;__csbitmaps;CharacterSets/CFCharacterSetBitmaps.bitmap;-sectcreate;__UNICODE;__properties;CharacterSets/CFUniCharPropertyDatabase.data;-sectcreate;__UNICODE;__data;CharacterSets/CFUnicodeData-L.mapping;-segprot;__UNICODE;r;r)
 endif()

--- a/CoreFoundation/URL.subproj/CFURLSessionInterface.h
+++ b/CoreFoundation/URL.subproj/CFURLSessionInterface.h
@@ -27,6 +27,7 @@
 #if !defined(__COREFOUNDATION_URLSESSIONINTERFACE__)
 #define __COREFOUNDATION_URLSESSIONINTERFACE__ 1
 
+#include <CoreFoundation/CoreFoundation.h>
 #include <stdio.h>
 #if defined(_WIN32)
 #include <winsock2.h>

--- a/CoreFoundation/URL.subproj/module.map
+++ b/CoreFoundation/URL.subproj/module.map
@@ -1,0 +1,3 @@
+module CFURLSessionInterface [extern_c] [system] {
+    umbrella header "CFURLSessionInterface.h"
+}

--- a/CoreFoundation/URL.subproj/module.modulemap
+++ b/CoreFoundation/URL.subproj/module.modulemap
@@ -1,0 +1,8 @@
+framework module CFURLSessionInterface [extern_c] [system] {
+    umbrella header "CFURLSessionInterface.h"
+
+    export *
+    module * {
+      export *
+    }
+}

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -34,8 +34,45 @@
 		158BCCAA2220A12600750239 /* TestDateIntervalFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158BCCA92220A12600750239 /* TestDateIntervalFormatter.swift */; };
 		158BCCAD2220A18F00750239 /* CFDateIntervalFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 158BCCAB2220A18F00750239 /* CFDateIntervalFormatter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		158BCCAE2220A18F00750239 /* CFDateIntervalFormatter.c in Sources */ = {isa = PBXBuildFile; fileRef = 158BCCAC2220A18F00750239 /* CFDateIntervalFormatter.c */; };
+		159870BC228F40BB00ADE509 /* NetworkingSpecific.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159870BB228F40BA00ADE509 /* NetworkingSpecific.swift */; };
+		159870BD228F413300ADE509 /* Boxing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B23AB861CE62D17000DB898 /* Boxing.swift */; };
+		159870BE228F73F800ADE509 /* SwiftFoundationNetworking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15B8043A228F376000B30FF6 /* SwiftFoundationNetworking.framework */; };
 		159884921DCC877700E3314C /* TestHTTPCookieStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159884911DCC877700E3314C /* TestHTTPCookieStorage.swift */; };
+		15B80388228F376000B30FF6 /* libcurl.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B1FD9E01D6D178E0080E83C /* libcurl.3.dylib */; };
+		15B8038E228F376000B30FF6 /* SwiftFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = AE35A1851CBAC85E0042DB84 /* SwiftFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		15B8039E228F376000B30FF6 /* URLProtectionSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B821BD15DFF00C49C64 /* URLProtectionSpace.swift */; };
+		15B803A5228F376000B30FF6 /* TaskRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD9D21D6D16580080E83C /* TaskRegistry.swift */; };
+		15B803A7228F376000B30FF6 /* URLSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD9D01D6D16580080E83C /* URLSessionDelegate.swift */; };
+		15B803B4228F376000B30FF6 /* URLCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B7F1BD15DFF00C49C64 /* URLCredential.swift */; };
+		15B803BD228F376000B30FF6 /* EasyHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B951EDF4A22007F15B8 /* EasyHandle.swift */; };
+		15B803CF228F376000B30FF6 /* URLAuthenticationChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B7D1BD15DFF00C49C64 /* URLAuthenticationChallenge.swift */; };
+		15B803E6228F376000B30FF6 /* NSURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B841BD15DFF00C49C64 /* NSURLRequest.swift */; };
+		15B803EE228F376000B30FF6 /* TransferState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B8F1EDF4A22007F15B8 /* TransferState.swift */; };
+		15B803F8228F376000B30FF6 /* BodySource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B941EDF4A22007F15B8 /* BodySource.swift */; };
+		15B803F9228F376000B30FF6 /* FTPURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616068EC225C82C5004FCC54 /* FTPURLProtocol.swift */; };
+		15B80400228F376000B30FF6 /* libcurlHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B911EDF4A22007F15B8 /* libcurlHelpers.swift */; };
+		15B80406228F376000B30FF6 /* URLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD9CE1D6D16580080E83C /* URLSession.swift */; };
+		15B80413228F376000B30FF6 /* URLSessionTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD9D11D6D16580080E83C /* URLSessionTask.swift */; };
+		15B80414228F376000B30FF6 /* URLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B831BD15DFF00C49C64 /* URLProtocol.swift */; };
+		15B8041C228F376000B30FF6 /* NativeProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D2F9AE1FECFB3E0033306A /* NativeProtocol.swift */; };
+		15B8041F228F376000B30FF6 /* HTTPURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B921EDF4A22007F15B8 /* HTTPURLProtocol.swift */; };
+		15B8042B228F376000B30FF6 /* HTTPMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B931EDF4A22007F15B8 /* HTTPMessage.swift */; };
+		15B80430228F376000B30FF6 /* HTTPCookieStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B611BD15DFF00C49C64 /* HTTPCookieStorage.swift */; };
+		15B80435228F376000B30FF6 /* URLSessionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD9CF1D6D16580080E83C /* URLSessionConfiguration.swift */; };
+		15B8043B228F385F00B30FF6 /* HTTPCookie.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B601BD15DFF00C49C64 /* HTTPCookie.swift */; };
+		15B8043C228F387400B30FF6 /* URLCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B7E1BD15DFF00C49C64 /* URLCache.swift */; };
+		15B8043D228F38A600B30FF6 /* URLCredentialStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B801BD15DFF00C49C64 /* URLCredentialStorage.swift */; };
+		15B8043E228F38C000B30FF6 /* URLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA9BEA31CF380E8009DBD6C /* URLRequest.swift */; };
+		15B8043F228F38C700B30FF6 /* URLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B851BD15DFF00C49C64 /* URLResponse.swift */; };
+		15B80441228F38E400B30FF6 /* MultiHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B901EDF4A22007F15B8 /* MultiHandle.swift */; };
+		15B80442228F38E400B30FF6 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD9C81D6D16580080E83C /* Configuration.swift */; };
+		15B80443228F38E400B30FF6 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105D30E1FEBC5FC0022865A /* Message.swift */; };
+		15B80444228F396600B30FF6 /* SwiftFoundationNetworking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15B8043A228F376000B30FF6 /* SwiftFoundationNetworking.framework */; };
 		15F10CDC218909BF00D88114 /* TestNSCalendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F10CDB218909BF00D88114 /* TestNSCalendar.swift */; };
+		15FF004B229348F2004AD205 /* CFURLSessionInterface.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD9C11D6D160F0080E83C /* CFURLSessionInterface.c */; };
+		15FF00CB22934A3C004AD205 /* CFURLSessionInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B1FD9C21D6D160F0080E83C /* CFURLSessionInterface.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		15FF00CC22934AD7004AD205 /* libCFURLSessionInterface.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 15FF00CA229348F2004AD205 /* libCFURLSessionInterface.a */; };
+		15FF00CE22934B78004AD205 /* module.map in Headers */ = {isa = PBXBuildFile; fileRef = 15FF00CD22934B49004AD205 /* module.map */; settings = {ATTRIBUTES = (Public, ); }; };
 		231503DB1D8AEE5D0061694D /* TestDecimal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231503DA1D8AEE5D0061694D /* TestDecimal.swift */; };
 		294E3C1D1CC5E19300E4F44C /* TestNSAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 294E3C1C1CC5E19300E4F44C /* TestNSAttributedString.swift */; };
 		2EBE67A51C77BF0E006583D5 /* TestDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EBE67A31C77BF05006583D5 /* TestDateFormatter.swift */; };
@@ -93,13 +130,6 @@
 		5B13B3511C582D4C00651CE2 /* TestByteCountFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A34B551C18C85D00FD972B /* TestByteCountFormatter.swift */; };
 		5B13B3521C582D4C00651CE2 /* TestNSValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3047AEB1C38BC3300295652 /* TestNSValue.swift */; };
 		5B1FD9C51D6D16150080E83C /* CFURLSessionInterface.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD9C11D6D160F0080E83C /* CFURLSessionInterface.c */; };
-		5B1FD9C61D6D161A0080E83C /* CFURLSessionInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B1FD9C21D6D160F0080E83C /* CFURLSessionInterface.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5B1FD9D41D6D16580080E83C /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD9C81D6D16580080E83C /* Configuration.swift */; };
-		5B1FD9DA1D6D16580080E83C /* URLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD9CE1D6D16580080E83C /* URLSession.swift */; };
-		5B1FD9DB1D6D16580080E83C /* URLSessionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD9CF1D6D16580080E83C /* URLSessionConfiguration.swift */; };
-		5B1FD9DC1D6D16580080E83C /* URLSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD9D01D6D16580080E83C /* URLSessionDelegate.swift */; };
-		5B1FD9DD1D6D16580080E83C /* URLSessionTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD9D11D6D16580080E83C /* URLSessionTask.swift */; };
-		5B1FD9DE1D6D16580080E83C /* TaskRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD9D21D6D16580080E83C /* TaskRegistry.swift */; };
 		5B1FD9E11D6D178E0080E83C /* libcurl.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B1FD9E01D6D178E0080E83C /* libcurl.3.dylib */; };
 		5B1FD9E31D6D17B80080E83C /* TestURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD9E21D6D17B80080E83C /* TestURLSession.swift */; };
 		5B23AB871CE62D17000DB898 /* Boxing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B23AB861CE62D17000DB898 /* Boxing.swift */; };
@@ -268,7 +298,6 @@
 		5B8BA1621D0B773A00938C27 /* IndexSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8BA1611D0B773A00938C27 /* IndexSet.swift */; };
 		5B94E8821C430DE70055C035 /* NSStringAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B94E8811C430DE70055C035 /* NSStringAPI.swift */; };
 		5BA0106E1DF212B300E56898 /* NSPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA0106D1DF212B300E56898 /* NSPlatform.swift */; };
-		5BA9BEA41CF380E8009DBD6C /* URLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA9BEA31CF380E8009DBD6C /* URLRequest.swift */; };
 		5BA9BEA61CF3D747009DBD6C /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA9BEA51CF3D747009DBD6C /* Data.swift */; };
 		5BA9BEA81CF3E7E7009DBD6C /* CharacterSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA9BEA71CF3E7E7009DBD6C /* CharacterSet.swift */; };
 		5BA9BEBD1CF4F3B8009DBD6C /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA9BEBC1CF4F3B8009DBD6C /* Notification.swift */; };
@@ -340,11 +369,8 @@
 		5BF9B8011FABD5DA00EE1A7C /* CFBundle_ResourceFork.c in Sources */ = {isa = PBXBuildFile; fileRef = 5BF9B7F61FABD5D400EE1A7C /* CFBundle_ResourceFork.c */; };
 		5BF9B8021FABD5DA00EE1A7C /* CFBundle_Tables.c in Sources */ = {isa = PBXBuildFile; fileRef = 5BF9B7F71FABD5D400EE1A7C /* CFBundle_Tables.c */; };
 		5FE52C951D147D1C00F7D270 /* TestNSTextCheckingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE52C941D147D1C00F7D270 /* TestNSTextCheckingResult.swift */; };
-		6105D30F1FEBC5FC0022865A /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105D30E1FEBC5FC0022865A /* Message.swift */; };
-		616068ED225C82C5004FCC54 /* FTPURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616068EC225C82C5004FCC54 /* FTPURLProtocol.swift */; };
 		616068F3225DE5C2004FCC54 /* FTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616068F2225DE5C2004FCC54 /* FTPServer.swift */; };
 		616068F5225DE606004FCC54 /* TestURLSessionFTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616068F4225DE606004FCC54 /* TestURLSessionFTP.swift */; };
-		61D2F9AF1FECFB3E0033306A /* NativeProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D2F9AE1FECFB3E0033306A /* NativeProtocol.swift */; };
 		61E0117D1C1B5590000037DD /* RunLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B761BD15DFF00C49C64 /* RunLoop.swift */; };
 		61E0117E1C1B55B9000037DD /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDC3F481BCC5DCB00ED97BB /* Timer.swift */; };
 		61E0117F1C1B5990000037DD /* CFRunLoop.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B5D88D81BBC9AD800234F36 /* CFRunLoop.c */; };
@@ -379,13 +405,6 @@
 		B940492D223B146800FB4384 /* TestProgressFraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B940492C223B146800FB4384 /* TestProgressFraction.swift */; };
 		B951B5EC1F4E2A2000D8B332 /* TestNSLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B951B5EB1F4E2A2000D8B332 /* TestNSLock.swift */; };
 		B98E33DD2136AA740044EBE9 /* TestFileWithZeros.txt in Resources */ = {isa = PBXBuildFile; fileRef = B98E33DC2136AA740044EBE9 /* TestFileWithZeros.txt */; };
-		B9974B961EDF4A22007F15B8 /* TransferState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B8F1EDF4A22007F15B8 /* TransferState.swift */; };
-		B9974B971EDF4A22007F15B8 /* MultiHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B901EDF4A22007F15B8 /* MultiHandle.swift */; };
-		B9974B981EDF4A22007F15B8 /* libcurlHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B911EDF4A22007F15B8 /* libcurlHelpers.swift */; };
-		B9974B991EDF4A22007F15B8 /* HTTPURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B921EDF4A22007F15B8 /* HTTPURLProtocol.swift */; };
-		B9974B9A1EDF4A22007F15B8 /* HTTPMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B931EDF4A22007F15B8 /* HTTPMessage.swift */; };
-		B9974B9B1EDF4A22007F15B8 /* BodySource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B941EDF4A22007F15B8 /* BodySource.swift */; };
-		B9974B9C1EDF4A22007F15B8 /* EasyHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B951EDF4A22007F15B8 /* EasyHandle.swift */; };
 		B9C0E89620C31AB60064C68C /* CFInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B5D888A1BBC963C00234F36 /* CFInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BB3D7558208A1E500085CFDC /* TestImports.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3D7557208A1E500085CFDC /* TestImports.swift */; };
 		BD8042161E09857800487EB8 /* TestLengthFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8042151E09857800487EB8 /* TestLengthFormatter.swift */; };
@@ -447,8 +466,6 @@
 		EADE0B9B1BD15DFF00C49C64 /* FileHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B5D1BD15DFF00C49C64 /* FileHandle.swift */; };
 		EADE0B9C1BD15DFF00C49C64 /* FileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B5E1BD15DFF00C49C64 /* FileManager.swift */; };
 		EADE0B9D1BD15DFF00C49C64 /* NSGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B5F1BD15DFF00C49C64 /* NSGeometry.swift */; };
-		EADE0B9E1BD15DFF00C49C64 /* HTTPCookie.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B601BD15DFF00C49C64 /* HTTPCookie.swift */; };
-		EADE0B9F1BD15DFF00C49C64 /* HTTPCookieStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B611BD15DFF00C49C64 /* HTTPCookieStorage.swift */; };
 		EADE0BA01BD15DFF00C49C64 /* NSIndexPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B621BD15DFF00C49C64 /* NSIndexPath.swift */; };
 		EADE0BA11BD15DFF00C49C64 /* NSIndexSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B631BD15DFF00C49C64 /* NSIndexSet.swift */; };
 		EADE0BA21BD15E0000C49C64 /* JSONSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B641BD15DFF00C49C64 /* JSONSerialization.swift */; };
@@ -472,15 +489,7 @@
 		EADE0BB71BD15E0000C49C64 /* Stream.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B791BD15DFF00C49C64 /* Stream.swift */; };
 		EADE0BB81BD15E0000C49C64 /* Process.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B7A1BD15DFF00C49C64 /* Process.swift */; };
 		EADE0BB91BD15E0000C49C64 /* NSTextCheckingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B7B1BD15DFF00C49C64 /* NSTextCheckingResult.swift */; };
-		EADE0BBB1BD15E0000C49C64 /* URLAuthenticationChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B7D1BD15DFF00C49C64 /* URLAuthenticationChallenge.swift */; };
-		EADE0BBC1BD15E0000C49C64 /* URLCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B7E1BD15DFF00C49C64 /* URLCache.swift */; };
-		EADE0BBD1BD15E0000C49C64 /* URLCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B7F1BD15DFF00C49C64 /* URLCredential.swift */; };
-		EADE0BBE1BD15E0000C49C64 /* URLCredentialStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B801BD15DFF00C49C64 /* URLCredentialStorage.swift */; };
 		EADE0BBF1BD15E0000C49C64 /* NSURLError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B811BD15DFF00C49C64 /* NSURLError.swift */; };
-		EADE0BC01BD15E0000C49C64 /* URLProtectionSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B821BD15DFF00C49C64 /* URLProtectionSpace.swift */; };
-		EADE0BC11BD15E0000C49C64 /* URLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B831BD15DFF00C49C64 /* URLProtocol.swift */; };
-		EADE0BC21BD15E0000C49C64 /* NSURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B841BD15DFF00C49C64 /* NSURLRequest.swift */; };
-		EADE0BC31BD15E0000C49C64 /* URLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B851BD15DFF00C49C64 /* URLResponse.swift */; };
 		EADE0BC51BD15E0000C49C64 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B871BD15DFF00C49C64 /* UserDefaults.swift */; };
 		EADE0BC71BD15E0000C49C64 /* XMLDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B891BD15DFF00C49C64 /* XMLDocument.swift */; };
 		EADE0BC81BD15E0000C49C64 /* XMLDTD.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B8A1BD15DFF00C49C64 /* XMLDTD.swift */; };
@@ -494,6 +503,41 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		159870BF228F741000ADE509 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 15B80384228F376000B30FF6;
+			remoteInfo = SwiftFoundationNetworking;
+		};
+		15B80386228F376000B30FF6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5B7C8A6D1BEA7F8F00C5B690;
+			remoteInfo = CoreFoundation;
+		};
+		15B80445228F39B200B30FF6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5B5D885C1BBC938800234F36;
+			remoteInfo = SwiftFoundation;
+		};
+		15FF00CF22934C39004AD205 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 15FF0006229348F2004AD205;
+			remoteInfo = CFURLSessionInterface;
+		};
+		15FF00D122935004004AD205 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5B7C8A6D1BEA7F8F00C5B690;
+			remoteInfo = CoreFoundation;
+		};
 		AE2FC5941CFEFC70008F7981 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
@@ -525,6 +569,16 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		15B80390228F376000B30FF6 /* Framework Headers */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = Headers;
+			dstSubfolderSpec = 1;
+			files = (
+			);
+			name = "Framework Headers";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5BDC3F6F1BCC608700ED97BB /* Framework Headers */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -584,8 +638,12 @@
 		158BCCA92220A12600750239 /* TestDateIntervalFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDateIntervalFormatter.swift; sourceTree = "<group>"; };
 		158BCCAB2220A18F00750239 /* CFDateIntervalFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFDateIntervalFormatter.h; sourceTree = "<group>"; };
 		158BCCAC2220A18F00750239 /* CFDateIntervalFormatter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFDateIntervalFormatter.c; sourceTree = "<group>"; };
+		159870BB228F40BA00ADE509 /* NetworkingSpecific.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkingSpecific.swift; sourceTree = "<group>"; };
 		159884911DCC877700E3314C /* TestHTTPCookieStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHTTPCookieStorage.swift; sourceTree = "<group>"; };
+		15B8043A228F376000B30FF6 /* SwiftFoundationNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftFoundationNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		15F10CDB218909BF00D88114 /* TestNSCalendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNSCalendar.swift; sourceTree = "<group>"; };
+		15FF00CA229348F2004AD205 /* libCFURLSessionInterface.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCFURLSessionInterface.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		15FF00CD22934B49004AD205 /* module.map */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; name = module.map; path = CoreFoundation/URL.subproj/module.map; sourceTree = SOURCE_ROOT; };
 		22B9C1E01C165D7A00DECFF9 /* TestDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDate.swift; sourceTree = "<group>"; };
 		231503DA1D8AEE5D0061694D /* TestDecimal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDecimal.swift; sourceTree = "<group>"; };
 		294E3C1C1CC5E19300E4F44C /* TestNSAttributedString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSAttributedString.swift; sourceTree = "<group>"; };
@@ -1063,6 +1121,22 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		15B80387228F376000B30FF6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				15FF00CC22934AD7004AD205 /* libCFURLSessionInterface.a in Frameworks */,
+				15B80388228F376000B30FF6 /* libcurl.3.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		15FF0064229348F2004AD205 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5B5D88591BBC938800234F36 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1086,6 +1160,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				15B80444228F396600B30FF6 /* SwiftFoundationNetworking.framework in Frameworks */,
 				5BDC406C1BD6D89300ED97BB /* SwiftFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1094,6 +1169,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				159870BE228F73F800ADE509 /* SwiftFoundationNetworking.framework in Frameworks */,
 				9F0DD3571ECD783500F68030 /* SwiftFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1122,6 +1198,8 @@
 		5B1FD9C71D6D162D0080E83C /* Session */ = {
 			isa = PBXGroup;
 			children = (
+				15FF00CD22934B49004AD205 /* module.map */,
+				159870BB228F40BA00ADE509 /* NetworkingSpecific.swift */,
 				616068EB225C82C5004FCC54 /* ftp */,
 				614732781FC2DEB7005B5E61 /* libcurl */,
 				E4F889331E9CF04D008A70EB /* http */,
@@ -1166,6 +1244,8 @@
 				5B7C8A6E1BEA7F8F00C5B690 /* libCoreFoundation.a */,
 				EA66F66F1BF56CCB00136161 /* plutil */,
 				9F0DD33F1ECD734200F68030 /* xdgTestHelper.app */,
+				15B8043A228F376000B30FF6 /* SwiftFoundationNetworking.framework */,
+				15FF00CA229348F2004AD205 /* libCFURLSessionInterface.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2032,6 +2112,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		15B8038D228F376000B30FF6 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				15B8038E228F376000B30FF6 /* SwiftFoundation.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		15FF0065229348F2004AD205 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				15FF00CE22934B78004AD205 /* module.map in Headers */,
+				15FF00CB22934A3C004AD205 /* CFURLSessionInterface.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5B5D885A1BBC938800234F36 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -2120,7 +2217,6 @@
 				5B7C8AFF1BEA81AC00C5B690 /* CFURLPriv.h in Headers */,
 				5B7C8AEE1BEA81AC00C5B690 /* CFBundle_Internal.h in Headers */,
 				5B7C8AF01BEA81AC00C5B690 /* CFPlugIn_Factory.h in Headers */,
-				5B1FD9C61D6D161A0080E83C /* CFURLSessionInterface.h in Headers */,
 				5B7C8AE41BEA81AC00C5B690 /* CFPriv.h in Headers */,
 				5B7C8AD91BEA80FC00C5B690 /* CFMachPort.h in Headers */,
 				5B7C8AE71BEA81AC00C5B690 /* CFBasicHash.h in Headers */,
@@ -2147,6 +2243,46 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		15B80384228F376000B30FF6 /* SwiftFoundationNetworking */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 15B80437228F376000B30FF6 /* Build configuration list for PBXNativeTarget "SwiftFoundationNetworking" */;
+			buildPhases = (
+				15B80387228F376000B30FF6 /* Frameworks */,
+				15B8038D228F376000B30FF6 /* Headers */,
+				15B8038F228F376000B30FF6 /* Resources */,
+				15B80390228F376000B30FF6 /* Framework Headers */,
+				15B80391228F376000B30FF6 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				15FF00D022934C39004AD205 /* PBXTargetDependency */,
+				15B80446228F39B200B30FF6 /* PBXTargetDependency */,
+				15B80385228F376000B30FF6 /* PBXTargetDependency */,
+			);
+			name = SwiftFoundationNetworking;
+			productName = CoreFoundation;
+			productReference = 15B8043A228F376000B30FF6 /* SwiftFoundationNetworking.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		15FF0006229348F2004AD205 /* CFURLSessionInterface */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 15FF00C7229348F2004AD205 /* Build configuration list for PBXNativeTarget "CFURLSessionInterface" */;
+			buildPhases = (
+				15FF0065229348F2004AD205 /* Headers */,
+				15FF0007229348F2004AD205 /* Sources */,
+				15FF0064229348F2004AD205 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				15FF00D222935004004AD205 /* PBXTargetDependency */,
+			);
+			name = CFURLSessionInterface;
+			productName = CoreFoundation;
+			productReference = 15FF00CA229348F2004AD205 /* libCFURLSessionInterface.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 		5B5D885C1BBC938800234F36 /* SwiftFoundation */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5B5D88651BBC938800234F36 /* Build configuration list for PBXNativeTarget "SwiftFoundation" */;
@@ -2171,9 +2307,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5B7C8A711BEA7F8F00C5B690 /* Build configuration list for PBXNativeTarget "CoreFoundation" */;
 			buildPhases = (
+				5B7C8A6C1BEA7F8F00C5B690 /* Headers */,
 				5B7C8A6A1BEA7F8F00C5B690 /* Sources */,
 				5B7C8A6B1BEA7F8F00C5B690 /* Frameworks */,
-				5B7C8A6C1BEA7F8F00C5B690 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -2216,6 +2352,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				159870C0228F741000ADE509 /* PBXTargetDependency */,
 				B90FD23220C2FF840087EF44 /* PBXTargetDependency */,
 			);
 			name = xdgTestHelper;
@@ -2297,11 +2434,20 @@
 				5B7C8A6D1BEA7F8F00C5B690 /* CoreFoundation */,
 				EA66F66E1BF56CCB00136161 /* plutil */,
 				9F0DD33E1ECD734200F68030 /* xdgTestHelper */,
+				15B80384228F376000B30FF6 /* SwiftFoundationNetworking */,
+				15FF0006229348F2004AD205 /* CFURLSessionInterface */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		15B8038F228F376000B30FF6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5B5D885B1BBC938800234F36 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2365,6 +2511,50 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		15B80391228F376000B30FF6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				15B8043D228F38A600B30FF6 /* URLCredentialStorage.swift in Sources */,
+				15B8043E228F38C000B30FF6 /* URLRequest.swift in Sources */,
+				159870BC228F40BB00ADE509 /* NetworkingSpecific.swift in Sources */,
+				15B8039E228F376000B30FF6 /* URLProtectionSpace.swift in Sources */,
+				15B80441228F38E400B30FF6 /* MultiHandle.swift in Sources */,
+				15B803A5228F376000B30FF6 /* TaskRegistry.swift in Sources */,
+				15B803A7228F376000B30FF6 /* URLSessionDelegate.swift in Sources */,
+				15B803B4228F376000B30FF6 /* URLCredential.swift in Sources */,
+				15B803BD228F376000B30FF6 /* EasyHandle.swift in Sources */,
+				15B803CF228F376000B30FF6 /* URLAuthenticationChallenge.swift in Sources */,
+				15B803E6228F376000B30FF6 /* NSURLRequest.swift in Sources */,
+				15B803EE228F376000B30FF6 /* TransferState.swift in Sources */,
+				159870BD228F413300ADE509 /* Boxing.swift in Sources */,
+				15B8043C228F387400B30FF6 /* URLCache.swift in Sources */,
+				15B803F8228F376000B30FF6 /* BodySource.swift in Sources */,
+				15B803F9228F376000B30FF6 /* FTPURLProtocol.swift in Sources */,
+				15B80400228F376000B30FF6 /* libcurlHelpers.swift in Sources */,
+				15B8043F228F38C700B30FF6 /* URLResponse.swift in Sources */,
+				15B80406228F376000B30FF6 /* URLSession.swift in Sources */,
+				15B80413228F376000B30FF6 /* URLSessionTask.swift in Sources */,
+				15B80414228F376000B30FF6 /* URLProtocol.swift in Sources */,
+				15B8041C228F376000B30FF6 /* NativeProtocol.swift in Sources */,
+				15B80442228F38E400B30FF6 /* Configuration.swift in Sources */,
+				15B80443228F38E400B30FF6 /* Message.swift in Sources */,
+				15B8041F228F376000B30FF6 /* HTTPURLProtocol.swift in Sources */,
+				15B8042B228F376000B30FF6 /* HTTPMessage.swift in Sources */,
+				15B8043B228F385F00B30FF6 /* HTTPCookie.swift in Sources */,
+				15B80430228F376000B30FF6 /* HTTPCookieStorage.swift in Sources */,
+				15B80435228F376000B30FF6 /* URLSessionConfiguration.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		15FF0007229348F2004AD205 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				15FF004B229348F2004AD205 /* CFURLSessionInterface.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5B5D88581BBC938800234F36 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2372,7 +2562,6 @@
 				63DCE9D21EAA430100E9CB02 /* ISO8601DateFormatter.swift in Sources */,
 				5BC1B9A621F2759C00524D8C /* DataProtocol.swift in Sources */,
 				5BF7AE831BCD50CD008F214A /* NSArray.swift in Sources */,
-				B9974B971EDF4A22007F15B8 /* MultiHandle.swift in Sources */,
 				EADE0B991BD15DFF00C49C64 /* EnergyFormatter.swift in Sources */,
 				EADE0BBF1BD15E0000C49C64 /* NSURLError.swift in Sources */,
 				EADE0BAF1BD15E0000C49C64 /* PersonNameComponentsFormatter.swift in Sources */,
@@ -2381,16 +2570,13 @@
 				5B23AB8D1CE63228000DB898 /* URL.swift in Sources */,
 				EADE0BC91BD15E0000C49C64 /* XMLDTDNode.swift in Sources */,
 				EADE0BA91BD15E0000C49C64 /* NSNull.swift in Sources */,
-				EADE0BC01BD15E0000C49C64 /* URLProtectionSpace.swift in Sources */,
 				5BF7AEAC1BCD51F9008F214A /* NSEnumerator.swift in Sources */,
 				5BA9BEA81CF3E7E7009DBD6C /* CharacterSet.swift in Sources */,
 				5BC1B9AA21F275C400524D8C /* DispatchData+DataProtocol.swift in Sources */,
 				61E0117E1C1B55B9000037DD /* Timer.swift in Sources */,
 				EADE0BCD1BD15E0000C49C64 /* XMLParser.swift in Sources */,
 				5BDC3FD01BCF17E600ED97BB /* NSCFSet.swift in Sources */,
-				5B1FD9DE1D6D16580080E83C /* TaskRegistry.swift in Sources */,
 				EADE0B931BD15DFF00C49C64 /* NSComparisonPredicate.swift in Sources */,
-				5B1FD9DC1D6D16580080E83C /* URLSessionDelegate.swift in Sources */,
 				EADE0B921BD15DFF00C49C64 /* NSCache.swift in Sources */,
 				EADE0BAB1BD15E0000C49C64 /* Operation.swift in Sources */,
 				5BECBA3C1D1CAF8800B39B1F /* Unit.swift in Sources */,
@@ -2403,7 +2589,6 @@
 				5BF7AEBE1BCD51F9008F214A /* NSTimeZone.swift in Sources */,
 				EADE0B951BD15DFF00C49C64 /* DateComponentsFormatter.swift in Sources */,
 				5BC1B9AE21F275E900524D8C /* Pointers+DataProtocol.swift in Sources */,
-				EADE0BBD1BD15E0000C49C64 /* URLCredential.swift in Sources */,
 				EADE0BCA1BD15E0000C49C64 /* XMLElement.swift in Sources */,
 				EADE0BA21BD15E0000C49C64 /* JSONSerialization.swift in Sources */,
 				5BF7AEBA1BCD51F9008F214A /* NSString.swift in Sources */,
@@ -2412,13 +2597,11 @@
 				5BF7AEBB1BCD51F9008F214A /* NSSwiftRuntime.swift in Sources */,
 				5B5C5EF01CE61FA4001346BD /* Date.swift in Sources */,
 				EADE0B9B1BD15DFF00C49C64 /* FileHandle.swift in Sources */,
-				B9974B9C1EDF4A22007F15B8 /* EasyHandle.swift in Sources */,
 				EADE0BB11BD15E0000C49C64 /* NSPredicate.swift in Sources */,
 				5BF7AEC01BCD51F9008F214A /* NSUUID.swift in Sources */,
 				EADE0BCB1BD15E0000C49C64 /* XMLNode.swift in Sources */,
 				5BF7AEB01BCD51F9008F214A /* NSLocale.swift in Sources */,
 				EADE0BA31BD15E0000C49C64 /* NSKeyedArchiver.swift in Sources */,
-				6105D30F1FEBC5FC0022865A /* Message.swift in Sources */,
 				5BF7AEAD1BCD51F9008F214A /* NSError.swift in Sources */,
 				EADE0BB61BD15E0000C49C64 /* NSSortDescriptor.swift in Sources */,
 				5B23AB871CE62D17000DB898 /* Boxing.swift in Sources */,
@@ -2430,7 +2613,6 @@
 				91B668A32252B3C5001487A1 /* FileManager+POSIX.swift in Sources */,
 				5BD31D201D5CE8C400563814 /* Bridging.swift in Sources */,
 				3EDCE50C1EF04D8100C2EC04 /* Codable.swift in Sources */,
-				EADE0BBB1BD15E0000C49C64 /* URLAuthenticationChallenge.swift in Sources */,
 				EADE0BA11BD15DFF00C49C64 /* NSIndexSet.swift in Sources */,
 				5BF7AEA91BCD51F9008F214A /* NSDate.swift in Sources */,
 				5BF7AEC11BCD51F9008F214A /* NSValue.swift in Sources */,
@@ -2453,7 +2635,6 @@
 				EADE0BB51BD15E0000C49C64 /* Scanner.swift in Sources */,
 				EADE0BA01BD15DFF00C49C64 /* NSIndexPath.swift in Sources */,
 				5BF7AEB51BCD51F9008F214A /* NSPathUtilities.swift in Sources */,
-				EADE0BC21BD15E0000C49C64 /* NSURLRequest.swift in Sources */,
 				EADE0B9D1BD15DFF00C49C64 /* NSGeometry.swift in Sources */,
 				5BF7AEAA1BCD51F9008F214A /* DateFormatter.swift in Sources */,
 				5BECBA361D1CACC500B39B1F /* MeasurementFormatter.swift in Sources */,
@@ -2461,31 +2642,25 @@
 				EADE0BB31BD15E0000C49C64 /* NSRegularExpression.swift in Sources */,
 				EADE0BA41BD15E0000C49C64 /* LengthFormatter.swift in Sources */,
 				5BDC3FCA1BCF176100ED97BB /* NSCFArray.swift in Sources */,
-				B9974B961EDF4A22007F15B8 /* TransferState.swift in Sources */,
 				EADE0BB21BD15E0000C49C64 /* Progress.swift in Sources */,
 				EADE0B961BD15DFF00C49C64 /* DateIntervalFormatter.swift in Sources */,
 				5B5BFEAC1E6CC0C200AC8D9E /* NSCFBoolean.swift in Sources */,
 				6EB768281D18C12C00D4B719 /* UUID.swift in Sources */,
-				5B1FD9D41D6D16580080E83C /* Configuration.swift in Sources */,
 				5BF7AEA51BCD51F9008F214A /* NSCalendar.swift in Sources */,
 				EADE0BB81BD15E0000C49C64 /* Process.swift in Sources */,
 				5BF7AEB31BCD51F9008F214A /* NSObjCRuntime.swift in Sources */,
 				5BD31D3F1D5D19D600563814 /* Dictionary.swift in Sources */,
-				B9974B9B1EDF4A22007F15B8 /* BodySource.swift in Sources */,
-				616068ED225C82C5004FCC54 /* FTPURLProtocol.swift in Sources */,
 				5B94E8821C430DE70055C035 /* NSStringAPI.swift in Sources */,
 				5B0163BB1D024EB7003CCD96 /* DateComponents.swift in Sources */,
 				5BF7AEAB1BCD51F9008F214A /* NSDictionary.swift in Sources */,
 				EADE0BAA1BD15E0000C49C64 /* NumberFormatter.swift in Sources */,
 				D39A14011C2D6E0A00295652 /* NSKeyedUnarchiver.swift in Sources */,
 				5B4092101D1B304C0022B067 /* StringEncodings.swift in Sources */,
-				B9974B981EDF4A22007F15B8 /* libcurlHelpers.swift in Sources */,
 				5BECBA381D1CAD7000B39B1F /* Measurement.swift in Sources */,
 				5BF7AEAF1BCD51F9008F214A /* Host.swift in Sources */,
 				EADE0B4E1BD09E0800C49C64 /* AffineTransform.swift in Sources */,
 				EADE0BC71BD15E0000C49C64 /* XMLDocument.swift in Sources */,
 				5BDC3FCE1BCF17D300ED97BB /* NSCFDictionary.swift in Sources */,
-				5B1FD9DA1D6D16580080E83C /* URLSession.swift in Sources */,
 				EADE0BA81BD15E0000C49C64 /* NotificationQueue.swift in Sources */,
 				EA418C261D57257D005EAD0D /* NSKeyedArchiverHelpers.swift in Sources */,
 				EADE0B981BD15DFF00C49C64 /* NSDecimalNumber.swift in Sources */,
@@ -2498,8 +2673,6 @@
 				5BF7AEB41BCD51F9008F214A /* NSObject.swift in Sources */,
 				EADE0B521BD09F2F00C49C64 /* ByteCountFormatter.swift in Sources */,
 				5BA0106E1DF212B300E56898 /* NSPlatform.swift in Sources */,
-				5B1FD9DD1D6D16580080E83C /* URLSessionTask.swift in Sources */,
-				EADE0BC11BD15E0000C49C64 /* URLProtocol.swift in Sources */,
 				D3BCEB9E1C2EDED800295652 /* NSLog.swift in Sources */,
 				61E0117D1C1B5590000037DD /* RunLoop.swift in Sources */,
 				EADE0BC81BD15E0000C49C64 /* XMLDTD.swift in Sources */,
@@ -2507,32 +2680,22 @@
 				EADE0BA61BD15E0000C49C64 /* MassFormatter.swift in Sources */,
 				5BECBA3A1D1CAE9A00B39B1F /* NSMeasurement.swift in Sources */,
 				5BF7AEB21BCD51F9008F214A /* NSNumber.swift in Sources */,
-				61D2F9AF1FECFB3E0033306A /* NativeProtocol.swift in Sources */,
 				1513A8432044893F00539722 /* FileManager_XDG.swift in Sources */,
 				91B668A52252B3E7001487A1 /* FileManager+Win32.swift in Sources */,
-				B9974B991EDF4A22007F15B8 /* HTTPURLProtocol.swift in Sources */,
 				5BCD03821D3EE35C00E3FF9B /* TimeZone.swift in Sources */,
-				EADE0BBC1BD15E0000C49C64 /* URLCache.swift in Sources */,
 				5BC1B9AC21F275D500524D8C /* NSData+DataProtocol.swift in Sources */,
 				5B4092121D1B30B40022B067 /* ExtraStringAPIs.swift in Sources */,
 				5BC46D541D05D6D900005853 /* DateInterval.swift in Sources */,
 				EADE0BC51BD15E0000C49C64 /* UserDefaults.swift in Sources */,
 				5BF7AEB11BCD51F9008F214A /* NSLock.swift in Sources */,
 				5BF7AEB91BCD51F9008F214A /* NSSet.swift in Sources */,
-				EADE0B9E1BD15DFF00C49C64 /* HTTPCookie.swift in Sources */,
 				5BCCA8D91CE6697F0059B963 /* URLComponents.swift in Sources */,
 				5BDC3FCC1BCF177E00ED97BB /* NSCFString.swift in Sources */,
-				B9974B9A1EDF4A22007F15B8 /* HTTPMessage.swift in Sources */,
 				EADE0BAC1BD15E0000C49C64 /* NSOrderedSet.swift in Sources */,
 				5BC1B9A421F2757F00524D8C /* ContiguousBytes.swift in Sources */,
-				EADE0BC31BD15E0000C49C64 /* URLResponse.swift in Sources */,
 				EADE0B971BD15DFF00C49C64 /* Decimal.swift in Sources */,
-				EADE0B9F1BD15DFF00C49C64 /* HTTPCookieStorage.swift in Sources */,
 				5B78185B1D6CB5D2004A01F2 /* CGFloat.swift in Sources */,
-				EADE0BBE1BD15E0000C49C64 /* URLCredentialStorage.swift in Sources */,
-				5BA9BEA41CF380E8009DBD6C /* URLRequest.swift in Sources */,
 				5BF7AEB71BCD51F9008F214A /* PropertyListSerialization.swift in Sources */,
-				5B1FD9DB1D6D16580080E83C /* URLSessionConfiguration.swift in Sources */,
 				EADE0BAE1BD15E0000C49C64 /* NSPersonNameComponents.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2757,6 +2920,31 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		159870C0228F741000ADE509 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 15B80384228F376000B30FF6 /* SwiftFoundationNetworking */;
+			targetProxy = 159870BF228F741000ADE509 /* PBXContainerItemProxy */;
+		};
+		15B80385228F376000B30FF6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5B7C8A6D1BEA7F8F00C5B690 /* CoreFoundation */;
+			targetProxy = 15B80386228F376000B30FF6 /* PBXContainerItemProxy */;
+		};
+		15B80446228F39B200B30FF6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5B5D885C1BBC938800234F36 /* SwiftFoundation */;
+			targetProxy = 15B80445228F39B200B30FF6 /* PBXContainerItemProxy */;
+		};
+		15FF00D022934C39004AD205 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 15FF0006229348F2004AD205 /* CFURLSessionInterface */;
+			targetProxy = 15FF00CF22934C39004AD205 /* PBXContainerItemProxy */;
+		};
+		15FF00D222935004004AD205 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5B7C8A6D1BEA7F8F00C5B690 /* CoreFoundation */;
+			targetProxy = 15FF00D122935004004AD205 /* PBXContainerItemProxy */;
+		};
 		AE2FC5951CFEFC70008F7981 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 5B5D885C1BBC938800234F36 /* SwiftFoundation */;
@@ -2780,6 +2968,199 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		15B80438228F376000B30FF6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 150;
+				DYLIB_CURRENT_VERSION = 1303;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_PREFIX_HEADER = CoreFoundation/Base.subproj/CoreFoundation_Prefix.h;
+				HEADER_SEARCH_PATHS = (
+					"$(CONFIGURATION_BUILD_DIR)/usr/local/include",
+					/usr/include/libxml2,
+				);
+				INFOPLIST_FILE = "Foundation/URLSession/FoundationNetworking-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				OTHER_CFLAGS = (
+					"-isysroot",
+					"$(BUILT_PRODUCTS_DIR)",
+					"-DCF_BUILDING_CF",
+					"-DDEPLOYMENT_RUNTIME_SWIFT",
+					"-DDEPLOYMENT_ENABLE_LIBDISPATCH",
+					"-DHAVE_STRUCT_TIMESPEC",
+					"-I$(SRCROOT)/bootstrap/common/usr/include",
+					"-I$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/include",
+					"-I$(SRCROOT)/bootstrap/common/usr/local/include",
+					"-I$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/local/include",
+					"-g3",
+					"-fconstant-cfstrings",
+					"-fexceptions",
+					"-Wno-shorten-64-to-32",
+					"-Wno-deprecated-declarations",
+					"-Wno-unreachable-code",
+					"-Wno-conditional-uninitialized",
+					"-Wno-unused-variable",
+					"-Wno-int-conversion",
+					"-Wno-unused-function",
+				);
+				OTHER_LDFLAGS = "-twolevel_namespace";
+				OTHER_SWIFT_FLAGS = "-DDEPLOYMENT_ENABLE_LIBDISPATCH -DDEPLOYMENT_RUNTIME_SWIFT -swift-version 4.2";
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.Foundation.Networking;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "NS_BUILDING_FOUNDATION_NETWORKING $(inherited)";
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		15B80439228F376000B30FF6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 150;
+				DYLIB_CURRENT_VERSION = 1303;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_PREFIX_HEADER = CoreFoundation/Base.subproj/CoreFoundation_Prefix.h;
+				HEADER_SEARCH_PATHS = (
+					"$(CONFIGURATION_BUILD_DIR)/usr/local/include",
+					/usr/include/libxml2,
+				);
+				INFOPLIST_FILE = "Foundation/URLSession/FoundationNetworking-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				OTHER_CFLAGS = (
+					"-isysroot",
+					"$(BUILT_PRODUCTS_DIR)",
+					"-DCF_BUILDING_CF",
+					"-DDEPLOYMENT_RUNTIME_SWIFT",
+					"-DDEPLOYMENT_ENABLE_LIBDISPATCH",
+					"-DHAVE_STRUCT_TIMESPEC",
+					"-I$(SRCROOT)/bootstrap/common/usr/include",
+					"-I$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/include",
+					"-I$(SRCROOT)/bootstrap/common/usr/local/include",
+					"-I$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/local/include",
+					"-g3",
+					"-fconstant-cfstrings",
+					"-fexceptions",
+					"-Wno-shorten-64-to-32",
+					"-Wno-deprecated-declarations",
+					"-Wno-unreachable-code",
+					"-Wno-conditional-uninitialized",
+					"-Wno-unused-variable",
+					"-Wno-int-conversion",
+					"-Wno-unused-function",
+				);
+				OTHER_LDFLAGS = "-twolevel_namespace";
+				OTHER_SWIFT_FLAGS = "-DDEPLOYMENT_ENABLE_LIBDISPATCH -DDEPLOYMENT_RUNTIME_SWIFT -swift-version 4.2";
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.Foundation.Networking;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "NS_BUILDING_FOUNDATION_NETWORKING $(inherited)";
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		15FF00C8229348F2004AD205 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				EXECUTABLE_PREFIX = lib;
+				GCC_PREFIX_HEADER = CoreFoundation/Base.subproj/CoreFoundation_Prefix.h;
+				HEADER_SEARCH_PATHS = /usr/include/libxml2;
+				OTHER_CFLAGS = (
+					"-DCF_BUILDING_CF",
+					"-DDEPLOYMENT_RUNTIME_SWIFT",
+					"-DDEPLOYMENT_ENABLE_LIBDISPATCH",
+					"-I$(SRCROOT)/bootstrap/common/usr/include",
+					"-I$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/include",
+					"-I$(SRCROOT)/bootstrap/common/usr/local/include",
+					"-I$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/local/include",
+					"-g3",
+					"-fconstant-cfstrings",
+					"-fexceptions",
+					"-Wno-shorten-64-to-32",
+					"-Wno-deprecated-declarations",
+					"-Wno-unreachable-code",
+					"-Wno-conditional-uninitialized",
+					"-Wno-unused-variable",
+					"-Wno-int-conversion",
+					"-Wno-unused-function",
+					"-DHAVE_STRUCT_TIMESPEC",
+					"-DCF_CHARACTERSET_UNICODE_DATA_L=\\\\\"CoreFoundation/CharacterSets/CFUnicodeData-L.mapping\\\\\"",
+					"-DCF_CHARACTERSET_UNICODE_DATA_B=\\\\\"CoreFoundation/CharacterSets/CFUnicodeData-B.mapping\\\\\"",
+					"-DCF_CHARACTERSET_UNICHAR_DB=\\\\\"CoreFoundation/CharacterSets/CFUniCharPropertyDatabase.data\\\\\"",
+					"-DCF_CHARACTERSET_BITMAP=\\\\\"CoreFoundation/CharacterSets/CFCharacterSetBitmaps.bitmap\\\\\"",
+					"-Wno-format-security",
+				);
+				PRIVATE_HEADERS_FOLDER_PATH = "/usr/local/include/$(PRODUCT_NAME)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "/usr/local/include/$(PRODUCT_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		15FF00C9229348F2004AD205 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				EXECUTABLE_PREFIX = lib;
+				GCC_PREFIX_HEADER = CoreFoundation/Base.subproj/CoreFoundation_Prefix.h;
+				HEADER_SEARCH_PATHS = /usr/include/libxml2;
+				OTHER_CFLAGS = (
+					"-DCF_BUILDING_CF",
+					"-DDEPLOYMENT_RUNTIME_SWIFT",
+					"-DDEPLOYMENT_ENABLE_LIBDISPATCH",
+					"-I$(SRCROOT)/bootstrap/common/usr/include",
+					"-I$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/include",
+					"-I$(SRCROOT)/bootstrap/common/usr/local/include",
+					"-I$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/local/include",
+					"-g3",
+					"-fconstant-cfstrings",
+					"-fexceptions",
+					"-Wno-shorten-64-to-32",
+					"-Wno-deprecated-declarations",
+					"-Wno-unreachable-code",
+					"-Wno-conditional-uninitialized",
+					"-Wno-unused-variable",
+					"-Wno-int-conversion",
+					"-Wno-unused-function",
+					"-DHAVE_STRUCT_TIMESPEC",
+					"-DCF_CHARACTERSET_UNICODE_DATA_L=\\\\\"CoreFoundation/CharacterSets/CFUnicodeData-L.mapping\\\\\"",
+					"-DCF_CHARACTERSET_UNICODE_DATA_B=\\\\\"CoreFoundation/CharacterSets/CFUnicodeData-B.mapping\\\\\"",
+					"-DCF_CHARACTERSET_UNICHAR_DB=\\\\\"CoreFoundation/CharacterSets/CFUniCharPropertyDatabase.data\\\\\"",
+					"-DCF_CHARACTERSET_BITMAP=\\\\\"CoreFoundation/CharacterSets/CFCharacterSetBitmaps.bitmap\\\\\"",
+					"-Wno-format-security",
+				);
+				PRIVATE_HEADERS_FOLDER_PATH = "/usr/local/include/$(PRODUCT_NAME)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "/usr/local/include/$(PRODUCT_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		5B5D88631BBC938800234F36 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3187,6 +3568,10 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(CONFIGURATION_BUILD_DIR)/usr/local/include",
+					/usr/include/libxml2,
+				);
 				INFOPLIST_FILE = TestFoundation/xdgTestHelper/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../../.. @loader_path/../../.. @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
@@ -3209,6 +3594,10 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(CONFIGURATION_BUILD_DIR)/usr/local/include",
+					/usr/include/libxml2,
+				);
 				INFOPLIST_FILE = TestFoundation/xdgTestHelper/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../../.. @loader_path/../../.. @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
@@ -3244,6 +3633,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		15B80437228F376000B30FF6 /* Build configuration list for PBXNativeTarget "SwiftFoundationNetworking" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				15B80438228F376000B30FF6 /* Debug */,
+				15B80439228F376000B30FF6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		15FF00C7229348F2004AD205 /* Build configuration list for PBXNativeTarget "CFURLSessionInterface" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				15FF00C8229348F2004AD205 /* Debug */,
+				15FF00C9229348F2004AD205 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		5B5D88571BBC938800234F36 /* Build configuration list for PBXProject "Foundation" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Foundation.xcodeproj/xcshareddata/xcschemes/CFURLSessionInterface.xcscheme
+++ b/Foundation.xcodeproj/xcshareddata/xcschemes/CFURLSessionInterface.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "15FF0006229348F2004AD205"
+               BuildableName = "libCFURLSessionInterface.a"
+               BlueprintName = "CFURLSessionInterface"
+               ReferencedContainer = "container:Foundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "15FF0006229348F2004AD205"
+            BuildableName = "libCFURLSessionInterface.a"
+            BlueprintName = "CFURLSessionInterface"
+            ReferencedContainer = "container:Foundation.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "15FF0006229348F2004AD205"
+            BuildableName = "libCFURLSessionInterface.a"
+            BlueprintName = "CFURLSessionInterface"
+            ReferencedContainer = "container:Foundation.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Foundation.xcodeproj/xcshareddata/xcschemes/SwiftFoundationNetworking.xcscheme
+++ b/Foundation.xcodeproj/xcshareddata/xcschemes/SwiftFoundationNetworking.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "15B80384228F376000B30FF6"
+               BuildableName = "SwiftFoundationNetworking.framework"
+               BlueprintName = "SwiftFoundationNetworking"
+               ReferencedContainer = "container:Foundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "15B80384228F376000B30FF6"
+            BuildableName = "SwiftFoundationNetworking.framework"
+            BlueprintName = "SwiftFoundationNetworking"
+            ReferencedContainer = "container:Foundation.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "15B80384228F376000B30FF6"
+            BuildableName = "SwiftFoundationNetworking.framework"
+            BlueprintName = "SwiftFoundationNetworking"
+            ReferencedContainer = "container:Foundation.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Foundation.xcodeproj/xcshareddata/xcschemes/TestFoundation.xcscheme
+++ b/Foundation.xcodeproj/xcshareddata/xcschemes/TestFoundation.xcscheme
@@ -28,6 +28,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "15B80384228F376000B30FF6"
+               BuildableName = "SwiftFoundationNetworking.framework"
+               BlueprintName = "SwiftFoundationNetworking"
+               ReferencedContainer = "container:Foundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "5B5D86DA1BBC74AD00234F36"
                BuildableName = "SwiftXCTest.framework"
                BlueprintName = "SwiftXCTest"

--- a/Foundation/Boxing.swift
+++ b/Foundation/Boxing.swift
@@ -10,6 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if NS_BUILDING_FOUNDATION_NETWORKING
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
+#endif
+
 /// A class type which acts as a handle (pointer-to-pointer) to a Foundation reference type which has only a mutable class (e.g., NSURLComponents).
 ///
 /// Note: This assumes that the result of calling copy() is mutable. The documentation says that classes which do not have a mutable/immutable distinction should just adopt NSCopying instead of NSMutableCopying.

--- a/Foundation/HTTPCookie.swift
+++ b/Foundation/HTTPCookie.swift
@@ -7,6 +7,12 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
+
 public struct HTTPCookiePropertyKey : RawRepresentable, Equatable, Hashable {
     public private(set) var rawValue: String
     

--- a/Foundation/HTTPCookieStorage.swift
+++ b/Foundation/HTTPCookieStorage.swift
@@ -6,7 +6,13 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
-import Dispatch
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
+
 import CoreFoundation
 
 /*!
@@ -74,7 +80,7 @@ open class HTTPCookieStorage: NSObject {
             if let range = bundleName.range(of: ".", options: .backwards, range: nil, locale: nil) {
                 bundleName = String(bundleName[..<range.lowerBound])
             }
-            let cookieFolderPath = _CFXDGCreateDataHomePath()._swiftObject + "/" + bundleName
+            let cookieFolderPath = (((_CFXDGCreateDataHomePath() as! AnyObject) as! NSString) as String) + "/" + bundleName
             cookieFilePath = filePath(path: cookieFolderPath, fileName: "/.cookies." + cookieStorageName, bundleName: bundleName)
             loadPersistedCookies()
         }
@@ -224,7 +230,7 @@ open class HTTPCookieStorage: NSObject {
             persistDictionary[key] = cookie.persistableDictionary()
         }
 
-        let nsdict = __SwiftValue.store(persistDictionary) as! NSDictionary
+        let nsdict = persistDictionary as NSDictionary
         _ = nsdict.write(toFile: cookieFilePath, atomically: true)
     }
 

--- a/Foundation/NSObjCRuntime.swift
+++ b/Foundation/NSObjCRuntime.swift
@@ -431,3 +431,77 @@ public func NSClassFromString(_ aClassName: String) -> AnyClass? {
     
     return _typeByName(aClassNameWithPrefix) as? AnyClass
 }
+
+// The following types have been moved to FoundationNetworking. They exist here only to allow appropriate diagnostics to surface in the compiler.
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+    renamed: "FoundationNetworking.CachedURLResponse")
+public typealias CachedURLResponse = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+renamed: "FoundationNetworking.HTTPCookie")
+public typealias HTTPCookie = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+renamed: "FoundationNetworking.HTTPCookieStorage")
+public typealias HTTPCookieStorage = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+renamed: "FoundationNetworking.HTTPURLResponse")
+public typealias HTTPURLResponse = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+renamed: "FoundationNetworking.URLResponse")
+public typealias URLResponse = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+renamed: "FoundationNetworking.URLSession")
+public typealias URLSession = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+renamed: "FoundationNetworking.URLSessionConfiguration")
+public typealias URLSessionConfiguration = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+renamed: "FoundationNetworking.URLSessionDataTask")
+public typealias URLSessionDataTask = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+renamed: "FoundationNetworking.URLSessionDownloadTask")
+public typealias URLSessionDownloadTask = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+renamed: "FoundationNetworking.URLSessionStreamTask")
+public typealias URLSessionStreamTask = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+renamed: "FoundationNetworking.URLSessionTask")
+public typealias URLSessionTask = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+renamed: "FoundationNetworking.URLSessionUploadTask")
+public typealias URLSessionUploadTask = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+renamed: "FoundationNetworking.URLAuthenticationChallenge")
+public typealias URLAuthenticationChallenge = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+renamed: "FoundationNetworking.URLCache")
+public typealias URLCache = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+renamed: "FoundationNetworking.URLCredential")
+public typealias URLCredential = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+renamed: "FoundationNetworking.URLCredentialStorage")
+public typealias URLCredentialStorage = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+renamed: "FoundationNetworking.URLProtectionSpace")
+public typealias URLProtectionSpace = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
+renamed: "FoundationNetworking.URLProtocol")
+public typealias URLProtocol = AnyObject

--- a/Foundation/NSObjCRuntime.swift
+++ b/Foundation/NSObjCRuntime.swift
@@ -434,74 +434,56 @@ public func NSClassFromString(_ aClassName: String) -> AnyClass? {
 
 // The following types have been moved to FoundationNetworking. They exist here only to allow appropriate diagnostics to surface in the compiler.
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-    renamed: "FoundationNetworking.CachedURLResponse")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias CachedURLResponse = AnyObject
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-renamed: "FoundationNetworking.HTTPCookie")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias HTTPCookie = AnyObject
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-renamed: "FoundationNetworking.HTTPCookieStorage")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias HTTPCookieStorage = AnyObject
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-renamed: "FoundationNetworking.HTTPURLResponse")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias HTTPURLResponse = AnyObject
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-renamed: "FoundationNetworking.URLResponse")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias URLResponse = AnyObject
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-renamed: "FoundationNetworking.URLSession")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias URLSession = AnyObject
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-renamed: "FoundationNetworking.URLSessionConfiguration")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias URLSessionConfiguration = AnyObject
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-renamed: "FoundationNetworking.URLSessionDataTask")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias URLSessionDataTask = AnyObject
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-renamed: "FoundationNetworking.URLSessionDownloadTask")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias URLSessionDownloadTask = AnyObject
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-renamed: "FoundationNetworking.URLSessionStreamTask")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias URLSessionStreamTask = AnyObject
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-renamed: "FoundationNetworking.URLSessionTask")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias URLSessionTask = AnyObject
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-renamed: "FoundationNetworking.URLSessionUploadTask")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias URLSessionUploadTask = AnyObject
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-renamed: "FoundationNetworking.URLAuthenticationChallenge")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias URLAuthenticationChallenge = AnyObject
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-renamed: "FoundationNetworking.URLCache")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias URLCache = AnyObject
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-renamed: "FoundationNetworking.URLCredential")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias URLCredential = AnyObject
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-renamed: "FoundationNetworking.URLCredentialStorage")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias URLCredentialStorage = AnyObject
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-renamed: "FoundationNetworking.URLProtectionSpace")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias URLProtectionSpace = AnyObject
 
-@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.",
-renamed: "FoundationNetworking.URLProtocol")
+@available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias URLProtocol = AnyObject

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -1302,7 +1302,7 @@ extension NSString {
     }
 
     public convenience init(contentsOf url: URL, usedEncoding enc: UnsafeMutablePointer<UInt>?) throws {
-        let (readResult, urlResponse) = try NSData.contentsOf(url: url)
+        let (readResult, textEncodingNameMaybe) = try NSData.contentsOf(url: url)
 
         let encoding: UInt
         let offset: Int
@@ -1325,7 +1325,7 @@ extension NSString {
             encoding = String.Encoding.utf32BigEndian.rawValue
             offset = 4
         }
-        else if let charSet = urlResponse?.textEncodingName, let textEncoding = String.Encoding(charSet: charSet) {
+        else if let charSet = textEncodingNameMaybe, let textEncoding = String.Encoding(charSet: charSet) {
             encoding = textEncoding.rawValue
             offset = 0
         } else {

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -394,3 +394,27 @@ extension Array {
 #else
     internal typealias _DarwinCompatibleBoolean = Bool
 #endif
+
+public protocol _NSNonfileURLContentLoading: AnyObject {
+    init()
+    func contentsOf(url: URL) throws -> (result: NSData, textEncodingNameIfAvailable: String?)
+}
+
+
+internal enum _NSNonfileURLContentLoader {
+    static private(set) var external: _NSNonfileURLContentLoading?
+    
+    static var current: _NSNonfileURLContentLoading {
+        if let external = _NSNonfileURLContentLoader.external {
+            return external
+        } else {
+            guard let type = _typeByName(_SwiftFoundationNetworkingModuleName + "._NSNonfileURLContentLoader") as? _NSNonfileURLContentLoading.Type else {
+                fatalError("You must link or load module \(_SwiftFoundationNetworkingModuleName) to load non-file: URL content using String(contentsOf:…), Data(contentsOf:…), etc.")
+            }
+            
+            let result = type.init()
+            _NSNonfileURLContentLoader.external = result
+            return result
+        }
+    }
+}

--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -7,6 +7,11 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 
 // -----------------------------------------------------------------------------
 ///
@@ -170,7 +175,7 @@ open class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopying 
         super.init()
         
         if let encodedURL = aDecoder.decodeObject(forKey: "NS.url") as? NSURL {
-            self.url = encodedURL._swiftObject
+            self.url = encodedURL as URL
         }
         
         if let encodedHeaders = aDecoder.decodeObject(forKey: "NS._allHTTPHeaderFields") as? NSDictionary {
@@ -178,18 +183,18 @@ open class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopying 
                 var result = result
                 if let key = item.key as? NSString,
                     let value = item.value as? NSString {
-                    result[key._swiftObject] = value._swiftObject
+                    result[key as String] = value as String
                 }
                 return result
             }
         }
         
         if let encodedDocumentURL = aDecoder.decodeObject(forKey: "NS.mainDocumentURL") as? NSURL {
-            self.mainDocumentURL = encodedDocumentURL._swiftObject
+            self.mainDocumentURL = encodedDocumentURL as URL
         }
         
         if let encodedMethod = aDecoder.decodeObject(forKey: "NS.httpMethod") as? NSString {
-            self.httpMethod = encodedMethod._swiftObject
+            self.httpMethod = encodedMethod as String
         }
         
         let encodedCachePolicy = aDecoder.decodeObject(forKey: "NS._cachePolicy") as! NSNumber
@@ -300,7 +305,7 @@ open class NSURLRequest : NSObject, NSSecureCoding, NSCopying, NSMutableCopying 
             return "GET"
         }
 
-        let nsMethod = NSString(raw)
+        let nsMethod = NSString(string: raw)
 
         for method in ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT"] {
             if nsMethod.caseInsensitiveCompare(method) == .orderedSame {

--- a/Foundation/Stream.swift
+++ b/Foundation/Stream.swift
@@ -220,6 +220,18 @@ open class OutputStream : Stream {
     }
 }
 
+public struct _InputStreamSPIForFoundationNetworkingUseOnly {
+    var inputStream: InputStream
+    
+    public init(_ inputStream: InputStream) {
+        self.inputStream = inputStream
+    }
+    
+    public func seek(to position: UInt64) throws {
+        try inputStream.seek(to: position)
+    }
+}
+
 extension InputStream {
     func seek(to position: UInt64) throws {
         guard position > 0 else {

--- a/Foundation/URLAuthenticationChallenge.swift
+++ b/Foundation/URLAuthenticationChallenge.swift
@@ -7,6 +7,12 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
+
 public protocol URLAuthenticationChallengeSender : NSObjectProtocol {
     
     

--- a/Foundation/URLCache.swift
+++ b/Foundation/URLCache.swift
@@ -7,6 +7,11 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 
 /*!
     @enum URLCache.StoragePolicy

--- a/Foundation/URLCredential.swift
+++ b/Foundation/URLCredential.swift
@@ -7,6 +7,11 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 
 /*!
     @enum URLCredential.Persistence

--- a/Foundation/URLCredentialStorage.swift
+++ b/Foundation/URLCredentialStorage.swift
@@ -7,6 +7,11 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 
 /*!
     @class URLCredential.Storage

--- a/Foundation/URLProtectionSpace.swift
+++ b/Foundation/URLProtectionSpace.swift
@@ -7,6 +7,11 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 
 /*!
    @const NSURLProtectionSpaceHTTP

--- a/Foundation/URLProtocol.swift
+++ b/Foundation/URLProtocol.swift
@@ -7,8 +7,11 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-import CoreFoundation
-import Dispatch
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 
 /*!
     @header URLProtocol.h

--- a/Foundation/URLRequest.swift
+++ b/Foundation/URLRequest.swift
@@ -10,6 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
+
 public struct URLRequest : ReferenceConvertible, Equatable, Hashable {
     public typealias ReferenceType = NSURLRequest
     public typealias CachePolicy = NSURLRequest.CachePolicy

--- a/Foundation/URLResponse.swift
+++ b/Foundation/URLResponse.swift
@@ -7,6 +7,11 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 
 /// An `URLResponse` object represents a URL load response in a
 /// manner independent of protocol and URL scheme.
@@ -28,21 +33,21 @@ open class URLResponse : NSObject, NSSecureCoding, NSCopying {
         }
         
         if let encodedUrl = aDecoder.decodeObject(forKey: "NS.url") as? NSURL {
-            self.url = encodedUrl._swiftObject
+            self.url = encodedUrl as URL
         }
         
         if let encodedMimeType = aDecoder.decodeObject(forKey: "NS.mimeType") as? NSString {
-            self.mimeType = encodedMimeType._swiftObject
+            self.mimeType = encodedMimeType as String
         }
         
         self.expectedContentLength = aDecoder.decodeInt64(forKey: "NS.expectedContentLength")
         
         if let encodedEncodingName = aDecoder.decodeObject(forKey: "NS.textEncodingName") as? NSString {
-            self.textEncodingName = encodedEncodingName._swiftObject
+            self.textEncodingName = encodedEncodingName as String
         }
         
         if let encodedFilename = aDecoder.decodeObject(forKey: "NS.suggestedFilename") as? NSString {
-            self.suggestedFilename = encodedFilename._swiftObject
+            self.suggestedFilename = encodedFilename as String
         }
     }
     
@@ -170,7 +175,7 @@ open class HTTPURLResponse : URLResponse {
         self.statusCode = aDecoder.decodeInteger(forKey: "NS.statusCode")
         
         if let encodedHeaders = aDecoder.decodeObject(forKey: "NS.allHeaderFields") as? NSDictionary {
-            self.allHeaderFields = encodedHeaders._swiftObject
+            self.allHeaderFields = encodedHeaders as! [AnyHashable: Any]
         } else {
             self.allHeaderFields = [:]
         }
@@ -322,7 +327,7 @@ private func getSuggestedFilename(fromHeaderFields headerFields: [String : Strin
         else { return nil }
     for part in field.parameters where part.attribute == "filename" {
         if let path = part.value {
-            return _pathComponents(path)?.map{ $0 == "/" ? "" : $0}.joined(separator: "_")
+            return (path as? NSString)?.pathComponents.map{ $0 == "/" ? "" : $0}.joined(separator: "_")
         } else {
             return nil
         }

--- a/Foundation/URLSession/BodySource.swift
+++ b/Foundation/URLSession/BodySource.swift
@@ -16,7 +16,14 @@
 ///
 // -----------------------------------------------------------------------------
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
+
 import CoreFoundation
+import CFURLSessionInterface
 import Dispatch
 
 

--- a/Foundation/URLSession/Configuration.swift
+++ b/Foundation/URLSession/Configuration.swift
@@ -16,6 +16,11 @@
 ///
 // -----------------------------------------------------------------------------
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 
 internal extension URLSession {
     /// This is an immutable / `struct` version of `URLSessionConfiguration`.

--- a/Foundation/URLSession/FoundationNetworking-Info.plist
+++ b/Foundation/URLSession/FoundationNetworking-Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>SwiftFoundation</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.Foundation</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>SwiftFoundation</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Foundation/URLSession/Message.swift
+++ b/Foundation/URLSession/Message.swift
@@ -16,6 +16,12 @@
 ///
 // -----------------------------------------------------------------------------
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
+
 extension _NativeProtocol {
     /// A native protocol like FTP or HTTP header being parsed.
     ///

--- a/Foundation/URLSession/NativeProtocol.swift
+++ b/Foundation/URLSession/NativeProtocol.swift
@@ -17,6 +17,12 @@
 ///
 // -----------------------------------------------------------------------------
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
+
 import CoreFoundation
 import Dispatch
 
@@ -280,7 +286,7 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
             case .transferInProgress(let currentTransferState):
                 switch currentTransferState.requestBodySource {
                 case is _BodyStreamSource:
-                    try inputStream.seek(to: position)
+                    try _InputStreamSPIForFoundationNetworkingUseOnly(inputStream).seek(to: position)
                     let drain = self.createTransferBodyDataDrain()
                     let source = _BodyStreamSource(inputStream: inputStream)
                     let transferState = _TransferState(url: url, bodyDataDrain: drain, bodySource: source)

--- a/Foundation/URLSession/NetworkingSpecific.swift
+++ b/Foundation/URLSession/NetworkingSpecific.swift
@@ -1,0 +1,72 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
+
+internal func NSUnimplemented(_ fn: String = #function, file: StaticString = #file, line: UInt = #line) -> Never {
+    #if os(Android)
+    NSLog("\(fn) is not yet implemented. \(file):\(line)")
+    #endif
+    fatalError("\(fn) is not yet implemented", file: file, line: line)
+}
+
+internal func NSUnsupported(_ fn: String = #function, file: StaticString = #file, line: UInt = #line) -> Never {
+    #if os(Android)
+    NSLog("\(fn) is not supported. \(file):\(line)")
+    #endif
+    fatalError("\(fn) is not supported", file: file, line: line)
+}
+
+internal func NSRequiresConcreteImplementation(_ fn: String = #function, file: StaticString = #file, line: UInt = #line) -> Never {
+    #if os(Android)
+    NSLog("\(fn) must be overridden. \(file):\(line)")
+    #endif
+    fatalError("\(fn) must be overridden", file: file, line: line)
+}
+
+@usableFromInline
+class _NSNonfileURLContentLoader: _NSNonfileURLContentLoading {
+    @usableFromInline
+    required init() {}
+    
+    @usableFromInline
+    func contentsOf(url: URL) throws -> (result: NSData, textEncodingNameIfAvailable: String?) {
+        var urlResponse: URLResponse?
+        let session = URLSession(configuration: URLSessionConfiguration.default)
+        let cond = NSCondition()
+        cond.lock()
+        
+        var resError: Error?
+        var resData: Data?
+        var taskFinished = false
+        let task = session.dataTask(with: url, completionHandler: { data, response, error in
+            cond.lock()
+            resData = data
+            urlResponse = response
+            resError = error
+            taskFinished = true
+            cond.signal()
+            cond.unlock()
+        })
+        
+        task.resume()
+        while taskFinished == false {
+            cond.wait()
+        }
+        cond.unlock()
+        
+        guard let data = resData else {
+            throw resError!
+        }
+        return (NSData(bytes: UnsafeMutableRawPointer(mutating: (data as NSData).bytes), length: data.count), urlResponse?.textEncodingName)
+    }
+}

--- a/Foundation/URLSession/TaskRegistry.swift
+++ b/Foundation/URLSession/TaskRegistry.swift
@@ -16,6 +16,12 @@
 ///
 // -----------------------------------------------------------------------------
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
+
 import CoreFoundation
 import Dispatch
 

--- a/Foundation/URLSession/TransferState.swift
+++ b/Foundation/URLSession/TransferState.swift
@@ -17,6 +17,11 @@
 ///
 // -----------------------------------------------------------------------------
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 import CoreFoundation
 
 

--- a/Foundation/URLSession/URLSession.swift
+++ b/Foundation/URLSession/URLSession.swift
@@ -162,9 +162,12 @@
 // -----------------------------------------------------------------------------
 
 
-
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 import CoreFoundation
-import Dispatch
 
 extension URLSession {
     public enum DelayedRequestDisposition {

--- a/Foundation/URLSession/URLSessionConfiguration.swift
+++ b/Foundation/URLSession/URLSessionConfiguration.swift
@@ -15,7 +15,11 @@
 ///
 // -----------------------------------------------------------------------------
 
-
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 
 /// Configuration options for an URLSession.
 ///

--- a/Foundation/URLSession/URLSessionDelegate.swift
+++ b/Foundation/URLSession/URLSessionDelegate.swift
@@ -15,7 +15,11 @@
 ///
 // -----------------------------------------------------------------------------
 
-
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 
 extension URLSession {
     /*

--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -15,11 +15,12 @@
 ///
 // -----------------------------------------------------------------------------
 
-
-
-
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 import CoreFoundation
-import Dispatch
 
 /// A cancelable object that refers to the lifetime
 /// of processing a given request.

--- a/Foundation/URLSession/ftp/FTPURLProtocol.swift
+++ b/Foundation/URLSession/ftp/FTPURLProtocol.swift
@@ -7,6 +7,12 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
+
 import CoreFoundation
 import Dispatch
 

--- a/Foundation/URLSession/http/HTTPMessage.swift
+++ b/Foundation/URLSession/http/HTTPMessage.swift
@@ -17,6 +17,11 @@
 ///
 // -----------------------------------------------------------------------------
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 import CoreFoundation
 
 internal extension _HTTPURLProtocol._ResponseHeaderLines {

--- a/Foundation/URLSession/http/HTTPURLProtocol.swift
+++ b/Foundation/URLSession/http/HTTPURLProtocol.swift
@@ -7,7 +7,14 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
+
 import CoreFoundation
+import CFURLSessionInterface
 import Dispatch
 
 internal class _HTTPURLProtocol: _NativeProtocol {

--- a/Foundation/URLSession/libcurl/EasyHandle.swift
+++ b/Foundation/URLSession/libcurl/EasyHandle.swift
@@ -17,7 +17,14 @@
 ///
 // -----------------------------------------------------------------------------
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
+
 import CoreFoundation
+import CFURLSessionInterface
 import Dispatch
 
 

--- a/Foundation/URLSession/libcurl/libcurlHelpers.swift
+++ b/Foundation/URLSession/libcurl/libcurlHelpers.swift
@@ -18,7 +18,7 @@
 
 
 import CoreFoundation
-
+import CFURLSessionInterface
 
 //TODO: Move things in this file?
 

--- a/TestFoundation/HTTPServer.swift
+++ b/TestFoundation/HTTPServer.swift
@@ -413,8 +413,13 @@ struct _HTTPRequest {
     var messageBody: String?
     let headers: [String]
 
-    public init(request: String) {
+    enum Error: Swift.Error {
+        case headerEndNotFound
+    }
+    
+    public init(request: String) throws {
         let headerEnd = (request as NSString).range(of: _HTTPUtils.CRLF2)
+        guard headerEnd.location != NSNotFound else { throw Error.headerEndNotFound }
         let header = (request as NSString).substring(to: headerEnd.location)
         headers = header.components(separatedBy: _HTTPUtils.CRLF)
         let action = headers[0]

--- a/TestFoundation/TestImports.swift
+++ b/TestFoundation/TestImports.swift
@@ -9,10 +9,12 @@
 
 // Centralized conditional imports for all test sources
 
-#if !DEPLOYMENT_RUNTIME_OBJC && canImport(SwiftFoundation) && canImport(SwiftXCTest)
+#if !DEPLOYMENT_RUNTIME_OBJC && canImport(SwiftFoundation) && canImport(SwiftFoundationNetworking) && canImport(SwiftXCTest) 
 @_exported import SwiftFoundation
+@_exported import SwiftFoundationNetworking
 @_exported import SwiftXCTest
 #else
 @_exported import Foundation
+@_exported import FoundationNetworking
 @_exported import XCTest
 #endif

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -7,10 +7,12 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if canImport(SwiftFoundation) && !DEPLOYMENT_RUNTIME_OBJC
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import SwiftFoundation
+import SwiftFoundationNetworking
 #else
 import Foundation
+import FoundationNetworking
 #endif
 #if os(Windows)
 import WinSDK


### PR DESCRIPTION
This patch introduces a new module, `FoundationNetworking`, which will include all classes related to loading from remote URLs. Several types have been moved to that module, which downstream clients must import explicitly, e.g.:

```
#if canImport(FoundationNetworking)
import FoundationNetworking
#endif
```

 - Split the `CFURLSessionInterface` files out of Core Foundation and into their own library, `libCFURLSessionInterface`. This is produced by the CF CMakeLists.txt file on non-Darwin platforms. Just like CF, we strongly discourage linking to this library directly.

 - Split `URLSession` and related classes (except for `URL` and `URLComponents`) into a new `FoundationNetworking` module (`SwiftFoundationNetworking` on Darwin). Note:

  1. The features in Boxing.swift are needed to both modules. This file is compiled separately in both modules, and relies on a `NS_BUILDING_FOUNDATION_NETWORKING` compilation condition to compile correctly in `FoundationNetworking`

  2. SPI that was used in `InputStream` is now available through a public struct named `_InputStreamSPIForFoundationNetworkingUseOnly` for FoundationNetworking to use. This isn’t API, much like `_ObjectiveCBridgeable`.


Also:

 - Change some details to make tests fail without a fatal error for issues that aren’t programmer errors.

 - In some circumstances, CURL can set an immediate timeout reentrantly if the timeout callback invokes CURL hooks. Always dispatch the CURL hook call asynchronously from a request for an immediate timeout. 

 - Types that have a `contentsOf url: URL` initializer can still accept non-file: URLs if FoundationNetworking is available in the address space of the current process (if it has been linked or dynamically loaded, for example). Loading non-file: URLs without this will result in a fatal error. Loading file: URLs will always succeed even in the absence of `FoundationNetworking`.