### PR TITLE
[5.4] SR-12981: Foundation.StreamDelegate has required methods on Linux but not Darwin

### DIFF
--- a/Sources/Foundation/Stream.swift
+++ b/Sources/Foundation/Stream.swift
@@ -323,12 +323,13 @@ extension Stream {
 }
 #endif
 
-extension StreamDelegate {
-    func stream(_ aStream: Stream, handle eventCode: Stream.Event) { }
-}
 
 public protocol StreamDelegate : class {
     func stream(_ aStream: Stream, handle eventCode: Stream.Event)
+}
+
+extension StreamDelegate {
+    public func stream(_ aStream: Stream, handle eventCode: Stream.Event) { }
 }
 
 // MARK: -


### PR DESCRIPTION
- Make func stream(_ aStream: Stream, handle eventCode: Stream.Event)
  public.

(cherry picked from commit 9bd879b16bd0f41b6d6dfcd0eb25a0cbcf7ca309)