### PR TITLE
Another file to only include sys/sysctl.h if macOS or BSD

### DIFF
--- a/CoreFoundation/PlugIn.subproj/CFBundle_Resources.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Resources.c
@@ -27,7 +27,7 @@
 
 #if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
 #include <unistd.h>
-#if !TARGET_OS_ANDROID
+#if TARGET_OS_MAC || TARGET_OS_BSD
 #include <sys/sysctl.h>
 #endif
 #include <sys/stat.h>


### PR DESCRIPTION
My rebasing dropped `CoreFoundation/PlugIn.subproj/CFBundle_Resources.c` from [this PR](https://github.com/apple/swift-corelibs-foundation/pull/2771). Thanks to @buttaface for pointing it out. 