### PR TITLE
SR-5576: Calendar.dateComponents(_:from:) crashes using .nanosecond or .quarter

### DIFF
--- a/Tests/Foundation/Tests/TestCodable.swift
+++ b/Tests/Foundation/Tests/TestCodable.swift
@@ -421,10 +421,8 @@ class TestCodable : XCTestCase {
         .yearForWeekOfYear,
         .timeZone,
         .calendar,
-        // [SR-5576] Disabled due to a bug in Calendar.dateComponents(_:from:) which crashes on Darwin and returns
-        // invalid values on Linux if components include .nanosecond or .quarter.
-        // .nanosecond,
-        // .quarter,
+        .nanosecond,
+        .quarter,
     ]
 
     func test_DateComponents_JSON() {

--- a/Tests/Foundation/Tests/TestDate.swift
+++ b/Tests/Foundation/Tests/TestDate.swift
@@ -145,21 +145,19 @@ class TestDate : XCTestCase {
         XCTAssertEqual(recreatedComponents.era, 1)
         XCTAssertEqual(recreatedComponents.year, 2017)
         XCTAssertEqual(recreatedComponents.month, 11)
+        XCTAssertEqual(recreatedComponents.day, 5)
         XCTAssertEqual(recreatedComponents.hour, 20)
         XCTAssertEqual(recreatedComponents.minute, 38)
-        
-        // Nanoseconds are currently not supported by UCalendar C API, returns nil
-        // XCTAssertEqual(recreatedComponents.nanosecond, 40)
-        
+        XCTAssertEqual(recreatedComponents.second, 11)
+        XCTAssertEqual(recreatedComponents.nanosecond, 59)
         XCTAssertEqual(recreatedComponents.weekday, 1)
         XCTAssertEqual(recreatedComponents.weekdayOrdinal, 1)
-        
-        // Quarter is currently not supported by UCalendar C API, returns nil
-        // XCTAssertEqual(recreatedComponents.quarter, 3)
-        
         XCTAssertEqual(recreatedComponents.weekOfMonth, 2)
         XCTAssertEqual(recreatedComponents.weekOfYear, 45)
         XCTAssertEqual(recreatedComponents.yearForWeekOfYear, 2017)
+
+        // Quarter is currently not supported by UCalendar C API, returns 0
+        XCTAssertEqual(recreatedComponents.quarter, 0)
     }
 
     func test_Hashing() {


### PR DESCRIPTION
- .nanosecond is implemented so re-enable tests.

- .quarter doesnt crash but always returns 0 for now so also re-enable
  in tests.