### PR TITLE
SR-6450: Leak in Process on Linux

### DIFF
--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -1126,6 +1126,7 @@ open class Process: NSObject {
         } while( self.isRunning == true && RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.05)) )
         
         self.runLoop = nil
+        self.runLoopSource = nil
     }
 }
 


### PR DESCRIPTION
- The runLoopSource was holding a reference to self creating a retain
  cycle. Set to nil after the child process has finished.