### PR TITLE
SR-13979: Calendar.nextDate() segmentation fault

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -93,7 +93,7 @@ CF_PRIVATE Boolean __CFAllocatorRespectsHintZeroWhenAllocating(CFAllocatorRef _N
 static CFOptionFlags _CFAllocatorHintZeroWhenAllocating = 1;
 
 CF_CROSS_PLATFORM_EXPORT Boolean _CFCalendarGetNextWeekend(CFCalendarRef calendar, _CFCalendarWeekendRange *range);
-CF_CROSS_PLATFORM_EXPORT void _CFCalendarEnumerateDates(CFCalendarRef calendar, CFDateRef start, CFDateComponentsRef matchingComponents, CFOptionFlags opts, void (^block)(CFDateRef, Boolean, Boolean*));
+CF_CROSS_PLATFORM_EXPORT void _CFCalendarEnumerateDates(CFCalendarRef calendar, CFDateRef start, CFDateComponentsRef matchingComponents, CFOptionFlags opts, void (^block)(CFDateRef _Nullable, Boolean, Boolean*));
 CF_EXPORT void CFCalendarSetGregorianStartDate(CFCalendarRef calendar, CFDateRef _Nullable date);
 CF_EXPORT _Nullable CFDateRef CFCalendarCopyGregorianStartDate(CFCalendarRef calendar);
 

--- a/CoreFoundation/Locale.subproj/CFCalendar_Enumerate.c
+++ b/CoreFoundation/Locale.subproj/CFCalendar_Enumerate.c
@@ -2123,7 +2123,7 @@ static CFDateRef _Nullable _CFCalendarCreateAdjustedDateForMismatches(CFCalendar
 #pragma mark -
 #pragma mark Enumerate Entry Point
 
-CF_CROSS_PLATFORM_EXPORT void _CFCalendarEnumerateDates(CFCalendarRef calendar, CFDateRef start, CFDateComponentsRef matchingComponents, CFOptionFlags opts, void (^block)(CFDateRef, Boolean, Boolean*)) {
+CF_CROSS_PLATFORM_EXPORT void _CFCalendarEnumerateDates(CFCalendarRef calendar, CFDateRef start, CFDateComponentsRef matchingComponents, CFOptionFlags opts, void (^block)(CFDateRef _Nullable, Boolean, Boolean*)) {
     if (!start || !_CFCalendarVerifyCalendarOptions(opts) || !_CFCalendarVerifyCFDateComponentsValues(calendar, matchingComponents)) {
         return;
     }

--- a/CoreFoundation/Locale.subproj/CFCalendar_Internal.h
+++ b/CoreFoundation/Locale.subproj/CFCalendar_Internal.h
@@ -108,7 +108,7 @@ CF_PRIVATE _Nullable CFDateRef _CFCalendarCreateStartDateForTimeRangeOfUnitForDa
 CF_PRIVATE _Nullable CFDateIntervalRef _CFCalendarCreateDateInterval(CFAllocatorRef allocator, CFCalendarRef calendar, CFCalendarUnit unit, CFDateRef date);
 CF_PRIVATE _Nullable CFDateRef _CFCalendarCreateDateByAddingValueOfUnitToDate(CFCalendarRef calendar, CFIndex val, CFCalendarUnit unit, CFDateRef date);
     
-CF_CROSS_PLATFORM_EXPORT void _CFCalendarEnumerateDates(CFCalendarRef calendar, CFDateRef start, CFDateComponentsRef matchingComponents, CFOptionFlags opts, void (^block)(CFDateRef, Boolean, Boolean*));
+CF_CROSS_PLATFORM_EXPORT void _CFCalendarEnumerateDates(CFCalendarRef calendar, CFDateRef start, CFDateComponentsRef matchingComponents, CFOptionFlags opts, void (^block)(CFDateRef _Nullable, Boolean, Boolean*));
 
 CF_EXPORT void CFCalendarSetGregorianStartDate(CFCalendarRef calendar, CFDateRef _Nullable date);
 CF_EXPORT _Nullable CFDateRef CFCalendarCopyGregorianStartDate(CFCalendarRef calendar);

--- a/Sources/Foundation/NSCalendar.swift
+++ b/Sources/Foundation/NSCalendar.swift
@@ -1050,6 +1050,10 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         
         withoutActuallyEscaping(block) { (nonescapingBlock) in
             _CFCalendarEnumerateDates(_cfObject, start._cfObject, comps._createCFDateComponents(), CFOptionFlags(opts.rawValue)) { (cfDate, exact, stop) in
+                guard let cfDate = cfDate else {
+                    stop.pointee = true
+                    return
+                }
                 var ourStop: ObjCBool = false
                 nonescapingBlock(cfDate._swiftObject, exact, &ourStop)
                 if ourStop.boolValue {

--- a/Tests/Foundation/Tests/TestCalendar.swift
+++ b/Tests/Foundation/Tests/TestCalendar.swift
@@ -268,6 +268,26 @@ class TestCalendar: XCTestCase {
         XCTAssertGreaterThan(cal.eraSymbols.count, 0)
     }
 
+    func test_nextDate() throws {
+        var calendar = Calendar.current
+        calendar.timeZone = try XCTUnwrap(TimeZone(identifier: "US/Pacific"))
+        let date_20200101 = try XCTUnwrap(calendar.date(from: DateComponents(year: 2020, month: 01, day: 1)))
+
+        do {
+            let expected = try XCTUnwrap(calendar.date(from: DateComponents(year: 2020, month: 01, day: 2, hour: 0)))
+            let components = DateComponents(year: 2020, month: 1, day: 2, hour: 0, minute: 0, second: 0)
+            let next = calendar.nextDate(after: date_20200101, matching: components, matchingPolicy: .nextTimePreservingSmallerComponents, direction: .forward)
+            XCTAssertEqual(next, expected)
+        }
+
+        do {
+            // SR-13979 - Check nil result when no valid nextDate
+            let components = DateComponents(year: 2019, month: 2, day: 1, hour: 0, minute: 0, second: 0)
+            let next = calendar.nextDate(after: date_20200101, matching: components, matchingPolicy: .nextTimePreservingSmallerComponents, direction: .forward)
+            XCTAssertNil(next)
+        }
+    }
+
     static var allTests: [(String, (TestCalendar) -> () throws -> Void)] {
         return [
             ("test_allCalendars", test_allCalendars),
@@ -287,6 +307,7 @@ class TestCalendar: XCTestCase {
             ("test_hashing", test_hashing),
             ("test_dateFromDoesntMutate", test_dateFromDoesntMutate),
             ("test_sr10638", test_sr10638),
+            ("test_nextDate", test_nextDate),
         ]
     }
 }


### PR DESCRIPTION
- Annotate _CFCalendarEnumerateDates() with a _Nullable pointer used by
  the block to allow better handling of a NULL CFDateRef.