### PR TITLE
[test] Rewrite URLSession cookie tests to be independent.

### DIFF
--- a/TestFoundation/HTTPServer.swift
+++ b/TestFoundation/HTTPServer.swift
@@ -588,17 +588,16 @@ public class TestURLSessionServer {
         }
 
         if uri == "/requestCookies" {
-            let text = request.getCommaSeparatedHeaders()
-            return _HTTPResponse(response: .OK, headers: "Content-Length: \(text.data(using: .utf8)!.count)\r\nSet-Cookie: fr=anjd&232; Max-Age=7776000; path=/\r\nSet-Cookie: nm=sddf&232; Max-Age=7776000; path=/; domain=.swift.org; secure; httponly\r\n", body: text)
+            return _HTTPResponse(response: .OK, headers: "Set-Cookie: fr=anjd&232; Max-Age=7776000; path=/\r\nSet-Cookie: nm=sddf&232; Max-Age=7776000; path=/; domain=.swift.org; secure; httponly\r\n", body: "")
         }
 
-        if uri == "/setCookies" {
+        if uri == "/echoHeaders" {
             let text = request.getCommaSeparatedHeaders()
             return _HTTPResponse(response: .OK, headers: "Content-Length: \(text.data(using: .utf8)!.count)", body: text)
         }
         
-        if uri == "/redirectSetCookies" {
-            return _HTTPResponse(response: .REDIRECT, headers: "Location: /setCookies\r\nSet-Cookie: redirect=true; Max-Age=7776000; path=/", body: "")
+        if uri == "/redirectToEchoHeaders" {
+            return _HTTPResponse(response: .REDIRECT, headers: "Location: /echoHeaders\r\nSet-Cookie: redirect=true; Max-Age=7776000; path=/", body: "")
         }
 
         if uri == "/UnitedStates" {


### PR DESCRIPTION
Some cookie tests were depending on previously run tests to be
successful. Rewrite all the tests to be independent from each other.

The first change is that all the tests that deal with cookies try to
clean their cookie storages before starting the testing. This should
avoid previous state leaking into the current test.

Some other changes are made to clarify how the cookie tests are actually
performed. To check that the cookies are set by URLSession, an special
endpoint that echoes back the request header are used. To make it clear,
that endpoint has changed names.

In the cases that we were checking that the response headers were
setting the cookies, we actually check for the right headers to been
set, not some random data in the response (because for some reason, the
request headers were also being echo in another endpoint, which might
have created false positives).

There is also some cleaning of unused variables and var that should have
been let.

I tested this by running all the tests in TestURLSession in the same
run, and also running the individual tests one by one from the command
line.

I recommend reading this diff with whitespace changes disabled (`?w=1` in the address bar).