### PR TITLE
[5.1] SR-11354: Foundation.Process inherits file descriptors into the child process

### DIFF
--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -8,7 +8,10 @@
 //
 
 import CoreFoundation
+
+#if canImport(Darwin)
 import Darwin
+#endif
 
 extension Process {
     public enum TerminationReason : Int {
@@ -826,12 +829,16 @@ open class Process: NSObject {
             posix(_CFPosixSpawnFileActionsAddClose(fileActions, fd))
         }
 
-        #if os(macOS)
+        #if canImport(Darwin)
         var spawnAttrs: posix_spawnattr_t? = nil
         posix_spawnattr_init(&spawnAttrs)
         posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_CLOEXEC_DEFAULT))
         #else
-        for fd in 3..<getdtablesize() {
+        for fd in 3 ..< getdtablesize() {
+            guard adddup2[fd] == nil &&
+                  !addclose.contains(fd) else {
+                    continue // Do not double-close descriptors, or close those pertaining to Pipes or FileHandles we want inherited.
+            }
             posix(_CFPosixSpawnFileActionsAddClose(fileActions, fd))
         }
         #endif

--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -48,6 +48,43 @@ private var managerThreadRunLoopIsRunningCondition = NSCondition()
 internal let kCFSocketDataCallBack = CFSocketCallBackType.dataCallBack.rawValue
 #endif
 
+#if !canImport(Darwin) && !os(Windows)
+private func findMaximumOpenFromProcSelfFD() -> CInt? {
+    guard let dirPtr = opendir("/proc/self/fd") else {
+        return nil
+    }
+    defer {
+        closedir(dirPtr)
+    }
+    var highestFDSoFar = CInt(0)
+
+    while let dirEntPtr = readdir(dirPtr) {
+        var entryName = dirEntPtr.pointee.d_name
+        let thisFD = withUnsafeBytes(of: &entryName) { entryNamePtr -> CInt? in
+            CInt(String(decoding: entryNamePtr.prefix(while: { $0 != 0 }), as: Unicode.UTF8.self))
+        }
+        highestFDSoFar = max(thisFD ?? -1, highestFDSoFar)
+    }
+
+    return highestFDSoFar
+}
+
+func findMaximumOpenFD() -> CInt {
+    if let maxFD = findMaximumOpenFromProcSelfFD() {
+        // the precise method worked, let's return this fd.
+        return maxFD
+    }
+
+    // We don't have /proc, let's go with the best estimate.
+#if os(Linux)
+    return getdtablesize()
+#else
+    return 4096
+#endif
+}
+#endif
+
+
 private func emptyRunLoopCallback(_ context : UnsafeMutableRawPointer?) -> Void {}
 
 
@@ -834,7 +871,7 @@ open class Process: NSObject {
         posix_spawnattr_init(&spawnAttrs)
         posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_CLOEXEC_DEFAULT))
         #else
