### PR TITLE
[cmake] Allow cross-compilation of add_swift_executable targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,6 +386,8 @@ endif()
 add_swift_executable(plutil
                      SOURCES
                        Tools/plutil/main.swift
+                     TARGET
+                       ${CMAKE_C_COMPILER_TARGET}
                      CFLAGS
                        -F${CMAKE_CURRENT_BINARY_DIR}
                      LINK_FLAGS
@@ -409,6 +411,8 @@ add_swift_executable(plutil
 
 if(ENABLE_TESTING)
   add_swift_executable(xdgTestHelper
+                       TARGET
+                         ${CMAKE_C_COMPILER_TARGET}
                        CFLAGS
                          -F${CMAKE_CURRENT_BINARY_DIR}
                        LINK_FLAGS
@@ -528,6 +532,8 @@ if(ENABLE_TESTING)
                          TestFoundation/TestUUID.swift
                          TestFoundation/TestXMLDocument.swift
                          TestFoundation/TestXMLParser.swift
+                       TARGET
+                         ${CMAKE_C_COMPILER_TARGET}
                        CFLAGS
                          -F${CMAKE_CURRENT_BINARY_DIR}
                        LINK_FLAGS

--- a/Tools/plutil/main.swift
+++ b/Tools/plutil/main.swift
@@ -6,13 +6,13 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
-#if os(macOS) || os(iOS)
+#if canImport(Darwin)
 import Darwin
 import SwiftFoundation
-#elseif os(Linux)
+#elseif canImport(Glibc)
 import Foundation
 import Glibc
-#elseif os(Windows)
+#elseif canImport(MSVCRT)
 import Foundation
 import MSVCRT
 #endif


### PR DESCRIPTION
Add an explicit TARGET for executable targets, to allow cross
compilation and fix plutil to import Glibc also in Android.