### PR TITLE
Consistently add #error when compiling on unsupported architectures.

### DIFF
--- a/Foundation/CGFloat.swift
+++ b/Foundation/CGFloat.swift
@@ -17,6 +17,8 @@ public struct CGFloat {
     /// The native type used to store the CGFloat, which is Float on
     /// 32-bit architectures and Double on 64-bit architectures.
     public typealias NativeType = Double
+#else
+    #error("This architecture isn't known. Add it to the 32-bit or 64-bit line.")
 #endif
     
     @_transparent public init() {
@@ -187,6 +189,8 @@ extension CGFloat : BinaryFloatingPoint {
         native = NativeType(bitPattern: UInt32(bitPattern))
 #elseif arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
         native = NativeType(bitPattern: UInt64(bitPattern))
+#else
+    #error("This architecture isn't known. Add it to the 32-bit or 64-bit line.")
 #endif
     }
 

--- a/Foundation/Data.swift
+++ b/Foundation/Data.swift
@@ -661,6 +661,8 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         @usableFromInline typealias Buffer = (UInt8, UInt8, UInt8, UInt8,
                                               UInt8, UInt8) //len  //enum
         @usableFromInline var bytes: Buffer
+#else
+    #error("This architecture isn't known. Add it to the 32-bit or 64-bit line.")
 #endif
         @usableFromInline var length: UInt8
 
@@ -686,6 +688,8 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             bytes = (UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0))
 #elseif arch(i386) || arch(arm)
             bytes = (UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0))
+#else
+    #error("This architecture isn't known. Add it to the 32-bit or 64-bit line.")
 #endif
             length = UInt8(count)
         }
@@ -867,6 +871,8 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     @usableFromInline internal typealias HalfInt = Int32
 #elseif arch(i386) || arch(arm)
     @usableFromInline internal typealias HalfInt = Int16
+#else
+    #error("This architecture isn't known. Add it to the 32-bit or 64-bit line.")
 #endif
 
     // A buffer of bytes too large to fit in an InlineData, but still small enough to fit a storage pointer + range in two words.

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -718,6 +718,8 @@ open class NSNumber : NSValue {
             self.init(bytes: &value, numberType: kCFNumberSInt64Type)
         #elseif arch(i386) || arch(arm)
             self.init(bytes: &value, numberType: kCFNumberSInt32Type)
+        #else
+            #error("This architecture isn't known. Add it to the 32-bit or 64-bit line.")
         #endif
     }
     
@@ -733,6 +735,8 @@ open class NSNumber : NSValue {
     #elseif arch(i386) || arch(arm)
         var value = Int64(value)
         self.init(bytes: &value, numberType: kCFNumberSInt64Type)
+    #else
+        #error("This architecture isn't known. Add it to the 32-bit or 64-bit line.")
     #endif
     }
     

--- a/Foundation/NSRange.swift
+++ b/Foundation/NSRange.swift
@@ -384,7 +384,7 @@ extension NSRange: NSSpecialValueCoding {
 #elseif arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
         return "{_NSRange=QQ}"
 #else
-        NSUnimplemented()
+        #error("This architecture isn't known. Add it to the 32-bit or 64-bit line.")
 #endif
     }
     

--- a/TestFoundation/TestNSNumber.swift
+++ b/TestFoundation/TestNSNumber.swift
@@ -1230,6 +1230,8 @@ class TestNSNumber : XCTestCase {
             XCTAssertEqual("i" /* 0x71 */, objCType(NSNumber(value: Int.max)))
             XCTAssertEqual("q" /* 0x71 */, objCType(NSNumber(value: UInt(Int.max))))
             XCTAssertEqual("q" /* 0x51 */, objCType(NSNumber(value: UInt(Int.max) + 1)))
+        #else
+            #error("This architecture isn't known. Add it to the 32-bit or 64-bit line.")
         #endif
 
         XCTAssertEqual("f" /* 0x66 */, objCType(NSNumber(value: Float.greatestFiniteMagnitude)))


### PR DESCRIPTION
- #if arch() guard blocks are used for per architecture code paths, so
  for unsupported architectures add an #else/#error message to ensure
  the correct path is added.

- This fixes some initializers that may have otherwise been empty.

- Ignore blocks with just one architecture as this is usually a specific
  targeted fix.

I think the message is correct for all cases but can be changed if necessary.