### PR TITLE
Fix TestProcess on Windows

### DIFF
--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -882,7 +882,7 @@ open class Process: NSObject {
     open func terminate() {
         precondition(hasStarted, "task not launched")
 #if os(Windows)
-        TerminateProcess(processHandle, UINT(SIGTERM))
+        TerminateProcess(processHandle, UINT(0xC0000000 | DWORD(SIGTERM)))
 #else
         kill(processIdentifier, SIGTERM)
 #endif
@@ -944,6 +944,9 @@ open class Process: NSObject {
 #if os(Windows)
     open private(set) var processHandle: HANDLE = INVALID_HANDLE_VALUE
     open var processIdentifier: Int32 {
+      guard processHandle != INVALID_HANDLE_VALUE else {
+          return 0
+      }
       return Int32(GetProcessId(processHandle))
     }
     open private(set) var isRunning: Bool = false

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -240,7 +240,7 @@ case "--sleep":
 case "--signal-self":
     if let signalnum = arguments.next(), let signal = Int32(signalnum) {
 #if os(Windows)
-        TerminateProcess(GetCurrentProcess(), UINT(signal))
+        TerminateProcess(GetCurrentProcess(), UINT(0xC0000000 | UINT(signal)))
 #else
         kill(ProcessInfo.processInfo.processIdentifier, signal)
 #endif


### PR DESCRIPTION
Changes to make TestProcess compatible with Windows.

This fixes all the tests except for `test_current_working_directory` which is having issues with path formatting -- the different ways to get a temp directory give different things (`"C:\Users\gwenm\AppData\Local\Temp"`, `"C:\Users\gwenm\AppData\Local\Temp\"`, and `"/C:/Users/gwenm/AppData/Local/Temp"`). Since the cause is not Process.swift related I'd like to get the other path changes merged first to avoid gratuitous rebasing when fixing that.