### PR TITLE
build: add a compatibility shim for 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ enable_testing()
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL" CACHE
   STRING "MSVC Runtime Library")
 if(CMAKE_VERSION VERSION_LESS 3.16.0)
+  cmake_initialize_per_config_variable(CMAKE_Swift_FLAGS "Swift Compiler Flags")
   if(NOT (CMAKE_SYSTEM_NAME STREQUAL Windows OR CMAKE_SYSTEM_NAME STREQUAL Darwin))
     set(CMAKE_SHARED_LIBRARY_RUNTIME_Swift_FLAG "-Xlinker -rpath -Xlinker ")
     set(CMAKE_SHARED_LIBRARY_RUNTIME_Swift_FLAG_SEP ":")


### PR DESCRIPTION
The default flags were not handled properly when using CMake 3.15.  This
adds a shim for CMake 3.15 to provide a targeted fix for a regression
caused by Foundation being built unoptimized even in release mode.