### PR TITLE
Use receiver's timezone in isValidDate() as per documentation

### DIFF
--- a/Sources/Foundation/NSCalendar.swift
+++ b/Sources/Foundation/NSCalendar.swift
@@ -1879,7 +1879,7 @@ open class NSDateComponents : NSObject, NSCopying, NSSecureCoding {
         if ns != NSDateComponentUndefined && 0 < ns {
             nanosecond = 0
         }
-        let d = calendar.date(from: self._swiftObject)
+        let d = cal.date(from: self._swiftObject)
         if ns != NSDateComponentUndefined && 0 < ns {
             nanosecond = ns
         }

--- a/Tests/Foundation/Tests/TestNSDateComponents.swift
+++ b/Tests/Foundation/Tests/TestNSDateComponents.swift
@@ -269,6 +269,22 @@ class TestNSDateComponents: XCTestCase {
         XCTAssertEqual(Calendar.current.compare(d2, to: d1, toGranularity: .weekday), .orderedDescending)
     }
 
+    func test_isValidDate() {
+        let components = NSDateComponents()
+        components.year = 2019
+        components.month = 11
+        components.day = 3
+        components.hour = 7
+        components.minute = 5
+        components.second = 54
+        components.timeZone = TimeZone(secondsFromGMT: -18000)!
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/Chicago")!
+
+        XCTAssert(components.isValidDate(in: Calendar(identifier: Calendar.Identifier.gregorian)))
+    }
+
     static var allTests: [(String, (TestNSDateComponents) -> () throws -> Void)] {
         return [
             ("test_hash", test_hash),
@@ -276,6 +292,7 @@ class TestNSDateComponents: XCTestCase {
             ("test_dateDifferenceComponents", test_dateDifferenceComponents),
             ("test_nanoseconds", test_nanoseconds),
             ("test_currentCalendar", test_currentCalendar),
+            ("test_isValidDate", test_isValidDate),
         ]
     }
 }


### PR DESCRIPTION
The [documentation of DateComponents.isValidDate(in:)](https://developer.apple.com/documentation/foundation/nsdatecomponents/1412707-isvaliddate) indicates that the receiver's timezone is used, if it is set. The code also appears to be attempting to implement this, by setting the `timeZone` property on a local `cal` var, but this var wasn't being used at all later in the function. 

The result is that seemingly valid DateComponents can return false for isValidDate(), when the receiver's timezone differs from the passed in calendar's timezone, which is often system timezone. 