### PR TITLE
SwiftRuntime: synchronise CoreFoundation.h

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -27,6 +27,9 @@
 #include <CoreFoundation/CFDateIntervalFormatter.h>
 #include <CoreFoundation/ForFoundationOnly.h>
 #include <CoreFoundation/CFCharacterSetPriv.h>
+#include <CoreFoundation/CFURLPriv.h>
+#include <CoreFoundation/CFURLComponents.h>
+#include <CoreFoundation/CFRunArray.h>
 
 #if TARGET_OS_WIN32
 #define NOMINMAX

--- a/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
+++ b/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
@@ -85,18 +85,16 @@
 #include <CoreFoundation/CFUUID.h>
 #include <CoreFoundation/CFUtilities.h>
 #include <CoreFoundation/CFBundle.h>
+
 #include <CoreFoundation/CFMessagePort.h>
 #include <CoreFoundation/CFPlugIn.h>
 #include <CoreFoundation/CFRunLoop.h>
 #include <CoreFoundation/CFStream.h>
 #include <CoreFoundation/CFSocket.h>
 #include <CoreFoundation/CFMachPort.h>
+
 #include <CoreFoundation/CFAttributedString.h>
 #include <CoreFoundation/CFNotificationCenter.h>
-
-#include <CoreFoundation/CFURLPriv.h>
-#include <CoreFoundation/CFURLComponents.h>
-#include <CoreFoundation/CFRunArray.h>
 
 #include <CoreFoundation/ForSwiftFoundationOnly.h>
 


### PR DESCRIPTION
The SwiftRuntime has a modified CoreFoundation.h which has additional
includes.  Synchronise it with the base CoreFoundation.h which should
remove the use of the private headers.