### PR TITLE
SR-12336: URLSessionTask should allow extras resume()'s

### DIFF
--- a/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
@@ -438,8 +438,7 @@ open class URLSessionTask : NSObject, NSCopying {
     open func resume() {
         workQueue.sync {
             guard self.state != .canceling && self.state != .completed else { return }
-            self.suspendCount -= 1
-            guard 0 <= self.suspendCount else { fatalError("Resuming a task that's not suspended. Calls to resume() / suspend() need to be matched.") }
+            if self.suspendCount > 0 { self.suspendCount -= 1 }
             self.updateTaskState()
             if self.suspendCount == 0 {
                 self.hasTriggeredResume = true

--- a/Tests/Foundation/Tests/TestURLSession.swift
+++ b/Tests/Foundation/Tests/TestURLSession.swift
@@ -272,6 +272,44 @@ class TestURLSession : LoopbackServerTest {
         d.cancel()
         waitForExpectations(timeout: 12)
     }
+
+    func test_suspendResumeTask() throws {
+        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/get"
+        let url = try XCTUnwrap(URL(string: urlString))
+
+        let expect = expectation(description: "GET \(urlString)")
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+             guard let httpResponse = response as? HTTPURLResponse else {
+                XCTFail("response (\(response.debugDescription)) invalid")
+                return
+            }
+            if httpResponse.statusCode == 200 {
+                expect.fulfill()
+            }
+        }
+
+        // The task starts suspended (1) so this requires 1 extra resume to perform the task
+        task.suspend()                          // 2
+        XCTAssertEqual(task.state, .suspended)
+        task.suspend()                          // 3
+        XCTAssertEqual(task.state, .suspended)
+
+        task.resume()                           // 2
+        XCTAssertEqual(task.state, .suspended)  // Darwin reports this as .running even though the task hasnt actually resumed
+        task.resume()                           // 1
+        XCTAssertEqual(task.state, .suspended)  // Darwin reports this as .running even though the task hasnt actually resumed
+
+        task.resume()                           // 0 - Task can run
+        XCTAssertEqual(task.state, .running)
+
+        task.resume()                           // -1
+        XCTAssertEqual(task.state, .running)
+        task.resume()                           // -2
+        XCTAssertEqual(task.state, .running)
+
+        waitForExpectations(timeout: 3)
+    }
+
     
     func test_verifyRequestHeaders() {
         let config = URLSessionConfiguration.default
@@ -1095,6 +1133,7 @@ class TestURLSession : LoopbackServerTest {
             ("test_taskError", test_taskError),
             ("test_taskCopy", test_taskCopy),
             ("test_cancelTask", test_cancelTask),
+            ("test_suspendResumeTask", test_suspendResumeTask),
             ("test_taskTimeout", test_taskTimeout),
             ("test_verifyRequestHeaders", test_verifyRequestHeaders),
             ("test_verifyHttpAdditionalHeaders", test_verifyHttpAdditionalHeaders),


### PR DESCRIPTION
- Every .suspend() has to be balanced with a .resume() to resume a task
  but multiple suspend()s or resume()s are allowed, so remove the check
  that the suspend count was not going < 0.

- Enhance the test HTTPServer by adding /get, /post, /put URLs that
  require the HTTP method to match the endpoint and return the headers
  as a JSON body.