### PR TITLE
Foundation: migrate to the new `CRT` module

### DIFF
--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -17,7 +17,7 @@ fileprivate let UF_HIDDEN: Int32 = 1
 
 @_implementationOnly import CoreFoundation
 #if os(Windows)
-import MSVCRT
+import CRT
 #endif
 
 #if os(Windows)

--- a/Sources/Foundation/NSError.swift
+++ b/Sources/Foundation/NSError.swift
@@ -14,8 +14,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
-#elseif canImport(MSVCRT)
-import MSVCRT
+#elseif canImport(CRT)
+import CRT
 #endif
 
 @_implementationOnly import CoreFoundation

--- a/Sources/Foundation/NSSwiftRuntime.swift
+++ b/Sources/Foundation/NSSwiftRuntime.swift
@@ -17,7 +17,7 @@
 #elseif os(Linux) || os(Android) || CYGWIN
 @_exported import Glibc
 #elseif os(Windows)
-@_exported import MSVCRT
+@_exported import CRT
 #endif
 
 @_exported import Dispatch

--- a/Sources/Tools/plutil/main.swift
+++ b/Sources/Tools/plutil/main.swift
@@ -12,9 +12,9 @@ import SwiftFoundation
 #elseif canImport(Glibc)
 import Foundation
 import Glibc
-#elseif canImport(MSVCRT)
+#elseif canImport(CRT)
 import Foundation
-import MSVCRT
+import CRT
 #endif
 
 func help() -> Int32 {

--- a/Tests/Foundation/HTTPServer.swift
+++ b/Tests/Foundation/HTTPServer.swift
@@ -14,8 +14,8 @@
 
 import Dispatch
 
-#if canImport(MSVCRT)
-    import MSVCRT
+#if canImport(CRT)
+    import CRT
     import WinSDK
 #elseif canImport(Darwin)
     import Darwin


### PR DESCRIPTION
The Windows environment calls the library `CRT`.  Additionally, this
enables the removal of the `visualc` module from the Swift SDK overlay
for Windows.