### PR TITLE
[SR-13300] FileManager _updateTimes (microseconds)

### DIFF
--- a/Sources/Foundation/FileManager+POSIX.swift
+++ b/Sources/Foundation/FileManager+POSIX.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -1180,10 +1180,10 @@ extension FileManager {
         let modificationDate = modificationTime ?? stat.lastModificationDate
 
         let (accessTimeSince1970Seconds, accessTimeSince1970FractionsOfSecond) = modf(accessDate.timeIntervalSince1970)
-        let accessTimeval = timeval(tv_sec: time_t(accessTimeSince1970Seconds), tv_usec: suseconds_t(1.0e9 * accessTimeSince1970FractionsOfSecond))
+        let accessTimeval = timeval(tv_sec: time_t(accessTimeSince1970Seconds), tv_usec: suseconds_t(1.0e6 * accessTimeSince1970FractionsOfSecond))
 
         let (modificationTimeSince1970Seconds, modificationTimeSince1970FractionsOfSecond) = modf(modificationDate.timeIntervalSince1970)
-        let modificationTimeval = timeval(tv_sec: time_t(modificationTimeSince1970Seconds), tv_usec: suseconds_t(1.0e9 * modificationTimeSince1970FractionsOfSecond))
+        let modificationTimeval = timeval(tv_sec: time_t(modificationTimeSince1970Seconds), tv_usec: suseconds_t(1.0e6 * modificationTimeSince1970FractionsOfSecond))
 
         let array = [accessTimeval, modificationTimeval]
         let errnoValue = array.withUnsafeBufferPointer { (bytes) -> Int32? in

--- a/Sources/Foundation/FileManager+POSIX.swift
+++ b/Sources/Foundation/FileManager+POSIX.swift
@@ -1179,23 +1179,14 @@ extension FileManager {
         let accessDate = accessTime ?? stat.lastAccessDate
         let modificationDate = modificationTime ?? stat.lastModificationDate
 
-        let (accessTimeSince1970Seconds, accessTimeSince1970FractionsOfSecond) = modf(accessDate.timeIntervalSince1970)
-        let accessTimeval = timeval(tv_sec: time_t(accessTimeSince1970Seconds), tv_usec: suseconds_t(1.0e6 * accessTimeSince1970FractionsOfSecond))
-
-        let (modificationTimeSince1970Seconds, modificationTimeSince1970FractionsOfSecond) = modf(modificationDate.timeIntervalSince1970)
-        let modificationTimeval = timeval(tv_sec: time_t(modificationTimeSince1970Seconds), tv_usec: suseconds_t(1.0e6 * modificationTimeSince1970FractionsOfSecond))
-
-        let array = [accessTimeval, modificationTimeval]
-        let errnoValue = array.withUnsafeBufferPointer { (bytes) -> Int32? in
-            if utimes(fsr, bytes.baseAddress) < 0 {
-                return errno
-            } else {
-                return nil
+        let array = [
+            timeval(_timeIntervalSince1970: accessDate.timeIntervalSince1970), 
+            timeval(_timeIntervalSince1970: modificationDate.timeIntervalSince1970),
+        ]
+        try array.withUnsafeBufferPointer {
+            guard utimes(fsr, $0.baseAddress) == 0 else {
+                throw _NSErrorWithErrno(errno, reading: false, path: path)
             }
-        }
-
-        if let error = errnoValue {
-            throw _NSErrorWithErrno(error, reading: false, path: path)
         }
     }
 

--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -402,20 +402,16 @@ open class FileManager : NSObject {
                 
                 case .modificationDate: fallthrough
                 case ._accessDate:
-                    #if os(Windows)
-                        // Setting this attribute is unsupported on these platforms.
-                        throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileWriteUnknown.rawValue)
-                    #else
-                        guard let providedDate = attributeValues[attribute] as? Date else {
-                            fatalError("Can't set \(attribute) to \(attributeValues[attribute] as Any?)")
-                        }
-                    
+                    guard let providedDate = attributeValues[attribute] as? Date else {
+                        fatalError("Can't set \(attribute) to \(attributeValues[attribute] as Any?)")
+                    }
+
                     if attribute == .modificationDate {
                         newModificationDate = providedDate
                     } else if attribute == ._accessDate {
                         newAccessDate = providedDate
                     }
-                    #endif
+
                 case .immutable: fallthrough
                 case ._userImmutable:
                     prepareToSetOrUnsetFlag(UF_IMMUTABLE)

--- a/Tests/Foundation/Tests/TestFileManager.swift
+++ b/Tests/Foundation/Tests/TestFileManager.swift
@@ -408,15 +408,11 @@ class TestFileManager : XCTestCase {
         try? fm.removeItem(atPath: path)
         XCTAssertTrue(fm.createFile(atPath: path, contents: Data(), attributes: nil))
 
-#if !os(Windows)
         let modificationDate = NSDate(timeIntervalSince1970: 1234567890.5) // 2009-02-13T23:31:30.500Z
-#endif
-        
+
         do {
             try fm.setAttributes([.posixPermissions : NSNumber(value: Int16(0o0600))], ofItemAtPath: path)
-#if !os(Windows)
             try fm.setAttributes([.modificationDate: modificationDate], ofItemAtPath: path)
-#endif
         }
         catch { XCTFail("\(error)") }
         
@@ -427,8 +423,8 @@ class TestFileManager : XCTestCase {
             XCTAssert((attributes[.posixPermissions] as? NSNumber)?.int16Value == 0o0700)
 #else
             XCTAssert((attributes[.posixPermissions] as? NSNumber)?.int16Value == 0o0600)
-            XCTAssertEqual((attributes[.modificationDate] as? NSDate)?.timeIntervalSince1970 ?? .nan, modificationDate.timeIntervalSince1970, accuracy: 1.0)
 #endif
+            XCTAssertEqual((attributes[.modificationDate] as? NSDate)?.timeIntervalSince1970 ?? .nan, modificationDate.timeIntervalSince1970, accuracy: 1.0)
         }
         catch { XCTFail("\(error)") }
 


### PR DESCRIPTION
The `_updateTimes` function is multiplying by `1.0e9` as if for nanoseconds, but it should be using `1.0e6` for microseconds.

The `timeval.tv_usec` value will be too large, hence the `EINVAL` errno on Raspberry Pi OS (SR-13300).