### PR TITLE
[5.2] SR-11354: Foundation.Process inherits file descriptors into the child process

### DIFF
--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -883,7 +883,8 @@ open class Process: NSObject {
         #else
         for fd in 3 ..< getdtablesize() {
             guard adddup2[fd] == nil &&
-                  !addclose.contains(fd) else {
+                  !addclose.contains(fd) &&
+                  fd != taskSocketPair[1] else {
                     continue // Do not double-close descriptors, or close those pertaining to Pipes or FileHandles we want inherited.
             }
             posix(_CFPosixSpawnFileActionsAddClose(fileActions, fd))

--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -8,6 +8,7 @@
 //
 
 import CoreFoundation
+import Darwin
 
 extension Process {
     public enum TerminationReason : Int {
@@ -872,6 +873,16 @@ open class Process: NSObject {
             posix(_CFPosixSpawnFileActionsAddClose(fileActions, fd))
         }
 
+        #if os(macOS)
+        var spawnAttrs: posix_spawnattr_t? = nil
+        posix_spawnattr_init(&spawnAttrs)
+        posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_CLOEXEC_DEFAULT))
+        #else
+        for fd in 3..<getdtablesize() {
+            posix(_CFPosixSpawnFileActionsAddClose(fileActions, fd))
+        }
+        #endif
+
         let fileManager = FileManager()
         let previousDirectoryPath = fileManager.currentDirectoryPath
         if let dir = currentDirectoryURL?.path, !fileManager.changeCurrentDirectoryPath(dir) {
@@ -885,9 +896,16 @@ open class Process: NSObject {
 
         // Launch
         var pid = pid_t()
+        #if os(macOS)
+        guard _CFPosixSpawn(&pid, launchPath, fileActions, &spawnAttrs, argv, envp) == 0 else {
+            throw _NSErrorWithErrno(errno, reading: true, path: launchPath)
+        }
+        #else
         guard _CFPosixSpawn(&pid, launchPath, fileActions, nil, argv, envp) == 0 else {
             throw _NSErrorWithErrno(errno, reading: true, path: launchPath)
         }
+        #endif
+
 
         // Close the write end of the input and output pipes.
         if let pipe = standardInput as? Pipe {

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -750,9 +750,10 @@ class TestProcess : XCTestCase {
         }
     }
 
+    #if !os(Windows)
     func test_fileDescriptorsAreNotInherited() throws {
         let task = Process()
-        let clonedFD = dup(1)
+        let someExtraFDs = [dup(1), dup(1), dup(1), dup(1), dup(1), dup(1), dup(1)]
         task.executableURL = xdgTestHelperURL()
         task.arguments = ["--print-open-file-descriptors"]
         task.standardInput = FileHandle.nullDevice
@@ -761,14 +762,32 @@ class TestProcess : XCTestCase {
         task.standardError = FileHandle.nullDevice
         XCTAssertNoThrow(try task.run())
 
-        try task.run()
         try stdoutPipe.fileHandleForWriting.close()
         let stdoutData = try stdoutPipe.fileHandleForReading.readToEnd()
         task.waitUntilExit()
-        print(String(decoding: stdoutData ?? Data(), as: Unicode.UTF8.self))
-        XCTAssertEqual("0\n1\n2\n", String(decoding: stdoutData ?? Data(), as: Unicode.UTF8.self))
-        close(clonedFD)
+        let stdoutString = String(decoding: stdoutData ?? Data(), as: Unicode.UTF8.self)
+        #if os(macOS)
+        XCTAssertEqual("0\n1\n2\n", stdoutString)
+        #else
+        // on Linux we may also have a /dev/urandom open as well as some socket that Process uses for something.
+
+        // we should definitely have stdin (0), stdout (1), and stderr (2) open
+        XCTAssert(stdoutString.utf8.starts(with: "0\n1\n2\n".utf8))
+
+        // in total we should have 6 or fewer lines:
+        // 1. stdin
+        // 2. stdout
+        // 3. stderr
+        // 4. /dev/urandom (optional)
+        // 5. communication socket (optional)
+        // 6. trailing new line
+        XCTAssertLessThanOrEqual(stdoutString.components(separatedBy: "\n").count, 6, "\(stdoutString)")
+        #endif
+        for fd in someExtraFDs {
+            close(fd)
+        }
     }
+    #endif
 
     static var allTests: [(String, (TestProcess) -> () throws -> Void)] {
         var tests = [
@@ -807,6 +826,7 @@ class TestProcess : XCTestCase {
         tests += [
             ("test_interrupt", test_interrupt),
             ("test_suspend_resume", test_suspend_resume),
+            ("test_fileDescriptorsAreNotInherited", test_fileDescriptorsAreNotInherited),
         ]
 #endif
         return tests

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -818,7 +818,6 @@ class TestProcess : XCTestCase {
             ("test_currentDirectory", test_currentDirectory),
             ("test_pipeCloseBeforeLaunch", test_pipeCloseBeforeLaunch),
             ("test_multiProcesses", test_multiProcesses),
-            ("test_fileDescriptorsAreNotInherited", test_fileDescriptorsAreNotInherited),
         ]
 
 #if !os(Windows)

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -198,7 +198,13 @@ func cat(_ args: ArraySlice<String>.Iterator) {
 
 #if !os(Windows)
 func printOpenFileDescriptors() {
-    for fd in 0..<getdtablesize() {
+    let reasonableMaxFD: CInt
+    #if os(Linux) || os(macOS)
+    reasonableMaxFD = getdtablesize()
+    #else
+    reasonableMaxFD = 4096
+    #endif
+    for fd in 0..<reasonableMaxFD {
         if fcntl(fd, F_GETFD) != -1 {
             print(fd)
         }

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -196,6 +196,15 @@ func cat(_ args: ArraySlice<String>.Iterator) {
     exit(exitCode)
 }
 
+func printOpenFileDescriptors() {
+    for fd in 0..<getdtablesize() {
+        if fcntl(fd, F_GETFD) != -1 {
+            print(fd)
+        }
+    }
+    exit(0)
+}
+
 // -----
 
 var arguments = ProcessInfo.processInfo.arguments.dropFirst().makeIterator()
@@ -255,7 +264,10 @@ case "--nspathfor":
 case "--signal-test":
     signalTest()
 #endif
-    
+
+case "--print-open-file-descriptors":
+    printOpenFileDescriptors()
+
 default:
     fatalError("These arguments are not recognized. Only run this from a unit test.")
 }

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -196,6 +196,7 @@ func cat(_ args: ArraySlice<String>.Iterator) {
     exit(exitCode)
 }
 
+#if !os(Windows)
 func printOpenFileDescriptors() {
     for fd in 0..<getdtablesize() {
         if fcntl(fd, F_GETFD) != -1 {
@@ -204,6 +205,7 @@ func printOpenFileDescriptors() {
     }
     exit(0)
 }
+#endif
 
 // -----
 
@@ -263,10 +265,10 @@ case "--nspathfor":
 #if !os(Windows)
 case "--signal-test":
     signalTest()
-#endif
 
 case "--print-open-file-descriptors":
     printOpenFileDescriptors()
+#endif
 
 default:
     fatalError("These arguments are not recognized. Only run this from a unit test.")


### PR DESCRIPTION
This is a backport of #2542 & #2586 which together fix https://bugs.swift.org/browse/SR-11354 which is an important bug fix.

Same as #2608 but this one is for 5.2.