### PR TITLE
Parity: URLCache adoption for HTTP and FTP invocations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,6 +519,7 @@ if(ENABLE_TESTING)
                          TestFoundation/TestTimeZone.swift
                          TestFoundation/TestUnitConverter.swift
                          TestFoundation/TestUnit.swift
+                         TestFoundation/TestURLCache.swift
                          TestFoundation/TestURLCredential.swift
                          TestFoundation/TestURLProtectionSpace.swift
                          TestFoundation/TestURLProtocol.swift

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1513A8432044893F00539722 /* FileManager_XDG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1513A8422044893F00539722 /* FileManager_XDG.swift */; };
 		1520469B1D8AEABE00D02E36 /* HTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1520469A1D8AEABE00D02E36 /* HTTPServer.swift */; };
 		1539391422A07007006DFF4F /* TestCachedURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1539391322A07007006DFF4F /* TestCachedURLResponse.swift */; };
+		1539391522A07160006DFF4F /* TestNSSortDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152EF3932283457B001E1269 /* TestNSSortDescriptor.swift */; };
 		153CC8352215E00200BFE8F3 /* ScannerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153CC8322214C3D100BFE8F3 /* ScannerAPI.swift */; };
 		153E951120111DC500F250BE /* CFKnownLocations.h in Headers */ = {isa = PBXBuildFile; fileRef = 153E950F20111DC500F250BE /* CFKnownLocations.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		153E951220111DC500F250BE /* CFKnownLocations.c in Sources */ = {isa = PBXBuildFile; fileRef = 153E951020111DC500F250BE /* CFKnownLocations.c */; };
@@ -31,6 +32,7 @@
 		1578DA11212B407B003C9516 /* CFString_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1578DA10212B407B003C9516 /* CFString_Internal.h */; };
 		1578DA13212B4C35003C9516 /* CFOverflow.h in Headers */ = {isa = PBXBuildFile; fileRef = 1578DA12212B4C35003C9516 /* CFOverflow.h */; };
 		1578DA15212B6F33003C9516 /* CFCollections_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1578DA14212B6F33003C9516 /* CFCollections_Internal.h */; };
+		1581706322B1A29100348861 /* TestURLCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1581706222B1A29100348861 /* TestURLCache.swift */; };
 		158BCCAA2220A12600750239 /* TestDateIntervalFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158BCCA92220A12600750239 /* TestDateIntervalFormatter.swift */; };
 		158BCCAD2220A18F00750239 /* CFDateIntervalFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 158BCCAB2220A18F00750239 /* CFDateIntervalFormatter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		158BCCAE2220A18F00750239 /* CFDateIntervalFormatter.c in Sources */ = {isa = PBXBuildFile; fileRef = 158BCCAC2220A18F00750239 /* CFDateIntervalFormatter.c */; };
@@ -651,6 +653,7 @@
 		1578DA10212B407B003C9516 /* CFString_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFString_Internal.h; sourceTree = "<group>"; };
 		1578DA12212B4C35003C9516 /* CFOverflow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFOverflow.h; sourceTree = "<group>"; };
 		1578DA14212B6F33003C9516 /* CFCollections_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFCollections_Internal.h; sourceTree = "<group>"; };
+		1581706222B1A29100348861 /* TestURLCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestURLCache.swift; sourceTree = "<group>"; };
 		158BCCA92220A12600750239 /* TestDateIntervalFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDateIntervalFormatter.swift; sourceTree = "<group>"; };
 		158BCCAB2220A18F00750239 /* CFDateIntervalFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFDateIntervalFormatter.h; sourceTree = "<group>"; };
 		158BCCAC2220A18F00750239 /* CFDateIntervalFormatter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFDateIntervalFormatter.c; sourceTree = "<group>"; };
@@ -1771,6 +1774,7 @@
 				84BA558D1C16F90900F48C54 /* TestTimeZone.swift */,
 				EA66F6431BF1619600136161 /* TestURL.swift */,
 				F9E0BB361CA70B8000F7FF3C /* TestURLCredential.swift */,
+				1581706222B1A29100348861 /* TestURLCache.swift */,
 				83712C8D1C1684900049AD49 /* TestNSURLRequest.swift */,
 				DAA79BD820D42C07004AF044 /* TestURLProtectionSpace.swift */,
 				7A7D6FBA1C16439400957E2E /* TestURLResponse.swift */,
@@ -2916,8 +2920,10 @@
 				5B13B3271C582D4C00651CE2 /* TestNSArray.swift in Sources */,
 				5B13B3461C582D4C00651CE2 /* TestProcess.swift in Sources */,
 				555683BD1C1250E70041D4C6 /* TestUserDefaults.swift in Sources */,
+				1539391522A07160006DFF4F /* TestNSSortDescriptor.swift in Sources */,
 				DCA8120B1F046D13000D0C86 /* TestCodable.swift in Sources */,
 				7900433B1CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift in Sources */,
