### PR TITLE
[Windows] Restore original working directory in TestFileManager.test_windowsPaths

### DIFF
--- a/Tests/Foundation/Tests/TestFileManager.swift
+++ b/Tests/Foundation/Tests/TestFileManager.swift
@@ -1832,6 +1832,10 @@ VIDEOS=StopgapVideos
         } catch {
             XCTFail()
         }
+        let originalWorkingDirectory = fm.currentDirectoryPath
+        defer {
+            fm.changeCurrentDirectoryPath(originalWorkingDirectory)
+        }
         fm.changeCurrentDirectoryPath(tmpPath)
         func checkPath(path: String) throws {
             XCTAssertTrue(fm.createFile(atPath: path, contents: Data(), attributes: nil))


### PR DESCRIPTION
Staying inside the directory breaks cleanup on tear down. This is part 1 of 2 of FileManager tests cleanup improvements. Second part is not specific to Windows, so goes separately.