### PR TITLE
[android] Provide implementation for Android Bionic.

### DIFF
--- a/TestFoundation/FTPServer.swift
+++ b/TestFoundation/FTPServer.swift
@@ -87,6 +87,8 @@ class _FTPSocket {
         let netPort = port.bigEndian
         #if os(Linux)
             return sockaddr_in(sin_family: sa_family_t(AF_INET), sin_port: netPort, sin_addr: in_addr(s_addr: addr), sin_zero: (0,0,0,0,0,0,0,0))
+        #elseif os(Android)
+            return sockaddr_in(sin_family: sa_family_t(AF_INET), sin_port: netPort, sin_addr: in_addr(s_addr: addr), __pad: (0,0,0,0,0,0,0,0))
         #else
             return sockaddr_in(sin_len: 0, sin_family: sa_family_t(AF_INET), sin_port: netPort, sin_addr: in_addr(s_addr: addr), sin_zero: (0,0,0,0,0,0,0,0))
         #endif


### PR DESCRIPTION
In Android the last element of the sockaddr_in struct is actually called
__pad instead of sin_zero, so a special codepath is needed.

/cc @saiHemak 