### PR TITLE
Foundation: drop `acceptConnectionInBackgroundAndNotify` on Windows

### DIFF
--- a/Sources/Foundation/FileHandle.swift
+++ b/Sources/Foundation/FileHandle.swift
@@ -939,8 +939,13 @@ extension FileHandle {
         }
     }
     
+    @available(Windows, unavailable, message: "A SOCKET cannot be treated as a fd")
     open func acceptConnectionInBackgroundAndNotify() {
+#if os(Windows)
+        NSUnsupported()
+#else
         acceptConnectionInBackgroundAndNotify(forModes: [.default])
+#endif
     }
 
     @available(Windows, unavailable, message: "A SOCKET cannot be treated as a fd")


### PR DESCRIPTION
`acceptConnectionInBackgroundAndNotify(forModes:)` is already
unavailable on Windows.  This makes the helper functional also
unavailable on Windows as `SOCKET` is not a `FileHandle` on Windows.