### PR TITLE
[5.3][CMake] fix runpath for ELF platforms

### DIFF
--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -157,6 +157,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   add_dependencies(Foundation CoreFoundationResources)
   target_link_options(Foundation PRIVATE
     $<TARGET_OBJECTS:CoreFoundationResources>)
+elseif(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_options(Foundation PRIVATE "SHELL:-no-toolchain-stdlib-rpath")
 endif()
 
 

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -66,6 +66,10 @@ set_target_properties(FoundationNetworking PROPERTIES
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/swift)
 
+if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
+  target_link_options(FoundationNetworking PRIVATE "SHELL:-no-toolchain-stdlib-rpath")
+endif()
+
 
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS FoundationNetworking)
 install(TARGETS FoundationNetworking

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -20,6 +20,10 @@ set_target_properties(FoundationXML PROPERTIES
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/swift)
 
+if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
+  target_link_options(FoundationXML PRIVATE "SHELL:-no-toolchain-stdlib-rpath")
+endif()
+
 
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS FoundationXML)
 install(TARGETS FoundationXML


### PR DESCRIPTION
Remove the absolute path to the host toolchain's stdlib from the three Foundation shared libraries.

@millenomi, here you go.