### PR TITLE
Fix Running Synchronous Operations Without a Queue

### DIFF
--- a/Foundation/Operation.swift
+++ b/Foundation/Operation.swift
@@ -347,7 +347,7 @@ open class Operation : NSObject {
             _state = .executing
             Operation.observeValue(forKeyPath: _NSOperationIsExecuting, ofObject: self)
             
-            _queue?._execute(self)
+            _queue?._execute(self) ?? main()
         }
         
         if __NSOperationState.executing == _state {

--- a/TestFoundation/TestOperationQueue.swift
+++ b/TestFoundation/TestOperationQueue.swift
@@ -15,7 +15,7 @@ class TestOperationQueue : XCTestCase {
             ("test_OperationPriorities", test_OperationPriorities),
             ("test_OperationCount", test_OperationCount),
             ("test_AsyncOperation", test_AsyncOperation),
-            ("test_SyncOperation", test_SyncOperation),
+            ("test_SyncOperationWithoutAQueue", test_SyncOperationWithoutAQueue),
             ("test_isExecutingWorks", test_isExecutingWorks),
             ("test_MainQueueGetter", test_MainQueueGetter),
             ("test_CancelOneOperation", test_CancelOneOperation),
@@ -106,7 +106,7 @@ class TestOperationQueue : XCTestCase {
         XCTAssertTrue(operation.isFinished)
     }
     
-    func test_SyncOperation() {
+    func test_SyncOperationWithoutAQueue() {
         let operation = SyncOperation()
         XCTAssertFalse(operation.isExecuting)
         XCTAssertFalse(operation.isFinished)

--- a/TestFoundation/TestOperationQueue.swift
+++ b/TestFoundation/TestOperationQueue.swift
@@ -15,6 +15,7 @@ class TestOperationQueue : XCTestCase {
             ("test_OperationPriorities", test_OperationPriorities),
             ("test_OperationCount", test_OperationCount),
             ("test_AsyncOperation", test_AsyncOperation),
+            ("test_SyncOperation", test_SyncOperation),
             ("test_isExecutingWorks", test_isExecutingWorks),
             ("test_MainQueueGetter", test_MainQueueGetter),
             ("test_CancelOneOperation", test_CancelOneOperation),
@@ -103,6 +104,18 @@ class TestOperationQueue : XCTestCase {
 
         XCTAssertFalse(operation.isExecuting)
         XCTAssertTrue(operation.isFinished)
+    }
+    
+    func test_SyncOperation() {
+        let operation = SyncOperation()
+        XCTAssertFalse(operation.isExecuting)
+        XCTAssertFalse(operation.isFinished)
+
+        operation.start()
+
+        XCTAssertFalse(operation.isExecuting)
+        XCTAssertTrue(operation.isFinished)
+        XCTAssertTrue(operation.hasRun)
     }
     
     func test_MainQueueGetter() {
@@ -342,6 +355,17 @@ class AsyncOperation: Operation {
             self.isExecuting = false
             self.isFinished = true
         }
+    }
+
+}
+
+class SyncOperation: Operation {
+
+    var hasRun = false
+
+    override func main() {
+        Thread.sleep(forTimeInterval: 1)
+        hasRun = true
     }
 
 }


### PR DESCRIPTION
Fixed issue SR-11621.

When calling `start()` on a synchronous operation, the main was not called.
