### PR TITLE
SR-13861: Process should spawn a child process it its own process group.

### DIFF
--- a/Tests/Foundation/Tests/TestProcess.swift
+++ b/Tests/Foundation/Tests/TestProcess.swift
@@ -806,6 +806,35 @@ class TestProcess : XCTestCase {
         }
     }
 
+    func test_processGroup() throws {
+        // The process group of the child process should be different to the parent's.
+        let process = Process()
+
+        process.executableURL = xdgTestHelperURL()
+        process.arguments = ["--pgrp"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = nil
+
+        try process.run()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0)
+
+        let data = pipe.fileHandleForReading.availableData
+        guard let string = String(data: data, encoding: .ascii) else {
+            XCTFail("Could not read stdout")
+            return
+        }
+
+        let parts = string.trimmingCharacters(in: .newlines).components(separatedBy: ": ")
+        guard parts.count == 2, parts[0] == "pgrp", let childPgrp = Int(parts[1]) else {
+            XCTFail("Could not pgrp fron stdout")
+            return
+        }
+        let parentPgrp = Int(getpgrp())
+        XCTAssertNotEqual(parentPgrp, childPgrp, "Child process group \(parentPgrp) should not equal parent process group \(childPgrp)")
+    }
+
     static var allTests: [(String, (TestProcess) -> () throws -> Void)] {
         var tests = [
             ("test_exit0" , test_exit0),
@@ -835,6 +864,7 @@ class TestProcess : XCTestCase {
             ("test_currentDirectory", test_currentDirectory),
             ("test_pipeCloseBeforeLaunch", test_pipeCloseBeforeLaunch),
             ("test_multiProcesses", test_multiProcesses),
+            ("test_processGroup", test_processGroup),
         ]
 
 #if !os(Windows)

--- a/Tests/Tools/XDGTestHelper/main.swift
+++ b/Tests/Tools/XDGTestHelper/main.swift
@@ -274,6 +274,10 @@ case "--signal-test":
 
 case "--print-open-file-descriptors":
     printOpenFileDescriptors()
+
+case "--pgrp":
+    print("pgrp: \(getpgrp())")
+
 #endif
 
 default:


### PR DESCRIPTION
- Unify use of posix_spawnattr_t between Darwin and other platforms,
  and set the POSIX_SPAWN_SETPGROUP attribute.

- This matches Darwin's behaviour.