### PR TITLE
Give SwiftValue a tailored `description` property similar to Darwin's

### DIFF
--- a/DarwinCompatibilityTests.xcodeproj/project.pbxproj
+++ b/DarwinCompatibilityTests.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		659FB6E02405E65D00F5F63F /* TestBridging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659FB6DF2405E65D00F5F63F /* TestBridging.swift */; };
 		B917D32420B0DB9700728EE0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B917D32320B0DB9700728EE0 /* Foundation.framework */; };
 		B94B07402401847C00B244E8 /* FTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B94B073C2401847C00B244E8 /* FTPServer.swift */; };
 		B94B07412401847C00B244E8 /* HTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B94B073D2401847C00B244E8 /* HTTPServer.swift */; };
@@ -171,6 +172,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		659FB6DF2405E65D00F5F63F /* TestBridging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestBridging.swift; path = Tests/Foundation/Tests/TestBridging.swift; sourceTree = "<group>"; };
 		B917D31C20B0DB8B00728EE0 /* xdgTestHelper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = xdgTestHelper; sourceTree = BUILT_PRODUCTS_DIR; };
 		B917D32320B0DB9700728EE0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		B94B073C2401847C00B244E8 /* FTPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FTPServer.swift; path = Tests/Foundation/FTPServer.swift; sourceTree = "<group>"; };
@@ -339,6 +341,7 @@
 			children = (
 				B94B08342401854E00B244E8 /* main.swift */,
 				B94B07822401849700B244E8 /* TestAffineTransform.swift */,
+				659FB6DF2405E65D00F5F63F /* TestBridging.swift */,
 				B94B07472401849300B244E8 /* TestBundle.swift */,
 				B94B078D2401849800B244E8 /* TestByteCountFormatter.swift */,
 				B94B078F2401849800B244E8 /* TestCachedURLResponse.swift */,
@@ -666,6 +669,7 @@
 				B94B07CF2401849B00B244E8 /* TestURLProtocol.swift in Sources */,
 				B94B07D02401849B00B244E8 /* TestScanner.swift in Sources */,
 				B94B07D12401849B00B244E8 /* TestXMLParser.swift in Sources */,
+				659FB6E02405E65D00F5F63F /* TestBridging.swift in Sources */,
 				B94B07D22401849B00B244E8 /* TestNSUUID.swift in Sources */,
 				B94B07D32401849B00B244E8 /* TestThread.swift in Sources */,
 				B94B07D42401849B00B244E8 /* TestNSLocale.swift in Sources */,

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -378,6 +378,7 @@
 		61E011821C1B599A000037DD /* CFMachPort.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B5D88D01BBC9AAC00234F36 /* CFMachPort.c */; };
 		63DCE9D21EAA430100E9CB02 /* ISO8601DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DCE9D11EAA430100E9CB02 /* ISO8601DateFormatter.swift */; };
 		63DCE9D41EAA432400E9CB02 /* TestISO8601DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DCE9D31EAA432400E9CB02 /* TestISO8601DateFormatter.swift */; };
+		659FB6DE2405E5E300F5F63F /* TestBridging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659FB6DD2405E5E200F5F63F /* TestBridging.swift */; };
 		684C79011F62B611005BD73E /* TestNSNumberBridging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684C79001F62B611005BD73E /* TestNSNumberBridging.swift */; };
 		6EB768281D18C12C00D4B719 /* UUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB768271D18C12C00D4B719 /* UUID.swift */; };
 		7900433B1CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790043391CACD33E00ECCBF1 /* TestNSCompoundPredicate.swift */; };
@@ -1074,6 +1075,7 @@
 		61F8AE7C1C180FC600FB62F0 /* TestNotificationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNotificationCenter.swift; sourceTree = "<group>"; };
 		63DCE9D11EAA430100E9CB02 /* ISO8601DateFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ISO8601DateFormatter.swift; sourceTree = "<group>"; };
 		63DCE9D31EAA432400E9CB02 /* TestISO8601DateFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestISO8601DateFormatter.swift; sourceTree = "<group>"; };
+		659FB6DD2405E5E200F5F63F /* TestBridging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestBridging.swift; sourceTree = "<group>"; };
 		684C79001F62B611005BD73E /* TestNSNumberBridging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSNumberBridging.swift; sourceTree = "<group>"; };
 		6E203B8C1C1303BB003B2576 /* TestBundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestBundle.swift; sourceTree = "<group>"; };
 		6EB768271D18C12C00D4B719 /* UUID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UUID.swift; sourceTree = "<group>"; };
@@ -1789,6 +1791,7 @@
 			isa = PBXGroup;
 			children = (
 				C93559281C12C49F009FD6A9 /* TestAffineTransform.swift */,
