### PR TITLE
Fix warning "initialization of '...' results in a dangling pointer"

### DIFF
--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -207,22 +207,22 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     /// Initializes a data object with the given Base64 encoded string.
     public init?(base64Encoded base64String: String, options: Base64DecodingOptions = []) {
         let encodedBytes = Array(base64String.utf8)
-        guard let decodedBytes = NSData.base64DecodeBytes(encodedBytes, options: options) else {
+        guard var decodedBytes = NSData.base64DecodeBytes(encodedBytes, options: options) else {
             return nil
         }
         super.init()
-        _init(bytes: UnsafeMutableRawPointer(mutating: decodedBytes), length: decodedBytes.count, copy: true)
+        _init(bytes: &decodedBytes, length: decodedBytes.count, copy: true)
     }
 
     /// Initializes a data object with the given Base64 encoded data.
     public init?(base64Encoded base64Data: Data, options: Base64DecodingOptions = []) {
         var encodedBytes = [UInt8](repeating: 0, count: base64Data.count)
         base64Data._nsObject.getBytes(&encodedBytes, length: encodedBytes.count)
-        guard let decodedBytes = NSData.base64DecodeBytes(encodedBytes, options: options) else {
+        guard var decodedBytes = NSData.base64DecodeBytes(encodedBytes, options: options) else {
             return nil
         }
         super.init()
-        _init(bytes: UnsafeMutableRawPointer(mutating: decodedBytes), length: decodedBytes.count, copy: true)
+        _init(bytes: &decodedBytes, length: decodedBytes.count, copy: true)
     }
     
     deinit {

--- a/TestFoundation/TestJSONSerialization.swift
+++ b/TestFoundation/TestJSONSerialization.swift
@@ -1415,11 +1415,11 @@ extension TestJSONSerialization {
         }
     }
     
-    func test_jsonObjectToOutputStreamBuffer(){
+    func test_jsonObjectToOutputStreamBuffer() {
         let dict = ["a":["b":1]]
         do {
-            let buffer = Array<UInt8>(repeating: 0, count: 20)
-            let outputStream = OutputStream(toBuffer: UnsafeMutablePointer(mutating: buffer), capacity: 20)
+            var buffer = Array<UInt8>(repeating: 0, count: 20)
+            let outputStream = OutputStream(toBuffer: &buffer, capacity: buffer.count)
             outputStream.open()
             let result = try JSONSerialization.writeJSONObject(dict, toStream: outputStream, options: [])
             outputStream.close()
@@ -1463,8 +1463,8 @@ extension TestJSONSerialization {
     func test_jsonObjectToOutputStreamInsufficientBuffer() {
 #if !DARWIN_COMPATIBILITY_TESTS  // Hangs
         let dict = ["a":["b":1]]
-        let buffer = Array<UInt8>(repeating: 0, count: 10)
-        let outputStream = OutputStream(toBuffer: UnsafeMutablePointer(mutating: buffer), capacity: buffer.count)
+        var buffer = Array<UInt8>(repeating: 0, count: 10)
+        let outputStream = OutputStream(toBuffer: &buffer, capacity: buffer.count)
         outputStream.open()
         do {
             let result = try JSONSerialization.writeJSONObject(dict, toStream: outputStream, options: [])

--- a/TestFoundation/TestNSKeyedArchiver.swift
+++ b/TestFoundation/TestNSKeyedArchiver.swift
@@ -277,15 +277,16 @@ class TestNSKeyedArchiver : XCTestCase {
     
     func test_archive_charptr() {
         let charArray = [CChar]("Hello world, we are testing!\0".utf8CString)
-        var charPtr = UnsafeMutablePointer(mutating: charArray)
 
-        test_archive({ archiver -> Bool in
+        charArray.withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<CChar>) in
+            var charPtr = buffer.baseAddress!
+            test_archive({ archiver -> Bool in
                 let value = NSValue(bytes: &charPtr, objCType: "*")
                 
                 archiver.encode(value, forKey: "root")
                 return true
             },
-             decode: {unarchiver -> Bool in
+            decode: {unarchiver -> Bool in
                 guard let value = unarchiver.decodeObject(of: NSValue.self, forKey: "root") else {
                     return false
                 }
@@ -299,7 +300,8 @@ class TestNSKeyedArchiver : XCTestCase {
 
                     return s1 == s2
                 }
-        })
+            })
+        }
     }
     
     func test_archive_user_class() {

--- a/TestFoundation/TestNSValue.swift
+++ b/TestFoundation/TestNSValue.swift
@@ -110,12 +110,14 @@ class TestNSValue : XCTestCase {
     }
 
     func test_valueWithCharPtr() {
-        let charArray = [UInt8]("testing123".utf8)
-        var charPtr = UnsafeMutablePointer(mutating: charArray)
-        var expectedPtr: UnsafeMutablePointer<UInt8>? = nil
+        var charArray = [UInt8]("testing123".utf8)
+        charArray.withUnsafeMutableBufferPointer {
+            var charPtr = $0.baseAddress!
+            var expectedPtr: UnsafeMutablePointer<UInt8>? = nil
         
-        NSValue(bytes: &charPtr, objCType: "*").getValue(&expectedPtr)
-        XCTAssertEqual(charPtr, expectedPtr)
+            NSValue(bytes: &charPtr, objCType: "*").getValue(&expectedPtr)
+            XCTAssertEqual(charPtr, expectedPtr)
+        }
     }
 
     func test_isEqual() {

--- a/TestFoundation/TestStream.swift
+++ b/TestFoundation/TestStream.swift
@@ -195,7 +195,7 @@ class TestStream : XCTestCase {
         var buffer = Array<UInt8>(repeating: 0, count: 12)
         let myString = "Hello world!"
         let encodedData = [UInt8](myString.utf8)
-        let outputStream = OutputStream(toBuffer: UnsafeMutablePointer(mutating: buffer), capacity: 12)
+        let outputStream = OutputStream(toBuffer: &buffer, capacity: buffer.count)
         XCTAssertEqual(.notOpen, outputStream.streamStatus)
         outputStream.open()
         XCTAssertEqual(.open, outputStream.streamStatus)
@@ -238,19 +238,19 @@ class TestStream : XCTestCase {
         //verify the data written
         let dataWritten  = outputStream.property(forKey: Stream.PropertyKey.dataWrittenToMemoryStreamKey)
         if let nsdataWritten = dataWritten as? NSData {
-            nsdataWritten.getBytes(UnsafeMutablePointer(mutating: buffer), length: result!)
-            XCTAssertEqual(NSString(bytes: &buffer, length: buffer.count, encoding: String.Encoding.utf8.rawValue), NSString(string: myString))
+            nsdataWritten.getBytes(&buffer, length: result!)
+            XCTAssertEqual(NSString(bytes: buffer, length: buffer.count, encoding: String.Encoding.utf8.rawValue), NSString(string: myString))
             outputStream.close()
         } else {
-            XCTFail("Unable to get data from memeory.")
+            XCTFail("Unable to get data from memory.")
         }
     }
 
     func test_outputStreamHasSpaceAvailable() {
-        let buffer = Array<UInt8>(repeating: 0, count: 12)
+        var buffer = Array<UInt8>(repeating: 0, count: 12)
         let myString = "Welcome To Hello world  !"
         let encodedData = [UInt8](myString.utf8)
-        let outputStream = OutputStream(toBuffer: UnsafeMutablePointer(mutating: buffer), capacity: 12)
+        let outputStream = OutputStream(toBuffer: &buffer, capacity: buffer.count)
         outputStream.open()
         XCTAssertTrue(outputStream.hasSpaceAvailable)
         _ = outputStream.write(encodedData, maxLength: encodedData.count)


### PR DESCRIPTION
- When taking an UnsafePointer to an array etc, the array could be
  deallocated whilst the pointer is still in use. This is fixed by
  either:

  1. Eliminating the pointer entirely and just passing the array or
     &array to the function.

  2. Creating and using the pointer inside a .withUnsafeBytes {}
     or .withUnsafeMutableBytes {} closure.