### PR TITLE
build: add a workaround for CMake <3.16

### DIFF
--- a/Foundation/CMakeLists.txt
+++ b/Foundation/CMakeLists.txt
@@ -1,4 +1,8 @@
 
+if(CMAKE_VERSION VERSION_LESS 3.16)
+  set(CMAKE_LINK_LIBRARY_FLAG "-l")
+endif()
+
 add_library(Foundation
   AffineTransform.swift
   Array.swift


### PR DESCRIPTION
This adjusts the prefix used for linking libraries.  This is needed to
ensure that the system libraries are linked properly on Windows.  This
has been fixed properly in CMake 3.16, adjust for 3.15.1.