### PR TITLE
Update NumberFormatter for better default values and Darwin compatibility

### DIFF
--- a/Foundation/ByteCountFormatter.swift
+++ b/Foundation/ByteCountFormatter.swift
@@ -350,16 +350,14 @@ open class ByteCountFormatter : Formatter {
                 let result: String
                 //Need to add in an extra case for negative numbers as NumberFormatter formats 0.005 to 0 rather than
                 // 0.01
+                numberFormatter.minimumFractionDigits = 0
+                numberFormatter.maximumFractionDigits = 2
                 if bytes < 0 {
                     let negBytes = round(bytes * 100) / 100
                     result = numberFormatter.string(from: NSNumber(value: negBytes))!
                 } else {
-                    numberFormatter.minimumFractionDigits = 0
-                    numberFormatter.maximumFractionDigits = 2
                     result = numberFormatter.string(from: NSNumber(value: bytes))!
                 }
-                
-                
                 return partsToIncludeFor(value: result, unit: unit)
             }
         //zeroPadsFractionDigits is false, isAdaptive is false

--- a/Foundation/NumberFormatter.swift
+++ b/Foundation/NumberFormatter.swift
@@ -121,34 +121,47 @@ open class NumberFormatter : Formatter {
     }
 
     private func _setFormatterAttributes(_ formatter: CFNumberFormatter) {
-        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterCurrencyCode, value: _currencyCode?._cfObject)
+        if numberStyle == .currency {
+          let symbol = _currencySymbol ?? _currencyCode ?? locale.currencySymbol ?? locale.currencyCode
+           _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterCurrencySymbol, value: symbol?._cfObject)
+       }
+       if numberStyle == .currencyISOCode {
+          let code = _currencyCode ?? _currencySymbol ?? locale.currencyCode ?? locale.currencySymbol
+           _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterCurrencyCode, value: code?._cfObject)
+        }
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterDecimalSeparator, value: _decimalSeparator?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterCurrencyDecimalSeparator, value: _currencyDecimalSeparator?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterAlwaysShowDecimalSeparator, value: _alwaysShowsDecimalSeparator._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterGroupingSeparator, value: _groupingSeparator?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterUseGroupingSeparator, value: _usesGroupingSeparator._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterUseGroupingSeparator, value: usesGroupingSeparator._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterPercentSymbol, value: _percentSymbol?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterZeroSymbol, value: _zeroSymbol?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterNaNSymbol, value: _notANumberSymbol?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterInfinitySymbol, value: _positiveInfinitySymbol._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMinusSign, value: _minusSign?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterPlusSign, value: _plusSign?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterCurrencySymbol, value: _currencySymbol?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterExponentSymbol, value: _exponentSymbol?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMinIntegerDigits, value: minimumIntegerDigits._bridgeToObjectiveC()._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMaxIntegerDigits, value: _maximumIntegerDigits._bridgeToObjectiveC()._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMinFractionDigits, value: _minimumFractionDigits._bridgeToObjectiveC()._cfObject)
-        if _minimumFractionDigits <= 0 {
-            _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMaxFractionDigits, value: _maximumFractionDigits._bridgeToObjectiveC()._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMinIntegerDigits, value: _minimumIntegerDigits?._bridgeToObjectiveC()._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMaxIntegerDigits, value: _maximumIntegerDigits?._bridgeToObjectiveC()._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMinFractionDigits, value: _minimumFractionDigits?._bridgeToObjectiveC()._cfObject)
+        if minimumFractionDigits <= 0 {
+            _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMaxFractionDigits, value: maximumFractionDigits._bridgeToObjectiveC()._cfObject)
         }
-        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterGroupingSize, value: _groupingSize._bridgeToObjectiveC()._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterGroupingSize, value: groupingSize._bridgeToObjectiveC()._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterSecondaryGroupingSize, value: _secondaryGroupingSize._bridgeToObjectiveC()._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterRoundingMode, value: _roundingMode.rawValue._bridgeToObjectiveC()._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterRoundingIncrement, value: _roundingIncrement?._cfObject)
+
+        var width: Int = 0
+        CFNumberGetValue(_formatWidth._bridgeToObjectiveC()._cfObject, kCFNumberLongType, &width)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterFormatWidth, value: _formatWidth._bridgeToObjectiveC()._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterPaddingCharacter, value: _paddingCharacter?._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterPaddingPosition, value: _paddingPosition.rawValue._bridgeToObjectiveC()._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMultiplier, value: _multiplier?._cfObject)
+        if width > 0 {
+            _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterPaddingCharacter, value: _paddingCharacter?._cfObject)
+            _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterPaddingPosition, value: _paddingPosition.rawValue._bridgeToObjectiveC()._cfObject)
+        } else {
+           _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterPaddingCharacter, value: ""._cfObject)
+        }
+        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMultiplier, value: multiplier?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterPositivePrefix, value: _positivePrefix?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterPositiveSuffix, value: _positiveSuffix?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterNegativePrefix, value: _negativePrefix?._cfObject)
@@ -157,10 +170,10 @@ open class NumberFormatter : Formatter {
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterInternationalCurrencySymbol, value: _internationalCurrencySymbol?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterCurrencyGroupingSeparator, value: _currencyGroupingSeparator?._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterIsLenient, value: _lenient._cfObject)
-        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterUseSignificantDigits, value: _usesSignificantDigits._cfObject)
-        if _usesSignificantDigits {
-            _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMinSignificantDigits, value: _minimumSignificantDigits._bridgeToObjectiveC()._cfObject)
-            _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMaxSignificantDigits, value: _maximumSignificantDigits._bridgeToObjectiveC()._cfObject)
+        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterUseSignificantDigits, value: usesSignificantDigits._cfObject)
+        if usesSignificantDigits {
+            _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMinSignificantDigits, value: minimumSignificantDigits._bridgeToObjectiveC()._cfObject)
+            _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMaxSignificantDigits, value: maximumSignificantDigits._bridgeToObjectiveC()._cfObject)
         }
     }
 
