### PR TITLE
Fix for Foundation on Android 6.0

### DIFF
--- a/Sources/Foundation/Host.swift
+++ b/Sources/Foundation/Host.swift
@@ -25,7 +25,9 @@ import CoreFoundation
         return Glibc.getnameinfo(addr, addrlen, host, Int(hostlen), serv, Int(servlen), flags)
     }
 
-    // getifaddrs and freeifaddrs are not available in Android 6.0 or earlier, so call the functions dynamically.
+    // getifaddrs and freeifaddrs are not available in Android 6.0 or earlier, so call these functions dynamically.
+    // This only happens during the initial lookup of the addresses and then the results are cached and _resolved is marked true.
+    // If this API changes so these functions are called more frequently, it might be beneficial to cache the function pointers.
 
     private typealias GetIfAddrsFunc = @convention(c) (UnsafeMutablePointer<UnsafeMutablePointer<ifaddrs>?>) -> Int32
     private func getifaddrs(_ ifap: UnsafeMutablePointer<UnsafeMutablePointer<ifaddrs>?>) -> Int32 {

--- a/Sources/Foundation/Host.swift
+++ b/Sources/Foundation/Host.swift
@@ -31,7 +31,7 @@ import CoreFoundation
 
     private typealias GetIfAddrsFunc = @convention(c) (UnsafeMutablePointer<UnsafeMutablePointer<ifaddrs>?>) -> Int32
     private func getifaddrs(_ ifap: UnsafeMutablePointer<UnsafeMutablePointer<ifaddrs>?>) -> Int32 {
-        var result: Int32 = 0
+        var result: Int32 = -1
         if let handle = dlopen("libc.so", RTLD_NOLOAD) {
             if let entry = dlsym(handle, "getifaddrs") {
                 result = unsafeBitCast(entry, to: GetIfAddrsFunc.self)(ifap)


### PR DESCRIPTION
Foundation's Host.swift uses `getifaddrs` and `freeifaddrs`, which currently causes Android 6.0 or below to fail to link.

This PR changes these functions so they are called using `dlsym`, which allows Android 6.0 to link while providing full support on later versions of Android.

This is a replacement for PR https://github.com/apple/swift-corelibs-foundation/pull/2439.