### PR TITLE
NSDecimalNumber: Fix comparison with NSNumber

### DIFF
--- a/Sources/Foundation/NSDecimalNumber.swift
+++ b/Sources/Foundation/NSDecimalNumber.swift
@@ -324,13 +324,14 @@ open class NSDecimalNumber : NSNumber {
         NSDecimalRound(&result, &input, Int(scale), roundingMode)
         return NSDecimalNumber(decimal: result)
     }
-    
+
     // compare two NSDecimalNumbers
     open override func compare(_ decimalNumber: NSNumber) -> ComparisonResult {
         if let num = decimalNumber as? NSDecimalNumber {
-            return decimal.compare(to:num.decimal)
+            return decimal.compare(to: num.decimal)
         } else {
-            return decimal.compare(to:Decimal(decimalNumber.doubleValue))
+            // NOTE: The lhs must be an NSNumber and not self (an NSDecimalNumber) so that NSNumber.compare() is used
+            return decimalNumber.compare(self)
         }
     }
 
@@ -402,8 +403,14 @@ open class NSDecimalNumber : NSNumber {
     }
 
     open override func isEqual(_ value: Any?) -> Bool {
-        guard let other = value as? NSDecimalNumber else { return false }
-        return self.decimal == other.decimal
+        if let other = value as? NSDecimalNumber {
+            return self.decimal == other.decimal
+        }
+        if  let other = value as? NSNumber {
+            // NOTE: The lhs must be an NSNumber and not self (an NSDecimalNumber) so that NSNumber.compare() is used
+            return other.compare(self) == .orderedSame
+        }
+        return false
     }
 
     override var _swiftValueOfOptimalType: Any {

--- a/Sources/Foundation/NSNumber.swift
+++ b/Sources/Foundation/NSNumber.swift
@@ -590,7 +590,7 @@ open class NSNumber : NSValue {
     open override var hash: Int {
         return Int(bitPattern: CFHash(_cfObject))
     }
-    
+
     open override func isEqual(_ value: Any?) -> Bool {
         // IMPORTANT:
         // .isEqual() is invoked by the bridging machinery that gets triggered whenever you use '(-a NSNumber value-) as{,?,!} Int', so using a refutable pattern ('case let other as NSNumber') below will cause an infinite loop if value is an Int, and similarly for other types we can bridge to.
@@ -960,6 +960,10 @@ open class NSNumber : NSValue {
             if lhs.low > rhs.low { return .orderedDescending }
             return .orderedSame
         }
+    }
+
+    open func isEqual(to number: NSNumber) -> Bool {
+        return compare(number) == .orderedSame
     }
 
     open func description(withLocale locale: Locale?) -> String {

--- a/Tests/Foundation/Tests/TestDecimal.swift
+++ b/Tests/Foundation/Tests/TestDecimal.swift
@@ -1254,6 +1254,32 @@ class TestDecimal: XCTestCase {
         XCTAssertEqual(d8?._length, 1)
     }
 
+    func test_NSNumberEquality() {
+
+        let values = [
+            (NSNumber(value: Int.min), NSDecimalNumber(decimal: Decimal(Int.min))),
+            (NSNumber(value: Int.max), NSDecimalNumber(decimal: Decimal(Int.max))),
+            (NSNumber(value: Double(1.1)), NSDecimalNumber(decimal: Decimal(Double(1.1)))),
+            (NSNumber(value: Float(-1.0)), NSDecimalNumber(decimal: Decimal(-1))),
+            (NSNumber(value: Int8(1)), NSDecimalNumber(decimal: Decimal(1))),
+            (NSNumber(value: UInt8.max), NSDecimalNumber(decimal: Decimal(255))),
+            (NSNumber(value: Int16.min), NSDecimalNumber(decimal: Decimal(-32768))),
+        ]
+
+        for pair in values {
+            let number = pair.0
+            let decimalNumber = pair.1
+
+            XCTAssertEqual(number.compare(decimalNumber), .orderedSame)
+            XCTAssertTrue(number.isEqual(to: decimalNumber))
+            XCTAssertEqual(number, decimalNumber)
+
+            XCTAssertEqual(decimalNumber.compare(number), .orderedSame)
+            XCTAssertTrue(decimalNumber.isEqual(to: number))
+            XCTAssertEqual(decimalNumber, number)
+        }
+    }
+
     static var allTests : [(String, (TestDecimal) -> () throws -> Void)] {
         return [
             ("test_NSDecimalNumberInit", test_NSDecimalNumberInit),
@@ -1283,6 +1309,7 @@ class TestDecimal: XCTestCase {
             ("test_NSDecimalString", test_NSDecimalString),
             ("test_multiplyingByPowerOf10", test_multiplyingByPowerOf10),
             ("test_initExactly", test_initExactly),
+            ("test_NSNumberEquality", test_NSNumberEquality),
         ]
     }
 }


### PR DESCRIPTION
- NSDecimalNumber: When compare(_:) / isEqual(_:) has a rhs which is an
  NSNumber that cannot be cast as an NSDecimalNumber, use
  NSNumber.compare() to test them.

- NSNumber: Add missing isEqual(to:)