### PR TITLE
feat: support three different formats

### DIFF
--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
@@ -239,34 +239,31 @@ internal class _HTTPURLProtocol: _NativeProtocol {
         return true
     }
     
-    static let dateFormatter: DateFormatter = {
-        let x = DateFormatter()
-        return x
-    }()
-    
-    static func date(from string: String) -> Date? {
+    static let dateFormatters: [DateFormatter] = {
         // https://tools.ietf.org/html/rfc2616#section-3.3.1
         // HTTP applications have historically allowed three different formats
         // for the representation of date/time stamps
         
         // RCF 822 --- Sun, 06 Nov 1994 08:49:37 GMT
-        self.dateFormatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
-        if let d1 = self.dateFormatter.date(from: string) {
-            return d1
-        }
+        let d1 = DateFormatter()
+        d1.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
         
         // RCF 855 --- Sunday, 06-Nov-94 08:49:37 GMT
-        self.dateFormatter.dateFormat = "EEEE, dd-MMM-yy HH:mm:ss zzz"
-        if let d2 = self.dateFormatter.date(from: string) {
-            return d2
-        }
+        let d2 = DateFormatter()
+        d2.dateFormat = "EEEE, dd-MMM-yy HH:mm:ss zzz"
         
         // ANSI C's asctime() format --- Sun Nov  6 08:49:37 1994
-        self.dateFormatter.dateFormat = "EEE MMM dd HH:mm:ss yy"
-        if let d3 = self.dateFormatter.date(from: string) {
-            return d3
+        let d3 = DateFormatter()
+        d3.dateFormat = "EEE MMM dd HH:mm:ss yy"
+        return [d1, d2, d3]
+    }()
+    
+    static func date(from string: String) -> Date? {
+        for dateFormat in self.dateFormatters {
+            if let d = dateFormat.date(from: string) {
+                return d
+            }
         }
-        
         return nil
     }
     

--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
@@ -119,7 +119,7 @@ internal class _HTTPURLProtocol: _NativeProtocol {
         let expirationStart: Date
         
         if let dateString = httpResponse.allHeaderFields["Date"] as? String,
-           let date = _HTTPURLProtocol.dateFormatter.date(from: dateString) {
+           let date = _HTTPURLProtocol.date(from: dateString) {
             expirationStart = min(date, response.date) // Do not accept a date in the future of the point where we stored it, or of now if we haven't stored it yet. That is: a Date header can only make a response expire _faster_ than if it was issued now, and can't be used to prolong its age.
         } else {
             expirationStart = response.date
@@ -221,7 +221,7 @@ internal class _HTTPURLProtocol: _NativeProtocol {
         // We should not cache a response that has already expired. (This is also the expiration check for canRespondFromCaching(using:) below.)
         // We MUST ignore this if we have Cache-Control: max-age or s-maxage.
         if !hasMaxAge, let expires = httpResponse.allHeaderFields["Expires"] as? String {
-            guard let expiration = _HTTPURLProtocol.dateFormatter.date(from: expires) else {
+            guard let expiration = _HTTPURLProtocol.date(from: expires) else {
                 // From the spec:
                 /* "A cache recipient MUST interpret invalid date formats, especially the
                  value "0", as representing a time in the past (i.e., 'already
@@ -241,10 +241,34 @@ internal class _HTTPURLProtocol: _NativeProtocol {
     
     static let dateFormatter: DateFormatter = {
         let x = DateFormatter()
-        x.locale = NSLocale.system
-        x.dateFormat = "EEE',' dd' 'MMM' 'yyyy HH':'mm':'ss zzz"
         return x
     }()
+    
+    static func date(from string: String) -> Date? {
+        // https://tools.ietf.org/html/rfc2616#section-3.3.1
+        // HTTP applications have historically allowed three different formats
+        // for the representation of date/time stamps
+        
+        // RCF 822 --- Sun, 06 Nov 1994 08:49:37 GMT
+        self.dateFormatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        if let d1 = self.dateFormatter.date(from: string) {
+            return d1
+        }
+        
+        // RCF 855 --- Sunday, 06-Nov-94 08:49:37 GMT
+        self.dateFormatter.dateFormat = "EEEE, dd-MMM-yy HH:mm:ss zzz"
+        if let d2 = self.dateFormatter.date(from: string) {
+            return d2
+        }
+        
+        // ANSI C's asctime() format --- Sun Nov  6 08:49:37 1994
+        self.dateFormatter.dateFormat = "EEE MMM dd HH:mm:ss yy"
+        if let d3 = self.dateFormatter.date(from: string) {
+            return d3
+        }
+        
+        return nil
+    }
     
     override func canRespondFromCache(using response: CachedURLResponse) -> Bool {
         // If somehow cached a response that shouldn't have been, we should remove it.
@@ -461,7 +485,7 @@ fileprivate extension _HTTPURLProtocol {
     func curlHeaders(for httpHeaders: [AnyHashable : Any]?) -> [String] {
         var result: [String] = []
         var names = Set<String>()
-	if let hh = httpHeaders as? [String : String] {
+    if let hh = httpHeaders as? [String : String] {
             hh.forEach {
                 let name = $0.0.lowercased()
                 guard !names.contains(name) else { return }


### PR DESCRIPTION
This PR solves a bug and adds a feature
* unable to process Date field in header
* according the RCF 3.3.1 description, support three different formats (https://tools.ietf.org/html/rfc2616#section-3.3.1)

![image](https://user-images.githubusercontent.com/6263633/76329056-05c6a400-6327-11ea-8c43-b19c4ee651bf.png)

### old code screenshot
![image](https://user-images.githubusercontent.com/6263633/76329248-48887c00-6327-11ea-88bc-42a42adcc5a3.png)


### new code screenshot
![image](https://user-images.githubusercontent.com/6263633/76329389-78378400-6327-11ea-9296-450848a3d729.png)
