### PR TITLE
Add kilopound per square inch (ksi) and megapound per square inch to UnitPressure

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -449,6 +449,7 @@
 		E1A03F361C4828650023AF4D /* PropertyList-1.0.dtd in Resources */ = {isa = PBXBuildFile; fileRef = E1A03F351C4828650023AF4D /* PropertyList-1.0.dtd */; };
 		E1A03F381C482C730023AF4D /* NSXMLDTDTestData.xml in Resources */ = {isa = PBXBuildFile; fileRef = E1A03F371C482C730023AF4D /* NSXMLDTDTestData.xml */; };
 		E1A3726F1C31EBFB0023AF4D /* NSXMLDocumentTestData.xml in Resources */ = {isa = PBXBuildFile; fileRef = E1A3726E1C31EBFB0023AF4D /* NSXMLDocumentTestData.xml */; };
+		E5D8723824324D9C002AA44F /* TestUnitPressure.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D8723724324D9C002AA44F /* TestUnitPressure.swift */; };
 		EA01AAEC1DA839C4008F4E07 /* TestProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA01AAEB1DA839C4008F4E07 /* TestProgress.swift */; };
 		EA0812691DA71C8A00651B70 /* ProgressFraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0812681DA71C8A00651B70 /* ProgressFraction.swift */; };
 		EA418C261D57257D005EAD0D /* NSKeyedArchiverHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA418C251D57257D005EAD0D /* NSKeyedArchiverHelpers.swift */; };
@@ -1159,6 +1160,7 @@
 		E1A03F351C4828650023AF4D /* PropertyList-1.0.dtd */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "PropertyList-1.0.dtd"; sourceTree = "<group>"; };
 		E1A03F371C482C730023AF4D /* NSXMLDTDTestData.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = NSXMLDTDTestData.xml; sourceTree = "<group>"; };
 		E1A3726E1C31EBFB0023AF4D /* NSXMLDocumentTestData.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = NSXMLDocumentTestData.xml; sourceTree = "<group>"; };
+		E5D8723724324D9C002AA44F /* TestUnitPressure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUnitPressure.swift; sourceTree = "<group>"; };
 		E876A73D1C1180E000F279EC /* TestNSRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSRange.swift; sourceTree = "<group>"; };
 		EA01AAEB1DA839C4008F4E07 /* TestProgress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestProgress.swift; sourceTree = "<group>"; };
 		EA0812681DA71C8A00651B70 /* ProgressFraction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressFraction.swift; sourceTree = "<group>"; };
@@ -1872,6 +1874,7 @@
 				84BA558D1C16F90900F48C54 /* TestTimeZone.swift */,
 				3E55A2321F52463B00082000 /* TestUnit.swift */,
 				CC5249BF1D341D23007CB54D /* TestUnitConverter.swift */,
+				E5D8723724324D9C002AA44F /* TestUnitPressure.swift */,
 				5D0E1BDA237A1FE800C35C5A /* TestUnitVolume.swift */,
 				EA66F6431BF1619600136161 /* TestURL.swift */,
 				1581706222B1A29100348861 /* TestURLCache.swift */,
@@ -3082,6 +3085,7 @@
 				5B13B3381C582D4C00651CE2 /* TestNotificationQueue.swift in Sources */,
 				CC5249C01D341D23007CB54D /* TestUnitConverter.swift in Sources */,
 				5B13B3331C582D4C00651CE2 /* TestJSONSerialization.swift in Sources */,
+				E5D8723824324D9C002AA44F /* TestUnitPressure.swift in Sources */,
 				5B13B33C1C582D4C00651CE2 /* TestNSOrderedSet.swift in Sources */,
 				90E645DF1E4C89A400D0D47C /* TestNSCache.swift in Sources */,
 				5B13B34A1C582D4C00651CE2 /* TestURL.swift in Sources */,

