### PR TITLE
NSNumber: .boolValue should return true for Int64.min

### DIFF
--- a/Sources/Foundation/NSNumber.swift
+++ b/Sources/Foundation/NSNumber.swift
@@ -896,10 +896,7 @@ open class NSNumber : NSValue {
     }
     
     open var boolValue: Bool {
-        // Darwin Foundation NSNumber appears to have a bug and return false for NSNumber(value: Int64.min).boolValue,
-        // even though the documentation says:
-        // "A 0 value always means false, and any nonzero value is interpreted as true."
-        return (int64Value != 0) && (int64Value != Int64.min)
+        return int64Value != 0
     }
 
     open var intValue: Int {

--- a/Tests/Foundation/Tests/TestNSNumber.swift
+++ b/Tests/Foundation/Tests/TestNSNumber.swift
@@ -501,10 +501,7 @@ class TestNSNumber : XCTestCase {
         XCTAssertEqual(NSNumber(value: Int64(0)).floatValue, 0)
         XCTAssertEqual(NSNumber(value: Int64(0)).doubleValue, 0)
 
-        //------
-
-        XCTAssertEqual(NSNumber(value: Int64.min).boolValue, false)
-
+        XCTAssertEqual(NSNumber(value: Int64.min).boolValue, true)
         XCTAssertEqual(NSNumber(value: Int64.min).int8Value, 0)
         XCTAssertEqual(NSNumber(value: Int64.min).int16Value, 0)
         XCTAssertEqual(NSNumber(value: Int64.min).int32Value, 0)
@@ -700,7 +697,7 @@ class TestNSNumber : XCTestCase {
 #if arch(arm)
             break
 #else
-            XCTAssertEqual(NSNumber(value: Int.min).boolValue, false)
+            XCTAssertEqual(NSNumber(value: Int.min).boolValue, true)
 
             XCTAssertEqual(NSNumber(value: Int.min).int8Value, 0)
             XCTAssertEqual(NSNumber(value: Int.min).int16Value, 0)
@@ -1455,13 +1452,13 @@ class TestNSNumber : XCTestCase {
 
         XCTAssertEqual(NSNumber(value: Int64.max).boolValue, true)
         XCTAssertEqual(NSNumber(value: Int64.max - 1).boolValue, true)
-        XCTAssertEqual(NSNumber(value: Int64.min).boolValue, false) // Darwin compatibility
+        XCTAssertEqual(NSNumber(value: Int64.min).boolValue, true)
         XCTAssertEqual(NSNumber(value: Int64.min + 1).boolValue, true)
         XCTAssertEqual(NSNumber(value: Int64(-1)).boolValue, true)
 
         XCTAssertEqual(NSNumber(value: Int.max).boolValue, true)
         XCTAssertEqual(NSNumber(value: Int.max - 1).boolValue, true)
-        XCTAssertEqual(NSNumber(value: Int.min).boolValue, false)   // Darwin compatibility
+        XCTAssertEqual(NSNumber(value: Int.min).boolValue, true)
         XCTAssertEqual(NSNumber(value: Int.min + 1).boolValue, true)
         XCTAssertEqual(NSNumber(value: Int(-1)).boolValue, true)
     }


### PR DESCRIPTION
- The previous behaviour was matching a buggy macOS implementation
  but has been fixed in recent versions.