### PR TITLE
SR-644: test_completePathIntoString can takes a long time on build servers

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -1773,6 +1773,7 @@
 				1520469A1D8AEABE00D02E36 /* HTTPServer.swift */,
 				EA66F6381BF1619600136161 /* main.swift */,
 				BB3D7557208A1E500085CFDC /* TestImports.swift */,
+				7D0DE86D211883F500540061 /* Utilities.swift */,
 				9F4ADBCF1ECD4F56001F0B3D /* xdgTestHelper */,
 				EA66F65A1BF1976100136161 /* Tests */,
 				EA66F6391BF1619600136161 /* Resources */,
@@ -1814,7 +1815,6 @@
 		EA66F65A1BF1976100136161 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				7D0DE86D211883F500540061 /* Utilities.swift */,
 				155D3BBB22401D1100B0D38E /* FixtureValues.swift */,
 				C93559281C12C49F009FD6A9 /* TestAffineTransform.swift */,
 				6E203B8C1C1303BB003B2576 /* TestBundle.swift */,

--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -441,7 +441,7 @@ extension NSString {
         if matches.count == 1 {
             let theOnlyFoundItem = URL(fileURLWithPath: matches[0], relativeTo: urlWhereToSearch)
             if theOnlyFoundItem.hasDirectoryPath {
-                matches = _getNamesAtURL(theOnlyFoundItem, prependWith: matches[0], namePredicate: { _ in true }, typePredicate: checkExtension)
+                matches = _getNamesAtURL(theOnlyFoundItem, prependWith: matches[0], namePredicate: nil, typePredicate: checkExtension)
             }
         }
         
@@ -464,60 +464,60 @@ extension NSString {
         if !validPathSeps.contains(where: { path.hasSuffix(String($0)) }) {
             return false
         }
-        
+
         var isDirectory: ObjCBool = false
         let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
         return exists && isDirectory.boolValue
     }
-    
-    internal typealias _FileNamePredicate = (String?) -> Bool
-    
-    internal func _getNamesAtURL(_ filePathURL: URL, prependWith: String, namePredicate: _FileNamePredicate, typePredicate: _FileNamePredicate) -> [String] {
+
+
+    fileprivate typealias _FileNamePredicate = (String) -> Bool
+
+    fileprivate func _getNamesAtURL(_ filePathURL: URL, prependWith: String, namePredicate: _FileNamePredicate?, typePredicate: _FileNamePredicate?) -> [String] {
         var result: [String] = []
-        
+
         if let enumerator = FileManager.default.enumerator(at: filePathURL, includingPropertiesForKeys: nil, options: .skipsSubdirectoryDescendants, errorHandler: nil) {
             for item in enumerator.lazy.map({ $0 as! URL }) {
                 let itemName = item.lastPathComponent
-                
-                let matchByName = namePredicate(itemName)
-                let matchByExtension = typePredicate(item.pathExtension)
-                
-                if matchByName && matchByExtension {
-                    if prependWith.isEmpty {
-                        result.append(itemName)
-                    } else {
-                        result.append(prependWith._bridgeToObjectiveC().appendingPathComponent(itemName))
-                    }
+
+                if let predicate = namePredicate, !predicate(itemName) { continue }
+                if let predicate = typePredicate, !predicate(item.pathExtension) { continue }
+                if prependWith.isEmpty {
+                    result.append(itemName)
+                } else {
+                    result.append(prependWith._bridgeToObjectiveC().appendingPathComponent(itemName))
                 }
             }
         }
-        
+
         return result
     }
-    
-    fileprivate func _getExtensionPredicate(_ extensions: [String]?, caseSensitive: Bool) -> _FileNamePredicate {
+
+
+    fileprivate func _getExtensionPredicate(_ extensions: [String]?, caseSensitive: Bool) -> _FileNamePredicate? {
         guard let exts = extensions else {
-            return { _ in true }
+            return nil
         }
         
         if caseSensitive {
             let set = Set(exts)
-            return { $0 != nil && set.contains($0!) }
+            return { set.contains($0) }
         } else {
             let set = Set(exts.map { $0.lowercased() })
-            return { $0 != nil && set.contains($0!.lowercased()) }
+            return {set.contains($0.lowercased()) }
         }
     }
     
-    fileprivate func _getFileNamePredicate(_ prefix: String, caseSensitive: Bool) -> _FileNamePredicate {
+    fileprivate func _getFileNamePredicate(_ prefix: String, caseSensitive: Bool) -> _FileNamePredicate? {
         guard !prefix.isEmpty else {
-            return { _ in true }
+            return nil
         }
 
         if caseSensitive {
-            return { $0 != nil && $0!.hasPrefix(prefix) }
+            return { $0.hasPrefix(prefix) }
         } else {
-            return { $0 != nil && $0!._bridgeToObjectiveC().range(of: prefix, options: .caseInsensitive).location == 0 }
+            let prefix = prefix.lowercased()
+            return { $0.lowercased().hasPrefix(prefix) }
         }
     }
     


### PR DESCRIPTION
- The test was slow for 2 reasons, NSPathUtilities.completePath() was
  slow and the test directory used may already have an unknown number of
  files in it.
    
- Use a subdirectory of NSTemporaryDirectory() to control number of
  files in the directory. This stops the tests running on an unbounded
  number of files which can increase test time.
    
- _getNamesAtURL(): Simplify the enumerator by making the filename test
  predicates Optional.
    
- Keep the test disabled on Windows as it appears to have never worked.
