### PR TITLE
[CMake] fix runpath for ELF platforms

### DIFF
--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -157,6 +157,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   add_dependencies(Foundation CoreFoundationResources)
   target_link_options(Foundation PRIVATE
     $<TARGET_OBJECTS:CoreFoundationResources>)
+elseif(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_options(Foundation PRIVATE "SHELL:-no-toolchain-stdlib-rpath")
 endif()
 
 

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -68,6 +68,10 @@ set_target_properties(FoundationNetworking PROPERTIES
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/swift)
 
+if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
+  target_link_options(FoundationNetworking PRIVATE "SHELL:-no-toolchain-stdlib-rpath")
+endif()
+
 
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS FoundationNetworking)
 _install_target(FoundationNetworking)

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -20,6 +20,10 @@ set_target_properties(FoundationXML PROPERTIES
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/swift)
 
+if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
+  target_link_options(FoundationXML PRIVATE "SHELL:-no-toolchain-stdlib-rpath")
+endif()
+
 
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS FoundationXML)
 _install_target(FoundationXML)


### PR DESCRIPTION
Remove the absolute path to the host toolchain's stdlib from the three Foundation shared libraries. Also, add it as a CMake `BUILD_PATH` to plutil, so that it's removed upon installation.

Otherwise, you see the following in the latest official 5.3 snapshot release for linux:
```
> readelf -d swift-5.3-DEVELOPMENT-SNAPSHOT-2020-05-04-a-ubuntu18.04/usr/lib/swift/linux/libFoundation*so swift-5.3-DEVELOPMENT-SNAPSHOT-2020-05-04-a-ubuntu18.04/usr/bin/plutil | ag "File:|runpath"
File: swift-5.3-DEVELOPMENT-SNAPSHOT-2020-05-04-a-ubuntu18.04/usr/lib/swift/linux/libFoundation.so
 0x000000000000001d (RUNPATH)            Library runpath: [/home/buildnode/jenkins/workspace/oss-swift-5.3-package-linux-ubuntu-18_04/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux:$ORIGIN]
File: swift-5.3-DEVELOPMENT-SNAPSHOT-2020-05-04-a-ubuntu18.04/usr/lib/swift/linux/libFoundationNetworking.so
 0x000000000000001d (RUNPATH)            Library runpath: [/home/buildnode/jenkins/workspace/oss-swift-5.3-package-linux-ubuntu-18_04/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux:$ORIGIN]
File: swift-5.3-DEVELOPMENT-SNAPSHOT-2020-05-04-a-ubuntu18.04/usr/lib/swift/linux/libFoundationXML.so
 0x000000000000001d (RUNPATH)            Library runpath: [/home/buildnode/jenkins/workspace/oss-swift-5.3-package-linux-ubuntu-18_04/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux:$ORIGIN]
File: swift-5.3-DEVELOPMENT-SNAPSHOT-2020-05-04-a-ubuntu18.04/usr/bin/plutil
 0x000000000000001d (RUNPATH)            Library runpath: [/home/buildnode/jenkins/workspace/oss-swift-5.3-package-linux-ubuntu-18_04/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux]
```