### PR TITLE
SR-12021: Improve the performance of NSData Base64 Encoding.

### DIFF
--- a/TestFoundation/TestNSData.swift
+++ b/TestFoundation/TestNSData.swift
@@ -226,6 +226,7 @@ class TestNSData: LoopbackServerTest {
             ("test_initializeWithBase64EncodedDataWithNonBase64CharacterIsNil", test_initializeWithBase64EncodedDataWithNonBase64CharacterIsNil),
             ("test_initializeWithBase64EncodedDataWithNonBase64CharacterWithOptionToAllowItSkipsCharacter", test_initializeWithBase64EncodedDataWithNonBase64CharacterWithOptionToAllowItSkipsCharacter),
             ("test_base64EncodedDataGetsEncodedText", test_base64EncodedDataGetsEncodedText),
+            ("test_base64EncodeEmptyData", test_base64EncodeEmptyData),
             ("test_base64EncodedDataWithOptionToInsertCarriageReturnContainsCarriageReturn", test_base64EncodedDataWithOptionToInsertCarriageReturnContainsCarriageReturn),
             ("test_base64EncodedDataWithOptionToInsertLineFeedsContainsLineFeed", test_base64EncodedDataWithOptionToInsertLineFeedsContainsLineFeed),
             ("test_base64EncodedDataWithOptionToInsertCarriageReturnAndLineFeedContainsBoth", test_base64EncodedDataWithOptionToInsertCarriageReturnAndLineFeedContainsBoth),
@@ -753,6 +754,14 @@ class TestNSData: LoopbackServerTest {
         XCTAssertEqual(encodedTextResult, encodedText)
 
     }
+
+    func test_base64EncodeEmptyData() {
+        XCTAssertEqual(Data().base64EncodedString(), "")
+        XCTAssertEqual(NSData().base64EncodedString(), "")
+        XCTAssertEqual(Data().base64EncodedData(), Data())
+        XCTAssertEqual(NSData().base64EncodedData(), Data())
+    }
+
     func test_base64DecodeWithPadding1() {
         let encodedPadding1 = "AoR="
         let dataPadding1Bytes : [UInt8] = [0x02,0x84]
@@ -765,6 +774,7 @@ class TestNSData: LoopbackServerTest {
         }
         XCTAssert(dataPadding1.isEqual(to: decodedPadding1))
     }
+
     func test_base64DecodeWithPadding2() {
         let encodedPadding2 = "Ao=="
         let dataPadding2Bytes : [UInt8] = [0x02]
@@ -777,6 +787,7 @@ class TestNSData: LoopbackServerTest {
         }
         XCTAssert(dataPadding2.isEqual(to: decodedPadding2))
     }
+
     func test_rangeOfData() {
         let baseData : [UInt8] = [0x00,0x01,0x02,0x03,0x04]
         let base = NSData(bytes: baseData, length: baseData.count)


### PR DESCRIPTION
- When writing the result to a Data() or String() buffer,
  avoid doing a copy and use Data(bytesNoCopy:count:deallocator:)
  and String(bytesNoCopy:length:encoding:freeWhenDone:) instead.
  This also avoids an extra copy when doing the encoding.

- When encoding the 6bit value to an ASCII character, use a table
  lookup instead of using base64EncodeByte() that was doing a slow
  loop for each value.

- A copy to a buffer is still used as NSData.makeIterator() has
  excessive overhead that needs to be fixed in the fuutre, this
  will allow the copy to be eliminated at that point in time.

- This gives a speedup in the order of 10x.

 Performance tests

    Tests were performed using the Base64 module from swift-nio as a control
    using the test code below, on a MacBook Pro (Retina, 15-inch, Mid 2015)
    2.5 GHz Quad-Core Intel Core i7 running macOS Catalina 10.15.2 and using
    the following version of the Base64 module.
    
    https://github.com/apple/swift-nio/blob/653492753c817bdb5a4fe28370819f1a7450c90d/Sources/NIOWebSocket/Base64.swift
    
    Note the difference of 10 seconds for NIO Base64 on scl-foundation
    against Darwin shows the current overhead of scl-foundation's
    Data.makeIterator()
    
```
    Native Foundation
    Number of invocations: 1000000
    Foundation-nsdata       | took: 6735ms
    Foundation-data         | took: 6677ms
    NIO-Base64              | took: 10279ms
    empty data              | took: 258ms
    
    This PR
    Number of invocations: 1000000
    Foundation-nsdata       | took: 5878ms
    Foundation-data         | took: 7131ms
    NIO-Base64              | took: 21029ms
    empty data              | took: 1232ms
    
    Previous
    Number of invocations: 1000000
    Foundation-nsdata       | took: 81898ms
    Foundation-data         | took: 83239ms
    NIO-Base64              | took: 20618ms
    empty data              | took: 1752ms
 

        func test_base64EncodeSpeed() {
    
            @discardableResult
            func timing(name: String, execute: () -> ()) {
                let start = Date()
                execute()
                let time = Int(-start.timeIntervalSinceNow * 1000)
                print("\(name) | took: \(time)ms")
            }
    
            let runs = 1000_000
            let bytes1 = Array(UInt8(0)...UInt8(255))
            let bytes2 = Array(UInt8(0)...UInt8(254))
            let bytes3 = Array(UInt8(0)...UInt8(253))
    
            let data1 = Data(bytes1)
            let data2 = Data(bytes2)
            let data3 = Data(bytes3)
    
            let nsdata1 = NSData(data: data1)
            let nsdata2 = NSData(data: data2)
            let nsdata3 = NSData(data: data3)
    
            let nsdata1String = nsdata1.base64EncodedString()
            let nsdata2String = nsdata2.base64EncodedString()
            let nsdata3String = nsdata3.base64EncodedString()
    
            let data1String = data1.base64EncodedString()
            let data2String = data2.base64EncodedString()
            let data3String = data3.base64EncodedString()
    
            let nio1String = Base64.encode(bytes: data1)
            let nio2String = Base64.encode(bytes: data2)
            let nio3String = Base64.encode(bytes: data3)
    
            XCTAssertEqual(nsdata1String, data1String)
            XCTAssertEqual(nsdata1String, nio1String)
            XCTAssertEqual(nio1String, data1String)
    
            XCTAssertEqual(nsdata2String, data2String)
            XCTAssertEqual(nsdata2String, nio2String)
            XCTAssertEqual(nio2String, data2String)
    
            XCTAssertEqual(nsdata3String, data3String)
            XCTAssertEqual(nsdata3String, nio3String)
            XCTAssertEqual(nio3String, data3String)
    
            print("Number of invocations: \(runs)")
            timing(name: "Foundation-nsdata\t") {
                for _ in 1...runs {
                    _ = nsdata1.base64EncodedString()
                    _ = nsdata2.base64EncodedString()
                    _ = nsdata3.base64EncodedString()
                }
            }
    
            timing(name: "Foundation-data\t") {
                for _ in 1...runs {
                    _ = data1.base64EncodedString()
                    _ = data2.base64EncodedString()
                    _ = data3.base64EncodedString()
                }
            }
    
            timing(name: "NIO-Base64\t\t") {
                for _ in 1...runs {
                    _ = Base64.encode(bytes: data1)
                    _ = Base64.encode(bytes: data2)
                    _ = Base64.encode(bytes: data3)
                }
            }
    
            timing(name: "empty data\t\t") {
                for _ in 1...runs {
                    Data().base64EncodedString()
                    NSData().base64EncodedString()
                }
            }
        }
```