### PR TITLE
[Windows] Match error behavior of POSIX

### DIFF
--- a/Foundation/FoundationErrors.swift
+++ b/Foundation/FoundationErrors.swift
@@ -248,8 +248,8 @@ internal func _NSErrorWithWindowsError(_ windowsError: DWORD, reading: Bool, pat
                         // On an empty path, Windows will return FILE/PATH_NOT_FOUND
                         // rather than invalid path as posix does
                         cocoaError = paths?.contains("") ?? false
-                            ? .fileReadInvalidFileName
-                            : .fileReadNoSuchFile
+                            ? .fileWriteInvalidFileName
+                            : .fileNoSuchFile
                     case ERROR_ACCESS_DENIED: cocoaError = .fileWriteNoPermission
                     case ERROR_INVALID_ACCESS: cocoaError = .fileWriteNoPermission
                     case ERROR_INVALID_DRIVE: cocoaError = .fileNoSuchFile


### PR DESCRIPTION
On POSIX Foundation, removing  a file is considered writing to it and so
when the file to be removed isn't found, it throws fileNoSuchFile. Since
Windows instead checks for the file attributes first which is considered
a read, it throws there with fileReadNoSuchFile. In removeItem to match
that behavior, we catch the fileReadNoSuchFile and turn it into
fileNoSuchFile.