### PR TITLE
[CF] Simplify including TargetConditionals.h.

### DIFF
--- a/CoreFoundation/Base.subproj/CFAvailability.h
+++ b/CoreFoundation/Base.subproj/CFAvailability.h
@@ -10,13 +10,7 @@
 #if !defined(__COREFOUNDATION_CFAVAILABILITY__)
 #define __COREFOUNDATION_CFAVAILABILITY__ 1
 
-#if __has_include(<CoreFoundation/TargetConditionals.h>)
 #include <CoreFoundation/TargetConditionals.h>
-#elif __has_include(<TargetConditionals.h>)
-#include <TargetConditionals.h>
-#else
-#error Missing header TargetConditionals.h
-#endif
 
 #if __has_include(<Availability.h>) && __has_include(<os/availability.h>) && __has_include(<AvailabilityMacros.h>)
 #include <Availability.h>

--- a/CoreFoundation/Base.subproj/CFBase.h
+++ b/CoreFoundation/Base.subproj/CFBase.h
@@ -10,11 +10,7 @@
 #if !defined(__COREFOUNDATION_CFBASE__)
 #define __COREFOUNDATION_CFBASE__ 1
 
-#if DEPLOYMENT_RUNTIME_SWIFT
 #include <CoreFoundation/TargetConditionals.h>
-#else
-#include <TargetConditionals.h>
-#endif
 #include <CoreFoundation/CFAvailability.h>
 
 #if (defined(__CYGWIN32__) || defined(_WIN32)) && !defined(__WIN32__)


### PR DESCRIPTION
CoreFoundation gets built as a framework.  TargetConditionals.h is a
public header in this framework, so in order for the compiler to find
the header, it has to be referenced through the framework, that is,
<CoreFoundation/TargetConditionals.h>.

In CFBase.h, if we are building standalone (c.f. #2646), we are not
DEPLOYMENT_RUNTIME_SWIFT and so we try and look for TargetConditionals.h
with <TargetConditionals.h>. Presumably this is fine on macOS, since
perhaps this is included elsewhere on that system, but on other
platforms this won't be found and we get an error.

But it's actually unnecessary to reference any other
TargetConditionals.h that may be defined elsewhere, because
TargetConditionals.h is part of the CoreFoundation framework. It is then
similarly unnecessary to test for the include, or to fall back on any
other TargetConditionals.h, so just refer to it in the framework
unconditionally. If there are any problems, we get a straightforward
compiler error.