### PR TITLE
FoundationXML: convert CFXMLInterface to ImplementationOnly

### DIFF
--- a/Sources/FoundationXML/XMLDTD.swift
+++ b/Sources/FoundationXML/XMLDTD.swift
@@ -13,7 +13,7 @@ import SwiftFoundation
 import Foundation
 #endif
 @_implementationOnly import CoreFoundation
-import CFXMLInterface
+@_implementationOnly import CFXMLInterface
 
 /*!
     @class XMLDTD

--- a/Sources/FoundationXML/XMLDTDNode.swift
+++ b/Sources/FoundationXML/XMLDTDNode.swift
@@ -13,7 +13,7 @@ import SwiftFoundation
 import Foundation
 #endif
 @_implementationOnly import CoreFoundation
-import CFXMLInterface
+@_implementationOnly import CFXMLInterface
 
 /*!
     @typedef XMLDTDNodeKind

--- a/Sources/FoundationXML/XMLDocument.swift
+++ b/Sources/FoundationXML/XMLDocument.swift
@@ -13,7 +13,7 @@ import SwiftFoundation
 import Foundation
 #endif
 @_implementationOnly import CoreFoundation
-import CFXMLInterface
+@_implementationOnly import CFXMLInterface
 
 // Input options
 //  NSXMLNodeOptionsNone

--- a/Sources/FoundationXML/XMLElement.swift
+++ b/Sources/FoundationXML/XMLElement.swift
@@ -13,7 +13,7 @@ import SwiftFoundation
 import Foundation
 #endif
 @_implementationOnly import CoreFoundation
-import CFXMLInterface
+@_implementationOnly import CFXMLInterface
 
 /*!
     @class XMLElement

--- a/Sources/FoundationXML/XMLNode.swift
+++ b/Sources/FoundationXML/XMLNode.swift
@@ -14,7 +14,7 @@ import SwiftFoundation
 import Foundation
 #endif
 @_implementationOnly import CoreFoundation
-import CFXMLInterface
+@_implementationOnly import CFXMLInterface
 
 // initWithKind options
 //  NSXMLNodeOptionsNone

--- a/Sources/FoundationXML/XMLParser.swift
+++ b/Sources/FoundationXML/XMLParser.swift
@@ -13,7 +13,7 @@ import SwiftFoundation
 import Foundation
 #endif
 @_implementationOnly import CoreFoundation
-import CFXMLInterface
+@_implementationOnly import CFXMLInterface
 
 extension XMLParser {
     public enum ExternalEntityResolvingPolicy : UInt {


### PR DESCRIPTION
The CoreFoundation interfaces are not expected to be exposed.  Convert
the import of `CFXMLInterface` to `@_implementationOnly`.