### PR TITLE
Install uuid when statically building Foundation

### DIFF
--- a/Sources/UUID/CMakeLists.txt
+++ b/Sources/UUID/CMakeLists.txt
@@ -22,4 +22,10 @@ set_target_properties(uuid PROPERTIES
 
 if(NOT BUILD_SHARED_LIBS)
   set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS uuid)
+
+  get_swift_host_arch(swift_arch)
+  install(TARGETS uuid
+    ARCHIVE DESTINATION lib/swift_static/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch}
+    LIBRARY DESTINATION lib/swift_static/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch}
+    RUNTIME DESTINATION bin)
 endif()


### PR DESCRIPTION
When building the shared libs, this will be included in `libFoundation.so`, but when building the static libs, we have to install it with the other libraries, so it can be found when linking user binaries.