### PR TITLE
[NFC] Grammar: a URL, not an URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Here is a simple `main.swift` file which uses Foundation. This guide assumes you
 ```swift
 import Foundation
 
-// Make an URLComponents instance
+// Make a URLComponents instance
 let swifty = URLComponents(string: "https://swift.org")!
 
 // Print something useful about the URL


### PR DESCRIPTION
Fixes a very small nit: Whether you're reading "URL" or "uniform resource locator," the correct article is "a."