### PR TITLE
[5.2] Sync NSData+DataProtocol from the SDK overlay

### DIFF
--- a/Foundation/NSData+DataProtocol.swift
+++ b/Foundation/NSData+DataProtocol.swift
@@ -12,23 +12,23 @@
 
 
 extension NSData : DataProtocol {
-    
+
     @nonobjc
     public var startIndex: Int { return 0 }
-    
+
     @nonobjc
     public var endIndex: Int { return length }
-    
+
     @nonobjc
     public func lastRange<D, R>(of data: D, in r: R) -> Range<Int>? where D : DataProtocol, R : RangeExpression, NSData.Index == R.Bound {
         return Range<Int>(range(of: Data(data), options: .backwards, in: NSRange(r)))
     }
-    
+
     @nonobjc
     public func firstRange<D, R>(of data: D, in r: R) -> Range<Int>? where D : DataProtocol, R : RangeExpression, NSData.Index == R.Bound {
         return Range<Int>(range(of: Data(data), in: NSRange(r)))
     }
-    
+
     @nonobjc
     public var regions: [Data] {
         var datas = [Data]()
@@ -39,13 +39,15 @@ extension NSData : DataProtocol {
         }
         return datas
     }
-    
+
     @nonobjc
     public subscript(position: Int) -> UInt8 {
         var byte = UInt8(0)
+        var offset = position
         enumerateBytes { (ptr, range, stop) in
-            if range.location <= position && position < range.upperBound {
-                byte = ptr.load(fromByteOffset: range.location - position, as: UInt8.self)
+            offset -= range.lowerBound
+            if range.contains(position) {
+                byte = ptr.load(fromByteOffset: offset, as: UInt8.self)
                 stop.pointee = true
             }
         }

--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -528,6 +528,8 @@ class TestNSData: LoopbackServerTest {
             ("test_replaceSubrangeReferencingMutable", test_replaceSubrangeReferencingMutable),
             ("test_replaceSubrangeReferencingImmutable", test_replaceSubrangeReferencingImmutable),
             ("test_rangeOfSlice", test_rangeOfSlice),
+            ("test_nsdataSequence", test_nsdataSequence),
+            ("test_dispatchSequence", test_dispatchSequence),
         ]
     }
     
@@ -4528,5 +4530,38 @@ extension TestNSData {
         let decodedData = NSData(coder: unarchiver)
         XCTAssertEqual(data, decodedData)
     }
+
+    func test_nsdataSequence() {
+        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+            let bytes: [UInt8] = Array(0x00...0xFF)
+            let data = bytes.withUnsafeBytes { NSData(bytes: $0.baseAddress, length: $0.count) }
+
+            for byte in bytes {
+                expectEqual(data[Int(byte)], byte)
+            }
+        }
+    }
+
+    func test_dispatchSequence() {
+        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+            let bytes1: [UInt8] = Array(0x00..<0xF0)
+            let bytes2: [UInt8] = Array(0xF0..<0xFF)
+            var data = DispatchData.empty
+            bytes1.withUnsafeBytes {
+                data.append($0)
+            }
+            bytes2.withUnsafeBytes {
+                data.append($0)
+            }
+
+            for byte in bytes1 {
+                expectEqual(data[Int(byte)], byte)
+            }
+            for byte in bytes2 {
+                expectEqual(data[Int(byte)], byte)
+            }
+        }
+    }
+
 }
 


### PR DESCRIPTION
(cherry picked from commit 11ce11199e2fd563372adbf00f61fea5c8c1a5f6)

This fixes an invalid offset bug.