### PR TITLE
refactored NotificationCenter to use hash based storage for faster filtering

### DIFF
--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -160,10 +160,9 @@ open class NotificationCenter: NSObject {
         let receiverIdentifier: ObjectIdentifier = ObjectIdentifier(observer)
         
         _observersLock.synchronized({
-            if _observers[notificationNameIdentifier]?[senderIdentifier]?.count == 1 {
+            _observers[notificationNameIdentifier]?[senderIdentifier]?.removeValue(forKey: receiverIdentifier)
+            if _observers[notificationNameIdentifier]?[senderIdentifier]?.count == 0 {
                 _observers[notificationNameIdentifier]?.removeValue(forKey: senderIdentifier)
-            } else {
-                _observers[notificationNameIdentifier]?[senderIdentifier]?.removeValue(forKey: receiverIdentifier)
             }
         })
     }

--- a/Foundation/NSNotification.swift
+++ b/Foundation/NSNotification.swift
@@ -149,8 +149,8 @@ open class NotificationCenter: NSObject {
     open func removeObserver(_ observer: Any, name aName: NSNotification.Name?, object: Any?) {
         guard let observer = observer as? NSNotificationReceiver,
             // These 2 parameters would only be useful for removing notifications added by `addObserver:selector:name:object:`
-            observer.name == aName || aName == nil,
-            observer.sender === __SwiftValue.store(object) || object == nil
+            aName == nil || observer.name == aName,
+            object == nil || observer.sender === __SwiftValue.store(object)
         else {
             return
         }


### PR DESCRIPTION
I'm rewriting the NotificationCenter API for myself to use associated types and my performance tests have to be boosted on Linux because of the low performance. This should increase performance when NotificationCenter has a lot of observations.

You can find the performance tests in this repo: https://github.com/Cyberbeni/TypedNotificationCenter