### PR TITLE
we need to end copiedArgs

### DIFF
--- a/CoreFoundation/String.subproj/CFString.c
+++ b/CoreFoundation/String.subproj/CFString.c
@@ -7004,7 +7004,8 @@ static Boolean __CFStringAppendFormatCore(CFMutableStringRef outputString, CFStr
 	    newMaxArgNum = specs[curSpec].widthArgNum;
 	}
 	if (sizeArgNum < newMaxArgNum) {
-	    if (specs != localSpecsBuffer) CFAllocatorDeallocate(tmpAlloc, specs);
+	    if (numConfigs > 0) va_end(copiedArgs);
+	    if (specs != localSpecsBuffer) CFAllocatorDeallocate(tmpAlloc, specs);	
 	    if (values != localValuesBuffer) CFAllocatorDeallocate(tmpAlloc, values);
 	    if (formatChars && (formatChars != localFormatBuffer)) CFAllocatorDeallocate(tmpAlloc, formatChars);
             


### PR DESCRIPTION
we need to end copiedArgs. In fact, why do we need copyargs?