### PR TITLE
Hash implementation for NSIndexSet

### DIFF
--- a/Sources/Foundation/NSIndexSet.swift
+++ b/Sources/Foundation/NSIndexSet.swift
@@ -187,6 +187,15 @@ open class NSIndexSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         return isEqual(to: indexSet._swiftObject)
     }
     
+    open override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(_count)
+        hasher.combine(_ranges.count)
+        hasher.combine(firstIndex)
+        hasher.combine(lastIndex)
+        return hasher.finalize()
+    }
+    
     open var count: Int {
         return _count
     }

--- a/Tests/Foundation/Tests/TestIndexSet.swift
+++ b/Tests/Foundation/Tests/TestIndexSet.swift
@@ -1240,6 +1240,36 @@ class TestIndexSet : XCTestCase {
         }
     }
     
+    func testHashValue() throws {
+        var sample1 = IndexSet()
+        sample1.insert(integersIn: 1..<2)
+        sample1.insert(integersIn: 100..<200)
+        sample1.insert(integersIn: 1000..<2000)
+
+        var sample2 = IndexSet()
+        sample2.insert(integersIn: 1..<2)
+        sample2.insert(integersIn: 100..<200)
+        sample2.insert(integersIn: 1000..<2000)
+        
+        XCTAssertEqual(sample1.hashValue, sample2.hashValue)
+        
+        let sample3 = IndexSet([3, 5, 6, 7, 9])
+        let sample4 = IndexSet([3, 5, 6, 7, 9])
+        XCTAssertEqual(sample3.hashValue, sample4.hashValue)
+        
+        let sample5 = IndexSet([100, NSNotFound - 1, 200])
+        let sample6 = IndexSet([100, NSNotFound - 1, 200])
+        XCTAssertEqual(sample5.hashValue, sample6.hashValue)
+        
+        let sample7 = IndexSet(integer: NSNotFound - 1)
+        let sample8 = IndexSet(integer: NSNotFound - 1)
+        XCTAssertEqual(sample7.hashValue, sample8.hashValue)
+        
+        let sample9 = IndexSet()
+        let sample10 = IndexSet()
+        XCTAssertEqual(sample9.hashValue, sample10.hashValue)
+    }
+    
     static var allTests: [(String, (TestIndexSet) -> () throws -> Void)] {
         return [
             ("test_BasicConstruction", test_BasicConstruction),
@@ -1288,6 +1318,7 @@ class TestIndexSet : XCTestCase {
             ("testRemoveSplitting", testRemoveSplitting),
             ("testCodingRoundtrip", testCodingRoundtrip),
             ("testLoadedValuesMatch", testLoadedValuesMatch),
+            ("testHashValue", testHashValue),
         ]
     }
     


### PR DESCRIPTION
We noticed that `NSIndexSet` is missing implementation of `hash` property. Not a big deal, as NSObject provides default hash, but there are some cons:
- Equal `NSIndexSet`s would have different hashes based on their object identifier
- `IndexSet` is backed by `NSIndexSet`, deriving same inconvenience
- This behavior is not consistent with Apple Foundation

After some experiments with NSIndexSet from macOS Foundation, these details were observed:
- Calculation complexity is O(1). No matter how many indexes/ranges is stored, `hash` is always fast.
- The only parameters affecting hash are: count of indexes, first and last index value. This explains constant complexity.
- Empty index set has hash equal to 0.

I think the most important detail here is calculation speed, because my first thoughts on implementation were about iterating over all ranges in set. Which is, obviously, slower. But we still could take into account number of ranges to make hash better.

Based on all above, we'd like to suggest hash implementation powered by standard Hasher and based on index count, range count, first and last index.
