### PR TITLE
Foundation: change `HTTPCookieStorage` to use `FileManager`

### DIFF
--- a/Foundation/HTTPCookieStorage.swift
+++ b/Foundation/HTTPCookieStorage.swift
@@ -80,7 +80,7 @@ open class HTTPCookieStorage: NSObject {
             if let range = bundleName.range(of: ".", options: .backwards, range: nil, locale: nil) {
                 bundleName = String(bundleName[..<range.lowerBound])
             }
-            let cookieFolderPath = (((_CFXDGCreateDataHomePath() as! AnyObject) as! NSString) as String) + "/" + bundleName
+            let cookieFolderPath = URL(fileURLWithPath: bundleName, relativeTo: FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]).path
             cookieFilePath = filePath(path: cookieFolderPath, fileName: "/.cookies." + cookieStorageName, bundleName: bundleName)
             loadPersistedCookies()
         }


### PR DESCRIPTION
Change the implementation of `HTTPCookieStorage` to use
`FileManager.default.url(for:in:)` instead of the internal
_CFXDGCreateDataHomePath` method.  Now that `HTTPCookieStorage` is moved
off to its own library (FoundationNetworking), it no longer has access
to the internal function.  Use the URL query to get the path to the
storage location.