### PR TITLE
CoreFoundation: remove private headers from public directory

### DIFF
--- a/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
+++ b/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
@@ -96,7 +96,5 @@
 #include <CoreFoundation/CFAttributedString.h>
 #include <CoreFoundation/CFNotificationCenter.h>
 
-#include <CoreFoundation/ForSwiftFoundationOnly.h>
-
 #endif /* ! __COREFOUNDATION_COREFOUNDATION__ */
 

--- a/CoreFoundation/Base.subproj/module.private.modulemap
+++ b/CoreFoundation/Base.subproj/module.private.modulemap
@@ -1,0 +1,8 @@
+framework module CoreFoundation_Private [extern_c] [system] {
+  umbrella header "ForSwiftFoundationOnly.h"
+
+  export *
+  module * {
+    export *
+  }
+}

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -117,11 +117,13 @@ add_framework(CoreFoundation
                 CoreFoundation_FRAMEWORK_DIRECTORY
               MODULE_MAP
                 Base.subproj/module.modulemap
+                Base.subproj/module.private.modulemap
               PRIVATE_HEADERS
                 # Base
                 Base.subproj/CFAsmMacros.h
                 Base.subproj/CFInternal.h
                 Base.subproj/CFKnownLocations.h
+                Base.subproj/CFLocking.h
                 Base.subproj/CFLogUtilities.h
                 Base.subproj/CFPriv.h
                 Base.subproj/CFOverflow.h
@@ -185,29 +187,6 @@ add_framework(CoreFoundation
                 URL.subproj/CFURLPriv.h
                 URL.subproj/CFURLSessionInterface.h
               PUBLIC_HEADERS
-                # FIXME: PrivateHeaders referenced by public headers
-                Base.subproj/CFKnownLocations.h
-                Base.subproj/CFLocking.h
-                Base.subproj/CFLogUtilities.h
-                Base.subproj/CFPriv.h
-                Base.subproj/CFRuntime.h
-                Base.subproj/ForFoundationOnly.h
-                Base.subproj/ForSwiftFoundationOnly.h
-                Locale.subproj/CFCalendar_Internal.h
-                Locale.subproj/CFDateComponents.h
-                Locale.subproj/CFDateInterval.h
-                Locale.subproj/CFLocaleInternal.h
-                PlugIn.subproj/CFBundlePriv.h
-                Stream.subproj/CFStreamPriv.h
-                String.subproj/CFCharacterSetPriv.h
-                String.subproj/CFRegularExpression.h
-                String.subproj/CFRunArray.h
-                StringEncodings.subproj/CFStringEncodingConverter.h
-                StringEncodings.subproj/CFStringEncodingConverterExt.h
-                URL.subproj/CFURLPriv.h
-                URL.subproj/CFURLSessionInterface.h
-                Locale.subproj/CFDateIntervalFormatter.h
-
                 # AppServices
                 AppServices.subproj/CFNotificationCenter.h
                 AppServices.subproj/CFUserNotification.h
@@ -414,8 +393,6 @@ add_framework(CFURLSessionInterface
                 CFURLSessionInterface_FRAMEWORK_DIRECTORY
               MODULE_MAP
                 URL.subproj/module.modulemap
-              PRIVATE_HEADERS
-                URL.subproj/CFURLSessionInterface.h
               PUBLIC_HEADERS
                 URL.subproj/CFURLSessionInterface.h
               SOURCES
@@ -437,8 +414,6 @@ add_framework(CFXMLInterface
                 CFXMLInterface_FRAMEWORK_DIRECTORY
               MODULE_MAP
                 Parsing.subproj/module.modulemap
-              PRIVATE_HEADERS
-                Parsing.subproj/CFXMLInterface.h
               PUBLIC_HEADERS
                 Parsing.subproj/CFXMLInterface.h
               SOURCES

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -343,7 +343,7 @@ void _CFXMLInterfaceSAX2UnparsedEntityDecl(_CFXMLInterfaceParserContext ctx, con
 }
 
 CFErrorRef _CFErrorCreateFromXMLInterface(_CFXMLInterfaceError err) {
-    return __CFSwiftXMLParserBridge.CF.CFErrorCreate(*(__CFSwiftXMLParserBridge.CF.kCFAllocatorSystemDefault), __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, "NSXMLParserErrorDomain", kCFStringEncodingUTF8), err->code, NULL);
+    return __CFSwiftXMLParserBridge.CF->CFErrorCreate(*(__CFSwiftXMLParserBridge.CF->kCFAllocatorSystemDefault), __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, "NSXMLParserErrorDomain", kCFStringEncodingUTF8), err->code, NULL);
 }
 
 _CFXMLNodePtr _CFXMLNewNode(_CFXMLNamespacePtr namespace, const char* name) {
@@ -408,9 +408,9 @@ CFStringRef _CFXMLNodeCopyURI(_CFXMLNodePtr node) {
         case XML_ATTRIBUTE_NODE:
         case XML_ELEMENT_NODE:
             if (nodePtr->ns && nodePtr->ns->href) {
-                return __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)nodePtr->ns->href, kCFStringEncodingUTF8);
+                return __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)nodePtr->ns->href, kCFStringEncodingUTF8);
             } else if (nodePtr->nsDef && nodePtr->nsDef->href) {
-                return __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)nodePtr->nsDef->href, kCFStringEncodingUTF8);
+                return __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)nodePtr->nsDef->href, kCFStringEncodingUTF8);
             } else {
                 return NULL;
             }
@@ -418,7 +418,7 @@ CFStringRef _CFXMLNodeCopyURI(_CFXMLNodePtr node) {
         case XML_DOCUMENT_NODE:
         {
             xmlDocPtr doc = (xmlDocPtr)node;
-            return __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)doc->URL, kCFStringEncodingUTF8);
+            return __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)doc->URL, kCFStringEncodingUTF8);
         }
 
         default:
@@ -522,7 +522,7 @@ CFStringRef _Nullable _CFXMLNodeCopyName(_CFXMLNodePtr node) {
     xmlChar* qName = _getQName(xmlNode);
     
     if (qName != NULL) {
-        CFStringRef result = __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)qName, kCFStringEncodingUTF8);
+        CFStringRef result = __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)qName, kCFStringEncodingUTF8);
         if (qName != xmlNode->name) {
             xmlFree(qName);
         }
@@ -552,7 +552,7 @@ CFStringRef _CFXMLNodeCopyContent(_CFXMLNodePtr node) {
         {
             char* buffer = calloc(2048, 1);
             xmlSnprintfElementContent(buffer, 2047, ((xmlElementPtr)node)->content, 1);
-            CFStringRef result = __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, buffer, kCFStringEncodingUTF8);
+            CFStringRef result = __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, buffer, kCFStringEncodingUTF8);
             free(buffer);
             return result;
         }
@@ -563,7 +563,7 @@ CFStringRef _CFXMLNodeCopyContent(_CFXMLNodePtr node) {
             if (content == NULL) {
                 return NULL;
             }
-            CFStringRef result = __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)content, kCFStringEncodingUTF8);
+            CFStringRef result = __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)content, kCFStringEncodingUTF8);
             xmlFree(content);
             
             return result;
