### PR TITLE
SR-10921: Fix bugs related to XML Namespace.

### DIFF
--- a/Foundation/XMLNode.swift
+++ b/Foundation/XMLNode.swift
@@ -314,7 +314,7 @@ open class XMLNode: NSObject, NSCopying {
     open var name: String? {
         get {
             if case .namespace = kind {
-                return _CFXMLNamespaceCopyPrefix(_xmlNode)?._swiftObject
+                return _CFXMLNamespaceCopyPrefix(_xmlNode)?._swiftObject ?? ""
             }
 
             return _CFXMLNodeCopyName(_xmlNode)?._swiftObject


### PR DESCRIPTION
`struct _xmlNode` has two members related to namespace: `ns` and `nsDef`. CoreFoundation uses `ns` instead of `nsDef` in some situations and that causes some bugs such as [SR-10921](https://bugs.swift.org/browse/SR-10921). This PR fixes the issue.

Resolves [SR-10921](https://bugs.swift.org/browse/SR-10921).
(Partially resolves [SR-10764](https://bugs.swift.org/browse/SR-10764).)
