### PR TITLE
Fixes Cmake error "file called with network path DESTINATION"

### DIFF
--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -589,6 +589,11 @@ install(TARGETS
 		  CFURLSessionInterface
         DESTINATION
           "${CMAKE_INSTALL_FULL_LIBDIR}")
+
+# Needed to avoid double slash "//" when CMAKE_INSTALL_PREFIX set to "/" and DESTDIR used to relocate whole installation.
+# Double slash raise CMake error "file called with network path DESTINATION //System/Library/Frameworks".
+string(REGEX REPLACE "/$" "" CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+
 install(DIRECTORY
           ${CoreFoundation_FRAMEWORK_DIRECTORY}
         DESTINATION


### PR DESCRIPTION
This PR fixes install step failure:

```
...
-- Installing: /Install/armv7a/swift-corelibs-foundation/lib/swift/CoreFoundation/ForSwiftFoundationOnly.h
-- Installing: /Install/armv7a/swift-corelibs-foundation/lib/swift/CoreFoundation/module.map
-- Installing: /Install/armv7a/swift-corelibs-foundation/lib/swift/CFURLSessionInterface
-- Installing: /Install/armv7a/swift-corelibs-foundation/lib/swift/CFURLSessionInterface/CFURLSessionInterface.h
-- Installing: /Install/armv7a/swift-corelibs-foundation/lib/swift/CFURLSessionInterface/module.map
-- Installing: /Install/armv7a/swift-corelibs-foundation/usr/lib/libCoreFoundation.a
-- Installing: /Install/armv7a/swift-corelibs-foundation/usr/lib/libCFURLSessionInterface.a
CMake Error at CoreFoundation/cmake_install.cmake:73 (file):
  file called with network path DESTINATION.  This does not make sense when
  using DESTDIR.  Specify local absolute path or remove DESTDIR environment
  variable.

  DESTINATION=

  //System/Library/Frameworks
Call Stack (most recent call first):
  cmake_install.cmake:74 (include)


FAILED: CMakeFiles/install.util
cd /Build/armv7a/swift-corelibs-foundation && /Volumes/Data/Developer/Brew/Cellar/cmake/3.14.5/bin/cmake -P cmake_install.cmake
ninja: build stopped: subcommand failed.
```

Here is a contents of file `/Build/CoreFoundation/cmake_install.cmake`

```
...
if("x${CMAKE_INSTALL_COMPONENT}x" STREQUAL "xUnspecifiedx" OR NOT CMAKE_INSTALL_COMPONENT)
  list(APPEND CMAKE_ABSOLUTE_DESTINATION_FILES
   "//System/Library/Frameworks/CFURLSessionInterface.framework")
  if(CMAKE_WARN_ON_ABSOLUTE_INSTALL_DESTINATION)
    message(WARNING "ABSOLUTE path INSTALL DESTINATION : ${CMAKE_ABSOLUTE_DESTINATION_FILES}")
  endif()
  if(CMAKE_ERROR_ON_ABSOLUTE_INSTALL_DESTINATION)
    message(FATAL_ERROR "ABSOLUTE path INSTALL DESTINATION forbidden (by caller): ${CMAKE_ABSOLUTE_DESTINATION_FILES}")
  endif()
file(INSTALL DESTINATION "//System/Library/Frameworks" TYPE DIRECTORY FILES "/ToolChain/Build/armv7a/swift-corelibs-foundation/CFURLSessionInterface.framework" USE_SOURCE_PERMISSIONS REGEX "/privateheaders$" EXCLUDE)
endif()
```

As you can see there is a double slash `//` in install destination. This cause CMake error. So, we need to avoid such case by performing RegEx replace when `CMAKE_INSTALL_PREFIX` set to `/`. Usually `CMAKE_INSTALL_PREFIX` set to `/` when whole installation relocated with [`DESTDIR` option](https://cmake.org/cmake/help/v3.12/envvar/DESTDIR.html).
