### PR TITLE
[POSIX] readdir_r() deprectated, replace with readdir()

### DIFF
--- a/CoreFoundation/Base.subproj/CFFileUtilities.c
+++ b/CoreFoundation/Base.subproj/CFFileUtilities.c
@@ -372,7 +372,6 @@ CF_PRIVATE CFMutableArrayRef _CFCreateContentsOfDirectory(CFAllocatorRef alloc, 
         }
     }
     
-    struct dirent buffer;
     struct dirent *dp;
     int err;
    
@@ -389,7 +388,7 @@ CF_PRIVATE CFMutableArrayRef _CFCreateContentsOfDirectory(CFAllocatorRef alloc, 
     }
     files = CFArrayCreateMutable(alloc, 0, & kCFTypeArrayCallBacks);
 
-    while((0 == readdir_r(dirp, &buffer, &dp)) && dp) {
+    while((dp = readdir(dirp))) {
         CFURLRef fileURL;
 	unsigned namelen = strlen(dp->d_name);
 


### PR DESCRIPTION
- readdir_r() may be unsafe where NAME_MAX is unspecified as the
  buffer length isnt passed in. This may cause NUL termination issues.

- glibc >= 2.24 deprecates readdir_r()

- POSIX.1-2008 doesnt require readdir() to be thread-safe but, in glibc,
  calls with different directory streams are.

- Callers of readdir() using methods need to ensure synchronisation
  if the same directory is read by multiple threads.