### PR TITLE
[URLSession] Do not allow resuming cancelled/completed tasks.

### DIFF
--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -331,6 +331,7 @@ open class URLSessionTask : NSObject, NSCopying {
         // returns, but the actual suspend will be done asynchronous to avoid
         // dead-locks.
         workQueue.sync {
+            guard self.state != .canceling && self.state != .completed else { return }
             self.suspendCount += 1
             guard self.suspendCount < Int.max else { fatalError("Task suspended too many times \(Int.max).") }
             self.updateTaskState()
@@ -349,6 +350,7 @@ open class URLSessionTask : NSObject, NSCopying {
     /// - SeeAlso: `suspend()`
     open func resume() {
         workQueue.sync {
+            guard self.state != .canceling && self.state != .completed else { return }
             self.suspendCount -= 1
             guard 0 <= self.suspendCount else { fatalError("Resuming a task that's not suspended. Calls to resume() / suspend() need to be matched.") }
             self.updateTaskState()


### PR DESCRIPTION
A cancelling or completed task might have been resumed (or suspended)
because the implementation didn't check for the state of the task to be
valid.

Includes a small test that reproduces the problem when this patch is not
applied and that doesn't fail when it is.