### PR TITLE
Make Host NSUnimplemented for Android

### DIFF
--- a/Foundation/Host.swift
+++ b/Foundation/Host.swift
@@ -140,6 +140,11 @@ open class Host: NSObject {
           pAdapter = pAdapter!.pointee.Next
         }
         _resolved = true
+#elseif os(Android)
+        // Android 5.0 doesn't contain an implementation of `getifaddrs`
+        // and therefore crashes when trying to load libFoundation.so.
+        // The existing code, below, may work on higher Android versions.
+        NSUnimplemented()
 #else
         var ifaddr: UnsafeMutablePointer<ifaddrs>? = nil
         if getifaddrs(&ifaddr) != 0 {


### PR DESCRIPTION
It is currently impossible to load Foundation on Android 5.0 because `getifaddrs` is not available there.

In the absence of `#if available(Android 24, *)` (which would be the ideal solution here), we need to avoid compiling any mention of `getifaddrs`, which is what this PR aims to achieve.