### PR TITLE
[5.1] SR-6450: Leak in Process on Linux

### DIFF
--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -1081,6 +1081,7 @@ open class Process: NSObject {
         } while( self.isRunning == true && RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.05)) )
         
         self.runLoop = nil
+        self.runLoopSource = nil
     }
 }
 


### PR DESCRIPTION
- The runLoopSource was holding a reference to self creating a retain
  cycle. Set to nil after the child process has finished.

(cherry picked from commit b15e4f43a8de844c44070a5987727ef1b864a426)

Back port of #2631 5.2 version is #2694 