### PR TITLE
[CF] Unify return types in CFPropertyList again.

### DIFF
--- a/CoreFoundation/Parsing.subproj/CFPropertyList.c
+++ b/CoreFoundation/Parsing.subproj/CFPropertyList.c
@@ -2633,7 +2633,7 @@ CFTypeRef _CFPropertyListCreateFromXMLString(CFAllocatorRef allocator, CFStringR
 CF_PRIVATE bool __CFBinaryPlistCreateObjectFiltered(const uint8_t *databytes, uint64_t datalen, uint64_t startOffset, const CFBinaryPlistTrailer *trailer, CFAllocatorRef allocator, CFOptionFlags mutabilityOption, CFMutableDictionaryRef objects, CFMutableSetRef set, CFIndex curDepth, CFSetRef keyPaths, CFPropertyListRef *plist, CFTypeID *outPlistTypeID);
 
 // Returns a subset of the property list, only including the key paths in the CFSet.
-Boolean _CFPropertyListCreateFiltered(CFAllocatorRef allocator, CFDataRef data, CFOptionFlags option, CFSetRef keyPaths, CFPropertyListRef *value, CFErrorRef *error) {
+bool _CFPropertyListCreateFiltered(CFAllocatorRef allocator, CFDataRef data, CFOptionFlags option, CFSetRef keyPaths, CFPropertyListRef *value, CFErrorRef *error) {
     
     if (!keyPaths || !data) {
         return false;
@@ -2682,7 +2682,7 @@ Boolean _CFPropertyListCreateFiltered(CFAllocatorRef allocator, CFDataRef data, 
  @param error If an error occurs, will be set to a valid CFErrorRef. It is the caller's responsibility to release this value.
  @return True if the key is found, false otherwise.
  */
-Boolean _CFPropertyListCreateSingleValue(CFAllocatorRef allocator, CFDataRef data, CFOptionFlags option, CFStringRef keyPath, CFPropertyListRef *value, CFErrorRef *error) {
+bool _CFPropertyListCreateSingleValue(CFAllocatorRef allocator, CFDataRef data, CFOptionFlags option, CFStringRef keyPath, CFPropertyListRef *value, CFErrorRef *error) {
     
     if (!keyPath || CFStringGetLength(keyPath) == 0) {
         return false;


### PR DESCRIPTION
In #2598, we brought the prototypes and declarations into alignment for
_CFPropertyListCreateFiltered and _CFPropertyListCreateSingleValue,
namely, using a `Boolean` for prototype and declaration, since they were
not matched.

It appears with the Catalina merge they were brought into alignment the
other way around, namely using `bool` instead. Since the Catalina merge
chose `bool`, let's just go with that.