### PR TITLE
Remove _CFBridgeable

### DIFF
--- a/Sources/Foundation/Bridging.swift
+++ b/Sources/Foundation/Bridging.swift
@@ -51,11 +51,7 @@ extension _StructTypeBridgeable {
     }
 }
 
-// slated for removal, these are the swift-corelibs-only variant of the _ObjectiveCBridgeable
-internal protocol _CFBridgeable {
-    associatedtype CFType
-    var _cfObject: CFType { get }
-}
+// slated for removal, these are the swift-corelibs-only variant of the _ObjectiveCBridgeable\
 
 internal protocol _SwiftBridgeable {
     associatedtype SwiftType

--- a/Sources/Foundation/Bridging.swift
+++ b/Sources/Foundation/Bridging.swift
@@ -51,7 +51,7 @@ extension _StructTypeBridgeable {
     }
 }
 
-// slated for removal, these are the swift-corelibs-only variant of the _ObjectiveCBridgeable\
+// slated for removal, these are the swift-corelibs-only variant of the _ObjectiveCBridgeable
 
 internal protocol _SwiftBridgeable {
     associatedtype SwiftType

--- a/Sources/Foundation/Bundle.swift
+++ b/Sources/Foundation/Bundle.swift
@@ -278,7 +278,7 @@ open class Bundle: NSObject {
     }
     
     open class func urls(forResourcesWithExtension ext: String?, subdirectory subpath: String?, in bundleURL: NSURL) -> [NSURL]? {
-        return CFBundleCopyResourceURLsOfTypeInDirectory(bundleURL._cfObject, ext?._cfObject, subpath?._cfObject)?._unsafeTypedBridge()
+        return CFBundleCopyResourceURLsOfTypeInDirectory(bundleURL._cfObject, ext?._cfObject, subpath?._cfObject)._nsObject as? [NSURL]
     }
     
     // -----------------------------------------------------------------------------------
@@ -306,11 +306,11 @@ open class Bundle: NSObject {
     }
     
     open func urls(forResourcesWithExtension ext: String?, subdirectory subpath: String?) -> [NSURL]? {
-        return CFBundleCopyResourceURLsOfType(_bundle, ext?._cfObject, subpath?._cfObject)?._unsafeTypedBridge()
+        return CFBundleCopyResourceURLsOfType(_bundle, ext?._cfObject, subpath?._cfObject)?._nsObject as? [NSURL]
     }
     
     open func urls(forResourcesWithExtension ext: String?, subdirectory subpath: String?, localization localizationName: String?) -> [NSURL]? {
-        return CFBundleCopyResourceURLsOfTypeForLocalization(_bundle, ext?._cfObject, subpath?._cfObject, localizationName?._cfObject)?._unsafeTypedBridge()
+        return CFBundleCopyResourceURLsOfTypeForLocalization(_bundle, ext?._cfObject, subpath?._cfObject, localizationName?._cfObject)?._nsObject as? [NSURL]
     }
     
     // -----------------------------------------------------------------------------------

--- a/Sources/Foundation/DateIntervalFormatter.swift
+++ b/Sources/Foundation/DateIntervalFormatter.swift
@@ -102,10 +102,9 @@ open class DateIntervalFormatter: Formatter {
     public required init?(coder: NSCoder) {
         guard coder.allowsKeyedCoding else { fatalError("Requires a keyed coding-capable archiver.") }
         
-        func cfObject<T: NSObject & _CFBridgeable>(of aClass: T.Type, from coder: NSCoder, forKey key: String) -> T.CFType? {
+        func object<T: NSObject>(of aClass: T.Type, from coder: NSCoder, forKey key: String) -> T? {
             if coder.containsValue(forKey: key) {
-                let object = coder.decodeObject(forKey: key) as? T
-                return object?._cfObject
+                return coder.decodeObject(forKey: key) as? T
             } else {
                 return nil
             }
@@ -115,13 +114,13 @@ open class DateIntervalFormatter: Formatter {
         _CFDateIntervalFormatterInitializeFromCoderValues(core,
                                                           coder.decodeInt64(forKey: "NS.dateStyle"),
                                                           coder.decodeInt64(forKey: "NS.timeStyle"),
-                                                          cfObject(of: NSString.self, from: coder, forKey: "NS.dateTemplate"),
-                                                          cfObject(of: NSString.self, from: coder, forKey: "NS.dateTemplateFromStyle"),
+                                                          object(of: NSString.self, from: coder, forKey: "NS.dateTemplate")?._cfObject,
+                                                          object(of: NSString.self, from: coder, forKey: "NS.dateTemplateFromStyle")?._cfObject,
                                                           coder.decodeBool(forKey: "NS.modified"),
                                                           coder.decodeBool(forKey: "NS.useTemplate"),
-                                                          cfObject(of: NSLocale.self, from: coder, forKey: "NS.locale"),
-                                                          cfObject(of: NSCalendar.self, from: coder, forKey: "NS.calendar"),
-                                                          cfObject(of: NSTimeZone.self, from: coder, forKey: "NS.timeZone"))
+                                                          object(of: NSLocale.self, from: coder, forKey: "NS.locale")?._cfObject,
+                                                          object(of: NSCalendar.self, from: coder, forKey: "NS.calendar")?._cfObject,
+                                                          object(of: NSTimeZone.self, from: coder, forKey: "NS.timeZone")?._cfObject)
         self._core = core
         
         super.init(coder: coder)

--- a/Sources/Foundation/NSArray.swift
+++ b/Sources/Foundation/NSArray.swift
@@ -714,7 +714,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
     }
 }
 
-extension NSArray : _CFBridgeable, _SwiftBridgeable {
+extension NSArray : _SwiftBridgeable {
     internal var _cfObject: CFArray { return unsafeBitCast(self, to: CFArray.self) }
     internal var _swiftObject: [AnyObject] { return Array._unconditionallyBridgeFromObjectiveC(self) }
 }
@@ -728,21 +728,7 @@ extension CFArray : _NSBridgeable, _SwiftBridgeable {
     internal var _swiftObject: Array<Any> { return _nsObject._swiftObject }
 }
 
-extension CFArray {
-    /// Bridge something returned from CF to an Array<T>. Useful when we already know that a CFArray contains objects that are toll-free bridged with Swift objects, e.g. CFArray<CFURLRef>.
-    /// - Note: This bridging operation is unfortunately still O(n), but it only traverses the NSArray once, creating the Swift array and casting at the same time.
-    func _unsafeTypedBridge<T : _CFBridgeable>() -> Array<T> {
-        var result = Array<T>()
-        let count = CFArrayGetCount(self)
-        result.reserveCapacity(count)
-        for i in 0..<count {
-            result.append(unsafeBitCast(CFArrayGetValueAtIndex(self, i), to: T.self))
-        }
-        return result
-    }
-}
-
-extension Array : _NSBridgeable, _CFBridgeable {
+extension Array : _NSBridgeable {
     internal var _nsObject: NSArray { return _bridgeToObjectiveC() }
     internal var _cfObject: CFArray { return _nsObject._cfObject }
 }

--- a/Sources/Foundation/NSAttributedString.swift
+++ b/Sources/Foundation/NSAttributedString.swift
@@ -375,7 +375,7 @@ private extension NSAttributedString {
     }
 }
 
-extension NSAttributedString: _CFBridgeable {
+extension NSAttributedString {
     internal var _cfObject: CFAttributedString { return unsafeBitCast(self, to: CFAttributedString.self) }
 }
 

--- a/Sources/Foundation/NSCalendar.swift
+++ b/Sources/Foundation/NSCalendar.swift
@@ -1986,11 +1986,11 @@ extension DateComponents : _NSBridgeable {
     var _nsObject: NSType { return _bridgeToObjectiveC() }
 }
 
-extension NSCalendar: _SwiftBridgeable, _CFBridgeable {
+extension NSCalendar: _SwiftBridgeable {
     typealias SwiftType = Calendar
     var _swiftObject: SwiftType { return Calendar(reference: self) }
 }
-extension Calendar: _NSBridgeable, _CFBridgeable {
+extension Calendar: _NSBridgeable {
     typealias NSType = NSCalendar
     typealias CFType = CFCalendar
     var _nsObject: NSCalendar { return _bridgeToObjectiveC() }

--- a/Sources/Foundation/NSCharacterSet.swift
+++ b/Sources/Foundation/NSCharacterSet.swift
@@ -482,7 +482,7 @@ open class NSMutableCharacterSet : NSCharacterSet {
     }
 }
 
-extension CharacterSet : _CFBridgeable, _NSBridgeable {
+extension CharacterSet : _NSBridgeable {
     typealias CFType = CFCharacterSet
     typealias NSType = NSCharacterSet
     internal var _cfObject: CFType {

--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -909,12 +909,12 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
 }
 
 // MARK: -
-extension NSData : _CFBridgeable, _SwiftBridgeable {
+extension NSData : _SwiftBridgeable {
     typealias SwiftType = Data
     internal var _swiftObject: SwiftType { return Data(referencing: self) }
 }
 
-extension Data : _NSBridgeable, _CFBridgeable {
+extension Data : _NSBridgeable {
     typealias CFType = CFData
     typealias NSType = NSData
     internal var _cfObject: CFType { return _nsObject._cfObject }

--- a/Sources/Foundation/NSDate.swift
+++ b/Sources/Foundation/NSDate.swift
@@ -231,7 +231,7 @@ extension NSDate {
     }
 }
 
-extension NSDate: _CFBridgeable, _SwiftBridgeable {
+extension NSDate: _SwiftBridgeable {
     typealias SwiftType = Date
     var _swiftObject: Date {
         return Date(timeIntervalSinceReferenceDate: timeIntervalSinceReferenceDate)
@@ -246,7 +246,7 @@ extension CFDate : _NSBridgeable, _SwiftBridgeable {
     internal var _swiftObject: Date { return _nsObject._swiftObject }
 }
 
-extension Date : _NSBridgeable, _CFBridgeable {
+extension Date : _NSBridgeable {
     typealias NSType = NSDate
     typealias CFType = CFDate
     

--- a/Sources/Foundation/NSDictionary.swift
+++ b/Sources/Foundation/NSDictionary.swift
@@ -578,7 +578,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     }
 }
 
-extension NSDictionary : _CFBridgeable, _SwiftBridgeable {
+extension NSDictionary : _SwiftBridgeable {
     internal var _cfObject: CFDictionary { return unsafeBitCast(self, to: CFDictionary.self) }
     internal var _swiftObject: Dictionary<AnyHashable, Any> { return Dictionary._unconditionallyBridgeFromObjectiveC(self) }
 }
@@ -592,7 +592,7 @@ extension CFDictionary : _NSBridgeable, _SwiftBridgeable {
     internal var _swiftObject: [AnyHashable: Any] { return _nsObject._swiftObject }
 }
 
-extension Dictionary : _NSBridgeable, _CFBridgeable {
+extension Dictionary : _NSBridgeable {
     internal var _nsObject: NSDictionary { return _bridgeToObjectiveC() }
     internal var _cfObject: CFDictionary { return _nsObject._cfObject }
 }

--- a/Sources/Foundation/NSError.swift
+++ b/Sources/Foundation/NSError.swift
@@ -204,7 +204,6 @@ open class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
 
 extension NSError : Swift.Error { }
 
-extension NSError : _CFBridgeable { }
 extension CFError : _NSBridgeable {
     typealias NSType = NSError
     internal var _nsObject: NSType {

--- a/Sources/Foundation/NSLocale.swift
+++ b/Sources/Foundation/NSLocale.swift
@@ -10,7 +10,7 @@
 
 @_implementationOnly import CoreFoundation
 
-open class NSLocale: NSObject, NSCopying, NSSecureCoding, _CFBridgeable {
+open class NSLocale: NSObject, NSCopying, NSSecureCoding {
     typealias CFType = CFLocale
 
     // struct __CFLocale
@@ -222,7 +222,7 @@ extension NSLocale : _SwiftBridgeable {
     }
 }
 
-extension Locale : _CFBridgeable {
+extension Locale {
     typealias CFType = CFLocale
     internal var _cfObject: CFLocale {
         return _bridgeToObjectiveC()._cfObject

--- a/Sources/Foundation/NSNumber.swift
+++ b/Sources/Foundation/NSNumber.swift
@@ -557,7 +557,7 @@ extension Bool : _ObjectiveCBridgeable {
     }
 }
 
-extension Bool : _CFBridgeable {
+extension Bool {
     typealias CFType = CFBoolean
     var _cfObject: CFType {
         return self ? kCFBooleanTrue : kCFBooleanFalse

--- a/Sources/Foundation/NSSet.swift
+++ b/Sources/Foundation/NSSet.swift
@@ -334,7 +334,7 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
     }
 }
 
-extension NSSet : _CFBridgeable, _SwiftBridgeable {
+extension NSSet : _SwiftBridgeable {
     internal var _cfObject: CFSet { return unsafeBitCast(self, to: CFSet.self) }
     internal var _swiftObject: Set<NSObject> { return Set._unconditionallyBridgeFromObjectiveC(self) }
 }
@@ -348,7 +348,7 @@ extension NSMutableSet {
     internal var _cfMutableObject: CFMutableSet { return unsafeBitCast(self, to: CFMutableSet.self) }
 }
 
-extension Set : _NSBridgeable, _CFBridgeable {
+extension Set : _NSBridgeable {
     internal var _nsObject: NSSet { return _bridgeToObjectiveC() }
     internal var _cfObject: CFSet { return _nsObject._cfObject }
 }

--- a/Sources/Foundation/NSString.swift
+++ b/Sources/Foundation/NSString.swift
@@ -1613,7 +1613,7 @@ extension String {
     }
 }
 
-extension NSString : _CFBridgeable, _SwiftBridgeable {
+extension NSString : _SwiftBridgeable {
     typealias SwiftType = String
     internal var _cfObject: CFString { return unsafeBitCast(self, to: CFString.self) }
     internal var _swiftObject: String { return String._unconditionallyBridgeFromObjectiveC(self) }
@@ -1630,7 +1630,7 @@ extension CFString : _NSBridgeable, _SwiftBridgeable {
     internal var _swiftObject: String { return _nsObject._swiftObject }
 }
 
-extension String : _NSBridgeable, _CFBridgeable {
+extension String : _NSBridgeable {
     typealias NSType = NSString
     typealias CFType = CFString
     internal var _nsObject: NSType { return _bridgeToObjectiveC() }

--- a/Sources/Foundation/NSTimeZone.swift
+++ b/Sources/Foundation/NSTimeZone.swift
@@ -252,7 +252,7 @@ open class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
 
 }
 
-extension NSTimeZone: _SwiftBridgeable, _CFBridgeable {
+extension NSTimeZone: _SwiftBridgeable {
     typealias SwiftType = TimeZone
     var _swiftObject: TimeZone { return TimeZone(reference: self) }
 }
@@ -263,7 +263,7 @@ extension CFTimeZone : _SwiftBridgeable, _NSBridgeable {
     var _swiftObject: TimeZone { return _nsObject._swiftObject }
 }
 
-extension TimeZone : _NSBridgeable, _CFBridgeable {
+extension TimeZone : _NSBridgeable {
     typealias NSType = NSTimeZone
     typealias CFType = CFTimeZone
     var _nsObject : NSTimeZone { return _bridgeToObjectiveC() }

--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -1492,7 +1492,7 @@ open class NSURLComponents: NSObject, NSCopying {
     }
 }
 
-extension NSURL: _CFBridgeable, _SwiftBridgeable {
+extension NSURL: _SwiftBridgeable {
     typealias SwiftType = URL
     internal var _swiftObject: SwiftType { return URL(reference: self) }
 }
@@ -1504,7 +1504,7 @@ extension CFURL : _NSBridgeable, _SwiftBridgeable {
     internal var _swiftObject: SwiftType { return _nsObject._swiftObject }
 }
 
-extension URL : _NSBridgeable, _CFBridgeable {
+extension URL : _NSBridgeable {
     typealias NSType = NSURL
     typealias CFType = CFURL
     internal var _nsObject: NSType { return self.reference }


### PR DESCRIPTION
Windows is seeing deserialization errors when dealing with `_CFBridgeable`; the protocol was slated for removal anyway, and it can be removed now.

Note that `_cfObject` still exists for all objects that implemented that protocol. This merely removes the protocol, the conformance and reworks the constraints associated with it.