### PR TITLE
CoreFoundation: enforce 8-byte alignment on CFRuntimeBase

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.h
+++ b/CoreFoundation/Base.subproj/CFRuntime.h
@@ -190,7 +190,7 @@ CF_EXPORT void _CFRuntimeUnregisterClassWithTypeID(CFTypeID typeID);
  */
 #if DEPLOYMENT_RUNTIME_SWIFT
 
-typedef struct __CFRuntimeBase {
+typedef struct __attribute__((__aligned__(8))) __CFRuntimeBase {
     // This matches the isa and retain count storage in Swift
     uintptr_t _cfisa;
     uintptr_t _swift_rc;

--- a/CoreFoundation/String.subproj/CFString.c
+++ b/CoreFoundation/String.subproj/CFString.c
@@ -149,7 +149,7 @@ struct __notInlineMutable {
 
 /* !!! Never do sizeof(CFString); the union is here just to make it easier to access some fields.
 */
-struct __CFString {
+struct __attribute__((__aligned__(8))) __CFString {
     CFRuntimeBase base;
     union {	// In many cases the allocated structs are smaller than these
 	struct __inline1 {


### PR DESCRIPTION
The atomic typed reference count is a 64-bit value.  We need to ensure
that any statically allocated structure is 8-byte aligned.  This comes
up in the case of CFString where CFConstantString types are emitted into
`__cfstring` on ELF, which can end up 4-byte aligned on ARMv7.  When
accessed at runtime, the offset becomes underaligned, resulting in a bus
error due to the unaligned access.

Although the attribution of `CFRuntimeBase` to 8-byte alignment should
enforce the alignment of `__CFString` due to the member alignment
requirement, just be extra cautious and mark both as requiring 8-byte
alignment.