### PR TITLE
SR-10652: URLProtocolClient.urlProtocolDidFinishLoading crashes with no response

### DIFF
--- a/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
@@ -782,7 +782,7 @@ extension _ProtocolClient : URLProtocolClient {
     func urlProtocolDidFinishLoading(_ urlProtocol: URLProtocol) {
         guard let task = urlProtocol.task else { fatalError() }
         guard let session = task.session as? URLSession else { fatalError() }
-        guard let urlResponse = task.response else { fatalError("No response") }
+        let urlResponse = task.response
         if let response = urlResponse as? HTTPURLResponse, response.statusCode == 401 {
             if let protectionSpace = createProtectionSpace(response) {
 


### PR DESCRIPTION
- urlProtocolDidFinishLoading may be called without a response being set
  if the protocol needs to early abort, so remove the check for a valid
  response.