+				1581706322B1A29100348861 /* TestURLCache.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Foundation/NSKeyedArchiver.swift
+++ b/Foundation/NSKeyedArchiver.swift
@@ -94,6 +94,13 @@ open class NSKeyedArchiver : NSCoder {
     /// The archiver’s delegate.
     open weak var delegate: NSKeyedArchiverDelegate?
     
+    /// The latest error.
+    private var _error: Error?
+    open override var error: Error? {
+        get { return _error }
+        set { _error = newValue }
+    }
+    
     /// The format in which the receiver encodes its data.
     ///
     /// The available formats are `xml` and `binary`.

--- a/Foundation/NSKeyedUnarchiver.swift
+++ b/Foundation/NSKeyedUnarchiver.swift
@@ -79,7 +79,11 @@ open class NSKeyedUnarchiver : NSCoder {
         unarchiver.requiresSecureCoding = true
         unarchiver.decodingFailurePolicy = .setErrorAndReturn
         
-        return try unarchiver.decodeObject(of: classes, forKey: NSKeyedArchiveRootObjectKey)
+        let result = unarchiver.decodeObject(of: classes, forKey: NSKeyedArchiveRootObjectKey)
+        if let error = unarchiver.error {
+            throw error
+        }
+        return result
     }
     
     @available(swift, deprecated: 9999, renamed: "unarchivedObject(ofClass:from:)")

--- a/Foundation/NSURLRequest.swift
+++ b/Foundation/NSURLRequest.swift
@@ -564,6 +564,9 @@ open class NSMutableURLRequest : NSURLRequest {
         get { return super.httpShouldUsePipelining }
         set { super.httpShouldUsePipelining = newValue }
     }
+    
+    // These properties are settable using URLProtocol's class methods.
+    var protocolProperties: [String: Any] = [:]
 }
 
 /// Returns an existing key-value pair inside the header fields if it exists.

--- a/Foundation/URLRequest.swift
+++ b/Foundation/URLRequest.swift
@@ -240,6 +240,15 @@ public struct URLRequest : ReferenceConvertible, Equatable, Hashable {
     public static func ==(lhs: URLRequest, rhs: URLRequest) -> Bool {
         return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
     }
+    
+    var protocolProperties: [String: Any] {
+        get {
+            return _handle.map { $0.protocolProperties }
+        }
+        set {
+            _applyMutation { $0.protocolProperties = newValue }
+        }
+    }
 }
 
 extension URLRequest : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {

--- a/Foundation/URLResponse.swift
+++ b/Foundation/URLResponse.swift
@@ -36,8 +36,9 @@ open class URLResponse : NSObject, NSSecureCoding, NSCopying {
         self.url = nsurl as URL
         
         
-        let nsmimetype = aDecoder.decodeObject(of: NSString.self, forKey: "NS.mimeType")
-        self.mimeType = nsmimetype as String?
+        if let mimetype = aDecoder.decodeObject(of: NSString.self, forKey: "NS.mimeType") {
+            self.mimeType = mimetype as String
+        }
         
         self.expectedContentLength = aDecoder.decodeInt64(forKey: "NS.expectedContentLength")
         

--- a/Foundation/URLResponse.swift
+++ b/Foundation/URLResponse.swift
@@ -32,21 +32,20 @@ open class URLResponse : NSObject, NSSecureCoding, NSCopying {
             preconditionFailure("Unkeyed coding is unsupported.")
         }
         
-        if let encodedUrl = aDecoder.decodeObject(forKey: "NS.url") as? NSURL {
-            self.url = encodedUrl as URL
-        }
+        guard let nsurl = aDecoder.decodeObject(of: NSURL.self, forKey: "NS.url") else { return nil }
+        self.url = nsurl as URL
         
-        if let encodedMimeType = aDecoder.decodeObject(forKey: "NS.mimeType") as? NSString {
-            self.mimeType = encodedMimeType as String
-        }
+        
+        let nsmimetype = aDecoder.decodeObject(of: NSString.self, forKey: "NS.mimeType")
+        self.mimeType = nsmimetype as String?
         
         self.expectedContentLength = aDecoder.decodeInt64(forKey: "NS.expectedContentLength")
         
-        if let encodedEncodingName = aDecoder.decodeObject(forKey: "NS.textEncodingName") as? NSString {
+        if let encodedEncodingName = aDecoder.decodeObject(of: NSString.self, forKey: "NS.textEncodingName") {
             self.textEncodingName = encodedEncodingName as String
         }
         
-        if let encodedFilename = aDecoder.decodeObject(forKey: "NS.suggestedFilename") as? NSString {
+        if let encodedFilename = aDecoder.decodeObject(of: NSString.self, forKey: "NS.suggestedFilename") {
             self.suggestedFilename = encodedFilename as String
         }
     }
@@ -203,8 +202,8 @@ open class HTTPURLResponse : URLResponse {
         
         self.statusCode = aDecoder.decodeInteger(forKey: "NS.statusCode")
         
-        if let encodedHeaders = aDecoder.decodeObject(forKey: "NS.allHeaderFields") as? NSDictionary {
-            self.allHeaderFields = encodedHeaders as! [AnyHashable: Any]
+        if aDecoder.containsValue(forKey: "NS.allHeaderFields") {
+            self.allHeaderFields = aDecoder.decodeObject(of: NSDictionary.self, forKey: "NS.allHeaderFields") as! [AnyHashable: Any]
         } else {
             self.allHeaderFields = [:]
         }
@@ -216,7 +215,7 @@ open class HTTPURLResponse : URLResponse {
         super.encode(with: aCoder) //Will fail if .allowsKeyedCoding == false
         
         aCoder.encode(self.statusCode, forKey: "NS.statusCode")
-        aCoder.encode(self.allHeaderFields._bridgeToObjectiveC(), forKey: "NS.allHeaderFields")
+        aCoder.encode(self.allHeaderFields as NSDictionary, forKey: "NS.allHeaderFields")
         
     }
     

--- a/Foundation/URLSession/URLSession.swift
+++ b/Foundation/URLSession/URLSession.swift
@@ -629,6 +629,8 @@ internal protocol URLSessionProtocol: class {
     func add(handle: _EasyHandle)
     func remove(handle: _EasyHandle)
     func behaviour(for: URLSessionTask) -> URLSession._TaskBehaviour
+    var configuration: URLSessionConfiguration { get }
+    var delegate: URLSessionDelegate? { get }
 }
 extension URLSession: URLSessionProtocol {
     func add(handle: _EasyHandle) {
@@ -642,6 +644,12 @@ extension URLSession: URLSessionProtocol {
 ///
 /// - SeeAlso: URLSessionTask.init()
 final internal class _MissingURLSession: URLSessionProtocol {
+    var delegate: URLSessionDelegate? {
+        fatalError()
+    }
+    var configuration: URLSessionConfiguration {
+        fatalError()
+    }
     func add(handle: _EasyHandle) {
         fatalError()
     }

--- a/Foundation/URLSession/URLSessionConfiguration.swift
+++ b/Foundation/URLSession/URLSessionConfiguration.swift
@@ -39,21 +39,21 @@ open class URLSessionConfiguration : NSObject, NSCopying {
     // -init is silently incorrect in URLSessionCofiguration on the desktop. Ensure code that relied on swift-corelibs-foundation's init() being functional is redirected to the appropriate cross-platform class property.
     @available(*, deprecated, message: "Use .default instead.", renamed: "URLSessionConfiguration.default")
     public override init() {
-        self.requestCachePolicy = .useProtocolCachePolicy
-        self.timeoutIntervalForRequest = 60
-        self.timeoutIntervalForResource = 604800
-        self.networkServiceType = .default
-        self.allowsCellularAccess = true
-        self.isDiscretionary = false
-        self.httpShouldUsePipelining = false
-        self.httpShouldSetCookies = true
-        self.httpCookieAcceptPolicy = .onlyFromMainDocumentDomain
-        self.httpMaximumConnectionsPerHost = 6
-        self.httpCookieStorage = HTTPCookieStorage.shared
-        self.urlCredentialStorage = nil
-        self.urlCache = nil
-        self.shouldUseExtendedBackgroundIdleMode = false
-        self.protocolClasses = [_HTTPURLProtocol.self, _FTPURLProtocol.self]
+        self.requestCachePolicy = URLSessionConfiguration.default.requestCachePolicy
+        self.timeoutIntervalForRequest = URLSessionConfiguration.default.timeoutIntervalForRequest
+        self.timeoutIntervalForResource = URLSessionConfiguration.default.timeoutIntervalForResource
+        self.networkServiceType = URLSessionConfiguration.default.networkServiceType
+        self.allowsCellularAccess = URLSessionConfiguration.default.allowsCellularAccess
+        self.isDiscretionary = URLSessionConfiguration.default.isDiscretionary
+        self.httpShouldUsePipelining = URLSessionConfiguration.default.httpShouldUsePipelining
+        self.httpShouldSetCookies = URLSessionConfiguration.default.httpShouldSetCookies
+        self.httpCookieAcceptPolicy = URLSessionConfiguration.default.httpCookieAcceptPolicy
+        self.httpMaximumConnectionsPerHost = URLSessionConfiguration.default.httpMaximumConnectionsPerHost
+        self.httpCookieStorage = URLSessionConfiguration.default.httpCookieStorage
+        self.urlCredentialStorage = URLSessionConfiguration.default.urlCredentialStorage
+        self.urlCache = URLSessionConfiguration.default.urlCache
+        self.shouldUseExtendedBackgroundIdleMode = URLSessionConfiguration.default.shouldUseExtendedBackgroundIdleMode
+        self.protocolClasses = URLSessionConfiguration.default.protocolClasses
         super.init()
     }
     
@@ -73,7 +73,7 @@ open class URLSessionConfiguration : NSObject, NSCopying {
                   httpMaximumConnectionsPerHost: 6,
                   httpCookieStorage: .shared,
                   urlCredentialStorage: nil, // Should be .shared once implemented.
-                  urlCache: nil,
+                  urlCache: .shared,
                   shouldUseExtendedBackgroundIdleMode: false,
                   protocolClasses: [_HTTPURLProtocol.self, _FTPURLProtocol.self])
     }
@@ -149,10 +149,11 @@ open class URLSessionConfiguration : NSObject, NSCopying {
 
     open class var ephemeral: URLSessionConfiguration {
         // Return a new ephemeral URLSessionConfiguration every time this property is invoked
-        // TODO: urlCache and urlCredentialStorage should also be ephemeral/in-memory
-        // URLCache and URLCredentialStorage are still unimplemented
+        // TODO: urlCredentialStorage should also be ephemeral/in-memory
+        // URLCredentialStorage is still unimplemented
         let ephemeralConfiguration = URLSessionConfiguration.default.copy() as! URLSessionConfiguration
         ephemeralConfiguration.httpCookieStorage = .ephemeralStorage()
+        ephemeralConfiguration.urlCache = URLCache(memoryCapacity: 4 * 1024 * 1024, diskCapacity: 0, diskPath: nil)
         return ephemeralConfiguration
     }
 

--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -22,6 +22,10 @@ import Foundation
 #endif
 import CoreFoundation
 
+private class Bag<Element> {
+    var values: [Element] = []
+}
+
 /// A cancelable object that refers to the lifetime
 /// of processing a given request.
 open class URLSessionTask : NSObject, NSCopying {
@@ -38,7 +42,101 @@ open class URLSessionTask : NSObject, NSCopying {
     internal var suspendCount = 1
     internal var session: URLSessionProtocol! //change to nil when task completes
     internal let body: _Body
-    fileprivate var _protocol: URLProtocol? = nil
+    
+    fileprivate enum ProtocolState {
+        case toBeCreated
+        case awaitingCacheReply(Bag<(URLProtocol?) -> Void>)
+        case existing(URLProtocol)
+        case invalidated
+    }
+    
+    fileprivate let _protocolLock = NSLock()
+    fileprivate var _protocolStorage: ProtocolState = .toBeCreated
+    
+    private var _protocolClass: URLProtocol.Type {
+        guard let request = currentRequest else { fatalError("A protocol class was requested, but we do not have a current request") }
+        let protocolClasses = session.configuration.protocolClasses ?? []
+        if let urlProtocolClass = URLProtocol.getProtocolClass(protocols: protocolClasses, request: request) {
+            guard let urlProtocol = urlProtocolClass as? URLProtocol.Type else { fatalError("A protocol class specified in the URLSessionConfiguration's .protocolClasses array was not a URLProtocol subclass: \(urlProtocolClass)") }
+            return urlProtocol
+        } else {
+            let protocolClasses = URLProtocol.getProtocols() ?? []
+            if let urlProtocolClass = URLProtocol.getProtocolClass(protocols: protocolClasses, request: request) {
+                guard let urlProtocol = urlProtocolClass as? URLProtocol.Type else { fatalError("A protocol class registered with URLProtocol.register… was not a URLProtocol subclass: \(urlProtocolClass)") }
+                return urlProtocol
+            }
+        }
+        
+        fatalError("Couldn't find a protocol appropriate for request: \(request)")
+    }
+    
+    func _getProtocol(_ callback: @escaping (URLProtocol?) -> Void) {
+        _protocolLock.lock() // Must be balanced below, before we call out ⬇
+        
+        switch _protocolStorage {
+        case .toBeCreated:
+            if let cache = session.configuration.urlCache, let me = self as? URLSessionDataTask {
+                let bag: Bag<(URLProtocol?) -> Void> = Bag()
+                bag.values.append(callback)
+                
+                _protocolStorage = .awaitingCacheReply(bag)
+                _protocolLock.unlock() // Balances above ⬆
+                
+                cache.getCachedResponse(for: me) { (response) in
+                    let urlProtocol = self._protocolClass.init(task: self, cachedResponse: response, client: nil)
+                    self._satisfyProtocolRequest(with: urlProtocol)
+                }
+            } else {
+                let urlProtocol = _protocolClass.init(task: self, cachedResponse: nil, client: nil)
+                _protocolStorage = .existing(urlProtocol)
+                _protocolLock.unlock() // Balances above ⬆
+                
+                callback(urlProtocol)
+            }
+            
+        case .awaitingCacheReply(let bag):
+            bag.values.append(callback)
+            _protocolLock.unlock() // Balances above ⬆
+        
+        case .existing(let urlProtocol):
+            _protocolLock.unlock() // Balances above ⬆
+            
+            callback(urlProtocol)
+        
+        case .invalidated:
+            _protocolLock.unlock() // Balances above ⬆
+            
+            callback(nil)
+        }
+    }
+    
+    func _satisfyProtocolRequest(with urlProtocol: URLProtocol) {
+        _protocolLock.lock() // Must be balanced below, before we call out ⬇
+        switch _protocolStorage {
+        case .toBeCreated:
+            _protocolStorage = .existing(urlProtocol)
+            _protocolLock.unlock() // Balances above ⬆
+            
+        case .awaitingCacheReply(let bag):
+            _protocolStorage = .existing(urlProtocol)
+            _protocolLock.unlock() // Balances above ⬆
+            
+            for callback in bag.values {
+                callback(urlProtocol)
+            }
+            
+        case .existing(_): fallthrough
+        case .invalidated:
+            _protocolLock.unlock() // Balances above ⬆
+        }
+    }
+    
+    func _invalidateProtocol() {
+        _protocolLock.performLocked {
+            _protocolStorage = .invalidated
+        }
+    }
+    
     private let syncQ = DispatchQueue(label: "org.swift.URLSessionTask.SyncQ")
     private var hasTriggeredResume: Bool = false
     internal var isSuspendedAfterResume: Bool {
@@ -80,25 +178,7 @@ open class URLSessionTask : NSObject, NSCopying {
         self.originalRequest = request
         self.body = body
         super.init()
-        if session.configuration.protocolClasses != nil {
-            guard let protocolClasses = session.configuration.protocolClasses else { fatalError() }
-            if let urlProtocolClass = URLProtocol.getProtocolClass(protocols: protocolClasses, request: request) {
-                guard let urlProtocol = urlProtocolClass as? URLProtocol.Type else { fatalError() }
-                self._protocol = urlProtocol.init(task: self, cachedResponse: nil, client: nil)
-            } else {
-                guard let protocolClasses = URLProtocol.getProtocols() else { fatalError() }
-                if let urlProtocolClass = URLProtocol.getProtocolClass(protocols: protocolClasses, request: request) {
-                    guard let urlProtocol = urlProtocolClass as? URLProtocol.Type else { fatalError() }
-                    self._protocol = urlProtocol.init(task: self, cachedResponse: nil, client: nil)
-                }
-            }
-        } else {
-            guard let protocolClasses = URLProtocol.getProtocols() else { fatalError() }
-            if let urlProtocolClass = URLProtocol.getProtocolClass(protocols: protocolClasses, request: request) {
-                guard let urlProtocol = urlProtocolClass as? URLProtocol.Type else { fatalError() }
-                self._protocol = urlProtocol.init(task: self, cachedResponse: nil, client: nil)
-            }
-        }
+        self.currentRequest = request
     }
     deinit {
         //TODO: Do we remove the EasyHandle from the session here? This might run on the wrong thread / queue.
@@ -193,11 +273,15 @@ open class URLSessionTask : NSObject, NSCopying {
         workQueue.sync {
             guard self.state == .running || self.state == .suspended else { return }
             self.state = .canceling
-            self.workQueue.async {
-                let urlError = URLError(_nsError: NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil))
-                self.error = urlError
-                self._protocol?.stopLoading()
-                self._protocol?.client?.urlProtocol(self._protocol!, didFailWithError: urlError)
+            self._getProtocol { (urlProtocol) in
+                self.workQueue.async {
+                    let urlError = URLError(_nsError: NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil))
+                    self.error = urlError
+                    if let urlProtocol = urlProtocol {
+                        urlProtocol.stopLoading()
+                        urlProtocol.client?.urlProtocol(urlProtocol, didFailWithError: urlError)
+                    }
+                }
             }
         }
     }
@@ -252,8 +336,10 @@ open class URLSessionTask : NSObject, NSCopying {
             self.updateTaskState()
             
             if self.suspendCount == 1 {
-                self.workQueue.async {
-                    self._protocol?.stopLoading()
+                self._getProtocol { (urlProtocol) in
+                    self.workQueue.async {
+                        urlProtocol?.stopLoading()
+                    }
                 }
             }
         }
@@ -268,21 +354,23 @@ open class URLSessionTask : NSObject, NSCopying {
             self.updateTaskState()
             if self.suspendCount == 0 {
                 self.hasTriggeredResume = true
-                self.workQueue.async {
-                    if let _protocol = self._protocol {
-                        _protocol.startLoading()
-                    }
-                    else if self.error == nil {
-                        var userInfo: [String: Any] = [NSLocalizedDescriptionKey: "unsupported URL"]
-                        if let url = self.originalRequest?.url {
-                            userInfo[NSURLErrorFailingURLErrorKey] = url
-                            userInfo[NSURLErrorFailingURLStringErrorKey] = url.absoluteString
+                self._getProtocol { (urlProtocol) in
+                    self.workQueue.async {
+                        if let _protocol = urlProtocol {
+                            _protocol.startLoading()
                         }
-                        let urlError = URLError(_nsError: NSError(domain: NSURLErrorDomain,
-                                                                  code: NSURLErrorUnsupportedURL,
-                                                                  userInfo: userInfo))
-                        self.error = urlError
-                        _ProtocolClient().urlProtocol(task: self, didFailWithError: urlError)
+                        else if self.error == nil {
+                            var userInfo: [String: Any] = [NSLocalizedDescriptionKey: "unsupported URL"]
+                            if let url = self.originalRequest?.url {
+                                userInfo[NSURLErrorFailingURLErrorKey] = url
+                                userInfo[NSURLErrorFailingURLStringErrorKey] = url.absoluteString
+                            }
+                            let urlError = URLError(_nsError: NSError(domain: NSURLErrorDomain,
+                                                                      code: NSURLErrorUnsupportedURL,
+                                                                      userInfo: userInfo))
+                            self.error = urlError
+                            _ProtocolClient().urlProtocol(task: self, didFailWithError: urlError)
+                        }
                     }
                 }
             }
@@ -546,6 +634,22 @@ extension _ProtocolClient : URLProtocolClient {
         task.response = response
         let session = task.session as! URLSession
         guard let dataTask = task as? URLSessionDataTask else { return }
+        
+        // Only cache data tasks:
+        self.cachePolicy = policy
+        
+        if session.configuration.urlCache != nil {
+            switch policy {
+            case .allowed: fallthrough
+            case .allowedInMemoryOnly:
+                cacheableData = []
+                cacheableResponse = response
+                
+            case .notAllowed:
+                break
+            }
+        }
+        
         switch session.behaviour(for: task) {
         case .taskDelegate(let delegate as URLSessionDataDelegate):
             session.delegateQueue.addOperation {
@@ -572,8 +676,8 @@ extension _ProtocolClient : URLProtocolClient {
         }
     }
 
-    func urlProtocolDidFinishLoading(_ protocol: URLProtocol) {
-        guard let task = `protocol`.task else { fatalError() }
+    func urlProtocolDidFinishLoading(_ urlProtocol: URLProtocol) {
+        guard let task = urlProtocol.task else { fatalError() }
         guard let session = task.session as? URLSession else { fatalError() }
         guard let urlResponse = task.response else { fatalError("No response") }
         if let response = urlResponse as? HTTPURLResponse, response.statusCode == 401 {
@@ -581,17 +685,38 @@ extension _ProtocolClient : URLProtocolClient {
                 //TODO: Fetch and set proposed credentials if they exist
                 let authenticationChallenge = URLAuthenticationChallenge(protectionSpace: protectionSpace, proposedCredential: nil,
                                                                      previousFailureCount: task.previousFailureCount, failureResponse: response, error: nil,
-                                                                     sender: `protocol` as! _HTTPURLProtocol)
+                                                                     sender: urlProtocol as! _HTTPURLProtocol)
                 task.previousFailureCount += 1
-                urlProtocol(`protocol`, didReceive: authenticationChallenge)
+                self.urlProtocol(urlProtocol, didReceive: authenticationChallenge)
                 return
             }
         }
+        
+        if let cache = session.configuration.urlCache,
+           let data = cacheableData,
+           let response = cacheableResponse,
+           let task = task as? URLSessionDataTask {
+            
+            let cacheable = CachedURLResponse(response: response, data: Data(data.joined()), storagePolicy: cachePolicy)
+            let protocolAllows = (urlProtocol as? _NativeProtocol)?.canCache(cacheable) ?? false
+            if protocolAllows {
+                if let delegate = task.session.delegate as? URLSessionDataDelegate {
+                    delegate.urlSession(task.session as! URLSession, dataTask: task, willCacheResponse: cacheable) { (actualCacheable) in
+                        if let actualCacheable = actualCacheable {
+                            cache.storeCachedResponse(actualCacheable, for: task)
+                        }
+                    }
+                } else {
+                    cache.storeCachedResponse(cacheable, for: task)
+                }
+            }
+        }
+        
         switch session.behaviour(for: task) {
         case .taskDelegate(let delegate):
             if let downloadDelegate = delegate as? URLSessionDownloadDelegate, let downloadTask = task as? URLSessionDownloadTask {
                 session.delegateQueue.addOperation {
-                    downloadDelegate.urlSession(session, downloadTask: downloadTask, didFinishDownloadingTo: `protocol`.properties[URLProtocol._PropertyKey.temporaryFileURL] as! URL)
+                    downloadDelegate.urlSession(session, downloadTask: downloadTask, didFinishDownloadingTo: urlProtocol.properties[URLProtocol._PropertyKey.temporaryFileURL] as! URL)
                 }
             }
             session.delegateQueue.addOperation {
@@ -608,7 +733,7 @@ extension _ProtocolClient : URLProtocolClient {
             }
         case .dataCompletionHandler(let completion):
             session.delegateQueue.addOperation {
-                completion(`protocol`.properties[URLProtocol._PropertyKey.responseData] as? Data ?? Data(), task.response, nil)
+                completion(urlProtocol.properties[URLProtocol._PropertyKey.responseData] as? Data ?? Data(), task.response, nil)
                 task.state = .completed
                 session.workQueue.async {
                     session.taskRegistry.remove(task)
@@ -616,14 +741,14 @@ extension _ProtocolClient : URLProtocolClient {
             }
         case .downloadCompletionHandler(let completion):
             session.delegateQueue.addOperation {
-                completion(`protocol`.properties[URLProtocol._PropertyKey.temporaryFileURL] as? URL, task.response, nil)
+                completion(urlProtocol.properties[URLProtocol._PropertyKey.temporaryFileURL] as? URL, task.response, nil)
                 task.state = .completed
                 session.workQueue.async {
                     session.taskRegistry.remove(task)
                 }
             }
         }
-        task._protocol = nil
+        task._invalidateProtocol()
     }
 
     func urlProtocol(_ protocol: URLProtocol, didCancel challenge: URLAuthenticationChallenge) {
@@ -643,7 +768,11 @@ extension _ProtocolClient : URLProtocolClient {
                         fatalError("\(authScheme) is not supported")
                     }
                     handler(task, disposition, credential)
-                    task._protocol = _HTTPURLProtocol(task: task, cachedResponse: nil, client: nil)
+                    
+                    task._protocolLock.performLocked {
+                        task._protocolStorage = .existing(_HTTPURLProtocol(task: task, cachedResponse: nil, client: nil))
+                    }
+                    
                     task.resume()
                 }
             }
@@ -655,6 +784,16 @@ extension _ProtocolClient : URLProtocolClient {
         `protocol`.properties[.responseData] = data
         guard let task = `protocol`.task else { fatalError() }
         guard let session = task.session as? URLSession else { fatalError() }
+        
+        switch cachePolicy {
+        case .allowed: fallthrough
+        case .allowedInMemoryOnly:
+            cacheableData?.append(data)
+
+        case .notAllowed:
+            break
+        }
+        
         switch session.behaviour(for: task) {
         case .taskDelegate(let delegate):
             let dataDelegate = delegate as? URLSessionDataDelegate
@@ -704,12 +843,10 @@ extension _ProtocolClient : URLProtocolClient {
                 }
             }
         }
-        task._protocol = nil
+        task._invalidateProtocol()
     }
 
-    func urlProtocol(_ protocol: URLProtocol, cachedResponseIsValid cachedResponse: CachedURLResponse) {
-        NSUnimplemented()
-    }
+    func urlProtocol(_ protocol: URLProtocol, cachedResponseIsValid cachedResponse: CachedURLResponse) {}
 
     func urlProtocol(_ protocol: URLProtocol, wasRedirectedTo request: URLRequest, redirectResponse: URLResponse) {
         NSUnimplemented()

--- a/TestFoundation/TestURLCache.swift
+++ b/TestFoundation/TestURLCache.swift
@@ -1,0 +1,186 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+class TestURLCache : XCTestCase {
+    
+    let aBit = 2 * 1024 /* 2 KB */
+    let lots = 200 * 1024 * 1024 /* 200 MB */
+    
+    func testStorageRoundtrip() throws {
+        let cache = try self.cache(memoryCapacity: lots, diskCapacity: lots)
+
+        let (request, response) = try cachePair(for: "https://google.com/", ofSize: aBit, storagePolicy: .allowed)
+        cache.storeCachedResponse(response, for: request)
+
+        let storedResponse = cache.cachedResponse(for: request)
+        XCTAssertEqual(response, storedResponse)
+    }
+    
+    func testStoragePolicy() throws {
+        do {
+            let cache = try self.cache(memoryCapacity: lots, diskCapacity: lots)
+
+            let (request, response) = try cachePair(for: "https://google.com/", ofSize: aBit, storagePolicy: .allowed)
+            cache.storeCachedResponse(response, for: request)
+            
+            XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: writableTestDirectoryURL.path).count, 1)
+            XCTAssertNotNil(cache.cachedResponse(for: request))
+        }
+        
+        try FileManager.default.removeItem(at: writableTestDirectoryURL)
+        
+        do {
+            let cache = try self.cache(memoryCapacity: lots, diskCapacity: lots)
+            
+            let (request, response) = try cachePair(for: "https://google.com/", ofSize: aBit, storagePolicy: .allowedInMemoryOnly)
+            cache.storeCachedResponse(response, for: request)
+            
+            XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: writableTestDirectoryURL.path).count, 0)
+            XCTAssertNotNil(cache.cachedResponse(for: request))
+        }
+        
+        try FileManager.default.removeItem(at: writableTestDirectoryURL)
+        
+        do {
+            let cache = try self.cache(memoryCapacity: lots, diskCapacity: lots)
+            
+            let (request, response) = try cachePair(for: "https://google.com/", ofSize: aBit, storagePolicy: .notAllowed)
+            cache.storeCachedResponse(response, for: request)
+            
+            XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: writableTestDirectoryURL.path).count, 0)
+            XCTAssertNil(cache.cachedResponse(for: request))
+        }
+        
+        try FileManager.default.removeItem(at: writableTestDirectoryURL)
+    }
+    
+    func testNoDiskUsageIfDisabled() throws {
+        let cache = try self.cache(memoryCapacity: lots, diskCapacity: 0)
+        let (request, response) = try cachePair(for: "https://google.com/", ofSize: aBit)
+        cache.storeCachedResponse(response, for: request)
+        
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: writableTestDirectoryURL.path).count, 0)
+        XCTAssertNotNil(cache.cachedResponse(for: request))
+    }
+    
+    func testShrinkingDiskCapacityEvictsItems() throws {
+        let cache = try self.cache(memoryCapacity: lots, diskCapacity: lots)
+        
+        let urls = [ "https://apple.com/",
+                     "https://google.com/",
+                     "https://facebook.com/" ]
+        
+        for (request, response) in try urls.map({ try cachePair(for: $0, ofSize: aBit) }) {
+            cache.storeCachedResponse(response, for: request)
+        }
+        
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: writableTestDirectoryURL.path).count, 3)
+        for url in urls {
+            XCTAssertNotNil(cache.cachedResponse(for: URLRequest(url: URL(string: url)!)))
+        }
+        
+        cache.diskCapacity = 0
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: writableTestDirectoryURL.path).count, 0)
+        for url in urls {
+            XCTAssertNotNil(cache.cachedResponse(for: URLRequest(url: URL(string: url)!)))
+        }
+    }
+    
+    func testNoMemoryUsageIfDisabled() throws {
+        let cache = try self.cache(memoryCapacity: 0, diskCapacity: lots)
+        let (request, response) = try cachePair(for: "https://google.com/", ofSize: aBit)
+        cache.storeCachedResponse(response, for: request)
+        
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: writableTestDirectoryURL.path).count, 1)
+        XCTAssertNotNil(cache.cachedResponse(for: request))
+        
+        // Ensure that the fulfillment doesn't come from memory:
+        try FileManager.default.removeItem(at: writableTestDirectoryURL)
+        try FileManager.default.createDirectory(at: writableTestDirectoryURL, withIntermediateDirectories: true)
+        
+        XCTAssertNil(cache.cachedResponse(for: request))
+    }
+    
+    func testShrinkingMemoryCapacityEvictsItems() throws {
+        let cache = try self.cache(memoryCapacity: lots, diskCapacity: lots)
+        
+        let urls = [ "https://apple.com/",
+                     "https://google.com/",
+                     "https://facebook.com/" ]
+        
+        for (request, response) in try urls.map({ try cachePair(for: $0, ofSize: aBit) }) {
+            cache.storeCachedResponse(response, for: request)
+        }
+        
+        // Ensure these can be fulfilled from memory:
+        try FileManager.default.removeItem(at: writableTestDirectoryURL)
+        try FileManager.default.createDirectory(at: writableTestDirectoryURL, withIntermediateDirectories: true)
+
+        for url in urls {
+            XCTAssertNotNil(cache.cachedResponse(for: URLRequest(url: URL(string: url)!)))
+        }
+        
+        // And evict all:
+        cache.memoryCapacity = 0
+
+        for url in urls {
+            XCTAssertNil(cache.cachedResponse(for: URLRequest(url: URL(string: url)!)))
+        }
+    }
+    
+    // -----
+    
+    static var allTests: [(String, (TestURLCache) -> () throws -> Void)] {
+        return [
+            ("testStorageRoundtrip", testStorageRoundtrip),
+            ("testStoragePolicy", testStoragePolicy),
+            ("testNoDiskUsageIfDisabled", testNoDiskUsageIfDisabled),
+            ("testShrinkingDiskCapacityEvictsItems", testShrinkingDiskCapacityEvictsItems),
+            ("testNoMemoryUsageIfDisabled", testNoMemoryUsageIfDisabled),
+            ("testShrinkingMemoryCapacityEvictsItems", testShrinkingMemoryCapacityEvictsItems),
+        ]
+    }
+    
+    // -----
+    
+    func cache(memoryCapacity: Int = 0, diskCapacity: Int = 0) throws -> URLCache {
+        try FileManager.default.createDirectory(at: writableTestDirectoryURL, withIntermediateDirectories: true)
+        return URLCache(memoryCapacity: memoryCapacity, diskCapacity: diskCapacity, diskPath: writableTestDirectoryURL.path)
+    }
+    
+    func cachePair(for urlString: String, ofSize size: Int, storagePolicy: URLCache.StoragePolicy = .allowed) throws -> (URLRequest, CachedURLResponse) {
+        let url = try URL(string: urlString).unwrapped()
+        let request = URLRequest(url: url)
+        let response = try HTTPURLResponse(url: url, statusCode: 200, httpVersion: "1.1", headerFields: [:]).unwrapped()
+        return (request, CachedURLResponse(response: response, data: Data(count: size), storagePolicy: storagePolicy))
+    }
+    
+    var writableTestDirectoryURL: URL!
+    
+    override func setUp() {
+        super.setUp()
+        
+        let pid = ProcessInfo.processInfo.processIdentifier
+        writableTestDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("org.swift.TestFoundation.TestURLCache.\(pid)")
+    }
+    
+    override func tearDown() {
+        if let directoryURL = writableTestDirectoryURL,
+            (try? FileManager.default.attributesOfItem(atPath: directoryURL.path)) != nil {
+            do {
+                try FileManager.default.removeItem(at: directoryURL)
+            } catch {
+                NSLog("Could not remove test directory at URL \(directoryURL): \(error)")
+            }
+        }
+        
+        super.tearDown()
+    }
+    
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -82,6 +82,7 @@ var allTestCases = [
     testCase(TestTimer.allTests),
     testCase(TestTimeZone.allTests),
     testCase(TestURL.allTests),
+    testCase(TestURLCache.allTests),
     testCase(TestURLComponents.allTests),
     testCase(TestURLCredential.allTests),
     testCase(TestURLProtectionSpace.allTests),


### PR DESCRIPTION
⚠️ Needs extensive testing and adding many of the fixes discussed in the comments of the PR linked below.

 - Includes the changes from previous PR: <https://github.com/apple/swift-corelibs-foundation/pull/2341>. They introduce an implementation of `URLCache`.

 - Store and provide the storage date for cached responses, for internal use only.

 - Implement protocol properties.

 - `URLSessionConfiguration` now configures the shared and ephemeral sessions with caches of appropriate size and storage setup. Each ephemeral session has a new in-memory-only cache, and the shared session used the shared `URLCache .

 - The `URLProtocolClient` that drives `URLSession` tasks now asks its delegate for caching, and if a cacheable response is determined, uses the `URLSession`’s cache to store it. It will also fetch from the cache if appropriate, and will initialize the protocol with that response.

 - Add hooks to `_NativeProtocol` to affect whether the transfer can be satisfied by the cached response it was initialized with. If it can, the response will be replayed instead.

 - `_HTTPURLProtocol` implements those hooks to make the `URLCache` behave as a RFC 7234 private cache. (Note that `_FTPURLProtocol` uses the default implementation of those hooks, which will cause related responses to be evicted from the cache and no response to be fulfilled from the cache. This is intentional.)