### PR TITLE
Remove Verification of UTF32 XML on Windows

### DIFF
--- a/TestFoundation/TestXMLParser.swift
+++ b/TestFoundation/TestXMLParser.swift
@@ -118,7 +118,11 @@ class TestXMLParser : XCTestCase {
         // If th <?xml header isn't present, any non-UTF8 encodings fail. This appears to be libxml2 behavior.
         // These don't work, it may just be an issue with the `encoding=xxx`.
         //   - .nextstep, .utf32LittleEndian
-        let encodings: [String.Encoding] = [.utf16LittleEndian, .utf16BigEndian, .utf32BigEndian, .ascii]
+        var encodings: [String.Encoding] = [.utf16LittleEndian, .utf16BigEndian,  .ascii]
+#if !os(Windows)
+        // libxml requires iconv support for UTF32
+        encodings.append(.utf32BigEndian)
+#endif
         for encoding in encodings {
             let xml = TestXMLParser.xmlUnderTest(encoding: encoding)
             let parser = XMLParser(data: xml.data(using: encoding)!)


### PR DESCRIPTION
Unless compiled with iconv support, libxml2 only supports
- UTF-8
- UTF-16, both little and big endian
- ISO-Latin-1 (ISO-8859-1)
- ASCII

See http://www.xmlsoft.org/encoding.html#Default for details