### PR TITLE
[5.2] SR-6450: Leak in Process on Linux

### DIFF
--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -1128,6 +1128,7 @@ open class Process: NSObject {
         } while( self.isRunning == true && RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.05)) )
         
         self.runLoop = nil
+        self.runLoopSource = nil
     }
 }
 


### PR DESCRIPTION
- The runLoopSource was holding a reference to self creating a retain
  cycle. Set to nil after the child process has finished.

(cherry picked from commit b15e4f43a8de844c44070a5987727ef1b864a426)

Backport of #2631