### PR TITLE
Parity: XMLDTD.init()

### DIFF
--- a/Foundation/XMLDTD.swift
+++ b/Foundation/XMLDTD.swift
@@ -26,7 +26,7 @@ open class XMLDTD : XMLNode {
     }
     
     public init() {
-        NSUnimplemented()
+        super.init(kind: .DTDKind, options: [])
     }
     
     public convenience init(contentsOf url: URL, options mask: XMLNode.Options = []) throws {

--- a/TestFoundation/TestXMLDocument.swift
+++ b/TestFoundation/TestXMLDocument.swift
@@ -620,6 +620,17 @@ class TestXMLDocument : LoopbackServerTest {
         _ = XMLNode()
     }
     
+    func test_creatingAnEmptyDTD() {
+        let dtd = XMLDTD()
+        XCTAssertEqual(dtd.publicID, "")
+        XCTAssertEqual(dtd.systemID, "")
+        XCTAssertEqual(dtd.children ?? [], [])
+        
+        let plistDTDUrl = "https://www.apple.com/DTDs/PropertyList-1.0.dtd"
+        dtd.systemID = plistDTDUrl
+        XCTAssertEqual(dtd.systemID, plistDTDUrl)
+    }
+    
     static var allTests: [(String, (TestXMLDocument) -> () throws -> Void)] {
         return [
             ("test_basicCreation", test_basicCreation),
@@ -653,6 +664,7 @@ class TestXMLDocument : LoopbackServerTest {
             ("test_nodeKinds", test_nodeKinds),
             ("test_sr10776_documentName", test_sr10776_documentName),
             ("test_creatingAnEmptyDocumentAndNode", test_creatingAnEmptyDocumentAndNode),
+            ("test_creatingAnEmptyDTD", test_creatingAnEmptyDTD),
         ]
     }
 }


### PR DESCRIPTION
Implement it to create an empty `.DTDKind` node, as it does on Darwin.