### PR TITLE
Foundation: explicitly convert value to `Date`

### DIFF
--- a/Sources/Foundation/URL.swift
+++ b/Sources/Foundation/URL.swift
@@ -149,7 +149,10 @@ public struct URLResourceValues {
     
     /// The date the resource was created.
     public var creationDate: Date? {
-        get { return _get(.creationDateKey) }
+        get {
+          guard let timestamp: Int = _get(.creationDateKey) else { return nil }
+          return Date(timeIntervalSince1970: TimeInterval(timestamp))
+        }
         set { _set(.creationDateKey, newValue: newValue) }
     }
     


### PR DESCRIPTION
There is no implicit conversion from `Int` to `Date`.  The implicit cast
fails, resulting in `nil` being returned for the `creationDate`
property.  Explicitly unwrap the result of the `.creationDate` attribute
and use that to construct the `Date` to return.

Partially addresses: SR-13617