### PR TITLE
[CF] Move pthread types to ForFoundationOnly.h.

### DIFF
--- a/CoreFoundation/Base.subproj/ForFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForFoundationOnly.h
@@ -695,6 +695,20 @@ CF_EXPORT void *_CFCreateArrayStorage(size_t numPointers, Boolean zeroed, size_t
 
 #endif
 
+// pthread setup
+
+#if TARGET_OS_WIN32
+typedef void *_CFThreadRef;
+typedef struct _CFThreadAttributes {
+  unsigned long dwSizeOfAttributes;
+  unsigned long dwThreadStackReservation;
+} _CFThreadAttributes;
+typedef unsigned long _CFThreadSpecificKey;
+#elif _POSIX_THREADS
+typedef pthread_t _CFThreadRef;
+typedef pthread_attr_t _CFThreadAttributes;
+typedef pthread_key_t _CFThreadSpecificKey;
+#endif
 
 _CF_EXPORT_SCOPE_END
 

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -38,12 +38,6 @@
 #else
 #include <fts.h>
 #endif
-#if __has_include(<unistd.h>)
-#include <unistd.h>
-#endif
-#if _POSIX_THREADS
-#include <pthread.h>
-#endif
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <dirent.h>
 #endif
@@ -353,19 +347,6 @@ extern CFWriteStreamRef _CFWriteStreamCreateFromFileDescriptor(CFAllocatorRef al
 CF_EXPORT char *_Nullable *_Nonnull _CFEnviron(void);
 
 CF_EXPORT void CFLog1(CFLogLevel lev, CFStringRef message);
-
-#if TARGET_OS_WIN32
-typedef void *_CFThreadRef;
-typedef struct _CFThreadAttributes {
-  unsigned long dwSizeOfAttributes;
-  unsigned long dwThreadStackReservation;
-} _CFThreadAttributes;
-typedef unsigned long _CFThreadSpecificKey;
-#elif _POSIX_THREADS
-typedef pthread_t _CFThreadRef;
-typedef pthread_attr_t _CFThreadAttributes;
-typedef pthread_key_t _CFThreadSpecificKey;
-#endif
 
 CF_CROSS_PLATFORM_EXPORT Boolean _CFIsMainThread(void);
 CF_EXPORT _CFThreadRef _CFMainPThread;


### PR DESCRIPTION
CFPlatform.c has dependencies on pthreads, such as in _CFIsMainThread
and the type of __CFTSDIndexKey, so the pthread header needs to be
included somewhere and the relevant typedefs for _CFThreadRef and others
need to be present.

One place this could be done is in CoreFoundation_Prefix.h, however, we
find the necessary definitions for Windows and pthread environments
present in ForSwiftFoundationOnly.h. Unfortunately, as these
declarations are necessary outside of the Swift context, this leads us
to ForFoundationOnly.h, since that is included (in CFInternal.h) for
_both_ Swift and non-Swift builds of CoreFoundation.

To remove duplication, the unistd.h and pthread.h checks are removed
from ForSwiftFoundationOnly.h, because these are also found in
CFInternal.h.