### PR TITLE
Fix two Decimal members with respect to NaN

### DIFF
--- a/Foundation/Decimal.swift
+++ b/Foundation/Decimal.swift
@@ -202,16 +202,12 @@ extension Decimal {
 extension Decimal : Hashable, Comparable {
     internal var doubleValue: Double {
         if _length == 0 {
-            if _isNegative == 1 {
-                return Double.nan
-            } else {
-                return 0
-            }
+            return _isNegative == 1 ? Double.nan : 0
         }
 
         var d = 0.0
-        for idx in stride(from: min(_length, 8), to: 0, by: -1) {
-            d = d * 65536 + Double(self[idx - 1])
+        for idx in (0..<min(_length, 8)).reversed() {
+            d = d * 65536 + Double(self[idx])
         }
 
         if _exponent < 0 {
@@ -336,7 +332,11 @@ extension Decimal : ExpressibleByIntegerLiteral {
 
 extension Decimal : SignedNumeric {
     public var magnitude: Decimal {
-        return Decimal(_exponent: _exponent, _length: _length, _isNegative: 0, _isCompact: _isCompact, _reserved: 0, _mantissa: _mantissa)
+        guard _length != 0 else { return self }
+        return Decimal(
+            _exponent: self._exponent, _length: self._length,
+            _isNegative: 0, _isCompact: self._isCompact,
+            _reserved: 0, _mantissa: self._mantissa)
     }
 
     // FIXME(integers): implement properly

--- a/TestFoundation/TestDecimal.swift
+++ b/TestFoundation/TestDecimal.swift
@@ -375,6 +375,16 @@ class TestDecimal: XCTestCase {
         XCTAssertEqual(Decimal(68040), Decimal(386).advanced(by: Decimal(67654)))
         XCTAssertEqual(Decimal(1.234), abs(Decimal(1.234)))
         XCTAssertEqual(Decimal(1.234), abs(Decimal(-1.234)))
+        XCTAssertEqual((0 as Decimal).magnitude, 0 as Decimal)
+        XCTAssertEqual((1 as Decimal).magnitude, 1 as Decimal)
+        XCTAssertEqual((1 as Decimal).magnitude, abs(1 as Decimal))
+        XCTAssertEqual((1 as Decimal).magnitude, abs(-1 as Decimal))
+        XCTAssertEqual((-1 as Decimal).magnitude, abs(-1 as Decimal))
+        XCTAssertEqual((-1 as Decimal).magnitude, abs(1 as Decimal))
+        XCTAssertEqual(Decimal.leastFiniteMagnitude.magnitude, -Decimal.leastFiniteMagnitude) // A bit of a misnomer.
+        XCTAssertEqual(Decimal.greatestFiniteMagnitude.magnitude, Decimal.greatestFiniteMagnitude)
+        XCTAssertTrue(Decimal.nan.magnitude.isNaN)
+
         var a = Decimal(1234)
         var result = Decimal(0)
         XCTAssertEqual(.noError, NSDecimalMultiplyByPowerOf10(&result, &a, 1, .plain))


### PR DESCRIPTION
_This PR corresponds to apple/swift#25698._

It fixes `Decimal.magnitude` so that `Decimal.nan.magnitude` is no longer incorrectly `0`.

The corresponding PR in the apple/swift repository also incorporates changes from #1759; here, minor edits (NFC), including one suggested on review, are back-propagated so as to help the two versions of `Foundation.Decimal` remain in sync.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-10938](https://bugs.swift.org/browse/SR-10938).