### PR TITLE
Foundation: extract `cfSource` from `RunLoop._Source`

### DIFF
--- a/Sources/Foundation/RunLoop.swift
+++ b/Sources/Foundation/RunLoop.swift
@@ -327,8 +327,6 @@ extension RunLoop {
     @available(*, deprecated, message: "For XCTest use only.")
     open class _Source: NSObject {
         fileprivate var _cfSourceStorage: AnyObject!
-        fileprivate var cfSource: CFRunLoopSource { unsafeBitCast(_cfSourceStorage, to: CFRunLoopSource.self) }
-        
         
         public init(order: Int = 0) {
             super.init()
@@ -408,5 +406,11 @@ extension RunLoop {
         deinit {
             invalidate()
         }
+    }
+}
+
+extension RunLoop._Source {
+    fileprivate var cfSource: CFRunLoopSource {
+      unsafeBitCast(_cfSourceStorage, to: CFRunLoopSource.self)
     }
 }


### PR DESCRIPTION
Making `cfSource` a member within the structure prevents allowing
overriding of the `open` class as the type it returns cannot be
deserialised.  Because the member is not a stored property, extract it
to an extension which removes it from the vtable.  This allows the use
of the private type in an external context.