### PR TITLE
build: add workaround for CMake 3.15

### DIFF
--- a/TestFoundation/CMakeLists.txt
+++ b/TestFoundation/CMakeLists.txt
@@ -1,4 +1,8 @@
 
+if(CMAKE_VERSION VERSION_LESS 3.16)
+  set(CMAKE_LIBRARY_PATH_FLAG "-L")
+endif()
+
 add_subdirectory(xdgTestHelper)
 
 add_executable(TestFoundation


### PR DESCRIPTION
When building with CMake <3.16, the `target_link_directories` would be
ignored and the test binary would fail to link on Windows.  Add a
workaround to ensure that the library path is honoured.