### PR TITLE
Parity: XMLElement: XML Namespaces (final part)

### DIFF
--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -1570,3 +1570,18 @@ void _CFXMLFreeDTD(_CFXMLDTDPtr dtd) {
 void _CFXMLFreeProperty(_CFXMLNodePtr prop) {
     xmlFreeProp(prop);
 }
+
+const char *_CFXMLSplitQualifiedName(const char *_Nonnull qname) {
+    int len = 0;
+    return (const char *)xmlSplitQName3((const xmlChar *)qname, &len);
+}
+
+bool _CFXMLGetLengthOfPrefixInQualifiedName(const char *_Nonnull qname, size_t *length) {
+    int len = 0;
+    if (xmlSplitQName3((const xmlChar *)qname, &len) != NULL) {
+        *length = len;
+        return true;
+    } else {
+        return false;
+    }
+}

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.h
@@ -17,6 +17,7 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <stdint.h>
 #include <sys/types.h>
+#include <stdbool.h>
 
 CF_IMPLICIT_BRIDGING_ENABLED
 CF_ASSUME_NONNULL_BEGIN
@@ -254,6 +255,9 @@ void _CFXMLFreeNode(_CFXMLNodePtr node);
 void _CFXMLFreeDocument(_CFXMLDocPtr doc);
 void _CFXMLFreeDTD(_CFXMLDTDPtr dtd);
 void _CFXMLFreeProperty(_CFXMLNodePtr prop);
+
+const char *_Nullable _CFXMLSplitQualifiedName(const char *_Nonnull qname);
+bool _CFXMLGetLengthOfPrefixInQualifiedName(const char *_Nonnull qname, size_t *_Nonnull length);
 
 // Bridging
 

--- a/Foundation/XMLParser.swift
+++ b/Foundation/XMLParser.swift
@@ -963,6 +963,13 @@ internal func NSUnimplemented(_ fn: String = #function, file: StaticString = #fi
     fatalError("\(fn) is not yet implemented", file: file, line: line)
 }
 
+internal func NSUnsupported(_ fn: String = #function, file: StaticString = #file, line: UInt = #line) -> Never {
+    #if os(Android)
+    NSLog("\(fn) is not supported on this platform. \(file):\(line)")
+    #endif
+    fatalError("\(fn) is not supported on this platform", file: file, line: line)
+}
+
 extension NSObject {
     func withUnretainedReference<T, R>(_ work: (UnsafePointer<T>) -> R) -> R {
         let selfPtr = Unmanaged.passUnretained(self).toOpaque().assumingMemoryBound(to: T.self)


### PR DESCRIPTION
⚠️ Needs tests.

Fixes what `NSUnimplemented()` invocations remained in FoundationXML:

 - Finish implementing namespace accessors.
 - Finish implementing namespace utility methods for working with qnames;
 - Note that XQuery is unavailable in s-c-f.