### PR TITLE
SR-10638: Change the type of force casting in `NSCalendar`.

### DIFF
--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -329,7 +329,7 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     private func _symbols(_ key: CFString) -> [String] {
         let dateFormatter = CFDateFormatterCreate(kCFAllocatorSystemDefault, locale?._cfObject, kCFDateFormatterNoStyle, kCFDateFormatterNoStyle)
         CFDateFormatterSetProperty(dateFormatter, kCFDateFormatterCalendarKey, _cfObject)
-        let result = (CFDateFormatterCopyProperty(dateFormatter, key) as! CFArray)._swiftObject
+        let result = (CFDateFormatterCopyProperty(dateFormatter, key) as! NSArray)._swiftObject
         return result.map {
             return ($0 as! NSString)._swiftObject
         }

--- a/TestFoundation/TestCalendar.swift
+++ b/TestFoundation/TestCalendar.swift
@@ -26,6 +26,7 @@ class TestCalendar: XCTestCase {
             ("test_currentCalendarRRstability", test_currentCalendarRRstability),
             ("test_hashing", test_hashing),
             ("test_dateFromDoesntMutate", test_dateFromDoesntMutate),
+            ("test_sr10638", test_sr10638),
         ]
     }
     
@@ -253,6 +254,12 @@ class TestCalendar: XCTestCase {
         XCTAssertEqual(calendarCopy.timeZone.description, "GMT (fixed)")
         XCTAssertEqual(calendarCopy.timeZone, calendar.timeZone)
         XCTAssertEqual(calendarCopy, calendar)
+    }
+    
+    func test_sr10638() {
+        // https://bugs.swift.org/browse/SR-10638
+        let cal = Calendar(identifier: .gregorian)
+        XCTAssertGreaterThan(cal.eraSymbols.count, 0)
     }
 }
 


### PR DESCRIPTION
Despite `CFDateFormatterCopyProperty(_:_:)` returns `CFArrayRef` when the key is `kCFDateFormatterEraSymbolsKey`, the compiler on Linux assume that the type is `_NSCFArray` and fails to cast even though they are compatible. 

Resolves [SR-10638](https://bugs.swift.org/browse/SR-10638).

Note: This bug is blocking [PR#2200](https://github.com/apple/swift-corelibs-foundation/pull/2200).

