### PR TITLE
Revert "Foundation: fix missing string terminator"

### DIFF
--- a/Docs/ReleaseNotes_Swift5.md
+++ b/Docs/ReleaseNotes_Swift5.md
@@ -156,3 +156,11 @@ A few notes:
 * The exception-throwing API will be deprecated in a future release. It is now marked as `@available(…, deprecated: 100000, …)`, which matches what you would see if `API_TO_BE_DEPRECATED` was used in a Objective-C header.
 
 * Subclassing `NSFileHandle` is strongly discouraged. Many of the new methods are `public` and cannot be overridden.
+
+## `NSString(bytesNoCopy:length:encoding:freeWhenDone:)` deviations from reference implementation
+
+On Windows, `NSString(bytesNoCopy:length:encoding:freeWhenDone:)` deviates from
+the behaviour on Darwin and uses the buffer's `deallocate` routine rather than
+`free`.  This is done to ensure that the correct routine is invoked for
+releasing the resources acquired through `UnsafeMutablePointer.allocate` or
+`UnsafeMutableRawPointer.allocate`.

--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -599,12 +599,10 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
 
         let capacity = estimateBase64Size(length: dataLength)
         let ptr = UnsafeMutableRawPointer.allocate(byteCount: capacity, alignment: 1)
-        defer { ptr.deallocate() }
         let buffer = UnsafeMutableRawBufferPointer(start: ptr, count: capacity)
         let length = NSData.base64EncodeBytes(self, options: options, buffer: buffer)
 
-        let utf8buffer = UnsafeBufferPointer<UInt8>(start: ptr.assumingMemoryBound(to: UInt8.self), count: length)
-        return String(decoding: utf8buffer, as: UTF8.self)
+        return String(bytesNoCopy: ptr, length: length, encoding: .ascii, freeWhenDone: true)!
     }
 
     /// Creates a Base64, UTF-8 encoded Data from the data object using the given options.

--- a/Sources/Foundation/NSString.swift
+++ b/Sources/Foundation/NSString.swift
@@ -1359,7 +1359,11 @@ extension NSString {
         // just copy for now since the internal storage will be a copy anyhow
         self.init(bytes: bytes, length: len, encoding: encoding)
         if freeBuffer { // don't take the hint
-            free(bytes)
+#if os(Windows)
+          bytes.deallocate()
+#else
+          free(bytes)
+#endif
         }
     }
 


### PR DESCRIPTION
This reverts commit f3a6f50105ae4e922cc4146a25eb1a9313992a98.  It also
fixes the underlying issue of the heap corruption.

There is no guarantee that the underlying storage for an allocation is
done by `malloc`.  It is possible that the size may be small enough to
be pushed down to a stack allocation, which cannot be released by
`free`.  Buffers record how they are allocated and adjust the release
accordingly.  The safe way to release the memory is to use `deallocate`.

Although the initial approach fixed the heap corruption, it did so at
the single site, but this is a problem with a public interface.  Use the
`deallocate` method on the buffer when releasing the memory to ensure
that the correct mechanism is used for releasing the resources.

Thanks to Lily Vulcano for pressing me to investigate this further and
root cause the failure in the public interface!