### PR TITLE
Parity: URLCredentialStorage

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		153E951120111DC500F250BE /* CFKnownLocations.h in Headers */ = {isa = PBXBuildFile; fileRef = 153E950F20111DC500F250BE /* CFKnownLocations.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		153E951220111DC500F250BE /* CFKnownLocations.c in Sources */ = {isa = PBXBuildFile; fileRef = 153E951020111DC500F250BE /* CFKnownLocations.c */; };
 		15496CF1212CAEBA00450F5A /* CFAttributedStringPriv.h in Headers */ = {isa = PBXBuildFile; fileRef = 15496CF0212CAEBA00450F5A /* CFAttributedStringPriv.h */; };
+		155B77AC22E63D2D00D901DE /* TestURLCredentialStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155B77AB22E63D2D00D901DE /* TestURLCredentialStorage.swift */; };
 		155D3BBC22401D1100B0D38E /* FixtureValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155D3BBB22401D1100B0D38E /* FixtureValues.swift */; };
 		1569BFA12187D04C009518FA /* CFCalendar_Enumerate.c in Sources */ = {isa = PBXBuildFile; fileRef = 1569BF9F2187D003009518FA /* CFCalendar_Enumerate.c */; };
 		1569BFA22187D04F009518FA /* CFCalendar_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1569BF9D2187CFFF009518FA /* CFCalendar_Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -638,6 +639,7 @@
 		153E950F20111DC500F250BE /* CFKnownLocations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CFKnownLocations.h; sourceTree = "<group>"; };
 		153E951020111DC500F250BE /* CFKnownLocations.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = CFKnownLocations.c; sourceTree = "<group>"; };
 		15496CF0212CAEBA00450F5A /* CFAttributedStringPriv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFAttributedStringPriv.h; sourceTree = "<group>"; };
+		155B77AB22E63D2D00D901DE /* TestURLCredentialStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestURLCredentialStorage.swift; sourceTree = "<group>"; };
 		155D3BBB22401D1100B0D38E /* FixtureValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixtureValues.swift; sourceTree = "<group>"; };
 		1569BF9D2187CFFF009518FA /* CFCalendar_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFCalendar_Internal.h; sourceTree = "<group>"; };
 		1569BF9F2187D003009518FA /* CFCalendar_Enumerate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFCalendar_Enumerate.c; sourceTree = "<group>"; };
@@ -1779,6 +1781,7 @@
 				DAA79BD820D42C07004AF044 /* TestURLProtectionSpace.swift */,
 				7A7D6FBA1C16439400957E2E /* TestURLResponse.swift */,
 				5B1FD9E21D6D17B80080E83C /* TestURLSession.swift */,
+				155B77AB22E63D2D00D901DE /* TestURLCredentialStorage.swift */,
 				555683BC1C1250E70041D4C6 /* TestUserDefaults.swift */,
 				C2A9D75B1C15C08B00993803 /* TestNSUUID.swift */,
 				D3047AEB1C38BC3300295652 /* TestNSValue.swift */,
@@ -2912,6 +2915,7 @@
 				684C79011F62B611005BD73E /* TestNSNumberBridging.swift in Sources */,
 				DAA79BD920D42C07004AF044 /* TestURLProtectionSpace.swift in Sources */,
 				616068F5225DE606004FCC54 /* TestURLSessionFTP.swift in Sources */,
+				155B77AC22E63D2D00D901DE /* TestURLCredentialStorage.swift in Sources */,
 				B951B5EC1F4E2A2000D8B332 /* TestNSLock.swift in Sources */,
 				5B13B33A1C582D4C00651CE2 /* TestNSNumber.swift in Sources */,
 				5B13B3521C582D4C00651CE2 /* TestNSValue.swift in Sources */,

--- a/Foundation/URLCredential.swift
+++ b/Foundation/URLCredential.swift
@@ -28,6 +28,8 @@ extension URLCredential {
         case none
         case forSession
         case permanent
+        
+        @available(*, deprecated, message: "Synchronizable credential storage is not available in swift-corelibs-foundation. If you rely on synchronization for your functionality, please audit your code.")
         case synchronizable
     }
 }

