### PR TITLE
SR-2682: URLSession redirect does not inherit request timeout value

### DIFF
--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
@@ -699,8 +699,9 @@ internal extension _HTTPURLProtocol {
 
         guard let urlString = components.string else { fatalError("Invalid URL") }
         request.url = URL(string: urlString)
-        let timeSpent = easyHandle.getTimeoutIntervalSpent()
-        request.timeoutInterval = fromRequest.timeoutInterval - timeSpent
+
+        // Inherit the timeout from the previous request
+        request.timeoutInterval = fromRequest.timeoutInterval
         return request
     }
 }

--- a/Tests/Foundation/HTTPServer.swift
+++ b/Tests/Foundation/HTTPServer.swift
@@ -722,6 +722,14 @@ public class TestURLSessionServer {
             return try headersAsJSONResponse()
         }
 
+        if uri.hasPrefix("/redirect/") {
+            let components = uri.components(separatedBy: "/")
+            if components.count >= 3, let count = Int(components[2]) {
+                let newLocation = (count <= 1) ? "/jsonBody" : "/redirect/\(count - 1)"
+                return try _HTTPResponse(response: .FOUND, headers: "Location: \(newLocation)", body: "Redirecting to \(newLocation)")
+            }
+        }
+
         if uri == "/upload" {
             if let contentLength = request.getHeader(for: "content-length") {
                 let text = "Upload completed!, Content-Length: \(contentLength)"


### PR DESCRIPTION
- Ensure that the HTTP requests created when following redirects have
  the same timeout as the original request.