### PR TITLE
[Windows] O_EXCL should override O_TRUNC

### DIFF
--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -906,14 +906,15 @@ CF_EXPORT int _NS_open(const char *name, int oflag, int pmode) {
 
     DWORD dwCreationDisposition;
     switch (oflag & (O_CREAT | O_EXCL | O_TRUNC)) {
+      case O_CREAT | O_EXCL | O_TRUNC:
+      case O_CREAT | O_EXCL:
+        dwCreationDisposition = CREATE_NEW;
+        break;
       case O_CREAT | O_TRUNC:
         dwCreationDisposition = CREATE_ALWAYS;
         break;
       case O_CREAT:
         dwCreationDisposition = OPEN_ALWAYS;
-        break;
-      case O_EXCL:
-        dwCreationDisposition = CREATE_NEW;
         break;
       case O_TRUNC:
         dwCreationDisposition = TRUNCATE_EXISTING;


### PR DESCRIPTION
Setting `O_CREAT` and `O_EXCL` together should always force the creation
of a new file and fail otherwise, regardless of if O_TRUNC is set.

In addition, `O_EXCL` should only take effect if `O_CREAT` is set,
otherwise, the result is undefined behavior per the specification (in
our case, setting to OPEN_EXISTING).