-        for fd in 3 ..< getdtablesize() {
+        for fd in 3 ... findMaximumOpenFD() {
             guard adddup2[fd] == nil &&
                   !addclose.contains(fd) &&
                   fd != taskSocketPair[1] else {

--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -836,7 +836,8 @@ open class Process: NSObject {
         #else
         for fd in 3 ..< getdtablesize() {
             guard adddup2[fd] == nil &&
-                  !addclose.contains(fd) else {
+                  !addclose.contains(fd) &&
+                  fd != taskSocketPair[1] else {
                     continue // Do not double-close descriptors, or close those pertaining to Pipes or FileHandles we want inherited.
             }
             posix(_CFPosixSpawnFileActionsAddClose(fileActions, fd))

--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -8,6 +8,7 @@
 //
 
 import CoreFoundation
+import Darwin
 
 extension Process {
     public enum TerminationReason : Int {
@@ -825,6 +826,16 @@ open class Process: NSObject {
             posix(_CFPosixSpawnFileActionsAddClose(fileActions, fd))
         }
 
+        #if os(macOS)
+        var spawnAttrs: posix_spawnattr_t? = nil
+        posix_spawnattr_init(&spawnAttrs)
+        posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_CLOEXEC_DEFAULT))
+        #else
+        for fd in 3..<getdtablesize() {
+            posix(_CFPosixSpawnFileActionsAddClose(fileActions, fd))
+        }
+        #endif
+
         let fileManager = FileManager()
         let previousDirectoryPath = fileManager.currentDirectoryPath
         if !fileManager.changeCurrentDirectoryPath(currentDirectoryURL.path) {
@@ -838,9 +849,16 @@ open class Process: NSObject {
 
         // Launch
         var pid = pid_t()
+        #if os(macOS)
+        guard _CFPosixSpawn(&pid, launchPath, fileActions, &spawnAttrs, argv, envp) == 0 else {
+            throw _NSErrorWithErrno(errno, reading: true, path: launchPath)
+        }
+        #else
         guard _CFPosixSpawn(&pid, launchPath, fileActions, nil, argv, envp) == 0 else {
             throw _NSErrorWithErrno(errno, reading: true, path: launchPath)
         }
+        #endif
+
 
         // Close the write end of the input and output pipes.
         if let pipe = standardInput as? Pipe {

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -630,8 +630,6 @@ class TestProcess : XCTestCase {
             ("test_redirect_all_using_null", test_redirect_all_using_null),
             ("test_redirect_all_using_nil", test_redirect_all_using_nil),
             ("test_plutil", test_plutil),
-            ("test_currentDirectory", test_currentDirectory),
-            ("test_fileDescriptorsAreNotInherited", test_fileDescriptorsAreNotInherited),
         ]
 
 #if !os(Windows)

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -565,9 +565,10 @@ class TestProcess : XCTestCase {
         XCTAssertEqual(String(data: stdoutData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), "No files specified.")
     }
 
+    #if !os(Windows)
     func test_fileDescriptorsAreNotInherited() throws {
         let task = Process()
-        let clonedFD = dup(1)
+        let someExtraFDs = [dup(1), dup(1), dup(1), dup(1), dup(1), dup(1), dup(1)]
         task.executableURL = xdgTestHelperURL()
         task.arguments = ["--print-open-file-descriptors"]
         task.standardInput = FileHandle.nullDevice
@@ -576,14 +577,32 @@ class TestProcess : XCTestCase {
         task.standardError = FileHandle.nullDevice
         XCTAssertNoThrow(try task.run())
 
-        try task.run()
         try stdoutPipe.fileHandleForWriting.close()
         let stdoutData = try stdoutPipe.fileHandleForReading.readToEnd()
         task.waitUntilExit()
-        print(String(decoding: stdoutData ?? Data(), as: Unicode.UTF8.self))
-        XCTAssertEqual("0\n1\n2\n", String(decoding: stdoutData ?? Data(), as: Unicode.UTF8.self))
-        close(clonedFD)
+        let stdoutString = String(decoding: stdoutData ?? Data(), as: Unicode.UTF8.self)
+        #if os(macOS)
+        XCTAssertEqual("0\n1\n2\n", stdoutString)
+        #else
+        // on Linux we may also have a /dev/urandom open as well as some socket that Process uses for something.
+
+        // we should definitely have stdin (0), stdout (1), and stderr (2) open
+        XCTAssert(stdoutString.utf8.starts(with: "0\n1\n2\n".utf8))
+
+        // in total we should have 6 or fewer lines:
+        // 1. stdin
+        // 2. stdout
+        // 3. stderr
+        // 4. /dev/urandom (optional)
+        // 5. communication socket (optional)
+        // 6. trailing new line
+        XCTAssertLessThanOrEqual(stdoutString.components(separatedBy: "\n").count, 6, "\(stdoutString)")
+        #endif
+        for fd in someExtraFDs {
+            close(fd)
+        }
     }
+    #endif
 
     static var allTests: [(String, (TestProcess) -> () throws -> Void)] {
         var tests = [
@@ -620,6 +639,7 @@ class TestProcess : XCTestCase {
         tests += [
             ("test_interrupt", test_interrupt),
             ("test_suspend_resume", test_suspend_resume),
+            ("test_fileDescriptorsAreNotInherited", test_fileDescriptorsAreNotInherited),
         ]
 #endif
         return tests

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -565,6 +565,25 @@ class TestProcess : XCTestCase {
         XCTAssertEqual(String(data: stdoutData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), "No files specified.")
     }
 
+    func test_fileDescriptorsAreNotInherited() throws {
+        let task = Process()
+        let clonedFD = dup(1)
+        task.executableURL = xdgTestHelperURL()
+        task.arguments = ["--print-open-file-descriptors"]
+        task.standardInput = FileHandle.nullDevice
+        let stdoutPipe = Pipe()
+        task.standardOutput = stdoutPipe.fileHandleForWriting
+        task.standardError = FileHandle.nullDevice
+        XCTAssertNoThrow(try task.run())
+
+        try task.run()
+        try stdoutPipe.fileHandleForWriting.close()
+        let stdoutData = try stdoutPipe.fileHandleForReading.readToEnd()
+        task.waitUntilExit()
+        print(String(decoding: stdoutData ?? Data(), as: Unicode.UTF8.self))
+        XCTAssertEqual("0\n1\n2\n", String(decoding: stdoutData ?? Data(), as: Unicode.UTF8.self))
+        close(clonedFD)
+    }
 
     static var allTests: [(String, (TestProcess) -> () throws -> Void)] {
         var tests = [
@@ -592,6 +611,8 @@ class TestProcess : XCTestCase {
             ("test_redirect_all_using_null", test_redirect_all_using_null),
             ("test_redirect_all_using_nil", test_redirect_all_using_nil),
             ("test_plutil", test_plutil),
+            ("test_currentDirectory", test_currentDirectory),
+            ("test_fileDescriptorsAreNotInherited", test_fileDescriptorsAreNotInherited),
         ]
 
 #if !os(Windows)

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -208,7 +208,13 @@ func cat(_ args: ArraySlice<String>.Iterator) {
 
 #if !os(Windows)
 func printOpenFileDescriptors() {
-    for fd in 0..<getdtablesize() {
+    let reasonableMaxFD: CInt
+    #if os(Linux) || os(macOS)
+    reasonableMaxFD = getdtablesize()
+    #else
+    reasonableMaxFD = 4096
+    #endif
+    for fd in 0..<reasonableMaxFD {
         if fcntl(fd, F_GETFD) != -1 {
             print(fd)
         }

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -206,6 +206,15 @@ func cat(_ args: ArraySlice<String>.Iterator) {
     exit(exitCode)
 }
 
+func printOpenFileDescriptors() {
+    for fd in 0..<getdtablesize() {
+        if fcntl(fd, F_GETFD) != -1 {
+            print(fd)
+        }
+    }
+    exit(0)
+}
+
 // -----
 
 var arguments = ProcessInfo.processInfo.arguments.dropFirst().makeIterator()
@@ -265,7 +274,10 @@ case "--nspathfor":
 case "--signal-test":
     signalTest()
 #endif
-    
+
+case "--print-open-file-descriptors":
+    printOpenFileDescriptors()
+
 default:
     fatalError("These arguments are not recognized. Only run this from a unit test.")
 }

--- a/TestFoundation/xdgTestHelper/main.swift
+++ b/TestFoundation/xdgTestHelper/main.swift
@@ -206,6 +206,7 @@ func cat(_ args: ArraySlice<String>.Iterator) {
     exit(exitCode)
 }
 
+#if !os(Windows)
 func printOpenFileDescriptors() {
     for fd in 0..<getdtablesize() {
         if fcntl(fd, F_GETFD) != -1 {
@@ -214,6 +215,7 @@ func printOpenFileDescriptors() {
     }
     exit(0)
 }
+#endif
 
 // -----
 
@@ -273,10 +275,10 @@ case "--nspathfor":
 #if !os(Windows)
 case "--signal-test":
     signalTest()
-#endif
 
 case "--print-open-file-descriptors":
     printOpenFileDescriptors()
+#endif
 
 default:
     fatalError("These arguments are not recognized. Only run this from a unit test.")


### PR DESCRIPTION
This is a backport of #2542 & #2586 which together fix https://bugs.swift.org/browse/SR-11354 which is an important bug fix.

Same as #2607 but this one is for 5.1