### PR TITLE
Add modulemaps that work for statically compiled Foundation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,39 +62,44 @@ if(ENABLE_TESTING)
   add_subdirectory(Tests)
 endif()
 
+set(swift_lib_dir "lib/swift")
+
 if(NOT BUILD_SHARED_LIBS)
+  set(swift_lib_dir "lib/swift_static")
+  
   set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS
     CoreFoundation CFXMLInterface CFURLSessionInterface)
   install(TARGETS CoreFoundation CFXMLInterface CFURLSessionInterface
     DESTINATION lib/swift_static/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>)
 endif()
+
 # TODO(compnerd) install as a Framework as that is how swift actually is built
 install(DIRECTORY
           ${CMAKE_CURRENT_BINARY_DIR}/CoreFoundation.framework/Headers/
         DESTINATION
-          lib/swift/CoreFoundation
+          ${swift_lib_dir}/CoreFoundation
         FILES_MATCHING PATTERN "*.h")
 install(FILES
-          CoreFoundation/Base.subproj/module.map
+          CoreFoundation/Base.subproj/$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:static/>module.map
         DESTINATION
-          lib/swift/CoreFoundation)
+          ${swift_lib_dir}/CoreFoundation)
 install(DIRECTORY
           ${CMAKE_CURRENT_BINARY_DIR}/CFURLSessionInterface.framework/Headers/
         DESTINATION
-          lib/swift/CFURLSessionInterface
+          ${swift_lib_dir}/CFURLSessionInterface
         FILES_MATCHING PATTERN "*.h")
 install(FILES
-          CoreFoundation/URL.subproj/module.map
+          CoreFoundation/URL.subproj/$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:static/>module.map
         DESTINATION
-          lib/swift/CFURLSessionInterface)
+          ${swift_lib_dir}/CFURLSessionInterface)
 install(DIRECTORY
           ${CMAKE_CURRENT_BINARY_DIR}/CFXMLInterface.framework/Headers/
         DESTINATION
-          lib/swift/CFXMLInterface
+          ${swift_lib_dir}/CFXMLInterface
         FILES_MATCHING PATTERN "*.h")
 install(FILES
-          CoreFoundation/Parsing.subproj/module.map
+          CoreFoundation/Parsing.subproj/$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:static/>module.map
         DESTINATION
-          lib/swift/CFXMLInterface)
+          ${swift_lib_dir}/CFXMLInterface)
 
 add_subdirectory(cmake/modules)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,15 +62,16 @@ if(ENABLE_TESTING)
   add_subdirectory(Tests)
 endif()
 
-set(swift_lib_dir "lib/swift")
-
 if(NOT BUILD_SHARED_LIBS)
-  set(swift_lib_dir "lib/swift_static")
-  
   set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS
     CoreFoundation CFXMLInterface CFURLSessionInterface)
   install(TARGETS CoreFoundation CFXMLInterface CFURLSessionInterface
     DESTINATION lib/swift_static/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>)
+endif()
+
+set(swift_lib_dir "lib/swift")
+if(NOT BUILD_SHARED_LIBS)
+  set(swift_lib_dir "lib/swift_static")
 endif()
 
 # TODO(compnerd) install as a Framework as that is how swift actually is built

--- a/CoreFoundation/Base.subproj/static/module.map
+++ b/CoreFoundation/Base.subproj/static/module.map
@@ -1,0 +1,7 @@
+module CoreFoundation [extern_c] [system] {
+    umbrella header "CoreFoundation.h"
+    explicit module CFPlugInCOM { header "CFPlugInCOM.h" }
+
+    link "CoreFoundation"
+    link "uuid"
+}

--- a/CoreFoundation/Parsing.subproj/static/module.map
+++ b/CoreFoundation/Parsing.subproj/static/module.map
@@ -1,0 +1,6 @@
+module CFXMLInterface [extern_c] [system] {
+    umbrella header "CFXMLInterface.h"
+
+    link "CFXMLInterface"
+    link "xml2"
+}

--- a/CoreFoundation/URL.subproj/static/module.map
+++ b/CoreFoundation/URL.subproj/static/module.map
@@ -1,0 +1,6 @@
+module CFURLSessionInterface [extern_c] [system] {
+    umbrella header "CFURLSessionInterface.h"
+
+    link "CFURLSessionInterface"
+    link "curl"
+}


### PR DESCRIPTION
The static libraries need to link against additional dependencies, which are listed in the newly added modulemaps