### PR TITLE
[CF] TARGET_OS_BSD for FS representation behavior.

### DIFF
--- a/CoreFoundation/URL.subproj/CFURL.c
+++ b/CoreFoundation/URL.subproj/CFURL.c
@@ -4064,7 +4064,7 @@ static CFStringRef URLPathToPOSIXPath(CFStringRef path, CFAllocatorRef allocator
     return result;
 }
 
-#if TARGET_OS_MAC || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
 static Boolean CanonicalFileURLStringToFileSystemRepresentation(CFStringRef str, UInt8 *inBuffer, CFIndex inBufferLen)
 {
     size_t fileURLPrefixLength;
@@ -4534,13 +4534,24 @@ CFStringRef CFURLCreateStringWithFileSystemPath(CFAllocatorRef allocator, CFURLR
 }
 
 Boolean CFURLGetFileSystemRepresentation(CFURLRef url, Boolean resolveAgainstBase, uint8_t *buffer, CFIndex bufLen) {
-#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_WIN32
     CFAllocatorRef alloc = CFGetAllocator(url);
     CFStringRef path;
 
     if (!url) return false;
-#endif
-#if TARGET_OS_MAC || TARGET_OS_LINUX
+
+#if TARGET_OS_WIN32
+    path = CFURLCreateStringWithFileSystemPath(alloc, url, kCFURLWindowsPathStyle, resolveAgainstBase);
+    if (path) {
+        CFIndex usedLen;
+        CFIndex pathLen = CFStringGetLength(path);
+        CFIndex numConverted = CFStringGetBytes(path, CFRangeMake(0, pathLen), CFStringFileSystemEncoding(), 0, true, buffer, bufLen-1, &usedLen); // -1 because we need one byte to zero-terminate.
+        CFRelease(path);
+        if (numConverted == pathLen) {
+            buffer[usedLen] = '\0';
+            return true;
+        }
+    }
+#else
     if ( !resolveAgainstBase || (CFURLGetBaseURL(url) == NULL) ) {
         if (!CF_IS_OBJC(CFURLGetTypeID(), url)) {
             // We can access the ivars
@@ -4555,18 +4566,6 @@ Boolean CFURLGetFileSystemRepresentation(CFURLRef url, Boolean resolveAgainstBas
         Boolean convResult = CFStringGetFileSystemRepresentation(path, (char *)buffer, bufLen);
         CFRelease(path);
         return convResult;
-    }
-#elif TARGET_OS_WIN32
-    path = CFURLCreateStringWithFileSystemPath(alloc, url, kCFURLWindowsPathStyle, resolveAgainstBase);
-    if (path) {
-        CFIndex usedLen;
-        CFIndex pathLen = CFStringGetLength(path);
-        CFIndex numConverted = CFStringGetBytes(path, CFRangeMake(0, pathLen), CFStringFileSystemEncoding(), 0, true, buffer, bufLen-1, &usedLen); // -1 because we need one byte to zero-terminate.
-        CFRelease(path);
-        if (numConverted == pathLen) {
-            buffer[usedLen] = '\0';
-            return true;
-        }
     }
 #endif
     return false;


### PR DESCRIPTION
CFURLGetFileSystemRepresentation's implementation has TARGET_OS_MAC and
TARGET_OS_LINUX, but not TARGET_OS_BSD. Nothing here appears macOS or
Linux specific, and things seem to work okay with TARGET_OS_BSD, so
enable it here too.

This also requires CanonicalFileURLStringToFileSystemRepresentation to
be exposed.