### PR TITLE
[Windows] Handle EOF with Pipes

### DIFF
--- a/Foundation/FileHandle.swift
+++ b/Foundation/FileHandle.swift
@@ -266,8 +266,12 @@ open class FileHandle : NSObject {
 
           var BytesRead: DWORD = 0
           if !ReadFile(_handle, buffer.advanced(by: total), BytesToRead, &BytesRead, nil) {
+            let err = GetLastError()
+            if err == ERROR_BROKEN_PIPE && untilEOF {
+                break
+            }
             free(buffer)
-            throw _NSErrorWithWindowsError(GetLastError(), reading: true)
+            throw _NSErrorWithWindowsError(err, reading: true)
           }
           total += Int(BytesRead)
           if BytesRead == 0 || !untilEOF {


### PR DESCRIPTION
Windows indicates an EOF for a pipe by returning ERROR_BROKEN_PIPE as a
result from ReadFile.