### PR TITLE
Check renameat2() is available on Linux

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -59,6 +59,7 @@
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #elif TARGET_OS_LINUX
+#include <errno.h>
 #include <features.h>
 
 #if __GLIBC_PREREQ(2, 28) == 0
@@ -594,10 +595,21 @@ _stat_with_btime(const char *filename, struct stat *buffer, struct timespec *bti
 #endif // __NR_statx
 
 static unsigned int const _CF_renameat2_RENAME_EXCHANGE = 1 << 1;
-static int _CF_renameat2(int olddirfd, const char *_Nonnull oldpath,
-                            int newdirfd, const char *_Nonnull newpath, unsigned int flags) {
+#ifdef SYS_renameat2
+static _Bool const _CFHasRenameat2 = 1;
+static inline int _CF_renameat2(int olddirfd, const char *_Nonnull oldpath,
+                                int newdirfd, const char *_Nonnull newpath, unsigned int flags) {
     return syscall(SYS_renameat2, olddirfd, oldpath, newdirfd, newpath, flags);
 }
+#else
+static _Bool const _CFHasRenameat2 = 0;
+static inline int _CF_renameat2(int olddirfd, const char *_Nonnull oldpath,
+                                int newdirfd, const char *_Nonnull newpath, unsigned int flags) {
+    return ENOSYS;
+}
+#endif // __SYS_renameat2
+
+
 #endif // TARGET_OS_LINUX
 
 #if __HAS_STATX

--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -841,6 +841,12 @@ open class FileManager : NSObject {
         let requiredVersion = OperatingSystemVersion(majorVersion: 4, minorVersion: 11, patchVersion: 0)
         return ProcessInfo.processInfo.isOperatingSystemAtLeast(requiredVersion)
     }()
+
+    // renameat2() is only supported by Linux kernels >= 3.15
+    internal lazy var kernelSupportsRenameat2: Bool = {
+        let requiredVersion = OperatingSystemVersion(majorVersion: 3, minorVersion: 15, patchVersion: 0)
+        return ProcessInfo.processInfo.isOperatingSystemAtLeast(requiredVersion)
+    }()
 #endif
 
     /* -contentsEqualAtPath:andPath: does not take into account data stored in the resource fork or filesystem extended attributes.


### PR DESCRIPTION
Add a check that the system call is defined and the kernel version is high enough.