### PR TITLE
Disable FileManager XDG Tests on Windows

### DIFF
--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -1818,7 +1818,7 @@ VIDEOS=StopgapVideos
             ])
         #endif
         
-        #if !DEPLOYMENT_RUNTIME_OBJC && !os(Android)
+        #if !DEPLOYMENT_RUNTIME_OBJC && !os(Android) && !os(Windows)
         tests.append(contentsOf: [
             ("test_fetchXDGPathsFromHelper", test_fetchXDGPathsFromHelper),
             ])


### PR DESCRIPTION
Windows doesn't conform to XDG so the tests are not applicable.