### PR TITLE
Fix Operation.swift Operation addDependency bug

### DIFF
--- a/Foundation/Operation.swift
+++ b/Foundation/Operation.swift
@@ -407,7 +407,7 @@ open class Operation : NSObject {
             withExtendedLifetime(op) {
                 var up: Operation?
                 _lock()
-                if __dependencies.first(where: { $0 === op }) != nil {
+                if __dependencies.first(where: { $0 === op }) == nil {
                     __dependencies.append(op)
                     up = op
                 }

--- a/TestFoundation/TestOperationQueue.swift
+++ b/TestFoundation/TestOperationQueue.swift
@@ -25,6 +25,7 @@ class TestOperationQueue : XCTestCase {
             ("test_CurrentQueueWithCustomUnderlyingQueue", test_CurrentQueueWithCustomUnderlyingQueue),
             ("test_CurrentQueueWithUnderlyingQueueResetToNil", test_CurrentQueueWithUnderlyingQueueResetToNil),
             ("test_isSuspended", test_isSuspended),
+            ("test_OperationDependencies", test_OperationDependencies),
         ]
     }
     
@@ -263,6 +264,26 @@ class TestOperationQueue : XCTestCase {
         }
         
         waitForExpectations(timeout: 1)
+    }
+    
+    func test_OperationDependencies() {
+        let queue = OperationQueue()
+        var results = [Int]()
+        queue.maxConcurrentOperationCount = 1
+        let op1 = BlockOperation {
+            results.append(1)
+        }
+        op1.name = "op1"
+        let op2 = BlockOperation {
+            results.append(2)
+        }
+        op2.name = "op2"
+        op1.addDependency(op2)
+        XCTAssert(op1.dependencies.count == 1)
+        queue.addOperation(op1)
+        queue.addOperation(op2)
+        queue.waitUntilAllOperationsAreFinished()
+        XCTAssertEqual(results, [2, 1])
     }
 }
 


### PR DESCRIPTION
In this commit, I only fixed the `addDependency` bug.  However, there is a critical bug [https://bugs.swift.org/browse/SR-11333](https://bugs.swift.org/browse/SR-11333), exists from swift5.0 (I didn't check swift version < 5.0).

I created a test case for OperationQueue and Operation which testing the dependency.