### PR TITLE
FileManager: use the proper FSR on Windows

### DIFF
--- a/Foundation/FileManager.swift
+++ b/Foundation/FileManager.swift
@@ -1285,17 +1285,21 @@ public struct FileAttributeType : RawRepresentable, Equatable, Hashable {
             self = .typeCharacterSpecial
         } else if attributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_REPARSE_POINT) == DWORD(FILE_ATTRIBUTE_REPARSE_POINT) {
             // A reparse point may or may not actually be a symbolic link, we need to read the reparse tag
-            let handle = path.withCString(encodedAs: UTF16.self) {
-                CreateFileW($0, /*dwDesiredAccess=*/DWORD(0), DWORD(FILE_SHARE_READ | FILE_SHARE_WRITE), /*lpSecurityAttributes=*/nil,
-                            DWORD(OPEN_EXISTING), DWORD(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS), /*hTemplateFile=*/nil)
-            }
-            guard handle != INVALID_HANDLE_VALUE else {
+            let handle: HANDLE = (try? FileManager.default._fileSystemRepresentation(withPath: path) {
+              CreateFileW($0, /*dwDesiredAccess=*/DWORD(0),
+                          DWORD(FILE_SHARE_READ | FILE_SHARE_WRITE),
+                          /*lpSecurityAttributes=*/nil, DWORD(OPEN_EXISTING),
+                          DWORD(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS),
+                          /*hTemplateFile=*/nil)
+            }) ?? INVALID_HANDLE_VALUE
+            if handle == INVALID_HANDLE_VALUE {
                 self = .typeUnknown
                 return
             }
             defer { CloseHandle(handle) }
             var tagInfo = FILE_ATTRIBUTE_TAG_INFO()
-            guard GetFileInformationByHandleEx(handle, FileAttributeTagInfo, &tagInfo, DWORD(MemoryLayout<FILE_ATTRIBUTE_TAG_INFO>.size)) else {
+            if !GetFileInformationByHandleEx(handle, FileAttributeTagInfo, &tagInfo,
+                                             DWORD(MemoryLayout<FILE_ATTRIBUTE_TAG_INFO>.size)) {
                 self = .typeUnknown
                 return
             }


### PR DESCRIPTION
This converts the previous re-encoding of the string to the file system
representation instead.