### PR TITLE
Process: .currentDirectoryURL and .executableURL fixes

### DIFF
--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -99,6 +99,7 @@ class TestFileManager : XCTestCase {
 
     func test_creatingDirectoryWithShortIntermediatePath() {
         let fileManager = FileManager.default
+        let cwd = fileManager.currentDirectoryPath
         fileManager.changeCurrentDirectoryPath(NSTemporaryDirectory())
 
         let relativePath = NSUUID().uuidString
@@ -109,6 +110,7 @@ class TestFileManager : XCTestCase {
         } catch {
             XCTFail("Failed to create and clean up directory")
         }
+        fileManager.changeCurrentDirectoryPath(cwd)
     }
 
     func test_moveFile() {

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -255,17 +255,18 @@ class TestProcess : XCTestCase {
             if (dir.hasSuffix("/") && dir != "/") || dir.hasSuffix("\\") {
                dir.removeLast()
             }
-            return dir
+            return dir.standardizePath()
         }()
 
         let fm = FileManager.default
         let previousWorkingDirectory = fm.currentDirectoryPath
+        XCTAssertNotEqual(previousWorkingDirectory.standardizePath(), tmpDir)
 
         // Test that getcwd() returns the currentDirectoryPath
         do {
             let (pwd, _) = try runTask([xdgTestHelperURL().path, "--getcwd"], currentDirectoryPath: tmpDir)
             // Check the sub-process used the correct directory
-            XCTAssertEqual(pwd.trimmingCharacters(in: .newlines), tmpDir)
+            XCTAssertEqual(pwd.trimmingCharacters(in: .newlines).standardizePath(), tmpDir)
         } catch {
             XCTFail("Test failed: \(error)")
         }
@@ -274,7 +275,9 @@ class TestProcess : XCTestCase {
         do {
             let (pwd, _) = try runTask([xdgTestHelperURL().path, "--echo-PWD"], currentDirectoryPath: tmpDir)
             // Check the sub-process used the correct directory
-            XCTAssertEqual(pwd.trimmingCharacters(in: .newlines), tmpDir)
+            let cwd = FileManager.default.currentDirectoryPath.standardizePath()
+            XCTAssertNotEqual(cwd, tmpDir)
+            XCTAssertNotEqual(pwd.trimmingCharacters(in: .newlines).standardizePath(), tmpDir)
         } catch {
             XCTFail("Test failed: \(error)")
         }
@@ -566,6 +569,42 @@ class TestProcess : XCTestCase {
     }
 
 
+    func test_currentDirectory() throws {
+
+        let process = Process()
+        XCTAssertNil(process.executableURL)
+        XCTAssertNotNil(process.currentDirectoryURL)
+        process.executableURL = URL(fileURLWithPath: "/some_file_that_doesnt_exist", isDirectory: false)
+        XCTAssertThrowsError(try process.run()) {
+            let code = CocoaError.Code(rawValue: ($0 as? NSError)!.code)
+            XCTAssertEqual(code, .fileReadNoSuchFile)
+        }
+
+        do {
+            let (stdout, _) = try runTask([xdgTestHelperURL().path, "--getcwd"], currentDirectoryPath: "/")
+            XCTAssertEqual(stdout.trimmingCharacters(in: CharacterSet(["\n", "\r"])), "/")
+        }
+
+        do {
+            XCTAssertNotEqual("/", FileManager.default.currentDirectoryPath)
+            XCTAssertNotEqual(FileManager.default.currentDirectoryPath, "/")
+            let (stdout, _) = try runTask([xdgTestHelperURL().path, "--echo-PWD"], currentDirectoryPath: "/")
+            let directory = stdout.trimmingCharacters(in: CharacterSet(["\n", "\r"]))
+            XCTAssertEqual(directory, ProcessInfo.processInfo.environment["PWD"])
+            XCTAssertNotEqual(directory, "/")
+        }
+
+        do {
+            try runTask([xdgTestHelperURL().path, "--getcwd"], currentDirectoryPath: "/some_directory_that_doesnt_exsit")
+        } catch {
+            let code = CocoaError.Code(rawValue: (error as? NSError)!.code)
+            XCTAssertEqual(code, .fileReadNoSuchFile)
+            return
+        }
+        XCTFail("Failed to catch error")
+    }
+
+
     static var allTests: [(String, (TestProcess) -> () throws -> Void)] {
         var tests = [
             ("test_exit0" , test_exit0),
@@ -592,6 +631,7 @@ class TestProcess : XCTestCase {
             ("test_redirect_all_using_null", test_redirect_all_using_null),
             ("test_redirect_all_using_nil", test_redirect_all_using_nil),
             ("test_plutil", test_plutil),
+            ("test_currentDirectory", test_currentDirectory),
         ]
 
 #if !os(Windows)
@@ -690,6 +730,7 @@ class _SignalHelperRunner {
     }
 }
 
+@discardableResult
 internal func runTask(_ arguments: [String], environment: [String: String]? = nil, currentDirectoryPath: String? = nil) throws -> (String, String) {
     let process = Process()
 

--- a/TestFoundation/Utilities.swift
+++ b/TestFoundation/Utilities.swift
@@ -621,6 +621,12 @@ extension XCTest {
     }
 }
 
+extension String {
+    public func standardizePath() -> String {
+        URL(fileURLWithPath: self).resolvingSymlinksInPath().path
+    }
+}
+
 extension FileHandle: TextOutputStream {
     public func write(_ string: String) {
         write(Data(string.utf8))


### PR DESCRIPTION
- currentDirectoryURL should be of type URL?
    
- Disallow setting either property to nil or a non-File URL,
  to match Darwin.
    
- Dont set PWD environment variable, it should just be copied from the
  current environment, to match Darwin.
