### PR TITLE
Parity: XMLDocument.init(), XMLNode.init()

### DIFF
--- a/Foundation/XMLDocument.swift
+++ b/Foundation/XMLDocument.swift
@@ -67,8 +67,8 @@ open class XMLDocument : XMLNode {
         return _CFXMLDocPtr(_xmlNode)
     }
     
-    public init() {
-        NSUnimplemented()
+    public convenience init() {
+        self.init(rootElement: nil)
     }
     
     /*!

--- a/Foundation/XMLElement.swift
+++ b/Foundation/XMLElement.swift
@@ -237,7 +237,7 @@ open class XMLElement: XMLNode {
         }
 
         set {
-            if var nodes = newValue?.map({ $0._xmlNode }) {
+            if var nodes = newValue?.map({ $0._xmlNode! }) {
                 nodes.withUnsafeMutableBufferPointer({ (bufPtr) in
                     _CFXMLSetNamespaces(_xmlNode, bufPtr.baseAddress, bufPtr.count)
                 })

--- a/TestFoundation/TestXMLDocument.swift
+++ b/TestFoundation/TestXMLDocument.swift
@@ -9,41 +9,6 @@
 
 class TestXMLDocument : LoopbackServerTest {
 
-    static var allTests: [(String, (TestXMLDocument) -> () throws -> Void)] {
-        return [
-            ("test_basicCreation", test_basicCreation),
-            ("test_nextPreviousNode", test_nextPreviousNode),
-            // Disabled because of https://bugs.swift.org/browse/SR-10098
-            // ("test_xpath", test_xpath),
-            ("test_elementCreation", test_elementCreation),
-            ("test_elementChildren", test_elementChildren),
-            ("test_stringValue", test_stringValue),
-            ("test_objectValue", test_objectValue),
-            ("test_attributes", test_attributes),
-            ("test_attributesWithNamespace", test_attributesWithNamespace),
-            ("test_comments", test_comments),
-            ("test_processingInstruction", test_processingInstruction),
-            ("test_parseXMLString", test_parseXMLString),
-            ("test_prefixes", test_prefixes),
-            /* ⚠️ */ ("test_validation_success", testExpectedToFail(test_validation_success,
-            /* ⚠️ */     #"<https://bugs.swift.org/browse/SR-10643> Could not build URI for external subset "http://127.0.0.1:-2/DTDs/PropertyList-1.0.dtd""#)),
-            /* ⚠️ */ ("test_validation_failure", testExpectedToFail(test_validation_failure,
-            /* ⚠️ */     "<https://bugs.swift.org/browse/SR-10643> XCTAssert in last catch block fails")),
-            ("test_dtd", test_dtd),
-            ("test_documentWithDTD", test_documentWithDTD),
-            ("test_dtd_attributes", test_dtd_attributes),
-            ("test_documentWithEncodingSetDoesntCrash", test_documentWithEncodingSetDoesntCrash),
-            ("test_nodeFindingWithNamespaces", test_nodeFindingWithNamespaces),
-            ("test_createElement", test_createElement),
-            ("test_addNamespace", test_addNamespace),
-            ("test_removeNamespace", test_removeNamespace),
-            ("test_optionPreserveAll", test_optionPreserveAll),
-            ("test_rootElementRetainsDocument", test_rootElementRetainsDocument),
-            ("test_nodeKinds", test_nodeKinds),
-            ("test_sr10776_documentName", test_sr10776_documentName),
-        ]
-    }
-
     func test_basicCreation() {
         let doc = XMLDocument(rootElement: nil)
         XCTAssert(doc.version == "1.0", "expected 1.0, got \(String(describing: doc.version))")
@@ -648,6 +613,47 @@ class TestXMLDocument : LoopbackServerTest {
         
         doc.name = "name"
         XCTAssertNil(doc.name) // `name` of XMLDocument is always nil.
+    }
+    
+    func test_creatingAnEmptyDocumentAndNode() {
+        _ = XMLDocument()
+        _ = XMLNode()
+    }
+    
+    static var allTests: [(String, (TestXMLDocument) -> () throws -> Void)] {
+        return [
+            ("test_basicCreation", test_basicCreation),
+            ("test_nextPreviousNode", test_nextPreviousNode),
+            // Disabled because of https://bugs.swift.org/browse/SR-10098
+            // ("test_xpath", test_xpath),
+            ("test_elementCreation", test_elementCreation),
+            ("test_elementChildren", test_elementChildren),
+            ("test_stringValue", test_stringValue),
+            ("test_objectValue", test_objectValue),
+            ("test_attributes", test_attributes),
+            ("test_attributesWithNamespace", test_attributesWithNamespace),
+            ("test_comments", test_comments),
+            ("test_processingInstruction", test_processingInstruction),
+            ("test_parseXMLString", test_parseXMLString),
+            ("test_prefixes", test_prefixes),
+            /* ⚠️ */ ("test_validation_success", testExpectedToFail(test_validation_success,
+            /* ⚠️ */     #"<https://bugs.swift.org/browse/SR-10643> Could not build URI for external subset "http://127.0.0.1:-2/DTDs/PropertyList-1.0.dtd""#)),
+            /* ⚠️ */ ("test_validation_failure", testExpectedToFail(test_validation_failure,
+            /* ⚠️ */     "<https://bugs.swift.org/browse/SR-10643> XCTAssert in last catch block fails")),
+            ("test_dtd", test_dtd),
+            ("test_documentWithDTD", test_documentWithDTD),
+            ("test_dtd_attributes", test_dtd_attributes),
+            ("test_documentWithEncodingSetDoesntCrash", test_documentWithEncodingSetDoesntCrash),
+            ("test_nodeFindingWithNamespaces", test_nodeFindingWithNamespaces),
+            ("test_createElement", test_createElement),
+            ("test_addNamespace", test_addNamespace),
+            ("test_removeNamespace", test_removeNamespace),
+            ("test_optionPreserveAll", test_optionPreserveAll),
+            ("test_rootElementRetainsDocument", test_rootElementRetainsDocument),
+            ("test_nodeKinds", test_nodeKinds),
+            ("test_sr10776_documentName", test_sr10776_documentName),
+            ("test_creatingAnEmptyDocumentAndNode", test_creatingAnEmptyDocumentAndNode),
+        ]
     }
 }
 


### PR DESCRIPTION
Match Darwin’s behavior.