### PR TITLE
URLSession: Better handling for willPerformHTTPRedirection delegate calls

### DIFF
--- a/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
@@ -106,6 +106,13 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
         // Note this excludes code 300 which should return the response of the redirect and not follow it.
         // For other redirect codes dont notify the delegate of the data received in the redirect response.
         if let httpResponse = ts.response as? HTTPURLResponse, 301...308 ~= httpResponse.statusCode {
+            if let _http = self as? _HTTPURLProtocol {
+                // Save the response body in case the delegate does not perform a redirect and the 3xx response
+                // including its body needs to be returned to the client.
+                var redirectBody = _http.lastRedirectBody ?? Data()
+                redirectBody.append(data)
+                _http.lastRedirectBody = redirectBody
+            }
             return .proceed
         }
 


### PR DESCRIPTION
- If the delegate calls the completionHandler with a nil response, then
  return the 3xx redirection response and its body data to the caller as
  the final response.

- If the delegate fails to call the completionHandler before the timeout
  interval for the request has expired, then dont treat is as an error
  and dont call urlSession(_:task:didCompleteWithError:).

- Fix TestURLSession.test_httpRedirectionWithDefaultPort() to work
  correctly now that the HTTPRedirectionDataTask delegate needs to call
  the completion handler with nil to cancel the redirect.

- This handling now matches Darwin.