### PR TITLE
[5.3] improve URLError returned upon task cancellation

### DIFF
--- a/Tests/Foundation/Tests/TestURLSession.swift
+++ b/Tests/Foundation/Tests/TestURLSession.swift
@@ -1443,6 +1443,9 @@ class TestURLSession: LoopbackServerTest {
             XCTAssertNotNil(error as? URLError)
             if let urlError = error as? URLError {
                 XCTAssertEqual(urlError._nsError.code, NSURLErrorCancelled)
+                XCTAssertEqual(urlError.userInfo[NSURLErrorFailingURLErrorKey] as? URL, URL(string: urlString))
+                XCTAssertEqual(urlError.userInfo[NSURLErrorFailingURLStringErrorKey] as? String, urlString)
+                XCTAssertEqual(urlError.localizedDescription, "cancelled")
             }
 
             expect.fulfill()


### PR DESCRIPTION
- fixes SR-13017 (https://bugs.swift.org/browse/SR-13017)

(previously merged to master in #2825)