### PR TITLE
Fix authentication through the session task delegate (SR-12676)

### DIFF
--- a/Sources/FoundationNetworking/URLResponse.swift
+++ b/Sources/FoundationNetworking/URLResponse.swift
@@ -197,6 +197,8 @@ open class HTTPURLResponse : URLResponse {
                 if key.isEmpty { continue }
                 if key.hasPrefix("x-") || key.hasPrefix("X-") {
                     canonicalizedFields[key] = value
+                } else if key.caseInsensitiveCompare("WWW-Authenticate") == .orderedSame {
+                    canonicalizedFields["WWW-Authenticate"] = value
                 } else {
                     canonicalizedFields[key.capitalized] = value
                 }

--- a/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
@@ -950,8 +950,7 @@ extension _ProtocolClient : URLProtocolClient {
             }
         }
         
-        switch session.behaviour(for: task) {
-        case .taskDelegate(let delegate):
+        if let delegate = session.delegate as? URLSessionTaskDelegate {
             session.delegateQueue.addOperation {
                 delegate.urlSession(session, task: task, didReceive: challenge) { disposition, credential in
                     
@@ -971,7 +970,7 @@ extension _ProtocolClient : URLProtocolClient {
                     
                 }
             }
-        default:
+        } else {
             attemptProceedingWithDefaultCredential()
         }
     }


### PR DESCRIPTION
- WWW-Authenticate must canonicalize with 'WWW' uppercase.
- The session delegate must be consulted for authentication even for tasks that have completion blocks.

https://bugs.swift.org/browse/SR-12676