### PR TITLE
Enable Enum Imports and Synchronize Paths

### DIFF
--- a/CoreFoundation/Base.subproj/CFAvailability.h
+++ b/CoreFoundation/Base.subproj/CFAvailability.h
@@ -123,7 +123,7 @@
 #endif
 
 #define __CF_ENUM_GET_MACRO(_1, _2, NAME, ...) NAME
-#if (__cplusplus && __cplusplus >= 201103L && (__has_extension(cxx_strong_enums) || __has_feature(objc_fixed_enum))) || (!__cplusplus && __has_feature(objc_fixed_enum))
+#if (__cplusplus && __cplusplus >= 201103L && (__has_extension(cxx_strong_enums) || __has_feature(objc_fixed_enum))) || (!__cplusplus && (__has_feature(objc_fixed_enum) || __has_extension(cxx_fixed_enum)))
 #define __CF_NAMED_ENUM(_type, _name)     enum __CF_ENUM_ATTRIBUTES _name : _type _name; enum _name : _type
 #define __CF_ANON_ENUM(_type)             enum __CF_ENUM_ATTRIBUTES : _type
 #define CF_CLOSED_ENUM(_type, _name)      enum __CF_CLOSED_ENUM_ATTRIBUTES _name : _type _name; enum _name : _type

--- a/CoreFoundation/Locale.subproj/CFDateComponents.h
+++ b/CoreFoundation/Locale.subproj/CFDateComponents.h
@@ -16,8 +16,13 @@ CF_IMPLICIT_BRIDGING_ENABLED
 CF_EXTERN_C_BEGIN
 CF_ASSUME_NONNULL_BEGIN
 
