### PR TITLE
[Windows] CFThreadSpecific implementation allows access to deallocated value

### DIFF
--- a/Tests/Foundation/Tests/TestNotificationQueue.swift
+++ b/Tests/Foundation/Tests/TestNotificationQueue.swift
@@ -229,5 +229,12 @@ class TestNotificationQueue : XCTestCase {
         bgThread.start()
 
         waitForExpectations(timeout: 0.2)
+
+        // There is a small time gap between "e.fulfill()"
+        // and actuall thread termination.
+        // We need a little delay to allow bgThread actually die.
+        // Callers of this function are assuming thread is
+        // deallocated after call.
+        Thread.sleep(forTimeInterval: 0.05)
     }
 }


### PR DESCRIPTION
Unlike pthread-based implementation, TLS/FLS on Windows doesn't return NULL when reading value after destructor call.

To avoid that we have to nullify value in destructor callback.
The implementation needs to store key along with user data to perform proper cleanup.

This fixes crashes in `NotificationQueue` and `OperationQueue` on Windows.

Also introduced small delay in helper func of `TestNotificationQueue` to avoid false positive/false negative results in `test_defaultQueue` and `test_notificationQueueLifecycle`.