### PR TITLE
build: add workaround for CMake <3.16

### DIFF
--- a/TestFoundation/CMakeLists.txt
+++ b/TestFoundation/CMakeLists.txt
@@ -1,4 +1,8 @@
 
+if(CMAKE_VERSION VERSION_LESS 3.16)
+  set(CMAKE_LINK_LIBRARY_FLAG "-l")
+endif()
+
 add_subdirectory(xdgTestHelper)
 
 add_executable(TestFoundation


### PR DESCRIPTION
This repairs the TestFoundation build for CMake <3.16 which failed to
link against the import libraries on Windows.