### PR TITLE
FileManager: correct symbolic link handling on Windows

### DIFF
--- a/Foundation/FileManager+Win32.swift
+++ b/Foundation/FileManager+Win32.swift
@@ -397,8 +397,16 @@ extension FileManager {
         }
 
         let substituteNameBuff = Data(bytes: pathBufferPtr + substituteNameOffset, count: substituteNameBytes)
-        guard let substitutePath = String(data: substituteNameBuff, encoding: .utf16LittleEndian) else {
+        guard var substitutePath = String(data: substituteNameBuff, encoding: .utf16LittleEndian) else {
             throw _NSErrorWithWindowsError(DWORD(ERROR_INVALID_DATA), reading: false)
+        }
+
+        // Canonicalize the NT Object Manager Path to the DOS style path
+        // instead.  Unfortunately, there is no nice API which can allow us to
+        // do this in a guranteed way.
+        let kObjectManagerPrefix = "\\??\\"
+        if substitutePath.hasPrefix(kObjectManagerPrefix) {
+          substitutePath = String(substitutePath.dropFirst(kObjectManagerPrefix.count))
         }
         return substitutePath
     }


### PR DESCRIPTION
When the symbolic link points across a drive, querying the symbolic link
will provide a NT style path.  The NT style path is not valid for a
reparse point destination.  Use a hand-rolled canonicalization (removal
of the `\??\` prefix) for the path to get a path that we can use in the
symbolic link.  `NTPathToDosPath` is a possible approach to a more
robust solution but relies on undocumented kernel APIs.