### PR TITLE
Fix crash that occurs when attempting to retrieve the name property of an XMLDocument by making it return nil.

### DIFF
--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -470,7 +470,7 @@ void _CFXMLNodeSetPrivateData(_CFXMLNodePtr node, void* data) {
     if (!node) {
         return;
     }
-	((xmlNodePtr)node)->_private = data;
+    ((xmlNodePtr)node)->_private = data;
 }
 
 void* _Nullable  _CFXMLNodeGetPrivateData(_CFXMLNodePtr node) {

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -467,9 +467,10 @@ void _CFXMLNodeSetURI(_CFXMLNodePtr node, const unsigned char* URI) {
 }
 
 void _CFXMLNodeSetPrivateData(_CFXMLNodePtr node, void* data) {
-    if (node) {
-        ((xmlNodePtr)node)->_private = data;
+    if (!node) {
+        return;
     }
+	((xmlNodePtr)node)->_private = data;
 }
 
 void* _Nullable  _CFXMLNodeGetPrivateData(_CFXMLNodePtr node) {

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -450,7 +450,7 @@ void _CFXMLNodeSetURI(_CFXMLNodePtr node, const unsigned char* URI) {
             }
 
             xmlSetNs(nodePtr, ns);
-            return;
+            break;
 
         case XML_DOCUMENT_NODE:
         {
@@ -459,7 +459,7 @@ void _CFXMLNodeSetURI(_CFXMLNodePtr node, const unsigned char* URI) {
                 xmlFree((xmlChar*)doc->URL);
             }
             doc->URL = xmlStrdup(URI);
-            return;
+            break;
         }
         default:
             return;

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -450,7 +450,7 @@ void _CFXMLNodeSetURI(_CFXMLNodePtr node, const unsigned char* URI) {
             }
 
             xmlSetNs(nodePtr, ns);
-            break;
+            return;
 
         case XML_DOCUMENT_NODE:
         {
@@ -459,9 +459,8 @@ void _CFXMLNodeSetURI(_CFXMLNodePtr node, const unsigned char* URI) {
                 xmlFree((xmlChar*)doc->URL);
             }
             doc->URL = xmlStrdup(URI);
+            return;
         }
-            break;
-
         default:
             return;
     }
@@ -469,10 +468,8 @@ void _CFXMLNodeSetURI(_CFXMLNodePtr node, const unsigned char* URI) {
 
 void _CFXMLNodeSetPrivateData(_CFXMLNodePtr node, void* data) {
     if (!node) {
-        return;
+        ((xmlNodePtr)node)->_private = data;
     }
-    
-    ((xmlNodePtr)node)->_private = data;
 }
 
 void* _Nullable  _CFXMLNodeGetPrivateData(_CFXMLNodePtr node) {
@@ -484,10 +481,10 @@ _CFXMLNodePtr _CFXMLNodeProperties(_CFXMLNodePtr node) {
 }
 
 CFIndex _CFXMLNodeGetType(_CFXMLNodePtr node) {
-    if (!node) {
-        return _kCFXMLTypeInvalid;
+    if (node) {
+        return ((xmlNodePtr)node)->type;
     }
-    return ((xmlNodePtr)node)->type;
+    return _kCFXMLTypeInvalid; 
 }
 
 static inline xmlChar* _getQName(xmlNodePtr node) {
@@ -495,6 +492,7 @@ static inline xmlChar* _getQName(xmlNodePtr node) {
     const xmlChar* ncname = node->name;
     
     switch (node->type) {
+        case XML_DOCUMENT_NODE:
         case XML_NOTATION_NODE:
         case XML_DTD_NODE:
         case XML_ELEMENT_DECL:

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -467,7 +467,7 @@ void _CFXMLNodeSetURI(_CFXMLNodePtr node, const unsigned char* URI) {
 }
 
 void _CFXMLNodeSetPrivateData(_CFXMLNodePtr node, void* data) {
-    if (!node) {
+    if (node) {
         ((xmlNodePtr)node)->_private = data;
     }
 }

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -459,8 +459,9 @@ void _CFXMLNodeSetURI(_CFXMLNodePtr node, const unsigned char* URI) {
                 xmlFree((xmlChar*)doc->URL);
             }
             doc->URL = xmlStrdup(URI);
-            break;
         }
+            break;
+
         default:
             return;
     }

--- a/CoreFoundation/Stream.subproj/CFSocketStream.c
+++ b/CoreFoundation/Stream.subproj/CFSocketStream.c
@@ -209,7 +209,7 @@ CF_PRIVATE CFStreamError _CFStreamErrorFromError(CFErrorRef error) {
     } else if (CFEqual(domain, kCFErrorDomainOSStatus)) {
         result.domain = kCFStreamErrorDomainMacOSStatus;
     } else if (CFEqual(domain, kCFErrorDomainMach)) {
-         result.domain = 11; // kCFStreamErrorDomainMach, but that symbol is in CFNetwork
+        result.domain = 11; // kCFStreamErrorDomainMach, but that symbol is in CFNetwork
     } else {
         result.domain = kCFStreamErrorDomainCustom;
     }
@@ -242,5 +242,4 @@ CF_PRIVATE CFErrorRef _CFErrorFromStreamError(CFAllocatorRef alloc, CFStreamErro
     CFRelease(value);
     CFRelease(dict);
     return result;
-    }
 }

--- a/CoreFoundation/Stream.subproj/CFSocketStream.c
+++ b/CoreFoundation/Stream.subproj/CFSocketStream.c
@@ -226,7 +226,6 @@ CF_PRIVATE CFErrorRef _CFErrorFromStreamError(CFAllocatorRef alloc, CFStreamErro
     canUpCall = (CFNetworkSupport._CFErrorCreateWithStreamError != NULL);
     __CFUnlock(&(CFNetworkSupport.lock));
 
-    
     if (canUpCall) {
         result = CFNETWORK_CALL(_CFErrorCreateWithStreamError, (alloc, streamError));
     } else {

--- a/CoreFoundation/Stream.subproj/CFSocketStream.c
+++ b/CoreFoundation/Stream.subproj/CFSocketStream.c
@@ -215,6 +215,7 @@ CF_PRIVATE CFStreamError _CFStreamErrorFromError(CFErrorRef error) {
     }
     result.error = CFErrorGetCode(error);
     return result;
+    
 }
 
 CF_PRIVATE CFErrorRef _CFErrorFromStreamError(CFAllocatorRef alloc, CFStreamError *streamError) {

--- a/CoreFoundation/Stream.subproj/CFSocketStream.c
+++ b/CoreFoundation/Stream.subproj/CFSocketStream.c
@@ -209,7 +209,7 @@ CF_PRIVATE CFStreamError _CFStreamErrorFromError(CFErrorRef error) {
     } else if (CFEqual(domain, kCFErrorDomainOSStatus)) {
         result.domain = kCFStreamErrorDomainMacOSStatus;
     } else if (CFEqual(domain, kCFErrorDomainMach)) {
-        result.domain = 11; // kCFStreamErrorDomainMach, but that symbol is in CFNetwork
+         result.domain = 11; // kCFStreamErrorDomainMach, but that symbol is in CFNetwork
     } else {
         result.domain = kCFStreamErrorDomainCustom;
     }
@@ -242,4 +242,5 @@ CF_PRIVATE CFErrorRef _CFErrorFromStreamError(CFAllocatorRef alloc, CFStreamErro
     CFRelease(value);
     CFRelease(dict);
     return result;
+    }
 }

--- a/CoreFoundation/Stream.subproj/CFSocketStream.c
+++ b/CoreFoundation/Stream.subproj/CFSocketStream.c
@@ -201,7 +201,7 @@ CF_PRIVATE CFStreamError _CFStreamErrorFromError(CFErrorRef error) {
     if (canUpCall) {
         return CFNETWORK_CALL(_CFStreamErrorFromCFError, (error));
     } 
-    
+
     CFStreamError result;
     CFStringRef domain = CFErrorGetDomain(error); 
     if (CFEqual(domain, kCFErrorDomainPOSIX)) {
@@ -243,6 +243,5 @@ CF_PRIVATE CFErrorRef _CFErrorFromStreamError(CFAllocatorRef alloc, CFStreamErro
     CFRelease(value);
     CFRelease(dict);
     return result;
-        
     }
 }

--- a/CoreFoundation/Stream.subproj/CFSocketStream.c
+++ b/CoreFoundation/Stream.subproj/CFSocketStream.c
@@ -215,7 +215,6 @@ CF_PRIVATE CFStreamError _CFStreamErrorFromError(CFErrorRef error) {
     }
     result.error = CFErrorGetCode(error);
     return result;
-    
 }
 
 CF_PRIVATE CFErrorRef _CFErrorFromStreamError(CFAllocatorRef alloc, CFStreamError *streamError) {

--- a/CoreFoundation/Stream.subproj/CFSocketStream.c
+++ b/CoreFoundation/Stream.subproj/CFSocketStream.c
@@ -220,19 +220,20 @@ CF_PRIVATE CFStreamError _CFStreamErrorFromError(CFErrorRef error) {
 CF_PRIVATE CFErrorRef _CFErrorFromStreamError(CFAllocatorRef alloc, CFStreamError *streamError) {
     CFErrorRef result;
     Boolean canUpCall;
-    
+
     __CFLock(&(CFNetworkSupport.lock));
     if (!__CFBitIsSet(CFNetworkSupport.flags, kTriedToLoad)) initializeCFNetworkSupport();
     canUpCall = (CFNetworkSupport._CFErrorCreateWithStreamError != NULL);
     __CFUnlock(&(CFNetworkSupport.lock));
 
+    
     if (canUpCall) {
         result = CFNETWORK_CALL(_CFErrorCreateWithStreamError, (alloc, streamError));
     } else {
         if (streamError->domain == kCFStreamErrorDomainPOSIX) {
-            return CFErrorCreate(alloc, kCFErrorDomainPOSIX, streamError->error, NULL);
+            result = CFErrorCreate(alloc, kCFErrorDomainPOSIX, streamError->error, NULL);
         } else if (streamError->domain == kCFStreamErrorDomainMacOSStatus) {
-            return CFErrorCreate(alloc, kCFErrorDomainOSStatus, streamError->error, NULL);
+            result = CFErrorCreate(alloc, kCFErrorDomainOSStatus, streamError->error, NULL);
         } else {
             CFStringRef key = CFSTR("CFStreamErrorDomainKey");
             CFNumberRef value = CFNumberCreate(alloc, kCFNumberCFIndexType, &streamError->domain);

--- a/CoreFoundation/Stream.subproj/CFSocketStream.c
+++ b/CoreFoundation/Stream.subproj/CFSocketStream.c
@@ -226,6 +226,7 @@ CF_PRIVATE CFErrorRef _CFErrorFromStreamError(CFAllocatorRef alloc, CFStreamErro
     canUpCall = (CFNetworkSupport._CFErrorCreateWithStreamError != NULL);
     __CFUnlock(&(CFNetworkSupport.lock));
 
+    
     if (canUpCall) {
         result = CFNETWORK_CALL(_CFErrorCreateWithStreamError, (alloc, streamError));
     } else {

--- a/CoreFoundation/Stream.subproj/CFSocketStream.c
+++ b/CoreFoundation/Stream.subproj/CFSocketStream.c
@@ -220,20 +220,19 @@ CF_PRIVATE CFStreamError _CFStreamErrorFromError(CFErrorRef error) {
 CF_PRIVATE CFErrorRef _CFErrorFromStreamError(CFAllocatorRef alloc, CFStreamError *streamError) {
     CFErrorRef result;
     Boolean canUpCall;
-
+    
     __CFLock(&(CFNetworkSupport.lock));
     if (!__CFBitIsSet(CFNetworkSupport.flags, kTriedToLoad)) initializeCFNetworkSupport();
     canUpCall = (CFNetworkSupport._CFErrorCreateWithStreamError != NULL);
     __CFUnlock(&(CFNetworkSupport.lock));
 
-    
     if (canUpCall) {
         result = CFNETWORK_CALL(_CFErrorCreateWithStreamError, (alloc, streamError));
     } else {
         if (streamError->domain == kCFStreamErrorDomainPOSIX) {
-            result = CFErrorCreate(alloc, kCFErrorDomainPOSIX, streamError->error, NULL);
+            return CFErrorCreate(alloc, kCFErrorDomainPOSIX, streamError->error, NULL);
         } else if (streamError->domain == kCFStreamErrorDomainMacOSStatus) {
-            result = CFErrorCreate(alloc, kCFErrorDomainOSStatus, streamError->error, NULL);
+            return CFErrorCreate(alloc, kCFErrorDomainOSStatus, streamError->error, NULL);
         } else {
             CFStringRef key = CFSTR("CFStreamErrorDomainKey");
             CFNumberRef value = CFNumberCreate(alloc, kCFNumberCFIndexType, &streamError->domain);

--- a/CoreFoundation/Stream.subproj/CFSocketStream.c
+++ b/CoreFoundation/Stream.subproj/CFSocketStream.c
@@ -201,7 +201,7 @@ CF_PRIVATE CFStreamError _CFStreamErrorFromError(CFErrorRef error) {
     if (canUpCall) {
         return CFNETWORK_CALL(_CFStreamErrorFromCFError, (error));
     } 
-
+    
     CFStreamError result;
     CFStringRef domain = CFErrorGetDomain(error); 
     if (CFEqual(domain, kCFErrorDomainPOSIX)) {
@@ -243,5 +243,6 @@ CF_PRIVATE CFErrorRef _CFErrorFromStreamError(CFAllocatorRef alloc, CFStreamErro
     CFRelease(value);
     CFRelease(dict);
     return result;
+        
     }
 }

--- a/CoreFoundation/Stream.subproj/CFSocketStream.c
+++ b/CoreFoundation/Stream.subproj/CFSocketStream.c
@@ -200,21 +200,22 @@ CF_PRIVATE CFStreamError _CFStreamErrorFromError(CFErrorRef error) {
 
     if (canUpCall) {
         return CFNETWORK_CALL(_CFStreamErrorFromCFError, (error));
+    } 
+    
+    CFStreamError result;
+    CFStringRef domain = CFErrorGetDomain(error); 
+    if (CFEqual(domain, kCFErrorDomainPOSIX)) {
+        result.domain = kCFStreamErrorDomainPOSIX;
+    } else if (CFEqual(domain, kCFErrorDomainOSStatus)) {
+        result.domain = kCFStreamErrorDomainMacOSStatus;
+    } else if (CFEqual(domain, kCFErrorDomainMach)) {
+         result.domain = 11; // kCFStreamErrorDomainMach, but that symbol is in CFNetwork
     } else {
-        CFStreamError result;
-        CFStringRef domain = CFErrorGetDomain(error); 
-        if (CFEqual(domain, kCFErrorDomainPOSIX)) {
-            result.domain = kCFStreamErrorDomainPOSIX;
-        } else if (CFEqual(domain, kCFErrorDomainOSStatus)) {
-            result.domain = kCFStreamErrorDomainMacOSStatus;
-        } else if (CFEqual(domain, kCFErrorDomainMach)) {
-            result.domain = 11; // kCFStreamErrorDomainMach, but that symbol is in CFNetwork
-        } else {
-            result.domain = kCFStreamErrorDomainCustom;
-        }
-        result.error = CFErrorGetCode(error);
-        return result;
+        result.domain = kCFStreamErrorDomainCustom;
     }
+    result.error = CFErrorGetCode(error);
+    return result;
+    
 }
 
 CF_PRIVATE CFErrorRef _CFErrorFromStreamError(CFAllocatorRef alloc, CFStreamError *streamError) {
@@ -227,19 +228,21 @@ CF_PRIVATE CFErrorRef _CFErrorFromStreamError(CFAllocatorRef alloc, CFStreamErro
 
     if (canUpCall) {
         return CFNETWORK_CALL(_CFErrorCreateWithStreamError, (alloc, streamError));
-    } else {
-        if (streamError->domain == kCFStreamErrorDomainPOSIX) {
-            return CFErrorCreate(alloc, kCFErrorDomainPOSIX, streamError->error, NULL);
-        } else if (streamError->domain == kCFStreamErrorDomainMacOSStatus) {
-            return CFErrorCreate(alloc, kCFErrorDomainOSStatus, streamError->error, NULL);
-        } else {
-            CFStringRef key = CFSTR("CFStreamErrorDomainKey");
-            CFNumberRef value = CFNumberCreate(alloc, kCFNumberCFIndexType, &streamError->domain);
-            CFDictionaryRef dict = CFDictionaryCreate(alloc, (const void **)(&key), (const void **)(&value), 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-            CFErrorRef result = CFErrorCreate(alloc, CFSTR("BogusCFStreamErrorCompatibilityDomain"), streamError->error, dict);
-            CFRelease(value);
-            CFRelease(dict);
-            return result;
-        }
+    }
+    if (streamError->domain == kCFStreamErrorDomainPOSIX) {
+        return CFErrorCreate(alloc, kCFErrorDomainPOSIX, streamError->error, NULL);
+    }
+    if (streamError->domain == kCFStreamErrorDomainMacOSStatus) {
+        return CFErrorCreate(alloc, kCFErrorDomainOSStatus, streamError->error, NULL);
+    }
+    
+    CFStringRef key = CFSTR("CFStreamErrorDomainKey");
+    CFNumberRef value = CFNumberCreate(alloc, kCFNumberCFIndexType, &streamError->domain);
+    CFDictionaryRef dict = CFDictionaryCreate(alloc, (const void **)(&key), (const void **)(&value), 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFErrorRef result = CFErrorCreate(alloc, CFSTR("BogusCFStreamErrorCompatibilityDomain"), streamError->error, dict);
+    CFRelease(value);
+    CFRelease(dict);
+    return result;
+        
     }
 }

--- a/Foundation/XMLNode.swift
+++ b/Foundation/XMLNode.swift
@@ -332,7 +332,7 @@ open class XMLNode: NSObject, NSCopying {
         set {
             if case .namespace = kind {
                 _CFXMLNamespaceSetPrefix(_xmlNode, newValue, Int64(newValue?.utf8.count ?? 0))
-            } else {
+            } else if .namespace != document {
                 if let newName = newValue {
                     _CFXMLNodeSetName(_xmlNode, newName)
                 } else {

--- a/TestFoundation/TestXMLDocument.swift
+++ b/TestFoundation/TestXMLDocument.swift
@@ -40,6 +40,7 @@ class TestXMLDocument : LoopbackServerTest {
             ("test_optionPreserveAll", test_optionPreserveAll),
             ("test_rootElementRetainsDocument", test_rootElementRetainsDocument),
             ("test_nodeKinds", test_nodeKinds),
+             ("test_sr10776_documentName", test_sr10776_documentName),
         ]
     }
 
@@ -640,6 +641,13 @@ class TestXMLDocument : LoopbackServerTest {
         XCTAssertEqual(XMLDTDNode(xmlString: "<!ELEMENT E EMPTY>")?.kind, .elementDeclaration)
         XCTAssertEqual(XMLDTDNode(xmlString: #"<!NOTATION f SYSTEM "F">"#)?.kind, .notationDeclaration)
     }
+    func test_SR10776_documentName() {
+         let doc = XMLDocument(rootElement: nil)
+         XCTAssertNil(doc.name)
+
+          doc.name = "name"
+         XCTAssertNil(doc.name) // `name` of XMLDocument is always nil.
+     }
 }
 
 fileprivate extension XMLNode {


### PR DESCRIPTION
Runtime crash occurs when one attempts to retrieve XMLDocument's name property. This was due to the lack of checking if Documents were allowed or not to have its name property retrieved.

This came from SR-10776, and a PR has been written, but no tests were run and the PR has not been attended to: #2316.

Unlike the original PR, this PR does not have any changes on XMLDocument in Swift, as there is no need to check for document there, but rather in the _getQName function.