@@ -586,16 +586,16 @@ void _CFXMLNodeSetContent(_CFXMLNodePtr node, const unsigned char* _Nullable  co
 
             // rather than writing custom code to parse the new content into the correct
             // xmlElementContent structures, let's leverage what we've already got.
-            CFMutableStringRef xmlString = __CFSwiftXMLParserBridge.CF.CFStringCreateMutable(NULL, 0);
-            __CFSwiftXMLParserBridge.CF.CFStringAppend(xmlString, __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, "<!ELEMENT ", kCFStringEncodingUTF8));
-            __CFSwiftXMLParserBridge.CF.CFStringAppendCString(xmlString, (const char*)element->name, kCFStringEncodingUTF8);
-            __CFSwiftXMLParserBridge.CF.CFStringAppend(xmlString, __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, " ", kCFStringEncodingUTF8));
-            __CFSwiftXMLParserBridge.CF.CFStringAppendCString(xmlString, (const char*)content, kCFStringEncodingUTF8);
-            __CFSwiftXMLParserBridge.CF.CFStringAppend(xmlString, __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, ">", kCFStringEncodingUTF8));
+            CFMutableStringRef xmlString = __CFSwiftXMLParserBridge.CF->CFStringCreateMutable(NULL, 0);
+            __CFSwiftXMLParserBridge.CF->CFStringAppend(xmlString, __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, "<!ELEMENT ", kCFStringEncodingUTF8));
+            __CFSwiftXMLParserBridge.CF->CFStringAppendCString(xmlString, (const char*)element->name, kCFStringEncodingUTF8);
+            __CFSwiftXMLParserBridge.CF->CFStringAppend(xmlString, __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, " ", kCFStringEncodingUTF8));
+            __CFSwiftXMLParserBridge.CF->CFStringAppendCString(xmlString, (const char*)content, kCFStringEncodingUTF8);
+            __CFSwiftXMLParserBridge.CF->CFStringAppend(xmlString, __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, ">", kCFStringEncodingUTF8));
 
-            size_t bufferSize = __CFSwiftXMLParserBridge.CF.CFStringGetMaximumSizeForEncoding(__CFSwiftXMLParserBridge.CF.CFStringGetLength(xmlString), kCFStringEncodingUTF8) + 1;
+            size_t bufferSize = __CFSwiftXMLParserBridge.CF->CFStringGetMaximumSizeForEncoding(__CFSwiftXMLParserBridge.CF->CFStringGetLength(xmlString), kCFStringEncodingUTF8) + 1;
             char* buffer = calloc(bufferSize, 1);
-            __CFSwiftXMLParserBridge.CF.CFStringGetCString(xmlString, buffer, bufferSize, kCFStringEncodingUTF8);
+            __CFSwiftXMLParserBridge.CF->CFStringGetCString(xmlString, buffer, bufferSize, kCFStringEncodingUTF8);
             xmlElementPtr resultNode = _CFXMLParseDTDNode((const xmlChar*)buffer);
 
             if (resultNode) {
@@ -639,7 +639,7 @@ CFStringRef _CFXMLEncodeEntities(_CFXMLDocPtr doc, const unsigned char* string) 
     
     const xmlChar* stringResult = xmlEncodeEntitiesReentrant(doc, string);
     
-    CFStringRef result = __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)stringResult, kCFStringEncodingUTF8);
+    CFStringRef result = __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)stringResult, kCFStringEncodingUTF8);
 
     xmlFree((xmlChar*)stringResult);
 
@@ -739,7 +739,7 @@ void _CFXMLDocSetRootElement(_CFXMLDocPtr doc, _CFXMLNodePtr node) {
 }
 
 CFStringRef _CFXMLDocCopyCharacterEncoding(_CFXMLDocPtr doc) {
-    return __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)((xmlDocPtr)doc)->encoding, kCFStringEncodingUTF8);
+    return __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)((xmlDocPtr)doc)->encoding, kCFStringEncodingUTF8);
 }
 
 void _CFXMLDocSetCharacterEncoding(_CFXMLDocPtr doc,  const unsigned char* _Nullable  encoding) {
@@ -753,7 +753,7 @@ void _CFXMLDocSetCharacterEncoding(_CFXMLDocPtr doc,  const unsigned char* _Null
 }
 
 CFStringRef _CFXMLDocCopyVersion(_CFXMLDocPtr doc) {
-    return __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)((xmlDocPtr)doc)->version, kCFStringEncodingUTF8);
+    return __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)((xmlDocPtr)doc)->version, kCFStringEncodingUTF8);
 }
 
 void _CFXMLDocSetVersion(_CFXMLDocPtr doc, const unsigned char* version) {
@@ -846,7 +846,7 @@ CFStringRef _CFXMLCopyEntityContent(_CFXMLEntityPtr entity) {
     }
 
     CFIndex length = ((xmlEntityPtr)entity)->length;
-    CFStringRef result = __CFSwiftXMLParserBridge.CF.CFStringCreateWithBytes(NULL, content, length, kCFStringEncodingUTF8, false);
+    CFStringRef result = __CFSwiftXMLParserBridge.CF->CFStringCreateWithBytes(NULL, content, length, kCFStringEncodingUTF8, false);
 
     return result;
 }
@@ -856,36 +856,36 @@ CFStringRef _CFXMLCopyStringWithOptions(_CFXMLNodePtr node, uint32_t options) {
         ((xmlEntityPtr)node)->etype == XML_INTERNAL_PREDEFINED_ENTITY) {
         // predefined entities need special handling, libxml2 just tosses an error and returns a NULL string
         // if we try to use xmlSaveTree on a predefined entity
-        CFMutableStringRef result = __CFSwiftXMLParserBridge.CF.CFStringCreateMutable(NULL, 0);
-        __CFSwiftXMLParserBridge.CF.CFStringAppend(result, __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, "<!ENTITY ", kCFStringEncodingUTF8));
-        __CFSwiftXMLParserBridge.CF.CFStringAppendCString(result, (const char*)((xmlEntityPtr)node)->name, kCFStringEncodingUTF8);
-        __CFSwiftXMLParserBridge.CF.CFStringAppend(result, __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, " \"", kCFStringEncodingUTF8));
-        __CFSwiftXMLParserBridge.CF.CFStringAppendCString(result, (const char*)((xmlEntityPtr)node)->content, kCFStringEncodingUTF8);
-        __CFSwiftXMLParserBridge.CF.CFStringAppend(result, __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, "\">", kCFStringEncodingUTF8));
+        CFMutableStringRef result = __CFSwiftXMLParserBridge.CF->CFStringCreateMutable(NULL, 0);
+        __CFSwiftXMLParserBridge.CF->CFStringAppend(result, __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, "<!ENTITY ", kCFStringEncodingUTF8));
+        __CFSwiftXMLParserBridge.CF->CFStringAppendCString(result, (const char*)((xmlEntityPtr)node)->name, kCFStringEncodingUTF8);
+        __CFSwiftXMLParserBridge.CF->CFStringAppend(result, __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, " \"", kCFStringEncodingUTF8));
+        __CFSwiftXMLParserBridge.CF->CFStringAppendCString(result, (const char*)((xmlEntityPtr)node)->content, kCFStringEncodingUTF8);
+        __CFSwiftXMLParserBridge.CF->CFStringAppend(result, __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, "\">", kCFStringEncodingUTF8));
 
         return result;
     } else if (((xmlNodePtr)node)->type == XML_NOTATION_NODE) {
         // This is not actually a thing that occurs naturally in libxml2
         xmlNotationPtr notation = ((_cfxmlNotation*)node)->notation;
-        CFMutableStringRef result = __CFSwiftXMLParserBridge.CF.CFStringCreateMutable(NULL, 0);
-        __CFSwiftXMLParserBridge.CF.CFStringAppend(result, __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, "<!NOTATION ", kCFStringEncodingUTF8));
-        __CFSwiftXMLParserBridge.CF.CFStringAppendCString(result, (const char*)notation->name, kCFStringEncodingUTF8);
-        __CFSwiftXMLParserBridge.CF.CFStringAppend(result, __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, " ", kCFStringEncodingUTF8));
+        CFMutableStringRef result = __CFSwiftXMLParserBridge.CF->CFStringCreateMutable(NULL, 0);
+        __CFSwiftXMLParserBridge.CF->CFStringAppend(result, __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, "<!NOTATION ", kCFStringEncodingUTF8));
+        __CFSwiftXMLParserBridge.CF->CFStringAppendCString(result, (const char*)notation->name, kCFStringEncodingUTF8);
+        __CFSwiftXMLParserBridge.CF->CFStringAppend(result, __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, " ", kCFStringEncodingUTF8));
         if (notation->PublicID == NULL && notation->SystemID != NULL) {
-            __CFSwiftXMLParserBridge.CF.CFStringAppend(result, __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, "SYSTEM ", kCFStringEncodingUTF8));
+            __CFSwiftXMLParserBridge.CF->CFStringAppend(result, __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, "SYSTEM ", kCFStringEncodingUTF8));
         } else if (notation->PublicID != NULL) {
-            __CFSwiftXMLParserBridge.CF.CFStringAppend(result, __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, "PUBLIC \"", kCFStringEncodingUTF8));
-            __CFSwiftXMLParserBridge.CF.CFStringAppendCString(result, (const char*)notation->PublicID, kCFStringEncodingUTF8);
-            __CFSwiftXMLParserBridge.CF.CFStringAppend(result, __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, "\"", kCFStringEncodingUTF8));
+            __CFSwiftXMLParserBridge.CF->CFStringAppend(result, __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, "PUBLIC \"", kCFStringEncodingUTF8));
+            __CFSwiftXMLParserBridge.CF->CFStringAppendCString(result, (const char*)notation->PublicID, kCFStringEncodingUTF8);
+            __CFSwiftXMLParserBridge.CF->CFStringAppend(result, __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, "\"", kCFStringEncodingUTF8));
         }
 
         if (notation->SystemID != NULL) {
-            __CFSwiftXMLParserBridge.CF.CFStringAppend(result, __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, "\"", kCFStringEncodingUTF8));
-            __CFSwiftXMLParserBridge.CF.CFStringAppendCString(result, (const char*)notation->SystemID, kCFStringEncodingUTF8);
-            __CFSwiftXMLParserBridge.CF.CFStringAppend(result, __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, "\"", kCFStringEncodingUTF8));
+            __CFSwiftXMLParserBridge.CF->CFStringAppend(result, __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, "\"", kCFStringEncodingUTF8));
+            __CFSwiftXMLParserBridge.CF->CFStringAppendCString(result, (const char*)notation->SystemID, kCFStringEncodingUTF8);
+            __CFSwiftXMLParserBridge.CF->CFStringAppend(result, __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, "\"", kCFStringEncodingUTF8));
         }
 
