### PR TITLE
Fixes 5 static analyser issues in CFPreferences.c

### DIFF
--- a/CoreFoundation/Preferences.subproj/CFPreferences.c
+++ b/CoreFoundation/Preferences.subproj/CFPreferences.c
@@ -382,7 +382,7 @@ const CFRuntimeClass __CFPreferencesDomainClass = {
 };
 
 /* We spend a lot of time constructing these prefixes; we should cache.  REW, 7/19/99 */
-static CFStringRef  _CFPreferencesCachePrefixForUserHost(CFStringRef  userName, CFStringRef  hostName) {
+static CFStringRef  _CFPreferencesCreateCachePrefixForUserHost(CFStringRef  userName, CFStringRef  hostName) {
     if (userName == kCFPreferencesAnyUser && hostName == kCFPreferencesAnyHost) {
         return (CFStringRef)CFRetain(CFSTR("*/*/"));
     }
@@ -407,7 +407,7 @@ static CFStringRef  _CFPreferencesCachePrefixForUserHost(CFStringRef  userName, 
 
 // It would be nice if we could remember the key for "well-known" combinations, so we're not constantly allocing more strings....  - REW 2/3/99
 static CFStringRef  _CFPreferencesStandardDomainCacheKey(CFStringRef  domainName, CFStringRef  userName, CFStringRef  hostName) {
-    CFStringRef  prefix = _CFPreferencesCachePrefixForUserHost(userName, hostName);
+    CFStringRef  prefix = _CFPreferencesCreateCachePrefixForUserHost(userName, hostName);
     CFStringRef  result = NULL;
     
     if (prefix) {
@@ -604,7 +604,7 @@ CF_PRIVATE CFArrayRef _CFPreferencesCreateDomainList(CFStringRef  userName, CFSt
     cachedDomains = (CFPreferencesDomainRef *)(cachedDomainKeys + cnt);
     CFDictionaryGetKeysAndValues(domainCache, (const void **)cachedDomainKeys, (const void **)cachedDomains);
     __CFUnlock(&domainCacheLock);
-    suffix = _CFPreferencesCachePrefixForUserHost(userName, hostName);
+    suffix = _CFPreferencesCreateCachePrefixForUserHost(userName, hostName);
     suffixLen = CFStringGetLength(suffix);
     
     for (idx = 0; idx < cnt; idx ++) {

--- a/CoreFoundation/Preferences.subproj/CFPreferences.c
+++ b/CoreFoundation/Preferences.subproj/CFPreferences.c
@@ -169,7 +169,7 @@ CF_PRIVATE CFStringRef _CFPreferencesGetByHostIdentifierString(void) {
 
 static unsigned long __CFSafeLaunchLevel = 0;
 
-static CFURLRef _preferencesDirectoryForUserHostSafetyLevel(CFStringRef userName, CFStringRef hostName, unsigned long safeLevel) {
+static CFURLRef _preferencesCreateDirectoryForUserHostSafetyLevel(CFStringRef userName, CFStringRef hostName, unsigned long safeLevel) {
     CFURLRef location = NULL;
     
     CFKnownLocationUser user;
@@ -196,7 +196,7 @@ static CFURLRef _preferencesDirectoryForUserHostSafetyLevel(CFStringRef userName
 }
 
 static CFURLRef  _preferencesDirectoryForUserHost(CFStringRef  userName, CFStringRef  hostName) {
-    return _preferencesDirectoryForUserHostSafetyLevel(userName, hostName, __CFSafeLaunchLevel);
+    return _preferencesCreateDirectoryForUserHostSafetyLevel(userName, hostName, __CFSafeLaunchLevel);
 }
 
 static Boolean __CFPreferencesWritesXML = true;
@@ -421,7 +421,7 @@ static CFURLRef _CFPreferencesURLForStandardDomainWithSafetyLevel(CFStringRef do
     CFURLRef theURL = NULL;
     CFAllocatorRef prefAlloc = __CFPreferencesAllocator();
 #if TARGET_OS_OSX || TARGET_OS_WIN32 || TARGET_OS_LINUX
-    CFURLRef prefDir = _preferencesDirectoryForUserHostSafetyLevel(userName, hostName, safeLevel);
+    CFURLRef prefDir = _preferencesCreateDirectoryForUserHostSafetyLevel(userName, hostName, safeLevel);
     CFStringRef  appName;
     CFStringRef  fileName;
     Boolean mustFreeAppName = false;

--- a/CoreFoundation/Preferences.subproj/CFPreferences.c
+++ b/CoreFoundation/Preferences.subproj/CFPreferences.c
@@ -281,7 +281,6 @@ void CFPreferencesSetMultiple(CFDictionaryRef keysToSet, CFArrayRef keysToRemove
 
     CFTypeRef *keys = NULL;
     CFTypeRef *values;
-    CFIndex numOfKeysToSet = 0;
     
     domain = _CFPreferencesStandardDomain(appName, user, host);
     if (!domain) return;
@@ -289,7 +288,6 @@ void CFPreferencesSetMultiple(CFDictionaryRef keysToSet, CFArrayRef keysToRemove
     CFAllocatorRef alloc = CFGetAllocator(domain);
     
     if (keysToSet && (count = CFDictionaryGetCount(keysToSet))) {
-        numOfKeysToSet = count;
         keys = (CFTypeRef *)CFAllocatorAllocate(alloc, 2*count*sizeof(CFTypeRef), 0);
         if (keys) {
             values = &(keys[count]);

--- a/CoreFoundation/Preferences.subproj/CFPreferences.c
+++ b/CoreFoundation/Preferences.subproj/CFPreferences.c
@@ -170,7 +170,6 @@ CF_PRIVATE CFStringRef _CFPreferencesGetByHostIdentifierString(void) {
 static unsigned long __CFSafeLaunchLevel = 0;
 
 static CFURLRef _preferencesDirectoryForUserHostSafetyLevel(CFStringRef userName, CFStringRef hostName, unsigned long safeLevel) {
-    CFAllocatorRef alloc = __CFPreferencesAllocator();
     CFURLRef location = NULL;
     
     CFKnownLocationUser user;

--- a/CoreFoundation/Preferences.subproj/CFPreferences.c
+++ b/CoreFoundation/Preferences.subproj/CFPreferences.c
@@ -459,12 +459,12 @@ static CFURLRef _CFPreferencesURLForStandardDomainWithSafetyLevel(CFStringRef do
 #elif TARGET_OS_WIN32
 		theURL = CFURLCreateWithFileSystemPathRelativeToBase(prefAlloc, fileName, kCFURLWindowsPathStyle, false, prefDir);
 #endif
-        if (prefDir) CFRelease(prefDir);
         CFRelease(fileName);
     }
 #else
 //#error Do not know where to store NSUserDefaults on this platform
 #endif
+    if (prefDir) CFRelease(prefDir);
     return theURL;
 }
 

--- a/CoreFoundation/Preferences.subproj/CFPreferences.c
+++ b/CoreFoundation/Preferences.subproj/CFPreferences.c
@@ -735,9 +735,8 @@ static void freeVolatileDomain(CFAllocatorRef allocator, CFTypeRef  context, voi
     CFRelease((CFTypeRef)domain);
 }
 
-static CFTypeRef  fetchVolatileValue(CFTypeRef  context, void *domain, CFStringRef  key) {
-    CFTypeRef  result = CFDictionaryGetValue((CFMutableDictionaryRef  )domain, key);
-    if (result) CFRetain(result);
+static CFTypeRef fetchVolatileValue(CFTypeRef  context, void *domain, CFStringRef  key) {
+    CFTypeRef result = CFDictionaryGetValue((CFMutableDictionaryRef  )domain, key);
     return result;
 }
 


### PR DESCRIPTION
Fixes memory leak in _CFPreferencesURLForStandardDomainWithSafetyLevel
Rename function according to convention to stop static analyzer complaining on overreleasing
Fix memory leak (extra retain) in function fetchVolatileValue
Remove not used variable from function CFPreferencesSetMultiple
Remove not used allocator in function _preferencesDirectoryForUserHostSafetyLevel