### PR TITLE
NFC: Fix -Welaborated-enum-base error

### DIFF
--- a/CoreFoundation/AppServices.subproj/CFNotificationCenter.h
+++ b/CoreFoundation/AppServices.subproj/CFNotificationCenter.h
@@ -22,7 +22,7 @@ typedef struct CF_BRIDGED_MUTABLE_TYPE(id) __CFNotificationCenter * CFNotificati
 
 typedef void (*CFNotificationCallback)(CFNotificationCenterRef center, void *observer, CFNotificationName name, const void *object, CFDictionaryRef userInfo);
 
-typedef CF_ENUM(CFIndex, CFNotificationSuspensionBehavior) {
+CF_ENUM(CFIndex, CFNotificationSuspensionBehavior) {
     CFNotificationSuspensionBehaviorDrop = 1,
         // The server will not queue any notifications with this name and object while the process/app is in the background.
     CFNotificationSuspensionBehaviorCoalesce = 2,

--- a/CoreFoundation/Base.subproj/CFAvailability.h
+++ b/CoreFoundation/Base.subproj/CFAvailability.h
@@ -135,13 +135,16 @@
 #define __CF_ENUM_FIXED_IS_AVAILABLE (__cplusplus && __cplusplus >= 201103L && (__has_extension(cxx_strong_enums) || __has_feature(objc_fixed_enum))) || (!__cplusplus && (__has_feature(objc_fixed_enum) || __has_extension(cxx_fixed_enum)))
 
 #if __CF_ENUM_FIXED_IS_AVAILABLE
-#define __CF_NAMED_ENUM(_type, _name)     enum __CF_ENUM_ATTRIBUTES _name : _type _name; enum _name : _type
-#define __CF_ANON_ENUM(_type)             enum __CF_ENUM_ATTRIBUTES : _type
-#define CF_CLOSED_ENUM(_type, _name)      enum __CF_CLOSED_ENUM_ATTRIBUTES _name : _type _name; enum _name : _type
 #if (__cplusplus)
+#define __CF_NAMED_ENUM(_type, _name)     enum __CF_ENUM_ATTRIBUTES _name : _type
+#define __CF_ANON_ENUM(_type)             enum __CF_ENUM_ATTRIBUTES : _type
+#define CF_CLOSED_ENUM(_type, _name)      enum __CF_CLOSED_ENUM_ATTRIBUTES _name : _type
 #define CF_OPTIONS(_type, _name) _type _name; enum __CF_OPTIONS_ATTRIBUTES : _type
 #else
-#define CF_OPTIONS(_type, _name) enum __CF_OPTIONS_ATTRIBUTES _name : _type _name; enum _name : _type
+#define __CF_NAMED_ENUM(_type, _name)     enum __CF_ENUM_ATTRIBUTES _name : _type; typedef enum _name _name; enum _name : _type
+#define __CF_ANON_ENUM(_type)             enum __CF_ENUM_ATTRIBUTES : _type
+#define CF_CLOSED_ENUM(_type, _name)      enum __CF_CLOSED_ENUM_ATTRIBUTES _name : _type; typedef enum _name  _name; enum _name : _type
+#define CF_OPTIONS(_type, _name) enum __CF_OPTIONS_ATTRIBUTES _name : _type; typedef enum _name _name; enum _name : _type
 #endif
 #else
 #define __CF_NAMED_ENUM(_type, _name) _type _name; enum
@@ -150,17 +153,18 @@
 #define CF_OPTIONS(_type, _name) _type _name; enum
 #endif
 
-/* CF_ENUM supports the use of one or two arguments. The first argument is always the integer type used for the values of the enum. The second argument is an optional type name for the macro. When specifying a type name, you must precede the macro with 'typedef' like so:
+/* CF_ENUM supports the use of one or two arguments. The first argument is always the integer type used for the values of the enum. The second argument is an optional type name for the macro. Like so:
 
-typedef CF_ENUM(CFIndex, CFComparisonResult) {
+CF_ENUM(CFIndex, CFComparisonResult) {
     ...
 };
 
-If you do not specify a type name, do not use 'typdef', like so:
+or:
 
 CF_ENUM(CFIndex) {
     ...
 };
+
 */
 #define CF_ENUM(...) __CF_ENUM_GET_MACRO(__VA_ARGS__, __CF_NAMED_ENUM, __CF_ANON_ENUM, )(__VA_ARGS__)
 

--- a/CoreFoundation/Base.subproj/CFBase.h
+++ b/CoreFoundation/Base.subproj/CFBase.h
@@ -478,7 +478,7 @@ typedef struct CF_BRIDGED_MUTABLE_TYPE(NSMutableString) __CFString * CFMutableSt
 typedef CF_BRIDGED_TYPE(id) CFTypeRef CFPropertyListRef;
 
 /* Values returned from comparison functions */
-typedef CF_ENUM(CFIndex, CFComparisonResult) {
+CF_ENUM(CFIndex, CFComparisonResult) {
     kCFCompareLessThan = -1L,
     kCFCompareEqualTo = 0,
     kCFCompareGreaterThan = 1

--- a/CoreFoundation/Base.subproj/CFKnownLocations.h
+++ b/CoreFoundation/Base.subproj/CFKnownLocations.h
@@ -15,7 +15,7 @@
 
 CF_ASSUME_NONNULL_BEGIN
 
-typedef CF_ENUM(CFIndex, CFKnownLocationUser) {
+CF_ENUM(CFIndex, CFKnownLocationUser) {
     _kCFKnownLocationUserAny,
     _kCFKnownLocationUserCurrent,
     _kCFKnownLocationUserByName,

--- a/CoreFoundation/Base.subproj/CFOverflow.h
+++ b/CoreFoundation/Base.subproj/CFOverflow.h
@@ -31,7 +31,7 @@
     #endif
 #endif // __has_include(<os/overflow.h>)
 
-typedef CF_ENUM(uint8_t, _CFOverflowResult) {
+CF_ENUM(uint8_t, _CFOverflowResult) {
     _CFOverflowResultOK = 0,
     _CFOverflowResultNegativeParameters,
     _CFOverflowResultOverflows,

--- a/CoreFoundation/Base.subproj/CFPriv.h
+++ b/CoreFoundation/Base.subproj/CFPriv.h
@@ -106,7 +106,7 @@ CFURLRef _CFCreateURLFromFSSpec(CFAllocatorRef alloc, const struct FSSpec *voids
 #endif
 #endif
 
-typedef CF_ENUM(CFIndex, CFURLComponentDecomposition) {
+CF_ENUM(CFIndex, CFURLComponentDecomposition) {
 	kCFURLComponentDecompositionNonHierarchical,
 	kCFURLComponentDecompositionRFC1808, /* use this for RFC 1738 decompositions as well */
 	kCFURLComponentDecompositionRFC2396
@@ -188,7 +188,7 @@ CFURLRef CFCopyHomeDirectoryURLForUser(CFStringRef uName);	/* Pass NULL for the 
 	directories!
 	??? On MacOS 8 this function currently returns an empty array.
 */
-typedef CF_ENUM(CFIndex, CFSearchPathDirectory) {
+CF_ENUM(CFIndex, CFSearchPathDirectory) {
     kCFApplicationDirectory = 1,	/* supported applications (Applications) */
     kCFDemoApplicationDirectory,	/* unsupported applications, demonstration versions (Demos) */
     kCFDeveloperApplicationDirectory,	/* developer applications (Developer/Applications) */
@@ -217,7 +217,7 @@ typedef CF_ENUM(CFIndex, CFSearchPathDirectory) {
     kCFAllLibrariesDirectory = 101	/* all directories where resources can occur (Library, Developer) */
 };
 
-typedef CF_OPTIONS(CFOptionFlags, CFSearchPathDomainMask) {
+CF_OPTIONS(CFOptionFlags, CFSearchPathDomainMask) {
     kCFUserDomainMask = 1,	/* user's home directory --- place to install user's personal items (~) */
     kCFLocalDomainMask = 2,	/* local to the current machine --- place to install items available to everyone on this machine (/Local) */
     kCFNetworkDomainMask = 4, 	/* publically available location in the local area network --- place to install items available on the network (/Network) */
@@ -261,7 +261,7 @@ CF_EXPORT void CFQSortArray(void *list, CFIndex count, CFIndex elementSize, CFCo
 
 // For non-Darwin platforms _CFExecutableLinkedOnOrAfter(…) always returns true.
 
-typedef CF_ENUM(CFIndex, CFSystemVersion) {
+CF_ENUM(CFIndex, CFSystemVersion) {
     CFSystemVersionCheetah = 0,         /* 10.0 */
     CFSystemVersionPuma = 1,            /* 10.1 */
     CFSystemVersionJaguar = 2,          /* 10.2 */
@@ -278,7 +278,7 @@ typedef CF_ENUM(CFIndex, CFSystemVersion) {
 CF_EXPORT Boolean _CFExecutableLinkedOnOrAfter(CFSystemVersion version);
 
 
-typedef CF_ENUM(CFIndex, CFStringCharacterClusterType) {
+CF_ENUM(CFIndex, CFStringCharacterClusterType) {
     kCFStringGraphemeCluster = 1, /* Unicode Grapheme Cluster */
     kCFStringComposedCharacterCluster = 2, /* Compose all non-base (including spacing marks) */
     kCFStringCursorMovementCluster = 3, /* Cluster suitable for cursor movements */
@@ -626,7 +626,7 @@ CF_EXPORT CFSetRef _CFPropertyListCopyTopLevelKeys(CFAllocatorRef allocator, CFD
 CF_EXPORT bool _CFPropertyListValidateData(CFDataRef data, CFTypeID *outTopLevelTypeID) API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0), tvos(13.0));
 
 // Returns a subset of a bundle's Info.plist. The keyPaths follow the same rules as above CFPropertyList function. This function takes platform and product keys into account.
-typedef CF_OPTIONS(CFOptionFlags, _CFBundleFilteredPlistOptions) {
+CF_OPTIONS(CFOptionFlags, _CFBundleFilteredPlistOptions) {
     _CFBundleFilteredPlistMemoryMapped = 1
 } API_AVAILABLE(macos(10.8), ios(6.0), watchos(2.0), tvos(9.0));
 

--- a/CoreFoundation/Base.subproj/ForFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForFoundationOnly.h
@@ -632,7 +632,7 @@ CF_INLINE UInt64 __CFReadTSR(void) {
 
 /* Identical to CFStringGetFileSystemRepresentation, but returns additional information about the failure.
  */
-typedef CF_ENUM(CFIndex, _CFStringFileSystemRepresentationError) {
+CF_ENUM(CFIndex, _CFStringFileSystemRepresentationError) {
     _kCFStringFileSystemRepresentationErrorNone = 0,            // 'characterIndex' is undefined.
     _kCFStringFileSystemRepresentationErrorBufferFull,          // 'characterIndex' is undefined.
     _kCFStringFileSystemRepresentationErrorEmbeddedNull,        // 'characterIndex' == index of first NULL character in 'buffer'.

--- a/CoreFoundation/Collections.subproj/CFData.h
+++ b/CoreFoundation/Collections.subproj/CFData.h
@@ -64,7 +64,7 @@ void CFDataReplaceBytes(CFMutableDataRef theData, CFRange range, const UInt8 *ne
 CF_EXPORT
 void CFDataDeleteBytes(CFMutableDataRef theData, CFRange range);
 
-typedef CF_OPTIONS(CFOptionFlags, CFDataSearchFlags) {
+CF_OPTIONS(CFOptionFlags, CFDataSearchFlags) {
     kCFDataSearchBackwards = 1UL << 0,
     kCFDataSearchAnchored = 1UL << 1
 } API_AVAILABLE(macos(10.6), ios(4.0), watchos(2.0), tvos(9.0));

--- a/CoreFoundation/Collections.subproj/CFStorage.h
+++ b/CoreFoundation/Collections.subproj/CFStorage.h
@@ -34,7 +34,7 @@ storage was a single block.
 
 #include <CoreFoundation/CFBase.h>
 
-typedef CF_OPTIONS(CFOptionFlags, CFStorageEnumerationOptionFlags) {
+CF_OPTIONS(CFOptionFlags, CFStorageEnumerationOptionFlags) {
         kCFStorageEnumerationConcurrent = (1UL << 0) /* Allow enumeration to proceed concurrently */
 };
 

--- a/CoreFoundation/Locale.subproj/CFCalendar.h
+++ b/CoreFoundation/Locale.subproj/CFCalendar.h
@@ -60,7 +60,7 @@ CF_EXPORT
 void CFCalendarSetMinimumDaysInFirstWeek(CFCalendarRef calendar, CFIndex mwd);
 
 
-typedef CF_OPTIONS(CFOptionFlags, CFCalendarUnit) {
+CF_OPTIONS(CFOptionFlags, CFCalendarUnit) {
 	kCFCalendarUnitEra = (1UL << 1),
 	kCFCalendarUnitYear = (1UL << 2),
 	kCFCalendarUnitMonth = (1UL << 3),

--- a/CoreFoundation/Locale.subproj/CFDateFormatter.h
+++ b/CoreFoundation/Locale.subproj/CFDateFormatter.h
@@ -42,7 +42,7 @@ CFTypeID CFDateFormatterGetTypeID(void);
 // should not rely on styles and localization, but set the format string and
 // use nothing but numbers.
 
-typedef CF_ENUM(CFIndex, CFDateFormatterStyle) {	// date and time format styles
+CF_ENUM(CFIndex, CFDateFormatterStyle) {	// date and time format styles
     kCFDateFormatterNoStyle = 0,
     kCFDateFormatterShortStyle = 1,
     kCFDateFormatterMediumStyle = 2,
@@ -50,7 +50,7 @@ typedef CF_ENUM(CFIndex, CFDateFormatterStyle) {	// date and time format styles
     kCFDateFormatterFullStyle = 4
 };
 
-typedef CF_OPTIONS(CFOptionFlags, CFISO8601DateFormatOptions) {
+CF_OPTIONS(CFOptionFlags, CFISO8601DateFormatOptions) {
     /* The format for year is inferred based on whether or not the week of year option is specified.
      - if week of year is present, "YYYY" is used to display week dates.
      - if week of year is not present, "yyyy" is used by default.

--- a/CoreFoundation/Locale.subproj/CFDateIntervalFormatter.h
+++ b/CoreFoundation/Locale.subproj/CFDateIntervalFormatter.h
@@ -23,7 +23,7 @@ CF_EXTERN_C_BEGIN
 
 typedef struct CF_BRIDGED_TYPE(id) __CFDateIntervalFormatter * CFDateIntervalFormatterRef;
 
-typedef CF_ENUM(CFIndex, CFDateIntervalFormatterStyle) {
+CF_ENUM(CFIndex, CFDateIntervalFormatterStyle) {
     kCFDateIntervalFormatterNoStyle = 0,
     kCFDateIntervalFormatterShortStyle = 1,
     kCFDateIntervalFormatterMediumStyle = 2,
@@ -31,7 +31,7 @@ typedef CF_ENUM(CFIndex, CFDateIntervalFormatterStyle) {
     kCFDateIntervalFormatterFullStyle = 4,
 };
 
-typedef CF_ENUM(CFIndex, _CFDateIntervalFormatterBoundaryStyle) {
+CF_ENUM(CFIndex, _CFDateIntervalFormatterBoundaryStyle) {
     kCFDateIntervalFormatterBoundaryStyleDefault = 0,
 #if TARGET_OS_MAC
     kCFDateIntervalFormatterBoundaryStyleMinimizeAdjacentMonths = 1,

--- a/CoreFoundation/Locale.subproj/CFLocale.h
+++ b/CoreFoundation/Locale.subproj/CFLocale.h
@@ -95,7 +95,7 @@ CF_EXPORT
 uint32_t CFLocaleGetWindowsLocaleCodeFromLocaleIdentifier(CFLocaleIdentifier localeIdentifier) API_AVAILABLE(macos(10.6), ios(4.0), watchos(2.0), tvos(9.0));
 	// Map a locale identifier to a Windows LCID.
 
-typedef CF_ENUM(CFIndex, CFLocaleLanguageDirection) {
+CF_ENUM(CFIndex, CFLocaleLanguageDirection) {
     kCFLocaleLanguageDirectionUnknown = 0,
     kCFLocaleLanguageDirectionLeftToRight = 1,
     kCFLocaleLanguageDirectionRightToLeft = 2,

--- a/CoreFoundation/Locale.subproj/CFLocale_Private.h
+++ b/CoreFoundation/Locale.subproj/CFLocale_Private.h
@@ -15,7 +15,7 @@
 /// Returns the user’s preferred locale as-is, without attempting to match the locale’s language to the main bundle, unlike `CFLocaleCopyCurrent`.
 CF_EXPORT CFLocaleRef _CFLocaleCopyPreferred(void) API_AVAILABLE(macosx(10.13), ios(11.0), watchos(4.0), tvos(11.0));
 
-typedef CF_ENUM(CFIndex, _CFLocaleCalendarDirection) {
+CF_ENUM(CFIndex, _CFLocaleCalendarDirection) {
     _kCFLocaleCalendarDirectionLeftToRight = 0,
     _kCFLocaleCalendarDirectionRightToLeft = 1
 } API_AVAILABLE(macosx(10.12), ios(10.0), watchos(3.0), tvos(10.0));

--- a/CoreFoundation/Locale.subproj/CFNumberFormatter.h
+++ b/CoreFoundation/Locale.subproj/CFNumberFormatter.h
@@ -26,7 +26,7 @@ typedef struct CF_BRIDGED_MUTABLE_TYPE(id) __CFNumberFormatter *CFNumberFormatte
 CF_EXPORT
 CFTypeID CFNumberFormatterGetTypeID(void);
 
-typedef CF_ENUM(CFIndex, CFNumberFormatterStyle) {	// number format styles
+CF_ENUM(CFIndex, CFNumberFormatterStyle) {	// number format styles
 	kCFNumberFormatterNoStyle = 0,
 	kCFNumberFormatterDecimalStyle = 1,
 	kCFNumberFormatterCurrencyStyle = 2,
@@ -74,7 +74,7 @@ CFStringRef CFNumberFormatterCreateStringWithValue(CFAllocatorRef allocator, CFN
 	// using the current state of the number formatter.
 
 
-typedef CF_OPTIONS(CFOptionFlags, CFNumberFormatterOptionFlags) {
+CF_OPTIONS(CFOptionFlags, CFNumberFormatterOptionFlags) {
     kCFNumberFormatterParseIntegersOnly = 1	/* only parse integers */
 };
 
@@ -141,7 +141,7 @@ CF_EXPORT const CFNumberFormatterKey kCFNumberFormatterUseSignificantDigits API_
 CF_EXPORT const CFNumberFormatterKey kCFNumberFormatterMinSignificantDigits API_AVAILABLE(macos(10.5), ios(2.0), watchos(2.0), tvos(9.0));	// CFNumber
 CF_EXPORT const CFNumberFormatterKey kCFNumberFormatterMaxSignificantDigits API_AVAILABLE(macos(10.5), ios(2.0), watchos(2.0), tvos(9.0));	// CFNumber
 
-typedef CF_ENUM(CFIndex, CFNumberFormatterRoundingMode) {
+CF_ENUM(CFIndex, CFNumberFormatterRoundingMode) {
     kCFNumberFormatterRoundCeiling = 0,
     kCFNumberFormatterRoundFloor = 1,
     kCFNumberFormatterRoundDown = 2,
@@ -151,7 +151,7 @@ typedef CF_ENUM(CFIndex, CFNumberFormatterRoundingMode) {
     kCFNumberFormatterRoundHalfUp = 6
 };
 
-typedef CF_ENUM(CFIndex, CFNumberFormatterPadPosition) {
+CF_ENUM(CFIndex, CFNumberFormatterPadPosition) {
     kCFNumberFormatterPadBeforePrefix = 0,
     kCFNumberFormatterPadAfterPrefix = 1,
     kCFNumberFormatterPadBeforeSuffix = 2,

--- a/CoreFoundation/NumberDate.subproj/CFDate.h
+++ b/CoreFoundation/NumberDate.subproj/CFDate.h
@@ -73,7 +73,7 @@ typedef struct {
     double seconds;
 } CFGregorianUnits API_DEPRECATED("Use CFCalendar or NSCalendar API instead", macos(10.4, 10.10), ios(2.0, 8.0), watchos(2.0, 2.0), tvos(9.0, 9.0));
 
-typedef CF_OPTIONS(CFOptionFlags, CFGregorianUnitFlags) {
+CF_OPTIONS(CFOptionFlags, CFGregorianUnitFlags) {
     kCFGregorianUnitsYears API_DEPRECATED("Use CFCalendar or NSCalendar API instead", macos(10.4, 10.10), ios(2.0, 8.0), watchos(2.0, 2.0), tvos(9.0, 9.0)) = (1UL << 0),
     kCFGregorianUnitsMonths API_DEPRECATED("Use CFCalendar or NSCalendar API instead", macos(10.4, 10.10), ios(2.0, 8.0), watchos(2.0, 2.0), tvos(9.0, 9.0)) = (1UL << 1),
     kCFGregorianUnitsDays API_DEPRECATED("Use CFCalendar or NSCalendar API instead", macos(10.4, 10.10), ios(2.0, 8.0), watchos(2.0, 2.0), tvos(9.0, 9.0)) = (1UL << 2),

--- a/CoreFoundation/NumberDate.subproj/CFNumber.h
+++ b/CoreFoundation/NumberDate.subproj/CFNumber.h
@@ -28,7 +28,7 @@ CFTypeID CFBooleanGetTypeID(void);
 CF_EXPORT
 Boolean CFBooleanGetValue(CFBooleanRef boolean);
 
-typedef CF_ENUM(CFIndex, CFNumberType) {
+CF_ENUM(CFIndex, CFNumberType) {
     /* Fixed-width types */
     kCFNumberSInt8Type = 1,
     kCFNumberSInt16Type = 2,

--- a/CoreFoundation/NumberDate.subproj/CFTimeZone.h
+++ b/CoreFoundation/NumberDate.subproj/CFTimeZone.h
@@ -76,7 +76,7 @@ CFTimeInterval CFTimeZoneGetDaylightSavingTimeOffset(CFTimeZoneRef tz, CFAbsolut
 CF_EXPORT
 CFAbsoluteTime CFTimeZoneGetNextDaylightSavingTimeTransition(CFTimeZoneRef tz, CFAbsoluteTime at) API_AVAILABLE(macos(10.5), ios(2.0), watchos(2.0), tvos(9.0));
 
-typedef CF_ENUM(CFIndex, CFTimeZoneNameStyle) {
+CF_ENUM(CFIndex, CFTimeZoneNameStyle) {
 	kCFTimeZoneNameStyleStandard,
 	kCFTimeZoneNameStyleShortStandard,
 	kCFTimeZoneNameStyleDaylightSaving,

--- a/CoreFoundation/Parsing.subproj/CFPropertyList.h
+++ b/CoreFoundation/Parsing.subproj/CFPropertyList.h
@@ -19,7 +19,7 @@
 CF_IMPLICIT_BRIDGING_ENABLED
 CF_EXTERN_C_BEGIN
 
-typedef CF_OPTIONS(CFOptionFlags, CFPropertyListMutabilityOptions) {
+CF_OPTIONS(CFOptionFlags, CFPropertyListMutabilityOptions) {
     kCFPropertyListImmutable = 0,
     kCFPropertyListMutableContainers = 1 << 0,
     kCFPropertyListMutableContainersAndLeaves = 1 << 1,
@@ -66,7 +66,7 @@ CF_IMPLICIT_BRIDGING_ENABLED
 CF_EXPORT
 CFPropertyListRef CFPropertyListCreateDeepCopy(CFAllocatorRef allocator, CFPropertyListRef propertyList, CFOptionFlags mutabilityOption);
 
-typedef CF_ENUM(CFIndex, CFPropertyListFormat) {
+CF_ENUM(CFIndex, CFPropertyListFormat) {
     kCFPropertyListOpenStepFormat = 1,
     kCFPropertyListXMLFormat_v1_0 = 100,
     kCFPropertyListBinaryFormat_v1_0 = 200

--- a/CoreFoundation/Parsing.subproj/CFPropertyList_Private.h
+++ b/CoreFoundation/Parsing.subproj/CFPropertyList_Private.h
@@ -10,7 +10,7 @@
 #include <CoreFoundation/CFPropertyList.h>
 
 // this is only allowed the first 8 bits
-typedef CF_OPTIONS(CFOptionFlags, CFPropertyListSupportedFormats) {
+CF_OPTIONS(CFOptionFlags, CFPropertyListSupportedFormats) {
     kCFPropertyListSupportedFormatOpenStepFormat = 1 << 8,
     kCFPropertyListSupportedFormatBinary_v1_0 = 1 << 9,
     kCFPropertyListSupportedFormatXML_v1_0 = 1 << 10,

--- a/CoreFoundation/RunLoop.subproj/CFMachPort_Lifetime.h
+++ b/CoreFoundation/RunLoop.subproj/CFMachPort_Lifetime.h
@@ -16,7 +16,7 @@ CF_EXTERN_C_BEGIN
 #include <mach/mach_port.h>
 #include <os/lock.h>
 
-typedef CF_ENUM(uint8_t, _CFMPLifetimeClient) {
+CF_ENUM(uint8_t, _CFMPLifetimeClient) {
     _CFMPLifetimeClientCFMachPort = 0,
     _CFMPLifetimeClientCFMessagePort = 1,
     // NOTE: We current support MAX_CLIENTS more clients (currently 2)

--- a/CoreFoundation/RunLoop.subproj/CFRunLoop.h
+++ b/CoreFoundation/RunLoop.subproj/CFRunLoop.h
@@ -32,7 +32,7 @@ typedef struct CF_BRIDGED_MUTABLE_TYPE(id) __CFRunLoopObserver * CFRunLoopObserv
 typedef struct CF_BRIDGED_MUTABLE_TYPE(NSTimer) __CFRunLoopTimer * CFRunLoopTimerRef;
 
 /* Reasons for CFRunLoopRunInMode() to Return */
-typedef CF_ENUM(SInt32, CFRunLoopRunResult) {
+CF_ENUM(SInt32, CFRunLoopRunResult) {
     kCFRunLoopRunFinished = 1,
     kCFRunLoopRunStopped = 2,
     kCFRunLoopRunTimedOut = 3,
@@ -40,7 +40,7 @@ typedef CF_ENUM(SInt32, CFRunLoopRunResult) {
 };
 
 /* Run Loop Observer Activities */
-typedef CF_OPTIONS(CFOptionFlags, CFRunLoopActivity) {
+CF_OPTIONS(CFOptionFlags, CFRunLoopActivity) {
     kCFRunLoopEntry = (1UL << 0),
     kCFRunLoopBeforeTimers = (1UL << 1),
     kCFRunLoopBeforeSources = (1UL << 2),

--- a/CoreFoundation/RunLoop.subproj/CFSocket.h
+++ b/CoreFoundation/RunLoop.subproj/CFSocket.h
@@ -96,7 +96,7 @@ filled in properly when passing in an address.
 */
 
 /* Values for CFSocketError */
-typedef CF_ENUM(CFIndex, CFSocketError) {
+CF_ENUM(CFIndex, CFSocketError) {
     kCFSocketSuccess = 0,
     kCFSocketError = -1L,
     kCFSocketTimeout = -2L
@@ -110,7 +110,7 @@ typedef struct {
 } CFSocketSignature;
 
 /* Values for CFSocketCallBackType */
-typedef CF_OPTIONS(CFOptionFlags, CFSocketCallBackType) {
+CF_OPTIONS(CFOptionFlags, CFSocketCallBackType) {
     kCFSocketNoCallBack = 0,
     kCFSocketReadCallBack = 1,
     kCFSocketAcceptCallBack = 2,

--- a/CoreFoundation/Stream.subproj/CFStream.h
+++ b/CoreFoundation/Stream.subproj/CFStream.h
@@ -29,7 +29,7 @@ typedef struct {
 
 typedef CFStringRef CFStreamPropertyKey CF_EXTENSIBLE_STRING_ENUM;
 
-typedef CF_ENUM(CFIndex, CFStreamStatus) {
+CF_ENUM(CFIndex, CFStreamStatus) {
     kCFStreamStatusNotOpen = 0,
     kCFStreamStatusOpening,  /* open is in-progress */
     kCFStreamStatusOpen,
@@ -40,7 +40,7 @@ typedef CF_ENUM(CFIndex, CFStreamStatus) {
     kCFStreamStatusError
 };
 
-typedef CF_OPTIONS(CFOptionFlags, CFStreamEventType) {
+CF_OPTIONS(CFOptionFlags, CFStreamEventType) {
     kCFStreamEventNone = 0,
     kCFStreamEventOpenCompleted = 1,
     kCFStreamEventHasBytesAvailable = 2,
@@ -483,7 +483,7 @@ dispatch_queue_t _Null_unspecified CFWriteStreamCopyDispatchQueue(CFWriteStreamR
 
 
 /* The following API is deprecated starting in 10.5; please use CFRead/WriteStreamCopyError(), above, instead */
-typedef CF_ENUM(CFIndex, CFStreamErrorDomain) {
+CF_ENUM(CFIndex, CFStreamErrorDomain) {
     kCFStreamErrorDomainCustom = -1L,      /* custom to the kind of stream in question */
     kCFStreamErrorDomainPOSIX = 1,        /* POSIX errno; interpret using <sys/errno.h> */
     kCFStreamErrorDomainMacOSStatus      /* OSStatus type from Carbon APIs; interpret using <MacTypes.h> */

--- a/CoreFoundation/String.subproj/CFBurstTrie.h
+++ b/CoreFoundation/String.subproj/CFBurstTrie.h
@@ -18,7 +18,7 @@ CF_EXTERN_C_BEGIN
 typedef struct CF_BRIDGED_MUTABLE_TYPE(id) _CFBurstTrie *CFBurstTrieRef;
 typedef struct CF_BRIDGED_MUTABLE_TYPE(id) _CFBurstTrieCursor *CFBurstTrieCursorRef;
 
-typedef CF_OPTIONS(CFOptionFlags, CFBurstTrieOpts) {
+CF_OPTIONS(CFOptionFlags, CFBurstTrieOpts) {
         /*!
          BurstTrie Options
          Use one or more of these options with CFBurstTrieCreate to tailor optimizations to the data

--- a/CoreFoundation/String.subproj/CFCharacterSet.h
+++ b/CoreFoundation/String.subproj/CFCharacterSet.h
@@ -59,7 +59,7 @@ typedef struct CF_BRIDGED_MUTABLE_TYPE(NSMutableCharacterSet) __CFCharacterSet *
         Type of the predefined CFCharacterSet selector values.
 */
    
-typedef CF_ENUM(CFIndex, CFCharacterSetPredefinedSet) {
+CF_ENUM(CFIndex, CFCharacterSetPredefinedSet) {
     kCFCharacterSetControl = 1, /* Control character set (Unicode General Category Cc and Cf) */
     kCFCharacterSetWhitespace, /* Whitespace character set (Unicode General Category Zs and U0009 CHARACTER TABULATION) */
     kCFCharacterSetWhitespaceAndNewline,  /* Whitespace and Newline character set (Unicode General Category Z*, U000A ~ U000D, and U0085) */

--- a/CoreFoundation/String.subproj/CFCharacterSetPriv.h
+++ b/CoreFoundation/String.subproj/CFCharacterSetPriv.h
@@ -52,7 +52,7 @@ CF_EXPORT Boolean CFCharacterSetIsSurrogatePairMember(CFCharacterSetRef theSet, 
 
 /* Keyed-coding support
 */
-typedef CF_ENUM(CFIndex, CFCharacterSetKeyedCodingType) {
+CF_ENUM(CFIndex, CFCharacterSetKeyedCodingType) {
     kCFCharacterSetKeyedCodingTypeBitmap = 1,
     kCFCharacterSetKeyedCodingTypeBuiltin = 2,
     kCFCharacterSetKeyedCodingTypeRange = 3,

--- a/CoreFoundation/String.subproj/CFRegularExpression.h
+++ b/CoreFoundation/String.subproj/CFRegularExpression.h
@@ -21,7 +21,7 @@
 CF_ASSUME_NONNULL_BEGIN
 CF_IMPLICIT_BRIDGING_ENABLED
 
-typedef CF_OPTIONS(CFOptionFlags, _CFRegularExpressionOptions) {
+CF_OPTIONS(CFOptionFlags, _CFRegularExpressionOptions) {
     _kCFRegularExpressionCaseInsensitive             = 1 << 0,
     _kCFRegularExpressionAllowCommentsAndWhitespace  = 1 << 1,
     _kCFRegularExpressionIgnoreMetacharacters        = 1 << 2,
@@ -31,7 +31,7 @@ typedef CF_OPTIONS(CFOptionFlags, _CFRegularExpressionOptions) {
     _kCFRegularExpressionUseUnicodeWordBoundaries    = 1 << 6
 };
 
-typedef CF_OPTIONS(CFOptionFlags, _CFRegularExpressionMatchingOptions) {
+CF_OPTIONS(CFOptionFlags, _CFRegularExpressionMatchingOptions) {
     _kCFRegularExpressionMatchingReportProgress         = 1 << 0,
     _kCFRegularExpressionMatchingReportCompletion       = 1 << 1,
     _kCFRegularExpressionMatchingAnchored               = 1 << 2,
@@ -40,7 +40,7 @@ typedef CF_OPTIONS(CFOptionFlags, _CFRegularExpressionMatchingOptions) {
     _kCFRegularExpressionMatchingOmitResult             = 1 << 13
 };
 
-typedef CF_OPTIONS(CFOptionFlags, _CFRegularExpressionMatchingFlags) {
+CF_OPTIONS(CFOptionFlags, _CFRegularExpressionMatchingFlags) {
     _kCFRegularExpressionMatchingProgress               = 1 << 0,       /* Set when the block is called to report progress during a long-running match operation. */
     _kCFRegularExpressionMatchingCompleted              = 1 << 1,       /* Set when the block is called after completion of any matching. */
     _kCFRegularExpressionMatchingHitEnd                 = 1 << 2,       /* Set when the current match operation reached the end of the search range. */

--- a/CoreFoundation/String.subproj/CFString.h
+++ b/CoreFoundation/String.subproj/CFString.h
@@ -102,7 +102,7 @@ typedef UInt32 CFStringEncoding;
    Call CFStringGetSystemEncoding() to get the default system encoding.
 */
 #define kCFStringEncodingInvalidId (0xffffffffU)
-typedef CF_ENUM(CFStringEncoding, CFStringBuiltInEncodings) {
+CF_ENUM(CFStringEncoding, CFStringBuiltInEncodings) {
     kCFStringEncodingMacRoman = 0,
     kCFStringEncodingWindowsLatin1 = 0x0500, /* ANSI codepage 1252 */
     kCFStringEncodingISOLatin1 = 0x0201, /* ISO 8859-1 */
@@ -407,7 +407,7 @@ CFStringRef CFStringCreateWithFileSystemRepresentation(CFAllocatorRef alloc, con
 
 /* Find and compare flags; these are OR'ed together and provided as CFStringCompareFlags in the various functions. 
 */
-typedef CF_OPTIONS(CFOptionFlags, CFStringCompareFlags) {
+CF_OPTIONS(CFOptionFlags, CFStringCompareFlags) {
     kCFCompareCaseInsensitive = 1,	
     kCFCompareBackwards = 4,		/* Starting from the end of the string */
     kCFCompareAnchored = 8,		/* Only at the specified starting point */
@@ -683,7 +683,7 @@ void CFStringCapitalize(CFMutableStringRef theString, CFLocaleRef locale);
 	Unicode Technical Report #15. To normalize for use with file
 	system calls, use CFStringGetFileSystemRepresentation().
 */
-typedef CF_ENUM(CFIndex, CFStringNormalizationForm) {
+CF_ENUM(CFIndex, CFStringNormalizationForm) {
 	kCFStringNormalizationFormD = 0, // Canonical Decomposition
 	kCFStringNormalizationFormKD, // Compatibility Decomposition
 	kCFStringNormalizationFormC, // Canonical Decomposition followed by Canonical Composition

--- a/CoreFoundation/String.subproj/CFStringEncodingExt.h
+++ b/CoreFoundation/String.subproj/CFStringEncodingExt.h
@@ -14,7 +14,7 @@
 
 CF_EXTERN_C_BEGIN
 
-typedef CF_ENUM(CFIndex, CFStringEncodings) {
+CF_ENUM(CFIndex, CFStringEncodings) {
 /*  kCFStringEncodingMacRoman = 0L, defined in CoreFoundation/CFString.h */
     kCFStringEncodingMacJapanese = 1,
     kCFStringEncodingMacChineseTrad = 2,

--- a/CoreFoundation/URL.subproj/CFURL.h
+++ b/CoreFoundation/URL.subproj/CFURL.h
@@ -18,7 +18,7 @@
 CF_IMPLICIT_BRIDGING_ENABLED
 CF_EXTERN_C_BEGIN
 
-typedef CF_ENUM(CFIndex, CFURLPathStyle) {
+CF_ENUM(CFIndex, CFURLPathStyle) {
     kCFURLPOSIXPathStyle = 0,
     kCFURLHFSPathStyle API_DEPRECATED("Carbon File Manager is deprecated, use kCFURLPOSIXPathStyle where possible", macos(10.0,10.9), ios(2.0,7.0), watchos(2.0,2.0), tvos(9.0,9.0)), /* The use of kCFURLHFSPathStyle is deprecated. The Carbon File Manager, which uses HFS style paths, is deprecated. HFS style paths are unreliable because they can arbitrarily refer to multiple volumes if those volumes have identical volume names. You should instead use kCFURLPOSIXPathStyle wherever possible. */
     kCFURLWindowsPathStyle
@@ -290,7 +290,7 @@ CFURLRef CFURLCreateCopyDeletingPathExtension(CFAllocatorRef allocator, CFURLRef
 CF_EXPORT
 CFIndex CFURLGetBytes(CFURLRef url, UInt8 *buffer, CFIndex bufferLength);
 
-typedef CF_ENUM(CFIndex, CFURLComponentType) {
+CF_ENUM(CFIndex, CFURLComponentType) {
 	kCFURLComponentScheme = 1,
 	kCFURLComponentNetLocation = 2,
 	kCFURLComponentPath = 3,
@@ -1139,7 +1139,7 @@ const CFStringRef kCFURLUbiquitousItemDownloadingStatusCurrent API_AVAILABLE(mac
 
 #if !DEPLOYMENT_TARGET_SWIFT
 
-typedef CF_OPTIONS(CFOptionFlags, CFURLBookmarkCreationOptions) {
+CF_OPTIONS(CFOptionFlags, CFURLBookmarkCreationOptions) {
     kCFURLBookmarkCreationMinimalBookmarkMask = ( 1UL << 9 ), // creates bookmark data with "less" information, which may be smaller but still be able to resolve in certain ways
     kCFURLBookmarkCreationSuitableForBookmarkFile = ( 1UL << 10 ), // include the properties required by CFURLWriteBookmarkDataToFile() in the bookmark data created
     kCFURLBookmarkCreationWithSecurityScope API_AVAILABLE(macos(10.7))  API_UNAVAILABLE(ios, watchos, tvos) = ( 1UL << 11 ), // Mac OS X 10.7.3 and later, include information in the bookmark data which allows the same sandboxed process to access the resource after being relaunched
@@ -1150,7 +1150,7 @@ typedef CF_OPTIONS(CFOptionFlags, CFURLBookmarkCreationOptions) {
     API_DEPRECATED("kCFURLBookmarkCreationPreferFileIDResolutionMask does nothing and has no effect on bookmark resolution", macos(10.6,10.9), ios(4.0,7.0)) = ( 1UL << 8 ),
 } API_AVAILABLE(macos(10.6), ios(4.0), watchos(2.0), tvos(9.0));
 
-typedef CF_OPTIONS(CFOptionFlags, CFURLBookmarkResolutionOptions) {
+CF_OPTIONS(CFOptionFlags, CFURLBookmarkResolutionOptions) {
     kCFURLBookmarkResolutionWithoutUIMask = ( 1UL << 8 ), // don't perform any user interaction during bookmark resolution
     kCFURLBookmarkResolutionWithoutMountingMask = ( 1UL << 9 ), // don't mount a volume during bookmark resolution
     kCFURLBookmarkResolutionWithSecurityScope API_AVAILABLE(macos(10.7)) API_UNAVAILABLE(ios, watchos, tvos) = ( 1UL << 10 ), // Mac OS X 10.7.3 and later, use the secure information included at creation time to provide the ability to access the resource in a sandboxed process.

--- a/CoreFoundation/URL.subproj/CFURLAccess.h
+++ b/CoreFoundation/URL.subproj/CFURLAccess.h
@@ -79,7 +79,7 @@ CFTypeRef CFURLCreatePropertyFromResource(CFAllocatorRef alloc, CFURLRef url, CF
 
 
 /* Common error codes (returned only by the older APIs that predate CFError) */
-typedef CF_ENUM(CFIndex, CFURLError) {
+CF_ENUM(CFIndex, CFURLError) {
     kCFURLUnknownError = -10L,
     kCFURLUnknownSchemeError = -11L,
     kCFURLResourceNotFoundError = -12L,

--- a/CoreFoundation/URL.subproj/CFURLComponents_Internal.h
+++ b/CoreFoundation/URL.subproj/CFURLComponents_Internal.h
@@ -38,7 +38,7 @@ struct _URIParseInfo {
     unsigned long	fragmentExists          : 1;
 };
 
-typedef CF_ENUM(unsigned short, _CFURIParserURLAllowedCharacter) {
+CF_ENUM(unsigned short, _CFURIParserURLAllowedCharacter) {
     kURLSchemeAllowed	= 0x0001,
     kURLUserAllowed	= 0x0002,
     kURLPasswordAllowed	= 0x0004,

--- a/CoreFoundation/URL.subproj/CFURLPriv.h
+++ b/CoreFoundation/URL.subproj/CFURLPriv.h
@@ -460,7 +460,7 @@ Boolean _CFURLGetResourcePropertyFlags(CFURLRef url, CFURLResourcePropertyFlags 
 /*
     File resource properties which can be obtained with _CFURLCopyFilePropertyValuesAndFlags().
  */
-typedef CF_OPTIONS(unsigned long long, CFURLFilePropertyBitmap) {
+CF_OPTIONS(unsigned long long, CFURLFilePropertyBitmap) {
     kCFURLName				    = 0x0000000000000001,
     kCFURLLinkCount			    = 0x0000000000000002,
     kCFURLVolumeIdentifier		    = 0x0000000000000004,
@@ -510,7 +510,7 @@ Boolean _CFURLCopyResourcePropertyValuesAndFlags( CFURLRef url, CFURLFilePropert
 /*
     Volume property flags
  */
-typedef CF_OPTIONS(unsigned long long, CFURLVolumePropertyFlags) {
+CF_OPTIONS(unsigned long long, CFURLVolumePropertyFlags) {
     kCFURLVolumeIsLocal                                 =                0x1LL,	// Local device (vs. network device)
     kCFURLVolumeIsAutomount				=                0x2LL,	// Mounted by the automounter
     kCFURLVolumeDontBrowse				=                0x4LL,	// Hidden from user browsing
@@ -774,7 +774,7 @@ enum {
     kCFBookmarkResolutionQuarantineMountedNetworkVolumesMask API_AVAILABLE(macosx(10.12), ios(10.0), watchos(3.0), tvos(10.0)) = ( 1UL << 13 ), // quarantine any network volume mounted during resolution
 };
 
-typedef CF_ENUM(CFIndex, CFURLBookmarkMatchResult) {
+CF_ENUM(CFIndex, CFURLBookmarkMatchResult) {
     kCFURLBookmarkComparisonUnableToCompare = 0x00000000,   /* the two bookmarks could not be compared for some reason */
     kCFURLBookmarkComparisonNoMatch         = 0x00001000,   /* Bookmarks do not refer to the same item */
     kCFURLBookmarkComparisonUnlikelyToMatch = 0x00002000,   /* it is unlikely that the two items refer to the same filesystem item */


### PR DESCRIPTION
Recent versions of clang default -Welaborated-enum-base to -Werror.