### PR TITLE
Implemented _getFileSystemRepresentation for Windows

### DIFF
--- a/CoreFoundation/URL.subproj/CFURL.c
+++ b/CoreFoundation/URL.subproj/CFURL.c
@@ -3965,10 +3965,13 @@ CF_EXPORT void __CFURLSetResourceInfoPtr(CFURLRef url, void *ptr) {
 /* HFSPath<->URLPath functions at the bottom of the file */
 static CFArrayRef WindowsPathToURLComponents(CFStringRef path, CFAllocatorRef alloc, Boolean isDir, Boolean isAbsolute) CF_RETURNS_RETAINED {
     CFArrayRef tmp;
+    CFMutableStringRef mutablePath = CFStringCreateMutableCopy(alloc, 0, path);
     CFMutableArrayRef urlComponents = NULL;
     CFIndex i=0;
-
-    tmp = CFStringCreateArrayBySeparatingStrings(alloc, path, CFSTR("\\"));
+    // Since '/' is a valid Windows path separator, we convert / to \ before splitting
+    CFStringFindAndReplace(mutablePath, CFSTR("/"), CFSTR("\\"), CFRangeMake(0, CFStringGetLength(mutablePath)), 0);
+    tmp = CFStringCreateArrayBySeparatingStrings(alloc, mutablePath, CFSTR("\\"));
+    CFRelease(mutablePath);
     urlComponents = CFArrayCreateMutableCopy(alloc, 0, tmp);
     CFRelease(tmp);
 

--- a/Foundation/FileManager+Win32.swift
+++ b/Foundation/FileManager+Win32.swift
@@ -637,7 +637,7 @@ extension FileManager {
         var szDirectory: [WCHAR] = Array<WCHAR>(repeating: 0, count: Int(dwLength + 1))
 
         GetCurrentDirectoryW(dwLength, &szDirectory)
-        return String(decodingCString: &szDirectory, as: UTF16.self)
+        return String(decodingCString: &szDirectory, as: UTF16.self).standardizingPath
     }
 
     @discardableResult
@@ -701,8 +701,8 @@ extension FileManager {
         return true
     }
 
-    internal func _lstatFile(atPath path: String, withFileSystemRepresentation fsRep: UnsafePointer<Int8>? = nil) throws -> stat {
-        let _fsRep: UnsafePointer<Int8>
+    internal func _lstatFile(atPath path: String, withFileSystemRepresentation fsRep: UnsafePointer<NativeFSRCharType>? = nil) throws -> stat {
+        let _fsRep: UnsafePointer<NativeFSRCharType>
         if fsRep == nil {
             _fsRep = try __fileSystemRepresentation(withPath: path)
         } else {
@@ -714,15 +714,13 @@ extension FileManager {
         }
 
         var statInfo = stat()
-        let h = path.withCString(encodedAs: UTF16.self) {
-            CreateFileW(/*lpFileName=*/$0,
-                        /*dwDesiredAccess=*/DWORD(0),
-                        /*dwShareMode=*/DWORD(FILE_SHARE_READ),
-                        /*lpSecurityAttributes=*/nil,
-                        /*dwCreationDisposition=*/DWORD(OPEN_EXISTING),
-                        /*dwFlagsAndAttributes=*/DWORD(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS),
-                        /*hTemplateFile=*/nil)
-        }
+        let h = CreateFileW(_fsRep,
+                            /*dwDesiredAccess=*/DWORD(0),
+                            DWORD(FILE_SHARE_READ),
+                            /*lpSecurityAttributes=*/nil,
+                            DWORD(OPEN_EXISTING),
+                            DWORD(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS),
+                            /*hTemplateFile=*/nil)
         if h == INVALID_HANDLE_VALUE {
             throw _NSErrorWithWindowsError(GetLastError(), reading: false, paths: [path])
         }
@@ -858,7 +856,7 @@ extension FileManager {
     }
 
     internal func _updateTimes(atPath path: String,
-                               withFileSystemRepresentation fsr: UnsafePointer<Int8>,
+                               withFileSystemRepresentation fsr: UnsafePointer<NativeFSRCharType>,
                                creationTime: Date? = nil,
                                accessTime: Date? = nil,
                                modificationTime: Date? = nil) throws {
@@ -869,10 +867,7 @@ extension FileManager {
       var mtime: FILETIME =
           FILETIME(from: time_t((modificationTime ?? stat.lastModificationDate).timeIntervalSince1970))
 
-      let hFile: HANDLE = String(utf8String: fsr)!.withCString(encodedAs: UTF16.self) {
-        CreateFileW($0, DWORD(GENERIC_WRITE), DWORD(FILE_SHARE_WRITE),
-                    nil, DWORD(OPEN_EXISTING), 0, nil)
-      }
+      let hFile = CreateFileW(fsr, DWORD(GENERIC_WRITE), DWORD(FILE_SHARE_WRITE), nil, DWORD(OPEN_EXISTING), 0, nil)
       if hFile == INVALID_HANDLE_VALUE {
           throw _NSErrorWithWindowsError(GetLastError(), reading: true, paths: [path])
       }

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -30,7 +30,11 @@ private func _standardizedPath(_ path: String) -> String {
     if !path.isAbsolutePath {
         return path._nsObject.standardizingPath
     }
+#if os(Windows)
+    return path.unixPath
+#else
     return path
+#endif
 }
 
 internal func _pathComponents(_ path: String?) -> [String]? {
@@ -335,7 +339,7 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
         let thePath = _standardizedPath(path)
         
         var isDir: ObjCBool = false
-        if thePath.hasSuffix("/") {
+        if validPathSeps.contains(where: { thePath.hasSuffix(String($0)) }) {
             isDir = true
         } else {
             let absolutePath: String
@@ -356,16 +360,9 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     }
 
     public init(fileURLWithPath path: String) {
-        let thePath: String
-        let pathString = NSString(string: path)
-        if !pathString.isAbsolutePath {
-            thePath = pathString.standardizingPath
-        } else {
-            thePath = path
-        }
-
+        let thePath = _standardizedPath(path)
         var isDir: ObjCBool = false
-        if thePath.hasSuffix("/") {
+        if validPathSeps.contains(where: { thePath.hasSuffix(String($0)) }) {
             isDir = true
         } else {
             if !FileManager.default.fileExists(atPath: path, isDirectory: &isDir) {
@@ -542,7 +539,19 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     
     open var path: String? {
         let absURL = CFURLCopyAbsoluteURL(_cfObject)
-        return CFURLCopyFileSystemPath(absURL, kCFURLPlatformPathStyle)?._swiftObject
+        guard var url = CFURLCopyFileSystemPath(absURL, kCFURLPOSIXPathStyle)?._swiftObject else {
+            return nil
+        }
+#if os(Windows)
+        // Per RFC 8089:E.2, if we have an absolute Windows/DOS path
+        // we can begin the url with a drive letter rather than a '/'
+        let scalars = Array(url.unicodeScalars)
+        if isFileURL, url.isAbsolutePath,
+           scalars.count >= 3, scalars[0] == "/", scalars[2] == ":" {
+            url.removeFirst()
+        }
+#endif
+        return url
     }
     
     open var fragment: String? {
@@ -559,7 +568,7 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     
     // The same as path if baseURL is nil
     open var relativePath: String? {
-        return CFURLCopyFileSystemPath(_cfObject, kCFURLPlatformPathStyle)?._swiftObject
+        return CFURLCopyFileSystemPath(_cfObject, kCFURLPOSIXPathStyle)?._swiftObject
     }
     
     /* Determines if a given URL string's path represents a directory (i.e. the path component in the URL string ends with a '/' character). This does not check the resource the URL refers to.

--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -62,8 +62,9 @@ class TestURL : XCTestCase {
       // ensure that the trailing slashes are compressed even when mixed
       // e.g. NOT file:///S:/b/u3%2F%/%2F%2/
       let u3 = URL(fileURLWithPath: "S:\\b\\u3//\\//")
-      // XCTAssertEqual(u3.absoluteString, "file:///S:/b/u3/%2F/")
-      XCTAssertEqual(u3.path, "S:\\b\\u3\\")
+      // URL.path is defined to strip trailing slashes
+      XCTAssertEqual(u3.absoluteString, "file:///S:/b/u3/")
+      XCTAssertEqual(u3.path, "S:/b/u3")
 
       // ensure that the regular conversion works
       let u4 = URL(fileURLWithPath: "S:\\b\\u4")
@@ -377,7 +378,13 @@ class TestURL : XCTestCase {
         // 1 for path separator
         let expectedLength = UInt(strlen(TestURL.gFileDoesNotExistName)) + TestURL.gRelativeOffsetFromBaseCurrentWorkingDirectory
         XCTAssertEqual(UInt(actualLength), expectedLength, "fileSystemRepresentation was too short")
+#if os(Windows)
+        // On Windows, the url path should have '/' separators, and
+        // the fileSystemRepresentation should '\' separators.
+        XCTAssertTrue(strncmp(String(TestURL.gBaseCurrentWorkingDirectoryPath.map {$0 == "/" ? "\\" : $0} ), fileSystemRep, Int(strlen(TestURL.gBaseCurrentWorkingDirectoryPath))) == 0, "fileSystemRepresentation of base path is wrong")
+#else
         XCTAssertTrue(strncmp(TestURL.gBaseCurrentWorkingDirectoryPath, fileSystemRep, Int(strlen(TestURL.gBaseCurrentWorkingDirectoryPath))) == 0, "fileSystemRepresentation of base path is wrong")
+#endif
         let lengthOfRelativePath = Int(strlen(TestURL.gFileDoesNotExistName))
         let relativePath = fileSystemRep.advanced(by: Int(TestURL.gRelativeOffsetFromBaseCurrentWorkingDirectory))
         XCTAssertTrue(strncmp(TestURL.gFileDoesNotExistName, relativePath, lengthOfRelativePath) == 0, "fileSystemRepresentation of file path is wrong")
@@ -432,7 +439,13 @@ class TestURL : XCTestCase {
         // 1 for path separator
         let expectedLength = UInt(strlen(TestURL.gFileDoesNotExistName)) + TestURL.gRelativeOffsetFromBaseCurrentWorkingDirectory
         XCTAssertEqual(actualLength, expectedLength, "fileSystemRepresentation was too short")
+#if os(Windows)
+        // On Windows, the url path should have '/' separators, and
+        // the fileSystemRepresentation should '\' separators.
+        XCTAssertTrue(strncmp(String(TestURL.gBaseCurrentWorkingDirectoryPath.map { $0 == "/" ? "\\" : $0 }), fileSystemRep, Int(strlen(TestURL.gBaseCurrentWorkingDirectoryPath))) == 0, "fileSystemRepresentation of base path is wrong")
+#else
         XCTAssertTrue(strncmp(TestURL.gBaseCurrentWorkingDirectoryPath, fileSystemRep, Int(strlen(TestURL.gBaseCurrentWorkingDirectoryPath))) == 0, "fileSystemRepresentation of base path is wrong")
+#endif
         let lengthOfRelativePath = Int(strlen(TestURL.gFileDoesNotExistName))
         let relativePath = fileSystemRep.advanced(by: Int(TestURL.gRelativeOffsetFromBaseCurrentWorkingDirectory))
         XCTAssertTrue(strncmp(TestURL.gFileDoesNotExistName, relativePath, lengthOfRelativePath) == 0, "fileSystemRepresentation of file path is wrong")
@@ -459,14 +472,26 @@ class TestURL : XCTestCase {
         do {
             let url = URL(fileURLWithPath: "~")
             let result = url.resolvingSymlinksInPath().absoluteString
+#if os(Windows)
+            // On Windows, currentDirectoryPath will return something
+            // like C:/Users/... Which doesn't have a leading slash
+            let expected = "file:///" + FileManager.default.currentDirectoryPath + "/~"
+#else
             let expected = "file://" + FileManager.default.currentDirectoryPath + "/~"
+#endif
             XCTAssertEqual(result, expected, "URLByResolvingSymlinksInPath resolves relative paths using current working directory.")
         }
 
         do {
             let url = URL(fileURLWithPath: "anysite.com/search")
             let result = url.resolvingSymlinksInPath().absoluteString
+#if os(Windows)
+            // On Windows, currentDirectoryPath will return something
+            // like C:/Users/... Which doesn't have a leading slash
+            let expected = "file:///" + FileManager.default.currentDirectoryPath + "/anysite.com/search"
+#else
             let expected = "file://" + FileManager.default.currentDirectoryPath + "/anysite.com/search"
+#endif
             XCTAssertEqual(result, expected)
         }
 


### PR DESCRIPTION
Modified the helper _getFileSystemRepresentation functions to return a
UTF16 Windows style path.

This makes URL.path return a RFC 1808 path on Windows as opposed to the `C:\...` path before. Since `.path` would no longer be valid to pass to win32 functions, it adds Windows specific file system standardization for `standardizingPath` and `getFileSystemRepresentation`. Paths should now be represented internally as RFC 1808 paths on Windows, and only converted when being passed to win32 functions.