### PR TITLE
Split: FoundationXML

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -721,7 +721,7 @@ install(DIRECTORY
           lib/swift/CFXMLInterface
         FILES_MATCHING PATTERN "*.h")
 install(FILES
-          CoreFoundation/Parser.subproj/module.map
+          CoreFoundation/Parsing.subproj/module.map
         DESTINATION
           lib/swift/CFXMLInterface)
 install(PROGRAMS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,11 +116,13 @@ endif()
 # `target_link_libraries(Foundation PRIVATE CoreFoundation)`.
 set(CoreFoundation_LIBRARIES $<TARGET_FILE:CoreFoundation>)
 set(CFURLSessionInterface_LIBRARIES $<TARGET_FILE:CFURLSessionInterface>)
+set(CFXMLInterface_LIBRARIES $<TARGET_FILE:CFXMLInterface>)
 get_target_property(CoreFoundation_LINK_LIBRARIES CoreFoundation LINK_LIBRARIES)
 foreach(library ${CoreFoundation_LINK_LIBRARIES})
   if(NOT library STREQUAL Threads::Threads)
     list(APPEND CoreFoundation_LIBRARIES -l${library})
     list(APPEND CFURLSessionInterface_LIBRARIES -l${library})
+    list(APPEND CFXMLInterface_LIBRARIES -l${library})
   endif()
 endforeach()
 
@@ -264,18 +266,11 @@ add_swift_library(Foundation
                     Foundation/URLComponents.swift
                     Foundation/UserDefaults.swift
                     Foundation/UUID.swift
-                    Foundation/XMLDocument.swift
-                    Foundation/XMLDTD.swift
-                    Foundation/XMLDTDNode.swift
-                    Foundation/XMLElement.swift
-                    Foundation/XMLNode.swift
-                    Foundation/XMLParser.swift
                   TARGET
                     ${CMAKE_C_COMPILER_TARGET}
                   LINK_FLAGS
                     ${CoreFoundation_LIBRARIES}
                     ${ICU_UC_LIBRARY} ${ICU_I18N_LIBRARY}
-                    ${LIBXML2_LIBRARIES}
                     ${libdispatch_ldflags}
                     $<TARGET_FILE:uuid>
                     ${Foundation_RPATH}
@@ -363,6 +358,48 @@ add_swift_library(FoundationNetworking
                     $<$<PLATFORM_ID:Windows>:CoreFoundationResources>
                     Foundation)
 
+add_swift_library(FoundationXML
+                  MODULE_NAME
+                    FoundationXML
+                  MODULE_LINK_NAME
+                    FoundationXML
+                  MODULE_PATH
+                    ${CMAKE_CURRENT_BINARY_DIR}/swift/FoundationXML.swiftmodule
+                  SOURCES
+                  Foundation/XMLDocument.swift
+                  Foundation/XMLDTD.swift
+                  Foundation/XMLDTDNode.swift
+                  Foundation/XMLElement.swift
+                  Foundation/XMLNode.swift
+                  Foundation/XMLParser.swift
+                  TARGET
+                    ${CMAKE_C_COMPILER_TARGET}
+                  LINK_FLAGS
+                    ${MSVCRT_LINK_FLAGS}
+                    -L${CMAKE_CURRENT_BINARY_DIR}
+                    ${libdispatch_ldflags}
+                    -lFoundation
+                    ${Foundation_INTERFACE_LIBRARIES}
+                    ${CFXMLInterface_LIBRARIES}
+                    ${LIBXML2_LIBRARIES}
+                    ${Foundation_RPATH}
+                    ${WORKAROUND_SR9138}
+                    ${WORKAROUND_SR9995}
+                  SWIFT_FLAGS
+                    -DDEPLOYMENT_RUNTIME_SWIFT
+                    -DNS_BUILDING_FOUNDATION_NETWORKING
+                    -Xcc -F${CMAKE_CURRENT_BINARY_DIR}
+                    ${deployment_enable_libdispatch}
+                    -I;${CMAKE_CURRENT_BINARY_DIR}/swift
+                    ${libdispatch_cflags}
+                    $<$<BOOL:ENABLE_TESTING>:-enable-testing>
+                    $<$<NOT:$<CONFIG:Debug>>:-O>
+                  DEPENDS
+                    uuid
+                    CoreFoundation
+                    $<$<PLATFORM_ID:Windows>:CoreFoundationResources>
+                    Foundation)
+
 
 
 if(NOT BUILD_SHARED_LIBS)
@@ -423,6 +460,7 @@ if(ENABLE_TESTING)
                          uuid
                          Foundation
                          FoundationNetworking
+                         FoundationXML
                          CoreFoundation)
 
   add_swift_executable(TestFoundation
@@ -572,6 +610,7 @@ if(ENABLE_TESTING)
                        DEPENDS
                          Foundation
                          FoundationNetworking
+                         FoundationXML
                          CoreFoundation
                          xdgTestHelper)
 
@@ -622,6 +661,8 @@ install(FILES
           ${CMAKE_CURRENT_BINARY_DIR}/swift/Foundation.swiftmodule
           ${CMAKE_CURRENT_BINARY_DIR}/swift/FoundationNetworking.swiftdoc
           ${CMAKE_CURRENT_BINARY_DIR}/swift/FoundationNetworking.swiftmodule
+          ${CMAKE_CURRENT_BINARY_DIR}/swift/FoundationXML.swiftdoc
+          ${CMAKE_CURRENT_BINARY_DIR}/swift/FoundationXML.swiftmodule
         DESTINATION
           lib/${swift_dir}/${swift_os}/${swift_arch})
 
@@ -630,22 +671,27 @@ set(Foundation_OUTPUT_FILE
   ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_${library_kind}_LIBRARY_PREFIX}Foundation${CMAKE_${library_kind}_LIBRARY_SUFFIX})
 set(FoundationNetworking_OUTPUT_FILE
   ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_${library_kind}_LIBRARY_PREFIX}FoundationNetworking${CMAKE_${library_kind}_LIBRARY_SUFFIX})
+set(FoundationXML_OUTPUT_FILE
+  ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_${library_kind}_LIBRARY_PREFIX}FoundationXML${CMAKE_${library_kind}_LIBRARY_SUFFIX})
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows AND BUILD_SHARED_LIBS)
   install(FILES
             ${Foundation_OUTPUT_FILE}
             ${FoundationNetworking_OUTPUT_FILE}
+            ${FoundationXML_OUTPUT_FILE}
           DESTINATION
             bin)
   install(FILES
             ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_IMPORT_LIBRARY_PREFIX}Foundation${CMAKE_IMPORT_LIBRARY_SUFFIX}
             ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_IMPORT_LIBRARY_PREFIX}FoundationNetworking${CMAKE_IMPORT_LIBRARY_SUFFIX}
+            ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_IMPORT_LIBRARY_PREFIX}FoundationXML${CMAKE_IMPORT_LIBRARY_SUFFIX}
           DESTINATION
             lib/${swift_dir}/${swift_os})
 else()
   install(FILES
             ${Foundation_OUTPUT_FILE}
             ${FoundationNetworking_OUTPUT_FILE}
+            ${FoundationXML_OUTPUT_FILE}
           DESTINATION
             lib/${swift_dir}/${swift_os})
 endif()
@@ -669,6 +715,15 @@ install(FILES
           CoreFoundation/URL.subproj/module.map
         DESTINATION
           lib/swift/CFURLSessionInterface)
