### PR TITLE
Basic implementation of URLCredentialStorage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -518,6 +518,7 @@ if(ENABLE_TESTING)
                          TestFoundation/TestUnitConverter.swift
                          TestFoundation/TestUnit.swift
                          TestFoundation/TestURLCredential.swift
+                         TestFoundation/TestURLCredentialStorage.swift
                          TestFoundation/TestURLProtectionSpace.swift
                          TestFoundation/TestURLProtocol.swift
                          TestFoundation/TestURLRequest.swift

--- a/Foundation/URLCredential.swift
+++ b/Foundation/URLCredential.swift
@@ -51,9 +51,6 @@ open class URLCredential : NSObject, NSSecureCoding, NSCopying {
         @result The initialized URLCredential
      */
     public init(user: String, password: String, persistence: Persistence) {
-        guard persistence != .permanent && persistence != .synchronizable else {
-            NSUnimplemented()
-        }
         _user = user
         _password = password
         _persistence = persistence

--- a/Foundation/URLCredentialStorage.swift
+++ b/Foundation/URLCredentialStorage.swift
@@ -18,22 +18,38 @@ import Foundation
     @discussion URLCredential.Storage implements a singleton object (shared instance) which manages the shared credentials cache. Note: Whereas in Mac OS X any application can access any credential with a persistence of URLCredential.Persistence.permanent provided the user gives permission, in iPhone OS an application can access only its own credentials.
 */
 open class URLCredentialStorage: NSObject {
-    
+
+    private static var _shared = URLCredentialStorage()
+
     /*!
         @method sharedCredentialStorage
         @abstract Get the shared singleton authentication storage
         @result the shared authentication storage
     */
-    open class var shared: URLCredentialStorage { get { NSUnimplemented() } }
-    
+    open class var shared: URLCredentialStorage { return _shared }
+
+    private let _lock: NSLock
+    private var _credentials: [URLProtectionSpace: [String: URLCredential]]
+    private var _defaultCredentials: [URLProtectionSpace: URLCredential]
+
+    public override init() {
+        _lock = NSLock()
+        _credentials = [:]
+        _defaultCredentials = [:]
+    }
+
     /*!
         @method credentialsForProtectionSpace:
         @abstract Get a dictionary mapping usernames to credentials for the specified protection space.
         @param protectionSpace An URLProtectionSpace indicating the protection space for which to get credentials
         @result A dictionary where the keys are usernames and the values are the corresponding URLCredentials.
     */
-    open func credentials(for space: URLProtectionSpace) -> [String : URLCredential]? { NSUnimplemented() }
-    
+    open func credentials(for space: URLProtectionSpace) -> [String : URLCredential]? {
+        _lock.lock()
+        defer { _lock.unlock() }
+        return _credentials[space]
+    }
+
     /*!
         @method allCredentials
         @abstract Get a dictionary mapping URLProtectionSpaces to dictionaries which map usernames to URLCredentials
@@ -41,19 +57,39 @@ open class URLCredentialStorage: NSObject {
         and the values are dictionaries, in which the keys are usernames
         and the values are URLCredentials
     */
-    open var allCredentials: [URLProtectionSpace : [String : URLCredential]] { NSUnimplemented() }
-    
+    open var allCredentials: [URLProtectionSpace : [String : URLCredential]] {
+        _lock.lock()
+        defer { _lock.unlock() }
+        return _credentials
+    }
+
     /*!
         @method setCredential:forProtectionSpace:
         @abstract Add a new credential to the set for the specified protection space or replace an existing one.
         @param credential The credential to set.
-        @param space The protection space for which to add it. 
+        @param space The protection space for which to add it.
         @discussion Multiple credentials may be set for a given protection space, but each must have
         a distinct user. If a credential with the same user is already set for the protection space,
         the new one will replace it.
     */
-    open func set(_ credential: URLCredential, for space: URLProtectionSpace) { NSUnimplemented() }
-    
+    open func set(_ credential: URLCredential, for space: URLProtectionSpace) {
+        guard credential.persistence != .synchronizable else {
+            NSUnimplemented()
+        }
+
+        guard credential.persistence != .none else {
+            return
+        }
+
+        _lock.lock()
+        let needsNotification = _setWhileLocked(credential, for: space)
+        _lock.unlock()
+
+        if needsNotification {
+            _sendNotificationWhileUnlocked()
+        }
+    }
+
     /*!
         @method removeCredential:forProtectionSpace:
         @abstract Remove the credential from the set for the specified protection space.
@@ -63,8 +99,10 @@ open class URLCredentialStorage: NSObject {
         has a persistence policy of URLCredential.Persistence.synchronizable will fail.
         See removeCredential:forProtectionSpace:options.
     */
-    open func remove(_ credential: URLCredential, for space: URLProtectionSpace) { NSUnimplemented() }
-    
+    open func remove(_ credential: URLCredential, for space: URLProtectionSpace) {
+        remove(credential, for: space, options: nil)
+    }
+
     /*!
      @method removeCredential:forProtectionSpace:options
      @abstract Remove the credential from the set for the specified protection space based on options.
@@ -76,15 +114,55 @@ open class URLCredentialStorage: NSObject {
      are removed, the credential will be removed on all devices that contain this credential.
      @discussion The credential is removed from both persistent and temporary storage.
      */
-    open func remove(_ credential: URLCredential, for space: URLProtectionSpace, options: [String : AnyObject]? = [:]) { NSUnimplemented() }
-    
+    open func remove(_ credential: URLCredential, for space: URLProtectionSpace, options: [String : AnyObject]? = [:]) {
+        if credential.persistence == .synchronizable {
+            guard let options = options,
+                  let removeSynchronizable = options[NSURLCredentialStorageRemoveSynchronizableCredentials] as? NSNumber,
+                  removeSynchronizable.boolValue == true else {
+                return
+            }
+        }
+
+        var needsNotification = false
+
+        _lock.lock()
+
+        if let user = credential.user {
+            if _credentials[space]?[user] == credential {
+                _credentials[space]?[user] = nil
+                needsNotification = true
+                // If we remove the last entry, remove the protection space.
+                if _credentials[space]?.count == 0 {
+                    _credentials[space] = nil
+                }
+            }
+        }
+        // Also, look for a default object, if it exists, but check equality.
+        if let defaultCredential = _defaultCredentials[space],
+           defaultCredential == credential {
+            _defaultCredentials[space] = nil
+            needsNotification = true
+        }
+
+        _lock.unlock()
+
+        if needsNotification {
+            _sendNotificationWhileUnlocked()
+        }
+    }
+
     /*!
         @method defaultCredentialForProtectionSpace:
         @abstract Get the default credential for the specified protection space.
         @param space The protection space for which to get the default credential.
     */
-    open func defaultCredential(for space: URLProtectionSpace) -> URLCredential? { NSUnimplemented() }
-    
+    open func defaultCredential(for space: URLProtectionSpace) -> URLCredential? {
+        _lock.lock()
+        defer { _lock.unlock() }
+
+        return _defaultCredentials[space]
+    }
+
     /*!
         @method setDefaultCredential:forProtectionSpace:
         @abstract Set the default credential for the specified protection space.
@@ -92,15 +170,70 @@ open class URLCredentialStorage: NSObject {
         @param space The protection space for which the credential should be set as default.
         @discussion If the credential is not yet in the set for the protection space, it will be added to it.
     */
-    open func setDefaultCredential(_ credential: URLCredential, for space: URLProtectionSpace) { NSUnimplemented() }
+    open func setDefaultCredential(_ credential: URLCredential, for space: URLProtectionSpace) {
+        guard credential.persistence != .synchronizable else {
+            NSUnimplemented()
+        }
+
+        guard credential.persistence != .none else {
+            return
+        }
+
+        _lock.lock()
+        let needsNotification = _setWhileLocked(credential, for: space, isDefault: true)
+        _lock.unlock()
+
+        if needsNotification {
+            _sendNotificationWhileUnlocked()
+        }
+    }
+
+    private func _setWhileLocked(_ credential: URLCredential, for space: URLProtectionSpace, isDefault: Bool = false) -> Bool {
+        var modified = false
+
+        if let user = credential.user {
+            if _credentials[space] == nil {
+                _credentials[space] = [:]
+            }
+
+            modified = _credentials[space]![user] != credential
+            _credentials[space]![user] = credential
+        }
+
+        if isDefault || _defaultCredentials[space] == nil {
+            modified = modified || _defaultCredentials[space] != credential
+            _defaultCredentials[space] = credential
+        }
+
+        return modified
+    }
+
+    private func _sendNotificationWhileUnlocked() {
+        let notification = Notification(name: .NSURLCredentialStorageChanged, object: self, userInfo: nil)
+        NotificationCenter.default.post(notification)
+    }
 }
 
 extension URLCredentialStorage {
-    public func getCredentials(for protectionSpace: URLProtectionSpace, task: URLSessionTask, completionHandler: ([String : URLCredential]?) -> Void) { NSUnimplemented() }
-    public func set(_ credential: URLCredential, for protectionSpace: URLProtectionSpace, task: URLSessionTask) { NSUnimplemented() }
-    public func remove(_ credential: URLCredential, for protectionSpace: URLProtectionSpace, options: [String : AnyObject]? = [:], task: URLSessionTask) { NSUnimplemented() }
-    public func getDefaultCredential(for space: URLProtectionSpace, task: URLSessionTask, completionHandler: (URLCredential?) -> Void) { NSUnimplemented() }
-    public func setDefaultCredential(_ credential: URLCredential, for protectionSpace: URLProtectionSpace, task: URLSessionTask) { NSUnimplemented() }
+    public func getCredentials(for protectionSpace: URLProtectionSpace, task: URLSessionTask, completionHandler: ([String : URLCredential]?) -> Void) {
+        completionHandler(credentials(for: protectionSpace))
+    }
+
+    public func set(_ credential: URLCredential, for protectionSpace: URLProtectionSpace, task: URLSessionTask) {
+        set(credential, for: protectionSpace)
+    }
+
+    public func remove(_ credential: URLCredential, for protectionSpace: URLProtectionSpace, options: [String : AnyObject]? = [:], task: URLSessionTask) {
+        remove(credential, for: protectionSpace, options: options)
+    }
+
+    public func getDefaultCredential(for space: URLProtectionSpace, task: URLSessionTask, completionHandler: (URLCredential?) -> Void) {
+        completionHandler(defaultCredential(for: space))
+    }
+
+    public func setDefaultCredential(_ credential: URLCredential, for protectionSpace: URLProtectionSpace, task: URLSessionTask) {
+        setDefaultCredential(credential, for: protectionSpace)
+    }
 }
 
 extension Notification.Name {
@@ -119,4 +252,3 @@ extension Notification.Name {
  *		to remove such a credential.
  */
 public let NSURLCredentialStorageRemoveSynchronizableCredentials: String = "NSURLCredentialStorageRemoveSynchronizableCredentials"
-

--- a/TestFoundation/TestURLCredentialStorage.swift
+++ b/TestFoundation/TestURLCredentialStorage.swift
@@ -1,0 +1,549 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+class TestURLCredentialStorage : XCTestCase {
+
+    static var allTests: [(String, (TestURLCredentialStorage) -> () throws -> Void)] {
+        return [
+            ("test_storageStartsEmpty", test_storageStartsEmpty),
+            ("test_sessionCredentialGetsReturnedForTheRightProtectionSpace", test_sessionCredentialGetsReturnedForTheRightProtectionSpace),
+            ("test_sessionCredentialDoesNotGetReturnedForTheWrongProtectionSpace", test_sessionCredentialDoesNotGetReturnedForTheWrongProtectionSpace),
+            ("test_sessionCredentialBecomesDefaultForProtectionSpace", test_sessionCredentialBecomesDefaultForProtectionSpace),
+            ("test_sessionCredentialGetsReturnedAsDefaultIfSetAsDefaultForSpace", test_sessionCredentialGetsReturnedAsDefaultIfSetAsDefaultForSpace),
+            ("test_sessionCredentialGetsReturnedIfSetAsDefaultForSpace", test_sessionCredentialGetsReturnedIfSetAsDefaultForSpace),
+            ("test_sessionCredentialDoesNotGetReturnedIfSetAsDefaultForOtherSpace", test_sessionCredentialDoesNotGetReturnedIfSetAsDefaultForOtherSpace),
+            ("test_sessionCredentialDoesNotGetReturnedWhenNotAddedAsDefault", test_sessionCredentialDoesNotGetReturnedWhenNotAddedAsDefault),
+            ("test_sessionCredentialCanBeRemovedFromSpace", test_sessionCredentialCanBeRemovedFromSpace),
+            ("test_sessionDefaultCredentialCanBeRemovedFromSpace", test_sessionDefaultCredentialCanBeRemovedFromSpace),
+            ("test_synchronizableCredentialCanBeRemovedWithRightOptions", test_synchronizableCredentialCanBeRemovedWithRightOptions),
+            ("test_synchronizableCredentialWillNotBeRemovedWithoutRightOptions", test_synchronizableCredentialWillNotBeRemovedWithoutRightOptions),
+            ("test_storageCanRemoveArbitraryCredentialWithoutFailing", test_storageCanRemoveArbitraryCredentialWithoutFailing),
+            ("test_storageWillNotSaveCredentialsWithoutPersistence", test_storageWillNotSaveCredentialsWithoutPersistence),
+            ("test_storageWillSendNotificationWhenAddingNewCredential", test_storageWillSendNotificationWhenAddingNewCredential),
+            ("test_storageWillSendNotificationWhenAddingExistingCredentialToDifferentSpace", test_storageWillSendNotificationWhenAddingExistingCredentialToDifferentSpace),
+            ("test_storageWillNotSendNotificationWhenAddingExistingCredential", test_storageWillNotSendNotificationWhenAddingExistingCredential),
+            ("test_storageWillSendNotificationWhenAddingNewDefaultCredential", test_storageWillSendNotificationWhenAddingNewDefaultCredential),
+            ("test_storageWillNotSendNotificationWhenAddingExistingDefaultCredential", test_storageWillNotSendNotificationWhenAddingExistingDefaultCredential),
+            ("test_storageWillSendNotificationWhenAddingDifferentDefaultCredential", test_storageWillSendNotificationWhenAddingDifferentDefaultCredential),
+            ("test_storageWillSendNotificationWhenRemovingExistingCredential", test_storageWillSendNotificationWhenRemovingExistingCredential),
+            ("test_storageWillNotSendNotificationWhenRemovingExistingCredentialInOtherSpace", test_storageWillNotSendNotificationWhenRemovingExistingCredentialInOtherSpace),
+            ("test_storageWillSendNotificationWhenRemovingDefaultNotification", test_storageWillSendNotificationWhenRemovingDefaultNotification),
+            ("test_taskBasedGetCredentialsReturnsCredentialsForSpace", test_taskBasedGetCredentialsReturnsCredentialsForSpace),
+            ("test_taskBasedSetCredentialStoresGivenCredentials", test_taskBasedSetCredentialStoresGivenCredentials),
+            ("test_taskBasedRemoveCredentialDeletesCredentialsFromSpace", test_taskBasedRemoveCredentialDeletesCredentialsFromSpace),
+            ("test_taskBasedGetDefaultCredentialReturnsTheDefaultCredential", test_taskBasedGetDefaultCredentialReturnsTheDefaultCredential),
+            ("test_taskBasedSetDefaultCredentialStoresTheDefaultCredential", test_taskBasedSetDefaultCredentialStoresTheDefaultCredential),
+        ]
+    }
+
+    func test_storageStartsEmpty() {
+        let storage = URLCredentialStorage.shared
+        XCTAssertEqual(storage.allCredentials.count, 0)
+    }
+
+    func test_sessionCredentialGetsReturnedForTheRightProtectionSpace() throws {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        expectChanges(storage.allCredentials.count, by: 1) {
+            storage.set(credential, for: space)
+        }
+        XCTAssertEqual(storage.credentials(for: space)?.count, 1)
+
+        guard let credentials = storage.credentials(for: space),
+              let recovered = credentials[try credential.user.unwrapped()] else {
+            XCTFail("Credential not found in storage")
+            return
+        }
+        XCTAssertEqual(recovered, credential)
+
+        storage.remove(credential, for: space)
+    }
+
+    func test_sessionCredentialDoesNotGetReturnedForTheWrongProtectionSpace() {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+        let wrongSpace = URLProtectionSpace(host: "example2.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        storage.set(credential, for: space)
+        XCTAssertNil(storage.credentials(for: wrongSpace))
+
+        storage.remove(credential, for: space)
+    }
+
+    func test_sessionCredentialBecomesDefaultForProtectionSpace() {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        storage.set(credential, for: space)
+        XCTAssertEqual(storage.defaultCredential(for: space), credential)
+
+        storage.remove(credential, for: space)
+    }
+
+    func test_sessionCredentialGetsReturnedAsDefaultIfSetAsDefaultForSpace() {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        storage.setDefaultCredential(credential, for: space)
+        XCTAssertEqual(storage.defaultCredential(for: space), credential)
+
+        storage.remove(credential, for: space)
+    }
+
+    func test_sessionCredentialGetsReturnedIfSetAsDefaultForSpace() throws {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        expectChanges(storage.allCredentials.count, by: 1) {
+            storage.setDefaultCredential(credential, for: space)
+        }
+        XCTAssertEqual(storage.credentials(for: space)?.count, 1)
+
+        guard let credentials = storage.credentials(for: space),
+              let recovered = credentials[try credential.user.unwrapped()] else {
+            XCTFail("Credential not found in storage")
+            return
+        }
+        XCTAssertEqual(recovered, credential)
+
+        storage.remove(credential, for: space)
+    }
+
+    func test_sessionCredentialDoesNotGetReturnedIfSetAsDefaultForOtherSpace() {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+        let wrongSpace = URLProtectionSpace(host: "example2.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        storage.setDefaultCredential(credential, for: space)
+        XCTAssertNil(storage.defaultCredential(for: wrongSpace))
+
+        storage.remove(credential, for: space)
+    }
+
+    func test_sessionCredentialDoesNotGetReturnedWhenNotAddedAsDefault() {
+        let storage = URLCredentialStorage.shared
+
+        let credential1 = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let credential2 = URLCredential(user: "user2", password: "password2", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        storage.set(credential2, for: space)
+        storage.setDefaultCredential(credential1, for: space)
+        XCTAssertNotEqual(storage.defaultCredential(for: space), credential2)
+
+        storage.remove(credential2, for: space)
+        storage.remove(credential1, for: space)
+    }
+
+    func test_sessionCredentialCanBeRemovedFromSpace() {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        storage.set(credential, for: space)
+        expectChanges(storage.allCredentials.count, by: -1) {
+            storage.remove(credential, for: space)
+        }
+        XCTAssertNil(storage.credentials(for: space))
+
+        storage.remove(credential, for: space)
+    }
+
+    func test_sessionDefaultCredentialCanBeRemovedFromSpace() {
+        let storage = URLCredentialStorage.shared
+
+        let credential1 = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let credential2 = URLCredential(user: "user2", password: "password2", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        storage.setDefaultCredential(credential1, for: space)
+        storage.set(credential2, for: space)
+        storage.remove(credential1, for: space)
+        XCTAssertNil(storage.defaultCredential(for: space))
+        XCTAssertEqual(storage.credentials(for: space)?.count, 1)
+
+        storage.remove(credential2, for: space)
+    }
+
+    func test_synchronizableCredentialCanBeRemovedWithRightOptions() {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .synchronizable)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        storage.set(credential, for: space)
+        expectChanges(storage.allCredentials.count, by: -1) {
+            storage.remove(credential, for: space, options: [NSURLCredentialStorageRemoveSynchronizableCredentials: NSNumber(value: true)])
+        }
+    }
+
+    func test_synchronizableCredentialWillNotBeRemovedWithoutRightOptions() {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .synchronizable)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        storage.set(credential, for: space)
+
+        // No options, no removal of synchronizable credentials
+        storage.remove(credential, for: space)
+        XCTAssertEqual(storage.allCredentials.count, 1)
+
+        // Empty options, no removal of synchronizable credentials
+        storage.remove(credential, for: space, options: [:])
+        XCTAssertEqual(storage.allCredentials.count, 1)
+
+        // Invalid type, no removal of synchronizable credentials
+        storage.remove(credential, for: space, options: [NSURLCredentialStorageRemoveSynchronizableCredentials: "of course" as NSString])
+        XCTAssertEqual(storage.allCredentials.count, 1)
+
+        // False value, no removal of synchronizable credentials
+        storage.remove(credential, for: space, options: [NSURLCredentialStorageRemoveSynchronizableCredentials: NSNumber(value: false)])
+        XCTAssertEqual(storage.allCredentials.count, 1)
+
+        storage.remove(credential, for: space, options: [NSURLCredentialStorageRemoveSynchronizableCredentials: NSNumber(value: true)])
+    }
+
+    func test_storageCanRemoveArbitraryCredentialWithoutFailing() {
+        let storage = URLCredentialStorage.shared
+
+        let credential1 = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let credential2 = URLCredential(user: "user2", password: "password2", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        storage.set(credential2, for: space)
+        XCTAssertNoThrow(storage.remove(credential1, for: space))
+
+        storage.remove(credential2, for: space)
+    }
+
+    func test_storageWillNotSaveCredentialsWithoutPersistence() {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .none)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        expectNoChanges(storage.allCredentials.count) {
+            storage.set(credential, for: space)
+        }
+
+        storage.remove(credential, for: space)
+    }
+
+    // TODO: test that credentials without name/password are not saved. There's
+    // no support for other kind of credentials, so it cannot be tested right
+    // now.
+
+    // TODO: test that credentials without name/password can be set as default.
+    // There's no support for other kinds of credentials, so it cannot be tested
+    // right now.
+
+    func test_storageWillSendNotificationWhenAddingNewCredential() {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        let notificationReceived = expectation(description: "Notification Received")
+        let observer = NotificationCenter.default.addObserver(forName: .NSURLCredentialStorageChanged, object: storage, queue: nil) { _ in
+            notificationReceived.fulfill()
+        }
+
+        storage.set(credential, for: space)
+        waitForExpectations(timeout: 0)
+
+        NotificationCenter.default.removeObserver(observer)
+        storage.remove(credential, for: space)
+    }
+
+    func test_storageWillSendNotificationWhenAddingExistingCredentialToDifferentSpace() {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space1 = URLProtectionSpace(host: "example1.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+        let space2 = URLProtectionSpace(host: "example2.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        storage.set(credential, for: space1)
+
+        let notificationReceived = expectation(description: "Notification Received")
+        let observer = NotificationCenter.default.addObserver(forName: .NSURLCredentialStorageChanged, object: storage, queue: nil) { _ in
+            notificationReceived.fulfill()
+        }
+
+        storage.set(credential, for: space2)
+        waitForExpectations(timeout: 0)
+
+        NotificationCenter.default.removeObserver(observer)
+        storage.remove(credential, for: space1)
+        storage.remove(credential, for: space2)
+    }
+
+    func test_storageWillNotSendNotificationWhenAddingExistingCredential() {
+        let storage = URLCredentialStorage.shared
+
+        let credential1 = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let credential2 = URLCredential(user: "user1", password: "password1", persistence: .forSession) // intentially equal
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        storage.set(credential1, for: space)
+
+        let notificationReceived = expectation(description: "Notification Received")
+        notificationReceived.isInverted = true
+        let observer = NotificationCenter.default.addObserver(forName: .NSURLCredentialStorageChanged, object: storage, queue: nil) { _ in
+            notificationReceived.fulfill()
+        }
+
+        storage.set(credential2, for: space)
+        waitForExpectations(timeout: 0)
+
+        NotificationCenter.default.removeObserver(observer)
+        storage.remove(credential1, for: space)
+        storage.remove(credential2, for: space)
+    }
+
+    func test_storageWillSendNotificationWhenAddingNewDefaultCredential() {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        let notificationReceived = expectation(description: "Notification Received")
+        let observer = NotificationCenter.default.addObserver(forName: .NSURLCredentialStorageChanged, object: storage, queue: nil) { _ in
+            notificationReceived.fulfill()
+        }
+
+        storage.setDefaultCredential(credential, for: space)
+        waitForExpectations(timeout: 0)
+
+        NotificationCenter.default.removeObserver(observer)
+        storage.remove(credential, for: space)
+    }
+
+    func test_storageWillNotSendNotificationWhenAddingExistingDefaultCredential() {
+        let storage = URLCredentialStorage.shared
+
+        let credential1 = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let credential2 = URLCredential(user: "user1", password: "password1", persistence: .forSession) // intentionally equal
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        storage.setDefaultCredential(credential1, for: space)
+
+        let notificationReceived = expectation(description: "Notification Received")
+        notificationReceived.isInverted = true
+        let observer = NotificationCenter.default.addObserver(forName: .NSURLCredentialStorageChanged, object: storage, queue: nil) { _ in
+            notificationReceived.fulfill()
+        }
+
+        storage.setDefaultCredential(credential2, for: space)
+        waitForExpectations(timeout: 0)
+
+        NotificationCenter.default.removeObserver(observer)
+        storage.remove(credential1, for: space)
+        storage.remove(credential2, for: space)
+    }
+
+    func test_storageWillSendNotificationWhenAddingDifferentDefaultCredential() {
+        let storage = URLCredentialStorage.shared
+
+        let credential1 = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let credential2 = URLCredential(user: "user2", password: "password2", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        storage.setDefaultCredential(credential1, for: space)
+
+        let notificationReceived = expectation(description: "Notification Received")
+        let observer = NotificationCenter.default.addObserver(forName: .NSURLCredentialStorageChanged, object: storage, queue: nil) { _ in
+            notificationReceived.fulfill()
+        }
+
+        storage.setDefaultCredential(credential2, for: space)
+        waitForExpectations(timeout: 0)
+
+        NotificationCenter.default.removeObserver(observer)
+        storage.remove(credential1, for: space)
+        storage.remove(credential2, for: space)
+    }
+
+    func test_storageWillSendNotificationWhenRemovingExistingCredential() {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        storage.set(credential, for: space)
+
+        let notificationReceived = expectation(description: "Notification Received")
+        let observer = NotificationCenter.default.addObserver(forName: .NSURLCredentialStorageChanged, object: storage, queue: nil) { _ in
+            notificationReceived.fulfill()
+        }
+
+        storage.remove(credential, for: space)
+        waitForExpectations(timeout: 0)
+
+        NotificationCenter.default.removeObserver(observer)
+        storage.remove(credential, for: space)
+    }
+
+    func test_storageWillNotSendNotificationWhenRemovingExistingCredentialInOtherSpace() {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space1 = URLProtectionSpace(host: "example1.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+        let space2 = URLProtectionSpace(host: "example2.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        storage.set(credential, for: space1)
+
+        let notificationReceived = expectation(description: "Notification Received")
+        notificationReceived.isInverted = true
+        let observer = NotificationCenter.default.addObserver(forName: .NSURLCredentialStorageChanged, object: storage, queue: nil) { _ in
+            notificationReceived.fulfill()
+        }
+
+        storage.remove(credential, for: space2)
+        waitForExpectations(timeout: 0)
+
+        NotificationCenter.default.removeObserver(observer)
+        storage.remove(credential, for: space1)
+    }
+
+    func test_storageWillSendNotificationWhenRemovingDefaultNotification() {
+        let storage = URLCredentialStorage.shared
+
+        // TODO: this test will be better is we can create credentials without
+        // user/password, but currently is not possible. At least we are testing
+        // that only one notification is fired.
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        storage.setDefaultCredential(credential, for: space)
+
+        let notificationReceived = expectation(description: "Notification Received")
+        let observer = NotificationCenter.default.addObserver(forName: .NSURLCredentialStorageChanged, object: storage, queue: nil) { _ in
+            notificationReceived.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        storage.remove(credential, for: space)
+        waitForExpectations(timeout: 0)
+    }
+
+    func test_taskBasedGetCredentialsReturnsCredentialsForSpace() throws {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        let urlSession = URLSession.shared
+        let task = urlSession.dataTask(with: try URL(string: "http://example.com/").unwrapped())
+
+        storage.set(credential, for: space)
+
+        let completionCallbackCalled = expectation(description: "Completion callback called")
+        storage.getCredentials(for: space, task: task) { credentials in
+            completionCallbackCalled.fulfill()
+            XCTAssertNotNil(credentials)
+            XCTAssertEqual(credentials?["user1"], credential)
+        }
+
+        waitForExpectations(timeout: 0)
+
+        storage.remove(credential, for: space)
+    }
+
+    func test_taskBasedSetCredentialStoresGivenCredentials() throws {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        let urlSession = URLSession.shared
+        let task = urlSession.dataTask(with: try URL(string: "http://example.com/").unwrapped())
+
+        storage.set(credential, for: space, task: task)
+
+        guard let credentials = storage.credentials(for: space),
+              let recovered = credentials[try credential.user.unwrapped()] else {
+            XCTFail("Credential not found in storage")
+            return
+        }
+        XCTAssertEqual(recovered, credential)
+
+        storage.remove(credential, for: space)
+    }
+
+    func test_taskBasedRemoveCredentialDeletesCredentialsFromSpace() throws {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        let urlSession = URLSession.shared
+        let task = urlSession.dataTask(with: try URL(string: "http://example.com/").unwrapped())
+
+        storage.set(credential, for: space)
+
+        expectChanges(storage.allCredentials.count, by: -1) {
+            storage.remove(credential, for: space, options: [:], task: task)
+        }
+    }
+
+    func test_taskBasedGetDefaultCredentialReturnsTheDefaultCredential() throws {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        let urlSession = URLSession.shared
+        let task = urlSession.dataTask(with: try URL(string: "http://example.com/").unwrapped())
+
+        storage.setDefaultCredential(credential, for: space)
+
+        let completionCallbackCalled = expectation(description: "Completion callback called")
+        storage.getDefaultCredential(for: space, task: task) {
+            completionCallbackCalled.fulfill()
+            XCTAssertEqual($0, credential)
+        }
+
+        waitForExpectations(timeout: 0)
+
+        storage.remove(credential, for: space)
+    }
+
+    func test_taskBasedSetDefaultCredentialStoresTheDefaultCredential() throws {
+        let storage = URLCredentialStorage.shared
+
+        let credential = URLCredential(user: "user1", password: "password1", persistence: .forSession)
+        let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
+
+        let urlSession = URLSession.shared
+        let task = urlSession.dataTask(with: try URL(string: "http://example.com/").unwrapped())
+
+        expectChanges(storage.allCredentials.count, by: 1) {
+            storage.setDefaultCredential(credential, for: space, task: task)
+        }
+
+        XCTAssertEqual(storage.defaultCredential(for: space), credential)
+
+        storage.remove(credential, for: space)
+    }
+}

--- a/TestFoundation/Utilities.swift
+++ b/TestFoundation/Utilities.swift
@@ -187,6 +187,28 @@ func expectEqual(
     XCTAssertTrue(expected == actual, message(), file: file, line: line)
 }
 
+func expectChanges<T: BinaryInteger>(_ check: @autoclosure () -> T, by difference: T? = nil, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line, _ expression: () throws -> ()) rethrows {
+    let valueBefore = check()
+    try expression()
+    let valueAfter = check()
+    if let difference = difference {
+        XCTAssertEqual(valueAfter, valueBefore + difference, message(), file: file, line: line)
+    } else {
+        XCTAssertNotEqual(valueAfter, valueBefore, message(), file: file, line: line)
+    }
+}
+
+func expectNoChanges<T: BinaryInteger>(_ check: @autoclosure () -> T, by difference: T? = nil, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line, _ expression: () throws -> ()) rethrows {
+    let valueBefore = check()
+    try expression()
+    let valueAfter = check()
+    if let difference = difference {
+        XCTAssertNotEqual(valueAfter, valueBefore + difference, message(), file: file, line: line)
+    } else {
+        XCTAssertEqual(valueAfter, valueBefore, message(), file: file, line: line)
+    }
+}
+
 extension Fixture where ValueType: NSObject & NSCoding {
     func loadEach(handler: (ValueType, FixtureVariant) throws -> Void) throws {
         try self.loadEach(fixtureRepository: try testBundle().url(forResource: "Fixtures", withExtension: nil).unwrapped(), handler: handler)


### PR DESCRIPTION
A basic implementation of URLCredentialStorage, mainly oriented to
credentials for the session. It is an in-memory storage and ignores any
usage of permantent or synchronizable persistency. This should cover
many usage cases, and should allow to built on top of it.

Includes tests.

**Known differences with macOS:**

I tried to run the set of test against macOS (10.14.5) and found a couple of weird results (I run the tests in a playground, so that might cause interesting behaviours).

- `.permanent` credentials are only stored in-memory (so they are equivalent to `.forSession`). Each operating system might have their own permanent storage, so each implementation might be different (or not exist at all). This can be tackled after this basic implementation is reviewed, and in a per-OS strategy.
- Seems that `URLCredentialStorage()` in macOS will not return a storage that can store credentials (not even `.forSession` ones). In the tests I decided to use `URLCredentialStorage.shared` since it will work on macOS, but makes the tests harder to read, because you have to implicitely clean.
- Seems that setting a credential for a protection space, even if it is not through `setDefaultCredential(…)`, sets it as default.
- I could not get the change notifications to happen in macOS. I added the notifications nonetheless where I think they should happen.
- I could not add a `.synchronizable` credential in macOS. I imagine the playground I was using might not have the right permissions for the iCloud Keychain. However, in the implementation, the `.synchronizable` credentials are added to the in-memory storage, and are removed only when providing the special key.
