### PR TITLE
[Windows] Fix thread local storage cleanup

### DIFF
--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -663,16 +663,6 @@ CF_PRIVATE void __CFTSDWindowsCleanup() {
     FlsFree(__CFTSDIndexKey);
 }
 
-// Called for each thread as it exits, on Windows only
-CF_PRIVATE void __CFFinalizeWindowsThreadData() {
-    // Normally, this should call the finalizer several times to emulate the behavior of pthreads on Windows. However, a few bugs keep us from doing this:
-    // <rdar://problem/8989063> REGRESSION(CF-610-CF-611): Crash closing Safari in BonjourDB destructor (Windows)
-    // <rdar://problem/9326814> SyncUIHandler crashes after conflict is resolved and we do SyncNow
-    //  and a bug in dispatch keeps us from using pthreadsWin32 directly, because it does not deal with the case of a dispatch_async happening during process exit (it attempts to create a thread, but that is illegal on Win32 and causes a hang).
-    // So instead we just finalize once, which is the behavior pre-Airwolf anyway
-    __CFTSDFinalize(TlsGetValue(__CFTSDIndexKey));
-}
-
 #else
 
 static _CFThreadSpecificKey __CFTSDIndexKey;

--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -978,7 +978,6 @@ CF_PRIVATE void __CFTSDInitialize(void);
 #if TARGET_OS_WIN32
 // From CFPlatform.c
 CF_PRIVATE void __CFTSDWindowsCleanup(void);
-CF_PRIVATE void __CFFinalizeWindowsThreadData(void);
 #endif
 
 #if TARGET_OS_MAC
@@ -1352,8 +1351,6 @@ int DllMain( HINSTANCE hInstance, DWORD dwReason, LPVOID pReserved ) {
 	// do these last
 	if (cfBundle) CFRelease(cfBundle);
         __CFStringCleanup();
-    } else if (dwReason == DLL_THREAD_DETACH) {
-        __CFFinalizeWindowsThreadData();
     }
     return TRUE;
 }


### PR DESCRIPTION
CoreFoundation thread local storage on Windows is based on FLS API. FLS provides automatic cleanup of storage, and it is already got used. Old manual cleanup is not needed anymore.

We have observed often crashes in thread cleanup routines of CRT. Despite I didn't manage to extract the issue out of live project code, I suppose that mixing TLS and FLS in cleanup code could eventually corrupt the storage. Replacing `TlsGetValue` with `FlsGetValue` brings desired stability, but, as the code is obsolete, we could just remove it.
