### PR TITLE
Fix TestFileManager Crash in test_displayNames

### DIFF
--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -1581,7 +1581,9 @@ VIDEOS=StopgapVideos
             #endif
             
             XCTAssertGreaterThanOrEqual(components.count, 3)
-            XCTAssertEqual(components[components.count - 2], "a")
+            if components.count >= 3 {
+                XCTAssertEqual(components[components.count - 2], "a")
+            }
             
             #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
             XCTAssertEqual(components.last, "Prova")
@@ -1598,11 +1600,13 @@ VIDEOS=StopgapVideos
             #endif
             
             XCTAssertGreaterThanOrEqual(components.count, 4)
-            XCTAssertEqual(components[components.count - 3], "a")
-            
-            #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
-            XCTAssertEqual(components[components.count - 2], "Test")
-            #endif
+            if components.count >= 4 {
+                XCTAssertEqual(components[components.count - 3], "a")
+                
+                #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+                XCTAssertEqual(components[components.count - 2], "Test")
+                #endif
+            }
             
             XCTAssertEqual(components.last, "b")
         }


### PR DESCRIPTION
test_displayNames XCTAsserts that there are enough components in the
array, but if the test fails it still continues on, subtracting from
components.count and causing a negative number out of bounds access.
This doesn't prevent the test from failing since the GreaterThanOrEqual
check will still fail, but it does prevent the test from causing the
test suite to crash.