### PR TITLE
[Windows] Search for Dlls in Bundles Properly

### DIFF
--- a/TestFoundation/TestBundle.swift
+++ b/TestFoundation/TestBundle.swift
@@ -98,7 +98,11 @@ class BundlePlayground {
             case .executable:
                 return ""
             case .library:
+#if os(Windows)
+                return ""
+#else
                 return "lib"
+#endif
             }
         }
     }


### PR DESCRIPTION
On Windows, dlls don't begin with "lib" so the tests should be searching
for "MyDLL.dll", not "libMyDLL.dll"