### PR TITLE
Fix test fail triggered by multiline environment variables

### DIFF
--- a/Tests/Foundation/Tests/TestProcess.swift
+++ b/Tests/Foundation/Tests/TestProcess.swift
@@ -215,7 +215,12 @@ class TestProcess : XCTestCase {
         do {
             let (output, _) = try runTask([xdgTestHelperURL().path, "--env"], environment: nil)
             let env = try parseEnv(output)
+#if os(Windows)
+            // On Windows, Path is always passed to the sub process
+            XCTAssertGreaterThan(env.count, 1)
+#else
             XCTAssertGreaterThan(env.count, 0)
+#endif
         } catch {
             XCTFail("Test failed: \(error)")
         }

--- a/Tests/Tools/XDGTestHelper/main.swift
+++ b/Tests/Tools/XDGTestHelper/main.swift
@@ -232,7 +232,7 @@ case "--echo-PWD":
     print(ProcessInfo.processInfo.environment["PWD"] ?? "")
 
 case "--env":
-    print(ProcessInfo.processInfo.environment.filter { $0.key != "__CF_USER_TEXT_ENCODING" }.map { "\($0.key)=\($0.value)" }.joined(separator: "\n"))
+    print(ProcessInfo.processInfo.environment.filter { $0.key != "__CF_USER_TEXT_ENCODING" }.map { "\($0.key)=\($0.value.filter { !$0.isNewline })" }.joined(separator: "\n"))
 
 case "--cat":
     cat(arguments)


### PR DESCRIPTION
Fix `TestProcess.test_passthrough_environment` fails when an environment variable has multiple lines.