### PR TITLE
Use arguments of same type with _CFMultiplyBufferSizeWithoutOverflow

### DIFF
--- a/CoreFoundation/URL.subproj/CFURLComponents_URIParser.c
+++ b/CoreFoundation/URL.subproj/CFURLComponents_URIParser.c
@@ -280,9 +280,11 @@ CF_EXPORT CFStringRef _CFStringCreateByAddingPercentEncodingWithAllowedCharacter
             }
             else {
                 // not big enough? malloc it.
-                size_t mallocSize;
+                CFIndex mallocSize;
                 if ( _CFMultiplyBufferSizeWithoutOverflow(maxBufferSize, 4, &mallocSize) ) {
-                    inBuf = (UInt8 *)malloc(mallocSize);
+                    if (mallocSize >= 0) {
+                        inBuf = (UInt8 *)malloc(mallocSize);
+                    }
                 }
             }
             if ( inBuf ) {
@@ -455,9 +457,11 @@ CF_EXPORT CFStringRef _CFStringCreateByRemovingPercentEncoding(CFAllocatorRef al
             }
             else {
                 // not big enough? malloc it.
-                size_t mallocSize;
+                CFIndex mallocSize;
                 if ( _CFMultiplyBufferSizeWithoutOverflow(maxBufferSize, 2, &mallocSize) ) {
-                    encodedBuf = (UInt8 *)malloc(mallocSize);
+                    if (mallocSize >= 0) {
+                        encodedBuf = (UInt8 *)malloc(mallocSize);
+                    }
                 }
             }
             if ( encodedBuf ) {


### PR DESCRIPTION
Using a mix of signed and unsigned types here caused a librt call to __mulito4 to be emitted instead of properly lowering the call.