### PR TITLE
NSCoder.decodingFailurePolicy should be read-only.

### DIFF
--- a/Foundation/NSCoder.swift
+++ b/Foundation/NSCoder.swift
@@ -747,7 +747,7 @@ open class NSCoder : NSObject {
     
     internal private(set) var _hasFailed = false
     
-    open var decodingFailurePolicy: NSCoder.DecodingFailurePolicy = .raiseException
+    open internal(set) var decodingFailurePolicy: NSCoder.DecodingFailurePolicy = .raiseException
     
     open var error: Error? {
         NSRequiresConcreteImplementation()

--- a/TestFoundation/Utilities.swift
+++ b/TestFoundation/Utilities.swift
@@ -203,7 +203,6 @@ extension Fixture where ValueType: NSObject & NSCoding {
         let original = try make()
         
         let coder = NSKeyedArchiver(forWritingWith: NSMutableData())
-        coder.decodingFailurePolicy = .setErrorAndReturn
         archiverSetup(coder)
         
         coder.encode(original, forKey: NSKeyedArchiveRootObjectKey)


### PR DESCRIPTION
- See https://developer.apple.com/documentation/foundation/nscoder/1642984-decodingfailurepolicy

- NSKeyedUnarchiver overrides it to be read-write, but NSKeyedArchiver
  does not.