### PR TITLE
TestFoundation: change CWD to TMPDIR and restore previous CWD when test finishes

### DIFF
--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -286,6 +286,7 @@ class TestURL : XCTestCase {
     static var gBaseCurrentWorkingDirectoryPath : String {
         return FileManager.default.currentDirectoryPath
     }
+    static var gSavedPath = ""
     static var gRelativeOffsetFromBaseCurrentWorkingDirectory: UInt = 0
     static let gFileExistsName = "TestCFURL_file_exists\(ProcessInfo.processInfo.globallyUniqueString)"
     static let gFileDoesNotExistName = "TestCFURL_file_does_not_exist"
@@ -339,9 +340,8 @@ class TestURL : XCTestCase {
             }
         }
 
-        #if os(Android)
-        FileManager.default.changeCurrentDirectoryPath("/data/local/tmp")
-        #endif
+        TestURL.gSavedPath = FileManager.default.currentDirectoryPath
+        FileManager.default.changeCurrentDirectoryPath(NSTemporaryDirectory())
 
         let cwd = FileManager.default.currentDirectoryPath
         let cwdURL = URL(fileURLWithPath: cwd, isDirectory: true)
@@ -358,6 +358,7 @@ class TestURL : XCTestCase {
             let error = strerror(errno)!
             XCTFail("Failed to set up test paths: \(String(cString: error))")
         }
+        defer { FileManager.default.changeCurrentDirectoryPath(TestURL.gSavedPath) }
         
         // test with file that exists
         var path = TestURL.gFileExistsPath
@@ -403,6 +404,7 @@ class TestURL : XCTestCase {
             let error = strerror(errno)!
             XCTFail("Failed to set up test paths: \(String(cString: error))")
         }
+        defer { FileManager.default.changeCurrentDirectoryPath(TestURL.gSavedPath) }
         
         // test with file that exists
         var path = TestURL.gFileExistsPath


### PR DESCRIPTION
The working directory was changed to /data/local/tmp on Android assuming that adb is being used, but this isn't necessary in the Termux app. Additionally the working directory was not reset back, so later tests were affected by the change.

Along with the still-unmerged #2145, this finally gets all the TestFoundation tests passing for me on Android.

Pinging @drodriguez, who did a lot of this Android porting work.