### PR TITLE
Foundation: correctly read thread name

### DIFF
--- a/Foundation/Thread.swift
+++ b/Foundation/Thread.swift
@@ -251,9 +251,12 @@ open class Thread : NSObject {
     }
 
     open var name: String? {
-        didSet {
+        get {
+            return _name
+        }
+        set {
             if let thread = _thread {
-                _CFThreadSetName(thread, name ?? "" )
+                _CFThreadSetName(thread, newValue ?? "" )
             }
         }
     }

--- a/TestFoundation/TestThread.swift
+++ b/TestFoundation/TestThread.swift
@@ -68,16 +68,17 @@ class TestThread : XCTestCase {
     
 #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
     func test_threadName() {
-        // No name is set initially
-        XCTAssertNil(Thread.current.name)
-
 #if os(Linux) // Linux sets the initial thread name to the process name.
+        XCTAssertEqual(Thread.current.name, "TestFoundation")
         XCTAssertEqual(Thread.current._name, "TestFoundation")
 #else
+        // No name is set initially
+        XCTAssertEqual(Thread.current.name, "")
         XCTAssertEqual(Thread.current._name, "")
 #endif
         Thread.current.name = "mainThread"
         XCTAssertEqual(Thread.mainThread.name, "mainThread")
+        XCTAssertEqual(Thread.mainThread._name, "mainThread")
 
         let condition = NSCondition()
         condition.lock()


### PR DESCRIPTION
Foundation was correctly setting the thread name, but it would only ever
read the name that was stored in the thread object. This meant that if
the thread name was set elsewhere (e.g. by Linux, or by SwiftNIO) that
name would not be reflected in Thread's name property.