### PR TITLE
[cmake] Fix dependencies for xdgTestHelp

### DIFF
--- a/TestFoundation/xdgTestHelper/CMakeLists.txt
+++ b/TestFoundation/xdgTestHelper/CMakeLists.txt
@@ -2,7 +2,9 @@
 add_executable(xdgTestHelper
   main.swift)
 target_link_libraries(xdgTestHelper PRIVATE
-  Foundation)
+  Foundation
+  FoundationNetworking
+  FoundationXML)
 # TODO(compnerd) properly propogate `BUILD_RPATH` to the target using CMake
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows AND NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_options(xdgTestHelper PRIVATE


### PR DESCRIPTION
xdgTestHelper imports FoundationNetworking and FoundationXML but doesn't
have an explicit dependency on them which can cause a race condition
while building.