### PR TITLE
Process: Adapt #2928 for Android

### DIFF
--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -944,16 +944,16 @@ open class Process: NSObject {
             try _throwIfPosixError(_CFPosixSpawnFileActionsAddClose(fileActions, fd))
         }
 
-#if canImport(Darwin)
+#if canImport(Darwin) || os(Android)
         var spawnAttrs: posix_spawnattr_t? = nil
-        try _throwIfPosixError(posix_spawnattr_init(&spawnAttrs))
-        try _throwIfPosixError(posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_SETPGROUP)))
-        try _throwIfPosixError(posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_CLOEXEC_DEFAULT)))
 #else
         var spawnAttrs: posix_spawnattr_t = posix_spawnattr_t()
+#endif
         try _throwIfPosixError(posix_spawnattr_init(&spawnAttrs))
         try _throwIfPosixError(posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_SETPGROUP)))
-
+#if canImport(Darwin)
+        try _throwIfPosixError(posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_CLOEXEC_DEFAULT)))
+#else
         // POSIX_SPAWN_CLOEXEC_DEFAULT is an Apple extension so emulate it.
         for fd in 3 ... findMaximumOpenFD() {
             guard adddup2[fd] == nil &&


### PR DESCRIPTION
I hit this when trying to cross-compile with apple/swift#33724 for Android with the Dec. 5 trunk source snapshot. I'm going to set up a CI soon for Android cross-compilation of the SDK and some Swift packages for both the trunk and release branches, which will catch such regressions faster.

I ran the tests natively on Android with the Dec. 11 source snapshot and this pull, got the same failing tests as with ~this pull~#2928 reverted (some URLComponents tests now trap unrelated to this pull).

@spevans, would be good to get this in before the 5.4 branch.