### PR TITLE
Avoid a crash when the hash value of a shimmed run loop source is negative

### DIFF
--- a/Sources/Foundation/RunLoop.swift
+++ b/Sources/Foundation/RunLoop.swift
@@ -323,7 +323,7 @@ extension RunLoop {
                 },
                 hash: { (info) -> CFHashCode in
                     let me = Unmanaged<_Source>.fromOpaque(info!).takeUnretainedValue()
-                    return CFHashCode(me.hashValue)
+                    return CFHashCode(bitPattern: me.hashValue)
                 },
                 schedule: { (info, cfRunLoop, cfRunLoopMode) in
                     let me = Unmanaged<_Source>.fromOpaque(info!).takeUnretainedValue()


### PR DESCRIPTION
`me.hashValue` is `Int`, and `CFHashCode` is `UInt`, so they have the same size.