### PR TITLE
fix missing cf.CFLAGS

### DIFF
--- a/CoreFoundation/build.py
+++ b/CoreFoundation/build.py
@@ -21,6 +21,7 @@ elif Configuration.current.target.sdk == OSType.FreeBSD:
 	cf.CFLAGS = '-I/usr/local/include -I/usr/local/include/libxml2 -I/usr/local/include/curl '
 	cf.LDFLAGS = ''
 elif Configuration.current.target.sdk == OSType.MacOSX:
+	cf.CFLAGS = ''
 	cf.LDFLAGS = '-licucore -twolevel_namespace -Wl,-alias_list,Base.subproj/DarwinSymbolAliases -sectcreate __UNICODE __csbitmaps CharacterSets/CFCharacterSetBitmaps.bitmap -sectcreate __UNICODE __properties CharacterSets/CFUniCharPropertyDatabase.data -sectcreate __UNICODE __data CharacterSets/CFUnicodeData-L.mapping -segprot __UNICODE r r '
 elif Configuration.current.target.sdk == OSType.Win32 and Configuration.current.target.environ == EnvironmentType.Cygnus:
 	cf.CFLAGS = '-D_GNU_SOURCE -mcmodel=large '


### PR DESCRIPTION
It seems get lost before 5.2, you may want some backport because it blocks building on MacOSX.

Since all `*FLAGS` are strings, should we make them empty string by default instead of `None`? And we can use `+=` instead of `=` all the time.