--- a/Foundation/URLCredentialStorage.swift
+++ b/Foundation/URLCredentialStorage.swift
@@ -74,7 +74,8 @@ open class URLCredentialStorage: NSObject {
     */
     open func set(_ credential: URLCredential, for space: URLProtectionSpace) {
         guard credential.persistence != .synchronizable else {
-            NSUnimplemented()
+            // Do what logged-out-from-iCloud Darwin does, and refuse to save synchronizable credentials when a sync service is not available (which, in s-c-f, is always)
+            return
         }
 
         guard credential.persistence != .none else {
@@ -172,7 +173,7 @@ open class URLCredentialStorage: NSObject {
     */
     open func setDefaultCredential(_ credential: URLCredential, for space: URLProtectionSpace) {
         guard credential.persistence != .synchronizable else {
-            NSUnimplemented()
+            return
         }
 
         guard credential.persistence != .none else {

--- a/Foundation/URLCredentialStorage.swift
+++ b/Foundation/URLCredentialStorage.swift
@@ -38,6 +38,12 @@ open class URLCredentialStorage: NSObject {
         _defaultCredentials = [:]
     }
 
+    convenience init(ephemeral: Bool) {
+        // Some URLCredentialStorages must be ephemeral, to support ephemeral URLSessions. They should not write anything to persistent storage.
+        // All URLCredentialStorage instances are _currently_ ephemeral, so there's no need to record the value of 'ephemeral' here, but if we implement persistent storage in the future using platform secure storage, implementers of that functionality will have to heed this flag here.
+        self.init()
+    }
+    
     /*!
         @method credentialsForProtectionSpace:
         @abstract Get a dictionary mapping usernames to credentials for the specified protection space.

--- a/Foundation/URLSession/URLSession.swift
+++ b/Foundation/URLSession/URLSession.swift
@@ -212,8 +212,6 @@ open class URLSession : NSObject {
     fileprivate static let _shared: URLSession = {
         var configuration = URLSessionConfiguration.default
         configuration.httpCookieStorage = HTTPCookieStorage.shared
-        //TODO: Set urlCache to URLCache.shared. Needs implementation of URLCache.
-        //TODO: Set urlCredentialStorage to `URLCredentialStorage.shared`. Needs implementation of URLCredentialStorage.
         configuration.protocolClasses = URLProtocol.getProtocols()
         return URLSession(configuration: configuration, delegate: nil, delegateQueue: nil)
     }()

--- a/Foundation/URLSession/URLSessionConfiguration.swift
+++ b/Foundation/URLSession/URLSessionConfiguration.swift
@@ -72,7 +72,7 @@ open class URLSessionConfiguration : NSObject, NSCopying {
                   httpAdditionalHeaders: nil,
                   httpMaximumConnectionsPerHost: 6,
                   httpCookieStorage: .shared,
-                  urlCredentialStorage: nil, // Should be .shared once implemented.
+                  urlCredentialStorage: .shared,
                   urlCache: .shared,
                   shouldUseExtendedBackgroundIdleMode: false,
                   protocolClasses: [_HTTPURLProtocol.self, _FTPURLProtocol.self])
@@ -148,11 +148,9 @@ open class URLSessionConfiguration : NSObject, NSCopying {
     }
 
     open class var ephemeral: URLSessionConfiguration {
-        // Return a new ephemeral URLSessionConfiguration every time this property is invoked
-        // TODO: urlCredentialStorage should also be ephemeral/in-memory
-        // URLCredentialStorage is still unimplemented
         let ephemeralConfiguration = URLSessionConfiguration.default.copy() as! URLSessionConfiguration
         ephemeralConfiguration.httpCookieStorage = .ephemeralStorage()
+        ephemeralConfiguration.urlCredentialStorage = URLCredentialStorage() // All credential storage in s-c-f are ephemeral.
         ephemeralConfiguration.urlCache = URLCache(memoryCapacity: 4 * 1024 * 1024, diskCapacity: 0, diskPath: nil)
         return ephemeralConfiguration
     }

--- a/Foundation/URLSession/URLSessionConfiguration.swift
+++ b/Foundation/URLSession/URLSessionConfiguration.swift
@@ -150,7 +150,7 @@ open class URLSessionConfiguration : NSObject, NSCopying {
     open class var ephemeral: URLSessionConfiguration {
         let ephemeralConfiguration = URLSessionConfiguration.default.copy() as! URLSessionConfiguration
         ephemeralConfiguration.httpCookieStorage = .ephemeralStorage()
-        ephemeralConfiguration.urlCredentialStorage = URLCredentialStorage() // All credential storage in s-c-f are ephemeral.
+        ephemeralConfiguration.urlCredentialStorage = URLCredentialStorage(ephemeral: true)
         ephemeralConfiguration.urlCache = URLCache(memoryCapacity: 4 * 1024 * 1024, diskCapacity: 0, diskPath: nil)
         return ephemeralConfiguration
     }

--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -50,8 +50,9 @@ open class URLSessionTask : NSObject, NSCopying {
         case invalidated
     }
     
-    fileprivate let _protocolLock = NSLock()
+    fileprivate let _protocolLock = NSLock() // protects:
     fileprivate var _protocolStorage: ProtocolState = .toBeCreated
+    internal    var _lastCredentialUsedFromStorageDuringAuthentication: (protectionSpace: URLProtectionSpace, credential: URLCredential)?
     
     private var _protocolClass: URLProtocol.Type {
         guard let request = currentRequest else { fatalError("A protocol class was requested, but we do not have a current request") }
@@ -682,14 +683,47 @@ extension _ProtocolClient : URLProtocolClient {
         guard let urlResponse = task.response else { fatalError("No response") }
         if let response = urlResponse as? HTTPURLResponse, response.statusCode == 401 {
             if let protectionSpace = createProtectionSpace(response) {
-                //TODO: Fetch and set proposed credentials if they exist
-                let authenticationChallenge = URLAuthenticationChallenge(protectionSpace: protectionSpace, proposedCredential: nil,
-                                                                     previousFailureCount: task.previousFailureCount, failureResponse: response, error: nil,
-                                                                     sender: urlProtocol as! _HTTPURLProtocol)
-                task.previousFailureCount += 1
-                self.urlProtocol(urlProtocol, didReceive: authenticationChallenge)
+
+                func proceed(proposing credential: URLCredential?) {
+                    let proposedCredential: URLCredential?
+                    let last = task._protocolLock.performLocked { task._lastCredentialUsedFromStorageDuringAuthentication }
+                    
+                    if last?.credential != credential {
+                        proposedCredential = credential
+                    } else {
+                        proposedCredential = nil
+                    }
+                    
+                    let authenticationChallenge = URLAuthenticationChallenge(protectionSpace: protectionSpace, proposedCredential: proposedCredential,
+                                                                             previousFailureCount: task.previousFailureCount, failureResponse: response, error: nil,
+                                                                             sender: urlProtocol as! _HTTPURLProtocol)
+                    task.previousFailureCount += 1
+                    self.urlProtocol(urlProtocol, didReceive: authenticationChallenge)
+                }
+                
+                if let storage = session.configuration.urlCredentialStorage {
+                    storage.getCredentials(for: protectionSpace, task: task) { (credentials) in
+                        if let credentials = credentials,
+                            let firstKeyLexicographically = credentials.keys.sorted().first {
+                            proceed(proposing: credentials[firstKeyLexicographically])
+                        } else {
+                            storage.getDefaultCredential(for: protectionSpace, task: task) { (credential) in
+                                proceed(proposing: credential)
+                            }
+                        }
+                    }
+                } else {
+                    proceed(proposing: nil)
+                }
+                
                 return
             }
+        }
+        
+        if let storage = session.configuration.urlCredentialStorage,
+           let last = task._protocolLock.performLocked({ task._lastCredentialUsedFromStorageDuringAuthentication }),
+           last.credential.persistence != .none && last.credential.persistence != .forSession {
+            storage.set(last.credential, for: last.protectionSpace, task: task)
         }
         
         if let cache = session.configuration.urlCache,
@@ -762,25 +796,65 @@ extension _ProtocolClient : URLProtocolClient {
     func urlProtocol(_ protocol: URLProtocol, didReceive challenge: URLAuthenticationChallenge) {
         guard let task = `protocol`.task else { fatalError("Received response, but there's no task.") }
         guard let session = task.session as? URLSession else { fatalError("Task not associated with URLSession.") }
+        
+        func proceed(using credential: URLCredential?) {
+            let protectionSpace = challenge.protectionSpace
+            let authScheme = protectionSpace.authenticationMethod
+
+            task.suspend()
+            
+            guard let handler = URLSessionTask.authHandler(for: authScheme) else {
+                fatalError("\(authScheme) is not supported")
+            }
+            handler(task, .useCredential, credential)
+
+            task._protocolLock.performLocked {
+                if let credential = credential {
+                    task._lastCredentialUsedFromStorageDuringAuthentication = (protectionSpace: protectionSpace, credential: credential)
+                } else {
+                    task._lastCredentialUsedFromStorageDuringAuthentication = nil
+                }
+                task._protocolStorage = .existing(_HTTPURLProtocol(task: task, cachedResponse: nil, client: nil))
+            }
+            
+            task.resume()
+        }
+        
+        func attemptProceedingWithDefaultCredential() {
+            if let credential = challenge.proposedCredential {
+                let last = task._protocolLock.performLocked { task._lastCredentialUsedFromStorageDuringAuthentication }
+                
+                if last?.credential != credential {
+                    proceed(using: credential)
+                } else {
+                    task.cancel()
+                }
+            }
+        }
+        
         switch session.behaviour(for: task) {
         case .taskDelegate(let delegate):
             session.delegateQueue.addOperation {
-                let authScheme = challenge.protectionSpace.authenticationMethod
                 delegate.urlSession(session, task: task, didReceive: challenge) { disposition, credential in
-                    task.suspend()
-                    guard let handler = URLSessionTask.authHandler(for: authScheme) else {
-                        fatalError("\(authScheme) is not supported")
-                    }
-                    handler(task, disposition, credential)
                     
-                    task._protocolLock.performLocked {
-                        task._protocolStorage = .existing(_HTTPURLProtocol(task: task, cachedResponse: nil, client: nil))
+                    switch disposition {
+                    case .useCredential:
+                        proceed(using: credential!)
+                        
+                    case .performDefaultHandling:
+                        attemptProceedingWithDefaultCredential()
+                        
+                    case .rejectProtectionSpace:
+                        // swift-corelibs-foundation currently supports only a single protection space per request.
+                        fallthrough
+                    case .cancelAuthenticationChallenge:
+                        task.cancel()
                     }
                     
-                    task.resume()
                 }
             }
-        default: return
+        default:
+            attemptProceedingWithDefaultCredential()
         }
     }
 

--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -721,8 +721,7 @@ extension _ProtocolClient : URLProtocolClient {
         }
         
         if let storage = session.configuration.urlCredentialStorage,
-           let last = task._protocolLock.performLocked({ task._lastCredentialUsedFromStorageDuringAuthentication }),
-           last.credential.persistence != .none && last.credential.persistence != .forSession {
+           let last = task._protocolLock.performLocked({ task._lastCredentialUsedFromStorageDuringAuthentication }) {
             storage.set(last.credential, for: last.protectionSpace, task: task)
         }
         

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -85,6 +85,7 @@ var allTestCases = [
     testCase(TestURLCache.allTests),
     testCase(TestURLComponents.allTests),
     testCase(TestURLCredential.allTests),
+    testCase(TestURLCredentialStorage.allTests),
     testCase(TestURLProtectionSpace.allTests),
     testCase(TestURLProtocol.allTests),
     testCase(TestNSURLRequest.allTests),


### PR DESCRIPTION
 - Do not crash when a synchronizable credential is added. Instead, act as Darwin does in similar situations (do not store). To make sure the difference is visible, diagnose uses of `.synchronized`.

 - `URLSession` is now correctly initialized with appropriate credential storages via its configuration.

 - Credentials are fetched appropriately from storage, and when a delegate is consulted about authentication fetched credentials are proposed as part of the auth challenge correctly. (If multiple credentials match, always propose the first in lexicographical order.)

 - Interpret the disposition of a delegate if queried. If `.performDefaultHandling` is used, or if the task has no delegate, use the default proposed credential once automatically before giving up.

 - When a task finishes, if a credential was used, save it in the credential storage if appropriate.