### PR TITLE
FoundationNetworking: make `CFURLSessionInterface` `@_implementationO…

### DIFF
--- a/Sources/FoundationNetworking/URLSession/BodySource.swift
+++ b/Sources/FoundationNetworking/URLSession/BodySource.swift
@@ -23,7 +23,7 @@ import Foundation
 #endif
 
 @_implementationOnly import CoreFoundation
-import CFURLSessionInterface
+@_implementationOnly import CFURLSessionInterface
 import Dispatch
 
 

--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
@@ -14,7 +14,7 @@ import Foundation
 #endif
 
 @_implementationOnly import CoreFoundation
-import CFURLSessionInterface
+@_implementationOnly import CFURLSessionInterface
 import Dispatch
 
 internal class _HTTPURLProtocol: _NativeProtocol {

--- a/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
+++ b/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
@@ -24,7 +24,7 @@ import Foundation
 #endif
 
 @_implementationOnly import CoreFoundation
-import CFURLSessionInterface
+@_implementationOnly import CFURLSessionInterface
 import Dispatch
 
 
@@ -76,9 +76,12 @@ internal final class _EasyHandle {
     }
 }
 
-extension _EasyHandle: Equatable {}
-    internal func ==(lhs: _EasyHandle, rhs: _EasyHandle) -> Bool {
-        return lhs.rawHandle == rhs.rawHandle
+internal func ==(lhs: _EasyHandle, rhs: _EasyHandle) -> Bool {
+    return lhs.rawHandle == rhs.rawHandle
+}
+
+internal func ~=(lhs: _EasyHandle, rhs: _EasyHandle) -> Bool {
+    return lhs == rhs
 }
 
 extension _EasyHandle {
@@ -392,23 +395,24 @@ internal extension _EasyHandle {
 }
 
 
-extension CFURLSessionInfo : Equatable {
-    public static func ==(lhs: CFURLSessionInfo, rhs: CFURLSessionInfo) -> Bool {
-        return lhs.value == rhs.value
-    }
+internal func ==(lhs: CFURLSessionInfo, rhs: CFURLSessionInfo) -> Bool {
+    return lhs.value == rhs.value
+}
+internal func ~=(lhs: CFURLSessionInfo, rhs: CFURLSessionInfo) -> Bool {
+    return lhs == rhs
 }
 
 extension CFURLSessionInfo {
-    public var debugHeader: String {
+    internal var debugHeader: String {
         switch self {
         case CFURLSessionInfoTEXT:         return "                 "
-        case CFURLSessionInfoHEADER_OUT:   return "=> Send header   ";
-        case CFURLSessionInfoDATA_OUT:     return "=> Send data     ";
-        case CFURLSessionInfoSSL_DATA_OUT: return "=> Send SSL data ";
-        case CFURLSessionInfoHEADER_IN:    return "<= Recv header   ";
-        case CFURLSessionInfoDATA_IN:      return "<= Recv data     ";
-        case CFURLSessionInfoSSL_DATA_IN:  return "<= Recv SSL data ";
-        default:                            return "                 "
+        case CFURLSessionInfoHEADER_OUT:   return "=> Send header   "
+        case CFURLSessionInfoDATA_OUT:     return "=> Send data     "
+        case CFURLSessionInfoSSL_DATA_OUT: return "=> Send SSL data "
+        case CFURLSessionInfoHEADER_IN:    return "<= Recv header   "
+        case CFURLSessionInfoDATA_IN:      return "<= Recv data     "
+        case CFURLSessionInfoSSL_DATA_IN:  return "<= Recv SSL data "
+        default:                           return "                 "
         }
     }
 }
@@ -671,18 +675,16 @@ extension _EasyHandle._CurlStringList {
     }
 }
 
-extension CFURLSessionEasyCode : Equatable {
-    public static func ==(lhs: CFURLSessionEasyCode, rhs: CFURLSessionEasyCode) -> Bool {
-        return lhs.value == rhs.value
-    }
+internal func ==(lhs: CFURLSessionEasyCode, rhs: CFURLSessionEasyCode) -> Bool {
+    return lhs.value == rhs.value
 }
-extension CFURLSessionEasyCode : Error {
-    public var _domain: String { return "libcurl.Easy" }
-    public var _code: Int { return Int(self.value) }
+internal func ~=(lhs: CFURLSessionEasyCode, rhs: CFURLSessionEasyCode) -> Bool {
+    return lhs == rhs
 }
-internal extension CFURLSessionEasyCode {
-    func asError() throws {
+
+extension CFURLSessionEasyCode {
+    internal func asError() throws {
         if self == CFURLSessionEasyCodeOK { return }
-        throw self
+        throw NSError(domain: "libcurl.Easy", code: Int(self.value))
     }
 }

--- a/Sources/FoundationNetworking/URLSession/libcurl/MultiHandle.swift
+++ b/Sources/FoundationNetworking/URLSession/libcurl/MultiHandle.swift
@@ -23,7 +23,7 @@ import Foundation
 #endif
 
 @_implementationOnly import CoreFoundation
-import CFURLSessionInterface
+@_implementationOnly import CFURLSessionInterface
 import Dispatch
 
 
@@ -148,6 +148,17 @@ fileprivate extension URLSession._MultiHandle {
         case registerReadAndWrite
         case unregister
     }
+}
+
+extension Collection where Element == _EasyHandle {
+  internal func firstIndex(of element: Element) -> Index? {
+    var i = self.startIndex
+    while i != self.endIndex {
+      if self[i] == element { return i }
+      self.formIndex(after: &i)
+    }
+    return nil
+  }
 }
 
 internal extension URLSession._MultiHandle {
@@ -277,6 +288,13 @@ fileprivate extension _EasyHandle {
     }
 }
 
+internal func ==(lhs: CFURLSessionPoll, rhs: CFURLSessionPoll) -> Bool {
+    return lhs.value == rhs.value
+}
+internal func ~=(lhs: CFURLSessionPoll, rhs: CFURLSessionPoll) -> Bool {
+    return lhs == rhs
+}
+
 fileprivate extension URLSession._MultiHandle._SocketRegisterAction {
     init(rawValue: CFURLSessionPoll) {
         switch rawValue {
@@ -295,11 +313,7 @@ fileprivate extension URLSession._MultiHandle._SocketRegisterAction {
         }
     }
 }
-extension CFURLSessionPoll : Equatable {
-    public static func ==(lhs: CFURLSessionPoll, rhs: CFURLSessionPoll) -> Bool {
-        return lhs.value == rhs.value
-    }
-}
+
 fileprivate extension URLSession._MultiHandle._SocketRegisterAction {
     /// Should a libdispatch source be registered for **read** readiness?
     var needsReadSource: Bool {
@@ -470,18 +484,16 @@ extension _SocketSources {
 }
 
 
-extension CFURLSessionMultiCode : Equatable {
-    public static func ==(lhs: CFURLSessionMultiCode, rhs: CFURLSessionMultiCode) -> Bool {
-        return lhs.value == rhs.value
-    }
+internal func ==(lhs: CFURLSessionMultiCode, rhs: CFURLSessionMultiCode) -> Bool {
+    return lhs.value == rhs.value
 }
-extension CFURLSessionMultiCode : Error {
-    public var _domain: String { return "libcurl.Multi" }
-    public var _code: Int { return Int(self.value) }
+internal func ~=(lhs: CFURLSessionMultiCode, rhs: CFURLSessionMultiCode) -> Bool {
+    return lhs == rhs
 }
-internal extension CFURLSessionMultiCode {
-    func asError() throws {
+
+extension CFURLSessionMultiCode {
+    internal func asError() throws {
         if self == CFURLSessionMultiCodeOK { return }
-        throw self
+        throw NSError(domain: "libcurl.multi", code: Int(self.value))
     }
 }

--- a/Sources/FoundationNetworking/URLSession/libcurl/libcurlHelpers.swift
+++ b/Sources/FoundationNetworking/URLSession/libcurl/libcurlHelpers.swift
@@ -18,7 +18,7 @@
 
 
 @_implementationOnly import CoreFoundation
-import CFURLSessionInterface
+@_implementationOnly import CFURLSessionInterface
 
 //TODO: Move things in this file?
 


### PR DESCRIPTION
…nly`

Remove the public exposure to `CFURLSessionInterface` which was never
meant to be public.  This requires removal of some of the `Equatable`
conformances as scoped conformances are not yet a part of the language.
This does the minimal change for to get `FoundationNetworking` to build.