### PR TITLE
TestFoundation: correct assumption on Windows

### DIFF
--- a/TestFoundation/TestURL.swift
+++ b/TestFoundation/TestURL.swift
@@ -79,7 +79,7 @@ class TestURL : XCTestCase {
 
       // ensure that we do not index beyond the start of the string
       let u7 = URL(fileURLWithPath: "eh", relativeTo: URL(fileURLWithPath: "S:\\b"))
-      XCTAssertEqual(u7.absoluteString, "file:///S:/b/eh")
+      XCTAssertEqual(u7.absoluteString, "file:///S:/eh")
 
       // ensure that / is handled properly
       let u8 = URL(fileURLWithPath: "/")


### PR DESCRIPTION
This corrects the expectation on Windows.  This was obviously incorrect
previously as:

1. `URL(fileURLWithPath: "S:\\b")` would provide a *file* URL
2. `URL(fileURLWithPath: "eh", relativeTo: ...)` would then construct a
   path relative to the file, thus, the final path would be `S:\eh`.

This matches the reference implementation as demonstrated by:
```
// %clang %s -framework Foundation
int main() {
  NSLog(@"result: %@",
        [[NSURL fileURLWithPath:@"eh"
                  relativeToURL:[NSURL fileURLWithPath:@"/tmp/b"]]
         absoluteString]);
  return 0;
}
```