### PR TITLE
[5.3] Return success from `FileManager` recursive directory creation even if a directory was created by another thread concurrently.

### DIFF
--- a/Tests/Foundation/Tests/TestFileManager.swift
+++ b/Tests/Foundation/Tests/TestFileManager.swift
@@ -15,6 +15,8 @@
     #endif
 #endif
 
+import Dispatch
+
 class TestFileManager : XCTestCase {
 #if os(Windows)
     let pathSep = "\\"
@@ -1755,6 +1757,49 @@ VIDEOS=StopgapVideos
         }
         #endif
     }
+
+    /**
+     Tests that we can get an item replacement directory concurrently.
+
+     - Bug: [SR-12272](https://bugs.swift.org/browse/SR-12272)
+     */
+    func test_concurrentGetItemReplacementDirectory() throws {
+        let fileManager = FileManager.default
+
+        let operationCount = 10
+
+        var directoryURLs = [URL?](repeating: nil, count: operationCount)
+        var errors = [Error?](repeating: nil, count: operationCount)
+
+        let dispatchGroup = DispatchGroup()
+        for operationIndex in 0..<operationCount {
+            DispatchQueue.global().async(group: dispatchGroup) {
+                do {
+                    let directory = try fileManager.url(for: .itemReplacementDirectory,
+                                                        in: .userDomainMask,
+                                                        appropriateFor: URL(fileURLWithPath: NSTemporaryDirectory(),
+                                                                            isDirectory: true),
+                                                        create: true)
+                    directoryURLs[operationIndex] = directory
+                } catch {
+                    errors[operationIndex] = error
+                }
+            }
+        }
+        dispatchGroup.wait()
+
+        for directoryURL in directoryURLs {
+            if let directoryURL = directoryURL {
+                try? fileManager.removeItem(at: directoryURL)
+            }
+        }
+
+        for error in errors {
+            if let error = error {
+                XCTFail("One of the concurrent calls to get the item replacement directory failed: \(error)")
+            }
+        }
+    }
     
     // -----
     
@@ -1812,6 +1857,7 @@ VIDEOS=StopgapVideos
             ("test_contentsEqual", test_contentsEqual),
             /* ⚠️  */ ("test_replacement", testExpectedToFail(test_replacement,
             /* ⚠️  */     "<https://bugs.swift.org/browse/SR-10819> Re-enable Foundation test TestFileManager.test_replacement")),
+            ("test_concurrentGetItemReplacementDirectory", test_concurrentGetItemReplacementDirectory),
         ]
         
         #if !DEPLOYMENT_RUNTIME_OBJC && NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT && !os(Android)


### PR DESCRIPTION
If another thread creates one of the same directories in the target path, the `!fileExists` check may pass while the `mkdir` call fails with `EEXIST`. However, if the existing file is a directory, then that should still be a success.

Fixes [SR-12272](https://bugs.swift.org/browse/SR-12272).

(cherry picked from commit b6eea02e84ea46e8bc36588f250d36930fe2ee80)