### PR TITLE
Add support and tests for URLComponents.percentEncodedQueryItems

### DIFF
--- a/CoreFoundation/URL.subproj/CFURLComponents.c
+++ b/CoreFoundation/URL.subproj/CFURLComponents.c
@@ -1282,7 +1282,7 @@ static CFArrayRef _CFURLComponentsCopyQueryItemsInternal(CFURLComponentsRef comp
                             }
                         }
                         else {
-                            nameString =  CFSTR("");
+                            nameString = CFRetain(CFSTR(""));
                         }
                         CFTypeRef keys[] = {_kCFURLComponentsNameKey};
                         CFTypeRef values[] = {nameString};
@@ -1343,7 +1343,7 @@ static CFArrayRef _CFURLComponentsCopyQueryItemsInternal(CFURLComponentsRef comp
                     }
                 }
                 else {
-                    nameString =  CFSTR("");
+                    nameString = CFRetain(CFSTR(""));
                 }
                 CFTypeRef keys[] = {_kCFURLComponentsNameKey};
                 CFTypeRef values[] = {nameString};
@@ -1463,6 +1463,8 @@ static Boolean _CFURLComponentsSetQueryItemsInternal(CFURLComponentsRef componen
     }
     return ( result );
 }
+
+
 
 CF_EXPORT void _CFURLComponentsSetQueryItems(CFURLComponentsRef components, CFArrayRef names, CFArrayRef values ) {
     (void)_CFURLComponentsSetQueryItemsInternal(components, names, values, true); // _CFURLComponentsSetQueryItemsInternal cannot fail if addPercentEncoding is true

--- a/CoreFoundation/URL.subproj/CFURLComponents.h
+++ b/CoreFoundation/URL.subproj/CFURLComponents.h
@@ -17,95 +17,104 @@
 #include <CoreFoundation/CFString.h>
 #include <CoreFoundation/CFNumber.h>
 
+// For swift-corelibs-foundation:
+// When SCF is compiled under Darwin, these are IPI, not SPI.
+// Do not associate availability with them.
+#if DEPLOYMENT_RUNTIME_SWIFT
+#define _CF_URL_COMPONENTS_API_AVAILABLE(...)
+#else
+#define _CF_URL_COMPONENTS_API_AVAILABLE(...) API_AVAILABLE(__VA_ARGS__)
+#endif
+
 CF_IMPLICIT_BRIDGING_ENABLED
 CF_EXTERN_C_BEGIN
 CF_ASSUME_NONNULL_BEGIN
 
 typedef struct CF_BRIDGED_TYPE(id) __CFURLComponents *CFURLComponentsRef;
 
-CF_EXPORT CFTypeID _CFURLComponentsGetTypeID(void) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFTypeID _CFURLComponentsGetTypeID(void) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
 // URLComponents are always mutable.
-CF_EXPORT _Nullable CFURLComponentsRef _CFURLComponentsCreate(CFAllocatorRef alloc) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFURLComponentsRef _CFURLComponentsCreate(CFAllocatorRef alloc) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
-CF_EXPORT _Nullable CFURLComponentsRef _CFURLComponentsCreateWithURL(CFAllocatorRef alloc, CFURLRef url, Boolean resolveAgainstBaseURL) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFURLComponentsRef _CFURLComponentsCreateWithURL(CFAllocatorRef alloc, CFURLRef url, Boolean resolveAgainstBaseURL) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
-CF_EXPORT _Nullable CFURLComponentsRef _CFURLComponentsCreateWithString(CFAllocatorRef alloc, CFStringRef string) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFURLComponentsRef _CFURLComponentsCreateWithString(CFAllocatorRef alloc, CFStringRef string) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
-CF_EXPORT _Nullable CFURLComponentsRef _CFURLComponentsCreateCopy(CFAllocatorRef alloc, CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFURLComponentsRef _CFURLComponentsCreateCopy(CFAllocatorRef alloc, CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
-CF_EXPORT _Nullable CFURLRef _CFURLComponentsCopyURL(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFURLRef _CFURLComponentsCopyURL(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
-CF_EXPORT _Nullable CFURLRef _CFURLComponentsCopyURLRelativeToURL(CFURLComponentsRef components, _Nullable CFURLRef relativeToURL) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFURLRef _CFURLComponentsCopyURLRelativeToURL(CFURLComponentsRef components, _Nullable CFURLRef relativeToURL) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
-CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyString(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyString(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
-CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyScheme(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyUser(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyPassword(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyHost(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT _Nullable CFNumberRef _CFURLComponentsCopyPort(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyPath(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyQuery(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyFragment(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyScheme(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyUser(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyPassword(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyHost(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFNumberRef _CFURLComponentsCopyPort(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyPath(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyQuery(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyFragment(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
 // Returns true if the scheme argument can be passed to _CFURLComponentsSetScheme. A valid scheme string is an ALPHA character followed by 0 or more ALPHA, DIGIT, "+", "-", or "." characters. Because NULL can be passed to _CFURLComponentsSetScheme to clear the scheme component, passing NULL to this function also returns true.
-CF_EXPORT Boolean _CFURLComponentsSchemeIsValid(_Nullable CFStringRef scheme) API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0), tvos(13.0));
+CF_EXPORT Boolean _CFURLComponentsSchemeIsValid(_Nullable CFStringRef scheme) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0), tvos(13.0));
 
 // These return false if the conversion fails
-CF_EXPORT Boolean _CFURLComponentsSetScheme(CFURLComponentsRef components, _Nullable CFStringRef scheme) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT Boolean _CFURLComponentsSetUser(CFURLComponentsRef components, _Nullable CFStringRef user) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT Boolean _CFURLComponentsSetPassword(CFURLComponentsRef components, _Nullable CFStringRef password) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT Boolean _CFURLComponentsSetHost(CFURLComponentsRef components, _Nullable CFStringRef host) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT Boolean _CFURLComponentsSetPort(CFURLComponentsRef components, _Nullable CFNumberRef port) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT Boolean _CFURLComponentsSetPath(CFURLComponentsRef components, _Nullable CFStringRef path) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT Boolean _CFURLComponentsSetQuery(CFURLComponentsRef components, _Nullable CFStringRef query) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT Boolean _CFURLComponentsSetFragment(CFURLComponentsRef components, _Nullable CFStringRef fragment) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT Boolean _CFURLComponentsSetScheme(CFURLComponentsRef components, _Nullable CFStringRef scheme) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT Boolean _CFURLComponentsSetUser(CFURLComponentsRef components, _Nullable CFStringRef user) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT Boolean _CFURLComponentsSetPassword(CFURLComponentsRef components, _Nullable CFStringRef password) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT Boolean _CFURLComponentsSetHost(CFURLComponentsRef components, _Nullable CFStringRef host) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT Boolean _CFURLComponentsSetPort(CFURLComponentsRef components, _Nullable CFNumberRef port) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT Boolean _CFURLComponentsSetPath(CFURLComponentsRef components, _Nullable CFStringRef path) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT Boolean _CFURLComponentsSetQuery(CFURLComponentsRef components, _Nullable CFStringRef query) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT Boolean _CFURLComponentsSetFragment(CFURLComponentsRef components, _Nullable CFStringRef fragment) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
-CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyPercentEncodedUser(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyPercentEncodedPassword(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyPercentEncodedHost(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyPercentEncodedPath(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyPercentEncodedQuery(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyPercentEncodedFragment(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyPercentEncodedUser(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyPercentEncodedPassword(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyPercentEncodedHost(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyPercentEncodedPath(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyPercentEncodedQuery(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFStringRef _CFURLComponentsCopyPercentEncodedFragment(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
 // These return false if the conversion fails
-CF_EXPORT Boolean _CFURLComponentsSetPercentEncodedUser(CFURLComponentsRef components, _Nullable CFStringRef user) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT Boolean _CFURLComponentsSetPercentEncodedPassword(CFURLComponentsRef components, _Nullable CFStringRef password) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT Boolean _CFURLComponentsSetPercentEncodedHost(CFURLComponentsRef components, _Nullable CFStringRef host) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT Boolean _CFURLComponentsSetPercentEncodedPath(CFURLComponentsRef components, _Nullable CFStringRef path) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT Boolean _CFURLComponentsSetPercentEncodedQuery(CFURLComponentsRef components, _Nullable CFStringRef query) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT Boolean _CFURLComponentsSetPercentEncodedFragment(CFURLComponentsRef components, _Nullable CFStringRef fragment) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT Boolean _CFURLComponentsSetPercentEncodedUser(CFURLComponentsRef components, _Nullable CFStringRef user) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT Boolean _CFURLComponentsSetPercentEncodedPassword(CFURLComponentsRef components, _Nullable CFStringRef password) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT Boolean _CFURLComponentsSetPercentEncodedHost(CFURLComponentsRef components, _Nullable CFStringRef host) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT Boolean _CFURLComponentsSetPercentEncodedPath(CFURLComponentsRef components, _Nullable CFStringRef path) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT Boolean _CFURLComponentsSetPercentEncodedQuery(CFURLComponentsRef components, _Nullable CFStringRef query) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT Boolean _CFURLComponentsSetPercentEncodedFragment(CFURLComponentsRef components, _Nullable CFStringRef fragment) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
-CF_EXPORT CFRange _CFURLComponentsGetRangeOfScheme(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT CFRange _CFURLComponentsGetRangeOfUser(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT CFRange _CFURLComponentsGetRangeOfPassword(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT CFRange _CFURLComponentsGetRangeOfHost(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT CFRange _CFURLComponentsGetRangeOfPort(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT CFRange _CFURLComponentsGetRangeOfPath(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT CFRange _CFURLComponentsGetRangeOfQuery(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT CFRange _CFURLComponentsGetRangeOfFragment(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFRange _CFURLComponentsGetRangeOfScheme(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFRange _CFURLComponentsGetRangeOfUser(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFRange _CFURLComponentsGetRangeOfPassword(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFRange _CFURLComponentsGetRangeOfHost(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFRange _CFURLComponentsGetRangeOfPort(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFRange _CFURLComponentsGetRangeOfPath(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFRange _CFURLComponentsGetRangeOfQuery(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFRange _CFURLComponentsGetRangeOfFragment(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
-CF_EXPORT CFStringRef _CFStringCreateByAddingPercentEncodingWithAllowedCharacters(CFAllocatorRef alloc, CFStringRef string, CFCharacterSetRef allowedCharacters) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT CFStringRef _Nullable _CFStringCreateByRemovingPercentEncoding(CFAllocatorRef alloc, CFStringRef string) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFStringRef _CFStringCreateByAddingPercentEncodingWithAllowedCharacters(CFAllocatorRef alloc, CFStringRef string, CFCharacterSetRef allowedCharacters) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFStringRef _Nullable _CFStringCreateByRemovingPercentEncoding(CFAllocatorRef alloc, CFStringRef string) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
 // These return singletons
-CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLUserAllowedCharacterSet(void) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLPasswordAllowedCharacterSet(void) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLHostAllowedCharacterSet(void) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLPathAllowedCharacterSet(void) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLQueryAllowedCharacterSet(void) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLFragmentAllowedCharacterSet(void) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLUserAllowedCharacterSet(void) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLPasswordAllowedCharacterSet(void) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLHostAllowedCharacterSet(void) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLPathAllowedCharacterSet(void) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLQueryAllowedCharacterSet(void) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLFragmentAllowedCharacterSet(void) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
 // keys for dictionaries returned by _CFURLComponentsCopyQueryItems
-CF_EXPORT const CFStringRef _kCFURLComponentsNameKey API_AVAILABLE(macos(10.13), ios(11.0), watchos(4.0), tvos(11.0));
-CF_EXPORT const CFStringRef _kCFURLComponentsValueKey API_AVAILABLE(macos(10.13), ios(11.0), watchos(4.0), tvos(11.0));
+CF_EXPORT const CFStringRef _kCFURLComponentsNameKey _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.13), ios(11.0), watchos(4.0), tvos(11.0));
+CF_EXPORT const CFStringRef _kCFURLComponentsValueKey _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.13), ios(11.0), watchos(4.0), tvos(11.0));
 
-CF_EXPORT _Nullable CFArrayRef _CFURLComponentsCopyQueryItems(CFURLComponentsRef components) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
-CF_EXPORT void _CFURLComponentsSetQueryItems(CFURLComponentsRef components, CFArrayRef names, CFArrayRef values) API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT _Nullable CFArrayRef _CFURLComponentsCopyQueryItems(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT void _CFURLComponentsSetQueryItems(CFURLComponentsRef components, CFArrayRef names, CFArrayRef values) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
-CF_EXPORT _Nullable CFArrayRef _CFURLComponentsCopyPercentEncodedQueryItems(CFURLComponentsRef components) API_AVAILABLE(macos(10.13), ios(11.0), watchos(4.0), tvos(11.0));
-CF_EXPORT Boolean _CFURLComponentsSetPercentEncodedQueryItems(CFURLComponentsRef components, CFArrayRef names, CFArrayRef values) API_AVAILABLE(macos(10.13), ios(11.0), watchos(4.0), tvos(11.0));
+CF_EXPORT _Nullable CFArrayRef _CFURLComponentsCopyPercentEncodedQueryItems(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.13), ios(11.0), watchos(4.0), tvos(11.0));
+CF_EXPORT Boolean _CFURLComponentsSetPercentEncodedQueryItems(CFURLComponentsRef components, CFArrayRef names, CFArrayRef values) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.13), ios(11.0), watchos(4.0), tvos(11.0));
 
 CF_ASSUME_NONNULL_END
 CF_EXTERN_C_END

--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -1451,9 +1451,15 @@ open class NSURLComponents: NSObject, NSCopying {
         return NSRange(_CFURLComponentsGetRangeOfFragment(_components))
     }
     
-    // The getter method that underlies the queryItems property parses the query string based on these delimiters and returns an NSArray containing any number of NSURLQueryItem objects, each of which represents a single key-value pair, in the order in which they appear in the original query string.  Note that a name may appear more than once in a single query string, so the name values are not guaranteed to be unique. If the NSURLComponents object has an empty query component, queryItems returns an empty NSArray. If the NSURLComponents object has no query component, queryItems returns nil.
-    // The setter method that underlies the queryItems property combines an NSArray containing any number of NSURLQueryItem objects, each of which represents a single key-value pair, into a query string and sets the NSURLComponents' query property. Passing an empty NSArray to setQueryItems sets the query component of the NSURLComponents object to an empty string. Passing nil to setQueryItems removes the query component of the NSURLComponents object.
-    // Note: If a name-value pair in a query is empty (i.e. the query string starts with '&', ends with '&', or has "&&" within it), you get a NSURLQueryItem with a zero-length name and and a nil value. If a query's name-value pair has nothing before the equals sign, you get a zero-length name. If a query's name-value pair has nothing after the equals sign, you get a zero-length value. If a query's name-value pair has no equals sign, the query name-value pair string is the name and you get a nil value.
+    /// Returns an array of query items for this `URLComponents`, in the order in which they appear in the original query string.
+    ///
+    /// Each `URLQueryItem` represents a single key-value pair,
+    ///
+    /// Note that a name may appear more than once in a single query string, so the name values are not guaranteed to be unique. If the `URLComponents` has an empty query component, returns an empty array. If the `URLComponents` has no query component, returns nil.
+    ///
+    /// The setter combines an array containing any number of `URLQueryItem`s, each of which represents a single key-value pair, into a query string and sets the `URLComponents` query property. Passing an empty array sets the query component of the `URLComponents` to an empty string. Passing nil removes the query component of the `URLComponents`.
+    ///
+    /// - note: If a name-value pair in a query is empty (i.e. the query string starts with '&', ends with '&', or has "&&" within it), you get a `URLQueryItem` with a zero-length name and a nil value. If a query's name-value pair has nothing before the equals sign, you get a zero-length name. If a query's name-value pair has nothing after the equals sign, you get a zero-length value. If a query's name-value pair has no equals sign, the query name-value pair string is the name and you get a nil value.
     open var queryItems: [URLQueryItem]? {
         get {
             // This CFURL implementation returns a CFArray of CFDictionary; each CFDictionary has an entry for name and optionally an entry for value
@@ -1465,8 +1471,8 @@ open class NSURLComponents: NSObject, NSCopying {
             return (0..<count).map { idx in
                 let oneEntry = unsafeBitCast(CFArrayGetValueAtIndex(queryArray, idx), to: NSDictionary.self)
                 let swiftEntry = oneEntry._swiftObject
-                let entryName = swiftEntry["name"] as! String
-                let entryValue = swiftEntry["value"] as? String
+                let entryName = swiftEntry[_kCFURLComponentsNameKey as! String] as! String
+                let entryValue = swiftEntry[_kCFURLComponentsValueKey as! String] as? String
                 return URLQueryItem(name: entryName, value: entryValue)
             }
         }
@@ -1488,6 +1494,49 @@ open class NSURLComponents: NSObject, NSCopying {
                 }
             }
             _CFURLComponentsSetQueryItems(_components, names._cfObject, values._cfObject)
+        }
+    }
+
+    /// Returns an array of query items for this `URLComponents`, in the order in which they appear in the original query string. Any percent-encoding in a query item name or value is retained
+    ///
+    /// The setter combines an array containing any number of `URLQueryItem`s, each of which represents a single key-value pair, into a query string and sets the `URLComponents` query property. This property assumes the query item names and values are already correctly percent-encoded, and that the query item names do not contain the query item delimiter characters '&' and '='. Attempting to set an incorrectly percent-encoded query item or a query item name with the query item delimiter characters '&' and '=' will cause a `fatalError`.
+    open var percentEncodedQueryItems: [URLQueryItem]? {
+        get {
+            // This CFURL implementation returns a CFArray of CFDictionary; each CFDictionary has an entry for name and optionally an entry for value
+            guard let queryArray = _CFURLComponentsCopyPercentEncodedQueryItems(_components) else {
+                return nil
+            }
+
+            let count = CFArrayGetCount(queryArray)
+            return (0..<count).map { idx in
+                let oneEntry = unsafeBitCast(CFArrayGetValueAtIndex(queryArray, idx), to: NSDictionary.self)
+                let swiftEntry = oneEntry._swiftObject
+                let entryName = swiftEntry[_kCFURLComponentsNameKey as! String] as! String
+                let entryValue = swiftEntry[_kCFURLComponentsValueKey as! String] as? String
+                return URLQueryItem(name: entryName, value: entryValue)
+            }
+        }
+        // This setter essentially acts like `throws!` as described in https://forums.swift.org/t/handling-c-exceptions/34823/7 as throwing accessors are not yet supported, see https://forums.swift.org/t/throwable-accessors/20509 for more details.
+        set(new) /* throws! */ {
+            guard let new = new else {
+                self.percentEncodedQuery = nil
+                return
+            }
+
+            // The CFURL implementation requires two CFArrays, one for names and one for values
+            var names = [CFTypeRef]()
+            var values = [CFTypeRef]()
+            for entry in new {
+                names.append(entry.name._cfObject)
+                if let v = entry.value {
+                    values.append(v._cfObject)
+                } else {
+                    values.append(kCFNull)
+                }
+            }
+            guard _CFURLComponentsSetPercentEncodedQueryItems(_components, names._cfObject, values._cfObject) else {
+                fatalError("NSInvalidArgumentException: invalid characters in percentEncodedQueryItems")
+            }
         }
     }
 }

--- a/Sources/Foundation/URLComponents.swift
+++ b/Sources/Foundation/URLComponents.swift
@@ -267,7 +267,15 @@ public struct URLComponents : ReferenceConvertible, Hashable, Equatable, _Mutabl
         get { return _handle.map { $0.queryItems } }
         set { _applyMutation { $0.queryItems = newValue } }
     }
-    
+
+    /// Returns an array of query items for this `URLComponents`, in the order in which they appear in the original query string. Any percent-encoding in a query item name or value is retained
+    ///
+    /// The setter combines an array containing any number of `URLQueryItem`s, each of which represents a single key-value pair, into a query string and sets the `URLComponents` query property. This property assumes the query item names and values are already correctly percent-encoded, and that the query item names do not contain the query item delimiter characters '&' and '='. Attempting to set an incorrectly percent-encoded query item or a query item name with the query item delimiter characters '&' and '=' will cause a `fatalError`.
+    public var percentEncodedQueryItems: [URLQueryItem]? {
+        get { return _handle.map { $0.percentEncodedQueryItems } }
+        set { _applyMutation { $0.percentEncodedQueryItems = newValue } }
+    }
+
     public func hash(into hasher: inout Hasher) {
         hasher.combine(_handle.map { $0 })
     }

--- a/Tests/Foundation/Tests/TestURLComponents.swift
+++ b/Tests/Foundation/Tests/TestURLComponents.swift
@@ -247,6 +247,224 @@ class TestURLComponents: XCTestCase {
         XCTAssertEqual(c6?.percentEncodedPath, "/foo/b%20r")
     }
 
+    func test_percentEncodedQueryItems() {
+        var components = URLComponents()
+        // no query component
+        var items = components.queryItems
+        XCTAssertNil(items, "nil expected from queryItems when there's no query component.")
+        components.queryItems = items
+        XCTAssertNil(components.percentEncodedQuery, "nil query component expected when queryItems is set to nil.")
+        // again with percentEncodedQueryItems
+        components.percentEncodedQueryItems = items
+        XCTAssertNil(components.percentEncodedQuery, "nil query component expected when percentEncodedQueryItems is set to nil.")
+
+        // query component zero-length string
+        components.percentEncodedQuery = ""
+        items = components.queryItems
+        XCTAssertNotNil(items, "Expected queryItems array.")
+        XCTAssertEqual(items?.count, 0)
+        components.queryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "", "\"\" query component expected when queryItems is set to empty array.")
+        // again with percentEncodedQueryItems
+        components.percentEncodedQueryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "")
+
+        // query component with normal name-value pairs at beginning, in middle, and at end
+        components.percentEncodedQuery = "name1=value1&name2=value2&name3=value3"
+        items = components.queryItems
+        XCTAssertNotNil(items, "Expected queryItems array.")
+        XCTAssertEqual(items?.count, 3)
+        XCTAssertEqual(items, [
+            URLQueryItem(name: "name1", value: "value1"),
+            URLQueryItem(name: "name2", value: "value2"),
+            URLQueryItem(name: "name3", value: "value3"),
+        ])
+        components.queryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "name1=value1&name2=value2&name3=value3")
+        // again with percentEncodedQueryItems
+        items = components.percentEncodedQueryItems
+        XCTAssertNotNil(items, "Expected queryItems array.")
+        XCTAssertEqual(items?.count, 3)
+        XCTAssertEqual(items, [
+            URLQueryItem(name: "name1", value: "value1"),
+            URLQueryItem(name: "name2", value: "value2"),
+            URLQueryItem(name: "name3", value: "value3"),
+        ])
+        components.percentEncodedQueryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "name1=value1&name2=value2&name3=value3")
+
+        // query component with zero-length name-value pairs at beginning, in middle, and at end
+        components.percentEncodedQuery = "&&"
+        items = components.queryItems
+        XCTAssertNotNil(items, "Expected queryItems array.")
+        XCTAssertEqual(items?.count, 3)
+        XCTAssertEqual(items, [
+            URLQueryItem(name: "", value: nil),
+            URLQueryItem(name: "", value: nil),
+            URLQueryItem(name: "", value: nil),
+        ])
+        components.queryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "&&")
+        // again with percentEncodedQueryItems
+        items = components.percentEncodedQueryItems
+        XCTAssertNotNil(items, "Expected queryItems array.")
+        XCTAssertEqual(items?.count, 3)
+        XCTAssertEqual(items, [
+            URLQueryItem(name: "", value: nil),
+            URLQueryItem(name: "", value: nil),
+            URLQueryItem(name: "", value: nil),
+        ])
+        components.percentEncodedQueryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "&&")
+
+        // query component not in "name=value&name=value" format
+        components.percentEncodedQuery = "query"
+        items = components.queryItems
+        XCTAssertNotNil(items, "Expected queryItems array.")
+        XCTAssertEqual(items?.count, 1)
+        XCTAssertEqual(items, [URLQueryItem(name: "query", value: nil)])
+        components.queryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "query")
+        // again with percentEncodedQueryItems
+        items = components.percentEncodedQueryItems
+        XCTAssertNotNil(items, "Expected queryItems array.")
+        XCTAssertEqual(items?.count, 1)
+        XCTAssertEqual(items, [URLQueryItem(name: "query", value: nil)])
+        components.percentEncodedQueryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "query")
+
+        // query component with a name and a zero-length value at beginning, in middle, and at end
+        components.percentEncodedQuery = "name1=&name2=&name3="
+        items = components.queryItems
+        XCTAssertNotNil(items, "Expected queryItems array.")
+        XCTAssertEqual(items?.count, 3)
+        XCTAssertEqual(items, [
+            URLQueryItem(name: "name1", value: ""),
+            URLQueryItem(name: "name2", value: ""),
+            URLQueryItem(name: "name3", value: ""),
+        ])
+        components.queryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "name1=&name2=&name3=")
+        // again with percentEncodedQueryItems
+        items = components.percentEncodedQueryItems
+        XCTAssertNotNil(items, "Expected queryItems array.")
+        XCTAssertEqual(items?.count, 3)
+        XCTAssertEqual(items, [
+            URLQueryItem(name: "name1", value: ""),
+            URLQueryItem(name: "name2", value: ""),
+            URLQueryItem(name: "name3", value: ""),
+        ])
+        components.percentEncodedQueryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "name1=&name2=&name3=")
+
+        // query component with a zero-length name and a value at beginning, in middle, and at end
+        components.percentEncodedQuery = "=value1&=value2&=value3"
+        items = components.queryItems
+        XCTAssertNotNil(items, "Expected queryItems array.")
+        XCTAssertEqual(items?.count, 3)
+        XCTAssertEqual(items, [
+            URLQueryItem(name: "", value: "value1"),
+            URLQueryItem(name: "", value: "value2"),
+            URLQueryItem(name: "", value: "value3"),
+        ])
+        components.queryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "=value1&=value2&=value3")
+        // again with percentEncodedQueryItems
+        items = components.percentEncodedQueryItems
+        XCTAssertNotNil(items, "Expected queryItems array.")
+        XCTAssertEqual(items?.count, 3)
+        XCTAssertEqual(items, [
+            URLQueryItem(name: "", value: "value1"),
+            URLQueryItem(name: "", value: "value2"),
+            URLQueryItem(name: "", value: "value3"),
+        ])
+        components.percentEncodedQueryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "=value1&=value2&=value3")
+
+        // query component with name-value pair containing an equal character in the value at beginning, in middle, and at end
+        components.percentEncodedQuery = "name1=value1=withEqual&name2=value2=withEqual&name3=value3=withEqual"
+        items = components.queryItems
+        XCTAssertNotNil(items, "Expected queryItems array.")
+        XCTAssertEqual(items?.count, 3)
+        XCTAssertEqual(items, [
+            URLQueryItem(name: "name1", value: "value1=withEqual"),
+            URLQueryItem(name: "name2", value: "value2=withEqual"),
+            URLQueryItem(name: "name3", value: "value3=withEqual"),
+        ])
+        components.queryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "name1=value1%3DwithEqual&name2=value2%3DwithEqual&name3=value3%3DwithEqual")
+        // again with percentEncodedQueryItems
+        items = components.percentEncodedQueryItems
+        XCTAssertNotNil(items, "Expected queryItems array.")
+        XCTAssertEqual(items?.count, 3)
+        XCTAssertEqual(items, [
+            URLQueryItem(name: "name1", value: "value1%3DwithEqual"),
+            URLQueryItem(name: "name2", value: "value2%3DwithEqual"),
+            URLQueryItem(name: "name3", value: "value3%3DwithEqual"),
+        ])
+        components.percentEncodedQueryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "name1=value1%3DwithEqual&name2=value2%3DwithEqual&name3=value3%3DwithEqual")
+
+        // query component with name-value pair containing percent-encoded characters at beginning, in middle, and at end
+        components.percentEncodedQuery = "name1%E2%80%A2=value1%E2%80%A2&name2%E2%80%A2=value2%E2%80%A2&name3%E2%80%A2=value3%E2%80%A2"
+        items = components.queryItems
+        XCTAssertNotNil(items, "Expected queryItems array.")
+        XCTAssertEqual(items?.count, 3)
+        XCTAssertEqual(items, [
+            URLQueryItem(name: "name1•", value: "value1•"),
+            URLQueryItem(name: "name2•", value: "value2•"),
+            URLQueryItem(name: "name3•", value: "value3•"),
+        ])
+        components.queryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "name1%E2%80%A2=value1%E2%80%A2&name2%E2%80%A2=value2%E2%80%A2&name3%E2%80%A2=value3%E2%80%A2")
+        // again with percentEncodedQueryItems
+        items = components.percentEncodedQueryItems
+        XCTAssertNotNil(items, "Expected queryItems array.")
+        XCTAssertEqual(items?.count, 3)
+        XCTAssertEqual(items, [
+            URLQueryItem(name: "name1%E2%80%A2",value: "value1%E2%80%A2"),
+            URLQueryItem(name: "name2%E2%80%A2",value: "value2%E2%80%A2"),
+            URLQueryItem(name: "name3%E2%80%A2",value: "value3%E2%80%A2"),
+        ])
+        components.percentEncodedQueryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "name1%E2%80%A2=value1%E2%80%A2&name2%E2%80%A2=value2%E2%80%A2&name3%E2%80%A2=value3%E2%80%A2")
+
+        // query component with name-value pair containing percent-encoded characters that didn't need to be percent-encoded
+        components.percentEncodedQuery = "%41%42%43%44=%61%62%63%64"
+        items = components.queryItems
+        XCTAssertNotNil(items, "Expected queryItems array.")
+        XCTAssertEqual(items?.count, 1)
+        XCTAssertEqual(items, [URLQueryItem(name: "ABCD", value: "abcd")])
+        components.queryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "ABCD=abcd")
+        // again with percentEncodedQueryItems
+        components.percentEncodedQuery = "%41%42%43%44=%61%62%63%64"
+        items = components.percentEncodedQueryItems
+        XCTAssertNotNil(items, "Expected queryItems array.")
+        XCTAssertEqual(items?.count, 1)
+        XCTAssertEqual(items, [URLQueryItem(name: "%41%42%43%44", value: "%61%62%63%64")])
+        components.percentEncodedQueryItems = items
+        XCTAssertEqual(components.percentEncodedQuery, "%41%42%43%44=%61%62%63%64")
+
+        /* These cases cannot be tested by XCTest since `URLComponents.percentEncodedQueryItems` will fatalError on invalid inputs.
+         * Ideally, once swift gains throwing accessors percentEncodedQueryItems:setter can be marked as throws instead and tested properly.
+         * Forum thread: https://forums.swift.org/t/throwable-accessors/20509
+         *
+         * // invalid NSURLQueryItem name with '='
+         * items = [URLQueryItem(name: "name", value: "value")]
+         * XCTAssertThrowsError(try components.percentEncodedQueryItems = items, "percentEncodedQueryItems.set should have thrown an error when the name has an unpercent-encoded '='.")
+         * // invalid NSURLQueryItem name with '&'
+         * items = [URLQueryItem(name: "name&", value:"value")]
+         * XCTAssertThrowsError(try components.percentEncodedQueryItems = items, "percentEncodedQueryItems.set should have thrown an error when the name has an unpercent-encoded '&'.")
+         * // invalid NSURLQueryItem name with '•'
+         * items = [URLQueryItem(name: "name•", value:"value")]
+         * XCTAssertThrowsError(try components.percentEncodedQueryItems = items, "percentEncodedQueryItems.set should have thrown an error when the name has an unpercent-encoded '•'.")
+         * // invalid NSURLQueryItem value with '•'
+         * items = [URLQueryItem(name: "name", value:"value•")]
+         * XCTAssertThrowsError(try components.percentEncodedQueryItems = items, "percentEncodedQueryItems.set should have thrown an error when the value has an unpercent-encoded '•'.")
+         */
+    }
+
     static var allTests: [(String, (TestURLComponents) -> () throws -> Void)] {
         return [
             ("test_queryItems", test_queryItems),
@@ -258,6 +476,7 @@ class TestURLComponents: XCTestCase {
             ("test_createURLWithComponents", test_createURLWithComponents),
             ("test_path", test_path),
             ("test_percentEncodedPath", test_percentEncodedPath),
+            ("test_percentEncodedQueryItems", test_percentEncodedQueryItems),
         ]
     }
 }


### PR DESCRIPTION
rdar://59439703 (URLComponents.percentEncodedQueryItems missing on linux)

resubmission of #2870 against `main`