### PR TITLE
build: centralise the install logic for the Swift modules

### DIFF
--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -161,12 +161,4 @@ endif()
 
 
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS Foundation)
-install(TARGETS Foundation
-  ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-  LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-  RUNTIME DESTINATION bin)
-get_swift_host_arch(swift_arch)
-install(FILES
-  $<TARGET_PROPERTY:Foundation,Swift_MODULE_DIRECTORY>/Foundation.swiftdoc
-  $<TARGET_PROPERTY:Foundation,Swift_MODULE_DIRECTORY>/Foundation.swiftmodule
-  DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})
+_install_target(Foundation)

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -70,12 +70,4 @@ set_target_properties(FoundationNetworking PROPERTIES
 
 
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS FoundationNetworking)
-install(TARGETS FoundationNetworking
-  ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-  LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-  RUNTIME DESTINATION bin)
-get_swift_host_arch(swift_arch)
-install(FILES
-  $<TARGET_PROPERTY:FoundationNetworking,Swift_MODULE_DIRECTORY>/FoundationNetworking.swiftdoc
-  $<TARGET_PROPERTY:FoundationNetworking,Swift_MODULE_DIRECTORY>/FoundationNetworking.swiftmodule
-  DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})
+_install_target(FoundationNetworking)

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -22,12 +22,4 @@ set_target_properties(FoundationXML PROPERTIES
 
 
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS FoundationXML)
-install(TARGETS FoundationXML
-  ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-  LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-  RUNTIME DESTINATION bin)
-get_swift_host_arch(swift_arch)
-install(FILES
-  $<TARGET_PROPERTY:FoundationXML,Swift_MODULE_DIRECTORY>/FoundationXML.swiftdoc
-  $<TARGET_PROPERTY:FoundationXML,Swift_MODULE_DIRECTORY>/FoundationXML.swiftmodule
-  DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})
+_install_target(FoundationXML)

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -35,3 +35,59 @@ function(get_swift_host_arch result_var_name)
     message(FATAL_ERROR "Unrecognized architecture on host system: ${CMAKE_SYSTEM_PROCESSOR}")
   endif()
 endfunction()
+
+# Returns the os name in a variable
+#
+# Usage:
+#   get_swift_host_os(result_var_name)
+#
+#
+# Sets ${result_var_name} with the converted OS name derived from
+# CMAKE_SYSTEM_NAME.
+function(get_swift_host_os result_var_name)
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(${result_var_name} macosx PARENT_SCOPE)
+  else()
+    string(TOLOWER ${CMAKE_SYSTEM_NAME} cmake_system_name_lc)
+    set(${result_var_name} ${cmake_system_name_lc} PARENT_SCOPE)
+  endif()
+endfunction()
+
+function(_install_target module)
+  get_swift_host_os(swift_os)
+  get_target_property(type ${module} TYPE)
+
+  if(type STREQUAL STATIC_LIBRARY)
+    set(swift swift_static)
+  else()
+    set(swift swift)
+  endif()
+
+  install(TARGETS ${module}
+    ARCHIVE DESTINATION lib/${swift}/${swift_os}
+    LIBRARY DESTINATION lib/${swift}/${swift_os}
+    RUNTIME DESTINATION bin)
+  if(type STREQUAL EXECUTABLE)
+    return()
+  endif()
+
+  get_swift_host_arch(swift_arch)
+  get_target_property(module_name ${module} Swift_MODULE_NAME)
+  if(NOT module_name)
+    set(module_name ${module})
+  endif()
+
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
+      DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
+      RENAME ${swift_arch}.swiftdoc)
+    install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
+      DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
+      RENAME ${swift_arch}.swiftmodule)
+  else()
+    install(FILES
+      $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
+      $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
+      DESTINATION lib/${swift}/${swift_os}/${swift_arch})
+  endif()
+endfunction()


### PR DESCRIPTION
Add support for installation for macOS targets to the CMake
installation.  Centralise the logic for the installation of the files.
This properly handles the installation of the swiftdoc, swiftinterface,
swiftmodule and the runtime libraries across all the platforms in either
static or shared configurations.