### PR TITLE
[Android]: Fix for compile error addressed Float80 data type.

### DIFF
--- a/Foundation/CGFloat.swift
+++ b/Foundation/CGFloat.swift
@@ -31,7 +31,7 @@ public struct CGFloat {
         self.native = NativeType(value)
     }
     
-#if !os(Windows) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
     @_transparent public init(_ value: Float80) {
         self.native = NativeType(value)
     }


### PR DESCRIPTION
This PR is just a continuation of similar PR made in Swift repository (already merged): https://github.com/apple/swift/pull/25502

Swift forum discussion: https://forums.swift.org/t/android-crosscompilation-on-macos-is-swift-float80-support-really-needed-for-android-intel-x86-and-x86-64-targets/25835