### PR TITLE
[5.1] Process: Setting stdout or stderr to nil or nullDevice set stdin instead.

### DIFF
--- a/Foundation/Process.swift
+++ b/Foundation/Process.swift
@@ -829,7 +829,7 @@ open class Process: NSObject {
         // nil or NullDevice map to /dev/null
         case let handle as FileHandle where handle === FileHandle._nulldeviceFileHandle: fallthrough
         case .none:
-            adddup2[STDIN_FILENO] = try devNullFd()
+            adddup2[STDOUT_FILENO] = try devNullFd()
 
         // No need to dup stdout to stdout
         case let handle as FileHandle where handle === FileHandle._stdoutFileHandle: break
@@ -848,7 +848,7 @@ open class Process: NSObject {
         // nil or NullDevice map to /dev/null
         case let handle as FileHandle where handle === FileHandle._nulldeviceFileHandle: fallthrough
         case .none:
-            adddup2[STDIN_FILENO] = try devNullFd()
+            adddup2[STDERR_FILENO] = try devNullFd()
 
         // No need to dup stderr to stderr
         case let handle as FileHandle where handle === FileHandle._stderrFileHandle: break

--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -80,8 +80,15 @@ class TestProcess : XCTestCase {
 
         let inputPipe = Pipe()
         process.standardInput = inputPipe
+        process.standardError = FileHandle.nullDevice
         try process.run()
-        inputPipe.fileHandleForWriting.write("Hello, 🐶.\n".data(using: .utf8)!)
+        let msg = try XCTUnwrap("Hello, 🐶.\n".data(using: .utf8))
+        do {
+            try inputPipe.fileHandleForWriting.write(contentsOf: msg)
+        } catch {
+            XCTFail("Cant write to pipe: \(error)")
+            return
+        }
 
         // Close the input pipe to send EOF to cat.
         inputPipe.fileHandleForWriting.closeFile()


### PR DESCRIPTION
- If .standardOutput or .standardError was set to nil or
  FileHandle.nullDevice, stdin was set to /dev/null instead.

(cherry picked from commit dffe77420524dbd980edefeca93a0223274d49d7)

Backport of #2545 

cc @weissi 