### PR TITLE
Add locking primitives for TARGET_OS_WASI in CFLocking.h

### DIFF
--- a/CoreFoundation/Base.subproj/CFLocking.h
+++ b/CoreFoundation/Base.subproj/CFLocking.h
@@ -97,6 +97,8 @@ typedef CFLock_t OSSpinLock;
 #define OSSpinLockUnlock(lock) __CFUnlock(lock)
 
 #elif TARGET_OS_WASI
+
+// Empty shims until https://bugs.swift.org/browse/SR-12097 is resolved.
 typedef int32_t CFLock_t;
 typedef CFLock_t OSSpinLock;
 #define CFLockInit 0

--- a/CoreFoundation/Base.subproj/CFLocking.h
+++ b/CoreFoundation/Base.subproj/CFLocking.h
@@ -96,6 +96,20 @@ typedef CFLock_t OSSpinLock;
 #define OSSpinLockLock(lock) __CFLock(lock)
 #define OSSpinLockUnlock(lock) __CFUnlock(lock)
 
+#elif TARGET_OS_WASI
+typedef int32_t CFLock_t;
+typedef CFLock_t OSSpinLock;
+#define CFLockInit 0
+#define CF_LOCK_INIT_FOR_STRUCTS(X) (X = CFLockInit)
+#define OS_SPINLOCK_INIT CFLockInit
+
+#define OSSpinLockLock(lock) __CFLock(lock)
+#define OSSpinLockUnlock(lock) __CFUnlock(lock)
+#define __CFLock(A)     do {} while (0)
+#define __CFUnlock(A)   do {} while (0)
+
+static inline CFLock_t __CFLockInit(void) { return CFLockInit; }
+
 #else
 
 #warning CF locks not defined for this platform -- CF is not thread-safe


### PR DESCRIPTION
WebAssembly/WASI doesn't support multi-threading yet (as reported in SR-12097), so these primitives don't do anything in this single-threaded environment, but allow the rest of the code using them to compile.