### PR TITLE
SR-12135: Data(contentsOf:) does not account for failed HTTP response codes.

### DIFF
--- a/Tests/Foundation/HTTPServer.swift
+++ b/Tests/Foundation/HTTPServer.swift
@@ -716,7 +716,11 @@ public class TestURLSessionServer {
                                  bodyData: helloWorld)
         }
 
-        return _HTTPResponse(response: .OK, body: capitals[String(uri.dropFirst())]!)
+        guard let capital = capitals[String(uri.dropFirst())] else {
+            return _HTTPResponse(response: .NOTFOUND, body: "Not Found")
+        }
+        return _HTTPResponse(response: .OK, body: capital)
+
     }
 }
 

--- a/Tests/Foundation/Tests/TestNSData.swift
+++ b/Tests/Foundation/Tests/TestNSData.swift
@@ -1517,13 +1517,44 @@ extension TestNSData {
 #endif
     }
 
-    func test_contentsOfURL() {
-        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/country.txt"
-        let url = URL(string: urlString)!
-        let contents = NSData(contentsOf: url)
-        XCTAssertNotNil(contents)
-        if let contents = contents {
-            XCTAssertTrue(contents.length > 0)
+    func test_contentsOfURL() throws {
+        do {
+            let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/country.txt"
+            let url = try XCTUnwrap(URL(string: urlString))
+            let contents = NSData(contentsOf: url)
+            XCTAssertNotNil(contents)
+            if let contents = contents {
+                XCTAssertTrue(contents.length > 0)
+            }
+        }
+
+        do {
+            let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/NotFound"
+            let url = try XCTUnwrap(URL(string: urlString))
+            XCTAssertNil(NSData(contentsOf: url))
+            do {
+                _ = try NSData(contentsOf: url, options: [])
+                XCTFail("NSData(contentsOf:options: did not throw")
+            } catch let error as NSError {
+                if let nserror = error as? NSError {
+                    XCTAssertEqual(NSCocoaErrorDomain, nserror.domain)
+                    XCTAssertEqual(CocoaError.fileReadUnknown.rawValue, nserror.code)
+                } else {
+                    XCTFail("Not an NSError")
+                }
+            }
+
+            do {
+                _ = try Data(contentsOf: url)
+                XCTFail("Data(contentsOf:options: did not throw")
+            } catch let error as NSError {
+                if let nserror = error as? NSError {
+                    XCTAssertEqual(NSCocoaErrorDomain, nserror.domain)
+                    XCTAssertEqual(CocoaError.fileReadUnknown.rawValue, nserror.code)
+                } else {
+                    XCTFail("Not an NSError")
+                }
+            }
         }
     }
 


### PR DESCRIPTION
- _NSNonfileURLContentLoader.contentsOf(url:) Only return the body
  response for certain HTTP codes, for others throw an error.