### PR TITLE
Judge executables with API on Windows

### DIFF
--- a/Sources/Foundation/FileManager+Win32.swift
+++ b/Sources/Foundation/FileManager+Win32.swift
@@ -711,7 +711,11 @@ extension FileManager {
     internal func _isExecutableFile(atPath path: String) -> Bool {
         var isDirectory: ObjCBool = false
         guard fileExists(atPath: path, isDirectory: &isDirectory) else { return false }
-        return !isDirectory.boolValue && _isReadableFile(atPath: path)
+        guard !isDirectory.boolValue, _isReadableFile(atPath: path) else { return false }
+        return path.withCString(encodedAs: UTF16.self) {
+            var binaryType = DWORD(0)
+            return GetBinaryTypeW($0, &binaryType)
+        }
     }
 
     internal func _isDeletableFile(atPath path: String) -> Bool {

--- a/Sources/Foundation/FileManager+Win32.swift
+++ b/Sources/Foundation/FileManager+Win32.swift
@@ -709,12 +709,9 @@ extension FileManager {
     }
 
     internal func _isExecutableFile(atPath path: String) -> Bool {
-        var isDirectory: ObjCBool = false
-        guard fileExists(atPath: path, isDirectory: &isDirectory) else { return false }
-        guard !isDirectory.boolValue, _isReadableFile(atPath: path) else { return false }
+        var binaryType = DWORD(0)
         return path.withCString(encodedAs: UTF16.self) {
-            var binaryType = DWORD(0)
-            return GetBinaryTypeW($0, &binaryType)
+            GetBinaryTypeW($0, &binaryType)
         }
     }
 

--- a/Tests/Foundation/Tests/TestFileManager.swift
+++ b/Tests/Foundation/Tests/TestFileManager.swift
@@ -277,12 +277,17 @@ class TestFileManager : XCTestCase {
             try fm.setAttributes([.posixPermissions : NSNumber(value: Int16(0o0000))], ofItemAtPath: path)
             XCTAssertFalse(fm.isExecutableFile(atPath: path))
 
+#if os(Windows)
+            // test against cmd.exe
+            let systemDir: String = {
+                var buffer = Array<WCHAR>(repeating: 0, count: Int(MAX_PATH + 1))
+                GetSystemDirectoryW(&buffer, .init(MAX_PATH + 1))
+                return String(decodingCString: buffer, as: UTF16.self)
+            }()
+            XCTAssertTrue(fm.isExecutableFile(atPath: "\(systemDir)\\cmd.exe"))
+#else
             // test executable if file has execute permissions
             try fm.setAttributes([.posixPermissions : NSNumber(value: Int16(0o0100))], ofItemAtPath: path)
-#if os(Windows)
-            // a Windows executable needs to be binary
-            XCTAssertFalse(fm.isExecutableFile(atPath: path))
-#else
             XCTAssertTrue(fm.isExecutableFile(atPath: path))
 #endif
         } catch let e {

--- a/Tests/Foundation/Tests/TestFileManager.swift
+++ b/Tests/Foundation/Tests/TestFileManager.swift
@@ -275,16 +275,16 @@ class TestFileManager : XCTestCase {
 
             // test unExecutable if file has no permissions
             try fm.setAttributes([.posixPermissions : NSNumber(value: Int16(0o0000))], ofItemAtPath: path)
-#if os(Windows)
-            // Files are always executable on Windows
-            XCTAssertTrue(fm.isExecutableFile(atPath: path))
-#else
             XCTAssertFalse(fm.isExecutableFile(atPath: path))
-#endif
 
             // test executable if file has execute permissions
             try fm.setAttributes([.posixPermissions : NSNumber(value: Int16(0o0100))], ofItemAtPath: path)
+#if os(Windows)
+            // a Windows executable needs to be binary
+            XCTAssertFalse(fm.isExecutableFile(atPath: path))
+#else
             XCTAssertTrue(fm.isExecutableFile(atPath: path))
+#endif
         } catch let e {
             XCTFail("\(e)")
         }


### PR DESCRIPTION
Use [`GetBinaryTypeW` function](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getbinarytypew) to judge whether a file is executable on Windows.