### PR TITLE
SR-9930: Re-enable assertion in TestProcess.test_passthrough_environment()

### DIFF
--- a/Tests/Foundation/Tests/TestProcess.swift
+++ b/Tests/Foundation/Tests/TestProcess.swift
@@ -217,9 +217,7 @@ class TestProcess : XCTestCase {
             let env = try parseEnv(output)
             XCTAssertGreaterThan(env.count, 0)
         } catch {
-            // FIXME: SR-9930 parseEnv fails if an environment variable contains
-            // a newline.
-            // XCTFail("Test failed: \(error)")
+            XCTFail("Test failed: \(error)")
         }
     }
 


### PR DESCRIPTION
- This test is believed to have broken due to thread issues when reading
  from stdout/stderr of the child process.

- The threading issue was fixed in https://github.com/apple/swift-corelibs-foundation/pull/2523