### PR TITLE
Fix Darwin Compatibility Tests build

### DIFF
--- a/Tests/Foundation/Tests/TestFileManager.swift
+++ b/Tests/Foundation/Tests/TestFileManager.swift
@@ -25,6 +25,12 @@ class TestFileManager : XCTestCase {
 #endif
 
     func test_NSTemporaryDirectory() {
+        #if os(Windows)
+        let validPathSeps: [Character] = ["\\", "/"]
+        #else
+        let validPathSeps: [Character] = ["/"]
+        #endif
+        
         let tempDir = NSTemporaryDirectory()
         XCTAssertTrue(validPathSeps.contains(where: { tempDir.hasSuffix(String($0)) }), "Temporary directory path must end with path separator")
     }


### PR DESCRIPTION
Broken since #2910. `validPathSeps` is internal to SwiftFoundation
and can't be accessed from Compatibility tests.
I think it is ok to define expected values in local scope of test.