### PR TITLE
TestURLSession: Pass .allow in the completionHandler.

### DIFF
--- a/Tests/Foundation/Tests/TestURLSession.swift
+++ b/Tests/Foundation/Tests/TestURLSession.swift
@@ -2100,8 +2100,10 @@ extension DataTask : URLSessionDataDelegate {
                     dataTask: URLSessionDataTask,
                     didReceive response: URLResponse,
                     completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
-        guard responseReceivedExpectation != nil else { return }
-        responseReceivedExpectation!.fulfill()
+        if let expectation = responseReceivedExpectation {
+            expectation.fulfill()
+        }
+        completionHandler(.allow)
     }
 }
 


### PR DESCRIPTION
- Running tests on macOS under DarwinCompatibilityTests would timeout
  and fail as the .urlSession(_:dataTask:didReceive:completionHandler:)
  method would not call the completion handler at all. Update the tests
  to pass .allow.

- The tests pass on scl-f because URLSession is currently ignoring the
  value passed to the completion handler and always continuing the task,
  even though it should not be.

- The URLSession bug is logged as https://bugs.swift.org/browse/SR-14032