### PR TITLE
[SR-7857] URL.resolvingSymlinksInPath() now recursively resolves symlinks

### DIFF
--- a/Sources/Foundation/FileManager+POSIX.swift
+++ b/Sources/Foundation/FileManager+POSIX.swift
@@ -472,6 +472,9 @@ extension FileManager {
     }
         
     internal func _recursiveDestinationOfSymbolicLink(atPath path: String) throws -> String {
+        // Throw error if path is not a symbolic link:
+        let path = try _destinationOfSymbolicLink(atPath: path)
+        
         let bufSize = Int(PATH_MAX + 1)
         var buf = [Int8](repeating: 0, count: bufSize)
         let _resolvedPath = try _fileSystemRepresentation(withPath: path) {

--- a/Sources/Foundation/FileManager+POSIX.swift
+++ b/Sources/Foundation/FileManager+POSIX.swift
@@ -470,7 +470,20 @@ extension FileManager {
 
         return self.string(withFileSystemRepresentation: buf, length: Int(len))
     }
-    
+        
+    internal func _recursiveDestinationOfSymbolicLink(atPath path: String) throws -> String {
+        let bufSize = Int(PATH_MAX + 1)
+        var buf = [Int8](repeating: 0, count: bufSize)
+        let _resolvedPath = try _fileSystemRepresentation(withPath: path) {
+            realpath($0, &buf)
+        }
+        guard let resolvedPath = _resolvedPath else {
+            throw _NSErrorWithErrno(errno, reading: true, path: path)
+        }
+
+        return String(cString: resolvedPath)
+    }
+
     /* Returns a String with a canonicalized path for the element at the specified path. */
     internal func _canonicalizedPath(toFileAtPath path: String) throws -> String {
         let bufSize = Int(PATH_MAX + 1)

--- a/Sources/Foundation/FileManager+POSIX.swift
+++ b/Sources/Foundation/FileManager+POSIX.swift
@@ -464,7 +464,7 @@ extension FileManager {
             let len = try _fileSystemRepresentation(withPath: path) {
                 readlink($0, buffer.baseAddress, bufferSize)
             }
-            if len < 0 {
+            guard len >= 0 else {
                 throw _NSErrorWithErrno(errno, reading: true, path: path)
             }
             initializedCount = len

--- a/Sources/Foundation/FileManager+POSIX.swift
+++ b/Sources/Foundation/FileManager+POSIX.swift
@@ -462,12 +462,7 @@ extension FileManager {
         let bufferSize = Int(PATH_MAX + 1)
         let buffer = try [Int8](unsafeUninitializedCapacity: bufferSize) { buffer, initializedCount in
             let len = try _fileSystemRepresentation(withPath: path) { (path) -> Int in
-                #if canImport(Darwin)
-                let bufferBaseAddress = buffer.baseAddress
-                #else
-                let bufferBaseAddress = buffer
-                #endif
-                return readlink(path, bufferBaseAddress, bufferSize)
+                return readlink(path, buffer.baseAddress!, bufferSize)
             }
             guard len >= 0 else {
                 throw _NSErrorWithErrno(errno, reading: true, path: path)

--- a/Sources/Foundation/FileManager+Win32.swift
+++ b/Sources/Foundation/FileManager+Win32.swift
@@ -418,7 +418,8 @@ extension FileManager {
     }
     
     internal func _recursiveDestinationOfSymbolicLink(atPath path: String) throws -> String {
-        var previousIterationDestination = _nonThrowingDestinationOfSymbolicLink(atPath: path)
+        // Throw error if path is not a symbolic link:
+        var previousIterationDestination = try _destinationOfSymbolicLink(atPath: path)
         
         // Same recursion limit as in Darwin:
         let symbolicLinkRecursionLimit = 32

--- a/Sources/Foundation/FileManager+Win32.swift
+++ b/Sources/Foundation/FileManager+Win32.swift
@@ -412,6 +412,27 @@ extension FileManager {
         }
         return substitutePath
     }
+    
+    private func _nonThrowingDestinationOfSymbolicLink(atPath path: String) -> String {
+        return (try? _destinationOfSymbolicLink(atPath: path)) ?? path
+    }
+    
+    internal func _recursiveDestinationOfSymbolicLink(atPath path: String) throws -> String {
+        var previousIterationDestination = _nonThrowingDestinationOfSymbolicLink(atPath: path)
+        
+        // Same recursion limit as in Darwin:
+        let symbolicLinkRecursionLimit = 32
+        for _ in 0..<symbolicLinkRecursionLimit {
+            let iterationDestination = _nonThrowingDestinationOfSymbolicLink(atPath: previousIterationDestination)
+            if previousIterationDestination == iterationDestination {
+                return iterationDestination
+            }
+            previousIterationDestination = iterationDestination
+        }
+        
+        // As in Darwin Foundation, after the recursion limit we return the initial path without resolution.
+        return path
+    }
 
     internal func _canonicalizedPath(toFileAtPath path: String) throws -> String {
         let hFile: HANDLE = try FileManager.default._fileSystemRepresentation(withPath: path) {

--- a/Sources/Foundation/FileManager+Win32.swift
+++ b/Sources/Foundation/FileManager+Win32.swift
@@ -413,7 +413,7 @@ extension FileManager {
         return substitutePath
     }
     
-    private func _nonThrowingDestinationOfSymbolicLink(atPath path: String) -> String {
+    private func _realpath(_ path: String) -> String {
         return (try? _destinationOfSymbolicLink(atPath: path)) ?? path
     }
     
@@ -424,7 +424,7 @@ extension FileManager {
         // Same recursion limit as in Darwin:
         let symbolicLinkRecursionLimit = 32
         for _ in 0..<symbolicLinkRecursionLimit {
-            let iterationDestination = _nonThrowingDestinationOfSymbolicLink(atPath: previousIterationDestination)
+            let iterationDestination = _realpath(previousIterationDestination)
             if previousIterationDestination == iterationDestination {
                 return iterationDestination
             }

--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -630,6 +630,10 @@ open class FileManager : NSObject {
     open func destinationOfSymbolicLink(atPath path: String) throws -> String {
         return try _destinationOfSymbolicLink(atPath: path)
     }
+    
+    internal func recursiveDestinationOfSymbolicLink(atPath path: String) throws -> String {
+        return try _recursiveDestinationOfSymbolicLink(atPath: path)
+    }
 
     internal func extraErrorInfo(srcPath: String?, dstPath: String?, userVariant: String?) -> [String : Any] {
         var result = [String : Any]()
@@ -1123,8 +1127,7 @@ open class FileManager : NSObject {
     }
 
     internal func _tryToResolveTrailingSymlinkInPath(_ path: String) -> String? {
-        // destinationOfSymbolicLink(atPath:) will fail if the path is not a symbolic link
-        guard let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: path) else {
+        guard let destination = try? FileManager.default.recursiveDestinationOfSymbolicLink(atPath: path) else {
             return nil
         }
 

--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -1127,7 +1127,8 @@ open class FileManager : NSObject {
     }
 
     internal func _tryToResolveTrailingSymlinkInPath(_ path: String) -> String? {
-        guard let destination = try? FileManager.default.recursiveDestinationOfSymbolicLink(atPath: path) else {
+        // FileManager.recursiveDestinationOfSymbolicLink(atPath:) will fail if the path is not a symbolic link
+        guard let destination = try? self.recursiveDestinationOfSymbolicLink(atPath: path) else {
             return nil
         }
 

--- a/Tests/Foundation/Tests/TestFileManager.swift
+++ b/Tests/Foundation/Tests/TestFileManager.swift
@@ -934,6 +934,83 @@ class TestFileManager : XCTestCase {
         }
         XCTAssertNil(try? fm.linkItem(atPath: srcLink, toPath: destLink), "Creating link where one already exists")
     }
+    
+    func test_resolvingSymlinksInPath() throws {
+        try withTemporaryDirectory { (temporaryDirectoryURL, _) in
+            // Initialization
+            var baseURL = temporaryDirectoryURL
+                .appendingPathComponent("test_resolvingSymlinksInPath")
+                .appendingPathComponent(UUID().uuidString)
+
+            try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
+            let testData = Data([0x01])
+
+            baseURL.resolveSymlinksInPath()
+            baseURL.standardize()
+
+            let link1URL = baseURL.appendingPathComponent("link1")
+            let link2URL = baseURL.appendingPathComponent("link2")
+            let link3URL = baseURL.appendingPathComponent("link3")
+            let testFileURL = baseURL.appendingPathComponent("test").standardized.absoluteURL
+
+            try FileManager.default.removeItem(at: baseURL)
+
+            // A) Check non-symbolic linking resolution
+            try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
+
+            try testData.write(to: testFileURL)
+
+            let resolvedURL_A = testFileURL.resolvingSymlinksInPath().standardized.absoluteURL
+
+            XCTAssertEqual(resolvedURL_A.path, testFileURL.path)
+
+            try FileManager.default.removeItem(at: baseURL)
+
+            // B) Check simple symbolic linking resolution
+            try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
+
+            try testData.write(to: testFileURL)
+
+            try FileManager.default.createSymbolicLink(at: link1URL, withDestinationURL: testFileURL)
+
+            let resolvedURL_B = link1URL.resolvingSymlinksInPath().standardized.absoluteURL
+
+            XCTAssertEqual(resolvedURL_B.path, testFileURL.path)
+
+            try FileManager.default.removeItem(at: baseURL)
+
+            // C) Check recursive symbolic linking resolution
+            try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
+
+            try testData.write(to: testFileURL)
+
+            try FileManager.default.createSymbolicLink(at: link1URL, withDestinationURL: link2URL)
+            try FileManager.default.createSymbolicLink(at: link2URL, withDestinationURL: testFileURL)
+
+            let resolvedURL_C = link1URL.resolvingSymlinksInPath().standardized.absoluteURL
+            XCTAssertEqual(resolvedURL_C.path, testFileURL.path)
+
+            let resolvedURL_NSString_C = NSString(link1URL.path).resolvingSymlinksInPath.standardizePath()
+            XCTAssertEqual(resolvedURL_NSString_C, testFileURL.path)
+
+            // C-2) And that FileManager.destinationOfSymbolicLink(atPath:) does not recursively resolves them
+            let destinationOfSymbolicLink1 = try FileManager.default.destinationOfSymbolicLink(atPath: link1URL.path)
+            XCTAssertEqual(destinationOfSymbolicLink1, link2URL.path)
+
+            try FileManager.default.removeItem(at: baseURL)
+
+            // D) Check infinite recursion loops are stopped and the function returns the intial symlink
+            try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
+
+            try FileManager.default.createSymbolicLink(at: link1URL, withDestinationURL: link2URL)
+            try FileManager.default.createSymbolicLink(at: link2URL, withDestinationURL: link3URL)
+            try FileManager.default.createSymbolicLink(at: link3URL, withDestinationURL: link1URL)
+
+            let resolvedURL_D = link1URL.resolvingSymlinksInPath()
+
+            XCTAssertEqual(resolvedURL_D.lastPathComponent, link1URL.lastPathComponent)
+        }
+    }
 
     func test_homedirectoryForUser() {
         let filemanger = FileManager.default
@@ -1800,6 +1877,7 @@ VIDEOS=StopgapVideos
             ("test_subpathsOfDirectoryAtPath", test_subpathsOfDirectoryAtPath),
             ("test_copyItemAtPathToPath", test_copyItemAtPathToPath),
             ("test_linkItemAtPathToPath", testExpectedToFailOnAndroid(test_linkItemAtPathToPath, "Android doesn't allow hard links")),
+            ("test_resolvingSymlinksInPath", test_resolvingSymlinksInPath),
             ("test_homedirectoryForUser", test_homedirectoryForUser),
             ("test_temporaryDirectoryForUser", test_temporaryDirectoryForUser),
             ("test_creatingDirectoryWithShortIntermediatePath", test_creatingDirectoryWithShortIntermediatePath),


### PR DESCRIPTION
URL.resolvingSymlinksInPath() now recursively resolves symlinks as in Darwin.