### PR TITLE
SR-12981: Foundation.StreamDelegate has required methods on Linux but not Darwin

### DIFF
--- a/Sources/Foundation/Stream.swift
+++ b/Sources/Foundation/Stream.swift
@@ -323,12 +323,13 @@ extension Stream {
 }
 #endif
 
-extension StreamDelegate {
-    func stream(_ aStream: Stream, handle eventCode: Stream.Event) { }
-}
 
 public protocol StreamDelegate: AnyObject {
     func stream(_ aStream: Stream, handle eventCode: Stream.Event)
+}
+
+extension StreamDelegate {
+    public func stream(_ aStream: Stream, handle eventCode: Stream.Event) { }
 }
 
 // MARK: -


### PR DESCRIPTION
- Make func stream(_ aStream: Stream, handle eventCode: Stream.Event)
  public.

This was tested by building a local toolchain and then compiling the test file from https://bugs.swift.org/browse/SR-12981

```
$ cat test.swift 
import Foundation
class Foo: NSObject, StreamDelegate {}
$ ~/swift-DEVELOPMENT-SNAPSHOT-2020-12-14-a-ubuntu20.04/usr/bin/swiftc -o test1 test.swift 
test.swift:2:7: error: type 'Foo' does not conform to protocol 'StreamDelegate'
class Foo: NSObject, StreamDelegate {}
      ^
Foundation.StreamDelegate:2:10: note: protocol requires function 'stream(_:handle:)' with type '(Stream, Stream.Event) -> ()'
    func stream(_ aStream: Stream, handle eventCode: Stream.Event)
         ^
$ ~/swift-build/toolchains/main-test/usr/bin/swiftc -o test1 test.swift
$
```
