### PR TITLE
URLSession: Fix redirection response handling

### DIFF
--- a/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
@@ -102,6 +102,13 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
         if let response = validateHeaderComplete(transferState:ts) {
             ts.response = response
         }
+
+        // Note this excludes code 300 which should return the response of the redirect and not follow it.
+        // For other redirect codes dont notify the delegate of the data received in the redirect response.
+        if let httpResponse = ts.response as? HTTPURLResponse, 301...308 ~= httpResponse.statusCode {
+            return .proceed
+        }
+
         notifyDelegate(aboutReceivedData: data)
         internalState = .transferInProgress(ts.byAppending(bodyData: data))
         return .proceed


### PR DESCRIPTION
- 300 Multiple Choices: Do not follow the redirect, just return the body
  from the response. However HEAD requests return no body.

- 301 Moved Permanently, 302 Found: Follow the redirect but send POST
  requests as GET when following the redirect.

- 303 See Other: Follow the redirect but always send the request to the
  new Location as a GET.

- 304 Not Modified: No special handling or redirects to follow since the
  server decides whether to send a response based on the request headers
  If-Modified-Since or If-None-Match.

- 305 Use Proxy, 306 Switch Proxy, 307 Temporary Redirect,
  308 Permanent Redirect:
  Follow the redirection but do not change the method, just repeat the
  request to the new location.

- This fix applies for valid redirections in the range 300-308, other
  3xx codes have no specific support.

- Redirection handling should now match Darwin more closely.

  Resolves SR-2679: URLSession delivers redirection delegate methods
                    in the wrong order.
          SR-11673: URLSession download task merges redirect responses.