### PR TITLE
dont include objc when INCLUDE_OBJC not set

### DIFF
--- a/CoreFoundation/Base.subproj/ForFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForFoundationOnly.h
@@ -56,7 +56,7 @@ CF_IMPLICIT_BRIDGING_DISABLED
 #include <mach/mach_time.h>
 #endif
 
-#if (INCLUDE_OBJC || TARGET_OS_MAC || TARGET_OS_WIN32) && !DEPLOYMENT_RUNTIME_SWIFT
+#if INCLUDE_OBJC && (TARGET_OS_MAC || TARGET_OS_WIN32) && !DEPLOYMENT_RUNTIME_SWIFT
 #include <objc/message.h>
 #endif
 


### PR DESCRIPTION
We don't need objc for pure CoreFoundation. I check the blame history it seems this logic is what you want. 