### PR TITLE
URLSession: Fix InputStream usage

### DIFF
--- a/Sources/FoundationNetworking/URLSession/BodySource.swift
+++ b/Sources/FoundationNetworking/URLSession/BodySource.swift
@@ -66,6 +66,8 @@ internal final class _BodyStreamSource {
     let inputStream: InputStream
     
     init(inputStream: InputStream) {
+        assert(inputStream.streamStatus == .notOpen)
+        inputStream.open()
         self.inputStream = inputStream
     }
 }


### PR DESCRIPTION
- When passing a stream to a URLSession delegate, the stream must not
  be open(). It is opened by the underlying URLSession.

- This makes usage of InputStreams compatible with Darwin.