### PR TITLE
Look for abbreviations when creating time zones.

### DIFF
--- a/CoreFoundation/NumberDate.subproj/CFTimeZone.c
+++ b/CoreFoundation/NumberDate.subproj/CFTimeZone.c
@@ -889,7 +889,7 @@ static CFTimeZoneRef __CFTimeZoneCreateSystem(void) {
     }
 #endif
     if (name) {
-        result = CFTimeZoneCreateWithName(kCFAllocatorSystemDefault, name, false);
+        result = CFTimeZoneCreateWithName(kCFAllocatorSystemDefault, name, true);
         CFRelease(name);
         if (result) return result;
     }


### PR DESCRIPTION
In the case the code ends up in the fallback that uses localtime_r (in
Unixes), the returned value in tm_zone is an abbreviation, but the code
that created the CFTimeZoneRef was not looking for abbreviations.

This code was hit in Android all the time (since it doesn't have an
Olson TZ file structure), but I didn't realized because my test machine
were using UTC instead of an actual time zone.