### PR TITLE
Disable test_ftpDataTaskDelegate crashing occasionally in CI

### DIFF
--- a/TestFoundation/TestURLSessionFTP.swift
+++ b/TestFoundation/TestURLSessionFTP.swift
@@ -15,7 +15,8 @@ class TestURLSessionFTP : LoopbackFTPServerTest {
         return [
             /* ⚠️ */ ("test_ftpDataTask", testExpectedToFail(test_ftpDataTask,
             /* ⚠️ */     "<https://bugs.swift.org/browse/SR-10922>  non-deterministic SEGFAULT in TestURLSessionFTP.test_ftpDataTask")),
-            ("test_ftpDataTaskDelegate", test_ftpDataTaskDelegate),
+            /* ⚠️ */ ("test_ftpDataTaskDelegate", testExpectedToFail(test_ftpDataTaskDelegate,
+            /* ⚠️ */     "<https://bugs.swift.org/browse/SR-10922>  non-deterministic SEGFAULT in TestURLSessionFTP.test_ftpDataTask")),
         ]
     }
 


### PR DESCRIPTION
Looks like the same issue as test_ftpDataTask, so marking with the same cause.

https://bugs.swift.org/browse/SR-10922