### PR TITLE
Revert "Process: do not inherit all file descriptors to child processes"

### DIFF
--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -9,10 +9,6 @@
 
 import CoreFoundation
 
-#if canImport(Darwin)
-import Darwin
-#endif
-
 extension Process {
     public enum TerminationReason : Int {
         case exit
@@ -841,21 +837,6 @@ open class Process: NSObject {
             posix(_CFPosixSpawnFileActionsAddClose(fileActions, fd))
         }
 
-        #if canImport(Darwin)
-        var spawnAttrs: posix_spawnattr_t? = nil
-        posix_spawnattr_init(&spawnAttrs)
-        posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_CLOEXEC_DEFAULT))
-        #else
-        for fd in 3 ..< getdtablesize() {
-            guard adddup2[fd] == nil &&
-                  !addclose.contains(fd) &&
-                  fd != taskSocketPair[1] else {
-                    continue // Do not double-close descriptors, or close those pertaining to Pipes or FileHandles we want inherited.
-            }
-            posix(_CFPosixSpawnFileActionsAddClose(fileActions, fd))
-        }
-        #endif
-
         let fileManager = FileManager()
         let previousDirectoryPath = fileManager.currentDirectoryPath
         if !fileManager.changeCurrentDirectoryPath(currentDirectoryURL.path) {
@@ -869,16 +850,9 @@ open class Process: NSObject {
 
         // Launch
         var pid = pid_t()
-        #if os(macOS)
-        guard _CFPosixSpawn(&pid, launchPath, fileActions, &spawnAttrs, argv, envp) == 0 else {
-            throw _NSErrorWithErrno(errno, reading: true, path: launchPath)
-        }
-        #else
         guard _CFPosixSpawn(&pid, launchPath, fileActions, nil, argv, envp) == 0 else {
             throw _NSErrorWithErrno(errno, reading: true, path: launchPath)
         }
-        #endif
-
 
         // Close the write end of the input and output pipes.
         if let pipe = standardInput as? Pipe {

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -565,32 +565,6 @@ class TestProcess : XCTestCase {
         XCTAssertEqual(String(data: stdoutData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), "No files specified.")
     }
 
-    func test_fileDescriptorsAreNotInherited() throws {
-        let task = Process()
-        let someExtraFDs = [dup(1), dup(1), dup(1), dup(1), dup(1), dup(1), dup(1)]
-        task.executableURL = xdgTestHelperURL()
-        task.arguments = ["--print-open-file-descriptors"]
-        task.standardInput = FileHandle.nullDevice
-        let stdoutPipe = Pipe()
-        task.standardOutput = stdoutPipe.fileHandleForWriting
-        task.standardError = FileHandle.nullDevice
-        XCTAssertNoThrow(try task.run())
-
-        try stdoutPipe.fileHandleForWriting.close()
-        let stdoutData = try stdoutPipe.fileHandleForReading.readToEnd()
-        task.waitUntilExit()
-        let stdoutString = String(decoding: stdoutData ?? Data(), as: Unicode.UTF8.self)
-        #if os(macOS)
-        XCTAssertEqual("0\n1\n2\n", stdoutString)
-        #else
-        // on Linux we should also have a /dev/urandom open as well as some socket that Process uses for something.
-        XCTAssert(stdoutString.utf8.starts(with: "0\n1\n2\n3\n".utf8))
-        XCTAssertEqual(stdoutString.components(separatedBy: "\n").count, 6, "\(stdoutString)")
-        #endif
-        for fd in someExtraFDs {
-            close(fd)
-        }
-    }
 
     static var allTests: [(String, (TestProcess) -> () throws -> Void)] {
         var tests = [
@@ -625,7 +599,6 @@ class TestProcess : XCTestCase {
         tests += [
             ("test_interrupt", test_interrupt),
             ("test_suspend_resume", test_suspend_resume),
-            ("test_fileDescriptorsAreNotInherited", test_fileDescriptorsAreNotInherited),
         ]
 #endif
         return tests

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -206,17 +206,6 @@ func cat(_ args: ArraySlice<String>.Iterator) {
     exit(exitCode)
 }
 
-#if !os(Windows)
-func printOpenFileDescriptors() {
-    for fd in 0..<getdtablesize() {
-        if fcntl(fd, F_GETFD) != -1 {
-            print(fd)
-        }
-    }
-    exit(0)
-}
-#endif
-
 // -----
 
 var arguments = ProcessInfo.processInfo.arguments.dropFirst().makeIterator()
@@ -275,11 +264,8 @@ case "--nspathfor":
 #if !os(Windows)
 case "--signal-test":
     signalTest()
-
-case "--print-open-file-descriptors":
-    printOpenFileDescriptors()
 #endif
-
+    
 default:
     fatalError("These arguments are not recognized. Only run this from a unit test.")
 }


### PR DESCRIPTION
Reverts apple/swift-corelibs-foundation#2485

We are seeing failure on Ubuntu 18.04: 

https://ci.swift.org/job/oss-swift-package-linux-ubuntu-18_04/2002/console

```
21:15:52 Test Case 'TestProcess.test_fileDescriptorsAreNotInherited' started at 2019-10-15 04:15:28.804
21:15:52 
/home/buildnode/jenkins/workspace/oss-swift-package-linux-ubuntu-18_04/swift-corelibs-foundation/TestFoundation/TestProcess.swift:587: error: TestProcess.test_fileDescriptorsAreNotInherited : XCTAssertTrue failed - 
21:15:52 /home/buildnode/jenkins/workspace/oss-swift-package-linux-ubuntu-18_04/swift-corelibs-foundation/TestFoundation/TestProcess.swift:588: error: TestProcess.test_fileDescriptorsAreNotInherited : XCTAssertEqual failed: ("5") is not equal to ("6") - 0
21:15:52 1
21:15:52 2
21:15:52 94
21:15:52 
21:15:52 Test Case 'TestProcess.test_fileDescriptorsAreNotInherited' failed (3.39 seconds)
```

cc: @weissi 