### PR TITLE
Link correctly to zlib when using cURL statically.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ option(FOUNDATION_PATH_TO_LIBDISPATCH_SOURCE "Path to libdispatch source" "")
 option(FOUNDATION_PATH_TO_LIBDISPATCH_BUILD "Path to libdispatch build" "")
 option(FOUNDATION_PATH_TO_XCTEST_BUILD "Path to XCTest build" "")
 
-find_package(CURL REQUIRED)
+find_package(CURL COMPONENTS libz REQUIRED)
 find_package(ICU COMPONENTS uc i18n REQUIRED)
 find_package(LibXml2 REQUIRED)
 
@@ -123,6 +123,12 @@ foreach(library ${CoreFoundation_LINK_LIBRARIES})
     list(APPEND CFURLSessionInterface_LIBRARIES -l${library})
   endif()
 endforeach()
+
+if (CURL_LIBRARIES MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
+  set(CURL_LINK_FLAGS ${CURL_LIBRARIES} ${CMAKE_LINK_LIBRARY_FLAG}z)
+else()
+  set(CURL_LINK_FLAGS ${CURL_LIBRARIES})
+endif()
 
 add_swift_library(Foundation
                   MODULE_NAME
@@ -275,7 +281,6 @@ add_swift_library(Foundation
                   LINK_FLAGS
                     ${CoreFoundation_LIBRARIES}
                     ${ICU_UC_LIBRARY} ${ICU_I18N_LIBRARY}
-                    ${LIBXML2_LIBRARIES}
                     ${libdispatch_ldflags}
                     $<TARGET_FILE:uuid>
                     ${Foundation_RPATH}
@@ -344,7 +349,7 @@ add_swift_library(FoundationNetworking
                     -lFoundation
                     ${Foundation_INTERFACE_LIBRARIES}
                     ${CFURLSessionInterface_LIBRARIES}
-                    ${CURL_LIBRARIES}
+                    ${CURL_LINK_FLAGS}
                     ${Foundation_RPATH}
                     ${WORKAROUND_SR9138}
                     ${WORKAROUND_SR9995}
@@ -371,7 +376,6 @@ if(NOT BUILD_SHARED_LIBS)
       -lCoreFoundation
       -L${CMAKE_CURRENT_BINARY_DIR}
       -luuid
-      ${CURL_LIBRARIES}
       ${ICU_UC_LIBRARY}
       ${ICU_I18N_LIBRARY}
       ${LIBXML2_LIBRARIES})

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -421,7 +421,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_include_directories(CoreFoundation
                              PRIVATE
                                ${LIBXML2_INCLUDE_DIR})
-  find_package(CURL REQUIRED)
+  find_package(CURL COMPONENTS libz REQUIRED)
   target_include_directories(CFURLSessionInterface
                              PRIVATE
                                ${CURL_INCLUDE_DIRS})


### PR DESCRIPTION
Since we are not using target_link_libraries, it seems that CMake is not
automatically linking to the cURL dependencies when cURL is compiled
statically. This will mean that libFoundationNetworking might have
undefined symbols and cannot be used.

Since the tests check for a gzipped request/response and no modern
client should not support gzipped responses, the find_package calls
require the zlib component for cURL. Additionally, in the case of being
a static library, libz is linked in the cURL dependencies.

The cURL libraries are also removed as interface dependencies of
Foundation, since the only library that depends on cURL is
FoundationNetworking.

There's also a little bit of movement around LIBXML2_LIBRARIES since
they are suppose to come from CoreFoundation_LIBRARIES, so no need to
repeat them.

@compnerd: Let's review if this will work on Windows. I have to figure out if cURL in Windows is built with support for zlib, and how it supposed to be linked. This should fix the problem with the Azure Android SDKs where libFoundationNetworking.so is normally unusable.