+install(DIRECTORY
+          ${CMAKE_CURRENT_BINARY_DIR}/CFXMLInterface.framework/Headers/
+        DESTINATION
+          lib/swift/CFXMLInterface
+        FILES_MATCHING PATTERN "*.h")
+install(FILES
+          CoreFoundation/Parser.subproj/module.map
+        DESTINATION
+          lib/swift/CFXMLInterface)
 install(PROGRAMS
           ${CMAKE_CURRENT_BINARY_DIR}/plutil${CMAKE_EXECUTABLE_SUFFIX}
         DESTINATION

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -21,7 +21,6 @@
 #include <CoreFoundation/CFLocaleInternal.h>
 #include <CoreFoundation/CFCalendar.h>
 #include <CoreFoundation/CFPriv.h>
-#include <CoreFoundation/CFXMLInterface.h>
 #include <CoreFoundation/CFRegularExpression.h>
 #include <CoreFoundation/CFLogUtilities.h>
 #include <CoreFoundation/CFDateIntervalFormatter.h>
@@ -187,68 +186,6 @@ struct _NSMutableStringBridge {
     void (*_cfAppendCString)(CFTypeRef str, const char *chars, CFIndex appendLength);
 };
 
-struct _NSXMLParserBridge {
-    _CFXMLInterface _Nullable (*_Nonnull currentParser)(void);
-    _CFXMLInterfaceParserInput _Nullable (*_Nonnull _xmlExternalEntityWithURL)(_CFXMLInterface /*interface*/, const char * /*url*/, const char * /*identifier*/, _CFXMLInterfaceParserContext /*context*/, _CFXMLInterfaceExternalEntityLoader /*originalLoaderFunction*/);
-    
-    _CFXMLInterfaceParserContext _Nonnull (*_Nonnull getContext)(_CFXMLInterface ctx);
-    
-    void (*internalSubset)(_CFXMLInterface ctx, const unsigned char *name, const unsigned char *ExternalID, const unsigned char *SystemID);
-    int (*isStandalone)(_CFXMLInterface ctx);
-    int (*hasInternalSubset)(_CFXMLInterface ctx);
-    int (*hasExternalSubset)(_CFXMLInterface ctx);
-    _CFXMLInterfaceEntity _Nullable (*_Nonnull getEntity)(_CFXMLInterface ctx, const unsigned char *name);
-    void (*notationDecl)(_CFXMLInterface ctx,
-                         const unsigned char *name,
-                         const unsigned char *publicId,
-                         const unsigned char *systemId);
-    void (*attributeDecl)(_CFXMLInterface ctx,
-                          const unsigned char *elem,
-                          const unsigned char *fullname,
-                          int type,
-                          int def,
-                          const unsigned char *defaultValue,
-                          _CFXMLInterfaceEnumeration tree);
-    void (*elementDecl)(_CFXMLInterface ctx,
-                        const unsigned char *name,
-                        int type,
-                        _CFXMLInterfaceElementContent content);
-    void (*unparsedEntityDecl)(_CFXMLInterface ctx,
-                               const unsigned char *name,
-                               const unsigned char *publicId,
-                               const unsigned char *systemId,
-                               const unsigned char *notationName);
-    void (*startDocument)(_CFXMLInterface ctx);
-    void (*endDocument)(_CFXMLInterface ctx);
-    void (*startElementNs)(_CFXMLInterface ctx,
-                           const unsigned char *localname,
-                           const unsigned char *_Nullable prefix,
-                           const unsigned char *_Nullable URI,
-                           int nb_namespaces,
-                           const unsigned char *_Nullable *_Nonnull namespaces,
-                           int nb_attributes,
-                           int nb_defaulted,
-                           const unsigned char *_Nullable *_Nonnull attributes);
-    void (*endElementNs)(_CFXMLInterface ctx,
-                         const unsigned char *localname,
-                         const unsigned char *_Nullable prefix,
-                         const unsigned char *_Nullable URI);
-    void (*characters)(_CFXMLInterface ctx,
-                       const unsigned char *ch,
-                       int len);
-    void (*processingInstruction)(_CFXMLInterface ctx,
-                                  const unsigned char *target,
-                                  const unsigned char *data);
-    void (*cdataBlock)(_CFXMLInterface ctx,
-                       const unsigned char *value,
-                       int len);
-    void (*comment)(_CFXMLInterface ctx, const unsigned char *value);
-    void (*externalSubset)(_CFXMLInterface ctx,
-                           const unsigned char *name,
-                           const unsigned char *ExternalID,
-                           const unsigned char *SystemID);
-};
-
 struct _NSRunLoop {
     _Nonnull CFTypeRef (*_Nonnull _new)(CFRunLoopRef rl);
 };
@@ -327,7 +264,6 @@ struct _CFSwiftBridge {
     struct _NSMutableSetBridge NSMutableSet;
     struct _NSStringBridge NSString;
     struct _NSMutableStringBridge NSMutableString;
-    struct _NSXMLParserBridge NSXMLParser;
     struct _NSRunLoop NSRunLoop;
     struct _NSCharacterSetBridge NSCharacterSet;
     struct _NSMutableCharacterSetBridge NSMutableCharacterSet;

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -87,7 +87,6 @@ add_framework(CoreFoundation
                 # Parsing
                 Parsing.subproj/CFPropertyList_Private.h
                 Parsing.subproj/CFXMLInputStream.h
-                Parsing.subproj/CFXMLInterface.h
                 # PlugIn
                 PlugIn.subproj/CFBundlePriv.h
                 PlugIn.subproj/CFBundle_BinaryTypes.h
@@ -136,7 +135,6 @@ add_framework(CoreFoundation
                 Locale.subproj/CFDateComponents.h
                 Locale.subproj/CFDateInterval.h
                 Locale.subproj/CFLocaleInternal.h
-                Parsing.subproj/CFXMLInterface.h
                 PlugIn.subproj/CFBundlePriv.h
                 Stream.subproj/CFStreamPriv.h
                 String.subproj/CFCharacterSetPriv.h
@@ -251,7 +249,6 @@ add_framework(CoreFoundation
                 Parsing.subproj/CFOldStylePList.c
                 Parsing.subproj/CFPropertyList.c
                 Parsing.subproj/CFXMLInputStream.c
-                Parsing.subproj/CFXMLInterface.c
                 Parsing.subproj/CFXMLNode.c
                 Parsing.subproj/CFXMLParser.c
                 Parsing.subproj/CFXMLTree.c
@@ -319,7 +316,7 @@ add_framework(CoreFoundation
 add_framework(CFURLSessionInterface
                 ${FRAMEWORK_LIBRARY_TYPE}
               FRAMEWORK_DIRECTORY
-                CoreFoundation_FRAMEWORK_DIRECTORY
+                CFURLSessionInterface_FRAMEWORK_DIRECTORY
               MODULE_MAP
                 URL.subproj/module.modulemap
               PRIVATE_HEADERS
@@ -329,6 +326,20 @@ add_framework(CFURLSessionInterface
               SOURCES
                 URL.subproj/CFURLSessionInterface.c)
 add_dependencies(CFURLSessionInterface CoreFoundation)
+
+add_framework(CFXMLInterface
+                ${FRAMEWORK_LIBRARY_TYPE}
+              FRAMEWORK_DIRECTORY
+                CFXMLInterface_FRAMEWORK_DIRECTORY
+              MODULE_MAP
+                Parsing.subproj/module.modulemap
+              PRIVATE_HEADERS
+                Parsing.subproj/CFXMLInterface.h
+              PUBLIC_HEADERS
+                Parsing.subproj/CFXMLInterface.h
+              SOURCES
+                Parsing.subproj/CFXMLInterface.c)
+add_dependencies(CFXMLInterface CoreFoundation)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   add_library(CoreFoundationResources OBJECT
@@ -354,11 +365,17 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android)
   target_compile_definitions(CFURLSessionInterface
                              PRIVATE
                                -D_GNU_SOURCE)
+  target_compile_definitions(CFXMLInterface
+                             PRIVATE
+                               -D_GNU_SOURCE)
   if(HAVE_SCHED_GETAFFINITY)
     target_compile_definitions(CoreFoundation
                                PRIVATE
                                  -DHAVE_SCHED_GETAFFINITY)
     target_compile_definitions(CFURLSessionInterface
+                               PRIVATE
+                                 -DHAVE_SCHED_GETAFFINITY)
+    target_compile_definitions(CFXMLInterface
                                PRIVATE
                                  -DHAVE_SCHED_GETAFFINITY)
   endif()
@@ -371,11 +388,17 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
   target_compile_definitions(CFURLSessionInterface
                              PRIVATE
                                -D_DLL)
+  target_compile_definitions(CFXMLInterface
+                             PRIVATE
+                               -D_DLL)
   if(BUILD_SHARED_LIBS)
     target_compile_definitions(CoreFoundation
                                PRIVATE
                                  -D_WINDLL)
     target_compile_definitions(CFURLSessionInterface
+                               PRIVATE
+                                 -D_WINDLL)
+    target_compile_definitions(CFXMLInterface
                                PRIVATE
                                  -D_WINDLL)
   endif()
@@ -391,6 +414,10 @@ target_compile_definitions(CFURLSessionInterface
                            PRIVATE
                              -DU_SHOW_DRAFT_API
                              -DCF_BUILDING_CF)
+target_compile_definitions(CFXMLInterface
+                           PRIVATE
+                             -DU_SHOW_DRAFT_API
+                             -DCF_BUILDING_CF)
 if(CF_DEPLOYMENT_SWIFT)
   target_compile_definitions(CoreFoundation
                              PRIVATE
@@ -398,11 +425,17 @@ if(CF_DEPLOYMENT_SWIFT)
   target_compile_definitions(CFURLSessionInterface
                              PRIVATE
                                -DDEPLOYMENT_RUNTIME_SWIFT)
+  target_compile_definitions(CFXMLInterface
+                             PRIVATE
+                               -DDEPLOYMENT_RUNTIME_SWIFT)
 else()
   target_compile_definitions(CoreFoundation
                              PRIVATE
                                -DDEPLOYMENT_RUNTIME_C)
   target_compile_definitions(CFURLSessionInterface
+                             PRIVATE
+                               -DDEPLOYMENT_RUNTIME_C)
+  target_compile_definitions(CFXMLInterface
                              PRIVATE
                                -DDEPLOYMENT_RUNTIME_C)
 endif()
@@ -418,7 +451,7 @@ target_include_directories(CoreFoundation
                              ${PROJECT_SOURCE_DIR})
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   find_package(LibXml2 REQUIRED)
-  target_include_directories(CoreFoundation
+  target_include_directories(CFXMLInterface
                              PRIVATE
                                ${LIBXML2_INCLUDE_DIR})
   find_package(CURL REQUIRED)
@@ -438,11 +471,18 @@ target_include_directories(CFURLSessionInterface
                            PRIVATE
                              ${CF_PATH_TO_LIBDISPATCH_SOURCE}
                              ${CF_PATH_TO_LIBDISPATCH_BUILD}/tests)
+target_include_directories(CFXMLInterface
+                           PRIVATE
+                             ${CF_PATH_TO_LIBDISPATCH_SOURCE}
+                             ${CF_PATH_TO_LIBDISPATCH_BUILD}/tests)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_include_directories(CoreFoundation
                              SYSTEM PRIVATE
                                ${CF_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
   target_include_directories(CFURLSessionInterface
+                             SYSTEM PRIVATE
+                               ${CF_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
+  target_include_directories(CFXMLInterface
                              SYSTEM PRIVATE
                                ${CF_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
 endif()
@@ -454,11 +494,17 @@ if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
   target_compile_options(CFURLSessionInterface
                          PRIVATE
                            $<$<COMPILE_LANGUAGE:C>:/FI${PROJECT_SOURCE_DIR}/Base.subproj/CoreFoundation_Prefix.h>)
+  target_compile_options(CFXMLInterface
+                         PRIVATE
+                           $<$<COMPILE_LANGUAGE:C>:/FI${PROJECT_SOURCE_DIR}/Base.subproj/CoreFoundation_Prefix.h>)
 else()
   target_compile_options(CoreFoundation
                          PRIVATE
                            $<$<COMPILE_LANGUAGE:C>:-include;${PROJECT_SOURCE_DIR}/Base.subproj/CoreFoundation_Prefix.h>)
   target_compile_options(CFURLSessionInterface
+                         PRIVATE
+                           $<$<COMPILE_LANGUAGE:C>:-include;${PROJECT_SOURCE_DIR}/Base.subproj/CoreFoundation_Prefix.h>)
+  target_compile_options(CFXMLInterface
                          PRIVATE
                            $<$<COMPILE_LANGUAGE:C>:-include;${PROJECT_SOURCE_DIR}/Base.subproj/CoreFoundation_Prefix.h>)
 endif()
@@ -469,6 +515,10 @@ if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
                            -fblocks
                            /EHsc)
   target_compile_options(CFURLSessionInterface
+                         PRIVATE
+                           -fblocks
+                           /EHsc)
+  target_compile_options(CFXMLInterface
                          PRIVATE
                            -fblocks
                            /EHsc)
@@ -481,6 +531,13 @@ else()
                            -fexceptions
                            -fno-common)
   target_compile_options(CFURLSessionInterface
+                         PRIVATE
+                           -fblocks
+                           -fconstant-cfstrings
+                           -fdollars-in-identifiers
+                           -fexceptions
+                           -fno-common)
+  target_compile_options(CFXMLInterface
                          PRIVATE
                            -fblocks
                            -fconstant-cfstrings
@@ -496,11 +553,17 @@ if(CF_DEPLOYMENT_SWIFT)
     target_compile_options(CFURLSessionInterface
                            PRIVATE
                              /clang:-fcf-runtime-abi=swift)
+    target_compile_options(CFXMLInterface
+                           PRIVATE
+                             /clang:-fcf-runtime-abi=swift)
   else()
     target_compile_options(CoreFoundation
                            PRIVATE
                              -fcf-runtime-abi=swift)
     target_compile_options(CFURLSessionInterface
+                           PRIVATE
+                             -fcf-runtime-abi=swift)
+    target_compile_options(CFXMLInterface
                            PRIVATE
                              -fcf-runtime-abi=swift)
   endif()
@@ -526,9 +589,19 @@ target_compile_options(CFURLSessionInterface
                          -Wno-int-conversion
                          -Wno-unused-function
                          -Wno-microsoft-enum-forward-reference)
+target_compile_options(CFXMLInterface
+                       PRIVATE
+                         -Wno-shorten-64-to-32
+                         -Wno-deprecated-declarations
+                         -Wno-unreachable-code
+                         -Wno-conditional-uninitialized
+                         -Wno-unused-variable
+                         -Wno-int-conversion
+                         -Wno-unused-function
+                         -Wno-microsoft-enum-forward-reference)
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  target_link_libraries(CoreFoundation
+  target_link_libraries(CFXMLInterface
                         PRIVATE
                           ${LIBXML2_LIBRARIES})
   target_link_libraries(CFURLSessionInterface
@@ -557,12 +630,21 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
                           Secur32
                           User32
                           mincore)
+  target_link_libraries(CFXMLInterface
+                        PRIVATE
+                          AdvAPI32
+                          Secur32
+                          User32
+                          mincore)
 endif()
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows AND NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(CoreFoundation
                         PRIVATE
                           m)
   target_link_libraries(CFURLSessionInterface
+                        PRIVATE
+                          m)
+  target_link_libraries(CFXMLInterface
                         PRIVATE
                           m)
 endif()
@@ -572,11 +654,17 @@ target_link_libraries(CoreFoundation
 target_link_libraries(CFURLSessionInterface
                       PRIVATE
                         dispatch)
+target_link_libraries(CFXMLInterface
+                      PRIVATE
+                        dispatch)
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(CoreFoundation
                         PRIVATE
                           icucore)
   target_link_libraries(CFURLSessionInterface
+                        PRIVATE
+                          icucore)
+  target_link_libraries(CFXMLInterface
                         PRIVATE
                           icucore)
   set_target_properties(CoreFoundation
@@ -586,7 +674,8 @@ endif()
 
 install(TARGETS
           CoreFoundation
-		  CFURLSessionInterface
+          CFURLSessionInterface
+          CFXMLInterface
         DESTINATION
           "${CMAKE_INSTALL_FULL_LIBDIR}")
 

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -140,7 +140,7 @@ void _CFSetupXMLInterface(void) {
 #endif // DEPLOYMENT_RUNTIME_SWIFT
 }
 
-void _CFSetupXMLBridgeIfNeededUsingBlock(dispatch_block_t block) {
+void _CFSetupXMLBridgeIfNeededUsingBlock(void (^block)(void)) {
 #if DEPLOYMENT_RUNTIME_SWIFT
     static dispatch_once_t bridgeInitGuard;
     dispatch_once(&bridgeInitGuard, block);

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.h
@@ -15,6 +15,7 @@
 #define __COREFOUNDATION_CFXMLINTERFACE__ 1
 
 #include <CoreFoundation/CoreFoundation.h>
+#include <stdint.h>
 #include <sys/types.h>
 
 CF_IMPLICIT_BRIDGING_ENABLED

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.h
@@ -15,6 +15,7 @@
 #define __COREFOUNDATION_CFXMLINTERFACE__ 1
 
 #include <CoreFoundation/CoreFoundation.h>
+#include <sys/types.h>
 
 CF_IMPLICIT_BRIDGING_ENABLED
 CF_ASSUME_NONNULL_BEGIN

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.h
@@ -14,12 +14,7 @@
 #if !defined(__COREFOUNDATION_CFXMLINTERFACE__)
 #define __COREFOUNDATION_CFXMLINTERFACE__ 1
 
-#include <CoreFoundation/CFBase.h>
-#include <CoreFoundation/CFArray.h>
-#include <CoreFoundation/CFData.h>
-#include <CoreFoundation/CFDictionary.h>
-#include <CoreFoundation/CFTree.h>
-#include <CoreFoundation/CFURL.h>
+#include <CoreFoundation/CoreFoundation.h>
 
 CF_IMPLICIT_BRIDGING_ENABLED
 CF_ASSUME_NONNULL_BEGIN
@@ -102,6 +97,8 @@ typedef _CFXMLInterfaceParserInput _Nonnull (*_CFXMLInterfaceExternalEntityLoade
 typedef void (*_CFXMLInterfaceStructuredErrorFunc)(_CFXMLInterface ctx, _CFXMLInterfaceError error);
 
 void _CFSetupXMLInterface(void);
+void _CFSetupXMLBridgeIfNeededUsingBlock(dispatch_block_t block);
+
 _CFXMLInterfaceParserInput _CFXMLInterfaceNoNetExternalEntityLoader(const char *URL, const char *ID, _CFXMLInterfaceParserContext ctxt);
 _CFXMLInterfaceSAXHandler _CFXMLInterfaceCreateSAXHandler(void);
 void _CFXMLInterfaceDestroySAXHandler(_CFXMLInterfaceSAXHandler handler);
@@ -252,6 +249,72 @@ void _CFXMLFreeNode(_CFXMLNodePtr node);
 void _CFXMLFreeDocument(_CFXMLDocPtr doc);
 void _CFXMLFreeDTD(_CFXMLDTDPtr dtd);
 void _CFXMLFreeProperty(_CFXMLNodePtr prop);
+
+// Bridging
+
+struct _NSXMLParserBridge {
+    _CFXMLInterface _Nullable (*_Nonnull currentParser)(void);
+    _CFXMLInterfaceParserInput _Nullable (*_Nonnull _xmlExternalEntityWithURL)(_CFXMLInterface /*interface*/, const char * /*url*/, const char * /*identifier*/, _CFXMLInterfaceParserContext /*context*/, _CFXMLInterfaceExternalEntityLoader /*originalLoaderFunction*/);
+    
+    _CFXMLInterfaceParserContext _Nonnull (*_Nonnull getContext)(_CFXMLInterface ctx);
+    
+    void (*internalSubset)(_CFXMLInterface ctx, const unsigned char *name, const unsigned char *ExternalID, const unsigned char *SystemID);
+    int (*isStandalone)(_CFXMLInterface ctx);
+    int (*hasInternalSubset)(_CFXMLInterface ctx);
+    int (*hasExternalSubset)(_CFXMLInterface ctx);
+    _CFXMLInterfaceEntity _Nullable (*_Nonnull getEntity)(_CFXMLInterface ctx, const unsigned char *name);
+    void (*notationDecl)(_CFXMLInterface ctx,
+                         const unsigned char *name,
+                         const unsigned char *publicId,
+                         const unsigned char *systemId);
+    void (*attributeDecl)(_CFXMLInterface ctx,
+                          const unsigned char *elem,
+                          const unsigned char *fullname,
+                          int type,
+                          int def,
+                          const unsigned char *defaultValue,
+                          _CFXMLInterfaceEnumeration tree);
+    void (*elementDecl)(_CFXMLInterface ctx,
+                        const unsigned char *name,
+                        int type,
+                        _CFXMLInterfaceElementContent content);
+    void (*unparsedEntityDecl)(_CFXMLInterface ctx,
+                               const unsigned char *name,
+                               const unsigned char *publicId,
+                               const unsigned char *systemId,
+                               const unsigned char *notationName);
+    void (*startDocument)(_CFXMLInterface ctx);
+    void (*endDocument)(_CFXMLInterface ctx);
+    void (*startElementNs)(_CFXMLInterface ctx,
+                           const unsigned char *localname,
+                           const unsigned char *_Nullable prefix,
+                           const unsigned char *_Nullable URI,
+                           int nb_namespaces,
+                           const unsigned char *_Nullable *_Nonnull namespaces,
+                           int nb_attributes,
+                           int nb_defaulted,
+                           const unsigned char *_Nullable *_Nonnull attributes);
+    void (*endElementNs)(_CFXMLInterface ctx,
+                         const unsigned char *localname,
+                         const unsigned char *_Nullable prefix,
+                         const unsigned char *_Nullable URI);
+    void (*characters)(_CFXMLInterface ctx,
+                       const unsigned char *ch,
+                       int len);
+    void (*processingInstruction)(_CFXMLInterface ctx,
+                                  const unsigned char *target,
+                                  const unsigned char *data);
+    void (*cdataBlock)(_CFXMLInterface ctx,
+                       const unsigned char *value,
+                       int len);
+    void (*comment)(_CFXMLInterface ctx, const unsigned char *value);
+    void (*externalSubset)(_CFXMLInterface ctx,
+                           const unsigned char *name,
+                           const unsigned char *ExternalID,
+                           const unsigned char *SystemID);
+};
+
+CF_EXPORT struct _NSXMLParserBridge __CFSwiftXMLParserBridge;
 
 CF_EXTERN_C_END
 CF_ASSUME_NONNULL_END

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.h
@@ -97,7 +97,7 @@ typedef _CFXMLInterfaceParserInput _Nonnull (*_CFXMLInterfaceExternalEntityLoade
 typedef void (*_CFXMLInterfaceStructuredErrorFunc)(_CFXMLInterface ctx, _CFXMLInterfaceError error);
 
 void _CFSetupXMLInterface(void);
-void _CFSetupXMLBridgeIfNeededUsingBlock(dispatch_block_t block);
+void _CFSetupXMLBridgeIfNeededUsingBlock(void (^block)(void));
 
 _CFXMLInterfaceParserInput _CFXMLInterfaceNoNetExternalEntityLoader(const char *URL, const char *ID, _CFXMLInterfaceParserContext ctxt);
 _CFXMLInterfaceSAXHandler _CFXMLInterfaceCreateSAXHandler(void);

--- a/CoreFoundation/Parsing.subproj/module.map
+++ b/CoreFoundation/Parsing.subproj/module.map
@@ -1,0 +1,3 @@
+module CFXMLInterface [extern_c] [system] {
+    umbrella header "CFXMLInterface.h"
+}

--- a/CoreFoundation/Parsing.subproj/module.modulemap
+++ b/CoreFoundation/Parsing.subproj/module.modulemap
@@ -1,0 +1,8 @@
+framework module CFXMLInterface [extern_c] [system] {
+    umbrella header "CFXMLInterface.h"
+
+    export *
+    module * {
+      export *
+    }
+}

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -524,13 +524,6 @@
 			remoteGlobalIDString = 15500FA722EA24D10088F082;
 			remoteInfo = CFXMLInterface;
 		};
-		1550111522EA42780088F082 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 15500FA722EA24D10088F082;
-			remoteInfo = CFXMLInterface;
-		};
 		1550111922EA43E00088F082 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
@@ -560,6 +553,13 @@
 			remoteInfo = CoreFoundation;
 		};
 		15B80445228F39B200B30FF6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5B5D885C1BBC938800234F36;
+			remoteInfo = SwiftFoundation;
+		};
+		15F14D3922EB9F80001598B5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
 			proxyType = 1;
@@ -2402,8 +2402,8 @@
 			buildRules = (
 			);
 			dependencies = (
+				15F14D3A22EB9F80001598B5 /* PBXTargetDependency */,
 				1550110C22EA26780088F082 /* PBXTargetDependency */,
-				1550111622EA42780088F082 /* PBXTargetDependency */,
 			);
 			name = SwiftFoundationXML;
 			productName = CoreFoundation;
@@ -3125,11 +3125,6 @@
 			target = 15500FA722EA24D10088F082 /* CFXMLInterface */;
 			targetProxy = 1550110B22EA26780088F082 /* PBXContainerItemProxy */;
 		};
-		1550111622EA42780088F082 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 15500FA722EA24D10088F082 /* CFXMLInterface */;
-			targetProxy = 1550111522EA42780088F082 /* PBXContainerItemProxy */;
-		};
 		1550111A22EA43E00088F082 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 1550106E22EA266B0088F082 /* SwiftFoundationXML */;
@@ -3154,6 +3149,11 @@
 			isa = PBXTargetDependency;
 			target = 5B5D885C1BBC938800234F36 /* SwiftFoundation */;
 			targetProxy = 15B80445228F39B200B30FF6 /* PBXContainerItemProxy */;
+		};
+		15F14D3A22EB9F80001598B5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5B5D885C1BBC938800234F36 /* SwiftFoundation */;
+			targetProxy = 15F14D3922EB9F80001598B5 /* PBXContainerItemProxy */;
 		};
 		15FF00D022934C39004AD205 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -17,6 +17,23 @@
 		153E951120111DC500F250BE /* CFKnownLocations.h in Headers */ = {isa = PBXBuildFile; fileRef = 153E950F20111DC500F250BE /* CFKnownLocations.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		153E951220111DC500F250BE /* CFKnownLocations.c in Sources */ = {isa = PBXBuildFile; fileRef = 153E951020111DC500F250BE /* CFKnownLocations.c */; };
 		15496CF1212CAEBA00450F5A /* CFAttributedStringPriv.h in Headers */ = {isa = PBXBuildFile; fileRef = 15496CF0212CAEBA00450F5A /* CFAttributedStringPriv.h */; };
+		15500FB722EA24D10088F082 /* CFXMLInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B40F9EC1C124F45000E72E3 /* CFXMLInterface.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1550102C22EA24D10088F082 /* CFXMLInterface.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B40F9EB1C124F45000E72E3 /* CFXMLInterface.c */; };
+		1550106D22EA25280088F082 /* module.map in Headers */ = {isa = PBXBuildFile; fileRef = 1550106B22EA25140088F082 /* module.map */; settings = {ATTRIBUTES = (Public, ); }; };
+		1550107322EA266B0088F082 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B40F9F31C12524C000E72E3 /* libxml2.dylib */; };
+		1550110D22EA268E0088F082 /* SwiftFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B5D885D1BBC938800234F36 /* SwiftFoundation.framework */; };
+		1550110E22EA26CA0088F082 /* XMLDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B891BD15DFF00C49C64 /* XMLDocument.swift */; };
+		1550110F22EA26CA0088F082 /* XMLDTD.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B8A1BD15DFF00C49C64 /* XMLDTD.swift */; };
+		1550111022EA26CA0088F082 /* XMLDTDNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B8B1BD15DFF00C49C64 /* XMLDTDNode.swift */; };
+		1550111122EA26CA0088F082 /* XMLElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B8C1BD15DFF00C49C64 /* XMLElement.swift */; };
+		1550111222EA26CA0088F082 /* XMLNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B8D1BD15DFF00C49C64 /* XMLNode.swift */; };
+		1550111322EA26CA0088F082 /* XMLParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B8F1BD15DFF00C49C64 /* XMLParser.swift */; };
+		1550111422EA42780088F082 /* libCFXMLInterface.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1550106A22EA24D10088F082 /* libCFXMLInterface.a */; };
+		1550111722EA43E00088F082 /* SwiftFoundationXML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1550110922EA266B0088F082 /* SwiftFoundationXML.framework */; };
+		1550111822EA43E00088F082 /* SwiftFoundationXML.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1550110922EA266B0088F082 /* SwiftFoundationXML.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1550111B22EA43E20088F082 /* SwiftFoundationNetworking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15B8043A228F376000B30FF6 /* SwiftFoundationNetworking.framework */; };
+		1550111C22EA43E20088F082 /* SwiftFoundationNetworking.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 15B8043A228F376000B30FF6 /* SwiftFoundationNetworking.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1550111D22EA473B0088F082 /* SwiftFoundationXML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1550110922EA266B0088F082 /* SwiftFoundationXML.framework */; };
 		155B77AC22E63D2D00D901DE /* TestURLCredentialStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155B77AB22E63D2D00D901DE /* TestURLCredentialStorage.swift */; };
 		155D3BBC22401D1100B0D38E /* FixtureValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155D3BBB22401D1100B0D38E /* FixtureValues.swift */; };
 		1569BFA12187D04C009518FA /* CFCalendar_Enumerate.c in Sources */ = {isa = PBXBuildFile; fileRef = 1569BF9F2187D003009518FA /* CFCalendar_Enumerate.c */; };
