### PR TITLE
Remove old alias _$S15SwiftFoundation19_NSCFConstantStringCN

### DIFF
--- a/CoreFoundation/Base.subproj/SymbolAliases
+++ b/CoreFoundation/Base.subproj/SymbolAliases
@@ -98,8 +98,3 @@ _kCFNumberFormatterZeroSymbolKey		_kCFNumberFormatterZeroSymbol
 _kCFNumberFormatterUsesCharacterDirectionKey	_kCFNumberFormatterUsesCharacterDirection
 _kCFDateFormatterUsesCharacterDirectionKey	_kCFDateFormatterUsesCharacterDirection
 _kCFDateFormatterCalendarIdentifierKey		_kCFDateFormatterCalendarName
-
-# Workaround for being able to compile with a swift compiler with the old mangling prefix $S.
-# This can eventually be removed if everyone compiles with the ABI-stable Swift 5.0 compiler.
-_$S15SwiftFoundation19_NSCFConstantStringCN	_$s15SwiftFoundation19_NSCFConstantStringCN
-


### PR DESCRIPTION
- This is an alias for _$s15SwiftFoundation19_NSCFConstantStringCN
  used while the mangling was being switched from $S to $s but is
  not required anymore.