### PR TITLE
TestFoundation: convert boolean check on Windows

### DIFF
--- a/TestFoundation/TestFileHandle.swift
+++ b/TestFoundation/TestFileHandle.swift
@@ -99,11 +99,11 @@ class TestFileHandle : XCTestCase {
 #if os(Windows)
         var hReadPipe: HANDLE? = INVALID_HANDLE_VALUE
         var hWritePipe: HANDLE? = INVALID_HANDLE_VALUE
-        if CreatePipe(&hReadPipe, &hWritePipe, nil, 0) == FALSE {
+        if !CreatePipe(&hReadPipe, &hWritePipe, nil, 0) {
           assert(false)
         }
 
-        if CloseHandle(hWritePipe) == FALSE {
+        if !CloseHandle(hWritePipe) {
           assert(false)
         }
 


### PR DESCRIPTION
`FALSE` and `TRUE` were converted to proper booleans and do not get
imported as custom names.  Update the tests.