### PR TITLE
don't rely on getdtablesize()

### DIFF
--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -198,7 +198,13 @@ func cat(_ args: ArraySlice<String>.Iterator) {
 
 #if !os(Windows)
 func printOpenFileDescriptors() {
-    for fd in 0..<getdtablesize() {
+    let reasonableMaxFD: CInt
+    #if os(Linux) || os(macOS)
+    reasonableMaxFD = getdtablesize()
+    #else
+    reasonableMaxFD = 4096
+    #endif
+    for fd in 0..<reasonableMaxFD {
         if fcntl(fd, F_GETFD) != -1 {
             print(fd)
         }


### PR DESCRIPTION
Android and possibly other UNIX systems lack getdtablesize() so let's
try to use a better way of estimating the file descriptors we need to
close post-fork, pre-exec by listing /proc/self/fd. If that fails, we
fall back on getdtablesize or as a last resort a hard-coded 4096.