### PR TITLE
Explicitly import Glibc in files that rely on it

### DIFF
--- a/Sources/Foundation/Data.swift
+++ b/Sources/Foundation/Data.swift
@@ -21,6 +21,10 @@ internal func malloc_good_size(_ size: Int) -> Int {
 
 @_implementationOnly import CoreFoundation
 
+#if canImport(Glibc)
+import Glibc
+#endif
+
 internal func __NSDataInvokeDeallocatorUnmap(_ mem: UnsafeMutableRawPointer, _ length: Int) {
 #if os(Windows)
     UnmapViewOfFile(mem)

--- a/Sources/Foundation/NSLock.swift
+++ b/Sources/Foundation/NSLock.swift
@@ -8,6 +8,11 @@
 //
 
 @_implementationOnly import CoreFoundation
+
+#if canImport(Glibc)
+import Glibc
+#endif
+
 #if os(Windows)
 import WinSDK
 #endif

--- a/Sources/Foundation/Thread.swift
+++ b/Sources/Foundation/Thread.swift
@@ -9,6 +9,10 @@
 
 @_implementationOnly import CoreFoundation
 
+#if canImport(Glibc)
+import Glibc
+#endif
+
 // WORKAROUND_SR9811
 #if os(Windows)
 internal typealias _swift_CFThreadRef = HANDLE


### PR DESCRIPTION
These files rely on Glibc declarations in their public interface, even though they don’t import Glibc. Currently, these declarations are discovered through CoreFoundation, but due to implementation details, Swift canonicalizes the declarations and at the end uses declarations from Glibc (which is imported by other files in the module). This confuses `@_implementationOnly` checker to recognize these declarations as visible even though they shouldn't be.

This is fragile as Foundation now relies on implementation details of Glibc, which in fact we are trying to change in https://github.com/apple/swift/pull/32404.

This PR fixes the issue by explicitly importing Glibc in affected files.
