### PR TITLE
[5.4] SR-13822: FileHandle closeOnDealloc causes a Stack Overflow on Windows

### DIFF
--- a/Sources/Foundation/FileHandle.swift
+++ b/Sources/Foundation/FileHandle.swift
@@ -634,19 +634,20 @@ open class FileHandle : NSObject {
         readabilitySource = nil
         privateAsyncVariablesLock.unlock()
 
-        if closeFd {
 #if os(Windows)
+            // SR-13822 - Not Closing the file descriptor on Windows causes a Stack Overflow
             guard CloseHandle(self._handle) else {
                 throw _NSErrorWithWindowsError(GetLastError(), reading: true)
             }
             self._handle = INVALID_HANDLE_VALUE
 #else
-            guard _close(_fd) >= 0 else {
-                throw _NSErrorWithErrno(errno, reading: true)
+            if closeFd {
+                guard _close(_fd) >= 0 else {
+                    throw _NSErrorWithErrno(errno, reading: true)
+                }
+                _fd = -1
             }
-            _fd = -1
 #endif
-        }
     }
     
     // MARK: -

--- a/Tests/Foundation/Tests/TestFileHandle.swift
+++ b/Tests/Foundation/Tests/TestFileHandle.swift
@@ -580,7 +580,7 @@ class TestFileHandle : XCTestCase {
         }
     }
 
-#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT && !os(Windows)
     func test_closeOnDealloc() throws {
         try withTemporaryDirectory() { (url, path) in
             let data = try XCTUnwrap("hello".data(using: .utf8))
@@ -640,8 +640,14 @@ class TestFileHandle : XCTestCase {
             ("test_nullDevice", test_nullDevice),
             ("testHandleCreationAndCleanup", testHandleCreationAndCleanup),
             ("testOffset", testOffset),
+        ])
+
+    #if !os(Windows)
+        tests.append(contentsOf: [
+            /* ⚠️  SR-13822 - closeOnDealloc doesnt work on Windows and so this test is disabled there. */
             ("test_closeOnDealloc", test_closeOnDealloc),
         ])
+    #endif
 #endif
 
         return tests


### PR DESCRIPTION
- Setting closeOnDealloc to false seems to cause a stack Overflow on
  Windows so disable the functionality of NOT closing the file, but only
  on Windows.

(cherry picked from commit 42a5b306e25458784796e606ba83ed4c7ef7d08f)