### PR TITLE
NSSet: add missing convenience initializer

### DIFF
--- a/Sources/Foundation/NSSet.swift
+++ b/Sources/Foundation/NSSet.swift
@@ -86,6 +86,10 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
         self.init(array: [object])
     }
 
+    public convenience init(objects elements: Any...) {
+        self.init(array: elements)
+    }
+
     internal class func _objects(from aDecoder: NSCoder, allowDecodingNonindexedArrayKey: Bool = true) -> [NSObject] {
         guard aDecoder.allowsKeyedCoding else {
             preconditionFailure("Unkeyed coding is unsupported.")

--- a/Tests/Foundation/Tests/TestNSSet.swift
+++ b/Tests/Foundation/Tests/TestNSSet.swift
@@ -26,6 +26,10 @@ class TestNSSet : XCTestCase {
         XCTAssertEqual(set5, set3)
         set5.add(2)
         XCTAssertNotEqual(set5, set3)
+
+        let set6 = NSSet(objects: "foo", "bar")
+        XCTAssertEqual(set6.count, 2)
+        XCTAssertEqual(set2, set6)
     }
 
     func testInitWithSet() {


### PR DESCRIPTION
This initializer exists in the macOS version of Foundation, but isn't present on Linux/Windows.
While it doesn't add any new functionality, it simplifies porting existing code to those platforms.