### PR TITLE
No need for a for loop

### DIFF
--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -1337,10 +1337,7 @@ void _CF_dispatch_once(dispatch_once_t *predicate, void (^block)(void)) {
     } else {
         dow.dow_sema = _CF_get_thread_semaphore();
         next = *vval;
-        for (;;) {
-            if (next == CF_DISPATCH_ONCE_DONE) {
-                break;
-            }
+        while (next != CF_DISPATCH_ONCE_DONE) {
             if (__sync_bool_compare_and_swap(vval, next, tail, &next)) {
                 dow.dow_thread = next->dow_thread;
                 dow.dow_next = next;


### PR DESCRIPTION
One of the infinite loops has an immediate check to see if next == CF_DISPATCH_ONCE_DONE. If it is, the loop will break. However, this infinite loop is simple enough to be changed into a while loop. It looks better too and results in more readable code.