### PR TITLE
Place read-only data symbols in the .rodata section.

### DIFF
--- a/CoreFoundation/String.subproj/CFCharacterSetData.S
+++ b/CoreFoundation/String.subproj/CFCharacterSetData.S
@@ -9,6 +9,10 @@
 
 #include <CoreFoundation/CFAsmMacros.h>
 
+#if defined(__ELF__)
+.section .rodata
+#endif
+
     .global _C_LABEL(__CFCharacterSetBitmapData)
 _C_LABEL(__CFCharacterSetBitmapData):
     .incbin CF_CHARACTERSET_BITMAP

--- a/CoreFoundation/String.subproj/CFUniCharPropertyDatabase.S
+++ b/CoreFoundation/String.subproj/CFUniCharPropertyDatabase.S
@@ -9,6 +9,10 @@
 
 #include <CoreFoundation/CFAsmMacros.h>
 
+#if defined(__ELF__)
+.section .rodata
+#endif
+
     .global _C_LABEL(__CFUniCharPropertyDatabase)
 _C_LABEL(__CFUniCharPropertyDatabase):
     .incbin CF_CHARACTERSET_UNICHAR_DB

--- a/CoreFoundation/String.subproj/CFUnicodeData.S
+++ b/CoreFoundation/String.subproj/CFUnicodeData.S
@@ -9,6 +9,10 @@
 
 #include <CoreFoundation/CFAsmMacros.h>
 
+#if defined(__ELF__)
+.section .rodata
+#endif
+
 #if defined(__BIG_ENDIAN__)
     .global _C_LABEL(__CFUnicodeDataB)
 _C_LABEL(__CFUnicodeDataB):


### PR DESCRIPTION
This data was previously put into the default section, .text, which
is generally used for executable data.

This fixes a gold warning on IBM Z: "S/390 code fill of odd length
requested". This warning was triggered because executable
instructions on IBM Z must be 2-byte aligned and the data in one of
these sections is 1-byte aligned.