### PR TITLE
Allow whitespaces after parsed content in DateFormatter.date(from:)

### DIFF
--- a/Sources/Foundation/DateFormatter.swift
+++ b/Sources/Foundation/DateFormatter.swift
@@ -64,8 +64,15 @@ open class DateFormatter : Formatter {
         }
 
         // range.length is updated with the last position of the input string that was parsed
-        guard range.length == string.length else {
-            // The whole string was not parsed
+        guard let swiftRange = Range(NSRange(range), in: string) else {
+            fatalError("Incorrect range \(range) in \(string)")
+        }
+        
+        // Apple DateFormatter implementation returns nil
+        // if non-whitespace sharacters are left after parsed content.
+        let remainder = String(string[swiftRange.upperBound...])
+        let characterSet = CharacterSet(charactersIn: remainder)
+        guard CharacterSet.whitespaces.isSuperset(of: characterSet) else {
             return nil
         }
         return date

--- a/Tests/Foundation/Tests/TestDateFormatter.swift
+++ b/Tests/Foundation/Tests/TestDateFormatter.swift
@@ -419,6 +419,15 @@ class TestDateFormatter: XCTestCase {
         let d1 = try XCTUnwrap(formatter.date(from: "2018-03-09"))
         XCTAssertEqual(d1.description, "2018-03-09 00:00:00 +0000")
 
+        // DateFormatter should allow any kind of whitespace before and after parsed content
+        let whitespaces = " \t\u{00a0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200a}\u{202f}\u{205f}\u{3000}"
+        let d1Prefix = try XCTUnwrap(formatter.date(from: "\(whitespaces)2018-03-09"))
+        XCTAssertEqual(d1.description, d1Prefix.description)
+        let d1PrefixSuffix = try XCTUnwrap(formatter.date(from: "\(whitespaces)2018-03-09\(whitespaces)"))
+        XCTAssertEqual(d1.description, d1PrefixSuffix.description)
+        let d1Suffix = try XCTUnwrap(formatter.date(from: "2018-03-09\(whitespaces)"))
+        XCTAssertEqual(d1.description, d1Suffix.description)
+        
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
         XCTAssertNil(formatter.date(from: "2018-03-09"))
         let d2 = try XCTUnwrap(formatter.date(from: "2018-03-09T10:25:16+01:00"))


### PR DESCRIPTION
Noticed the difference between macOS and Windows test results in our codebase (we are heavily dependent on date parsing). I have not found any docs about this, but actual results and deep debugging left no doubt about the mechanics.

Apple implementation checks for unparsed content in source string.
**Any non-whitespace** leftover characters are considered as failure.
On the other hand, **whitespaces are permitted** and should not affect the result.

Related to #1822 (SR-9322).
This patch alters verification logic to be closer to Apple implementation.

Not sure about `preconditionFailure` check, but that's really unexpected condition.

cc @compnerd @spevans 