### PR TITLE
Fix Process tests that fails when stdin is empty

### DIFF
--- a/TestFoundation/TestProcess.swift
+++ b/TestFoundation/TestProcess.swift
@@ -373,7 +373,9 @@ class TestProcess : XCTestCase {
         XCTAssertEqual(process.processIdentifier, 0)
         XCTAssertEqual(process.qualityOfService, .default)
 
+        let pipe = Pipe()
         process.executableURL = xdgTestHelperURL()
+        process.standardInput = pipe.fileHandleForReading
         process.arguments = ["--cat"]
         _ = try? process.run()
         XCTAssertTrue(process.isRunning)
@@ -426,7 +428,12 @@ class TestProcess : XCTestCase {
     }
 
     func test_terminate() {
-        guard let process = try? Process.run(xdgTestHelperURL(), arguments: ["--cat"]) else {
+        let pipe = Pipe()
+        let process = Process()
+        process.executableURL = xdgTestHelperURL()
+        process.arguments = ["--cat"]
+        process.standardInput = pipe.fileHandleForReading
+        guard (try? process.run()) != nil else {
             XCTFail("Cant run 'cat'")
             return
         }


### PR DESCRIPTION
When building Swift in a docker via `docker build`, `stdin` returns `EOF` at each read and there is nothing we can do about it.
Because of this, the tests `test_terminate` and `test_preStartEndState` fail because the helper exits w/ code 0 before the swift `Process` can terminate it.

This PR fixes this problem by setting a `Pipe` stdin to the `Process`es.