--- a/Sources/Foundation/Unit.swift
+++ b/Sources/Foundation/Unit.swift
@@ -1757,6 +1757,7 @@ public final class UnitPressure : Dimension {
         static let millimetersOfMercury         = "mmHg"
         static let poundsForcePerSquareInch     = "psi"
         static let kilopoundsForcePerSquareInch = "ksi"
+        static let megapoundsForcePerSquareInch = "Mpsi"
     }
     
     private struct Coefficient {
@@ -1769,8 +1770,9 @@ public final class UnitPressure : Dimension {
         static let bars                         = 1e5
         static let millibars                    = 1e2
         static let millimetersOfMercury         = 133.322
-        static let poundsForcePerSquareInch     = 6894.76
+        static let poundsForcePerSquareInch     = 689476e-2
         static let kilopoundsForcePerSquareInch = 689476e1
+        static let megapoundsForcePerSquareInch = 689476e4
     }
     
     private convenience init(symbol: String, coefficient: Double) {
@@ -1842,7 +1844,13 @@ public final class UnitPressure : Dimension {
             return UnitPressure(symbol: Symbol.kilopoundsForcePerSquareInch, coefficient: Coefficient.kilopoundsForcePerSquareInch)
         }
     }
-    
+
+    public class var megapoundsForcePerSquareInch: UnitPressure {
+        get {
+            return UnitPressure(symbol: Symbol.megapoundsForcePerSquareInch, coefficient: Coefficient.megapoundsForcePerSquareInch)
+        }
+    }
+
     public override class func baseUnit() -> UnitPressure {
         return .newtonsPerMetersSquared
     }

--- a/Sources/Foundation/Unit.swift
+++ b/Sources/Foundation/Unit.swift
@@ -1746,29 +1746,31 @@ public final class UnitPressure : Dimension {
      */
     
     private struct Symbol {
-        static let newtonsPerMetersSquared  = "N/m²"
-        static let gigapascals              = "GPa"
-        static let megapascals              = "MPa"
-        static let kilopascals              = "kPa"
-        static let hectopascals             = "hPa"
-        static let inchesOfMercury          = "inHg"
-        static let bars                     = "bar"
-        static let millibars                = "mbar"
-        static let millimetersOfMercury     = "mmHg"
-        static let poundsForcePerSquareInch = "psi"
+        static let newtonsPerMetersSquared      = "N/m²"
+        static let gigapascals                  = "GPa"
+        static let megapascals                  = "MPa"
+        static let kilopascals                  = "kPa"
+        static let hectopascals                 = "hPa"
+        static let inchesOfMercury              = "inHg"
+        static let bars                         = "bar"
+        static let millibars                    = "mbar"
+        static let millimetersOfMercury         = "mmHg"
+        static let poundsForcePerSquareInch     = "psi"
+        static let kilopoundsForcePerSquareInch = "ksi"
     }
     
     private struct Coefficient {
-        static let newtonsPerMetersSquared  = 1.0
-        static let gigapascals              = 1e9
-        static let megapascals              = 1e6
-        static let kilopascals              = 1e3
-        static let hectopascals             = 1e2
-        static let inchesOfMercury          = 3386.39
-        static let bars                     = 1e5
-        static let millibars                = 1e2
-        static let millimetersOfMercury     = 133.322
-        static let poundsForcePerSquareInch = 6894.76
+        static let newtonsPerMetersSquared      = 1.0
+        static let gigapascals                  = 1e9
+        static let megapascals                  = 1e6
+        static let kilopascals                  = 1e3
+        static let hectopascals                 = 1e2
+        static let inchesOfMercury              = 3386.39
+        static let bars                         = 1e5
+        static let millibars                    = 1e2
+        static let millimetersOfMercury         = 133.322
+        static let poundsForcePerSquareInch     = 6894.76
+        static let kilopoundsForcePerSquareInch = 689476e1
     }
     
     private convenience init(symbol: String, coefficient: Double) {
@@ -1832,6 +1834,12 @@ public final class UnitPressure : Dimension {
     public class var poundsForcePerSquareInch: UnitPressure {
         get {
             return UnitPressure(symbol: Symbol.poundsForcePerSquareInch, coefficient: Coefficient.poundsForcePerSquareInch)
+        }
+    }
+
+    public class var kilopoundsForcePerSquareInch: UnitPressure {
+        get {
+            return UnitPressure(symbol: Symbol.kilopoundsForcePerSquareInch, coefficient: Coefficient.kilopoundsForcePerSquareInch)
         }
     }
     

--- a/Tests/Foundation/Tests/TestUnitConverter.swift
+++ b/Tests/Foundation/Tests/TestUnitConverter.swift
@@ -217,6 +217,7 @@ class TestUnitConverter: XCTestCase {
         XCTAssertEqual(testIdentity(UnitPressure.millibars), 1, accuracy: delta)
         XCTAssertEqual(testIdentity(UnitPressure.millimetersOfMercury), 1, accuracy: delta)
         XCTAssertEqual(testIdentity(UnitPressure.poundsForcePerSquareInch), 1, accuracy: delta)
+        XCTAssertEqual(testIdentity(UnitPressure.kilopoundsForcePerSquareInch), 1, accuracy: delta)
 
         XCTAssertEqual(testIdentity(UnitSpeed.metersPerSecond), 1, accuracy: delta)
         XCTAssertEqual(testIdentity(UnitSpeed.kilometersPerHour), 1, accuracy: delta)

--- a/Tests/Foundation/Tests/TestUnitConverter.swift
+++ b/Tests/Foundation/Tests/TestUnitConverter.swift
@@ -218,6 +218,7 @@ class TestUnitConverter: XCTestCase {
         XCTAssertEqual(testIdentity(UnitPressure.millimetersOfMercury), 1, accuracy: delta)
         XCTAssertEqual(testIdentity(UnitPressure.poundsForcePerSquareInch), 1, accuracy: delta)
         XCTAssertEqual(testIdentity(UnitPressure.kilopoundsForcePerSquareInch), 1, accuracy: delta)
+        XCTAssertEqual(testIdentity(UnitPressure.megapoundsForcePerSquareInch), 1, accuracy: delta)
 
         XCTAssertEqual(testIdentity(UnitSpeed.metersPerSecond), 1, accuracy: delta)
         XCTAssertEqual(testIdentity(UnitSpeed.kilometersPerHour), 1, accuracy: delta)

--- a/Tests/Foundation/Tests/TestUnitPressure.swift
+++ b/Tests/Foundation/Tests/TestUnitPressure.swift
@@ -1,0 +1,41 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+class TestUnitPressure: XCTestCase {
+    func testMetricPressureConversions() {
+        let newtonsPerMetersSquared = Measurement(value: 4_010, unit: UnitPressure.newtonsPerMetersSquared)
+        XCTAssertEqual(newtonsPerMetersSquared, Measurement(value: 40.1, unit: UnitPressure.hectopascals), "Conversion from newtonsPerMetersSquared to hectopascals")
+        XCTAssertEqual(newtonsPerMetersSquared, Measurement(value: 40.1, unit: UnitPressure.millibars), "Conversion from newtonsPerMetersSquared to millibars")
+
+        let hectopascals = Measurement(value: 5_020, unit: UnitPressure.hectopascals)
+        XCTAssertEqual(hectopascals, Measurement(value: 502, unit: UnitPressure.kilopascals), "Conversion from hectopascals to kilopascals")
+
+        let kilopascals = Measurement(value: 6_030, unit: UnitPressure.kilopascals)
+        XCTAssertEqual(kilopascals, Measurement(value: 6.03, unit: UnitPressure.megapascals), "Conversion from kilopascals to megapascals")
+
+        let megapascals = Measurement(value: 7_040, unit: UnitPressure.megapascals)
+        XCTAssertEqual(megapascals, Measurement(value: 7.04, unit: UnitPressure.gigapascals), "Conversion from megapascals to gigapascals")
+
+        let millibars = Measurement(value: 8_000, unit: UnitPressure.millibars)
+        XCTAssertEqual(millibars, Measurement(value: 8, unit: UnitPressure.bars), "Conversion from millibars to bars")
+        XCTAssertEqual(millibars.converted(to: .millimetersOfMercury).value, 6_000.51, accuracy: 0.001, "Conversion from millibars to millimetersOfMercury")
+
+    }
+
+    func testMetricToImperialPressureConversion() {
+        let newtonsPerMetersSquared = Measurement(value: 1_000_000, unit: UnitPressure.newtonsPerMetersSquared)
+        XCTAssertEqual(newtonsPerMetersSquared.converted(to: .poundsForcePerSquareInch).value, 145.037, accuracy: 0.001, "Conversion from newtonsPerMetersSquared to poundsForcePerSquareInch")
+    }
+
+    static let allTests = [
+        ("testMetricPressureConversions", testMetricPressureConversions),
+        ("testMetricToImperialPressureConversion", testMetricToImperialPressureConversion),
+    ]
+}
+

--- a/Tests/Foundation/Tests/TestUnitPressure.swift
+++ b/Tests/Foundation/Tests/TestUnitPressure.swift
@@ -33,9 +33,15 @@ class TestUnitPressure: XCTestCase {
         XCTAssertEqual(newtonsPerMetersSquared.converted(to: .poundsForcePerSquareInch).value, 145.037, accuracy: 0.001, "Conversion from newtonsPerMetersSquared to poundsForcePerSquareInch")
     }
 
+    func testImperialPressureConversion() {
+        let poundsForcePerSquareInch = Measurement(value: 1_000, unit: UnitPressure.poundsForcePerSquareInch)
+        XCTAssertEqual(poundsForcePerSquareInch, Measurement(value: 1, unit: UnitPressure.kilopoundsForcePerSquareInch), "Conversion from poundsForcePerSquareInch to kilopoundsForcePerSquareInch")
+    }
+
     static let allTests = [
         ("testMetricPressureConversions", testMetricPressureConversions),
         ("testMetricToImperialPressureConversion", testMetricToImperialPressureConversion),
+        ("testImperialPressureConversion", testImperialPressureConversion)
     ]
 }
 

--- a/Tests/Foundation/Tests/TestUnitPressure.swift
+++ b/Tests/Foundation/Tests/TestUnitPressure.swift
@@ -36,6 +36,9 @@ class TestUnitPressure: XCTestCase {
     func testImperialPressureConversion() {
         let poundsForcePerSquareInch = Measurement(value: 1_000, unit: UnitPressure.poundsForcePerSquareInch)
         XCTAssertEqual(poundsForcePerSquareInch, Measurement(value: 1, unit: UnitPressure.kilopoundsForcePerSquareInch), "Conversion from poundsForcePerSquareInch to kilopoundsForcePerSquareInch")
+
+        let kilopoundsForcePerSquareInch = Measurement(value: 2_000, unit: UnitPressure.kilopoundsForcePerSquareInch)
+        XCTAssertEqual(kilopoundsForcePerSquareInch, Measurement(value: 2, unit: UnitPressure.megapoundsForcePerSquareInch), "Conversion from kilopoundsForcePerSquareInch to megapoundsForcePerSquareInch")
     }
 
     static let allTests = [

--- a/Tests/Foundation/main.swift
+++ b/Tests/Foundation/main.swift
@@ -116,6 +116,7 @@ var allTestCases = [
     testCase(TestUnit.allTests),
     testCase(TestDimension.allTests),
     testCase(TestMeasurement.allTests),
+    testCase(TestUnitPressure.allTests),
     testCase(TestUnitVolume.allTests),
     testCase(TestNSLock.allTests),
     testCase(TestNSSortDescriptor.allTests),


### PR DESCRIPTION
The goal of this PR is to extend the available measure units for `UnitPressure` by adding `ksi` (kilopound per square inch) and `Mpsi` (megapound per square inch) to the available measure units.