### PR TITLE
Parity: FileManager.replaceItem(…)

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -64,6 +64,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <linux/stat.h>
+#include <linux/fs.h>
 #define AT_STATX_SYNC_AS_STAT   0x0000  /* - Do whatever stat() does */
 #endif //__GLIBC_PREREQ(2. 28)
 #endif // TARGET_OS_LINUX
@@ -591,6 +592,12 @@ _stat_with_btime(const char *filename, struct stat *buffer, struct timespec *bti
     return lstat(filename, buffer);
 }
 #endif // __NR_statx
+
+static unsigned int const _CF_renameat2_RENAME_EXCHANGE = 1 << 1;
+static int _CF_renameat2(int olddirfd, const char *_Nonnull oldpath,
+                            int newdirfd, const char *_Nonnull newpath, unsigned int flags) {
+    return syscall(SYS_renameat2, olddirfd, oldpath, newdirfd, newpath, flags);
+}
 #endif // TARGET_OS_LINUX
 
 #if __HAS_STATX

--- a/TestFoundation/Utilities.swift
+++ b/TestFoundation/Utilities.swift
@@ -561,3 +561,24 @@ extension XCTest {
         }
     }
 }
+
+extension FileHandle: TextOutputStream {
+    public func write(_ string: String) {
+        write(Data(string.utf8))
+    }
+    
+    struct EncodedOutputStream: TextOutputStream {
+        let fileHandle: FileHandle
+        let encoding: String.Encoding
+        
+        init(_ fileHandle: FileHandle, encoding: String.Encoding) {
+            self.fileHandle = fileHandle
+            self.encoding = encoding
+        }
+        
+        func write(_ string: String) {
+            fileHandle.write(string.data(using: encoding)!)
+        }
+    }
+}
+


### PR DESCRIPTION
 - Instead of returning nothing from .url(for: .itemReplacementDirectory…), produce a path the same way Darwin does.

 - Implement replaceItems(…) for POSIX-y platforms. We try to use Darwin and Linux swap syscalls to ensure race-free atomicity if available, and if these fail we fall back to an implementation that has different degrees of atomicity depending on what object is replaced with what object.

 - Add tests.