### PR TITLE
Fix Pipe Inheritance on Windows

### DIFF
--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -979,9 +979,12 @@ open class Pipe: NSObject {
 
     public override init() {
 #if os(Windows)
+        var saAttr: SECURITY_ATTRIBUTES = SECURITY_ATTRIBUTES(nLength: DWORD(MemoryLayout<SECURITY_ATTRIBUTES>.size), lpSecurityDescriptor: nil, bInheritHandle: true)
+
         var hReadPipe: HANDLE?
         var hWritePipe: HANDLE?
-        if !CreatePipe(&hReadPipe, &hWritePipe, nil, 0) {
+
+        if !CreatePipe(&hReadPipe, &hWritePipe, &saAttr, 0) {
           fatalError("CreatePipe failed")
         }
         self.fileHandleForReading = FileHandle(handle: hReadPipe!,


### PR DESCRIPTION
- The Security Attributes should allow handle inheritance
- The Startup info should indicate the child should use the passed in
  pipes for stdin/stdout/stderr
- The write end of stdin and read end of stdout/stderr shouldn't be
  inherited by the child