### PR TITLE
SR-12833: processInfo.activeProcessorCount ignores CFS quotas

### DIFF
--- a/Tests/Foundation/Tests/TestProcessInfo.swift
+++ b/Tests/Foundation/Tests/TestProcessInfo.swift
@@ -7,16 +7,15 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+    #if canImport(SwiftFoundation) && !DEPLOYMENT_RUNTIME_OBJC
+        @testable import SwiftFoundation
+    #else
+        @testable import Foundation
+    #endif
+#endif
+
 class TestProcessInfo : XCTestCase {
-    
-    static var allTests: [(String, (TestProcessInfo) -> () throws -> Void)] {
-        return [
-            ("test_operatingSystemVersion", test_operatingSystemVersion ),
-            ("test_processName", test_processName ),
-            ("test_globallyUniqueString", test_globallyUniqueString ),
-            ("test_environment", test_environment),
-        ]
-    }
     
     func test_operatingSystemVersion() {
         let processInfo = ProcessInfo.processInfo
@@ -133,5 +132,52 @@ class TestProcessInfo : XCTestCase {
         XCTAssertEqual(env["var3"], "=x")
         XCTAssertEqual(env["var4"], "x=")
         XCTAssertEqual(env["var5"], "=x=")
+    }
+
+
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT && os(Linux)
+    func test_cfquota_parsing() throws {
+
+        let tests = [
+            ("50000", "100000", 1),
+            ("100000", "100000", 1),
+            ("100000\n", "100000", 1),
+            ("100000", "100000\n", 1),
+            ("150000", "100000", 2),
+            ("200000", "100000", 2),
+            ("-1", "100000", nil),
+            ("100000", "-1", nil),
+            ("", "100000", nil),
+            ("100000", "", nil),
+            ("100000", "0", nil)
+        ]
+
+        try withTemporaryDirectory() { (_, tempDirPath) -> Void in
+            try tests.forEach { quota, period, count in
+                let (fd1, quotaPath) = try _NSCreateTemporaryFile(tempDirPath + "/quota")
+                FileHandle(fileDescriptor: fd1, closeOnDealloc: true).write(quota)
+
+                let (fd2, periodPath) = try _NSCreateTemporaryFile(tempDirPath + "/period")
+                FileHandle(fileDescriptor: fd2, closeOnDealloc: true).write(period)
+                XCTAssertEqual(ProcessInfo.coreCount(quota: quotaPath, period: periodPath), count)
+            }
+        }
+    }
+#endif
+
+
+    static var allTests: [(String, (TestProcessInfo) -> () throws -> Void)] {
+        var tests: [(String, (TestProcessInfo) -> () throws -> ())] = [
+            ("test_operatingSystemVersion", test_operatingSystemVersion ),
+            ("test_processName", test_processName ),
+            ("test_globallyUniqueString", test_globallyUniqueString ),
+            ("test_environment", test_environment),
+        ]
+
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT && os(Linux)
+        tests.append(contentsOf: [ ("test_cfquota_parsing", test_cfquota_parsing) ])
+#endif
+
+        return tests
     }
 }

--- a/Tests/Foundation/Utilities.swift
+++ b/Tests/Foundation/Utilities.swift
@@ -667,8 +667,10 @@ public func withTemporaryDirectory<R>(functionName: String = #function, block: (
         throw TestError.unexpectedNil
     }
 
-    let fname = String(functionName[..<idx])
-    let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent(testBundleName()).appendingPathComponent(fname).appendingPathComponent(NSUUID().uuidString)
+    // Create the temporary directory as one level so that it doesnt leave a directory hierarchy on the filesystem
+    // eg tmp dir will be something like:  /tmp/TestFoundation-test_name-BE16B2FF-37FA-4F70-8A84-923D1CC2A860
+    let fname = testBundleName() + "-" + String(functionName[..<idx]) + "-" + NSUUID().uuidString
+    let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent(fname)
     let fm = FileManager.default
     try? fm.removeItem(at: tmpDir)
     try fm.createDirectory(at: tmpDir, withIntermediateDirectories: true)


### PR DESCRIPTION
- For Linux, take into account CFS quotes eg, if running under Docker.

- Based on swift-nio code, https://github.com/apple/swift-nio/pull/1518

Tested on a docker instance:
```
$ docker run -it --rm --privileged --cpus=1 swift-main-test /main-test/usr/bin/swift
Welcome to Swift version 5.3-dev (LLVM d6fb8423828a5e4, Swift 638d5e7be2d38c7).
Type :help for assistance.
  1>  import Foundation; ProcessInfo.processInfo.activeProcessorCount
$R0: Int = 1

$ docker run -it --rm --privileged --cpus=2 swift-main-test /main-test/usr/bin/swift
Welcome to Swift version 5.3-dev (LLVM d6fb8423828a5e4, Swift 638d5e7be2d38c7).
Type :help for assistance.
  1>  import Foundation; ProcessInfo.processInfo.activeProcessorCount
$R0: Int = 2
  
$ docker run -it --rm --privileged --cpus=5 swift-main-test /main-test/usr/bin/swift
Welcome to Swift version 5.3-dev (LLVM d6fb8423828a5e4, Swift 638d5e7be2d38c7).
Type :help for assistance.
  1>  import Foundation; ProcessInfo.processInfo.activeProcessorCount
$R0: Int = 5
```