### PR TITLE
Parity: URLCache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -518,6 +518,7 @@ if(ENABLE_TESTING)
                          TestFoundation/TestTimeZone.swift
                          TestFoundation/TestUnitConverter.swift
                          TestFoundation/TestUnit.swift
+                         TestFoundation/TestURLCache.swift
                          TestFoundation/TestURLCredential.swift
                          TestFoundation/TestURLProtectionSpace.swift
                          TestFoundation/TestURLProtocol.swift

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1513A8432044893F00539722 /* FileManager_XDG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1513A8422044893F00539722 /* FileManager_XDG.swift */; };
 		1520469B1D8AEABE00D02E36 /* HTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1520469A1D8AEABE00D02E36 /* HTTPServer.swift */; };
 		1539391422A07007006DFF4F /* TestCachedURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1539391322A07007006DFF4F /* TestCachedURLResponse.swift */; };
+		1539391522A07160006DFF4F /* TestNSSortDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152EF3932283457B001E1269 /* TestNSSortDescriptor.swift */; };
 		153CC8352215E00200BFE8F3 /* ScannerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153CC8322214C3D100BFE8F3 /* ScannerAPI.swift */; };
 		153E951120111DC500F250BE /* CFKnownLocations.h in Headers */ = {isa = PBXBuildFile; fileRef = 153E950F20111DC500F250BE /* CFKnownLocations.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		153E951220111DC500F250BE /* CFKnownLocations.c in Sources */ = {isa = PBXBuildFile; fileRef = 153E951020111DC500F250BE /* CFKnownLocations.c */; };
@@ -31,6 +32,7 @@
 		1578DA11212B407B003C9516 /* CFString_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1578DA10212B407B003C9516 /* CFString_Internal.h */; };
 		1578DA13212B4C35003C9516 /* CFOverflow.h in Headers */ = {isa = PBXBuildFile; fileRef = 1578DA12212B4C35003C9516 /* CFOverflow.h */; };
 		1578DA15212B6F33003C9516 /* CFCollections_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1578DA14212B6F33003C9516 /* CFCollections_Internal.h */; };
+		1581706322B1A29100348861 /* TestURLCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1581706222B1A29100348861 /* TestURLCache.swift */; };
 		158BCCAA2220A12600750239 /* TestDateIntervalFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158BCCA92220A12600750239 /* TestDateIntervalFormatter.swift */; };
 		158BCCAD2220A18F00750239 /* CFDateIntervalFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 158BCCAB2220A18F00750239 /* CFDateIntervalFormatter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		158BCCAE2220A18F00750239 /* CFDateIntervalFormatter.c in Sources */ = {isa = PBXBuildFile; fileRef = 158BCCAC2220A18F00750239 /* CFDateIntervalFormatter.c */; };
@@ -636,6 +638,7 @@
 		1578DA10212B407B003C9516 /* CFString_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFString_Internal.h; sourceTree = "<group>"; };
 		1578DA12212B4C35003C9516 /* CFOverflow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFOverflow.h; sourceTree = "<group>"; };
 		1578DA14212B6F33003C9516 /* CFCollections_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFCollections_Internal.h; sourceTree = "<group>"; };
+		1581706222B1A29100348861 /* TestURLCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestURLCache.swift; sourceTree = "<group>"; };
 		158BCCA92220A12600750239 /* TestDateIntervalFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDateIntervalFormatter.swift; sourceTree = "<group>"; };
 		158BCCAB2220A18F00750239 /* CFDateIntervalFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFDateIntervalFormatter.h; sourceTree = "<group>"; };
 		158BCCAC2220A18F00750239 /* CFDateIntervalFormatter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFDateIntervalFormatter.c; sourceTree = "<group>"; };
@@ -1756,6 +1759,7 @@
 				84BA558D1C16F90900F48C54 /* TestTimeZone.swift */,
 				EA66F6431BF1619600136161 /* TestURL.swift */,
 				F9E0BB361CA70B8000F7FF3C /* TestURLCredential.swift */,
+				1581706222B1A29100348861 /* TestURLCache.swift */,
 				83712C8D1C1684900049AD49 /* TestNSURLRequest.swift */,
 				DAA79BD820D42C07004AF044 /* TestURLProtectionSpace.swift */,
 				7A7D6FBA1C16439400957E2E /* TestURLResponse.swift */,
@@ -2814,7 +2818,6 @@
 				B90C57BB1EEEEA5A005208AE /* TestFileManager.swift in Sources */,
 				A058C2021E529CF100B07AA1 /* TestMassFormatter.swift in Sources */,
 				5B13B3381C582D4C00651CE2 /* TestNotificationQueue.swift in Sources */,
