### PR TITLE
DarwinCompatibilty: Add shims for missing FileHandle methods

### DIFF
--- a/DarwinCompatibilityTests.xcodeproj/project.pbxproj
+++ b/DarwinCompatibilityTests.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		B9C89FCC1F6DCAEB00087AF4 /* NSKeyedUnarchiver-NotificationTest.plist in Resources */ = {isa = PBXBuildFile; fileRef = B9C89FB71F6DCAEB00087AF4 /* NSKeyedUnarchiver-NotificationTest.plist */; };
 		B9C89FCD1F6DCAEB00087AF4 /* PropertyList-1.0.dtd in Resources */ = {isa = PBXBuildFile; fileRef = B9C89FB81F6DCAEB00087AF4 /* PropertyList-1.0.dtd */; };
 		B9C89FCE1F6DCAEB00087AF4 /* Test.plist in Resources */ = {isa = PBXBuildFile; fileRef = B9C89FB91F6DCAEB00087AF4 /* Test.plist */; };
+		B9ED84FD23641F7000A58AF2 /* DarwinShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F3269E1FC714DD003C3599 /* DarwinShims.swift */; };
 		B9F137A120B998D0000B7577 /* xdgTestHelper in CopyFiles */ = {isa = PBXBuildFile; fileRef = B917D31C20B0DB8B00728EE0 /* xdgTestHelper */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		B9F326A01FC714DD003C3599 /* DarwinShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F3269E1FC714DD003C3599 /* DarwinShims.swift */; };
 		DAE7D0F320D8224200DC6C54 /* TestURLProtectionSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE7D0F220D8224200DC6C54 /* TestURLProtectionSpace.swift */; };
@@ -605,6 +606,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B917D32620B0DE2000728EE0 /* main.swift in Sources */,
+				B9ED84FD23641F7000A58AF2 /* DarwinShims.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -727,7 +729,7 @@
 				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CODE_SIGN_STYLE = Automatic;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_SWIFT_FLAGS = "-DDEPLOYMENT_RUNTIME_OBJC -DDARWIN_COMPATIBILITY_TESTS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -741,7 +743,7 @@
 				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CODE_SIGN_STYLE = Automatic;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_SWIFT_FLAGS = "-DDEPLOYMENT_RUNTIME_OBJC -DDARWIN_COMPATIBILITY_TESTS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -796,7 +798,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -847,7 +849,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -861,7 +863,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = DarwinCompatibilityTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				"OTHER_SWIFT_FLAGS[arch=*]" = "-DDEPLOYMENT_RUNTIME_OBJC -DDARWIN_COMPATIBILITY_TESTS";
 				PRODUCT_BUNDLE_IDENTIFIER = org.swift.DarwinCompatibilityTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -876,7 +878,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = DarwinCompatibilityTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				"OTHER_SWIFT_FLAGS[arch=*]" = "-DDEPLOYMENT_RUNTIME_OBJC -DDARWIN_COMPATIBILITY_TESTS";
 				PRODUCT_BUNDLE_IDENTIFIER = org.swift.DarwinCompatibilityTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/DarwinCompatibilityTests.xcodeproj/xcshareddata/xcschemes/xdgTestHelper.xcscheme
+++ b/DarwinCompatibilityTests.xcodeproj/xcshareddata/xcschemes/xdgTestHelper.xcscheme
@@ -51,12 +51,6 @@
                   Identifier = "TestDateComponents/test_hash()">
                </Test>
                <Test
-                  Identifier = "TestFileHandle">
-               </Test>
-               <Test
-                  Identifier = "TestPipe">
-               </Test>
-               <Test
                   Identifier = "TestURLComponents/test_hash()">
                </Test>
                <Test

--- a/DarwinCompatibilityTests/DarwinShims.swift
+++ b/DarwinCompatibilityTests/DarwinShims.swift
@@ -83,3 +83,27 @@ extension NSCharacterSet {
         return self as CharacterSet
     }
 }
+
+
+extension FileHandle {
+    public func offset() throws -> UInt64 {
+        return self.offsetInFile
+    }
+
+    public func read(upToCount count: Int) throws -> Data? {
+        guard count > 0 else { return nil }
+        let data = readData(ofLength: count)
+        if data.count == 0 { return nil }
+        return data
+    }
+
+    public func readToEnd() throws -> Data? {
+        try read(upToCount: Int.max)
+    }
+
+    public func write<T: DataProtocol>(contentsOf data: T) throws {
+        if let d = data as? Data {
+            self.write(d)
+        }
+    }
+}

--- a/TestFoundation/TestFileHandle.swift
+++ b/TestFoundation/TestFileHandle.swift
@@ -7,7 +7,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if !DARWIN_COMPATIBILITY_TESTS // Disable until Foundation has the new FileHandle API
 
 #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
     #if canImport(SwiftFoundation) && !DEPLOYMENT_RUNTIME_OBJC
@@ -565,5 +564,3 @@ class TestFileHandle : XCTestCase {
         return tests
     }
 }
-
-#endif

--- a/TestFoundation/TestPipe.swift
+++ b/TestFoundation/TestPipe.swift
@@ -7,7 +7,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if !DARWIN_COMPATIBILITY_TESTS     // Disable until Foundation has the new FileHandle API
 
 #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
     #if canImport(SwiftFoundation) && !DEPLOYMENT_RUNTIME_OBJC
@@ -79,4 +78,3 @@ class TestPipe: XCTestCase {
         XCTAssertEqual(text, convertedData)
     }
 }
-#endif

--- a/TestFoundation/TestScanner.swift
+++ b/TestFoundation/TestScanner.swift
@@ -7,8 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if !DARWIN_COMPATIBILITY_TESTS     // Disable until Foundation has the new Scanner API
-
 fileprivate func withScanner(for string: String, invoking block: ((Scanner) throws -> Void)? = nil) rethrows {
     let scanner = Scanner(string: string)
     scanner.locale = Locale(identifier: "en_US_POSIX")
@@ -528,5 +526,3 @@ class TestScanner : XCTestCase {
         ]
     }
 }
-
-#endif

--- a/TestFoundation/Utilities.swift
+++ b/TestFoundation/Utilities.swift
@@ -528,11 +528,7 @@ private var shouldRunXFailTests: Bool {
 
 
 private func printStderr(_ msg: String) {
-#if DARWIN_COMPATIBILITY_TESTS
-    FileHandle.standardError.write(Data(msg.utf8))
-#else
     try? FileHandle.standardError.write(contentsOf: Data(msg.utf8))
-#endif
 }
 
 func shouldAttemptXFailTests(_ reason: String) -> Bool {

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -180,19 +180,9 @@ func cat(_ args: ArraySlice<String>.Iterator) {
                 exitCode = 1
                 return
             }
- #if DARWIN_COMPATIBILITY_TESTS
-            var data: Data
-            repeat {
-                data = fh.readData(ofLength: Int.max)
-                if data.count > 0 {
-                    FileHandle.standardOutput.write(data)
-                }
-            } while data.count > 0
-#else
             while let data = try fh.readToEnd() {
                 try FileHandle.standardOutput.write(contentsOf: data)
             }
-#endif
         }
         catch { print(error) }
     }


### PR DESCRIPTION
- offset(), read(upToCount:) readToEnd() and wite(contentsOf:)
  are not currently available on Darwin so add wrappers and
  remove #if gates in tests using them.

- Bump the deployment target to 10.15