### PR TITLE
[CF] Add missing DEPLOYMENT_RUNTIME_SWIFT guard.

### DIFF
--- a/CoreFoundation/Collections.subproj/CFArray.c
+++ b/CoreFoundation/Collections.subproj/CFArray.c
@@ -971,8 +971,10 @@ void CFArraySortValues(CFMutableArrayRef array, CFRange range, CFComparatorFunct
         result = CF_OBJC_CALLV((NSMutableArray *)array, isKindOfClass:[NSMutableArray class]);
         immutable = !result;
     } else if (CF_IS_SWIFT(CFArrayGetTypeID(), array)) {
+#if DEPLOYMENT_RUNTIME_SWIFT
         Boolean result = __CFSwiftBridge.NSArray.isSubclassOfNSMutableArray(array);
         immutable = !result;
+#endif
     } else if (__kCFArrayImmutable == __CFArrayGetType(array)) {
         immutable = true;
     }


### PR DESCRIPTION
CFArray.c references __CFSwiftBridge which is defined behind
DEPLOYMENT_RUNTIME_SWIFT, so this needs to be behind that guard
as well when DEPLOYMENT_RUNTIME_SWIFT is not set.