### PR TITLE
CoreFoundation: ensure that the bundle path exists

### DIFF
--- a/CoreFoundation/PlugIn.subproj/CFBundle_Executable.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Executable.c
@@ -344,6 +344,10 @@ static CFURLRef _CFBundleCopyBundleURLForExecutablePath(CFStringRef str) {
             buffLen += extensionLength;
             outstr = CFStringCreateWithCharactersNoCopy(kCFAllocatorSystemDefault, buff, buffLen, kCFAllocatorNull);
             url = CFURLCreateWithFileSystemPath(kCFAllocatorSystemDefault, outstr, PLATFORM_PATH_STYLE, true);
+            if (!_CFURLExists(url)) {
+                CFRelease(url);
+                url = NULL;
+            }
             CFRelease(outstr);
         }
     }


### PR DESCRIPTION
On Windows, we would assume that the bundle path computed will exist.
However, it is possible to have an executable using Foundation without a
bundle.  In such a case, the main bundle would never be setup, and when
SwiftFoundation would attempt to access it, it would assume that it was
setup.  This would cause a failure due to the forced unwrapping.