@@ -70,7 +87,6 @@
 		15B80441228F38E400B30FF6 /* MultiHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9974B901EDF4A22007F15B8 /* MultiHandle.swift */; };
 		15B80442228F38E400B30FF6 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD9C81D6D16580080E83C /* Configuration.swift */; };
 		15B80443228F38E400B30FF6 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105D30E1FEBC5FC0022865A /* Message.swift */; };
-		15B80444228F396600B30FF6 /* SwiftFoundationNetworking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15B8043A228F376000B30FF6 /* SwiftFoundationNetworking.framework */; };
 		15F10CDC218909BF00D88114 /* TestNSCalendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F10CDB218909BF00D88114 /* TestNSCalendar.swift */; };
 		15FF004B229348F2004AD205 /* CFURLSessionInterface.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD9C11D6D160F0080E83C /* CFURLSessionInterface.c */; };
 		15FF00CB22934A3C004AD205 /* CFURLSessionInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B1FD9C21D6D160F0080E83C /* CFURLSessionInterface.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -495,18 +511,40 @@
 		EADE0BB91BD15E0000C49C64 /* NSTextCheckingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B7B1BD15DFF00C49C64 /* NSTextCheckingResult.swift */; };
 		EADE0BBF1BD15E0000C49C64 /* NSURLError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B811BD15DFF00C49C64 /* NSURLError.swift */; };
 		EADE0BC51BD15E0000C49C64 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B871BD15DFF00C49C64 /* UserDefaults.swift */; };
-		EADE0BC71BD15E0000C49C64 /* XMLDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B891BD15DFF00C49C64 /* XMLDocument.swift */; };
-		EADE0BC81BD15E0000C49C64 /* XMLDTD.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B8A1BD15DFF00C49C64 /* XMLDTD.swift */; };
-		EADE0BC91BD15E0000C49C64 /* XMLDTDNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B8B1BD15DFF00C49C64 /* XMLDTDNode.swift */; };
-		EADE0BCA1BD15E0000C49C64 /* XMLElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B8C1BD15DFF00C49C64 /* XMLElement.swift */; };
-		EADE0BCB1BD15E0000C49C64 /* XMLNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B8D1BD15DFF00C49C64 /* XMLNode.swift */; };
-		EADE0BCD1BD15E0000C49C64 /* XMLParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADE0B8F1BD15DFF00C49C64 /* XMLParser.swift */; };
 		F03A43181D4877DD00A7791E /* CFAsmMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = F03A43161D48778200A7791E /* CFAsmMacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F085A1302283C5B700F909F9 /* CFLocking.h in Headers */ = {isa = PBXBuildFile; fileRef = F085A12E2283C50A00F909F9 /* CFLocking.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F9E0BB371CA70B8000F7FF3C /* TestURLCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E0BB361CA70B8000F7FF3C /* TestURLCredential.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		1550110B22EA26780088F082 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 15500FA722EA24D10088F082;
+			remoteInfo = CFXMLInterface;
+		};
+		1550111522EA42780088F082 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 15500FA722EA24D10088F082;
+			remoteInfo = CFXMLInterface;
+		};
+		1550111922EA43E00088F082 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1550106E22EA266B0088F082;
+			remoteInfo = SwiftFoundationXML;
+		};
+		1550111F22EA473B0088F082 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1550106E22EA266B0088F082;
+			remoteInfo = SwiftFoundationXML;
+		};
 		159870BF228F741000ADE509 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 5B5D88541BBC938800234F36 /* Project object */;
@@ -587,6 +625,26 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		1550107A22EA266B0088F082 /* Framework Headers */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = Headers;
+			dstSubfolderSpec = 1;
+			files = (
+			);
+			name = "Framework Headers";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1550112122EA473B0088F082 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		15B80390228F376000B30FF6 /* Framework Headers */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -614,6 +672,8 @@
 			dstSubfolderSpec = 10;
 			files = (
 				5BDC406E1BD6D8C400ED97BB /* SwiftFoundation.framework in CopyFiles */,
+				1550111822EA43E00088F082 /* SwiftFoundationXML.framework in CopyFiles */,
+				1550111C22EA43E20088F082 /* SwiftFoundationNetworking.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -639,6 +699,11 @@
 		153E950F20111DC500F250BE /* CFKnownLocations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CFKnownLocations.h; sourceTree = "<group>"; };
 		153E951020111DC500F250BE /* CFKnownLocations.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = CFKnownLocations.c; sourceTree = "<group>"; };
 		15496CF0212CAEBA00450F5A /* CFAttributedStringPriv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFAttributedStringPriv.h; sourceTree = "<group>"; };
+		1550106A22EA24D10088F082 /* libCFXMLInterface.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCFXMLInterface.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		1550106B22EA25140088F082 /* module.map */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; name = module.map; path = CoreFoundation/Parsing.subproj/module.map; sourceTree = SOURCE_ROOT; };
+		1550106C22EA25140088F082 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; name = module.modulemap; path = CoreFoundation/Parsing.subproj/module.modulemap; sourceTree = SOURCE_ROOT; };
+		1550110922EA266B0088F082 /* SwiftFoundationXML.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftFoundationXML.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1550110A22EA266C0088F082 /* SwiftFoundation copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "SwiftFoundation copy-Info.plist"; path = "/Volumes/AppleDeveloper/Sources/Swift/swift-corelibs-foundation/SwiftFoundation copy-Info.plist"; sourceTree = "<absolute>"; };
 		155B77AB22E63D2D00D901DE /* TestURLCredentialStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestURLCredentialStorage.swift; sourceTree = "<group>"; };
 		155D3BBB22401D1100B0D38E /* FixtureValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixtureValues.swift; sourceTree = "<group>"; };
 		1569BF9D2187CFFF009518FA /* CFCalendar_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFCalendar_Internal.h; sourceTree = "<group>"; };
@@ -1142,6 +1207,23 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1550106622EA24D10088F082 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1550107122EA266B0088F082 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1550110D22EA268E0088F082 /* SwiftFoundation.framework in Frameworks */,
+				1550107322EA266B0088F082 /* libxml2.dylib in Frameworks */,
+				1550111422EA42780088F082 /* libCFXMLInterface.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		15B80387228F376000B30FF6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1181,8 +1263,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				15B80444228F396600B30FF6 /* SwiftFoundationNetworking.framework in Frameworks */,
+				1550111722EA43E00088F082 /* SwiftFoundationXML.framework in Frameworks */,
 				5BDC406C1BD6D89300ED97BB /* SwiftFoundation.framework in Frameworks */,
+				1550111B22EA43E20088F082 /* SwiftFoundationNetworking.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1191,6 +1274,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				159870BE228F73F800ADE509 /* SwiftFoundationNetworking.framework in Frameworks */,
+				1550111D22EA473B0088F082 /* SwiftFoundationXML.framework in Frameworks */,
 				9F0DD3571ECD783500F68030 /* SwiftFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1251,6 +1335,7 @@
 				EA66F6371BF1619600136161 /* TestFoundation */,
 				5B5D89AB1BBDCD0B00234F36 /* Frameworks */,
 				5B5D885E1BBC938800234F36 /* Products */,
+				1550110A22EA266C0088F082 /* SwiftFoundation copy-Info.plist */,
 			);
 			indentWidth = 4;
 			sourceTree = "<group>";
@@ -1267,6 +1352,8 @@
 				9F0DD33F1ECD734200F68030 /* xdgTestHelper.app */,
 				15B8043A228F376000B30FF6 /* SwiftFoundationNetworking.framework */,
 				15FF00CA229348F2004AD205 /* libCFURLSessionInterface.a */,
