### PR TITLE
[Windows] Fix TestURL/test_URLStrings

### DIFF
--- a/TestFoundation/Resources/NSURLTestData.plist
+++ b/TestFoundation/Resources/NSURLTestData.plist
@@ -3493,13 +3493,67 @@
 		</dict>
 		<dict>
 			<key>In-Title</key>
-			<string>NSURLWithString-parse-absolute-escape-006</string>
+			<string>NSURLWithString-parse-absolute-escape-006-pipe-invalid</string>
 			<key>In-URLCreator</key>
 			<string>NSURLWithString</string>
 			<key>In-Url</key>
 			<string>http://test.com/unescaped|pipe</string>
 			<key>Out-NSResults</key>
 			<string>&lt;null url&gt;</string>
+		</dict>
+		<dict>
+			<key>In-Title</key>
+			<string>NSURLWithString-parse-absolute-escape-006-pipe-valid</string>
+			<key>In-URLCreator</key>
+			<string>NSURLWithString</string>
+			<key>In-Url</key>
+			<string>http://test.com/unescaped|pipe</string>
+			<key>Out-NSResults</key>
+			<dict>
+				<key>absoluteString</key>
+				<string>http://test.com/unescaped%7Cpipe</string>
+				<key>absoluteURLString</key>
+				<string>http://test.com/unescaped%7Cpipe</string>
+				<key>baseURLString</key>
+				<string>&lt;null&gt;</string>
+				<key>deletingLastPathComponent</key>
+				<string>http://test.com/</string>
+				<key>deletingLastPathExtension</key>
+				<string>http://test.com/unescaped%7Cpipe</string>
+				<key>fragment</key>
+				<string>&lt;null&gt;</string>
+				<key>host</key>
+				<string>test.com</string>
+				<key>isFileURL</key>
+				<string>NO</string>
+				<key>lastPathComponent</key>
+				<string>unescaped|pipe</string>
+				<key>password</key>
+				<string>&lt;null&gt;</string>
+				<key>path</key>
+				<string>/unescaped|pipe</string>
+				<key>pathComponents</key>
+				<array>
+					<string>/</string>
+					<string>unescaped|pipe</string>
+				</array>
+				<key>pathExtension</key>
+				<string></string>
+				<key>port</key>
+				<string>&lt;null&gt;</string>
+				<key>query</key>
+				<string>&lt;null&gt;</string>
+				<key>relativePath</key>
+				<string>/unescaped|pipe</string>
+				<key>relativeString</key>
+				<string>http://test.com/unescaped%7Cpipe</string>
+				<key>scheme</key>
+				<string>http</string>
+				<key>standardizedURL</key>
+				<string>http://test.com/unescaped%7Cpipe</string>
+				<key>user</key>
+				<string>&lt;null&gt;</string>
+		    </dict>
 		</dict>
 		<dict>
 			<key>In-Title</key>

--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -248,25 +248,40 @@ class TestURL : XCTestCase {
             default:
                 XCTFail()
             }
-            if title == "NSURLWithString-parse-ambiguous-url-001" {
-                // TODO: Fix this test
-            } else {
-                if let url = url {
-                        let results = generateResults(url, pathComponent: inPathComponent, pathExtension: inPathExtension)
-                        if let expected = expectedNSResult as? [String: Any] {
-                            let (isEqual, differences) = compareResults(url, expected: expected, got: results)
-                            XCTAssertTrue(isEqual, "\(title): \(differences.joined(separator: "\n"))")
-                        } else {
-                            XCTFail("\(url) should not be a valid url")
-                        }
+
+#if os(Windows)
+            // On Windows, pipes are valid charcters which can be used
+            // to replace a ':'. See RFC 8089 Section E.2.2 for
+            // details.
+            //
+            // Skip the test which expects pipes to be invalid
+            let skippedPipeTest = "NSURLWithString-parse-absolute-escape-006-pipe-invalid"
+#else
+            // On other platforms, pipes are not valid
+            //
+            // Skip the test which expects pipes to be valid
+            let skippedPipeTest = "NSURLWithString-parse-absolute-escape-006-pipe-valid"
+#endif
+            let skippedTests = [
+                "NSURLWithString-parse-ambiguous-url-001", // TODO: Fix Test
+                skippedPipeTest,
+            ]
+            if skippedTests.contains(title) { continue }
+
+            if let url = url {
+                let results = generateResults(url, pathComponent: inPathComponent, pathExtension: inPathExtension)
+                if let expected = expectedNSResult as? [String: Any] {
+                    let (isEqual, differences) = compareResults(url, expected: expected, got: results)
+                    XCTAssertTrue(isEqual, "\(title): \(differences.joined(separator: "\n"))")
                 } else {
-                    XCTAssertEqual(expectedNSResult as? String, kNullURLString)
+                    XCTFail("\(url) should not be a valid url")
                 }
+            } else {
+                XCTAssertEqual(expectedNSResult as? String, kNullURLString)
             }
         }
-        
     }
-    
+
     static let gBaseTemporaryDirectoryPath = (NSTemporaryDirectory() as NSString).appendingPathComponent("org.swift.foundation.TestFoundation.TestURL.\(ProcessInfo.processInfo.processIdentifier)")
     static var gBaseCurrentWorkingDirectoryPath : String {
         return FileManager.default.currentDirectoryPath


### PR DESCRIPTION
Since '|' is a valid character in a url on Windows as implemented by
CoreFoundation, on Windows, we should expect that `unescaped|pipe`
should be properly parsed.

This is hacky, but adds a test case on Windows, and disables it on other
platforms and vice versa.