### PR TITLE
SR-12036: Incorrect and Inconsistent NumberFormatter currency behavior on Linux

### DIFF
--- a/Foundation/NumberFormatter.swift
+++ b/Foundation/NumberFormatter.swift
@@ -113,11 +113,13 @@ open class NumberFormatter : Formatter {
 
     private func _setFormatterAttributes(_ formatter: CFNumberFormatter) {
         if numberStyle == .currency {
-            let symbol = _currencySymbol ?? locale.currencySymbol
-            _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterCurrencySymbol, value: symbol?._cfObject)
-
-            if let code = _currencyCode, code.count == 3 {
+            // Prefer currencySymbol, then currencyCode then locale.currencySymbol
+            if let symbol = _currencySymbol {
+                _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterCurrencySymbol, value: symbol._cfObject)
+            } else if let code = _currencyCode, code.count == 3 {
                 _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterCurrencyCode, value: code._cfObject)
+            } else {
+                _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterCurrencySymbol, value: locale.currencySymbol?._cfObject)
             }
        }
        if numberStyle == .currencyISOCode {

--- a/TestFoundation/TestNumberFormatter.swift
+++ b/TestFoundation/TestNumberFormatter.swift
@@ -273,6 +273,13 @@ class TestNumberFormatter: XCTestCase {
 
         let formattedString = numberFormatter.string(from: 42)
         XCTAssertEqual(formattedString, "£42_00")
+
+        // Check that the currencyCode is preferred over the locale when no currencySymbol is set
+        let codeFormatter = NumberFormatter()
+        codeFormatter.numberStyle = .currency
+        codeFormatter.locale = Locale(identifier: "en_US")
+        codeFormatter.currencyCode = "GBP"
+        XCTAssertEqual(codeFormatter.string(from: 3.02), "£3.02")
     }
 
     func test_decimalSeparator() {


### PR DESCRIPTION
- For numberStyle .currency, when .currencyCode was set but
  .currencySymbol was nil, the .locale.currencySymbol was used before
  the .currencyCode.