### PR TITLE
Base: implement KnownLocations for android

### DIFF
--- a/CoreFoundation/Base.subproj/CFKnownLocations.c
+++ b/CoreFoundation/Base.subproj/CFKnownLocations.c
@@ -91,6 +91,26 @@ CFURLRef _Nullable _CFKnownLocationCreatePreferencesURLForUser(CFKnownLocationUs
             break;
     }
 
+#elif TARGET_OS_ANDROID
+
+    switch (user) {
+    case _kCFKnownLocationUserAny:
+    case _kCFKnownLocationUserByName:
+      abort();
+    case _kCFKnownLocationUserCurrent: {
+      const char *buffer = getenv("CFFIXED_USER_HOME");
+      if (buffer == NULL || *buffer = '\0') {
+        CFLog(__kCFLogAssertion, CFSTR("CFFIXED_USER_HOME is unset"));
+        HALT;
+      }
+
+      CFURLRef userdir = CFURLCreateFromFileSystemRepresentation(kCFAllocatorSystemDefault, (const unsigned char *)buffer, strlen(buffer), true);
+      location = CFURLCreateWithFileSystemPathRelativeToBase(kCFAllocatorSystemDefault, CFSTR("/Apple/Library/Preferences"), kCFURLPOSIXPathStyle, true, userdir);
+      CFRelease(userdir);
+      break;
+    }
+    }
+
 #else
     
     #error For this platform, you need to define a preferences path for both 'any user' (i.e. installation-wide preferences) or the current user.


### PR DESCRIPTION
Add support for android to KnownLocations.  Assume that only current
user is supported as all applications in android are isolated and single
user.  For now, place all files in ~/Apple/Library/Preferences.  This is
the last piece needed in CoreFoundation for Android support.