### PR TITLE
Allow NSTemporaryDirectory() to be defined on Android

### DIFF
--- a/Sources/Foundation/NSPathUtilities.swift
+++ b/Sources/Foundation/NSPathUtilities.swift
@@ -64,9 +64,8 @@ public func NSTemporaryDirectory() -> String {
         }
     }
 #if os(Android)
-    // Bionic uses /data/local/tmp/ as temporary directory. TMPDIR is rarely
-    // defined.
-    return "/data/local/tmp/"
+    // Fall back to /data/local/tmp/, which is used by Bionic, if TMPDIR is not defined.
+    return ProcessInfo.processInfo.environment["TMPDIR"] ?? "/data/local/tmp/"
 #else
     return "/tmp/"
 #endif


### PR DESCRIPTION
`NSTemporaryDirectory()` currently returns the hard-coded path `/data/local/tmp/` on Android. While this directory is used by the system for temporary files, apps do not appear to have permission to write to it. This causes many operations in Foundation to fail, such as downloading a file using URLSession.

According to the [Android Documentation](https://developer.android.com/training/data-storage/app-specific#internal-create-cache), temporary files should be created using `File.createTempFile`. This creates a file in the default temporary-file directory, which corresponds to the directory obtain when calling `context.cacheDir`.

This PR allows a path to be provided through the `TMPDIR` environment variable. If it is not present, the current path will be used as fallback. Not only does it make `NSTemporaryDirectory()` usable from within an app, but it also allows the developer to choose whether temporary files are placed on internal or external storage.

The path to the app-specific temporary file directory can be set by calling 
```kotlin
Os.setenv("TMPDIR", context.cacheDir.path, true)
```
in Kotlin/Java before using `NSTemporaryDirectory()` in Swift.