### PR TITLE
Import the Foundation overlay codebase from the Swift repository

### DIFF
--- a/Darwin/Config/install-swiftmodules.sh
+++ b/Darwin/Config/install-swiftmodules.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+#===----------------------------------------------------------------------===//
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2020 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+#===----------------------------------------------------------------------===//
+
+set -e
+#set -xv
+
+# This only needs to run during installation, but that includes "installapi".
+[ "$ACTION" = "installapi" -o "$ACTION" = "install" ] || exit 0
+
+[ "$SKIP_INSTALL" != "YES" ] || exit 0
+[ "$SWIFT_INSTALL_MODULES" = "YES" ] || exit 0
+
+srcmodule="${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.swiftmodule"
+dstpath="${INSTALL_ROOT}/${INSTALL_PATH}/"
+
+if [ ! -d "$srcmodule" ]; then
+    echo "Cannot find Swift module at $srcmodule" >&2
+    exit 1
+fi
+
+mkdir -p "$dstpath"
+cp -r "$srcmodule" "$dstpath"

--- a/Darwin/Config/overlay-base.xcconfig
+++ b/Darwin/Config/overlay-base.xcconfig
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+// Base configuration for Swift overlays.
+
+EXECUTABLE_PREFIX = libswift
+SWIFT_OVERLAY_INSTALL_PATH=/usr/lib/swift
+STRIP_SWIFT_SYMBOLS = NO
+BUILD_LIBRARY_FOR_DISTRIBUTION = YES
+GENERATE_TEXT_BASED_STUBS = YES
+SWIFT_LINK_OBJC_RUNTIME = NO
+CLANG_LINK_OBJC_RUNTIME = NO
+
+// Enable InstallAPI.
+SUPPORTS_TEXT_BASED_API = YES
+
+// We need to run install-swiftmodules.sh during the installapi action.
+INSTALLHDRS_SCRIPT_PHASE = YES
+
+INSTALL_PATH=$(SWIFT_OVERLAY_INSTALL_PATH)
+
+OTHER_SWIFT_FLAGS = -module-link-name $(SWIFT_MODULE_LINK_NAME) -autolink-force-load -runtime-compatibility-version none
+SWIFT_MODULE_LINK_NAME = swift$(PRODUCT_NAME)
+SWIFT_ENABLE_INCREMENTAL_COMPILATION = NO // YES conflicts with -autolink-force-load
+
+// Custom build settings for install-swiftmodules.sh.
+SWIFT_INSTALL_MODULES = YES
+SWIFT_MODULE_INSTALL_PATH = $(INSTALL_PATH)
+
+// We need to generate swiftmodules for these architectures, so that they can be
+// imported in apps that are deployable on OS versions that support them.
+// However, we can only generate module files for these; we can't emit binaries.
+// (All imported definitions will be unavailable on these older OS versions.)
+SWIFT_MODULE_ONLY_IPHONEOS_DEPLOYMENT_TARGET = 10.3
+SWIFT_MODULE_ONLY_ARCHS_iphoneos = armv7 armv7s
+SWIFT_MODULE_ONLY_ARCHS_iphonesimulator = i386
+SWIFT_MODULE_ONLY_ARCHS = $(SWIFT_MODULE_ONLY_ARCHS_$(PLATFORM_NAME))

--- a/Darwin/Config/overlay-debug.xcconfig
+++ b/Darwin/Config/overlay-debug.xcconfig
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+#include "../Config/overlay-base.xcconfig"
+
+ONLY_ACTIVE_ARCH = YES
+ENABLE_TESTABILITY = YES
+GCC_OPTIMIZATION_LEVEL = 0
+SWIFT_OPTIMIZATION_LEVEL = -Onone
+DEBUG_INFORMATION_FORMAT = dwarf
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG
+GCC_PREPROCESSOR_DEFINITIONS = DEBUG=1 $(inherited)

--- a/Darwin/Config/overlay-release.xcconfig
+++ b/Darwin/Config/overlay-release.xcconfig
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+#include "../Config/overlay-base.xcconfig"
+
+ONLY_ACTIVE_ARCH = NO
+ENABLE_TESTABILITY = NO
+GCC_OPTIMIZATION_LEVEL = s
+SWIFT_OPTIMIZATION_LEVEL = -O
+DEBUG_INFORMATION_FORMAT = dwarf-with-dsym
+SWIFT_COMPILATION_MODE = wholemodule
+ENABLE_NS_ASSERTIONS = NO

--- a/Darwin/Config/overlay-shared.xcconfig
+++ b/Darwin/Config/overlay-shared.xcconfig
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+SWIFT_IS_OVERLAY = YES
+
+SWIFT_VERSION = 5.0
+SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator
+
+// TAPI needs to be told about the magic-symbols-for-install-name header.
+OTHER_TAPI_FLAGS = $(inherited) -extra-public-header $(SRCROOT)/$(PRODUCT_NAME)-swiftoverlay/magic-symbols-for-install-name.h
+
+// Pass the module link name to C/C++ files; this is needed to generate the
+// magic install name symbols for overlays that existed in Swift 5.0.
+GCC_PREPROCESSOR_DEFINITIONS = SWIFT_TARGET_LIBRARY_NAME=$(SWIFT_MODULE_LINK_NAME)
+
+// We need to generate swiftmodules for these architectures, so that they can be
+// imported in apps that are deployable on OS versions that support them.
+// However, we can only generate module files for these; we can't emit binaries.
+// (All imported definitions will be unavailable on these older OS versions.)
+SWIFT_MODULE_ONLY_IPHONEOS_DEPLOYMENT_TARGET = 10.3
+SWIFT_MODULE_ONLY_ARCHS_iphoneos = armv7 armv7s
+SWIFT_MODULE_ONLY_ARCHS_iphonesimulator = i386
+SWIFT_MODULE_ONLY_ARCHS = $(SWIFT_MODULE_ONLY_ARCHS_$(PLATFORM_NAME))
+
+// Custom settings specific for the Foundation overlay
+OTHER_SWIFT_FLAGS = $(inherited) -Xllvm -sil-inline-generics -Xllvm -sil-partial-specialization
+ALWAYS_SEARCH_USER_PATHS = NO
+CLANG_ENABLE_OBJC_ARC = NO

--- a/Darwin/Config/overlay-tests-shared.xcconfig
+++ b/Darwin/Config/overlay-tests-shared.xcconfig
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+SWIFT_VERSION = 5.0
+
+ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks @loader_path/../Frameworks
+
+PRODUCT_NAME = $(TARGET_NAME)
+INFOPLIST_FILE = $(PROJECT_DIR)/$(PRODUCT_NAME)/Info.plist
+
+// Can't emit a swift module interface with bridging headers
+SWIFT_EMIT_MODULE_INTERFACE = NO
+
+CLANG_LINK_OBJC_RUNTIME = YES
+SWIFT_LINK_OBJC_RUNTIME = YES
+CLANG_ENABLE_OBJC_ARC = YES
+
+ALWAYS_SEARCH_USER_PATHS = NO

--- a/Darwin/CoreFoundation-swiftoverlay-Tests/CoreFoundationTests.swift
+++ b/Darwin/CoreFoundation-swiftoverlay-Tests/CoreFoundationTests.swift
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import CoreFoundation
+
+class CoreFoundationTests: XCTestCase {
+    // There are no tests dedicated to the CoreFoundation overlay yet.
+}

--- a/Darwin/CoreFoundation-swiftoverlay-Tests/CoreFoundationTests.xcconfig
+++ b/Darwin/CoreFoundation-swiftoverlay-Tests/CoreFoundationTests.xcconfig
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "../Config/overlay-tests-shared.xcconfig"
+
+PRODUCT_BUNDLE_IDENTIFIER = org.swift.CoreFoundationTests

--- a/Darwin/CoreFoundation-swiftoverlay-Tests/Info.plist
+++ b/Darwin/CoreFoundation-swiftoverlay-Tests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Darwin/CoreFoundation-swiftoverlay/CoreFoundation.swift
+++ b/Darwin/CoreFoundation-swiftoverlay/CoreFoundation.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import CoreFoundation
+
+public protocol _CFObject: class, Hashable {}
+extension _CFObject {
+  public var hashValue: Int {
+    return Int(bitPattern: CFHash(self))
+  }
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(self.hashValue)
+  }
+  public static func ==(left: Self, right: Self) -> Bool {
+    return CFEqual(left, right)
+  }
+}

--- a/Darwin/CoreFoundation-swiftoverlay/CoreFoundation.xcconfig
+++ b/Darwin/CoreFoundation-swiftoverlay/CoreFoundation.xcconfig
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "../Config/overlay-shared.xcconfig"
+
+PRODUCT_NAME = CoreFoundation
+OTHER_LDFLAGS = $(inherited) -framework CoreFoundation
+
+// Use 0.0.0 as the version number for development builds.
+CURRENT_PROJECT_VERSION = 0.0.0
+DYLIB_CURRENT_VERSION = $(CURRENT_PROJECT_VERSION)
+MODULE_VERSION = $(CURRENT_PROJECT_VERSION)

--- a/Darwin/CoreFoundation-swiftoverlay/magic-symbols-for-install-name.c
+++ b/Darwin/CoreFoundation-swiftoverlay/magic-symbols-for-install-name.c
@@ -1,0 +1,13 @@
+//===--- magic-symbols-for-install-name.c - Magic linker directive symbols ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "magic-symbols-for-install-name.h"

--- a/Darwin/CoreFoundation-swiftoverlay/magic-symbols-for-install-name.h
+++ b/Darwin/CoreFoundation-swiftoverlay/magic-symbols-for-install-name.h
@@ -1,0 +1,100 @@
+//===--- magic-symbols-for-install-name.h - Magic linker directive symbols ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// A file containing magic symbols that instruct the linker to use a
+// different install name when targeting older OSes. This file gets
+// compiled into all of the libraries that are embedded for backward
+// deployment.
+//
+//===----------------------------------------------------------------------===//
+
+#if defined(__APPLE__) && defined(__MACH__)
+
+#include <Availability.h>
+#include <TargetConditionals.h>
+
+#ifndef SWIFT_TARGET_LIBRARY_NAME
+#error Please define SWIFT_TARGET_LIBRARY_NAME
+#endif
+
+#define SWIFT_RUNTIME_EXPORT __attribute__((__visibility__("default")))
+
+#define RPATH_INSTALL_NAME_DIRECTIVE_IMPL2(name, major, minor) \
+  SWIFT_RUNTIME_EXPORT const char install_name_ ## major ## _ ## minor \
+  __asm("$ld$install_name$os" #major "." #minor "$@rpath/lib" #name ".dylib"); \
+  const char install_name_ ## major ## _ ## minor = 0;
+
+#define RPATH_INSTALL_NAME_DIRECTIVE_IMPL(name, major, minor) \
+  RPATH_INSTALL_NAME_DIRECTIVE_IMPL2(name, major, minor)
+
+#define RPATH_INSTALL_NAME_DIRECTIVE(major, minor) \
+  RPATH_INSTALL_NAME_DIRECTIVE_IMPL(SWIFT_TARGET_LIBRARY_NAME, major, minor)
+
+
+// Check iOS last, because TARGET_OS_IPHONE includes both watchOS and macCatalyst.
+#if TARGET_OS_OSX
+  RPATH_INSTALL_NAME_DIRECTIVE(10,  9)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 10)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 11)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 12)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 13)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 14)
+#elif TARGET_OS_MACCATALYST
+  // Note: This only applies to zippered overlays.
+  RPATH_INSTALL_NAME_DIRECTIVE(10,  9)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 10)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 11)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 12)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 13)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 14)
+#elif TARGET_OS_WATCH
+  RPATH_INSTALL_NAME_DIRECTIVE( 2, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE( 2, 1)
+  RPATH_INSTALL_NAME_DIRECTIVE( 2, 2)
+  RPATH_INSTALL_NAME_DIRECTIVE( 3, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE( 3, 1)
+  RPATH_INSTALL_NAME_DIRECTIVE( 3, 2)
+  RPATH_INSTALL_NAME_DIRECTIVE( 4, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE( 4, 1)
+  RPATH_INSTALL_NAME_DIRECTIVE( 4, 2)
+  RPATH_INSTALL_NAME_DIRECTIVE( 4, 3)
+  RPATH_INSTALL_NAME_DIRECTIVE( 5, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE( 5, 1)
+#elif TARGET_OS_IPHONE
+  RPATH_INSTALL_NAME_DIRECTIVE( 7, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE( 7, 1)
+  RPATH_INSTALL_NAME_DIRECTIVE( 8, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE( 8, 1)
+  RPATH_INSTALL_NAME_DIRECTIVE( 8, 2)
+  RPATH_INSTALL_NAME_DIRECTIVE( 8, 3)
+  RPATH_INSTALL_NAME_DIRECTIVE( 8, 4)
+  RPATH_INSTALL_NAME_DIRECTIVE( 9, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE( 9, 1)
+  RPATH_INSTALL_NAME_DIRECTIVE( 9, 2)
+  RPATH_INSTALL_NAME_DIRECTIVE( 9, 3)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 1)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 2)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 3)
+  RPATH_INSTALL_NAME_DIRECTIVE(11, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE(11, 1)
+  RPATH_INSTALL_NAME_DIRECTIVE(11, 2)
+  RPATH_INSTALL_NAME_DIRECTIVE(11, 3)
+  RPATH_INSTALL_NAME_DIRECTIVE(11, 4)
+  RPATH_INSTALL_NAME_DIRECTIVE(12, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE(12, 1)
+
+#else
+  #error Unknown target.
+#endif
+
+#endif // defined(__APPLE__) && defined(__MACH__)

--- a/Darwin/Foundation-swiftoverlay-Tests/CodableTests.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/CodableTests.swift
@@ -1,0 +1,865 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import CoreGraphics
+import XCTest
+
+// MARK: - Helper Functions
+@available(macOS 10.11, iOS 9.0, watchOS 2.0, tvOS 9.0, *)
+func makePersonNameComponents(namePrefix: String? = nil,
+                              givenName: String? = nil,
+                              middleName: String? = nil,
+                              familyName: String? = nil,
+                              nameSuffix: String? = nil,
+                              nickname: String? = nil) -> PersonNameComponents {
+    var result = PersonNameComponents()
+    result.namePrefix = namePrefix
+    result.givenName = givenName
+    result.middleName = middleName
+    result.familyName = familyName
+    result.nameSuffix = nameSuffix
+    result.nickname = nickname
+    return result
+}
+
+func _debugDescription<T>(_ value: T) -> String {
+    if let debugDescribable = value as? CustomDebugStringConvertible {
+        return debugDescribable.debugDescription
+    } else if let describable = value as? CustomStringConvertible {
+        return describable.description
+    } else {
+        return "\(value)"
+    }
+}
+
+func performEncodeAndDecode<T : Codable>(of value: T, encode: (T) throws -> Data, decode: (T.Type, Data) throws -> T, lineNumber: Int) -> T {
+
+    let data: Data
+    do {
+        data = try encode(value)
+    } catch {
+        fatalError("\(#file):\(lineNumber): Unable to encode \(T.self) <\(_debugDescription(value))>: \(error)")
+    }
+
+    do {
+        return try decode(T.self, data)
+    } catch {
+        fatalError("\(#file):\(lineNumber): Unable to decode \(T.self) <\(_debugDescription(value))>: \(error)")
+    }
+}
+
+func expectRoundTripEquality<T : Codable>(of value: T, encode: (T) throws -> Data, decode: (T.Type, Data) throws -> T, lineNumber: Int) where T : Equatable {
+
+    let decoded = performEncodeAndDecode(of: value, encode: encode, decode: decode, lineNumber: lineNumber)
+
+    XCTAssertEqual(value, decoded, "\(#file):\(lineNumber): Decoded \(T.self) <\(_debugDescription(decoded))> not equal to original <\(_debugDescription(value))>")
+}
+
+func expectRoundTripEqualityThroughJSON<T : Codable>(for value: T, lineNumber: Int) where T : Equatable {
+    let inf = "INF", negInf = "-INF", nan = "NaN"
+    let encode = { (_ value: T) throws -> Data in
+        let encoder = JSONEncoder()
+        encoder.nonConformingFloatEncodingStrategy = .convertToString(positiveInfinity: inf,
+                                                                      negativeInfinity: negInf,
+                                                                      nan: nan)
+        return try encoder.encode(value)
+    }
+
+    let decode = { (_ type: T.Type, _ data: Data) throws -> T in
+        let decoder = JSONDecoder()
+        decoder.nonConformingFloatDecodingStrategy = .convertFromString(positiveInfinity: inf,
+                                                                        negativeInfinity: negInf,
+                                                                        nan: nan)
+        return try decoder.decode(type, from: data)
+    }
+
+    expectRoundTripEquality(of: value, encode: encode, decode: decode, lineNumber: lineNumber)
+}
+
+func expectRoundTripEqualityThroughPlist<T : Codable>(for value: T, lineNumber: Int) where T : Equatable {
+    let encode = { (_ value: T) throws -> Data in
+        return try PropertyListEncoder().encode(value)
+    }
+
+    let decode = { (_ type: T.Type,_ data: Data) throws -> T in
+        return try PropertyListDecoder().decode(type, from: data)
+    }
+
+    expectRoundTripEquality(of: value, encode: encode, decode: decode, lineNumber: lineNumber)
+}
+
+// MARK: - Helper Types
+// A wrapper around a UUID that will allow it to be encoded at the top level of an encoder.
+struct UUIDCodingWrapper : Codable, Equatable {
+    let value: UUID
+
+    init(_ value: UUID) {
+        self.value = value
+    }
+
+    static func ==(_ lhs: UUIDCodingWrapper, _ rhs: UUIDCodingWrapper) -> Bool {
+        return lhs.value == rhs.value
+    }
+}
+
+// MARK: - Tests
+class TestCodable : XCTestCase {
+    // MARK: - AffineTransform
+#if os(macOS)
+    lazy var affineTransformValues: [Int : AffineTransform] = [
+        #line : AffineTransform.identity,
+        #line : AffineTransform(),
+        #line : AffineTransform(translationByX: 2.0, byY: 2.0),
+        #line : AffineTransform(scale: 2.0),
+        #line : AffineTransform(rotationByDegrees: .pi / 2),
+
+        #line : AffineTransform(m11: 1.0, m12: 2.5, m21: 66.2, m22: 40.2, tX: -5.5, tY: 3.7),
+        #line : AffineTransform(m11: -55.66, m12: 22.7, m21: 1.5, m22: 0.0, tX: -22, tY: -33),
+        #line : AffineTransform(m11: 4.5, m12: 1.1, m21: 0.025, m22: 0.077, tX: -0.55, tY: 33.2),
+        #line : AffineTransform(m11: 7.0, m12: -2.3, m21: 6.7, m22: 0.25, tX: 0.556, tY: 0.99),
+        #line : AffineTransform(m11: 0.498, m12: -0.284, m21: -0.742, m22: 0.3248, tX: 12, tY: 44)
+    ]
+
+    func test_AffineTransform_JSON() {
+        for (testLine, transform) in affineTransformValues {
+            expectRoundTripEqualityThroughJSON(for: transform, lineNumber: testLine)
+        }
+    }
+
+    func test_AffineTransform_Plist() {
+        for (testLine, transform) in affineTransformValues {
+            expectRoundTripEqualityThroughPlist(for: transform, lineNumber: testLine)
+        }
+    }
+#endif
+
+    // MARK: - Calendar
+    lazy var calendarValues: [Int : Calendar] = [
+        #line : Calendar(identifier: .gregorian),
+        #line : Calendar(identifier: .buddhist),
+        #line : Calendar(identifier: .chinese),
+        #line : Calendar(identifier: .coptic),
+        #line : Calendar(identifier: .ethiopicAmeteMihret),
+        #line : Calendar(identifier: .ethiopicAmeteAlem),
+        #line : Calendar(identifier: .hebrew),
+        #line : Calendar(identifier: .iso8601),
+        #line : Calendar(identifier: .indian),
+        #line : Calendar(identifier: .islamic),
+        #line : Calendar(identifier: .islamicCivil),
+        #line : Calendar(identifier: .japanese),
+        #line : Calendar(identifier: .persian),
+        #line : Calendar(identifier: .republicOfChina),
+    ]
+
+    func test_Calendar_JSON() {
+        for (testLine, calendar) in calendarValues {
+            expectRoundTripEqualityThroughJSON(for: calendar, lineNumber: testLine)
+        }
+    }
+
+    func test_Calendar_Plist() {
+        for (testLine, calendar) in calendarValues {
+            expectRoundTripEqualityThroughPlist(for: calendar, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - CharacterSet
+    lazy var characterSetValues: [Int : CharacterSet] = [
+        #line : CharacterSet.controlCharacters,
+        #line : CharacterSet.whitespaces,
+        #line : CharacterSet.whitespacesAndNewlines,
+        #line : CharacterSet.decimalDigits,
+        #line : CharacterSet.letters,
+        #line : CharacterSet.lowercaseLetters,
+        #line : CharacterSet.uppercaseLetters,
+        #line : CharacterSet.nonBaseCharacters,
+        #line : CharacterSet.alphanumerics,
+        #line : CharacterSet.decomposables,
+        #line : CharacterSet.illegalCharacters,
+        #line : CharacterSet.punctuationCharacters,
+        #line : CharacterSet.capitalizedLetters,
+        #line : CharacterSet.symbols,
+        #line : CharacterSet.newlines
+    ]
+
+    func test_CharacterSet_JSON() {
+        for (testLine, characterSet) in characterSetValues {
+            expectRoundTripEqualityThroughJSON(for: characterSet, lineNumber: testLine)
+        }
+    }
+
+    func test_CharacterSet_Plist() {
+        for (testLine, characterSet) in characterSetValues {
+            expectRoundTripEqualityThroughPlist(for: characterSet, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - CGAffineTransform
+    lazy var cg_affineTransformValues: [Int : CGAffineTransform] = {
+        var values = [
+            #line : CGAffineTransform.identity,
+            #line : CGAffineTransform(),
+            #line : CGAffineTransform(translationX: 2.0, y: 2.0),
+            #line : CGAffineTransform(scaleX: 2.0, y: 2.0),
+            #line : CGAffineTransform(a: 1.0, b: 2.5, c: 66.2, d: 40.2, tx: -5.5, ty: 3.7),
+            #line : CGAffineTransform(a: -55.66, b: 22.7, c: 1.5, d: 0.0, tx: -22, ty: -33),
+            #line : CGAffineTransform(a: 4.5, b: 1.1, c: 0.025, d: 0.077, tx: -0.55, ty: 33.2),
+            #line : CGAffineTransform(a: 7.0, b: -2.3, c: 6.7, d: 0.25, tx: 0.556, ty: 0.99),
+            #line : CGAffineTransform(a: 0.498, b: -0.284, c: -0.742, d: 0.3248, tx: 12, ty: 44)
+        ]
+
+        if #available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
+            values[#line] = CGAffineTransform(rotationAngle: .pi / 2)
+        }
+
+        return values
+    }()
+
+    func test_CGAffineTransform_JSON() {
+        for (testLine, transform) in cg_affineTransformValues {
+            expectRoundTripEqualityThroughJSON(for: transform, lineNumber: testLine)
+        }
+    }
+
+    func test_CGAffineTransform_Plist() {
+        for (testLine, transform) in cg_affineTransformValues {
+            expectRoundTripEqualityThroughPlist(for: transform, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - CGPoint
+    lazy var cg_pointValues: [Int : CGPoint] = {
+        var values = [
+            #line : CGPoint.zero,
+            #line : CGPoint(x: 10, y: 20)
+        ]
+
+        if #available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
+            // Limit on magnitude in JSON. See rdar://problem/12717407
+            values[#line] = CGPoint(x: CGFloat.greatestFiniteMagnitude,
+                                    y: CGFloat.greatestFiniteMagnitude)
+        }
+
+        return values
+    }()
+
+    func test_CGPoint_JSON() {
+        for (testLine, point) in cg_pointValues {
+            expectRoundTripEqualityThroughJSON(for: point, lineNumber: testLine)
+        }
+    }
+
+    func test_CGPoint_Plist() {
+        for (testLine, point) in cg_pointValues {
+            expectRoundTripEqualityThroughPlist(for: point, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - CGSize
+    lazy var cg_sizeValues: [Int : CGSize] = {
+        var values = [
+            #line : CGSize.zero,
+            #line : CGSize(width: 30, height: 40)
+        ]
+
+        if #available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
+            // Limit on magnitude in JSON. See rdar://problem/12717407
+            values[#line] = CGSize(width: CGFloat.greatestFiniteMagnitude,
+                                   height: CGFloat.greatestFiniteMagnitude)
+        }
+
+        return values
+    }()
+
+    func test_CGSize_JSON() {
+        for (testLine, size) in cg_sizeValues {
+            expectRoundTripEqualityThroughJSON(for: size, lineNumber: testLine)
+        }
+    }
+
+    func test_CGSize_Plist() {
+        for (testLine, size) in cg_sizeValues {
+            expectRoundTripEqualityThroughPlist(for: size, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - CGRect
+    lazy var cg_rectValues: [Int : CGRect] = {
+        var values = [
+            #line : CGRect.zero,
+            #line : CGRect.null,
+            #line : CGRect(x: 10, y: 20, width: 30, height: 40)
+        ]
+
+        if #available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
+            // Limit on magnitude in JSON. See rdar://problem/12717407
+            values[#line] = CGRect.infinite
+        }
+
+        return values
+    }()
+
+    func test_CGRect_JSON() {
+        for (testLine, rect) in cg_rectValues {
+            expectRoundTripEqualityThroughJSON(for: rect, lineNumber: testLine)
+        }
+    }
+
+    func test_CGRect_Plist() {
+        for (testLine, rect) in cg_rectValues {
+            expectRoundTripEqualityThroughPlist(for: rect, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - CGVector
+    lazy var cg_vectorValues: [Int : CGVector] = {
+        var values = [
+            #line : CGVector.zero,
+            #line : CGVector(dx: 0.0, dy: -9.81)
+        ]
+
+        if #available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
+            // Limit on magnitude in JSON. See rdar://problem/12717407
+            values[#line] = CGVector(dx: CGFloat.greatestFiniteMagnitude,
+                                     dy: CGFloat.greatestFiniteMagnitude)
+        }
+
+        return values
+    }()
+
+    func test_CGVector_JSON() {
+        for (testLine, vector) in cg_vectorValues {
+            expectRoundTripEqualityThroughJSON(for: vector, lineNumber: testLine)
+        }
+    }
+
+    func test_CGVector_Plist() {
+        for (testLine, vector) in cg_vectorValues {
+            expectRoundTripEqualityThroughPlist(for: vector, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - ClosedRange
+    func test_ClosedRange_JSON() {
+        // NSJSONSerialization used to produce NSDecimalNumber values with different ranges, making Int.max as a bound lossy.
+        if #available(macOS 10.10, iOS 8.0, tvOS 9.0, watchOS 2.0, *) {
+            let value = 0...Int.max
+            let decoded = performEncodeAndDecode(of: value, encode: { try JSONEncoder().encode($0) }, decode: { try JSONDecoder().decode($0, from: $1)  }, lineNumber: #line)
+            XCTAssertEqual(value.upperBound, decoded.upperBound, "\(#file):\(#line): Decoded ClosedRange upperBound <\(_debugDescription(decoded))> not equal to original <\(_debugDescription(value))>")
+            XCTAssertEqual(value.lowerBound, decoded.lowerBound, "\(#file):\(#line): Decoded ClosedRange lowerBound <\(_debugDescription(decoded))> not equal to original <\(_debugDescription(value))>")
+        }
+    }
+
+    func test_ClosedRange_Plist() {
+        let value = 0...Int.max
+        let decoded = performEncodeAndDecode(of: value, encode: { try PropertyListEncoder().encode($0) }, decode: { try PropertyListDecoder().decode($0, from: $1)  }, lineNumber: #line)
+        XCTAssertEqual(value.upperBound, decoded.upperBound, "\(#file):\(#line): Decoded ClosedRange upperBound <\(_debugDescription(decoded))> not equal to original <\(_debugDescription(value))>")
+        XCTAssertEqual(value.lowerBound, decoded.lowerBound, "\(#file):\(#line): Decoded ClosedRange lowerBound <\(_debugDescription(decoded))> not equal to original <\(_debugDescription(value))>")
+    }
+
+    // MARK: - ContiguousArray
+    lazy var contiguousArrayValues: [Int : ContiguousArray<String>] = [
+        #line : [],
+        #line : ["foo"],
+        #line : ["foo", "bar"],
+        #line : ["foo", "bar", "baz"],
+    ]
+
+    func test_ContiguousArray_JSON() {
+        for (testLine, contiguousArray) in contiguousArrayValues {
+            expectRoundTripEqualityThroughJSON(for: contiguousArray, lineNumber: testLine)
+        }
+    }
+
+    func test_ContiguousArray_Plist() {
+        for (testLine, contiguousArray) in contiguousArrayValues {
+            expectRoundTripEqualityThroughPlist(for: contiguousArray, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - DateComponents
+    lazy var dateComponents: Set<Calendar.Component> = [
+        .era, .year, .month, .day, .hour, .minute, .second, .nanosecond,
+        .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear,
+        .yearForWeekOfYear, .timeZone, .calendar
+    ]
+
+    func test_DateComponents_JSON() {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = calendar.dateComponents(dateComponents, from: Date())
+        expectRoundTripEqualityThroughJSON(for: components, lineNumber: #line - 1)
+    }
+
+    func test_DateComponents_Plist() {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = calendar.dateComponents(dateComponents, from: Date())
+        expectRoundTripEqualityThroughPlist(for: components, lineNumber: #line - 1)
+    }
+
+    // MARK: - DateInterval
+    @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+    lazy var dateIntervalValues: [Int : DateInterval] = [
+        #line : DateInterval(),
+        #line : DateInterval(start: Date.distantPast, end: Date()),
+        #line : DateInterval(start: Date(), end: Date.distantFuture),
+        #line : DateInterval(start: Date.distantPast, end: Date.distantFuture)
+    ]
+
+    @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+    func test_DateInterval_JSON() {
+        for (testLine, interval) in dateIntervalValues {
+            expectRoundTripEqualityThroughJSON(for: interval, lineNumber: testLine)
+        }
+    }
+
+    @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+    func test_DateInterval_Plist() {
+        for (testLine, interval) in dateIntervalValues {
+            expectRoundTripEqualityThroughPlist(for: interval, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - Decimal
+    lazy var decimalValues: [Int : Decimal] = [
+        #line : Decimal.leastFiniteMagnitude,
+        #line : Decimal.greatestFiniteMagnitude,
+        #line : Decimal.leastNormalMagnitude,
+        #line : Decimal.leastNonzeroMagnitude,
+        #line : Decimal(),
+
+        // See 33996620 for re-enabling this test.
+        // #line : Decimal.pi,
+    ]
+
+    func test_Decimal_JSON() {
+        for (testLine, decimal) in decimalValues {
+            // Decimal encodes as a number in JSON and cannot be encoded at the top level.
+            expectRoundTripEqualityThroughJSON(for: TopLevelWrapper(decimal), lineNumber: testLine)
+        }
+    }
+
+    func test_Decimal_Plist() {
+        for (testLine, decimal) in decimalValues {
+            expectRoundTripEqualityThroughPlist(for: decimal, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - IndexPath
+    lazy var indexPathValues: [Int : IndexPath] = [
+        #line : IndexPath(), // empty
+        #line : IndexPath(index: 0), // single
+        #line : IndexPath(indexes: [1, 2]), // pair
+        #line : IndexPath(indexes: [3, 4, 5, 6, 7, 8]), // array
+    ]
+
+    func test_IndexPath_JSON() {
+        for (testLine, indexPath) in indexPathValues {
+            expectRoundTripEqualityThroughJSON(for: indexPath, lineNumber: testLine)
+        }
+    }
+
+    func test_IndexPath_Plist() {
+        for (testLine, indexPath) in indexPathValues {
+            expectRoundTripEqualityThroughPlist(for: indexPath, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - IndexSet
+    lazy var indexSetValues: [Int : IndexSet] = [
+        #line : IndexSet(),
+        #line : IndexSet(integer: 42),
+    ]
+    lazy var indexSetMaxValues: [Int : IndexSet] = [
+        #line : IndexSet(integersIn: 0 ..< Int.max)
+    ]
+
+    func test_IndexSet_JSON() {
+        for (testLine, indexSet) in indexSetValues {
+            expectRoundTripEqualityThroughJSON(for: indexSet, lineNumber: testLine)
+        }
+        if #available(macOS 10.10, iOS 8, *) {
+            // Mac OS X 10.9 and iOS 7 weren't able to round-trip Int.max in JSON.
+            for (testLine, indexSet) in indexSetMaxValues {
+                expectRoundTripEqualityThroughJSON(for: indexSet, lineNumber: testLine)
+            }
+        }
+    }
+
+    func test_IndexSet_Plist() {
+        for (testLine, indexSet) in indexSetValues {
+            expectRoundTripEqualityThroughPlist(for: indexSet, lineNumber: testLine)
+        }
+        for (testLine, indexSet) in indexSetMaxValues {
+            expectRoundTripEqualityThroughPlist(for: indexSet, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - Locale
+    lazy var localeValues: [Int : Locale] = [
+        #line : Locale(identifier: ""),
+        #line : Locale(identifier: "en"),
+        #line : Locale(identifier: "en_US"),
+        #line : Locale(identifier: "en_US_POSIX"),
+        #line : Locale(identifier: "uk"),
+        #line : Locale(identifier: "fr_FR"),
+        #line : Locale(identifier: "fr_BE"),
+        #line : Locale(identifier: "zh-Hant-HK")
+    ]
+
+    func test_Locale_JSON() {
+        for (testLine, locale) in localeValues {
+            expectRoundTripEqualityThroughJSON(for: locale, lineNumber: testLine)
+        }
+    }
+
+    func test_Locale_Plist() {
+        for (testLine, locale) in localeValues {
+            expectRoundTripEqualityThroughPlist(for: locale, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - Measurement
+    @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+    lazy var unitValues: [Int : Dimension] = [
+        #line : UnitAcceleration.metersPerSecondSquared,
+        #line : UnitMass.kilograms,
+        #line : UnitLength.miles
+    ]
+
+    #if false // FIXME: This test is broken; it was commented out in the original StdlibUnittest setup.
+    // (The problem is that it uses encodes/decodes through `Measurement<Dimension>` which should not be a thing.)
+    @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+    func test_Measurement_JSON() {
+        for (testLine, unit) in unitValues {
+            expectRoundTripEqualityThroughJSON(for: Measurement(value: 42, unit: unit), lineNumber: testLine)
+        }
+    }
+
+    @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+    func test_Measurement_Plist() {
+        for (testLine, unit) in unitValues {
+            expectRoundTripEqualityThroughJSON(for: Measurement(value: 42, unit: unit), lineNumber: testLine)
+        }
+    }
+    #endif
+
+    // MARK: - NSRange
+    lazy var nsrangeValues: [Int : NSRange] = [
+        #line : NSRange(),
+        #line : NSRange(location: 5, length: 20),
+    ]
+    lazy var nsrangeMaxValues: [Int : NSRange] = [
+        #line : NSRange(location: 0, length: Int.max),
+        #line : NSRange(location: NSNotFound, length: 0),
+    ]
+
+    func test_NSRange_JSON() {
+        for (testLine, range) in nsrangeValues {
+            expectRoundTripEqualityThroughJSON(for: range, lineNumber: testLine)
+        }
+        if #available(macOS 10.10, iOS 8, *) {
+            // Mac OS X 10.9 and iOS 7 weren't able to round-trip Int.max in JSON.
+            for (testLine, range) in nsrangeMaxValues {
+                expectRoundTripEqualityThroughJSON(for: range, lineNumber: testLine)
+            }
+        }
+    }
+
+    func test_NSRange_Plist() {
+        for (testLine, range) in nsrangeValues {
+            expectRoundTripEqualityThroughPlist(for: range, lineNumber: testLine)
+        }
+        for (testLine, range) in nsrangeMaxValues {
+            expectRoundTripEqualityThroughPlist(for: range, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - PartialRangeFrom
+    func test_PartialRangeFrom_JSON() {
+        let value = 0...
+        let decoded = performEncodeAndDecode(of: value, encode: { try JSONEncoder().encode($0) }, decode: { try JSONDecoder().decode($0, from: $1)  }, lineNumber: #line)
+        XCTAssertEqual(value.lowerBound, decoded.lowerBound, "\(#file):\(#line): Decoded PartialRangeFrom <\(_debugDescription(decoded))> not equal to original <\(_debugDescription(value))>")
+    }
+
+    func test_PartialRangeFrom_Plist() {
+        let value = 0...
+        let decoded = performEncodeAndDecode(of: value, encode: { try PropertyListEncoder().encode($0) }, decode: { try PropertyListDecoder().decode($0, from: $1)  }, lineNumber: #line)
+        XCTAssertEqual(value.lowerBound, decoded.lowerBound, "\(#file):\(#line): Decoded PartialRangeFrom <\(_debugDescription(decoded))> not equal to original <\(_debugDescription(value))>")
+    }
+
+    // MARK: - PartialRangeThrough
+    func test_PartialRangeThrough_JSON() {
+        // NSJSONSerialization used to produce NSDecimalNumber values with different ranges, making Int.max as a bound lossy.
+        if #available(macOS 10.10, iOS 8.0, tvOS 9.0, watchOS 2.0, *) {
+
+            let value = ...Int.max
+            let decoded = performEncodeAndDecode(of: value, encode: { try JSONEncoder().encode($0) }, decode: { try JSONDecoder().decode($0, from: $1)  }, lineNumber: #line)
+            XCTAssertEqual(value.upperBound, decoded.upperBound, "\(#file):\(#line): Decoded PartialRangeThrough <\(_debugDescription(decoded))> not equal to original <\(_debugDescription(value))>")
+        }
+    }
+
+    func test_PartialRangeThrough_Plist() {
+        let value = ...Int.max
+        let decoded = performEncodeAndDecode(of: value, encode: { try PropertyListEncoder().encode($0) }, decode: { try PropertyListDecoder().decode($0, from: $1)  }, lineNumber: #line)
+        XCTAssertEqual(value.upperBound, decoded.upperBound, "\(#file):\(#line): Decoded PartialRangeThrough <\(_debugDescription(decoded))> not equal to original <\(_debugDescription(value))>")
+    }
+
+    // MARK: - PartialRangeUpTo
+    func test_PartialRangeUpTo_JSON() {
+        // NSJSONSerialization used to produce NSDecimalNumber values with different ranges, making Int.max as a bound lossy.
+        if #available(macOS 10.10, iOS 8.0, tvOS 9.0, watchOS 2.0, *) {
+
+            let value = ..<Int.max
+            let decoded = performEncodeAndDecode(of: value, encode: { try JSONEncoder().encode($0) }, decode: { try JSONDecoder().decode($0, from: $1)  }, lineNumber: #line)
+            XCTAssertEqual(value.upperBound, decoded.upperBound, "\(#file):\(#line): Decoded PartialRangeUpTo <\(_debugDescription(decoded))> not equal to original <\(_debugDescription(value))>")
+        }
+    }
+
+    func test_PartialRangeUpTo_Plist() {
+        let value = ..<Int.max
+        let decoded = performEncodeAndDecode(of: value, encode: { try PropertyListEncoder().encode($0) }, decode: { try PropertyListDecoder().decode($0, from: $1)  }, lineNumber: #line)
+        XCTAssertEqual(value.upperBound, decoded.upperBound, "\(#file):\(#line): Decoded PartialRangeUpTo <\(_debugDescription(decoded))> not equal to original <\(_debugDescription(value))>")
+    }
+
+    // MARK: - PersonNameComponents
+    @available(macOS 10.11, iOS 9.0, watchOS 2.0, tvOS 9.0, *)
+    lazy var personNameComponentsValues: [Int : PersonNameComponents] = [
+        #line : makePersonNameComponents(givenName: "John", familyName: "Appleseed"),
+        #line : makePersonNameComponents(givenName: "John", familyName: "Appleseed", nickname: "Johnny"),
+        #line : makePersonNameComponents(namePrefix: "Dr.", givenName: "Jane", middleName: "A.", familyName: "Appleseed", nameSuffix: "Esq.", nickname: "Janie")
+    ]
+
+    @available(macOS 10.11, iOS 9.0, watchOS 2.0, tvOS 9.0, *)
+    func test_PersonNameComponents_JSON() {
+        for (testLine, components) in personNameComponentsValues {
+            expectRoundTripEqualityThroughJSON(for: components, lineNumber: testLine)
+        }
+    }
+
+    @available(macOS 10.11, iOS 9.0, watchOS 2.0, tvOS 9.0, *)
+    func test_PersonNameComponents_Plist() {
+        for (testLine, components) in personNameComponentsValues {
+            expectRoundTripEqualityThroughPlist(for: components, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - Range
+    func test_Range_JSON() {
+        // NSJSONSerialization used to produce NSDecimalNumber values with different ranges, making Int.max as a bound lossy.
+        if #available(macOS 10.10, iOS 8.0, tvOS 9.0, watchOS 2.0, *) {
+            let value = 0..<Int.max
+            let decoded = performEncodeAndDecode(of: value, encode: { try JSONEncoder().encode($0) }, decode: { try JSONDecoder().decode($0, from: $1)  }, lineNumber: #line)
+            XCTAssertEqual(value.upperBound, decoded.upperBound, "\(#file):\(#line): Decoded Range upperBound <\(_debugDescription(decoded))> not equal to original <\(_debugDescription(value))>")
+            XCTAssertEqual(value.lowerBound, decoded.lowerBound, "\(#file):\(#line): Decoded Range lowerBound<\(_debugDescription(decoded))> not equal to original <\(_debugDescription(value))>")
+        }
+    }
+
+    func test_Range_Plist() {
+        let value = 0..<Int.max
+        let decoded = performEncodeAndDecode(of: value, encode: { try PropertyListEncoder().encode($0) }, decode: { try PropertyListDecoder().decode($0, from: $1)  }, lineNumber: #line)
+        XCTAssertEqual(value.upperBound, decoded.upperBound, "\(#file):\(#line): Decoded Range upperBound<\(_debugDescription(decoded))> not equal to original <\(_debugDescription(value))>")
+        XCTAssertEqual(value.lowerBound, decoded.lowerBound, "\(#file):\(#line): Decoded Range lowerBound<\(_debugDescription(decoded))> not equal to original <\(_debugDescription(value))>")
+    }
+
+    // MARK: - TimeZone
+    lazy var timeZoneValues: [Int : TimeZone] = [
+        #line : TimeZone(identifier: "America/Los_Angeles")!,
+        #line : TimeZone(identifier: "UTC")!,
+        #line : TimeZone.current
+    ]
+
+    func test_TimeZone_JSON() {
+        for (testLine, timeZone) in timeZoneValues {
+            expectRoundTripEqualityThroughJSON(for: timeZone, lineNumber: testLine)
+        }
+    }
+
+    func test_TimeZone_Plist() {
+        for (testLine, timeZone) in timeZoneValues {
+            expectRoundTripEqualityThroughPlist(for: timeZone, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - URL
+    lazy var urlValues: [Int : URL] = {
+        var values: [Int : URL] = [
+            #line : URL(fileURLWithPath: NSTemporaryDirectory()),
+            #line : URL(fileURLWithPath: "/"),
+            #line : URL(string: "http://swift.org")!,
+            #line : URL(string: "documentation", relativeTo: URL(string: "http://swift.org")!)!
+        ]
+
+        if #available(macOS 10.11, iOS 9.0, watchOS 2.0, tvOS 9.0, *) {
+            values[#line] = URL(fileURLWithPath: "bin/sh", relativeTo: URL(fileURLWithPath: "/"))
+        }
+
+        return values
+    }()
+
+    func test_URL_JSON() {
+        for (testLine, url) in urlValues {
+            // URLs encode as single strings in JSON. They lose their baseURL this way.
+            // For relative URLs, we don't expect them to be equal to the original.
+            if url.baseURL == nil {
+                // This is an absolute URL; we can expect equality.
+                expectRoundTripEqualityThroughJSON(for: TopLevelWrapper(url), lineNumber: testLine)
+            } else {
+                // This is a relative URL. Make it absolute first.
+                let absoluteURL = URL(string: url.absoluteString)!
+                expectRoundTripEqualityThroughJSON(for: TopLevelWrapper(absoluteURL), lineNumber: testLine)
+            }
+        }
+    }
+
+    func test_URL_Plist() {
+        for (testLine, url) in urlValues {
+            expectRoundTripEqualityThroughPlist(for: url, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - URLComponents
+    lazy var urlComponentsValues: [Int : URLComponents] = [
+        #line : URLComponents(),
+
+        #line : URLComponents(string: "http://swift.org")!,
+        #line : URLComponents(string: "http://swift.org:80")!,
+        #line : URLComponents(string: "https://www.mywebsite.org/api/v42/something.php#param1=hi&param2=hello")!,
+        #line : URLComponents(string: "ftp://johnny:apples@myftpserver.org:4242/some/path")!,
+
+        #line : URLComponents(url: URL(string: "http://swift.org")!, resolvingAgainstBaseURL: false)!,
+        #line : URLComponents(url: URL(string: "http://swift.org:80")!, resolvingAgainstBaseURL: false)!,
+        #line : URLComponents(url: URL(string: "https://www.mywebsite.org/api/v42/something.php#param1=hi&param2=hello")!, resolvingAgainstBaseURL: false)!,
+        #line : URLComponents(url: URL(string: "ftp://johnny:apples@myftpserver.org:4242/some/path")!, resolvingAgainstBaseURL: false)!,
+        #line : URLComponents(url: URL(fileURLWithPath: NSTemporaryDirectory()), resolvingAgainstBaseURL: false)!,
+        #line : URLComponents(url: URL(fileURLWithPath: "/"), resolvingAgainstBaseURL: false)!,
+        #line : URLComponents(url: URL(string: "documentation", relativeTo: URL(string: "http://swift.org")!)!, resolvingAgainstBaseURL: false)!,
+
+        #line : URLComponents(url: URL(string: "http://swift.org")!, resolvingAgainstBaseURL: true)!,
+        #line : URLComponents(url: URL(string: "http://swift.org:80")!, resolvingAgainstBaseURL: true)!,
+        #line : URLComponents(url: URL(string: "https://www.mywebsite.org/api/v42/something.php#param1=hi&param2=hello")!, resolvingAgainstBaseURL: true)!,
+        #line : URLComponents(url: URL(string: "ftp://johnny:apples@myftpserver.org:4242/some/path")!, resolvingAgainstBaseURL: true)!,
+        #line : URLComponents(url: URL(fileURLWithPath: NSTemporaryDirectory()), resolvingAgainstBaseURL: true)!,
+        #line : URLComponents(url: URL(fileURLWithPath: "/"), resolvingAgainstBaseURL: true)!,
+        #line : URLComponents(url: URL(string: "documentation", relativeTo: URL(string: "http://swift.org")!)!, resolvingAgainstBaseURL: true)!,
+
+        #line : {
+            var components = URLComponents()
+            components.scheme = "https"
+            return components
+        }(),
+
+        #line : {
+            var components = URLComponents()
+            components.user = "johnny"
+            return components
+        }(),
+
+        #line : {
+            var components = URLComponents()
+            components.password = "apples"
+            return components
+        }(),
+
+        #line : {
+            var components = URLComponents()
+            components.host = "0.0.0.0"
+            return components
+        }(),
+
+        #line : {
+            var components = URLComponents()
+            components.port = 8080
+            return components
+        }(),
+
+        #line : {
+            var components = URLComponents()
+            components.path = ".."
+            return components
+        }(),
+
+        #line : {
+            var components = URLComponents()
+            components.query = "param1=hi&param2=there"
+            return components
+        }(),
+
+        #line : {
+            var components = URLComponents()
+            components.fragment = "anchor"
+            return components
+        }(),
+
+        #line : {
+            var components = URLComponents()
+            components.scheme = "ftp"
+            components.user = "johnny"
+            components.password = "apples"
+            components.host = "0.0.0.0"
+            components.port = 4242
+            components.path = "/some/file"
+            components.query = "utf8=✅"
+            components.fragment = "anchor"
+            return components
+        }()
+    ]
+
+    func test_URLComponents_JSON() {
+        for (testLine, components) in urlComponentsValues {
+            expectRoundTripEqualityThroughJSON(for: components, lineNumber: testLine)
+        }
+    }
+
+    func test_URLComponents_Plist() {
+        for (testLine, components) in urlComponentsValues {
+            expectRoundTripEqualityThroughPlist(for: components, lineNumber: testLine)
+        }
+    }
+
+    // MARK: - UUID
+    lazy var uuidValues: [Int : UUID] = [
+        #line : UUID(),
+        #line : UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")!,
+        #line : UUID(uuidString: "e621e1f8-c36c-495a-93fc-0c247a3e6e5f")!,
+        #line : UUID(uuid: uuid_t(0xe6,0x21,0xe1,0xf8,0xc3,0x6c,0x49,0x5a,0x93,0xfc,0x0c,0x24,0x7a,0x3e,0x6e,0x5f))
+    ]
+
+    func test_UUID_JSON() {
+        for (testLine, uuid) in uuidValues {
+            // We have to wrap the UUID since we cannot have a top-level string.
+            expectRoundTripEqualityThroughJSON(for: UUIDCodingWrapper(uuid), lineNumber: testLine)
+        }
+    }
+
+    func test_UUID_Plist() {
+        for (testLine, uuid) in uuidValues {
+            // We have to wrap the UUID since we cannot have a top-level string.
+            expectRoundTripEqualityThroughPlist(for: UUIDCodingWrapper(uuid), lineNumber: testLine)
+        }
+    }
+}
+
+// MARK: - Helper Types
+
+private struct TopLevelWrapper<T> : Codable, Equatable where T : Codable, T : Equatable {
+    let value: T
+
+    init(_ value: T) {
+        self.value = value
+    }
+
+    static func ==(_ lhs: TopLevelWrapper<T>, _ rhs: TopLevelWrapper<T>) -> Bool {
+        return lhs.value == rhs.value
+    }
+}
+

--- a/Darwin/Foundation-swiftoverlay-Tests/FoundationBridge.h
+++ b/Darwin/Foundation-swiftoverlay-Tests/FoundationBridge.h
@@ -1,0 +1,97 @@
+//===--- FoundationBridge.h -------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, ObjectBehaviorAction) {
+    ObjectBehaviorActionRetain,
+    ObjectBehaviorActionCopy,
+    ObjectBehaviorActionMutableCopy
+};
+
+// NOTE: this class is NOT meant to be used in threaded contexts.
+@interface ObjectBehaviorVerifier : NSObject
+@property (readonly) BOOL wasRetained;
+@property (readonly) BOOL wasCopied;
+@property (readonly) BOOL wasMutableCopied;
+
+- (void)appendAction:(ObjectBehaviorAction)action;
+- (void)enumerate:(void (^)(ObjectBehaviorAction))block;
+- (void)reset;
+- (void)dump;
+@end
+
+#pragma mark - NSData verification
+
+@interface ImmutableDataVerifier : NSData {
+    ObjectBehaviorVerifier *_verifier;
+    NSData *_data;
+}
+@property (readonly) ObjectBehaviorVerifier *verifier;
+@end
+
+@interface MutableDataVerifier : NSMutableData {
+    ObjectBehaviorVerifier *_verifier;
+    NSMutableData *_data;
+}
+@property (readonly) ObjectBehaviorVerifier *verifier;
+@end
+
+void takesData(NSData *object);
+NSData *returnsData();
+BOOL identityOfData(NSData *data);
+
+#pragma mark - NSCalendar verification
+
+@interface CalendarBridgingTester : NSObject
+- (NSCalendar *)autoupdatingCurrentCalendar;
+- (BOOL)verifyAutoupdatingCalendar:(NSCalendar *)calendar;
+@end
+
+@interface TimeZoneBridgingTester : NSObject
+- (NSTimeZone *)autoupdatingCurrentTimeZone;
+- (BOOL)verifyAutoupdatingTimeZone:(NSTimeZone *)tz;
+@end
+
+@interface LocaleBridgingTester : NSObject
+- (NSLocale *)autoupdatingCurrentLocale;
+- (BOOL)verifyAutoupdatingLocale:(NSLocale *)locale;
+@end
+
+#pragma mark - NSNumber verification
+
+@interface NumberBridgingTester : NSObject
+- (BOOL)verifyKeysInRange:(NSRange)range existInDictionary:(NSDictionary *)dictionary;
+@end
+
+#pragma mark - NSString bridging
+
+static inline NSString *getNSStringEqualTestString() {
+  return [NSString stringWithUTF8String:"2166002315@874404110.1042078977"];
+}
+
+static inline BOOL NSStringBridgeTestEqual(NSString * _Nonnull a, NSString * _Nonnull b) {
+  return [a isEqual:b];
+}
+
+static inline NSString *getNSStringWithUnpairedSurrogate() {
+  unichar chars[16] = {
+    0x0020, 0x0020, 0x0020, 0x0020, 0x0020, 0x0020,
+    0x0020, 0x0020, 0x0020, 0x0020, 0x0020, 0x0020,
+    0x0020, 0x0020, 0x0020, 0x0020, 0x0020, 0x0020,
+    0xD800 };
+  return [NSString stringWithCharacters:chars length:1];
+}
+
+NS_ASSUME_NONNULL_END

--- a/Darwin/Foundation-swiftoverlay-Tests/FoundationBridge.m
+++ b/Darwin/Foundation-swiftoverlay-Tests/FoundationBridge.m
@@ -1,0 +1,279 @@
+//===--- FoundationBridge.m -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import "FoundationBridge.h"
+#import <objc/runtime.h>
+
+@implementation ObjectBehaviorVerifier {
+    NSMutableArray *_actions;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _actions = [[NSMutableArray alloc] init];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [_actions release];
+    [super dealloc];
+}
+
+- (void)appendAction:(ObjectBehaviorAction)action {
+    [_actions addObject:@(action)];
+    switch (action) {
+        case ObjectBehaviorActionRetain:
+            _wasRetained = YES;
+            break;
+        case ObjectBehaviorActionMutableCopy:
+            _wasMutableCopied = YES;
+            // fall through
+        case ObjectBehaviorActionCopy:
+            _wasCopied = YES;
+            break;
+    }
+}
+
+- (void)enumerate:(void (^)(ObjectBehaviorAction))block {
+    for (NSNumber *action in _actions) {
+        block((ObjectBehaviorAction)action.integerValue);
+    }
+}
+
+- (void)reset {
+    [_actions removeAllObjects];
+    _wasRetained = NO;
+    _wasMutableCopied = NO;
+    _wasCopied = NO;
+}
+
+- (void)dump {
+    [self enumerate:^(ObjectBehaviorAction action) {
+        switch (action) {
+            case ObjectBehaviorActionRetain:
+                printf("retain\n");
+                break;
+            case ObjectBehaviorActionMutableCopy:
+                printf("mutableCopy\n");
+                break;
+            case ObjectBehaviorActionCopy:
+                printf("copy\n");
+                break;
+        }
+    }];
+}
+
+@end
+
+
+@implementation ImmutableDataVerifier
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _verifier = [[ObjectBehaviorVerifier alloc] init];
+        char *bytes = "hello world";
+        _data = [[NSData alloc] initWithBytes:bytes length:strlen(bytes)];
+    }
+    return self;
+}
+
+- (instancetype)initWithData:(NSData *)data verifier:(ObjectBehaviorVerifier *)verifier {
+    self = [super init];
+    if (self) {
+        _verifier = [verifier retain];
+        _data = [data mutableCopyWithZone:nil];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [_verifier release];
+    [_data release];
+    [super dealloc];
+}
+
+- (id)retain {
+    [_verifier appendAction:ObjectBehaviorActionRetain];
+    return [super retain];
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    [_verifier appendAction:ObjectBehaviorActionCopy];
+    return [super retain];
+}
+
+- (id)mutableCopyWithZone:(NSZone *)zone {
+    [_verifier appendAction:ObjectBehaviorActionMutableCopy];
+    return [[MutableDataVerifier alloc] initWithData:_data verifier:_verifier];
+}
+
+- (NSUInteger)length {
+    return _data.length;
+}
+
+- (const void *)bytes {
+    return _data.bytes;
+}
+
+- (NSData *)subdataWithRange:(NSRange)range {
+    return [_data subdataWithRange:range];
+}
+
+@end
+
+@implementation MutableDataVerifier
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _verifier = [[ObjectBehaviorVerifier alloc] init];
+        char *bytes = "hello world";
+        _data = [[NSMutableData alloc] initWithBytes:bytes length:strlen(bytes)];
+    }
+    return self;
+}
+
+- (instancetype)initWithData:(NSData *)data verifier:(ObjectBehaviorVerifier *)verifier {
+    self = [super init];
+    if (self) {
+        _verifier = [verifier retain];
+        _data = [data mutableCopyWithZone:nil];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [_verifier release];
+    [_data release];
+    [super dealloc];
+}
+
+- (id)retain {
+    [_verifier appendAction:ObjectBehaviorActionRetain];
+    return [super retain];
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    [_verifier appendAction:ObjectBehaviorActionCopy];
+    return [[ImmutableDataVerifier alloc] initWithData:_data verifier:_verifier];
+}
+
+- (id)mutableCopyWithZone:(NSZone *)zone {
+    [_verifier appendAction:ObjectBehaviorActionMutableCopy];
+    return [[MutableDataVerifier alloc] initWithData:_data verifier:_verifier];
+}
+
+- (NSUInteger)length {
+    return _data.length;
+}
+
+- (void)setLength:(NSUInteger)length {
+    _data.length = length;
+}
+
+- (const void *)bytes {
+    return _data.bytes;
+}
+
+- (void *)mutableBytes {
+    return _data.mutableBytes;
+}
+
+- (void)appendBytes:(const void *)bytes length:(NSUInteger)length {
+    [_data appendBytes:bytes length:length];
+}
+
+- (NSData *)subdataWithRange:(NSRange)range {
+    return [_data subdataWithRange:range];
+}
+
+@end
+
+void takesData(NSData *object) {
+    // do NOTHING here...
+}
+
+NSData *returnsData() {
+    static dispatch_once_t once = 0L;
+    static NSData *data = nil;
+    dispatch_once(&once, ^{
+        char *bytes = "hello world";
+        data = [[NSData alloc] initWithBytes:bytes length:strlen(bytes)];
+    });
+    return data;
+}
+
+BOOL identityOfData(NSData *data) {
+    return data == returnsData();
+}
+
+
+@implementation CalendarBridgingTester
+
+- (NSCalendar *)autoupdatingCurrentCalendar {
+    return [NSCalendar autoupdatingCurrentCalendar];
+}
+
+- (BOOL)verifyAutoupdatingCalendar:(NSCalendar *)calendar {
+    Class autoCalendarClass = (Class)objc_lookUpClass("_NSAutoCalendar");
+    if (autoCalendarClass && [calendar isKindOfClass:autoCalendarClass]) {
+        return YES;
+    } else {
+        autoCalendarClass = (Class)objc_lookUpClass("NSAutoCalendar");
+        return [calendar isKindOfClass:autoCalendarClass];
+    }
+}
+
+@end
+
+@implementation TimeZoneBridgingTester
+
+- (NSTimeZone *)autoupdatingCurrentTimeZone {
+    return [NSTimeZone localTimeZone];
+}
+
+- (BOOL)verifyAutoupdatingTimeZone:(NSTimeZone *)tz {
+    Class autoTimeZoneClass = (Class)objc_lookUpClass("__NSLocalTimeZone");
+    return [tz isKindOfClass:autoTimeZoneClass];
+
+}
+@end
+
+@implementation LocaleBridgingTester
+
+- (NSLocale *)autoupdatingCurrentLocale {
+    return [NSLocale autoupdatingCurrentLocale];
+}
+
+- (BOOL)verifyAutoupdatingLocale:(NSLocale *)locale {
+    Class autoLocaleClass = (Class)objc_lookUpClass("NSAutoLocale");
+    return [locale isKindOfClass:autoLocaleClass];
+}
+
+@end
+
+@implementation NumberBridgingTester
+
+- (BOOL)verifyKeysInRange:(NSRange)range existInDictionary:(NSDictionary *)dictionary {
+    for (NSUInteger i = 0; i < range.length; i += 1) {
+        if (!dictionary[@(range.location + i)]) {
+            return NO;
+        }
+    }
+
+    return YES;
+}
+
+@end

--- a/Darwin/Foundation-swiftoverlay-Tests/FoundationTests.xcconfig
+++ b/Darwin/Foundation-swiftoverlay-Tests/FoundationTests.xcconfig
@@ -1,0 +1,16 @@
+//===--- FoundationBridge.h -------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "../Config/overlay-tests-shared.xcconfig"
+
+PRODUCT_BUNDLE_IDENTIFIER = org.swift.FoundationTests
+SWIFT_OBJC_BRIDGING_HEADER = $(PROJECT_DIR)/Foundation-swiftoverlay-Tests/FoundationBridge.h

--- a/Darwin/Foundation-swiftoverlay-Tests/Info.plist
+++ b/Darwin/Foundation-swiftoverlay-Tests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Darwin/Foundation-swiftoverlay-Tests/StdlibUnittest checkEquatable.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/StdlibUnittest checkEquatable.swift
@@ -1,0 +1,124 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// FIXME: This should be in a separate package:
+// rdar://57247249 Port StdlibUnittest's collection test suite to XCTest
+
+import XCTest
+
+//
+// Semantic tests for protocol conformance
+//
+
+/// Test that the elements of `instances` satisfy the semantic
+/// requirements of `Equatable`, using `oracle` to generate equality
+/// expectations from pairs of positions in `instances`.
+///
+/// - Note: `oracle` is also checked for conformance to the
+///   laws.
+public func checkEquatable<Instances: Collection>(
+  _ instances: Instances,
+  oracle: (Instances.Index, Instances.Index) -> Bool,
+  allowBrokenTransitivity: Bool = false,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #file, line: UInt = #line
+) where
+  Instances.Element: Equatable
+{
+  let indices = Array(instances.indices)
+  _checkEquatableImpl(
+    Array(instances),
+    oracle: { oracle(indices[$0], indices[$1]) },
+    allowBrokenTransitivity: allowBrokenTransitivity,
+    message(),
+    file: file,
+    line: line)
+}
+
+public final class Box<T> {
+  public init(_ value: T) { self.value = value }
+  public var value: T
+}
+
+internal func _checkEquatableImpl<Instance : Equatable>(
+  _ instances: [Instance],
+  oracle: (Int, Int) -> Bool,
+  allowBrokenTransitivity: Bool = false,
+
+  _ message: @autoclosure () -> String = "",
+  file: StaticString,
+  line: UInt
+) {
+  // For each index (which corresponds to an instance being tested) track the
+  // set of equal instances.
+  var transitivityScoreboard: [Box<Set<Int>>] =
+    instances.indices.map { _ in Box(Set()) }
+
+  // TODO: swift-3-indexing-model: add tests for this function.
+  for i in instances.indices {
+    let x = instances[i]
+    XCTAssertTrue(oracle(i, i), "bad oracle: broken reflexivity at index \(i)", file: file, line: line)
+
+    for j in instances.indices {
+      let y = instances[j]
+
+      let predictedXY = oracle(i, j)
+      XCTAssertEqual(
+        predictedXY, oracle(j, i),
+        "bad oracle: broken symmetry between indices \(i), \(j)",
+        file: file, line: line)
+
+      let isEqualXY = x == y
+      XCTAssertEqual(
+        predictedXY, isEqualXY,
+        """
+        \((predictedXY
+           ? "expected equal, found not equal"
+           : "expected not equal, found equal"))
+        lhs (at index \(i)): \(String(reflecting: x))
+        rhs (at index \(j)): \(String(reflecting: y))
+        """,
+        file: file, line: line)
+
+      // Not-equal is an inverse of equal.
+      XCTAssertNotEqual(
+        isEqualXY, x != y,
+        """
+        lhs (at index \(i)): \(String(reflecting: x))
+        rhs (at index \(j)): \(String(reflecting: y))
+        """,
+        file: file, line: line)
+
+      if !allowBrokenTransitivity {
+        // Check transitivity of the predicate represented by the oracle.
+        // If we are adding the instance `j` into an equivalence set, check that
+        // it is equal to every other instance in the set.
+        if predictedXY && i < j && transitivityScoreboard[i].value.insert(j).inserted {
+          if transitivityScoreboard[i].value.count == 1 {
+            transitivityScoreboard[i].value.insert(i)
+          }
+          for k in transitivityScoreboard[i].value {
+            XCTAssertTrue(
+              oracle(j, k),
+              "bad oracle: broken transitivity at indices \(i), \(j), \(k)",
+              file: file, line: line)
+              // No need to check equality between actual values, we will check
+              // them with the checks above.
+          }
+          precondition(transitivityScoreboard[j].value.isEmpty)
+          transitivityScoreboard[j] = transitivityScoreboard[i]
+        }
+      }
+    }
+  }
+}
+

--- a/Darwin/Foundation-swiftoverlay-Tests/StdlibUnittest checkHashable.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/StdlibUnittest checkHashable.swift
@@ -1,0 +1,178 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// FIXME: This should be in a separate package:
+// rdar://57247249 Port StdlibUnittest's collection test suite to XCTest
+
+import XCTest
+
+/// Produce an integer hash value for `value` by feeding it to a dedicated
+/// `Hasher`. This is always done by calling the `hash(into:)` method.
+/// If a non-nil `seed` is given, it is used to perturb the hasher state;
+/// this is useful for resolving accidental hash collisions.
+private func hash<H: Hashable>(_ value: H, seed: Int? = nil) -> Int {
+  var hasher = Hasher()
+  if let seed = seed {
+    hasher.combine(seed)
+  }
+  hasher.combine(value)
+  return hasher.finalize()
+}
+
+/// Test that the elements of `groups` consist of instances that satisfy the
+/// semantic requirements of `Hashable`, with each group defining a distinct
+/// equivalence class under `==`.
+public func checkHashableGroups<Groups: Collection>(
+  _ groups: Groups,
+  _ message: @autoclosure () -> String = "",
+  allowIncompleteHashing: Bool = false,
+  file: StaticString = #file, line: UInt = #line
+) where Groups.Element: Collection, Groups.Element.Element: Hashable {
+  let instances = groups.flatMap { $0 }
+  // groupIndices[i] is the index of the element in groups that contains
+  // instances[i].
+  let groupIndices =
+    zip(0..., groups).flatMap { i, group in group.map { _ in i } }
+  func equalityOracle(_ lhs: Int, _ rhs: Int) -> Bool {
+    return groupIndices[lhs] == groupIndices[rhs]
+  }
+  checkHashable(
+    instances,
+    equalityOracle: equalityOracle,
+    hashEqualityOracle: equalityOracle,
+    allowBrokenTransitivity: false,
+    allowIncompleteHashing: allowIncompleteHashing,
+    file: file, line: line)
+}
+
+/// Test that the elements of `instances` satisfy the semantic requirements of
+/// `Hashable`, using `equalityOracle` to generate equality and hashing
+/// expectations from pairs of positions in `instances`.
+public func checkHashable<Instances: Collection>(
+  _ instances: Instances,
+  equalityOracle: (Instances.Index, Instances.Index) -> Bool,
+  allowBrokenTransitivity: Bool = false,
+  allowIncompleteHashing: Bool = false,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #file, line: UInt = #line
+) where Instances.Element: Hashable {
+  checkHashable(
+    instances,
+    equalityOracle: equalityOracle,
+    hashEqualityOracle: equalityOracle,
+    allowBrokenTransitivity: allowBrokenTransitivity,
+    allowIncompleteHashing: allowIncompleteHashing,
+    file: file, line: line)
+}
+
+/// Test that the elements of `instances` satisfy the semantic
+/// requirements of `Hashable`, using `equalityOracle` to generate
+/// equality expectations from pairs of positions in `instances`,
+/// and `hashEqualityOracle` to do the same for hashing.
+public func checkHashable<Instances: Collection>(
+  _ instances: Instances,
+  equalityOracle: (Instances.Index, Instances.Index) -> Bool,
+  hashEqualityOracle: (Instances.Index, Instances.Index) -> Bool,
+  allowBrokenTransitivity: Bool = false,
+  allowIncompleteHashing: Bool = false,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #file, line: UInt = #line
+) where
+  Instances.Element: Hashable {
+  checkEquatable(
+    instances,
+    oracle: equalityOracle,
+    allowBrokenTransitivity: allowBrokenTransitivity,
+    message(),
+    file: file, line: line)
+
+  for i in instances.indices {
+    let x = instances[i]
+    for j in instances.indices {
+      let y = instances[j]
+      let predicted = hashEqualityOracle(i, j)
+      XCTAssertEqual(
+        predicted, hashEqualityOracle(j, i),
+        "bad hash oracle: broken symmetry between indices \(i), \(j)",
+        file: file, line: line)
+      if x == y {
+        XCTAssertTrue(
+          predicted,
+          """
+          bad hash oracle: equality must imply hash equality
+          lhs (at index \(i)): \(x)
+          rhs (at index \(j)): \(y)
+          """,
+          file: file, line: line)
+      }
+      if predicted {
+        XCTAssertEqual(
+          hash(x), hash(y),
+          """
+          hash(into:) expected to match, found to differ
+          lhs (at index \(i)): \(x)
+          rhs (at index \(j)): \(y)
+          """,
+          file: file, line: line)
+        XCTAssertEqual(
+          x.hashValue, y.hashValue,
+          """
+          hashValue expected to match, found to differ
+          lhs (at index \(i)): \(x)
+          rhs (at index \(j)): \(y)
+          """,
+          file: file, line: line)
+        XCTAssertEqual(
+          x._rawHashValue(seed: 0), y._rawHashValue(seed: 0),
+          """
+          _rawHashValue(seed:) expected to match, found to differ
+          lhs (at index \(i)): \(x)
+          rhs (at index \(j)): \(y)
+          """,
+          file: file, line: line)
+      } else if !allowIncompleteHashing {
+        // Try a few different seeds; at least one of them should discriminate
+        // between the hashes. It is extremely unlikely this check will fail
+        // all ten attempts, unless the type's hash encoding is not unique,
+        // or unless the hash equality oracle is wrong.
+        XCTAssertTrue(
+          (0..<10).contains { hash(x, seed: $0) != hash(y, seed: $0) },
+          """
+          hash(into:) expected to differ, found to match
+          lhs (at index \(i)): \(x)
+          rhs (at index \(j)): \(y)
+          """,
+          file: file, line: line)
+        XCTAssertTrue(
+          (0..<10).contains { i in
+            x._rawHashValue(seed: i) != y._rawHashValue(seed: i)
+          },
+          """
+          _rawHashValue(seed:) expected to differ, found to match
+          lhs (at index \(i)): \(x)
+          rhs (at index \(j)): \(y)
+          """,
+          file: file, line: line)
+      }
+    }
+  }
+}
+
+public func checkHashable<T : Hashable>(
+  expectedEqual: Bool, _ lhs: T, _ rhs: T,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #file, line: UInt = #line
+) {
+  checkHashable(
+    [lhs, rhs], equalityOracle: { expectedEqual || $0 == $1 }, message(),
+    file: file, line: line)
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/StdlibUnittest expectEqual Types.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/StdlibUnittest expectEqual Types.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// FIXME: This should be in a separate package:
+// rdar://57247249 Port StdlibUnittest's collection test suite to XCTest
+
+import XCTest
+
+public func expectEqual(
+  _ expected: Any.Type, _ actual: Any.Type,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #file, line: UInt = #line
+) {
+    guard expected != actual else { return }
+    var report =  """
+        expected: \(String(reflecting: expected)) (of type \(String(reflecting: type(of: expected))))
+        actual: \(String(reflecting: actual)) (of type \(String(reflecting: type(of: actual))))
+        """
+    let message = message()
+    if message != "" {
+        report += "\n\(message)"
+    }
+    XCTFail(report, file: file, line: line)
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestAffineTransform.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestAffineTransform.swift
@@ -1,0 +1,396 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+#if os(macOS)
+extension AffineTransform {
+    func transform(_ aRect: NSRect) -> NSRect {
+        return NSRect(origin: transform(aRect.origin), size: transform(aRect.size))
+    }
+}
+
+class TestAffineTransform : XCTestCase {
+    private let accuracyThreshold = 0.001
+    
+    func checkPointTransformation(_ transform: AffineTransform, point: NSPoint, expectedPoint: NSPoint, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+        let newPoint = transform.transform(point)
+        XCTAssertEqual(Double(newPoint.x), Double(expectedPoint.x), accuracy: accuracyThreshold,
+                                   "x (expected: \(expectedPoint.x), was: \(newPoint.x)): \(message)", file: file, line: line)
+        XCTAssertEqual(Double(newPoint.y), Double(expectedPoint.y), accuracy: accuracyThreshold,
+                                   "y (expected: \(expectedPoint.y), was: \(newPoint.y)): \(message)", file: file, line: line)
+    }
+    
+    func checkSizeTransformation(_ transform: AffineTransform, size: NSSize, expectedSize: NSSize, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+        let newSize = transform.transform(size)
+        XCTAssertEqual(Double(newSize.width), Double(expectedSize.width), accuracy: accuracyThreshold,
+                                   "width (expected: \(expectedSize.width), was: \(newSize.width)): \(message)", file: file, line: line)
+        XCTAssertEqual(Double(newSize.height), Double(expectedSize.height), accuracy: accuracyThreshold,
+                                   "height (expected: \(expectedSize.height), was: \(newSize.height)): \(message)", file: file, line: line)
+    }
+    
+    func checkRectTransformation(_ transform: AffineTransform, rect: NSRect, expectedRect: NSRect, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+        let newRect = transform.transform(rect)
+        
+        checkPointTransformation(transform, point: newRect.origin, expectedPoint: expectedRect.origin,
+                                 "origin (expected: \(expectedRect.origin), was: \(newRect.origin)): \(message)", file: file, line: line)
+        checkSizeTransformation(transform, size: newRect.size, expectedSize: expectedRect.size,
+                                "size (expected: \(expectedRect.size), was: \(newRect.size)): \(message)", file: file, line: line)
+    }
+    
+    func test_BasicConstruction() {
+        let defaultAffineTransform = AffineTransform()
+        let identityTransform = AffineTransform.identity
+
+        XCTAssertEqual(defaultAffineTransform, identityTransform)
+        
+        // The diagonal entries (1,1) and (2,2) of the identity matrix are ones. The other entries are zeros.
+        // TODO: These should use DBL_MAX but it's not available as part of Glibc on Linux
+        XCTAssertEqual(Double(identityTransform.m11), Double(1), accuracy: accuracyThreshold)
+        XCTAssertEqual(Double(identityTransform.m22), Double(1), accuracy: accuracyThreshold)
+        
+        XCTAssertEqual(Double(identityTransform.m12), Double(0), accuracy: accuracyThreshold)
+        XCTAssertEqual(Double(identityTransform.m21), Double(0), accuracy: accuracyThreshold)
+        XCTAssertEqual(Double(identityTransform.tX), Double(0), accuracy: accuracyThreshold)
+        XCTAssertEqual(Double(identityTransform.tY), Double(0), accuracy: accuracyThreshold)
+    }
+    
+    func test_IdentityTransformation() {
+        let identityTransform = AffineTransform.identity
+        
+        func checkIdentityPointTransformation(_ point: NSPoint) {
+            checkPointTransformation(identityTransform, point: point, expectedPoint: point)
+        }
+        
+        checkIdentityPointTransformation(NSPoint())
+        checkIdentityPointTransformation(NSPoint(x: CGFloat(24.5), y: CGFloat(10.0)))
+        checkIdentityPointTransformation(NSPoint(x: CGFloat(-7.5), y: CGFloat(2.0)))
+        
+        func checkIdentitySizeTransformation(_ size: NSSize) {
+            checkSizeTransformation(identityTransform, size: size, expectedSize: size)
+        }
+        
+        checkIdentitySizeTransformation(NSSize())
+        checkIdentitySizeTransformation(NSSize(width: CGFloat(13.0), height: CGFloat(12.5)))
+        checkIdentitySizeTransformation(NSSize(width: CGFloat(100.0), height: CGFloat(-100.0)))
+    }
+    
+    func test_Translation() {
+        let point = NSPoint(x: CGFloat(0.0), y: CGFloat(0.0))
+        
+        var noop = AffineTransform.identity
+        noop.translate(x: CGFloat(), y: CGFloat())
+        checkPointTransformation(noop, point: point, expectedPoint: point)
+        
+        var translateH = AffineTransform.identity
+        translateH.translate(x: CGFloat(10.0), y: CGFloat())
+        checkPointTransformation(translateH, point: point, expectedPoint: NSPoint(x: CGFloat(10.0), y: CGFloat()))
+        
+        var translateV = AffineTransform.identity
+        translateV.translate(x: CGFloat(), y: CGFloat(20.0))
+        checkPointTransformation(translateV, point: point, expectedPoint: NSPoint(x: CGFloat(), y: CGFloat(20.0)))
+        
+        var translate = AffineTransform.identity
+        translate.translate(x: CGFloat(-30.0), y: CGFloat(40.0))
+        checkPointTransformation(translate, point: point, expectedPoint: NSPoint(x: CGFloat(-30.0), y: CGFloat(40.0)))
+    }
+    
+    func test_Scale() {
+        let size = NSSize(width: CGFloat(10.0), height: CGFloat(10.0))
+        
+        var noop = AffineTransform.identity
+        noop.scale(CGFloat(1.0))
+        checkSizeTransformation(noop, size: size, expectedSize: size)
+        
+        var shrink = AffineTransform.identity
+        shrink.scale(CGFloat(0.5))
+        checkSizeTransformation(shrink, size: size, expectedSize: NSSize(width: CGFloat(5.0), height: CGFloat(5.0)))
+        
+        var grow = AffineTransform.identity
+        grow.scale(CGFloat(3.0))
+        checkSizeTransformation(grow, size: size, expectedSize: NSSize(width: CGFloat(30.0), height: CGFloat(30.0)))
+        
+        var stretch = AffineTransform.identity
+        stretch.scale(x: CGFloat(2.0), y: CGFloat(0.5))
+        checkSizeTransformation(stretch, size: size, expectedSize: NSSize(width: CGFloat(20.0), height: CGFloat(5.0)))
+    }
+    
+    func test_Rotation_Degrees() {
+        let point = NSPoint(x: CGFloat(10.0), y: CGFloat(10.0))
+        
+        var noop = AffineTransform.identity
+        noop.rotate(byDegrees: CGFloat())
+        checkPointTransformation(noop, point: point, expectedPoint: point)
+        
+        var tenEighty = AffineTransform.identity
+        tenEighty.rotate(byDegrees: CGFloat(1080.0))
+        checkPointTransformation(tenEighty, point: point, expectedPoint: point)
+        
+        var rotateCounterClockwise = AffineTransform.identity
+        rotateCounterClockwise.rotate(byDegrees: CGFloat(90.0))
+        checkPointTransformation(rotateCounterClockwise, point: point, expectedPoint: NSPoint(x: CGFloat(-10.0), y: CGFloat(10.0)))
+        
+        var rotateClockwise = AffineTransform.identity
+        rotateClockwise.rotate(byDegrees: CGFloat(-90.0))
+        checkPointTransformation(rotateClockwise, point: point, expectedPoint: NSPoint(x: CGFloat(10.0), y: CGFloat(-10.0)))
+        
+        var reflectAboutOrigin = AffineTransform.identity
+        reflectAboutOrigin.rotate(byDegrees: CGFloat(180.0))
+        checkPointTransformation(reflectAboutOrigin, point: point, expectedPoint: NSPoint(x: CGFloat(-10.0), y: CGFloat(-10.0)))
+    }
+    
+    func test_Rotation_Radians() {
+        let point = NSPoint(x: CGFloat(10.0), y: CGFloat(10.0))
+        
+        var noop = AffineTransform.identity
+        noop.rotate(byRadians: CGFloat())
+        checkPointTransformation(noop, point: point, expectedPoint: point)
+        
+        var tenEighty = AffineTransform.identity
+        tenEighty.rotate(byRadians: 6 * .pi)
+        checkPointTransformation(tenEighty, point: point, expectedPoint: point)
+        
+        var rotateCounterClockwise = AffineTransform.identity
+        rotateCounterClockwise.rotate(byRadians: .pi / 2)
+        checkPointTransformation(rotateCounterClockwise, point: point, expectedPoint: NSPoint(x: CGFloat(-10.0), y: CGFloat(10.0)))
+        
+        var rotateClockwise = AffineTransform.identity
+        rotateClockwise.rotate(byRadians: -.pi / 2)
+        checkPointTransformation(rotateClockwise, point: point, expectedPoint: NSPoint(x: CGFloat(10.0), y: CGFloat(-10.0)))
+        
+        var reflectAboutOrigin = AffineTransform.identity
+        reflectAboutOrigin.rotate(byRadians: .pi)
+        checkPointTransformation(reflectAboutOrigin, point: point, expectedPoint: NSPoint(x: CGFloat(-10.0), y: CGFloat(-10.0)))
+        
+        var scaleThenRotate = AffineTransform(scale: 2)
+        scaleThenRotate.rotate(byRadians: .pi / 2)
+        checkPointTransformation(scaleThenRotate, point: point, expectedPoint: NSPoint(x: CGFloat(-20.0), y: CGFloat(20.0)))
+    }
+    
+    func test_Inversion() {
+        let point = NSPoint(x: CGFloat(10.0), y: CGFloat(10.0))
+        
+        var translate = AffineTransform.identity
+        translate.translate(x: CGFloat(-30.0), y: CGFloat(40.0))
+        
+        var rotate = AffineTransform.identity
+        translate.rotate(byDegrees: CGFloat(30.0))
+        
+        var scale = AffineTransform.identity
+        scale.scale(CGFloat(2.0))
+        
+        var identityTransform = AffineTransform.identity
+        
+        // append transformations
+        identityTransform.append(translate)
+        identityTransform.append(rotate)
+        identityTransform.append(scale)
+        
+        // invert transformations
+        scale.invert()
+        rotate.invert()
+        translate.invert()
+        
+        // append inverse transformations in reverse order
+        identityTransform.append(scale)
+        identityTransform.append(rotate)
+        identityTransform.append(translate)
+        
+        checkPointTransformation(identityTransform, point: point, expectedPoint: point)
+    }
+    
+    func test_TranslationComposed() {
+        var xyPlus5 = AffineTransform.identity
+        xyPlus5.translate(x: CGFloat(2.0), y: CGFloat(3.0))
+        xyPlus5.translate(x: CGFloat(3.0), y: CGFloat(2.0))
+        
+        checkPointTransformation(xyPlus5, point: NSPoint(x: CGFloat(-2.0), y: CGFloat(-3.0)),
+                                 expectedPoint: NSPoint(x: CGFloat(3.0), y: CGFloat(2.0)))
+    }
+    
+    func test_Scaling() {
+        var xyTimes5 = AffineTransform.identity
+        xyTimes5.scale(CGFloat(5.0))
+        
+        checkPointTransformation(xyTimes5, point: NSPoint(x: CGFloat(-2.0), y: CGFloat(3.0)),
+                                 expectedPoint: NSPoint(x: CGFloat(-10.0), y: CGFloat(15.0)))
+        
+        var xTimes2YTimes3 = AffineTransform.identity
+        xTimes2YTimes3.scale(x: CGFloat(2.0), y: CGFloat(-3.0))
+        
+        checkPointTransformation(xTimes2YTimes3, point: NSPoint(x: CGFloat(-1.0), y: CGFloat(3.5)),
+                                 expectedPoint: NSPoint(x: CGFloat(-2.0), y: CGFloat(-10.5)))
+    }
+    
+    func test_TranslationScaling() {
+        var xPlus2XYTimes5 = AffineTransform.identity
+        xPlus2XYTimes5.translate(x: CGFloat(2.0), y: CGFloat())
+        xPlus2XYTimes5.scale(x: CGFloat(5.0), y: CGFloat(-5.0))
+        
+        checkPointTransformation(xPlus2XYTimes5, point: NSPoint(x: CGFloat(1.0), y: CGFloat(2.0)),
+                                 expectedPoint: NSPoint(x: CGFloat(7.0), y: CGFloat(-10.0)))
+    }
+    
+    func test_ScalingTranslation() {
+        var xyTimes5XPlus3 = AffineTransform.identity
+        xyTimes5XPlus3.scale(CGFloat(5.0))
+        xyTimes5XPlus3.translate(x: CGFloat(3.0), y: CGFloat())
+        
+        checkPointTransformation(xyTimes5XPlus3, point: NSPoint(x: CGFloat(1.0), y: CGFloat(2.0)),
+                                 expectedPoint: NSPoint(x: CGFloat(20.0), y: CGFloat(10.0)))
+    }
+    
+    func test_AppendTransform() {
+        let point = NSPoint(x: CGFloat(10.0), y: CGFloat(10.0))
+        
+        var identityTransform = AffineTransform.identity
+        identityTransform.append(identityTransform)
+        checkPointTransformation(identityTransform, point: point, expectedPoint: point)
+        
+        let translate = AffineTransform(translationByX: 10.0, byY: 0.0)
+        
+        let scale = AffineTransform(scale: 2.0)
+        
+        var translateThenScale = translate
+        translateThenScale.append(scale)
+        checkPointTransformation(translateThenScale, point: point, expectedPoint: NSPoint(x: CGFloat(40.0), y: CGFloat(20.0)))
+    }
+    
+    func test_PrependTransform() {
+        let point = NSPoint(x: CGFloat(10.0), y: CGFloat(10.0))
+        
+        var identityTransform = AffineTransform.identity
+        identityTransform.append(identityTransform)
+        checkPointTransformation(identityTransform, point: point, expectedPoint: point)
+        
+        let translate = AffineTransform(translationByX: 10.0, byY: 0.0)
+        
+        let scale = AffineTransform(scale: 2.0)
+        
+        var scaleThenTranslate = translate
+        scaleThenTranslate.prepend(scale)
+        checkPointTransformation(scaleThenTranslate, point: point, expectedPoint: NSPoint(x: CGFloat(30.0), y: CGFloat(20.0)))
+    }
+    
+    func test_TransformComposition() {
+        let origin = NSPoint(x: CGFloat(10.0), y: CGFloat(10.0))
+        let size = NSSize(width: CGFloat(40.0), height: CGFloat(20.0))
+        let rect = NSRect(origin: origin, size: size)
+        let center = NSPoint(x: NSMidX(rect), y: NSMidY(rect))
+        
+        let rotate = AffineTransform(rotationByDegrees: 90.0)
+        
+        let moveOrigin = AffineTransform(translationByX: -center.x, byY: -center.y)
+        
+        var moveBack = moveOrigin
+        moveBack.invert()
+        
+        var rotateAboutCenter = rotate
+        rotateAboutCenter.prepend(moveOrigin)
+        rotateAboutCenter.append(moveBack)
+        
+        // center of rect shouldn't move as its the rotation anchor
+        checkPointTransformation(rotateAboutCenter, point: center, expectedPoint: center)
+    }
+    
+    func test_hashing() {
+        guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else { return }
+
+        // the transforms are made up and the values don't matter
+        let a = AffineTransform(m11: 1.0, m12: 2.5, m21: 66.2, m22: 40.2, tX: -5.5, tY: 3.7)
+        let b = AffineTransform(m11: -55.66, m12: 22.7, m21: 1.5, m22: 0.0, tX: -22, tY: -33)
+        let c = AffineTransform(m11: 4.5, m12: 1.1, m21: 0.025, m22: 0.077, tX: -0.55, tY: 33.2)
+        let d = AffineTransform(m11: 7.0, m12: -2.3, m21: 6.7, m22: 0.25, tX: 0.556, tY: 0.99)
+        let e = AffineTransform(m11: 0.498, m12: -0.284, m21: -0.742, m22: 0.3248, tX: 12, tY: 44)
+
+        // Samples testing that every component is properly hashed
+        let x1 = AffineTransform(m11: 1.0, m12: 2.0, m21: 3.0, m22: 4.0, tX: 5.0, tY: 6.0)
+        let x2 = AffineTransform(m11: 1.5, m12: 2.0, m21: 3.0, m22: 4.0, tX: 5.0, tY: 6.0)
+        let x3 = AffineTransform(m11: 1.0, m12: 2.5, m21: 3.0, m22: 4.0, tX: 5.0, tY: 6.0)
+        let x4 = AffineTransform(m11: 1.0, m12: 2.0, m21: 3.5, m22: 4.0, tX: 5.0, tY: 6.0)
+        let x5 = AffineTransform(m11: 1.0, m12: 2.0, m21: 3.0, m22: 4.5, tX: 5.0, tY: 6.0)
+        let x6 = AffineTransform(m11: 1.0, m12: 2.0, m21: 3.0, m22: 4.0, tX: 5.5, tY: 6.0)
+        let x7 = AffineTransform(m11: 1.0, m12: 2.0, m21: 3.0, m22: 4.0, tX: 5.0, tY: 6.5)
+
+        @inline(never)
+        func bridged(_ t: AffineTransform) -> NSAffineTransform {
+            return t as NSAffineTransform
+        }
+
+        let values: [[AffineTransform]] = [
+            [AffineTransform.identity, NSAffineTransform() as AffineTransform],
+            [a, bridged(a) as AffineTransform],
+            [b, bridged(b) as AffineTransform],
+            [c, bridged(c) as AffineTransform],
+            [d, bridged(d) as AffineTransform],
+            [e, bridged(e) as AffineTransform],
+            [x1], [x2], [x3], [x4], [x5], [x6], [x7]
+        ]
+        checkHashableGroups(values)
+    }
+
+    func test_AnyHashable() {
+        func makeNSAffineTransform(rotatedByDegrees angle: CGFloat) -> NSAffineTransform {
+            let result = NSAffineTransform()
+            result.rotate(byDegrees: angle)
+            return result
+        }
+
+        let s1 = AffineTransform.identity
+        let s2 = AffineTransform(m11: -55.66, m12: 22.7, m21: 1.5, m22: 0.0, tX: -22, tY: -33)
+        let s3 = AffineTransform(m11: -55.66, m12: 22.7, m21: 1.5, m22: 0.0, tX: -22, tY: -33)
+        let s4 = makeNSAffineTransform(rotatedByDegrees: 10) as AffineTransform
+        let s5 = makeNSAffineTransform(rotatedByDegrees: 10) as AffineTransform
+
+        let c1 = NSAffineTransform(transform: s1)
+        let c2 = NSAffineTransform(transform: s2)
+        let c3 = NSAffineTransform(transform: s3)
+        let c4 = makeNSAffineTransform(rotatedByDegrees: 10)
+        let c5 = makeNSAffineTransform(rotatedByDegrees: 10)
+
+        let groups: [[AnyHashable]] = [
+            [s1, c1],
+            [s2, c2, s3, c3],
+            [s4, c4, s5, c5]
+        ]
+        checkHashableGroups(groups)
+
+        expectEqual(AffineTransform.self, type(of: (s1 as AnyHashable).base))
+        expectEqual(AffineTransform.self, type(of: (s2 as AnyHashable).base))
+        expectEqual(AffineTransform.self, type(of: (s3 as AnyHashable).base))
+        expectEqual(AffineTransform.self, type(of: (s4 as AnyHashable).base))
+        expectEqual(AffineTransform.self, type(of: (s5 as AnyHashable).base))
+
+        expectEqual(AffineTransform.self, type(of: (c1 as AnyHashable).base))
+        expectEqual(AffineTransform.self, type(of: (c2 as AnyHashable).base))
+        expectEqual(AffineTransform.self, type(of: (c3 as AnyHashable).base))
+        expectEqual(AffineTransform.self, type(of: (c4 as AnyHashable).base))
+        expectEqual(AffineTransform.self, type(of: (c5 as AnyHashable).base))
+    }
+
+    func test_unconditionallyBridgeFromObjectiveC() {
+        XCTAssertEqual(AffineTransform(), AffineTransform._unconditionallyBridgeFromObjectiveC(nil))
+    }
+
+    func test_rotation_compose() {
+        var t = AffineTransform.identity
+        t.translate(x: 1.0, y: 1.0)
+        t.rotate(byDegrees: 90)
+        t.translate(x: -1.0, y: -1.0)
+        let result = t.transform(NSPoint(x: 1.0, y: 2.0))
+        XCTAssertEqual(0.0, Double(result.x), accuracy: accuracyThreshold)
+        XCTAssertEqual(1.0, Double(result.y), accuracy: accuracyThreshold)
+    }
+}
+
+#endif

--- a/Darwin/Foundation-swiftoverlay-Tests/TestCalendar.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestCalendar.swift
@@ -1,0 +1,296 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+class TestCalendar : XCTestCase {
+    
+    func test_copyOnWrite() {
+        var c = Calendar(identifier: .gregorian)
+        let c2 = c
+        XCTAssertEqual(c, c2)
+        
+        // Change the weekday and check result
+        let firstWeekday = c.firstWeekday
+        let newFirstWeekday = firstWeekday < 7 ? firstWeekday + 1 : firstWeekday - 1
+        
+        c.firstWeekday = newFirstWeekday
+        XCTAssertEqual(newFirstWeekday, c.firstWeekday)
+        XCTAssertEqual(c2.firstWeekday, firstWeekday)
+        
+        XCTAssertNotEqual(c, c2)
+        
+        // Change the time zone and check result
+        let c3 = c
+        XCTAssertEqual(c, c3)
+        
+        let tz = c.timeZone
+        // Use two different identifiers so we don't fail if the current time zone happens to be the one returned
+        let aTimeZoneId = TimeZone.knownTimeZoneIdentifiers[1]
+        let anotherTimeZoneId = TimeZone.knownTimeZoneIdentifiers[0]
+        
+        let newTz = tz.identifier == aTimeZoneId ? TimeZone(identifier: anotherTimeZoneId)! : TimeZone(identifier: aTimeZoneId)!
+        
+        c.timeZone = newTz
+        XCTAssertNotEqual(c, c3)
+        
+    }
+    
+    func test_bridgingAutoupdating() {
+        let tester = CalendarBridgingTester()
+        
+        do {
+            let c = Calendar.autoupdatingCurrent
+            let result = tester.verifyAutoupdating(c)
+            XCTAssertTrue(result)
+        }
+        
+        // Round trip an autoupdating calendar
+        do {
+            let c = tester.autoupdatingCurrentCalendar()
+            let result = tester.verifyAutoupdating(c)
+            XCTAssertTrue(result)
+        }
+    }
+    
+    func test_equality() {
+        let autoupdating = Calendar.autoupdatingCurrent
+        let autoupdating2 = Calendar.autoupdatingCurrent
+
+        XCTAssertEqual(autoupdating, autoupdating2)
+        
+        let current = Calendar.current
+        
+        XCTAssertNotEqual(autoupdating, current)
+        
+        // Make a copy of current
+        var current2 = current
+        XCTAssertEqual(current, current2)
+        
+        // Mutate something (making sure we don't use the current time zone)
+        if current2.timeZone.identifier == "America/Los_Angeles" {
+            current2.timeZone = TimeZone(identifier: "America/New_York")!
+        } else {
+            current2.timeZone = TimeZone(identifier: "America/Los_Angeles")!
+        }
+        XCTAssertNotEqual(current, current2)
+        
+        // Mutate something else
+        current2 = current
+        XCTAssertEqual(current, current2)
+        
+        current2.locale = Locale(identifier: "MyMadeUpLocale")
+        XCTAssertNotEqual(current, current2)
+  }
+
+    func test_hash() {
+        let calendars: [Calendar] = [
+            Calendar.autoupdatingCurrent,
+            Calendar(identifier: .buddhist),
+            Calendar(identifier: .gregorian),
+            Calendar(identifier: .islamic),
+            Calendar(identifier: .iso8601),
+        ]
+        checkHashable(calendars, equalityOracle: { $0 == $1 })
+
+        // autoupdating calendar isn't equal to the current, even though it's
+        // likely to be the same.
+        let calendars2: [Calendar] = [
+            Calendar.autoupdatingCurrent,
+            Calendar.current,
+        ]
+        checkHashable(calendars2, equalityOracle: { $0 == $1 })
+    }
+
+    func test_properties() {
+        // Mainly we want to just make sure these go through to the NSCalendar implementation at this point.
+        if #available(iOS 8.0, OSX 10.7, *) {
+            var c = Calendar(identifier: .gregorian)
+            // Use english localization
+            c.locale = Locale(identifier: "en_US")
+            c.timeZone = TimeZone(identifier: "America/Los_Angeles")!
+            
+            XCTAssertEqual("AM", c.amSymbol)
+            XCTAssertEqual("PM", c.pmSymbol)
+            XCTAssertEqual(["1st quarter", "2nd quarter", "3rd quarter", "4th quarter"], c.quarterSymbols)
+            XCTAssertEqual(["1st quarter", "2nd quarter", "3rd quarter", "4th quarter"], c.standaloneQuarterSymbols)
+            XCTAssertEqual(["BC", "AD"], c.eraSymbols)
+            XCTAssertEqual(["Before Christ", "Anno Domini"], c.longEraSymbols)
+            XCTAssertEqual(["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"], c.veryShortMonthSymbols)
+            XCTAssertEqual(["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"], c.veryShortStandaloneMonthSymbols)
+            XCTAssertEqual(["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"], c.shortMonthSymbols)
+            XCTAssertEqual(["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"], c.shortStandaloneMonthSymbols)
+            XCTAssertEqual(["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"], c.monthSymbols)
+            XCTAssertEqual(["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"], c.standaloneMonthSymbols)
+            XCTAssertEqual(["Q1", "Q2", "Q3", "Q4"], c.shortQuarterSymbols)
+            XCTAssertEqual(["Q1", "Q2", "Q3", "Q4"], c.shortStandaloneQuarterSymbols)
+            XCTAssertEqual(["S", "M", "T", "W", "T", "F", "S"], c.veryShortStandaloneWeekdaySymbols)
+            XCTAssertEqual(["S", "M", "T", "W", "T", "F", "S"], c.veryShortWeekdaySymbols)
+            XCTAssertEqual(["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"], c.shortStandaloneWeekdaySymbols)
+            XCTAssertEqual(["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"], c.shortWeekdaySymbols)
+            XCTAssertEqual(["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"], c.standaloneWeekdaySymbols)
+            XCTAssertEqual(["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"], c.weekdaySymbols)
+            
+            // The idea behind these tests is not to test calendrical math, but to simply verify that we are getting some kind of result from calling through to the underlying Foundation and ICU logic. If we move that logic into this struct in the future, then we will need to expand the test cases.
+            
+            // This is a very special Date in my life: the exact moment when I wrote these test cases and therefore knew all of the answers.
+            let d = Date(timeIntervalSince1970: 1468705593.2533731)
+            let earlierD = c.date(byAdding: DateComponents(day: -10), to: d)!
+                
+            XCTAssertEqual(1..<29, c.minimumRange(of: .day))
+            XCTAssertEqual(1..<54, c.maximumRange(of: .weekOfYear))
+            XCTAssertEqual(0..<60, c.range(of: .second, in: .minute, for: d))
+            
+            var d1 = Date()
+            var ti : TimeInterval = 0
+            
+            XCTAssertTrue(c.dateInterval(of: .day, start: &d1, interval: &ti, for: d))
+            XCTAssertEqual(Date(timeIntervalSince1970: 1468652400.0), d1)
+            XCTAssertEqual(86400, ti)
+            
+            if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+                let dateInterval = c.dateInterval(of: .day, for: d)
+                XCTAssertEqual(DateInterval(start: d1, duration: ti), dateInterval)
+            }
+            
+            XCTAssertEqual(15, c.ordinality(of: .hour, in: .day, for: d))
+            
+            XCTAssertEqual(Date(timeIntervalSince1970: 1468791993.2533731), c.date(byAdding: .day, value: 1, to: d))
+            XCTAssertEqual(Date(timeIntervalSince1970: 1468791993.2533731), c.date(byAdding: DateComponents(day: 1),  to: d))
+            
+            XCTAssertEqual(Date(timeIntervalSince1970: 946627200.0), c.date(from: DateComponents(year: 1999, month: 12, day: 31)))
+            
+            let comps = c.dateComponents([.year, .month, .day], from: Date(timeIntervalSince1970: 946627200.0))
+            XCTAssertEqual(1999, comps.year)
+            XCTAssertEqual(12, comps.month)
+            XCTAssertEqual(31, comps.day)
+            
+            XCTAssertEqual(10, c.dateComponents([.day], from: d, to: c.date(byAdding: DateComponents(day: 10), to: d)!).day)
+            
+            XCTAssertEqual(30, c.dateComponents([.day], from: DateComponents(year: 1999, month: 12, day: 1), to: DateComponents(year: 1999, month: 12, day: 31)).day)
+            
+            XCTAssertEqual(2016, c.component(.year, from: d))
+            
+            XCTAssertEqual(Date(timeIntervalSince1970: 1468652400.0), c.startOfDay(for: d))
+            
+            if #available(iOS 8, macOS 10.10, *) {
+              // Mac OS X 10.9 and iOS 7 had a bug in NSCalendar for hour, minute, and second granularities.
+              XCTAssertEqual(.orderedSame, c.compare(d, to: d + 10, toGranularity: .minute))
+            }
+            
+            XCTAssertFalse(c.isDate(d, equalTo: d + 10, toGranularity: .second))
+            XCTAssertTrue(c.isDate(d, equalTo: d + 10, toGranularity: .day))
+            
+            XCTAssertFalse(c.isDate(earlierD, inSameDayAs: d))
+            XCTAssertTrue(c.isDate(d, inSameDayAs: d))
+            
+            XCTAssertFalse(c.isDateInToday(earlierD))
+            XCTAssertFalse(c.isDateInYesterday(earlierD))
+            XCTAssertFalse(c.isDateInTomorrow(earlierD))
+            
+            XCTAssertTrue(c.isDateInWeekend(d)) // 😢
+            
+            XCTAssertTrue(c.dateIntervalOfWeekend(containing: d, start: &d1, interval: &ti))
+            
+            if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+                let thisWeekend = DateInterval(start: Date(timeIntervalSince1970: 1468652400.0), duration: 172800.0)
+                
+                XCTAssertEqual(thisWeekend, DateInterval(start: d1, duration: ti))
+                XCTAssertEqual(thisWeekend, c.dateIntervalOfWeekend(containing: d))
+            }
+            
+
+            XCTAssertTrue(c.nextWeekend(startingAfter: d, start: &d1, interval: &ti))
+            
+            if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+                let nextWeekend = DateInterval(start: Date(timeIntervalSince1970: 1469257200.0), duration: 172800.0)
+            
+                XCTAssertEqual(nextWeekend, DateInterval(start: d1, duration: ti))
+                XCTAssertEqual(nextWeekend, c.nextWeekend(startingAfter: d))
+            }
+            
+            // Enumeration
+            
+            var count = 0
+            var exactCount = 0
+            
+            // Find the days numbered '31' after 'd', allowing the algorithm to move to the next day if required
+            c.enumerateDates(startingAfter: d, matching: DateComponents(day: 31), matchingPolicy: .nextTime) { result, exact, stop in
+                // Just stop some arbitrary time in the future
+                if result! > d + 86400*365 { stop = true }
+                count += 1
+                if exact { exactCount += 1 }
+            }
+            
+            /*
+             Optional(2016-07-31 07:00:00 +0000)
+             Optional(2016-08-31 07:00:00 +0000)
+             Optional(2016-10-01 07:00:00 +0000)
+             Optional(2016-10-31 07:00:00 +0000)
+             Optional(2016-12-01 08:00:00 +0000)
+             Optional(2016-12-31 08:00:00 +0000)
+             Optional(2017-01-31 08:00:00 +0000)
+             Optional(2017-03-01 08:00:00 +0000)
+             Optional(2017-03-31 07:00:00 +0000)
+             Optional(2017-05-01 07:00:00 +0000)
+             Optional(2017-05-31 07:00:00 +0000)
+             Optional(2017-07-01 07:00:00 +0000)
+             Optional(2017-07-31 07:00:00 +0000)
+             */
+
+            XCTAssertEqual(count, 13)
+            XCTAssertEqual(exactCount, 8)
+            
+            
+            XCTAssertEqual(Date(timeIntervalSince1970: 1469948400.0), c.nextDate(after: d, matching: DateComponents(day: 31), matchingPolicy: .nextTime))
+            
+            
+            XCTAssertEqual(Date(timeIntervalSince1970: 1468742400.0),  c.date(bySetting: .hour, value: 1, of: d))
+            
+            XCTAssertEqual(Date(timeIntervalSince1970: 1468656123.0), c.date(bySettingHour: 1, minute: 2, second: 3, of: d, matchingPolicy: .nextTime))
+            
+            XCTAssertTrue(c.date(d, matchesComponents: DateComponents(month: 7)))
+            XCTAssertFalse(c.date(d, matchesComponents: DateComponents(month: 7, day: 31)))
+        }
+    }
+
+    func test_AnyHashableContainingCalendar() {
+        let values: [Calendar] = [
+            Calendar(identifier: .gregorian),
+            Calendar(identifier: .japanese),
+            Calendar(identifier: .japanese)
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(Calendar.self, type(of: anyHashables[0].base))
+        expectEqual(Calendar.self, type(of: anyHashables[1].base))
+        expectEqual(Calendar.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableCreatedFromNSCalendar() {
+        if #available(iOS 8.0, *) {
+            let values: [NSCalendar] = [
+                NSCalendar(identifier: .gregorian)!,
+                NSCalendar(identifier: .japanese)!,
+                NSCalendar(identifier: .japanese)!,
+            ]
+            let anyHashables = values.map(AnyHashable.init)
+            expectEqual(Calendar.self, type(of: anyHashables[0].base))
+            expectEqual(Calendar.self, type(of: anyHashables[1].base))
+            expectEqual(Calendar.self, type(of: anyHashables[2].base))
+            XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+            XCTAssertEqual(anyHashables[1], anyHashables[2])
+        }
+    }
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestCharacterSet.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestCharacterSet.swift
@@ -1,0 +1,327 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+class TestCharacterSet : XCTestCase {
+    let capitalA = UnicodeScalar(0x0041)! // LATIN CAPITAL LETTER A
+    let capitalB = UnicodeScalar(0x0042)! // LATIN CAPITAL LETTER B
+    let capitalC = UnicodeScalar(0x0043)! // LATIN CAPITAL LETTER C
+    
+    func testBasicConstruction() {
+        // Create a character set
+        let cs = CharacterSet.letters
+        
+        // Use some method from it
+        let invertedCs = cs.inverted
+        XCTAssertTrue(!invertedCs.contains(capitalA), "Character set must not contain our letter")
+        
+        // Use another method from it
+        let originalCs = invertedCs.inverted
+        
+        XCTAssertTrue(originalCs.contains(capitalA), "Character set must contain our letter")
+    }
+    
+    func testMutability_copyOnWrite() {
+        var firstCharacterSet = CharacterSet(charactersIn: "ABC")
+        XCTAssertTrue(firstCharacterSet.contains(capitalA), "Character set must contain our letter")
+        XCTAssertTrue(firstCharacterSet.contains(capitalB), "Character set must contain our letter")
+        XCTAssertTrue(firstCharacterSet.contains(capitalC), "Character set must contain our letter")
+        
+        // Make a 'copy' (just the struct)
+        var secondCharacterSet = firstCharacterSet
+        // first: ABC, second: ABC
+        
+        // Mutate first and verify that it has correct content
+        firstCharacterSet.remove(charactersIn: "A")
+        // first: BC, second: ABC
+        
+        XCTAssertTrue(!firstCharacterSet.contains(capitalA), "Character set must not contain our letter")
+        XCTAssertTrue(secondCharacterSet.contains(capitalA), "Copy should not have been mutated")
+        
+        // Make a 'copy' (just the struct) of the second set, mutate it
+        let thirdCharacterSet = secondCharacterSet
+        // first: BC, second: ABC, third: ABC
+        
+        secondCharacterSet.remove(charactersIn: "B")
+        // first: BC, second: AC, third: ABC
+        
+        XCTAssertTrue(firstCharacterSet.contains(capitalB), "Character set must contain our letter")
+        XCTAssertTrue(!secondCharacterSet.contains(capitalB), "Character set must not contain our letter")
+        XCTAssertTrue(thirdCharacterSet.contains(capitalB), "Character set must contain our letter")
+        
+        firstCharacterSet.remove(charactersIn: "C")
+        // first: B, second: AC, third: ABC
+        
+        XCTAssertTrue(!firstCharacterSet.contains(capitalC), "Character set must not contain our letter")
+        XCTAssertTrue(secondCharacterSet.contains(capitalC), "Character set must not contain our letter")
+        XCTAssertTrue(thirdCharacterSet.contains(capitalC), "Character set must contain our letter")
+    }
+
+    func testMutability_mutableCopyCrash() {
+        let cs = CharacterSet(charactersIn: "ABC")
+        (cs as NSCharacterSet).mutableCopy() // this should not crash
+    }
+    
+    func testMutability_SR_1782() {
+        var nonAlphanumeric = CharacterSet.alphanumerics.inverted
+        nonAlphanumeric.remove(charactersIn: " ") // this should not crash
+    }
+
+    func testRanges() {
+        // Simple range check
+        let asciiUppercase = CharacterSet(charactersIn: UnicodeScalar(0x41)!...UnicodeScalar(0x5A)!)
+        XCTAssertTrue(asciiUppercase.contains(UnicodeScalar(0x49)!))
+        XCTAssertTrue(asciiUppercase.contains(UnicodeScalar(0x5A)!))
+        XCTAssertTrue(asciiUppercase.contains(UnicodeScalar(0x41)!))
+        XCTAssertTrue(!asciiUppercase.contains(UnicodeScalar(0x5B)!))
+        
+        // Some string filtering tests
+        let asciiLowercase = CharacterSet(charactersIn: UnicodeScalar(0x61)!...UnicodeScalar(0x7B)!)
+        let testString = "helloHELLOhello"
+        let expected = "HELLO"
+        
+        let result = testString.trimmingCharacters(in: asciiLowercase)
+        XCTAssertEqual(result, expected)
+    }
+
+    func testClosedRanges_SR_2988() {
+      // "CharacterSet.insert(charactersIn: ClosedRange) crashes on a closed ClosedRange<UnicodeScalar> containing U+D7FF"
+      let problematicChar = UnicodeScalar(0xD7FF)!
+      let range = capitalA...problematicChar
+      var characters = CharacterSet(charactersIn: range) // this should not crash
+      XCTAssertTrue(characters.contains(problematicChar))
+      characters.remove(charactersIn: range) // this should not crash
+      XCTAssertTrue(!characters.contains(problematicChar))
+      characters.insert(charactersIn: range) // this should not crash
+      XCTAssertTrue(characters.contains(problematicChar))
+    }
+
+    func testUpperBoundaryInsert_SR_2988() {
+      // "CharacterSet.insert(_: Unicode.Scalar) crashes on U+D7FF"
+      let problematicChar = UnicodeScalar(0xD7FF)!
+      var characters = CharacterSet()
+      characters.insert(problematicChar) // this should not crash
+      XCTAssertTrue(characters.contains(problematicChar))
+      characters.remove(problematicChar) // this should not crash
+      XCTAssertTrue(!characters.contains(problematicChar))
+    }
+
+    func testInsertAndRemove() {
+        var asciiUppercase = CharacterSet(charactersIn: UnicodeScalar(0x41)!...UnicodeScalar(0x5A)!)
+        XCTAssertTrue(asciiUppercase.contains(UnicodeScalar(0x49)!))
+        XCTAssertTrue(asciiUppercase.contains(UnicodeScalar(0x5A)!))
+        XCTAssertTrue(asciiUppercase.contains(UnicodeScalar(0x41)!))
+        
+        asciiUppercase.remove(UnicodeScalar(0x49)!)
+        XCTAssertTrue(!asciiUppercase.contains(UnicodeScalar(0x49)!))
+        XCTAssertTrue(asciiUppercase.contains(UnicodeScalar(0x5A)!))
+        XCTAssertTrue(asciiUppercase.contains(UnicodeScalar(0x41)!))
+       
+
+        // Zero-length range
+        asciiUppercase.remove(charactersIn: UnicodeScalar(0x41)!..<UnicodeScalar(0x41)!)
+        XCTAssertTrue(asciiUppercase.contains(UnicodeScalar(0x41)!))
+
+        asciiUppercase.remove(charactersIn: UnicodeScalar(0x41)!..<UnicodeScalar(0x42)!)
+        XCTAssertTrue(!asciiUppercase.contains(UnicodeScalar(0x41)!))
+        
+        asciiUppercase.remove(charactersIn: "Z")
+        XCTAssertTrue(!asciiUppercase.contains(UnicodeScalar(0x5A)))
+    }
+    
+    func testBasics() {
+        
+        var result : [String] = []
+        
+        let string = "The quick, brown, fox jumps over the lazy dog - because, why not?"
+        var set = CharacterSet(charactersIn: ",-")
+        result = string.components(separatedBy: set)
+        XCTAssertEqual(5, result.count)
+        
+        set.remove(charactersIn: ",")
+        set.insert(charactersIn: " ")
+        result = string.components(separatedBy: set)
+        XCTAssertEqual(14, result.count)
+        
+        set.remove(" ".unicodeScalars.first!)
+        result = string.components(separatedBy: set)
+        XCTAssertEqual(2, result.count)
+    }
+
+    // MARK: -
+    func test_classForCoder() {
+        // confirm internal bridged impl types are not exposed to archival machinery
+        let cs = CharacterSet() as NSCharacterSet
+        
+        // Either of the following two are OK
+        let expectedImmutable: AnyClass = NSCharacterSet.self as AnyClass
+        let expectedMutable: AnyClass = NSMutableCharacterSet.self as AnyClass
+        
+        let actualClass: AnyClass = cs.classForCoder
+        let actualClassForCoder: AnyClass = cs.classForKeyedArchiver!
+        
+        XCTAssertTrue(actualClass == expectedImmutable || actualClass == expectedMutable)
+        XCTAssertTrue(actualClassForCoder == expectedImmutable || actualClassForCoder == expectedMutable)
+    }
+
+    func test_hashing() {
+        let a = CharacterSet(charactersIn: "ABC")
+        let b = CharacterSet(charactersIn: "CBA")
+        let c = CharacterSet(charactersIn: "bad")
+        let d = CharacterSet(charactersIn: "abd")
+        let e = CharacterSet.capitalizedLetters
+        let f = CharacterSet.lowercaseLetters
+        checkHashableGroups(
+            [[a, b], [c, d], [e], [f]],
+            // FIXME: CharacterSet delegates equality and hashing to
+            // CFCharacterSet, which uses unseeded hashing, so it's not
+            // complete.
+            allowIncompleteHashing: true)
+    }
+
+    func test_AnyHashableContainingCharacterSet() {
+        let values: [CharacterSet] = [
+            CharacterSet(charactersIn: "ABC"),
+            CharacterSet(charactersIn: "XYZ"),
+            CharacterSet(charactersIn: "XYZ")
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(CharacterSet.self, type(of: anyHashables[0].base))
+        expectEqual(CharacterSet.self, type(of: anyHashables[1].base))
+        expectEqual(CharacterSet.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableCreatedFromNSCharacterSet() {
+        let values: [NSCharacterSet] = [
+            NSCharacterSet(charactersIn: "ABC"),
+            NSCharacterSet(charactersIn: "XYZ"),
+            NSCharacterSet(charactersIn: "XYZ"),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(CharacterSet.self, type(of: anyHashables[0].base))
+        expectEqual(CharacterSet.self, type(of: anyHashables[1].base))
+        expectEqual(CharacterSet.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_superSet() {
+        let a = CharacterSet.letters.isSuperset(of: CharacterSet(charactersIn: "ab"))
+        XCTAssertTrue(a)
+    }
+
+    func test_union() {
+        let union = CharacterSet(charactersIn: "ab").union(CharacterSet(charactersIn: "cd"))
+        let expected = CharacterSet(charactersIn: "abcd")
+        XCTAssertEqual(expected, union)
+    }
+
+    func test_subtracting() {
+        let difference = CharacterSet(charactersIn: "abc").subtracting(CharacterSet(charactersIn: "b"))
+        let expected = CharacterSet(charactersIn: "ac")
+        XCTAssertEqual(expected, difference)
+    }
+
+    func test_subtractEmptySet() {
+        var mutableSet = CharacterSet(charactersIn: "abc")
+        let emptySet = CharacterSet()
+        mutableSet.subtract(emptySet)
+        let expected = CharacterSet(charactersIn: "abc")
+        XCTAssertEqual(expected, mutableSet)
+    }
+
+    func test_subtractNonEmptySet() {
+        var mutableSet = CharacterSet()
+        let nonEmptySet = CharacterSet(charactersIn: "abc")
+        mutableSet.subtract(nonEmptySet)
+        XCTAssertTrue(mutableSet.isEmpty)
+    }
+
+    func test_symmetricDifference() {
+        let symmetricDifference = CharacterSet(charactersIn: "ac").symmetricDifference(CharacterSet(charactersIn: "b"))
+        let expected = CharacterSet(charactersIn: "abc")
+        XCTAssertEqual(expected, symmetricDifference)
+    }
+
+    func test_hasMember() {
+        let contains = CharacterSet.letters.hasMember(inPlane: 1)
+        XCTAssertTrue(contains)
+    }
+
+    func test_bitmap() {
+        let bitmap = CharacterSet(charactersIn: "ab").bitmapRepresentation
+        XCTAssertEqual(0x6, bitmap[12])
+        XCTAssertEqual(8192, bitmap.count)
+    }
+    
+    func test_setOperationsOfEmptySet() {
+        // The following tests pass on these versions of the OS
+        if #available(OSX 10.12.3, iOS 10.3, watchOS 3.2, tvOS 10.2, *) {
+            let emptySet = CharacterSet()
+            let abcSet = CharacterSet(charactersIn: "abc")
+            
+            XCTAssertTrue(abcSet.isSuperset(of: emptySet))
+            XCTAssertTrue(emptySet.isSuperset(of: emptySet))
+            XCTAssertFalse(emptySet.isSuperset(of: abcSet))
+            
+            XCTAssertTrue(abcSet.isStrictSuperset(of: emptySet))
+            XCTAssertFalse(emptySet.isStrictSuperset(of: emptySet))
+            XCTAssertFalse(emptySet.isStrictSuperset(of: abcSet))
+            
+            XCTAssertTrue(emptySet.isSubset(of: abcSet))
+            XCTAssertTrue(emptySet.isSubset(of: emptySet))
+            XCTAssertFalse(abcSet.isSubset(of: emptySet))
+            
+            XCTAssertTrue(emptySet.isStrictSubset(of: abcSet))
+            XCTAssertFalse(emptySet.isStrictSubset(of: emptySet))
+            XCTAssertFalse(abcSet.isStrictSubset(of: emptySet))
+            XCTAssertFalse(abcSet.isStrictSubset(of: abcSet))
+            
+            XCTAssertEqual(emptySet, emptySet)
+            XCTAssertNotEqual(abcSet, emptySet)
+        }
+    }
+    
+    func test_moreSetOperations() {
+        // previous to these releases the subset methods improperly calculated strict subsets
+        // as of macOS 10.12.4, iOS 10.3, watchOS 3.2 and tvOS 10.2 CoreFoundation had a bug
+        // fix that corrected this behavior.
+        // TODO: figure out why the simulator is claiming this as a failure.
+        // https://bugs.swift.org/browse/SR-4457
+
+        /*  Disabled now: rdar://problem/31746923
+        #if os(macOS)
+            if #available(OSX 10.12.4, iOS 10.3, watchOS 3.2, tvOS 10.2, *) {
+                let abcSet = CharacterSet(charactersIn: "abc")
+                let abcdSet = CharacterSet(charactersIn: "abcd")
+                
+                XCTAssertEqual(abcSet, abcSet)
+                XCTAssertNotEqual(abcSet, abcdSet)
+                
+                XCTAssertTrue(abcSet.isStrictSubset(of:abcdSet))
+                XCTAssertFalse(abcdSet.isStrictSubset(of:abcSet))
+                XCTAssertTrue(abcdSet.isStrictSuperset(of:abcSet))
+                XCTAssertFalse(abcSet.isStrictSuperset(of:abcdSet))
+            }
+        #endif
+        */
+    }
+
+    func test_unconditionallyBridgeFromObjectiveC() {
+        XCTAssertEqual(CharacterSet(), CharacterSet._unconditionallyBridgeFromObjectiveC(nil))
+    }
+}
+

--- a/Darwin/Foundation-swiftoverlay-Tests/TestData.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestData.swift
@@ -1,0 +1,4142 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Dispatch
+import ObjectiveC
+import XCTest
+
+class TestData : XCTestCase {
+
+    class AllOnesImmutableData : NSData {
+        private var _length : Int
+        var _pointer : UnsafeMutableBufferPointer<UInt8>? {
+            willSet {
+                if let p = _pointer { free(p.baseAddress) }
+            }
+        }
+        
+        init(length : Int) {
+            _length = length
+            super.init()
+        }
+        
+        required init?(coder aDecoder: NSCoder) {
+            // Not tested
+            fatalError()
+        }
+        
+        deinit {
+            if let p = _pointer {
+                free(p.baseAddress)
+            }
+        }
+        
+        override var length : Int {
+            get {
+                return _length
+            }
+        }
+        
+        override var bytes : UnsafeRawPointer {
+            if let d = _pointer {
+                return UnsafeRawPointer(d.baseAddress!)
+            } else {
+                // Need to allocate the buffer now.
+                // It doesn't matter if the buffer is uniquely referenced or not here.
+                let buffer = malloc(length)
+                memset(buffer, 1, length)
+                let bytePtr = buffer!.bindMemory(to: UInt8.self, capacity: length)
+                let result = UnsafeMutableBufferPointer(start: bytePtr, count: length)
+                _pointer = result
+                return UnsafeRawPointer(result.baseAddress!)
+            }
+        }
+        
+        override func getBytes(_ buffer: UnsafeMutableRawPointer, length: Int) {
+            if let d = _pointer {
+                // Get the real data from the buffer
+                memmove(buffer, d.baseAddress, length)
+            } else {
+                // A more efficient implementation of getBytes in the case where no one has asked for our backing bytes
+                memset(buffer, 1, length)
+            }
+        }
+        
+        override func copy(with zone: NSZone? = nil) -> Any {
+            return self
+        }
+        
+        override func mutableCopy(with zone: NSZone? = nil) -> Any {
+            return AllOnesData(length: _length)
+        }
+    }
+    
+    
+    class AllOnesData : NSMutableData {
+        
+        private var _length : Int
+        var _pointer : UnsafeMutableBufferPointer<UInt8>? {
+            willSet {
+                if let p = _pointer { free(p.baseAddress) }
+            }
+        }
+        
+        override init(length : Int) {
+            _length = length
+            super.init()
+        }
+        
+        required init?(coder aDecoder: NSCoder) {
+            // Not tested
+            fatalError()
+        }
+        
+        deinit {
+            if let p = _pointer {
+                free(p.baseAddress)
+            }
+        }
+        
+        override var length : Int {
+            get {
+                return _length
+            }
+            set {
+                if let ptr = _pointer {
+                    // Copy the data to our new length buffer
+                    let newBuffer = malloc(newValue)!
+                    if newValue <= _length {
+                        memmove(newBuffer, ptr.baseAddress, newValue)
+                    } else if newValue > _length {
+                        memmove(newBuffer, ptr.baseAddress, _length)
+                        memset(newBuffer + _length, 1, newValue - _length)
+                    }
+                    let bytePtr = newBuffer.bindMemory(to: UInt8.self, capacity: newValue)
+                    _pointer = UnsafeMutableBufferPointer(start: bytePtr, count: newValue)
+                }
+                _length = newValue
+            }
+        }
+        
+        override var bytes : UnsafeRawPointer {
+            if let d = _pointer {
+                return UnsafeRawPointer(d.baseAddress!)
+            } else {
+                // Need to allocate the buffer now.
+                // It doesn't matter if the buffer is uniquely referenced or not here.
+                let buffer = malloc(length)
+                memset(buffer, 1, length)
+                let bytePtr = buffer!.bindMemory(to: UInt8.self, capacity: length)
+                let result = UnsafeMutableBufferPointer(start: bytePtr, count: length)
+                _pointer = result
+                return UnsafeRawPointer(result.baseAddress!)
+            }
+        }
+        
+        override var mutableBytes: UnsafeMutableRawPointer {
+            let newBufferLength = _length
+            let newBuffer = malloc(newBufferLength)
+            if let ptr = _pointer {
+                // Copy the existing data to the new box, then return its pointer
+                memmove(newBuffer, ptr.baseAddress, newBufferLength)
+            } else {
+                // Set new data to 1s
+                memset(newBuffer, 1, newBufferLength)
+            }
+            let bytePtr = newBuffer!.bindMemory(to: UInt8.self, capacity: newBufferLength)
+            let result = UnsafeMutableBufferPointer(start: bytePtr, count: newBufferLength)
+            _pointer = result
+            _length = newBufferLength
+            return UnsafeMutableRawPointer(result.baseAddress!)
+        }
+        
+        override func getBytes(_ buffer: UnsafeMutableRawPointer, length: Int) {
+            if let d = _pointer {
+                // Get the real data from the buffer
+                memmove(buffer, d.baseAddress, length)
+            } else {
+                // A more efficient implementation of getBytes in the case where no one has asked for our backing bytes
+                memset(buffer, 1, length)
+            }
+        }
+    }
+
+    var heldData: Data?
+    
+    // this holds a reference while applying the function which forces the internal ref type to become non-uniquely referenced
+    func holdReference(_ data: Data, apply: () -> Void) {
+        heldData = data
+        apply()
+        heldData = nil
+    }
+
+    // MARK: -
+    
+    // String of course has its own way to get data, but this way tests our own data struct
+    func dataFrom(_ string : String) -> Data {
+        // Create a Data out of those bytes
+        return string.utf8CString.withUnsafeBufferPointer { (ptr) in
+            ptr.baseAddress!.withMemoryRebound(to: UInt8.self, capacity: ptr.count) {
+                // Subtract 1 so we don't get the null terminator byte. This matches NSString behavior.
+                return Data(bytes: $0, count: ptr.count - 1)
+            }
+        }
+    }
+    
+    // MARK: -
+    
+    func testBasicConstruction() {
+
+        // Make sure that we were able to create some data
+        let hello = dataFrom("hello")
+        let helloLength = hello.count
+        XCTAssertEqual(hello[0], 0x68, "Unexpected first byte")
+        
+        let world = dataFrom(" world")
+        var helloWorld = hello
+        world.withUnsafeBytes {
+            helloWorld.append($0, count: world.count)
+        }
+                
+        XCTAssertEqual(hello[0], 0x68, "First byte should not have changed")
+        XCTAssertEqual(hello.count, helloLength, "Length of first data should not have changed")
+        XCTAssertEqual(helloWorld.count, hello.count + world.count, "The total length should include both buffers")
+    }
+    
+    func testInitializationWithArray() {
+        let data = Data(bytes: [1, 2, 3])
+        XCTAssertEqual(3, data.count)
+        
+        let data2 = Data(bytes: [1, 2, 3].filter { $0 >= 2 })
+        XCTAssertEqual(2, data2.count)
+        
+        let data3 = Data(bytes: [1, 2, 3, 4, 5][1..<3])
+        XCTAssertEqual(2, data3.count)
+    }
+
+    func testInitializationWithBufferPointer() {
+        let nilBuffer = UnsafeBufferPointer<UInt8>(start: nil, count: 0)
+        let data = Data(buffer: nilBuffer)
+        XCTAssertEqual(data, Data())
+
+        let validPointer = UnsafeMutablePointer<UInt8>.allocate(capacity: 2)
+        validPointer[0] = 0xCA
+        validPointer[1] = 0xFE
+        defer { validPointer.deallocate() }
+
+        let emptyBuffer = UnsafeBufferPointer<UInt8>(start: validPointer, count: 0)
+        let data2 = Data(buffer: emptyBuffer)
+        XCTAssertEqual(data2, Data())
+
+        let shortBuffer = UnsafeBufferPointer<UInt8>(start: validPointer, count: 1)
+        let data3 = Data(buffer: shortBuffer)
+        XCTAssertEqual(data3, Data([0xCA]))
+
+        let fullBuffer = UnsafeBufferPointer<UInt8>(start: validPointer, count: 2)
+        let data4 = Data(buffer: fullBuffer)
+        XCTAssertEqual(data4, Data([0xCA, 0xFE]))
+
+        let tuple: (UInt16, UInt16, UInt16, UInt16) = (0xFF, 0xFE, 0xFD, 0xFC)
+        withUnsafeBytes(of: tuple) {
+            // If necessary, port this to big-endian.
+            let tupleBuffer: UnsafeBufferPointer<UInt8> = $0.bindMemory(to: UInt8.self)
+            let data5 = Data(buffer: tupleBuffer)
+            XCTAssertEqual(data5, Data([0xFF, 0x00, 0xFE, 0x00, 0xFD, 0x00, 0xFC, 0x00]))
+        }
+    }
+
+    func testInitializationWithMutableBufferPointer() {
+        let nilBuffer = UnsafeMutableBufferPointer<UInt8>(start: nil, count: 0)
+        let data = Data(buffer: nilBuffer)
+        XCTAssertEqual(data, Data())
+
+        let validPointer = UnsafeMutablePointer<UInt8>.allocate(capacity: 2)
+        validPointer[0] = 0xCA
+        validPointer[1] = 0xFE
+        defer { validPointer.deallocate() }
+
+        let emptyBuffer = UnsafeMutableBufferPointer<UInt8>(start: validPointer, count: 0)
+        let data2 = Data(buffer: emptyBuffer)
+        XCTAssertEqual(data2, Data())
+
+        let shortBuffer = UnsafeMutableBufferPointer<UInt8>(start: validPointer, count: 1)
+        let data3 = Data(buffer: shortBuffer)
+        XCTAssertEqual(data3, Data([0xCA]))
+
+        let fullBuffer = UnsafeMutableBufferPointer<UInt8>(start: validPointer, count: 2)
+        let data4 = Data(buffer: fullBuffer)
+        XCTAssertEqual(data4, Data([0xCA, 0xFE]))
+
+        var tuple: (UInt16, UInt16, UInt16, UInt16) = (0xFF, 0xFE, 0xFD, 0xFC)
+        withUnsafeMutableBytes(of: &tuple) {
+            // If necessary, port this to big-endian.
+            let tupleBuffer: UnsafeMutableBufferPointer<UInt8> = $0.bindMemory(to: UInt8.self)
+            let data5 = Data(buffer: tupleBuffer)
+            XCTAssertEqual(data5, Data([0xFF, 0x00, 0xFE, 0x00, 0xFD, 0x00, 0xFC, 0x00]))
+        }
+    }
+    
+    func testMutableData() {
+        let hello = dataFrom("hello")
+        let helloLength = hello.count
+        XCTAssertEqual(hello[0], 0x68, "Unexpected first byte")
+
+        // Double the length
+        var mutatingHello = hello
+        mutatingHello.count *= 2
+        
+        XCTAssertEqual(hello.count, helloLength, "The length of the initial data should not have changed")
+        XCTAssertEqual(mutatingHello.count, helloLength * 2, "The length should have changed")
+        
+        // Get the underlying data for hello2
+        mutatingHello.withUnsafeMutableBytes { (bytes : UnsafeMutablePointer<UInt8>) in
+            XCTAssertEqual(bytes.pointee, 0x68, "First byte should be 0x68")
+            
+            // Mutate it
+            bytes.pointee = 0x67
+            XCTAssertEqual(bytes.pointee, 0x67, "First byte should be 0x67")
+
+            // Verify that the first data is still correct
+            XCTAssertEqual(hello[0], 0x68, "The first byte should still be 0x68")
+        }
+    }
+    
+    func testCustomData() {
+        let length = 5
+        let allOnesData = Data(referencing: AllOnesData(length: length))
+        XCTAssertEqual(1, allOnesData[0], "First byte of all 1s data should be 1")
+        
+        // Double the length
+        var allOnesCopyToMutate = allOnesData
+        allOnesCopyToMutate.count = allOnesData.count * 2
+        
+        XCTAssertEqual(allOnesData.count, length, "The length of the initial data should not have changed")
+        XCTAssertEqual(allOnesCopyToMutate.count, length * 2, "The length should have changed")
+        
+        // Force the second data to create its storage
+        allOnesCopyToMutate.withUnsafeMutableBytes { (bytes : UnsafeMutablePointer<UInt8>) in
+            XCTAssertEqual(bytes.pointee, 1, "First byte should be 1")
+            
+            // Mutate the second data
+            bytes.pointee = 0
+            XCTAssertEqual(bytes.pointee, 0, "First byte should be 0")
+            
+            // Verify that the first data is still 1
+            XCTAssertEqual(allOnesData[0], 1, "The first byte should still be 1")
+        }
+        
+    }
+    
+    func testBridgingDefault() {
+        let hello = dataFrom("hello")
+        // Convert from struct Data to NSData
+        if let s = NSString(data: hello, encoding: String.Encoding.utf8.rawValue) {
+            XCTAssertTrue(s.isEqual(to: "hello"), "The strings should be equal")
+        }
+        
+        // Convert from NSData to struct Data
+        let goodbye = dataFrom("goodbye")
+        if let resultingData = NSString(string: "goodbye").data(using: String.Encoding.utf8.rawValue) {
+            XCTAssertEqual(resultingData[0], goodbye[0], "First byte should be equal")
+        }
+    }
+    
+    func testBridgingMutable() {
+        // Create a mutable data
+        var helloWorld = dataFrom("hello")
+        helloWorld.append(dataFrom("world"))
+        
+        // Convert from struct Data to NSData
+        if let s = NSString(data: helloWorld, encoding: String.Encoding.utf8.rawValue) {
+            XCTAssertTrue(s.isEqual(to: "helloworld"), "The strings should be equal")
+        }
+
+    }
+    
+    func testBridgingCustom() {
+        // Let's use an AllOnesData with some Objective-C code
+        let allOnes = AllOnesData(length: 64)
+        
+        // Type-erased
+        let data = Data(referencing: allOnes)
+        
+        // Create a home for our test data
+        let dirPath = (NSTemporaryDirectory() as NSString).appendingPathComponent(NSUUID().uuidString)
+        try! FileManager.default.createDirectory(atPath: dirPath, withIntermediateDirectories: true, attributes: nil)
+        let filePath = (dirPath as NSString).appendingPathComponent("temp_file")
+        guard FileManager.default.createFile(atPath: filePath, contents: nil, attributes: nil) else { XCTAssertTrue(false, "Unable to create temporary file"); return}
+        guard let fh = FileHandle(forWritingAtPath: filePath) else { XCTAssertTrue(false, "Unable to open temporary file"); return }
+        defer { try! FileManager.default.removeItem(atPath: dirPath) }
+        
+        // Now use this data with some Objective-C code that takes NSData arguments
+        fh.write(data)
+        
+        // Get the data back
+        do {
+            let url = URL(fileURLWithPath: filePath)
+            let readData = try Data.init(contentsOf: url)
+            XCTAssertEqual(data.count, readData.count, "The length of the data is not the same")
+        } catch {
+            XCTAssertTrue(false, "Unable to read back data")
+            return
+        }
+    }
+    
+    func testEquality() {
+        let d1 = dataFrom("hello")
+        let d2 = dataFrom("hello")
+        
+        // Use == explicitly here to make sure we're calling the right methods
+        XCTAssertTrue(d1 == d2, "Data should be equal")
+    }
+    
+    func testDataInSet() {
+        let d1 = dataFrom("Hello")
+        let d2 = dataFrom("Hello")
+        let d3 = dataFrom("World")
+        
+        var s = Set<Data>()
+        s.insert(d1)
+        s.insert(d2)
+        s.insert(d3)
+        
+        XCTAssertEqual(s.count, 2, "Expected only two entries in the Set")
+    }
+    
+    func testReplaceSubrange() {
+        var hello = dataFrom("Hello")
+        let world = dataFrom("World")
+        
+        hello[0] = world[0]
+        XCTAssertEqual(hello[0], world[0])
+        
+        var goodbyeWorld = dataFrom("Hello World")
+        let goodbye = dataFrom("Goodbye")
+        let expected = dataFrom("Goodbye World")
+        
+        goodbyeWorld.replaceSubrange(0..<5, with: goodbye)
+        XCTAssertEqual(goodbyeWorld, expected)
+    }
+    
+    func testReplaceSubrange2() {
+        let hello = dataFrom("Hello")
+        let world = dataFrom(" World")
+        let goodbye = dataFrom("Goodbye")
+        let expected = dataFrom("Goodbye World")
+        
+        var mutateMe = hello
+        mutateMe.append(world)
+
+        if let found = mutateMe.range(of: hello) {
+            mutateMe.replaceSubrange(found, with: goodbye)
+        }
+        XCTAssertEqual(mutateMe, expected)
+    }
+    
+    func testReplaceSubrange3() {
+        // The expected result
+        let expectedBytes : [UInt8] = [1, 2, 9, 10, 11, 12, 13]
+        let expected = expectedBytes.withUnsafeBufferPointer {
+            return Data(buffer: $0)
+        }
+        
+        // The data we'll mutate
+        let someBytes : [UInt8] = [1, 2, 3, 4, 5]
+        var a = someBytes.withUnsafeBufferPointer {
+            return Data(buffer: $0)
+        }
+        
+        // The bytes we'll insert
+        let b : [UInt8] = [9, 10, 11, 12, 13]
+        b.withUnsafeBufferPointer {
+            a.replaceSubrange(2..<5, with: $0)
+        }
+        XCTAssertEqual(expected, a)
+    }
+    
+    func testReplaceSubrange4() {
+        let expectedBytes : [UInt8] = [1, 2, 9, 10, 11, 12, 13]
+        let expected = Data(bytes: expectedBytes)
+        
+        // The data we'll mutate
+        let someBytes : [UInt8] = [1, 2, 3, 4, 5]
+        var a = Data(bytes: someBytes)
+        
+        // The bytes we'll insert
+        let b : [UInt8] = [9, 10, 11, 12, 13]
+        a.replaceSubrange(2..<5, with: b)
+        XCTAssertEqual(expected, a)
+    }
+    
+    func testReplaceSubrange5() {
+        var d = Data(bytes: [1, 2, 3])
+        d.replaceSubrange(0..<0, with: [4])
+        XCTAssertEqual(Data(bytes: [4, 1, 2, 3]), d)
+        
+        d.replaceSubrange(0..<4, with: [9])
+        XCTAssertEqual(Data(bytes: [9]), d)
+        
+        d.replaceSubrange(0..<d.count, with: [])
+        XCTAssertEqual(Data(), d)
+        
+        d.replaceSubrange(0..<0, with: [1, 2, 3, 4])
+        XCTAssertEqual(Data(bytes: [1, 2, 3, 4]), d)
+        
+        d.replaceSubrange(1..<3, with: [9, 8])
+        XCTAssertEqual(Data(bytes: [1, 9, 8, 4]), d)
+        
+        d.replaceSubrange(d.count..<d.count, with: [5])
+        XCTAssertEqual(Data(bytes: [1, 9, 8, 4, 5]), d)
+    }
+
+    func testRange() {
+        let helloWorld = dataFrom("Hello World")
+        let goodbye = dataFrom("Goodbye")
+        let hello = dataFrom("Hello")
+
+        do {
+            let found = helloWorld.range(of: goodbye)
+            XCTAssertNil(found)
+        }
+
+        do {
+            let found = helloWorld.range(of: goodbye, options: .anchored)
+            XCTAssertNil(found)
+        }
+
+        do {
+            let found = helloWorld.range(of: hello, in: 7..<helloWorld.count)
+            XCTAssertNil(found)
+        }
+    }
+    
+    func testInsertData() {
+        let hello = dataFrom("Hello")
+        let world = dataFrom(" World")
+        let expected = dataFrom("Hello World")
+        var helloWorld = dataFrom("")
+        
+        helloWorld.replaceSubrange(0..<0, with: world)
+        helloWorld.replaceSubrange(0..<0, with: hello)
+        
+        XCTAssertEqual(helloWorld, expected)
+    }
+    
+    func testLoops() {
+        let hello = dataFrom("Hello")
+        var count = 0
+        for _ in hello {
+            count += 1
+        }
+        XCTAssertEqual(count, 5)
+    }
+    
+    func testGenericAlgorithms() {
+        let hello = dataFrom("Hello World")
+        
+        let isCapital = { (byte : UInt8) in byte >= 65 && byte <= 90 }
+        
+        let allCaps = hello.filter(isCapital)
+        XCTAssertEqual(allCaps.count, 2)
+        
+        let capCount = hello.reduce(0) { isCapital($1) ? $0 + 1 : $0 }
+        XCTAssertEqual(capCount, 2)
+        
+        let allLower = hello.map { isCapital($0) ? $0 + 31 : $0 }
+        XCTAssertEqual(allLower.count, hello.count)
+    }
+    
+    func testCustomDeallocator() {
+        var deallocatorCalled = false
+        
+        // Scope the data to a block to control lifecycle
+        autoreleasepool {
+            let buffer = malloc(16)!
+            let bytePtr = buffer.bindMemory(to: UInt8.self, capacity: 16)
+            var data = Data(bytesNoCopy: bytePtr, count: 16, deallocator: .custom({ (ptr, size) in
+                deallocatorCalled = true
+                free(UnsafeMutableRawPointer(ptr))
+            }))
+            // Use the data
+            data[0] = 1
+         }
+        
+        XCTAssertTrue(deallocatorCalled, "Custom deallocator was never called")
+    }
+    
+    func testCopyBytes() {
+        let c = 10
+        let underlyingBuffer = malloc(c * MemoryLayout<UInt16>.stride)!
+        let u16Ptr = underlyingBuffer.bindMemory(to: UInt16.self, capacity: c)
+        let buffer = UnsafeMutableBufferPointer<UInt16>(start: u16Ptr, count: c)
+        
+        buffer[0] = 0
+        buffer[1] = 0
+        
+        var data = Data(capacity: c * MemoryLayout<UInt16>.stride)
+        data.resetBytes(in: 0..<c * MemoryLayout<UInt16>.stride)
+        data[0] = 0xFF
+        data[1] = 0xFF
+        let copiedCount = data.copyBytes(to: buffer)
+        XCTAssertEqual(copiedCount, c * MemoryLayout<UInt16>.stride)
+        
+        XCTAssertEqual(buffer[0], 0xFFFF)
+        free(underlyingBuffer)
+    }
+    
+    func testCopyBytes_undersized() {
+        let a : [UInt8] = [1, 2, 3, 4, 5]
+        var data = a.withUnsafeBufferPointer {
+            return Data(buffer: $0)
+        }
+        let expectedSize = MemoryLayout<UInt8>.stride * a.count
+        XCTAssertEqual(expectedSize, data.count)
+        
+        let underlyingBuffer = unsafeBitCast(malloc(expectedSize - 1)!, to: UnsafeMutablePointer<UInt8>.self)
+        let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer, count: expectedSize - 1)
+        
+        // We should only copy in enough bytes that can fit in the buffer
+        let copiedCount = data.copyBytes(to: buffer)
+        XCTAssertEqual(expectedSize - 1, copiedCount)
+        
+        var index = 0
+        for v in a[0..<expectedSize-1] {
+            XCTAssertEqual(v, buffer[index])
+            index += 1
+        }
+        
+        free(underlyingBuffer)
+    }
+
+    func testCopyBytes_oversized() {
+        let a : [Int32] = [1, 0, 1, 0, 1]
+        var data = a.withUnsafeBufferPointer {
+            return Data(buffer: $0)
+        }
+        let expectedSize = MemoryLayout<Int32>.stride * a.count
+        XCTAssertEqual(expectedSize, data.count)
+        
+        let underlyingBuffer = unsafeBitCast(malloc(expectedSize + 1)!, to: UnsafeMutablePointer<UInt8>.self)
+        let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer, count: expectedSize + 1)
+        
+        let copiedCount = data.copyBytes(to: buffer)
+        XCTAssertEqual(expectedSize, copiedCount)
+
+        free(underlyingBuffer)
+    }
+
+    func testCopyBytes_ranges() {
+        
+        do {
+            // Equal sized buffer, data
+            let a : [UInt8] = [1, 2, 3, 4, 5]
+            var data = a.withUnsafeBufferPointer {
+                return Data(buffer: $0)
+            }
+            
+            let underlyingBuffer = unsafeBitCast(malloc(data.count)!, to: UnsafeMutablePointer<UInt8>.self)
+            let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer, count: data.count)
+            
+            var copiedCount : Int
+            
+            copiedCount = data.copyBytes(to: buffer, from: 0..<0)
+            XCTAssertEqual(0, copiedCount)
+            
+            copiedCount = data.copyBytes(to: buffer, from: 1..<1)
+            XCTAssertEqual(0, copiedCount)
+            
+            copiedCount = data.copyBytes(to: buffer, from: 0..<3)
+            XCTAssertEqual((0..<3).count, copiedCount)
+            
+            var index = 0
+            for v in a[0..<3] {
+                XCTAssertEqual(v, buffer[index])
+                index += 1
+            }
+            free(underlyingBuffer)
+        }
+        
+        do {
+            // Larger buffer than data
+            let a : [UInt8] = [1, 2, 3, 4]
+            let data = a.withUnsafeBufferPointer {
+                return Data(buffer: $0)
+            }
+            
+            let underlyingBuffer = unsafeBitCast(malloc(10)!, to: UnsafeMutablePointer<UInt8>.self)
+            let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer, count: 10)
+            
+            var copiedCount : Int
+            
+            copiedCount = data.copyBytes(to: buffer, from: 0..<3)
+            XCTAssertEqual((0..<3).count, copiedCount)
+            
+            var index = 0
+            for v in a[0..<3] {
+                XCTAssertEqual(v, buffer[index])
+                index += 1
+            }
+            free(underlyingBuffer)
+        }
+        
+        do {
+            // Larger data than buffer
+            let a : [UInt8] = [1, 2, 3, 4, 5, 6]
+            let data = a.withUnsafeBufferPointer {
+                return Data(buffer: $0)
+            }
+            
+            let underlyingBuffer = unsafeBitCast(malloc(4)!, to: UnsafeMutablePointer<UInt8>.self)
+            let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer, count: 4)
+            
+            var copiedCount : Int
+            
+            copiedCount = data.copyBytes(to: buffer, from: 0..<data.index(before: data.endIndex))
+            XCTAssertEqual(4, copiedCount)
+            
+            var index = 0
+            for v in a[0..<4] {
+                XCTAssertEqual(v, buffer[index])
+                index += 1
+            }
+            free(underlyingBuffer)
+
+        }
+    }
+
+    func test_base64Data_small() {
+        let data = "Hello World".data(using: .utf8)!
+        let base64 = data.base64EncodedString()
+        XCTAssertEqual("SGVsbG8gV29ybGQ=", base64, "trivial base64 conversion should work")
+    }
+
+    func test_base64Data_medium() {
+        let data = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut at tincidunt arcu. Suspendisse nec sodales erat, sit amet imperdiet ipsum. Etiam sed ornare felis. Nunc mauris turpis, bibendum non lectus quis, malesuada placerat turpis. Nam adipiscing non massa et semper. Nulla convallis semper bibendum. Aliquam dictum nulla cursus mi ultricies, at tincidunt mi sagittis. Nulla faucibus at dui quis sodales. Morbi rutrum, dui id ultrices venenatis, arcu urna egestas felis, vel suscipit mauris arcu quis risus. Nunc venenatis ligula at orci tristique, et mattis purus pulvinar. Etiam ultricies est odio. Nunc eleifend malesuada justo, nec euismod sem ultrices quis. Etiam nec nibh sit amet lorem faucibus dapibus quis nec leo. Praesent sit amet mauris vel lacus hendrerit porta mollis consectetur mi. Donec eget tortor dui. Morbi imperdiet, arcu sit amet elementum interdum, quam nisl tempor quam, vitae feugiat augue purus sed lacus. In ac urna adipiscing purus venenatis volutpat vel et metus. Nullam nec auctor quam. Phasellus porttitor felis ac nibh gravida suscipit tempus at ante. Nunc pellentesque iaculis sapien a mattis. Aenean eleifend dolor non nunc laoreet, non dictum massa aliquam. Aenean quis turpis augue. Praesent augue lectus, mollis nec elementum eu, dignissim at velit. Ut congue neque id ullamcorper pellentesque. Maecenas euismod in elit eu vehicula. Nullam tristique dui nulla, nec convallis metus suscipit eget. Cras semper augue nec cursus blandit. Nulla rhoncus et odio quis blandit. Praesent lobortis dignissim velit ut pulvinar. Duis interdum quam adipiscing dolor semper semper. Nunc bibendum convallis dui, eget mollis magna hendrerit et. Morbi facilisis, augue eu fringilla convallis, mauris est cursus dolor, eu posuere odio nunc quis orci. Ut eu justo sem. Phasellus ut erat rhoncus, faucibus arcu vitae, vulputate erat. Aliquam nec magna viverra, interdum est vitae, rhoncus sapien. Duis tincidunt tempor ipsum ut dapibus. Nullam commodo varius metus, sed sollicitudin eros. Etiam nec odio et dui tempor blandit posuere.".data(using: .utf8)!
+        let base64 = data.base64EncodedString()
+        XCTAssertEqual("TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gVXQgYXQgdGluY2lkdW50IGFyY3UuIFN1c3BlbmRpc3NlIG5lYyBzb2RhbGVzIGVyYXQsIHNpdCBhbWV0IGltcGVyZGlldCBpcHN1bS4gRXRpYW0gc2VkIG9ybmFyZSBmZWxpcy4gTnVuYyBtYXVyaXMgdHVycGlzLCBiaWJlbmR1bSBub24gbGVjdHVzIHF1aXMsIG1hbGVzdWFkYSBwbGFjZXJhdCB0dXJwaXMuIE5hbSBhZGlwaXNjaW5nIG5vbiBtYXNzYSBldCBzZW1wZXIuIE51bGxhIGNvbnZhbGxpcyBzZW1wZXIgYmliZW5kdW0uIEFsaXF1YW0gZGljdHVtIG51bGxhIGN1cnN1cyBtaSB1bHRyaWNpZXMsIGF0IHRpbmNpZHVudCBtaSBzYWdpdHRpcy4gTnVsbGEgZmF1Y2lidXMgYXQgZHVpIHF1aXMgc29kYWxlcy4gTW9yYmkgcnV0cnVtLCBkdWkgaWQgdWx0cmljZXMgdmVuZW5hdGlzLCBhcmN1IHVybmEgZWdlc3RhcyBmZWxpcywgdmVsIHN1c2NpcGl0IG1hdXJpcyBhcmN1IHF1aXMgcmlzdXMuIE51bmMgdmVuZW5hdGlzIGxpZ3VsYSBhdCBvcmNpIHRyaXN0aXF1ZSwgZXQgbWF0dGlzIHB1cnVzIHB1bHZpbmFyLiBFdGlhbSB1bHRyaWNpZXMgZXN0IG9kaW8uIE51bmMgZWxlaWZlbmQgbWFsZXN1YWRhIGp1c3RvLCBuZWMgZXVpc21vZCBzZW0gdWx0cmljZXMgcXVpcy4gRXRpYW0gbmVjIG5pYmggc2l0IGFtZXQgbG9yZW0gZmF1Y2lidXMgZGFwaWJ1cyBxdWlzIG5lYyBsZW8uIFByYWVzZW50IHNpdCBhbWV0IG1hdXJpcyB2ZWwgbGFjdXMgaGVuZHJlcml0IHBvcnRhIG1vbGxpcyBjb25zZWN0ZXR1ciBtaS4gRG9uZWMgZWdldCB0b3J0b3IgZHVpLiBNb3JiaSBpbXBlcmRpZXQsIGFyY3Ugc2l0IGFtZXQgZWxlbWVudHVtIGludGVyZHVtLCBxdWFtIG5pc2wgdGVtcG9yIHF1YW0sIHZpdGFlIGZldWdpYXQgYXVndWUgcHVydXMgc2VkIGxhY3VzLiBJbiBhYyB1cm5hIGFkaXBpc2NpbmcgcHVydXMgdmVuZW5hdGlzIHZvbHV0cGF0IHZlbCBldCBtZXR1cy4gTnVsbGFtIG5lYyBhdWN0b3IgcXVhbS4gUGhhc2VsbHVzIHBvcnR0aXRvciBmZWxpcyBhYyBuaWJoIGdyYXZpZGEgc3VzY2lwaXQgdGVtcHVzIGF0IGFudGUuIE51bmMgcGVsbGVudGVzcXVlIGlhY3VsaXMgc2FwaWVuIGEgbWF0dGlzLiBBZW5lYW4gZWxlaWZlbmQgZG9sb3Igbm9uIG51bmMgbGFvcmVldCwgbm9uIGRpY3R1bSBtYXNzYSBhbGlxdWFtLiBBZW5lYW4gcXVpcyB0dXJwaXMgYXVndWUuIFByYWVzZW50IGF1Z3VlIGxlY3R1cywgbW9sbGlzIG5lYyBlbGVtZW50dW0gZXUsIGRpZ25pc3NpbSBhdCB2ZWxpdC4gVXQgY29uZ3VlIG5lcXVlIGlkIHVsbGFtY29ycGVyIHBlbGxlbnRlc3F1ZS4gTWFlY2VuYXMgZXVpc21vZCBpbiBlbGl0IGV1IHZlaGljdWxhLiBOdWxsYW0gdHJpc3RpcXVlIGR1aSBudWxsYSwgbmVjIGNvbnZhbGxpcyBtZXR1cyBzdXNjaXBpdCBlZ2V0LiBDcmFzIHNlbXBlciBhdWd1ZSBuZWMgY3Vyc3VzIGJsYW5kaXQuIE51bGxhIHJob25jdXMgZXQgb2RpbyBxdWlzIGJsYW5kaXQuIFByYWVzZW50IGxvYm9ydGlzIGRpZ25pc3NpbSB2ZWxpdCB1dCBwdWx2aW5hci4gRHVpcyBpbnRlcmR1bSBxdWFtIGFkaXBpc2NpbmcgZG9sb3Igc2VtcGVyIHNlbXBlci4gTnVuYyBiaWJlbmR1bSBjb252YWxsaXMgZHVpLCBlZ2V0IG1vbGxpcyBtYWduYSBoZW5kcmVyaXQgZXQuIE1vcmJpIGZhY2lsaXNpcywgYXVndWUgZXUgZnJpbmdpbGxhIGNvbnZhbGxpcywgbWF1cmlzIGVzdCBjdXJzdXMgZG9sb3IsIGV1IHBvc3VlcmUgb2RpbyBudW5jIHF1aXMgb3JjaS4gVXQgZXUganVzdG8gc2VtLiBQaGFzZWxsdXMgdXQgZXJhdCByaG9uY3VzLCBmYXVjaWJ1cyBhcmN1IHZpdGFlLCB2dWxwdXRhdGUgZXJhdC4gQWxpcXVhbSBuZWMgbWFnbmEgdml2ZXJyYSwgaW50ZXJkdW0gZXN0IHZpdGFlLCByaG9uY3VzIHNhcGllbi4gRHVpcyB0aW5jaWR1bnQgdGVtcG9yIGlwc3VtIHV0IGRhcGlidXMuIE51bGxhbSBjb21tb2RvIHZhcml1cyBtZXR1cywgc2VkIHNvbGxpY2l0dWRpbiBlcm9zLiBFdGlhbSBuZWMgb2RpbyBldCBkdWkgdGVtcG9yIGJsYW5kaXQgcG9zdWVyZS4=", base64, "medium base64 conversion should work")
+    }
+
+    func test_discontiguousEnumerateBytes() {
+        let dataToEncode = "Hello World".data(using: .utf8)!
+
+        let subdata1 = dataToEncode.withUnsafeBytes { bytes in
+            return DispatchData(bytes: UnsafeBufferPointer(start: bytes, count: dataToEncode.count))
+        }
+        let subdata2 = dataToEncode.withUnsafeBytes { bytes in
+            return DispatchData(bytes: UnsafeBufferPointer(start: bytes, count: dataToEncode.count))
+        }
+        var data = subdata1
+        data.append(subdata2)
+
+        var numChunks = 0
+        var offsets = [Int]()
+        data.enumerateBytes() { buffer, offset, stop in
+            numChunks += 1
+            offsets.append(offset)
+        }
+
+        XCTAssertEqual(2, numChunks, "composing two dispatch_data should enumerate as structural data as 2 chunks")
+        XCTAssertEqual(0, offsets[0], "composing two dispatch_data should enumerate as structural data with the first offset as the location of the region")
+        XCTAssertEqual(dataToEncode.count, offsets[1], "composing two dispatch_data should enumerate as structural data with the first offset as the location of the region")
+    }
+
+    func test_basicReadWrite() {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent("testfile")
+
+        let count = 1 << 24
+        let randomMemory = malloc(count)!
+        let ptr = randomMemory.bindMemory(to: UInt8.self, capacity: count)
+        let data = Data(bytesNoCopy: ptr, count: count, deallocator: .free)
+        do {
+            try data.write(to: url)
+            let readData = try Data(contentsOf: url)
+            XCTAssertEqual(data, readData)
+        } catch {
+            XCTAssertTrue(false, "Should not have thrown")
+        }
+        
+        do {
+            try FileManager.default.removeItem(at: url)
+        } catch {
+            // ignore
+        }
+    }
+
+    func test_writeFailure() {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent("testfile")
+        
+        let data = Data()
+        do {
+            try data.write(to: url)
+        } catch let error as NSError {
+            print(error)
+            XCTAssertTrue(false, "Should not have thrown")
+        }
+        
+        do {
+            try data.write(to: url, options: [.withoutOverwriting])
+            XCTAssertTrue(false, "Should have thrown")
+        } catch let error as NSError {
+            XCTAssertEqual(error.code, NSFileWriteFileExistsError)
+        }
+        
+        do {
+            try FileManager.default.removeItem(at: url)
+        } catch {
+            // ignore
+        }
+        
+        // Make sure clearing the error condition allows the write to succeed
+        do {
+            try data.write(to: url, options: [.withoutOverwriting])
+        } catch {
+            XCTAssertTrue(false, "Should not have thrown")
+        }
+        
+        do {
+            try FileManager.default.removeItem(at: url)
+        } catch {
+            // ignore
+        }
+    }
+    
+    func test_genericBuffers() {
+        let a : [Int32] = [1, 0, 1, 0, 1]
+        var data = a.withUnsafeBufferPointer {
+            return Data(buffer: $0)
+        }
+        
+        var expectedSize = MemoryLayout<Int32>.stride * a.count
+        XCTAssertEqual(expectedSize, data.count)
+        
+        [false, true].withUnsafeBufferPointer {
+            data.append($0)
+        }
+        
+        expectedSize += MemoryLayout<Bool>.stride * 2
+        XCTAssertEqual(expectedSize, data.count)
+        
+        let underlyingBuffer = unsafeBitCast(malloc(expectedSize)!, to: UnsafeMutablePointer<UInt8>.self)
+        
+        let buffer = UnsafeMutableBufferPointer(start: underlyingBuffer, count: expectedSize)
+        let copiedCount = data.copyBytes(to: buffer)
+        XCTAssertEqual(copiedCount, expectedSize)
+        
+        free(underlyingBuffer)
+    }
+
+    func test_basicDataMutation() {
+        let object = ImmutableDataVerifier()
+
+        object.verifier.reset()
+        var data = object as Data
+        XCTAssertTrue(object.verifier.wasCopied)
+        XCTAssertFalse(object.verifier.wasMutableCopied, "Expected an invocation to mutableCopy")
+
+        object.verifier.reset()
+        XCTAssertTrue(data.count == object.length)
+        XCTAssertFalse(object.verifier.wasCopied, "Expected an invocation to copy")
+    }
+
+    func test_basicMutableDataMutation() {
+        let object = MutableDataVerifier()
+        
+        object.verifier.reset()
+        var data = object as Data
+        XCTAssertTrue(object.verifier.wasCopied)
+        XCTAssertFalse(object.verifier.wasMutableCopied, "Expected an invocation to mutableCopy")
+        
+        object.verifier.reset()
+        XCTAssertTrue(data.count == object.length)
+        XCTAssertFalse(object.verifier.wasCopied, "Expected an invocation to copy")
+    }
+
+    func test_passing() {
+        let object = ImmutableDataVerifier()
+        let object_notPeepholed = object as Data
+        takesData(object_notPeepholed)
+        XCTAssertTrue(object.verifier.wasCopied)
+    }
+
+    func test_passing_peepholed() {
+        let object = ImmutableDataVerifier()
+        takesData(object as Data)
+        XCTAssertFalse(object.verifier.wasCopied) // because of the peephole
+    }
+    
+    // intentionally structured so sizeof() != strideof()
+    struct MyStruct {
+        var time: UInt64
+        let x: UInt32
+        let y: UInt32
+        let z: UInt32
+        init() {
+            time = 0
+            x = 1
+            y = 2
+            z = 3
+        }
+    }
+    
+    func test_bufferSizeCalculation() {
+        // Make sure that Data is correctly using strideof instead of sizeof.
+        // n.b. if sizeof(MyStruct) == strideof(MyStruct), this test is not as useful as it could be
+        
+        // init
+        let stuff = [MyStruct(), MyStruct(), MyStruct()]
+        var data = stuff.withUnsafeBufferPointer {
+            return Data(buffer: $0)
+        }
+        
+        XCTAssertEqual(data.count, MemoryLayout<MyStruct>.stride * 3)
+        
+        
+        // append
+        stuff.withUnsafeBufferPointer {
+            data.append($0)
+        }
+        
+        XCTAssertEqual(data.count, MemoryLayout<MyStruct>.stride * 6)
+
+        // copyBytes
+        do {
+            // equal size
+            let underlyingBuffer = malloc(6 * MemoryLayout<MyStruct>.stride)!
+            defer { free(underlyingBuffer) }
+
+            let ptr = underlyingBuffer.bindMemory(to: MyStruct.self, capacity: 6)
+            let buffer = UnsafeMutableBufferPointer<MyStruct>(start: ptr, count: 6)
+            
+            let byteCount = data.copyBytes(to: buffer)
+            XCTAssertEqual(6 * MemoryLayout<MyStruct>.stride, byteCount)
+        }
+        
+        do {
+            // undersized
+            let underlyingBuffer = malloc(3 * MemoryLayout<MyStruct>.stride)!
+            defer { free(underlyingBuffer) }
+
+            let ptr = underlyingBuffer.bindMemory(to: MyStruct.self, capacity: 3)
+            let buffer = UnsafeMutableBufferPointer<MyStruct>(start: ptr, count: 3)
+            
+            let byteCount = data.copyBytes(to: buffer)
+            XCTAssertEqual(3 * MemoryLayout<MyStruct>.stride, byteCount)
+        }
+        
+        do {
+            // oversized
+            let underlyingBuffer = malloc(12 * MemoryLayout<MyStruct>.stride)!
+            defer { free(underlyingBuffer) }
+            
+            let ptr = underlyingBuffer.bindMemory(to: MyStruct.self, capacity: 6)
+            let buffer = UnsafeMutableBufferPointer<MyStruct>(start: ptr, count: 6)
+            
+            let byteCount = data.copyBytes(to: buffer)
+            XCTAssertEqual(6 * MemoryLayout<MyStruct>.stride, byteCount)
+        }
+    }
+    
+
+    // MARK: -
+    func test_classForCoder() {
+        // confirm internal bridged impl types are not exposed to archival machinery
+        let d = Data() as NSData
+        let expected: AnyClass = NSData.self as AnyClass
+        XCTAssertTrue(d.classForCoder == expected)
+        XCTAssertTrue(d.classForKeyedArchiver == expected)
+    }
+
+    func test_AnyHashableContainingData() {
+        let values: [Data] = [
+            Data(base64Encoded: "AAAA")!,
+            Data(base64Encoded: "AAAB")!,
+            Data(base64Encoded: "AAAB")!,
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(Data.self, type(of: anyHashables[0].base))
+        expectEqual(Data.self, type(of: anyHashables[1].base))
+        expectEqual(Data.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableCreatedFromNSData() {
+        let values: [NSData] = [
+            NSData(base64Encoded: "AAAA")!,
+            NSData(base64Encoded: "AAAB")!,
+            NSData(base64Encoded: "AAAB")!,
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(Data.self, type(of: anyHashables[0].base))
+        expectEqual(Data.self, type(of: anyHashables[1].base))
+        expectEqual(Data.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_noCopyBehavior() {
+        let ptr = UnsafeMutableRawPointer.allocate(byteCount: 17, alignment: 1)
+        
+        var deallocated = false
+        autoreleasepool {
+            let data = Data(bytesNoCopy: ptr, count: 17, deallocator: .custom({ (bytes, length) in
+                deallocated = true
+                ptr.deallocate()
+            }))
+            XCTAssertFalse(deallocated)
+            let equal = data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> Bool in
+                return ptr == UnsafeMutableRawPointer(mutating: bytes)
+            }
+            
+            XCTAssertTrue(equal)
+        }
+        XCTAssertTrue(deallocated)
+    }
+
+    func test_doubleDeallocation() {
+        let data = "12345679".data(using: .utf8)!
+        let len = data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> Int in
+            let slice = Data(bytesNoCopy: UnsafeMutablePointer(mutating: bytes), count: 1, deallocator: .none)
+            return slice.count
+        }
+        XCTAssertEqual(len, 1)
+    }
+
+    func test_repeatingValueInitialization() {
+        var d = Data(repeating: 0x01, count: 3)
+        let elements = repeatElement(UInt8(0x02), count: 3) // ensure we fall into the sequence case
+        d.append(contentsOf: elements)
+
+        XCTAssertEqual(d[0], 0x01)
+        XCTAssertEqual(d[1], 0x01)
+        XCTAssertEqual(d[2], 0x01)
+
+        XCTAssertEqual(d[3], 0x02)
+        XCTAssertEqual(d[4], 0x02)
+        XCTAssertEqual(d[5], 0x02)
+    }
+
+    func test_rangeSlice() {
+        var a: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7]
+        var d = Data(bytes: a)
+        for i in 0..<d.count {
+            for j in i..<d.count {
+                let slice = d[i..<j]
+                XCTAssertEqual(slice.count, j - i, "where index range is \(i)..<\(j)")
+                XCTAssertEqual(slice.map { $0 }, a[i..<j].map { $0 }, "where index range is \(i)..<\(j)")
+                XCTAssertEqual(slice.startIndex, i, "where index range is \(i)..<\(j)")
+                XCTAssertEqual(slice.endIndex, j, "where index range is \(i)..<\(j)")
+                for n in slice.startIndex..<slice.endIndex {
+                    let p = slice[n]
+                    let q = a[n]
+                    XCTAssertEqual(p, q, "where index range is \(i)..<\(j) at index \(n)")
+                }
+            }
+        }
+    }
+
+    func test_rangeZoo() {
+        let r1: Range = 0..<1
+        let r2: Range = 0..<1
+        let r3 = ClosedRange(0..<1)
+        let r4 = ClosedRange(0..<1)
+
+        let data = Data(bytes: [8, 1, 2, 3, 4])
+        let slice1: Data = data[r1]
+        let slice2: Data = data[r2]
+        let slice3: Data = data[r3]
+        let slice4: Data = data[r4]
+        XCTAssertEqual(slice1[0], 8)
+        XCTAssertEqual(slice2[0], 8)
+        XCTAssertEqual(slice3[0], 8)
+        XCTAssertEqual(slice4[0], 8)
+    }
+
+    func test_rangeOfDataProtocol() {
+        // https://bugs.swift.org/browse/SR-10689
+        guard #available(macOS 11, iOS 14, watchOS 7, tvOS 14, *) else { return }
+
+        let base = Data([0x00, 0x01, 0x02, 0x03, 0x00, 0x01, 0x02, 0x03,
+                         0x00, 0x01, 0x02, 0x03, 0x00, 0x01, 0x02, 0x03])
+        let subdata = base[10..<13] // [0x02, 0x03, 0x00]
+        let oneByte = base[14..<15] // [0x02]
+        
+        do { // firstRange(of:in:)
+            func assertFirstRange(_ data: Data, _ fragment: Data, range: ClosedRange<Int>? = nil,
+                                  expectedStartIndex: Int?,
+                                  _ message: @autoclosure () -> String = "",
+                                  file: StaticString = #file, line: UInt = #line) {
+                if let index = expectedStartIndex {
+                    let expectedRange: Range<Int> = index..<(index + fragment.count)
+                    if let someRange = range {
+                        XCTAssertEqual(data.firstRange(of: fragment, in: someRange), expectedRange, message(), file: file, line: line)
+                    } else {
+                        XCTAssertEqual(data.firstRange(of: fragment), expectedRange, message(), file: file, line: line)
+                    }
+                } else {
+                    if let someRange = range {
+                        XCTAssertNil(data.firstRange(of: fragment, in: someRange), message(), file: file, line: line)
+                    } else {
+                        XCTAssertNil(data.firstRange(of: fragment), message(), file: file, line: line)
+                    }
+                }
+            }
+            
+            assertFirstRange(base, base, expectedStartIndex: base.startIndex)
+            assertFirstRange(base, subdata, expectedStartIndex: 2)
+            assertFirstRange(base, oneByte, expectedStartIndex: 2)
+            
+            assertFirstRange(subdata, base, expectedStartIndex: nil)
+            assertFirstRange(subdata, subdata, expectedStartIndex: subdata.startIndex)
+            assertFirstRange(subdata, oneByte, expectedStartIndex: subdata.startIndex)
+            
+            assertFirstRange(oneByte, base, expectedStartIndex: nil)
+            assertFirstRange(oneByte, subdata, expectedStartIndex: nil)
+            assertFirstRange(oneByte, oneByte, expectedStartIndex: oneByte.startIndex)
+            
+            assertFirstRange(base, subdata, range: 1...14, expectedStartIndex: 2)
+            assertFirstRange(base, subdata, range: 6...8, expectedStartIndex: 6)
+            assertFirstRange(base, subdata, range: 8...10, expectedStartIndex: nil)
+            
+            assertFirstRange(base, oneByte, range: 1...14, expectedStartIndex: 2)
+            assertFirstRange(base, oneByte, range: 6...6, expectedStartIndex: 6)
+            assertFirstRange(base, oneByte, range: 8...9, expectedStartIndex: nil)
+        }
+        
+        do { // lastRange(of:in:)
+            func assertLastRange(_ data: Data, _ fragment: Data, range: ClosedRange<Int>? = nil,
+                                 expectedStartIndex: Int?,
+                                 _ message: @autoclosure () -> String = "",
+                                 file: StaticString = #file, line: UInt = #line) {
+                if let index = expectedStartIndex {
+                    let expectedRange: Range<Int> = index..<(index + fragment.count)
+                    if let someRange = range {
+                        XCTAssertEqual(data.lastRange(of: fragment, in: someRange), expectedRange, file: file, line: line)
+                    } else {
+                        XCTAssertEqual(data.lastRange(of: fragment), expectedRange, message(), file: file, line: line)
+                    }
+                } else {
+                    if let someRange = range {
+                        XCTAssertNil(data.lastRange(of: fragment, in: someRange), message(), file: file, line: line)
+                    } else {
+                        XCTAssertNil(data.lastRange(of: fragment), message(), file: file, line: line)
+                    }
+                }
+            }
+            
+            assertLastRange(base, base, expectedStartIndex: base.startIndex)
+            assertLastRange(base, subdata, expectedStartIndex: 10)
+            assertLastRange(base, oneByte, expectedStartIndex: 14)
+            
+            assertLastRange(subdata, base, expectedStartIndex: nil)
+            assertLastRange(subdata, subdata, expectedStartIndex: subdata.startIndex)
+            assertLastRange(subdata, oneByte, expectedStartIndex: subdata.startIndex)
+            
+            assertLastRange(oneByte, base, expectedStartIndex: nil)
+            assertLastRange(oneByte, subdata, expectedStartIndex: nil)
+            assertLastRange(oneByte, oneByte, expectedStartIndex: oneByte.startIndex)
+            
+            assertLastRange(base, subdata, range: 1...14, expectedStartIndex: 10)
+            assertLastRange(base, subdata, range: 6...8, expectedStartIndex: 6)
+            assertLastRange(base, subdata, range: 8...10, expectedStartIndex: nil)
+            
+            assertLastRange(base, oneByte, range: 1...14, expectedStartIndex: 14)
+            assertLastRange(base, oneByte, range: 6...6, expectedStartIndex: 6)
+            assertLastRange(base, oneByte, range: 8...9, expectedStartIndex: nil)
+        }
+    }
+
+    func test_sliceAppending() {
+        // https://bugs.swift.org/browse/SR-4473
+        var fooData = Data()
+        let barData = Data([0, 1, 2, 3, 4, 5])
+        let slice = barData.suffix(from: 3)
+        fooData.append(slice)
+        XCTAssertEqual(fooData[0], 0x03)
+        XCTAssertEqual(fooData[1], 0x04)
+        XCTAssertEqual(fooData[2], 0x05)
+    }
+    
+    func test_replaceSubrange() {
+        // https://bugs.swift.org/browse/SR-4462
+        let data = Data(bytes: [0x01, 0x02])
+        var dataII = Data(base64Encoded: data.base64EncodedString())!
+        dataII.replaceSubrange(0..<1, with: Data())
+        XCTAssertEqual(dataII[0], 0x02)
+    }
+    
+    func test_sliceWithUnsafeBytes() {
+        let base = Data([0, 1, 2, 3, 4, 5])
+        let slice = base[2..<4]
+        let segment = slice.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> [UInt8] in
+            return [ptr.pointee, ptr.advanced(by: 1).pointee]
+        }
+        XCTAssertEqual(segment, [UInt8(2), UInt8(3)])
+    }
+
+    func test_sliceIteration() {
+        let base = Data([0, 1, 2, 3, 4, 5])
+        let slice = base[2..<4]
+        var found = [UInt8]()
+        for byte in slice {
+            found.append(byte)
+        }
+        XCTAssertEqual(found[0], 2)
+        XCTAssertEqual(found[1], 3)
+    }
+  
+    func test_unconditionallyBridgeFromObjectiveC() {
+        XCTAssertEqual(Data(), Data._unconditionallyBridgeFromObjectiveC(nil))
+    }
+
+    func test_sliceIndexing() {
+        let d = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+        let slice = d[5..<10]
+        XCTAssertEqual(slice[5], d[5])
+    }
+    
+    func test_sliceEquality() {
+        let d = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+        let slice = d[5..<7]
+        let expected = Data(bytes: [5, 6])
+        XCTAssertEqual(expected, slice)
+    }
+    
+    func test_sliceEquality2() {
+        let d = Data(bytes: [5, 6, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+        let slice1 = d[0..<2]
+        let slice2 = d[5..<7]
+        XCTAssertEqual(slice1, slice2)
+    }
+    
+    func test_splittingHttp() {
+        func split(_ data: Data, on delimiter: String) -> [Data] {
+            let dataDelimiter = delimiter.data(using: .utf8)!
+            var found = [Data]()
+            let start = data.startIndex
+            let end = data.endIndex.advanced(by: -dataDelimiter.count)
+            guard end >= start else { return [data] }
+            var index = start
+            var previousIndex = index
+            while index < end {
+                let slice = data[index..<index.advanced(by: dataDelimiter.count)]
+                
+                if slice == dataDelimiter {
+                    found.append(data[previousIndex..<index])
+                    previousIndex = index + dataDelimiter.count
+                }
+                
+                index = index.advanced(by: 1)
+            }
+            if index < data.endIndex { found.append(data[index..<index]) }
+            return found
+        }
+        let data = "GET /index.html HTTP/1.1\r\nHost: www.example.com\r\n\r\n".data(using: .ascii)!
+        let fields = split(data, on: "\r\n")
+        let splitFields = fields.map { String(data:$0, encoding: .utf8)! }
+        XCTAssertEqual([
+            "GET /index.html HTTP/1.1",
+            "Host: www.example.com",
+            ""
+        ], splitFields)
+    }
+
+    func test_map() {
+        let d1 = Data(bytes: [81, 0, 0, 0, 14])
+        let d2 = d1[1...4]
+        XCTAssertEqual(4, d2.count)
+        let expected: [UInt8] = [0, 0, 0, 14]
+        let actual = d2.map { $0 }
+        XCTAssertEqual(expected, actual)
+    }
+
+    func test_dropFirst() {
+        var data = Data([0, 1, 2, 3, 4, 5])
+        let sliced = data.dropFirst()
+        XCTAssertEqual(data.count - 1, sliced.count)
+        XCTAssertEqual(UInt8(1), sliced[1])
+        XCTAssertEqual(UInt8(2), sliced[2])
+        XCTAssertEqual(UInt8(3), sliced[3])
+        XCTAssertEqual(UInt8(4), sliced[4])
+        XCTAssertEqual(UInt8(5), sliced[5])
+    }
+
+    func test_dropFirst2() {
+        var data = Data([0, 1, 2, 3, 4, 5])
+        let sliced = data.dropFirst(2)
+        XCTAssertEqual(data.count - 2, sliced.count)
+        XCTAssertEqual(UInt8(2), sliced[2])
+        XCTAssertEqual(UInt8(3), sliced[3])
+        XCTAssertEqual(UInt8(4), sliced[4])
+        XCTAssertEqual(UInt8(5), sliced[5])
+    }
+
+    func test_copyBytes1() {
+        var array: [UInt8] = [0, 1, 2, 3]
+        var data = Data(bytes: array)
+        
+        array.withUnsafeMutableBufferPointer {
+            data[1..<3].copyBytes(to: $0.baseAddress!, from: 1..<3)
+        }
+        XCTAssertEqual([UInt8(1), UInt8(2), UInt8(2), UInt8(3)], array)
+    }
+    
+    func test_copyBytes2() {
+        let array: [UInt8] = [0, 1, 2, 3]
+        var data = Data(bytes: array)
+        
+        let expectedSlice = array[1..<3]
+        
+        let start = data.index(after: data.startIndex)
+        let end = data.index(before: data.endIndex)
+        let slice = data[start..<end]
+        
+        XCTAssertEqual(expectedSlice[expectedSlice.startIndex], slice[slice.startIndex])
+    }
+
+    func test_sliceOfSliceViaRangeExpression() {
+        let data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        let slice = data[2..<7]
+
+        let sliceOfSlice1 = slice[..<(slice.startIndex + 2)] // this triggers the range expression
+        let sliceOfSlice2 = slice[(slice.startIndex + 2)...] // also triggers range expression
+
+        XCTAssertEqual(Data(bytes: [2, 3]), sliceOfSlice1)
+        XCTAssertEqual(Data(bytes: [4, 5, 6]), sliceOfSlice2)
+    }
+
+    func test_appendingSlices() {
+        let d1 = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let slice = d1[1..<2]
+        var d2 = Data()
+        d2.append(slice)
+        XCTAssertEqual(Data(bytes: [1]), slice)
+    }
+
+    // This test uses `repeatElement` to produce a sequence -- the produced sequence reports its actual count as its `.underestimatedCount`.
+    func test_appendingNonContiguousSequence_exactCount() {
+        var d = Data()
+
+        // d should go from .empty representation to .inline.
+        // Appending a small enough sequence to fit in .inline should actually be copied.
+        d.append(contentsOf: 0x00...0x01)
+        XCTAssertEqual(Data([0x00, 0x01]), d)
+
+        // Appending another small sequence should similarly still work.
+        d.append(contentsOf: 0x02...0x02)
+        XCTAssertEqual(Data([0x00, 0x01, 0x02]), d)
+
+        // If we append a sequence of elements larger than a single InlineData, the internal append here should buffer.
+        // We want to make sure that buffering in this way does not accidentally drop trailing elements on the floor.
+        d.append(contentsOf: 0x03...0x2F)
+        XCTAssertEqual(Data([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+                          0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+                          0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+                          0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
+                          0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27,
+                          0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F]), d)
+    }
+
+    // This test is like test_appendingNonContiguousSequence_exactCount but uses a sequence which reports 0 for its `.underestimatedCount`.
+    // This attempts to hit the worst-case scenario of `Data.append<S>(_:)` -- a discontiguous sequence of unknown length.
+    func test_appendingNonContiguousSequence_underestimatedCount() {
+        var d = Data()
+
+        // d should go from .empty representation to .inline.
+        // Appending a small enough sequence to fit in .inline should actually be copied.
+        d.append(contentsOf: (0x00...0x01).makeIterator()) // `.makeIterator()` produces a sequence whose `.underestimatedCount` is 0.
+        XCTAssertEqual(Data([0x00, 0x01]), d)
+
+        // Appending another small sequence should similarly still work.
+        d.append(contentsOf: (0x02...0x02).makeIterator()) // `.makeIterator()` produces a sequence whose `.underestimatedCount` is 0.
+        XCTAssertEqual(Data([0x00, 0x01, 0x02]), d)
+
+        // If we append a sequence of elements larger than a single InlineData, the internal append here should buffer.
+        // We want to make sure that buffering in this way does not accidentally drop trailing elements on the floor.
+        d.append(contentsOf: (0x03...0x2F).makeIterator()) // `.makeIterator()` produces a sequence whose `.underestimatedCount` is 0.
+        XCTAssertEqual(Data([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+                          0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+                          0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+                          0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
+                          0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27,
+                          0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F]), d)
+    }
+
+    func test_sequenceInitializers() {
+        let seq = repeatElement(UInt8(0x02), count: 3) // ensure we fall into the sequence case
+        
+        let dataFromSeq = Data(seq)
+        XCTAssertEqual(3, dataFromSeq.count)
+        XCTAssertEqual(UInt8(0x02), dataFromSeq[0])
+        XCTAssertEqual(UInt8(0x02), dataFromSeq[1])
+        XCTAssertEqual(UInt8(0x02), dataFromSeq[2])
+
+        let array: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+
+        let dataFromArray = Data(array)
+        XCTAssertEqual(array.count, dataFromArray.count)
+        XCTAssertEqual(array[0], dataFromArray[0])
+        XCTAssertEqual(array[1], dataFromArray[1])
+        XCTAssertEqual(array[2], dataFromArray[2])
+        XCTAssertEqual(array[3], dataFromArray[3])
+
+        let slice = array[1..<4]
+        
+        let dataFromSlice = Data(slice)
+        XCTAssertEqual(slice.count, dataFromSlice.count)
+        XCTAssertEqual(slice.first, dataFromSlice.first)
+        XCTAssertEqual(slice.last, dataFromSlice.last)
+
+        let data = Data(bytes: [1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        let dataFromData = Data(data)
+        XCTAssertEqual(data, dataFromData)
+
+        let sliceOfData = data[1..<3]
+
+        let dataFromSliceOfData = Data(sliceOfData)
+        XCTAssertEqual(sliceOfData, dataFromSliceOfData)
+    }
+
+    func test_reversedDataInit() {
+        let data = Data(bytes: [1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let reversedData = Data(data.reversed())
+        let expected = Data(bytes: [9, 8, 7, 6, 5, 4, 3, 2, 1])
+        XCTAssertEqual(expected, reversedData)
+    }
+
+    func test_replaceSubrangeReferencingMutable() {
+        let mdataObj = NSMutableData(bytes: [0x01, 0x02, 0x03, 0x04], length: 4)
+        var data = Data(referencing: mdataObj)
+        let expected = data.count
+        data.replaceSubrange(4 ..< 4, with: Data(bytes: []))
+        XCTAssertEqual(expected, data.count)
+        data.replaceSubrange(4 ..< 4, with: Data(bytes: []))
+        XCTAssertEqual(expected, data.count)
+    }
+
+    func test_replaceSubrangeReferencingImmutable() {
+        let dataObj = NSData(bytes: [0x01, 0x02, 0x03, 0x04], length: 4)
+        var data = Data(referencing: dataObj)
+        let expected = data.count
+        data.replaceSubrange(4 ..< 4, with: Data(bytes: []))
+        XCTAssertEqual(expected, data.count)
+        data.replaceSubrange(4 ..< 4, with: Data(bytes: []))
+        XCTAssertEqual(expected, data.count)
+    }
+
+    func test_replaceSubrangeFromBridged() {
+        var data = NSData(bytes: [0x01, 0x02, 0x03, 0x04], length: 4) as Data
+        let expected = data.count
+        data.replaceSubrange(4 ..< 4, with: Data(bytes: []))
+        XCTAssertEqual(expected, data.count)
+        data.replaceSubrange(4 ..< 4, with: Data(bytes: []))
+        XCTAssertEqual(expected, data.count)
+    }
+
+        func test_validateMutation_withUnsafeMutableBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 5).pointee = 0xFF
+        }
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 0xFF, 6, 7, 8, 9]))
+    }
+    
+    func test_validateMutation_appendBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        data.append("hello", count: 5)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0x5)
+    }
+    
+    func test_validateMutation_appendData() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let other = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        data.append(other)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 9)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0)
+    }
+    
+    func test_validateMutation_appendBuffer() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 9)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0)
+    }
+    
+    func test_validateMutation_appendSequence() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let seq = repeatElement(UInt8(1), count: 10)
+        data.append(contentsOf: seq)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 9)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 1)
+    }
+    
+    func test_validateMutation_appendContentsOf() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        data.append(contentsOf: bytes)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 9)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0)
+    }
+    
+    func test_validateMutation_resetBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 0, 0, 0, 8, 9]))
+    }
+    
+    func test_validateMutation_replaceSubrange() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let replacement = Data(bytes: [0xFF, 0xFF])
+        data.replaceSubrange(range, with: replacement)
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_replaceSubrangeRange() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let replacement = Data(bytes: [0xFF, 0xFF])
+        data.replaceSubrange(range, with: replacement)
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_replaceSubrangeWithBuffer() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer {
+            data.replaceSubrange(range, with: $0)
+        }
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_replaceSubrangeWithCollection() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        data.replaceSubrange(range, with: bytes)
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_replaceSubrangeWithBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBytes {
+            data.replaceSubrange(range, with: $0.baseAddress!, count: 2)
+        }
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_slice_withUnsafeMutableBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 1).pointee = 0xFF
+        }
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 6, 7, 8]))
+    }
+    
+    func test_validateMutation_slice_appendBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_appendData() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let other = Data(bytes: [0xFF, 0xFF])
+        data.append(other)
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_appendBuffer() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_appendSequence() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let seq = repeatElement(UInt8(0xFF), count: 2)
+        data.append(contentsOf: seq)
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_appendContentsOf() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        data.append(contentsOf: bytes)
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_resetBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data, Data(bytes: [4, 0, 0, 0, 8]))
+    }
+    
+    func test_validateMutation_slice_replaceSubrange() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let replacement = Data(bytes: [0xFF, 0xFF])
+        data.replaceSubrange(range, with: replacement)
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_slice_replaceSubrangeRange() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let replacement = Data(bytes: [0xFF, 0xFF])
+        data.replaceSubrange(range, with: replacement)
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_slice_replaceSubrangeWithBuffer() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer {
+            data.replaceSubrange(range, with: $0)
+        }
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_slice_replaceSubrangeWithCollection() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        data.replaceSubrange(range, with: bytes)
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_slice_replaceSubrangeWithBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBytes {
+            data.replaceSubrange(range, with: $0.baseAddress!, count: 2)
+        }
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_cow_withUnsafeMutableBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 5).pointee = 0xFF
+            }
+            XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 0xFF, 6, 7, 8, 9]))
+        }
+    }
+    
+    func test_validateMutation_cow_appendBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            data.append("hello", count: 5)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 0x9)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x68)
+        }
+    }
+    
+    func test_validateMutation_cow_appendData() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let other = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+            data.append(other)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 9)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0)
+        }
+    }
+    
+    func test_validateMutation_cow_appendBuffer() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+            bytes.withUnsafeBufferPointer { data.append($0) }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 9)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0)
+        }
+    }
+    
+    func test_validateMutation_cow_appendSequence() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let seq = repeatElement(UInt8(1), count: 10)
+            data.append(contentsOf: seq)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 9)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 1)
+        }
+    }
+    
+    func test_validateMutation_cow_appendContentsOf() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+            data.append(contentsOf: bytes)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 9)], 9)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0)
+        }
+    }
+    
+    func test_validateMutation_cow_resetBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 0, 0, 0, 8, 9]))
+        }
+    }
+    
+    func test_validateMutation_cow_replaceSubrange() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let replacement = Data(bytes: [0xFF, 0xFF])
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+        }
+    }
+    
+    func test_validateMutation_cow_replaceSubrangeRange() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let replacement = Data(bytes: [0xFF, 0xFF])
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+        }
+    }
+    
+    func test_validateMutation_cow_replaceSubrangeWithBuffer() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer {
+                data.replaceSubrange(range, with: $0)
+            }
+            XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+        }
+    }
+    
+    func test_validateMutation_cow_replaceSubrangeWithCollection() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            data.replaceSubrange(range, with: bytes)
+            XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+        }
+    }
+    
+    func test_validateMutation_cow_replaceSubrangeWithBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBytes {
+                data.replaceSubrange(range, with: $0.baseAddress!, count: 2)
+            }
+            XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 0xFF, 0xFF, 9]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_withUnsafeMutableBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 1).pointee = 0xFF
+            }
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 6, 7, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_appendBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            data.append("hello", count: 5)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 4)], 0x8)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0x68)
+        }
+    }
+    
+    func test_validateMutation_slice_cow_appendData() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let other = Data(bytes: [0xFF, 0xFF])
+            data.append(other)
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_appendBuffer() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.append($0) }
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_appendSequence() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let seq = repeatElement(UInt8(0xFF), count: 2)
+            data.append(contentsOf: seq)
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_appendContentsOf() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            data.append(contentsOf: bytes)
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_resetBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data, Data(bytes: [4, 0, 0, 0, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_replaceSubrange() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let replacement = Data(bytes: [0xFF, 0xFF])
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_replaceSubrangeRange() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let replacement = Data(bytes: [0xFF, 0xFF])
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_replaceSubrangeWithBuffer() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer {
+                data.replaceSubrange(range, with: $0)
+            }
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_replaceSubrangeWithCollection() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            data.replaceSubrange(range, with: bytes)
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_replaceSubrangeWithBytes() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBytes {
+                data.replaceSubrange(range, with: $0.baseAddress!, count: 2)
+            }
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_immutableBacking_withUnsafeMutableBytes() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 5).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0xFF)
+    }
+    
+    func test_validateMutation_immutableBacking_appendBytes() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        data.append("hello", count: 5)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 0x68)
+    }
+    
+    func test_validateMutation_immutableBacking_appendData() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        let other = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        data.append(other)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 0)
+    }
+    
+    func test_validateMutation_immutableBacking_appendBuffer() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 0)
+    }
+    
+    func test_validateMutation_immutableBacking_appendSequence() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        let seq = repeatElement(UInt8(1), count: 10)
+        data.append(contentsOf: seq)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 1)
+    }
+    
+    func test_validateMutation_immutableBacking_appendContentsOf() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        data.append(contentsOf: bytes)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 0)
+    }
+    
+    func test_validateMutation_immutableBacking_resetBytes() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x00, 0x00, 0x00, 0x72, 0x6c, 0x64]))
+    }
+    
+    func test_validateMutation_immutableBacking_replaceSubrange() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let replacement = Data(bytes: [0xFF, 0xFF])
+        data.replaceSubrange(range, with: replacement)
+        XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xFF, 0xFF, 0x6c, 0x64]))
+    }
+    
+    func test_validateMutation_immutableBacking_replaceSubrangeRange() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let replacement = Data(bytes: [0xFF, 0xFF])
+        data.replaceSubrange(range, with: replacement)
+        XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xFF, 0xFF, 0x6c, 0x64]))
+    }
+    
+    func test_validateMutation_immutableBacking_replaceSubrangeWithBuffer() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer {
+            data.replaceSubrange(range, with: $0)
+        }
+        XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xFF, 0xFF, 0x6c, 0x64]))
+    }
+    
+    func test_validateMutation_immutableBacking_replaceSubrangeWithCollection() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        data.replaceSubrange(range, with: bytes)
+        XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xFF, 0xFF, 0x6c, 0x64]))
+    }
+    
+    func test_validateMutation_immutableBacking_replaceSubrangeWithBytes() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        data.replaceSubrange(range, with: bytes)
+        XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xFF, 0xFF, 0x6c, 0x64]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_withUnsafeMutableBytes() {
+        var data = (NSData(bytes: "hello world", length: 11) as Data)[4..<9]
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 1).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+    }
+    
+    func test_validateMutation_slice_immutableBacking_appendBytes() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_appendData() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        data.append(Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_appendBuffer() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_appendSequence() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        data.append(contentsOf: repeatElement(UInt8(0xFF), count: 2))
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_appendContentsOf() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        data.append(contentsOf: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_resetBytes() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data, Data(bytes: [4, 0, 0, 0, 8]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_replaceSubrange() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_replaceSubrangeRange() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_replaceSubrangeWithBuffer() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        let replacement: [UInt8] = [0xFF, 0xFF]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        replacement.withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<UInt8>) in
+            data.replaceSubrange(range, with: buffer)
+        }
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_replaceSubrangeWithCollection() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let replacement: [UInt8] = [0xFF, 0xFF]
+        data.replaceSubrange(range, with:replacement)
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_replaceSubrangeWithBytes() {
+        let base: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = base.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        let replacement: [UInt8] = [0xFF, 0xFF]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        replacement.withUnsafeBytes {
+            data.replaceSubrange(range, with: $0.baseAddress!, count: 2)
+        }
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+    }
+    
+    func test_validateMutation_cow_immutableBacking_withUnsafeMutableBytes() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 5).pointee = 0xFF
+            }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0xFF)
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_appendBytes() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        holdReference(data) {
+            data.append("hello", count: 5)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 0x68)
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_appendData() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        holdReference(data) {
+            let other = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+            data.append(other)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 0)
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_appendBuffer() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        holdReference(data) {
+            let bytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+            bytes.withUnsafeBufferPointer { data.append($0) }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 0)
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_appendSequence() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        holdReference(data) {
+            let seq = repeatElement(UInt8(1), count: 10)
+            data.append(contentsOf: seq)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 1)
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_appendContentsOf() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        holdReference(data) {
+            let bytes: [UInt8] = [1, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+            data.append(contentsOf: bytes)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 10)], 0x64)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 11)], 1)
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_resetBytes() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x00, 0x00, 0x00, 0x72, 0x6c, 0x64]))
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_replaceSubrange() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let replacement = Data(bytes: [0xFF, 0xFF])
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xff, 0xff, 0x6c, 0x64]))
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_replaceSubrangeRange() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let replacement = Data(bytes: [0xFF, 0xFF])
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xff, 0xff, 0x6c, 0x64]))
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_replaceSubrangeWithBuffer() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        holdReference(data) {
+            let replacement: [UInt8] = [0xFF, 0xFF]
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            replacement.withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<UInt8>) in
+                data.replaceSubrange(range, with: buffer)
+            }
+            XCTAssertEqual(data, Data(bytes: [0x68, 0xff, 0xff, 0x64]))
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_replaceSubrangeWithCollection() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        holdReference(data) {
+            let replacement: [UInt8] = [0xFF, 0xFF]
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [0x68, 0xff, 0xff, 0x64]))
+        }
+    }
+    
+    func test_validateMutation_cow_immutableBacking_replaceSubrangeWithBytes() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        holdReference(data) {
+            let replacement: [UInt8] = [0xFF, 0xFF]
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            replacement.withUnsafeBytes {
+                data.replaceSubrange(range, with: $0.baseAddress!, count: 2)
+            }
+            XCTAssertEqual(data, Data(bytes: [0x68, 0xff, 0xff, 0x64]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_withUnsafeMutableBytes() {
+        var data = (NSData(bytes: "hello world", length: 11) as Data)[4..<9]
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 1).pointee = 0xFF
+            }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_appendBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_appendData() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        holdReference(data) {
+            data.append(Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_appendBuffer() {
+        var data = (NSData(bytes: "hello world", length: 11) as Data)[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer{ data.append($0) }
+            XCTAssertEqual(data, Data(bytes: [0x6f, 0x20, 0x77, 0x6f, 0x72, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_appendSequence() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        holdReference(data) {
+            let bytes = repeatElement(UInt8(0xFF), count: 2)
+            data.append(contentsOf: bytes)
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_appendContentsOf() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            data.append(contentsOf: bytes)
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_resetBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data, Data(bytes: [4, 0, 0, 0, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_replaceSubrange() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_replaceSubrangeRange() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithBuffer() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0) }
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithCollection() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            data.replaceSubrange(range, with: bytes)
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_immutableBacking_replaceSubrangeWithBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return (NSData(bytes: $0.baseAddress!, length: $0.count) as Data)[4..<9]
+        }
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBytes { data.replaceSubrange(range, with: $0.baseAddress!, count: 2) }
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_mutableBacking_withUnsafeMutableBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        data.append(contentsOf: [7, 8, 9])
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 5).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0xFF)
+    }
+    
+    func test_validateMutation_mutableBacking_appendBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        data.append(contentsOf: [7, 8, 9])
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_mutableBacking_appendData() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        data.append(contentsOf: [7, 8, 9])
+        data.append(Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_mutableBacking_appendBuffer() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        data.append(contentsOf: [7, 8, 9])
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_mutableBacking_appendSequence() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        data.append(contentsOf: [7, 8, 9])
+        data.append(contentsOf: repeatElement(UInt8(0xFF), count: 2))
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_mutableBacking_appendContentsOf() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        data.append(contentsOf: [7, 8, 9])
+        data.append(contentsOf: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_mutableBacking_resetBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        data.append(contentsOf: [7, 8, 9])
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data, Data(bytes: [0, 1, 2, 3, 4, 0, 0, 0, 8, 9]))
+    }
+    
+    func test_validateMutation_mutableBacking_replaceSubrange() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        data.append(contentsOf: [7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let replacement = Data(bytes: [0xFF, 0xFF])
+        data.replaceSubrange(range, with: replacement)
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_mutableBacking_replaceSubrangeRange() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        data.append(contentsOf: [7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let replacement = Data(bytes: [0xFF, 0xFF])
+        data.replaceSubrange(range, with: replacement)
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_mutableBacking_replaceSubrangeWithBuffer() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        data.append(contentsOf: [7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer {
+            data.replaceSubrange(range, with: $0)
+        }
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_mutableBacking_replaceSubrangeWithCollection() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        data.append(contentsOf: [7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_mutableBacking_replaceSubrangeWithBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var data = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        data.append(contentsOf: [7, 8, 9])
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBytes {
+            data.replaceSubrange(range, with: $0.baseAddress!, count: $0.count)
+        }
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 9]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_withUnsafeMutableBytes() {
+        var base = NSData(bytes: "hello world", length: 11) as Data
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 1).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+    }
+    
+    func test_validateMutation_slice_mutableBacking_appendBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_appendData() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        data.append(Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_appendBuffer() {
+        var base = NSData(bytes: "hello world", length: 11) as Data
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        let bytes: [UInt8] = [1, 2, 3]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data, Data(bytes: [0x6f, 0x20, 0x77, 0x6f, 0x72, 0x1, 0x2, 0x3]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_appendSequence() {
+        var base = NSData(bytes: "hello world", length: 11) as Data
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        let seq = repeatElement(UInt8(1), count: 3)
+        data.append(contentsOf: seq)
+        XCTAssertEqual(data, Data(bytes: [0x6f, 0x20, 0x77, 0x6f, 0x72, 0x1, 0x1, 0x1]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_appendContentsOf() {
+        var base = NSData(bytes: "hello world", length: 11) as Data
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        let bytes: [UInt8] = [1, 2, 3]
+        data.append(contentsOf: bytes)
+        XCTAssertEqual(data, Data(bytes: [0x6f, 0x20, 0x77, 0x6f, 0x72, 0x1, 0x2, 0x3]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_resetBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data, Data(bytes: [4, 0, 0, 0, 8]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_replaceSubrange() {
+        var base = NSData(bytes: "hello world", length: 11) as Data
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [0x6f, 0xFF, 0xFF, 0x72]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_replaceSubrangeRange() {
+        var base = NSData(bytes: "hello world", length: 11) as Data
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [0x6f, 0xFF, 0xFF, 0x72]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_replaceSubrangeWithBuffer() {
+        var base = NSData(bytes: "hello world", length: 11) as Data
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        let replacement: [UInt8] = [0xFF, 0xFF]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        replacement.withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<UInt8>) in
+            data.replaceSubrange(range, with: buffer)
+        }
+        XCTAssertEqual(data, Data(bytes: [0x6f, 0xFF, 0xFF, 0x72]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_replaceSubrangeWithCollection() {
+        var base = NSData(bytes: "hello world", length: 11) as Data
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let replacement: [UInt8] = [0xFF, 0xFF]
+        data.replaceSubrange(range, with:replacement)
+        XCTAssertEqual(data, Data(bytes: [0x6f, 0xFF, 0xFF, 0x72]))
+    }
+    
+    func test_validateMutation_slice_mutableBacking_replaceSubrangeWithBytes() {
+        var base = NSData(bytes: "hello world", length: 11) as Data
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        let replacement: [UInt8] = [0xFF, 0xFF]
+        let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        replacement.withUnsafeBytes {
+            data.replaceSubrange(range, with: $0.baseAddress!, count: 2)
+        }
+        XCTAssertEqual(data, Data(bytes: [0x6f, 0xFF, 0xFF, 0x72]))
+    }
+    
+    func test_validateMutation_cow_mutableBacking_withUnsafeMutableBytes() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 5).pointee = 0xFF
+            }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0xFF)
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_appendBytes() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            data.append("hello", count: 5)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 16)], 6)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 17)], 0x68)
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_appendData() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            data.append("hello", count: 5)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 16)], 6)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 17)], 0x68)
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_appendBuffer() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            let other = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+            data.append(other)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 16)], 6)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 17)], 0)
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_appendSequence() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            let seq = repeatElement(UInt8(1), count: 10)
+            data.append(contentsOf: seq)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 16)], 6)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 17)], 1)
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_appendContentsOf() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            let bytes: [UInt8] = [1, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+            data.append(contentsOf: bytes)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 16)], 6)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 17)], 1)
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_resetBytes() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x00, 0x00, 0x00, 0x72, 0x6c, 0x64, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]))
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_replaceSubrange() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let replacement = Data(bytes: [0xFF, 0xFF])
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xff, 0xff, 0x6c, 0x64, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]))
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_replaceSubrangeRange() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let replacement = Data(bytes: [0xFF, 0xFF])
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xff, 0xff, 0x6c, 0x64, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]))
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_replaceSubrangeWithBuffer() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            let replacement: [UInt8] = [0xFF, 0xFF]
+            replacement.withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<UInt8>) in
+                data.replaceSubrange(range, with: buffer)
+            }
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xff, 0xff, 0x6c, 0x64, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]))
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_replaceSubrangeWithCollection() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            let replacement: [UInt8] = [0xFF, 0xFF]
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            data.replaceSubrange(range, with: replacement)
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xff, 0xff, 0x6c, 0x64, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]))
+        }
+    }
+    
+    func test_validateMutation_cow_mutableBacking_replaceSubrangeWithBytes() {
+        var data = NSData(bytes: "hello world", length: 11) as Data
+        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        holdReference(data) {
+            let replacement: [UInt8] = [0xFF, 0xFF]
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 4)..<data.startIndex.advanced(by: 9)
+            replacement.withUnsafeBytes {
+                data.replaceSubrange(range, with: $0.baseAddress!, count: 2)
+            }
+            XCTAssertEqual(data, Data(bytes: [0x68, 0x65, 0x6c, 0x6c, 0xff, 0xff, 0x6c, 0x64, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_withUnsafeMutableBytes() {
+        var base = NSData(bytes: "hello world", length: 11) as Data
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<9]
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 1).pointee = 0xFF
+            }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_appendBytes() {
+        let bytes: [UInt8] = [0, 1, 2]
+        var base = bytes.withUnsafeBytes { (ptr) in
+            return NSData(bytes: ptr.baseAddress!, length: ptr.count) as Data
+        }
+        base.append(contentsOf: [3, 4, 5])
+        var data = base[1..<4]
+        holdReference(data) {
+            let bytesToAppend: [UInt8] = [6, 7, 8]
+            bytesToAppend.withUnsafeBytes { (ptr) in
+                data.append(ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), count: ptr.count)
+            }
+            XCTAssertEqual(data, Data(bytes: [1, 2, 3, 6, 7, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_appendData() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            data.append(Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_appendBuffer() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer{ data.append($0) }
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_appendSequence() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            let bytes = repeatElement(UInt8(0xFF), count: 2)
+            data.append(contentsOf: bytes)
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_appendContentsOf() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            data.append(contentsOf: bytes)
+            XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 8, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_resetBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data, Data(bytes: [4, 0, 0, 0, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_replaceSubrange() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_replaceSubrangeRange() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithBuffer() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0) }
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithCollection() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            data.replaceSubrange(range, with: bytes)
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_mutableBacking_replaceSubrangeWithBytes() {
+        let baseBytes: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+        var base = baseBytes.withUnsafeBufferPointer {
+            return NSData(bytes: $0.baseAddress!, length: $0.count) as Data
+        }
+        base.append(contentsOf: [7, 8, 9])
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Data.Index> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBytes { data.replaceSubrange(range, with: $0.baseAddress!, count: 2) }
+            XCTAssertEqual(data, Data(bytes: [4, 0xFF, 0xFF, 8]))
+        }
+    }
+    
+    func test_validateMutation_customBacking_withUnsafeMutableBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 5).pointee = 0xFF
+        }
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 1, 1, 1, 1]))
+    }
+    
+    func test_validateMutation_customBacking_appendBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customBacking_appendData() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        data.append(Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customBacking_appendBuffer() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { (buffer) in
+            data.append(buffer)
+        }
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        
+    }
+    
+    func test_validateMutation_customBacking_appendSequence() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        data.append(contentsOf: repeatElement(UInt8(0xFF), count: 2))
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customBacking_appendContentsOf() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        data.append(contentsOf: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customBacking_resetBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0, 0, 0, 1, 1]))
+    }
+    
+    func test_validateMutation_customBacking_replaceSubrange() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        let range: Range<Int> = 1..<4
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1, 1, 1, 1, 1, 1]))
+    }
+    
+    func test_validateMutation_customBacking_replaceSubrangeRange() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        let range: Range<Int> = 1..<4
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1, 1, 1, 1, 1, 1]))
+    }
+    
+    func test_validateMutation_customBacking_replaceSubrangeWithBuffer() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        let range: Range<Int> = 1..<4
+        bytes.withUnsafeBufferPointer { (buffer) in
+            data.replaceSubrange(range, with: buffer)
+        }
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1, 1, 1, 1, 1, 1]))
+    }
+    
+    func test_validateMutation_customBacking_replaceSubrangeWithCollection() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        let range: Range<Int> = 1..<4
+        data.replaceSubrange(range, with: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1, 1, 1, 1, 1, 1]))
+    }
+    
+    func test_validateMutation_customBacking_replaceSubrangeWithBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        let range: Range<Int> = 1..<5
+        bytes.withUnsafeBufferPointer { (buffer) in
+            data.replaceSubrange(range, with: buffer.baseAddress!, count: buffer.count)
+        }
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1, 1, 1, 1, 1]))
+    }
+    
+    func test_validateMutation_slice_customBacking_withUnsafeMutableBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 1).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+    }
+    
+    func test_validateMutation_slice_customBacking_appendBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBytes { ptr in
+            data.append(ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), count: ptr.count)
+        }
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customBacking_appendData() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        data.append(Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customBacking_appendBuffer() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { (buffer) in
+            data.append(buffer)
+        }
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customBacking_appendSequence() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        let seq = repeatElement(UInt8(0xFF), count: 2)
+        data.append(contentsOf: seq)
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customBacking_appendContentsOf() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        data.append(contentsOf: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customBacking_resetBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 1]))
+    }
+    
+    func test_validateMutation_slice_customBacking_replaceSubrange() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+    }
+    
+    func test_validateMutation_slice_customBacking_replaceSubrangeRange() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+    }
+    
+    func test_validateMutation_slice_customBacking_replaceSubrangeWithBuffer() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { (buffer) in
+            data.replaceSubrange(range, with: buffer)
+        }
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+    }
+    
+    func test_validateMutation_slice_customBacking_replaceSubrangeWithCollection() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+    }
+    
+    func test_validateMutation_slice_customBacking_replaceSubrangeWithBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBytes { buffer in
+            data.replaceSubrange(range, with: buffer.baseAddress!, count: 2)
+        }
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+    }
+    
+    func test_validateMutation_cow_customBacking_withUnsafeMutableBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 5).pointee = 0xFF
+            }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0xFF)
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_appendBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { (buffer) in
+                data.append(buffer.baseAddress!, count: buffer.count)
+            }
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_appendData() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            data.append(Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_appendBuffer() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.append($0) }
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_appendSequence() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            data.append(contentsOf: repeatElement(UInt8(0xFF), count: 2))
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_appendContentsOf() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            data.append(contentsOf: [0xFF, 0xFF])
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_resetBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0, 0, 0, 1, 1]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_replaceSubrange() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_replaceSubrangeRange() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_replaceSubrangeWithBuffer() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0) }
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_replaceSubrangeWithCollection() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: [0xFF, 0xFF])
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_cow_customBacking_replaceSubrangeWithBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            bytes.withUnsafeBytes {
+                data.replaceSubrange(range, with: $0.baseAddress!, count: $0.count)
+            }
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_withUnsafeMutableBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 1).pointee = 0xFF
+            }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_appendBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { (buffer) in
+                data.append(buffer.baseAddress!, count: buffer.count)
+            }
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_appendData() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            data.append(Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_appendBuffer() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.append($0) }
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_appendSequence() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            data.append(contentsOf: repeatElement(UInt8(0xFF), count: 2))
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_appendContentsOf() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            data.append(contentsOf: [0xFF, 0xFF])
+            XCTAssertEqual(data, Data(bytes: [1, 1, 1, 1, 1, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_resetBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 1]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_replaceSubrange() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_replaceSubrangeRange() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_replaceSubrangeWithBuffer() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0) }
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_replaceSubrangeWithCollection() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: [0xFF, 0xFF])
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customBacking_replaceSubrangeWithBytes() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBytes {
+                data.replaceSubrange(range, with: $0.baseAddress!, count: $0.count)
+            }
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 1]))
+        }
+    }
+    
+    func test_validateMutation_customMutableBacking_withUnsafeMutableBytes() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 5).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0xFF)
+    }
+    
+    func test_validateMutation_customMutableBacking_appendBytes() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customMutableBacking_appendData() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        data.append(Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customMutableBacking_appendBuffer() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customMutableBacking_appendSequence() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        data.append(contentsOf: repeatElement(UInt8(0xFF), count: 2))
+        XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customMutableBacking_appendContentsOf() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        data.append(contentsOf: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_customMutableBacking_resetBytes() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        data.resetBytes(in: 5..<8)
+        XCTAssertEqual(data.count, 10)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 0)], 1)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 6)], 0)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 7)], 0)
+    }
+    
+    func test_validateMutation_customMutableBacking_replaceSubrange() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_customMutableBacking_replaceSubrangeRange() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_customMutableBacking_replaceSubrangeWithBuffer() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0) }
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_customMutableBacking_replaceSubrangeWithCollection() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_customMutableBacking_replaceSubrangeWithBytes() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_withUnsafeMutableBytes() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 1).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_appendBytes() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_appendData() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        data.append(Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_appendBuffer() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_appendSequence() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.append($0) }
+        XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_appendContentsOf() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        data.append(contentsOf: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_resetBytes() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        data.resetBytes(in: 5..<8)
+        
+        XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 2)], 0)
+        XCTAssertEqual(data[data.startIndex.advanced(by: 3)], 0)
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_replaceSubrange() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_replaceSubrangeRange() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_replaceSubrangeWithBuffer() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0) }
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_replaceSubrangeWithCollection() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        data.replaceSubrange(range, with: [0xFF, 0xFF])
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_replaceSubrangeWithBytes() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+        let bytes: [UInt8] = [0xFF, 0xFF]
+        bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0.baseAddress!, count: $0.count) }
+        XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_withUnsafeMutableBytes() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 5).pointee = 0xFF
+            }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0xFF)
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_appendBytes() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+            XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_appendData() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            data.append(Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_appendBuffer() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.append($0) }
+            XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_appendSequence() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            data.append(contentsOf: repeatElement(UInt8(0xFF), count: 2))
+            XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_appendContentsOf() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            data.append(contentsOf: [0xFF, 0xFF])
+            XCTAssertEqual(data, Data(bytes: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_resetBytes() {
+        var data = Data(referencing: AllOnesData(length: 10))
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data.count, 10)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 0)], 1)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 5)], 0)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 6)], 0)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 7)], 0)
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_replaceSubrange() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0]))
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_replaceSubrangeRange() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0]))
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_replaceSubrangeWithBuffer() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0) }
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0]))
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_replaceSubrangeWithCollection() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: [0xFF, 0xFF])
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0]))
+        }
+    }
+    
+    func test_validateMutation_cow_customMutableBacking_replaceSubrangeWithBytes() {
+        var data = Data(referencing: AllOnesData(length: 1))
+        data.count = 10
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0.baseAddress!, count: $0.count) }
+            XCTAssertEqual(data, Data(bytes: [1, 0xFF, 0xFF, 0]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_withUnsafeMutableBytes() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+                ptr.advanced(by: 1).pointee = 0xFF
+            }
+            XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_appendBytes() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.append($0.baseAddress!, count: $0.count) }
+            XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_appendData() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            data.append(Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_appendBuffer() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.append($0) }
+            XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_appendSequence() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            data.append(contentsOf: repeatElement(UInt8(0xFF), count: 2))
+            XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_appendContentsOf() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            data.append(contentsOf: [0xFF, 0xFF])
+            XCTAssertEqual(data, Data(bytes: [0, 0, 0, 0, 0, 0xFF, 0xFF]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_resetBytes() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            data.resetBytes(in: 5..<8)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 2)], 0)
+            XCTAssertEqual(data[data.startIndex.advanced(by: 3)], 0)
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_replaceSubrange() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeRange() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: Data(bytes: [0xFF, 0xFF]))
+            XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithBuffer() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0) }
+            XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithCollection() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            data.replaceSubrange(range, with: [0xFF, 0xFF])
+            XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+        }
+    }
+    
+    func test_validateMutation_slice_cow_customMutableBacking_replaceSubrangeWithBytes() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<9]
+        holdReference(data) {
+            let range: Range<Int> = data.startIndex.advanced(by: 1)..<data.endIndex.advanced(by: -1)
+            let bytes: [UInt8] = [0xFF, 0xFF]
+            bytes.withUnsafeBufferPointer { data.replaceSubrange(range, with: $0.baseAddress!, count: $0.count) }
+            XCTAssertEqual(data, Data(bytes: [0, 0xFF, 0xFF, 0]))
+        }
+    }
+    
+    func test_sliceHash() {
+        let base1 = Data(bytes: [0, 0xFF, 0xFF, 0])
+        let base2 = Data(bytes: [0, 0xFF, 0xFF, 0])
+        let base3 = Data(bytes: [0xFF, 0xFF, 0xFF, 0])
+        let sliceEmulation = Data(bytes: [0xFF, 0xFF])
+        XCTAssertEqual(base1.hashValue, base2.hashValue)
+        let slice1 = base1[base1.startIndex.advanced(by: 1)..<base1.endIndex.advanced(by: -1)]
+        let slice2 = base2[base2.startIndex.advanced(by: 1)..<base2.endIndex.advanced(by: -1)]
+        let slice3 = base3[base3.startIndex.advanced(by: 1)..<base3.endIndex.advanced(by: -1)]
+        XCTAssertEqual(slice1.hashValue, sliceEmulation.hashValue)
+        XCTAssertEqual(slice1.hashValue, slice2.hashValue)
+        XCTAssertEqual(slice2.hashValue, slice3.hashValue)
+    }
+
+    func test_slice_resize_growth() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<9]
+        data.resetBytes(in: data.endIndex.advanced(by: -1)..<data.endIndex.advanced(by: 1))
+        XCTAssertEqual(data, Data(bytes: [4, 5, 6, 7, 0, 0]))
+    }
+
+    func test_hashEmptyData() {
+        let d1 = Data()
+        let h1 = d1.hashValue
+
+        let d2 = NSData() as Data
+        let h2 = d2.hashValue
+        XCTAssertEqual(h1, h2)
+
+        let data = Data(bytes: [0, 1, 2, 3, 4, 5, 6])
+        let d3 = data[4..<4]
+        let h3 = d3.hashValue
+        XCTAssertEqual(h1, h3)
+    }
+    
+    func test_validateMutation_slice_withUnsafeMutableBytes_lengthLessThanLowerBound() {
+        var data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])[4..<6]
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 1).pointee = 0xFF
+        }
+        XCTAssertEqual(data, Data(bytes: [4, 0xFF]))
+    }
+    
+    func test_validateMutation_slice_immutableBacking_withUnsafeMutableBytes_lengthLessThanLowerBound() {
+        var data = Data(referencing: NSData(bytes: "hello world", length: 11))[4..<6]
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 1).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+    }
+    
+    func test_validateMutation_slice_mutableBacking_withUnsafeMutableBytes_lengthLessThanLowerBound() {
+        var base = Data(referencing: NSData(bytes: "hello world", length: 11))
+        base.append(contentsOf: [1, 2, 3, 4, 5, 6])
+        var data = base[4..<6]
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 1).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+    }
+    
+    func test_validateMutation_slice_customBacking_withUnsafeMutableBytes_lengthLessThanLowerBound() {
+        var data = Data(referencing: AllOnesImmutableData(length: 10))[4..<6]
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 1).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+    }
+    
+    func test_validateMutation_slice_customMutableBacking_withUnsafeMutableBytes_lengthLessThanLowerBound() {
+        var base = Data(referencing: AllOnesData(length: 1))
+        base.count = 10
+        var data = base[4..<6]
+        data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) in
+            ptr.advanced(by: 1).pointee = 0xFF
+        }
+        XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 0xFF)
+    }
+
+    func test_byte_access_of_discontiguousData() {
+        var d = DispatchData.empty
+        let bytes: [UInt8] = [0, 1, 2, 3, 4, 5]
+        for _ in 0..<3 {
+            bytes.withUnsafeBufferPointer {
+                d.append($0)
+            }
+        }
+        let ref = d as AnyObject
+        let data = ref as! Data
+
+        let cnt = data.count - 4
+        let t = data.dropFirst(4).withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
+            return Data(bytes: bytes, count: cnt)
+        }
+
+        XCTAssertEqual(Data(bytes: [4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5]), t)
+    }
+
+    func test_rangeOfSlice() {
+        let data = "FooBar".data(using: .ascii)!
+        let slice = data[3...] // Bar
+
+        let range = slice.range(of: "a".data(using: .ascii)!)
+        XCTAssertEqual(range, 4..<5 as Range<Data.Index>)
+    }
+
+    func test_nsdataSequence() {
+        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+            let bytes: [UInt8] = Array(0x00...0xFF)
+            let data = bytes.withUnsafeBytes { NSData(bytes: $0.baseAddress, length: $0.count) }
+
+            for byte in bytes {
+                XCTAssertEqual(data[Int(byte)], byte)
+            }
+        }
+    }
+
+    func test_dispatchSequence() {
+        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+            let bytes1: [UInt8] = Array(0x00..<0xF0)
+            let bytes2: [UInt8] = Array(0xF0..<0xFF)
+            var data = DispatchData.empty
+            bytes1.withUnsafeBytes {
+                data.append($0)
+            }
+            bytes2.withUnsafeBytes {
+                data.append($0)
+            }
+
+            for byte in bytes1 {
+                XCTAssertEqual(data[Int(byte)], byte)
+            }
+            for byte in bytes2 {
+                XCTAssertEqual(data[Int(byte)], byte)
+            }
+        }
+    }
+
+    func test_increaseCount() {
+        // https://github.com/apple/swift/pull/28919
+        guard #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) else { return }
+        let initials: [Range<UInt8>] = [
+            0..<0,
+            0..<2,
+            0..<4,
+            0..<8,
+            0..<16,
+            0..<32,
+            0..<64
+        ]
+        let diffs = [0, 1, 2, 4, 8, 16, 32]
+        for initial in initials {
+            for diff in diffs {
+                var data = Data(initial)
+                data.count += diff
+                XCTAssertEqual(
+                    Data(Array(initial) + Array(repeating: 0, count: diff)),
+                    data)
+            }
+        }
+    }
+
+    func test_decreaseCount() {
+        // https://github.com/apple/swift/pull/28919
+        guard #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) else { return }
+        let initials: [Range<UInt8>] = [
+            0..<0,
+            0..<2,
+            0..<4,
+            0..<8,
+            0..<16,
+            0..<32,
+            0..<64
+        ]
+        let diffs = [0, 1, 2, 4, 8, 16, 32]
+        for initial in initials {
+            for diff in diffs {
+                guard initial.count >= diff else { continue }
+                var data = Data(initial)
+                data.count -= diff
+                XCTAssertEqual(
+                    Data(initial.dropLast(diff)),
+                    data)
+            }
+        }
+    }
+
+    // This is a (potentially invalid) sequence that produces a configurable number of 42s and has a freely customizable `underestimatedCount`.
+    struct TestSequence: Sequence {
+        typealias Element = UInt8
+        struct Iterator: IteratorProtocol {
+            var _remaining: Int
+            init(_ count: Int) {
+                _remaining = count
+            }
+            mutating func next() -> UInt8? {
+                guard _remaining > 0 else { return nil }
+                _remaining -= 1
+                return 42
+            }
+        }
+        let underestimatedCount: Int
+        let count: Int
+
+        func makeIterator() -> Iterator {
+            return Iterator(count)
+        }
+    }
+
+    func test_init_TestSequence() {
+        // Underestimated count
+        do {
+            let d = Data(TestSequence(underestimatedCount: 0, count: 10))
+            XCTAssertEqual(10, d.count)
+            XCTAssertEqual(Array(repeating: 42 as UInt8, count: 10), Array(d))
+        }
+
+        // Very underestimated count (to exercise realloc path)
+        do {
+            let d = Data(TestSequence(underestimatedCount: 0, count: 1000))
+            XCTAssertEqual(1000, d.count)
+            XCTAssertEqual(Array(repeating: 42 as UInt8, count: 1000), Array(d))
+        }
+
+        // Exact count
+        do {
+            let d = Data(TestSequence(underestimatedCount: 10, count: 10))
+            XCTAssertEqual(10, d.count)
+            XCTAssertEqual(Array(repeating: 42 as UInt8, count: 10), Array(d))
+        }
+
+        // Overestimated count. This is an illegal case, so trapping would be fine.
+        // However, for compatibility with the implementation in Swift 5, Data
+        // handles this case by simply truncating itself to the actual size.
+        do {
+            let d = Data(TestSequence(underestimatedCount: 20, count: 10))
+            XCTAssertEqual(10, d.count)
+            XCTAssertEqual(Array(repeating: 42 as UInt8, count: 10), Array(d))
+        }
+    }
+
+    func test_append_TestSequence() {
+        let base = Data(Array(repeating: 23 as UInt8, count: 10))
+
+        // Underestimated count
+        do {
+            var d = base
+            d.append(contentsOf: TestSequence(underestimatedCount: 0, count: 10))
+            XCTAssertEqual(20, d.count)
+            XCTAssertEqual(Array(base) + Array(repeating: 42 as UInt8, count: 10),
+                           Array(d))
+        }
+
+        // Very underestimated count (to exercise realloc path)
+        do {
+            var d = base
+            d.append(contentsOf: TestSequence(underestimatedCount: 0, count: 1000))
+            XCTAssertEqual(1010, d.count)
+            XCTAssertEqual(Array(base) + Array(repeating: 42 as UInt8, count: 1000), Array(d))
+        }
+
+        // Exact count
+        do {
+            var d = base
+            d.append(contentsOf: TestSequence(underestimatedCount: 10, count: 10))
+            XCTAssertEqual(20, d.count)
+            XCTAssertEqual(Array(base) + Array(repeating: 42 as UInt8, count: 10), Array(d))
+        }
+
+        // Overestimated count. This is an illegal case, so trapping would be fine.
+        // However, for compatibility with the implementation in Swift 5, Data
+        // handles this case by simply truncating itself to the actual size.
+        do {
+            var d = base
+            d.append(contentsOf: TestSequence(underestimatedCount: 20, count: 10))
+            XCTAssertEqual(20, d.count)
+            XCTAssertEqual(Array(base) + Array(repeating: 42 as UInt8, count: 10), Array(d))
+        }
+    }
+
+    #if false // FIXME: XCTest doesn't support crash tests yet rdar://20195010&22387653
+    func test_bounding_failure_subdata() {
+        let data = "Hello World".data(using: .utf8)!
+        expectCrashLater()
+        let c = data.subdata(in: 5..<200)
+    }
+    #endif
+
+    #if false // FIXME: XCTest doesn't support crash tests yet rdar://20195010&22387653
+    func test_bounding_failure_replace() {
+        var data = "Hello World".data(using: .utf8)!
+        expectCrashLater()
+        data.replaceSubrange(5..<200, with: Data())
+    }
+    #endif
+
+    #if false // FIXME: XCTest doesn't support crash tests yet rdar://20195010&22387653
+    func test_bounding_failure_replace2() {
+        var data = "a".data(using: .utf8)!
+        var bytes : [UInt8] = [1, 2, 3]
+        expectCrashLater()
+        bytes.withUnsafeBufferPointer {
+            // lowerBound ok, upperBound after end of data
+            data.replaceSubrange(0..<2, with: $0)
+        }
+    }
+    #endif
+
+    #if false // FIXME: XCTest doesn't support crash tests yet rdar://20195010&22387653
+    func test_bounding_failure_replace3() {
+        var data = "a".data(using: .utf8)!
+        var bytes : [UInt8] = [1, 2, 3]
+        expectCrashLater()
+        bytes.withUnsafeBufferPointer {
+            // lowerBound is > length
+            data.replaceSubrange(2..<4, with: $0)
+        }
+    }
+    #endif
+
+    #if false // FIXME: XCTest doesn't support crash tests yet rdar://20195010&22387653
+    func test_bounding_failure_replace4() {
+        var data = "a".data(using: .utf8)!
+        var bytes : [UInt8] = [1, 2, 3]
+        expectCrashLater()
+        // lowerBound is > length
+        data.replaceSubrange(2..<4, with: bytes)
+    }
+    #endif
+
+    #if false // FIXME: XCTest doesn't support crash tests yet rdar://20195010&22387653
+    func test_bounding_failure_reset_range() {
+        var data = "Hello World".data(using: .utf8)!
+        expectCrashLater()
+        data.resetBytes(in: 100..<200)
+    }
+    #endif
+
+    #if false // FIXME: XCTest doesn't support crash tests yet rdar://20195010&22387653
+    func test_bounding_failure_append_bad_length() {
+        var data = "Hello World".data(using: .utf8)!
+        expectCrashLater()
+        data.append("hello", count: -2)
+    }
+    #endif
+
+    #if false // FIXME: XCTest doesn't support crash tests yet rdar://20195010&22387653
+    func test_bounding_failure_append_absurd_length() {
+        var data = "Hello World".data(using: .utf8)!
+        expectCrashLater()
+        data.append("hello", count: Int.min)
+    }
+    #endif
+
+    #if false // FIXME: XCTest doesn't support crash tests yet rdar://20195010&22387653
+    func test_bounding_failure_subscript() {
+        var data = "Hello World".data(using: .utf8)!
+        expectCrashLater()
+        data[100] = 4
+    }
+    #endif
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestDate.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestDate.swift
@@ -1,0 +1,204 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import CoreFoundation
+import XCTest
+
+class TestDate : XCTestCase {
+
+    func testDateComparison() {
+        let d1 = Date()
+        let d2 = d1 + 1
+        
+        XCTAssertTrue(d2 > d1)
+        XCTAssertTrue(d1 < d2)
+        
+        let d3 = Date(timeIntervalSince1970: 12345)
+        let d4 = Date(timeIntervalSince1970: 12345)
+        
+        XCTAssertTrue(d3 == d4)
+        XCTAssertTrue(d3 <= d4)
+        XCTAssertTrue(d4 >= d3)
+    }
+    
+    func testDateMutation() {
+        let d0 = Date()
+        var d1 = Date()
+        d1 = d1 + 1
+        let d2 = Date(timeIntervalSinceNow: 10)
+        
+        XCTAssertTrue(d2 > d1)
+        XCTAssertTrue(d1 != d0)
+        
+        let d3 = d1
+        d1 += 10
+        XCTAssertTrue(d1 > d3)
+    }
+
+    func testCast() {
+        let d0 = NSDate()
+        let d1 = d0 as Date
+        XCTAssertEqual(d0.timeIntervalSinceReferenceDate, d1.timeIntervalSinceReferenceDate)
+    }
+
+    func testDistantPast() {
+        let distantPast = Date.distantPast
+        let currentDate = Date()
+        XCTAssertTrue(distantPast < currentDate)
+        XCTAssertTrue(currentDate > distantPast)
+        XCTAssertTrue(distantPast.timeIntervalSince(currentDate) < 3600.0*24*365*100) /* ~1 century in seconds */
+    }
+
+    func testDistantFuture() {
+        let distantFuture = Date.distantFuture
+        let currentDate = Date()
+        XCTAssertTrue(currentDate < distantFuture)
+        XCTAssertTrue(distantFuture > currentDate)
+        XCTAssertTrue(distantFuture.timeIntervalSince(currentDate) > 3600.0*24*365*100) /* ~1 century in seconds */
+    }
+
+    func dateWithString(_ str: String) -> Date {
+        let formatter = DateFormatter()
+        // Note: Calendar(identifier:) is OSX 10.9+ and iOS 8.0+ whereas the CF version has always been available
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        return formatter.date(from: str)! as Date
+    }
+
+    func testEquality() {
+        let date = dateWithString("2010-05-17 14:49:47 -0700")
+        let sameDate = dateWithString("2010-05-17 14:49:47 -0700")
+        XCTAssertEqual(date, sameDate)
+        XCTAssertEqual(sameDate, date)
+
+        let differentDate = dateWithString("2010-05-17 14:49:46 -0700")
+        XCTAssertNotEqual(date, differentDate)
+        XCTAssertNotEqual(differentDate, date)
+
+        let sameDateByTimeZone = dateWithString("2010-05-17 13:49:47 -0800")
+        XCTAssertEqual(date, sameDateByTimeZone)
+        XCTAssertEqual(sameDateByTimeZone, date)
+
+        let differentDateByTimeZone = dateWithString("2010-05-17 14:49:47 -0800")
+        XCTAssertNotEqual(date, differentDateByTimeZone)
+        XCTAssertNotEqual(differentDateByTimeZone, date)
+    }
+
+    func testTimeIntervalSinceDate() {
+        let referenceDate = dateWithString("1900-01-01 00:00:00 +0000")
+        let sameDate = dateWithString("1900-01-01 00:00:00 +0000")
+        let laterDate = dateWithString("2010-05-17 14:49:47 -0700")
+        let earlierDate = dateWithString("1810-05-17 14:49:47 -0700")
+
+        let laterSeconds = laterDate.timeIntervalSince(referenceDate)
+        XCTAssertEqual(laterSeconds, 3483121787.0)
+
+        let earlierSeconds = earlierDate.timeIntervalSince(referenceDate)
+        XCTAssertEqual(earlierSeconds, -2828311813.0)
+
+        let sameSeconds = sameDate.timeIntervalSince(referenceDate)
+        XCTAssertEqual(sameSeconds, 0.0)
+    }
+    
+    func testDateComponents() {
+        // Make sure the optional init stuff works
+        let dc = DateComponents()
+        
+        XCTAssertNil(dc.year)
+        
+        let dc2 = DateComponents(year: 1999)
+        
+        XCTAssertNil(dc2.day)
+        XCTAssertEqual(1999, dc2.year)
+    }
+
+    func test_DateHashing() {
+        let values: [Date] = [
+            dateWithString("2010-05-17 14:49:47 -0700"),
+            dateWithString("2011-05-17 14:49:47 -0700"),
+            dateWithString("2010-06-17 14:49:47 -0700"),
+            dateWithString("2010-05-18 14:49:47 -0700"),
+            dateWithString("2010-05-17 15:49:47 -0700"),
+            dateWithString("2010-05-17 14:50:47 -0700"),
+            dateWithString("2010-05-17 14:49:48 -0700"),
+        ]
+        checkHashable(values, equalityOracle: { $0 == $1 })
+    }
+
+    func test_AnyHashableContainingDate() {
+        let values: [Date] = [
+            dateWithString("2016-05-17 14:49:47 -0700"),
+            dateWithString("2010-05-17 14:49:47 -0700"),
+            dateWithString("2010-05-17 14:49:47 -0700"),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(Date.self, type(of: anyHashables[0].base))
+        expectEqual(Date.self, type(of: anyHashables[1].base))
+        expectEqual(Date.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableCreatedFromNSDate() {
+        let values: [NSDate] = [
+            NSDate(timeIntervalSince1970: 1000000000),
+            NSDate(timeIntervalSince1970: 1000000001),
+            NSDate(timeIntervalSince1970: 1000000001),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(Date.self, type(of: anyHashables[0].base))
+        expectEqual(Date.self, type(of: anyHashables[1].base))
+        expectEqual(Date.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableContainingDateComponents() {
+        let values: [DateComponents] = [
+            DateComponents(year: 2016),
+            DateComponents(year: 1995),
+            DateComponents(year: 1995),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(DateComponents.self, type(of: anyHashables[0].base))
+        expectEqual(DateComponents.self, type(of: anyHashables[1].base))
+        expectEqual(DateComponents.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableCreatedFromNSDateComponents() {
+        func makeNSDateComponents(year: Int) -> NSDateComponents {
+            let result = NSDateComponents()
+            result.year = year
+            return result
+        }
+        let values: [NSDateComponents] = [
+            makeNSDateComponents(year: 2016),
+            makeNSDateComponents(year: 1995),
+            makeNSDateComponents(year: 1995),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(DateComponents.self, type(of: anyHashables[0].base))
+        expectEqual(DateComponents.self, type(of: anyHashables[1].base))
+        expectEqual(DateComponents.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_dateComponents_unconditionallyBridgeFromObjectiveC() {
+        XCTAssertEqual(DateComponents(), DateComponents._unconditionallyBridgeFromObjectiveC(nil))
+    }
+}
+

--- a/Darwin/Foundation-swiftoverlay-Tests/TestDateInterval.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestDateInterval.swift
@@ -1,0 +1,191 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+class TestDateInterval : XCTestCase {
+    func dateWithString(_ str: String) -> Date {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+        return formatter.date(from: str)! as Date
+    }
+
+    func test_compareDateIntervals() {
+        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+            let start = dateWithString("2010-05-17 14:49:47 -0700")
+            let duration: TimeInterval = 10000000.0
+            let testInterval1 = DateInterval(start: start, duration: duration)
+            let testInterval2 = DateInterval(start: start, duration: duration)
+            XCTAssertEqual(testInterval1, testInterval2)
+            XCTAssertEqual(testInterval2, testInterval1)
+            XCTAssertEqual(testInterval1.compare(testInterval2), ComparisonResult.orderedSame)
+            
+            let testInterval3 = DateInterval(start: start, duration: 10000000000.0)
+            XCTAssertTrue(testInterval1 < testInterval3)
+            XCTAssertTrue(testInterval3 > testInterval1)
+            
+            let earlierStart = dateWithString("2009-05-17 14:49:47 -0700")
+            let testInterval4 = DateInterval(start: earlierStart, duration: duration)
+            
+            XCTAssertTrue(testInterval4 < testInterval1)
+            XCTAssertTrue(testInterval1 > testInterval4)
+        }
+    }
+
+    func test_isEqualToDateInterval() {
+        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+            let start = dateWithString("2010-05-17 14:49:47 -0700")
+            let duration = 10000000.0
+            let testInterval1 = DateInterval(start: start, duration: duration)
+            let testInterval2 = DateInterval(start: start, duration: duration)
+            
+            XCTAssertEqual(testInterval1, testInterval2)
+            
+            let testInterval3 = DateInterval(start: start, duration: 100.0)
+            XCTAssertNotEqual(testInterval1, testInterval3)
+        }
+    }
+
+    func test_hashing() {
+        guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else { return }
+
+        let start1a = dateWithString("2019-04-04 17:09:23 -0700")
+        let start1b = dateWithString("2019-04-04 17:09:23 -0700")
+        let start2a = Date(timeIntervalSinceReferenceDate: start1a.timeIntervalSinceReferenceDate.nextUp)
+        let start2b = Date(timeIntervalSinceReferenceDate: start1a.timeIntervalSinceReferenceDate.nextUp)
+        let duration1 = 1800.0
+        let duration2 = duration1.nextUp
+        let intervals: [[DateInterval]] = [
+            [
+                DateInterval(start: start1a, duration: duration1),
+                DateInterval(start: start1b, duration: duration1),
+            ],
+            [
+                DateInterval(start: start1a, duration: duration2),
+                DateInterval(start: start1b, duration: duration2),
+            ],
+            [
+                DateInterval(start: start2a, duration: duration1),
+                DateInterval(start: start2b, duration: duration1),
+            ],
+            [
+                DateInterval(start: start2a, duration: duration2),
+                DateInterval(start: start2b, duration: duration2),
+            ],
+        ]
+        checkHashableGroups(intervals)
+    }
+
+    func test_checkIntersection() {
+        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+            let start1 = dateWithString("2010-05-17 14:49:47 -0700")
+            let end1 = dateWithString("2010-08-17 14:49:47 -0700")
+            
+            let testInterval1 = DateInterval(start: start1, end: end1)
+            
+            let start2 = dateWithString("2010-02-17 14:49:47 -0700")
+            let end2 = dateWithString("2010-07-17 14:49:47 -0700")
+            
+            let testInterval2 = DateInterval(start: start2, end: end2)
+            
+            XCTAssertTrue(testInterval1.intersects(testInterval2))
+            
+            let start3 = dateWithString("2010-10-17 14:49:47 -0700")
+            let end3 = dateWithString("2010-11-17 14:49:47 -0700")
+            
+            let testInterval3 = DateInterval(start: start3, end: end3)
+            
+            XCTAssertFalse(testInterval1.intersects(testInterval3))
+        }
+    }
+
+    func test_validIntersections() {
+        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+            let start1 = dateWithString("2010-05-17 14:49:47 -0700")
+            let end1 = dateWithString("2010-08-17 14:49:47 -0700")
+            
+            let testInterval1 = DateInterval(start: start1, end: end1)
+            
+            let start2 = dateWithString("2010-02-17 14:49:47 -0700")
+            let end2 = dateWithString("2010-07-17 14:49:47 -0700")
+            
+            let testInterval2 = DateInterval(start: start2, end: end2)
+            
+            let start3 = dateWithString("2010-05-17 14:49:47 -0700")
+            let end3 = dateWithString("2010-07-17 14:49:47 -0700")
+            
+            let testInterval3 = DateInterval(start: start3, end: end3)
+            
+            let intersection1 = testInterval2.intersection(with: testInterval1)
+            XCTAssertNotNil(intersection1)
+            XCTAssertEqual(testInterval3, intersection1)
+            
+            let intersection2 = testInterval1.intersection(with: testInterval2)
+            XCTAssertNotNil(intersection2)
+            XCTAssertEqual(intersection1, intersection2)
+        }
+    }
+
+    func test_containsDate() {
+        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+            let start = dateWithString("2010-05-17 14:49:47 -0700")
+            let duration = 10000000.0
+            
+            let testInterval = DateInterval(start: start, duration: duration)
+            let containedDate = dateWithString("2010-05-17 20:49:47 -0700")
+            
+            XCTAssertTrue(testInterval.contains(containedDate))
+            
+            let earlierStart = dateWithString("2009-05-17 14:49:47 -0700")
+            XCTAssertFalse(testInterval.contains(earlierStart))
+        }
+    }
+
+    func test_AnyHashableContainingDateInterval() {
+        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+            let start = dateWithString("2010-05-17 14:49:47 -0700")
+            let duration = 10000000.0
+            let values: [DateInterval] = [
+                DateInterval(start: start, duration: duration),
+                DateInterval(start: start, duration: duration / 2),
+                DateInterval(start: start, duration: duration / 2),
+            ]
+            let anyHashables = values.map(AnyHashable.init)
+            expectEqual(DateInterval.self, type(of: anyHashables[0].base))
+            expectEqual(DateInterval.self, type(of: anyHashables[1].base))
+            expectEqual(DateInterval.self, type(of: anyHashables[2].base))
+            XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+            XCTAssertEqual(anyHashables[1], anyHashables[2])
+        }
+    }
+
+    func test_AnyHashableCreatedFromNSDateInterval() {
+        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+            let start = dateWithString("2010-05-17 14:49:47 -0700")
+            let duration = 10000000.0
+            let values: [NSDateInterval] = [
+                NSDateInterval(start: start, duration: duration),
+                NSDateInterval(start: start, duration: duration / 2),
+                NSDateInterval(start: start, duration: duration / 2),
+            ]
+            let anyHashables = values.map(AnyHashable.init)
+            expectEqual(DateInterval.self, type(of: anyHashables[0].base))
+            expectEqual(DateInterval.self, type(of: anyHashables[1].base))
+            expectEqual(DateInterval.self, type(of: anyHashables[2].base))
+            XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+            XCTAssertEqual(anyHashables[1], anyHashables[2])
+        }
+    }
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
@@ -1,0 +1,595 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+class TestDecimal : XCTestCase {
+    func test_AdditionWithNormalization() {
+        
+        let biggie = Decimal(65536)
+        let smallee = Decimal(65536)
+        let answer = biggie/smallee
+        XCTAssertEqual(Decimal(1),answer)
+        
+        var one = Decimal(1)
+        var addend = Decimal(1)
+        var expected = Decimal()
+        var result = Decimal()
+        
+        expected._isNegative = 0;
+        expected._isCompact = 0;
+        
+        // 2 digits -- certain to work
+        addend._exponent = -1;
+        XCTAssertEqual(.noError, NSDecimalAdd(&result, &one, &addend, .plain), "1 + 0.1")
+        expected._exponent = -1;
+        expected._length = 1;
+        expected._mantissa.0 = 11;
+        XCTAssertEqual(.orderedSame, NSDecimalCompare(&expected, &result), "1.1 == 1 + 0.1")
+        
+        // 38 digits -- guaranteed by NSDecimal to work
+        addend._exponent = -37;
+        XCTAssertEqual(.noError, NSDecimalAdd(&result, &one, &addend, .plain), "1 + 1e-37")
+        expected._exponent = -37;
+        expected._length = 8;
+        expected._mantissa.0 = 0x0001;
+        expected._mantissa.1 = 0x0000;
+        expected._mantissa.2 = 0x36a0;
+        expected._mantissa.3 = 0x00f4;
+        expected._mantissa.4 = 0x46d9;
+        expected._mantissa.5 = 0xd5da;
+        expected._mantissa.6 = 0xee10;
+        expected._mantissa.7 = 0x0785;
+        XCTAssertEqual(.orderedSame, NSDecimalCompare(&expected, &result), "1 + 1e-37")
+        
+        // 39 digits -- not guaranteed to work but it happens to, so we make the test work either way
+        addend._exponent = -38;
+        let error = NSDecimalAdd(&result, &one, &addend, .plain)
+        XCTAssertTrue(error == .noError || error == .lossOfPrecision, "1 + 1e-38")
+        if error == .noError {
+            expected._exponent = -38;
+            expected._length = 8;
+            expected._mantissa.0 = 0x0001;
+            expected._mantissa.1 = 0x0000;
+            expected._mantissa.2 = 0x2240;
+            expected._mantissa.3 = 0x098a;
+            expected._mantissa.4 = 0xc47a;
+            expected._mantissa.5 = 0x5a86;
+            expected._mantissa.6 = 0x4ca8;
+            expected._mantissa.7 = 0x4b3b;
+            XCTAssertEqual(.orderedSame, NSDecimalCompare(&expected, &result), "1 + 1e-38")
+        } else {
+            XCTAssertEqual(.orderedSame, NSDecimalCompare(&one, &result), "1 + 1e-38")
+        }
+        
+        // 40 digits -- doesn't work; need to make sure it's rounding for us
+        addend._exponent = -39;
+        XCTAssertEqual(.lossOfPrecision, NSDecimalAdd(&result, &one, &addend, .plain), "1 + 1e-39")
+        XCTAssertEqual("1", result.description)
+        XCTAssertEqual(.orderedSame, NSDecimalCompare(&one, &result), "1 + 1e-39")
+    }
+
+    func test_BasicConstruction() {
+        let zero = Decimal()
+        XCTAssertEqual(20, MemoryLayout<Decimal>.size)
+        XCTAssertEqual(0, zero._exponent)
+        XCTAssertEqual(0, zero._length)
+        XCTAssertEqual(0, zero._isNegative)
+        XCTAssertEqual(0, zero._isCompact)
+        XCTAssertEqual(0, zero._reserved)
+        let (m0, m1, m2, m3, m4, m5, m6, m7) = zero._mantissa
+        XCTAssertEqual(0, m0)
+        XCTAssertEqual(0, m1)
+        XCTAssertEqual(0, m2)
+        XCTAssertEqual(0, m3)
+        XCTAssertEqual(0, m4)
+        XCTAssertEqual(0, m5)
+        XCTAssertEqual(0, m6)
+        XCTAssertEqual(0, m7)
+        XCTAssertEqual(8, NSDecimalMaxSize)
+        XCTAssertEqual(32767, NSDecimalNoScale)
+        XCTAssertFalse(zero.isNormal)
+        XCTAssertTrue(zero.isFinite)
+        XCTAssertTrue(zero.isZero)
+        XCTAssertFalse(zero.isSubnormal)
+        XCTAssertFalse(zero.isInfinite)
+        XCTAssertFalse(zero.isNaN)
+        XCTAssertFalse(zero.isSignaling)
+
+        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+            let d1 = Decimal(1234567890123456789 as UInt64)
+            XCTAssertEqual(d1._exponent, 0)
+            XCTAssertEqual(d1._length, 4)
+        }
+    }
+    func test_Constants() {
+        XCTAssertEqual(8, NSDecimalMaxSize)
+        XCTAssertEqual(32767, NSDecimalNoScale)
+        let smallest = Decimal(_exponent: 127, _length: 8, _isNegative: 1, _isCompact: 1, _reserved: 0, _mantissa: (UInt16.max, UInt16.max, UInt16.max, UInt16.max, UInt16.max, UInt16.max, UInt16.max, UInt16.max))
+        XCTAssertEqual(smallest, Decimal.leastFiniteMagnitude)
+        let biggest = Decimal(_exponent: 127, _length: 8, _isNegative: 0, _isCompact: 1, _reserved: 0, _mantissa: (UInt16.max, UInt16.max, UInt16.max, UInt16.max, UInt16.max, UInt16.max, UInt16.max, UInt16.max))
+        XCTAssertEqual(biggest, Decimal.greatestFiniteMagnitude)
+        let leastNormal = Decimal(_exponent: -127, _length: 1, _isNegative: 0, _isCompact: 1, _reserved: 0, _mantissa: (1, 0, 0, 0, 0, 0, 0, 0))
+        XCTAssertEqual(leastNormal, Decimal.leastNormalMagnitude)
+        let leastNonzero = Decimal(_exponent: -127, _length: 1, _isNegative: 0, _isCompact: 1, _reserved: 0, _mantissa: (1, 0, 0, 0, 0, 0, 0, 0))
+        XCTAssertEqual(leastNonzero, Decimal.leastNonzeroMagnitude)
+        let pi = Decimal(_exponent: -38, _length: 8, _isNegative: 0, _isCompact: 1, _reserved: 0, _mantissa: (0x6623, 0x7d57, 0x16e7, 0xad0d, 0xaf52, 0x4641, 0xdfa7, 0xec58))
+        XCTAssertEqual(pi, Decimal.pi)
+        XCTAssertEqual(10, Decimal.radix)
+        XCTAssertTrue(Decimal().isCanonical)
+        XCTAssertFalse(Decimal().isSignalingNaN)
+        XCTAssertFalse(Decimal.nan.isSignalingNaN)
+        XCTAssertTrue(Decimal.nan.isNaN)
+        XCTAssertEqual(.quietNaN, Decimal.nan.floatingPointClass)
+        XCTAssertEqual(.positiveZero, Decimal().floatingPointClass)
+        XCTAssertEqual(.negativeNormal, smallest.floatingPointClass)
+        XCTAssertEqual(.positiveNormal, biggest.floatingPointClass)
+        XCTAssertFalse(Double.nan.isFinite)
+        XCTAssertFalse(Double.nan.isInfinite)
+    }
+
+    func test_Description() {
+        XCTAssertEqual("0", Decimal().description)
+        XCTAssertEqual("0", Decimal(0).description)
+        XCTAssertEqual("10", Decimal(_exponent: 1, _length: 1, _isNegative: 0, _isCompact: 1, _reserved: 0, _mantissa: (1, 0, 0, 0, 0, 0, 0, 0)).description)
+        XCTAssertEqual("10", Decimal(10).description)
+        XCTAssertEqual("123.458", Decimal(_exponent: -3, _length: 2, _isNegative: 0, _isCompact:1, _reserved: 0, _mantissa: (57922, 1, 0, 0, 0, 0, 0, 0)).description)
+        XCTAssertEqual("123.458", Decimal(123.458).description)
+        XCTAssertEqual("123", Decimal(UInt8(123)).description)
+        XCTAssertEqual("45", Decimal(Int8(45)).description)
+        XCTAssertEqual("3.14159265358979323846264338327950288419", Decimal.pi.description)
+        XCTAssertEqual("-30000000000", Decimal(sign: .minus, exponent: 10, significand: Decimal(3)).description)
+        XCTAssertEqual("300000", Decimal(sign: .plus, exponent: 5, significand: Decimal(3)).description)
+        XCTAssertEqual("5", Decimal(signOf: Decimal(3), magnitudeOf: Decimal(5)).description)
+        XCTAssertEqual("-5", Decimal(signOf: Decimal(-3), magnitudeOf: Decimal(5)).description)
+        XCTAssertEqual("5", Decimal(signOf: Decimal(3), magnitudeOf: Decimal(-5)).description)
+        XCTAssertEqual("-5", Decimal(signOf: Decimal(-3), magnitudeOf: Decimal(-5)).description)
+    }
+
+    func test_ExplicitConstruction() {
+        var explicit = Decimal(
+            _exponent: 0x17f,
+            _length: 0xff,
+            _isNegative: 3,
+            _isCompact: 4,
+            _reserved: UInt32(1<<18 + 1<<17 + 1),
+            _mantissa: (6, 7, 8, 9, 10, 11, 12, 13)
+        )
+        XCTAssertEqual(0x7f, explicit._exponent)
+        XCTAssertEqual(0x7f, explicit.exponent)
+        XCTAssertEqual(0x0f, explicit._length)
+        XCTAssertEqual(1, explicit._isNegative)
+        XCTAssertEqual(FloatingPointSign.minus, explicit.sign)
+        XCTAssertTrue(explicit.isSignMinus)
+        XCTAssertEqual(0, explicit._isCompact)
+        XCTAssertEqual(UInt32(1<<17 + 1), explicit._reserved)
+        let (m0, m1, m2, m3, m4, m5, m6, m7) = explicit._mantissa
+        XCTAssertEqual(6, m0)
+        XCTAssertEqual(7, m1)
+        XCTAssertEqual(8, m2)
+        XCTAssertEqual(9, m3)
+        XCTAssertEqual(10, m4)
+        XCTAssertEqual(11, m5)
+        XCTAssertEqual(12, m6)
+        XCTAssertEqual(13, m7)
+        explicit._isCompact = 5
+        explicit._isNegative = 6
+        XCTAssertEqual(0, explicit._isNegative)
+        XCTAssertEqual(1, explicit._isCompact)
+        XCTAssertEqual(FloatingPointSign.plus, explicit.sign)
+        XCTAssertFalse(explicit.isSignMinus)
+        XCTAssertTrue(explicit.isNormal)
+        
+        let significand = explicit.significand
+        XCTAssertEqual(0, significand._exponent)
+        XCTAssertEqual(0, significand.exponent)
+        XCTAssertEqual(0x0f, significand._length)
+        XCTAssertEqual(0, significand._isNegative)
+        XCTAssertEqual(1, significand._isCompact)
+        XCTAssertEqual(0, significand._reserved)
+        let (sm0, sm1, sm2, sm3, sm4, sm5, sm6, sm7) = significand._mantissa
+        XCTAssertEqual(6, sm0)
+        XCTAssertEqual(7, sm1)
+        XCTAssertEqual(8, sm2)
+        XCTAssertEqual(9, sm3)
+        XCTAssertEqual(10, sm4)
+        XCTAssertEqual(11, sm5)
+        XCTAssertEqual(12, sm6)
+        XCTAssertEqual(13, sm7)
+        
+        let ulp = explicit.ulp
+        XCTAssertEqual(0x7f, ulp.exponent)
+        XCTAssertEqual(8, ulp._length)
+        XCTAssertEqual(0, ulp._isNegative)
+        XCTAssertEqual(1, ulp._isCompact)
+        XCTAssertEqual(0, ulp._reserved)
+        XCTAssertEqual(1, ulp._mantissa.0)
+        XCTAssertEqual(0, ulp._mantissa.1)
+        XCTAssertEqual(0, ulp._mantissa.2)
+        XCTAssertEqual(0, ulp._mantissa.3)
+        XCTAssertEqual(0, ulp._mantissa.4)
+        XCTAssertEqual(0, ulp._mantissa.5)
+        XCTAssertEqual(0, ulp._mantissa.6)
+        XCTAssertEqual(0, ulp._mantissa.7)
+    }
+
+    func test_Maths() {
+        for i in -2...10 {
+            for j in 0...5 {
+                XCTAssertEqual(Decimal(i*j), Decimal(i) * Decimal(j), "\(Decimal(i*j)) == \(i) * \(j)")
+                XCTAssertEqual(Decimal(i+j), Decimal(i) + Decimal(j), "\(Decimal(i+j)) == \(i)+\(j)")
+                XCTAssertEqual(Decimal(i-j), Decimal(i) - Decimal(j), "\(Decimal(i-j)) == \(i)-\(j)")
+                if j != 0 {
+                    let approximation = Decimal(Double(i)/Double(j))
+                    let answer = Decimal(i) / Decimal(j)
+                    let answerDescription = answer.description
+                    let approximationDescription = approximation.description
+                    var failed: Bool = false
+                    var count = 0
+                    let SIG_FIG = 14
+                    for (a, b) in zip(answerDescription, approximationDescription) {
+                        if a != b {
+                            failed = true
+                            break
+                        }
+                        if count == 0 && (a == "-" || a == "0" || a == ".") {
+                            continue // don't count these as significant figures
+                        }
+                        if count >= SIG_FIG {
+                            break
+                        }
+                        count += 1
+                    }
+                    XCTAssertFalse(failed, "\(Decimal(i/j)) == \(i)/\(j)")
+                }
+            }
+        }
+    }
+
+    func test_Misc() {
+        XCTAssertEqual(.minus, Decimal(-5.2).sign)
+        XCTAssertEqual(.plus, Decimal(5.2).sign)
+        var d = Decimal(5.2)
+        XCTAssertEqual(.plus, d.sign)
+        d.negate()
+        XCTAssertEqual(.minus, d.sign)
+        d.negate()
+        XCTAssertEqual(.plus, d.sign)
+        var e = Decimal(0)
+        e.negate()
+        XCTAssertEqual(e, 0)
+        XCTAssertTrue(Decimal(3.5).isEqual(to: Decimal(3.5)))
+        XCTAssertTrue(Decimal.nan.isEqual(to: Decimal.nan))
+        XCTAssertTrue(Decimal(1.28).isLess(than: Decimal(2.24)))
+        XCTAssertFalse(Decimal(2.28).isLess(than: Decimal(2.24)))
+        XCTAssertTrue(Decimal(1.28).isTotallyOrdered(belowOrEqualTo: Decimal(2.24)))
+        XCTAssertFalse(Decimal(2.28).isTotallyOrdered(belowOrEqualTo: Decimal(2.24)))
+        XCTAssertTrue(Decimal(1.2).isTotallyOrdered(belowOrEqualTo: Decimal(1.2)))
+        XCTAssertTrue(Decimal.nan.isEqual(to: Decimal.nan))
+        XCTAssertTrue(Decimal.nan.isLess(than: Decimal(0)))
+        XCTAssertFalse(Decimal.nan.isLess(than: Decimal.nan))
+        XCTAssertTrue(Decimal.nan.isLessThanOrEqualTo(Decimal(0)))
+        XCTAssertTrue(Decimal.nan.isLessThanOrEqualTo(Decimal.nan))
+        XCTAssertFalse(Decimal.nan.isTotallyOrdered(belowOrEqualTo: Decimal.nan))
+        XCTAssertFalse(Decimal.nan.isTotallyOrdered(belowOrEqualTo: Decimal(2.3)))
+        XCTAssertTrue(Decimal(2) < Decimal(3))
+        XCTAssertTrue(Decimal(3) > Decimal(2))
+        XCTAssertEqual(Decimal(-9), Decimal(1) - Decimal(10))
+        XCTAssertEqual(Decimal(3), Decimal(2).nextUp)
+        XCTAssertEqual(Decimal(2), Decimal(3).nextDown)
+        XCTAssertEqual(Decimal(-476), Decimal(1024).distance(to: Decimal(1500)))
+        XCTAssertEqual(Decimal(68040), Decimal(386).advanced(by: Decimal(67654)))
+        XCTAssertEqual(Decimal(1.234), abs(Decimal(1.234)))
+        XCTAssertEqual(Decimal(1.234), abs(Decimal(-1.234)))
+        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+            XCTAssertTrue(Decimal.nan.magnitude.isNaN)
+        }
+        var a = Decimal(1234)
+        var r = a
+        XCTAssertEqual(.noError, NSDecimalMultiplyByPowerOf10(&r, &a, 1, .plain))
+        XCTAssertEqual(Decimal(12340), r)
+        a = Decimal(1234)
+        XCTAssertEqual(.noError, NSDecimalMultiplyByPowerOf10(&r, &a, 2, .plain))
+        XCTAssertEqual(Decimal(123400), r)
+        XCTAssertEqual(.overflow, NSDecimalMultiplyByPowerOf10(&r, &a, 128, .plain))
+        XCTAssertTrue(r.isNaN)
+        a = Decimal(1234)
+        XCTAssertEqual(.noError, NSDecimalMultiplyByPowerOf10(&r, &a, -2, .plain))
+        XCTAssertEqual(Decimal(12.34), r)
+        var ur = r
+        XCTAssertEqual(.underflow, NSDecimalMultiplyByPowerOf10(&ur, &r, -128, .plain))
+        XCTAssertTrue(ur.isNaN)
+        a = Decimal(1234)
+        XCTAssertEqual(.noError, NSDecimalPower(&r, &a, 0, .plain))
+        XCTAssertEqual(Decimal(1), r)
+        a = Decimal(8)
+        XCTAssertEqual(.noError, NSDecimalPower(&r, &a, 2, .plain))
+        XCTAssertEqual(Decimal(64), r)
+        a = Decimal(-2)
+        XCTAssertEqual(.noError, NSDecimalPower(&r, &a, 3, .plain))
+        XCTAssertEqual(Decimal(-8), r)
+        for i in -2...10 {
+            for j in 0...5 {
+                var actual = Decimal(i)
+                var result = actual
+                XCTAssertEqual(.noError, NSDecimalPower(&result, &actual, j, .plain))
+                let expected = Decimal(pow(Double(i), Double(j)))
+                XCTAssertEqual(expected, result, "\(result) == \(i)^\(j)")
+                if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+                    XCTAssertEqual(expected, pow(actual, j))
+                }
+            }
+        }
+    }
+
+    func test_MultiplicationOverflow() {
+        var multiplicand = Decimal(_exponent: 0, _length: 8, _isNegative: 0, _isCompact: 0, _reserved: 0, _mantissa: ( 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff ))
+        
+        var result = Decimal()
+        var multiplier = Decimal(1)
+        
+        multiplier._mantissa.0 = 2
+        
+        XCTAssertEqual(.noError, NSDecimalMultiply(&result, &multiplicand, &multiplier, .plain), "2 * max mantissa")
+        XCTAssertEqual(.noError, NSDecimalMultiply(&result, &multiplier, &multiplicand, .plain), "max mantissa * 2")
+        
+        multiplier._exponent = 0x7f
+        XCTAssertEqual(.overflow, NSDecimalMultiply(&result, &multiplicand, &multiplier, .plain), "2e127 * max mantissa")
+        XCTAssertEqual(.overflow, NSDecimalMultiply(&result, &multiplier, &multiplicand, .plain), "max mantissa * 2e127")
+    }
+
+    func test_NaNInput() {
+        var NaN = Decimal.nan
+        var one = Decimal(1)
+        var result = Decimal()
+        
+        XCTAssertNotEqual(.noError, NSDecimalAdd(&result, &NaN, &one, .plain))
+        XCTAssertTrue(NSDecimalIsNotANumber(&result), "NaN + 1")
+        XCTAssertNotEqual(.noError, NSDecimalAdd(&result, &one, &NaN, .plain))
+        XCTAssertTrue(NSDecimalIsNotANumber(&result), "1 + NaN")
+        
+        XCTAssertNotEqual(.noError, NSDecimalSubtract(&result, &NaN, &one, .plain))
+        XCTAssertTrue(NSDecimalIsNotANumber(&result), "NaN - 1")
+        XCTAssertNotEqual(.noError, NSDecimalSubtract(&result, &one, &NaN, .plain))
+        XCTAssertTrue(NSDecimalIsNotANumber(&result), "1 - NaN")
+        
+        XCTAssertNotEqual(.noError, NSDecimalMultiply(&result, &NaN, &one, .plain))
+        XCTAssertTrue(NSDecimalIsNotANumber(&result), "NaN * 1")
+        XCTAssertNotEqual(.noError, NSDecimalMultiply(&result, &one, &NaN, .plain))
+        XCTAssertTrue(NSDecimalIsNotANumber(&result), "1 * NaN")
+        
+        XCTAssertNotEqual(.noError, NSDecimalDivide(&result, &NaN, &one, .plain))
+        XCTAssertTrue(NSDecimalIsNotANumber(&result), "NaN / 1")
+        XCTAssertNotEqual(.noError, NSDecimalDivide(&result, &one, &NaN, .plain))
+        XCTAssertTrue(NSDecimalIsNotANumber(&result), "1 / NaN")
+        
+        XCTAssertNotEqual(.noError, NSDecimalPower(&result, &NaN, 0, .plain))
+        XCTAssertTrue(NSDecimalIsNotANumber(&result), "NaN ^ 0")
+        XCTAssertNotEqual(.noError, NSDecimalPower(&result, &NaN, 4, .plain))
+        XCTAssertTrue(NSDecimalIsNotANumber(&result), "NaN ^ 4")
+        XCTAssertNotEqual(.noError, NSDecimalPower(&result, &NaN, 5, .plain))
+        XCTAssertTrue(NSDecimalIsNotANumber(&result), "NaN ^ 5")
+        
+        XCTAssertNotEqual(.noError, NSDecimalMultiplyByPowerOf10(&result, &NaN, 0, .plain))
+        XCTAssertTrue(NSDecimalIsNotANumber(&result), "NaN e0")
+        XCTAssertNotEqual(.noError, NSDecimalMultiplyByPowerOf10(&result, &NaN, 4, .plain))
+        XCTAssertTrue(NSDecimalIsNotANumber(&result), "NaN e4")
+        XCTAssertNotEqual(.noError, NSDecimalMultiplyByPowerOf10(&result, &NaN, 5, .plain))
+        XCTAssertTrue(NSDecimalIsNotANumber(&result), "NaN e5")
+    }
+
+    func test_NegativeAndZeroMultiplication() {
+        var one = Decimal(1)
+        var zero = Decimal(0)
+        var negativeOne = Decimal(-1)
+        
+        var result = Decimal()
+        
+        XCTAssertEqual(.noError, NSDecimalMultiply(&result, &one, &one, .plain), "1 * 1")
+        XCTAssertEqual(.orderedSame, NSDecimalCompare(&one, &result), "1 * 1")
+        
+        XCTAssertEqual(.noError, NSDecimalMultiply(&result, &one, &negativeOne, .plain), "1 * -1")
+        XCTAssertEqual(.orderedSame, NSDecimalCompare(&negativeOne, &result), "1 * -1")
+        
+        XCTAssertEqual(.noError, NSDecimalMultiply(&result, &negativeOne, &one, .plain), "-1 * 1")
+        XCTAssertEqual(.orderedSame, NSDecimalCompare(&negativeOne, &result), "-1 * 1")
+        
+        XCTAssertEqual(.noError, NSDecimalMultiply(&result, &negativeOne, &negativeOne, .plain), "-1 * -1")
+        XCTAssertEqual(.orderedSame, NSDecimalCompare(&one, &result), "-1 * -1")
+        
+        XCTAssertEqual(.noError, NSDecimalMultiply(&result, &one, &zero, .plain), "1 * 0")
+        XCTAssertEqual(.orderedSame, NSDecimalCompare(&zero, &result), "1 * 0")
+        XCTAssertEqual(0, result._isNegative, "1 * 0")
+        
+        XCTAssertEqual(.noError, NSDecimalMultiply(&result, &zero, &one, .plain), "0 * 1")
+        XCTAssertEqual(.orderedSame, NSDecimalCompare(&zero, &result), "0 * 1")
+        XCTAssertEqual(0, result._isNegative, "0 * 1")
+        
+        XCTAssertEqual(.noError, NSDecimalMultiply(&result, &negativeOne, &zero, .plain), "-1 * 0")
+        XCTAssertEqual(.orderedSame, NSDecimalCompare(&zero, &result), "-1 * 0")
+        XCTAssertEqual(0, result._isNegative, "-1 * 0")
+        
+        XCTAssertEqual(.noError, NSDecimalMultiply(&result, &zero, &negativeOne, .plain), "0 * -1")
+        XCTAssertEqual(.orderedSame, NSDecimalCompare(&zero, &result), "0 * -1")
+        XCTAssertEqual(0, result._isNegative, "0 * -1")
+    }
+
+    func test_Normalize() {
+        var one = Decimal(1)
+        var ten = Decimal(-10)
+        XCTAssertEqual(.noError, NSDecimalNormalize(&one, &ten, .plain))
+        XCTAssertEqual(Decimal(1), one)
+        XCTAssertEqual(Decimal(-10), ten)
+        XCTAssertEqual(1, one._length)
+        XCTAssertEqual(1, ten._length)
+        one = Decimal(1)
+        ten = Decimal(10)
+        XCTAssertEqual(.noError, NSDecimalNormalize(&one, &ten, .plain))
+        XCTAssertEqual(Decimal(1), one)
+        XCTAssertEqual(Decimal(10), ten)
+        XCTAssertEqual(1, one._length)
+        XCTAssertEqual(1, ten._length)
+    }
+
+    func test_NSDecimal() {
+        var nan = Decimal.nan
+        XCTAssertTrue(NSDecimalIsNotANumber(&nan))
+        var zero = Decimal()
+        XCTAssertFalse(NSDecimalIsNotANumber(&zero))
+        var three = Decimal(3)
+        var guess = Decimal()
+        NSDecimalCopy(&guess, &three)
+        XCTAssertEqual(three, guess)
+        
+        var f = Decimal(_exponent: 0, _length: 2, _isNegative: 0, _isCompact: 0, _reserved: 0, _mantissa: (0x0000, 0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
+        let before = f.description
+        XCTAssertEqual(0, f._isCompact)
+        NSDecimalCompact(&f)
+        XCTAssertEqual(1, f._isCompact)
+        let after = f.description
+        XCTAssertEqual(before, after)
+    }
+
+    func test_RepeatingDivision()  {
+        let repeatingNumerator = Decimal(16)
+        let repeatingDenominator = Decimal(9)
+        let repeating = repeatingNumerator / repeatingDenominator
+        
+        let numerator = Decimal(1010)
+        var result = numerator / repeating
+        
+        var expected = Decimal()
+        expected._exponent = -35;
+        expected._length = 8;
+        expected._isNegative = 0;
+        expected._isCompact = 1;
+        expected._reserved = 0;
+        expected._mantissa.0 = 51946;
+        expected._mantissa.1 = 3;
+        expected._mantissa.2 = 15549;
+        expected._mantissa.3 = 55864;
+        expected._mantissa.4 = 57984;
+        expected._mantissa.5 = 55436;
+        expected._mantissa.6 = 45186;
+        expected._mantissa.7 = 10941;
+        
+        XCTAssertEqual(.orderedSame, NSDecimalCompare(&expected, &result), "568.12500000000000000000000000000248554: \(expected.description) != \(result.description)");
+    }
+
+    func test_Round() {
+        var testCases = [
+            // expected, start, scale, round
+            ( 0, 0.5, 0, Decimal.RoundingMode.down ),
+            ( 1, 0.5, 0, Decimal.RoundingMode.up ),
+            ( 2, 2.5, 0, Decimal.RoundingMode.bankers ),
+            ( 4, 3.5, 0, Decimal.RoundingMode.bankers ),
+            ( 5, 5.2, 0, Decimal.RoundingMode.plain ),
+            ( 4.5, 4.5, 1, Decimal.RoundingMode.down ),
+            ( 5.5, 5.5, 1, Decimal.RoundingMode.up ),
+            ( 6.5, 6.5, 1, Decimal.RoundingMode.plain ),
+            ( 7.5, 7.5, 1, Decimal.RoundingMode.bankers ),
+            
+            ( -1, -0.5, 0, Decimal.RoundingMode.down ),
+            ( -2, -2.5, 0, Decimal.RoundingMode.up ),
+            ( -5, -5.2, 0, Decimal.RoundingMode.plain ),
+            ( -4.5, -4.5, 1, Decimal.RoundingMode.down ),
+            ( -5.5, -5.5, 1, Decimal.RoundingMode.up ),
+            ( -6.5, -6.5, 1, Decimal.RoundingMode.plain ),
+            ( -7.5, -7.5, 1, Decimal.RoundingMode.bankers ),
+        ]
+        if #available(macOS 10.16, iOS 14, watchOS 7, tvOS 14, *) {
+            testCases += [
+                ( -2, -2.5, 0, Decimal.RoundingMode.bankers ),
+                ( -4, -3.5, 0, Decimal.RoundingMode.bankers ),
+            ]
+        }
+        for testCase in testCases {
+            let (expected, start, scale, mode) = testCase
+            var num = Decimal(start)
+            var r = num
+            NSDecimalRound(&r, &num, scale, mode)
+            XCTAssertEqual(Decimal(expected), r)
+            let numnum = NSDecimalNumber(decimal:Decimal(start))
+            let behavior = NSDecimalNumberHandler(roundingMode: mode, scale: Int16(scale), raiseOnExactness: false, raiseOnOverflow: true, raiseOnUnderflow: true, raiseOnDivideByZero: true)
+            let result = numnum.rounding(accordingToBehavior:behavior)
+            XCTAssertEqual(Double(expected), result.doubleValue)
+        }
+    }
+
+    func test_ScanDecimal() {
+        let testCases = [
+            // expected, value
+            ( 123.456e78, "123.456e78" ),
+            ( -123.456e78, "-123.456e78" ),
+            ( 123.456, " 123.456 " ),
+            ( 3.14159, " 3.14159e0" ),
+            ( 3.14159, " 3.14159e-0" ),
+            ( 0.314159, " 3.14159e-1" ),
+            ( 3.14159, " 3.14159e+0" ),
+            ( 31.4159, " 3.14159e+1" ),
+            ( 12.34, " 01234e-02"),
+            ]
+        for testCase in testCases {
+            let (expected, string) = testCase
+            let decimal = Decimal(string:string)!
+            let aboutOne = Decimal(expected) / decimal
+            let approximatelyRight = aboutOne >= Decimal(0.99999) && aboutOne <= Decimal(1.00001)
+            XCTAssertTrue(approximatelyRight, "\(expected) ~= \(decimal) : \(aboutOne) \(aboutOne >= Decimal(0.99999)) \(aboutOne <= Decimal(1.00001))" )
+        }
+        guard let ones = Decimal(string:"111111111111111111111111111111111111111") else {
+            XCTFail("Unable to parse Decimal(string:'111111111111111111111111111111111111111')")
+            return
+        }
+        let num = ones / Decimal(9)
+        guard let answer = Decimal(string:"12345679012345679012345679012345679012.3") else {
+            XCTFail("Unable to parse Decimal(string:'12345679012345679012345679012345679012.3')")
+            return
+        }
+        XCTAssertEqual(answer,num,"\(ones) / 9 = \(answer) \(num)")
+    }
+
+    func test_SimpleMultiplication() {
+        var multiplicand = Decimal()
+        multiplicand._isNegative = 0
+        multiplicand._isCompact = 0
+        multiplicand._length = 1
+        multiplicand._exponent = 1
+        
+        var multiplier = multiplicand
+        multiplier._exponent = 2
+        
+        var expected = multiplicand
+        expected._isNegative = 0
+        expected._isCompact = 0
+        expected._exponent = 3
+        expected._length = 1
+        
+        var result = Decimal()
+        
+        for i in 1..<UInt8.max {
+            multiplicand._mantissa.0 = UInt16(i)
+            
+            for j in 1..<UInt8.max {
+                multiplier._mantissa.0 = UInt16(j)
+                expected._mantissa.0 = UInt16(i) * UInt16(j)
+                
+                XCTAssertEqual(.noError, NSDecimalMultiply(&result, &multiplicand, &multiplier, .plain), "\(i) * \(j)")
+                XCTAssertEqual(.orderedSame, NSDecimalCompare(&expected, &result), "\(expected._mantissa.0) == \(i) * \(j)");
+            }
+        }
+    }
+
+    func test_unconditionallyBridgeFromObjectiveC() {
+        XCTAssertEqual(Decimal(), Decimal._unconditionallyBridgeFromObjectiveC(nil))
+    }
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestFileManager.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestFileManager.swift
@@ -1,0 +1,116 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+import XCTest
+
+class TestFileManager : XCTestCase {
+    func testReplaceItem() {
+        let fm = FileManager.default
+        
+        // Temporary directory
+        let dirPath = (NSTemporaryDirectory() as NSString).appendingPathComponent(NSUUID().uuidString)
+        try! fm.createDirectory(atPath: dirPath, withIntermediateDirectories: true, attributes: nil)
+        defer { try! FileManager.default.removeItem(atPath: dirPath) }
+        
+        let filePath = (dirPath as NSString).appendingPathComponent("temp_file")
+        try! "1".write(toFile: filePath, atomically: true, encoding: String.Encoding.utf8)
+        
+        let newItemPath = (dirPath as NSString).appendingPathComponent("temp_file_new")
+        try! "2".write(toFile: newItemPath, atomically: true, encoding: String.Encoding.utf8)
+        
+        let result = try! fm.replaceItemAt(URL(fileURLWithPath:filePath, isDirectory:false), withItemAt:URL(fileURLWithPath:newItemPath, isDirectory:false))
+        XCTAssertEqual(result!.path, filePath)
+        
+        let fromDisk = try! String(contentsOf: URL(fileURLWithPath:filePath, isDirectory:false), encoding: String.Encoding.utf8)
+        XCTAssertEqual(fromDisk, "2")
+
+    }
+    
+    func testReplaceItem_error() {
+        let fm = FileManager.default
+        
+        // Temporary directory
+        let dirPath = (NSTemporaryDirectory() as NSString).appendingPathComponent(NSUUID().uuidString)
+        try! fm.createDirectory(atPath: dirPath, withIntermediateDirectories: true, attributes: nil)
+        defer { try! FileManager.default.removeItem(atPath: dirPath) }
+        
+        let filePath = (dirPath as NSString).appendingPathComponent("temp_file")
+        try! "1".write(toFile: filePath, atomically: true, encoding: String.Encoding.utf8)
+        
+        let newItemPath = (dirPath as NSString).appendingPathComponent("temp_file_new")
+        // Don't write the file.
+        
+        var threw = false
+        do {
+            let _ = try fm.replaceItemAt(URL(fileURLWithPath:filePath, isDirectory:false), withItemAt:URL(fileURLWithPath:newItemPath, isDirectory:false))
+        } catch {
+            threw = true
+        }
+        XCTAssertTrue(threw, "Should have thrown")
+
+    }
+    
+    func testDirectoryEnumerator_error() {
+        let fm = FileManager.default
+        let nonexistentURL = URL(fileURLWithPath: "\(NSTemporaryDirectory())/nonexistent")
+        
+        var invoked = false
+        let e = fm.enumerator(at: nonexistentURL, includingPropertiesForKeys: []) { (url, err) in
+            invoked = true
+            XCTAssertEqual(nonexistentURL, url)
+            XCTAssertEqual((err as NSError).code, NSFileReadNoSuchFileError)
+            return true
+        }
+
+        let url = e?.nextObject()
+        XCTAssertTrue(invoked)
+        XCTAssertTrue(url == nil)
+        
+    }
+
+    func testDirectoryEnumerator_error_noHandler() {
+        let fm = FileManager.default
+        let nonexistentURL = URL(fileURLWithPath: "\(NSTemporaryDirectory())/nonexistent")
+        
+        let e = fm.enumerator(at: nonexistentURL, includingPropertiesForKeys: [])
+        let url = e?.nextObject()
+        XCTAssertTrue(url == nil)
+        
+    }
+    
+    func testDirectoryEnumerator_simple() {
+        let fm = FileManager.default
+        let dirPath = (NSTemporaryDirectory() as NSString).appendingPathComponent(NSUUID().uuidString)
+        try! fm.createDirectory(atPath: dirPath, withIntermediateDirectories: true, attributes: nil)
+        defer { try! FileManager.default.removeItem(atPath: dirPath) }
+
+        let item1 = URL(fileURLWithPath: "\(dirPath)/1", isDirectory: false)
+        let item2 = URL(fileURLWithPath: "\(dirPath)/2", isDirectory: false)
+        
+        try! Data().write(to: item1)
+        try! Data().write(to: item2)
+        
+        let e = fm.enumerator(at: URL(fileURLWithPath: dirPath, isDirectory: true), includingPropertiesForKeys: [])
+        let result1 = e?.nextObject()
+        let result2 = e?.nextObject()
+        let result3 = e?.nextObject()
+        
+        // Avoid potential symlink discrepancy between the result and the original URL
+        XCTAssertEqual((result1! as! URL).lastPathComponent, item1.lastPathComponent)
+        XCTAssertEqual((result2! as! URL).lastPathComponent, item2.lastPathComponent)
+        XCTAssertTrue(result3 == nil)
+        
+    }
+
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestIndexPath.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestIndexPath.swift
@@ -1,0 +1,737 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+class TestIndexPath: XCTestCase {
+    func testEmpty() {
+        let ip = IndexPath()
+        XCTAssertEqual(ip.count, 0)
+    }
+    
+    func testSingleIndex() {
+        let ip = IndexPath(index: 1)
+        XCTAssertEqual(ip.count, 1)
+        XCTAssertEqual(ip[0], 1)
+        
+        let highValueIp = IndexPath(index: .max)
+        XCTAssertEqual(highValueIp.count, 1)
+        XCTAssertEqual(highValueIp[0], .max)
+        
+        let lowValueIp = IndexPath(index: .min)
+        XCTAssertEqual(lowValueIp.count, 1)
+        XCTAssertEqual(lowValueIp[0], .min)
+    }
+    
+    func testTwoIndexes() {
+        let ip = IndexPath(indexes: [0, 1])
+        XCTAssertEqual(ip.count, 2)
+        XCTAssertEqual(ip[0], 0)
+        XCTAssertEqual(ip[1], 1)
+    }
+    
+    func testManyIndexes() {
+        let ip = IndexPath(indexes: [0, 1, 2, 3, 4])
+        XCTAssertEqual(ip.count, 5)
+        XCTAssertEqual(ip[0], 0)
+        XCTAssertEqual(ip[1], 1)
+        XCTAssertEqual(ip[2], 2)
+        XCTAssertEqual(ip[3], 3)
+        XCTAssertEqual(ip[4], 4)
+    }
+    
+    func testCreateFromSequence() {
+        let seq = repeatElement(5, count: 3)
+        let ip = IndexPath(indexes: seq)
+        XCTAssertEqual(ip.count, 3)
+        XCTAssertEqual(ip[0], 5)
+        XCTAssertEqual(ip[1], 5)
+        XCTAssertEqual(ip[2], 5)
+    }
+    
+    func testCreateFromLiteral() {
+        let ip: IndexPath = [1, 2, 3, 4]
+        XCTAssertEqual(ip.count, 4)
+        XCTAssertEqual(ip[0], 1)
+        XCTAssertEqual(ip[1], 2)
+        XCTAssertEqual(ip[2], 3)
+        XCTAssertEqual(ip[3], 4)
+    }
+    
+    func testDropLast() {
+        let ip: IndexPath = [1, 2, 3, 4]
+        let ip2 = ip.dropLast()
+        XCTAssertEqual(ip2.count, 3)
+        XCTAssertEqual(ip2[0], 1)
+        XCTAssertEqual(ip2[1], 2)
+        XCTAssertEqual(ip2[2], 3)
+    }
+    
+    func testDropLastFromEmpty() {
+        let ip: IndexPath = []
+        let ip2 = ip.dropLast()
+        XCTAssertEqual(ip2.count, 0)
+    }
+    
+    func testDropLastFromSingle() {
+        let ip: IndexPath = [1]
+        let ip2 = ip.dropLast()
+        XCTAssertEqual(ip2.count, 0)
+    }
+    
+    func testDropLastFromPair() {
+        let ip: IndexPath = [1, 2]
+        let ip2 = ip.dropLast()
+        XCTAssertEqual(ip2.count, 1)
+        XCTAssertEqual(ip2[0], 1)
+    }
+    
+    func testDropLastFromTriple() {
+        let ip: IndexPath = [1, 2, 3]
+        let ip2 = ip.dropLast()
+        XCTAssertEqual(ip2.count, 2)
+        XCTAssertEqual(ip2[0], 1)
+        XCTAssertEqual(ip2[1], 2)
+    }
+    
+    func testStartEndIndex() {
+        let ip: IndexPath = [1, 2, 3, 4]
+        XCTAssertEqual(ip.startIndex, 0)
+        XCTAssertEqual(ip.endIndex, ip.count)
+    }
+    
+    func testIterator() {
+        let ip: IndexPath = [1, 2, 3, 4]
+        var iter = ip.makeIterator()
+        var sum = 0
+        while let index = iter.next() {
+            sum += index
+        }
+        XCTAssertEqual(sum, 1 + 2 + 3 + 4)
+    }
+    
+    func testIndexing() {
+        let ip: IndexPath = [1, 2, 3, 4]
+        XCTAssertEqual(ip.index(before: 1), 0)
+        XCTAssertEqual(ip.index(before: 0), -1) // beyond range!
+        XCTAssertEqual(ip.index(after: 1), 2)
+        XCTAssertEqual(ip.index(after: 4), 5) // beyond range!
+    }
+    
+    func testCompare() {
+        let ip1: IndexPath = [1, 2]
+        let ip2: IndexPath = [3, 4]
+        let ip3: IndexPath = [5, 1]
+        let ip4: IndexPath = [1, 1, 1]
+        let ip5: IndexPath = [1, 1, 9]
+        
+        XCTAssertEqual(ip1.compare(ip1), ComparisonResult.orderedSame)
+        XCTAssertEqual(ip1 < ip1, false)
+        XCTAssertEqual(ip1 <= ip1, true)
+        XCTAssertEqual(ip1 == ip1, true)
+        XCTAssertEqual(ip1 >= ip1, true)
+        XCTAssertEqual(ip1 > ip1, false)
+        
+        XCTAssertEqual(ip1.compare(ip2), ComparisonResult.orderedAscending)
+        XCTAssertEqual(ip1 < ip2, true)
+        XCTAssertEqual(ip1 <= ip2, true)
+        XCTAssertEqual(ip1 == ip2, false)
+        XCTAssertEqual(ip1 >= ip2, false)
+        XCTAssertEqual(ip1 > ip2, false)
+        
+        XCTAssertEqual(ip1.compare(ip3), ComparisonResult.orderedAscending)
+        XCTAssertEqual(ip1 < ip3, true)
+        XCTAssertEqual(ip1 <= ip3, true)
+        XCTAssertEqual(ip1 == ip3, false)
+        XCTAssertEqual(ip1 >= ip3, false)
+        XCTAssertEqual(ip1 > ip3, false)
+        
+        XCTAssertEqual(ip1.compare(ip4), ComparisonResult.orderedDescending)
+        XCTAssertEqual(ip1 < ip4, false)
+        XCTAssertEqual(ip1 <= ip4, false)
+        XCTAssertEqual(ip1 == ip4, false)
+        XCTAssertEqual(ip1 >= ip4, true)
+        XCTAssertEqual(ip1 > ip4, true)
+        
+        XCTAssertEqual(ip1.compare(ip5), ComparisonResult.orderedDescending)
+        XCTAssertEqual(ip1 < ip5, false)
+        XCTAssertEqual(ip1 <= ip5, false)
+        XCTAssertEqual(ip1 == ip5, false)
+        XCTAssertEqual(ip1 >= ip5, true)
+        XCTAssertEqual(ip1 > ip5, true)
+        
+        XCTAssertEqual(ip2.compare(ip1), ComparisonResult.orderedDescending)
+        XCTAssertEqual(ip2 < ip1, false)
+        XCTAssertEqual(ip2 <= ip1, false)
+        XCTAssertEqual(ip2 == ip1, false)
+        XCTAssertEqual(ip2 >= ip1, true)
+        XCTAssertEqual(ip2 > ip1, true)
+        
+        XCTAssertEqual(ip2.compare(ip2), ComparisonResult.orderedSame)
+        XCTAssertEqual(ip2 < ip2, false)
+        XCTAssertEqual(ip2 <= ip2, true)
+        XCTAssertEqual(ip2 == ip2, true)
+        XCTAssertEqual(ip2 >= ip2, true)
+        XCTAssertEqual(ip2 > ip2, false)
+        
+        XCTAssertEqual(ip2.compare(ip3), ComparisonResult.orderedAscending)
+        XCTAssertEqual(ip2 < ip3, true)
+        XCTAssertEqual(ip2 <= ip3, true)
+        XCTAssertEqual(ip2 == ip3, false)
+        XCTAssertEqual(ip2 >= ip3, false)
+        XCTAssertEqual(ip2 > ip3, false)
+        
+        XCTAssertEqual(ip2.compare(ip4), ComparisonResult.orderedDescending)
+        XCTAssertEqual(ip2.compare(ip5), ComparisonResult.orderedDescending)
+        XCTAssertEqual(ip3.compare(ip1), ComparisonResult.orderedDescending)
+        XCTAssertEqual(ip3.compare(ip2), ComparisonResult.orderedDescending)
+        XCTAssertEqual(ip3.compare(ip3), ComparisonResult.orderedSame)
+        XCTAssertEqual(ip3.compare(ip4), ComparisonResult.orderedDescending)
+        XCTAssertEqual(ip3.compare(ip5), ComparisonResult.orderedDescending)
+        XCTAssertEqual(ip4.compare(ip1), ComparisonResult.orderedAscending)
+        XCTAssertEqual(ip4.compare(ip2), ComparisonResult.orderedAscending)
+        XCTAssertEqual(ip4.compare(ip3), ComparisonResult.orderedAscending)
+        XCTAssertEqual(ip4.compare(ip4), ComparisonResult.orderedSame)
+        XCTAssertEqual(ip4.compare(ip5), ComparisonResult.orderedAscending)
+        XCTAssertEqual(ip5.compare(ip1), ComparisonResult.orderedAscending)
+        XCTAssertEqual(ip5.compare(ip2), ComparisonResult.orderedAscending)
+        XCTAssertEqual(ip5.compare(ip3), ComparisonResult.orderedAscending)
+        XCTAssertEqual(ip5.compare(ip4), ComparisonResult.orderedDescending)
+        XCTAssertEqual(ip5.compare(ip5), ComparisonResult.orderedSame)
+        
+        let ip6: IndexPath = [1, 1]
+        XCTAssertEqual(ip6.compare(ip5), ComparisonResult.orderedAscending)
+        XCTAssertEqual(ip5.compare(ip6), ComparisonResult.orderedDescending)
+    }
+    
+    func testHashing() {
+        guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else { return }
+        let samples: [IndexPath] = [
+            [],
+            [1],
+            [2],
+            [Int.max],
+            [1, 1],
+            [2, 1],
+            [1, 2],
+            [1, 1, 1],
+            [2, 1, 1],
+            [1, 2, 1],
+            [1, 1, 2],
+            [Int.max, Int.max, Int.max],
+        ]
+        checkHashable(samples, equalityOracle: { $0 == $1 })
+
+        // this should not cause an overflow crash
+        _ = IndexPath(indexes: [Int.max >> 8, 2, Int.max >> 36]).hashValue 
+    }
+    
+    func testEquality() {
+        let ip1: IndexPath = [1, 1]
+        let ip2: IndexPath = [1, 1]
+        let ip3: IndexPath = [1, 1, 1]
+        let ip4: IndexPath = []
+        let ip5: IndexPath = [1]
+        
+        XCTAssertTrue(ip1 == ip2)
+        XCTAssertFalse(ip1 == ip3)
+        XCTAssertFalse(ip1 == ip4)
+        XCTAssertFalse(ip4 == ip1)
+        XCTAssertFalse(ip5 == ip1)
+        XCTAssertFalse(ip5 == ip4)
+        XCTAssertTrue(ip4 == ip4)
+        XCTAssertTrue(ip5 == ip5)
+    }
+    
+    func testSubscripting() {
+        var ip1: IndexPath = [1]
+        var ip2: IndexPath = [1, 2]
+        var ip3: IndexPath = [1, 2, 3]
+        
+        XCTAssertEqual(ip1[0], 1)
+        
+        XCTAssertEqual(ip2[0], 1)
+        XCTAssertEqual(ip2[1], 2)
+        
+        XCTAssertEqual(ip3[0], 1)
+        XCTAssertEqual(ip3[1], 2)
+        XCTAssertEqual(ip3[2], 3)
+        
+        ip1[0] = 2
+        XCTAssertEqual(ip1[0], 2)
+        
+        ip2[0] = 2
+        ip2[1] = 3
+        XCTAssertEqual(ip2[0], 2)
+        XCTAssertEqual(ip2[1], 3)
+        
+        ip3[0] = 2
+        ip3[1] = 3
+        ip3[2] = 4
+        XCTAssertEqual(ip3[0], 2)
+        XCTAssertEqual(ip3[1], 3)
+        XCTAssertEqual(ip3[2], 4)
+        
+        let ip4 = ip3[0..<2]
+        XCTAssertEqual(ip4.count, 2)
+        XCTAssertEqual(ip4[0], 2)
+        XCTAssertEqual(ip4[1], 3)
+    }
+    
+    func testAppending() {
+        var ip : IndexPath = [1, 2, 3, 4]
+        let ip2 = IndexPath(indexes: [5, 6, 7])
+        
+        ip.append(ip2)
+        
+        XCTAssertEqual(ip.count, 7)
+        XCTAssertEqual(ip[0], 1)
+        XCTAssertEqual(ip[6], 7)
+        
+        let ip3 = ip.appending(IndexPath(indexes: [8, 9]))
+        XCTAssertEqual(ip3.count, 9)
+        XCTAssertEqual(ip3[7], 8)
+        XCTAssertEqual(ip3[8], 9)
+        
+        let ip4 = ip3.appending([10, 11])
+        XCTAssertEqual(ip4.count, 11)
+        XCTAssertEqual(ip4[9], 10)
+        XCTAssertEqual(ip4[10], 11)
+        
+        let ip5 = ip.appending(8)
+        XCTAssertEqual(ip5.count, 8)
+        XCTAssertEqual(ip5[7], 8)
+    }
+    
+    func testAppendEmpty() {
+        var ip: IndexPath = []
+        ip.append(1)
+        
+        XCTAssertEqual(ip.count, 1)
+        XCTAssertEqual(ip[0], 1)
+        
+        ip.append(2)
+        XCTAssertEqual(ip.count, 2)
+        XCTAssertEqual(ip[0], 1)
+        XCTAssertEqual(ip[1], 2)
+        
+        ip.append(3)
+        XCTAssertEqual(ip.count, 3)
+        XCTAssertEqual(ip[0], 1)
+        XCTAssertEqual(ip[1], 2)
+        XCTAssertEqual(ip[2], 3)
+        
+        ip.append(4)
+        XCTAssertEqual(ip.count, 4)
+        XCTAssertEqual(ip[0], 1)
+        XCTAssertEqual(ip[1], 2)
+        XCTAssertEqual(ip[2], 3)
+        XCTAssertEqual(ip[3], 4)
+    }
+    
+    func testAppendEmptyIndexPath() {
+        var ip: IndexPath = []
+        ip.append(IndexPath(indexes: []))
+        
+        XCTAssertEqual(ip.count, 0)
+    }
+    
+    func testAppendManyIndexPath() {
+        var ip: IndexPath = []
+        ip.append(IndexPath(indexes: [1, 2, 3]))
+        
+        XCTAssertEqual(ip.count, 3)
+        XCTAssertEqual(ip[0], 1)
+        XCTAssertEqual(ip[1], 2)
+        XCTAssertEqual(ip[2], 3)
+    }
+    
+    func testAppendEmptyIndexPathToSingle() {
+        var ip: IndexPath = [1]
+        ip.append(IndexPath(indexes: []))
+        
+        XCTAssertEqual(ip.count, 1)
+        XCTAssertEqual(ip[0], 1)
+    }
+    
+    func testAppendSingleIndexPath() {
+        var ip: IndexPath = []
+        ip.append(IndexPath(indexes: [1]))
+        
+        XCTAssertEqual(ip.count, 1)
+        XCTAssertEqual(ip[0], 1)
+    }
+    
+    func testAppendSingleIndexPathToSingle() {
+        var ip: IndexPath = [1]
+        ip.append(IndexPath(indexes: [1]))
+        
+        XCTAssertEqual(ip.count, 2)
+        XCTAssertEqual(ip[0], 1)
+        XCTAssertEqual(ip[1], 1)
+    }
+    
+    func testAppendPairIndexPath() {
+        var ip: IndexPath = []
+        ip.append(IndexPath(indexes: [1, 2]))
+        
+        XCTAssertEqual(ip.count, 2)
+        XCTAssertEqual(ip[0], 1)
+        XCTAssertEqual(ip[1], 2)
+    }
+    
+    func testAppendManyIndexPathToEmpty() {
+        var ip: IndexPath = []
+        ip.append(IndexPath(indexes: [1, 2, 3]))
+        
+        XCTAssertEqual(ip.count, 3)
+        XCTAssertEqual(ip[0], 1)
+        XCTAssertEqual(ip[1], 2)
+        XCTAssertEqual(ip[2], 3)
+    }
+    
+    func testAppendByOperator() {
+        let ip1: IndexPath = []
+        let ip2: IndexPath = []
+        
+        let ip3 = ip1 + ip2
+        XCTAssertEqual(ip3.count, 0)
+        
+        let ip4: IndexPath = [1]
+        let ip5: IndexPath = [2]
+        
+        let ip6 = ip4 + ip5
+        XCTAssertEqual(ip6.count, 2)
+        XCTAssertEqual(ip6[0], 1)
+        XCTAssertEqual(ip6[1], 2)
+        
+        var ip7: IndexPath = []
+        ip7 += ip6
+        XCTAssertEqual(ip7.count, 2)
+        XCTAssertEqual(ip7[0], 1)
+        XCTAssertEqual(ip7[1], 2)
+    }
+    
+    func testAppendArray() {
+        var ip: IndexPath = [1, 2, 3, 4]
+        let indexes = [5, 6, 7]
+        
+        ip.append(indexes)
+        
+        XCTAssertEqual(ip.count, 7)
+        XCTAssertEqual(ip[0], 1)
+        XCTAssertEqual(ip[6], 7)
+    }
+    
+    func testRanges() {
+        let ip1 = IndexPath(indexes: [1, 2, 3])
+        let ip2 = IndexPath(indexes: [6, 7, 8])
+        
+        // Replace the whole range
+        var mutateMe = ip1
+        mutateMe[0..<3] = ip2
+        XCTAssertEqual(mutateMe, ip2)
+        
+        // Insert at the beginning
+        mutateMe = ip1
+        mutateMe[0..<0] = ip2
+        XCTAssertEqual(mutateMe, IndexPath(indexes: [6, 7, 8, 1, 2, 3]))
+        
+        // Insert at the end
+        mutateMe = ip1
+        mutateMe[3..<3] = ip2
+        XCTAssertEqual(mutateMe, IndexPath(indexes: [1, 2, 3, 6, 7, 8]))
+        
+        // Insert in middle
+        mutateMe = ip1
+        mutateMe[2..<2] = ip2
+        XCTAssertEqual(mutateMe, IndexPath(indexes: [1, 2, 6, 7, 8, 3]))
+    }
+    
+    func testRangeFromEmpty() {
+        let ip1 = IndexPath()
+        let ip2 = ip1[0..<0]
+        XCTAssertEqual(ip2.count, 0)
+    }
+    
+    func testRangeFromSingle() {
+        let ip1 = IndexPath(indexes: [1])
+        let ip2 = ip1[0..<0]
+        XCTAssertEqual(ip2.count, 0)
+        let ip3 = ip1[0..<1]
+        XCTAssertEqual(ip3.count, 1)
+        XCTAssertEqual(ip3[0], 1)
+    }
+    
+    func testRangeFromPair() {
+        let ip1 = IndexPath(indexes: [1, 2])
+        let ip2 = ip1[0..<0]
+        XCTAssertEqual(ip2.count, 0)
+        let ip3 = ip1[0..<1]
+        XCTAssertEqual(ip3.count, 1)
+        XCTAssertEqual(ip3[0], 1)
+        let ip4 = ip1[1..<1]
+        XCTAssertEqual(ip4.count, 0)
+        let ip5 = ip1[0..<2]
+        XCTAssertEqual(ip5.count, 2)
+        XCTAssertEqual(ip5[0], 1)
+        XCTAssertEqual(ip5[1], 2)
+        let ip6 = ip1[1..<2]
+        XCTAssertEqual(ip6.count, 1)
+        XCTAssertEqual(ip6[0], 2)
+        let ip7 = ip1[2..<2]
+        XCTAssertEqual(ip7.count, 0)
+    }
+    
+    func testRangeFromMany() {
+        let ip1 = IndexPath(indexes: [1, 2, 3])
+        let ip2 = ip1[0..<0]
+        XCTAssertEqual(ip2.count, 0)
+        let ip3 = ip1[0..<1]
+        XCTAssertEqual(ip3.count, 1)
+        let ip4 = ip1[0..<2]
+        XCTAssertEqual(ip4.count, 2)
+        let ip5 = ip1[0..<3]
+        XCTAssertEqual(ip5.count, 3)
+    }
+    
+    func testRangeReplacementSingle() {
+        var ip1 = IndexPath(indexes: [1])
+        ip1[0..<1] = IndexPath(indexes: [2])
+        XCTAssertEqual(ip1[0], 2)
+        
+        ip1[0..<1] = IndexPath(indexes: [])
+        XCTAssertEqual(ip1.count, 0)
+    }
+    
+    func testRangeReplacementPair() {
+        var ip1 = IndexPath(indexes: [1, 2])
+        ip1[0..<1] = IndexPath(indexes: [2, 3])
+        XCTAssertEqual(ip1.count, 3)
+        XCTAssertEqual(ip1[0], 2)
+        XCTAssertEqual(ip1[1], 3)
+        XCTAssertEqual(ip1[2], 2)
+        
+        ip1[0..<1] = IndexPath(indexes: [])
+        XCTAssertEqual(ip1.count, 2)
+    }
+    
+    func testMoreRanges() {
+        var ip = IndexPath(indexes: [1, 2, 3])
+        let ip2 = IndexPath(indexes: [5, 6, 7, 8, 9, 10])
+        
+        ip[1..<2] = ip2
+        XCTAssertEqual(ip, IndexPath(indexes: [1, 5, 6, 7, 8, 9, 10, 3]))
+    }
+    
+    func testIteration() {
+        let ip = IndexPath(indexes: [1, 2, 3])
+        
+        var count = 0
+        for _ in ip {
+            count += 1
+        }
+        
+        XCTAssertEqual(3, count)
+    }
+    
+    func testDescription() {
+        let ip1: IndexPath = []
+        let ip2: IndexPath = [1]
+        let ip3: IndexPath = [1, 2]
+        let ip4: IndexPath = [1, 2, 3]
+        
+        XCTAssertEqual(ip1.description, "[]")
+        XCTAssertEqual(ip2.description, "[1]")
+        XCTAssertEqual(ip3.description, "[1, 2]")
+        XCTAssertEqual(ip4.description, "[1, 2, 3]")
+        
+        XCTAssertEqual(ip1.debugDescription, ip1.description)
+        XCTAssertEqual(ip2.debugDescription, ip2.description)
+        XCTAssertEqual(ip3.debugDescription, ip3.description)
+        XCTAssertEqual(ip4.debugDescription, ip4.description)
+    }
+    
+    func testBridgeToObjC() {
+        let ip1: IndexPath = []
+        let ip2: IndexPath = [1]
+        let ip3: IndexPath = [1, 2]
+        let ip4: IndexPath = [1, 2, 3]
+        
+        let nsip1 = ip1._bridgeToObjectiveC()
+        let nsip2 = ip2._bridgeToObjectiveC()
+        let nsip3 = ip3._bridgeToObjectiveC()
+        let nsip4 = ip4._bridgeToObjectiveC()
+        
+        XCTAssertEqual(nsip1.length, 0)
+        XCTAssertEqual(nsip2.length, 1)
+        XCTAssertEqual(nsip3.length, 2)
+        XCTAssertEqual(nsip4.length, 3)
+    }
+    
+    func testForceBridgeFromObjC() {
+        let nsip1 = NSIndexPath()
+        let nsip2 = NSIndexPath(index: 1)
+        let nsip3 = [1, 2].withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<Int>) -> NSIndexPath in
+            return NSIndexPath(indexes: buffer.baseAddress, length: buffer.count)
+        }
+        let nsip4 = [1, 2, 3].withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<Int>) -> NSIndexPath in
+            return NSIndexPath(indexes: buffer.baseAddress, length: buffer.count)
+        }
+        
+        var ip1: IndexPath? = IndexPath()
+        IndexPath._forceBridgeFromObjectiveC(nsip1, result: &ip1)
+        XCTAssertNotNil(ip1)
+        XCTAssertEqual(ip1!.count, 0)
+        
+        var ip2: IndexPath? = IndexPath()
+        IndexPath._forceBridgeFromObjectiveC(nsip2, result: &ip2)
+        XCTAssertNotNil(ip2)
+        XCTAssertEqual(ip2!.count, 1)
+        XCTAssertEqual(ip2![0], 1)
+        
+        var ip3: IndexPath? = IndexPath()
+        IndexPath._forceBridgeFromObjectiveC(nsip3, result: &ip3)
+        XCTAssertNotNil(ip3)
+        XCTAssertEqual(ip3!.count, 2)
+        XCTAssertEqual(ip3![0], 1)
+        XCTAssertEqual(ip3![1], 2)
+        
+        var ip4: IndexPath? = IndexPath()
+        IndexPath._forceBridgeFromObjectiveC(nsip4, result: &ip4)
+        XCTAssertNotNil(ip4)
+        XCTAssertEqual(ip4!.count, 3)
+        XCTAssertEqual(ip4![0], 1)
+        XCTAssertEqual(ip4![1], 2)
+        XCTAssertEqual(ip4![2], 3)
+    }
+    
+    func testConditionalBridgeFromObjC() {
+        let nsip1 = NSIndexPath()
+        let nsip2 = NSIndexPath(index: 1)
+        let nsip3 = [1, 2].withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<Int>) -> NSIndexPath in
+            return NSIndexPath(indexes: buffer.baseAddress, length: buffer.count)
+        }
+        let nsip4 = [1, 2, 3].withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<Int>) -> NSIndexPath in
+            return NSIndexPath(indexes: buffer.baseAddress, length: buffer.count)
+        }
+        
+        var ip1: IndexPath? = IndexPath()
+        XCTAssertTrue(IndexPath._conditionallyBridgeFromObjectiveC(nsip1, result: &ip1))
+        XCTAssertNotNil(ip1)
+        XCTAssertEqual(ip1!.count, 0)
+        
+        var ip2: IndexPath? = IndexPath()
+        XCTAssertTrue(IndexPath._conditionallyBridgeFromObjectiveC(nsip2, result: &ip2))
+        XCTAssertNotNil(ip2)
+        XCTAssertEqual(ip2!.count, 1)
+        XCTAssertEqual(ip2![0], 1)
+        
+        var ip3: IndexPath? = IndexPath()
+        XCTAssertTrue(IndexPath._conditionallyBridgeFromObjectiveC(nsip3, result: &ip3))
+        XCTAssertNotNil(ip3)
+        XCTAssertEqual(ip3!.count, 2)
+        XCTAssertEqual(ip3![0], 1)
+        XCTAssertEqual(ip3![1], 2)
+        
+        var ip4: IndexPath? = IndexPath()
+        XCTAssertTrue(IndexPath._conditionallyBridgeFromObjectiveC(nsip4, result: &ip4))
+        XCTAssertNotNil(ip4)
+        XCTAssertEqual(ip4!.count, 3)
+        XCTAssertEqual(ip4![0], 1)
+        XCTAssertEqual(ip4![1], 2)
+        XCTAssertEqual(ip4![2], 3)
+    }
+    
+    func testUnconditionalBridgeFromObjC() {
+        let nsip1 = NSIndexPath()
+        let nsip2 = NSIndexPath(index: 1)
+        let nsip3 = [1, 2].withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<Int>) -> NSIndexPath in
+            return NSIndexPath(indexes: buffer.baseAddress, length: buffer.count)
+        }
+        let nsip4 = [1, 2, 3].withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<Int>) -> NSIndexPath in
+            return NSIndexPath(indexes: buffer.baseAddress, length: buffer.count)
+        }
+        
+        let ip1: IndexPath = IndexPath._unconditionallyBridgeFromObjectiveC(nsip1)
+        XCTAssertEqual(ip1.count, 0)
+        
+        var ip2: IndexPath = IndexPath._unconditionallyBridgeFromObjectiveC(nsip2)
+        XCTAssertEqual(ip2.count, 1)
+        XCTAssertEqual(ip2[0], 1)
+        
+        var ip3: IndexPath = IndexPath._unconditionallyBridgeFromObjectiveC(nsip3)
+        XCTAssertEqual(ip3.count, 2)
+        XCTAssertEqual(ip3[0], 1)
+        XCTAssertEqual(ip3[1], 2)
+        
+        var ip4: IndexPath = IndexPath._unconditionallyBridgeFromObjectiveC(nsip4)
+        XCTAssertEqual(ip4.count, 3)
+        XCTAssertEqual(ip4[0], 1)
+        XCTAssertEqual(ip4[1], 2)
+        XCTAssertEqual(ip4[2], 3)
+    }
+    
+    func testObjcBridgeType() {
+        XCTAssertTrue(IndexPath._getObjectiveCType() == NSIndexPath.self)
+    }
+    
+    func test_AnyHashableContainingIndexPath() {
+        let values: [IndexPath] = [
+            IndexPath(indexes: [1, 2]),
+            IndexPath(indexes: [1, 2, 3]),
+            IndexPath(indexes: [1, 2, 3]),
+            ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(IndexPath.self, type(of: anyHashables[0].base))
+        expectEqual(IndexPath.self, type(of: anyHashables[1].base))
+        expectEqual(IndexPath.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableCreatedFromNSIndexPath() {
+        let values: [NSIndexPath] = [
+            NSIndexPath(index: 1),
+            NSIndexPath(index: 2),
+            NSIndexPath(index: 2),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(IndexPath.self, type(of: anyHashables[0].base))
+        expectEqual(IndexPath.self, type(of: anyHashables[1].base))
+        expectEqual(IndexPath.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_unconditionallyBridgeFromObjectiveC() {
+        XCTAssertEqual(IndexPath(), IndexPath._unconditionallyBridgeFromObjectiveC(nil))
+    }
+
+    func test_slice_1ary() {
+        let indexPath: IndexPath = [0]
+        let res = indexPath.dropFirst()
+        XCTAssertEqual(0, res.count)
+
+        let slice = indexPath[1..<1]
+        XCTAssertEqual(0, slice.count)
+    }
+
+    func test_dropFirst() {
+        var pth = IndexPath(indexes:[1,2,3,4])
+        while !pth.isEmpty {
+            // this should not crash 
+            pth = pth.dropFirst()
+        }
+    }
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestIndexSet.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestIndexSet.swift
@@ -1,0 +1,840 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+class TestIndexSet : XCTestCase {
+    
+    func testEnumeration() {
+        let someIndexes = IndexSet(integersIn: 3...4)
+        let first = someIndexes.startIndex
+        let last = someIndexes.endIndex
+        
+        XCTAssertNotEqual(first, last)
+        
+        var count = 0
+        var firstValue = 0
+        var secondValue = 0
+        for v in someIndexes {
+            if count == 0 { firstValue = v }
+            if count == 1 { secondValue = v }
+            count += 1
+        }
+        
+        XCTAssertEqual(2, count)
+        XCTAssertEqual(3, firstValue)
+        XCTAssertEqual(4, secondValue)
+    }
+    
+    func testSubsequence() {
+        var someIndexes = IndexSet(integersIn: 1..<3)
+        someIndexes.insert(integersIn: 10..<20)
+        
+        let intersectingRange = someIndexes.indexRange(in: 5..<21)
+        XCTAssertFalse(intersectingRange.isEmpty)
+        
+        let sub = someIndexes[intersectingRange]
+        var count = 0
+        for i in sub {
+            if count == 0 {
+                XCTAssertEqual(10, i)
+            }
+            if count == 9 {
+                XCTAssertEqual(19, i)
+            }
+            count += 1
+        }
+        XCTAssertEqual(count, 10)
+    }
+    
+    func testIndexRange() {
+        var someIndexes = IndexSet(integersIn: 1..<3)
+        someIndexes.insert(integersIn: 10..<20)
+
+        var r : Range<IndexSet.Index>
+        
+        r = someIndexes.indexRange(in: 1..<3)
+        XCTAssertEqual(1, someIndexes[r.lowerBound])
+        XCTAssertEqual(10, someIndexes[r.upperBound])
+        
+        r = someIndexes.indexRange(in: 0..<0)
+        XCTAssertEqual(r.lowerBound, r.upperBound)
+        
+        r = someIndexes.indexRange(in: 100..<201)
+        XCTAssertEqual(r.lowerBound, r.upperBound)
+        XCTAssertTrue(r.isEmpty)
+        
+        r = someIndexes.indexRange(in: 0..<100)
+        XCTAssertEqual(r.lowerBound, someIndexes.startIndex)
+        XCTAssertEqual(r.upperBound, someIndexes.endIndex)
+        
+        r = someIndexes.indexRange(in: 1..<11)
+        XCTAssertEqual(1, someIndexes[r.lowerBound])
+        XCTAssertEqual(11, someIndexes[r.upperBound])
+        
+        let empty = IndexSet()
+        XCTAssertTrue(empty.indexRange(in: 1..<3).isEmpty)
+    }
+    
+    func testMutation() {
+        var someIndexes = IndexSet(integersIn: 1..<3)
+        someIndexes.insert(3)
+        someIndexes.insert(4)
+        someIndexes.insert(5)
+        
+        someIndexes.insert(10)
+        someIndexes.insert(11)
+        
+        XCTAssertEqual(someIndexes.count, 7)
+        
+        someIndexes.remove(11)
+        
+        XCTAssertEqual(someIndexes.count, 6)
+        
+        someIndexes.insert(integersIn: 100...101)
+        XCTAssertEqual(8, someIndexes.count)
+        XCTAssertEqual(2, someIndexes.count(in: 100...101))
+        
+        someIndexes.remove(integersIn: 100...101)
+        XCTAssertEqual(6, someIndexes.count)
+        XCTAssertEqual(0, someIndexes.count(in: 100...101))
+
+        someIndexes.insert(integersIn: 200..<202)
+        XCTAssertEqual(8, someIndexes.count)
+        XCTAssertEqual(2, someIndexes.count(in: 200..<202))
+        
+        someIndexes.remove(integersIn: 200..<202)
+        XCTAssertEqual(6, someIndexes.count)
+        XCTAssertEqual(0, someIndexes.count(in: 200..<202))
+    }
+    
+    func testContainsAndIntersects() {
+        let someIndexes = IndexSet(integersIn: 1..<10)
+
+        XCTAssertTrue(someIndexes.contains(integersIn: 1..<10))
+        XCTAssertTrue(someIndexes.contains(integersIn: 1...9))
+        XCTAssertTrue(someIndexes.contains(integersIn: 2..<10))
+        XCTAssertTrue(someIndexes.contains(integersIn: 2...9))
+        XCTAssertTrue(someIndexes.contains(integersIn: 1..<9))
+        XCTAssertTrue(someIndexes.contains(integersIn: 1...8))
+
+        XCTAssertFalse(someIndexes.contains(integersIn: 0..<10))
+        XCTAssertFalse(someIndexes.contains(integersIn: 0...9))
+        XCTAssertFalse(someIndexes.contains(integersIn: 2..<11))
+        XCTAssertFalse(someIndexes.contains(integersIn: 2...10))
+        XCTAssertFalse(someIndexes.contains(integersIn: 0..<9))
+        XCTAssertFalse(someIndexes.contains(integersIn: 0...8))
+        
+        XCTAssertTrue(someIndexes.intersects(integersIn: 1..<10))
+        XCTAssertTrue(someIndexes.intersects(integersIn: 1...9))
+        XCTAssertTrue(someIndexes.intersects(integersIn: 2..<10))
+        XCTAssertTrue(someIndexes.intersects(integersIn: 2...9))
+        XCTAssertTrue(someIndexes.intersects(integersIn: 1..<9))
+        XCTAssertTrue(someIndexes.intersects(integersIn: 1...8))
+        
+        XCTAssertTrue(someIndexes.intersects(integersIn: 0..<10))
+        XCTAssertTrue(someIndexes.intersects(integersIn: 0...9))
+        XCTAssertTrue(someIndexes.intersects(integersIn: 2..<11))
+        XCTAssertTrue(someIndexes.intersects(integersIn: 2...10))
+        XCTAssertTrue(someIndexes.intersects(integersIn: 0..<9))
+        XCTAssertTrue(someIndexes.intersects(integersIn: 0...8))
+
+        XCTAssertFalse(someIndexes.intersects(integersIn: 0..<0))
+        XCTAssertFalse(someIndexes.intersects(integersIn: 10...12))
+        XCTAssertFalse(someIndexes.intersects(integersIn: 10..<12))
+    }
+    
+    func testIteration() {
+        var someIndexes = IndexSet(integersIn: 1..<5)
+        someIndexes.insert(integersIn: 8..<11)
+        someIndexes.insert(15)
+        
+        let start = someIndexes.startIndex
+        let end = someIndexes.endIndex
+        
+        // Count forwards
+        var i = start
+        var count = 0
+        while i != end {
+            count += 1
+            i = someIndexes.index(after: i)
+        }
+        XCTAssertEqual(8, count)
+        
+        // Count backwards
+        i = end
+        count = 0
+        while i != start {
+            i = someIndexes.index(before: i)
+            count += 1
+        }
+        XCTAssertEqual(8, count)
+        
+        // Count using a for loop
+        count = 0
+        for _ in someIndexes {
+            count += 1
+        }
+        XCTAssertEqual(8, count)
+
+        // Go the other way
+        count = 0
+        for _ in someIndexes.reversed() {
+            count += 1
+        }
+        XCTAssertEqual(8, count)
+    }
+    
+    func testRangeIteration() {
+        var someIndexes = IndexSet(integersIn: 1..<5)
+        someIndexes.insert(integersIn: 8..<11)
+        someIndexes.insert(15)
+        
+        var count = 0
+        for r in someIndexes.rangeView {
+            // print("\(r)")
+            count += 1
+            if count == 3 {
+                XCTAssertEqual(r, 15..<16)
+            }
+        }
+        XCTAssertEqual(3, count)
+        
+        // Backwards
+        count = 0
+        for r in someIndexes.rangeView.reversed() {
+            // print("\(r)")
+            count += 1
+            if count == 3 {
+                XCTAssertEqual(r, 1..<5)
+            }
+        }
+        XCTAssertEqual(3, count)
+    }
+    
+    func testSubrangeIteration() {
+        func XCTAssertRanges(_ ranges: [Range<IndexSet.RangeView.Index>], in view: IndexSet.RangeView) {
+            XCTAssertEqual(ranges.count, view.count)
+
+            for i in 0 ..< min(ranges.count, view.count) {
+                XCTAssertEqual(ranges[i], view[i])
+            }
+        }
+
+        // Inclusive ranges for test:
+        // 2-4, 8-10, 15-19, 30-39, 60-79
+        var indexes = IndexSet()
+        indexes.insert(integersIn: 2..<5)
+        indexes.insert(integersIn: 8...10)
+        indexes.insert(integersIn: 15..<20)
+        indexes.insert(integersIn: 30...39)
+        indexes.insert(integersIn: 60..<80)
+
+        // Empty ranges should yield no results:
+        XCTAssertRanges([], in: indexes.rangeView(of: 0..<0))
+
+        // Ranges below contained indexes should yield no results:
+        XCTAssertRanges([], in: indexes.rangeView(of: 0...1))
+
+        // Ranges starting below first index but overlapping should yield a result:
+        XCTAssertRanges([2..<3], in: indexes.rangeView(of: 0...2))
+
+        // Ranges starting below first index but enveloping a range should yield a result:
+        XCTAssertRanges([2..<5], in: indexes.rangeView(of: 0...6))
+
+        // Ranges within subranges should yield a result:
+        XCTAssertRanges([2..<5], in: indexes.rangeView(of: 2...4))
+        XCTAssertRanges([3..<5], in: indexes.rangeView(of: 3...4))
+        XCTAssertRanges([3..<4], in: indexes.rangeView(of: 3..<4))
+
+        // Ranges starting within subranges and going over the end should yield a result:
+        XCTAssertRanges([3..<5], in: indexes.rangeView(of: 3...6))
+
+        // Ranges not matching any indexes should yield no results:
+        XCTAssertRanges([], in: indexes.rangeView(of: 5...6))
+        XCTAssertRanges([], in: indexes.rangeView(of: 5..<8))
+
+        // Same as above -- overlapping with a range of indexes should slice it appropriately:
+        XCTAssertRanges([8..<9], in: indexes.rangeView(of: 6...8))
+        XCTAssertRanges([8..<11], in: indexes.rangeView(of: 8...10))
+        XCTAssertRanges([8..<11], in: indexes.rangeView(of: 8...13))
+
+        XCTAssertRanges([2..<5, 8..<10], in: indexes.rangeView(of: 0...9))
+        XCTAssertRanges([2..<5, 8..<11], in: indexes.rangeView(of: 0...12))
+        XCTAssertRanges([3..<5, 8..<11], in: indexes.rangeView(of: 3...14))
+
+        XCTAssertRanges([3..<5, 8..<11, 15..<18], in: indexes.rangeView(of: 3...17))
+        XCTAssertRanges([3..<5, 8..<11, 15..<20], in: indexes.rangeView(of: 3...20))
+        XCTAssertRanges([3..<5, 8..<11, 15..<20], in: indexes.rangeView(of: 3...21))
+
+        // Ranges inclusive of the end index should yield all of the contained ranges:
+        XCTAssertRanges([2..<5, 8..<11, 15..<20, 30..<40, 60..<80], in: indexes.rangeView(of: 0...80))
+        XCTAssertRanges([2..<5, 8..<11, 15..<20, 30..<40, 60..<80], in: indexes.rangeView(of: 2..<80))
+        XCTAssertRanges([2..<5, 8..<11, 15..<20, 30..<40, 60..<80], in: indexes.rangeView(of: 2...80))
+
+        // Ranges above the end index should yield no results:
+        XCTAssertRanges([], in: indexes.rangeView(of: 90..<90))
+        XCTAssertRanges([], in: indexes.rangeView(of: 90...90))
+        XCTAssertRanges([], in: indexes.rangeView(of: 90...100))
+    }
+    
+    func testSlicing() {
+        var someIndexes = IndexSet(integersIn: 2..<5)
+        someIndexes.insert(integersIn: 8..<11)
+        someIndexes.insert(integersIn: 15..<20)
+        someIndexes.insert(integersIn: 30..<40)
+        someIndexes.insert(integersIn: 60..<80)
+        
+        var r : Range<IndexSet.Index>
+        
+        r = someIndexes.indexRange(in: 5..<25)
+        XCTAssertEqual(8, someIndexes[r.lowerBound])
+        XCTAssertEqual(19, someIndexes[someIndexes.index(before: r.upperBound)])
+        var count = 0
+        for _ in someIndexes[r] {
+            count += 1
+        }
+        
+        XCTAssertEqual(8, someIndexes.count(in: 5..<25))
+        XCTAssertEqual(8, count)
+        
+        r = someIndexes.indexRange(in: 100...199)
+        XCTAssertTrue(r.isEmpty)
+        
+        let emptySlice = someIndexes[r]
+        XCTAssertEqual(0, emptySlice.count)
+        
+        let boundarySlice = someIndexes[someIndexes.indexRange(in: 2..<3)]
+        XCTAssertEqual(1, boundarySlice.count)
+        
+        let boundarySlice2 = someIndexes[someIndexes.indexRange(in: 79..<80)]
+        XCTAssertEqual(1, boundarySlice2.count)
+        
+        let largeSlice = someIndexes[someIndexes.indexRange(in: 0..<100000)]
+        XCTAssertEqual(someIndexes.count, largeSlice.count)
+    }
+    
+    func testEmptyIteration() {
+        var empty = IndexSet()
+        let start = empty.startIndex
+        let end = empty.endIndex
+        
+        XCTAssertEqual(start, end)
+        
+        var count = 0
+        for _ in empty {
+            count += 1
+        }
+        
+        XCTAssertEqual(count, 0)
+        
+        count = 0
+        for _ in empty.rangeView {
+            count += 1
+        }
+        
+        XCTAssertEqual(count, 0)
+
+        empty.insert(5)
+        empty.remove(5)
+        
+        count = 0
+        for _ in empty {
+            count += 1
+        }
+        XCTAssertEqual(count, 0)
+
+        count = 0
+        for _ in empty.rangeView {
+            count += 1
+        }
+        XCTAssertEqual(count, 0)
+    }
+    
+    func testSubsequences() {
+        var someIndexes = IndexSet(integersIn: 1..<5)
+        someIndexes.insert(integersIn: 8..<11)
+        someIndexes.insert(15)
+
+        // Get a subsequence of this IndexSet
+        let range = someIndexes.indexRange(in: 4..<15)
+        let subSet = someIndexes[range]
+        
+        XCTAssertEqual(subSet.count, 4)
+        
+        // Iterate a subset
+        var count = 0
+        for _ in subSet {
+            count += 1
+        }
+        XCTAssertEqual(count, 4)
+        
+        // And in reverse
+        count = 0
+        for _ in subSet.reversed() {
+            count += 1
+        }
+        XCTAssertEqual(count, 4)
+    }
+    
+    func testFiltering() {
+        var someIndexes = IndexSet(integersIn: 1..<5)
+        someIndexes.insert(integersIn: 8..<11)
+        someIndexes.insert(15)
+        
+        // An array
+        let resultArray = someIndexes.filter { $0 % 2 == 0 }
+        XCTAssertEqual(resultArray.count, 4)
+
+        let resultSet = someIndexes.filteredIndexSet { $0 % 2 == 0 }
+        XCTAssertEqual(resultSet.count, 4)
+        
+        let resultOutsideRange = someIndexes.filteredIndexSet(in: 20..<30, includeInteger: { _ in return true } )
+        XCTAssertEqual(resultOutsideRange.count, 0)
+        
+        let resultInRange = someIndexes.filteredIndexSet(in: 0..<16, includeInteger: { _ in return true } )
+        XCTAssertEqual(resultInRange.count, someIndexes.count)
+    }
+    
+    func testFilteringRanges() {
+        var someIndexes = IndexSet(integersIn: 1..<5)
+        someIndexes.insert(integersIn: 8..<11)
+        someIndexes.insert(15)
+
+        let resultArray = someIndexes.rangeView.filter { $0.count > 1 }
+        XCTAssertEqual(resultArray.count, 2)
+    }
+    
+    func testShift() {
+        var someIndexes = IndexSet(integersIn: 1..<5)
+        someIndexes.insert(integersIn: 8..<11)
+        someIndexes.insert(15)
+        
+        let lastValue = someIndexes.last!
+        
+        someIndexes.shift(startingAt: 13, by: 1)
+        
+        // Count should not have changed
+        XCTAssertEqual(someIndexes.count, 8)
+        
+        // But the last value should have
+        XCTAssertEqual(lastValue + 1, someIndexes.last!)
+        
+        // Shift starting at something not in the set
+        someIndexes.shift(startingAt: 0, by: 1)
+        
+        // Count should not have changed, again
+        XCTAssertEqual(someIndexes.count, 8)
+        
+        // But the last value should have, again
+        XCTAssertEqual(lastValue + 2, someIndexes.last!)
+    }
+    
+    func testSymmetricDifference() {
+        var is1 : IndexSet
+        var is2 : IndexSet
+        var expected : IndexSet
+
+        do {
+            is1 = IndexSet()
+            is1.insert(integersIn: 1..<3)
+            is1.insert(integersIn: 4..<11)
+            is1.insert(integersIn: 15..<21)
+            is1.insert(integersIn: 40..<51)
+            
+            is2 = IndexSet()
+            is2.insert(integersIn: 5..<18)
+            is2.insert(integersIn: 45..<61)
+            
+            expected = IndexSet()
+            expected.insert(integersIn: 1..<3)
+            expected.insert(4)
+            expected.insert(integersIn: 11..<15)
+            expected.insert(integersIn: 18..<21)
+            expected.insert(integersIn: 40..<45)
+            expected.insert(integersIn: 51..<61)
+            
+            XCTAssertEqual(expected, is1.symmetricDifference(is2))
+            XCTAssertEqual(expected, is2.symmetricDifference(is1))
+        }
+        
+        do {
+            is1 = IndexSet()
+            is1.insert(integersIn: 5..<18)
+            is1.insert(integersIn: 45..<61)
+            
+            is2 = IndexSet()
+            is2.insert(integersIn: 5..<18)
+            is2.insert(integersIn: 45..<61)
+
+            expected = IndexSet()
+            XCTAssertEqual(expected, is1.symmetricDifference(is2))
+            XCTAssertEqual(expected, is2.symmetricDifference(is1))
+        }
+        
+        do {
+            is1 = IndexSet(integersIn: 1..<10)
+            is2 = IndexSet(integersIn: 20..<30)
+            
+            expected = IndexSet()
+            expected.insert(integersIn: 1..<10)
+            expected.insert(integersIn: 20..<30)
+            XCTAssertEqual(expected, is1.symmetricDifference(is2))
+            XCTAssertEqual(expected, is2.symmetricDifference(is1))
+        }
+        
+        do {
+            is1 = IndexSet(integersIn: 1..<10)
+            is2 = IndexSet(integersIn: 1..<11)
+            expected = IndexSet(integer: 10)
+            XCTAssertEqual(expected, is1.symmetricDifference(is2))
+            XCTAssertEqual(expected, is2.symmetricDifference(is1))
+        }
+        
+        do {
+            is1 = IndexSet(integer: 42)
+            is2 = IndexSet(integer: 42)
+            XCTAssertEqual(IndexSet(), is1.symmetricDifference(is2))
+            XCTAssertEqual(IndexSet(), is2.symmetricDifference(is1))
+        }
+        
+        do {
+            is1 = IndexSet(integer: 1)
+            is1.insert(3)
+            is1.insert(5)
+            is1.insert(7)
+            
+            is2 = IndexSet(integer: 0)
+            is2.insert(2)
+            is2.insert(4)
+            is2.insert(6)
+            
+            expected = IndexSet(integersIn: 0..<8)
+            XCTAssertEqual(expected, is1.symmetricDifference(is2))
+            XCTAssertEqual(expected, is2.symmetricDifference(is1))
+        }
+        
+        do {
+            is1 = IndexSet(integersIn: 0..<5)
+            is2 = IndexSet(integersIn: 3..<10)
+            
+            expected = IndexSet(integersIn: 0..<3)
+            expected.insert(integersIn: 5..<10)
+            
+            XCTAssertEqual(expected, is1.symmetricDifference(is2))
+            XCTAssertEqual(expected, is2.symmetricDifference(is1))
+        }
+        
+        do {
+            is1 = IndexSet([0, 2])
+            is2 = IndexSet([0, 1, 2])
+            XCTAssertEqual(IndexSet(integer: 1), is1.symmetricDifference(is2))
+        }
+    }
+    
+    func testIntersection() {
+        var is1 : IndexSet
+        var is2 : IndexSet
+        var expected : IndexSet
+
+        do {
+            is1 = IndexSet()
+            is1.insert(integersIn: 1..<3)
+            is1.insert(integersIn: 4..<11)
+            is1.insert(integersIn: 15..<21)
+            is1.insert(integersIn: 40..<51)
+            
+            is2 = IndexSet()
+            is2.insert(integersIn: 5..<18)
+            is2.insert(integersIn: 45..<61)
+            
+            expected = IndexSet()
+            expected.insert(integersIn: 5..<11)
+            expected.insert(integersIn: 15..<18)
+            expected.insert(integersIn: 45..<51)
+            
+            XCTAssertEqual(expected, is1.intersection(is2))
+            XCTAssertEqual(expected, is2.intersection(is1))
+        }
+        
+        do {
+            is1 = IndexSet()
+            is1.insert(integersIn: 5..<11)
+            is1.insert(integersIn: 20..<31)
+            
+            is2 = IndexSet()
+            is2.insert(integersIn: 11..<20)
+            is2.insert(integersIn: 31..<40)
+            
+            XCTAssertEqual(IndexSet(), is1.intersection(is2))
+            XCTAssertEqual(IndexSet(), is2.intersection(is1))
+        }
+        
+        do {
+            is1 = IndexSet(integer: 42)
+            is2 = IndexSet(integer: 42)
+            XCTAssertEqual(IndexSet(integer: 42), is1.intersection(is2))
+        }
+        
+        do {
+            is1 = IndexSet(integer: 1)
+            is1.insert(3)
+            is1.insert(5)
+            is1.insert(7)
+            
+            is2 = IndexSet(integer: 0)
+            is2.insert(2)
+            is2.insert(4)
+            is2.insert(6)
+            
+            expected = IndexSet()
+            XCTAssertEqual(expected, is1.intersection(is2))
+            XCTAssertEqual(expected, is2.intersection(is1))
+        }
+        
+        do {
+            is1 = IndexSet(integersIn: 0..<5)
+            is2 = IndexSet(integersIn: 4..<10)
+            
+            expected = IndexSet(integer: 4)
+            
+            XCTAssertEqual(expected, is1.intersection(is2))
+            XCTAssertEqual(expected, is2.intersection(is1))
+        }
+        
+        do {
+            is1 = IndexSet([0, 2])
+            is2 = IndexSet([0, 1, 2])
+            XCTAssertEqual(is1, is1.intersection(is2))
+        }
+    }
+    
+    func testUnion() {
+        var is1 : IndexSet
+        var is2 : IndexSet
+        var expected : IndexSet
+        
+        do {
+            is1 = IndexSet()
+            is1.insert(integersIn: 1..<3)
+            is1.insert(integersIn: 4..<11)
+            is1.insert(integersIn: 15..<21)
+            is1.insert(integersIn: 40..<51)
+            
+            is2 = IndexSet()
+            is2.insert(integersIn: 5..<18)
+            is2.insert(integersIn: 45..<61)
+            
+            expected = IndexSet()
+            expected.insert(integersIn: 1..<3)
+            expected.insert(integersIn: 4..<21)
+            expected.insert(integersIn: 40..<61)
+            
+            XCTAssertEqual(expected, is1.union(is2))
+            XCTAssertEqual(expected, is2.union(is1))
+        }
+        
+        do {
+            is1 = IndexSet()
+            is1.insert(integersIn: 5..<11)
+            is1.insert(integersIn: 20..<31)
+            
+            is2 = IndexSet()
+            is2.insert(integersIn: 11..<20)
+            is2.insert(integersIn: 31..<40)
+            
+            expected = IndexSet()
+            expected.insert(integersIn: 5..<11)
+            expected.insert(integersIn: 20..<31)
+            expected.insert(integersIn: 11..<20)
+            expected.insert(integersIn: 31..<40)
+            
+            XCTAssertEqual(expected, is1.union(is2))
+            XCTAssertEqual(expected, is2.union(is1))
+        }
+        
+        do {
+            is1 = IndexSet(integer: 42)
+            is2 = IndexSet(integer: 42)
+            
+            XCTAssertEqual(IndexSet(integer: 42), is1.union(is2))
+        }
+        
+        do {
+            is1 = IndexSet()
+            is1.insert(integersIn: 5..<10)
+            is1.insert(integersIn: 15..<20)
+            
+            is2 = IndexSet()
+            is2.insert(integersIn: 1..<4)
+            is2.insert(integersIn: 15..<20)
+            
+            expected = IndexSet()
+            expected.insert(integersIn: 1..<4)
+            expected.insert(integersIn: 5..<10)
+            expected.insert(integersIn: 15..<20)
+            
+            XCTAssertEqual(expected, is1.union(is2))
+            XCTAssertEqual(expected, is2.union(is1))
+        }
+
+        XCTAssertEqual(IndexSet(), IndexSet().union(IndexSet()))
+        
+        do {
+            is1 = IndexSet(integer: 1)
+            is1.insert(3)
+            is1.insert(5)
+            is1.insert(7)
+            
+            is2 = IndexSet(integer: 0)
+            is2.insert(2)
+            is2.insert(4)
+            is2.insert(6)
+            
+            expected = IndexSet()
+            XCTAssertEqual(expected, is1.intersection(is2))
+            XCTAssertEqual(expected, is2.intersection(is1))
+        }
+        
+        do {
+            is1 = IndexSet(integersIn: 0..<5)
+            is2 = IndexSet(integersIn: 3..<10)
+            
+            expected = IndexSet(integersIn: 0..<10)
+            
+            XCTAssertEqual(expected, is1.union(is2))
+            XCTAssertEqual(expected, is2.union(is1))
+        }
+
+        do {
+            is1 = IndexSet()
+            is1.insert(2)
+            is1.insert(6)
+            is1.insert(21)
+            is1.insert(22)
+            
+            is2 = IndexSet()
+            is2.insert(8)
+            is2.insert(14)
+            is2.insert(21)
+            is2.insert(22)
+            is2.insert(24)
+            
+            expected = IndexSet()
+            expected.insert(2)
+            expected.insert(6)
+            expected.insert(21)
+            expected.insert(22)
+            expected.insert(8)
+            expected.insert(14)
+            expected.insert(21)
+            expected.insert(22)
+            expected.insert(24)
+
+            XCTAssertEqual(expected, is1.union(is2))
+            XCTAssertEqual(expected, is2.union(is1))
+        }
+    }
+    
+    func test_findIndex() {
+        var i = IndexSet()
+        
+        // Verify nil result for empty sets
+        XCTAssertEqual(nil, i.first)
+        XCTAssertEqual(nil, i.last)
+        XCTAssertEqual(nil, i.integerGreaterThan(5))
+        XCTAssertEqual(nil, i.integerLessThan(5))
+        XCTAssertEqual(nil, i.integerGreaterThanOrEqualTo(5))
+        XCTAssertEqual(nil, i.integerLessThanOrEqualTo(5))
+        
+        i.insert(integersIn: 5..<10)
+        i.insert(integersIn: 15..<20)
+
+        // Verify non-nil result
+        XCTAssertEqual(5, i.first)
+        XCTAssertEqual(19, i.last)
+        
+        XCTAssertEqual(nil, i.integerGreaterThan(19))
+        XCTAssertEqual(5, i.integerGreaterThan(3))
+        
+        XCTAssertEqual(nil, i.integerLessThan(5))
+        XCTAssertEqual(5, i.integerLessThan(6))
+        
+        XCTAssertEqual(nil, i.integerGreaterThanOrEqualTo(20))
+        XCTAssertEqual(19, i.integerGreaterThanOrEqualTo(19))
+        
+        XCTAssertEqual(nil, i.integerLessThanOrEqualTo(4))
+        XCTAssertEqual(5, i.integerLessThanOrEqualTo(5))
+    }
+
+    // MARK: -
+    // MARK: Performance Testing
+    
+    func largeIndexSet() -> IndexSet {
+        var result = IndexSet()
+        
+        for i in 1..<10000 {
+            let start = i * 10
+            let end = start + 9
+            result.insert(integersIn: start..<end + 1)
+        }
+        
+        return result
+    }
+    
+    func testIndexingPerformance() {
+        /*
+        let set = largeIndexSet()
+        self.measureBlock {
+            var count = 0
+            while count < 20 {
+                for _ in set {
+                }
+                count += 1
+            }
+        }
+        */
+    }
+
+    func test_AnyHashableContainingIndexSet() {
+        let values: [IndexSet] = [
+            IndexSet([0, 1]),
+            IndexSet([0, 1, 2]),
+            IndexSet([0, 1, 2]),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(IndexSet.self, type(of: anyHashables[0].base))
+        expectEqual(IndexSet.self, type(of: anyHashables[1].base))
+        expectEqual(IndexSet.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableCreatedFromNSIndexSet() {
+        let values: [NSIndexSet] = [
+            NSIndexSet(index: 0),
+            NSIndexSet(index: 1),
+            NSIndexSet(index: 1),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(IndexSet.self, type(of: anyHashables[0].base))
+        expectEqual(IndexSet.self, type(of: anyHashables[1].base))
+        expectEqual(IndexSet.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_unconditionallyBridgeFromObjectiveC() {
+        XCTAssertEqual(IndexSet(), IndexSet._unconditionallyBridgeFromObjectiveC(nil))
+    }
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestJSONEncoder.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestJSONEncoder.swift
@@ -1,0 +1,1691 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+import Foundation
+import XCTest
+
+// MARK: - Test Suite
+
+class TestJSONEncoder : XCTestCase {
+  // MARK: - Encoding Top-Level Empty Types
+  func testEncodingTopLevelEmptyStruct() {
+    let empty = EmptyStruct()
+    _testRoundTrip(of: empty, expectedJSON: _jsonEmptyDictionary)
+  }
+
+  func testEncodingTopLevelEmptyClass() {
+    let empty = EmptyClass()
+    _testRoundTrip(of: empty, expectedJSON: _jsonEmptyDictionary)
+  }
+
+  // MARK: - Encoding Top-Level Single-Value Types
+  func testEncodingTopLevelSingleValueEnum() {
+    _testRoundTrip(of: Switch.off)
+    _testRoundTrip(of: Switch.on)
+  }
+
+  func testEncodingTopLevelSingleValueStruct() {
+    _testRoundTrip(of: Timestamp(3141592653))
+  }
+
+  func testEncodingTopLevelSingleValueClass() {
+    _testRoundTrip(of: Counter())
+  }
+
+  // MARK: - Encoding Top-Level Structured Types
+  func testEncodingTopLevelStructuredStruct() {
+    // Address is a struct type with multiple fields.
+    let address = Address.testValue
+    _testRoundTrip(of: address)
+  }
+
+  func testEncodingTopLevelStructuredClass() {
+    // Person is a class with multiple fields.
+    let expectedJSON = "{\"name\":\"Johnny Appleseed\",\"email\":\"appleseed@apple.com\"}".data(using: .utf8)!
+    let person = Person.testValue
+    _testRoundTrip(of: person, expectedJSON: expectedJSON)
+  }
+
+  func testEncodingTopLevelStructuredSingleStruct() {
+    // Numbers is a struct which encodes as an array through a single value container.
+    let numbers = Numbers.testValue
+    _testRoundTrip(of: numbers)
+  }
+
+  func testEncodingTopLevelStructuredSingleClass() {
+    // Mapping is a class which encodes as a dictionary through a single value container.
+    let mapping = Mapping.testValue
+    _testRoundTrip(of: mapping)
+  }
+
+  func testEncodingTopLevelDeepStructuredType() {
+    // Company is a type with fields which are Codable themselves.
+    let company = Company.testValue
+    _testRoundTrip(of: company)
+  }
+
+  func testEncodingClassWhichSharesEncoderWithSuper() {
+    // Employee is a type which shares its encoder & decoder with its superclass, Person.
+    let employee = Employee.testValue
+    _testRoundTrip(of: employee)
+  }
+
+  func testEncodingTopLevelNullableType() {
+    // EnhancedBool is a type which encodes either as a Bool or as nil.
+    _testRoundTrip(of: EnhancedBool.true, expectedJSON: "true".data(using: .utf8)!)
+    _testRoundTrip(of: EnhancedBool.false, expectedJSON: "false".data(using: .utf8)!)
+    _testRoundTrip(of: EnhancedBool.fileNotFound, expectedJSON: "null".data(using: .utf8)!)
+  }
+  
+  func testEncodingMultipleNestedContainersWithTheSameTopLevelKey() {
+    struct Model : Codable, Equatable {
+      let first: String
+      let second: String
+      
+      init(from coder: Decoder) throws {
+        let container = try coder.container(keyedBy: TopLevelCodingKeys.self)
+        
+        let firstNestedContainer = try container.nestedContainer(keyedBy: FirstNestedCodingKeys.self, forKey: .top)
+        self.first = try firstNestedContainer.decode(String.self, forKey: .first)
+        
+        let secondNestedContainer = try container.nestedContainer(keyedBy: SecondNestedCodingKeys.self, forKey: .top)
+        self.second = try secondNestedContainer.decode(String.self, forKey: .second)
+      }
+      
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: TopLevelCodingKeys.self)
+        
+        var firstNestedContainer = container.nestedContainer(keyedBy: FirstNestedCodingKeys.self, forKey: .top)
+        try firstNestedContainer.encode(self.first, forKey: .first)
+        
+        var secondNestedContainer = container.nestedContainer(keyedBy: SecondNestedCodingKeys.self, forKey: .top)
+        try secondNestedContainer.encode(self.second, forKey: .second)
+      }
+      
+      init(first: String, second: String) {
+        self.first = first
+        self.second = second
+      }
+      
+      static var testValue: Model {
+        return Model(first: "Johnny Appleseed",
+                     second: "appleseed@apple.com")
+      }
+      
+      enum TopLevelCodingKeys : String, CodingKey {
+        case top
+      }
+      
+      enum FirstNestedCodingKeys : String, CodingKey {
+        case first
+      }
+      enum SecondNestedCodingKeys : String, CodingKey {
+        case second
+      }
+    }
+    
+    let model = Model.testValue
+    if #available(OSX 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
+      let expectedJSON = "{\"top\":{\"first\":\"Johnny Appleseed\",\"second\":\"appleseed@apple.com\"}}".data(using: .utf8)!
+      _testRoundTrip(of: model, expectedJSON: expectedJSON, outputFormatting: [.sortedKeys])
+    } else {
+      _testRoundTrip(of: model)
+    }
+  }
+
+  #if false // FIXME: XCTest doesn't support crash tests yet rdar://20195010&22387653
+  func testEncodingConflictedTypeNestedContainersWithTheSameTopLevelKey() {
+    struct Model : Encodable, Equatable {
+      let first: String
+
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: TopLevelCodingKeys.self)
+        
+        var firstNestedContainer = container.nestedContainer(keyedBy: FirstNestedCodingKeys.self, forKey: .top)
+        try firstNestedContainer.encode(self.first, forKey: .first)
+        
+        // The following line would fail as it attempts to re-encode into already encoded container is invalid. This will always fail
+        var secondNestedContainer = container.nestedUnkeyedContainer(forKey: .top)
+        try secondNestedContainer.encode("second")
+      }
+      
+      init(first: String) {
+        self.first = first
+      }
+      
+      static var testValue: Model {
+        return Model(first: "Johnny Appleseed")
+      }
+      
+      enum TopLevelCodingKeys : String, CodingKey {
+        case top
+      }
+      enum FirstNestedCodingKeys : String, CodingKey {
+        case first
+      }
+    }
+    
+    let model = Model.testValue
+    // This following test would fail as it attempts to re-encode into already encoded container is invalid. This will always fail
+    expectCrashLater()
+    if #available(OSX 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
+      _testEncodeFailure(of: model)
+    } else {
+      _testEncodeFailure(of: model)
+    }
+  }
+  #endif
+  
+  // MARK: - Output Formatting Tests
+  func testEncodingOutputFormattingDefault() {
+    let expectedJSON = "{\"name\":\"Johnny Appleseed\",\"email\":\"appleseed@apple.com\"}".data(using: .utf8)!
+    let person = Person.testValue
+    _testRoundTrip(of: person, expectedJSON: expectedJSON)
+  }
+
+  func testEncodingOutputFormattingPrettyPrinted() {
+    let expectedJSON = "{\n  \"name\" : \"Johnny Appleseed\",\n  \"email\" : \"appleseed@apple.com\"\n}".data(using: .utf8)!
+    let person = Person.testValue
+    _testRoundTrip(of: person, expectedJSON: expectedJSON, outputFormatting: [.prettyPrinted])
+  }
+
+  func testEncodingOutputFormattingSortedKeys() {
+    if #available(OSX 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
+      let expectedJSON = "{\"email\":\"appleseed@apple.com\",\"name\":\"Johnny Appleseed\"}".data(using: .utf8)!
+      let person = Person.testValue
+      _testRoundTrip(of: person, expectedJSON: expectedJSON, outputFormatting: [.sortedKeys])
+    }
+  }
+
+  func testEncodingOutputFormattingPrettyPrintedSortedKeys() {
+    if #available(OSX 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
+      let expectedJSON = "{\n  \"email\" : \"appleseed@apple.com\",\n  \"name\" : \"Johnny Appleseed\"\n}".data(using: .utf8)!
+      let person = Person.testValue
+      _testRoundTrip(of: person, expectedJSON: expectedJSON, outputFormatting: [.prettyPrinted, .sortedKeys])
+    }
+  }
+
+  // MARK: - Date Strategy Tests
+
+  // Disabled for now till we resolve rdar://52618414
+  func x_testEncodingDate() {
+
+    func formattedLength(of value: Double) -> Int {
+      let empty = UnsafeMutablePointer<Int8>.allocate(capacity: 0)
+      defer { empty.deallocate() }
+      let length = snprintf(ptr: empty, 0, "%0.*g", DBL_DECIMAL_DIG, value)
+      return Int(length)
+    }
+
+    // Duplicated to handle a special case
+    func localTestRoundTrip<T: Codable & Equatable>(of value: T) {
+      var payload: Data! = nil
+      do {
+        let encoder = JSONEncoder()
+        payload = try encoder.encode(value)
+      } catch {
+        XCTFail("Failed to encode \(T.self) to JSON: \(error)")
+      }
+
+      do {
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(T.self, from: payload)
+
+        /// `snprintf`'s `%g`, which `JSONSerialization` uses internally for double values, does not respect 
+        /// our precision requests in every case. This bug effects Darwin, FreeBSD, and Linux currently
+        /// causing this test (which uses the current time) to fail occasionally.
+        if formattedLength(of: (decoded as! Date).timeIntervalSinceReferenceDate) > DBL_DECIMAL_DIG + 2 {
+          let adjustedTimeIntervalSinceReferenceDate: (Date) -> Double = { date in
+              let adjustment = pow(10, Double(DBL_DECIMAL_DIG))
+              return Double(floor(adjustment * date.timeIntervalSinceReferenceDate).rounded() / adjustment)
+          }
+          
+          let decodedAprox = adjustedTimeIntervalSinceReferenceDate(decoded as! Date)
+          let valueAprox = adjustedTimeIntervalSinceReferenceDate(value as! Date)
+          XCTAssertEqual(decodedAprox, valueAprox, "\(T.self) did not round-trip to an equal value after DBL_DECIMAL_DIG adjustment \(decodedAprox) != \(valueAprox).")
+          return
+        }
+
+        XCTAssertEqual(decoded, value, "\(T.self) did not round-trip to an equal value. \((decoded as! Date).timeIntervalSinceReferenceDate) != \((value as! Date).timeIntervalSinceReferenceDate)")
+      } catch {
+        XCTFail("Failed to decode \(T.self) from JSON: \(error)")
+      }
+    }
+
+    // Test the above `snprintf` edge case evaluation with a known triggering case
+    let knownBadDate = Date(timeIntervalSinceReferenceDate: 0.0021413276231263384)
+    localTestRoundTrip(of: knownBadDate)
+
+    localTestRoundTrip(of: Date())
+
+    // Optional dates should encode the same way.
+    localTestRoundTrip(of: Optional(Date()))
+  }
+
+  func testEncodingDateSecondsSince1970() {
+    // Cannot encode an arbitrary number of seconds since we've lost precision since 1970.
+    let seconds = 1000.0
+    let expectedJSON = "1000".data(using: .utf8)!
+
+    _testRoundTrip(of: Date(timeIntervalSince1970: seconds),
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .secondsSince1970,
+                   dateDecodingStrategy: .secondsSince1970)
+
+    // Optional dates should encode the same way.
+    _testRoundTrip(of: Optional(Date(timeIntervalSince1970: seconds)),
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .secondsSince1970,
+                   dateDecodingStrategy: .secondsSince1970)
+  }
+
+  func testEncodingDateMillisecondsSince1970() {
+    // Cannot encode an arbitrary number of seconds since we've lost precision since 1970.
+    let seconds = 1000.0
+    let expectedJSON = "1000000".data(using: .utf8)!
+
+    _testRoundTrip(of: Date(timeIntervalSince1970: seconds),
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .millisecondsSince1970,
+                   dateDecodingStrategy: .millisecondsSince1970)
+
+    // Optional dates should encode the same way.
+    _testRoundTrip(of: Optional(Date(timeIntervalSince1970: seconds)),
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .millisecondsSince1970,
+                   dateDecodingStrategy: .millisecondsSince1970)
+  }
+
+  func testEncodingDateISO8601() {
+    if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+      let formatter = ISO8601DateFormatter()
+      formatter.formatOptions = .withInternetDateTime
+
+      let timestamp = Date(timeIntervalSince1970: 1000)
+      let expectedJSON = "\"\(formatter.string(from: timestamp))\"".data(using: .utf8)!
+
+      _testRoundTrip(of: timestamp,
+                     expectedJSON: expectedJSON,
+                     dateEncodingStrategy: .iso8601,
+                     dateDecodingStrategy: .iso8601)
+
+
+      // Optional dates should encode the same way.
+      _testRoundTrip(of: Optional(timestamp),
+                     expectedJSON: expectedJSON,
+                     dateEncodingStrategy: .iso8601,
+                     dateDecodingStrategy: .iso8601)
+    }
+  }
+
+  func testEncodingDateFormatted() {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .full
+    formatter.timeStyle = .full
+
+    let timestamp = Date(timeIntervalSince1970: 1000)
+    let expectedJSON = "\"\(formatter.string(from: timestamp))\"".data(using: .utf8)!
+
+    _testRoundTrip(of: timestamp,
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .formatted(formatter),
+                   dateDecodingStrategy: .formatted(formatter))
+
+    // Optional dates should encode the same way.
+    _testRoundTrip(of: Optional(timestamp),
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .formatted(formatter),
+                   dateDecodingStrategy: .formatted(formatter))
+  }
+
+  func testEncodingDateCustom() {
+    let timestamp = Date()
+
+    // We'll encode a number instead of a date.
+    let encode = { (_ data: Date, _ encoder: Encoder) throws -> Void in
+      var container = encoder.singleValueContainer()
+      try container.encode(42)
+    }
+    let decode = { (_: Decoder) throws -> Date in return timestamp }
+
+    let expectedJSON = "42".data(using: .utf8)!
+    _testRoundTrip(of: timestamp,
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .custom(encode),
+                   dateDecodingStrategy: .custom(decode))
+
+    // Optional dates should encode the same way.
+    _testRoundTrip(of: Optional(timestamp),
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .custom(encode),
+                   dateDecodingStrategy: .custom(decode))
+  }
+
+  func testEncodingDateCustomEmpty() {
+    let timestamp = Date()
+
+    // Encoding nothing should encode an empty keyed container ({}).
+    let encode = { (_: Date, _: Encoder) throws -> Void in }
+    let decode = { (_: Decoder) throws -> Date in return timestamp }
+
+    let expectedJSON = "{}".data(using: .utf8)!
+    _testRoundTrip(of: timestamp,
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .custom(encode),
+                   dateDecodingStrategy: .custom(decode))
+
+    // Optional dates should encode the same way.
+    _testRoundTrip(of: Optional(timestamp),
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .custom(encode),
+                   dateDecodingStrategy: .custom(decode))
+  }
+
+  // MARK: - Data Strategy Tests
+  func testEncodingData() {
+    let data = Data(bytes: [0xDE, 0xAD, 0xBE, 0xEF])
+
+    let expectedJSON = "[222,173,190,239]".data(using: .utf8)!
+    _testRoundTrip(of: data,
+                   expectedJSON: expectedJSON,
+                   dataEncodingStrategy: .deferredToData,
+                   dataDecodingStrategy: .deferredToData)
+
+    // Optional data should encode the same way.
+    _testRoundTrip(of: Optional(data),
+                   expectedJSON: expectedJSON,
+                   dataEncodingStrategy: .deferredToData,
+                   dataDecodingStrategy: .deferredToData)
+  }
+
+  func testEncodingDataBase64() {
+    let data = Data(bytes: [0xDE, 0xAD, 0xBE, 0xEF])
+
+    let expectedJSON = "\"3q2+7w==\"".data(using: .utf8)!
+    _testRoundTrip(of: data, expectedJSON: expectedJSON)
+
+    // Optional data should encode the same way.
+    _testRoundTrip(of: Optional(data), expectedJSON: expectedJSON)
+  }
+
+  func testEncodingDataCustom() {
+    // We'll encode a number instead of data.
+    let encode = { (_ data: Data, _ encoder: Encoder) throws -> Void in
+      var container = encoder.singleValueContainer()
+      try container.encode(42)
+    }
+    let decode = { (_: Decoder) throws -> Data in return Data() }
+
+    let expectedJSON = "42".data(using: .utf8)!
+    _testRoundTrip(of: Data(),
+                   expectedJSON: expectedJSON,
+                   dataEncodingStrategy: .custom(encode),
+                   dataDecodingStrategy: .custom(decode))
+
+    // Optional data should encode the same way.
+    _testRoundTrip(of: Optional(Data()),
+                   expectedJSON: expectedJSON,
+                   dataEncodingStrategy: .custom(encode),
+                   dataDecodingStrategy: .custom(decode))
+  }
+
+  func testEncodingDataCustomEmpty() {
+    // Encoding nothing should encode an empty keyed container ({}).
+    let encode = { (_: Data, _: Encoder) throws -> Void in }
+    let decode = { (_: Decoder) throws -> Data in return Data() }
+
+    let expectedJSON = "{}".data(using: .utf8)!
+    _testRoundTrip(of: Data(),
+                   expectedJSON: expectedJSON,
+                   dataEncodingStrategy: .custom(encode),
+                   dataDecodingStrategy: .custom(decode))
+
+    // Optional Data should encode the same way.
+    _testRoundTrip(of: Optional(Data()),
+                   expectedJSON: expectedJSON,
+                   dataEncodingStrategy: .custom(encode),
+                   dataDecodingStrategy: .custom(decode))
+  }
+
+  // MARK: - Non-Conforming Floating Point Strategy Tests
+  func testEncodingNonConformingFloats() {
+    _testEncodeFailure(of: Float.infinity)
+    _testEncodeFailure(of: Float.infinity)
+    _testEncodeFailure(of: -Float.infinity)
+    _testEncodeFailure(of: Float.nan)
+
+    _testEncodeFailure(of: Double.infinity)
+    _testEncodeFailure(of: -Double.infinity)
+    _testEncodeFailure(of: Double.nan)
+
+    // Optional Floats/Doubles should encode the same way.
+    _testEncodeFailure(of: Float.infinity)
+    _testEncodeFailure(of: -Float.infinity)
+    _testEncodeFailure(of: Float.nan)
+
+    _testEncodeFailure(of: Double.infinity)
+    _testEncodeFailure(of: -Double.infinity)
+    _testEncodeFailure(of: Double.nan)
+  }
+
+  func testEncodingNonConformingFloatStrings() {
+    let encodingStrategy: JSONEncoder.NonConformingFloatEncodingStrategy = .convertToString(positiveInfinity: "INF", negativeInfinity: "-INF", nan: "NaN")
+    let decodingStrategy: JSONDecoder.NonConformingFloatDecodingStrategy = .convertFromString(positiveInfinity: "INF", negativeInfinity: "-INF", nan: "NaN")
+
+    _testRoundTrip(of: Float.infinity,
+                   expectedJSON: "\"INF\"".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+    _testRoundTrip(of: -Float.infinity,
+                   expectedJSON: "\"-INF\"".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+
+    // Since Float.nan != Float.nan, we have to use a placeholder that'll encode NaN but actually round-trip.
+    _testRoundTrip(of: FloatNaNPlaceholder(),
+                   expectedJSON: "\"NaN\"".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+
+    _testRoundTrip(of: Double.infinity,
+                   expectedJSON: "\"INF\"".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+    _testRoundTrip(of: -Double.infinity,
+                   expectedJSON: "\"-INF\"".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+
+    // Since Double.nan != Double.nan, we have to use a placeholder that'll encode NaN but actually round-trip.
+    _testRoundTrip(of: DoubleNaNPlaceholder(),
+                   expectedJSON: "\"NaN\"".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+
+    // Optional Floats and Doubles should encode the same way.
+    _testRoundTrip(of: Optional(Float.infinity),
+                   expectedJSON: "\"INF\"".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+    _testRoundTrip(of: Optional(-Float.infinity),
+                   expectedJSON: "\"-INF\"".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+    _testRoundTrip(of: Optional(Double.infinity),
+                   expectedJSON: "\"INF\"".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+    _testRoundTrip(of: Optional(-Double.infinity),
+                   expectedJSON: "\"-INF\"".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+  }
+
+  // MARK: - Key Strategy Tests
+  private struct EncodeMe : Encodable {
+    var keyName: String
+    func encode(to coder: Encoder) throws {
+      var c = coder.container(keyedBy: _TestKey.self)
+      try c.encode("test", forKey: _TestKey(stringValue: keyName)!)
+    }
+  }
+
+  func testEncodingKeyStrategySnake() {
+    let toSnakeCaseTests = [
+      ("simpleOneTwo", "simple_one_two"),
+      ("myURL", "my_url"),
+      ("singleCharacterAtEndX", "single_character_at_end_x"),
+      ("thisIsAnXMLProperty", "this_is_an_xml_property"),
+      ("single", "single"), // no underscore
+      ("", ""), // don't die on empty string
+      ("a", "a"), // single character
+      ("aA", "a_a"), // two characters
+      ("version4Thing", "version4_thing"), // numerics
+      ("partCAPS", "part_caps"), // only insert underscore before first all caps
+      ("partCAPSLowerAGAIN", "part_caps_lower_again"), // switch back and forth caps.
+      ("manyWordsInThisThing", "many_words_in_this_thing"), // simple lowercase + underscore + more
+      ("asdfĆqer", "asdf_ćqer"),
+      ("already_snake_case", "already_snake_case"),
+      ("dataPoint22", "data_point22"),
+      ("dataPoint22Word", "data_point22_word"),
+      ("_oneTwoThree", "_one_two_three"),
+      ("oneTwoThree_", "one_two_three_"),
+      ("__oneTwoThree", "__one_two_three"),
+      ("oneTwoThree__", "one_two_three__"),
+      ("_oneTwoThree_", "_one_two_three_"),
+      ("__oneTwoThree", "__one_two_three"),
+      ("__oneTwoThree__", "__one_two_three__"),
+      ("_test", "_test"),
+      ("_test_", "_test_"),
+      ("__test", "__test"),
+      ("test__", "test__"),
+      ("m͉̟̹y̦̳G͍͚͎̳r̤͉̤͕ͅea̲͕t͇̥̼͖U͇̝̠R͙̻̥͓̣L̥̖͎͓̪̫ͅR̩͖̩eq͈͓u̞e̱s̙t̤̺ͅ", "m͉̟̹y̦̳_g͍͚͎̳r̤͉̤͕ͅea̲͕t͇̥̼͖_u͇̝̠r͙̻̥͓̣l̥̖͎͓̪̫ͅ_r̩͖̩eq͈͓u̞e̱s̙t̤̺ͅ"), // because Itai wanted to test this
+      ("🐧🐟", "🐧🐟") // fishy emoji example?
+    ]
+
+    for test in toSnakeCaseTests {
+      let expected = "{\"\(test.1)\":\"test\"}"
+      let encoded = EncodeMe(keyName: test.0)
+      
+      let encoder = JSONEncoder()
+      encoder.keyEncodingStrategy = .convertToSnakeCase
+      let resultData = try! encoder.encode(encoded)
+      let resultString = String(bytes: resultData, encoding: .utf8)
+      
+      XCTAssertEqual(expected, resultString)
+    }
+  }
+  
+  func testEncodingKeyStrategyCustom() {
+    let expected = "{\"QQQhello\":\"test\"}"
+    let encoded = EncodeMe(keyName: "hello")
+    
+    let encoder = JSONEncoder()
+    let customKeyConversion = { (_ path : [CodingKey]) -> CodingKey in
+      let key = _TestKey(stringValue: "QQQ" + path.last!.stringValue)!
+      return key
+    }
+    encoder.keyEncodingStrategy = .custom(customKeyConversion)
+    let resultData = try! encoder.encode(encoded)
+    let resultString = String(bytes: resultData, encoding: .utf8)
+    
+    XCTAssertEqual(expected, resultString)
+  }
+
+  func testEncodingDictionaryStringKeyConversionUntouched() {
+    let expected = "{\"leaveMeAlone\":\"test\"}"
+    let toEncode: [String: String] = ["leaveMeAlone": "test"]
+
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    let resultData = try! encoder.encode(toEncode)
+    let resultString = String(bytes: resultData, encoding: .utf8)
+
+    XCTAssertEqual(expected, resultString)
+  }
+
+  private struct EncodeFailure : Encodable {
+    var someValue: Double
+  }
+
+  private struct EncodeFailureNested : Encodable {
+    var nestedValue: EncodeFailure
+  }
+
+  func testEncodingDictionaryFailureKeyPath() {
+    let toEncode: [String: EncodeFailure] = ["key": EncodeFailure(someValue: Double.nan)]
+
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    do {
+      _ = try encoder.encode(toEncode)
+    } catch EncodingError.invalidValue(_, let context) {
+      XCTAssertEqual(2, context.codingPath.count)
+      XCTAssertEqual("key", context.codingPath[0].stringValue)
+      XCTAssertEqual("someValue", context.codingPath[1].stringValue)
+    } catch {
+      XCTFail("Unexpected error: \(String(describing: error))")
+    }
+  }
+
+  func testEncodingDictionaryFailureKeyPathNested() {
+    let toEncode: [String: [String: EncodeFailureNested]] = ["key": ["sub_key": EncodeFailureNested(nestedValue: EncodeFailure(someValue: Double.nan))]]
+
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    do {
+      _ = try encoder.encode(toEncode)
+    } catch EncodingError.invalidValue(_, let context) {
+      XCTAssertEqual(4, context.codingPath.count)
+      XCTAssertEqual("key", context.codingPath[0].stringValue)
+      XCTAssertEqual("sub_key", context.codingPath[1].stringValue)
+      XCTAssertEqual("nestedValue", context.codingPath[2].stringValue)
+      XCTAssertEqual("someValue", context.codingPath[3].stringValue)
+    } catch {
+      XCTFail("Unexpected error: \(String(describing: error))")
+    }
+  }
+
+  private struct EncodeNested : Encodable {
+    let nestedValue: EncodeMe
+  }
+  
+  private struct EncodeNestedNested : Encodable {
+    let outerValue: EncodeNested
+  }
+  
+  func testEncodingKeyStrategyPath() {
+    // Make sure a more complex path shows up the way we want
+    // Make sure the path reflects keys in the Swift, not the resulting ones in the JSON
+    let expected = "{\"QQQouterValue\":{\"QQQnestedValue\":{\"QQQhelloWorld\":\"test\"}}}"
+    let encoded = EncodeNestedNested(outerValue: EncodeNested(nestedValue: EncodeMe(keyName: "helloWorld")))
+    
+    let encoder = JSONEncoder()
+    var callCount = 0
+    
+    let customKeyConversion = { (_ path : [CodingKey]) -> CodingKey in
+      // This should be called three times:
+      // 1. to convert 'outerValue' to something
+      // 2. to convert 'nestedValue' to something
+      // 3. to convert 'helloWorld' to something
+      callCount = callCount + 1
+      
+      if path.count == 0 {
+        XCTFail("The path should always have at least one entry")
+      } else if path.count == 1 {
+        XCTAssertEqual(["outerValue"], path.map { $0.stringValue })
+      } else if path.count == 2 {
+        XCTAssertEqual(["outerValue", "nestedValue"], path.map { $0.stringValue })
+      } else if path.count == 3 {
+        XCTAssertEqual(["outerValue", "nestedValue", "helloWorld"], path.map { $0.stringValue })
+      } else {
+        XCTFail("The path mysteriously had more entries")
+      }
+      
+      let key = _TestKey(stringValue: "QQQ" + path.last!.stringValue)!
+      return key
+    }
+    encoder.keyEncodingStrategy = .custom(customKeyConversion)
+    let resultData = try! encoder.encode(encoded)
+    let resultString = String(bytes: resultData, encoding: .utf8)
+    
+    XCTAssertEqual(expected, resultString)
+    XCTAssertEqual(3, callCount)
+  }
+  
+  private struct DecodeMe : Decodable {
+    let found: Bool
+    init(from coder: Decoder) throws {
+      let c = try coder.container(keyedBy: _TestKey.self)
+      // Get the key that we expect to be passed in (camel case)
+      let camelCaseKey = try c.decode(String.self, forKey: _TestKey(stringValue: "camelCaseKey")!)
+        
+      // Use the camel case key to decode from the JSON. The decoder should convert it to snake case to find it.
+      found = try c.decode(Bool.self, forKey: _TestKey(stringValue: camelCaseKey)!)
+    }
+  }
+
+  func testDecodingKeyStrategyCamel() {
+    let fromSnakeCaseTests = [
+      ("", ""), // don't die on empty string
+      ("a", "a"), // single character
+      ("ALLCAPS", "ALLCAPS"), // If no underscores, we leave the word as-is
+      ("ALL_CAPS", "allCaps"), // Conversion from screaming snake case
+      ("single", "single"), // do not capitalize anything with no underscore
+      ("snake_case", "snakeCase"), // capitalize a character
+      ("one_two_three", "oneTwoThree"), // more than one word
+      ("one_2_three", "one2Three"), // numerics
+      ("one2_three", "one2Three"), // numerics, part 2
+      ("snake_Ćase", "snakeĆase"), // do not further modify a capitalized diacritic
+      ("snake_ćase", "snakeĆase"), // capitalize a diacritic
+      ("alreadyCamelCase", "alreadyCamelCase"), // do not modify already camel case
+      ("__this_and_that", "__thisAndThat"),
+      ("_this_and_that", "_thisAndThat"),
+      ("this__and__that", "thisAndThat"),
+      ("this_and_that__", "thisAndThat__"),
+      ("this_aNd_that", "thisAndThat"),
+      ("_one_two_three", "_oneTwoThree"),
+      ("one_two_three_", "oneTwoThree_"),
+      ("__one_two_three", "__oneTwoThree"),
+      ("one_two_three__", "oneTwoThree__"),
+      ("_one_two_three_", "_oneTwoThree_"),
+      ("__one_two_three", "__oneTwoThree"),
+      ("__one_two_three__", "__oneTwoThree__"),
+      ("_test", "_test"),
+      ("_test_", "_test_"),
+      ("__test", "__test"),
+      ("test__", "test__"),
+      ("_", "_"),
+      ("__", "__"),
+      ("___", "___"),
+      ("m͉̟̹y̦̳G͍͚͎̳r̤͉̤͕ͅea̲͕t͇̥̼͖U͇̝̠R͙̻̥͓̣L̥̖͎͓̪̫ͅR̩͖̩eq͈͓u̞e̱s̙t̤̺ͅ", "m͉̟̹y̦̳G͍͚͎̳r̤͉̤͕ͅea̲͕t͇̥̼͖U͇̝̠R͙̻̥͓̣L̥̖͎͓̪̫ͅR̩͖̩eq͈͓u̞e̱s̙t̤̺ͅ"), // because Itai wanted to test this
+      ("🐧_🐟", "🐧🐟") // fishy emoji example?
+    ]
+    
+    for test in fromSnakeCaseTests {
+      // This JSON contains the camel case key that the test object should decode with, then it uses the snake case key (test.0) as the actual key for the boolean value.
+      let input = "{\"camelCaseKey\":\"\(test.1)\",\"\(test.0)\":true}".data(using: .utf8)!
+      
+      let decoder = JSONDecoder()
+      decoder.keyDecodingStrategy = .convertFromSnakeCase
+      
+      let result = try! decoder.decode(DecodeMe.self, from: input)
+      
+      XCTAssertTrue(result.found)
+    }
+  }
+  
+  private struct DecodeMe2 : Decodable { var hello: String }
+  
+  func testDecodingKeyStrategyCustom() {
+    let input = "{\"----hello\":\"test\"}".data(using: .utf8)!
+    let decoder = JSONDecoder()
+    let customKeyConversion = { (_ path: [CodingKey]) -> CodingKey in
+      // This converter removes the first 4 characters from the start of all string keys, if it has more than 4 characters
+      let string = path.last!.stringValue
+      guard string.count > 4 else { return path.last! }
+      let newString = String(string.dropFirst(4))
+      return _TestKey(stringValue: newString)!
+    }
+    decoder.keyDecodingStrategy = .custom(customKeyConversion)
+    let result = try! decoder.decode(DecodeMe2.self, from: input)
+    
+    XCTAssertEqual("test", result.hello)
+  }
+
+  func testDecodingDictionaryStringKeyConversionUntouched() {
+    let input = "{\"leave_me_alone\":\"test\"}".data(using: .utf8)!
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    let result = try! decoder.decode([String: String].self, from: input)
+
+    XCTAssertEqual(["leave_me_alone": "test"], result)
+  }
+
+  func testDecodingDictionaryFailureKeyPath() {
+    let input = "{\"leave_me_alone\":\"test\"}".data(using: .utf8)!
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    do {
+      _ = try decoder.decode([String: Int].self, from: input)
+    } catch DecodingError.typeMismatch(_, let context) {
+      XCTAssertEqual(1, context.codingPath.count)
+      XCTAssertEqual("leave_me_alone", context.codingPath[0].stringValue)
+    } catch {
+      XCTFail("Unexpected error: \(String(describing: error))")
+    }
+  }
+
+  private struct DecodeFailure : Decodable {
+    var intValue: Int
+  }
+
+  private struct DecodeFailureNested : Decodable {
+    var nestedValue: DecodeFailure
+  }
+
+  func testDecodingDictionaryFailureKeyPathNested() {
+    let input = "{\"top_level\": {\"sub_level\": {\"nested_value\": {\"int_value\": \"not_an_int\"}}}}".data(using: .utf8)!
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    do {
+      _ = try decoder.decode([String: [String : DecodeFailureNested]].self, from: input)
+    } catch DecodingError.typeMismatch(_, let context) {
+      XCTAssertEqual(4, context.codingPath.count)
+      XCTAssertEqual("top_level", context.codingPath[0].stringValue)
+      XCTAssertEqual("sub_level", context.codingPath[1].stringValue)
+      XCTAssertEqual("nestedValue", context.codingPath[2].stringValue)
+      XCTAssertEqual("intValue", context.codingPath[3].stringValue)
+    } catch {
+      XCTFail("Unexpected error: \(String(describing: error))")
+    }
+  }
+  
+  private struct DecodeMe3 : Codable {
+      var thisIsCamelCase : String
+  }
+    
+  func testEncodingKeyStrategySnakeGenerated() {
+    // Test that this works with a struct that has automatically generated keys
+    let input = "{\"this_is_camel_case\":\"test\"}".data(using: .utf8)!
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    let result = try! decoder.decode(DecodeMe3.self, from: input)
+    
+    XCTAssertEqual("test", result.thisIsCamelCase)
+  }
+    
+  func testDecodingKeyStrategyCamelGenerated() {
+    let encoded = DecodeMe3(thisIsCamelCase: "test")
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    let resultData = try! encoder.encode(encoded)
+    let resultString = String(bytes: resultData, encoding: .utf8)
+    XCTAssertEqual("{\"this_is_camel_case\":\"test\"}", resultString)
+  }
+    
+  func testKeyStrategySnakeGeneratedAndCustom() {
+    // Test that this works with a struct that has automatically generated keys
+    struct DecodeMe4 : Codable {
+        var thisIsCamelCase : String
+        var thisIsCamelCaseToo : String
+        private enum CodingKeys : String, CodingKey {
+            case thisIsCamelCase = "fooBar"
+            case thisIsCamelCaseToo
+        }
+    }
+
+    // Decoding
+    let input = "{\"foo_bar\":\"test\",\"this_is_camel_case_too\":\"test2\"}".data(using: .utf8)!
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    let decodingResult = try! decoder.decode(DecodeMe4.self, from: input)
+    
+    XCTAssertEqual("test", decodingResult.thisIsCamelCase)
+    XCTAssertEqual("test2", decodingResult.thisIsCamelCaseToo)
+    
+    // Encoding
+    let encoded = DecodeMe4(thisIsCamelCase: "test", thisIsCamelCaseToo: "test2")
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    let encodingResultData = try! encoder.encode(encoded)
+    let encodingResultString = String(bytes: encodingResultData, encoding: .utf8)
+    XCTAssertEqual("{\"foo_bar\":\"test\",\"this_is_camel_case_too\":\"test2\"}", encodingResultString)
+  }
+
+  func testKeyStrategyDuplicateKeys() {
+    // This test is mostly to make sure we don't assert on duplicate keys
+    struct DecodeMe5 : Codable {
+        var oneTwo : String
+        var numberOfKeys : Int
+        
+        enum CodingKeys : String, CodingKey {
+          case oneTwo
+          case oneTwoThree
+        }
+        
+        init() {
+            oneTwo = "test"
+            numberOfKeys = 0
+        }
+        
+        init(from decoder: Decoder) throws {
+          let container = try decoder.container(keyedBy: CodingKeys.self)
+          oneTwo = try container.decode(String.self, forKey: .oneTwo)
+          numberOfKeys = container.allKeys.count
+        }
+        
+        func encode(to encoder: Encoder) throws {
+          var container = encoder.container(keyedBy: CodingKeys.self)
+          try container.encode(oneTwo, forKey: .oneTwo)
+          try container.encode("test2", forKey: .oneTwoThree)
+        }
+    }
+
+    let customKeyConversion = { (_ path: [CodingKey]) -> CodingKey in
+      // All keys are the same!
+      return _TestKey(stringValue: "oneTwo")!
+    }
+    
+    // Decoding
+    // This input has a dictionary with two keys, but only one will end up in the container
+    let input = "{\"unused key 1\":\"test1\",\"unused key 2\":\"test2\"}".data(using: .utf8)!
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .custom(customKeyConversion)
+
+    let decodingResult = try! decoder.decode(DecodeMe5.self, from: input)
+    // There will be only one result for oneTwo (the second one in the json)
+    XCTAssertEqual(1, decodingResult.numberOfKeys)
+    
+    // Encoding
+    let encoded = DecodeMe5()
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .custom(customKeyConversion)
+    let decodingResultData = try! encoder.encode(encoded)
+    let decodingResultString = String(bytes: decodingResultData, encoding: .utf8)
+    
+    // There will be only one value in the result (the second one encoded)
+    XCTAssertEqual("{\"oneTwo\":\"test2\"}", decodingResultString)
+  }
+
+  // MARK: - Encoder Features
+  func testNestedContainerCodingPaths() {
+    let encoder = JSONEncoder()
+    do {
+      let _ = try encoder.encode(NestedContainersTestType())
+    } catch let error as NSError {
+      XCTFail("Caught error during encoding nested container types: \(error)")
+    }
+  }
+
+  func testSuperEncoderCodingPaths() {
+    let encoder = JSONEncoder()
+    do {
+      let _ = try encoder.encode(NestedContainersTestType(testSuperEncoder: true))
+    } catch let error as NSError {
+      XCTFail("Caught error during encoding nested container types: \(error)")
+    }
+  }
+
+  func testInterceptDecimal() {
+    let expectedJSON = "10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".data(using: .utf8)!
+
+    // Want to make sure we write out a JSON number, not the keyed encoding here.
+    // 1e127 is too big to fit natively in a Double, too, so want to make sure it's encoded as a Decimal.
+    let decimal = Decimal(sign: .plus, exponent: 127, significand: Decimal(1))
+    _testRoundTrip(of: decimal, expectedJSON: expectedJSON)
+
+    // Optional Decimals should encode the same way.
+    _testRoundTrip(of: Optional(decimal), expectedJSON: expectedJSON)
+  }
+
+  func testInterceptURL() {
+    // Want to make sure JSONEncoder writes out single-value URLs, not the keyed encoding.
+    let expectedJSON = "\"http:\\/\\/swift.org\"".data(using: .utf8)!
+    let url = URL(string: "http://swift.org")!
+    _testRoundTrip(of: url, expectedJSON: expectedJSON)
+
+    // Optional URLs should encode the same way.
+    _testRoundTrip(of: Optional(url), expectedJSON: expectedJSON)
+  }
+
+  func testInterceptURLWithoutEscapingOption() {
+    if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+      // Want to make sure JSONEncoder writes out single-value URLs, not the keyed encoding.
+      let expectedJSON = "\"http://swift.org\"".data(using: .utf8)!
+      let url = URL(string: "http://swift.org")!
+      _testRoundTrip(of: url, expectedJSON: expectedJSON, outputFormatting: [.withoutEscapingSlashes])
+
+      // Optional URLs should encode the same way.
+      _testRoundTrip(of: Optional(url), expectedJSON: expectedJSON, outputFormatting: [.withoutEscapingSlashes])
+    }
+  }
+    
+  // MARK: - Type coercion
+  func testTypeCoercion() {
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int8].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int16].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int32].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int64].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt8].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt16].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt32].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt64].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [Float].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [Double].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int8], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int16], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int32], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int64], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt8], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt16], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt32], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt64], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0.0, 1.0] as [Float], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0.0, 1.0] as [Double], as: [Bool].self)
+  }
+
+  func testDecodingConcreteTypeParameter() {
+      let encoder = JSONEncoder()
+      guard let json = try? encoder.encode(Employee.testValue) else {
+          XCTFail("Unable to encode Employee.")
+          return
+      }
+
+      let decoder = JSONDecoder()
+      guard let decoded = try? decoder.decode(Employee.self as Person.Type, from: json) else {
+          XCTFail("Failed to decode Employee as Person from JSON.")
+          return
+      }
+
+      expectEqual(type(of: decoded), Employee.self, "Expected decoded value to be of type Employee; got \(type(of: decoded)) instead.")
+  }
+
+  // MARK: - Encoder State
+  // SR-6078
+  func testEncoderStateThrowOnEncode() {
+    struct ReferencingEncoderWrapper<T : Encodable> : Encodable {
+      let value: T
+      init(_ value: T) { self.value = value }
+
+      func encode(to encoder: Encoder) throws {
+        // This approximates a subclass calling into its superclass, where the superclass encodes a value that might throw.
+        // The key here is that getting the superEncoder creates a referencing encoder.
+        var container = encoder.unkeyedContainer()
+        let superEncoder = container.superEncoder()
+
+        // Pushing a nested container on leaves the referencing encoder with multiple containers.
+        var nestedContainer = superEncoder.unkeyedContainer()
+        try nestedContainer.encode(value)
+      }
+    }
+
+    // The structure that would be encoded here looks like
+    //
+    //   [[[Float.infinity]]]
+    //
+    // The wrapper asks for an unkeyed container ([^]), gets a super encoder, and creates a nested container into that ([[^]]).
+    // We then encode an array into that ([[[^]]]), which happens to be a value that causes us to throw an error.
+    //
+    // The issue at hand reproduces when you have a referencing encoder (superEncoder() creates one) that has a container on the stack (unkeyedContainer() adds one) that encodes a value going through box_() (Array does that) that encodes something which throws (Float.infinity does that).
+    // When reproducing, this will cause a test failure via fatalError().
+    _ = try? JSONEncoder().encode(ReferencingEncoderWrapper([Float.infinity]))
+  }
+
+  func testEncoderStateThrowOnEncodeCustomDate() {
+    // This test is identical to testEncoderStateThrowOnEncode, except throwing via a custom Date closure.
+    struct ReferencingEncoderWrapper<T : Encodable> : Encodable {
+      let value: T
+      init(_ value: T) { self.value = value }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        let superEncoder = container.superEncoder()
+        var nestedContainer = superEncoder.unkeyedContainer()
+        try nestedContainer.encode(value)
+      }
+    }
+
+    // The closure needs to push a container before throwing an error to trigger.
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .custom({ _, encoder in
+      let _ = encoder.unkeyedContainer()
+      enum CustomError : Error { case foo }
+      throw CustomError.foo
+    })
+
+    _ = try? encoder.encode(ReferencingEncoderWrapper(Date()))
+  }
+
+  func testEncoderStateThrowOnEncodeCustomData() {
+    // This test is identical to testEncoderStateThrowOnEncode, except throwing via a custom Data closure.
+    struct ReferencingEncoderWrapper<T : Encodable> : Encodable {
+      let value: T
+      init(_ value: T) { self.value = value }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        let superEncoder = container.superEncoder()
+        var nestedContainer = superEncoder.unkeyedContainer()
+        try nestedContainer.encode(value)
+      }
+    }
+
+    // The closure needs to push a container before throwing an error to trigger.
+    let encoder = JSONEncoder()
+    encoder.dataEncodingStrategy = .custom({ _, encoder in
+      let _ = encoder.unkeyedContainer()
+      enum CustomError : Error { case foo }
+      throw CustomError.foo
+    })
+
+    _ = try? encoder.encode(ReferencingEncoderWrapper(Data()))
+  }
+
+  // MARK: - Decoder State
+  // SR-6048
+  func testDecoderStateThrowOnDecode() {
+    // The container stack here starts as [[1,2,3]]. Attempting to decode as [String] matches the outer layer (Array), and begins decoding the array.
+    // Once Array decoding begins, 1 is pushed onto the container stack ([[1,2,3], 1]), and 1 is attempted to be decoded as String. This throws a .typeMismatch, but the container is not popped off the stack.
+    // When attempting to decode [Int], the container stack is still ([[1,2,3], 1]), and 1 fails to decode as [Int].
+    let json = "[1,2,3]".data(using: .utf8)!
+    let _ = try! JSONDecoder().decode(EitherDecodable<[String], [Int]>.self, from: json)
+  }
+
+  func testDecoderStateThrowOnDecodeCustomDate() {
+    // This test is identical to testDecoderStateThrowOnDecode, except we're going to fail because our closure throws an error, not because we hit a type mismatch.
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .custom({ decoder in
+      enum CustomError : Error { case foo }
+      throw CustomError.foo
+    })
+
+    let json = "1".data(using: .utf8)!
+    let _ = try! decoder.decode(EitherDecodable<Date, Int>.self, from: json)
+  }
+
+  func testDecoderStateThrowOnDecodeCustomData() {
+    // This test is identical to testDecoderStateThrowOnDecode, except we're going to fail because our closure throws an error, not because we hit a type mismatch.
+    let decoder = JSONDecoder()
+    decoder.dataDecodingStrategy = .custom({ decoder in
+      enum CustomError : Error { case foo }
+      throw CustomError.foo
+    })
+
+    let json = "1".data(using: .utf8)!
+    let _ = try! decoder.decode(EitherDecodable<Data, Int>.self, from: json)
+  }
+
+  // MARK: - Helper Functions
+  private var _jsonEmptyDictionary: Data {
+    return "{}".data(using: .utf8)!
+  }
+
+  private func _testEncodeFailure<T : Encodable>(of value: T) {
+    do {
+      let _ = try JSONEncoder().encode(value)
+      XCTFail("Encode of top-level \(T.self) was expected to fail.")
+    } catch {}
+  }
+
+  private func _testRoundTrip<T>(of value: T,
+                                 expectedJSON json: Data? = nil,
+                                 outputFormatting: JSONEncoder.OutputFormatting = [],
+                                 dateEncodingStrategy: JSONEncoder.DateEncodingStrategy = .deferredToDate,
+                                 dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .deferredToDate,
+                                 dataEncodingStrategy: JSONEncoder.DataEncodingStrategy = .base64,
+                                 dataDecodingStrategy: JSONDecoder.DataDecodingStrategy = .base64,
+                                 keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy = .useDefaultKeys,
+                                 keyDecodingStrategy: JSONDecoder.KeyDecodingStrategy = .useDefaultKeys,
+                                 nonConformingFloatEncodingStrategy: JSONEncoder.NonConformingFloatEncodingStrategy = .throw,
+                                 nonConformingFloatDecodingStrategy: JSONDecoder.NonConformingFloatDecodingStrategy = .throw) where T : Codable, T : Equatable {
+    var payload: Data! = nil
+    do {
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = outputFormatting
+      encoder.dateEncodingStrategy = dateEncodingStrategy
+      encoder.dataEncodingStrategy = dataEncodingStrategy
+      encoder.nonConformingFloatEncodingStrategy = nonConformingFloatEncodingStrategy
+      encoder.keyEncodingStrategy = keyEncodingStrategy
+      payload = try encoder.encode(value)
+    } catch {
+      XCTFail("Failed to encode \(T.self) to JSON: \(error)")
+    }
+
+    if let expectedJSON = json {
+        XCTAssertEqual(expectedJSON, payload, "Produced JSON not identical to expected JSON.")
+    }
+
+    do {
+      let decoder = JSONDecoder()
+      decoder.dateDecodingStrategy = dateDecodingStrategy
+      decoder.dataDecodingStrategy = dataDecodingStrategy
+      decoder.nonConformingFloatDecodingStrategy = nonConformingFloatDecodingStrategy
+      decoder.keyDecodingStrategy = keyDecodingStrategy
+      let decoded = try decoder.decode(T.self, from: payload)
+      XCTAssertEqual(decoded, value, "\(T.self) did not round-trip to an equal value.")
+    } catch {
+      XCTFail("Failed to decode \(T.self) from JSON: \(error)")
+    }
+  }
+
+    private func _testRoundTripTypeCoercionFailure<T,U>(of value: T, as type: U.Type) where T : Codable, U : Codable {
+        do {
+            let data = try JSONEncoder().encode(value)
+            let _ = try JSONDecoder().decode(U.self, from: data)
+            XCTFail("Coercion from \(T.self) to \(U.self) was expected to fail.")
+        } catch {}
+    }
+}
+
+// MARK: - Helper Global Functions
+func expectEqualPaths(_ lhs: [CodingKey], _ rhs: [CodingKey], _ prefix: String) {
+  if lhs.count != rhs.count {
+    XCTFail("\(prefix) [CodingKey].count mismatch: \(lhs.count) != \(rhs.count)")
+    return
+  }
+
+  for (key1, key2) in zip(lhs, rhs) {
+    switch (key1.intValue, key2.intValue) {
+    case (.none, .none): break
+    case (.some(let i1), .none):
+      XCTFail("\(prefix) CodingKey.intValue mismatch: \(type(of: key1))(\(i1)) != nil")
+      return
+    case (.none, .some(let i2)):
+      XCTFail("\(prefix) CodingKey.intValue mismatch: nil != \(type(of: key2))(\(i2))")
+      return
+    case (.some(let i1), .some(let i2)):
+        guard i1 == i2 else {
+            XCTFail("\(prefix) CodingKey.intValue mismatch: \(type(of: key1))(\(i1)) != \(type(of: key2))(\(i2))")
+            return
+        }
+    }
+
+    XCTAssertEqual(key1.stringValue, key2.stringValue, "\(prefix) CodingKey.stringValue mismatch: \(type(of: key1))('\(key1.stringValue)') != \(type(of: key2))('\(key2.stringValue)')")
+  }
+}
+
+// MARK: - Test Types
+/* FIXME: Import from %S/Inputs/Coding/SharedTypes.swift somehow. */
+
+// MARK: - Empty Types
+fileprivate struct EmptyStruct : Codable, Equatable {
+  static func ==(_ lhs: EmptyStruct, _ rhs: EmptyStruct) -> Bool {
+    return true
+  }
+}
+
+fileprivate class EmptyClass : Codable, Equatable {
+  static func ==(_ lhs: EmptyClass, _ rhs: EmptyClass) -> Bool {
+    return true
+  }
+}
+
+// MARK: - Single-Value Types
+/// A simple on-off switch type that encodes as a single Bool value.
+fileprivate enum Switch : Codable {
+  case off
+  case on
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    switch try container.decode(Bool.self) {
+    case false: self = .off
+    case true:  self = .on
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .off: try container.encode(false)
+    case .on:  try container.encode(true)
+    }
+  }
+}
+
+/// A simple timestamp type that encodes as a single Double value.
+fileprivate struct Timestamp : Codable, Equatable {
+  let value: Double
+
+  init(_ value: Double) {
+    self.value = value
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    value = try container.decode(Double.self)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(self.value)
+  }
+
+  static func ==(_ lhs: Timestamp, _ rhs: Timestamp) -> Bool {
+    return lhs.value == rhs.value
+  }
+}
+
+/// A simple referential counter type that encodes as a single Int value.
+fileprivate final class Counter : Codable, Equatable {
+  var count: Int = 0
+
+  init() {}
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    count = try container.decode(Int.self)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(self.count)
+  }
+
+  static func ==(_ lhs: Counter, _ rhs: Counter) -> Bool {
+    return lhs === rhs || lhs.count == rhs.count
+  }
+}
+
+// MARK: - Structured Types
+/// A simple address type that encodes as a dictionary of values.
+fileprivate struct Address : Codable, Equatable {
+  let street: String
+  let city: String
+  let state: String
+  let zipCode: Int
+  let country: String
+
+  init(street: String, city: String, state: String, zipCode: Int, country: String) {
+    self.street = street
+    self.city = city
+    self.state = state
+    self.zipCode = zipCode
+    self.country = country
+  }
+
+  static func ==(_ lhs: Address, _ rhs: Address) -> Bool {
+    return lhs.street == rhs.street &&
+           lhs.city == rhs.city &&
+           lhs.state == rhs.state &&
+           lhs.zipCode == rhs.zipCode &&
+           lhs.country == rhs.country
+  }
+
+  static var testValue: Address {
+    return Address(street: "1 Infinite Loop",
+                   city: "Cupertino",
+                   state: "CA",
+                   zipCode: 95014,
+                   country: "United States")
+  }
+}
+
+/// A simple person class that encodes as a dictionary of values.
+fileprivate class Person : Codable, Equatable {
+  let name: String
+  let email: String
+  let website: URL?
+
+  init(name: String, email: String, website: URL? = nil) {
+    self.name = name
+    self.email = email
+    self.website = website
+  }
+
+  func isEqual(_ other: Person) -> Bool {
+    return self.name == other.name &&
+           self.email == other.email &&
+           self.website == other.website
+  }
+
+  static func ==(_ lhs: Person, _ rhs: Person) -> Bool {
+    return lhs.isEqual(rhs)
+  }
+
+  class var testValue: Person {
+    return Person(name: "Johnny Appleseed", email: "appleseed@apple.com")
+  }
+}
+
+/// A class which shares its encoder and decoder with its superclass.
+fileprivate class Employee : Person {
+  let id: Int
+
+  init(name: String, email: String, website: URL? = nil, id: Int) {
+    self.id = id
+    super.init(name: name, email: email, website: website)
+  }
+
+  enum CodingKeys : String, CodingKey {
+    case id
+  }
+
+  required init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(Int.self, forKey: .id)
+    try super.init(from: decoder)
+  }
+
+  override func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(id, forKey: .id)
+    try super.encode(to: encoder)
+  }
+
+  override func isEqual(_ other: Person) -> Bool {
+    if let employee = other as? Employee {
+      guard self.id == employee.id else { return false }
+    }
+
+    return super.isEqual(other)
+  }
+
+  override class var testValue: Employee {
+    return Employee(name: "Johnny Appleseed", email: "appleseed@apple.com", id: 42)
+  }
+}
+
+/// A simple company struct which encodes as a dictionary of nested values.
+fileprivate struct Company : Codable, Equatable {
+  let address: Address
+  var employees: [Employee]
+
+  init(address: Address, employees: [Employee]) {
+    self.address = address
+    self.employees = employees
+  }
+
+  static func ==(_ lhs: Company, _ rhs: Company) -> Bool {
+    return lhs.address == rhs.address && lhs.employees == rhs.employees
+  }
+
+  static var testValue: Company {
+    return Company(address: Address.testValue, employees: [Employee.testValue])
+  }
+}
+
+/// An enum type which decodes from Bool?.
+fileprivate enum EnhancedBool : Codable {
+  case `true`
+  case `false`
+  case fileNotFound
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if container.decodeNil() {
+      self = .fileNotFound
+    } else {
+      let value = try container.decode(Bool.self)
+      self = value ? .true : .false
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .true: try container.encode(true)
+    case .false: try container.encode(false)
+    case .fileNotFound: try container.encodeNil()
+    }
+  }
+}
+
+/// A type which encodes as an array directly through a single value container.
+private struct Numbers : Codable, Equatable {
+  let values = [4, 8, 15, 16, 23, 42]
+
+  init() {}
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let decodedValues = try container.decode([Int].self)
+    guard decodedValues == values else {
+      throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "The Numbers are wrong!"))
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(values)
+  }
+
+  static func ==(_ lhs: Numbers, _ rhs: Numbers) -> Bool {
+    return lhs.values == rhs.values
+  }
+
+  static var testValue: Numbers {
+    return Numbers()
+  }
+}
+
+/// A type which encodes as a dictionary directly through a single value container.
+fileprivate final class Mapping : Codable, Equatable {
+  let values: [String : URL]
+
+  init(values: [String : URL]) {
+    self.values = values
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    values = try container.decode([String : URL].self)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(values)
+  }
+
+  static func ==(_ lhs: Mapping, _ rhs: Mapping) -> Bool {
+    return lhs === rhs || lhs.values == rhs.values
+  }
+
+  static var testValue: Mapping {
+    return Mapping(values: ["Apple": URL(string: "http://apple.com")!,
+                            "localhost": URL(string: "http://127.0.0.1")!])
+  }
+}
+
+private struct NestedContainersTestType : Encodable {
+  let testSuperEncoder: Bool
+
+  init(testSuperEncoder: Bool = false) {
+    self.testSuperEncoder = testSuperEncoder
+  }
+
+  enum TopLevelCodingKeys : Int, CodingKey {
+    case a
+    case b
+    case c
+  }
+
+  enum IntermediateCodingKeys : Int, CodingKey {
+      case one
+      case two
+  }
+
+  func encode(to encoder: Encoder) throws {
+    if self.testSuperEncoder {
+      var topLevelContainer = encoder.container(keyedBy: TopLevelCodingKeys.self)
+      expectEqualPaths(encoder.codingPath, [], "Top-level Encoder's codingPath changed.")
+      expectEqualPaths(topLevelContainer.codingPath, [], "New first-level keyed container has non-empty codingPath.")
+
+      let superEncoder = topLevelContainer.superEncoder(forKey: .a)
+      expectEqualPaths(encoder.codingPath, [], "Top-level Encoder's codingPath changed.")
+      expectEqualPaths(topLevelContainer.codingPath, [], "First-level keyed container's codingPath changed.")
+      expectEqualPaths(superEncoder.codingPath, [TopLevelCodingKeys.a], "New superEncoder had unexpected codingPath.")
+      _testNestedContainers(in: superEncoder, baseCodingPath: [TopLevelCodingKeys.a])
+    } else {
+      _testNestedContainers(in: encoder, baseCodingPath: [])
+    }
+  }
+
+  func _testNestedContainers(in encoder: Encoder, baseCodingPath: [CodingKey]) {
+    expectEqualPaths(encoder.codingPath, baseCodingPath, "New encoder has non-empty codingPath.")
+
+    // codingPath should not change upon fetching a non-nested container.
+    var firstLevelContainer = encoder.container(keyedBy: TopLevelCodingKeys.self)
+    expectEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+    expectEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "New first-level keyed container has non-empty codingPath.")
+
+    // Nested Keyed Container
+    do {
+      // Nested container for key should have a new key pushed on.
+      var secondLevelContainer = firstLevelContainer.nestedContainer(keyedBy: IntermediateCodingKeys.self, forKey: .a)
+      expectEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+      expectEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
+      expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.a], "New second-level keyed container had unexpected codingPath.")
+
+      // Inserting a keyed container should not change existing coding paths.
+      let thirdLevelContainerKeyed = secondLevelContainer.nestedContainer(keyedBy: IntermediateCodingKeys.self, forKey: .one)
+      expectEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+      expectEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
+      expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.a], "Second-level keyed container's codingPath changed.")
+      expectEqualPaths(thirdLevelContainerKeyed.codingPath, baseCodingPath + [TopLevelCodingKeys.a, IntermediateCodingKeys.one], "New third-level keyed container had unexpected codingPath.")
+
+      // Inserting an unkeyed container should not change existing coding paths.
+      let thirdLevelContainerUnkeyed = secondLevelContainer.nestedUnkeyedContainer(forKey: .two)
+      expectEqualPaths(encoder.codingPath, baseCodingPath + [], "Top-level Encoder's codingPath changed.")
+      expectEqualPaths(firstLevelContainer.codingPath, baseCodingPath + [], "First-level keyed container's codingPath changed.")
+      expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.a], "Second-level keyed container's codingPath changed.")
+      expectEqualPaths(thirdLevelContainerUnkeyed.codingPath, baseCodingPath + [TopLevelCodingKeys.a, IntermediateCodingKeys.two], "New third-level unkeyed container had unexpected codingPath.")
+    }
+
+    // Nested Unkeyed Container
+    do {
+      // Nested container for key should have a new key pushed on.
+      var secondLevelContainer = firstLevelContainer.nestedUnkeyedContainer(forKey: .b)
+      expectEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+      expectEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
+      expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.b], "New second-level keyed container had unexpected codingPath.")
+
+      // Appending a keyed container should not change existing coding paths.
+      let thirdLevelContainerKeyed = secondLevelContainer.nestedContainer(keyedBy: IntermediateCodingKeys.self)
+      expectEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+      expectEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
+      expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.b], "Second-level unkeyed container's codingPath changed.")
+      expectEqualPaths(thirdLevelContainerKeyed.codingPath, baseCodingPath + [TopLevelCodingKeys.b, _TestKey(index: 0)], "New third-level keyed container had unexpected codingPath.")
+
+      // Appending an unkeyed container should not change existing coding paths.
+      let thirdLevelContainerUnkeyed = secondLevelContainer.nestedUnkeyedContainer()
+      expectEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+      expectEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
+      expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.b], "Second-level unkeyed container's codingPath changed.")
+      expectEqualPaths(thirdLevelContainerUnkeyed.codingPath, baseCodingPath + [TopLevelCodingKeys.b, _TestKey(index: 1)], "New third-level unkeyed container had unexpected codingPath.")
+    }
+  }
+}
+
+// MARK: - Helper Types
+
+/// A key type which can take on any string or integer value.
+/// This needs to mirror _JSONKey.
+fileprivate struct _TestKey : CodingKey {
+  var stringValue: String
+  var intValue: Int?
+
+  init?(stringValue: String) {
+    self.stringValue = stringValue
+    self.intValue = nil
+  }
+
+  init?(intValue: Int) {
+    self.stringValue = "\(intValue)"
+    self.intValue = intValue
+  }
+
+  init(index: Int) {
+    self.stringValue = "Index \(index)"
+    self.intValue = index
+  }
+}
+
+fileprivate struct FloatNaNPlaceholder : Codable, Equatable {
+  init() {}
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(Float.nan)
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let float = try container.decode(Float.self)
+    if !float.isNaN {
+      throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Couldn't decode NaN."))
+    }
+  }
+
+  static func ==(_ lhs: FloatNaNPlaceholder, _ rhs: FloatNaNPlaceholder) -> Bool {
+    return true
+  }
+}
+
+fileprivate struct DoubleNaNPlaceholder : Codable, Equatable {
+  init() {}
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(Double.nan)
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let double = try container.decode(Double.self)
+    if !double.isNaN {
+      throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Couldn't decode NaN."))
+    }
+  }
+
+  static func ==(_ lhs: DoubleNaNPlaceholder, _ rhs: DoubleNaNPlaceholder) -> Bool {
+    return true
+  }
+}
+
+fileprivate enum EitherDecodable<T : Decodable, U : Decodable> : Decodable {
+  case t(T)
+  case u(U)
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    do {
+      self = .t(try container.decode(T.self))
+    } catch {
+      self = .u(try container.decode(U.self))
+    }
+  }
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestLocale.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestLocale.swift
@@ -1,0 +1,127 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+class TestLocale : XCTestCase {
+    
+    func test_bridgingAutoupdating() {
+        let tester = LocaleBridgingTester()
+        
+        do {
+            let loc = Locale.autoupdatingCurrent
+            let result = tester.verifyAutoupdating(loc)
+            XCTAssertTrue(result)
+        }
+        
+        do {
+            let loc = tester.autoupdatingCurrentLocale()
+            let result = tester.verifyAutoupdating(loc)
+            XCTAssertTrue(result)
+        }
+    }
+    
+    func test_equality() {
+        let autoupdating = Locale.autoupdatingCurrent
+        let autoupdating2 = Locale.autoupdatingCurrent
+
+        XCTAssertEqual(autoupdating, autoupdating2)
+        
+        let current = Locale.current
+        
+        XCTAssertNotEqual(autoupdating, current)
+    }
+    
+    func test_localizedStringFunctions() {
+        let locale = Locale(identifier: "en")
+
+        XCTAssertEqual("English", locale.localizedString(forIdentifier: "en"))
+        XCTAssertEqual("France", locale.localizedString(forRegionCode: "fr"))
+        XCTAssertEqual("Spanish", locale.localizedString(forLanguageCode: "es"))
+        XCTAssertEqual("Simplified Han", locale.localizedString(forScriptCode: "Hans"))
+        XCTAssertEqual("Computer", locale.localizedString(forVariantCode: "POSIX"))
+        XCTAssertEqual("Buddhist Calendar", locale.localizedString(for: .buddhist))
+        XCTAssertEqual("US Dollar", locale.localizedString(forCurrencyCode: "USD"))
+        XCTAssertEqual("Phonebook Sort Order", locale.localizedString(forCollationIdentifier: "phonebook"))
+        // Need to find a good test case for collator identifier
+        // XCTAssertEqual("something", locale.localizedString(forCollatorIdentifier: "en"))
+    }
+    
+    func test_properties() {
+        let locale = Locale(identifier: "zh-Hant-HK")
+        
+        XCTAssertEqual("zh-Hant-HK", locale.identifier)
+        XCTAssertEqual("zh", locale.languageCode)
+        XCTAssertEqual("HK", locale.regionCode)
+        XCTAssertEqual("Hant", locale.scriptCode)
+        XCTAssertEqual("POSIX", Locale(identifier: "en_POSIX").variantCode)
+        XCTAssertTrue(locale.exemplarCharacterSet != nil)
+        // The calendar we get back from Locale has the locale set, but not the one we create with Calendar(identifier:). So we configure our comparison calendar first.
+        var c = Calendar(identifier: .gregorian)
+        c.locale = Locale(identifier: "en_US")
+        XCTAssertEqual(c, Locale(identifier: "en_US").calendar)
+        XCTAssertEqual("「", locale.quotationBeginDelimiter)
+        XCTAssertEqual("」", locale.quotationEndDelimiter)
+        XCTAssertEqual("『", locale.alternateQuotationBeginDelimiter)
+        XCTAssertEqual("』", locale.alternateQuotationEndDelimiter)
+        XCTAssertEqual("phonebook", Locale(identifier: "en_US@collation=phonebook").collationIdentifier)
+        XCTAssertEqual(".", locale.decimalSeparator)
+
+        
+        XCTAssertEqual(".", locale.decimalSeparator)
+        XCTAssertEqual(",", locale.groupingSeparator)
+        if #available(macOS 10.11, *) {
+          XCTAssertEqual("HK$", locale.currencySymbol)
+        }
+        XCTAssertEqual("HKD", locale.currencyCode)
+        
+        XCTAssertTrue(Locale.availableIdentifiers.count > 0)
+        XCTAssertTrue(Locale.isoLanguageCodes.count > 0)
+        XCTAssertTrue(Locale.isoRegionCodes.count > 0)
+        XCTAssertTrue(Locale.isoCurrencyCodes.count > 0)
+        XCTAssertTrue(Locale.commonISOCurrencyCodes.count > 0)
+        
+        XCTAssertTrue(Locale.preferredLanguages.count > 0)
+        
+        // Need to find a good test case for collator identifier
+        // XCTAssertEqual("something", locale.collatorIdentifier)
+    }
+
+    func test_AnyHashableContainingLocale() {
+        let values: [Locale] = [
+            Locale(identifier: "en"),
+            Locale(identifier: "uk"),
+            Locale(identifier: "uk"),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(Locale.self, type(of: anyHashables[0].base))
+        expectEqual(Locale.self, type(of: anyHashables[1].base))
+        expectEqual(Locale.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableCreatedFromNSLocale() {
+        let values: [NSLocale] = [
+            NSLocale(localeIdentifier: "en"),
+            NSLocale(localeIdentifier: "uk"),
+            NSLocale(localeIdentifier: "uk"),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(Locale.self, type(of: anyHashables[0].base))
+        expectEqual(Locale.self, type(of: anyHashables[1].base))
+        expectEqual(Locale.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestMeasurement.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestMeasurement.swift
@@ -1,0 +1,220 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+// We define our own units here so that we can have closer control over checking the behavior of just struct Measurement and not the rest of Foundation
+@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+class MyDimensionalUnit : Dimension {
+    class var unitA : MyDimensionalUnit {
+        return MyDimensionalUnit(symbol: "a", converter: UnitConverterLinear(coefficient: 1))
+    }
+    class var unitKiloA : MyDimensionalUnit {
+        return MyDimensionalUnit(symbol: "ka", converter: UnitConverterLinear(coefficient: 1_000))
+    }
+    class var unitMegaA : MyDimensionalUnit {
+        return MyDimensionalUnit(symbol: "Ma", converter: UnitConverterLinear(coefficient: 1_000_000))
+    }
+    override class func baseUnit() -> Self {
+        return MyDimensionalUnit.unitA as! Self
+    }
+}
+
+@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+class CustomUnit : Unit {
+    override init(symbol: String) {
+        super.init(symbol: symbol)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    public static let bugs = CustomUnit(symbol: "bug")
+    public static let features = CustomUnit(symbol: "feature")
+}
+
+@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+class TestMeasurement : XCTestCase {
+    
+    func testBasicConstruction() {
+        let m1 = Measurement(value: 3, unit: MyDimensionalUnit.unitA)
+        let m2 = Measurement(value: 3, unit: MyDimensionalUnit.unitA)
+        
+        let m3 = m1 + m2
+        
+        XCTAssertEqual(6, m3.value)
+        XCTAssertEqual(m1, m2)
+        
+        let m10 = Measurement(value: 2, unit: CustomUnit.bugs)
+        let m11 = Measurement(value: 2, unit: CustomUnit.bugs)
+        let m12 = Measurement(value: 3, unit: CustomUnit.bugs)
+        
+        XCTAssertEqual(m10, m11)
+        XCTAssertNotEqual(m10, m12)
+        
+        // This test has 2 + 2 + 3 bugs
+        XCTAssertEqual((m10 + m11 + m12).value, 7)
+    }
+    
+    func testConversion() {
+        let m1 = Measurement(value: 1000, unit: MyDimensionalUnit.unitA)
+        let kiloM1 = Measurement(value: 1, unit: MyDimensionalUnit.unitKiloA)
+
+        let result = m1.converted(to: MyDimensionalUnit.unitKiloA)
+        XCTAssertEqual(kiloM1, result)
+        
+        let sameResult = m1.converted(to: MyDimensionalUnit.unitA)
+        XCTAssertEqual(sameResult, m1)
+        
+        // This correctly fails to build
+        
+        // let m2 = Measurement(value: 1, unit: CustomUnit.bugs)
+        // m2.converted(to: MyDimensionalUnit.unitKiloA)
+    }
+    
+    func testOperators() {
+        // Which is bigger: 1 ka or 1 Ma?
+        let oneKiloA = Measurement(value: 1, unit: MyDimensionalUnit.unitKiloA)
+        let oneMegaA = Measurement(value: 1, unit: MyDimensionalUnit.unitMegaA)
+        
+        XCTAssertTrue(oneKiloA < oneMegaA)
+        XCTAssertFalse(oneKiloA > oneMegaA)
+        XCTAssertTrue(oneKiloA * 2000 > oneMegaA)
+        XCTAssertTrue(oneMegaA / 1_000_000 < oneKiloA)
+        XCTAssertTrue(2000 * oneKiloA > oneMegaA)
+        XCTAssertTrue(2 / oneMegaA > oneMegaA)
+        XCTAssertEqual(2 / (oneMegaA * 2), oneMegaA)
+        XCTAssertTrue(oneMegaA <= oneKiloA * 1000)
+        XCTAssertTrue(oneMegaA - oneKiloA <= oneKiloA * 1000)
+        XCTAssertTrue(oneMegaA >= oneKiloA * 1000)
+        XCTAssertTrue(oneMegaA >= ((oneKiloA * 1000) - oneKiloA))
+        
+        // Dynamically different dimensions
+        XCTAssertEqual(Measurement(value: 1_001_000, unit: MyDimensionalUnit.unitA), oneMegaA + oneKiloA)
+        
+        var bugCount = Measurement(value: 1, unit: CustomUnit.bugs)
+        XCTAssertEqual(bugCount.value, 1)
+        bugCount = bugCount + Measurement(value: 4, unit: CustomUnit.bugs)
+        XCTAssertEqual(bugCount.value, 5)
+    }
+    
+    func testUnits() {
+        XCTAssertEqual(MyDimensionalUnit.unitA, MyDimensionalUnit.unitA)
+        XCTAssertTrue(MyDimensionalUnit.unitA == MyDimensionalUnit.unitA)
+    }
+    
+    func testMeasurementFormatter() {
+        let formatter = MeasurementFormatter()
+        let measurement = Measurement(value: 100, unit: UnitLength.kilometers)
+        let result = formatter.string(from: measurement)
+        
+        // Just make sure we get a result at all here
+        XCTAssertFalse(result.isEmpty)
+    }
+
+    func testEquality() {
+        let fiveKM = Measurement(value: 5, unit: UnitLength.kilometers)
+        let fiveSeconds = Measurement(value: 5, unit: UnitDuration.seconds)
+        let fiveThousandM = Measurement(value: 5000, unit: UnitLength.meters)
+
+        XCTAssertTrue(fiveKM == fiveThousandM)
+        XCTAssertEqual(fiveKM, fiveThousandM)
+        XCTAssertFalse(fiveKM == fiveSeconds)
+    }
+
+    func testComparison() {
+        let fiveKM = Measurement(value: 5, unit: UnitLength.kilometers)
+        let fiveThousandM = Measurement(value: 5000, unit: UnitLength.meters)
+        let sixKM = Measurement(value: 6, unit: UnitLength.kilometers)
+        let sevenThousandM = Measurement(value: 7000, unit: UnitLength.meters)
+
+        XCTAssertTrue(fiveKM < sixKM)
+        XCTAssertTrue(fiveKM < sevenThousandM)
+        XCTAssertTrue(fiveKM <= fiveThousandM)
+    }
+
+    func testHashing() {
+        guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else { return }
+        let lengths: [[Measurement<UnitLength>]] = [
+            [
+                Measurement(value: 5, unit: UnitLength.kilometers),
+                Measurement(value: 5000, unit: UnitLength.meters),
+                Measurement(value: 5000, unit: UnitLength.meters),
+            ],
+            [
+                Measurement(value: 1, unit: UnitLength.kilometers),
+                Measurement(value: 1000, unit: UnitLength.meters),
+            ],
+            [
+                Measurement(value: 1, unit: UnitLength.meters),
+                Measurement(value: 1000, unit: UnitLength.millimeters),
+            ],
+        ]
+        checkHashableGroups(lengths)
+
+        let durations: [[Measurement<UnitDuration>]] = [
+            [
+                Measurement(value: 3600, unit: UnitDuration.seconds),
+                Measurement(value: 60, unit: UnitDuration.minutes),
+                Measurement(value: 1, unit: UnitDuration.hours),
+            ],
+            [
+                Measurement(value: 1800, unit: UnitDuration.seconds),
+                Measurement(value: 30, unit: UnitDuration.minutes),
+                Measurement(value: 0.5, unit: UnitDuration.hours),
+            ]
+        ]
+        checkHashableGroups(durations)
+
+        let custom: [Measurement<CustomUnit>] = [
+            Measurement(value: 1, unit: CustomUnit.bugs),
+            Measurement(value: 2, unit: CustomUnit.bugs),
+            Measurement(value: 3, unit: CustomUnit.bugs),
+            Measurement(value: 4, unit: CustomUnit.bugs),
+            Measurement(value: 1, unit: CustomUnit.features),
+            Measurement(value: 2, unit: CustomUnit.features),
+            Measurement(value: 3, unit: CustomUnit.features),
+            Measurement(value: 4, unit: CustomUnit.features),
+        ]
+        checkHashable(custom, equalityOracle: { $0 == $1 })
+    }
+
+    func test_AnyHashableContainingMeasurement() {
+        let values: [Measurement<UnitLength>] = [
+          Measurement(value: 100, unit: UnitLength.meters),
+          Measurement(value: 100, unit: UnitLength.kilometers),
+          Measurement(value: 100, unit: UnitLength.kilometers),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(Measurement<UnitLength>.self, type(of: anyHashables[0].base))
+        expectEqual(Measurement<UnitLength>.self, type(of: anyHashables[1].base))
+        expectEqual(Measurement<UnitLength>.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableCreatedFromNSMeasurement() {
+        let values: [NSMeasurement] = [
+            NSMeasurement(doubleValue: 100, unit: UnitLength.meters),
+            NSMeasurement(doubleValue: 100, unit: UnitLength.kilometers),
+            NSMeasurement(doubleValue: 100, unit: UnitLength.kilometers),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(Measurement<Unit>.self, type(of: anyHashables[0].base))
+        expectEqual(Measurement<Unit>.self, type(of: anyHashables[1].base))
+        expectEqual(Measurement<Unit>.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestNSRange.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestNSRange.swift
@@ -1,0 +1,142 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+class TestNSRange : XCTestCase {
+    func testEquality() {
+        let r1 = NSRange(location: 1, length: 10)
+        let r2 = NSRange(location: 1, length: 11)
+        let r3 = NSRange(location: 2, length: 10)
+        let r4 = NSRange(location: 1, length: 10)
+        let r5 = NSRange(location: NSNotFound, length: 0)
+        let r6 = NSRange(location: NSNotFound, length: 2)
+
+        XCTAssertNotEqual(r1, r2)
+        XCTAssertNotEqual(r1, r3)
+        XCTAssertEqual(r1, r4)
+        XCTAssertNotEqual(r1, r5)
+        XCTAssertNotEqual(r5, r6)
+    }
+
+    func testDescription() {
+        let r1 = NSRange(location: 0, length: 22)
+        let r2 = NSRange(location: 10, length: 22)
+        let r3 = NSRange(location: NSNotFound, length: 0)
+        let r4 = NSRange(location: NSNotFound, length: 22)
+        XCTAssertEqual("{0, 22}", r1.description)
+        XCTAssertEqual("{10, 22}", r2.description)
+        XCTAssertEqual("{\(NSNotFound), 0}", r3.description)
+        XCTAssertEqual("{\(NSNotFound), 22}", r4.description)
+
+        XCTAssertEqual("{0, 22}", r1.debugDescription)
+        XCTAssertEqual("{10, 22}", r2.debugDescription)
+        XCTAssertEqual("{NSNotFound, 0}", r3.debugDescription)
+        XCTAssertEqual("{NSNotFound, 22}", r4.debugDescription)
+    }
+
+    func testCreationFromString() {
+        let r1 = NSRange("")
+        XCTAssertNil(r1)
+        let r2 = NSRange("1")
+        XCTAssertNil(r2)
+        let r3 = NSRange("1 2")
+        XCTAssertEqual(NSRange(location: 1, length: 2), r3)
+        let r4 = NSRange("{1 8")
+        XCTAssertEqual(NSRange(location: 1, length: 8), r4)
+        let r5 = NSRange("1.8")
+        XCTAssertNil(r5)
+        let r6 = NSRange("1-9")
+        XCTAssertEqual(NSRange(location: 1, length: 9), r6)
+        let r7 = NSRange("{1,9}")
+        XCTAssertEqual(NSRange(location: 1, length: 9), r7)
+        let r8 = NSRange("{1,9}asdfasdf")
+        XCTAssertEqual(NSRange(location: 1, length: 9), r8)
+        let r9 = NSRange("{1,9}{2,7}")
+        XCTAssertEqual(NSRange(location: 1, length: 9), r9)
+        let r10 = NSRange("{１,９}")        
+        XCTAssertEqual(NSRange(location: 1, length: 9), r10)
+        let r11 = NSRange("{1.0,9}")
+        XCTAssertEqual(NSRange(location: 1, length: 9), r11)
+        let r12 = NSRange("{1,9.0}")
+        XCTAssertEqual(NSRange(location: 1, length: 9), r12)
+        let r13 = NSRange("{1.2,9}")
+        XCTAssertNil(r13)
+        let r14 = NSRange("{1,9.8}")
+        XCTAssertNil(r14)
+    }
+
+    func testHashing() {
+        let large = Int.max >> 2
+        let samples: [NSRange] = [
+            NSRange(location: 1, length: 1),
+            NSRange(location: 1, length: 2),
+            NSRange(location: 2, length: 1),
+            NSRange(location: 2, length: 2),
+            NSRange(location: large, length: large),
+            NSRange(location: 0, length: large),
+            NSRange(location: large, length: 0),
+        ]
+        checkHashable(samples, equalityOracle: { $0 == $1 })
+    }
+
+    func testBounding() {
+        let r1 = NSRange(location: 1000, length: 2222)
+        XCTAssertEqual(r1.location, r1.lowerBound)
+        XCTAssertEqual(r1.location + r1.length, r1.upperBound)
+    }
+
+    func testContains() {
+        let r1 = NSRange(location: 1000, length: 2222)
+        XCTAssertFalse(r1.contains(3))
+        XCTAssertTrue(r1.contains(1001))
+        XCTAssertFalse(r1.contains(4000))
+    }
+
+    func testUnion() {
+        let r1 = NSRange(location: 10, length: 20)
+        let r2 = NSRange(location: 30, length: 5)
+        let union1 = r1.union(r2)
+
+        XCTAssertEqual(Swift.min(r1.lowerBound, r2.lowerBound), union1.lowerBound)
+        XCTAssertEqual(Swift.max(r1.upperBound, r2.upperBound), union1.upperBound)
+
+        let r3 = NSRange(location: 10, length: 20)
+        let r4 = NSRange(location: 11, length: 5)
+        let union2 = r3.union(r4)
+
+        XCTAssertEqual(Swift.min(r3.lowerBound, r4.lowerBound), union2.lowerBound)
+        XCTAssertEqual(Swift.max(r3.upperBound, r4.upperBound), union2.upperBound)
+        
+        let r5 = NSRange(location: 10, length: 20)
+        let r6 = NSRange(location: 11, length: 29)
+        let union3 = r5.union(r6)
+        
+        XCTAssertEqual(Swift.min(r5.lowerBound, r6.upperBound), union3.lowerBound)
+        XCTAssertEqual(Swift.max(r5.upperBound, r6.upperBound), union3.upperBound)
+    }
+
+    func testIntersection() {
+        let r1 = NSRange(location: 1, length: 7)
+        let r2 = NSRange(location: 2, length: 20)
+        let r3 = NSRange(location: 2, length: 2)
+        let r4 = NSRange(location: 10, length: 7)
+
+        let intersection1 = r1.intersection(r2)
+        XCTAssertEqual(NSRange(location: 2, length: 6), intersection1)
+        let intersection2 = r1.intersection(r3)
+        XCTAssertEqual(NSRange(location: 2, length: 2), intersection2)
+        let intersection3 = r1.intersection(r4)
+        XCTAssertEqual(nil, intersection3)
+    }
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestNSString.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestNSString.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+class TestNSString : XCTestCase {
+    
+  func test_equalOverflow() {
+    let cyrillic = "чебурашка@ящик-с-апельсинами.рф"
+    let other = getNSStringEqualTestString()
+    print(NSStringBridgeTestEqual(cyrillic, other))
+  }
+  
+  func test_smallString_BOM() {
+    let bom = "\u{FEFF}" // U+FEFF (ZERO WIDTH NO-BREAK SPACE)
+//    XCTAssertEqual(1, NSString(string: bom).length)
+//    XCTAssertEqual(4, NSString(string: "\(bom)abc").length)
+//    XCTAssertEqual(5, NSString(string: "\(bom)\(bom)abc").length)
+//    XCTAssertEqual(4, NSString(string: "a\(bom)bc").length)
+//    XCTAssertEqual(13, NSString(string: "\(bom)234567890123").length)
+//    XCTAssertEqual(14, NSString(string: "\(bom)2345678901234").length)
+    
+    XCTAssertEqual(1, (bom as NSString).length)
+    XCTAssertEqual(4, ("\(bom)abc" as NSString).length)
+    XCTAssertEqual(5, ("\(bom)\(bom)abc" as NSString).length)
+    XCTAssertEqual(4, ("a\(bom)bc" as NSString).length)
+    XCTAssertEqual(13, ("\(bom)234567890123" as NSString).length)
+    XCTAssertEqual(14, ("\(bom)2345678901234" as NSString).length)
+    
+    let string = "\(bom)abc"
+    let middleIndex = string.index(string.startIndex, offsetBy: 2)
+    string.enumerateSubstrings(in: middleIndex..<string.endIndex, options: .byLines) { (_, _, _, _) in }  //shouldn't crash
+  }
+  
+  func test_unpairedSurrogates() {
+    let evil = getNSStringWithUnpairedSurrogate();
+    print("\(evil)")
+  }
+  
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestNotification.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestNotification.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+class TestNotification : XCTestCase {
+    func test_unconditionallyBridgeFromObjectiveC() {
+        XCTAssertEqual(Notification(name: Notification.Name("")), Notification._unconditionallyBridgeFromObjectiveC(nil))
+    }
+
+    func test_hashing() {
+        guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else { return }
+
+        let o1 = NSObject()
+        let o2 = NSObject()
+        let values: [Notification] = [
+            /* 0 */ Notification(name: .init("a"), object: o1, userInfo: nil),
+            /* 1 */ Notification(name: .init("a"), object: o2, userInfo: nil),
+            /* 2 */ Notification(name: .init("b"), object: o1, userInfo: nil),
+            /* 3 */ Notification(name: .init("b"), object: o2, userInfo: nil),
+            /* 4 */ Notification(name: .init("a"), object: o1, userInfo: ["Foo": 1]),
+            /* 5 */ Notification(name: .init("a"), object: o1, userInfo: ["Foo": 2]),
+            /* 6 */ Notification(name: .init("a"), object: o1, userInfo: ["Bar": 1]),
+            /* 7 */ Notification(name: .init("a"), object: o1, userInfo: ["Foo": 1, "Bar": 2]),
+        ]
+
+        let hashGroups: [Int: Int] = [
+            0: 0,
+            1: 0,
+            2: 1,
+            3: 1,
+            4: 2,
+            5: 2,
+            6: 3,
+            7: 4
+        ]
+
+        checkHashable(
+            values,
+            equalityOracle: { $0 == $1 },
+            hashEqualityOracle: {
+                // FIXME: Unfortunately while we have 8 different notifications,
+                // three pairs of them have colliding hash encodings.
+                hashGroups[$0] == hashGroups[$1]
+            })
+    }
+
+
+    private struct NonHashableValueType: Equatable {
+        let value: Int
+        init(_ value: Int) {
+            self.value = value
+        }
+    }
+
+    func test_reflexivity_violation() {
+        // <rdar://problem/49797185> Foundation.Notification's equality relation isn't reflexive
+        let name = Notification.Name("name")
+        let a = NonHashableValueType(1)
+        let b = NonHashableValueType(2)
+        // Currently none of these values compare equal to themselves:
+        let values: [Notification] = [
+            Notification(name: name, object: a, userInfo: nil),
+            Notification(name: name, object: b, userInfo: nil),
+            Notification(name: name, object: nil, userInfo: ["foo": a]),
+            Notification(name: name, object: nil, userInfo: ["foo": b]),
+        ]
+        #if true // What we have
+        for value in values {
+            XCTAssertNotEqual(value, value)
+        }
+        #else // What we want
+        checkHashable(values, equalityOracle: { $0 == $1 })
+        #endif
+    }
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestPersonNameComponents.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestPersonNameComponents.swift
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import CoreFoundation
+import XCTest
+
+class TestPersonNameComponents : XCTestCase {
+    @available(OSX 10.11, iOS 9.0, *)
+    func makePersonNameComponents(givenName: String, familyName: String) -> PersonNameComponents {
+        var result = PersonNameComponents()
+        result.givenName = givenName
+        result.familyName = familyName
+        return result
+    }
+
+    func test_Hashing() {
+        guard #available(macOS 10.13, iOS 11.0, *) else {
+            // PersonNameComponents was available in earlier versions, but its
+            // hashing did not match its definition for equality.
+            return
+        }
+
+        let values: [[PersonNameComponents]] = [
+            [
+                makePersonNameComponents(givenName: "Kevin", familyName: "Frank"),
+                makePersonNameComponents(givenName: "Kevin", familyName: "Frank"),
+            ],
+            [
+                makePersonNameComponents(givenName: "John", familyName: "Frank"),
+                makePersonNameComponents(givenName: "John", familyName: "Frank"),
+            ],
+            [
+                makePersonNameComponents(givenName: "Kevin", familyName: "Appleseed"),
+                makePersonNameComponents(givenName: "Kevin", familyName: "Appleseed"),
+            ],
+            [
+                makePersonNameComponents(givenName: "John", familyName: "Appleseed"),
+                makePersonNameComponents(givenName: "John", familyName: "Appleseed"),
+            ]
+        ]
+        checkHashableGroups(
+            values,
+            // FIXME: PersonNameComponents hashes aren't seeded.
+            allowIncompleteHashing: true)
+    }
+
+    func test_AnyHashableContainingPersonNameComponents() {
+        if #available(OSX 10.11, iOS 9.0, *) {
+            let values: [PersonNameComponents] = [
+                makePersonNameComponents(givenName: "Kevin", familyName: "Frank"),
+                makePersonNameComponents(givenName: "John", familyName: "Appleseed"),
+                makePersonNameComponents(givenName: "John", familyName: "Appleseed"),
+            ]
+            let anyHashables = values.map(AnyHashable.init)
+            expectEqual(PersonNameComponents.self, type(of: anyHashables[0].base))
+            expectEqual(PersonNameComponents.self, type(of: anyHashables[1].base))
+            expectEqual(PersonNameComponents.self, type(of: anyHashables[2].base))
+            XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+            XCTAssertEqual(anyHashables[1], anyHashables[2])
+        }
+    }
+
+    @available(OSX 10.11, iOS 9.0, *)
+    func makeNSPersonNameComponents(givenName: String, familyName: String) -> NSPersonNameComponents {
+        let result = NSPersonNameComponents()
+        result.givenName = givenName
+        result.familyName = familyName
+        return result
+    }
+
+    func test_AnyHashableCreatedFromNSPersonNameComponents() {
+        if #available(OSX 10.11, iOS 9.0, *) {
+            let values: [NSPersonNameComponents] = [
+                makeNSPersonNameComponents(givenName: "Kevin", familyName: "Frank"),
+                makeNSPersonNameComponents(givenName: "John", familyName: "Appleseed"),
+                makeNSPersonNameComponents(givenName: "John", familyName: "Appleseed"),
+            ]
+            let anyHashables = values.map(AnyHashable.init)
+            expectEqual(PersonNameComponents.self, type(of: anyHashables[0].base))
+            expectEqual(PersonNameComponents.self, type(of: anyHashables[1].base))
+            expectEqual(PersonNameComponents.self, type(of: anyHashables[2].base))
+            XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+            XCTAssertEqual(anyHashables[1], anyHashables[2])
+        }
+    }
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestPlistEncoder.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestPlistEncoder.swift
@@ -1,0 +1,857 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+import Foundation
+import XCTest
+
+// MARK: - Test Suite
+
+class TestPropertyListEncoder : XCTestCase {
+  // MARK: - Encoding Top-Level Empty Types
+  func testEncodingTopLevelEmptyStruct() {
+    let empty = EmptyStruct()
+    _testRoundTrip(of: empty, in: .binary, expectedPlist: _plistEmptyDictionaryBinary)
+    _testRoundTrip(of: empty, in: .xml, expectedPlist: _plistEmptyDictionaryXML)
+  }
+
+  func testEncodingTopLevelEmptyClass() {
+    let empty = EmptyClass()
+    _testRoundTrip(of: empty, in: .binary, expectedPlist: _plistEmptyDictionaryBinary)
+    _testRoundTrip(of: empty, in: .xml, expectedPlist: _plistEmptyDictionaryXML)
+  }
+
+  // MARK: - Encoding Top-Level Single-Value Types
+  func testEncodingTopLevelSingleValueEnum() {
+    let s1 = Switch.off
+    _testEncodeFailure(of: s1, in: .binary)
+    _testEncodeFailure(of: s1, in: .xml)
+    _testRoundTrip(of: TopLevelWrapper(s1), in: .binary)
+    _testRoundTrip(of: TopLevelWrapper(s1), in: .xml)
+
+    let s2 = Switch.on
+    _testEncodeFailure(of: s2, in: .binary)
+    _testEncodeFailure(of: s2, in: .xml)
+    _testRoundTrip(of: TopLevelWrapper(s2), in: .binary)
+    _testRoundTrip(of: TopLevelWrapper(s2), in: .xml)
+  }
+
+  func testEncodingTopLevelSingleValueStruct() {
+    let t = Timestamp(3141592653)
+    _testEncodeFailure(of: t, in: .binary)
+    _testEncodeFailure(of: t, in: .xml)
+    _testRoundTrip(of: TopLevelWrapper(t), in: .binary)
+    _testRoundTrip(of: TopLevelWrapper(t), in: .xml)
+  }
+
+  func testEncodingTopLevelSingleValueClass() {
+    let c = Counter()
+    _testEncodeFailure(of: c, in: .binary)
+    _testEncodeFailure(of: c, in: .xml)
+    _testRoundTrip(of: TopLevelWrapper(c), in: .binary)
+    _testRoundTrip(of: TopLevelWrapper(c), in: .xml)
+  }
+
+  // MARK: - Encoding Top-Level Structured Types
+  func testEncodingTopLevelStructuredStruct() {
+    // Address is a struct type with multiple fields.
+    let address = Address.testValue
+    _testRoundTrip(of: address, in: .binary)
+    _testRoundTrip(of: address, in: .xml)
+  }
+
+  func testEncodingTopLevelStructuredClass() {
+    // Person is a class with multiple fields.
+    let person = Person.testValue
+    _testRoundTrip(of: person, in: .binary)
+    _testRoundTrip(of: person, in: .xml)
+  }
+
+  func testEncodingTopLevelStructuredSingleStruct() {
+    // Numbers is a struct which encodes as an array through a single value container.
+    let numbers = Numbers.testValue
+    _testRoundTrip(of: numbers, in: .binary)
+    _testRoundTrip(of: numbers, in: .xml)
+  }
+
+  func testEncodingTopLevelStructuredSingleClass() {
+    // Mapping is a class which encodes as a dictionary through a single value container.
+    let mapping = Mapping.testValue
+    _testRoundTrip(of: mapping, in: .binary)
+    _testRoundTrip(of: mapping, in: .xml)
+  }
+
+  func testEncodingTopLevelDeepStructuredType() {
+    // Company is a type with fields which are Codable themselves.
+    let company = Company.testValue
+    _testRoundTrip(of: company, in: .binary)
+    _testRoundTrip(of: company, in: .xml)
+  }
+
+  func testEncodingClassWhichSharesEncoderWithSuper() {
+    // Employee is a type which shares its encoder & decoder with its superclass, Person.
+    let employee = Employee.testValue
+    _testRoundTrip(of: employee, in: .binary)
+    _testRoundTrip(of: employee, in: .xml)
+  }
+
+  func testEncodingTopLevelNullableType() {
+    // EnhancedBool is a type which encodes either as a Bool or as nil.
+    _testEncodeFailure(of: EnhancedBool.true, in: .binary)
+    _testEncodeFailure(of: EnhancedBool.true, in: .xml)
+    _testEncodeFailure(of: EnhancedBool.false, in: .binary)
+    _testEncodeFailure(of: EnhancedBool.false, in: .xml)
+    _testEncodeFailure(of: EnhancedBool.fileNotFound, in: .binary)
+    _testEncodeFailure(of: EnhancedBool.fileNotFound, in: .xml)
+
+    _testRoundTrip(of: TopLevelWrapper(EnhancedBool.true), in: .binary)
+    _testRoundTrip(of: TopLevelWrapper(EnhancedBool.true), in: .xml)
+    _testRoundTrip(of: TopLevelWrapper(EnhancedBool.false), in: .binary)
+    _testRoundTrip(of: TopLevelWrapper(EnhancedBool.false), in: .xml)
+    _testRoundTrip(of: TopLevelWrapper(EnhancedBool.fileNotFound), in: .binary)
+    _testRoundTrip(of: TopLevelWrapper(EnhancedBool.fileNotFound), in: .xml)
+  }
+
+  func testEncodingMultipleNestedContainersWithTheSameTopLevelKey() {
+    guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else { return }
+
+    struct Model : Codable, Equatable {
+      let first: String
+      let second: String
+      
+      init(from coder: Decoder) throws {
+        let container = try coder.container(keyedBy: TopLevelCodingKeys.self)
+        
+        let firstNestedContainer = try container.nestedContainer(keyedBy: FirstNestedCodingKeys.self, forKey: .top)
+        self.first = try firstNestedContainer.decode(String.self, forKey: .first)
+        
+        let secondNestedContainer = try container.nestedContainer(keyedBy: SecondNestedCodingKeys.self, forKey: .top)
+        self.second = try secondNestedContainer.decode(String.self, forKey: .second)
+      }
+      
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: TopLevelCodingKeys.self)
+        
+        var firstNestedContainer = container.nestedContainer(keyedBy: FirstNestedCodingKeys.self, forKey: .top)
+        try firstNestedContainer.encode(self.first, forKey: .first)
+        
+        var secondNestedContainer = container.nestedContainer(keyedBy: SecondNestedCodingKeys.self, forKey: .top)
+        try secondNestedContainer.encode(self.second, forKey: .second)
+      }
+      
+      init(first: String, second: String) {
+        self.first = first
+        self.second = second
+      }
+      
+      static var testValue: Model {
+        return Model(first: "Johnny Appleseed",
+                     second: "appleseed@apple.com")
+      }
+      enum TopLevelCodingKeys : String, CodingKey {
+        case top
+      }
+      
+      enum FirstNestedCodingKeys : String, CodingKey {
+        case first
+      }
+      enum SecondNestedCodingKeys : String, CodingKey {
+        case second
+      }
+    }
+    
+    let model = Model.testValue
+    let expectedXML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n\t<key>top</key>\n\t<dict>\n\t\t<key>first</key>\n\t\t<string>Johnny Appleseed</string>\n\t\t<key>second</key>\n\t\t<string>appleseed@apple.com</string>\n\t</dict>\n</dict>\n</plist>\n".data(using: .utf8)!
+    _testRoundTrip(of: model, in: .xml, expectedPlist: expectedXML)
+  }
+
+  #if false // FIXME: XCTest doesn't support crash tests yet rdar://20195010&22387653
+  func testEncodingConflictedTypeNestedContainersWithTheSameTopLevelKey() {
+    struct Model : Encodable, Equatable {
+      let first: String
+      
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: TopLevelCodingKeys.self)
+        
+        var firstNestedContainer = container.nestedContainer(keyedBy: FirstNestedCodingKeys.self, forKey: .top)
+        try firstNestedContainer.encode(self.first, forKey: .first)
+        
+        // The following line would fail as it attempts to re-encode into already encoded container is invalid. This will always fail
+        var secondNestedContainer = container.nestedUnkeyedContainer(forKey: .top)
+        try secondNestedContainer.encode("second")
+      }
+      
+      init(first: String) {
+        self.first = first
+      }
+      
+      static var testValue: Model {
+        return Model(first: "Johnny Appleseed")
+      }
+      enum TopLevelCodingKeys : String, CodingKey {
+        case top
+      }
+      
+      enum FirstNestedCodingKeys : String, CodingKey {
+        case first
+      }
+    }
+    
+    let model = Model.testValue
+    // This following test would fail as it attempts to re-encode into already encoded container is invalid. This will always fail
+    expectCrashLater()
+    _testEncodeFailure(of: model, in: .xml)
+  }
+  #endif
+  
+  // MARK: - Encoder Features
+  func testNestedContainerCodingPaths() {
+    let encoder = JSONEncoder()
+    do {
+      let _ = try encoder.encode(NestedContainersTestType())
+    } catch let error as NSError {
+      XCTFail("Caught error during encoding nested container types: \(error)")
+    }
+  }
+
+  func testSuperEncoderCodingPaths() {
+    let encoder = JSONEncoder()
+    do {
+      let _ = try encoder.encode(NestedContainersTestType(testSuperEncoder: true))
+    } catch let error as NSError {
+      XCTFail("Caught error during encoding nested container types: \(error)")
+    }
+  }
+
+  func testEncodingTopLevelData() {
+    let data = try! JSONSerialization.data(withJSONObject: [], options: [])
+    _testRoundTrip(of: data, in: .binary, expectedPlist: try! PropertyListSerialization.data(fromPropertyList: data, format: .binary, options: 0))
+    _testRoundTrip(of: data, in: .xml, expectedPlist: try! PropertyListSerialization.data(fromPropertyList: data, format: .xml, options: 0))
+  }
+
+  func testInterceptData() {
+    let data = try! JSONSerialization.data(withJSONObject: [], options: [])
+    let topLevel = TopLevelWrapper(data)
+    let plist = ["value": data]
+    _testRoundTrip(of: topLevel, in: .binary, expectedPlist: try! PropertyListSerialization.data(fromPropertyList: plist, format: .binary, options: 0))
+    _testRoundTrip(of: topLevel, in: .xml, expectedPlist: try! PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0))
+  }
+
+  func testInterceptDate() {
+    let date = Date(timeIntervalSinceReferenceDate: 0)
+    let topLevel = TopLevelWrapper(date)
+    let plist = ["value": date]
+    _testRoundTrip(of: topLevel, in: .binary, expectedPlist: try! PropertyListSerialization.data(fromPropertyList: plist, format: .binary, options: 0))
+    _testRoundTrip(of: topLevel, in: .xml, expectedPlist: try! PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0))
+  }
+
+  // MARK: - Type coercion
+  func testTypeCoercion() {
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int8].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int16].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int32].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [Int64].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt8].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt16].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt32].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [UInt64].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [Float].self)
+    _testRoundTripTypeCoercionFailure(of: [false, true], as: [Double].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int8], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int16], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int32], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [Int64], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt8], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt16], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt32], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0, 1] as [UInt64], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0.0, 1.0] as [Float], as: [Bool].self)
+    _testRoundTripTypeCoercionFailure(of: [0.0, 1.0] as [Double], as: [Bool].self)
+  }
+
+  func testDecodingConcreteTypeParameter() {
+      let encoder = PropertyListEncoder()
+      guard let plist = try? encoder.encode(Employee.testValue) else {
+          XCTFail("Unable to encode Employee.")
+          return
+      }
+
+      let decoder = PropertyListDecoder()
+      guard let decoded = try? decoder.decode(Employee.self as Person.Type, from: plist) else {
+          XCTFail("Failed to decode Employee as Person from plist.")
+          return
+      }
+
+      expectEqual(type(of: decoded), Employee.self, "Expected decoded value to be of type Employee; got \(type(of: decoded)) instead.")
+  }
+
+  // MARK: - Encoder State
+  // SR-6078
+  func testEncoderStateThrowOnEncode() {
+    struct Wrapper<T : Encodable> : Encodable {
+      let value: T
+      init(_ value: T) { self.value = value }
+
+      func encode(to encoder: Encoder) throws {
+        // This approximates a subclass calling into its superclass, where the superclass encodes a value that might throw.
+        // The key here is that getting the superEncoder creates a referencing encoder.
+        var container = encoder.unkeyedContainer()
+        let superEncoder = container.superEncoder()
+
+        // Pushing a nested container on leaves the referencing encoder with multiple containers.
+        var nestedContainer = superEncoder.unkeyedContainer()
+        try nestedContainer.encode(value)
+      }
+    }
+
+    struct Throwing : Encodable {
+      func encode(to encoder: Encoder) throws {
+        enum EncodingError : Error { case foo }
+        throw EncodingError.foo
+      }
+    }
+
+    // The structure that would be encoded here looks like
+    //
+    //   <array>
+    //     <array>
+    //       <array>
+    //         [throwing]
+    //       </array>
+    //     </array>
+    //   </array>
+    //
+    // The wrapper asks for an unkeyed container ([^]), gets a super encoder, and creates a nested container into that ([[^]]).
+    // We then encode an array into that ([[[^]]]), which happens to be a value that causes us to throw an error.
+    //
+    // The issue at hand reproduces when you have a referencing encoder (superEncoder() creates one) that has a container on the stack (unkeyedContainer() adds one) that encodes a value going through box_() (Array does that) that encodes something which throws (Throwing does that).
+    // When reproducing, this will cause a test failure via fatalError().
+    _ = try? PropertyListEncoder().encode(Wrapper([Throwing()]))
+  }
+
+  // MARK: - Encoder State
+  // SR-6048
+  func testDecoderStateThrowOnDecode() {
+    let plist = try! PropertyListEncoder().encode([1,2,3])
+    let _ = try! PropertyListDecoder().decode(EitherDecodable<[String], [Int]>.self, from: plist)
+  }
+
+  // MARK: - Helper Functions
+  private var _plistEmptyDictionaryBinary: Data {
+    return Data(base64Encoded: "YnBsaXN0MDDQCAAAAAAAAAEBAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAJ")!
+  }
+
+  private var _plistEmptyDictionaryXML: Data {
+    return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict/>\n</plist>\n".data(using: .utf8)!
+  }
+
+  private func _testEncodeFailure<T : Encodable>(of value: T, in format: PropertyListSerialization.PropertyListFormat) {
+    do {
+      let encoder = PropertyListEncoder()
+      encoder.outputFormat = format
+      let _ = try encoder.encode(value)
+      XCTFail("Encode of top-level \(T.self) was expected to fail.")
+    } catch {}
+  }
+
+  private func _testRoundTrip<T>(of value: T, in format: PropertyListSerialization.PropertyListFormat, expectedPlist plist: Data? = nil) where T : Codable, T : Equatable {
+    var payload: Data! = nil
+    do {
+      let encoder = PropertyListEncoder()
+      encoder.outputFormat = format
+      payload = try encoder.encode(value)
+    } catch {
+      XCTFail("Failed to encode \(T.self) to plist: \(error)")
+    }
+
+    if let expectedPlist = plist {
+      XCTAssertEqual(expectedPlist, payload, "Produced plist not identical to expected plist.")
+    }
+
+    do {
+      var decodedFormat: PropertyListSerialization.PropertyListFormat = .xml
+      let decoded = try PropertyListDecoder().decode(T.self, from: payload, format: &decodedFormat)
+      XCTAssertEqual(format, decodedFormat, "Encountered plist format differed from requested format.")
+      XCTAssertEqual(decoded, value, "\(T.self) did not round-trip to an equal value.")
+    } catch {
+      XCTFail("Failed to decode \(T.self) from plist: \(error)")
+    }
+  }
+
+  private func _testRoundTripTypeCoercionFailure<T,U>(of value: T, as type: U.Type) where T : Codable, U : Codable {
+    do {
+      let data = try PropertyListEncoder().encode(value)
+      let _ = try PropertyListDecoder().decode(U.self, from: data)
+      XCTFail("Coercion from \(T.self) to \(U.self) was expected to fail.")
+    } catch {}
+  }
+}
+
+// MARK: - Helper Global Functions
+func XCTAssertEqualPaths(_ lhs: [CodingKey], _ rhs: [CodingKey], _ prefix: String) {
+  if lhs.count != rhs.count {
+    XCTFail("\(prefix) [CodingKey].count mismatch: \(lhs.count) != \(rhs.count)")
+    return
+  }
+
+  for (key1, key2) in zip(lhs, rhs) {
+    switch (key1.intValue, key2.intValue) {
+    case (.none, .none): break
+    case (.some(let i1), .none):
+      XCTFail("\(prefix) CodingKey.intValue mismatch: \(type(of: key1))(\(i1)) != nil")
+      return
+    case (.none, .some(let i2)):
+      XCTFail("\(prefix) CodingKey.intValue mismatch: nil != \(type(of: key2))(\(i2))")
+      return
+    case (.some(let i1), .some(let i2)):
+        guard i1 == i2 else {
+            XCTFail("\(prefix) CodingKey.intValue mismatch: \(type(of: key1))(\(i1)) != \(type(of: key2))(\(i2))")
+            return
+        }
+
+        break
+    }
+
+    XCTAssertEqual(key1.stringValue, key2.stringValue, "\(prefix) CodingKey.stringValue mismatch: \(type(of: key1))('\(key1.stringValue)') != \(type(of: key2))('\(key2.stringValue)')")
+  }
+}
+
+// MARK: - Test Types
+/* FIXME: Import from %S/Inputs/Coding/SharedTypes.swift somehow. */
+
+// MARK: - Empty Types
+fileprivate struct EmptyStruct : Codable, Equatable {
+  static func ==(_ lhs: EmptyStruct, _ rhs: EmptyStruct) -> Bool {
+    return true
+  }
+}
+
+fileprivate class EmptyClass : Codable, Equatable {
+  static func ==(_ lhs: EmptyClass, _ rhs: EmptyClass) -> Bool {
+    return true
+  }
+}
+
+// MARK: - Single-Value Types
+/// A simple on-off switch type that encodes as a single Bool value.
+fileprivate enum Switch : Codable {
+  case off
+  case on
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    switch try container.decode(Bool.self) {
+    case false: self = .off
+    case true:  self = .on
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .off: try container.encode(false)
+    case .on:  try container.encode(true)
+    }
+  }
+}
+
+/// A simple timestamp type that encodes as a single Double value.
+fileprivate struct Timestamp : Codable, Equatable {
+  let value: Double
+
+  init(_ value: Double) {
+    self.value = value
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    value = try container.decode(Double.self)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(self.value)
+  }
+
+  static func ==(_ lhs: Timestamp, _ rhs: Timestamp) -> Bool {
+    return lhs.value == rhs.value
+  }
+}
+
+/// A simple referential counter type that encodes as a single Int value.
+fileprivate final class Counter : Codable, Equatable {
+  var count: Int = 0
+
+  init() {}
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    count = try container.decode(Int.self)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(self.count)
+  }
+
+  static func ==(_ lhs: Counter, _ rhs: Counter) -> Bool {
+    return lhs === rhs || lhs.count == rhs.count
+  }
+}
+
+// MARK: - Structured Types
+/// A simple address type that encodes as a dictionary of values.
+fileprivate struct Address : Codable, Equatable {
+  let street: String
+  let city: String
+  let state: String
+  let zipCode: Int
+  let country: String
+
+  init(street: String, city: String, state: String, zipCode: Int, country: String) {
+    self.street = street
+    self.city = city
+    self.state = state
+    self.zipCode = zipCode
+    self.country = country
+  }
+
+  static func ==(_ lhs: Address, _ rhs: Address) -> Bool {
+    return lhs.street == rhs.street &&
+           lhs.city == rhs.city &&
+           lhs.state == rhs.state &&
+           lhs.zipCode == rhs.zipCode &&
+           lhs.country == rhs.country
+  }
+
+  static var testValue: Address {
+    return Address(street: "1 Infinite Loop",
+                   city: "Cupertino",
+                   state: "CA",
+                   zipCode: 95014,
+                   country: "United States")
+  }
+}
+
+/// A simple person class that encodes as a dictionary of values.
+fileprivate class Person : Codable, Equatable {
+  let name: String
+  let email: String
+  let website: URL?
+
+  init(name: String, email: String, website: URL? = nil) {
+    self.name = name
+    self.email = email
+    self.website = website
+  }
+
+  func isEqual(_ other: Person) -> Bool {
+    return self.name == other.name &&
+           self.email == other.email &&
+           self.website == other.website
+  }
+
+  static func ==(_ lhs: Person, _ rhs: Person) -> Bool {
+    return lhs.isEqual(rhs)
+  }
+
+  class var testValue: Person {
+    return Person(name: "Johnny Appleseed", email: "appleseed@apple.com")
+  }
+}
+
+/// A class which shares its encoder and decoder with its superclass.
+fileprivate class Employee : Person {
+  let id: Int
+
+  init(name: String, email: String, website: URL? = nil, id: Int) {
+    self.id = id
+    super.init(name: name, email: email, website: website)
+  }
+
+  enum CodingKeys : String, CodingKey {
+    case id
+  }
+
+  required init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(Int.self, forKey: .id)
+    try super.init(from: decoder)
+  }
+
+  override func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(id, forKey: .id)
+    try super.encode(to: encoder)
+  }
+
+  override func isEqual(_ other: Person) -> Bool {
+    if let employee = other as? Employee {
+      guard self.id == employee.id else { return false }
+    }
+
+    return super.isEqual(other)
+  }
+
+  override class var testValue: Employee {
+    return Employee(name: "Johnny Appleseed", email: "appleseed@apple.com", id: 42)
+  }
+}
+
+/// A simple company struct which encodes as a dictionary of nested values.
+fileprivate struct Company : Codable, Equatable {
+  let address: Address
+  var employees: [Employee]
+
+  init(address: Address, employees: [Employee]) {
+    self.address = address
+    self.employees = employees
+  }
+
+  static func ==(_ lhs: Company, _ rhs: Company) -> Bool {
+    return lhs.address == rhs.address && lhs.employees == rhs.employees
+  }
+
+  static var testValue: Company {
+    return Company(address: Address.testValue, employees: [Employee.testValue])
+  }
+}
+
+/// An enum type which decodes from Bool?.
+fileprivate enum EnhancedBool : Codable {
+  case `true`
+  case `false`
+  case fileNotFound
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if container.decodeNil() {
+      self = .fileNotFound
+    } else {
+      let value = try container.decode(Bool.self)
+      self = value ? .true : .false
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .true: try container.encode(true)
+    case .false: try container.encode(false)
+    case .fileNotFound: try container.encodeNil()
+    }
+  }
+}
+
+/// A type which encodes as an array directly through a single value container.
+private struct Numbers : Codable, Equatable {
+  let values = [4, 8, 15, 16, 23, 42]
+
+  init() {}
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let decodedValues = try container.decode([Int].self)
+    guard decodedValues == values else {
+      throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "The Numbers are wrong!"))
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(values)
+  }
+
+  static func ==(_ lhs: Numbers, _ rhs: Numbers) -> Bool {
+    return lhs.values == rhs.values
+  }
+
+  static var testValue: Numbers {
+    return Numbers()
+  }
+}
+
+/// A type which encodes as a dictionary directly through a single value container.
+fileprivate final class Mapping : Codable, Equatable {
+  let values: [String : URL]
+
+  init(values: [String : URL]) {
+    self.values = values
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    values = try container.decode([String : URL].self)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(values)
+  }
+
+  static func ==(_ lhs: Mapping, _ rhs: Mapping) -> Bool {
+    return lhs === rhs || lhs.values == rhs.values
+  }
+
+  static var testValue: Mapping {
+    return Mapping(values: ["Apple": URL(string: "http://apple.com")!,
+                            "localhost": URL(string: "http://127.0.0.1")!])
+  }
+}
+
+private struct NestedContainersTestType : Encodable {
+  let testSuperEncoder: Bool
+
+  init(testSuperEncoder: Bool = false) {
+    self.testSuperEncoder = testSuperEncoder
+  }
+
+  enum TopLevelCodingKeys : Int, CodingKey {
+    case a
+    case b
+    case c
+  }
+
+  enum IntermediateCodingKeys : Int, CodingKey {
+      case one
+      case two
+  }
+
+  func encode(to encoder: Encoder) throws {
+    if self.testSuperEncoder {
+      var topLevelContainer = encoder.container(keyedBy: TopLevelCodingKeys.self)
+      XCTAssertEqualPaths(encoder.codingPath, [], "Top-level Encoder's codingPath changed.")
+      XCTAssertEqualPaths(topLevelContainer.codingPath, [], "New first-level keyed container has non-empty codingPath.")
+
+      let superEncoder = topLevelContainer.superEncoder(forKey: .a)
+      XCTAssertEqualPaths(encoder.codingPath, [], "Top-level Encoder's codingPath changed.")
+      XCTAssertEqualPaths(topLevelContainer.codingPath, [], "First-level keyed container's codingPath changed.")
+      XCTAssertEqualPaths(superEncoder.codingPath, [TopLevelCodingKeys.a], "New superEncoder had unexpected codingPath.")
+      _testNestedContainers(in: superEncoder, baseCodingPath: [TopLevelCodingKeys.a])
+    } else {
+      _testNestedContainers(in: encoder, baseCodingPath: [])
+    }
+  }
+
+  func _testNestedContainers(in encoder: Encoder, baseCodingPath: [CodingKey]) {
+    XCTAssertEqualPaths(encoder.codingPath, baseCodingPath, "New encoder has non-empty codingPath.")
+
+    // codingPath should not change upon fetching a non-nested container.
+    var firstLevelContainer = encoder.container(keyedBy: TopLevelCodingKeys.self)
+    XCTAssertEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+    XCTAssertEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "New first-level keyed container has non-empty codingPath.")
+
+    // Nested Keyed Container
+    do {
+      // Nested container for key should have a new key pushed on.
+      var secondLevelContainer = firstLevelContainer.nestedContainer(keyedBy: IntermediateCodingKeys.self, forKey: .a)
+      XCTAssertEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+      XCTAssertEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
+      XCTAssertEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.a], "New second-level keyed container had unexpected codingPath.")
+
+      // Inserting a keyed container should not change existing coding paths.
+      let thirdLevelContainerKeyed = secondLevelContainer.nestedContainer(keyedBy: IntermediateCodingKeys.self, forKey: .one)
+      XCTAssertEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+      XCTAssertEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
+      XCTAssertEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.a], "Second-level keyed container's codingPath changed.")
+      XCTAssertEqualPaths(thirdLevelContainerKeyed.codingPath, baseCodingPath + [TopLevelCodingKeys.a, IntermediateCodingKeys.one], "New third-level keyed container had unexpected codingPath.")
+
+      // Inserting an unkeyed container should not change existing coding paths.
+      let thirdLevelContainerUnkeyed = secondLevelContainer.nestedUnkeyedContainer(forKey: .two)
+      XCTAssertEqualPaths(encoder.codingPath, baseCodingPath + [], "Top-level Encoder's codingPath changed.")
+      XCTAssertEqualPaths(firstLevelContainer.codingPath, baseCodingPath + [], "First-level keyed container's codingPath changed.")
+      XCTAssertEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.a], "Second-level keyed container's codingPath changed.")
+      XCTAssertEqualPaths(thirdLevelContainerUnkeyed.codingPath, baseCodingPath + [TopLevelCodingKeys.a, IntermediateCodingKeys.two], "New third-level unkeyed container had unexpected codingPath.")
+    }
+
+    // Nested Unkeyed Container
+    do {
+      // Nested container for key should have a new key pushed on.
+      var secondLevelContainer = firstLevelContainer.nestedUnkeyedContainer(forKey: .b)
+      XCTAssertEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+      XCTAssertEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
+      XCTAssertEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.b], "New second-level keyed container had unexpected codingPath.")
+
+      // Appending a keyed container should not change existing coding paths.
+      let thirdLevelContainerKeyed = secondLevelContainer.nestedContainer(keyedBy: IntermediateCodingKeys.self)
+      XCTAssertEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+      XCTAssertEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
+      XCTAssertEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.b], "Second-level unkeyed container's codingPath changed.")
+      XCTAssertEqualPaths(thirdLevelContainerKeyed.codingPath, baseCodingPath + [TopLevelCodingKeys.b, _TestKey(index: 0)], "New third-level keyed container had unexpected codingPath.")
+
+      // Appending an unkeyed container should not change existing coding paths.
+      let thirdLevelContainerUnkeyed = secondLevelContainer.nestedUnkeyedContainer()
+      XCTAssertEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
+      XCTAssertEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
+      XCTAssertEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.b], "Second-level unkeyed container's codingPath changed.")
+      XCTAssertEqualPaths(thirdLevelContainerUnkeyed.codingPath, baseCodingPath + [TopLevelCodingKeys.b, _TestKey(index: 1)], "New third-level unkeyed container had unexpected codingPath.")
+    }
+  }
+}
+
+// MARK: - Helper Types
+
+/// A key type which can take on any string or integer value.
+/// This needs to mirror _PlistKey.
+fileprivate struct _TestKey : CodingKey {
+  var stringValue: String
+  var intValue: Int?
+
+  init?(stringValue: String) {
+    self.stringValue = stringValue
+    self.intValue = nil
+  }
+
+  init?(intValue: Int) {
+    self.stringValue = "\(intValue)"
+    self.intValue = intValue
+  }
+
+  init(index: Int) {
+    self.stringValue = "Index \(index)"
+    self.intValue = index
+  }
+}
+
+/// Wraps a type T so that it can be encoded at the top level of a payload.
+fileprivate struct TopLevelWrapper<T> : Codable, Equatable where T : Codable, T : Equatable {
+  let value: T
+
+  init(_ value: T) {
+    self.value = value
+  }
+
+  static func ==(_ lhs: TopLevelWrapper<T>, _ rhs: TopLevelWrapper<T>) -> Bool {
+    return lhs.value == rhs.value
+  }
+}
+
+fileprivate enum EitherDecodable<T : Decodable, U : Decodable> : Decodable {
+  case t(T)
+  case u(U)
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if let t = try? container.decode(T.self) {
+      self = .t(t)
+    } else if let u = try? container.decode(U.self) {
+      self = .u(u)
+    } else {
+      throw DecodingError.dataCorruptedError(in: container, debugDescription: "Data was neither \(T.self) nor \(U.self).")
+    }
+  }
+}
+

--- a/Darwin/Foundation-swiftoverlay-Tests/TestProgress.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestProgress.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+class TestProgress : XCTestCase {
+    func testUserInfoConveniences() {
+        if #available(OSX 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
+            let p = Progress(parent:nil, userInfo: nil)
+            
+            XCTAssertNil(p.userInfo[.throughputKey])
+            XCTAssertNil(p.throughput)
+            p.throughput = 50
+            XCTAssertEqual(p.throughput, 50)
+            XCTAssertNotNil(p.userInfo[.throughputKey])
+            
+            XCTAssertNil(p.userInfo[.estimatedTimeRemainingKey])
+            XCTAssertNil(p.estimatedTimeRemaining)
+            p.estimatedTimeRemaining = 100
+            XCTAssertEqual(p.estimatedTimeRemaining, 100)
+            XCTAssertNotNil(p.userInfo[.estimatedTimeRemainingKey])
+            
+            XCTAssertNil(p.userInfo[.fileTotalCountKey])
+            XCTAssertNil(p.fileTotalCount)
+            p.fileTotalCount = 42
+            XCTAssertEqual(p.fileTotalCount, 42)
+            XCTAssertNotNil(p.userInfo[.fileTotalCountKey])
+            
+            XCTAssertNil(p.userInfo[.fileCompletedCountKey])
+            XCTAssertNil(p.fileCompletedCount)
+            p.fileCompletedCount = 24
+            XCTAssertEqual(p.fileCompletedCount, 24)
+            XCTAssertNotNil(p.userInfo[.fileCompletedCountKey])
+        }
+    }
+    
+    func testPerformAsCurrent() {
+        if #available(OSX 10.11, iOS 8.0, *) {
+            // This test can be enabled once <rdar://problem/31867347> is in the SDK
+            /*
+            let p = Progress.discreteProgress(totalUnitCount: 10)
+            let r = p.performAsCurrent(withPendingUnitCount: 10) {
+                XCTAssertNotNil(Progress.current())
+                return 42
+            }
+            XCTAssertEqual(r, 42)
+            XCTAssertEqual(p.completedUnitCount, 10)
+            XCTAssertNil(Progress.current())
+            */
+        }
+    }
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestTimeZone.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestTimeZone.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+class TestTimeZone : XCTestCase {
+    
+    func test_timeZoneBasics() {
+        let tz = TimeZone(identifier: "America/Los_Angeles")!
+        
+        XCTAssertTrue(!tz.identifier.isEmpty)
+    }
+    
+    func test_bridgingAutoupdating() {
+        let tester = TimeZoneBridgingTester()
+        
+        do {
+            let tz = TimeZone.autoupdatingCurrent
+            let result = tester.verifyAutoupdating(tz)
+            XCTAssertTrue(result)
+        }
+        
+        // Round trip an autoupdating calendar
+        do {
+            let tz = tester.autoupdatingCurrentTimeZone()
+            let result = tester.verifyAutoupdating(tz)
+            XCTAssertTrue(result)
+        }
+    }
+    
+    func test_equality() {
+        let autoupdating = TimeZone.autoupdatingCurrent
+        let autoupdating2 = TimeZone.autoupdatingCurrent
+
+        XCTAssertEqual(autoupdating, autoupdating2)
+        
+        let current = TimeZone.current
+        
+        XCTAssertNotEqual(autoupdating, current)
+    }
+
+    func test_AnyHashableContainingTimeZone() {
+        let values: [TimeZone] = [
+            TimeZone(identifier: "America/Los_Angeles")!,
+            TimeZone(identifier: "Europe/Kiev")!,
+            TimeZone(identifier: "Europe/Kiev")!,
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(TimeZone.self, type(of: anyHashables[0].base))
+        expectEqual(TimeZone.self, type(of: anyHashables[1].base))
+        expectEqual(TimeZone.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableCreatedFromNSTimeZone() {
+        let values: [NSTimeZone] = [
+            NSTimeZone(name: "America/Los_Angeles")!,
+            NSTimeZone(name: "Europe/Kiev")!,
+            NSTimeZone(name: "Europe/Kiev")!,
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(TimeZone.self, type(of: anyHashables[0].base))
+        expectEqual(TimeZone.self, type(of: anyHashables[1].base))
+        expectEqual(TimeZone.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestURL.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestURL.swift
@@ -1,0 +1,410 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+class TestURL : XCTestCase {
+    
+    func testBasics() {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+        
+        XCTAssertTrue(url.pathComponents.count > 0)
+    }
+    
+    func testProperties() {
+        let url = URL(fileURLWithPath: "/")
+        do {
+            let resourceValues = try url.resourceValues(forKeys: [.isVolumeKey, .nameKey])
+            if let isVolume = resourceValues.isVolume {
+                XCTAssertTrue(isVolume)
+            }
+            XCTAssertNotNil(resourceValues.name)
+        } catch {
+            XCTAssertTrue(false, "Should not have thrown")
+        }
+    }
+    
+    func testSetProperties() {
+        // Create a temporary file
+        var file = URL(fileURLWithPath: NSTemporaryDirectory())
+        let name = "my_great_file" + UUID().uuidString
+        file.appendPathComponent(name)
+        let data = Data(bytes: [1, 2, 3, 4, 5])
+        do {
+            try data.write(to: file)
+        } catch {
+            XCTAssertTrue(false, "Unable to write data")
+        }
+        
+        // Modify an existing resource value
+        do {
+            var resourceValues = try file.resourceValues(forKeys: [.nameKey])
+            XCTAssertNotNil(resourceValues.name)
+            XCTAssertEqual(resourceValues.name!, name)
+            
+            let newName = "goodbye cruel " + UUID().uuidString
+            resourceValues.name = newName
+            try file.setResourceValues(resourceValues)
+        } catch {
+            XCTAssertTrue(false, "Unable to set resources")
+        }
+    }
+    
+#if os(macOS)
+    func testQuarantineProperties() {
+        // Test the quarantine stuff; it has special logic
+        if #available(OSX 10.11, iOS 9.0, *) {
+            // Create a temporary file
+            var file = URL(fileURLWithPath: NSTemporaryDirectory())
+            let name = "my_great_file" + UUID().uuidString
+            file.appendPathComponent(name)
+            let data = Data(bytes: [1, 2, 3, 4, 5])
+            do {
+                try data.write(to: file)
+            } catch {
+                XCTAssertTrue(false, "Unable to write data")
+            }
+
+            // Set the quarantine info on a file
+            do {
+                var resourceValues = URLResourceValues()
+                resourceValues.quarantineProperties = ["LSQuarantineAgentName" : "TestURL"]
+                try file.setResourceValues(resourceValues)
+            } catch {
+                XCTAssertTrue(false, "Unable to set quarantine info")
+            }
+            
+            // Get the quarantine info back
+            do {
+                var resourceValues = try file.resourceValues(forKeys: [.quarantinePropertiesKey])
+                XCTAssertEqual(resourceValues.quarantineProperties?["LSQuarantineAgentName"] as? String, "TestURL")
+            } catch {
+                XCTAssertTrue(false, "Unable to get quarantine info")
+            }
+            
+            // Clear the quarantine info
+            do {
+                var resourceValues = URLResourceValues()
+                resourceValues.quarantineProperties = nil // this effectively sets a flag
+                try file.setResourceValues(resourceValues)
+                
+                // Make sure that the resourceValues property returns nil
+                XCTAssertNil(resourceValues.quarantineProperties)
+            } catch {
+                XCTAssertTrue(false, "Unable to clear quarantine info")
+            }
+
+            // Get the quarantine info back again
+            do {
+                var resourceValues = try file.resourceValues(forKeys: [.quarantinePropertiesKey])
+                XCTAssertNil(resourceValues.quarantineProperties)
+            } catch {
+                XCTAssertTrue(false, "Unable to get quarantine info after clearing")
+            }
+
+        }
+    }
+#endif
+    
+    func testMoreSetProperties() {
+        // Create a temporary file
+        var file = URL(fileURLWithPath: NSTemporaryDirectory())
+        let name = "my_great_file" + UUID().uuidString
+        file.appendPathComponent(name)
+        let data = Data(bytes: [1, 2, 3, 4, 5])
+        do {
+            try data.write(to: file)
+        } catch {
+            XCTAssertTrue(false, "Unable to write data")
+        }
+
+        do {
+            var resourceValues = try file.resourceValues(forKeys: [.labelNumberKey])
+            XCTAssertNotNil(resourceValues.labelNumber)
+            
+            // set label number
+            resourceValues.labelNumber = 1
+            try file.setResourceValues(resourceValues)
+            
+            // get label number
+            let _ = try file.resourceValues(forKeys: [.labelNumberKey])
+            XCTAssertNotNil(resourceValues.labelNumber)
+            XCTAssertEqual(resourceValues.labelNumber!, 1)
+        } catch (let e as NSError) {
+            XCTAssertTrue(false, "Unable to load or set resources \(e)")
+        } catch {
+            XCTAssertTrue(false, "Unable to load or set resources (mysterious error)")
+        }
+        
+        // Construct values from scratch
+        do {
+            var resourceValues = URLResourceValues()
+            resourceValues.labelNumber = 2
+            
+            try file.setResourceValues(resourceValues)
+            let resourceValues2 = try file.resourceValues(forKeys: [.labelNumberKey])
+            XCTAssertNotNil(resourceValues2.labelNumber)
+            XCTAssertEqual(resourceValues2.labelNumber!, 2)
+        } catch (let e as NSError) {
+            XCTAssertTrue(false, "Unable to load or set resources \(e)")
+        } catch {
+            XCTAssertTrue(false, "Unable to load or set resources (mysterious error)")
+        }
+        
+        do {
+            try FileManager.default.removeItem(at: file)
+        } catch {
+            XCTAssertTrue(false, "Unable to remove file")
+        }
+
+    }
+    
+    func testURLComponents() {
+        // Not meant to be a test of all URL components functionality, just some basic bridging stuff
+        let s = "http://www.apple.com/us/search/ipad?src=global%7Cnav"
+        var components = URLComponents(string: s)!
+        XCTAssertNotNil(components)
+        
+        XCTAssertNotNil(components.host)
+        XCTAssertEqual("www.apple.com", components.host)
+        
+        
+        if #available(OSX 10.11, iOS 9.0, *) {
+            let rangeOfHost = components.rangeOfHost!
+            XCTAssertNotNil(rangeOfHost)
+            XCTAssertEqual(s[rangeOfHost], "www.apple.com")
+        }
+        
+        if #available(OSX 10.10, iOS 8.0, *) {
+            let qi = components.queryItems!
+            XCTAssertNotNil(qi)
+            
+            XCTAssertEqual(1, qi.count)
+            let first = qi[0]
+            
+            XCTAssertEqual("src", first.name)
+            XCTAssertNotNil(first.value)
+            XCTAssertEqual("global|nav", first.value)
+        }
+
+        if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+            components.percentEncodedQuery = "name1%E2%80%A2=value1%E2%80%A2&name2%E2%80%A2=value2%E2%80%A2"
+            var qi = components.queryItems!
+            XCTAssertNotNil(qi)
+            
+            XCTAssertEqual(2, qi.count)
+            
+            XCTAssertEqual("name1•", qi[0].name)
+            XCTAssertNotNil(qi[0].value)
+            XCTAssertEqual("value1•", qi[0].value)
+            
+            XCTAssertEqual("name2•", qi[1].name)
+            XCTAssertNotNil(qi[1].value)
+            XCTAssertEqual("value2•", qi[1].value)
+            
+            qi = components.percentEncodedQueryItems!
+            XCTAssertNotNil(qi)
+            
+            XCTAssertEqual(2, qi.count)
+            
+            XCTAssertEqual("name1%E2%80%A2", qi[0].name)
+            XCTAssertNotNil(qi[0].value)
+            XCTAssertEqual("value1%E2%80%A2", qi[0].value)
+            
+            XCTAssertEqual("name2%E2%80%A2", qi[1].name)
+            XCTAssertNotNil(qi[0].value)
+            XCTAssertEqual("value2%E2%80%A2", qi[1].value)
+            
+            qi[0].name = "%E2%80%A2name1"
+            qi[0].value = "%E2%80%A2value1"
+            qi[1].name = "%E2%80%A2name2"
+            qi[1].value = "%E2%80%A2value2"
+            
+            components.percentEncodedQueryItems = qi
+            
+            XCTAssertEqual("%E2%80%A2name1=%E2%80%A2value1&%E2%80%A2name2=%E2%80%A2value2", components.percentEncodedQuery)
+        }
+    }
+    
+    func testURLResourceValues() {
+        
+        let fileName = "temp_file"
+        var dir = URL(fileURLWithPath: NSTemporaryDirectory())
+        dir.appendPathComponent(UUID().uuidString)
+        
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true, attributes: nil)
+        
+        dir.appendPathComponent(fileName)
+        try! Data(bytes: [1,2,3,4]).write(to: dir)
+        
+        defer {
+            do {
+                try FileManager.default.removeItem(at: dir)
+            } catch {
+                // Oh well
+            }
+        }
+        
+        do {
+            let values = try dir.resourceValues(forKeys: [.nameKey, .isDirectoryKey])
+            XCTAssertEqual(values.name, fileName)
+            XCTAssertFalse(values.isDirectory!)
+            XCTAssertEqual(nil, values.creationDate) // Didn't ask for this
+        } catch {
+            XCTAssertTrue(false, "Unable to get resource value")
+        }
+        
+        let originalDate : Date
+        do {
+            var values = try dir.resourceValues(forKeys: [.creationDateKey])
+            XCTAssertNotEqual(nil, values.creationDate)
+            originalDate = values.creationDate!
+        } catch {
+            originalDate = Date()
+            XCTAssertTrue(false, "Unable to get creation date")
+        }
+        
+        let newDate = originalDate + 100
+        
+        do {
+            var values = URLResourceValues()
+            values.creationDate = newDate
+            try dir.setResourceValues(values)
+        } catch {
+            XCTAssertTrue(false, "Unable to set resource value")
+        }
+        
+        do {
+            let values = try dir.resourceValues(forKeys: [.creationDateKey])
+            XCTAssertEqual(newDate, values.creationDate)
+        } catch {
+            XCTAssertTrue(false, "Unable to get values")
+        }
+    }
+
+    func test_AnyHashableContainingURL() {
+        let values: [URL] = [
+            URL(string: "https://example.com/")!,
+            URL(string: "https://example.org/")!,
+            URL(string: "https://example.org/")!,
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(URL.self, type(of: anyHashables[0].base))
+        expectEqual(URL.self, type(of: anyHashables[1].base))
+        expectEqual(URL.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableCreatedFromNSURL() {
+        let values: [NSURL] = [
+            NSURL(string: "https://example.com/")!,
+            NSURL(string: "https://example.org/")!,
+            NSURL(string: "https://example.org/")!,
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(URL.self, type(of: anyHashables[0].base))
+        expectEqual(URL.self, type(of: anyHashables[1].base))
+        expectEqual(URL.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableContainingURLComponents() {
+        let values: [URLComponents] = [
+            URLComponents(string: "https://example.com/")!,
+            URLComponents(string: "https://example.org/")!,
+            URLComponents(string: "https://example.org/")!,
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(URLComponents.self, type(of: anyHashables[0].base))
+        expectEqual(URLComponents.self, type(of: anyHashables[1].base))
+        expectEqual(URLComponents.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableCreatedFromNSURLComponents() {
+        let values: [NSURLComponents] = [
+            NSURLComponents(string: "https://example.com/")!,
+            NSURLComponents(string: "https://example.org/")!,
+            NSURLComponents(string: "https://example.org/")!,
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(URLComponents.self, type(of: anyHashables[0].base))
+        expectEqual(URLComponents.self, type(of: anyHashables[1].base))
+        expectEqual(URLComponents.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableContainingURLQueryItem() {
+        if #available(OSX 10.10, iOS 8.0, *) {
+            let values: [URLQueryItem] = [
+                URLQueryItem(name: "foo", value: nil),
+                URLQueryItem(name: "bar", value: nil),
+                URLQueryItem(name: "bar", value: nil),
+            ]
+            let anyHashables = values.map(AnyHashable.init)
+            expectEqual(URLQueryItem.self, type(of: anyHashables[0].base))
+            expectEqual(URLQueryItem.self, type(of: anyHashables[1].base))
+            expectEqual(URLQueryItem.self, type(of: anyHashables[2].base))
+            XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+            XCTAssertEqual(anyHashables[1], anyHashables[2])
+        }
+    }
+
+    func test_AnyHashableCreatedFromNSURLQueryItem() {
+        if #available(OSX 10.10, iOS 8.0, *) {
+            let values: [NSURLQueryItem] = [
+                NSURLQueryItem(name: "foo", value: nil),
+                NSURLQueryItem(name: "bar", value: nil),
+                NSURLQueryItem(name: "bar", value: nil),
+            ]
+            let anyHashables = values.map(AnyHashable.init)
+            expectEqual(URLQueryItem.self, type(of: anyHashables[0].base))
+            expectEqual(URLQueryItem.self, type(of: anyHashables[1].base))
+            expectEqual(URLQueryItem.self, type(of: anyHashables[2].base))
+            XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+            XCTAssertEqual(anyHashables[1], anyHashables[2])
+        }
+    }
+
+    func test_AnyHashableContainingURLRequest() {
+        let values: [URLRequest] = [
+            URLRequest(url: URL(string: "https://example.com/")!),
+            URLRequest(url: URL(string: "https://example.org/")!),
+            URLRequest(url: URL(string: "https://example.org/")!),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(URLRequest.self, type(of: anyHashables[0].base))
+        expectEqual(URLRequest.self, type(of: anyHashables[1].base))
+        expectEqual(URLRequest.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableCreatedFromNSURLRequest() {
+        let values: [NSURLRequest] = [
+            NSURLRequest(url: URL(string: "https://example.com/")!),
+            NSURLRequest(url: URL(string: "https://example.org/")!),
+            NSURLRequest(url: URL(string: "https://example.org/")!),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(URLRequest.self, type(of: anyHashables[0].base))
+        expectEqual(URLRequest.self, type(of: anyHashables[1].base))
+        expectEqual(URLRequest.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+}

--- a/Darwin/Foundation-swiftoverlay-Tests/TestUUID.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestUUID.swift
@@ -1,0 +1,133 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+class TestUUID : XCTestCase {
+    func test_NS_Equality() {
+        let uuidA = NSUUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")
+        let uuidB = NSUUID(uuidString: "e621e1f8-c36c-495a-93fc-0c247a3e6e5f")
+        let uuidC = NSUUID(uuidBytes: [0xe6,0x21,0xe1,0xf8,0xc3,0x6c,0x49,0x5a,0x93,0xfc,0x0c,0x24,0x7a,0x3e,0x6e,0x5f])
+        let uuidD = NSUUID()
+        
+        XCTAssertEqual(uuidA, uuidB, "String case must not matter.")
+        XCTAssertEqual(uuidA, uuidC, "A UUID initialized with a string must be equal to the same UUID initialized with its UnsafePointer<UInt8> equivalent representation.")
+        XCTAssertNotEqual(uuidC, uuidD, "Two different UUIDs must not be equal.")
+    }
+    
+    func test_Equality() {
+        let uuidA = UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")
+        let uuidB = UUID(uuidString: "e621e1f8-c36c-495a-93fc-0c247a3e6e5f")
+        let uuidC = UUID(uuid: uuid_t(0xe6,0x21,0xe1,0xf8,0xc3,0x6c,0x49,0x5a,0x93,0xfc,0x0c,0x24,0x7a,0x3e,0x6e,0x5f))
+        let uuidD = UUID()
+        
+        XCTAssertEqual(uuidA, uuidB, "String case must not matter.")
+        XCTAssertEqual(uuidA, uuidC, "A UUID initialized with a string must be equal to the same UUID initialized with its UnsafePointer<UInt8> equivalent representation.")
+        XCTAssertNotEqual(uuidC, uuidD, "Two different UUIDs must not be equal.")
+    }
+    
+    func test_NS_InvalidUUID() {
+        let uuid = NSUUID(uuidString: "Invalid UUID")
+        XCTAssertNil(uuid, "The convenience initializer `init?(uuidString string:)` must return nil for an invalid UUID string.")
+    }
+    
+    func test_InvalidUUID() {
+        let uuid = UUID(uuidString: "Invalid UUID")
+        XCTAssertNil(uuid, "The convenience initializer `init?(uuidString string:)` must return nil for an invalid UUID string.")
+    }
+    
+    func test_NS_uuidString() {
+        let uuid = NSUUID(uuidBytes: [0xe6,0x21,0xe1,0xf8,0xc3,0x6c,0x49,0x5a,0x93,0xfc,0x0c,0x24,0x7a,0x3e,0x6e,0x5f])
+        XCTAssertEqual(uuid.uuidString, "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")
+    }
+    
+    func test_uuidString() {
+        let uuid = UUID(uuid: uuid_t(0xe6,0x21,0xe1,0xf8,0xc3,0x6c,0x49,0x5a,0x93,0xfc,0x0c,0x24,0x7a,0x3e,0x6e,0x5f))
+        XCTAssertEqual(uuid.uuidString, "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")
+    }
+    
+    func test_description() {
+        let uuid = UUID()
+        XCTAssertEqual(uuid.description, uuid.uuidString, "The description must be the same as the uuidString.")
+    }
+
+    func test_roundTrips() {
+        let ref = NSUUID()
+        let valFromRef = ref as UUID
+        var bytes: [UInt8] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+        let valFromBytes = bytes.withUnsafeMutableBufferPointer { buffer -> UUID in
+            ref.getBytes(buffer.baseAddress!)
+            return UUID(uuid: UnsafeRawPointer(buffer.baseAddress!).load(as: uuid_t.self))
+        }
+        let valFromStr = UUID(uuidString: ref.uuidString)
+        XCTAssertEqual(ref.uuidString, valFromRef.uuidString)
+        XCTAssertEqual(ref.uuidString, valFromBytes.uuidString)
+        XCTAssertNotNil(valFromStr)
+        XCTAssertEqual(ref.uuidString, valFromStr!.uuidString)
+    }
+    
+    func test_hash() {
+        guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else { return }
+        let values: [UUID] = [
+            // This list takes a UUID and tweaks every byte while
+            // leaving the version/variant intact.
+            UUID(uuidString: "a53baa1c-b4f5-48db-9467-9786b76b256c")!,
+            UUID(uuidString: "a63baa1c-b4f5-48db-9467-9786b76b256c")!,
+            UUID(uuidString: "a53caa1c-b4f5-48db-9467-9786b76b256c")!,
+            UUID(uuidString: "a53bab1c-b4f5-48db-9467-9786b76b256c")!,
+            UUID(uuidString: "a53baa1d-b4f5-48db-9467-9786b76b256c")!,
+            UUID(uuidString: "a53baa1c-b5f5-48db-9467-9786b76b256c")!,
+            UUID(uuidString: "a53baa1c-b4f6-48db-9467-9786b76b256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-49db-9467-9786b76b256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48dc-9467-9786b76b256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48db-9567-9786b76b256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48db-9468-9786b76b256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48db-9467-9886b76b256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48db-9467-9787b76b256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48db-9467-9786b86b256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48db-9467-9786b76c256c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48db-9467-9786b76b266c")!,
+            UUID(uuidString: "a53baa1c-b4f5-48db-9467-9786b76b256d")!,
+        ]
+        checkHashable(values, equalityOracle: { $0 == $1 })
+    }
+
+    func test_AnyHashableContainingUUID() {
+        let values: [UUID] = [
+            UUID(uuidString: "e621e1f8-c36c-495a-93fc-0c247a3e6e5f")!,
+            UUID(uuidString: "f81d4fae-7dec-11d0-a765-00a0c91e6bf6")!,
+            UUID(uuidString: "f81d4fae-7dec-11d0-a765-00a0c91e6bf6")!,
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(UUID.self, type(of: anyHashables[0].base))
+        expectEqual(UUID.self, type(of: anyHashables[1].base))
+        expectEqual(UUID.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableCreatedFromNSUUID() {
+        let values: [NSUUID] = [
+            NSUUID(uuidString: "e621e1f8-c36c-495a-93fc-0c247a3e6e5f")!,
+            NSUUID(uuidString: "f81d4fae-7dec-11d0-a765-00a0c91e6bf6")!,
+            NSUUID(uuidString: "f81d4fae-7dec-11d0-a765-00a0c91e6bf6")!,
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(UUID.self, type(of: anyHashables[0].base))
+        expectEqual(UUID.self, type(of: anyHashables[1].base))
+        expectEqual(UUID.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+}
+

--- a/Darwin/Foundation-swiftoverlay-Tests/TestUserInfo.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestUserInfo.swift
@@ -1,0 +1,170 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+struct SubStruct: Equatable {
+    var i: Int
+    var str: String
+
+    static func ==(lhs: SubStruct, rhs: SubStruct) -> Bool {
+        return lhs.i == rhs.i && 
+               lhs.str == rhs.str
+    }
+}
+
+struct SomeStructure: Hashable {
+    var i: Int
+    var str: String
+    var sub: SubStruct
+
+    static func ==(lhs: SomeStructure, rhs: SomeStructure) -> Bool {
+        return lhs.i == rhs.i && 
+               lhs.str == rhs.str && 
+               lhs.sub == rhs.sub
+    }
+
+    // FIXME: we don't care about this, but Any only finds == on Hashables
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(i)
+        hasher.combine(str)
+        hasher.combine(sub.i)
+        hasher.combine(sub.str)
+    }
+}
+
+/*
+ Notification and potentially other structures require a representation of a 
+ userInfo dictionary. The Objective-C counterparts are represented via
+ NSDictionary which can only store a hashable key (actually 
+ NSObject<NSCopying> *) and a value of AnyObject (actually NSObject *). However
+ it is desired in swift to store Any in the value. These structure expositions
+ in swift have an adapter that allows them to pass a specialized NSDictionary
+ subclass to the Objective-C layer that can round trip the stored Any types back
+ out into Swift.
+
+ In this case NSNotification -> Notification bridging is suitable to verify that
+ behavior.
+*/
+
+class TestUserInfo : XCTestCase {
+    var posted: Notification?
+
+    func validate(_ testStructure: SomeStructure, _ value: SomeStructure) {
+        XCTAssertEqual(testStructure.i, value.i)
+        XCTAssertEqual(testStructure.str, value.str)
+        XCTAssertEqual(testStructure.sub.i, value.sub.i)
+        XCTAssertEqual(testStructure.sub.str, value.sub.str)
+    }
+
+    func test_userInfoPost() {
+        let userInfoKey = "userInfoKey"
+        let notifName = Notification.Name(rawValue: "TestSwiftNotification")
+        let testStructure = SomeStructure(i: 5, str: "10", sub: SubStruct(i: 6, str: "11"))
+        let info: [AnyHashable : Any] = [
+            AnyHashable(userInfoKey) : testStructure
+        ]
+        let note = Notification(name: notifName, userInfo: info)
+        XCTAssertNotNil(note.userInfo)
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(TestUserInfo.notification(_:)), name: notifName, object: nil)
+        nc.post(note)
+        XCTAssertNotNil(posted)
+        if let notification = posted {
+            let postedInfo = notification.userInfo
+            XCTAssertNotNil(postedInfo)
+            if let userInfo = postedInfo {
+                let postedValue = userInfo[AnyHashable(userInfoKey)] as? SomeStructure
+                XCTAssertNotNil(postedValue)
+                if let value = postedValue {
+                    validate(testStructure, value)
+                }
+            }
+        }
+    }
+
+    func test_equality() {
+        let userInfoKey = "userInfoKey"
+        let notifName = Notification.Name(rawValue: "TestSwiftNotification")
+        let testStructure = SomeStructure(i: 5, str: "10", sub: SubStruct(i: 6, str: "11"))
+        let testStructure2 = SomeStructure(i: 6, str: "10", sub: SubStruct(i: 6, str: "11"))
+        let info1: [AnyHashable : Any] = [
+            AnyHashable(userInfoKey) : testStructure
+        ]
+        let info2: [AnyHashable : Any] = [
+            AnyHashable(userInfoKey) : "this can convert"
+        ]
+        let info3: [AnyHashable : Any] = [
+            AnyHashable(userInfoKey) : testStructure2
+        ]
+
+        let note1 = Notification(name: notifName, userInfo: info1)
+        let note2 = Notification(name: notifName, userInfo: info1)
+        XCTAssertEqual(note1, note2)
+
+        let note3 = Notification(name: notifName, userInfo: info2)
+        let note4 = Notification(name: notifName, userInfo: info2)
+        XCTAssertEqual(note3, note4)
+
+        let note5 = Notification(name: notifName, userInfo: info3)
+        XCTAssertNotEqual(note1, note5)
+    }
+
+    @objc func notification(_ notif: Notification) {
+        posted = notif
+    }
+
+    // MARK: -
+    func test_classForCoder() {
+        // confirm internal bridged impl types are not exposed to archival machinery
+        // we have to be circuitous here, as bridging makes it very difficult to confirm this
+        //
+        // Gated on the availability of NSKeyedArchiver.archivedData(withRootObject:).
+        if #available(macOS 10.11, iOS 9.0, tvOS 9.0, watchOS 2.0, *) {
+            let note = Notification(name: Notification.Name(rawValue: "TestSwiftNotification"), userInfo: [AnyHashable("key"):"value"])
+            let archivedNote = NSKeyedArchiver.archivedData(withRootObject: note)
+            let noteAsPlist = try! PropertyListSerialization.propertyList(from: archivedNote, options: [], format: nil)
+            let plistAsData = try! PropertyListSerialization.data(fromPropertyList: noteAsPlist, format: .xml, options: 0)
+            let xml = NSString(data: plistAsData, encoding: String.Encoding.utf8.rawValue)!
+            XCTAssertEqual(xml.range(of: "_NSUserInfoDictionary").location, NSNotFound)
+        }
+    }
+
+    func test_AnyHashableContainingNotification() {
+        let values: [Notification] = [
+            Notification(name: Notification.Name(rawValue: "TestSwiftNotification")),
+            Notification(name: Notification.Name(rawValue: "TestOtherSwiftNotification")),
+            Notification(name: Notification.Name(rawValue: "TestOtherSwiftNotification")),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(Notification.self, type(of: anyHashables[0].base))
+        expectEqual(Notification.self, type(of: anyHashables[1].base))
+        expectEqual(Notification.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableCreatedFromNSNotification() {
+        let values: [NSNotification] = [
+            NSNotification(name: Notification.Name(rawValue: "TestSwiftNotification"), object: nil),
+            NSNotification(name: Notification.Name(rawValue: "TestOtherSwiftNotification"), object: nil),
+            NSNotification(name: Notification.Name(rawValue: "TestOtherSwiftNotification"), object: nil),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(Notification.self, type(of: anyHashables[0].base))
+        expectEqual(Notification.self, type(of: anyHashables[1].base))
+        expectEqual(Notification.self, type(of: anyHashables[2].base))
+        XCTAssertNotEqual(anyHashables[0], anyHashables[1])
+        XCTAssertEqual(anyHashables[1], anyHashables[2])
+    }
+}

--- a/Darwin/Foundation-swiftoverlay.xcodeproj/project.pbxproj
+++ b/Darwin/Foundation-swiftoverlay.xcodeproj/project.pbxproj
@@ -1,0 +1,1003 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		15F987BD2475AB6E00451F92 /* Combine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15F987BC2475AB6E00451F92 /* Combine.framework */; };
+		7D0AE23323886AE9001948BD /* magic-symbols-for-install-name.c in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE23223886AE9001948BD /* magic-symbols-for-install-name.c */; };
+		7D0AE23A23886B53001948BD /* BundleLookup.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE23423886B50001948BD /* BundleLookup.mm */; };
+		7D0AE23B23886B53001948BD /* Calendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE23523886B50001948BD /* Calendar.swift */; };
+		7D0AE23C23886B53001948BD /* CharacterSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE23623886B51001948BD /* CharacterSet.swift */; };
+		7D0AE23E23886B53001948BD /* AffineTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE23823886B52001948BD /* AffineTransform.swift */; };
+		7D0AE23F23886B53001948BD /* Boxing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE23923886B53001948BD /* Boxing.swift */; };
+		7D0AE26F23886B83001948BD /* NSItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE24023886B65001948BD /* NSItemProvider.swift */; };
+		7D0AE27023886B83001948BD /* NSTextCheckingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE24123886B66001948BD /* NSTextCheckingResult.swift */; };
+		7D0AE27123886B83001948BD /* NSDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE24223886B67001948BD /* NSDate.swift */; };
+		7D0AE27323886B83001948BD /* CombineTypealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE24423886B68001948BD /* CombineTypealiases.swift */; };
+		7D0AE27423886B83001948BD /* IndexPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE24523886B69001948BD /* IndexPath.swift */; };
+		7D0AE27523886B83001948BD /* NSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE24623886B69001948BD /* NSError.swift */; };
+		7D0AE27623886B83001948BD /* Decimal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE24723886B6A001948BD /* Decimal.swift */; };
+		7D0AE27723886B83001948BD /* NSDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE24823886B6A001948BD /* NSDictionary.swift */; };
+		7D0AE27823886B83001948BD /* NSIndexSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE24923886B6B001948BD /* NSIndexSet.swift */; };
+		7D0AE27A23886B83001948BD /* NSArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE24B23886B6C001948BD /* NSArray.swift */; };
+		7D0AE27B23886B83001948BD /* DataThunks.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE24C23886B6D001948BD /* DataThunks.m */; };
+		7D0AE27C23886B84001948BD /* JSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE24D23886B6E001948BD /* JSONEncoder.swift */; };
+		7D0AE27E23886B84001948BD /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE24F23886B6F001948BD /* NSObject.swift */; };
+		7D0AE27F23886B84001948BD /* DataProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE25023886B6F001948BD /* DataProtocol.swift */; };
+		7D0AE28023886B84001948BD /* NSGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE25123886B70001948BD /* NSGeometry.swift */; };
+		7D0AE28123886B84001948BD /* NSNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE25223886B71001948BD /* NSNumber.swift */; };
+		7D0AE28223886B84001948BD /* NSPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE25323886B72001948BD /* NSPredicate.swift */; };
+		7D0AE28323886B84001948BD /* NSSortDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE25423886B72001948BD /* NSSortDescriptor.swift */; };
+		7D0AE28423886B84001948BD /* IndexSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE25523886B73001948BD /* IndexSet.swift */; };
+		7D0AE28523886B84001948BD /* DateComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE25623886B73001948BD /* DateComponents.swift */; };
+		7D0AE28623886B84001948BD /* NSCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE25723886B74001948BD /* NSCoder.swift */; };
+		7D0AE28723886B84001948BD /* NSExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE25823886B75001948BD /* NSExpression.swift */; };
+		7D0AE28823886B84001948BD /* DateInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE25923886B75001948BD /* DateInterval.swift */; };
+		7D0AE28923886B84001948BD /* NSSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE25A23886B76001948BD /* NSSet.swift */; };
+		7D0AE28A23886B84001948BD /* NSString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE25B23886B77001948BD /* NSString.swift */; };
+		7D0AE28B23886B84001948BD /* Measurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE25C23886B77001948BD /* Measurement.swift */; };
+		7D0AE28C23886B84001948BD /* DispatchData+DataProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE25D23886B78001948BD /* DispatchData+DataProtocol.swift */; };
+		7D0AE28D23886B84001948BD /* ContiguousBytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE25E23886B79001948BD /* ContiguousBytes.swift */; };
+		7D0AE28E23886B84001948BD /* Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE25F23886B79001948BD /* Foundation.swift */; };
+		7D0AE28F23886B84001948BD /* FileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE26023886B7A001948BD /* FileManager.swift */; };
+		7D0AE29023886B84001948BD /* NSStringAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE26123886B7B001948BD /* NSStringAPI.swift */; };
+		7D0AE29123886B84001948BD /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE26223886B7B001948BD /* Data.swift */; };
+		7D0AE29223886B84001948BD /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE26323886B7C001948BD /* Date.swift */; };
+		7D0AE29323886B85001948BD /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE26423886B7D001948BD /* Notification.swift */; };
+		7D0AE29423886B85001948BD /* NSFastEnumeration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE26523886B7D001948BD /* NSFastEnumeration.swift */; };
+		7D0AE29523886B85001948BD /* Locale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE26623886B7E001948BD /* Locale.swift */; };
+		7D0AE29623886B85001948BD /* NSOrderedCollectionDifference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE26723886B7E001948BD /* NSOrderedCollectionDifference.swift */; };
+		7D0AE29723886B85001948BD /* NSRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE26823886B7F001948BD /* NSRange.swift */; };
+		7D0AE29823886B85001948BD /* NSStringEncodings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE26923886B80001948BD /* NSStringEncodings.swift */; };
+		7D0AE29923886B85001948BD /* NSUndoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE26A23886B80001948BD /* NSUndoManager.swift */; };
+		7D0AE29A23886B85001948BD /* NSURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE26B23886B81001948BD /* NSURL.swift */; };
+		7D0AE29B23886B85001948BD /* Collections+DataProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE26C23886B82001948BD /* Collections+DataProtocol.swift */; };
+		7D0AE29C23886B85001948BD /* Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE26D23886B82001948BD /* Codable.swift */; };
+		7D0AE29D23886B85001948BD /* NSData+DataProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE26E23886B83001948BD /* NSData+DataProtocol.swift */; };
+		7D0AE2B423886B9F001948BD /* ReferenceConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE29E23886B91001948BD /* ReferenceConvertible.swift */; };
+		7D0AE2B523886B9F001948BD /* URLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE29F23886B92001948BD /* URLSession.swift */; };
+		7D0AE2B623886B9F001948BD /* Scanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2A023886B92001948BD /* Scanner.swift */; };
+		7D0AE2B723886B9F001948BD /* UUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2A123886B93001948BD /* UUID.swift */; };
+		7D0AE2B823886B9F001948BD /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2A223886B94001948BD /* String.swift */; };
+		7D0AE2B923886B9F001948BD /* Schedulers+OperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2A323886B94001948BD /* Schedulers+OperationQueue.swift */; };
+		7D0AE2BA23886B9F001948BD /* PersonNameComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2A423886B95001948BD /* PersonNameComponents.swift */; };
+		7D0AE2BB23886B9F001948BD /* Publishers+URLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2A523886B96001948BD /* Publishers+URLSession.swift */; };
+		7D0AE2BC23886B9F001948BD /* PlistEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2A623886B96001948BD /* PlistEncoder.swift */; };
+		7D0AE2BD23886B9F001948BD /* Publishers+NotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2A723886B97001948BD /* Publishers+NotificationCenter.swift */; };
+		7D0AE2BE23886B9F001948BD /* Schedulers+RunLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2A823886B98001948BD /* Schedulers+RunLoop.swift */; };
+		7D0AE2BF23886B9F001948BD /* TimeZone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2A923886B98001948BD /* TimeZone.swift */; };
+		7D0AE2C023886B9F001948BD /* Schedulers+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2AA23886B99001948BD /* Schedulers+Date.swift */; };
+		7D0AE2C123886B9F001948BD /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2AB23886B9A001948BD /* URL.swift */; };
+		7D0AE2C223886BA0001948BD /* Pointers+DataProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2AC23886B9A001948BD /* Pointers+DataProtocol.swift */; };
+		7D0AE2C323886BA0001948BD /* Publishers+Locking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2AD23886B9B001948BD /* Publishers+Locking.swift */; };
+		7D0AE2C423886BA0001948BD /* URLCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2AE23886B9C001948BD /* URLCache.swift */; };
+		7D0AE2C523886BA0001948BD /* URLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2AF23886B9C001948BD /* URLRequest.swift */; };
+		7D0AE2C623886BA0001948BD /* URLComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2B023886B9D001948BD /* URLComponents.swift */; };
+		7D0AE2C723886BA0001948BD /* Publishers+Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2B123886B9D001948BD /* Publishers+Timer.swift */; };
+		7D0AE2C823886BA0001948BD /* Progress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2B223886B9E001948BD /* Progress.swift */; };
+		7D0AE2C923886BA0001948BD /* Publishers+KeyValueObserving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE2B323886B9F001948BD /* Publishers+KeyValueObserving.swift */; };
+		7D0AE2CC23888DE0001948BD /* CheckClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0AE23723886B52001948BD /* CheckClass.swift */; };
+		7D0AE2F12388A4E5001948BD /* magic-symbols-for-install-name.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D0AE2F02388A4E5001948BD /* magic-symbols-for-install-name.h */; };
+		7D2006D722F3D3DA008DF640 /* libswiftFoundation.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D20064D22F24524008DF640 /* libswiftFoundation.dylib */; };
+		7DA3867023C804740050CCB3 /* libswiftCoreFoundation.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DA3866323C804530050CCB3 /* libswiftCoreFoundation.dylib */; };
+		7DA3867623C804B60050CCB3 /* magic-symbols-for-install-name.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DA3865823C803810050CCB3 /* magic-symbols-for-install-name.h */; };
+		7DA3867723C804BC0050CCB3 /* magic-symbols-for-install-name.c in Sources */ = {isa = PBXBuildFile; fileRef = 7DA3865723C803810050CCB3 /* magic-symbols-for-install-name.c */; };
+		7DA3867823C804BC0050CCB3 /* CoreFoundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DA3865923C803810050CCB3 /* CoreFoundation.swift */; };
+		7DA3867923C804C40050CCB3 /* CoreFoundationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DA3865D23C803810050CCB3 /* CoreFoundationTests.swift */; };
+		7DD9FCEE254A91F500E58DC4 /* NSValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DD9FCED254A91F500E58DC4 /* NSValue.swift */; };
+		7DFB966D23B174BB00D8DB10 /* TestPlistEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB966B23B174BA00D8DB10 /* TestPlistEncoder.swift */; };
+		7DFB966E23B174BB00D8DB10 /* TestUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB966C23B174BB00D8DB10 /* TestUUID.swift */; };
+		7DFB967223B174D200D8DB10 /* TestCalendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB966F23B174D200D8DB10 /* TestCalendar.swift */; };
+		7DFB967323B174D200D8DB10 /* TestNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB967023B174D200D8DB10 /* TestNotification.swift */; };
+		7DFB967423B174D200D8DB10 /* TestLocale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB967123B174D200D8DB10 /* TestLocale.swift */; };
+		7DFB967823B174E500D8DB10 /* TestIndexPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB967523B174E500D8DB10 /* TestIndexPath.swift */; };
+		7DFB967923B174E500D8DB10 /* TestNSRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB967623B174E500D8DB10 /* TestNSRange.swift */; };
+		7DFB967A23B174E500D8DB10 /* TestURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB967723B174E500D8DB10 /* TestURL.swift */; };
+		7DFB967E23B174FF00D8DB10 /* TestDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB967B23B174FF00D8DB10 /* TestDate.swift */; };
+		7DFB967F23B174FF00D8DB10 /* TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB967C23B174FF00D8DB10 /* TestData.swift */; };
+		7DFB968023B174FF00D8DB10 /* TestDateInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB967D23B174FF00D8DB10 /* TestDateInterval.swift */; };
+		7DFB968423B1751100D8DB10 /* TestDecimal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB968123B1751100D8DB10 /* TestDecimal.swift */; };
+		7DFB968523B1751100D8DB10 /* TestPersonNameComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB968223B1751100D8DB10 /* TestPersonNameComponents.swift */; };
+		7DFB968623B1751100D8DB10 /* TestFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB968323B1751100D8DB10 /* TestFileManager.swift */; };
+		7DFB968B23B1752300D8DB10 /* TestNSString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB968723B1752200D8DB10 /* TestNSString.swift */; };
+		7DFB968C23B1752300D8DB10 /* TestMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB968823B1752200D8DB10 /* TestMeasurement.swift */; };
+		7DFB968D23B1752300D8DB10 /* TestTimeZone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB968923B1752200D8DB10 /* TestTimeZone.swift */; };
+		7DFB968E23B1752300D8DB10 /* TestUserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB968A23B1752300D8DB10 /* TestUserInfo.swift */; };
+		7DFB969223B1753600D8DB10 /* TestAffineTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB968F23B1753500D8DB10 /* TestAffineTransform.swift */; };
+		7DFB969323B1753600D8DB10 /* TestCharacterSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB969023B1753600D8DB10 /* TestCharacterSet.swift */; };
+		7DFB969423B1753600D8DB10 /* TestJSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB969123B1753600D8DB10 /* TestJSONEncoder.swift */; };
+		7DFB969723B1754D00D8DB10 /* TestIndexSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB969523B1754D00D8DB10 /* TestIndexSet.swift */; };
+		7DFB969823B1754D00D8DB10 /* TestProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB969623B1754D00D8DB10 /* TestProgress.swift */; };
+		7DFB969A23B175A100D8DB10 /* CodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB969923B175A100D8DB10 /* CodableTests.swift */; };
+		7DFB969D23B17E0C00D8DB10 /* FoundationBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB969C23B17E0C00D8DB10 /* FoundationBridge.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		7DFB96A023B180F300D8DB10 /* StdlibUnittest expectEqual Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB969F23B180F300D8DB10 /* StdlibUnittest expectEqual Types.swift */; };
+		7DFB96A323B187B400D8DB10 /* StdlibUnittest checkEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB96A123B187B300D8DB10 /* StdlibUnittest checkEquatable.swift */; };
+		7DFB96A423B187B400D8DB10 /* StdlibUnittest checkHashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB96A223B187B300D8DB10 /* StdlibUnittest checkHashable.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		7D2006D422F3D3D1008DF640 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7D81A8D522E936E700739BB9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7D20064C22F24524008DF640;
+			remoteInfo = Foundation;
+		};
+		7DA3867123C804740050CCB3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7D81A8D522E936E700739BB9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7DA3866223C804530050CCB3;
+			remoteInfo = CoreFoundation;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		15F987BC2475AB6E00451F92 /* Combine.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Combine.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.16.Internal.sdk/System/Library/Frameworks/Combine.framework; sourceTree = DEVELOPER_DIR; };
+		7D0AE23223886AE9001948BD /* magic-symbols-for-install-name.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "magic-symbols-for-install-name.c"; sourceTree = "<group>"; };
+		7D0AE23423886B50001948BD /* BundleLookup.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BundleLookup.mm; sourceTree = "<group>"; };
+		7D0AE23523886B50001948BD /* Calendar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Calendar.swift; sourceTree = "<group>"; };
+		7D0AE23623886B51001948BD /* CharacterSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CharacterSet.swift; sourceTree = "<group>"; };
+		7D0AE23723886B52001948BD /* CheckClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheckClass.swift; sourceTree = "<group>"; };
+		7D0AE23823886B52001948BD /* AffineTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AffineTransform.swift; sourceTree = "<group>"; };
+		7D0AE23923886B53001948BD /* Boxing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Boxing.swift; sourceTree = "<group>"; };
+		7D0AE24023886B65001948BD /* NSItemProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSItemProvider.swift; sourceTree = "<group>"; };
+		7D0AE24123886B66001948BD /* NSTextCheckingResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTextCheckingResult.swift; sourceTree = "<group>"; };
+		7D0AE24223886B67001948BD /* NSDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDate.swift; sourceTree = "<group>"; };
+		7D0AE24423886B68001948BD /* CombineTypealiases.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CombineTypealiases.swift; sourceTree = "<group>"; };
+		7D0AE24523886B69001948BD /* IndexPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndexPath.swift; sourceTree = "<group>"; };
+		7D0AE24623886B69001948BD /* NSError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSError.swift; sourceTree = "<group>"; };
+		7D0AE24723886B6A001948BD /* Decimal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Decimal.swift; sourceTree = "<group>"; };
+		7D0AE24823886B6A001948BD /* NSDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDictionary.swift; sourceTree = "<group>"; };
+		7D0AE24923886B6B001948BD /* NSIndexSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSIndexSet.swift; sourceTree = "<group>"; };
+		7D0AE24B23886B6C001948BD /* NSArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSArray.swift; sourceTree = "<group>"; };
+		7D0AE24C23886B6D001948BD /* DataThunks.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DataThunks.m; sourceTree = "<group>"; };
+		7D0AE24D23886B6E001948BD /* JSONEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONEncoder.swift; sourceTree = "<group>"; };
+		7D0AE24F23886B6F001948BD /* NSObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSObject.swift; sourceTree = "<group>"; };
+		7D0AE25023886B6F001948BD /* DataProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataProtocol.swift; sourceTree = "<group>"; };
+		7D0AE25123886B70001948BD /* NSGeometry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSGeometry.swift; sourceTree = "<group>"; };
+		7D0AE25223886B71001948BD /* NSNumber.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSNumber.swift; sourceTree = "<group>"; };
+		7D0AE25323886B72001948BD /* NSPredicate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSPredicate.swift; sourceTree = "<group>"; };
+		7D0AE25423886B72001948BD /* NSSortDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSSortDescriptor.swift; sourceTree = "<group>"; };
+		7D0AE25523886B73001948BD /* IndexSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndexSet.swift; sourceTree = "<group>"; };
+		7D0AE25623886B73001948BD /* DateComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateComponents.swift; sourceTree = "<group>"; };
+		7D0AE25723886B74001948BD /* NSCoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSCoder.swift; sourceTree = "<group>"; };
+		7D0AE25823886B75001948BD /* NSExpression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSExpression.swift; sourceTree = "<group>"; };
+		7D0AE25923886B75001948BD /* DateInterval.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateInterval.swift; sourceTree = "<group>"; };
+		7D0AE25A23886B76001948BD /* NSSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSSet.swift; sourceTree = "<group>"; };
+		7D0AE25B23886B77001948BD /* NSString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSString.swift; sourceTree = "<group>"; };
+		7D0AE25C23886B77001948BD /* Measurement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Measurement.swift; sourceTree = "<group>"; };
+		7D0AE25D23886B78001948BD /* DispatchData+DataProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DispatchData+DataProtocol.swift"; sourceTree = "<group>"; };
+		7D0AE25E23886B79001948BD /* ContiguousBytes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContiguousBytes.swift; sourceTree = "<group>"; };
+		7D0AE25F23886B79001948BD /* Foundation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Foundation.swift; sourceTree = "<group>"; };
+		7D0AE26023886B7A001948BD /* FileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileManager.swift; sourceTree = "<group>"; };
+		7D0AE26123886B7B001948BD /* NSStringAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSStringAPI.swift; sourceTree = "<group>"; };
+		7D0AE26223886B7B001948BD /* Data.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
+		7D0AE26323886B7C001948BD /* Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
+		7D0AE26423886B7D001948BD /* Notification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
+		7D0AE26523886B7D001948BD /* NSFastEnumeration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSFastEnumeration.swift; sourceTree = "<group>"; };
+		7D0AE26623886B7E001948BD /* Locale.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Locale.swift; sourceTree = "<group>"; };
+		7D0AE26723886B7E001948BD /* NSOrderedCollectionDifference.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSOrderedCollectionDifference.swift; sourceTree = "<group>"; };
+		7D0AE26823886B7F001948BD /* NSRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSRange.swift; sourceTree = "<group>"; };
+		7D0AE26923886B80001948BD /* NSStringEncodings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSStringEncodings.swift; sourceTree = "<group>"; };
+		7D0AE26A23886B80001948BD /* NSUndoManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSUndoManager.swift; sourceTree = "<group>"; };
+		7D0AE26B23886B81001948BD /* NSURL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSURL.swift; sourceTree = "<group>"; };
+		7D0AE26C23886B82001948BD /* Collections+DataProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Collections+DataProtocol.swift"; sourceTree = "<group>"; };
+		7D0AE26D23886B82001948BD /* Codable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Codable.swift; sourceTree = "<group>"; };
+		7D0AE26E23886B83001948BD /* NSData+DataProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSData+DataProtocol.swift"; sourceTree = "<group>"; };
+		7D0AE29E23886B91001948BD /* ReferenceConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReferenceConvertible.swift; sourceTree = "<group>"; };
+		7D0AE29F23886B92001948BD /* URLSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSession.swift; sourceTree = "<group>"; };
+		7D0AE2A023886B92001948BD /* Scanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Scanner.swift; sourceTree = "<group>"; };
+		7D0AE2A123886B93001948BD /* UUID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UUID.swift; sourceTree = "<group>"; };
+		7D0AE2A223886B94001948BD /* String.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		7D0AE2A323886B94001948BD /* Schedulers+OperationQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Schedulers+OperationQueue.swift"; sourceTree = "<group>"; };
+		7D0AE2A423886B95001948BD /* PersonNameComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersonNameComponents.swift; sourceTree = "<group>"; };
+		7D0AE2A523886B96001948BD /* Publishers+URLSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Publishers+URLSession.swift"; sourceTree = "<group>"; };
+		7D0AE2A623886B96001948BD /* PlistEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlistEncoder.swift; sourceTree = "<group>"; };
+		7D0AE2A723886B97001948BD /* Publishers+NotificationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Publishers+NotificationCenter.swift"; sourceTree = "<group>"; };
+		7D0AE2A823886B98001948BD /* Schedulers+RunLoop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Schedulers+RunLoop.swift"; sourceTree = "<group>"; };
+		7D0AE2A923886B98001948BD /* TimeZone.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeZone.swift; sourceTree = "<group>"; };
+		7D0AE2AA23886B99001948BD /* Schedulers+Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Schedulers+Date.swift"; sourceTree = "<group>"; };
+		7D0AE2AB23886B9A001948BD /* URL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
+		7D0AE2AC23886B9A001948BD /* Pointers+DataProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Pointers+DataProtocol.swift"; sourceTree = "<group>"; };
+		7D0AE2AD23886B9B001948BD /* Publishers+Locking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Publishers+Locking.swift"; sourceTree = "<group>"; };
+		7D0AE2AE23886B9C001948BD /* URLCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLCache.swift; sourceTree = "<group>"; };
+		7D0AE2AF23886B9C001948BD /* URLRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLRequest.swift; sourceTree = "<group>"; };
+		7D0AE2B023886B9D001948BD /* URLComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLComponents.swift; sourceTree = "<group>"; };
+		7D0AE2B123886B9D001948BD /* Publishers+Timer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Publishers+Timer.swift"; sourceTree = "<group>"; };
+		7D0AE2B223886B9E001948BD /* Progress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Progress.swift; sourceTree = "<group>"; };
+		7D0AE2B323886B9F001948BD /* Publishers+KeyValueObserving.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Publishers+KeyValueObserving.swift"; sourceTree = "<group>"; };
+		7D0AE2F02388A4E5001948BD /* magic-symbols-for-install-name.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "magic-symbols-for-install-name.h"; sourceTree = "<group>"; };
+		7D20064D22F24524008DF640 /* libswiftFoundation.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libswiftFoundation.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		7D20065B22F251BE008DF640 /* Foundation.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Foundation.xcconfig; sourceTree = "<group>"; };
+		7D2006C922F3D3AB008DF640 /* Foundation-swiftoverlay-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Foundation-swiftoverlay-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7D2006CD22F3D3AB008DF640 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7D8BD9D822FE956C004C00CC /* FoundationTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = FoundationTests.xcconfig; sourceTree = "<group>"; };
+		7DA3865723C803810050CCB3 /* magic-symbols-for-install-name.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "magic-symbols-for-install-name.c"; sourceTree = "<group>"; };
+		7DA3865823C803810050CCB3 /* magic-symbols-for-install-name.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "magic-symbols-for-install-name.h"; sourceTree = "<group>"; };
+		7DA3865923C803810050CCB3 /* CoreFoundation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreFoundation.swift; sourceTree = "<group>"; };
+		7DA3865A23C803810050CCB3 /* CoreFoundation.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = CoreFoundation.xcconfig; sourceTree = "<group>"; };
+		7DA3865C23C803810050CCB3 /* CoreFoundationTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = CoreFoundationTests.xcconfig; sourceTree = "<group>"; };
+		7DA3865D23C803810050CCB3 /* CoreFoundationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreFoundationTests.swift; sourceTree = "<group>"; };
+		7DA3865E23C803810050CCB3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7DA3866323C804530050CCB3 /* libswiftCoreFoundation.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libswiftCoreFoundation.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		7DA3866B23C804740050CCB3 /* CoreFoundation-swiftoverlay-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CoreFoundation-swiftoverlay-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7DA3867D23C807A80050CCB3 /* CoreFoundationOverlayShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreFoundationOverlayShims.h; sourceTree = "<group>"; };
+		7DA3867E23C807C90050CCB3 /* CFHashingShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CFHashingShims.h; sourceTree = "<group>"; };
+		7DA3867F23C807C90050CCB3 /* CFCharacterSetShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CFCharacterSetShims.h; sourceTree = "<group>"; };
+		7DD9FCED254A91F500E58DC4 /* NSValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSValue.swift; sourceTree = "<group>"; };
+		7DEBC66223AD7FFE00B40DAF /* FoundationOverlayShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FoundationOverlayShims.h; sourceTree = "<group>"; };
+		7DEBC66323AD805000B40DAF /* FoundationShimSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FoundationShimSupport.h; sourceTree = "<group>"; };
+		7DEBC67323AD80D800B40DAF /* NSDataShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSDataShims.h; sourceTree = "<group>"; };
+		7DEBC67423AD80D800B40DAF /* NSErrorShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSErrorShims.h; sourceTree = "<group>"; };
+		7DEBC67523AD80D800B40DAF /* NSIndexSetShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSIndexSetShims.h; sourceTree = "<group>"; };
+		7DEBC67623AD80D800B40DAF /* NSUndoManagerShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSUndoManagerShims.h; sourceTree = "<group>"; };
+		7DEBC67723AD80D800B40DAF /* NSCalendarShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSCalendarShims.h; sourceTree = "<group>"; };
+		7DEBC67823AD80D800B40DAF /* NSDictionaryShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSDictionaryShims.h; sourceTree = "<group>"; };
+		7DEBC67923AD80D800B40DAF /* NSCharacterSetShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSCharacterSetShims.h; sourceTree = "<group>"; };
+		7DEBC67A23AD80D800B40DAF /* NSLocaleShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSLocaleShims.h; sourceTree = "<group>"; };
+		7DEBC67B23AD80D900B40DAF /* NSKeyedArchiverShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSKeyedArchiverShims.h; sourceTree = "<group>"; };
+		7DEBC67C23AD80D900B40DAF /* NSIndexPathShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSIndexPathShims.h; sourceTree = "<group>"; };
+		7DEBC67D23AD80D900B40DAF /* NSTimeZoneShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSTimeZoneShims.h; sourceTree = "<group>"; };
+		7DEBC67E23AD80D900B40DAF /* NSFileManagerShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSFileManagerShims.h; sourceTree = "<group>"; };
+		7DEBC67F23AD80D900B40DAF /* NSCoderShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSCoderShims.h; sourceTree = "<group>"; };
+		7DEBC68023AD80EA00B40DAF /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		7DF02CC022F4DF1A00C66A76 /* overlay-base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "overlay-base.xcconfig"; sourceTree = "<group>"; };
+		7DF02CC422F4DF1A00C66A76 /* install-swiftmodules.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "install-swiftmodules.sh"; sourceTree = "<group>"; };
+		7DFB966B23B174BA00D8DB10 /* TestPlistEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestPlistEncoder.swift; sourceTree = "<group>"; };
+		7DFB966C23B174BB00D8DB10 /* TestUUID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUUID.swift; sourceTree = "<group>"; };
+		7DFB966F23B174D200D8DB10 /* TestCalendar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCalendar.swift; sourceTree = "<group>"; };
+		7DFB967023B174D200D8DB10 /* TestNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNotification.swift; sourceTree = "<group>"; };
+		7DFB967123B174D200D8DB10 /* TestLocale.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLocale.swift; sourceTree = "<group>"; };
+		7DFB967523B174E500D8DB10 /* TestIndexPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestIndexPath.swift; sourceTree = "<group>"; };
+		7DFB967623B174E500D8DB10 /* TestNSRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSRange.swift; sourceTree = "<group>"; };
+		7DFB967723B174E500D8DB10 /* TestURL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestURL.swift; sourceTree = "<group>"; };
+		7DFB967B23B174FF00D8DB10 /* TestDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDate.swift; sourceTree = "<group>"; };
+		7DFB967C23B174FF00D8DB10 /* TestData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestData.swift; sourceTree = "<group>"; };
+		7DFB967D23B174FF00D8DB10 /* TestDateInterval.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDateInterval.swift; sourceTree = "<group>"; };
+		7DFB968123B1751100D8DB10 /* TestDecimal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDecimal.swift; sourceTree = "<group>"; };
+		7DFB968223B1751100D8DB10 /* TestPersonNameComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestPersonNameComponents.swift; sourceTree = "<group>"; };
+		7DFB968323B1751100D8DB10 /* TestFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestFileManager.swift; sourceTree = "<group>"; };
+		7DFB968723B1752200D8DB10 /* TestNSString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSString.swift; sourceTree = "<group>"; };
+		7DFB968823B1752200D8DB10 /* TestMeasurement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestMeasurement.swift; sourceTree = "<group>"; };
+		7DFB968923B1752200D8DB10 /* TestTimeZone.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestTimeZone.swift; sourceTree = "<group>"; };
+		7DFB968A23B1752300D8DB10 /* TestUserInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUserInfo.swift; sourceTree = "<group>"; };
+		7DFB968F23B1753500D8DB10 /* TestAffineTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAffineTransform.swift; sourceTree = "<group>"; };
+		7DFB969023B1753600D8DB10 /* TestCharacterSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCharacterSet.swift; sourceTree = "<group>"; };
+		7DFB969123B1753600D8DB10 /* TestJSONEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestJSONEncoder.swift; sourceTree = "<group>"; };
+		7DFB969523B1754D00D8DB10 /* TestIndexSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestIndexSet.swift; sourceTree = "<group>"; };
+		7DFB969623B1754D00D8DB10 /* TestProgress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestProgress.swift; sourceTree = "<group>"; };
+		7DFB969923B175A100D8DB10 /* CodableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodableTests.swift; sourceTree = "<group>"; };
+		7DFB969C23B17E0C00D8DB10 /* FoundationBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FoundationBridge.m; sourceTree = "<group>"; };
+		7DFB969E23B17E3400D8DB10 /* FoundationBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FoundationBridge.h; sourceTree = "<group>"; };
+		7DFB969F23B180F300D8DB10 /* StdlibUnittest expectEqual Types.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StdlibUnittest expectEqual Types.swift"; sourceTree = "<group>"; };
+		7DFB96A123B187B300D8DB10 /* StdlibUnittest checkEquatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StdlibUnittest checkEquatable.swift"; sourceTree = "<group>"; };
+		7DFB96A223B187B300D8DB10 /* StdlibUnittest checkHashable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StdlibUnittest checkHashable.swift"; sourceTree = "<group>"; };
+		DD2756C4249814450079060F /* overlay-release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "overlay-release.xcconfig"; sourceTree = "<group>"; };
+		DD2756C5249814450079060F /* overlay-debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "overlay-debug.xcconfig"; sourceTree = "<group>"; };
+		DD8301FA24993C14008940B5 /* overlay-shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "overlay-shared.xcconfig"; sourceTree = "<group>"; };
+		DD8301FB24993D7C008940B5 /* overlay-tests-shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "overlay-tests-shared.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		7D20064B22F24524008DF640 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				15F987BD2475AB6E00451F92 /* Combine.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7D2006C622F3D3AB008DF640 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7D2006D722F3D3DA008DF640 /* libswiftFoundation.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7DA3866123C804530050CCB3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7DA3866823C804740050CCB3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7DA3867023C804740050CCB3 /* libswiftCoreFoundation.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		7D20064E22F24525008DF640 /* Foundation-swiftoverlay */ = {
+			isa = PBXGroup;
+			children = (
+				7D20065B22F251BE008DF640 /* Foundation.xcconfig */,
+				7D0AE2F02388A4E5001948BD /* magic-symbols-for-install-name.h */,
+				7D0AE23223886AE9001948BD /* magic-symbols-for-install-name.c */,
+				7D0AE23823886B52001948BD /* AffineTransform.swift */,
+				7D0AE23923886B53001948BD /* Boxing.swift */,
+				7D0AE23423886B50001948BD /* BundleLookup.mm */,
+				7D0AE23523886B50001948BD /* Calendar.swift */,
+				7D0AE23623886B51001948BD /* CharacterSet.swift */,
+				7D0AE23723886B52001948BD /* CheckClass.swift */,
+				7D0AE26D23886B82001948BD /* Codable.swift */,
+				7D0AE26C23886B82001948BD /* Collections+DataProtocol.swift */,
+				7D0AE24423886B68001948BD /* CombineTypealiases.swift */,
+				7D0AE25E23886B79001948BD /* ContiguousBytes.swift */,
+				7D0AE26223886B7B001948BD /* Data.swift */,
+				7D0AE25023886B6F001948BD /* DataProtocol.swift */,
+				7D0AE24C23886B6D001948BD /* DataThunks.m */,
+				7D0AE26323886B7C001948BD /* Date.swift */,
+				7D0AE25623886B73001948BD /* DateComponents.swift */,
+				7D0AE25923886B75001948BD /* DateInterval.swift */,
+				7D0AE24723886B6A001948BD /* Decimal.swift */,
+				7D0AE25D23886B78001948BD /* DispatchData+DataProtocol.swift */,
+				7D0AE26023886B7A001948BD /* FileManager.swift */,
+				7D0AE25F23886B79001948BD /* Foundation.swift */,
+				7D0AE24523886B69001948BD /* IndexPath.swift */,
+				7D0AE25523886B73001948BD /* IndexSet.swift */,
+				7D0AE24D23886B6E001948BD /* JSONEncoder.swift */,
+				7D0AE26623886B7E001948BD /* Locale.swift */,
+				7D0AE25C23886B77001948BD /* Measurement.swift */,
+				7D0AE26423886B7D001948BD /* Notification.swift */,
+				7D0AE24B23886B6C001948BD /* NSArray.swift */,
+				7D0AE25723886B74001948BD /* NSCoder.swift */,
+				7D0AE26E23886B83001948BD /* NSData+DataProtocol.swift */,
+				7D0AE24223886B67001948BD /* NSDate.swift */,
+				7D0AE24823886B6A001948BD /* NSDictionary.swift */,
+				7D0AE24623886B69001948BD /* NSError.swift */,
+				7D0AE25823886B75001948BD /* NSExpression.swift */,
+				7D0AE26523886B7D001948BD /* NSFastEnumeration.swift */,
+				7D0AE25123886B70001948BD /* NSGeometry.swift */,
+				7D0AE24923886B6B001948BD /* NSIndexSet.swift */,
+				7D0AE24023886B65001948BD /* NSItemProvider.swift */,
+				7D0AE25223886B71001948BD /* NSNumber.swift */,
+				7D0AE24F23886B6F001948BD /* NSObject.swift */,
+				7D0AE26723886B7E001948BD /* NSOrderedCollectionDifference.swift */,
+				7D0AE25323886B72001948BD /* NSPredicate.swift */,
+				7D0AE26823886B7F001948BD /* NSRange.swift */,
+				7D0AE25A23886B76001948BD /* NSSet.swift */,
+				7D0AE25423886B72001948BD /* NSSortDescriptor.swift */,
+				7D0AE25B23886B77001948BD /* NSString.swift */,
+				7D0AE26123886B7B001948BD /* NSStringAPI.swift */,
+				7D0AE26923886B80001948BD /* NSStringEncodings.swift */,
+				7D0AE24123886B66001948BD /* NSTextCheckingResult.swift */,
+				7D0AE26A23886B80001948BD /* NSUndoManager.swift */,
+				7D0AE26B23886B81001948BD /* NSURL.swift */,
+				7DD9FCED254A91F500E58DC4 /* NSValue.swift */,
+				7D0AE2A423886B95001948BD /* PersonNameComponents.swift */,
+				7D0AE2A623886B96001948BD /* PlistEncoder.swift */,
+				7D0AE2AC23886B9A001948BD /* Pointers+DataProtocol.swift */,
+				7D0AE2B223886B9E001948BD /* Progress.swift */,
+				7D0AE2B323886B9F001948BD /* Publishers+KeyValueObserving.swift */,
+				7D0AE2AD23886B9B001948BD /* Publishers+Locking.swift */,
+				7D0AE2A723886B97001948BD /* Publishers+NotificationCenter.swift */,
+				7D0AE2B123886B9D001948BD /* Publishers+Timer.swift */,
+				7D0AE2A523886B96001948BD /* Publishers+URLSession.swift */,
+				7D0AE29E23886B91001948BD /* ReferenceConvertible.swift */,
+				7D0AE2A023886B92001948BD /* Scanner.swift */,
+				7D0AE2AA23886B99001948BD /* Schedulers+Date.swift */,
+				7D0AE2A323886B94001948BD /* Schedulers+OperationQueue.swift */,
+				7D0AE2A823886B98001948BD /* Schedulers+RunLoop.swift */,
+				7D0AE2A223886B94001948BD /* String.swift */,
+				7D0AE2A923886B98001948BD /* TimeZone.swift */,
+				7D0AE2AB23886B9A001948BD /* URL.swift */,
+				7D0AE2AE23886B9C001948BD /* URLCache.swift */,
+				7D0AE2B023886B9D001948BD /* URLComponents.swift */,
+				7D0AE2AF23886B9C001948BD /* URLRequest.swift */,
+				7D0AE29F23886B92001948BD /* URLSession.swift */,
+				7D0AE2A123886B93001948BD /* UUID.swift */,
+			);
+			path = "Foundation-swiftoverlay";
+			sourceTree = "<group>";
+		};
+		7D2006CA22F3D3AB008DF640 /* Foundation-swiftoverlay-Tests */ = {
+			isa = PBXGroup;
+			children = (
+				7D8BD9D822FE956C004C00CC /* FoundationTests.xcconfig */,
+				7D2006CD22F3D3AB008DF640 /* Info.plist */,
+				7DFB969E23B17E3400D8DB10 /* FoundationBridge.h */,
+				7DFB969C23B17E0C00D8DB10 /* FoundationBridge.m */,
+				7DFB969F23B180F300D8DB10 /* StdlibUnittest expectEqual Types.swift */,
+				7DFB96A123B187B300D8DB10 /* StdlibUnittest checkEquatable.swift */,
+				7DFB96A223B187B300D8DB10 /* StdlibUnittest checkHashable.swift */,
+				7DFB969923B175A100D8DB10 /* CodableTests.swift */,
+				7DFB968F23B1753500D8DB10 /* TestAffineTransform.swift */,
+				7DFB966F23B174D200D8DB10 /* TestCalendar.swift */,
+				7DFB969023B1753600D8DB10 /* TestCharacterSet.swift */,
+				7DFB967C23B174FF00D8DB10 /* TestData.swift */,
+				7DFB967B23B174FF00D8DB10 /* TestDate.swift */,
+				7DFB967D23B174FF00D8DB10 /* TestDateInterval.swift */,
+				7DFB968123B1751100D8DB10 /* TestDecimal.swift */,
+				7DFB968323B1751100D8DB10 /* TestFileManager.swift */,
+				7DFB967523B174E500D8DB10 /* TestIndexPath.swift */,
+				7DFB969523B1754D00D8DB10 /* TestIndexSet.swift */,
+				7DFB969123B1753600D8DB10 /* TestJSONEncoder.swift */,
+				7DFB967123B174D200D8DB10 /* TestLocale.swift */,
+				7DFB968823B1752200D8DB10 /* TestMeasurement.swift */,
+				7DFB967023B174D200D8DB10 /* TestNotification.swift */,
+				7DFB967623B174E500D8DB10 /* TestNSRange.swift */,
+				7DFB968723B1752200D8DB10 /* TestNSString.swift */,
+				7DFB968223B1751100D8DB10 /* TestPersonNameComponents.swift */,
+				7DFB966B23B174BA00D8DB10 /* TestPlistEncoder.swift */,
+				7DFB969623B1754D00D8DB10 /* TestProgress.swift */,
+				7DFB968923B1752200D8DB10 /* TestTimeZone.swift */,
+				7DFB967723B174E500D8DB10 /* TestURL.swift */,
+				7DFB968A23B1752300D8DB10 /* TestUserInfo.swift */,
+				7DFB966C23B174BB00D8DB10 /* TestUUID.swift */,
+			);
+			path = "Foundation-swiftoverlay-Tests";
+			sourceTree = "<group>";
+		};
+		7D2006D622F3D3DA008DF640 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				15F987BC2475AB6E00451F92 /* Combine.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		7D81A8D422E936E700739BB9 = {
+			isa = PBXGroup;
+			children = (
+				7DF02CBE22F4DF1A00C66A76 /* Config */,
+				7DEBC66123AD7FD900B40DAF /* shims */,
+				7DA3865623C803810050CCB3 /* CoreFoundation-swiftoverlay */,
+				7DA3865B23C803810050CCB3 /* CoreFoundation-swiftoverlay-Tests */,
+				7D20064E22F24525008DF640 /* Foundation-swiftoverlay */,
+				7D2006CA22F3D3AB008DF640 /* Foundation-swiftoverlay-Tests */,
+				7D81A8DE22E936E700739BB9 /* Products */,
+				7D2006D622F3D3DA008DF640 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		7D81A8DE22E936E700739BB9 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7D20064D22F24524008DF640 /* libswiftFoundation.dylib */,
+				7D2006C922F3D3AB008DF640 /* Foundation-swiftoverlay-Tests.xctest */,
+				7DA3866323C804530050CCB3 /* libswiftCoreFoundation.dylib */,
+				7DA3866B23C804740050CCB3 /* CoreFoundation-swiftoverlay-Tests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		7DA3865623C803810050CCB3 /* CoreFoundation-swiftoverlay */ = {
+			isa = PBXGroup;
+			children = (
+				7DA3865A23C803810050CCB3 /* CoreFoundation.xcconfig */,
+				7DA3865823C803810050CCB3 /* magic-symbols-for-install-name.h */,
+				7DA3865723C803810050CCB3 /* magic-symbols-for-install-name.c */,
+				7DA3865923C803810050CCB3 /* CoreFoundation.swift */,
+			);
+			path = "CoreFoundation-swiftoverlay";
+			sourceTree = "<group>";
+		};
+		7DA3865B23C803810050CCB3 /* CoreFoundation-swiftoverlay-Tests */ = {
+			isa = PBXGroup;
+			children = (
+				7DA3865C23C803810050CCB3 /* CoreFoundationTests.xcconfig */,
+				7DA3865D23C803810050CCB3 /* CoreFoundationTests.swift */,
+				7DA3865E23C803810050CCB3 /* Info.plist */,
+			);
+			path = "CoreFoundation-swiftoverlay-Tests";
+			sourceTree = "<group>";
+		};
+		7DEBC66123AD7FD900B40DAF /* shims */ = {
+			isa = PBXGroup;
+			children = (
+				7DEBC68023AD80EA00B40DAF /* module.modulemap */,
+				7DEBC66223AD7FFE00B40DAF /* FoundationOverlayShims.h */,
+				7DEBC66323AD805000B40DAF /* FoundationShimSupport.h */,
+				7DEBC67723AD80D800B40DAF /* NSCalendarShims.h */,
+				7DEBC67923AD80D800B40DAF /* NSCharacterSetShims.h */,
+				7DEBC67F23AD80D900B40DAF /* NSCoderShims.h */,
+				7DEBC67323AD80D800B40DAF /* NSDataShims.h */,
+				7DEBC67823AD80D800B40DAF /* NSDictionaryShims.h */,
+				7DEBC67423AD80D800B40DAF /* NSErrorShims.h */,
+				7DEBC67E23AD80D900B40DAF /* NSFileManagerShims.h */,
+				7DEBC67C23AD80D900B40DAF /* NSIndexPathShims.h */,
+				7DEBC67523AD80D800B40DAF /* NSIndexSetShims.h */,
+				7DEBC67B23AD80D900B40DAF /* NSKeyedArchiverShims.h */,
+				7DEBC67A23AD80D800B40DAF /* NSLocaleShims.h */,
+				7DEBC67D23AD80D900B40DAF /* NSTimeZoneShims.h */,
+				7DEBC67623AD80D800B40DAF /* NSUndoManagerShims.h */,
+				7DA3867D23C807A80050CCB3 /* CoreFoundationOverlayShims.h */,
+				7DA3867F23C807C90050CCB3 /* CFCharacterSetShims.h */,
+				7DA3867E23C807C90050CCB3 /* CFHashingShims.h */,
+			);
+			path = shims;
+			sourceTree = "<group>";
+		};
+		7DF02CBE22F4DF1A00C66A76 /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				7DF02CC022F4DF1A00C66A76 /* overlay-base.xcconfig */,
+				DD2756C5249814450079060F /* overlay-debug.xcconfig */,
+				DD2756C4249814450079060F /* overlay-release.xcconfig */,
+				DD8301FA24993C14008940B5 /* overlay-shared.xcconfig */,
+				7DF02CC422F4DF1A00C66A76 /* install-swiftmodules.sh */,
+				DD8301FB24993D7C008940B5 /* overlay-tests-shared.xcconfig */,
+			);
+			path = Config;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		7D20064922F24524008DF640 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7D0AE2F12388A4E5001948BD /* magic-symbols-for-install-name.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7DA3865F23C804530050CCB3 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7DA3867623C804B60050CCB3 /* magic-symbols-for-install-name.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		7D20064C22F24524008DF640 /* Foundation-swiftoverlay */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7D20065522F24525008DF640 /* Build configuration list for PBXNativeTarget "Foundation-swiftoverlay" */;
+			buildPhases = (
+				7D20064922F24524008DF640 /* Headers */,
+				7D20064A22F24524008DF640 /* Sources */,
+				7D20064B22F24524008DF640 /* Frameworks */,
+				7D20065C22F25325008DF640 /* Install Swift Module */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Foundation-swiftoverlay";
+			productName = Foundation;
+			productReference = 7D20064D22F24524008DF640 /* libswiftFoundation.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		7D2006C822F3D3AB008DF640 /* Foundation-swiftoverlay-Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7D2006D322F3D3AB008DF640 /* Build configuration list for PBXNativeTarget "Foundation-swiftoverlay-Tests" */;
+			buildPhases = (
+				7D2006C522F3D3AB008DF640 /* Sources */,
+				7D2006C622F3D3AB008DF640 /* Frameworks */,
+				7D2006C722F3D3AB008DF640 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				7D2006D522F3D3D1008DF640 /* PBXTargetDependency */,
+			);
+			name = "Foundation-swiftoverlay-Tests";
+			productName = FoundationTests;
+			productReference = 7D2006C922F3D3AB008DF640 /* Foundation-swiftoverlay-Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		7DA3866223C804530050CCB3 /* CoreFoundation-swiftoverlay */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7DA3866423C804530050CCB3 /* Build configuration list for PBXNativeTarget "CoreFoundation-swiftoverlay" */;
+			buildPhases = (
+				7DA3865F23C804530050CCB3 /* Headers */,
+				7DA3866023C804530050CCB3 /* Sources */,
+				7DA3866123C804530050CCB3 /* Frameworks */,
+				3631B4BB23CFDE7400D910A5 /* Install Swift Module */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "CoreFoundation-swiftoverlay";
+			productName = CoreFoundation;
+			productReference = 7DA3866323C804530050CCB3 /* libswiftCoreFoundation.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		7DA3866A23C804740050CCB3 /* CoreFoundation-swiftoverlay-Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7DA3867323C804740050CCB3 /* Build configuration list for PBXNativeTarget "CoreFoundation-swiftoverlay-Tests" */;
+			buildPhases = (
+				7DA3866723C804740050CCB3 /* Sources */,
+				7DA3866823C804740050CCB3 /* Frameworks */,
+				7DA3866923C804740050CCB3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				7DA3867223C804740050CCB3 /* PBXTargetDependency */,
+			);
+			name = "CoreFoundation-swiftoverlay-Tests";
+			productName = "CoreFoundation-swiftoverlay-Tests";
+			productReference = 7DA3866B23C804740050CCB3 /* CoreFoundation-swiftoverlay-Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		7D81A8D522E936E700739BB9 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1200;
+				LastUpgradeCheck = 1220;
+				ORGANIZATIONNAME = Apple;
+				TargetAttributes = {
+					7D20064C22F24524008DF640 = {
+						CreatedOnToolsVersion = 11.0;
+						LastSwiftMigration = 1100;
+					};
+					7D2006C822F3D3AB008DF640 = {
+						CreatedOnToolsVersion = 11.0;
+						LastSwiftMigration = 1140;
+					};
+					7DA3866223C804530050CCB3 = {
+						CreatedOnToolsVersion = 12.0;
+					};
+					7DA3866A23C804740050CCB3 = {
+						CreatedOnToolsVersion = 12.0;
+					};
+				};
+			};
+			buildConfigurationList = 7D81A8D822E936E700739BB9 /* Build configuration list for PBXProject "Foundation-swiftoverlay" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 7D81A8D422E936E700739BB9;
+			productRefGroup = 7D81A8DE22E936E700739BB9 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				7D20064C22F24524008DF640 /* Foundation-swiftoverlay */,
+				7D2006C822F3D3AB008DF640 /* Foundation-swiftoverlay-Tests */,
+				7DA3866223C804530050CCB3 /* CoreFoundation-swiftoverlay */,
+				7DA3866A23C804740050CCB3 /* CoreFoundation-swiftoverlay-Tests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		7D2006C722F3D3AB008DF640 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7DA3866923C804740050CCB3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		3631B4BB23CFDE7400D910A5 /* Install Swift Module */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Install Swift Module";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "exec \"${PROJECT_DIR}/Config/install-swiftmodules.sh\"\n";
+		};
+		7D20065C22F25325008DF640 /* Install Swift Module */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 12;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Install Swift Module";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "exec \"${PROJECT_DIR}/Config/install-swiftmodules.sh\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		7D20064A22F24524008DF640 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7D0AE2B823886B9F001948BD /* String.swift in Sources */,
+				7D0AE29A23886B85001948BD /* NSURL.swift in Sources */,
+				7D0AE27F23886B84001948BD /* DataProtocol.swift in Sources */,
+				7D0AE2C023886B9F001948BD /* Schedulers+Date.swift in Sources */,
+				7D0AE2B523886B9F001948BD /* URLSession.swift in Sources */,
+				7D0AE28523886B84001948BD /* DateComponents.swift in Sources */,
+				7D0AE23323886AE9001948BD /* magic-symbols-for-install-name.c in Sources */,
+				7D0AE2C923886BA0001948BD /* Publishers+KeyValueObserving.swift in Sources */,
+				7DD9FCEE254A91F500E58DC4 /* NSValue.swift in Sources */,
+				7D0AE27E23886B84001948BD /* NSObject.swift in Sources */,
+				7D0AE2C823886BA0001948BD /* Progress.swift in Sources */,
+				7D0AE23E23886B53001948BD /* AffineTransform.swift in Sources */,
+				7D0AE28A23886B84001948BD /* NSString.swift in Sources */,
+				7D0AE29923886B85001948BD /* NSUndoManager.swift in Sources */,
+				7D0AE2C323886BA0001948BD /* Publishers+Locking.swift in Sources */,
+				7D0AE27423886B83001948BD /* IndexPath.swift in Sources */,
+				7D0AE29B23886B85001948BD /* Collections+DataProtocol.swift in Sources */,
+				7D0AE2BF23886B9F001948BD /* TimeZone.swift in Sources */,
+				7D0AE28423886B84001948BD /* IndexSet.swift in Sources */,
+				7D0AE29423886B85001948BD /* NSFastEnumeration.swift in Sources */,
+				7D0AE27023886B83001948BD /* NSTextCheckingResult.swift in Sources */,
+				7D0AE27723886B83001948BD /* NSDictionary.swift in Sources */,
+				7D0AE28E23886B84001948BD /* Foundation.swift in Sources */,
+				7D0AE2C723886BA0001948BD /* Publishers+Timer.swift in Sources */,
+				7D0AE26F23886B83001948BD /* NSItemProvider.swift in Sources */,
+				7D0AE27A23886B83001948BD /* NSArray.swift in Sources */,
+				7D0AE2BD23886B9F001948BD /* Publishers+NotificationCenter.swift in Sources */,
+				7D0AE2BC23886B9F001948BD /* PlistEncoder.swift in Sources */,
+				7D0AE29123886B84001948BD /* Data.swift in Sources */,
+				7D0AE27323886B83001948BD /* CombineTypealiases.swift in Sources */,
+				7D0AE28223886B84001948BD /* NSPredicate.swift in Sources */,
+				7D0AE28323886B84001948BD /* NSSortDescriptor.swift in Sources */,
+				7D0AE29C23886B85001948BD /* Codable.swift in Sources */,
+				7D0AE29723886B85001948BD /* NSRange.swift in Sources */,
+				7D0AE2B923886B9F001948BD /* Schedulers+OperationQueue.swift in Sources */,
+				7D0AE27B23886B83001948BD /* DataThunks.m in Sources */,
+				7D0AE2B623886B9F001948BD /* Scanner.swift in Sources */,
+				7D0AE2B423886B9F001948BD /* ReferenceConvertible.swift in Sources */,
+				7D0AE29523886B85001948BD /* Locale.swift in Sources */,
+				7D0AE29623886B85001948BD /* NSOrderedCollectionDifference.swift in Sources */,
+				7D0AE28823886B84001948BD /* DateInterval.swift in Sources */,
+				7D0AE2C123886B9F001948BD /* URL.swift in Sources */,
+				7D0AE2BB23886B9F001948BD /* Publishers+URLSession.swift in Sources */,
+				7D0AE27C23886B84001948BD /* JSONEncoder.swift in Sources */,
+				7D0AE27123886B83001948BD /* NSDate.swift in Sources */,
+				7D0AE28F23886B84001948BD /* FileManager.swift in Sources */,
+				7D0AE28723886B84001948BD /* NSExpression.swift in Sources */,
+				7D0AE29D23886B85001948BD /* NSData+DataProtocol.swift in Sources */,
+				7D0AE28623886B84001948BD /* NSCoder.swift in Sources */,
+				7D0AE28C23886B84001948BD /* DispatchData+DataProtocol.swift in Sources */,
+				7D0AE2B723886B9F001948BD /* UUID.swift in Sources */,
+				7D0AE27623886B83001948BD /* Decimal.swift in Sources */,
+				7D0AE2C423886BA0001948BD /* URLCache.swift in Sources */,
+				7D0AE2C223886BA0001948BD /* Pointers+DataProtocol.swift in Sources */,
+				7D0AE28023886B84001948BD /* NSGeometry.swift in Sources */,
+				7D0AE27523886B83001948BD /* NSError.swift in Sources */,
+				7D0AE28123886B84001948BD /* NSNumber.swift in Sources */,
+				7D0AE28B23886B84001948BD /* Measurement.swift in Sources */,
+				7D0AE29823886B85001948BD /* NSStringEncodings.swift in Sources */,
+				7D0AE28D23886B84001948BD /* ContiguousBytes.swift in Sources */,
+				7D0AE2CC23888DE0001948BD /* CheckClass.swift in Sources */,
+				7D0AE27823886B83001948BD /* NSIndexSet.swift in Sources */,
+				7D0AE2BA23886B9F001948BD /* PersonNameComponents.swift in Sources */,
+				7D0AE23A23886B53001948BD /* BundleLookup.mm in Sources */,
+				7D0AE23C23886B53001948BD /* CharacterSet.swift in Sources */,
+				7D0AE2C623886BA0001948BD /* URLComponents.swift in Sources */,
+				7D0AE29223886B84001948BD /* Date.swift in Sources */,
+				7D0AE23F23886B53001948BD /* Boxing.swift in Sources */,
+				7D0AE29323886B85001948BD /* Notification.swift in Sources */,
+				7D0AE23B23886B53001948BD /* Calendar.swift in Sources */,
+				7D0AE29023886B84001948BD /* NSStringAPI.swift in Sources */,
+				7D0AE28923886B84001948BD /* NSSet.swift in Sources */,
+				7D0AE2C523886BA0001948BD /* URLRequest.swift in Sources */,
+				7D0AE2BE23886B9F001948BD /* Schedulers+RunLoop.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7D2006C522F3D3AB008DF640 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7DFB969423B1753600D8DB10 /* TestJSONEncoder.swift in Sources */,
+				7DFB968423B1751100D8DB10 /* TestDecimal.swift in Sources */,
+				7DFB966E23B174BB00D8DB10 /* TestUUID.swift in Sources */,
+				7DFB967F23B174FF00D8DB10 /* TestData.swift in Sources */,
+				7DFB968623B1751100D8DB10 /* TestFileManager.swift in Sources */,
+				7DFB969723B1754D00D8DB10 /* TestIndexSet.swift in Sources */,
+				7DFB967423B174D200D8DB10 /* TestLocale.swift in Sources */,
+				7DFB968B23B1752300D8DB10 /* TestNSString.swift in Sources */,
+				7DFB968D23B1752300D8DB10 /* TestTimeZone.swift in Sources */,
+				7DFB96A423B187B400D8DB10 /* StdlibUnittest checkHashable.swift in Sources */,
+				7DFB968E23B1752300D8DB10 /* TestUserInfo.swift in Sources */,
+				7DFB969823B1754D00D8DB10 /* TestProgress.swift in Sources */,
+				7DFB967923B174E500D8DB10 /* TestNSRange.swift in Sources */,
+				7DFB967E23B174FF00D8DB10 /* TestDate.swift in Sources */,
+				7DFB969323B1753600D8DB10 /* TestCharacterSet.swift in Sources */,
+				7DFB969A23B175A100D8DB10 /* CodableTests.swift in Sources */,
+				7DFB968C23B1752300D8DB10 /* TestMeasurement.swift in Sources */,
+				7DFB967323B174D200D8DB10 /* TestNotification.swift in Sources */,
+				7DFB969223B1753600D8DB10 /* TestAffineTransform.swift in Sources */,
+				7DFB966D23B174BB00D8DB10 /* TestPlistEncoder.swift in Sources */,
+				7DFB969D23B17E0C00D8DB10 /* FoundationBridge.m in Sources */,
+				7DFB968023B174FF00D8DB10 /* TestDateInterval.swift in Sources */,
+				7DFB96A023B180F300D8DB10 /* StdlibUnittest expectEqual Types.swift in Sources */,
+				7DFB96A323B187B400D8DB10 /* StdlibUnittest checkEquatable.swift in Sources */,
+				7DFB967223B174D200D8DB10 /* TestCalendar.swift in Sources */,
+				7DFB967823B174E500D8DB10 /* TestIndexPath.swift in Sources */,
+				7DFB967A23B174E500D8DB10 /* TestURL.swift in Sources */,
+				7DFB968523B1751100D8DB10 /* TestPersonNameComponents.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7DA3866023C804530050CCB3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7DA3867723C804BC0050CCB3 /* magic-symbols-for-install-name.c in Sources */,
+				7DA3867823C804BC0050CCB3 /* CoreFoundation.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7DA3866723C804740050CCB3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7DA3867923C804C40050CCB3 /* CoreFoundationTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		7D2006D522F3D3D1008DF640 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7D20064C22F24524008DF640 /* Foundation-swiftoverlay */;
+			targetProxy = 7D2006D422F3D3D1008DF640 /* PBXContainerItemProxy */;
+		};
+		7DA3867223C804740050CCB3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7DA3866223C804530050CCB3 /* CoreFoundation-swiftoverlay */;
+			targetProxy = 7DA3867123C804740050CCB3 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		7D20065322F24525008DF640 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7D20065B22F251BE008DF640 /* Foundation.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		7D20065422F24525008DF640 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7D20065B22F251BE008DF640 /* Foundation.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		7D2006D122F3D3AB008DF640 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7D8BD9D822FE956C004C00CC /* FoundationTests.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		7D2006D222F3D3AB008DF640 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7D8BD9D822FE956C004C00CC /* FoundationTests.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		7D81A8E422E936E700739BB9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = DD2756C5249814450079060F /* overlay-debug.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		7D81A8E522E936E700739BB9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = DD2756C4249814450079060F /* overlay-release.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		7DA3866523C804530050CCB3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7DA3865A23C803810050CCB3 /* CoreFoundation.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		7DA3866623C804530050CCB3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7DA3865A23C803810050CCB3 /* CoreFoundation.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		7DA3867423C804740050CCB3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7DA3865C23C803810050CCB3 /* CoreFoundationTests.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		7DA3867523C804740050CCB3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7DA3865C23C803810050CCB3 /* CoreFoundationTests.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		7D20065522F24525008DF640 /* Build configuration list for PBXNativeTarget "Foundation-swiftoverlay" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7D20065322F24525008DF640 /* Debug */,
+				7D20065422F24525008DF640 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7D2006D322F3D3AB008DF640 /* Build configuration list for PBXNativeTarget "Foundation-swiftoverlay-Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7D2006D122F3D3AB008DF640 /* Debug */,
+				7D2006D222F3D3AB008DF640 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7D81A8D822E936E700739BB9 /* Build configuration list for PBXProject "Foundation-swiftoverlay" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7D81A8E422E936E700739BB9 /* Debug */,
+				7D81A8E522E936E700739BB9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7DA3866423C804530050CCB3 /* Build configuration list for PBXNativeTarget "CoreFoundation-swiftoverlay" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7DA3866523C804530050CCB3 /* Debug */,
+				7DA3866623C804530050CCB3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7DA3867323C804740050CCB3 /* Build configuration list for PBXNativeTarget "CoreFoundation-swiftoverlay-Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7DA3867423C804740050CCB3 /* Debug */,
+				7DA3867523C804740050CCB3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 7D81A8D522E936E700739BB9 /* Project object */;
+}

--- a/Darwin/Foundation-swiftoverlay.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Darwin/Foundation-swiftoverlay.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Darwin/Foundation-swiftoverlay.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Darwin/Foundation-swiftoverlay.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Darwin/Foundation-swiftoverlay.xcodeproj/xcshareddata/xcschemes/CoreFoundation-swiftoverlay.xcscheme
+++ b/Darwin/Foundation-swiftoverlay.xcodeproj/xcshareddata/xcschemes/CoreFoundation-swiftoverlay.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1220"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7DA3866223C804530050CCB3"
+               BuildableName = "libswiftCoreFoundation.dylib"
+               BlueprintName = "CoreFoundation-swiftoverlay"
+               ReferencedContainer = "container:Foundation-swiftoverlay.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7DA3866A23C804740050CCB3"
+               BuildableName = "CoreFoundation-swiftoverlay-Tests.xctest"
+               BlueprintName = "CoreFoundation-swiftoverlay-Tests"
+               ReferencedContainer = "container:Foundation-swiftoverlay.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7DA3866223C804530050CCB3"
+            BuildableName = "libswiftCoreFoundation.dylib"
+            BlueprintName = "CoreFoundation-swiftoverlay"
+            ReferencedContainer = "container:Foundation-swiftoverlay.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+   <InstallAction
+      buildConfiguration = "Release">
+   </InstallAction>
+</Scheme>

--- a/Darwin/Foundation-swiftoverlay.xcodeproj/xcshareddata/xcschemes/Foundation-swiftoverlay.xcscheme
+++ b/Darwin/Foundation-swiftoverlay.xcodeproj/xcshareddata/xcschemes/Foundation-swiftoverlay.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1220"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7D20064C22F24524008DF640"
+               BuildableName = "libswiftFoundation.dylib"
+               BlueprintName = "Foundation-swiftoverlay"
+               ReferencedContainer = "container:Foundation-swiftoverlay.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7D2006C822F3D3AB008DF640"
+               BuildableName = "Foundation-swiftoverlay-Tests.xctest"
+               BlueprintName = "Foundation-swiftoverlay-Tests"
+               ReferencedContainer = "container:Foundation-swiftoverlay.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7D20064C22F24524008DF640"
+            BuildableName = "libswiftFoundation.dylib"
+            BlueprintName = "Foundation-swiftoverlay"
+            ReferencedContainer = "container:Foundation-swiftoverlay.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Darwin/Foundation-swiftoverlay/AffineTransform.swift
+++ b/Darwin/Foundation-swiftoverlay/AffineTransform.swift
@@ -1,0 +1,362 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+#if os(macOS)
+
+private let ε: CGFloat = 2.22045e-16
+
+public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConvertible {
+    public var m11, m12, m21, m22, tX, tY: CGFloat
+    
+    public typealias ReferenceType = NSAffineTransform
+    
+    /**
+     Creates an affine transformation.
+    */
+    public init(m11: CGFloat, m12: CGFloat, m21: CGFloat, m22: CGFloat, tX: CGFloat, tY: CGFloat) {
+        self.m11 = m11
+        self.m12 = m12
+        self.m21 = m21
+        self.m22 = m22
+        self.tX = tX
+        self.tY = tY
+    }
+    
+    private init(reference: __shared NSAffineTransform) {
+        m11 = reference.transformStruct.m11
+        m12 = reference.transformStruct.m12
+        m21 = reference.transformStruct.m21
+        m22 = reference.transformStruct.m22
+        tX = reference.transformStruct.tX
+        tY = reference.transformStruct.tY
+    }
+    
+    private var reference: NSAffineTransform {
+        let ref = NSAffineTransform()
+        ref.transformStruct = NSAffineTransformStruct(m11: m11, m12: m12, m21: m21, m22: m22, tX: tX, tY: tY)
+        return ref
+    }
+    
+    /**
+     Creates an affine transformation matrix with identity values.
+     - seealso: identity
+    */
+    public init() {
+        self.init(m11: CGFloat(1.0), m12: CGFloat(0.0),
+                  m21: CGFloat(0.0), m22: CGFloat(1.0),
+                  tX: CGFloat(0.0), tY: CGFloat(0.0))
+    }
+    
+    /**
+     Creates an affine transformation matrix from translation values.
+     The matrix takes the following form:
+     
+         [ 1  0  0 ]
+         [ 0  1  0 ]
+         [ x  y  1 ]
+     */
+    public init(translationByX x: CGFloat, byY y: CGFloat) {
+        self.init(m11: CGFloat(1.0), m12: CGFloat(0.0),
+                  m21: CGFloat(0.0), m22: CGFloat(1.0),
+                   tX: x,             tY: y)
+    }
+    
+    /**
+     Creates an affine transformation matrix from scaling values.
+     The matrix takes the following form:
+     
+         [ x  0  0 ]
+         [ 0  y  0 ]
+         [ 0  0  1 ]
+     */
+    public init(scaleByX x: CGFloat, byY y: CGFloat) {
+        self.init(m11: x,            m12: CGFloat(0.0),
+                  m21: CGFloat(0.0), m22: y,
+                   tX: CGFloat(0.0),  tY: CGFloat(0.0))
+    }
+    
+    /**
+     Creates an affine transformation matrix from scaling a single value.
+     The matrix takes the following form:
+     
+         [ f  0  0 ]
+         [ 0  f  0 ]
+         [ 0  0  1 ]
+     */
+    public init(scale factor: CGFloat) {
+        self.init(scaleByX: factor, byY: factor)
+    }
+    
+    /**
+     Creates an affine transformation matrix from rotation value (angle in radians).
+     The matrix takes the following form:
+     
+         [  cos α   sin α  0 ]
+         [ -sin α   cos α  0 ]
+         [    0       0    1 ]
+     */
+    public init(rotationByRadians angle: CGFloat) {
+        let α = Double(angle)
+        
+        let sine = CGFloat(sin(α))
+        let cosine = CGFloat(cos(α))
+        
+        self.init(m11: cosine, m12: sine, m21: -sine, m22: cosine, tX: 0, tY: 0)
+    }
+    
+    /**
+     Creates an affine transformation matrix from a rotation value (angle in degrees).
+     The matrix takes the following form:
+     
+         [  cos α   sin α  0 ]
+         [ -sin α   cos α  0 ]
+         [    0       0    1 ]
+     */
+    public init(rotationByDegrees angle: CGFloat) {
+        let α = angle * .pi / 180.0
+        self.init(rotationByRadians: α)
+    }
+    
+    /**
+     An identity affine transformation matrix
+     
+         [ 1  0  0 ]
+         [ 0  1  0 ]
+         [ 0  0  1 ]
+     */
+    public static let identity = AffineTransform(m11: 1, m12: 0, m21: 0, m22: 1, tX: 0, tY: 0)
+    
+    // Translating
+    
+    public mutating func translate(x: CGFloat, y: CGFloat) {
+        tX += m11 * x + m21 * y
+        tY += m12 * x + m22 * y
+    }
+    
+    /**
+     Mutates an affine transformation matrix from a rotation value (angle α in degrees).
+     The matrix takes the following form:
+     
+         [  cos α   sin α  0 ]
+         [ -sin α   cos α  0 ]
+         [    0       0    1 ]
+     */
+    public mutating func rotate(byDegrees angle: CGFloat) {
+        let α = angle * .pi / 180.0
+        return rotate(byRadians: α)
+    }
+    
+    /**
+     Mutates an affine transformation matrix from a rotation value (angle α in radians).
+     The matrix takes the following form:
+     
+         [  cos α   sin α  0 ]
+         [ -sin α   cos α  0 ]
+         [    0       0    1 ]
+     */
+    public mutating func rotate(byRadians angle: CGFloat) {
+        let t2 = self
+        let t1 = AffineTransform(rotationByRadians: angle)
+
+        var t = AffineTransform.identity
+
+        t.m11 = t1.m11 * t2.m11 + t1.m12 * t2.m21
+        t.m12 = t1.m11 * t2.m12 + t1.m12 * t2.m22
+        t.m21 = t1.m21 * t2.m11 + t1.m22 * t2.m21
+        t.m22 = t1.m21 * t2.m12 + t1.m22 * t2.m22
+        t.tX = t1.tX * t2.m11 + t1.tY * t2.m21 + t2.tX
+        t.tY = t1.tX * t2.m12 + t1.tY * t2.m22 + t2.tY
+
+        self = t
+    }
+    
+    /**
+     Creates an affine transformation matrix by combining the receiver with `transformStruct`.
+     That is, it computes `T * M` and returns the result, where `T` is the receiver's and `M` is
+     the `transformStruct`'s affine transformation matrix.
+     The resulting matrix takes the following form:
+     
+                 [ m11_T  m12_T  0 ] [ m11_M  m12_M  0 ]
+         T * M = [ m21_T  m22_T  0 ] [ m21_M  m22_M  0 ]
+                 [  tX_T   tY_T  1 ] [  tX_M   tY_M  1 ]
+     
+                 [    (m11_T*m11_M + m12_T*m21_M)       (m11_T*m12_M + m12_T*m22_M)    0 ]
+               = [    (m21_T*m11_M + m22_T*m21_M)       (m21_T*m12_M + m22_T*m22_M)    0 ]
+                 [ (tX_T*m11_M + tY_T*m21_M + tX_M)  (tX_T*m12_M + tY_T*m22_M + tY_M)  1 ]
+     */
+    private func concatenated(_ other: AffineTransform) -> AffineTransform {
+        let (t, m) = (self, other)
+        
+        // this could be optimized with a vector version
+        return AffineTransform(
+            m11: (t.m11 * m.m11) + (t.m12 * m.m21), m12: (t.m11 * m.m12) + (t.m12 * m.m22),
+            m21: (t.m21 * m.m11) + (t.m22 * m.m21), m22: (t.m21 * m.m12) + (t.m22 * m.m22),
+            tX: (t.tX * m.m11) + (t.tY * m.m21) + m.tX,
+            tY: (t.tX * m.m12) + (t.tY * m.m22) + m.tY
+        )
+    }
+    
+    // Scaling
+    public mutating func scale(_ scale: CGFloat) {
+        self.scale(x: scale, y: scale)
+    }
+    
+    public mutating func scale(x: CGFloat, y: CGFloat) {
+        m11 *= x
+        m12 *= x
+        m21 *= y
+        m22 *= y
+    }
+    
+    /**
+     Inverts the transformation matrix if possible. Matrices with a determinant that is less than
+     the smallest valid representation of a double value greater than zero are considered to be 
+     invalid for representing as an inverse. If the input AffineTransform can potentially fall into
+     this case then the inverted() method is suggested to be used instead since that will return
+     an optional value that will be nil in the case that the matrix cannot be inverted.
+     
+     D = (m11 * m22) - (m12 * m21)
+     
+     D < ε the inverse is undefined and will be nil
+    */
+    public mutating func invert() {
+        guard let inverse = inverted() else {
+            fatalError("Transform has no inverse")
+        }
+        self = inverse
+    }
+    
+    public func inverted() -> AffineTransform? {
+        let determinant = (m11 * m22) - (m12 * m21)
+        if abs(determinant) <= ε {
+            return nil
+        }
+        var inverse = AffineTransform()
+        inverse.m11 = m22 / determinant
+        inverse.m12 = -m12 / determinant
+        inverse.m21 = -m21 / determinant
+        inverse.m22 = m11 / determinant
+        inverse.tX = (m21 * tY - m22 * tX) / determinant
+        inverse.tY = (m12 * tX - m11 * tY) / determinant
+        return inverse
+    }
+    
+    // Transforming with transform
+    public mutating func append(_ transform: AffineTransform) {
+        self = concatenated(transform)
+    }
+    
+    public mutating func prepend(_ transform: AffineTransform) {
+        self = transform.concatenated(self)
+    }
+    
+    // Transforming points and sizes
+    public func transform(_ point: NSPoint) -> NSPoint {
+        var newPoint = NSPoint()
+        newPoint.x = (m11 * point.x) + (m21 * point.y) + tX
+        newPoint.y = (m12 * point.x) + (m22 * point.y) + tY
+        return newPoint
+    }
+    
+    public func transform(_ size: NSSize) -> NSSize {
+        var newSize = NSSize()
+        newSize.width = (m11 * size.width) + (m21 * size.height)
+        newSize.height = (m12 * size.width) + (m22 * size.height)
+        return newSize
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(m11)
+        hasher.combine(m12)
+        hasher.combine(m21)
+        hasher.combine(m22)
+        hasher.combine(tX)
+        hasher.combine(tY)
+    }
+    
+    public var description: String {
+        return "{m11:\(m11), m12:\(m12), m21:\(m21), m22:\(m22), tX:\(tX), tY:\(tY)}"
+    }
+    
+    public var debugDescription: String {
+        return description
+    }
+
+    public static func ==(lhs: AffineTransform, rhs: AffineTransform) -> Bool {
+        return lhs.m11 == rhs.m11 && lhs.m12 == rhs.m12 &&
+               lhs.m21 == rhs.m21 && lhs.m22 == rhs.m22 &&
+               lhs.tX == rhs.tX && lhs.tY == rhs.tY
+    }
+
+}
+
+extension AffineTransform : _ObjectiveCBridgeable {
+    public static func _getObjectiveCType() -> Any.Type {
+        return NSAffineTransform.self
+    }
+    
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSAffineTransform {
+        return self.reference
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSAffineTransform, result: inout AffineTransform?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge type")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSAffineTransform, result: inout AffineTransform?) -> Bool {
+        result = AffineTransform(reference: x)
+        return true // Can't fail
+    }
+
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ x: NSAffineTransform?) -> AffineTransform {
+        guard let src = x else { return AffineTransform.identity }
+        return AffineTransform(reference: src)
+    }
+}
+
+extension NSAffineTransform : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as AffineTransform)
+    }
+}
+
+extension AffineTransform : Codable {
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        m11 = try container.decode(CGFloat.self)
+        m12 = try container.decode(CGFloat.self)
+        m21 = try container.decode(CGFloat.self)
+        m22 = try container.decode(CGFloat.self)
+        tX  = try container.decode(CGFloat.self)
+        tY  = try container.decode(CGFloat.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(self.m11)
+        try container.encode(self.m12)
+        try container.encode(self.m21)
+        try container.encode(self.m22)
+        try container.encode(self.tX)
+        try container.encode(self.tY)
+    }
+}
+
+#endif

--- a/Darwin/Foundation-swiftoverlay/Boxing.swift
+++ b/Darwin/Foundation-swiftoverlay/Boxing.swift
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+/// A class type which acts as a handle (pointer-to-pointer) to a Foundation reference type which has only a mutable class (e.g., NSURLComponents).
+///
+/// Note: This assumes that the result of calling copy() is mutable. The documentation says that classes which do not have a mutable/immutable distinction should just adopt NSCopying instead of NSMutableCopying.
+internal final class _MutableHandle<MutableType : NSObject>
+  where MutableType : NSCopying {
+    fileprivate var _pointer : MutableType
+    
+    init(reference : __shared MutableType) {
+        _pointer = reference.copy() as! MutableType
+    }
+    
+    init(adoptingReference reference: MutableType) {
+        _pointer = reference
+    }
+    
+    /// Apply a closure to the reference type.
+    func map<ReturnType>(_ whatToDo : (MutableType) throws -> ReturnType) rethrows -> ReturnType {
+        return try whatToDo(_pointer)
+    }
+    
+    func _copiedReference() -> MutableType {
+        return _pointer.copy() as! MutableType
+    }
+    
+    func _uncopiedReference() -> MutableType {
+        return _pointer
+    }
+}
+
+/// Describes common operations for Foundation struct types that are bridged to a mutable object (e.g. NSURLComponents).
+internal protocol _MutableBoxing : ReferenceConvertible {
+    var _handle : _MutableHandle<ReferenceType> { get set }
+    
+    /// Apply a mutating closure to the reference type, regardless if it is mutable or immutable.
+    ///
+    /// This function performs the correct copy-on-write check for efficient mutation.
+    mutating func _applyMutation<ReturnType>(_ whatToDo : (ReferenceType) -> ReturnType) -> ReturnType
+}
+
+extension _MutableBoxing {
+    @inline(__always)
+    mutating func _applyMutation<ReturnType>(_ whatToDo : (ReferenceType) -> ReturnType) -> ReturnType {
+        // Only create a new box if we are not uniquely referenced
+        if !isKnownUniquelyReferenced(&_handle) {
+            let ref = _handle._pointer
+            _handle = _MutableHandle(reference: ref)
+        }
+        return whatToDo(_handle._pointer)
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/BundleLookup.mm
+++ b/Darwin/Foundation-swiftoverlay/BundleLookup.mm
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import <Foundation/Foundation.h>
+
+#include <objc/runtime.h>
+
+// This method is only used on "embedded" targets. It's not necessary on
+// Mac or simulators.
+#if TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
+
+/// CoreFoundation SPI for finding the enclosing bundle. This is only
+/// ever called on older OSes, so there's no worry of running into
+/// trouble if the implementation is changed later on.
+extern "C" CFURLRef _CFBundleCopyBundleURLForExecutableURL(CFURLRef url);
+
+@implementation NSBundle (SwiftAdditions)
+
+/// Given an executable path as a C string, look up the corresponding
+/// NSBundle instance, if any.
++ (NSBundle *)_swift_bundleWithExecutablePath: (const char *)path {
+  NSString *nspath = [[NSFileManager defaultManager]
+    stringWithFileSystemRepresentation:path length:strlen(path)];
+  NSURL *executableURL = [NSURL fileURLWithPath:nspath];
+  NSURL *bundleURL =
+    (NSURL *)_CFBundleCopyBundleURLForExecutableURL((CFURLRef)executableURL);
+  if (!bundleURL)
+    return nil;
+  
+  NSBundle *bundle = [NSBundle bundleWithURL: bundleURL];
+  [bundleURL release];
+  return bundle;
+}
+
+@end
+
+#endif

--- a/Darwin/Foundation-swiftoverlay/Calendar.swift
+++ b/Darwin/Foundation-swiftoverlay/Calendar.swift
@@ -1,0 +1,1164 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+@_implementationOnly import _FoundationOverlayShims
+
+/**
+ `Calendar` encapsulates information about systems of reckoning time in which the beginning, length, and divisions of a year are defined. It provides information about the calendar and support for calendrical computations such as determining the range of a given calendrical unit and adding units to a given absolute time.
+*/
+public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxing {
+    public typealias ReferenceType = NSCalendar
+    
+    private var _autoupdating: Bool
+    internal var _handle: _MutableHandle<NSCalendar>
+
+    /// Calendar supports many different kinds of calendars. Each is identified by an identifier here.
+    public enum Identifier {
+        /// The common calendar in Europe, the Western Hemisphere, and elsewhere.
+        case gregorian
+        
+        case buddhist
+        case chinese
+        case coptic
+        case ethiopicAmeteMihret
+        case ethiopicAmeteAlem
+        case hebrew
+        case iso8601
+        case indian
+        case islamic
+        case islamicCivil
+        case japanese
+        case persian
+        case republicOfChina
+        
+        /// A simple tabular Islamic calendar using the astronomical/Thursday epoch of CE 622 July 15
+        @available(macOS 10.10, iOS 8.0, *)
+        case islamicTabular
+        
+        /// The Islamic Umm al-Qura calendar used in Saudi Arabia. This is based on astronomical calculation, instead of tabular behavior.
+        @available(macOS 10.10, iOS 8.0, *)
+        case islamicUmmAlQura
+        
+    }
+    
+    /// An enumeration for the various components of a calendar date.
+    ///
+    /// Several `Calendar` APIs use either a single unit or a set of units as input to a search algorithm.
+    ///
+    /// - seealso: `DateComponents`
+    public enum Component {
+        case era
+        case year
+        case month
+        case day
+        case hour
+        case minute
+        case second
+        case weekday
+        case weekdayOrdinal
+        case quarter
+        case weekOfMonth
+        case weekOfYear
+        case yearForWeekOfYear
+        case nanosecond
+        case calendar
+        case timeZone
+    }
+    
+    /// Returns the user's current calendar.
+    ///
+    /// This calendar does not track changes that the user makes to their preferences.
+    public static var current : Calendar {
+        return Calendar(adoptingReference: __NSCalendarCurrent() as! NSCalendar, autoupdating: false)
+    }
+    
+    /// A Calendar that tracks changes to user's preferred calendar.
+    ///
+    /// If mutated, this calendar will no longer track the user's preferred calendar.
+    ///
+    /// - note: The autoupdating Calendar will only compare equal to another autoupdating Calendar.
+    public static var autoupdatingCurrent : Calendar {
+        return Calendar(adoptingReference: __NSCalendarAutoupdating() as! NSCalendar, autoupdating: true)
+    }
+
+    // MARK: -
+    // MARK: init
+    
+    /// Returns a new Calendar.
+    ///
+    /// - parameter identifier: The kind of calendar to use.
+    public init(identifier: __shared Identifier) {
+        let result = __NSCalendarCreate(Calendar._toNSCalendarIdentifier(identifier))
+        _handle = _MutableHandle(adoptingReference: result as! NSCalendar)
+        _autoupdating = false
+    }
+    
+    // MARK: -
+    // MARK: Bridging
+    
+    fileprivate init(reference : __shared NSCalendar) {
+        _handle = _MutableHandle(reference: reference)
+        if __NSCalendarIsAutoupdating(reference) {
+            _autoupdating = true
+        } else {
+            _autoupdating = false
+        }
+    }
+
+    private init(adoptingReference reference: NSCalendar, autoupdating: Bool) {
+        _handle = _MutableHandle(adoptingReference: reference)
+        _autoupdating = autoupdating
+    }
+
+    // MARK: -
+    // 
+    
+    /// The identifier of the calendar.
+    public var identifier : Identifier {
+        return Calendar._fromNSCalendarIdentifier(_handle.map({ $0.calendarIdentifier }))
+    }
+
+    /// The locale of the calendar.
+    public var locale : Locale? {
+        get {
+            return _handle.map { $0.locale }
+        }
+        set {
+            _applyMutation { $0.locale = newValue }
+        }
+    }
+    
+    /// The time zone of the calendar.
+    public var timeZone : TimeZone {
+        get {
+            return _handle.map { $0.timeZone }
+        }
+        set {
+            _applyMutation { $0.timeZone = newValue }
+        }
+    }
+    
+    /// The first weekday of the calendar.
+    public var firstWeekday : Int {
+        get {
+            return _handle.map { $0.firstWeekday }
+        }
+        set {
+            _applyMutation { $0.firstWeekday = newValue }
+        }
+    }
+    
+    /// The number of minimum days in the first week.
+    public var minimumDaysInFirstWeek : Int {
+        get {
+            return _handle.map { $0.minimumDaysInFirstWeek }
+        }
+        set {
+            _applyMutation { $0.minimumDaysInFirstWeek = newValue }
+        }
+    }
+    
+    /// A list of eras in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["BC", "AD"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var eraSymbols: [String] {
+        return _handle.map { $0.eraSymbols }
+    }
+    
+    /// A list of longer-named eras in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Before Christ", "Anno Domini"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var longEraSymbols: [String] {
+        return _handle.map { $0.longEraSymbols }
+    }
+    
+    /// A list of months in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var monthSymbols: [String] {
+        return _handle.map { $0.monthSymbols }
+    }
+    
+    /// A list of shorter-named months in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var shortMonthSymbols: [String] {
+        return _handle.map { $0.shortMonthSymbols }
+    }
+    
+    /// A list of very-shortly-named months in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var veryShortMonthSymbols: [String] {
+        return _handle.map { $0.veryShortMonthSymbols }
+    }
+    
+    /// A list of standalone months in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]`.
+    /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var standaloneMonthSymbols: [String] {
+        return _handle.map { $0.standaloneMonthSymbols }
+    }
+    
+    /// A list of shorter-named standalone months in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]`.
+    /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var shortStandaloneMonthSymbols: [String] {
+        return _handle.map { $0.shortStandaloneMonthSymbols }
+    }
+    
+    /// A list of very-shortly-named standalone months in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"]`.
+    /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var veryShortStandaloneMonthSymbols: [String] {
+        return _handle.map { $0.veryShortStandaloneMonthSymbols }
+    }
+    
+    /// A list of weekdays in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var weekdaySymbols: [String] {
+        return _handle.map { $0.weekdaySymbols }
+    }
+    
+    /// A list of shorter-named weekdays in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var shortWeekdaySymbols: [String] {
+        return _handle.map { $0.shortWeekdaySymbols }
+    }
+    
+    /// A list of very-shortly-named weekdays in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["S", "M", "T", "W", "T", "F", "S"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var veryShortWeekdaySymbols: [String] {
+        return _handle.map { $0.veryShortWeekdaySymbols }
+    }
+    
+    /// A list of standalone weekday names in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]`.
+    /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var standaloneWeekdaySymbols: [String] {
+        return _handle.map { $0.standaloneWeekdaySymbols }
+    }
+    
+    /// A list of shorter-named standalone weekdays in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]`.
+    /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var shortStandaloneWeekdaySymbols: [String] {
+        return _handle.map { $0.shortStandaloneWeekdaySymbols }
+    }
+    
+    /// A list of very-shortly-named weekdays in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["S", "M", "T", "W", "T", "F", "S"]`.
+    /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var veryShortStandaloneWeekdaySymbols: [String] {
+        return _handle.map { $0.veryShortStandaloneWeekdaySymbols }
+    }
+    
+    /// A list of quarter names in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["1st quarter", "2nd quarter", "3rd quarter", "4th quarter"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var quarterSymbols: [String] {
+        return _handle.map { $0.quarterSymbols }
+    }
+    
+    /// A list of shorter-named quarters in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Q1", "Q2", "Q3", "Q4"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var shortQuarterSymbols: [String] {
+        return _handle.map { $0.shortQuarterSymbols }
+    }
+    
+    /// A list of standalone quarter names in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["1st quarter", "2nd quarter", "3rd quarter", "4th quarter"]`.
+    /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var standaloneQuarterSymbols: [String] {
+        return _handle.map { $0.standaloneQuarterSymbols }
+    }
+    
+    /// A list of shorter-named standalone quarters in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Q1", "Q2", "Q3", "Q4"]`.
+    /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var shortStandaloneQuarterSymbols: [String] {
+        return _handle.map { $0.shortStandaloneQuarterSymbols }
+    }
+    
+    /// The symbol used to represent "AM", localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `"AM"`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var amSymbol: String {
+        return _handle.map { $0.amSymbol }
+    }
+    
+    /// The symbol used to represent "PM", localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `"PM"`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var pmSymbol: String {
+        return _handle.map { $0.pmSymbol }
+    }
+    
+    // MARK: -
+    //
+    
+    /// Returns the minimum range limits of the values that a given component can take on in the receiver.
+    ///
+    /// As an example, in the Gregorian calendar the minimum range of values for the Day component is 1-28.
+    /// - parameter component: A component to calculate a range for.
+    /// - returns: The range, or nil if it could not be calculated.
+    public func minimumRange(of component: Component) -> Range<Int>? {
+        return _handle.map { Range($0.minimumRange(of: Calendar._toCalendarUnit([component]))) }
+    }
+    
+    /// The maximum range limits of the values that a given component can take on in the receive
+    ///
+    /// As an example, in the Gregorian calendar the maximum range of values for the Day component is 1-31.
+    /// - parameter component: A component to calculate a range for.
+    /// - returns: The range, or nil if it could not be calculated.
+    public func maximumRange(of component: Component) -> Range<Int>? {
+        return _handle.map { Range($0.maximumRange(of: Calendar._toCalendarUnit([component]))) }
+    }
+    
+    
+    @available(*, unavailable, message: "use range(of:in:for:) instead")
+    public func range(of smaller: NSCalendar.Unit, in larger: NSCalendar.Unit, for date: Date) -> NSRange {
+        fatalError()
+    }
+    
+    /// Returns the range of absolute time values that a smaller calendar component (such as a day) can take on in a larger calendar component (such as a month) that includes a specified absolute time.
+    ///
+    /// You can use this method to calculate, for example, the range the `day` component can take on in the `month` in which `date` lies.
+    /// - parameter smaller: The smaller calendar component.
+    /// - parameter larger: The larger calendar component.
+    /// - parameter date: The absolute time for which the calculation is performed.
+    /// - returns: The range of absolute time values smaller can take on in larger at the time specified by date. Returns `nil` if larger is not logically bigger than smaller in the calendar, or the given combination of components does not make sense (or is a computation which is undefined).
+    public func range(of smaller: Component, in larger: Component, for date: Date) -> Range<Int>? {
+        return _handle.map { Range($0.range(of: Calendar._toCalendarUnit([smaller]), in: Calendar._toCalendarUnit([larger]), for: date)) }
+    }
+    
+    @available(*, unavailable, message: "use range(of:in:for:) instead")
+    public func range(of unit: NSCalendar.Unit, start datep: AutoreleasingUnsafeMutablePointer<NSDate?>?, interval tip: UnsafeMutablePointer<TimeInterval>?, for date: Date) -> Bool {
+        fatalError()
+    }
+    
+    /// Returns, via two inout parameters, the starting time and duration of a given calendar component that contains a given date.
+    ///
+    /// - seealso: `range(of:for:)`
+    /// - seealso: `dateInterval(of:for:)`
+    /// - parameter component: A calendar component.
+    /// - parameter start: Upon return, the starting time of the calendar component that contains the date.
+    /// - parameter interval: Upon return, the duration of the calendar component that contains the date.
+    /// - parameter date: The specified date.
+    /// - returns: `true` if the starting time and duration of a component could be calculated, otherwise `false`.
+    public func dateInterval(of component: Component, start: inout Date, interval: inout TimeInterval, for date: Date) -> Bool {
+        var nsDate : NSDate?
+        var ti : TimeInterval = 0
+        if _handle.map({ $0.range(of: Calendar._toCalendarUnit([component]), start: &nsDate, interval: &ti, for: date) }) {
+            start = nsDate! as Date
+            interval = ti
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    /// Returns the starting time and duration of a given calendar component that contains a given date.
+    ///
+    /// - parameter component: A calendar component.
+    /// - parameter date: The specified date.
+    /// - returns: A new `DateInterval` if the starting time and duration of a component could be calculated, otherwise `nil`.
+    @available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+    public func dateInterval(of component: Component, for date: Date) -> DateInterval? {
+        var start : Date = Date(timeIntervalSinceReferenceDate: 0)
+        var interval : TimeInterval = 0
+        if self.dateInterval(of: component, start: &start, interval: &interval, for: date) {
+            return DateInterval(start: start, duration: interval)
+        } else {
+            return nil
+        }
+    }
+    
+    /// Returns, for a given absolute time, the ordinal number of a smaller calendar component (such as a day) within a specified larger calendar component (such as a week).
+    ///
+    /// The ordinality is in most cases not the same as the decomposed value of the component. Typically return values are 1 and greater. For example, the time 00:45 is in the first hour of the day, and for components `hour` and `day` respectively, the result would be 1. An exception is the week-in-month calculation, which returns 0 for days before the first week in the month containing the date.
+    ///
+    /// - note: Some computations can take a relatively long time.
+    /// - parameter smaller: The smaller calendar component.
+    /// - parameter larger: The larger calendar component.
+    /// - parameter date: The absolute time for which the calculation is performed.
+    /// - returns: The ordinal number of smaller within larger at the time specified by date. Returns `nil` if larger is not logically bigger than smaller in the calendar, or the given combination of components does not make sense (or is a computation which is undefined).
+    public func ordinality(of smaller: Component, in larger: Component, for date: Date) -> Int? {
+        let result = _handle.map { $0.ordinality(of: Calendar._toCalendarUnit([smaller]), in: Calendar._toCalendarUnit([larger]), for: date) }
+        if result == NSNotFound { return nil }
+        return result
+    }
+    
+    // MARK: -
+    //
+    
+    @available(*, unavailable, message: "use dateComponents(_:from:) instead")
+    public func getEra(_ eraValuePointer: UnsafeMutablePointer<Int>?, year yearValuePointer: UnsafeMutablePointer<Int>?, month monthValuePointer: UnsafeMutablePointer<Int>?, day dayValuePointer: UnsafeMutablePointer<Int>?, from date: Date) { fatalError() }
+    
+    @available(*, unavailable, message: "use dateComponents(_:from:) instead")
+    public func getEra(_ eraValuePointer: UnsafeMutablePointer<Int>?, yearForWeekOfYear yearValuePointer: UnsafeMutablePointer<Int>?, weekOfYear weekValuePointer: UnsafeMutablePointer<Int>?, weekday weekdayValuePointer: UnsafeMutablePointer<Int>?, from date: Date) { fatalError() }
+    
+    @available(*, unavailable, message: "use dateComponents(_:from:) instead")
+    public func getHour(_ hourValuePointer: UnsafeMutablePointer<Int>?, minute minuteValuePointer: UnsafeMutablePointer<Int>?, second secondValuePointer: UnsafeMutablePointer<Int>?, nanosecond nanosecondValuePointer: UnsafeMutablePointer<Int>?, from date: Date) { fatalError() }
+    
+    // MARK: -
+    //
+    
+    
+    @available(*, unavailable, message: "use date(byAdding:to:wrappingComponents:) instead")
+    public func date(byAdding unit: NSCalendar.Unit, value: Int, to date: Date, options: NSCalendar.Options = []) -> Date? { fatalError() }
+    
+    /// Returns a new `Date` representing the date calculated by adding components to a given date.
+    ///
+    /// - parameter components: A set of values to add to the date.
+    /// - parameter date: The starting date.
+    /// - parameter wrappingComponents: If `true`, the component should be incremented and wrap around to zero/one on overflow, and should not cause higher components to be incremented. The default value is `false`.
+    /// - returns: A new date, or nil if a date could not be calculated with the given input.
+    public func date(byAdding components: DateComponents, to date: Date, wrappingComponents: Bool = false) -> Date? {
+        return _handle.map { $0.date(byAdding: components, to: date, options: wrappingComponents ? [.wrapComponents] : []) }
+    }
+    
+    
+    @available(*, unavailable, message: "use date(byAdding:to:wrappingComponents:) instead")
+    public func date(byAdding comps: DateComponents, to date: Date, options opts: NSCalendar.Options = []) -> Date? { fatalError() }
+    
+    /// Returns a new `Date` representing the date calculated by adding an amount of a specific component to a given date.
+    ///
+    /// - parameter component: A single component to add.
+    /// - parameter value: The value of the specified component to add.
+    /// - parameter date: The starting date.
+    /// - parameter wrappingComponents: If `true`, the component should be incremented and wrap around to zero/one on overflow, and should not cause higher components to be incremented. The default value is `false`.
+    /// - returns: A new date, or nil if a date could not be calculated with the given input.
+    @available(iOS 8.0, *)
+    public func date(byAdding component: Component, value: Int, to date: Date, wrappingComponents: Bool = false) -> Date? {
+        return _handle.map { $0.date(byAdding: Calendar._toCalendarUnit([component]), value: value, to: date, options: wrappingComponents ? [.wrapComponents] : []) }
+    }
+    
+    /// Returns a date created from the specified components.
+    ///
+    /// - parameter components: Used as input to the search algorithm for finding a corresponding date.
+    /// - returns: A new `Date`, or nil if a date could not be found which matches the components.
+    public func date(from components: DateComponents) -> Date? {
+        return _handle.map { $0.date(from: components) }
+    }
+    
+    @available(*, unavailable, renamed: "dateComponents(_:from:)")
+    public func components(_ unitFlags: NSCalendar.Unit, from date: Date) -> DateComponents { fatalError() }
+    
+    /// Returns all the date components of a date, using the calendar time zone.
+    ///
+    /// - note: If you want "date information in a given time zone" in order to display it, you should use `DateFormatter` to format the date.
+    /// - parameter date: The `Date` to use.
+    /// - returns: The date components of the specified date.
+    public func dateComponents(_ components: Set<Component>, from date: Date) -> DateComponents {
+        return _handle.map { $0.components(Calendar._toCalendarUnit(components), from: date) }
+    }
+    
+    
+    @available(*, unavailable, renamed: "dateComponents(in:from:)")
+    public func components(in timezone: TimeZone, from date: Date) -> DateComponents { fatalError() }
+    
+    /// Returns all the date components of a date, as if in a given time zone (instead of the `Calendar` time zone).
+    ///
+    /// The time zone overrides the time zone of the `Calendar` for the purposes of this calculation.
+    /// - note: If you want "date information in a given time zone" in order to display it, you should use `DateFormatter` to format the date.
+    /// - parameter timeZone: The `TimeZone` to use.
+    /// - parameter date: The `Date` to use.
+    /// - returns: All components, calculated using the `Calendar` and `TimeZone`.
+    @available(iOS 8.0, *)
+    public func dateComponents(in timeZone: TimeZone, from date: Date) -> DateComponents {
+        return _handle.map { $0.components(in: timeZone, from: date) }
+    }
+    
+    @available(*, unavailable, renamed: "dateComponents(_:from:to:)")
+    public func components(_ unitFlags: NSCalendar.Unit, from startingDate: Date, to resultDate: Date, options opts: NSCalendar.Options = []) -> DateComponents { fatalError() }
+    
+    /// Returns the difference between two dates.
+    ///
+    /// - parameter components: Which components to compare.
+    /// - parameter start: The starting date.
+    /// - parameter end: The ending date.
+    /// - returns: The result of calculating the difference from start to end.
+    public func dateComponents(_ components: Set<Component>, from start: Date, to end: Date) -> DateComponents {
+        return _handle.map { $0.components(Calendar._toCalendarUnit(components), from: start, to: end, options: []) }
+    }
+    
+    @available(*, unavailable, renamed: "dateComponents(_:from:to:)")
+    public func components(_ unitFlags: NSCalendar.Unit, from startingDateComp: DateComponents, to resultDateComp: DateComponents, options: NSCalendar.Options = []) -> DateComponents { fatalError() }
+    
+    /// Returns the difference between two dates specified as `DateComponents`.
+    ///
+    /// For components which are not specified in each `DateComponents`, but required to specify an absolute date, the base value of the component is assumed.  For example, for an `DateComponents` with just a `year` and a `month` specified, a `day` of 1, and an `hour`, `minute`, `second`, and `nanosecond` of 0 are assumed.
+    /// Calendrical calculations with unspecified `year` or `year` value prior to the start of a calendar are not advised.
+    /// For each `DateComponents`, if its `timeZone` property is set, that time zone is used for it. If the `calendar` property is set, that is used rather than the receiving calendar, and if both the `calendar` and `timeZone` are set, the `timeZone` property value overrides the time zone of the `calendar` property.
+    ///
+    /// - parameter components: Which components to compare.
+    /// - parameter start: The starting date components.
+    /// - parameter end: The ending date components.
+    /// - returns: The result of calculating the difference from start to end.
+    @available(iOS 8.0, *)
+    public func dateComponents(_ components: Set<Component>, from start: DateComponents, to end: DateComponents) -> DateComponents {
+        return _handle.map { $0.components(Calendar._toCalendarUnit(components), from: start, to: end, options: []) }
+    }
+    
+    
+    /// Returns the value for one component of a date.
+    ///
+    /// - parameter component: The component to calculate.
+    /// - parameter date: The date to use.
+    /// - returns: The value for the component.
+    @available(iOS 8.0, *)
+    public func component(_ component: Component, from date: Date) -> Int {
+        return _handle.map { $0.component(Calendar._toCalendarUnit([component]), from: date) }
+    }
+    
+    
+    @available(*, unavailable, message: "Use date(from:) instead")
+    public func date(era: Int, year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int, nanosecond: Int) -> Date? { fatalError() }
+    
+    
+    @available(*, unavailable, message: "Use date(from:) instead")
+    public func date(era: Int, yearForWeekOfYear: Int, weekOfYear: Int, weekday: Int, hour: Int, minute: Int, second: Int, nanosecond: Int) -> Date? { fatalError() }
+    
+    
+    /// Returns the first moment of a given Date, as a Date.
+    ///
+    /// For example, pass in `Date()`, if you want the start of today.
+    /// If there were two midnights, it returns the first.  If there was none, it returns the first moment that did exist.
+    /// - parameter date: The date to search.
+    /// - returns: The first moment of the given date.
+    @available(iOS 8.0, *)
+    public func startOfDay(for date: Date) -> Date {
+        return _handle.map { $0.startOfDay(for: date) }
+    }
+    
+    
+    @available(*, unavailable, renamed: "compare(_:to:toGranularity:)")
+    public func compare(_ date1: Date, to date2: Date, toUnitGranularity unit: NSCalendar.Unit) -> ComparisonResult { fatalError() }
+    
+    
+    /// Compares the given dates down to the given component, reporting them `orderedSame` if they are the same in the given component and all larger components, otherwise either `orderedAscending` or `orderedDescending`.
+    ///
+    /// - parameter date1: A date to compare.
+    /// - parameter date2: A date to compare.
+    /// - parameter: component: A granularity to compare. For example, pass `.hour` to check if two dates are in the same hour.
+    @available(iOS 8.0, *)
+    public func compare(_ date1: Date, to date2: Date, toGranularity component: Component) -> ComparisonResult {
+        return _handle.map { $0.compare(date1, to: date2, toUnitGranularity: Calendar._toCalendarUnit([component])) }
+    }
+    
+    
+    @available(*, unavailable, renamed: "isDate(_:equalTo:toGranularity:)")
+    public func isDate(_ date1: Date, equalTo date2: Date, toUnitGranularity unit: NSCalendar.Unit) -> Bool { fatalError() }
+    
+    /// Compares the given dates down to the given component, reporting them equal if they are the same in the given component and all larger components.
+    ///
+    /// - parameter date1: A date to compare.
+    /// - parameter date2: A date to compare.
+    /// - parameter component: A granularity to compare. For example, pass `.hour` to check if two dates are in the same hour.
+    /// - returns: `true` if the given date is within tomorrow.
+    @available(iOS 8.0, *)
+    public func isDate(_ date1: Date, equalTo date2: Date, toGranularity component: Component) -> Bool {
+        return _handle.map { $0.isDate(date1, equalTo: date2, toUnitGranularity: Calendar._toCalendarUnit([component])) }
+    }
+    
+    
+    /// Returns `true` if the given date is within the same day as another date, as defined by the calendar and calendar's locale.
+    ///
+    /// - parameter date1: A date to check for containment.
+    /// - parameter date2: A date to check for containment.
+    /// - returns: `true` if `date1` and `date2` are in the same day.
+    @available(iOS 8.0, *)
+    public func isDate(_ date1: Date, inSameDayAs date2: Date) -> Bool {
+        return _handle.map { $0.isDate(date1, inSameDayAs: date2) }
+    }
+    
+    
+    /// Returns `true` if the given date is within today, as defined by the calendar and calendar's locale.
+    ///
+    /// - parameter date: The specified date.
+    /// - returns: `true` if the given date is within today.
+    @available(iOS 8.0, *)
+    public func isDateInToday(_ date: Date) -> Bool {
+        return _handle.map { $0.isDateInToday(date) }
+    }
+    
+    
+    /// Returns `true` if the given date is within yesterday, as defined by the calendar and calendar's locale.
+    ///
+    /// - parameter date: The specified date.
+    /// - returns: `true` if the given date is within yesterday.
+    @available(iOS 8.0, *)
+    public func isDateInYesterday(_ date: Date) -> Bool {
+        return _handle.map { $0.isDateInYesterday(date) }
+    }
+    
+    
+    /// Returns `true` if the given date is within tomorrow, as defined by the calendar and calendar's locale.
+    ///
+    /// - parameter date: The specified date.
+    /// - returns: `true` if the given date is within tomorrow.
+    @available(iOS 8.0, *)
+    public func isDateInTomorrow(_ date: Date) -> Bool {
+        return _handle.map { $0.isDateInTomorrow(date) }
+    }
+    
+    
+    /// Returns `true` if the given date is within a weekend period, as defined by the calendar and calendar's locale.
+    ///
+    /// - parameter date: The specified date.
+    /// - returns: `true` if the given date is within a weekend.
+    @available(iOS 8.0, *)
+    public func isDateInWeekend(_ date: Date) -> Bool {
+        return _handle.map { $0.isDateInWeekend(date) }
+    }
+    
+    @available(*, unavailable, message: "use dateIntervalOfWeekend(containing:start:interval:) instead")
+    public func range(ofWeekendStart datep: AutoreleasingUnsafeMutablePointer<NSDate?>?, interval tip: UnsafeMutablePointer<TimeInterval>?, containing date: Date) -> Bool { fatalError() }
+    
+    /// Find the range of the weekend around the given date, returned via two by-reference parameters.
+    ///
+    /// Note that a given entire day within a calendar is not necessarily all in a weekend or not; weekends can start in the middle of a day in some calendars and locales.
+    /// - seealso: `dateIntervalOfWeekend(containing:)`
+    /// - parameter date: The date at which to start the search.
+    /// - parameter start: When the result is `true`, set
+    /// - returns: `true` if a date range could be found, and `false` if the date is not in a weekend.
+    @available(iOS 8.0, *)
+    public func dateIntervalOfWeekend(containing date: Date, start: inout Date, interval: inout TimeInterval) -> Bool {
+        var nsDate : NSDate?
+        var ti : TimeInterval = 0
+        if _handle.map({ $0.range(ofWeekendStart: &nsDate, interval: &ti, containing: date) }) {
+            start = nsDate! as Date
+            interval = ti
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    /// Returns a `DateInterval` of the weekend contained by the given date, or nil if the date is not in a weekend.
+    ///
+    /// - parameter date: The date contained in the weekend.
+    /// - returns: A `DateInterval`, or nil if the date is not in a weekend.
+    @available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+    public func dateIntervalOfWeekend(containing date: Date) -> DateInterval? {
+        var nsDate : NSDate?
+        var ti : TimeInterval = 0
+        if _handle.map({ $0.range(ofWeekendStart: &nsDate, interval: &ti, containing: date) }) {
+            return DateInterval(start: nsDate! as Date, duration: ti)
+        } else {
+            return nil
+        }
+    }
+    
+    
+    @available(*, unavailable, message: "use nextWeekend(startingAfter:start:interval:direction:) instead")
+    public func nextWeekendStart(_ datep: AutoreleasingUnsafeMutablePointer<NSDate?>?, interval tip: UnsafeMutablePointer<TimeInterval>?, options: NSCalendar.Options = [], after date: Date) -> Bool { fatalError() }
+    
+    /// Returns the range of the next weekend via two inout parameters. The weekend starts strictly after the given date.
+    ///
+    /// If `direction` is `.backward`, then finds the previous weekend range strictly before the given date.
+    ///
+    /// Note that a given entire Day within a calendar is not necessarily all in a weekend or not; weekends can start in the middle of a day in some calendars and locales.
+    /// - parameter date: The date at which to begin the search.
+    /// - parameter direction: Which direction in time to search. The default value is `.forward`.
+    /// - returns: A `DateInterval`, or nil if the weekend could not be found.
+    @available(iOS 8.0, *)
+    public func nextWeekend(startingAfter date: Date, start: inout Date, interval: inout TimeInterval, direction: SearchDirection = .forward) -> Bool {
+        // The implementation actually overrides previousKeepSmaller and nextKeepSmaller with matchNext, always - but strict still trumps all.
+        var nsDate : NSDate?
+        var ti : TimeInterval = 0
+        if _handle.map({ $0.nextWeekendStart(&nsDate, interval: &ti, options: direction == .backward ? [.searchBackwards] : [], after: date) }) {
+            start = nsDate! as Date
+            interval = ti
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    /// Returns a `DateInterval` of the next weekend, which starts strictly after the given date.
+    ///
+    /// If `direction` is `.backward`, then finds the previous weekend range strictly before the given date.
+    ///
+    /// Note that a given entire Day within a calendar is not necessarily all in a weekend or not; weekends can start in the middle of a day in some calendars and locales.
+    /// - parameter date: The date at which to begin the search.
+    /// - parameter direction: Which direction in time to search. The default value is `.forward`.
+    /// - returns: A `DateInterval`, or nil if weekends do not exist in the specific calendar or locale.
+    @available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+    public func nextWeekend(startingAfter date: Date, direction: SearchDirection = .forward) -> DateInterval? {
+        // The implementation actually overrides previousKeepSmaller and nextKeepSmaller with matchNext, always - but strict still trumps all.
+        var nsDate : NSDate?
+        var ti : TimeInterval = 0
+        if _handle.map({ $0.nextWeekendStart(&nsDate, interval: &ti, options: direction == .backward ? [.searchBackwards] : [], after: date) }) {
+            /// WARNING: searching backwards is totally broken! 26643365
+            return DateInterval(start: nsDate! as Date, duration: ti)
+        } else {
+            return nil
+        }
+    }
+    
+    // MARK: -
+    // MARK: Searching
+    
+    /// The direction in time to search.
+    public enum SearchDirection {
+        /// Search for a date later in time than the start date.
+        case forward
+        
+        /// Search for a date earlier in time than the start date.
+        case backward
+    }
+    
+    /// Determines which result to use when a time is repeated on a day in a calendar (for example, during a daylight saving transition when the times between 2:00am and 3:00am may happen twice).
+    public enum RepeatedTimePolicy {
+        /// If there are two or more matching times (all the components are the same, including isLeapMonth) before the end of the next instance of the next higher component to the highest specified component, then the algorithm will return the first occurrence.
+        case first
+        
+        /// If there are two or more matching times (all the components are the same, including isLeapMonth) before the end of the next instance of the next higher component to the highest specified component, then the algorithm will return the last occurrence.
+        case last
+    }
+    
+    /// A hint to the search algorithm to control the method used for searching for dates.
+    public enum MatchingPolicy {
+        /// If there is no matching time before the end of the next instance of the next higher component to the highest specified component in the `DateComponents` argument, the algorithm will return the next existing time which exists.
+        ///
+        /// For example, during a daylight saving transition there may be no 2:37am. The result would then be 3:00am, if that does exist.
+        case nextTime
+        
+        /// If specified, and there is no matching time before the end of the next instance of the next higher component to the highest specified component in the `DateComponents` argument, the method will return the next existing value of the missing component and preserves the lower components' values (e.g., no 2:37am results in 3:37am, if that exists).
+        case nextTimePreservingSmallerComponents
+        
+        /// If there is no matching time before the end of the next instance of the next higher component to the highest specified component in the `DateComponents` argument, the algorithm will return the previous existing value of the missing component and preserves the lower components' values.
+        ///
+        /// For example, during a daylight saving transition there may be no 2:37am. The result would then be 1:37am, if that does exist.
+        case previousTimePreservingSmallerComponents
+        
+        /// If specified, the algorithm travels as far forward or backward as necessary looking for a match.
+        ///
+        /// For example, if searching for Feb 29 in the Gregorian calendar, the algorithm may choose March 1 instead (for example, if the year is not a leap year). If you wish to find the next Feb 29 without the algorithm adjusting the next higher component in the specified `DateComponents`, then use the `strict` option.
+        /// - note: There are ultimately implementation-defined limits in how far distant the search will go.
+        case strict
+    }
+    
+    @available(*, unavailable, message: "use nextWeekend(startingAfter:matching:matchingPolicy:repeatedTimePolicy:direction:using:) instead")
+    public func enumerateDates(startingAfter start: Date, matching comps: DateComponents, options opts: NSCalendar.Options = [], using block: (Date?, Bool, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) { fatalError() }
+    
+    /// Computes the dates which match (or most closely match) a given set of components, and calls the closure once for each of them, until the enumeration is stopped.
+    ///
+    /// There will be at least one intervening date which does not match all the components (or the given date itself must not match) between the given date and any result.
+    ///
+    /// If `direction` is set to `.backward`, this method finds the previous match before the given date. The intent is that the same matches as for a `.forward` search will be found (that is, if you are enumerating forwards or backwards for each hour with minute "27", the seconds in the date you will get in forwards search would obviously be 00, and the same will be true in a backwards search in order to implement this rule.  Similarly for DST backwards jumps which repeats times, you'll get the first match by default, where "first" is defined from the point of view of searching forwards.  So, when searching backwards looking for a particular hour, with no minute and second specified, you don't get a minute and second of 59:59 for the matching hour (which would be the nominal first match within a given hour, given the other rules here, when searching backwards).
+    ///
+    /// If an exact match is not possible, and requested with the `strict` option, nil is passed to the closure and the enumeration ends.  (Logically, since an exact match searches indefinitely into the future, if no match is found there's no point in continuing the enumeration.)
+    ///
+    /// Result dates have an integer number of seconds (as if 0 was specified for the nanoseconds property of the `DateComponents` matching parameter), unless a value was set in the nanoseconds property, in which case the result date will have that number of nanoseconds (or as close as possible with floating point numbers).
+    ///
+    /// The enumeration is stopped by setting `stop` to `true` in the closure and returning. It is not necessary to set `stop` to `false` to keep the enumeration going.
+    /// - parameter start: The `Date` at which to start the search.
+    /// - parameter components: The `DateComponents` to use as input to the search algorithm.
+    /// - parameter matchingPolicy: Determines the behavior of the search algorithm when the input produces an ambiguous result.
+    /// - parameter repeatedTimePolicy: Determines the behavior of the search algorithm when the input produces a time that occurs twice on a particular day.
+    /// - parameter direction: Which direction in time to search. The default value is `.forward`, which means later in time.
+    /// - parameter block: A closure that is called with search results.
+    @available(iOS 8.0, *)
+    public func enumerateDates(startingAfter start: Date, matching components: DateComponents, matchingPolicy: MatchingPolicy, repeatedTimePolicy: RepeatedTimePolicy = .first, direction: SearchDirection = .forward, using block: (_ result: Date?, _ exactMatch: Bool, _ stop: inout Bool) -> Void) {
+        _handle.map {
+            $0.enumerateDates(startingAfter: start, matching: components, options: Calendar._toCalendarOptions(matchingPolicy: matchingPolicy, repeatedTimePolicy: repeatedTimePolicy, direction: direction)) { (result, exactMatch, stop) in
+                var stopv = false
+                block(result, exactMatch, &stopv)
+                if stopv {
+                    stop.pointee = true
+                }
+            }
+        }
+    }
+    
+    
+    @available(*, unavailable, message: "use nextDate(after:matching:matchingPolicy:repeatedTimePolicy:direction:) instead")
+    public func nextDate(after date: Date, matching comps: DateComponents, options: NSCalendar.Options = []) -> Date? { fatalError() }
+    
+    /// Computes the next date which matches (or most closely matches) a given set of components.
+    ///
+    /// The general semantics follow those of the `enumerateDates` function.
+    /// To compute a sequence of results, use the `enumerateDates` function, rather than looping and calling this method with the previous loop iteration's result.
+    /// - parameter date: The starting date.
+    /// - parameter components: The components to search for.
+    /// - parameter matchingPolicy: Specifies the technique the search algorithm uses to find results. Default value is `.nextTime`.
+    /// - parameter repeatedTimePolicy: Specifies the behavior when multiple matches are found. Default value is `.first`.
+    /// - parameter direction: Specifies the direction in time to search. Default is `.forward`.
+    /// - returns: A `Date` representing the result of the search, or `nil` if a result could not be found.
+    @available(iOS 8.0, *)
+    public func nextDate(after date: Date, matching components: DateComponents, matchingPolicy: MatchingPolicy, repeatedTimePolicy: RepeatedTimePolicy = .first, direction: SearchDirection = .forward) -> Date? {
+        return _handle.map { $0.nextDate(after: date, matching: components, options: Calendar._toCalendarOptions(matchingPolicy: matchingPolicy, repeatedTimePolicy: repeatedTimePolicy, direction: direction)) }
+    }
+    
+    @available(*, unavailable, message: "use nextDate(after:matching:matchingPolicy:repeatedTimePolicy:direction:) instead")
+    public func nextDate(after date: Date, matchingHour hourValue: Int, minute minuteValue: Int, second secondValue: Int, options: NSCalendar.Options = []) -> Date? { fatalError() }
+
+    // MARK: -
+    //
+    
+    @available(*, unavailable, renamed: "date(bySetting:value:of:)")
+    public func date(bySettingUnit unit: NSCalendar.Unit, value v: Int, of date: Date, options opts: NSCalendar.Options = []) -> Date? { fatalError() }
+    
+    /// Returns a new `Date` representing the date calculated by setting a specific component to a given time, and trying to keep lower components the same.  If the component already has that value, this may result in a date which is the same as the given date.
+    ///
+    /// Changing a component's value often will require higher or coupled components to change as well.  For example, setting the Weekday to Thursday usually will require the Day component to change its value, and possibly the Month and Year as well.
+    /// If no such time exists, the next available time is returned (which could, for example, be in a different day, week, month, ... than the nominal target date).  Setting a component to something which would be inconsistent forces other components to change; for example, setting the Weekday to Thursday probably shifts the Day and possibly Month and Year.
+    /// The exact behavior of this method is implementation-defined. For example, if changing the weekday to Thursday, does that move forward to the next, backward to the previous, or to the nearest Thursday? The algorithm will try to produce a result which is in the next-larger component to the one given (there's a table of this mapping at the top of this document).  So for the "set to Thursday" example, find the Thursday in the Week in which the given date resides (which could be a forwards or backwards move, and not necessarily the nearest Thursday). For more control over the exact behavior, use `nextDate(after:matching:matchingPolicy:behavior:direction:)`.
+    @available(iOS 8.0, *)
+    public func date(bySetting component: Component, value: Int, of date: Date) -> Date? {
+        return _handle.map { $0.date(bySettingUnit: Calendar._toCalendarUnit([component]), value: value, of: date, options: []) }
+    }
+    
+    
+    @available(*, unavailable, message: "use date(bySettingHour:minute:second:of:matchingPolicy:repeatedTimePolicy:direction:) instead")
+    public func date(bySettingHour h: Int, minute m: Int, second s: Int, of date: Date, options opts: NSCalendar.Options = []) -> Date? { fatalError() }
+    
+    /// Returns a new `Date` representing the date calculated by setting hour, minute, and second to a given time on a specified `Date`.
+    ///
+    /// If no such time exists, the next available time is returned (which could, for example, be in a different day than the nominal target date).
+    /// The intent is to return a date on the same day as the original date argument.  This may result in a date which is backward than the given date, of course.
+    /// - parameter hour: A specified hour.
+    /// - parameter minute: A specified minute.
+    /// - parameter second: A specified second.
+    /// - parameter date: The date to start calculation with.
+    /// - parameter matchingPolicy: Specifies the technique the search algorithm uses to find results. Default value is `.nextTime`.
+    /// - parameter repeatedTimePolicy: Specifies the behavior when multiple matches are found. Default value is `.first`.
+    /// - parameter direction: Specifies the direction in time to search. Default is `.forward`.
+    /// - returns: A `Date` representing the result of the search, or `nil` if a result could not be found.
+    @available(iOS 8.0, *)
+    public func date(bySettingHour hour: Int, minute: Int, second: Int, of date: Date, matchingPolicy: MatchingPolicy = .nextTime, repeatedTimePolicy: RepeatedTimePolicy = .first, direction: SearchDirection = .forward) -> Date? {
+        return _handle.map { $0.date(bySettingHour: hour, minute: minute, second: second, of: date, options: Calendar._toCalendarOptions(matchingPolicy: matchingPolicy, repeatedTimePolicy: repeatedTimePolicy, direction: direction)) }
+    }
+    
+    /// Determine if the `Date` has all of the specified `DateComponents`.
+    ///
+    /// It may be useful to test the return value of `nextDate(after:matching:matchingPolicy:behavior:direction:)` to find out if the components were obeyed or if the method had to fudge the result value due to missing time (for example, a daylight saving time transition).
+    ///
+    /// - returns: `true` if the date matches all of the components, otherwise `false`.
+    @available(iOS 8.0, *)
+    public func date(_ date: Date, matchesComponents components: DateComponents) -> Bool {
+        return _handle.map { $0.date(date, matchesComponents: components) }
+    }
+    
+    // MARK: -
+    
+    public func hash(into hasher: inout Hasher) {
+        // We need to make sure autoupdating calendars have the same hash
+        if _autoupdating {
+            hasher.combine(false)
+        } else {
+            hasher.combine(true)
+            hasher.combine(_handle.map { $0 })
+        }
+    }
+
+    // MARK: -
+    // MARK: Conversion Functions
+    
+    /// Turn our more-specific options into the big bucket option set of NSCalendar
+    private static func _toCalendarOptions(matchingPolicy: MatchingPolicy, repeatedTimePolicy: RepeatedTimePolicy, direction: SearchDirection) -> NSCalendar.Options {
+        var result : NSCalendar.Options = []
+        
+        switch matchingPolicy {
+        case .nextTime:
+            result.insert(.matchNextTime)
+        case .nextTimePreservingSmallerComponents:
+            result.insert(.matchNextTimePreservingSmallerUnits)
+        case .previousTimePreservingSmallerComponents:
+            result.insert(.matchPreviousTimePreservingSmallerUnits)
+        case .strict:
+            result.insert(.matchStrictly)
+        }
+        
+        switch repeatedTimePolicy {
+        case .first:
+            result.insert(.matchFirst)
+        case .last:
+            result.insert(.matchLast)
+        }
+        
+        switch direction {
+        case .backward:
+            result.insert(.searchBackwards)
+        case .forward:
+            break
+        }
+        
+        return result
+    }
+    
+    internal static func _toCalendarUnit(_ units : Set<Component>) -> NSCalendar.Unit {
+        let unitMap : [Component : NSCalendar.Unit] =
+            [.era : .era,
+             .year : .year,
+             .month : .month,
+             .day : .day,
+             .hour : .hour,
+             .minute : .minute,
+             .second : .second,
+             .weekday : .weekday,
+             .weekdayOrdinal : .weekdayOrdinal,
+             .quarter : .quarter,
+             .weekOfMonth : .weekOfMonth,
+             .weekOfYear : .weekOfYear,
+             .yearForWeekOfYear : .yearForWeekOfYear,
+             .nanosecond : .nanosecond,
+             .calendar : .calendar,
+             .timeZone : .timeZone]
+        
+        var result = NSCalendar.Unit()
+        for u in units {
+            result.insert(unitMap[u]!)
+        }
+        return result
+    }
+    
+    internal static func _toNSCalendarIdentifier(_ identifier : Identifier) -> NSCalendar.Identifier {
+        if #available(macOS 10.10, iOS 8.0, *) {
+            let identifierMap : [Identifier : NSCalendar.Identifier] =
+                [.gregorian : .gregorian,
+                 .buddhist : .buddhist,
+                 .chinese : .chinese,
+                 .coptic : .coptic,
+                 .ethiopicAmeteMihret : .ethiopicAmeteMihret,
+                 .ethiopicAmeteAlem : .ethiopicAmeteAlem,
+                 .hebrew : .hebrew,
+                 .iso8601 : .ISO8601,
+                 .indian : .indian,
+                 .islamic : .islamic,
+                 .islamicCivil : .islamicCivil,
+                 .japanese : .japanese,
+                 .persian : .persian,
+                 .republicOfChina : .republicOfChina,
+                 .islamicTabular : .islamicTabular,
+                 .islamicUmmAlQura : .islamicUmmAlQura]
+            return identifierMap[identifier]!
+        } else {
+            let identifierMap : [Identifier : NSCalendar.Identifier] =
+                [.gregorian : .gregorian,
+                 .buddhist : .buddhist,
+                 .chinese : .chinese,
+                 .coptic : .coptic,
+                 .ethiopicAmeteMihret : .ethiopicAmeteMihret,
+                 .ethiopicAmeteAlem : .ethiopicAmeteAlem,
+                 .hebrew : .hebrew,
+                 .iso8601 : .ISO8601,
+                 .indian : .indian,
+                 .islamic : .islamic,
+                 .islamicCivil : .islamicCivil,
+                 .japanese : .japanese,
+                 .persian : .persian,
+                 .republicOfChina : .republicOfChina]
+            return identifierMap[identifier]!
+        }
+    }
+    
+    internal static func _fromNSCalendarIdentifier(_ identifier : NSCalendar.Identifier) -> Identifier {
+        if #available(macOS 10.10, iOS 8.0, *) {
+            let identifierMap : [NSCalendar.Identifier : Identifier] =
+                [.gregorian : .gregorian,
+                 .buddhist : .buddhist,
+                 .chinese : .chinese,
+                 .coptic : .coptic,
+                 .ethiopicAmeteMihret : .ethiopicAmeteMihret,
+                 .ethiopicAmeteAlem : .ethiopicAmeteAlem,
+                 .hebrew : .hebrew,
+                 .ISO8601 : .iso8601,
+                 .indian : .indian,
+                 .islamic : .islamic,
+                 .islamicCivil : .islamicCivil,
+                 .japanese : .japanese,
+                 .persian : .persian,
+                 .republicOfChina : .republicOfChina,
+                 .islamicTabular : .islamicTabular,
+                 .islamicUmmAlQura : .islamicUmmAlQura]
+            return identifierMap[identifier]!
+        } else {
+            let identifierMap : [NSCalendar.Identifier : Identifier] =
+                [.gregorian : .gregorian,
+                 .buddhist : .buddhist,
+                 .chinese : .chinese,
+                 .coptic : .coptic,
+                 .ethiopicAmeteMihret : .ethiopicAmeteMihret,
+                 .ethiopicAmeteAlem : .ethiopicAmeteAlem,
+                 .hebrew : .hebrew,
+                 .ISO8601 : .iso8601,
+                 .indian : .indian,
+                 .islamic : .islamic,
+                 .islamicCivil : .islamicCivil,
+                 .japanese : .japanese,
+                 .persian : .persian,
+                 .republicOfChina : .republicOfChina]
+            return identifierMap[identifier]!
+        }
+    }
+
+    public static func ==(lhs: Calendar, rhs: Calendar) -> Bool {
+        if lhs._autoupdating || rhs._autoupdating {
+            return lhs._autoupdating == rhs._autoupdating
+        } else {
+            // NSCalendar's isEqual is broken (27019864) so we must implement this ourselves
+            return lhs.identifier == rhs.identifier &&
+                lhs.locale == rhs.locale &&
+                lhs.timeZone == rhs.timeZone &&
+                lhs.firstWeekday == rhs.firstWeekday &&
+                lhs.minimumDaysInFirstWeek == rhs.minimumDaysInFirstWeek
+        }
+    }
+
+}
+
+extension Calendar : CustomDebugStringConvertible, CustomStringConvertible, CustomReflectable {
+    private var _kindDescription : String {
+        if self == Calendar.autoupdatingCurrent {
+            return "autoupdatingCurrent"
+        } else if self == Calendar.current {
+            return "current"
+        } else {
+            return "fixed"
+        }
+    }
+    
+    public var description: String {
+        return "\(identifier) (\(_kindDescription))"
+    }
+    
+    public var debugDescription : String {
+        return "\(identifier) (\(_kindDescription))"
+    }
+    
+    public var customMirror : Mirror {
+        let c: [(label: String?, value: Any)] = [
+          ("identifier", identifier),
+          ("kind", _kindDescription),
+          ("locale", locale as Any),
+          ("timeZone", timeZone),
+          ("firstWeekday", firstWeekday),
+          ("minimumDaysInFirstWeek", minimumDaysInFirstWeek),
+        ]
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+    }
+}
+
+extension Calendar : _ObjectiveCBridgeable {
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSCalendar {
+        return _handle._copiedReference()
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ input: NSCalendar, result: inout Calendar?) {
+        if !_conditionallyBridgeFromObjectiveC(input, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ input: NSCalendar, result: inout Calendar?) -> Bool {
+        result = Calendar(reference: input)
+        return true
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSCalendar?) -> Calendar {
+        var result: Calendar?
+        _forceBridgeFromObjectiveC(source!, result: &result)
+        return result!
+    }
+}
+
+extension NSCalendar : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as Calendar)
+    }
+}
+
+extension Calendar : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case identifier
+        case locale
+        case timeZone
+        case firstWeekday
+        case minimumDaysInFirstWeek
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let identifierString = try container.decode(String.self, forKey: .identifier)
+        let identifier = Calendar._fromNSCalendarIdentifier(NSCalendar.Identifier(rawValue: identifierString))
+        self.init(identifier: identifier)
+
+        self.locale = try container.decodeIfPresent(Locale.self, forKey: .locale)
+        self.timeZone = try container.decode(TimeZone.self, forKey: .timeZone)
+        self.firstWeekday = try container.decode(Int.self, forKey: .firstWeekday)
+        self.minimumDaysInFirstWeek = try container.decode(Int.self, forKey: .minimumDaysInFirstWeek)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        let identifier = Calendar._toNSCalendarIdentifier(self.identifier).rawValue
+        try container.encode(identifier, forKey: .identifier)
+        try container.encode(self.locale, forKey: .locale)
+        try container.encode(self.timeZone, forKey: .timeZone)
+        try container.encode(self.firstWeekday, forKey: .firstWeekday)
+        try container.encode(self.minimumDaysInFirstWeek, forKey: .minimumDaysInFirstWeek)
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/CharacterSet.swift
+++ b/Darwin/Foundation-swiftoverlay/CharacterSet.swift
@@ -1,0 +1,829 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+import CoreFoundation
+@_implementationOnly import _CoreFoundationOverlayShims
+@_implementationOnly import _FoundationOverlayShims
+
+private func _utfRangeToCFRange(_ inRange : Range<Unicode.Scalar>) -> CFRange {
+    return CFRange(
+        location: Int(inRange.lowerBound.value),
+        length: Int(inRange.upperBound.value - inRange.lowerBound.value))
+}
+
+private func _utfRangeToCFRange(_ inRange : ClosedRange<Unicode.Scalar>) -> CFRange {
+    return CFRange(
+        location: Int(inRange.lowerBound.value),
+        length: Int(inRange.upperBound.value - inRange.lowerBound.value + 1))
+}
+
+// MARK: -
+
+// NOTE: older overlays called this class _CharacterSetStorage.
+// The two must coexist without a conflicting ObjC class name, so it
+// was renamed. The old name must not be used in the new runtime.
+private final class __CharacterSetStorage : Hashable {
+    enum Backing {
+        case immutable(CFCharacterSet)
+        case mutable(CFMutableCharacterSet)
+    }
+    
+    var _backing: Backing
+   
+    @nonobjc 
+    init(immutableReference r: CFCharacterSet) {
+        _backing = .immutable(r)
+    }
+
+    @nonobjc
+    init(mutableReference r: CFMutableCharacterSet) {
+        _backing = .mutable(r)
+    }
+    
+    // MARK: -
+    
+    func hash(into hasher: inout Hasher) {
+        switch _backing {
+        case .immutable(let cs):
+            hasher.combine(CFHash(cs))
+        case .mutable(let cs):
+            hasher.combine(CFHash(cs))
+        }
+    }
+
+    static func ==(lhs: __CharacterSetStorage, rhs: __CharacterSetStorage) -> Bool {
+        switch (lhs._backing, rhs._backing) {
+        case (.immutable(let cs1), .immutable(let cs2)):
+            return CFEqual(cs1, cs2)
+        case (.immutable(let cs1), .mutable(let cs2)):
+            return CFEqual(cs1, cs2)
+        case (.mutable(let cs1), .immutable(let cs2)):
+            return CFEqual(cs1, cs2)
+        case (.mutable(let cs1), .mutable(let cs2)):
+            return CFEqual(cs1, cs2)
+        }
+    }
+    
+    // MARK: -
+    
+    func mutableCopy() -> __CharacterSetStorage {
+        switch _backing {
+        case .immutable(let cs):
+            return __CharacterSetStorage(mutableReference: CFCharacterSetCreateMutableCopy(nil, cs))
+        case .mutable(let cs):
+            return __CharacterSetStorage(mutableReference: CFCharacterSetCreateMutableCopy(nil, cs))
+        }
+    }
+
+    
+    // MARK: Immutable Functions
+    
+    var bitmapRepresentation: Data {
+        switch _backing {
+        case .immutable(let cs):
+            return CFCharacterSetCreateBitmapRepresentation(nil, cs) as Data
+        case .mutable(let cs):
+            return CFCharacterSetCreateBitmapRepresentation(nil, cs) as Data
+        }
+    }
+    
+    func hasMember(inPlane plane: UInt8) -> Bool {
+        switch _backing {
+        case .immutable(let cs):
+            return CFCharacterSetHasMemberInPlane(cs, CFIndex(plane))
+        case .mutable(let cs):
+            return CFCharacterSetHasMemberInPlane(cs, CFIndex(plane))
+        }
+    }
+    
+    // MARK: Mutable functions
+    
+    func insert(charactersIn range: Range<Unicode.Scalar>) {
+        switch _backing {
+        case .immutable(let cs):
+            let r = CFCharacterSetCreateMutableCopy(nil, cs)!
+            CFCharacterSetAddCharactersInRange(r, _utfRangeToCFRange(range))
+            _backing = .mutable(r)
+        case .mutable(let cs):
+            CFCharacterSetAddCharactersInRange(cs, _utfRangeToCFRange(range))
+        }
+    }
+    
+    func insert(charactersIn range: ClosedRange<Unicode.Scalar>) {
+        switch _backing {
+        case .immutable(let cs):
+            let r = CFCharacterSetCreateMutableCopy(nil, cs)!
+            CFCharacterSetAddCharactersInRange(r, _utfRangeToCFRange(range))
+            _backing = .mutable(r)
+        case .mutable(let cs):
+            CFCharacterSetAddCharactersInRange(cs, _utfRangeToCFRange(range))
+        }
+    }
+    
+    func remove(charactersIn range: Range<Unicode.Scalar>) {
+        switch _backing {
+        case .immutable(let cs):
+            let r = CFCharacterSetCreateMutableCopy(nil, cs)!
+            CFCharacterSetRemoveCharactersInRange(r, _utfRangeToCFRange(range))
+            _backing = .mutable(r)
+        case .mutable(let cs):
+            CFCharacterSetRemoveCharactersInRange(cs, _utfRangeToCFRange(range))
+        }
+    }
+    
+    func remove(charactersIn range: ClosedRange<Unicode.Scalar>) {
+        switch _backing {
+        case .immutable(let cs):
+            let r = CFCharacterSetCreateMutableCopy(nil, cs)!
+            CFCharacterSetRemoveCharactersInRange(r, _utfRangeToCFRange(range))
+            _backing = .mutable(r)
+        case .mutable(let cs):
+            CFCharacterSetRemoveCharactersInRange(cs, _utfRangeToCFRange(range))
+        }
+    }
+    
+    func insert(charactersIn string: String) {
+        switch _backing {
+        case .immutable(let cs):
+            let r = CFCharacterSetCreateMutableCopy(nil, cs)!
+            CFCharacterSetAddCharactersInString(r, string as CFString)
+            _backing = .mutable(r)
+        case .mutable(let cs):
+            CFCharacterSetAddCharactersInString(cs, string as CFString)
+        }
+    }
+    
+    func remove(charactersIn string: String) {
+        switch _backing {
+        case .immutable(let cs):
+            let r = CFCharacterSetCreateMutableCopy(nil, cs)!
+            CFCharacterSetRemoveCharactersInString(r, string as CFString)
+            _backing = .mutable(r)
+        case .mutable(let cs):
+            CFCharacterSetRemoveCharactersInString(cs, string as CFString)
+        }
+    }
+    
+    func invert() {
+        switch _backing {
+        case .immutable(let cs):
+            let r = CFCharacterSetCreateMutableCopy(nil, cs)!
+            CFCharacterSetInvert(r)
+            _backing = .mutable(r)
+        case .mutable(let cs):
+            CFCharacterSetInvert(cs)
+        }
+    }
+    
+    // -----
+    // MARK: -
+    // MARK: SetAlgebra
+    
+    @discardableResult
+    func insert(_ character: Unicode.Scalar) -> (inserted: Bool, memberAfterInsert: Unicode.Scalar) {
+        insert(charactersIn: character...character)
+        // TODO: This should probably return the truth, but figuring it out requires two calls into NSCharacterSet
+        return (true, character)
+    }
+    
+    @discardableResult
+    func update(with character: Unicode.Scalar) -> Unicode.Scalar? {
+        insert(character)
+        // TODO: This should probably return the truth, but figuring it out requires two calls into NSCharacterSet
+        return character
+    }
+    
+    @discardableResult
+    func remove(_ character: Unicode.Scalar) -> Unicode.Scalar? {
+        // TODO: Add method to CFCharacterSet to do this in one call
+        let result : Unicode.Scalar? = contains(character) ? character : nil
+        remove(charactersIn: character...character)
+        return result
+    }
+    
+    func contains(_ member: Unicode.Scalar) -> Bool {
+        switch _backing {
+        case .immutable(let cs):
+            return CFCharacterSetIsLongCharacterMember(cs, member.value)
+        case .mutable(let cs):
+            return CFCharacterSetIsLongCharacterMember(cs, member.value)
+        }
+    }
+    
+    // MARK: -
+    // Why do these return CharacterSet instead of CharacterSetStorage?
+    // We want to keep the knowledge of if the returned value happened to contain a mutable or immutable CFCharacterSet as close to the creation of that instance as possible
+    
+
+    // When the underlying collection does not have a method to return new CharacterSets with changes applied, so we will copy and apply here
+    private static func _apply(_ lhs : __CharacterSetStorage, _ rhs : __CharacterSetStorage, _ f : (CFMutableCharacterSet, CFCharacterSet) -> ()) -> CharacterSet {
+        let copyOfMe : CFMutableCharacterSet
+        switch lhs._backing {
+        case .immutable(let cs):
+            copyOfMe = CFCharacterSetCreateMutableCopy(nil, cs)!
+        case .mutable(let cs):
+            copyOfMe = CFCharacterSetCreateMutableCopy(nil, cs)!
+        }
+        
+        switch rhs._backing {
+        case .immutable(let cs):
+            f(copyOfMe, cs)
+        case .mutable(let cs):
+            f(copyOfMe, cs)
+        }
+        
+        return CharacterSet(_uncopiedStorage: __CharacterSetStorage(mutableReference: copyOfMe))
+    }
+    
+    private func _applyMutation(_ other : __CharacterSetStorage, _ f : (CFMutableCharacterSet, CFCharacterSet) -> ()) {
+        switch _backing {
+        case .immutable(let cs):
+            let r = CFCharacterSetCreateMutableCopy(nil, cs)!
+            switch other._backing {
+            case .immutable(let otherCs):
+                f(r, otherCs)
+            case .mutable(let otherCs):
+                f(r, otherCs)
+            }
+            _backing = .mutable(r)
+        case .mutable(let cs):
+            switch other._backing {
+            case .immutable(let otherCs):
+                f(cs, otherCs)
+            case .mutable(let otherCs):
+                f(cs, otherCs)
+            }
+        }
+
+    }
+    
+    var inverted: CharacterSet {
+        switch _backing {
+        case .immutable(let cs):
+            return CharacterSet(_uncopiedStorage: __CharacterSetStorage(immutableReference: CFCharacterSetCreateInvertedSet(nil, cs)))
+        case .mutable(let cs):
+            // Even if input is mutable, the result is immutable
+            return CharacterSet(_uncopiedStorage: __CharacterSetStorage(immutableReference: CFCharacterSetCreateInvertedSet(nil, cs)))
+        }
+    }
+
+    func union(_ other: __CharacterSetStorage) -> CharacterSet {
+        return __CharacterSetStorage._apply(self, other, CFCharacterSetUnion)
+    }
+    
+    func formUnion(_ other: __CharacterSetStorage) {
+        _applyMutation(other, CFCharacterSetUnion)
+    }
+    
+    func intersection(_ other: __CharacterSetStorage) -> CharacterSet {
+        return __CharacterSetStorage._apply(self, other, CFCharacterSetIntersect)
+    }
+    
+    func formIntersection(_ other: __CharacterSetStorage) {
+        _applyMutation(other, CFCharacterSetIntersect)
+    }
+    
+    func subtracting(_ other: __CharacterSetStorage) -> CharacterSet {
+        return intersection(other.inverted._storage)
+    }
+    
+    func subtract(_ other: __CharacterSetStorage) {
+        _applyMutation(other.inverted._storage, CFCharacterSetIntersect)
+    }
+    
+    func symmetricDifference(_ other: __CharacterSetStorage) -> CharacterSet {
+        return union(other).subtracting(intersection(other))
+    }
+    
+    func formSymmetricDifference(_ other: __CharacterSetStorage) {
+        // This feels like cheating
+        _backing = symmetricDifference(other)._storage._backing
+    }
+    
+    func isSuperset(of other: __CharacterSetStorage) -> Bool {
+        switch _backing {
+        case .immutable(let cs):
+            switch other._backing {
+            case .immutable(let otherCs):
+                return CFCharacterSetIsSupersetOfSet(cs, otherCs)
+            case .mutable(let otherCs):
+                return CFCharacterSetIsSupersetOfSet(cs, otherCs)
+            }
+        case .mutable(let cs):
+            switch other._backing {
+            case .immutable(let otherCs):
+                return CFCharacterSetIsSupersetOfSet(cs, otherCs)
+            case .mutable(let otherCs):
+                return CFCharacterSetIsSupersetOfSet(cs, otherCs)
+            }
+        }
+    }
+    
+    // MARK: -
+    
+    var description: String {
+        switch _backing {
+        case .immutable(let cs):
+            return CFCopyDescription(cs) as String
+        case .mutable(let cs):
+            return CFCopyDescription(cs) as String
+        }
+    }
+    
+    var debugDescription: String {
+        return description
+    }
+    
+    // MARK: -
+    
+    public func bridgedReference() -> NSCharacterSet {
+        switch _backing {
+        case .immutable(let cs):
+            return cs as NSCharacterSet
+        case .mutable(let cs):
+            return cs as NSCharacterSet
+        }
+    }
+}
+
+// MARK: -
+
+/**
+ A `CharacterSet` represents a set of Unicode-compliant characters. Foundation types use `CharacterSet` to group characters together for searching operations, so that they can find any of a particular set of characters during a search.
+ 
+ This type provides "copy-on-write" behavior, and is also bridged to the Objective-C `NSCharacterSet` class.
+*/
+public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgebra {
+    public typealias ReferenceType = NSCharacterSet
+    
+    fileprivate var _storage: __CharacterSetStorage
+    
+    // MARK: Init methods
+    
+    /// Initialize an empty instance.
+    public init() {
+        // It's unlikely that we are creating an empty character set with no intention to mutate it
+        _storage = __CharacterSetStorage(mutableReference: CFCharacterSetCreateMutable(nil))
+    }
+    
+    /// Initialize with a range of integers.
+    ///
+    /// It is the caller's responsibility to ensure that the values represent valid `Unicode.Scalar` values, if that is what is desired.
+    public init(charactersIn range: Range<Unicode.Scalar>) {
+        _storage = __CharacterSetStorage(immutableReference: CFCharacterSetCreateWithCharactersInRange(nil, _utfRangeToCFRange(range)))
+    }
+
+    /// Initialize with a closed range of integers.
+    ///
+    /// It is the caller's responsibility to ensure that the values represent valid `Unicode.Scalar` values, if that is what is desired.
+    public init(charactersIn range: ClosedRange<Unicode.Scalar>) {
+        _storage = __CharacterSetStorage(immutableReference: CFCharacterSetCreateWithCharactersInRange(nil, _utfRangeToCFRange(range)))
+    }
+
+    /// Initialize with the characters in the given string.
+    ///
+    /// - parameter string: The string content to inspect for characters.
+    public init(charactersIn string: __shared String) {
+        _storage = __CharacterSetStorage(immutableReference: CFCharacterSetCreateWithCharactersInString(nil, string as CFString))
+    }
+    
+    /// Initialize with a bitmap representation.
+    ///
+    /// This method is useful for creating a character set object with data from a file or other external data source.
+    /// - parameter data: The bitmap representation.
+    public init(bitmapRepresentation data: __shared Data) {
+        _storage = __CharacterSetStorage(immutableReference: CFCharacterSetCreateWithBitmapRepresentation(nil, data as CFData))
+    }
+    
+    /// Initialize with the contents of a file.
+    ///
+    /// Returns `nil` if there was an error reading the file.
+    /// - parameter file: The file to read.
+    public init?(contentsOfFile file: __shared String) {
+        do {
+            let data = try Data(contentsOf: URL(fileURLWithPath: file), options: .mappedIfSafe)
+            _storage = __CharacterSetStorage(immutableReference: CFCharacterSetCreateWithBitmapRepresentation(nil, data as CFData))
+        } catch {
+            return nil
+        }
+    }
+
+    private init(_bridged characterSet: __shared NSCharacterSet) {
+        _storage = __CharacterSetStorage(immutableReference: characterSet.copy() as! CFCharacterSet)
+    }
+    
+    private init(_uncopiedImmutableReference characterSet: CFCharacterSet) {
+        _storage = __CharacterSetStorage(immutableReference: characterSet)
+    }
+
+    fileprivate init(_uncopiedStorage: __CharacterSetStorage) {
+        _storage = _uncopiedStorage
+    }
+
+    private init(_builtIn: __shared CFCharacterSetPredefinedSet) {
+        _storage = __CharacterSetStorage(immutableReference: CFCharacterSetGetPredefined(_builtIn))
+    }
+    
+    // MARK: Static functions
+    
+    /// Returns a character set containing the characters in Unicode General Category Cc and Cf.
+    public static var controlCharacters : CharacterSet {
+        return CharacterSet(_builtIn: .control)
+    }
+    
+    /// Returns a character set containing the characters in Unicode General Category Zs and `CHARACTER TABULATION (U+0009)`.
+    public static var whitespaces : CharacterSet {
+        return CharacterSet(_builtIn: .whitespace)
+    }
+    
+    /// Returns a character set containing characters in Unicode General Category Z*, `U+000A ~ U+000D`, and `U+0085`.
+    public static var whitespacesAndNewlines : CharacterSet {
+        return CharacterSet(_builtIn: .whitespaceAndNewline)
+    }
+    
+    /// Returns a character set containing the characters in the category of Decimal Numbers.
+    public static var decimalDigits : CharacterSet {
+        return CharacterSet(_builtIn: .decimalDigit)
+    }
+    
+    /// Returns a character set containing the characters in Unicode General Category L* & M*.
+    public static var letters : CharacterSet {
+        return CharacterSet(_builtIn: .letter)
+    }
+    
+    /// Returns a character set containing the characters in Unicode General Category Ll.
+    public static var lowercaseLetters : CharacterSet {
+        return CharacterSet(_builtIn: .lowercaseLetter)
+    }
+    
+    /// Returns a character set containing the characters in Unicode General Category Lu and Lt.
+    public static var uppercaseLetters : CharacterSet {
+        return CharacterSet(_builtIn: .uppercaseLetter)
+    }
+    
+    /// Returns a character set containing the characters in Unicode General Category M*.
+    public static var nonBaseCharacters : CharacterSet {
+        return CharacterSet(_builtIn: .nonBase)
+    }
+    
+    /// Returns a character set containing the characters in Unicode General Categories L*, M*, and N*.
+    public static var alphanumerics : CharacterSet {
+        return CharacterSet(_builtIn: .alphaNumeric)
+    }
+    
+    /// Returns a character set containing individual Unicode characters that can also be represented as composed character sequences (such as for letters with accents), by the definition of "standard decomposition" in version 3.2 of the Unicode character encoding standard.
+    public static var decomposables : CharacterSet {
+        return CharacterSet(_builtIn: .decomposable)
+    }
+    
+    /// Returns a character set containing values in the category of Non-Characters or that have not yet been defined in version 3.2 of the Unicode standard.
+    public static var illegalCharacters : CharacterSet {
+        return CharacterSet(_builtIn: .illegal)
+    }
+    
+    @available(*, unavailable, renamed: "punctuationCharacters")
+    public static var punctuation : CharacterSet {
+        return CharacterSet(_builtIn: .punctuation)
+    }
+
+    /// Returns a character set containing the characters in Unicode General Category P*.
+    public static var punctuationCharacters : CharacterSet {
+        return CharacterSet(_builtIn: .punctuation)
+    }
+    
+    /// Returns a character set containing the characters in Unicode General Category Lt.
+    public static var capitalizedLetters : CharacterSet {
+        return CharacterSet(_builtIn: .capitalizedLetter)
+    }
+    
+    /// Returns a character set containing the characters in Unicode General Category S*.
+    public static var symbols : CharacterSet {
+        return CharacterSet(_builtIn: .symbol)
+    }
+    
+    /// Returns a character set containing the newline characters (`U+000A ~ U+000D`, `U+0085`, `U+2028`, and `U+2029`).
+    public static var newlines : CharacterSet {
+        return CharacterSet(_builtIn: .newline)
+    }
+    
+    // MARK: Static functions, from NSURL
+
+    /// Returns the character set for characters allowed in a user URL subcomponent.
+    public static var urlUserAllowed : CharacterSet {
+        if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+            return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLUserAllowedCharacterSet() as NSCharacterSet)
+        } else {
+            return CharacterSet(_uncopiedImmutableReference: _NSURLComponentsGetURLUserAllowedCharacterSet() as! NSCharacterSet)
+        }
+    }
+    
+    /// Returns the character set for characters allowed in a password URL subcomponent.
+    public static var urlPasswordAllowed : CharacterSet {
+        if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+            return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLPasswordAllowedCharacterSet() as NSCharacterSet)
+        } else {
+            return CharacterSet(_uncopiedImmutableReference: _NSURLComponentsGetURLPasswordAllowedCharacterSet() as! NSCharacterSet)
+        }
+    }
+    
+    /// Returns the character set for characters allowed in a host URL subcomponent.
+    public static var urlHostAllowed : CharacterSet {
+        if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+            return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLHostAllowedCharacterSet() as NSCharacterSet)
+        } else {
+            return CharacterSet(_uncopiedImmutableReference: _NSURLComponentsGetURLHostAllowedCharacterSet() as! NSCharacterSet)
+        }
+    }
+    
+    /// Returns the character set for characters allowed in a path URL component.
+    public static var urlPathAllowed : CharacterSet {
+        if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+            return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLPathAllowedCharacterSet() as NSCharacterSet)
+        } else {
+            return CharacterSet(_uncopiedImmutableReference: _NSURLComponentsGetURLPathAllowedCharacterSet() as! NSCharacterSet)
+        }
+    }
+    
+    /// Returns the character set for characters allowed in a query URL component.
+    public static var urlQueryAllowed : CharacterSet {
+        if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+            return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLQueryAllowedCharacterSet() as NSCharacterSet)
+        } else {
+            return CharacterSet(_uncopiedImmutableReference: _NSURLComponentsGetURLQueryAllowedCharacterSet() as! NSCharacterSet)
+        }
+    }
+    
+    /// Returns the character set for characters allowed in a fragment URL component.
+    public static var urlFragmentAllowed : CharacterSet {
+        if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+            return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLFragmentAllowedCharacterSet() as NSCharacterSet)
+        } else {
+            return CharacterSet(_uncopiedImmutableReference: _NSURLComponentsGetURLFragmentAllowedCharacterSet() as! NSCharacterSet)
+        }
+    }
+    
+    // MARK: Immutable functions
+    
+    /// Returns a representation of the `CharacterSet` in binary format.
+    @nonobjc
+    public var bitmapRepresentation: Data {
+        return _storage.bitmapRepresentation
+    }
+    
+    /// Returns an inverted copy of the receiver.
+    @nonobjc
+    public var inverted : CharacterSet {
+        return _storage.inverted
+    }
+    
+    /// Returns true if the `CharacterSet` has a member in the specified plane.
+    ///
+    /// This method makes it easier to find the plane containing the members of the current character set. The Basic Multilingual Plane (BMP) is plane 0.
+    public func hasMember(inPlane plane: UInt8) -> Bool {
+        return _storage.hasMember(inPlane: plane)
+    }
+    
+    // MARK: Mutable functions
+    
+    /// Insert a range of integer values in the `CharacterSet`.
+    ///
+    /// It is the caller's responsibility to ensure that the values represent valid `Unicode.Scalar` values, if that is what is desired.
+    public mutating func insert(charactersIn range: Range<Unicode.Scalar>) {
+        if !isKnownUniquelyReferenced(&_storage) {
+            _storage = _storage.mutableCopy()
+        }
+        _storage.insert(charactersIn: range)
+    }
+
+    /// Insert a closed range of integer values in the `CharacterSet`.
+    ///
+    /// It is the caller's responsibility to ensure that the values represent valid `Unicode.Scalar` values, if that is what is desired.
+    public mutating func insert(charactersIn range: ClosedRange<Unicode.Scalar>) {
+        if !isKnownUniquelyReferenced(&_storage) {
+            _storage = _storage.mutableCopy()
+        }
+        _storage.insert(charactersIn: range)
+    }
+
+    /// Remove a range of integer values from the `CharacterSet`.
+    public mutating func remove(charactersIn range: Range<Unicode.Scalar>) {
+        if !isKnownUniquelyReferenced(&_storage) {
+            _storage = _storage.mutableCopy()
+        }
+        _storage.remove(charactersIn: range)
+    }
+
+    /// Remove a closed range of integer values from the `CharacterSet`.
+    public mutating func remove(charactersIn range: ClosedRange<Unicode.Scalar>) {
+        if !isKnownUniquelyReferenced(&_storage) {
+            _storage = _storage.mutableCopy()
+        }
+        _storage.remove(charactersIn: range)
+    }
+
+    /// Insert the values from the specified string into the `CharacterSet`.
+    public mutating func insert(charactersIn string: String) {
+        if !isKnownUniquelyReferenced(&_storage) {
+            _storage = _storage.mutableCopy()
+        }
+        _storage.insert(charactersIn: string)
+    }
+    
+    /// Remove the values from the specified string from the `CharacterSet`.
+    public mutating func remove(charactersIn string: String) {
+        if !isKnownUniquelyReferenced(&_storage) {
+            _storage = _storage.mutableCopy()
+        }
+        _storage.remove(charactersIn: string)
+    }
+    
+    /// Invert the contents of the `CharacterSet`.
+    public mutating func invert() {
+        if !isKnownUniquelyReferenced(&_storage) {
+            _storage = _storage.mutableCopy()
+        }
+        _storage.invert()
+    }
+    
+    // -----
+    // MARK: -
+    // MARK: SetAlgebra
+    
+    /// Insert a `Unicode.Scalar` representation of a character into the `CharacterSet`.
+    ///
+    /// `Unicode.Scalar` values are available on `Swift.String.UnicodeScalarView`.
+    @discardableResult
+    public mutating func insert(_ character: Unicode.Scalar) -> (inserted: Bool, memberAfterInsert: Unicode.Scalar) {
+        if !isKnownUniquelyReferenced(&_storage) {
+            _storage = _storage.mutableCopy()
+        }
+        return _storage.insert(character)
+    }
+
+    /// Insert a `Unicode.Scalar` representation of a character into the `CharacterSet`.
+    ///
+    /// `Unicode.Scalar` values are available on `Swift.String.UnicodeScalarView`.
+    @discardableResult
+    public mutating func update(with character: Unicode.Scalar) -> Unicode.Scalar? {
+        if !isKnownUniquelyReferenced(&_storage) {
+            _storage = _storage.mutableCopy()
+        }
+        return _storage.update(with: character)
+    }
+
+    
+    /// Remove a `Unicode.Scalar` representation of a character from the `CharacterSet`.
+    ///
+    /// `Unicode.Scalar` values are available on `Swift.String.UnicodeScalarView`.
+    @discardableResult
+    public mutating func remove(_ character: Unicode.Scalar) -> Unicode.Scalar? {
+        if !isKnownUniquelyReferenced(&_storage) {
+            _storage = _storage.mutableCopy()
+        }
+        return _storage.remove(character)
+    }
+    
+    /// Test for membership of a particular `Unicode.Scalar` in the `CharacterSet`.
+    public func contains(_ member: Unicode.Scalar) -> Bool {
+        return _storage.contains(member)
+    }
+    
+    /// Returns a union of the `CharacterSet` with another `CharacterSet`.
+    public func union(_ other: CharacterSet) -> CharacterSet {
+        return _storage.union(other._storage)
+    }
+    
+    /// Sets the value to a union of the `CharacterSet` with another `CharacterSet`.
+    public mutating func formUnion(_ other: CharacterSet) {
+        if !isKnownUniquelyReferenced(&_storage) {
+            _storage = _storage.mutableCopy()
+        }
+        _storage.formUnion(other._storage)
+    }
+    
+    /// Returns an intersection of the `CharacterSet` with another `CharacterSet`.
+    public func intersection(_ other: CharacterSet) -> CharacterSet {
+        return _storage.intersection(other._storage)
+    }
+    
+    /// Sets the value to an intersection of the `CharacterSet` with another `CharacterSet`.
+    public mutating func formIntersection(_ other: CharacterSet) {
+        if !isKnownUniquelyReferenced(&_storage) {
+            _storage = _storage.mutableCopy()
+        }
+        _storage.formIntersection(other._storage)
+    }
+
+    /// Returns a `CharacterSet` created by removing elements in `other` from `self`.
+    public func subtracting(_ other: CharacterSet) -> CharacterSet {
+        return _storage.subtracting(other._storage)
+    }
+
+    /// Sets the value to a `CharacterSet` created by removing elements in `other` from `self`.
+    public mutating func subtract(_ other: CharacterSet) {
+        if !isKnownUniquelyReferenced(&_storage) {
+            _storage = _storage.mutableCopy()
+        }
+        _storage.subtract(other._storage)
+    }
+
+    /// Returns an exclusive or of the `CharacterSet` with another `CharacterSet`.
+    public func symmetricDifference(_ other: CharacterSet) -> CharacterSet {
+        return _storage.symmetricDifference(other._storage)
+    }
+    
+    /// Sets the value to an exclusive or of the `CharacterSet` with another `CharacterSet`.
+    public mutating func formSymmetricDifference(_ other: CharacterSet) {
+        self = symmetricDifference(other)
+    }
+    
+    /// Returns true if `self` is a superset of `other`.
+    public func isSuperset(of other: CharacterSet) -> Bool {
+        return _storage.isSuperset(of: other._storage)
+    }
+
+    // MARK: -
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_storage)
+    }
+
+    /// Returns true if the two `CharacterSet`s are equal.
+    public static func ==(lhs : CharacterSet, rhs: CharacterSet) -> Bool {
+        return lhs._storage == rhs._storage
+    }
+}
+
+
+// MARK: Objective-C Bridging
+extension CharacterSet : _ObjectiveCBridgeable {
+    public static func _getObjectiveCType() -> Any.Type {
+        return NSCharacterSet.self
+    }
+    
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSCharacterSet {
+        return _storage.bridgedReference()
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ input: NSCharacterSet, result: inout CharacterSet?) {
+        result = CharacterSet(_bridged: input)
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ input: NSCharacterSet, result: inout CharacterSet?) -> Bool {
+        result = CharacterSet(_bridged: input)
+        return true
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSCharacterSet?) -> CharacterSet {
+        guard let src = source else { return CharacterSet() }
+        return CharacterSet(_bridged: src)
+    }
+    
+}
+
+extension CharacterSet : CustomStringConvertible, CustomDebugStringConvertible {
+    public var description: String {
+        return _storage.description
+    }
+
+    public var debugDescription: String {
+        return _storage.debugDescription
+    }
+}
+
+extension NSCharacterSet : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as CharacterSet)
+    }
+}
+
+extension CharacterSet : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case bitmap
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let bitmap = try container.decode(Data.self, forKey: .bitmap)
+        self.init(bitmapRepresentation: bitmap)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.bitmapRepresentation, forKey: .bitmap)
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/CheckClass.swift
+++ b/Darwin/Foundation-swiftoverlay/CheckClass.swift
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+@_implementationOnly import _SwiftFoundationOverlayShims
+import Dispatch
+
+private let _queue = DispatchQueue(label: "com.apple.SwiftFoundation._checkClassAndWarnForKeyedArchivingQueue")
+private var _seenClasses: Set<ObjectIdentifier> = []
+private func _isClassFirstSeen(_ theClass: AnyClass) -> Bool {
+  _queue.sync {
+    let id = ObjectIdentifier(theClass)
+    return _seenClasses.insert(id).inserted
+  }
+}
+
+internal func _logRuntimeIssue(_ message: String) {
+  NSLog("%@", message)
+  _swift_reportToDebugger(0, message, nil)
+}
+
+extension NSKeyedUnarchiver {
+  /// Checks if class `theClass` is good for archiving.
+  ///
+  /// If not, a runtime warning is printed.
+  ///
+  /// - Parameter operation: Specifies the archiving operation. Supported values
+  ///     are 0 for archiving, and 1 for unarchiving.
+  /// - Returns: 0 if the given class is safe to archive, and non-zero if it
+  ///     isn't.
+  @objc(_swift_checkClassAndWarnForKeyedArchiving:operation:)
+  internal class func __swift_checkClassAndWarnForKeyedArchiving(
+    _ theClass: AnyClass,
+    operation: CInt
+  ) -> CInt {
+    if _swift_isObjCTypeNameSerializable(theClass) { return 0 }
+
+    if _isClassFirstSeen(theClass) {
+      let demangledName = String(reflecting: theClass)
+      let mangledName = NSStringFromClass(theClass)
+
+      let op = (operation == 1 ? "unarchive" : "archive")
+
+      let message = """
+        Attempting to \(op) Swift class '\(demangledName)' with unstable runtime name '\(mangledName)'.
+        The runtime name for this class may change in the future, leading to non-decodable data.
+
+        You can use the 'objc' attribute to ensure that the name will not change:
+        "@objc(\(mangledName))"
+
+        If there are no existing archives containing this class, you should choose a unique, prefixed name instead:
+        "@objc(ABCMyModel)"
+        """
+      _logRuntimeIssue(message)
+    }
+    return 1
+  }
+}

--- a/Darwin/Foundation-swiftoverlay/Codable.swift
+++ b/Darwin/Foundation-swiftoverlay/Codable.swift
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Errors
+//===----------------------------------------------------------------------===//
+
+// Both of these error types bridge to NSError, and through the entry points they use, no further work is needed to make them localized.
+extension EncodingError : LocalizedError {}
+extension DecodingError : LocalizedError {}
+
+//===----------------------------------------------------------------------===//
+// Error Utilities
+//===----------------------------------------------------------------------===//
+
+extension DecodingError {
+    /// Returns a `.typeMismatch` error describing the expected type.
+    ///
+    /// - parameter path: The path of `CodingKey`s taken to decode a value of this type.
+    /// - parameter expectation: The type expected to be encountered.
+    /// - parameter reality: The value that was encountered instead of the expected type.
+    /// - returns: A `DecodingError` with the appropriate path and debug description.
+    internal static func _typeMismatch(at path: [CodingKey], expectation: Any.Type, reality: Any) -> DecodingError {
+        let description = "Expected to decode \(expectation) but found \(_typeDescription(of: reality)) instead."
+        return .typeMismatch(expectation, Context(codingPath: path, debugDescription: description))
+    }
+
+    /// Returns a description of the type of `value` appropriate for an error message.
+    ///
+    /// - parameter value: The value whose type to describe.
+    /// - returns: A string describing `value`.
+    /// - precondition: `value` is one of the types below.
+    private static func _typeDescription(of value: Any) -> String {
+        if value is NSNull {
+            return "a null value"
+        } else if value is NSNumber /* FIXME: If swift-corelibs-foundation isn't updated to use NSNumber, this check will be necessary: || value is Int || value is Double */ {
+            return "a number"
+        } else if value is String {
+            return "a string/data"
+        } else if value is [Any] {
+            return "an array"
+        } else if value is [String : Any] {
+            return "a dictionary"
+        } else {
+            return "\(type(of: value))"
+        }
+    }
+}
+
+// Only support 64bit
+#if !(os(iOS) && (arch(i386) || arch(arm)))
+
+import Combine
+
+//===----------------------------------------------------------------------===//
+// Generic Decoding
+//===----------------------------------------------------------------------===//
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension JSONEncoder: TopLevelEncoder { }
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension PropertyListEncoder: TopLevelEncoder { }
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension JSONDecoder: TopLevelDecoder { }
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension PropertyListDecoder: TopLevelDecoder { }
+
+#endif /* !(os(iOS) && (arch(i386) || arch(arm))) */

--- a/Darwin/Foundation-swiftoverlay/Collections+DataProtocol.swift
+++ b/Darwin/Foundation-swiftoverlay/Collections+DataProtocol.swift
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+//===--- DataProtocol -----------------------------------------------------===//
+
+extension Array: DataProtocol where Element == UInt8 {
+    public var regions: CollectionOfOne<Array<UInt8>> {
+        return CollectionOfOne(self)
+    }
+}
+
+extension ArraySlice: DataProtocol where Element == UInt8 {
+    public var regions: CollectionOfOne<ArraySlice<UInt8>> {
+        return CollectionOfOne(self)
+    }
+}
+
+extension ContiguousArray: DataProtocol where Element == UInt8 {
+    public var regions: CollectionOfOne<ContiguousArray<UInt8>> {
+        return CollectionOfOne(self)
+    }
+}
+
+// FIXME: This currently crashes compilation in the Late Inliner.
+// extension CollectionOfOne : DataProtocol where Element == UInt8 {
+//     public typealias Regions = CollectionOfOne<Data>
+//
+//     public var regions: CollectionOfOne<Data> {
+//         return CollectionOfOne<Data>(Data(self))
+//     }
+// }
+
+extension EmptyCollection : DataProtocol where Element == UInt8 {
+    public var regions: EmptyCollection<Data> {
+        return EmptyCollection<Data>()
+    }
+}
+
+extension Repeated: DataProtocol where Element == UInt8 {
+    public typealias Regions = Repeated<Data>
+
+    public var regions: Repeated<Data> {
+        guard !self.isEmpty else { return repeatElement(Data(), count: 0) }
+        return repeatElement(Data(CollectionOfOne(self.first!)), count: self.count)
+    }
+}
+
+//===--- MutableDataProtocol ----------------------------------------------===//
+
+extension Array: MutableDataProtocol where Element == UInt8 { }
+
+extension ContiguousArray: MutableDataProtocol where Element == UInt8 { }

--- a/Darwin/Foundation-swiftoverlay/CombineTypealiases.swift
+++ b/Darwin/Foundation-swiftoverlay/CombineTypealiases.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if !(os(iOS) && (arch(i386) || arch(arm))) // Combine isn't on 32-bit iOS
+
+import Combine
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public typealias Published = Combine.Published
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public typealias ObservableObject = Combine.ObservableObject
+
+#endif /* !(os(iOS) && (arch(i386) || arch(arm))) */

--- a/Darwin/Foundation-swiftoverlay/ContiguousBytes.swift
+++ b/Darwin/Foundation-swiftoverlay/ContiguousBytes.swift
@@ -1,0 +1,100 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+//===--- ContiguousBytes --------------------------------------------------===//
+
+/// Indicates that the conforming type is a contiguous collection of raw bytes
+/// whose underlying storage is directly accessible by withUnsafeBytes.
+public protocol ContiguousBytes {
+    /// Calls the given closure with the contents of underlying storage.
+    ///
+    /// - note: Calling `withUnsafeBytes` multiple times does not guarantee that
+    ///         the same buffer pointer will be passed in every time.
+    /// - warning: The buffer argument to the body should not be stored or used
+    ///            outside of the lifetime of the call to the closure.
+    func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R
+}
+
+//===--- Collection Conformances ------------------------------------------===//
+
+// FIXME: When possible, expand conformance to `where Element : Trivial`.
+extension Array : ContiguousBytes where Element == UInt8 { }
+
+// FIXME: When possible, expand conformance to `where Element : Trivial`.
+extension ArraySlice : ContiguousBytes where Element == UInt8 { }
+
+// FIXME: When possible, expand conformance to `where Element : Trivial`.
+extension ContiguousArray : ContiguousBytes where Element == UInt8 { }
+
+//===--- Pointer Conformances ---------------------------------------------===//
+
+extension UnsafeRawBufferPointer : ContiguousBytes {
+    @inlinable
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try body(self)
+    }
+}
+
+extension UnsafeMutableRawBufferPointer : ContiguousBytes {
+    @inlinable
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try body(UnsafeRawBufferPointer(self))
+    }
+}
+
+// FIXME: When possible, expand conformance to `where Element : Trivial`.
+extension UnsafeBufferPointer : ContiguousBytes where Element == UInt8 {
+    @inlinable
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try body(UnsafeRawBufferPointer(self))
+    }
+}
+
+// FIXME: When possible, expand conformance to `where Element : Trivial`.
+extension UnsafeMutableBufferPointer : ContiguousBytes where Element == UInt8 {
+    @inlinable
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try body(UnsafeRawBufferPointer(self))
+    }
+}
+
+// FIXME: When possible, expand conformance to `where Element : Trivial`.
+extension EmptyCollection : ContiguousBytes where Element == UInt8 {
+    @inlinable
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try body(UnsafeRawBufferPointer(start: nil, count: 0))
+    }
+}
+
+// FIXME: When possible, expand conformance to `where Element : Trivial`.
+extension CollectionOfOne : ContiguousBytes where Element == UInt8 {
+    @inlinable
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        let element = self.first!
+        return try Swift.withUnsafeBytes(of: element) {
+            return try body($0)
+        }
+    }
+}
+
+//===--- Conditional Conformances -----------------------------------------===//
+
+extension Slice : ContiguousBytes where Base : ContiguousBytes {
+    public func withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
+        let offset = base.distance(from: base.startIndex, to: self.startIndex)
+        return try base.withUnsafeBytes { ptr in
+            let slicePtr = ptr.baseAddress?.advanced(by: offset)
+            let sliceBuffer = UnsafeRawBufferPointer(start: slicePtr, count: self.count)
+            return try body(sliceBuffer)
+        }
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/Data.swift
+++ b/Darwin/Foundation-swiftoverlay/Data.swift
@@ -1,0 +1,2853 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if DEPLOYMENT_RUNTIME_SWIFT
+
+#if os(macOS) || os(iOS)
+import Darwin
+#elseif os(Linux)
+import Glibc
+
+@inlinable // This is @inlinable as trivially computable.
+private func malloc_good_size(_ size: Int) -> Int {
+    return size
+}
+
+#endif
+
+import CoreFoundation
+
+internal func __NSDataInvokeDeallocatorUnmap(_ mem: UnsafeMutableRawPointer, _ length: Int) {
+    munmap(mem, length)
+}
+
+internal func __NSDataInvokeDeallocatorFree(_ mem: UnsafeMutableRawPointer, _ length: Int) {
+    free(mem)
+}
+
+internal func __NSDataIsCompact(_ data: NSData) -> Bool {
+    return data._isCompact()
+}
+
+#else
+
+@_exported import Foundation // Clang module
+@_implementationOnly import _FoundationOverlayShims
+@_implementationOnly import _CoreFoundationOverlayShims
+
+internal func __NSDataIsCompact(_ data: NSData) -> Bool {
+    if #available(OSX 10.10, iOS 8.0, tvOS 9.0, watchOS 2.0, *) {
+        return data._isCompact()
+    } else {
+        var compact = true
+        let len = data.length
+        data.enumerateBytes { (_, byteRange, stop) in
+            if byteRange.length != len {
+                compact = false
+            }
+            stop.pointee = true
+        }
+        return compact
+    }
+}
+
+#endif
+
+@_alwaysEmitIntoClient
+internal func _withStackOrHeapBuffer(capacity: Int, _ body: (UnsafeMutableBufferPointer<UInt8>) -> Void) {
+    guard capacity > 0 else {
+        body(UnsafeMutableBufferPointer(start: nil, count: 0))
+        return
+    }
+    typealias InlineBuffer = ( // 32 bytes
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
+    )
+    let inlineCount = MemoryLayout<InlineBuffer>.size
+    if capacity <= inlineCount {
+        var buffer: InlineBuffer = (
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0
+        )
+        withUnsafeMutableBytes(of: &buffer) { buffer in
+            assert(buffer.count == inlineCount)
+            let start = buffer.baseAddress!.assumingMemoryBound(to: UInt8.self)
+            body(UnsafeMutableBufferPointer(start: start, count: capacity))
+        }
+        return
+    }
+
+    let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: capacity)
+    defer { buffer.deallocate() }
+    body(buffer)
+}
+
+// Underlying storage representation for medium and large data.
+// Inlinability strategy: methods from here should not inline into InlineSlice or LargeSlice unless trivial.
+// NOTE: older overlays called this class _DataStorage. The two must
+// coexist without a conflicting ObjC class name, so it was renamed.
+// The old name must not be used in the new runtime.
+@usableFromInline
+internal final class __DataStorage {
+    @usableFromInline static let maxSize = Int.max >> 1
+    @usableFromInline static let vmOpsThreshold = NSPageSize() * 4
+    
+    @inlinable // This is @inlinable as trivially forwarding, and does not escape the _DataStorage boundary layer.
+    static func allocate(_ size: Int, _ clear: Bool) -> UnsafeMutableRawPointer? {
+        if clear {
+            return calloc(1, size)
+        } else {
+            return malloc(size)
+        }
+    }
+    
+    @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
+    static func move(_ dest_: UnsafeMutableRawPointer, _ source_: UnsafeRawPointer?, _ num_: Int) {
+        var dest = dest_
+        var source = source_
+        var num = num_
+        if __DataStorage.vmOpsThreshold <= num && ((unsafeBitCast(source, to: Int.self) | Int(bitPattern: dest)) & (NSPageSize() - 1)) == 0 {
+            let pages = NSRoundDownToMultipleOfPageSize(num)
+            NSCopyMemoryPages(source!, dest, pages)
+            source = source!.advanced(by: pages)
+            dest = dest.advanced(by: pages)
+            num -= pages
+        }
+        if num > 0 {
+            memmove(dest, source!, num)
+        }
+    }
+    
+    @inlinable // This is @inlinable as trivially forwarding, and does not escape the _DataStorage boundary layer.
+    static func shouldAllocateCleared(_ size: Int) -> Bool {
+        return (size > (128 * 1024))
+    }
+    
+    @usableFromInline var _bytes: UnsafeMutableRawPointer?
+    @usableFromInline var _length: Int
+    @usableFromInline var _capacity: Int
+    @usableFromInline var _offset: Int
+    @usableFromInline var _deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?
+    @usableFromInline var _needToZero: Bool
+
+    @inlinable // This is @inlinable as trivially computable.
+    var bytes: UnsafeRawPointer? {
+        return UnsafeRawPointer(_bytes)?.advanced(by: -_offset)
+    }
+
+    @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is generic and trivially forwarding.
+    @discardableResult
+    func withUnsafeBytes<Result>(in range: Range<Int>, apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
+        return try apply(UnsafeRawBufferPointer(start: _bytes?.advanced(by: range.lowerBound - _offset), count: Swift.min(range.upperBound - range.lowerBound, _length)))
+    }
+    
+    @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is generic and trivially forwarding.
+    @discardableResult
+    func withUnsafeMutableBytes<Result>(in range: Range<Int>, apply: (UnsafeMutableRawBufferPointer) throws -> Result) rethrows -> Result {
+        return try apply(UnsafeMutableRawBufferPointer(start: _bytes!.advanced(by:range.lowerBound - _offset), count: Swift.min(range.upperBound - range.lowerBound, _length)))
+    }
+
+    @inlinable // This is @inlinable as trivially computable.
+    var mutableBytes: UnsafeMutableRawPointer? {
+        return _bytes?.advanced(by: -_offset)
+    }
+
+    @inlinable // This is @inlinable as trivially computable.
+    var capacity: Int {
+        return _capacity
+    }
+    
+    @inlinable // This is @inlinable as trivially computable.
+    var length: Int {
+        get {
+            return _length
+        }
+        set {
+            setLength(newValue)
+        }
+    }
+    
+    @inlinable // This is inlinable as trivially computable.
+    var isExternallyOwned: Bool {
+        // all __DataStorages will have some sort of capacity, because empty cases hit the .empty enum _Representation
+        // anything with 0 capacity means that we have not allocated this pointer and concequently mutation is not ours to make.
+        return _capacity == 0
+    }
+    
+    @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
+    func ensureUniqueBufferReference(growingTo newLength: Int = 0, clear: Bool = false) {
+        guard isExternallyOwned || newLength > _capacity else { return }
+
+        if newLength == 0 {
+            if isExternallyOwned {
+                let newCapacity = malloc_good_size(_length)
+                let newBytes = __DataStorage.allocate(newCapacity, false)
+                __DataStorage.move(newBytes!, _bytes!, _length)
+                _freeBytes()
+                _bytes = newBytes
+                _capacity = newCapacity
+                _needToZero = false
+            }
+        } else if isExternallyOwned {
+            let newCapacity = malloc_good_size(newLength)
+            let newBytes = __DataStorage.allocate(newCapacity, clear)
+            if let bytes = _bytes {
+                __DataStorage.move(newBytes!, bytes, _length)
+            }
+            _freeBytes()
+            _bytes = newBytes
+            _capacity = newCapacity
+            _length = newLength
+            _needToZero = true
+        } else {
+            let cap = _capacity
+            var additionalCapacity = (newLength >> (__DataStorage.vmOpsThreshold <= newLength ? 2 : 1))
+            if Int.max - additionalCapacity < newLength {
+                additionalCapacity = 0
+            }
+            var newCapacity = malloc_good_size(Swift.max(cap, newLength + additionalCapacity))
+            let origLength = _length
+            var allocateCleared = clear && __DataStorage.shouldAllocateCleared(newCapacity)
+            var newBytes: UnsafeMutableRawPointer? = nil
+            if _bytes == nil {
+                newBytes = __DataStorage.allocate(newCapacity, allocateCleared)
+                if newBytes == nil {
+                    /* Try again with minimum length */
+                    allocateCleared = clear && __DataStorage.shouldAllocateCleared(newLength)
+                    newBytes = __DataStorage.allocate(newLength, allocateCleared)
+                }
+            } else {
+                let tryCalloc = (origLength == 0 || (newLength / origLength) >= 4)
+                if allocateCleared && tryCalloc {
+                    newBytes = __DataStorage.allocate(newCapacity, true)
+                    if let newBytes = newBytes {
+                        __DataStorage.move(newBytes, _bytes!, origLength)
+                        _freeBytes()
+                    }
+                }
+                /* Where calloc/memmove/free fails, realloc might succeed */
+                if newBytes == nil {
+                    allocateCleared = false
+                    if _deallocator != nil {
+                        newBytes = __DataStorage.allocate(newCapacity, true)
+                        if let newBytes = newBytes {
+                            __DataStorage.move(newBytes, _bytes!, origLength)
+                            _freeBytes()
+                        }
+                    } else {
+                        newBytes = realloc(_bytes!, newCapacity)
+                    }
+                }
+                /* Try again with minimum length */
+                if newBytes == nil {
+                    newCapacity = malloc_good_size(newLength)
+                    allocateCleared = clear && __DataStorage.shouldAllocateCleared(newCapacity)
+                    if allocateCleared && tryCalloc {
+                        newBytes = __DataStorage.allocate(newCapacity, true)
+                        if let newBytes = newBytes {
+                            __DataStorage.move(newBytes, _bytes!, origLength)
+                            _freeBytes()
+                        }
+                    }
+                    if newBytes == nil {
+                        allocateCleared = false
+                        newBytes = realloc(_bytes!, newCapacity)
+                    }
+                }
+            }
+
+            if newBytes == nil {
+                /* Could not allocate bytes */
+                // At this point if the allocation cannot occur the process is likely out of memory
+                // and Bad-Things™ are going to happen anyhow
+                fatalError("unable to allocate memory for length (\(newLength))")
+            }
+
+            if origLength < newLength && clear && !allocateCleared {
+                memset(newBytes!.advanced(by: origLength), 0, newLength - origLength)
+            }
+
+            /* _length set by caller */
+            _bytes = newBytes
+            _capacity = newCapacity
+            /* Realloc/memset doesn't zero out the entire capacity, so we must be safe and clear next time we grow the length */
+            _needToZero = !allocateCleared
+        }
+    }
+
+    @inlinable // This is @inlinable as it does not escape the _DataStorage boundary layer.
+    func _freeBytes() {
+        if let bytes = _bytes {
+            if let dealloc = _deallocator {
+                dealloc(bytes, length)
+            } else {
+                free(bytes)
+            }
+        }
+        _deallocator = nil
+    }
+
+    @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is trivially computed.
+    func enumerateBytes(in range: Range<Int>, _ block: (_ buffer: UnsafeBufferPointer<UInt8>, _ byteIndex: Data.Index, _ stop: inout Bool) -> Void) {
+        var stopv: Bool = false
+        block(UnsafeBufferPointer<UInt8>(start: _bytes?.advanced(by: range.lowerBound - _offset).assumingMemoryBound(to: UInt8.self), count: Swift.min(range.upperBound - range.lowerBound, _length)), 0, &stopv)
+    }
+    
+    @inlinable // This is @inlinable as it does not escape the _DataStorage boundary layer.
+    func setLength(_ length: Int) {
+        let origLength = _length
+        let newLength = length
+        if _capacity < newLength || _bytes == nil {
+            ensureUniqueBufferReference(growingTo: newLength, clear: true)
+        } else if origLength < newLength && _needToZero {
+            memset(_bytes! + origLength, 0, newLength - origLength)
+        } else if newLength < origLength {
+            _needToZero = true
+        }
+        _length = newLength
+    }
+    
+    @inlinable // This is @inlinable as it does not escape the _DataStorage boundary layer.
+    func append(_ bytes: UnsafeRawPointer, length: Int) {
+        precondition(length >= 0, "Length of appending bytes must not be negative")
+        let origLength = _length
+        let newLength = origLength + length
+        if _capacity < newLength || _bytes == nil {
+            ensureUniqueBufferReference(growingTo: newLength, clear: false)
+        }
+        _length = newLength
+        __DataStorage.move(_bytes!.advanced(by: origLength), bytes, length)
+    }
+    
+    @inlinable // This is @inlinable despite escaping the __DataStorage boundary layer because it is trivially computed.
+    func get(_ index: Int) -> UInt8 {
+        return _bytes!.advanced(by: index - _offset).assumingMemoryBound(to: UInt8.self).pointee
+    }
+    
+    @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is trivially computed.
+    func set(_ index: Int, to value: UInt8) {
+        ensureUniqueBufferReference()
+        _bytes!.advanced(by: index - _offset).assumingMemoryBound(to: UInt8.self).pointee = value
+    }
+
+    @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is trivially computed.
+    func copyBytes(to pointer: UnsafeMutableRawPointer, from range: Range<Int>) {
+        let offsetPointer = UnsafeRawBufferPointer(start: _bytes?.advanced(by: range.lowerBound - _offset), count: Swift.min(range.upperBound - range.lowerBound, _length))
+        UnsafeMutableRawBufferPointer(start: pointer, count: range.upperBound - range.lowerBound).copyMemory(from: offsetPointer)
+    }
+
+    @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
+    func replaceBytes(in range_: NSRange, with replacementBytes: UnsafeRawPointer?, length replacementLength: Int) {
+        let range = NSRange(location: range_.location - _offset, length: range_.length)
+        let currentLength = _length
+        let resultingLength = currentLength - range.length + replacementLength
+        let shift = resultingLength - currentLength
+        let mutableBytes: UnsafeMutableRawPointer
+        if resultingLength > currentLength {
+            ensureUniqueBufferReference(growingTo: resultingLength)
+            _length = resultingLength
+        } else {
+            ensureUniqueBufferReference()
+        }
+        mutableBytes = _bytes!
+        /* shift the trailing bytes */
+        let start = range.location
+        let length = range.length
+        if shift != 0 {
+            memmove(mutableBytes + start + replacementLength, mutableBytes + start + length, currentLength - start - length)
+        }
+        if replacementLength != 0 {
+            if let replacementBytes = replacementBytes {
+                memmove(mutableBytes + start, replacementBytes, replacementLength)
+            } else {
+                memset(mutableBytes + start, 0, replacementLength)
+            }
+        }
+        
+        if resultingLength < currentLength {
+            setLength(resultingLength)
+        }
+    }
+    
+    @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
+    func resetBytes(in range_: Range<Int>) {
+        let range = NSRange(location: range_.lowerBound - _offset, length: range_.upperBound - range_.lowerBound)
+        if range.length == 0 { return }
+        if _length < range.location + range.length {
+            let newLength = range.location + range.length
+            if _capacity <= newLength {
+                ensureUniqueBufferReference(growingTo: newLength, clear: false)
+            }
+            _length = newLength
+        } else {
+            ensureUniqueBufferReference()
+        }
+        memset(_bytes!.advanced(by: range.location), 0, range.length)
+    }
+
+    @usableFromInline // This is not @inlinable as a non-trivial, non-convenience initializer.
+    init(length: Int) {
+        precondition(length < __DataStorage.maxSize)
+        var capacity = (length < 1024 * 1024 * 1024) ? length + (length >> 2) : length
+        if __DataStorage.vmOpsThreshold <= capacity {
+            capacity = NSRoundUpToMultipleOfPageSize(capacity)
+        }
+        
+        let clear = __DataStorage.shouldAllocateCleared(length)
+        _bytes = __DataStorage.allocate(capacity, clear)!
+        _capacity = capacity
+        _needToZero = !clear
+        _length = 0
+        _offset = 0
+        setLength(length)
+    }
+    
+    @usableFromInline // This is not @inlinable as a non-convience initializer.
+    init(capacity capacity_: Int = 0) {
+        var capacity = capacity_
+        precondition(capacity < __DataStorage.maxSize)
+        if __DataStorage.vmOpsThreshold <= capacity {
+            capacity = NSRoundUpToMultipleOfPageSize(capacity)
+        }
+        _length = 0
+        _bytes = __DataStorage.allocate(capacity, false)!
+        _capacity = capacity
+        _needToZero = true
+        _offset = 0
+    }
+    
+    @usableFromInline // This is not @inlinable as a non-convience initializer.
+    init(bytes: UnsafeRawPointer?, length: Int) {
+        precondition(length < __DataStorage.maxSize)
+        _offset = 0
+        if length == 0 {
+            _capacity = 0
+            _length = 0
+            _needToZero = false
+            _bytes = nil
+        } else if __DataStorage.vmOpsThreshold <= length {
+            _capacity = length
+            _length = length
+            _needToZero = true
+            _bytes = __DataStorage.allocate(length, false)!
+            __DataStorage.move(_bytes!, bytes, length)
+        } else {
+            var capacity = length
+            if __DataStorage.vmOpsThreshold <= capacity {
+                capacity = NSRoundUpToMultipleOfPageSize(capacity)
+            }
+            _length = length
+            _bytes = __DataStorage.allocate(capacity, false)!
+            _capacity = capacity
+            _needToZero = true
+            __DataStorage.move(_bytes!, bytes, length)
+        }
+    }
+    
+    @usableFromInline // This is not @inlinable as a non-convience initializer.
+    init(bytes: UnsafeMutableRawPointer?, length: Int, copy: Bool, deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?, offset: Int) {
+        precondition(length < __DataStorage.maxSize)
+        _offset = offset
+        if length == 0 {
+            _capacity = 0
+            _length = 0
+            _needToZero = false
+            _bytes = nil
+            if let dealloc = deallocator,
+               let bytes_ = bytes {
+                dealloc(bytes_, length)
+            }
+        } else if !copy {
+            _capacity = length
+            _length = length
+            _needToZero = false
+            _bytes = bytes
+            _deallocator = deallocator
+        } else if __DataStorage.vmOpsThreshold <= length {
+            _capacity = length
+            _length = length
+            _needToZero = true
+            _bytes = __DataStorage.allocate(length, false)!
+            __DataStorage.move(_bytes!, bytes, length)
+            if let dealloc = deallocator {
+                dealloc(bytes!, length)
+            }
+        } else {
+            var capacity = length
+            if __DataStorage.vmOpsThreshold <= capacity {
+                capacity = NSRoundUpToMultipleOfPageSize(capacity)
+            }
+            _length = length
+            _bytes = __DataStorage.allocate(capacity, false)!
+            _capacity = capacity
+            _needToZero = true
+            __DataStorage.move(_bytes!, bytes, length)
+            if let dealloc = deallocator {
+                dealloc(bytes!, length)
+            }
+        }
+    }
+
+    @usableFromInline // This is not @inlinable as a non-convience initializer.
+    init(immutableReference: NSData, offset: Int) {
+        _offset = offset
+        _bytes = UnsafeMutableRawPointer(mutating: immutableReference.bytes)
+        _capacity = 0
+        _needToZero = false
+        _length = immutableReference.length
+        _deallocator = { _, _ in
+            _fixLifetime(immutableReference)
+        }
+    }
+    
+    @usableFromInline // This is not @inlinable as a non-convience initializer.
+    init(mutableReference: NSMutableData, offset: Int) {
+        _offset = offset
+        _bytes = mutableReference.mutableBytes
+        _capacity = 0
+        _needToZero = false
+        _length = mutableReference.length
+        _deallocator = { _, _ in
+            _fixLifetime(mutableReference)
+        }
+    }
+    
+    @usableFromInline // This is not @inlinable as a non-convience initializer.
+    init(customReference: NSData, offset: Int) {
+        _offset = offset
+        _bytes = UnsafeMutableRawPointer(mutating: customReference.bytes)
+        _capacity = 0
+        _needToZero = false
+        _length = customReference.length
+        _deallocator = { _, _ in
+            _fixLifetime(customReference)
+        }
+    }
+    
+    @usableFromInline // This is not @inlinable as a non-convience initializer.
+    init(customMutableReference: NSMutableData, offset: Int) {
+        _offset = offset
+        _bytes = customMutableReference.mutableBytes
+        _capacity = 0
+        _needToZero = false
+        _length = customMutableReference.length
+        _deallocator = { _, _ in
+            _fixLifetime(customMutableReference)
+        }
+    }
+    
+    deinit {
+        _freeBytes()
+    }
+    
+    @inlinable // This is @inlinable despite escaping the __DataStorage boundary layer because it is trivially computed.
+    func mutableCopy(_ range: Range<Int>) -> __DataStorage {
+        return __DataStorage(bytes: _bytes?.advanced(by: range.lowerBound - _offset), length: range.upperBound - range.lowerBound, copy: true, deallocator: nil, offset: range.lowerBound)
+    }
+
+    @inlinable // This is @inlinable despite escaping the _DataStorage boundary layer because it is generic and trivially computed.
+    func withInteriorPointerReference<T>(_ range: Range<Int>, _ work: (NSData) throws -> T) rethrows -> T {
+        if range.isEmpty {
+            return try work(NSData()) // zero length data can be optimized as a singleton
+        }
+        return try work(NSData(bytesNoCopy: _bytes!.advanced(by: range.lowerBound - _offset), length: range.upperBound - range.lowerBound, freeWhenDone: false))
+    }
+
+    @inline(never) // This is not @inlinable to avoid emission of the private `__NSSwiftData` class name into clients.
+    @usableFromInline
+    func bridgedReference(_ range: Range<Int>) -> NSData {
+        if range.isEmpty {
+            return NSData() // zero length data can be optimized as a singleton
+        }
+
+        return __NSSwiftData(backing: self, range: range)
+    }
+}
+
+// NOTE: older overlays called this _NSSwiftData. The two must
+// coexist, so it was renamed. The old name must not be used in the new
+// runtime.
+internal class __NSSwiftData : NSData {
+    var _backing: __DataStorage!
+    var _range: Range<Data.Index>!
+
+    convenience init(backing: __DataStorage, range: Range<Data.Index>) {
+        self.init()
+        _backing = backing
+        _range = range
+    }
+    @objc override var length: Int {
+        return _range.upperBound - _range.lowerBound
+    }
+
+    @objc override var bytes: UnsafeRawPointer {
+        // NSData's byte pointer methods are not annotated for nullability correctly
+        // (but assume non-null by the wrapping macro guards). This placeholder value
+        // is to work-around this bug. Any indirection to the underlying bytes of an NSData
+        // with a length of zero would have been a programmer error anyhow so the actual
+        // return value here is not needed to be an allocated value. This is specifically
+        // needed to live like this to be source compatible with Swift3. Beyond that point
+        // this API may be subject to correction.
+        guard let bytes = _backing.bytes else {
+            return UnsafeRawPointer(bitPattern: 0xBAD0)!
+        }
+
+        return bytes.advanced(by: _range.lowerBound)
+    }
+
+    @objc override func copy(with zone: NSZone? = nil) -> Any {
+        return self
+    }
+
+    @objc override func mutableCopy(with zone: NSZone? = nil) -> Any {
+        return NSMutableData(bytes: bytes, length: length)
+    }
+
+#if !DEPLOYMENT_RUNTIME_SWIFT
+    @objc override
+    func _isCompact() -> Bool {
+        return true
+    }
+#endif
+
+#if DEPLOYMENT_RUNTIME_SWIFT
+    override func _providesConcreteBacking() -> Bool {
+        return true
+    }
+#else
+    @objc(_providesConcreteBacking)
+    func _providesConcreteBacking() -> Bool {
+        return true
+    }
+#endif
+}
+
+@frozen
+public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessCollection, MutableCollection, RangeReplaceableCollection, MutableDataProtocol, ContiguousBytes {
+    public typealias ReferenceType = NSData
+
+    public typealias ReadingOptions = NSData.ReadingOptions
+    public typealias WritingOptions = NSData.WritingOptions
+    public typealias SearchOptions = NSData.SearchOptions
+    public typealias Base64EncodingOptions = NSData.Base64EncodingOptions
+    public typealias Base64DecodingOptions = NSData.Base64DecodingOptions
+
+    public typealias Index = Int
+    public typealias Indices = Range<Int>
+
+    // A small inline buffer of bytes suitable for stack-allocation of small data.
+    // Inlinability strategy: everything here should be inlined for direct operation on the stack wherever possible.
+    @usableFromInline
+    @frozen
+    internal struct InlineData {
+#if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+        @usableFromInline typealias Buffer = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+                                              UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) //len  //enum
+        @usableFromInline var bytes: Buffer
+#elseif arch(i386) || arch(arm)
+        @usableFromInline typealias Buffer = (UInt8, UInt8, UInt8, UInt8,
+                                              UInt8, UInt8) //len  //enum
+        @usableFromInline var bytes: Buffer
+#endif
+        @usableFromInline var length: UInt8
+
+        @inlinable // This is @inlinable as trivially computable.
+        static func canStore(count: Int) -> Bool {
+            return count <= MemoryLayout<Buffer>.size
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ srcBuffer: UnsafeRawBufferPointer) {
+            self.init(count: srcBuffer.count)
+            if !srcBuffer.isEmpty {
+                Swift.withUnsafeMutableBytes(of: &bytes) { dstBuffer in
+                    dstBuffer.baseAddress?.copyMemory(from: srcBuffer.baseAddress!, byteCount: srcBuffer.count)
+                }
+            }
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(count: Int = 0) {
+            assert(count <= MemoryLayout<Buffer>.size)
+#if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+            bytes = (UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0))
+#elseif arch(i386) || arch(arm)
+            bytes = (UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0))
+#endif
+            length = UInt8(count)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ slice: InlineSlice, count: Int) {
+            self.init(count: count)
+            Swift.withUnsafeMutableBytes(of: &bytes) { dstBuffer in
+                slice.withUnsafeBytes { srcBuffer in
+                    dstBuffer.copyMemory(from: UnsafeRawBufferPointer(start: srcBuffer.baseAddress, count: count))
+                }
+            }
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ slice: LargeSlice, count: Int) {
+            self.init(count: count)
+            Swift.withUnsafeMutableBytes(of: &bytes) { dstBuffer in
+                slice.withUnsafeBytes { srcBuffer in
+                    dstBuffer.copyMemory(from: UnsafeRawBufferPointer(start: srcBuffer.baseAddress, count: count))
+                }
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var capacity: Int {
+            return MemoryLayout<Buffer>.size
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var count: Int {
+            get {
+                return Int(length)
+            }
+            set(newValue) {
+                assert(newValue <= MemoryLayout<Buffer>.size)
+                length = UInt8(newValue)
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var startIndex: Int {
+            return 0
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var endIndex: Int {
+            return count
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        func withUnsafeBytes<Result>(_ apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
+            let count = Int(length)
+            return try Swift.withUnsafeBytes(of: bytes) { (rawBuffer) throws -> Result in
+                return try apply(UnsafeRawBufferPointer(start: rawBuffer.baseAddress, count: count))
+            }
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        mutating func withUnsafeMutableBytes<Result>(_ apply: (UnsafeMutableRawBufferPointer) throws -> Result) rethrows -> Result {
+            let count = Int(length)
+            return try Swift.withUnsafeMutableBytes(of: &bytes) { (rawBuffer) throws -> Result in
+                return try apply(UnsafeMutableRawBufferPointer(start: rawBuffer.baseAddress, count: count))
+            }
+        }
+
+        @inlinable // This is @inlinable as tribially computable.
+        mutating func append(byte: UInt8) {
+            let count = self.count
+            assert(count + 1 <= MemoryLayout<Buffer>.size)
+            Swift.withUnsafeMutableBytes(of: &bytes) { $0[count] = byte }
+            self.length += 1
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        mutating func append(contentsOf buffer: UnsafeRawBufferPointer) {
+            guard !buffer.isEmpty else { return }
+            assert(count + buffer.count <= MemoryLayout<Buffer>.size)
+            let cnt = count
+            _ = Swift.withUnsafeMutableBytes(of: &bytes) { rawBuffer in
+                rawBuffer.baseAddress?.advanced(by: cnt).copyMemory(from: buffer.baseAddress!, byteCount: buffer.count)
+            }
+
+            length += UInt8(buffer.count)
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        subscript(index: Index) -> UInt8 {
+            get {
+                assert(index <= MemoryLayout<Buffer>.size)
+                precondition(index < length, "index \(index) is out of bounds of 0..<\(length)")
+                return Swift.withUnsafeBytes(of: bytes) { rawBuffer -> UInt8 in
+                    return rawBuffer[index]
+                }
+            }
+            set(newValue) {
+                assert(index <= MemoryLayout<Buffer>.size)
+                precondition(index < length, "index \(index) is out of bounds of 0..<\(length)")
+                Swift.withUnsafeMutableBytes(of: &bytes) { rawBuffer in
+                    rawBuffer[index] = newValue
+                }
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        mutating func resetBytes(in range: Range<Index>) {
+            assert(range.lowerBound <= MemoryLayout<Buffer>.size)
+            assert(range.upperBound <= MemoryLayout<Buffer>.size)
+            precondition(range.lowerBound <= length, "index \(range.lowerBound) is out of bounds of 0..<\(length)")
+            if count < range.upperBound {
+                count = range.upperBound
+            }
+
+            let _ = Swift.withUnsafeMutableBytes(of: &bytes) { rawBuffer in
+              memset(rawBuffer.baseAddress?.advanced(by: range.lowerBound), 0, range.upperBound - range.lowerBound)
+            }
+        }
+
+        @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
+        mutating func replaceSubrange(_ subrange: Range<Index>, with replacementBytes: UnsafeRawPointer?, count replacementLength: Int) {
+            assert(subrange.lowerBound <= MemoryLayout<Buffer>.size)
+            assert(subrange.upperBound <= MemoryLayout<Buffer>.size)
+            assert(count - (subrange.upperBound - subrange.lowerBound) + replacementLength <= MemoryLayout<Buffer>.size)
+            precondition(subrange.lowerBound <= length, "index \(subrange.lowerBound) is out of bounds of 0..<\(length)")
+            precondition(subrange.upperBound <= length, "index \(subrange.upperBound) is out of bounds of 0..<\(length)")
+            let currentLength = count
+            let resultingLength = currentLength - (subrange.upperBound - subrange.lowerBound) + replacementLength
+            let shift = resultingLength - currentLength
+            Swift.withUnsafeMutableBytes(of: &bytes) { mutableBytes in
+                /* shift the trailing bytes */
+                let start = subrange.lowerBound
+                let length = subrange.upperBound - subrange.lowerBound
+                if shift != 0 {
+                    memmove(mutableBytes.baseAddress?.advanced(by: start + replacementLength), mutableBytes.baseAddress?.advanced(by: start + length), currentLength - start - length)
+                }
+                if replacementLength != 0 {
+                    memmove(mutableBytes.baseAddress?.advanced(by: start), replacementBytes!, replacementLength)
+                }
+            }
+            count = resultingLength
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        func copyBytes(to pointer: UnsafeMutableRawPointer, from range: Range<Int>) {
+            precondition(startIndex <= range.lowerBound, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(startIndex <= range.upperBound, "index \(range.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(range.upperBound <= endIndex, "index \(range.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+
+            Swift.withUnsafeBytes(of: bytes) {
+                let cnt = Swift.min($0.count, range.upperBound - range.lowerBound)
+                guard cnt > 0 else { return }
+                pointer.copyMemory(from: $0.baseAddress!.advanced(by: range.lowerBound), byteCount: cnt)
+            }
+        }
+
+        @inline(__always) // This should always be inlined into _Representation.hash(into:).
+        func hash(into hasher: inout Hasher) {
+            // **NOTE**: this uses `count` (an Int) and NOT `length` (a UInt8)
+            //           Despite having the same value, they hash differently. InlineSlice and LargeSlice both use `count` (an Int); if you combine the same bytes but with `length` over `count`, you can get a different hash.
+            //
+            // This affects slices, which are InlineSlice and not InlineData:
+            //
+            //   let d = Data([0xFF, 0xFF])                // InlineData
+            //   let s = Data([0, 0xFF, 0xFF]).dropFirst() // InlineSlice
+            //   assert(s == d)
+            //   assert(s.hashValue == d.hashValue)
+            hasher.combine(count)
+
+            Swift.withUnsafeBytes(of: bytes) {
+                // We have access to the full byte buffer here, but not all of it is meaningfully used (bytes past self.length may be garbage).
+                let bytes = UnsafeRawBufferPointer(start: $0.baseAddress, count: self.count)
+                hasher.combine(bytes: bytes)
+            }
+        }
+    }
+
+#if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+    @usableFromInline internal typealias HalfInt = Int32
+#elseif arch(i386) || arch(arm)
+    @usableFromInline internal typealias HalfInt = Int16
+#endif
+
+    // A buffer of bytes too large to fit in an InlineData, but still small enough to fit a storage pointer + range in two words.
+    // Inlinability strategy: everything here should be easily inlinable as large _DataStorage methods should not inline into here.
+    @usableFromInline
+    @frozen
+    internal struct InlineSlice {
+        // ***WARNING***
+        // These ivars are specifically laid out so that they cause the enum _Representation to be 16 bytes on 64 bit platforms. This means we _MUST_ have the class type thing last
+        @usableFromInline var slice: Range<HalfInt>
+        @usableFromInline var storage: __DataStorage
+
+        @inlinable // This is @inlinable as trivially computable.
+        static func canStore(count: Int) -> Bool {
+            return count < HalfInt.max
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ buffer: UnsafeRawBufferPointer) {
+            assert(buffer.count < HalfInt.max)
+            self.init(__DataStorage(bytes: buffer.baseAddress, length: buffer.count), count: buffer.count)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(capacity: Int) {
+            assert(capacity < HalfInt.max)
+            self.init(__DataStorage(capacity: capacity), count: 0)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(count: Int) {
+            assert(count < HalfInt.max)
+            self.init(__DataStorage(length: count), count: count)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ inline: InlineData) {
+            assert(inline.count < HalfInt.max)
+            self.init(inline.withUnsafeBytes { return __DataStorage(bytes: $0.baseAddress, length: $0.count) }, count: inline.count)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ inline: InlineData, range: Range<Int>) {
+            assert(range.lowerBound < HalfInt.max)
+            assert(range.upperBound < HalfInt.max)
+            self.init(inline.withUnsafeBytes { return __DataStorage(bytes: $0.baseAddress, length: $0.count) }, range: range)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ large: LargeSlice) {
+            assert(large.range.lowerBound < HalfInt.max)
+            assert(large.range.upperBound < HalfInt.max)
+            self.init(large.storage, range: large.range)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ large: LargeSlice, range: Range<Int>) {
+            assert(range.lowerBound < HalfInt.max)
+            assert(range.upperBound < HalfInt.max)
+            self.init(large.storage, range: range)
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(_ storage: __DataStorage, count: Int) {
+            assert(count < HalfInt.max)
+            self.storage = storage
+            slice = 0..<HalfInt(count)
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(_ storage: __DataStorage, range: Range<Int>) {
+            assert(range.lowerBound < HalfInt.max)
+            assert(range.upperBound < HalfInt.max)
+            self.storage = storage
+            slice = HalfInt(range.lowerBound)..<HalfInt(range.upperBound)
+        }
+
+        @inlinable // This is @inlinable as trivially computable (and inlining may help avoid retain-release traffic).
+        mutating func ensureUniqueReference() {
+            if !isKnownUniquelyReferenced(&storage) {
+                storage = storage.mutableCopy(self.range)
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var startIndex: Int {
+            return Int(slice.lowerBound)
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var endIndex: Int {
+            return Int(slice.upperBound)
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var capacity: Int {
+            return storage.capacity
+        }
+
+        @inlinable // This is @inlinable as trivially computable (and inlining may help avoid retain-release traffic).
+        mutating func reserveCapacity(_ minimumCapacity: Int) {
+            ensureUniqueReference()
+            // the current capacity can be zero (representing externally owned buffer), and count can be greater than the capacity
+            storage.ensureUniqueBufferReference(growingTo: Swift.max(minimumCapacity, count))
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var count: Int {
+            get {
+                return Int(slice.upperBound - slice.lowerBound)
+            }
+            set(newValue) {
+                assert(newValue < HalfInt.max)
+                ensureUniqueReference()
+                storage.length = newValue
+                slice = slice.lowerBound..<(slice.lowerBound + HalfInt(newValue))
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var range: Range<Int> {
+            get {
+                return Int(slice.lowerBound)..<Int(slice.upperBound)
+            }
+            set(newValue) {
+                assert(newValue.lowerBound < HalfInt.max)
+                assert(newValue.upperBound < HalfInt.max)
+                slice = HalfInt(newValue.lowerBound)..<HalfInt(newValue.upperBound)
+            }
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        func withUnsafeBytes<Result>(_ apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
+            return try storage.withUnsafeBytes(in: range, apply: apply)
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        mutating func withUnsafeMutableBytes<Result>(_ apply: (UnsafeMutableRawBufferPointer) throws -> Result) rethrows -> Result {
+            ensureUniqueReference()
+            return try storage.withUnsafeMutableBytes(in: range, apply: apply)
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        mutating func append(contentsOf buffer: UnsafeRawBufferPointer) {
+            assert(endIndex + buffer.count < HalfInt.max)
+            ensureUniqueReference()
+            storage.replaceBytes(in: NSRange(location: range.upperBound, length: storage.length - (range.upperBound - storage._offset)), with: buffer.baseAddress, length: buffer.count)
+            slice = slice.lowerBound..<HalfInt(Int(slice.upperBound) + buffer.count)
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        subscript(index: Index) -> UInt8 {
+            get {
+                assert(index < HalfInt.max)
+                precondition(startIndex <= index, "index \(index) is out of bounds of \(startIndex)..<\(endIndex)")
+                precondition(index < endIndex, "index \(index) is out of bounds of \(startIndex)..<\(endIndex)")
+                return storage.get(index)
+            }
+            set(newValue) {
+                assert(index < HalfInt.max)
+                precondition(startIndex <= index, "index \(index) is out of bounds of \(startIndex)..<\(endIndex)")
+                precondition(index < endIndex, "index \(index) is out of bounds of \(startIndex)..<\(endIndex)")
+                ensureUniqueReference()
+                storage.set(index, to: newValue)
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        func bridgedReference() -> NSData {
+            return storage.bridgedReference(self.range)
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        mutating func resetBytes(in range: Range<Index>) {
+            assert(range.lowerBound < HalfInt.max)
+            assert(range.upperBound < HalfInt.max)
+            precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            ensureUniqueReference()
+            storage.resetBytes(in: range)
+            if slice.upperBound < range.upperBound {
+                slice = slice.lowerBound..<HalfInt(range.upperBound)
+            }
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        mutating func replaceSubrange(_ subrange: Range<Index>, with bytes: UnsafeRawPointer?, count cnt: Int) {
+            precondition(startIndex <= subrange.lowerBound, "index \(subrange.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(subrange.lowerBound <= endIndex, "index \(subrange.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(startIndex <= subrange.upperBound, "index \(subrange.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(subrange.upperBound <= endIndex, "index \(subrange.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+
+            let nsRange = NSRange(location: subrange.lowerBound, length: subrange.upperBound - subrange.lowerBound)
+            ensureUniqueReference()
+            let upper = range.upperBound
+            storage.replaceBytes(in: nsRange, with: bytes, length: cnt)
+            let resultingUpper = upper - nsRange.length + cnt
+            slice = slice.lowerBound..<HalfInt(resultingUpper)
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        func copyBytes(to pointer: UnsafeMutableRawPointer, from range: Range<Int>) {
+            precondition(startIndex <= range.lowerBound, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(startIndex <= range.upperBound, "index \(range.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(range.upperBound <= endIndex, "index \(range.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            storage.copyBytes(to: pointer, from: range)
+        }
+
+        @inline(__always) // This should always be inlined into _Representation.hash(into:).
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(count)
+
+            // At most, hash the first 80 bytes of this data.
+            let range = startIndex ..< Swift.min(startIndex + 80, endIndex)
+            storage.withUnsafeBytes(in: range) {
+                hasher.combine(bytes: $0)
+            }
+        }
+    }
+
+    // A reference wrapper around a Range<Int> for when the range of a data buffer is too large to whole in a single word.
+    // Inlinability strategy: everything should be inlinable as trivial.
+    @usableFromInline
+    @_fixed_layout
+    internal final class RangeReference {
+        @usableFromInline var range: Range<Int>
+
+        @inlinable @inline(__always) // This is @inlinable as trivially forwarding.
+        var lowerBound: Int {
+            return range.lowerBound
+        }
+
+        @inlinable @inline(__always) // This is @inlinable as trivially forwarding.
+        var upperBound: Int {
+            return range.upperBound
+        }
+
+        @inlinable @inline(__always) // This is @inlinable as trivially computable.
+        var count: Int {
+            return range.upperBound - range.lowerBound
+        }
+
+        @inlinable @inline(__always) // This is @inlinable as a trivial initializer.
+        init(_ range: Range<Int>) {
+            self.range = range
+        }
+    }
+
+    // A buffer of bytes whose range is too large to fit in a signle word. Used alongside a RangeReference to make it fit into _Representation's two-word size.
+    // Inlinability strategy: everything here should be easily inlinable as large _DataStorage methods should not inline into here.
+    @usableFromInline
+    @frozen
+    internal struct LargeSlice {
+        // ***WARNING***
+        // These ivars are specifically laid out so that they cause the enum _Representation to be 16 bytes on 64 bit platforms. This means we _MUST_ have the class type thing last
+        @usableFromInline var slice: RangeReference
+        @usableFromInline var storage: __DataStorage
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ buffer: UnsafeRawBufferPointer) {
+            self.init(__DataStorage(bytes: buffer.baseAddress, length: buffer.count), count: buffer.count)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(capacity: Int) {
+            self.init(__DataStorage(capacity: capacity), count: 0)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(count: Int) {
+            self.init(__DataStorage(length: count), count: count)
+        }
+
+        @inlinable // This is @inlinable as a convenience initializer.
+        init(_ inline: InlineData) {
+            let storage = inline.withUnsafeBytes { return __DataStorage(bytes: $0.baseAddress, length: $0.count) }
+            self.init(storage, count: inline.count)
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(_ slice: InlineSlice) {
+            self.storage = slice.storage
+            self.slice = RangeReference(slice.range)
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(_ storage: __DataStorage, count: Int) {
+            self.storage = storage
+            self.slice = RangeReference(0..<count)
+        }
+
+        @inlinable // This is @inlinable as trivially computable (and inlining may help avoid retain-release traffic).
+        mutating func ensureUniqueReference() {
+            if !isKnownUniquelyReferenced(&storage) {
+                storage = storage.mutableCopy(range)
+            }
+            if !isKnownUniquelyReferenced(&slice) {
+                slice = RangeReference(range)
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        var startIndex: Int {
+            return slice.range.lowerBound
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        var endIndex: Int {
+          return slice.range.upperBound
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        var capacity: Int {
+            return storage.capacity
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        mutating func reserveCapacity(_ minimumCapacity: Int) {
+            ensureUniqueReference()
+            // the current capacity can be zero (representing externally owned buffer), and count can be greater than the capacity
+            storage.ensureUniqueBufferReference(growingTo: Swift.max(minimumCapacity, count))
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        var count: Int {
+            get {
+                return slice.count
+            }
+            set(newValue) {
+                ensureUniqueReference()
+                storage.length = newValue
+                slice.range = slice.range.lowerBound..<(slice.range.lowerBound + newValue)
+            }
+        }
+
+        @inlinable // This is @inlinable as it is trivially forwarding.
+        var range: Range<Int> {
+            return slice.range
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        func withUnsafeBytes<Result>(_ apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
+            return try storage.withUnsafeBytes(in: range, apply: apply)
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        mutating func withUnsafeMutableBytes<Result>(_ apply: (UnsafeMutableRawBufferPointer) throws -> Result) rethrows -> Result {
+            ensureUniqueReference()
+            return try storage.withUnsafeMutableBytes(in: range, apply: apply)
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        mutating func append(contentsOf buffer: UnsafeRawBufferPointer) {
+            ensureUniqueReference()
+            storage.replaceBytes(in: NSRange(location: range.upperBound, length: storage.length - (range.upperBound - storage._offset)), with: buffer.baseAddress, length: buffer.count)
+            slice.range = slice.range.lowerBound..<slice.range.upperBound + buffer.count
+        }
+
+        @inlinable // This is @inlinable as trivially computable.
+        subscript(index: Index) -> UInt8 {
+            get {
+                precondition(startIndex <= index, "index \(index) is out of bounds of \(startIndex)..<\(endIndex)")
+                precondition(index < endIndex, "index \(index) is out of bounds of \(startIndex)..<\(endIndex)")
+                return storage.get(index)
+            }
+            set(newValue) {
+                precondition(startIndex <= index, "index \(index) is out of bounds of \(startIndex)..<\(endIndex)")
+                precondition(index < endIndex, "index \(index) is out of bounds of \(startIndex)..<\(endIndex)")
+                ensureUniqueReference()
+                storage.set(index, to: newValue)
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        func bridgedReference() -> NSData {
+            return storage.bridgedReference(self.range)
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        mutating func resetBytes(in range: Range<Int>) {
+            precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            ensureUniqueReference()
+            storage.resetBytes(in: range)
+            if slice.range.upperBound < range.upperBound {
+                slice.range = slice.range.lowerBound..<range.upperBound
+            }
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        mutating func replaceSubrange(_ subrange: Range<Index>, with bytes: UnsafeRawPointer?, count cnt: Int) {
+            precondition(startIndex <= subrange.lowerBound, "index \(subrange.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(subrange.lowerBound <= endIndex, "index \(subrange.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(startIndex <= subrange.upperBound, "index \(subrange.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(subrange.upperBound <= endIndex, "index \(subrange.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+
+            let nsRange = NSRange(location: subrange.lowerBound, length: subrange.upperBound - subrange.lowerBound)
+            ensureUniqueReference()
+            let upper = range.upperBound
+            storage.replaceBytes(in: nsRange, with: bytes, length: cnt)
+            let resultingUpper = upper - nsRange.length + cnt
+            slice.range = slice.range.lowerBound..<resultingUpper
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        func copyBytes(to pointer: UnsafeMutableRawPointer, from range: Range<Int>) {
+            precondition(startIndex <= range.lowerBound, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(startIndex <= range.upperBound, "index \(range.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            precondition(range.upperBound <= endIndex, "index \(range.upperBound) is out of bounds of \(startIndex)..<\(endIndex)")
+            storage.copyBytes(to: pointer, from: range)
+        }
+
+        @inline(__always) // This should always be inlined into _Representation.hash(into:).
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(count)
+
+            // Hash at most the first 80 bytes of this data.
+            let range = startIndex ..< Swift.min(startIndex + 80, endIndex)
+            storage.withUnsafeBytes(in: range) {
+                hasher.combine(bytes: $0)
+            }
+        }
+    }
+
+    // The actual storage for Data's various representations.
+    // Inlinability strategy: almost everything should be inlinable as forwarding the underlying implementations. (Inlining can also help avoid retain-release traffic around pulling values out of enums.)
+    @usableFromInline
+    @frozen
+    internal enum _Representation {
+        case empty
+        case inline(InlineData)
+        case slice(InlineSlice)
+        case large(LargeSlice)
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(_ buffer: UnsafeRawBufferPointer) {
+            if buffer.isEmpty {
+                self = .empty
+            } else if InlineData.canStore(count: buffer.count) {
+                self = .inline(InlineData(buffer))
+            } else if InlineSlice.canStore(count: buffer.count) {
+                self = .slice(InlineSlice(buffer))
+            } else {
+                self = .large(LargeSlice(buffer))
+            }
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(_ buffer: UnsafeRawBufferPointer, owner: AnyObject) {
+            if buffer.isEmpty {
+                self = .empty
+            } else if InlineData.canStore(count: buffer.count) {
+                self = .inline(InlineData(buffer))
+            } else {
+                let count = buffer.count
+                let storage = __DataStorage(bytes: UnsafeMutableRawPointer(mutating: buffer.baseAddress), length: count, copy: false, deallocator: { _, _ in
+                    _fixLifetime(owner)
+                }, offset: 0)
+                if InlineSlice.canStore(count: count) {
+                    self = .slice(InlineSlice(storage, count: count))
+                } else {
+                    self = .large(LargeSlice(storage, count: count))
+                }
+            }
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(capacity: Int) {
+            if capacity == 0 {
+                self = .empty
+            } else if InlineData.canStore(count: capacity) {
+                self = .inline(InlineData())
+            } else if InlineSlice.canStore(count: capacity) {
+                self = .slice(InlineSlice(capacity: capacity))
+            } else {
+                self = .large(LargeSlice(capacity: capacity))
+            }
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(count: Int) {
+            if count == 0 {
+                self = .empty
+            } else if InlineData.canStore(count: count) {
+                self = .inline(InlineData(count: count))
+            } else if InlineSlice.canStore(count: count) {
+                self = .slice(InlineSlice(count: count))
+            } else {
+                self = .large(LargeSlice(count: count))
+            }
+        }
+
+        @inlinable // This is @inlinable as a trivial initializer.
+        init(_ storage: __DataStorage, count: Int) {
+            if count == 0 {
+                self = .empty
+            } else if InlineData.canStore(count: count) {
+                self = .inline(storage.withUnsafeBytes(in: 0..<count) { InlineData($0) })
+            } else if InlineSlice.canStore(count: count) {
+                self = .slice(InlineSlice(storage, count: count))
+            } else {
+                self = .large(LargeSlice(storage, count: count))
+            }
+        }
+
+        @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
+        mutating func reserveCapacity(_ minimumCapacity: Int) {
+            guard minimumCapacity > 0 else { return }
+            switch self {
+            case .empty:
+                if InlineData.canStore(count: minimumCapacity) {
+                    self = .inline(InlineData())
+                } else if InlineSlice.canStore(count: minimumCapacity) {
+                    self = .slice(InlineSlice(capacity: minimumCapacity))
+                } else {
+                    self = .large(LargeSlice(capacity: minimumCapacity))
+                }
+            case .inline(let inline):
+                guard minimumCapacity > inline.capacity else { return }
+                // we know we are going to be heap promoted
+                if InlineSlice.canStore(count: minimumCapacity) {
+                    var slice = InlineSlice(inline)
+                    slice.reserveCapacity(minimumCapacity)
+                    self = .slice(slice)
+                } else {
+                    var slice = LargeSlice(inline)
+                    slice.reserveCapacity(minimumCapacity)
+                    self = .large(slice)
+                }
+            case .slice(var slice):
+                guard minimumCapacity > slice.capacity else { return }
+                if InlineSlice.canStore(count: minimumCapacity) {
+                    self = .empty
+                    slice.reserveCapacity(minimumCapacity)
+                    self = .slice(slice)
+                } else {
+                    var large = LargeSlice(slice)
+                    large.reserveCapacity(minimumCapacity)
+                    self = .large(large)
+                }
+            case .large(var slice):
+                guard minimumCapacity > slice.capacity else { return }
+                self = .empty
+                slice.reserveCapacity(minimumCapacity)
+                self = .large(slice)
+            }
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        var count: Int {
+            get {
+                switch self {
+                case .empty: return 0
+                case .inline(let inline): return inline.count
+                case .slice(let slice): return slice.count
+                case .large(let slice): return slice.count
+                }
+            }
+            set(newValue) {
+                // HACK: The definition of this inline function takes an inout reference to self, giving the optimizer a unique referencing guarantee.
+                //       This allows us to avoid excessive retain-release traffic around modifying enum values, and inlining the function then avoids the additional frame.
+                @inline(__always)
+                func apply(_ representation: inout _Representation, _ newValue: Int) -> _Representation? {
+                    switch representation {
+                    case .empty:
+                        if newValue == 0 {
+                            return nil
+                        } else if InlineData.canStore(count: newValue) {
+                            return .inline(InlineData(count: newValue))
+                        } else if InlineSlice.canStore(count: newValue) {
+                            return .slice(InlineSlice(count: newValue))
+                        } else {
+                            return .large(LargeSlice(count: newValue))
+                        }
+                    case .inline(var inline):
+                        if newValue == 0 {
+                            return .empty
+                        } else if InlineData.canStore(count: newValue) {
+                            guard inline.count != newValue else { return nil }
+                            inline.count = newValue
+                            return .inline(inline)
+                        } else if InlineSlice.canStore(count: newValue) {
+                            var slice = InlineSlice(inline)
+                            slice.count = newValue
+                            return .slice(slice)
+                        } else {
+                            var slice = LargeSlice(inline)
+                            slice.count = newValue
+                            return .large(slice)
+                        }
+                    case .slice(var slice):
+                        if newValue == 0 && slice.startIndex == 0 {
+                            return .empty
+                        } else if slice.startIndex == 0 && InlineData.canStore(count: newValue) {
+                            return .inline(InlineData(slice, count: newValue))
+                        } else if InlineSlice.canStore(count: newValue + slice.startIndex) {
+                            guard slice.count != newValue else { return nil }
+                            representation = .empty // TODO: remove this when mgottesman lands optimizations
+                            slice.count = newValue
+                            return .slice(slice)
+                        } else {
+                            var newSlice = LargeSlice(slice)
+                            newSlice.count = newValue
+                            return .large(newSlice)
+                        }
+                    case .large(var slice):
+                        if newValue == 0 && slice.startIndex == 0 {
+                            return .empty
+                        } else if slice.startIndex == 0 && InlineData.canStore(count: newValue) {
+                            return .inline(InlineData(slice, count: newValue))
+                        } else {
+                            guard slice.count != newValue else { return nil}
+                            representation = .empty // TODO: remove this when mgottesman lands optimizations
+                            slice.count = newValue
+                            return .large(slice)
+                        }
+                    }
+                }
+
+                if let rep = apply(&self, newValue) {
+                    self = rep
+                }
+            }
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        func withUnsafeBytes<Result>(_ apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
+            switch self {
+            case .empty:
+                let empty = InlineData()
+                return try empty.withUnsafeBytes(apply)
+            case .inline(let inline):
+                return try inline.withUnsafeBytes(apply)
+            case .slice(let slice):
+                return try slice.withUnsafeBytes(apply)
+            case .large(let slice):
+                return try slice.withUnsafeBytes(apply)
+            }
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        mutating func withUnsafeMutableBytes<Result>(_ apply: (UnsafeMutableRawBufferPointer) throws -> Result) rethrows -> Result {
+            switch self {
+            case .empty:
+                var empty = InlineData()
+                return try empty.withUnsafeMutableBytes(apply)
+            case .inline(var inline):
+                defer { self = .inline(inline) }
+                return try inline.withUnsafeMutableBytes(apply)
+            case .slice(var slice):
+                self = .empty
+                defer { self = .slice(slice) }
+                return try slice.withUnsafeMutableBytes(apply)
+            case .large(var slice):
+                self = .empty
+                defer { self = .large(slice) }
+                return try slice.withUnsafeMutableBytes(apply)
+            }
+        }
+
+        @inlinable // This is @inlinable as a generic, trivially forwarding function.
+        func withInteriorPointerReference<T>(_ work: (NSData) throws -> T) rethrows -> T {
+            switch self {
+            case .empty:
+                return try work(NSData())
+            case .inline(let inline):
+                return try inline.withUnsafeBytes {
+                    return try work(NSData(bytesNoCopy: UnsafeMutableRawPointer(mutating: $0.baseAddress ?? UnsafeRawPointer(bitPattern: 0xBAD0)!), length: $0.count, freeWhenDone: false))
+                }
+            case .slice(let slice):
+                return try slice.storage.withInteriorPointerReference(slice.range, work)
+            case .large(let slice):
+                return try slice.storage.withInteriorPointerReference(slice.range, work)
+            }
+        }
+
+        @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
+        func enumerateBytes(_ block: (_ buffer: UnsafeBufferPointer<UInt8>, _ byteIndex: Index, _ stop: inout Bool) -> Void) {
+            switch self {
+            case .empty:
+                var stop = false
+                block(UnsafeBufferPointer<UInt8>(start: nil, count: 0), 0, &stop)
+            case .inline(let inline):
+                inline.withUnsafeBytes {
+                    var stop = false
+                    block(UnsafeBufferPointer<UInt8>(start: $0.baseAddress?.assumingMemoryBound(to: UInt8.self), count: $0.count), 0, &stop)
+                }
+            case .slice(let slice):
+                slice.storage.enumerateBytes(in: slice.range, block)
+            case .large(let slice):
+                slice.storage.enumerateBytes(in: slice.range, block)
+            }
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        mutating func append(contentsOf buffer: UnsafeRawBufferPointer) {
+            switch self {
+            case .empty:
+                self = _Representation(buffer)
+            case .inline(var inline):
+                if InlineData.canStore(count: inline.count + buffer.count) {
+                    inline.append(contentsOf: buffer)
+                    self = .inline(inline)
+                } else if InlineSlice.canStore(count: inline.count + buffer.count) {
+                    var newSlice = InlineSlice(inline)
+                    newSlice.append(contentsOf: buffer)
+                    self = .slice(newSlice)
+                } else {
+                    var newSlice = LargeSlice(inline)
+                    newSlice.append(contentsOf: buffer)
+                    self = .large(newSlice)
+                }
+            case .slice(var slice):
+                if InlineSlice.canStore(count: slice.range.upperBound + buffer.count) {
+                    self = .empty
+                    defer { self = .slice(slice) }
+                    slice.append(contentsOf: buffer)
+                } else {
+                    self = .empty
+                    var newSlice = LargeSlice(slice)
+                    newSlice.append(contentsOf: buffer)
+                    self = .large(newSlice)
+                }
+            case .large(var slice):
+                self = .empty
+                defer { self = .large(slice) }
+                slice.append(contentsOf: buffer)
+            }
+        }
+
+        @inlinable // This is @inlinable as reasonably small.
+        mutating func resetBytes(in range: Range<Index>) {
+            switch self {
+            case .empty:
+                if range.upperBound == 0 {
+                    self = .empty
+                } else if InlineData.canStore(count: range.upperBound) {
+                    precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+                    self = .inline(InlineData(count: range.upperBound))
+                } else if InlineSlice.canStore(count: range.upperBound) {
+                    precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+                    self = .slice(InlineSlice(count: range.upperBound))
+                } else {
+                    precondition(range.lowerBound <= endIndex, "index \(range.lowerBound) is out of bounds of \(startIndex)..<\(endIndex)")
+                    self = .large(LargeSlice(count: range.upperBound))
+                }
+            case .inline(var inline):
+                if inline.count < range.upperBound {
+                    if InlineSlice.canStore(count: range.upperBound) {
+                        var slice = InlineSlice(inline)
+                        slice.resetBytes(in: range)
+                        self = .slice(slice)
+                    } else {
+                        var slice = LargeSlice(inline)
+                        slice.resetBytes(in: range)
+                        self = .large(slice)
+                    }
+                } else {
+                    inline.resetBytes(in: range)
+                    self = .inline(inline)
+                }
+            case .slice(var slice):
+                if InlineSlice.canStore(count: range.upperBound) {
+                    self = .empty
+                    slice.resetBytes(in: range)
+                    self = .slice(slice)
+                } else {
+                    self = .empty
+                    var newSlice = LargeSlice(slice)
+                    newSlice.resetBytes(in: range)
+                    self = .large(newSlice)
+                }
+            case .large(var slice):
+                self = .empty
+                slice.resetBytes(in: range)
+                self = .large(slice)
+            }
+        }
+
+        @usableFromInline // This is not @inlinable as it is a non-trivial, non-generic function.
+        mutating func replaceSubrange(_ subrange: Range<Index>, with bytes: UnsafeRawPointer?, count cnt: Int) {
+            switch self {
+            case .empty:
+                precondition(subrange.lowerBound == 0 && subrange.upperBound == 0, "range \(subrange) out of bounds of 0..<0")
+                if cnt == 0 {
+                    return
+                } else if InlineData.canStore(count: cnt) {
+                    self = .inline(InlineData(UnsafeRawBufferPointer(start: bytes, count: cnt)))
+                } else if InlineSlice.canStore(count: cnt) {
+                    self = .slice(InlineSlice(UnsafeRawBufferPointer(start: bytes, count: cnt)))
+                } else {
+                    self = .large(LargeSlice(UnsafeRawBufferPointer(start: bytes, count: cnt)))
+                }
+            case .inline(var inline):
+                let resultingCount = inline.count + cnt - (subrange.upperBound - subrange.lowerBound)
+                if resultingCount == 0 {
+                    self = .empty
+                } else if InlineData.canStore(count: resultingCount) {
+                    inline.replaceSubrange(subrange, with: bytes, count: cnt)
+                    self = .inline(inline)
+                } else if InlineSlice.canStore(count: resultingCount) {
+                    var slice = InlineSlice(inline)
+                    slice.replaceSubrange(subrange, with: bytes, count: cnt)
+                    self = .slice(slice)
+                } else {
+                    var slice = LargeSlice(inline)
+                    slice.replaceSubrange(subrange, with: bytes, count: cnt)
+                    self = .large(slice)
+                }
+            case .slice(var slice):
+                let resultingUpper = slice.endIndex + cnt - (subrange.upperBound - subrange.lowerBound)
+                if slice.startIndex == 0 && resultingUpper == 0 {
+                    self = .empty
+                } else if slice.startIndex == 0 && InlineData.canStore(count: resultingUpper) {
+                    self = .empty
+                    slice.replaceSubrange(subrange, with: bytes, count: cnt)
+                    self = .inline(InlineData(slice, count: slice.count))
+                } else if InlineSlice.canStore(count: resultingUpper) {
+                    self = .empty
+                    slice.replaceSubrange(subrange, with: bytes, count: cnt)
+                    self = .slice(slice)
+                } else {
+                    self = .empty
+                    var newSlice = LargeSlice(slice)
+                    newSlice.replaceSubrange(subrange, with: bytes, count: cnt)
+                    self = .large(newSlice)
+                }
+            case .large(var slice):
+                let resultingUpper = slice.endIndex + cnt - (subrange.upperBound - subrange.lowerBound)
+                if slice.startIndex == 0 && resultingUpper == 0 {
+                    self = .empty
+                } else if slice.startIndex == 0 && InlineData.canStore(count: resultingUpper) {
+                    var inline = InlineData(count: resultingUpper)
+                    inline.withUnsafeMutableBytes { inlineBuffer in
+                        if cnt > 0 {
+                            inlineBuffer.baseAddress?.advanced(by: subrange.lowerBound).copyMemory(from: bytes!, byteCount: cnt)
+                        }
+                        slice.withUnsafeBytes { buffer in
+                            if subrange.lowerBound > 0 {
+                                inlineBuffer.baseAddress?.copyMemory(from: buffer.baseAddress!, byteCount: subrange.lowerBound)
+                            }
+                            if subrange.upperBound < resultingUpper {
+                                inlineBuffer.baseAddress?.advanced(by: subrange.upperBound).copyMemory(from: buffer.baseAddress!.advanced(by: subrange.upperBound), byteCount: resultingUpper - subrange.upperBound)
+                            }
+                        }
+                    }
+                    self = .inline(inline)
+                } else if InlineSlice.canStore(count: slice.startIndex) && InlineSlice.canStore(count: resultingUpper) {
+                    self = .empty
+                    var newSlice = InlineSlice(slice)
+                    newSlice.replaceSubrange(subrange, with: bytes, count: cnt)
+                    self = .slice(newSlice)
+                } else {
+                    self = .empty
+                    slice.replaceSubrange(subrange, with: bytes, count: cnt)
+                    self = .large(slice)
+                }
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        subscript(index: Index) -> UInt8 {
+            get {
+                switch self {
+                case .empty: preconditionFailure("index \(index) out of range of 0")
+                case .inline(let inline): return inline[index]
+                case .slice(let slice): return slice[index]
+                case .large(let slice): return slice[index]
+                }
+            }
+            set(newValue) {
+                switch self {
+                case .empty: preconditionFailure("index \(index) out of range of 0")
+                case .inline(var inline):
+                    inline[index] = newValue
+                    self = .inline(inline)
+                case .slice(var slice):
+                    self = .empty
+                    slice[index] = newValue
+                    self = .slice(slice)
+                case .large(var slice):
+                    self = .empty
+                    slice[index] = newValue
+                    self = .large(slice)
+                }
+            }
+        }
+        
+        @inlinable // This is @inlinable as reasonably small.
+        subscript(bounds: Range<Index>) -> Data {
+            get {
+                switch self {
+                case .empty:
+                    precondition(bounds.lowerBound == 0 && (bounds.upperBound - bounds.lowerBound) == 0, "Range \(bounds) out of bounds 0..<0")
+                    return Data()
+                case .inline(let inline):
+                    precondition(bounds.upperBound <= inline.count, "Range \(bounds) out of bounds 0..<\(inline.count)")
+                    if bounds.lowerBound == 0 {
+                        var newInline = inline
+                        newInline.count = bounds.upperBound
+                        return Data(representation: .inline(newInline))
+                    } else {
+                        return Data(representation: .slice(InlineSlice(inline, range: bounds)))
+                    }
+                case .slice(let slice):
+                    precondition(slice.startIndex <= bounds.lowerBound, "Range \(bounds) out of bounds \(slice.range)")
+                    precondition(bounds.lowerBound <= slice.endIndex, "Range \(bounds) out of bounds \(slice.range)")
+                    precondition(slice.startIndex <= bounds.upperBound, "Range \(bounds) out of bounds \(slice.range)")
+                    precondition(bounds.upperBound <= slice.endIndex, "Range \(bounds) out of bounds \(slice.range)")
+                    if bounds.lowerBound == 0 && bounds.upperBound == 0 {
+                        return Data()
+                    } else if bounds.lowerBound == 0 && InlineData.canStore(count: bounds.count) {
+                        return Data(representation: .inline(InlineData(slice, count: bounds.count)))
+                    } else {
+                        var newSlice = slice
+                        newSlice.range = bounds
+                        return Data(representation: .slice(newSlice))
+                    }
+                case .large(let slice):
+                    precondition(slice.startIndex <= bounds.lowerBound, "Range \(bounds) out of bounds \(slice.range)")
+                    precondition(bounds.lowerBound <= slice.endIndex, "Range \(bounds) out of bounds \(slice.range)")
+                    precondition(slice.startIndex <= bounds.upperBound, "Range \(bounds) out of bounds \(slice.range)")
+                    precondition(bounds.upperBound <= slice.endIndex, "Range \(bounds) out of bounds \(slice.range)")
+                    if bounds.lowerBound == 0 && bounds.upperBound == 0 {
+                        return Data()
+                    } else if bounds.lowerBound == 0 && InlineData.canStore(count: bounds.upperBound) {
+                        return Data(representation: .inline(InlineData(slice, count: bounds.upperBound)))
+                    } else if InlineSlice.canStore(count: bounds.lowerBound) && InlineSlice.canStore(count: bounds.upperBound) {
+                        return Data(representation: .slice(InlineSlice(slice, range: bounds)))
+                    } else {
+                        var newSlice = slice
+                        newSlice.slice = RangeReference(bounds)
+                        return Data(representation: .large(newSlice))
+                    }
+                }
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        var startIndex: Int {
+            switch self {
+            case .empty: return 0
+            case .inline: return 0
+            case .slice(let slice): return slice.startIndex
+            case .large(let slice): return slice.startIndex
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        var endIndex: Int {
+            switch self {
+            case .empty: return 0
+            case .inline(let inline): return inline.count
+            case .slice(let slice): return slice.endIndex
+            case .large(let slice): return slice.endIndex
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        func bridgedReference() -> NSData {
+            switch self {
+            case .empty: return NSData()
+            case .inline(let inline):
+                return inline.withUnsafeBytes {
+                    return NSData(bytes: $0.baseAddress, length: $0.count)
+                }
+            case .slice(let slice):
+                return slice.bridgedReference()
+            case .large(let slice):
+                return slice.bridgedReference()
+            }
+        }
+
+        @inlinable // This is @inlinable as trivially forwarding.
+        func copyBytes(to pointer: UnsafeMutableRawPointer, from range: Range<Int>) {
+            switch self {
+            case .empty:
+                precondition(range.lowerBound == 0 && range.upperBound == 0, "Range \(range) out of bounds 0..<0")
+                return
+            case .inline(let inline):
+                inline.copyBytes(to: pointer, from: range)
+            case .slice(let slice):
+                slice.copyBytes(to: pointer, from: range)
+            case .large(let slice):
+                slice.copyBytes(to: pointer, from: range)
+            }
+        }
+        
+        @inline(__always) // This should always be inlined into Data.hash(into:).
+        func hash(into hasher: inout Hasher) {
+            switch self {
+            case .empty:
+                hasher.combine(0)
+            case .inline(let inline):
+                inline.hash(into: &hasher)
+            case .slice(let slice):
+                slice.hash(into: &hasher)
+            case .large(let large):
+                large.hash(into: &hasher)
+            }
+        }
+    }
+    
+    @usableFromInline internal var _representation: _Representation
+    
+    // A standard or custom deallocator for `Data`.
+    ///
+    /// When creating a `Data` with the no-copy initializer, you may specify a `Data.Deallocator` to customize the behavior of how the backing store is deallocated.
+    public enum Deallocator {
+        /// Use a virtual memory deallocator.
+#if !DEPLOYMENT_RUNTIME_SWIFT
+        case virtualMemory
+#endif
+        
+        /// Use `munmap`.
+        case unmap
+        
+        /// Use `free`.
+        case free
+        
+        /// Do nothing upon deallocation.
+        case none
+        
+        /// A custom deallocator.
+        case custom((UnsafeMutableRawPointer, Int) -> Void)
+        
+        @usableFromInline internal var _deallocator : ((UnsafeMutableRawPointer, Int) -> Void) {
+#if DEPLOYMENT_RUNTIME_SWIFT
+            switch self {
+            case .unmap:
+                return { __NSDataInvokeDeallocatorUnmap($0, $1) }
+            case .free:
+                return { __NSDataInvokeDeallocatorFree($0, $1) }
+            case .none:
+                return { _, _ in }
+            case .custom(let b):
+                return b
+            }
+#else
+            switch self {
+            case .virtualMemory:
+                return { NSDataDeallocatorVM($0, $1) }
+            case .unmap:
+                return { NSDataDeallocatorUnmap($0, $1) }
+            case .free:
+                return { NSDataDeallocatorFree($0, $1) }
+            case .none:
+                return { _, _ in }
+            case .custom(let b):
+                return b
+            }
+#endif
+        }
+    }
+    
+    // MARK: -
+    // MARK: Init methods
+    
+    /// Initialize a `Data` with copied memory content.
+    ///
+    /// - parameter bytes: A pointer to the memory. It will be copied.
+    /// - parameter count: The number of bytes to copy.
+    @inlinable // This is @inlinable as a trivial initializer.
+    public init(bytes: UnsafeRawPointer, count: Int) {
+        _representation = _Representation(UnsafeRawBufferPointer(start: bytes, count: count))
+    }
+
+    /// Initialize a `Data` with copied memory content.
+    ///
+    /// - parameter buffer: A buffer pointer to copy. The size is calculated from `SourceType` and `buffer.count`.
+    @inlinable // This is @inlinable as a trivial, generic initializer.
+    public init<SourceType>(buffer: UnsafeBufferPointer<SourceType>) {
+        _representation = _Representation(UnsafeRawBufferPointer(buffer))
+    }
+    
+    /// Initialize a `Data` with copied memory content.
+    ///
+    /// - parameter buffer: A buffer pointer to copy. The size is calculated from `SourceType` and `buffer.count`.
+    @inlinable // This is @inlinable as a trivial, generic initializer.
+    public init<SourceType>(buffer: UnsafeMutableBufferPointer<SourceType>) {
+        _representation = _Representation(UnsafeRawBufferPointer(buffer))
+    }
+    
+    /// Initialize a `Data` with a repeating byte pattern
+    ///
+    /// - parameter repeatedValue: A byte to initialize the pattern
+    /// - parameter count: The number of bytes the data initially contains initialized to the repeatedValue
+    @inlinable // This is @inlinable as a convenience initializer.
+    public init(repeating repeatedValue: UInt8, count: Int) {
+        self.init(count: count)
+        withUnsafeMutableBytes { (buffer: UnsafeMutableRawBufferPointer) -> Void in
+            memset(buffer.baseAddress, Int32(repeatedValue), buffer.count)
+        }
+    }
+    
+    /// Initialize a `Data` with the specified size.
+    ///
+    /// This initializer doesn't necessarily allocate the requested memory right away. `Data` allocates additional memory as needed, so `capacity` simply establishes the initial capacity. When it does allocate the initial memory, though, it allocates the specified amount.
+    ///
+    /// This method sets the `count` of the data to 0.
+    ///
+    /// If the capacity specified in `capacity` is greater than four memory pages in size, this may round the amount of requested memory up to the nearest full page.
+    ///
+    /// - parameter capacity: The size of the data.
+    @inlinable // This is @inlinable as a trivial initializer.
+    public init(capacity: Int) {
+        _representation = _Representation(capacity: capacity)
+    }
+    
+    /// Initialize a `Data` with the specified count of zeroed bytes.
+    ///
+    /// - parameter count: The number of bytes the data initially contains.
+    @inlinable // This is @inlinable as a trivial initializer.
+    public init(count: Int) {
+        _representation = _Representation(count: count)
+    }
+    
+    /// Initialize an empty `Data`.
+    @inlinable // This is @inlinable as a trivial initializer.
+    public init() {
+        _representation = .empty
+    }
+    
+    
+    /// Initialize a `Data` without copying the bytes.
+    ///
+    /// If the result is mutated and is not a unique reference, then the `Data` will still follow copy-on-write semantics. In this case, the copy will use its own deallocator. Therefore, it is usually best to only use this initializer when you either enforce immutability with `let` or ensure that no other references to the underlying data are formed.
+    /// - parameter bytes: A pointer to the bytes.
+    /// - parameter count: The size of the bytes.
+    /// - parameter deallocator: Specifies the mechanism to free the indicated buffer, or `.none`.
+    @inlinable // This is @inlinable as a trivial initializer.
+    public init(bytesNoCopy bytes: UnsafeMutableRawPointer, count: Int, deallocator: Deallocator) {
+        let whichDeallocator = deallocator._deallocator
+        if count == 0 {
+            deallocator._deallocator(bytes, count)
+            _representation = .empty
+        } else {
+            _representation = _Representation(__DataStorage(bytes: bytes, length: count, copy: false, deallocator: whichDeallocator, offset: 0), count: count)
+        }
+    }
+    
+    /// Initialize a `Data` with the contents of a `URL`.
+    ///
+    /// - parameter url: The `URL` to read.
+    /// - parameter options: Options for the read operation. Default value is `[]`.
+    /// - throws: An error in the Cocoa domain, if `url` cannot be read.
+    @inlinable // This is @inlinable as a convenience initializer.
+    public init(contentsOf url: __shared URL, options: Data.ReadingOptions = []) throws {
+        let d = try NSData(contentsOf: url, options: ReadingOptions(rawValue: options.rawValue))
+        self.init(referencing: d)
+    }
+    
+    /// Initialize a `Data` from a Base-64 encoded String using the given options.
+    ///
+    /// Returns nil when the input is not recognized as valid Base-64.
+    /// - parameter base64String: The string to parse.
+    /// - parameter options: Encoding options. Default value is `[]`.
+    @inlinable // This is @inlinable as a convenience initializer.
+    public init?(base64Encoded base64String: __shared String, options: Data.Base64DecodingOptions = []) {
+        if let d = NSData(base64Encoded: base64String, options: Base64DecodingOptions(rawValue: options.rawValue)) {
+            self.init(referencing: d)
+        } else {
+            return nil
+        }
+    }
+    
+    /// Initialize a `Data` from a Base-64, UTF-8 encoded `Data`.
+    ///
+    /// Returns nil when the input is not recognized as valid Base-64.
+    ///
+    /// - parameter base64Data: Base-64, UTF-8 encoded input data.
+    /// - parameter options: Decoding options. Default value is `[]`.
+    @inlinable // This is @inlinable as a convenience initializer.
+    public init?(base64Encoded base64Data: __shared Data, options: Data.Base64DecodingOptions = []) {
+        if let d = NSData(base64Encoded: base64Data, options: Base64DecodingOptions(rawValue: options.rawValue)) {
+            self.init(referencing: d)
+        } else {
+            return nil
+        }
+    }
+    
+    /// Initialize a `Data` by adopting a reference type.
+    ///
+    /// You can use this initializer to create a `struct Data` that wraps a `class NSData`. `struct Data` will use the `class NSData` for all operations. Other initializers (including casting using `as Data`) may choose to hold a reference or not, based on a what is the most efficient representation.
+    ///
+    /// If the resulting value is mutated, then `Data` will invoke the `mutableCopy()` function on the reference to copy the contents. You may customize the behavior of that function if you wish to return a specialized mutable subclass.
+    ///
+    /// - parameter reference: The instance of `NSData` that you wish to wrap. This instance will be copied by `struct Data`.
+    public init(referencing reference: __shared NSData) {
+        // This is not marked as inline because _providesConcreteBacking would need to be marked as usable from inline however that is a dynamic lookup in objc contexts.
+        let length = reference.length
+        if length == 0 {
+            _representation = .empty
+        } else {
+#if DEPLOYMENT_RUNTIME_SWIFT
+            let providesConcreteBacking = reference._providesConcreteBacking()
+#else
+            let providesConcreteBacking = (reference as AnyObject)._providesConcreteBacking?() ?? false
+#endif
+            if providesConcreteBacking {
+                _representation = _Representation(__DataStorage(immutableReference: reference.copy() as! NSData, offset: 0), count: length)
+            } else {
+                _representation = _Representation(__DataStorage(customReference: reference.copy() as! NSData, offset: 0), count: length)
+            }
+        }
+        
+    }
+    
+    // slightly faster paths for common sequences
+    @inlinable // This is @inlinable as an important generic funnel point, despite being a non-trivial initializer.
+    public init<S: Sequence>(_ elements: S) where S.Element == UInt8 {
+        // If the sequence is already contiguous, access the underlying raw memory directly.
+        if let contiguous = elements as? ContiguousBytes {
+            _representation = contiguous.withUnsafeBytes { return _Representation($0) }
+            return
+        }
+
+        // The sequence might still be able to provide direct access to typed memory.
+        // NOTE: It's safe to do this because we're already guarding on S's element as `UInt8`. This would not be safe on arbitrary sequences.
+        let representation = elements.withContiguousStorageIfAvailable {
+            _Representation(UnsafeRawBufferPointer($0))
+        }
+        if let representation = representation {
+            _representation = representation
+            return
+        }
+
+        // Copy as much as we can in one shot from the sequence.
+        let underestimatedCount = elements.underestimatedCount
+        _representation = _Representation(count: underestimatedCount)
+        var (iter, endIndex): (S.Iterator, Int) = _representation.withUnsafeMutableBytes { buffer in
+            let start = buffer.baseAddress!.assumingMemoryBound(to: UInt8.self)
+            let b = UnsafeMutableBufferPointer(start: start, count: buffer.count)
+            return elements._copyContents(initializing: b)
+        }
+        guard endIndex == _representation.count else {
+            // We can't trap here. We have to allow an underfilled buffer
+            // to emulate the previous implementation.
+            _representation.replaceSubrange(endIndex ..< _representation.endIndex, with: nil, count: 0)
+            return
+        }
+
+        // Append the rest byte-wise, buffering through an InlineData.
+        var buffer = InlineData()
+        while let element = iter.next() {
+            buffer.append(byte: element)
+            if buffer.count == buffer.capacity {
+                buffer.withUnsafeBytes { _representation.append(contentsOf: $0) }
+                buffer.count = 0
+            }
+        }
+
+        // If we've still got bytes left in the buffer (i.e. the loop ended before we filled up the buffer and cleared it out), append them.
+        if buffer.count > 0 {
+            buffer.withUnsafeBytes { _representation.append(contentsOf: $0) }
+            buffer.count = 0
+        }
+    }
+    
+    @available(swift, introduced: 4.2)
+    @available(swift, deprecated: 5, message: "use `init(_:)` instead")
+    public init<S: Sequence>(bytes elements: S) where S.Iterator.Element == UInt8 {
+        self.init(elements)
+    }
+
+    @available(swift, obsoleted: 4.2)
+    public init(bytes: Array<UInt8>) {
+       self.init(bytes)
+    }
+    
+    @available(swift, obsoleted: 4.2)
+    public init(bytes: ArraySlice<UInt8>) {
+       self.init(bytes)
+    }
+    
+    @inlinable // This is @inlinable as a trivial initializer.
+    internal init(representation: _Representation) {
+        _representation = representation
+    }
+    
+    // -----------------------------------
+    // MARK: - Properties and Functions
+
+    @inlinable // This is @inlinable as trivially forwarding.
+    public mutating func reserveCapacity(_ minimumCapacity: Int) {
+        _representation.reserveCapacity(minimumCapacity)
+    }
+    
+    /// The number of bytes in the data.
+    @inlinable // This is @inlinable as trivially forwarding.
+    public var count: Int {
+        get {
+            return _representation.count
+        }
+        set(newValue) {
+            precondition(newValue >= 0, "count must not be negative")
+            _representation.count = newValue
+        }
+    }
+
+    @inlinable // This is @inlinable as trivially computable.
+    public var regions: CollectionOfOne<Data> {
+        return CollectionOfOne(self)
+    }
+    
+    /// Access the bytes in the data.
+    ///
+    /// - warning: The byte pointer argument should not be stored and used outside of the lifetime of the call to the closure.
+    @available(swift, deprecated: 5, message: "use `withUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) rethrows -> R` instead")
+    public func withUnsafeBytes<ResultType, ContentType>(_ body: (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
+        return try _representation.withUnsafeBytes {
+            return try body($0.baseAddress?.assumingMemoryBound(to: ContentType.self) ?? UnsafePointer<ContentType>(bitPattern: 0xBAD0)!)
+        }
+    }
+    
+    @inlinable // This is @inlinable as a generic, trivially forwarding function.
+    public func withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
+        return try _representation.withUnsafeBytes(body)
+    }
+
+    /// Mutate the bytes in the data.
+    ///
+    /// This function assumes that you are mutating the contents.
+    /// - warning: The byte pointer argument should not be stored and used outside of the lifetime of the call to the closure.
+    @available(swift, deprecated: 5, message: "use `withUnsafeMutableBytes<R>(_: (UnsafeMutableRawBufferPointer) throws -> R) rethrows -> R` instead")
+    public mutating func withUnsafeMutableBytes<ResultType, ContentType>(_ body: (UnsafeMutablePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
+        return try _representation.withUnsafeMutableBytes {
+            return try body($0.baseAddress?.assumingMemoryBound(to: ContentType.self) ?? UnsafeMutablePointer<ContentType>(bitPattern: 0xBAD0)!)
+        }
+    }
+
+    @inlinable // This is @inlinable as a generic, trivially forwarding function.
+    public mutating func withUnsafeMutableBytes<ResultType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
+        return try _representation.withUnsafeMutableBytes(body)
+    }
+    
+    // MARK: -
+    // MARK: Copy Bytes
+    
+    /// Copy the contents of the data to a pointer.
+    ///
+    /// - parameter pointer: A pointer to the buffer you wish to copy the bytes into.
+    /// - parameter count: The number of bytes to copy.
+    /// - warning: This method does not verify that the contents at pointer have enough space to hold `count` bytes.
+    @inlinable // This is @inlinable as trivially forwarding.
+    public func copyBytes(to pointer: UnsafeMutablePointer<UInt8>, count: Int) {
+        precondition(count >= 0, "count of bytes to copy must not be negative")
+        if count == 0 { return }
+        _copyBytesHelper(to: UnsafeMutableRawPointer(pointer), from: startIndex..<(startIndex + count))
+    }
+    
+    @inlinable // This is @inlinable as trivially forwarding.
+    internal func _copyBytesHelper(to pointer: UnsafeMutableRawPointer, from range: Range<Int>) {
+        if range.isEmpty { return }
+        _representation.copyBytes(to: pointer, from: range)
+    }
+    
+    /// Copy a subset of the contents of the data to a pointer.
+    ///
+    /// - parameter pointer: A pointer to the buffer you wish to copy the bytes into.
+    /// - parameter range: The range in the `Data` to copy.
+    /// - warning: This method does not verify that the contents at pointer have enough space to hold the required number of bytes.
+    @inlinable // This is @inlinable as trivially forwarding.
+    public func copyBytes(to pointer: UnsafeMutablePointer<UInt8>, from range: Range<Index>) {
+        _copyBytesHelper(to: pointer, from: range)
+    }
+    
+    // Copy the contents of the data into a buffer.
+    ///
+    /// This function copies the bytes in `range` from the data into the buffer. If the count of the `range` is greater than `MemoryLayout<DestinationType>.stride * buffer.count` then the first N bytes will be copied into the buffer.
+    /// - precondition: The range must be within the bounds of the data. Otherwise `fatalError` is called.
+    /// - parameter buffer: A buffer to copy the data into.
+    /// - parameter range: A range in the data to copy into the buffer. If the range is empty, this function will return 0 without copying anything. If the range is nil, as much data as will fit into `buffer` is copied.
+    /// - returns: Number of bytes copied into the destination buffer.
+    @inlinable // This is @inlinable as generic and reasonably small.
+    public func copyBytes<DestinationType>(to buffer: UnsafeMutableBufferPointer<DestinationType>, from range: Range<Index>? = nil) -> Int {
+        let cnt = count
+        guard cnt > 0 else { return 0 }
+        
+        let copyRange : Range<Index>
+        if let r = range {
+            guard !r.isEmpty else { return 0 }
+            copyRange = r.lowerBound..<(r.lowerBound + Swift.min(buffer.count * MemoryLayout<DestinationType>.stride, r.upperBound - r.lowerBound))
+        } else {
+            copyRange = 0..<Swift.min(buffer.count * MemoryLayout<DestinationType>.stride, cnt)
+        }
+        
+        guard !copyRange.isEmpty else { return 0 }
+        
+        _copyBytesHelper(to: buffer.baseAddress!, from: copyRange)
+        return copyRange.upperBound - copyRange.lowerBound
+    }
+    
+    // MARK: -
+#if !DEPLOYMENT_RUNTIME_SWIFT
+    private func _shouldUseNonAtomicWriteReimplementation(options: Data.WritingOptions = []) -> Bool {
+    
+        // Avoid a crash that happens on OS X 10.11.x and iOS 9.x or before when writing a bridged Data non-atomically with Foundation's standard write() implementation.
+        if !options.contains(.atomic) {
+            #if os(macOS)
+                return NSFoundationVersionNumber <= Double(NSFoundationVersionNumber10_11_Max)
+            #else
+                return NSFoundationVersionNumber <= Double(NSFoundationVersionNumber_iOS_9_x_Max)
+            #endif
+        } else {
+            return false
+        }
+    }
+#endif
+    
+    /// Write the contents of the `Data` to a location.
+    ///
+    /// - parameter url: The location to write the data into.
+    /// - parameter options: Options for writing the data. Default value is `[]`.
+    /// - throws: An error in the Cocoa domain, if there is an error writing to the `URL`.
+    public func write(to url: URL, options: Data.WritingOptions = []) throws {
+        // this should not be marked as inline since in objc contexts we correct atomicity via _shouldUseNonAtomicWriteReimplementation
+        try _representation.withInteriorPointerReference {
+#if DEPLOYMENT_RUNTIME_SWIFT
+            try $0.write(to: url, options: WritingOptions(rawValue: options.rawValue))
+#else
+            if _shouldUseNonAtomicWriteReimplementation(options: options) {
+                var error: NSError? = nil
+                guard __NSDataWriteToURL($0, url, options, &error) else { throw error! }
+            } else {
+                try $0.write(to: url, options: options)
+            }
+#endif
+        }
+    }
+    
+    // MARK: -
+    
+    /// Find the given `Data` in the content of this `Data`.
+    ///
+    /// - parameter dataToFind: The data to be searched for.
+    /// - parameter options: Options for the search. Default value is `[]`.
+    /// - parameter range: The range of this data in which to perform the search. Default value is `nil`, which means the entire content of this data.
+    /// - returns: A `Range` specifying the location of the found data, or nil if a match could not be found.
+    /// - precondition: `range` must be in the bounds of the Data.
+    public func range(of dataToFind: Data, options: Data.SearchOptions = [], in range: Range<Index>? = nil) -> Range<Index>? {
+        let nsRange : NSRange
+        if let r = range {
+            nsRange = NSRange(location: r.lowerBound - startIndex, length: r.upperBound - r.lowerBound)
+        } else {
+            nsRange = NSRange(location: 0, length: count)
+        }
+        let result = _representation.withInteriorPointerReference {
+            $0.range(of: dataToFind, options: options, in: nsRange)
+        }
+        if result.location == NSNotFound {
+            return nil
+        }
+        return (result.location + startIndex)..<((result.location + startIndex) + result.length)
+    }
+    
+    /// Enumerate the contents of the data.
+    ///
+    /// In some cases, (for example, a `Data` backed by a `dispatch_data_t`, the bytes may be stored discontiguously. In those cases, this function invokes the closure for each contiguous region of bytes.
+    /// - parameter block: The closure to invoke for each region of data. You may stop the enumeration by setting the `stop` parameter to `true`.
+    @available(swift, deprecated: 5, message: "use `regions` or `for-in` instead")
+    public func enumerateBytes(_ block: (_ buffer: UnsafeBufferPointer<UInt8>, _ byteIndex: Index, _ stop: inout Bool) -> Void) {
+        _representation.enumerateBytes(block)
+    }
+
+    @inlinable // This is @inlinable as a generic, trivially forwarding function.
+    internal mutating func _append<SourceType>(_ buffer : UnsafeBufferPointer<SourceType>) {
+        if buffer.isEmpty { return }
+        _representation.append(contentsOf: UnsafeRawBufferPointer(buffer))
+    }
+    
+    @inlinable // This is @inlinable as a generic, trivially forwarding function.
+    public mutating func append(_ bytes: UnsafePointer<UInt8>, count: Int) {
+        if count == 0 { return }
+        _append(UnsafeBufferPointer(start: bytes, count: count))
+    }
+    
+    public mutating func append(_ other: Data) {
+        guard !other.isEmpty else { return }
+        other.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
+            _representation.append(contentsOf: buffer)
+        }
+    }
+    
+    /// Append a buffer of bytes to the data.
+    ///
+    /// - parameter buffer: The buffer of bytes to append. The size is calculated from `SourceType` and `buffer.count`.
+    @inlinable // This is @inlinable as a generic, trivially forwarding function.
+    public mutating func append<SourceType>(_ buffer : UnsafeBufferPointer<SourceType>) {
+        _append(buffer)
+    }
+
+    @inlinable // This is @inlinable as trivially forwarding.
+    public mutating func append(contentsOf bytes: [UInt8]) {
+        bytes.withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<UInt8>) -> Void in
+            _append(buffer)
+        }
+    }
+
+    @inlinable // This is @inlinable as an important generic funnel point, despite being non-trivial.
+    public mutating func append<S: Sequence>(contentsOf elements: S) where S.Element == Element {
+        // If the sequence is already contiguous, access the underlying raw memory directly.
+        if let contiguous = elements as? ContiguousBytes {
+            contiguous.withUnsafeBytes {
+                _representation.append(contentsOf: $0)
+            }
+
+            return
+        }
+
+        // The sequence might still be able to provide direct access to typed memory.
+        // NOTE: It's safe to do this because we're already guarding on S's element as `UInt8`. This would not be safe on arbitrary sequences.
+        let appended: Void? = elements.withContiguousStorageIfAvailable {
+            _representation.append(contentsOf: UnsafeRawBufferPointer($0))
+        }
+        guard appended == nil else { return }
+
+        // The sequence is really not contiguous.
+        // Copy as much as we can in one shot.
+        let underestimatedCount = elements.underestimatedCount
+        let originalCount = _representation.count
+        resetBytes(in: self.endIndex ..< self.endIndex + underestimatedCount)
+        var (iter, copiedCount): (S.Iterator, Int) = _representation.withUnsafeMutableBytes { buffer in
+            assert(buffer.count == originalCount + underestimatedCount)
+            let start = buffer.baseAddress!.assumingMemoryBound(to: UInt8.self) + originalCount
+            let b = UnsafeMutableBufferPointer(start: start, count: buffer.count - originalCount)
+            return elements._copyContents(initializing: b)
+        }
+        guard copiedCount == underestimatedCount else {
+            // We can't trap here. We have to allow an underfilled buffer
+            // to emulate the previous implementation.
+            _representation.replaceSubrange(startIndex + originalCount + copiedCount ..< endIndex, with: nil, count: 0)
+            return
+        }
+
+        // Append the rest byte-wise, buffering through an InlineData.
+        var buffer = InlineData()
+        while let element = iter.next() {
+            buffer.append(byte: element)
+            if buffer.count == buffer.capacity {
+                buffer.withUnsafeBytes { _representation.append(contentsOf: $0) }
+                buffer.count = 0
+            }
+        }
+
+        // If we've still got bytes left in the buffer (i.e. the loop ended before we filled up the buffer and cleared it out), append them.
+        if buffer.count > 0 {
+            buffer.withUnsafeBytes { _representation.append(contentsOf: $0) }
+            buffer.count = 0
+        }
+    }
+    
+    // MARK: -
+    
+    /// Set a region of the data to `0`.
+    ///
+    /// If `range` exceeds the bounds of the data, then the data is resized to fit.
+    /// - parameter range: The range in the data to set to `0`.
+    @inlinable // This is @inlinable as trivially forwarding.
+    public mutating func resetBytes(in range: Range<Index>) {
+        // it is worth noting that the range here may be out of bounds of the Data itself (which triggers a growth)
+        precondition(range.lowerBound >= 0, "Ranges must not be negative bounds")
+        precondition(range.upperBound >= 0, "Ranges must not be negative bounds")
+        _representation.resetBytes(in: range)
+    }
+    
+    /// Replace a region of bytes in the data with new data.
+    ///
+    /// This will resize the data if required, to fit the entire contents of `data`.
+    ///
+    /// - precondition: The bounds of `subrange` must be valid indices of the collection.
+    /// - parameter subrange: The range in the data to replace. If `subrange.lowerBound == data.count && subrange.count == 0` then this operation is an append.
+    /// - parameter data: The replacement data.
+    @inlinable // This is @inlinable as trivially forwarding.
+    public mutating func replaceSubrange(_ subrange: Range<Index>, with data: Data) {
+        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
+            _representation.replaceSubrange(subrange, with: buffer.baseAddress, count: buffer.count)
+        }
+    }
+    
+    /// Replace a region of bytes in the data with new bytes from a buffer.
+    ///
+    /// This will resize the data if required, to fit the entire contents of `buffer`.
+    ///
+    /// - precondition: The bounds of `subrange` must be valid indices of the collection.
+    /// - parameter subrange: The range in the data to replace.
+    /// - parameter buffer: The replacement bytes.
+    @inlinable // This is @inlinable as a generic, trivially forwarding function.
+    public mutating func replaceSubrange<SourceType>(_ subrange: Range<Index>, with buffer: UnsafeBufferPointer<SourceType>) {
+        guard !buffer.isEmpty  else { return }
+        replaceSubrange(subrange, with: buffer.baseAddress!, count: buffer.count * MemoryLayout<SourceType>.stride)
+    }
+    
+    /// Replace a region of bytes in the data with new bytes from a collection.
+    ///
+    /// This will resize the data if required, to fit the entire contents of `newElements`.
+    ///
+    /// - precondition: The bounds of `subrange` must be valid indices of the collection.
+    /// - parameter subrange: The range in the data to replace.
+    /// - parameter newElements: The replacement bytes.
+    @inlinable // This is @inlinable as generic and reasonably small.
+    public mutating func replaceSubrange<ByteCollection : Collection>(_ subrange: Range<Index>, with newElements: ByteCollection) where ByteCollection.Iterator.Element == Data.Iterator.Element {
+        // If the collection is already contiguous, access the underlying raw memory directly.
+        if let contiguous = newElements as? ContiguousBytes {
+            contiguous.withUnsafeBytes { buffer in
+                _representation.replaceSubrange(subrange, with: buffer.baseAddress, count: buffer.count)
+            }
+            return
+        }
+        // The collection might still be able to provide direct access to typed memory.
+        // NOTE: It's safe to do this because we're already guarding on ByteCollection's element as `UInt8`. This would not be safe on arbitrary collections.
+        let replaced: Void? = newElements.withContiguousStorageIfAvailable { buffer in
+            _representation.replaceSubrange(subrange, with: buffer.baseAddress, count: buffer.count)
+        }
+        guard replaced == nil else { return }
+
+        let totalCount = Int(newElements.count)
+        _withStackOrHeapBuffer(capacity: totalCount) { buffer in
+            var (iterator, index) = newElements._copyContents(initializing: buffer)
+            precondition(index == buffer.endIndex, "Collection has less elements than its count")
+            precondition(iterator.next() == nil, "Collection has more elements than its count")
+            _representation.replaceSubrange(subrange, with: buffer.baseAddress, count: totalCount)
+        }
+    }
+    
+    @inlinable // This is @inlinable as trivially forwarding.
+    public mutating func replaceSubrange(_ subrange: Range<Index>, with bytes: UnsafeRawPointer, count cnt: Int) {
+        _representation.replaceSubrange(subrange, with: bytes, count: cnt)
+    }
+    
+    /// Return a new copy of the data in a specified range.
+    ///
+    /// - parameter range: The range to copy.
+    public func subdata(in range: Range<Index>) -> Data {
+        if isEmpty || range.upperBound - range.lowerBound == 0 {
+            return Data()
+        }
+        let slice = self[range]
+
+        return slice.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Data in
+            return Data(bytes: buffer.baseAddress!, count: buffer.count)
+        }
+    }
+    
+    // MARK: -
+    //
+    
+    /// Returns a Base-64 encoded string.
+    ///
+    /// - parameter options: The options to use for the encoding. Default value is `[]`.
+    /// - returns: The Base-64 encoded string.
+    @inlinable // This is @inlinable as trivially forwarding.
+    public func base64EncodedString(options: Data.Base64EncodingOptions = []) -> String {
+        return _representation.withInteriorPointerReference {
+            return $0.base64EncodedString(options: options)
+        }
+    }
+    
+    /// Returns a Base-64 encoded `Data`.
+    ///
+    /// - parameter options: The options to use for the encoding. Default value is `[]`.
+    /// - returns: The Base-64 encoded data.
+    @inlinable // This is @inlinable as trivially forwarding.
+    public func base64EncodedData(options: Data.Base64EncodingOptions = []) -> Data {
+        return _representation.withInteriorPointerReference {
+            return $0.base64EncodedData(options: options)
+        }
+    }
+    
+    // MARK: -
+    //
+    
+    /// The hash value for the data.
+    @inline(never) // This is not inlinable as emission into clients could cause cross-module inconsistencies if they are not all recompiled together.
+    public func hash(into hasher: inout Hasher) {
+        _representation.hash(into: &hasher)
+    }
+    
+    public func advanced(by amount: Int) -> Data {
+        let length = count - amount
+        precondition(length > 0)
+        return withUnsafeBytes { (ptr: UnsafeRawBufferPointer) -> Data in
+            return Data(bytes: ptr.baseAddress!.advanced(by: amount), count: length)
+        }
+    }
+    
+    // MARK: -
+    
+    // MARK: -
+    // MARK: Index and Subscript
+    
+    /// Sets or returns the byte at the specified index.
+    @inlinable // This is @inlinable as trivially forwarding.
+    public subscript(index: Index) -> UInt8 {
+        get {
+            return _representation[index]
+        }
+        set(newValue) {
+            _representation[index] = newValue
+        }
+    }
+    
+    @inlinable // This is @inlinable as trivially forwarding.
+    public subscript(bounds: Range<Index>) -> Data {
+        get {
+            return _representation[bounds]
+        }
+        set {
+            replaceSubrange(bounds, with: newValue)
+        }
+    }
+    
+    @inlinable // This is @inlinable as a generic, trivially forwarding function.
+    public subscript<R: RangeExpression>(_ rangeExpression: R) -> Data
+        where R.Bound: FixedWidthInteger {
+        get {
+            let lower = R.Bound(startIndex)
+            let upper = R.Bound(endIndex)
+            let range = rangeExpression.relative(to: lower..<upper)
+            let start = Int(range.lowerBound)
+            let end = Int(range.upperBound)
+            let r: Range<Int> = start..<end
+            return _representation[r]
+        }
+        set {
+            let lower = R.Bound(startIndex)
+            let upper = R.Bound(endIndex)
+            let range = rangeExpression.relative(to: lower..<upper)
+            let start = Int(range.lowerBound)
+            let end = Int(range.upperBound)
+            let r: Range<Int> = start..<end
+            replaceSubrange(r, with: newValue)
+        }
+        
+    }
+    
+    /// The start `Index` in the data.
+    @inlinable // This is @inlinable as trivially forwarding.
+    public var startIndex: Index {
+        get {
+            return _representation.startIndex
+        }
+    }
+    
+    /// The end `Index` into the data.
+    ///
+    /// This is the "one-past-the-end" position, and will always be equal to the `count`.
+    @inlinable // This is @inlinable as trivially forwarding.
+    public var endIndex: Index {
+        get {
+            return _representation.endIndex
+        }
+    }
+    
+    @inlinable // This is @inlinable as trivially computable.
+    public func index(before i: Index) -> Index {
+        return i - 1
+    }
+    
+    @inlinable // This is @inlinable as trivially computable.
+    public func index(after i: Index) -> Index {
+        return i + 1
+    }
+    
+    @inlinable // This is @inlinable as trivially computable.
+    public var indices: Range<Int> {
+        get {
+            return startIndex..<endIndex
+        }
+    }
+    
+    @inlinable // This is @inlinable as a fast-path for emitting into generic Sequence usages.
+    public func _copyContents(initializing buffer: UnsafeMutableBufferPointer<UInt8>) -> (Iterator, UnsafeMutableBufferPointer<UInt8>.Index) {
+        guard !isEmpty else { return (makeIterator(), buffer.startIndex) }
+        let cnt = Swift.min(count, buffer.count)
+        
+        withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
+            _ = memcpy(UnsafeMutableRawPointer(buffer.baseAddress), bytes.baseAddress, cnt)
+        }
+        
+        return (Iterator(self, at: startIndex + cnt), buffer.index(buffer.startIndex, offsetBy: cnt))
+    }
+    
+    /// An iterator over the contents of the data.
+    ///
+    /// The iterator will increment byte-by-byte.
+    @inlinable // This is @inlinable as trivially computable.
+    public func makeIterator() -> Data.Iterator {
+        return Iterator(self, at: startIndex)
+    }
+    
+    public struct Iterator : IteratorProtocol {
+        @usableFromInline
+        internal typealias Buffer = (
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
+
+        @usableFromInline internal let _data: Data
+        @usableFromInline internal var _buffer: Buffer
+        @usableFromInline internal var _idx: Data.Index
+        @usableFromInline internal let _endIdx: Data.Index
+        
+        @usableFromInline // This is @usableFromInline as a non-trivial initializer.
+        internal init(_ data: Data, at loc: Data.Index) {
+            // The let vars prevent this from being marked as @inlinable
+            _data = data
+            _buffer = (0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
+            _idx = loc
+            _endIdx = data.endIndex
+
+            let bufferSize = MemoryLayout<Buffer>.size
+            Swift.withUnsafeMutableBytes(of: &_buffer) {
+                let ptr = $0.bindMemory(to: UInt8.self)
+                let bufferIdx = (loc - data.startIndex) % bufferSize
+                data.copyBytes(to: ptr, from: (loc - bufferIdx)..<(data.endIndex - (loc - bufferIdx) > bufferSize ? (loc - bufferIdx) + bufferSize : data.endIndex))
+            }
+        }
+        
+        public mutating func next() -> UInt8? {
+            let idx = _idx
+            let bufferSize = MemoryLayout<Buffer>.size
+
+            guard idx < _endIdx else { return nil }
+            _idx += 1
+
+            let bufferIdx = (idx - _data.startIndex) % bufferSize
+
+
+            if bufferIdx == 0 {
+                var buffer = _buffer
+                Swift.withUnsafeMutableBytes(of: &buffer) {
+                    let ptr = $0.bindMemory(to: UInt8.self)
+                    // populate the buffer
+                    _data.copyBytes(to: ptr, from: idx..<(_endIdx - idx > bufferSize ? idx + bufferSize : _endIdx))
+                }
+                _buffer = buffer
+            }
+
+            return Swift.withUnsafeMutableBytes(of: &_buffer) {
+                let ptr = $0.bindMemory(to: UInt8.self)
+                return ptr[bufferIdx]
+            }
+        }
+    }
+    
+    // MARK: -
+    //
+    
+    @available(*, unavailable, renamed: "count")
+    public var length: Int {
+        get { fatalError() }
+        set { fatalError() }
+    }
+    
+    @available(*, unavailable, message: "use withUnsafeBytes instead")
+    public var bytes: UnsafeRawPointer { fatalError() }
+    
+    @available(*, unavailable, message: "use withUnsafeMutableBytes instead")
+    public var mutableBytes: UnsafeMutableRawPointer { fatalError() }
+    
+    /// Returns `true` if the two `Data` arguments are equal.
+    @inlinable // This is @inlinable as emission into clients is safe -- the concept of equality on Data will not change.
+    public static func ==(d1 : Data, d2 : Data) -> Bool {
+        let length1 = d1.count
+        if length1 != d2.count {
+            return false
+        }
+        if length1 > 0 {
+            return d1.withUnsafeBytes { (b1: UnsafeRawBufferPointer) in
+                return d2.withUnsafeBytes { (b2: UnsafeRawBufferPointer) in
+                    return memcmp(b1.baseAddress!, b2.baseAddress!, b2.count) == 0
+                }
+            }
+        }
+        return true
+    }
+}
+
+
+extension Data : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    /// A human-readable description for the data.
+    public var description: String {
+        return "\(self.count) bytes"
+    }
+    
+    /// A human-readable debug description for the data.
+    public var debugDescription: String {
+        return self.description
+    }
+    
+    public var customMirror: Mirror {
+        let nBytes = self.count
+        var children: [(label: String?, value: Any)] = []
+        children.append((label: "count", value: nBytes))
+        
+        self.withUnsafeBytes { (bytes : UnsafeRawBufferPointer) in
+            children.append((label: "pointer", value: bytes.baseAddress!))
+        }
+        
+        // Minimal size data is output as an array
+        if nBytes < 64 {
+            children.append((label: "bytes", value: Array(self[startIndex..<Swift.min(nBytes + startIndex, endIndex)])))
+        }
+        
+        let m = Mirror(self, children:children, displayStyle: Mirror.DisplayStyle.struct)
+        return m
+    }
+}
+
+extension Data {
+    @available(*, unavailable, renamed: "copyBytes(to:count:)")
+    public func getBytes<UnsafeMutablePointerVoid: _Pointer>(_ buffer: UnsafeMutablePointerVoid, length: Int) { }
+    
+    @available(*, unavailable, renamed: "copyBytes(to:from:)")
+    public func getBytes<UnsafeMutablePointerVoid: _Pointer>(_ buffer: UnsafeMutablePointerVoid, range: NSRange) { }
+}
+
+/// Provides bridging functionality for struct Data to class NSData and vice-versa.
+
+extension Data : _ObjectiveCBridgeable {
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSData {
+        return _representation.bridgedReference()
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ input: NSData, result: inout Data?) {
+        // We must copy the input because it might be mutable; just like storing a value type in ObjC
+        result = Data(referencing: input)
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ input: NSData, result: inout Data?) -> Bool {
+        // We must copy the input because it might be mutable; just like storing a value type in ObjC
+        result = Data(referencing: input)
+        return true
+    }
+
+//    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSData?) -> Data {
+        guard let src = source else { return Data() }
+        return Data(referencing: src)
+    }
+}
+
+extension NSData : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(Data._unconditionallyBridgeFromObjectiveC(self))
+    }
+}
+
+extension Data : Codable {
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        
+        // It's more efficient to pre-allocate the buffer if we can.
+        if let count = container.count {
+            self.init(count: count)
+            
+            // Loop only until count, not while !container.isAtEnd, in case count is underestimated (this is misbehavior) and we haven't allocated enough space.
+            // We don't want to write past the end of what we allocated.
+            for i in 0 ..< count {
+                let byte = try container.decode(UInt8.self)
+                self[i] = byte
+            }
+        } else {
+            self.init()
+        }
+        
+        while !container.isAtEnd {
+            var byte = try container.decode(UInt8.self)
+            self.append(&byte, count: 1)
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
+            try container.encode(contentsOf: buffer)
+        }
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/DataProtocol.swift
+++ b/Darwin/Foundation-swiftoverlay/DataProtocol.swift
@@ -1,0 +1,295 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(macOS) || os(iOS)
+import Darwin
+#elseif os(Linux)
+import Glibc
+#endif
+
+//===--- DataProtocol -----------------------------------------------------===//
+
+public protocol DataProtocol : RandomAccessCollection where Element == UInt8, SubSequence : DataProtocol {
+    // FIXME: Remove in favor of opaque type on `regions`.
+    associatedtype Regions: BidirectionalCollection where Regions.Element : DataProtocol & ContiguousBytes, Regions.Element.SubSequence : ContiguousBytes
+
+    /// A `BidirectionalCollection` of `DataProtocol` elements which compose a
+    /// discontiguous buffer of memory.  Each region is a contiguous buffer of
+    /// bytes.
+    ///
+    /// The sum of the lengths of the associated regions must equal `self.count`
+    /// (such that iterating `regions` and iterating `self` produces the same
+    /// sequence of indices in the same number of index advancements).
+    var regions: Regions { get }
+
+    /// Returns the first found range of the given data buffer.
+    ///
+    /// A default implementation is given in terms of `self.regions`.
+    func firstRange<D: DataProtocol, R: RangeExpression>(of: D, in: R) -> Range<Index>? where R.Bound == Index
+
+    /// Returns the last found range of the given data buffer.
+    ///
+    /// A default implementation is given in terms of `self.regions`.
+    func lastRange<D: DataProtocol, R: RangeExpression>(of: D, in: R) -> Range<Index>? where R.Bound == Index
+
+    /// Copies `count` bytes from the start of the buffer to the destination
+    /// buffer.
+    ///
+    /// A default implementation is given in terms of `copyBytes(to:from:)`.
+    @discardableResult
+    func copyBytes(to: UnsafeMutableRawBufferPointer, count: Int) -> Int
+
+    /// Copies `count` bytes from the start of the buffer to the destination
+    /// buffer.
+    ///
+    /// A default implementation is given in terms of `copyBytes(to:from:)`.
+    @discardableResult
+    func copyBytes<DestinationType>(to: UnsafeMutableBufferPointer<DestinationType>, count: Int) -> Int
+
+    /// Copies the bytes from the given range to the destination buffer.
+    ///
+    /// A default implementation is given in terms of `self.regions`.
+    @discardableResult
+    func copyBytes<R: RangeExpression>(to: UnsafeMutableRawBufferPointer, from: R) -> Int where R.Bound == Index
+
+    /// Copies the bytes from the given range to the destination buffer.
+    ///
+    /// A default implementation is given in terms of `self.regions`.
+    @discardableResult
+    func copyBytes<DestinationType, R: RangeExpression>(to: UnsafeMutableBufferPointer<DestinationType>, from: R) -> Int where R.Bound == Index
+}
+
+//===--- MutableDataProtocol ----------------------------------------------===//
+
+public protocol MutableDataProtocol : DataProtocol, MutableCollection, RangeReplaceableCollection {
+    /// Replaces the contents of the buffer at the given range with zeroes.
+    ///
+    /// A default implementation is given in terms of
+    /// `replaceSubrange(_:with:)`.
+    mutating func resetBytes<R: RangeExpression>(in range: R) where R.Bound == Index
+}
+
+//===--- DataProtocol Extensions ------------------------------------------===//
+
+extension DataProtocol {
+    public func firstRange<D: DataProtocol>(of data: D) -> Range<Index>? {
+        return self.firstRange(of: data, in: self.startIndex ..< self.endIndex)
+    }
+
+    public func lastRange<D: DataProtocol>(of data: D) -> Range<Index>? {
+        return self.lastRange(of: data, in: self.startIndex ..< self.endIndex)
+    }
+
+    @discardableResult
+    public func copyBytes(to ptr: UnsafeMutableRawBufferPointer) -> Int {
+        return copyBytes(to: ptr, from: self.startIndex ..< self.endIndex)
+    }
+
+    @discardableResult
+    public func copyBytes<DestinationType>(to ptr: UnsafeMutableBufferPointer<DestinationType>) -> Int {
+        return copyBytes(to: ptr, from: self.startIndex ..< self.endIndex)
+    }
+
+    @discardableResult
+    public func copyBytes(to ptr: UnsafeMutableRawBufferPointer, count: Int) -> Int {
+        return copyBytes(to: ptr, from: self.startIndex ..< self.index(self.startIndex, offsetBy: count))
+    }
+
+    @discardableResult
+    public func copyBytes<DestinationType>(to ptr: UnsafeMutableBufferPointer<DestinationType>, count: Int) -> Int {
+        return copyBytes(to: ptr, from: self.startIndex ..< self.index(self.startIndex, offsetBy: count))
+    }
+
+    @discardableResult
+    public func copyBytes<R: RangeExpression>(to ptr: UnsafeMutableRawBufferPointer, from range: R) -> Int where R.Bound == Index {
+        precondition(ptr.baseAddress != nil)
+
+        let concreteRange = range.relative(to: self)
+        let slice = self[concreteRange]
+
+        // The type isn't contiguous, so we need to copy one region at a time.
+        var offset = 0
+        let rangeCount = distance(from: concreteRange.lowerBound, to: concreteRange.upperBound)
+        var amountToCopy = Swift.min(ptr.count, rangeCount)
+        for region in slice.regions {
+            guard amountToCopy > 0 else {
+                break
+            }
+
+            region.withUnsafeBytes { buffer in
+                let offsetPtr = UnsafeMutableRawBufferPointer(rebasing: ptr[offset...])
+                let buf = UnsafeRawBufferPointer(start: buffer.baseAddress, count: Swift.min(buffer.count, amountToCopy))
+                offsetPtr.copyMemory(from: buf)
+                offset += buf.count
+                amountToCopy -= buf.count
+            }
+        }
+
+        return offset
+    }
+
+    @discardableResult
+    public func copyBytes<DestinationType, R: RangeExpression>(to ptr: UnsafeMutableBufferPointer<DestinationType>, from range: R) -> Int where R.Bound == Index {
+        return self.copyBytes(to: UnsafeMutableRawBufferPointer(start: ptr.baseAddress, count: ptr.count * MemoryLayout<DestinationType>.stride), from: range)
+    }
+
+    private func matches<D: DataProtocol>(_ data: D, from index: Index) -> Bool {
+        var haystackIndex = index
+        var needleIndex = data.startIndex
+        
+        while true {
+            guard self[haystackIndex] == data[needleIndex] else { return false }
+            
+            haystackIndex = self.index(after: haystackIndex)
+            needleIndex = data.index(after: needleIndex)
+            if needleIndex == data.endIndex {
+                // i.e. needle is found.
+                return true
+            } else if haystackIndex == endIndex {
+                return false
+            }
+        }
+    }
+    
+    public func firstRange<D: DataProtocol, R: RangeExpression>(of data: D, in range: R) -> Range<Index>? where R.Bound == Index {
+        let r = range.relative(to: self)
+        let length = data.count
+        
+        if length == 0 || length > distance(from: r.lowerBound, to: r.upperBound) {
+            return nil
+        }
+        
+        var position = r.lowerBound
+        while position < r.upperBound && distance(from: position, to: r.upperBound) >= length {
+            if matches(data, from: position) {
+                return position..<index(position, offsetBy: length)
+            }
+            position = index(after: position)
+        }
+        return nil
+    }
+    
+    public func lastRange<D: DataProtocol, R: RangeExpression>(of data: D, in range: R) -> Range<Index>? where R.Bound == Index {
+        let r = range.relative(to: self)
+        let length = data.count
+        
+        if length == 0 || length > distance(from: r.lowerBound, to: r.upperBound) {
+            return nil
+        }
+        
+        var position = index(r.upperBound, offsetBy: -length)
+        while position >= r.lowerBound {
+            if matches(data, from: position) {
+                return position..<index(position, offsetBy: length)
+            }
+            position = index(before: position)
+        }
+        return nil
+    }
+}
+
+extension DataProtocol where Self : ContiguousBytes {
+    public func copyBytes<DestinationType, R: RangeExpression>(to ptr: UnsafeMutableBufferPointer<DestinationType>, from range: R) where R.Bound == Index {
+        precondition(ptr.baseAddress != nil)
+
+        let concreteRange = range.relative(to: self)
+        withUnsafeBytes { fullBuffer in
+            let adv = distance(from: startIndex, to: concreteRange.lowerBound)
+            let delta = distance(from: concreteRange.lowerBound, to: concreteRange.upperBound)
+            memcpy(ptr.baseAddress!, fullBuffer.baseAddress?.advanced(by: adv), delta)
+        }
+    }
+}
+
+//===--- MutableDataProtocol Extensions -----------------------------------===//
+
+extension MutableDataProtocol {
+    public mutating func resetBytes<R: RangeExpression>(in range: R) where R.Bound == Index {
+        let r = range.relative(to: self)
+        let count = distance(from: r.lowerBound, to: r.upperBound)
+        replaceSubrange(r, with: repeatElement(UInt8(0), count: count))
+    }
+}
+
+//===--- DataProtocol Conditional Conformances ----------------------------===//
+
+extension Slice : DataProtocol where Base : DataProtocol {
+    public typealias Regions = [Base.Regions.Element.SubSequence]
+
+    public var regions: [Base.Regions.Element.SubSequence] {
+        let sliceLowerBound = startIndex
+        let sliceUpperBound = endIndex
+        var regionUpperBound = base.startIndex
+
+        return base.regions.compactMap { (region) -> Base.Regions.Element.SubSequence? in
+            let regionLowerBound = regionUpperBound
+            regionUpperBound = base.index(regionUpperBound, offsetBy: region.count)
+
+            /*
+             [------ Region ------]
+             [--- Slice ---] =>
+
+                      OR
+
+             [------ Region ------]
+                 <= [--- Slice ---]
+             */
+            if sliceLowerBound >= regionLowerBound && sliceUpperBound <= regionUpperBound {
+                let regionRelativeSliceLowerBound = region.index(region.startIndex, offsetBy: base.distance(from: regionLowerBound, to: sliceLowerBound))
+                let regionRelativeSliceUpperBound = region.index(region.startIndex, offsetBy: base.distance(from: regionLowerBound, to: sliceUpperBound))
+                return region[regionRelativeSliceLowerBound..<regionRelativeSliceUpperBound]
+            }
+
+            /*
+             [--- Region ---] =>
+             [------ Slice ------]
+
+                      OR
+
+               <= [--- Region ---]
+             [------ Slice ------]
+             */
+            if regionLowerBound >= sliceLowerBound && regionUpperBound <= sliceUpperBound {
+                return region[region.startIndex..<region.endIndex]
+            }
+
+            /*
+             [------ Region ------]
+                 [------ Slice ------]
+             */
+            if sliceLowerBound >= regionLowerBound && sliceLowerBound <= regionUpperBound {
+                let regionRelativeSliceLowerBound = region.index(region.startIndex, offsetBy: base.distance(from: regionLowerBound, to: sliceLowerBound))
+                return region[regionRelativeSliceLowerBound..<region.endIndex]
+            }
+
+            /*
+                 [------ Region ------]
+             [------ Slice ------]
+             */
+            if regionLowerBound >= sliceLowerBound && regionLowerBound <= sliceUpperBound {
+                let regionRelativeSliceUpperBound = region.index(region.startIndex, offsetBy: base.distance(from: regionLowerBound, to: sliceUpperBound))
+                return region[region.startIndex..<regionRelativeSliceUpperBound]
+            }
+
+            /*
+             [--- Region ---]
+                              [--- Slice ---]
+
+                      OR
+
+                             [--- Region ---]
+             [--- Slice ---]
+             */
+            return nil
+        }
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/DataThunks.m
+++ b/Darwin/Foundation-swiftoverlay/DataThunks.m
@@ -1,0 +1,176 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import <Foundation/Foundation.h>
+#import <sys/fcntl.h>
+
+// Note: This came from SwiftShims/Visibility.h
+#define SWIFT_RUNTIME_STDLIB_INTERNAL __attribute__ ((visibility("hidden")))
+
+#if TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
+static int __NSFileProtectionClassForOptions(NSUInteger options) {
+    int result;
+    switch (options & NSDataWritingFileProtectionMask) {
+        case NSDataWritingFileProtectionComplete:  // Class A
+            result = 1;
+            break;
+        case NSDataWritingFileProtectionCompleteUnlessOpen:  // Class B
+            result = 2;
+            break;
+        case NSDataWritingFileProtectionCompleteUntilFirstUserAuthentication:  // Class C
+            result = 3;
+            break;
+        case NSDataWritingFileProtectionNone:  // Class D
+            result = 4;
+            break;
+        default:
+            result = 0;
+            break;
+    }
+    return result;
+}
+#endif
+
+static int32_t _NSOpenFileDescriptor(const char *path, NSInteger flags, int protectionClass, NSInteger mode) {
+    int fd = -1;
+    if (protectionClass != 0) {
+        fd = open_dprotected_np(path, flags, protectionClass, 0, mode);
+    } else {
+        fd = open(path, flags, mode);
+    }
+    return fd;
+}
+
+static NSInteger _NSWriteToFileDescriptor(int32_t fd, const void *buffer, NSUInteger length) {
+    size_t preferredChunkSize = (size_t)length;
+    size_t numBytesRemaining = (size_t)length;
+    while (numBytesRemaining > 0UL) {
+        size_t numBytesRequested = (preferredChunkSize < (1LL << 31)) ? preferredChunkSize : ((1LL << 31) - 1);
+        if (numBytesRequested > numBytesRemaining) numBytesRequested = numBytesRemaining;
+        ssize_t numBytesWritten;
+        do {
+            numBytesWritten = write(fd, buffer, numBytesRequested);
+        } while (numBytesWritten < 0L && errno == EINTR);
+        if (numBytesWritten < 0L) {
+            return -1;
+        } else if (numBytesWritten == 0L) {
+            break;
+        } else {
+            numBytesRemaining -= numBytesWritten;
+            if ((size_t)numBytesWritten < numBytesRequested) break;
+            buffer = (char *)buffer + numBytesWritten;
+        }
+    }
+    return length - numBytesRemaining;
+}
+
+static NSError *_NSErrorWithFilePath(NSInteger code, id pathOrURL) {
+    NSString *key = [pathOrURL isKindOfClass:[NSURL self]] ? NSURLErrorKey : NSFilePathErrorKey;
+    return [NSError errorWithDomain:NSCocoaErrorDomain code:code userInfo:[NSDictionary dictionaryWithObjectsAndKeys:pathOrURL, key, nil]];
+}
+
+static NSError *_NSErrorWithFilePathAndErrno(NSInteger posixErrno, id pathOrURL, BOOL reading) {
+    NSInteger code;
+    if (reading) {
+        switch (posixErrno) {
+            case EFBIG:          code = NSFileReadTooLargeError; break;
+            case ENOENT:         code = NSFileReadNoSuchFileError; break;
+            case EPERM:          // fallthrough
+            case EACCES:         code = NSFileReadNoPermissionError; break;
+            case ENAMETOOLONG:   code = NSFileReadInvalidFileNameError; break;
+            default:             code = NSFileReadUnknownError; break;
+        }
+    } else {
+        switch (posixErrno) {
+            case ENOENT:         code = NSFileNoSuchFileError; break;
+            case EPERM:          // fallthrough
+            case EACCES:         code = NSFileWriteNoPermissionError; break;
+            case ENAMETOOLONG:   code = NSFileWriteInvalidFileNameError; break;
+#if DEPLOYMENT_TARGET_MACOSX || DEPLOYMENT_TARGET_EMBEDDED
+            case EDQUOT:
+#endif
+            case ENOSPC:         code = NSFileWriteOutOfSpaceError; break;
+            case EROFS:          code = NSFileWriteVolumeReadOnlyError; break;
+            case EEXIST:         code = NSFileWriteFileExistsError; break;
+            default:             code = NSFileWriteUnknownError; break;
+        }
+    }
+    
+    NSString *key = [pathOrURL isKindOfClass:[NSURL self]] ? NSURLErrorKey : NSFilePathErrorKey;
+    NSDictionary *userInfo = [[NSDictionary alloc] initWithObjectsAndKeys:pathOrURL, key, [NSError errorWithDomain:NSPOSIXErrorDomain code:posixErrno userInfo:nil], NSUnderlyingErrorKey, nil];
+    NSError *error = [NSError errorWithDomain:NSCocoaErrorDomain code:code userInfo:userInfo];
+    [userInfo release];
+    return error;
+}
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+BOOL __NSDataWriteToURL(NSData * _Nonnull data NS_RELEASES_ARGUMENT, NSURL * _Nonnull url NS_RELEASES_ARGUMENT, NSDataWritingOptions writingOptions, NSError **errorPtr) {
+    assert((writingOptions & NSDataWritingAtomic) == 0);
+
+    NSString *path = url.path;
+    char cpath[1026];
+
+    if (![path getFileSystemRepresentation:cpath maxLength:1024]) {
+        if (errorPtr) *errorPtr = _NSErrorWithFilePath(NSFileWriteInvalidFileNameError, path);
+        return NO;
+    }
+
+    int protectionClass = 0;
+#if TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
+    protectionClass = __NSFileProtectionClassForOptions(writingOptions);
+#endif
+
+    int flags = O_WRONLY|O_CREAT|O_TRUNC;
+    if (writingOptions & NSDataWritingWithoutOverwriting) {
+        flags |= O_EXCL;
+    }
+    int32_t fd = _NSOpenFileDescriptor(cpath, flags, protectionClass, 0666);
+    if (fd < 0) {
+        if (errorPtr) *errorPtr = _NSErrorWithFilePathAndErrno(errno, path, NO);
+        return NO;
+    }
+
+    __block BOOL writingFailed = NO;
+    __block int32_t saveerr = 0;
+    NSUInteger dataLength = [data length];
+    [data enumerateByteRangesUsingBlock:^(const void *bytes, NSRange byteRange, BOOL *stop) {
+        NSUInteger length = byteRange.length;
+        BOOL success = NO;
+        if (length > 0) {
+            NSInteger writtenLength = _NSWriteToFileDescriptor(fd, bytes, length);
+            success = writtenLength > 0 && (NSUInteger)writtenLength == length;
+        } else {
+            success = YES; // Writing nothing always succeeds.
+        }
+        if (!success) {
+            saveerr = errno;
+            writingFailed = YES;
+            *stop = YES;
+        }
+    }];
+    if (dataLength && !writingFailed) {
+        if (fsync(fd) < 0) {
+            writingFailed = YES;
+            saveerr = errno;
+        }
+    }
+    if (writingFailed) {
+        close(fd);
+        errno = (saveerr);
+        if (errorPtr) {
+            *errorPtr = _NSErrorWithFilePathAndErrno(errno, path, NO);
+        }
+        return NO;
+    }
+    close(fd);
+    return YES;
+}

--- a/Darwin/Foundation-swiftoverlay/Date.swift
+++ b/Darwin/Foundation-swiftoverlay/Date.swift
@@ -1,0 +1,297 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+import CoreFoundation
+@_implementationOnly import _CoreFoundationOverlayShims
+
+/**
+ `Date` represents a single point in time.
+ 
+ A `Date` is independent of a particular calendar or time zone. To represent a `Date` to a user, you must interpret it in the context of a `Calendar`.
+*/
+public struct Date : ReferenceConvertible, Comparable, Equatable {
+    public typealias ReferenceType = NSDate
+    
+    fileprivate var _time : TimeInterval
+
+    /// The number of seconds from 1 January 1970 to the reference date, 1 January 2001.
+    public static let timeIntervalBetween1970AndReferenceDate : TimeInterval = 978307200.0
+  
+    /// The interval between 00:00:00 UTC on 1 January 2001 and the current date and time. 
+    public static var timeIntervalSinceReferenceDate : TimeInterval {
+        return CFAbsoluteTimeGetCurrent()
+    }
+
+    /// Returns a `Date` initialized to the current date and time.
+    public init() {
+        _time = CFAbsoluteTimeGetCurrent()
+    }
+    
+    /// Returns a `Date` initialized relative to the current date and time by a given number of seconds.
+    public init(timeIntervalSinceNow: TimeInterval) {
+        self.init(timeIntervalSinceReferenceDate: timeIntervalSinceNow + CFAbsoluteTimeGetCurrent())
+    }
+    
+    /// Returns a `Date` initialized relative to 00:00:00 UTC on 1 January 1970 by a given number of seconds.
+    public init(timeIntervalSince1970: TimeInterval) {
+        self.init(timeIntervalSinceReferenceDate: timeIntervalSince1970 - Date.timeIntervalBetween1970AndReferenceDate)
+    }
+    
+    /**
+    Returns a `Date` initialized relative to another given date by a given number of seconds.
+    
+    - Parameter timeInterval: The number of seconds to add to `date`. A negative value means the receiver will be earlier than `date`.
+    - Parameter date: The reference date.
+    */
+    public init(timeInterval: TimeInterval, since date: Date) {
+        self.init(timeIntervalSinceReferenceDate: date.timeIntervalSinceReferenceDate + timeInterval)
+    }
+
+    /// Returns a `Date` initialized relative to 00:00:00 UTC on 1 January 2001 by a given number of seconds.
+    public init(timeIntervalSinceReferenceDate ti: TimeInterval) {
+        _time = ti
+    }
+        
+    /**
+    Returns the interval between the date object and 00:00:00 UTC on 1 January 2001.
+    
+    This property's value is negative if the date object is earlier than the system's absolute reference date (00:00:00 UTC on 1 January 2001).
+    */
+    public var timeIntervalSinceReferenceDate: TimeInterval {
+        return _time
+    }
+
+    /**
+    Returns the interval between the receiver and another given date.
+
+    - Parameter another: The date with which to compare the receiver.
+
+    - Returns: The interval between the receiver and the `another` parameter. If the receiver is earlier than `anotherDate`, the return value is negative. If `anotherDate` is `nil`, the results are undefined.
+
+    - SeeAlso: `timeIntervalSince1970`
+    - SeeAlso: `timeIntervalSinceNow`
+    - SeeAlso: `timeIntervalSinceReferenceDate`
+    */
+    public func timeIntervalSince(_ date: Date) -> TimeInterval {
+        return self.timeIntervalSinceReferenceDate - date.timeIntervalSinceReferenceDate
+    }
+    
+    /**
+    The time interval between the date and the current date and time.
+
+    If the date is earlier than the current date and time, this property's value is negative.
+
+    - SeeAlso: `timeIntervalSince(_:)`
+    - SeeAlso: `timeIntervalSince1970`
+    - SeeAlso: `timeIntervalSinceReferenceDate`
+    */
+    public var timeIntervalSinceNow: TimeInterval {
+        return self.timeIntervalSinceReferenceDate - CFAbsoluteTimeGetCurrent()
+    }
+    
+    /**
+    The interval between the date object and 00:00:00 UTC on 1 January 1970.
+
+    This property's value is negative if the date object is earlier than 00:00:00 UTC on 1 January 1970.
+
+    - SeeAlso: `timeIntervalSince(_:)`
+    - SeeAlso: `timeIntervalSinceNow`
+    - SeeAlso: `timeIntervalSinceReferenceDate`
+    */
+    public var timeIntervalSince1970: TimeInterval {
+        return self.timeIntervalSinceReferenceDate + Date.timeIntervalBetween1970AndReferenceDate
+    }
+    
+    /// Return a new `Date` by adding a `TimeInterval` to this `Date`.
+    ///
+    /// - parameter timeInterval: The value to add, in seconds.
+    /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
+    public func addingTimeInterval(_ timeInterval: TimeInterval) -> Date {
+        return self + timeInterval
+    }
+    
+    /// Add a `TimeInterval` to this `Date`.
+    ///
+    /// - parameter timeInterval: The value to add, in seconds.
+    /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
+    public mutating func addTimeInterval(_ timeInterval: TimeInterval) {
+        self += timeInterval
+    }
+    
+    /**
+    Creates and returns a Date value representing a date in the distant future.
+    
+    The distant future is in terms of centuries.
+    */
+    public static let distantFuture = Date(timeIntervalSinceReferenceDate: 63113904000.0)
+    
+    /**
+    Creates and returns a Date value representing a date in the distant past.
+    
+    The distant past is in terms of centuries.
+    */
+    public static let distantPast = Date(timeIntervalSinceReferenceDate: -63114076800.0)
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_time)
+    }
+
+    /// Compare two `Date` values.
+    public func compare(_ other: Date) -> ComparisonResult {
+        if _time < other.timeIntervalSinceReferenceDate {
+            return .orderedAscending
+        } else if _time > other.timeIntervalSinceReferenceDate {
+            return .orderedDescending
+        } else {
+            return .orderedSame
+        }
+    }
+    
+    /// Returns true if the two `Date` values represent the same point in time.
+    public static func ==(lhs: Date, rhs: Date) -> Bool {
+        return lhs.timeIntervalSinceReferenceDate == rhs.timeIntervalSinceReferenceDate
+    }
+
+    /// Returns true if the left hand `Date` is earlier in time than the right hand `Date`.
+    public static func <(lhs: Date, rhs: Date) -> Bool {
+        return lhs.timeIntervalSinceReferenceDate < rhs.timeIntervalSinceReferenceDate
+    }
+
+    /// Returns true if the left hand `Date` is later in time than the right hand `Date`.
+    public static func >(lhs: Date, rhs: Date) -> Bool {
+        return lhs.timeIntervalSinceReferenceDate > rhs.timeIntervalSinceReferenceDate
+    }
+
+    /// Returns a `Date` with a specified amount of time added to it.
+    public static func +(lhs: Date, rhs: TimeInterval) -> Date {
+        return Date(timeIntervalSinceReferenceDate: lhs.timeIntervalSinceReferenceDate + rhs)
+    }
+
+    /// Returns a `Date` with a specified amount of time subtracted from it.
+    public static func -(lhs: Date, rhs: TimeInterval) -> Date {
+        return Date(timeIntervalSinceReferenceDate: lhs.timeIntervalSinceReferenceDate - rhs)
+    }
+
+    /// Add a `TimeInterval` to a `Date`.
+    ///
+    /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
+    public static func +=(lhs: inout Date, rhs: TimeInterval) {
+        lhs = lhs + rhs
+    }
+
+    /// Subtract a `TimeInterval` from a `Date`.
+    ///
+    /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
+    public static func -=(lhs: inout Date, rhs: TimeInterval) {
+        lhs = lhs - rhs
+    }
+
+}
+
+extension Date : CustomDebugStringConvertible, CustomStringConvertible, CustomReflectable {
+    /**
+     A string representation of the date object (read-only).
+     
+     The representation is useful for debugging only.
+     
+     There are a number of options to acquire a formatted string for a date including: date formatters (see
+     [NSDateFormatter](//apple_ref/occ/cl/NSDateFormatter) and [Data Formatting Guide](//apple_ref/doc/uid/10000029i)), and the `Date` function `description(locale:)`.
+     */
+    public var description: String {
+        // Defer to NSDate for description
+        return NSDate(timeIntervalSinceReferenceDate: _time).description
+    }
+    
+    /**
+     Returns a string representation of the receiver using the given
+     locale.
+     
+     - Parameter locale: A `Locale`. If you pass `nil`, `Date` formats the date in the same way as the `description` property.
+     
+     - Returns: A string representation of the `Date`, using the given locale, or if the locale argument is `nil`, in the international format `YYYY-MM-DD HH:MM:SS ±HHMM`, where `±HHMM` represents the time zone offset in hours and minutes from UTC (for example, "`2001-03-24 10:45:32 +0600`").
+     */
+    public func description(with locale: Locale?) -> String {
+        return NSDate(timeIntervalSinceReferenceDate: _time).description(with: locale)
+    }
+    
+    public var debugDescription: String {
+        return description
+    }
+
+    public var customMirror: Mirror {
+        let c: [(label: String?, value: Any)] = [
+          ("timeIntervalSinceReferenceDate", timeIntervalSinceReferenceDate)
+        ]
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+    }
+}
+
+extension Date : _ObjectiveCBridgeable {
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSDate {
+        return NSDate(timeIntervalSinceReferenceDate: _time)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSDate, result: inout Date?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSDate, result: inout Date?) -> Bool {
+        result = Date(timeIntervalSinceReferenceDate: x.timeIntervalSinceReferenceDate)
+        return true
+    }
+
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSDate?) -> Date {
+        var result: Date?
+        _forceBridgeFromObjectiveC(source!, result: &result)
+        return result!
+    }
+}
+
+extension NSDate : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as Date)
+    }
+}
+
+extension Date : _CustomPlaygroundQuickLookable {
+    var summary: String {
+        let df = DateFormatter()
+        df.dateStyle = .medium
+        df.timeStyle = .short
+        return df.string(from: self)
+    }
+    
+    @available(*, deprecated, message: "Date.customPlaygroundQuickLook will be removed in a future Swift version")
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .text(summary)
+    }
+}
+
+extension Date : Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let timestamp = try container.decode(Double.self)
+        self.init(timeIntervalSinceReferenceDate: timestamp)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.timeIntervalSinceReferenceDate)
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/DateComponents.swift
+++ b/Darwin/Foundation-swiftoverlay/DateComponents.swift
@@ -1,0 +1,429 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+/**
+ `DateComponents` encapsulates the components of a date in an extendable, structured manner. 
+ 
+ It is used to specify a date by providing the temporal components that make up a date and time in a particular calendar: hour, minutes, seconds, day, month, year, and so on. It can also be used to specify a duration of time, for example, 5 hours and 16 minutes. A `DateComponents` is not required to define all the component fields. 
+ 
+ When a new instance of `DateComponents` is created, the date components are set to `nil`.
+*/
+public struct DateComponents : ReferenceConvertible, Hashable, Equatable, _MutableBoxing {
+    public typealias ReferenceType = NSDateComponents
+    
+    internal var _handle: _MutableHandle<NSDateComponents>
+
+    /// Initialize a `DateComponents`, optionally specifying values for its fields.
+    public init(calendar: Calendar? = nil,
+         timeZone: TimeZone? = nil,
+         era: Int? = nil,
+         year: Int? = nil,
+         month: Int? = nil,
+         day: Int? = nil,
+         hour: Int? = nil,
+         minute: Int? = nil,
+         second: Int? = nil,
+         nanosecond: Int? = nil,
+         weekday: Int? = nil,
+         weekdayOrdinal: Int? = nil,
+         quarter: Int? = nil,
+         weekOfMonth: Int? = nil,
+         weekOfYear: Int? = nil,
+         yearForWeekOfYear: Int? = nil) {
+        _handle = _MutableHandle(adoptingReference: NSDateComponents())
+        if let _calendar = calendar { self.calendar = _calendar }
+        if let _timeZone = timeZone { self.timeZone = _timeZone }
+        if let _era = era { self.era = _era }
+        if let _year = year { self.year = _year }
+        if let _month = month { self.month = _month }
+        if let _day = day { self.day = _day }
+        if let _hour = hour { self.hour = _hour }
+        if let _minute = minute { self.minute = _minute }
+        if let _second = second { self.second = _second }
+        if let _nanosecond = nanosecond { self.nanosecond = _nanosecond }
+        if let _weekday = weekday { self.weekday = _weekday }
+        if let _weekdayOrdinal = weekdayOrdinal { self.weekdayOrdinal = _weekdayOrdinal }
+        if let _quarter = quarter { self.quarter = _quarter }
+        if let _weekOfMonth = weekOfMonth { self.weekOfMonth = _weekOfMonth }
+        if let _weekOfYear = weekOfYear { self.weekOfYear = _weekOfYear }
+        if let _yearForWeekOfYear = yearForWeekOfYear { self.yearForWeekOfYear = _yearForWeekOfYear }
+    }
+
+    
+    // MARK: - Properties
+    
+    /// Translate from the NSDateComponentUndefined value into a proper Swift optional
+    private func _getter(_ x : Int) -> Int? { return x == NSDateComponentUndefined ? nil : x }
+    
+    /// Translate from the proper Swift optional value into an NSDateComponentUndefined
+    private static func _setter(_ x : Int?) -> Int { if let xx = x { return xx } else { return NSDateComponentUndefined } }
+
+    /// The `Calendar` used to interpret the other values in this structure.
+    ///
+    /// - note: API which uses `DateComponents` may have different behavior if this value is `nil`. For example, assuming the current calendar or ignoring certain values.
+    public var calendar: Calendar? {
+        get { return _handle.map { $0.calendar } }
+        set { _applyMutation { $0.calendar = newValue } }
+    }
+    
+    /// A time zone.
+    /// - note: This value is interpreted in the context of the calendar in which it is used.
+    public var timeZone: TimeZone? {
+        get { return _handle.map { $0.timeZone } }
+        set { _applyMutation { $0.timeZone = newValue } }
+    }
+    
+    /// An era or count of eras.
+    /// - note: This value is interpreted in the context of the calendar in which it is used.
+    public var era: Int? {
+        get { return _handle.map { _getter($0.era) } }
+        set { _applyMutation { $0.era = DateComponents._setter(newValue) } }
+    }
+    
+    /// A year or count of years.
+    /// - note: This value is interpreted in the context of the calendar in which it is used.
+    public var year: Int? {
+        get { return _handle.map { _getter($0.year) } }
+        set { _applyMutation { $0.year = DateComponents._setter(newValue) } }
+    }
+    
+    /// A month or count of months.
+    /// - note: This value is interpreted in the context of the calendar in which it is used.
+    public var month: Int? {
+        get { return _handle.map { _getter($0.month) } }
+        set { _applyMutation { $0.month = DateComponents._setter(newValue) } }
+    }
+    
+    /// A day or count of days.
+    /// - note: This value is interpreted in the context of the calendar in which it is used.
+    public var day: Int? {
+        get { return _handle.map { _getter($0.day) } }
+        set { _applyMutation { $0.day = DateComponents._setter(newValue) } }
+    }
+    
+    /// An hour or count of hours.
+    /// - note: This value is interpreted in the context of the calendar in which it is used.
+    public var hour: Int? {
+        get { return _handle.map { _getter($0.hour) } }
+        set { _applyMutation { $0.hour = DateComponents._setter(newValue) } }
+    }
+    
+    /// A minute or count of minutes.
+    /// - note: This value is interpreted in the context of the calendar in which it is used.
+    public var minute: Int? {
+        get { return _handle.map { _getter($0.minute) } }
+        set { _applyMutation { $0.minute = DateComponents._setter(newValue) } }
+    }
+    
+    /// A second or count of seconds.
+    /// - note: This value is interpreted in the context of the calendar in which it is used.
+    public var second: Int? {
+        get { return _handle.map { _getter($0.second) } }
+        set { _applyMutation { $0.second = DateComponents._setter(newValue) } }
+    }
+    
+    /// A nanosecond or count of nanoseconds.
+    /// - note: This value is interpreted in the context of the calendar in which it is used.
+    public var nanosecond: Int? {
+        get { return _handle.map { _getter($0.nanosecond) } }
+        set { _applyMutation { $0.nanosecond = DateComponents._setter(newValue) } }
+    }
+    
+    /// A weekday or count of weekdays.
+    /// - note: This value is interpreted in the context of the calendar in which it is used.
+    public var weekday: Int? {
+        get { return _handle.map { _getter($0.weekday) } }
+        set { _applyMutation { $0.weekday = DateComponents._setter(newValue) } }
+    }
+    
+    /// A weekday ordinal or count of weekday ordinals.
+    /// Weekday ordinal units represent the position of the weekday within the next larger calendar unit, such as the month. For example, 2 is the weekday ordinal unit for the second Friday of the month.///
+    /// - note: This value is interpreted in the context of the calendar in which it is used.
+    public var weekdayOrdinal: Int? {
+        get { return _handle.map { _getter($0.weekdayOrdinal) } }
+        set { _applyMutation { $0.weekdayOrdinal = DateComponents._setter(newValue) } }
+    }
+    
+    /// A quarter or count of quarters.
+    /// - note: This value is interpreted in the context of the calendar in which it is used.
+    public var quarter: Int? {
+        get { return _handle.map { _getter($0.quarter) } }
+        set { _applyMutation { $0.quarter = DateComponents._setter(newValue) } }
+    }
+    
+    /// A week of the month or a count of weeks of the month.
+    /// - note: This value is interpreted in the context of the calendar in which it is used.
+    public var weekOfMonth: Int? {
+        get { return _handle.map { _getter($0.weekOfMonth) } }
+        set { _applyMutation { $0.weekOfMonth = DateComponents._setter(newValue) } }
+    }
+    
+    /// A week of the year or count of the weeks of the year.
+    /// - note: This value is interpreted in the context of the calendar in which it is used.
+    public var weekOfYear: Int? {
+        get { return _handle.map { _getter($0.weekOfYear) } }
+        set { _applyMutation { $0.weekOfYear = DateComponents._setter(newValue) } }
+    }
+    
+    /// The ISO 8601 week-numbering year of the receiver.
+    ///
+    /// The Gregorian calendar defines a week to have 7 days, and a year to have 365 days, or 366 in a leap year. However, neither 365 or 366 divide evenly into a 7 day week, so it is often the case that the last week of a year ends on a day in the next year, and the first week of a year begins in the preceding year. To reconcile this, ISO 8601 defines a week-numbering year, consisting of either 52 or 53 full weeks (364 or 371 days), such that the first week of a year is designated to be the week containing the first Thursday of the year.
+    ///
+    /// You can use the yearForWeekOfYear property with the weekOfYear and weekday properties to get the date corresponding to a particular weekday of a given week of a year. For example, the 6th day of the 53rd week of the year 2005 (ISO 2005-W53-6) corresponds to Sat 1 January 2005 on the Gregorian calendar.
+    /// - note: This value is interpreted in the context of the calendar in which it is used.
+    public var yearForWeekOfYear: Int? {
+        get { return _handle.map { _getter($0.yearForWeekOfYear) } }
+        set { _applyMutation { $0.yearForWeekOfYear = DateComponents._setter(newValue) } }
+    }
+    
+    /// Set to true if these components represent a leap month.
+    public var isLeapMonth: Bool? {
+        get { return _handle.map { $0.isLeapMonth } }
+        set {
+            _applyMutation {
+                // Technically, the underlying class does not support setting isLeapMonth to nil, but it could - so we leave the API consistent.
+                if let b = newValue {
+                    $0.isLeapMonth = b
+                } else {
+                    $0.isLeapMonth = false
+                }
+            }
+        }
+    }
+    
+    /// Returns a `Date` calculated from the current components using the `calendar` property.
+    public var date: Date? {
+        return _handle.map { $0.date } 
+    }
+    
+    // MARK: - Generic Setter/Getters
+    
+    /// Set the value of one of the properties, using an enumeration value instead of a property name.
+    ///
+    /// The calendar and timeZone and isLeapMonth properties cannot be set by this method.
+    @available(macOS 10.9, iOS 8.0, *)
+    public mutating func setValue(_ value: Int?, for component: Calendar.Component) {
+        _applyMutation {
+            $0.setValue(DateComponents._setter(value), forComponent: Calendar._toCalendarUnit([component]))
+        }
+    }
+    
+    /// Returns the value of one of the properties, using an enumeration value instead of a property name.
+    ///
+    /// The calendar and timeZone and isLeapMonth property values cannot be retrieved by this method.
+    @available(macOS 10.9, iOS 8.0, *)
+    public func value(for component: Calendar.Component) -> Int? {
+        return _handle.map {
+            $0.value(forComponent: Calendar._toCalendarUnit([component]))
+        }
+    }
+    
+    // MARK: -
+    
+    /// Returns true if the combination of properties which have been set in the receiver is a date which exists in the `calendar` property.
+    ///
+    /// This method is not appropriate for use on `DateComponents` values which are specifying relative quantities of calendar components.
+    ///
+    /// Except for some trivial cases (e.g., 'seconds' should be 0 - 59 in any calendar), this method is not necessarily cheap.
+    ///
+    /// If the time zone property is set in the `DateComponents`, it is used.
+    ///
+    /// The calendar property must be set, or the result is always `false`.
+    @available(macOS 10.9, iOS 8.0, *)
+    public var isValidDate: Bool {
+        return _handle.map { $0.isValidDate }
+    }
+    
+    /// Returns true if the combination of properties which have been set in the receiver is a date which exists in the specified `Calendar`.
+    ///
+    /// This method is not appropriate for use on `DateComponents` values which are specifying relative quantities of calendar components.
+    ///
+    /// Except for some trivial cases (e.g., 'seconds' should be 0 - 59 in any calendar), this method is not necessarily cheap.
+    ///
+    /// If the time zone property is set in the `DateComponents`, it is used.
+    @available(macOS 10.9, iOS 8.0, *)
+    public func isValidDate(in calendar: Calendar) -> Bool {
+        return _handle.map { $0.isValidDate(in: calendar) }
+    }
+    
+    // MARK: -
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_handle._uncopiedReference())
+    }
+
+    // MARK: - Bridging Helpers
+    
+    private init(reference: __shared NSDateComponents) {
+        _handle = _MutableHandle(reference: reference)
+    }
+
+    public static func ==(lhs : DateComponents, rhs: DateComponents) -> Bool {
+        // Don't copy references here; no one should be storing anything
+        return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
+    }
+
+}
+
+extension DateComponents : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    
+    public var description: String {
+        return self.customMirror.children.reduce("") {
+            $0.appending("\($1.label ?? ""): \($1.value) ")
+        }
+    }
+    
+    public var debugDescription: String {
+        return self.description
+    }
+    
+    public var customMirror: Mirror {
+        var c: [(label: String?, value: Any)] = []
+        if let r = calendar { c.append((label: "calendar", value: r)) }
+        if let r = timeZone { c.append((label: "timeZone", value: r)) }
+        if let r = era { c.append((label: "era", value: r)) }
+        if let r = year { c.append((label: "year", value: r)) }
+        if let r = month { c.append((label: "month", value: r)) }
+        if let r = day { c.append((label: "day", value: r)) }
+        if let r = hour { c.append((label: "hour", value: r)) }
+        if let r = minute { c.append((label: "minute", value: r)) }
+        if let r = second { c.append((label: "second", value: r)) }
+        if let r = nanosecond { c.append((label: "nanosecond", value: r)) }
+        if let r = weekday { c.append((label: "weekday", value: r)) }
+        if let r = weekdayOrdinal { c.append((label: "weekdayOrdinal", value: r)) }
+        if let r = quarter { c.append((label: "quarter", value: r)) }
+        if let r = weekOfMonth { c.append((label: "weekOfMonth", value: r)) }
+        if let r = weekOfYear { c.append((label: "weekOfYear", value: r)) }
+        if let r = yearForWeekOfYear { c.append((label: "yearForWeekOfYear", value: r)) }
+        if let r = isLeapMonth { c.append((label: "isLeapMonth", value: r)) }
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+    }
+}
+
+// MARK: - Bridging
+
+extension DateComponents : _ObjectiveCBridgeable {
+    public static func _getObjectiveCType() -> Any.Type {
+        return NSDateComponents.self
+    }
+    
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSDateComponents {
+        return _handle._copiedReference()
+    }
+
+    public static func _forceBridgeFromObjectiveC(_ dateComponents: NSDateComponents, result: inout DateComponents?) {
+        if !_conditionallyBridgeFromObjectiveC(dateComponents, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ dateComponents: NSDateComponents, result: inout DateComponents?) -> Bool {
+        result = DateComponents(reference: dateComponents)
+        return true
+    }
+
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSDateComponents?) -> DateComponents {
+        guard let src = source else { return DateComponents() }
+        return DateComponents(reference: src)
+    }
+}
+
+extension NSDateComponents : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as DateComponents)
+    }
+}
+
+extension DateComponents : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case calendar
+        case timeZone
+        case era
+        case year
+        case month
+        case day
+        case hour
+        case minute
+        case second
+        case nanosecond
+        case weekday
+        case weekdayOrdinal
+        case quarter
+        case weekOfMonth
+        case weekOfYear
+        case yearForWeekOfYear
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container  = try decoder.container(keyedBy: CodingKeys.self)
+        let calendar   = try container.decodeIfPresent(Calendar.self, forKey: .calendar)
+        let timeZone   = try container.decodeIfPresent(TimeZone.self, forKey: .timeZone)
+        let era        = try container.decodeIfPresent(Int.self, forKey: .era)
+        let year       = try container.decodeIfPresent(Int.self, forKey: .year)
+        let month      = try container.decodeIfPresent(Int.self, forKey: .month)
+        let day        = try container.decodeIfPresent(Int.self, forKey: .day)
+        let hour       = try container.decodeIfPresent(Int.self, forKey: .hour)
+        let minute     = try container.decodeIfPresent(Int.self, forKey: .minute)
+        let second     = try container.decodeIfPresent(Int.self, forKey: .second)
+        let nanosecond = try container.decodeIfPresent(Int.self, forKey: .nanosecond)
+
+        let weekday           = try container.decodeIfPresent(Int.self, forKey: .weekday)
+        let weekdayOrdinal    = try container.decodeIfPresent(Int.self, forKey: .weekdayOrdinal)
+        let quarter           = try container.decodeIfPresent(Int.self, forKey: .quarter)
+        let weekOfMonth       = try container.decodeIfPresent(Int.self, forKey: .weekOfMonth)
+        let weekOfYear        = try container.decodeIfPresent(Int.self, forKey: .weekOfYear)
+        let yearForWeekOfYear = try container.decodeIfPresent(Int.self, forKey: .yearForWeekOfYear)
+
+        self.init(calendar: calendar,
+                  timeZone: timeZone,
+                  era: era,
+                  year: year,
+                  month: month,
+                  day: day,
+                  hour: hour,
+                  minute: minute,
+                  second: second,
+                  nanosecond: nanosecond,
+                  weekday: weekday,
+                  weekdayOrdinal: weekdayOrdinal,
+                  quarter: quarter,
+                  weekOfMonth: weekOfMonth,
+                  weekOfYear: weekOfYear,
+                  yearForWeekOfYear: yearForWeekOfYear)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(self.calendar, forKey: .calendar)
+        try container.encodeIfPresent(self.timeZone, forKey: .timeZone)
+        try container.encodeIfPresent(self.era, forKey: .era)
+        try container.encodeIfPresent(self.year, forKey: .year)
+        try container.encodeIfPresent(self.month, forKey: .month)
+        try container.encodeIfPresent(self.day, forKey: .day)
+        try container.encodeIfPresent(self.hour, forKey: .hour)
+        try container.encodeIfPresent(self.minute, forKey: .minute)
+        try container.encodeIfPresent(self.second, forKey: .second)
+        try container.encodeIfPresent(self.nanosecond, forKey: .nanosecond)
+        try container.encodeIfPresent(self.weekday, forKey: .weekday)
+        try container.encodeIfPresent(self.weekdayOrdinal, forKey: .weekdayOrdinal)
+        try container.encodeIfPresent(self.quarter, forKey: .quarter)
+        try container.encodeIfPresent(self.weekOfMonth, forKey: .weekOfMonth)
+        try container.encodeIfPresent(self.weekOfYear, forKey: .weekOfYear)
+        try container.encodeIfPresent(self.yearForWeekOfYear, forKey: .yearForWeekOfYear)
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/DateInterval.swift
+++ b/Darwin/Foundation-swiftoverlay/DateInterval.swift
@@ -1,0 +1,228 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+@_implementationOnly import _CoreFoundationOverlayShims
+
+/// DateInterval represents a closed date interval in the form of [startDate, endDate].  It is possible for the start and end dates to be the same with a duration of 0.  DateInterval does not support reverse intervals i.e. intervals where the duration is less than 0 and the end date occurs earlier in time than the start date.
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+public struct DateInterval : ReferenceConvertible, Comparable, Hashable, Codable {
+    public typealias ReferenceType = NSDateInterval
+    
+    /// The start date.
+    public var start : Date
+    
+    /// The end date.
+    ///
+    /// - precondition: `end >= start`
+    public var end : Date {
+        get {
+            return start + duration
+        }
+        set {
+            precondition(newValue >= start, "Reverse intervals are not allowed")
+            duration = newValue.timeIntervalSinceReferenceDate - start.timeIntervalSinceReferenceDate
+        }
+    }
+    
+    /// The duration.
+    ///
+    /// - precondition: `duration >= 0`
+    public var duration : TimeInterval {
+        willSet {
+            precondition(newValue >= 0, "Negative durations are not allowed")
+        }
+    }
+
+    /// Initializes a `DateInterval` with start and end dates set to the current date and the duration set to `0`.
+    public init() {
+        let d = Date()
+        start = d
+        duration = 0
+    }
+    
+    /// Initialize a `DateInterval` with the specified start and end date.
+    ///
+    /// - precondition: `end >= start`
+    public init(start: Date, end: Date) {
+        precondition(end >= start, "Reverse intervals are not allowed")
+        self.start = start
+        duration = end.timeIntervalSince(start)
+    }
+    
+    /// Initialize a `DateInterval` with the specified start date and duration.
+    ///
+    /// - precondition: `duration >= 0`
+    public init(start: Date, duration: TimeInterval) {
+        precondition(duration >= 0, "Negative durations are not allowed")
+        self.start = start
+        self.duration = duration
+    }
+    
+    /**
+     Compare two DateIntervals.
+     
+     This method prioritizes ordering by start date. If the start dates are equal, then it will order by duration.
+     e.g. Given intervals a and b
+     ```
+     a.   |-----|
+     b.      |-----|
+     ```
+     
+     `a.compare(b)` would return `.OrderedAscending` because a's start date is earlier in time than b's start date.
+    
+     In the event that the start dates are equal, the compare method will attempt to order by duration.
+     e.g. Given intervals c and d
+     ```
+     c.  |-----|
+     d.  |---|
+     ```
+     `c.compare(d)` would result in `.OrderedDescending` because c is longer than d.
+    
+     If both the start dates and the durations are equal, then the intervals are considered equal and `.OrderedSame` is returned as the result.
+    */
+    public func compare(_ dateInterval: DateInterval) -> ComparisonResult {
+        let result = start.compare(dateInterval.start)
+        if result == .orderedSame {
+            if self.duration < dateInterval.duration { return .orderedAscending }
+            if self.duration > dateInterval.duration { return .orderedDescending }
+            return .orderedSame
+        }
+        return result
+    }
+    
+    /// Returns `true` if `self` intersects the `dateInterval`.
+    public func intersects(_ dateInterval: DateInterval) -> Bool {
+        return contains(dateInterval.start) || contains(dateInterval.end) || dateInterval.contains(start) || dateInterval.contains(end)
+    }
+    
+    /// Returns a DateInterval that represents the interval where the given date interval and the current instance intersect.
+    ///
+    /// In the event that there is no intersection, the method returns nil.
+    public func intersection(with dateInterval: DateInterval) -> DateInterval? {
+        if !intersects(dateInterval) {
+            return nil
+        }
+        
+        if self == dateInterval {
+            return self
+        }
+        
+        let timeIntervalForSelfStart = start.timeIntervalSinceReferenceDate
+        let timeIntervalForSelfEnd = end.timeIntervalSinceReferenceDate
+        let timeIntervalForGivenStart = dateInterval.start.timeIntervalSinceReferenceDate
+        let timeIntervalForGivenEnd = dateInterval.end.timeIntervalSinceReferenceDate
+        
+        let resultStartDate : Date
+        if timeIntervalForGivenStart >= timeIntervalForSelfStart {
+            resultStartDate = dateInterval.start
+        } else {
+            // self starts after given
+            resultStartDate = start
+        }
+        
+        let resultEndDate : Date
+        if timeIntervalForGivenEnd >= timeIntervalForSelfEnd {
+            resultEndDate = end
+        } else {
+            // given ends before self
+            resultEndDate = dateInterval.end
+        }
+        
+        return DateInterval(start: resultStartDate, end: resultEndDate)
+    }
+ 
+    /// Returns `true` if `self` contains `date`.
+    public func contains(_ date: Date) -> Bool {
+        let timeIntervalForGivenDate = date.timeIntervalSinceReferenceDate
+        let timeIntervalForSelfStart = start.timeIntervalSinceReferenceDate
+        let timeIntervalforSelfEnd = end.timeIntervalSinceReferenceDate
+        if (timeIntervalForGivenDate >= timeIntervalForSelfStart) && (timeIntervalForGivenDate <= timeIntervalforSelfEnd) {
+            return true
+        }
+        return false
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(start)
+        hasher.combine(duration)
+    }
+
+    @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+    public static func ==(lhs: DateInterval, rhs: DateInterval) -> Bool {
+        return lhs.start == rhs.start && lhs.duration == rhs.duration
+    }
+
+    @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+    public static func <(lhs: DateInterval, rhs: DateInterval) -> Bool {
+        return lhs.compare(rhs) == .orderedAscending
+    }
+}
+
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+extension DateInterval : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    public var description: String {
+        return "\(start) to \(end)"
+    }
+    
+    public var debugDescription: String {
+        return description
+    }
+
+    public var customMirror: Mirror {
+        var c: [(label: String?, value: Any)] = []
+        c.append((label: "start", value: start))
+        c.append((label: "end", value: end))
+        c.append((label: "duration", value: duration))
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+    }
+}
+
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+extension DateInterval : _ObjectiveCBridgeable {
+    public static func _getObjectiveCType() -> Any.Type {
+        return NSDateInterval.self
+    }
+    
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSDateInterval {
+        return NSDateInterval(start: start, duration: duration)
+    }
+
+    public static func _forceBridgeFromObjectiveC(_ dateInterval: NSDateInterval, result: inout DateInterval?) {
+        if !_conditionallyBridgeFromObjectiveC(dateInterval, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ dateInterval : NSDateInterval, result: inout DateInterval?) -> Bool {
+        result = DateInterval(start: dateInterval.startDate, duration: dateInterval.duration)
+        return true
+    }
+
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSDateInterval?) -> DateInterval {
+        var result: DateInterval?
+        _forceBridgeFromObjectiveC(source!, result: &result)
+        return result!
+    }
+}
+
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+extension NSDateInterval : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as DateInterval)
+    }
+}
+

--- a/Darwin/Foundation-swiftoverlay/Decimal.swift
+++ b/Darwin/Foundation-swiftoverlay/Decimal.swift
@@ -1,0 +1,630 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+@_implementationOnly import _CoreFoundationOverlayShims
+
+extension Decimal {
+    public typealias RoundingMode = NSDecimalNumber.RoundingMode
+    public typealias CalculationError = NSDecimalNumber.CalculationError
+}
+
+public func pow(_ x: Decimal, _ y: Int) -> Decimal {
+    var x = x
+    var result = Decimal()
+    NSDecimalPower(&result, &x, y, .plain)
+    return result
+}
+
+extension Decimal : Hashable, Comparable {
+    private subscript(index: UInt32) -> UInt16 {
+        get {
+            switch index {
+            case 0: return _mantissa.0
+            case 1: return _mantissa.1
+            case 2: return _mantissa.2
+            case 3: return _mantissa.3
+            case 4: return _mantissa.4
+            case 5: return _mantissa.5
+            case 6: return _mantissa.6
+            case 7: return _mantissa.7
+            default: fatalError("Invalid index \(index) for _mantissa")
+            }
+        }
+    }
+    
+    internal var doubleValue: Double {
+        if _length == 0 {
+            return _isNegative == 1 ? Double.nan : 0
+        }
+
+        var d = 0.0
+        for idx in (0..<min(_length, 8)).reversed() {
+            d = d * 65536 + Double(self[idx])
+        }
+        
+        if _exponent < 0 {
+            for _ in _exponent..<0 {
+                d /= 10.0
+            }
+        } else {
+            for _ in 0..<_exponent {
+                d *= 10.0
+            }
+        }
+        return _isNegative != 0 ? -d : d
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        // FIXME: This is a weak hash.  We should rather normalize self to a
+        // canonical member of the exact same equivalence relation that
+        // NSDecimalCompare implements, then simply feed all components to the
+        // hasher.
+        hasher.combine(doubleValue)
+    }
+
+    public static func ==(lhs: Decimal, rhs: Decimal) -> Bool {
+        var lhsVal = lhs
+        var rhsVal = rhs
+        // Note: In swift-corelibs-foundation, a bitwise comparison is first
+        // performed using fileprivate members not accessible here.
+        return NSDecimalCompare(&lhsVal, &rhsVal) == .orderedSame
+    }
+
+    public static func <(lhs: Decimal, rhs: Decimal) -> Bool {
+        var lhsVal = lhs
+        var rhsVal = rhs
+        return NSDecimalCompare(&lhsVal, &rhsVal) == .orderedAscending
+    }
+}
+
+extension Decimal : CustomStringConvertible {
+    public init?(string: __shared String, locale: __shared Locale? = nil) {
+        let scan = Scanner(string: string)
+        var theDecimal = Decimal()
+        scan.locale = locale
+        if !scan.scanDecimal(&theDecimal) {
+            return nil
+        }
+        self = theDecimal
+    }
+
+    // Note: In swift-corelibs-foundation, `NSDecimalString(_:_:)` is
+    // implemented in terms of `description`; here, it's the other way around.
+    public var description: String {
+        var value = self
+        return NSDecimalString(&value, nil)
+    }
+}
+
+extension Decimal : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case exponent
+        case length
+        case isNegative
+        case isCompact
+        case mantissa
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let exponent = try container.decode(CInt.self, forKey: .exponent)
+        let length = try container.decode(CUnsignedInt.self, forKey: .length)
+        let isNegative = try container.decode(Bool.self, forKey: .isNegative)
+        let isCompact = try container.decode(Bool.self, forKey: .isCompact)
+
+        var mantissaContainer = try container.nestedUnkeyedContainer(forKey: .mantissa)
+        var mantissa: (CUnsignedShort, CUnsignedShort, CUnsignedShort, CUnsignedShort,
+                       CUnsignedShort, CUnsignedShort, CUnsignedShort, CUnsignedShort) = (0,0,0,0,0,0,0,0)
+        mantissa.0 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.1 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.2 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.3 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.4 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.5 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.6 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.7 = try mantissaContainer.decode(CUnsignedShort.self)
+
+        self = Decimal(_exponent: exponent,
+                       _length: length,
+                       _isNegative: CUnsignedInt(isNegative ? 1 : 0),
+                       _isCompact: CUnsignedInt(isCompact ? 1 : 0),
+                       _reserved: 0,
+                       _mantissa: mantissa)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(_exponent, forKey: .exponent)
+        try container.encode(_length, forKey: .length)
+        try container.encode(_isNegative == 0 ? false : true, forKey: .isNegative)
+        try container.encode(_isCompact == 0 ? false : true, forKey: .isCompact)
+
+        var mantissaContainer = container.nestedUnkeyedContainer(forKey: .mantissa)
+        try mantissaContainer.encode(_mantissa.0)
+        try mantissaContainer.encode(_mantissa.1)
+        try mantissaContainer.encode(_mantissa.2)
+        try mantissaContainer.encode(_mantissa.3)
+        try mantissaContainer.encode(_mantissa.4)
+        try mantissaContainer.encode(_mantissa.5)
+        try mantissaContainer.encode(_mantissa.6)
+        try mantissaContainer.encode(_mantissa.7)
+    }
+}
+
+extension Decimal : ExpressibleByFloatLiteral {
+    public init(floatLiteral value: Double) {
+        self.init(value)
+    }
+}
+
+extension Decimal : ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int) {
+        self.init(value)
+    }
+}
+
+extension Decimal : SignedNumeric {
+    public var magnitude: Decimal {
+        guard _length != 0 else { return self }
+        return Decimal(
+            _exponent: self._exponent, _length: self._length,
+            _isNegative: 0, _isCompact: self._isCompact,
+            _reserved: 0, _mantissa: self._mantissa)
+    }
+
+    // FIXME(integers): implement properly
+    public init?<T : BinaryInteger>(exactly source: T) {
+        fatalError()
+    }
+
+    public static func +=(lhs: inout Decimal, rhs: Decimal) {
+        var rhs = rhs
+        _ = withUnsafeMutablePointer(to: &lhs) {
+            NSDecimalAdd($0, $0, &rhs, .plain)
+        }
+    }
+
+    public static func -=(lhs: inout Decimal, rhs: Decimal) {
+        var rhs = rhs
+        _ = withUnsafeMutablePointer(to: &lhs) {
+            NSDecimalSubtract($0, $0, &rhs, .plain)
+        }
+    }
+
+    public static func *=(lhs: inout Decimal, rhs: Decimal) {
+        var rhs = rhs
+        _ = withUnsafeMutablePointer(to: &lhs) {
+            NSDecimalMultiply($0, $0, &rhs, .plain)
+        }
+    }
+
+    public static func /=(lhs: inout Decimal, rhs: Decimal) {
+        var rhs = rhs
+        _ = withUnsafeMutablePointer(to: &lhs) {
+            NSDecimalDivide($0, $0, &rhs, .plain)
+        }
+    }
+
+    public static func +(lhs: Decimal, rhs: Decimal) -> Decimal {
+        var answer = lhs
+        answer += rhs
+        return answer
+    }
+
+    public static func -(lhs: Decimal, rhs: Decimal) -> Decimal {
+        var answer = lhs
+        answer -= rhs
+        return answer
+    }
+
+    public static func *(lhs: Decimal, rhs: Decimal) -> Decimal {
+        var answer = lhs
+        answer *= rhs
+        return answer
+    }
+
+    public static func /(lhs: Decimal, rhs: Decimal) -> Decimal {
+        var answer = lhs
+        answer /= rhs
+        return answer
+    }
+
+    public mutating func negate() {
+        guard _length != 0 else { return }
+        _isNegative = _isNegative == 0 ? 1 : 0
+    }
+}
+
+extension Decimal {
+    @available(swift, obsoleted: 4, message: "Please use arithmetic operators instead")
+    @_transparent
+    public mutating func add(_ other: Decimal) {
+        self += other
+    }
+
+    @available(swift, obsoleted: 4, message: "Please use arithmetic operators instead")
+    @_transparent
+    public mutating func subtract(_ other: Decimal) {
+        self -= other
+    }
+
+    @available(swift, obsoleted: 4, message: "Please use arithmetic operators instead")
+    @_transparent
+    public mutating func multiply(by other: Decimal) {
+        self *= other
+    }
+
+    @available(swift, obsoleted: 4, message: "Please use arithmetic operators instead")
+    @_transparent
+    public mutating func divide(by other: Decimal) {
+        self /= other
+    }
+}
+
+extension Decimal : Strideable {
+    public func distance(to other: Decimal) -> Decimal {
+        return self - other
+    }
+
+    public func advanced(by n: Decimal) -> Decimal {
+        return self + n
+    }
+}
+
+// The methods in this extension exist to match the protocol requirements of
+// FloatingPoint, even if we can't conform directly.
+//
+// If it becomes clear that conformance is truly impossible, we can deprecate
+// some of the methods (e.g. `isEqual(to:)` in favor of operators).
+extension Decimal {
+    public static let leastFiniteMagnitude = Decimal(
+        _exponent: 127,
+        _length: 8,
+        _isNegative: 1,
+        _isCompact: 1,
+        _reserved: 0,
+        _mantissa: (0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff)
+    )
+
+    public static let greatestFiniteMagnitude = Decimal(
+        _exponent: 127,
+        _length: 8,
+        _isNegative: 0,
+        _isCompact: 1,
+        _reserved: 0,
+        _mantissa: (0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff)
+    )
+
+    public static let leastNormalMagnitude = Decimal(
+        _exponent: -127,
+        _length: 1,
+        _isNegative: 0,
+        _isCompact: 1,
+        _reserved: 0,
+        _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000)
+    )
+
+    public static let leastNonzeroMagnitude = Decimal(
+        _exponent: -127,
+        _length: 1,
+        _isNegative: 0,
+        _isCompact: 1,
+        _reserved: 0,
+        _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000)
+    )
+
+    public static let pi = Decimal(
+        _exponent: -38,
+        _length: 8,
+        _isNegative: 0,
+        _isCompact: 1,
+        _reserved: 0,
+        _mantissa: (0x6623, 0x7d57, 0x16e7, 0xad0d, 0xaf52, 0x4641, 0xdfa7, 0xec58)
+    )
+
+    @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
+    public static var infinity: Decimal { fatalError("Decimal does not yet fully adopt FloatingPoint") }
+
+    @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
+    public static var signalingNaN: Decimal { fatalError("Decimal does not yet fully adopt FloatingPoint") }
+
+    public static var quietNaN: Decimal {
+        return Decimal(
+            _exponent: 0, _length: 0, _isNegative: 1, _isCompact: 0,
+            _reserved: 0, _mantissa: (0, 0, 0, 0, 0, 0, 0, 0))
+    }
+
+    public static var nan: Decimal { quietNaN }
+
+    public static var radix: Int { 10 }
+
+    public init(_ value: UInt8) {
+        self.init(UInt64(value))
+    }
+    
+    public init(_ value: Int8) {
+        self.init(Int64(value))
+    }
+    
+    public init(_ value: UInt16) {
+        self.init(UInt64(value))
+    }
+    
+    public init(_ value: Int16) {
+        self.init(Int64(value))
+    }
+    
+    public init(_ value: UInt32) {
+        self.init(UInt64(value))
+    }
+    
+    public init(_ value: Int32) {
+        self.init(Int64(value))
+    }
+
+    public init(_ value: UInt64) {
+        self = Decimal()
+        if value == 0 {
+            return
+        }
+
+        var compactValue = value
+        var exponent: Int32 = 0
+        while compactValue % 10 == 0 {
+            compactValue /= 10
+            exponent += 1
+        }
+        _isCompact = 1
+        _exponent = exponent
+
+        let wordCount = ((UInt64.bitWidth - compactValue.leadingZeroBitCount) + (UInt16.bitWidth - 1)) / UInt16.bitWidth
+        _length = UInt32(wordCount)
+        _mantissa.0 = UInt16(truncatingIfNeeded: compactValue >> 0)
+        _mantissa.1 = UInt16(truncatingIfNeeded: compactValue >> 16)
+        _mantissa.2 = UInt16(truncatingIfNeeded: compactValue >> 32)
+        _mantissa.3 = UInt16(truncatingIfNeeded: compactValue >> 48)
+    }
+    
+    public init(_ value: Int64) {
+        self.init(value.magnitude)
+        if value < 0 {
+            _isNegative = 1
+        }
+    }
+    
+    public init(_ value: UInt) {
+        self.init(UInt64(value))
+    }
+    
+    public init(_ value: Int) {
+        self.init(Int64(value))
+    }
+
+    public init(_ value: Double) {
+        precondition(!value.isInfinite, "Decimal does not yet fully adopt FloatingPoint")
+        if value.isNaN {
+            self = Decimal.nan
+        } else if value == 0.0 {
+            self = Decimal()
+        } else {
+            self = Decimal()
+            let negative = value < 0
+            var val = negative ? -1 * value : value
+            var exponent = 0
+            while val < Double(UInt64.max - 1) {
+                val *= 10.0
+                exponent -= 1
+            }
+            while Double(UInt64.max - 1) < val {
+                val /= 10.0
+                exponent += 1
+            }
+            var mantissa = UInt64(val)
+
+            var i: UInt32 = 0
+            // This is a bit ugly but it is the closest approximation of the C
+            // initializer that can be expressed here.
+            while mantissa != 0 && i < 8 /* NSDecimalMaxSize */ {
+                switch i {
+                case 0:
+                    _mantissa.0 = UInt16(truncatingIfNeeded: mantissa)
+                case 1:
+                    _mantissa.1 = UInt16(truncatingIfNeeded: mantissa)
+                case 2:
+                    _mantissa.2 = UInt16(truncatingIfNeeded: mantissa)
+                case 3:
+                    _mantissa.3 = UInt16(truncatingIfNeeded: mantissa)
+                case 4:
+                    _mantissa.4 = UInt16(truncatingIfNeeded: mantissa)
+                case 5:
+                    _mantissa.5 = UInt16(truncatingIfNeeded: mantissa)
+                case 6:
+                    _mantissa.6 = UInt16(truncatingIfNeeded: mantissa)
+                case 7:
+                    _mantissa.7 = UInt16(truncatingIfNeeded: mantissa)
+                default:
+                    fatalError("initialization overflow")
+                }
+                mantissa = mantissa >> 16
+                i += 1
+            }
+            _length = i
+            _isNegative = negative ? 1 : 0
+            _isCompact = 0
+            _exponent = Int32(exponent)
+            NSDecimalCompact(&self)
+        }
+    }
+
+    public init(sign: FloatingPointSign, exponent: Int, significand: Decimal) {
+        self.init(
+            _exponent: Int32(exponent) + significand._exponent,
+            _length: significand._length,
+            _isNegative: sign == .plus ? 0 : 1,
+            _isCompact: significand._isCompact,
+            _reserved: 0,
+            _mantissa: significand._mantissa)
+    }
+
+    public init(signOf: Decimal, magnitudeOf magnitude: Decimal) {
+        self.init(
+            _exponent: magnitude._exponent,
+            _length: magnitude._length,
+            _isNegative: signOf._isNegative,
+            _isCompact: magnitude._isCompact,
+            _reserved: 0,
+            _mantissa: magnitude._mantissa)
+    }
+
+    public var exponent: Int {
+        return Int(_exponent)
+    }
+
+    public var significand: Decimal {
+        return Decimal(
+            _exponent: 0, _length: _length, _isNegative: _isNegative, _isCompact: _isCompact,
+            _reserved: 0, _mantissa: _mantissa)
+    }
+
+    public var sign: FloatingPointSign {
+        return _isNegative == 0 ? FloatingPointSign.plus : FloatingPointSign.minus
+    }
+
+    public var ulp: Decimal {
+        if !self.isFinite { return Decimal.nan }
+        return Decimal(
+            _exponent: _exponent, _length: 8, _isNegative: 0, _isCompact: 1,
+            _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
+    }
+
+    public var nextUp: Decimal {
+        return self + Decimal(
+            _exponent: _exponent, _length: 1, _isNegative: 0, _isCompact: 1,
+            _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
+    }
+
+    public var nextDown: Decimal {
+        return self - Decimal(
+            _exponent: _exponent, _length: 1, _isNegative: 0, _isCompact: 1,
+            _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
+    }
+
+    /// The IEEE 754 "class" of this type.
+    public var floatingPointClass: FloatingPointClassification {
+        if _length == 0 && _isNegative == 1 {
+            return .quietNaN
+        } else if _length == 0 {
+            return .positiveZero
+        }
+        // NSDecimal does not really represent normal and subnormal in the same
+        // manner as the IEEE standard, for now we can probably claim normal for
+        // any nonzero, non-NaN values.
+        if _isNegative == 1 {
+            return .negativeNormal
+        } else {
+            return .positiveNormal
+        }
+    }
+
+    public var isCanonical: Bool { true }
+
+    /// `true` if `self` is negative, `false` otherwise.
+    public var isSignMinus: Bool { _isNegative != 0 }
+
+    /// `true` if `self` is +0.0 or -0.0, `false` otherwise.
+    public var isZero: Bool { _length == 0 && _isNegative == 0 }
+
+    /// `true` if `self` is subnormal, `false` otherwise.
+    public var isSubnormal: Bool { false }
+
+    /// `true` if `self` is normal (not zero, subnormal, infinity, or NaN),
+    /// `false` otherwise.
+    public var isNormal: Bool { !isZero && !isInfinite && !isNaN }
+
+    /// `true` if `self` is zero, subnormal, or normal (not infinity or NaN),
+    /// `false` otherwise.
+    public var isFinite: Bool { !isNaN }
+
+    /// `true` if `self` is infinity, `false` otherwise.
+    public var isInfinite: Bool { false }
+
+    /// `true` if `self` is NaN, `false` otherwise.
+    public var isNaN: Bool { _length == 0 && _isNegative == 1 }
+
+    /// `true` if `self` is a signaling NaN, `false` otherwise.
+    public var isSignaling: Bool { false }
+
+    /// `true` if `self` is a signaling NaN, `false` otherwise.
+    public var isSignalingNaN: Bool { false }
+
+    public func isEqual(to other: Decimal) -> Bool {
+        var lhs = self
+        var rhs = other
+        return NSDecimalCompare(&lhs, &rhs) == .orderedSame
+    }
+
+    public func isLess(than other: Decimal) -> Bool {
+        var lhs = self
+        var rhs = other
+        return NSDecimalCompare(&lhs, &rhs) == .orderedAscending
+    }
+
+    public func isLessThanOrEqualTo(_ other: Decimal) -> Bool {
+        var lhs = self
+        var rhs = other
+        let order = NSDecimalCompare(&lhs, &rhs)
+        return order == .orderedAscending || order == .orderedSame
+    }
+
+    public func isTotallyOrdered(belowOrEqualTo other: Decimal) -> Bool {
+        // Note: Decimal does not have -0 or infinities to worry about
+        if self.isNaN {
+            return false
+        }
+        if self < other {
+            return true
+        }
+        if other < self {
+            return false
+        }
+        // Fall through to == behavior
+        return true
+    }
+
+    @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
+    public mutating func formTruncatingRemainder(dividingBy other: Decimal) { fatalError("Decimal does not yet fully adopt FloatingPoint") }
+}
+
+extension Decimal : _ObjectiveCBridgeable {
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSDecimalNumber {
+        return NSDecimalNumber(decimal: self)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSDecimalNumber, result: inout Decimal?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ input: NSDecimalNumber, result: inout Decimal?) -> Bool {
+        result = input.decimalValue
+        return true
+    }
+
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSDecimalNumber?) -> Decimal {
+        guard let src = source else { return Decimal(_exponent: 0, _length: 0, _isNegative: 0, _isCompact: 0, _reserved: 0, _mantissa: (0, 0, 0, 0, 0, 0, 0, 0)) }
+        return src.decimalValue
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/DispatchData+DataProtocol.swift
+++ b/Darwin/Foundation-swiftoverlay/DispatchData+DataProtocol.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+
+import Dispatch
+
+extension DispatchData : DataProtocol {
+    public struct Region : DataProtocol, ContiguousBytes {
+        internal let bytes: UnsafeBufferPointer<UInt8>
+        internal let index: DispatchData.Index
+        internal let owner: DispatchData
+        internal init(bytes: UnsafeBufferPointer<UInt8>, index: DispatchData.Index, owner: DispatchData) {
+            self.bytes = bytes
+            self.index = index
+            self.owner = owner
+        }
+
+        public var regions: CollectionOfOne<Region> {
+            return CollectionOfOne(self)
+        }
+
+        public subscript(position: DispatchData.Index) -> UInt8 {
+            precondition(index <= position && position <= index + bytes.count)
+            return bytes[position - index]
+        }
+
+        public var startIndex: DispatchData.Index {
+            return index
+        }
+
+        public var endIndex: DispatchData.Index {
+            return index + bytes.count
+        }
+
+        public func withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
+            return try body(UnsafeRawBufferPointer(bytes))
+        }
+    }
+
+    public var regions: [Region] {
+        var regions = [Region]()
+        enumerateBytes { (bytes, index, stop) in
+            regions.append(Region(bytes: bytes, index: index, owner: self))
+        }
+        return regions
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/FileManager.swift
+++ b/Darwin/Foundation-swiftoverlay/FileManager.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+@_implementationOnly import _FoundationOverlayShims
+
+extension FileManager {
+    /*
+     renamed syntax should be:
+     public func replaceItem(at originalItemURL: URL, withItemAt newItemURL: URL, backupItemName: String? = nil, options : FileManager.ItemReplacementOptions = []) throws -> URL?
+    */
+    
+    @available(*, deprecated, renamed:"replaceItemAt(_:withItemAt:backupItemName:options:)")
+    public func replaceItemAtURL(originalItemURL: NSURL, withItemAtURL newItemURL: NSURL, backupItemName: String? = nil, options: FileManager.ItemReplacementOptions = []) throws -> NSURL? {
+        var error: NSError? = nil
+        guard let result = __NSFileManagerReplaceItemAtURL(self, originalItemURL as URL, newItemURL as URL, backupItemName, options, &error) else { throw error! }
+        return result as NSURL
+    }
+
+    @available(swift, obsoleted: 4)
+    @available(macOS 10.6, iOS 4.0, *)
+    public func replaceItemAt(_ originalItemURL: URL, withItemAt newItemURL: URL, backupItemName: String? = nil, options: FileManager.ItemReplacementOptions = []) throws -> NSURL? {
+        var error: NSError?
+        guard let result = __NSFileManagerReplaceItemAtURL(self, originalItemURL, newItemURL , backupItemName, options, &error) else { throw error! }
+        return result as NSURL
+    }
+    
+    @available(swift, introduced: 4)
+    @available(macOS 10.6, iOS 4.0, *)
+    public func replaceItemAt(_ originalItemURL: URL, withItemAt newItemURL: URL, backupItemName: String? = nil, options: FileManager.ItemReplacementOptions = []) throws -> URL? {
+        var error: NSError?
+        guard let result = __NSFileManagerReplaceItemAtURL(self, originalItemURL, newItemURL , backupItemName, options, &error) else { throw error! }
+        return result
+    }
+
+    @available(macOS 10.6, iOS 4.0, *)
+    @nonobjc
+    public func enumerator(at url: URL, includingPropertiesForKeys keys: [URLResourceKey]?, options mask: FileManager.DirectoryEnumerationOptions = [], errorHandler handler: ((URL, Error) -> Bool)? = nil) -> FileManager.DirectoryEnumerator? {
+        return __NSFileManagerEnumeratorAtURL(self, url, keys, mask, { (url, error) in
+            var errorResult = true
+            if let h = handler {
+                errorResult = h(url, error)
+            }
+            return errorResult
+        })
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/Foundation.swift
+++ b/Darwin/Foundation-swiftoverlay/Foundation.swift
@@ -1,0 +1,245 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+import CoreFoundation
+import CoreGraphics
+
+//===----------------------------------------------------------------------===//
+// NSObject
+//===----------------------------------------------------------------------===//
+
+// These conformances should be located in the `ObjectiveC` module, but they can't
+// be placed there because string bridging is not available there.
+extension NSObject : CustomStringConvertible {}
+extension NSObject : CustomDebugStringConvertible {}
+
+public let NSNotFound: Int = .max
+
+//===----------------------------------------------------------------------===//
+// NSLocalizedString
+//===----------------------------------------------------------------------===//
+
+/// Returns the localized version of a string.
+///
+/// - parameter key: An identifying value used to reference a localized string.
+///   Don't use the empty string as a key. Values keyed by the empty string will
+///   not be localized.
+/// - parameter tableName: The name of the table containing the localized string
+///   identified by `key`. This is the prefix of the strings file—a file with
+///   the `.strings` extension—containing the localized values. If `tableName`
+///   is `nil` or the empty string, the `Localizable` table is used.
+/// - parameter bundle: The bundle containing the table's strings file. The main
+///   bundle is used by default.
+/// - parameter value: A user-visible string to return when the localized string
+///   for `key` cannot be found in the table. If `value` is the empty string,
+///   `key` would be returned instead.
+/// - parameter comment: A note to the translator describing the context where
+///   the localized string is presented to the user.
+///
+/// - returns: A localized version of the string designated by `key` in the
+///   table identified by `tableName`. If the localized string for `key` cannot
+///   be found within the table, `value` is returned. However, `key` is returned
+///   instead when `value` is the empty string.
+///
+/// Export Localizations with Xcode
+/// -------------------------------
+///
+/// Xcode can read through a project's code to find invocations of
+/// `NSLocalizedString(_:tableName:bundle:value:comment:)` and automatically
+/// generate the appropriate strings files for the project's base localization.
+///
+/// In Xcode, open the project file and, in the `Edit` menu, select
+/// `Export for Localization`. This will generate an XLIFF bundle containing
+/// strings files derived from your code along with other localizable assets.
+/// `xcodebuild` can also be used to generate the localization bundle from the
+/// command line with the `exportLocalizations` option.
+///
+///     xcodebuild -exportLocalizations -project <projectname>.xcodeproj \
+///                                     -localizationPath <path>
+///
+/// These bundles can be sent to translators for localization, and then
+/// reimported into your Xcode project. In Xcode, open the project file. In the
+/// `Edit` menu, select `Import Localizations...`, and select the XLIFF
+/// folder to import. You can also use `xcodebuild` to import localizations with
+/// the `importLocalizations` option.
+///
+///     xcodebuild -importLocalizations -project <projectname>.xcodeproj \
+///                                     -localizationPath <path>
+///
+/// Choose Meaningful Keys
+/// ----------------------
+///
+/// Words can often have multiple different meanings depending on the context
+/// in which they're used. For example, the word "Book" can be used as a noun—a
+/// printed literary work—and it can be used as a verb—the action of making a
+/// reservation. Words with different meanings which share the same spelling are
+/// heteronyms.
+///
+/// Different languages often have different heteronyms. "Book" in English is
+/// one such heteronym, but that's not so in French, where the noun translates
+/// to "Livre", and the verb translates to "Réserver". For this reason, it's
+/// important make sure that each use of the same phrase is translated
+/// appropriately for its context by assigning unique keys to each phrase and
+/// adding a description comment describing how that phrase is used.
+///
+///     NSLocalizedString("book-tag-title", value: "Book", comment: """
+///     noun: A label attached to literary items in the library.
+///     """)
+///
+///     NSLocalizedString("book-button-title", value: "Book", comment: """
+///     verb: Title of the button that makes a reservation.
+///     """)
+///
+/// Use Only String Literals
+/// ------------------------
+///
+/// String literal values must be used with `key`, `tableName`, `value`, and
+/// `comment`.
+///
+/// Xcode does not evaluate interpolated strings and string variables when
+/// generating strings files from code. Attempting to localize a string using
+/// those language features will cause Xcode to export something that resembles
+/// the original code expression instead of its expected value at runtime.
+/// Translators would then translate that exported value—leaving
+/// international users with a localized string containing code.
+///
+///     // Translators will see "1 + 1 = (1 + 1)".
+///     // International users will see a localization "1 + 1 = (1 + 1)".
+///     let localizedString = NSLocalizedString("string-interpolation",
+///                                             value: "1 + 1 = \(1 + 1)"
+///                                             comment: "A math equation.")
+///
+/// To dynamically insert values within localized strings, set `value` to a
+/// format string, and use `String.localizedStringWithFormat(_:_:)` to insert
+/// those values.
+///
+///     // Translators will see "1 + 1 = %d" (they know what "%d" means).
+///     // International users will see a localization of "1 + 1 = 2".
+///     let format = NSLocalizedString("string-literal",
+///                                    value: "1 + 1 = %d",
+///                                    comment: "A math equation.")
+///     let localizedString = String.localizedStringWithFormat(format, (1 + 1))
+///
+/// Multiline string literals are technically supported, but will result in
+/// unexpected behavior during internationalization. A newline will be inserted
+/// before and after the body of text within the string, and translators will
+/// likely preserve those in their internationalizations.
+///
+/// To preserve some of the aesthetics of having newlines in the string mirrored
+/// in their code representation, string literal concatenation with the `+`
+/// operator can be used.
+///
+///     NSLocalizedString("multiline-string-literal",
+///                       value: """
+///     This multiline string literal won't work as expected.
+///     An extra newline is added to the beginning and end of the string.
+///     """,
+///                       comment: "The description of a sample of code.")
+///
+///     NSLocalizedString("string-literal-contatenation",
+///                       value: "This string literal concatenated with"
+///                            + "this other string literal works just fine.",
+///                       comment: "The description of a sample of code.")
+///
+/// Since comments aren't localized, multiline string literals can be safely
+/// used with `comment`.
+///
+/// Work with Manually Managed Strings
+/// ----------------------------------
+///
+/// If having Xcode generate strings files from code isn't desired behavior,
+/// call `Bundle.localizedString(forKey:value:table:)` instead.
+///
+///     let greeting = Bundle.localizedString(forKey: "program-greeting",
+///                                           value: "Hello, World!",
+///                                           table: "Localization")
+///
+/// However, this requires the manual creation and management of that table's
+/// strings file.
+///
+///     /* Localization.strings */
+///
+///     /* A friendly greeting to the user when the program starts. */
+///     "program-greeting" = "Hello, World!";
+///
+/// - note: Although `NSLocalizedString(_:tableName:bundle:value:comment:)`
+/// and `Bundle.localizedString(forKey:value:table:)` can be used in a project
+/// at the same time, data from manually managed strings files will be
+/// overwritten by Xcode when their table is also used to look up localized
+/// strings with `NSLocalizedString(_:tableName:bundle:value:comment:)`.
+public
+func NSLocalizedString(_ key: String,
+                       tableName: String? = nil,
+                       bundle: Bundle = Bundle.main,
+                       value: String = "",
+                       comment: String) -> String {
+  return bundle.localizedString(forKey: key, value:value, table:tableName)
+}
+
+//===----------------------------------------------------------------------===//
+// NSLog
+//===----------------------------------------------------------------------===//
+
+public func NSLog(_ format: String, _ args: CVarArg...) {
+  withVaList(args) { NSLogv(format, $0) }
+}
+
+//===----------------------------------------------------------------------===//
+// AnyHashable
+//===----------------------------------------------------------------------===//
+
+extension AnyHashable : _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSObject {
+    // This is unprincipled, but pretty much any object we'll encounter in
+    // Swift is NSObject-conforming enough to have -hash and -isEqual:.
+    return unsafeBitCast(base as AnyObject, to: NSObject.self)
+  }
+
+  public static func _forceBridgeFromObjectiveC(
+    _ x: NSObject,
+    result: inout AnyHashable?
+  ) {
+    result = AnyHashable(x)
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSObject,
+    result: inout AnyHashable?
+  ) -> Bool {
+    self._forceBridgeFromObjectiveC(x, result: &result)
+    return result != nil
+  }
+
+  @_effects(readonly)
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ source: NSObject?
+  ) -> AnyHashable {
+    // `nil` has historically been used as a stand-in for an empty
+    // string; map it to an empty string.
+    if _slowPath(source == nil) { return AnyHashable(String()) }
+    return AnyHashable(source!)
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// CVarArg for bridged types
+//===----------------------------------------------------------------------===//
+
+extension CVarArg where Self: _ObjectiveCBridgeable {
+  /// Default implementation for bridgeable types.
+  public var _cVarArgEncoding: [Int] {
+    let object = self._bridgeToObjectiveC()
+    _autorelease(object)
+    return _encodeBitsAsWords(object)
+  }
+}

--- a/Darwin/Foundation-swiftoverlay/Foundation.xcconfig
+++ b/Darwin/Foundation-swiftoverlay/Foundation.xcconfig
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "../Config/overlay-shared.xcconfig"
+
+PRODUCT_NAME = Foundation
+SWIFT_VERSION = 5.0
+OTHER_LDFLAGS = $(inherited) -framework Foundation
+
+// Shims are helper declarations that are only needed to compile the
+// implementation of this overlay. They are defined in a headers-only module
+// in the project folder that isn't installed anywhere.
+SWIFT_INCLUDE_PATHS = $(inherited) shims
+
+// Aggravating special case: we need to add shims to the system header search
+// path, so that NSUInteger gets imported as Int, not UInt. The shims originally
+// shipped in the SDK, so they were written to depend on this. (c.f. rdar://17473606)
+SYSTEM_HEADER_SEARCH_PATHS = $(inherited) shims
+
+// Use 0.0.0 as the version number for development builds.
+CURRENT_PROJECT_VERSION = 0.0.0
+DYLIB_CURRENT_VERSION = $(CURRENT_PROJECT_VERSION)
+MODULE_VERSION = $(CURRENT_PROJECT_VERSION)

--- a/Darwin/Foundation-swiftoverlay/IndexPath.swift
+++ b/Darwin/Foundation-swiftoverlay/IndexPath.swift
@@ -1,0 +1,767 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+@_implementationOnly import _FoundationOverlayShims
+
+/**
+ `IndexPath` represents the path to a specific node in a tree of nested array collections.
+ 
+ Each index in an index path represents the index into an array of children from one node in the tree to another, deeper, node.
+ */
+public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableCollection, RandomAccessCollection, Comparable, ExpressibleByArrayLiteral {
+    public typealias ReferenceType = NSIndexPath
+    public typealias Element = Int
+    public typealias Index = Array<Int>.Index
+    public typealias Indices = DefaultIndices<IndexPath>
+    
+    fileprivate enum Storage : ExpressibleByArrayLiteral {
+        typealias Element = Int
+        case empty
+        case single(Int)
+        case pair(Int, Int)
+        case array([Int])
+        
+        init(arrayLiteral elements: Int...) {
+            self.init(elements)
+        }
+        
+        init(_ elements: [Int]) {
+            switch elements.count {
+            case 0:
+                self = .empty
+            case 1:
+                self = .single(elements[0])
+            case 2:
+                self = .pair(elements[0], elements[1])
+            default:
+                self = .array(elements)
+            }
+        }
+        
+        func dropLast() -> Storage {
+            switch self {
+            case .empty:
+                return .empty
+            case .single(_):
+                return .empty
+            case .pair(let first, _):
+                return .single(first)
+            case .array(let indexes):
+                switch indexes.count {
+                case 3:
+                    return .pair(indexes[0], indexes[1])
+                default:
+                    return .array(Array<Int>(indexes.dropLast()))
+                }
+            }
+        }
+        
+        mutating func append(_ other: Int) {
+            switch self {
+            case .empty:
+                self = .single(other)
+            case .single(let first):
+                self = .pair(first, other)
+            case .pair(let first, let second):
+                self = .array([first, second, other])
+            case .array(let indexes):
+                self = .array(indexes + [other])
+            }
+        }
+        
+        mutating func append(contentsOf other: Storage) {
+            switch self {
+            case .empty:
+                switch other {
+                case .empty:
+                    // DO NOTHING
+                    break
+                case .single(let rhsIndex):
+                    self = .single(rhsIndex)
+                case .pair(let rhsFirst, let rhsSecond):
+                    self = .pair(rhsFirst, rhsSecond)
+                case .array(let rhsIndexes):
+                    self = .array(rhsIndexes)
+                }
+            case .single(let lhsIndex):
+                switch other {
+                case .empty:
+                    // DO NOTHING
+                    break
+                case .single(let rhsIndex):
+                    self = .pair(lhsIndex, rhsIndex)
+                case .pair(let rhsFirst, let rhsSecond):
+                    self = .array([lhsIndex, rhsFirst, rhsSecond])
+                case .array(let rhsIndexes):
+                    self = .array([lhsIndex] + rhsIndexes)
+                }
+            case .pair(let lhsFirst, let lhsSecond):
+                switch other {
+                case .empty:
+                    // DO NOTHING
+                    break
+                case .single(let rhsIndex):
+                    self = .array([lhsFirst, lhsSecond, rhsIndex])
+                case .pair(let rhsFirst, let rhsSecond):
+                    self = .array([lhsFirst, lhsSecond, rhsFirst, rhsSecond])
+                case .array(let rhsIndexes):
+                    self = .array([lhsFirst, lhsSecond] + rhsIndexes)
+                }
+            case .array(let lhsIndexes):
+                switch other {
+                case .empty:
+                    // DO NOTHING
+                    break
+                case .single(let rhsIndex):
+                    self = .array(lhsIndexes + [rhsIndex])
+                case .pair(let rhsFirst, let rhsSecond):
+                    self = .array(lhsIndexes + [rhsFirst, rhsSecond])
+                case .array(let rhsIndexes):
+                    self = .array(lhsIndexes + rhsIndexes)
+                }
+            }
+        }
+        
+        mutating func append(contentsOf other: __owned [Int]) {
+            switch self {
+            case .empty:
+                switch other.count {
+                case 0:
+                    // DO NOTHING
+                    break
+                case 1:
+                    self = .single(other[0])
+                case 2:
+                    self = .pair(other[0], other[1])
+                default:
+                    self = .array(other)
+                }
+            case .single(let first):
+                switch other.count {
+                case 0:
+                    // DO NOTHING
+                    break
+                case 1:
+                    self = .pair(first, other[0])
+                default:
+                    self = .array([first] + other)
+                }
+            case .pair(let first, let second):
+                switch other.count {
+                case 0:
+                    // DO NOTHING
+                    break
+                default:
+                    self = .array([first, second] + other)
+                }
+            case .array(let indexes):
+                self = .array(indexes + other)
+            }
+        }
+        
+        subscript(_ index: Int) -> Int {
+            get {
+                switch self {
+                case .empty:
+                    fatalError("Index \(index) out of bounds of count 0")
+                case .single(let first):
+                    precondition(index == 0, "Index \(index) out of bounds of count 1")
+                    return first
+                case .pair(let first, let second):
+                    precondition(index >= 0 && index < 2, "Index \(index) out of bounds of count 2")
+                    return index == 0 ? first : second
+                case .array(let indexes):
+                    return indexes[index]
+                }
+            }
+            set {
+                switch self {
+                case .empty:
+                    fatalError("Index \(index) out of bounds of count 0")
+                case .single(_):
+                    precondition(index == 0, "Index \(index) out of bounds of count 1")
+                    self = .single(newValue)
+                case .pair(let first, let second):
+                    precondition(index >= 0 && index < 2, "Index \(index) out of bounds of count 2")
+                    if index == 0 {
+                        self = .pair(newValue, second)
+                    } else {
+                        self = .pair(first, newValue)
+                    }
+                case .array(let indexes_):
+                    var indexes = indexes_
+                    indexes[index] = newValue
+                    self = .array(indexes)
+                }
+            }
+        }
+        
+        subscript(range: Range<Index>) -> Storage {
+            get {
+                switch self {
+                case .empty:
+                    switch (range.lowerBound, range.upperBound) {
+                    case (0, 0):
+                        return .empty
+                    default:
+                        fatalError("Range \(range) is out of bounds of count 0")
+                    }
+                case .single(let index):
+                    switch (range.lowerBound, range.upperBound) {
+                    case (0, 0),
+                         (1, 1):
+                        return .empty
+                    case (0, 1):
+                        return .single(index)
+                    default:
+                        fatalError("Range \(range) is out of bounds of count 1")
+                    }
+                case .pair(let first, let second):
+                    switch (range.lowerBound, range.upperBound) {
+                    case (0, 0),
+                         (1, 1),
+                         (2, 2):
+                        return .empty
+                    case (0, 1):
+                        return .single(first)
+                    case (1, 2):
+                        return .single(second)
+                    case (0, 2):
+                        return self
+                    default:
+                        fatalError("Range \(range) is out of bounds of count 2")
+                    }
+                case .array(let indexes):
+                    let slice = indexes[range]
+                    switch slice.count {
+                    case 0:
+                        return .empty
+                    case 1:
+                        return .single(slice.first!)
+                    case 2:
+                        return .pair(slice.first!, slice.last!)
+                    default:
+                        return .array(Array<Int>(slice))
+                    }
+                }
+            }
+            set {
+                switch self {
+                case .empty:
+                    precondition(range.lowerBound == 0 && range.upperBound == 0, "Range \(range) is out of bounds of count 0")
+                    self = newValue
+                case .single(let index):
+                    switch (range.lowerBound, range.upperBound, newValue) {
+                    case (0, 0, .empty),
+                         (1, 1, .empty):
+                        break
+                    case (0, 0, .single(let other)):
+                        self = .pair(other, index)
+                    case (0, 0, .pair(let first, let second)):
+                        self = .array([first, second, index])
+                    case (0, 0, .array(let other)):
+                        self = .array(other + [index])
+                    case (0, 1, .empty),
+                         (0, 1, .single),
+                         (0, 1, .pair),
+                         (0, 1, .array):
+                        self = newValue
+                    case (1, 1, .single(let other)):
+                        self = .pair(index, other)
+                    case (1, 1, .pair(let first, let second)):
+                        self = .array([index, first, second])
+                    case (1, 1, .array(let other)):
+                        self = .array([index] + other)
+                    default:
+                        fatalError("Range \(range) is out of bounds of count 1")
+                    }
+                case .pair(let first, let second):
+                    switch (range.lowerBound, range.upperBound) {
+                    case (0, 0):
+                        switch newValue {
+                        case .empty:
+                            break
+                        case .single(let other):
+                            self = .array([other, first, second])
+                        case .pair(let otherFirst, let otherSecond):
+                            self = .array([otherFirst, otherSecond, first, second])
+                        case .array(let other):
+                            self = .array(other + [first, second])
+                        }
+                    case (0, 1):
+                        switch newValue {
+                        case .empty:
+                            self = .single(second)
+                        case .single(let other):
+                            self = .pair(other, second)
+                        case .pair(let otherFirst, let otherSecond):
+                            self = .array([otherFirst, otherSecond, second])
+                        case .array(let other):
+                            self = .array(other + [second])
+                        }
+                    case (0, 2):
+                        self = newValue
+                    case (1, 2):
+                        switch newValue {
+                        case .empty:
+                            self = .single(first)
+                        case .single(let other):
+                            self = .pair(first, other)
+                        case .pair(let otherFirst, let otherSecond):
+                            self = .array([first, otherFirst, otherSecond])
+                        case .array(let other):
+                            self = .array([first] + other)
+                        }
+                    case (2, 2):
+                        switch newValue {
+                        case .empty:
+                            break
+                        case .single(let other):
+                            self = .array([first, second, other])
+                        case .pair(let otherFirst, let otherSecond):
+                            self = .array([first, second, otherFirst, otherSecond])
+                        case .array(let other):
+                            self = .array([first, second] + other)
+                        }
+                    default:
+                        fatalError("Range \(range) is out of bounds of count 2")
+                    }
+                case .array(let indexes):
+                    var newIndexes = indexes
+                    newIndexes.removeSubrange(range)
+                    switch newValue {
+                    case .empty:
+                        break
+                    case .single(let index):
+                        newIndexes.insert(index, at: range.lowerBound)
+                    case .pair(let first, let second):
+                        newIndexes.insert(first, at: range.lowerBound)
+                        newIndexes.insert(second, at: range.lowerBound + 1)
+                    case .array(let other):
+                        newIndexes.insert(contentsOf: other, at: range.lowerBound)
+                    }
+                    self = Storage(newIndexes)
+                }
+            }
+        }
+        
+        var count: Int {
+            switch self {
+            case .empty:
+                return 0
+            case .single:
+                return 1
+            case .pair:
+                return 2
+            case .array(let indexes):
+                return indexes.count
+            }
+        }
+        
+        var startIndex: Int {
+            return 0
+        }
+        
+        var endIndex: Int {
+            return count
+        }
+
+        var allValues: [Int] {
+            switch self {
+            case .empty: return []
+            case .single(let index): return [index]
+            case .pair(let first, let second): return [first, second]
+            case .array(let indexes): return indexes
+            }
+        }
+        
+        func index(before i: Int) -> Int {
+            return i - 1
+        }
+        
+        func index(after i: Int) -> Int {
+            return i + 1
+        }
+        
+        var description: String {
+            switch self {
+            case .empty:
+                return "[]"
+            case .single(let index):
+                return "[\(index)]"
+            case .pair(let first, let second):
+                return "[\(first), \(second)]"
+            case .array(let indexes):
+                return indexes.description
+            }
+        }
+        
+        func withUnsafeBufferPointer<R>(_ body: (UnsafeBufferPointer<Int>) throws -> R) rethrows -> R {
+            switch self {
+            case .empty:
+                return try body(UnsafeBufferPointer<Int>(start: nil, count: 0))
+            case .single(let index_):
+                var index = index_
+                return try withUnsafePointer(to: &index) { (start) throws -> R in
+                    return try body(UnsafeBufferPointer<Int>(start: start, count: 1))
+                }
+            case .pair(let first, let second):
+                var pair = (first, second)
+                return try withUnsafeBytes(of: &pair) { (rawBuffer: UnsafeRawBufferPointer) throws -> R in
+                    return try body(UnsafeBufferPointer<Int>(start: rawBuffer.baseAddress?.assumingMemoryBound(to: Int.self), count: 2))
+                }
+            case .array(let indexes):
+                return try indexes.withUnsafeBufferPointer(body)
+            }
+        }
+        
+        var debugDescription: String { return description }
+        
+        static func +(lhs: Storage, rhs: Storage) -> Storage {
+            var res = lhs
+            res.append(contentsOf: rhs)
+            return res
+        }
+        
+        static func +(lhs: Storage, rhs: [Int]) -> Storage {
+            var res = lhs
+            res.append(contentsOf: rhs)
+            return res
+        }
+        
+        static func ==(lhs: Storage, rhs: Storage) -> Bool {
+            switch (lhs, rhs) {
+            case (.empty, .empty):
+                return true
+            case (.single(let lhsIndex), .single(let rhsIndex)):
+                return lhsIndex == rhsIndex
+            case (.pair(let lhsFirst, let lhsSecond), .pair(let rhsFirst, let rhsSecond)):
+                return lhsFirst == rhsFirst && lhsSecond == rhsSecond
+            case (.array(let lhsIndexes), .array(let rhsIndexes)):
+                return lhsIndexes == rhsIndexes
+            default:
+                return false
+            }
+        }
+    }
+    
+    fileprivate var _indexes : Storage
+    
+    /// Initialize an empty index path.
+    public init() {
+        _indexes = []
+    }
+    
+    /// Initialize with a sequence of integers.
+    public init<ElementSequence : Sequence>(indexes: ElementSequence)
+        where ElementSequence.Iterator.Element == Element {
+            _indexes = Storage(indexes.map { $0 })
+    }
+    
+    /// Initialize with an array literal.
+    public init(arrayLiteral indexes: Element...) {
+        _indexes = Storage(indexes)
+    }
+    
+    /// Initialize with an array of elements.
+    public init(indexes: Array<Element>) {
+        _indexes = Storage(indexes)
+    }
+    
+    fileprivate init(storage: Storage) {
+        _indexes = storage
+    }
+    
+    /// Initialize with a single element.
+    public init(index: Element) {
+        _indexes = [index]
+    }
+    
+    /// Return a new `IndexPath` containing all but the last element.
+    public func dropLast() -> IndexPath {
+        return IndexPath(storage: _indexes.dropLast())
+    }
+    
+    /// Append an `IndexPath` to `self`.
+    public mutating func append(_ other: IndexPath) {
+        _indexes.append(contentsOf: other._indexes)
+    }
+    
+    /// Append a single element to `self`.
+    public mutating func append(_ other: Element) {
+        _indexes.append(other)
+    }
+    
+    /// Append an array of elements to `self`.
+    public mutating func append(_ other: Array<Element>) {
+        _indexes.append(contentsOf: other)
+    }
+    
+    /// Return a new `IndexPath` containing the elements in self and the elements in `other`.
+    public func appending(_ other: Element) -> IndexPath {
+        var result = _indexes
+        result.append(other)
+        return IndexPath(storage: result)
+    }
+    
+    /// Return a new `IndexPath` containing the elements in self and the elements in `other`.
+    public func appending(_ other: IndexPath) -> IndexPath {
+        return IndexPath(storage: _indexes + other._indexes)
+    }
+    
+    /// Return a new `IndexPath` containing the elements in self and the elements in `other`.
+    public func appending(_ other: Array<Element>) -> IndexPath {
+        return IndexPath(storage: _indexes + other)
+    }
+    
+    public subscript(index: Index) -> Element {
+        get {
+            return _indexes[index]
+        }
+        set {
+            _indexes[index] = newValue
+        }
+    }
+    
+    public subscript(range: Range<Index>) -> IndexPath {
+        get {
+            return IndexPath(storage: _indexes[range])
+        }
+        set {
+            _indexes[range] = newValue._indexes
+        }
+    }
+    
+    public func makeIterator() -> IndexingIterator<IndexPath> {
+        return IndexingIterator(_elements: self)
+    }
+    
+    public var count: Int {
+        return _indexes.count
+    }
+    
+    public var startIndex: Index {
+        return _indexes.startIndex
+    }
+    
+    public var endIndex: Index {
+        return _indexes.endIndex
+    }
+    
+    public func index(before i: Index) -> Index {
+        return _indexes.index(before: i)
+    }
+    
+    public func index(after i: Index) -> Index {
+        return _indexes.index(after: i)
+    }
+    
+    /// Sorting an array of `IndexPath` using this comparison results in an array representing nodes in depth-first traversal order.
+    public func compare(_ other: IndexPath) -> ComparisonResult  {
+        let thisLength = count
+        let otherLength = other.count
+        let length = Swift.min(thisLength, otherLength)
+        for idx in 0..<length {
+            let otherValue = other[idx]
+            let value = self[idx]
+            if value < otherValue {
+                return .orderedAscending
+            } else if value > otherValue {
+                return .orderedDescending
+            }
+        }
+        if thisLength > otherLength {
+            return .orderedDescending
+        } else if thisLength < otherLength {
+            return .orderedAscending
+        }
+        return .orderedSame
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        // Note: We compare all indices in ==, so for proper hashing, we must
+        // also feed them all to the hasher.
+        //
+        // To ensure we have unique hash encodings in nested hashing contexts,
+        // we combine the count of indices as well as the indices themselves.
+        // (This matches what Array does.)
+        switch _indexes {
+        case .empty:
+            hasher.combine(0)
+        case let .single(index):
+            hasher.combine(1)
+            hasher.combine(index)
+        case let .pair(first, second):
+            hasher.combine(2)
+            hasher.combine(first)
+            hasher.combine(second)
+        case let .array(indexes):
+            hasher.combine(indexes.count)
+            for index in indexes {
+                hasher.combine(index)
+            }
+        }
+    }
+
+    // MARK: - Bridging Helpers
+    
+    fileprivate init(nsIndexPath: __shared ReferenceType) {
+        let count = nsIndexPath.length
+        switch count {
+        case 0:
+            _indexes = []
+        case 1:
+            _indexes = .single(nsIndexPath.index(atPosition: 0))
+        case 2:
+            _indexes = .pair(nsIndexPath.index(atPosition: 0), nsIndexPath.index(atPosition: 1))
+        default:
+            let indexes = Array<Int>(unsafeUninitializedCapacity: count) { buffer, initializedCount in
+                nsIndexPath.getIndexes(buffer.baseAddress!, range: NSRange(location: 0, length: count))
+                initializedCount = count
+            }
+            _indexes = .array(indexes)
+        }
+    }
+    
+    fileprivate func makeReference() -> ReferenceType {
+        switch _indexes {
+        case .empty:
+            return ReferenceType()
+        case .single(let index):
+            return ReferenceType(index: index)
+        case .pair(let first, let second):
+            return _NSIndexPathCreateFromIndexes(first, second) as! ReferenceType
+        default:
+            return _indexes.withUnsafeBufferPointer {
+                return ReferenceType(indexes: $0.baseAddress, length: $0.count)
+            }
+        }
+    }
+    
+    public static func ==(lhs: IndexPath, rhs: IndexPath) -> Bool {
+        return lhs._indexes == rhs._indexes
+    }
+    
+    public static func +(lhs: IndexPath, rhs: IndexPath) -> IndexPath {
+        return lhs.appending(rhs)
+    }
+    
+    public static func +=(lhs: inout IndexPath, rhs: IndexPath) {
+        lhs.append(rhs)
+    }
+    
+    public static func <(lhs: IndexPath, rhs: IndexPath) -> Bool {
+        return lhs.compare(rhs) == ComparisonResult.orderedAscending
+    }
+    
+    public static func <=(lhs: IndexPath, rhs: IndexPath) -> Bool {
+        let order = lhs.compare(rhs)
+        return order == ComparisonResult.orderedAscending || order == ComparisonResult.orderedSame
+    }
+    
+    public static func >(lhs: IndexPath, rhs: IndexPath) -> Bool {
+        return lhs.compare(rhs) == ComparisonResult.orderedDescending
+    }
+    
+    public static func >=(lhs: IndexPath, rhs: IndexPath) -> Bool {
+        let order = lhs.compare(rhs)
+        return order == ComparisonResult.orderedDescending || order == ComparisonResult.orderedSame
+    }
+}
+
+extension IndexPath : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    public var description: String {
+        return _indexes.description
+    }
+    
+    public var debugDescription: String {
+        return _indexes.debugDescription
+    }
+    
+    public var customMirror: Mirror {
+        return Mirror(self, unlabeledChildren: self, displayStyle: .collection)
+    }
+}
+
+extension IndexPath : _ObjectiveCBridgeable {
+    public static func _getObjectiveCType() -> Any.Type {
+        return NSIndexPath.self
+    }
+    
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSIndexPath {
+        return makeReference()
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSIndexPath, result: inout IndexPath?) {
+        result = IndexPath(nsIndexPath: x)
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSIndexPath, result: inout IndexPath?) -> Bool {
+        result = IndexPath(nsIndexPath: x)
+        return true
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSIndexPath?) -> IndexPath {
+        guard let src = source else { return IndexPath() }
+        return IndexPath(nsIndexPath: src)
+    }
+}
+
+extension NSIndexPath : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as IndexPath)
+    }
+}
+
+extension IndexPath : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case indexes
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        var indexesContainer = try container.nestedUnkeyedContainer(forKey: .indexes)
+
+        var indexes = [Int]()
+        if let count = indexesContainer.count {
+            indexes.reserveCapacity(count)
+        }
+
+        while !indexesContainer.isAtEnd {
+            let index = try indexesContainer.decode(Int.self)
+            indexes.append(index)
+        }
+
+        self.init(indexes: indexes)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var indexesContainer = container.nestedUnkeyedContainer(forKey: .indexes)
+        switch self._indexes {
+        case .empty:
+            break
+        case .single(let index):
+            try indexesContainer.encode(index)
+        case .pair(let first, let second):
+            try indexesContainer.encode(first)
+            try indexesContainer.encode(second)
+        case .array(let indexes):
+            try indexesContainer.encode(contentsOf: indexes)
+        }
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/IndexSet.swift
+++ b/Darwin/Foundation-swiftoverlay/IndexSet.swift
@@ -1,0 +1,899 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+@_implementationOnly import _FoundationOverlayShims
+
+extension IndexSet.Index {
+    public static func ==(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
+        return lhs.value == rhs.value
+    }
+
+    public static func <(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
+        return lhs.value < rhs.value
+    }
+
+    public static func <=(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
+        return lhs.value <= rhs.value
+    }
+
+    public static func >(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
+        return lhs.value > rhs.value
+    }
+
+    public static func >=(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
+        return lhs.value >= rhs.value
+    }
+}
+
+extension IndexSet.RangeView {
+    public static func ==(lhs: IndexSet.RangeView, rhs: IndexSet.RangeView) -> Bool {
+        return lhs.startIndex == rhs.startIndex && lhs.endIndex == rhs.endIndex && lhs.indexSet == rhs.indexSet
+    }
+}
+
+/// Manages a `Set` of integer values, which are commonly used as an index type in Cocoa API.
+///
+/// The range of valid integer values is 0..<INT_MAX-1. Anything outside this range is an error.
+public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollection, SetAlgebra {
+    
+    /// An view of the contents of an IndexSet, organized by range.
+    ///
+    /// For example, if an IndexSet is composed of:
+    ///  `[1..<5]` and `[7..<10]` and `[13]`
+    /// then calling `next()` on this view's iterator will produce 3 ranges before returning nil.
+    public struct RangeView : Equatable, BidirectionalCollection {
+        public typealias Index = Int
+        public let startIndex: Index
+        public let endIndex: Index
+        
+        fileprivate var indexSet: IndexSet
+        
+        fileprivate init(indexSet : IndexSet, intersecting range : Range<IndexSet.Element>?) {
+            if let r = range {
+                let otherIndexes = IndexSet(integersIn: r)
+                self.indexSet = indexSet.intersection(otherIndexes)
+            } else {
+                self.indexSet = indexSet
+            }
+
+            self.startIndex = 0
+            self.endIndex = self.indexSet._rangeCount
+        }
+        
+        public func makeIterator() -> IndexingIterator<RangeView> {
+            return IndexingIterator(_elements: self)
+        }
+        
+        public subscript(index : Index) -> Range<IndexSet.Element> {
+            let indexSetRange = indexSet._range(at: index)
+            return indexSetRange.lowerBound..<indexSetRange.upperBound
+        }
+        
+        public subscript(bounds: Range<Index>) -> Slice<RangeView> {
+            return Slice(base: self, bounds: bounds)
+        }
+
+        public func index(after i: Index) -> Index {
+            return i + 1
+        }
+        
+        public func index(before i: Index) -> Index {
+            return i - 1
+        }
+        
+    }
+    
+    /// The mechanism for accessing the integers stored in an IndexSet.
+    public struct Index : CustomStringConvertible, Comparable {
+        fileprivate var value: IndexSet.Element
+        fileprivate var extent: Range<IndexSet.Element>
+        fileprivate var rangeIndex: Int
+        fileprivate let rangeCount: Int
+        
+        fileprivate init(value: Int, extent: Range<Int>, rangeIndex: Int, rangeCount: Int) {
+            self.value = value
+            self.extent = extent
+            self.rangeCount = rangeCount
+            self.rangeIndex = rangeIndex
+        }
+        
+        public var description: String {
+            return "index \(value) in a range of \(extent) [range #\(rangeIndex + 1)/\(rangeCount)]"
+        }
+    }
+
+    public typealias ReferenceType = NSIndexSet
+    public typealias Element = Int
+    
+    private var _handle: _MutablePairHandle<NSIndexSet, NSMutableIndexSet>
+    
+    /// Initialize an `IndexSet` with a range of integers.
+    public init(integersIn range: Range<Element>) {
+        _handle = _MutablePairHandle(NSIndexSet(indexesIn: _toNSRange(range)), copying: false)
+    }
+    
+    /// Initialize an `IndexSet` with a range of integers.
+    public init<R: RangeExpression>(integersIn range: R) where R.Bound == Element { 
+      self.init(integersIn: range.relative(to: 0..<Int.max))
+    }
+  
+    /// Initialize an `IndexSet` with a single integer.
+    public init(integer: Element) {
+        _handle = _MutablePairHandle(NSIndexSet(index: integer), copying: false)
+    }
+    
+    /// Initialize an empty `IndexSet`.
+    public init() {
+        _handle = _MutablePairHandle(NSIndexSet(), copying: false)
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        _handle.map { hasher.combine($0) }
+    }
+    
+    /// Returns the number of integers in `self`.
+    public var count: Int {
+        return _handle.map { $0.count }
+    }
+    
+    public func makeIterator() -> IndexingIterator<IndexSet> {
+        return IndexingIterator(_elements: self)
+    }
+
+    /// Returns a `Range`-based view of the entire contents of `self`.
+    ///
+    /// - seealso: rangeView(of:)
+    public var rangeView: RangeView {
+        return RangeView(indexSet: self, intersecting: nil)
+    }
+
+    /// Returns a `Range`-based view of `self`.
+    ///
+    /// - parameter range: A subrange of `self` to view.
+    public func rangeView(of range : Range<Element>) -> RangeView {
+        return RangeView(indexSet: self, intersecting: range)
+    }
+    
+    /// Returns a `Range`-based view of `self`.
+    ///
+    /// - parameter range: A subrange of `self` to view.
+    public func rangeView<R: RangeExpression>(of range : R) -> RangeView where R.Bound == Element { 
+      return self.rangeView(of: range.relative(to: 0..<Int.max)) 
+    }
+  
+    private func _indexOfRange(containing integer : Element) -> RangeView.Index? {
+        let result = _handle.map { 
+            __NSIndexSetIndexOfRangeContainingIndex($0, integer)
+        }
+        if result == NSNotFound {
+            return nil
+        } else {
+            return Int(result)
+        }
+    }
+    
+    private func _range(at index: RangeView.Index) -> Range<Element> {
+        return _handle.map {
+            var location: Int = 0
+            var length: Int = 0
+            __NSIndexSetRangeAtIndex($0, index, &location, &length)
+            return Int(location)..<Int(location)+Int(length)
+        }
+    }
+    
+    private var _rangeCount : Int {
+        return _handle.map { 
+            Int(__NSIndexSetRangeCount($0))
+        }
+    }
+    
+    public var startIndex: Index {
+        let rangeCount = _rangeCount
+        if rangeCount > 0 {
+            // If this winds up being NSNotFound, that's ok because then endIndex is also NSNotFound, and empty collections have startIndex == endIndex
+            let extent = _range(at: 0)
+            return Index(value: extent.lowerBound, extent: extent, rangeIndex: 0, rangeCount: _rangeCount)
+        } else {
+            return Index(value: 0, extent: 0..<0, rangeIndex: -1, rangeCount: rangeCount)
+        }
+    }
+
+    public var endIndex: Index {
+        let rangeCount = _rangeCount
+        let rangeIndex = rangeCount - 1
+        let extent: Range<Int>
+        let value: Int
+        if rangeCount > 0 {
+            extent = _range(at: rangeCount - 1)
+            value = extent.upperBound // "1 past the end" position is the last range, 1 + the end of that range's extent
+        } else {
+            extent = 0..<0
+            value = 0
+        }
+        
+        return Index(value: value, extent: extent, rangeIndex: rangeIndex, rangeCount: rangeCount)
+    }
+    
+    public subscript(index : Index) -> Element {
+        return index.value
+    }
+
+    public subscript(bounds: Range<Index>) -> Slice<IndexSet> {
+        return Slice(base: self, bounds: bounds)
+    }
+
+    // We adopt the default implementation of subscript(range: Range<Index>) from MutableCollection
+    
+    private func _toOptional(_ x : Int) -> Int? {
+        if x == NSNotFound { return nil } else { return x }
+    }
+
+    /// Returns the first integer in `self`, or nil if `self` is empty.
+    public var first: Element? {
+        return _handle.map { _toOptional($0.firstIndex) }
+    }
+    
+    /// Returns the last integer in `self`, or nil if `self` is empty.
+    public var last: Element? {
+        return _handle.map { _toOptional($0.lastIndex) }
+    }
+    
+    /// Returns an integer contained in `self` which is greater than `integer`, or `nil` if a result could not be found.
+    public func integerGreaterThan(_ integer: Element) -> Element? {
+        return _handle.map { _toOptional($0.indexGreaterThanIndex(integer)) }
+    }
+    
+    /// Returns an integer contained in `self` which is less than `integer`, or `nil` if a result could not be found.
+    public func integerLessThan(_ integer: Element) -> Element? {
+        return _handle.map { _toOptional($0.indexLessThanIndex(integer)) }
+    }
+    
+    /// Returns an integer contained in `self` which is greater than or equal to `integer`, or `nil` if a result could not be found.
+    public func integerGreaterThanOrEqualTo(_ integer: Element) -> Element? {
+        return _handle.map { _toOptional($0.indexGreaterThanOrEqual(to: integer)) }
+    }
+    
+    /// Returns an integer contained in `self` which is less than or equal to `integer`, or `nil` if a result could not be found.
+    public func integerLessThanOrEqualTo(_ integer: Element) -> Element? {
+        return _handle.map { _toOptional($0.indexLessThanOrEqual(to: integer)) }
+    }
+    
+    /// Return a `Range<IndexSet.Index>` which can be used to subscript the index set.
+    ///
+    /// The resulting range is the range of the intersection of the integers in `range` with the index set. The resulting range will be `isEmpty` if the intersection is empty.
+    ///
+    /// - parameter range: The range of integers to include.
+    public func indexRange(in range: Range<Element>) -> Range<Index> {
+        guard !range.isEmpty, let first = first, let last = last else {
+            let i = _index(ofInteger: 0)
+            return i..<i
+        }
+
+        if range.lowerBound > last || (range.upperBound - 1) < first {
+            let i = _index(ofInteger: 0)
+            return i..<i
+        }
+        
+        if let start = integerGreaterThanOrEqualTo(range.lowerBound), let end = integerLessThanOrEqualTo(range.upperBound - 1) {
+            let resultFirst = _index(ofInteger: start)
+            let resultLast = _index(ofInteger: end)
+            return resultFirst..<index(after: resultLast)
+        } else {
+            let i = _index(ofInteger: 0)
+            return i..<i
+        }
+    }
+    
+    /// Return a `Range<IndexSet.Index>` which can be used to subscript the index set.
+    ///
+    /// The resulting range is the range of the intersection of the integers in `range` with the index set.
+    ///
+    /// - parameter range: The range of integers to include.
+    public func indexRange<R: RangeExpression>(in range: R) -> Range<Index> where R.Bound == Element { 
+      return self.indexRange(in: range.relative(to: 0..<Int.max))
+    }
+
+    /// Returns the count of integers in `self` that intersect `range`.
+    public func count(in range: Range<Element>) -> Int {
+        return _handle.map { $0.countOfIndexes(in: _toNSRange(range)) }
+    }
+
+    /// Returns the count of integers in `self` that intersect `range`.
+    public func count<R: RangeExpression>(in range: R) -> Int where R.Bound == Element { 
+      return self.count(in: range.relative(to: 0..<Int.max))
+    }
+
+    /// Returns `true` if `self` contains `integer`.
+    public func contains(_ integer: Element) -> Bool {
+        return _handle.map { $0.contains(integer) }
+    }
+    
+    /// Returns `true` if `self` contains all of the integers in `range`.
+    public func contains(integersIn range: Range<Element>) -> Bool {
+        return _handle.map { $0.contains(in: _toNSRange(range)) }
+    }
+
+    /// Returns `true` if `self` contains all of the integers in `range`.
+    public func contains<R: RangeExpression>(integersIn range: R) -> Bool where R.Bound == Element { 
+      return self.contains(integersIn: range.relative(to: 0..<Int.max))
+    }
+
+    
+    /// Returns `true` if `self` contains all of the integers in `indexSet`.
+    public func contains(integersIn indexSet: IndexSet) -> Bool {
+        return _handle.map { $0.contains(indexSet) }
+    }
+    
+    /// Returns `true` if `self` intersects any of the integers in `range`.
+    public func intersects(integersIn range: Range<Element>) -> Bool {
+        return _handle.map { $0.intersects(in: _toNSRange(range)) }
+    }
+
+    /// Returns `true` if `self` intersects any of the integers in `range`.
+    public func intersects<R: RangeExpression>(integersIn range: R) -> Bool where R.Bound == Element { 
+      return self.intersects(integersIn: range.relative(to: 0..<Int.max))
+    }
+
+    // MARK: -
+    // Collection
+    
+    public func index(after i: Index) -> Index {
+        if i.value + 1 == i.extent.upperBound {
+            // Move to the next range
+            if i.rangeIndex + 1 == i.rangeCount {
+                // We have no more to go; return a 'past the end' index
+                return Index(value: i.value + 1, extent: i.extent, rangeIndex: i.rangeIndex, rangeCount: i.rangeCount)
+            } else {
+                let rangeIndex = i.rangeIndex + 1
+                let rangeCount = i.rangeCount
+                let extent = _range(at: rangeIndex)
+                let value = extent.lowerBound
+                return Index(value: value, extent: extent, rangeIndex: rangeIndex, rangeCount: rangeCount)
+            }
+        } else {
+            // Move to the next value in this range
+            return Index(value: i.value + 1, extent: i.extent, rangeIndex: i.rangeIndex, rangeCount: i.rangeCount)
+        }
+    }
+    
+    public func formIndex(after i: inout Index) {
+        if i.value + 1 == i.extent.upperBound {
+            // Move to the next range
+            if i.rangeIndex + 1 == i.rangeCount {
+                // We have no more to go; return a 'past the end' index
+                i.value += 1
+            } else {
+                i.rangeIndex += 1
+                i.extent = _range(at: i.rangeIndex)
+                i.value = i.extent.lowerBound
+            }
+        } else {
+            // Move to the next value in this range
+            i.value += 1
+        }
+    }
+    
+    public func index(before i: Index) -> Index {
+        if i.value == i.extent.lowerBound {
+            // Move to the next range
+            if i.rangeIndex == 0 {
+                // We have no more to go
+                return Index(value: i.value, extent: i.extent, rangeIndex: i.rangeIndex, rangeCount: i.rangeCount)
+            } else {
+                let rangeIndex = i.rangeIndex - 1
+                let rangeCount = i.rangeCount
+                let extent = _range(at: rangeIndex)
+                let value = extent.upperBound - 1
+                return Index(value: value, extent: extent, rangeIndex: rangeIndex, rangeCount: rangeCount)
+            }
+        } else {
+            // Move to the previous value in this range
+            return Index(value: i.value - 1, extent: i.extent, rangeIndex: i.rangeIndex, rangeCount: i.rangeCount)
+        }
+    }
+    
+    public func formIndex(before i: inout Index) {
+        if i.value == i.extent.lowerBound {
+            // Move to the next range
+            if i.rangeIndex == 0 {
+                // We have no more to go
+            } else {
+                i.rangeIndex -= 1
+                i.extent = _range(at: i.rangeIndex)
+                i.value = i.extent.upperBound - 1
+            }
+        } else {
+            // Move to the previous value in this range
+            i.value -= 1
+        }
+    }
+    
+    private func _index(ofInteger integer: Element) -> Index {
+        let rangeCount = _rangeCount
+        let value = integer
+        if let rangeIndex = _indexOfRange(containing: integer) {
+            let extent = _range(at: rangeIndex)
+            let rangeIndex = rangeIndex
+            return Index(value: value, extent: extent, rangeIndex: rangeIndex, rangeCount: rangeCount)
+        } else {
+            let extent = 0..<0
+            let rangeIndex = 0
+            return Index(value: value, extent: extent, rangeIndex: rangeIndex, rangeCount: rangeCount)
+        }
+    }
+    
+    // MARK: -
+    // MARK: SetAlgebra
+    
+    /// Union the `IndexSet` with `other`.
+    public mutating func formUnion(_ other: IndexSet) {
+        self = self.union(other)
+    }
+    
+    /// Union the `IndexSet` with `other`.
+    public func union(_ other: IndexSet) -> IndexSet {
+        var result: IndexSet
+        var dense: IndexSet
+
+        // Prepare to make a copy of the more sparse IndexSet to prefer copy over repeated inserts
+        if self.rangeView.count > other.rangeView.count {
+            result = self
+            dense = other
+        } else {
+            result = other
+            dense = self
+        }
+
+        // Insert each range from the less sparse IndexSet
+        dense.rangeView.forEach {
+            result.insert(integersIn: $0)
+        }
+
+        return result
+    }
+    
+    /// Exclusive or the `IndexSet` with `other`.
+    public func symmetricDifference(_ other: IndexSet) -> IndexSet {
+        var result = IndexSet()
+        var boundaryIterator = IndexSetBoundaryIterator(self, other)
+        var flag = false
+        var start = 0
+
+        while let i = boundaryIterator.next() {
+            if !flag {
+                // Start a range if one set contains but not the other.
+                if self.contains(i) != other.contains(i) {
+                    flag = true
+                    start = i
+                }
+            } else {
+                // End a range if both sets contain or both sets do not contain.
+                if self.contains(i) == other.contains(i) {
+                    flag = false
+                    result.insert(integersIn: start..<i)
+                }
+            }
+            // We never have to worry about having flag set to false after exiting this loop because the last boundary is guaranteed to be past the end of ranges in both index sets
+        }
+        
+        return result
+    }
+    
+    /// Exclusive or the `IndexSet` with `other`.
+    public mutating func formSymmetricDifference(_ other: IndexSet) {
+        self = self.symmetricDifference(other)
+    }
+    
+    /// Intersect the `IndexSet` with `other`.
+    public func intersection(_ other: IndexSet) -> IndexSet {
+        var result = IndexSet()
+        var boundaryIterator = IndexSetBoundaryIterator(self, other)
+        var flag = false
+        var start = 0
+        
+        while let i = boundaryIterator.next() {
+            if !flag {
+                // If both sets contain then start a range.
+                if self.contains(i) && other.contains(i) {
+                    flag = true
+                    start = i
+                }
+            } else {
+                // If both sets do not contain then end a range.
+                if !self.contains(i) || !other.contains(i) {
+                    flag = false
+                    result.insert(integersIn: start..<i)
+                }
+            }
+        }
+        
+        return result
+    }
+
+    /// Intersect the `IndexSet` with `other`.
+    public mutating func formIntersection(_ other: IndexSet) {
+        self = self.intersection(other)
+    }
+
+    /// Insert an integer into the `IndexSet`.
+    @discardableResult
+    public mutating func insert(_ integer: Element) -> (inserted: Bool, memberAfterInsert: Element) {
+        _applyMutation { $0.add(integer) }
+        // TODO: figure out how to return the truth here
+        return (true, integer)
+    }
+
+    /// Insert an integer into the `IndexSet`.
+    @discardableResult
+    public mutating func update(with integer: Element) -> Element? {
+        _applyMutation { $0.add(integer) }
+        // TODO: figure out how to return the truth here
+        return integer
+    }
+
+
+    /// Remove an integer from the `IndexSet`.
+    @discardableResult
+    public mutating func remove(_ integer: Element) -> Element? {
+        // TODO: Add method to NSIndexSet to do this in one call
+        let result : Element? = contains(integer) ? integer : nil
+        _applyMutation { $0.remove(integer) }
+        return result
+    }
+
+    // MARK: -
+    
+    /// Remove all values from the `IndexSet`.
+    public mutating func removeAll() {
+        _applyMutation { $0.removeAllIndexes() }
+    }
+    
+    /// Insert a range of integers into the `IndexSet`.
+    public mutating func insert(integersIn range: Range<Element>) {
+        _applyMutation { $0.add(in: _toNSRange(range)) }
+    }
+
+    /// Insert a range of integers into the `IndexSet`.
+    public mutating func insert<R: RangeExpression>(integersIn range: R) where R.Bound == Element { 
+      self.insert(integersIn: range.relative(to: 0..<Int.max))
+    }
+
+    /// Remove a range of integers from the `IndexSet`.
+    public mutating func remove(integersIn range: Range<Element>) {
+        _applyMutation { $0.remove(in: _toNSRange(range)) }
+    }
+    
+    /// Remove a range of integers from the `IndexSet`.
+    public mutating func remove(integersIn range: ClosedRange<Element>) { 
+      self.remove(integersIn: Range(range))
+    }
+
+    /// Returns `true` if self contains no values.
+    public var isEmpty : Bool {
+        return self.count == 0
+    }
+    
+    /// Returns an IndexSet filtered according to the result of `includeInteger`.
+    ///
+    /// - parameter range: A range of integers. For each integer in the range that intersects the integers in the IndexSet, then the `includeInteger` predicate will be invoked.
+    /// - parameter includeInteger: The predicate which decides if an integer will be included in the result or not.
+    public func filteredIndexSet(in range : Range<Element>, includeInteger: (Element) throws -> Bool) rethrows -> IndexSet {
+        let r : NSRange = _toNSRange(range)
+        return try _handle.map {
+            var error: Error?
+            let result = $0.indexes(in: r, options: [], passingTest: { (i, stop) -> Bool in
+                do {
+                    let include = try includeInteger(i)
+                    return include
+                } catch let e {
+                    error = e
+                    stop.pointee = true
+                    return false
+                }
+            })
+            if let e = error {
+                throw e
+            } else {
+                return result
+            }
+        }
+    }
+    
+    /// Returns an IndexSet filtered according to the result of `includeInteger`.
+    ///
+    /// - parameter range: A range of integers. For each integer in the range that intersects the integers in the IndexSet, then the `includeInteger` predicate will be invoked.
+    /// - parameter includeInteger: The predicate which decides if an integer will be included in the result or not.
+    public func filteredIndexSet(in range : ClosedRange<Element>, includeInteger: (Element) throws -> Bool) rethrows -> IndexSet { 
+      return try self.filteredIndexSet(in: Range(range), includeInteger: includeInteger) 
+    }
+  
+    /// Returns an IndexSet filtered according to the result of `includeInteger`.
+    ///
+    /// - parameter includeInteger: The predicate which decides if an integer will be included in the result or not.
+    public func filteredIndexSet(includeInteger: (Element) throws -> Bool) rethrows -> IndexSet {
+        return try self.filteredIndexSet(in: 0..<NSNotFound-1, includeInteger: includeInteger)
+    }
+
+    /// For a positive delta, shifts the indexes in [index, INT_MAX] to the right, thereby inserting an "empty space" [index, delta], for a negative delta, shifts the indexes in [index, INT_MAX] to the left, thereby deleting the indexes in the range [index - delta, delta].
+    public mutating func shift(startingAt integer: Element, by delta: Int) {
+        _applyMutation { $0.shiftIndexesStarting(at: integer, by: delta) }
+    }
+    
+    // Temporary boxing function, until we can get a native Swift type for NSIndexSet
+    @inline(__always)
+    mutating func _applyMutation<ReturnType>(_ whatToDo : (NSMutableIndexSet) throws -> ReturnType) rethrows -> ReturnType {
+        // This check is done twice because: <rdar://problem/24939065> Value kept live for too long causing uniqueness check to fail
+        var unique = true
+        switch _handle._pointer {
+        case .Default(_):
+            break
+        case .Mutable(_):
+            unique = isKnownUniquelyReferenced(&_handle)
+        }
+        
+        switch _handle._pointer {
+        case .Default(let i):
+            // We need to become mutable; by creating a new box we also become unique
+            let copy = i.mutableCopy() as! NSMutableIndexSet
+            // Be sure to set the _handle before calling out; otherwise references to the struct in the closure may be looking at the old _handle
+            _handle = _MutablePairHandle(copy, copying: false)
+            let result = try whatToDo(copy)
+            return result
+        case .Mutable(let m):
+            // Only create a new box if we are not uniquely referenced
+            if !unique {
+                let copy = m.mutableCopy() as! NSMutableIndexSet
+                _handle = _MutablePairHandle(copy, copying: false)
+                let result = try whatToDo(copy)
+                return result
+            } else {
+                return try whatToDo(m)
+            }
+        }
+    }
+    
+    // MARK: - Bridging Support
+    
+    private var reference: NSIndexSet {
+        return _handle.reference
+    }
+    
+    private init(reference: __shared NSIndexSet) {
+        _handle = _MutablePairHandle(reference)
+    }
+}
+
+extension IndexSet : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    public var description: String {
+        return "\(count) indexes"
+    }
+    
+    public var debugDescription: String {
+        return "\(count) indexes"
+    }
+
+    public var customMirror: Mirror {
+        var c: [(label: String?, value: Any)] = []
+        c.append((label: "ranges", value: Array(rangeView)))
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+    }
+}
+
+/// Iterate two index sets on the boundaries of their ranges. This is where all of the interesting stuff happens for exclusive or, intersect, etc.
+private struct IndexSetBoundaryIterator : IteratorProtocol {
+    typealias Element = IndexSet.Element
+    
+    private var i1: IndexSet.RangeView.Iterator
+    private var i2: IndexSet.RangeView.Iterator
+    private var i1Range: Range<Element>?
+    private var i2Range: Range<Element>?
+    private var i1UsedLower: Bool
+    private var i2UsedLower: Bool
+    
+    init(_ is1: IndexSet, _ is2: IndexSet) {
+        i1 = is1.rangeView.makeIterator()
+        i2 = is2.rangeView.makeIterator()
+        
+        i1Range = i1.next()
+        i2Range = i2.next()
+        
+        // A sort of cheap iterator on [i1Range.lowerBound, i1Range.upperBound]
+        i1UsedLower = false
+        i2UsedLower = false
+    }
+    
+    mutating func next() -> Element? {
+        if i1Range == nil && i2Range == nil {
+            return nil
+        }
+        
+        let nextIn1: Element
+        if let r = i1Range {
+            nextIn1 = i1UsedLower ? r.upperBound : r.lowerBound
+        } else {
+            nextIn1 = Int.max
+        }
+        
+        let nextIn2: Element
+        if let r = i2Range {
+            nextIn2 = i2UsedLower ? r.upperBound : r.lowerBound
+        } else {
+            nextIn2 = Int.max
+        }
+        
+        var result: Element
+        if nextIn1 <= nextIn2 {
+            // 1 has the next element, or they are the same.
+            result = nextIn1
+            if i1UsedLower { i1Range = i1.next() }
+            // We need to iterate both the value from is1 and is2 in the == case.
+            if result == nextIn2 {
+                if i2UsedLower { i2Range = i2.next() }
+                i2UsedLower = !i2UsedLower
+            }
+            i1UsedLower = !i1UsedLower
+        } else {
+            // 2 has the next element
+            result = nextIn2
+            if i2UsedLower { i2Range = i2.next() }
+            i2UsedLower = !i2UsedLower
+        }
+        
+        return result
+    }
+}
+
+extension IndexSet {
+    public static func ==(lhs: IndexSet, rhs: IndexSet) -> Bool {
+        return lhs._handle.map { $0.isEqual(to: rhs) }
+    }
+}
+
+private func _toNSRange(_ r: Range<IndexSet.Element>) -> NSRange {
+    return NSRange(location: r.lowerBound, length: r.upperBound - r.lowerBound)
+}
+
+extension IndexSet : _ObjectiveCBridgeable {
+    public static func _getObjectiveCType() -> Any.Type {
+        return NSIndexSet.self
+    }
+    
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSIndexSet {
+        return reference
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSIndexSet, result: inout IndexSet?) {
+        result = IndexSet(reference: x)
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSIndexSet, result: inout IndexSet?) -> Bool {
+        result = IndexSet(reference: x)
+        return true
+    }
+
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSIndexSet?) -> IndexSet {
+        guard let src = source else { return IndexSet() }
+        return IndexSet(reference: src)
+    }    
+    
+}
+
+extension NSIndexSet : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as IndexSet)
+    }
+}
+
+// MARK: Protocol
+
+// TODO: This protocol should be replaced with a native Swift object like the other Foundation bridged types. However, NSIndexSet does not have an abstract zero-storage base class like NSCharacterSet, NSData, and NSAttributedString. Therefore the same trick of laying it out with Swift ref counting does not work.and
+/// Holds either the immutable or mutable version of a Foundation type.
+///
+/// In many cases, the immutable type has optimizations which make it preferred when we know we do not need mutation.
+private enum _MutablePair<ImmutableType, MutableType> {
+    case Default(ImmutableType)
+    case Mutable(MutableType)
+}
+
+/// A class type which acts as a handle (pointer-to-pointer) to a Foundation reference type which has both an immutable and mutable class (e.g., NSData, NSMutableData).
+///
+/// a.k.a. Box
+private final class _MutablePairHandle<ImmutableType : NSObject, MutableType : NSObject>
+  where ImmutableType : NSMutableCopying, MutableType : NSMutableCopying {
+    var _pointer: _MutablePair<ImmutableType, MutableType>
+    
+    /// Initialize with an immutable reference instance.
+    ///
+    /// - parameter immutable: The thing to stash.
+    /// - parameter copying: Should be true unless you just created the instance (or called copy) and want to transfer ownership to this handle.
+    init(_ immutable: ImmutableType, copying: Bool = true) {
+        if copying {
+            self._pointer = _MutablePair.Default(immutable.copy() as! ImmutableType)
+        } else {
+            self._pointer = _MutablePair.Default(immutable)
+        }
+    }
+    
+    /// Initialize with a mutable reference instance.
+    ///
+    /// - parameter mutable: The thing to stash.
+    /// - parameter copying: Should be true unless you just created the instance (or called copy) and want to transfer ownership to this handle.
+    init(_ mutable: MutableType, copying: Bool = true) {
+        if copying {
+            self._pointer = _MutablePair.Mutable(mutable.mutableCopy() as! MutableType)
+        } else {
+            self._pointer = _MutablePair.Mutable(mutable)
+        }
+    }
+    
+    /// Apply a closure to the reference type, regardless if it is mutable or immutable.
+    @inline(__always)
+    func map<ReturnType>(_ whatToDo: (ImmutableType) throws -> ReturnType) rethrows -> ReturnType {
+        switch _pointer {
+        case .Default(let i):
+            return try whatToDo(i)
+        case .Mutable(let m):
+            // TODO: It should be possible to reflect the constraint that MutableType is a subtype of ImmutableType in the generics for the class, but I haven't figured out how yet. For now, cheat and unsafe bit cast.
+            return try whatToDo(unsafeDowncast(m, to: ImmutableType.self))
+        }
+    }
+    
+    var reference: ImmutableType {
+        switch _pointer {
+        case .Default(let i):
+            return i
+        case .Mutable(let m):
+            // TODO: It should be possible to reflect the constraint that MutableType is a subtype of ImmutableType in the generics for the class, but I haven't figured out how yet. For now, cheat and unsafe bit cast.
+            return unsafeDowncast(m, to: ImmutableType.self)
+        }
+    }
+}
+
+extension IndexSet : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case indexes
+    }
+
+    private enum RangeCodingKeys : Int, CodingKey {
+        case location
+        case length
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        var indexesContainer = try container.nestedUnkeyedContainer(forKey: .indexes)
+        self.init()
+
+        while !indexesContainer.isAtEnd {
+            let rangeContainer = try indexesContainer.nestedContainer(keyedBy: RangeCodingKeys.self)
+            let startIndex = try rangeContainer.decode(Int.self, forKey: .location)
+            let count = try rangeContainer.decode(Int.self, forKey: .length)
+            self.insert(integersIn: startIndex ..< (startIndex + count))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var indexesContainer = container.nestedUnkeyedContainer(forKey: .indexes)
+
+        for range in self.rangeView {
+            var rangeContainer = indexesContainer.nestedContainer(keyedBy: RangeCodingKeys.self)
+            try rangeContainer.encode(range.startIndex, forKey: .location)
+            try rangeContainer.encode(range.count, forKey: .length)
+        }
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/JSONEncoder.swift
+++ b/Darwin/Foundation-swiftoverlay/JSONEncoder.swift
@@ -1,0 +1,2583 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A marker protocol used to determine whether a value is a `String`-keyed `Dictionary`
+/// containing `Encodable` values (in which case it should be exempt from key conversion strategies).
+///
+/// NOTE: The architecture and environment check is due to a bug in the current (2018-08-08) Swift 4.2
+/// runtime when running on i386 simulator. The issue is tracked in https://bugs.swift.org/browse/SR-8276
+/// Making the protocol `internal` instead of `private` works around this issue.
+/// Once SR-8276 is fixed, this check can be removed and the protocol always be made private.
+#if arch(i386) || arch(arm)
+internal protocol _JSONStringDictionaryEncodableMarker { }
+#else
+private protocol _JSONStringDictionaryEncodableMarker { }
+#endif
+
+extension Dictionary : _JSONStringDictionaryEncodableMarker where Key == String, Value: Encodable { }
+
+/// A marker protocol used to determine whether a value is a `String`-keyed `Dictionary`
+/// containing `Decodable` values (in which case it should be exempt from key conversion strategies).
+///
+/// The marker protocol also provides access to the type of the `Decodable` values,
+/// which is needed for the implementation of the key conversion strategy exemption.
+///
+/// NOTE: Please see comment above regarding SR-8276
+#if arch(i386) || arch(arm)
+internal protocol _JSONStringDictionaryDecodableMarker {
+    static var elementType: Decodable.Type { get }
+}
+#else
+private protocol _JSONStringDictionaryDecodableMarker {
+    static var elementType: Decodable.Type { get }
+}
+#endif
+
+extension Dictionary : _JSONStringDictionaryDecodableMarker where Key == String, Value: Decodable {
+    static var elementType: Decodable.Type { return Value.self }
+}
+
+//===----------------------------------------------------------------------===//
+// JSON Encoder
+//===----------------------------------------------------------------------===//
+
+/// `JSONEncoder` facilitates the encoding of `Encodable` values into JSON.
+// NOTE: older overlays had Foundation.JSONEncoder as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtC10Foundation13__JSONEncoder is the
+// mangled name for Foundation.__JSONEncoder.
+@_objcRuntimeName(_TtC10Foundation13__JSONEncoder)
+open class JSONEncoder {
+    // MARK: Options
+
+    /// The formatting of the output JSON data.
+    public struct OutputFormatting : OptionSet {
+        /// The format's default value.
+        public let rawValue: UInt
+
+        /// Creates an OutputFormatting value with the given raw value.
+        public init(rawValue: UInt) {
+            self.rawValue = rawValue
+        }
+
+        /// Produce human-readable JSON with indented output.
+        public static let prettyPrinted = OutputFormatting(rawValue: 1 << 0)
+
+        /// Produce JSON with dictionary keys sorted in lexicographic order.
+        @available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
+        public static let sortedKeys    = OutputFormatting(rawValue: 1 << 1)
+
+        /// By default slashes get escaped ("/" → "\/", "http://apple.com/" → "http:\/\/apple.com\/")
+        /// for security reasons, allowing outputted JSON to be safely embedded within HTML/XML.
+        /// In contexts where this escaping is unnecessary, the JSON is known to not be embedded,
+        /// or is intended only for display, this option avoids this escaping.
+        @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+        public static let withoutEscapingSlashes = OutputFormatting(rawValue: 1 << 3)
+    }
+
+    /// The strategy to use for encoding `Date` values.
+    public enum DateEncodingStrategy {
+        /// Defer to `Date` for choosing an encoding. This is the default strategy.
+        case deferredToDate
+
+        /// Encode the `Date` as a UNIX timestamp (as a JSON number).
+        case secondsSince1970
+
+        /// Encode the `Date` as UNIX millisecond timestamp (as a JSON number).
+        case millisecondsSince1970
+
+        /// Encode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
+        @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+        case iso8601
+
+        /// Encode the `Date` as a string formatted by the given formatter.
+        case formatted(DateFormatter)
+
+        /// Encode the `Date` as a custom value encoded by the given closure.
+        ///
+        /// If the closure fails to encode a value into the given encoder, the encoder will encode an empty automatic container in its place.
+        case custom((Date, Encoder) throws -> Void)
+    }
+
+    /// The strategy to use for encoding `Data` values.
+    public enum DataEncodingStrategy {
+        /// Defer to `Data` for choosing an encoding.
+        case deferredToData
+
+        /// Encoded the `Data` as a Base64-encoded string. This is the default strategy.
+        case base64
+
+        /// Encode the `Data` as a custom value encoded by the given closure.
+        ///
+        /// If the closure fails to encode a value into the given encoder, the encoder will encode an empty automatic container in its place.
+        case custom((Data, Encoder) throws -> Void)
+    }
+
+    /// The strategy to use for non-JSON-conforming floating-point values (IEEE 754 infinity and NaN).
+    public enum NonConformingFloatEncodingStrategy {
+        /// Throw upon encountering non-conforming values. This is the default strategy.
+        case `throw`
+
+        /// Encode the values using the given representation strings.
+        case convertToString(positiveInfinity: String, negativeInfinity: String, nan: String)
+    }
+
+    /// The strategy to use for automatically changing the value of keys before encoding.
+    public enum KeyEncodingStrategy {
+        /// Use the keys specified by each type. This is the default strategy.
+        case useDefaultKeys
+        
+        /// Convert from "camelCaseKeys" to "snake_case_keys" before writing a key to JSON payload.
+        ///
+        /// Capital characters are determined by testing membership in `CharacterSet.uppercaseLetters` and `CharacterSet.lowercaseLetters` (Unicode General Categories Lu and Lt).
+        /// The conversion to lower case uses `Locale.system`, also known as the ICU "root" locale. This means the result is consistent regardless of the current user's locale and language preferences.
+        ///
+        /// Converting from camel case to snake case:
+        /// 1. Splits words at the boundary of lower-case to upper-case
+        /// 2. Inserts `_` between words
+        /// 3. Lowercases the entire string
+        /// 4. Preserves starting and ending `_`.
+        ///
+        /// For example, `oneTwoThree` becomes `one_two_three`. `_oneTwoThree_` becomes `_one_two_three_`.
+        ///
+        /// - Note: Using a key encoding strategy has a nominal performance cost, as each string key has to be converted.
+        case convertToSnakeCase
+        
+        /// Provide a custom conversion to the key in the encoded JSON from the keys specified by the encoded types.
+        /// The full path to the current encoding position is provided for context (in case you need to locate this key within the payload). The returned key is used in place of the last component in the coding path before encoding.
+        /// If the result of the conversion is a duplicate key, then only one value will be present in the result.
+        case custom((_ codingPath: [CodingKey]) -> CodingKey)
+        
+        fileprivate static func _convertToSnakeCase(_ stringKey: String) -> String {
+            guard !stringKey.isEmpty else { return stringKey }
+        
+            var words : [Range<String.Index>] = []
+            // The general idea of this algorithm is to split words on transition from lower to upper case, then on transition of >1 upper case characters to lowercase
+            //
+            // myProperty -> my_property
+            // myURLProperty -> my_url_property
+            //
+            // We assume, per Swift naming conventions, that the first character of the key is lowercase.
+            var wordStart = stringKey.startIndex
+            var searchRange = stringKey.index(after: wordStart)..<stringKey.endIndex
+        
+            // Find next uppercase character
+            while let upperCaseRange = stringKey.rangeOfCharacter(from: CharacterSet.uppercaseLetters, options: [], range: searchRange) {
+                let untilUpperCase = wordStart..<upperCaseRange.lowerBound
+                words.append(untilUpperCase)
+                
+                // Find next lowercase character
+                searchRange = upperCaseRange.lowerBound..<searchRange.upperBound
+                guard let lowerCaseRange = stringKey.rangeOfCharacter(from: CharacterSet.lowercaseLetters, options: [], range: searchRange) else {
+                    // There are no more lower case letters. Just end here.
+                    wordStart = searchRange.lowerBound
+                    break
+                }
+                
+                // Is the next lowercase letter more than 1 after the uppercase? If so, we encountered a group of uppercase letters that we should treat as its own word
+                let nextCharacterAfterCapital = stringKey.index(after: upperCaseRange.lowerBound)
+                if lowerCaseRange.lowerBound == nextCharacterAfterCapital {
+                    // The next character after capital is a lower case character and therefore not a word boundary.
+                    // Continue searching for the next upper case for the boundary.
+                    wordStart = upperCaseRange.lowerBound
+                } else {
+                    // There was a range of >1 capital letters. Turn those into a word, stopping at the capital before the lower case character.
+                    let beforeLowerIndex = stringKey.index(before: lowerCaseRange.lowerBound)
+                    words.append(upperCaseRange.lowerBound..<beforeLowerIndex)
+                    
+                    // Next word starts at the capital before the lowercase we just found
+                    wordStart = beforeLowerIndex
+                }
+                searchRange = lowerCaseRange.upperBound..<searchRange.upperBound
+            }
+            words.append(wordStart..<searchRange.upperBound)
+            let result = words.map({ (range) in
+                return stringKey[range].lowercased()
+            }).joined(separator: "_")
+            return result
+        }
+    }
+
+    /// The output format to produce. Defaults to `[]`.
+    open var outputFormatting: OutputFormatting = []
+
+    /// The strategy to use in encoding dates. Defaults to `.deferredToDate`.
+    open var dateEncodingStrategy: DateEncodingStrategy = .deferredToDate
+
+    /// The strategy to use in encoding binary data. Defaults to `.base64`.
+    open var dataEncodingStrategy: DataEncodingStrategy = .base64
+
+    /// The strategy to use in encoding non-conforming numbers. Defaults to `.throw`.
+    open var nonConformingFloatEncodingStrategy: NonConformingFloatEncodingStrategy = .throw
+
+    /// The strategy to use for encoding keys. Defaults to `.useDefaultKeys`.
+    open var keyEncodingStrategy: KeyEncodingStrategy = .useDefaultKeys
+    
+    /// Contextual user-provided information for use during encoding.
+    open var userInfo: [CodingUserInfoKey : Any] = [:]
+
+    /// Options set on the top-level encoder to pass down the encoding hierarchy.
+    fileprivate struct _Options {
+        let dateEncodingStrategy: DateEncodingStrategy
+        let dataEncodingStrategy: DataEncodingStrategy
+        let nonConformingFloatEncodingStrategy: NonConformingFloatEncodingStrategy
+        let keyEncodingStrategy: KeyEncodingStrategy
+        let userInfo: [CodingUserInfoKey : Any]
+    }
+
+    /// The options set on the top-level encoder.
+    fileprivate var options: _Options {
+        return _Options(dateEncodingStrategy: dateEncodingStrategy,
+                        dataEncodingStrategy: dataEncodingStrategy,
+                        nonConformingFloatEncodingStrategy: nonConformingFloatEncodingStrategy,
+                        keyEncodingStrategy: keyEncodingStrategy,
+                        userInfo: userInfo)
+    }
+
+    // MARK: - Constructing a JSON Encoder
+
+    /// Initializes `self` with default strategies.
+    public init() {}
+
+    // MARK: - Encoding Values
+
+    /// Encodes the given top-level value and returns its JSON representation.
+    ///
+    /// - parameter value: The value to encode.
+    /// - returns: A new `Data` value containing the encoded JSON data.
+    /// - throws: `EncodingError.invalidValue` if a non-conforming floating-point value is encountered during encoding, and the encoding strategy is `.throw`.
+    /// - throws: An error if any value throws an error during encoding.
+    open func encode<T : Encodable>(_ value: T) throws -> Data {
+        let encoder = __JSONEncoder(options: self.options)
+
+        guard let topLevel = try encoder.box_(value) else {
+            throw EncodingError.invalidValue(value, 
+                                             EncodingError.Context(codingPath: [], debugDescription: "Top-level \(T.self) did not encode any values."))
+        }
+
+        let writingOptions = JSONSerialization.WritingOptions(rawValue: self.outputFormatting.rawValue).union(.fragmentsAllowed)
+        do {
+           return try JSONSerialization.data(withJSONObject: topLevel, options: writingOptions)
+        } catch {
+            throw EncodingError.invalidValue(value, 
+                                             EncodingError.Context(codingPath: [], debugDescription: "Unable to encode the given top-level value to JSON.", underlyingError: error))
+        }
+    }
+}
+
+// MARK: - __JSONEncoder
+
+// NOTE: older overlays called this class _JSONEncoder.
+// The two must coexist without a conflicting ObjC class name, so it
+// was renamed. The old name must not be used in the new runtime.
+private class __JSONEncoder : Encoder {
+    // MARK: Properties
+
+    /// The encoder's storage.
+    var storage: _JSONEncodingStorage
+
+    /// Options set on the top-level encoder.
+    let options: JSONEncoder._Options
+
+    /// The path to the current point in encoding.
+    public var codingPath: [CodingKey]
+
+    /// Contextual user-provided information for use during encoding.
+    public var userInfo: [CodingUserInfoKey : Any] {
+        return self.options.userInfo
+    }
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with the given top-level encoder options.
+    init(options: JSONEncoder._Options, codingPath: [CodingKey] = []) {
+        self.options = options
+        self.storage = _JSONEncodingStorage()
+        self.codingPath = codingPath
+    }
+
+    /// Returns whether a new element can be encoded at this coding path.
+    ///
+    /// `true` if an element has not yet been encoded at this coding path; `false` otherwise.
+    var canEncodeNewValue: Bool {
+        // Every time a new value gets encoded, the key it's encoded for is pushed onto the coding path (even if it's a nil key from an unkeyed container).
+        // At the same time, every time a container is requested, a new value gets pushed onto the storage stack.
+        // If there are more values on the storage stack than on the coding path, it means the value is requesting more than one container, which violates the precondition.
+        //
+        // This means that anytime something that can request a new container goes onto the stack, we MUST push a key onto the coding path.
+        // Things which will not request containers do not need to have the coding path extended for them (but it doesn't matter if it is, because they will not reach here).
+        return self.storage.count == self.codingPath.count
+    }
+
+    // MARK: - Encoder Methods
+    public func container<Key>(keyedBy: Key.Type) -> KeyedEncodingContainer<Key> {
+        // If an existing keyed container was already requested, return that one.
+        let topContainer: NSMutableDictionary
+        if self.canEncodeNewValue {
+            // We haven't yet pushed a container at this level; do so here.
+            topContainer = self.storage.pushKeyedContainer()
+        } else {
+            guard let container = self.storage.containers.last as? NSMutableDictionary else {
+                preconditionFailure("Attempt to push new keyed encoding container when already previously encoded at this path.")
+            }
+
+            topContainer = container
+        }
+
+        let container = _JSONKeyedEncodingContainer<Key>(referencing: self, codingPath: self.codingPath, wrapping: topContainer)
+        return KeyedEncodingContainer(container)
+    }
+
+    public func unkeyedContainer() -> UnkeyedEncodingContainer {
+        // If an existing unkeyed container was already requested, return that one.
+        let topContainer: NSMutableArray
+        if self.canEncodeNewValue {
+            // We haven't yet pushed a container at this level; do so here.
+            topContainer = self.storage.pushUnkeyedContainer()
+        } else {
+            guard let container = self.storage.containers.last as? NSMutableArray else {
+                preconditionFailure("Attempt to push new unkeyed encoding container when already previously encoded at this path.")
+            }
+
+            topContainer = container
+        }
+
+        return _JSONUnkeyedEncodingContainer(referencing: self, codingPath: self.codingPath, wrapping: topContainer)
+    }
+
+    public func singleValueContainer() -> SingleValueEncodingContainer {
+        return self
+    }
+}
+
+// MARK: - Encoding Storage and Containers
+
+private struct _JSONEncodingStorage {
+    // MARK: Properties
+
+    /// The container stack.
+    /// Elements may be any one of the JSON types (NSNull, NSNumber, NSString, NSArray, NSDictionary).
+    private(set) var containers: [NSObject] = []
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with no containers.
+    init() {}
+
+    // MARK: - Modifying the Stack
+
+    var count: Int {
+        return self.containers.count
+    }
+
+    mutating func pushKeyedContainer() -> NSMutableDictionary {
+        let dictionary = NSMutableDictionary()
+        self.containers.append(dictionary)
+        return dictionary
+    }
+
+    mutating func pushUnkeyedContainer() -> NSMutableArray {
+        let array = NSMutableArray()
+        self.containers.append(array)
+        return array
+    }
+
+    mutating func push(container: __owned NSObject) {
+        self.containers.append(container)
+    }
+
+    mutating func popContainer() -> NSObject {
+        precondition(!self.containers.isEmpty, "Empty container stack.")
+        return self.containers.popLast()!
+    }
+}
+
+// MARK: - Encoding Containers
+
+private struct _JSONKeyedEncodingContainer<K : CodingKey> : KeyedEncodingContainerProtocol {
+    typealias Key = K
+
+    // MARK: Properties
+
+    /// A reference to the encoder we're writing to.
+    private let encoder: __JSONEncoder
+
+    /// A reference to the container we're writing to.
+    private let container: NSMutableDictionary
+
+    /// The path of coding keys taken to get to this point in encoding.
+    private(set) public var codingPath: [CodingKey]
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with the given references.
+    init(referencing encoder: __JSONEncoder, codingPath: [CodingKey], wrapping container: NSMutableDictionary) {
+        self.encoder = encoder
+        self.codingPath = codingPath
+        self.container = container
+    }
+
+    // MARK: - Coding Path Operations
+
+    private func _converted(_ key: CodingKey) -> CodingKey {
+        switch encoder.options.keyEncodingStrategy {
+        case .useDefaultKeys:
+            return key
+        case .convertToSnakeCase:
+            let newKeyString = JSONEncoder.KeyEncodingStrategy._convertToSnakeCase(key.stringValue)
+            return _JSONKey(stringValue: newKeyString, intValue: key.intValue)
+        case .custom(let converter):
+            return converter(codingPath + [key])
+        }
+    }
+    
+    // MARK: - KeyedEncodingContainerProtocol Methods
+
+    public mutating func encodeNil(forKey key: Key) throws {
+        self.container[_converted(key).stringValue] = NSNull()
+    }
+    public mutating func encode(_ value: Bool, forKey key: Key) throws {
+        self.container[_converted(key).stringValue] = self.encoder.box(value)
+    }
+    public mutating func encode(_ value: Int, forKey key: Key) throws {
+        self.container[_converted(key).stringValue] = self.encoder.box(value)
+    }
+    public mutating func encode(_ value: Int8, forKey key: Key) throws {
+        self.container[_converted(key).stringValue] = self.encoder.box(value)
+    }
+    public mutating func encode(_ value: Int16, forKey key: Key) throws {
+        self.container[_converted(key).stringValue] = self.encoder.box(value)
+    }
+    public mutating func encode(_ value: Int32, forKey key: Key) throws {
+        self.container[_converted(key).stringValue] = self.encoder.box(value)
+    }
+    public mutating func encode(_ value: Int64, forKey key: Key) throws {
+        self.container[_converted(key).stringValue] = self.encoder.box(value)
+    }
+    public mutating func encode(_ value: UInt, forKey key: Key) throws {
+        self.container[_converted(key).stringValue] = self.encoder.box(value)
+    }
+    public mutating func encode(_ value: UInt8, forKey key: Key) throws {
+        self.container[_converted(key).stringValue] = self.encoder.box(value)
+    }
+    public mutating func encode(_ value: UInt16, forKey key: Key) throws {
+        self.container[_converted(key).stringValue] = self.encoder.box(value)
+    }
+    public mutating func encode(_ value: UInt32, forKey key: Key) throws {
+        self.container[_converted(key).stringValue] = self.encoder.box(value)
+    }
+    public mutating func encode(_ value: UInt64, forKey key: Key) throws {
+        self.container[_converted(key).stringValue] = self.encoder.box(value)
+    }
+    public mutating func encode(_ value: String, forKey key: Key) throws {
+        self.container[_converted(key).stringValue] = self.encoder.box(value)
+    }
+    
+    public mutating func encode(_ value: Float, forKey key: Key) throws {
+        // Since the float may be invalid and throw, the coding path needs to contain this key.
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+        self.container[_converted(key).stringValue] = try self.encoder.box(value)
+    }
+
+    public mutating func encode(_ value: Double, forKey key: Key) throws {
+        // Since the double may be invalid and throw, the coding path needs to contain this key.
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+        self.container[_converted(key).stringValue] = try self.encoder.box(value)
+    }
+
+    public mutating func encode<T : Encodable>(_ value: T, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+        self.container[_converted(key).stringValue] = try self.encoder.box(value)
+    }
+
+    public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+        let containerKey = _converted(key).stringValue
+        let dictionary: NSMutableDictionary
+        if let existingContainer = self.container[containerKey] {
+            precondition(
+                existingContainer is NSMutableDictionary,
+                "Attempt to re-encode into nested KeyedEncodingContainer<\(Key.self)> for key \"\(containerKey)\" is invalid: non-keyed container already encoded for this key"
+            )
+            dictionary = existingContainer as! NSMutableDictionary
+        } else {
+            dictionary = NSMutableDictionary()
+            self.container[containerKey] = dictionary
+        }
+
+        self.codingPath.append(key)
+        defer { self.codingPath.removeLast() }
+
+        let container = _JSONKeyedEncodingContainer<NestedKey>(referencing: self.encoder, codingPath: self.codingPath, wrapping: dictionary)
+        return KeyedEncodingContainer(container)
+    }
+
+    public mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+        let containerKey = _converted(key).stringValue
+        let array: NSMutableArray
+        if let existingContainer = self.container[containerKey] {
+            precondition(
+                existingContainer is NSMutableArray,
+                "Attempt to re-encode into nested UnkeyedEncodingContainer for key \"\(containerKey)\" is invalid: keyed container/single value already encoded for this key"
+            )
+            array = existingContainer as! NSMutableArray
+        } else {
+            array = NSMutableArray()
+            self.container[containerKey] = array
+        }
+
+        self.codingPath.append(key)
+        defer { self.codingPath.removeLast() }
+        return _JSONUnkeyedEncodingContainer(referencing: self.encoder, codingPath: self.codingPath, wrapping: array)
+    }
+
+    public mutating func superEncoder() -> Encoder {
+        return __JSONReferencingEncoder(referencing: self.encoder, key: _JSONKey.super, convertedKey: _converted(_JSONKey.super), wrapping: self.container)
+    }
+
+    public mutating func superEncoder(forKey key: Key) -> Encoder {
+        return __JSONReferencingEncoder(referencing: self.encoder, key: key, convertedKey: _converted(key), wrapping: self.container)
+    }
+}
+
+private struct _JSONUnkeyedEncodingContainer : UnkeyedEncodingContainer {
+    // MARK: Properties
+
+    /// A reference to the encoder we're writing to.
+    private let encoder: __JSONEncoder
+
+    /// A reference to the container we're writing to.
+    private let container: NSMutableArray
+
+    /// The path of coding keys taken to get to this point in encoding.
+    private(set) public var codingPath: [CodingKey]
+
+    /// The number of elements encoded into the container.
+    public var count: Int {
+        return self.container.count
+    }
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with the given references.
+    init(referencing encoder: __JSONEncoder, codingPath: [CodingKey], wrapping container: NSMutableArray) {
+        self.encoder = encoder
+        self.codingPath = codingPath
+        self.container = container
+    }
+
+    // MARK: - UnkeyedEncodingContainer Methods
+
+    public mutating func encodeNil()             throws { self.container.add(NSNull()) }
+    public mutating func encode(_ value: Bool)   throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: Int)    throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: Int8)   throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: Int16)  throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: Int32)  throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: Int64)  throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: UInt)   throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: UInt8)  throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: UInt16) throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: UInt32) throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: UInt64) throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: String) throws { self.container.add(self.encoder.box(value)) }
+
+    public mutating func encode(_ value: Float)  throws {
+        // Since the float may be invalid and throw, the coding path needs to contain this key.
+        self.encoder.codingPath.append(_JSONKey(index: self.count))
+        defer { self.encoder.codingPath.removeLast() }
+        self.container.add(try self.encoder.box(value))
+    }
+
+    public mutating func encode(_ value: Double) throws {
+        // Since the double may be invalid and throw, the coding path needs to contain this key.
+        self.encoder.codingPath.append(_JSONKey(index: self.count))
+        defer { self.encoder.codingPath.removeLast() }
+        self.container.add(try self.encoder.box(value))
+    }
+
+    public mutating func encode<T : Encodable>(_ value: T) throws {
+        self.encoder.codingPath.append(_JSONKey(index: self.count))
+        defer { self.encoder.codingPath.removeLast() }
+        self.container.add(try self.encoder.box(value))
+    }
+
+    public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
+        self.codingPath.append(_JSONKey(index: self.count))
+        defer { self.codingPath.removeLast() }
+
+        let dictionary = NSMutableDictionary()
+        self.container.add(dictionary)
+
+        let container = _JSONKeyedEncodingContainer<NestedKey>(referencing: self.encoder, codingPath: self.codingPath, wrapping: dictionary)
+        return KeyedEncodingContainer(container)
+    }
+
+    public mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+        self.codingPath.append(_JSONKey(index: self.count))
+        defer { self.codingPath.removeLast() }
+
+        let array = NSMutableArray()
+        self.container.add(array)
+        return _JSONUnkeyedEncodingContainer(referencing: self.encoder, codingPath: self.codingPath, wrapping: array)
+    }
+
+    public mutating func superEncoder() -> Encoder {
+        return __JSONReferencingEncoder(referencing: self.encoder, at: self.container.count, wrapping: self.container)
+    }
+}
+
+extension __JSONEncoder : SingleValueEncodingContainer {
+    // MARK: - SingleValueEncodingContainer Methods
+
+    private func assertCanEncodeNewValue() {
+        precondition(self.canEncodeNewValue, "Attempt to encode value through single value container when previously value already encoded.")
+    }
+
+    public func encodeNil() throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: NSNull())
+    }
+
+    public func encode(_ value: Bool) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: Int) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: Int8) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: Int16) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: Int32) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: Int64) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: UInt) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: UInt8) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: UInt16) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: UInt32) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: UInt64) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: String) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: Float) throws {
+        assertCanEncodeNewValue()
+        try self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: Double) throws {
+        assertCanEncodeNewValue()
+        try self.storage.push(container: self.box(value))
+    }
+
+    public func encode<T : Encodable>(_ value: T) throws {
+        assertCanEncodeNewValue()
+        try self.storage.push(container: self.box(value))
+    }
+}
+
+// MARK: - Concrete Value Representations
+
+private extension __JSONEncoder {
+    /// Returns the given value boxed in a container appropriate for pushing onto the container stack.
+    func box(_ value: Bool)   -> NSObject { return NSNumber(value: value) }
+    func box(_ value: Int)    -> NSObject { return NSNumber(value: value) }
+    func box(_ value: Int8)   -> NSObject { return NSNumber(value: value) }
+    func box(_ value: Int16)  -> NSObject { return NSNumber(value: value) }
+    func box(_ value: Int32)  -> NSObject { return NSNumber(value: value) }
+    func box(_ value: Int64)  -> NSObject { return NSNumber(value: value) }
+    func box(_ value: UInt)   -> NSObject { return NSNumber(value: value) }
+    func box(_ value: UInt8)  -> NSObject { return NSNumber(value: value) }
+    func box(_ value: UInt16) -> NSObject { return NSNumber(value: value) }
+    func box(_ value: UInt32) -> NSObject { return NSNumber(value: value) }
+    func box(_ value: UInt64) -> NSObject { return NSNumber(value: value) }
+    func box(_ value: String) -> NSObject { return NSString(string: value) }
+
+    func box(_ float: Float) throws -> NSObject {
+        guard !float.isInfinite && !float.isNaN else {
+            guard case let .convertToString(positiveInfinity: posInfString,
+                                            negativeInfinity: negInfString,
+                                            nan: nanString) = self.options.nonConformingFloatEncodingStrategy else {
+                throw EncodingError._invalidFloatingPointValue(float, at: codingPath)
+            }
+
+            if float == Float.infinity {
+                return NSString(string: posInfString)
+            } else if float == -Float.infinity {
+                return NSString(string: negInfString)
+            } else {
+                return NSString(string: nanString)
+            }
+        }
+
+        return NSNumber(value: float)
+    }
+
+    func box(_ double: Double) throws -> NSObject {
+        guard !double.isInfinite && !double.isNaN else {
+            guard case let .convertToString(positiveInfinity: posInfString,
+                                            negativeInfinity: negInfString,
+                                            nan: nanString) = self.options.nonConformingFloatEncodingStrategy else {
+                throw EncodingError._invalidFloatingPointValue(double, at: codingPath)
+            }
+
+            if double == Double.infinity {
+                return NSString(string: posInfString)
+            } else if double == -Double.infinity {
+                return NSString(string: negInfString)
+            } else {
+                return NSString(string: nanString)
+            }
+        }
+
+        return NSNumber(value: double)
+    }
+
+    func box(_ date: Date) throws -> NSObject {
+        switch self.options.dateEncodingStrategy {
+        case .deferredToDate:
+            // Must be called with a surrounding with(pushedKey:) call.
+            // Dates encode as single-value objects; this can't both throw and push a container, so no need to catch the error.
+            try date.encode(to: self)
+            return self.storage.popContainer()
+
+        case .secondsSince1970:
+            return NSNumber(value: date.timeIntervalSince1970)
+
+        case .millisecondsSince1970:
+            return NSNumber(value: 1000.0 * date.timeIntervalSince1970)
+
+        case .iso8601:
+            if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+                return NSString(string: _iso8601Formatter.string(from: date))
+            } else {
+                fatalError("ISO8601DateFormatter is unavailable on this platform.")
+            }
+
+        case .formatted(let formatter):
+            return NSString(string: formatter.string(from: date))
+
+        case .custom(let closure):
+            let depth = self.storage.count
+            do {
+                try closure(date, self)
+            } catch {
+                // If the value pushed a container before throwing, pop it back off to restore state.
+                if self.storage.count > depth {
+                    let _ = self.storage.popContainer()
+                }
+
+                throw error
+            }
+
+            guard self.storage.count > depth else {
+                // The closure didn't encode anything. Return the default keyed container.
+                return NSDictionary()
+            }
+
+            // We can pop because the closure encoded something.
+            return self.storage.popContainer()
+        }
+    }
+
+    func box(_ data: Data) throws -> NSObject {
+        switch self.options.dataEncodingStrategy {
+        case .deferredToData:
+            // Must be called with a surrounding with(pushedKey:) call.
+            let depth = self.storage.count
+            do {
+                try data.encode(to: self)
+            } catch {
+                // If the value pushed a container before throwing, pop it back off to restore state.
+                // This shouldn't be possible for Data (which encodes as an array of bytes), but it can't hurt to catch a failure.
+                if self.storage.count > depth {
+                    let _ = self.storage.popContainer()
+                }
+
+                throw error
+            }
+
+            return self.storage.popContainer()
+
+        case .base64:
+            return NSString(string: data.base64EncodedString())
+
+        case .custom(let closure):
+            let depth = self.storage.count
+            do {
+                try closure(data, self)
+            } catch {
+                // If the value pushed a container before throwing, pop it back off to restore state.
+                if self.storage.count > depth {
+                    let _ = self.storage.popContainer()
+                }
+
+                throw error
+            }
+
+            guard self.storage.count > depth else {
+                // The closure didn't encode anything. Return the default keyed container.
+                return NSDictionary()
+            }
+
+            // We can pop because the closure encoded something.
+            return self.storage.popContainer()
+        }
+    }
+
+    func box(_ dict: [String : Encodable]) throws -> NSObject? {
+        let depth = self.storage.count
+        let result = self.storage.pushKeyedContainer()
+        do {
+            for (key, value) in dict {
+                self.codingPath.append(_JSONKey(stringValue: key, intValue: nil))
+                defer { self.codingPath.removeLast() }
+                result[key] = try box(value)
+            }
+        } catch {
+            // If the value pushed a container before throwing, pop it back off to restore state.
+            if self.storage.count > depth {
+                let _ = self.storage.popContainer()
+            }
+
+            throw error
+        }
+
+        // The top container should be a new container.
+        guard self.storage.count > depth else {
+            return nil
+        }
+
+        return self.storage.popContainer()
+    }
+
+    func box(_ value: Encodable) throws -> NSObject {
+        return try self.box_(value) ?? NSDictionary()
+    }
+
+    // This method is called "box_" instead of "box" to disambiguate it from the overloads. Because the return type here is different from all of the "box" overloads (and is more general), any "box" calls in here would call back into "box" recursively instead of calling the appropriate overload, which is not what we want.
+    func box_(_ value: Encodable) throws -> NSObject? {
+        // Disambiguation between variable and function is required due to
+        // issue tracked at: https://bugs.swift.org/browse/SR-1846
+        let type = Swift.type(of: value)
+        if type == Date.self || type == NSDate.self {
+            // Respect Date encoding strategy
+            return try self.box((value as! Date))
+        } else if type == Data.self || type == NSData.self {
+            // Respect Data encoding strategy
+            return try self.box((value as! Data))
+        } else if type == URL.self || type == NSURL.self {
+            // Encode URLs as single strings.
+            return self.box((value as! URL).absoluteString)
+        } else if type == Decimal.self || type == NSDecimalNumber.self {
+            // JSONSerialization can natively handle NSDecimalNumber.
+            return (value as! NSDecimalNumber)
+        } else if value is _JSONStringDictionaryEncodableMarker {
+            return try self.box(value as! [String : Encodable])
+        }
+
+        // The value should request a container from the __JSONEncoder.
+        let depth = self.storage.count
+        do {
+            try value.encode(to: self)
+        } catch {
+            // If the value pushed a container before throwing, pop it back off to restore state.
+            if self.storage.count > depth {
+                let _ = self.storage.popContainer()
+            }
+
+            throw error
+        }
+
+        // The top container should be a new container.
+        guard self.storage.count > depth else {
+            return nil
+        }
+
+        return self.storage.popContainer()
+    }
+}
+
+// MARK: - __JSONReferencingEncoder
+
+/// __JSONReferencingEncoder is a special subclass of __JSONEncoder which has its own storage, but references the contents of a different encoder.
+/// It's used in superEncoder(), which returns a new encoder for encoding a superclass -- the lifetime of the encoder should not escape the scope it's created in, but it doesn't necessarily know when it's done being used (to write to the original container).
+// NOTE: older overlays called this class _JSONReferencingEncoder.
+// The two must coexist without a conflicting ObjC class name, so it
+// was renamed. The old name must not be used in the new runtime.
+private class __JSONReferencingEncoder : __JSONEncoder {
+    // MARK: Reference types.
+
+    /// The type of container we're referencing.
+    private enum Reference {
+        /// Referencing a specific index in an array container.
+        case array(NSMutableArray, Int)
+
+        /// Referencing a specific key in a dictionary container.
+        case dictionary(NSMutableDictionary, String)
+    }
+
+    // MARK: - Properties
+
+    /// The encoder we're referencing.
+    let encoder: __JSONEncoder
+
+    /// The container reference itself.
+    private let reference: Reference
+
+    // MARK: - Initialization
+
+    /// Initializes `self` by referencing the given array container in the given encoder.
+    init(referencing encoder: __JSONEncoder, at index: Int, wrapping array: NSMutableArray) {
+        self.encoder = encoder
+        self.reference = .array(array, index)
+        super.init(options: encoder.options, codingPath: encoder.codingPath)
+
+        self.codingPath.append(_JSONKey(index: index))
+    }
+
+    /// Initializes `self` by referencing the given dictionary container in the given encoder.
+    init(referencing encoder: __JSONEncoder, key: CodingKey, convertedKey: __shared CodingKey, wrapping dictionary: NSMutableDictionary) {
+        self.encoder = encoder
+        self.reference = .dictionary(dictionary, convertedKey.stringValue)
+        super.init(options: encoder.options, codingPath: encoder.codingPath)
+
+        self.codingPath.append(key)
+    }
+
+    // MARK: - Coding Path Operations
+
+    override var canEncodeNewValue: Bool {
+        // With a regular encoder, the storage and coding path grow together.
+        // A referencing encoder, however, inherits its parents coding path, as well as the key it was created for.
+        // We have to take this into account.
+        return self.storage.count == self.codingPath.count - self.encoder.codingPath.count - 1
+    }
+
+    // MARK: - Deinitialization
+
+    // Finalizes `self` by writing the contents of our storage to the referenced encoder's storage.
+    deinit {
+        let value: Any
+        switch self.storage.count {
+        case 0: value = NSDictionary()
+        case 1: value = self.storage.popContainer()
+        default: fatalError("Referencing encoder deallocated with multiple containers on stack.")
+        }
+        
+        switch self.reference {
+        case .array(let array, let index):
+            array.insert(value, at: index)
+
+        case .dictionary(let dictionary, let key):
+            dictionary[NSString(string: key)] = value
+        }
+    }
+}
+
+//===----------------------------------------------------------------------===//
+// JSON Decoder
+//===----------------------------------------------------------------------===//
+
+/// `JSONDecoder` facilitates the decoding of JSON into semantic `Decodable` types.
+// NOTE: older overlays had Foundation.JSONDecoder as the ObjC name.
+// The two must coexist, so it was renamed. The old name must not be
+// used in the new runtime. _TtC10Foundation13__JSONDecoder is the
+// mangled name for Foundation.__JSONDecoder.
+@_objcRuntimeName(_TtC10Foundation13__JSONDecoder)
+open class JSONDecoder {
+    // MARK: Options
+
+    /// The strategy to use for decoding `Date` values.
+    public enum DateDecodingStrategy {
+        /// Defer to `Date` for decoding. This is the default strategy.
+        case deferredToDate
+
+        /// Decode the `Date` as a UNIX timestamp from a JSON number.
+        case secondsSince1970
+
+        /// Decode the `Date` as UNIX millisecond timestamp from a JSON number.
+        case millisecondsSince1970
+
+        /// Decode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
+        @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+        case iso8601
+
+        /// Decode the `Date` as a string parsed by the given formatter.
+        case formatted(DateFormatter)
+
+        /// Decode the `Date` as a custom value decoded by the given closure.
+        case custom((_ decoder: Decoder) throws -> Date)
+    }
+
+    /// The strategy to use for decoding `Data` values.
+    public enum DataDecodingStrategy {
+        /// Defer to `Data` for decoding.
+        case deferredToData
+
+        /// Decode the `Data` from a Base64-encoded string. This is the default strategy.
+        case base64
+
+        /// Decode the `Data` as a custom value decoded by the given closure.
+        case custom((_ decoder: Decoder) throws -> Data)
+    }
+
+    /// The strategy to use for non-JSON-conforming floating-point values (IEEE 754 infinity and NaN).
+    public enum NonConformingFloatDecodingStrategy {
+        /// Throw upon encountering non-conforming values. This is the default strategy.
+        case `throw`
+
+        /// Decode the values from the given representation strings.
+        case convertFromString(positiveInfinity: String, negativeInfinity: String, nan: String)
+    }
+
+    /// The strategy to use for automatically changing the value of keys before decoding.
+    public enum KeyDecodingStrategy {
+        /// Use the keys specified by each type. This is the default strategy.
+        case useDefaultKeys
+        
+        /// Convert from "snake_case_keys" to "camelCaseKeys" before attempting to match a key with the one specified by each type.
+        /// 
+        /// The conversion to upper case uses `Locale.system`, also known as the ICU "root" locale. This means the result is consistent regardless of the current user's locale and language preferences.
+        ///
+        /// Converting from snake case to camel case:
+        /// 1. Capitalizes the word starting after each `_`
+        /// 2. Removes all `_`
+        /// 3. Preserves starting and ending `_` (as these are often used to indicate private variables or other metadata).
+        /// For example, `one_two_three` becomes `oneTwoThree`. `_one_two_three_` becomes `_oneTwoThree_`.
+        ///
+        /// - Note: Using a key decoding strategy has a nominal performance cost, as each string key has to be inspected for the `_` character.
+        case convertFromSnakeCase
+        
+        /// Provide a custom conversion from the key in the encoded JSON to the keys specified by the decoded types.
+        /// The full path to the current decoding position is provided for context (in case you need to locate this key within the payload). The returned key is used in place of the last component in the coding path before decoding.
+        /// If the result of the conversion is a duplicate key, then only one value will be present in the container for the type to decode from.
+        case custom((_ codingPath: [CodingKey]) -> CodingKey)
+        
+        fileprivate static func _convertFromSnakeCase(_ stringKey: String) -> String {
+            guard !stringKey.isEmpty else { return stringKey }
+        
+            // Find the first non-underscore character
+            guard let firstNonUnderscore = stringKey.firstIndex(where: { $0 != "_" }) else {
+                // Reached the end without finding an _
+                return stringKey
+            }
+        
+            // Find the last non-underscore character
+            var lastNonUnderscore = stringKey.index(before: stringKey.endIndex)
+            while lastNonUnderscore > firstNonUnderscore && stringKey[lastNonUnderscore] == "_" {
+                stringKey.formIndex(before: &lastNonUnderscore)
+            }
+        
+            let keyRange = firstNonUnderscore...lastNonUnderscore
+            let leadingUnderscoreRange = stringKey.startIndex..<firstNonUnderscore
+            let trailingUnderscoreRange = stringKey.index(after: lastNonUnderscore)..<stringKey.endIndex
+        
+            let components = stringKey[keyRange].split(separator: "_")
+            let joinedString : String
+            if components.count == 1 {
+                // No underscores in key, leave the word as is - maybe already camel cased
+                joinedString = String(stringKey[keyRange])
+            } else {
+                joinedString = ([components[0].lowercased()] + components[1...].map { $0.capitalized }).joined()
+            }
+        
+            // Do a cheap isEmpty check before creating and appending potentially empty strings
+            let result : String
+            if (leadingUnderscoreRange.isEmpty && trailingUnderscoreRange.isEmpty) {
+                result = joinedString
+            } else if (!leadingUnderscoreRange.isEmpty && !trailingUnderscoreRange.isEmpty) {
+                // Both leading and trailing underscores
+                result = String(stringKey[leadingUnderscoreRange]) + joinedString + String(stringKey[trailingUnderscoreRange])
+            } else if (!leadingUnderscoreRange.isEmpty) {
+                // Just leading
+                result = String(stringKey[leadingUnderscoreRange]) + joinedString
+            } else {
+                // Just trailing
+                result = joinedString + String(stringKey[trailingUnderscoreRange])
+            }
+            return result
+        }
+    }
+    
+    /// The strategy to use in decoding dates. Defaults to `.deferredToDate`.
+    open var dateDecodingStrategy: DateDecodingStrategy = .deferredToDate
+
+    /// The strategy to use in decoding binary data. Defaults to `.base64`.
+    open var dataDecodingStrategy: DataDecodingStrategy = .base64
+
+    /// The strategy to use in decoding non-conforming numbers. Defaults to `.throw`.
+    open var nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy = .throw
+
+    /// The strategy to use for decoding keys. Defaults to `.useDefaultKeys`.
+    open var keyDecodingStrategy: KeyDecodingStrategy = .useDefaultKeys
+    
+    /// Contextual user-provided information for use during decoding.
+    open var userInfo: [CodingUserInfoKey : Any] = [:]
+
+    /// Options set on the top-level encoder to pass down the decoding hierarchy.
+    fileprivate struct _Options {
+        let dateDecodingStrategy: DateDecodingStrategy
+        let dataDecodingStrategy: DataDecodingStrategy
+        let nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy
+        let keyDecodingStrategy: KeyDecodingStrategy
+        let userInfo: [CodingUserInfoKey : Any]
+    }
+
+    /// The options set on the top-level decoder.
+    fileprivate var options: _Options {
+        return _Options(dateDecodingStrategy: dateDecodingStrategy,
+                        dataDecodingStrategy: dataDecodingStrategy,
+                        nonConformingFloatDecodingStrategy: nonConformingFloatDecodingStrategy,
+                        keyDecodingStrategy: keyDecodingStrategy,
+                        userInfo: userInfo)
+    }
+
+    // MARK: - Constructing a JSON Decoder
+
+    /// Initializes `self` with default strategies.
+    public init() {}
+
+    // MARK: - Decoding Values
+
+    /// Decodes a top-level value of the given type from the given JSON representation.
+    ///
+    /// - parameter type: The type of the value to decode.
+    /// - parameter data: The data to decode from.
+    /// - returns: A value of the requested type.
+    /// - throws: `DecodingError.dataCorrupted` if values requested from the payload are corrupted, or if the given data is not valid JSON.
+    /// - throws: An error if any value throws an error during decoding.
+    open func decode<T : Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        let topLevel: Any
+        do {
+           topLevel = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+        } catch {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid JSON.", underlyingError: error))
+        }
+
+        let decoder = __JSONDecoder(referencing: topLevel, options: self.options)
+        guard let value = try decoder.unbox(topLevel, as: type) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: [], debugDescription: "The given data did not contain a top-level value."))
+        }
+
+        return value
+    }
+}
+
+// MARK: - __JSONDecoder
+
+// NOTE: older overlays called this class _JSONDecoder. The two must
+// coexist without a conflicting ObjC class name, so it was renamed.
+// The old name must not be used in the new runtime.
+private class __JSONDecoder : Decoder {
+    // MARK: Properties
+
+    /// The decoder's storage.
+    var storage: _JSONDecodingStorage
+
+    /// Options set on the top-level decoder.
+    let options: JSONDecoder._Options
+
+    /// The path to the current point in encoding.
+    fileprivate(set) public var codingPath: [CodingKey]
+
+    /// Contextual user-provided information for use during encoding.
+    public var userInfo: [CodingUserInfoKey : Any] {
+        return self.options.userInfo
+    }
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with the given top-level container and options.
+    init(referencing container: Any, at codingPath: [CodingKey] = [], options: JSONDecoder._Options) {
+        self.storage = _JSONDecodingStorage()
+        self.storage.push(container: container)
+        self.codingPath = codingPath
+        self.options = options
+    }
+
+    // MARK: - Decoder Methods
+
+    public func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
+        guard !(self.storage.topContainer is NSNull) else {
+            throw DecodingError.valueNotFound(KeyedDecodingContainer<Key>.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get keyed decoding container -- found null value instead."))
+        }
+
+        guard let topContainer = self.storage.topContainer as? [String : Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: self.storage.topContainer)
+        }
+
+        let container = _JSONKeyedDecodingContainer<Key>(referencing: self, wrapping: topContainer)
+        return KeyedDecodingContainer(container)
+    }
+
+    public func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        guard !(self.storage.topContainer is NSNull) else {
+            throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get unkeyed decoding container -- found null value instead."))
+        }
+
+        guard let topContainer = self.storage.topContainer as? [Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [Any].self, reality: self.storage.topContainer)
+        }
+
+        return _JSONUnkeyedDecodingContainer(referencing: self, wrapping: topContainer)
+    }
+
+    public func singleValueContainer() throws -> SingleValueDecodingContainer {
+        return self
+    }
+}
+
+// MARK: - Decoding Storage
+
+private struct _JSONDecodingStorage {
+    // MARK: Properties
+
+    /// The container stack.
+    /// Elements may be any one of the JSON types (NSNull, NSNumber, String, Array, [String : Any]).
+    private(set) var containers: [Any] = []
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with no containers.
+    init() {}
+
+    // MARK: - Modifying the Stack
+
+    var count: Int {
+        return self.containers.count
+    }
+
+    var topContainer: Any {
+        precondition(!self.containers.isEmpty, "Empty container stack.")
+        return self.containers.last!
+    }
+
+    mutating func push(container: __owned Any) {
+        self.containers.append(container)
+    }
+
+    mutating func popContainer() {
+        precondition(!self.containers.isEmpty, "Empty container stack.")
+        self.containers.removeLast()
+    }
+}
+
+// MARK: Decoding Containers
+
+private struct _JSONKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProtocol {
+    typealias Key = K
+
+    // MARK: Properties
+
+    /// A reference to the decoder we're reading from.
+    private let decoder: __JSONDecoder
+
+    /// A reference to the container we're reading from.
+    private let container: [String : Any]
+
+    /// The path of coding keys taken to get to this point in decoding.
+    private(set) public var codingPath: [CodingKey]
+
+    // MARK: - Initialization
+
+    /// Initializes `self` by referencing the given decoder and container.
+    init(referencing decoder: __JSONDecoder, wrapping container: [String : Any]) {
+        self.decoder = decoder
+        switch decoder.options.keyDecodingStrategy {
+        case .useDefaultKeys:
+            self.container = container
+        case .convertFromSnakeCase:
+            // Convert the snake case keys in the container to camel case.
+            // If we hit a duplicate key after conversion, then we'll use the first one we saw. Effectively an undefined behavior with JSON dictionaries.
+            self.container = Dictionary(container.map {
+                key, value in (JSONDecoder.KeyDecodingStrategy._convertFromSnakeCase(key), value)
+            }, uniquingKeysWith: { (first, _) in first })
+        case .custom(let converter):
+            self.container = Dictionary(container.map {
+                key, value in (converter(decoder.codingPath + [_JSONKey(stringValue: key, intValue: nil)]).stringValue, value)
+            }, uniquingKeysWith: { (first, _) in first })
+        }
+        self.codingPath = decoder.codingPath
+    }
+
+    // MARK: - KeyedDecodingContainerProtocol Methods
+
+    public var allKeys: [Key] {
+        return self.container.keys.compactMap { Key(stringValue: $0) }
+    }
+
+    public func contains(_ key: Key) -> Bool {
+        return self.container[key.stringValue] != nil
+    }
+
+    private func _errorDescription(of key: CodingKey) -> String {
+        switch decoder.options.keyDecodingStrategy {
+        case .convertFromSnakeCase:
+            // In this case we can attempt to recover the original value by reversing the transform
+            let original = key.stringValue
+            let converted = JSONEncoder.KeyEncodingStrategy._convertToSnakeCase(original)
+            let roundtrip = JSONDecoder.KeyDecodingStrategy._convertFromSnakeCase(converted)
+            if converted == original {
+                return "\(key) (\"\(original)\")"
+            } else if roundtrip == original {
+                return "\(key) (\"\(original)\"), converted to \(converted)"
+            } else {
+                return "\(key) (\"\(original)\"), with divergent representation \(roundtrip), converted to \(converted)"
+            }
+        default:
+            // Otherwise, just report the converted string
+            return "\(key) (\"\(key.stringValue)\")"
+        }
+    }
+    
+    public func decodeNil(forKey key: Key) throws -> Bool {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+        }
+
+        return entry is NSNull
+    }
+
+    public func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: Bool.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: Int.Type, forKey key: Key) throws -> Int {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: Int.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: Int8.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: Int16.Type, forKey key: Key) throws -> Int16 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: Int16.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: Int32.Type, forKey key: Key) throws -> Int32 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: Int32.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: Int64.Type, forKey key: Key) throws -> Int64 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: Int64.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: UInt.Type, forKey key: Key) throws -> UInt {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: UInt.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: UInt8.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: UInt16.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: UInt32.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: UInt64.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: Float.Type, forKey key: Key) throws -> Float {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: Float.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: Double.Type, forKey key: Key) throws -> Double {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: Double.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: String.Type, forKey key: Key) throws -> String {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: String.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode<T : Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: type) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key,
+                                            DecodingError.Context(codingPath: self.codingPath,
+                                                                  debugDescription: "Cannot get \(KeyedDecodingContainer<NestedKey>.self) -- no value found for key \(_errorDescription(of: key))"))
+        }
+
+        guard let dictionary = value as? [String : Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: value)
+        }
+
+        let container = _JSONKeyedDecodingContainer<NestedKey>(referencing: self.decoder, wrapping: dictionary)
+        return KeyedDecodingContainer(container)
+    }
+
+    public func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key,
+                                            DecodingError.Context(codingPath: self.codingPath,
+                                                                  debugDescription: "Cannot get UnkeyedDecodingContainer -- no value found for key \(_errorDescription(of: key))"))
+        }
+
+        guard let array = value as? [Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [Any].self, reality: value)
+        }
+
+        return _JSONUnkeyedDecodingContainer(referencing: self.decoder, wrapping: array)
+    }
+
+    private func _superDecoder(forKey key: __owned CodingKey) throws -> Decoder {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let value: Any = self.container[key.stringValue] ?? NSNull()
+        return __JSONDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
+    }
+
+    public func superDecoder() throws -> Decoder {
+        return try _superDecoder(forKey: _JSONKey.super)
+    }
+
+    public func superDecoder(forKey key: Key) throws -> Decoder {
+        return try _superDecoder(forKey: key)
+    }
+}
+
+private struct _JSONUnkeyedDecodingContainer : UnkeyedDecodingContainer {
+    // MARK: Properties
+
+    /// A reference to the decoder we're reading from.
+    private let decoder: __JSONDecoder
+
+    /// A reference to the container we're reading from.
+    private let container: [Any]
+
+    /// The path of coding keys taken to get to this point in decoding.
+    private(set) public var codingPath: [CodingKey]
+
+    /// The index of the element we're about to decode.
+    private(set) public var currentIndex: Int
+
+    // MARK: - Initialization
+
+    /// Initializes `self` by referencing the given decoder and container.
+    init(referencing decoder: __JSONDecoder, wrapping container: [Any]) {
+        self.decoder = decoder
+        self.container = container
+        self.codingPath = decoder.codingPath
+        self.currentIndex = 0
+    }
+
+    // MARK: - UnkeyedDecodingContainer Methods
+
+    public var count: Int? {
+        return self.container.count
+    }
+
+    public var isAtEnd: Bool {
+        return self.currentIndex >= self.count!
+    }
+
+    public mutating func decodeNil() throws -> Bool {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(Any?.self, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        if self.container[self.currentIndex] is NSNull {
+            self.currentIndex += 1
+            return true
+        } else {
+            return false
+        }
+    }
+
+    public mutating func decode(_ type: Bool.Type) throws -> Bool {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Bool.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: Int.Type) throws -> Int {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: Int8.Type) throws -> Int8 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int8.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: Int16.Type) throws -> Int16 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int16.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: Int32.Type) throws -> Int32 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int32.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: Int64.Type) throws -> Int64 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int64.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: UInt.Type) throws -> UInt {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: UInt8.Type) throws -> UInt8 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt8.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: UInt16.Type) throws -> UInt16 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt16.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: UInt32.Type) throws -> UInt32 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt32.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: UInt64.Type) throws -> UInt64 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt64.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: Float.Type) throws -> Float {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Float.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: Double.Type) throws -> Double {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Double.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: String.Type) throws -> String {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: String.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode<T : Decodable>(_ type: T.Type) throws -> T {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: type) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_JSONKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> {
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(KeyedDecodingContainer<NestedKey>.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get nested keyed container -- unkeyed container is at end."))
+        }
+
+        let value = self.container[self.currentIndex]
+        guard !(value is NSNull) else {
+            throw DecodingError.valueNotFound(KeyedDecodingContainer<NestedKey>.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get keyed decoding container -- found null value instead."))
+        }
+
+        guard let dictionary = value as? [String : Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: value)
+        }
+
+        self.currentIndex += 1
+        let container = _JSONKeyedDecodingContainer<NestedKey>(referencing: self.decoder, wrapping: dictionary)
+        return KeyedDecodingContainer(container)
+    }
+
+    public mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get nested keyed container -- unkeyed container is at end."))
+        }
+
+        let value = self.container[self.currentIndex]
+        guard !(value is NSNull) else {
+            throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get keyed decoding container -- found null value instead."))
+        }
+
+        guard let array = value as? [Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [Any].self, reality: value)
+        }
+
+        self.currentIndex += 1
+        return _JSONUnkeyedDecodingContainer(referencing: self.decoder, wrapping: array)
+    }
+
+    public mutating func superDecoder() throws -> Decoder {
+        self.decoder.codingPath.append(_JSONKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(Decoder.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get superDecoder() -- unkeyed container is at end."))
+        }
+
+        let value = self.container[self.currentIndex]
+        self.currentIndex += 1
+        return __JSONDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
+    }
+}
+
+extension __JSONDecoder : SingleValueDecodingContainer {
+    // MARK: SingleValueDecodingContainer Methods
+
+    private func expectNonNull<T>(_ type: T.Type) throws {
+        guard !self.decodeNil() else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected \(type) but found null value instead."))
+        }
+    }
+
+    public func decodeNil() -> Bool {
+        return self.storage.topContainer is NSNull
+    }
+
+    public func decode(_ type: Bool.Type) throws -> Bool {
+        try expectNonNull(Bool.self)
+        return try self.unbox(self.storage.topContainer, as: Bool.self)!
+    }
+
+    public func decode(_ type: Int.Type) throws -> Int {
+        try expectNonNull(Int.self)
+        return try self.unbox(self.storage.topContainer, as: Int.self)!
+    }
+
+    public func decode(_ type: Int8.Type) throws -> Int8 {
+        try expectNonNull(Int8.self)
+        return try self.unbox(self.storage.topContainer, as: Int8.self)!
+    }
+
+    public func decode(_ type: Int16.Type) throws -> Int16 {
+        try expectNonNull(Int16.self)
+        return try self.unbox(self.storage.topContainer, as: Int16.self)!
+    }
+
+    public func decode(_ type: Int32.Type) throws -> Int32 {
+        try expectNonNull(Int32.self)
+        return try self.unbox(self.storage.topContainer, as: Int32.self)!
+    }
+
+    public func decode(_ type: Int64.Type) throws -> Int64 {
+        try expectNonNull(Int64.self)
+        return try self.unbox(self.storage.topContainer, as: Int64.self)!
+    }
+
+    public func decode(_ type: UInt.Type) throws -> UInt {
+        try expectNonNull(UInt.self)
+        return try self.unbox(self.storage.topContainer, as: UInt.self)!
+    }
+
+    public func decode(_ type: UInt8.Type) throws -> UInt8 {
+        try expectNonNull(UInt8.self)
+        return try self.unbox(self.storage.topContainer, as: UInt8.self)!
+    }
+
+    public func decode(_ type: UInt16.Type) throws -> UInt16 {
+        try expectNonNull(UInt16.self)
+        return try self.unbox(self.storage.topContainer, as: UInt16.self)!
+    }
+
+    public func decode(_ type: UInt32.Type) throws -> UInt32 {
+        try expectNonNull(UInt32.self)
+        return try self.unbox(self.storage.topContainer, as: UInt32.self)!
+    }
+
+    public func decode(_ type: UInt64.Type) throws -> UInt64 {
+        try expectNonNull(UInt64.self)
+        return try self.unbox(self.storage.topContainer, as: UInt64.self)!
+    }
+
+    public func decode(_ type: Float.Type) throws -> Float {
+        try expectNonNull(Float.self)
+        return try self.unbox(self.storage.topContainer, as: Float.self)!
+    }
+
+    public func decode(_ type: Double.Type) throws -> Double {
+        try expectNonNull(Double.self)
+        return try self.unbox(self.storage.topContainer, as: Double.self)!
+    }
+
+    public func decode(_ type: String.Type) throws -> String {
+        try expectNonNull(String.self)
+        return try self.unbox(self.storage.topContainer, as: String.self)!
+    }
+
+    public func decode<T : Decodable>(_ type: T.Type) throws -> T {
+        try expectNonNull(type)
+        return try self.unbox(self.storage.topContainer, as: type)!
+    }
+}
+
+// MARK: - Concrete Value Representations
+
+private extension __JSONDecoder {
+    /// Returns the given value unboxed from a container.
+    func unbox(_ value: Any, as type: Bool.Type) throws -> Bool? {
+        guard !(value is NSNull) else { return nil }
+
+        if let number = value as? NSNumber {
+            // TODO: Add a flag to coerce non-boolean numbers into Bools?
+            if number === kCFBooleanTrue as NSNumber {
+                return true
+            } else if number === kCFBooleanFalse as NSNumber {
+                return false
+            }
+
+        /* FIXME: If swift-corelibs-foundation doesn't change to use NSNumber, this code path will need to be included and tested:
+        } else if let bool = value as? Bool {
+            return bool
+        */
+
+        }
+
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+
+    func unbox(_ value: Any, as type: Int.Type) throws -> Int? {
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int = number.intValue
+        guard NSNumber(value: int) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return int
+    }
+
+    func unbox(_ value: Any, as type: Int8.Type) throws -> Int8? {
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int8 = number.int8Value
+        guard NSNumber(value: int8) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return int8
+    }
+
+    func unbox(_ value: Any, as type: Int16.Type) throws -> Int16? {
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int16 = number.int16Value
+        guard NSNumber(value: int16) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return int16
+    }
+
+    func unbox(_ value: Any, as type: Int32.Type) throws -> Int32? {
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int32 = number.int32Value
+        guard NSNumber(value: int32) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return int32
+    }
+
+    func unbox(_ value: Any, as type: Int64.Type) throws -> Int64? {
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int64 = number.int64Value
+        guard NSNumber(value: int64) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return int64
+    }
+
+    func unbox(_ value: Any, as type: UInt.Type) throws -> UInt? {
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint = number.uintValue
+        guard NSNumber(value: uint) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint
+    }
+
+    func unbox(_ value: Any, as type: UInt8.Type) throws -> UInt8? {
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint8 = number.uint8Value
+        guard NSNumber(value: uint8) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint8
+    }
+
+    func unbox(_ value: Any, as type: UInt16.Type) throws -> UInt16? {
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint16 = number.uint16Value
+        guard NSNumber(value: uint16) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint16
+    }
+
+    func unbox(_ value: Any, as type: UInt32.Type) throws -> UInt32? {
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint32 = number.uint32Value
+        guard NSNumber(value: uint32) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint32
+    }
+
+    func unbox(_ value: Any, as type: UInt64.Type) throws -> UInt64? {
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint64 = number.uint64Value
+        guard NSNumber(value: uint64) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint64
+    }
+
+    func unbox(_ value: Any, as type: Float.Type) throws -> Float? {
+        guard !(value is NSNull) else { return nil }
+
+        if let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse {
+            // We are willing to return a Float by losing precision:
+            // * If the original value was integral,
+            //   * and the integral value was > Float.greatestFiniteMagnitude, we will fail
+            //   * and the integral value was <= Float.greatestFiniteMagnitude, we are willing to lose precision past 2^24
+            // * If it was a Float, you will get back the precise value
+            // * If it was a Double or Decimal, you will get back the nearest approximation if it will fit
+            let double = number.doubleValue
+            guard abs(double) <= Double(Float.greatestFiniteMagnitude) else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number \(number) does not fit in \(type)."))
+            }
+
+            return Float(double)
+
+        /* FIXME: If swift-corelibs-foundation doesn't change to use NSNumber, this code path will need to be included and tested:
+        } else if let double = value as? Double {
+            if abs(double) <= Double(Float.max) {
+                return Float(double)
+            }
+
+            overflow = true
+        } else if let int = value as? Int {
+            if let float = Float(exactly: int) {
+                return float
+            }
+
+            overflow = true
+        */
+
+        } else if let string = value as? String,
+            case .convertFromString(let posInfString, let negInfString, let nanString) = self.options.nonConformingFloatDecodingStrategy {
+            if string == posInfString {
+                return Float.infinity
+            } else if string == negInfString {
+                return -Float.infinity
+            } else if string == nanString {
+                return Float.nan
+            }
+        }
+
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+
+    func unbox(_ value: Any, as type: Double.Type) throws -> Double? {
+        guard !(value is NSNull) else { return nil }
+
+        if let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse {
+            // We are always willing to return the number as a Double:
+            // * If the original value was integral, it is guaranteed to fit in a Double; we are willing to lose precision past 2^53 if you encoded a UInt64 but requested a Double
+            // * If it was a Float or Double, you will get back the precise value
+            // * If it was Decimal, you will get back the nearest approximation
+            return number.doubleValue
+
+        /* FIXME: If swift-corelibs-foundation doesn't change to use NSNumber, this code path will need to be included and tested:
+        } else if let double = value as? Double {
+            return double
+        } else if let int = value as? Int {
+            if let double = Double(exactly: int) {
+                return double
+            }
+
+            overflow = true
+        */
+
+        } else if let string = value as? String,
+            case .convertFromString(let posInfString, let negInfString, let nanString) = self.options.nonConformingFloatDecodingStrategy {
+            if string == posInfString {
+                return Double.infinity
+            } else if string == negInfString {
+                return -Double.infinity
+            } else if string == nanString {
+                return Double.nan
+            }
+        }
+
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+
+    func unbox(_ value: Any, as type: String.Type) throws -> String? {
+        guard !(value is NSNull) else { return nil }
+
+        guard let string = value as? String else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        return string
+    }
+
+    func unbox(_ value: Any, as type: Date.Type) throws -> Date? {
+        guard !(value is NSNull) else { return nil }
+
+        switch self.options.dateDecodingStrategy {
+        case .deferredToDate:
+            self.storage.push(container: value)
+            defer { self.storage.popContainer() }
+            return try Date(from: self)
+
+        case .secondsSince1970:
+            let double = try self.unbox(value, as: Double.self)!
+            return Date(timeIntervalSince1970: double)
+
+        case .millisecondsSince1970:
+            let double = try self.unbox(value, as: Double.self)!
+            return Date(timeIntervalSince1970: double / 1000.0)
+
+        case .iso8601:
+            if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+                let string = try self.unbox(value, as: String.self)!
+                guard let date = _iso8601Formatter.date(from: string) else {
+                    throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected date string to be ISO8601-formatted."))
+                }
+
+                return date
+            } else {
+                fatalError("ISO8601DateFormatter is unavailable on this platform.")
+            }
+
+        case .formatted(let formatter):
+            let string = try self.unbox(value, as: String.self)!
+            guard let date = formatter.date(from: string) else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Date string does not match format expected by formatter."))
+            }
+
+            return date
+
+        case .custom(let closure):
+            self.storage.push(container: value)
+            defer { self.storage.popContainer() }
+            return try closure(self)
+        }
+    }
+
+    func unbox(_ value: Any, as type: Data.Type) throws -> Data? {
+        guard !(value is NSNull) else { return nil }
+
+        switch self.options.dataDecodingStrategy {
+        case .deferredToData:
+            self.storage.push(container: value)
+            defer { self.storage.popContainer() }
+            return try Data(from: self)
+
+        case .base64:
+            guard let string = value as? String else {
+                throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+            }
+
+            guard let data = Data(base64Encoded: string) else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Encountered Data is not valid Base64."))
+            }
+
+            return data
+
+        case .custom(let closure):
+            self.storage.push(container: value)
+            defer { self.storage.popContainer() }
+            return try closure(self)
+        }
+    }
+
+    func unbox(_ value: Any, as type: Decimal.Type) throws -> Decimal? {
+        guard !(value is NSNull) else { return nil }
+
+        // Attempt to bridge from NSDecimalNumber.
+        if let decimal = value as? Decimal {
+            return decimal
+        } else {
+            let doubleValue = try self.unbox(value, as: Double.self)!
+            return Decimal(doubleValue)
+        }
+    }
+
+    func unbox<T>(_ value: Any, as type: _JSONStringDictionaryDecodableMarker.Type) throws -> T? {
+        guard !(value is NSNull) else { return nil }
+
+        var result = [String : Any]()
+        guard let dict = value as? NSDictionary else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+        let elementType = type.elementType
+        for (key, value) in dict {
+            let key = key as! String
+            self.codingPath.append(_JSONKey(stringValue: key, intValue: nil))
+            defer { self.codingPath.removeLast() }
+
+            result[key] = try unbox_(value, as: elementType)
+        }
+
+        return result as? T
+    }
+
+    func unbox<T : Decodable>(_ value: Any, as type: T.Type) throws -> T? {
+        return try unbox_(value, as: type) as? T
+    }
+
+    func unbox_(_ value: Any, as type: Decodable.Type) throws -> Any? {
+        if type == Date.self || type == NSDate.self {
+            return try self.unbox(value, as: Date.self)
+        } else if type == Data.self || type == NSData.self {
+            return try self.unbox(value, as: Data.self)
+        } else if type == URL.self || type == NSURL.self {
+            guard let urlString = try self.unbox(value, as: String.self) else {
+                return nil
+            }
+
+            guard let url = URL(string: urlString) else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                        debugDescription: "Invalid URL string."))
+            }
+            return url
+        } else if type == Decimal.self || type == NSDecimalNumber.self {
+            return try self.unbox(value, as: Decimal.self)
+        } else if let stringKeyedDictType = type as? _JSONStringDictionaryDecodableMarker.Type {
+            return try self.unbox(value, as: stringKeyedDictType)
+        } else {
+            self.storage.push(container: value)
+            defer { self.storage.popContainer() }
+            return try type.init(from: self)
+        }
+    }
+}
+
+//===----------------------------------------------------------------------===//
+// Shared Key Types
+//===----------------------------------------------------------------------===//
+
+private struct _JSONKey : CodingKey {
+    public var stringValue: String
+    public var intValue: Int?
+
+    public init?(stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = nil
+    }
+
+    public init?(intValue: Int) {
+        self.stringValue = "\(intValue)"
+        self.intValue = intValue
+    }
+
+    public init(stringValue: String, intValue: Int?) {
+        self.stringValue = stringValue
+        self.intValue = intValue
+    }
+
+    init(index: Int) {
+        self.stringValue = "Index \(index)"
+        self.intValue = index
+    }
+
+    static let `super` = _JSONKey(stringValue: "super")!
+}
+
+//===----------------------------------------------------------------------===//
+// Shared ISO8601 Date Formatter
+//===----------------------------------------------------------------------===//
+
+// NOTE: This value is implicitly lazy and _must_ be lazy. We're compiled against the latest SDK (w/ ISO8601DateFormatter), but linked against whichever Foundation the user has. ISO8601DateFormatter might not exist, so we better not hit this code path on an older OS.
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+private var _iso8601Formatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = .withInternetDateTime
+    return formatter
+}()
+
+//===----------------------------------------------------------------------===//
+// Error Utilities
+//===----------------------------------------------------------------------===//
+
+extension EncodingError {
+    /// Returns a `.invalidValue` error describing the given invalid floating-point value.
+    ///
+    ///
+    /// - parameter value: The value that was invalid to encode.
+    /// - parameter path: The path of `CodingKey`s taken to encode this value.
+    /// - returns: An `EncodingError` with the appropriate path and debug description.
+    fileprivate static func _invalidFloatingPointValue<T : FloatingPoint>(_ value: T, at codingPath: [CodingKey]) -> EncodingError {
+        let valueDescription: String
+        if value == T.infinity {
+            valueDescription = "\(T.self).infinity"
+        } else if value == -T.infinity {
+            valueDescription = "-\(T.self).infinity"
+        } else {
+            valueDescription = "\(T.self).nan"
+        }
+
+        let debugDescription = "Unable to encode \(valueDescription) directly in JSON. Use JSONEncoder.NonConformingFloatEncodingStrategy.convertToString to specify how the value should be encoded."
+        return .invalidValue(value, EncodingError.Context(codingPath: codingPath, debugDescription: debugDescription))
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/Locale.swift
+++ b/Darwin/Foundation-swiftoverlay/Locale.swift
@@ -1,0 +1,501 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+@_implementationOnly import _FoundationOverlayShims
+
+/**
+ `Locale` encapsulates information about linguistic, cultural, and technological conventions and standards. Examples of information encapsulated by a locale include the symbol used for the decimal separator in numbers and the way dates are formatted.
+ 
+ Locales are typically used to provide, format, and interpret information about and according to the user's customs and preferences. They are frequently used in conjunction with formatters. Although you can use many locales, you usually use the one associated with the current user.
+*/
+public struct Locale : Hashable, Equatable, ReferenceConvertible {
+    public typealias ReferenceType = NSLocale
+    
+    public typealias LanguageDirection = NSLocale.LanguageDirection
+    
+    fileprivate var _wrapped : NSLocale
+    private var _autoupdating : Bool
+
+    /// Returns a locale which tracks the user's current preferences.
+    ///
+    /// If mutated, this Locale will no longer track the user's preferences.
+    ///
+    /// - note: The autoupdating Locale will only compare equal to another autoupdating Locale.
+    public static var autoupdatingCurrent : Locale {
+        return Locale(adoptingReference: __NSLocaleAutoupdating() as! NSLocale, autoupdating: true)
+    }
+    
+    /// Returns the user's current locale.
+    public static var current : Locale {
+        return Locale(adoptingReference: __NSLocaleCurrent() as! NSLocale, autoupdating: false)
+    }
+    
+    @available(*, unavailable, message: "Consider using the user's locale or nil instead, depending on use case")
+    public static var system : Locale { fatalError() }
+    
+    // MARK: -
+    //
+    
+    /// Return a locale with the specified identifier.
+    public init(identifier: String) {
+        _wrapped = NSLocale(localeIdentifier: identifier)
+        _autoupdating = false
+    }
+    
+    fileprivate init(reference: __shared NSLocale) {
+        _wrapped = reference.copy() as! NSLocale
+        if __NSLocaleIsAutoupdating(reference) {
+            _autoupdating = true
+        } else {
+            _autoupdating = false
+        }
+    }
+    
+    private init(adoptingReference reference: NSLocale, autoupdating: Bool) {
+        _wrapped = reference
+        _autoupdating = autoupdating
+    }
+
+    // MARK: -
+    //
+    
+    /// Returns a localized string for a specified identifier.
+    ///
+    /// For example, in the "en" locale, the result for `"es"` is `"Spanish"`.
+    public func localizedString(forIdentifier identifier: String) -> String? {
+        return _wrapped.displayName(forKey: .identifier, value: identifier)
+    }
+    
+    /// Returns a localized string for a specified language code.
+    ///
+    /// For example, in the "en" locale, the result for `"es"` is `"Spanish"`.
+    public func localizedString(forLanguageCode languageCode: String) -> String? {
+        return _wrapped.displayName(forKey: .languageCode, value: languageCode)
+    }
+
+    /// Returns a localized string for a specified region code.
+    ///
+    /// For example, in the "en" locale, the result for `"fr"` is `"France"`.
+    public func localizedString(forRegionCode regionCode: String) -> String? {
+        return _wrapped.displayName(forKey: .countryCode, value: regionCode)
+    }
+    
+    /// Returns a localized string for a specified script code.
+    ///
+    /// For example, in the "en" locale, the result for `"Hans"` is `"Simplified Han"`.
+    public func localizedString(forScriptCode scriptCode: String) -> String? {
+        return _wrapped.displayName(forKey: .scriptCode, value: scriptCode)
+    }
+
+    /// Returns a localized string for a specified variant code.
+    ///
+    /// For example, in the "en" locale, the result for `"POSIX"` is `"Computer"`.
+    public func localizedString(forVariantCode variantCode: String) -> String? {
+        return _wrapped.displayName(forKey: .variantCode, value: variantCode)
+    }
+    
+    /// Returns a localized string for a specified `Calendar.Identifier`.
+    ///
+    /// For example, in the "en" locale, the result for `.buddhist` is `"Buddhist Calendar"`.
+    public func localizedString(for calendarIdentifier: Calendar.Identifier) -> String? {
+        // NSLocale doesn't export a constant for this
+        let result = CFLocaleCopyDisplayNameForPropertyValue(unsafeBitCast(_wrapped, to: CFLocale.self), .calendarIdentifier, Calendar._toNSCalendarIdentifier(calendarIdentifier).rawValue as CFString) as String?
+        return result
+    }
+
+    /// Returns a localized string for a specified ISO 4217 currency code.
+    ///
+    /// For example, in the "en" locale, the result for `"USD"` is `"US Dollar"`.
+    /// - seealso: `Locale.isoCurrencyCodes`
+    public func localizedString(forCurrencyCode currencyCode: String) -> String? {
+        return _wrapped.displayName(forKey: .currencyCode, value: currencyCode)
+    }
+
+    /// Returns a localized string for a specified ICU collation identifier.
+    ///
+    /// For example, in the "en" locale, the result for `"phonebook"` is `"Phonebook Sort Order"`.
+    public func localizedString(forCollationIdentifier collationIdentifier: String) -> String? {
+        return _wrapped.displayName(forKey: .collationIdentifier, value: collationIdentifier)
+    }
+
+    /// Returns a localized string for a specified ICU collator identifier.
+    public func localizedString(forCollatorIdentifier collatorIdentifier: String) -> String? {
+        return _wrapped.displayName(forKey: .collatorIdentifier, value: collatorIdentifier)
+    }
+
+    // MARK: -
+    //
+
+    /// Returns the identifier of the locale.
+    public var identifier: String {
+        return _wrapped.localeIdentifier
+    }
+    
+    /// Returns the language code of the locale, or nil if has none.
+    ///
+    /// For example, for the locale "zh-Hant-HK", returns "zh".
+    public var languageCode: String? {
+        return _wrapped.object(forKey: .languageCode) as? String
+    }
+
+    /// Returns the region code of the locale, or nil if it has none.
+    ///
+    /// For example, for the locale "zh-Hant-HK", returns "HK".
+    public var regionCode: String? {
+        // n.b. this is called countryCode in ObjC
+        if let result = _wrapped.object(forKey: .countryCode) as? String {
+            if result.isEmpty {
+                return nil
+            } else {
+                return result
+            }
+        } else {
+            return nil
+        }
+    }
+    
+    /// Returns the script code of the locale, or nil if has none.
+    ///
+    /// For example, for the locale "zh-Hant-HK", returns "Hant".
+    public var scriptCode: String? {
+        return _wrapped.object(forKey: .scriptCode) as? String
+    }
+    
+    /// Returns the variant code for the locale, or nil if it has none.
+    ///
+    /// For example, for the locale "en_POSIX", returns "POSIX".
+    public var variantCode: String? {
+        if let result = _wrapped.object(forKey: .variantCode) as? String {
+            if result.isEmpty {
+                return nil
+            } else {
+                return result
+            }
+        } else {
+            return nil
+        }
+    }
+    
+    /// Returns the exemplar character set for the locale, or nil if has none.
+    public var exemplarCharacterSet: CharacterSet? {
+        return _wrapped.object(forKey: .exemplarCharacterSet) as? CharacterSet
+    }
+    
+    /// Returns the calendar for the locale, or the Gregorian calendar as a fallback.
+    public var calendar: Calendar {
+        // NSLocale should not return nil here
+        if let result = _wrapped.object(forKey: .calendar) as? Calendar {
+            return result
+        } else {
+            return Calendar(identifier: .gregorian)
+        }
+    }
+    
+    /// Returns the collation identifier for the locale, or nil if it has none.
+    ///
+    /// For example, for the locale "en_US@collation=phonebook", returns "phonebook".
+    public var collationIdentifier: String? {
+        return _wrapped.object(forKey: .collationIdentifier) as? String
+    }
+    
+    /// Returns true if the locale uses the metric system.
+    ///
+    /// -seealso: MeasurementFormatter
+    public var usesMetricSystem: Bool {
+        // NSLocale should not return nil here, but just in case
+        if let result = (_wrapped.object(forKey: .usesMetricSystem) as? NSNumber)?.boolValue {
+            return result
+        } else {
+            return false
+        }
+    }
+    
+    /// Returns the decimal separator of the locale.
+    ///
+    /// For example, for "en_US", returns ".".
+    public var decimalSeparator: String? {
+        return _wrapped.object(forKey: .decimalSeparator) as? String
+    }
+    
+    /// Returns the grouping separator of the locale.
+    ///
+    /// For example, for "en_US", returns ",".
+    public var groupingSeparator: String? {
+        return _wrapped.object(forKey: .groupingSeparator) as? String
+    }
+    
+    /// Returns the currency symbol of the locale.
+    ///
+    /// For example, for "zh-Hant-HK", returns "HK$".
+    public var currencySymbol: String? {
+        return _wrapped.object(forKey: .currencySymbol) as? String
+    }
+    
+    /// Returns the currency code of the locale.
+    ///
+    /// For example, for "zh-Hant-HK", returns "HKD".
+    public var currencyCode: String? {
+        return _wrapped.object(forKey: .currencyCode) as? String
+    }
+    
+    /// Returns the collator identifier of the locale.
+    public var collatorIdentifier: String? {
+        return _wrapped.object(forKey: .collatorIdentifier) as? String
+    }
+    
+    /// Returns the quotation begin delimiter of the locale.
+    ///
+    /// For example, returns `“` for "en_US", and `「` for "zh-Hant-HK".
+    public var quotationBeginDelimiter: String? {
+        return _wrapped.object(forKey: .quotationBeginDelimiterKey) as? String
+    }
+    
+    /// Returns the quotation end delimiter of the locale.
+    ///
+    /// For example, returns `”` for "en_US", and `」` for "zh-Hant-HK".
+    public var quotationEndDelimiter: String? {
+        return _wrapped.object(forKey: .quotationEndDelimiterKey) as? String
+    }
+    
+    /// Returns the alternate quotation begin delimiter of the locale.
+    ///
+    /// For example, returns `‘` for "en_US", and `『` for "zh-Hant-HK".
+    public var alternateQuotationBeginDelimiter: String? {
+        return _wrapped.object(forKey: .alternateQuotationBeginDelimiterKey) as? String
+    }
+    
+    /// Returns the alternate quotation end delimiter of the locale.
+    ///
+    /// For example, returns `’` for "en_US", and `』` for "zh-Hant-HK".
+    public var alternateQuotationEndDelimiter: String? {
+        return _wrapped.object(forKey: .alternateQuotationEndDelimiterKey) as? String
+    }
+    
+    // MARK: -
+    // 
+    
+    /// Returns a list of available `Locale` identifiers.
+    public static var availableIdentifiers: [String] {
+        return NSLocale.availableLocaleIdentifiers
+    }
+    
+    /// Returns a list of available `Locale` language codes.
+    public static var isoLanguageCodes: [String] {
+        return NSLocale.isoLanguageCodes
+    }
+    
+    /// Returns a list of available `Locale` region codes.
+    public static var isoRegionCodes: [String] {
+        // This was renamed from Obj-C
+        return NSLocale.isoCountryCodes
+    }
+    
+    /// Returns a list of available `Locale` currency codes.
+    public static var isoCurrencyCodes: [String] {
+        return NSLocale.isoCurrencyCodes
+    }
+    
+    /// Returns a list of common `Locale` currency codes.
+    public static var commonISOCurrencyCodes: [String] {
+        return NSLocale.commonISOCurrencyCodes
+    }
+    
+    /// Returns a list of the user's preferred languages.
+    ///
+    /// - note: `Bundle` is responsible for determining the language that your application will run in, based on the result of this API and combined with the languages your application supports.
+    /// - seealso: `Bundle.preferredLocalizations(from:)`
+    /// - seealso: `Bundle.preferredLocalizations(from:forPreferences:)`
+    public static var preferredLanguages: [String] {
+        return NSLocale.preferredLanguages
+    }
+    
+    /// Returns a dictionary that splits an identifier into its component pieces.
+    public static func components(fromIdentifier string: String) -> [String : String] {
+        return NSLocale.components(fromLocaleIdentifier: string)
+    }
+    
+    /// Constructs an identifier from a dictionary of components.
+    public static func identifier(fromComponents components: [String : String]) -> String {
+        return NSLocale.localeIdentifier(fromComponents: components)
+    }
+    
+    /// Returns a canonical identifier from the given string.
+    public static func canonicalIdentifier(from string: String) -> String {
+        return NSLocale.canonicalLocaleIdentifier(from: string)
+    }
+    
+    /// Returns a canonical language identifier from the given string.
+    public static func canonicalLanguageIdentifier(from string: String) -> String {
+        return NSLocale.canonicalLanguageIdentifier(from: string)
+    }
+    
+    /// Returns the `Locale` identifier from a given Windows locale code, or nil if it could not be converted.
+    public static func identifier(fromWindowsLocaleCode code: Int) -> String? {
+        return NSLocale.localeIdentifier(fromWindowsLocaleCode: UInt32(code))
+    }
+    
+    /// Returns the Windows locale code from a given identifier, or nil if it could not be converted.
+    public static func windowsLocaleCode(fromIdentifier identifier: String) -> Int? {
+        let result = NSLocale.windowsLocaleCode(fromLocaleIdentifier: identifier)
+        if result == 0 {
+            return nil
+        } else {
+            return Int(result)
+        }
+    }
+    
+    /// Returns the character direction for a specified language code.
+    public static func characterDirection(forLanguage isoLangCode: String) -> Locale.LanguageDirection {
+        return NSLocale.characterDirection(forLanguage: isoLangCode)
+    }
+    
+    /// Returns the line direction for a specified language code.
+    public static func lineDirection(forLanguage isoLangCode: String) -> Locale.LanguageDirection {
+        return NSLocale.lineDirection(forLanguage: isoLangCode)
+    }
+    
+    // MARK: -
+    
+    @available(*, unavailable, renamed: "init(identifier:)")
+    public init(localeIdentifier: String) { fatalError() }
+    
+    @available(*, unavailable, renamed: "identifier")
+    public var localeIdentifier: String { fatalError() }
+    
+    @available(*, unavailable, renamed: "localizedString(forIdentifier:)")
+    public func localizedString(forLocaleIdentifier localeIdentifier: String) -> String { fatalError() }
+    
+    @available(*, unavailable, renamed: "availableIdentifiers")
+    public static var availableLocaleIdentifiers: [String] { fatalError() }
+    
+    @available(*, unavailable, renamed: "components(fromIdentifier:)")
+    public static func components(fromLocaleIdentifier string: String) -> [String : String] { fatalError() }
+    
+    @available(*, unavailable, renamed: "identifier(fromComponents:)")
+    public static func localeIdentifier(fromComponents dict: [String : String]) -> String { fatalError() }
+    
+    @available(*, unavailable, renamed: "canonicalIdentifier(from:)")
+    public static func canonicalLocaleIdentifier(from string: String) -> String { fatalError() }
+    
+    @available(*, unavailable, renamed: "identifier(fromWindowsLocaleCode:)")
+    public static func localeIdentifier(fromWindowsLocaleCode lcid: UInt32) -> String? { fatalError() }
+    
+    @available(*, unavailable, renamed: "windowsLocaleCode(fromIdentifier:)")
+    public static func windowsLocaleCode(fromLocaleIdentifier localeIdentifier: String) -> UInt32 { fatalError() }
+    
+    @available(*, unavailable, message: "use regionCode instead")
+    public var countryCode: String { fatalError() }
+    
+    @available(*, unavailable, message: "use localizedString(forRegionCode:) instead")
+    public func localizedString(forCountryCode countryCode: String) -> String { fatalError() }
+
+    @available(*, unavailable, renamed: "isoRegionCodes")
+    public static var isoCountryCodes: [String] { fatalError() }
+
+    // MARK: -
+    //
+    
+    public func hash(into hasher: inout Hasher) {
+        if _autoupdating {
+            hasher.combine(false)
+        } else {
+            hasher.combine(true)
+            hasher.combine(_wrapped)
+        }
+    }
+
+    public static func ==(lhs: Locale, rhs: Locale) -> Bool {
+        if lhs._autoupdating || rhs._autoupdating {
+            return lhs._autoupdating == rhs._autoupdating
+        } else {
+            return lhs._wrapped.isEqual(rhs._wrapped)
+        }
+    }
+}
+
+extension Locale : CustomDebugStringConvertible, CustomStringConvertible, CustomReflectable {
+    private var _kindDescription : String {
+        if self == Locale.autoupdatingCurrent {
+            return "autoupdatingCurrent"
+        } else if self == Locale.current {
+            return "current"
+        } else {
+            return "fixed"
+        }
+    }
+    
+    public var customMirror : Mirror {
+        var c: [(label: String?, value: Any)] = []
+        c.append((label: "identifier", value: identifier))
+        c.append((label: "kind", value: _kindDescription))
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+    }
+    
+    public var description: String {
+        return "\(identifier) (\(_kindDescription))"
+    }
+    
+    public var debugDescription : String {
+        return "\(identifier) (\(_kindDescription))"
+    }
+}
+
+extension Locale : _ObjectiveCBridgeable {
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSLocale {
+        return _wrapped
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ input: NSLocale, result: inout Locale?) {
+        if !_conditionallyBridgeFromObjectiveC(input, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ input: NSLocale, result: inout Locale?) -> Bool {
+        result = Locale(reference: input)
+        return true
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSLocale?) -> Locale {
+        var result: Locale?
+        _forceBridgeFromObjectiveC(source!, result: &result)
+        return result!
+    }
+}
+
+extension NSLocale : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as Locale)
+    }
+}
+
+extension Locale : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case identifier
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let identifier = try container.decode(String.self, forKey: .identifier)
+        self.init(identifier: identifier)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.identifier, forKey: .identifier)
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/Measurement.swift
+++ b/Darwin/Foundation-swiftoverlay/Measurement.swift
@@ -1,0 +1,358 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if DEPLOYMENT_RUNTIME_SWIFT
+import CoreFoundation
+#else
+@_exported import Foundation // Clang module
+@_implementationOnly import _CoreFoundationOverlayShims
+#endif
+
+/// A `Measurement` is a model type that holds a `Double` value associated with a `Unit`.
+///
+/// Measurements support a large set of operators, including `+`, `-`, `*`, `/`, and a full set of comparison operators.
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+public struct Measurement<UnitType : Unit> : ReferenceConvertible, Comparable, Equatable {
+    public typealias ReferenceType = NSMeasurement
+
+    /// The unit component of the `Measurement`.
+    public let unit: UnitType
+
+    /// The value component of the `Measurement`.
+    public var value: Double
+
+    /// Create a `Measurement` given a specified value and unit.
+    public init(value: Double, unit: UnitType) {
+        self.value = value
+        self.unit = unit
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        // Warning: The canonicalization performed here needs to be kept in
+        // perfect sync with the definition of == below. The floating point
+        // values that are compared there must match exactly with the values fed
+        // to the hasher here, or hashing would break.
+        if let dimension = unit as? Dimension {
+            // We don't need to feed the base unit to the hasher here; all
+            // dimensional measurements of the same type share the same unit.
+            hasher.combine(dimension.converter.baseUnitValue(fromValue: value))
+        } else {
+            hasher.combine(unit)
+            hasher.combine(value)
+        }
+    }
+}
+
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+extension Measurement : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    public var description: String {
+        return "\(value) \(unit.symbol)"
+    }
+
+    public var debugDescription: String {
+        return "\(value) \(unit.symbol)"
+    }
+
+    public var customMirror: Mirror {
+        var c: [(label: String?, value: Any)] = []
+        c.append((label: "value", value: value))
+        c.append((label: "unit", value: unit.symbol))
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+    }
+}
+
+
+/// When a `Measurement` contains a `Dimension` unit, it gains the ability to convert between the kinds of units in that dimension.
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+extension Measurement where UnitType : Dimension {
+    /// Returns a new measurement created by converting to the specified unit.
+    ///
+    /// - parameter otherUnit: A unit of the same `Dimension`.
+    /// - returns: A converted measurement.
+    public func converted(to otherUnit: UnitType) -> Measurement<UnitType> {
+        if unit.isEqual(otherUnit) {
+            return Measurement(value: value, unit: otherUnit)
+        } else {
+            let valueInTermsOfBase = unit.converter.baseUnitValue(fromValue: value)
+            if otherUnit.isEqual(type(of: unit).baseUnit()) {
+                return Measurement(value: valueInTermsOfBase, unit: otherUnit)
+            } else {
+                let otherValueFromTermsOfBase = otherUnit.converter.value(fromBaseUnitValue: valueInTermsOfBase)
+                return Measurement(value: otherValueFromTermsOfBase, unit: otherUnit)
+            }
+        }
+    }
+
+    /// Converts the measurement to the specified unit.
+    ///
+    /// - parameter otherUnit: A unit of the same `Dimension`.
+    public mutating func convert(to otherUnit: UnitType) {
+        self = converted(to: otherUnit)
+    }
+
+    /// Add two measurements of the same Dimension.
+    ///
+    /// If the `unit` of the `lhs` and `rhs` are `isEqual`, then this returns the result of adding the `value` of each `Measurement`. If they are not equal, then this will convert both to the base unit of the `Dimension` and return the result as a `Measurement` of that base unit.
+    /// - returns: The result of adding the two measurements.
+    public static func +(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
+        if lhs.unit.isEqual(rhs.unit) {
+            return Measurement(value: lhs.value + rhs.value, unit: lhs.unit)
+        } else {
+            let lhsValueInTermsOfBase = lhs.unit.converter.baseUnitValue(fromValue: lhs.value)
+            let rhsValueInTermsOfBase = rhs.unit.converter.baseUnitValue(fromValue: rhs.value)
+            return Measurement(value: lhsValueInTermsOfBase + rhsValueInTermsOfBase, unit: type(of: lhs.unit).baseUnit())
+        }
+    }
+
+    /// Subtract two measurements of the same Dimension.
+    ///
+    /// If the `unit` of the `lhs` and `rhs` are `==`, then this returns the result of subtracting the `value` of each `Measurement`. If they are not equal, then this will convert both to the base unit of the `Dimension` and return the result as a `Measurement` of that base unit.
+    /// - returns: The result of adding the two measurements.
+    public static func -(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
+        if lhs.unit == rhs.unit {
+            return Measurement(value: lhs.value - rhs.value, unit: lhs.unit)
+        } else {
+            let lhsValueInTermsOfBase = lhs.unit.converter.baseUnitValue(fromValue: lhs.value)
+            let rhsValueInTermsOfBase = rhs.unit.converter.baseUnitValue(fromValue: rhs.value)
+            return Measurement(value: lhsValueInTermsOfBase - rhsValueInTermsOfBase, unit: type(of: lhs.unit).baseUnit())
+        }
+    }
+}
+
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+extension Measurement {
+    /// Add two measurements of the same Unit.
+    /// - precondition: The `unit` of `lhs` and `rhs` must be `isEqual`.
+    /// - returns: A measurement of value `lhs.value + rhs.value` and unit `lhs.unit`.
+    public static func +(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
+        if lhs.unit.isEqual(rhs.unit) {
+            return Measurement(value: lhs.value + rhs.value, unit: lhs.unit)
+        } else {
+            fatalError("Attempt to add measurements with non-equal units")
+        }
+    }
+
+    /// Subtract two measurements of the same Unit.
+    /// - precondition: The `unit` of `lhs` and `rhs` must be `isEqual`.
+    /// - returns: A measurement of value `lhs.value - rhs.value` and unit `lhs.unit`.
+    public static func -(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
+        if lhs.unit.isEqual(rhs.unit) {
+            return Measurement(value: lhs.value - rhs.value, unit: lhs.unit)
+        } else {
+            fatalError("Attempt to subtract measurements with non-equal units")
+        }
+    }
+
+    /// Multiply a measurement by a scalar value.
+    /// - returns: A measurement of value `lhs.value * rhs` with the same unit as `lhs`.
+    public static func *(lhs: Measurement<UnitType>, rhs: Double) -> Measurement<UnitType> {
+        return Measurement(value: lhs.value * rhs, unit: lhs.unit)
+    }
+
+    /// Multiply a scalar value by a measurement.
+    /// - returns: A measurement of value `lhs * rhs.value` with the same unit as `rhs`.
+    public static func *(lhs: Double, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
+        return Measurement(value: lhs * rhs.value, unit: rhs.unit)
+    }
+
+    /// Divide a measurement by a scalar value.
+    /// - returns: A measurement of value `lhs.value / rhs` with the same unit as `lhs`.
+    public static func /(lhs: Measurement<UnitType>, rhs: Double) -> Measurement<UnitType> {
+        return Measurement(value: lhs.value / rhs, unit: lhs.unit)
+    }
+
+    /// Divide a scalar value by a measurement.
+    /// - returns: A measurement of value `lhs / rhs.value` with the same unit as `rhs`.
+    public static func /(lhs: Double, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
+        return Measurement(value: lhs / rhs.value, unit: rhs.unit)
+    }
+
+    /// Compare two measurements of the same `Dimension`.
+    ///
+    /// If `lhs.unit == rhs.unit`, returns `lhs.value == rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
+    /// - returns: `true` if the measurements are equal.
+    public static func ==<LeftHandSideType, RightHandSideType>(lhs: Measurement<LeftHandSideType>, rhs: Measurement<RightHandSideType>) -> Bool {
+        // Warning: This defines an equivalence relation that needs to be kept
+        // in perfect sync with the hash(into:) definition above. The floating
+        // point values that are fed to the hasher there must match exactly with
+        // the values compared here, or hashing would break.
+        if lhs.unit == rhs.unit {
+            return lhs.value == rhs.value
+        } else {
+            if let lhsDimensionalUnit = lhs.unit as? Dimension,
+                let rhsDimensionalUnit = rhs.unit as? Dimension {
+                if type(of: lhsDimensionalUnit).baseUnit() == type(of: rhsDimensionalUnit).baseUnit() {
+                    let lhsValueInTermsOfBase = lhsDimensionalUnit.converter.baseUnitValue(fromValue: lhs.value)
+                    let rhsValueInTermsOfBase = rhsDimensionalUnit.converter.baseUnitValue(fromValue: rhs.value)
+                    return lhsValueInTermsOfBase == rhsValueInTermsOfBase
+                }
+            }
+            return false
+        }
+    }
+
+    /// Compare two measurements of the same `Unit`.
+    /// - returns: `true` if the measurements can be compared and the `lhs` is less than the `rhs` converted value.
+    public static func <<LeftHandSideType, RightHandSideType>(lhs: Measurement<LeftHandSideType>, rhs: Measurement<RightHandSideType>) -> Bool {
+        if lhs.unit == rhs.unit {
+            return lhs.value < rhs.value
+        } else {
+            if let lhsDimensionalUnit = lhs.unit as? Dimension,
+                let rhsDimensionalUnit = rhs.unit as? Dimension {
+                if type(of: lhsDimensionalUnit).baseUnit() == type(of: rhsDimensionalUnit).baseUnit() {
+                    let lhsValueInTermsOfBase = lhsDimensionalUnit.converter.baseUnitValue(fromValue: lhs.value)
+                    let rhsValueInTermsOfBase = rhsDimensionalUnit.converter.baseUnitValue(fromValue: rhs.value)
+                    return lhsValueInTermsOfBase < rhsValueInTermsOfBase
+                }
+            }
+            fatalError("Attempt to compare measurements with non-equal dimensions")
+        }
+    }
+}
+
+// Implementation note: similar to NSArray, NSDictionary, etc., NSMeasurement's import as an ObjC generic type is suppressed by the importer. Eventually we will need a more general purpose mechanism to correctly import generic types.
+
+// FIXME: Remove @usableFromInline from MeasurementBridgeType once
+// rdar://problem/44662501 is fixed. (The Radar basically just says "look
+// through typealiases and inherited protocols when printing extensions".)
+
+#if DEPLOYMENT_RUNTIME_SWIFT
+@usableFromInline
+internal typealias MeasurementBridgeType = _ObjectTypeBridgeable
+#else
+@usableFromInline
+internal typealias MeasurementBridgeType = _ObjectiveCBridgeable
+#endif
+
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+extension Measurement : MeasurementBridgeType {
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSMeasurement {
+        return NSMeasurement(doubleValue: value, unit: unit)
+    }
+
+    public static func _forceBridgeFromObjectiveC(_ source: NSMeasurement, result: inout Measurement?) {
+        result = Measurement(value: source.doubleValue, unit: source.unit as! UnitType)
+    }
+
+    public static func _conditionallyBridgeFromObjectiveC(_ source: NSMeasurement, result: inout Measurement?) -> Bool {
+        if let u = source.unit as? UnitType {
+            result = Measurement(value: source.doubleValue, unit: u)
+            return true
+        } else {
+            return false
+        }
+    }
+
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSMeasurement?) -> Measurement {
+        let u = source!.unit as! UnitType
+        return Measurement(value: source!.doubleValue, unit: u)
+    }
+}
+
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+extension NSMeasurement : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+#if DEPLOYMENT_RUNTIME_SWIFT
+        return AnyHashable(Measurement._unconditionallyBridgeFromObjectiveC(self))
+#else
+        return AnyHashable(self as Measurement)
+#endif
+    }
+}
+
+// This workaround is required for the time being, because Swift doesn't support covariance for Measurement (26607639)
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+extension MeasurementFormatter {
+    public func string<UnitType>(from measurement: Measurement<UnitType>) -> String {
+        if let result = string(for: measurement) {
+            return result
+        } else {
+            return ""
+        }
+    }
+}
+
+// @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+// extension Unit : Codable {
+//     public convenience init(from decoder: Decoder) throws {
+//         let container = try decoder.singleValueContainer()
+//         let symbol = try container.decode(String.self)
+//         self.init(symbol: symbol)
+//     }
+
+//     public func encode(to encoder: Encoder) throws {
+//         var container = encoder.singleValueContainer()
+//         try container.encode(self.symbol)
+//     }
+// }
+
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+extension Measurement : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case value
+        case unit
+    }
+
+    private enum UnitCodingKeys : Int, CodingKey {
+        case symbol
+        case converter
+    }
+
+    private enum LinearConverterCodingKeys : Int, CodingKey {
+        case coefficient
+        case constant
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let value = try container.decode(Double.self, forKey: .value)
+
+        let unitContainer = try container.nestedContainer(keyedBy: UnitCodingKeys.self, forKey: .unit)
+        let symbol = try unitContainer.decode(String.self, forKey: .symbol)
+
+        let unit: UnitType
+        if UnitType.self is Dimension.Type {
+            let converterContainer = try unitContainer.nestedContainer(keyedBy: LinearConverterCodingKeys.self, forKey: .converter)
+            let coefficient = try converterContainer.decode(Double.self, forKey: .coefficient)
+            let constant = try converterContainer.decode(Double.self, forKey: .constant)
+            let unitMetaType = (UnitType.self as! Dimension.Type)
+            unit = (unitMetaType.init(symbol: symbol, converter: UnitConverterLinear(coefficient: coefficient, constant: constant)) as! UnitType)
+        } else {
+            unit = UnitType(symbol: symbol)
+        }
+
+        self.init(value: value, unit: unit)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.value, forKey: .value)
+
+        var unitContainer = container.nestedContainer(keyedBy: UnitCodingKeys.self, forKey: .unit)
+        try unitContainer.encode(self.unit.symbol, forKey: .symbol)
+
+        if UnitType.self is Dimension.Type {
+            guard type(of: (self.unit as! Dimension).converter) is UnitConverterLinear.Type else {
+                preconditionFailure("Cannot encode a Measurement whose UnitType has a non-linear unit converter.")
+            }
+
+            let converter = (self.unit as! Dimension).converter as! UnitConverterLinear
+            var converterContainer = unitContainer.nestedContainer(keyedBy: LinearConverterCodingKeys.self, forKey: .converter)
+            try converterContainer.encode(converter.coefficient, forKey: .coefficient)
+            try converterContainer.encode(converter.constant, forKey: .constant)
+        }
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/NSArray.swift
+++ b/Darwin/Foundation-swiftoverlay/NSArray.swift
@@ -1,0 +1,166 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+//===----------------------------------------------------------------------===//
+// Arrays
+//===----------------------------------------------------------------------===//
+
+extension NSArray : ExpressibleByArrayLiteral {
+  /// Create an instance initialized with `elements`.
+  public required convenience init(arrayLiteral elements: Any...) {
+    // Let bridging take care of it.
+    self.init(array: elements)
+  }
+}
+
+extension Array : _ObjectiveCBridgeable {
+
+  /// Private initializer used for bridging.
+  ///
+  /// The provided `NSArray` will be copied to ensure that the copy can
+  /// not be mutated by other code.
+  internal init(_cocoaArray: __shared NSArray) {
+    assert(_isBridgedVerbatimToObjectiveC(Element.self),
+      "Array can be backed by NSArray only when the element type can be bridged verbatim to Objective-C")
+    // FIXME: We would like to call CFArrayCreateCopy() to avoid doing an
+    // objc_msgSend() for instances of CoreFoundation types.  We can't do that
+    // today because CFArrayCreateCopy() copies array contents unconditionally,
+    // resulting in O(n) copies even for immutable arrays.
+    //
+    // <rdar://problem/19773555> CFArrayCreateCopy() is >10x slower than
+    // -[NSArray copyWithZone:]
+    //
+    // The bug is fixed in: OS X 10.11.0, iOS 9.0, all versions of tvOS
+    // and watchOS.
+    self = Array(_immutableCocoaArray: _cocoaArray.copy() as AnyObject)
+  }
+
+  @_semantics("convertToObjectiveC")
+  public func _bridgeToObjectiveC() -> NSArray {
+    return unsafeBitCast(self._bridgeToObjectiveCImpl(), to: NSArray.self)
+  }
+
+  public static func _forceBridgeFromObjectiveC(
+    _ source: NSArray,
+    result: inout Array?
+  ) {
+    // If we have the appropriate native storage already, just adopt it.
+    if let native =
+        Array._bridgeFromObjectiveCAdoptingNativeStorageOf(source) {
+      result = native
+      return
+    }
+
+    if _fastPath(_isBridgedVerbatimToObjectiveC(Element.self)) {
+      // Forced down-cast (possible deferred type-checking)
+      result = Array(_cocoaArray: source)
+      return
+    }
+
+    result = _arrayForceCast([AnyObject](_cocoaArray: source))
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ source: NSArray,
+    result: inout Array?
+  ) -> Bool {
+    // Construct the result array by conditionally bridging each element.
+    let anyObjectArr = [AnyObject](_cocoaArray: source)
+
+    result = _arrayConditionalCast(anyObjectArr)
+    return result != nil
+  }
+
+  @_effects(readonly)
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ source: NSArray?
+  ) -> Array {
+    // `nil` has historically been used as a stand-in for an empty
+    // array; map it to an empty array instead of failing.
+    if _slowPath(source == nil) { return Array() }
+
+    // If we have the appropriate native storage already, just adopt it.
+    if let native =
+        Array._bridgeFromObjectiveCAdoptingNativeStorageOf(source!) {
+      return native
+    }
+
+    if _fastPath(_isBridgedVerbatimToObjectiveC(Element.self)) {
+      // Forced down-cast (possible deferred type-checking)
+      return Array(_cocoaArray: source!)
+    }
+
+    return _arrayForceCast([AnyObject](_cocoaArray: source!))
+  }
+}
+
+extension NSArray : _HasCustomAnyHashableRepresentation {
+  // Must be @nonobjc to avoid infinite recursion during bridging
+  @nonobjc
+  public func _toCustomAnyHashable() -> AnyHashable? {
+    return AnyHashable(self as! Array<AnyHashable>)
+  }
+}
+
+extension NSArray : Sequence {
+  /// Return an *iterator* over the elements of this *sequence*.
+  ///
+  /// - Complexity: O(1).
+  final public func makeIterator() -> NSFastEnumerationIterator {
+    return NSFastEnumerationIterator(self)
+  }
+}
+
+/* TODO: API review
+extension NSArray : Swift.Collection {
+  final public var startIndex: Int {
+    return 0
+  }
+
+  final public var endIndex: Int {
+    return count
+  }
+}
+ */
+
+extension NSArray {
+  // Overlay: - (instancetype)initWithObjects:(id)firstObj, ...
+  public convenience init(objects elements: Any...) {
+    self.init(array: elements)
+  }
+}
+
+extension NSArray {
+  /// Initializes a newly allocated array by placing in it the objects
+  /// contained in a given array.
+  ///
+  /// - Returns: An array initialized to contain the objects in
+  ///    `anArray``. The returned object might be different than the
+  ///    original receiver.
+  ///
+  /// Discussion: After an immutable array has been initialized in
+  /// this way, it cannot be modified.
+  @nonobjc
+  public convenience init(array anArray: __shared NSArray) {
+    self.init(array: anArray as Array)
+  }
+}
+
+extension NSArray : CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(reflecting: self as [AnyObject])
+  }
+}
+
+extension Array: CVarArg {}

--- a/Darwin/Foundation-swiftoverlay/NSCoder.swift
+++ b/Darwin/Foundation-swiftoverlay/NSCoder.swift
@@ -1,0 +1,231 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+@_implementationOnly import _FoundationOverlayShims
+
+//===----------------------------------------------------------------------===//
+// NSCoder
+//===----------------------------------------------------------------------===//
+
+@available(macOS 10.11, iOS 9.0, *)
+internal func resolveError(_ error: NSError?) throws {
+  if let error = error, error.code != NSCoderValueNotFoundError {
+    throw error
+  }
+}
+
+extension NSCoder {
+  @available(*, unavailable, renamed: "decodeObject(of:forKey:)")
+  public func decodeObjectOfClass<DecodedObjectType>(
+    _ cls: DecodedObjectType.Type, forKey key: String
+  ) -> DecodedObjectType?
+    where DecodedObjectType : NSCoding, DecodedObjectType : NSObject {
+    fatalError("This API has been renamed")
+  }
+
+  public func decodeObject<DecodedObjectType>(
+    of cls: DecodedObjectType.Type, forKey key: String
+  ) -> DecodedObjectType?
+    where DecodedObjectType : NSCoding, DecodedObjectType : NSObject {
+    let result = __NSCoderDecodeObjectOfClassForKey(self, cls, key, nil)
+    return result as? DecodedObjectType
+  }
+
+  @available(*, unavailable, renamed: "decodeObject(of:forKey:)")
+  @nonobjc
+  public func decodeObjectOfClasses(_ classes: NSSet?, forKey key: String) -> AnyObject? {
+    fatalError("This API has been renamed")
+  }
+
+  @nonobjc
+  public func decodeObject(of classes: [AnyClass]?, forKey key: String) -> Any? {
+    var classesAsNSObjects: NSSet?
+    if let theClasses = classes {
+      classesAsNSObjects = NSSet(array: theClasses.map { $0 as AnyObject })
+    }
+    return __NSCoderDecodeObjectOfClassesForKey(self, classesAsNSObjects, key, nil).map { $0 }
+  }
+
+  @nonobjc
+  @available(macOS 10.11, iOS 9.0, *)
+  public func decodeTopLevelObject() throws -> Any? {
+    var error: NSError?
+    let result = __NSCoderDecodeObject(self, &error)
+    try resolveError(error)
+    return result.map { $0 }
+  }
+
+  @available(*, unavailable, renamed: "decodeTopLevelObject(forKey:)")
+  public func decodeTopLevelObjectForKey(_ key: String) throws -> AnyObject? {
+    fatalError("This API has been renamed")
+  }
+
+  @nonobjc
+  @available(swift, obsoleted: 4)
+  @available(macOS 10.11, iOS 9.0, *)
+  public func decodeTopLevelObject(forKey key: String) throws -> AnyObject? {
+    var error: NSError?
+    let result = __NSCoderDecodeObjectForKey(self, key, &error)
+    try resolveError(error)
+    return result as AnyObject?
+  }
+
+  @nonobjc
+  @available(swift, introduced: 4)
+  @available(macOS 10.11, iOS 9.0, *)
+  public func decodeTopLevelObject(forKey key: String) throws -> Any? {
+    var error: NSError?
+    let result = __NSCoderDecodeObjectForKey(self, key, &error)
+    try resolveError(error)
+    return result
+  }
+
+  @available(*, unavailable, renamed: "decodeTopLevelObject(of:forKey:)")
+  public func decodeTopLevelObjectOfClass<DecodedObjectType>(
+    _ cls: DecodedObjectType.Type, forKey key: String
+  ) throws -> DecodedObjectType?
+    where DecodedObjectType : NSCoding, DecodedObjectType : NSObject {
+    fatalError("This API has been renamed")
+  }
+
+  @available(macOS 10.11, iOS 9.0, *)
+  public func decodeTopLevelObject<DecodedObjectType>(
+    of cls: DecodedObjectType.Type, forKey key: String
+  ) throws -> DecodedObjectType?
+    where DecodedObjectType : NSCoding, DecodedObjectType : NSObject {
+    var error: NSError?
+    let result = __NSCoderDecodeObjectOfClassForKey(self, cls, key, &error)
+    try resolveError(error)
+    return result as? DecodedObjectType
+  }
+
+  @nonobjc
+  @available(*, unavailable, renamed: "decodeTopLevelObject(of:forKey:)")
+  public func decodeTopLevelObjectOfClasses(_ classes: NSSet?, forKey key: String) throws -> AnyObject? {
+    fatalError("This API has been renamed")
+  }
+
+  @nonobjc
+  @available(macOS 10.11, iOS 9.0, *)
+  public func decodeTopLevelObject(of classes: [AnyClass]?, forKey key: String) throws -> Any? {
+    var error: NSError?
+    var classesAsNSObjects: NSSet?
+    if let theClasses = classes {
+      classesAsNSObjects = NSSet(array: theClasses.map { $0 as AnyObject })
+    }
+    let result = __NSCoderDecodeObjectOfClassesForKey(self, classesAsNSObjects, key, &error)
+    try resolveError(error)
+    return result.map { $0 }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// NSKeyedArchiver
+//===----------------------------------------------------------------------===//
+
+extension NSKeyedArchiver {
+  @nonobjc
+  @available(macOS 10.11, iOS 9.0, *)
+  public func encodeEncodable<T : Encodable>(_ value: T, forKey key: String) throws {
+    let plistEncoder = PropertyListEncoder()
+    let plist = try plistEncoder.encodeToTopLevelContainer(value)
+    self.encode(plist, forKey: key)
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// NSKeyedUnarchiver
+//===----------------------------------------------------------------------===//
+
+extension NSKeyedUnarchiver {
+  @nonobjc
+  @available(swift, obsoleted: 4)
+  @available(macOS 10.11, iOS 9.0, *)
+  public class func unarchiveTopLevelObjectWithData(_ data: NSData) throws -> AnyObject? {
+    var error: NSError?
+    let result = __NSKeyedUnarchiverUnarchiveObject(self, data, &error)
+    try resolveError(error)
+    return result as AnyObject?
+  }
+
+  @nonobjc
+  @available(swift, introduced: 4)
+  @available(macOS 10.11, iOS 9.0, *)
+  public class func unarchiveTopLevelObjectWithData(_ data: Data) throws -> Any? {
+    var error: NSError?
+    let result = __NSKeyedUnarchiverUnarchiveObject(self, data as NSData, &error)
+    try resolveError(error)
+    return result
+  }
+
+  @nonobjc
+  @available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
+  public static func unarchivedObject<DecodedObjectType>(ofClass cls: DecodedObjectType.Type, from data: Data) throws -> DecodedObjectType? where DecodedObjectType : NSCoding, DecodedObjectType : NSObject {
+    var error: NSError?
+    let result = __NSKeyedUnarchiverSecureUnarchiveObjectOfClass(cls as AnyClass, data, &error)
+    if let error = error { throw error }
+    return result as? DecodedObjectType
+  }
+
+  @nonobjc
+  @available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
+  public static func unarchivedObject(ofClasses classes: [AnyClass], from data: Data) throws -> Any? {
+    var error: NSError?
+    let classesAsNSObjects = NSSet(array: classes.map { $0 as AnyObject })
+    let result = __NSKeyedUnarchiverSecureUnarchiveObjectOfClasses(classesAsNSObjects, data, &error)
+    if let error = error { throw error }
+    return result
+  }
+  
+  @nonobjc
+  private static let __plistClasses: [AnyClass] = [
+    NSArray.self,
+    NSData.self,
+    NSDate.self,
+    NSDictionary.self,
+    NSNumber.self,
+    NSString.self
+  ]
+
+  @nonobjc
+  @available(macOS 10.11, iOS 9.0, *)
+  public func decodeDecodable<T : Decodable>(_ type: T.Type, forKey key: String) -> T? {
+      guard let value = self.decodeObject(of: NSKeyedUnarchiver.__plistClasses, forKey: key) else {
+          return nil
+      }
+
+      let plistDecoder = PropertyListDecoder()
+      do {
+          return try plistDecoder.decode(T.self, fromTopLevel: value)
+      } catch {
+          self.failWithError(error)
+          return nil
+      }
+  }
+
+  @nonobjc
+  @available(macOS 10.11, iOS 9.0, *)
+  public func decodeTopLevelDecodable<T : Decodable>(_ type: T.Type, forKey key: String) throws  -> T? {
+    guard let value = try self.decodeTopLevelObject(of: NSKeyedUnarchiver.__plistClasses, forKey: key) else {
+      return nil
+    }
+
+    let plistDecoder = PropertyListDecoder()
+    do {
+      return try plistDecoder.decode(T.self, fromTopLevel: value)
+    } catch {
+      self.failWithError(error)
+      throw error;
+    }
+  }
+}

--- a/Darwin/Foundation-swiftoverlay/NSData+DataProtocol.swift
+++ b/Darwin/Foundation-swiftoverlay/NSData+DataProtocol.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+
+extension NSData : DataProtocol {
+
+    @nonobjc
+    public var startIndex: Int { return 0 }
+
+    @nonobjc
+    public var endIndex: Int { return length }
+
+    @nonobjc
+    public func lastRange<D, R>(of data: D, in r: R) -> Range<Int>? where D : DataProtocol, R : RangeExpression, NSData.Index == R.Bound {
+        return Range<Int>(range(of: Data(data), options: .backwards, in: NSRange(r)))
+    }
+
+    @nonobjc
+    public func firstRange<D, R>(of data: D, in r: R) -> Range<Int>? where D : DataProtocol, R : RangeExpression, NSData.Index == R.Bound {
+        return Range<Int>(range(of: Data(data), in: NSRange(r)))
+    }
+
+    @nonobjc
+    public var regions: [Data] {
+        var datas = [Data]()
+        enumerateBytes { (ptr, range, stop) in
+            datas.append(Data(bytesNoCopy: UnsafeMutableRawPointer(mutating: ptr), count: range.length, deallocator: .custom({ (ptr: UnsafeMutableRawPointer, count: Int) -> Void in
+                withExtendedLifetime(self) { }
+            })))
+        }
+        return datas
+    }
+
+    @nonobjc
+    public subscript(position: Int) -> UInt8 {
+        var byte = UInt8(0)
+        var offset = position
+        enumerateBytes { (ptr, range, stop) in
+            offset -= range.lowerBound
+            if range.contains(position) {
+                byte = ptr.load(fromByteOffset: offset, as: UInt8.self)
+                stop.pointee = true
+            }
+        }
+        return byte
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/NSDate.swift
+++ b/Darwin/Foundation-swiftoverlay/NSDate.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+extension NSDate : _CustomPlaygroundQuickLookable {
+  @nonobjc
+  var summary: String {
+    let df = DateFormatter()
+    df.dateStyle = .medium
+    df.timeStyle = .short
+    return df.string(from: self as Date)
+  }
+
+  @available(*, deprecated, message: "NSDate.customPlaygroundQuickLook will be removed in a future Swift version")
+  public var customPlaygroundQuickLook: PlaygroundQuickLook {
+    return .text(summary)
+  }
+}

--- a/Darwin/Foundation-swiftoverlay/NSDictionary.swift
+++ b/Darwin/Foundation-swiftoverlay/NSDictionary.swift
@@ -1,0 +1,465 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+@_implementationOnly import _FoundationOverlayShims
+
+// We don't check for NSCopying here for performance reasons. We would
+// just crash anyway, and NSMutableDictionary will still do that when
+// it tries to call -copyWithZone: and it's not there
+private func duckCastToNSCopying(_ x: Any) -> NSCopying {
+  return _unsafeReferenceCast(x as AnyObject, to: NSCopying.self)
+}
+
+//===----------------------------------------------------------------------===//
+// Dictionaries
+//===----------------------------------------------------------------------===//
+
+extension NSDictionary : ExpressibleByDictionaryLiteral {
+  public required convenience init(
+    dictionaryLiteral elements: (Any, Any)...
+  ) {
+    
+    self.init(
+      objects: elements.map { $0.1 as AnyObject },
+      forKeys: elements.map { duckCastToNSCopying($0.0) },
+      count: elements.count)
+  }
+}
+
+extension Dictionary {
+  /// Private initializer used for bridging.
+  ///
+  /// The provided `NSDictionary` will be copied to ensure that the copy can
+  /// not be mutated by other code.
+  private init(_cocoaDictionary: __shared NSDictionary) {
+    assert(
+      _isBridgedVerbatimToObjectiveC(Key.self) &&
+      _isBridgedVerbatimToObjectiveC(Value.self),
+      "Dictionary can be backed by NSDictionary storage only when both key and value are bridged verbatim to Objective-C")
+    // FIXME: We would like to call CFDictionaryCreateCopy() to avoid doing an
+    // objc_msgSend() for instances of CoreFoundation types.  We can't do that
+    // today because CFDictionaryCreateCopy() copies dictionary contents
+    // unconditionally, resulting in O(n) copies even for immutable dictionaries.
+    //
+    // <rdar://problem/20690755> CFDictionaryCreateCopy() does not call copyWithZone:
+    //
+    // The bug is fixed in: OS X 10.11.0, iOS 9.0, all versions of tvOS
+    // and watchOS.
+    self = Dictionary(
+      _immutableCocoaDictionary: _cocoaDictionary.copy(with: nil) as AnyObject)
+  }
+}
+
+// Dictionary<Key, Value> is conditionally bridged to NSDictionary
+extension Dictionary : _ObjectiveCBridgeable {
+  @_semantics("convertToObjectiveC")
+  public func _bridgeToObjectiveC() -> NSDictionary {
+    return unsafeBitCast(_bridgeToObjectiveCImpl(),
+                         to: NSDictionary.self)
+  }
+
+  /***
+  Precondition: `buffer` points to a region of memory bound to `AnyObject`,
+    with a capacity large enough to fit at least `index`+1 elements of type `T`
+  
+  _bridgeInitialize rebinds the `index`th `T` of `buffer` to `T`,
+    and initializes it to `value`
+
+  Note: *not* the `index`th element of `buffer`, since T and AnyObject may be
+  different sizes. e.g. if T is String (2 words) then given a buffer like so:
+
+  [object:AnyObject, object:AnyObject, uninitialized, uninitialized]
+
+  `_bridgeInitialize(1, of: buffer, to: buffer[1] as! T)` will leave it as:
+
+  [object:AnyObject, object:AnyObject, string:String]
+
+  and `_bridgeInitialize(0, of: buffer, to: buffer[0] as! T)` will then leave:
+
+  [string:String, string:String]
+
+  Doing this in reverse order as shown above is required if T and AnyObject are
+  different sizes. Here's what we get if instead of 1, 0 we did 0, 1:
+
+  [object:AnyObject, object:AnyObject, uninitialized, uninitialized]
+  [string:String, uninitialized, uninitialized]
+  <segfault trying to treat the second word of 'string' as an AnyObject>
+
+  Note: if you have retained any of the objects in `buffer`, you must release
+  them separately, _bridgeInitialize will overwrite them without releasing them
+  */
+  @inline(__always)
+  private static func _bridgeInitialize<T>(index:Int,
+    of buffer: UnsafePointer<AnyObject>, to value: T) {
+    let typedBase = UnsafeMutableRawPointer(mutating:
+                      buffer).assumingMemoryBound(to: T.self)
+    let rawTarget = UnsafeMutableRawPointer(mutating: typedBase + index)
+    rawTarget.initializeMemory(as: T.self, repeating: value, count: 1)
+  }
+
+  @inline(__always)
+  private static func _verbatimForceBridge<T>(
+    _ buffer: UnsafeMutablePointer<AnyObject>,
+    count: Int,
+    to: T.Type
+  ) {
+    //doesn't have to iterate in reverse because sizeof(T) == sizeof(AnyObject)
+    for i in 0..<count {
+      _bridgeInitialize(index: i, of: buffer, to: buffer[i] as! T)
+    }
+  }
+
+  @inline(__always)
+  private static func _verbatimBridge<T>(
+    _ buffer: UnsafeMutablePointer<AnyObject>,
+    count: Int,
+    to type: T.Type
+  ) -> Int {
+    var numUninitialized = count
+    while numUninitialized > 0 {
+      guard let bridged = buffer[numUninitialized - 1] as? T else {
+        return numUninitialized
+      }
+      numUninitialized -= 1
+      _bridgeInitialize(index: numUninitialized, of: buffer, to: bridged)
+    }
+    return numUninitialized
+  }
+
+  @inline(__always)
+  private static func _nonVerbatimForceBridge<T>(
+    _ buffer: UnsafeMutablePointer<AnyObject>,
+    count: Int,
+    to: T.Type
+  ) {
+    for i in (0..<count).reversed() {
+      let bridged = buffer[i] as! T
+      _bridgeInitialize(index: i, of: buffer, to: bridged)
+    }
+  }
+  
+  @inline(__always)
+  private static func _nonVerbatimBridge<T>(
+    _ buffer: UnsafeMutablePointer<AnyObject>,
+    count: Int,
+    to: T.Type
+  ) -> Int {
+    var numUninitialized = count
+    while numUninitialized > 0 {
+      guard let bridged = Swift._conditionallyBridgeFromObjectiveC(
+        buffer[numUninitialized - 1], T.self)
+        else {
+        return numUninitialized
+      }
+      numUninitialized -= 1
+      _bridgeInitialize(index: numUninitialized, of: buffer, to: bridged)
+    }
+    return numUninitialized
+  }
+
+  @inline(__always)
+  private static func _forceBridge<T>(
+    _ buffer: UnsafeMutablePointer<AnyObject>,
+    count: Int,
+    to: T.Type
+  ) {
+    if _isBridgedVerbatimToObjectiveC(T.self) {
+      _verbatimForceBridge(buffer, count: count, to: T.self)
+    } else {
+      _nonVerbatimForceBridge(buffer, count: count, to: T.self)
+    }
+  }
+  
+  @inline(__always)
+  private static func _conditionallyBridge<T>(
+    _ buffer: UnsafeMutablePointer<AnyObject>,
+    count: Int,
+    to: T.Type
+  ) -> Bool {
+    let numUninitialized:Int
+    if _isBridgedVerbatimToObjectiveC(T.self) {
+      numUninitialized = _verbatimBridge(buffer, count: count, to: T.self)
+    } else {
+      numUninitialized = _nonVerbatimBridge(buffer, count: count, to: T.self)
+    }
+    if numUninitialized == 0 {
+      return true
+    }
+    let numInitialized = count - numUninitialized
+    (UnsafeMutableRawPointer(mutating: buffer).assumingMemoryBound(to:
+      T.self) + numUninitialized).deinitialize(count: numInitialized)
+    return false
+  }
+
+  @_specialize(where Key == String, Value == Any)
+  public static func _forceBridgeFromObjectiveC(
+    _ d: NSDictionary,
+    result: inout Dictionary?
+  ) {
+    if let native = [Key : Value]._bridgeFromObjectiveCAdoptingNativeStorageOf(
+        d as AnyObject) {
+      result = native
+      return
+    }
+
+    if _isBridgedVerbatimToObjectiveC(Key.self) &&
+       _isBridgedVerbatimToObjectiveC(Value.self) {
+      //Lazily type-checked on access
+      result = [Key : Value](_cocoaDictionary: d)
+      return
+    }
+
+    let keyStride = MemoryLayout<Key>.stride
+    let valueStride = MemoryLayout<Value>.stride
+    let objectStride = MemoryLayout<AnyObject>.stride
+
+    //If Key or Value are smaller than AnyObject, a Dictionary with N elements
+    //doesn't have large enough backing stores to hold the objects to be bridged
+    //For now we just handle that case the slow way.
+    if keyStride < objectStride || valueStride < objectStride {
+      var builder = _DictionaryBuilder<Key, Value>(count: d.count)
+      d.enumerateKeysAndObjects({ (anyKey: Any, anyValue: Any, _) in
+        builder.add(
+          key: anyKey as! Key,
+          value: anyValue as! Value)
+      })
+      result = builder.take()
+    } else {
+      defer { _fixLifetime(d) }
+    
+      let numElems = d.count
+      
+      // String and NSString have different concepts of equality, so
+      // string-keyed NSDictionaries may generate key collisions when bridged
+      // over to Swift. See rdar://problem/35995647
+      let handleDuplicates = (Key.self == String.self)
+      
+      result = Dictionary(_unsafeUninitializedCapacity: numElems,
+        allowingDuplicates: handleDuplicates) { keys, vals in
+        
+        let objectKeys = UnsafeMutableRawPointer(mutating:
+          keys.baseAddress!).assumingMemoryBound(to: AnyObject.self)
+        let objectVals = UnsafeMutableRawPointer(mutating:
+          vals.baseAddress!).assumingMemoryBound(to: AnyObject.self)
+
+        //This initializes the first N AnyObjects of the Dictionary buffers.
+        //Any unused buffer space is left uninitialized
+        //This is fixed up in-place as we bridge elements, by _bridgeInitialize
+        __NSDictionaryGetObjects(d, objectVals, objectKeys, numElems)
+
+        _forceBridge(objectKeys, count: numElems, to: Key.self)
+        _forceBridge(objectVals, count: numElems, to: Value.self)
+        
+        return numElems
+      }
+    }
+  }
+  
+  @_specialize(where Key == String, Value == Any)
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSDictionary,
+    result: inout Dictionary?
+  ) -> Bool {
+
+    if let native = [Key : Value]._bridgeFromObjectiveCAdoptingNativeStorageOf(
+        x as AnyObject) {
+      result = native
+      return true
+    }
+
+    let keyStride = MemoryLayout<Key>.stride
+    let valueStride = MemoryLayout<Value>.stride
+    let objectStride = MemoryLayout<AnyObject>.stride
+
+    //If Key or Value are smaller than AnyObject, a Dictionary with N elements
+    //doesn't have large enough backing stores to hold the objects to be bridged
+    //For now we just handle that case the slow way.
+    if keyStride < objectStride || valueStride < objectStride {
+      result = x as [NSObject : AnyObject] as? Dictionary
+      return result != nil
+    }
+
+    defer { _fixLifetime(x) }
+    
+    let numElems = x.count
+    var success = true
+    
+    // String and NSString have different concepts of equality, so
+    // string-keyed NSDictionaries may generate key collisions when bridged
+    // over to Swift. See rdar://problem/35995647
+    let handleDuplicates = (Key.self == String.self)
+    
+    let tmpResult = Dictionary(_unsafeUninitializedCapacity: numElems,
+      allowingDuplicates: handleDuplicates) { keys, vals in
+      
+      let objectKeys = UnsafeMutableRawPointer(mutating:
+        keys.baseAddress!).assumingMemoryBound(to: AnyObject.self)
+      let objectVals = UnsafeMutableRawPointer(mutating:
+        vals.baseAddress!).assumingMemoryBound(to: AnyObject.self)
+
+      //This initializes the first N AnyObjects of the Dictionary buffers.
+      //Any unused buffer space is left uninitialized
+      //This is fixed up in-place as we bridge elements, by _bridgeInitialize
+      __NSDictionaryGetObjects(x, objectVals, objectKeys, numElems)
+
+      success = _conditionallyBridge(objectKeys, count: numElems, to: Key.self)
+      if success {
+        success = _conditionallyBridge(objectVals,
+                                       count: numElems, to: Value.self)
+        if !success {
+          (UnsafeMutableRawPointer(mutating: objectKeys).assumingMemoryBound(to:
+            Key.self)).deinitialize(count: numElems)
+        }
+      }
+      return success ? numElems : 0
+    }
+    
+    result = success ? tmpResult : nil
+    return success
+  }
+
+  @_effects(readonly)
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ d: NSDictionary?
+  ) -> Dictionary {
+    // `nil` has historically been used as a stand-in for an empty
+    // dictionary; map it to an empty dictionary.
+    if _slowPath(d == nil) { return Dictionary() }
+
+    var result: Dictionary? = nil
+    _forceBridgeFromObjectiveC(d!, result: &result)
+    return result!
+  }
+}
+
+extension NSDictionary : _HasCustomAnyHashableRepresentation {
+  // Must be @nonobjc to avoid infinite recursion during bridging
+  @nonobjc
+  public func _toCustomAnyHashable() -> AnyHashable? {
+    return AnyHashable(self as! Dictionary<AnyHashable, AnyHashable>)
+  }
+}
+
+extension NSDictionary : Sequence {
+  // FIXME: A class because we can't pass a struct with class fields through an
+  // [objc] interface without prematurely destroying the references.
+  // NOTE: older runtimes had
+  // _TtCE10FoundationCSo12NSDictionary8Iterator as the ObjC name. The
+  // two must coexist, so it was renamed. The old name must not be used
+  // in the new runtime.
+  @_objcRuntimeName(_TtCE10FoundationCSo12NSDictionary9_Iterator)
+  final public class Iterator : IteratorProtocol {
+    var _fastIterator: NSFastEnumerationIterator
+    var _dictionary: NSDictionary {
+      return _fastIterator.enumerable as! NSDictionary
+    }
+
+    public func next() -> (key: Any, value: Any)? {
+      if let key = _fastIterator.next() {
+        // Deliberately avoid the subscript operator in case the dictionary
+        // contains non-copyable keys. This is rare since NSMutableDictionary
+        // requires them, but we don't want to paint ourselves into a corner.
+        return (key: key, value: _dictionary.object(forKey: key)!)
+      }
+      return nil
+    }
+
+    internal init(_ _dict: __shared NSDictionary) {
+      _fastIterator = NSFastEnumerationIterator(_dict)
+    }
+  }
+
+  // Bridging subscript.
+  @objc
+  public subscript(key: Any) -> Any? {
+    @objc(__swift_objectForKeyedSubscript:)
+    get {
+      // Deliberately avoid the subscript operator in case the dictionary
+      // contains non-copyable keys. This is rare since NSMutableDictionary
+      // requires them, but we don't want to paint ourselves into a corner.
+      return self.object(forKey: key)
+    }
+  }
+
+  /// Return an *iterator* over the elements of this *sequence*.
+  ///
+  /// - Complexity: O(1).
+  public func makeIterator() -> Iterator {
+    return Iterator(self)
+  }
+}
+
+extension NSMutableDictionary {
+  // Bridging subscript.
+  @objc override public subscript(key: Any) -> Any? {
+    @objc(__swift_objectForKeyedSubscript:)
+    get {
+      return self.object(forKey: key)
+    }
+    @objc(__swift_setObject:forKeyedSubscript:)
+    set {
+      let copyingKey = duckCastToNSCopying(key)
+      if let newValue = newValue {
+        self.setObject(newValue, forKey: copyingKey)
+      } else {
+        self.removeObject(forKey: copyingKey)
+      }
+    }
+  }
+}
+
+extension NSDictionary {
+  /// Initializes a newly allocated dictionary and adds to it objects from
+  /// another given dictionary.
+  ///
+  /// - Returns: An initialized dictionary--which might be different
+  ///   than the original receiver--containing the keys and values
+  ///   found in `otherDictionary`.
+  @objc(__swiftInitWithDictionary_NSDictionary:)
+  public convenience init(dictionary otherDictionary: __shared NSDictionary) {
+    // FIXME(performance)(compiler limitation): we actually want to do just
+    // `self = otherDictionary.copy()`, but Swift does not have factory
+    // initializers right now.
+    let numElems = otherDictionary.count
+    let stride = MemoryLayout<AnyObject>.stride
+    let alignment = MemoryLayout<AnyObject>.alignment
+    let singleSize = stride * numElems
+    let totalSize = singleSize * 2
+    assert(stride == MemoryLayout<NSCopying>.stride)
+    assert(alignment == MemoryLayout<NSCopying>.alignment)
+
+    // Allocate a buffer containing both the keys and values.
+    let buffer = UnsafeMutableRawPointer.allocate(
+      byteCount: totalSize, alignment: alignment)
+    defer {
+      buffer.deallocate()
+      _fixLifetime(otherDictionary)
+    }
+
+    let valueBuffer = buffer.bindMemory(to: AnyObject.self, capacity: numElems)
+    let buffer2 = buffer + singleSize
+
+    __NSDictionaryGetObjects(otherDictionary, buffer, buffer2, numElems)
+
+    let keyBufferCopying = buffer2.assumingMemoryBound(to: NSCopying.self)
+    self.init(objects: valueBuffer, forKeys: keyBufferCopying, count: numElems)
+  }
+}
+
+extension NSDictionary : CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(reflecting: self as [NSObject : AnyObject])
+  }
+}
+
+extension Dictionary: CVarArg {}

--- a/Darwin/Foundation-swiftoverlay/NSError.swift
+++ b/Darwin/Foundation-swiftoverlay/NSError.swift
@@ -1,0 +1,3330 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+import CoreFoundation
+import Darwin
+@_implementationOnly import _FoundationOverlayShims
+
+//===----------------------------------------------------------------------===//
+// NSError (as an out parameter).
+//===----------------------------------------------------------------------===//
+
+public typealias NSErrorPointer = AutoreleasingUnsafeMutablePointer<NSError?>?
+
+// Note: NSErrorPointer becomes ErrorPointer in Swift 3.
+public typealias ErrorPointer = NSErrorPointer
+
+// An error value to use when an Objective-C API indicates error
+// but produces a nil error object.
+// This is 'internal' rather than 'private' for no other reason but to make the
+// type print more nicely. It's not part of the ABI, so if type printing of
+// private things improves we can change it.
+internal enum _GenericObjCError : Error {
+  case nilError
+}
+// A cached instance of the above in order to save on the conversion to Error.
+private let _nilObjCError: Error = _GenericObjCError.nilError
+
+public // COMPILER_INTRINSIC
+func _convertNSErrorToError(_ error: NSError?) -> Error {
+  if let error = error {
+    return error
+  }
+  return _nilObjCError
+}
+
+public // COMPILER_INTRINSIC
+func _convertErrorToNSError(_ error: Error) -> NSError {
+  return unsafeDowncast(_bridgeErrorToNSError(error), to: NSError.self)
+}
+
+/// Describes an error that provides localized messages describing why
+/// an error occurred and provides more information about the error.
+public protocol LocalizedError : Error {
+  /// A localized message describing what error occurred.
+  var errorDescription: String? { get }
+
+  /// A localized message describing the reason for the failure.
+  var failureReason: String? { get }
+
+  /// A localized message describing how one might recover from the failure.
+  var recoverySuggestion: String? { get }
+
+  /// A localized message providing "help" text if the user requests help.
+  var helpAnchor: String? { get }
+}
+
+public extension LocalizedError {
+  var errorDescription: String? { return nil }
+  var failureReason: String? { return nil }
+  var recoverySuggestion: String? { return nil }
+  var helpAnchor: String? { return nil }
+}
+
+/// Class that implements the informal protocol
+/// NSErrorRecoveryAttempting, which is used by NSError when it
+/// attempts recovery from an error.
+// NOTE: older overlays called this class _NSErrorRecoveryAttempter.
+// The two must coexist without a conflicting ObjC class name, so it
+// was renamed. The old name must not be used in the new runtime.
+class __NSErrorRecoveryAttempter {
+  @objc(attemptRecoveryFromError:optionIndex:delegate:didRecoverSelector:contextInfo:)
+  func attemptRecovery(fromError nsError: NSError,
+                       optionIndex recoveryOptionIndex: Int,
+                       delegate: AnyObject?,
+                       didRecoverSelector: Selector,
+                       contextInfo: UnsafeMutableRawPointer?) {
+    let error = nsError as Error as! RecoverableError
+    error.attemptRecovery(optionIndex: recoveryOptionIndex) { success in
+      __NSErrorPerformRecoverySelector(delegate, didRecoverSelector, success, contextInfo)
+    }
+  }
+
+  @objc(attemptRecoveryFromError:optionIndex:)
+  func attemptRecovery(fromError nsError: NSError,
+                       optionIndex recoveryOptionIndex: Int) -> Bool {
+    let error = nsError as Error as! RecoverableError
+    return error.attemptRecovery(optionIndex: recoveryOptionIndex)
+  }
+}
+
+/// Describes an error that may be recoverable by presenting several
+/// potential recovery options to the user.
+public protocol RecoverableError : Error {
+  /// Provides a set of possible recovery options to present to the user.
+  var recoveryOptions: [String] { get }
+
+  /// Attempt to recover from this error when the user selected the
+  /// option at the given index. This routine must call handler and
+  /// indicate whether recovery was successful (or not).
+  ///
+  /// This entry point is used for recovery of errors handled at a
+  /// "document" granularity, that do not affect the entire
+  /// application.
+  func attemptRecovery(optionIndex recoveryOptionIndex: Int,
+                       resultHandler handler: @escaping (_ recovered: Bool) -> Void)
+
+  /// Attempt to recover from this error when the user selected the
+  /// option at the given index. Returns true to indicate
+  /// successful recovery, and false otherwise.
+  ///
+  /// This entry point is used for recovery of errors handled at
+  /// the "application" granularity, where nothing else in the
+  /// application can proceed until the attempted error recovery
+  /// completes.
+  func attemptRecovery(optionIndex recoveryOptionIndex: Int) -> Bool
+}
+
+public extension RecoverableError {
+  /// Default implementation that uses the application-model recovery
+  /// mechanism (``attemptRecovery(optionIndex:)``) to implement
+  /// document-modal recovery.
+  func attemptRecovery(optionIndex recoveryOptionIndex: Int,
+                       resultHandler handler: @escaping (_ recovered: Bool) -> Void) {
+    handler(attemptRecovery(optionIndex: recoveryOptionIndex))
+  }
+}
+
+/// Describes an error type that specifically provides a domain, code,
+/// and user-info dictionary.
+public protocol CustomNSError : Error {
+  /// The domain of the error.
+  static var errorDomain: String { get }
+
+  /// The error code within the given domain.
+  var errorCode: Int { get }
+
+  /// The user-info dictionary.
+  var errorUserInfo: [String : Any] { get }
+}
+
+public extension CustomNSError {
+  /// Default domain of the error.
+  static var errorDomain: String {
+    return String(reflecting: self)
+  }
+
+  /// The error code within the given domain.
+  var errorCode: Int {
+    return _getDefaultErrorCode(self)
+  }
+
+  /// The default user-info dictionary.
+  var errorUserInfo: [String : Any] {
+    return [:]
+  }
+}
+
+/// Convert an arbitrary binary integer to an Int, reinterpreting signed
+/// -> unsigned if needed but trapping if the result is otherwise not
+/// expressible.
+func unsafeBinaryIntegerToInt<T: BinaryInteger>(_ value: T) -> Int {
+    if T.isSigned {
+        return numericCast(value)
+    }
+
+    let uintValue: UInt = numericCast(value)
+    return Int(bitPattern: uintValue)
+}
+
+/// Convert from an Int to an arbitrary binary integer, reinterpreting signed ->
+/// unsigned if needed but trapping if the result is otherwise not expressible.
+func unsafeBinaryIntegerFromInt<T: BinaryInteger>(_ value: Int) -> T {
+  if T.isSigned {
+    return numericCast(value)
+  }
+
+  let uintValue = UInt(bitPattern: value)
+  return numericCast(uintValue)
+}
+
+extension CustomNSError
+    where Self: RawRepresentable, Self.RawValue: FixedWidthInteger {
+  // The error code of Error with integral raw values is the raw value.
+  public var errorCode: Int {
+    return unsafeBinaryIntegerToInt(self.rawValue)
+  }
+}
+
+public extension Error where Self : CustomNSError {
+  /// Default implementation for customized NSErrors.
+  var _domain: String { return Self.errorDomain }
+
+  /// Default implementation for customized NSErrors.
+  var _code: Int { return self.errorCode }
+}
+
+public extension Error where Self: CustomNSError, Self: RawRepresentable,
+    Self.RawValue: FixedWidthInteger {
+  /// Default implementation for customized NSErrors.
+  var _code: Int { return self.errorCode }  
+}
+
+public extension Error {
+  /// Retrieve the localized description for this error.
+  var localizedDescription: String {
+    return (self as NSError).localizedDescription
+  }
+}
+
+internal let _errorDomainUserInfoProviderQueue = DispatchQueue(
+  label: "SwiftFoundation._errorDomainUserInfoProviderQueue")
+
+/// Retrieve the default userInfo dictionary for a given error.
+public func _getErrorDefaultUserInfo<T: Error>(_ error: T)
+  -> AnyObject? {
+  let hasUserInfoValueProvider: Bool
+
+  // If the OS supports user info value providers, use those
+  // to lazily populate the user-info dictionary for this domain.
+  if #available(macOS 10.11, iOS 9.0, tvOS 9.0, watchOS 2.0, *) {
+    // Note: the Cocoa error domain specifically excluded from
+    // user-info value providers.
+    let domain = error._domain
+    if domain != NSCocoaErrorDomain {
+      _errorDomainUserInfoProviderQueue.sync {
+        if NSError.userInfoValueProvider(forDomain: domain) != nil { return }
+        NSError.setUserInfoValueProvider(forDomain: domain) { (error, key) in
+
+          switch key {
+          case NSLocalizedDescriptionKey:
+            return (error as? LocalizedError)?.errorDescription
+
+          case NSLocalizedFailureReasonErrorKey:
+            return (error as? LocalizedError)?.failureReason
+
+          case NSLocalizedRecoverySuggestionErrorKey:
+            return (error as? LocalizedError)?.recoverySuggestion
+
+          case NSHelpAnchorErrorKey:
+            return (error as? LocalizedError)?.helpAnchor
+
+          case NSLocalizedRecoveryOptionsErrorKey:
+            return (error as? RecoverableError)?.recoveryOptions
+
+          case NSRecoveryAttempterErrorKey:
+            if error is RecoverableError {
+              return __NSErrorRecoveryAttempter()
+            }
+            return nil
+
+          default:
+            return nil
+          }
+        }
+      }
+      assert(NSError.userInfoValueProvider(forDomain: domain) != nil)
+
+      hasUserInfoValueProvider = true
+    } else {
+      hasUserInfoValueProvider = false
+    }
+  } else {
+    hasUserInfoValueProvider = false
+  }
+
+  // Populate the user-info dictionary 
+  var result: [String : Any]
+
+  // Initialize with custom user-info.
+  if let customNSError = error as? CustomNSError {
+    result = customNSError.errorUserInfo
+  } else {
+    result = [:]
+  }
+
+  // Handle localized errors. If we registered a user-info value
+  // provider, these will computed lazily.
+  if !hasUserInfoValueProvider,
+     let localizedError = error as? LocalizedError {
+    if let description = localizedError.errorDescription {
+      result[NSLocalizedDescriptionKey] = description
+    }
+    
+    if let reason = localizedError.failureReason {
+      result[NSLocalizedFailureReasonErrorKey] = reason
+    }
+    
+    if let suggestion = localizedError.recoverySuggestion {   
+      result[NSLocalizedRecoverySuggestionErrorKey] = suggestion
+    }
+    
+    if let helpAnchor = localizedError.helpAnchor {   
+      result[NSHelpAnchorErrorKey] = helpAnchor
+    }
+  }
+
+  // Handle recoverable errors. If we registered a user-info value
+  // provider, these will computed lazily.
+  if !hasUserInfoValueProvider,
+     let recoverableError = error as? RecoverableError {
+    result[NSLocalizedRecoveryOptionsErrorKey] =
+      recoverableError.recoveryOptions
+    result[NSRecoveryAttempterErrorKey] = __NSErrorRecoveryAttempter()
+  }
+
+  return result as AnyObject
+}
+
+// NSError and CFError conform to the standard Error protocol. Compiler
+// magic allows this to be done as a "toll-free" conversion when an NSError
+// or CFError is used as an Error existential.
+
+extension NSError : Error {
+  @nonobjc
+  public var _domain: String { return domain }
+
+  @nonobjc
+  public var _code: Int { return code }
+
+  @nonobjc
+  public var _userInfo: AnyObject? { return userInfo as NSDictionary }
+
+  /// The "embedded" NSError is itself.
+  @nonobjc
+  public func _getEmbeddedNSError() -> AnyObject? {
+    return self
+  }
+}
+
+extension CFError : Error {
+  public var _domain: String {
+    return CFErrorGetDomain(self) as String
+  }
+
+  public var _code: Int {
+    return CFErrorGetCode(self)
+  }
+
+  public var _userInfo: AnyObject? {
+    return CFErrorCopyUserInfo(self) as AnyObject
+  }
+
+  /// The "embedded" NSError is itself.
+  public func _getEmbeddedNSError() -> AnyObject? {
+    return self
+  }
+}
+
+/// An internal protocol to represent Swift error enums that map to standard
+/// Cocoa NSError domains.
+public protocol _ObjectiveCBridgeableError : Error {
+  /// Produce a value of the error type corresponding to the given NSError,
+  /// or return nil if it cannot be bridged.
+  init?(_bridgedNSError: __shared NSError)
+}
+
+/// A hook for the runtime to use _ObjectiveCBridgeableError in order to
+/// attempt an "errorTypeValue as? SomeError" cast.
+///
+/// If the bridge succeeds, the bridged value is written to the uninitialized
+/// memory pointed to by 'out', and true is returned. Otherwise, 'out' is
+/// left uninitialized, and false is returned.
+public func _bridgeNSErrorToError<
+  T : _ObjectiveCBridgeableError
+>(_ error: NSError, out: UnsafeMutablePointer<T>) -> Bool {
+  if let bridged = T(_bridgedNSError: error) {
+    out.initialize(to: bridged)
+    return true
+  } else {
+    return false
+  }
+}
+
+/// Describes a raw representable type that is bridged to a particular
+/// NSError domain.
+///
+/// This protocol is used primarily to generate the conformance to
+/// _ObjectiveCBridgeableError for such an enum defined in Swift.
+public protocol _BridgedNSError :
+    _ObjectiveCBridgeableError, RawRepresentable, Hashable
+    where Self.RawValue: FixedWidthInteger {
+  /// The NSError domain to which this type is bridged.
+  static var _nsErrorDomain: String { get }
+}
+
+extension _BridgedNSError {
+  public var _domain: String { return Self._nsErrorDomain }
+}
+
+extension _BridgedNSError where Self.RawValue: FixedWidthInteger {
+  public var _code: Int { return Int(rawValue) }
+
+  public init?(_bridgedNSError: __shared NSError) {
+    if _bridgedNSError.domain != Self._nsErrorDomain {
+      return nil
+    }
+
+    self.init(rawValue: RawValue(_bridgedNSError.code))
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(_code)
+  }
+}
+
+/// Describes a bridged error that stores the underlying NSError, so
+/// it can be queried.
+public protocol _BridgedStoredNSError :
+     _ObjectiveCBridgeableError, CustomNSError, Hashable {
+  /// The type of an error code.
+  associatedtype Code: _ErrorCodeProtocol, RawRepresentable
+  where Code.RawValue: FixedWidthInteger
+
+  //// Retrieves the embedded NSError.
+  var _nsError: NSError { get }
+
+  /// Create a new instance of the error type with the given embedded
+  /// NSError.
+  ///
+  /// The \c error must have the appropriate domain for this error
+  /// type.
+  init(_nsError error: NSError)
+}
+
+/// Various helper implementations for _BridgedStoredNSError
+extension _BridgedStoredNSError {
+  public var code: Code {
+    return Code(rawValue: unsafeBinaryIntegerFromInt(_nsError.code))!
+  }
+
+  /// Initialize an error within this domain with the given ``code``
+  /// and ``userInfo``.
+  public init(_ code: Code, userInfo: [String : Any] = [:]) {
+    self.init(_nsError: NSError(domain: Self.errorDomain,
+                                code: unsafeBinaryIntegerToInt(code.rawValue),
+                                userInfo: userInfo))
+  }
+
+  /// The user-info dictionary for an error that was bridged from
+  /// NSError.
+  public var userInfo: [String : Any] { return errorUserInfo }
+}
+
+/// Implementation of _ObjectiveCBridgeableError for all _BridgedStoredNSErrors.
+extension _BridgedStoredNSError {
+  /// Default implementation of ``init(_bridgedNSError:)`` to provide
+  /// bridging from NSError.
+  public init?(_bridgedNSError error: NSError) {
+    if error.domain != Self.errorDomain {
+      return nil
+    }
+
+    self.init(_nsError: error)
+  }
+}
+
+/// Implementation of CustomNSError for all _BridgedStoredNSErrors.
+public extension _BridgedStoredNSError {
+  // FIXME: Would prefer to have a clear "extract an NSError
+  // directly" operation.
+
+  // Synthesized by the compiler.
+  // static var errorDomain: String
+
+  var errorCode: Int { return _nsError.code }
+
+  var errorUserInfo: [String : Any] {
+    var result: [String : Any] = [:]
+    for (key, value) in _nsError.userInfo {
+      result[key] = value
+    }
+    return result
+  }
+}
+
+/// Implementation of Hashable for all _BridgedStoredNSErrors.
+extension _BridgedStoredNSError {
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(_nsError)
+  }
+
+  @_alwaysEmitIntoClient public var hashValue: Int {
+    return _nsError.hashValue
+  }
+}
+
+/// Describes the code of an error.
+public protocol _ErrorCodeProtocol : Equatable {
+  /// The corresponding error code.
+  associatedtype _ErrorType: _BridgedStoredNSError where _ErrorType.Code == Self
+}
+
+extension _ErrorCodeProtocol {
+  /// Allow one to match an error code against an arbitrary error.
+  public static func ~=(match: Self, error: Error) -> Bool {
+    guard let specificError = error as? Self._ErrorType else { return false }
+
+    return match == specificError.code
+  }
+}
+
+extension _BridgedStoredNSError {
+  /// Retrieve the embedded NSError from a bridged, stored NSError.
+  public func _getEmbeddedNSError() -> AnyObject? {
+    return _nsError
+  }
+
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    return lhs._nsError.isEqual(rhs._nsError)
+  }
+}
+
+extension _SwiftNewtypeWrapper where Self.RawValue == Error {
+  @inlinable // FIXME(sil-serialize-all)
+  public func _bridgeToObjectiveC() -> NSError {
+    return rawValue as NSError
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public static func _forceBridgeFromObjectiveC(
+    _ source: NSError,
+    result: inout Self?
+  ) {
+    result = Self(rawValue: source)
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ source: NSError,
+    result: inout Self?
+  ) -> Bool {
+    result = Self(rawValue: source)
+    return result != nil
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @_effects(readonly)
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ source: NSError?
+  ) -> Self {
+    return Self(rawValue: _convertNSErrorToError(source))!
+  }
+}
+
+
+@available(*, unavailable, renamed: "CocoaError")
+public typealias NSCocoaError = CocoaError
+
+/// Describes errors within the Cocoa error domain.
+public struct CocoaError : _BridgedStoredNSError {
+  public let _nsError: NSError
+
+  public init(_nsError error: NSError) {
+    precondition(error.domain == NSCocoaErrorDomain)
+    self._nsError = error
+  }
+
+  public static var errorDomain: String { return NSCocoaErrorDomain }
+
+  public var hashValue: Int {
+    return _nsError.hashValue
+  }
+
+  /// The error code itself.
+  public struct Code : RawRepresentable, Hashable, _ErrorCodeProtocol {
+    public typealias _ErrorType = CocoaError
+
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+      self.rawValue = rawValue
+    }
+  }
+}
+
+public extension CocoaError {
+  private var _nsUserInfo: [AnyHashable : Any] {
+    return (self as NSError).userInfo
+  }
+
+  /// The file path associated with the error, if any.
+  var filePath: String? {
+    return _nsUserInfo[NSFilePathErrorKey as NSString] as? String
+  }
+
+  /// The string encoding associated with this error, if any.
+  var stringEncoding: String.Encoding? {
+    return (_nsUserInfo[NSStringEncodingErrorKey as NSString] as? NSNumber)
+             .map { String.Encoding(rawValue: $0.uintValue) }
+  }
+
+  /// The underlying error behind this error, if any.
+  var underlying: Error? {
+    return _nsUserInfo[NSUnderlyingErrorKey as NSString] as? Error
+  }
+
+  /// The URL associated with this error, if any.
+  var url: URL? {
+    return _nsUserInfo[NSURLErrorKey as NSString] as? URL
+  }
+}
+
+extension CocoaError {
+    public static func error(_ code: CocoaError.Code, userInfo: [AnyHashable : Any]? = nil, url: URL? = nil) -> Error {
+        var info: [String : Any] = userInfo as? [String : Any] ?? [:]
+        if let url = url {
+            info[NSURLErrorKey] = url
+        }
+        return NSError(domain: NSCocoaErrorDomain, code: code.rawValue, userInfo: info)
+    }
+}
+
+extension CocoaError.Code {
+  public static var fileNoSuchFile: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4)
+  }
+  public static var fileLocking: CocoaError.Code {
+    return CocoaError.Code(rawValue: 255)
+  }
+  public static var fileReadUnknown: CocoaError.Code {
+    return CocoaError.Code(rawValue: 256)
+  }
+  public static var fileReadNoPermission: CocoaError.Code {
+    return CocoaError.Code(rawValue: 257)
+  }
+  public static var fileReadInvalidFileName: CocoaError.Code {
+    return CocoaError.Code(rawValue: 258)
+  }
+  public static var fileReadCorruptFile: CocoaError.Code {
+    return CocoaError.Code(rawValue: 259)
+  }
+  public static var fileReadNoSuchFile: CocoaError.Code {
+    return CocoaError.Code(rawValue: 260)
+  }
+  public static var fileReadInapplicableStringEncoding: CocoaError.Code {
+    return CocoaError.Code(rawValue: 261)
+  }
+  public static var fileReadUnsupportedScheme: CocoaError.Code {
+    return CocoaError.Code(rawValue: 262)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var fileReadTooLarge: CocoaError.Code {
+    return CocoaError.Code(rawValue: 263)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var fileReadUnknownStringEncoding: CocoaError.Code {
+    return CocoaError.Code(rawValue: 264)
+  }
+
+  public static var fileWriteUnknown: CocoaError.Code {
+    return CocoaError.Code(rawValue: 512)
+  }
+  public static var fileWriteNoPermission: CocoaError.Code {
+    return CocoaError.Code(rawValue: 513)
+  }
+  public static var fileWriteInvalidFileName: CocoaError.Code {
+    return CocoaError.Code(rawValue: 514)
+  }
+
+  @available(macOS, introduced: 10.7) @available(iOS, introduced: 5.0)
+  public static var fileWriteFileExists: CocoaError.Code {
+    return CocoaError.Code(rawValue: 516)
+  }
+
+  public static var fileWriteInapplicableStringEncoding: CocoaError.Code {
+    return CocoaError.Code(rawValue: 517)
+  }
+  public static var fileWriteUnsupportedScheme: CocoaError.Code {
+    return CocoaError.Code(rawValue: 518)
+  }
+  public static var fileWriteOutOfSpace: CocoaError.Code {
+    return CocoaError.Code(rawValue: 640)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  public static var fileWriteVolumeReadOnly: CocoaError.Code {
+    return CocoaError.Code(rawValue: 642)
+  }
+
+  @available(macOS, introduced: 10.11) @available(iOS, unavailable)
+  public static var fileManagerUnmountUnknown: CocoaError.Code {
+    return CocoaError.Code(rawValue: 768)
+  }
+
+  @available(macOS, introduced: 10.11) @available(iOS, unavailable)
+  public static var fileManagerUnmountBusy: CocoaError.Code {
+    return CocoaError.Code(rawValue: 769)
+  }
+
+  public static var keyValueValidation: CocoaError.Code {
+    return CocoaError.Code(rawValue: 1024)
+  }
+  public static var formatting: CocoaError.Code {
+    return CocoaError.Code(rawValue: 2048)
+  }
+  public static var userCancelled: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3072)
+  }
+
+  @available(macOS, introduced: 10.8) @available(iOS, introduced: 6.0)
+  public static var featureUnsupported: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3328)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var executableNotLoadable: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3584)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var executableArchitectureMismatch: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3585)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var executableRuntimeMismatch: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3586)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var executableLoad: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3587)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var executableLink: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3588)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  public static var propertyListReadCorrupt: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3840)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  public static var propertyListReadUnknownVersion: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3841)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  public static var propertyListReadStream: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3842)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  public static var propertyListWriteStream: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3851)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var propertyListWriteInvalid: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3852)
+  }
+
+  @available(macOS, introduced: 10.8) @available(iOS, introduced: 6.0)
+  public static var xpcConnectionInterrupted: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4097)
+  }
+
+  @available(macOS, introduced: 10.8) @available(iOS, introduced: 6.0)
+  public static var xpcConnectionInvalid: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4099)
+  }
+
+  @available(macOS, introduced: 10.8) @available(iOS, introduced: 6.0)
+  public static var xpcConnectionReplyInvalid: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4101)
+  }
+
+  @available(macOS, introduced: 10.9) @available(iOS, introduced: 7.0)
+  public static var ubiquitousFileUnavailable: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4353)
+  }
+
+  @available(macOS, introduced: 10.9) @available(iOS, introduced: 7.0)
+  public static var ubiquitousFileNotUploadedDueToQuota: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4354)
+  }
+
+  @available(macOS, introduced: 10.9) @available(iOS, introduced: 7.0)
+  public static var ubiquitousFileUbiquityServerNotAvailable: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4355)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var userActivityHandoffFailed: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4608)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var userActivityConnectionUnavailable: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4609)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var userActivityRemoteApplicationTimedOut: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4610)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var userActivityHandoffUserInfoTooLarge: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4611)
+  }
+
+  @available(macOS, introduced: 10.11) @available(iOS, introduced: 9.0)
+  public static var coderReadCorrupt: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4864)
+  }
+
+  @available(macOS, introduced: 10.11) @available(iOS, introduced: 9.0)
+  public static var coderValueNotFound: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4865)
+  }
+
+  public static var coderInvalidValue: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4866)
+  }
+}
+
+extension CocoaError.Code {
+  @available(*, deprecated, renamed: "fileNoSuchFile")
+  public static var fileNoSuchFileError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4)
+  }
+  @available(*, deprecated, renamed: "fileLocking")
+  public static var fileLockingError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 255)
+  }
+  @available(*, deprecated, renamed: "fileReadUnknown")
+  public static var fileReadUnknownError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 256)
+  }
+  @available(*, deprecated, renamed: "fileReadNoPermission")
+  public static var fileReadNoPermissionError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 257)
+  }
+  @available(*, deprecated, renamed: "fileReadInvalidFileName")
+  public static var fileReadInvalidFileNameError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 258)
+  }
+  @available(*, deprecated, renamed: "fileReadCorruptFile")
+  public static var fileReadCorruptFileError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 259)
+  }
+  @available(*, deprecated, renamed: "fileReadNoSuchFile")
+  public static var fileReadNoSuchFileError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 260)
+  }
+  @available(*, deprecated, renamed: "fileReadInapplicableStringEncoding")
+  public static var fileReadInapplicableStringEncodingError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 261)
+  }
+  @available(*, deprecated, renamed: "fileReadUnsupportedScheme")
+  public static var fileReadUnsupportedSchemeError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 262)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  @available(*, deprecated, renamed: "fileReadTooLarge")
+  public static var fileReadTooLargeError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 263)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  @available(*, deprecated, renamed: "fileReadUnknownStringEncoding")
+  public static var fileReadUnknownStringEncodingError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 264)
+  }
+
+  @available(*, deprecated, renamed: "fileWriteUnknown")
+  public static var fileWriteUnknownError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 512)
+  }
+
+  @available(*, deprecated, renamed: "fileWriteNoPermission")
+  public static var fileWriteNoPermissionError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 513)
+  }
+
+  @available(*, deprecated, renamed: "fileWriteInvalidFileName")
+  public static var fileWriteInvalidFileNameError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 514)
+  }
+
+  @available(macOS, introduced: 10.7) @available(iOS, introduced: 5.0)
+  @available(*, deprecated, renamed: "fileWriteFileExists")
+  public static var fileWriteFileExistsError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 516)
+  }
+
+  @available(*, deprecated, renamed: "fileWriteInapplicableStringEncoding")
+  public static var fileWriteInapplicableStringEncodingError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 517)
+  }
+
+  @available(*, deprecated, renamed: "fileWriteUnsupportedScheme")
+  public static var fileWriteUnsupportedSchemeError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 518)
+  }
+
+  @available(*, deprecated, renamed: "fileWriteOutOfSpace")
+  public static var fileWriteOutOfSpaceError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 640)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  @available(*, deprecated, renamed: "fileWriteVolumeReadOnly")
+  public static var fileWriteVolumeReadOnlyError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 642)
+  }
+
+  @available(macOS, introduced: 10.11) @available(iOS, unavailable)
+  @available(*, deprecated, renamed: "fileManagerUnmountUnknown")
+  public static var fileManagerUnmountUnknownError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 768)
+  }
+
+  @available(macOS, introduced: 10.11) @available(iOS, unavailable)
+  @available(*, deprecated, renamed: "fileManagerUnmountBusy")
+  public static var fileManagerUnmountBusyError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 769)
+  }
+
+  @available(*, deprecated, renamed: "keyValueValidation")
+  public static var keyValueValidationError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 1024)
+  }
+
+  @available(*, deprecated, renamed: "formatting")
+  public static var formattingError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 2048)
+  }
+
+  @available(*, deprecated, renamed: "userCancelled")
+  public static var userCancelledError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3072)
+  }
+
+  @available(macOS, introduced: 10.8) @available(iOS, introduced: 6.0)
+  @available(*, deprecated, renamed: "featureUnsupported")
+  public static var featureUnsupportedError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3328)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  @available(*, deprecated, renamed: "executableNotLoadable")
+  public static var executableNotLoadableError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3584)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  @available(*, deprecated, renamed: "executableArchitectureMismatch")
+  public static var executableArchitectureMismatchError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3585)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  @available(*, deprecated, renamed: "executableRuntimeMismatch")
+  public static var executableRuntimeMismatchError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3586)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  @available(*, deprecated, renamed: "executableLoad")
+  public static var executableLoadError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3587)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  @available(*, deprecated, renamed: "executableLink")
+  public static var executableLinkError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3588)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  @available(*, deprecated, renamed: "propertyListReadCorrupt")
+  public static var propertyListReadCorruptError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3840)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  @available(*, deprecated, renamed: "propertyListReadUnknownVersion")
+  public static var propertyListReadUnknownVersionError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3841)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  @available(*, deprecated, renamed: "propertyListReadStream")
+  public static var propertyListReadStreamError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3842)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  @available(*, deprecated, renamed: "propertyListWriteStream")
+  public static var propertyListWriteStreamError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3851)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  @available(*, deprecated, renamed: "propertyListWriteInvalid")
+  public static var propertyListWriteInvalidError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3852)
+  }
+
+  @available(macOS, introduced: 10.9) @available(iOS, introduced: 7.0)
+  @available(*, deprecated, renamed: "ubiquitousFileUnavailable")
+  public static var ubiquitousFileUnavailableError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4353)
+  }
+
+  @available(macOS, introduced: 10.9) @available(iOS, introduced: 7.0)
+  @available(*, deprecated, renamed: "ubiquitousFileNotUploadedDueToQuota")
+  public static var ubiquitousFileNotUploadedDueToQuotaError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4354)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  @available(*, deprecated, renamed: "userActivityHandoffFailed")
+  public static var userActivityHandoffFailedError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4608)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  @available(*, deprecated, renamed: "userActivityConnectionUnavailable")
+  public static var userActivityConnectionUnavailableError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4609)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  @available(*, deprecated, renamed: "userActivityRemoteApplicationTimedOut")
+  public static var userActivityRemoteApplicationTimedOutError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4610)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  @available(*, deprecated, renamed: "userActivityHandoffUserInfoTooLarge")
+  public static var userActivityHandoffUserInfoTooLargeError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4611)
+  }
+
+  @available(macOS, introduced: 10.11) @available(iOS, introduced: 9.0)
+  @available(*, deprecated, renamed: "coderReadCorrupt")
+  public static var coderReadCorruptError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4864)
+  }
+
+  @available(macOS, introduced: 10.11) @available(iOS, introduced: 9.0)
+  @available(*, deprecated, renamed: "coderValueNotFound")
+  public static var coderValueNotFoundError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4865)
+  }
+}
+
+extension CocoaError {
+  public static var fileNoSuchFile: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4)
+  }
+  public static var fileLocking: CocoaError.Code {
+    return CocoaError.Code(rawValue: 255)
+  }
+  public static var fileReadUnknown: CocoaError.Code {
+    return CocoaError.Code(rawValue: 256)
+  }
+  public static var fileReadNoPermission: CocoaError.Code {
+    return CocoaError.Code(rawValue: 257)
+  }
+  public static var fileReadInvalidFileName: CocoaError.Code {
+    return CocoaError.Code(rawValue: 258)
+  }
+  public static var fileReadCorruptFile: CocoaError.Code {
+    return CocoaError.Code(rawValue: 259)
+  }
+  public static var fileReadNoSuchFile: CocoaError.Code {
+    return CocoaError.Code(rawValue: 260)
+  }
+  public static var fileReadInapplicableStringEncoding: CocoaError.Code {
+    return CocoaError.Code(rawValue: 261)
+  }
+  public static var fileReadUnsupportedScheme: CocoaError.Code {
+    return CocoaError.Code(rawValue: 262)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var fileReadTooLarge: CocoaError.Code {
+    return CocoaError.Code(rawValue: 263)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var fileReadUnknownStringEncoding: CocoaError.Code {
+    return CocoaError.Code(rawValue: 264)
+  }
+
+  public static var fileWriteUnknown: CocoaError.Code {
+    return CocoaError.Code(rawValue: 512)
+  }
+  public static var fileWriteNoPermission: CocoaError.Code {
+    return CocoaError.Code(rawValue: 513)
+  }
+  public static var fileWriteInvalidFileName: CocoaError.Code {
+    return CocoaError.Code(rawValue: 514)
+  }
+
+  @available(macOS, introduced: 10.7) @available(iOS, introduced: 5.0)
+  public static var fileWriteFileExists: CocoaError.Code {
+    return CocoaError.Code(rawValue: 516)
+  }
+
+  public static var fileWriteInapplicableStringEncoding: CocoaError.Code {
+    return CocoaError.Code(rawValue: 517)
+  }
+  public static var fileWriteUnsupportedScheme: CocoaError.Code {
+    return CocoaError.Code(rawValue: 518)
+  }
+  public static var fileWriteOutOfSpace: CocoaError.Code {
+    return CocoaError.Code(rawValue: 640)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  public static var fileWriteVolumeReadOnly: CocoaError.Code {
+    return CocoaError.Code(rawValue: 642)
+  }
+
+  @available(macOS, introduced: 10.11) @available(iOS, unavailable)
+  public static var fileManagerUnmountUnknown: CocoaError.Code {
+    return CocoaError.Code(rawValue: 768)
+  }
+
+  @available(macOS, introduced: 10.11) @available(iOS, unavailable)
+  public static var fileManagerUnmountBusy: CocoaError.Code {
+    return CocoaError.Code(rawValue: 769)
+  }
+
+  public static var keyValueValidation: CocoaError.Code {
+    return CocoaError.Code(rawValue: 1024)
+  }
+  public static var formatting: CocoaError.Code {
+    return CocoaError.Code(rawValue: 2048)
+  }
+  public static var userCancelled: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3072)
+  }
+
+  @available(macOS, introduced: 10.8) @available(iOS, introduced: 6.0)
+  public static var featureUnsupported: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3328)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var executableNotLoadable: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3584)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var executableArchitectureMismatch: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3585)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var executableRuntimeMismatch: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3586)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var executableLoad: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3587)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var executableLink: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3588)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  public static var propertyListReadCorrupt: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3840)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  public static var propertyListReadUnknownVersion: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3841)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  public static var propertyListReadStream: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3842)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  public static var propertyListWriteStream: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3851)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var propertyListWriteInvalid: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3852)
+  }
+
+  @available(macOS, introduced: 10.8) @available(iOS, introduced: 6.0)
+  public static var xpcConnectionInterrupted: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4097)
+  }
+
+  @available(macOS, introduced: 10.8) @available(iOS, introduced: 6.0)
+  public static var xpcConnectionInvalid: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4099)
+  }
+
+  @available(macOS, introduced: 10.8) @available(iOS, introduced: 6.0)
+  public static var xpcConnectionReplyInvalid: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4101)
+  }
+
+  @available(macOS, introduced: 10.9) @available(iOS, introduced: 7.0)
+  public static var ubiquitousFileUnavailable: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4353)
+  }
+
+  @available(macOS, introduced: 10.9) @available(iOS, introduced: 7.0)
+  public static var ubiquitousFileNotUploadedDueToQuota: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4354)
+  }
+
+  @available(macOS, introduced: 10.9) @available(iOS, introduced: 7.0)
+  public static var ubiquitousFileUbiquityServerNotAvailable: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4355)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var userActivityHandoffFailed: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4608)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var userActivityConnectionUnavailable: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4609)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var userActivityRemoteApplicationTimedOut: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4610)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var userActivityHandoffUserInfoTooLarge: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4611)
+  }
+
+  @available(macOS, introduced: 10.11) @available(iOS, introduced: 9.0)
+  public static var coderReadCorrupt: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4864)
+  }
+
+  @available(macOS, introduced: 10.11) @available(iOS, introduced: 9.0)
+  public static var coderValueNotFound: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4865)
+  }
+
+  public static var coderInvalidValue: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4866)
+  }
+}
+
+extension CocoaError {
+  @available(*, deprecated, renamed: "fileNoSuchFile")
+  public static var fileNoSuchFileError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4)
+  }
+  @available(*, deprecated, renamed: "fileLocking")
+  public static var fileLockingError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 255)
+  }
+  @available(*, deprecated, renamed: "fileReadUnknown")
+  public static var fileReadUnknownError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 256)
+  }
+  @available(*, deprecated, renamed: "fileReadNoPermission")
+  public static var fileReadNoPermissionError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 257)
+  }
+  @available(*, deprecated, renamed: "fileReadInvalidFileName")
+  public static var fileReadInvalidFileNameError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 258)
+  }
+  @available(*, deprecated, renamed: "fileReadCorruptFile")
+  public static var fileReadCorruptFileError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 259)
+  }
+  @available(*, deprecated, renamed: "fileReadNoSuchFile")
+  public static var fileReadNoSuchFileError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 260)
+  }
+  @available(*, deprecated, renamed: "fileReadInapplicableStringEncoding")
+  public static var fileReadInapplicableStringEncodingError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 261)
+  }
+  @available(*, deprecated, renamed: "fileReadUnsupportedScheme")
+  public static var fileReadUnsupportedSchemeError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 262)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  @available(*, deprecated, renamed: "fileReadTooLarge")
+  public static var fileReadTooLargeError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 263)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  @available(*, deprecated, renamed: "fileReadUnknownStringEncoding")
+  public static var fileReadUnknownStringEncodingError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 264)
+  }
+
+  @available(*, deprecated, renamed: "fileWriteUnknown")
+  public static var fileWriteUnknownError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 512)
+  }
+
+  @available(*, deprecated, renamed: "fileWriteNoPermission")
+  public static var fileWriteNoPermissionError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 513)
+  }
+
+  @available(*, deprecated, renamed: "fileWriteInvalidFileName")
+  public static var fileWriteInvalidFileNameError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 514)
+  }
+
+  @available(macOS, introduced: 10.7) @available(iOS, introduced: 5.0)
+  @available(*, deprecated, renamed: "fileWriteFileExists")
+  public static var fileWriteFileExistsError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 516)
+  }
+
+  @available(*, deprecated, renamed: "fileWriteInapplicableStringEncoding")
+  public static var fileWriteInapplicableStringEncodingError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 517)
+  }
+
+  @available(*, deprecated, renamed: "fileWriteUnsupportedScheme")
+  public static var fileWriteUnsupportedSchemeError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 518)
+  }
+
+  @available(*, deprecated, renamed: "fileWriteOutOfSpace")
+  public static var fileWriteOutOfSpaceError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 640)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  @available(*, deprecated, renamed: "fileWriteVolumeReadOnly")
+  public static var fileWriteVolumeReadOnlyError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 642)
+  }
+
+  @available(macOS, introduced: 10.11) @available(iOS, unavailable)
+  @available(*, deprecated, renamed: "fileManagerUnmountUnknown")
+  public static var fileManagerUnmountUnknownError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 768)
+  }
+
+  @available(macOS, introduced: 10.11) @available(iOS, unavailable)
+  @available(*, deprecated, renamed: "fileManagerUnmountBusy")
+  public static var fileManagerUnmountBusyError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 769)
+  }
+
+  @available(*, deprecated, renamed: "keyValueValidation")
+  public static var keyValueValidationError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 1024)
+  }
+
+  @available(*, deprecated, renamed: "formatting")
+  public static var formattingError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 2048)
+  }
+
+  @available(*, deprecated, renamed: "userCancelled")
+  public static var userCancelledError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3072)
+  }
+
+  @available(macOS, introduced: 10.8) @available(iOS, introduced: 6.0)
+  @available(*, deprecated, renamed: "featureUnsupported")
+  public static var featureUnsupportedError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3328)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  @available(*, deprecated, renamed: "executableNotLoadable")
+  public static var executableNotLoadableError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3584)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  @available(*, deprecated, renamed: "executableArchitectureMismatch")
+  public static var executableArchitectureMismatchError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3585)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  @available(*, deprecated, renamed: "executableRuntimeMismatch")
+  public static var executableRuntimeMismatchError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3586)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  @available(*, deprecated, renamed: "executableLoad")
+  public static var executableLoadError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3587)
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  @available(*, deprecated, renamed: "executableLink")
+  public static var executableLinkError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3588)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  @available(*, deprecated, renamed: "propertyListReadCorrupt")
+  public static var propertyListReadCorruptError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3840)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  @available(*, deprecated, renamed: "propertyListReadUnknownVersion")
+  public static var propertyListReadUnknownVersionError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3841)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  @available(*, deprecated, renamed: "propertyListReadStream")
+  public static var propertyListReadStreamError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3842)
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  @available(*, deprecated, renamed: "propertyListWriteStream")
+  public static var propertyListWriteStreamError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3851)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  @available(*, deprecated, renamed: "propertyListWriteInvalid")
+  public static var propertyListWriteInvalidError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 3852)
+  }
+
+  @available(macOS, introduced: 10.9) @available(iOS, introduced: 7.0)
+  @available(*, deprecated, renamed: "ubiquitousFileUnavailable")
+  public static var ubiquitousFileUnavailableError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4353)
+  }
+
+  @available(macOS, introduced: 10.9) @available(iOS, introduced: 7.0)
+  @available(*, deprecated, renamed: "ubiquitousFileNotUploadedDueToQuota")
+  public static var ubiquitousFileNotUploadedDueToQuotaError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4354)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  @available(*, deprecated, renamed: "userActivityHandoffFailed")
+  public static var userActivityHandoffFailedError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4608)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  @available(*, deprecated, renamed: "userActivityConnectionUnavailable")
+  public static var userActivityConnectionUnavailableError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4609)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  @available(*, deprecated, renamed: "userActivityRemoteApplicationTimedOut")
+  public static var userActivityRemoteApplicationTimedOutError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4610)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  @available(*, deprecated, renamed: "userActivityHandoffUserInfoTooLarge")
+  public static var userActivityHandoffUserInfoTooLargeError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4611)
+  }
+
+  @available(macOS, introduced: 10.11) @available(iOS, introduced: 9.0)
+  @available(*, deprecated, renamed: "coderReadCorrupt")
+  public static var coderReadCorruptError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4864)
+  }
+
+  @available(macOS, introduced: 10.11) @available(iOS, introduced: 9.0)
+  @available(*, deprecated, renamed: "coderValueNotFound")
+  public static var coderValueNotFoundError: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4865)
+  }
+}
+
+extension CocoaError {
+  @available(macOS, introduced: 10.11) @available(iOS, introduced: 9.0)
+  public var isCoderError: Bool {
+    return code.rawValue >= 4864 && code.rawValue <= 4991
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public var isExecutableError: Bool {
+    return code.rawValue >= 3584 && code.rawValue <= 3839
+  }
+
+  public var isFileError: Bool {
+    return code.rawValue >= 0 && code.rawValue <= 1023
+  }
+
+  public var isFormattingError: Bool {
+    return code.rawValue >= 2048 && code.rawValue <= 2559
+  }
+
+  @available(macOS, introduced: 10.6) @available(iOS, introduced: 4.0)
+  public var isPropertyListError: Bool {
+    return code.rawValue >= 3840 && code.rawValue <= 4095
+  }
+
+  @available(macOS, introduced: 10.9) @available(iOS, introduced: 7.0)
+  public var isUbiquitousFileError: Bool {
+    return code.rawValue >= 4352 && code.rawValue <= 4607
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public var isUserActivityError: Bool {
+    return code.rawValue >= 4608 && code.rawValue <= 4863
+  }
+
+  public var isValidationError: Bool {
+    return code.rawValue >= 1024 && code.rawValue <= 2047
+  }
+
+  @available(macOS, introduced: 10.8) @available(iOS, introduced: 6.0)
+  public var isXPCConnectionError: Bool {
+    return code.rawValue >= 4096 && code.rawValue <= 4224
+  }
+}
+
+extension CocoaError.Code {
+  @available(*, unavailable, renamed: "fileNoSuchFile")
+  public static var FileNoSuchFileError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileLocking")
+  public static var FileLockingError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileReadUnknown")
+  public static var FileReadUnknownError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileReadNoPermission")
+  public static var FileReadNoPermissionError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileReadInvalidFileName")
+  public static var FileReadInvalidFileNameError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileReadCorruptFile")
+  public static var FileReadCorruptFileError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileReadNoSuchFile")
+  public static var FileReadNoSuchFileError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileReadInapplicableStringEncoding")
+  public static var FileReadInapplicableStringEncodingError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileReadUnsupportedScheme")
+  public static var FileReadUnsupportedSchemeError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileReadTooLarge")
+  public static var FileReadTooLargeError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileReadUnknownStringEncoding")
+  public static var FileReadUnknownStringEncodingError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileWriteUnknown")
+  public static var FileWriteUnknownError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileWriteNoPermission")
+  public static var FileWriteNoPermissionError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileWriteInvalidFileName")
+  public static var FileWriteInvalidFileNameError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileWriteFileExists")
+  public static var FileWriteFileExistsError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileWriteInapplicableStringEncoding")
+  public static var FileWriteInapplicableStringEncodingError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileWriteUnsupportedScheme")
+  public static var FileWriteUnsupportedSchemeError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileWriteOutOfSpace")
+  public static var FileWriteOutOfSpaceError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileWriteVolumeReadOnly")
+  public static var FileWriteVolumeReadOnlyError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileManagerUnmountUnknown")
+  public static var FileManagerUnmountUnknownError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileManagerUnmountBusy")
+  public static var FileManagerUnmountBusyError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "keyValueValidation")
+  public static var KeyValueValidationError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "formatting")
+  public static var FormattingError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "userCancelled")
+  public static var UserCancelledError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "featureUnsupported")
+  public static var FeatureUnsupportedError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "executableNotLoadable")
+  public static var ExecutableNotLoadableError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "executableArchitectureMismatch")
+  public static var ExecutableArchitectureMismatchError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "executableRuntimeMismatch")
+  public static var ExecutableRuntimeMismatchError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "executableLoad")
+  public static var ExecutableLoadError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "executableLink")
+  public static var ExecutableLinkError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "propertyListReadCorrupt")
+  public static var PropertyListReadCorruptError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "propertyListReadUnknownVersion")
+  public static var PropertyListReadUnknownVersionError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "propertyListReadStream")
+  public static var PropertyListReadStreamError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "propertyListWriteStream")
+  public static var PropertyListWriteStreamError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "propertyListWriteInvalid")
+  public static var PropertyListWriteInvalidError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "xpcConnectionInterrupted")
+  public static var XPCConnectionInterrupted: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "xpcConnectionInvalid")
+  public static var XPCConnectionInvalid: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "xpcConnectionReplyInvalid")
+  public static var XPCConnectionReplyInvalid: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "ubiquitousFileUnavailable")
+  public static var UbiquitousFileUnavailableError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "ubiquitousFileNotUploadedDueToQuota")
+  public static var UbiquitousFileNotUploadedDueToQuotaError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "ubiquitousFileUbiquityServerNotAvailable")
+  public static var UbiquitousFileUbiquityServerNotAvailable: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "userActivityHandoffFailed")
+  public static var UserActivityHandoffFailedError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "userActivityConnectionUnavailable")
+  public static var UserActivityConnectionUnavailableError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "userActivityRemoteApplicationTimedOut")
+  public static var UserActivityRemoteApplicationTimedOutError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "userActivityHandoffUserInfoTooLarge")
+  public static var UserActivityHandoffUserInfoTooLargeError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "coderReadCorrupt")
+  public static var CoderReadCorruptError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "coderValueNotFound")
+  public static var CoderValueNotFoundError: CocoaError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+}
+
+/// Describes errors in the URL error domain.
+public struct URLError : _BridgedStoredNSError {
+  public let _nsError: NSError
+
+  public init(_nsError error: NSError) {
+    precondition(error.domain == NSURLErrorDomain)
+    self._nsError = error
+  }
+
+  public static var errorDomain: String { return NSURLErrorDomain }
+
+  public var hashValue: Int {
+    return _nsError.hashValue
+  }
+
+  /// The error code itself.
+  public struct Code : RawRepresentable, Hashable, _ErrorCodeProtocol {
+    public typealias _ErrorType = URLError
+
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+      self.rawValue = rawValue
+    }
+  }
+}
+
+extension URLError.Code {
+  public static var unknown: URLError.Code {
+    return URLError.Code(rawValue: -1)
+  }
+  public static var cancelled: URLError.Code {
+    return URLError.Code(rawValue: -999)
+  }
+  public static var badURL: URLError.Code {
+    return URLError.Code(rawValue: -1000)
+  }
+  public static var timedOut: URLError.Code {
+    return URLError.Code(rawValue: -1001)
+  }
+  public static var unsupportedURL: URLError.Code {
+    return URLError.Code(rawValue: -1002)
+  }
+  public static var cannotFindHost: URLError.Code {
+    return URLError.Code(rawValue: -1003)
+  }
+  public static var cannotConnectToHost: URLError.Code {
+    return URLError.Code(rawValue: -1004)
+  }
+  public static var networkConnectionLost: URLError.Code {
+    return URLError.Code(rawValue: -1005)
+  }
+  public static var dnsLookupFailed: URLError.Code {
+    return URLError.Code(rawValue: -1006)
+  }
+  public static var httpTooManyRedirects: URLError.Code {
+    return URLError.Code(rawValue: -1007)
+  }
+  public static var resourceUnavailable: URLError.Code {
+    return URLError.Code(rawValue: -1008)
+  }
+  public static var notConnectedToInternet: URLError.Code {
+    return URLError.Code(rawValue: -1009)
+  }
+  public static var redirectToNonExistentLocation: URLError.Code {
+    return URLError.Code(rawValue: -1010)
+  }
+  public static var badServerResponse: URLError.Code {
+    return URLError.Code(rawValue: -1011)
+  }
+  public static var userCancelledAuthentication: URLError.Code {
+    return URLError.Code(rawValue: -1012)
+  }
+  public static var userAuthenticationRequired: URLError.Code {
+    return URLError.Code(rawValue: -1013)
+  }
+  public static var zeroByteResource: URLError.Code {
+    return URLError.Code(rawValue: -1014)
+  }
+  public static var cannotDecodeRawData: URLError.Code {
+    return URLError.Code(rawValue: -1015)
+  }
+  public static var cannotDecodeContentData: URLError.Code {
+    return URLError.Code(rawValue: -1016)
+  }
+  public static var cannotParseResponse: URLError.Code {
+    return URLError.Code(rawValue: -1017)
+  }
+  @available(macOS, introduced: 10.11) @available(iOS, introduced: 9.0)
+  public static var appTransportSecurityRequiresSecureConnection: URLError.Code {
+    return URLError.Code(rawValue: -1022)
+  }
+  public static var fileDoesNotExist: URLError.Code {
+    return URLError.Code(rawValue: -1100)
+  }
+  public static var fileIsDirectory: URLError.Code {
+    return URLError.Code(rawValue: -1101)
+  }
+  public static var noPermissionsToReadFile: URLError.Code {
+    return URLError.Code(rawValue: -1102)
+  }
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var dataLengthExceedsMaximum: URLError.Code {
+    return URLError.Code(rawValue: -1103)
+  }
+  public static var secureConnectionFailed: URLError.Code {
+    return URLError.Code(rawValue: -1200)
+  }
+  public static var serverCertificateHasBadDate: URLError.Code {
+    return URLError.Code(rawValue: -1201)
+  }
+  public static var serverCertificateUntrusted: URLError.Code {
+    return URLError.Code(rawValue: -1202)
+  }
+  public static var serverCertificateHasUnknownRoot: URLError.Code {
+    return URLError.Code(rawValue: -1203)
+  }
+  public static var serverCertificateNotYetValid: URLError.Code {
+    return URLError.Code(rawValue: -1204)
+  }
+  public static var clientCertificateRejected: URLError.Code {
+    return URLError.Code(rawValue: -1205)
+  }
+  public static var clientCertificateRequired: URLError.Code {
+    return URLError.Code(rawValue: -1206)
+  }
+  public static var cannotLoadFromNetwork: URLError.Code {
+    return URLError.Code(rawValue: -2000)
+  }
+  public static var cannotCreateFile: URLError.Code {
+    return URLError.Code(rawValue: -3000)
+  }
+  public static var cannotOpenFile: URLError.Code {
+    return URLError.Code(rawValue: -3001)
+  }
+  public static var cannotCloseFile: URLError.Code {
+    return URLError.Code(rawValue: -3002)
+  }
+  public static var cannotWriteToFile: URLError.Code {
+    return URLError.Code(rawValue: -3003)
+  }
+  public static var cannotRemoveFile: URLError.Code {
+    return URLError.Code(rawValue: -3004)
+  }
+  public static var cannotMoveFile: URLError.Code {
+    return URLError.Code(rawValue: -3005)
+  }
+  public static var downloadDecodingFailedMidStream: URLError.Code {
+    return URLError.Code(rawValue: -3006)
+  }
+  public static var downloadDecodingFailedToComplete: URLError.Code {
+    return URLError.Code(rawValue: -3007)
+  }
+
+  @available(macOS, introduced: 10.7) @available(iOS, introduced: 3.0)
+  public static var internationalRoamingOff: URLError.Code {
+    return URLError.Code(rawValue: -1018)
+  }
+
+  @available(macOS, introduced: 10.7) @available(iOS, introduced: 3.0)
+  public static var callIsActive: URLError.Code {
+    return URLError.Code(rawValue: -1019)
+  }
+
+  @available(macOS, introduced: 10.7) @available(iOS, introduced: 3.0)
+  public static var dataNotAllowed: URLError.Code {
+    return URLError.Code(rawValue: -1020)
+  }
+
+  @available(macOS, introduced: 10.7) @available(iOS, introduced: 3.0)
+  public static var requestBodyStreamExhausted: URLError.Code {
+    return URLError.Code(rawValue: -1021)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var backgroundSessionRequiresSharedContainer: URLError.Code {
+    return URLError.Code(rawValue: -995)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var backgroundSessionInUseByAnotherProcess: URLError.Code {
+    return URLError.Code(rawValue: -996)
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var backgroundSessionWasDisconnected: URLError.Code {
+    return URLError.Code(rawValue: -997)
+  }
+}
+
+extension URLError {
+  /// Reasons used by URLError to indicate why a background URLSessionTask was cancelled.
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  public enum BackgroundTaskCancelledReason : Int {
+    case userForceQuitApplication
+    case backgroundUpdatesDisabled
+    case insufficientSystemResources
+  }
+}
+
+extension URLError {
+  /// Reasons used by URLError to indicate that a URLSessionTask failed because of unsatisfiable network constraints.
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  public enum NetworkUnavailableReason : Int {
+    case cellular
+    case expensive
+    case constrained
+  }
+}
+
+extension URLError {
+  private var _nsUserInfo: [AnyHashable : Any] {
+    return (self as NSError).userInfo
+  }
+
+  /// The URL which caused a load to fail.
+  public var failingURL: URL? {
+    return _nsUserInfo[NSURLErrorFailingURLErrorKey as NSString] as? URL
+  }
+
+  /// The string for the URL which caused a load to fail. 
+  public var failureURLString: String? {
+    return _nsUserInfo[NSURLErrorFailingURLStringErrorKey as NSString] as? String
+  }
+
+  /// The state of a failed SSL handshake.
+  public var failureURLPeerTrust: SecTrust? {
+    if let secTrust = _nsUserInfo[NSURLErrorFailingURLPeerTrustErrorKey as NSString] {
+      return (secTrust as! SecTrust)
+    }
+
+    return nil
+  }
+
+  /// The reason why a background URLSessionTask was cancelled.
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  public var backgroundTaskCancelledReason: BackgroundTaskCancelledReason? {
+    return (_nsUserInfo[NSURLErrorBackgroundTaskCancelledReasonKey] as? Int).flatMap(BackgroundTaskCancelledReason.init(rawValue:))
+  }
+
+  /// The reason why the network is unavailable when the task failed due to unsatisfiable network constraints.
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  public var networkUnavailableReason: NetworkUnavailableReason? {
+    return (_nsUserInfo[NSURLErrorNetworkUnavailableReasonKey] as? Int).flatMap(NetworkUnavailableReason.init(rawValue:))
+  }
+
+  /// An opaque data blob to resume a failed download task.
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  public var downloadTaskResumeData: Data? {
+    return _nsUserInfo[NSURLSessionDownloadTaskResumeData] as? Data
+  }
+}
+
+extension URLError {
+  public static var unknown: URLError.Code {
+    return .unknown
+  }
+
+  public static var cancelled: URLError.Code {
+    return .cancelled
+  }
+
+  public static var badURL: URLError.Code {
+    return .badURL
+  }
+
+  public static var timedOut: URLError.Code {
+    return .timedOut
+  }
+
+  public static var unsupportedURL: URLError.Code {
+    return .unsupportedURL
+  }
+
+  public static var cannotFindHost: URLError.Code {
+    return .cannotFindHost
+  }
+
+  public static var cannotConnectToHost: URLError.Code {
+    return .cannotConnectToHost
+  }
+
+  public static var networkConnectionLost: URLError.Code {
+    return .networkConnectionLost
+  }
+
+  public static var dnsLookupFailed: URLError.Code {
+    return .dnsLookupFailed
+  }
+
+  public static var httpTooManyRedirects: URLError.Code {
+    return .httpTooManyRedirects
+  }
+
+  public static var resourceUnavailable: URLError.Code {
+    return .resourceUnavailable
+  }
+
+  public static var notConnectedToInternet: URLError.Code {
+    return .notConnectedToInternet
+  }
+
+  public static var redirectToNonExistentLocation: URLError.Code {
+    return .redirectToNonExistentLocation
+  }
+
+  public static var badServerResponse: URLError.Code {
+    return .badServerResponse
+  }
+
+  public static var userCancelledAuthentication: URLError.Code {
+    return .userCancelledAuthentication
+  }
+
+  public static var userAuthenticationRequired: URLError.Code {
+    return .userAuthenticationRequired
+  }
+
+  public static var zeroByteResource: URLError.Code {
+    return .zeroByteResource
+  }
+
+  public static var cannotDecodeRawData: URLError.Code {
+    return .cannotDecodeRawData
+  }
+
+  public static var cannotDecodeContentData: URLError.Code {
+    return .cannotDecodeContentData
+  }
+
+  public static var cannotParseResponse: URLError.Code {
+    return .cannotParseResponse
+  }
+
+  @available(macOS, introduced: 10.11) @available(iOS, introduced: 9.0)
+  public static var appTransportSecurityRequiresSecureConnection: URLError.Code {
+    return .appTransportSecurityRequiresSecureConnection
+  }
+
+  public static var fileDoesNotExist: URLError.Code {
+    return .fileDoesNotExist
+  }
+
+  public static var fileIsDirectory: URLError.Code {
+    return .fileIsDirectory
+  }
+
+  public static var noPermissionsToReadFile: URLError.Code {
+    return .noPermissionsToReadFile
+  }
+
+  @available(macOS, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var dataLengthExceedsMaximum: URLError.Code {
+    return .dataLengthExceedsMaximum
+  }
+
+  public static var secureConnectionFailed: URLError.Code {
+    return .secureConnectionFailed
+  }
+
+  public static var serverCertificateHasBadDate: URLError.Code {
+    return .serverCertificateHasBadDate
+  }
+
+  public static var serverCertificateUntrusted: URLError.Code {
+    return .serverCertificateUntrusted
+  }
+
+  public static var serverCertificateHasUnknownRoot: URLError.Code {
+    return .serverCertificateHasUnknownRoot
+  }
+
+  public static var serverCertificateNotYetValid: URLError.Code {
+    return .serverCertificateNotYetValid
+  }
+
+  public static var clientCertificateRejected: URLError.Code {
+    return .clientCertificateRejected
+  }
+
+  public static var clientCertificateRequired: URLError.Code {
+    return .clientCertificateRequired
+  }
+
+  public static var cannotLoadFromNetwork: URLError.Code {
+    return .cannotLoadFromNetwork
+  }
+
+  public static var cannotCreateFile: URLError.Code {
+    return .cannotCreateFile
+  }
+
+  public static var cannotOpenFile: URLError.Code {
+    return .cannotOpenFile
+  }
+
+  public static var cannotCloseFile: URLError.Code {
+    return .cannotCloseFile
+  }
+
+  public static var cannotWriteToFile: URLError.Code {
+    return .cannotWriteToFile
+  }
+
+  public static var cannotRemoveFile: URLError.Code {
+    return .cannotRemoveFile
+  }
+
+  public static var cannotMoveFile: URLError.Code {
+    return .cannotMoveFile
+  }
+
+  public static var downloadDecodingFailedMidStream: URLError.Code {
+    return .downloadDecodingFailedMidStream
+  }
+
+  public static var downloadDecodingFailedToComplete: URLError.Code {
+    return .downloadDecodingFailedToComplete
+  }
+
+  @available(macOS, introduced: 10.7) @available(iOS, introduced: 3.0)
+  public static var internationalRoamingOff: URLError.Code {
+    return .internationalRoamingOff
+  }
+
+  @available(macOS, introduced: 10.7) @available(iOS, introduced: 3.0)
+  public static var callIsActive: URLError.Code {
+    return .callIsActive
+  }
+
+  @available(macOS, introduced: 10.7) @available(iOS, introduced: 3.0)
+  public static var dataNotAllowed: URLError.Code {
+    return .dataNotAllowed
+  }
+
+  @available(macOS, introduced: 10.7) @available(iOS, introduced: 3.0)
+  public static var requestBodyStreamExhausted: URLError.Code {
+    return .requestBodyStreamExhausted
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var backgroundSessionRequiresSharedContainer: Code {
+    return .backgroundSessionRequiresSharedContainer
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var backgroundSessionInUseByAnotherProcess: Code {
+    return .backgroundSessionInUseByAnotherProcess
+  }
+
+  @available(macOS, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var backgroundSessionWasDisconnected: Code {
+    return .backgroundSessionWasDisconnected
+  }
+}
+
+extension URLError {
+  @available(*, unavailable, renamed: "unknown")
+  public static var Unknown: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "cancelled")
+  public static var Cancelled: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "badURL")
+  public static var BadURL: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "timedOut")
+  public static var TimedOut: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "unsupportedURL")
+  public static var UnsupportedURL: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "cannotFindHost")
+  public static var CannotFindHost: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "cannotConnectToHost")
+  public static var CannotConnectToHost: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "networkConnectionLost")
+  public static var NetworkConnectionLost: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "dnsLookupFailed")
+  public static var DNSLookupFailed: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "httpTooManyRedirects")
+  public static var HTTPTooManyRedirects: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "resourceUnavailable")
+  public static var ResourceUnavailable: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "notConnectedToInternet")
+  public static var NotConnectedToInternet: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "redirectToNonExistentLocation")
+  public static var RedirectToNonExistentLocation: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "badServerResponse")
+  public static var BadServerResponse: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "userCancelledAuthentication")
+  public static var UserCancelledAuthentication: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "userAuthenticationRequired")
+  public static var UserAuthenticationRequired: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "zeroByteResource")
+  public static var ZeroByteResource: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "cannotDecodeRawData")
+  public static var CannotDecodeRawData: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "cannotDecodeContentData")
+  public static var CannotDecodeContentData: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "cannotParseResponse")
+  public static var CannotParseResponse: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "appTransportSecurityRequiresSecureConnection")
+  public static var AppTransportSecurityRequiresSecureConnection: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileDoesNotExist")
+  public static var FileDoesNotExist: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "fileIsDirectory")
+  public static var FileIsDirectory: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "noPermissionsToReadFile")
+  public static var NoPermissionsToReadFile: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "dataLengthExceedsMaximum")
+  public static var DataLengthExceedsMaximum: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "secureConnectionFailed")
+  public static var SecureConnectionFailed: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "serverCertificateHasBadDate")
+  public static var ServerCertificateHasBadDate: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "serverCertificateUntrusted")
+  public static var ServerCertificateUntrusted: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "serverCertificateHasUnknownRoot")
+  public static var ServerCertificateHasUnknownRoot: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "serverCertificateNotYetValid")
+  public static var ServerCertificateNotYetValid: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "clientCertificateRejected")
+  public static var ClientCertificateRejected: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "clientCertificateRequired")
+  public static var ClientCertificateRequired: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "cannotLoadFromNetwork")
+  public static var CannotLoadFromNetwork: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "cannotCreateFile")
+  public static var CannotCreateFile: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "cannotOpenFile")
+  public static var CannotOpenFile: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "cannotCloseFile")
+  public static var CannotCloseFile: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "cannotWriteToFile")
+  public static var CannotWriteToFile: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "cannotRemoveFile")
+  public static var CannotRemoveFile: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "cannotMoveFile")
+  public static var CannotMoveFile: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "downloadDecodingFailedMidStream")
+  public static var DownloadDecodingFailedMidStream: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "downloadDecodingFailedToComplete")
+  public static var DownloadDecodingFailedToComplete: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "internationalRoamingOff")
+  public static var InternationalRoamingOff: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "callIsActive")
+  public static var CallIsActive: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "dataNotAllowed")
+  public static var DataNotAllowed: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "requestBodyStreamExhausted")
+  public static var RequestBodyStreamExhausted: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "backgroundSessionRequiresSharedContainer")
+  public static var BackgroundSessionRequiresSharedContainer: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "backgroundSessionInUseByAnotherProcess")
+  public static var BackgroundSessionInUseByAnotherProcess: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "backgroundSessionWasDisconnected")
+  public static var BackgroundSessionWasDisconnected: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+}
+
+/// Describes an error in the POSIX error domain.
+public struct POSIXError : _BridgedStoredNSError {
+  public let _nsError: NSError
+
+  public init(_nsError error: NSError) {
+    precondition(error.domain == NSPOSIXErrorDomain)
+    self._nsError = error
+  }
+
+  public static var errorDomain: String { return NSPOSIXErrorDomain }
+
+  public var hashValue: Int {
+    return _nsError.hashValue
+  }
+
+  public typealias Code = POSIXErrorCode
+}
+
+extension POSIXErrorCode : _ErrorCodeProtocol {
+  public typealias _ErrorType = POSIXError
+}
+
+extension POSIXError {
+  public static var EPERM: POSIXErrorCode {
+    return .EPERM
+  }
+
+  /// No such file or directory.
+  public static var ENOENT: POSIXErrorCode {
+    return .ENOENT
+  }
+
+  /// No such process.
+  public static var ESRCH: POSIXErrorCode {
+    return .ESRCH
+  }
+
+  /// Interrupted system call.
+  public static var EINTR: POSIXErrorCode {
+    return .EINTR
+  }
+
+  /// Input/output error.
+  public static var EIO: POSIXErrorCode {
+    return .EIO
+  }
+
+  /// Device not configured.
+  public static var ENXIO: POSIXErrorCode {
+    return .ENXIO
+  }
+
+  /// Argument list too long.
+  public static var E2BIG: POSIXErrorCode {
+    return .E2BIG
+  }
+
+  /// Exec format error.
+  public static var ENOEXEC: POSIXErrorCode {
+    return .ENOEXEC
+  }
+
+  /// Bad file descriptor.
+  public static var EBADF: POSIXErrorCode {
+    return .EBADF
+  }
+
+  /// No child processes.
+  public static var ECHILD: POSIXErrorCode {
+    return .ECHILD
+  }
+
+  /// Resource deadlock avoided.
+  public static var EDEADLK: POSIXErrorCode {
+    return .EDEADLK
+  }
+
+  /// Cannot allocate memory.
+  public static var ENOMEM: POSIXErrorCode {
+    return .ENOMEM
+  }
+
+  /// Permission denied.
+  public static var EACCES: POSIXErrorCode {
+    return .EACCES
+  }
+
+  /// Bad address.
+  public static var EFAULT: POSIXErrorCode {
+    return .EFAULT
+  }
+
+  /// Block device required.
+  public static var ENOTBLK: POSIXErrorCode {
+    return .ENOTBLK
+  }
+  /// Device / Resource busy.
+  public static var EBUSY: POSIXErrorCode {
+    return .EBUSY
+  }
+  /// File exists.
+  public static var EEXIST: POSIXErrorCode {
+    return .EEXIST
+  }
+  /// Cross-device link.
+  public static var EXDEV: POSIXErrorCode {
+    return .EXDEV
+  }
+  /// Operation not supported by device.
+  public static var ENODEV: POSIXErrorCode {
+    return .ENODEV
+  }
+  /// Not a directory.
+  public static var ENOTDIR: POSIXErrorCode {
+    return .ENOTDIR
+  }
+  /// Is a directory.
+  public static var EISDIR: POSIXErrorCode {
+    return .EISDIR
+  }
+  /// Invalid argument.
+  public static var EINVAL: POSIXErrorCode {
+    return .EINVAL
+  }
+  /// Too many open files in system.
+  public static var ENFILE: POSIXErrorCode {
+    return .ENFILE
+  }
+  /// Too many open files.
+  public static var EMFILE: POSIXErrorCode {
+    return .EMFILE
+  }
+  /// Inappropriate ioctl for device.
+  public static var ENOTTY: POSIXErrorCode {
+    return .ENOTTY
+  }
+  /// Text file busy.
+  public static var ETXTBSY: POSIXErrorCode {
+    return .ETXTBSY
+  }
+  /// File too large.
+  public static var EFBIG: POSIXErrorCode {
+    return .EFBIG
+  }
+  /// No space left on device.
+  public static var ENOSPC: POSIXErrorCode {
+    return .ENOSPC
+  }
+  /// Illegal seek.
+  public static var ESPIPE: POSIXErrorCode {
+    return .ESPIPE
+  }
+  /// Read-only file system.
+  public static var EROFS: POSIXErrorCode {
+    return .EROFS
+  }
+  /// Too many links.
+  public static var EMLINK: POSIXErrorCode {
+    return .EMLINK
+  }
+  /// Broken pipe.
+  public static var EPIPE: POSIXErrorCode {
+    return .EPIPE
+  }
+
+/// math software.
+  /// Numerical argument out of domain.
+  public static var EDOM: POSIXErrorCode {
+    return .EDOM
+  }
+  /// Result too large.
+  public static var ERANGE: POSIXErrorCode {
+    return .ERANGE
+  }
+
+/// non-blocking and interrupt i/o.
+  /// Resource temporarily unavailable.
+  public static var EAGAIN: POSIXErrorCode {
+    return .EAGAIN
+  }
+  /// Operation would block.
+  public static var EWOULDBLOCK: POSIXErrorCode {
+    return .EWOULDBLOCK
+  }
+  /// Operation now in progress.
+  public static var EINPROGRESS: POSIXErrorCode {
+    return .EINPROGRESS
+  }
+  /// Operation already in progress.
+  public static var EALREADY: POSIXErrorCode {
+    return .EALREADY
+  }
+
+/// ipc/network software -- argument errors.
+  /// Socket operation on non-socket.
+  public static var ENOTSOCK: POSIXErrorCode {
+    return .ENOTSOCK
+  }
+  /// Destination address required.
+  public static var EDESTADDRREQ: POSIXErrorCode {
+    return .EDESTADDRREQ
+  }
+  /// Message too long.
+  public static var EMSGSIZE: POSIXErrorCode {
+    return .EMSGSIZE
+  }
+  /// Protocol wrong type for socket.
+  public static var EPROTOTYPE: POSIXErrorCode {
+    return .EPROTOTYPE
+  }
+  /// Protocol not available.
+  public static var ENOPROTOOPT: POSIXErrorCode {
+    return .ENOPROTOOPT
+  }
+  /// Protocol not supported.
+  public static var EPROTONOSUPPORT: POSIXErrorCode {
+    return .EPROTONOSUPPORT
+  }
+  /// Socket type not supported.
+  public static var ESOCKTNOSUPPORT: POSIXErrorCode {
+    return .ESOCKTNOSUPPORT
+  }
+  /// Operation not supported.
+  public static var ENOTSUP: POSIXErrorCode {
+    return .ENOTSUP
+  }
+  /// Protocol family not supported.
+  public static var EPFNOSUPPORT: POSIXErrorCode {
+    return .EPFNOSUPPORT
+  }
+  /// Address family not supported by protocol family.
+  public static var EAFNOSUPPORT: POSIXErrorCode {
+    return .EAFNOSUPPORT
+  }
+
+  /// Address already in use.
+  public static var EADDRINUSE: POSIXErrorCode {
+    return .EADDRINUSE
+  }
+  /// Can't assign requested address.
+  public static var EADDRNOTAVAIL: POSIXErrorCode {
+    return .EADDRNOTAVAIL
+  }
+
+/// ipc/network software -- operational errors
+  /// Network is down.
+  public static var ENETDOWN: POSIXErrorCode {
+    return .ENETDOWN
+  }
+  /// Network is unreachable.
+  public static var ENETUNREACH: POSIXErrorCode {
+    return .ENETUNREACH
+  }
+  /// Network dropped connection on reset.
+  public static var ENETRESET: POSIXErrorCode {
+    return .ENETRESET
+  }
+  /// Software caused connection abort.
+  public static var ECONNABORTED: POSIXErrorCode {
+    return .ECONNABORTED
+  }
+  /// Connection reset by peer.
+  public static var ECONNRESET: POSIXErrorCode {
+    return .ECONNRESET
+  }
+  /// No buffer space available.
+  public static var ENOBUFS: POSIXErrorCode {
+    return .ENOBUFS
+  }
+  /// Socket is already connected.
+  public static var EISCONN: POSIXErrorCode {
+    return .EISCONN
+  }
+  /// Socket is not connected.
+  public static var ENOTCONN: POSIXErrorCode {
+    return .ENOTCONN
+  }
+  /// Can't send after socket shutdown.
+  public static var ESHUTDOWN: POSIXErrorCode {
+    return .ESHUTDOWN
+  }
+  /// Too many references: can't splice.
+  public static var ETOOMANYREFS: POSIXErrorCode {
+    return .ETOOMANYREFS
+  }
+  /// Operation timed out.
+  public static var ETIMEDOUT: POSIXErrorCode {
+    return .ETIMEDOUT
+  }
+  /// Connection refused.
+  public static var ECONNREFUSED: POSIXErrorCode {
+    return .ECONNREFUSED
+  }
+
+  /// Too many levels of symbolic links.
+  public static var ELOOP: POSIXErrorCode {
+    return .ELOOP
+  }
+  /// File name too long.
+  public static var ENAMETOOLONG: POSIXErrorCode {
+    return .ENAMETOOLONG
+  }
+
+  /// Host is down.
+  public static var EHOSTDOWN: POSIXErrorCode {
+    return .EHOSTDOWN
+  }
+  /// No route to host.
+  public static var EHOSTUNREACH: POSIXErrorCode {
+    return .EHOSTUNREACH
+  }
+  /// Directory not empty.
+  public static var ENOTEMPTY: POSIXErrorCode {
+    return .ENOTEMPTY
+  }
+
+/// quotas & mush.
+  /// Too many processes.
+  public static var EPROCLIM: POSIXErrorCode {
+    return .EPROCLIM
+  }
+  /// Too many users.
+  public static var EUSERS: POSIXErrorCode {
+    return .EUSERS
+  }
+  /// Disc quota exceeded.
+  public static var EDQUOT: POSIXErrorCode {
+    return .EDQUOT
+  }
+
+/// Network File System.
+  /// Stale NFS file handle.
+  public static var ESTALE: POSIXErrorCode {
+    return .ESTALE
+  }
+  /// Too many levels of remote in path.
+  public static var EREMOTE: POSIXErrorCode {
+    return .EREMOTE
+  }
+  /// RPC struct is bad.
+  public static var EBADRPC: POSIXErrorCode {
+    return .EBADRPC
+  }
+  /// RPC version wrong.
+  public static var ERPCMISMATCH: POSIXErrorCode {
+    return .ERPCMISMATCH
+  }
+  /// RPC prog. not avail.
+  public static var EPROGUNAVAIL: POSIXErrorCode {
+    return .EPROGUNAVAIL
+  }
+  /// Program version wrong.
+  public static var EPROGMISMATCH: POSIXErrorCode {
+    return .EPROGMISMATCH
+  }
+  /// Bad procedure for program.
+  public static var EPROCUNAVAIL: POSIXErrorCode {
+    return .EPROCUNAVAIL
+  }
+
+  /// No locks available.
+  public static var ENOLCK: POSIXErrorCode {
+    return .ENOLCK
+  }
+  /// Function not implemented.
+  public static var ENOSYS: POSIXErrorCode {
+    return .ENOSYS
+  }
+
+  /// Inappropriate file type or format.
+  public static var EFTYPE: POSIXErrorCode {
+    return .EFTYPE
+  }
+  /// Authentication error.
+  public static var EAUTH: POSIXErrorCode {
+    return .EAUTH
+  }
+  /// Need authenticator.
+  public static var ENEEDAUTH: POSIXErrorCode {
+    return .ENEEDAUTH
+  }
+
+/// Intelligent device errors.
+  /// Device power is off.
+  public static var EPWROFF: POSIXErrorCode {
+    return .EPWROFF
+  }
+  /// Device error, e.g. paper out.
+  public static var EDEVERR: POSIXErrorCode {
+    return .EDEVERR
+  }
+
+  /// Value too large to be stored in data type.
+  public static var EOVERFLOW: POSIXErrorCode {
+    return .EOVERFLOW
+  }
+
+/// Program loading errors.
+  /// Bad executable.
+  public static var EBADEXEC: POSIXErrorCode {
+    return .EBADEXEC
+  }
+  /// Bad CPU type in executable.
+  public static var EBADARCH: POSIXErrorCode {
+    return .EBADARCH
+  }
+  /// Shared library version mismatch.
+  public static var ESHLIBVERS: POSIXErrorCode {
+    return .ESHLIBVERS
+  }
+  /// Malformed Macho file.
+  public static var EBADMACHO: POSIXErrorCode {
+    return .EBADMACHO
+  }
+
+  /// Operation canceled.
+  public static var ECANCELED: POSIXErrorCode {
+    return .ECANCELED
+  }
+
+  /// Identifier removed.
+  public static var EIDRM: POSIXErrorCode {
+    return .EIDRM
+  }
+  /// No message of desired type.
+  public static var ENOMSG: POSIXErrorCode {
+    return .ENOMSG
+  }
+  /// Illegal byte sequence.
+  public static var EILSEQ: POSIXErrorCode {
+    return .EILSEQ
+  }
+  /// Attribute not found.
+  public static var ENOATTR: POSIXErrorCode {
+    return .ENOATTR
+  }
+
+  /// Bad message.
+  public static var EBADMSG: POSIXErrorCode {
+    return .EBADMSG
+  }
+  /// Reserved.
+  public static var EMULTIHOP: POSIXErrorCode {
+    return .EMULTIHOP
+  }
+  /// No message available on STREAM.
+  public static var ENODATA: POSIXErrorCode {
+    return .ENODATA
+  }
+  /// Reserved.
+  public static var ENOLINK: POSIXErrorCode {
+    return .ENOLINK
+  }
+  /// No STREAM resources.
+  public static var ENOSR: POSIXErrorCode {
+    return .ENOSR
+  }
+  /// Not a STREAM.
+  public static var ENOSTR: POSIXErrorCode {
+    return .ENOSTR
+  }
+  /// Protocol error.
+  public static var EPROTO: POSIXErrorCode {
+    return .EPROTO
+  }
+  /// STREAM ioctl timeout.
+  public static var ETIME: POSIXErrorCode {
+    return .ETIME
+  }
+
+  /// No such policy registered.
+  public static var ENOPOLICY: POSIXErrorCode {
+    return .ENOPOLICY
+  }
+
+  /// State not recoverable.
+  public static var ENOTRECOVERABLE: POSIXErrorCode {
+    return .ENOTRECOVERABLE
+  }
+  /// Previous owner died.
+  public static var EOWNERDEAD: POSIXErrorCode {
+    return .EOWNERDEAD
+  }
+
+  /// Interface output queue is full.
+  public static var EQFULL: POSIXErrorCode {
+    return .EQFULL
+  }
+}
+
+/// Describes an error in the Mach error domain.
+public struct MachError : _BridgedStoredNSError {
+  public let _nsError: NSError
+
+  public init(_nsError error: NSError) {
+    precondition(error.domain == NSMachErrorDomain)
+    self._nsError = error
+  }
+
+  public static var errorDomain: String { return NSMachErrorDomain }
+
+  public var hashValue: Int {
+    return _nsError.hashValue
+  }
+
+  public typealias Code = MachErrorCode
+}
+
+extension MachErrorCode : _ErrorCodeProtocol {
+  public typealias _ErrorType = MachError
+}
+
+extension MachError {
+  public static var success: MachError.Code {
+    return .success
+  }
+
+  /// Specified address is not currently valid.
+  public static var invalidAddress: MachError.Code {
+    return .invalidAddress
+  }
+
+  /// Specified memory is valid, but does not permit the required
+  /// forms of access.
+  public static var protectionFailure: MachError.Code {
+    return .protectionFailure
+  }
+
+  /// The address range specified is already in use, or no address
+  /// range of the size specified could be found.  
+  public static var noSpace: MachError.Code {
+    return .noSpace
+  }
+
+  /// The function requested was not applicable to this type of
+  /// argument, or an argument is invalid.
+  public static var invalidArgument: MachError.Code {
+    return .invalidArgument
+  }
+
+  /// The function could not be performed.  A catch-all.
+  public static var failure: MachError.Code {
+    return .failure
+  }
+
+  /// A system resource could not be allocated to fulfill this
+  /// request.  This failure may not be permanent.
+  public static var resourceShortage: MachError.Code {
+    return .resourceShortage
+  }
+
+  /// The task in question does not hold receive rights for the port
+  /// argument.
+  public static var notReceiver: MachError.Code {
+    return .notReceiver
+  }
+
+  /// Bogus access restriction.
+  public static var noAccess: MachError.Code {
+    return .noAccess
+  }
+
+  /// During a page fault, the target address refers to a memory
+  /// object that has been destroyed.  This failure is permanent.
+  public static var memoryFailure: MachError.Code {
+    return .memoryFailure
+  }
+
+  /// During a page fault, the memory object indicated that the data
+  /// could not be returned.  This failure may be temporary; future
+  /// attempts to access this same data may succeed, as defined by the
+  /// memory object.
+  public static var memoryError: MachError.Code {
+    return .memoryError
+  }
+
+  /// The receive right is already a member of the portset.
+  public static var alreadyInSet: MachError.Code {
+    return .alreadyInSet
+  }
+
+  /// The receive right is not a member of a port set.
+  public static var notInSet: MachError.Code {
+    return .notInSet
+  }
+
+  /// The name already denotes a right in the task.
+  public static var nameExists: MachError.Code {
+    return .nameExists
+  }
+
+  /// The operation was aborted.  Ipc code will catch this and reflect
+  /// it as a message error.
+  public static var aborted: MachError.Code {
+    return .aborted
+  }
+
+  /// The name doesn't denote a right in the task.
+  public static var invalidName: MachError.Code {
+    return .invalidName
+  }
+
+  /// Target task isn't an active task.
+  public static var invalidTask: MachError.Code {
+    return .invalidTask
+  }
+
+  /// The name denotes a right, but not an appropriate right.
+  public static var invalidRight: MachError.Code {
+    return .invalidRight
+  }
+
+  /// A blatant range error.
+  public static var invalidValue: MachError.Code {
+    return .invalidValue
+  }
+
+  /// Operation would overflow limit on user-references.
+  public static var userReferencesOverflow: MachError.Code {
+    return .userReferencesOverflow
+  }
+
+  /// The supplied (port) capability is improper.
+  public static var invalidCapability: MachError.Code {
+    return .invalidCapability
+  }
+
+  /// The task already has send or receive rights for the port under
+  /// another name.
+  public static var rightExists: MachError.Code {
+    return .rightExists
+  }
+
+  /// Target host isn't actually a host.
+  public static var invalidHost: MachError.Code {
+    return .invalidHost
+  }
+
+  /// An attempt was made to supply "precious" data for memory that is
+  /// already present in a memory object.
+  public static var memoryPresent: MachError.Code {
+    return .memoryPresent
+  }
+
+  /// A page was requested of a memory manager via
+  /// memory_object_data_request for an object using a
+  /// MEMORY_OBJECT_COPY_CALL strategy, with the VM_PROT_WANTS_COPY
+  /// flag being used to specify that the page desired is for a copy
+  /// of the object, and the memory manager has detected the page was
+  /// pushed into a copy of the object while the kernel was walking
+  /// the shadow chain from the copy to the object. This error code is
+  /// delivered via memory_object_data_error and is handled by the
+  /// kernel (it forces the kernel to restart the fault). It will not
+  /// be seen by users.
+  public static var memoryDataMoved: MachError.Code {
+    return .memoryDataMoved
+  }
+
+  /// A strategic copy was attempted of an object upon which a quicker
+  /// copy is now possible.  The caller should retry the copy using
+  /// vm_object_copy_quickly. This error code is seen only by the
+  /// kernel.
+  public static var memoryRestartCopy: MachError.Code {
+    return .memoryRestartCopy
+  }
+
+  /// An argument applied to assert processor set privilege was not a
+  /// processor set control port.
+  public static var invalidProcessorSet: MachError.Code {
+    return .invalidProcessorSet
+  }
+
+  /// The specified scheduling attributes exceed the thread's limits.
+  public static var policyLimit: MachError.Code {
+    return .policyLimit
+  }
+
+  /// The specified scheduling policy is not currently enabled for the
+  /// processor set.
+  public static var invalidPolicy: MachError.Code {
+    return .invalidPolicy
+  }
+
+  /// The external memory manager failed to initialize the memory object.
+  public static var invalidObject: MachError.Code {
+    return .invalidObject
+  }
+
+  /// A thread is attempting to wait for an event for which there is
+  /// already a waiting thread.
+  public static var alreadyWaiting: MachError.Code {
+    return .alreadyWaiting
+  }
+
+  /// An attempt was made to destroy the default processor set.
+  public static var defaultSet: MachError.Code {
+    return .defaultSet
+  }
+
+  /// An attempt was made to fetch an exception port that is
+  /// protected, or to abort a thread while processing a protected
+  /// exception.
+  public static var exceptionProtected: MachError.Code {
+    return .exceptionProtected
+  }
+
+  /// A ledger was required but not supplied.
+  public static var invalidLedger: MachError.Code {
+    return .invalidLedger
+  }
+
+  /// The port was not a memory cache control port.
+  public static var invalidMemoryControl: MachError.Code {
+    return .invalidMemoryControl
+  }
+
+  /// An argument supplied to assert security privilege was not a host
+  /// security port.
+  public static var invalidSecurity: MachError.Code {
+    return .invalidSecurity
+  }
+
+  /// thread_depress_abort was called on a thread which was not
+  /// currently depressed.
+  public static var notDepressed: MachError.Code {
+    return .notDepressed
+  }
+
+  /// Object has been terminated and is no longer available.
+  public static var terminated: MachError.Code {
+    return .terminated
+  }
+
+  /// Lock set has been destroyed and is no longer available.
+  public static var lockSetDestroyed: MachError.Code {
+    return .lockSetDestroyed
+  }
+
+  /// The thread holding the lock terminated before releasing the lock.
+  public static var lockUnstable: MachError.Code {
+    return .lockUnstable
+  }
+
+  /// The lock is already owned by another thread.
+  public static var lockOwned: MachError.Code {
+    return .lockOwned
+  }
+
+  /// The lock is already owned by the calling thread.
+  public static var lockOwnedSelf: MachError.Code {
+    return .lockOwnedSelf
+  }
+
+  /// Semaphore has been destroyed and is no longer available.
+  public static var semaphoreDestroyed: MachError.Code {
+    return .semaphoreDestroyed
+  }
+
+  /// Return from RPC indicating the target server was terminated
+  /// before it successfully replied.
+  public static var rpcServerTerminated: MachError.Code {
+    return .rpcServerTerminated
+  }
+
+  /// Terminate an orphaned activation.
+  public static var rpcTerminateOrphan: MachError.Code {
+    return .rpcTerminateOrphan
+  }
+
+  /// Allow an orphaned activation to continue executing.
+  public static var rpcContinueOrphan: MachError.Code {
+    return .rpcContinueOrphan
+  }
+
+  /// Empty thread activation (No thread linked to it).
+  public static var notSupported: MachError.Code {
+    return .notSupported
+  }
+
+  /// Remote node down or inaccessible.
+  public static var nodeDown: MachError.Code {
+    return .nodeDown
+  }
+
+  /// A signalled thread was not actually waiting.
+  public static var notWaiting: MachError.Code {
+    return .notWaiting
+  }
+
+  /// Some thread-oriented operation (semaphore_wait) timed out.
+  public static var operationTimedOut: MachError.Code {
+    return .operationTimedOut
+  }
+
+  /// During a page fault, indicates that the page was rejected as a
+  /// result of a signature check.
+  public static var codesignError: MachError.Code {
+    return .codesignError
+  }
+
+  /// The requested property cannot be changed at this time.
+  public static var policyStatic: MachError.Code {
+    return .policyStatic
+  }
+}
+
+public struct ErrorUserInfoKey : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable, _ObjectiveCBridgeable {
+  public typealias _ObjectiveCType = NSString
+  public init(rawValue: String) { self.rawValue = rawValue }
+  public var rawValue: String
+}
+
+public extension ErrorUserInfoKey {
+  @available(*, deprecated, renamed: "NSUnderlyingErrorKey")
+  static let underlyingErrorKey = ErrorUserInfoKey(rawValue: NSUnderlyingErrorKey)
+
+  @available(*, deprecated, renamed: "NSLocalizedDescriptionKey")
+  static let localizedDescriptionKey = ErrorUserInfoKey(rawValue: NSLocalizedDescriptionKey)
+
+  @available(*, deprecated, renamed: "NSLocalizedFailureReasonErrorKey")
+  static let localizedFailureReasonErrorKey = ErrorUserInfoKey(rawValue: NSLocalizedFailureReasonErrorKey)
+
+  @available(*, deprecated, renamed: "NSLocalizedRecoverySuggestionErrorKey")
+  static let localizedRecoverySuggestionErrorKey = ErrorUserInfoKey(rawValue: NSLocalizedRecoverySuggestionErrorKey)
+
+  @available(*, deprecated, renamed: "NSLocalizedRecoveryOptionsErrorKey")
+  static let localizedRecoveryOptionsErrorKey = ErrorUserInfoKey(rawValue: NSLocalizedRecoveryOptionsErrorKey)
+
+  @available(*, deprecated, renamed: "NSRecoveryAttempterErrorKey")
+  static let recoveryAttempterErrorKey = ErrorUserInfoKey(rawValue: NSRecoveryAttempterErrorKey)
+
+  @available(*, deprecated, renamed: "NSHelpAnchorErrorKey")
+  static let helpAnchorErrorKey = ErrorUserInfoKey(rawValue: NSHelpAnchorErrorKey)
+
+  @available(*, deprecated, renamed: "NSStringEncodingErrorKey")
+  static let stringEncodingErrorKey = ErrorUserInfoKey(rawValue: NSStringEncodingErrorKey)
+
+  @available(*, deprecated, renamed: "NSURLErrorKey")
+  static let NSURLErrorKey = ErrorUserInfoKey(rawValue: Foundation.NSURLErrorKey)
+
+  @available(*, deprecated, renamed: "NSFilePathErrorKey")
+  static let filePathErrorKey = ErrorUserInfoKey(rawValue: NSFilePathErrorKey)
+}

--- a/Darwin/Foundation-swiftoverlay/NSExpression.swift
+++ b/Darwin/Foundation-swiftoverlay/NSExpression.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+extension NSExpression {
+  // + (NSExpression *) expressionWithFormat:(NSString *)expressionFormat, ...;
+  public
+  convenience init(format expressionFormat: __shared String, _ args: CVarArg...) {
+    let va_args = getVaList(args)
+    self.init(format: expressionFormat, arguments: va_args)
+  }
+}
+
+extension NSExpression {
+    public convenience init<Root, Value>(forKeyPath keyPath: KeyPath<Root, Value>) {
+        self.init(forKeyPath: _bridgeKeyPathToString(keyPath))
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/NSFastEnumeration.swift
+++ b/Darwin/Foundation-swiftoverlay/NSFastEnumeration.swift
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+/// A dummy value to be used as the target for `mutationsPtr` in fast enumeration implementations.
+private var _fastEnumerationMutationsTarget: CUnsignedLong = 0
+/// A dummy pointer to be used as `mutationsPtr` in fast enumeration implementations.
+private let _fastEnumerationMutationsPtr = UnsafeMutablePointer<CUnsignedLong>(&_fastEnumerationMutationsTarget)
+
+//===----------------------------------------------------------------------===//
+// Fast enumeration
+//===----------------------------------------------------------------------===//
+public struct NSFastEnumerationIterator : IteratorProtocol {
+    var enumerable: NSFastEnumeration
+    var objects: (Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?) = (nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+    var state = NSFastEnumerationState(state: 0, itemsPtr: nil, mutationsPtr: _fastEnumerationMutationsPtr, extra: (0, 0, 0, 0, 0))
+    var index = 0
+    var count = 0
+    var useObjectsBuffer = false
+    
+    public init(_ enumerable: NSFastEnumeration) {
+        self.enumerable = enumerable
+    }
+    
+    public mutating func next() -> Any? {
+        if index + 1 > count {
+            index = 0
+            // ensure NO ivars of self are actually captured
+            let enumeratedObject = enumerable
+            var localState = state
+            var localObjects = objects
+            
+            (count, useObjectsBuffer) = withUnsafeMutablePointer(to: &localObjects) {
+                let buffer = AutoreleasingUnsafeMutablePointer<AnyObject?>($0)
+                return withUnsafeMutablePointer(to: &localState) { (statePtr: UnsafeMutablePointer<NSFastEnumerationState>) -> (Int, Bool) in
+                    let result = enumeratedObject.countByEnumerating(with: statePtr, objects: buffer, count: 16)
+                    if statePtr.pointee.itemsPtr == buffer {
+                        // Most cocoa classes will emit their own inner pointer buffers instead of traversing this path. Notable exceptions include NSDictionary and NSSet
+                        return (result, true)
+                    } else {
+                        // this is the common case for things like NSArray
+                        return (result, false)
+                    }
+                }
+            }
+            
+            state = localState // restore the state value
+            objects = localObjects // copy the object pointers back to the self storage
+            
+            if count == 0 { return nil }
+        }
+        defer { index += 1 }
+        if !useObjectsBuffer {
+            return state.itemsPtr![index]
+        } else {
+            switch index {
+            case 0: return objects.0!.takeUnretainedValue()
+            case 1: return objects.1!.takeUnretainedValue()
+            case 2: return objects.2!.takeUnretainedValue()
+            case 3: return objects.3!.takeUnretainedValue()
+            case 4: return objects.4!.takeUnretainedValue()
+            case 5: return objects.5!.takeUnretainedValue()
+            case 6: return objects.6!.takeUnretainedValue()
+            case 7: return objects.7!.takeUnretainedValue()
+            case 8: return objects.8!.takeUnretainedValue()
+            case 9: return objects.9!.takeUnretainedValue()
+            case 10: return objects.10!.takeUnretainedValue()
+            case 11: return objects.11!.takeUnretainedValue()
+            case 12: return objects.12!.takeUnretainedValue()
+            case 13: return objects.13!.takeUnretainedValue()
+            case 14: return objects.14!.takeUnretainedValue()
+            case 15: return objects.15!.takeUnretainedValue()
+            default: fatalError("Access beyond storage buffer")
+            }
+        }
+    }
+}
+
+extension NSEnumerator : Sequence {
+    /// Return an *iterator* over the *enumerator*.
+    ///
+    /// - Complexity: O(1).
+    public func makeIterator() -> NSFastEnumerationIterator {
+        return NSFastEnumerationIterator(self)
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/NSGeometry.swift
+++ b/Darwin/Foundation-swiftoverlay/NSGeometry.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+import CoreGraphics
+
+
+#if os(macOS)
+
+//===----------------------------------------------------------------------===//
+// NSRectEdge
+//===----------------------------------------------------------------------===//
+
+extension NSRectEdge {
+  @inlinable
+  public init(rectEdge: CGRectEdge) {
+    self = NSRectEdge(rawValue: UInt(rectEdge.rawValue))!
+  }
+}
+
+extension CGRectEdge {
+  @inlinable
+  public init(rectEdge: NSRectEdge) {
+    self = CGRectEdge(rawValue: UInt32(rectEdge.rawValue))!
+  }
+}
+
+#endif

--- a/Darwin/Foundation-swiftoverlay/NSIndexSet.swift
+++ b/Darwin/Foundation-swiftoverlay/NSIndexSet.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+// TODO: Evaluate deprecating with a message in favor of IndexSet.
+public struct NSIndexSetIterator : IteratorProtocol {
+  public typealias Element = Int
+
+  internal let _set: NSIndexSet
+  internal var _first: Bool = true
+  internal var _current: Int?
+
+  internal init(set: NSIndexSet) {
+    self._set = set
+    self._current = nil
+  }
+
+  public mutating func next() -> Int? {
+    if _first {
+      _current = _set.firstIndex
+      _first = false
+    } else if let c = _current {
+      _current = _set.indexGreaterThanIndex(c)
+    } else {
+      // current is already nil
+    }
+    if _current == NSNotFound {
+      _current = nil
+    }
+    return _current
+  }
+}
+
+extension NSIndexSet : Sequence {
+  /// Return an *iterator* over the elements of this *sequence*.
+  ///
+  /// - Complexity: O(1).
+  public func makeIterator() -> NSIndexSetIterator {
+    return NSIndexSetIterator(set: self)
+  }
+}

--- a/Darwin/Foundation-swiftoverlay/NSItemProvider.swift
+++ b/Darwin/Foundation-swiftoverlay/NSItemProvider.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+@available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
+extension NSItemProvider  {
+
+  @available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
+  public func registerObject<
+    T : _ObjectiveCBridgeable
+  > (
+    ofClass: T.Type,
+    visibility: NSItemProviderRepresentationVisibility,
+    loadHandler: @escaping ((T?, Error?) -> Void) -> Progress?
+  ) where T._ObjectiveCType : NSItemProviderWriting {
+    self.registerObject(
+      ofClass: T._ObjectiveCType.self, visibility: visibility) {
+      completionHandler in loadHandler {
+        // Using `x as! T._ObjectiveCType?` triggers an assertion in the
+        // compiler, hence the explicit call to `_bridgeToObjectiveC`.
+        (x, error) in completionHandler(x?._bridgeToObjectiveC(), error)
+      }
+    }
+  }
+
+  @available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
+  public func canLoadObject<
+    T : _ObjectiveCBridgeable
+  >(ofClass: T.Type) -> Bool
+  where T._ObjectiveCType : NSItemProviderReading {
+    return self.canLoadObject(ofClass: T._ObjectiveCType.self)
+  }
+
+  @available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
+  public func loadObject<
+    T : _ObjectiveCBridgeable
+  >(
+    ofClass: T.Type,
+    completionHandler: @escaping (T?, Error?) -> Void
+  ) -> Progress where T._ObjectiveCType : NSItemProviderReading {
+    return self.loadObject(ofClass: T._ObjectiveCType.self) {
+      x, error in completionHandler(x as! T?, error)
+    }
+  }
+
+}

--- a/Darwin/Foundation-swiftoverlay/NSNumber.swift
+++ b/Darwin/Foundation-swiftoverlay/NSNumber.swift
@@ -1,0 +1,700 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+import CoreGraphics
+
+extension Int8 : _ObjectiveCBridgeable {
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
+    public init(_ number: __shared NSNumber) {
+        self = number.int8Value
+    }
+
+    public init(truncating number: __shared NSNumber) {
+        self = number.int8Value
+    }
+
+    public init?(exactly number: __shared NSNumber) {
+        let value = number.int8Value
+        guard NSNumber(value: value) == number else { return nil }
+        self = value
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(value: self)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout Int8?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Int8?) -> Bool {
+        guard let value = Int8(exactly: x) else { return false }
+        result = value
+        return true
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> Int8 {
+        var result: Int8?
+        guard let src = source else { return Int8(0) }
+        guard _conditionallyBridgeFromObjectiveC(src, result: &result) else { return Int8(0) }
+        return result!
+    }
+}
+
+extension UInt8 : _ObjectiveCBridgeable {
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
+    public init(_ number: __shared NSNumber) {
+        self = number.uint8Value
+    }
+
+    public init(truncating number: __shared NSNumber) {
+        self = number.uint8Value
+    }
+
+    public init?(exactly number: __shared NSNumber) {
+        let value = number.uint8Value
+        guard NSNumber(value: value) == number else { return nil }
+        self = value
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(value: self)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt8?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt8?) -> Bool {
+        guard let value = UInt8(exactly: x) else { return false }
+        result = value
+        return true
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> UInt8 {
+        var result: UInt8?
+        guard let src = source else { return UInt8(0) }
+        guard _conditionallyBridgeFromObjectiveC(src, result: &result) else { return UInt8(0) }
+        return result!
+    }
+}
+
+extension Int16 : _ObjectiveCBridgeable {
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
+    public init(_ number: __shared NSNumber) {
+        self = number.int16Value
+    }
+
+    public init(truncating number: __shared NSNumber) {
+        self = number.int16Value
+    }
+
+    public init?(exactly number: __shared NSNumber) {
+        let value = number.int16Value
+        guard NSNumber(value: value) == number else { return nil }
+        self = value
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(value: self)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout Int16?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Int16?) -> Bool {
+        guard let value = Int16(exactly: x) else { return false }
+        result = value
+        return true
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> Int16 {
+        var result: Int16?
+        guard let src = source else { return Int16(0) }
+        guard _conditionallyBridgeFromObjectiveC(src, result: &result) else { return Int16(0) }
+        return result!
+    }
+}
+
+extension UInt16 : _ObjectiveCBridgeable {
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
+    public init(_ number: __shared NSNumber) {
+        self = number.uint16Value
+    }
+
+    public init(truncating number: __shared NSNumber) {
+        self = number.uint16Value
+    }
+
+    public init?(exactly number: __shared NSNumber) {
+        let value = number.uint16Value
+        guard NSNumber(value: value) == number else { return nil }
+        self = value
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(value: self)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt16?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt16?) -> Bool {
+        guard let value = UInt16(exactly: x) else { return false }
+        result = value
+        return true
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> UInt16 {
+        var result: UInt16?
+        guard let src = source else { return UInt16(0) }
+        guard _conditionallyBridgeFromObjectiveC(src, result: &result) else { return UInt16(0) }
+        return result!
+    }
+}
+
+extension Int32 : _ObjectiveCBridgeable {
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
+    public init(_ number: __shared NSNumber) {
+        self = number.int32Value
+    }
+
+    public init(truncating number: __shared NSNumber) {
+        self = number.int32Value
+    }
+
+    public init?(exactly number: __shared NSNumber) {
+        let value = number.int32Value
+        guard NSNumber(value: value) == number else { return nil }
+        self = value
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(value: self)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout Int32?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Int32?) -> Bool {
+        guard let value = Int32(exactly: x) else { return false }
+        result = value
+        return true
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> Int32 {
+        var result: Int32?
+        guard let src = source else { return Int32(0) }
+        guard _conditionallyBridgeFromObjectiveC(src, result: &result) else { return Int32(0) }
+        return result!
+    }
+}
+
+extension UInt32 : _ObjectiveCBridgeable {
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
+    public init(_ number: __shared NSNumber) {
+        self = number.uint32Value
+    }
+
+    public init(truncating number: __shared NSNumber) {
+        self = number.uint32Value
+    }
+
+    public init?(exactly number: __shared NSNumber) {
+        let value = number.uint32Value
+        guard NSNumber(value: value) == number else { return nil }
+        self = value
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(value: self)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt32?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt32?) -> Bool {
+        guard let value = UInt32(exactly: x) else { return false }
+        result = value
+        return true
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> UInt32 {
+        var result: UInt32?
+        guard let src = source else { return UInt32(0) }
+        guard _conditionallyBridgeFromObjectiveC(src, result: &result) else { return UInt32(0) }
+        return result!
+    }
+}
+
+extension Int64 : _ObjectiveCBridgeable {
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
+    public init(_ number: __shared NSNumber) {
+        self = number.int64Value
+    }
+
+    public init(truncating number: __shared NSNumber) {
+        self = number.int64Value
+    }
+
+    public init?(exactly number: __shared NSNumber) {
+        let value = number.int64Value
+        guard NSNumber(value: value) == number else { return nil }
+        self = value
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(value: self)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout Int64?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Int64?) -> Bool {
+        guard let value = Int64(exactly: x) else { return false }
+        result = value
+        return true
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> Int64 {
+        var result: Int64?
+        guard let src = source else { return Int64(0) }
+        guard _conditionallyBridgeFromObjectiveC(src, result: &result) else { return Int64(0) }
+        return result!
+    }
+}
+
+extension UInt64 : _ObjectiveCBridgeable {
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
+    public init(_ number: __shared NSNumber) {
+        self = number.uint64Value
+    }
+
+    public init(truncating number: __shared NSNumber) {
+        self = number.uint64Value
+    }
+
+    public init?(exactly number: __shared NSNumber) {
+        let value = number.uint64Value
+        guard NSNumber(value: value) == number else { return nil }
+        self = value
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(value: self)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt64?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt64?) -> Bool {
+        guard let value = UInt64(exactly: x) else { return false }
+        result = value
+        return true
+    }
+
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> UInt64 {
+        var result: UInt64?
+        guard let src = source else { return UInt64(0) }
+        guard _conditionallyBridgeFromObjectiveC(src, result: &result) else { return UInt64(0) }
+        return result!
+    }
+}
+
+extension Int : _ObjectiveCBridgeable {
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
+    public init(_ number: __shared NSNumber) {
+        self = number.intValue
+    }
+
+    public init(truncating number: __shared NSNumber) {
+        self = number.intValue
+    }
+
+    public init?(exactly number: __shared NSNumber) {
+        let value = number.intValue
+        guard NSNumber(value: value) == number else { return nil }
+        self = value
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(value: self)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout Int?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Int?) -> Bool {
+        guard let value = Int(exactly: x) else { return false }
+        result = value
+        return true
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> Int {
+        var result: Int?
+        guard let src = source else { return Int(0) }
+        guard _conditionallyBridgeFromObjectiveC(src, result: &result) else { return Int(0) }
+        return result!
+    }
+}
+
+extension UInt : _ObjectiveCBridgeable {
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
+    public init(_ number: __shared NSNumber) {
+        self = number.uintValue
+    }
+
+    public init(truncating number: __shared NSNumber) {
+        self = number.uintValue
+    }
+
+    public init?(exactly number: __shared NSNumber) {
+        let value = number.uintValue
+        guard NSNumber(value: value) == number else { return nil }
+        self = value
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(value: self)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt?) -> Bool {
+        guard let value = UInt(exactly: x) else { return false }
+        result = value
+        return true
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> UInt {
+        var result: UInt?
+        guard let src = source else { return UInt(0) }
+        guard _conditionallyBridgeFromObjectiveC(src, result: &result) else { return UInt(0) }
+        return result!
+    }
+}
+
+extension Float : _ObjectiveCBridgeable {
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
+    public init(_ number: __shared NSNumber) {
+        self = number.floatValue
+    }
+
+    public init(truncating number: __shared NSNumber) {
+        self = number.floatValue
+    }
+
+    public init?(exactly number: __shared NSNumber) {
+        let type = number.objCType.pointee
+        if type == 0x49 || type == 0x4c || type == 0x51 {
+            guard let result = Float(exactly: number.uint64Value) else { return nil }
+            self = result
+        } else if type == 0x69 || type == 0x6c || type == 0x71 {
+            guard let result = Float(exactly: number.int64Value) else { return nil }
+            self = result
+        } else {
+            guard let result = Float(exactly: number.doubleValue) else { return nil }
+            self = result
+        }
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(value: self)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout Float?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Float?) -> Bool {
+        if x.floatValue.isNaN {
+            result = x.floatValue
+            return true
+        }
+        result = Float(exactly: x)
+        return result != nil
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> Float {
+        var result: Float?
+        guard let src = source else { return Float(0) }
+        guard _conditionallyBridgeFromObjectiveC(src, result: &result) else { return Float(0) }
+        return result!
+    }
+}
+
+extension Double : _ObjectiveCBridgeable {
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
+    public init(_ number: __shared NSNumber) {
+        self = number.doubleValue
+    }
+
+    public init(truncating number: __shared NSNumber) {
+        self = number.doubleValue
+    }
+
+    public init?(exactly number: __shared NSNumber) {
+        let type = number.objCType.pointee
+        if type == 0x51 {
+            guard let result = Double(exactly: number.uint64Value) else { return nil }
+            self = result
+        } else if type == 0x71 {
+            guard let result = Double(exactly: number.int64Value) else  { return nil }
+            self = result
+        } else {
+            // All other integer types and single-precision floating points will
+            // fit in a `Double` without truncation.
+            guard let result = Double(exactly: number.doubleValue) else { return nil }
+            self = result
+        }
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(value: self)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout Double?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Double?) -> Bool {
+        if x.doubleValue.isNaN {
+            result = x.doubleValue
+            return true
+        }
+        result = Double(exactly: x)
+        return result != nil
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> Double {
+        var result: Double?
+        guard let src = source else { return Double(0) }
+        guard _conditionallyBridgeFromObjectiveC(src, result: &result) else { return Double(0) }
+        return result!
+    }
+}
+
+extension Bool : _ObjectiveCBridgeable {
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
+    public init(_ number: __shared NSNumber) {
+        self = number.boolValue
+    }
+
+    public init(truncating number: __shared NSNumber) {
+        self = number.boolValue
+    }
+
+    public init?(exactly number: __shared NSNumber) {
+        if number === kCFBooleanTrue as NSNumber || NSNumber(value: 1) == number {
+            self = true
+        } else if number === kCFBooleanFalse as NSNumber || NSNumber(value: 0) == number {
+            self = false
+        } else {
+            return nil
+        }
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(value: self)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout Bool?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Bool?) -> Bool {
+        if x === kCFBooleanTrue as NSNumber || NSNumber(value: 1) == x {
+            result = true
+            return true
+        } else if x === kCFBooleanFalse as NSNumber || NSNumber(value: 0) == x {
+            result = false
+            return true
+        }
+        
+        return false
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> Bool {
+        var result: Bool?
+        guard let src = source else { return false }
+        guard _conditionallyBridgeFromObjectiveC(src, result: &result) else { return false }
+        return result!
+    }
+}
+
+extension CGFloat : _ObjectiveCBridgeable {
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
+    public init(_ number: __shared NSNumber) {
+        self.init(CGFloat.NativeType(truncating: number))
+    }
+
+    public init(truncating number: __shared NSNumber) {
+        self.init(CGFloat.NativeType(truncating: number))
+    }
+
+    public init?(exactly number: __shared NSNumber) {
+        var nativeValue: CGFloat.NativeType? = 0
+        guard CGFloat.NativeType._conditionallyBridgeFromObjectiveC(number, result: &nativeValue) else { return nil }
+        self.init(nativeValue!)
+    }
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNumber {
+        return NSNumber(value: self.native)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout CGFloat?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout CGFloat?) -> Bool {
+        var nativeValue: CGFloat.NativeType? = 0
+        guard CGFloat.NativeType._conditionallyBridgeFromObjectiveC(x, result: &nativeValue) else { return false }
+        result = CGFloat(nativeValue!)
+        return true
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> CGFloat {
+        var result: CGFloat?
+        guard let src = source else { return CGFloat(0) }
+        guard _conditionallyBridgeFromObjectiveC(src, result: &result) else { return CGFloat(0) }
+        return result!
+    }
+}
+
+// Literal support for NSNumber
+extension NSNumber : ExpressibleByFloatLiteral, ExpressibleByIntegerLiteral, ExpressibleByBooleanLiteral {
+    /// Create an instance initialized to `value`.
+    @nonobjc
+    public required convenience init(integerLiteral value: Int) {
+        self.init(value: value)
+    }
+
+    /// Create an instance initialized to `value`.
+    @nonobjc
+    public required convenience init(floatLiteral value: Double) {
+        self.init(value: value)
+    }
+
+    /// Create an instance initialized to `value`.
+    @nonobjc
+    public required convenience init(booleanLiteral value: Bool) {
+        self.init(value: value)
+    }
+}
+
+extension NSNumber : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to prevent infinite recursion trying to bridge
+    // AnyHashable to NSObject.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        // The custom AnyHashable representation here is used when checking for
+        // equality during bridging NSDictionary to Dictionary (or looking up
+        // values in a Dictionary bridged to NSDictionary).
+        // 
+        // When we've got NSNumber values as keys that we want to compare
+        // through an AnyHashable box, we want to compare values through the
+        // largest box size we've got available to us (i.e. upcast numbers).
+        // This happens to resemble the representation that NSNumber uses
+        // internally: (long long | unsigned long long | double).
+        // 
+        // This allows us to compare things like
+        // 
+        //     ([Int : Any] as [AnyHashable : Any]) vs. [NSNumber : Any]
+        // 
+        // because Int can be upcast to Int64 and compared with the number's
+        // Int64 value.
+        // 
+        // If NSNumber adds 128-bit representations, this will need to be
+        // updated to use those.
+        if let nsDecimalNumber: NSDecimalNumber = self as? NSDecimalNumber {
+            return AnyHashable(nsDecimalNumber.decimalValue)
+        } else if self === kCFBooleanTrue as NSNumber {
+            return AnyHashable(true)
+        } else if self === kCFBooleanFalse as NSNumber {
+            return AnyHashable(false)
+        } else if NSNumber(value: int64Value) == self {
+            return AnyHashable(int64Value)
+        } else if NSNumber(value: uint64Value) == self {
+            return AnyHashable(uint64Value)
+        } else if NSNumber(value: doubleValue) == self {
+            return AnyHashable(doubleValue)
+        } else {
+            return nil
+        }
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/NSObject.swift
+++ b/Darwin/Foundation-swiftoverlay/NSObject.swift
@@ -1,0 +1,313 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2017 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+import ObjectiveC
+@_implementationOnly import _FoundationOverlayShims
+
+// This exists to allow for dynamic dispatch on KVO methods added to NSObject.
+// Extending NSObject with these methods would disallow overrides.
+public protocol _KeyValueCodingAndObserving {}
+extension NSObject : _KeyValueCodingAndObserving {}
+
+public struct NSKeyValueObservedChange<Value> {
+    public typealias Kind = NSKeyValueChange
+    public let kind: Kind
+    ///newValue and oldValue will only be non-nil if .new/.old is passed to `observe()`. In general, get the most up to date value by accessing it directly on the observed object instead.
+    public let newValue: Value?
+    public let oldValue: Value?
+    ///indexes will be nil unless the observed KeyPath refers to an ordered to-many property
+    public let indexes: IndexSet?
+    ///'isPrior' will be true if this change observation is being sent before the change happens, due to .prior being passed to `observe()`
+    public let isPrior:Bool
+}
+
+///Conforming to NSKeyValueObservingCustomization is not required to use Key-Value Observing. Provide an implementation of these functions if you need to disable auto-notifying for a key, or add dependent keys
+public protocol NSKeyValueObservingCustomization : NSObjectProtocol {
+    static func keyPathsAffectingValue(for key: AnyKeyPath) -> Set<AnyKeyPath>
+    static func automaticallyNotifiesObservers(for key: AnyKeyPath) -> Bool
+}
+
+private extension NSObject {
+    
+    @objc class func __old_unswizzled_automaticallyNotifiesObservers(forKey key: String?) -> Bool {
+        fatalError("Should never be reached")
+    }
+    
+    @objc class func __old_unswizzled_keyPathsForValuesAffectingValue(forKey key: String?) -> Set<String> {
+        fatalError("Should never be reached")
+    }
+
+}
+
+// NOTE: older overlays called this _KVOKeyPathBridgeMachinery. The two
+// must coexist, so it was renamed. The old name must not be used in the
+// new runtime.
+@objc private class __KVOKeyPathBridgeMachinery : NSObject {
+    @nonobjc static let swizzler: () = {
+        /*
+         Move all our methods into place. We want the following:
+         __KVOKeyPathBridgeMachinery's automaticallyNotifiesObserversForKey:, and keyPathsForValuesAffectingValueForKey: methods replaces NSObject's versions of them
+         NSObject's automaticallyNotifiesObserversForKey:, and keyPathsForValuesAffectingValueForKey: methods replace NSObject's __old_unswizzled_* methods
+         NSObject's _old_unswizzled_* methods replace __KVOKeyPathBridgeMachinery's methods, and are never invoked
+         */
+        threeWaySwizzle(#selector(NSObject.keyPathsForValuesAffectingValue(forKey:)), with: #selector(NSObject.__old_unswizzled_keyPathsForValuesAffectingValue(forKey:)))
+        threeWaySwizzle(#selector(NSObject.automaticallyNotifiesObservers(forKey:)), with: #selector(NSObject.__old_unswizzled_automaticallyNotifiesObservers(forKey:)))
+    }()
+    
+    /// Performs a 3-way swizzle between `NSObject` and `__KVOKeyPathBridgeMachinery`.
+    ///
+    /// The end result of this swizzle is the following:
+    /// * `NSObject.selector` contains the IMP from `__KVOKeyPathBridgeMachinery.selector`
+    /// * `NSObject.unswizzledSelector` contains the IMP from the original `NSObject.selector`.
+    /// * __KVOKeyPathBridgeMachinery.selector` contains the (useless) IMP from `NSObject.unswizzledSelector`.
+    ///
+    /// This swizzle is done in a manner that modifies `NSObject.selector` last, in order to ensure thread safety
+    /// (by the time `NSObject.selector` is swizzled, `NSObject.unswizzledSelector` will contain the original IMP)
+    @nonobjc private static func threeWaySwizzle(_ selector: Selector, with unswizzledSelector: Selector) {
+        let rootClass: AnyClass = NSObject.self
+        let bridgeClass: AnyClass = __KVOKeyPathBridgeMachinery.self
+        
+        // Swap bridge.selector <-> NSObject.unswizzledSelector
+        let unswizzledMethod = class_getClassMethod(rootClass, unswizzledSelector)!
+        let bridgeMethod = class_getClassMethod(bridgeClass, selector)!
+        method_exchangeImplementations(unswizzledMethod, bridgeMethod)
+        
+        // Swap NSObject.selector <-> NSObject.unswizzledSelector
+        // NSObject.unswizzledSelector at this point contains the bridge IMP
+        let rootMethod = class_getClassMethod(rootClass, selector)!
+        method_exchangeImplementations(rootMethod, unswizzledMethod)
+    }
+
+    private class BridgeKey : NSObject, NSCopying {
+        let value: String
+
+        init(_ value: String) {
+            self.value = value
+        }
+
+        func copy(with zone: NSZone? = nil) -> Any {
+            return self
+        }
+
+        override func isEqual(_ object: Any?) -> Bool {
+            return value == (object as? BridgeKey)?.value
+        }
+
+        override var hash: Int {
+            var hasher = Hasher()
+            hasher.combine(ObjectIdentifier(BridgeKey.self))
+            hasher.combine(value)
+            return hasher.finalize()
+        }
+    }
+
+    /// Temporarily maps a `String` to an `AnyKeyPath` that can be retrieved with `_bridgeKeyPath(_:)`.
+    ///
+    /// This uses a per-thread storage so key paths on other threads don't interfere.
+    @nonobjc static func _withBridgeableKeyPath(from keyPathString: String, to keyPath: AnyKeyPath, block: () -> Void) {
+        _ = __KVOKeyPathBridgeMachinery.swizzler
+        let key = BridgeKey(keyPathString)
+        let oldValue = Thread.current.threadDictionary[key]
+        Thread.current.threadDictionary[key] = keyPath
+        defer { Thread.current.threadDictionary[key] = oldValue }
+        block()
+    }
+    
+    @nonobjc static func _bridgeKeyPath(_ keyPath:String?) -> AnyKeyPath? {
+        guard let keyPath = keyPath else { return nil }
+        return Thread.current.threadDictionary[BridgeKey(keyPath)] as? AnyKeyPath
+    }
+    
+    @objc override class func automaticallyNotifiesObservers(forKey key: String) -> Bool {
+        //This is swizzled so that it's -[NSObject automaticallyNotifiesObserversForKey:]
+        if let customizingSelf = self as? NSKeyValueObservingCustomization.Type, let path = __KVOKeyPathBridgeMachinery._bridgeKeyPath(key) {
+            return customizingSelf.automaticallyNotifiesObservers(for: path)
+        } else {
+            return self.__old_unswizzled_automaticallyNotifiesObservers(forKey: key) //swizzled to be NSObject's original implementation
+        }
+    }
+    
+    @objc override class func keyPathsForValuesAffectingValue(forKey key: String?) -> Set<String> {
+        //This is swizzled so that it's -[NSObject keyPathsForValuesAffectingValueForKey:]
+        if let customizingSelf = self as? NSKeyValueObservingCustomization.Type, let path = __KVOKeyPathBridgeMachinery._bridgeKeyPath(key!) {
+            let resultSet = customizingSelf.keyPathsAffectingValue(for: path)
+            return Set(resultSet.lazy.map {
+                guard let str = $0._kvcKeyPathString else { fatalError("Could not extract a String from KeyPath \($0)") }
+                return str
+            })
+        } else {
+            return self.__old_unswizzled_keyPathsForValuesAffectingValue(forKey: key) //swizzled to be NSObject's original implementation
+        }
+    }
+}
+
+func _bridgeKeyPathToString(_ keyPath:AnyKeyPath) -> String {
+    guard let keyPathString = keyPath._kvcKeyPathString else { fatalError("Could not extract a String from KeyPath \(keyPath)") }
+    return keyPathString
+}
+
+// NOTE: older overlays called this NSKeyValueObservation. We now use
+// that name in the source code, but add an underscore to the runtime
+// name to avoid conflicts when both are loaded into the same process.
+@objc(_NSKeyValueObservation)
+public class NSKeyValueObservation : NSObject {
+    // We use a private helper class as the actual observer. This lets us attach the helper as an associated object
+    // to the object we're observing, thus ensuring the helper will still be alive whenever a KVO change notification
+    // is broadcast, even on a background thread.
+    //
+    // For the associated object, we use the Helper instance itself as its own key. This guarantees key uniqueness.
+    private class Helper : NSObject {
+        @nonobjc weak var object : NSObject?
+        @nonobjc let path: String
+        @nonobjc let callback : (NSObject, NSKeyValueObservedChange<Any>) -> Void
+        
+        // workaround for <rdar://problem/31640524> Erroneous (?) error when using bridging in the Foundation overlay
+        // specifically, overriding observeValue(forKeyPath:of:change:context:) complains that it's not Obj-C-compatible
+        @nonobjc static let swizzler: () = {
+            let cls = NSClassFromString("_NSKVOCompatibility") as? _NSKVOCompatibilityShim.Type
+            cls?._noteProcessHasUsedKVOSwiftOverlay()
+            
+            let bridgeClass: AnyClass = Helper.self
+            let observeSel = #selector(NSObject.observeValue(forKeyPath:of:change:context:))
+            let swapSel = #selector(Helper._swizzle_me_observeValue(forKeyPath:of:change:context:))
+            let swapObserveMethod = class_getInstanceMethod(bridgeClass, swapSel)!
+            class_addMethod(bridgeClass, observeSel, method_getImplementation(swapObserveMethod), method_getTypeEncoding(swapObserveMethod))
+        }()
+        
+        @nonobjc init(object: NSObject, keyPath: AnyKeyPath, options: NSKeyValueObservingOptions, callback: @escaping (NSObject, NSKeyValueObservedChange<Any>) -> Void) {
+            _ = Helper.swizzler
+            let path = _bridgeKeyPathToString(keyPath)
+            self.object = object
+            self.path = path
+            self.callback = callback
+            super.init()
+            objc_setAssociatedObject(object, associationKey(), self, .OBJC_ASSOCIATION_RETAIN)
+            __KVOKeyPathBridgeMachinery._withBridgeableKeyPath(from: path, to: keyPath) {
+                object.addObserver(self, forKeyPath: path, options: options, context: nil)
+            }
+        }
+        
+        @nonobjc func invalidate() {
+            guard let object = self.object else { return }
+            object.removeObserver(self, forKeyPath: path, context: nil)
+            objc_setAssociatedObject(object, associationKey(), nil, .OBJC_ASSOCIATION_ASSIGN)
+            self.object = nil
+        }
+        
+        @nonobjc private func associationKey() -> UnsafeRawPointer {
+            return UnsafeRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        }
+        
+        @objc private func _swizzle_me_observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSString : Any]?, context: UnsafeMutableRawPointer?) {
+            guard let object = object as? NSObject, object === self.object, let change = change else { return }
+            let rawKind:UInt = change[NSKeyValueChangeKey.kindKey.rawValue as NSString] as! UInt
+            let kind = NSKeyValueChange(rawValue: rawKind)!
+            let notification = NSKeyValueObservedChange(kind: kind,
+                                                        newValue: change[NSKeyValueChangeKey.newKey.rawValue as NSString],
+                                                        oldValue: change[NSKeyValueChangeKey.oldKey.rawValue as NSString],
+                                                        indexes: change[NSKeyValueChangeKey.indexesKey.rawValue as NSString] as! IndexSet?,
+                                                        isPrior: change[NSKeyValueChangeKey.notificationIsPriorKey.rawValue as NSString] as? Bool ?? false)
+            callback(object, notification)
+        }
+    }
+    
+    @nonobjc private let helper: Helper
+    
+    fileprivate init(object: NSObject, keyPath: AnyKeyPath, options: NSKeyValueObservingOptions, callback: @escaping (NSObject, NSKeyValueObservedChange<Any>) -> Void) {
+        helper = Helper(object: object, keyPath: keyPath, options: options, callback: callback)
+    }
+    
+    ///invalidate() will be called automatically when an NSKeyValueObservation is deinited
+    @objc public func invalidate() {
+        helper.invalidate()
+    }
+    
+    deinit {
+        invalidate()
+    }
+}
+
+// Used for type-erase Optional type
+private protocol _OptionalForKVO {
+    static func _castForKVO(_ value: Any) -> Any?
+}
+
+extension Optional: _OptionalForKVO {
+    static func _castForKVO(_ value: Any) -> Any? {
+        return value as? Wrapped
+    }
+}
+
+extension _KeyValueCodingAndObserving {
+    
+    ///when the returned NSKeyValueObservation is deinited or invalidated, it will stop observing
+    public func observe<Value>(
+            _ keyPath: KeyPath<Self, Value>,
+            options: NSKeyValueObservingOptions = [],
+            changeHandler: @escaping (Self, NSKeyValueObservedChange<Value>) -> Void)
+        -> NSKeyValueObservation {
+        return NSKeyValueObservation(object: self as! NSObject, keyPath: keyPath, options: options) { (obj, change) in
+            
+            let converter = { (changeValue: Any?) -> Value? in
+                if let optionalType = Value.self as? _OptionalForKVO.Type {
+                    // Special logic for keyPath having a optional target value. When the keyPath referencing a nil value, the newValue/oldValue should be in the form .some(nil) instead of .none
+                    // Solve https://bugs.swift.org/browse/SR-6066
+                    
+                    // NSNull is used by KVO to signal that the keyPath value is nil.
+                    // If Value == Optional<T>.self, We will get nil instead of .some(nil) when casting Optional(<null>) directly.
+                    // To fix this behavior, we will eliminate NSNull first, then cast the transformed value.
+                    
+                    if let unwrapped = changeValue {
+                        // We use _castForKVO to cast first.
+                        // If Value != Optional<NSNull>.self, the NSNull value will be eliminated.
+                        let nullEliminatedValue = optionalType._castForKVO(unwrapped) as Any
+                        let transformedOptional: Any? = nullEliminatedValue
+                        return transformedOptional as? Value
+                    }
+                }
+                return changeValue as? Value
+            }
+            
+            let notification = NSKeyValueObservedChange(kind: change.kind,
+                                                        newValue: converter(change.newValue),
+                                                        oldValue: converter(change.oldValue),
+                                                        indexes: change.indexes,
+                                                        isPrior: change.isPrior)
+            changeHandler(obj as! Self, notification)
+        }
+    }
+    
+    public func willChangeValue<Value>(for keyPath: __owned KeyPath<Self, Value>) {
+        (self as! NSObject).willChangeValue(forKey: _bridgeKeyPathToString(keyPath))
+    }
+    
+    public func willChange<Value>(_ changeKind: NSKeyValueChange, valuesAt indexes: IndexSet, for keyPath: __owned KeyPath<Self, Value>) {
+        (self as! NSObject).willChange(changeKind, valuesAt: indexes, forKey: _bridgeKeyPathToString(keyPath))
+    }
+    
+    public func willChangeValue<Value>(for keyPath: __owned KeyPath<Self, Value>, withSetMutation mutation: NSKeyValueSetMutationKind, using set: Set<Value>) -> Void {
+        (self as! NSObject).willChangeValue(forKey: _bridgeKeyPathToString(keyPath), withSetMutation: mutation, using: set)
+    }
+    
+    public func didChangeValue<Value>(for keyPath: __owned KeyPath<Self, Value>) {
+        (self as! NSObject).didChangeValue(forKey: _bridgeKeyPathToString(keyPath))
+    }
+    
+    public func didChange<Value>(_ changeKind: NSKeyValueChange, valuesAt indexes: IndexSet, for keyPath: __owned KeyPath<Self, Value>) {
+        (self as! NSObject).didChange(changeKind, valuesAt: indexes, forKey: _bridgeKeyPathToString(keyPath))
+    }
+    
+    public func didChangeValue<Value>(for keyPath: __owned KeyPath<Self, Value>, withSetMutation mutation: NSKeyValueSetMutationKind, using set: Set<Value>) -> Void {
+        (self as! NSObject).didChangeValue(forKey: _bridgeKeyPathToString(keyPath), withSetMutation: mutation, using: set)
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/NSOrderedCollectionDifference.swift
+++ b/Darwin/Foundation-swiftoverlay/NSOrderedCollectionDifference.swift
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+// CollectionDifference<ChangeElement>.Change is conditionally bridged to NSOrderedCollectionChange
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension CollectionDifference.Change : _ObjectiveCBridgeable {
+  @_semantics("convertToObjectiveC")
+  public func _bridgeToObjectiveC() -> NSOrderedCollectionChange {
+    switch self {
+    case .insert(offset: let o, element: let e, associatedWith: let a):
+      return NSOrderedCollectionChange(object: e, type: .insert, index: o, associatedIndex: a ?? NSNotFound)
+    case .remove(offset: let o, element: let e, associatedWith: let a):
+      return NSOrderedCollectionChange(object: e, type: .remove, index: o, associatedIndex: a ?? NSNotFound)
+    }
+  }
+  
+  public static func _forceBridgeFromObjectiveC(_ input: NSOrderedCollectionChange, result: inout CollectionDifference.Change?) {
+    let _ = input.object as! ChangeElement
+
+    if !_conditionallyBridgeFromObjectiveC(input, result: &result) {
+      fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+    }
+  }
+  
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSOrderedCollectionChange, result: inout CollectionDifference.Change?
+  ) -> Bool {
+    guard let element = x.object as? ChangeElement else { return false }
+
+    let a: Int?
+    if x.associatedIndex == NSNotFound {
+      a = nil
+    } else {
+      a = x.associatedIndex
+    }
+
+    switch x.changeType {
+    case .insert:
+      result = .insert(offset: x.index, element: element, associatedWith: a)
+    case .remove:
+      result = .remove(offset: x.index, element: element, associatedWith: a)
+    default:
+      return false
+    }
+
+    return true
+  }
+  
+  @_effects(readonly)
+  public static func _unconditionallyBridgeFromObjectiveC(_ s: NSOrderedCollectionChange?) -> CollectionDifference.Change {
+    var result: CollectionDifference<ChangeElement>.Change? = nil
+    CollectionDifference<ChangeElement>.Change._forceBridgeFromObjectiveC(s!, result: &result)
+    return result!
+  }
+}
+
+// CollectionDifference<ChangeElement> is conditionally bridged to NSOrderedCollectionDifference
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension CollectionDifference : _ObjectiveCBridgeable {
+  @_semantics("convertToObjectiveC")
+  public func _bridgeToObjectiveC() -> NSOrderedCollectionDifference {
+    return NSOrderedCollectionDifference(changes: self.map({ $0 as NSOrderedCollectionChange }))
+  }
+  
+  public static func _forceBridgeFromObjectiveC(_ input: NSOrderedCollectionDifference, result: inout CollectionDifference?) {
+    if !_conditionallyBridgeFromObjectiveC(input, result: &result) {
+      fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+    }
+  }
+
+  private static func _formDifference(
+    from input: NSOrderedCollectionDifference,
+    _ changeConverter: (Any) -> CollectionDifference<ChangeElement>.Change?
+  ) -> CollectionDifference<ChangeElement>? {
+    var changes = Array<Change>()
+    let iteratorSeq = IteratorSequence(NSFastEnumerationIterator(input))
+    for objc_change in iteratorSeq {
+      guard let swift_change = changeConverter(objc_change) else { return nil }
+      changes.append(swift_change)
+    }
+    return CollectionDifference(changes)
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ input: NSOrderedCollectionDifference, result: inout CollectionDifference?
+  ) -> Bool {
+    result = _formDifference(from: input) { $0 as? Change }
+    return result != nil
+  }
+  
+  @_effects(readonly)
+  public static func _unconditionallyBridgeFromObjectiveC(_ s: NSOrderedCollectionDifference?) -> CollectionDifference {
+    return _formDifference(from: s!) { ($0 as! Change) }!
+  }
+}

--- a/Darwin/Foundation-swiftoverlay/NSPredicate.swift
+++ b/Darwin/Foundation-swiftoverlay/NSPredicate.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+extension NSPredicate {
+  // + (NSPredicate *)predicateWithFormat:(NSString *)predicateFormat, ...;
+  public
+  convenience init(format predicateFormat: __shared String, _ args: CVarArg...) {
+    let va_args = getVaList(args)
+    self.init(format: predicateFormat, arguments: va_args)
+  }
+}

--- a/Darwin/Foundation-swiftoverlay/NSRange.swift
+++ b/Darwin/Foundation-swiftoverlay/NSRange.swift
@@ -1,0 +1,249 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+extension NSRange : Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(location)
+        hasher.combine(length)
+    }
+
+    public static func==(lhs: NSRange, rhs: NSRange) -> Bool {
+        return lhs.location == rhs.location && lhs.length == rhs.length
+    }
+}
+
+extension NSRange : CustomStringConvertible, CustomDebugStringConvertible {
+    public var description: String { return "{\(location), \(length)}" }
+    public var debugDescription: String {
+        guard location != NSNotFound else {
+            return "{NSNotFound, \(length)}"     
+        }
+        return "{\(location), \(length)}" 
+    }
+}
+
+extension NSRange {
+    public init?(_ string: __shared String) {
+        var savedLocation = 0
+        if string.isEmpty {
+            // fail early if the string is empty
+            return nil
+        }
+        let scanner = Scanner(string: string)
+        let digitSet = CharacterSet.decimalDigits
+        let _ = scanner.scanUpToCharacters(from: digitSet, into: nil)
+        if scanner.isAtEnd {
+            // fail early if there are no decimal digits
+            return nil
+        }
+        var location = 0
+        savedLocation = scanner.scanLocation
+        guard scanner.scanInt(&location) else {
+            return nil
+        }
+        if scanner.isAtEnd {
+            // return early if there are no more characters after the first int in the string
+            return nil
+        }
+        if scanner.scanString(".", into: nil) {
+            scanner.scanLocation = savedLocation
+            var double = 0.0
+            guard scanner.scanDouble(&double) else {
+                return nil
+            }
+            guard let integral = Int(exactly: double) else {
+                return nil
+            }
+            location = integral
+        }
+        
+        let _ = scanner.scanUpToCharacters(from: digitSet, into: nil)
+        if scanner.isAtEnd {
+            // return early if there are no integer characters after the first int in the string
+            return nil
+        }
+        var length = 0
+        savedLocation = scanner.scanLocation
+        guard scanner.scanInt(&length) else {
+            return nil
+        }
+        
+        if !scanner.isAtEnd {
+            if scanner.scanString(".", into: nil) {
+                scanner.scanLocation = savedLocation
+                var double = 0.0
+                guard scanner.scanDouble(&double) else {
+                    return nil
+                }
+                guard let integral = Int(exactly: double) else {
+                    return nil
+                }
+                length = integral
+            }
+        }
+        
+        
+        self.init(location: location, length: length)
+    }
+}
+
+extension NSRange {
+    public var lowerBound: Int { return location }
+    
+    public var upperBound: Int { return location + length }
+    
+    public func contains(_ index: Int) -> Bool { return (!(index < location) && (index - location) < length) }
+    
+    public mutating func formUnion(_ other: NSRange) {
+        self = union(other)
+    }
+
+    public func union(_ other: NSRange) -> NSRange {
+        let max1 = location + length
+        let max2 = other.location + other.length
+        let maxend = (max1 < max2) ? max2 : max1
+        let minloc = location < other.location ? location : other.location
+        return NSRange(location: minloc, length: maxend - minloc)
+    }
+
+    public func intersection(_ other: NSRange) -> NSRange? {
+        let max1 = location + length
+        let max2 = other.location + other.length
+        let minend = (max1 < max2) ? max1 : max2
+        if other.location <= location && location < max2 {
+            return NSRange(location: location, length: minend - location)
+        } else if location <= other.location && other.location < max1 {
+            return NSRange(location: other.location, length: minend - other.location);
+        }
+        return nil
+    }
+}
+
+
+//===----------------------------------------------------------------------===//
+// Ranges
+//===----------------------------------------------------------------------===//
+
+extension NSRange {
+  public init<R: RangeExpression>(_ region: R)
+  where R.Bound: FixedWidthInteger {
+    let r = region.relative(to: 0..<R.Bound.max)
+    self.init(location: numericCast(r.lowerBound), length: numericCast(r.count))
+  }
+  
+  public init<R: RangeExpression, S: StringProtocol>(_ region: R, in target: S)
+  where R.Bound == S.Index {
+    let r = region.relative(to: target)
+    self.init(target._toUTF16Offsets(r))
+  }
+
+  @available(swift, deprecated: 4, renamed: "Range.init(_:)")
+  public func toRange() -> Range<Int>? {
+      if location == NSNotFound { return nil }
+      return location..<(location+length)
+  }
+}
+
+extension Range where Bound: BinaryInteger {
+  public init?(_ range: NSRange) {
+    guard range.location != NSNotFound else { return nil }
+    self.init(uncheckedBounds: (numericCast(range.lowerBound), numericCast(range.upperBound)))
+  }
+}
+
+// This additional overload will mean Range.init(_:) defaults to Range<Int> when
+// no additional type context is provided:
+extension Range where Bound == Int {
+  public init?(_ range: NSRange) {
+    guard range.location != NSNotFound else { return nil }
+    self.init(uncheckedBounds: (range.lowerBound, range.upperBound))
+  }
+}
+
+extension Range where Bound == String.Index {
+  private init?<S: StringProtocol>(
+    _ range: NSRange, _genericIn string: __shared S
+  ) {
+    // Corresponding stdlib version
+    guard #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
+      fatalError()
+    }
+    let u = string.utf16
+    guard range.location != NSNotFound,
+      let start = u.index(
+        u.startIndex, offsetBy: range.location, limitedBy: u.endIndex),
+      let end = u.index(
+        start, offsetBy: range.length, limitedBy: u.endIndex),
+      let lowerBound = String.Index(start, within: string),
+      let upperBound = String.Index(end, within: string)
+    else { return nil }
+
+    self = lowerBound..<upperBound
+  }
+
+  public init?(_ range: NSRange, in string: __shared String) {
+    if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+      // When building for an OS that has the new stuff that supports
+      // the generic version available, we just use that.
+      self.init(range, _genericIn: string)
+    } else {
+      // Need to have the old version available to support testing a just-
+      // built standard library on 10.14. We may want to figure out a more
+      // principled way to handle this in the future, but this should keep
+      // local and PR testing working.
+      let u = string.utf16
+      guard range.location != NSNotFound,
+        let start = u.index(u.startIndex, offsetBy: range.location, limitedBy: u.endIndex),
+        let end = u.index(u.startIndex, offsetBy: range.location + range.length, limitedBy: u.endIndex),
+        let lowerBound = String.Index(start, within: string),
+        let upperBound = String.Index(end, within: string)
+      else { return nil }
+      
+      self = lowerBound..<upperBound
+    }
+  }
+  
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  public init?<S: StringProtocol>(_ range: NSRange, in string: __shared S) {
+    self.init(range, _genericIn: string)
+  }
+}
+
+extension NSRange : CustomReflectable {
+    public var customMirror: Mirror {
+        return Mirror(self, children: ["location": location, "length": length])
+    }
+}
+
+extension NSRange : _CustomPlaygroundQuickLookable {
+    @available(*, deprecated, message: "NSRange.customPlaygroundQuickLook will be removed in a future Swift version")
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .range(Int64(location), Int64(length))
+    }
+}
+
+extension NSRange : Codable {
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        let location = try container.decode(Int.self)
+        let length = try container.decode(Int.self)
+        self.init(location: location, length: length)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(self.location)
+        try container.encode(self.length)
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/NSSet.swift
+++ b/Darwin/Foundation-swiftoverlay/NSSet.swift
@@ -1,0 +1,195 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+extension Set {
+  /// Private initializer used for bridging.
+  ///
+  /// The provided `NSSet` will be copied to ensure that the copy can
+  /// not be mutated by other code.
+  private init(_cocoaSet: __shared NSSet) {
+    assert(_isBridgedVerbatimToObjectiveC(Element.self),
+      "Set can be backed by NSSet _variantStorage only when the member type can be bridged verbatim to Objective-C")
+    // FIXME: We would like to call CFSetCreateCopy() to avoid doing an
+    // objc_msgSend() for instances of CoreFoundation types.  We can't do that
+    // today because CFSetCreateCopy() copies dictionary contents
+    // unconditionally, resulting in O(n) copies even for immutable dictionaries.
+    //
+    // <rdar://problem/20697680> CFSetCreateCopy() does not call copyWithZone:
+    //
+    // The bug is fixed in: OS X 10.11.0, iOS 9.0, all versions of tvOS
+    // and watchOS.
+    self = Set(_immutableCocoaSet: _cocoaSet.copy(with: nil) as AnyObject)
+  }
+}
+
+extension NSSet : Sequence {
+  /// Return an *iterator* over the elements of this *sequence*.
+  ///
+  /// - Complexity: O(1).
+  public func makeIterator() -> NSFastEnumerationIterator {
+    return NSFastEnumerationIterator(self)
+  }
+}
+
+extension NSOrderedSet : Sequence {
+  /// Return an *iterator* over the elements of this *sequence*.
+  ///
+  /// - Complexity: O(1).
+  public func makeIterator() -> NSFastEnumerationIterator {
+    return NSFastEnumerationIterator(self)
+  }
+}
+
+// Set<Element> is conditionally bridged to NSSet
+extension Set : _ObjectiveCBridgeable {
+  @_semantics("convertToObjectiveC")
+  public func _bridgeToObjectiveC() -> NSSet {
+    return unsafeBitCast(_bridgeToObjectiveCImpl(), to: NSSet.self)
+  }
+
+  public static func _forceBridgeFromObjectiveC(_ s: NSSet, result: inout Set?) {
+    if let native =
+      Set<Element>._bridgeFromObjectiveCAdoptingNativeStorageOf(s as AnyObject) {
+
+      result = native
+      return
+    }
+
+    if _isBridgedVerbatimToObjectiveC(Element.self) {
+      result = Set<Element>(_cocoaSet: s)
+      return
+    }
+
+    if Element.self == String.self {
+      // String and NSString have different concepts of equality, so
+      // string-keyed NSSets may generate key collisions when bridged over to
+      // Swift. See rdar://problem/35995647
+      var set = Set(minimumCapacity: s.count)
+      s.enumerateObjects({ (anyMember: Any, _) in
+        // FIXME: Log a warning if `member` is already in the set.
+        set.insert(anyMember as! Element)
+      })
+      result = set
+      return
+    }
+
+    // `Set<Element>` where `Element` is a value type may not be backed by
+    // an NSSet.
+    var builder = _SetBuilder<Element>(count: s.count)
+    s.enumerateObjects({ (anyMember: Any, _) in
+      builder.add(member: anyMember as! Element)
+    })
+    result = builder.take()
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSSet, result: inout Set?
+  ) -> Bool {
+    let anySet = x as Set<NSObject>
+    if _isBridgedVerbatimToObjectiveC(Element.self) {
+      result = Swift._setDownCastConditional(anySet)
+      return result != nil
+    }
+
+    result = anySet as? Set
+    return result != nil
+  }
+
+  @_effects(readonly)
+  public static func _unconditionallyBridgeFromObjectiveC(_ s: NSSet?) -> Set {
+    // `nil` has historically been used as a stand-in for an empty
+    // set; map it to an empty set.
+    if _slowPath(s == nil) { return Set() }
+
+    var result: Set? = nil
+    Set<Element>._forceBridgeFromObjectiveC(s!, result: &result)
+    return result!
+  }
+}
+
+extension NSSet : _HasCustomAnyHashableRepresentation {
+  // Must be @nonobjc to avoid infinite recursion during bridging
+  @nonobjc
+  public func _toCustomAnyHashable() -> AnyHashable? {
+    return AnyHashable(self as! Set<AnyHashable>)
+  }
+}
+
+extension NSOrderedSet {
+  // - (instancetype)initWithObjects:(id)firstObj, ...
+  public convenience init(objects elements: Any...) {
+    self.init(array: elements)
+  }
+}
+
+extension NSSet {
+  // - (instancetype)initWithObjects:(id)firstObj, ...
+  public convenience init(objects elements: Any...) {
+    self.init(array: elements)
+  }
+}
+
+extension NSSet : ExpressibleByArrayLiteral {
+  public required convenience init(arrayLiteral elements: Any...) {
+    self.init(array: elements)
+  }
+}
+
+extension NSOrderedSet : ExpressibleByArrayLiteral {
+  public required convenience init(arrayLiteral elements: Any...) {
+    self.init(array: elements)
+  }
+}
+
+extension NSSet {
+  /// Initializes a newly allocated set and adds to it objects from
+  /// another given set.
+  ///
+  /// - Returns: An initialized objects set containing the objects from
+  ///   `set`. The returned set might be different than the original
+  ///   receiver.
+  @nonobjc
+  public convenience init(set anSet: __shared NSSet) {
+    // FIXME(performance)(compiler limitation): we actually want to do just
+    // `self = anSet.copy()`, but Swift does not have factory
+    // initializers right now.
+    let numElems = anSet.count
+    let stride = MemoryLayout<Optional<UnsafeRawPointer>>.stride
+    let alignment = MemoryLayout<Optional<UnsafeRawPointer>>.alignment
+    let bufferSize = stride * numElems
+    assert(stride == MemoryLayout<AnyObject>.stride)
+    assert(alignment == MemoryLayout<AnyObject>.alignment)
+
+    let rawBuffer = UnsafeMutableRawPointer.allocate(
+      byteCount: bufferSize, alignment: alignment)
+    defer {
+      rawBuffer.deallocate()
+      _fixLifetime(anSet)
+    }
+    let valueBuffer = rawBuffer.bindMemory(
+     to: Optional<UnsafeRawPointer>.self, capacity: numElems)
+
+    CFSetGetValues(anSet, valueBuffer)
+    let valueBufferForInit = rawBuffer.assumingMemoryBound(to: AnyObject.self)
+    self.init(objects: valueBufferForInit, count: numElems)
+  }
+}
+
+extension NSSet : CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(reflecting: self as Set<NSObject>)
+  }
+}
+
+extension Set: CVarArg {}

--- a/Darwin/Foundation-swiftoverlay/NSSortDescriptor.swift
+++ b/Darwin/Foundation-swiftoverlay/NSSortDescriptor.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2017 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+import ObjectiveC
+
+extension NSSortDescriptor {
+    public convenience init<Root, Value>(keyPath: KeyPath<Root, Value>, ascending: Bool) {
+        self.init(key: _bridgeKeyPathToString(keyPath), ascending: ascending)
+        objc_setAssociatedObject(self, UnsafeRawPointer(&associationKey), keyPath, .OBJC_ASSOCIATION_RETAIN)
+    }
+    
+    public convenience init<Root, Value>(keyPath: KeyPath<Root, Value>, ascending: Bool, comparator cmptr: @escaping Foundation.Comparator) {
+        self.init(key: _bridgeKeyPathToString(keyPath), ascending: ascending, comparator: cmptr)
+        objc_setAssociatedObject(self, UnsafeRawPointer(&associationKey), keyPath, .OBJC_ASSOCIATION_RETAIN)
+    }
+    
+    public var keyPath: AnyKeyPath? {
+        return objc_getAssociatedObject(self, UnsafeRawPointer(&associationKey)) as? AnyKeyPath
+    }
+}
+
+private var associationKey: ()?

--- a/Darwin/Foundation-swiftoverlay/NSString.swift
+++ b/Darwin/Foundation-swiftoverlay/NSString.swift
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+//===----------------------------------------------------------------------===//
+// Strings
+//===----------------------------------------------------------------------===//
+
+extension NSString : ExpressibleByStringLiteral {
+  /// Create an instance initialized to `value`.
+  public required convenience init(stringLiteral value: StaticString) {
+    var immutableResult: NSString
+    if value.hasPointerRepresentation {
+      immutableResult = NSString(
+        bytesNoCopy: UnsafeMutableRawPointer(mutating: value.utf8Start),
+        length: Int(value.utf8CodeUnitCount),
+        encoding: value.isASCII ? String.Encoding.ascii.rawValue : String.Encoding.utf8.rawValue,
+        freeWhenDone: false)!
+    } else {
+      var uintValue = value.unicodeScalar
+      immutableResult = NSString(
+        bytes: &uintValue,
+        length: 4,
+        encoding: String.Encoding.utf32.rawValue)!
+    }
+    self.init(string: immutableResult as String)
+  }
+}
+
+extension NSString : _HasCustomAnyHashableRepresentation {
+  // Must be @nonobjc to prevent infinite recursion trying to bridge
+  // AnyHashable to NSObject.
+  @nonobjc
+  public func _toCustomAnyHashable() -> AnyHashable? {
+    // Consistently use Swift equality and hashing semantics for all strings.
+    return AnyHashable(self as String)
+  }
+}
+
+extension NSString {
+  public convenience init(format: __shared NSString, _ args: CVarArg...) {
+    // We can't use withVaList because 'self' cannot be captured by a closure
+    // before it has been initialized.
+    let va_args = getVaList(args)
+    self.init(format: format as String, arguments: va_args)
+  }
+
+  public convenience init(
+    format: __shared NSString, locale: Locale?, _ args: CVarArg...
+  ) {
+    // We can't use withVaList because 'self' cannot be captured by a closure
+    // before it has been initialized.
+    let va_args = getVaList(args)
+    self.init(format: format as String, locale: locale, arguments: va_args)
+  }
+
+  public class func localizedStringWithFormat(
+    _ format: NSString, _ args: CVarArg...
+  ) -> Self {
+    return withVaList(args) {
+      self.init(format: format as String, locale: Locale.current, arguments: $0)
+    }
+  }
+
+  public func appendingFormat(_ format: NSString, _ args: CVarArg...)
+  -> NSString {
+    return withVaList(args) {
+      self.appending(NSString(format: format as String, arguments: $0) as String) as NSString
+    }
+  }
+}
+
+extension NSMutableString {
+  public func appendFormat(_ format: NSString, _ args: CVarArg...) {
+    return withVaList(args) {
+      self.append(NSString(format: format as String, arguments: $0) as String)
+    }
+  }
+}
+
+extension NSString {
+  /// Returns an `NSString` object initialized by copying the characters
+  /// from another given string.
+  ///
+  /// - Returns: An `NSString` object initialized by copying the
+  ///   characters from `aString`. The returned object may be different
+  ///   from the original receiver.
+  @nonobjc
+  public convenience init(string aString: __shared NSString) {
+    self.init(string: aString as String)
+  }
+}
+
+extension NSString : _CustomPlaygroundQuickLookable {
+  @available(*, deprecated, message: "NSString.customPlaygroundQuickLook will be removed in a future Swift version")
+  public var customPlaygroundQuickLook: PlaygroundQuickLook {
+    return .text(self as String)
+  }
+}

--- a/Darwin/Foundation-swiftoverlay/NSStringAPI.swift
+++ b/Darwin/Foundation-swiftoverlay/NSStringAPI.swift
@@ -1,0 +1,2206 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Exposing the API of NSString on Swift's String
+//
+//===----------------------------------------------------------------------===//
+
+// Important Note
+// ==============
+//
+// This file is shared between two projects:
+//
+// 1. https://github.com/apple/swift/tree/main/stdlib/public/Darwin/Foundation
+// 2. https://github.com/apple/swift-corelibs-foundation/tree/main/Foundation
+//
+// If you change this file, you must update it in both places.
+
+#if !DEPLOYMENT_RUNTIME_SWIFT
+@_exported import Foundation // Clang module
+#endif
+
+// Open Issues
+// ===========
+//
+// Property Lists need to be properly bridged
+//
+
+func _toNSArray<T, U : AnyObject>(_ a: [T], f: (T) -> U) -> NSArray {
+  let result = NSMutableArray(capacity: a.count)
+  for s in a {
+    result.add(f(s))
+  }
+  return result
+}
+
+#if !DEPLOYMENT_RUNTIME_SWIFT
+// We only need this for UnsafeMutablePointer, but there's not currently a way
+// to write that constraint.
+extension Optional {
+  /// Invokes `body` with `nil` if `self` is `nil`; otherwise, passes the
+  /// address of `object` to `body`.
+  ///
+  /// This is intended for use with Foundation APIs that return an Objective-C
+  /// type via out-parameter where it is important to be able to *ignore* that
+  /// parameter by passing `nil`. (For some APIs, this may allow the
+  /// implementation to avoid some work.)
+  ///
+  /// In most cases it would be simpler to just write this code inline, but if
+  /// `body` is complicated than that results in unnecessarily repeated code.
+  internal func _withNilOrAddress<NSType : AnyObject, ResultType>(
+    of object: inout NSType?,
+    _ body:
+      (AutoreleasingUnsafeMutablePointer<NSType?>?) -> ResultType
+  ) -> ResultType {
+    return self == nil ? body(nil) : body(&object)
+  }
+}
+#endif
+
+/// From a non-`nil` `UnsafePointer` to a null-terminated string
+/// with possibly-transient lifetime, create a null-terminated array of 'C' char.
+/// Returns `nil` if passed a null pointer.
+internal func _persistCString(_ p: UnsafePointer<CChar>?) -> [CChar]? {
+  guard let cString = p else {
+    return nil
+  }
+  let bytesToCopy = UTF8._nullCodeUnitOffset(in: cString) + 1 // +1 for the terminating NUL
+  let result = [CChar](unsafeUninitializedCapacity: bytesToCopy) { buffer, initializedCount in
+      buffer.baseAddress!.initialize(from: cString, count: bytesToCopy)
+      initializedCount = bytesToCopy
+  }
+  return result
+}
+
+extension String {
+  //===--- Class Methods --------------------------------------------------===//
+  //===--------------------------------------------------------------------===//
+
+  // @property (class) const NSStringEncoding *availableStringEncodings;
+
+  /// An array of the encodings that strings support in the application's
+  /// environment.
+  public static var availableStringEncodings: [Encoding] {
+    var result = [Encoding]()
+    var p = NSString.availableStringEncodings
+    while p.pointee != 0 {
+      result.append(Encoding(rawValue: p.pointee))
+      p += 1
+    }
+    return result
+  }
+
+  // @property (class) NSStringEncoding defaultCStringEncoding;
+
+  /// The C-string encoding assumed for any method accepting a C string as an
+  /// argument.
+  public static var defaultCStringEncoding: Encoding {
+    return Encoding(rawValue: NSString.defaultCStringEncoding)
+  }
+
+  // + (NSString *)localizedNameOfStringEncoding:(NSStringEncoding)encoding
+
+  /// Returns a human-readable string giving the name of the specified encoding.
+  ///
+  /// - Parameter encoding: A string encoding. For possible values, see
+  ///   `String.Encoding`.
+  /// - Returns: A human-readable string giving the name of `encoding` in the
+  ///   current locale.
+  public static func localizedName(
+    of encoding: Encoding
+  ) -> String {
+    return NSString.localizedName(of: encoding.rawValue)
+  }
+
+  // + (instancetype)localizedStringWithFormat:(NSString *)format, ...
+
+  /// Returns a string created by using a given format string as a
+  /// template into which the remaining argument values are substituted
+  /// according to the user's default locale.
+  public static func localizedStringWithFormat(
+    _ format: String, _ arguments: CVarArg...
+  ) -> String {
+    return String(format: format, locale: Locale.current,
+      arguments: arguments)
+  }
+
+  //===--------------------------------------------------------------------===//
+  // NSString factory functions that have a corresponding constructor
+  // are omitted.
+  //
+  // + (instancetype)string
+  //
+  // + (instancetype)
+  //     stringWithCharacters:(const unichar *)chars length:(NSUInteger)length
+  //
+  // + (instancetype)stringWithFormat:(NSString *)format, ...
+  //
+  // + (instancetype)
+  //     stringWithContentsOfFile:(NSString *)path
+  //     encoding:(NSStringEncoding)enc
+  //     error:(NSError **)error
+  //
+  // + (instancetype)
+  //     stringWithContentsOfFile:(NSString *)path
+  //     usedEncoding:(NSStringEncoding *)enc
+  //     error:(NSError **)error
+  //
+  // + (instancetype)
+  //     stringWithContentsOfURL:(NSURL *)url
+  //     encoding:(NSStringEncoding)enc
+  //     error:(NSError **)error
+  //
+  // + (instancetype)
+  //     stringWithContentsOfURL:(NSURL *)url
+  //     usedEncoding:(NSStringEncoding *)enc
+  //     error:(NSError **)error
+  //
+  // + (instancetype)
+  //     stringWithCString:(const char *)cString
+  //     encoding:(NSStringEncoding)enc
+  //===--------------------------------------------------------------------===//
+
+  //===--- Adds nothing for String beyond what String(s) does -------------===//
+  // + (instancetype)stringWithString:(NSString *)aString
+  //===--------------------------------------------------------------------===//
+
+  // + (instancetype)stringWithUTF8String:(const char *)bytes
+
+  /// Creates a string by copying the data from a given
+  /// C array of UTF8-encoded bytes.
+  public init?(utf8String bytes: UnsafePointer<CChar>) {
+    if let str = String(validatingUTF8: bytes) {
+      self = str
+      return
+    }
+    if let ns = NSString(utf8String: bytes) {
+      self = String._unconditionallyBridgeFromObjectiveC(ns)
+    } else {
+      return nil
+    }
+  }
+}
+
+extension String {
+  //===--- Already provided by String's core ------------------------------===//
+  // - (instancetype)init
+
+  //===--- Initializers that can fail -------------------------------------===//
+  // - (instancetype)
+  //     initWithBytes:(const void *)bytes
+  //     length:(NSUInteger)length
+  //     encoding:(NSStringEncoding)encoding
+
+  /// Creates a new string equivalent to the given bytes interpreted in the
+  /// specified encoding.
+  ///
+  /// - Parameters:
+  ///   - bytes: A sequence of bytes to interpret using `encoding`.
+  ///   - encoding: The ecoding to use to interpret `bytes`.
+  public init?<S: Sequence>(bytes: __shared S, encoding: Encoding)
+  where S.Iterator.Element == UInt8 {
+    let byteArray = Array(bytes)
+    if encoding == .utf8,
+       let str = byteArray.withUnsafeBufferPointer({ String._tryFromUTF8($0) })
+    {
+      self = str
+      return
+    }
+
+    if let ns = NSString(
+      bytes: byteArray, length: byteArray.count, encoding: encoding.rawValue) {
+      self = String._unconditionallyBridgeFromObjectiveC(ns)
+    } else {
+      return nil
+    }
+  }
+
+  // - (instancetype)
+  //     initWithBytesNoCopy:(void *)bytes
+  //     length:(NSUInteger)length
+  //     encoding:(NSStringEncoding)encoding
+  //     freeWhenDone:(BOOL)flag
+
+  /// Creates a new string that contains the specified number of bytes from the
+  /// given buffer, interpreted in the specified encoding, and optionally
+  /// frees the buffer.
+  ///
+  /// - Warning: This initializer is not memory-safe!
+  public init?(
+    bytesNoCopy bytes: UnsafeMutableRawPointer, length: Int,
+    encoding: Encoding, freeWhenDone flag: Bool
+  ) {
+    if let ns = NSString(
+      bytesNoCopy: bytes, length: length, encoding: encoding.rawValue,
+      freeWhenDone: flag) {
+
+      self = String._unconditionallyBridgeFromObjectiveC(ns)
+    } else {
+      return nil
+    }
+  }
+
+
+  // - (instancetype)
+  //     initWithCharacters:(const unichar *)characters
+  //     length:(NSUInteger)length
+
+  /// Creates a new string that contains the specified number of characters
+  /// from the given C array of Unicode characters.
+  public init(
+    utf16CodeUnits: UnsafePointer<unichar>,
+    count: Int
+  ) {
+    self = String._unconditionallyBridgeFromObjectiveC(NSString(characters: utf16CodeUnits, length: count))
+  }
+
+  // - (instancetype)
+  //     initWithCharactersNoCopy:(unichar *)characters
+  //     length:(NSUInteger)length
+  //     freeWhenDone:(BOOL)flag
+
+  /// Creates a new string that contains the specified number of characters
+  /// from the given C array of UTF-16 code units.
+  public init(
+    utf16CodeUnitsNoCopy: UnsafePointer<unichar>,
+    count: Int,
+    freeWhenDone flag: Bool
+  ) {
+    self = String._unconditionallyBridgeFromObjectiveC(NSString(
+      charactersNoCopy: UnsafeMutablePointer(mutating: utf16CodeUnitsNoCopy),
+      length: count,
+      freeWhenDone: flag))
+  }
+
+  //===--- Initializers that can fail -------------------------------------===//
+
+  // - (instancetype)
+  //     initWithContentsOfFile:(NSString *)path
+  //     encoding:(NSStringEncoding)enc
+  //     error:(NSError **)error
+  //
+
+  /// Produces a string created by reading data from the file at a
+  /// given path interpreted using a given encoding.
+  public init(
+    contentsOfFile path: __shared String,
+    encoding enc: Encoding
+  ) throws {
+    let ns = try NSString(contentsOfFile: path, encoding: enc.rawValue)
+    self = String._unconditionallyBridgeFromObjectiveC(ns)
+  }
+
+  // - (instancetype)
+  //     initWithContentsOfFile:(NSString *)path
+  //     usedEncoding:(NSStringEncoding *)enc
+  //     error:(NSError **)error
+
+  /// Produces a string created by reading data from the file at
+  /// a given path and returns by reference the encoding used to
+  /// interpret the file.
+  public init(
+    contentsOfFile path: __shared String,
+    usedEncoding: inout Encoding
+  ) throws {
+    var enc: UInt = 0
+    let ns = try NSString(contentsOfFile: path, usedEncoding: &enc)
+    usedEncoding = Encoding(rawValue: enc)
+    self = String._unconditionallyBridgeFromObjectiveC(ns)
+  }
+
+  public init(
+    contentsOfFile path: __shared String
+  ) throws {
+    let ns = try NSString(contentsOfFile: path, usedEncoding: nil)
+    self = String._unconditionallyBridgeFromObjectiveC(ns)
+  }
+
+  // - (instancetype)
+  //     initWithContentsOfURL:(NSURL *)url
+  //     encoding:(NSStringEncoding)enc
+  //     error:(NSError**)error
+
+  /// Produces a string created by reading data from a given URL
+  /// interpreted using a given encoding.  Errors are written into the
+  /// inout `error` argument.
+  public init(
+    contentsOf url: __shared URL,
+    encoding enc: Encoding
+  ) throws {
+    let ns = try NSString(contentsOf: url, encoding: enc.rawValue)
+    self = String._unconditionallyBridgeFromObjectiveC(ns)
+  }
+
+  // - (instancetype)
+  //     initWithContentsOfURL:(NSURL *)url
+  //     usedEncoding:(NSStringEncoding *)enc
+  //     error:(NSError **)error
+
+  /// Produces a string created by reading data from a given URL
+  /// and returns by reference the encoding used to interpret the
+  /// data.  Errors are written into the inout `error` argument.
+  public init(
+    contentsOf url: __shared URL,
+    usedEncoding: inout Encoding
+  ) throws {
+    var enc: UInt = 0
+    let ns = try NSString(contentsOf: url, usedEncoding: &enc)
+    usedEncoding = Encoding(rawValue: enc)
+    self = String._unconditionallyBridgeFromObjectiveC(ns)
+  }
+
+  public init(
+    contentsOf url: __shared URL
+  ) throws {
+    let ns = try NSString(contentsOf: url, usedEncoding: nil)
+    self = String._unconditionallyBridgeFromObjectiveC(ns)
+  }
+
+  // - (instancetype)
+  //     initWithCString:(const char *)nullTerminatedCString
+  //     encoding:(NSStringEncoding)encoding
+
+  /// Produces a string containing the bytes in a given C array,
+  /// interpreted according to a given encoding.
+  public init?(
+    cString: UnsafePointer<CChar>,
+    encoding enc: Encoding
+  ) {
+    if enc == .utf8, let str = String(validatingUTF8: cString) {
+      self = str
+      return
+    }
+    if let ns = NSString(cString: cString, encoding: enc.rawValue) {
+      self = String._unconditionallyBridgeFromObjectiveC(ns)
+    } else {
+      return nil
+    }
+  }
+
+  // FIXME: handle optional locale with default arguments
+
+  // - (instancetype)
+  //     initWithData:(NSData *)data
+  //     encoding:(NSStringEncoding)encoding
+
+  /// Returns a `String` initialized by converting given `data` into
+  /// Unicode characters using a given `encoding`.
+  public init?(data: __shared Data, encoding: Encoding) {
+    if encoding == .utf8,
+       let str = data.withUnsafeBytes({
+         String._tryFromUTF8($0.bindMemory(to: UInt8.self))
+    }) {
+      self = str
+      return
+    }
+
+    guard let s = NSString(data: data, encoding: encoding.rawValue) else { return nil }
+    self = String._unconditionallyBridgeFromObjectiveC(s)
+  }
+
+  // - (instancetype)initWithFormat:(NSString *)format, ...
+
+  /// Returns a `String` object initialized by using a given
+  /// format string as a template into which the remaining argument
+  /// values are substituted.
+  public init(format: __shared String, _ arguments: CVarArg...) {
+    self = String(format: format, arguments: arguments)
+  }
+
+  // - (instancetype)
+  //     initWithFormat:(NSString *)format
+  //     arguments:(va_list)argList
+
+  /// Returns a `String` object initialized by using a given
+  /// format string as a template into which the remaining argument
+  /// values are substituted according to the user's default locale.
+  public init(format: __shared String, arguments: __shared [CVarArg]) {
+    self = String(format: format, locale: nil, arguments: arguments)
+  }
+
+  // - (instancetype)initWithFormat:(NSString *)format locale:(id)locale, ...
+
+  /// Returns a `String` object initialized by using a given
+  /// format string as a template into which the remaining argument
+  /// values are substituted according to given locale information.
+  public init(format: __shared String, locale: __shared Locale?, _ args: CVarArg...) {
+    self = String(format: format, locale: locale, arguments: args)
+  }
+
+  // - (instancetype)
+  //     initWithFormat:(NSString *)format
+  //     locale:(id)locale
+  //     arguments:(va_list)argList
+
+  /// Returns a `String` object initialized by using a given
+  /// format string as a template into which the remaining argument
+  /// values are substituted according to given locale information.
+  public init(format: __shared String, locale: __shared Locale?, arguments: __shared [CVarArg]) {
+#if DEPLOYMENT_RUNTIME_SWIFT
+    self = withVaList(arguments) {
+      String._unconditionallyBridgeFromObjectiveC(
+        NSString(format: format, locale: locale?._bridgeToObjectiveC(), arguments: $0)
+      )
+    }
+#else
+    self = withVaList(arguments) {
+      NSString(format: format, locale: locale, arguments: $0) as String
+    }
+#endif
+  }
+
+}
+
+extension StringProtocol where Index == String.Index {
+  //===--- Bridging Helpers -----------------------------------------------===//
+  //===--------------------------------------------------------------------===//
+
+  /// The corresponding `NSString` - a convenience for bridging code.
+  // FIXME(strings): There is probably a better way to bridge Self to NSString
+  var _ns: NSString {
+    return self._ephemeralString._bridgeToObjectiveC()
+  }
+
+  /// Return an `Index` corresponding to the given offset in our UTF-16
+  /// representation.
+  func _toIndex(_ utf16Index: Int) -> Index {
+    return self._toUTF16Index(utf16Index)
+  }
+
+  /// Return the UTF-16 code unit offset corresponding to an Index
+  func _toOffset(_ idx: String.Index) -> Int {
+    return self._toUTF16Offset(idx)
+  }
+
+  @inlinable
+  internal func _toRelativeNSRange(_ r: Range<String.Index>) -> NSRange {
+    return NSRange(self._toUTF16Offsets(r))
+  }
+
+  /// Return a `Range<Index>` corresponding to the given `NSRange` of
+  /// our UTF-16 representation.
+  func _toRange(_ r: NSRange) -> Range<Index> {
+    return self._toUTF16Indices(Range(r)!)
+  }
+
+  /// Return a `Range<Index>?` corresponding to the given `NSRange` of
+  /// our UTF-16 representation.
+  func _optionalRange(_ r: NSRange) -> Range<Index>? {
+    if r.location == NSNotFound {
+      return nil
+    }
+    return _toRange(r)
+  }
+
+  /// Invoke `body` on an `Int` buffer.  If `index` was converted from
+  /// non-`nil`, convert the buffer to an `Index` and write it into the
+  /// memory referred to by `index`
+  func _withOptionalOutParameter<Result>(
+    _ index: UnsafeMutablePointer<Index>?,
+    _ body: (UnsafeMutablePointer<Int>?) -> Result
+  ) -> Result {
+    var utf16Index: Int = 0
+    let result = (index != nil ? body(&utf16Index) : body(nil))
+    index?.pointee = _toIndex(utf16Index)
+    return result
+  }
+
+  /// Invoke `body` on an `NSRange` buffer.  If `range` was converted
+  /// from non-`nil`, convert the buffer to a `Range<Index>` and write
+  /// it into the memory referred to by `range`
+  func _withOptionalOutParameter<Result>(
+    _ range: UnsafeMutablePointer<Range<Index>>?,
+    _ body: (UnsafeMutablePointer<NSRange>?) -> Result
+  ) -> Result {
+    var nsRange = NSRange(location: 0, length: 0)
+    let result = (range != nil ? body(&nsRange) : body(nil))
+    range?.pointee = self._toRange(nsRange)
+    return result
+  }
+
+  //===--- Instance Methods/Properties-------------------------------------===//
+  //===--------------------------------------------------------------------===//
+
+  //===--- Omitted by agreement during API review 5/20/2014 ---------------===//
+  // @property BOOL boolValue;
+
+  // - (BOOL)canBeConvertedToEncoding:(NSStringEncoding)encoding
+
+  /// Returns a Boolean value that indicates whether the string can be
+  /// converted to the specified encoding without loss of information.
+  ///
+  /// - Parameter encoding: A string encoding.
+  /// - Returns: `true` if the string can be encoded in `encoding` without loss
+  ///   of information; otherwise, `false`.
+  public func canBeConverted(to encoding: String.Encoding) -> Bool {
+    return _ns.canBeConverted(to: encoding.rawValue)
+  }
+
+  // @property NSString* capitalizedString
+
+  /// A copy of the string with each word changed to its corresponding
+  /// capitalized spelling.
+  ///
+  /// This property performs the canonical (non-localized) mapping. It is
+  /// suitable for programming operations that require stable results not
+  /// depending on the current locale.
+  ///
+  /// A capitalized string is a string with the first character in each word
+  /// changed to its corresponding uppercase value, and all remaining
+  /// characters set to their corresponding lowercase values. A "word" is any
+  /// sequence of characters delimited by spaces, tabs, or line terminators.
+  /// Some common word delimiting punctuation isn't considered, so this
+  /// property may not generally produce the desired results for multiword
+  /// strings. See the `getLineStart(_:end:contentsEnd:for:)` method for
+  /// additional information.
+  ///
+  /// Case transformations aren’t guaranteed to be symmetrical or to produce
+  /// strings of the same lengths as the originals.
+  public var capitalized: String {
+    return _ns.capitalized
+  }
+
+  // @property (readonly, copy) NSString *localizedCapitalizedString NS_AVAILABLE(10_11, 9_0);
+
+  /// A capitalized representation of the string that is produced
+  /// using the current locale.
+  @available(macOS 10.11, iOS 9.0, *)
+  public var localizedCapitalized: String {
+    return _ns.localizedCapitalized
+  }
+
+  // - (NSString *)capitalizedStringWithLocale:(Locale *)locale
+
+  /// Returns a capitalized representation of the string
+  /// using the specified locale.
+  public func capitalized(with locale: Locale?) -> String {
+    return _ns.capitalized(with: locale)
+  }
+
+  // - (NSComparisonResult)caseInsensitiveCompare:(NSString *)aString
+
+  /// Returns the result of invoking `compare:options:` with
+  /// `NSCaseInsensitiveSearch` as the only option.
+  public func caseInsensitiveCompare<
+    T : StringProtocol
+  >(_ aString: T) -> ComparisonResult {
+    return _ns.caseInsensitiveCompare(aString._ephemeralString)
+  }
+
+  //===--- Omitted by agreement during API review 5/20/2014 ---------------===//
+  // - (unichar)characterAtIndex:(NSUInteger)index
+  //
+  // We have a different meaning for "Character" in Swift, and we are
+  // trying not to expose error-prone UTF-16 integer indexes
+
+  // - (NSString *)
+  //     commonPrefixWithString:(NSString *)aString
+  //     options:(StringCompareOptions)mask
+
+  /// Returns a string containing characters this string and the
+  /// given string have in common, starting from the beginning of each
+  /// up to the first characters that aren't equivalent.
+  public func commonPrefix<
+    T : StringProtocol
+  >(with aString: T, options: String.CompareOptions = []) -> String {
+    return _ns.commonPrefix(with: aString._ephemeralString, options: options)
+  }
+
+  // - (NSComparisonResult)
+  //     compare:(NSString *)aString
+  //
+  // - (NSComparisonResult)
+  //     compare:(NSString *)aString options:(StringCompareOptions)mask
+  //
+  // - (NSComparisonResult)
+  //     compare:(NSString *)aString options:(StringCompareOptions)mask
+  //     range:(NSRange)range
+  //
+  // - (NSComparisonResult)
+  //     compare:(NSString *)aString options:(StringCompareOptions)mask
+  //     range:(NSRange)range locale:(id)locale
+
+  /// Compares the string using the specified options and
+  /// returns the lexical ordering for the range.
+  public func compare<T : StringProtocol>(
+    _ aString: T,
+    options mask: String.CompareOptions = [],
+    range: Range<Index>? = nil,
+    locale: Locale? = nil
+  ) -> ComparisonResult {
+    // According to Ali Ozer, there may be some real advantage to
+    // dispatching to the minimal selector for the supplied options.
+    // So let's do that; the switch should compile away anyhow.
+    let aString = aString._ephemeralString
+    return locale != nil ? _ns.compare(
+      aString,
+      options: mask,
+      range: _toRelativeNSRange(
+        range ?? startIndex..<endIndex
+      ),
+      locale: locale?._bridgeToObjectiveC()
+    )
+
+    : range != nil ? _ns.compare(
+      aString,
+      options: mask,
+      range: _toRelativeNSRange(range!)
+    )
+
+    : !mask.isEmpty ? _ns.compare(aString, options: mask)
+
+    : _ns.compare(aString)
+  }
+
+  // - (NSUInteger)
+  //     completePathIntoString:(NSString **)outputName
+  //     caseSensitive:(BOOL)flag
+  //     matchesIntoArray:(NSArray **)outputArray
+  //     filterTypes:(NSArray *)filterTypes
+
+  /// Interprets the string as a path in the file system and
+  /// attempts to perform filename completion, returning a numeric
+  /// value that indicates whether a match was possible, and by
+  /// reference the longest path that matches the string.
+  ///
+  /// - Returns: The actual number of matching paths.
+  public func completePath(
+    into outputName: UnsafeMutablePointer<String>? = nil,
+    caseSensitive: Bool,
+    matchesInto outputArray: UnsafeMutablePointer<[String]>? = nil,
+    filterTypes: [String]? = nil
+  ) -> Int {
+#if DEPLOYMENT_RUNTIME_SWIFT
+    var outputNamePlaceholder: String?
+    var outputArrayPlaceholder = [String]()
+    let res = self._ns.completePath(
+        into: &outputNamePlaceholder,
+        caseSensitive: caseSensitive,
+        matchesInto: &outputArrayPlaceholder,
+        filterTypes: filterTypes
+    )
+    if let n = outputNamePlaceholder {
+        outputName?.pointee = n
+    } else {
+        outputName?.pointee = ""
+    }
+    outputArray?.pointee = outputArrayPlaceholder
+    return res
+#else // DEPLOYMENT_RUNTIME_SWIFT
+    var nsMatches: NSArray?
+    var nsOutputName: NSString?
+
+    let result: Int = outputName._withNilOrAddress(of: &nsOutputName) {
+      outputName in outputArray._withNilOrAddress(of: &nsMatches) {
+        outputArray in
+        // FIXME: completePath(...) is incorrectly annotated as requiring
+        // non-optional output parameters. rdar://problem/25494184
+        let outputNonOptionalName = unsafeBitCast(
+          outputName, to: AutoreleasingUnsafeMutablePointer<NSString?>.self)
+        let outputNonOptionalArray = unsafeBitCast(
+          outputArray, to: AutoreleasingUnsafeMutablePointer<NSArray?>.self)
+        return self._ns.completePath(
+          into: outputNonOptionalName,
+          caseSensitive: caseSensitive,
+          matchesInto: outputNonOptionalArray,
+          filterTypes: filterTypes
+        )
+      }
+    }
+
+    if let matches = nsMatches {
+      // Since this function is effectively a bridge thunk, use the
+      // bridge thunk semantics for the NSArray conversion
+      outputArray?.pointee = matches as! [String]
+    }
+
+    if let n = nsOutputName {
+      outputName?.pointee = n as String
+    }
+    return result
+#endif // DEPLOYMENT_RUNTIME_SWIFT
+  }
+
+  // - (NSArray *)
+  //     componentsSeparatedByCharactersInSet:(NSCharacterSet *)separator
+
+  /// Returns an array containing substrings from the string
+  /// that have been divided by characters in the given set.
+  public func components(separatedBy separator: CharacterSet) -> [String] {
+    return _ns.components(separatedBy: separator)
+  }
+
+  // - (NSArray *)componentsSeparatedByString:(NSString *)separator
+
+  /// Returns an array containing substrings from the string that have been
+  /// divided by the given separator.
+  ///
+  /// The substrings in the resulting array appear in the same order as the
+  /// original string. Adjacent occurrences of the separator string produce
+  /// empty strings in the result. Similarly, if the string begins or ends
+  /// with the separator, the first or last substring, respectively, is empty.
+  /// The following example shows this behavior:
+  ///
+  ///     let list1 = "Karin, Carrie, David"
+  ///     let items1 = list1.components(separatedBy: ", ")
+  ///     // ["Karin", "Carrie", "David"]
+  ///
+  ///     // Beginning with the separator:
+  ///     let list2 = ", Norman, Stanley, Fletcher"
+  ///     let items2 = list2.components(separatedBy: ", ")
+  ///     // ["", "Norman", "Stanley", "Fletcher"
+  ///
+  /// If the list has no separators, the array contains only the original
+  /// string itself.
+  ///
+  ///     let name = "Karin"
+  ///     let list = name.components(separatedBy: ", ")
+  ///     // ["Karin"]
+  ///
+  /// - Parameter separator: The separator string.
+  /// - Returns: An array containing substrings that have been divided from the
+  ///   string using `separator`.
+  // FIXME(strings): now when String conforms to Collection, this can be
+  //   replaced by split(separator:maxSplits:omittingEmptySubsequences:)
+  public func components<
+    T : StringProtocol
+  >(separatedBy separator: T) -> [String] {
+    return _ns.components(separatedBy: separator._ephemeralString)
+  }
+
+  // - (const char *)cStringUsingEncoding:(NSStringEncoding)encoding
+
+  /// Returns a representation of the string as a C string
+  /// using a given encoding.
+  public func cString(using encoding: String.Encoding) -> [CChar]? {
+    return withExtendedLifetime(_ns) {
+      (s: NSString) -> [CChar]? in
+      _persistCString(s.cString(using: encoding.rawValue))
+    }
+  }
+
+  // - (NSData *)dataUsingEncoding:(NSStringEncoding)encoding
+  //
+  // - (NSData *)
+  //     dataUsingEncoding:(NSStringEncoding)encoding
+  //     allowLossyConversion:(BOOL)flag
+
+  /// Returns a `Data` containing a representation of
+  /// the `String` encoded using a given encoding.
+  public func data(
+    using encoding: String.Encoding,
+    allowLossyConversion: Bool = false
+  ) -> Data? {
+    switch encoding {
+    case .utf8:
+      return Data(self.utf8)
+    default:
+      return _ns.data(
+        using: encoding.rawValue,
+        allowLossyConversion: allowLossyConversion)
+    }
+  }
+
+  // @property NSString* decomposedStringWithCanonicalMapping;
+
+  /// A string created by normalizing the string's contents using Form D.
+  public var decomposedStringWithCanonicalMapping: String {
+    return _ns.decomposedStringWithCanonicalMapping
+  }
+
+  // @property NSString* decomposedStringWithCompatibilityMapping;
+
+  /// A string created by normalizing the string's contents using Form KD.
+  public var decomposedStringWithCompatibilityMapping: String {
+    return _ns.decomposedStringWithCompatibilityMapping
+  }
+
+  //===--- Importing Foundation should not affect String printing ---------===//
+  // Therefore, we're not exposing this:
+  //
+  //   @property NSString* description
+
+
+  //===--- Omitted for consistency with API review results 5/20/2014 -----===//
+  // @property double doubleValue;
+
+  // - (void)
+  //     enumerateLinesUsing:(void (^)(NSString *line, BOOL *stop))block
+
+  /// Enumerates all the lines in a string.
+  public func enumerateLines(
+    invoking body: @escaping (_ line: String, _ stop: inout Bool) -> Void
+  ) {
+    _ns.enumerateLines {
+      (line: String, stop: UnsafeMutablePointer<ObjCBool>)
+    in
+      var stop_ = false
+      body(line, &stop_)
+      if stop_ {
+        stop.pointee = true
+      }
+    }
+  }
+
+  // @property NSStringEncoding fastestEncoding;
+
+  /// The fastest encoding to which the string can be converted without loss
+  /// of information.
+  public var fastestEncoding: String.Encoding {
+    return String.Encoding(rawValue: _ns.fastestEncoding)
+  }
+
+  // - (BOOL)
+  //     getCString:(char *)buffer
+  //     maxLength:(NSUInteger)maxBufferCount
+  //     encoding:(NSStringEncoding)encoding
+
+  /// Converts the `String`'s content to a given encoding and
+  /// stores them in a buffer.
+  /// - Note: will store a maximum of `min(buffer.count, maxLength)` bytes.
+  public func getCString(
+    _ buffer: inout [CChar], maxLength: Int, encoding: String.Encoding
+  ) -> Bool {
+    return _ns.getCString(&buffer,
+                          maxLength: Swift.min(buffer.count, maxLength),
+                          encoding: encoding.rawValue)
+  }
+
+  // - (NSUInteger)hash
+
+  /// An unsigned integer that can be used as a hash table address.
+  public var hash: Int {
+    return _ns.hash
+  }
+
+  // - (NSUInteger)lengthOfBytesUsingEncoding:(NSStringEncoding)enc
+
+  /// Returns the number of bytes required to store the
+  /// `String` in a given encoding.
+  public func lengthOfBytes(using encoding: String.Encoding) -> Int {
+    return _ns.lengthOfBytes(using: encoding.rawValue)
+  }
+
+  // - (NSComparisonResult)localizedCaseInsensitiveCompare:(NSString *)aString
+
+  /// Compares the string and the given string using a case-insensitive,
+  /// localized, comparison.
+  public
+  func localizedCaseInsensitiveCompare<
+    T : StringProtocol
+  >(_ aString: T) -> ComparisonResult {
+    return _ns.localizedCaseInsensitiveCompare(aString._ephemeralString)
+  }
+
+  // - (NSComparisonResult)localizedCompare:(NSString *)aString
+
+  /// Compares the string and the given string using a localized comparison.
+  public func localizedCompare<
+    T : StringProtocol
+  >(_ aString: T) -> ComparisonResult {
+    return _ns.localizedCompare(aString._ephemeralString)
+  }
+
+  /// Compares the string and the given string as sorted by the Finder.
+  public func localizedStandardCompare<
+    T : StringProtocol
+  >(_ string: T) -> ComparisonResult {
+    return _ns.localizedStandardCompare(string._ephemeralString)
+  }
+
+  //===--- Omitted for consistency with API review results 5/20/2014 ------===//
+  // @property long long longLongValue
+
+  // @property (readonly, copy) NSString *localizedLowercase NS_AVAILABLE(10_11, 9_0);
+
+  /// A lowercase version of the string that is produced using the current
+  /// locale.
+  @available(macOS 10.11, iOS 9.0, *)
+  public var localizedLowercase: String {
+    return _ns.localizedLowercase
+  }
+
+  // - (NSString *)lowercaseStringWithLocale:(Locale *)locale
+
+  /// Returns a version of the string with all letters
+  /// converted to lowercase, taking into account the specified
+  /// locale.
+  public func lowercased(with locale: Locale?) -> String {
+    return _ns.lowercased(with: locale)
+  }
+
+  // - (NSUInteger)maximumLengthOfBytesUsingEncoding:(NSStringEncoding)enc
+
+  /// Returns the maximum number of bytes needed to store the
+  /// `String` in a given encoding.
+  public
+  func maximumLengthOfBytes(using encoding: String.Encoding) -> Int {
+    return _ns.maximumLengthOfBytes(using: encoding.rawValue)
+  }
+
+  // @property NSString* precomposedStringWithCanonicalMapping;
+
+  /// A string created by normalizing the string's contents using Form C.
+  public var precomposedStringWithCanonicalMapping: String {
+    return _ns.precomposedStringWithCanonicalMapping
+  }
+
+  // @property NSString * precomposedStringWithCompatibilityMapping;
+
+  /// A string created by normalizing the string's contents using Form KC.
+  public var precomposedStringWithCompatibilityMapping: String {
+    return _ns.precomposedStringWithCompatibilityMapping
+  }
+
+#if !DEPLOYMENT_RUNTIME_SWIFT
+  // - (id)propertyList
+
+  /// Parses the `String` as a text representation of a
+  /// property list, returning an NSString, NSData, NSArray, or
+  /// NSDictionary object, according to the topmost element.
+  public func propertyList() -> Any {
+    return _ns.propertyList()
+  }
+
+  // - (NSDictionary *)propertyListFromStringsFileFormat
+
+  /// Returns a dictionary object initialized with the keys and
+  /// values found in the `String`.
+  public func propertyListFromStringsFileFormat() -> [String : String] {
+    return _ns.propertyListFromStringsFileFormat() as! [String : String]? ?? [:]
+  }
+#endif
+
+  // - (BOOL)localizedStandardContainsString:(NSString *)str NS_AVAILABLE(10_11, 9_0);
+
+  /// Returns a Boolean value indicating whether the string contains the given
+  /// string, taking the current locale into account.
+  ///
+  /// This is the most appropriate method for doing user-level string searches,
+  /// similar to how searches are done generally in the system.  The search is
+  /// locale-aware, case and diacritic insensitive.  The exact list of search
+  /// options applied may change over time.
+  @available(macOS 10.11, iOS 9.0, *)
+  public func localizedStandardContains<
+    T : StringProtocol
+  >(_ string: T) -> Bool {
+    return _ns.localizedStandardContains(string._ephemeralString)
+  }
+
+  // @property NSStringEncoding smallestEncoding;
+
+  /// The smallest encoding to which the string can be converted without
+  /// loss of information.
+  public var smallestEncoding: String.Encoding {
+    return String.Encoding(rawValue: _ns.smallestEncoding)
+  }
+
+  // - (NSString *)
+  //     stringByAddingPercentEncodingWithAllowedCharacters:
+  //       (NSCharacterSet *)allowedCharacters
+
+  /// Returns a new string created by replacing all characters in the string
+  /// not in the specified set with percent encoded characters.
+  public func addingPercentEncoding(
+    withAllowedCharacters allowedCharacters: CharacterSet
+  ) -> String? {
+    // FIXME: the documentation states that this method can return nil if the
+    // transformation is not possible, without going into further details.  The
+    // implementation can only return nil if malloc() returns nil, so in
+    // practice this is not possible.  Still, to be consistent with
+    // documentation, we declare the method as returning an optional String.
+    //
+    // <rdar://problem/17901698> Docs for -[NSString
+    // stringByAddingPercentEncodingWithAllowedCharacters] don't precisely
+    // describe when return value is nil
+    return _ns.addingPercentEncoding(withAllowedCharacters:
+      allowedCharacters
+    )
+  }
+
+  // - (NSString *)stringByAppendingFormat:(NSString *)format, ...
+
+  /// Returns a string created by appending a string constructed from a given
+  /// format string and the following arguments.
+  public func appendingFormat<
+    T : StringProtocol
+  >(
+    _ format: T, _ arguments: CVarArg...
+  ) -> String {
+    return _ns.appending(
+      String(format: format._ephemeralString, arguments: arguments))
+  }
+
+  // - (NSString *)stringByAppendingString:(NSString *)aString
+
+  /// Returns a new string created by appending the given string.
+  // FIXME(strings): shouldn't it be deprecated in favor of `+`?
+  public func appending<
+    T : StringProtocol
+  >(_ aString: T) -> String {
+    return _ns.appending(aString._ephemeralString)
+  }
+
+  /// Returns a string with the given character folding options
+  /// applied.
+  public func folding(
+    options: String.CompareOptions = [], locale: Locale?
+  ) -> String {
+    return _ns.folding(options: options, locale: locale)
+  }
+
+  // - (NSString *)stringByPaddingToLength:(NSUInteger)newLength
+  //     withString:(NSString *)padString
+  //     startingAtIndex:(NSUInteger)padIndex
+
+  /// Returns a new string formed from the `String` by either
+  /// removing characters from the end, or by appending as many
+  /// occurrences as necessary of a given pad string.
+  public func padding<
+    T : StringProtocol
+  >(
+    toLength newLength: Int,
+    withPad padString: T,
+    startingAt padIndex: Int
+  ) -> String {
+    return _ns.padding(
+      toLength: newLength,
+      withPad: padString._ephemeralString,
+      startingAt: padIndex)
+  }
+
+  // @property NSString* stringByRemovingPercentEncoding;
+
+  /// A new string made from the string by replacing all percent encoded
+  /// sequences with the matching UTF-8 characters.
+  public var removingPercentEncoding: String? {
+    return _ns.removingPercentEncoding
+  }
+
+  // - (NSString *)
+  //     stringByReplacingCharactersInRange:(NSRange)range
+  //     withString:(NSString *)replacement
+
+  /// Returns a new string in which the characters in a
+  /// specified range of the `String` are replaced by a given string.
+  public func replacingCharacters<
+    T : StringProtocol, R : RangeExpression
+  >(in range: R, with replacement: T) -> String where R.Bound == Index {
+    return _ns.replacingCharacters(
+      in: _toRelativeNSRange(range.relative(to: self)),
+      with: replacement._ephemeralString)
+  }
+
+  // - (NSString *)
+  //     stringByReplacingOccurrencesOfString:(NSString *)target
+  //     withString:(NSString *)replacement
+  //
+  // - (NSString *)
+  //     stringByReplacingOccurrencesOfString:(NSString *)target
+  //     withString:(NSString *)replacement
+  //     options:(StringCompareOptions)options
+  //     range:(NSRange)searchRange
+
+  /// Returns a new string in which all occurrences of a target
+  /// string in a specified range of the string are replaced by
+  /// another given string.
+  public func replacingOccurrences<
+    Target : StringProtocol,
+    Replacement : StringProtocol
+  >(
+    of target: Target,
+    with replacement: Replacement,
+    options: String.CompareOptions = [],
+    range searchRange: Range<Index>? = nil
+  ) -> String {
+    let target = target._ephemeralString
+    let replacement = replacement._ephemeralString
+    return (searchRange != nil) || (!options.isEmpty)
+    ? _ns.replacingOccurrences(
+      of: target,
+      with: replacement,
+      options: options,
+      range: _toRelativeNSRange(
+        searchRange ?? startIndex..<endIndex
+      )
+    )
+    : _ns.replacingOccurrences(of: target, with: replacement)
+  }
+
+#if !DEPLOYMENT_RUNTIME_SWIFT
+  // - (NSString *)
+  //     stringByReplacingPercentEscapesUsingEncoding:(NSStringEncoding)encoding
+
+  /// Returns a new string made by replacing in the `String`
+  /// all percent escapes with the matching characters as determined
+  /// by a given encoding.
+  @available(swift, deprecated: 3.0, obsoleted: 4.0,
+    message: "Use removingPercentEncoding instead, which always uses the recommended UTF-8 encoding.")
+  public func replacingPercentEscapes(
+    using encoding: String.Encoding
+  ) -> String? {
+    return _ns.replacingPercentEscapes(using: encoding.rawValue)
+  }
+#endif
+
+  // - (NSString *)stringByTrimmingCharactersInSet:(NSCharacterSet *)set
+
+  /// Returns a new string made by removing from both ends of
+  /// the `String` characters contained in a given character set.
+  public func trimmingCharacters(in set: CharacterSet) -> String {
+    return _ns.trimmingCharacters(in: set)
+  }
+
+  // @property (readonly, copy) NSString *localizedUppercaseString NS_AVAILABLE(10_11, 9_0);
+
+  /// An uppercase version of the string that is produced using the current
+  /// locale.
+  @available(macOS 10.11, iOS 9.0, *)
+  public var localizedUppercase: String {
+    return _ns.localizedUppercase
+  }
+
+  // - (NSString *)uppercaseStringWithLocale:(Locale *)locale
+
+  /// Returns a version of the string with all letters
+  /// converted to uppercase, taking into account the specified
+  /// locale.
+  public func uppercased(with locale: Locale?) -> String {
+    return _ns.uppercased(with: locale)
+  }
+
+  //===--- Omitted due to redundancy with "utf8" property -----------------===//
+  // - (const char *)UTF8String
+
+  // - (BOOL)
+  //     writeToFile:(NSString *)path
+  //     atomically:(BOOL)useAuxiliaryFile
+  //     encoding:(NSStringEncoding)enc
+  //     error:(NSError **)error
+
+  /// Writes the contents of the `String` to a file at a given
+  /// path using a given encoding.
+  public func write<
+    T : StringProtocol
+  >(
+    toFile path: T, atomically useAuxiliaryFile: Bool,
+    encoding enc: String.Encoding
+  ) throws {
+    try _ns.write(
+      toFile: path._ephemeralString,
+      atomically: useAuxiliaryFile,
+      encoding: enc.rawValue)
+  }
+
+  // - (BOOL)
+  //     writeToURL:(NSURL *)url
+  //     atomically:(BOOL)useAuxiliaryFile
+  //     encoding:(NSStringEncoding)enc
+  //     error:(NSError **)error
+
+  /// Writes the contents of the `String` to the URL specified
+  /// by url using the specified encoding.
+  public func write(
+    to url: URL, atomically useAuxiliaryFile: Bool,
+    encoding enc: String.Encoding
+  ) throws {
+    try _ns.write(
+      to: url, atomically: useAuxiliaryFile, encoding: enc.rawValue)
+  }
+
+  // - (nullable NSString *)stringByApplyingTransform:(NSString *)transform reverse:(BOOL)reverse NS_AVAILABLE(10_11, 9_0);
+
+#if !DEPLOYMENT_RUNTIME_SWIFT
+  /// Perform string transliteration.
+  @available(macOS 10.11, iOS 9.0, *)
+  public func applyingTransform(
+    _ transform: StringTransform, reverse: Bool
+  ) -> String? {
+    return _ns.applyingTransform(transform, reverse: reverse)
+  }
+
+  // - (void)
+  //     enumerateLinguisticTagsInRange:(NSRange)range
+  //     scheme:(NSString *)tagScheme
+  //     options:(LinguisticTaggerOptions)opts
+  //     orthography:(Orthography *)orthography
+  //     usingBlock:(
+  //       void (^)(
+  //         NSString *tag, NSRange tokenRange,
+  //         NSRange sentenceRange, BOOL *stop)
+  //       )block
+
+  /// Performs linguistic analysis on the specified string by
+  /// enumerating the specific range of the string, providing the
+  /// Block with the located tags.
+  public func enumerateLinguisticTags<
+    T : StringProtocol, R : RangeExpression
+  >(
+    in range: R,
+    scheme tagScheme: T,
+    options opts: NSLinguisticTagger.Options = [],
+    orthography: NSOrthography? = nil,
+    invoking body:
+      (String, Range<Index>, Range<Index>, inout Bool) -> Void
+  ) where R.Bound == Index {
+    let range = range.relative(to: self)
+    _ns.enumerateLinguisticTags(
+      in: _toRelativeNSRange(range),
+      scheme: NSLinguisticTagScheme(rawValue: tagScheme._ephemeralString),
+      options: opts,
+      orthography: orthography
+    ) {
+      var stop_ = false
+      body($0!.rawValue, self._toRange($1), self._toRange($2), &stop_)
+      if stop_ {
+        $3.pointee = true
+      }
+    }
+  }
+#endif
+
+  // - (void)
+  //     enumerateSubstringsInRange:(NSRange)range
+  //     options:(NSStringEnumerationOptions)opts
+  //     usingBlock:(
+  //       void (^)(
+  //         NSString *substring,
+  //         NSRange substringRange,
+  //         NSRange enclosingRange,
+  //         BOOL *stop)
+  //       )block
+
+  /// Enumerates the substrings of the specified type in the specified range of
+  /// the string.
+  ///
+  /// Mutation of a string value while enumerating its substrings is not
+  /// supported. If you need to mutate a string from within `body`, convert
+  /// your string to an `NSMutableString` instance and then call the
+  /// `enumerateSubstrings(in:options:using:)` method.
+  ///
+  /// - Parameters:
+  ///   - range: The range within the string to enumerate substrings.
+  ///   - opts: Options specifying types of substrings and enumeration styles.
+  ///     If `opts` is omitted or empty, `body` is called a single time with
+  ///     the range of the string specified by `range`.
+  ///   - body: The closure executed for each substring in the enumeration. The
+  ///     closure takes four arguments:
+  ///     - The enumerated substring. If `substringNotRequired` is included in
+  ///       `opts`, this parameter is `nil` for every execution of the
+  ///       closure.
+  ///     - The range of the enumerated substring in the string that
+  ///       `enumerate(in:options:_:)` was called on.
+  ///     - The range that includes the substring as well as any separator or
+  ///       filler characters that follow. For instance, for lines,
+  ///       `enclosingRange` contains the line terminators. The enclosing
+  ///       range for the first string enumerated also contains any characters
+  ///       that occur before the string. Consecutive enclosing ranges are
+  ///       guaranteed not to overlap, and every single character in the
+  ///       enumerated range is included in one and only one enclosing range.
+  ///     - An `inout` Boolean value that the closure can use to stop the
+  ///       enumeration by setting `stop = true`.
+  public func enumerateSubstrings<
+    R : RangeExpression
+  >(
+    in range: R,
+    options opts: String.EnumerationOptions = [],
+    _ body: @escaping (
+      _ substring: String?, _ substringRange: Range<Index>,
+      _ enclosingRange: Range<Index>, inout Bool
+    ) -> Void
+  ) where R.Bound == Index {
+    _ns.enumerateSubstrings(
+      in: _toRelativeNSRange(range.relative(to: self)), options: opts) {
+      var stop_ = false
+
+      body($0,
+        self._toRange($1),
+        self._toRange($2),
+        &stop_)
+
+      if stop_ {
+        UnsafeMutablePointer($3).pointee = true
+      }
+    }
+  }
+
+  //===--- Omitted for consistency with API review results 5/20/2014 ------===//
+  // @property float floatValue;
+
+  // - (BOOL)
+  //     getBytes:(void *)buffer
+  //     maxLength:(NSUInteger)maxBufferCount
+  //     usedLength:(NSUInteger*)usedBufferCount
+  //     encoding:(NSStringEncoding)encoding
+  //     options:(StringEncodingConversionOptions)options
+  //     range:(NSRange)range
+  //     remainingRange:(NSRangePointer)leftover
+
+  /// Writes the given `range` of characters into `buffer` in a given
+  /// `encoding`, without any allocations.  Does not NULL-terminate.
+  ///
+  /// - Parameter buffer: A buffer into which to store the bytes from
+  ///   the receiver. The returned bytes are not NUL-terminated.
+  ///
+  /// - Parameter maxBufferCount: The maximum number of bytes to write
+  ///   to buffer.
+  ///
+  /// - Parameter usedBufferCount: The number of bytes used from
+  ///   buffer. Pass `nil` if you do not need this value.
+  ///
+  /// - Parameter encoding: The encoding to use for the returned bytes.
+  ///
+  /// - Parameter options: A mask to specify options to use for
+  ///   converting the receiver's contents to `encoding` (if conversion
+  ///   is necessary).
+  ///
+  /// - Parameter range: The range of characters in the receiver to get.
+  ///
+  /// - Parameter leftover: The remaining range. Pass `nil` If you do
+  ///   not need this value.
+  ///
+  /// - Returns: `true` if some characters were converted, `false` otherwise.
+  ///
+  /// - Note: Conversion stops when the buffer fills or when the
+  ///   conversion isn't possible due to the chosen encoding.
+  ///
+  /// - Note: will get a maximum of `min(buffer.count, maxLength)` bytes.
+  public func getBytes<
+    R : RangeExpression
+  >(
+    _ buffer: inout [UInt8],
+    maxLength maxBufferCount: Int,
+    usedLength usedBufferCount: UnsafeMutablePointer<Int>,
+    encoding: String.Encoding,
+    options: String.EncodingConversionOptions = [],
+    range: R,
+    remaining leftover: UnsafeMutablePointer<Range<Index>>
+  ) -> Bool where R.Bound == Index {
+    return _withOptionalOutParameter(leftover) {
+      self._ns.getBytes(
+        &buffer,
+        maxLength: Swift.min(buffer.count, maxBufferCount),
+        usedLength: usedBufferCount,
+        encoding: encoding.rawValue,
+        options: options,
+        range: _toRelativeNSRange(range.relative(to: self)),
+        remaining: $0)
+    }
+  }
+
+  // - (void)
+  //     getLineStart:(NSUInteger *)startIndex
+  //     end:(NSUInteger *)lineEndIndex
+  //     contentsEnd:(NSUInteger *)contentsEndIndex
+  //     forRange:(NSRange)aRange
+
+  /// Returns by reference the beginning of the first line and
+  /// the end of the last line touched by the given range.
+  public func getLineStart<
+    R : RangeExpression
+  >(
+    _ start: UnsafeMutablePointer<Index>,
+    end: UnsafeMutablePointer<Index>,
+    contentsEnd: UnsafeMutablePointer<Index>,
+    for range: R
+  ) where R.Bound == Index {
+    _withOptionalOutParameter(start) {
+      start in self._withOptionalOutParameter(end) {
+        end in self._withOptionalOutParameter(contentsEnd) {
+          contentsEnd in self._ns.getLineStart(
+            start, end: end,
+            contentsEnd: contentsEnd,
+            for: _toRelativeNSRange(range.relative(to: self)))
+        }
+      }
+    }
+  }
+
+  // - (void)
+  //     getParagraphStart:(NSUInteger *)startIndex
+  //     end:(NSUInteger *)endIndex
+  //     contentsEnd:(NSUInteger *)contentsEndIndex
+  //     forRange:(NSRange)aRange
+
+  /// Returns by reference the beginning of the first paragraph
+  /// and the end of the last paragraph touched by the given range.
+  public func getParagraphStart<
+    R : RangeExpression
+  >(
+    _ start: UnsafeMutablePointer<Index>,
+    end: UnsafeMutablePointer<Index>,
+    contentsEnd: UnsafeMutablePointer<Index>,
+    for range: R
+  ) where R.Bound == Index {
+    _withOptionalOutParameter(start) {
+      start in self._withOptionalOutParameter(end) {
+        end in self._withOptionalOutParameter(contentsEnd) {
+          contentsEnd in self._ns.getParagraphStart(
+            start, end: end,
+            contentsEnd: contentsEnd,
+            for: _toRelativeNSRange(range.relative(to: self)))
+        }
+      }
+    }
+  }
+
+  //===--- Already provided by core Swift ---------------------------------===//
+  // - (instancetype)initWithString:(NSString *)aString
+
+  //===--- Initializers that can fail dropped for factory functions -------===//
+  // - (instancetype)initWithUTF8String:(const char *)bytes
+
+  //===--- Omitted for consistency with API review results 5/20/2014 ------===//
+  // @property NSInteger integerValue;
+  // @property Int intValue;
+
+  //===--- Omitted by apparent agreement during API review 5/20/2014 ------===//
+  // @property BOOL absolutePath;
+  // - (BOOL)isEqualToString:(NSString *)aString
+
+  // - (NSRange)lineRangeForRange:(NSRange)aRange
+
+  /// Returns the range of characters representing the line or lines
+  /// containing a given range.
+  public func lineRange<
+    R : RangeExpression
+  >(for aRange: R) -> Range<Index> where R.Bound == Index {
+    return _toRange(_ns.lineRange(
+      for: _toRelativeNSRange(aRange.relative(to: self))))
+  }
+
+#if !DEPLOYMENT_RUNTIME_SWIFT
+  // - (NSArray *)
+  //     linguisticTagsInRange:(NSRange)range
+  //     scheme:(NSString *)tagScheme
+  //     options:(LinguisticTaggerOptions)opts
+  //     orthography:(Orthography *)orthography
+  //     tokenRanges:(NSArray**)tokenRanges
+
+  /// Returns an array of linguistic tags for the specified
+  /// range and requested tags within the receiving string.
+  public func linguisticTags<
+    T : StringProtocol, R : RangeExpression
+  >(
+    in range: R,
+    scheme tagScheme: T,
+    options opts: NSLinguisticTagger.Options = [],
+    orthography: NSOrthography? = nil,
+    tokenRanges: UnsafeMutablePointer<[Range<Index>]>? = nil // FIXME:Can this be nil?
+  ) -> [String] where R.Bound == Index {
+    var nsTokenRanges: NSArray?
+    let result = tokenRanges._withNilOrAddress(of: &nsTokenRanges) {
+      self._ns.linguisticTags(
+        in: _toRelativeNSRange(range.relative(to: self)),
+        scheme: NSLinguisticTagScheme(rawValue: tagScheme._ephemeralString),
+        options: opts,
+        orthography: orthography,
+        tokenRanges: $0) as NSArray
+    }
+
+    if let nsTokenRanges = nsTokenRanges {
+      tokenRanges?.pointee = (nsTokenRanges as [AnyObject]).map {
+        self._toRange($0.rangeValue)
+      }
+    }
+
+    return result as! [String]
+  }
+
+  // - (NSRange)paragraphRangeForRange:(NSRange)aRange
+
+  /// Returns the range of characters representing the
+  /// paragraph or paragraphs containing a given range.
+  public func paragraphRange<
+    R : RangeExpression
+  >(for aRange: R) -> Range<Index> where R.Bound == Index {
+    return _toRange(
+      _ns.paragraphRange(for: _toRelativeNSRange(aRange.relative(to: self))))
+  }
+#endif
+
+  // - (NSRange)rangeOfCharacterFromSet:(NSCharacterSet *)aSet
+  //
+  // - (NSRange)
+  //     rangeOfCharacterFromSet:(NSCharacterSet *)aSet
+  //     options:(StringCompareOptions)mask
+  //
+  // - (NSRange)
+  //     rangeOfCharacterFromSet:(NSCharacterSet *)aSet
+  //     options:(StringCompareOptions)mask
+  //     range:(NSRange)aRange
+
+  /// Finds and returns the range in the `String` of the first
+  /// character from a given character set found in a given range with
+  /// given options.
+  public func rangeOfCharacter(
+    from aSet: CharacterSet,
+    options mask: String.CompareOptions = [],
+    range aRange: Range<Index>? = nil
+  ) -> Range<Index>? {
+    return _optionalRange(
+      _ns.rangeOfCharacter(
+        from: aSet,
+        options: mask,
+        range: _toRelativeNSRange(
+          aRange ?? startIndex..<endIndex
+        )
+      )
+    )
+  }
+
+  // - (NSRange)rangeOfComposedCharacterSequenceAtIndex:(NSUInteger)anIndex
+
+  /// Returns the range in the `String` of the composed
+  /// character sequence located at a given index.
+  public
+  func rangeOfComposedCharacterSequence(at anIndex: Index) -> Range<Index> {
+    return _toRange(
+      _ns.rangeOfComposedCharacterSequence(at: _toOffset(anIndex)))
+  }
+
+  // - (NSRange)rangeOfComposedCharacterSequencesForRange:(NSRange)range
+
+  /// Returns the range in the string of the composed character
+  /// sequences for a given range.
+  public func rangeOfComposedCharacterSequences<
+    R : RangeExpression
+  >(
+    for range: R
+  ) -> Range<Index> where R.Bound == Index {
+    // Theoretically, this will be the identity function.  In practice
+    // I think users will be able to observe differences in the input
+    // and output ranges due (if nothing else) to locale changes
+    return _toRange(
+      _ns.rangeOfComposedCharacterSequences(
+        for: _toRelativeNSRange(range.relative(to: self))))
+  }
+
+  // - (NSRange)rangeOfString:(NSString *)aString
+  //
+  // - (NSRange)
+  //     rangeOfString:(NSString *)aString options:(StringCompareOptions)mask
+  //
+  // - (NSRange)
+  //     rangeOfString:(NSString *)aString
+  //     options:(StringCompareOptions)mask
+  //     range:(NSRange)aRange
+  //
+  // - (NSRange)
+  //     rangeOfString:(NSString *)aString
+  //     options:(StringCompareOptions)mask
+  //     range:(NSRange)searchRange
+  //     locale:(Locale *)locale
+
+  /// Finds and returns the range of the first occurrence of a
+  /// given string within a given range of the `String`, subject to
+  /// given options, using the specified locale, if any.
+  public func range<
+    T : StringProtocol
+  >(
+    of aString: T,
+    options mask: String.CompareOptions = [],
+    range searchRange: Range<Index>? = nil,
+    locale: Locale? = nil
+  ) -> Range<Index>? {
+    let aString = aString._ephemeralString
+    return _optionalRange(
+      locale != nil ? _ns.range(
+        of: aString,
+        options: mask,
+        range: _toRelativeNSRange(
+          searchRange ?? startIndex..<endIndex
+        ),
+        locale: locale
+      )
+      : searchRange != nil ? _ns.range(
+        of: aString, options: mask, range: _toRelativeNSRange(searchRange!)
+      )
+      : !mask.isEmpty ? _ns.range(of: aString, options: mask)
+      : _ns.range(of: aString)
+    )
+  }
+
+  // - (NSRange)localizedStandardRangeOfString:(NSString *)str NS_AVAILABLE(10_11, 9_0);
+
+  /// Finds and returns the range of the first occurrence of a given string,
+  /// taking the current locale into account.  Returns `nil` if the string was
+  /// not found.
+  ///
+  /// This is the most appropriate method for doing user-level string searches,
+  /// similar to how searches are done generally in the system.  The search is
+  /// locale-aware, case and diacritic insensitive.  The exact list of search
+  /// options applied may change over time.
+  @available(macOS 10.11, iOS 9.0, *)
+  public func localizedStandardRange<
+    T : StringProtocol
+  >(of string: T) -> Range<Index>? {
+    return _optionalRange(
+      _ns.localizedStandardRange(of: string._ephemeralString))
+  }
+
+#if !DEPLOYMENT_RUNTIME_SWIFT
+  // - (NSString *)
+  //     stringByAddingPercentEscapesUsingEncoding:(NSStringEncoding)encoding
+
+  /// Returns a representation of the `String` using a given
+  /// encoding to determine the percent escapes necessary to convert
+  /// the `String` into a legal URL string.
+  @available(swift, deprecated: 3.0, obsoleted: 4.0,
+    message: "Use addingPercentEncoding(withAllowedCharacters:) instead, which always uses the recommended UTF-8 encoding, and which encodes for a specific URL component or subcomponent since each URL component or subcomponent has different rules for what characters are valid.")
+  public func addingPercentEscapes(
+    using encoding: String.Encoding
+  ) -> String? {
+    return _ns.addingPercentEscapes(using: encoding.rawValue)
+  }
+#endif
+
+  //===--- From the 10.10 release notes; not in public documentation ------===//
+  // No need to make these unavailable on earlier OSes, since they can
+  // forward trivially to rangeOfString.
+
+  /// Returns `true` if `other` is non-empty and contained within `self` by
+  /// case-sensitive, non-literal search. Otherwise, returns `false`.
+  ///
+  /// Equivalent to `self.range(of: other) != nil`
+  public func contains<T : StringProtocol>(_ other: T) -> Bool {
+    let r = self.range(of: other) != nil
+    if #available(macOS 10.10, iOS 8.0, *) {
+      assert(r == _ns.contains(other._ephemeralString))
+    }
+    return r
+  }
+
+  /// Returns a Boolean value indicating whether the given string is non-empty
+  /// and contained within this string by case-insensitive, non-literal
+  /// search, taking into account the current locale.
+  ///
+  /// Locale-independent case-insensitive operation, and other needs, can be
+  /// achieved by calling `range(of:options:range:locale:)`.
+  ///
+  /// Equivalent to:
+  ///
+  ///     range(of: other, options: .caseInsensitiveSearch,
+  ///           locale: Locale.current) != nil
+  public func localizedCaseInsensitiveContains<
+    T : StringProtocol
+  >(_ other: T) -> Bool {
+    let r = self.range(
+      of: other, options: .caseInsensitive, locale: Locale.current
+    ) != nil
+    if #available(macOS 10.10, iOS 8.0, *) {
+      assert(r ==
+        _ns.localizedCaseInsensitiveContains(other._ephemeralString))
+    }
+    return r
+  }
+}
+
+// Deprecated slicing
+extension StringProtocol where Index == String.Index {
+  // - (NSString *)substringFromIndex:(NSUInteger)anIndex
+
+  /// Returns a new string containing the characters of the
+  /// `String` from the one at a given index to the end.
+  @available(swift, deprecated: 4.0,
+    message: "Please use String slicing subscript with a 'partial range from' operator.")
+  public func substring(from index: Index) -> String {
+    return _ns.substring(from: _toOffset(index))
+  }
+
+  // - (NSString *)substringToIndex:(NSUInteger)anIndex
+
+  /// Returns a new string containing the characters of the
+  /// `String` up to, but not including, the one at a given index.
+  @available(swift, deprecated: 4.0,
+    message: "Please use String slicing subscript with a 'partial range upto' operator.")
+  public func substring(to index: Index) -> String {
+    return _ns.substring(to: _toOffset(index))
+  }
+
+  // - (NSString *)substringWithRange:(NSRange)aRange
+
+  /// Returns a string object containing the characters of the
+  /// `String` that lie within a given range.
+  @available(swift, deprecated: 4.0,
+    message: "Please use String slicing subscript.")
+  public func substring(with aRange: Range<Index>) -> String {
+    return _ns.substring(with: _toRelativeNSRange(aRange))
+  }
+}
+
+extension StringProtocol {
+  // - (const char *)fileSystemRepresentation
+
+  /// Returns a file system-specific representation of the `String`.
+  @available(*, unavailable, message: "Use getFileSystemRepresentation on URL instead.")
+  public var fileSystemRepresentation: [CChar] {
+    fatalError("unavailable function can't be called")
+  }
+
+  // - (BOOL)
+  //     getFileSystemRepresentation:(char *)buffer
+  //     maxLength:(NSUInteger)maxLength
+
+  /// Interprets the `String` as a system-independent path and
+  /// fills a buffer with a C-string in a format and encoding suitable
+  /// for use with file-system calls.
+  /// - Note: will store a maximum of `min(buffer.count, maxLength)` bytes.
+  @available(*, unavailable, message: "Use getFileSystemRepresentation on URL instead.")
+  public func getFileSystemRepresentation(
+    _ buffer: inout [CChar], maxLength: Int) -> Bool {
+    fatalError("unavailable function can't be called")
+  }
+
+  //===--- Kept for consistency with API review results 5/20/2014 ---------===//
+  // We decided to keep pathWithComponents, so keeping this too
+  // @property NSString lastPathComponent;
+
+  /// Returns the last path component of the `String`.
+  @available(*, unavailable, message: "Use lastPathComponent on URL instead.")
+  public var lastPathComponent: String {
+    fatalError("unavailable function can't be called")
+  }
+
+  //===--- Renamed by agreement during API review 5/20/2014 ---------------===//
+  // @property NSUInteger length;
+
+  /// Returns the number of Unicode characters in the `String`.
+  @available(*, unavailable,
+    message: "Take the count of a UTF-16 view instead, i.e. str.utf16.count")
+  public var utf16Count: Int {
+    fatalError("unavailable function can't be called")
+  }
+
+  // @property NSArray* pathComponents
+
+  /// Returns an array of NSString objects containing, in
+  /// order, each path component of the `String`.
+  @available(*, unavailable, message: "Use pathComponents on URL instead.")
+  public var pathComponents: [String] {
+    fatalError("unavailable function can't be called")
+  }
+
+  // @property NSString* pathExtension;
+
+  /// Interprets the `String` as a path and returns the
+  /// `String`'s extension, if any.
+  @available(*, unavailable, message: "Use pathExtension on URL instead.")
+  public var pathExtension: String {
+    fatalError("unavailable function can't be called")
+  }
+
+  // @property NSString *stringByAbbreviatingWithTildeInPath;
+
+  /// Returns a new string that replaces the current home
+  /// directory portion of the current path with a tilde (`~`)
+  /// character.
+  @available(*, unavailable, message: "Use abbreviatingWithTildeInPath on NSString instead.")
+  public var abbreviatingWithTildeInPath: String {
+    fatalError("unavailable function can't be called")
+  }
+
+  // - (NSString *)stringByAppendingPathComponent:(NSString *)aString
+
+  /// Returns a new string made by appending to the `String` a given string.
+  @available(*, unavailable, message: "Use appendingPathComponent on URL instead.")
+  public func appendingPathComponent(_ aString: String) -> String {
+    fatalError("unavailable function can't be called")
+  }
+
+  // - (NSString *)stringByAppendingPathExtension:(NSString *)ext
+
+  /// Returns a new string made by appending to the `String` an
+  /// extension separator followed by a given extension.
+  @available(*, unavailable, message: "Use appendingPathExtension on URL instead.")
+  public func appendingPathExtension(_ ext: String) -> String? {
+    fatalError("unavailable function can't be called")
+  }
+
+  // @property NSString* stringByDeletingLastPathComponent;
+
+  /// Returns a new string made by deleting the last path
+  /// component from the `String`, along with any final path
+  /// separator.
+  @available(*, unavailable, message: "Use deletingLastPathComponent on URL instead.")
+  public var deletingLastPathComponent: String {
+    fatalError("unavailable function can't be called")
+  }
+
+  // @property NSString* stringByDeletingPathExtension;
+
+  /// Returns a new string made by deleting the extension (if
+  /// any, and only the last) from the `String`.
+  @available(*, unavailable, message: "Use deletingPathExtension on URL instead.")
+  public var deletingPathExtension: String {
+    fatalError("unavailable function can't be called")
+  }
+
+  // @property NSString* stringByExpandingTildeInPath;
+
+  /// Returns a new string made by expanding the initial
+  /// component of the `String` to its full path value.
+  @available(*, unavailable, message: "Use expandingTildeInPath on NSString instead.")
+  public var expandingTildeInPath: String {
+    fatalError("unavailable function can't be called")
+  }
+
+  // - (NSString *)
+  //     stringByFoldingWithOptions:(StringCompareOptions)options
+  //     locale:(Locale *)locale
+
+  @available(*, unavailable, renamed: "folding(options:locale:)")
+  public func folding(
+    _ options: String.CompareOptions = [], locale: Locale?
+  ) -> String {
+    fatalError("unavailable function can't be called")
+  }
+
+  // @property NSString* stringByResolvingSymlinksInPath;
+
+  /// Returns a new string made from the `String` by resolving
+  /// all symbolic links and standardizing path.
+  @available(*, unavailable, message: "Use resolvingSymlinksInPath on URL instead.")
+  public var resolvingSymlinksInPath: String {
+    fatalError("unavailable property")
+  }
+
+  // @property NSString* stringByStandardizingPath;
+
+  /// Returns a new string made by removing extraneous path
+  /// components from the `String`.
+  @available(*, unavailable, message: "Use standardizingPath on URL instead.")
+  public var standardizingPath: String {
+    fatalError("unavailable function can't be called")
+  }
+
+  // - (NSArray *)stringsByAppendingPaths:(NSArray *)paths
+
+  /// Returns an array of strings made by separately appending
+  /// to the `String` each string in a given array.
+  @available(*, unavailable, message: "Map over paths with appendingPathComponent instead.")
+  public func strings(byAppendingPaths paths: [String]) -> [String] {
+    fatalError("unavailable function can't be called")
+  }
+
+}
+
+// Pre-Swift-3 method names
+extension String {
+  @available(*, unavailable, renamed: "localizedName(of:)")
+  public static func localizedNameOfStringEncoding(
+    _ encoding: String.Encoding
+  ) -> String {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, message: "Use fileURL(withPathComponents:) on URL instead.")
+  public static func pathWithComponents(_ components: [String]) -> String {
+    fatalError("unavailable function can't be called")
+  }
+
+  // + (NSString *)pathWithComponents:(NSArray *)components
+
+  /// Returns a string built from the strings in a given array
+  /// by concatenating them with a path separator between each pair.
+  @available(*, unavailable, message: "Use fileURL(withPathComponents:) on URL instead.")
+  public static func path(withComponents components: [String]) -> String {
+    fatalError("unavailable function can't be called")
+  }
+}
+
+extension StringProtocol {
+
+  @available(*, unavailable, renamed: "canBeConverted(to:)")
+  public func canBeConvertedToEncoding(_ encoding: String.Encoding) -> Bool {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "capitalizedString(with:)")
+  public func capitalizedStringWith(_ locale: Locale?) -> String {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "commonPrefix(with:options:)")
+  public func commonPrefixWith(
+    _ aString: String, options: String.CompareOptions) -> String {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "completePath(into:outputName:caseSensitive:matchesInto:filterTypes:)")
+  public func completePathInto(
+    _ outputName: UnsafeMutablePointer<String>? = nil,
+    caseSensitive: Bool,
+    matchesInto matchesIntoArray: UnsafeMutablePointer<[String]>? = nil,
+    filterTypes: [String]? = nil
+  ) -> Int {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "components(separatedBy:)")
+  public func componentsSeparatedByCharactersIn(
+    _ separator: CharacterSet
+  ) -> [String] {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "components(separatedBy:)")
+  public func componentsSeparatedBy(_ separator: String) -> [String] {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "cString(usingEncoding:)")
+  public func cStringUsingEncoding(_ encoding: String.Encoding) -> [CChar]? {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "data(usingEncoding:allowLossyConversion:)")
+  public func dataUsingEncoding(
+    _ encoding: String.Encoding,
+    allowLossyConversion: Bool = false
+  ) -> Data? {
+    fatalError("unavailable function can't be called")
+  }
+
+#if !DEPLOYMENT_RUNTIME_SWIFT
+  @available(*, unavailable, renamed: "enumerateLinguisticTags(in:scheme:options:orthography:_:)")
+  public func enumerateLinguisticTagsIn(
+    _ range: Range<Index>,
+    scheme tagScheme: String,
+    options opts: NSLinguisticTagger.Options,
+    orthography: NSOrthography?,
+    _ body:
+      (String, Range<Index>, Range<Index>, inout Bool) -> Void
+  ) {
+    fatalError("unavailable function can't be called")
+  }
+#endif
+
+  @available(*, unavailable, renamed: "enumerateSubstrings(in:options:_:)")
+  public func enumerateSubstringsIn(
+    _ range: Range<Index>,
+    options opts: String.EnumerationOptions = [],
+    _ body: (
+      _ substring: String?, _ substringRange: Range<Index>,
+      _ enclosingRange: Range<Index>, inout Bool
+    ) -> Void
+  ) {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "getBytes(_:maxLength:usedLength:encoding:options:range:remaining:)")
+  public func getBytes(
+    _ buffer: inout [UInt8],
+    maxLength maxBufferCount: Int,
+    usedLength usedBufferCount: UnsafeMutablePointer<Int>,
+    encoding: String.Encoding,
+    options: String.EncodingConversionOptions = [],
+    range: Range<Index>,
+    remainingRange leftover: UnsafeMutablePointer<Range<Index>>
+  ) -> Bool {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "getLineStart(_:end:contentsEnd:for:)")
+  public func getLineStart(
+    _ start: UnsafeMutablePointer<Index>,
+    end: UnsafeMutablePointer<Index>,
+    contentsEnd: UnsafeMutablePointer<Index>,
+    forRange: Range<Index>
+  ) {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "getParagraphStart(_:end:contentsEnd:for:)")
+  public func getParagraphStart(
+    _ start: UnsafeMutablePointer<Index>,
+    end: UnsafeMutablePointer<Index>,
+    contentsEnd: UnsafeMutablePointer<Index>,
+    forRange: Range<Index>
+  ) {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "lengthOfBytes(using:)")
+  public func lengthOfBytesUsingEncoding(_ encoding: String.Encoding) -> Int {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "lineRange(for:)")
+  public func lineRangeFor(_ aRange: Range<Index>) -> Range<Index> {
+    fatalError("unavailable function can't be called")
+  }
+
+#if !DEPLOYMENT_RUNTIME_SWIFT
+  @available(*, unavailable, renamed: "linguisticTags(in:scheme:options:orthography:tokenRanges:)")
+  public func linguisticTagsIn(
+    _ range: Range<Index>,
+    scheme tagScheme: String,
+    options opts: NSLinguisticTagger.Options = [],
+    orthography: NSOrthography? = nil,
+    tokenRanges: UnsafeMutablePointer<[Range<Index>]>? = nil
+  ) -> [String] {
+    fatalError("unavailable function can't be called")
+  }
+#endif
+
+  @available(*, unavailable, renamed: "lowercased(with:)")
+  public func lowercaseStringWith(_ locale: Locale?) -> String {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "maximumLengthOfBytes(using:)")
+  public
+  func maximumLengthOfBytesUsingEncoding(_ encoding: String.Encoding) -> Int {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "paragraphRange(for:)")
+  public func paragraphRangeFor(_ aRange: Range<Index>) -> Range<Index> {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "rangeOfCharacter(from:options:range:)")
+  public func rangeOfCharacterFrom(
+    _ aSet: CharacterSet,
+    options mask: String.CompareOptions = [],
+    range aRange: Range<Index>? = nil
+  ) -> Range<Index>? {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "rangeOfComposedCharacterSequence(at:)")
+  public
+  func rangeOfComposedCharacterSequenceAt(_ anIndex: Index) -> Range<Index> {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "rangeOfComposedCharacterSequences(for:)")
+  public func rangeOfComposedCharacterSequencesFor(
+    _ range: Range<Index>
+  ) -> Range<Index> {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "range(of:options:range:locale:)")
+  public func rangeOf(
+    _ aString: String,
+    options mask: String.CompareOptions = [],
+    range searchRange: Range<Index>? = nil,
+    locale: Locale? = nil
+  ) -> Range<Index>? {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "localizedStandardRange(of:)")
+  public func localizedStandardRangeOf(_ string: String) -> Range<Index>? {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "addingPercentEncoding(withAllowedCharacters:)")
+  public func addingPercentEncodingWithAllowedCharacters(
+    _ allowedCharacters: CharacterSet
+  ) -> String? {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "addingPercentEscapes(using:)")
+  public func addingPercentEscapesUsingEncoding(
+    _ encoding: String.Encoding
+  ) -> String? {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "appendingFormat")
+  public func stringByAppendingFormat(
+    _ format: String, _ arguments: CVarArg...
+  ) -> String {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "padding(toLength:with:startingAt:)")
+  public func byPaddingToLength(
+    _ newLength: Int, withString padString: String, startingAt padIndex: Int
+  ) -> String {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "replacingCharacters(in:with:)")
+  public func replacingCharactersIn(
+    _ range: Range<Index>, withString replacement: String
+  ) -> String {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "replacingOccurrences(of:with:options:range:)")
+  public func replacingOccurrencesOf(
+    _ target: String,
+    withString replacement: String,
+    options: String.CompareOptions = [],
+    range searchRange: Range<Index>? = nil
+  ) -> String {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "replacingPercentEscapes(usingEncoding:)")
+  public func replacingPercentEscapesUsingEncoding(
+    _ encoding: String.Encoding
+  ) -> String? {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "trimmingCharacters(in:)")
+  public func byTrimmingCharactersIn(_ set: CharacterSet) -> String {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "strings(byAppendingPaths:)")
+  public func stringsByAppendingPaths(_ paths: [String]) -> [String] {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "substring(from:)")
+  public func substringFrom(_ index: Index) -> String {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "substring(to:)")
+  public func substringTo(_ index: Index) -> String {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "substring(with:)")
+  public func substringWith(_ aRange: Range<Index>) -> String {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "uppercased(with:)")
+  public func uppercaseStringWith(_ locale: Locale?) -> String {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "write(toFile:atomically:encoding:)")
+  public func writeToFile(
+    _ path: String, atomically useAuxiliaryFile:Bool,
+    encoding enc: String.Encoding
+  ) throws {
+    fatalError("unavailable function can't be called")
+  }
+
+  @available(*, unavailable, renamed: "write(to:atomically:encoding:)")
+  public func writeToURL(
+    _ url: URL, atomically useAuxiliaryFile: Bool,
+    encoding enc: String.Encoding
+  ) throws {
+    fatalError("unavailable function can't be called")
+  }
+}

--- a/Darwin/Foundation-swiftoverlay/NSStringEncodings.swift
+++ b/Darwin/Foundation-swiftoverlay/NSStringEncodings.swift
@@ -1,0 +1,183 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// FIXME: one day this will be bridged from CoreFoundation and we
+// should drop it here. <rdar://problem/14497260> (need support
+// for CF bridging)
+public var kCFStringEncodingASCII: CFStringEncoding { return 0x0600 }
+
+extension String {
+  public struct Encoding : RawRepresentable {
+    public var rawValue: UInt
+    public init(rawValue: UInt) { self.rawValue = rawValue }
+
+    public static let ascii = Encoding(rawValue: 1)
+    public static let nextstep = Encoding(rawValue: 2)
+    public static let japaneseEUC = Encoding(rawValue: 3)
+    public static let utf8 = Encoding(rawValue: 4)
+    public static let isoLatin1 = Encoding(rawValue: 5)
+    public static let symbol = Encoding(rawValue: 6)
+    public static let nonLossyASCII = Encoding(rawValue: 7)
+    public static let shiftJIS = Encoding(rawValue: 8)
+    public static let isoLatin2 = Encoding(rawValue: 9)
+    public static let unicode = Encoding(rawValue: 10)
+    public static let windowsCP1251 = Encoding(rawValue: 11)
+    public static let windowsCP1252 = Encoding(rawValue: 12)
+    public static let windowsCP1253 = Encoding(rawValue: 13)
+    public static let windowsCP1254 = Encoding(rawValue: 14)
+    public static let windowsCP1250 = Encoding(rawValue: 15)
+    public static let iso2022JP = Encoding(rawValue: 21)
+    public static let macOSRoman = Encoding(rawValue: 30)
+    public static let utf16 = Encoding.unicode
+    public static let utf16BigEndian = Encoding(rawValue: 0x90000100)
+    public static let utf16LittleEndian = Encoding(rawValue: 0x94000100)
+    public static let utf32 = Encoding(rawValue: 0x8c000100)
+    public static let utf32BigEndian = Encoding(rawValue: 0x98000100)
+    public static let utf32LittleEndian = Encoding(rawValue: 0x9c000100)
+  }
+
+  public typealias EncodingConversionOptions = NSString.EncodingConversionOptions
+  public typealias EnumerationOptions = NSString.EnumerationOptions
+  public typealias CompareOptions = NSString.CompareOptions
+}
+
+extension String.Encoding : Hashable {
+    public var hashValue: Int {
+        // Note: This is effectively the same hashValue definition that
+        // RawRepresentable provides on its own. We only need to keep this to
+        // ensure ABI compatibility with 5.0.
+        return rawValue.hashValue
+    }
+
+    @_alwaysEmitIntoClient // Introduced in 5.1
+    public func hash(into hasher: inout Hasher) {
+        // Note: `hash(only:)` is only defined here because we also define
+        // `hashValue`.
+        //
+        // In 5.0, `hash(into:)` was resolved to RawRepresentable's functionally
+        // equivalent definition; we added this definition in 5.1 to make it
+        // clear this `hash(into:)` isn't synthesized by the compiler.
+        // (Otherwise someone may be tempted to define it, possibly breaking the
+        // hash encoding and thus the ABI. RawRepresentable's definition is
+        // inlinable.)
+        hasher.combine(rawValue)
+    }
+
+    public static func ==(lhs: String.Encoding, rhs: String.Encoding) -> Bool {
+        // Note: This is effectively the same == definition that
+        // RawRepresentable provides on its own. We only need to keep this to
+        // ensure ABI compatibility with 5.0.
+        return lhs.rawValue == rhs.rawValue
+    }
+}
+
+extension String.Encoding : CustomStringConvertible {
+  public var description: String {
+    return String.localizedName(of: self)
+  }
+}
+
+@available(*, unavailable, renamed: "String.Encoding")
+public typealias NSStringEncoding = UInt
+
+@available(*, unavailable, renamed: "String.Encoding.ascii")
+public var NSASCIIStringEncoding: String.Encoding {
+  return String.Encoding.ascii
+}
+@available(*, unavailable, renamed: "String.Encoding.nextstep")
+public var NSNEXTSTEPStringEncoding: String.Encoding {
+  return String.Encoding.nextstep
+}
+@available(*, unavailable, renamed: "String.Encoding.japaneseEUC")
+public var NSJapaneseEUCStringEncoding: String.Encoding {
+  return String.Encoding.japaneseEUC
+}
+@available(*, unavailable, renamed: "String.Encoding.utf8")
+public var NSUTF8StringEncoding: String.Encoding {
+  return String.Encoding.utf8
+}
+@available(*, unavailable, renamed: "String.Encoding.isoLatin1")
+public var NSISOLatin1StringEncoding: String.Encoding {
+  return String.Encoding.isoLatin1
+}
+@available(*, unavailable, renamed: "String.Encoding.symbol")
+public var NSSymbolStringEncoding: String.Encoding {
+  return String.Encoding.symbol
+}
+@available(*, unavailable, renamed: "String.Encoding.nonLossyASCII")
+public var NSNonLossyASCIIStringEncoding: String.Encoding {
+  return String.Encoding.nonLossyASCII
+}
+@available(*, unavailable, renamed: "String.Encoding.shiftJIS")
+public var NSShiftJISStringEncoding: String.Encoding {
+  return String.Encoding.shiftJIS
+}
+@available(*, unavailable, renamed: "String.Encoding.isoLatin2")
+public var NSISOLatin2StringEncoding: String.Encoding {
+  return String.Encoding.isoLatin2
+}
+@available(*, unavailable, renamed: "String.Encoding.unicode")
+public var NSUnicodeStringEncoding: String.Encoding {
+  return String.Encoding.unicode
+}
+@available(*, unavailable, renamed: "String.Encoding.windowsCP1251")
+public var NSWindowsCP1251StringEncoding: String.Encoding {
+  return String.Encoding.windowsCP1251
+}
+@available(*, unavailable, renamed: "String.Encoding.windowsCP1252")
+public var NSWindowsCP1252StringEncoding: String.Encoding {
+  return String.Encoding.windowsCP1252
+}
+@available(*, unavailable, renamed: "String.Encoding.windowsCP1253")
+public var NSWindowsCP1253StringEncoding: String.Encoding {
+  return String.Encoding.windowsCP1253
+}
+@available(*, unavailable, renamed: "String.Encoding.windowsCP1254")
+public var NSWindowsCP1254StringEncoding: String.Encoding {
+  return String.Encoding.windowsCP1254
+}
+@available(*, unavailable, renamed: "String.Encoding.windowsCP1250")
+public var NSWindowsCP1250StringEncoding: String.Encoding {
+  return String.Encoding.windowsCP1250
+}
+@available(*, unavailable, renamed: "String.Encoding.iso2022JP")
+public var NSISO2022JPStringEncoding: String.Encoding {
+  return String.Encoding.iso2022JP
+}
+@available(*, unavailable, renamed: "String.Encoding.macOSRoman")
+public var NSMacOSRomanStringEncoding: String.Encoding {
+  return String.Encoding.macOSRoman
+}
+@available(*, unavailable, renamed: "String.Encoding.utf16")
+public var NSUTF16StringEncoding: String.Encoding {
+  return String.Encoding.utf16
+}
+@available(*, unavailable, renamed: "String.Encoding.utf16BigEndian")
+public var NSUTF16BigEndianStringEncoding: String.Encoding {
+  return String.Encoding.utf16BigEndian
+}
+@available(*, unavailable, renamed: "String.Encoding.utf16LittleEndian")
+public var NSUTF16LittleEndianStringEncoding: String.Encoding {
+  return String.Encoding.utf16LittleEndian
+}
+@available(*, unavailable, renamed: "String.Encoding.utf32")
+public var NSUTF32StringEncoding: String.Encoding {
+  return String.Encoding.utf32
+}
+@available(*, unavailable, renamed: "String.Encoding.utf32BigEndian")
+public var NSUTF32BigEndianStringEncoding: String.Encoding {
+  return String.Encoding.utf32BigEndian
+}
+@available(*, unavailable, renamed: "String.Encoding.utf32LittleEndian")
+public var NSUTF32LittleEndianStringEncoding: String.Encoding {
+  return String.Encoding.utf32LittleEndian
+}

--- a/Darwin/Foundation-swiftoverlay/NSTextCheckingResult.swift
+++ b/Darwin/Foundation-swiftoverlay/NSTextCheckingResult.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+//===----------------------------------------------------------------------===//
+// TextChecking
+//===----------------------------------------------------------------------===//
+
+extension NSTextCheckingResult.CheckingType {
+    public static var allSystemTypes : NSTextCheckingResult.CheckingType {
+        return NSTextCheckingResult.CheckingType(rawValue: 0xffffffff)
+    }
+    
+    public static var allCustomTypes : NSTextCheckingResult.CheckingType {
+        return NSTextCheckingResult.CheckingType(rawValue: 0xffffffff << 32)
+    }
+    
+    public static var allTypes : NSTextCheckingResult.CheckingType {
+        return NSTextCheckingResult.CheckingType(rawValue: UInt64.max)
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/NSURL.swift
+++ b/Darwin/Foundation-swiftoverlay/NSURL.swift
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+extension NSURL : _CustomPlaygroundQuickLookable {
+  @available(*, deprecated, message: "NSURL.customPlaygroundQuickLook will be removed in a future Swift version")
+  public var customPlaygroundQuickLook: PlaygroundQuickLook {
+    guard let str = absoluteString else { return .text("Unknown URL") }
+    return .url(str)
+  }
+}

--- a/Darwin/Foundation-swiftoverlay/NSUndoManager.swift
+++ b/Darwin/Foundation-swiftoverlay/NSUndoManager.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+@_implementationOnly import _FoundationOverlayShims
+
+extension UndoManager {
+  @available(*, unavailable, renamed: "registerUndo(withTarget:handler:)")
+  public func registerUndoWithTarget<TargetType : AnyObject>(_ target: TargetType, handler: (TargetType) -> Void) {
+    fatalError("This API has been renamed")
+  }
+
+  @available(macOS 10.11, iOS 9.0, *)
+  public func registerUndo<TargetType : AnyObject>(withTarget target: TargetType, handler: @escaping (TargetType) -> Void) {
+    __NSUndoManagerRegisterWithTargetHandler( self, target) { internalTarget in
+      handler(internalTarget as! TargetType)
+    }
+  }
+}

--- a/Darwin/Foundation-swiftoverlay/NSValue.swift
+++ b/Darwin/Foundation-swiftoverlay/NSValue.swift
@@ -1,0 +1,352 @@
+//===--- NSValue.swift - Bridging things in NSValue -----------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import CoreGraphics
+
+
+extension NSRange: _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSValue {
+    var myself = self
+    return NSValue(bytes: &myself, objCType: _getObjCTypeEncoding(NSRange.self))
+  }
+
+  public static func _forceBridgeFromObjectiveC(_ source: NSValue,
+                                                result: inout NSRange?) {
+    precondition(strcmp(source.objCType,
+                        _getObjCTypeEncoding(NSRange.self)) == 0,
+                 "NSValue does not contain the right type to bridge to NSRange")
+    result = NSRange()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      source.getValue(&result!, size: MemoryLayout<NSRange>.size)
+    } else {
+      source.getValue(&result!)
+    }
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(_ source: NSValue,
+                                                        result: inout NSRange?)
+      -> Bool {
+    if strcmp(source.objCType, _getObjCTypeEncoding(NSRange.self)) != 0 {
+      result = nil
+      return false
+    }
+    result = NSRange()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      source.getValue(&result!, size: MemoryLayout<NSRange>.size)
+    } else {
+      source.getValue(&result!)
+    }
+    return true
+  }
+
+  public static func _unconditionallyBridgeFromObjectiveC(_ source: NSValue?)
+      -> NSRange {
+    let unwrappedSource = source!
+    precondition(strcmp(unwrappedSource.objCType,
+                        _getObjCTypeEncoding(NSRange.self)) == 0,
+                 "NSValue does not contain the right type to bridge to NSRange")
+    var result = NSRange()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      unwrappedSource.getValue(&result, size: MemoryLayout<NSRange>.size)
+    } else {
+      unwrappedSource.getValue(&result)
+    }
+    return result
+  }
+}
+
+
+extension CGRect: _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSValue {
+    var myself = self
+    return NSValue(bytes: &myself, objCType: _getObjCTypeEncoding(CGRect.self))
+  }
+
+  public static func _forceBridgeFromObjectiveC(_ source: NSValue,
+                                                result: inout CGRect?) {
+    precondition(strcmp(source.objCType,
+                        _getObjCTypeEncoding(CGRect.self)) == 0,
+                 "NSValue does not contain the right type to bridge to CGRect")
+    result = CGRect()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      source.getValue(&result!, size: MemoryLayout<CGRect>.size)
+    } else {
+      source.getValue(&result!)
+    }
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(_ source: NSValue,
+                                                        result: inout CGRect?)
+      -> Bool {
+    if strcmp(source.objCType, _getObjCTypeEncoding(CGRect.self)) != 0 {
+      result = nil
+      return false
+    }
+    result = CGRect()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      source.getValue(&result!, size: MemoryLayout<CGRect>.size)
+    } else {
+      source.getValue(&result!)
+    }
+    return true
+  }
+
+  public static func _unconditionallyBridgeFromObjectiveC(_ source: NSValue?)
+      -> CGRect {
+    let unwrappedSource = source!
+    precondition(strcmp(unwrappedSource.objCType,
+                        _getObjCTypeEncoding(CGRect.self)) == 0,
+                 "NSValue does not contain the right type to bridge to CGRect")
+    var result = CGRect()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      unwrappedSource.getValue(&result, size: MemoryLayout<CGRect>.size)
+    } else {
+      unwrappedSource.getValue(&result)
+    }
+    return result
+  }
+}
+
+
+extension CGPoint: _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSValue {
+    var myself = self
+    return NSValue(bytes: &myself, objCType: _getObjCTypeEncoding(CGPoint.self))
+  }
+
+  public static func _forceBridgeFromObjectiveC(_ source: NSValue,
+                                                result: inout CGPoint?) {
+    precondition(strcmp(source.objCType,
+                        _getObjCTypeEncoding(CGPoint.self)) == 0,
+                 "NSValue does not contain the right type to bridge to CGPoint")
+    result = CGPoint()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      source.getValue(&result!, size: MemoryLayout<CGPoint>.size)
+    } else {
+      source.getValue(&result!)
+    }
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(_ source: NSValue,
+                                                        result: inout CGPoint?)
+      -> Bool {
+    if strcmp(source.objCType, _getObjCTypeEncoding(CGPoint.self)) != 0 {
+      result = nil
+      return false
+    }
+    result = CGPoint()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      source.getValue(&result!, size: MemoryLayout<CGPoint>.size)
+    } else {
+      source.getValue(&result!)
+    }
+    return true
+  }
+
+  public static func _unconditionallyBridgeFromObjectiveC(_ source: NSValue?)
+      -> CGPoint {
+    let unwrappedSource = source!
+    precondition(strcmp(unwrappedSource.objCType,
+                        _getObjCTypeEncoding(CGPoint.self)) == 0,
+                 "NSValue does not contain the right type to bridge to CGPoint")
+    var result = CGPoint()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      unwrappedSource.getValue(&result, size: MemoryLayout<CGPoint>.size)
+    } else {
+      unwrappedSource.getValue(&result)
+    }
+    return result
+  }
+}
+
+
+extension CGVector: _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSValue {
+    var myself = self
+    return NSValue(bytes: &myself, objCType: _getObjCTypeEncoding(CGVector.self))
+  }
+
+  public static func _forceBridgeFromObjectiveC(_ source: NSValue,
+                                                result: inout CGVector?) {
+    precondition(strcmp(source.objCType,
+                        _getObjCTypeEncoding(CGVector.self)) == 0,
+                 "NSValue does not contain the right type to bridge to CGVector")
+    result = CGVector()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      source.getValue(&result!, size: MemoryLayout<CGVector>.size)
+    } else {
+      source.getValue(&result!)
+    }
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(_ source: NSValue,
+                                                        result: inout CGVector?)
+      -> Bool {
+    if strcmp(source.objCType, _getObjCTypeEncoding(CGVector.self)) != 0 {
+      result = nil
+      return false
+    }
+    result = CGVector()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      source.getValue(&result!, size: MemoryLayout<CGVector>.size)
+    } else {
+      source.getValue(&result!)
+    }
+    return true
+  }
+
+  public static func _unconditionallyBridgeFromObjectiveC(_ source: NSValue?)
+      -> CGVector {
+    let unwrappedSource = source!
+    precondition(strcmp(unwrappedSource.objCType,
+                        _getObjCTypeEncoding(CGVector.self)) == 0,
+                 "NSValue does not contain the right type to bridge to CGVector")
+    var result = CGVector()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      unwrappedSource.getValue(&result, size: MemoryLayout<CGVector>.size)
+    } else {
+      unwrappedSource.getValue(&result)
+    }
+    return result
+  }
+}
+
+
+extension CGSize: _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSValue {
+    var myself = self
+    return NSValue(bytes: &myself, objCType: _getObjCTypeEncoding(CGSize.self))
+  }
+
+  public static func _forceBridgeFromObjectiveC(_ source: NSValue,
+                                                result: inout CGSize?) {
+    precondition(strcmp(source.objCType,
+                        _getObjCTypeEncoding(CGSize.self)) == 0,
+                 "NSValue does not contain the right type to bridge to CGSize")
+    result = CGSize()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      source.getValue(&result!, size: MemoryLayout<CGSize>.size)
+    } else {
+      source.getValue(&result!)
+    }
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(_ source: NSValue,
+                                                        result: inout CGSize?)
+      -> Bool {
+    if strcmp(source.objCType, _getObjCTypeEncoding(CGSize.self)) != 0 {
+      result = nil
+      return false
+    }
+    result = CGSize()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      source.getValue(&result!, size: MemoryLayout<CGSize>.size)
+    } else {
+      source.getValue(&result!)
+    }
+    return true
+  }
+
+  public static func _unconditionallyBridgeFromObjectiveC(_ source: NSValue?)
+      -> CGSize {
+    let unwrappedSource = source!
+    precondition(strcmp(unwrappedSource.objCType,
+                        _getObjCTypeEncoding(CGSize.self)) == 0,
+                 "NSValue does not contain the right type to bridge to CGSize")
+    var result = CGSize()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      unwrappedSource.getValue(&result, size: MemoryLayout<CGSize>.size)
+    } else {
+      unwrappedSource.getValue(&result)
+    }
+    return result
+  }
+}
+
+
+extension CGAffineTransform: _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSValue {
+    var myself = self
+    return NSValue(bytes: &myself, objCType: _getObjCTypeEncoding(CGAffineTransform.self))
+  }
+
+  public static func _forceBridgeFromObjectiveC(_ source: NSValue,
+                                                result: inout CGAffineTransform?) {
+    precondition(strcmp(source.objCType,
+                        _getObjCTypeEncoding(CGAffineTransform.self)) == 0,
+                 "NSValue does not contain the right type to bridge to CGAffineTransform")
+    result = CGAffineTransform()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      source.getValue(&result!, size: MemoryLayout<CGAffineTransform>.size)
+    } else {
+      source.getValue(&result!)
+    }
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(_ source: NSValue,
+                                                        result: inout CGAffineTransform?)
+      -> Bool {
+    if strcmp(source.objCType, _getObjCTypeEncoding(CGAffineTransform.self)) != 0 {
+      result = nil
+      return false
+    }
+    result = CGAffineTransform()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      source.getValue(&result!, size: MemoryLayout<CGAffineTransform>.size)
+    } else {
+      source.getValue(&result!)
+    }
+    return true
+  }
+
+  public static func _unconditionallyBridgeFromObjectiveC(_ source: NSValue?)
+      -> CGAffineTransform {
+    let unwrappedSource = source!
+    precondition(strcmp(unwrappedSource.objCType,
+                        _getObjCTypeEncoding(CGAffineTransform.self)) == 0,
+                 "NSValue does not contain the right type to bridge to CGAffineTransform")
+    var result = CGAffineTransform()
+    if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+      unwrappedSource.getValue(&result, size: MemoryLayout<CGAffineTransform>.size)
+    } else {
+      unwrappedSource.getValue(&result)
+    }
+    return result
+  }
+}
+
+
+extension NSValue {
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    public func value<StoredType>(of type: StoredType.Type) -> StoredType? {
+        if StoredType.self is AnyObject.Type {
+            let encoding = String(cString: objCType)
+            // some subclasses of NSValue can return @ and the default initialized variant returns ^v for encoding
+            guard encoding == "^v" || encoding == "@" else {
+                return nil
+            }
+            return nonretainedObjectValue as? StoredType
+        } else if _isPOD(StoredType.self) {
+            var storedSize = 0
+            var storedAlignment = 0
+            NSGetSizeAndAlignment(objCType, &storedSize, &storedAlignment)
+            guard MemoryLayout<StoredType>.size == storedSize && MemoryLayout<StoredType>.alignment == storedAlignment else {
+                return nil
+            }
+            let allocated = UnsafeMutablePointer<StoredType>.allocate(capacity: 1)
+            defer { allocated.deallocate() }
+            getValue(allocated, size: storedSize)
+            return allocated.pointee
+        }
+        return nil
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/Notification.swift
+++ b/Darwin/Foundation-swiftoverlay/Notification.swift
@@ -1,0 +1,166 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+
+/**
+ `Notification` encapsulates information broadcast to observers via a `NotificationCenter`.
+*/
+public struct Notification : ReferenceConvertible, Equatable, Hashable {
+    public typealias ReferenceType = NSNotification
+    
+    /// A tag identifying the notification.
+    public var name: Name
+    
+    /// An object that the poster wishes to send to observers.
+    ///
+    /// Typically this is the object that posted the notification.
+    public var object: Any?
+    
+    /// Storage for values or objects related to this notification.
+    public var userInfo: [AnyHashable : Any]?
+    
+    /// Initialize a new `Notification`.
+    ///
+    /// The default value for `userInfo` is nil.
+    public init(name: Name, object: Any? = nil, userInfo: [AnyHashable : Any]? = nil) {
+        self.name = name
+        self.object = object
+        self.userInfo = userInfo
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+
+        // FIXME: We should feed `object` to the hasher, too. However, this
+        // cannot be safely done if its value happens not to be Hashable.
+
+        // FIXME: == compares `userInfo` by bridging it to NSDictionary, so its
+        // contents should be fully hashed here.  However, to prevent stability
+        // issues with userInfo dictionaries that include non-Hashable values,
+        // we only feed the keys to the hasher here.
+        //
+        // FIXME: This makes for weak hashes. We really should hash everything
+        // that's compared in ==.
+        //
+        // The algorithm below is the same as the one used by Dictionary.
+        var commutativeKeyHash = 0
+        if let userInfo = userInfo {
+            for (k, _) in userInfo {
+                var nestedHasher = hasher
+                nestedHasher.combine(k)
+                commutativeKeyHash ^= nestedHasher.finalize()
+            }
+        }
+        hasher.combine(commutativeKeyHash)
+    }
+
+    public var description: String {
+        return "name = \(name.rawValue), object = \(String(describing: object)), userInfo = \(String(describing: userInfo))"
+    }
+    
+    public var debugDescription: String {
+        return description
+    }
+
+    // FIXME: Handle directly via API Notes
+    public typealias Name = NSNotification.Name
+
+    /// Compare two notifications for equality.
+    public static func ==(lhs: Notification, rhs: Notification) -> Bool {
+        if lhs.name.rawValue != rhs.name.rawValue {
+            return false
+        }
+        if let lhsObj = lhs.object {
+            if let rhsObj = rhs.object {
+                // FIXME: Converting an arbitrary value to AnyObject won't use a
+                // stable address when the value needs to be boxed.  Therefore,
+                // this comparison makes == non-reflexive, violating Equatable
+                // requirements. (rdar://problem/49797185)
+                if lhsObj as AnyObject !== rhsObj as AnyObject {
+                    return false
+                }
+            } else {
+                return false
+            }
+        } else if rhs.object != nil {
+            return false
+        }
+        if lhs.userInfo != nil {
+            if rhs.userInfo != nil {
+                // user info must be compared in the object form since the userInfo in swift is not comparable
+
+                // FIXME: This violates reflexivity when userInfo contains any
+                // non-Hashable values, for the same reason as described above.
+                return lhs._bridgeToObjectiveC() == rhs._bridgeToObjectiveC()
+            } else {
+                return false
+            }
+        } else if rhs.userInfo != nil {
+            return false
+        }
+        return true
+    }
+}
+
+extension Notification: CustomReflectable {
+    public var customMirror: Mirror {
+        var children: [(label: String?, value: Any)] = []
+        children.append((label: "name", value: self.name.rawValue))
+        if let o = self.object {
+            children.append((label: "object", value: o))
+        }
+        if let u = self.userInfo {
+            children.append((label: "userInfo", value: u))
+        }
+        let m = Mirror(self, children:children, displayStyle: Mirror.DisplayStyle.class)
+        return m
+    }
+}
+
+extension Notification : _ObjectiveCBridgeable {
+    public static func _getObjectiveCType() -> Any.Type {
+        return NSNotification.self
+    }
+    
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSNotification {
+        return NSNotification(name: name, object: object, userInfo: userInfo)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSNotification, result: inout Notification?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge type")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSNotification, result: inout Notification?) -> Bool {
+        result = Notification(name: x.name, object: x.object, userInfo: x.userInfo)
+        return true
+    }
+
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNotification?) -> Notification {
+        guard let src = source else { return Notification(name: Notification.Name("")) }
+        return Notification(name: src.name, object: src.object, userInfo: src.userInfo)
+    }
+}
+
+extension NSNotification : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as Notification)
+    }
+}
+

--- a/Darwin/Foundation-swiftoverlay/PersonNameComponents.swift
+++ b/Darwin/Foundation-swiftoverlay/PersonNameComponents.swift
@@ -1,0 +1,181 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+@available(macOS 10.11, iOS 9.0, *)
+public struct PersonNameComponents : ReferenceConvertible, Hashable, Equatable, _MutableBoxing {
+    public typealias ReferenceType = NSPersonNameComponents
+    internal var _handle: _MutableHandle<NSPersonNameComponents>
+    
+    public init() {
+        _handle = _MutableHandle(adoptingReference: NSPersonNameComponents())
+    }
+    
+    private init(reference: __shared NSPersonNameComponents) {
+        _handle = _MutableHandle(reference: reference)
+    }
+
+    /* The below examples all assume the full name Dr. Johnathan Maple Appleseed Esq., nickname "Johnny" */
+    
+    /* Pre-nominal letters denoting title, salutation, or honorific, e.g. Dr., Mr. */
+    public var namePrefix: String? {
+        get { return _handle.map { $0.namePrefix } }
+        set { _applyMutation { $0.namePrefix = newValue } }
+    }
+    
+    /* Name bestowed upon an individual by one's parents, e.g. Johnathan */
+    public var givenName: String? {
+        get { return _handle.map { $0.givenName } }
+        set { _applyMutation { $0.givenName = newValue } }
+    }
+    
+    /* Secondary given name chosen to differentiate those with the same first name, e.g. Maple  */
+    public var middleName: String? {
+        get { return _handle.map { $0.middleName } }
+        set { _applyMutation { $0.middleName = newValue } }
+    }
+    
+    /* Name passed from one generation to another to indicate lineage, e.g. Appleseed  */
+    public var familyName: String? {
+        get { return _handle.map { $0.familyName } }
+        set { _applyMutation { $0.familyName = newValue } }
+    }
+    
+    /* Post-nominal letters denoting degree, accreditation, or other honor, e.g. Esq., Jr., Ph.D. */
+    public var nameSuffix: String? {
+        get { return _handle.map { $0.nameSuffix } }
+        set { _applyMutation { $0.nameSuffix = newValue } }
+    }
+    
+    /* Name substituted for the purposes of familiarity, e.g. "Johnny"*/
+    public var nickname: String? {
+        get { return _handle.map { $0.nickname } }
+        set { _applyMutation { $0.nickname = newValue } }
+    }
+    
+    /* Each element of the phoneticRepresentation should correspond to an element of the original PersonNameComponents instance.
+     The phoneticRepresentation of the phoneticRepresentation object itself will be ignored. nil by default, must be instantiated.
+     */
+    public var phoneticRepresentation: PersonNameComponents? {
+        get { return _handle.map { $0.phoneticRepresentation } }
+        set { _applyMutation { $0.phoneticRepresentation = newValue } }
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_handle._uncopiedReference())
+    }
+
+    @available(macOS 10.11, iOS 9.0, *)
+    public static func ==(lhs : PersonNameComponents, rhs: PersonNameComponents) -> Bool {
+        // Don't copy references here; no one should be storing anything
+        return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
+    }
+}
+
+@available(macOS 10.11, iOS 9.0, *)
+extension PersonNameComponents : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    public var description: String {
+        return self.customMirror.children.reduce("") {
+            $0.appending("\($1.label ?? ""): \($1.value) ")
+        }
+    }
+    
+    public var debugDescription: String {
+        return self.description
+    }
+
+    public var customMirror: Mirror {
+        var c: [(label: String?, value: Any)] = []
+        if let r = namePrefix { c.append((label: "namePrefix", value: r)) }
+        if let r = givenName { c.append((label: "givenName", value: r)) }
+        if let r = middleName { c.append((label: "middleName", value: r)) }
+        if let r = familyName { c.append((label: "familyName", value: r)) }
+        if let r = nameSuffix { c.append((label: "nameSuffix", value: r)) }
+        if let r = nickname { c.append((label: "nickname", value: r)) }
+        if let r = phoneticRepresentation { c.append((label: "phoneticRepresentation", value: r)) }
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+    }
+}
+
+@available(macOS 10.11, iOS 9.0, *)
+extension PersonNameComponents : _ObjectiveCBridgeable {
+    public static func _getObjectiveCType() -> Any.Type {
+        return NSPersonNameComponents.self
+    }
+    
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSPersonNameComponents {
+        return _handle._copiedReference()
+    }
+
+    public static func _forceBridgeFromObjectiveC(_ personNameComponents: NSPersonNameComponents, result: inout PersonNameComponents?) {
+        if !_conditionallyBridgeFromObjectiveC(personNameComponents, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ personNameComponents: NSPersonNameComponents, result: inout PersonNameComponents?) -> Bool {
+        result = PersonNameComponents(reference: personNameComponents)
+        return true
+    }
+
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSPersonNameComponents?) -> PersonNameComponents {
+        var result: PersonNameComponents?
+        _forceBridgeFromObjectiveC(source!, result: &result)
+        return result!
+    }
+}
+
+@available(macOS 10.11, iOS 9.0, *)
+extension NSPersonNameComponents : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as PersonNameComponents)
+    }
+}
+
+@available(macOS 10.11, iOS 9.0, *)
+extension PersonNameComponents : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case namePrefix
+        case givenName
+        case middleName
+        case familyName
+        case nameSuffix
+        case nickname
+    }
+
+    public init(from decoder: Decoder) throws {
+        self.init()
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.namePrefix = try container.decodeIfPresent(String.self, forKey: .namePrefix)
+        self.givenName  = try container.decodeIfPresent(String.self, forKey: .givenName)
+        self.middleName = try container.decodeIfPresent(String.self, forKey: .middleName)
+        self.familyName = try container.decodeIfPresent(String.self, forKey: .familyName)
+        self.nameSuffix = try container.decodeIfPresent(String.self, forKey: .nameSuffix)
+        self.nickname   = try container.decodeIfPresent(String.self, forKey: .nickname)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        if let np = self.namePrefix { try container.encode(np, forKey: .namePrefix) }
+        if let gn = self.givenName  { try container.encode(gn, forKey: .givenName) }
+        if let mn = self.middleName { try container.encode(mn, forKey: .middleName) }
+        if let fn = self.familyName { try container.encode(fn, forKey: .familyName) }
+        if let ns = self.nameSuffix { try container.encode(ns, forKey: .nameSuffix) }
+        if let nn = self.nickname   { try container.encode(nn, forKey: .nickname) }
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/PlistEncoder.swift
+++ b/Darwin/Foundation-swiftoverlay/PlistEncoder.swift
@@ -1,0 +1,1851 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Plist Encoder
+//===----------------------------------------------------------------------===//
+
+/// `PropertyListEncoder` facilitates the encoding of `Encodable` values into property lists.
+// NOTE: older overlays had Foundation.PropertyListEncoder as the ObjC
+// name. The two must coexist, so it was renamed. The old name must not
+// be used in the new runtime. _TtC10Foundation20_PropertyListEncoder
+// is the mangled name for Foundation._PropertyListEncoder.
+@_objcRuntimeName(_TtC10Foundation20_PropertyListEncoder)
+open class PropertyListEncoder {
+
+    // MARK: - Options
+
+    /// The output format to write the property list data in. Defaults to `.binary`.
+    open var outputFormat: PropertyListSerialization.PropertyListFormat = .binary
+
+    /// Contextual user-provided information for use during encoding.
+    open var userInfo: [CodingUserInfoKey : Any] = [:]
+
+    /// Options set on the top-level encoder to pass down the encoding hierarchy.
+    fileprivate struct _Options {
+        let outputFormat: PropertyListSerialization.PropertyListFormat
+        let userInfo: [CodingUserInfoKey : Any]
+    }
+
+    /// The options set on the top-level encoder.
+    fileprivate var options: _Options {
+        return _Options(outputFormat: outputFormat, userInfo: userInfo)
+    }
+
+    // MARK: - Constructing a Property List Encoder
+
+    /// Initializes `self` with default strategies.
+    public init() {}
+
+    // MARK: - Encoding Values
+
+    /// Encodes the given top-level value and returns its property list representation.
+    ///
+    /// - parameter value: The value to encode.
+    /// - returns: A new `Data` value containing the encoded property list data.
+    /// - throws: `EncodingError.invalidValue` if a non-conforming floating-point value is encountered during encoding, and the encoding strategy is `.throw`.
+    /// - throws: An error if any value throws an error during encoding.
+    open func encode<Value : Encodable>(_ value: Value) throws -> Data {
+      let topLevel = try encodeToTopLevelContainer(value)
+      if topLevel is NSNumber {
+          throw EncodingError.invalidValue(value,
+                                           EncodingError.Context(codingPath: [],
+                                                                 debugDescription: "Top-level \(Value.self) encoded as number property list fragment."))
+      } else if topLevel is NSString {
+          throw EncodingError.invalidValue(value,
+                                           EncodingError.Context(codingPath: [],
+                                                                 debugDescription: "Top-level \(Value.self) encoded as string property list fragment."))
+      } else if topLevel is NSDate {
+          throw EncodingError.invalidValue(value,
+                                           EncodingError.Context(codingPath: [],
+                                                                 debugDescription: "Top-level \(Value.self) encoded as date property list fragment."))
+      }
+      
+      do {
+          return try PropertyListSerialization.data(fromPropertyList: topLevel, format: self.outputFormat, options: 0)
+      } catch {
+          throw EncodingError.invalidValue(value, 
+                                           EncodingError.Context(codingPath: [], debugDescription: "Unable to encode the given top-level value as a property list", underlyingError: error))
+      }
+    }
+
+    /// Encodes the given top-level value and returns its plist-type representation.
+    ///
+    /// - parameter value: The value to encode.
+    /// - returns: A new top-level array or dictionary representing the value.
+    /// - throws: `EncodingError.invalidValue` if a non-conforming floating-point value is encountered during encoding, and the encoding strategy is `.throw`.
+    /// - throws: An error if any value throws an error during encoding.
+    internal func encodeToTopLevelContainer<Value : Encodable>(_ value: Value) throws -> Any {
+        let encoder = __PlistEncoder(options: self.options)
+        guard let topLevel = try encoder.box_(value) else {
+            throw EncodingError.invalidValue(value,
+                                             EncodingError.Context(codingPath: [],
+                                                                   debugDescription: "Top-level \(Value.self) did not encode any values."))
+        }
+
+        return topLevel
+    }
+}
+
+// MARK: - __PlistEncoder
+
+// NOTE: older overlays called this class _PlistEncoder. The two must
+// coexist without a conflicting ObjC class name, so it was renamed.
+// The old name must not be used in the new runtime.
+fileprivate class __PlistEncoder : Encoder {
+    // MARK: Properties
+
+    /// The encoder's storage.
+    fileprivate var storage: _PlistEncodingStorage
+
+    /// Options set on the top-level encoder.
+    fileprivate let options: PropertyListEncoder._Options
+
+    /// The path to the current point in encoding.
+    fileprivate(set) public var codingPath: [CodingKey]
+
+    /// Contextual user-provided information for use during encoding.
+    public var userInfo: [CodingUserInfoKey : Any] {
+        return self.options.userInfo
+    }
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with the given top-level encoder options.
+    fileprivate init(options: PropertyListEncoder._Options, codingPath: [CodingKey] = []) {
+        self.options = options
+        self.storage = _PlistEncodingStorage()
+        self.codingPath = codingPath
+    }
+
+    /// Returns whether a new element can be encoded at this coding path.
+    ///
+    /// `true` if an element has not yet been encoded at this coding path; `false` otherwise.
+    fileprivate var canEncodeNewValue: Bool {
+        // Every time a new value gets encoded, the key it's encoded for is pushed onto the coding path (even if it's a nil key from an unkeyed container).
+        // At the same time, every time a container is requested, a new value gets pushed onto the storage stack.
+        // If there are more values on the storage stack than on the coding path, it means the value is requesting more than one container, which violates the precondition.
+        //
+        // This means that anytime something that can request a new container goes onto the stack, we MUST push a key onto the coding path.
+        // Things which will not request containers do not need to have the coding path extended for them (but it doesn't matter if it is, because they will not reach here).
+        return self.storage.count == self.codingPath.count
+    }
+
+    // MARK: - Encoder Methods
+    public func container<Key>(keyedBy: Key.Type) -> KeyedEncodingContainer<Key> {
+        // If an existing keyed container was already requested, return that one.
+        let topContainer: NSMutableDictionary
+        if self.canEncodeNewValue {
+            // We haven't yet pushed a container at this level; do so here.
+            topContainer = self.storage.pushKeyedContainer()
+        } else {
+            guard let container = self.storage.containers.last as? NSMutableDictionary else {
+                preconditionFailure("Attempt to push new keyed encoding container when already previously encoded at this path.")
+            }
+
+            topContainer = container
+        }
+
+        let container = _PlistKeyedEncodingContainer<Key>(referencing: self, codingPath: self.codingPath, wrapping: topContainer)
+        return KeyedEncodingContainer(container)
+    }
+
+    public func unkeyedContainer() -> UnkeyedEncodingContainer {
+        // If an existing unkeyed container was already requested, return that one.
+        let topContainer: NSMutableArray
+        if self.canEncodeNewValue {
+            // We haven't yet pushed a container at this level; do so here.
+            topContainer = self.storage.pushUnkeyedContainer()
+        } else {
+            guard let container = self.storage.containers.last as? NSMutableArray else {
+                preconditionFailure("Attempt to push new unkeyed encoding container when already previously encoded at this path.")
+            }
+
+            topContainer = container
+        }
+
+        return _PlistUnkeyedEncodingContainer(referencing: self, codingPath: self.codingPath, wrapping: topContainer)
+    }
+
+    public func singleValueContainer() -> SingleValueEncodingContainer {
+        return self
+    }
+}
+
+// MARK: - Encoding Storage and Containers
+
+fileprivate struct _PlistEncodingStorage {
+    // MARK: Properties
+
+    /// The container stack.
+    /// Elements may be any one of the plist types (NSNumber, NSString, NSDate, NSArray, NSDictionary).
+    private(set) fileprivate var containers: [NSObject] = []
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with no containers.
+    fileprivate init() {}
+
+    // MARK: - Modifying the Stack
+
+    fileprivate var count: Int {
+        return self.containers.count
+    }
+
+    fileprivate mutating func pushKeyedContainer() -> NSMutableDictionary {
+        let dictionary = NSMutableDictionary()
+        self.containers.append(dictionary)
+        return dictionary
+    }
+
+    fileprivate mutating func pushUnkeyedContainer() -> NSMutableArray {
+        let array = NSMutableArray()
+        self.containers.append(array)
+        return array
+    }
+
+    fileprivate mutating func push(container: __owned NSObject) {
+        self.containers.append(container)
+    }
+
+    fileprivate mutating func popContainer() -> NSObject {
+        precondition(!self.containers.isEmpty, "Empty container stack.")
+        return self.containers.popLast()!
+    }
+}
+
+// MARK: - Encoding Containers
+
+fileprivate struct _PlistKeyedEncodingContainer<K : CodingKey> : KeyedEncodingContainerProtocol {
+    typealias Key = K
+
+    // MARK: Properties
+
+    /// A reference to the encoder we're writing to.
+    private let encoder: __PlistEncoder
+
+    /// A reference to the container we're writing to.
+    private let container: NSMutableDictionary
+
+    /// The path of coding keys taken to get to this point in encoding.
+    private(set) public var codingPath: [CodingKey]
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with the given references.
+    fileprivate init(referencing encoder: __PlistEncoder, codingPath: [CodingKey], wrapping container: NSMutableDictionary) {
+        self.encoder = encoder
+        self.codingPath = codingPath
+        self.container = container
+    }
+
+    // MARK: - KeyedEncodingContainerProtocol Methods
+
+    public mutating func encodeNil(forKey key: Key)               throws { self.container[key.stringValue] = _plistNullNSString }
+    public mutating func encode(_ value: Bool, forKey key: Key)   throws { self.container[key.stringValue] = self.encoder.box(value) }
+    public mutating func encode(_ value: Int, forKey key: Key)    throws { self.container[key.stringValue] = self.encoder.box(value) }
+    public mutating func encode(_ value: Int8, forKey key: Key)   throws { self.container[key.stringValue] = self.encoder.box(value) }
+    public mutating func encode(_ value: Int16, forKey key: Key)  throws { self.container[key.stringValue] = self.encoder.box(value) }
+    public mutating func encode(_ value: Int32, forKey key: Key)  throws { self.container[key.stringValue] = self.encoder.box(value) }
+    public mutating func encode(_ value: Int64, forKey key: Key)  throws { self.container[key.stringValue] = self.encoder.box(value) }
+    public mutating func encode(_ value: UInt, forKey key: Key)   throws { self.container[key.stringValue] = self.encoder.box(value) }
+    public mutating func encode(_ value: UInt8, forKey key: Key)  throws { self.container[key.stringValue] = self.encoder.box(value) }
+    public mutating func encode(_ value: UInt16, forKey key: Key) throws { self.container[key.stringValue] = self.encoder.box(value) }
+    public mutating func encode(_ value: UInt32, forKey key: Key) throws { self.container[key.stringValue] = self.encoder.box(value) }
+    public mutating func encode(_ value: UInt64, forKey key: Key) throws { self.container[key.stringValue] = self.encoder.box(value) }
+    public mutating func encode(_ value: String, forKey key: Key) throws { self.container[key.stringValue] = self.encoder.box(value) }
+    public mutating func encode(_ value: Float, forKey key: Key)  throws { self.container[key.stringValue] = self.encoder.box(value) }
+    public mutating func encode(_ value: Double, forKey key: Key) throws { self.container[key.stringValue] = self.encoder.box(value) }
+
+    public mutating func encode<T : Encodable>(_ value: T, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+        self.container[key.stringValue] = try self.encoder.box(value)
+    }
+
+    public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+        let containerKey = key.stringValue
+        let dictionary: NSMutableDictionary
+        if let existingContainer = self.container[containerKey] {
+            precondition(
+                existingContainer is NSMutableDictionary,
+                "Attempt to re-encode into nested KeyedEncodingContainer<\(Key.self)> for key \"\(containerKey)\" is invalid: non-keyed container already encoded for this key"
+            )
+            dictionary = existingContainer as! NSMutableDictionary
+        } else {
+            dictionary = NSMutableDictionary()
+            self.container[containerKey] = dictionary
+        }
+        
+        self.codingPath.append(key)
+        defer { self.codingPath.removeLast() }
+
+        let container = _PlistKeyedEncodingContainer<NestedKey>(referencing: self.encoder, codingPath: self.codingPath, wrapping: dictionary)
+        return KeyedEncodingContainer(container)
+    }
+
+    public mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+        let containerKey = key.stringValue
+        let array: NSMutableArray
+        if let existingContainer = self.container[containerKey] {
+            precondition(
+                existingContainer is NSMutableArray, 
+                "Attempt to re-encode into nested UnkeyedEncodingContainer for key \"\(containerKey)\" is invalid: keyed container/single value already encoded for this key"
+            )
+            array = existingContainer as! NSMutableArray
+        } else {
+            array = NSMutableArray()
+            self.container[containerKey] = array
+        }
+
+        self.codingPath.append(key)
+        defer { self.codingPath.removeLast() }
+        return _PlistUnkeyedEncodingContainer(referencing: self.encoder, codingPath: self.codingPath, wrapping: array)
+    }
+
+    public mutating func superEncoder() -> Encoder {
+        return __PlistReferencingEncoder(referencing: self.encoder, at: _PlistKey.super, wrapping: self.container)
+    }
+
+    public mutating func superEncoder(forKey key: Key) -> Encoder {
+        return __PlistReferencingEncoder(referencing: self.encoder, at: key, wrapping: self.container)
+    }
+}
+
+fileprivate struct _PlistUnkeyedEncodingContainer : UnkeyedEncodingContainer {
+    // MARK: Properties
+
+    /// A reference to the encoder we're writing to.
+    private let encoder: __PlistEncoder
+
+    /// A reference to the container we're writing to.
+    private let container: NSMutableArray
+
+    /// The path of coding keys taken to get to this point in encoding.
+    private(set) public var codingPath: [CodingKey]
+
+    /// The number of elements encoded into the container.
+    public var count: Int {
+        return self.container.count
+    }
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with the given references.
+    fileprivate init(referencing encoder: __PlistEncoder, codingPath: [CodingKey], wrapping container: NSMutableArray) {
+        self.encoder = encoder
+        self.codingPath = codingPath
+        self.container = container
+    }
+
+    // MARK: - UnkeyedEncodingContainer Methods
+
+    public mutating func encodeNil()             throws { self.container.add(_plistNullNSString) }
+    public mutating func encode(_ value: Bool)   throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: Int)    throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: Int8)   throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: Int16)  throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: Int32)  throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: Int64)  throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: UInt)   throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: UInt8)  throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: UInt16) throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: UInt32) throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: UInt64) throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: Float)  throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: Double) throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encode(_ value: String) throws { self.container.add(self.encoder.box(value)) }
+
+    public mutating func encode<T : Encodable>(_ value: T) throws {
+        self.encoder.codingPath.append(_PlistKey(index: self.count))
+        defer { self.encoder.codingPath.removeLast() }
+        self.container.add(try self.encoder.box(value))
+    }
+
+    public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
+        self.codingPath.append(_PlistKey(index: self.count))
+        defer { self.codingPath.removeLast() }
+
+        let dictionary = NSMutableDictionary()
+        self.container.add(dictionary)
+
+        let container = _PlistKeyedEncodingContainer<NestedKey>(referencing: self.encoder, codingPath: self.codingPath, wrapping: dictionary)
+        return KeyedEncodingContainer(container)
+    }
+
+    public mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+        self.codingPath.append(_PlistKey(index: self.count))
+        defer { self.codingPath.removeLast() }
+
+        let array = NSMutableArray()
+        self.container.add(array)
+        return _PlistUnkeyedEncodingContainer(referencing: self.encoder, codingPath: self.codingPath, wrapping: array)
+    }
+
+    public mutating func superEncoder() -> Encoder {
+        return __PlistReferencingEncoder(referencing: self.encoder, at: self.container.count, wrapping: self.container)
+    }
+}
+
+extension __PlistEncoder : SingleValueEncodingContainer {
+    // MARK: - SingleValueEncodingContainer Methods
+
+    private func assertCanEncodeNewValue() {
+        precondition(self.canEncodeNewValue, "Attempt to encode value through single value container when previously value already encoded.")
+    }
+
+    public func encodeNil() throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: _plistNullNSString)
+    }
+
+    public func encode(_ value: Bool) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: Int) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: Int8) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: Int16) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: Int32) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: Int64) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: UInt) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: UInt8) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: UInt16) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: UInt32) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: UInt64) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: String) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: Float) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode(_ value: Double) throws {
+        assertCanEncodeNewValue()
+        self.storage.push(container: self.box(value))
+    }
+
+    public func encode<T : Encodable>(_ value: T) throws {
+        assertCanEncodeNewValue()
+        try self.storage.push(container: self.box(value))
+    }
+}
+
+// MARK: - Concrete Value Representations
+
+extension __PlistEncoder {
+
+    /// Returns the given value boxed in a container appropriate for pushing onto the container stack.
+    fileprivate func box(_ value: Bool)   -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: Int)    -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: Int8)   -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: Int16)  -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: Int32)  -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: Int64)  -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: UInt)   -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: UInt8)  -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: UInt16) -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: UInt32) -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: UInt64) -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: Float)  -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: Double) -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: String) -> NSObject { return NSString(string: value) }
+
+    fileprivate func box<T : Encodable>(_ value: T) throws -> NSObject {
+        return try self.box_(value) ?? NSDictionary()
+    }
+
+    fileprivate func box_<T : Encodable>(_ value: T) throws -> NSObject? {
+        if T.self == Date.self || T.self == NSDate.self {
+            // PropertyListSerialization handles NSDate directly.
+            return (value as! NSDate)
+        } else if T.self == Data.self || T.self == NSData.self {
+            // PropertyListSerialization handles NSData directly.
+            return (value as! NSData)
+        }
+
+        // The value should request a container from the __PlistEncoder.
+        let depth = self.storage.count
+        do {
+            try value.encode(to: self)
+        } catch let error {
+            // If the value pushed a container before throwing, pop it back off to restore state.
+            if self.storage.count > depth {
+                let _ = self.storage.popContainer()
+            }
+
+            throw error
+        }
+
+        // The top container should be a new container.
+        guard self.storage.count > depth else {
+            return nil
+        }
+
+        return self.storage.popContainer()
+    }
+}
+
+// MARK: - __PlistReferencingEncoder
+
+/// __PlistReferencingEncoder is a special subclass of __PlistEncoder which has its own storage, but references the contents of a different encoder.
+/// It's used in superEncoder(), which returns a new encoder for encoding a superclass -- the lifetime of the encoder should not escape the scope it's created in, but it doesn't necessarily know when it's done being used (to write to the original container).
+// NOTE: older overlays called this class _PlistReferencingEncoder.
+// The two must coexist without a conflicting ObjC class name, so it
+// was renamed. The old name must not be used in the new runtime.
+fileprivate class __PlistReferencingEncoder : __PlistEncoder {
+    // MARK: Reference types.
+
+    /// The type of container we're referencing.
+    private enum Reference {
+        /// Referencing a specific index in an array container.
+        case array(NSMutableArray, Int)
+
+        /// Referencing a specific key in a dictionary container.
+        case dictionary(NSMutableDictionary, String)
+    }
+
+    // MARK: - Properties
+
+    /// The encoder we're referencing.
+    private let encoder: __PlistEncoder
+
+    /// The container reference itself.
+    private let reference: Reference
+
+    // MARK: - Initialization
+
+    /// Initializes `self` by referencing the given array container in the given encoder.
+    fileprivate init(referencing encoder: __PlistEncoder, at index: Int, wrapping array: NSMutableArray) {
+        self.encoder = encoder
+        self.reference = .array(array, index)
+        super.init(options: encoder.options, codingPath: encoder.codingPath)
+
+        self.codingPath.append(_PlistKey(index: index))
+    }
+
+    /// Initializes `self` by referencing the given dictionary container in the given encoder.
+    fileprivate init(referencing encoder: __PlistEncoder, at key: CodingKey, wrapping dictionary: NSMutableDictionary) {
+        self.encoder = encoder
+        self.reference = .dictionary(dictionary, key.stringValue)
+        super.init(options: encoder.options, codingPath: encoder.codingPath)
+
+        self.codingPath.append(key)
+    }
+
+    // MARK: - Coding Path Operations
+
+    fileprivate override var canEncodeNewValue: Bool {
+        // With a regular encoder, the storage and coding path grow together.
+        // A referencing encoder, however, inherits its parents coding path, as well as the key it was created for.
+        // We have to take this into account.
+        return self.storage.count == self.codingPath.count - self.encoder.codingPath.count - 1
+    }
+
+    // MARK: - Deinitialization
+
+    // Finalizes `self` by writing the contents of our storage to the referenced encoder's storage.
+    deinit {
+        let value: Any
+        switch self.storage.count {
+        case 0: value = NSDictionary()
+        case 1: value = self.storage.popContainer()
+        default: fatalError("Referencing encoder deallocated with multiple containers on stack.")
+        }
+
+        switch self.reference {
+        case .array(let array, let index):
+            array.insert(value, at: index)
+
+        case .dictionary(let dictionary, let key):
+            dictionary[NSString(string: key)] = value
+        }
+    }
+}
+
+//===----------------------------------------------------------------------===//
+// Plist Decoder
+//===----------------------------------------------------------------------===//
+
+/// `PropertyListDecoder` facilitates the decoding of property list values into semantic `Decodable` types.
+// NOTE: older overlays had Foundation.PropertyListDecoder as the ObjC
+// name. The two must coexist, so it was renamed. The old name must not
+// be used in the new runtime. _TtC10Foundation20_PropertyListDecoder
+// is the mangled name for Foundation._PropertyListDecoder.
+@_objcRuntimeName(_TtC10Foundation20_PropertyListDecoder)
+open class PropertyListDecoder {
+    // MARK: Options
+
+    /// Contextual user-provided information for use during decoding.
+    open var userInfo: [CodingUserInfoKey : Any] = [:]
+
+    /// Options set on the top-level encoder to pass down the decoding hierarchy.
+    fileprivate struct _Options {
+        let userInfo: [CodingUserInfoKey : Any]
+    }
+
+    /// The options set on the top-level decoder.
+    fileprivate var options: _Options {
+        return _Options(userInfo: userInfo)
+    }
+
+    // MARK: - Constructing a Property List Decoder
+
+    /// Initializes `self` with default strategies.
+    public init() {}
+
+    // MARK: - Decoding Values
+
+    /// Decodes a top-level value of the given type from the given property list representation.
+    ///
+    /// - parameter type: The type of the value to decode.
+    /// - parameter data: The data to decode from.
+    /// - returns: A value of the requested type.
+    /// - throws: `DecodingError.dataCorrupted` if values requested from the payload are corrupted, or if the given data is not a valid property list.
+    /// - throws: An error if any value throws an error during decoding.
+    open func decode<T : Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        var format: PropertyListSerialization.PropertyListFormat = .binary
+        return try decode(type, from: data, format: &format)
+    }
+
+    /// Decodes a top-level value of the given type from the given property list representation.
+    ///
+    /// - parameter type: The type of the value to decode.
+    /// - parameter data: The data to decode from.
+    /// - parameter format: The parsed property list format.
+    /// - returns: A value of the requested type along with the detected format of the property list.
+    /// - throws: `DecodingError.dataCorrupted` if values requested from the payload are corrupted, or if the given data is not a valid property list.
+    /// - throws: An error if any value throws an error during decoding.
+    open func decode<T : Decodable>(_ type: T.Type, from data: Data, format: inout PropertyListSerialization.PropertyListFormat) throws -> T {
+        let topLevel: Any
+        do {
+            topLevel = try PropertyListSerialization.propertyList(from: data, options: [], format: &format)
+        } catch {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "The given data was not a valid property list.", underlyingError: error))
+        }
+
+        return try decode(type, fromTopLevel: topLevel)
+    }
+
+    /// Decodes a top-level value of the given type from the given property list container (top-level array or dictionary).
+    ///
+    /// - parameter type: The type of the value to decode.
+    /// - parameter container: The top-level plist container.
+    /// - returns: A value of the requested type.
+    /// - throws: `DecodingError.dataCorrupted` if values requested from the payload are corrupted, or if the given data is not a valid property list.
+    /// - throws: An error if any value throws an error during decoding.
+    internal func decode<T : Decodable>(_ type: T.Type, fromTopLevel container: Any) throws -> T {
+        let decoder = __PlistDecoder(referencing: container, options: self.options)
+        guard let value = try decoder.unbox(container, as: type) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: [], debugDescription: "The given data did not contain a top-level value."))
+        }
+
+        return value
+    }
+}
+
+// MARK: - __PlistDecoder
+
+// NOTE: older overlays called this class _PlistDecoder. The two must
+// coexist without a conflicting ObjC class name, so it was renamed.
+// The old name must not be used in the new runtime.
+fileprivate class __PlistDecoder : Decoder {
+    // MARK: Properties
+
+    /// The decoder's storage.
+    fileprivate var storage: _PlistDecodingStorage
+
+    /// Options set on the top-level decoder.
+    fileprivate let options: PropertyListDecoder._Options
+
+    /// The path to the current point in encoding.
+    fileprivate(set) public var codingPath: [CodingKey]
+
+    /// Contextual user-provided information for use during encoding.
+    public var userInfo: [CodingUserInfoKey : Any] {
+        return self.options.userInfo
+    }
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with the given top-level container and options.
+    fileprivate init(referencing container: Any, at codingPath: [CodingKey] = [], options: PropertyListDecoder._Options) {
+        self.storage = _PlistDecodingStorage()
+        self.storage.push(container: container)
+        self.codingPath = codingPath
+        self.options = options
+    }
+
+    // MARK: - Decoder Methods
+
+    public func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
+        guard !(self.storage.topContainer is NSNull) else {
+            throw DecodingError.valueNotFound(KeyedDecodingContainer<Key>.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                      debugDescription: "Cannot get keyed decoding container -- found null value instead."))
+        }
+
+        guard let topContainer = self.storage.topContainer as? [String : Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: self.storage.topContainer)
+        }
+
+        let container = _PlistKeyedDecodingContainer<Key>(referencing: self, wrapping: topContainer)
+        return KeyedDecodingContainer(container)
+    }
+
+    public func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        guard !(self.storage.topContainer is NSNull) else {
+            throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                      debugDescription: "Cannot get unkeyed decoding container -- found null value instead."))
+        }
+
+        guard let topContainer = self.storage.topContainer as? [Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [Any].self, reality: self.storage.topContainer)
+        }
+
+        return _PlistUnkeyedDecodingContainer(referencing: self, wrapping: topContainer)
+    }
+
+    public func singleValueContainer() throws -> SingleValueDecodingContainer {
+        return self
+    }
+}
+
+// MARK: - Decoding Storage
+
+fileprivate struct _PlistDecodingStorage {
+    // MARK: Properties
+
+    /// The container stack.
+    /// Elements may be any one of the plist types (NSNumber, Date, String, Array, [String : Any]).
+    private(set) fileprivate var containers: [Any] = []
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with no containers.
+    fileprivate init() {}
+
+    // MARK: - Modifying the Stack
+
+    fileprivate var count: Int {
+        return self.containers.count
+    }
+
+    fileprivate var topContainer: Any {
+        precondition(!self.containers.isEmpty, "Empty container stack.")
+        return self.containers.last!
+    }
+
+    fileprivate mutating func push(container: __owned Any) {
+        self.containers.append(container)
+    }
+
+    fileprivate mutating func popContainer() {
+        precondition(!self.containers.isEmpty, "Empty container stack.")
+        self.containers.removeLast()
+    }
+}
+
+// MARK: Decoding Containers
+
+fileprivate struct _PlistKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProtocol {
+    typealias Key = K
+
+    // MARK: Properties
+
+    /// A reference to the decoder we're reading from.
+    private let decoder: __PlistDecoder
+
+    /// A reference to the container we're reading from.
+    private let container: [String : Any]
+
+    /// The path of coding keys taken to get to this point in decoding.
+    private(set) public var codingPath: [CodingKey]
+
+    // MARK: - Initialization
+
+    /// Initializes `self` by referencing the given decoder and container.
+    fileprivate init(referencing decoder: __PlistDecoder, wrapping container: [String : Any]) {
+        self.decoder = decoder
+        self.container = container
+        self.codingPath = decoder.codingPath
+    }
+
+    // MARK: - KeyedDecodingContainerProtocol Methods
+
+    public var allKeys: [Key] {
+        return self.container.keys.compactMap { Key(stringValue: $0) }
+    }
+
+    public func contains(_ key: Key) -> Bool {
+        return self.container[key.stringValue] != nil
+    }
+
+    public func decodeNil(forKey key: Key) throws -> Bool {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+
+        guard let value = entry as? String else {
+            return false
+        }
+
+        return value == _plistNull
+    }
+
+    public func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: Bool.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: Int.Type, forKey key: Key) throws -> Int {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: Int.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: Int8.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: Int16.Type, forKey key: Key) throws -> Int16 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: Int16.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: Int32.Type, forKey key: Key) throws -> Int32 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: Int32.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: Int64.Type, forKey key: Key) throws -> Int64 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: Int64.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: UInt.Type, forKey key: Key) throws -> UInt {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: UInt.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: UInt8.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: UInt16.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: UInt32.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: UInt64.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: Float.Type, forKey key: Key) throws -> Float {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        guard let value = try self.decoder.unbox(entry, as: Float.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: Double.Type, forKey key: Key) throws -> Double {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: Double.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode(_ type: String.Type, forKey key: Key) throws -> String {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: String.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func decode<T : Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = try self.decoder.unbox(entry, as: type) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+
+        return value
+    }
+
+    public func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = self.container[key.stringValue] else {
+            throw DecodingError.valueNotFound(KeyedDecodingContainer<NestedKey>.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                      debugDescription: "Cannot get nested keyed container -- no value found for key \"\(key.stringValue)\""))
+        }
+
+        guard let dictionary = value as? [String : Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: value)
+        }
+
+        let container = _PlistKeyedDecodingContainer<NestedKey>(referencing: self.decoder, wrapping: dictionary)
+        return KeyedDecodingContainer(container)
+    }
+
+    public func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let value = self.container[key.stringValue] else {
+            throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                      debugDescription: "Cannot get nested unkeyed container -- no value found for key \"\(key.stringValue)\""))
+        }
+
+        guard let array = value as? [Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [Any].self, reality: value)
+        }
+
+        return _PlistUnkeyedDecodingContainer(referencing: self.decoder, wrapping: array)
+    }
+
+    private func _superDecoder(forKey key: __owned CodingKey) throws -> Decoder {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let value: Any = self.container[key.stringValue] ?? NSNull()
+        return __PlistDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
+    }
+
+    public func superDecoder() throws -> Decoder {
+        return try _superDecoder(forKey: _PlistKey.super)
+    }
+
+    public func superDecoder(forKey key: Key) throws -> Decoder {
+        return try _superDecoder(forKey: key)
+    }
+}
+
+fileprivate struct _PlistUnkeyedDecodingContainer : UnkeyedDecodingContainer {
+    // MARK: Properties
+
+    /// A reference to the decoder we're reading from.
+    private let decoder: __PlistDecoder
+
+    /// A reference to the container we're reading from.
+    private let container: [Any]
+
+    /// The path of coding keys taken to get to this point in decoding.
+    private(set) public var codingPath: [CodingKey]
+
+    /// The index of the element we're about to decode.
+    private(set) public var currentIndex: Int
+
+    // MARK: - Initialization
+
+    /// Initializes `self` by referencing the given decoder and container.
+    fileprivate init(referencing decoder: __PlistDecoder, wrapping container: [Any]) {
+        self.decoder = decoder
+        self.container = container
+        self.codingPath = decoder.codingPath
+        self.currentIndex = 0
+    }
+
+    // MARK: - UnkeyedDecodingContainer Methods
+
+    public var count: Int? {
+        return self.container.count
+    }
+
+    public var isAtEnd: Bool {
+        return self.currentIndex >= self.count!
+    }
+
+    public mutating func decodeNil() throws -> Bool {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(Any?.self, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        if self.container[self.currentIndex] is NSNull {
+            self.currentIndex += 1
+            return true
+        } else {
+            return false
+        }
+    }
+
+    public mutating func decode(_ type: Bool.Type) throws -> Bool {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Bool.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: Int.Type) throws -> Int {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: Int8.Type) throws -> Int8 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int8.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: Int16.Type) throws -> Int16 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int16.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: Int32.Type) throws -> Int32 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int32.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: Int64.Type) throws -> Int64 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int64.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: UInt.Type) throws -> UInt {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: UInt8.Type) throws -> UInt8 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt8.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: UInt16.Type) throws -> UInt16 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt16.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: UInt32.Type) throws -> UInt32 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt32.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: UInt64.Type) throws -> UInt64 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt64.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: Float.Type) throws -> Float {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Float.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: Double.Type) throws -> Double {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Double.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode(_ type: String.Type) throws -> String {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: String.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func decode<T : Decodable>(_ type: T.Type) throws -> T {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: type) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_PlistKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+
+        self.currentIndex += 1
+        return decoded
+    }
+
+    public mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> {
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(KeyedDecodingContainer<NestedKey>.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                      debugDescription: "Cannot get nested keyed container -- unkeyed container is at end."))
+        }
+
+        let value = self.container[self.currentIndex]
+        guard !(value is NSNull) else {
+            throw DecodingError.valueNotFound(KeyedDecodingContainer<NestedKey>.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                      debugDescription: "Cannot get keyed decoding container -- found null value instead."))
+        }
+
+        guard let dictionary = value as? [String : Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: value)
+        }
+
+        self.currentIndex += 1
+        let container = _PlistKeyedDecodingContainer<NestedKey>(referencing: self.decoder, wrapping: dictionary)
+        return KeyedDecodingContainer(container)
+    }
+
+    public mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                      debugDescription: "Cannot get nested unkeyed container -- unkeyed container is at end."))
+        }
+
+        let value = self.container[self.currentIndex]
+        guard !(value is NSNull) else {
+            throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                      debugDescription: "Cannot get keyed decoding container -- found null value instead."))
+        }
+
+        guard let array = value as? [Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [Any].self, reality: value)
+        }
+
+        self.currentIndex += 1
+        return _PlistUnkeyedDecodingContainer(referencing: self.decoder, wrapping: array)
+    }
+
+    public mutating func superDecoder() throws -> Decoder {
+        self.decoder.codingPath.append(_PlistKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(Decoder.self, DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get superDecoder() -- unkeyed container is at end."))
+        }
+
+        let value = self.container[self.currentIndex]
+        self.currentIndex += 1
+        return __PlistDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
+    }
+}
+
+extension __PlistDecoder : SingleValueDecodingContainer {
+    // MARK: SingleValueDecodingContainer Methods
+
+    private func expectNonNull<T>(_ type: T.Type) throws {
+        guard !self.decodeNil() else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected \(type) but found null value instead."))
+        }
+    }
+
+    public func decodeNil() -> Bool {
+        guard let string = self.storage.topContainer as? String else {
+            return false
+        }
+
+        return string == _plistNull
+    }
+
+    public func decode(_ type: Bool.Type) throws -> Bool {
+        try expectNonNull(Bool.self)
+        return try self.unbox(self.storage.topContainer, as: Bool.self)!
+    }
+
+    public func decode(_ type: Int.Type) throws -> Int {
+        try expectNonNull(Int.self)
+        return try self.unbox(self.storage.topContainer, as: Int.self)!
+    }
+
+    public func decode(_ type: Int8.Type) throws -> Int8 {
+        try expectNonNull(Int8.self)
+        return try self.unbox(self.storage.topContainer, as: Int8.self)!
+    }
+
+    public func decode(_ type: Int16.Type) throws -> Int16 {
+        try expectNonNull(Int16.self)
+        return try self.unbox(self.storage.topContainer, as: Int16.self)!
+    }
+
+    public func decode(_ type: Int32.Type) throws -> Int32 {
+        try expectNonNull(Int32.self)
+        return try self.unbox(self.storage.topContainer, as: Int32.self)!
+    }
+
+    public func decode(_ type: Int64.Type) throws -> Int64 {
+        try expectNonNull(Int64.self)
+        return try self.unbox(self.storage.topContainer, as: Int64.self)!
+    }
+
+    public func decode(_ type: UInt.Type) throws -> UInt {
+        try expectNonNull(UInt.self)
+        return try self.unbox(self.storage.topContainer, as: UInt.self)!
+    }
+
+    public func decode(_ type: UInt8.Type) throws -> UInt8 {
+        try expectNonNull(UInt8.self)
+        return try self.unbox(self.storage.topContainer, as: UInt8.self)!
+    }
+
+    public func decode(_ type: UInt16.Type) throws -> UInt16 {
+        try expectNonNull(UInt16.self)
+        return try self.unbox(self.storage.topContainer, as: UInt16.self)!
+    }
+
+    public func decode(_ type: UInt32.Type) throws -> UInt32 {
+        try expectNonNull(UInt32.self)
+        return try self.unbox(self.storage.topContainer, as: UInt32.self)!
+    }
+
+    public func decode(_ type: UInt64.Type) throws -> UInt64 {
+        try expectNonNull(UInt64.self)
+        return try self.unbox(self.storage.topContainer, as: UInt64.self)!
+    }
+
+    public func decode(_ type: Float.Type) throws -> Float {
+        try expectNonNull(Float.self)
+        return try self.unbox(self.storage.topContainer, as: Float.self)!
+    }
+
+    public func decode(_ type: Double.Type) throws -> Double {
+        try expectNonNull(Double.self)
+        return try self.unbox(self.storage.topContainer, as: Double.self)!
+    }
+
+    public func decode(_ type: String.Type) throws -> String {
+        try expectNonNull(String.self)
+        return try self.unbox(self.storage.topContainer, as: String.self)!
+    }
+
+    public func decode<T : Decodable>(_ type: T.Type) throws -> T {
+        try expectNonNull(type)
+        return try self.unbox(self.storage.topContainer, as: type)!
+    }
+}
+
+// MARK: - Concrete Value Representations
+
+extension __PlistDecoder {
+    /// Returns the given value unboxed from a container.
+    fileprivate func unbox(_ value: Any, as type: Bool.Type) throws -> Bool? {
+        if let string = value as? String, string == _plistNull { return nil }
+
+        if let number = value as? NSNumber {
+            // TODO: Add a flag to coerce non-boolean numbers into Bools?
+            if number === kCFBooleanTrue as NSNumber {
+                return true
+            } else if number === kCFBooleanFalse as NSNumber {
+                return false
+            }
+
+        /* FIXME: If swift-corelibs-foundation doesn't change to use NSNumber, this code path will need to be included and tested:
+        } else if let bool = value as? Bool {
+            return bool
+        */
+
+        }
+
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+
+    fileprivate func unbox(_ value: Any, as type: Int.Type) throws -> Int? {
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int = number.intValue
+        guard NSNumber(value: int) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return int
+    }
+
+    fileprivate func unbox(_ value: Any, as type: Int8.Type) throws -> Int8? {
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int8 = number.int8Value
+        guard NSNumber(value: int8) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return int8
+    }
+
+    fileprivate func unbox(_ value: Any, as type: Int16.Type) throws -> Int16? {
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int16 = number.int16Value
+        guard NSNumber(value: int16) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return int16
+    }
+
+    fileprivate func unbox(_ value: Any, as type: Int32.Type) throws -> Int32? {
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int32 = number.int32Value
+        guard NSNumber(value: int32) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return int32
+    }
+
+    fileprivate func unbox(_ value: Any, as type: Int64.Type) throws -> Int64? {
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int64 = number.int64Value
+        guard NSNumber(value: int64) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return int64
+    }
+
+    fileprivate func unbox(_ value: Any, as type: UInt.Type) throws -> UInt? {
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint = number.uintValue
+        guard NSNumber(value: uint) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint
+    }
+
+    fileprivate func unbox(_ value: Any, as type: UInt8.Type) throws -> UInt8? {
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint8 = number.uint8Value
+        guard NSNumber(value: uint8) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint8
+    }
+
+    fileprivate func unbox(_ value: Any, as type: UInt16.Type) throws -> UInt16? {
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint16 = number.uint16Value
+        guard NSNumber(value: uint16) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint16
+    }
+
+    fileprivate func unbox(_ value: Any, as type: UInt32.Type) throws -> UInt32? {
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint32 = number.uint32Value
+        guard NSNumber(value: uint32) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint32
+    }
+
+    fileprivate func unbox(_ value: Any, as type: UInt64.Type) throws -> UInt64? {
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint64 = number.uint64Value
+        guard NSNumber(value: uint64) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint64
+    }
+
+    fileprivate func unbox(_ value: Any, as type: Float.Type) throws -> Float? {
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let float = number.floatValue
+        guard NSNumber(value: float) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return float
+    }
+
+    fileprivate func unbox(_ value: Any, as type: Double.Type) throws -> Double? {
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber, number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let double = number.doubleValue
+        guard NSNumber(value: double) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return double
+    }
+
+    fileprivate func unbox(_ value: Any, as type: String.Type) throws -> String? {
+        guard let string = value as? String else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        return string == _plistNull ? nil : string
+    }
+
+    fileprivate func unbox(_ value: Any, as type: Date.Type) throws -> Date? {
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let date = value as? Date else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        return date
+    }
+
+    fileprivate func unbox(_ value: Any, as type: Data.Type) throws -> Data? {
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let data = value as? Data else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        return data
+    }
+
+    fileprivate func unbox<T : Decodable>(_ value: Any, as type: T.Type) throws -> T? {
+        if type == Date.self || type == NSDate.self {
+            return try self.unbox(value, as: Date.self) as? T
+        } else if type == Data.self || type == NSData.self {
+            return try self.unbox(value, as: Data.self) as? T
+        } else {
+            self.storage.push(container: value)
+            defer { self.storage.popContainer() }
+            return try type.init(from: self)
+        }
+    }
+}
+
+//===----------------------------------------------------------------------===//
+// Shared Plist Null Representation
+//===----------------------------------------------------------------------===//
+
+// Since plists do not support null values by default, we will encode them as "$null".
+fileprivate let _plistNull = "$null"
+fileprivate let _plistNullNSString = NSString(string: _plistNull)
+
+//===----------------------------------------------------------------------===//
+// Shared Key Types
+//===----------------------------------------------------------------------===//
+
+fileprivate struct _PlistKey : CodingKey {
+    public var stringValue: String
+    public var intValue: Int?
+
+    public init?(stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = nil
+    }
+
+    public init?(intValue: Int) {
+        self.stringValue = "\(intValue)"
+        self.intValue = intValue
+    }
+
+    fileprivate init(index: Int) {
+        self.stringValue = "Index \(index)"
+        self.intValue = index
+    }
+
+    fileprivate static let `super` = _PlistKey(stringValue: "super")!
+}

--- a/Darwin/Foundation-swiftoverlay/Pointers+DataProtocol.swift
+++ b/Darwin/Foundation-swiftoverlay/Pointers+DataProtocol.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+
+extension UnsafeRawBufferPointer : DataProtocol {
+    public var regions: CollectionOfOne<UnsafeRawBufferPointer> {
+        return CollectionOfOne(self)
+    }
+}
+
+extension UnsafeBufferPointer : DataProtocol where Element == UInt8 {
+    public var regions: CollectionOfOne<UnsafeBufferPointer<Element>> {
+        return CollectionOfOne(self)
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/Progress.swift
+++ b/Darwin/Foundation-swiftoverlay/Progress.swift
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+extension Progress {
+    @available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
+    public var estimatedTimeRemaining: TimeInterval? {
+        get {
+            guard let v = self.__estimatedTimeRemaining else { return nil }
+            return v.doubleValue
+        }
+        set {
+            guard let nv = newValue else {
+                self.__estimatedTimeRemaining = nil
+                return
+            }
+            let v = NSNumber(value: nv)
+            self.__estimatedTimeRemaining = v
+        }
+    }
+    
+    @available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
+    public var throughput: Int? {
+        get {
+            guard let v = self.__throughput else { return nil }
+            return v.intValue
+        }
+        set {
+            guard let nv = newValue else {
+                self.__throughput = nil
+                return
+            }
+            let v = NSNumber(value: nv)
+            self.__throughput = v
+        }
+    }
+    
+    @available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
+    public var fileTotalCount: Int? {
+        get {
+            guard let v = self.__fileTotalCount else { return nil }
+            return v.intValue
+        }
+        set {
+            guard let nv = newValue else {
+                self.__fileTotalCount = nil
+                return
+            }
+            let v = NSNumber(value: nv)
+            self.__fileTotalCount = v
+        }
+    }
+    
+    @available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
+    public var fileCompletedCount: Int? {
+        get {
+            guard let v = self.__fileCompletedCount else { return nil }
+            return v.intValue
+        }
+        set {
+            guard let nv = newValue else {
+                self.__fileCompletedCount = nil
+                return
+            }
+            let v = NSNumber(value: nv)
+            self.__fileCompletedCount = v
+        }
+    }
+    
+    public func performAsCurrent<ReturnType>(withPendingUnitCount unitCount: Int64, using work: () throws -> ReturnType) rethrows -> ReturnType {
+        becomeCurrent(withPendingUnitCount: unitCount)
+        defer { resignCurrent() }
+        return try work()
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/Publishers+KeyValueObserving.swift
+++ b/Darwin/Foundation-swiftoverlay/Publishers+KeyValueObserving.swift
@@ -1,0 +1,210 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Only support 64bit
+#if !(os(iOS) && (arch(i386) || arch(arm)))
+
+@_exported import Foundation // Clang module
+import Combine
+
+// The following protocol is so that we can reference `Self` in the Publisher
+// below. This is based on a trick used in the the standard library's
+// implementation of `NSObject.observe(key path)`
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public protocol _KeyValueCodingAndObservingPublishing {}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension NSObject: _KeyValueCodingAndObservingPublishing {}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension _KeyValueCodingAndObservingPublishing where Self: NSObject {
+    /// Publish values when the value identified by a KVO-compliant keypath changes.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The keypath of the property to publish.
+    ///   - options: Key-value observing options.
+    /// - Returns: A publisher that emits elements each time the property’s value changes.
+    public func publisher<Value>(for keyPath: KeyPath<Self, Value>,
+                                 options: NSKeyValueObservingOptions = [.initial, .new])
+        -> NSObject.KeyValueObservingPublisher<Self, Value> {
+        return NSObject.KeyValueObservingPublisher(object: self, keyPath: keyPath, options: options)
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension NSObject.KeyValueObservingPublisher {
+    /// Returns a publisher that emits values when a KVO-compliant property changes.
+    ///
+    /// - Returns: A key-value observing publisher.
+    public func didChange()
+        -> Publishers.Map<NSObject.KeyValueObservingPublisher<Subject, Value>, Void> {
+        return map { _ in () }
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension NSObject {
+    /// A publisher that emits events when the value of a KVO-compliant property changes.
+    public struct KeyValueObservingPublisher<Subject: NSObject, Value> : Equatable {
+        public let object: Subject
+        public let keyPath: KeyPath<Subject, Value>
+        public let options: NSKeyValueObservingOptions
+
+        public init(
+            object: Subject,
+            keyPath: KeyPath<Subject, Value>,
+            options: NSKeyValueObservingOptions
+        ) {
+            self.object = object
+            self.keyPath = keyPath
+            self.options = options
+        }
+
+        public static func == (
+            lhs: KeyValueObservingPublisher,
+            rhs: KeyValueObservingPublisher
+        ) -> Bool {
+            return lhs.object === rhs.object
+                && lhs.keyPath == rhs.keyPath
+                && lhs.options == rhs.options
+        }
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension NSObject.KeyValueObservingPublisher: Publisher {
+    public typealias Output = Value
+    public typealias Failure = Never
+
+    public func receive<S: Subscriber>(subscriber: S) where S.Input == Output, S.Failure == Failure {
+        let s = NSObject.KVOSubscription(object, keyPath, options, subscriber)
+        subscriber.receive(subscription: s)
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension NSObject {
+    private final class KVOSubscription<Subject: NSObject, Value>: Subscription, CustomStringConvertible, CustomReflectable, CustomPlaygroundDisplayConvertible {
+        private var observation: NSKeyValueObservation?         // GuardedBy(lock)
+        private var demand: Subscribers.Demand                  // GuardedBy(lock)
+
+        // for configurations that care about '.initial' we need to 'cache' the value to account for backpressure, along with whom to send it to
+        //
+        // TODO: in the future we might want to consider interjecting a temporary publisher that does this, so that all KVO subscriptions don't incur the cost.
+        private var receivedInitial: Bool                       // GuardedBy(lock)
+        private var last: Value?                                // GuardedBy(lock)
+        private var subscriber: AnySubscriber<Value, Never>?    // GuardedBy(lock)
+
+        private let lock = Lock()
+
+        // This lock can only be held for the duration of downstream callouts
+        private let downstreamLock = RecursiveLock()
+
+        var description: String { return "KVOSubscription" }
+        var customMirror: Mirror {
+            lock.lock()
+            defer { lock.unlock() }
+            return Mirror(self, children: [
+                "observation": observation as Any,
+                "demand": demand
+            ])
+        }
+        var playgroundDescription: Any { return description }
+
+        init<S: Subscriber>(
+            _ object: Subject,
+            _ keyPath: KeyPath<Subject, Value>,
+            _ options: NSKeyValueObservingOptions,
+            _ subscriber: S)
+            where
+                S.Input == Value,
+                S.Failure == Never
+        {
+            demand = .max(0)
+            receivedInitial = false
+            self.subscriber = AnySubscriber(subscriber)
+
+            observation = object.observe(
+                keyPath,
+                options: options
+            ) { [weak self] obj, _ in
+                guard let self = self else {
+                    return
+                }
+                let value = obj[keyPath: keyPath]
+                self.lock.lock()
+                if self.demand > 0, let sub = self.subscriber {
+                    self.demand -= 1
+                    self.lock.unlock()
+
+                    self.downstreamLock.lock()
+                    let additional = sub.receive(value)
+                    self.downstreamLock.unlock()
+
+                    self.lock.lock()
+                    self.demand += additional
+                    self.lock.unlock()
+                } else {
+                    // Drop the value, unless we've asked for .initial, and this
+                    // is the first value.
+                    if self.receivedInitial == false && options.contains(.initial) {
+                        self.last = value
+                        self.receivedInitial = true
+                    }
+                    self.lock.unlock()
+                }
+            }
+        }
+
+        deinit {
+            lock.cleanupLock()
+            downstreamLock.cleanupLock()
+        }
+
+        func request(_ d: Subscribers.Demand) {
+            lock.lock()
+            demand += d
+            if demand > 0, let v = last, let sub = subscriber {
+                demand -= 1
+                last = nil
+                lock.unlock()
+
+                downstreamLock.lock()
+                let additional = sub.receive(v)
+                downstreamLock.unlock()
+
+                lock.lock()
+                demand += additional
+            } else {
+                demand -= 1
+                last = nil
+            }
+            lock.unlock()
+        }
+
+        func cancel() {
+            lock.lock()
+            guard let o = observation else {
+                lock.unlock()
+                return
+            }
+            lock.unlock()
+
+            observation = nil
+            subscriber = nil
+            last = nil
+            o.invalidate()
+        }
+    }
+}
+
+#endif /* !(os(iOS) && (arch(i386) || arch(arm))) */

--- a/Darwin/Foundation-swiftoverlay/Publishers+Locking.swift
+++ b/Darwin/Foundation-swiftoverlay/Publishers+Locking.swift
@@ -1,0 +1,117 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Only support 64bit
+#if !(os(iOS) && (arch(i386) || arch(arm)))
+
+import Darwin
+
+@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+extension UnsafeMutablePointer where Pointee == os_unfair_lock_s {
+    internal init() {
+        let l = UnsafeMutablePointer.allocate(capacity: 1)
+        l.initialize(to: os_unfair_lock())
+        self = l
+    }
+    
+    internal func cleanupLock() {
+        deinitialize(count: 1)
+        deallocate()
+    }
+    
+    internal func lock() {
+        os_unfair_lock_lock(self)
+    }
+    
+    internal func tryLock() -> Bool {
+        let result = os_unfair_lock_trylock(self)
+        return result
+    }
+    
+    internal func unlock() {
+        os_unfair_lock_unlock(self)
+    }
+}
+
+@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+typealias Lock = os_unfair_lock_t
+
+#if canImport(DarwinPrivate)
+
+@_implementationOnly import DarwinPrivate
+
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 5.0, *)
+extension UnsafeMutablePointer where Pointee == os_unfair_recursive_lock_s {
+    internal init() {
+        let l = UnsafeMutablePointer.allocate(capacity: 1)
+        l.initialize(to: os_unfair_recursive_lock_s())
+        self = l
+    }
+    
+    internal func cleanupLock() {
+        deinitialize(count: 1)
+        deallocate()
+    }
+    
+    internal func lock() {
+        os_unfair_recursive_lock_lock(self)
+    }
+    
+    internal func tryLock() -> Bool {
+        let result = os_unfair_recursive_lock_trylock(self)
+        return result
+    }
+
+    internal func unlock() {
+        os_unfair_recursive_lock_unlock(self)
+    }
+}
+
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 5.0, *)
+typealias RecursiveLock = os_unfair_recursive_lock_t
+
+#else
+
+// Kept in overlay since some builds may not have `DarwinPrivate` but we should have the availability the same
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 5.0, *)
+internal struct RecursiveLock {
+    private let lockPtr: UnsafeMutablePointer<pthread_mutex_t>
+    
+    internal init() {
+        lockPtr = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
+        var attr = pthread_mutexattr_t()
+        pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE)
+        pthread_mutex_init(lockPtr, &attr)
+    }
+    
+    internal func cleanupLock() {
+        pthread_mutex_destroy(lockPtr)
+        lockPtr.deinitialize(count: 1)
+        lockPtr.deallocate()
+    }
+    
+    internal func lock() {
+        pthread_mutex_lock(lockPtr)
+    }
+    
+    internal func tryLock() -> Bool {
+        return pthread_mutex_trylock(lockPtr) == 0
+    }
+
+    internal func unlock() {
+        pthread_mutex_unlock(lockPtr)
+    }
+}
+
+#endif
+
+#endif /* !(os(iOS) && (arch(i386) || arch(arm))) */

--- a/Darwin/Foundation-swiftoverlay/Publishers+NotificationCenter.swift
+++ b/Darwin/Foundation-swiftoverlay/Publishers+NotificationCenter.swift
@@ -1,0 +1,183 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Only support 64bit
+#if !(os(iOS) && (arch(i386) || arch(arm)))
+
+@_exported import Foundation // Clang module
+import Combine
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension NotificationCenter {
+    /// Returns a publisher that emits events when broadcasting notifications.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the notification to publish.
+    ///   - object: The object posting the named notfication. If `nil`, the publisher emits elements for any object producing a notification with the given name.
+    /// - Returns: A publisher that emits events when broadcasting notifications.
+    public func publisher(
+        for name: Notification.Name,
+        object: AnyObject? = nil
+    ) -> NotificationCenter.Publisher {
+        return NotificationCenter.Publisher(center: self, name: name, object: object)
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension NotificationCenter {
+    /// A publisher that emits elements when broadcasting notifications.
+    public struct Publisher: Combine.Publisher {
+        public typealias Output = Notification
+        public typealias Failure = Never
+
+        /// The notification center this publisher uses as a source.
+        public let center: NotificationCenter
+        /// The name of notifications published by this publisher.
+        public let name: Notification.Name
+        /// The object posting the named notfication.
+        public let object: AnyObject?
+
+        /// Creates a publisher that emits events when broadcasting notifications.
+        ///
+        /// - Parameters:
+        ///   - center: The notification center to publish notifications for.
+        ///   - name: The name of the notification to publish.
+        ///   - object: The object posting the named notfication. If `nil`, the publisher emits elements for any object producing a notification with the given name.
+        public init(center: NotificationCenter, name: Notification.Name, object: AnyObject? = nil) {
+            self.center = center
+            self.name = name
+            self.object = object
+        }
+        
+        public func receive<S: Subscriber>(subscriber: S) where S.Input == Output, S.Failure == Failure {
+            subscriber.receive(subscription: Notification.Subscription(center, name, object, subscriber))
+        }
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension NotificationCenter.Publisher: Equatable {
+    public static func == (
+        lhs: NotificationCenter.Publisher,
+        rhs: NotificationCenter.Publisher
+    ) -> Bool {
+        return lhs.center === rhs.center
+            && lhs.name == rhs.name
+            && lhs.object === rhs.object
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Notification {
+    fileprivate final class Subscription<S: Subscriber>: Combine.Subscription, CustomStringConvertible, CustomReflectable, CustomPlaygroundDisplayConvertible
+        where
+            S.Input == Notification
+    {
+        private let lock = Lock()
+        
+        // This lock can only be held for the duration of downstream callouts
+        private let downstreamLock = RecursiveLock()
+
+        private var demand: Subscribers.Demand      // GuardedBy(lock)
+
+        private var center: NotificationCenter?     // GuardedBy(lock)
+        private let name: Notification.Name         // Stored only for debug info
+        private var object: AnyObject?              // Stored only for debug info
+        private var observation: AnyObject?         // GuardedBy(lock)
+
+        var description: String { return "NotificationCenter Observer" }
+        var customMirror: Mirror {
+            lock.lock()
+            defer { lock.unlock() }
+            return Mirror(self, children: [
+                "center": center as Any,
+                "name": name as Any,
+                "object": object as Any,
+                "demand": demand
+            ])
+        }
+        var playgroundDescription: Any { return description }
+
+        init(_ center: NotificationCenter,
+             _ name: Notification.Name,
+             _ object: AnyObject?,
+             _ next: S)
+        {
+            self.demand = .max(0)
+            self.center = center
+            self.name = name
+            self.object = object
+
+            self.observation = center.addObserver(
+                forName: name,
+                object: object,
+                queue: nil
+            ) { [weak self] note in
+                guard let self = self else { return }
+
+                self.lock.lock()
+                guard self.observation != nil else {
+                    self.lock.unlock()
+                    return
+                }
+
+                let demand = self.demand
+                if demand > 0 {
+                    self.demand -= 1
+                }
+                self.lock.unlock()
+
+                if demand > 0 {
+                    self.downstreamLock.lock()
+                    let additionalDemand = next.receive(note)
+                    self.downstreamLock.unlock()
+
+                    if additionalDemand > 0 {
+                        self.lock.lock()
+                        self.demand += additionalDemand
+                        self.lock.unlock()
+                    }
+                } else {
+                    // Drop it on the floor
+                }
+            }
+        }
+
+        deinit {
+            lock.cleanupLock()
+            downstreamLock.cleanupLock()
+        }
+
+        func request(_ d: Subscribers.Demand) {
+            lock.lock()
+            demand += d
+            lock.unlock()
+        }
+
+        func cancel() {
+            lock.lock()
+            guard let center = self.center,
+                let observation = self.observation else {
+                    lock.unlock()
+                    return
+            }
+            self.center = nil
+            self.observation = nil
+            self.object = nil
+            lock.unlock()
+
+            center.removeObserver(observation)
+        }
+    }
+}
+
+#endif /* !(os(iOS) && (arch(i386) || arch(arm))) */

--- a/Darwin/Foundation-swiftoverlay/Publishers+Timer.swift
+++ b/Darwin/Foundation-swiftoverlay/Publishers+Timer.swift
@@ -1,0 +1,328 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Only support 64bit
+#if !(os(iOS) && (arch(i386) || arch(arm)))
+
+@_exported import Foundation // Clang module
+import Combine
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Timer {
+    /// Returns a publisher that repeatedly emits the current date on the given interval.
+    ///
+    /// - Parameters:
+    ///   - interval: The time interval on which to publish events. For example, a value of `0.5` publishes an event approximately every half-second.
+    ///   - tolerance: The allowed timing variance when emitting events. Defaults to `nil`, which allows any variance.
+    ///   - runLoop: The run loop on which the timer runs.
+    ///   - mode: The run loop mode in which to run the timer.
+    ///   - options: Scheduler options passed to the timer. Defaults to `nil`.
+    /// - Returns: A publisher that repeatedly emits the current date on the given interval.
+    public static func publish(
+        every interval: TimeInterval,
+        tolerance: TimeInterval? = nil,
+        on runLoop: RunLoop,
+        in mode: RunLoop.Mode,
+        options: RunLoop.SchedulerOptions? = nil)
+        -> TimerPublisher
+    {
+        return TimerPublisher(interval: interval, runLoop: runLoop, mode: mode, options: options)
+    }
+    
+    /// A publisher that repeatedly emits the current date on a given interval.
+    public final class TimerPublisher: ConnectablePublisher {
+        public typealias Output = Date
+        public typealias Failure = Never
+
+        public let interval: TimeInterval
+        public let tolerance: TimeInterval?
+        public let runLoop: RunLoop
+        public let mode: RunLoop.Mode
+        public let options: RunLoop.SchedulerOptions?
+
+        private lazy var routingSubscription: RoutingSubscription = {
+            return RoutingSubscription(parent: self)
+        }()
+        
+        // Stores if a `.connect()` happened before subscription, internally readable for tests
+        internal var isConnected: Bool {
+            return routingSubscription.isConnected
+        }
+        
+        /// Creates a publisher that repeatedly emits the current date on the given interval.
+        ///
+        /// - Parameters:
+        ///   - interval: The interval on which to publish events.
+        ///   - tolerance: The allowed timing variance when emitting events. Defaults to `nil`, which allows any variance.
+        ///   - runLoop: The run loop on which the timer runs.
+        ///   - mode: The run loop mode in which to run the timer.
+        ///   - options: Scheduler options passed to the timer. Defaults to `nil`.
+        public init(interval: TimeInterval, tolerance: TimeInterval? = nil, runLoop: RunLoop, mode: RunLoop.Mode, options: RunLoop.SchedulerOptions? = nil) {
+            self.interval = interval
+            self.tolerance = tolerance
+            self.runLoop = runLoop
+            self.mode = mode
+            self.options = options
+        }
+
+        /// Adapter subscription to allow `Timer` to multiplex to multiple subscribers
+        /// the values produced by a single `TimerPublisher.Inner`
+        private class RoutingSubscription: Subscription, Subscriber, CustomStringConvertible, CustomReflectable, CustomPlaygroundDisplayConvertible {
+            typealias Input = Date
+            typealias Failure = Never
+
+            private typealias ErasedSubscriber = AnySubscriber<Output, Failure>
+
+            private let lock: Lock
+
+            // Inner is IUP due to init requirements
+            private var inner: Inner<RoutingSubscription>!
+            private var subscribers: [ErasedSubscriber] = []
+
+            private var _lockedIsConnected = false
+            var isConnected: Bool {
+                get {
+                    lock.lock()
+                    defer { lock.unlock() }
+                    return _lockedIsConnected
+                }
+
+                set {
+                    lock.lock()
+                    let oldValue = _lockedIsConnected
+                    _lockedIsConnected = newValue
+
+                    // Inner will always be non-nil
+                    let inner = self.inner!
+                    lock.unlock()
+
+                    guard newValue, !oldValue else {
+                        return
+                    }
+                    inner.enqueue()
+                }
+            }
+            
+            var description: String { return "Timer" }
+            var customMirror: Mirror { return inner.customMirror }
+            var playgroundDescription: Any { return description }
+            var combineIdentifier: CombineIdentifier { return inner.combineIdentifier }
+            
+            init(parent: TimerPublisher) {
+                self.lock = Lock()
+                self.inner = Inner(parent, self)
+            }
+
+            deinit {
+                lock.cleanupLock()
+            }
+
+            func addSubscriber<S: Subscriber>(_ sub: S)
+                where
+                    S.Failure == Failure,
+                    S.Input == Output
+            {
+                lock.lock()
+                subscribers.append(AnySubscriber(sub))
+                lock.unlock()
+
+                sub.receive(subscription: self)
+            }
+
+            func receive(subscription: Subscription) {
+                lock.lock()
+                let subscribers = self.subscribers
+                lock.unlock()
+
+                for sub in subscribers {
+                    sub.receive(subscription: subscription)
+                }
+            }
+
+            func receive(_ value: Input) -> Subscribers.Demand {
+                var resultingDemand: Subscribers.Demand = .max(0)
+                lock.lock()
+                let subscribers = self.subscribers
+                let isConnected = _lockedIsConnected
+                lock.unlock()
+
+                guard isConnected else { return .none }
+
+                for sub in subscribers {
+                    resultingDemand += sub.receive(value)
+                }
+                return resultingDemand
+            }
+
+            func receive(completion: Subscribers.Completion<Failure>) {
+                lock.lock()
+                let subscribers = self.subscribers
+                lock.unlock()
+
+                for sub in subscribers {
+                    sub.receive(completion: completion)
+                }
+            }
+
+            func request(_ demand: Subscribers.Demand) {
+                lock.lock()
+                // Inner will always be non-nil
+                let inner = self.inner!
+                lock.unlock()
+
+                inner.request(demand)
+            }
+
+            func cancel() {
+                lock.lock()
+                // Inner will always be non-nil
+                let inner = self.inner!
+                _lockedIsConnected = false
+                self.subscribers = []
+                lock.unlock()
+
+                inner.cancel()
+            }
+        }
+
+        public func receive<S: Subscriber>(subscriber: S) where Failure == S.Failure, Output == S.Input {
+            routingSubscription.addSubscriber(subscriber)
+        }
+
+        public func connect() -> Cancellable {
+            routingSubscription.isConnected = true
+            return routingSubscription
+        }
+
+        private typealias Parent = TimerPublisher
+        private final class Inner<Downstream: Subscriber>: NSObject, Subscription, CustomReflectable, CustomPlaygroundDisplayConvertible
+            where
+                Downstream.Input == Date,
+                Downstream.Failure == Never
+        {
+            private lazy var timer: Timer? = {
+                let t = Timer(
+                    timeInterval: parent?.interval ?? 0,
+                    target: self,
+                    selector: #selector(timerFired),
+                    userInfo: nil,
+                    repeats: true
+                )
+
+                t.tolerance = parent?.tolerance ?? 0
+
+                return t
+            }()
+
+            private let lock: Lock
+            private var downstream: Downstream?
+            private var parent: Parent?
+            private var started: Bool
+            private var demand: Subscribers.Demand
+            
+            override var description: String { return "Timer" }
+            var customMirror: Mirror {
+                lock.lock()
+                defer { lock.unlock() }
+                return Mirror(self, children: [
+                    "downstream": downstream as Any,
+                    "interval": parent?.interval as Any,
+                    "tolerance": parent?.tolerance as Any
+                ])
+            }
+            var playgroundDescription: Any { return description }
+            
+            init(_ parent: Parent, _ downstream: Downstream) {
+                self.lock = Lock()
+                self.parent = parent
+                self.downstream = downstream
+                self.started = false
+                self.demand = .max(0)
+                super.init()
+            }
+
+            deinit {
+                lock.cleanupLock()
+            }
+
+            func enqueue() {
+                lock.lock()
+                guard let t = timer, let parent = self.parent, !started else {
+                    lock.unlock()
+                    return
+                }
+
+                started = true
+                lock.unlock()
+                
+                parent.runLoop.add(t, forMode: parent.mode)
+            }
+            
+            func cancel() {
+                lock.lock()
+                guard let t = timer else {
+                    lock.unlock()
+                    return
+                }
+
+                // clear out all optionals
+                downstream = nil
+                parent = nil
+                started = false
+                demand = .max(0)
+                timer = nil
+                lock.unlock()
+
+                // cancel the timer
+                t.invalidate()
+            }
+            
+            func request(_ n: Subscribers.Demand) {
+                lock.lock()
+                defer { lock.unlock() }
+                guard parent != nil else {
+                    return
+                }
+                demand += n
+            }
+
+            @objc
+            func timerFired(arg: Any) {
+                lock.lock()
+                guard let ds = downstream, parent != nil else {
+                    lock.unlock()
+                    return
+                }
+
+                // This publisher drops events on the floor when there is no space in the subscriber
+                guard demand > 0 else {
+                    lock.unlock()
+                    return
+                }
+
+                demand -= 1
+                lock.unlock()
+                
+                let extra = ds.receive(Date())
+                guard extra > 0 else {
+                    return
+                }
+
+                lock.lock()
+                demand += extra
+                lock.unlock()
+            }
+        }
+    }
+}
+
+#endif /* !(os(iOS) && (arch(i386) || arch(arm))) */

--- a/Darwin/Foundation-swiftoverlay/Publishers+URLSession.swift
+++ b/Darwin/Foundation-swiftoverlay/Publishers+URLSession.swift
@@ -1,0 +1,175 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Only support 64bit
+#if !(os(iOS) && (arch(i386) || arch(arm)))
+
+@_exported import Foundation // Clang module
+import Combine
+
+// MARK: Data Tasks
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension URLSession {
+    /// Returns a publisher that wraps a URL session data task for a given URL.
+    ///
+    /// The publisher publishes data when the task completes, or terminates if the task fails with an error.
+    /// - Parameter url: The URL for which to create a data task.
+    /// - Returns: A publisher that wraps a data task for the URL.
+    public func dataTaskPublisher(
+        for url: URL)
+        -> DataTaskPublisher
+    {
+        let request = URLRequest(url: url)
+        return DataTaskPublisher(request: request, session: self)
+    }
+
+    /// Returns a publisher that wraps a URL session data task for a given URL request.
+    ///
+    /// The publisher publishes data when the task completes, or terminates if the task fails with an error.
+    /// - Parameter request: The URL request for which to create a data task.
+    /// - Returns: A publisher that wraps a data task for the URL request.
+    public func dataTaskPublisher(
+        for request: URLRequest)
+        -> DataTaskPublisher
+    {
+        return DataTaskPublisher(request: request, session: self)
+    }
+
+    public struct DataTaskPublisher: Publisher {
+        public typealias Output = (data: Data, response: URLResponse)
+        public typealias Failure = URLError
+        
+        public let request: URLRequest
+        public let session: URLSession
+        
+        public init(request: URLRequest, session: URLSession) {
+            self.request = request
+            self.session = session
+        }
+        
+        public func receive<S: Subscriber>(subscriber: S) where Failure == S.Failure, Output == S.Input {
+            subscriber.receive(subscription: Inner(self, subscriber))
+        }
+        
+        private typealias Parent = DataTaskPublisher
+        private final class Inner<Downstream: Subscriber>: Subscription, CustomStringConvertible, CustomReflectable, CustomPlaygroundDisplayConvertible
+            where
+                Downstream.Input == Parent.Output,
+                Downstream.Failure == Parent.Failure
+        {
+            typealias Input = Downstream.Input
+            typealias Failure = Downstream.Failure
+            
+            private let lock: Lock
+            private var parent: Parent?             // GuardedBy(lock)
+            private var downstream: Downstream?     // GuardedBy(lock)
+            private var demand: Subscribers.Demand  // GuardedBy(lock)
+            private var task: URLSessionDataTask!   // GuardedBy(lock)
+
+            var description: String { return "DataTaskPublisher" }
+            var customMirror: Mirror {
+                lock.lock()
+                defer { lock.unlock() }
+                return Mirror(self, children: [
+                    "task": task as Any,
+                    "downstream": downstream as Any,
+                    "parent": parent as Any,
+                    "demand": demand,
+                ])
+            }
+            var playgroundDescription: Any { return description }
+            
+            init(_ parent: Parent, _ downstream: Downstream) {
+                self.lock = Lock()
+                self.parent = parent
+                self.downstream = downstream
+                self.demand = .max(0)
+            }
+            
+            deinit {
+                lock.cleanupLock()
+            }
+            
+            // MARK: - Upward Signals
+            func request(_ d: Subscribers.Demand) {
+                precondition(d > 0, "Invalid request of zero demand")
+                
+                lock.lock()
+                guard let p = parent else {
+                    // We've already been cancelled so bail
+                    lock.unlock()
+                    return
+                }
+                
+                // Avoid issues around `self` before init by setting up only once here
+                if self.task == nil {
+                    let task = p.session.dataTask(
+                        with: p.request,
+                        completionHandler: handleResponse(data:response:error:)
+                    )
+                    self.task = task
+                }
+                
+                self.demand += d
+                let task = self.task!
+                lock.unlock()
+                
+                task.resume()
+            }
+            
+            private func handleResponse(data: Data?, response: URLResponse?, error: Error?) {
+                lock.lock()
+                guard demand > 0,
+                      parent != nil,
+                      let ds = downstream
+                else {
+                    lock.unlock()
+                    return
+                }
+                
+                parent = nil
+                downstream = nil
+
+                // We clear demand since this is a single shot shape
+                demand = .max(0)
+                task = nil
+                lock.unlock()
+                
+                if let response = response, error == nil {
+                    _ = ds.receive((data ?? Data(), response))
+                    ds.receive(completion: .finished)
+                } else {
+                    let urlError = error as? URLError ?? URLError(.unknown)
+                    ds.receive(completion: .failure(urlError))
+                }
+            }
+            
+            func cancel() {
+                lock.lock()
+                guard parent != nil else {
+                    lock.unlock()
+                    return
+                }
+                parent = nil
+                downstream = nil
+                demand = .max(0)
+                let task = self.task
+                self.task = nil
+                lock.unlock()
+                task?.cancel()
+            }
+        }
+    }
+}
+
+#endif /* !(os(iOS) && (arch(i386) || arch(arm))) */

--- a/Darwin/Foundation-swiftoverlay/ReferenceConvertible.swift
+++ b/Darwin/Foundation-swiftoverlay/ReferenceConvertible.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+/// Decorates types which are backed by a Foundation reference type.
+///
+/// All `ReferenceConvertible` types are hashable, equatable, and provide description functions.
+public protocol ReferenceConvertible : _ObjectiveCBridgeable, CustomStringConvertible, CustomDebugStringConvertible, Hashable {
+    associatedtype ReferenceType : NSObject, NSCopying
+}

--- a/Darwin/Foundation-swiftoverlay/Scanner.swift
+++ b/Darwin/Foundation-swiftoverlay/Scanner.swift
@@ -1,0 +1,217 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+extension CharacterSet {
+    fileprivate func contains(_ character: Character) -> Bool {
+        return character.unicodeScalars.allSatisfy(self.contains(_:))
+    }
+}
+
+// -----
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension Scanner {
+    public enum NumberRepresentation {
+        case decimal // See the %d, %f and %F format conversions.
+        case hexadecimal // See the %x, %X, %a and %A format conversions. For integers, a leading 0x or 0X is optional; for floating-point numbers, it is required.
+    }
+    
+    public var currentIndex: String.Index {
+        get {
+            let string = self.string
+            var index = string._toUTF16Index(scanLocation)
+            
+            var delta = 0
+            while index != string.endIndex && index.samePosition(in: string) == nil {
+                delta += 1
+                index = string._toUTF16Index(scanLocation + delta)
+            }
+            
+            return index
+        }
+        set { scanLocation = string._toUTF16Offset(newValue) }
+    }
+    
+    fileprivate func _scan<Integer: FixedWidthInteger>
+        (representation: NumberRepresentation,
+         scanDecimal: (UnsafeMutablePointer<Integer>?) -> Bool,
+         scanHexadecimal: (UnsafeMutablePointer<Integer>?) -> Bool) -> Integer? {
+        var value: Integer = .max
+        
+        switch representation {
+        case .decimal: guard scanDecimal(&value) else { return nil }
+        case .hexadecimal: guard scanHexadecimal(&value) else { return nil }
+        }
+        
+        return value
+    }
+    
+    fileprivate func _scan<FloatingPoint: BinaryFloatingPoint>
+        (representation: NumberRepresentation,
+         scanDecimal: (UnsafeMutablePointer<FloatingPoint>?) -> Bool,
+         scanHexadecimal: (UnsafeMutablePointer<FloatingPoint>?) -> Bool) -> FloatingPoint? {
+        var value: FloatingPoint = .greatestFiniteMagnitude
+        
+        switch representation {
+        case .decimal: guard scanDecimal(&value) else { return nil }
+        case .hexadecimal: guard scanHexadecimal(&value) else { return nil }
+        }
+        
+        return value
+    }
+    
+    fileprivate func _scan<Integer: FixedWidthInteger, OverflowingHexadecimalInteger: FixedWidthInteger & UnsignedInteger>
+        (representation: NumberRepresentation,
+         scanDecimal: (UnsafeMutablePointer<Integer>?) -> Bool,
+         overflowingScanHexadecimal: (UnsafeMutablePointer<OverflowingHexadecimalInteger>?) -> Bool) -> Integer? {
+        return _scan(representation: representation, scanDecimal: scanDecimal, scanHexadecimal: { (pointer) -> Bool in
+            var unsignedValue: OverflowingHexadecimalInteger = .max
+            guard overflowingScanHexadecimal(&unsignedValue) else { return false }
+            if unsignedValue <= Integer.max {
+                pointer?.pointee = Integer(unsignedValue)
+            }
+            return true
+        })
+    }
+    
+    public func scanInt(representation: NumberRepresentation = .decimal) -> Int? {
+#if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
+        if let value = scanInt64(representation: representation) { 
+            return Int(value)
+        }
+#elseif arch(i386) || arch(arm)
+        if let value = scanInt32(representation: representation) { 
+            return Int(value)
+        }
+#else
+    #error("This architecture isn't known. Add it to the 32-bit or 64-bit line; if the machine word isn't either of those, you need to implement appropriate scanning and handle the potential overflow here.")
+#endif
+        return nil
+    }
+    
+    public func scanInt32(representation: NumberRepresentation = .decimal) -> Int32? {
+        return _scan(representation: representation, scanDecimal: self.scanInt32(_:), overflowingScanHexadecimal: self.scanHexInt32(_:))
+    }
+    
+    public func scanInt64(representation: NumberRepresentation = .decimal) -> Int64? {
+        return _scan(representation: representation, scanDecimal: self.scanInt64(_:), overflowingScanHexadecimal: self.scanHexInt64(_:))
+    }
+    
+    public func scanUInt64(representation: NumberRepresentation = .decimal) -> UInt64? {
+        return _scan(representation: representation, scanDecimal: self.scanUnsignedLongLong(_:), scanHexadecimal: self.scanHexInt64(_:))
+    }
+    
+    public func scanFloat(representation: NumberRepresentation = .decimal) -> Float? {
+        return _scan(representation: representation, scanDecimal: self.scanFloat(_:), scanHexadecimal: self.scanHexFloat(_:))
+    }
+    
+    public func scanDouble(representation: NumberRepresentation = .decimal) -> Double? {
+        return _scan(representation: representation, scanDecimal: self.scanDouble(_:), scanHexadecimal: self.scanHexDouble(_:))
+    }
+    
+    public func scanDecimal() -> Decimal? {
+        var value: Decimal = 0
+        guard scanDecimal(&value) else { return nil }
+        return value
+    }
+    
+    
+    fileprivate var _currentIndexAfterSkipping: String.Index {
+        guard let skips = charactersToBeSkipped else { return currentIndex }
+        
+        let index = string[currentIndex...].firstIndex(where: { !skips.contains($0) })
+        return index ?? string.endIndex
+    }
+    
+    public func scanString(_ searchString: String) -> String? {
+        let currentIndex = _currentIndexAfterSkipping
+        
+        guard let substringEnd = string.index(currentIndex, offsetBy: searchString.count, limitedBy: string.endIndex) else { return nil }
+        
+        if string.compare(searchString, options: self.caseSensitive ? [] : .caseInsensitive, range: currentIndex ..< substringEnd, locale: self.locale as? Locale) == .orderedSame {
+            let it = string[currentIndex ..< substringEnd]
+            self.currentIndex = substringEnd
+            return String(it)
+        } else {
+            return nil
+        }
+    }
+    
+    public func scanCharacters(from set: CharacterSet) -> String? {
+        let currentIndex = _currentIndexAfterSkipping
+        
+        let substringEnd = string[currentIndex...].firstIndex(where: { !set.contains($0) }) ?? string.endIndex
+        guard currentIndex != substringEnd else { return nil }
+        
+        let substring = string[currentIndex ..< substringEnd]
+        self.currentIndex = substringEnd
+        return String(substring)
+    }
+    
+    public func scanUpToString(_ substring: String) -> String? {
+        guard !substring.isEmpty else { return nil }
+        let string = self.string
+        let startIndex = _currentIndexAfterSkipping
+
+        var beginningOfNewString = string.endIndex
+        var currentSearchIndex = startIndex
+        
+        repeat {
+            guard let range = string.range(of: substring, options: self.caseSensitive ? [] : .caseInsensitive, range: currentSearchIndex ..< string.endIndex, locale: self.locale as? Locale) else {
+                // If the string isn't found at all, it means it's not in the string. Just take everything to the end.
+                beginningOfNewString = string.endIndex
+                break
+            }
+            
+            // range(of:…) can return partial grapheme ranges when dealing with emoji.
+            // Make sure we take a range only if it doesn't split a grapheme in the string.
+            if let maybeBeginning = range.lowerBound.samePosition(in: string),
+                range.upperBound.samePosition(in: string) != nil {
+                beginningOfNewString = maybeBeginning
+                break
+            }
+            
+            // If we got here, we need to search again starting from just after the location we found.
+            currentSearchIndex = range.upperBound
+        } while beginningOfNewString == string.endIndex && currentSearchIndex < string.endIndex
+        
+        guard startIndex != beginningOfNewString else { return nil }
+        
+        let foundSubstring = string[startIndex ..< beginningOfNewString]
+        self.currentIndex = beginningOfNewString
+        return String(foundSubstring)
+    }
+    
+    public func scanUpToCharacters(from set: CharacterSet) -> String? {
+        let currentIndex = _currentIndexAfterSkipping
+        let string = self.string
+        
+        let firstCharacterInSet = string[currentIndex...].firstIndex(where: { set.contains($0) }) ?? string.endIndex
+        guard currentIndex != firstCharacterInSet else { return nil }
+        self.currentIndex = firstCharacterInSet
+        return String(string[currentIndex ..< firstCharacterInSet])
+    }
+    
+    public func scanCharacter() -> Character? {
+        let currentIndex = _currentIndexAfterSkipping
+        
+        let string = self.string
+        
+        guard currentIndex != string.endIndex else { return nil }
+        
+        let character = string[currentIndex]
+        self.currentIndex = string.index(after: currentIndex)
+        return character
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/Schedulers+Date.swift
+++ b/Darwin/Foundation-swiftoverlay/Schedulers+Date.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Only support 64bit
+#if !(os(iOS) && (arch(i386) || arch(arm)))
+
+@_exported import Foundation // Clang module
+import Combine
+
+// Date cannot conform to Strideable per rdar://35158274
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+ extension Date /* : Strideable */ {
+    public typealias Stride = TimeInterval
+    
+    public func distance(to other: Date) -> TimeInterval {
+        return other.timeIntervalSinceReferenceDate - self.timeIntervalSinceReferenceDate
+    }
+    
+    public func advanced(by n: TimeInterval) -> Date {
+        return self + n
+    }
+}
+
+#endif /* !(os(iOS) && (arch(i386) || arch(arm)))  */

--- a/Darwin/Foundation-swiftoverlay/Schedulers+OperationQueue.swift
+++ b/Darwin/Foundation-swiftoverlay/Schedulers+OperationQueue.swift
@@ -1,0 +1,214 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Only support 64bit
+#if !(os(iOS) && (arch(i386) || arch(arm)))
+
+@_exported import Foundation // Clang module
+import Combine
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension OperationQueue: Scheduler {
+    /// The scheduler time type used by the operation queue.
+    public struct SchedulerTimeType: Strideable, Codable, Hashable {
+        /// The date represented by this type.
+        public var date: Date
+        
+        /// Initializes a operation queue scheduler time with the given date.
+        ///
+        /// - Parameter date: The date to represent.
+        public init(_ date: Date) {
+            self.date = date
+        }
+
+        /// Returns the distance to another operation queue scheduler time.
+        ///
+        /// - Parameter other: Another operation queue time.
+        /// - Returns: The time interval between this time and the provided time.
+        public func distance(to other: OperationQueue.SchedulerTimeType) -> OperationQueue.SchedulerTimeType.Stride {
+            return OperationQueue.SchedulerTimeType.Stride(floatLiteral: date.distance(to: other.date))
+        }
+    
+        /// Returns a operation queue scheduler time calculated by advancing this instance’s time by the given interval.
+        ///
+        /// - Parameter n: A time interval to advance.
+        /// - Returns: A operation queue time advanced by the given interval from this instance’s time.
+        public func advanced(by n: OperationQueue.SchedulerTimeType.Stride) -> OperationQueue.SchedulerTimeType {
+            return OperationQueue.SchedulerTimeType(date.advanced(by: n.timeInterval))
+        }
+        
+        /// The interval by which operation queue times advance.
+        public struct Stride: ExpressibleByFloatLiteral, Comparable, SignedNumeric, Codable, SchedulerTimeIntervalConvertible {
+            public typealias FloatLiteralType = TimeInterval
+            public typealias IntegerLiteralType = TimeInterval
+            public typealias Magnitude = TimeInterval
+
+            /// The value of this time interval in seconds.
+            public var magnitude: TimeInterval
+            
+            /// The value of this time interval in seconds.
+            public var timeInterval: TimeInterval {
+                return magnitude
+            }
+
+            public init(integerLiteral value: TimeInterval) {
+                magnitude = value
+            }
+            
+            public init(floatLiteral value: TimeInterval) {
+                magnitude = value
+            }
+            
+            public init(_ timeInterval: TimeInterval) {
+                magnitude = timeInterval
+            }
+            
+            public init?<T>(exactly source: T) where T: BinaryInteger {
+                if let d = TimeInterval(exactly: source) {
+                    magnitude = d
+                } else {
+                    return nil
+                }
+            }
+            
+            // ---
+            
+            public static func < (lhs: Stride, rhs: Stride) -> Bool {
+                return lhs.magnitude < rhs.magnitude
+            }
+
+            // ---
+            
+            public static func * (lhs: Stride, rhs: Stride) -> Stride {
+                return Stride(lhs.timeInterval * rhs.timeInterval)
+            }
+            
+            public static func + (lhs: Stride, rhs: Stride) -> Stride {
+                return Stride(lhs.magnitude + rhs.magnitude)
+            }
+            
+            public static func - (lhs: Stride, rhs: Stride) -> Stride {
+                return Stride(lhs.magnitude - rhs.magnitude)
+            }
+
+            // ---
+            
+            public static func *= (lhs: inout Stride, rhs: Stride) {
+                let result = lhs * rhs
+                lhs = result
+            }
+            
+            public static func += (lhs: inout Stride, rhs: Stride) {
+                let result = lhs + rhs
+                lhs = result
+            }
+
+            public static func -= (lhs: inout Stride, rhs: Stride) {
+                let result = lhs - rhs
+                lhs = result
+            }
+            
+            // ---
+            
+            public static func seconds(_ s: Int) -> Stride {
+                return Stride(Double(s))
+            }
+            
+            public static func seconds(_ s: Double) -> Stride {
+                return Stride(s)
+            }
+            
+            public static func milliseconds(_ ms: Int) -> Stride {
+                return Stride(Double(ms) / 1_000.0)
+            }
+            
+            public static func microseconds(_ us: Int) -> Stride {
+                return Stride(Double(us) / 1_000_000.0)
+            }
+            
+            public static func nanoseconds(_ ns: Int) -> Stride {
+                return Stride(Double(ns) / 1_000_000_000.0)
+            }
+        }
+    }
+
+    /// Options that affect the operation of the operation queue scheduler.
+    public struct SchedulerOptions { }
+
+    private final class DelayReadyOperation: Operation, Cancellable {
+        static var readySchedulingQueue: DispatchQueue = {
+            return DispatchQueue(label: "DelayReadyOperation")
+        }()
+
+        var action: (() -> Void)?
+        var readyFromAfter: Bool
+
+        init(_ action: @escaping() -> Void, after: OperationQueue.SchedulerTimeType) {
+            self.action = action
+            readyFromAfter = false
+            super.init()
+            let deadline = DispatchTime.now() + after.date.timeIntervalSinceNow            
+            DelayReadyOperation.readySchedulingQueue.asyncAfter(deadline: deadline) { [weak self] in
+                self?.becomeReady()
+            }
+        }
+        
+        override func main() {
+            action!()
+            action = nil
+        }
+        
+        func becomeReady() {
+            willChangeValue(for: \.isReady)
+            readyFromAfter = true
+            didChangeValue(for: \.isReady)
+        }
+        
+        override var isReady: Bool {
+            return super.isReady && readyFromAfter
+        }
+    }
+
+    public func schedule(options: OperationQueue.SchedulerOptions?,
+                         _ action: @escaping () -> Void) {
+        let op = BlockOperation(block: action)
+        addOperation(op)
+    }
+
+    public func schedule(after date: OperationQueue.SchedulerTimeType,
+                         tolerance: OperationQueue.SchedulerTimeType.Stride,
+                         options: OperationQueue.SchedulerOptions?,
+                         _ action: @escaping () -> Void) {
+        let op = DelayReadyOperation(action, after: date)
+        addOperation(op)
+    }
+    
+    public func schedule(after date: OperationQueue.SchedulerTimeType,
+                         interval: OperationQueue.SchedulerTimeType.Stride,
+                         tolerance: OperationQueue.SchedulerTimeType.Stride,
+                         options: OperationQueue.SchedulerOptions?,
+                         _ action: @escaping () -> Void) -> Cancellable {
+        let op = DelayReadyOperation(action, after: date.advanced(by: interval))
+        addOperation(op)
+        return AnyCancellable(op)
+    }
+
+    public var now: OperationQueue.SchedulerTimeType {
+        return OperationQueue.SchedulerTimeType(Date())
+    }
+    
+    public var minimumTolerance: OperationQueue.SchedulerTimeType.Stride {
+        return OperationQueue.SchedulerTimeType.Stride(0.0)
+    }
+}
+
+#endif /* !(os(iOS) && (arch(i386) || arch(arm))) */

--- a/Darwin/Foundation-swiftoverlay/Schedulers+RunLoop.swift
+++ b/Darwin/Foundation-swiftoverlay/Schedulers+RunLoop.swift
@@ -1,0 +1,199 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Only support 64bit
+#if !(os(iOS) && (arch(i386) || arch(arm)))
+
+@_exported import Foundation // Clang module
+import Combine
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension RunLoop: Scheduler {
+    /// The scheduler time type used by the run loop.
+    public struct SchedulerTimeType: Strideable, Codable, Hashable {
+        /// The date represented by this type.
+        public var date: Date
+        
+        /// Initializes a run loop scheduler time with the given date.
+        ///
+        /// - Parameter date: The date to represent.
+        public init(_ date: Date) {
+            self.date = date
+        }
+
+        /// Returns the distance to another run loop scheduler time.
+        ///
+        /// - Parameter other: Another dispatch queue time.
+        /// - Returns: The time interval between this time and the provided time.
+        public func distance(to other: RunLoop.SchedulerTimeType) -> SchedulerTimeType.Stride {
+            return Stride(floatLiteral: date.distance(to: other.date))
+        }
+    
+        /// Returns a run loop scheduler time calculated by advancing this instance’s time by the given interval.
+        ///
+        /// - Parameter n: A time interval to advance.
+        /// - Returns: A dispatch queue time advanced by the given interval from this instance’s time.
+        public func advanced(by n: SchedulerTimeType.Stride) -> RunLoop.SchedulerTimeType {
+            return SchedulerTimeType(date.advanced(by: n.timeInterval))
+        }
+        
+        /// The interval by which run loop times advance.
+        public struct Stride: ExpressibleByFloatLiteral, Comparable, SignedNumeric, Codable, SchedulerTimeIntervalConvertible {
+            public typealias FloatLiteralType = TimeInterval
+            public typealias IntegerLiteralType = TimeInterval
+            public typealias Magnitude = TimeInterval
+
+            /// The value of this time interval in seconds.
+            public var magnitude: TimeInterval
+            
+            /// The value of this time interval in seconds.
+            public var timeInterval: TimeInterval {
+                return magnitude
+            }
+
+            public init(integerLiteral value: TimeInterval) {
+                magnitude = value
+            }
+            
+            public init(floatLiteral value: TimeInterval) {
+                magnitude = value
+            }
+            
+            public init(_ timeInterval: TimeInterval) {
+                magnitude = timeInterval
+            }
+            
+            public init?<T>(exactly source: T) where T: BinaryInteger {
+                if let d = TimeInterval(exactly: source) {
+                    magnitude = d
+                } else {
+                    return nil
+                }
+            }
+            
+            // ---
+            
+            public static func < (lhs: Stride, rhs: Stride) -> Bool {
+                return lhs.magnitude < rhs.magnitude
+            }
+
+            // ---
+            
+            public static func * (lhs: Stride, rhs: Stride) -> Stride {
+                return Stride(lhs.timeInterval * rhs.timeInterval)
+            }
+            
+            public static func + (lhs: Stride, rhs: Stride) -> Stride {
+                return Stride(lhs.magnitude + rhs.magnitude)
+            }
+            
+            public static func - (lhs: Stride, rhs: Stride) -> Stride {
+                return Stride(lhs.magnitude - rhs.magnitude)
+            }
+
+            // ---
+            
+            public static func *= (lhs: inout Stride, rhs: Stride) {
+                let result = lhs * rhs
+                lhs = result
+            }
+            
+            public static func += (lhs: inout Stride, rhs: Stride) {
+                let result = lhs + rhs
+                lhs = result
+            }
+
+            public static func -= (lhs: inout Stride, rhs: Stride) {
+                let result = lhs - rhs
+                lhs = result
+            }
+            
+            // ---
+            
+            public static func seconds(_ s: Int) -> Stride {
+                return Stride(Double(s))
+            }
+            
+            public static func seconds(_ s: Double) -> Stride {
+                return Stride(s)
+            }
+            
+            public static func milliseconds(_ ms: Int) -> Stride {
+                return Stride(Double(ms) / 1_000.0)
+            }
+            
+            public static func microseconds(_ us: Int) -> Stride {
+                return Stride(Double(us) / 1_000_000.0)
+            }
+            
+            public static func nanoseconds(_ ns: Int) -> Stride {
+                return Stride(Double(ns) / 1_000_000_000.0)
+            }
+        }
+    }
+    
+    /// Options that affect the operation of the run loop scheduler.
+    public struct SchedulerOptions { }
+
+    public func schedule(options: SchedulerOptions?,
+                         _ action: @escaping () -> Void) {
+        self.perform(action)
+    }
+    
+    public func schedule(after date: SchedulerTimeType,
+                         tolerance: SchedulerTimeType.Stride,
+                         options: SchedulerOptions?,
+                         _ action: @escaping () -> Void) {
+        let ti = date.date.timeIntervalSince(Date())
+        self.perform(#selector(self.runLoopScheduled), with: _CombineRunLoopAction(action), afterDelay: ti)
+    }
+    
+    public func schedule(after date: SchedulerTimeType,
+                         interval: SchedulerTimeType.Stride,
+                         tolerance: SchedulerTimeType.Stride,
+                         options: SchedulerOptions?,
+                         _ action: @escaping () -> Void) -> Cancellable {
+        let timer = Timer(fire: date.date, interval: interval.timeInterval, repeats: true) { _ in
+            action()
+        }
+
+        timer.tolerance = tolerance.timeInterval
+        self.add(timer, forMode: .default)
+
+        return AnyCancellable(timer.invalidate)
+    }
+
+    public var now: SchedulerTimeType {
+        return SchedulerTimeType(Date())
+    }
+        
+    public var minimumTolerance: SchedulerTimeType.Stride {
+        return 0.0
+    }
+    
+    @objc
+    fileprivate func runLoopScheduled(action: _CombineRunLoopAction) {
+        action.action()
+    }
+}
+
+@objc
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private class _CombineRunLoopAction: NSObject {
+    let action: () -> Void
+    
+    init(_ action: @escaping () -> Void) {
+        self.action = action
+    }
+}
+
+#endif /* !(os(iOS) && (arch(i386) || arch(arm))) */

--- a/Darwin/Foundation-swiftoverlay/String.swift
+++ b/Darwin/Foundation-swiftoverlay/String.swift
@@ -1,0 +1,124 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+@_spi(Foundation) import Swift
+
+//===----------------------------------------------------------------------===//
+// New Strings
+//===----------------------------------------------------------------------===//
+
+//
+// Conversion from NSString to Swift's native representation
+//
+
+extension String {
+  public init(_ cocoaString: NSString) {
+    self = String(_cocoaString: cocoaString)
+  }
+}
+
+extension String : _ObjectiveCBridgeable {
+  @_semantics("convertToObjectiveC")
+  public func _bridgeToObjectiveC() -> NSString {
+    // This method should not do anything extra except calling into the
+    // implementation inside core.  (These two entry points should be
+    // equivalent.)
+    return unsafeBitCast(_bridgeToObjectiveCImpl(), to: NSString.self)
+  }
+
+  public static func _forceBridgeFromObjectiveC(
+    _ x: NSString,
+    result: inout String?
+  ) {
+    result = String(x)
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSString,
+    result: inout String?
+  ) -> Bool {
+    self._forceBridgeFromObjectiveC(x, result: &result)
+    return result != nil
+  }
+
+  @_effects(readonly)
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ source: NSString?
+  ) -> String {
+    // `nil` has historically been used as a stand-in for an empty
+    // string; map it to an empty string.
+    if _slowPath(source == nil) { return String() }
+    return String(source!)
+  }
+}
+
+extension Substring : _ObjectiveCBridgeable {
+  @_semantics("convertToObjectiveC")
+  public func _bridgeToObjectiveC() -> NSString {
+    return String(self)._bridgeToObjectiveC()
+  }
+
+  public static func _forceBridgeFromObjectiveC(
+    _ x: NSString,
+    result: inout Substring?
+  ) {
+    let s = String(x)
+    result = s[...]
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSString,
+    result: inout Substring?
+  ) -> Bool {
+    self._forceBridgeFromObjectiveC(x, result: &result)
+    return result != nil
+  }
+
+  @_effects(readonly)
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ source: NSString?
+  ) -> Substring {
+    // `nil` has historically been used as a stand-in for an empty
+    // string; map it to an empty substring.
+    if _slowPath(source == nil) { return Substring() }
+    let s = String(source!)
+    return s[...]
+  }
+}
+
+extension String: CVarArg {}
+
+/*
+ This is on NSObject so that the stdlib can call it in StringBridge.swift
+ without having to synthesize a receiver (e.g. lookup a class or allocate)
+ 
+ In the future (once the Foundation overlay can know about SmallString), we
+ should move the caller of this method up into the overlay and avoid this
+ indirection.
+ */
+private extension NSObject {
+  // The ObjC selector has to start with "new" to get ARC to not autorelease
+  @_effects(releasenone)
+  @objc(newTaggedNSStringWithASCIIBytes_:length_:)
+  func createTaggedString(bytes: UnsafePointer<UInt8>,
+                          count: Int) -> AnyObject? {
+    //TODO: update this to use _CFStringCreateTaggedPointerString once we can
+    return CFStringCreateWithBytes(
+      kCFAllocatorSystemDefault,
+      bytes,
+      count,
+      CFStringBuiltInEncodings.UTF8.rawValue,
+      false
+    ) as NSString as NSString? //just "as AnyObject" inserts unwanted bridging
+  }
+}

--- a/Darwin/Foundation-swiftoverlay/TimeZone.swift
+++ b/Darwin/Foundation-swiftoverlay/TimeZone.swift
@@ -1,0 +1,303 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+@_implementationOnly import _FoundationOverlayShims
+
+/**
+ `TimeZone` defines the behavior of a time zone. Time zone values represent geopolitical regions. Consequently, these values have names for these regions. Time zone values also represent a temporal offset, either plus or minus, from Greenwich Mean Time (GMT) and an abbreviation (such as PST for Pacific Standard Time).
+ 
+ `TimeZone` provides two static functions to get time zone values: `current` and `autoupdatingCurrent`. The `autoupdatingCurrent` time zone automatically tracks updates made by the user.
+ 
+ Note that time zone database entries such as "America/Los_Angeles" are IDs, not names. An example of a time zone name is "Pacific Daylight Time". Although many `TimeZone` functions include the word "name", they refer to IDs.
+ 
+ Cocoa does not provide any API to change the time zone of the computer, or of other applications.
+ */
+public struct TimeZone : Hashable, Equatable, ReferenceConvertible {
+    public typealias ReferenceType = NSTimeZone
+    
+    private var _wrapped : NSTimeZone
+    private var _autoupdating : Bool
+    
+    /// The time zone currently used by the system.
+    public static var current : TimeZone {
+        return TimeZone(adoptingReference: __NSTimeZoneCurrent() as! NSTimeZone, autoupdating: false)
+    }
+    
+    /// The time zone currently used by the system, automatically updating to the user's current preference.
+    ///
+    /// If this time zone is mutated, then it no longer tracks the system time zone.
+    ///
+    /// The autoupdating time zone only compares equal to itself.
+    public static var autoupdatingCurrent : TimeZone {
+        return TimeZone(adoptingReference: __NSTimeZoneAutoupdating() as! NSTimeZone, autoupdating: true)
+    }
+    
+    // MARK: -
+    //
+    
+    /// Returns a time zone initialized with a given identifier.
+    ///
+    /// An example identifier is "America/Los_Angeles".
+    ///
+    /// If `identifier` is an unknown identifier, then returns `nil`.
+    public init?(identifier: __shared String) {
+        if let r = NSTimeZone(name: identifier) {
+            _wrapped = r
+            _autoupdating = false
+        } else {
+            return nil
+        }
+    }
+    
+    @available(*, unavailable, renamed: "init(secondsFromGMT:)")
+    public init(forSecondsFromGMT seconds: Int) { fatalError() }
+    
+    /// Returns a time zone initialized with a specific number of seconds from GMT.
+    ///
+    /// Time zones created with this never have daylight savings and the offset is constant no matter the date. The identifier and abbreviation do NOT follow the POSIX convention (of minutes-west).
+    ///
+    /// - parameter seconds: The number of seconds from GMT.
+    /// - returns: A time zone, or `nil` if a valid time zone could not be created from `seconds`.
+    public init?(secondsFromGMT seconds: Int) {
+        if let r = NSTimeZone(forSecondsFromGMT: seconds) as NSTimeZone? {
+            _wrapped = r
+            _autoupdating = false
+        } else {
+            return nil
+        }
+    }
+    
+    /// Returns a time zone identified by a given abbreviation.
+    ///
+    /// In general, you are discouraged from using abbreviations except for unique instances such as "GMT". Time Zone abbreviations are not standardized and so a given abbreviation may have multiple meanings--for example, "EST" refers to Eastern Time in both the United States and Australia
+    ///
+    /// - parameter abbreviation: The abbreviation for the time zone.
+    /// - returns: A time zone identified by abbreviation determined by resolving the abbreviation to an identifier using the abbreviation dictionary and then returning the time zone for that identifier. Returns `nil` if there is no match for abbreviation.
+    public init?(abbreviation: __shared String) {
+        if let r = NSTimeZone(abbreviation: abbreviation) {
+            _wrapped = r
+            _autoupdating = false
+        } else {
+            return nil
+        }
+    }
+    
+    private init(reference: NSTimeZone) {
+        if __NSTimeZoneIsAutoupdating(reference) {
+            // we can't copy this or we lose its auto-ness (27048257)
+            // fortunately it's immutable
+            _autoupdating = true
+            _wrapped = reference
+        } else {
+            _autoupdating = false
+            _wrapped = reference.copy() as! NSTimeZone
+        }
+    }
+
+    private init(adoptingReference reference: NSTimeZone, autoupdating: Bool) {
+        // this path is only used for types we do not need to copy (we are adopting the ref)
+        _wrapped = reference
+        _autoupdating = autoupdating
+    }
+
+    // MARK: -
+    //
+    
+    @available(*, unavailable, renamed: "identifier")
+    public var name: String { fatalError() }
+
+    /// The geopolitical region identifier that identifies the time zone.
+    public var identifier: String {
+        return _wrapped.name
+    }
+    
+    @available(*, unavailable, message: "use the identifier instead")
+    public var data: Data { fatalError() }
+    
+    /// The current difference in seconds between the time zone and Greenwich Mean Time.
+    ///
+    /// - parameter date: The date to use for the calculation. The default value is the current date.
+    public func secondsFromGMT(for date: Date = Date()) -> Int {
+        return _wrapped.secondsFromGMT(for: date)
+    }
+    
+    /// Returns the abbreviation for the time zone at a given date.
+    ///
+    /// Note that the abbreviation may be different at different dates. For example, during daylight saving time the US/Eastern time zone has an abbreviation of "EDT." At other times, its abbreviation is "EST."
+    /// - parameter date: The date to use for the calculation. The default value is the current date.
+    public func abbreviation(for date: Date = Date()) -> String? {
+        return _wrapped.abbreviation(for: date)
+    }
+    
+    /// Returns a Boolean value that indicates whether the receiver uses daylight saving time at a given date.
+    ///
+    /// - parameter date: The date to use for the calculation. The default value is the current date.
+    public func isDaylightSavingTime(for date: Date = Date()) -> Bool {
+        return _wrapped.isDaylightSavingTime(for: date)
+    }
+    
+    /// Returns the daylight saving time offset for a given date.
+    ///
+    /// - parameter date: The date to use for the calculation. The default value is the current date.
+    public func daylightSavingTimeOffset(for date: Date = Date()) -> TimeInterval {
+        return _wrapped.daylightSavingTimeOffset(for: date)
+    }
+    
+    /// Returns the next daylight saving time transition after a given date.
+    ///
+    /// - parameter date: A date.
+    /// - returns: The next daylight saving time transition after `date`. Depending on the time zone, this function may return a change of the time zone's offset from GMT. Returns `nil` if the time zone of the receiver does not observe daylight savings time as of `date`.
+    public func nextDaylightSavingTimeTransition(after date: Date) -> Date? {
+        return _wrapped.nextDaylightSavingTimeTransition(after: date)
+    }
+    
+    /// Returns an array of strings listing the identifier of all the time zones known to the system.
+    public static var knownTimeZoneIdentifiers : [String] {
+        return NSTimeZone.knownTimeZoneNames
+    }
+    
+    /// Returns the mapping of abbreviations to time zone identifiers.
+    public static var abbreviationDictionary : [String : String] {
+        get {
+            return NSTimeZone.abbreviationDictionary
+        }
+        set {
+            NSTimeZone.abbreviationDictionary = newValue
+        }
+    }
+    
+    /// Returns the time zone data version.
+    public static var timeZoneDataVersion : String {
+        return NSTimeZone.timeZoneDataVersion
+    }
+    
+    /// Returns the date of the next (after the current instant) daylight saving time transition for the time zone. Depending on the time zone, the value of this property may represent a change of the time zone's offset from GMT. Returns `nil` if the time zone does not currently observe daylight saving time.
+    public var nextDaylightSavingTimeTransition: Date? {
+        return _wrapped.nextDaylightSavingTimeTransition
+    }
+
+    @available(*, unavailable, renamed: "localizedName(for:locale:)")
+    public func localizedName(_ style: NSTimeZone.NameStyle, locale: Locale?) -> String? { fatalError() }
+
+    /// Returns the name of the receiver localized for a given locale.
+    public func localizedName(for style: NSTimeZone.NameStyle, locale: Locale?) -> String? {
+        return _wrapped.localizedName(style, locale: locale)
+    }
+    
+    // MARK: -
+    
+    public func hash(into hasher: inout Hasher) {
+        if _autoupdating {
+            hasher.combine(false)
+        } else {
+            hasher.combine(true)
+            hasher.combine(_wrapped)
+        }
+    }
+
+    public static func ==(lhs: TimeZone, rhs: TimeZone) -> Bool {
+        if lhs._autoupdating || rhs._autoupdating {
+            return lhs._autoupdating == rhs._autoupdating
+        } else {
+            return lhs._wrapped.isEqual(rhs._wrapped)
+        }
+    }
+}
+
+extension TimeZone : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    private var _kindDescription : String {
+        if self == TimeZone.autoupdatingCurrent {
+            return "autoupdatingCurrent"
+        } else if self == TimeZone.current {
+            return "current"
+        } else {
+            return "fixed"
+        }
+    }
+    
+    public var customMirror : Mirror {
+        let c: [(label: String?, value: Any)] = [
+          ("identifier", identifier),
+          ("kind", _kindDescription),
+          ("abbreviation", abbreviation() as Any),
+          ("secondsFromGMT", secondsFromGMT()),
+          ("isDaylightSavingTime", isDaylightSavingTime()),
+        ]
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+    }
+    
+    public var description: String {
+        return "\(identifier) (\(_kindDescription))"
+    }
+    
+    public var debugDescription : String {
+        return "\(identifier) (\(_kindDescription))"
+    }
+}
+
+extension TimeZone : _ObjectiveCBridgeable {
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSTimeZone {
+        // _wrapped is immutable
+        return _wrapped
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ input: NSTimeZone, result: inout TimeZone?) {
+        if !_conditionallyBridgeFromObjectiveC(input, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ input: NSTimeZone, result: inout TimeZone?) -> Bool {
+        result = TimeZone(reference: input)
+        return true
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSTimeZone?) -> TimeZone {
+        var result: TimeZone?
+        _forceBridgeFromObjectiveC(source!, result: &result)
+        return result!
+    }
+}
+
+extension NSTimeZone : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as TimeZone)
+    }
+}
+
+extension TimeZone : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case identifier
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let identifier = try container.decode(String.self, forKey: .identifier)
+
+        guard let timeZone = TimeZone(identifier: identifier) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Invalid TimeZone identifier."))
+        }
+
+        self = timeZone
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.identifier, forKey: .identifier)
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/URL.swift
+++ b/Darwin/Foundation-swiftoverlay/URL.swift
@@ -1,0 +1,1240 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+/**
+ URLs to file system resources support the properties defined below. Note that not all property values will exist for all file system URLs. For example, if a file is located on a volume that does not support creation dates, it is valid to request the creation date property, but the returned value will be nil, and no error will be generated.
+ 
+ Only the fields requested by the keys you pass into the `URL` function to receive this value will be populated. The others will return `nil` regardless of the underlying property on the file system.
+ 
+ As a convenience, volume resource values can be requested from any file system URL. The value returned will reflect the property value for the volume on which the resource is located.
+*/
+public struct URLResourceValues {
+    fileprivate var _values: [URLResourceKey: Any]
+    fileprivate var _keys: Set<URLResourceKey>
+    
+    public init() {
+        _values = [:]
+        _keys = []
+    }
+    
+    fileprivate init(keys: Set<URLResourceKey>, values: [URLResourceKey: Any]) {
+        _values = values
+        _keys = keys
+    }
+    
+    private func contains(_ key: URLResourceKey) -> Bool {
+        return _keys.contains(key)
+    }
+    
+    private func _get<T>(_ key : URLResourceKey) -> T? {
+        return _values[key] as? T
+    }
+    private func _get(_ key : URLResourceKey) -> Bool? {
+        return (_values[key] as? NSNumber)?.boolValue
+    }
+    private func _get(_ key: URLResourceKey) -> Int? {
+        return (_values[key] as? NSNumber)?.intValue
+    }
+    
+    private mutating func _set(_ key : URLResourceKey, newValue : __owned Any?) {
+        _keys.insert(key)
+        _values[key] = newValue
+    }
+    private mutating func _set(_ key : URLResourceKey, newValue : String?) {
+        _keys.insert(key)
+        _values[key] = newValue as NSString?
+    }
+    private mutating func _set(_ key : URLResourceKey, newValue : [String]?) {
+        _keys.insert(key)
+        _values[key] = newValue as NSObject?
+    }
+    private mutating func _set(_ key : URLResourceKey, newValue : Date?) {
+        _keys.insert(key)
+        _values[key] = newValue as NSDate?
+    }
+    private mutating func _set(_ key : URLResourceKey, newValue : URL?) {
+        _keys.insert(key)
+        _values[key] = newValue as NSURL?
+    }
+    private mutating func _set(_ key : URLResourceKey, newValue : Bool?) {
+        _keys.insert(key)
+        if let value = newValue {
+            _values[key] = NSNumber(value: value)
+        } else {
+            _values[key] = nil
+        }
+    }
+    private mutating func _set(_ key : URLResourceKey, newValue : Int?) {
+        _keys.insert(key)
+        if let value = newValue {
+            _values[key] = NSNumber(value: value)
+        } else {
+            _values[key] = nil
+        }
+    }
+    
+    /// A loosely-typed dictionary containing all keys and values.
+    ///
+    /// If you have set temporary keys or non-standard keys, you can find them in here.
+    public var allValues : [URLResourceKey : Any] {
+        return _values
+    }
+    
+    /// The resource name provided by the file system.
+    public var name: String? {
+        get { return _get(.nameKey) }
+        set { _set(.nameKey, newValue: newValue) }
+    }
+    
+    /// Localized or extension-hidden name as displayed to users.
+    public var localizedName: String? { return _get(.localizedNameKey) }
+    
+    /// True for regular files.
+    public var isRegularFile: Bool? { return _get(.isRegularFileKey) }
+    
+    /// True for directories.
+    public var isDirectory: Bool? { return _get(.isDirectoryKey) }
+    
+    /// True for symlinks.
+    public var isSymbolicLink: Bool? { return _get(.isSymbolicLinkKey) }
+    
+    /// True for the root directory of a volume.
+    public var isVolume: Bool? { return _get(.isVolumeKey) }
+    
+    /// True for packaged directories. 
+    ///
+    /// - note: You can only set or clear this property on directories; if you try to set this property on non-directory objects, the property is ignored. If the directory is a package for some other reason (extension type, etc), setting this property to false will have no effect.
+    public var isPackage: Bool? {
+        get { return _get(.isPackageKey) }
+        set { _set(.isPackageKey, newValue: newValue) }
+    }
+    
+    /// True if resource is an application.
+    @available(macOS 10.11, iOS 9.0, *)
+    public var isApplication: Bool? { return _get(.isApplicationKey) }
+    
+#if os(macOS)
+    /// True if the resource is scriptable. Only applies to applications.
+    @available(macOS 10.11, *)
+    public var applicationIsScriptable: Bool? { return _get(.applicationIsScriptableKey) }
+#endif
+    
+    /// True for system-immutable resources.
+    public var isSystemImmutable: Bool? { return _get(.isSystemImmutableKey) }
+    
+    /// True for user-immutable resources
+    public var isUserImmutable: Bool? {
+        get { return _get(.isUserImmutableKey) }
+        set { _set(.isUserImmutableKey, newValue: newValue) }
+    }
+    
+    /// True for resources normally not displayed to users.
+    /// 
+    /// - note: If the resource is a hidden because its name starts with a period, setting this property to false will not change the property.
+    public var isHidden: Bool? {
+        get { return _get(.isHiddenKey) }
+        set { _set(.isHiddenKey, newValue: newValue) }
+    }
+    
+    /// True for resources whose filename extension is removed from the localized name property.
+    public var hasHiddenExtension: Bool? {
+        get { return _get(.hasHiddenExtensionKey) }
+        set { _set(.hasHiddenExtensionKey, newValue: newValue) }
+    }
+    
+    /// The date the resource was created.
+    public var creationDate: Date? {
+        get { return _get(.creationDateKey) }
+        set { _set(.creationDateKey, newValue: newValue) }
+    }
+    
+    /// The date the resource was last accessed.
+    public var contentAccessDate: Date? {
+        get { return _get(.contentAccessDateKey) }
+        set { _set(.contentAccessDateKey, newValue: newValue) }
+    }
+    
+    /// The time the resource content was last modified.
+    public var contentModificationDate: Date? {
+        get { return _get(.contentModificationDateKey) }
+        set { _set(.contentModificationDateKey, newValue: newValue) }
+    }
+    
+    /// The time the resource's attributes were last modified.
+    public var attributeModificationDate: Date? { return _get(.attributeModificationDateKey) }
+    
+    /// Number of hard links to the resource.
+    public var linkCount: Int? { return _get(.linkCountKey) }
+    
+    /// The resource's parent directory, if any.
+    public var parentDirectory: URL? { return _get(.parentDirectoryURLKey) }
+    
+    /// URL of the volume on which the resource is stored.
+    public var volume: URL? { return _get(.volumeURLKey) }
+    
+    /// Uniform type identifier (UTI) for the resource.
+    public var typeIdentifier: String? { return _get(.typeIdentifierKey) }
+    
+    /// User-visible type or "kind" description.
+    public var localizedTypeDescription: String? { return _get(.localizedTypeDescriptionKey) }
+    
+    /// The label number assigned to the resource.
+    public var labelNumber: Int? {
+        get { return _get(.labelNumberKey) }
+        set { _set(.labelNumberKey, newValue: newValue) }
+    }
+    
+    
+    /// The user-visible label text.
+    public var localizedLabel: String? {
+        get { return _get(.localizedLabelKey) }
+    }
+        
+    /// An identifier which can be used to compare two file system objects for equality using `isEqual`.
+    ///
+    /// Two object identifiers are equal if they have the same file system path or if the paths are linked to same inode on the same file system. This identifier is not persistent across system restarts.
+    public var fileResourceIdentifier: (NSCopying & NSCoding & NSSecureCoding & NSObjectProtocol)? { return _get(.fileResourceIdentifierKey) }
+    
+    /// An identifier that can be used to identify the volume the file system object is on. 
+    ///
+    /// Other objects on the same volume will have the same volume identifier and can be compared using for equality using `isEqual`. This identifier is not persistent across system restarts.
+    public var volumeIdentifier: (NSCopying & NSCoding & NSSecureCoding & NSObjectProtocol)? { return _get(.volumeIdentifierKey) }
+    
+    /// The optimal block size when reading or writing this file's data, or nil if not available.
+    public var preferredIOBlockSize: Int? { return _get(.preferredIOBlockSizeKey) }
+    
+    /// True if this process (as determined by EUID) can read the resource.
+    public var isReadable: Bool? { return _get(.isReadableKey) }
+    
+    /// True if this process (as determined by EUID) can write to the resource.
+    public var isWritable: Bool? { return _get(.isWritableKey) }
+    
+    /// True if this process (as determined by EUID) can execute a file resource or search a directory resource.
+    public var isExecutable: Bool? { return _get(.isExecutableKey) }
+    
+    /// The file system object's security information encapsulated in a FileSecurity object.
+    public var fileSecurity: NSFileSecurity? {
+        get { return _get(.fileSecurityKey) }
+        set { _set(.fileSecurityKey, newValue: newValue) }
+    }
+    
+    /// True if resource should be excluded from backups, false otherwise.
+    ///
+    /// This property is only useful for excluding cache and other application support files which are not needed in a backup. Some operations commonly made to user documents will cause this property to be reset to false and so this property should not be used on user documents.
+    public var isExcludedFromBackup: Bool? {
+        get { return _get(.isExcludedFromBackupKey) }
+        set { _set(.isExcludedFromBackupKey, newValue: newValue) }
+    }
+    
+#if os(macOS)
+    /// The array of Tag names.
+    public var tagNames: [String]? { return _get(.tagNamesKey) }
+#endif
+    /// The URL's path as a file system path.
+    public var path: String? { return _get(.pathKey) }
+    
+    /// The URL's path as a canonical absolute file system path.
+    @available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+    public var canonicalPath: String? { return _get(.canonicalPathKey) }
+    
+    /// True if this URL is a file system trigger directory. Traversing or opening a file system trigger will cause an attempt to mount a file system on the trigger directory.
+    public var isMountTrigger: Bool? { return _get(.isMountTriggerKey) }
+    
+    /// An opaque generation identifier which can be compared using `==` to determine if the data in a document has been modified.
+    ///
+    /// For URLs which refer to the same file inode, the generation identifier will change when the data in the file's data fork is changed (changes to extended attributes or other file system metadata do not change the generation identifier). For URLs which refer to the same directory inode, the generation identifier will change when direct children of that directory are added, removed or renamed (changes to the data of the direct children of that directory will not change the generation identifier). The generation identifier is persistent across system restarts. The generation identifier is tied to a specific document on a specific volume and is not transferred when the document is copied to another volume. This property is not supported by all volumes.
+    @available(macOS 10.10, iOS 8.0, *)
+    public var generationIdentifier: (NSCopying & NSCoding & NSSecureCoding & NSObjectProtocol)? { return _get(.generationIdentifierKey) }
+    
+    /// The document identifier -- a value assigned by the kernel to a document (which can be either a file or directory) and is used to identify the document regardless of where it gets moved on a volume.
+    ///
+    /// The document identifier survives "safe save" operations; i.e it is sticky to the path it was assigned to (`replaceItem(at:,withItemAt:,backupItemName:,options:,resultingItem:) throws` is the preferred safe-save API). The document identifier is persistent across system restarts. The document identifier is not transferred when the file is copied. Document identifiers are only unique within a single volume. This property is not supported by all volumes.
+    @available(macOS 10.10, iOS 8.0, *)
+    public var documentIdentifier: Int? { return _get(.documentIdentifierKey) }
+    
+    /// The date the resource was created, or renamed into or within its parent directory. Note that inconsistent behavior may be observed when this attribute is requested on hard-linked items. This property is not supported by all volumes.
+    @available(macOS 10.10, iOS 8.0, *)
+    public var addedToDirectoryDate: Date? { return _get(.addedToDirectoryDateKey) }
+    
+#if os(macOS)
+    /// The quarantine properties as defined in LSQuarantine.h. To remove quarantine information from a file, pass `nil` as the value when setting this property.
+    @available(macOS 10.10, *)
+    public var quarantineProperties: [String : Any]? {
+        get {
+            let value = _values[.quarantinePropertiesKey]
+            // If a caller has caused us to stash NSNull in the dictionary (via set), make sure to return nil instead of NSNull
+            if value is NSNull {
+                return nil
+            } else {
+                return value as? [String : Any]
+            }
+        }
+        set {
+            // Use NSNull for nil, a special case for deleting quarantine
+            // properties
+            _set(.quarantinePropertiesKey, newValue: newValue ?? NSNull())
+        }
+    }
+#endif
+    
+    /// Returns the file system object type.
+    public var fileResourceType: URLFileResourceType? { return _get(.fileResourceTypeKey) }
+    
+    /// The user-visible volume format.
+    public var volumeLocalizedFormatDescription : String? { return _get(.volumeLocalizedFormatDescriptionKey) }
+    
+    /// Total volume capacity in bytes.
+    public var volumeTotalCapacity : Int? { return _get(.volumeTotalCapacityKey) }
+    
+    /// Total free space in bytes.
+    public var volumeAvailableCapacity : Int? { return _get(.volumeAvailableCapacityKey) }
+    
+#if os(macOS) || os(iOS)
+    /// Total available capacity in bytes for "Important" resources, including space expected to be cleared by purging non-essential and cached resources. "Important" means something that the user or application clearly expects to be present on the local system, but is ultimately replaceable. This would include items that the user has explicitly requested via the UI, and resources that an application requires in order to provide functionality.
+    /// Examples: A video that the user has explicitly requested to watch but has not yet finished watching or an audio file that the user has requested to download.
+    /// This value should not be used in determining if there is room for an irreplaceable resource. In the case of irreplaceable resources, always attempt to save the resource regardless of available capacity and handle failure as gracefully as possible.
+    @available(macOS 10.13, iOS 11.0, *) @available(tvOS, unavailable) @available(watchOS, unavailable)
+    public var volumeAvailableCapacityForImportantUsage: Int64? { return _get(.volumeAvailableCapacityForImportantUsageKey) }
+    
+    /// Total available capacity in bytes for "Opportunistic" resources, including space expected to be cleared by purging non-essential and cached resources. "Opportunistic" means something that the user is likely to want but does not expect to be present on the local system, but is ultimately non-essential and replaceable. This would include items that will be created or downloaded without an explicit request from the user on the current device.
+    /// Examples: A background download of a newly available episode of a TV series that a user has been recently watching, a piece of content explicitly requested on another device, and a new document saved to a network server by the current user from another device.
+    @available(macOS 10.13, iOS 11.0, *) @available(tvOS, unavailable) @available(watchOS, unavailable)
+    public var volumeAvailableCapacityForOpportunisticUsage: Int64? { return _get(.volumeAvailableCapacityForOpportunisticUsageKey) }
+#endif
+    
+    /// Total number of resources on the volume.
+    public var volumeResourceCount : Int? { return _get(.volumeResourceCountKey) }
+    
+    /// true if the volume format supports persistent object identifiers and can look up file system objects by their IDs.
+    public var volumeSupportsPersistentIDs : Bool? { return _get(.volumeSupportsPersistentIDsKey) }
+    
+    /// true if the volume format supports symbolic links.
+    public var volumeSupportsSymbolicLinks : Bool? { return _get(.volumeSupportsSymbolicLinksKey) }
+    
+    /// true if the volume format supports hard links.
+    public var volumeSupportsHardLinks : Bool? { return _get(.volumeSupportsHardLinksKey) }
+    
+    /// true if the volume format supports a journal used to speed recovery in case of unplanned restart (such as a power outage or crash). This does not necessarily mean the volume is actively using a journal. 
+    public var volumeSupportsJournaling : Bool? { return _get(.volumeSupportsJournalingKey) }
+    
+    /// true if the volume is currently using a journal for speedy recovery after an unplanned restart. 
+    public var volumeIsJournaling : Bool? { return _get(.volumeIsJournalingKey) }
+    
+    /// true if the volume format supports sparse files, that is, files which can have 'holes' that have never been written to, and thus do not consume space on disk. A sparse file may have an allocated size on disk that is less than its logical length.
+    public var volumeSupportsSparseFiles : Bool? { return _get(.volumeSupportsSparseFilesKey) }
+    
+    /// For security reasons, parts of a file (runs) that have never been written to must appear to contain zeroes. true if the volume keeps track of allocated but unwritten runs of a file so that it can substitute zeroes without actually writing zeroes to the media. 
+    public var volumeSupportsZeroRuns : Bool? { return _get(.volumeSupportsZeroRunsKey) }
+
+    /// true if the volume format treats upper and lower case characters in file and directory names as different. Otherwise an upper case character is equivalent to a lower case character, and you can't have two names that differ solely in the case of the characters. 
+    public var volumeSupportsCaseSensitiveNames : Bool? { return _get(.volumeSupportsCaseSensitiveNamesKey) }
+
+    /// true if the volume format preserves the case of file and directory names.  Otherwise the volume may change the case of some characters (typically making them all upper or all lower case). 
+    public var volumeSupportsCasePreservedNames : Bool? { return _get(.volumeSupportsCasePreservedNamesKey) }
+
+    /// true if the volume supports reliable storage of times for the root directory. 
+    public var volumeSupportsRootDirectoryDates : Bool? { return _get(.volumeSupportsRootDirectoryDatesKey) }
+
+    /// true if the volume supports returning volume size values (`volumeTotalCapacity` and `volumeAvailableCapacity`).
+    public var volumeSupportsVolumeSizes : Bool? { return _get(.volumeSupportsVolumeSizesKey) }
+
+    /// true if the volume can be renamed. 
+    public var volumeSupportsRenaming : Bool? { return _get(.volumeSupportsRenamingKey) }
+
+    /// true if the volume implements whole-file flock(2) style advisory locks, and the O_EXLOCK and O_SHLOCK flags of the open(2) call. 
+    public var volumeSupportsAdvisoryFileLocking : Bool? { return _get(.volumeSupportsAdvisoryFileLockingKey) }
+
+    /// true if the volume implements extended security (ACLs). 
+    public var volumeSupportsExtendedSecurity : Bool? { return _get(.volumeSupportsExtendedSecurityKey) }
+
+    /// true if the volume should be visible via the GUI (i.e., appear on the Desktop as a separate volume). 
+    public var volumeIsBrowsable : Bool? { return _get(.volumeIsBrowsableKey) }
+
+    /// The largest file size (in bytes) supported by this file system, or nil if this cannot be determined. 
+    public var volumeMaximumFileSize : Int? { return _get(.volumeMaximumFileSizeKey) }
+
+    /// true if the volume's media is ejectable from the drive mechanism under software control. 
+    public var volumeIsEjectable : Bool? { return _get(.volumeIsEjectableKey) }
+
+    /// true if the volume's media is removable from the drive mechanism. 
+    public var volumeIsRemovable : Bool? { return _get(.volumeIsRemovableKey) }
+
+    /// true if the volume's device is connected to an internal bus, false if connected to an external bus, or nil if not available. 
+    public var volumeIsInternal : Bool? { return _get(.volumeIsInternalKey) }
+
+    /// true if the volume is automounted. Note: do not mistake this with the functionality provided by kCFURLVolumeSupportsBrowsingKey. 
+    public var volumeIsAutomounted : Bool? { return _get(.volumeIsAutomountedKey) }
+
+    /// true if the volume is stored on a local device. 
+    public var volumeIsLocal : Bool? { return _get(.volumeIsLocalKey) }
+
+    /// true if the volume is read-only. 
+    public var volumeIsReadOnly : Bool? { return _get(.volumeIsReadOnlyKey) }
+
+    /// The volume's creation date, or nil if this cannot be determined. 
+    public var volumeCreationDate : Date? { return _get(.volumeCreationDateKey) }
+
+    /// The `URL` needed to remount a network volume, or nil if not available.
+    public var volumeURLForRemounting : URL? { return _get(.volumeURLForRemountingKey) }
+
+    /// The volume's persistent `UUID` as a string, or nil if a persistent `UUID` is not available for the volume.
+    public var volumeUUIDString : String? { return _get(.volumeUUIDStringKey) }
+
+    /// The name of the volume 
+    public var volumeName : String? {
+        get { return _get(.volumeNameKey) }
+        set { _set(.volumeNameKey, newValue: newValue) }
+    }
+    
+    /// The user-presentable name of the volume 
+    public var volumeLocalizedName : String? { return _get(.volumeLocalizedNameKey) }
+    
+    /// true if the volume is encrypted. 
+    @available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+    public var volumeIsEncrypted : Bool? { return _get(.volumeIsEncryptedKey) }
+
+    /// true if the volume is the root filesystem. 
+    @available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+    public var volumeIsRootFileSystem : Bool? { return _get(.volumeIsRootFileSystemKey) }
+
+    /// true if the volume supports transparent decompression of compressed files using decmpfs. 
+    @available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+    public var volumeSupportsCompression : Bool? { return _get(.volumeSupportsCompressionKey) }
+    
+    /// true if the volume supports clonefile(2).
+    @available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+    public var volumeSupportsFileCloning : Bool? { return _get(.volumeSupportsFileCloningKey) }
+    
+    /// true if the volume supports renamex_np(2)'s RENAME_SWAP option.
+    @available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+    public var volumeSupportsSwapRenaming : Bool? { return _get(.volumeSupportsSwapRenamingKey) }
+    
+    /// true if the volume supports renamex_np(2)'s RENAME_EXCL option.
+    @available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+    public var volumeSupportsExclusiveRenaming : Bool? { return _get(.volumeSupportsExclusiveRenamingKey) }
+    
+    /// true if the volume supports making files immutable with isUserImmutable or isSystemImmutable.
+    @available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *)
+    public var volumeSupportsImmutableFiles : Bool? { return _get(.volumeSupportsImmutableFilesKey) }
+    
+    /// true if the volume supports setting POSIX access permissions with fileSecurity.
+    @available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *)
+    public var volumeSupportsAccessPermissions : Bool? { return _get(.volumeSupportsAccessPermissionsKey) }
+    
+    /// true if this item is synced to the cloud, false if it is only a local file. 
+    public var isUbiquitousItem : Bool? { return _get(.isUbiquitousItemKey) }
+
+    /// true if this item has conflicts outstanding. 
+    public var ubiquitousItemHasUnresolvedConflicts : Bool? { return _get(.ubiquitousItemHasUnresolvedConflictsKey) }
+
+    /// true if data is being downloaded for this item. 
+    public var ubiquitousItemIsDownloading : Bool? { return _get(.ubiquitousItemIsDownloadingKey) }
+
+    /// true if there is data present in the cloud for this item. 
+    public var ubiquitousItemIsUploaded : Bool? { return _get(.ubiquitousItemIsUploadedKey) }
+
+    /// true if data is being uploaded for this item. 
+    public var ubiquitousItemIsUploading : Bool? { return _get(.ubiquitousItemIsUploadingKey) }
+    
+    /// returns the download status of this item.
+    public var ubiquitousItemDownloadingStatus : URLUbiquitousItemDownloadingStatus? { return _get(.ubiquitousItemDownloadingStatusKey) }
+    
+    /// returns the error when downloading the item from iCloud failed, see the NSUbiquitousFile section in FoundationErrors.h
+    public var ubiquitousItemDownloadingError : NSError? { return _get(.ubiquitousItemDownloadingErrorKey) }
+
+    /// returns the error when uploading the item to iCloud failed, see the NSUbiquitousFile section in FoundationErrors.h
+    public var ubiquitousItemUploadingError : NSError? { return _get(.ubiquitousItemUploadingErrorKey) }
+    
+    /// returns whether a download of this item has already been requested with an API like `startDownloadingUbiquitousItem(at:) throws`.
+    @available(macOS 10.10, iOS 8.0, *)
+    public var ubiquitousItemDownloadRequested : Bool? { return _get(.ubiquitousItemDownloadRequestedKey) }
+    
+    /// returns the name of this item's container as displayed to users.
+    @available(macOS 10.10, iOS 8.0, *)
+    public var ubiquitousItemContainerDisplayName : String? { return _get(.ubiquitousItemContainerDisplayNameKey) }
+    
+#if os(macOS) || os(iOS)
+    // true if ubiquitous item is shared.
+    @available(macOS 10.13, iOS 11.0, *) @available(tvOS, unavailable) @available(watchOS, unavailable)
+    public var ubiquitousItemIsShared: Bool? { return _get(.ubiquitousItemIsSharedKey) }
+    
+    // The current user's role for this shared item, or nil if not shared
+    @available(macOS 10.13, iOS 11.0, *) @available(tvOS, unavailable) @available(watchOS, unavailable)
+    public var ubiquitousSharedItemCurrentUserRole: URLUbiquitousSharedItemRole? { return _get(.ubiquitousSharedItemCurrentUserRoleKey) }
+    
+    // The permissions for the current user, or nil if not shared.
+    @available(macOS 10.13, iOS 11.0, *) @available(tvOS, unavailable) @available(watchOS, unavailable)
+    public var ubiquitousSharedItemCurrentUserPermissions: URLUbiquitousSharedItemPermissions? { return _get(.ubiquitousSharedItemCurrentUserPermissionsKey) }
+    
+    // The name components for the owner, or nil if not shared.
+    @available(macOS 10.13, iOS 11.0, *) @available(tvOS, unavailable) @available(watchOS, unavailable)
+    public var ubiquitousSharedItemOwnerNameComponents: PersonNameComponents? { return _get(.ubiquitousSharedItemOwnerNameComponentsKey) }
+    
+    // The name components for the most recent editor, or nil if not shared.
+    @available(macOS 10.13, iOS 11.0, *) @available(tvOS, unavailable) @available(watchOS, unavailable)
+    public var ubiquitousSharedItemMostRecentEditorNameComponents: PersonNameComponents? { return _get(.ubiquitousSharedItemMostRecentEditorNameComponentsKey) }
+#endif
+    
+#if !os(macOS)
+    /// The protection level for this file
+    @available(iOS 9.0, *)
+    public var fileProtection : URLFileProtection? { return _get(.fileProtectionKey) }
+#endif
+    
+    /// Total file size in bytes
+    ///
+    /// - note: Only applicable to regular files.
+    public var fileSize : Int? { return _get(.fileSizeKey) }
+    
+    /// Total size allocated on disk for the file in bytes (number of blocks times block size)
+    ///
+    /// - note: Only applicable to regular files.
+    public var fileAllocatedSize : Int? { return _get(.fileAllocatedSizeKey) }
+    
+    /// Total displayable size of the file in bytes (this may include space used by metadata), or nil if not available.
+    ///
+    /// - note: Only applicable to regular files.
+    public var totalFileSize : Int? { return _get(.totalFileSizeKey) }
+    
+    /// Total allocated size of the file in bytes (this may include space used by metadata), or nil if not available. This can be less than the value returned by `totalFileSize` if the resource is compressed.
+    ///
+    /// - note: Only applicable to regular files.
+    public var totalFileAllocatedSize : Int? { return _get(.totalFileAllocatedSizeKey) }
+
+    /// true if the resource is a Finder alias file or a symlink, false otherwise
+    ///
+    /// - note: Only applicable to regular files.
+    public var isAliasFile : Bool? { return _get(.isAliasFileKey) }
+
+}
+
+/**
+ A URL is a type that can potentially contain the location of a resource on a remote server, the path of a local file on disk, or even an arbitrary piece of encoded data.
+ 
+ You can construct URLs and access their parts. For URLs that represent local files, you can also manipulate properties of those files directly, such as changing the file's last modification date. Finally, you can pass URLs to other APIs to retrieve the contents of those URLs. For example, you can use the URLSession classes to access the contents of remote resources, as described in URL Session Programming Guide.
+ 
+ URLs are the preferred way to refer to local files. Most objects that read data from or write data to a file have methods that accept a URL instead of a pathname as the file reference. For example, you can get the contents of a local file URL as `String` by calling `func init(contentsOf:encoding) throws`, or as a `Data` by calling `func init(contentsOf:options) throws`.
+*/
+public struct URL : ReferenceConvertible, Equatable {
+    public typealias ReferenceType = NSURL
+    private var _url: NSURL
+    
+    public typealias BookmarkResolutionOptions = NSURL.BookmarkResolutionOptions
+    public typealias BookmarkCreationOptions = NSURL.BookmarkCreationOptions
+
+    /// Initialize with string.
+    ///
+    /// Returns `nil` if a `URL` cannot be formed with the string (for example, if the string contains characters that are illegal in a URL, or is an empty string).
+    public init?(string: __shared String) {
+        guard !string.isEmpty, let inner = NSURL(string: string) else { return nil }
+        _url = URL._converted(from: inner)
+    }
+    
+    /// Initialize with string, relative to another URL.
+    ///
+    /// Returns `nil` if a `URL` cannot be formed with the string (for example, if the string contains characters that are illegal in a URL, or is an empty string).
+    public init?(string: __shared String, relativeTo url: __shared URL?) {
+        guard !string.isEmpty, let inner = NSURL(string: string, relativeTo: url) else { return nil }
+        _url = URL._converted(from: inner)
+    }
+    
+    /// Initializes a newly created file URL referencing the local file or directory at path, relative to a base URL.
+    ///
+    /// If an empty string is used for the path, then the path is assumed to be ".".
+    /// - note: This function avoids an extra file system access to check if the file URL is a directory. You should use it if you know the answer already.
+    @available(macOS 10.11, iOS 9.0, *)
+    public init(fileURLWithPath path: __shared String, isDirectory: Bool, relativeTo base: __shared URL?) {
+        _url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path, isDirectory: isDirectory, relativeTo: base))
+    }
+    
+    /// Initializes a newly created file URL referencing the local file or directory at path, relative to a base URL.
+    ///
+    /// If an empty string is used for the path, then the path is assumed to be ".".
+    @available(macOS 10.11, iOS 9.0, *)
+    public init(fileURLWithPath path: __shared String, relativeTo base: __shared URL?) {
+        _url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path, relativeTo: base))
+    }
+    
+    /// Initializes a newly created file URL referencing the local file or directory at path.
+    ///
+    /// If an empty string is used for the path, then the path is assumed to be ".".
+    /// - note: This function avoids an extra file system access to check if the file URL is a directory. You should use it if you know the answer already.
+    public init(fileURLWithPath path: __shared String, isDirectory: Bool) {
+        _url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path, isDirectory: isDirectory))
+    }
+    
+    /// Initializes a newly created file URL referencing the local file or directory at path.
+    ///
+    /// If an empty string is used for the path, then the path is assumed to be ".".
+    public init(fileURLWithPath path: __shared String) {
+        _url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path))
+    }
+    
+    /// Initializes a newly created URL using the contents of the given data, relative to a base URL.
+    ///
+    /// If the data representation is not a legal URL string as ASCII bytes, the URL object may not behave as expected. If the URL cannot be formed then this will return nil.
+    @available(macOS 10.11, iOS 9.0, *)
+    public init?(dataRepresentation: __shared Data, relativeTo url: __shared URL?, isAbsolute: Bool = false) {
+        guard !dataRepresentation.isEmpty else { return nil }
+        
+        if isAbsolute {
+            _url = URL._converted(from: NSURL(absoluteURLWithDataRepresentation: dataRepresentation, relativeTo: url))
+        } else {
+            _url = URL._converted(from: NSURL(dataRepresentation: dataRepresentation, relativeTo: url))
+        }
+    }
+
+    /// Initializes a URL that refers to a location specified by resolving bookmark data.
+    @available(swift, obsoleted: 4.2)
+    public init?(resolvingBookmarkData data: __shared Data, options: BookmarkResolutionOptions = [], relativeTo url: __shared URL? = nil, bookmarkDataIsStale: inout Bool) throws {
+        var stale : ObjCBool = false
+        _url = URL._converted(from: try NSURL(resolvingBookmarkData: data, options: options, relativeTo: url, bookmarkDataIsStale: &stale))
+        bookmarkDataIsStale = stale.boolValue
+    }
+
+    /// Initializes a URL that refers to a location specified by resolving bookmark data.
+    @available(swift, introduced: 4.2)
+    public init(resolvingBookmarkData data: __shared Data, options: BookmarkResolutionOptions = [], relativeTo url: __shared URL? = nil, bookmarkDataIsStale: inout Bool) throws {
+        var stale : ObjCBool = false
+        _url = URL._converted(from: try NSURL(resolvingBookmarkData: data, options: options, relativeTo: url, bookmarkDataIsStale: &stale))
+        bookmarkDataIsStale = stale.boolValue
+    }
+    
+    /// Creates and initializes an NSURL that refers to the location specified by resolving the alias file at url. If the url argument does not refer to an alias file as defined by the NSURLIsAliasFileKey property, the NSURL returned is the same as url argument. This method fails and returns nil if the url argument is unreachable, or if the original file or directory could not be located or is not reachable, or if the original file or directory is on a volume that could not be located or mounted. The URLBookmarkResolutionWithSecurityScope option is not supported by this method.
+    @available(macOS 10.10, iOS 8.0, *)
+    public init(resolvingAliasFileAt url: __shared URL, options: BookmarkResolutionOptions = []) throws {
+        self.init(reference: try NSURL(resolvingAliasFileAt: url, options: options))
+    }
+
+    /// Initializes a newly created URL referencing the local file or directory at the file system representation of the path. File system representation is a null-terminated C string with canonical UTF-8 encoding.
+    public init(fileURLWithFileSystemRepresentation path: UnsafePointer<Int8>, isDirectory: Bool, relativeTo baseURL: __shared URL?) {
+        _url = URL._converted(from: NSURL(fileURLWithFileSystemRepresentation: path, isDirectory: isDirectory, relativeTo: baseURL))
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_url)
+    }
+
+    // MARK: -
+    
+    /// Returns the data representation of the URL's relativeString. 
+    ///
+    /// If the URL was initialized with `init?(dataRepresentation:relativeTo:isAbsolute:)`, the data representation returned are the same bytes as those used at initialization; otherwise, the data representation returned are the bytes of the `relativeString` encoded with UTF8 string encoding.
+    @available(macOS 10.11, iOS 9.0, *)
+    public var dataRepresentation: Data {
+        return _url.dataRepresentation
+    }
+    
+    // MARK: -
+    
+    // Future implementation note:
+    // NSURL (really CFURL, which provides its implementation) has quite a few quirks in its processing of some more esoteric (and some not so esoteric) strings. We would like to move much of this over to the more modern NSURLComponents, but binary compat concerns have made this difficult.
+    // Hopefully soon, we can replace some of the below delegation to NSURL with delegation to NSURLComponents instead. It cannot be done piecemeal, because otherwise we will get inconsistent results from the API.
+    
+    /// Returns the absolute string for the URL.
+    public var absoluteString: String {
+        if let string = _url.absoluteString {
+            return string
+        } else {
+            // This should never fail for non-file reference URLs
+            return ""
+        }
+    }
+    
+    /// The relative portion of a URL.
+    ///
+    /// If `baseURL` is nil, or if the receiver is itself absolute, this is the same as `absoluteString`.
+    public var relativeString: String {
+        return _url.relativeString
+    }
+    
+    /// Returns the base URL.
+    ///
+    /// If the URL is itself absolute, then this value is nil.
+    public var baseURL: URL? {
+        return _url.baseURL
+    }
+    
+    /// Returns the absolute URL.
+    ///
+    /// If the URL is itself absolute, this will return self.
+    public var absoluteURL: URL {
+        if let url = _url.absoluteURL {
+            return url
+        } else {
+            // This should never fail for non-file reference URLs
+            return self
+        }
+    }
+    
+    // MARK: -
+    
+    /// Returns the scheme of the URL.
+    public var scheme: String? {
+        return _url.scheme
+    }
+    
+    /// Returns true if the scheme is `file:`.
+    public var isFileURL: Bool {
+        return _url.isFileURL
+    }
+
+    // This thing was never really part of the URL specs
+    @available(*, unavailable, message: "Use `path`, `query`, and `fragment` instead")
+    public var resourceSpecifier: String {
+        fatalError()
+    }
+    
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the host component of the URL; otherwise it returns nil.
+    ///
+    /// - note: This function will resolve against the base `URL`.
+    public var host: String? {
+        return _url.host
+    }
+    
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the port component of the URL; otherwise it returns nil.
+    ///
+    /// - note: This function will resolve against the base `URL`.
+    public var port: Int? {
+        return _url.port?.intValue
+    }
+    
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the user component of the URL; otherwise it returns nil.
+    ///
+    /// - note: This function will resolve against the base `URL`.
+    public var user: String? {
+        return _url.user
+    }
+    
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the password component of the URL; otherwise it returns nil.
+    ///
+    /// - note: This function will resolve against the base `URL`.
+    public var password: String? {
+        return _url.password
+    }
+    
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the path component of the URL; otherwise it returns an empty string.
+    ///
+    /// If the URL contains a parameter string, it is appended to the path with a `;`.
+    /// - note: This function will resolve against the base `URL`.
+    /// - returns: The path, or an empty string if the URL has an empty path.
+    public var path: String {
+        if let parameterString = _url.parameterString {
+            if let path = _url.path {
+                return path + ";" + parameterString
+            } else {
+                return ";" + parameterString
+            }
+        } else if let path = _url.path {
+            return path
+        } else {
+            return ""
+        }
+    }
+    
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the relative path of the URL; otherwise it returns nil.
+    ///
+    /// This is the same as path if baseURL is nil.
+    /// If the URL contains a parameter string, it is appended to the path with a `;`.
+    ///
+    /// - note: This function will resolve against the base `URL`.
+    /// - returns: The relative path, or an empty string if the URL has an empty path.
+    public var relativePath: String {
+        if let parameterString = _url.parameterString {
+            if let path = _url.relativePath {
+                return path + ";" + parameterString
+            } else {
+                return ";" + parameterString
+            }
+        } else if let path = _url.relativePath {
+            return path
+        } else {
+            return ""
+        }
+    }
+
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the fragment component of the URL; otherwise it returns nil.
+    ///
+    /// - note: This function will resolve against the base `URL`.
+    public var fragment: String? {
+        return _url.fragment
+    }
+    
+    @available(*, unavailable, message: "use the 'path' property")
+    public var parameterString: String? {
+        fatalError()
+    }
+    
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the query of the URL; otherwise it returns nil.
+    ///
+    /// - note: This function will resolve against the base `URL`.
+    public var query: String? {
+        return _url.query
+    }
+    
+    /// Returns true if the URL path represents a directory.
+    @available(macOS 10.11, iOS 9.0, *)
+    public var hasDirectoryPath: Bool {
+        return _url.hasDirectoryPath
+    }
+    
+    /// Passes the URL's path in file system representation to `block`. 
+    /// 
+    /// File system representation is a null-terminated C string with canonical UTF-8 encoding.
+    /// - note: The pointer is not valid outside the context of the block.
+    @available(macOS 10.9, iOS 7.0, *)
+    public func withUnsafeFileSystemRepresentation<ResultType>(_ block: (UnsafePointer<Int8>?) throws -> ResultType) rethrows -> ResultType {
+        return try block(_url.fileSystemRepresentation)
+    }
+    
+    // MARK: -
+    // MARK: Path manipulation
+    
+    /// Returns the path components of the URL, or an empty array if the path is an empty string.
+    public var pathComponents: [String] {
+        // In accordance with our above change to never return a nil path, here we return an empty array.
+        return _url.pathComponents ?? []
+    }
+    
+    /// Returns the last path component of the URL, or an empty string if the path is an empty string.
+    public var lastPathComponent: String {
+        return _url.lastPathComponent ?? ""
+    }
+    
+    /// Returns the path extension of the URL, or an empty string if the path is an empty string.
+    public var pathExtension: String {
+        return _url.pathExtension ?? ""
+    }
+    
+    /// Returns a URL constructed by appending the given path component to self.
+    ///
+    /// - parameter pathComponent: The path component to add.
+    /// - parameter isDirectory: If `true`, then a trailing `/` is added to the resulting path.
+    public func appendingPathComponent(_ pathComponent: String, isDirectory: Bool) -> URL {
+        if let result = _url.appendingPathComponent(pathComponent, isDirectory: isDirectory) {
+            return result
+        } else {
+            // Now we need to do something more expensive
+            if var c = URLComponents(url: self, resolvingAgainstBaseURL: true) {
+                let path = (c.path as NSString).appendingPathComponent(pathComponent)
+                c.path = isDirectory ? path + "/" : path
+                
+                if let result = c.url {
+                    return result
+                } else {
+                    // Couldn't get url from components
+                    // Ultimate fallback:
+                    return self
+                }
+            } else {
+                return self
+            }
+        }
+    }
+    
+    /// Returns a URL constructed by appending the given path component to self.
+    ///
+    /// - note: This function performs a file system operation to determine if the path component is a directory. If so, it will append a trailing `/`. If you know in advance that the path component is a directory or not, then use `func appendingPathComponent(_:isDirectory:)`.
+    /// - parameter pathComponent: The path component to add.
+    public func appendingPathComponent(_ pathComponent: String) -> URL {
+        if let result = _url.appendingPathComponent(pathComponent) {
+            return result
+        } else {
+            // Now we need to do something more expensive
+            if var c = URLComponents(url: self, resolvingAgainstBaseURL: true) {
+                c.path = (c.path as NSString).appendingPathComponent(pathComponent)
+                
+                if let result = c.url {
+                    return result
+                } else {
+                    // Couldn't get url from components
+                    // Ultimate fallback:
+                    return self
+                }
+            } else {
+                // Ultimate fallback:
+                return self
+            }
+        }
+    }
+    
+    /// Returns a URL constructed by removing the last path component of self.
+    ///
+    /// This function may either remove a path component or append `/..`.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will return the URL unchanged.
+    public func deletingLastPathComponent() -> URL {
+        // This is a slight behavior change from NSURL, but better than returning "http://www.example.com../".
+        guard !path.isEmpty, let result = _url.deletingLastPathComponent.map({ URL(reference: $0 as NSURL) }) else { return self }
+        return result
+    }
+    
+    /// Returns a URL constructed by appending the given path extension to self.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will return the URL unchanged.
+    ///
+    /// Certain special characters (for example, Unicode Right-To-Left marks) cannot be used as path extensions. If any of those are contained in `pathExtension`, the function will return the URL unchanged.
+    /// - parameter pathExtension: The extension to append.
+    public func appendingPathExtension(_ pathExtension: String) -> URL {
+        guard !path.isEmpty, let result = _url.appendingPathExtension(pathExtension) else { return self }
+        return result
+    }
+    
+    /// Returns a URL constructed by removing any path extension.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will return the URL unchanged.
+    public func deletingPathExtension() -> URL {
+        guard !path.isEmpty, let result = _url.deletingPathExtension.map({ URL(reference: $0 as NSURL) }) else { return self }
+        return result
+    }
+
+    /// Appends a path component to the URL.
+    ///
+    /// - parameter pathComponent: The path component to add.
+    /// - parameter isDirectory: Use `true` if the resulting path is a directory.
+    public mutating func appendPathComponent(_ pathComponent: String, isDirectory: Bool) {
+        self = appendingPathComponent(pathComponent, isDirectory: isDirectory)
+    }
+    
+    /// Appends a path component to the URL.
+    ///
+    /// - note: This function performs a file system operation to determine if the path component is a directory. If so, it will append a trailing `/`. If you know in advance that the path component is a directory or not, then use `func appendingPathComponent(_:isDirectory:)`.
+    /// - parameter pathComponent: The path component to add.
+    public mutating func appendPathComponent(_ pathComponent: String) {
+        self = appendingPathComponent(pathComponent)
+    }
+    
+    /// Appends the given path extension to self.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will do nothing.
+    /// Certain special characters (for example, Unicode Right-To-Left marks) cannot be used as path extensions. If any of those are contained in `pathExtension`, the function will return the URL unchanged.
+    /// - parameter pathExtension: The extension to append.
+    public mutating func appendPathExtension(_ pathExtension: String) {
+        self = appendingPathExtension(pathExtension)
+    }
+
+    /// Returns a URL constructed by removing the last path component of self.
+    ///
+    /// This function may either remove a path component or append `/..`.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will do nothing.
+    public mutating func deleteLastPathComponent() {
+        self = deletingLastPathComponent()
+    }
+    
+
+    /// Returns a URL constructed by removing any path extension.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will do nothing.
+    public mutating func deletePathExtension() {
+        self = deletingPathExtension()
+    }
+    
+    /// Returns a `URL` with any instances of ".." or "." removed from its path.
+    public var standardized : URL {
+        // The NSURL API can only return nil in case of file reference URL, which we should not be
+        guard let result = _url.standardized.map({ URL(reference: $0 as NSURL) }) else { return self }
+        return result
+    }
+    
+    /// Standardizes the path of a file URL.
+    ///
+    /// If the `isFileURL` is false, this method does nothing.
+    public mutating func standardize() {
+        self = self.standardized
+    }
+    
+    /// Standardizes the path of a file URL.
+    ///
+    /// If the `isFileURL` is false, this method returns `self`.
+    public var standardizedFileURL : URL {
+        // NSURL should not return nil here unless this is a file reference URL, which should be impossible
+        guard let result = _url.standardizingPath.map({ URL(reference: $0 as NSURL) }) else { return self }
+        return result
+    }
+    
+    /// Resolves any symlinks in the path of a file URL.
+    ///
+    /// If the `isFileURL` is false, this method returns `self`.
+    public func resolvingSymlinksInPath() -> URL {
+        // NSURL should not return nil here unless this is a file reference URL, which should be impossible
+        guard let result = _url.resolvingSymlinksInPath.map({ URL(reference: $0 as NSURL) }) else { return self }
+        return result
+    }
+
+    /// Resolves any symlinks in the path of a file URL.
+    ///
+    /// If the `isFileURL` is false, this method does nothing.
+    public mutating func resolveSymlinksInPath() {
+        self = self.resolvingSymlinksInPath()
+    }
+
+    // MARK: - Reachability
+    
+    /// Returns whether the URL's resource exists and is reachable. 
+    ///
+    /// This method synchronously checks if the resource's backing store is reachable. Checking reachability is appropriate when making decisions that do not require other immediate operations on the resource, e.g. periodic maintenance of UI state that depends on the existence of a specific document. When performing operations such as opening a file or copying resource properties, it is more efficient to simply try the operation and handle failures. This method is currently applicable only to URLs for file system resources. For other URL types, `false` is returned.
+    public func checkResourceIsReachable() throws -> Bool {
+        var error : NSError?
+        let result = _url.checkResourceIsReachableAndReturnError(&error)
+        if let e = error {
+            throw e
+        } else {
+            return result
+        }
+    }
+    
+    /// Returns whether the promised item URL's resource exists and is reachable.
+    ///
+    /// This method synchronously checks if the resource's backing store is reachable. Checking reachability is appropriate when making decisions that do not require other immediate operations on the resource, e.g. periodic maintenance of UI state that depends on the existence of a specific document. When performing operations such as opening a file or copying resource properties, it is more efficient to simply try the operation and handle failures. This method is currently applicable only to URLs for file system resources. For other URL types, `false` is returned.
+    @available(macOS 10.10, iOS 8.0, *)
+    public func checkPromisedItemIsReachable() throws -> Bool {
+        var error : NSError?
+        let result = _url.checkPromisedItemIsReachableAndReturnError(&error)
+        if let e = error {
+            throw e
+        } else {
+            return result
+        }
+    }
+    
+    // MARK: - Resource Values
+    
+    /// Sets the resource value identified by a given resource key.
+    /// 
+    /// This method writes the new resource values out to the backing store. Attempts to set a read-only resource property or to set a resource property not supported by the resource are ignored and are not considered errors. This method is currently applicable only to URLs for file system resources.
+    ///
+    /// `URLResourceValues` keeps track of which of its properties have been set. Those values are the ones used by this function to determine which properties to write.
+    public mutating func setResourceValues(_ values: URLResourceValues) throws {
+        try _url.setResourceValues(values._values)
+    }
+    
+    /// Return a collection of resource values identified by the given resource keys.
+    ///
+    /// This method first checks if the URL object already caches the resource value. If so, it returns the cached resource value to the caller. If not, then this method synchronously obtains the resource value from the backing store, adds the resource value to the URL object's cache, and returns the resource value to the caller. The type of the resource value varies by resource property (see resource key definitions). If this method does not throw and the resulting value in the `URLResourceValues` is populated with nil, it means the resource property is not available for the specified resource and no errors occurred when determining the resource property was not available. This method is currently applicable only to URLs for file system resources.
+    ///
+    /// When this function is used from the main thread, resource values cached by the URL (except those added as temporary properties) are removed the next time the main thread's run loop runs. `func removeCachedResourceValue(forKey:)` and `func removeAllCachedResourceValues()` also may be used to remove cached resource values.
+    ///
+    /// Only the values for the keys specified in `keys` will be populated.
+    public func resourceValues(forKeys keys: Set<URLResourceKey>) throws -> URLResourceValues {
+        return URLResourceValues(keys: keys, values: try _url.resourceValues(forKeys: Array(keys)))
+    }
+
+    /// Sets a temporary resource value on the URL object.
+    ///
+    /// Temporary resource values are for client use. Temporary resource values exist only in memory and are never written to the resource's backing store. Once set, a temporary resource value can be copied from the URL object with `func resourceValues(forKeys:)`. The values are stored in the loosely-typed `allValues` dictionary property.
+    ///
+    /// To remove a temporary resource value from the URL object, use `func removeCachedResourceValue(forKey:)`. Care should be taken to ensure the key that identifies a temporary resource value is unique and does not conflict with system defined keys (using reverse domain name notation in your temporary resource value keys is recommended). This method is currently applicable only to URLs for file system resources.
+    public mutating func setTemporaryResourceValue(_ value : Any, forKey key: URLResourceKey) {
+        _url.setTemporaryResourceValue(value, forKey: key)
+    }
+    
+    /// Removes all cached resource values and all temporary resource values from the URL object.
+    /// 
+    /// This method is currently applicable only to URLs for file system resources.
+    public mutating func removeAllCachedResourceValues() {
+        _url.removeAllCachedResourceValues()
+    }
+    
+    /// Removes the cached resource value identified by a given resource value key from the URL object.
+    /// 
+    /// Removing a cached resource value may remove other cached resource values because some resource values are cached as a set of values, and because some resource values depend on other resource values (temporary resource values have no dependencies). This method is currently applicable only to URLs for file system resources.
+    public mutating func removeCachedResourceValue(forKey key: URLResourceKey) {
+        _url.removeCachedResourceValue(forKey: key)
+    }
+    
+    /// Get resource values from URLs of 'promised' items.
+    ///
+    /// A promised item is not guaranteed to have its contents in the file system until you use `FileCoordinator` to perform a coordinated read on its URL, which causes the contents to be downloaded or otherwise generated. Promised item URLs are returned by various APIs, including currently:
+    ///     NSMetadataQueryUbiquitousDataScope
+    ///     NSMetadataQueryUbiquitousDocumentsScope
+    ///     A `FilePresenter` presenting the contents of the directory located by -URLForUbiquitousContainerIdentifier: or a subdirectory thereof
+    ///
+    /// The following methods behave identically to their similarly named methods above (`func resourceValues(forKeys:)`, etc.), except that they allow you to get resource values and check for presence regardless of whether the promised item's contents currently exist at the URL. You must use these APIs instead of the normal URL resource value APIs if and only if any of the following are true:
+    ///     You are using a URL that you know came directly from one of the above APIs
+    ///     You are inside the accessor block of a coordinated read or write that used NSFileCoordinatorReadingImmediatelyAvailableMetadataOnly, NSFileCoordinatorWritingForDeleting, NSFileCoordinatorWritingForMoving, or NSFileCoordinatorWritingContentIndependentMetadataOnly
+    ///
+    /// Most of the URL resource value keys will work with these APIs. However, there are some that are tied to the item's contents that will not work, such as `contentAccessDateKey` or `generationIdentifierKey`. If one of these keys is used, the method will return a `URLResourceValues` value, but the value for that property will be nil.
+    @available(macOS 10.10, iOS 8.0, *)
+    public func promisedItemResourceValues(forKeys keys: Set<URLResourceKey>) throws -> URLResourceValues {
+        return URLResourceValues(keys: keys, values: try _url.promisedItemResourceValues(forKeys: Array(keys)))
+    }
+    
+    @available(*, unavailable, message: "Use struct URLResourceValues and URL.setResourceValues(_:) instead")
+    public func setResourceValue(_ value: AnyObject?, forKey key: URLResourceKey) throws {
+        fatalError()
+    }
+    
+    @available(*, unavailable, message: "Use struct URLResourceValues and URL.setResourceValues(_:) instead")
+    public func setResourceValues(_ keyedValues: [URLResourceKey : AnyObject]) throws {
+        fatalError()
+    }
+        
+    @available(*, unavailable, message: "Use struct URLResourceValues and URL.setResourceValues(_:) instead")
+    public func getResourceValue(_ value: AutoreleasingUnsafeMutablePointer<AnyObject?>, forKey key: URLResourceKey) throws {
+        fatalError()
+    }
+    
+    // MARK: - Bookmarks and Alias Files
+    
+    /// Returns bookmark data for the URL, created with specified options and resource values.
+    public func bookmarkData(options: BookmarkCreationOptions = [], includingResourceValuesForKeys keys: Set<URLResourceKey>? = nil, relativeTo url: URL? = nil) throws -> Data {
+        let result = try _url.bookmarkData(options: options, includingResourceValuesForKeys: keys.flatMap { Array($0) }, relativeTo: url)
+        return result
+    }
+    
+    /// Returns the resource values for properties identified by a specified array of keys contained in specified bookmark data. If the result dictionary does not contain a resource value for one or more of the requested resource keys, it means those resource properties are not available in the bookmark data.
+    public static func resourceValues(forKeys keys: Set<URLResourceKey>, fromBookmarkData data: Data) -> URLResourceValues? {
+        return NSURL.resourceValues(forKeys: Array(keys), fromBookmarkData: data).map { URLResourceValues(keys: keys, values: $0) }
+    }
+    
+    /// Creates an alias file on disk at a specified location with specified bookmark data. bookmarkData must have been created with the URLBookmarkCreationSuitableForBookmarkFile option. bookmarkFileURL must either refer to an existing file (which will be overwritten), or to location in an existing directory.
+    public static func writeBookmarkData(_ data : Data, to url: URL) throws {
+        // Options are unused
+        try NSURL.writeBookmarkData(data, to: url, options: 0)
+    }
+ 
+    /// Initializes and returns bookmark data derived from an alias file pointed to by a specified URL. If bookmarkFileURL refers to an alias file created prior to OS X v10.6 that contains Alias Manager information but no bookmark data, this method synthesizes bookmark data for the file.
+    public static func bookmarkData(withContentsOf url: URL) throws -> Data {
+        let result = try NSURL.bookmarkData(withContentsOf: url)
+        return result
+    }
+    
+    /// Given an NSURL created by resolving a bookmark data created with security scope, make the resource referenced by the url accessible to the process. When access to this resource is no longer needed the client must call stopAccessingSecurityScopedResource. Each call to startAccessingSecurityScopedResource must be balanced with a call to stopAccessingSecurityScopedResource (Note: this is not reference counted).
+    @available(macOS 10.7, iOS 8.0, *)
+    public func startAccessingSecurityScopedResource() -> Bool {
+        return _url.startAccessingSecurityScopedResource()
+    }
+    
+    /// Revokes the access granted to the url by a prior successful call to startAccessingSecurityScopedResource.
+    @available(macOS 10.7, iOS 8.0, *)
+    public func stopAccessingSecurityScopedResource() {
+        _url.stopAccessingSecurityScopedResource()
+    }
+    
+    // MARK: - Bridging Support
+    
+    /// We must not store an NSURL without running it through this function. This makes sure that we do not hold a file reference URL, which changes the nullability of many NSURL functions.
+    private static func _converted(from url: NSURL) -> NSURL {
+        // Future readers: file reference URL here is not the same as playgrounds "file reference"
+        if url.isFileReferenceURL() {
+            // Convert to a file path URL, or use an invalid scheme
+            return (url.filePathURL ?? URL(string: "com-apple-unresolvable-file-reference-url:")!) as NSURL
+        } else {
+            return url
+        }
+    }
+    
+    private init(reference: __shared NSURL) {
+        _url = URL._converted(from: reference).copy() as! NSURL
+    }
+    
+    private var reference: NSURL {
+        return _url
+    }
+
+    public static func ==(lhs: URL, rhs: URL) -> Bool {
+        return lhs.reference.isEqual(rhs.reference)
+    }
+}
+
+extension URL : _ObjectiveCBridgeable {
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSURL {
+        return _url
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ source: NSURL, result: inout URL?) {
+        if !_conditionallyBridgeFromObjectiveC(source, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ source: NSURL, result: inout URL?) -> Bool {
+        result = URL(reference: source)
+        return true
+    }
+
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSURL?) -> URL {
+        var result: URL?
+        _forceBridgeFromObjectiveC(source!, result: &result)
+        return result!
+    }
+}
+
+extension URL : CustomStringConvertible, CustomDebugStringConvertible {
+    public var description: String {
+        return _url.description
+    }
+    
+    public var debugDescription: String {
+        return _url.debugDescription
+    }
+}
+
+extension NSURL : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as URL)
+    }
+}
+
+extension URL : _CustomPlaygroundQuickLookable {
+    @available(*, deprecated, message: "URL.customPlaygroundQuickLook will be removed in a future Swift version")
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .url(absoluteString)
+    }
+}
+
+extension URL : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case base
+        case relative
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let relative = try container.decode(String.self, forKey: .relative)
+        let base = try container.decodeIfPresent(URL.self, forKey: .base)
+
+        guard let url = URL(string: relative, relativeTo: base) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Invalid URL string."))
+        }
+
+        self = url
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.relativeString, forKey: .relative)
+        if let base = self.baseURL {
+            try container.encode(base, forKey: .base)
+        }
+    }
+}
+
+//===----------------------------------------------------------------------===//
+// File references, for playgrounds.
+//===----------------------------------------------------------------------===//
+
+extension URL : _ExpressibleByFileReferenceLiteral {
+  public init(fileReferenceLiteralResourceName name: String) {
+    self = Bundle.main.url(forResource: name, withExtension: nil)!
+  }
+}
+
+public typealias _FileReferenceLiteralType = URL

--- a/Darwin/Foundation-swiftoverlay/URLCache.swift
+++ b/Darwin/Foundation-swiftoverlay/URLCache.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+extension URLCache {
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  public convenience init(memoryCapacity: Int, diskCapacity: Int, directory: URL? = nil) {
+    self.init(__memoryCapacity: memoryCapacity, diskCapacity: diskCapacity, directoryURL: directory)
+  }
+}

--- a/Darwin/Foundation-swiftoverlay/URLComponents.swift
+++ b/Darwin/Foundation-swiftoverlay/URLComponents.swift
@@ -1,0 +1,517 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+/// A structure designed to parse URLs based on RFC 3986 and to construct URLs from their constituent parts. 
+/// 
+/// Its behavior differs subtly from the `URL` struct, which conforms to older RFCs. However, you can easily obtain a `URL` based on the contents of a `URLComponents` or vice versa.
+public struct URLComponents : ReferenceConvertible, Hashable, Equatable, _MutableBoxing {
+    public typealias ReferenceType = NSURLComponents
+    
+    internal var _handle: _MutableHandle<NSURLComponents>
+    
+    /// Initialize with all components undefined.
+    public init() {
+        _handle = _MutableHandle(adoptingReference: NSURLComponents())
+    }
+    
+    /// Initialize with the components of a URL.
+    ///
+    /// If resolvingAgainstBaseURL is `true` and url is a relative URL, the components of url.absoluteURL are used. If the url string from the URL is malformed, nil is returned.
+    public init?(url: __shared URL, resolvingAgainstBaseURL resolve: Bool) {
+        guard let result = NSURLComponents(url: url, resolvingAgainstBaseURL: resolve) else { return nil }
+        _handle = _MutableHandle(adoptingReference: result)
+    }
+    
+    /// Initialize with a URL string.
+    ///
+    /// If the URLString is malformed, nil is returned.
+    public init?(string: __shared String) {
+        guard let result = NSURLComponents(string: string) else { return nil }
+        _handle = _MutableHandle(adoptingReference: result)
+    }
+    
+    /// Returns a URL created from the NSURLComponents. 
+    ///
+    /// If the NSURLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
+    public var url: URL? {
+        return _handle.map { $0.url }
+    }
+    
+    // Returns a URL created from the NSURLComponents relative to a base URL. 
+    ///
+    /// If the NSURLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
+    public func url(relativeTo base: URL?) -> URL? {
+        return _handle.map { $0.url(relativeTo: base) }
+    }
+    
+    // Returns a URL string created from the NSURLComponents. If the NSURLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
+    @available(macOS 10.10, iOS 8.0, *)
+    public var string: String? {
+        return _handle.map { $0.string }
+    }
+    
+    /// The scheme subcomponent of the URL.
+    ///
+    /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
+    /// Attempting to set the scheme with an invalid scheme string will cause an exception.
+    public var scheme: String? {
+        get { return _handle.map { $0.scheme } }
+        set { _applyMutation { $0.scheme = newValue } }
+    }
+    
+    /// The user subcomponent of the URL.
+    ///
+    /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
+    ///
+    /// Warning: IETF STD 66 (rfc3986) says the use of the format "user:password" in the userinfo subcomponent of a URI is deprecated because passing authentication information in clear text has proven to be a security risk. However, there are cases where this practice is still needed, and so the user and password components and methods are provided.
+    public var user: String? {
+        get { return _handle.map { $0.user } }
+        set { _applyMutation { $0.user = newValue } }
+    }
+    
+    /// The password subcomponent of the URL.
+    ///
+    /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
+    ///
+    /// Warning: IETF STD 66 (rfc3986) says the use of the format "user:password" in the userinfo subcomponent of a URI is deprecated because passing authentication information in clear text has proven to be a security risk. However, there are cases where this practice is still needed, and so the user and password components and methods are provided.
+    public var password: String? {
+        get { return _handle.map { $0.password } }
+        set { _applyMutation { $0.password = newValue } }
+    }
+    
+    /// The host subcomponent.
+    ///
+    /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
+    public var host: String? {
+        get { return _handle.map { $0.host } }
+        set { _applyMutation { $0.host = newValue } }
+    }
+    
+    /// The port subcomponent.
+    ///
+    /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
+    /// Attempting to set a negative port number will cause a fatal error.
+    public var port: Int? {
+        get { return _handle.map { $0.port?.intValue } }
+        set { _applyMutation { $0.port = newValue != nil ? newValue as NSNumber? : nil as NSNumber?} } 
+    }
+    
+    /// The path subcomponent.
+    ///
+    /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
+    public var path: String {
+        get {
+            guard let result = _handle.map({ $0.path }) else { return "" }
+            return result
+        }
+        set {
+            _applyMutation { $0.path = newValue }
+        }
+    }
+    
+    /// The query subcomponent.
+    ///
+    /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
+    public var query: String? {
+        get { return _handle.map { $0.query } }
+        set { _applyMutation { $0.query = newValue } }
+    }
+    
+    /// The fragment subcomponent.
+    ///
+    /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
+    public var fragment: String? {
+        get { return _handle.map { $0.fragment } }
+        set { _applyMutation { $0.fragment = newValue } }
+    }
+    
+    
+    /// The user subcomponent, percent-encoded.
+    ///
+    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlUserAllowed`).
+    public var percentEncodedUser: String? {
+        get { return _handle.map { $0.percentEncodedUser } }
+        set { _applyMutation { $0.percentEncodedUser = newValue } }
+    }
+    
+    /// The password subcomponent, percent-encoded.
+    ///
+    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlPasswordAllowed`).
+    public var percentEncodedPassword: String? {
+        get { return _handle.map { $0.percentEncodedPassword } }
+        set { _applyMutation { $0.percentEncodedPassword = newValue } }
+    }
+    
+    /// The host subcomponent, percent-encoded.
+    ///
+    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlHostAllowed`).
+    public var percentEncodedHost: String? {
+        get { return _handle.map { $0.percentEncodedHost } }
+        set { _applyMutation { $0.percentEncodedHost = newValue } }
+    }
+    
+    /// The path subcomponent, percent-encoded.
+    ///
+    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlPathAllowed`).
+    public var percentEncodedPath: String {
+        get {
+            guard let result = _handle.map({ $0.percentEncodedPath }) else { return "" }
+            return result
+        }
+        set {
+            _applyMutation { $0.percentEncodedPath = newValue }
+        }
+    }
+    
+    /// The query subcomponent, percent-encoded.
+    ///
+    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlQueryAllowed`).
+    public var percentEncodedQuery: String? {
+        get { return _handle.map { $0.percentEncodedQuery } }
+        set { _applyMutation { $0.percentEncodedQuery = newValue } }
+    }
+    
+    /// The fragment subcomponent, percent-encoded.
+    ///
+    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlFragmentAllowed`).
+    public var percentEncodedFragment: String? {
+        get { return _handle.map { $0.percentEncodedFragment } }
+        set { _applyMutation { $0.percentEncodedFragment = newValue } }
+    }
+    
+    @available(macOS 10.11, iOS 9.0, *)
+    private func _toStringRange(_ r : NSRange) -> Range<String.Index>? {
+        guard let s = self.string else { return nil }
+        return Range(r, in: s)
+    }
+    
+    /// Returns the character range of the scheme in the string returned by `var string`.
+    ///
+    /// If the component does not exist, nil is returned.
+    /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
+    @available(macOS 10.11, iOS 9.0, *)
+    public var rangeOfScheme: Range<String.Index>? {
+        return _toStringRange(_handle.map { $0.rangeOfScheme })
+    }
+    
+    /// Returns the character range of the user in the string returned by `var string`.
+    ///
+    /// If the component does not exist, nil is returned.
+    /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
+    @available(macOS 10.11, iOS 9.0, *)
+    public var rangeOfUser: Range<String.Index>? {
+        return _toStringRange(_handle.map { $0.rangeOfUser })
+    }
+    
+    /// Returns the character range of the password in the string returned by `var string`.
+    ///
+    /// If the component does not exist, nil is returned.
+    /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
+    @available(macOS 10.11, iOS 9.0, *)
+    public var rangeOfPassword: Range<String.Index>? {
+        return _toStringRange(_handle.map { $0.rangeOfPassword })
+    }
+    
+    /// Returns the character range of the host in the string returned by `var string`.
+    ///
+    /// If the component does not exist, nil is returned.
+    /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
+    @available(macOS 10.11, iOS 9.0, *)
+    public var rangeOfHost: Range<String.Index>? {
+        return _toStringRange(_handle.map { $0.rangeOfHost })
+    }
+    
+    /// Returns the character range of the port in the string returned by `var string`.
+    ///
+    /// If the component does not exist, nil is returned.
+    /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
+    @available(macOS 10.11, iOS 9.0, *)
+    public var rangeOfPort: Range<String.Index>? {
+        return _toStringRange(_handle.map { $0.rangeOfPort })
+    }
+    
+    /// Returns the character range of the path in the string returned by `var string`.
+    ///
+    /// If the component does not exist, nil is returned.
+    /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
+    @available(macOS 10.11, iOS 9.0, *)
+    public var rangeOfPath: Range<String.Index>? {
+        return _toStringRange(_handle.map { $0.rangeOfPath })
+    }
+    
+    /// Returns the character range of the query in the string returned by `var string`.
+    ///
+    /// If the component does not exist, nil is returned.
+    /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
+    @available(macOS 10.11, iOS 9.0, *)
+    public var rangeOfQuery: Range<String.Index>? {
+        return _toStringRange(_handle.map { $0.rangeOfQuery })
+    }
+    
+    /// Returns the character range of the fragment in the string returned by `var string`.
+    ///
+    /// If the component does not exist, nil is returned.
+    /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
+    @available(macOS 10.11, iOS 9.0, *)
+    public var rangeOfFragment: Range<String.Index>? {
+        return _toStringRange(_handle.map { $0.rangeOfFragment })
+    }
+
+    /// Returns an array of query items for this `URLComponents`, in the order in which they appear in the original query string.
+    ///
+    /// Each `URLQueryItem` represents a single key-value pair,
+    ///
+    /// Note that a name may appear more than once in a single query string, so the name values are not guaranteed to be unique. If the `URLComponents` has an empty query component, returns an empty array. If the `URLComponents` has no query component, returns nil.
+    ///
+    /// The setter combines an array containing any number of `URLQueryItem`s, each of which represents a single key-value pair, into a query string and sets the `URLComponents` query property. Passing an empty array sets the query component of the `URLComponents` to an empty string. Passing nil removes the query component of the `URLComponents`.
+    ///
+    /// - note: If a name-value pair in a query is empty (i.e. the query string starts with '&', ends with '&', or has "&&" within it), you get a `URLQueryItem` with a zero-length name and a nil value. If a query's name-value pair has nothing before the equals sign, you get a zero-length name. If a query's name-value pair has nothing after the equals sign, you get a zero-length value. If a query's name-value pair has no equals sign, the query name-value pair string is the name and you get a nil value.
+    @available(macOS 10.10, iOS 8.0, *)
+    public var queryItems: [URLQueryItem]? {
+        get { return _handle.map { $0.queryItems } }
+        set { _applyMutation { $0.queryItems = newValue } }
+    }
+    
+    /// Returns an array of query items for this `URLComponents`, in the order in which they appear in the original query string. Any percent-encoding in a query item name or value is retained
+    ///
+    /// The setter combines an array containing any number of `URLQueryItem`s, each of which represents a single key-value pair, into a query string and sets the `URLComponents` query property. This property assumes the query item names and values are already correctly percent-encoded, and that the query item names do not contain the query item delimiter characters '&' and '='. Attempting to set an incorrectly percent-encoded query item or a query item name with the query item delimiter characters '&' and '=' will cause a `fatalError`.
+    @available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *)
+    public var percentEncodedQueryItems: [URLQueryItem]? {
+        get { return _handle.map { $0.percentEncodedQueryItems } }
+        set { _applyMutation { $0.percentEncodedQueryItems = newValue } }
+    }
+	
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_handle._uncopiedReference())
+    }
+    
+    // MARK: - Bridging
+    
+    fileprivate init(reference: __shared NSURLComponents) {
+        _handle = _MutableHandle(reference: reference)
+    }
+    
+    public static func ==(lhs: URLComponents, rhs: URLComponents) -> Bool {
+        // Don't copy references here; no one should be storing anything
+        return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
+    }
+}
+
+extension URLComponents : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    
+    public var description: String {
+        if let u = url {
+            return u.description
+        } else {
+            return self.customMirror.children.reduce("") {
+                $0.appending("\($1.label ?? ""): \($1.value) ")
+            }
+        }
+    }
+    
+    public var debugDescription: String {
+        return self.description
+    }    
+
+    public var customMirror: Mirror {
+        var c: [(label: String?, value: Any)] = []
+        
+        if let s = self.scheme { c.append((label: "scheme", value: s)) }
+        if let u = self.user { c.append((label: "user", value: u)) }
+        if let pw = self.password { c.append((label: "password", value: pw)) }
+        if let h = self.host { c.append((label: "host", value: h)) }
+        if let p = self.port { c.append((label: "port", value: p)) }
+        
+        c.append((label: "path", value: self.path))
+        if #available(macOS 10.10, iOS 8.0, *) {
+            if let qi = self.queryItems { c.append((label: "queryItems", value: qi)) }
+        }
+        if let f = self.fragment { c.append((label: "fragment", value: f)) }
+        let m = Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+        return m
+    }
+}
+
+extension URLComponents : _ObjectiveCBridgeable {
+    public static func _getObjectiveCType() -> Any.Type {
+        return NSURLComponents.self
+    }
+    
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSURLComponents {
+        return _handle._copiedReference()
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSURLComponents, result: inout URLComponents?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSURLComponents, result: inout URLComponents?) -> Bool {
+        result = URLComponents(reference: x)
+        return true
+    }
+
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSURLComponents?) -> URLComponents {
+        guard let src = source else { return URLComponents() }
+        return URLComponents(reference: src)
+    }
+}
+
+extension NSURLComponents : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as URLComponents)
+    }
+}
+
+
+/// A single name-value pair, for use with `URLComponents`.
+@available(macOS 10.10, iOS 8.0, *)
+public struct URLQueryItem : ReferenceConvertible, Hashable, Equatable {
+    public typealias ReferenceType = NSURLQueryItem
+    
+    fileprivate var _queryItem : NSURLQueryItem
+    
+    public init(name: __shared String, value: __shared String?) {
+        _queryItem = NSURLQueryItem(name: name, value: value)
+    }
+    
+    fileprivate init(reference: __shared NSURLQueryItem) { _queryItem = reference.copy() as! NSURLQueryItem }
+    fileprivate var reference : NSURLQueryItem { return _queryItem }
+    
+    public var name : String {
+        get { return _queryItem.name }
+        set { _queryItem = NSURLQueryItem(name: newValue, value: value) }
+    }
+    
+    public var value : String? {
+        get { return _queryItem.value }
+        set { _queryItem = NSURLQueryItem(name: name, value: newValue) }
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_queryItem)
+    }
+
+    @available(macOS 10.10, iOS 8.0, *)
+    public static func ==(lhs: URLQueryItem, rhs: URLQueryItem) -> Bool {
+        return lhs._queryItem.isEqual(rhs as NSURLQueryItem)
+    }
+}
+
+@available(macOS 10.10, iOS 8.0, *)
+extension URLQueryItem : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    
+    public var description: String {
+        if let v = value {
+            return "\(name)=\(v)"
+        } else {
+            return name
+        }
+    }
+    
+    public var debugDescription: String {
+        return self.description
+    }
+
+    public var customMirror: Mirror {
+        let c: [(label: String?, value: Any)] = [
+          ("name", name),
+          ("value", value as Any),
+        ]
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+    }
+}
+
+@available(macOS 10.10, iOS 8.0, *)
+extension URLQueryItem : _ObjectiveCBridgeable {
+    public static func _getObjectiveCType() -> Any.Type {
+        return NSURLQueryItem.self
+    }
+    
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSURLQueryItem {
+        return _queryItem
+    }
+
+    public static func _forceBridgeFromObjectiveC(_ x: NSURLQueryItem, result: inout URLQueryItem?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSURLQueryItem, result: inout URLQueryItem?) -> Bool {
+        result = URLQueryItem(reference: x)
+        return true
+    }
+
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSURLQueryItem?) -> URLQueryItem {
+        var result: URLQueryItem?
+        _forceBridgeFromObjectiveC(source!, result: &result)
+        return result!
+    }
+}
+
+@available(macOS 10.10, iOS 8.0, *)
+extension NSURLQueryItem : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as URLQueryItem)
+    }
+}
+
+extension URLComponents : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case scheme
+        case user
+        case password
+        case host
+        case port
+        case path
+        case query
+        case fragment
+    }
+
+    public init(from decoder: Decoder) throws {
+        self.init()
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.scheme = try container.decodeIfPresent(String.self, forKey: .scheme)
+        self.user = try container.decodeIfPresent(String.self, forKey: .user)
+        self.password = try container.decodeIfPresent(String.self, forKey: .password)
+        self.host = try container.decodeIfPresent(String.self, forKey: .host)
+        self.port = try container.decodeIfPresent(Int.self, forKey: .port)
+        self.path = try container.decode(String.self, forKey: .path)
+        self.query = try container.decodeIfPresent(String.self, forKey: .query)
+        self.fragment = try container.decodeIfPresent(String.self, forKey: .fragment)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(self.scheme, forKey: .scheme)
+        try container.encodeIfPresent(self.user, forKey: .user)
+        try container.encodeIfPresent(self.password, forKey: .password)
+        try container.encodeIfPresent(self.host, forKey: .host)
+        try container.encodeIfPresent(self.port, forKey: .port)
+        try container.encode(self.path, forKey: .path)
+        try container.encodeIfPresent(self.query, forKey: .query)
+        try container.encodeIfPresent(self.fragment, forKey: .fragment)
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/URLRequest.swift
+++ b/Darwin/Foundation-swiftoverlay/URLRequest.swift
@@ -1,0 +1,328 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+@available(*, deprecated, message: "Please use the struct type URLRequest")
+public typealias MutableURLRequest = NSMutableURLRequest
+
+public struct URLRequest : ReferenceConvertible, Equatable, Hashable {
+    public typealias ReferenceType = NSURLRequest
+    public typealias CachePolicy = NSURLRequest.CachePolicy
+    public typealias NetworkServiceType = NSURLRequest.NetworkServiceType
+    
+    /*
+     NSURLRequest has a fragile ivar layout that prevents the swift subclass approach here, so instead we keep an always mutable copy
+    */
+    internal var _handle: _MutableHandle<NSMutableURLRequest>
+    
+    internal mutating func _applyMutation<ReturnType>(_ whatToDo : (NSMutableURLRequest) -> ReturnType) -> ReturnType {
+        if !isKnownUniquelyReferenced(&_handle) {
+            let ref = _handle._uncopiedReference()
+            _handle = _MutableHandle(reference: ref)
+        }
+        return whatToDo(_handle._uncopiedReference())
+    }
+
+    /// Creates and initializes a URLRequest with the given URL and cache policy.
+    /// - parameter: url The URL for the request. 
+    /// - parameter: cachePolicy The cache policy for the request. Defaults to `.useProtocolCachePolicy`
+    /// - parameter: timeoutInterval The timeout interval for the request. See the commentary for the `timeoutInterval` for more information on timeout intervals. Defaults to 60.0
+    public init(url: URL, cachePolicy: CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 60.0) {
+        _handle = _MutableHandle(adoptingReference: NSMutableURLRequest(url: url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval))
+    }
+
+    private init(_bridged request: __shared NSURLRequest) {
+        _handle = _MutableHandle(reference: request.mutableCopy() as! NSMutableURLRequest)
+    }
+    
+    /// The URL of the receiver.
+    public var url: URL? {
+        get {
+            return _handle.map { $0.url }
+        }
+        set {
+            _applyMutation { $0.url = newValue }
+        }
+    }
+    
+    /// The cache policy of the receiver.
+    public var cachePolicy: CachePolicy {
+        get {
+            return _handle.map { $0.cachePolicy }
+        }
+        set {
+            _applyMutation { $0.cachePolicy = newValue }
+        }
+    }
+    
+    /// Returns the timeout interval of the receiver.
+    /// - discussion: The timeout interval specifies the limit on the idle
+    /// interval allotted to a request in the process of loading. The "idle
+    /// interval" is defined as the period of time that has passed since the
+    /// last instance of load activity occurred for a request that is in the
+    /// process of loading. Hence, when an instance of load activity occurs
+    /// (e.g. bytes are received from the network for a request), the idle
+    /// interval for a request is reset to 0. If the idle interval ever
+    /// becomes greater than or equal to the timeout interval, the request
+    /// is considered to have timed out. This timeout interval is measured
+    /// in seconds.
+    public var timeoutInterval: TimeInterval {
+        get {
+            return _handle.map { $0.timeoutInterval }
+        }
+        set {
+            _applyMutation { $0.timeoutInterval = newValue }
+        }
+    }
+    
+    /// The main document URL associated with this load.
+    /// - discussion: This URL is used for the cookie "same domain as main
+    /// document" policy.
+    public var mainDocumentURL: URL? {
+        get {
+            return _handle.map { $0.mainDocumentURL }
+        }
+        set {
+            _applyMutation { $0.mainDocumentURL = newValue }
+        }
+    }
+    
+    /// The URLRequest.NetworkServiceType associated with this request.
+    /// - discussion: This will return URLRequest.NetworkServiceType.default for requests that have
+    /// not explicitly set a networkServiceType
+    @available(macOS 10.7, iOS 4.0, *)
+    public var networkServiceType: NetworkServiceType {
+        get {
+            return _handle.map { $0.networkServiceType }
+        }
+        set {
+            _applyMutation { $0.networkServiceType = newValue }
+        }
+    }
+    
+    /// `true` if the receiver is allowed to use the built in cellular radios to
+    /// satisfy the request, `false` otherwise.
+    @available(macOS 10.8, iOS 6.0, *)
+    public var allowsCellularAccess: Bool {
+        get {
+            return _handle.map { $0.allowsCellularAccess }
+        }
+        set {
+            _applyMutation { $0.allowsCellularAccess = newValue }
+        }
+    }
+    
+    /// `true` if the receiver is allowed to use an interface marked as expensive to
+    /// satify the request, `false` otherwise.
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    public var allowsExpensiveNetworkAccess: Bool {
+        get {
+            return _handle.map { $0.allowsExpensiveNetworkAccess }
+        }
+        set {
+            _applyMutation { $0.allowsExpensiveNetworkAccess = newValue }
+        }
+    }
+    
+    /// `true` if the receiver is allowed to use an interface marked as constrained to
+    /// satify the request, `false` otherwise.
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    public var allowsConstrainedNetworkAccess: Bool {
+        get {
+            return _handle.map { $0.allowsConstrainedNetworkAccess }
+        }
+        set {
+            _applyMutation { $0.allowsConstrainedNetworkAccess = newValue }
+        }
+    }
+    
+    /// The HTTP request method of the receiver.
+    public var httpMethod: String? {
+        get {
+            return _handle.map { $0.httpMethod }
+        }
+        set {
+            _applyMutation { 
+                if let value = newValue {
+                    $0.httpMethod = value
+                } else {
+                    $0.httpMethod = "GET"
+                }
+            }
+        }
+    }
+    
+    /// A dictionary containing all the HTTP header fields of the
+    /// receiver.
+    public var allHTTPHeaderFields: [String : String]? {
+        get {
+            return _handle.map { $0.allHTTPHeaderFields }
+        }
+        set {
+            _applyMutation { $0.allHTTPHeaderFields = newValue }
+        }
+    }
+
+    /// The value which corresponds to the given header
+    /// field. Note that, in keeping with the HTTP RFC, HTTP header field
+    /// names are case-insensitive.
+    /// - parameter: field the header field name to use for the lookup (case-insensitive).
+    public func value(forHTTPHeaderField field: String) -> String? {
+        return _handle.map { $0.value(forHTTPHeaderField: field) }
+    }
+    
+    /// If a value was previously set for the given header
+    /// field, that value is replaced with the given value. Note that, in
+    /// keeping with the HTTP RFC, HTTP header field names are
+    /// case-insensitive.
+    public mutating func setValue(_ value: String?, forHTTPHeaderField field: String) {
+        _applyMutation {
+            $0.setValue(value, forHTTPHeaderField: field)
+        }
+    }
+    
+    /// This method provides a way to add values to header
+    /// fields incrementally. If a value was previously set for the given
+    /// header field, the given value is appended to the previously-existing
+    /// value. The appropriate field delimiter, a comma in the case of HTTP,
+    /// is added by the implementation, and should not be added to the given
+    /// value by the caller. Note that, in keeping with the HTTP RFC, HTTP
+    /// header field names are case-insensitive.
+    public mutating func addValue(_ value: String, forHTTPHeaderField field: String) {
+        _applyMutation {
+            $0.addValue(value, forHTTPHeaderField: field)
+        }
+    }
+    
+    /// This data is sent as the message body of the request, as
+    /// in done in an HTTP POST request.
+    public var httpBody: Data? {
+        get {
+            return _handle.map { $0.httpBody }
+        }
+        set {
+            _applyMutation { $0.httpBody = newValue }
+        }
+    }
+    
+    /// The stream is returned for examination only; it is
+    /// not safe for the caller to manipulate the stream in any way.  Also
+    /// note that the HTTPBodyStream and HTTPBody are mutually exclusive - only
+    /// one can be set on a given request.  Also note that the body stream is
+    /// preserved across copies, but is LOST when the request is coded via the 
+    /// NSCoding protocol
+    public var httpBodyStream: InputStream? {
+        get {
+            return _handle.map { $0.httpBodyStream }
+        }
+        set {
+            _applyMutation { $0.httpBodyStream = newValue }
+        }
+    }
+    
+    /// `true` if cookies will be sent with and set for this request; otherwise `false`.
+    public var httpShouldHandleCookies: Bool {
+        get {
+            return _handle.map { $0.httpShouldHandleCookies }
+        }
+        set {
+            _applyMutation { $0.httpShouldHandleCookies = newValue }
+        }
+    }
+    
+    /// `true` if the receiver should transmit before the previous response
+    /// is received.  `false` if the receiver should wait for the previous response
+    /// before transmitting.
+    @available(macOS 10.7, iOS 4.0, *)
+    public var httpShouldUsePipelining: Bool {
+        get {
+            return _handle.map { $0.httpShouldUsePipelining }
+        }
+        set {
+            _applyMutation { $0.httpShouldUsePipelining = newValue }
+        }
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_handle._uncopiedReference())
+    }
+
+    public static func ==(lhs: URLRequest, rhs: URLRequest) -> Bool {
+        return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
+    }
+}
+
+extension URLRequest : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+
+    public var description: String {
+      return url?.description ?? "url: nil"
+    }
+    
+    public var debugDescription: String {
+        return self.description
+    }
+    
+    public var customMirror: Mirror {
+        let c: [(label: String?, value: Any)] = [
+          ("url", url as Any),
+          ("cachePolicy", cachePolicy.rawValue),
+          ("timeoutInterval", timeoutInterval),
+          ("mainDocumentURL", mainDocumentURL as Any),
+          ("networkServiceType", networkServiceType),
+          ("allowsCellularAccess", allowsCellularAccess),
+          ("httpMethod", httpMethod as Any),
+          ("allHTTPHeaderFields", allHTTPHeaderFields as Any),
+          ("httpBody", httpBody as Any),
+          ("httpBodyStream", httpBodyStream as Any),
+          ("httpShouldHandleCookies", httpShouldHandleCookies),
+          ("httpShouldUsePipelining", httpShouldUsePipelining),
+        ]
+        return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
+    }
+}
+
+extension URLRequest : _ObjectiveCBridgeable {
+    public static func _getObjectiveCType() -> Any.Type {
+        return NSURLRequest.self
+    }
+    
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSURLRequest {
+        return _handle._copiedReference()
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ input: NSURLRequest, result: inout URLRequest?) {
+        result = URLRequest(_bridged: input)
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ input: NSURLRequest, result: inout URLRequest?) -> Bool {
+        result = URLRequest(_bridged: input)
+        return true
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSURLRequest?) -> URLRequest {
+        var result: URLRequest?
+        _forceBridgeFromObjectiveC(source!, result: &result)
+        return result!
+    }
+}
+
+extension NSURLRequest : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as URLRequest)
+    }
+}
+

--- a/Darwin/Foundation-swiftoverlay/URLSession.swift
+++ b/Darwin/Foundation-swiftoverlay/URLSession.swift
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension URLSessionWebSocketTask {
+    public enum Message {
+        case data(Data)
+        case string(String)
+    }
+
+    public func send(_ message: Message, completionHandler: @escaping (Error?) -> Void) {
+        switch message {
+        case .data(let data):
+            __send(__NSURLSessionWebSocketMessage(data: data), completionHandler: completionHandler)
+        case .string(let string):
+            __send(__NSURLSessionWebSocketMessage(string: string), completionHandler: completionHandler)
+        }
+    }
+
+    public func receive(completionHandler: @escaping (Result<Message, Error>) -> Void) {
+        __receiveMessage { message, error in
+            switch (message, error) {
+            case (.some(let message), nil):
+                switch message.type {
+                case .data:
+                    completionHandler(.success(.data(message.data!)))
+                case .string:
+                    completionHandler(.success(.string(message.string!)))
+                @unknown default:
+                    break
+                }
+            case (nil, .some(let error)):
+                completionHandler(.failure(error))
+            case (_, _):
+                fatalError("Only one of message or error should be nil")
+            }
+        }
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension URLSessionTaskTransactionMetrics {
+  public var localPort: Int? {
+    return __localPort as? Int
+  }
+
+  public var remotePort: Int? {
+    return __remotePort as? Int
+  }
+
+  public var negotiatedTLSProtocolVersion: tls_protocol_version_t? {
+    return (__negotiatedTLSProtocolVersion as? UInt16).flatMap(tls_protocol_version_t.init(rawValue:))
+  }
+
+  public var negotiatedTLSCipherSuite: tls_ciphersuite_t? {
+    return (__negotiatedTLSCipherSuite as? UInt16).flatMap(tls_ciphersuite_t.init(rawValue:))
+  }
+}

--- a/Darwin/Foundation-swiftoverlay/UUID.swift
+++ b/Darwin/Foundation-swiftoverlay/UUID.swift
@@ -1,0 +1,172 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+import Darwin.uuid
+@_implementationOnly import _CoreFoundationOverlayShims
+
+/// Represents UUID strings, which can be used to uniquely identify types, interfaces, and other items.
+@available(macOS 10.8, iOS 6.0, *)
+public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConvertible {
+    public typealias ReferenceType = NSUUID
+
+    public private(set) var uuid: uuid_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    
+    /* Create a new UUID with RFC 4122 version 4 random bytes */
+    public init() {
+        withUnsafeMutablePointer(to: &uuid) {
+            $0.withMemoryRebound(to: UInt8.self, capacity: 16) {
+                uuid_generate_random($0)
+            }
+        }
+    }
+    
+    private init(reference: __shared NSUUID) {
+        var bytes: uuid_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        withUnsafeMutablePointer(to: &bytes) {
+            $0.withMemoryRebound(to: UInt8.self, capacity: 16) {
+                reference.getBytes($0)
+            }
+        }
+        uuid = bytes
+    }
+
+    /// Create a UUID from a string such as "E621E1F8-C36C-495A-93FC-0C247A3E6E5F".
+    /// 
+    /// Returns nil for invalid strings.
+    public init?(uuidString string: __shared String) {
+        let res = withUnsafeMutablePointer(to: &uuid) {
+            $0.withMemoryRebound(to: UInt8.self, capacity: 16) {
+                return uuid_parse(string, $0)
+            }
+        }
+        if res != 0 {
+            return nil
+        }
+    }
+    
+    /// Create a UUID from a `uuid_t`.
+    public init(uuid: uuid_t) {
+        self.uuid = uuid
+    }
+    
+    /// Returns a string created from the UUID, such as "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"
+    public var uuidString: String {
+        var bytes: uuid_string_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        return withUnsafePointer(to: uuid) {
+            $0.withMemoryRebound(to: UInt8.self, capacity: 16) { val in
+                withUnsafeMutablePointer(to: &bytes) {
+                    $0.withMemoryRebound(to: Int8.self, capacity: 37) { str in
+                        uuid_unparse(val, str)
+                        return String(cString: UnsafePointer(str), encoding: .utf8)!
+                    }
+                }
+            }
+        }
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        withUnsafeBytes(of: uuid) { buffer in
+            hasher.combine(bytes: buffer)
+        }
+    }
+
+    public var description: String {
+        return uuidString
+    }
+
+    public var debugDescription: String {
+        return description
+    }
+    
+    // MARK: - Bridging Support
+    
+    private var reference: NSUUID {
+        return withUnsafePointer(to: uuid) {
+            $0.withMemoryRebound(to: UInt8.self, capacity: 16) {
+                return NSUUID(uuidBytes: $0)
+            }
+        }
+    }
+
+    public static func ==(lhs: UUID, rhs: UUID) -> Bool {
+        return withUnsafeBytes(of: rhs.uuid) { (rhsPtr) -> Bool in
+            return withUnsafeBytes(of: lhs.uuid) { (lhsPtr) -> Bool in
+                let lhsFirstChunk = lhsPtr.load(fromByteOffset: 0, as: UInt64.self)
+                let lhsSecondChunk = lhsPtr.load(fromByteOffset: MemoryLayout<UInt64>.size, as: UInt64.self)
+                let rhsFirstChunk = rhsPtr.load(fromByteOffset: 0, as: UInt64.self)
+                let rhsSecondChunk = rhsPtr.load(fromByteOffset: MemoryLayout<UInt64>.size, as: UInt64.self)
+                return ((lhsFirstChunk ^ rhsFirstChunk) | (lhsSecondChunk ^ rhsSecondChunk)) == 0
+            }
+        }
+    }
+}
+
+extension UUID : CustomReflectable {
+    public var customMirror: Mirror {
+        let c : [(label: String?, value: Any)] = []
+        let m = Mirror(self, children:c, displayStyle: Mirror.DisplayStyle.struct)
+        return m
+    }
+}
+
+extension UUID : _ObjectiveCBridgeable {
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSUUID {
+        return reference
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSUUID, result: inout UUID?) {
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ input: NSUUID, result: inout UUID?) -> Bool {
+        result = UUID(reference: input)
+        return true
+    }
+
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSUUID?) -> UUID {
+        var result: UUID?
+        _forceBridgeFromObjectiveC(source!, result: &result)
+        return result!
+    }
+}
+
+extension NSUUID : _HasCustomAnyHashableRepresentation {
+    // Must be @nonobjc to avoid infinite recursion during bridging.
+    @nonobjc
+    public func _toCustomAnyHashable() -> AnyHashable? {
+        return AnyHashable(self as UUID)
+    }
+}
+
+extension UUID : Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let uuidString = try container.decode(String.self)
+
+        guard let uuid = UUID(uuidString: uuidString) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Attempted to decode UUID from invalid UUID string."))
+        }
+
+        self = uuid
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.uuidString)
+    }
+}

--- a/Darwin/Foundation-swiftoverlay/magic-symbols-for-install-name.c
+++ b/Darwin/Foundation-swiftoverlay/magic-symbols-for-install-name.c
@@ -1,0 +1,13 @@
+//===--- magic-symbols-for-install-name.c - Magic linker directive symbols ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "magic-symbols-for-install-name.h"

--- a/Darwin/Foundation-swiftoverlay/magic-symbols-for-install-name.h
+++ b/Darwin/Foundation-swiftoverlay/magic-symbols-for-install-name.h
@@ -1,0 +1,100 @@
+//===--- magic-symbols-for-install-name.h - Magic linker directive symbols ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// A file containing magic symbols that instruct the linker to use a
+// different install name when targeting older OSes. This file gets
+// compiled into all of the libraries that are embedded for backward
+// deployment.
+//
+//===----------------------------------------------------------------------===//
+
+#if defined(__APPLE__) && defined(__MACH__)
+
+#include <Availability.h>
+#include <TargetConditionals.h>
+
+#ifndef SWIFT_TARGET_LIBRARY_NAME
+#error Please define SWIFT_TARGET_LIBRARY_NAME
+#endif
+
+#define SWIFT_RUNTIME_EXPORT __attribute__((__visibility__("default")))
+
+#define RPATH_INSTALL_NAME_DIRECTIVE_IMPL2(name, major, minor) \
+  SWIFT_RUNTIME_EXPORT const char install_name_ ## major ## _ ## minor \
+  __asm("$ld$install_name$os" #major "." #minor "$@rpath/lib" #name ".dylib"); \
+  const char install_name_ ## major ## _ ## minor = 0;
+
+#define RPATH_INSTALL_NAME_DIRECTIVE_IMPL(name, major, minor) \
+  RPATH_INSTALL_NAME_DIRECTIVE_IMPL2(name, major, minor)
+
+#define RPATH_INSTALL_NAME_DIRECTIVE(major, minor) \
+  RPATH_INSTALL_NAME_DIRECTIVE_IMPL(SWIFT_TARGET_LIBRARY_NAME, major, minor)
+
+
+// Check iOS last, because TARGET_OS_IPHONE includes both watchOS and macCatalyst.
+#if TARGET_OS_OSX
+  RPATH_INSTALL_NAME_DIRECTIVE(10,  9)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 10)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 11)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 12)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 13)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 14)
+#elif TARGET_OS_MACCATALYST
+  // Note: This only applies to zippered overlays.
+  RPATH_INSTALL_NAME_DIRECTIVE(10,  9)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 10)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 11)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 12)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 13)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 14)
+#elif TARGET_OS_WATCH
+  RPATH_INSTALL_NAME_DIRECTIVE( 2, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE( 2, 1)
+  RPATH_INSTALL_NAME_DIRECTIVE( 2, 2)
+  RPATH_INSTALL_NAME_DIRECTIVE( 3, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE( 3, 1)
+  RPATH_INSTALL_NAME_DIRECTIVE( 3, 2)
+  RPATH_INSTALL_NAME_DIRECTIVE( 4, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE( 4, 1)
+  RPATH_INSTALL_NAME_DIRECTIVE( 4, 2)
+  RPATH_INSTALL_NAME_DIRECTIVE( 4, 3)
+  RPATH_INSTALL_NAME_DIRECTIVE( 5, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE( 5, 1)
+#elif TARGET_OS_IPHONE
+  RPATH_INSTALL_NAME_DIRECTIVE( 7, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE( 7, 1)
+  RPATH_INSTALL_NAME_DIRECTIVE( 8, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE( 8, 1)
+  RPATH_INSTALL_NAME_DIRECTIVE( 8, 2)
+  RPATH_INSTALL_NAME_DIRECTIVE( 8, 3)
+  RPATH_INSTALL_NAME_DIRECTIVE( 8, 4)
+  RPATH_INSTALL_NAME_DIRECTIVE( 9, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE( 9, 1)
+  RPATH_INSTALL_NAME_DIRECTIVE( 9, 2)
+  RPATH_INSTALL_NAME_DIRECTIVE( 9, 3)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 1)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 2)
+  RPATH_INSTALL_NAME_DIRECTIVE(10, 3)
+  RPATH_INSTALL_NAME_DIRECTIVE(11, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE(11, 1)
+  RPATH_INSTALL_NAME_DIRECTIVE(11, 2)
+  RPATH_INSTALL_NAME_DIRECTIVE(11, 3)
+  RPATH_INSTALL_NAME_DIRECTIVE(11, 4)
+  RPATH_INSTALL_NAME_DIRECTIVE(12, 0)
+  RPATH_INSTALL_NAME_DIRECTIVE(12, 1)
+
+#else
+  #error Unknown target.
+#endif
+
+#endif // defined(__APPLE__) && defined(__MACH__)

--- a/Darwin/shims/CFCharacterSetShims.h
+++ b/Darwin/shims/CFCharacterSetShims.h
@@ -1,0 +1,26 @@
+//===--- CFCharacterSetShims.h - Declarations for CF hashing functions ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+CF_IMPLICIT_BRIDGING_ENABLED
+CF_EXTERN_C_BEGIN
+_Pragma("clang assume_nonnull begin")
+
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLUserAllowedCharacterSet() API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLPasswordAllowedCharacterSet() API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLHostAllowedCharacterSet() API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLPathAllowedCharacterSet() API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLQueryAllowedCharacterSet() API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLFragmentAllowedCharacterSet() API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+
+_Pragma("clang assume_nonnull end")
+CF_EXTERN_C_END
+CF_IMPLICIT_BRIDGING_DISABLED

--- a/Darwin/shims/CFHashingShims.h
+++ b/Darwin/shims/CFHashingShims.h
@@ -1,0 +1,41 @@
+//===--- CFHashingShims.h - Declarations for CF hashing functions ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+CF_IMPLICIT_BRIDGING_ENABLED
+CF_EXTERN_C_BEGIN
+_Pragma("clang assume_nonnull begin")
+
+
+#define _CF_HASHFACTOR 2654435761U
+
+CF_INLINE CFHashCode __CFHashInt(long i) {
+    return ((i > 0) ? (CFHashCode)(i) : (CFHashCode)(-i)) * _CF_HASHFACTOR;
+}
+
+CF_INLINE CFHashCode __CFHashDouble(double d) {
+    double dInt;
+    if (d < 0) d = -d;
+    dInt = floor(d+0.5);
+    CFHashCode integralHash = _CF_HASHFACTOR * (CFHashCode)fmod(dInt, (double)ULONG_MAX);
+    return (CFHashCode)(integralHash + (CFHashCode)((d - dInt) * ULONG_MAX));
+}
+
+CF_EXPORT CFHashCode CFHashBytes(uint8_t *_Nullable bytes, CFIndex len);
+
+
+CF_INLINE CFHashCode __CFHashBytes(uint8_t *_Nullable bytes, CFIndex len) {
+    return CFHashBytes(bytes, len);
+}
+
+_Pragma("clang assume_nonnull end")
+CF_EXTERN_C_END
+CF_IMPLICIT_BRIDGING_DISABLED

--- a/Darwin/shims/CoreFoundationOverlayShims.h
+++ b/Darwin/shims/CoreFoundationOverlayShims.h
@@ -1,0 +1,21 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import <CoreFoundation/CoreFoundation.h>
+
+/// - Note: This file is intended to be used solely for the Foundation and CoreFoundation overlays in swift
+/// any and all other uses are not supported. The Foundation team reserves the right to alter the contract,
+/// calling convention, availability or any other facet of facilities offered in this file. If you use
+/// anything from here and your app breaks, expect any bug to be marked as "behaves correctly".
+
+#import "CFCharacterSetShims.h"
+#import "CFHashingShims.h"

--- a/Darwin/shims/FoundationOverlayShims.h
+++ b/Darwin/shims/FoundationOverlayShims.h
@@ -1,0 +1,82 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+#import <sys/fcntl.h>
+#import <alloca.h>
+#import <stdlib.h>
+#import <malloc/malloc.h>
+#import <pthread.h>
+
+#import "FoundationShimSupport.h"
+#import "NSCalendarShims.h"
+#import "NSCharacterSetShims.h"
+#import "NSCoderShims.h"
+#import "NSDataShims.h"
+#import "NSDictionaryShims.h"
+#import "NSErrorShims.h"
+#import "NSFileManagerShims.h"
+#import "NSIndexPathShims.h"
+#import "NSIndexSetShims.h"
+#import "NSKeyedArchiverShims.h"
+#import "NSLocaleShims.h"
+#import "NSTimeZoneShims.h"
+#import "NSUndoManagerShims.h"
+
+typedef struct {
+    void *_Nonnull memory;
+    size_t capacity;
+    _Bool onStack;
+} _ConditionalAllocationBuffer;
+
+static inline _Bool _resizeConditionalAllocationBuffer(_ConditionalAllocationBuffer *_Nonnull buffer, size_t amt) {
+    size_t amount = malloc_good_size(amt);
+    if (amount <= buffer->capacity) { return true; }
+    void *newMemory;
+    if (buffer->onStack) {
+        newMemory = malloc(amount);
+        if (newMemory == NULL) { return false; }
+        memcpy(newMemory, buffer->memory, buffer->capacity);
+        buffer->onStack = false;
+    } else {
+        newMemory = realloc(buffer->memory, amount);
+        if (newMemory == NULL) { return false; }
+    }
+    if (newMemory == NULL) { return false; }
+    buffer->memory = newMemory;
+    buffer->capacity = amount;
+    return true;
+}
+
+static inline _Bool _withStackOrHeapBuffer(size_t amount, void (__attribute__((noescape)) ^ _Nonnull applier)(_ConditionalAllocationBuffer *_Nonnull)) {
+    _ConditionalAllocationBuffer buffer;
+    buffer.capacity = malloc_good_size(amount);
+    buffer.onStack = (pthread_main_np() != 0 ? buffer.capacity < 2048 : buffer.capacity < 512);
+    buffer.memory = buffer.onStack ? alloca(buffer.capacity) : malloc(buffer.capacity);
+    if (buffer.memory == NULL) { return false; }
+    applier(&buffer);
+    if (!buffer.onStack) {
+        free(buffer.memory);
+    }
+    return true;
+}
+
+@protocol _NSKVOCompatibilityShim <NSObject>
++ (void)_noteProcessHasUsedKVOSwiftOverlay;
+@end
+
+
+// Exported by libswiftCore:
+extern bool _swift_isObjCTypeNameSerializable(Class theClass);
+extern void _swift_reportToDebugger(uintptr_t flags, const char *message, void *details);

--- a/Darwin/shims/FoundationShimSupport.h
+++ b/Darwin/shims/FoundationShimSupport.h
@@ -1,0 +1,33 @@
+//===--- FoundationShimSupport.h - Helper macros for Foundation overlay ---===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import <Foundation/Foundation.h>
+
+#ifndef NS_NON_BRIDGED
+#define NS_NON_BRIDGED(type) NSObject *
+#endif
+
+#ifndef NS_BEGIN_DECLS
+
+#define NS_BEGIN_DECLS \
+    __BEGIN_DECLS \
+    NS_ASSUME_NONNULL_BEGIN
+
+#endif
+
+#ifndef NS_END_DECLS
+
+#define NS_END_DECLS \
+    NS_ASSUME_NONNULL_END \
+    __END_DECLS
+
+#endif

--- a/Darwin/shims/NSCalendarShims.h
+++ b/Darwin/shims/NSCalendarShims.h
@@ -1,0 +1,40 @@
+//===--- NSCalendarShims.h - Foundation declarations for Calendar overlay -===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import "FoundationShimSupport.h"
+
+NS_BEGIN_DECLS
+
+NS_INLINE BOOL __NSCalendarIsAutoupdating(NS_NON_BRIDGED(NSCalendar *) calendar) {
+    static dispatch_once_t onceToken;
+    static Class autoCalendarClass;
+    static Class olderAutoCalendarClass; // Pre 10.12/10.0
+    dispatch_once(&onceToken, ^{
+        autoCalendarClass = (Class)objc_lookUpClass("_NSAutoCalendar");
+        olderAutoCalendarClass = (Class)objc_lookUpClass("NSAutoCalendar");
+    });
+    return (autoCalendarClass && [calendar isKindOfClass:autoCalendarClass]) || (olderAutoCalendarClass && [calendar isKindOfClass:olderAutoCalendarClass]);
+}
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSCalendar *) __NSCalendarCreate(NSCalendarIdentifier identifier) {
+  return [[NSCalendar alloc] initWithCalendarIdentifier:identifier];
+}
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSCalendar *) __NSCalendarAutoupdating() {
+    return [NSCalendar autoupdatingCurrentCalendar];
+}
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSCalendar *) __NSCalendarCurrent() {
+    return [NSCalendar currentCalendar];
+}
+
+NS_END_DECLS

--- a/Darwin/shims/NSCharacterSetShims.h
+++ b/Darwin/shims/NSCharacterSetShims.h
@@ -1,0 +1,41 @@
+//===--- NSCharacterSetShims.h - Foundation decl. for CharacterSet overlay ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import "FoundationShimSupport.h"
+
+NS_BEGIN_DECLS
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSCharacterSet *) _NSURLComponentsGetURLUserAllowedCharacterSet(void) {
+    return NSCharacterSet.URLUserAllowedCharacterSet;
+}
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSCharacterSet *) _NSURLComponentsGetURLPasswordAllowedCharacterSet(void) {
+    return NSCharacterSet.URLPasswordAllowedCharacterSet;
+}
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSCharacterSet *) _NSURLComponentsGetURLHostAllowedCharacterSet(void) {
+    return NSCharacterSet.URLHostAllowedCharacterSet;
+}
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSCharacterSet *) _NSURLComponentsGetURLPathAllowedCharacterSet(void) {
+    return NSCharacterSet.URLPathAllowedCharacterSet;
+}
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSCharacterSet *) _NSURLComponentsGetURLQueryAllowedCharacterSet(void) {
+    return NSCharacterSet.URLQueryAllowedCharacterSet;
+}
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSCharacterSet *) _NSURLComponentsGetURLFragmentAllowedCharacterSet(void) {
+    return NSCharacterSet.URLFragmentAllowedCharacterSet;
+}
+
+NS_END_DECLS

--- a/Darwin/shims/NSCoderShims.h
+++ b/Darwin/shims/NSCoderShims.h
@@ -1,0 +1,49 @@
+//===--- NSCoderShims.h - Foundation declarations for NSCoder overlay -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import "FoundationShimSupport.h"
+
+NS_BEGIN_DECLS
+
+NS_INLINE NS_RETURNS_RETAINED _Nullable id __NSCoderDecodeObject(NSCoder *self_, NSError **_Nullable error) {
+    if (error) {
+        return [self_ decodeTopLevelObjectAndReturnError:error];
+    } else {
+        return [self_ decodeObject];
+    }
+}
+
+NS_INLINE NS_RETURNS_RETAINED _Nullable id __NSCoderDecodeObjectForKey(NSCoder *self_, NSString *key, NSError **_Nullable error) {
+    if (error) {
+        return [self_ decodeTopLevelObjectForKey:key error:error];
+    } else {
+        return [self_ decodeObjectForKey:key];
+    }
+}
+
+NS_INLINE NS_RETURNS_RETAINED _Nullable id __NSCoderDecodeObjectOfClassForKey(NSCoder *self_, Class cls, NSString *key, NSError **_Nullable error) {
+    if (error) {
+        return [self_ decodeTopLevelObjectOfClass:cls forKey:key error:error];
+    } else {
+        return [self_ decodeObjectOfClass:cls forKey:key];
+    }
+}
+
+NS_INLINE NS_RETURNS_RETAINED _Nullable id __NSCoderDecodeObjectOfClassesForKey(NSCoder *self_, NS_NON_BRIDGED(NSSet *)_Nullable classes, NSString *key, NSError **_Nullable error) {
+    if (error) {
+        return [self_ decodeTopLevelObjectOfClasses:(NSSet<Class> *)classes forKey:key error:error];
+    } else {
+        return [self_ decodeObjectOfClasses:(NSSet<Class> *)classes forKey:key];
+    }
+}
+
+NS_END_DECLS

--- a/Darwin/shims/NSDataShims.h
+++ b/Darwin/shims/NSDataShims.h
@@ -1,0 +1,29 @@
+//===--- NSDataShims.h - Foundation declarations for Data overlay ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import "FoundationShimSupport.h"
+
+NS_BEGIN_DECLS
+
+typedef void (^NSDataDeallocator)(void * _Null_unspecified, NSUInteger);
+FOUNDATION_EXPORT const NSDataDeallocator NSDataDeallocatorVM;
+FOUNDATION_EXPORT const NSDataDeallocator NSDataDeallocatorUnmap;
+FOUNDATION_EXPORT const NSDataDeallocator NSDataDeallocatorFree;
+FOUNDATION_EXPORT const NSDataDeallocator NSDataDeallocatorNone;
+
+@interface NSData (FoundationSPI)
+- (BOOL)_isCompact API_AVAILABLE(macos(10.10), ios(8.0), watchos(2.0), tvos(9.0));
+@end
+
+BOOL __NSDataWriteToURL(NS_NON_BRIDGED(NSData *) _Nonnull data NS_RELEASES_ARGUMENT, NSURL * _Nonnull url NS_RELEASES_ARGUMENT, NSDataWritingOptions writingOptions, NSError **errorPtr);
+
+NS_END_DECLS

--- a/Darwin/shims/NSDictionaryShims.h
+++ b/Darwin/shims/NSDictionaryShims.h
@@ -1,0 +1,21 @@
+//===--- NSDictionaryShims.h - Foundation decl. for Dictionary overlay ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import "FoundationShimSupport.h"
+
+NS_BEGIN_DECLS
+
+NS_INLINE void __NSDictionaryGetObjects(NS_NON_BRIDGED(NSDictionary *)nsDictionary, void *_Nullable objects, void *_Nullable keys, NSUInteger count) {
+    [(NSDictionary *)nsDictionary getObjects:(__unsafe_unretained id  _Nonnull *)(void *)objects andKeys:(__unsafe_unretained id  _Nonnull *)(void *)keys count:count];
+}
+
+NS_END_DECLS

--- a/Darwin/shims/NSErrorShims.h
+++ b/Darwin/shims/NSErrorShims.h
@@ -1,0 +1,23 @@
+//===--- NSErrorShims.h - Foundation declarations for NSError overlay -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import "FoundationShimSupport.h"
+
+NS_BEGIN_DECLS
+
+NS_INLINE void __NSErrorPerformRecoverySelector(_Nullable id delegate, SEL selector, BOOL success, void *_Nullable contextInfo) {
+    void (*msg)(_Nullable id, SEL, BOOL, void* _Nullable) =
+        (void(*)(_Nullable id, SEL, BOOL, void* _Nullable))objc_msgSend;
+    msg(delegate, selector, success, contextInfo);
+}
+
+NS_END_DECLS

--- a/Darwin/shims/NSFileManagerShims.h
+++ b/Darwin/shims/NSFileManagerShims.h
@@ -1,0 +1,34 @@
+//===--- NSFileManagerShims.h - Foundation decl. for FileManager overlay --===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import "FoundationShimSupport.h"
+
+NS_BEGIN_DECLS
+
+NS_INLINE NS_RETURNS_RETAINED NSURL *_Nullable __NSFileManagerReplaceItemAtURL(NSFileManager *self_, NSURL *originalItemURL, NSURL *newItemURL, NSString *_Nullable backupItemName, NSFileManagerItemReplacementOptions options, NSError **_Nullable error) {
+    NSURL *result = nil;
+    BOOL success = [self_ replaceItemAtURL:originalItemURL withItemAtURL:newItemURL backupItemName:backupItemName options:options resultingItemURL:&result error:error];
+    return success ? result : nil;
+}
+
+NS_INLINE NS_RETURNS_RETAINED NSDirectoryEnumerator<NSURL *> *_Nullable __NSFileManagerEnumeratorAtURL(NSFileManager *self_, NSURL *url, NSArray<NSURLResourceKey> *_Nullable keys, NSDirectoryEnumerationOptions options, BOOL (^errorHandler)(NSURL *url, NSError *error) ) {
+    return [self_ enumeratorAtURL:url includingPropertiesForKeys:keys options:options errorHandler:^(NSURL *url, NSError *error) {
+        NSURL *realURL = url ?: error.userInfo[NSURLErrorKey];
+        if (!realURL) {
+            NSString *path = error.userInfo[NSFilePathErrorKey];
+            realURL = [NSURL fileURLWithPath:path];
+        }
+        return errorHandler(realURL, error);
+    }];
+}
+
+NS_END_DECLS

--- a/Darwin/shims/NSIndexPathShims.h
+++ b/Darwin/shims/NSIndexPathShims.h
@@ -1,0 +1,22 @@
+//===--- NSIndexPathShims.h - Found. decl. for IndexPath overl. -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import "FoundationShimSupport.h"
+
+NS_BEGIN_DECLS
+
+NS_INLINE NS_NON_BRIDGED(NSIndexPath *)_NSIndexPathCreateFromIndexes(NSUInteger idx1, NSUInteger idx2) NS_RETURNS_RETAINED {
+    NSUInteger indexes[] = {idx1, idx2};
+    return [[NSIndexPath alloc] initWithIndexes:&indexes[0] length:2];
+}
+
+NS_END_DECLS

--- a/Darwin/shims/NSIndexSetShims.h
+++ b/Darwin/shims/NSIndexSetShims.h
@@ -1,0 +1,37 @@
+//===--- NSIndexSetShims.h - Foundation declarations for IndexSet overlay -===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import "FoundationShimSupport.h"
+
+NS_BEGIN_DECLS
+
+@interface NSIndexSet (NSRanges)
+- (NSUInteger)rangeCount;
+- (NSRange)rangeAtIndex:(NSUInteger)rangeIndex;
+- (NSUInteger)_indexOfRangeContainingIndex:(NSUInteger)value;
+@end
+
+NS_INLINE NSUInteger __NSIndexSetRangeCount(NS_NON_BRIDGED(NSIndexSet *)self_) {
+    return [(NSIndexSet *)self_ rangeCount];
+}
+
+NS_INLINE void __NSIndexSetRangeAtIndex(NS_NON_BRIDGED(NSIndexSet *)self_, NSUInteger rangeIndex, NSUInteger *location, NSUInteger *length) {
+    NSRange result = [(NSIndexSet *)self_ rangeAtIndex:rangeIndex];
+    *location = result.location;
+    *length = result.length;
+}
+
+NS_INLINE NSUInteger __NSIndexSetIndexOfRangeContainingIndex(NS_NON_BRIDGED(NSIndexSet *)self_, NSUInteger index) {
+    return [(NSIndexSet *)self_ _indexOfRangeContainingIndex:index];
+}
+
+NS_END_DECLS

--- a/Darwin/shims/NSKeyedArchiverShims.h
+++ b/Darwin/shims/NSKeyedArchiverShims.h
@@ -1,0 +1,33 @@
+//===--- NSKeyedArchiverShims.h - Found. decl. for NSKeyedArchiver overlay ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import "FoundationShimSupport.h"
+
+NS_BEGIN_DECLS
+
+NS_INLINE NS_RETURNS_RETAINED _Nullable id __NSKeyedUnarchiverUnarchiveObject(id Self_, NS_NON_BRIDGED(NSData *)data, NSError **_Nullable error) {
+    if (error) {
+        return [Self_ unarchiveTopLevelObjectWithData:(NSData *)data error:error];
+    } else {
+        return [Self_ unarchiveObjectWithData:(NSData *)data];
+    }
+}
+
+NS_INLINE NS_RETURNS_RETAINED id _Nullable __NSKeyedUnarchiverSecureUnarchiveObjectOfClass(Class cls, NSData *data, NSError * _Nullable * _Nullable error) {
+    return [NSKeyedUnarchiver unarchivedObjectOfClass:cls fromData:data error:error];
+}
+
+NS_INLINE NS_RETURNS_RETAINED id _Nullable __NSKeyedUnarchiverSecureUnarchiveObjectOfClasses(NS_NON_BRIDGED(NSSet *) classes, NSData *data, NSError * _Nullable * _Nullable error) {
+    return [NSKeyedUnarchiver unarchivedObjectOfClasses:classes fromData:data error:error];
+}
+
+NS_END_DECLS

--- a/Darwin/shims/NSLocaleShims.h
+++ b/Darwin/shims/NSLocaleShims.h
@@ -1,0 +1,34 @@
+//===--- NSLocaleShims.h - Foundation declarations for Locale overlay -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import "FoundationShimSupport.h"
+
+NS_BEGIN_DECLS
+
+NS_INLINE BOOL __NSLocaleIsAutoupdating(NS_NON_BRIDGED(NSLocale *)locale) {
+    static dispatch_once_t onceToken;
+    static Class autoLocaleClass;
+    dispatch_once(&onceToken, ^{
+        autoLocaleClass = (Class)objc_lookUpClass("NSAutoLocale");
+    });
+    return [locale isKindOfClass:autoLocaleClass];
+}
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSLocale *)__NSLocaleCurrent() {
+    return [NSLocale currentLocale];
+}
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSLocale *)__NSLocaleAutoupdating() {
+    return [NSLocale autoupdatingCurrentLocale];
+}
+
+NS_END_DECLS

--- a/Darwin/shims/NSTimeZoneShims.h
+++ b/Darwin/shims/NSTimeZoneShims.h
@@ -1,0 +1,34 @@
+//===--- NSTimeZoneShims.h - Foundation declarations for TimeZone overlay -===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import "FoundationShimSupport.h"
+
+NS_BEGIN_DECLS
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSTimeZone *)__NSTimeZoneAutoupdating() {
+    return [NSTimeZone localTimeZone];
+}
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSTimeZone *)__NSTimeZoneCurrent() {
+    return [NSTimeZone systemTimeZone];
+}
+
+NS_INLINE BOOL __NSTimeZoneIsAutoupdating(NS_NON_BRIDGED(NSTimeZone *)timeZone) {
+    static dispatch_once_t onceToken;
+    static Class autoTimeZoneClass;
+    dispatch_once(&onceToken, ^{
+        autoTimeZoneClass = (Class)objc_lookUpClass("__NSLocalTimeZone");
+    });
+    return [timeZone isKindOfClass:autoTimeZoneClass];
+}
+
+NS_END_DECLS

--- a/Darwin/shims/NSUndoManagerShims.h
+++ b/Darwin/shims/NSUndoManagerShims.h
@@ -1,0 +1,21 @@
+//===--- NSUndoManagerShims.h - Foundation decl. for NSUndoManager overlay ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import "FoundationShimSupport.h"
+
+NS_BEGIN_DECLS
+
+NS_INLINE void __NSUndoManagerRegisterWithTargetHandler(NSUndoManager * self_, id target, void (^handler)(id)) {
+    [self_ registerUndoWithTarget:target handler:handler];
+}
+
+NS_END_DECLS

--- a/Darwin/shims/module.modulemap
+++ b/Darwin/shims/module.modulemap
@@ -1,0 +1,19 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+module _FoundationOverlayShims {
+  header "FoundationOverlayShims.h"
+}
+
+module _CoreFoundationOverlayShims {
+  header "CoreFoundationOverlayShims.h"
+}


### PR DESCRIPTION
This PR imports the Foundation overlay codebase from the Swift compiler repository up to [commit 7f2185d3][commit] on 2020-10-28.

[commit]: https://github.com/apple/swift/commit/7f2185d30e6408ede1981307677945f55b155d22

This includes the associated regression tests (ported to XCTest), and comes complete with a working Xcode project file to build the overlay.

The intention is that the Foundation overlay will be maintained in this repository from now on; the original codebase will be removed from the Swift repo once we teach the compiler's build system to pick up the overlay from here.

Note that while there is significant overlap in the functionality, implementations and test cases between swift-corelibs-foundation and the Foundation overlay, this particular PR makes no effort to share code or run unified tests across the two projects.

* * *

To build the overlay, you currently need to point Xcode to a local build of the Swift compiler & stdlib by manually overriding the SWIFT_EXEC and SWIFT_LIBRARY_PATH build settings to the location of your custom Swift compiler executable and Swift standard library, respectively:

```
env SWIFT_EXEC=.../build/Ninja-ReleaseAssert/swift-macosx-x86_64/bin/swiftc \
  SWIFT_LIBRARY_PATH=.../build/Ninja-ReleaseAssert/swift-macosx-x86_64/lib/swift/macosx \
  xcodebuild
```

(Replacing `macosx` with the platform you're targeting, as needed.)

* * *

This PR preserves the full commit history of the imported files, including attribution and commit messages. However, as this is a partial import, you cannot build the Foundation overlay from historical commits -- you'll need to use the Swift repository for
that.

The Swift repository's mailmap file as of the commit above was used to update/fix author names and email addresses.

Resolves rdar://70903483.