### PR TITLE
[5.2] Make URLSession and URLSessionTask more source-compatible with Darwin

### DIFF
--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -376,7 +376,7 @@ open class URLSessionTask : NSObject, NSCopying {
     /*
      * The current state of the task within the session.
      */
-    open var state: URLSessionTask.State {
+    open fileprivate(set) var state: URLSessionTask.State {
         get {
             return self.syncQ.sync { self._state }
         }


### PR DESCRIPTION
This is a cherry-pick of #2587 for Swift 5.2.

cc @millenomi @parkera @phausler 