### PR TITLE
Handle Windows Errors in FileHandle Tests

### DIFF
--- a/TestFoundation/TestFileHandle.swift
+++ b/TestFoundation/TestFileHandle.swift
@@ -145,7 +145,11 @@ class TestFileHandle : XCTestCase {
         return fh
     }
     
+#if os(Windows)
+    let readError = NSError(domain: NSCocoaErrorDomain, code: NSFileReadUnknownError, userInfo: [ NSUnderlyingErrorKey: NSError(domain: "org.swift.Foundation.WindowsError", code: 1, userInfo: [:])])
+#else
     let readError = NSError(domain: NSCocoaErrorDomain, code: NSFileReadUnknownError, userInfo: [ NSUnderlyingErrorKey: NSError(domain: NSPOSIXErrorDomain, code: Int(EISDIR), userInfo: [:])])
+#endif
     
     override func tearDown() {
         for handle in allHandles {
@@ -463,7 +467,11 @@ class TestFileHandle : XCTestCase {
             }
             
             XCTAssertNil(notification.userInfo?[NSFileHandleNotificationDataItem])
+#if os(Windows)
+            XCTAssertEqual(error, NSNumber(value: ERROR_DIRECTORY_NOT_SUPPORTED))
+#else
             XCTAssertEqual(error, NSNumber(value: EISDIR))
+#endif
             return true
         }
         


### PR DESCRIPTION
- Errors on Windows are in the WindowsError domain
- When a file handle for a directory is attemptted to be read, instead
of `ERROR_ACCESS_DENIED` as triggered by windows, intercept it and
return `ERROR_DIRECTORY_NOT_SUPPORTED` to emulate POSIX's `EISDIR`
instead.