+				1550106A22EA24D10088F082 /* libCFXMLInterface.a */,
+				1550110922EA266B0088F082 /* SwiftFoundationXML.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1510,6 +1597,8 @@
 		5B5D88F91BBC9B8100234F36 /* Parsing */ = {
 			isa = PBXGroup;
 			children = (
+				1550106B22EA25140088F082 /* module.map */,
+				1550106C22EA25140088F082 /* module.modulemap */,
 				5B5D89891BBDB1EF00234F36 /* CFBinaryPList.c */,
 				5B5D898F1BBDBFB100234F36 /* CFOldStylePList.c */,
 				5B5D88FB1BBC9B9500234F36 /* CFPropertyList.c */,
@@ -2136,6 +2225,22 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		15500FA822EA24D10088F082 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1550106D22EA25280088F082 /* module.map in Headers */,
+				15500FB722EA24D10088F082 /* CFXMLInterface.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1550107722EA266B0088F082 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		15B8038D228F376000B30FF6 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -2267,6 +2372,44 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		15500FA722EA24D10088F082 /* CFXMLInterface */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1550106722EA24D10088F082 /* Build configuration list for PBXNativeTarget "CFXMLInterface" */;
+			buildPhases = (
+				15500FA822EA24D10088F082 /* Headers */,
+				1550100922EA24D10088F082 /* Sources */,
+				1550106622EA24D10088F082 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CFXMLInterface;
+			productName = CoreFoundation;
+			productReference = 1550106A22EA24D10088F082 /* libCFXMLInterface.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		1550106E22EA266B0088F082 /* SwiftFoundationXML */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1550110622EA266B0088F082 /* Build configuration list for PBXNativeTarget "SwiftFoundationXML" */;
+			buildPhases = (
+				1550107122EA266B0088F082 /* Frameworks */,
+				1550107722EA266B0088F082 /* Headers */,
+				1550107922EA266B0088F082 /* Resources */,
+				1550107A22EA266B0088F082 /* Framework Headers */,
+				1550107B22EA266B0088F082 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1550110C22EA26780088F082 /* PBXTargetDependency */,
+				1550111622EA42780088F082 /* PBXTargetDependency */,
+			);
+			name = SwiftFoundationXML;
+			productName = CoreFoundation;
+			productReference = 1550110922EA266B0088F082 /* SwiftFoundationXML.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		15B80384228F376000B30FF6 /* SwiftFoundationNetworking */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 15B80437228F376000B30FF6 /* Build configuration list for PBXNativeTarget "SwiftFoundationNetworking" */;
@@ -2360,6 +2503,7 @@
 				B98F1740229AF5AF00F2B002 /* PBXTargetDependency */,
 				B90FD23020C2FF420087EF44 /* PBXTargetDependency */,
 				AE2FC5951CFEFC70008F7981 /* PBXTargetDependency */,
+				1550111A22EA43E00088F082 /* PBXTargetDependency */,
 			);
 			name = TestFoundation;
 			productName = TestFoundation;
@@ -2373,12 +2517,14 @@
 				9F0DD33B1ECD734200F68030 /* Sources */,
 				9F0DD33C1ECD734200F68030 /* Frameworks */,
 				9F0DD33D1ECD734200F68030 /* Resources */,
+				1550112122EA473B0088F082 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				159870C0228F741000ADE509 /* PBXTargetDependency */,
 				B90FD23220C2FF840087EF44 /* PBXTargetDependency */,
+				1550112022EA473B0088F082 /* PBXTargetDependency */,
 			);
 			name = xdgTestHelper;
 			productName = xdgTestHelper;
@@ -2462,11 +2608,20 @@
 				9F0DD33E1ECD734200F68030 /* xdgTestHelper */,
 				15B80384228F376000B30FF6 /* SwiftFoundationNetworking */,
 				15FF0006229348F2004AD205 /* CFURLSessionInterface */,
+				15500FA722EA24D10088F082 /* CFXMLInterface */,
+				1550106E22EA266B0088F082 /* SwiftFoundationXML */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		1550107922EA266B0088F082 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		15B8038F228F376000B30FF6 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2537,6 +2692,27 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		1550100922EA24D10088F082 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1550102C22EA24D10088F082 /* CFXMLInterface.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1550107B22EA266B0088F082 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1550110E22EA26CA0088F082 /* XMLDocument.swift in Sources */,
+				1550110F22EA26CA0088F082 /* XMLDTD.swift in Sources */,
+				1550111022EA26CA0088F082 /* XMLDTDNode.swift in Sources */,
+				1550111122EA26CA0088F082 /* XMLElement.swift in Sources */,
+				1550111222EA26CA0088F082 /* XMLNode.swift in Sources */,
+				1550111322EA26CA0088F082 /* XMLParser.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		15B80391228F376000B30FF6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2594,13 +2770,11 @@
 				EADE0B941BD15DFF00C49C64 /* NSCompoundPredicate.swift in Sources */,
 				528776141BF2629700CB0090 /* FoundationErrors.swift in Sources */,
 				5B23AB8D1CE63228000DB898 /* URL.swift in Sources */,
-				EADE0BC91BD15E0000C49C64 /* XMLDTDNode.swift in Sources */,
 				EADE0BA91BD15E0000C49C64 /* NSNull.swift in Sources */,
 				5BF7AEAC1BCD51F9008F214A /* NSEnumerator.swift in Sources */,
 				5BA9BEA81CF3E7E7009DBD6C /* CharacterSet.swift in Sources */,
 				5BC1B9AA21F275C400524D8C /* DispatchData+DataProtocol.swift in Sources */,
 				61E0117E1C1B55B9000037DD /* Timer.swift in Sources */,
-				EADE0BCD1BD15E0000C49C64 /* XMLParser.swift in Sources */,
 				5BDC3FD01BCF17E600ED97BB /* NSCFSet.swift in Sources */,
 				EADE0B931BD15DFF00C49C64 /* NSComparisonPredicate.swift in Sources */,
 				EADE0B921BD15DFF00C49C64 /* NSCache.swift in Sources */,
@@ -2615,7 +2789,6 @@
 				5BF7AEBE1BCD51F9008F214A /* NSTimeZone.swift in Sources */,
 				EADE0B951BD15DFF00C49C64 /* DateComponentsFormatter.swift in Sources */,
 				5BC1B9AE21F275E900524D8C /* Pointers+DataProtocol.swift in Sources */,
-				EADE0BCA1BD15E0000C49C64 /* XMLElement.swift in Sources */,
 				EADE0BA21BD15E0000C49C64 /* JSONSerialization.swift in Sources */,
 				5BF7AEBA1BCD51F9008F214A /* NSString.swift in Sources */,
 				5BF7AEB81BCD51F9008F214A /* NSRange.swift in Sources */,
@@ -2625,7 +2798,6 @@
 				EADE0B9B1BD15DFF00C49C64 /* FileHandle.swift in Sources */,
 				EADE0BB11BD15E0000C49C64 /* NSPredicate.swift in Sources */,
 				5BF7AEC01BCD51F9008F214A /* NSUUID.swift in Sources */,
-				EADE0BCB1BD15E0000C49C64 /* XMLNode.swift in Sources */,
 				5BF7AEB01BCD51F9008F214A /* NSLocale.swift in Sources */,
 				EADE0BA31BD15E0000C49C64 /* NSKeyedArchiver.swift in Sources */,
 				5BF7AEAD1BCD51F9008F214A /* NSError.swift in Sources */,
@@ -2685,7 +2857,6 @@
 				5BECBA381D1CAD7000B39B1F /* Measurement.swift in Sources */,
 				5BF7AEAF1BCD51F9008F214A /* Host.swift in Sources */,
 				EADE0B4E1BD09E0800C49C64 /* AffineTransform.swift in Sources */,
-				EADE0BC71BD15E0000C49C64 /* XMLDocument.swift in Sources */,
 				5BDC3FCE1BCF17D300ED97BB /* NSCFDictionary.swift in Sources */,
 				EADE0BA81BD15E0000C49C64 /* NotificationQueue.swift in Sources */,
 				EA418C261D57257D005EAD0D /* NSKeyedArchiverHelpers.swift in Sources */,
@@ -2701,7 +2872,6 @@
 				5BA0106E1DF212B300E56898 /* NSPlatform.swift in Sources */,
 				D3BCEB9E1C2EDED800295652 /* NSLog.swift in Sources */,
 				61E0117D1C1B5590000037DD /* RunLoop.swift in Sources */,
-				EADE0BC81BD15E0000C49C64 /* XMLDTD.swift in Sources */,
 				5B23AB8B1CE62F9B000DB898 /* PersonNameComponents.swift in Sources */,
 				EADE0BA61BD15E0000C49C64 /* MassFormatter.swift in Sources */,
 				5BECBA3A1D1CAE9A00B39B1F /* NSMeasurement.swift in Sources */,
@@ -2950,6 +3120,26 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		1550110C22EA26780088F082 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 15500FA722EA24D10088F082 /* CFXMLInterface */;
+			targetProxy = 1550110B22EA26780088F082 /* PBXContainerItemProxy */;
+		};
+		1550111622EA42780088F082 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 15500FA722EA24D10088F082 /* CFXMLInterface */;
+			targetProxy = 1550111522EA42780088F082 /* PBXContainerItemProxy */;
+		};
+		1550111A22EA43E00088F082 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1550106E22EA266B0088F082 /* SwiftFoundationXML */;
+			targetProxy = 1550111922EA43E00088F082 /* PBXContainerItemProxy */;
+		};
+		1550112022EA473B0088F082 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1550106E22EA266B0088F082 /* SwiftFoundationXML */;
+			targetProxy = 1550111F22EA473B0088F082 /* PBXContainerItemProxy */;
+		};
 		159870C0228F741000ADE509 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 15B80384228F376000B30FF6 /* SwiftFoundationNetworking */;
