### PR TITLE
[Windows] Fix Interpretation of Volume Name Array

### DIFF
--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -975,7 +975,12 @@ class TestFileManager : XCTestCase {
             return
         }
         XCTAssertNotEqual(0, volumes.count)
+#if os(Windows)
+        let url = URL(fileURLWithPath: String(NSTemporaryDirectory().prefix(3)))
+        XCTAssertTrue(volumes.contains(url))
+#else
         XCTAssertTrue(volumes.contains(URL(fileURLWithPath: "/")))
+#endif
 #if os(macOS)
         // On macOS, .skipHiddenVolumes should hide 'nobrowse' volumes of which there should be at least one
         guard let visibleVolumes = FileManager.default.mountedVolumeURLs(includingResourceValuesForKeys: [], options: [.skipHiddenVolumes]) else {


### PR DESCRIPTION
Taking &wszPathNAmes[...] doesn't properly get the string and leads to
garbled data. Instead, compute the pointer address and pass that.