### PR TITLE
[Windows] Fix precision loss in CFGetSystemUptime()

### DIFF
--- a/CoreFoundation/NumberDate.subproj/CFDate.c
+++ b/CoreFoundation/NumberDate.subproj/CFDate.c
@@ -122,7 +122,7 @@ CF_EXPORT CFTimeInterval CFGetSystemUptime(void) {
     return (double)res.tv_sec + ((double)res.tv_nsec)/1.0E9;
 #elif TARGET_OS_WIN32
     ULONGLONG ullTickCount = GetTickCount64();
-    return ullTickCount / 1000;
+    return ullTickCount / 1000.0;
 #else
 #error Unable to calculate uptime for this platform
 #endif


### PR DESCRIPTION
Integer division rounds result to whole seconds. This forces floating point division.

Noticed the issue because `XCTest.measure` depends on this value (through `ProcessInfo.systemUptime`) and produces unreliable results.