-				152EF3942283457C001E1269 /* TestNSSortDescriptor.swift in Sources */,
 				CC5249C01D341D23007CB54D /* TestUnitConverter.swift in Sources */,
 				5B13B3331C582D4C00651CE2 /* TestJSONSerialization.swift in Sources */,
 				5B13B33C1C582D4C00651CE2 /* TestNSOrderedSet.swift in Sources */,
@@ -2899,8 +2902,10 @@
 				5B13B3271C582D4C00651CE2 /* TestNSArray.swift in Sources */,
 				5B13B3461C582D4C00651CE2 /* TestProcess.swift in Sources */,
 				555683BD1C1250E70041D4C6 /* TestUserDefaults.swift in Sources */,
+				1539391522A07160006DFF4F /* TestNSSortDescriptor.swift in Sources */,
 				DCA8120B1F046D13000D0C86 /* TestCodable.swift in Sources */,
 				7900433B1CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift in Sources */,
+				1581706322B1A29100348861 /* TestURLCache.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -94,6 +94,13 @@ open class NSKeyedArchiver : NSCoder {
     /// The archiver’s delegate.
     open weak var delegate: NSKeyedArchiverDelegate?
     
+    /// The latest error.
+    private var _error: Error?
+    open override var error: Error? {
+        get { return _error }
+        set { _error = newValue }
+    }
+    
     /// The format in which the receiver encodes its data.
     ///
     /// The available formats are `xml` and `binary`.

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -79,7 +79,11 @@ open class NSKeyedUnarchiver : NSCoder {
         unarchiver.requiresSecureCoding = true
         unarchiver.decodingFailurePolicy = .setErrorAndReturn
         
-        return try unarchiver.decodeObject(of: classes, forKey: NSKeyedArchiveRootObjectKey)
+        let result = unarchiver.decodeObject(of: classes, forKey: NSKeyedArchiveRootObjectKey)
+        if let error = unarchiver.error {
+            throw error
+        }
+        return result
     }
     
     @available(swift, deprecated: 9999, renamed: "unarchivedObject(ofClass:from:)")

--- a/Foundation/URLResponse.swift
+++ b/Foundation/URLResponse.swift
@@ -32,21 +32,20 @@ open class URLResponse : NSObject, NSSecureCoding, NSCopying {
             preconditionFailure("Unkeyed coding is unsupported.")
         }
         
-        if let encodedUrl = aDecoder.decodeObject(forKey: "NS.url") as? NSURL {
-            self.url = encodedUrl as URL
-        }
+        guard let nsurl = aDecoder.decodeObject(of: NSURL.self, forKey: "NS.url") else { return nil }
+        self.url = nsurl as URL
         
-        if let encodedMimeType = aDecoder.decodeObject(forKey: "NS.mimeType") as? NSString {
-            self.mimeType = encodedMimeType as String
-        }
+        
+        let nsmimetype = aDecoder.decodeObject(of: NSString.self, forKey: "NS.mimeType")
+        self.mimeType = nsmimetype as String?
         
         self.expectedContentLength = aDecoder.decodeInt64(forKey: "NS.expectedContentLength")
         
-        if let encodedEncodingName = aDecoder.decodeObject(forKey: "NS.textEncodingName") as? NSString {
+        if let encodedEncodingName = aDecoder.decodeObject(of: NSString.self, forKey: "NS.textEncodingName") {
             self.textEncodingName = encodedEncodingName as String
         }
         
-        if let encodedFilename = aDecoder.decodeObject(forKey: "NS.suggestedFilename") as? NSString {
+        if let encodedFilename = aDecoder.decodeObject(of: NSString.self, forKey: "NS.suggestedFilename") {
             self.suggestedFilename = encodedFilename as String
         }
     }
@@ -203,8 +202,8 @@ open class HTTPURLResponse : URLResponse {
         
         self.statusCode = aDecoder.decodeInteger(forKey: "NS.statusCode")
         
-        if let encodedHeaders = aDecoder.decodeObject(forKey: "NS.allHeaderFields") as? NSDictionary {
-            self.allHeaderFields = encodedHeaders as! [AnyHashable: Any]
+        if aDecoder.containsValue(forKey: "NS.allHeaderFields") {
+            self.allHeaderFields = aDecoder.decodeObject(of: NSDictionary.self, forKey: "NS.allHeaderFields") as! [AnyHashable: Any]
         } else {
             self.allHeaderFields = [:]
         }
@@ -216,7 +215,7 @@ open class HTTPURLResponse : URLResponse {
         super.encode(with: aCoder) //Will fail if .allowsKeyedCoding == false
         
         aCoder.encode(self.statusCode, forKey: "NS.statusCode")
-        aCoder.encode(self.allHeaderFields._bridgeToObjectiveC(), forKey: "NS.allHeaderFields")
+        aCoder.encode(self.allHeaderFields as NSDictionary, forKey: "NS.allHeaderFields")
         
     }
     

--- a/TestFoundation/TestURLCache.swift
+++ b/TestFoundation/TestURLCache.swift
@@ -1,0 +1,186 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+class TestURLCache : XCTestCase {
+    
+    let aBit = 2 * 1024 /* 2 KB */
+    let lots = 200 * 1024 * 1024 /* 200 MB */
+    
+    func testStorageRoundtrip() throws {
+        let cache = try self.cache(memoryCapacity: lots, diskCapacity: lots)
+
+        let (request, response) = try cachePair(for: "https://google.com/", ofSize: aBit, storagePolicy: .allowed)
+        cache.storeCachedResponse(response, for: request)
+
+        let storedResponse = cache.cachedResponse(for: request)
+        XCTAssertEqual(response, storedResponse)
+    }
+    
+    func testStoragePolicy() throws {
+        do {
+            let cache = try self.cache(memoryCapacity: lots, diskCapacity: lots)
+
+            let (request, response) = try cachePair(for: "https://google.com/", ofSize: aBit, storagePolicy: .allowed)
+            cache.storeCachedResponse(response, for: request)
+            
+            XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: writableTestDirectoryURL.path).count, 1)
+            XCTAssertNotNil(cache.cachedResponse(for: request))
+        }
+        
+        try FileManager.default.removeItem(at: writableTestDirectoryURL)
+        
+        do {
+            let cache = try self.cache(memoryCapacity: lots, diskCapacity: lots)
+            
+            let (request, response) = try cachePair(for: "https://google.com/", ofSize: aBit, storagePolicy: .allowedInMemoryOnly)
+            cache.storeCachedResponse(response, for: request)
+            
+            XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: writableTestDirectoryURL.path).count, 0)
+            XCTAssertNotNil(cache.cachedResponse(for: request))
+        }
+        
+        try FileManager.default.removeItem(at: writableTestDirectoryURL)
+        
+        do {
+            let cache = try self.cache(memoryCapacity: lots, diskCapacity: lots)
+            
+            let (request, response) = try cachePair(for: "https://google.com/", ofSize: aBit, storagePolicy: .notAllowed)
+            cache.storeCachedResponse(response, for: request)
+            
+            XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: writableTestDirectoryURL.path).count, 0)
+            XCTAssertNil(cache.cachedResponse(for: request))
+        }
+        
+        try FileManager.default.removeItem(at: writableTestDirectoryURL)
+    }
+    
+    func testNoDiskUsageIfDisabled() throws {
+        let cache = try self.cache(memoryCapacity: lots, diskCapacity: 0)
+        let (request, response) = try cachePair(for: "https://google.com/", ofSize: aBit)
+        cache.storeCachedResponse(response, for: request)
+        
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: writableTestDirectoryURL.path).count, 0)
+        XCTAssertNotNil(cache.cachedResponse(for: request))
+    }
+    
+    func testShrinkingDiskCapacityEvictsItems() throws {
+        let cache = try self.cache(memoryCapacity: lots, diskCapacity: lots)
+        
+        let urls = [ "https://apple.com/",
+                     "https://google.com/",
+                     "https://facebook.com/" ]
+        
+        for (request, response) in try urls.map({ try cachePair(for: $0, ofSize: aBit) }) {
+            cache.storeCachedResponse(response, for: request)
+        }
+        
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: writableTestDirectoryURL.path).count, 3)
+        for url in urls {
+            XCTAssertNotNil(cache.cachedResponse(for: URLRequest(url: URL(string: url)!)))
+        }
+        
+        cache.diskCapacity = 0
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: writableTestDirectoryURL.path).count, 0)
+        for url in urls {
+            XCTAssertNotNil(cache.cachedResponse(for: URLRequest(url: URL(string: url)!)))
+        }
+    }
+    
+    func testNoMemoryUsageIfDisabled() throws {
+        let cache = try self.cache(memoryCapacity: 0, diskCapacity: lots)
+        let (request, response) = try cachePair(for: "https://google.com/", ofSize: aBit)
+        cache.storeCachedResponse(response, for: request)
+        
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: writableTestDirectoryURL.path).count, 1)
+        XCTAssertNotNil(cache.cachedResponse(for: request))
+        
+        // Ensure that the fulfillment doesn't come from memory:
+        try FileManager.default.removeItem(at: writableTestDirectoryURL)
+        try FileManager.default.createDirectory(at: writableTestDirectoryURL, withIntermediateDirectories: true)
+        
+        XCTAssertNil(cache.cachedResponse(for: request))
+    }
+    
+    func testShrinkingMemoryCapacityEvictsItems() throws {
+        let cache = try self.cache(memoryCapacity: lots, diskCapacity: lots)
+        
+        let urls = [ "https://apple.com/",
+                     "https://google.com/",
+                     "https://facebook.com/" ]
+        
+        for (request, response) in try urls.map({ try cachePair(for: $0, ofSize: aBit) }) {
+            cache.storeCachedResponse(response, for: request)
+        }
+        
+        // Ensure these can be fulfilled from memory:
+        try FileManager.default.removeItem(at: writableTestDirectoryURL)
+        try FileManager.default.createDirectory(at: writableTestDirectoryURL, withIntermediateDirectories: true)
+
+        for url in urls {
+            XCTAssertNotNil(cache.cachedResponse(for: URLRequest(url: URL(string: url)!)))
+        }
+        
+        // And evict all:
+        cache.memoryCapacity = 0
+
+        for url in urls {
+            XCTAssertNil(cache.cachedResponse(for: URLRequest(url: URL(string: url)!)))
+        }
+    }
+    
+    // -----
+    
+    static var allTests: [(String, (TestURLCache) -> () throws -> Void)] {
+        return [
+            ("testStorageRoundtrip", testStorageRoundtrip),
+            ("testStoragePolicy", testStoragePolicy),
+            ("testNoDiskUsageIfDisabled", testNoDiskUsageIfDisabled),
+            ("testShrinkingDiskCapacityEvictsItems", testShrinkingDiskCapacityEvictsItems),
+            ("testNoMemoryUsageIfDisabled", testNoMemoryUsageIfDisabled),
+            ("testShrinkingMemoryCapacityEvictsItems", testShrinkingMemoryCapacityEvictsItems),
+        ]
+    }
+    
+    // -----
+    
+    func cache(memoryCapacity: Int = 0, diskCapacity: Int = 0) throws -> URLCache {
+        try FileManager.default.createDirectory(at: writableTestDirectoryURL, withIntermediateDirectories: true)
+        return URLCache(memoryCapacity: memoryCapacity, diskCapacity: diskCapacity, diskPath: writableTestDirectoryURL.path)
+    }
+    
+    func cachePair(for urlString: String, ofSize size: Int, storagePolicy: URLCache.StoragePolicy = .allowed) throws -> (URLRequest, CachedURLResponse) {
+        let url = try URL(string: urlString).unwrapped()
+        let request = URLRequest(url: url)
+        let response = try HTTPURLResponse(url: url, statusCode: 200, httpVersion: "1.1", headerFields: [:]).unwrapped()
+        return (request, CachedURLResponse(response: response, data: Data(count: size), storagePolicy: storagePolicy))
+    }
+    
+    var writableTestDirectoryURL: URL!
+    
+    override func setUp() {
+        super.setUp()
+        
+        let pid = ProcessInfo.processInfo.processIdentifier
+        writableTestDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("org.swift.TestFoundation.TestURLCache.\(pid)")
+    }
+    
+    override func tearDown() {
+        if let directoryURL = writableTestDirectoryURL,
+            (try? FileManager.default.attributesOfItem(atPath: directoryURL.path)) != nil {
+            do {
+                try FileManager.default.removeItem(at: directoryURL)
+            } catch {
+                NSLog("Could not remove test directory at URL \(directoryURL): \(error)")
+            }
+        }
+        
+        super.tearDown()
+    }
+    
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -82,6 +82,7 @@ var allTestCases = [
     testCase(TestTimer.allTests),
     testCase(TestTimeZone.allTests),
     testCase(TestURL.allTests),
+    testCase(TestURLCache.allTests),
     testCase(TestURLComponents.allTests),
     testCase(TestURLCredential.allTests),
     testCase(TestURLProtectionSpace.allTests),


### PR DESCRIPTION
This strictly implements the class. We need a separate adoption patch to hook it up to `_HTTPProtocol`, `URLSession` and `URLSessionConfiguration`. It has on-disk and in-memory caching. This also fixes a couple issues with archiving.