### PR TITLE
Remove an invalid numeric JSON test

### DIFF
--- a/Tests/Foundation/Tests/TestJSONEncoder.swift
+++ b/Tests/Foundation/Tests/TestJSONEncoder.swift
@@ -750,7 +750,6 @@ class TestJSONEncoder : XCTestCase {
         testErrorThrown("Double", "-.1", errorMessage: "The given data was not valid JSON.")
         testErrorThrown("Int32", "+1", errorMessage: "The given data was not valid JSON.")
         testErrorThrown("Int", ".012", errorMessage: "The given data was not valid JSON.")
-        testErrorThrown("Double", "2.7976931348623158e+308", errorMessage: "The given data was not valid JSON.")
     }
 
     func test_snake_case_encoding() throws {


### PR DESCRIPTION
The value `2.7976931348623158e+308` is a perfectly valid JSON number
and should be accepted.  This test is only passing today because the Swift
standard library's `Double(_ String:)` initializer currently has a bug that
rejects numbers larger than the maximum Double value.

But we're getting ready to fix that bug in the Swift standard library,
(apple/swift#34339) which will break this test when it lands.

(After that PR lands, we should update this again to verify that this value
parses to `Double.infinity`.)