### PR TITLE
Parity: NSDictionary: _CFSwiftDictionaryContainsValue

### DIFF
--- a/Foundation/NSCFDictionary.swift
+++ b/Foundation/NSCFDictionary.swift
@@ -147,7 +147,11 @@ internal func _CFSwiftDictionaryGetCountOfValue(_ dictionary: AnyObject, value: 
 }
 
 internal func _CFSwiftDictionaryContainsValue(_ dictionary: AnyObject, value: AnyObject) -> Bool {
-    NSUnimplemented()
+    if let value = value as? AnyHashable {
+        return (dictionary as! NSDictionary).allValues.lazy.compactMap { $0 as? AnyHashable }.contains(value)
+    } else {
+        return false
+    }
 }
 
 // HAZARD! WARNING!


### PR DESCRIPTION
Correctly bridge this call to make`CFDictionaryContainsValue(…)` work. Fixes https://bugs.swift.org/browse/SR-10394