### PR TITLE
SR-12696: Add JSONEncoder.OutputFormatting.withoutEscapingSlashes for Linux

### DIFF
--- a/Sources/Foundation/JSONEncoder.swift
+++ b/Sources/Foundation/JSONEncoder.swift
@@ -57,6 +57,12 @@ open class JSONEncoder {
         /// Produce JSON with dictionary keys sorted in lexicographic order.
         @available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
         public static let sortedKeys    = OutputFormatting(rawValue: 1 << 1)
+
+        /// By default slashes get escaped ("/" → "\/", "http://apple.com/" → "http:\/\/apple.com\/")
+        /// for security reasons, allowing outputted JSON to be safely embedded within HTML/XML.
+        /// In contexts where this escaping is unnecessary, the JSON is known to not be embedded,
+        /// or is intended only for display, this option avoids this escaping.
+        public static let withoutEscapingSlashes = OutputFormatting(rawValue: 1 << 3)
     }
 
     /// The strategy to use for encoding `Date` values.

--- a/Tests/Foundation/Tests/TestJSONEncoder.swift
+++ b/Tests/Foundation/Tests/TestJSONEncoder.swift
@@ -853,6 +853,12 @@ class TestJSONEncoder : XCTestCase {
         XCTAssertEqual(jsonObject, camelCaseDictionary)
     }
 
+    func test_OutputFormattingValues() {
+        XCTAssertEqual(JSONEncoder.OutputFormatting.prettyPrinted.rawValue, 1)
+        XCTAssertEqual(JSONEncoder.OutputFormatting.sortedKeys.rawValue, 2)
+        XCTAssertEqual(JSONEncoder.OutputFormatting.withoutEscapingSlashes.rawValue, 8)
+    }
+
     // MARK: - Helper Functions
     private var _jsonEmptyDictionary: Data {
         return "{}".data(using: .utf8)!
@@ -1454,6 +1460,7 @@ extension TestJSONEncoder {
             ("test_snake_case_encoding", test_snake_case_encoding),
             ("test_dictionary_snake_case_decoding", test_dictionary_snake_case_decoding),
             ("test_dictionary_snake_case_encoding", test_dictionary_snake_case_encoding),
+            ("test_OutputFormattingValues", test_OutputFormattingValues),
         ]
     }
 }


### PR DESCRIPTION
- This was missing and is required to match Darwin.