### PR TITLE
[android] Mark link test in TestFileManager as failing for Android.

### DIFF
--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -1734,7 +1734,7 @@ VIDEOS=StopgapVideos
             ("test_contentsOfDirectoryAtPath", test_contentsOfDirectoryAtPath),
             ("test_subpathsOfDirectoryAtPath", test_subpathsOfDirectoryAtPath),
             ("test_copyItemAtPathToPath", test_copyItemAtPathToPath),
-            ("test_linkItemAtPathToPath", test_linkItemAtPathToPath),
+            ("test_linkItemAtPathToPath", testExpectedToFailOnAndroid(test_linkItemAtPathToPath, "Android doesn't allow hard links")),
             ("test_homedirectoryForUser", test_homedirectoryForUser),
             ("test_temporaryDirectoryForUser", test_temporaryDirectoryForUser),
             ("test_creatingDirectoryWithShortIntermediatePath", test_creatingDirectoryWithShortIntermediatePath),

--- a/TestFoundation/TestThread.swift
+++ b/TestFoundation/TestThread.swift
@@ -25,15 +25,9 @@ class TestThread : XCTestCase {
             ("test_currentThread", test_currentThread),
             ("test_threadStart", test_threadStart),
             ("test_mainThread", test_mainThread),
+            ("test_callStackSymbols", testExpectedToFailOnAndroid(test_callStackSymbols, "Android doesn't support backtraces at the moment.")),
+            ("test_callStackReturnAddresses", testExpectedToFailOnAndroid(test_callStackReturnAddresses, "Android doesn't support backtraces at the moment.")),
         ]
-
-#if !os(Android)
-        // Android doesn't support backtraces at the moment.
-        tests.append(contentsOf: [
-            ("test_callStackSymbols", test_callStackSymbols),
-            ("test_callStackReturnAddresses", test_callStackReturnAddresses),
-        ])
-#endif
 
 #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
         tests.append(contentsOf: [

--- a/TestFoundation/TestURLSession.swift
+++ b/TestFoundation/TestURLSession.swift
@@ -313,9 +313,6 @@ class TestURLSession : LoopbackServerTest {
 
     // This test is buggy becuase the server could respond before the task is cancelled.
     func test_cancelTask() {
-#if os(Android)
-        XCTFail("Intermittent failures on Android")
-#else
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/Peru"
         var urlRequest = URLRequest(url: URL(string: urlString)!)
         urlRequest.setValue("2.0", forHTTPHeaderField: "X-Pause")
@@ -324,7 +321,6 @@ class TestURLSession : LoopbackServerTest {
         d.run(with: urlRequest)
         d.cancel()
         waitForExpectations(timeout: 12)
-#endif
     }
     
     func test_verifyRequestHeaders() {

--- a/TestFoundation/Utilities.swift
+++ b/TestFoundation/Utilities.swift
@@ -534,6 +534,14 @@ func shouldAttemptWindowsXFailTests(_ reason: String) -> Bool {
     #endif
 }
 
+func shouldAttemptAndroidXFailTests(_ reason: String) -> Bool {
+    #if os(Android)
+    return shouldAttemptXFailTests(reason)
+    #else
+    return true
+    #endif
+}
+
 func appendTestCaseExpectedToFail<T: XCTestCase>(_ reason: String, _ allTests: [(String, (T) -> () throws -> Void)], into array: inout [XCTestCaseEntry]) {
     if shouldAttemptXFailTests(reason) {
         array.append(testCase(allTests))
@@ -546,6 +554,10 @@ func testExpectedToFail<T>(_ test:  @escaping (T) -> () throws -> Void, _ reason
 
 func testExpectedToFailOnWindows<T>(_ test:  @escaping (T) -> () throws -> Void, _ reason: String) -> (T) -> () throws -> Void {
     testExpectedToFailWithCheck(check: shouldAttemptWindowsXFailTests(_:), test, reason)
+}
+
+func testExpectedToFailOnAndroid<T>(_ test: @escaping (T) -> () throws -> Void, _ reason: String) -> (T) -> () throws -> Void {
+    testExpectedToFailWithCheck(check: shouldAttemptAndroidXFailTests(_:), test, reason)
 }
 
 func testExpectedToFailWithCheck<T>(check: (String) -> Bool, _ test:  @escaping (T) -> () throws -> Void, _ reason: String) -> (T) -> () throws -> Void {


### PR DESCRIPTION
Implement support for marking test as expected to fail in Android
similar to what Windows has already. Use the helper function to mark
the tests that were already disabled in Android (there are some others
with extra checks that should be done more carefully).

Additionally, mark one of the tests of TestFileManager as failing in
Android. Android doesn't allow normal programs to use the link syscall,
and it always fails with insuficient permissions. The test will never
work. Disable the test in Android completely. Users should deal with the
always failing API, since errors are always possible for other reason.

Also, remove a disabled test in TestURLSession because I cannot make it
fail in my setup. It might have fail before, but it not longer fails.