### PR TITLE
Compact number formats for NumberFormatter.

### DIFF
--- a/CoreFoundation/Locale.subproj/CFNumberFormatter.c
+++ b/CoreFoundation/Locale.subproj/CFNumberFormatter.c
@@ -111,6 +111,10 @@ CFNumberFormatterRef CFNumberFormatterCreate(CFAllocatorRef allocator, CFLocaleR
 #if U_ICU_VERSION_MAJOR_NUM >= 55
     case kCFNumberFormatterCurrencyAccountingStyle: ustyle = UNUM_CURRENCY_ACCOUNTING; break;
 #endif
+#if U_ICU_VERSION_MAJOR_NUM >= 56 || (U_ICU_VERSION_MAJOR_NUM >= 55 && !defined(U_HIDE_DRAFT_API))
+    case kCFNumberFormatterDecimalCompactStyle: ustyle = UNUM_DECIMAL_COMPACT_SHORT; break;
+    case kCFNumberFormatterDecimalCompactPluralStyle: ustyle = UNUM_DECIMAL_COMPACT_LONG; break;
+#endif
     default:
 	CFAssert2(0, __kCFLogAssertion, "%s(): unknown style %ld", __PRETTY_FUNCTION__, style);
 	ustyle = UNUM_DECIMAL;
@@ -200,6 +204,10 @@ static void __substituteFormatStringFromPrefsNF(CFNumberFormatterRef formatter) 
 #if U_ICU_VERSION_MAJOR_NUM >= 55
 	    case kCFNumberFormatterCurrencyAccountingStyle: key = CFSTR("10"); break;
 #endif
+#if U_ICU_VERSION_MAJOR_NUM >= 56 || (U_ICU_VERSION_MAJOR_NUM >= 55 && !defined(U_HIDE_DRAFT_API))
+        case kCFNumberFormatterDecimalCompactStyle: key = CFSTR("11"); break;
+        case kCFNumberFormatterDecimalCompactPluralStyle: key = CFSTR("12"); break;
+#endif
 	    default: key = CFSTR("0"); break;
 	    }
 	    pref = (CFStringRef)CFDictionaryGetValue((CFDictionaryRef)metapref, key);
@@ -218,6 +226,10 @@ static void __substituteFormatStringFromPrefsNF(CFNumberFormatterRef formatter) 
 	    case kCFNumberFormatterCurrencyPluralStyle: icustyle = UNUM_CURRENCY_PLURAL; break;
 #if U_ICU_VERSION_MAJOR_NUM >= 55
 	    case kCFNumberFormatterCurrencyAccountingStyle: icustyle = UNUM_CURRENCY_ACCOUNTING; break;
+#endif
+#if U_ICU_VERSION_MAJOR_NUM >= 56 || (U_ICU_VERSION_MAJOR_NUM >= 55 && !defined(U_HIDE_DRAFT_API))
+        case kCFNumberFormatterDecimalCompactStyle: icustyle = UNUM_DECIMAL_COMPACT_SHORT; break;
+        case kCFNumberFormatterDecimalCompactPluralStyle: icustyle = UNUM_DECIMAL_COMPACT_LONG; break;
 #endif
 	    }
 	    CFStringRef localeName = CFLocaleGetIdentifier(formatter->_locale);
@@ -313,6 +325,12 @@ static UErrorCode __CFNumberFormatterApplyPattern(CFNumberFormatterRef formatter
     if (kCFNumberFormatterOrdinalStyle == formatter->_style) return U_UNSUPPORTED_ERROR;
     if (kCFNumberFormatterDurationStyle == formatter->_style) return U_UNSUPPORTED_ERROR;
     if (kCFNumberFormatterCurrencyPluralStyle == formatter->_style) return U_UNSUPPORTED_ERROR;
+    #if U_ICU_VERSION_MAJOR_NUM >= 56 || (U_ICU_VERSION_MAJOR_NUM >= 55 && !defined(U_HIDE_DRAFT_API))
+    if (__builtin_available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)) {
+        if (kCFNumberFormatterDecimalCompactStyle == formatter->_style) return U_UNSUPPORTED_ERROR;
+        if (kCFNumberFormatterDecimalCompactPluralStyle == formatter->_style) return U_UNSUPPORTED_ERROR;
+    }
+    #endif
     CFIndex cnt = CFStringGetLength(pattern);
     SAFE_STACK_BUFFER_DECL(UChar, ubuffer, cnt, 256);
     const UChar *ustr = (const UChar *)CFStringGetCharactersPtr(pattern);

