### PR TITLE
tests: disable a test on Windows

### DIFF
--- a/Tests/Foundation/Tests/TestProcess.swift
+++ b/Tests/Foundation/Tests/TestProcess.swift
@@ -638,12 +638,17 @@ class TestProcess : XCTestCase {
         }
 
         do {
+            // NOTE: Windows does have an environment variable called `PWD`.
+            // The closed thing is %CD% which is a property of the shell rather
+            // than the environment.  Simply ignore this test on Windows.
+#if !os(Windows)
             XCTAssertNotEqual("/", FileManager.default.currentDirectoryPath)
             XCTAssertNotEqual(FileManager.default.currentDirectoryPath, "/")
             let (stdout, _) = try runTask([xdgTestHelperURL().path, "--echo-PWD"], currentDirectoryPath: "/")
             let directory = stdout.trimmingCharacters(in: CharacterSet(["\n", "\r"]))
             XCTAssertEqual(directory, ProcessInfo.processInfo.environment["PWD"])
             XCTAssertNotEqual(directory, "/")
+#endif
         }
 
         do {


### PR DESCRIPTION
Windows does not have the `PWD` environment variable.  The closest
analogue is the `%CD%` magic variable which is specific to the shell
rather than the environment.  Skip the test on Windows.