### PR TITLE
[Windows] Special case ~ as an absolute path

### DIFF
--- a/Foundation/NSPathUtilities.swift
+++ b/Foundation/NSPathUtilities.swift
@@ -125,7 +125,7 @@ extension String {
 
     internal var isAbsolutePath: Bool {
 #if os(Windows)
-        return !withCString(encodedAs: UTF16.self, PathIsRelativeW)
+        return hasPrefix("~") || !withCString(encodedAs: UTF16.self, PathIsRelativeW)
 #else
         return hasPrefix("~") || hasPrefix("/")
 #endif


### PR DESCRIPTION
PathIsRelativeW doesn't consider ~ to be an absolute path, so we special
case it in to match posix behaviour