### PR TITLE
Convert protocol ... : class to protocol ... : AnyObject

### DIFF
--- a/Sources/Foundation/Boxing.swift
+++ b/Sources/Foundation/Boxing.swift
@@ -73,7 +73,7 @@ internal enum _MutableUnmanagedWrapper<ImmutableType : NSObject, MutableType : N
     case Mutable(Unmanaged<MutableType>)
 }
 
-internal protocol _SwiftNativeFoundationType : class {
+internal protocol _SwiftNativeFoundationType: AnyObject {
     associatedtype ImmutableType : NSObject
     associatedtype MutableType : NSObject,  NSMutableCopying
     var __wrapped : _MutableUnmanagedWrapper<ImmutableType, MutableType> { get }

--- a/Sources/Foundation/NSKeyedArchiver.swift
+++ b/Sources/Foundation/NSKeyedArchiver.swift
@@ -945,7 +945,7 @@ extension NSKeyedArchiverDelegate {
 
 /// The `NSKeyedArchiverDelegate` protocol defines the optional methods implemented
 /// by delegates of `NSKeyedArchiver` objects.
-public protocol NSKeyedArchiverDelegate : class {
+public protocol NSKeyedArchiverDelegate: AnyObject {
     
     /// Informs the delegate that `object` is about to be encoded.
     ///

--- a/Sources/Foundation/NSKeyedUnarchiver.swift
+++ b/Sources/Foundation/NSKeyedUnarchiver.swift
@@ -921,7 +921,7 @@ open class NSKeyedUnarchiver : NSCoder {
     }
 }
 
-public protocol NSKeyedUnarchiverDelegate : class {
+public protocol NSKeyedUnarchiverDelegate: AnyObject {
     
     // Informs the delegate that the named class is not available during decoding.
     // The delegate may, for example, load some code to introduce the class to the

--- a/Sources/Foundation/NSObject.swift
+++ b/Sources/Foundation/NSObject.swift
@@ -20,7 +20,7 @@
 /// 
 /// The Cocoa root class, NSObject, adopts this protocol, so all objects inheriting
 /// from NSObject have the features described by this protocol.
-public protocol NSObjectProtocol : class {
+public protocol NSObjectProtocol: AnyObject {
     
     /// Returns a Boolean value that indicates whether the instance
     /// and a given `object` are equal.

--- a/Sources/Foundation/Port.swift
+++ b/Sources/Foundation/Port.swift
@@ -79,7 +79,7 @@ extension PortDelegate {
     func handle(_ message: PortMessage) { }
 }
 
-public protocol PortDelegate : class {
+public protocol PortDelegate: AnyObject {
     func handle(_ message: PortMessage)
 }
 

--- a/Sources/Foundation/Stream.swift
+++ b/Sources/Foundation/Stream.swift
@@ -327,7 +327,7 @@ extension StreamDelegate {
     func stream(_ aStream: Stream, handle eventCode: Stream.Event) { }
 }
 
-public protocol StreamDelegate : class {
+public protocol StreamDelegate: AnyObject {
     func stream(_ aStream: Stream, handle eventCode: Stream.Event)
 }
 

--- a/Sources/FoundationNetworking/URLSession/BodySource.swift
+++ b/Sources/FoundationNetworking/URLSession/BodySource.swift
@@ -45,7 +45,7 @@ internal func splitData(dispatchData data: DispatchData, atPosition position: In
 }
 
 /// A (non-blocking) source for body data.
-internal protocol _BodySource: class {
+internal protocol _BodySource: AnyObject {
     /// Get the next chunck of data.
     ///
     /// - Returns: `.data` until the source is exhausted, at which point it will

--- a/Sources/FoundationNetworking/URLSession/URLSession.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSession.swift
@@ -640,7 +640,7 @@ internal extension URLSession {
 }
 
 
-internal protocol URLSessionProtocol: class {
+internal protocol URLSessionProtocol: AnyObject {
     func add(handle: _EasyHandle)
     func remove(handle: _EasyHandle)
     func behaviour(for: URLSessionTask) -> URLSession._TaskBehaviour

--- a/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
+++ b/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
@@ -103,7 +103,7 @@ internal extension _EasyHandle {
         delegate?.transferCompleted(withError: error)
     }
 }
-internal protocol _EasyHandleDelegate: class {
+internal protocol _EasyHandleDelegate: AnyObject {
     /// Handle data read from the network.
     /// - returns: the action to be taken: abort, proceed, or pause.
     func didReceive(data: Data) -> _EasyHandle._Action

--- a/Sources/FoundationXML/XMLParser.swift
+++ b/Sources/FoundationXML/XMLParser.swift
@@ -661,7 +661,7 @@ open class XMLParser : NSObject {
  */
 
 // The parser's delegate is informed of events through the methods in the NSXMLParserDelegateEventAdditions category.
-public protocol XMLParserDelegate: class {
+public protocol XMLParserDelegate: AnyObject {
     
     // Document handling methods
     func parserDidStartDocument(_ parser: XMLParser)


### PR DESCRIPTION
- Fixes 'warning: using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead'