### PR TITLE
plutil: Add a specific rpath for plutil and use it when linking.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,10 +97,12 @@ if(FOUNDATION_ENABLE_LIBDISPATCH)
   endif()
 endif()
 
+set(plutil_rpath)
 if(CMAKE_SYSTEM_NAME STREQUAL Android OR CMAKE_SYSTEM_NAME STREQUAL Linux OR
     CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
   set(Foundation_RPATH -Xlinker;-rpath;-Xlinker;"\\\$\$ORIGIN")
   set(XDG_TEST_HELPER_RPATH -Xlinker;-rpath;-Xlinker;${CMAKE_CURRENT_BINARY_DIR})
+  set(plutil_rpath -Xlinker;-rpath;-Xlinker;"\\\$\$ORIGIN/../lib/swift/${swift_os}")
 elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
   # FIXME(SR9138) Silence "locally defined symbol '…' imported in function '…'
   set(WORKAROUND_SR9138 -Xlinker;-ignore:4049;-Xlinker;-ignore:4217)
@@ -389,11 +391,11 @@ add_swift_executable(plutil
                      CFLAGS
                        -F${CMAKE_CURRENT_BINARY_DIR}
                      LINK_FLAGS
-                       ${libdispatch_ldflags}
                        -L${CMAKE_CURRENT_BINARY_DIR}
+                       -L;${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src
                        -lFoundation
                        ${Foundation_INTERFACE_LIBRARIES}
-                       ${Foundation_RPATH}
+                       ${plutil_rpath}
                      SWIFT_FLAGS
                        -DDEPLOYMENT_RUNTIME_SWIFT
                        -I;${CMAKE_CURRENT_BINARY_DIR}/swift
@@ -601,7 +603,17 @@ if(ENABLE_TESTING)
                          ENVIRONMENT
                            LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:${FOUNDATION_PATH_TO_XCTEST_BUILD}:${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}:${FOUNDATION_PATH_TO_LIBDISPATCH_BUILD}/src
                          DEPENDS
-                           ${CMAKE_CURRENT_BINARY_DIR}/TestFoundation/xdgTestHelper${CMAKE_EXECUTABLE_SUFFIX})
+                         ${CMAKE_CURRENT_BINARY_DIR}/TestFoundation/xdgTestHelper${CMAKE_EXECUTABLE_SUFFIX})
+
+  add_custom_command(TARGET TestFoundation
+                     POST_BUILD
+                     BYPRODUCTS
+                       ${CMAKE_CURRENT_BINARY_DIR}/TestFoundation/plutil${CMAKE_EXECUTABLE_SUFFIX}
+                     COMMAND
+                       ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/plutil${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_CURRENT_BINARY_DIR}/TestFoundation/plutil${CMAKE_EXECUTABLE_SUFFIX}
+                     DEPENDS
+                       TestFoundation
+                       plutil)
 endif()
 
 if(BUILD_SHARED_LIBS)

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -560,6 +560,20 @@
 			remoteGlobalIDString = 5B5D885C1BBC938800234F36;
 			remoteInfo = SwiftFoundation;
 		};
+		B98F173F229AF5AF00F2B002 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EA66F66E1BF56CCB00136161;
+			remoteInfo = plutil;
+		};
+		B98F1741229AF5F900F2B002 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5B5D885C1BBC938800234F36;
+			remoteInfo = SwiftFoundation;
+		};
 		EA993CE21BEACD8E000969A2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
@@ -2336,6 +2350,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				B98F1740229AF5AF00F2B002 /* PBXTargetDependency */,
 				B90FD23020C2FF420087EF44 /* PBXTargetDependency */,
 				AE2FC5951CFEFC70008F7981 /* PBXTargetDependency */,
 			);
@@ -2374,6 +2389,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				B98F1742229AF5F900F2B002 /* PBXTargetDependency */,
 			);
 			name = plutil;
 			productName = plutil;
@@ -2509,7 +2525,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cp ${BUILT_PRODUCTS_DIR}/xdgTestHelper.app/Contents/MacOS/xdgTestHelper ${BUILT_PRODUCTS_DIR}/TestFoundation.app/Contents/MacOS/\n";
+			shellScript = "cp ${BUILT_PRODUCTS_DIR}/xdgTestHelper.app/Contents/MacOS/xdgTestHelper ${BUILT_PRODUCTS_DIR}/TestFoundation.app/Contents/MacOS/\ncp ${BUILT_PRODUCTS_DIR}/plutil ${BUILT_PRODUCTS_DIR}/TestFoundation.app/Contents/MacOS/\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -2963,6 +2979,16 @@
 			isa = PBXTargetDependency;
 			target = 5B5D885C1BBC938800234F36 /* SwiftFoundation */;
 			targetProxy = B90FD23120C2FF840087EF44 /* PBXContainerItemProxy */;
+		};
+		B98F1740229AF5AF00F2B002 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EA66F66E1BF56CCB00136161 /* plutil */;
+			targetProxy = B98F173F229AF5AF00F2B002 /* PBXContainerItemProxy */;
+		};
+		B98F1742229AF5F900F2B002 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5B5D885C1BBC938800234F36 /* SwiftFoundation */;
+			targetProxy = B98F1741229AF5F900F2B002 /* PBXContainerItemProxy */;
 		};
 		EA993CE31BEACD8E000969A2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;


### PR DESCRIPTION
- plutil requires an rpath of '$ORIGIN/../lib/swift/${swift_os}'
  so set this specificaly for plutil.

- Add a test for running plutil, which relies on LD_LIBRARY_PATH
  being set when the tests are run to point to the build directories.