### PR TITLE
build: add DT_SONAME for ELF libraries

### DIFF
--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -133,7 +133,11 @@ function(add_swift_target target)
   file(WRITE ${rsp_file} ${rsp_text})
 
   if(AST_LIBRARY)
+    if(CMAKE_SYSTEM_NAME STREQUAL Windows OR CMAKE_SYSTEM_NAME STREQUAL Darwin)
       set(emit_library -emit-library)
+    else()
+      set(emit_library -emit-library -Xlinker -soname -Xlinker ${AST_OUTPUT})
+    endif()
   endif()
   if(NOT AST_LIBRARY OR library_kind STREQUAL SHARED)
     add_custom_command(OUTPUT


### PR DESCRIPTION
Unfortunately, because we do not use CMake for generating the libraries,
we need to explicitly control the library names for the time being.  Add
a DT_SONAME entry to the ELF binary that we generate to ensure that we
are able to properly link to the libraries at load time.