### PR TITLE
SR-11323: NSCalendar functions are not thread safe

### DIFF
--- a/CoreFoundation/Locale.subproj/CFCalendar.c
+++ b/CoreFoundation/Locale.subproj/CFCalendar.c
@@ -639,6 +639,7 @@ CF_CROSS_PLATFORM_EXPORT bool _CFCalendarInitWithIdentifier(CFCalendarRef calend
     calendar->_userSet_firstWeekday = false;
     calendar->_userSet_minDaysInFirstWeek = false;
     calendar->_userSet_gregorianStart = false;
+    CF_LOCK_INIT_FOR_STRUCTS(calendar->_lock);
     ICU_LOG("                // _CFCalendarInitWithIdentifier exit true\n");
     return true;
 }

--- a/CoreFoundation/Locale.subproj/CFCalendar_Internal.h
+++ b/CoreFoundation/Locale.subproj/CFCalendar_Internal.h
@@ -15,6 +15,7 @@
 #include <CoreFoundation/CFPriv.h>
 #include <CoreFoundation/CFTimeZone.h>
 #include <CoreFoundation/CFString.h>
+#include <CoreFoundation/CFLocking.h>
 
 #include "CFDateComponents.h"
 #include "CFDateInterval.h"
@@ -46,6 +47,7 @@ struct __CFCalendar {
     Boolean _userSet_firstWeekday;
     Boolean _userSet_minDaysInFirstWeek;
     Boolean _userSet_gregorianStart;
+    CFLock_t _lock;
 };
 
 struct __CFDateComponents {
@@ -87,6 +89,16 @@ CF_ENUM(CFOptionFlags) {
     kCFCalendarMatchFirst = (1ULL << 12),
     kCFCalendarMatchLast = (1ULL << 13)
 };
+
+
+CF_INLINE void __CFCalendarLock(CFCalendarRef calendar) {
+    __CFLock(&calendar->_lock);
+}
+
+CF_INLINE void __CFCalendarUnlock(CFCalendarRef calendar) {
+    __CFUnlock(&calendar->_lock);
+}
+
 
 CF_PRIVATE void __CFCalendarSetupCal(CFCalendarRef calendar);
 CF_PRIVATE void __CFCalendarZapCal(CFCalendarRef calendar);


### PR DESCRIPTION
- CFCalendarGetTimeRangeOfUnit() modifies the calendar->_cal object
  so make a copy of the NSCalendar before calling it.