### PR TITLE
Foundation: make `-enable-library-evolution` build

### DIFF
--- a/Sources/Foundation/Data.swift
+++ b/Sources/Foundation/Data.swift
@@ -1088,8 +1088,8 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
 
     // A reference wrapper around a Range<Int> for when the range of a data buffer is too large to whole in a single word.
     // Inlinability strategy: everything should be inlinable as trivial.
-    @usableFromInline
-    internal final class RangeReference {
+    // @usableFromInline
+    public /* internal */ final class RangeReference {
         @usableFromInline var range: Range<Int>
 
         @inlinable @inline(__always) // This is @inlinable as trivially forwarding.
@@ -1107,8 +1107,8 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             return range.upperBound - range.lowerBound
         }
 
-        @inlinable @inline(__always) // This is @inlinable as a trivial initializer.
-        init(_ range: Range<Int>) {
+        /* @inlinable */ @inline(__always) // This is @inlinable as a trivial initializer.
+        public init(_ range: Range<Int>) {
             self.range = range
         }
     }

--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -110,7 +110,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         }
     }
 
-    fileprivate init(bytes: UnsafeMutableRawPointer?, length: Int, copy: Bool = false, deallocator: ((UnsafeMutableRawPointer, Int) -> Void)? = nil) {
+    public /* fileprivate */ init(bytes: UnsafeMutableRawPointer?, length: Int, copy: Bool = false, deallocator: ((UnsafeMutableRawPointer, Int) -> Void)? = nil) {
         super.init()
         _init(bytes: bytes, length: length, copy: copy, deallocator: deallocator)
     }


### PR DESCRIPTION
When building Foundation with library evolution (resilience), we fail to
build due to `RangeReference` being internal and marked as
`@usableFromInline` but used in an `@inlinable` `public` context,
exposing the type.  Additionally, the constructor was internal and
`@inlinable` which requires the constructor to be delegating.

Additionally, because `Data.init(bytes:length:copy:deallocator)` is used
in a public context, it leaks and results in an undefined reference to
the allocating initializer.

This allows building Foundation with library evolution, though exposes
some of the internal interfaces.