-        __CFSwiftXMLParserBridge.CF.CFStringAppend(result, __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, " >", kCFStringEncodingUTF8));
+        __CFSwiftXMLParserBridge.CF->CFStringAppend(result, __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, " >", kCFStringEncodingUTF8));
 
         return result;
     }
@@ -911,12 +911,12 @@ CFStringRef _CFXMLCopyStringWithOptions(_CFXMLNodePtr node, uint32_t options) {
     int error = xmlSaveClose(ctx);
 
     if (error == -1) {
-        return __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, "", kCFStringEncodingUTF8);
+        return __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, "", kCFStringEncodingUTF8);
     }
 
     const xmlChar* bufferContents = xmlBufferContent(buffer);
 
-    CFStringRef result = __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)bufferContents, kCFStringEncodingUTF8);
+    CFStringRef result = __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)bufferContents, kCFStringEncodingUTF8);
 
     xmlBufferFree(buffer);
 
@@ -944,9 +944,9 @@ CFArrayRef _CFXMLNodesForXPath(_CFXMLNodePtr node, const unsigned char* xpath) {
     xmlNodeSetPtr nodes = evalResult->nodesetval;
     int count = nodes ? nodes->nodeNr : 0;
 
-    CFMutableArrayRef results = __CFSwiftXMLParserBridge.CF.CFArrayCreateMutable(NULL, count, NULL);
+    CFMutableArrayRef results = __CFSwiftXMLParserBridge.CF->CFArrayCreateMutable(NULL, count, NULL);
     for (int i = 0; i < count; i++) {
-        __CFSwiftXMLParserBridge.CF.CFArrayAppendValue(results, nodes->nodeTab[i]);
+        __CFSwiftXMLParserBridge.CF->CFArrayAppendValue(results, nodes->nodeTab[i]);
     }
 
     xmlXPathFreeContext(context);
@@ -957,7 +957,7 @@ CFArrayRef _CFXMLNodesForXPath(_CFXMLNodePtr node, const unsigned char* xpath) {
 
 CFStringRef _Nullable _CFXMLCopyPathForNode(_CFXMLNodePtr node) {
     xmlChar* path = xmlGetNodePath(node);
-    CFStringRef result = __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)path, kCFStringEncodingUTF8);
+    CFStringRef result = __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)path, kCFStringEncodingUTF8);
     xmlFree(path);
     return result;
 }
@@ -1050,7 +1050,7 @@ _CFXMLDocPtr _CFXMLDocPtrFromDataWithOptions(CFDataRef data, unsigned int option
     xmlOptions |= XML_PARSE_RECOVER;
     xmlOptions |= XML_PARSE_NSCLEAN;
     
-    return xmlReadMemory((const char*)__CFSwiftXMLParserBridge.CF.CFDataGetBytePtr(data), __CFSwiftXMLParserBridge.CF.CFDataGetLength(data), NULL, NULL, xmlOptions);
+    return xmlReadMemory((const char*)__CFSwiftXMLParserBridge.CF->CFDataGetBytePtr(data), __CFSwiftXMLParserBridge.CF->CFDataGetLength(data), NULL, NULL, xmlOptions);
 }
 
 CFStringRef _CFXMLNodeCopyLocalName(_CFXMLNodePtr node) {
@@ -1060,14 +1060,14 @@ CFStringRef _CFXMLNodeCopyLocalName(_CFXMLNodePtr node) {
         result = ((xmlNodePtr)node)->name;
     }
     
-    return __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)result, kCFStringEncodingUTF8);
+    return __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)result, kCFStringEncodingUTF8);
 }
 
 CFStringRef _CFXMLNodeCopyPrefix(_CFXMLNodePtr node) {
     xmlChar* result = NULL;
     xmlChar* unused = xmlSplitQName2(_getQName((xmlNodePtr)node), &result);
 
-    CFStringRef resultString = __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)result, kCFStringEncodingUTF8);
+    CFStringRef resultString = __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)result, kCFStringEncodingUTF8);
     xmlFree(result);
     xmlFree(unused);
 
