### PR TITLE
[CF] Fix typo in TARGET_RT_64_BIT ifdef.

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -787,7 +787,7 @@ static CFLock_t __CFRuntimeExternRefCountTableLock = CFLockInit;
 #else
 static uint64_t __CFGetFullRetainCount(CFTypeRef cf) {
     if (NULL == cf) { CRSetCrashLogMessage("*** __CFGetFullRetainCount() called with NULL ***"); HALT; }
-#if TARGET_RT64_BIT
+#if TARGET_RT_64_BIT
     __CFInfoType info = atomic_load(&(((CFRuntimeBase *)cf)->_cfinfoa));
     uint32_t rc = __CFHighRCFromInfo(info);
     if (0 == rc) {


### PR DESCRIPTION
__CFGetFullRetainCount contains an ifdef with symbol name
TARGET_RT64_BIT. This is likely a typo since otherwise,
__CFDoExternRefOperation is referenced, but is guarded by an ifdef with
name TARGET_RT_64_BIT instead, which then manifests as a missing symbol.
Other calls to __CFDoExternRefOperation are guarded by the same symbol.