### PR TITLE
Parity: Stream

### DIFF
--- a/TestFoundation/TestStream.swift
+++ b/TestFoundation/TestStream.swift
@@ -34,27 +34,6 @@ private extension Data {
 }
 
 class TestStream : XCTestCase {
-    static var allTests: [(String, (TestStream) -> () throws -> Void)] {
-        var tests: [(String, (TestStream) -> () throws -> Void)] = [
-            ("test_InputStreamWithData", test_InputStreamWithData),
-            ("test_InputStreamWithUrl", test_InputStreamWithUrl),
-            ("test_InputStreamWithFile", test_InputStreamWithFile),
-            ("test_InputStreamHasBytesAvailable", test_InputStreamHasBytesAvailable),
-            ("test_InputStreamInvalidPath", test_InputStreamInvalidPath),
-            ("test_outputStreamCreationToFile", test_outputStreamCreationToFile),
-            ("test_outputStreamCreationToBuffer", test_outputStreamCreationToBuffer),
-            ("test_outputStreamCreationWithUrl", test_outputStreamCreationWithUrl),
-            ("test_outputStreamCreationToMemory", test_outputStreamCreationToMemory),
-            ("test_outputStreamHasSpaceAvailable", test_outputStreamHasSpaceAvailable),
-            ("test_ouputStreamWithInvalidPath", test_ouputStreamWithInvalidPath),
-        ]
-
-#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
-        tests.append(("test_InputStreamSeekToPosition", test_InputStreamSeekToPosition))
-#endif
-        return tests
-    }
-    
     func test_InputStreamWithData(){
         let message: NSString = "Hello, playground"
         let messageData: Data = message.data(using: String.Encoding.utf8.rawValue)!
@@ -283,6 +262,27 @@ class TestStream : XCTestCase {
         XCTAssertEqual(.notOpen, outputStream!.streamStatus)
         outputStream?.open()
         XCTAssertEqual(.error, outputStream!.streamStatus)
+    }
+    
+    static var allTests: [(String, (TestStream) -> () throws -> Void)] {
+        var tests: [(String, (TestStream) -> () throws -> Void)] = [
+            ("test_InputStreamWithData", test_InputStreamWithData),
+            ("test_InputStreamWithUrl", test_InputStreamWithUrl),
+            ("test_InputStreamWithFile", test_InputStreamWithFile),
+            ("test_InputStreamHasBytesAvailable", test_InputStreamHasBytesAvailable),
+            ("test_InputStreamInvalidPath", test_InputStreamInvalidPath),
+            ("test_outputStreamCreationToFile", test_outputStreamCreationToFile),
+            ("test_outputStreamCreationToBuffer", test_outputStreamCreationToBuffer),
+            ("test_outputStreamCreationWithUrl", test_outputStreamCreationWithUrl),
+            ("test_outputStreamCreationToMemory", test_outputStreamCreationToMemory),
+            ("test_outputStreamHasSpaceAvailable", test_outputStreamHasSpaceAvailable),
+            ("test_ouputStreamWithInvalidPath", test_ouputStreamWithInvalidPath),
+        ]
+        
+        #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+        tests.append(("test_InputStreamSeekToPosition", test_InputStreamSeekToPosition))
+        #endif
+        return tests
     }
     
     private func createTestFile(_ path: String, _contents: Data) -> String? {


### PR DESCRIPTION
 - Fix the base class to work like it does on Darwin.
 - Allow scheduling input and output streams.
 - Allow setting and retrieving properties.
Fixes https://bugs.swift.org/browse/SR-10369