### PR TITLE
FoundationNetworking: repair the build on Windows

### DIFF
--- a/Foundation/HTTPCookie.swift
+++ b/Foundation/HTTPCookie.swift
@@ -13,6 +13,10 @@ import SwiftFoundation
 import Foundation
 #endif
 
+#if os(Windows)
+import WinSDK
+#endif
+
 public struct HTTPCookiePropertyKey : RawRepresentable, Equatable, Hashable {
     public private(set) var rawValue: String
     


### PR DESCRIPTION
Import WinSDK to enable import of networking APIs for Windows.