### PR TITLE
Add discardableResult to XMLParser.parse

### DIFF
--- a/Sources/FoundationXML/XMLParser.swift
+++ b/Sources/FoundationXML/XMLParser.swift
@@ -576,6 +576,7 @@ open class XMLParser : NSObject {
     }
     
     // called to start the event-driven parse. Returns YES in the event of a successful parse, and NO in case of error.
+    @discardableResult
     open func parse() -> Bool {
         XMLParser.setCurrentParser(self)
         defer { XMLParser.setCurrentParser(nil) }


### PR DESCRIPTION
On macOS you don't get a warning when discarding the result of this
function. It isn't written in Swift so it doesn't have this attribute,
so I'm assuming it's Objective-C import semantics that imply allowing
discarding it without warnings.