### PR TITLE
NSString._getBlockStart - loose precondition check to avoid crash in edge case

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -727,7 +727,7 @@ extension NSString {
         let len = length
         var ch: unichar
         
-        precondition(range.length <= len && range.location < len - range.length, "Range {\(range.location), \(range.length)} is out of bounds of length \(len)")
+        precondition(range.length <= len && range.location <= len - range.length, "Range {\(range.location), \(range.length)} is out of bounds of length \(len)")
         
         if range.location == 0 && range.length == len && contentsEndPtr == nil { // This occurs often
             startPtr?.pointee = 0


### PR DESCRIPTION
I believe it was just a typo. There are other similar checks already, and all of them use `<=` comparison.

This was discovered as the reason of `paragraphRange(for:)` fail on whole string range. E.g, following code is crashing:
```
let s = "abc" as NSString
let range = NSRange(location: 0, length:3)
_ = s.paragraphRange(for: range) // <- crash
```

Test is also included.

Test checks paragraphRange on:
- whole string range
- every subrange in every single paragraph
- every subrange in every two consecutive paragraphs
