### PR TITLE
[URLSession] Avoid calling completion callbacks/delegates twice.

### DIFF
--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -720,6 +720,7 @@ extension _ProtocolClient : URLProtocolClient {
                 }
             }
             session.delegateQueue.addOperation {
+                guard task.state != .completed else { return }
                 delegate.urlSession(session, task: task, didCompleteWithError: nil)
                 task.state = .completed
                 session.workQueue.async {
@@ -727,12 +728,14 @@ extension _ProtocolClient : URLProtocolClient {
                 }
             }
         case .noDelegate:
+            guard task.state != .completed else { break }
             task.state = .completed
             session.workQueue.async {
                 session.taskRegistry.remove(task)
             }
         case .dataCompletionHandler(let completion):
             session.delegateQueue.addOperation {
+                guard task.state != .completed else { return }
                 completion(urlProtocol.properties[URLProtocol._PropertyKey.responseData] as? Data ?? Data(), task.response, nil)
                 task.state = .completed
                 session.workQueue.async {
@@ -741,6 +744,7 @@ extension _ProtocolClient : URLProtocolClient {
             }
         case .downloadCompletionHandler(let completion):
             session.delegateQueue.addOperation {
+                guard task.state != .completed else { return }
                 completion(urlProtocol.properties[URLProtocol._PropertyKey.temporaryFileURL] as? URL, task.response, nil)
                 task.state = .completed
                 session.workQueue.async {
@@ -815,6 +819,7 @@ extension _ProtocolClient : URLProtocolClient {
         switch session.behaviour(for: task) {
         case .taskDelegate(let delegate):
             session.delegateQueue.addOperation {
+                guard task.state != .completed else { return }
                 delegate.urlSession(session, task: task, didCompleteWithError: error as Error)
                 task.state = .completed
                 session.workQueue.async {
@@ -822,12 +827,14 @@ extension _ProtocolClient : URLProtocolClient {
                 }
             }
         case .noDelegate:
+            guard task.state != .completed else { break }
             task.state = .completed
             session.workQueue.async {
                 session.taskRegistry.remove(task)
             }
         case .dataCompletionHandler(let completion):
             session.delegateQueue.addOperation {
+                guard task.state != .completed else { return }
                 completion(nil, nil, error)
                 task.state = .completed
                 session.workQueue.async {
@@ -836,6 +843,7 @@ extension _ProtocolClient : URLProtocolClient {
             }
         case .downloadCompletionHandler(let completion):
             session.delegateQueue.addOperation {
+                guard task.state != .completed else { return }
                 completion(nil, nil, error)
                 task.state = .completed
                 session.workQueue.async {


### PR DESCRIPTION
A callback/delegate call could have been called twice for the same task
if the task error happened during the task initialization and the task
was cancelled shortly after. The error was delivered first, but the
state of the task do not change to completed until after the completion
block has been called, which allows the cancellation to happen and
enqueue another failure callback.

The solution is checking for the task not being already completed before
the completion callbacks are invoked again. Basically the state machine
was allowing a transition from .completed to .completed, when it should
not allow it.

Includes a test that uses a bogus protocol to fail the task quickly and
being able to check for the double callback. The test will have fail
before this change is applied, and passes after it.