### PR TITLE
[CF] Define DECLARE_STATIC_CLASS_REF macro.

### DIFF
--- a/CoreFoundation/Base.subproj/ForFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForFoundationOnly.h
@@ -691,6 +691,7 @@ CF_EXPORT void *_CFCreateArrayStorage(size_t numPointers, Boolean zeroed, size_t
 
 // We don't need static class refs if CF is used standalone, as there's no Swift or ObjC runtime to interoperate with.
 #define STATIC_CLASS_REF(...) NULL
+#define DECLARE_STATIC_CLASS_REF(...)
 
 #endif
 


### PR DESCRIPTION
If !DEPLOYMENT_RUNTIME_SWIFT, just defining STATIC_CLASS_REF is
insufficient, since CFBase refers to DECLARE_STATIC_CLASS_REF.