@@ -3008,6 +3198,191 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		1550106822EA24D10088F082 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				EXECUTABLE_PREFIX = lib;
+				GCC_PREFIX_HEADER = CoreFoundation/Base.subproj/CoreFoundation_Prefix.h;
+				HEADER_SEARCH_PATHS = /usr/include/libxml2;
+				OTHER_CFLAGS = (
+					"-DCF_BUILDING_CF",
+					"-DDEPLOYMENT_RUNTIME_SWIFT",
+					"-DDEPLOYMENT_ENABLE_LIBDISPATCH",
+					"-I$(SRCROOT)/bootstrap/common/usr/include",
+					"-I$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/include",
+					"-I$(SRCROOT)/bootstrap/common/usr/local/include",
+					"-I$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/local/include",
+					"-g3",
+					"-fconstant-cfstrings",
+					"-fexceptions",
+					"-Wno-shorten-64-to-32",
+					"-Wno-deprecated-declarations",
+					"-Wno-unreachable-code",
+					"-Wno-conditional-uninitialized",
+					"-Wno-unused-variable",
+					"-Wno-int-conversion",
+					"-Wno-unused-function",
+					"-DHAVE_STRUCT_TIMESPEC",
+					"-DCF_CHARACTERSET_UNICODE_DATA_L=\\\\\"CoreFoundation/CharacterSets/CFUnicodeData-L.mapping\\\\\"",
+					"-DCF_CHARACTERSET_UNICODE_DATA_B=\\\\\"CoreFoundation/CharacterSets/CFUnicodeData-B.mapping\\\\\"",
+					"-DCF_CHARACTERSET_UNICHAR_DB=\\\\\"CoreFoundation/CharacterSets/CFUniCharPropertyDatabase.data\\\\\"",
+					"-DCF_CHARACTERSET_BITMAP=\\\\\"CoreFoundation/CharacterSets/CFCharacterSetBitmaps.bitmap\\\\\"",
+					"-Wno-format-security",
+				);
+				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include/CFXMLInterface;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = /usr/local/include/CFXMLInterface;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		1550106922EA24D10088F082 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				EXECUTABLE_PREFIX = lib;
+				GCC_PREFIX_HEADER = CoreFoundation/Base.subproj/CoreFoundation_Prefix.h;
+				HEADER_SEARCH_PATHS = /usr/include/libxml2;
+				OTHER_CFLAGS = (
+					"-DCF_BUILDING_CF",
+					"-DDEPLOYMENT_RUNTIME_SWIFT",
+					"-DDEPLOYMENT_ENABLE_LIBDISPATCH",
+					"-I$(SRCROOT)/bootstrap/common/usr/include",
+					"-I$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/include",
+					"-I$(SRCROOT)/bootstrap/common/usr/local/include",
+					"-I$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/local/include",
+					"-g3",
+					"-fconstant-cfstrings",
+					"-fexceptions",
+					"-Wno-shorten-64-to-32",
+					"-Wno-deprecated-declarations",
+					"-Wno-unreachable-code",
+					"-Wno-conditional-uninitialized",
+					"-Wno-unused-variable",
+					"-Wno-int-conversion",
+					"-Wno-unused-function",
+					"-DHAVE_STRUCT_TIMESPEC",
+					"-DCF_CHARACTERSET_UNICODE_DATA_L=\\\\\"CoreFoundation/CharacterSets/CFUnicodeData-L.mapping\\\\\"",
+					"-DCF_CHARACTERSET_UNICODE_DATA_B=\\\\\"CoreFoundation/CharacterSets/CFUnicodeData-B.mapping\\\\\"",
+					"-DCF_CHARACTERSET_UNICHAR_DB=\\\\\"CoreFoundation/CharacterSets/CFUniCharPropertyDatabase.data\\\\\"",
+					"-DCF_CHARACTERSET_BITMAP=\\\\\"CoreFoundation/CharacterSets/CFCharacterSetBitmaps.bitmap\\\\\"",
+					"-Wno-format-security",
+				);
+				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include/CFXMLInterface;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = /usr/local/include/CFXMLInterface;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		1550110722EA266B0088F082 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 150;
+				DYLIB_CURRENT_VERSION = 1303;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_PREFIX_HEADER = CoreFoundation/Base.subproj/CoreFoundation_Prefix.h;
+				HEADER_SEARCH_PATHS = (
+					"$(CONFIGURATION_BUILD_DIR)/usr/local/include",
+					/usr/include/libxml2,
+				);
+				INFOPLIST_FILE = Foundation/XML/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				OTHER_CFLAGS = (
+					"-DCF_BUILDING_CF",
+					"-DDEPLOYMENT_RUNTIME_SWIFT",
+					"-DDEPLOYMENT_ENABLE_LIBDISPATCH",
+					"-DHAVE_STRUCT_TIMESPEC",
+					"-I$(SRCROOT)/bootstrap/common/usr/include",
+					"-I$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/include",
+					"-I$(SRCROOT)/bootstrap/common/usr/local/include",
+					"-I$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/local/include",
+					"-g3",
+					"-fconstant-cfstrings",
+					"-fexceptions",
+					"-Wno-shorten-64-to-32",
+					"-Wno-deprecated-declarations",
+					"-Wno-unreachable-code",
+					"-Wno-conditional-uninitialized",
+					"-Wno-unused-variable",
+					"-Wno-int-conversion",
+					"-Wno-unused-function",
+				);
+				OTHER_SWIFT_FLAGS = "-DDEPLOYMENT_ENABLE_LIBDISPATCH -DDEPLOYMENT_RUNTIME_SWIFT -swift-version 4.2";
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.Foundation.XML;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		1550110822EA266B0088F082 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 150;
+				DYLIB_CURRENT_VERSION = 1303;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_PREFIX_HEADER = CoreFoundation/Base.subproj/CoreFoundation_Prefix.h;
+				HEADER_SEARCH_PATHS = (
+					"$(CONFIGURATION_BUILD_DIR)/usr/local/include",
+					/usr/include/libxml2,
+				);
+				INFOPLIST_FILE = Foundation/XML/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				OTHER_CFLAGS = (
+					"-DCF_BUILDING_CF",
+					"-DDEPLOYMENT_RUNTIME_SWIFT",
+					"-DDEPLOYMENT_ENABLE_LIBDISPATCH",
+					"-DHAVE_STRUCT_TIMESPEC",
+					"-I$(SRCROOT)/bootstrap/common/usr/include",
+					"-I$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/include",
+					"-I$(SRCROOT)/bootstrap/common/usr/local/include",
+					"-I$(SRCROOT)/bootstrap/x86_64-apple-darwin/usr/local/include",
+					"-g3",
+					"-fconstant-cfstrings",
+					"-fexceptions",
+					"-Wno-shorten-64-to-32",
+					"-Wno-deprecated-declarations",
+					"-Wno-unreachable-code",
+					"-Wno-conditional-uninitialized",
+					"-Wno-unused-variable",
+					"-Wno-int-conversion",
+					"-Wno-unused-function",
+				);
+				OTHER_SWIFT_FLAGS = "-DDEPLOYMENT_ENABLE_LIBDISPATCH -DDEPLOYMENT_RUNTIME_SWIFT -swift-version 4.2";
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.Foundation.XML;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		15B80438228F376000B30FF6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3673,6 +4048,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1550106722EA24D10088F082 /* Build configuration list for PBXNativeTarget "CFXMLInterface" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1550106822EA24D10088F082 /* Debug */,
+				1550106922EA24D10088F082 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1550110622EA266B0088F082 /* Build configuration list for PBXNativeTarget "SwiftFoundationXML" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1550110722EA266B0088F082 /* Debug */,
+				1550110822EA266B0088F082 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		15B80437228F376000B30FF6 /* Build configuration list for PBXNativeTarget "SwiftFoundationNetworking" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -222,8 +222,8 @@ extension CFError : _NSBridgeable {
 
 public struct _CFErrorSPIForFoundationXMLUseOnly {
     let error: CFError
-    public init(_ error: AnyObject) {
-        self.error = error as! CFError
+    public init(unsafelyAssumingIsCFError error: AnyObject) {
+        self.error = unsafeBitCast(error, to: CFError.self)
     }
     
     public var _nsObject: NSError {

--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -220,6 +220,17 @@ extension CFError : _NSBridgeable {
     }
 }
 
+public struct _CFErrorSPIForFoundationXMLUseOnly {
+    let error: CFError
+    public init(_ error: AnyObject) {
+        self.error = error as! CFError
+    }
+    
+    public var _nsObject: NSError {
+        return error._nsObject
+    }
+}
+
 /// Describes an error that provides localized messages describing why
 /// an error occurred and provides more information about the error.
 public protocol LocalizedError : Error {

--- a/Foundation/NSObjCRuntime.swift
+++ b/Foundation/NSObjCRuntime.swift
@@ -438,7 +438,7 @@ public func NSClassFromString(_ aClassName: String) -> AnyClass? {
     return _typeByName(aClassNameWithPrefix) as? AnyClass
 }
 
-// The following types have been moved to FoundationNetworking. They exist here only to allow appropriate diagnostics to surface in the compiler.
+// The following types have been moved to FoundationNetworking or FoundationXML. They exist here only to allow appropriate diagnostics to surface in the compiler.
 
 @available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias CachedURLResponse = AnyObject
@@ -493,3 +493,21 @@ public typealias URLProtectionSpace = AnyObject
 
 @available(*, unavailable, message: "This type has moved to the FoundationNetworking module. Import that module to use it.")
 public typealias URLProtocol = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationXML module. Import that module to use it.")
+public typealias XMLDTD = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationXML module. Import that module to use it.")
+public typealias XMLDTDNode = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationXML module. Import that module to use it.")
+public typealias XMLDocument = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationXML module. Import that module to use it.")
+public typealias XMLElement = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationXML module. Import that module to use it.")
+public typealias XMLNode = AnyObject
+
+@available(*, unavailable, message: "This type has moved to the FoundationXML module. Import that module to use it.")
+public typealias XMLParser = AnyObject

--- a/Foundation/NSObjCRuntime.swift
+++ b/Foundation/NSObjCRuntime.swift
@@ -234,7 +234,7 @@ internal struct _CFInfo {
 // NSStringFromClass(_:) will return the ObjC name when passed one of these classes, and NSClassFromString(_:) will return the class when passed the ObjC name.
 // This is important for NSCoding archives created on Apple OSes to decode with swift-corelibs-foundation and for general source and data format compatibility.
 
-internal let _NSClassesRenamedByObjCAPINotesInNetworking: [(swiftName: String, objCName: String)] = [
+internal let _NSClassesRenamedByObjCAPINotesInNetworkingOrXML: [(swiftName: String, objCName: String)] = [
     (_SwiftFoundationNetworkingModuleName + ".CachedURLResponse", "NSCachedURLResponse"),
     (_SwiftFoundationNetworkingModuleName + ".HTTPCookie", "NSHTTPCookie"),
     (_SwiftFoundationNetworkingModuleName + ".HTTPCookieStorage", "NSHTTPCookieStorage"),
@@ -253,6 +253,12 @@ internal let _NSClassesRenamedByObjCAPINotesInNetworking: [(swiftName: String, o
     (_SwiftFoundationNetworkingModuleName + ".URLCredentialStorage", "NSURLCredentialStorage"),
     (_SwiftFoundationNetworkingModuleName + ".URLProtectionSpace", "NSURLProtectionSpace"),
     (_SwiftFoundationNetworkingModuleName + ".URLProtocol", "NSURLProtocol"),
+    (_SwiftFoundationXMLModuleName + ".XMLDTD", "NSXMLDTD"),
+    (_SwiftFoundationXMLModuleName + ".XMLDTDNode", "NSXMLDTDNode"),
+    (_SwiftFoundationXMLModuleName + ".XMLDocument", "NSXMLDocument"),
+    (_SwiftFoundationXMLModuleName + ".XMLElement", "NSXMLElement"),
+    (_SwiftFoundationXMLModuleName + ".XMLNode", "NSXMLNode"),
+    (_SwiftFoundationXMLModuleName + ".XMLParser", "NSXMLParser"),
 ]
 
 internal let _NSClassesRenamedByObjCAPINotes: [(class: AnyClass, objCName: String)] = {
@@ -262,12 +268,6 @@ internal let _NSClassesRenamedByObjCAPINotes: [(class: AnyClass, objCName: Strin
         (Port.self, "NSPort"),
         (PortMessage.self, "NSPortMessage"),
         (SocketPort.self, "NSSocketPort"),
-        (XMLDTD.self, "NSXMLDTD"),
-        (XMLDTDNode.self, "NSXMLDTDNode"),
-        (XMLDocument.self, "NSXMLDocument"),
-        (XMLElement.self, "NSXMLElement"),
-        (XMLNode.self, "NSXMLNode"),
-        (XMLParser.self, "NSXMLParser"),
         (Bundle.self, "NSBundle"),
         (ByteCountFormatter.self, "NSByteCountFormatter"),
         (Host.self, "NSHost"),
@@ -332,7 +332,7 @@ internal let _NSClassesRenamedByObjCAPINotes: [(class: AnyClass, objCName: Strin
 
 fileprivate var mapFromObjCNameToKnownName: [String: String] = {
     var map: [String: String] = [:]
-    for entry in _NSClassesRenamedByObjCAPINotesInNetworking {
+    for entry in _NSClassesRenamedByObjCAPINotesInNetworkingOrXML {
         map[entry.objCName] = entry.swiftName
     }
     return map
@@ -340,7 +340,7 @@ fileprivate var mapFromObjCNameToKnownName: [String: String] = {
 
 fileprivate var mapFromKnownNameToObjCName: [String: String] = {
     var map: [String: String] = [:]
-    for entry in _NSClassesRenamedByObjCAPINotesInNetworking {
+    for entry in _NSClassesRenamedByObjCAPINotesInNetworkingOrXML {
         map[entry.swiftName] = entry.objCName
     }
     return map
@@ -369,6 +369,7 @@ private let _SwiftFoundationModuleName = "Foundation"
 #endif
 
 internal let _SwiftFoundationNetworkingModuleName = _SwiftFoundationModuleName + "Networking"
+internal let _SwiftFoundationXMLModuleName = _SwiftFoundationModuleName + "XML"
 
 /**
     Returns the class name for a class. For compatibility with Foundation on Darwin,
@@ -393,7 +394,7 @@ public func NSStringFromClass(_ aClass: AnyClass) -> String {
     
     if components[0] == _SwiftFoundationModuleName {
         return components[1]
-    } else if components[0] == _SwiftFoundationNetworkingModuleName, let actualName = mapFromKnownNameToObjCName[classNameString] {
+    } else if components[0] == _SwiftFoundationNetworkingModuleName || components[0] == _SwiftFoundationXMLModuleName, let actualName = mapFromKnownNameToObjCName[classNameString] {
         return actualName
     } else {
         return String(describing: aClassName)

--- a/Foundation/NSSwiftRuntime.swift
+++ b/Foundation/NSSwiftRuntime.swift
@@ -247,28 +247,6 @@ internal func __CFInitializeSwift() {
     __CFSwiftBridge.NSMutableString.appendCharacters = _CFSwiftStringAppendCharacters
     __CFSwiftBridge.NSMutableString._cfAppendCString = _CFSwiftStringAppendCString
     
-    __CFSwiftBridge.NSXMLParser.currentParser = _NSXMLParserCurrentParser
-    __CFSwiftBridge.NSXMLParser._xmlExternalEntityWithURL = _NSXMLParserExternalEntityWithURL
-    __CFSwiftBridge.NSXMLParser.getContext = _NSXMLParserGetContext
-    __CFSwiftBridge.NSXMLParser.internalSubset = _NSXMLParserInternalSubset
-    __CFSwiftBridge.NSXMLParser.isStandalone = _NSXMLParserIsStandalone
-    __CFSwiftBridge.NSXMLParser.hasInternalSubset = _NSXMLParserHasInternalSubset
-    __CFSwiftBridge.NSXMLParser.hasExternalSubset = _NSXMLParserHasExternalSubset
-    __CFSwiftBridge.NSXMLParser.getEntity = _NSXMLParserGetEntity
-    __CFSwiftBridge.NSXMLParser.notationDecl = _NSXMLParserNotationDecl
-    __CFSwiftBridge.NSXMLParser.attributeDecl = _NSXMLParserAttributeDecl
-    __CFSwiftBridge.NSXMLParser.elementDecl = _NSXMLParserElementDecl
-    __CFSwiftBridge.NSXMLParser.unparsedEntityDecl = _NSXMLParserUnparsedEntityDecl
-    __CFSwiftBridge.NSXMLParser.startDocument = _NSXMLParserStartDocument
-    __CFSwiftBridge.NSXMLParser.endDocument = _NSXMLParserEndDocument
-    __CFSwiftBridge.NSXMLParser.startElementNs = _NSXMLParserStartElementNs
-    __CFSwiftBridge.NSXMLParser.endElementNs = _NSXMLParserEndElementNs
-    __CFSwiftBridge.NSXMLParser.characters = _NSXMLParserCharacters
-    __CFSwiftBridge.NSXMLParser.processingInstruction = _NSXMLParserProcessingInstruction
-    __CFSwiftBridge.NSXMLParser.cdataBlock = _NSXMLParserCdataBlock
-    __CFSwiftBridge.NSXMLParser.comment = _NSXMLParserComment
-    __CFSwiftBridge.NSXMLParser.externalSubset = _NSXMLParserExternalSubset
-    
     __CFSwiftBridge.NSRunLoop._new = _NSRunLoopNew
     
     __CFSwiftBridge.NSCharacterSet._expandedCFCharacterSet = _CFSwiftCharacterSetExpandedCFCharacterSet

--- a/Foundation/XML/Info.plist
+++ b/Foundation/XML/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>SwiftFoundation</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>SwiftFoundation</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Foundation/XMLDTD.swift
+++ b/Foundation/XMLDTD.swift
@@ -44,7 +44,7 @@ open class XMLDTD : XMLNode {
         
         guard let node = _CFXMLParseDTDFromData(unsafeBitCast(data as NSData, to: CFData.self), &unmanagedError) else {
             if let error = unmanagedError?.takeRetainedValue() {
-                throw _CFErrorSPIForFoundationXMLUseOnly(error)._nsObject
+                throw _CFErrorSPIForFoundationXMLUseOnly(unsafelyAssumingIsCFError: error)._nsObject
             }
             //TODO: throw a generic error?
             fatalError("parsing dtd from data failed")

--- a/Foundation/XMLDTDNode.swift
+++ b/Foundation/XMLDTDNode.swift
@@ -7,7 +7,14 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 import CoreFoundation
+import CFXMLInterface
+
 /*!
     @typedef XMLDTDNodeKind
 	@abstract The subkind of a DTD node kind.
@@ -200,7 +207,8 @@ open class XMLDTDNode: XMLNode {
     */
     open var publicID: String? {
         get {
-            return _CFXMLDTDNodeCopyPublicID(_xmlNode)?._swiftObject
+            let returned = _CFXMLDTDNodeCopyPublicID(_xmlNode)
+            return returned == nil ? nil : unsafeBitCast(returned!, to: NSString.self) as String
         }
         set {
             if let value = newValue {
@@ -217,7 +225,8 @@ open class XMLDTDNode: XMLNode {
     */
     open var systemID: String? {
         get {
-            return _CFXMLDTDNodeCopySystemID(_xmlNode)?._swiftObject
+            let returned = _CFXMLDTDNodeCopySystemID(_xmlNode)
+            return returned == nil ? nil : unsafeBitCast(returned!, to: NSString.self) as String
         }
         set {
             if let value = newValue {
@@ -238,7 +247,8 @@ open class XMLDTDNode: XMLNode {
                 return nil
             }
 
-            return _CFXMLCopyEntityContent(_xmlNode)?._swiftObject
+            let returned = _CFXMLCopyEntityContent(_xmlNode)
+            return returned == nil ? nil : unsafeBitCast(returned!, to: NSString.self) as String
         }
         set {
             guard dtdKind == .unparsed else {
@@ -261,7 +271,7 @@ open class XMLDTDNode: XMLNode {
                      type == _kCFXMLDTDNodeTypeElement)
 
         if let privateData = _CFXMLNodeGetPrivateData(node) {
-            return XMLDTDNode.unretainedReference(privateData)
+            return unsafeBitCast(privateData, to: XMLDTDNode.self)
         }
 
         return XMLDTDNode(ptr: node)

--- a/Foundation/XMLDocument.swift
+++ b/Foundation/XMLDocument.swift
@@ -99,7 +99,7 @@ open class XMLDocument : XMLNode {
         @abstract Returns a document created from data. Parse errors are returned in <tt>error</tt>.
     */
     public init(data: Data, options mask: XMLNode.Options = []) throws {
-        let docPtr = _CFXMLDocPtrFromDataWithOptions((data as AnyObject) as! CFData, UInt32(mask.rawValue))
+        let docPtr = _CFXMLDocPtrFromDataWithOptions(unsafeBitCast(data as NSData, to: CFData.self), UInt32(mask.rawValue))
         super.init(ptr: _CFXMLNodePtr(docPtr))
 
         if mask.contains(.documentValidate) {

--- a/Foundation/XMLDocument.swift
+++ b/Foundation/XMLDocument.swift
@@ -363,7 +363,7 @@ open class XMLDocument : XMLNode {
         if !result,
             let unmanagedError = unmanagedError {
             let error = unmanagedError.takeRetainedValue()
-            throw _CFErrorSPIForFoundationXMLUseOnly(error)._nsObject
+            throw _CFErrorSPIForFoundationXMLUseOnly(unsafelyAssumingIsCFError: error)._nsObject
         }
     }
 

--- a/Foundation/XMLElement.swift
+++ b/Foundation/XMLElement.swift
@@ -7,7 +7,14 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 import CoreFoundation
+import CFXMLInterface
+
 /*!
     @class XMLElement
     @abstract An XML element
@@ -85,9 +92,11 @@ open class XMLElement: XMLNode {
         @abstract Adds an attribute. Attributes with duplicate names replace the old one.
     */
     open func addAttribute(_ attribute: XMLNode) {
-        guard let name = _CFXMLNodeCopyName(attribute._xmlNode)?._swiftObject else {
+        guard let cfname = _CFXMLNodeCopyName(attribute._xmlNode) else {
             fatalError("Attributes must have a name!")
         }
+        
+        let name = unsafeBitCast(cfname, to: NSString.self) as String
 
         removeAttribute(forName: name)
         _CFXMLCompletePropURI(attribute._xmlNode, _xmlNode);        
@@ -140,7 +149,7 @@ open class XMLElement: XMLNode {
         while let attribute = nextAttribute {
             var shouldFreeNode = true
             if let privateData = _CFXMLNodeGetPrivateData(attribute) {
-                _childNodes.remove(XMLNode.unretainedReference(privateData))
+                _childNodes.remove(unsafeBitCast(privateData, to: XMLNode.self))
 
                 shouldFreeNode = false
             }
@@ -314,7 +323,7 @@ open class XMLElement: XMLNode {
         precondition(_CFXMLNodeGetType(node) == _kCFXMLTypeElement)
 
         if let privateData = _CFXMLNodeGetPrivateData(node) {
-            return XMLElement.unretainedReference(privateData)
+            return unsafeBitCast(privateData, to: XMLElement.self)
         }
 
         return XMLElement(ptr: node)

--- a/Foundation/XMLNode.swift
+++ b/Foundation/XMLNode.swift
@@ -8,7 +8,13 @@
 //
 
 //import libxml2
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 import CoreFoundation
+import CFXMLInterface
 
 // initWithKind options
 //  NSXMLNodeOptionsNone
@@ -28,11 +34,11 @@ import CoreFoundation
 
 
 /*!
-    @class NSXMLNode
-    @abstract The basic unit of an XML document.
-*/
+ @class NSXMLNode
+ @abstract The basic unit of an XML document.
+ */
 open class XMLNode: NSObject, NSCopying {
-
+    
     public enum Kind : UInt {
         case invalid
         case document
@@ -48,30 +54,30 @@ open class XMLNode: NSObject, NSCopying {
         case elementDeclaration
         case notationDeclaration
     }
-
+    
     public struct Options : OptionSet {
         public let rawValue : UInt
         public init(rawValue: UInt) { self.rawValue = rawValue }
-
+        
         public static let nodeIsCDATA = Options(rawValue: 1 << 0)
         public static let nodeExpandEmptyElement = Options(rawValue: 1 << 1)
         public static let nodeCompactEmptyElement = Options(rawValue: 1 << 2)
         public static let nodeUseSingleQuotes = Options(rawValue: 1 << 3)
         public static let nodeUseDoubleQuotes = Options(rawValue: 1 << 4)
         public static let nodeNeverEscapeContents = Options(rawValue: 1 << 5)
-
+        
         public static let documentTidyHTML = Options(rawValue: 1 << 9)
         public static let documentTidyXML = Options(rawValue: 1 << 10)
         public static let documentValidate = Options(rawValue: 1 << 13)
-
+        
         public static let nodeLoadExternalEntitiesAlways = Options(rawValue: 1 << 14)
         public static let nodeLoadExternalEntitiesSameOriginOnly = Options(rawValue: 1 << 15)
         public static let nodeLoadExternalEntitiesNever = Options(rawValue: 1 << 19)
-
+        
         public static let documentXInclude = Options(rawValue: 1 << 16)
         public static let nodePrettyPrint = Options(rawValue: 1 << 17)
         public static let documentIncludeContentTypeDeclaration = Options(rawValue: 1 << 18)
-
+        
         public static let nodePreserveNamespaceOrder = Options(rawValue: 1 << 20)
         public static let nodePreserveAttributeOrder = Options(rawValue: 1 << 21)
         public static let nodePreserveEntities = Options(rawValue: 1 << 22)
@@ -85,239 +91,241 @@ open class XMLNode: NSObject, NSCopying {
         public static let nodePreserveQuotes = Options([.nodeUseSingleQuotes, .nodeUseDoubleQuotes])
         public static let nodePreserveAll = Options(rawValue: 0xFFF00000).union([.nodePreserveNamespaceOrder, .nodePreserveAttributeOrder, .nodePreserveEntities, .nodePreservePrefixes, .nodePreserveCDATA, .nodePreserveEmptyElements, .nodePreserveQuotes, .nodePreserveWhitespace, .nodePreserveDTD, .nodePreserveCharacterReferences])
     }
-
+    
     open override func copy() -> Any {
         return copy(with: nil)
     }
-
+    
     internal let _xmlNode: _CFXMLNodePtr
     internal var _xmlDocument: XMLDocument?
-
+    
     open func copy(with zone: NSZone? = nil) -> Any {
         let newNode = _CFXMLCopyNode(_xmlNode, true)
         return XMLNode._objectNodeForNode(newNode)
     }
-
+    
     /*!
-        @method initWithKind:
-        @abstract Invokes @link initWithKind:options: @/link with options set to NSXMLNodeOptionsNone
-    */
+     @method initWithKind:
+     @abstract Invokes @link initWithKind:options: @/link with options set to NSXMLNodeOptionsNone
+     */
     public convenience init(kind: XMLNode.Kind) {
         self.init(kind: kind, options: [])
     }
-
+    
     /*!
-        @method initWithKind:options:
-        @abstract Inits a node with fidelity options as description NSXMLNodeOptions.h
-    */
+     @method initWithKind:options:
+     @abstract Inits a node with fidelity options as description NSXMLNodeOptions.h
+     */
     public init(kind: XMLNode.Kind, options: XMLNode.Options = []) {
-
+        
         switch kind {
         case .document:
             let docPtr = _CFXMLNewDoc("1.0")
             _CFXMLDocSetStandalone(docPtr, false) // same default as on Darwin
             _xmlNode = _CFXMLNodePtr(docPtr)
-
+            
         case .element:
             _xmlNode = _CFXMLNewNode(nil, "")
-
+            
         case .attribute:
             _xmlNode = _CFXMLNodePtr(_CFXMLNewProperty(nil, "", nil, ""))
-
+            
         case .DTDKind:
             _xmlNode = _CFXMLNewDTD(nil, "", "", "")
-
+            
         case .namespace:
             _xmlNode = _CFXMLNewNamespace("", "")
-
+            
         default:
             fatalError("invalid node kind for this initializer")
         }
-
+        
         super.init()
 
-        withUnretainedReference {
+        withOpaqueUnretainedReference {
             _CFXMLNodeSetPrivateData(_xmlNode, $0)
         }
     }
-
+    
     /*!
-        @method document:
-        @abstract Returns an empty document.
-    */
+     @method document:
+     @abstract Returns an empty document.
+     */
     open class func document() -> Any {
         return XMLDocument(rootElement: nil)
     }
-
+    
     /*!
-        @method documentWithRootElement:
-        @abstract Returns a document
-        @param element The document's root node.
-    */
+     @method documentWithRootElement:
+     @abstract Returns a document
+     @param element The document's root node.
+     */
     open class func document(withRootElement element: XMLElement) -> Any {
         return XMLDocument(rootElement: element)
     }
-
+    
     /*!
-        @method elementWithName:
-        @abstract Returns an element <tt>&lt;name>&lt;/name></tt>.
-    */
+     @method elementWithName:
+     @abstract Returns an element <tt>&lt;name>&lt;/name></tt>.
+     */
     open class func element(withName name: String) -> Any {
         return XMLElement(name: name)
     }
-
+    
     /*!
-        @method elementWithName:URI:
-        @abstract Returns an element whose full QName is specified.
-    */
+     @method elementWithName:URI:
+     @abstract Returns an element whose full QName is specified.
+     */
     open class func element(withName name: String, uri: String) -> Any {
         return XMLElement(name: name, uri: uri)
     }
-
+    
     /*!
-        @method elementWithName:stringValue:
-        @abstract Returns an element with a single text node child <tt>&lt;name>string&lt;/name></tt>.
-    */
+     @method elementWithName:stringValue:
+     @abstract Returns an element with a single text node child <tt>&lt;name>string&lt;/name></tt>.
+     */
     open class func element(withName name: String, stringValue string: String) -> Any {
         return XMLElement(name: name, stringValue: string)
     }
-
+    
     /*!
-        @method elementWithName:children:attributes:
-        @abstract Returns an element children and attributes <tt>&lt;name attr1="foo" attr2="bar">&lt;-- child1 -->child2&lt;/name></tt>.
-    */
+     @method elementWithName:children:attributes:
+     @abstract Returns an element children and attributes <tt>&lt;name attr1="foo" attr2="bar">&lt;-- child1 -->child2&lt;/name></tt>.
+     */
     open class func element(withName name: String, children: [XMLNode]?, attributes: [XMLNode]?) -> Any {
         let element = XMLElement(name: name)
         element.setChildren(children)
         element.attributes = attributes
-
+        
         return element
     }
-
+    
     /*!
-        @method attributeWithName:stringValue:
-        @abstract Returns an attribute <tt>name="stringValue"</tt>.
-    */
+     @method attributeWithName:stringValue:
+     @abstract Returns an attribute <tt>name="stringValue"</tt>.
+     */
     open class func attribute(withName name: String, stringValue: String) -> Any {
         let attribute = _CFXMLNewProperty(nil, name, nil, stringValue)
-
+        
         return XMLNode(ptr: attribute)
     }
-
+    
     /*!
-        @method attributeWithLocalName:URI:stringValue:
-        @abstract Returns an attribute whose full QName is specified.
-    */
+     @method attributeWithLocalName:URI:stringValue:
+     @abstract Returns an attribute whose full QName is specified.
+     */
     open class func attribute(withName name: String, uri: String, stringValue: String) -> Any {
         let attribute = _CFXMLNewProperty(nil, name, uri, stringValue)
-
+        
         return XMLNode(ptr: attribute)
     }
-
+    
     /*!
-        @method namespaceWithName:stringValue:
-        @abstract Returns a namespace <tt>xmlns:name="stringValue"</tt>.
-    */
+     @method namespaceWithName:stringValue:
+     @abstract Returns a namespace <tt>xmlns:name="stringValue"</tt>.
+     */
     open class func namespace(withName name: String, stringValue: String) -> Any {
         let node = _CFXMLNewNamespace(name, stringValue)
         return XMLNode(ptr: node)
     }
-
+    
     /*!
-        @method processingInstructionWithName:stringValue:
-        @abstract Returns a processing instruction <tt>&lt;?name stringValue></tt>.
-    */
+     @method processingInstructionWithName:stringValue:
+     @abstract Returns a processing instruction <tt>&lt;?name stringValue></tt>.
+     */
     public class func processingInstruction(withName name: String, stringValue: String) -> Any {
         let node = _CFXMLNewProcessingInstruction(name, stringValue)
         return XMLNode(ptr: node)
     }
-
+    
     /*!
-        @method commentWithStringValue:
-        @abstract Returns a comment <tt>&lt;--stringValue--></tt>.
-    */
+     @method commentWithStringValue:
+     @abstract Returns a comment <tt>&lt;--stringValue--></tt>.
+     */
     open class func comment(withStringValue stringValue: String) -> Any {
         let node = _CFXMLNewComment(stringValue)
         return XMLNode(ptr: node)
     }
-
+    
     /*!
-        @method textWithStringValue:
-        @abstract Returns a text node.
-    */
+     @method textWithStringValue:
+     @abstract Returns a text node.
+     */
     open class func text(withStringValue stringValue: String) -> Any {
         let node = _CFXMLNewTextNode(stringValue)
         return XMLNode(ptr: node)
     }
-
+    
     /*!
-        @method DTDNodeWithXMLString:
-        @abstract Returns an element, attribute, entity, or notation DTD node based on the full XML string.
-    */
+     @method DTDNodeWithXMLString:
+     @abstract Returns an element, attribute, entity, or notation DTD node based on the full XML string.
+     */
     open class func dtdNode(withXMLString string: String) -> Any? {
         guard let node = _CFXMLParseDTDNode(string) else { return nil }
-
+        
         return XMLDTDNode(ptr: node)
     }
-
+    
     /*!
-        @method kind
-        @abstract Returns an element, attribute, entity, or notation DTD node based on the full XML string.
-    */
+     @method kind
+     @abstract Returns an element, attribute, entity, or notation DTD node based on the full XML string.
+     */
     open var kind: XMLNode.Kind  {
         switch _CFXMLNodeGetType(_xmlNode) {
         case _kCFXMLTypeElement:
             return .element
-
+            
         case _kCFXMLTypeAttribute:
             return .attribute
-
+            
         case _kCFXMLTypeDocument:
             return .document
-
+            
         case _kCFXMLTypeDTD:
             return .DTDKind
-
+            
         case _kCFXMLDTDNodeTypeElement:
             return .elementDeclaration
-
+            
         case _kCFXMLDTDNodeTypeEntity:
             return .entityDeclaration
-
+            
         case _kCFXMLDTDNodeTypeNotation:
             return .notationDeclaration
-
+            
         case _kCFXMLDTDNodeTypeAttribute:
             return .attributeDeclaration
-
+            
         case _kCFXMLTypeNamespace:
             return .namespace
-
+            
         case _kCFXMLTypeProcessingInstruction:
             return .processingInstruction
-
+            
         case _kCFXMLTypeComment:
             return .comment
-
+            
         case _kCFXMLTypeText:
             return .text
-
+            
         default:
             return .invalid
         }
     }
-
+    
     /*!
-        @method name
-        @abstract Sets the nodes name. Applicable for element, attribute, namespace, processing-instruction, document type declaration, element declaration, attribute declaration, entity declaration, and notation declaration.
-    */
+     @method name
+     @abstract Sets the nodes name. Applicable for element, attribute, namespace, processing-instruction, document type declaration, element declaration, attribute declaration, entity declaration, and notation declaration.
+     */
     open var name: String? {
         get {
             if case .namespace = kind {
-                return _CFXMLNamespaceCopyPrefix(_xmlNode)?._swiftObject ?? ""
+                let returned = _CFXMLNamespaceCopyPrefix(_xmlNode)
+                return returned == nil ? "" : unsafeBitCast(returned!, to: NSString.self) as String
             }
-
-            return _CFXMLNodeCopyName(_xmlNode)?._swiftObject
+            
+            let returned = _CFXMLNodeCopyName(_xmlNode)
+            return returned == nil ? nil : unsafeBitCast(returned!, to: NSString.self) as String
         }
         set {
             if case .namespace = kind {
@@ -331,13 +339,13 @@ open class XMLNode: NSObject, NSCopying {
             }
         }
     }
-
+    
     private var _objectValue: Any? = nil
-
+    
     /*!
-        @method objectValue
-        @abstract Sets the content of the node. Setting the objectValue removes all existing children including processing instructions and comments. Setting the object value on an element creates a single text node child.
-    */
+     @method objectValue
+     @abstract Sets the content of the node. Setting the objectValue removes all existing children including processing instructions and comments. Setting the object value on an element creates a single text node child.
+     */
     open var objectValue: Any? {
         get {
             if let value = _objectValue {
@@ -357,26 +365,29 @@ open class XMLNode: NSObject, NSCopying {
             }
         }
     }
-
+    
     /*!
-        @method stringValue:
-        @abstract Sets the content of the node. Setting the stringValue removes all existing children including processing instructions and comments. Setting the string value on an element creates a single text node child. The getter returns the string value of the node, which may be either its content or child text nodes, depending on the type of node. Elements are recursed and text nodes concatenated in document order with no intervening spaces.
-    */
+     @method stringValue:
+     @abstract Sets the content of the node. Setting the stringValue removes all existing children including processing instructions and comments. Setting the string value on an element creates a single text node child. The getter returns the string value of the node, which may be either its content or child text nodes, depending on the type of node. Elements are recursed and text nodes concatenated in document order with no intervening spaces.
+     */
     open var stringValue: String? {
         get {
             switch kind {
             case .entityDeclaration:
-                return _CFXMLCopyEntityContent(_CFXMLEntityPtr(_xmlNode))?._swiftObject
-
+                let returned = _CFXMLCopyEntityContent(_CFXMLEntityPtr(_xmlNode))
+                return returned == nil ? nil : unsafeBitCast(returned!, to: NSString.self) as String
+                
             case .namespace:
-                return _CFXMLNamespaceCopyValue(_xmlNode)?._swiftObject
-
+                let returned = _CFXMLNamespaceCopyValue(_xmlNode)
+                return returned == nil ? nil : unsafeBitCast(returned!, to: NSString.self) as String
+                
             case .element:
                 // As with Darwin, children's string values are just concanated without spaces.
                 return children?.compactMap({ $0.stringValue }).joined() ?? ""
-
+                
             default:
-                return _CFXMLNodeCopyContent(_xmlNode)?._swiftObject
+                let returned = _CFXMLNodeCopyContent(_xmlNode)
+                return returned == nil ? nil : unsafeBitCast(returned!, to: NSString.self) as String
             }
         }
         set {
@@ -386,14 +397,15 @@ open class XMLNode: NSObject, NSCopying {
                     precondition(URL(string: newValue) != nil, "namespace stringValue must be a valid href")
                 }
                 _CFXMLNamespaceSetValue(_xmlNode, newValue, Int64(newValue?.utf8.count ?? 0))
-
+                
             case .comment, .text:
                 _CFXMLNodeSetContent(_xmlNode, newValue)
-
+                
             default:
                 _removeAllChildNodesExceptAttributes() // in case anyone is holding a reference to any of these children we're about to destroy
                 if let string = newValue {
-                    let newContent = _CFXMLEncodeEntities(_CFXMLNodeGetDocument(_xmlNode), string)?._swiftObject ?? ""
+                    let returned = _CFXMLEncodeEntities(_CFXMLNodeGetDocument(_xmlNode), string)
+                    let newContent = returned == nil ? "" : unsafeBitCast(returned!, to: NSString.self) as String
                     _CFXMLNodeSetContent(_xmlNode, newContent)
                 } else {
                     _CFXMLNodeSetContent(_xmlNode, nil)
@@ -401,7 +413,7 @@ open class XMLNode: NSObject, NSCopying {
             }
         }
     }
-
+    
     private func _removeAllChildNodesExceptAttributes() {
         for node in _childNodes {
             if node.kind != .attribute {
@@ -410,7 +422,7 @@ open class XMLNode: NSObject, NSCopying {
             }
         }
     }
-
+    
     internal func _removeAllChildren() {
         var nextChild = _CFXMLNodeGetFirstChild(_xmlNode)
         while let child = nextChild {
@@ -419,19 +431,19 @@ open class XMLNode: NSObject, NSCopying {
         }
         _childNodes.removeAll(keepingCapacity: true)
     }
-
+    
     /*!
-        @method setStringValue:resolvingEntities:
-        @abstract Sets the content as with @link setStringValue: @/link, but when "resolve" is true, character references, predefined entities and user entities available in the document's dtd are resolved. Entities not available in the dtd remain in their entity form.
-    */
+     @method setStringValue:resolvingEntities:
+     @abstract Sets the content as with @link setStringValue: @/link, but when "resolve" is true, character references, predefined entities and user entities available in the document's dtd are resolved. Entities not available in the dtd remain in their entity form.
+     */
     open func setStringValue(_ string: String, resolvingEntities resolve: Bool) {
         guard resolve else {
             stringValue = string
             return
         }
-
+        
         _removeAllChildNodesExceptAttributes()
-
+        
         var entities: [(Range<Int>, String)] = []
         var entityChars: [Character] = []
         var inEntity = false
@@ -454,7 +466,7 @@ open class XMLNode: NSObject, NSCopying {
                 entityChars.append(char)
             }
         }
-
+        
         var result: [Character] = Array(string)
         let doc = _CFXMLNodeGetDocument(_xmlNode)!
         for (range, entity) in entities {
@@ -466,7 +478,8 @@ open class XMLNode: NSObject, NSCopying {
                 entityPtr = _CFXMLGetParameterEntity(doc, entity)
             }
             if let validEntity = entityPtr {
-                let replacement = _CFXMLCopyEntityContent(validEntity)?._swiftObject ?? ""
+                let returned = _CFXMLCopyEntityContent(validEntity)
+                let replacement = returned == nil ? "" : unsafeBitCast(returned!, to: NSString.self) as String
                 result.replaceSubrange(range, with: replacement)
             } else {
                 result.replaceSubrange(range, with: []) // This appears to be how Darwin Foundation does it
@@ -474,24 +487,24 @@ open class XMLNode: NSObject, NSCopying {
         }
         stringValue = String(result)
     }
-
+    
     /*!
-        @method index
-        @abstract A node's index amongst its siblings.
-    */
+     @method index
+     @abstract A node's index amongst its siblings.
+     */
     open var index: Int {
         if let siblings = self.parent?.children,
             let index = siblings.firstIndex(of: self) {
             return index
         }
-
+        
         return 0
     }
-
+    
     /*!
-        @method level
-        @abstract The depth of the node within the tree. Documents and standalone nodes are level 0.
-    */
+     @method level
+     @abstract The depth of the node within the tree. Documents and standalone nodes are level 0.
+     */
     open var level: Int {
         var result = 0
         var nextParent = _CFXMLNodeGetParent(_xmlNode)
@@ -499,42 +512,42 @@ open class XMLNode: NSObject, NSCopying {
             result += 1
             nextParent = _CFXMLNodeGetParent(parent)
         }
-
+        
         return result
     }
-
+    
     /*!
-        @method rootDocument
-        @abstract The encompassing document or nil.
-    */
+     @method rootDocument
+     @abstract The encompassing document or nil.
+     */
     open var rootDocument: XMLDocument? {
         guard let doc = _CFXMLNodeGetDocument(_xmlNode) else { return nil }
-
+        
         return XMLNode._objectNodeForNode(_CFXMLNodePtr(doc)) as? XMLDocument
     }
-
+    
     /*!
-        @method parent
-        @abstract The parent of this node. Documents and standalone Nodes have a nil parent; there is not a 1-to-1 relationship between parent and children, eg a namespace cannot be a child but has a parent element.
-    */
+     @method parent
+     @abstract The parent of this node. Documents and standalone Nodes have a nil parent; there is not a 1-to-1 relationship between parent and children, eg a namespace cannot be a child but has a parent element.
+     */
     /*@NSCopying*/ open var parent: XMLNode? {
         guard let parentPtr = _CFXMLNodeGetParent(_xmlNode) else { return nil }
-
+        
         return XMLNode._objectNodeForNode(parentPtr)
     }
-
+    
     /*!
-        @method childCount
-        @abstract The amount of children, relevant for documents, elements, and document type declarations. Use this instead of [[self children] count].
-    */
+     @method childCount
+     @abstract The amount of children, relevant for documents, elements, and document type declarations. Use this instead of [[self children] count].
+     */
     open var childCount: Int {
         return _CFXMLNodeGetElementChildCount(_xmlNode)
     }
-
+    
     /*!
-        @method children
-        @abstract An immutable array of child nodes. Relevant for documents, elements, and document type declarations.
-    */
+     @method children
+     @abstract An immutable array of child nodes. Relevant for documents, elements, and document type declarations.
+     */
     open var children: [XMLNode]? {
         switch kind {
         case .document:
@@ -543,47 +556,47 @@ open class XMLNode: NSObject, NSCopying {
             fallthrough
         case .DTDKind:
             return Array<XMLNode>(self as XMLNode)
-
+            
         default:
             return nil
         }
     }
-
+    
     /*!
-        @method childAtIndex:
-        @abstract Returns the child node at a particular index.
-    */
+     @method childAtIndex:
+     @abstract Returns the child node at a particular index.
+     */
     open func child(at index: Int) -> XMLNode? {
         precondition(index >= 0)
         precondition(index < childCount)
-
+        
         return self[self.index(startIndex, offsetBy: index)]
     }
-
+    
     /*!
-        @method previousSibling:
-        @abstract Returns the previous sibling, or nil if there isn't one.
-    */
+     @method previousSibling:
+     @abstract Returns the previous sibling, or nil if there isn't one.
+     */
     /*@NSCopying*/ open var previousSibling: XMLNode? {
         guard let prev = _CFXMLNodeGetPrevSibling(_xmlNode) else { return nil }
-
+        
         return XMLNode._objectNodeForNode(prev)
     }
-
+    
     /*!
-        @method nextSibling:
-        @abstract Returns the next sibling, or nil if there isn't one.
-    */
+     @method nextSibling:
+     @abstract Returns the next sibling, or nil if there isn't one.
+     */
     /*@NSCopying*/ open var nextSibling: XMLNode? {
         guard let next = _CFXMLNodeGetNextSibling(_xmlNode) else { return nil }
-
+        
         return XMLNode._objectNodeForNode(next)
     }
-
+    
     /*!
-        @method previousNode:
-        @abstract Returns the previous node in document order. This can be used to walk the tree backwards.
-    */
+     @method previousNode:
+     @abstract Returns the previous node in document order. This can be used to walk the tree backwards.
+     */
     /*@NSCopying*/ open var previous: XMLNode? {
         if let previousSibling = self.previousSibling {
             if let lastChild = _CFXMLNodeGetLastChild(previousSibling._xmlNode) {
@@ -597,11 +610,11 @@ open class XMLNode: NSObject, NSCopying {
             return nil
         }
     }
-
+    
     /*!
-        @method nextNode:
-        @abstract Returns the next node in document order. This can be used to walk the tree forwards.
-    */
+     @method nextNode:
+     @abstract Returns the next node in document order. This can be used to walk the tree forwards.
+     */
     /*@NSCopying*/ open var next: XMLNode? {
         if let children = _CFXMLNodeGetFirstChild(_xmlNode) {
             return XMLNode._objectNodeForNode(children)
@@ -613,54 +626,58 @@ open class XMLNode: NSObject, NSCopying {
             return nil
         }
     }
-
+    
     /*!
-        @method detach:
-        @abstract Detaches this node from its parent.
-    */
+     @method detach:
+     @abstract Detaches this node from its parent.
+     */
     open func detach() {
         guard let parentPtr = _CFXMLNodeGetParent(_xmlNode) else { return }
         _CFXMLUnlinkNode(_xmlNode)
-
+        
         guard let parentNodePtr = _CFXMLNodeGetPrivateData(parentPtr) else { return }
-
-        let parent: XMLNode = NSObject.unretainedReference(parentNodePtr)
+        
+        let parent = unsafeBitCast(parentNodePtr, to: XMLNode.self)
         parent._childNodes.remove(self)
     }
-
+    
     /*!
-        @method XPath
-        @abstract Returns the XPath to this node, for example foo/bar[2]/baz.
-    */
+     @method XPath
+     @abstract Returns the XPath to this node, for example foo/bar[2]/baz.
+     */
     open var xPath: String? {
         guard _CFXMLNodeGetDocument(_xmlNode) != nil else { return nil }
-
-        return _CFXMLCopyPathForNode(_xmlNode)?._swiftObject
+        
+        let returned = _CFXMLCopyPathForNode(_xmlNode)
+        return returned == nil ? nil : unsafeBitCast(returned!, to: NSString.self) as String
     }
-
+    
     /*!
-    	@method localName
-    	@abstract Returns the local name bar if this attribute or element's name is foo:bar
-    */
+     @method localName
+     @abstract Returns the local name bar if this attribute or element's name is foo:bar
+     */
     open var localName: String? {
-        return _CFXMLNodeCopyLocalName(_xmlNode)?._swiftObject
+        let returned = _CFXMLNodeCopyLocalName(_xmlNode)
+        return returned == nil ? nil : unsafeBitCast(returned!, to: NSString.self) as String
     }
-
+    
     /*!
-    	@method prefix
-    	@abstract Returns the prefix foo if this attribute or element's name if foo:bar
-    */
+     @method prefix
+     @abstract Returns the prefix foo if this attribute or element's name if foo:bar
+     */
     open var prefix: String? {
-        return _CFXMLNodeCopyPrefix(_xmlNode)?._swiftObject
+        let returned = _CFXMLNodeCopyPrefix(_xmlNode)
+        return returned == nil ? nil : unsafeBitCast(returned!, to: NSString.self) as String
     }
-
+    
     /*!
-    	@method URI
-    	@abstract Set the URI of this element, attribute, or document. For documents it is the URI of document origin. Getter returns the URI of this element, attribute, or document. For documents it is the URI of document origin and is automatically set when using initWithContentsOfURL.
-    */
+     @method URI
+     @abstract Set the URI of this element, attribute, or document. For documents it is the URI of document origin. Getter returns the URI of this element, attribute, or document. For documents it is the URI of document origin and is automatically set when using initWithContentsOfURL.
+     */
     open var uri: String? {
         get {
-            return _CFXMLNodeCopyURI(_xmlNode)?._swiftObject
+            let returned = _CFXMLNodeCopyURI(_xmlNode)
+            return returned == nil ? nil : unsafeBitCast(returned!, to: NSString.self) as String
         }
         set {
             if let URI = newValue {
@@ -670,161 +687,161 @@ open class XMLNode: NSObject, NSCopying {
             }
         }
     }
-
+    
     /*!
-        @method localNameForName:
-        @abstract Returns the local name bar in foo:bar.
+     @method localNameForName:
+     @abstract Returns the local name bar in foo:bar.
      */
     open class func localName(forName name: String) -> String {
-//        return name.withCString {
-//            var length: Int32 = 0
-//            let result = xmlSplitQName3(UnsafePointer<xmlChar>($0), &length)
-//            return String.fromCString(UnsafePointer<CChar>(result)) ?? ""
-//        }
+        //        return name.withCString {
+        //            var length: Int32 = 0
+        //            let result = xmlSplitQName3(UnsafePointer<xmlChar>($0), &length)
+        //            return String.fromCString(UnsafePointer<CChar>(result)) ?? ""
+        //        }
         NSUnimplemented()
     }
-
+    
     /*!
-        @method localNameForName:
-        @abstract Returns the prefix foo in the name foo:bar.
-    */
+     @method localNameForName:
+     @abstract Returns the prefix foo in the name foo:bar.
+     */
     open class func prefix(forName name: String) -> String? {
-//        return name.withCString {
-//            var result: UnsafeMutablePointer<xmlChar> = nil
-//            let unused = xmlSplitQName2(UnsafePointer<xmlChar>($0), &result)
-//            defer {
-//                xmlFree(result)
-//                xmlFree(UnsafeMutablePointer<xmlChar>(unused))
-//            }
-//            return String.fromCString(UnsafePointer<CChar>(result))
-//        }
+        //        return name.withCString {
+        //            var result: UnsafeMutablePointer<xmlChar> = nil
+        //            let unused = xmlSplitQName2(UnsafePointer<xmlChar>($0), &result)
+        //            defer {
+        //                xmlFree(result)
+        //                xmlFree(UnsafeMutablePointer<xmlChar>(unused))
+        //            }
+        //            return String.fromCString(UnsafePointer<CChar>(result))
+        //        }
         NSUnimplemented()
     }
-
+    
     /*!
-        @method predefinedNamespaceForPrefix:
-        @abstract Returns the namespace belonging to one of the predefined namespaces xml, xs, or xsi
-    */
+     @method predefinedNamespaceForPrefix:
+     @abstract Returns the namespace belonging to one of the predefined namespaces xml, xs, or xsi
+     */
     open class func predefinedNamespace(forPrefix name: String) -> XMLNode? { NSUnimplemented() }
-
+    
     /*!
-        @method description
-        @abstract Used for debugging. May give more information than XMLString.
-    */
+     @method description
+     @abstract Used for debugging. May give more information than XMLString.
+     */
     open override var description: String {
         return xmlString
     }
-
+    
     /*!
-        @method XMLString
-        @abstract The representation of this node as it would appear in an XML document.
-    */
+     @method XMLString
+     @abstract The representation of this node as it would appear in an XML document.
+     */
     open var xmlString: String {
         return xmlString(options: [])
     }
-
+    
     /*!
-        @method XMLStringWithOptions:
-        @abstract The representation of this node as it would appear in an XML document, with various output options available.
-    */
+     @method XMLStringWithOptions:
+     @abstract The representation of this node as it would appear in an XML document, with various output options available.
+     */
     open func xmlString(options: Options) -> String {
-        return _CFXMLCopyStringWithOptions(_xmlNode, UInt32(options.rawValue))._swiftObject
+        return unsafeBitCast(_CFXMLCopyStringWithOptions(_xmlNode, UInt32(options.rawValue)), to: NSString.self) as String
     }
-
+    
     /*!
-        @method canonicalXMLStringPreservingComments:
-        @abstract W3 canonical form (http://www.w3.org/TR/xml-c14n). The input option NSXMLNodePreserveWhitespace should be set for true canonical form.
-    */
+     @method canonicalXMLStringPreservingComments:
+     @abstract W3 canonical form (http://www.w3.org/TR/xml-c14n). The input option NSXMLNodePreserveWhitespace should be set for true canonical form.
+     */
     open func canonicalXMLStringPreservingComments(_ comments: Bool) -> String { NSUnimplemented() }
-
+    
     /*!
-        @method nodesForXPath:error:
-        @abstract Returns the nodes resulting from applying an XPath to this node using the node as the context item ("."). normalizeAdjacentTextNodesPreservingCDATA:NO should be called if there are adjacent text nodes since they are not allowed under the XPath/XQuery Data Model.
-    	@returns An array whose elements are a kind of NSXMLNode.
-    */
+     @method nodesForXPath:error:
+     @abstract Returns the nodes resulting from applying an XPath to this node using the node as the context item ("."). normalizeAdjacentTextNodesPreservingCDATA:NO should be called if there are adjacent text nodes since they are not allowed under the XPath/XQuery Data Model.
+     @returns An array whose elements are a kind of NSXMLNode.
+     */
     open func nodes(forXPath xpath: String) throws -> [XMLNode] {
         guard let nodes = _CFXMLNodesForXPath(_xmlNode, xpath) else {
             NSUnimplemented()
         }
-
+        
         var result: [XMLNode] = []
         for i in 0..<CFArrayGetCount(nodes) {
             let nodePtr = CFArrayGetValueAtIndex(nodes, i)!
             result.append(XMLNode._objectNodeForNode(_CFXMLNodePtr(mutating: nodePtr)))
         }
-
+        
         return result
     }
-
+    
     /*!
-        @method objectsForXQuery:constants:error:
-        @abstract Returns the objects resulting from applying an XQuery to this node using the node as the context item ("."). Constants are a name-value dictionary for constants declared "external" in the query. normalizeAdjacentTextNodesPreservingCDATA:NO should be called if there are adjacent text nodes since they are not allowed under the XPath/XQuery Data Model.
-    	@returns An array whose elements are kinds of NSArray, NSData, NSDate, NSNumber, NSString, NSURL, or NSXMLNode.
-    */
+     @method objectsForXQuery:constants:error:
+     @abstract Returns the objects resulting from applying an XQuery to this node using the node as the context item ("."). Constants are a name-value dictionary for constants declared "external" in the query. normalizeAdjacentTextNodesPreservingCDATA:NO should be called if there are adjacent text nodes since they are not allowed under the XPath/XQuery Data Model.
+     @returns An array whose elements are kinds of NSArray, NSData, NSDate, NSNumber, NSString, NSURL, or NSXMLNode.
+     */
     open func objects(forXQuery xquery: String, constants: [String : Any]?) throws -> [Any] {
         NSUnimplemented()
     }
-
+    
     open func objects(forXQuery xquery: String) throws -> [Any] {
         NSUnimplemented()
     }
-
+    
     internal var _childNodes: Set<XMLNode> = []
-
+    
     deinit {
         for node in _childNodes {
             node.detach()
         }
-
+        
         _xmlDocument = nil
-
+        
         switch kind {
         case .document:
             _CFXMLFreeDocument(_CFXMLDocPtr(_xmlNode))
-
+            
         case .DTDKind:
             _CFXMLFreeDTD(_CFXMLDTDPtr(_xmlNode))
-
+            
         case .attribute:
             _CFXMLFreeProperty(_xmlNode)
-
+            
         default:
             _CFXMLFreeNode(_xmlNode)
         }
     }
-
+    
     internal init(ptr: _CFXMLNodePtr) {
         precondition(_CFXMLNodeGetPrivateData(ptr) == nil, "Only one XMLNode per xmlNodePtr allowed")
-
+        
         _xmlNode = ptr
         super.init()
-
+        
         if let parent = _CFXMLNodeGetParent(_xmlNode) {
             let parentNode = XMLNode._objectNodeForNode(parent)
             parentNode._childNodes.insert(self)
         }
-
-        withUnretainedReference {
-            _CFXMLNodeSetPrivateData(_xmlNode, $0)
-        }
+        
+        
+        _CFXMLNodeSetPrivateData(_xmlNode, Unmanaged.passRetained(self).toOpaque())
+        
         if let documentPtr = _CFXMLNodeGetDocument(_xmlNode) {
             if documentPtr != ptr {
                 _xmlDocument = XMLDocument._objectNodeForNode(documentPtr)
             }
         }
     }
-
+    
     internal class func _objectNodeForNode(_ node: _CFXMLNodePtr) -> XMLNode {
         switch _CFXMLNodeGetType(node) {
         case _kCFXMLTypeElement:
             return XMLElement._objectNodeForNode(node)
-
+            
         case _kCFXMLTypeDocument:
             return XMLDocument._objectNodeForNode(node)
-
+            
         case _kCFXMLTypeDTD:
             return XMLDTD._objectNodeForNode(node)
-
+            
         case _kCFXMLDTDNodeTypeEntity:
             fallthrough
         case _kCFXMLDTDNodeTypeElement:
@@ -833,16 +850,16 @@ open class XMLNode: NSObject, NSCopying {
             fallthrough
         case _kCFXMLDTDNodeTypeAttribute:
             return XMLDTDNode._objectNodeForNode(node)
-
+            
         default:
             if let _private = _CFXMLNodeGetPrivateData(node) {
-                return XMLNode.unretainedReference(_private)
+                return unsafeBitCast(_private, to: XMLNode.self)
             }
-
+            
             return XMLNode(ptr: node)
         }
     }
-
+    
     // libxml2 believes any node can have children, though XMLNode disagrees.
     // Nevertheless, this belongs here so that XMLElement and XMLDocument can share
     // the same implementation.
@@ -850,9 +867,9 @@ open class XMLNode: NSObject, NSCopying {
         precondition(index >= 0)
         precondition(index <= childCount)
         precondition(child.parent == nil)
-
+        
         _childNodes.insert(child)
-
+        
         if index == 0 {
             let first = _CFXMLNodeGetFirstChild(_xmlNode)!
             _CFXMLNodeAddPrevSibling(first, child._xmlNode)
@@ -861,14 +878,14 @@ open class XMLNode: NSObject, NSCopying {
             _CFXMLNodeAddNextSibling(currChild, child._xmlNode)
         }
     }
-
+    
     // see above
     internal func _insertChildren(_ children: [XMLNode], atIndex index: Int) {
         for (childIndex, node) in children.enumerated() {
             _insertChild(node, atIndex: index + childIndex)
         }
     }
-
+    
     /*!
      @method removeChildAtIndex:atIndex:
      @abstract Removes a child at a particular index.
@@ -878,23 +895,23 @@ open class XMLNode: NSObject, NSCopying {
         guard let child = child(at: index) else {
             fatalError("index out of bounds")
         }
-
+        
         _childNodes.remove(child)
         _CFXMLUnlinkNode(child._xmlNode)
     }
-
+    
     // see above
     internal func _setChildren(_ children: [XMLNode]?) {
         _removeAllChildren()
         guard let children = children else {
             return
         }
-
+        
         for child in children {
             _addChild(child)
         }
     }
-
+    
     /*!
      @method addChild:
      @abstract Adds a child to the end of the existing children.
@@ -902,11 +919,11 @@ open class XMLNode: NSObject, NSCopying {
     // see above
     internal func _addChild(_ child: XMLNode) {
         precondition(child.parent == nil)
-
+        
         _CFXMLNodeAddChild(_xmlNode, child._xmlNode)
         _childNodes.insert(child)
     }
-
+    
     /*!
      @method replaceChildAtIndex:withNode:
      @abstract Replaces a child at a particular index with another child.
@@ -923,25 +940,25 @@ open class XMLNode: NSObject, NSCopying {
 internal protocol _NSXMLNodeCollectionType: Collection { }
 
 extension XMLNode: _NSXMLNodeCollectionType {
-
+    
     public struct Index: Comparable {
         fileprivate let node: _CFXMLNodePtr?
         fileprivate let offset: Int?
     }
-
+    
     public subscript(index: Index) -> XMLNode {
         return XMLNode._objectNodeForNode(index.node!)
     }
-
+    
     public var startIndex: Index {
         let node = _CFXMLNodeGetFirstChild(_xmlNode)
         return Index(node: node, offset: node.map { _ in 0 })
     }
-
+    
     public var endIndex: Index {
         return Index(node: nil, offset: nil)
     }
-
+    
     public func index(after i: Index) -> Index {
         precondition(i.node != nil, "can't increment endIndex")
         let nextNode = _CFXMLNodeGetNextSibling(i.node!)
@@ -953,7 +970,7 @@ extension XMLNode.Index {
     public static func ==(lhs: XMLNode.Index, rhs: XMLNode.Index) -> Bool {
         return lhs.offset == rhs.offset
     }
-
+    
     public static func <(lhs: XMLNode.Index, rhs: XMLNode.Index) -> Bool {
         switch (lhs.offset, rhs.offset) {
         case (nil, nil):

--- a/Foundation/XMLParser.swift
+++ b/Foundation/XMLParser.swift
@@ -384,7 +384,7 @@ internal func _NSXMLParserExternalSubset(_ ctx: _CFXMLInterface, name: UnsafePoi
 
 internal func _structuredErrorFunc(_ interface: _CFXMLInterface, error: _CFXMLInterfaceError) {
     let cferr = _CFErrorCreateFromXMLInterface(error)
-    let err = _CFErrorSPIForFoundationXMLUseOnly(cferr)._nsObject
+    let err = _CFErrorSPIForFoundationXMLUseOnly(unsafelyAssumingIsCFError: cferr)._nsObject
     let parser = interface.parser
     parser._parserError = err
     if let delegate = parser.delegate {

--- a/Foundation/XMLParser.swift
+++ b/Foundation/XMLParser.swift
@@ -7,7 +7,13 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import SwiftFoundation
+#else
+import Foundation
+#endif
 import CoreFoundation
+import CFXMLInterface
 
 extension XMLParser {
     public enum ExternalEntityResolvingPolicy : UInt {
@@ -377,7 +383,8 @@ internal func _NSXMLParserExternalSubset(_ ctx: _CFXMLInterface, name: UnsafePoi
 }
 
 internal func _structuredErrorFunc(_ interface: _CFXMLInterface, error: _CFXMLInterfaceError) {
-    let err = _CFErrorCreateFromXMLInterface(error)._nsObject
+    let cferr = _CFErrorCreateFromXMLInterface(error)
+    let err = _CFErrorSPIForFoundationXMLUseOnly(cferr)._nsObject
     let parser = interface.parser
     parser._parserError = err
     if let delegate = parser.delegate {
@@ -421,7 +428,7 @@ open class XMLParser : NSObject {
     
     // create the parser from data
     public init(data: Data) {
-        _CFSetupXMLInterface()
+        setupXMLParsing()
         _data = data
         _handler = _CFXMLInterfaceCreateSAXHandler()
         _parserContext = nil
@@ -434,7 +441,7 @@ open class XMLParser : NSObject {
     
     //create a parser that incrementally pulls data from the specified stream and parses it.
     public init(stream: InputStream) {
-        _CFSetupXMLInterface()
+        setupXMLParsing()
         _stream = stream
         _handler = _CFXMLInterfaceCreateSAXHandler()
         _parserContext = nil
@@ -945,5 +952,51 @@ extension XMLParser {
         case noDTDError
         
         case delegateAbortedParseError
+    }
+}
+
+internal func NSUnimplemented(_ fn: String = #function, file: StaticString = #file, line: UInt = #line) -> Never {
+    #if os(Android)
+    NSLog("\(fn) is not yet implemented. \(file):\(line)")
+    #endif
+    fatalError("\(fn) is not yet implemented", file: file, line: line)
+}
+
+extension NSObject {
+    func withUnretainedReference<T, R>(_ work: (UnsafePointer<T>) -> R) -> R {
+        let selfPtr = Unmanaged.passUnretained(self).toOpaque().assumingMemoryBound(to: T.self)
+        return work(selfPtr)
+    }
+    
+    func withOpaqueUnretainedReference<R>(_ work: (UnsafeMutableRawPointer) -> R) -> R {
+        let selfPtr = Unmanaged.passUnretained(self).toOpaque()
+        return work(selfPtr)
+    }
+}
+
+func setupXMLParsing() {
+    _CFSetupXMLInterface()
+    _CFSetupXMLBridgeIfNeededUsingBlock {
+        __CFSwiftXMLParserBridge.currentParser = _NSXMLParserCurrentParser
+        __CFSwiftXMLParserBridge._xmlExternalEntityWithURL = _NSXMLParserExternalEntityWithURL
+        __CFSwiftXMLParserBridge.getContext = _NSXMLParserGetContext
+        __CFSwiftXMLParserBridge.internalSubset = _NSXMLParserInternalSubset
+        __CFSwiftXMLParserBridge.isStandalone = _NSXMLParserIsStandalone
+        __CFSwiftXMLParserBridge.hasInternalSubset = _NSXMLParserHasInternalSubset
+        __CFSwiftXMLParserBridge.hasExternalSubset = _NSXMLParserHasExternalSubset
+        __CFSwiftXMLParserBridge.getEntity = _NSXMLParserGetEntity
+        __CFSwiftXMLParserBridge.notationDecl = _NSXMLParserNotationDecl
+        __CFSwiftXMLParserBridge.attributeDecl = _NSXMLParserAttributeDecl
+        __CFSwiftXMLParserBridge.elementDecl = _NSXMLParserElementDecl
+        __CFSwiftXMLParserBridge.unparsedEntityDecl = _NSXMLParserUnparsedEntityDecl
+        __CFSwiftXMLParserBridge.startDocument = _NSXMLParserStartDocument
+        __CFSwiftXMLParserBridge.endDocument = _NSXMLParserEndDocument
+        __CFSwiftXMLParserBridge.startElementNs = _NSXMLParserStartElementNs
+        __CFSwiftXMLParserBridge.endElementNs = _NSXMLParserEndElementNs
+        __CFSwiftXMLParserBridge.characters = _NSXMLParserCharacters
+        __CFSwiftXMLParserBridge.processingInstruction = _NSXMLParserProcessingInstruction
+        __CFSwiftXMLParserBridge.cdataBlock = _NSXMLParserCdataBlock
+        __CFSwiftXMLParserBridge.comment = _NSXMLParserComment
+        __CFSwiftXMLParserBridge.externalSubset = _NSXMLParserExternalSubset
     }
 }

--- a/TestFoundation/TestImports.swift
+++ b/TestFoundation/TestImports.swift
@@ -9,14 +9,18 @@
 
 // Centralized conditional imports for all test sources
 
-#if !DEPLOYMENT_RUNTIME_OBJC && canImport(SwiftFoundation) && canImport(SwiftFoundationNetworking) && canImport(SwiftXCTest) 
+#if !DEPLOYMENT_RUNTIME_OBJC && canImport(SwiftFoundation) && canImport(SwiftFoundationNetworking) && canImport(SwiftFoundationXML) && canImport(SwiftXCTest) 
 @_exported import SwiftFoundation
 @_exported import SwiftFoundationNetworking
+@_exported import SwiftFoundationXML
 @_exported import SwiftXCTest
 #else
 @_exported import Foundation
 #if canImport(FoundationNetworking)
 @_exported import FoundationNetworking
+#endif
+#if canImport(FoundationXML)
+@_exported import FoundationXML
 #endif
 @_exported import XCTest
 #endif

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -7,9 +7,10 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if !DEPLOYMENT_RUNTIME_OBJC && canImport(SwiftFoundation) && canImport(SwiftFoundationNetworking)
+#if !DEPLOYMENT_RUNTIME_OBJC && canImport(SwiftFoundation) && canImport(SwiftFoundationNetworking) && canImport(SwiftFoundationXML)
 import SwiftFoundation
 import SwiftFoundationNetworking
+import SwiftFoundationXML
 #else
 import Foundation
 #if canImport(FoundationNetworking)


### PR DESCRIPTION
Split the portions of Foundation that depend on libxml2 into their own module, `FoundationXML`. This is the last module to be split off.