### PR TITLE
ICU: Disable a test in preperation for upgrading to ICU67

### DIFF
--- a/Tests/Foundation/Tests/TestNSNumber.swift
+++ b/Tests/Foundation/Tests/TestNSNumber.swift
@@ -1149,10 +1149,10 @@ class TestNSNumber : XCTestCase {
         XCTAssertEqual(NSNumber(value: Double.zero).description(withLocale: Locale(identifier: "en_GB")), "0")
         XCTAssertEqual(NSNumber(value: Double.nan).description(withLocale: Locale(identifier: "en_GB")), "NaN")
         XCTAssertEqual(NSNumber(value: Double.leastNormalMagnitude).description(withLocale: Locale(identifier: "en_GB")), "2.225073858507201E-308")
-        // Currently disabled as the latest ICU (62+) which uses Google's dobule-conversion library currently converts Double.leastNonzeroMagnitude to 0
-        // although the ICU61 version correctly converted it to 5E-324 - Test left in to check for the bug being fixed in the future.
+        // Currently disabled as the latest ICU (62+) which uses Google's double-conversion library currently converts Double.leastNonzeroMagnitude to 0
+        // although ICU61 version correctly converted it to 5E-324 - Test left in to check for the bug being fixed in the future.
+        // This test works in ICU67 so re-enable it after upgrading.
         //XCTAssertEqual(NSNumber(value: Double.leastNonzeroMagnitude).description(withLocale: Locale(identifier: "en_GB")), "5E-324")
-        XCTAssertEqual(NSNumber(value: Double.leastNonzeroMagnitude).description(withLocale: Locale(identifier: "en_GB")), "0E+00")
         XCTAssertEqual(NSNumber(value: 2 * Double.leastNonzeroMagnitude).description(withLocale: Locale(identifier: "en_GB")), "1E-323")
         XCTAssertEqual(NSNumber(value: Double.greatestFiniteMagnitude).description(withLocale: Locale(identifier: "en_GB")), "1.797693134862316E+308")
 
@@ -1197,10 +1197,10 @@ class TestNSNumber : XCTestCase {
         XCTAssertEqual(NSNumber(value: Double.zero).description(withLocale: Locale(identifier: "de_DE")), "0")
         XCTAssertEqual(NSNumber(value: Double.nan).description(withLocale: Locale(identifier: "de_DE")), "NaN")
         XCTAssertEqual(NSNumber(value: Double.leastNormalMagnitude).description(withLocale: Locale(identifier: "de_DE")), "2,225073858507201E-308")
-        // Currently disabled as the latest ICU (62+) which uses Google's dobule-conversion library currently converts Double.leastNonzeroMagnitude to 0
-        // although the ICU61 version correctly converted it to 5E-324 - Test left in to check for the bug being fixed in the future.
+        // Currently disabled as the latest ICU (62+) which uses Google's double-conversion library currently converts Double.leastNonzeroMagnitude to 0
+        // although ICU61 version correctly converted it to 5E-324 - Test left in to check for the bug being fixed in the future.
+        // This test works in ICU67 so re-enable it after upgrading.
         //XCTAssertEqual(NSNumber(value: Double.leastNonzeroMagnitude).description(withLocale: Locale(identifier: "de_DE")), "5E-324")
-        XCTAssertEqual(NSNumber(value: Double.leastNonzeroMagnitude).description(withLocale: Locale(identifier: "de_DE")), "0E+00")
         XCTAssertEqual(NSNumber(value: 2 * Double.leastNonzeroMagnitude).description(withLocale: Locale(identifier: "de_DE")), "1E-323")
         XCTAssertEqual(NSNumber(value: Double.greatestFiniteMagnitude).description(withLocale: Locale(identifier: "de_DE")), "1,797693134862316E+308")
     }


### PR DESCRIPTION
- Converting Double.leastNonzeroMagnitude with a Locale would result
  in the value '0E+00' instead of the correct '5E-324' in some versions
  of ICU (62-66). Disable the test against '0E+00' so that it wont break
  upgrading to ICU67.