### PR TITLE
Use Array.isEmpty instead of checking account property

### DIFF
--- a/Foundation/Operation.swift
+++ b/Foundation/Operation.swift
@@ -1142,7 +1142,7 @@ open class OperationQueue : NSObject, ProgressReporting {
     }
     
     internal func _addOperations(_ ops: [Operation], barrier: Bool = false) {
-        if 0 == ops.count { return }
+        if ops.isEmpty { return }
         
         var failures = 0
         var successes = 0


### PR DESCRIPTION
According to the Xcode documentation, we should use isEmpty property to check whether your collection is empty.
[https://developer.apple.com/documentation/swift/array/1688398-isempty](https://developer.apple.com/documentation/swift/array/1688398-isempty)
> When you need to check whether your collection is empty, use the isEmpty property instead of checking that the count property is equal to zero. For collections that don’t conform to RandomAccessCollection, accessing the count property iterates through the elements of the collection.