### PR TITLE
Synchronize Decimal with Darwin overlay

### DIFF
--- a/Foundation/Decimal.swift
+++ b/Foundation/Decimal.swift
@@ -196,6 +196,37 @@ extension Decimal {
 }
 
 extension Decimal : Hashable, Comparable {
+    // (Used by VariableLengthNumber and doubleValue.)
+    fileprivate subscript(index: UInt32) -> UInt16 {
+        get {
+            switch index {
+            case 0: return _mantissa.0
+            case 1: return _mantissa.1
+            case 2: return _mantissa.2
+            case 3: return _mantissa.3
+            case 4: return _mantissa.4
+            case 5: return _mantissa.5
+            case 6: return _mantissa.6
+            case 7: return _mantissa.7
+            default: fatalError("Invalid index \(index) for _mantissa")
+            }
+        }
+        set {
+            switch index {
+            case 0: _mantissa.0 = newValue
+            case 1: _mantissa.1 = newValue
+            case 2: _mantissa.2 = newValue
+            case 3: _mantissa.3 = newValue
+            case 4: _mantissa.4 = newValue
+            case 5: _mantissa.5 = newValue
+            case 6: _mantissa.6 = newValue
+            case 7: _mantissa.7 = newValue
+            default: fatalError("Invalid index \(index) for _mantissa")
+            }
+        }
+    }
+
+    // (Used by NSDecimalNumber and hash(into:).)
     internal var doubleValue: Double {
         if _length == 0 {
             return _isNegative == 1 ? Double.nan : 0
@@ -218,13 +249,12 @@ extension Decimal : Hashable, Comparable {
         return _isNegative != 0 ? -d : d
     }
 
-    // Return the low 64bits of the integer part
+    // The low 64 bits of the integer part. (Used by uint64Value and int64Value.)
     private var _unsignedInt64Value: UInt64 {
         if _exponent < -20 || _exponent > 20 {
             return 0
         }
-
-        if _length == 0 || isZero || magnitude < Decimal(0) {
+        if _length == 0 || isZero || magnitude < (0 as Decimal) {
             return 0
         }
 
@@ -243,33 +273,33 @@ extension Decimal : Hashable, Comparable {
         return uint64
     }
 
-    // Perform a best effort conversion of the integer value, trying to match Darwin for
-    // values outside of UInt64.min .. UInt64.max. Used by NSDecimalNumber.
+    // A best-effort conversion of the integer value, trying to match Darwin for
+    // values outside of UInt64.min...UInt64.max. (Used by NSDecimalNumber.)
     internal var uint64Value: UInt64 {
         let value = _unsignedInt64Value
         if !self.isNegative {
             return value
         }
-
         if value == Int64.max.magnitude + 1 {
             return UInt64(bitPattern: Int64.min)
-        } else if value <= Int64.max.magnitude {
+        }
+        if value <= Int64.max.magnitude {
             var value = Int64(value)
             value.negate()
             return UInt64(bitPattern: value)
-        } else {
-            return value
         }
+        return value
     }
 
-    // Perform a best effort conversion of the integer value, trying to match Darwin for
-    // values outside of Int64.min .. Int64.max. Used by NSDecimalNumber.
+    // A best-effort conversion of the integer value, trying to match Darwin for
+    // values outside of Int64.min...Int64.max. (Used by NSDecimalNumber.)
     internal var int64Value: Int64 {
         let uint64Value = _unsignedInt64Value
         if self.isNegative {
             if uint64Value == Int64.max.magnitude + 1 {
                 return Int64.min
-            } else if uint64Value <= Int64.max.magnitude {
+            }
+            if uint64Value <= Int64.max.magnitude {
                 var value = Int64(uint64Value)
                 value.negate()
                 return value
@@ -1900,34 +1930,7 @@ extension Decimal {
         }
         return comparison
     }
-    fileprivate subscript(index:UInt32) -> UInt16 {
-        get {
-            switch index {
-            case 0: return _mantissa.0
-            case 1: return _mantissa.1
-            case 2: return _mantissa.2
-            case 3: return _mantissa.3
-            case 4: return _mantissa.4
-            case 5: return _mantissa.5
-            case 6: return _mantissa.6
-            case 7: return _mantissa.7
-            default: fatalError("Invalid index \(index) for _mantissa")
-            }
-        }
-        set {
-            switch index {
-            case 0: _mantissa.0 = newValue
-            case 1: _mantissa.1 = newValue
-            case 2: _mantissa.2 = newValue
-            case 3: _mantissa.3 = newValue
-            case 4: _mantissa.4 = newValue
-            case 5: _mantissa.5 = newValue
-            case 6: _mantissa.6 = newValue
-            case 7: _mantissa.7 = newValue
-            default: fatalError("Invalid index \(index) for _mantissa")
-            }
-        }
-    }
+
     fileprivate mutating func setNaN() {
         _length = 0
         _isNegative = 1

--- a/Foundation/Decimal.swift
+++ b/Foundation/Decimal.swift
@@ -84,7 +84,7 @@ public struct Decimal {
         self.__reserved = 0
     }
 
-    public init(_exponent: Int32, _length: UInt32, _isNegative: UInt32, _isCompact: UInt32, _reserved: UInt32, _mantissa: (UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16)){
+    public init(_exponent: Int32, _length: UInt32, _isNegative: UInt32, _isCompact: UInt32, _reserved: UInt32, _mantissa: (UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16)) {
         self._mantissa = _mantissa
         self.__exponent = Int8(truncatingIfNeeded: _exponent)
         self.__lengthAndFlags = UInt8(_length & 0b1111)
@@ -340,56 +340,57 @@ extension Decimal : SignedNumeric {
         fatalError()
     }
 
-    public static func +=(_ lhs: inout Decimal, _ rhs: Decimal) {
-        var leftOp = lhs
-        var rightOp = rhs
-        _ = NSDecimalAdd(&lhs, &leftOp, &rightOp, .plain)
+    public static func +=(lhs: inout Decimal, rhs: Decimal) {
+        var rhs = rhs
+        _ = withUnsafeMutablePointer(to: &lhs) {
+            NSDecimalAdd($0, $0, &rhs, .plain)
+        }
     }
 
-    public static func -=(_ lhs: inout Decimal, _ rhs: Decimal) {
-        var leftOp = lhs
-        var rightOp = rhs
-        _ = NSDecimalSubtract(&lhs, &leftOp, &rightOp, .plain)
+    public static func -=(lhs: inout Decimal, rhs: Decimal) {
+        var rhs = rhs
+        _ = withUnsafeMutablePointer(to: &lhs) {
+            NSDecimalSubtract($0, $0, &rhs, .plain)
+        }
     }
 
-    public static func *=(_ lhs: inout Decimal, _ rhs: Decimal) {
-        var leftOp = lhs
-        var rightOp = rhs
-        _ = NSDecimalMultiply(&lhs, &leftOp, &rightOp, .plain)
+    public static func *=(lhs: inout Decimal, rhs: Decimal) {
+        var rhs = rhs
+        _ = withUnsafeMutablePointer(to: &lhs) {
+            NSDecimalMultiply($0, $0, &rhs, .plain)
+        }
     }
 
-    public static func /=(_ lhs: inout Decimal, _ rhs: Decimal) {
-        var leftOp = lhs
-        var rightOp = rhs
-        _ = NSDecimalDivide(&lhs, &leftOp, &rightOp, .plain)
+    public static func /=(lhs: inout Decimal, rhs: Decimal) {
+        var rhs = rhs
+        _ = withUnsafeMutablePointer(to: &lhs) {
+            NSDecimalDivide($0, $0, &rhs, .plain)
+        }
     }
 
     public static func +(lhs: Decimal, rhs: Decimal) -> Decimal {
         var answer = lhs
         answer += rhs
-        return answer;
+        return answer
     }
 
     public static func -(lhs: Decimal, rhs: Decimal) -> Decimal {
         var answer = lhs
         answer -= rhs
-        return answer;
-    }
-
-    public static func /(lhs: Decimal, rhs: Decimal) -> Decimal {
-        var answer = lhs
-        answer /= rhs
-        return answer;
+        return answer
     }
 
     public static func *(lhs: Decimal, rhs: Decimal) -> Decimal {
         var answer = lhs
         answer *= rhs
-        return answer;
+        return answer
     }
 
-    @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
-    public mutating func formTruncatingRemainder(dividingBy other: Decimal) { fatalError("Decimal does not yet fully adopt FloatingPoint") }
+    public static func /(lhs: Decimal, rhs: Decimal) -> Decimal {
+        var answer = lhs
+        answer /= rhs
+        return answer
+    }
 
     public mutating func negate() {
         guard _length != 0 else { return }
@@ -625,6 +626,9 @@ extension Decimal {
     public var isSignaling: Bool {
         return false
     }
+
+    @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
+    public mutating func formTruncatingRemainder(dividingBy other: Decimal) { fatalError("Decimal does not yet fully adopt FloatingPoint") }
 }
 
 extension Decimal: CustomStringConvertible {

--- a/Foundation/Decimal.swift
+++ b/Foundation/Decimal.swift
@@ -100,142 +100,6 @@ extension Decimal {
     public typealias CalculationError = NSDecimalNumber.CalculationError
 }
 
-extension Decimal {
-    public static let leastFiniteMagnitude = Decimal(
-        _exponent: 127,
-        _length: 8,
-        _isNegative: 1,
-        _isCompact: 1,
-        _reserved: 0,
-        _mantissa: (0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff)
-    )
-
-    public static let greatestFiniteMagnitude = Decimal(
-        _exponent: 127,
-        _length: 8,
-        _isNegative: 0,
-        _isCompact: 1,
-        _reserved: 0,
-        _mantissa: (0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff)
-    )
-
-    public static let leastNormalMagnitude = Decimal(
-        _exponent: -127,
-        _length: 1,
-        _isNegative: 0,
-        _isCompact: 1,
-        _reserved: 0,
-        _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000)
-    )
-
-    public static let leastNonzeroMagnitude = Decimal(
-        _exponent: -127,
-        _length: 1,
-        _isNegative: 0,
-        _isCompact: 1,
-        _reserved: 0,
-        _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000)
-    )
-
-    public static let pi = Decimal(
-        _exponent: -38,
-        _length: 8,
-        _isNegative: 0,
-        _isCompact: 1,
-        _reserved: 0,
-        _mantissa: (0x6623, 0x7d57, 0x16e7, 0xad0d, 0xaf52, 0x4641, 0xdfa7, 0xec58)
-    )
-
-    public var exponent: Int {
-        return Int(_exponent)
-    }
-
-    public var significand: Decimal {
-        return Decimal(
-            _exponent: 0, _length: _length, _isNegative: _isNegative, _isCompact: _isCompact,
-            _reserved: 0, _mantissa: _mantissa)
-    }
-
-    public init(sign: FloatingPointSign, exponent: Int, significand: Decimal) {
-        self.init(
-            _exponent: Int32(exponent) + significand._exponent,
-            _length: significand._length,
-            _isNegative: sign == .plus ? 0 : 1,
-            _isCompact: significand._isCompact,
-            _reserved: 0,
-            _mantissa: significand._mantissa)
-    }
-
-    public init(signOf: Decimal, magnitudeOf magnitude: Decimal) {
-        self.init(
-            _exponent: magnitude._exponent,
-            _length: magnitude._length,
-            _isNegative: signOf._isNegative,
-            _isCompact: magnitude._isCompact,
-            _reserved: 0,
-            _mantissa: magnitude._mantissa)
-    }
-
-    public var sign: FloatingPointSign {
-        return _isNegative == 0 ? FloatingPointSign.plus : FloatingPointSign.minus
-    }
-
-    public static var radix: Int {
-        return 10
-    }
-
-    public var ulp: Decimal {
-        if !self.isFinite { return Decimal.nan }
-        return Decimal(
-            _exponent: _exponent, _length: 8, _isNegative: 0, _isCompact: 1,
-            _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
-    }
-
-    public func isEqual(to other: Decimal) -> Bool {
-        return self.compare(to: other) == .orderedSame
-    }
-
-    public func isLess(than other: Decimal) -> Bool {
-        return self.compare(to: other) == .orderedAscending
-    }
-
-    public func isLessThanOrEqualTo(_ other: Decimal) -> Bool {
-        let comparison = self.compare(to: other)
-        return comparison == .orderedAscending || comparison == .orderedSame
-    }
-
-    public func isTotallyOrdered(belowOrEqualTo other: Decimal) -> Bool {
-        // Note: Decimal does not have -0 or infinities to worry about
-        if self.isNaN {
-            return false
-        }
-        if self < other {
-            return true
-        }
-        if other < self {
-            return false
-        }
-        // Fall through to == behavior
-        return true
-    }
-
-    public var isCanonical: Bool {
-        return true
-    }
-
-    public var nextUp: Decimal {
-        return self + Decimal(
-            _exponent: _exponent, _length: 1, _isNegative: 0, _isCompact: 1,
-            _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
-    }
-
-    public var nextDown: Decimal {
-        return self - Decimal(
-            _exponent: _exponent, _length: 1, _isNegative: 0, _isCompact: 1,
-            _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
-    }
-}
-
 extension Decimal : Hashable, Comparable {
     // (Used by VariableLengthNumber and doubleValue.)
     fileprivate subscript(index: UInt32) -> UInt16 {
@@ -634,6 +498,67 @@ extension Decimal : Strideable {
 // If it becomes clear that conformance is truly impossible, we can deprecate
 // some of the methods (e.g. `isEqual(to:)` in favor of operators).
 extension Decimal {
+    public static let leastFiniteMagnitude = Decimal(
+        _exponent: 127,
+        _length: 8,
+        _isNegative: 1,
+        _isCompact: 1,
+        _reserved: 0,
+        _mantissa: (0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff)
+    )
+
+    public static let greatestFiniteMagnitude = Decimal(
+        _exponent: 127,
+        _length: 8,
+        _isNegative: 0,
+        _isCompact: 1,
+        _reserved: 0,
+        _mantissa: (0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff)
+    )
+
+    public static let leastNormalMagnitude = Decimal(
+        _exponent: -127,
+        _length: 1,
+        _isNegative: 0,
+        _isCompact: 1,
+        _reserved: 0,
+        _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000)
+    )
+
+    public static let leastNonzeroMagnitude = Decimal(
+        _exponent: -127,
+        _length: 1,
+        _isNegative: 0,
+        _isCompact: 1,
+        _reserved: 0,
+        _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000)
+    )
+
+    public static let pi = Decimal(
+        _exponent: -38,
+        _length: 8,
+        _isNegative: 0,
+        _isCompact: 1,
+        _reserved: 0,
+        _mantissa: (0x6623, 0x7d57, 0x16e7, 0xad0d, 0xaf52, 0x4641, 0xdfa7, 0xec58)
+    )
+
+    @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
+    public static var infinity: Decimal { fatalError("Decimal does not yet fully adopt FloatingPoint") }
+
+    @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
+    public static var signalingNaN: Decimal { fatalError("Decimal does not yet fully adopt FloatingPoint") }
+
+    public static var quietNaN: Decimal {
+        return Decimal(
+            _exponent: 0, _length: 0, _isNegative: 1, _isCompact: 0,
+            _reserved: 0, _mantissa: (0, 0, 0, 0, 0, 0, 0, 0))
+    }
+
+    public static var nan: Decimal { quietNaN }
+
+    public static var radix: Int { 10 }
+
     public init(_ value: UInt8) {
         self.init(UInt64(value))
     }
@@ -655,6 +580,44 @@ extension Decimal {
     }
 
     public init(_ value: Int32) {
+        self.init(Int64(value))
+    }
+
+    public init(_ value: UInt64) {
+        self = Decimal()
+        if value == 0 {
+            return
+        }
+
+        var compactValue = value
+        var exponent: Int32 = 0
+        while compactValue % 10 == 0 {
+            compactValue /= 10
+            exponent += 1
+        }
+        _isCompact = 1
+        _exponent = exponent
+
+        let wordCount = ((UInt64.bitWidth - compactValue.leadingZeroBitCount) + (UInt16.bitWidth - 1)) / UInt16.bitWidth
+        _length = UInt32(wordCount)
+        _mantissa.0 = UInt16(truncatingIfNeeded: compactValue >> 0)
+        _mantissa.1 = UInt16(truncatingIfNeeded: compactValue >> 16)
+        _mantissa.2 = UInt16(truncatingIfNeeded: compactValue >> 32)
+        _mantissa.3 = UInt16(truncatingIfNeeded: compactValue >> 48)
+    }
+
+    public init(_ value: Int64) {
+        self.init(value.magnitude)
+        if value < 0 {
+            _isNegative = 1
+        }
+    }
+
+    public init(_ value: UInt) {
+        self.init(UInt64(value))
+    }
+
+    public init(_ value: Int) {
         self.init(Int64(value))
     }
 
@@ -714,70 +677,69 @@ extension Decimal {
         }
     }
 
-    public init(_ value: UInt64) {
-        self = Decimal()
-        if value == 0 {
-            return
-        }
-
-        var compactValue = value
-        var exponent: Int32 = 0
-        while compactValue % 10 == 0 {
-            compactValue /= 10
-            exponent += 1
-        }
-        _isCompact = 1
-        _exponent = exponent
-
-        let wordCount = ((UInt64.bitWidth - compactValue.leadingZeroBitCount) + (UInt16.bitWidth - 1)) / UInt16.bitWidth
-        _length = UInt32(wordCount)
-        _mantissa.0 = UInt16(truncatingIfNeeded: compactValue >> 0)
-        _mantissa.1 = UInt16(truncatingIfNeeded: compactValue >> 16)
-        _mantissa.2 = UInt16(truncatingIfNeeded: compactValue >> 32)
-        _mantissa.3 = UInt16(truncatingIfNeeded: compactValue >> 48)
+    public init(sign: FloatingPointSign, exponent: Int, significand: Decimal) {
+        self.init(
+            _exponent: Int32(exponent) + significand._exponent,
+            _length: significand._length,
+            _isNegative: sign == .plus ? 0 : 1,
+            _isCompact: significand._isCompact,
+            _reserved: 0,
+            _mantissa: significand._mantissa)
     }
 
-    public init(_ value: Int64) {
-        self.init(value.magnitude)
-        if value < 0 {
-            _isNegative = 1
-        }
+    public init(signOf: Decimal, magnitudeOf magnitude: Decimal) {
+        self.init(
+            _exponent: magnitude._exponent,
+            _length: magnitude._length,
+            _isNegative: signOf._isNegative,
+            _isCompact: magnitude._isCompact,
+            _reserved: 0,
+            _mantissa: magnitude._mantissa)
     }
 
-    public init(_ value: UInt) {
-        self.init(UInt64(value))
+    public var exponent: Int {
+        return Int(_exponent)
     }
 
-    public init(_ value: Int) {
-        self.init(Int64(value))
-    }
-
-    @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
-    public static var infinity: Decimal { fatalError("Decimal does not yet fully adopt FloatingPoint") }
-
-    @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
-    public static var signalingNaN: Decimal { fatalError("Decimal does not yet fully adopt FloatingPoint") }
-
-    public var isSignalingNaN: Bool {
-        return false
-    }
-
-    public static var nan: Decimal {
-        return quietNaN
-    }
-
-    public static var quietNaN: Decimal {
+    public var significand: Decimal {
         return Decimal(
-            _exponent: 0, _length: 0, _isNegative: 1, _isCompact: 0,
-            _reserved: 0, _mantissa: (0, 0, 0, 0, 0, 0, 0, 0))
+            _exponent: 0, _length: _length, _isNegative: _isNegative, _isCompact: _isCompact,
+            _reserved: 0, _mantissa: _mantissa)
     }
 
+    public var sign: FloatingPointSign {
+        return _isNegative == 0 ? FloatingPointSign.plus : FloatingPointSign.minus
+    }
+
+    public var ulp: Decimal {
+        if !self.isFinite { return Decimal.nan }
+        return Decimal(
+            _exponent: _exponent, _length: 8, _isNegative: 0, _isCompact: 1,
+            _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
+    }
+
+    public var nextUp: Decimal {
+        return self + Decimal(
+            _exponent: _exponent, _length: 1, _isNegative: 0, _isCompact: 1,
+            _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
+    }
+
+    public var nextDown: Decimal {
+        return self - Decimal(
+            _exponent: _exponent, _length: 1, _isNegative: 0, _isCompact: 1,
+            _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
+    }
+
+    /// The IEEE 754 "class" of this type.
     public var floatingPointClass: FloatingPointClassification {
         if _length == 0 && _isNegative == 1 {
             return .quietNaN
         } else if _length == 0 {
             return .positiveZero
         }
+        // NSDecimal does not really represent normal and subnormal in the same
+        // manner as the IEEE standard, for now we can probably claim normal for
+        // any nonzero, non-NaN values.
         if _isNegative == 1 {
             return .negativeNormal
         } else {
@@ -785,36 +747,61 @@ extension Decimal {
         }
     }
 
-    public var isSignMinus: Bool {
-        return _isNegative != 0
+    public var isCanonical: Bool { true }
+
+    /// `true` iff `self` is negative.
+    public var isSignMinus: Bool { _isNegative != 0 }
+
+    /// `true` iff `self` is +0.0 or -0.0.
+    public var isZero: Bool { _length == 0 && _isNegative == 0 }
+
+    /// `true` iff `self` is subnormal.
+    public var isSubnormal: Bool { false }
+
+    /// `true` iff `self` is normal (not zero, subnormal, infinity, or NaN).
+    public var isNormal: Bool { !isZero && !isInfinite && !isNaN }
+
+    /// `true` iff `self` is zero, subnormal, or normal (not infinity or NaN).
+    public var isFinite: Bool { !isNaN }
+
+    /// `true` iff `self` is infinity.
+    public var isInfinite: Bool { false }
+
+    /// `true` iff `self` is NaN.
+    public var isNaN: Bool { _length == 0 && _isNegative == 1 }
+
+    /// `true` iff `self` is a signaling NaN.
+    public var isSignaling: Bool { false }
+
+    /// `true` iff `self` is a signaling NaN.
+    public var isSignalingNaN: Bool { false }
+
+    public func isEqual(to other: Decimal) -> Bool {
+        return self.compare(to: other) == .orderedSame
     }
 
-    public var isNormal: Bool {
-        return !isZero && !isInfinite && !isNaN
+    public func isLess(than other: Decimal) -> Bool {
+        return self.compare(to: other) == .orderedAscending
     }
 
-    public var isFinite: Bool {
-        return !isNaN
+    public func isLessThanOrEqualTo(_ other: Decimal) -> Bool {
+        let comparison = self.compare(to: other)
+        return comparison == .orderedAscending || comparison == .orderedSame
     }
 
-    public var isZero: Bool {
-        return _length == 0 && _isNegative == 0
-    }
-
-    public var isSubnormal: Bool {
-        return false
-    }
-
-    public var isInfinite: Bool {
-        return false
-    }
-
-    public var isNaN: Bool {
-        return _length == 0 && _isNegative == 1
-    }
-
-    public var isSignaling: Bool {
-        return false
+    public func isTotallyOrdered(belowOrEqualTo other: Decimal) -> Bool {
+        // Note: Decimal does not have -0 or infinities to worry about
+        if self.isNaN {
+            return false
+        }
+        if self < other {
+            return true
+        }
+        if other < self {
+            return false
+        }
+        // Fall through to == behavior
+        return true
     }
 
     @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
@@ -842,6 +829,8 @@ extension Decimal: _ObjectiveCBridgeable {
         return result!
     }
 }
+
+// MARK: - End of conformances shared with Darwin overlay
 
 fileprivate func divideByShort<T:VariableLengthNumber>(_ d: inout T, _ divisor:UInt16) -> (UInt16,NSDecimalNumber.CalculationError) {
     if divisor == 0 {

--- a/Foundation/Decimal.swift
+++ b/Foundation/Decimal.swift
@@ -100,6 +100,13 @@ extension Decimal {
     public typealias CalculationError = NSDecimalNumber.CalculationError
 }
 
+public func pow(_ x: Decimal, _ y: Int) -> Decimal {
+    var x = x
+    var result = Decimal()
+    NSDecimalPower(&result, &x, y, .plain)
+    return result
+}
+
 extension Decimal : Hashable, Comparable {
     // (Used by VariableLengthNumber and doubleValue.)
     fileprivate subscript(index: UInt32) -> UInt16 {

--- a/Foundation/Decimal.swift
+++ b/Foundation/Decimal.swift
@@ -9,16 +9,14 @@
 
 import CoreFoundation
 
-public var NSDecimalMaxSize: Int32 { return 8 }
-// Give a precision of at least 38 decimal digits, 128 binary positions.
-
-public var NSDecimalNoScale: Int32 { return Int32(Int16.max) }
+public var NSDecimalMaxSize: Int32 { 8 }
+public var NSDecimalNoScale: Int32 { Int32(Int16.max) }
 
 public struct Decimal {
-    fileprivate static let maxSize: UInt32 = UInt32(NSDecimalMaxSize)
     fileprivate var __exponent: Int8
     fileprivate var __lengthAndFlags: UInt8
     fileprivate var __reserved: UInt16
+
     public var _exponent: Int32 {
         get {
             return Int32(__exponent)
@@ -27,7 +25,8 @@ public struct Decimal {
             __exponent = Int8(truncatingIfNeeded: newValue)
         }
     }
-    // length == 0 && isNegative -> NaN
+
+    // _length == 0 && _isNegative == 1 -> NaN.
     public var _length: UInt32 {
         get {
             return UInt32((__lengthAndFlags & 0b0000_1111))
@@ -41,6 +40,7 @@ public struct Decimal {
                 UInt8(newValue & 0b0000_1111)
         }
     }
+
     public var _isNegative: UInt32 {
         get {
             return UInt32(((__lengthAndFlags) & 0b0001_0000) >> 4)
@@ -51,6 +51,7 @@ public struct Decimal {
                 (UInt8(newValue & 0b0000_0001 ) << 4)
         }
     }
+
     public var _isCompact: UInt32 {
         get {
             return UInt32(((__lengthAndFlags) & 0b0010_0000) >> 5)
@@ -61,6 +62,7 @@ public struct Decimal {
                 (UInt8(newValue & 0b0000_00001 ) << 5)
         }
     }
+
     public var _reserved: UInt32 {
         get {
             return UInt32(UInt32(__lengthAndFlags & 0b1100_0000) << 10 | UInt32(__reserved))
@@ -72,20 +74,14 @@ public struct Decimal {
             __reserved = UInt16(newValue & 0b1111_1111_1111_1111)
         }
     }
+
     public var _mantissa: (UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16)
+
     public init() {
         self._mantissa = (0,0,0,0,0,0,0,0)
         self.__exponent = 0
         self.__lengthAndFlags = 0
         self.__reserved = 0
-    }
-
-    fileprivate init(length: UInt32, mantissa: (UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16)) {
-        self._mantissa = mantissa
-        self.__exponent = 0
-        self.__lengthAndFlags = 0
-        self.__reserved = 0
-        self._length = length
     }
 
     public init(_exponent: Int32, _length: UInt32, _isNegative: UInt32, _isCompact: UInt32, _reserved: UInt32, _mantissa: (UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16)){
@@ -1726,9 +1722,19 @@ fileprivate struct WideDecimal : VariableLengthNumber {
     }
 }
 
-// == Internal (Swifty) functions ==
+// MARK: - Internal (Swifty) functions
 
 extension Decimal {
+    fileprivate static let maxSize: UInt32 = UInt32(NSDecimalMaxSize)
+
+    fileprivate init(length: UInt32, mantissa: (UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16)) {
+        self._mantissa = mantissa
+        self.__exponent = 0
+        self.__lengthAndFlags = 0
+        self.__reserved = 0
+        self._length = length
+    }
+
     fileprivate var isCompact: Bool {
         get {
             return _isCompact != 0

--- a/Foundation/Decimal.swift
+++ b/Foundation/Decimal.swift
@@ -96,6 +96,11 @@ public struct Decimal {
 }
 
 extension Decimal {
+    public typealias RoundingMode = NSDecimalNumber.RoundingMode
+    public typealias CalculationError = NSDecimalNumber.CalculationError
+}
+
+extension Decimal {
     public static let leastFiniteMagnitude = Decimal(
         _exponent: 127,
         _length: 8,
@@ -104,6 +109,7 @@ extension Decimal {
         _reserved: 0,
         _mantissa: (0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff)
     )
+
     public static let greatestFiniteMagnitude = Decimal(
         _exponent: 127,
         _length: 8,
@@ -112,6 +118,7 @@ extension Decimal {
         _reserved: 0,
         _mantissa: (0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff)
     )
+
     public static let leastNormalMagnitude = Decimal(
         _exponent: -127,
         _length: 1,
@@ -120,6 +127,7 @@ extension Decimal {
         _reserved: 0,
         _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000)
     )
+
     public static let leastNonzeroMagnitude = Decimal(
         _exponent: -127,
         _length: 1,
@@ -128,6 +136,7 @@ extension Decimal {
         _reserved: 0,
         _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000)
     )
+
     public static let pi = Decimal(
         _exponent: -38,
         _length: 8,
@@ -136,62 +145,94 @@ extension Decimal {
         _reserved: 0,
         _mantissa: (0x6623, 0x7d57, 0x16e7, 0xad0d, 0xaf52, 0x4641, 0xdfa7, 0xec58)
     )
+
     public var exponent: Int {
-        get {
-            return Int(self.__exponent)
-        }
+        return Int(_exponent)
     }
+
     public var significand: Decimal {
-        get {
-            return Decimal(_exponent: 0, _length: _length, _isNegative: _isNegative, _isCompact: _isCompact, _reserved: 0, _mantissa: _mantissa)
-        }
+        return Decimal(
+            _exponent: 0, _length: _length, _isNegative: _isNegative, _isCompact: _isCompact,
+            _reserved: 0, _mantissa: _mantissa)
     }
+
     public init(sign: FloatingPointSign, exponent: Int, significand: Decimal) {
-        self.init(_exponent: Int32(exponent) + significand._exponent, _length: significand._length, _isNegative: sign == .plus ? 0 : 1, _isCompact: significand._isCompact, _reserved: 0, _mantissa: significand._mantissa)
+        self.init(
+            _exponent: Int32(exponent) + significand._exponent,
+            _length: significand._length,
+            _isNegative: sign == .plus ? 0 : 1,
+            _isCompact: significand._isCompact,
+            _reserved: 0,
+            _mantissa: significand._mantissa)
     }
+
     public init(signOf: Decimal, magnitudeOf magnitude: Decimal) {
-        self.init(_exponent: magnitude._exponent, _length: magnitude._length, _isNegative: signOf._isNegative, _isCompact: magnitude._isCompact, _reserved: 0, _mantissa: magnitude._mantissa)
+        self.init(
+            _exponent: magnitude._exponent,
+            _length: magnitude._length,
+            _isNegative: signOf._isNegative,
+            _isCompact: magnitude._isCompact,
+            _reserved: 0,
+            _mantissa: magnitude._mantissa)
     }
+
     public var sign: FloatingPointSign {
         return _isNegative == 0 ? FloatingPointSign.plus : FloatingPointSign.minus
     }
+
     public static var radix: Int {
         return 10
     }
+
     public var ulp: Decimal {
         if !self.isFinite { return Decimal.nan }
-        return Decimal(_exponent: _exponent, _length: 8, _isNegative: 0, _isCompact: 1, _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
+        return Decimal(
+            _exponent: _exponent, _length: 8, _isNegative: 0, _isCompact: 1,
+            _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
     }
+
     public func isEqual(to other: Decimal) -> Bool {
         return self.compare(to: other) == .orderedSame
     }
+
     public func isLess(than other: Decimal) -> Bool {
         return self.compare(to: other) == .orderedAscending
     }
+
     public func isLessThanOrEqualTo(_ other: Decimal) -> Bool {
         let comparison = self.compare(to: other)
         return comparison == .orderedAscending || comparison == .orderedSame
     }
+
     public func isTotallyOrdered(belowOrEqualTo other: Decimal) -> Bool {
-        // Notes: Decimal does not have -0 or infinities to worry about
+        // Note: Decimal does not have -0 or infinities to worry about
         if self.isNaN {
             return false
-        } else if self < other {
+        }
+        if self < other {
             return true
-        } else if other < self {
+        }
+        if other < self {
             return false
         }
-        // fall through to == behavior
+        // Fall through to == behavior
         return true
     }
+
     public var isCanonical: Bool {
         return true
     }
+
     public var nextUp: Decimal {
-        return self + Decimal(_exponent: _exponent, _length: 1, _isNegative: 0, _isCompact: 1, _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
+        return self + Decimal(
+            _exponent: _exponent, _length: 1, _isNegative: 0, _isCompact: 1,
+            _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
     }
+
     public var nextDown: Decimal {
-        return self - Decimal(_exponent: _exponent, _length: 1, _isNegative: 0, _isCompact: 1, _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
+        return self - Decimal(
+            _exponent: _exponent, _length: 1, _isNegative: 0, _isCompact: 1,
+            _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
     }
 }
 
@@ -587,27 +628,36 @@ extension Decimal : Strideable {
     }
 }
 
+// The methods in this extension exist to match the protocol requirements of
+// FloatingPoint, even if we can't conform directly.
+//
+// If it becomes clear that conformance is truly impossible, we can deprecate
+// some of the methods (e.g. `isEqual(to:)` in favor of operators).
 extension Decimal {
-    public typealias RoundingMode = NSDecimalNumber.RoundingMode
-    public typealias CalculationError = NSDecimalNumber.CalculationError
     public init(_ value: UInt8) {
         self.init(UInt64(value))
     }
+
     public init(_ value: Int8) {
         self.init(Int64(value))
     }
+
     public init(_ value: UInt16) {
         self.init(UInt64(value))
     }
+
     public init(_ value: Int16) {
         self.init(Int64(value))
     }
+
     public init(_ value: UInt32) {
         self.init(UInt64(value))
     }
+
     public init(_ value: Int32) {
         self.init(Int64(value))
     }
+
     public init(_ value: Double) {
         precondition(!value.isInfinite, "Decimal does not yet fully adopt FloatingPoint")
         if value.isNaN {
@@ -629,26 +679,27 @@ extension Decimal {
             }
             var mantissa = UInt64(val)
 
-            var i = Int32(0)
-            // this is a bit ugly but it is the closest approximation of the C initializer that can be expressed here.
+            var i: Int32 = 0
+            // This is a bit ugly but it is the closest approximation of the C
+            // initializer that can be expressed here.
             while mantissa != 0 && i < NSDecimalMaxSize {
                 switch i {
                 case 0:
-                    _mantissa.0 = UInt16(truncatingIfNeeded:mantissa)
+                    _mantissa.0 = UInt16(truncatingIfNeeded: mantissa)
                 case 1:
-                    _mantissa.1 = UInt16(truncatingIfNeeded:mantissa)
+                    _mantissa.1 = UInt16(truncatingIfNeeded: mantissa)
                 case 2:
-                    _mantissa.2 = UInt16(truncatingIfNeeded:mantissa)
+                    _mantissa.2 = UInt16(truncatingIfNeeded: mantissa)
                 case 3:
-                    _mantissa.3 = UInt16(truncatingIfNeeded:mantissa)
+                    _mantissa.3 = UInt16(truncatingIfNeeded: mantissa)
                 case 4:
-                    _mantissa.4 = UInt16(truncatingIfNeeded:mantissa)
+                    _mantissa.4 = UInt16(truncatingIfNeeded: mantissa)
                 case 5:
-                    _mantissa.5 = UInt16(truncatingIfNeeded:mantissa)
+                    _mantissa.5 = UInt16(truncatingIfNeeded: mantissa)
                 case 6:
-                    _mantissa.6 = UInt16(truncatingIfNeeded:mantissa)
+                    _mantissa.6 = UInt16(truncatingIfNeeded: mantissa)
                 case 7:
-                    _mantissa.7 = UInt16(truncatingIfNeeded:mantissa)
+                    _mantissa.7 = UInt16(truncatingIfNeeded: mantissa)
                 default:
                     fatalError("initialization overflow")
                 }
@@ -716,10 +767,11 @@ extension Decimal {
     }
 
     public static var quietNaN: Decimal {
-        var quiet = Decimal()
-        quiet._isNegative = 1
-        return quiet
+        return Decimal(
+            _exponent: 0, _length: 0, _isNegative: 1, _isCompact: 0,
+            _reserved: 0, _mantissa: (0, 0, 0, 0, 0, 0, 0, 0))
     }
+
     public var floatingPointClass: FloatingPointClassification {
         if _length == 0 && _isNegative == 1 {
             return .quietNaN
@@ -732,27 +784,35 @@ extension Decimal {
             return .positiveNormal
         }
     }
+
     public var isSignMinus: Bool {
         return _isNegative != 0
     }
+
     public var isNormal: Bool {
         return !isZero && !isInfinite && !isNaN
     }
+
     public var isFinite: Bool {
         return !isNaN
     }
+
     public var isZero: Bool {
         return _length == 0 && _isNegative == 0
     }
+
     public var isSubnormal: Bool {
         return false
     }
+
     public var isInfinite: Bool {
         return false
     }
+
     public var isNaN: Bool {
         return _length == 0 && _isNegative == 1
     }
+
     public var isSignaling: Bool {
         return false
     }

--- a/TestFoundation/TestDecimal.swift
+++ b/TestFoundation/TestDecimal.swift
@@ -417,6 +417,7 @@ class TestDecimal: XCTestCase {
                 XCTAssertEqual(.noError, NSDecimalPower(&actual, &power, j, .plain))
                 let expected = Decimal(pow(Double(i), Double(j)))
                 XCTAssertEqual(expected, actual, "\(actual) == \(i)^\(j)")
+                XCTAssertEqual(expected, pow(power, j))
             }
         }
     }


### PR DESCRIPTION
Reorganize Decimal.swift, bringing the two implementations back into alignment where it makes sense to do so. Even the organization of the two files has fallen out of sync, making it increasingly difficult to ensure parity.

A [corresponding PR](https://github.com/apple/swift/pull/25745) has been drafted for the Darwin overlay.

The major functional change here is incorporation of the function `pow(_: Decimal, _: Int)`, which is present in the Darwin overlay but not found in swift-corelibs-foundation.