### PR TITLE
[Windows] Add trailing slash to NSTemporaryDirectory result

### DIFF
--- a/Tests/Foundation/Tests/TestFileManager.swift
+++ b/Tests/Foundation/Tests/TestFileManager.swift
@@ -24,6 +24,11 @@ class TestFileManager : XCTestCase {
     let pathSep = "/"
 #endif
 
+    func test_NSTemporaryDirectory() {
+        let tempDir = NSTemporaryDirectory()
+        XCTAssertTrue(validPathSeps.contains(where: { tempDir.hasSuffix(String($0)) }), "Temporary directory path must end with path separator")
+    }
+
     func test_createDirectory() {
         let fm = FileManager.default
         let path = NSTemporaryDirectory() + "testdir\(NSUUID().uuidString)"
@@ -1974,6 +1979,7 @@ VIDEOS=StopgapVideos
             /* ⚠️  */ ("test_replacement", testExpectedToFail(test_replacement,
             /* ⚠️  */     "<https://bugs.swift.org/browse/SR-10819> Re-enable Foundation test TestFileManager.test_replacement")),
             ("test_concurrentGetItemReplacementDirectory", test_concurrentGetItemReplacementDirectory),
+            ("test_NSTemporaryDirectory", test_NSTemporaryDirectory),
         ]
         
         #if !DEPLOYMENT_RUNTIME_OBJC && NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT && !os(Android)


### PR DESCRIPTION
NSTemporaryDirectory on Darwin returns path with trailing slash, and almost every test in TestFileManager counts on it.

Without slash tests are generating temporary paths like `C:\Users\user\AppData\Temptest_isReadableFile5004BFCF-4356-4000-8000-000000000000`, which is, obviously, out of Temp directory.

Non-Darwin and non-Windows platforms have already implemented similar workaround, so I just adapted existing solution for Windows.