### PR TITLE
[FileManager] _attributesOfItem: use creationDate from the stat extension in NSURL

### DIFF
--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -544,14 +544,7 @@ open class FileManager : NSObject {
         result[.creationDate] = creationDate
 #else
         let s = try _lstatFile(atPath: path)
-        // Darwin provides a `st_ctimespec` rather than the traditional Unix
-        // `st_ctime` field.  Since `st_ctime` is more traditional, special case
-        // Darwin platforms and convert the timespec to the absolute time.
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-        result[.creationDate] = Date(timespec: s.st_ctimespec)
-#else
-        result[.creationDate] = Date(timeIntervalSince1970: TimeInterval(s.st_ctime))
-#endif
+        result[.creationDate] = s.creationDate
 #endif
 
         result[.size] = NSNumber(value: UInt64(s.st_size))


### PR DESCRIPTION
rather than [repeating that logic](https://github.com/apple/swift-corelibs-foundation/blob/0f06824e7f81393614201fc67d1d740a8f913df7/Sources/Foundation/NSURL.swift#L2109)

The last case in stat.creationDate also works for Android.

Note that it uses `st_birthtimespec` instead on Darwin, let me know if that makes a difference. @compnerd, this pull redoes #2884 because it didn't work on Android and to reuse the existing logic, let me know what you think.