### PR TITLE
Fix TestURLSession.test_noDoubleCallbackWhenCancellingAndProtocolFailsFast()

### DIFF
--- a/Tests/Foundation/Tests/TestURLSession.swift
+++ b/Tests/Foundation/Tests/TestURLSession.swift
@@ -1004,7 +1004,7 @@ class TestURLSession : LoopbackServerTest {
             callbackCount += 1
             XCTAssertNotNil(error)
             if let urlError = error as? URLError {
-                XCTAssertNotEqual(urlError._nsError.code, NSURLErrorCancelled)
+                XCTAssertEqual(urlError._nsError.code, NSURLErrorCancelled)
             }
 
             if callbackCount == 1 {
@@ -1403,6 +1403,10 @@ class FailFastProtocol: URLProtocol {
 
     override class func canInit(with request: URLRequest) -> Bool {
         return request.url?.scheme == "failfast"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
     }
 
     override class func canInit(with task: URLSessionTask) -> Bool {


### PR DESCRIPTION
- Darwin requires implementation of FailFastProtocol.canonicalRequest()
  to override abstract method in URLProtocol

- Fix the error code from in the callback to be equal to NSURLErrorCancelled.

- This test now passes on Darwin and Linux but is currently left disabled.