### PR TITLE
Make fileActions constant, not variable in Process.swift

### DIFF
--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -825,7 +825,7 @@ open class Process: NSObject {
         let source = CFSocketCreateRunLoopSource(kCFAllocatorDefault, socket, 0)
         CFRunLoopAddSource(managerThreadRunLoop?._cfRunLoop, source, kCFRunLoopDefaultMode)
 
-        var fileActions = _CFPosixSpawnFileActionsAlloc()
+        let fileActions = _CFPosixSpawnFileActionsAlloc()
         posix(_CFPosixSpawnFileActionsInit(fileActions))
         defer {
             _CFPosixSpawnFileActionsDestroy(fileActions)


### PR DESCRIPTION
The pointer value of it is not changed, which with `var` currently leads to this warning:

```
/Sources/Foundation/Process.swift:828:13: 
warning: variable 'fileActions' was never mutated; consider changing to 'let' constant
        var fileActions = _CFPosixSpawnFileActionsAlloc()
```