### PR TITLE
Added CVarArg support to NSString and String

### DIFF
--- a/Sources/Foundation/NSString.swift
+++ b/Sources/Foundation/NSString.swift
@@ -1648,7 +1648,7 @@ extension NSString : _StructTypeBridgeable {
 extension NSString : CVarArg {
     @inlinable // c-abi
     public var _cVarArgEncoding: [Int] {
-        return _encodeBitsAsWords(unsafeBitCast(self, to: CFString.self))
+        return _encodeBitsAsWords(unsafeBitCast(self, to: AnyObject.self))
     }
 }
 

--- a/Sources/Foundation/NSString.swift
+++ b/Sources/Foundation/NSString.swift
@@ -1652,15 +1652,14 @@ extension NSString : CVarArg {
     }
 }
 
-extension String : CVarArg {
+extension String : CVarArg, _CVarArgObject {
+    @inlinable // c-abi
+    public var _cVarArgObject: CVarArg {
+        return NSString(string: self)
+    }
+
     @inlinable // c-abi
     public var _cVarArgEncoding: [Int] {
-        // We don't have an autorelease pool to retain the NSString until the withVaList closure is complete.
-        // So add an operation to release on the next cycle of this thread.
-        let ns = Unmanaged.passRetained(NSString(string: self))
-        OperationQueue.current?.addOperation {
-            ns.release()
-        }
-        return ns.takeUnretainedValue()._cVarArgEncoding
+        fatalError("_cVarArgEncoding must be called on NSString instead")
     }
 }

--- a/Sources/Foundation/NSString.swift
+++ b/Sources/Foundation/NSString.swift
@@ -1652,6 +1652,7 @@ extension NSString : CVarArg {
     }
 }
 
+#if !_runtime(_ObjC)
 extension String : CVarArg, _CVarArgObject {
     @inlinable // c-abi
     public var _cVarArgObject: CVarArg {
@@ -1663,3 +1664,4 @@ extension String : CVarArg, _CVarArgObject {
         fatalError("_cVarArgEncoding must be called on NSString instead")
     }
 }
+#endif

--- a/Tests/Foundation/Tests/TestNSString.swift
+++ b/Tests/Foundation/Tests/TestNSString.swift
@@ -813,6 +813,15 @@ class TestNSString: LoopbackServerTest {
         }
     }
 
+    func test_initializeWithFormat4() {
+        let argument: [CVarArg] = ["One", "Two", "Three"]
+        withVaList(argument) {
+            pointer in
+            let string = NSString(format: "Testing %@ %@ %@", arguments: pointer)
+            XCTAssertEqual(string, "Testing One Two Three")
+        }
+    }
+
     func test_appendingPathComponent() {
         do {
             let path: NSString = "/tmp"
@@ -1677,6 +1686,7 @@ class TestNSString: LoopbackServerTest {
             ("test_initializeWithFormat", test_initializeWithFormat),
             ("test_initializeWithFormat2", test_initializeWithFormat2),
             ("test_initializeWithFormat3", test_initializeWithFormat3),
+            ("test_initializeWithFormat4", test_initializeWithFormat4),
             ("test_appendingPathComponent", test_appendingPathComponent),
             ("test_deletingLastPathComponent", test_deletingLastPathComponent),
             ("test_getCString_simple", test_getCString_simple),


### PR DESCRIPTION
This adds `CVarArg` protocol support to `NSString` and `String`.

```
print(String(format: "Testing %@ %@ %@", "One", "Two", "Three"))

Testing One Two Three
```

`NSString` support was easy since `%@` already exists for `CFString` in CoreFoundation.

`String` was a little bit more challenging, since `withVaList` doesn't provide an autorelease pool to retain the required `NSString` instance, which is needed for the `CFString`.

I solved this by using `OperationQueue` to schedule the release.  I'm not sure if there are any other options at this point.

This resolves [SR-957](https://bugs.swift.org/browse/SR-957).