### PR TITLE
Foundation: support `_getFileSystemRepresentation` on Windows

### DIFF
--- a/CoreFoundation/URL.subproj/CFURL.c
+++ b/CoreFoundation/URL.subproj/CFURL.c
@@ -3965,10 +3965,15 @@ CF_EXPORT void __CFURLSetResourceInfoPtr(CFURLRef url, void *ptr) {
 /* HFSPath<->URLPath functions at the bottom of the file */
 static CFArrayRef WindowsPathToURLComponents(CFStringRef path, CFAllocatorRef alloc, Boolean isDir, Boolean isAbsolute) CF_RETURNS_RETAINED {
     CFArrayRef tmp;
+    CFMutableStringRef mutablePath;
     CFMutableArrayRef urlComponents = NULL;
     CFIndex i=0;
 
-    tmp = CFStringCreateArrayBySeparatingStrings(alloc, path, CFSTR("\\"));
+    // Since '/' is a valid Windows path separator, we convert '/' to '\' before splitting
+    mutablePath = CFStringCreateMutableCopy(alloc, 0, path);
+    CFStringFindAndReplace(mutablePath, CFSTR("/"), CFSTR("\\"), CFRangeMake(0, CFStringGetLength(mutablePath)), 0);
+    tmp = CFStringCreateArrayBySeparatingStrings(alloc, mutablePath, CFSTR("\\"));
+    CFRelease(mutablePath);
     urlComponents = CFArrayCreateMutableCopy(alloc, 0, tmp);
     CFRelease(tmp);
 

--- a/TestFoundation/TestFileManager.swift
+++ b/TestFoundation/TestFileManager.swift
@@ -569,15 +569,18 @@ class TestFileManager : XCTestCase {
 #endif
 
         func directoryItems(options: FileManager.DirectoryEnumerationOptions) -> [String: Int]? {
-            if let e = FileManager.default.enumerator(at: URL(fileURLWithPath: basePath), includingPropertiesForKeys: nil, options: options, errorHandler: nil) {
-                var foundItems = [String:Int]()
-                while let item = e.nextObject() as? URL {
-                    foundItems[item.lastPathComponent] = e.level
-                }
-                return foundItems
-            } else {
-                return nil
+            guard let enumerator =
+                FileManager.default.enumerator(at: URL(fileURLWithPath: basePath),
+                                               includingPropertiesForKeys: nil,
+                                               options: options, errorHandler: nil) else {
+              return nil
             }
+
+            var foundItems = [String:Int]()
+            while let item = enumerator.nextObject() as? URL {
+              foundItems[item.lastPathComponent] = enumerator.level
+            }
+            return foundItems
         }
 
         try? fm.removeItem(atPath: basePath)


### PR DESCRIPTION
Update the `_getFileSystemRepresentation` helper to return a UTF-16
Windows style path.  This enables us to properly model the file system
representation of the path and the URL representation of the path.