### PR TITLE
test: correct test assumption for Windows paths

### DIFF
--- a/Tests/Foundation/Tests/TestProcess.swift
+++ b/Tests/Foundation/Tests/TestProcess.swift
@@ -634,7 +634,16 @@ class TestProcess : XCTestCase {
 
         do {
             let (stdout, _) = try runTask([xdgTestHelperURL().path, "--getcwd"], currentDirectoryPath: "/")
-            XCTAssertEqual(stdout.trimmingCharacters(in: CharacterSet(["\n", "\r"])), "/")
+            var directory = stdout.trimmingCharacters(in: CharacterSet(["\n", "\r"]))
+#if os(Windows)
+            let zero: String.Index = directory.startIndex
+            let one: String.Index = directory.index(zero, offsetBy: 1)
+            XCTAssertTrue(directory[zero].isLetter)
+            XCTAssertEqual(directory[one], ":")
+            directory = "/" + String(directory.dropFirst(2))
+#endif
+            XCTAssertEqual(URL(fileURLWithPath: directory).absoluteURL,
+                           URL(fileURLWithPath: "/").absoluteURL)
         }
 
         do {


### PR DESCRIPTION
The Windows file system path representation `\` is a drive letter
relative path.  That is, the same path can be used across multiple
drives (similar to the concept of alternate roots).  We expect that
the path returned is `[[:letter:]]:` or `[[:letter:]]:[\\/]` rather
than the Unix `/`.  Adjust the expectation.