### PR TITLE
TestURLSession: Re-enable tests on Linux

### DIFF
--- a/DarwinCompatibilityTests.xcodeproj/xcshareddata/xcschemes/xdgTestHelper.xcscheme
+++ b/DarwinCompatibilityTests.xcodeproj/xcshareddata/xcschemes/xdgTestHelper.xcscheme
@@ -60,9 +60,6 @@
                   Identifier = "TestURLRequest/test_hash()">
                </Test>
                <Test
-                  Identifier = "TestURLSession">
-               </Test>
-               <Test
                   Identifier = "TestXMLDocument/test_creatingAnEmptyDocumentAndNode()">
                </Test>
             </SkippedTests>

--- a/Tests/Foundation/Tests/TestURLSession.swift
+++ b/Tests/Foundation/Tests/TestURLSession.swift
@@ -1794,7 +1794,7 @@ class TestURLSession: LoopbackServerTest {
             ("test_httpRedirectionChainInheritsTimeoutInterval", test_httpRedirectionChainInheritsTimeoutInterval),
             ("test_httpRedirectionExceededMaxRedirects", test_httpRedirectionExceededMaxRedirects),
             ("test_httpNotFound", test_httpNotFound),
-            ("test_http0_9SimpleResponses", test_http0_9SimpleResponses),
+            /* ⚠️ */ ("test_http0_9SimpleResponses", testExpectedToFail(test_http0_9SimpleResponses, "Breaks on Ubunut20.04")),
             ("test_outOfRangeButCorrectlyFormattedHTTPCode", test_outOfRangeButCorrectlyFormattedHTTPCode),
             ("test_missingContentLengthButStillABody", test_missingContentLengthButStillABody),
             ("test_illegalHTTPServerResponses", test_illegalHTTPServerResponses),
@@ -1802,7 +1802,7 @@ class TestURLSession: LoopbackServerTest {
             ("test_simpleUploadWithDelegate", test_simpleUploadWithDelegate),
             ("test_requestWithEmptyBody", test_requestWithEmptyBody),
             ("test_requestWithNonEmptyBody", test_requestWithNonEmptyBody),
-            ("test_concurrentRequests", test_concurrentRequests),
+            /* ⚠️ */ ("test_concurrentRequests", testExpectedToFail(test_concurrentRequests, "Fails about 4% of the time")),
             ("test_disableCookiesStorage", test_disableCookiesStorage),
             ("test_cookiesStorage", test_cookiesStorage),
             ("test_cookieStorageForEphemeralConfiguration", test_cookieStorageForEphemeralConfiguration),
@@ -1816,7 +1816,7 @@ class TestURLSession: LoopbackServerTest {
             ("test_checkErrorTypeAfterInvalidateAndCancel", test_checkErrorTypeAfterInvalidateAndCancel),
             ("test_taskCountAfterInvalidateAndCancel", test_taskCountAfterInvalidateAndCancel),
             ("test_sessionDelegateAfterInvalidateAndCancel", test_sessionDelegateAfterInvalidateAndCancel),
-            ("test_getAllTasks", test_getAllTasks),
+            /* ⚠️ */ ("test_getAllTasks", testExpectedToFail(test_getAllTasks, "This test causes later ones to crash")),
             ("test_getTasksWithCompletion", test_getTasksWithCompletion),
             /* ⚠️ */ ("test_invalidResumeDataForDownloadTask",
             /* ⚠️ */   testExpectedToFail(test_invalidResumeDataForDownloadTask, "This test crashes nondeterministically: https://bugs.swift.org/browse/SR-11353")),
@@ -1824,7 +1824,7 @@ class TestURLSession: LoopbackServerTest {
             /* ⚠️ */   testExpectedToFail(test_simpleUploadWithDelegateProvidingInputStream, "This test times out frequently: https://bugs.swift.org/browse/SR-11343")),
             /* ⚠️ */ ("test_noDoubleCallbackWhenCancellingAndProtocolFailsFast",
             /* ⚠️ */      testExpectedToFail(test_noDoubleCallbackWhenCancellingAndProtocolFailsFast, "This test crashes nondeterministically: https://bugs.swift.org/browse/SR-11310")),
-            ("test_cancelledTasksCannotBeResumed", test_cancelledTasksCannotBeResumed),
+            /* ⚠️ */ ("test_cancelledTasksCannotBeResumed", testExpectedToFail(test_cancelledTasksCannotBeResumed, "Breaks on Ubuntu 18.04")),
         ]
     }
     

--- a/Tests/Foundation/main.swift
+++ b/Tests/Foundation/main.swift
@@ -98,7 +98,6 @@ var allTestCases = [
     testCase(TestURLRequest.allTests),
     testCase(TestURLResponse.allTests),
     testCase(TestHTTPURLResponse.allTests),
-    testCaseExpectedToFail(TestURLSession.allTests, "URLSession test interdependencies are causing intermittent CI issues."),
     testCase(TestNSUUID.allTests),
     testCase(TestUUID.allTests),
     testCase(TestNSValue.allTests),
@@ -127,6 +126,7 @@ var allTestCases = [
 
 #if !os(Windows)
 allTestCases.append(contentsOf: [
+    testCase(TestURLSession.allTests),
     testCase(TestURLSessionFTP.allTests),
 ])
 #endif


### PR DESCRIPTION
- Re-enable the TestURLSession tests which should no longer be flaky
  however specifc tests are still disabled due to known issues.

- Enable the tests on DarwinCompatibilityTests also.

- Dont re-enable these tests on Windows yet as there are still random
  crashes.

- Disable test_concurrentRequests() as this fails about 4% of the time.

- Disable test_getAllTasks() as this causes other tests to fail.

- Disable test_http0_9SimpleResponses() as this fails on Ubuntu20.04.

- Disable test_cancelledTasksCannotBeResumed() as this sometimes fails
  on Ubuntu18.04.