### PR TITLE
SR-10596: Prevent Float being deserialized into an Int

### DIFF
--- a/Foundation/JSONEncoder.swift
+++ b/Foundation/JSONEncoder.swift
@@ -2109,13 +2109,13 @@ extension _JSONDecoder {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
-
         switch number._cfNumberType() {
         case kCFNumberFloatType, kCFNumberDoubleType:
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
         default:
             break
         }
+
         let int = number.intValue
         guard NSNumber(value: int) == number else {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))

--- a/Foundation/JSONEncoder.swift
+++ b/Foundation/JSONEncoder.swift
@@ -2109,6 +2109,13 @@ extension _JSONDecoder {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 
+
+        switch number._cfNumberType() {
+        case kCFNumberFloatType, kCFNumberDoubleType:
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        default:
+            break
+        }
         let int = number.intValue
         guard NSNumber(value: int) == number else {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))

--- a/TestFoundation/TestJSONEncoder.swift
+++ b/TestFoundation/TestJSONEncoder.swift
@@ -439,6 +439,20 @@ class TestJSONEncoder : XCTestCase {
         }
     }
 
+    func test_codingOfFloatToIntFails() {
+        do {
+            let json = "{ \"value\": 1.5, }".data(using: .utf8)!
+            let _ = try JSONDecoder().decode(TopLevelObjectWrapper<Int>.self, from: json)
+            XCTFail("Decoder should fail when decoding Float value to Int.")
+        } catch {}
+
+        do {
+            let json = "{ \"value\": 1.0, }".data(using: .utf8)!
+            let _ = try JSONDecoder().decode(TopLevelObjectWrapper<Int>.self, from: json)
+            XCTFail("Decoder should fail when decoding Float value to Int.")
+        } catch {}
+    }
+
     func test_codingOfUInt() {
         let uintSize = MemoryLayout<UInt>.size
         switch uintSize {
@@ -1291,6 +1305,7 @@ extension TestJSONEncoder {
             ("test_codingOfInt64", test_codingOfInt64),
             ("test_codingOfUInt64", test_codingOfUInt64),
             ("test_codingOfInt", test_codingOfInt),
+            ("test_codingOfFloatToIntFails", test_codingOfFloatToIntFails),
             ("test_codingOfUInt", test_codingOfUInt),
             ("test_codingOfUIntMinMax", test_codingOfUIntMinMax),
             ("test_codingOfFloat", test_codingOfFloat),


### PR DESCRIPTION
Check for the NSNumber's underlying value and throw an error if it is a floating point number when deserializing from JSON into an Int.
https://bugs.swift.org/browse/SR-10596