### PR TITLE
CoreFoundation: permit CURL's CMake package for configuration

### DIFF
--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -26,7 +26,10 @@ find_package(Threads)
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   find_package(LibXml2 REQUIRED)
-  find_package(CURL REQUIRED)
+  find_package(CURL CONFIG)
+  if(NOT CURL_FOUND)
+    find_package(CURL REQUIRED)
+  endif()
   find_package(ICU COMPONENTS uc i18n REQUIRED)
 endif()
 


### PR DESCRIPTION
Support both the CMake package provided by CURL's build as well as the
fallback path when detecting CURL.  This should restore the ability to
use zlib for compression on Windows.