### PR TITLE
build: allow passing Swift specific link flags

### DIFF
--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -41,7 +41,7 @@ function(add_swift_target target)
   cmake_parse_arguments(AST "${options}" "${single_value_options}" "${multiple_value_options}" ${ARGN})
 
   set(compile_flags ${CMAKE_SWIFT_FLAGS})
-  set(link_flags)
+  set(link_flags ${CMAKE_SWIFT_LINK_FLAGS})
 
   list(APPEND compile_flags -incremental)
   ProcessorCount(CPU_COUNT)


### PR DESCRIPTION
This mirrors the `CMAKE_SWIFT_FLAGS` allowing control over the flags
passed to the linker.  This is needed until the libraries are built
with a newer CMake which supports Swift properly.  This enables
cross-compiling libdispatch for Android on Windows.