### PR TITLE
SR-13015: Decimal calculation incorrect on Linux

### DIFF
--- a/Sources/Foundation/Decimal.swift
+++ b/Sources/Foundation/Decimal.swift
@@ -1025,7 +1025,7 @@ fileprivate func integerMultiply<T:VariableLengthNumber>(_ big: inout T,
                 accumulator = UInt32(carry) + bigij + UInt32(right[j]) * UInt32(left[i])
                 carry = UInt16(truncatingIfNeeded:accumulator >> 16)
                 big[i+j] = UInt16(truncatingIfNeeded:accumulator)
-            } else if carry != 0 || (right[j] == 0 && left[j] == 0) {
+            } else if carry != 0 || (right[j] > 0 && left[i] > 0) {
                 return .overflow
             }
         }


### PR DESCRIPTION
Fix typo and logic error in the overflow check in `integerMultiply()`, which was screwing up Decimal calculations under certain conditions.

I was able to reproduce on Android and spent hours tracking this down on there. I'm guessing it only worked on macOS because this code is unused on there.