### PR TITLE
Parity: Networking: URLUploadTask and URLDownloadTask

### DIFF
--- a/Foundation/URLSession/NativeProtocol.swift
+++ b/Foundation/URLSession/NativeProtocol.swift
@@ -333,12 +333,9 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
         }
     }
 
-    func createTransferState(url: URL, workQueue: DispatchQueue) -> _TransferState {
+    func createTransferState(url: URL, body: _Body, workQueue: DispatchQueue) -> _TransferState {
         let drain = createTransferBodyDataDrain()
-        guard let t = task else {
-            fatalError("Cannot create transfer state")
-        }
-        switch t.body {
+        switch body {
         case .none:
             return _TransferState(url: url, bodyDataDrain: drain)
         case .data(let data):
@@ -358,22 +355,19 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
 
     /// Start a new transfer
     func startNewTransfer(with request: URLRequest) {
-        guard let t = task else {
-            fatalError()
-        }
-        t.currentRequest = request
+        let task = self.task!
+        task.currentRequest = request
         guard let url = request.url else {
             fatalError("No URL in request.")
         }
 
-        self.internalState = .transferReady(createTransferState(url: url, workQueue: t.workQueue))
-        if let authRequest = task?.authRequest {
-            configureEasyHandle(for: authRequest)
-        } else {
-            configureEasyHandle(for: request)
-        }
-        if (t.suspendCount) < 1 {
-            resume()
+        task.getBody { (body) in
+            self.internalState = .transferReady(self.createTransferState(url: url, body: body, workQueue: task.workQueue))
+            let request = task.authRequest ?? request
+            self.configureEasyHandle(for: request, body: body)
+            if (task.suspendCount) < 1 {
+                self.resume()
+            }
         }
     }
 
@@ -427,7 +421,7 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
         }
     }
 
-    func configureEasyHandle(for: URLRequest) {
+    func configureEasyHandle(for request: URLRequest, body: _Body) {
         NSRequiresConcreteImplementation()
     }
 }
@@ -624,37 +618,7 @@ extension _NativeProtocol._ResponseHeaderLines {
 }
 
 internal extension _NativeProtocol {
-    enum _Body {
-        case none
-        case data(DispatchData)
-        /// Body data is read from the given file URL
-        case file(URL)
-        case stream(InputStream)
-    }
-}
-
-fileprivate extension _NativeProtocol._Body {
-    enum _Error : Error {
-        case fileForBodyDataNotFound
-    }
-
-    /// - Returns: The body length, or `nil` for no body (e.g. `GET` request).
-    func getBodyLength() throws -> UInt64? {
-        switch self {
-        case .none:
-            return 0
-        case .data(let d):
-            return UInt64(d.count)
-        /// Body data is read from the given file URL
-        case .file(let fileURL):
-            guard let s = try FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? NSNumber else {
-                throw _Error.fileForBodyDataNotFound
-            }
-            return s.uint64Value
-        case .stream:
-            return nil
-        }
-    }
+    typealias _Body = URLSessionTask._Body
 }
 
 extension _NativeProtocol {

--- a/Foundation/URLSession/URLSession.swift
+++ b/Foundation/URLSession/URLSession.swift
@@ -545,6 +545,7 @@ fileprivate extension URLSession {
         
         guard !self.invalidated else { fatalError("Session invalidated") }
         let task = URLSessionDownloadTask()
+        task.createdFromInvalidResumeData = true
         task.taskIdentifier = createNextTaskIdentifier()
         task.session = self
         workQueue.async {

--- a/Foundation/URLSession/URLSession.swift
+++ b/Foundation/URLSession/URLSession.swift
@@ -433,7 +433,10 @@ open class URLSession : NSObject {
     }
     
     /* Creates an upload task with the given request.  The previously set body stream of the request (if any) is ignored and the URLSession:task:needNewBodyStream: delegate will be called when the body payload is required. */
-    open func uploadTask(withStreamedRequest request: URLRequest) -> URLSessionUploadTask { NSUnimplemented() }
+    open func uploadTask(withStreamedRequest request: URLRequest) -> URLSessionUploadTask {
+        let r = URLSession._Request(request)
+        return uploadTask(with: r, body: nil, behaviour: .callDelegate)
+    }
     
     /* Creates a download task with the given request. */
     open func downloadTask(with request: URLRequest) -> URLSessionDownloadTask {
@@ -447,7 +450,9 @@ open class URLSession : NSObject {
     }
     
     /* Creates a download task with the resume data.  If the download cannot be successfully resumed, URLSession:task:didCompleteWithError: will be called. */
-    open func downloadTask(withResumeData resumeData: Data) -> URLSessionDownloadTask { NSUnimplemented() }
+    open func downloadTask(withResumeData resumeData: Data) -> URLSessionDownloadTask {
+        return invalidDownloadTask(behavior: .callDelegate)
+    }
     
     /* Creates a bidirectional stream task to a given host and port.
      */
@@ -511,7 +516,7 @@ fileprivate extension URLSession {
     /// Create an upload task.
     ///
     /// All public methods funnel into this one.
-    func uploadTask(with request: _Request, body: URLSessionTask._Body, behaviour: _TaskRegistry._Behaviour) -> URLSessionUploadTask {
+    func uploadTask(with request: _Request, body: URLSessionTask._Body?, behaviour: _TaskRegistry._Behaviour) -> URLSessionUploadTask {
         guard !self.invalidated else { fatalError("Session invalidated") }
         let r = createConfiguredRequest(from: request)
         let i = createNextTaskIdentifier()
@@ -528,6 +533,20 @@ fileprivate extension URLSession {
         let r = createConfiguredRequest(from: request)
         let i = createNextTaskIdentifier()
         let task = URLSessionDownloadTask(session: self, request: r, taskIdentifier: i)
+        workQueue.async {
+            self.taskRegistry.add(task, behaviour: behavior)
+        }
+        return task
+    }
+    
+    /// Create a download task that is marked invalid.
+    func invalidDownloadTask(behavior: _TaskRegistry._Behaviour) -> URLSessionDownloadTask {
+        /* We do not support resume data in swift-corelibs-foundation, so whatever we are passed, we should just behave as Darwin does in the presence of invalid data. */
+        
+        guard !self.invalidated else { fatalError("Session invalidated") }
+        let task = URLSessionDownloadTask()
+        task.taskIdentifier = createNextTaskIdentifier()
+        task.session = self
         workQueue.async {
             self.taskRegistry.add(task, behaviour: behavior)
         }
@@ -588,7 +607,9 @@ extension URLSession {
        return downloadTask(with: _Request(url), behavior: .downloadCompletionHandler(completionHandler)) 
     }
 
-    open func downloadTask(withResumeData resumeData: Data, completionHandler: @escaping (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask { NSUnimplemented() }
+    open func downloadTask(withResumeData resumeData: Data, completionHandler: @escaping (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask {
+        return invalidDownloadTask(behavior: .downloadCompletionHandler(completionHandler))
+    }
 }
 
 internal extension URLSession {

--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -54,7 +54,7 @@ open class URLSessionTask : NSObject, NSCopying {
                 
             default:
                 let toBeSent: Int64?
-                if let bodyLength = try? self.body.getBodyLength() {
+                if let bodyLength = try? self.knownBody?.getBodyLength() {
                     toBeSent = Int64(clamping: bodyLength)
                 } else if self.countOfBytesExpectedToSend > 0 {
                     toBeSent = Int64(clamping: self.countOfBytesExpectedToSend)

--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -98,8 +98,7 @@ open class URLSessionTask : NSObject, NSCopying {
     
     internal var actualSession: URLSession? { return session as? URLSession }
     internal var session: URLSessionProtocol! //change to nil when task completes
-    internal let body: _Body
-    
+
     fileprivate enum ProtocolState {
         case toBeCreated
         case awaitingCacheReply(Bag<(URLProtocol?) -> Void>)
@@ -611,6 +610,17 @@ open class URLSessionUploadTask : URLSessionDataTask {
  * local storage.
  */
 open class URLSessionDownloadTask : URLSessionTask {
+    
+    var createdFromInvalidResumeData = false
+    
+    // If a task is created from invalid resume data, prevent attempting creation of the protocol object.
+    override func _getProtocol(_ callback: @escaping (URLProtocol?) -> Void) {
+        if createdFromInvalidResumeData {
+            callback(nil)
+        } else {
+            super._getProtocol(callback)
+        }
+    }
     
     internal var fileLength = -1.0
     

--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -234,7 +234,7 @@ open class URLSessionTask : NSObject, NSCopying {
         session = _MissingURLSession()
         taskIdentifier = 0
         originalRequest = nil
-        knownBody = .none
+        knownBody = URLSessionTask._Body.none
         workQueue = DispatchQueue(label: "URLSessionTask.notused.0")
         super.init()
     }

--- a/Foundation/URLSession/ftp/FTPURLProtocol.swift
+++ b/Foundation/URLSession/ftp/FTPURLProtocol.swift
@@ -51,7 +51,7 @@ internal class _FTPURLProtocol: _NativeProtocol {
         }
     }
 
-    override func configureEasyHandle(for request: URLRequest) {
+    override func configureEasyHandle(for request: URLRequest, body: _Body) {
         easyHandle.set(verboseModeOn: enableLibcurlDebugOutput)
         easyHandle.set(debugOutputOn: enableLibcurlDebugOutput, task: task!)
         easyHandle.set(skipAllSignalHandling: true)
@@ -59,8 +59,8 @@ internal class _FTPURLProtocol: _NativeProtocol {
         easyHandle.set(url: url)
         easyHandle.set(preferredReceiveBufferSize: Int.max)
         do {
-            switch (task?.body, try task?.body.getBodyLength()) {
-            case (.some(URLSessionTask._Body.none), _):
+            switch (body, try body.getBodyLength()) {
+            case (.none, _):
                 set(requestBodyLength: .noBody)
             case (_, .some(let length)):
                 set(requestBodyLength: .length(length))

--- a/TestFoundation/TestURLSession.swift
+++ b/TestFoundation/TestURLSession.swift
@@ -9,58 +9,6 @@
 
 class TestURLSession : LoopbackServerTest {
     
-    static var allTests: [(String, (TestURLSession) -> () throws -> Void)] {
-        return [
-            ("test_dataTaskWithURL", test_dataTaskWithURL),
-            ("test_dataTaskWithURLRequest", test_dataTaskWithURLRequest),
-            ("test_dataTaskWithURLCompletionHandler", test_dataTaskWithURLCompletionHandler),
-            ("test_dataTaskWithURLRequestCompletionHandler", test_dataTaskWithURLRequestCompletionHandler),
-            // ("test_dataTaskWithHttpInputStream", test_dataTaskWithHttpInputStream), - Flaky test
-            ("test_gzippedDataTask", test_gzippedDataTask),
-            ("test_downloadTaskWithURL", test_downloadTaskWithURL),
-            ("test_downloadTaskWithURLRequest", test_downloadTaskWithURLRequest),
-            ("test_downloadTaskWithRequestAndHandler", test_downloadTaskWithRequestAndHandler),
-            ("test_downloadTaskWithURLAndHandler", test_downloadTaskWithURLAndHandler),
-            ("test_gzippedDownloadTask", test_gzippedDownloadTask),
-            ("test_finishTaskAndInvalidate", test_finishTasksAndInvalidate),
-            ("test_taskError", test_taskError),
-            ("test_taskCopy", test_taskCopy),
-            ("test_cancelTask", test_cancelTask),
-            ("test_taskTimeout", test_taskTimeout),
-            ("test_verifyRequestHeaders", test_verifyRequestHeaders),
-            ("test_verifyHttpAdditionalHeaders", test_verifyHttpAdditionalHeaders),
-            ("test_timeoutInterval", test_timeoutInterval),
-            ("test_httpRedirectionWithCompleteRelativePath", test_httpRedirectionWithCompleteRelativePath),
-            ("test_httpRedirectionWithInCompleteRelativePath", test_httpRedirectionWithInCompleteRelativePath),
-            ("test_httpRedirectionWithDefaultPort", test_httpRedirectionWithDefaultPort),
-            ("test_httpRedirectionTimeout", test_httpRedirectionTimeout),
-            ("test_http0_9SimpleResponses", test_http0_9SimpleResponses),
-            ("test_outOfRangeButCorrectlyFormattedHTTPCode", test_outOfRangeButCorrectlyFormattedHTTPCode),
-            ("test_missingContentLengthButStillABody", test_missingContentLengthButStillABody),
-            ("test_illegalHTTPServerResponses", test_illegalHTTPServerResponses),
-            ("test_dataTaskWithSharedDelegate", test_dataTaskWithSharedDelegate),
-            // ("test_simpleUploadWithDelegate", test_simpleUploadWithDelegate), - Server needs modification
-            ("test_concurrentRequests", test_concurrentRequests),
-            ("test_disableCookiesStorage", test_disableCookiesStorage),
-            ("test_cookiesStorage", test_cookiesStorage),
-            ("test_cookieStorageForEphmeralConfiguration", test_cookieStorageForEphmeralConfiguration),
-            ("test_setCookies", test_setCookies),
-            ("test_dontSetCookies", test_dontSetCookies),
-            ("test_initURLSessionConfiguration", test_initURLSessionConfiguration),
-            ("test_basicAuthRequest", test_basicAuthRequest),
-            ("test_redirectionWithSetCookies", test_redirectionWithSetCookies),
-            ("test_postWithEmptyBody", test_postWithEmptyBody),
-            ("test_basicAuthWithUnauthorizedHeader", test_basicAuthWithUnauthorizedHeader),
-            ("test_checkErrorTypeAfterInvalidateAndCancel", test_checkErrorTypeAfterInvalidateAndCancel),
-            ("test_taskCountAfterInvalidateAndCancel", test_taskCountAfterInvalidateAndCancel),
-            ("test_sessionDelegateAfterInvalidateAndCancel", test_sessionDelegateAfterInvalidateAndCancel),
-            ("test_getAllTasks", test_getAllTasks),
-            ("test_getTasksWithCompletion", test_getTasksWithCompletion),
-            ("test_noDoubleCallbackWhenCancellingAndProtocolFailsFast", test_noDoubleCallbackWhenCancellingAndProtocolFailsFast),
-            ("test_cancelledTasksCannotBeResumed", test_cancelledTasksCannotBeResumed),
-        ]
-    }
-    
     func test_dataTaskWithURL() {
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/Nepal"
         let url = URL(string: urlString)!
@@ -1026,6 +974,104 @@ class TestURLSession : LoopbackServerTest {
 
         waitForExpectations(timeout: 1)
     }
+    func test_invalidResumeDataForDownloadTask() {
+        let done = expectation(description: "Invalid resume data for download task (with completion block)")
+        URLSession.shared.downloadTask(withResumeData: Data()) { (url, response, error) in
+            XCTAssertNil(url)
+            XCTAssertNil(response)
+            XCTAssert(error is URLError)
+            XCTAssertEqual((error as? URLError)?.errorCode, URLError.unsupportedURL.rawValue)
+            
+            done.fulfill()
+        }.resume()
+        waitForExpectations(timeout: 20)
+        
+        let d = DownloadTask(with: expectation(description: "Invalid resume data for download task (with delegate)"))
+        d.run { (session) -> DownloadTask.Configuration in
+            return DownloadTask.Configuration(task: session.downloadTask(withResumeData: Data()),
+                                              errorExpectation:
+                { (error) in
+                    XCTAssert(error is URLError)
+                    XCTAssertEqual((error as? URLError)?.errorCode, URLError.unsupportedURL.rawValue)
+            })
+        }
+        waitForExpectations(timeout: 20)
+    }
+    
+    func test_simpleUploadWithDelegateProvidingInputStream() throws {
+        let delegate = HTTPUploadDelegate()
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/upload"
+        var request = URLRequest(url: URL(string: urlString)!)
+        request.httpMethod = "PUT"
+        
+        delegate.uploadCompletedExpectation = expectation(description: "PUT \(urlString): Upload data")
+        
+        
+        let fileData = Data(count: 16*1024)
+        let stream = InputStream(data: fileData)
+        stream.open()
+        delegate.streamToProvideOnRequest = stream
+        
+        let task = session.uploadTask(withStreamedRequest: request)
+        task.resume()
+        waitForExpectations(timeout: 20)
+    }
+    
+    static var allTests: [(String, (TestURLSession) -> () throws -> Void)] {
+        return [
+            ("test_dataTaskWithURL", test_dataTaskWithURL),
+            ("test_dataTaskWithURLRequest", test_dataTaskWithURLRequest),
+            ("test_dataTaskWithURLCompletionHandler", test_dataTaskWithURLCompletionHandler),
+            ("test_dataTaskWithURLRequestCompletionHandler", test_dataTaskWithURLRequestCompletionHandler),
+            // ("test_dataTaskWithHttpInputStream", test_dataTaskWithHttpInputStream), - Flaky test
+            ("test_gzippedDataTask", test_gzippedDataTask),
+            ("test_downloadTaskWithURL", test_downloadTaskWithURL),
+            ("test_downloadTaskWithURLRequest", test_downloadTaskWithURLRequest),
+            ("test_downloadTaskWithRequestAndHandler", test_downloadTaskWithRequestAndHandler),
+            ("test_downloadTaskWithURLAndHandler", test_downloadTaskWithURLAndHandler),
+            ("test_gzippedDownloadTask", test_gzippedDownloadTask),
+            ("test_finishTaskAndInvalidate", test_finishTasksAndInvalidate),
+            ("test_taskError", test_taskError),
+            ("test_taskCopy", test_taskCopy),
+            ("test_cancelTask", test_cancelTask),
+            ("test_taskTimeout", test_taskTimeout),
+            ("test_verifyRequestHeaders", test_verifyRequestHeaders),
+            ("test_verifyHttpAdditionalHeaders", test_verifyHttpAdditionalHeaders),
+            ("test_timeoutInterval", test_timeoutInterval),
+            ("test_httpRedirectionWithCompleteRelativePath", test_httpRedirectionWithCompleteRelativePath),
+            ("test_httpRedirectionWithInCompleteRelativePath", test_httpRedirectionWithInCompleteRelativePath),
+            ("test_httpRedirectionWithDefaultPort", test_httpRedirectionWithDefaultPort),
+            ("test_httpRedirectionTimeout", test_httpRedirectionTimeout),
+            ("test_http0_9SimpleResponses", test_http0_9SimpleResponses),
+            ("test_outOfRangeButCorrectlyFormattedHTTPCode", test_outOfRangeButCorrectlyFormattedHTTPCode),
+            ("test_missingContentLengthButStillABody", test_missingContentLengthButStillABody),
+            ("test_illegalHTTPServerResponses", test_illegalHTTPServerResponses),
+            ("test_dataTaskWithSharedDelegate", test_dataTaskWithSharedDelegate),
+            // ("test_simpleUploadWithDelegate", test_simpleUploadWithDelegate), - Server needs modification
+            ("test_concurrentRequests", test_concurrentRequests),
+            ("test_disableCookiesStorage", test_disableCookiesStorage),
+            ("test_cookiesStorage", test_cookiesStorage),
+            ("test_cookieStorageForEphmeralConfiguration", test_cookieStorageForEphmeralConfiguration),
+            ("test_setCookies", test_setCookies),
+            ("test_dontSetCookies", test_dontSetCookies),
+            ("test_initURLSessionConfiguration", test_initURLSessionConfiguration),
+            ("test_basicAuthRequest", test_basicAuthRequest),
+            ("test_redirectionWithSetCookies", test_redirectionWithSetCookies),
+            ("test_postWithEmptyBody", test_postWithEmptyBody),
+            ("test_basicAuthWithUnauthorizedHeader", test_basicAuthWithUnauthorizedHeader),
+            ("test_checkErrorTypeAfterInvalidateAndCancel", test_checkErrorTypeAfterInvalidateAndCancel),
+            ("test_taskCountAfterInvalidateAndCancel", test_taskCountAfterInvalidateAndCancel),
+            ("test_sessionDelegateAfterInvalidateAndCancel", test_sessionDelegateAfterInvalidateAndCancel),
+            ("test_getAllTasks", test_getAllTasks),
+            ("test_getTasksWithCompletion", test_getTasksWithCompletion),
+            ("test_invalidResumeDataForDownloadTask", test_invalidResumeDataForDownloadTask),
+            ("test_simpleUploadWithDelegateProvidingInputStream", test_simpleUploadWithDelegateProvidingInputStream),
+            ("test_noDoubleCallbackWhenCancellingAndProtocolFailsFast", test_noDoubleCallbackWhenCancellingAndProtocolFailsFast),
+            ("test_cancelledTasksCannotBeResumed", test_cancelledTasksCannotBeResumed),
+        ]
+    }
+    
 }
 
 class SharedDelegate: NSObject {
@@ -1191,6 +1237,7 @@ class DownloadTask : NSObject {
     let dwdExpectation: XCTestExpectation!
     var session: URLSession! = nil
     var task: URLSessionDownloadTask! = nil
+    var errorExpectation: ((Error) -> Void)?
     
     init(with expectation: XCTestExpectation) {
         dwdExpectation = expectation
@@ -1211,6 +1258,22 @@ class DownloadTask : NSObject {
         task = session.downloadTask(with: urlRequest)
         task.resume()
     }
+    
+    struct Configuration {
+        var task: URLSessionDownloadTask
+        var errorExpectation: ((Error) -> Void)?
+    }
+    
+    func run(configuration: (URLSession) -> Configuration) {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 8
+        session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
+        let taskConfiguration = configuration(session)
+        
+        task = taskConfiguration.task
+        errorExpectation = taskConfiguration.errorExpectation
+        task.resume()
+    }
 }
 
 extension DownloadTask : URLSessionDownloadDelegate {
@@ -1221,24 +1284,61 @@ extension DownloadTask : URLSessionDownloadDelegate {
     }
     
     public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        defer { dwdExpectation.fulfill() }
+        
+        guard self.errorExpectation == nil else {
+            XCTFail("Expected an error, but got …didFinishDownloadingTo… from download task \(downloadTask) (at \(location))")
+            return
+        }
+        
         do {
             let attr = try FileManager.default.attributesOfItem(atPath: location.path)
             XCTAssertEqual((attr[.size]! as? NSNumber)!.int64Value, totalBytesWritten, "Size of downloaded file not equal to total bytes downloaded")
         } catch {
             XCTFail("Unable to calculate size of the downloaded file")
         }
-        dwdExpectation.fulfill()
     }
 }
 
 extension DownloadTask : URLSessionTaskDelegate {
     public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        guard let e = error as? URLError else { return }
-        XCTAssertEqual(e.code, .timedOut, "Unexpected error code")
-        dwdExpectation.fulfill()
+        defer { dwdExpectation.fulfill() }
+        
+        if let errorExpectation = self.errorExpectation {
+            if let error = error {
+                errorExpectation(error)
+            } else {
+                XCTFail("Expected an error, but got a completion without error from download task \(task)")
+            }
+        } else {
+            guard let e = error as? URLError else { return }
+            XCTAssertEqual(e.code, .timedOut, "Unexpected error code")
+        }
     }
 }
 
+class FailFastProtocol: URLProtocol {
+    enum Error: Swift.Error {
+    case fastError
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return request.url?.scheme == "failfast"
+    }
+
+    override class func canInit(with task: URLSessionTask) -> Bool {
+        guard let request = task.currentRequest else { return false }
+        return canInit(with: request)
+    }
+
+    override func startLoading() {
+        client?.urlProtocol(self, didFailWithError: Error.fastError)
+    }
+
+    override func stopLoading() {
+        // Intentionally blank
+    }
+}
 class HTTPRedirectionDataTask : NSObject {
     let dataTaskExpectation: XCTestExpectation!
     var session: URLSession! = nil
@@ -1304,12 +1404,21 @@ extension HTTPRedirectionDataTask : URLSessionTaskDelegate {
 
 class HTTPUploadDelegate: NSObject {
     var uploadCompletedExpectation: XCTestExpectation!
+    var streamToProvideOnRequest: InputStream?
     var totalBytesSent: Int64 = 0
 }
 
 extension HTTPUploadDelegate: URLSessionTaskDelegate {
     func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
         self.totalBytesSent = totalBytesSent
+    }
+    
+    func urlSession(_ session: URLSession, task: URLSessionTask, needNewBodyStream completionHandler: @escaping (InputStream?) -> Void) {
+        if streamToProvideOnRequest == nil {
+            XCTFail("This shouldn't have been invoked -- no stream was set.")
+        }
+        
+        completionHandler(self.streamToProvideOnRequest)
     }
 }
 
@@ -1320,25 +1429,3 @@ extension HTTPUploadDelegate: URLSessionDataDelegate {
     }
 }
 
-class FailFastProtocol: URLProtocol {
-    enum Error: Swift.Error {
-    case fastError
-    }
-
-    override class func canInit(with request: URLRequest) -> Bool {
-        return request.url?.scheme == "failfast"
-    }
-
-    override class func canInit(with task: URLSessionTask) -> Bool {
-        guard let request = task.currentRequest else { return false }
-        return canInit(with: request)
-    }
-
-    override func startLoading() {
-        client?.urlProtocol(self, didFailWithError: Error.fastError)
-    }
-
-    override func stopLoading() {
-        // Intentionally blank
-    }
-}


### PR DESCRIPTION
 - Implement downloadTask(withResumeData…). We do not currently support resume data, so act as Darwin does when invalid data is fed to these methods.

 - Implement uploadTask(withStreamedRequest:).

 - Some cleanup, some testing.