### PR TITLE
SR-12450: Add missing String.init(_ cocoaString: NSString) initialiser

### DIFF
--- a/Sources/Foundation/NSStringAPI.swift
+++ b/Sources/Foundation/NSStringAPI.swift
@@ -458,6 +458,9 @@ extension String {
         #endif
     }
 
+    public init(_ cocoaString: NSString) {
+        self = cocoaString._storage
+    }
 }
 
 extension StringProtocol where Index == String.Index {

--- a/Tests/Foundation/Tests/TestNSString.swift
+++ b/Tests/Foundation/Tests/TestNSString.swift
@@ -1629,6 +1629,11 @@ class TestNSString: LoopbackServerTest {
         }
     }
 
+    func test_initStringWithNSString() {
+        let ns = NSString("Test")
+        XCTAssertEqual(String(ns), "Test")
+    }
+
     static var allTests: [(String, (TestNSString) -> () throws -> Void)] {
         var tests = [
             ("test_initData", test_initData),
@@ -1701,6 +1706,7 @@ class TestNSString: LoopbackServerTest {
             ("test_fileSystemRepresentation", test_fileSystemRepresentation),
             ("test_enumerateSubstrings", test_enumerateSubstrings),
             ("test_paragraphRange", test_paragraphRange),
+            ("test_initStringWithNSString", test_initStringWithNSString),
         ]
 
 #if !os(Windows)


### PR DESCRIPTION
- https://developer.apple.com/documentation/swift/string/1410075-init