+// Must match NSDateComponentUndefined
 CF_ENUM(CFIndex) {
-    CFDateComponentUndefined = __LONG_MAX__ // Must match NSDateComponentUndefined
+#if TARGET_OS_WIN32
+    CFDateComponentUndefined = LLONG_MAX
+#else
+    CFDateComponentUndefined = __LONG_MAX__
+#endif
 };
 
 enum {

--- a/Foundation/DateFormatter.swift
+++ b/Foundation/DateFormatter.swift
@@ -14,13 +14,8 @@ open class DateFormatter : Formatter {
     private var __cfObject: CFType?
     private var _cfObject: CFType {
         guard let obj = __cfObject else {
-            #if os(macOS) || os(iOS)
-                let dateStyle = CFDateFormatterStyle(rawValue: CFIndex(self.dateStyle.rawValue))!
-                let timeStyle = CFDateFormatterStyle(rawValue: CFIndex(self.timeStyle.rawValue))!
-            #else
-                let dateStyle = CFDateFormatterStyle(self.dateStyle.rawValue)
-                let timeStyle = CFDateFormatterStyle(self.timeStyle.rawValue)
-            #endif
+            let dateStyle = CFDateFormatterStyle(rawValue: CFIndex(self.dateStyle.rawValue))!
+            let timeStyle = CFDateFormatterStyle(rawValue: CFIndex(self.timeStyle.rawValue))!
 
             let obj = CFDateFormatterCreate(kCFAllocatorSystemDefault, locale._cfObject, dateStyle, timeStyle)!
             _setFormatterAttributes(obj)

--- a/Foundation/DateIntervalFormatter.swift
+++ b/Foundation/DateIntervalFormatter.swift
@@ -9,7 +9,6 @@
 
 import CoreFoundation
 
-#if _runtime(_ObjC)
 internal let kCFDateIntervalFormatterNoStyle = CFDateIntervalFormatterStyle.noStyle
 internal let kCFDateIntervalFormatterShortStyle = CFDateIntervalFormatterStyle.shortStyle
 internal let kCFDateIntervalFormatterMediumStyle = CFDateIntervalFormatterStyle.mediumStyle
@@ -19,7 +18,6 @@ internal let kCFDateIntervalFormatterFullStyle = CFDateIntervalFormatterStyle.fu
 internal let kCFDateIntervalFormatterBoundaryStyleDefault = _CFDateIntervalFormatterBoundaryStyle.cfDateIntervalFormatterBoundaryStyleDefault
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 internal let kCFDateIntervalFormatterBoundaryStyleMinimizeAdjacentMonths = _CFDateIntervalFormatterBoundaryStyle.cfDateIntervalFormatterBoundaryStyleMinimizeAdjacentMonths
-#endif
 #endif
 
 extension DateIntervalFormatter {

--- a/Foundation/ISO8601DateFormatter.swift
+++ b/Foundation/ISO8601DateFormatter.swift
@@ -54,11 +54,7 @@ open class ISO8601DateFormatter : Formatter, NSSecureCoding {
     private var __cfObject: CFType?
     private var _cfObject: CFType {
         guard let obj = __cfObject else {
-            #if os(macOS) || os(iOS)
-                let format = CFISO8601DateFormatOptions(rawValue: formatOptions.rawValue)
-            #else
-                let format = CFISO8601DateFormatOptions(self.formatOptions.rawValue)
-            #endif
+            let format = CFISO8601DateFormatOptions(rawValue: formatOptions.rawValue)
             let obj = CFDateFormatterCreateISO8601Formatter(kCFAllocatorSystemDefault, format)!
             CFDateFormatterSetProperty(obj, kCFDateFormatterTimeZone, timeZone._cfObject)
             __cfObject = obj
@@ -137,17 +133,10 @@ open class ISO8601DateFormatter : Formatter, NSSecureCoding {
     }
     
     open class func string(from date: Date, timeZone: TimeZone, formatOptions: ISO8601DateFormatter.Options = []) -> String {
-        
-        #if os(macOS) || os(iOS)
-            let format = CFISO8601DateFormatOptions(rawValue: formatOptions.rawValue)
-        #else
-            let format = CFISO8601DateFormatOptions(formatOptions.rawValue)
-        #endif
-        
+        let format = CFISO8601DateFormatOptions(rawValue: formatOptions.rawValue)
         let obj = CFDateFormatterCreateISO8601Formatter(kCFAllocatorSystemDefault, format)
         CFDateFormatterSetProperty(obj, kCFDateFormatterTimeZone, timeZone._cfObject)
         return CFDateFormatterCreateStringWithDate(kCFAllocatorSystemDefault, obj, date._cfObject)._swiftObject
-        
     }
     
     private func _reset() {

--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -9,7 +9,6 @@
 
 import CoreFoundation
 
-#if canImport(ObjectiveC) // automatic CF_OPTIONS(…) OptionSet hoisting depends on the objc_fixed_enum attribute
 internal let kCFCalendarUnitEra = CFCalendarUnit.era
 internal let kCFCalendarUnitYear = CFCalendarUnit.year
 internal let kCFCalendarUnitMonth = CFCalendarUnit.month
@@ -34,26 +33,6 @@ internal let kCFDateFormatterShortStyle = CFDateFormatterStyle.shortStyle
 internal let kCFDateFormatterMediumStyle = CFDateFormatterStyle.mediumStyle
 internal let kCFDateFormatterLongStyle = CFDateFormatterStyle.longStyle
 internal let kCFDateFormatterFullStyle = CFDateFormatterStyle.fullStyle
-#else
-internal let kCFCalendarUnitEra = CFCalendarUnit(CoreFoundation.kCFCalendarUnitEra)
-internal let kCFCalendarUnitYear = CFCalendarUnit(CoreFoundation.kCFCalendarUnitYear)
-internal let kCFCalendarUnitMonth = CFCalendarUnit(CoreFoundation.kCFCalendarUnitMonth)
-internal let kCFCalendarUnitDay = CFCalendarUnit(CoreFoundation.kCFCalendarUnitDay)
-internal let kCFCalendarUnitHour = CFCalendarUnit(CoreFoundation.kCFCalendarUnitHour)
-internal let kCFCalendarUnitMinute = CFCalendarUnit(CoreFoundation.kCFCalendarUnitMinute)
-internal let kCFCalendarUnitSecond = CFCalendarUnit(CoreFoundation.kCFCalendarUnitSecond)
-internal let kCFCalendarUnitWeekday = CFCalendarUnit(CoreFoundation.kCFCalendarUnitWeekday)
-internal let kCFCalendarUnitWeekdayOrdinal = CFCalendarUnit(CoreFoundation.kCFCalendarUnitWeekdayOrdinal)
-internal let kCFCalendarUnitQuarter = CFCalendarUnit(CoreFoundation.kCFCalendarUnitQuarter)
-internal let kCFCalendarUnitWeekOfMonth = CFCalendarUnit(CoreFoundation.kCFCalendarUnitWeekOfMonth)
-internal let kCFCalendarUnitWeekOfYear = CFCalendarUnit(CoreFoundation.kCFCalendarUnitWeekOfYear)
-internal let kCFCalendarUnitYearForWeekOfYear = CFCalendarUnit(CoreFoundation.kCFCalendarUnitYearForWeekOfYear)
-internal let kCFCalendarUnitNanosecond = CFCalendarUnit(CoreFoundation.kCFCalendarUnitNanosecond)
-
-internal func _CFCalendarUnitRawValue(_ unit: CFCalendarUnit) -> CFOptionFlags {
-    return unit
-}
-#endif
 
 extension NSCalendar {
     public struct Identifier : RawRepresentable, Equatable, Hashable, Comparable {
@@ -109,11 +88,7 @@ extension NSCalendar {
         public static let timeZone = Unit(rawValue: UInt(1 << 21))
 
         internal var _cfValue: CFCalendarUnit {
-#if os(macOS) || os(iOS)
             return CFCalendarUnit(rawValue: self.rawValue)
-#else
-            return CFCalendarUnit(self.rawValue)
-#endif
         }
     }
 

--- a/Foundation/NSCharacterSet.swift
+++ b/Foundation/NSCharacterSet.swift
@@ -10,7 +10,6 @@
 
 import CoreFoundation
 
-#if _runtime(_ObjC) // if objc_enum works, restore the old names:
 let kCFCharacterSetControl = CFCharacterSetPredefinedSet.control
 let kCFCharacterSetWhitespace = CFCharacterSetPredefinedSet.whitespace
 let kCFCharacterSetWhitespaceAndNewline = CFCharacterSetPredefinedSet.whitespaceAndNewline
@@ -32,9 +31,7 @@ let kCFCharacterSetKeyedCodingTypeBuiltin = CFCharacterSetKeyedCodingType.builti
 let kCFCharacterSetKeyedCodingTypeRange = CFCharacterSetKeyedCodingType.range
 let kCFCharacterSetKeyedCodingTypeString = CFCharacterSetKeyedCodingType.string
 let kCFCharacterSetKeyedCodingTypeBuiltinAndBitmap = CFCharacterSetKeyedCodingType.builtinAndBitmap
-#endif
 
-#if _runtime(_ObjC)
 fileprivate let lastKnownPredefinedCharacterSetConstant = kCFCharacterSetNewline.rawValue
 
 fileprivate extension Int {
@@ -42,17 +39,10 @@ fileprivate extension Int {
         self = predefinedSet.rawValue
     }
 }
-#else
-fileprivate let lastKnownPredefinedCharacterSetConstant = kCFCharacterSetNewline
-#endif
 
 fileprivate func knownPredefinedCharacterSet(rawValue: Int) -> CFCharacterSetPredefinedSet? {
     if rawValue > 0 && rawValue <= lastKnownPredefinedCharacterSetConstant {
-        #if _runtime(_ObjC)
             return CFCharacterSetPredefinedSet(rawValue: rawValue)
-        #else
-            return CFCharacterSetPredefinedSet(rawValue)
-        #endif
     } else {
         return nil
     }
@@ -69,7 +59,6 @@ fileprivate extension String {
     static let characterSetIsInvertedKey = "NSIsInverted"
     static let characterSetNewIsInvertedKey = "NSIsInverted2"
 }
-
 
 open class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     typealias CFType = CFCharacterSet

--- a/Foundation/NSLocale.swift
+++ b/Foundation/NSLocale.swift
@@ -150,20 +150,12 @@ extension NSLocale {
     
     open class func characterDirection(forLanguage isoLangCode: String) -> NSLocale.LanguageDirection {
         let dir = CFLocaleGetLanguageCharacterDirection(isoLangCode._cfObject)
-#if os(macOS) || os(iOS)
         return NSLocale.LanguageDirection(rawValue: UInt(dir.rawValue))!
-#else
-        return NSLocale.LanguageDirection(rawValue: UInt(dir))!
-#endif
     }
     
     open class func lineDirection(forLanguage isoLangCode: String) -> NSLocale.LanguageDirection {
         let dir = CFLocaleGetLanguageLineDirection(isoLangCode._cfObject)
-#if os(macOS) || os(iOS)
         return NSLocale.LanguageDirection(rawValue: UInt(dir.rawValue))!
-#else
-        return NSLocale.LanguageDirection(rawValue: UInt(dir))!
-#endif
     }
 }
 

--- a/Foundation/NSNumber.swift
+++ b/Foundation/NSNumber.swift
@@ -10,7 +10,6 @@
 
 import CoreFoundation
 
-#if os(macOS) || os(iOS)
 internal let kCFNumberSInt8Type = CFNumberType.sInt8Type
 internal let kCFNumberSInt16Type = CFNumberType.sInt16Type
 internal let kCFNumberSInt32Type = CFNumberType.sInt32Type
@@ -28,9 +27,6 @@ internal let kCFNumberCFIndexType = CFNumberType.cfIndexType
 internal let kCFNumberNSIntegerType = CFNumberType.nsIntegerType
 internal let kCFNumberCGFloatType = CFNumberType.cgFloatType
 internal let kCFNumberSInt128Type = CFNumberType(rawValue: 17)!
-#else
-internal let kCFNumberSInt128Type: CFNumberType = 17
-#endif
 
 extension Int8 : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")

--- a/Foundation/NSObjCRuntime.swift
+++ b/Foundation/NSObjCRuntime.swift
@@ -10,11 +10,9 @@
 
 import CoreFoundation
 
-#if os(macOS) || os(iOS)
 internal let kCFCompareLessThan = CFComparisonResult.compareLessThan
 internal let kCFCompareEqualTo = CFComparisonResult.compareEqualTo
 internal let kCFCompareGreaterThan = CFComparisonResult.compareGreaterThan
-#endif
 
 internal enum _NSSimpleObjCType : UnicodeScalar {
     case ID = "@"

--- a/Foundation/NSRegularExpression.swift
+++ b/Foundation/NSRegularExpression.swift
@@ -80,11 +80,7 @@ open class NSRegularExpression: NSObject, NSCopying, NSSecureCoding {
     
     public init(pattern: String, options: Options = []) throws {
         var error: Unmanaged<CFError>?
-#if os(macOS) || os(iOS)
         let opt =  _CFRegularExpressionOptions(rawValue: options.rawValue)
-#else
-        let opt = _CFRegularExpressionOptions(options.rawValue)
-#endif
         if let regex = _CFRegularExpressionCreate(kCFAllocatorSystemDefault, pattern._cfObject, opt, &error) {
             _internal = regex
         } else {
@@ -97,11 +93,7 @@ open class NSRegularExpression: NSObject, NSCopying, NSSecureCoding {
     }
     
     open var options: Options {
-#if os(macOS) || os(iOS)
         let opt = _CFRegularExpressionGetOptions(_internal).rawValue
-#else
-        let opt = _CFRegularExpressionGetOptions(_internal)
-#endif
     
         return Options(rawValue: opt)
     }
@@ -158,11 +150,7 @@ internal class _NSRegularExpressionMatcher {
 
 internal func _NSRegularExpressionMatch(_ context: UnsafeMutableRawPointer?, ranges: UnsafeMutablePointer<CFRange>?, count: CFIndex, flags: _CFRegularExpressionMatchingFlags, stop: UnsafeMutablePointer<_DarwinCompatibleBoolean>) -> Void {
     let matcher = unsafeBitCast(context, to: _NSRegularExpressionMatcher.self)
-#if os(macOS) || os(iOS)
     let flags = NSRegularExpression.MatchingFlags(rawValue: flags.rawValue)
-#else
-    let flags = NSRegularExpression.MatchingFlags(rawValue: flags)
-#endif
     let result = ranges?.withMemoryRebound(to: NSRange.self, capacity: count) { rangePtr in
         NSTextCheckingResult.regularExpressionCheckingResult(ranges: rangePtr, count: count, regularExpression: matcher.regex)
     }
@@ -179,11 +167,7 @@ extension NSRegularExpression {
     public func enumerateMatches(in string: String, options: NSRegularExpression.MatchingOptions = [], range: NSRange, using block: @escaping (NSTextCheckingResult?, NSRegularExpression.MatchingFlags, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) {
         let matcher = _NSRegularExpressionMatcher(regex: self, block: block)
         withExtendedLifetime(matcher) { (m: _NSRegularExpressionMatcher) -> Void in
-#if os(macOS) || os(iOS)
         let opts = _CFRegularExpressionMatchingOptions(rawValue: options.rawValue)
-#else
-        let opts = _CFRegularExpressionMatchingOptions(options.rawValue)
-#endif
             _CFRegularExpressionEnumerateMatchesInString(_internal, string._cfObject, opts, CFRange(range), unsafeBitCast(matcher, to: UnsafeMutableRawPointer.self), _NSRegularExpressionMatch)
         }
     }

--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -28,7 +28,6 @@ func NSLocalizedString(_ key: String,
     return bundle.localizedString(forKey: key, value: value, table: tableName)
 }
 
-#if os(macOS) || os(iOS)
 internal let kCFStringEncodingMacRoman =  CFStringBuiltInEncodings.macRoman.rawValue
 internal let kCFStringEncodingWindowsLatin1 =  CFStringBuiltInEncodings.windowsLatin1.rawValue
 internal let kCFStringEncodingISOLatin1 =  CFStringBuiltInEncodings.isoLatin1.rawValue
@@ -53,8 +52,6 @@ internal let kCFStringNormalizationFormD = CFStringNormalizationForm.D
 internal let kCFStringNormalizationFormKD = CFStringNormalizationForm.KD
 internal let kCFStringNormalizationFormC = CFStringNormalizationForm.C
 internal let kCFStringNormalizationFormKC = CFStringNormalizationForm.KC
-    
-#endif
 
 extension NSString {
 
@@ -105,11 +102,7 @@ extension NSString {
         public static let regularExpression = CompareOptions(rawValue: 1024)
         
         internal func _cfValue(_ fixLiteral: Bool = false) -> CFStringCompareFlags {
-#if os(macOS) || os(iOS)
             return contains(.literal) || !fixLiteral ? CFStringCompareFlags(rawValue: rawValue) : CFStringCompareFlags(rawValue: rawValue).union(.compareNonliteral)
-#else
-            return contains(.literal) || !fixLiteral ? CFStringCompareFlags(rawValue) : CFStringCompareFlags(rawValue) | UInt(kCFCompareNonliteral)
-#endif
         }
     }
 }

--- a/Foundation/NSTimeZone.swift
+++ b/Foundation/NSTimeZone.swift
@@ -256,11 +256,7 @@ open class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
     }
 
     open func localizedName(_ style: NameStyle, locale: Locale?) -> String? {
-        #if os(macOS) || os(iOS)
-            let cfStyle = CFTimeZoneNameStyle(rawValue: style.rawValue)!
-        #else
-            let cfStyle = CFTimeZoneNameStyle(style.rawValue)
-        #endif
+        let cfStyle = CFTimeZoneNameStyle(rawValue: style.rawValue)!
         return CFTimeZoneCopyLocalizedName(self._cfObject, cfStyle, locale?._cfObject ?? CFLocaleCopyCurrent())._swiftObject
     }
 

--- a/Foundation/NSURL.swift
+++ b/Foundation/NSURL.swift
@@ -10,10 +10,8 @@
 
 import CoreFoundation
 
-#if os(macOS) || os(iOS)
 internal let kCFURLPOSIXPathStyle = CFURLPathStyle.cfurlposixPathStyle
 internal let kCFURLWindowsPathStyle = CFURLPathStyle.cfurlWindowsPathStyle
-#endif
 
 #if canImport(Darwin)
 import Darwin
@@ -524,11 +522,7 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     
     open var password: String? {
         let absoluteURL = CFURLCopyAbsoluteURL(_cfObject)
-#if os(Linux) || os(Android) || os(Windows)
-        let passwordRange = CFURLGetByteRangeForComponent(absoluteURL, kCFURLComponentPassword, nil)
-#else
         let passwordRange = CFURLGetByteRangeForComponent(absoluteURL, .password, nil)
-#endif
         guard passwordRange.location != kCFNotFound else {
             return nil
         }

--- a/Foundation/NumberFormatter.swift
+++ b/Foundation/NumberFormatter.swift
@@ -9,7 +9,6 @@
 
 import CoreFoundation
 
-
 extension NumberFormatter {
     public enum Style : UInt {
         case none               = 0
@@ -50,11 +49,7 @@ open class NumberFormatter : Formatter {
         if let obj = _currentCfFormatter {
             return obj
         } else {
-            #if os(macOS) || os(iOS)
-                let numberStyle = CFNumberFormatterStyle(rawValue: CFIndex(self.numberStyle.rawValue))!
-            #else
-                let numberStyle = CFNumberFormatterStyle(self.numberStyle.rawValue)
-            #endif
+            let numberStyle = CFNumberFormatterStyle(rawValue: CFIndex(self.numberStyle.rawValue))!
 
             let obj = CFNumberFormatterCreate(kCFAllocatorSystemDefault, locale._cfObject, numberStyle)!
             _setFormatterAttributes(obj)
@@ -98,11 +93,7 @@ open class NumberFormatter : Formatter {
         var range = CFRange(location: 0, length: string.length)
         let number = withUnsafeMutablePointer(to: &range) { (rangePointer: UnsafeMutablePointer<CFRange>) -> NSNumber? in
 
-            #if os(macOS) || os(iOS)
-                let parseOption = allowsFloats ? 0 : CFNumberFormatterOptionFlags.parseIntegersOnly.rawValue
-            #else
-                let parseOption = allowsFloats ? 0 : CFOptionFlags(kCFNumberFormatterParseIntegersOnly)
-            #endif
+            let parseOption = allowsFloats ? 0 : CFNumberFormatterOptionFlags.parseIntegersOnly.rawValue
             let result = CFNumberFormatterCreateNumberFromString(kCFAllocatorSystemDefault, _cfFormatter, string._cfObject, rangePointer, parseOption)
 
             return result?._nsObject

--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -40,7 +40,6 @@ private var managerThreadRunLoop : RunLoop? = nil
 private var managerThreadRunLoopIsRunning = false
 private var managerThreadRunLoopIsRunningCondition = NSCondition()
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 internal let kCFSocketNoCallBack: CFOptionFlags = 0 // .noCallBack cannot be used because empty option flags are imported as unavailable.
 internal let kCFSocketAcceptCallBack = CFSocketCallBackType.acceptCallBack.rawValue
 internal let kCFSocketDataCallBack = CFSocketCallBackType.dataCallBack.rawValue
@@ -54,7 +53,6 @@ extension CFSocketError {
         self.init(rawValue: value)
     }
 }
-#endif
 
 private func emptyRunLoopCallback(_ context : UnsafeMutableRawPointer?) -> Void {}
 

--- a/Foundation/PropertyListSerialization.swift
+++ b/Foundation/PropertyListSerialization.swift
@@ -9,11 +9,9 @@
 
 import CoreFoundation
 
-#if os(macOS) || os(iOS)
 let kCFPropertyListOpenStepFormat = CFPropertyListFormat.openStepFormat
 let kCFPropertyListXMLFormat_v1_0 = CFPropertyListFormat.xmlFormat_v1_0
 let kCFPropertyListBinaryFormat_v1_0 = CFPropertyListFormat.binaryFormat_v1_0
-#endif
 
 extension PropertyListSerialization {
 
@@ -39,11 +37,7 @@ extension PropertyListSerialization {
 open class PropertyListSerialization : NSObject {
 
     open class func propertyList(_ plist: Any, isValidFor format: PropertyListFormat) -> Bool {
-#if os(macOS) || os(iOS)
         let fmt = CFPropertyListFormat(rawValue: CFIndex(format.rawValue))!
-#else
-        let fmt = CFPropertyListFormat(format.rawValue)
-#endif
         let plistObj = __SwiftValue.store(plist)
         return CFPropertyListIsValid(plistObj, fmt)
     }
@@ -51,11 +45,7 @@ open class PropertyListSerialization : NSObject {
     open class func data(fromPropertyList plist: Any, format: PropertyListFormat, options opt: WriteOptions) throws -> Data {
         var error: Unmanaged<CFError>? = nil
         let result = withUnsafeMutablePointer(to: &error) { (outErr: UnsafeMutablePointer<Unmanaged<CFError>?>) -> CFData? in
-#if os(macOS) || os(iOS)
             let fmt = CFPropertyListFormat(rawValue: CFIndex(format.rawValue))!
-#else
-            let fmt = CFPropertyListFormat(format.rawValue)
-#endif
             let options = CFOptionFlags(opt)
             let plistObj = __SwiftValue.store(plist)
             let d = CFPropertyListCreateData(kCFAllocatorSystemDefault, plistObj, fmt, options, outErr)
@@ -76,11 +66,7 @@ open class PropertyListSerialization : NSObject {
                 return unsafeBitCast(CFPropertyListCreateWithData(kCFAllocatorSystemDefault, data._cfObject, CFOptionFlags(CFIndex(opt.rawValue)), outFmt, outErr), to: NSObject.self)
             }
         }
-#if os(macOS) || os(iOS)
         format?.pointee = PropertyListFormat(rawValue: UInt(fmt.rawValue))!
-#else
-        format?.pointee = PropertyListFormat(rawValue: UInt(fmt))!
-#endif
         if let err = error {
             throw err.takeUnretainedValue()._nsObject
         } else {
@@ -96,11 +82,7 @@ open class PropertyListSerialization : NSObject {
                 return unsafeBitCast(CFPropertyListCreateWithStream(kCFAllocatorSystemDefault, stream, 0, CFOptionFlags(CFIndex(opt.rawValue)), outFmt, outErr), to: NSObject.self)
             }
         }
-#if os(macOS) || os(iOS)
         format?.pointee = PropertyListFormat(rawValue: UInt(fmt.rawValue))!
-#else
-        format?.pointee = PropertyListFormat(rawValue: UInt(fmt))!
-#endif
         if let err = error {
             throw err.takeUnretainedValue()._nsObject
         } else {

--- a/Foundation/RunLoop.swift
+++ b/Foundation/RunLoop.swift
@@ -9,15 +9,13 @@
 
 import CoreFoundation
 
-#if os(macOS) || os(iOS)
-    internal let kCFRunLoopEntry = CFRunLoopActivity.entry.rawValue
-    internal let kCFRunLoopBeforeTimers = CFRunLoopActivity.beforeTimers.rawValue
-    internal let kCFRunLoopBeforeSources = CFRunLoopActivity.beforeSources.rawValue
-    internal let kCFRunLoopBeforeWaiting = CFRunLoopActivity.beforeWaiting.rawValue
-    internal let kCFRunLoopAfterWaiting = CFRunLoopActivity.afterWaiting.rawValue
-    internal let kCFRunLoopExit = CFRunLoopActivity.exit.rawValue
-    internal let kCFRunLoopAllActivities = CFRunLoopActivity.allActivities.rawValue
-#endif
+internal let kCFRunLoopEntry = CFRunLoopActivity.entry.rawValue
+internal let kCFRunLoopBeforeTimers = CFRunLoopActivity.beforeTimers.rawValue
+internal let kCFRunLoopBeforeSources = CFRunLoopActivity.beforeSources.rawValue
+internal let kCFRunLoopBeforeWaiting = CFRunLoopActivity.beforeWaiting.rawValue
+internal let kCFRunLoopAfterWaiting = CFRunLoopActivity.afterWaiting.rawValue
+internal let kCFRunLoopExit = CFRunLoopActivity.exit.rawValue
+internal let kCFRunLoopAllActivities = CFRunLoopActivity.allActivities.rawValue
 
 extension RunLoop {
     public struct Mode : RawRepresentable, Equatable, Hashable {

--- a/Foundation/Stream.swift
+++ b/Foundation/Stream.swift
@@ -9,13 +9,11 @@
 
 import CoreFoundation
 
-#if os(macOS) || os(iOS)
 internal extension UInt {
     init(_ status: CFStreamStatus) {
         self.init(status.rawValue)
     }
 }
-#endif
 
 extension Stream {
     public struct PropertyKey : RawRepresentable, Equatable, Hashable {


### PR DESCRIPTION
Windows wasn't going down the 64bit enum path in CoreFoundation which caused CFDateComponentUndefined to be 32bit and NSDateComponentUndefined and thus not match. Since changing this causes the enum behavior to change, I've rebased https://github.com/apple/swift-corelibs-foundation/pull/1729 and included it in this pull.