### PR TITLE
[5.3] Make mach_absolute_time implementation consistent with libdispatch

### DIFF
--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -215,10 +215,9 @@ CF_EXPORT void OSMemoryBarrier();
 
 CF_INLINE uint64_t mach_absolute_time() {
 #if TARGET_OS_WIN32
-    LARGE_INTEGER count;
-    QueryPerformanceCounter(&count);
-    // mach_absolute_time is unsigned, but this function returns a signed value.
-    return (uint64_t)count.QuadPart;
+    ULONGLONG ullTime;
+	QueryUnbiasedInterruptTimePrecise(&ullTime);
+    return ullTime;
 #else
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);

--- a/CoreFoundation/NumberDate.subproj/CFDate.c
+++ b/CoreFoundation/NumberDate.subproj/CFDate.c
@@ -171,11 +171,10 @@ CF_PRIVATE void __CFDateInitialize(void) {
     __CFTSRRate = (1.0E9 / (double)info.numer) * (double)info.denom;
     __CF1_TSRRate = 1.0 / __CFTSRRate;
 #elif TARGET_OS_WIN32
-    LARGE_INTEGER freq;
-    if (!QueryPerformanceFrequency(&freq)) {
-        HALT;
-    }
-    __CFTSRRate = (double)freq.QuadPart;
+    // We are using QueryUnbiasedInterruptTimePrecise as time source.
+    // It returns result in system time units of 100 nanoseconds. 
+    // To get seconds we need to divide the value by 1e7 (10000000).
+    __CFTSRRate = 1.0e7;
     __CF1_TSRRate = 1.0 / __CFTSRRate;
 #elif TARGET_OS_LINUX || TARGET_OS_BSD
     struct timespec res;


### PR DESCRIPTION
Copied from #2907. The diff is exactly same. Considered safe and worth to port to 5.3.