### PR TITLE
Fix redirects following POST/PUT/PATCH requests

### DIFF
--- a/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
@@ -200,7 +200,7 @@ open class URLSessionTask : NSObject, NSCopying {
     }
     
     
-    internal let knownBody: _Body?
+    internal var knownBody: _Body?
     func getBody(completion: @escaping (_Body) -> Void) {
         if let body = knownBody {
             completion(body)

--- a/Tests/Foundation/Tests/TestURLSession.swift
+++ b/Tests/Foundation/Tests/TestURLSession.swift
@@ -174,6 +174,22 @@ class TestURLSession: LoopbackServerTest {
             }
         }
     }
+    
+    func test_dataTaskWithHTTPBodyRedirect() {
+        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/303?location=Peru"
+        let url = URL(string: urlString)!
+        let parameters = "foo=bar"
+        var postRequest = URLRequest(url: url)
+        postRequest.httpBody = parameters.data(using: .utf8)
+        postRequest.httpMethod = "POST"
+        
+        let d = HTTPRedirectionDataTask(with: expectation(description: "POST \(urlString): with HTTP redirection"))
+        d.run(with: postRequest)
+
+        waitForExpectations(timeout: 12)
+        
+        XCTAssertEqual("Lima", String(data: d.receivedData, encoding: .utf8), "\(#function) did not redirect properly.")
+    }
 
     func test_gzippedDataTask() {
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/gzipped-response"
@@ -1764,6 +1780,7 @@ class TestURLSession: LoopbackServerTest {
             ("test_dataTaskWithURLCompletionHandler", test_dataTaskWithURLCompletionHandler),
             ("test_dataTaskWithURLRequestCompletionHandler", test_dataTaskWithURLRequestCompletionHandler),
             // ("test_dataTaskWithHttpInputStream", test_dataTaskWithHttpInputStream), - Flaky test
+            ("test_dataTaskWithHTTPBodyRedirect", test_dataTaskWithHTTPBodyRedirect),
             ("test_gzippedDataTask", test_gzippedDataTask),
             ("test_downloadTaskWithURL", test_downloadTaskWithURL),
             ("test_downloadTaskWithURLRequest", test_downloadTaskWithURLRequest),


### PR DESCRIPTION
I’ve stumbled upon a problem in `URLSession` when a redirect occurs following a request with a request body (POST/PUT/PATCH).

Say we create a `URLRequest` with a httpBody and an httpMethod of "POST".

When the POST request is made, a [URLSessionTask is initialized with the httpBody from the URLRequest](https://github.com/apple/swift-corelibs-foundation/blob/bb511a3ac4aef1bb0c815f33efa72c38d0692a7a/Sources/FoundationNetworking/URLSession/URLSessionTask.swift#L263).

Later, when the server responds with a redirect to this request, a new request is made but the original task is reused. This involves calling `startNewTransfer`, which in turn [looks up any existing known body](https://github.com/apple/swift-corelibs-foundation/blob/bb511a3ac4aef1bb0c815f33efa72c38d0692a7a/Sources/FoundationNetworking/URLSession/NativeProtocol.swift#L378) in the `knownBody` property. 

The result is that the new request, which is supposed to follow the redirect, also includes the original request data. This trips [the following check](https://github.com/apple/swift-corelibs-foundation/blob/bb511a3ac4aef1bb0c815f33efa72c38d0692a7a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift#L287).

This PR attempts to work around the issue by unsetting the `knownBody` on `URLSessionTask` before a redirect request is performed. 

I also changed the behavior of how the redirect request is constructed. Previously, the original request (including httpBody) was copied and the httpMethod changed to GET. This is an invalid request.
Even though this turned out not to be the source of the problem (because the httpBody on the redirect request is never used), it doesn’t make sense for Foundation to be producing invalid requests internally.
