### PR TITLE
build: correct invocation of `cmake_policy`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND CMAKE_MODULE_PATH
 # NOTE(compnerd) enable CMP0091 - select MSVC runtime based on
 # CMAKE_MSVC_RUNTIME_LIBRARY.  Requires CMake 3.15 or newer
 if(POLICY CMP0091)
-  cmake_policy(CMP0091 NEW)
+  cmake_policy(SET CMP0091 NEW)
 endif()
 
 project(Foundation


### PR DESCRIPTION
The first parameter needs to be either `SET` or `GET`.  In this case, we
are trying to set the policy to NEW, so pass the correct parameter.