### PR TITLE
[5.2] fix convenience accessors on CocoaError and URLError

### DIFF
--- a/Foundation/NSError.swift
+++ b/Foundation/NSError.swift
@@ -719,29 +719,29 @@ internal extension CocoaError {
 }
 
 public extension CocoaError {
-    private var _nsUserInfo: [AnyHashable : Any] {
+    private var _nsUserInfo: [String: Any] {
         return _nsError.userInfo
     }
 
     /// The file path associated with the error, if any.
     var filePath: String? {
-        return _nsUserInfo[NSFilePathErrorKey._bridgeToObjectiveC()] as? String
+        return _nsUserInfo[NSFilePathErrorKey] as? String
     }
 
     /// The string encoding associated with this error, if any.
     var stringEncoding: String.Encoding? {
-        return (_nsUserInfo[NSStringEncodingErrorKey._bridgeToObjectiveC()] as? NSNumber)
+        return (_nsUserInfo[NSStringEncodingErrorKey] as? NSNumber)
         .map { String.Encoding(rawValue: $0.uintValue) }
     }
 
     /// The underlying error behind this error, if any.
     var underlying: Error? {
-        return _nsUserInfo[NSUnderlyingErrorKey._bridgeToObjectiveC()] as? Error
+        return _nsUserInfo[NSUnderlyingErrorKey] as? Error
     }
 
     /// The URL associated with this error, if any.
     var url: URL? {
-        return _nsUserInfo[NSURLErrorKey._bridgeToObjectiveC()] as? URL
+        return _nsUserInfo[NSURLErrorKey] as? URL
     }
 }
 
@@ -911,18 +911,18 @@ public struct URLError : _BridgedStoredNSError {
 }
 
 extension URLError {
-    private var _nsUserInfo: [AnyHashable : Any] {
+    private var _nsUserInfo: [String: Any] {
         return _nsError.userInfo
     }
 
     /// The URL which caused a load to fail.
     public var failingURL: URL? {
-        return _nsUserInfo[NSURLErrorFailingURLErrorKey._bridgeToObjectiveC()] as? URL
+        return _nsUserInfo[NSURLErrorFailingURLErrorKey] as? URL
     }
 
     /// The string for the URL which caused a load to fail.
     public var failureURLString: String? {
-        return _nsUserInfo[NSURLErrorFailingURLStringErrorKey._bridgeToObjectiveC()] as? String
+        return _nsUserInfo[NSURLErrorFailingURLStringErrorKey] as? String
     }
 }
 

--- a/TestFoundation/TestNSError.swift
+++ b/TestFoundation/TestNSError.swift
@@ -107,3 +107,96 @@ class TestNSError : XCTestCase {
         }
     }
 }
+
+class TestURLError: XCTestCase {
+
+    static var allTests: [(String, (TestURLError) -> () throws -> Void)] {
+        return [
+          ("test_errorCode", TestURLError.test_errorCode),
+          ("test_failingURL", TestURLError.test_failingURL),
+          ("test_failingURLString", TestURLError.test_failingURLString),
+        ]
+    }
+
+    static let testURL = URL(string: "https://swift.org")!
+    let userInfo: [String: Any] =  [
+        NSURLErrorFailingURLErrorKey: TestURLError.testURL,
+        NSURLErrorFailingURLStringErrorKey: TestURLError.testURL.absoluteString,
+    ]
+
+    func test_errorCode() {
+        let e = URLError(.unsupportedURL)
+        XCTAssertEqual(e.errorCode, URLError.Code.unsupportedURL.rawValue)
+    }
+
+    func test_failingURL() {
+        let e = URLError(.badURL, userInfo: userInfo)
+        XCTAssertNotNil(e.failingURL)
+        XCTAssertEqual(e.failingURL, e.userInfo[NSURLErrorFailingURLErrorKey] as? URL)
+    }
+
+    func test_failingURLString() {
+        let e = URLError(.badURL, userInfo: userInfo)
+        XCTAssertNotNil(e.failureURLString)
+        XCTAssertEqual(e.failureURLString, e.userInfo[NSURLErrorFailingURLStringErrorKey] as? String)
+    }
+}
+
+class TestCocoaError: XCTestCase {
+
+    static var allTests: [(String, (TestCocoaError) -> () throws -> Void)] {
+        return [
+            ("test_errorCode", TestCocoaError.test_errorCode),
+            ("test_filePath", TestCocoaError.test_filePath),
+            ("test_url", TestCocoaError.test_url),
+            ("test_stringEncoding", TestCocoaError.test_stringEncoding),
+            ("test_underlying", TestCocoaError.test_underlying),
+        ]
+    }
+
+    static let testURL = URL(string: "file:///")!
+    let userInfo: [String: Any] =  [
+        NSURLErrorKey: TestCocoaError.testURL,
+        NSFilePathErrorKey: TestCocoaError.testURL.path,
+        NSUnderlyingErrorKey: POSIXError(.EACCES),
+        NSStringEncodingErrorKey: String.Encoding.utf16.rawValue,
+    ]
+
+    func test_errorCode() {
+        let e = CocoaError(.fileReadNoSuchFile)
+        XCTAssertEqual(e.errorCode, CocoaError.Code.fileReadNoSuchFile.rawValue)
+        XCTAssertEqual(e.isCoderError, false)
+        XCTAssertEqual(e.isExecutableError, false)
+        XCTAssertEqual(e.isFileError, true)
+        XCTAssertEqual(e.isFormattingError, false)
+        XCTAssertEqual(e.isPropertyListError, false)
+        XCTAssertEqual(e.isUbiquitousFileError, false)
+        XCTAssertEqual(e.isUserActivityError, false)
+        XCTAssertEqual(e.isValidationError, false)
+        XCTAssertEqual(e.isXPCConnectionError, false)
+    }
+
+    func test_filePath() {
+        let e = CocoaError(.fileWriteNoPermission, userInfo: userInfo)
+        XCTAssertNotNil(e.filePath)
+        XCTAssertEqual(e.filePath, TestCocoaError.testURL.path)
+    }
+
+    func test_url() {
+        let e = CocoaError(.fileReadNoSuchFile, userInfo: userInfo)
+        XCTAssertNotNil(e.url)
+        XCTAssertEqual(e.url, TestCocoaError.testURL)
+    }
+
+    func test_stringEncoding() {
+        let e = CocoaError(.fileReadUnknownStringEncoding, userInfo: userInfo)
+        XCTAssertNotNil(e.stringEncoding)
+        XCTAssertEqual(e.stringEncoding, .utf16)
+    }
+
+    func test_underlying() {
+        let e = CocoaError(.fileWriteNoPermission, userInfo: userInfo)
+        XCTAssertNotNil(e.underlying as? POSIXError)
+        XCTAssertEqual(e.underlying as? POSIXError, POSIXError.init(.EACCES))
+    }
+}

--- a/TestFoundation/main.swift
+++ b/TestFoundation/main.swift
@@ -42,6 +42,8 @@ var allTestCases = [
     testCase(TestDecimal.allTests),
     testCase(TestNSDictionary.allTests),
     testCase(TestNSError.allTests),
+    testCase(TestCocoaError.allTests),
+    testCase(TestURLError.allTests),
     testCase(TestEnergyFormatter.allTests),
     testCase(TestFileManager.allTests),
     testCase(TestNSGeometry.allTests),


### PR DESCRIPTION
- fixes SR-13037 (https://bugs.swift.org/browse/SR-13037)

(previously merged to master in https://github.com/apple/swift-corelibs-foundation/pull/2828)