### PR TITLE
[CF] Locale symbol aliases required for BSD.

### DIFF
--- a/CoreFoundation/Locale.subproj/CFLocaleKeys.c
+++ b/CoreFoundation/Locale.subproj/CFLocaleKeys.c
@@ -132,8 +132,8 @@ CONST_STRING_DECL(kCFCalendarIdentifierCoptic, "coptic");
 CONST_STRING_DECL(kCFCalendarIdentifierEthiopicAmeteMihret, "ethiopic");
 CONST_STRING_DECL(kCFCalendarIdentifierEthiopicAmeteAlem, "ethiopic-amete-alem");
 
-// Aliases for Linux
-#if TARGET_OS_LINUX || TARGET_OS_WIN32
+// Aliases for other platforms.
+#if TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WIN32
 
 CF_EXPORT CFStringRef const kCFBuddhistCalendar __attribute__((alias ("kCFCalendarIdentifierBuddhist")));
 CF_EXPORT CFStringRef const kCFChineseCalendar __attribute__((alias ("kCFCalendarIdentifierChinese")));


### PR DESCRIPTION
These symbol aliases need to be exposed for TARGET_OS_BSD otherwise
undefined symbol errors will occur when linking.