### PR TITLE
Remove unnecessary Array copy.

### DIFF
--- a/Foundation/JSONSerialization.swift
+++ b/Foundation/JSONSerialization.swift
@@ -130,7 +130,7 @@ open class JSONSerialization : NSObject {
             sortedKeys: opt.contains(.sortedKeys),
             writer: { (str: String?) in
                 if let str = str {
-                    jsonStr.append(contentsOf: Array(str.utf8))
+                    jsonStr.append(contentsOf: str.utf8)
                 }
             }
         )


### PR DESCRIPTION
Array.append(contentsOf:) supports any Sequence, and String.UTF8View is
a sequence, so there's no need to create an Array from it to append it.

From a post-merge feedback in #2393.