### PR TITLE
[CanonicalOSSA] fix corelibs-foundation XMLTest

### DIFF
--- a/Tests/Foundation/Tests/TestXMLParser.swift
+++ b/Tests/Foundation/Tests/TestXMLParser.swift
@@ -155,6 +155,10 @@ class TestXMLParser : XCTestCase {
         let xml = TestXMLParser.xmlUnderTest(encoding: .utf8)
         let parser = XMLParser(data: xml.data(using: .utf8)!)
         let delegate = Delegate()
+        defer {
+            // XMLParser holds a weak reference to delegate. Keep it alive.
+            _fixLifetime(delegate)
+        }
         parser.delegate = delegate
         XCTAssertFalse(parser.parse())
         XCTAssertNotNil(parser.parserError)


### PR DESCRIPTION
Fix weak reference lifetime.

XMLParser has a weak delegate. OSSA optimization destroys the delegate
before this parser test runs.

Fixes rdar://73046709 ([CanonicalOSSA] corelibs-foundation XMLTest;
fix weak reference lifetime)

This test is blocking OSSA development.