### PR TITLE
Remove all uses of CF from the framework's interface outside of Linux or Darwin.

### DIFF
--- a/Sources/Foundation/Port.swift
+++ b/Sources/Foundation/Port.swift
@@ -659,7 +659,7 @@ open class SocketPort : Port {
     }
     
     open override func schedule(in runLoop: RunLoop, forMode mode: RunLoop.Mode) {
-        let loop = runLoop.getCFRunLoop()
+        let loop = runLoop.currentCFRunLoop
         let loopKey = ObjectIdentifier(loop)
         
         core.lock.synchronized {
@@ -685,7 +685,7 @@ open class SocketPort : Port {
     }
     
     open override func remove(from runLoop: RunLoop, forMode mode: RunLoop.Mode) {
-        let loop = runLoop.getCFRunLoop()
+        let loop = runLoop.currentCFRunLoop
         let loopKey = ObjectIdentifier(loop)
         
         core.lock.synchronized {

--- a/Sources/Foundation/Stream.swift
+++ b/Sources/Foundation/Stream.swift
@@ -172,11 +172,11 @@ open class InputStream: Stream {
     }
     
     open override func schedule(in aRunLoop: RunLoop, forMode mode: RunLoop.Mode) {
-        CFReadStreamScheduleWithRunLoop(_stream, aRunLoop.getCFRunLoop(), mode.rawValue._cfObject)
+        CFReadStreamScheduleWithRunLoop(_stream, aRunLoop.currentCFRunLoop, mode.rawValue._cfObject)
     }
     
     open override func remove(from aRunLoop: RunLoop, forMode mode: RunLoop.Mode) {
-        CFReadStreamUnscheduleFromRunLoop(_stream, aRunLoop.getCFRunLoop(), mode.rawValue._cfObject)
+        CFReadStreamUnscheduleFromRunLoop(_stream, aRunLoop.currentCFRunLoop, mode.rawValue._cfObject)
     }
 }
 
@@ -251,11 +251,11 @@ open class OutputStream : Stream {
     }
     
     open override func schedule(in aRunLoop: RunLoop, forMode mode: RunLoop.Mode) {
-        CFWriteStreamScheduleWithRunLoop(_stream, aRunLoop.getCFRunLoop(), mode.rawValue._cfObject)
+        CFWriteStreamScheduleWithRunLoop(_stream, aRunLoop.currentCFRunLoop, mode.rawValue._cfObject)
     }
     
     open override func remove(from aRunLoop: RunLoop, forMode mode: RunLoop.Mode) {
-        CFWriteStreamUnscheduleFromRunLoop(_stream, aRunLoop.getCFRunLoop(), mode.rawValue._cfObject)
+        CFWriteStreamUnscheduleFromRunLoop(_stream, aRunLoop.currentCFRunLoop, mode.rawValue._cfObject)
     }
 }
 


### PR DESCRIPTION
See https://forums.swift.org/t/formalizing-the-unavailability-of-core-foundation/40216 for details.