### PR TITLE
[Android] Use CFFIXED_USER_HOME for bundle path

### DIFF
--- a/CoreFoundation/PlugIn.subproj/CFBundle_Executable.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Executable.c
@@ -310,6 +310,20 @@ static CFURLRef _CFBundleCopyBundleURLForExecutablePath(CFStringRef str) {
     CFIndex buffLen;
     CFURLRef url = NULL;
     CFStringRef outstr;
+
+#if TARGET_OS_ANDROID
+    const char *fixedUserHome = __CFgetenv("CFFIXED_USER_HOME");
+    if (fixedUserHome) {
+        outstr = CFStringCreateWithCString(kCFAllocatorSystemDefault, fixedUserHome, kCFStringEncodingUTF8);
+        if (outstr) {
+            url = CFURLCreateWithFileSystemPath(kCFAllocatorSystemDefault, outstr, PLATFORM_PATH_STYLE, true);
+            CFRelease(outstr);
+            if (url) {
+                return url;
+            }
+        }
+    }
+#endif
     
     buffLen = CFStringGetLength(str);
     if (buffLen > CFMaxPathSize) buffLen = CFMaxPathSize;


### PR DESCRIPTION
For Android, the main bundle path is set to the executable directory, which is something like `/system/bin/app_process32`.  As a result, things like localized strings do not work.

This PR allows the bundle path to be set by the `CFFIXED_USER_HOME` environmental variable.

In my case, I set this in the Kotlin (or Java) initialization code as follows...

```
Os.setenv("CFFIXED_USER_HOME", mainActivity.filesDir.path, true)
```

I then copy the files from the asset manager into the files directory.  This includes `Info.plist` which configures the bundle identifier and development region, and `en.lproj/Localizable.strings` which contain the English strings.

Once these are in place, I can call `NSLocalizedString` to get the localized string.