### PR TITLE
URLSession: Update all task types with the byte count of sent data

### DIFF
--- a/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
@@ -160,8 +160,7 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
     }
 
     fileprivate func notifyDelegate(aboutUploadedData count: Int64) {
-        guard let task = self.task as? URLSessionUploadTask,
-            let session = self.task?.session as? URLSession,
+        guard let task = self.task, let session = task.session as? URLSession,
             case .taskDelegate(let delegate) = session.behaviour(for: task) else { return }
         task.countOfBytesSent += count
         session.delegateQueue.addOperation {


### PR DESCRIPTION
- urlSession(_:task:didSendBodyData:totalBytesSent:totalBytesExpectedToSend:)
  was only sent to tasks of type URLSesisonUploadTask, but testing showed
  it should be sent to all task types.

- Update tests that now see an extra delegate callback of this method.

- test_simpleUploadWithDelegateProvidingInputStream was flaky due to the
  expectation sometimes being fulfilled multiple times as it was
  fulfilled in the urlSession(_:dataTask:didReceive:) delegate.

- Migrate this test to the SessionDelegate and add extra tests to check
  the response and delegate callbacks for each HTTP method.

- For HTTPUploadDelegate, add the expectation fulfilment to a delegate
  callback for urlSession(_ :task:didCompleteWithError:) so that
  test_simpleUploadWithDelegate() still works.