### PR TITLE
Port, PortMessage: Rename sendBeforeDate(...) to send(before: Date...)

### DIFF
--- a/Sources/Foundation/Port.swift
+++ b/Sources/Foundation/Port.swift
@@ -60,12 +60,12 @@ open class Port : NSObject, NSCopying {
         return 0
     }
     
-    open func sendBeforeDate(_ limitDate: Date, components: NSMutableArray?, from receivePort: Port?, reserved headerSpaceReserved: Int) -> Bool {
+    open func send(before limitDate: Date, components: NSMutableArray?, from receivePort: Port?, reserved headerSpaceReserved: Int) -> Bool {
         NSRequiresConcreteImplementation()
     }
 
-    open func sendBeforeDate(_ limitDate: Date, msgid msgID: Int, components: NSMutableArray?, from receivePort: Port?, reserved headerSpaceReserved: Int) -> Bool {
-        return sendBeforeDate(limitDate, components: components, from: receivePort, reserved: headerSpaceReserved)
+    open func send(before limitDate: Date, msgid msgID: Int, components: NSMutableArray?, from receivePort: Port?, reserved headerSpaceReserved: Int) -> Bool {
+        return send(before: limitDate, components: components, from: receivePort, reserved: headerSpaceReserved)
     }
 }
 
@@ -946,11 +946,11 @@ open class SocketPort : Port {
         }
     }
     
-    open override func sendBeforeDate(_ limitDate: Date, components: NSMutableArray?, from receivePort: Port?, reserved headerSpaceReserved: Int) -> Bool {
-        sendBeforeDate(limitDate, msgid: 0, components: components, from: receivePort, reserved: headerSpaceReserved)
+    open override func send(before limitDate: Date, components: NSMutableArray?, from receivePort: Port?, reserved headerSpaceReserved: Int) -> Bool {
+        send(before: limitDate, msgid: 0, components: components, from: receivePort, reserved: headerSpaceReserved)
     }
     
-    open override func sendBeforeDate(_ limitDate: Date, msgid msgID: Int, components: NSMutableArray?, from receivePort: Port?, reserved headerSpaceReserved: Int) -> Bool {
+    open override func send(before limitDate: Date, msgid msgID: Int, components: NSMutableArray?, from receivePort: Port?, reserved headerSpaceReserved: Int) -> Bool {
         guard let sender = sendingSocket(for: self, before: limitDate.timeIntervalSinceReferenceDate),
               let signature = core.signature.darwinCompatibleDataRepresentation else {
             return false

--- a/Sources/Foundation/PortMessage.swift
+++ b/Sources/Foundation/PortMessage.swift
@@ -21,8 +21,8 @@ open class PortMessage : NSObject, NSCopying {
     open private(set) var receivePort: Port?
     open private(set) var sendPort: Port?
     
-    open func sendBeforeDate(_ date: Date) -> Bool {
-        return sendPort?.sendBeforeDate(date, msgid: Int(msgid), components: NSMutableArray(array: components ?? []), from: receivePort, reserved: 0) ?? false
+    open func send(before date: Date) -> Bool {
+        return sendPort?.send(before: date, msgid: Int(msgid), components: NSMutableArray(array: components ?? []), from: receivePort, reserved: 0) ?? false
     }
     
     public func copy(with zone: NSZone?) -> Any {

--- a/Tests/Foundation/Tests/TestSocketPort.swift
+++ b/Tests/Foundation/Tests/TestSocketPort.swift
@@ -99,7 +99,7 @@ class TestSocketPort : XCTestCase {
                 remote.remove(from: .main, forMode: .default)
             }
             
-            let sent = remote.sendBeforeDate(Date(timeIntervalSinceNow: 5), components: NSMutableArray(array: [data]), from: nil, reserved: 0)
+            let sent = remote.send(before: Date(timeIntervalSinceNow: 5), components: NSMutableArray(array: [data]), from: nil, reserved: 0)
             XCTAssertTrue(sent)
             
             waitForExpectations(timeout: 5.5)


### PR DESCRIPTION
- Update method signatures to match Darwin.