### PR TITLE
build: workaround hook for zlib dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,6 +327,7 @@ add_swift_library(FoundationNetworking
                     ${Foundation_INTERFACE_LIBRARIES}
                     ${CFURLSessionInterface_LIBRARIES}
                     ${CURL_LIBRARIES}
+                    ${ZLIB_LIBRARY}
                     ${Foundation_RPATH}
                     ${WORKAROUND_SR9138}
                     ${WORKAROUND_SR9995}


### PR DESCRIPTION
Until CMake 3.15, dependency tracking is not properly possible due to custom
commands for linking.  Provide an escape hatch in the form is a variable that
can be setup to force the linking of zlib.  We do not search for zlib, simply
allow the user specify a magic variable to permit them to inject the linking.