### PR TITLE
[Windows] `@available` unknown platform warnings

### DIFF
--- a/Sources/Foundation/Bundle.swift
+++ b/Sources/Foundation/Bundle.swift
@@ -1,10 +1,10 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
 @_implementationOnly import CoreFoundation
@@ -108,7 +108,7 @@ open class Bundle: NSObject {
     }
     
     #if os(Windows)
-    @available(Windows, deprecated, message: "Not yet implemented.")
+    @available(*, deprecated, message: "Not yet implemented")
     public init(for aClass: AnyClass) {
         NSUnimplemented()
     }

--- a/Sources/Foundation/FileHandle.swift
+++ b/Sources/Foundation/FileHandle.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016, 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -55,7 +55,7 @@ open class FileHandle : NSObject {
       return _handle
     }
 
-    @available(Windows, unavailable, message: "Cannot perform non-owning handle to fd conversion")
+    @available(*, unavailable, message: "Cannot perform non-owning handle to fd conversion")
     open var fileDescriptor: Int32 {
         NSUnsupported()
     }
@@ -943,11 +943,13 @@ extension FileHandle {
         acceptConnectionInBackgroundAndNotify(forModes: [.default])
     }
 
-    @available(Windows, unavailable, message: "A SOCKET cannot be treated as a fd")
-    open func acceptConnectionInBackgroundAndNotify(forModes modes: [RunLoop.Mode]?) {
 #if os(Windows)
+    @available(*, unavailable, message: "A SOCKET cannot be treated as a fd")
+    open func acceptConnectionInBackgroundAndNotify(forModes modes: [RunLoop.Mode]?) {
         NSUnsupported()
+    }
 #else
+    open func acceptConnectionInBackgroundAndNotify(forModes modes: [RunLoop.Mode]?) {
         let owner = monitor(forReading: true, resumed: false) { (handle, source) in
             var notification = Notification(name: .NSFileHandleConnectionAccepted, object: handle, userInfo: [:])
             let userInfo: [AnyHashable : Any]
@@ -975,8 +977,8 @@ extension FileHandle {
         privateAsyncVariablesLock.unlock()
         
         owner.resume()
-#endif
     }
+#endif
 
     open func waitForDataInBackgroundAndNotify() {
         waitForDataInBackgroundAndNotify(forModes: [.default])

--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -1102,12 +1102,12 @@ open class FileManager : NSObject {
     /// - Experiment: This is a draft API currently under consideration for official import into Foundation as a suitable alternative
     /// - Note: Since this API is under consideration it may be either removed or revised in the near future
     #if os(Windows)
-    @available(Windows, deprecated, message: "Not yet implemented")
+    @available(*, deprecated, message: "Not yet implemented")
     open func replaceItem(at originalItemURL: URL, withItemAt newItemURL: URL, backupItemName: String?, options: ItemReplacementOptions = []) throws -> URL? {
         NSUnimplemented()
     }
 
-    @available(Windows, deprecated, message: "Not yet implemented")
+    @available(*, deprecated, message: "Not yet implemented")
     public func replaceItemAt(_ originalItemURL: URL, withItemAt newItemURL: URL, backupItemName: String? = nil, options: ItemReplacementOptions = []) throws -> URL? {
         NSUnimplemented()
     }


### PR DESCRIPTION
Using `@available(Windows)` results in `warning: unknown platform 'Windows' for attribute 'available'`.

This pull request uses `@available(*)` within `#if os(Windows)` to avoid the warning.

Alternatively, support for `@available(Windows)` could be added (e.g. see apple/swift#31686 for OpenBSD).