### PR TITLE
Foundation: repair android ARMv7 builds

### DIFF
--- a/Foundation/FileManager+POSIX.swift
+++ b/Foundation/FileManager+POSIX.swift
@@ -591,7 +591,7 @@ extension FileManager {
     internal func _copyOrLinkDirectoryHelper(atPath srcPath: String, toPath dstPath: String, variant: String = "Copy", _ body: (String, String, FileAttributeType) throws -> ()) throws {
         let stat = try _lstatFile(atPath: srcPath)
 
-        let fileType = FileAttributeType(statMode: stat.st_mode)
+        let fileType = FileAttributeType(statMode: mode_t(stat.st_mode))
         if fileType == .typeDirectory {
             try createDirectory(atPath: dstPath, withIntermediateDirectories: false, attributes: nil)
 
@@ -603,7 +603,7 @@ extension FileManager {
                 let src = srcPath + "/" + item
                 let dst = dstPath + "/" + item
                 if let stat = try? _lstatFile(atPath: src) {
-                    let fileType = FileAttributeType(statMode: stat.st_mode)
+                    let fileType = FileAttributeType(statMode: mode_t(stat.st_mode))
                     if fileType == .typeDirectory {
                         try createDirectory(atPath: dst, withIntermediateDirectories: false, attributes: nil)
                     } else {

--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -560,7 +560,7 @@ open class FileManager : NSObject {
             result[.groupOwnerAccountName] = name
         }
 
-        let type = FileAttributeType(statMode: s.st_mode)
+        let type = FileAttributeType(statMode: mode_t(s.st_mode))
 #endif
         result[.type] = type
 


### PR DESCRIPTION
```
D:/a/1/s/swift-corelibs-foundation/Foundation/FileManager.swift:563:50: error: cannot convert value of type 'UInt32' to expected argument type 'mode_t' (aka 'UInt16')
        let type = FileAttributeType(statMode: s.st_mode)
                                               ~~^~~~~~~
                                        mode_t(         )
```