### PR TITLE
[CF] Apply missing includes and cleanups.

### DIFF
--- a/CoreFoundation/RunLoop.subproj/CFSocket.c
+++ b/CoreFoundation/RunLoop.subproj/CFSocket.c
@@ -942,14 +942,15 @@ Boolean __CFSocketGetBytesAvailable(CFSocketRef s, CFIndex* ctBytesAvailable) {
 #include <sys/un.h>
 #include <libc.h>
 #include <dlfcn.h>
-#if TARGET_OS_CYGWIN
-#include <sys/socket.h>
 #endif
+#if TARGET_OS_CYGWIN || TARGET_OS_BSD
+#include <sys/socket.h>
 #endif
 #if TARGET_OS_WIN32
 #include <WinSock2.h>
 #else
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #endif
 #if !TARGET_OS_WIN32
 #include <sys/ioctl.h>
@@ -1117,7 +1118,7 @@ static void __cfSocketLogWithSocket(CFSocketRef s, const char* function, int lin
 #endif
 
 
-#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_UNIX
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
 #define INVALID_SOCKET (CFSocketNativeHandle)(-1)
 #define closesocket(a) close((a))
 #define ioctlsocket(a,b,c) ioctl((a),(b),(c))
@@ -2174,10 +2175,9 @@ manageSelectError()
 
 static void *__CFSocketManager(void * arg)
 {
-#if (TARGET_OS_LINUX && !TARGET_OS_CYGWIN) || TARGET_OS_BSD
+#if TARGET_OS_LINUX && !TARGET_OS_CYGWIN
     pthread_setname_np(pthread_self(), "com.apple.CFSocket.private");
-#elif TARGET_OS_CYGWIN
-#else
+#elif !TARGET_OS_CYGWIN && !TARGET_OS_BSD
     pthread_setname_np("com.apple.CFSocket.private");
 #endif
     SInt32 nrfds, maxnrfds, fdentries = 1;


### PR DESCRIPTION
Here we apply a few cursory cleanups for porting purposes. These changes
are as follows:

  * move a TARGET_OS_CYGWIN block: it was nested under TARGET_OS_MAC,
    which is probably not intended.

  * include sys/socket.h for TARGET_OS_BSD: which should be provided.

  * include netinet/in.h for !TARGET_OS_WIN32: which is required for
    struct sockaddr_in; from memory, this is included transitively on
    Linux, but not elsewhere.

  * use TARGET_OS_BSD instead of TARGET_OS_UNIX: TARGET_OS_UNIX appears
    no longer used; TARGET_OS_BSD is a synonym for __unix__ anyway.

  * disuse pthread_setname_np for TARGET_OS_BSD: this doesn't appear in
    the FreeBSD manuals, it's not available on OpenBSD, so let's just
    disuse it.