### PR TITLE
Fixed a crash that happens when you attempt to get the name of an XML document

### DIFF
--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -435,7 +435,6 @@ void _CFXMLNodeSetPrivateData(_CFXMLNodePtr node, void* data) {
     if (!node) {
         return;
     }
-    
     ((xmlNodePtr)node)->_private = data;
 }
 
@@ -459,6 +458,7 @@ static inline xmlChar* _getQName(xmlNodePtr node) {
     const xmlChar* ncname = node->name;
     
     switch (node->type) {
+        case XML_DOCUMENT_NODE:
         case XML_NOTATION_NODE:
         case XML_DTD_NODE:
         case XML_ELEMENT_DECL:

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -435,6 +435,7 @@ void _CFXMLNodeSetPrivateData(_CFXMLNodePtr node, void* data) {
     if (!node) {
         return;
     }
+
     ((xmlNodePtr)node)->_private = data;
 }
 

--- a/CoreFoundation/String.subproj/CFString.c
+++ b/CoreFoundation/String.subproj/CFString.c
@@ -1468,7 +1468,7 @@ CF_PRIVATE CFStringRef __CFStringCreateImmutableFunnel3(
             if (noCopy) {
 
                 size = sizeof(void *);				// Pointer to the buffer
-                if ((0) || (contentsDeallocator != alloc && contentsDeallocator != kCFAllocatorNull)) {
+                if (contentsDeallocator != alloc && contentsDeallocator != kCFAllocatorNull) {
                     size += sizeof(void *);	// The contentsDeallocator
                 }
                 if (!hasLengthByte) size += sizeof(CFIndex);	// Explicit length
@@ -1480,12 +1480,14 @@ CF_PRIVATE CFStringRef __CFStringCreateImmutableFunnel3(
                 useInlineData = true;
                 size = numBytes;
 
-                if (hasLengthByte || (encoding != kCFStringEncodingUnicode && __CFCanUseLengthByte(numBytes))) {
+                if (hasLengthByte) {
                     useLengthByte = true;
-                    if (!hasLengthByte) size += 1;
+                } else if (encoding != kCFStringEncodingUnicode && __CFCanUseLengthByte(numBytes)) {
+                    useLengthByte = true;
+                    size += 1;
                 } else {
                     size += sizeof(CFIndex);	// Explicit length
-                }	    
+                }
                 if (hasNullByte || encoding != kCFStringEncodingUnicode) {
                     useNullByte = true;
                     size += 1;

--- a/Foundation/XMLNode.swift
+++ b/Foundation/XMLNode.swift
@@ -312,9 +312,13 @@ open class XMLNode: NSObject, NSCopying {
             return _CFXMLNodeCopyName(_xmlNode)?._swiftObject
         }
         set {
-            if case .namespace = kind {
+            switch kind {
+            case .document:
+                // As with Darwin, ignore the name when the node is document.
+                break
+            case .namespace:
                 _CFXMLNamespaceSetPrefix(_xmlNode, newValue, Int64(newValue?.utf8.count ?? 0))
-            } else {
+            default:
                 if let newName = newValue {
                     _CFXMLNodeSetName(_xmlNode, newName)
                 } else {

--- a/TestFoundation/TestXMLDocument.swift
+++ b/TestFoundation/TestXMLDocument.swift
@@ -35,6 +35,7 @@ class TestXMLDocument : LoopbackServerTest {
             ("test_removeNamespace", test_removeNamespace),
             ("test_optionPreserveAll", test_optionPreserveAll),
             ("test_rootElementRetainsDocument", test_rootElementRetainsDocument),
+            ("test_sr10776_documentName", test_SR10776_documentName),
         ]
     }
 
@@ -543,6 +544,13 @@ class TestXMLDocument : LoopbackServerTest {
         }
 
         XCTAssertEqual(try? test(), "plans")
+    }
+    func test_SR10776_documentName() {
+        let doc = XMLDocument(rootElement: nil)
+        XCTAssertNil(doc.name)
+
+        doc.name = "name"
+        XCTAssertNil(doc.name) // `name` of XMLDocument is always nil.
     }
 }
 


### PR DESCRIPTION
Name now returns nil instead of crashing. This was done by adding Document to the types of XML to ignore, returning early like the other XML types ineligible for a name are. 5.1 is not out yet, so I put this is 5.0.