### PR TITLE
SR-11766: Fix coefficients for UnitVolume

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -388,6 +388,7 @@
 		5BF9B8001FABD5DA00EE1A7C /* CFBundle_Main.c in Sources */ = {isa = PBXBuildFile; fileRef = 5BF9B7F41FABD5D300EE1A7C /* CFBundle_Main.c */; };
 		5BF9B8011FABD5DA00EE1A7C /* CFBundle_ResourceFork.c in Sources */ = {isa = PBXBuildFile; fileRef = 5BF9B7F61FABD5D400EE1A7C /* CFBundle_ResourceFork.c */; };
 		5BF9B8021FABD5DA00EE1A7C /* CFBundle_Tables.c in Sources */ = {isa = PBXBuildFile; fileRef = 5BF9B7F71FABD5D400EE1A7C /* CFBundle_Tables.c */; };
+		5D0E1BDB237A1FE800C35C5A /* TestUnitVolume.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D0E1BDA237A1FE800C35C5A /* TestUnitVolume.swift */; };
 		5FE52C951D147D1C00F7D270 /* TestNSTextCheckingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE52C941D147D1C00F7D270 /* TestNSTextCheckingResult.swift */; };
 		616068F3225DE5C2004FCC54 /* FTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616068F2225DE5C2004FCC54 /* FTPServer.swift */; };
 		616068F5225DE606004FCC54 /* TestURLSessionFTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616068F4225DE606004FCC54 /* TestURLSessionFTP.swift */; };
@@ -1018,6 +1019,7 @@
 		5BF9B7F61FABD5D400EE1A7C /* CFBundle_ResourceFork.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFBundle_ResourceFork.c; sourceTree = "<group>"; };
 		5BF9B7F71FABD5D400EE1A7C /* CFBundle_Tables.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFBundle_Tables.c; sourceTree = "<group>"; };
 		5BF9B7F81FABD5D500EE1A7C /* CFBundle_Executable.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CFBundle_Executable.c; sourceTree = "<group>"; };
+		5D0E1BDA237A1FE800C35C5A /* TestUnitVolume.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUnitVolume.swift; sourceTree = "<group>"; };
 		5E5835F31C20C9B500C81317 /* TestThread.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestThread.swift; sourceTree = "<group>"; };
 		5EB6A15C1C188FC40037DCB8 /* TestJSONSerialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestJSONSerialization.swift; sourceTree = "<group>"; };
 		5EF673AB1C28B527006212A3 /* TestNotificationQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNotificationQueue.swift; sourceTree = "<group>"; };
@@ -1899,6 +1901,7 @@
 				5B6F17961C48631C00935030 /* TestUtils.swift */,
 				03B6F5831F15F339004F25AF /* TestURLProtocol.swift */,
 				3E55A2321F52463B00082000 /* TestUnit.swift */,
+				5D0E1BDA237A1FE800C35C5A /* TestUnitVolume.swift */,
 				7D8BD738225ED1480057CF37 /* TestMeasurement.swift */,
 			);
 			name = Tests;
@@ -3096,6 +3099,7 @@
 				D4FE895B1D703D1100DA7986 /* TestURLRequest.swift in Sources */,
 				684C79011F62B611005BD73E /* TestNSNumberBridging.swift in Sources */,
 				DAA79BD920D42C07004AF044 /* TestURLProtectionSpace.swift in Sources */,
+				5D0E1BDB237A1FE800C35C5A /* TestUnitVolume.swift in Sources */,
 				616068F5225DE606004FCC54 /* TestURLSessionFTP.swift in Sources */,
 				155B77AC22E63D2D00D901DE /* TestURLCredentialStorage.swift in Sources */,
 				B951B5EC1F4E2A2000D8B332 /* TestNSLock.swift in Sources */,

