### PR TITLE
[5.1] SR-12036: Incorrect and Inconsistent NumberFormatter currency behavior on Linux

### DIFF
--- a/Foundation/NumberFormatter.swift
+++ b/Foundation/NumberFormatter.swift
@@ -122,8 +122,14 @@ open class NumberFormatter : Formatter {
 
     private func _setFormatterAttributes(_ formatter: CFNumberFormatter) {
         if numberStyle == .currency {
-          let symbol = _currencySymbol ?? _currencyCode ?? locale.currencySymbol ?? locale.currencyCode
-           _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterCurrencySymbol, value: symbol?._cfObject)
+            // Prefer currencySymbol, then currencyCode then locale.currencySymbol
+            if let symbol = _currencySymbol {
+                _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterCurrencySymbol, value: symbol._cfObject)
+            } else if let code = _currencyCode {
+                _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterCurrencyCode, value: code._cfObject)
+            } else {
+                _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterCurrencySymbol, value: locale.currencySymbol?._cfObject)
+            }
        }
        if numberStyle == .currencyISOCode {
           let code = _currencyCode ?? _currencySymbol ?? locale.currencyCode ?? locale.currencySymbol

--- a/TestFoundation/TestNumberFormatter.swift
+++ b/TestFoundation/TestNumberFormatter.swift
@@ -268,6 +268,13 @@ class TestNumberFormatter: XCTestCase {
 
         let formattedString = numberFormatter.string(from: 42)
         XCTAssertEqual(formattedString, "T42_00")
+
+        // Check that the currencyCode is preferred over the locale when no currencySymbol is set
+        let codeFormatter = NumberFormatter()
+        codeFormatter.numberStyle = .currency
+        codeFormatter.locale = Locale(identifier: "en_US")
+        codeFormatter.currencyCode = "GBP"
+        XCTAssertEqual(codeFormatter.string(from: 3.02), "£3.02")
     }
 
     func test_decimalSeparator() {


### PR DESCRIPTION
- For numberStyle .currency, when .currencyCode was set but
  .currencySymbol was nil, the .locale.currencySymbol was used before
  the .currencyCode.

(cherry picked from commit 187d6b37249459b6353079564143200c2a7c0900)