### PR TITLE
[CF] Add TARGET_OS_BSD in some places.

### DIFF
--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -131,7 +131,7 @@ const char *_CFProcessPath(void) {
 }
 #endif
 
-#if TARGET_OS_MAC || TARGET_OS_WIN32
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_BSD
 CF_CROSS_PLATFORM_EXPORT Boolean _CFIsMainThread(void) {
     return pthread_main_np() == 1;
 }
@@ -619,7 +619,7 @@ CF_PRIVATE void __CFTSDInitialize() {
 static void __CFTSDSetSpecific(void *arg) {
 #if TARGET_OS_MAC
     pthread_setspecific(__CFTSDIndexKey, arg);
-#elif TARGET_OS_LINUX
+#elif TARGET_OS_LINUX || TARGET_OS_BSD
     pthread_setspecific(__CFTSDIndexKey, arg);
 #elif TARGET_OS_WIN32
     FlsSetValue(__CFTSDIndexKey, arg);
@@ -629,7 +629,7 @@ static void __CFTSDSetSpecific(void *arg) {
 static void *__CFTSDGetSpecific() {
 #if TARGET_OS_MAC
     return pthread_getspecific(__CFTSDIndexKey);
-#elif TARGET_OS_LINUX
+#elif TARGET_OS_LINUX || TARGET_OS_BSD
     return pthread_getspecific(__CFTSDIndexKey);
 #elif TARGET_OS_WIN32
     return FlsGetValue(__CFTSDIndexKey);

--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -152,7 +152,7 @@ typedef int		boolean_t;
 typedef unsigned long fd_mask;
 #endif
     
-#if !TARGET_OS_ANDROID && !TARGET_OS_CYGWIN
+#if !TARGET_OS_ANDROID && !TARGET_OS_CYGWIN && !TARGET_OS_BSD
 CF_INLINE size_t
 strlcpy(char * dst, const char * src, size_t maxlen) {
     const size_t srclen = strlen(src);
@@ -180,7 +180,7 @@ strlcat(char * dst, const char * src, size_t maxlen) {
 }
 #endif
 
-#if !TARGET_OS_CYGWIN
+#if !TARGET_OS_CYGWIN && !TARGET_OS_BSD
 #define issetugid() 0
 #endif
     
@@ -250,7 +250,7 @@ void OSMemoryBarrier();
 
 #endif
 
-#if TARGET_OS_LINUX
+#if TARGET_OS_LINUX || TARGET_OS_BSD
 #include <sys/param.h>
 #endif
 #if TARGET_OS_WIN32 || TARGET_OS_LINUX

--- a/CoreFoundation/Collections.subproj/CFData.c
+++ b/CoreFoundation/Collections.subproj/CFData.c
@@ -43,7 +43,7 @@ CF_INLINE unsigned long __CFPageSize() {
     GetSystemInfo(&sysInfo);
     return sysInfo.dwPageSize;
 }
-#elif TARGET_OS_LINUX
+#elif TARGET_OS_LINUX || TARGET_OS_BSD
 #include <unistd.h>
 CF_INLINE unsigned long __CFPageSize() {
     return (unsigned long)getpagesize();

--- a/CoreFoundation/PlugIn.subproj/CFBundle_Resources.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Resources.c
@@ -25,7 +25,7 @@
 #include <errno.h>
 #include <sys/types.h>
 
-#if TARGET_OS_MAC || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
 #include <unistd.h>
 #if !TARGET_OS_ANDROID
 #include <sys/sysctl.h>

--- a/CoreFoundation/Preferences.subproj/CFXMLPreferencesDomain.c
+++ b/CoreFoundation/Preferences.subproj/CFXMLPreferencesDomain.c
@@ -55,7 +55,7 @@ static void __CFMilliSleep(uint32_t msecs) {
     SleepEx(msecs, false);
 #elif defined(__svr4__) || defined(__hpux__)
     sleep((msecs + 900) / 1000);
-#elif TARGET_OS_OSX || TARGET_OS_LINUX
+#elif TARGET_OS_OSX || TARGET_OS_LINUX || TARGET_OS_BSD
     struct timespec input;
     input.tv_sec = msecs / 1000;
     input.tv_nsec = (msecs - input.tv_sec * 1000) * 1000000;

--- a/CoreFoundation/String.subproj/CFBurstTrie.c
+++ b/CoreFoundation/String.subproj/CFBurstTrie.c
@@ -18,7 +18,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <limits.h>
-#if TARGET_OS_MAC || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
 #include <unistd.h>
 #include <sys/param.h>
 #include <sys/mman.h>


### PR DESCRIPTION
These particular uses should hopefully be uncontroversial.

* CFPlatform.c: to use the _CFIsMainThread pthread implementation; to
  properly implement __CFTSDSetSpecific and __CFTSDGetSpecific with the
  same pthread implementation as Linux (and Mac)

* CoreFoundation_Prefix.h: to exclude strlcpy and issetugid which is
  normally available in the system; to include sys/param.h for the
  MIN macro

* CFData.c: for the __CFPageSize implementation

* CFBundle_Resources.c: to include dirent.h symbols

* CFXMLPreferencesDomain.c: to define sleep for the platform

* CFBurstTrie.c: for mmap.