### PR TITLE
build: honour and use RPATHs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,12 @@ enable_testing()
 # Cache the variable to allow the user to alter the configuration.
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL" CACHE
   STRING "MSVC Runtime Library")
+if(CMAKE_VERSION VERSION_LESS 3.16.0)
+  if(NOT (CMAKE_SYSTEM_NAME STREQUAL Windows OR CMAKE_SYSTEM_NAME STREQUAL Darwin))
+    set(CMAKE_SHARED_LIBRARY_RUNTIME_Swift_FLAG "-Xlinker -rpath -Xlinker ")
+    set(CMAKE_SHARED_LIBRARY_RUNTIME_Swift_FLAG_SEP ":")
+  endif()
+endif()
 
 option(BUILD_SHARED_LIBS "build shared libraries" ON)
 

--- a/Foundation/CMakeLists.txt
+++ b/Foundation/CMakeLists.txt
@@ -149,6 +149,7 @@ target_link_libraries(Foundation PRIVATE
   uuid)
 target_link_libraries(Foundation PUBLIC
   swiftDispatch)
+
 # TODO(compnerd) properly propogate `BUILD_RPATH` to the target using CMake
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows AND NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_options(Foundation PRIVATE
@@ -163,6 +164,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
     pathcch)
 endif()
 set_target_properties(Foundation PROPERTIES
+  INSTALL_RPATH "$ORIGIN"
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/swift)
 
@@ -212,6 +214,7 @@ target_link_libraries(FoundationNetworking PRIVATE
   Foundation
   CFURLSessionInterface)
 set_target_properties(FoundationNetworking PROPERTIES
+  INSTALL_RPATH "$ORIGIN"
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/swift)
 
@@ -236,8 +239,10 @@ target_link_libraries(FoundationXML PRIVATE
   Foundation
   CFXMLInterface)
 set_target_properties(FoundationXML PROPERTIES
+  INSTALL_RPATH "$ORIGIN"
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/swift)
+
 
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS
   Foundation FoundationNetworking FoundationXML)

--- a/Tools/plutil/CMakeLists.txt
+++ b/Tools/plutil/CMakeLists.txt
@@ -3,11 +3,8 @@ add_executable(plutil
   main.swift)
 target_link_libraries(plutil PRIVATE
   Foundation)
-# TODO(compnerd) properly propogate `BUILD_RPATH` to the target using CMake
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows AND NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  target_link_options(plutil PRIVATE
-    "SHELL:-Xlinker -rpath -Xlinker $$$$ORIGIN/../lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>:$<TARGET_FILE_DIR:Foundation>")
-endif()
+set_target_properties(plutil PROPERTIES
+  INSTALL_RPATH "$ORIGIN/../lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
 
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS plutil)
 install(TARGETS plutil


### PR DESCRIPTION
RPATH handling in CMake 3.15 was unsupported on Swift targets.  Adjust
the configuration to support it on CMake <3.16 and use that to set the
install RPATH to $ORIGIN rather than the workaround for the build RPATH.