### PR TITLE
Work around for CMake 3.15 Resource file linking

### DIFF
--- a/Foundation/CMakeLists.txt
+++ b/Foundation/CMakeLists.txt
@@ -142,6 +142,12 @@ target_compile_options(Foundation PUBLIC
   "SHELL:-Xcc -F${CMAKE_BINARY_DIR}")
 target_compile_options(Foundation PRIVATE
   "SHELL:-Xcc -I${ICU_INCLUDE_DIR}")
+if(CMAKE_SYSTEM_NAME STREQUAL Windows AND CMAKE_VERSION VERSION_LESS 3.16)
+  # Work around for CMake 15 which doesn't link in the resource file
+  # target properly
+  add_dependencies(Foundation CoreFoundationResources)
+  target_link_options(Foundation PRIVATE $<TARGET_OBJECTS:CoreFoundationResources>)
+endif()
 if(ENABLE_TESTING)
   target_compile_options(Foundation PRIVATE
     -enable-testing)


### PR DESCRIPTION
CMake 3.15 doesn't properly include resource files when linking by being
passed a target which means Windows doesn't include the Olson timezone
data. Instead as a work around, link against the target object using
target_link_options.