### PR TITLE
Include null terminator in length for getCString

### DIFF
--- a/CoreFoundation/String.subproj/CFString.c
+++ b/CoreFoundation/String.subproj/CFString.c
@@ -2227,8 +2227,8 @@ Boolean CFStringGetCString(CFStringRef str, char *buffer, CFIndex bufferSize, CF
 
     __CFAssertIsNotNegative(bufferSize);
     if (bufferSize < 1) return false;
-    CF_SWIFT_FUNCDISPATCHV(_kCFRuntimeIDCFString, Boolean, (CFSwiftRef)str, NSString._getCString, buffer, bufferSize - 1, encoding);
-    CF_OBJC_FUNCDISPATCHV(_kCFRuntimeIDCFString, Boolean, (NSString *)str, _getCString:buffer maxLength:(NSUInteger)bufferSize - 1 encoding:encoding);
+    CF_SWIFT_FUNCDISPATCHV(_kCFRuntimeIDCFString, Boolean, (CFSwiftRef)str, NSString._getCString, buffer, bufferSize, encoding);
+    CF_OBJC_FUNCDISPATCHV(_kCFRuntimeIDCFString, Boolean, (NSString *)str, _getCString:buffer maxLength:(NSUInteger)bufferSize encoding:encoding);
 
     __CFAssertIsString(str);
 


### PR DESCRIPTION
Both CFStringGetCString and NSString._getCString expect the buffer size
to include space for a null terminator, so there is no reason to
subtract 1 from the buffer size before handing off to NSString

This was causing the last character to be truncated in certain calls to CFStringGetCString.