### PR TITLE
URLSession: Set default Content-Type for POST request.

### DIFF
--- a/Sources/Foundation/NSError.swift
+++ b/Sources/Foundation/NSError.swift
@@ -881,9 +881,11 @@ public struct URLError : _BridgedStoredNSError {
         case cannotDecodeRawData = -1015
         case cannotDecodeContentData = -1016
         case cannotParseResponse = -1017
+        case appTransportSecurityRequiresSecureConnection = -1022
         case fileDoesNotExist = -1100
         case fileIsDirectory = -1101
         case noPermissionsToReadFile = -1102
+        case dataLengthExceedsMaximum = -1103
         case secureConnectionFailed = -1200
         case serverCertificateHasBadDate = -1201
         case serverCertificateUntrusted = -1202

--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
@@ -376,8 +376,12 @@ internal class _HTTPURLProtocol: _NativeProtocol {
         }
         let customHeaders: [String]
         let headersForRequest = curlHeaders(for: httpHeaders)
-        if ((request.httpMethod == "POST") && (request.httpBody?.count ?? 0 > 0)
-            && (request.value(forHTTPHeaderField: "Content-Type") == nil)) {
+        var hasStream = (request.httpBodyStream != nil)
+        if case _Body.stream(_) = body {
+            hasStream = true
+        }
+        if (request.httpMethod == "POST") && (request.value(forHTTPHeaderField: "Content-Type") == nil)
+            && ((request.httpBody?.count ?? 0 > 0) || hasStream) {
             customHeaders = headersForRequest + ["Content-Type:application/x-www-form-urlencoded"]
         } else {
             customHeaders = headersForRequest

--- a/Tests/Foundation/HTTPServer.swift
+++ b/Tests/Foundation/HTTPServer.swift
@@ -563,6 +563,11 @@ struct _HTTPRequest {
                 headerDict[parts[0]] = parts[1].trimmingCharacters(in: CharacterSet(charactersIn: " "))
             }
         }
+
+        // Include the body as a Base64 Encoded entry
+        if let bodyData = messageData ?? messageBody?.data(using: .utf8) {
+            headerDict["x-base64-body"] = bodyData.base64EncodedString()
+        }
         return try JSONSerialization.data(withJSONObject: headerDict, options: .sortedKeys)
     }
 }


### PR DESCRIPTION
- If a POST request does not have a Content-Type set and the body has a
  size greater than zero, then an entry is added to the headers with
  type application/x-www-form-urlencoded.
  This was not being done if the body was an InputStream, so add a fix
  to ensure it is.

- Add missing URLError.Code cases for .dataLengthExceedsMaximum and
  .appTransportSecurityRequiresSecureConnection