### PR TITLE
SR-13027: Fix URL encoding in redirects

### DIFF
--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
@@ -476,9 +476,9 @@ internal class _HTTPURLProtocol: _NativeProtocol {
             // We need this ugly cast in order to be able to support `URLSessionTask.init()`
             session.delegateQueue.addOperation {
                 delegate.urlSession(session, task: self.task!, willPerformHTTPRedirection: response as! HTTPURLResponse, newRequest: request) { [weak self] (request: URLRequest?) in
-                    guard let task = self else { return }
-                    self?.task?.workQueue.async {
-                        task.didCompleteRedirectCallback(request)
+                    guard let self = self else { return }
+                    self.task?.workQueue.async {
+                        self.didCompleteRedirectCallback(request)
                     }
                 }
             }
@@ -651,7 +651,7 @@ internal extension _HTTPURLProtocol {
         //TODO: Do we ever want to redirect for HEAD requests?
         func methodAndURL() -> (String, URL)? {
             guard
-                let location = response.value(forHeaderField: .location, response: response),
+                let location = response.value(forHeaderField: .location),
                 let targetURL = URL(string: location)
                 else {
                     // Can't redirect when there's no location to redirect to.
@@ -728,10 +728,9 @@ fileprivate extension HTTPURLResponse {
         case location = "Location"
     }
 
-    func value(forHeaderField field: _Field, response: HTTPURLResponse?) -> String? {
+    func value(forHeaderField field: _Field) -> String? {
         let value = field.rawValue
-        guard let response = response else { fatalError("Response is nil") }
-        if let location = response.allHeaderFields[value] as? String {
+        if let location = self.allHeaderFields[value] as? String {
             return location
         }
         return nil

--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
@@ -689,28 +689,32 @@ internal extension _HTTPURLProtocol {
             return request
         }
 
-        let scheme = request.url?.scheme
-        let host = request.url?.host
-        let port = request.url?.port
+        guard
+            let fromUrl = fromRequest.url,
+            var components = URLComponents(url: fromUrl, resolvingAgainstBaseURL: false)
+            else { return nil }
 
-        var components = URLComponents()
-        components.scheme = scheme
-        components.host = host
-        // Use the original port if the new URL does not contain a host
-        // ie Location: /foo => <original host>:<original port>/Foo
-        // but Location: newhost/foo  will ignore the original port
-        if targetURL.host == nil {
-          components.port = port
+        // If the new URL contains a host, use the host and port from the new URL.
+        // Otherwise, the host and port from the original URL are used.
+        if targetURL.host != nil {
+            components.host = targetURL.host
+            components.port = targetURL.port
         }
-        //The path must either begin with "/" or be an empty string.
-        if targetURL.relativeString.first != "/" {
-            components.path = "/" + targetURL.relativeString
+        
+        // The path must either begin with "/" or be an empty string.
+        if targetURL.path.hasPrefix("/") {
+            components.path = targetURL.path
         } else {
-            components.path = targetURL.relativeString
+            components.path = "/" + targetURL.path
         }
+        
+        // The query and fragment components are set separately to prevent them from being
+        // percent encoded again.
+        components.percentEncodedQuery = targetURL.query
+        components.percentEncodedFragment = targetURL.fragment
 
-        guard let urlString = components.string else { fatalError("Invalid URL") }
-        request.url = URL(string: urlString)
+        guard let url = components.url else { fatalError("Invalid URL") }
+        request.url = url
 
         // Inherit the timeout from the previous request
         request.timeoutInterval = fromRequest.timeoutInterval

--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
@@ -716,8 +716,6 @@ internal extension _HTTPURLProtocol {
         guard let url = components.url else { fatalError("Invalid URL") }
         request.url = url
 
-        // Inherit the timeout from the previous request
-        request.timeoutInterval = fromRequest.timeoutInterval
         return request
     }
 }


### PR DESCRIPTION
This resolves a number of issues with how redirects are handled.

Query and fragment components were set as part of the path, resulting in them being percent-encoded even though they already are. Now, the path, query and fragment are set separately.

The authority component (username:password) from the original URL was not used in the new URL. Now, the new URL is constructed from the original, which ensures that the authority component is carried over.

Additionally, I've refactored a few things that were implemented in a slightly convoluted way.