### PR TITLE
[5.2] improve URLError returned upon task cancellation

### DIFF
--- a/Foundation/URLSession/URLSessionTask.swift
+++ b/Foundation/URLSession/URLSessionTask.swift
@@ -363,11 +363,20 @@ open class URLSessionTask : NSObject, NSCopying {
      */
     open func cancel() {
         workQueue.sync {
-            guard self.state == .running || self.state == .suspended else { return }
-            self.state = .canceling
+            let canceled = self.syncQ.sync { () -> Bool in
+                guard self._state == .running || self._state == .suspended else { return true }
+                self._state = .canceling
+                return false
+            }
+            guard !canceled else { return }
             self._getProtocol { (urlProtocol) in
                 self.workQueue.async {
-                    let urlError = URLError(_nsError: NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil))
+                    var info = [NSLocalizedDescriptionKey: "\(URLError.Code.cancelled)" as Any]
+                    if let url = self.originalRequest?.url {
+                        info[NSURLErrorFailingURLErrorKey] = url
+                        info[NSURLErrorFailingURLStringErrorKey] = url.absoluteString
+                    }
+                    let urlError = URLError(_nsError: NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: info))
                     self.error = urlError
                     if let urlProtocol = urlProtocol {
                         urlProtocol.stopLoading()

--- a/TestFoundation/TestURLSession.swift
+++ b/TestFoundation/TestURLSession.swift
@@ -846,6 +846,9 @@ class TestURLSession : LoopbackServerTest {
             XCTAssertNotNil(error as? URLError)
             if let urlError = error as? URLError {
                 XCTAssertEqual(urlError._nsError.code, NSURLErrorCancelled)
+                XCTAssertEqual(urlError.userInfo[NSURLErrorFailingURLErrorKey] as? URL, URL(string: urlString))
+                XCTAssertEqual(urlError.userInfo[NSURLErrorFailingURLStringErrorKey] as? String, urlString)
+                XCTAssertEqual(urlError.localizedDescription, "cancelled")
             }
 
             expect.fulfill()


### PR DESCRIPTION
previously merged to master in https://github.com/apple/swift-corelibs-foundation/pull/2825
