### PR TITLE
Foundation: remove unnecessary `-DDEPLOYMENT_ENABLE_LIBDISPATCH`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,7 +269,6 @@ add_swift_library(Foundation
                   SWIFT_FLAGS
                     -Xcc -F${CMAKE_CURRENT_BINARY_DIR}
                     -DDEPLOYMENT_RUNTIME_SWIFT
-                    -DDEPLOYMENT_ENABLE_LIBDISPATCH
                     -I;${ICU_INCLUDE_DIR}
                     ${libdispatch_cflags}
                     $<$<BOOL:ENABLE_TESTING>:-enable-testing>
@@ -334,7 +333,6 @@ add_swift_library(FoundationNetworking
                     -DDEPLOYMENT_RUNTIME_SWIFT
                     -DNS_BUILDING_FOUNDATION_NETWORKING
                     -Xcc -F${CMAKE_CURRENT_BINARY_DIR}
-                    -DDEPLOYMENT_ENABLE_LIBDISPATCH
                     -I;${CMAKE_CURRENT_BINARY_DIR}/swift
                     ${libdispatch_cflags}
                     $<$<BOOL:ENABLE_TESTING>:-enable-testing>
@@ -376,7 +374,6 @@ add_swift_library(FoundationXML
                     -DDEPLOYMENT_RUNTIME_SWIFT
                     -DNS_BUILDING_FOUNDATION_NETWORKING
                     -Xcc -F${CMAKE_CURRENT_BINARY_DIR}
-                    -DDEPLOYMENT_ENABLE_LIBDISPATCH
                     -I;${CMAKE_CURRENT_BINARY_DIR}/swift
                     ${libdispatch_cflags}
                     $<$<BOOL:ENABLE_TESTING>:-enable-testing>

--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -8,10 +8,7 @@
 //
 
 import CoreFoundation
-
-#if DEPLOYMENT_ENABLE_LIBDISPATCH
 import Dispatch
-#endif
 
 extension NSData {
     public struct ReadingOptions : OptionSet {
@@ -268,8 +265,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         } else if let data = value as? NSData {
             return isEqual(to: data._swiftObject)
         }
-        
-#if DEPLOYMENT_ENABLE_LIBDISPATCH
+
         if let data = value as? DispatchData {
             if data.count != length {
                 return false
@@ -279,7 +275,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
                 return memcmp(bytes1, bytes2, length) == 0
             }
         }
-#endif
+
         return false
     }
 


### PR DESCRIPTION
libdispatch is required by Foundation.  Remove the single case where we
depended on the flag to be set when building Foundation.