### PR TITLE
URLSession: Dont try to send a body when URLRequest.httpBody is an empty Data()

### DIFF
--- a/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
@@ -245,7 +245,7 @@ open class URLSessionTask : NSObject, NSCopying {
     }
     /// Create a data task. If there is a httpBody in the URLRequest, use that as a parameter
     internal convenience init(session: URLSession, request: URLRequest, taskIdentifier: Int) {
-        if let bodyData = request.httpBody {
+        if let bodyData = request.httpBody, !bodyData.isEmpty {
             self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: _Body.data(createDispatchData(bodyData)))
         } else if let bodyStream = request.httpBodyStream {
             self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: _Body.stream(bodyStream))
@@ -253,6 +253,7 @@ open class URLSessionTask : NSObject, NSCopying {
             self.init(session: session, request: request, taskIdentifier: taskIdentifier, body: _Body.none)
         }
     }
+
     internal init(session: URLSession, request: URLRequest, taskIdentifier: Int, body: _Body?) {
         self.session = session
         /* make sure we're actually having a serial queue as it's used for synchronization */


### PR DESCRIPTION
- If the .httpBody is set to an empty Data() instance then treat this
  as if there was no .httpBody set and do not attempt to send a zero
  byte body to the remote server.

- Update TestURLSession.test_requestWithEmptyBody() and
  TestURLSession.test_requestWithNonEmptyBody() to check the delegate
  callbacks and the posted body sent back in the response.