### PR TITLE
Revert "Create a file with permissions that respects umask"

### DIFF
--- a/Sources/Foundation/NSPathUtilities.swift
+++ b/Sources/Foundation/NSPathUtilities.swift
@@ -760,10 +760,7 @@ internal func _NSCreateTemporaryFile(_ filePath: String) throws -> (Int32, Strin
     let maxLength = Int(PATH_MAX) + 1
     var buf = [Int8](repeating: 0, count: maxLength)
     let _ = template._nsObject.getFileSystemRepresentation(&buf, maxLength: maxLength)
-    guard let name = mktemp(&buf) else {
-        throw _NSErrorWithErrno(errno, reading: false, path: filePath)
-    }
-    let fd = open(name, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)
+    let fd = mkstemp(&buf)
     if fd == -1 {
         throw _NSErrorWithErrno(errno, reading: false, path: filePath)
     }

--- a/Tests/Foundation/Tests/TestNSData.swift
+++ b/Tests/Foundation/Tests/TestNSData.swift
@@ -7,16 +7,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-import CoreFoundation
-
-#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
-    #if canImport(SwiftFoundation) && !DEPLOYMENT_RUNTIME_OBJC
-        @testable import SwiftFoundation
-    #else
-        @testable import Foundation
-    #endif
-#endif
-
 class TestNSData: LoopbackServerTest {
     
     class AllOnesImmutableData : NSData {
@@ -233,8 +223,6 @@ class TestNSData: LoopbackServerTest {
             ("test_limitDebugDescription", test_limitDebugDescription),
             ("test_edgeDebugDescription", test_edgeDebugDescription),
             ("test_writeToURLOptions", test_writeToURLOptions),
-            ("test_writeToURLPermissions", test_writeToURLPermissions),
-            ("test_writeToURLPermissionsWithAtomic", test_writeToURLPermissionsWithAtomic),
             ("test_edgeNoCopyDescription", test_edgeNoCopyDescription),
             ("test_initializeWithBase64EncodedDataGetsDecodedData", test_initializeWithBase64EncodedDataGetsDecodedData),
             ("test_initializeWithBase64EncodedDataWithNonBase64CharacterIsNil", test_initializeWithBase64EncodedDataWithNonBase64CharacterIsNil),
@@ -561,51 +549,6 @@ class TestNSData: LoopbackServerTest {
         } catch {
             XCTFail()
         }
-    }
-
-#if !os(Windows)
-    // NOTE: `umask(3)` is process global. Therefore, the behavior is unknown if `withUmask(_:_:)` is used simultaniously.
-    private func withUmask(_ mode: mode_t, _ block: () -> Void) {
-        let original = umask(mode)
-        block()
-        umask(original)
-    }
-#endif
-
-    func test_writeToURLPermissions() {
-#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT && !os(Windows)
-        withUmask(0) {
-            do {
-                let data = Data()
-                let url = URL(fileURLWithPath: NSTemporaryDirectory() + "meow")
-                try data.write(to: url)
-                let fileManager = FileManager.default
-                let permission = try fileManager._permissionsOfItem(atPath: url.path)
-                XCTAssertEqual(0o666, permission)
-                try! fileManager.removeItem(atPath: url.path)
-            } catch {
-                XCTFail()
-            }
-        }
-#endif
-    }
-
-    func test_writeToURLPermissionsWithAtomic() {
-#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT && !os(Windows)
-        withUmask(0) {
-            do {
-                let data = Data()
-                let url = URL(fileURLWithPath: NSTemporaryDirectory() + "meow")
-                try data.write(to: url, options: .atomic)
-                let fileManager = FileManager.default
-                let permission = try fileManager._permissionsOfItem(atPath: url.path)
-                XCTAssertEqual(0o666, permission)
-                try! fileManager.removeItem(atPath: url.path)
-            } catch {
-                XCTFail()
-            }
-        }
-#endif
     }
 
     func test_emptyDescription() {


### PR DESCRIPTION
Reverts apple/swift-corelibs-foundation#2851

This breaks on Windows