### PR TITLE
SR-12366: URL: standardizedFileURL inconsistent behavior on macOS and Linux

### DIFF
--- a/DarwinCompatibilityTests.xcodeproj/project.pbxproj
+++ b/DarwinCompatibilityTests.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		B94B0837240185FF00B244E8 /* DarwinShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = B94B0836240185FF00B244E8 /* DarwinShims.swift */; };
 		B9ED84FD23641F7000A58AF2 /* DarwinShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F3269E1FC714DD003C3599 /* DarwinShims.swift */; };
 		B9F137A120B998D0000B7577 /* xdgTestHelper in CopyFiles */ = {isa = PBXBuildFile; fileRef = B917D31C20B0DB8B00728EE0 /* xdgTestHelper */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		B9F4492A2483FA1E00B30F02 /* TestNSURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F449292483FA1E00B30F02 /* TestNSURL.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -310,6 +311,7 @@
 		B9C89EDB1F6BF77E00087AF4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B9C89EDF1F6BF79000087AF4 /* TestFoundation */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TestFoundation; path = ../TestFoundation; sourceTree = "<group>"; };
 		B9F3269E1FC714DD003C3599 /* DarwinShims.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DarwinShims.swift; sourceTree = "<group>"; };
+		B9F449292483FA1E00B30F02 /* TestNSURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestNSURL.swift; path = Tests/Foundation/Tests/TestNSURL.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -341,6 +343,7 @@
 		B9C89EB81F6BF47D00087AF4 = {
 			isa = PBXGroup;
 			children = (
+				B9F449292483FA1E00B30F02 /* TestNSURL.swift */,
 				B91161AE242A385A00BD2907 /* TestDataURLProtocol.swift */,
 				B94B08342401854E00B244E8 /* main.swift */,
 				B94B07822401849700B244E8 /* TestAffineTransform.swift */,
@@ -681,6 +684,7 @@
 				B94B07D62401849B00B244E8 /* TestUserDefaults.swift in Sources */,
 				B94B07D72401849B00B244E8 /* TestNSTextCheckingResult.swift in Sources */,
 				B94B07D82401849B00B244E8 /* TestNSNumberBridging.swift in Sources */,
+				B9F4492A2483FA1E00B30F02 /* TestNSURL.swift in Sources */,
 				B94B07D92401849B00B244E8 /* TestOperationQueue.swift in Sources */,
 				B94B07DA2401849B00B244E8 /* TestJSONEncoder.swift in Sources */,
 				B94B07DB2401849B00B244E8 /* TestNSKeyedArchiver.swift in Sources */,

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -409,6 +409,7 @@
 		B9D9734123D19E2E00AB249C /* TestNSDateComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9D9734023D19E2E00AB249C /* TestNSDateComponents.swift */; };
 		B9D9734323D19FD100AB249C /* TestURLComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9D9734223D19FD100AB249C /* TestURLComponents.swift */; };
 		B9D9734523D1A36E00AB249C /* TestHTTPURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9D9734423D1A36E00AB249C /* TestHTTPURLResponse.swift */; };
+		B9F4492D2483FFD700B30F02 /* TestNSURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F4492B2483FFBF00B30F02 /* TestNSURL.swift */; };
 		BB3D7558208A1E500085CFDC /* Imports.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3D7557208A1E500085CFDC /* Imports.swift */; };
 		BD8042161E09857800487EB8 /* TestLengthFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8042151E09857800487EB8 /* TestLengthFormatter.swift */; };
 		BDBB65901E256BFA001A7286 /* TestEnergyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDBB658F1E256BFA001A7286 /* TestEnergyFormatter.swift */; };
@@ -1108,6 +1109,7 @@
 		B9D9734023D19E2E00AB249C /* TestNSDateComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSDateComponents.swift; sourceTree = "<group>"; };
 		B9D9734223D19FD100AB249C /* TestURLComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestURLComponents.swift; sourceTree = "<group>"; };
 		B9D9734423D1A36E00AB249C /* TestHTTPURLResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHTTPURLResponse.swift; sourceTree = "<group>"; };
+		B9F4492B2483FFBF00B30F02 /* TestNSURL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSURL.swift; sourceTree = "<group>"; };
 		BB3D7557208A1E500085CFDC /* Imports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Imports.swift; sourceTree = "<group>"; };
 		BD8042151E09857800487EB8 /* TestLengthFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLengthFormatter.swift; sourceTree = "<group>"; };
 		BDBB658F1E256BFA001A7286 /* TestEnergyFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEnergyFormatter.swift; sourceTree = "<group>"; };
@@ -1832,6 +1834,7 @@
 				152EF3932283457B001E1269 /* TestNSSortDescriptor.swift */,
 				EA66F6421BF1619600136161 /* TestNSString.swift */,
 				5FE52C941D147D1C00F7D270 /* TestNSTextCheckingResult.swift */,