@@ -1083,14 +1083,14 @@ void _CFXMLValidityErrorHandler(void* ctxt, const char* msg, ...) {
     vsprintf(formattedMessage, msg, args);
     va_end(args);
 
-    CFStringRef message = __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, formattedMessage, kCFStringEncodingUTF8);
-    __CFSwiftXMLParserBridge.CF.CFStringAppend(ctxt, message);
-    __CFSwiftXMLParserBridge.CF.CFRelease(message);
+    CFStringRef message = __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, formattedMessage, kCFStringEncodingUTF8);
+    __CFSwiftXMLParserBridge.CF->CFStringAppend(ctxt, message);
+    __CFSwiftXMLParserBridge.CF->CFRelease(message);
     free(formattedMessage);
 }
 
 bool _CFXMLDocValidate(_CFXMLDocPtr doc, CFErrorRef _Nullable * error) {
-    CFMutableStringRef errorMessage = __CFSwiftXMLParserBridge.CF.CFStringCreateMutable(NULL, 0);
+    CFMutableStringRef errorMessage = __CFSwiftXMLParserBridge.CF->CFStringCreateMutable(NULL, 0);
 
     xmlValidCtxtPtr ctxt = xmlNewValidCtxt();
     ctxt->error = &_CFXMLValidityErrorHandler;
@@ -1101,15 +1101,15 @@ bool _CFXMLDocValidate(_CFXMLDocPtr doc, CFErrorRef _Nullable * error) {
     xmlFreeValidCtxt(ctxt);
 
     if (result == 0 && error != NULL) {
-        CFMutableDictionaryRef userInfo = __CFSwiftXMLParserBridge.CF.CFDictionaryCreateMutable(NULL, 1, __CFSwiftXMLParserBridge.CF.kCFCopyStringDictionaryKeyCallBacks, __CFSwiftXMLParserBridge.CF.kCFTypeDictionaryValueCallBacks);
-        __CFSwiftXMLParserBridge.CF.CFDictionarySetValue(userInfo, *(__CFSwiftXMLParserBridge.CF.kCFErrorLocalizedDescriptionKey), errorMessage);
+        CFMutableDictionaryRef userInfo = __CFSwiftXMLParserBridge.CF->CFDictionaryCreateMutable(NULL, 1, __CFSwiftXMLParserBridge.CF->kCFCopyStringDictionaryKeyCallBacks, __CFSwiftXMLParserBridge.CF->kCFTypeDictionaryValueCallBacks);
+        __CFSwiftXMLParserBridge.CF->CFDictionarySetValue(userInfo, *(__CFSwiftXMLParserBridge.CF->kCFErrorLocalizedDescriptionKey), errorMessage);
 
-        *error = __CFSwiftXMLParserBridge.CF.CFErrorCreate(NULL, __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, "NSXMLParserErrorDomain", kCFStringEncodingUTF8), 0, userInfo);
+        *error = __CFSwiftXMLParserBridge.CF->CFErrorCreate(NULL, __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, "NSXMLParserErrorDomain", kCFStringEncodingUTF8), 0, userInfo);
 
-        __CFSwiftXMLParserBridge.CF.CFRelease(userInfo);
+        __CFSwiftXMLParserBridge.CF->CFRelease(userInfo);
     }
 
-    __CFSwiftXMLParserBridge.CF.CFRelease(errorMessage);
+    __CFSwiftXMLParserBridge.CF->CFRelease(errorMessage);
 
     return result != 0;
 }
@@ -1127,9 +1127,9 @@ void _CFXMLNotationScanner(void* payload, void* data, xmlChar* name) {
 }
 
 _CFXMLDTDNodePtr _CFXMLParseDTDNode(const unsigned char* xmlString) {
-    CFDataRef data = __CFSwiftXMLParserBridge.CF.CFDataCreateWithBytesNoCopy(NULL, xmlString, xmlStrlen(xmlString), *(__CFSwiftXMLParserBridge.CF.kCFAllocatorNull));
+    CFDataRef data = __CFSwiftXMLParserBridge.CF->CFDataCreateWithBytesNoCopy(NULL, xmlString, xmlStrlen(xmlString), *(__CFSwiftXMLParserBridge.CF->kCFAllocatorNull));
     xmlDtdPtr dtd = _CFXMLParseDTDFromData(data, NULL);
-    __CFSwiftXMLParserBridge.CF.CFRelease(data);
+    __CFSwiftXMLParserBridge.CF->CFRelease(data);
 
     if (dtd == NULL) {
         return NULL;
@@ -1151,24 +1151,24 @@ _CFXMLDTDPtr _Nullable _CFXMLParseDTD(const unsigned char* URL) {
 }
 
 _CFXMLDTDPtr _Nullable _CFXMLParseDTDFromData(CFDataRef data, CFErrorRef _Nullable * error) {
-    xmlParserInputBufferPtr inBuffer = xmlParserInputBufferCreateMem((const char*)__CFSwiftXMLParserBridge.CF.CFDataGetBytePtr(data), __CFSwiftXMLParserBridge.CF.CFDataGetLength(data), XML_CHAR_ENCODING_UTF8);
+    xmlParserInputBufferPtr inBuffer = xmlParserInputBufferCreateMem((const char*)__CFSwiftXMLParserBridge.CF->CFDataGetBytePtr(data), __CFSwiftXMLParserBridge.CF->CFDataGetLength(data), XML_CHAR_ENCODING_UTF8);
 
     xmlSAXHandler handler;
     handler.error = &_CFXMLValidityErrorHandler;
-    CFMutableStringRef errorMessage = __CFSwiftXMLParserBridge.CF.CFStringCreateMutable(NULL, 0);
+    CFMutableStringRef errorMessage = __CFSwiftXMLParserBridge.CF->CFStringCreateMutable(NULL, 0);
     handler._private = errorMessage;
 
     xmlDtdPtr dtd = xmlIOParseDTD(NULL, inBuffer, XML_CHAR_ENCODING_UTF8);
 
     if (dtd == NULL && error != NULL) {
-        CFMutableDictionaryRef userInfo = __CFSwiftXMLParserBridge.CF.CFDictionaryCreateMutable(NULL, 1, __CFSwiftXMLParserBridge.CF.kCFCopyStringDictionaryKeyCallBacks, __CFSwiftXMLParserBridge.CF.kCFTypeDictionaryValueCallBacks);
-        __CFSwiftXMLParserBridge.CF.CFDictionarySetValue(userInfo, *(__CFSwiftXMLParserBridge.CF.kCFErrorLocalizedDescriptionKey), errorMessage);
+        CFMutableDictionaryRef userInfo = __CFSwiftXMLParserBridge.CF->CFDictionaryCreateMutable(NULL, 1, __CFSwiftXMLParserBridge.CF->kCFCopyStringDictionaryKeyCallBacks, __CFSwiftXMLParserBridge.CF->kCFTypeDictionaryValueCallBacks);
+        __CFSwiftXMLParserBridge.CF->CFDictionarySetValue(userInfo, *(__CFSwiftXMLParserBridge.CF->kCFErrorLocalizedDescriptionKey), errorMessage);
 
-        *error = __CFSwiftXMLParserBridge.CF.CFErrorCreate(NULL, __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, "NSXMLParserErrorDomain", kCFStringEncodingUTF8), 0, userInfo);
+        *error = __CFSwiftXMLParserBridge.CF->CFErrorCreate(NULL, __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, "NSXMLParserErrorDomain", kCFStringEncodingUTF8), 0, userInfo);
 
-        __CFSwiftXMLParserBridge.CF.CFRelease(userInfo);
+        __CFSwiftXMLParserBridge.CF->CFRelease(userInfo);
     }
-    __CFSwiftXMLParserBridge.CF.CFRelease(errorMessage);
+    __CFSwiftXMLParserBridge.CF->CFRelease(errorMessage);
 
     return dtd;
 }
@@ -1176,7 +1176,7 @@ _CFXMLDTDPtr _Nullable _CFXMLParseDTDFromData(CFDataRef data, CFErrorRef _Nullab
 CFStringRef _Nullable _CFXMLDTDCopyExternalID(_CFXMLDTDPtr dtd) {
     const unsigned char* externalID = ((xmlDtdPtr)dtd)->ExternalID;
     if (externalID) {
-        return __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)externalID, kCFStringEncodingUTF8);
+        return __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)externalID, kCFStringEncodingUTF8);
     }
 
     return NULL;
@@ -1201,7 +1201,7 @@ void _CFXMLDTDSetExternalID(_CFXMLDTDPtr dtd, const unsigned char* externalID) {
 CFStringRef _Nullable _CFXMLDTDCopySystemID(_CFXMLDTDPtr dtd) {
     const unsigned char* systemID = ((xmlDtdPtr)dtd)->SystemID;
     if (systemID) {
-        return __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)systemID, kCFStringEncodingUTF8);
+        return __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)systemID, kCFStringEncodingUTF8);
     }
 
     return NULL;
@@ -1288,10 +1288,10 @@ CFIndex _CFXMLDTDAttributeNodeGetType(_CFXMLDTDNodePtr node) {
 CFStringRef _Nullable _CFXMLDTDNodeCopySystemID(_CFXMLDTDNodePtr node) {
     switch (((xmlNodePtr)node)->type) {
         case XML_ENTITY_DECL:
-            return __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)((xmlEntityPtr)node)->SystemID, kCFStringEncodingUTF8);
+            return __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)((xmlEntityPtr)node)->SystemID, kCFStringEncodingUTF8);
 
         case XML_NOTATION_NODE:
