### PR TITLE
Removed Linux use of sys/sysctl.h

### DIFF
--- a/CoreFoundation/PlugIn.subproj/CFBundle_InfoPlist.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_InfoPlist.c
@@ -17,7 +17,7 @@
 
 #if (TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD) && !TARGET_OS_CYGWIN
 #include <dirent.h>
-#if !TARGET_OS_ANDROID
+#if TARGET_OS_MAC || TARGET_OS_BSD
 #include <sys/sysctl.h>
 #endif
 #include <sys/mman.h>


### PR DESCRIPTION
 The header is deprecated and removed in 5.5 of the kernel which causes Swift not to build.