### PR TITLE
Flesh out URLError information upon URLSessionTask cancellation

### DIFF
--- a/Tests/Foundation/Tests/TestURLSession.swift
+++ b/Tests/Foundation/Tests/TestURLSession.swift
@@ -1443,6 +1443,9 @@ class TestURLSession: LoopbackServerTest {
             XCTAssertNotNil(error as? URLError)
             if let urlError = error as? URLError {
                 XCTAssertEqual(urlError._nsError.code, NSURLErrorCancelled)
+                XCTAssertEqual(urlError.userInfo[NSURLErrorFailingURLErrorKey] as? URL, URL(string: urlString))
+                XCTAssertEqual(urlError.userInfo[NSURLErrorFailingURLStringErrorKey] as? String, urlString)
+                XCTAssertEqual(urlError.localizedDescription, "cancelled")
             }
 
             expect.fulfill()


### PR DESCRIPTION
The `URLError` received upon `URLSessionTask` cancellation by a `URLSessionTaskDelegate` or completion handler has a blank `userInfo` dictionary. This is an inconsistency when compared with macOS's Foundation and it makes actual error handling harder than it could be.

This PR fills it out to match the fields filled out by macOS Foundation.

I previously reported this as https://bugs.swift.org/browse/SR-13017, and I believe this fixes that (if a fix is even desirable, that is.)