### PR TITLE
SR-12211: URLSession doesn't add Content-Length to empty body requests

### DIFF
--- a/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
@@ -191,16 +191,16 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
         // If everything went well, we will simply forward the resulting data
         // to the delegate. But in case of redirects etc. we might send another
         // request.
+        guard error == nil else {
+            internalState = .transferFailed
+            failWith(error: error!, request: request)
+            return
+        }
         guard case .transferInProgress(let ts) = internalState else {
             fatalError("Transfer completed, but it wasn't in progress.")
         }
         guard let request = task?.currentRequest else {
             fatalError("Transfer completed, but there's no current request.")
-        }
-        guard error == nil else {
-            internalState = .transferFailed
-            failWith(error: error!, request: request)
-            return
         }
 
         if let response = task?.response {

--- a/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
@@ -245,7 +245,7 @@ open class URLSessionTask : NSObject, NSCopying {
         } else if let bodyStream = request.httpBodyStream {
             self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: _Body.stream(bodyStream))
         } else {
-            self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: .none)
+            self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: nil)
         }
     }
     internal init(session: URLSession, request: URLRequest, taskIdentifier: Int, body: _Body?) {


### PR DESCRIPTION
- For all methods except GET, if the request _Body is .none then
  set a length of 0. This will add a "Content-Length: 0" header.

- Fail any GET requests with a body, to match Darwin.