### PR TITLE
Use time_t.init directly when calling timespec

### DIFF
--- a/Sources/Foundation/NSLock.swift
+++ b/Sources/Foundation/NSLock.swift
@@ -419,7 +419,7 @@ private func timeSpecFrom(date: Date) -> timespec? {
     let interval = date.timeIntervalSince1970
     let intervalNS = Int64(interval * Double(nsecPerSec))
 
-    return timespec(tv_sec: Int(intervalNS / nsecPerSec),
+    return timespec(tv_sec: time_t(intervalNS / nsecPerSec),
                     tv_nsec: Int(intervalNS % nsecPerSec))
 }
 #endif


### PR DESCRIPTION
Currently an attempt to pass an `Int` fails on platforms where `time_t` is 64-bit, such as WASI with its [wasi-libc](https://github.com/WebAssembly/wasi-libc/blob/320054e84f8f2440def3b1c8700cedb8fd697bf8/basics/include/__typedef_time_t.h).

(cc @compnerd)