### PR TITLE
NSNumber: Forced bridging an invalid value would not trap.

### DIFF
--- a/Sources/Foundation/NSNumber.swift
+++ b/Sources/Foundation/NSNumber.swift
@@ -49,7 +49,9 @@ extension Int8 : _ObjectiveCBridgeable {
     }
 
     public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout Int8?) {
-        result = _unconditionallyBridgeFromObjectiveC(x)
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(type(of: x)) to \(self)")
+        }
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Int8?) -> Bool {
@@ -87,7 +89,9 @@ extension UInt8 : _ObjectiveCBridgeable {
     }
 
     public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt8?) {
-        result = _unconditionallyBridgeFromObjectiveC(x)
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(type(of: x)) to \(self)")
+        }
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt8?) -> Bool {
@@ -125,7 +129,9 @@ extension Int16 : _ObjectiveCBridgeable {
     }
 
     public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout Int16?) {
-        result = _unconditionallyBridgeFromObjectiveC(x)
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(type(of: x)) to \(self)")
+        }
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Int16?) -> Bool {
@@ -163,7 +169,9 @@ extension UInt16 : _ObjectiveCBridgeable {
     }
 
     public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt16?) {
-        result = _unconditionallyBridgeFromObjectiveC(x)
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(type(of: x)) to \(self)")
+        }
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt16?) -> Bool {
@@ -201,7 +209,9 @@ extension Int32 : _ObjectiveCBridgeable {
     }
 
     public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout Int32?) {
-        result = _unconditionallyBridgeFromObjectiveC(x)
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(type(of: x)) to \(self)")
+        }
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Int32?) -> Bool {
@@ -239,7 +249,9 @@ extension UInt32 : _ObjectiveCBridgeable {
     }
 
     public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt32?) {
-        result = _unconditionallyBridgeFromObjectiveC(x)
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(type(of: x)) to \(self)")
+        }
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt32?) -> Bool {
@@ -277,7 +289,9 @@ extension Int64 : _ObjectiveCBridgeable {
     }
 
     public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout Int64?) {
-        result = _unconditionallyBridgeFromObjectiveC(x)
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(type(of: x)) to \(self)")
+        }
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Int64?) -> Bool {
@@ -315,7 +329,9 @@ extension UInt64 : _ObjectiveCBridgeable {
     }
 
     public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt64?) {
-        result = _unconditionallyBridgeFromObjectiveC(x)
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(type(of: x)) to \(self)")
+        }
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt64?) -> Bool {
@@ -353,7 +369,9 @@ extension Int : _ObjectiveCBridgeable {
     }
     
     public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout Int?) {
-        result = _unconditionallyBridgeFromObjectiveC(x)
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(type(of: x)) to \(self)")
+        }
     }
     
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Int?) -> Bool {
@@ -391,7 +409,9 @@ extension UInt : _ObjectiveCBridgeable {
     }
     
     public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt?) {
-        result = _unconditionallyBridgeFromObjectiveC(x)
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(type(of: x)) to \(self)")
+        }
     }
     
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt?) -> Bool {
@@ -437,7 +457,9 @@ extension Float : _ObjectiveCBridgeable {
     }
     
     public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout Float?) {
-        result = _unconditionallyBridgeFromObjectiveC(x)
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(type(of: x)) to \(self)")
+        }
     }
     
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Float?) -> Bool {
@@ -488,7 +510,9 @@ extension Double : _ObjectiveCBridgeable {
     }
     
     public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout Double?) {
-        result = _unconditionallyBridgeFromObjectiveC(x)
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(type(of: x)) to \(self)")
+        }
     }
     
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Double?) -> Bool {
@@ -533,7 +557,9 @@ extension Bool : _ObjectiveCBridgeable {
     }
     
     public static func _forceBridgeFromObjectiveC(_ x: NSNumber, result: inout Bool?) {
-        result = _unconditionallyBridgeFromObjectiveC(x)
+        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+            fatalError("Unable to bridge \(type(of: x)) to \(self)")
+        }
     }
     
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Bool?) -> Bool {


### PR DESCRIPTION
- eg `NSNumber(value: 1.2) as! Int` would return 0 instead of trapping.
  Exit with fatalError() if the bridging failed.

- This matches Darwin.

Cant add a test for trapping behaviour but a toolchain was tested v 5.3.1

```
$ cat bridge.swift 
import Foundation

let x = NSNumber(value: 1.2) as? Int
let y = NSNumber(value: 1.2) as! Int
print(x as Any, y)

$ ~/swift-5.3.1-RELEASE-ubuntu20.04/usr/bin/swift bridge.swift 
nil 0

$ ~/swift-build/toolchains/main-test/usr/bin/swift bridge.swift 
Foundation/NSNumber.swift:373: Fatal error: Unable to bridge NSNumber to Int
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the project and the crash backtrace.
Stack dump:
.
.
.
Illegal instruction (core dumped)
```