### PR TITLE
JSONSerialization: Add support for .withoutEscapingSlashes, .fragmentsAllowed

### DIFF
--- a/Sources/Foundation/JSONEncoder.swift
+++ b/Sources/Foundation/JSONEncoder.swift
@@ -238,15 +238,8 @@ open class JSONEncoder {
             throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: [], debugDescription: "Top-level \(T.self) did not encode any values."))
         }
 
-        if topLevel is NSNull {
-            throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: [], debugDescription: "Top-level \(T.self) encoded as null JSON fragment."))
-        } else if topLevel is NSNumber {
-            throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: [], debugDescription: "Top-level \(T.self) encoded as number JSON fragment."))
-        } else if topLevel is NSString {
-            throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: [], debugDescription: "Top-level \(T.self) encoded as string JSON fragment."))
-        }
+        let writingOptions = JSONSerialization.WritingOptions(rawValue: self.outputFormatting.rawValue).union(.fragmentsAllowed)
 
-        let writingOptions = JSONSerialization.WritingOptions(rawValue: self.outputFormatting.rawValue)
         do {
             return try JSONSerialization.data(withJSONObject: topLevel, options: writingOptions)
         } catch {
@@ -1155,7 +1148,7 @@ open class JSONDecoder {
     open func decode<T : Decodable>(_ type: T.Type, from data: Data) throws -> T {
         let topLevel: Any
         do {
-            topLevel = try JSONSerialization.jsonObject(with: data)
+            topLevel = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
         } catch {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid JSON.", underlyingError: error))
         }

--- a/Sources/Foundation/JSONSerialization.swift
+++ b/Sources/Foundation/JSONSerialization.swift
@@ -25,6 +25,8 @@ extension JSONSerialization {
         
         public static let prettyPrinted = WritingOptions(rawValue: 1 << 0)
         public static let sortedKeys = WritingOptions(rawValue: 1 << 1)
+        public static let fragmentsAllowed = WritingOptions(rawValue: 1 << 2)
+        public static let withoutEscapingSlashes = WritingOptions(rawValue: 1 << 3)
     }
 }
 
@@ -139,8 +141,7 @@ open class JSONSerialization : NSObject {
         var jsonStr = [UInt8]()
         
         var writer = JSONWriter(
-            pretty: opt.contains(.prettyPrinted),
-            sortedKeys: opt.contains(.sortedKeys),
+            options: opt,
             writer: { (str: String?) in
                 if let str = str {
                     jsonStr.append(contentsOf: str.utf8)
@@ -157,7 +158,10 @@ open class JSONSerialization : NSObject {
         } else if let container = value as? Dictionary<AnyHashable, Any> {
             try writer.serializeJSON(container)
         } else {
-            fatalError("Top-level object was not NSArray or NSDictionary") // This is a fatal error in objective-c too (it is an NSInvalidArgumentException)
+            guard opt.contains(.fragmentsAllowed) else {
+                fatalError("Top-level object was not NSArray or NSDictionary") // This is a fatal error in objective-c too (it is an NSInvalidArgumentException)
+            }
+            try writer.serializeJSON(value)
         }
 
         let count = jsonStr.count
@@ -302,11 +306,13 @@ private struct JSONWriter {
     var indent = 0
     let pretty: Bool
     let sortedKeys: Bool
+    let withoutEscapingSlashes: Bool
     let writer: (String?) -> Void
 
-    init(pretty: Bool = false, sortedKeys: Bool = false, writer: @escaping (String?) -> Void) {
-        self.pretty = pretty
-        self.sortedKeys = sortedKeys
+    init(options: JSONSerialization.WritingOptions, writer: @escaping (String?) -> Void) {
+        pretty = options.contains(.prettyPrinted)
+        sortedKeys = options.contains(.sortedKeys)
+        withoutEscapingSlashes = options.contains(.withoutEscapingSlashes)
         self.writer = writer
     }
     
@@ -380,7 +386,8 @@ private struct JSONWriter {
                 case "\\":
                     writer("\\\\") // U+005C reverse solidus
                 case "/":
-                    writer("\\/") // U+002F solidus
+                    if !withoutEscapingSlashes { writer("\\") }
+                    writer("/") // U+002F solidus
                 case "\u{8}":
                     writer("\\b") // U+0008 backspace
                 case "\u{c}":

--- a/Tests/Foundation/Tests/TestJSONSerialization.swift
+++ b/Tests/Foundation/Tests/TestJSONSerialization.swift
@@ -1013,6 +1013,8 @@ extension TestJSONSerialization {
             ("test_serialize_Decimal", test_serialize_Decimal),
             ("test_serialize_NSDecimalNumber", test_serialize_NSDecimalNumber),
             ("test_serialize_stringEscaping", test_serialize_stringEscaping),
+            ("test_serialize_fragments", test_serialize_fragments),
+            ("test_serialize_withoutEscapingSlashes", test_serialize_withoutEscapingSlashes),
             ("test_jsonReadingOffTheEndOfBuffers", test_jsonReadingOffTheEndOfBuffers),
             ("test_jsonObjectToOutputStreamBuffer", test_jsonObjectToOutputStreamBuffer),
             ("test_jsonObjectToOutputStreamFile", test_jsonObjectToOutputStreamFile),
@@ -1369,6 +1371,26 @@ extension TestJSONSerialization {
 
         json = ["j/"]
         XCTAssertEqual(try trySerialize(json), "[\"j\\/\"]")
+    }
+
+    func test_serialize_fragments() {
+        XCTAssertEqual(try trySerialize(2, options: .fragmentsAllowed), "2")
+        XCTAssertEqual(try trySerialize(false, options: .fragmentsAllowed), "false")
+        XCTAssertEqual(try trySerialize(true, options: .fragmentsAllowed), "true")
+        XCTAssertEqual(try trySerialize(Float(1), options: .fragmentsAllowed), "1")
+        XCTAssertEqual(try trySerialize(Double(2), options: .fragmentsAllowed), "2")
+        XCTAssertEqual(try trySerialize(Decimal(Double.leastNormalMagnitude), options: .fragmentsAllowed), "0.0000000000000000000000000000000000000000000000000002225073858507201792")
+        XCTAssertEqual(try trySerialize("test", options: .fragmentsAllowed), "\"test\"")
+    }
+
+    func test_serialize_withoutEscapingSlashes() {
+        // .withoutEscapingSlashes controls whether a "/" is encoded as "\\/" or "/"
+        let testString      = "This /\\/ is a \\ \\\\ \\\\\\ \"string\"\n\r\t\u{0}\u{1}\u{8}\u{c}\u{f}"
+        let escapedString   = "\"This \\/\\\\\\/ is a \\\\ \\\\\\\\ \\\\\\\\\\\\ \\\"string\\\"\\n\\r\\t\\u0000\\u0001\\b\\f\\u000f\""
+        let unescapedString = "\"This /\\\\/ is a \\\\ \\\\\\\\ \\\\\\\\\\\\ \\\"string\\\"\\n\\r\\t\\u0000\\u0001\\b\\f\\u000f\""
+
+        XCTAssertEqual(try trySerialize(testString, options: .fragmentsAllowed), escapedString)
+        XCTAssertEqual(try trySerialize(testString, options: [.withoutEscapingSlashes, .fragmentsAllowed]), unescapedString)
     }
 
     /* These are a programming error and should not be done


### PR DESCRIPTION
Also fixes  SR-12275: JSONEncoder on Linux can't encode number JSON fragments
    
- JSONEncoder now encodes fragments by default to match Darwin.
    
- JSONDecoder now allows fragments when decoding to match Darwin.
  
- Update the following TestJSONEncoder tests now that fragments encode,
  these tests now pass on Darwin:
    
  test_encodingTopLevelSingleValueEnum
  test_encodingTopLevelSingleValueEnum
  test_encodingTopLevelSingleValueClass
