### PR TITLE
Fix more var/let warnings.

### DIFF
--- a/Sources/Foundation/FileHandle.swift
+++ b/Sources/Foundation/FileHandle.swift
@@ -1015,7 +1015,7 @@ open class Pipe: NSObject {
                                                closeOnDealloc: true)
 #else
         /// the `pipe` system call creates two `fd` in a malloc'ed area
-        var fds = UnsafeMutablePointer<Int32>.allocate(capacity: 2)
+        let fds = UnsafeMutablePointer<Int32>.allocate(capacity: 2)
         defer {
             fds.deallocate()
         }

--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -894,8 +894,8 @@ open class FileManager : NSObject {
         guard let file1 = FileHandle(fileSystemRepresentation: file1Rep, flags: O_RDONLY, createMode: 0) else { return false }
         guard let file2 = FileHandle(fileSystemRepresentation: file2Rep, flags: O_RDONLY, createMode: 0) else { return false }
 
-        var buffer1 = UnsafeMutablePointer<UInt8>.allocate(capacity: bufSize)
-        var buffer2 = UnsafeMutablePointer<UInt8>.allocate(capacity: bufSize)
+        let buffer1 = UnsafeMutablePointer<UInt8>.allocate(capacity: bufSize)
+        let buffer2 = UnsafeMutablePointer<UInt8>.allocate(capacity: bufSize)
         defer {
             buffer1.deallocate()
             buffer2.deallocate()

--- a/Sources/Foundation/JSONSerialization.swift
+++ b/Sources/Foundation/JSONSerialization.swift
@@ -832,7 +832,6 @@ private struct JSONReader {
         var string = ""
         var isInteger = true
         var exponent = 0
-        var positiveExponent = true
         var index = input
         var digitCount: Int?
         var ascii: UInt8 = 0    // set by nextASCII()
@@ -903,6 +902,8 @@ private struct JSONReader {
 
             // Process the exponent
             isInteger = false
+            let positiveExponent: Bool
+
             guard nextASCII() else { return false }
             if ascii == JSONReader.MINUS {
                 positiveExponent = false
@@ -910,6 +911,8 @@ private struct JSONReader {
             } else if ascii == JSONReader.PLUS {
                 positiveExponent = true
                 guard nextASCII() else { return false }
+            } else {
+                positiveExponent = true
             }
             guard JSONReader.allDigits.contains(ascii) else { return false }
             exponent = Int(ascii - JSONReader.ZERO)
@@ -921,6 +924,7 @@ private struct JSONReader {
                     return false
                 }
             }
+            exponent = positiveExponent ? exponent : -exponent
             return true
         }
 

--- a/Tests/Foundation/Tests/TestURLSession.swift
+++ b/Tests/Foundation/Tests/TestURLSession.swift
@@ -138,7 +138,8 @@ class TestURLSession: LoopbackServerTest {
                         let error = delegate.error as? URLError
                         XCTAssertEqual(error?.code.rawValue, NSURLErrorDataLengthExceedsMaximum)
                         XCTAssertEqual(error?.localizedDescription, "resource exceeds maximum size")
-                        let userInfo = error?.userInfo as? [String: Any]
+                        let userInfo = error?.userInfo
+                        XCTAssertNotNil(userInfo)
                         let errorURL = userInfo?[NSURLErrorFailingURLErrorKey] as? URL
                         XCTAssertEqual(errorURL, url)
 
@@ -823,7 +824,8 @@ class TestURLSession: LoopbackServerTest {
             let error = delegate.error as? URLError
             XCTAssertEqual(error?.code.rawValue, NSURLErrorHTTPTooManyRedirects)
             XCTAssertEqual(error?.localizedDescription, "too many HTTP redirects")
-            let userInfo = error?.userInfo as? [String: Any]
+            let userInfo = error?.userInfo
+            XCTAssertNotNil(userInfo)
             let errorURL = userInfo?[NSURLErrorFailingURLErrorKey] as? URL
             XCTAssertEqual(errorURL, exceededCountUrl)
 
@@ -1092,7 +1094,8 @@ class TestURLSession: LoopbackServerTest {
                         let error = delegate.error as? URLError
                         XCTAssertEqual(error?.code.rawValue, NSURLErrorDataLengthExceedsMaximum)
                         XCTAssertEqual(error?.localizedDescription, "resource exceeds maximum size")
-                        let userInfo = error?.userInfo as? [String: Any]
+                        let userInfo = error?.userInfo
+                        XCTAssertNotNil(userInfo)
                         let errorURL = userInfo?[NSURLErrorFailingURLErrorKey] as? URL
                         XCTAssertEqual(errorURL, url)
 
@@ -1251,12 +1254,12 @@ class TestURLSession: LoopbackServerTest {
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
 
         let urlString1 = "http://127.0.0.1:\(TestURLSession.serverPort)/requestCookies"
-        var expect1 = expectation(description: "POST \(urlString1)")
+        let expect1 = expectation(description: "POST \(urlString1)")
         var req1 = URLRequest(url: URL(string: urlString1)!)
         req1.httpMethod = "POST"
 
         let urlString2 = "http://127.0.0.1:\(TestURLSession.serverPort)/echoHeaders"
-        var expect2 = expectation(description: "POST \(urlString2)")
+        let expect2 = expectation(description: "POST \(urlString2)")
         var req2 = URLRequest(url: URL(string: urlString2)!)
         req2.httpMethod = "POST"
 
@@ -1320,12 +1323,12 @@ class TestURLSession: LoopbackServerTest {
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
 
         let urlString1 = "http://127.0.0.1:\(TestURLSession.serverPort)/requestCookies"
-        var expect1 = expectation(description: "POST \(urlString1)")
+        let expect1 = expectation(description: "POST \(urlString1)")
         var req1 = URLRequest(url: URL(string: urlString1)!)
         req1.httpMethod = "POST"
 
         let urlString2 = "http://127.0.0.1:\(TestURLSession.serverPort)/echoHeaders"
-        var expect2 = expectation(description: "POST \(urlString2)")
+        let expect2 = expectation(description: "POST \(urlString2)")
         var req2 = URLRequest(url: URL(string: urlString2)!)
         req2.httpMethod = "POST"
 
@@ -1695,7 +1698,8 @@ class TestURLSession: LoopbackServerTest {
                     let error = delegate.error as? URLError
                     XCTAssertEqual(error?.code.rawValue, NSURLErrorDataLengthExceedsMaximum)
                     XCTAssertEqual(error?.localizedDescription, "resource exceeds maximum size")
-                    let userInfo = error?.userInfo as? [String: Any]
+                    let userInfo = error?.userInfo
+                    XCTAssertNotNil(userInfo)
                     let errorURL = userInfo?[NSURLErrorFailingURLErrorKey] as? URL
                     XCTAssertEqual(errorURL, url)
                     XCTAssertNil(delegate.response)


### PR DESCRIPTION
- TestURLSession: URLError.userInfo is now [String: Any] so remove
  unnecessary as? cast.