### PR TITLE
[cxx-interop] Fix two headers to be valid in C++ mode.

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -672,8 +672,12 @@ CF_EXPORT int _CFPosixSpawnFileActionsDestroy(_CFPosixSpawnFileActionsRef file_a
 CF_EXPORT void _CFPosixSpawnFileActionsDealloc(_CFPosixSpawnFileActionsRef file_actions);
 CF_EXPORT int _CFPosixSpawnFileActionsAddDup2(_CFPosixSpawnFileActionsRef file_actions, int filedes, int newfiledes);
 CF_EXPORT int _CFPosixSpawnFileActionsAddClose(_CFPosixSpawnFileActionsRef file_actions, int filedes);
+#ifdef __cplusplus
+CF_EXPORT int _CFPosixSpawn(pid_t *_CF_RESTRICT pid, const char *_CF_RESTRICT path, _CFPosixSpawnFileActionsRef file_actions, _CFPosixSpawnAttrRef _Nullable _CF_RESTRICT attrp, char *const argv[], char *const envp[]);
+#else
 CF_EXPORT int _CFPosixSpawn(pid_t *_CF_RESTRICT pid, const char *_CF_RESTRICT path, _CFPosixSpawnFileActionsRef file_actions, _CFPosixSpawnAttrRef _Nullable _CF_RESTRICT attrp, char *_Nullable const argv[_Nullable _CF_RESTRICT], char *_Nullable const envp[_Nullable _CF_RESTRICT]);
-#endif
+#endif // __cplusplus
+#endif // !TARGET_OS_WIN32
 
 _CF_EXPORT_SCOPE_END
 

--- a/CoreFoundation/Locale.subproj/CFCalendar_Internal.h
+++ b/CoreFoundation/Locale.subproj/CFCalendar_Internal.h
@@ -19,7 +19,7 @@
 #include "CFDateComponents.h"
 #include "CFDateInterval.h"
 
-#if __has_include(<unicode/ucal.h>)
+#if __has_include(<unicode/ucal.h>) && !defined(__cplusplus)
 #include <unicode/ucal.h>
 #else
 typedef void *UCalendar;


### PR DESCRIPTION
This is exported as a C header but in C++ mode `ucal.h` will expose templates that aren't valid. This will hopefully fix the Linux build for https://github.com/apple/swift/pull/32721. 