### PR TITLE
[Windows] XFAIL Preflight Check Test

### DIFF
--- a/TestFoundation/TestBundle.swift
+++ b/TestFoundation/TestBundle.swift
@@ -575,7 +575,7 @@ class TestBundle : XCTestCase {
             ("test_bundleLoad", test_bundleLoad),
             ("test_bundleLoadWithError", test_bundleLoadWithError),
             ("test_bundleWithInvalidPath", test_bundleWithInvalidPath),
-            ("test_bundlePreflight", test_bundlePreflight),
+            ("test_bundlePreflight", testExpectedToFailOnWindows(test_bundlePreflight, "Preflight checks aren't supported for DLLs")),
             ("test_bundleFindExecutable", test_bundleFindExecutable),
             ("test_bundleFindAuxiliaryExecutables", test_bundleFindAuxiliaryExecutables),
             ("test_bundleForClass", testExpectedToFailOnWindows(test_bundleForClass, "Functionality not yet implemented on Windows. SR-XXXX")),


### PR DESCRIPTION
CoreFoundation doesn't have functionality to verify dlls, instead just
returning success. Since the preflight check doesn't throw, the test
fails.