### PR TITLE
Add failing test for dynamic cast

### DIFF
--- a/Tests/Foundation/Tests/TestBridging.swift
+++ b/Tests/Foundation/Tests/TestBridging.swift
@@ -26,6 +26,7 @@ class TestBridging : XCTestCase {
     static var allTests: [(String, (TestBridging) -> () throws -> Void)] {
         return [
             ("testBridgedDescription", testBridgedDescription),
+            ("testDynamicCast", testDynamicCast),
         ]
     }
 
@@ -61,5 +62,12 @@ class TestBridging : XCTestCase {
         XCTAssertEqual("description", c.description)
         XCTAssertEqual("description", c.debugDescription)
         #endif
+    }
+
+    func testDynamicCast() throws {
+        // Covers https://github.com/apple/swift-corelibs-foundation/pull/2500
+        class TestClass {}
+        let anyArray: Any = [TestClass()]
+        XCTAssertNotNil(anyArray as? NSObject)
     }
 }


### PR DESCRIPTION
I am getting crash when trying to perform dynamic cast like this:
```
let anyArray: Any = [TestClass()]
let maybeObject = anyArray as? NSObject
```

```
Could not cast value of type 'TestFoundation.TestBridging.(unknown context at $7ff798798298).(unknown context at $7ff7987982a0).TestClass' (00007FF7988CC248) to 'Foundation.NSObject' (00007FFD7253A528). 
```

While it is possibly a bug in new dynamic casting in compiler, I think it is good to cover it with test already.