### PR TITLE
[CF] Rename remaining __kCFAllocatorTypeID_CONST.

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1650,7 +1650,7 @@ static void _CFRelease(CFTypeRef CF_RELEASES_ARGUMENT cf) {
             allocator = CFGetAllocator(cf);
             usesSystemDefaultAllocator = _CFAllocatorIsSystemDefault(allocator);
 
-            if (__kCFAllocatorTypeID_CONST != __CFGenericTypeID_inline(cf)) {
+            if (_kCFRuntimeIDCFAllocator != __CFGenericTypeID_inline(cf)) {
                 allocatorToRelease = (CFAllocatorRef _Nonnull)__CFGetAllocator(cf);
             }
 	}


### PR DESCRIPTION
PR #2782 references symbol __kCFAllocatorTypeID_CONST in CFRuntime.c but
this was removed in #1708. After interpreting the commit, it looks like
this symbol was renamed to _kCFRuntimeIDCFAllocator. Therefore, make
this rename again.