### PR TITLE
[5.3] Fix OperationQueue scheduling logic to prevent disruption of operation lists

### DIFF
--- a/Sources/Foundation/Operation.swift
+++ b/Sources/Foundation/Operation.swift
@@ -993,7 +993,7 @@ open class OperationQueue : NSObject, ProgressReporting {
                 // if the cached state is possibly not valid then the isReady value needs to be re-updated
                 if Operation.__NSOperationState.enqueued == operation._state && operation._fetchCachedIsReady(&retest) {
                     if let previous = prev?.takeUnretainedValue() {
-                        previous.__nextOperation = next
+                        previous.__nextPriorityOperation = next
                     } else {
                         _setFirstPriorityOperation(prio, next)
                     }


### PR DESCRIPTION
OperationQueue would crash or hang if we force "non-natural" execution order. E.g. when first operation depends on second.

The reason is how we work with internal operation lists in `OperationQueue._schedule()`. I believe the original intention was to adjust `__nextPriorityOperation`, but instead we are modifying `__nextOperation`. This has no sense and leads to crosslinking of the main operation list and corresponding priority operation list. Subsequent scheduling would try to read already finished operation and hang. Also, at this point queue doesn't hold operation object anymore, so trying to read dead object is pretty realistic scenario.

Suggested test case checks scenario described above, and ensures correct operation order as a bonus.

(cherry picked from commit 9f44ed3, original PR #2930)