+				659FB6DD2405E5E200F5F63F /* TestBridging.swift */,
 				6E203B8C1C1303BB003B2576 /* TestBundle.swift */,
 				A5A34B551C18C85D00FD972B /* TestByteCountFormatter.swift */,
 				1539391322A07007006DFF4F /* TestCachedURLResponse.swift */,
@@ -3109,6 +3112,7 @@
 				B9D9734323D19FD100AB249C /* TestURLComponents.swift in Sources */,
 				5B13B3391C582D4C00651CE2 /* TestNSNull.swift in Sources */,
 				BD8042161E09857800487EB8 /* TestLengthFormatter.swift in Sources */,
+				659FB6DE2405E5E300F5F63F /* TestBridging.swift in Sources */,
 				5B13B3421C582D4C00651CE2 /* TestRunLoop.swift in Sources */,
 				155D3BBC22401D1100B0D38E /* FixtureValues.swift in Sources */,
 				5B13B34E1C582D4C00651CE2 /* TestXMLDocument.swift in Sources */,

--- a/Sources/Foundation/Bridging.swift
+++ b/Sources/Foundation/Bridging.swift
@@ -232,4 +232,6 @@ internal final class __SwiftValue : NSObject, NSCopying {
     }
     
     public static let null: AnyObject = NSNull()
+
+    override var description: String { String(describing: value) }
 }

