### PR TITLE
CoreFoundation: handle `isDirectory` properly in `WindowsPathToURLPath`

### DIFF
--- a/CoreFoundation/URL.subproj/CFURL.c
+++ b/CoreFoundation/URL.subproj/CFURL.c
@@ -3977,6 +3977,13 @@ static CFArrayRef WindowsPathToURLComponents(CFStringRef path, CFAllocatorRef al
     urlComponents = CFArrayCreateMutableCopy(alloc, 0, tmp);
     CFRelease(tmp);
 
+    if (isDir == FALSE) {
+      CFIndex last = CFArrayGetCount(urlComponents) - 1;
+      if (CFEqual(CFArrayGetValueAtIndex(urlComponents, last), CFSTR(""))) {
+        CFArrayRemoveValueAtIndex(urlComponents, last);
+      }
+    }
+
     CFStringRef str = (CFStringRef)CFArrayGetValueAtIndex(urlComponents, 0);
     if (isAbsolute && CFStringGetLength(str) == 2 && CFStringGetCharacterAtIndex(str, 1) == ':') {
         i = 1; // Skip over the drive letter 


### PR DESCRIPTION
In the case that we were given a non-directory path terminating in `\`,
we would preserve the last path arc constructing a directory path
instead of a file path.  This manifested as test failure in the Swift
test suite when converting paths.