+				B9F4492B2483FFBF00B30F02 /* TestNSURL.swift */,
 				83712C8D1C1684900049AD49 /* TestNSURLRequest.swift */,
 				C2A9D75B1C15C08B00993803 /* TestNSUUID.swift */,
 				D3047AEB1C38BC3300295652 /* TestNSValue.swift */,
@@ -2613,7 +2616,7 @@
 					};
 					5B7C8A6D1BEA7F8F00C5B690 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 1140;
+						LastSwiftMigration = 1150;
 						ProvisioningStyle = Manual;
 					};
 					5BDC405B1BD6D83B00ED97BB = {
@@ -3046,6 +3049,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B9F4492D2483FFD700B30F02 /* TestNSURL.swift in Sources */,
 				B91161AD242A363900BD2907 /* TestDataURLProtocol.swift in Sources */,
 				B95FC97622B84B0A005DEA0A /* TestNSSortDescriptor.swift in Sources */,
 				B940492D223B146800FB4384 /* TestProgressFraction.swift in Sources */,

--- a/Tests/Foundation/CMakeLists.txt
+++ b/Tests/Foundation/CMakeLists.txt
@@ -68,6 +68,7 @@ target_sources(TestFoundation PRIVATE
   Tests/TestNSSortDescriptor.swift
   Tests/TestNSString.swift
   Tests/TestNSTextCheckingResult.swift
+  Tests/TestNSURL.swift
   Tests/TestNSURLRequest.swift
   Tests/TestNSUUID.swift
   Tests/TestNSValue.swift

--- a/Tests/Foundation/Tests/TestNSURL.swift
+++ b/Tests/Foundation/Tests/TestNSURL.swift
@@ -1,0 +1,84 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+class TestNSURL: XCTestCase {
+
+    func test_absoluteString() {
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/folder", isDirectory: true).absoluteString, "file:///path/to/folder/")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/folder/", isDirectory: true).absoluteString, "file:///path/to/folder/")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/../folder", isDirectory: true).absoluteString, "file:///path/../folder/")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/./folder/..", isDirectory: true).absoluteString, "file:///path/to/./folder/../")
+
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/.file", isDirectory: false).absoluteString, "file:///path/to/.file")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/file/", isDirectory: false).absoluteString, "file:///path/to/file")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/../file", isDirectory: false).absoluteString, "file:///path/../file")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/./file/..", isDirectory: false).absoluteString, "file:///path/to/./file/..")
+    }
+
+    func test_pathComponents() {
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/folder", isDirectory: true).pathComponents, ["/", "path", "to", "folder"])
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/folder/", isDirectory: true).pathComponents, ["/", "path", "to", "folder"])
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/../folder", isDirectory: true).pathComponents, ["/", "path", "..", "folder"])
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/../folder", isDirectory: true).standardized?.pathComponents, ["/", "folder"])
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/./folder/..", isDirectory: true).pathComponents, ["/", "path", "to", ".", "folder", ".."])
+
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/.file", isDirectory: false).pathComponents, ["/", "path", "to", ".file"])
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/file/", isDirectory: false).pathComponents, ["/", "path", "to", "file"])
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/../file", isDirectory: false).pathComponents, ["/", "path", "..", "file"])
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/./file/..", isDirectory: false).pathComponents, ["/", "path", "to", ".", "file", ".."])
+    }
+
+    func test_standardized() {
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/folder", isDirectory: true).standardized?.absoluteString, "file:///path/to/folder/")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/folder/", isDirectory: true).standardized?.absoluteString, "file:///path/to/folder/")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/../folder", isDirectory: true).standardized?.absoluteString, "file:///folder/")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/./folder/..", isDirectory: true).standardized?.absoluteString, "file:///path/to/")
+
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/.file", isDirectory: false).standardized?.absoluteString, "file:///path/to/.file")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/file/", isDirectory: false).standardized?.absoluteString, "file:///path/to/file")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/../file", isDirectory: false).standardized?.absoluteString, "file:///file")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/./file/..", isDirectory: false).standardized?.absoluteString, "file:///path/to")
+    }
+
+    func test_standardizingPath() {
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/folder", isDirectory: true).standardizingPath?.absoluteString, "file:///path/to/folder/")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/folder/", isDirectory: true).standardizingPath?.absoluteString, "file:///path/to/folder/")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/../folder", isDirectory: true).standardizingPath?.absoluteString, "file:///folder/")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/./folder/..", isDirectory: true).standardizingPath?.absoluteString, "file:///path/to/")
+
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/.file", isDirectory: false).standardizingPath?.absoluteString, "file:///path/to/.file")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/file/", isDirectory: false).standardizingPath?.absoluteString, "file:///path/to/file")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/../file", isDirectory: false).standardizingPath?.absoluteString, "file:///file")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/./file/..", isDirectory: false).standardizingPath?.absoluteString, "file:///path/to")
+    }
+
+    func test_resolvingSymlinksInPath() {
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/folder", isDirectory: true).resolvingSymlinksInPath?.absoluteString, "file:///path/to/folder")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/folder/", isDirectory: true).resolvingSymlinksInPath?.absoluteString, "file:///path/to/folder")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/../folder", isDirectory: true).resolvingSymlinksInPath?.absoluteString, "file:///folder")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/./folder/..", isDirectory: true).resolvingSymlinksInPath?.absoluteString, "file:///path/to")
+
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/.file", isDirectory: false).resolvingSymlinksInPath?.absoluteString, "file:///path/to/.file")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/file/", isDirectory: false).resolvingSymlinksInPath?.absoluteString, "file:///path/to/file")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/../file", isDirectory: false).resolvingSymlinksInPath?.absoluteString, "file:///file")
+        XCTAssertEqual(NSURL(fileURLWithPath: "/path/to/./file/..", isDirectory: false).resolvingSymlinksInPath?.absoluteString, "file:///path/to")
+    }
+
+    static var allTests: [(String, (TestNSURL) -> () throws -> Void)] {
+        let tests: [(String, (TestNSURL) -> () throws -> Void)] = [
+            ("test_absoluteString", test_absoluteString),
+            ("test_pathComponents", test_pathComponents),
+            ("test_standardized", test_standardized),
+            ("test_standardizingPath", test_standardizingPath),
+            ("test_resolvingSymlinksInPath", test_resolvingSymlinksInPath),
+        ]
+
+        return tests
+    }
+}

--- a/Tests/Foundation/Tests/TestURL.swift
+++ b/Tests/Foundation/Tests/TestURL.swift
@@ -434,6 +434,11 @@ class TestURL : XCTestCase {
         let lengthOfRelativePath = Int(strlen(TestURL.gFileDoesNotExistName))
         let relativePath = fileSystemRep.advanced(by: Int(TestURL.gRelativeOffsetFromBaseCurrentWorkingDirectory))
         XCTAssertTrue(strncmp(TestURL.gFileDoesNotExistName, relativePath, lengthOfRelativePath) == 0, "fileSystemRepresentation of file path is wrong")
+
+        // SR-12366
+        let url1 = URL(fileURLWithPath: "/path/to/b/folder", isDirectory: true).standardizedFileURL.absoluteString
+        let url2 = URL(fileURLWithPath: "/path/to/b/folder", isDirectory: true).absoluteString
+        XCTAssertEqual(url1, url2)
     }
 
     func test_fileURLWithPath_isDirectory() {

--- a/Tests/Foundation/main.swift
+++ b/Tests/Foundation/main.swift
@@ -92,6 +92,7 @@ var allTestCases = [
     testCase(TestURLProtectionSpace.allTests),
     testCase(TestURLProtocol.allTests),
     testCase(TestNSURLRequest.allTests),
+    testCase(TestNSURL.allTests),
     testCase(TestURLRequest.allTests),
     testCase(TestURLResponse.allTests),
     testCase(TestHTTPURLResponse.allTests),


### PR DESCRIPTION
- When NSURL._resolvingSymlinksInPath() was creating a new URL(), it
  would use the default logic of checking if the file was a directory.
  Override this behaviour and use the .hasDirectoryPath property of the
  original NSURL when creating the resultant URL.

- Modify NSURL.standardized to remove use of force-unwrap.

- Add TestNSURL.swift for NSURL tests.