### PR TITLE
Use GetThreadId instead of Storing Handles Directly

### DIFF
--- a/CoreFoundation/RunLoop.subproj/CFRunLoop.c
+++ b/CoreFoundation/RunLoop.subproj/CFRunLoop.c
@@ -153,7 +153,7 @@ static void _runLoopTimerWithBlockContext(CFRunLoopTimerRef timer, void *opaqueB
 #if TARGET_OS_WIN32
 
 static _CFThreadRef const kNilPthreadT = INVALID_HANDLE_VALUE;
-#define pthreadPointer(a) a
+#define pthreadPointer(a) (GetThreadId(a))
 typedef	int kern_return_t;
 #define KERN_SUCCESS 0
 


### PR DESCRIPTION
CoreFoundation keeps a Dictionary of threads to their runloops. On
Windows, it previously used the threads' Handle as keys into the
dictionary. However, this doesn't work, as if you are attempting to look
up or set the current thread's RunLoop using GetCurrentThread.
GetCurrentThread returns a psuedo handle (FFFFFFFE) rather than a real
handle to a thread which causes it to index incorrectly into the
dictionary.

This was causing the creation of multiple runloops per thread and then
causing dispatch queues not to be pumped leaving blocks to never be run.

The fix here is to use the thread id instead of a handle which is unique
on the system until the thread terminates.