### PR TITLE
docs: fix simple typo, occured -> occurred

### DIFF
--- a/bootstrap/x86_64-apple-darwin/usr/local/include/unicode/coleitr.h
+++ b/bootstrap/x86_64-apple-darwin/usr/local/include/unicode/coleitr.h
@@ -124,7 +124,7 @@ public:
 
     enum {
         /**
-         * NULLORDER indicates that an error has occured while processing
+         * NULLORDER indicates that an error has occurred while processing
          * @stable ICU 2.0
          */
         NULLORDER = (int32_t)0xffffffff
@@ -176,7 +176,7 @@ public:
     * Gets the ordering priority of the next character in the string.
     * @param status the error code status.
     * @return the next character's ordering. otherwise returns NULLORDER if an 
-    *         error has occured or if the end of string has been reached
+    *         error has occurred or if the end of string has been reached
     * @stable ICU 2.0
     */
     int32_t next(UErrorCode& status);
@@ -185,7 +185,7 @@ public:
     * Get the ordering priority of the previous collation element in the string.
     * @param status the error code status.
     * @return the previous element's ordering. otherwise returns NULLORDER if an 
-    *         error has occured or if the start of string has been reached
+    *         error has occurred or if the start of string has been reached
     * @stable ICU 2.0
     */
     int32_t previous(UErrorCode& status);

--- a/bootstrap/x86_64-apple-darwin/usr/local/include/unicode/format.h
+++ b/bootstrap/x86_64-apple-darwin/usr/local/include/unicode/format.h
@@ -287,7 +287,7 @@ protected:
      * Simple function for initializing a UParseError from a UnicodeString.
      *
      * @param pattern The pattern to copy into the parseError
-     * @param pos The position in pattern where the error occured
+     * @param pos The position in pattern where the error occurred
      * @param parseError The UParseError object to fill in
      * @stable ICU 2.4
      */

--- a/bootstrap/x86_64-apple-darwin/usr/local/include/unicode/gregocal.h
+++ b/bootstrap/x86_64-apple-darwin/usr/local/include/unicode/gregocal.h
@@ -140,7 +140,7 @@ U_NAMESPACE_BEGIN
  *     cout << "DST_OFFSET: " << (calendar->get( UCAL_DST_OFFSET, success )/(60*60*1000)) << endl; // in hours
  *
  *     if (U_FAILURE(success)) {
- *         cout << "An error occured. success=" << u_errorName(success) << endl;
+ *         cout << "An error occurred. success=" << u_errorName(success) << endl;
  *     }
  *
  *     delete ids;

--- a/bootstrap/x86_64-apple-darwin/usr/local/include/unicode/ucol.h
+++ b/bootstrap/x86_64-apple-darwin/usr/local/include/unicode/ucol.h
@@ -457,7 +457,7 @@ ucol_openRules( const UChar        *rules,
  *                   instantiating collators (like out of memory or similar), this
  *                   API will return an error if an invalid attribute or attribute/value
  *                   combination is specified.
- * @return           A pointer to a UCollator or 0 if an error occured (including an 
+ * @return           A pointer to a UCollator or 0 if an error occurred (including an 
  *                   invalid attribute).
  * @see ucol_open
  * @see ucol_setAttribute

--- a/bootstrap/x86_64-apple-darwin/usr/local/include/unicode/ucoleitr.h
+++ b/bootstrap/x86_64-apple-darwin/usr/local/include/unicode/ucoleitr.h
@@ -23,7 +23,7 @@
 #if !UCONFIG_NO_COLLATION
 
 /**  
- * This indicates an error has occured during processing or if no more CEs is 
+ * This indicates an error has occurred during processing or if no more CEs is 
  * to be returned.
  * @stable ICU 2.0
  */
@@ -33,7 +33,7 @@
 /**
  * DO NOT USE, INTERNAL CONSTANT THAT WAS REMOVED AND THEN
  * TEMPORARILY RESTORED TO PREVENT THE BUILD FROM BREAKING.
- * This indicates an error has occured during processing or there are no more CEs
+ * This indicates an error has occurred during processing or there are no more CEs
  * to be returned.
  *
  * @internal
@@ -165,7 +165,7 @@ ucol_reset(UCollationElements *elems);
  * @param elems The UCollationElements containing the text.
  * @param status A pointer to a UErrorCode to receive any errors.
  * @return The next collation elements ordering, otherwise returns UCOL_NULLORDER 
- *         if an error has occured or if the end of string has been reached
+ *         if an error has occurred or if the end of string has been reached
  * @stable ICU 2.0
  */
 U_STABLE int32_t U_EXPORT2 
@@ -180,7 +180,7 @@ ucol_next(UCollationElements *elems, UErrorCode *status);
  *               a U_BUFFER_OVERFLOW_ERROR is returned if the internal stack
  *               buffer has been exhausted.
  * @return The previous collation elements ordering, otherwise returns 
- *         UCOL_NULLORDER if an error has occured or if the start of string has 
+ *         UCOL_NULLORDER if an error has occurred or if the start of string has 
  *         been reached.
  * @stable ICU 2.0
  */
@@ -199,7 +199,7 @@ ucol_previous(UCollationElements *elems, UErrorCode *status);
  * @param ixHigh a pointer to an int32_t to receive the iterator index after fetching the CE.
  * @param status A pointer to an UErrorCode to receive any errors.
  * @return The next collation elements ordering, otherwise returns UCOL_PROCESSED_NULLORDER
- *         if an error has occured or if the end of string has been reached
+ *         if an error has occurred or if the end of string has been reached
  *
  * @internal
  */
@@ -223,7 +223,7 @@ ucol_nextProcessed(UCollationElements *elems, int32_t *ixLow, int32_t *ixHigh, U
  *               a U_BUFFER_OVERFLOW_ERROR is returned if the internal stack
  *               buffer has been exhausted.
  * @return The previous collation elements ordering, otherwise returns
- *         UCOL_PROCESSED_NULLORDER if an error has occured or if the start of
+ *         UCOL_PROCESSED_NULLORDER if an error has occurred or if the start of
  *         string has been reached.
  *
  * @internal

--- a/bootstrap/x86_64-apple-darwin/usr/local/include/unicode/umsg.h
+++ b/bootstrap/x86_64-apple-darwin/usr/local/include/unicode/umsg.h
@@ -390,7 +390,7 @@ typedef void* UMessageFormat;
  * @param patternLength Length of the pattern to use
  * @param locale        The locale for which the messages are formatted.
  * @param parseError    A pointer to UParseError struct to receive any errors 
- *                      occured during parsing. Can be NULL.
+ *                      occurred during parsing. Can be NULL.
  * @param status        A pointer to an UErrorCode to receive any errors.
  * @return              A pointer to a UMessageFormat to use for formatting 
  *                      messages, or 0 if an error occurred. 


### PR DESCRIPTION
There is a small typo in bootstrap/x86_64-apple-darwin/usr/local/include/unicode/coleitr.h, bootstrap/x86_64-apple-darwin/usr/local/include/unicode/format.h, bootstrap/x86_64-apple-darwin/usr/local/include/unicode/gregocal.h, bootstrap/x86_64-apple-darwin/usr/local/include/unicode/ucol.h, bootstrap/x86_64-apple-darwin/usr/local/include/unicode/ucoleitr.h, bootstrap/x86_64-apple-darwin/usr/local/include/unicode/umsg.h.

Should read `occurred` rather than `occured`.