-            return __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)((_cfxmlNotation*)node)->notation->SystemID, kCFStringEncodingUTF8);
+            return __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)((_cfxmlNotation*)node)->notation->SystemID, kCFStringEncodingUTF8);
 
         default:
             return NULL;
@@ -1330,10 +1330,10 @@ void _CFXMLDTDNodeSetSystemID(_CFXMLDTDNodePtr node, const unsigned char* system
 CFStringRef _Nullable _CFXMLDTDNodeCopyPublicID(_CFXMLDTDNodePtr node) {
     switch (((xmlNodePtr)node)->type) {
         case XML_ENTITY_DECL:
-            return __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)((xmlEntityPtr)node)->ExternalID, kCFStringEncodingUTF8);
+            return __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)((xmlEntityPtr)node)->ExternalID, kCFStringEncodingUTF8);
             
         case XML_NOTATION_NODE:
-            return __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)((_cfxmlNotation*)node)->notation->PublicID, kCFStringEncodingUTF8);
+            return __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)((_cfxmlNotation*)node)->notation->PublicID, kCFStringEncodingUTF8);
             
         default:
             return NULL;
@@ -1422,7 +1422,7 @@ CFStringRef _Nullable _CFXMLNamespaceCopyValue(_CFXMLNodePtr node) {
         return NULL;
     }
     
