### PR TITLE
[DNM] Test Creating strings without CF

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -29,6 +29,7 @@
 #include <CoreFoundation/CFURLPriv.h>
 #include <CoreFoundation/CFURLComponents.h>
 #include <CoreFoundation/CFRunArray.h>
+#include <CoreFoundation/CFStringEncodingConverterPriv.h>
 
 #if TARGET_OS_WIN32
 #define NOMINMAX
@@ -366,6 +367,15 @@ typedef pthread_t _CFThreadRef;
 typedef pthread_attr_t _CFThreadAttributes;
 typedef pthread_key_t _CFThreadSpecificKey;
 #endif
+
+CF_EXPORT const CFStringEncodingConverter * _Nullable __CFStringEncodingConverterGetDefinitionForSwift(CFStringEncoding encoding);
+
+static inline bool
+__EncodeCheapEightBitToUnicode(const CFStringEncodingConverter *encoder, uint32_t flags, uint8_t byte, UniChar * _Nonnull character) {
+    CFStringEncodingCheapEightBitToUnicodeProc proc = encoder->toUnicode.cheapEightBit;
+    return (*proc)(flags, byte, character);
+}
+
 
 CF_CROSS_PLATFORM_EXPORT Boolean _CFIsMainThread(void);
 CF_EXPORT _CFThreadRef _CFMainPThread;

--- a/CoreFoundation/StringEncodings.subproj/CFStringEncodingConverter.c
+++ b/CoreFoundation/StringEncodings.subproj/CFStringEncodingConverter.c
@@ -579,6 +579,11 @@ CF_INLINE const CFStringEncodingConverter *__CFStringEncodingConverterGetDefinit
     }
 }
 
+CF_EXPORT const CFStringEncodingConverter *__CFStringEncodingConverterGetDefinitionForSwift(CFStringEncoding encoding) {
+    return __CFStringEncodingConverterGetDefinition(encoding);
+}
+
+
 static const _CFEncodingConverter *__CFGetConverter(uint32_t encoding) {
     const _CFEncodingConverter *converter = NULL;
     const _CFEncodingConverter **commonConverterSlot = NULL;


### PR DESCRIPTION
This tests directly using Swift instead of CF for a range of strings created with different encodings although it falls back to CF for encodings it doesn't understand.