### PR TITLE
[CF] Avoid using malloc introspection.

### DIFF
--- a/CoreFoundation/Collections.subproj/CFBasicHash.c
+++ b/CoreFoundation/Collections.subproj/CFBasicHash.c
@@ -1442,6 +1442,7 @@ CF_PRIVATE size_t CFBasicHashGetSize(CFConstBasicHashRef ht, Boolean total) {
     if (ht->bits.keys_offset) size += sizeof(CFBasicHashValue *);
     if (ht->bits.counts_offset) size += sizeof(void *);
     if (__CFBasicHashHasHashCache(ht)) size += sizeof(uintptr_t *);
+#if ENABLE_MEMORY_COUNTERS || ENABLE_DTRACE_PROBES
     if (total) {
         CFIndex num_buckets = __CFBasicHashTableSizes[ht->bits.num_buckets_idx];
         if (0 < num_buckets) {
@@ -1451,6 +1452,9 @@ CF_PRIVATE size_t CFBasicHashGetSize(CFConstBasicHashRef ht, Boolean total) {
             if (__CFBasicHashHasHashCache(ht)) size += malloc_size(__CFBasicHashGetHashes(ht));
         }
     }
+#else
+    (void)total;
+#endif
     return size;
 }
 

--- a/CoreFoundation/Collections.subproj/CFStorage.c
+++ b/CoreFoundation/Collections.subproj/CFStorage.c
@@ -1366,21 +1366,6 @@ static void __CFStorageApplyNodeBlock(CFStorageRef storage, void (^block)(CFStor
     __CFStorageApplyNodeBlockInterior(storage, &storage->rootNode, block);
 }
 
-static CFIndex __CFStorageEstimateTotalAllocatedSize(CFStorageRef storage) __attribute__((unused));
-static CFIndex __CFStorageEstimateTotalAllocatedSize(CFStorageRef storage) {
-    __block CFIndex nodeResult = 0;
-    __block CFIndex contentsResult = 0;
-    __CFStorageApplyNodeBlock(storage, ^(CFStorageRef storage, CFStorageNode *node) {
-	if (node != &storage->rootNode) {
-	    nodeResult += malloc_size(node);
-	    if (node->isLeaf && node->info.leaf.memory != NULL) {
-		contentsResult += malloc_size(node->info.leaf.memory);
-	    }
-	}
-    });
-    return nodeResult + contentsResult;
-}
-
 void __CFStorageSetAlwaysFrozen(CFStorageRef storage, bool alwaysFrozen) {
     storage->alwaysFrozen = alwaysFrozen;
 }


### PR DESCRIPTION
malloc introspection, as afforded by `malloc_size`, `malloc_usable_size`, or `_msize`, is nonportable (and thus not guaranteed to be present on all platforms), not guaranteed to be accurate (though certainly an upper bound), and is generally recommended for debugging.

For those reasons, the following commits are introduced in this PR:
* CFBasicHash.c: only expose `CFBasicHashGetSize`'s `total` branch when one or both of the debugging symbols `ENABLE_MEMORY_COUNTERS` or `ENABLE_DTRACE_PROBES` are true
* CFStorage.c: remove apparently unused function `__CFStorageEstimateTotalAllocatedSize`. If this is necessary for something, please let me know what constraints are required to avoid exposing the `malloc_size`call.