### PR TITLE
Fix more warnings.

### DIFF
--- a/Tests/Foundation/Tests/TestJSONEncoder.swift
+++ b/Tests/Foundation/Tests/TestJSONEncoder.swift
@@ -623,7 +623,7 @@ class TestJSONEncoder : XCTestCase {
     // UInt and Int
     func test_codingOfUIntMinMax() {
 
-        struct MyValue: Codable {
+        struct MyValue: Encodable {
             let int64Min = Int64.min
             let int64Max = Int64.max
             let uint64Min = UInt64.min

--- a/Tests/Foundation/Tests/TestNSString.swift
+++ b/Tests/Foundation/Tests/TestNSString.swift
@@ -33,7 +33,7 @@ class TestNSString: LoopbackServerTest {
         let testString = "\u{00} This is a test string"
         let data = testString.data(using: .utf8)!
         XCTAssertEqual(data.count, 23)
-        _ = data.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
+        data.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
             if let text1 = NSString(bytes: bytes.baseAddress!, length: data.count, encoding: String.Encoding.utf8.rawValue) {
                 XCTAssertEqual(text1.length, data.count)
                 XCTAssertEqual(text1, testString as NSString)

--- a/Tests/Foundation/Tests/TestStream.swift
+++ b/Tests/Foundation/Tests/TestStream.swift
@@ -162,7 +162,7 @@ class TestStream : XCTestCase {
         XCTAssertEqual(try testSubdata(UInt64(str.count))!.count, 0) // It shouldbe end
         
         do {
-            try testSubdata(UInt64(str.count + 1)) // out of boundaries
+            _ = try testSubdata(UInt64(str.count + 1)) // out of boundaries
             XCTFail()
         } catch let error as InputStream._Error {
             XCTAssertEqual(error, .cantSeekInputStream)

--- a/Tests/Foundation/Tests/TestURLSession.swift
+++ b/Tests/Foundation/Tests/TestURLSession.swift
@@ -357,7 +357,7 @@ class TestURLSession: LoopbackServerTest {
         config.timeoutIntervalForRequest = 5
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/requestHeaders"
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
-        var expect = expectation(description: "POST \(urlString): get request headers")
+        let expect = expectation(description: "POST \(urlString): get request headers")
         var req = URLRequest(url: URL(string: urlString)!)
         let headers = ["header1": "value1"]
         req.httpMethod = "POST"
@@ -384,7 +384,7 @@ class TestURLSession: LoopbackServerTest {
         config.httpAdditionalHeaders = ["header2": "svalue2", "header3": "svalue3", "header4": "svalue4"]
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/requestHeaders"
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
-        var expect = expectation(description: "POST \(urlString) with additional headers")
+        let expect = expectation(description: "POST \(urlString) with additional headers")
         var req = URLRequest(url: URL(string: urlString)!)
         let headers = ["header1": "rvalue1", "header2": "rvalue2", "Header4": "rvalue4"]
         req.httpMethod = "POST"
@@ -411,7 +411,7 @@ class TestURLSession: LoopbackServerTest {
         config.timeoutIntervalForRequest = 5
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/Peru"
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
-        var expect = expectation(description: "GET \(urlString): no timeout")
+        let expect = expectation(description: "GET \(urlString): no timeout")
         let req = URLRequest(url: URL(string: urlString)!)
         let task = session.dataTask(with: req) { (data, _, error) -> Void in
             defer { expect.fulfill() }
@@ -427,7 +427,7 @@ class TestURLSession: LoopbackServerTest {
         config.timeoutIntervalForRequest = 10
         let urlString = "http://127.0.0.1:-1/Peru"
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
-        var expect = expectation(description: "GET \(urlString): will timeout")
+        let expect = expectation(description: "GET \(urlString): will timeout")
         var req = URLRequest(url: URL(string: "http://127.0.0.1:-1/Peru")!)
         req.timeoutInterval = 1
         let task = session.dataTask(with: req) { (data, _, error) -> Void in
@@ -754,7 +754,7 @@ class TestURLSession: LoopbackServerTest {
         var req = URLRequest(url: URL(string: urlString)!)
         req.timeoutInterval = 3
         let config = URLSessionConfiguration.default
-        var expect = expectation(description: "GET \(urlString): timeout with redirection ")
+        let expect = expectation(description: "GET \(urlString): timeout with redirection ")
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
         let task = session.dataTask(with: req) { data, response, error in
             defer { expect.fulfill() }
@@ -1176,7 +1176,7 @@ class TestURLSession: LoopbackServerTest {
         XCTAssertEqual(config.httpCookieStorage?.cookies?.count, 0)
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/requestCookies"
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
-        var expect = expectation(description: "POST \(urlString)")
+        let expect = expectation(description: "POST \(urlString)")
         var req = URLRequest(url: URL(string: urlString)!)
         req.httpMethod = "POST"
         let task = session.dataTask(with: req) { (data, response, error) -> Void in
@@ -1201,7 +1201,7 @@ class TestURLSession: LoopbackServerTest {
         emptyCookieStorage(storage: config.httpCookieStorage)
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/requestCookies"
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
-        var expect = expectation(description: "POST \(urlString)")
+        let expect = expectation(description: "POST \(urlString)")
         var req = URLRequest(url: URL(string: urlString)!)
         req.httpMethod = "POST"
         let task = session.dataTask(with: req) { (data, response, error) -> Void in
@@ -1226,7 +1226,7 @@ class TestURLSession: LoopbackServerTest {
         emptyCookieStorage(storage: config.httpCookieStorage)
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/redirectToEchoHeaders"
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
-        var expect = expectation(description: "POST \(urlString)")
+        let expect = expectation(description: "POST \(urlString)")
         let req = URLRequest(url: URL(string: urlString)!)
         let task = session.dataTask(with: req) { (data, _, error) -> Void in
             defer { expect.fulfill() }
@@ -1294,7 +1294,7 @@ class TestURLSession: LoopbackServerTest {
 
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/requestCookies"
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
-        var expect = expectation(description: "POST \(urlString)")
+        let expect = expectation(description: "POST \(urlString)")
         var req = URLRequest(url: URL(string: urlString)!)
         req.httpMethod = "POST"
         let task = session.dataTask(with: req) { (data, _, error) -> Void in
@@ -1404,7 +1404,7 @@ class TestURLSession: LoopbackServerTest {
         config.timeoutIntervalForRequest = 5
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/emptyPost"
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
-        var expect = expectation(description: "POST \(urlString): post with empty body")
+        let expect = expectation(description: "POST \(urlString): post with empty body")
         var req = URLRequest(url: URL(string: urlString)!)
         req.httpMethod = "POST"
         let task = session.dataTask(with: req) { (_, response, error) -> Void in


### PR DESCRIPTION
- Use 'let' instead of 'var' on some immutable variables.

- TestJSONEncoder: Change a test struct from Codable to Encodable
  as the contents are constant and cant be used for Decoding.