--- a/Foundation/Unit.swift
+++ b/Foundation/Unit.swift
@@ -2030,8 +2030,8 @@ public final class UnitVolume : Dimension {
         static let cubicKilometers      = 1e12
         static let cubicMeters          = 1000.0
         static let cubicDecimeters      = 1.0
-        static let cubicCentimeters     = 0.01
-        static let cubicMillimeters     = 0.001
+        static let cubicCentimeters     = 1e-3
+        static let cubicMillimeters     = 1e-6
         static let cubicInches          = 0.0163871
         static let cubicFeet            = 28.3168
         static let cubicYards           = 764.555

--- a/TestFoundation/CMakeLists.txt
+++ b/TestFoundation/CMakeLists.txt
@@ -88,6 +88,7 @@ target_sources(TestFoundation PRIVATE
   TestTimer.swift
   TestTimeZone.swift
   TestUnitConverter.swift
+  TestUnitVolume.swift
   TestUnit.swift
   TestURLCache.swift
   TestURLCredential.swift

--- a/TestFoundation/TestUnitVolume.swift
+++ b/TestFoundation/TestUnitVolume.swift
@@ -1,0 +1,76 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+class TestUnitVolume: XCTestCase {
+    func testMetricVolumeConversions() {
+        let cubicKilometers = Measurement(value: 4, unit: UnitVolume.cubicKilometers)
+        XCTAssertEqual(cubicKilometers, Measurement(value: 4e9, unit: UnitVolume.cubicMeters), "Conversion from cubicKilometers to cubicMeters")
+
+        let megaliters = Measurement(value: 3, unit: UnitVolume.megaliters)
+        XCTAssertEqual(megaliters, Measurement(value: 3_000_000, unit: UnitVolume.liters), "Conversion from megaliters to liters")
+
+        let kiloliters = Measurement(value: 2, unit: UnitVolume.kiloliters)
+        XCTAssertEqual(kiloliters, Measurement(value: 2000, unit: UnitVolume.liters), "Conversion from kiloliters to liters")
+
+        let cubicMeters = Measurement(value: 2, unit: UnitVolume.cubicMeters)
+        XCTAssertEqual(cubicMeters, Measurement(value: 2000, unit: UnitVolume.liters), "Conversion from cubicMeters to liters")
+        XCTAssertEqual(kiloliters, cubicMeters, "Conversion from kiloliters to cubicMeters")
+
+        let liters = Measurement(value: 5, unit: UnitVolume.liters)
+        XCTAssertEqual(liters, Measurement(value: 5, unit: UnitVolume.cubicDecimeters), "Conversion from liters to cubicDecimeters")
+        XCTAssertEqual(liters, Measurement(value: 50, unit: UnitVolume.deciliters), "Conversion from liters to deciliters")
+        XCTAssertEqual(liters, Measurement(value: 500, unit: UnitVolume.centiliters), "Conversion from liters to centiliters")
+        XCTAssertEqual(liters, Measurement(value: 5000, unit: UnitVolume.milliliters), "Conversion from liters to milliliters")
+        XCTAssertEqual(liters, Measurement(value: 5000, unit: UnitVolume.cubicCentimeters), "Conversion from liters to cubicCentimeters")
+        XCTAssertEqual(liters, Measurement(value: 5e6, unit: UnitVolume.cubicMillimeters), "Conversion from liters to cubicMillimeters")
+    }
+
+    func testMetricToImperialVolumeConversion() {
+        let liters = Measurement(value: 10, unit: UnitVolume.liters)
+        XCTAssertEqual(liters.converted(to: .cubicInches).value, 610.236, accuracy: 0.001, "Conversion from liters to cubicInches")
+    }
+
+    func testImperialVolumeConversions() {
+        let cubicMiles = Measurement(value: 1, unit: UnitVolume.cubicMiles)
+        XCTAssertEqual(cubicMiles.converted(to: .cubicYards).value, 1760 * 1760 * 1760, accuracy: 1_000_000, "Conversion from cubicMiles to cubicYards")
+
+        let cubicYards = Measurement(value: 1, unit: UnitVolume.cubicYards)
+        XCTAssertEqual(cubicYards.converted(to: .cubicFeet).value, 27, accuracy: 0.001, "Conversion from cubicYards to cubicFeet")
+
+        let cubicFeet = Measurement(value: 1, unit: UnitVolume.cubicFeet)
+        XCTAssertEqual(cubicFeet.converted(to: .cubicInches).value, 1728, accuracy: 0.01, "Conversion from cubicFeet to cubicInches")
+
+        let gallons = Measurement(value: 1, unit: UnitVolume.gallons)
+        XCTAssertEqual(gallons.converted(to: .quarts).value, 4, accuracy: 0.001, "Conversion from gallons to quarts")
+
+        let quarts = Measurement(value: 1, unit: UnitVolume.quarts)
+        XCTAssertEqual(quarts.converted(to: .pints).value, 2, accuracy: 0.001, "Conversion from quarts to pints")
+
+        let pints = Measurement(value: 1, unit: UnitVolume.pints)
+        XCTAssertEqual(pints.converted(to: .cups).value, 2, accuracy: 0.05, "Conversion from pints to cups")
+
+        let cups = Measurement(value: 1, unit: UnitVolume.cups)
+        XCTAssertEqual(cups.converted(to: .fluidOunces).value, 8.12, accuracy: 0.01, "Conversion from cups to fluidOunces")
+
+        let fluidOunces = Measurement(value: 1, unit: UnitVolume.fluidOunces)
+        XCTAssertEqual(fluidOunces.converted(to: .tablespoons).value, 2, accuracy: 0.001, "Conversion from fluidOunces to tablespoons")
+
+        let tablespoons = Measurement(value: 1, unit: UnitVolume.tablespoons)
+        XCTAssertEqual(tablespoons.converted(to: .teaspoons).value, 3, accuracy: 0.001, "Conversion from tablespoons to teaspoons")
+
+        let teaspoons = Measurement(value: 1, unit: UnitVolume.teaspoons)
+        XCTAssertEqual(teaspoons.converted(to: .cubicInches).value, 0.3, accuracy: 0.001, "Conversion from teaspoons to cubicInches")
+    }
+
+    static let allTests = [
+        ("testMetricVolumeConversions", testMetricVolumeConversions),
+        ("testMetricToImperialVolumeConversion", testMetricToImperialVolumeConversion),
+        ("testImperialVolumeConversions", testImperialVolumeConversions),
+    ]
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -115,6 +115,7 @@ var allTestCases = [
     testCase(TestUnit.allTests),
     testCase(TestDimension.allTests),
     testCase(TestMeasurement.allTests),
+    testCase(TestUnitVolume.allTests),
     testCase(TestNSLock.allTests),
     testCase(TestNSSortDescriptor.allTests),
 ]


### PR DESCRIPTION
This fixes Measurement values expressed in cubic centimeters and cubic millimeters.

I found the errors in the coefficients because I tested one of my libraries on Linux for the first time and a test was failing (see https://github.com/ole/Ampere/issues/25).

I considered adding unit tests that test some conversions to Foundation, but I'm not sure how useful they would be. A test for converting a Measurement from one unit to another would essentially repeat the code that's being tested; it seems it would be almost equally likely for a bug to be in the test as it would be in the code being tested.