### PR TITLE
Parity: Networking: URLAuthenticationChallenge

### DIFF
--- a/Foundation/URLAuthenticationChallenge.swift
+++ b/Foundation/URLAuthenticationChallenge.swift
@@ -199,25 +199,24 @@ open class URLAuthenticationChallenge : NSObject, NSSecureCoding {
     }
 }
 
-extension _HTTPURLProtocol : URLAuthenticationChallengeSender {
-
+class URLSessionAuthenticationChallengeSender : NSObject, URLAuthenticationChallengeSender {
     func cancel(_ challenge: URLAuthenticationChallenge) {
-        NSUnimplemented()
+        fatalError("swift-corelibs-foundation only supports URLSession; for challenges coming from URLSession, please implement the appropriate URLSessionTaskDelegate methods rather than using the sender argument.")
     }
 
     func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {
-        NSUnimplemented()
+        fatalError("swift-corelibs-foundation only supports URLSession; for challenges coming from URLSession, please implement the appropriate URLSessionTaskDelegate methods rather than using the sender argument.")
     }
 
     func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {
-        NSUnimplemented()
+        fatalError("swift-corelibs-foundation only supports URLSession; for challenges coming from URLSession, please implement the appropriate URLSessionTaskDelegate methods rather than using the sender argument.")
     }
 
     func performDefaultHandling(for challenge: URLAuthenticationChallenge) {
-        NSUnimplemented()
+        fatalError("swift-corelibs-foundation only supports URLSession; for challenges coming from URLSession, please implement the appropriate URLSessionTaskDelegate methods rather than using the sender argument.")
     }
 
     func rejectProtectionSpaceAndContinue(with challenge: URLAuthenticationChallenge) {
-        NSUnimplemented()
+        fatalError("swift-corelibs-foundation only supports URLSession; for challenges coming from URLSession, please implement the appropriate URLSessionTaskDelegate methods rather than using the sender argument.")
     }
 }

--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -758,7 +758,7 @@ extension _ProtocolClient : URLProtocolClient {
                     
                     let authenticationChallenge = URLAuthenticationChallenge(protectionSpace: protectionSpace, proposedCredential: proposedCredential,
                                                                              previousFailureCount: task.previousFailureCount, failureResponse: response, error: nil,
-                                                                             sender: urlProtocol as! _HTTPURLProtocol)
+                                                                             sender: URLSessionAuthenticationChallengeSender())
                     task.previousFailureCount += 1
                     self.urlProtocol(urlProtocol, didReceive: authenticationChallenge)
                 }


### PR DESCRIPTION
The class is mostly implemented, but there are several `NSUnimplemented()` that mark methods that, according to URLSession’s contract, are not meant to be invoked. Replace them with more verbose fatalErrors().