### PR TITLE
SR-10776: Fix runtime crash of calling XMLDocument's `var name: String?`

### DIFF
--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -495,6 +495,7 @@ static inline xmlChar* _getQName(xmlNodePtr node) {
     const xmlChar* ncname = node->name;
     
     switch (node->type) {
+        case XML_DOCUMENT_NODE:
         case XML_NOTATION_NODE:
         case XML_DTD_NODE:
         case XML_ELEMENT_DECL:

--- a/Foundation/XMLNode.swift
+++ b/Foundation/XMLNode.swift
@@ -328,9 +328,13 @@ open class XMLNode: NSObject, NSCopying {
             return returned == nil ? nil : unsafeBitCast(returned!, to: NSString.self) as String
         }
         set {
-            if case .namespace = kind {
+            switch kind {
+            case .document:
+                // As with Darwin, ignore the name when the node is document.
+                break
+            case .namespace:
                 _CFXMLNamespaceSetPrefix(_xmlNode, newValue, Int64(newValue?.utf8.count ?? 0))
-            } else {
+            default:
                 if let newName = newValue {
                     _CFXMLNodeSetName(_xmlNode, newName)
                 } else {

--- a/TestFoundation/TestXMLDocument.swift
+++ b/TestFoundation/TestXMLDocument.swift
@@ -40,6 +40,7 @@ class TestXMLDocument : LoopbackServerTest {
             ("test_optionPreserveAll", test_optionPreserveAll),
             ("test_rootElementRetainsDocument", test_rootElementRetainsDocument),
             ("test_nodeKinds", test_nodeKinds),
+            ("test_sr10776_documentName", test_sr10776_documentName),
         ]
     }
 
@@ -625,7 +626,7 @@ class TestXMLDocument : LoopbackServerTest {
 
         XCTAssertEqual(try? test(), "plans")
     }
-    
+
     func test_nodeKinds() {
         XCTAssertEqual(XMLDocument(rootElement: nil).kind, .document)
         XCTAssertEqual(XMLElement(name: "prefix:localName").kind, .element)
@@ -639,6 +640,14 @@ class TestXMLDocument : LoopbackServerTest {
         XCTAssertEqual(XMLDTDNode(xmlString: "<!ATTLIST A B CDATA #IMPLIED>")?.kind, .attributeDeclaration)
         XCTAssertEqual(XMLDTDNode(xmlString: "<!ELEMENT E EMPTY>")?.kind, .elementDeclaration)
         XCTAssertEqual(XMLDTDNode(xmlString: #"<!NOTATION f SYSTEM "F">"#)?.kind, .notationDeclaration)
+    }
+
+    func test_sr10776_documentName() {
+        let doc = XMLDocument(rootElement: nil)
+        XCTAssertNil(doc.name)
+        
+        doc.name = "name"
+        XCTAssertNil(doc.name) // `name` of XMLDocument is always nil.
     }
 }
 


### PR DESCRIPTION
Runtime crash occurs when `XMLDocument`'s computed property `var name: String?` is called. This PR fixes the issue.

Resolves [SR-10776](https://bugs.swift.org/browse/SR-10776).

~~Note: This PR would conflict with [PR#2287](https://github.com/apple/swift-corelibs-foundation/pull/2287) and [PR#2313](https://github.com/apple/swift-corelibs-foundation/pull/2313). That's why it is a draft at the moment. This branch will be rebased after they are merged.~~

**EDITED**
#2287 has been merged. This PR seems not to conflict with #2313 after checking again. Sorry.