### PR TITLE
[test] Remove external networking in TestHost

### DIFF
--- a/TestFoundation/TestHost.swift
+++ b/TestFoundation/TestHost.swift
@@ -28,7 +28,7 @@ class TestHost: XCTestCase {
         let dnsAddressesSecond = dns.addresses
         XCTAssertEqual(dnsAddressesSecond.count, dnsAddressesFirst.count)
         
-        let swift = Host(name: "swift.org")
+        let swift = Host(name: "localhost")
         let swiftAddressesFirst = swift.addresses
         let swiftAddressesSecond = swift.addresses
         XCTAssertEqual(swiftAddressesSecond.count, swiftAddressesFirst.count)
@@ -42,8 +42,8 @@ class TestHost: XCTestCase {
         let host2 = Host(address: "8.8.8.9")
         XCTAssertFalse(host0.isEqual(to: host2))
 
-        let swift0 = Host(name: "swift.org")
-        let swift1 = Host(name: "swift.org")
+        let swift0 = Host(name: "localhost")
+        let swift1 = Host(name: "localhost")
         XCTAssertTrue(swift0.isEqual(to: swift1))
 
         let google = Host(name: "google.com")


### PR DESCRIPTION
Ideally the test suite should not depend on external factors. TestHost
was doing DNS requests to turn Host names into Host addresses.

To try to avoid external factors, one can use localhost, which should be
resolved locally all the time, and the check should work the same.

There's an usage of another external name in the test. Sadly there's no
guarantees of another name being defined locally. Some machines have an
IPv6 specific name, but it is not as standard as localhost. Luckily, the
test will work with an external name, even if it cannot be resolved,
since it should not be the same as localhost for most people.