### PR TITLE
[Windows] Mark Symlinked Directories as Symlinks

### DIFF
--- a/Foundation/FileManager+Win32.swift
+++ b/Foundation/FileManager+Win32.swift
@@ -219,7 +219,8 @@ extension FileManager {
 
         try _contentsOfDir(atPath: path, { (entryName, entryType) throws in
             contents.append(entryName)
-            if entryType & FILE_ATTRIBUTE_DIRECTORY == FILE_ATTRIBUTE_DIRECTORY {
+            if entryType & FILE_ATTRIBUTE_DIRECTORY == FILE_ATTRIBUTE_DIRECTORY
+                 && entryType & FILE_ATTRIBUTE_REPARSE_POINT != FILE_ATTRIBUTE_REPARSE_POINT {
                 let subPath: String = joinPath(prefix: path, suffix: entryName)
                 let entries = try subpathsOfDirectory(atPath: subPath)
                 contents.append(contentsOf: entries.map { joinPath(prefix: entryName, suffix: $0).standardizingPath })


### PR DESCRIPTION
On Windows, symlinks to directories are both symlinks and directories.
To emulate posix, we should treat them as only symlinks and not
directories.