### PR TITLE
[Windows] Thread.sleep(...) time interval precision loss

### DIFF
--- a/Foundation/Thread.swift
+++ b/Foundation/Thread.swift
@@ -119,7 +119,7 @@ open class Thread : NSObject {
 
         // the timeout is in 100ns units
         var liTimeout: LARGE_INTEGER =
-            LARGE_INTEGER(QuadPart: LONGLONG(date.timeIntervalSinceNow) * -10000000)
+            LARGE_INTEGER(QuadPart: LONGLONG(date.timeIntervalSinceNow * -10_000_000))
         if !SetWaitableTimer(hTimer, &liTimeout, 0, nil, nil, false) {
           return
         }
@@ -156,7 +156,7 @@ open class Thread : NSObject {
 
         // the timeout is in 100ns units
         var liTimeout: LARGE_INTEGER =
-            LARGE_INTEGER(QuadPart: LONGLONG(interval) * -10000000)
+            LARGE_INTEGER(QuadPart: LONGLONG(interval * -10_000_000))
         if !SetWaitableTimer(hTimer, &liTimeout, 0, nil, nil, false) {
           return
         }

--- a/TestFoundation/TestThread.swift
+++ b/TestFoundation/TestThread.swift
@@ -27,6 +27,8 @@ class TestThread : XCTestCase {
             ("test_mainThread", test_mainThread),
             ("test_callStackSymbols", testExpectedToFailOnAndroid(test_callStackSymbols, "Android doesn't support backtraces at the moment.")),
             ("test_callStackReturnAddresses", testExpectedToFailOnAndroid(test_callStackReturnAddresses, "Android doesn't support backtraces at the moment.")),
+            ("test_sleepForTimeInterval", test_sleepForTimeInterval),
+            ("test_sleepUntilDate", test_sleepUntilDate),
         ]
 
 #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
@@ -151,4 +153,46 @@ class TestThread : XCTestCase {
         XCTAssertTrue(addresses.count > 0)
         XCTAssertTrue(addresses.count <= 128)
     }
+    
+    func test_sleepForTimeInterval() {
+        let measureOversleep = { (timeInterval: TimeInterval) -> TimeInterval in
+            let start = Date()
+            Thread.sleep(forTimeInterval: timeInterval)
+
+            // Measures time Thread.sleep spends over specified timeInterval value
+            return -(start.timeIntervalSinceNow + timeInterval)
+        }
+
+        // Allow a little early wake-ups. Sleep timer on Windows
+        // is more precise than timer used in Date implementation.
+        let allowedOversleepRange = -0.00001..<0.1
+
+        let oversleep1 = measureOversleep(TimeInterval(0.9))
+        XCTAssertTrue(allowedOversleepRange.contains(oversleep1), "Oversleep \(oversleep1) is not in expected range \(allowedOversleepRange)")
+
+        let oversleep2 = measureOversleep(TimeInterval(1.2))
+        XCTAssertTrue(allowedOversleepRange.contains(oversleep2), "Oversleep \(oversleep2) is not in expected range \(allowedOversleepRange)")
+
+        let oversleep3 = measureOversleep(TimeInterval(1.0))
+        XCTAssertTrue(allowedOversleepRange.contains(oversleep3), "Oversleep \(oversleep3) is not in expected range \(allowedOversleepRange)")
+    }
+
+    func test_sleepUntilDate() {
+        let measureOversleep = { (date: Date) -> TimeInterval in
+            Thread.sleep(until: date)
+            return -date.timeIntervalSinceNow
+        }
+
+        let allowedOversleepRange = -0.00001..<0.1
+
+        let oversleep1 = measureOversleep(Date(timeIntervalSinceNow: 0.8))
+        XCTAssertTrue(allowedOversleepRange.contains(oversleep1), "Oversleep \(oversleep1) is not in expected range \(allowedOversleepRange)")
+
+        let oversleep2 = measureOversleep(Date(timeIntervalSinceNow: 1.1))
+        XCTAssertTrue(allowedOversleepRange.contains(oversleep2), "Oversleep \(oversleep2) is not in expected range \(allowedOversleepRange)")
+
+        let oversleep3 = measureOversleep(Date(timeIntervalSinceNow: 1.0))
+        XCTAssertTrue(allowedOversleepRange.contains(oversleep3), "Oversleep \(oversleep3) is not in expected range \(allowedOversleepRange)")
+    }
+
 }


### PR DESCRIPTION
`Thread.sleep(until date:)` and `Thread.sleep(forTimeInterval:)` are initializing `LONGLONG` (`Int64`) from `TimeInterval` (`Double`), cutting sleep time to whole seconds.

This moves "100ns" time units calculation prior to `LONGLONG` init.