### PR TITLE
Fallback if statx syscall is not permitted

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -538,20 +538,21 @@ static inline unsigned int _dev_minor(dev_t rdev) {
 
 // There is no glibc statx() function, it must be called using syscall().
 
-static inline ssize_t
+static inline int
 _statx(int dfd, const char *filename, unsigned int flags, unsigned int mask, struct statx *buffer) {
-    return syscall(__NR_statx, dfd, filename, flags, mask, buffer);
+    int ret = syscall(__NR_statx, dfd, filename, flags, mask, buffer);
+    return ret == 0 ? ret : errno;
 }
 
 // At the moment the only extra information statx() is used for is to get the btime (file creation time).
 // This function is here instead of in FileManager.swift because there is no way of setting a conditional
 // define that could be used with a #if in the Swift code.
-static inline ssize_t
+static inline int
 _stat_with_btime(const char *filename, struct stat *buffer, struct timespec *btime) {
     struct statx statx_buffer = {0};
     *btime = (struct timespec) {0};
 
-    ssize_t ret = _statx(AT_FDCWD, filename, AT_SYMLINK_NOFOLLOW | AT_STATX_SYNC_AS_STAT, STATX_ALL, &statx_buffer);
+    int ret = _statx(AT_FDCWD, filename, AT_SYMLINK_NOFOLLOW | AT_STATX_SYNC_AS_STAT, STATX_ALL, &statx_buffer);
     if (ret == 0) {
         *buffer = (struct stat) {
             .st_dev = makedev(statx_buffer.stx_dev_major, statx_buffer.stx_dev_minor),
@@ -587,10 +588,10 @@ _stat_with_btime(const char *filename, struct stat *buffer, struct timespec *bti
 
 // Dummy version when compiled where struct statx is not defined in the headers.
 // Just calles lstat() instead.
-static inline ssize_t
+static inline int
 _stat_with_btime(const char *filename, struct stat *buffer, struct timespec *btime) {
     *btime = (struct timespec) {0};
-    return lstat(filename, buffer);
+    return lstat(filename, buffer) == 0 ? 0 : errno;
 }
 #endif // __NR_statx
 


### PR DESCRIPTION
## Summary

This patch adds a fallback in the `_stat_with_btime` function to `lstat`, in the case where the `statx` system call is available, but is denied (`EPERM`).

## Motivation / context

In https://github.com/apple/swift-corelibs-foundation/pull/1837 the `statx` system call was introduced to be used - when available - to get file attributes including creation time.  If the call isn't available (eg. on older kernels) then the `_stat_with_btime` function falls back to `lstat`.

However, the call may be available but fail for permission reasons: if running under Docker, both Docker's security profile and `libseccomp` need to know about (and permit) the new system call. `libseccomp` added support [in version `2.3.3`](https://github.com/seccomp/libseccomp/commit/5cbecad4e885d63ed6fd174b846b6aee09749cdc), and Docker [in version `18.04`](https://github.com/docker/for-linux/issues/208).

It happens that, in a Travis environment, you get an older version of libseccomp that doesn't know about (and denies) statx, and this results in a Swift Package Manager failure (trying to verify the presence of `swiftc` by querying its file attributes).
...I was able to work around this our CI by upgrading the `libseccomp` package before invoking Docker, but this patch will ensure it functions if statx exists, but is denied.