### PR TITLE
[Windows] Disable TestHTTPCookieStorage XDG Test

### DIFF
--- a/TestFoundation/TestHTTPCookieStorage.swift
+++ b/TestFoundation/TestHTTPCookieStorage.swift
@@ -308,7 +308,7 @@ class TestHTTPCookieStorage: XCTestCase {
     }
 
     func test_cookieInXDGSpecPath() {
-#if !os(Android) && !DARWIN_COMPATIBILITY_TESTS // No XDG on native Foundation
+#if !os(Android) && !DARWIN_COMPATIBILITY_TESTS && !os(Windows)// No XDG on native Foundation
         //Test without setting the environment variable
         let testCookie = HTTPCookie(properties: [
            .name: "TestCookie0",


### PR DESCRIPTION
Windows doesn't conform to XDG so the test isn't applicable