### PR TITLE
[Windows] Fix TestURL.swift crash

### DIFF
--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -253,8 +253,12 @@ class TestURL : XCTestCase {
             } else {
                 if let url = url {
                         let results = generateResults(url, pathComponent: inPathComponent, pathExtension: inPathExtension)
-                        let (isEqual, differences) = compareResults(url, expected: expectedNSResult as! [String: Any], got: results)
-                        XCTAssertTrue(isEqual, "\(title): \(differences.joined(separator: "\n"))")
+                        if let expected = expectedNSResult as? [String: Any] {
+                            let (isEqual, differences) = compareResults(url, expected: expected, got: results)
+                            XCTAssertTrue(isEqual, "\(title): \(differences.joined(separator: "\n"))")
+                        } else {
+                            XCTFail("\(url) should not be a valid url")
+                        }
                 } else {
                     XCTAssertEqual(expectedNSResult as? String, kNullURLString)
                 }


### PR DESCRIPTION
On Windows, `|` is a valid character in a URL (as a replacement to `:`,
e.g. `/C|/Users/gwenm`. This causes a test testing
`http://test.com/unescaped|pipe` which is expected  to not parse to
parse successfully on Windows. The test then tries to parse the `<null
url>` in the expected result and crashes.

This changes the test to check to make sure it can parse the expected
result instead of force casting so that the test fails instead of
crashing.

This allows TestURL to run to completion in the mean time while working
on URL for Windows.