### PR TITLE
Refactored code to remove unnecessary checks

### DIFF
--- a/CoreFoundation/String.subproj/CFString.c
+++ b/CoreFoundation/String.subproj/CFString.c
@@ -1480,12 +1480,14 @@ CF_PRIVATE CFStringRef __CFStringCreateImmutableFunnel3(
                 useInlineData = true;
                 size = numBytes;
 
-                if (hasLengthByte || (encoding != kCFStringEncodingUnicode && __CFCanUseLengthByte(numBytes))) {
+                if (hasLengthByte) {
                     useLengthByte = true;
-                    if (!hasLengthByte) size += 1;
+                } else if (encoding != kCFStringEncodingUnicode && __CFCanUseLengthByte(numBytes)) {
+                    useLengthByte = true;
+                    size += 1;
                 } else {
                     size += sizeof(CFIndex);	// Explicit length
-                }	    
+                }
                 if (hasNullByte || encoding != kCFStringEncodingUnicode) {
                     useNullByte = true;
                     size += 1;


### PR DESCRIPTION
When creating an immutable funnel, the code checks the value of "hasLengthByte" twice if it ends up being true. Checking for it once is all that is needed, as another branch can check for the other boolean statement in the if statement previously on line 1483. Differentiating the branches allows less redundant checks and does not introduce any side effects.