### PR TITLE
Test fixes for Darwin

### DIFF
--- a/Tests/Foundation/Tests/TestFileManager.swift
+++ b/Tests/Foundation/Tests/TestFileManager.swift
@@ -1785,10 +1785,10 @@ VIDEOS=StopgapVideos
 
             // Relative Paths
             ".\\testfile",
-            "..\\\(tmpPath.lastPathComponent)\\.\\testfile",
+            "..\\\((tmpPath as NSString).lastPathComponent)\\.\\testfile",
             "testfile",
             "./testfile",
-            "../\(tmpPath.lastPathComponent)/./testfile",
+            "../\((tmpPath as NSString).lastPathComponent)/./testfile",
 
             // UNC Paths
             "\\\\.\\\(tmpPath)\\testfile",

--- a/Tests/Foundation/Tests/TestJSONEncoder.swift
+++ b/Tests/Foundation/Tests/TestJSONEncoder.swift
@@ -855,7 +855,9 @@ class TestJSONEncoder : XCTestCase {
 
     func test_OutputFormattingValues() {
         XCTAssertEqual(JSONEncoder.OutputFormatting.prettyPrinted.rawValue, 1)
-        XCTAssertEqual(JSONEncoder.OutputFormatting.sortedKeys.rawValue, 2)
+        if #available(OSX 10.13, *) {
+            XCTAssertEqual(JSONEncoder.OutputFormatting.sortedKeys.rawValue, 2)
+        }
         XCTAssertEqual(JSONEncoder.OutputFormatting.withoutEscapingSlashes.rawValue, 8)
     }
 


### PR DESCRIPTION
- lastPathComponent is a NSString method so bridge appropiately.

- JSONEncoder.OutputFormatting.sortedKeys requires macOS 10.13, add an
  #available around it.