@@ -174,8 +187,105 @@ open class NumberFormatter : Formatter {
         return CFNumberFormatterCopyProperty(formatter, attributeName) as? String
     }
 
+    // Attributes of a NumberFormatter. Many attributes have default values but if they are set by the caller
+    // the new value needs to be retained even if the .numberStyle is changed. Attributes are backed by an optional
+    // to indicate to use the default value (if nil) or the caller-supplied value (if not nil).
+    private func defaultMinimumIntegerDigits() -> Int {
+        switch numberStyle {
+        case .none, .ordinal, .spellOut, .currencyPlural, .scientific:
+            return 0
 
-    // Attributes of a NumberFormatter
+        case .currency, .currencyISOCode, .currencyAccounting, .decimal, .percent:
+            return 1
+        }
+    }
+
+    private func defaultMaximumIntegerDigits() -> Int {
+        switch numberStyle {
+        case .none:
+            return 42
+
+        case .ordinal, .spellOut, .currencyPlural:
+            return 0
+
+        case .currency, .currencyISOCode, .currencyAccounting, .decimal, .percent:
+            return 2_000_000_000
+
+        case .scientific:
+            return 1
+        }
+    }
+
+    private func defaultMinimumFractionDigits() -> Int {
+        switch numberStyle {
+        case .none, .ordinal, .spellOut, .currencyPlural, .decimal, .percent, .scientific:
+            return 0
+
+        case .currency, .currencyISOCode, .currencyAccounting:
+            return 2
+        }
+    }
+
+    private func defaultMaximumFractionDigits() -> Int {
+        switch numberStyle {
+        case .none, .ordinal, .spellOut, .currencyPlural, .percent, .scientific:
+            return 0
+
+        case .currency, .currencyISOCode, .currencyAccounting:
+            return 2
+
+        case .decimal:
+            return 3
+        }
+    }
+
+    private func defaultMinimumSignificantDigits() -> Int {
+        switch numberStyle {
+        case .ordinal, .spellOut, .currencyPlural:
+            return 0
+
+        case .currency, .none, .currencyISOCode, .currencyAccounting, .decimal, .percent, .scientific:
+            return 1
+        }
+    }
+
+    private func defaultMaximumSignificantDigits() -> Int {
+        switch numberStyle {
+        case .none, .currency, .currencyISOCode, .currencyAccounting, .decimal, .percent, .scientific:
+            return 6
+
+        case .ordinal, .spellOut, .currencyPlural:
+            return 0
+        }
+    }
+
+    private func defaultUsesGroupingSeparator() -> Bool {
+        switch numberStyle {
+        case .none, .scientific, .spellOut, .ordinal, .currencyPlural:
+            return false
+
+        case .decimal, .currency, .percent, .currencyAccounting, .currencyISOCode:
+            return true
+        }
+    }
+
+    private func defaultGroupingSize() -> Int {
+        switch numberStyle {
+        case .none, .ordinal, .spellOut, .currencyPlural, .scientific:
+            return 0
+
+        case .currency, .currencyISOCode, .currencyAccounting, .decimal, .percent:
+            return 3
+        }
+    }
+
+    private func defaultMultiplier() -> NSNumber? {
+        switch numberStyle {
+        case .percent:  return NSNumber(100)
+        default:        return nil
+        }
+    }
+
     private var _numberStyle: Style = .none
     open var numberStyle: Style {
         get {
@@ -183,58 +293,6 @@ open class NumberFormatter : Formatter {
         }
 
         set {
-            switch newValue {
-            case .none, .ordinal, .spellOut:
-                _usesSignificantDigits = false
-
-            case .currency, .currencyISOCode, .currencyAccounting:
-                _usesSignificantDigits = false
-                _usesGroupingSeparator = true
-                if _minimumIntegerDigits == nil {
-                    _minimumIntegerDigits = 1
-                }
-                if _groupingSize == 0 {
-                    _groupingSize = 3
-                }
-                _minimumFractionDigits = 2
-
-            case .currencyPlural:
-                _usesSignificantDigits = false
-                _usesGroupingSeparator = true
-                if _minimumIntegerDigits == nil {
-                    _minimumIntegerDigits = 0
-                }
-                _minimumFractionDigits = 2
-
-            case .decimal:
-                _usesGroupingSeparator = true
-                _maximumFractionDigits = 3
-                if _minimumIntegerDigits == nil {
-                    _minimumIntegerDigits = 1
-                }
-                if _groupingSize == 0 {
-                    _groupingSize = 3
-                }
-
-            case .percent:
-                _usesSignificantDigits = false
-                _usesGroupingSeparator = true
-                if _minimumIntegerDigits == nil {
-                    _minimumIntegerDigits = 1
-                }
-                if _groupingSize == 0 {
-                    _groupingSize = 3
-                }
-                _minimumFractionDigits = 0
-                _maximumFractionDigits = 0
-
-            case .scientific:
-                _usesSignificantDigits = false
-                _usesGroupingSeparator = false
-                if _minimumIntegerDigits == nil {
-                    _minimumIntegerDigits = 0
-                }
-            }
             _reset()
             _numberStyle = newValue
         }
@@ -328,10 +386,10 @@ open class NumberFormatter : Formatter {
         }
     }
 
-    private var _usesGroupingSeparator: Bool = false
+    private var _usesGroupingSeparator: Bool?
     open var usesGroupingSeparator: Bool {
         get {
-            return _usesGroupingSeparator
+            return _usesGroupingSeparator ?? defaultUsesGroupingSeparator()
         }
         set {
             _reset()
@@ -592,10 +650,10 @@ open class NumberFormatter : Formatter {
         }
     }
 
-    private var _groupingSize: Int = 0
+    private var _groupingSize: Int?
     open var groupingSize: Int {
         get {
-            return _groupingSize
+            return _groupingSize ?? defaultGroupingSize()
         }
         set {
             _reset()
@@ -617,7 +675,7 @@ open class NumberFormatter : Formatter {
     private var _multiplier: NSNumber?
     /*@NSCopying*/ open var multiplier: NSNumber? {
         get {
-            return _multiplier
+            return _multiplier ?? defaultMultiplier()
         }
         set {
             _reset()
@@ -636,7 +694,7 @@ open class NumberFormatter : Formatter {
         }
     }
 
-    private var _paddingCharacter: String!
+    private var _paddingCharacter: String! = " "
     open var paddingCharacter: String! {
         get {
             return _paddingCharacter ?? _getFormatterAttribute(_cfFormatter, attributeName: kCFNumberFormatterPaddingCharacter)
@@ -686,7 +744,7 @@ open class NumberFormatter : Formatter {
     private var _minimumIntegerDigits: Int?
     open var minimumIntegerDigits: Int {
         get {
-            return _minimumIntegerDigits ?? 0
+            return _minimumIntegerDigits ?? defaultMinimumIntegerDigits()
         }
         set {
             _reset()
@@ -694,10 +752,10 @@ open class NumberFormatter : Formatter {
         }
     }
 
-    private var _maximumIntegerDigits: Int = 42
+    private var _maximumIntegerDigits: Int?
     open var maximumIntegerDigits: Int {
         get {
-            return _maximumIntegerDigits
+            return _maximumIntegerDigits ?? defaultMaximumIntegerDigits()
         }
         set {
             _reset()
@@ -705,10 +763,10 @@ open class NumberFormatter : Formatter {
         }
     }
 
-    private var _minimumFractionDigits: Int = 0
+    private var _minimumFractionDigits: Int?
     open var minimumFractionDigits: Int {
         get {
-            return _minimumFractionDigits
+            return _minimumFractionDigits ?? defaultMinimumFractionDigits()
         }
         set {
             _reset()
@@ -716,10 +774,10 @@ open class NumberFormatter : Formatter {
         }
     }
 
-    private var _maximumFractionDigits: Int = 0
+    private var _maximumFractionDigits: Int?
     open var maximumFractionDigits: Int {
         get {
-            return _maximumFractionDigits
+            return _maximumFractionDigits ?? defaultMaximumFractionDigits()
         }
         set {
             _reset()
@@ -771,10 +829,10 @@ open class NumberFormatter : Formatter {
         }
     }
 
-    private var _usesSignificantDigits: Bool = false
+    private var _usesSignificantDigits: Bool?
     open var usesSignificantDigits: Bool {
         get {
-            return _usesSignificantDigits
+            return _usesSignificantDigits ?? false
         }
         set {
             _reset()
@@ -782,10 +840,10 @@ open class NumberFormatter : Formatter {
         }
     }
 
-    private var _minimumSignificantDigits: Int = 1
+    private var _minimumSignificantDigits: Int?
     open var minimumSignificantDigits: Int {
         get {
-            return _minimumSignificantDigits
+            return _minimumSignificantDigits ?? defaultMinimumSignificantDigits()
         }
         set {
             _reset()
@@ -794,10 +852,10 @@ open class NumberFormatter : Formatter {
         }
     }
 
-    private var _maximumSignificantDigits: Int = 6
+    private var _maximumSignificantDigits: Int?
     open var maximumSignificantDigits: Int {
         get {
-            return _maximumSignificantDigits
+            return _maximumSignificantDigits ?? defaultMaximumSignificantDigits()
         }
         set {
             _reset()
@@ -850,8 +908,10 @@ open class NumberFormatter : Formatter {
         }
     }
 
-    private func getFormatterComponents() -> (String, String) {
-        let format = CFNumberFormatterGetFormat(_cfFormatter)._swiftObject
+    private func getFormatterComponents() -> (String?, String?) {
+        guard let format = CFNumberFormatterGetFormat(_cfFormatter)?._swiftObject else {
+            return (nil, nil)
+        }
         let components = format.components(separatedBy: ";")
         let positive = _positiveFormat ?? components.first ?? "#"
         let negative = _negativeFormat ?? components.last ?? "#"
@@ -866,7 +926,7 @@ open class NumberFormatter : Formatter {
         get {
             let (p, n) = getFormatterComponents()
             let z = _zeroSymbol ?? getZeroFormat()
-            return "\(p);\(z);\(n)"
+            return "\(p ?? "(null)");\(z);\(n ?? "(null)")"
         }
         set {
             // Special case empty string

--- a/TestFoundation/TestNumberFormatter.swift
+++ b/TestFoundation/TestNumberFormatter.swift
@@ -7,61 +7,251 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+
 class TestNumberFormatter: XCTestCase {
 
-    static var allTests: [(String, (TestNumberFormatter) -> () throws -> Void)] {
-        return [
-            ("test_currencyCode", test_currencyCode),
-            ("test_decimalSeparator", test_decimalSeparator),
-            ("test_currencyDecimalSeparator", test_currencyDecimalSeparator),
-            ("test_alwaysShowDecimalSeparator", test_alwaysShowDecimalSeparator),
-            ("test_groupingSeparator", test_groupingSeparator),
-            ("test_percentSymbol", test_percentSymbol),
-            ("test_zeroSymbol", test_zeroSymbol),
-            ("test_notANumberSymbol", test_notANumberSymbol),
-            ("test_positiveInfinitySymbol", test_positiveInfinitySymbol),
-            ("test_minusSignSymbol", test_minusSignSymbol),
-            ("test_plusSignSymbol", test_plusSignSymbol),
-            ("test_currencySymbol", test_currencySymbol),
-            ("test_exponentSymbol", test_exponentSymbol),
-            ("test_decimalMinimumIntegerDigits", test_decimalMinimumIntegerDigits),
-            ("test_currencyMinimumIntegerDigits", test_currencyMinimumIntegerDigits),
-            ("test_percentMinimumIntegerDigits", test_percentMinimumIntegerDigits),
-            ("test_scientificMinimumIntegerDigits", test_scientificMinimumIntegerDigits),
-            ("test_spellOutMinimumIntegerDigits", test_spellOutMinimumIntegerDigits),
-            ("test_ordinalMinimumIntegerDigits", test_ordinalMinimumIntegerDigits),
-            ("test_currencyPluralMinimumIntegerDigits", test_currencyPluralMinimumIntegerDigits),
-            ("test_currencyISOCodeMinimumIntegerDigits", test_currencyISOCodeMinimumIntegerDigits),
-            ("test_currencyAccountingMinimumIntegerDigits", test_currencyAccountingMinimumIntegerDigits),
-            ("test_maximumIntegerDigits", test_maximumIntegerDigits),
-            ("test_minimumFractionDigits", test_minimumFractionDigits),
-            ("test_maximumFractionDigits", test_maximumFractionDigits),
-            ("test_groupingSize", test_groupingSize),
-            ("test_secondaryGroupingSize", test_secondaryGroupingSize),
-            ("test_roundingMode", test_roundingMode),
-            ("test_roundingIncrement", test_roundingIncrement),
-            ("test_formatWidth", test_formatWidth),
-            ("test_formatPosition", test_formatPosition),
-            ("test_multiplier", test_multiplier),
-            ("test_positivePrefix", test_positivePrefix),
-            ("test_positiveSuffix", test_positiveSuffix),
-            ("test_negativePrefix", test_negativePrefix),
-            ("test_negativeSuffix", test_negativeSuffix),
-            ("test_internationalCurrencySymbol", test_internationalCurrencySymbol),
-            ("test_currencyGroupingSeparator", test_currencyGroupingSeparator),
-            ("test_lenient", test_lenient),
-            ("test_minimumSignificantDigits", test_minimumSignificantDigits),
-            ("test_maximumSignificantDigits", test_maximumSignificantDigits),
-            ("test_stringFor", test_stringFor),
-            ("test_numberFrom", test_numberFrom),
-            ("test_en_US_initialValues", test_en_US_initialValues),
-            ("test_pt_BR_initialValues", test_pt_BR_initialValues),
-            ("test_changingLocale", test_changingLocale),
-            ("test_settingFormat", test_settingFormat),
-            ("test_usingFormat", test_usingFormat),
-        ]
+    func test_defaultPropertyValues() {
+        let numberFormatter = NumberFormatter()
+        XCTAssertEqual(numberFormatter.numberStyle, .none)
+        XCTAssertEqual(numberFormatter.generatesDecimalNumbers, false)
+        XCTAssertEqual(numberFormatter.localizesFormat, true)
+        XCTAssertEqual(numberFormatter.locale, Locale.current)
+        XCTAssertEqual(numberFormatter.minimumIntegerDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumIntegerDigits, 42)
+        XCTAssertEqual(numberFormatter.minimumFractionDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumFractionDigits, 0)
+        XCTAssertEqual(numberFormatter.minimumSignificantDigits, 1)
+        XCTAssertEqual(numberFormatter.maximumSignificantDigits, 6)
+        XCTAssertEqual(numberFormatter.usesSignificantDigits, false)
+        XCTAssertEqual(numberFormatter.formatWidth, 0)
+        XCTAssertEqual(numberFormatter.format, "#;0;#")
+        XCTAssertEqual(numberFormatter.positiveFormat, "#")
+        XCTAssertEqual(numberFormatter.negativeFormat, "#")
+        XCTAssertNil(numberFormatter.multiplier)
+        XCTAssertFalse(numberFormatter.usesGroupingSeparator)
+        XCTAssertEqual(numberFormatter.groupingSize, 0)
+        XCTAssertEqual(numberFormatter.secondaryGroupingSize, 0)
     }
-    
+
+    func test_defaultDecimalPropertyValues() {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        XCTAssertEqual(numberFormatter.generatesDecimalNumbers, false)
+        XCTAssertEqual(numberFormatter.localizesFormat, true)
+        XCTAssertEqual(numberFormatter.locale, Locale.current)
+        XCTAssertEqual(numberFormatter.minimumIntegerDigits, 1)
+        XCTAssertEqual(numberFormatter.maximumIntegerDigits, 2_000_000_000)
+        XCTAssertEqual(numberFormatter.minimumFractionDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumFractionDigits, 3)
+        XCTAssertEqual(numberFormatter.minimumSignificantDigits, 1)
+        XCTAssertEqual(numberFormatter.maximumSignificantDigits, 6)
+        XCTAssertEqual(numberFormatter.usesSignificantDigits, false)
+        XCTAssertEqual(numberFormatter.formatWidth, 0)
+        XCTAssertEqual(numberFormatter.format, "#,##0.###;0;#,##0.###")
+        XCTAssertEqual(numberFormatter.positiveFormat, "#,##0.###")
+        XCTAssertEqual(numberFormatter.negativeFormat, "#,##0.###")
+        XCTAssertNil(numberFormatter.multiplier)
+        XCTAssertTrue(numberFormatter.usesGroupingSeparator)
+        XCTAssertEqual(numberFormatter.groupingSize, 3)
+        XCTAssertEqual(numberFormatter.secondaryGroupingSize, 0)
+    }
+
+    func test_defaultCurrencyPropertyValues() {
+        let numberFormatter = NumberFormatter()
+        let currency = Locale.current.currencySymbol ?? ""
+        numberFormatter.numberStyle = .currency
+        XCTAssertEqual(numberFormatter.generatesDecimalNumbers, false)
+        XCTAssertEqual(numberFormatter.localizesFormat, true)
+        XCTAssertEqual(numberFormatter.locale, Locale.current)
+        XCTAssertEqual(numberFormatter.minimumIntegerDigits, 1)
+        XCTAssertEqual(numberFormatter.maximumIntegerDigits, 2_000_000_000)
+        XCTAssertEqual(numberFormatter.minimumFractionDigits, 2)
+        XCTAssertEqual(numberFormatter.maximumFractionDigits, 2)
+        XCTAssertEqual(numberFormatter.minimumSignificantDigits, 1)
+        XCTAssertEqual(numberFormatter.maximumSignificantDigits, 6)
+        XCTAssertEqual(numberFormatter.usesSignificantDigits, false)
+        XCTAssertEqual(numberFormatter.formatWidth, 0)
+        XCTAssertEqual(numberFormatter.format, "¤#,##0.00;\(currency)0.00;¤#,##0.00")
+        XCTAssertEqual(numberFormatter.positiveFormat, "¤#,##0.00")
+        XCTAssertEqual(numberFormatter.negativeFormat, "¤#,##0.00")
+        XCTAssertNil(numberFormatter.multiplier)
+        XCTAssertTrue(numberFormatter.usesGroupingSeparator)
+        XCTAssertEqual(numberFormatter.groupingSize, 3)
+        XCTAssertEqual(numberFormatter.secondaryGroupingSize, 0)
+    }
+
+    func test_defaultPercentPropertyValues() {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .percent
+        XCTAssertEqual(numberFormatter.generatesDecimalNumbers, false)
+        XCTAssertEqual(numberFormatter.localizesFormat, true)
+        XCTAssertEqual(numberFormatter.locale, Locale.current)
+        XCTAssertEqual(numberFormatter.minimumIntegerDigits, 1)
+        XCTAssertEqual(numberFormatter.maximumIntegerDigits, 2_000_000_000)
+        XCTAssertEqual(numberFormatter.minimumFractionDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumFractionDigits, 0)
+        XCTAssertEqual(numberFormatter.minimumSignificantDigits, 1)
+        XCTAssertEqual(numberFormatter.maximumSignificantDigits, 6)
+        XCTAssertEqual(numberFormatter.usesSignificantDigits, false)
+        XCTAssertEqual(numberFormatter.formatWidth, 0)
+        XCTAssertEqual(numberFormatter.format, "#,##0%;0%;#,##0%")
+        XCTAssertEqual(numberFormatter.positiveFormat, "#,##0%")
+        XCTAssertEqual(numberFormatter.negativeFormat, "#,##0%")
+        XCTAssertEqual(numberFormatter.multiplier, NSNumber(100))
+        XCTAssertTrue(numberFormatter.usesGroupingSeparator)
+        XCTAssertEqual(numberFormatter.groupingSize, 3)
+        XCTAssertEqual(numberFormatter.secondaryGroupingSize, 0)
+    }
+
+    func test_defaultScientificPropertyValues() {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .scientific
+        XCTAssertEqual(numberFormatter.generatesDecimalNumbers, false)
+        XCTAssertEqual(numberFormatter.localizesFormat, true)
+        XCTAssertEqual(numberFormatter.locale, Locale.current)
+        XCTAssertEqual(numberFormatter.minimumIntegerDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumIntegerDigits, 1)
+        XCTAssertEqual(numberFormatter.minimumFractionDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumFractionDigits, 0)
+        XCTAssertEqual(numberFormatter.minimumSignificantDigits, 1)
+        XCTAssertEqual(numberFormatter.maximumSignificantDigits, 6)
+        XCTAssertEqual(numberFormatter.usesSignificantDigits, false)
+        XCTAssertEqual(numberFormatter.formatWidth, 0)
+#if !DARWIN_COMPATIBILITY_TESTS
+        XCTAssertEqual(numberFormatter.format, "#E0;0E0;#E0")
+#else
+        XCTAssertEqual(numberFormatter.format, "#E0;1E-100;#E0")
+#endif
+        XCTAssertEqual(numberFormatter.positiveFormat, "#E0")
+        XCTAssertEqual(numberFormatter.negativeFormat, "#E0")
+        XCTAssertNil(numberFormatter.multiplier)
+        XCTAssertFalse(numberFormatter.usesGroupingSeparator)
+        XCTAssertEqual(numberFormatter.groupingSize, 0)
+        XCTAssertEqual(numberFormatter.secondaryGroupingSize, 0)
+    }
+
+    func test_defaultSpelloutPropertyValues() {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .spellOut
+        XCTAssertEqual(numberFormatter.generatesDecimalNumbers, false)
+        XCTAssertEqual(numberFormatter.localizesFormat, true)
+        XCTAssertEqual(numberFormatter.locale, Locale.current)
+        XCTAssertEqual(numberFormatter.minimumIntegerDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumIntegerDigits, 0)
+        XCTAssertEqual(numberFormatter.minimumFractionDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumFractionDigits, 0)
+        XCTAssertEqual(numberFormatter.minimumSignificantDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumSignificantDigits, 0)
+        XCTAssertEqual(numberFormatter.usesSignificantDigits, false)
+        XCTAssertEqual(numberFormatter.formatWidth, 0)
+#if !DARWIN_COMPATIBILITY_TESTS
+        XCTAssertEqual(numberFormatter.format, "(null);zero;(null)")
+#else
+        XCTAssertEqual(numberFormatter.format, "(null);zero point zero;(null)")
+#endif
+        XCTAssertEqual(numberFormatter.positiveFormat, nil)
+        XCTAssertEqual(numberFormatter.negativeFormat, nil)
+        XCTAssertNil(numberFormatter.multiplier)
+        XCTAssertFalse(numberFormatter.usesGroupingSeparator)
+        XCTAssertEqual(numberFormatter.groupingSize, 0)
+        XCTAssertEqual(numberFormatter.secondaryGroupingSize, 0)
+    }
+
+    func test_defaultOrdinalPropertyValues() {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .ordinal
+        XCTAssertEqual(numberFormatter.generatesDecimalNumbers, false)
+        XCTAssertEqual(numberFormatter.localizesFormat, true)
+        XCTAssertEqual(numberFormatter.locale, Locale.current)
+        XCTAssertEqual(numberFormatter.minimumIntegerDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumIntegerDigits, 0)
+        XCTAssertEqual(numberFormatter.minimumFractionDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumFractionDigits, 0)
+        XCTAssertEqual(numberFormatter.minimumSignificantDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumSignificantDigits, 0)
+        XCTAssertEqual(numberFormatter.usesSignificantDigits, false)
+        XCTAssertEqual(numberFormatter.formatWidth, 0)
+        XCTAssertEqual(numberFormatter.format, "(null);0th;(null)")
+        XCTAssertEqual(numberFormatter.positiveFormat, nil)
+        XCTAssertEqual(numberFormatter.negativeFormat, nil)
+        XCTAssertNil(numberFormatter.multiplier)
+        XCTAssertFalse(numberFormatter.usesGroupingSeparator)
+        XCTAssertEqual(numberFormatter.groupingSize, 0)
+        XCTAssertEqual(numberFormatter.secondaryGroupingSize, 0)
+    }
+
+    func test_defaultCurrencyISOCodePropertyValues() {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .currencyISOCode
+        numberFormatter.locale = Locale(identifier: "en_US")
+        XCTAssertEqual(numberFormatter.generatesDecimalNumbers, false)
+        XCTAssertEqual(numberFormatter.localizesFormat, true)
+        XCTAssertEqual(numberFormatter.locale, Locale(identifier: "en_US"))
+        XCTAssertEqual(numberFormatter.minimumIntegerDigits, 1)
+        XCTAssertEqual(numberFormatter.maximumIntegerDigits, 2_000_000_000)
+        XCTAssertEqual(numberFormatter.minimumFractionDigits, 2)
+        XCTAssertEqual(numberFormatter.maximumFractionDigits, 2)
+        XCTAssertEqual(numberFormatter.minimumSignificantDigits, 1)
+        XCTAssertEqual(numberFormatter.maximumSignificantDigits, 6)
+        XCTAssertEqual(numberFormatter.usesSignificantDigits, false)
+        XCTAssertEqual(numberFormatter.formatWidth, 0)
+        XCTAssertEqual(numberFormatter.format, "¤¤#,##0.00;USD0.00;¤¤#,##0.00")
+        XCTAssertEqual(numberFormatter.positiveFormat, "¤¤#,##0.00")
+        XCTAssertEqual(numberFormatter.negativeFormat, "¤¤#,##0.00")
+        XCTAssertNil(numberFormatter.multiplier)
+        XCTAssertTrue(numberFormatter.usesGroupingSeparator)
+        XCTAssertEqual(numberFormatter.groupingSize, 3)
+        XCTAssertEqual(numberFormatter.secondaryGroupingSize, 0)
+        XCTAssertEqual(numberFormatter.string(from: NSNumber(1234567890)), "USD1,234,567,890.00")
+    }
+
+    func test_defaultCurrencyPluralPropertyValues() {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .currencyPlural
+        numberFormatter.locale = Locale(identifier: "en_GB")
+        XCTAssertEqual(numberFormatter.generatesDecimalNumbers, false)
+        XCTAssertEqual(numberFormatter.localizesFormat, true)
+        XCTAssertEqual(numberFormatter.locale, Locale(identifier: "en_GB"))
+        XCTAssertEqual(numberFormatter.minimumIntegerDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumIntegerDigits, 0)
+        XCTAssertEqual(numberFormatter.minimumFractionDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumFractionDigits, 0)
+        XCTAssertEqual(numberFormatter.minimumSignificantDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumSignificantDigits, 0)
+        XCTAssertEqual(numberFormatter.usesSignificantDigits, false)
+        XCTAssertEqual(numberFormatter.formatWidth, 0)
+        XCTAssertEqual(numberFormatter.format, "(null);0.00 British pounds;(null)")
+        XCTAssertEqual(numberFormatter.positiveFormat, nil)
+        XCTAssertEqual(numberFormatter.negativeFormat, nil)
+        XCTAssertNil(numberFormatter.multiplier)
+        XCTAssertFalse(numberFormatter.usesGroupingSeparator)
+        XCTAssertEqual(numberFormatter.groupingSize, 0)
+        XCTAssertEqual(numberFormatter.secondaryGroupingSize, 0)
+    }
+
+    func test_defaultCurrenyAccountingPropertyValues() {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .currencyAccounting
+        numberFormatter.locale = Locale(identifier: "en_US")
+        XCTAssertEqual(numberFormatter.generatesDecimalNumbers, false)
+        XCTAssertEqual(numberFormatter.localizesFormat, true)
+        XCTAssertEqual(numberFormatter.minimumIntegerDigits, 1)
+        XCTAssertEqual(numberFormatter.maximumIntegerDigits, 2_000_000_000)
+        XCTAssertEqual(numberFormatter.minimumFractionDigits, 2)
+        XCTAssertEqual(numberFormatter.maximumFractionDigits, 2)
+        XCTAssertEqual(numberFormatter.minimumSignificantDigits, 1)
+        XCTAssertEqual(numberFormatter.maximumSignificantDigits, 6)
+        XCTAssertEqual(numberFormatter.usesSignificantDigits, false)
+        XCTAssertEqual(numberFormatter.formatWidth, 0)
+        XCTAssertEqual(numberFormatter.format, "¤#,##0.00;$0.00;(¤#,##0.00)")
+        XCTAssertEqual(numberFormatter.positiveFormat, "¤#,##0.00")
+        XCTAssertEqual(numberFormatter.negativeFormat, "(¤#,##0.00)")
+        XCTAssertNil(numberFormatter.multiplier)
+        XCTAssertTrue(numberFormatter.usesGroupingSeparator)
+        XCTAssertEqual(numberFormatter.groupingSize, 3)
+        XCTAssertEqual(numberFormatter.secondaryGroupingSize, 0)
+    }
+
     func test_currencyCode() {
         let numberFormatter = NumberFormatter()
         numberFormatter.locale = Locale(identifier: "en_GB")
@@ -151,6 +341,19 @@ class TestNumberFormatter: XCTestCase {
     
     func test_zeroSymbol() {
         let numberFormatter = NumberFormatter()
+        XCTAssertEqual(numberFormatter.numberStyle, .none)
+        XCTAssertEqual(numberFormatter.generatesDecimalNumbers, false)
+        XCTAssertEqual(numberFormatter.localizesFormat, true)
+        XCTAssertEqual(numberFormatter.locale, Locale.current)
+        XCTAssertEqual(numberFormatter.minimumIntegerDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumIntegerDigits, 42)
+        XCTAssertEqual(numberFormatter.minimumFractionDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumFractionDigits, 0)
+        XCTAssertEqual(numberFormatter.minimumSignificantDigits, 1)
+        XCTAssertEqual(numberFormatter.maximumSignificantDigits, 6)
+        XCTAssertEqual(numberFormatter.usesSignificantDigits, false)
+        XCTAssertEqual(numberFormatter.formatWidth, 0)
+        XCTAssertEqual(numberFormatter.format, "#;0;#")
         numberFormatter.zeroSymbol = "⚽️"
         XCTAssertEqual(numberFormatter.format, "#;⚽️;#")
 
@@ -193,10 +396,16 @@ class TestNumberFormatter: XCTestCase {
         let format = "#E+0"
         numberFormatter.format = format
         XCTAssertEqual(numberFormatter.positiveFormat, "#E+0")
-        XCTAssertEqual(numberFormatter.zeroSymbol, "0E+0")
         XCTAssertEqual(numberFormatter.negativeFormat, "-#E+0")
+#if !DARWIN_COMPATIBILITY_TESTS
+        XCTAssertEqual(numberFormatter.zeroSymbol, "0E+0")
         XCTAssertEqual(numberFormatter.format, "#E+0;0E+0;-#E+0")
         XCTAssertEqual(numberFormatter.string(from: 0), "0E+0")
+#else
+        XCTAssertEqual(numberFormatter.zeroSymbol, "1E-100")
+        XCTAssertEqual(numberFormatter.format, "#E+0;1E-100;-#E+0")
+        XCTAssertEqual(numberFormatter.string(from: 0), "1E-100")
+#endif
         XCTAssertEqual(numberFormatter.plusSign, "+")
         let sign = "👍"
         numberFormatter.plusSign = sign
@@ -229,7 +438,11 @@ class TestNumberFormatter: XCTestCase {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .scientific
         numberFormatter.exponentSymbol = "⬆️"
+#if DARWIN_COMPATIBILITY_TESTS
+        XCTAssertEqual(numberFormatter.format, "#E0;1⬆️-100;#E0")
+#else
         XCTAssertEqual(numberFormatter.format, "#E0;0⬆️0;#E0")
+#endif
         let formattedString = numberFormatter.string(from: 42)
         XCTAssertEqual(formattedString, "4.2⬆️1")
     }
@@ -833,9 +1046,14 @@ class TestNumberFormatter: XCTestCase {
 
         // Test setting only first 2 parts
         formatter.format = "+##.##;0.00"
+#if !DARWIN_COMPATIBILITY_TESTS
         XCTAssertEqual(formatter.format, "+##.##;00;0.00")
-        XCTAssertEqual(formatter.positiveFormat, "+##.##")
         XCTAssertEqual(formatter.zeroSymbol, "00")
+#else
+        XCTAssertEqual(formatter.format, "+##.##;+0;0.00")
+        XCTAssertEqual(formatter.zeroSymbol, "+0")
+#endif
+        XCTAssertEqual(formatter.positiveFormat, "+##.##")
         XCTAssertEqual(formatter.negativeFormat, "0.00")
 
         formatter.format = "+##.##;+0;0.00"
@@ -864,9 +1082,14 @@ class TestNumberFormatter: XCTestCase {
         XCTAssertEqual(formatter.negativeFormat, "3")
 
         formatter.format = ""
+#if !DARWIN_COMPATIBILITY_TESTS
         XCTAssertEqual(formatter.format, ";0;-")
-        XCTAssertEqual(formatter.positiveFormat, "")
         XCTAssertEqual(formatter.zeroSymbol, "0")
+#else
+        XCTAssertEqual(formatter.format, ";0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001;-")
+        XCTAssertEqual(formatter.zeroSymbol, "0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001")
+#endif
+        XCTAssertEqual(formatter.positiveFormat, "")
         XCTAssertEqual(formatter.negativeFormat, "-")
     }
 
@@ -908,5 +1131,84 @@ class TestNumberFormatter: XCTestCase {
         formatter.positiveFormat = "#.#########"
         XCTAssertEqual(formatter.string(from: NSNumber(value: 0.5)), "0.5")
         XCTAssertEqual(formatter.string(from: NSNumber(value: -0.5)), "-0.5")
+    }
+
+    func test_propertyChanges() {
+        let formatter = NumberFormatter()
+        XCTAssertNil(formatter.multiplier)
+        formatter.numberStyle = .percent
+        XCTAssertEqual(formatter.multiplier, NSNumber(100))
+        formatter.numberStyle = .decimal
+        XCTAssertNil(formatter.multiplier)
+        formatter.multiplier = NSNumber(1)
+        formatter.numberStyle = .percent
+        XCTAssertEqual(formatter.multiplier, NSNumber(1))
+        formatter.multiplier = NSNumber(27)
+        formatter.numberStyle = .decimal
+        XCTAssertEqual(formatter.multiplier, NSNumber(27))
+    }
+
+    static var allTests: [(String, (TestNumberFormatter) -> () throws -> Void)] {
+        return [
+            ("test_defaultPropertyValues", test_defaultPropertyValues),
+            ("test_defaultDecimalPropertyValues", test_defaultDecimalPropertyValues),
+            ("test_defaultCurrencyPropertyValues", test_defaultCurrencyPropertyValues),
+            ("test_defaultPercentPropertyValues", test_defaultPercentPropertyValues),
+            ("test_defaultScientificPropertyValues", test_defaultScientificPropertyValues),
+            ("test_defaultSpelloutPropertyValues", test_defaultSpelloutPropertyValues),
+            ("test_defaultOrdinalPropertyValues", test_defaultOrdinalPropertyValues),
+            ("test_defaultCurrencyISOCodePropertyValues", test_defaultCurrencyISOCodePropertyValues),
+            ("test_defaultCurrencyPluralPropertyValues", test_defaultCurrencyPluralPropertyValues),
+            ("test_defaultCurrenyAccountingPropertyValues", test_defaultCurrenyAccountingPropertyValues),
+            ("test_currencyCode", test_currencyCode),
+            ("test_decimalSeparator", test_decimalSeparator),
+            ("test_currencyDecimalSeparator", test_currencyDecimalSeparator),
+            ("test_alwaysShowDecimalSeparator", test_alwaysShowDecimalSeparator),
+            ("test_groupingSeparator", test_groupingSeparator),
+            ("test_percentSymbol", test_percentSymbol),
+            ("test_zeroSymbol", test_zeroSymbol),
+            ("test_notANumberSymbol", test_notANumberSymbol),
+            ("test_positiveInfinitySymbol", test_positiveInfinitySymbol),
+            ("test_minusSignSymbol", test_minusSignSymbol),
+            ("test_plusSignSymbol", test_plusSignSymbol),
+            ("test_currencySymbol", test_currencySymbol),
+            ("test_exponentSymbol", test_exponentSymbol),
+            ("test_decimalMinimumIntegerDigits", test_decimalMinimumIntegerDigits),
+            ("test_currencyMinimumIntegerDigits", test_currencyMinimumIntegerDigits),
+            ("test_percentMinimumIntegerDigits", test_percentMinimumIntegerDigits),
+            ("test_scientificMinimumIntegerDigits", test_scientificMinimumIntegerDigits),
+            ("test_spellOutMinimumIntegerDigits", test_spellOutMinimumIntegerDigits),
+            ("test_ordinalMinimumIntegerDigits", test_ordinalMinimumIntegerDigits),
+            ("test_currencyPluralMinimumIntegerDigits", test_currencyPluralMinimumIntegerDigits),
+            ("test_currencyISOCodeMinimumIntegerDigits", test_currencyISOCodeMinimumIntegerDigits),
+            ("test_currencyAccountingMinimumIntegerDigits", test_currencyAccountingMinimumIntegerDigits),
+            ("test_maximumIntegerDigits", test_maximumIntegerDigits),
+            ("test_minimumFractionDigits", test_minimumFractionDigits),
+            ("test_maximumFractionDigits", test_maximumFractionDigits),
+            ("test_groupingSize", test_groupingSize),
+            ("test_secondaryGroupingSize", test_secondaryGroupingSize),
+            ("test_roundingMode", test_roundingMode),
+            ("test_roundingIncrement", test_roundingIncrement),
+            ("test_formatWidth", test_formatWidth),
+            ("test_formatPosition", test_formatPosition),
+            ("test_multiplier", test_multiplier),
+            ("test_positivePrefix", test_positivePrefix),
+            ("test_positiveSuffix", test_positiveSuffix),
+            ("test_negativePrefix", test_negativePrefix),
+            ("test_negativeSuffix", test_negativeSuffix),
+            ("test_internationalCurrencySymbol", test_internationalCurrencySymbol),
+            ("test_currencyGroupingSeparator", test_currencyGroupingSeparator),
+            ("test_lenient", test_lenient),
+            ("test_minimumSignificantDigits", test_minimumSignificantDigits),
+            ("test_maximumSignificantDigits", test_maximumSignificantDigits),
+            ("test_stringFor", test_stringFor),
+            ("test_numberFrom", test_numberFrom),
+            ("test_en_US_initialValues", test_en_US_initialValues),
+            ("test_pt_BR_initialValues", test_pt_BR_initialValues),
+            ("test_changingLocale", test_changingLocale),
+            ("test_settingFormat", test_settingFormat),
+            ("test_usingFormat", test_usingFormat),
+            ("test_propertyChanges", test_propertyChanges),
+        ]
     }
 }


### PR DESCRIPTION
- Add default values for properties that allow the properties to retain
  user set values if the .numberStyle is changed.

- Match the default values to Darwin for improved compatibility.

- Allow some tests to be different on Darwin where the handing of Double
  values is not quite the same, especially for small values.
