### PR TITLE
[cmake] Create a GenerateTestFixtures targets in CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,6 +426,28 @@ add_swift_executable(plutil
                        Foundation
                        CoreFoundation)
 
+add_swift_executable(GenerateTestFixtures
+                     SOURCES
+                       Tools/GenerateTestFixtures/GenerateTestFixtures/main.swift
+                       Tools/GenerateTestFixtures/GenerateTestFixtures/Utilities.swift
+                       TestFoundation/FixtureValues.swift
+                     TARGET
+                       ${CMAKE_C_COMPILER_TARGET}
+                     LINK_FLAGS
+                       ${libdispatch_ldflags}
+                       -L${CMAKE_CURRENT_BINARY_DIR}
+                       -lFoundation
+                       ${Foundation_INTERFACE_LIBRARIES}
+                     SWIFT_FLAGS
+                       -Xcc -F${CMAKE_CURRENT_BINARY_DIR}
+                       -I;${CMAKE_CURRENT_BINARY_DIR}/swift
+                       -I;${ICU_INCLUDE_DIR}
+                       ${libdispatch_cflags}
+                       $<$<NOT:$<CONFIG:Debug>>:-O>
+                       ${swift_libc_flags}
+                     DEPENDS
+                       Foundation)
+
 if(ENABLE_TESTING)
   add_swift_executable(xdgTestHelper
                        TARGET


### PR DESCRIPTION
The target reproduces the basic structure of the Xcode project and
allows other platforms to build easily and test.

The target is not installed intentionally. It is supposed to be a
development tool.

(This would have avoided a problem that was almost introduced in #2462)