### PR TITLE
[android] Add errno.h header to the Android branch.

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -56,6 +56,7 @@
 #endif
 
 #if TARGET_OS_ANDROID
+#include <errno.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #elif TARGET_OS_LINUX


### PR DESCRIPTION
The inline code in this file has started using the errno symbol, which
was included correctly in Linux, but not included in Android. This
commit adds the include to allow compiling the code.

@compnerd: this breakage haven't reach yet the Azure CI, but it will tonight, I think.