### PR TITLE
[CF] Expose flsl and narrow scope of popcountll.

### DIFF
--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -367,6 +367,15 @@ CF_INLINE long long llabs(long long v) {
 #include <fcntl.h>
 #include <errno.h>
     
+CF_INLINE int popcountll(long long x) {
+    int count = 0;
+    while (x) {
+        count++;
+        x &= x - 1; // reset LS1B
+    }
+    return count;
+}
+
 #endif
 
 #if !defined(CF_PRIVATE)
@@ -386,15 +395,6 @@ CF_INLINE int flsl( long mask ) {
     int idx = 0;
     while (mask != 0) mask = (unsigned long)mask >> 1, idx++;
     return idx;
-}
-    
-CF_INLINE int popcountll(long long x) {
-    int count = 0;
-    while (x) {
-        count++;
-        x &= x - 1; // reset LS1B
-    }
-    return count;
 }
 
 CF_PRIVATE int asprintf(char **ret, const char *format, ...);

--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -201,6 +201,15 @@ CF_INLINE uint64_t mach_absolute_time() {
 #define strtol_l(a,b,c,locale) strtol(a,b,c)
 
 #define fprintf_l(a,locale,b,...) fprintf(a, b, __VA_ARGS__)
+
+CF_INLINE int flsl( long mask ) {
+    int idx = 0;
+    while (mask != 0) {
+        mask = (unsigned long)mask >> 1;
+        idx++;
+    }
+    return idx;
+}
 #endif // TARGET_OS_LINUX || TARGET_OS_WIN32 || defined(__OpenBSD__)
 
 #if TARGET_OS_LINUX
@@ -390,12 +399,6 @@ CF_INLINE int popcountll(long long x) {
 #if TARGET_OS_LINUX || TARGET_OS_WIN32
 
 #include <stdarg.h>
-
-CF_INLINE int flsl( long mask ) {
-    int idx = 0;
-    while (mask != 0) mask = (unsigned long)mask >> 1, idx++;
-    return idx;
-}
 
 CF_PRIVATE int asprintf(char **ret, const char *format, ...);
 


### PR DESCRIPTION
This PR encloses two primarily mechanical commits that deal with the scoping of the implementations of two intrinsic/like functions.

* Prefix defines popcountll for Linux and Windows. The only references to
popcountll exist in CFBurstTrie, and the Prefix implementation is only
used there when TARGET_OS_WIN32. Therefore, there's no need to expose
this outside of Windows.

* flsl is available on FreeBSD (and thus macOS), but not OpenBSD. This
commit makes the implementation of flsl currently exposed to Linux and
Windows also available to OpenBSD.