--- a/CoreFoundation/Locale.subproj/CFNumberFormatter.h
+++ b/CoreFoundation/Locale.subproj/CFNumberFormatter.h
@@ -37,6 +37,8 @@ typedef CF_ENUM(CFIndex, CFNumberFormatterStyle) {	// number format styles
 	kCFNumberFormatterCurrencyISOCodeStyle API_AVAILABLE(macos(10.11), ios(9.0), watchos(2.0), tvos(9.0)) = 8,
 	kCFNumberFormatterCurrencyPluralStyle API_AVAILABLE(macos(10.11), ios(9.0), watchos(2.0), tvos(9.0)) = 9,
 	kCFNumberFormatterCurrencyAccountingStyle API_AVAILABLE(macos(10.11), ios(9.0), watchos(2.0), tvos(9.0)) = 10,
+    kCFNumberFormatterDecimalCompactStyle API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0), tvos(13.0)) = 11,
+    kCFNumberFormatterDecimalCompactPluralStyle API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0), tvos(13.0)) = 12,
 };
 
 

--- a/Sources/Foundation/NumberFormatter.swift
+++ b/Sources/Foundation/NumberFormatter.swift
@@ -21,6 +21,8 @@ extension NumberFormatter {
         case currencyISOCode    = 8     // 7 is not used
         case currencyPlural     = 9
         case currencyAccounting = 10
+        case compact            = 11
+        case compactPlural      = 12
     }
 
     public enum PadPosition : UInt {
@@ -187,7 +189,7 @@ open class NumberFormatter : Formatter {
     // to indicate to use the default value (if nil) or the caller-supplied value (if not nil).
     private func defaultMinimumIntegerDigits() -> Int {
         switch numberStyle {
-        case .ordinal, .spellOut, .currencyPlural:
+        case .ordinal, .spellOut, .currencyPlural, .compact, .compactPlural:
             return 0
 
         case .none, .currency, .currencyISOCode, .currencyAccounting, .decimal, .percent, .scientific:
@@ -200,7 +202,7 @@ open class NumberFormatter : Formatter {
         case .none:
             return 42
 
-        case .ordinal, .spellOut, .currencyPlural:
+        case .ordinal, .spellOut, .currencyPlural, .compact, .compactPlural:
             return 0
 
         case .currency, .currencyISOCode, .currencyAccounting, .decimal, .percent:
@@ -213,7 +215,7 @@ open class NumberFormatter : Formatter {
 
     private func defaultMinimumFractionDigits() -> Int {
         switch numberStyle {
-        case .none, .ordinal, .spellOut, .currencyPlural, .decimal, .percent, .scientific:
+        case .none, .ordinal, .spellOut, .currencyPlural, .decimal, .percent, .scientific, .compact, .compactPlural:
             return 0
 
         case .currency, .currencyISOCode, .currencyAccounting:
@@ -226,7 +228,7 @@ open class NumberFormatter : Formatter {
         case .none, .ordinal, .spellOut, .currencyPlural, .percent, .scientific:
             return 0
 
-        case .currency, .currencyISOCode, .currencyAccounting:
+        case .currency, .currencyISOCode, .currencyAccounting, .compact, .compactPlural:
             return 2
 
         case .decimal:
@@ -239,14 +241,14 @@ open class NumberFormatter : Formatter {
         case .ordinal, .spellOut, .currencyPlural:
             return 0
 
-        case .currency, .none, .currencyISOCode, .currencyAccounting, .decimal, .percent, .scientific:
+        case .currency, .none, .currencyISOCode, .currencyAccounting, .decimal, .percent, .scientific, .compact, .compactPlural:
             return -1
         }
     }
 
     private func defaultMaximumSignificantDigits() -> Int {
         switch numberStyle {
-        case .none, .currency, .currencyISOCode, .currencyAccounting, .decimal, .percent, .scientific:
+        case .none, .currency, .currencyISOCode, .currencyAccounting, .decimal, .percent, .scientific, .compact, .compactPlural:
             return -1
 
         case .ordinal, .spellOut, .currencyPlural:
@@ -256,7 +258,7 @@ open class NumberFormatter : Formatter {
 
     private func defaultUsesGroupingSeparator() -> Bool {
         switch numberStyle {
-        case .none, .scientific, .spellOut, .ordinal, .currencyPlural:
+        case .none, .scientific, .spellOut, .ordinal, .currencyPlural, .compact, .compactPlural:
             return false
 
         case .decimal, .currency, .percent, .currencyAccounting, .currencyISOCode:
@@ -271,6 +273,22 @@ open class NumberFormatter : Formatter {
 
         case .currency, .currencyISOCode, .currencyAccounting, .decimal, .percent:
             return 3
+
+        case .compact, .compactPlural:
+            // some locales group compactions by 4-digit groups.
+            switch self.locale?.languageCode {
+            case "ko"?, "ja"?:
+                return 4
+            case "zh"?:
+                // "zh" and "zh_Hant" use groups of 4.
+                let script = self.locale?.scriptCode ?? "Hant"
+                if script == "Hant" {
+                    return 4
+                }
+                fallthrough // use 3
+            default:
+                return 3
+            }
         }
     }
 
@@ -283,10 +301,10 @@ open class NumberFormatter : Formatter {
 
     private func defaultFormatWidth() -> Int {
         switch numberStyle {
-        case .ordinal, .spellOut, .currencyPlural:
+        case .ordinal, .spellOut, .currencyPlural, .compactPlural:
             return 0
 
-        case .none, .decimal, .currency, .percent, .scientific, .currencyISOCode, .currencyAccounting:
+        case .none, .decimal, .currency, .percent, .scientific, .currencyISOCode, .currencyAccounting, .compact:
             return -1
         }
     }

--- a/Tests/Foundation/Tests/TestNumberFormatter.swift
+++ b/Tests/Foundation/Tests/TestNumberFormatter.swift
@@ -255,6 +255,102 @@ class TestNumberFormatter: XCTestCase {
         XCTAssertEqual(numberFormatter.secondaryGroupingSize, 0)
     }
 
+    func test_defaultCompactPropertyValues() {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .compact
+        numberFormatter.locale = Locale(identifier: "en_US")
+        XCTAssertEqual(numberFormatter.generatesDecimalNumbers, false)
+        XCTAssertEqual(numberFormatter.localizesFormat, true)
+        XCTAssertEqual(numberFormatter.minimumIntegerDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumIntegerDigits, 0)
+        XCTAssertEqual(numberFormatter.minimumFractionDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumFractionDigits, 2)
+        XCTAssertEqual(numberFormatter.minimumSignificantDigits, -1)
+        XCTAssertEqual(numberFormatter.maximumSignificantDigits, -1)
+        XCTAssertEqual(numberFormatter.usesSignificantDigits, false)
+        XCTAssertEqual(numberFormatter.formatWidth, -1)
+        XCTAssertEqual(numberFormatter.format, "#.##;0;#.##")
+        XCTAssertEqual(numberFormatter.positiveFormat, "#.##")
+        XCTAssertEqual(numberFormatter.negativeFormat, "#.##")
+        XCTAssertNil(numberFormatter.multiplier)
+        XCTAssertFalse(numberFormatter.usesGroupingSeparator)
+        XCTAssertEqual(numberFormatter.groupingSize, 3)
+        XCTAssertEqual(numberFormatter.secondaryGroupingSize, 0)
+    }
+
+    func test_defaultCompactPluralPropertyValues() {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .compactPlural
+        numberFormatter.locale = Locale(identifier: "en_US")
+        XCTAssertEqual(numberFormatter.generatesDecimalNumbers, false)
+        XCTAssertEqual(numberFormatter.localizesFormat, true)
+        XCTAssertEqual(numberFormatter.minimumIntegerDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumIntegerDigits, 0)
+        XCTAssertEqual(numberFormatter.minimumFractionDigits, 0)
+        XCTAssertEqual(numberFormatter.maximumFractionDigits, 2)
+        XCTAssertEqual(numberFormatter.minimumSignificantDigits, -1)
+        XCTAssertEqual(numberFormatter.maximumSignificantDigits, -1)
+        XCTAssertEqual(numberFormatter.usesSignificantDigits, false)
+        XCTAssertEqual(numberFormatter.formatWidth, 0)
+        XCTAssertEqual(numberFormatter.format, "#.##;0;#.##")
+        XCTAssertEqual(numberFormatter.positiveFormat, "#.##")
+        XCTAssertEqual(numberFormatter.negativeFormat, "#.##")
+        XCTAssertNil(numberFormatter.multiplier)
+        XCTAssertFalse(numberFormatter.usesGroupingSeparator)
+        XCTAssertEqual(numberFormatter.groupingSize, 3)
+        XCTAssertEqual(numberFormatter.secondaryGroupingSize, 0)
+    }
+
+    func test_compact() {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.locale = Locale(identifier: "en_US")
+        numberFormatter.numberStyle = .compact
+        XCTAssertEqual(numberFormatter.format, "#.##;0;#.##")
+        XCTAssertEqual(numberFormatter.string(from: 1.1), "1.1")
+        XCTAssertEqual(numberFormatter.string(from: 1100), "1.1K")
+        XCTAssertEqual(numberFormatter.string(from: 1100000), "1.1M");
+        XCTAssertEqual(numberFormatter.string(from: 1100000000), "1.1B");
+        XCTAssertEqual(numberFormatter.string(from: 1100000000000), "1.1T");
+
+        numberFormatter.decimalSeparator = "_";
+        XCTAssertEqual(numberFormatter.string(from: 1.1), "1_1")
+        XCTAssertEqual(numberFormatter.string(from: 1100), "1_1K")
+        XCTAssertEqual(numberFormatter.string(from: 1100000), "1_1M");
+        XCTAssertEqual(numberFormatter.string(from: 1100000000), "1_1B");
+        XCTAssertEqual(numberFormatter.string(from: 1100000000000), "1_1T");
+    }
+
+    func test_compactPlural() {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.locale = Locale(identifier: "en_US")
+        numberFormatter.numberStyle = .compactPlural
+        XCTAssertEqual(numberFormatter.format, "#.##;0;#.##")
+        XCTAssertEqual(numberFormatter.string(from: 1.1), "1.1")
+        XCTAssertEqual(numberFormatter.string(from: 1100), "1.1 thousand")
+        XCTAssertEqual(numberFormatter.string(from: 1100000), "1.1 million");
+        XCTAssertEqual(numberFormatter.string(from: 1100000000), "1.1 billion");
+        XCTAssertEqual(numberFormatter.string(from: 1100000000000), "1.1 trillion");
+
+        numberFormatter.decimalSeparator = "_";
+        XCTAssertEqual(numberFormatter.string(from: 1.1), "1_1")
+        XCTAssertEqual(numberFormatter.string(from: 1100), "1_1 thousand")
+        XCTAssertEqual(numberFormatter.string(from: 1100000), "1_1 million");
+        XCTAssertEqual(numberFormatter.string(from: 1100000000), "1_1 billion");
+        XCTAssertEqual(numberFormatter.string(from: 1100000000000), "1_1 trillion");
+    }
+
+    func test_compactGroupingSizes() {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.locale = Locale(identifier: "en_US")
+        numberFormatter.numberStyle = .compactPlural
+        XCTAssertEqual(numberFormatter.groupingSize, 3)
+
+        for ident in ["ko", "ja", "zh", "zh_Hant"] {
+            numberFormatter.locale = Locale(identifier: ident)
+            XCTAssertEqual(numberFormatter.groupingSize, 4)
+        }
+    }
+
     func test_currencyCode() {
         let numberFormatter = NumberFormatter()
         numberFormatter.locale = Locale(identifier: "en_GB")
@@ -1174,6 +1270,11 @@ class TestNumberFormatter: XCTestCase {
             ("test_defaultCurrencyISOCodePropertyValues", test_defaultCurrencyISOCodePropertyValues),
             ("test_defaultCurrencyPluralPropertyValues", test_defaultCurrencyPluralPropertyValues),
             ("test_defaultCurrenyAccountingPropertyValues", test_defaultCurrenyAccountingPropertyValues),
+            ("test_defaultCompactPropertyValues", test_defaultCompactPropertyValues),
+            ("test_defaultCompactPluralPropertyValues", test_defaultCompactPluralPropertyValues),
+            ("test_compact", test_compact),
+            ("test_compactPlural", test_compactPlural),
+            ("test_compactGroupingSizes", test_compactGroupingSizes),
             ("test_currencyCode", test_currencyCode),
             ("test_decimalSeparator", test_decimalSeparator),
             ("test_currencyDecimalSeparator", test_currencyDecimalSeparator),


### PR DESCRIPTION
Implements compact decimal number formatting in short and long forms.

In **en_US**:

| Input                   | Short Output   | Long Output  |
| ----------------------- | -------------- | ------------ |
| 1000                    | 1K             | 1 thousand   |
| 1100                    | 1.1K           | 1.1 thousand |
| 1_100_000               | 1.1M           | 1.1 million  |
| 1_100_000_000           | 1.1B           | 1.1 billion  |
| 1_100_000_000_000       | 1.1T           | 1.1 trillion |

In **ja_JP** (NB: groups by 4):

| Input                   | Short Output   | Long Output |
| ----------------------- | -------------- | ----------- |
| 10_000                  | 1万            | 1万         |
| 11_000                  | 1.1万          | 1.1万       |
| 110_000_000             | 1.1億          | 1.1億       |
| 1_100_000_000_000       | 1.1兆          | 1.1兆       |

This doesn't match macOS/iOS, but it's something of a glaring omission (especially since I've had to implement it by hand for all locales on top of `NSNumberFormatter` recently). The ICU implementation underneath CoreFoundation provides this support, and CLDR includes all the relevant data. Thus I've made a couple of small changes to enable access to this functionality through `CFNumberFormatter` and `NumberFormatter`. It is my sincere hope that someone at Apple will go "hm, that's interesting," and implement it in macOS 10.16 and so on.

This implementation makes use of the `UNUM_DECIMAL_COMPACT_SHORT` and `UNUM_DECIMAL_COMPACT_LONG` from `unicode/unum.h`. Corresponding constants have been defined for CoreFoundation and Foundation:

| ICU                        | CoreFoundation                              | Foundation                          |
| -------------------------  | ------------------------------------------- | ----------------------------------- |
| UNUM_DECIMAL_COMPACT_SHORT | kCFNumberFormatterDecimalCompactStyle       | NumberFormatter.Style.compact       |
| UNUM_DECIMAL_COMPACT_LONG  | kCFNumberFormatterDecimalCompactPluralStyle | NumberFormatter.Style.compactPlural |

Using these options will have some slight effects on default property values in some cases. In particular, default grouping will be adjusted to match the compaction grouping used by the locale: generally 3 digits, but "ko", "ja", "zh", and "zh_Hant" use 4.

This solution isn't ideal, as it doesn't support compact formats for currency values, only decimals. However, the ICU C API in `unum.h` still uses the old `NumberFormat` and `CompactDecimalFormat` classes under the hood, rather than the newer `NumberFormatter` which properly supports compact number formatting for pretty much everything. I'm not sure how to go about getting that support in place, though; I'm mulling sending a pull request to libicu to update the C API to optionally use `NumberFormatter` internally, or to expose a separate C interface to `NumberFormatter`, which could then be used by CoreFoundation.