### PR TITLE
Revert "Revert "URLSession: Fix redirection response handling""

### DIFF
--- a/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
@@ -102,6 +102,13 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
         if let response = validateHeaderComplete(transferState:ts) {
             ts.response = response
         }
+
+        // Note this excludes code 300 which should return the response of the redirect and not follow it.
+        // For other redirect codes dont notify the delegate of the data received in the redirect response.
+        if let httpResponse = ts.response as? HTTPURLResponse, 301...308 ~= httpResponse.statusCode {
+            return .proceed
+        }
+
         notifyDelegate(aboutReceivedData: data)
         internalState = .transferInProgress(ts.byAppending(bodyData: data))
         return .proceed


### PR DESCRIPTION
Reverts apple/swift-corelibs-foundation#2746

I think that this change was incorrectly flagged as the cause.  Lets get this un-reverted and tested to prepare for restoration.