### PR TITLE
Fix _destinationOfSymbolicLink behaviour on Windows

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -620,6 +620,32 @@ static inline int _CF_renameat2(int olddirfd, const char *_Nonnull oldpath,
 
 #if TARGET_OS_WIN32
 CF_EXPORT void __CFSocketInitializeWinSock(void);
+
+typedef struct _REPARSE_DATA_BUFFER {
+    ULONG  ReparseTag;
+    USHORT ReparseDataLength;
+    USHORT Reserved;
+    union {
+        struct {
+            USHORT SubstituteNameOffset;
+            USHORT SubstituteNameLength;
+            USHORT PrintNameOffset;
+            USHORT PrintNameLength;
+            ULONG  Flags;
+            WCHAR  PathBuffer[1];
+        } SymbolicLinkReparseBuffer;
+        struct {
+            USHORT SubstituteNameOffset;
+            USHORT SubstituteNameLength;
+            USHORT PrintNameOffset;
+            USHORT PrintNameLength;
+            WCHAR  PathBuffer[1];
+        } MountPointReparseBuffer;
+        struct {
+            UCHAR DataBuffer[1];
+        } GenericReparseBuffer;
+    } DUMMYUNIONNAME;
+} REPARSE_DATA_BUFFER;
 #endif
 
 _CF_EXPORT_SCOPE_END


### PR DESCRIPTION
_destinationOfSymbolic should return a relative path if the symlink is a
relative symlink. Now instead of returning the resolved symlink path, we
read the ReparsePoint to get the path it contains.