### PR TITLE
[CF] Match some declarations with their headers.

### DIFF
--- a/CoreFoundation/Locale.subproj/CFCalendar.c
+++ b/CoreFoundation/Locale.subproj/CFCalendar.c
@@ -604,7 +604,7 @@ static CFStringRef _CFCalendarGetCanonicalIdentifier(CFStringRef identifier) {
     return canonicalIdent;
 }
 
-CF_CROSS_PLATFORM_EXPORT bool _CFCalendarInitWithIdentifier(CFCalendarRef calendar, CFStringRef identifier) {
+CF_CROSS_PLATFORM_EXPORT Boolean _CFCalendarInitWithIdentifier(CFCalendarRef calendar, CFStringRef identifier) {
     CFStringRef canonicalIdent = _CFCalendarGetCanonicalIdentifier(identifier);
     if (!canonicalIdent) ICU_LOG("                // _CFCalendarInitWithIdentifier exit false 1\n");
     if (!canonicalIdent) return false;

--- a/CoreFoundation/Parsing.subproj/CFPropertyList.c
+++ b/CoreFoundation/Parsing.subproj/CFPropertyList.c
@@ -2642,7 +2642,7 @@ CFTypeRef _CFPropertyListCreateFromXMLString(CFAllocatorRef allocator, CFStringR
 CF_PRIVATE bool __CFBinaryPlistCreateObjectFiltered(const uint8_t *databytes, uint64_t datalen, uint64_t startOffset, const CFBinaryPlistTrailer *trailer, CFAllocatorRef allocator, CFOptionFlags mutabilityOption, CFMutableDictionaryRef objects, CFMutableSetRef set, CFIndex curDepth, CFSetRef keyPaths, CFPropertyListRef *plist);
 
 // Returns a subset of the property list, only including the key paths in the CFSet.
-bool _CFPropertyListCreateFiltered(CFAllocatorRef allocator, CFDataRef data, CFOptionFlags option, CFSetRef keyPaths, CFPropertyListRef *value, CFErrorRef *error) {
+Boolean _CFPropertyListCreateFiltered(CFAllocatorRef allocator, CFDataRef data, CFOptionFlags option, CFSetRef keyPaths, CFPropertyListRef *value, CFErrorRef *error) {
     
     if (!keyPaths || !data) {
         return false;
@@ -2691,7 +2691,7 @@ bool _CFPropertyListCreateFiltered(CFAllocatorRef allocator, CFDataRef data, CFO
  @param error If an error occurs, will be set to a valid CFErrorRef. It is the caller's responsibility to release this value.
  @return True if the key is found, false otherwise.
  */
-bool _CFPropertyListCreateSingleValue(CFAllocatorRef allocator, CFDataRef data, CFOptionFlags option, CFStringRef keyPath, CFPropertyListRef *value, CFErrorRef *error) {
+Boolean _CFPropertyListCreateSingleValue(CFAllocatorRef allocator, CFDataRef data, CFOptionFlags option, CFStringRef keyPath, CFPropertyListRef *value, CFErrorRef *error) {
     
     if (!keyPath || CFStringGetLength(keyPath) == 0) {
         return false;


### PR DESCRIPTION
It appears that standardization on CF types versus C99 types was made,
but some changes were missing. As I understand it, on platforms where
Boolean (a.k.a. unsigned char, when !DEPLOYMENT_RUNTIME_SWIFT) is
convertible to bool, this doesn't cause a problem, but on OpenBSD,
bool (a.k.a., _Bool) is an enum, so causes an error.

That being said, it certainly appears intended that these should be
written as Boolean.