### PR TITLE
suggestedFilename always returns a valid filename

### DIFF
--- a/Sources/FoundationNetworking/URLResponse.swift
+++ b/Sources/FoundationNetworking/URLResponse.swift
@@ -46,8 +46,11 @@ open class URLResponse : NSObject, NSSecureCoding, NSCopying {
             self.textEncodingName = encodedEncodingName as String
         }
         
-        if let encodedFilename = aDecoder.decodeObject(of: NSString.self, forKey: "NS.suggestedFilename") {
-            self.suggestedFilename = encodedFilename as String
+        if let encodedFilename = aDecoder.decodeObject(of: NSString.self, forKey: "NS.suggestedFilename")?.lastPathComponent,
+           !encodedFilename.isEmpty {
+            self.suggestedFilename = encodedFilename
+        } else {
+            self.suggestedFilename = "Unknown"
         }
     }
     


### PR DESCRIPTION
The property `suggestedFilename` is documented with:
>This method always returns a valid filename.

The default initializer `init(url:mimeType:expectedContentLength:textEncodingName:)` had a correct implementation, but the required `init?(coder:)` was unsafe.