### PR TITLE
[CF] DT_WHT is unavailable on OpenBSD.

### DIFF
--- a/CoreFoundation/Base.subproj/CFFileUtilities.c
+++ b/CoreFoundation/Base.subproj/CFFileUtilities.c
@@ -439,7 +439,11 @@ CF_PRIVATE CFMutableArrayRef _CFCreateContentsOfDirectory(CFAllocatorRef alloc, 
             dirURL = CFURLCreateFromFileSystemRepresentation(alloc, (uint8_t *)dirPath, pathLength, true);
             releaseBase = true;
         }
+#if !defined(__OpenBSD__)
         if (dp->d_type == DT_DIR || dp->d_type == DT_UNKNOWN || dp->d_type == DT_LNK || dp->d_type == DT_WHT) {
+#else
+        if (dp->d_type == DT_DIR || dp->d_type == DT_UNKNOWN || dp->d_type == DT_LNK) {
+#endif
             Boolean isDir = (dp->d_type == DT_DIR);
             if (!isDir) {
                 // Ugh; must stat.


### PR DESCRIPTION
Here we duplicate this extended conditional to not reference DT_WHT,
which is not available on OpenBSD. It is probably harmless to actually
remove DT_WHT entirely here unconditionally, but would require grokking
more context for a simple buildfix.

It also seems more readable to duplicate the entire line in the ifdef
despite being able to squish the ifdef in the clause.