### PR TITLE
Parity: Network: HTTPCookieStorage.sortedCookies(using:)

### DIFF
--- a/Foundation/HTTPCookieStorage.swift
+++ b/Foundation/HTTPCookieStorage.swift
@@ -339,7 +339,7 @@ open class HTTPCookieStorage: NSObject {
     open func sortedCookies(using sortOrder: [NSSortDescriptor]) -> [HTTPCookie] {
         var result: [HTTPCookie] = []
         syncQ.sync {
-            let cookies = Array(allCookies.values)._nsObject
+            let cookies = Array(allCookies.values) as NSArray
             result = cookies.sortedArray(using: sortOrder) as! [HTTPCookie]
         }
         return result

--- a/Foundation/HTTPCookieStorage.swift
+++ b/Foundation/HTTPCookieStorage.swift
@@ -336,7 +336,14 @@ open class HTTPCookieStorage: NSObject {
       @param sortOrder an array of NSSortDescriptors which represent the preferred sort order of the resulting array.
       @discussion proper sorting of cookies may require extensive string conversion, which can be avoided by allowing the system to perform the sorting.  This API is to be preferred over the more generic -[HTTPCookieStorage cookies] API, if sorting is going to be performed.
     */
-    open func sortedCookies(using sortOrder: [NSSortDescriptor]) -> [HTTPCookie] { NSUnimplemented() }
+    open func sortedCookies(using sortOrder: [NSSortDescriptor]) -> [HTTPCookie] {
+        var result: [HTTPCookie] = []
+        syncQ.sync {
+            let cookies = Array(allCookies.values)._nsObject
+            result = cookies.sortedArray(using: sortOrder) as! [HTTPCookie]
+        }
+        return result
+    }
 }
 
 extension Notification.Name {


### PR DESCRIPTION
Now that NSSortDescriptor is available, just forward to NSArray.sortedArray(…). Test and clean up a little.