### PR TITLE
Tests: repair the Windows CI

### DIFF
--- a/Tests/Foundation/Tests/TestPipe.swift
+++ b/Tests/Foundation/Tests/TestPipe.swift
@@ -44,7 +44,11 @@ class TestPipe: XCTestCase {
         for _ in 1...maxPipes {
             let pipe = Pipe()
             if !pipe.fileHandleForReading._isPlatformHandleValid {
+#if os(Windows)
+                XCTAssertEqual(pipe.fileHandleForReading._handle, pipe.fileHandleForWriting._handle)
+#else
                 XCTAssertEqual(pipe.fileHandleForReading.fileDescriptor, pipe.fileHandleForWriting.fileDescriptor)
+#endif
                 break
             }
             pipes.append(pipe)


### PR DESCRIPTION
The Windows CI was broken due to availability checks being supported in
the compiler causing the build to fail due to the `fileDescriptor` being
unavailable.