### PR TITLE
Parity: NSDictionary: Non-keyed archiving marked as NSUnimplemented()

### DIFF
--- a/Foundation/NSDictionary.swift
+++ b/Foundation/NSDictionary.swift
@@ -148,7 +148,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
             keyedArchiver._encodeArrayOfObjects(self.allKeys._nsObject, forKey:"NS.keys")
             keyedArchiver._encodeArrayOfObjects(self.allValues._nsObject, forKey:"NS.objects")
         } else {
-            NSUnimplemented()
+            NSUnsupported()
         }
     }
     


### PR DESCRIPTION
Move from NSUnimpletented() to NSUnsupported() We do not support non-keyed-capable archiving in swift-corelibs-foundation classes.

https://bugs.swift.org/browse/SR-10396