### PR TITLE
Parity: Networking: URLUploadTask and URLDownloadTask

### DIFF
--- a/Foundation/URLSession/NativeProtocol.swift
+++ b/Foundation/URLSession/NativeProtocol.swift
@@ -333,12 +333,9 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
         }
     }
 
-    func createTransferState(url: URL, workQueue: DispatchQueue) -> _TransferState {
+    func createTransferState(url: URL, body: _Body, workQueue: DispatchQueue) -> _TransferState {
         let drain = createTransferBodyDataDrain()
-        guard let t = task else {
-            fatalError("Cannot create transfer state")
-        }
-        switch t.body {
+        switch body {
         case .none:
             return _TransferState(url: url, bodyDataDrain: drain)
         case .data(let data):
@@ -358,22 +355,19 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
 
     /// Start a new transfer
     func startNewTransfer(with request: URLRequest) {
-        guard let t = task else {
-            fatalError()
-        }
-        t.currentRequest = request
+        let task = self.task!
+        task.currentRequest = request
         guard let url = request.url else {
             fatalError("No URL in request.")
         }
 
-        self.internalState = .transferReady(createTransferState(url: url, workQueue: t.workQueue))
-        if let authRequest = task?.authRequest {
-            configureEasyHandle(for: authRequest)
-        } else {
-            configureEasyHandle(for: request)
-        }
-        if (t.suspendCount) < 1 {
-            resume()
+        task.getBody { (body) in
+            self.internalState = .transferReady(self.createTransferState(url: url, body: body, workQueue: task.workQueue))
+            let request = task.authRequest ?? request
+            self.configureEasyHandle(for: request, body: body)
+            if (task.suspendCount) < 1 {
+                self.resume()
+            }
         }
     }
 
@@ -427,7 +421,7 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
         }
     }
 
-    func configureEasyHandle(for: URLRequest) {
+    func configureEasyHandle(for request: URLRequest, body: _Body) {
         NSRequiresConcreteImplementation()
     }
 }
@@ -624,37 +618,7 @@ extension _NativeProtocol._ResponseHeaderLines {
 }
 
 internal extension _NativeProtocol {
-    enum _Body {
-        case none
-        case data(DispatchData)
-        /// Body data is read from the given file URL
-        case file(URL)
-        case stream(InputStream)
-    }
-}
-
-fileprivate extension _NativeProtocol._Body {
-    enum _Error : Error {
-        case fileForBodyDataNotFound
-    }
-
-    /// - Returns: The body length, or `nil` for no body (e.g. `GET` request).
-    func getBodyLength() throws -> UInt64? {
-        switch self {
-        case .none:
-            return 0
-        case .data(let d):
-            return UInt64(d.count)
-        /// Body data is read from the given file URL
-        case .file(let fileURL):
-            guard let s = try FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? NSNumber else {
-                throw _Error.fileForBodyDataNotFound
-            }
-            return s.uint64Value
-        case .stream:
-            return nil
-        }
-    }
+    typealias _Body = URLSessionTask._Body
 }
 
 extension _NativeProtocol {

--- a/Foundation/URLSession/URLSession.swift
+++ b/Foundation/URLSession/URLSession.swift
@@ -433,7 +433,10 @@ open class URLSession : NSObject {
     }
     
     /* Creates an upload task with the given request.  The previously set body stream of the request (if any) is ignored and the URLSession:task:needNewBodyStream: delegate will be called when the body payload is required. */
-    open func uploadTask(withStreamedRequest request: URLRequest) -> URLSessionUploadTask { NSUnimplemented() }
+    open func uploadTask(withStreamedRequest request: URLRequest) -> URLSessionUploadTask {
+        let r = URLSession._Request(request)
+        return uploadTask(with: r, body: nil, behaviour: .callDelegate)
+    }
     
     /* Creates a download task with the given request. */
     open func downloadTask(with request: URLRequest) -> URLSessionDownloadTask {
@@ -447,7 +450,9 @@ open class URLSession : NSObject {
     }
     
     /* Creates a download task with the resume data.  If the download cannot be successfully resumed, URLSession:task:didCompleteWithError: will be called. */
-    open func downloadTask(withResumeData resumeData: Data) -> URLSessionDownloadTask { NSUnimplemented() }
+    open func downloadTask(withResumeData resumeData: Data) -> URLSessionDownloadTask {
+        return invalidDownloadTask(behavior: .callDelegate)
+    }
     
     /* Creates a bidirectional stream task to a given host and port.
      */
@@ -511,7 +516,7 @@ fileprivate extension URLSession {
     /// Create an upload task.
     ///
     /// All public methods funnel into this one.
-    func uploadTask(with request: _Request, body: URLSessionTask._Body, behaviour: _TaskRegistry._Behaviour) -> URLSessionUploadTask {
+    func uploadTask(with request: _Request, body: URLSessionTask._Body?, behaviour: _TaskRegistry._Behaviour) -> URLSessionUploadTask {
         guard !self.invalidated else { fatalError("Session invalidated") }
         let r = createConfiguredRequest(from: request)
         let i = createNextTaskIdentifier()
@@ -528,6 +533,21 @@ fileprivate extension URLSession {
         let r = createConfiguredRequest(from: request)
         let i = createNextTaskIdentifier()
         let task = URLSessionDownloadTask(session: self, request: r, taskIdentifier: i)
+        workQueue.async {
+            self.taskRegistry.add(task, behaviour: behavior)
+        }
+        return task
+    }
+    
+    /// Create a download task that is marked invalid.
+    func invalidDownloadTask(behavior: _TaskRegistry._Behaviour) -> URLSessionDownloadTask {
+        /* We do not support resume data in swift-corelibs-foundation, so whatever we are passed, we should just behave as Darwin does in the presence of invalid data. */
+        
+        guard !self.invalidated else { fatalError("Session invalidated") }
+        let task = URLSessionDownloadTask()
+        task.createdFromInvalidResumeData = true
+        task.taskIdentifier = createNextTaskIdentifier()
+        task.session = self
         workQueue.async {
             self.taskRegistry.add(task, behaviour: behavior)
         }
@@ -588,7 +608,9 @@ extension URLSession {
        return downloadTask(with: _Request(url), behavior: .downloadCompletionHandler(completionHandler)) 
     }
 
-    open func downloadTask(withResumeData resumeData: Data, completionHandler: @escaping (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask { NSUnimplemented() }
+    open func downloadTask(withResumeData resumeData: Data, completionHandler: @escaping (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask {
+        return invalidDownloadTask(behavior: .downloadCompletionHandler(completionHandler))
+    }
 }
 
 internal extension URLSession {

--- a/Foundation/URLSession/ftp/FTPURLProtocol.swift
+++ b/Foundation/URLSession/ftp/FTPURLProtocol.swift
@@ -51,7 +51,7 @@ internal class _FTPURLProtocol: _NativeProtocol {
         }
     }
 
-    override func configureEasyHandle(for request: URLRequest) {
+    override func configureEasyHandle(for request: URLRequest, body: _Body) {
         easyHandle.set(verboseModeOn: enableLibcurlDebugOutput)
         easyHandle.set(debugOutputOn: enableLibcurlDebugOutput, task: task!)
         easyHandle.set(skipAllSignalHandling: true)
@@ -59,8 +59,8 @@ internal class _FTPURLProtocol: _NativeProtocol {
         easyHandle.set(url: url)
         easyHandle.set(preferredReceiveBufferSize: Int.max)
         do {
-            switch (task?.body, try task?.body.getBodyLength()) {
-            case (.some(URLSessionTask._Body.none), _):
+            switch (body, try body.getBodyLength()) {
+            case (.none, _):
                 set(requestBodyLength: .noBody)
             case (_, .some(let length)):
                 set(requestBodyLength: .length(length))


### PR DESCRIPTION
 - Implement downloadTask(withResumeData…). We do not currently support resume data, so act as Darwin does when invalid data is fed to these methods.

 - Implement uploadTask(withStreamedRequest:).

 - Some cleanup, some testing.

This restores the patch after the revert at https://github.com/apple/swift-corelibs-foundation/pull/2461, after the test issues were revealed as unrelated.