### PR TITLE
[Windows] Fix NSURL.relativePath

### DIFF
--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -570,7 +570,19 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     
     // The same as path if baseURL is nil
     open var relativePath: String? {
-        return CFURLCopyFileSystemPath(_cfObject, kCFURLPOSIXPathStyle)?._swiftObject
+        guard var url = CFURLCopyFileSystemPath(_cfObject, kCFURLPOSIXPathStyle)?._swiftObject else {
+            return nil
+        }
+#if os(Windows)
+        // Per RFC 8089:E.2, if we have an absolute Windows/DOS path we can
+        // begin the URL with a drive letter rather than a `/`
+        let scalars = Array(url.unicodeScalars)
+        if isFileURL, url.isAbsolutePath,
+           scalars.count >= 3, scalars[0] == "/", scalars[2] == ":" {
+            url.removeFirst()
+        }
+#endif
+        return url
     }
     
     /* Determines if a given URL string's path represents a directory (i.e. the path component in the URL string ends with a '/' character). This does not check the resource the URL refers to.

--- a/Tests/Foundation/Tests/TestURL.swift
+++ b/Tests/Foundation/Tests/TestURL.swift
@@ -149,6 +149,22 @@ class TestURL : XCTestCase {
         XCTAssertEqual(url1, url3, "\(url1) was not equal to \(url3)")
     }
 
+    func test_relativeFilePath() {
+        let url1 = URL(fileURLWithPath: "/this/is/absolute", relativeTo: nil)
+        XCTAssertNil(url1.baseURL, "Absolute URLs should have no base URL")
+        XCTAssertEqual(url1.path, url1.relativePath, "URLs without base path should have equal path and relativePath")
+
+        let url2 = URL(fileURLWithPath: "this/is/relative", relativeTo: nil)
+        XCTAssertNotNil(url2.baseURL, "Relative URLs should have base URL assigned")
+        XCTAssertNotEqual(url2.path, url2.relativePath, "URLs without base path should have different path and relativePath")
+
+        #if os(Windows)
+        let url3 = URL(fileURLWithPath: "C:\\this\\is\\absolute", relativeTo: nil)
+        XCTAssertNil(url3.baseURL, "Absolute URLs should have no base URL")
+        XCTAssertEqual(url3.path, url3.relativePath, "URLs without base path should have equal path and relativePath")
+        #endif
+    }
+
     /// Returns a URL from the given url string and base
     private func URLWithString(_ urlString : String, baseString : String?) -> URL? {
         if let baseString = baseString {
@@ -780,6 +796,7 @@ class TestURL : XCTestCase {
         var tests: [(String, (TestURL) -> () throws -> Void)] = [
             ("test_URLStrings", test_URLStrings),
             ("test_fileURLWithPath_relativeTo", test_fileURLWithPath_relativeTo ),
+            ("test_relativeFilePath", test_relativeFilePath),
             // TODO: these tests fail on linux, more investigation is needed
             ("test_fileURLWithPath", test_fileURLWithPath),
             ("test_fileURLWithPath_isDirectory", test_fileURLWithPath_isDirectory),


### PR DESCRIPTION
The `path` property of `NSURL` contains important code for handling absolute paths with drive letters.

This adds similar handling to `relativePath`. Otherwise URLs like `C:\Some\Path` would report invalid relative path starting with `/C:`.
