### PR TITLE
Foundation: remove & overload for android

### DIFF
--- a/Foundation/FileManager+POSIX.swift
+++ b/Foundation/FileManager+POSIX.swift
@@ -7,7 +7,7 @@
 //
 #if !os(Windows)
 
-#if os(Android) // struct stat.st_mode is UInt32
+#if os(Android) && (arch(i386) || arch(arm)) // struct stat.st_mode is UInt32
 internal func &(left: UInt32, right: mode_t) -> mode_t {
     return mode_t(left) & right
 }

--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -7,12 +7,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if os(Android) // struct stat.st_mode is UInt32
-internal func &(left: UInt32, right: mode_t) -> mode_t {
-    return mode_t(left) & right
-}
-#endif
-
 #if !canImport(Darwin) && !os(FreeBSD)
 // The values do not matter as long as they are nonzero.
 fileprivate let UF_IMMUTABLE: Int32 = 1


### PR DESCRIPTION
These seem unnecessary, at least when building android aarch64.