--- a/Tests/Foundation/CMakeLists.txt
+++ b/Tests/Foundation/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(TestFoundation
 # Test Cases
 target_sources(TestFoundation PRIVATE
   Tests/TestAffineTransform.swift
+  Tests/TestBridging.swift
   Tests/TestBundle.swift
   Tests/TestByteCountFormatter.swift
   Tests/TestCachedURLResponse.swift

--- a/Tests/Foundation/Tests/TestBridging.swift
+++ b/Tests/Foundation/Tests/TestBridging.swift
@@ -1,0 +1,48 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+    #if canImport(SwiftFoundation) && !DEPLOYMENT_RUNTIME_OBJC
+        @testable import SwiftFoundation
+    #else
+        @testable import Foundation
+    #endif
+#endif
+
+struct StructWithDescriptionAndDebugDescription:
+    CustomStringConvertible, CustomDebugStringConvertible
+{
+    var description: String { "description" }
+    var debugDescription: String { "debugDescription" }
+}
+
+class TestBridging : XCTestCase {
+    static var allTests: [(String, (TestBridging) -> () throws -> Void)] {
+        return [
+            ("testBridgedDescription", testBridgedDescription),
+        ]
+    }
+
+    func testBridgedDescription() {
+        // Struct with working (debug)description properties:
+        let a = StructWithDescriptionAndDebugDescription()
+        XCTAssertEqual("description", a.description)
+        XCTAssertEqual("debugDescription", a.debugDescription)
+
+        // Wrap it up in a SwiftValue container
+        let b = (a as AnyObject) as? NSObject
+        XCTAssertNotNil(b)
+        let c = b!
+
+        // Check that the wrapper forwards (debug)description
+        // to the wrapped description property.
+        XCTAssertEqual("description", c.description)
+        XCTAssertEqual("description", c.debugDescription)
+    }
+}

--- a/Tests/Foundation/Tests/TestNSNumberBridging.swift
+++ b/Tests/Foundation/Tests/TestNSNumberBridging.swift
@@ -104,6 +104,7 @@ class TestNSNumberBridging : XCTestCase {
     func testNSNumberBridgeFromUInt8() {
         for interestingValue in UInt8._interestingValues {
             func testNumber(_ number: NSNumber) {
+                XCTAssertEqual(interestingValue.description, number.description)
                 let int8 = Int8(exactly: number)
                 XCTAssertEqual(Int8(exactly: interestingValue), int8)
                 let uint8 = UInt8(exactly: number)
@@ -139,6 +140,7 @@ class TestNSNumberBridging : XCTestCase {
     func testNSNumberBridgeFromInt16() {
         for interestingValue in Int16._interestingValues {
             func testNumber(_ number: NSNumber) {
+                XCTAssertEqual(interestingValue.description, number.description)
                 let int8 = Int8(exactly: number)
                 XCTAssertEqual(Int8(exactly: interestingValue), int8)
                 let uint8 = UInt8(exactly: number)
@@ -174,6 +176,7 @@ class TestNSNumberBridging : XCTestCase {
     func testNSNumberBridgeFromUInt16() {
         for interestingValue in UInt8._interestingValues {
             func testNumber(_ number: NSNumber) {
+                XCTAssertEqual(interestingValue.description, number.description)
                 let int8 = Int8(exactly: number)
                 XCTAssertEqual(Int8(exactly: interestingValue), int8)
                 let uint8 = UInt8(exactly: number)
@@ -209,6 +212,7 @@ class TestNSNumberBridging : XCTestCase {
     func testNSNumberBridgeFromInt32() {
         for interestingValue in Int32._interestingValues {
             func testNumber(_ number: NSNumber) {
+                XCTAssertEqual(interestingValue.description, number.description)
                 let int8 = Int8(exactly: number)
                 XCTAssertEqual(Int8(exactly: interestingValue), int8)
                 let uint8 = UInt8(exactly: number)
@@ -248,6 +252,7 @@ class TestNSNumberBridging : XCTestCase {
     func testNSNumberBridgeFromUInt32() {
         for interestingValue in UInt32._interestingValues {
             func testNumber(_ number: NSNumber) {
+                XCTAssertEqual(interestingValue.description, number.description)
                 let int8 = Int8(exactly: number)
                 XCTAssertEqual(Int8(exactly: interestingValue), int8)
                 let uint8 = UInt8(exactly: number)
@@ -287,6 +292,7 @@ class TestNSNumberBridging : XCTestCase {
     func testNSNumberBridgeFromInt64() {
         for interestingValue in Int64._interestingValues {
             func testNumber(_ number: NSNumber) {
+                XCTAssertEqual(interestingValue.description, number.description)
                 let int8 = Int8(exactly: number)
                 XCTAssertEqual(Int8(exactly: interestingValue), int8)
                 let uint8 = UInt8(exactly: number)
@@ -326,6 +332,7 @@ class TestNSNumberBridging : XCTestCase {
     func testNSNumberBridgeFromUInt64() {
         for interestingValue in UInt64._interestingValues {
             func testNumber(_ number: NSNumber) {
+                XCTAssertEqual(interestingValue.description, number.description)
                 let int8 = Int8(exactly: number)
                 XCTAssertEqual(Int8(exactly: interestingValue), int8)
                 let uint8 = UInt8(exactly: number)
@@ -365,6 +372,7 @@ class TestNSNumberBridging : XCTestCase {
     func testNSNumberBridgeFromInt() {
         for interestingValue in Int._interestingValues {
             func testNumber(_ number: NSNumber) {
+                XCTAssertEqual(interestingValue.description, number.description)
                 let int8 = Int8(exactly: number)
                 XCTAssertEqual(Int8(exactly: interestingValue), int8)
                 let uint8 = UInt8(exactly: number)
@@ -404,6 +412,7 @@ class TestNSNumberBridging : XCTestCase {
     func testNSNumberBridgeFromUInt() {
         for interestingValue in UInt._interestingValues {
             func testNumber(_ number: NSNumber) {
+                XCTAssertEqual(interestingValue.description, number.description)
                 let int8 = Int8(exactly: number)
                 XCTAssertEqual(Int8(exactly: interestingValue), int8)
                 let uint8 = UInt8(exactly: number)
@@ -443,6 +452,7 @@ class TestNSNumberBridging : XCTestCase {
     func testNSNumberBridgeFromFloat() {
         for interestingValue in Float._interestingValues {
             func testNumber(_ number: NSNumber) {
+                XCTAssertEqual(interestingValue.description, number.description)
                 let int8 = Int8(exactly: number)
                 XCTAssertEqual(Int8(exactly: interestingValue), int8)
                 let uint8 = UInt8(exactly: number)
@@ -482,6 +492,7 @@ class TestNSNumberBridging : XCTestCase {
     func testNSNumberBridgeFromDouble() {
         for interestingValue in Double._interestingValues {
             func testNumber(_ number: NSNumber) {
+                XCTAssertEqual(interestingValue.description, number.description)
                 let int8 = Int8(exactly: number)
                 XCTAssertEqual(Int8(exactly: interestingValue), int8)
                 let uint8 = UInt8(exactly: number)

--- a/Tests/Foundation/main.swift
+++ b/Tests/Foundation/main.swift
@@ -24,6 +24,7 @@ _ = signal(SIGPIPE, SIG_IGN)
 var allTestCases = [
     testCase(TestAffineTransform.allTests),
     testCase(TestNSArray.allTests),
+    testCase(TestBridging.allTests),
     testCase(TestBundle.allTests),
     testCase(TestByteCountFormatter.allTests),
     testCase(TestNSCache.allTests),


### PR DESCRIPTION
In particular, printing a SwiftValue on Darwin will print the
contained value, not the generic type + address dump that
is implemented by NSObject.

This brings that same behavior to non-Apple platforms.