-    return __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)ns->href, kCFStringEncodingUTF8);
+    return __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)ns->href, kCFStringEncodingUTF8);
 }
 
 void _CFXMLNamespaceSetValue(_CFXMLNodePtr node, const char* value, int64_t length) {
@@ -1437,7 +1437,7 @@ CFStringRef _Nullable _CFXMLNamespaceCopyPrefix(_CFXMLNodePtr node) {
         return NULL;
     }
     
-    return __CFSwiftXMLParserBridge.CF.CFStringCreateWithCString(NULL, (const char*)ns->prefix, kCFStringEncodingUTF8);
+    return __CFSwiftXMLParserBridge.CF->CFStringCreateWithCString(NULL, (const char*)ns->prefix, kCFStringEncodingUTF8);
 }
 
 void _CFXMLNamespaceSetPrefix(_CFXMLNodePtr node, const char* prefix, int64_t length) {

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.h
@@ -262,7 +262,7 @@ bool _CFXMLGetLengthOfPrefixInQualifiedName(const char *_Nonnull qname, size_t *
 // Bridging
 
 struct _NSXMLParserBridge {
-    struct _NSCFXMLBridge CF;
+    const struct _NSCFXMLBridge *CF;
 
     _CFXMLInterface _Nullable (*_Nonnull currentParser)(void);
     _CFXMLInterfaceParserInput _Nullable (*_Nonnull _xmlExternalEntityWithURL)(_CFXMLInterface /*interface*/, const char * /*url*/, const char * /*identifier*/, _CFXMLInterfaceParserContext /*context*/, _CFXMLInterfaceExternalEntityLoader /*originalLoaderFunction*/);

--- a/CoreFoundation/cmake/modules/CoreFoundationAddFramework.cmake
+++ b/CoreFoundation/cmake/modules/CoreFoundationAddFramework.cmake
@@ -3,8 +3,8 @@ include(CMakeParseArguments)
 
 function(add_framework NAME)
   set(options STATIC SHARED)
-  set(single_value_args MODULE_MAP FRAMEWORK_DIRECTORY)
-  set(multiple_value_args PRIVATE_HEADERS PUBLIC_HEADERS SOURCES)
+  set(single_value_args FRAMEWORK_DIRECTORY)
+  set(multiple_value_args MODULE_MAP PRIVATE_HEADERS PUBLIC_HEADERS SOURCES)
   cmake_parse_arguments(AF "${options}" "${single_value_args}" "${multiple_value_args}" ${ARGN})
 
   set(AF_TYPE)
@@ -60,18 +60,9 @@ function(add_framework NAME)
                         PROPERTIES
                           LIBRARY_OUTPUT_DIRECTORY
                               ${CMAKE_BINARY_DIR}/${NAME}.framework)
-  if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
-    target_compile_options(${NAME}
-                           PRIVATE
-                             -Xclang;-F${CMAKE_BINARY_DIR})
-  else()
-    target_compile_options(${NAME}
-                           PRIVATE
-                             -F;${CMAKE_BINARY_DIR})
-  endif()
-  target_compile_options(${NAME}
-                         PRIVATE
-                           $<$<OR:$<COMPILE_LANGUAGE:ASM>,$<COMPILE_LANGUAGE:C>>:-I;${CMAKE_BINARY_DIR}/${NAME}.framework/PrivateHeaders>)
+  target_compile_options(${NAME} PRIVATE
+    $<$<STREQUAL:${CMAKE_C_SIMULATE_ID},MSVC>:/clang:>-F;${CMAKE_BINARY_DIR}
+    $<$<OR:$<COMPILE_LANGUAGE:ASM>,$<COMPILE_LANGUAGE:C>>:-I;${CMAKE_BINARY_DIR}/${NAME}.framework/PrivateHeaders>)
   add_dependencies(${NAME} ${NAME}_POPULATE_HEADERS)
 
   if(AF_FRAMEWORK_DIRECTORY)

--- a/Sources/Foundation/Bundle.swift
+++ b/Sources/Foundation/Bundle.swift
@@ -9,6 +9,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 @_silgen_name("swift_getTypeContextDescriptor")
 private func _getTypeContextDescriptor(of cls: AnyClass) -> UnsafeRawPointer
 

--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -135,6 +135,7 @@ target_compile_definitions(Foundation PRIVATE
   DEPLOYMENT_RUNTIME_SWIFT)
 target_compile_options(Foundation PUBLIC
   $<$<BOOL:${ENABLE_TESTING}>:-enable-testing>
+  "SHELL:-Xcc -DDEPLOYMENT_RUNTIME_SWIFT"
   "SHELL:-Xcc -F${CMAKE_BINARY_DIR}")
 target_link_libraries(Foundation
   PRIVATE

--- a/Sources/Foundation/Data.swift
+++ b/Sources/Foundation/Data.swift
@@ -21,6 +21,13 @@ internal func malloc_good_size(_ size: Int) -> Int {
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
+#if os(Windows)
+import WinSDK
+#endif
+
 internal func __NSDataInvokeDeallocatorUnmap(_ mem: UnsafeMutableRawPointer, _ length: Int) {
 #if os(Windows)
     UnmapViewOfFile(mem)
@@ -61,17 +68,10 @@ internal func __NSDataIsCompact(_ data: NSData) -> Bool {
 
 #endif
 
-#if os(Windows)
-@usableFromInline @discardableResult
-internal func __withStackOrHeapBuffer(_ size: Int, _ block: (UnsafeMutablePointer<_ConditionalAllocationBuffer>) -> Void) -> Bool {
+@discardableResult
+private func __withStackOrHeapBuffer(_ size: Int, _ block: (UnsafeMutablePointer<_ConditionalAllocationBuffer>) -> Void) -> Bool {
   return _withStackOrHeapBuffer(size, block)
 }
-#else
-@inlinable @inline(__always) @discardableResult
-internal func __withStackOrHeapBuffer(_ size: Int, _ block: (UnsafeMutablePointer<_ConditionalAllocationBuffer>) -> Void) -> Bool {
-  return _withStackOrHeapBuffer(size, block)
-}
-#endif
 
 // Underlying storage representation for medium and large data.
 // Inlinability strategy: methods from here should not inline into InlineSlice or LargeSlice unless trivial.
@@ -2083,7 +2083,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     }
 
     // slightly faster paths for common sequences
-    @inlinable // This is @inlinable as an important generic funnel point, despite being a non-trivial initializer.
     public init<S: Sequence>(_ elements: S) where S.Element == UInt8 {
         // If the sequence is already contiguous, access the underlying raw memory directly.
         if let contiguous = elements as? ContiguousBytes {
@@ -2374,7 +2373,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
     }
 
-    @inlinable // This is @inlinable as an important generic funnel point, despite being non-trivial.
     public mutating func append<S: Sequence>(contentsOf elements: S) where S.Element == Element {
         // If the sequence is already contiguous, access the underlying raw memory directly.
         if let contiguous = elements as? ContiguousBytes {
@@ -2474,7 +2472,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - precondition: The bounds of `subrange` must be valid indices of the collection.
     /// - parameter subrange: The range in the data to replace.
     /// - parameter newElements: The replacement bytes.
-    @inlinable // This is @inlinable as generic and reasonably small.
     public mutating func replaceSubrange<ByteCollection : Collection>(_ subrange: Range<Index>, with newElements: ByteCollection) where ByteCollection.Iterator.Element == Data.Iterator.Element {
         let totalCount = Int(newElements.count)
         __withStackOrHeapBuffer(totalCount) { conditionalBuffer in

--- a/Sources/Foundation/DateIntervalFormatter.swift
+++ b/Sources/Foundation/DateIntervalFormatter.swift
@@ -9,6 +9,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 internal let kCFDateIntervalFormatterNoStyle = CFDateIntervalFormatterStyle.noStyle
 internal let kCFDateIntervalFormatterShortStyle = CFDateIntervalFormatterStyle.shortStyle
 internal let kCFDateIntervalFormatterMediumStyle = CFDateIntervalFormatterStyle.mediumStyle
@@ -83,15 +86,18 @@ internal extension _CFDateIntervalFormatterBoundaryStyle {
 // DateIntervalFormatter returns nil and NO for all methods in Formatter.
 
 open class DateIntervalFormatter: Formatter {
-    let core: CFDateIntervalFormatter
-    
+    let _core: AnyObject
+    var core: CFDateIntervalFormatter {
+      unsafeBitCast(_core, to: CFDateIntervalFormatter.self)
+    }
+
     public override init() {
-        core = CFDateIntervalFormatterCreate(nil, nil, kCFDateIntervalFormatterShortStyle, kCFDateIntervalFormatterShortStyle)
+        _core = CFDateIntervalFormatterCreate(nil, nil, kCFDateIntervalFormatterShortStyle, kCFDateIntervalFormatterShortStyle)
         super.init()
     }
 
     private init(cfFormatter: CFDateIntervalFormatter) {
-        self.core = cfFormatter
+        self._core = cfFormatter
         super.init()
     }
     
@@ -118,7 +124,7 @@ open class DateIntervalFormatter: Formatter {
                                                           cfObject(of: NSLocale.self, from: coder, forKey: "NS.locale"),
                                                           cfObject(of: NSCalendar.self, from: coder, forKey: "NS.calendar"),
                                                           cfObject(of: NSTimeZone.self, from: coder, forKey: "NS.timeZone"))
-        self.core = core
+        self._core = core
         
         super.init(coder: coder)
     }

--- a/Sources/Foundation/FileHandle.swift
+++ b/Sources/Foundation/FileHandle.swift
@@ -10,6 +10,13 @@
 import CoreFoundation
 import Dispatch
 
+@_implementationOnly
+import CoreFoundation_Private
+
+#if os(Windows)
+import WinSDK
+#endif
+
 // FileHandle has a .read(upToCount:) method. Just invoking read() will cause an ambiguity warning. Use _read instead.
 // Same with close()/.close().
 #if canImport(Darwin)

--- a/Sources/Foundation/FileManager+POSIX.swift
+++ b/Sources/Foundation/FileManager+POSIX.swift
@@ -15,6 +15,9 @@ internal func &(left: UInt32, right: mode_t) -> mode_t {
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 extension FileManager {
     internal func _mountedVolumeURLs(includingResourceValuesForKeys propertyKeys: [URLResourceKey]?, options: VolumeEnumerationOptions = []) -> [URL]? {
         var urls: [URL] = []

--- a/Sources/Foundation/FileManager+Win32.swift
+++ b/Sources/Foundation/FileManager+Win32.swift
@@ -9,7 +9,13 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 #if os(Windows)
+
+import WinSDK
+
 internal func joinPath(prefix: String, suffix: String) -> String {
     var pszPath: PWSTR?
 

--- a/Sources/Foundation/FileManager+XDG.swift
+++ b/Sources/Foundation/FileManager+XDG.swift
@@ -9,6 +9,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 enum _XDGUserDirectory: String {
     case desktop = "DESKTOP"
     case download = "DOWNLOAD"

--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -16,8 +16,13 @@ fileprivate let UF_HIDDEN: Int32 = 1
 #endif
 
 import CoreFoundation
+
+@_implementationOnly
+import CoreFoundation_Private
+
 #if os(Windows)
 import MSVCRT
+import WinSDK
 #endif
 
 #if os(Windows)

--- a/Sources/Foundation/Host.swift
+++ b/Sources/Foundation/Host.swift
@@ -9,6 +9,10 @@
 
 import CoreFoundation
 
+#if os(Windows)
+import WinSDK
+#endif
+
 #if os(Android)
     // Android Glibc differs a little with respect to the Linux Glibc.
 

--- a/Sources/Foundation/NSArray.swift
+++ b/Sources/Foundation/NSArray.swift
@@ -9,6 +9,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCoding, ExpressibleByArrayLiteral {
     private let _cfinfo = _CFInfo(typeID: CFArrayGetTypeID())
     internal var _storage = [AnyObject]()

--- a/Sources/Foundation/NSAttributedString.swift
+++ b/Sources/Foundation/NSAttributedString.swift
@@ -9,6 +9,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 extension NSAttributedString {
     public struct Key: RawRepresentable, Equatable, Hashable {
         public let rawValue: String
@@ -50,8 +53,12 @@ open class NSAttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
     
     private let _cfinfo = _CFInfo(typeID: CFAttributedStringGetTypeID())
     fileprivate var _string: NSString
-    fileprivate var _attributeArray: CFRunArrayRef
-    
+
+    fileprivate let __attributeArray: OpaquePointer
+    fileprivate var _attributeArray: CFRunArrayRef {
+      __attributeArray
+    }
+
     public required init?(coder aDecoder: NSCoder) {
         let mutableAttributedString = NSMutableAttributedString(string: "")
         guard _NSReadMutableAttributedStringWithCoder(aDecoder, mutableAttributedString: mutableAttributedString) else {
@@ -60,7 +67,7 @@ open class NSAttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
         
         // use the resulting _string and _attributeArray to initialize a new instance, just like init
         _string = mutableAttributedString._string
-        _attributeArray = mutableAttributedString._attributeArray
+        __attributeArray = mutableAttributedString._attributeArray
     }
     
     open func encode(with aCoder: NSCoder) {
@@ -197,7 +204,7 @@ open class NSAttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
     /// Returns an NSAttributedString object initialized with the characters of a given string and no attribute information.
     public init(string: String) {
         _string = string._nsObject
-        _attributeArray = CFRunArrayCreate(kCFAllocatorDefault)
+        __attributeArray = CFRunArrayCreate(kCFAllocatorDefault)
         
         super.init()
         addAttributesToAttributeArray(attrs: nil)
@@ -206,7 +213,7 @@ open class NSAttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
     /// Returns an NSAttributedString object initialized with a given string and attributes.
     public init(string: String, attributes attrs: [NSAttributedString.Key: Any]? = nil) {
         _string = string._nsObject
-        _attributeArray = CFRunArrayCreate(kCFAllocatorDefault)
+        __attributeArray = CFRunArrayCreate(kCFAllocatorDefault)
 
         super.init()
         addAttributesToAttributeArray(attrs: attrs)
@@ -220,7 +227,7 @@ open class NSAttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
         
         // use the resulting _string and _attributeArray to initialize a new instance
         _string = mutableAttributedString._string
-        _attributeArray = mutableAttributedString._attributeArray
+        __attributeArray = mutableAttributedString._attributeArray
     }
 
     /// Executes the block for each attribute in the range.

--- a/Sources/Foundation/NSCFArray.swift
+++ b/Sources/Foundation/NSCFArray.swift
@@ -10,6 +10,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 internal final class _NSCFArray : NSMutableArray {
     deinit {
         _CFDeinit(self)

--- a/Sources/Foundation/NSCFDictionary.swift
+++ b/Sources/Foundation/NSCFDictionary.swift
@@ -10,6 +10,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 internal final class _NSCFDictionary : NSMutableDictionary {
     deinit {
         _CFDeinit(self)

--- a/Sources/Foundation/NSCFSet.swift
+++ b/Sources/Foundation/NSCFSet.swift
@@ -10,6 +10,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 internal final class _NSCFSet : NSMutableSet {
     deinit {
         _CFDeinit(self)

--- a/Sources/Foundation/NSCFString.swift
+++ b/Sources/Foundation/NSCFString.swift
@@ -10,6 +10,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 @usableFromInline
 internal class _NSCFString : NSMutableString {
     required init(characters: UnsafePointer<unichar>, length: Int) {

--- a/Sources/Foundation/NSCalendar.swift
+++ b/Sources/Foundation/NSCalendar.swift
@@ -9,6 +9,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 internal let kCFCalendarUnitEra = CFCalendarUnit.era
 internal let kCFCalendarUnitYear = CFCalendarUnit.year
 internal let kCFCalendarUnitMonth = CFCalendarUnit.month
@@ -22,7 +25,7 @@ internal let kCFCalendarUnitQuarter = CFCalendarUnit.quarter
 internal let kCFCalendarUnitWeekOfMonth = CFCalendarUnit.weekOfMonth
 internal let kCFCalendarUnitWeekOfYear = CFCalendarUnit.weekOfYear
 internal let kCFCalendarUnitYearForWeekOfYear = CFCalendarUnit.yearForWeekOfYear
-internal let kCFCalendarUnitNanosecond = CFCalendarUnit(rawValue: CFOptionFlags(CoreFoundation.kCFCalendarUnitNanosecond))
+internal let kCFCalendarUnitNanosecond = CFCalendarUnit(rawValue: CFOptionFlags(CoreFoundation_Private.kCFCalendarUnitNanosecond))
 
 internal func _CFCalendarUnitRawValue(_ unit: CFCalendarUnit) -> CFOptionFlags {
     return unit.rawValue

--- a/Sources/Foundation/NSCharacterSet.swift
+++ b/Sources/Foundation/NSCharacterSet.swift
@@ -10,6 +10,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 let kCFCharacterSetControl = CFCharacterSetPredefinedSet.control
 let kCFCharacterSetWhitespace = CFCharacterSetPredefinedSet.whitespace
 let kCFCharacterSetWhitespaceAndNewline = CFCharacterSetPredefinedSet.whitespaceAndNewline

--- a/Sources/Foundation/NSConcreteValue.swift
+++ b/Sources/Foundation/NSConcreteValue.swift
@@ -9,6 +9,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 internal class NSConcreteValue : NSValue {
     
     struct TypeInfo : Equatable {

--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -10,6 +10,9 @@
 import CoreFoundation
 import Dispatch
 
+@_implementationOnly
+import CoreFoundation_Private
+
 extension NSData {
     public struct ReadingOptions : OptionSet {
         public let rawValue : UInt

--- a/Sources/Foundation/NSDate.swift
+++ b/Sources/Foundation/NSDate.swift
@@ -9,6 +9,13 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
+#if os(Windows)
+import WinSDK
+#endif
+
 public typealias TimeInterval = Double
 
 public var NSTimeIntervalSince1970: Double {

--- a/Sources/Foundation/NSKeyedArchiver.swift
+++ b/Sources/Foundation/NSKeyedArchiver.swift
@@ -9,6 +9,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 /// Archives created using the class method `archivedData(withRootObject:)` use this key
 /// for the root object in the hierarchy of encoded objects. The `NSKeyedUnarchiver` class method
 /// `unarchiveObject(with:)` looks for this root key as well.

--- a/Sources/Foundation/NSKeyedArchiverHelpers.swift
+++ b/Sources/Foundation/NSKeyedArchiverHelpers.swift
@@ -9,6 +9,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 extension CFKeyedArchiverUID : _NSBridgeable {
     typealias NSType = _NSKeyedArchiverUID
     

--- a/Sources/Foundation/NSLocale.swift
+++ b/Sources/Foundation/NSLocale.swift
@@ -10,6 +10,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 open class NSLocale: NSObject, NSCopying, NSSecureCoding, _CFBridgeable {
     typealias CFType = CFLocale
 
@@ -18,7 +21,8 @@ open class NSLocale: NSObject, NSCopying, NSSecureCoding, _CFBridgeable {
     private var _identifier: UnsafeMutableRawPointer? = nil
     private var _cache: UnsafeMutableRawPointer? = nil
     private var _prefs: UnsafeMutableRawPointer? = nil
-    private var _lock: CFLock_t = __CFLockInit()
+    // FIXME(compnerd) this should really be `CFLock_t` to be portable
+    private var _lock: Int32 = __CFLockInit()
     private var _nullLocale: Bool = false
 
     internal var _cfObject: CFType {

--- a/Sources/Foundation/NSLog.swift
+++ b/Sources/Foundation/NSLog.swift
@@ -9,6 +9,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 /* Output from NSLogv is serialized, in that only one thread in a process can be doing 
  * the writing/logging described above at a time. All attempts at writing/logging a 
  * message complete before the next thread can begin its attempts. The format specification 

--- a/Sources/Foundation/NSNumber.swift
+++ b/Sources/Foundation/NSNumber.swift
@@ -10,6 +10,13 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
+#if os(Windows)
+import WinSDK
+#endif
+
 internal let kCFNumberSInt8Type = CFNumberType.sInt8Type
 internal let kCFNumberSInt16Type = CFNumberType.sInt16Type
 internal let kCFNumberSInt32Type = CFNumberType.sInt32Type

--- a/Sources/Foundation/NSPathUtilities.swift
+++ b/Sources/Foundation/NSPathUtilities.swift
@@ -9,6 +9,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 #if os(Windows)
 let validPathSeps: [Character] = ["\\", "/"]
 #else

--- a/Sources/Foundation/NSRegularExpression.swift
+++ b/Sources/Foundation/NSRegularExpression.swift
@@ -12,6 +12,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 extension NSRegularExpression {
     public struct Options : OptionSet {
         public let rawValue : UInt
@@ -28,7 +31,10 @@ extension NSRegularExpression {
 }
 
 open class NSRegularExpression: NSObject, NSCopying, NSSecureCoding {
-    internal var _internal: _CFRegularExpression
+    private let __internal: AnyObject
+    internal var _internal: _CFRegularExpression {
+      unsafeBitCast(__internal, to: _CFRegularExpression.self)
+    }
     
     open override func copy() -> Any {
         return copy(with: nil)
@@ -82,7 +88,7 @@ open class NSRegularExpression: NSObject, NSCopying, NSSecureCoding {
         var error: Unmanaged<CFError>?
         let opt =  _CFRegularExpressionOptions(rawValue: options.rawValue)
         if let regex = _CFRegularExpressionCreate(kCFAllocatorSystemDefault, pattern._cfObject, opt, &error) {
-            _internal = regex
+            __internal = regex
         } else {
             throw error!.takeRetainedValue()
         }

--- a/Sources/Foundation/NSString.swift
+++ b/Sources/Foundation/NSString.swift
@@ -10,6 +10,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 public typealias unichar = UInt16
 
 extension unichar {

--- a/Sources/Foundation/NSSwiftRuntime.swift
+++ b/Sources/Foundation/NSSwiftRuntime.swift
@@ -10,6 +10,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 // Re-export Darwin and Glibc by importing Foundation
 // This mimics the behavior of the swift sdk overlay on Darwin
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
@@ -408,7 +411,7 @@ internal enum _NSNonfileURLContentLoader {
     }
 }
 
-public func _GetNSCFXMLBridge() -> _NSCFXMLBridge {
-  return __NSCFXMLBridge
+public func _GetNSCFXMLBridge() -> UnsafeRawPointer {
+  return UnsafeRawPointer(&__NSCFXMLBridge)
 }
 

--- a/Sources/Foundation/NSTimeZone.swift
+++ b/Sources/Foundation/NSTimeZone.swift
@@ -10,6 +10,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 open class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
     typealias CFType = CFTimeZone
     private var _base = _CFInfo(typeID: CFTimeZoneGetTypeID())

--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -10,6 +10,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 internal let kCFURLPOSIXPathStyle = CFURLPathStyle.cfurlposixPathStyle
 internal let kCFURLWindowsPathStyle = CFURLPathStyle.cfurlWindowsPathStyle
 
@@ -1144,7 +1147,10 @@ open class NSURLQueryItem : NSObject, NSSecureCoding, NSCopying {
 }
 
 open class NSURLComponents: NSObject, NSCopying {
-    private let _components : CFURLComponents!
+    private let __components: AnyObject!
+    private var _components: CFURLComponents {
+      unsafeBitCast(__components, to: CFURLComponents.self)
+    }
     
     open override func copy() -> Any {
         return copy(with: nil)
@@ -1191,24 +1197,24 @@ open class NSURLComponents: NSObject, NSCopying {
     
     // Initialize a NSURLComponents with the components of a URL. If resolvingAgainstBaseURL is YES and url is a relative URL, the components of [url absoluteURL] are used. If the url string from the NSURL is malformed, nil is returned.
     public init?(url: URL, resolvingAgainstBaseURL resolve: Bool) {
-        _components = _CFURLComponentsCreateWithURL(kCFAllocatorSystemDefault, url._cfObject, resolve)
+        __components = _CFURLComponentsCreateWithURL(kCFAllocatorSystemDefault, url._cfObject, resolve)
         super.init()
-        if _components == nil {
+        if __components == nil {
             return nil
         }
     }
     
     // Initialize a NSURLComponents with a URL string. If the URLString is malformed, nil is returned.
     public init?(string URLString: String) {
-        _components = _CFURLComponentsCreateWithString(kCFAllocatorSystemDefault, URLString._cfObject)
+        __components = _CFURLComponentsCreateWithString(kCFAllocatorSystemDefault, URLString._cfObject)
         super.init()
-        if _components == nil {
+        if __components == nil {
             return nil
         }
     }
     
     public override init() {
-        _components = _CFURLComponentsCreate(kCFAllocatorSystemDefault)
+        __components = _CFURLComponentsCreate(kCFAllocatorSystemDefault)
     }
     
     // Returns a URL created from the NSURLComponents. If the NSURLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.

--- a/Sources/Foundation/NSUUID.swift
+++ b/Sources/Foundation/NSUUID.swift
@@ -10,6 +10,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 open class NSUUID : NSObject, NSCopying, NSSecureCoding, NSCoding {
     internal var buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 16)
 

--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -9,6 +9,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 #if canImport(Darwin)
 import Darwin
 #endif

--- a/Sources/Foundation/ProcessInfo.swift
+++ b/Sources/Foundation/ProcessInfo.swift
@@ -9,6 +9,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 public struct OperatingSystemVersion {
     public var majorVersion: Int
     public var minorVersion: Int

--- a/Sources/Foundation/RunLoop.swift
+++ b/Sources/Foundation/RunLoop.swift
@@ -9,6 +9,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 internal let kCFRunLoopEntry = CFRunLoopActivity.entry.rawValue
 internal let kCFRunLoopBeforeTimers = CFRunLoopActivity.beforeTimers.rawValue
 internal let kCFRunLoopBeforeSources = CFRunLoopActivity.beforeSources.rawValue

--- a/Sources/Foundation/Stream.swift
+++ b/Sources/Foundation/Stream.swift
@@ -9,6 +9,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 internal extension UInt {
     init(_ status: CFStreamStatus) {
         self.init(status.rawValue)

--- a/Sources/Foundation/Thread.swift
+++ b/Sources/Foundation/Thread.swift
@@ -9,6 +9,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 // WORKAROUND_SR9811
 #if os(Windows)
 internal typealias _swift_CFThreadRef = HANDLE

--- a/Sources/Foundation/UUID.swift
+++ b/Sources/Foundation/UUID.swift
@@ -12,6 +12,9 @@
 
 import CoreFoundation
 
+@_implementationOnly
+import CoreFoundation_Private
+
 public typealias uuid_t = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
 public typealias uuid_string_t = (Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8)
 

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -55,6 +55,7 @@ target_compile_options(FoundationNetworking PUBLIC
   # forced load symbol when validating the TBD
   -Xfrontend -validate-tbd-against-ir=none
   $<$<BOOL:${ENABLE_TESTING}>:-enable-testing>
+  "SHELL:-Xcc -DDEPLOYMENT_RUNTIME_SWIFT"
   "SHELL:-Xcc -F${CMAKE_BINARY_DIR}")
 target_link_libraries(FoundationNetworking
   PRIVATE

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -9,6 +9,7 @@ target_compile_definitions(FoundationXML PRIVATE
   DEPLOYMENT_RUNTIME_SWIFT)
 target_compile_options(FoundationXML PUBLIC
   $<$<BOOL:${ENABLE_TESTING}>:-enable-testing>
+  "SHELL:-Xcc -DDEPLOYMENT_RUNTIME_SWIFT"
   "SHELL:-Xcc -F${CMAKE_BINARY_DIR}")
 target_link_libraries(FoundationXML
   PRIVATE

--- a/Sources/FoundationXML/XMLDocument.swift
+++ b/Sources/FoundationXML/XMLDocument.swift
@@ -15,6 +15,9 @@ import Foundation
 import CoreFoundation
 import CFXMLInterface
 
+@_implementationOnly
+import CoreFoundation_Private
+
 // Input options
 //  NSXMLNodeOptionsNone
 //  NSXMLNodePreserveAll

--- a/Sources/FoundationXML/XMLElement.swift
+++ b/Sources/FoundationXML/XMLElement.swift
@@ -12,8 +12,12 @@ import SwiftFoundation
 #else
 import Foundation
 #endif
-import CoreFoundation
 import CFXMLInterface
+
+import CoreFoundation
+
+@_implementationOnly
+import CoreFoundation_Private
 
 /*!
     @class XMLElement

--- a/Tests/Foundation/CMakeLists.txt
+++ b/Tests/Foundation/CMakeLists.txt
@@ -111,6 +111,8 @@ target_sources(TestFoundation PRIVATE
 
 target_compile_definitions(TestFoundation PRIVATE
   $<$<BOOL:${ENABLE_TESTING}>:NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT>)
+target_compile_options(TestFoundation PRIVATE
+  "SHELL:-Xcc -DDEPLOYMENT_RUNTIME_SWIFT")
 target_link_libraries(TestFoundation PRIVATE
   Foundation
   FoundationNetworking


### PR DESCRIPTION
Clean up the long standing issue with private headers being pushed into
the public headers directory.  Add a private modulemap so that we can
still access the private headers.