### PR TITLE
Parity: XMLElement.normalizeAdjacentTextNodes…

### DIFF
--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -62,6 +62,7 @@ CFIndex _kCFXMLTypeAttribute = XML_ATTRIBUTE_NODE;
 CFIndex _kCFXMLTypeProcessingInstruction = XML_PI_NODE;
 CFIndex _kCFXMLTypeComment = XML_COMMENT_NODE;
 CFIndex _kCFXMLTypeText = XML_TEXT_NODE;
+CFIndex _kCFXMLTypeCDataSection = XML_CDATA_SECTION_NODE;
 CFIndex _kCFXMLTypeDTD = XML_DTD_NODE;
 CFIndex _kCFXMLDocTypeHTML = XML_DOC_HTML;
 CFIndex _kCFXMLTypeNamespace = 22; // libxml2 does not define namespaces as nodes, so we have to fake it

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.h
@@ -53,6 +53,7 @@ extern CFIndex _kCFXMLTypeAttribute;
 extern CFIndex _kCFXMLTypeProcessingInstruction;
 extern CFIndex _kCFXMLTypeComment;
 extern CFIndex _kCFXMLTypeText;
+extern CFIndex _kCFXMLTypeCDataSection;
 extern CFIndex _kCFXMLTypeDTD;
 extern CFIndex _kCFXMLDocTypeHTML;
 extern CFIndex _kCFXMLTypeNamespace;

--- a/Foundation/XMLDTD.swift
+++ b/Foundation/XMLDTD.swift
@@ -98,6 +98,10 @@ open class XMLDTD : XMLNode {
         }
     }
 
+    open override var childCount: Int {
+        return _CFXMLNodeGetElementChildCount(_xmlNode)
+    }
+    
     /*!
         @method insertChild:atIndex:
         @abstract Inserts a child at a particular index.

--- a/Foundation/XMLDocument.swift
+++ b/Foundation/XMLDocument.swift
@@ -267,6 +267,10 @@ open class XMLDocument : XMLNode {
 
         return XMLNode._objectNodeForNode(rootPtr) as? XMLElement
     }
+    
+    open override var childCount: Int {
+        return _CFXMLNodeGetElementChildCount(_xmlNode)
+    }
 
     /*!
         @method insertChild:atIndex:

--- a/Foundation/XMLNode.swift
+++ b/Foundation/XMLNode.swift
@@ -315,12 +315,17 @@ open class XMLNode: NSObject, NSCopying {
         case _kCFXMLTypeComment:
             return .comment
             
+        case _kCFXMLTypeCDataSection: fallthrough
         case _kCFXMLTypeText:
             return .text
             
         default:
             return .invalid
         }
+    }
+    
+    internal var isCData: Bool {
+        return _CFXMLNodeGetType(_xmlNode) == _kCFXMLTypeCDataSection
     }
     
     /*!
@@ -446,8 +451,8 @@ open class XMLNode: NSObject, NSCopying {
     internal func _removeAllChildren() {
         var nextChild = _CFXMLNodeGetFirstChild(_xmlNode)
         while let child = nextChild {
-            _CFXMLUnlinkNode(child)
             nextChild = _CFXMLNodeGetNextSibling(child)
+            _CFXMLUnlinkNode(child)
         }
         _childNodes.removeAll(keepingCapacity: true)
     }
@@ -558,10 +563,10 @@ open class XMLNode: NSObject, NSCopying {
     
     /*!
      @method childCount
-     @abstract The amount of children, relevant for documents, elements, and document type declarations. Use this instead of [[self children] count].
+     @abstract The amount of children, relevant for documents, elements, and document type declarations.
      */
     open var childCount: Int {
-        return _CFXMLNodeGetElementChildCount(_xmlNode)
+        return self.children?.count ?? 0
     }
     
     /*!


### PR DESCRIPTION
 - Implement it like Darwin does.
 - Nodes representing CDATA sections now return .kind == .text, like on Darwin.
 - .setChildren() now correctly replaces all children, not just the first.
 - .childCount now returns correct results.

Fixes https://bugs.swift.org/browse/SR-10425