### PR TITLE
SR-12020: Cannot as-cast Substring to NSString on linux

### DIFF
--- a/Sources/Foundation/String.swift
+++ b/Sources/Foundation/String.swift
@@ -12,7 +12,7 @@
 
 import CoreFoundation
 
-extension String : _ObjectiveCBridgeable {
+extension String: _ObjectiveCBridgeable {
     
     public typealias _ObjectType = NSString
     public func _bridgeToObjectiveC() -> _ObjectType {
@@ -74,4 +74,38 @@ extension String : _ObjectiveCBridgeable {
             return ""
         }
     }
+}
+
+
+extension Substring: _ObjectiveCBridgeable {
+
+    public func _bridgeToObjectiveC() -> NSString {
+        return NSString(String(self))
+    }
+
+    public static func _forceBridgeFromObjectiveC(_ source: NSString, result: inout Substring?) {
+        result = _unconditionallyBridgeFromObjectiveC(source)
+    }
+
+    @discardableResult
+    public static func _conditionallyBridgeFromObjectiveC(_ source: NSString, result: inout Substring?) -> Bool {
+        var value: String?
+        if String._conditionallyBridgeFromObjectiveC(source, result: &value) {
+            result = Substring(value!)
+            return true
+        } else {
+            return false
+        }
+    }
+
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSString?) -> Substring {
+        if let object = source {
+            var value: Substring?
+            _conditionallyBridgeFromObjectiveC(object, result: &value)
+            return value!
+        } else {
+            return ""
+        }
+    }
+
 }

--- a/Tests/Foundation/Tests/TestNSString.swift
+++ b/Tests/Foundation/Tests/TestNSString.swift
@@ -122,6 +122,29 @@ class TestNSString: LoopbackServerTest {
         XCTAssertEqual(cluster.length, 3)
     }
 
+    func test_bridging() {
+        let nsstring = NSString("NSString")
+        let anyNSstring = nsstring as Any
+
+        XCTAssertEqual(nsstring as String, "NSString")
+        XCTAssertEqual(nsstring as Substring, "NSString")
+
+        XCTAssertEqual(anyNSstring as! String, "NSString")
+        XCTAssertEqual(anyNSstring as! Substring, "NSString")
+
+        XCTAssertEqual(anyNSstring as? String, "NSString")
+        XCTAssertEqual(anyNSstring as? Substring, "NSString")
+
+        let string = "String"
+        let subString = string.dropFirst()
+        XCTAssertEqual(string as NSString, NSString("String"))
+        XCTAssertEqual(subString as NSString, NSString("tring"))
+
+        let abc = "abc" as Substring as NSString
+        XCTAssertEqual(abc, NSString("abc"))
+    }
+
+
     func test_integerValue() {
         let string1: NSString = "123"
         XCTAssertEqual(string1.integerValue, 123)
@@ -1610,7 +1633,8 @@ class TestNSString: LoopbackServerTest {
         var tests = [
             ("test_initData", test_initData),
             ("test_boolValue", test_boolValue ),
-            ("test_BridgeConstruction", test_BridgeConstruction ),
+            ("test_BridgeConstruction", test_BridgeConstruction),
+            ("test_bridging", test_bridging),
             ("test_integerValue", test_integerValue ),
             ("test_intValue", test_intValue ),
             ("test_doubleValue", test_doubleValue),


### PR DESCRIPTION
- Add bridging between Substring and NSString.