### PR TITLE
Foundation: fix invalid free

### DIFF
--- a/Foundation/NSData.swift
+++ b/Foundation/NSData.swift
@@ -599,10 +599,12 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
 
         let capacity = estimateBase64Size(length: dataLength)
         let ptr = UnsafeMutableRawPointer.allocate(byteCount: capacity, alignment: 1)
+        defer { ptr.deallocate() }
         let buffer = UnsafeMutableRawBufferPointer(start: ptr, count: capacity)
         let length = NSData.base64EncodeBytes(self, options: options, buffer: buffer)
 
-        return String(bytesNoCopy: ptr, length: length, encoding: .ascii, freeWhenDone: true)!
+        let utf8buffer = UnsafeBufferPointer<UInt8>(start: ptr.assumingMemoryBound(to: UInt8.self), count: length)
+        return String(decoding: utf8buffer, as: UTF8.self)
     }
 
     /// Creates a Base64, UTF-8 encoded Data from the data object using the given options.


### PR DESCRIPTION
The memory in the `String` is not-being copied, and thus is more of a
view into the memory, not an owning reference.  Do not free this memory
after the destruction of the object.