### PR TITLE
Use receiver's timezone in isValidDate() as per documentation

### DIFF
--- a/Foundation/NSCalendar.swift
+++ b/Foundation/NSCalendar.swift
@@ -1904,13 +1904,13 @@ open class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         if ns != NSDateComponentUndefined && 0 < ns {
             nanosecond = 0
         }
-        let d = calendar.date(from: self._swiftObject)
+        let d = cal.date(from: self._swiftObject)
         if ns != NSDateComponentUndefined && 0 < ns {
             nanosecond = ns
         }
         if let date = d {
             let all: NSCalendar.Unit = [.era, .year, .month, .day, .hour, .minute, .second, .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear, .yearForWeekOfYear]
-            let comps = calendar._bridgeToObjectiveC().components(all, from: date)
+            let comps = cal._bridgeToObjectiveC().components(all, from: date)
             var val = era
             if val != NSDateComponentUndefined {
                 if comps.era != val {

--- a/TestFoundation/TestCalendar.swift
+++ b/TestFoundation/TestCalendar.swift
@@ -272,6 +272,7 @@ class TestNSDateComponents: XCTestCase {
             ("test_dateDifferenceComponents", test_dateDifferenceComponents),
             ("test_nanoseconds", test_nanoseconds),
             ("test_currentCalendar", test_currentCalendar),
+            ("test_isValidDate", test_isValidDate),
         ]
     }
 
@@ -533,5 +534,21 @@ class TestNSDateComponents: XCTestCase {
         XCTAssertEqual(Calendar.current.compare(d1, to: d2, toGranularity: .month), .orderedSame)
         XCTAssertEqual(Calendar.current.compare(d1, to: d2, toGranularity: .weekday), .orderedAscending)
         XCTAssertEqual(Calendar.current.compare(d2, to: d1, toGranularity: .weekday), .orderedDescending)
+    }
+    
+    func test_isValidDate() {
+        let components = NSDateComponents()
+        components.year = 2019
+        components.month = 11
+        components.day = 3
+        components.hour = 7
+        components.minute = 5
+        components.second = 54
+        components.timeZone = TimeZone(secondsFromGMT: -18000)!
+        
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/Chicago")!
+
+        XCTAssert(components.isValidDate(in: Calendar(identifier: Calendar.Identifier.gregorian)))
     }
 }


### PR DESCRIPTION
The [documentation of DateComponents.isValidDate(in:)](https://developer.apple.com/documentation/foundation/nsdatecomponents/1412707-isvaliddate) indicates that the receiver's timezone is used, if it is set. The code also appears to be attempting to implement this, by setting the `timeZone` property on a local `cal` var, but this var wasn't being used at all later in the function. 

The result is that seemingly valid DateComponents can return false for isValidDate(), when the receiver's timezone differs from the passed in calendar's timezone, which is often system timezone. 