### PR TITLE
[Android][Linux] Fixed hang when using RunLoop.main.run with Date()

### DIFF
--- a/CoreFoundation/RunLoop.subproj/CFRunLoop.c
+++ b/CoreFoundation/RunLoop.subproj/CFRunLoop.c
@@ -2846,7 +2846,7 @@ static int32_t __CFRunLoopRun(CFRunLoopRef rl, CFRunLoopModeRef rlm, CFTimeInter
         // Here, use the app-supplied message queue mask. They will set this if they are interested in having this run loop receive windows messages.
         __CFRunLoopWaitForMultipleObjects(waitSet, NULL, poll ? 0 : TIMEOUT_INFINITY, rlm->_msgQMask, &livePort, &windowsMessageReceived);
 #elif TARGET_OS_LINUX
-        __CFRunLoopServiceFileDescriptors(waitSet, CFPORT_NULL, TIMEOUT_INFINITY, &livePort);
+        __CFRunLoopServiceFileDescriptors(waitSet, CFPORT_NULL, poll ? 0 : TIMEOUT_INFINITY, &livePort);
 #endif
         
         __CFRunLoopLock(rl);

--- a/TestFoundation/TestRunLoop.swift
+++ b/TestFoundation/TestRunLoop.swift
@@ -69,6 +69,16 @@ class TestRunLoop : XCTestCase {
         
         XCTAssertLessThan(abs(timerTickInterval - expectedTimeInterval), 0.01)
     }
+
+    func test_runLoopPoll() {
+        let runLoop = RunLoop.current
+
+        let startDate = Date()
+        runLoop.run(until: Date())
+        let endDate = Date()
+
+        XCTAssertLessThan(endDate.timeIntervalSince(startDate), 0.5)
+    }
     
     func test_commonModes() {
         let runLoop = RunLoop.current
@@ -123,6 +133,7 @@ class TestRunLoop : XCTestCase {
             // these tests do not work the same as Darwin https://bugs.swift.org/browse/SR-399
             // ("test_runLoopRunMode", test_runLoopRunMode),
             // ("test_runLoopLimitDate", test_runLoopLimitDate),
+            ("test_runLoopPoll", test_runLoopPoll),
             ("test_addingRemovingPorts", test_addingRemovingPorts),
         ]
     }


### PR DESCRIPTION
When using `RunLoop.main.run(mode: .default, before: Date())` on Android, the call would not return.

This function, along with `limitDate` (which also would hang), calls `CFRunLoopRunInMode`.  According to the [documentation](https://developer.apple.com/documentation/corefoundation/1541988-cfrunloopruninmode), this should return immediately if seconds is 0.

I traced the problem to `__CFRunLoopRun` where there are a few platform specific cases for draining the message queue.  In the `TARGET_OS_LINUX` case, the polling condition was not being considered.

This PR fixes the parameter to be `poll ? 0 : TIMEOUT_INFINITY` as is done for the other platforms, which  allows polling to work on Android.