### PR TITLE
CoreFoundation: avoid `CFString` construction in `CFURLSessionINterface`

### DIFF
--- a/CoreFoundation/URL.subproj/CFURLSessionInterface.c
+++ b/CoreFoundation/URL.subproj/CFURLSessionInterface.c
@@ -32,10 +32,8 @@ static CFURLSessionMultiCode MakeMultiCode(CURLMcode value) {
     return (CFURLSessionMultiCode) { value };
 }
 
-CFStringRef CFURLSessionCreateErrorDescription(int value) {
-    const char *description = curl_easy_strerror(value);
-    return CFStringCreateWithBytes(kCFAllocatorSystemDefault,
-        (const uint8_t *)description, strlen(description), kCFStringEncodingUTF8, NO);
+const char *CFURLSessionEasyCodeDescription(CFURLSessionEasyCode code) {
+    return curl_easy_strerror(code.value);
 }
 
 CFURLSessionEasyHandle _Nonnull CFURLSessionEasyHandleInit() {

--- a/CoreFoundation/URL.subproj/CFURLSessionInterface.h
+++ b/CoreFoundation/URL.subproj/CFURLSessionInterface.h
@@ -56,7 +56,7 @@ typedef struct CFURLSessionEasyCode {
     int value;
 } CFURLSessionEasyCode;
 
-CF_EXPORT CFStringRef _Nonnull CFURLSessionCreateErrorDescription(int value);
+CF_EXPORT const char * _Nullable CFURLSessionEasyCodeDescription(CFURLSessionEasyCode code);
 
 CF_EXPORT int const CFURLSessionEasyErrorSize;
 

--- a/Foundation/URLSession/libcurl/MultiHandle.swift
+++ b/Foundation/URLSession/libcurl/MultiHandle.swift
@@ -217,9 +217,14 @@ fileprivate extension URLSession._MultiHandle {
         // Find the NSURLError code
         var error: NSError?
         if let errorCode = easyHandle.urlErrorCode(for: easyCode) {
-            let errorDescription = easyHandle.errorBuffer[0] != 0 ?
-                String(cString: easyHandle.errorBuffer) :
-                unsafeBitCast(CFURLSessionCreateErrorDescription(easyCode.value), to: NSString.self) as String
+            var errorDescription: String = ""
+            if easyHandle.errorBuffer[0] == 0 {
+              let description = CFURLSessionEasyCodeDescription(easyCode)!
+              errorDescription = NSString(bytes: UnsafeMutableRawPointer(mutating: description), length: strlen(description), encoding: String.Encoding.utf8.rawValue)! as String
+            } else {
+              errorDescription = String(cString: easyHandle.errorBuffer)
+            }
+
             error = NSError(domain: NSURLErrorDomain, code: errorCode, userInfo: [
                 NSLocalizedDescriptionKey: errorDescription
             ])


### PR DESCRIPTION
This causes a reference to `CFStringCreateWithBytes` and
`kCFDefaultSystemAllocator` in `CFURLSessionInterface` which requires
linking against CoreFoundation.  Since the swift deployment uses
CoreFoundation statically, this would require a second instance of
CoreFoundation OR that private CoreFoundation interfaces are re-exposed
through Foundation which is explicitly undesired.  Perform the String
construction in Swift and instead just have a trivial wrapper for
`curl_easy_strerror`.