### PR TITLE
CoreFoundation: prepare for modularization (NFC)

### DIFF
--- a/CoreFoundation/Base.subproj/CFLocking.h
+++ b/CoreFoundation/Base.subproj/CFLocking.h
@@ -37,16 +37,17 @@ static inline CFLock_t __CFLockInit(void) { return CFLockInit; }
 #elif TARGET_OS_WIN32
 
 #define NOMINMAX
+#define VC_EXTRALEAN
 #define WIN32_LEAN_AND_MEAN
-#define VCEXTRALEAN
 #include <Windows.h>
+#include <synchapi.h>
 
 typedef int32_t CFLock_t;
 #define CFLockInit 0
 #define CF_LOCK_INIT_FOR_STRUCTS(X) (X = CFLockInit)
 
 CF_INLINE void __CFLock(volatile CFLock_t *lock) {
-  while (InterlockedCompareExchange((LONG volatile *)lock, ~0, 0) != 0) {
+  while (InterlockedCompareExchange((long volatile *)lock, ~0, 0) != 0) {
     Sleep(0);
   }
 }
@@ -57,7 +58,7 @@ CF_INLINE void __CFUnlock(volatile CFLock_t *lock) {
 }
 
 CF_INLINE Boolean __CFLockTry(volatile CFLock_t *lock) {
-  return (InterlockedCompareExchange((LONG volatile *)lock, ~0, 0) == 0);
+  return (InterlockedCompareExchange((long volatile *)lock, ~0, 0) == 0);
 }
 
 // SPI to permit initialization of values in Swift
@@ -66,6 +67,7 @@ static inline CFLock_t __CFLockInit(void) { return CFLockInit; }
 #elif TARGET_OS_LINUX || TARGET_OS_BSD
 
 #include <stdint.h>
+#include <unistd.h>
 
 typedef int32_t CFLock_t;
 #define CFLockInit 0

--- a/CoreFoundation/Base.subproj/CFPriv.h
+++ b/CoreFoundation/Base.subproj/CFPriv.h
@@ -59,6 +59,8 @@ CF_EXPORT const char **_CFGetProcessPath(void);
 CF_EXPORT const char **_CFGetProgname(void);
 
 #if !TARGET_OS_WIN32
+#include <sys/types.h>
+
 CF_EXPORT void _CFGetUGIDs(uid_t *euid, gid_t *egid);
 CF_EXPORT uid_t _CFGetEUID(void);
 CF_EXPORT uid_t _CFGetEGID(void);
@@ -492,8 +494,8 @@ void CFCharacterSetInitInlineBuffer(CFCharacterSetRef cset, CFCharacterSetInline
  @result true, if the value is in the character set, otherwise false.
  */
 #if defined(CF_INLINE)
-CF_INLINE bool CFCharacterSetInlineBufferIsLongCharacterMember(const CFCharacterSetInlineBuffer *buffer, UTF32Char character) {
-    bool isInverted = ((0 == (buffer->flags & kCFCharacterSetIsInverted)) ? false : true);
+CF_INLINE Boolean CFCharacterSetInlineBufferIsLongCharacterMember(const CFCharacterSetInlineBuffer *buffer, UTF32Char character) {
+    Boolean isInverted = ((0 == (buffer->flags & kCFCharacterSetIsInverted)) ? FALSE : TRUE);
 
     if ((character >= buffer->rangeStart) && (character < buffer->rangeLimit)) {
         if ((character > 0xFFFF) || (0 != (buffer->flags & kCFCharacterSetNoBitmapAvailable))) return (CFCharacterSetIsLongCharacterMember(buffer->cset, character) != 0);
@@ -569,6 +571,7 @@ CF_EXPORT CFMessagePortRef _CFMessagePortCreateLocalEx(CFAllocatorRef allocator,
 #if _POSIX_THREADS
 #include <pthread.h>
 #endif
+#include <time.h>
 
 CF_INLINE CFAbsoluteTime _CFAbsoluteTimeFromFileTimeSpec(struct timespec ts) {
     return (CFAbsoluteTime)((CFTimeInterval)ts.tv_sec - kCFAbsoluteTimeIntervalSince1970) + (1.0e-9 * (CFTimeInterval)ts.tv_nsec);
@@ -592,10 +595,10 @@ CF_INLINE struct timespec _CFFileTimeSpecFromAbsoluteTime(CFAbsoluteTime at) {
 }
 
 // The 'filtered' function below is preferred to this older one
-CF_EXPORT bool _CFPropertyListCreateSingleValue(CFAllocatorRef allocator, CFDataRef data, CFOptionFlags option, CFStringRef keyPath, CFPropertyListRef *value, CFErrorRef *error);
+CF_EXPORT Boolean _CFPropertyListCreateSingleValue(CFAllocatorRef allocator, CFDataRef data, CFOptionFlags option, CFStringRef keyPath, CFPropertyListRef *value, CFErrorRef *error);
 
 // Returns a subset of the property list, only including the keyPaths in the CFSet. If the top level object is not a dictionary, you will get back an empty dictionary as the result.
-CF_EXPORT bool _CFPropertyListCreateFiltered(CFAllocatorRef allocator, CFDataRef data, CFOptionFlags option, CFSetRef keyPaths, CFPropertyListRef *value, CFErrorRef *error) API_AVAILABLE(macos(10.8), ios(6.0), watchos(2.0), tvos(9.0));
+CF_EXPORT Boolean _CFPropertyListCreateFiltered(CFAllocatorRef allocator, CFDataRef data, CFOptionFlags option, CFSetRef keyPaths, CFPropertyListRef *value, CFErrorRef *error) API_AVAILABLE(macos(10.8), ios(6.0), watchos(2.0), tvos(9.0));
 
 // Returns a set of the keys of the top-level dictionary of a plist. Optimized for bplist (though it works with XML too).  Only supports string keys. 
 CF_EXPORT CFSetRef _CFPropertyListCopyTopLevelKeys(CFAllocatorRef allocator, CFDataRef data, CFOptionFlags option, CFErrorRef *outError) API_AVAILABLE(macos(10.13), ios(11.0), watchos(4.0), tvos(11.0));

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -32,6 +32,7 @@
 
 #if TARGET_OS_WIN32
 #define NOMINMAX
+#define VC_EXTRALEAN
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #else
@@ -77,6 +78,8 @@
 #define AT_STATX_SYNC_AS_STAT   0x0000  /* - Do whatever stat() does */
 #endif //__GLIBC_PREREQ(2. 28)
 #endif // TARGET_OS_LINUX
+
+#include <stdlib.h>
 
 
 _CF_EXPORT_SCOPE_BEGIN
@@ -352,12 +355,12 @@ CF_EXPORT char *_Nullable *_Nonnull _CFEnviron(void);
 CF_EXPORT void CFLog1(CFLogLevel lev, CFStringRef message);
 
 #if TARGET_OS_WIN32
-typedef HANDLE _CFThreadRef;
+typedef void *_CFThreadRef;
 typedef struct _CFThreadAttributes {
-  DWORD dwSizeOfAttributes;
-  DWORD dwThreadStackReservation;
+  unsigned long dwSizeOfAttributes;
+  unsigned long dwThreadStackReservation;
 } _CFThreadAttributes;
-typedef DWORD _CFThreadSpecificKey;
+typedef unsigned long _CFThreadSpecificKey;
 #elif _POSIX_THREADS
 typedef pthread_t _CFThreadRef;
 typedef pthread_attr_t _CFThreadAttributes;
@@ -592,27 +595,27 @@ static inline int _CF_renameat2(int olddirfd, const char *_Nonnull oldpath,
 CF_EXPORT void __CFSocketInitializeWinSock(void);
 
 typedef struct _REPARSE_DATA_BUFFER {
-    ULONG  ReparseTag;
-    USHORT ReparseDataLength;
-    USHORT Reserved;
+    unsigned long  ReparseTag;
+    unsigned short ReparseDataLength;
+    unsigned short Reserved;
     union {
         struct {
-            USHORT SubstituteNameOffset;
-            USHORT SubstituteNameLength;
-            USHORT PrintNameOffset;
-            USHORT PrintNameLength;
-            ULONG  Flags;
-            WCHAR  PathBuffer[1];
+            unsigned short SubstituteNameOffset;
+            unsigned short SubstituteNameLength;
+            unsigned short PrintNameOffset;
+            unsigned short PrintNameLength;
+            unsigned long  Flags;
+            short          PathBuffer[1];
         } SymbolicLinkReparseBuffer;
         struct {
-            USHORT SubstituteNameOffset;
-            USHORT SubstituteNameLength;
-            USHORT PrintNameOffset;
-            USHORT PrintNameLength;
-            WCHAR  PathBuffer[1];
+            unsigned short SubstituteNameOffset;
+            unsigned short SubstituteNameLength;
+            unsigned short PrintNameOffset;
+            unsigned short PrintNameLength;
+            short          PathBuffer[1];
         } MountPointReparseBuffer;
         struct {
-            UCHAR DataBuffer[1];
+            unsigned char DataBuffer[1];
         } GenericReparseBuffer;
     } DUMMYUNIONNAME;
 } REPARSE_DATA_BUFFER;

--- a/CoreFoundation/Locale.subproj/CFDateIntervalFormatter.c
+++ b/CoreFoundation/Locale.subproj/CFDateIntervalFormatter.c
@@ -241,8 +241,8 @@ void _CFDateIntervalFormatterInitializeFromCoderValues(CFDateIntervalFormatterRe
                                                        int64_t timeStyle,
                                                        CFStringRef _Nullable dateTemplate,
                                                        CFStringRef _Nullable dateTemplateFromStyles,
-                                                       bool modified,
-                                                       bool useTemplate,
+                                                       Boolean modified,
+                                                       Boolean useTemplate,
                                                        CFLocaleRef _Nullable locale,
                                                        CFCalendarRef _Nullable calendar,
                                                        CFTimeZoneRef _Nullable timeZone) {
@@ -277,8 +277,8 @@ void _CFDateIntervalFormatterCopyCoderValues(CFDateIntervalFormatterRef formatte
                                              int64_t *timeStyle,
                                              CFStringRef _Nullable *dateTemplate,
                                              CFStringRef _Nullable *dateTemplateFromStyles,
-                                             bool *modified,
-                                             bool *useTemplate,
+                                             Boolean *modified,
+                                             Boolean *useTemplate,
                                              CFLocaleRef _Nullable *locale,
                                              CFCalendarRef _Nullable *calendar,
                                              CFTimeZoneRef _Nullable *timeZone) {

--- a/CoreFoundation/Locale.subproj/CFDateIntervalFormatter.h
+++ b/CoreFoundation/Locale.subproj/CFDateIntervalFormatter.h
@@ -71,8 +71,8 @@ CF_EXPORT void _CFDateIntervalFormatterInitializeFromCoderValues(CFDateIntervalF
                                                                  int64_t timeStyle,
                                                                  CFStringRef _Nullable dateTemplate,
                                                                  CFStringRef _Nullable dateTemplateFromStyles,
-                                                                 bool modified,
-                                                                 bool useTemplate,
+                                                                 Boolean modified,
+                                                                 Boolean useTemplate,
                                                                  CFLocaleRef _Nullable locale,
                                                                  CFCalendarRef _Nullable calendar,
                                                                  CFTimeZoneRef _Nullable timeZone);
@@ -82,8 +82,8 @@ CF_EXPORT void _CFDateIntervalFormatterCopyCoderValues(CFDateIntervalFormatterRe
                                                        int64_t *timeStyle,
                                                        CFStringRef _Nullable *_Nonnull dateTemplate,
                                                        CFStringRef _Nullable *_Nonnull dateTemplateFromStyles,
-                                                       bool *modified,
-                                                       bool *useTemplate,
+                                                       Boolean *modified,
+                                                       Boolean *useTemplate,
                                                        CFLocaleRef _Nullable *_Nonnull locale,
                                                        CFCalendarRef _Nullable *_Nonnull calendar,
                                                        CFTimeZoneRef _Nullable *_Nonnull timeZone);

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.h
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.h
@@ -142,7 +142,7 @@ typedef void* _CFXMLDTDPtr;
 typedef void* _CFXMLDTDNodePtr;
 
 _CFXMLNodePtr _CFXMLNewNode(_CFXMLNamespacePtr _Nullable name_space, const char* name);
-_CFXMLNodePtr _CFXMLCopyNode(_CFXMLNodePtr node, bool recursive);
+_CFXMLNodePtr _CFXMLCopyNode(_CFXMLNodePtr node, Boolean recursive);
 
 _CFXMLDocPtr _CFXMLNewDoc(const unsigned char* version);
 _CFXMLNodePtr _CFXMLNewProcessingInstruction(const unsigned char* name, const unsigned char* value);
@@ -178,8 +178,8 @@ void _CFXMLNodeReplaceNode(_CFXMLNodePtr node, _CFXMLNodePtr replacement);
 
 _CFXMLDocPtr _Nullable _CFXMLNodeGetDocument(_CFXMLNodePtr node);
 
-bool _CFXMLDocStandalone(_CFXMLDocPtr doc);
-void _CFXMLDocSetStandalone(_CFXMLDocPtr doc, bool standalone);
+Boolean _CFXMLDocStandalone(_CFXMLDocPtr doc);
+void _CFXMLDocSetStandalone(_CFXMLDocPtr doc, Boolean standalone);
 _CFXMLNodePtr _Nullable _CFXMLDocRootElement(_CFXMLDocPtr doc);
 void _CFXMLDocSetRootElement(_CFXMLDocPtr doc, _CFXMLNodePtr node);
 CFStringRef _Nullable _CFXMLDocCopyCharacterEncoding(_CFXMLDocPtr doc);
@@ -211,7 +211,7 @@ _CFXMLDocPtr _CFXMLDocPtrFromDataWithOptions(CFDataRef data, unsigned int option
 CFStringRef _Nullable _CFXMLNodeCopyLocalName(_CFXMLNodePtr node);
 CFStringRef _Nullable _CFXMLNodeCopyPrefix(_CFXMLNodePtr node);
 
-bool _CFXMLDocValidate(_CFXMLDocPtr doc, CFErrorRef _Nullable * error);
+Boolean _CFXMLDocValidate(_CFXMLDocPtr doc, CFErrorRef _Nullable * error);
 
 _CFXMLDTDPtr _CFXMLNewDTD(_CFXMLDocPtr _Nullable doc, const unsigned char* name, const unsigned char* publicID, const unsigned char* systemID);
 _CFXMLDTDNodePtr _Nullable _CFXMLParseDTDNode(const unsigned char* xmlString);

--- a/CoreFoundation/PlugIn.subproj/CFPlugInCOM.h
+++ b/CoreFoundation/PlugIn.subproj/CFPlugInCOM.h
@@ -20,7 +20,12 @@ CF_EXTERN_C_BEGIN
 /* The _reserved field is part of the Microsoft COM binary standard on Macintosh. */
 /* You can declare new C struct interfaces by defining a new struct that includes "IUNKNOWN_C_GUTS;" before the first field of the struct. */
 
-#if !TARGET_OS_WIN32
+#if TARGET_OS_WIN32
+#define NOMINMAX
+#define VC_EXTRALEAN
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#else
 typedef SInt32 HRESULT;
 typedef UInt32 ULONG;
 typedef void *LPVOID;

--- a/Foundation/DateIntervalFormatter.swift
+++ b/Foundation/DateIntervalFormatter.swift
@@ -133,8 +133,8 @@ open class DateIntervalFormatter: Formatter {
         var timeStyle: Int64 = 0
         var dateTemplate: Unmanaged<CFString>?
         var dateTemplateFromStyles: Unmanaged<CFString>?
-        var modified: Bool = false
-        var useTemplate: Bool = false
+        var modified: _DarwinCompatibleBoolean = false
+        var useTemplate: _DarwinCompatibleBoolean = false
         var locale: Unmanaged<CFLocale>?
         var calendar: Unmanaged<CFCalendar>?
         var timeZone: Unmanaged<CFTimeZone>?


### PR DESCRIPTION
Adjust the headers to convert CoreFoundation into a module to enable
extricating it from the public interface for Foundation.  This adjusts
some of the declarations to be more standalone and others to use the
CoreFoundation types rather than C99.  These changes do not impact the
ABI of the declarations.