### PR TITLE
XFAIL: test_noDoubleCallbackWhenCancellingAndProtocolFailsFast (again)

### DIFF
--- a/TestFoundation/TestURLSession.swift
+++ b/TestFoundation/TestURLSession.swift
@@ -1067,7 +1067,8 @@ class TestURLSession : LoopbackServerTest {
             ("test_getTasksWithCompletion", test_getTasksWithCompletion),
             ("test_invalidResumeDataForDownloadTask", test_invalidResumeDataForDownloadTask),
             ("test_simpleUploadWithDelegateProvidingInputStream", test_simpleUploadWithDelegateProvidingInputStream),
-            ("test_noDoubleCallbackWhenCancellingAndProtocolFailsFast", test_noDoubleCallbackWhenCancellingAndProtocolFailsFast),
+            /* ⚠️ */ ("test_noDoubleCallbackWhenCancellingAndProtocolFailsFast",
+            /* ⚠️ */      testExpectedToFail(test_noDoubleCallbackWhenCancellingAndProtocolFailsFast, "This test crashes nondeterministically: https://bugs.swift.org/browse/SR-11310")),
             ("test_cancelledTasksCannotBeResumed", test_cancelledTasksCannotBeResumed),
         ]
     }


### PR DESCRIPTION
A merge issue when un-reverting a patch caused this test to be un-XFAIL’ed incorrectly. Fix that.