### PR TITLE
Test HTTPServer: Minor improvements and fix for errors on Ubuntu20.04

### DIFF
--- a/Tests/Foundation/FTPServer.swift
+++ b/Tests/Foundation/FTPServer.swift
@@ -17,6 +17,17 @@ import Dispatch
     import Darwin
 #endif
 
+public class ServerSemaphore {
+    let dispatchSemaphore = DispatchSemaphore(value: 0)
+
+    public func wait(timeout: DispatchTime) -> DispatchTimeoutResult {
+        return dispatchSemaphore.wait(timeout: timeout)
+    }
+
+    public func signal() {
+        dispatchSemaphore.signal()
+    }
+}
 
 class _FTPSocket {
 


### PR DESCRIPTION
- Running some tests multiple times would eventually show an error on
  Ubuntu20.04 (approx 5-12%). This seems due to using multiple writes on
  the reply socket, so these are merged into one write in
  writeData(header:bodyData).

- Add server debugging enabled by an environment variable
  SCLF_HTTP_SERVER_DEBUG=YES

- Remove the ServerSemaphore and use a DispatchGroup() to wait for the
  server thread to start. ServerSemaphore has been moved to FTPServer
  but will be removed from there at some point.

- Simplify the writeData() function to remove the unused sending delays
  and remove the now unneeded _send() function.