### PR TITLE
URLSession: Fix bug requiring a new Body Stream

### DIFF
--- a/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
@@ -250,7 +250,7 @@ open class URLSessionTask : NSObject, NSCopying {
         } else if let bodyStream = request.httpBodyStream {
             self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: _Body.stream(bodyStream))
         } else {
-            self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: nil)
+            self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: _Body.none)
         }
     }
     internal init(session: URLSession, request: URLRequest, taskIdentifier: Int, body: _Body?) {


### PR DESCRIPTION
- Initial body stream was being passed as nil and not _Body.none when
  creating a data task without a body. This caused the delegate's
  urlSession(_:task:needNewBodyStream:) method to be called
  unnecessarily.

- Add a test case and enhance the TestURLSession SessionDelegate to log
  the callbacks as they are called to check the number and order.

Fixes a bug introduced in #2735 