### PR TITLE
[CF] OpenBSD doesn't have the xlocale header.

### DIFF
--- a/CoreFoundation/Base.subproj/CFInternal.h
+++ b/CoreFoundation/Base.subproj/CFInternal.h
@@ -97,9 +97,9 @@ CF_EXTERN_C_BEGIN
 
 #if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
 
-#if !TARGET_OS_CYGWIN && !defined(__linux__)
+#if TARGET_OS_MAC || (TARGET_OS_BSD && !defined(__OpenBSD__)) || TARGET_OS_ANDROID
 #include <xlocale.h>
-#endif // !TARGET_OS_CYGWIN && !defined(__linux__)
+#endif // TARGET_OS_MAC || (TARGET_OS_BSD && !defined(__OpenBSD__)) || TARGET_OS_ANDROID
 
 #include <sys/time.h>
 #include <signal.h>

--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -180,13 +180,13 @@ bool OSAtomicCompareAndSwap32Barrier( int32_t oldValue, int32_t newValue, volati
 void OSMemoryBarrier();
 #endif // TARGET_OS_LINUX || TARGET_OS_BSD
 
-#if TARGET_OS_LINUX || TARGET_OS_WIN32
+#if TARGET_OS_LINUX || TARGET_OS_WIN32 || defined(__OpenBSD__)
 #define strtod_l(a,b,locale) strtod(a,b)
 #define strtoul_l(a,b,c,locale) strtoul(a,b,c)
 #define strtol_l(a,b,c,locale) strtol(a,b,c)
 
 #define fprintf_l(a,locale,b,...) fprintf(a, b, __VA_ARGS__)
-#endif // TARGET_OS_LINUX || TARGET_OS_WIN32
+#endif // TARGET_OS_LINUX || TARGET_OS_WIN32 || defined(__OpenBSD__)
 
 #if TARGET_OS_LINUX
     
@@ -236,6 +236,10 @@ CF_INLINE uint64_t mach_absolute_time() {
 #define CF_PRIVATE extern __attribute__((visibility("hidden")))
 #define __strong
 #define __weak
+
+#if defined(__OpenBSD__)
+#define strtoll_l(a,b,c,locale) strtoll(a,b,c)
+#endif
 #endif
 
 #if TARGET_OS_LINUX || TARGET_OS_BSD


### PR DESCRIPTION
OpenBSD is one of the platforms that doesn't have xlocale.h, so ensure
that the header is not used and the relevant macros are exposed.